### PR TITLE
RUSH-1013: add live JSON-RPC and OAuth logs panel

### DIFF
--- a/apps/factory/src/core/debugLogs.test.ts
+++ b/apps/factory/src/core/debugLogs.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import { DebugLogStream } from './debugLogs';
+
+describe('DebugLogStream', () => {
+  test('records JSON-RPC request and response rows for a webview message', () => {
+    let now = 1000;
+    const stream = new DebugLogStream({ now: () => now += 10 });
+    const requestId = stream.recordJsonRpcRequest({ type: 'fetchAllTerminals', limit: 10 });
+    stream.recordJsonRpcResponse(requestId, 'fetchAllTerminals');
+
+    expect(stream.snapshot()).toEqual([
+      {
+        id: requestId,
+        ts: 1010,
+        source: 'jsonrpc',
+        direction: 'outgoing',
+        method: 'fetchAllTerminals',
+        status: 'pending',
+        payload: { type: 'fetchAllTerminals', limit: 10 },
+      },
+      {
+        id: `${requestId}:response`,
+        ts: 1020,
+        source: 'jsonrpc',
+        direction: 'incoming',
+        method: 'fetchAllTerminals',
+        status: 'ok',
+      },
+    ]);
+  });
+
+  test('publishes OAuth step rows to subscribers', () => {
+    const stream = new DebugLogStream({ now: () => 2000 });
+    const seen: string[] = [];
+    const unsubscribe = stream.subscribe((entry) => seen.push(`${entry.source}:${entry.method}:${entry.status}`));
+
+    stream.recordOAuthStep('linear.auth.check', 'pending', { provider: 'linear' });
+    stream.recordOAuthStep('linear.auth.check', 'ok', { connected: true });
+    unsubscribe();
+    stream.recordOAuthStep('github.auth.check', 'ok');
+
+    expect(seen).toEqual([
+      'oauth:linear.auth.check:pending',
+      'oauth:linear.auth.check:ok',
+    ]);
+  });
+
+  test('records a JSON-RPC response through subscribers exactly once', () => {
+    const stream = new DebugLogStream({ now: () => 3000 });
+    const seen: string[] = [];
+    const requestId = stream.recordJsonRpcRequest({ type: 'fetchTasks' });
+    stream.subscribe((entry) => seen.push(entry.id));
+
+    stream.recordJsonRpcResponse(requestId, 'fetchTasks');
+
+    expect(seen).toEqual([`${requestId}:response`]);
+  });
+
+  test('trims to the configured entry limit', () => {
+    const stream = new DebugLogStream({ now: () => 1, maxEntries: 2 });
+    stream.recordOAuthStep('one', 'ok');
+    stream.recordOAuthStep('two', 'ok');
+    stream.recordOAuthStep('three', 'ok');
+
+    expect(stream.snapshot().map((entry) => entry.method)).toEqual(['two', 'three']);
+  });
+});

--- a/apps/factory/src/core/debugLogs.ts
+++ b/apps/factory/src/core/debugLogs.ts
@@ -1,0 +1,114 @@
+export type DebugLogSource = 'jsonrpc' | 'oauth';
+export type DebugLogDirection = 'outgoing' | 'incoming' | 'step';
+export type DebugLogStatus = 'pending' | 'ok' | 'error' | 'retry';
+
+export interface DebugLogEntry {
+  id: string;
+  ts: number;
+  source: DebugLogSource;
+  direction: DebugLogDirection;
+  method: string;
+  status: DebugLogStatus;
+  payload?: unknown;
+  error?: string;
+}
+
+export interface DebugLogStreamOptions {
+  now?: () => number;
+  maxEntries?: number;
+}
+
+let nextLogSeq = 1;
+
+function sanitizePayload(value: unknown): unknown {
+  if (value == null) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+function messageType(message: unknown): string {
+  if (!message || typeof message !== 'object') return 'unknown';
+  const type = (message as { type?: unknown }).type;
+  return typeof type === 'string' && type.trim() ? type.trim() : 'unknown';
+}
+
+export class DebugLogStream {
+  private entries: DebugLogEntry[] = [];
+  private readonly subscribers = new Set<(entry: DebugLogEntry) => void>();
+  private readonly now: () => number;
+  private readonly maxEntries: number;
+
+  constructor(options: DebugLogStreamOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.maxEntries = options.maxEntries ?? 500;
+  }
+
+  snapshot(): DebugLogEntry[] {
+    return [...this.entries];
+  }
+
+  subscribe(fn: (entry: DebugLogEntry) => void): () => void {
+    this.subscribers.add(fn);
+    return () => this.subscribers.delete(fn);
+  }
+
+  append(entry: Omit<DebugLogEntry, 'id' | 'ts'> & Partial<Pick<DebugLogEntry, 'id' | 'ts'>>): DebugLogEntry {
+    const full: DebugLogEntry = {
+      id: entry.id ?? `dbg-${nextLogSeq++}`,
+      ts: entry.ts ?? this.now(),
+      source: entry.source,
+      direction: entry.direction,
+      method: entry.method,
+      status: entry.status,
+      ...(entry.payload !== undefined ? { payload: sanitizePayload(entry.payload) } : {}),
+      ...(entry.error ? { error: entry.error } : {}),
+    };
+    this.entries.push(full);
+    if (this.entries.length > this.maxEntries) {
+      this.entries.splice(0, this.entries.length - this.maxEntries);
+    }
+    for (const subscriber of this.subscribers) subscriber(full);
+    return full;
+  }
+
+  recordJsonRpcRequest(message: unknown): string {
+    const method = messageType(message);
+    const entry = this.append({
+      source: 'jsonrpc',
+      direction: 'outgoing',
+      method,
+      status: 'pending',
+      payload: message,
+    });
+    return entry.id;
+  }
+
+  recordJsonRpcResponse(requestId: string, method: string, error?: unknown): DebugLogEntry {
+    const errorMessage = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+    return this.append({
+      id: `${requestId}:response`,
+      source: 'jsonrpc',
+      direction: 'incoming',
+      method,
+      status: errorMessage ? 'error' : 'ok',
+      ...(errorMessage ? { error: errorMessage } : {}),
+    });
+  }
+
+  recordOAuthStep(method: string, status: DebugLogStatus, payload?: unknown, error?: unknown): DebugLogEntry {
+    const errorMessage = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+    return this.append({
+      source: 'oauth',
+      direction: 'step',
+      method,
+      status,
+      ...(payload !== undefined ? { payload } : {}),
+      ...(errorMessage ? { error: errorMessage } : {}),
+    });
+  }
+}
+

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -73,9 +73,11 @@ import {
   encodePowershellScript,
   buildDeviceDispatchRemoteCmd,
 } from '../core/deviceDispatchShell';
+import { DebugLogStream, type DebugLogEntry } from '../core/debugLogs';
 
 let foremanSession: ForemanAudioSession | undefined;
 let foremanSessionGen = 0;
+const debugLogStream = new DebugLogStream();
 // Smart-mode (turn-based text brain) rolling history. Capped on assignment
 // (via capHistory, on a safe turn boundary) so a long session doesn't grow the
 // OpenAI context unbounded.
@@ -1593,7 +1595,16 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
 
   settingsPanel.webview.html = getWebviewContent(settingsPanel.webview, context.extensionUri);
 
+  let unsubscribeDebugLogs: (() => void) | undefined;
+  const publishDebugLog = (entry: DebugLogEntry) => {
+    settingsPanel?.webview.postMessage({ type: 'logEntry', entry });
+  };
+
   settingsPanel.webview.onDidReceiveMessage(async (message) => {
+    const rpcMethod = typeof message?.type === 'string' ? message.type : 'unknown';
+    const rpcRequestId = debugLogStream.recordJsonRpcRequest(message);
+    let rpcError: unknown;
+    try {
     switch (message.type) {
       case 'ready':
         // Post the panel's actual visibility once so the webview doesn't have
@@ -1605,6 +1616,11 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
           visible: settingsPanel.visible,
         });
         updateWebview();
+        break;
+      case 'subscribeLogs':
+        unsubscribeDebugLogs?.();
+        settingsPanel?.webview.postMessage({ type: 'logsData', entries: debugLogStream.snapshot() });
+        unsubscribeDebugLogs = debugLogStream.subscribe(publishDebugLog);
         break;
       case 'saveSettings':
         // Compare display prefs to decide if we need to retitle open terminals
@@ -2091,11 +2107,14 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
       }
 
       case 'checkGitHubAuth': {
+        debugLogStream.recordOAuthStep('github.auth.check', 'pending', { provider: 'github' });
         try {
           const { isGitHubAvailable } = await import('./github.vscode');
           const connected = await isGitHubAvailable(context);
+          debugLogStream.recordOAuthStep('github.auth.check', connected ? 'ok' : 'error', { provider: 'github', connected });
           settingsPanel?.webview.postMessage({ type: 'integrationStatus', provider: 'github', connected });
-        } catch {
+        } catch (err) {
+          debugLogStream.recordOAuthStep('github.auth.check', 'error', { provider: 'github' }, err);
           settingsPanel?.webview.postMessage({ type: 'integrationStatus', provider: 'github', connected: false });
         }
         break;
@@ -2832,11 +2851,14 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         }
         break;
       case 'checkLinearAuth': {
+        debugLogStream.recordOAuthStep('linear.auth.check', 'pending', { provider: 'linear' });
         try {
           const { isLinearAvailable } = await import('./linear.vscode');
           const connected = await isLinearAvailable(context);
+          debugLogStream.recordOAuthStep('linear.auth.check', connected ? 'ok' : 'error', { provider: 'linear', connected });
           settingsPanel?.webview.postMessage({ type: 'integrationStatus', provider: 'linear', connected });
-        } catch {
+        } catch (err) {
+          debugLogStream.recordOAuthStep('linear.auth.check', 'error', { provider: 'linear' }, err);
           settingsPanel?.webview.postMessage({ type: 'integrationStatus', provider: 'linear', connected: false });
         }
         break;
@@ -3357,6 +3379,12 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         break;
       }
     }
+    } catch (err) {
+      rpcError = err;
+      throw err;
+    } finally {
+      debugLogStream.recordJsonRpcResponse(rpcRequestId, rpcMethod, rpcError);
+    }
   }, undefined, context.subscriptions);
 
   // Debounce terminal updates to avoid excessive webview messages
@@ -3416,6 +3444,8 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
   });
 
   settingsPanel.onDidDispose(() => {
+    unsubscribeDebugLogs?.();
+    unsubscribeDebugLogs = undefined;
     settingsPanel = undefined;
     terminalListener.dispose();
     terminalCloseListener.dispose();

--- a/apps/factory/ui/settings/App.tsx
+++ b/apps/factory/ui/settings/App.tsx
@@ -42,6 +42,7 @@ import { ResourcesTab } from './components/resources'
 import { GuideTab } from './components/tabs/GuideTab'
 import { ApiKeyDialog } from './components/common/OAuthDialog'
 import { ForemanOrb, ForemanCursor } from './components/foreman'
+import { LogsPanel, type LogEntry } from './components/logs'
 
 const vscode = getVsCodeApi()
 const icons = getIcons() as IconConfig
@@ -157,6 +158,8 @@ export default function App() {
   const [watchdogEnabled, setWatchdogEnabled] = useState(false)
   const [watchdogEvents, setWatchdogEvents] = useState<import('./components/mission-control/UnifiedAgentsPane').WatchdogEventUI[]>([])
   const [watchdogPlaybookStatus, setWatchdogPlaybookStatus] = useState<WatchdogPlaybookStatus | null>(null)
+  const [logEntries, setLogEntries] = useState<LogEntry[]>([])
+  const [totalLogEntryCount, setTotalLogEntryCount] = useState(0)
 
   // Workspace config state
   const [workspaceConfig, setWorkspaceConfig] = useState<WorkspaceConfig | null>(null)
@@ -333,6 +336,16 @@ export default function App() {
         case 'watchdogPlaybookStatus':
           if (message.status) setWatchdogPlaybookStatus(message.status)
           break
+        case 'logsData':
+          setLogEntries(Array.isArray(message.entries) ? message.entries.slice(-500) : [])
+          setTotalLogEntryCount(Array.isArray(message.entries) ? message.entries.length : 0)
+          break
+        case 'logEntry':
+          if (message.entry) {
+            setLogEntries((prev) => [...prev.slice(-499), message.entry])
+            setTotalLogEntryCount((count) => count + 1)
+          }
+          break
         case 'workspaceConfigData':
           setWorkspaceConfig(message.config)
           setWorkspaceConfigExists(message.exists)
@@ -368,6 +381,7 @@ export default function App() {
     vscode.postMessage({ type: 'getSecondaryAgent' })
     vscode.postMessage({ type: 'getWatchdogStatus' })
     vscode.postMessage({ type: 'getWatchdogPlaybookStatus' })
+    vscode.postMessage({ type: 'subscribeLogs' })
     vscode.postMessage({ type: 'getPrewarmStatus' })
     vscode.postMessage({ type: 'getWorkspaceConfig' })
     vscode.postMessage({ type: 'fetchAllTerminals' })
@@ -856,6 +870,11 @@ export default function App() {
 
       {activeTab === 'resources' && (
         <ResourcesTab />
+      )}
+
+      {/* Logs (dockable live JSON-RPC/OAuth panel) */}
+      {activeTab === 'logs' && (
+        <LogsPanel entries={logEntries} totalEntryCount={totalLogEntryCount} />
       )}
 
       {/* Panel (settings - 2-column sidebar layout) */}

--- a/apps/factory/ui/settings/components/logs/LogFilters.tsx
+++ b/apps/factory/ui/settings/components/logs/LogFilters.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { LogFilterState } from './types';
+
+interface LogFiltersProps {
+  filters: LogFilterState;
+  paused: boolean;
+  pendingCount: number;
+  onFiltersChange: (filters: LogFilterState) => void;
+  onPausedChange: (paused: boolean) => void;
+}
+
+export function LogFilters({ filters, paused, pendingCount, onFiltersChange, onPausedChange }: LogFiltersProps) {
+  return (
+    <div className="sw-logs-filters">
+      <label className="sw-logs-control">
+        <span>Source</span>
+        <select
+          value={filters.source}
+          onChange={(event) => onFiltersChange({ ...filters, source: event.target.value as LogFilterState['source'] })}
+        >
+          <option value="all">All</option>
+          <option value="jsonrpc">JSON-RPC</option>
+          <option value="oauth">OAuth</option>
+        </select>
+      </label>
+      <label className="sw-logs-control sw-logs-search">
+        <span>Method</span>
+        <input
+          value={filters.query}
+          onChange={(event) => onFiltersChange({ ...filters, query: event.target.value })}
+          placeholder="Filter method or payload"
+        />
+      </label>
+      <label className="sw-logs-check">
+        <input
+          type="checkbox"
+          checked={filters.errorsOnly}
+          onChange={(event) => onFiltersChange({ ...filters, errorsOnly: event.target.checked })}
+        />
+        <span>Errors only</span>
+      </label>
+      <button
+        type="button"
+        className={`sw-logs-pause ${paused ? 'paused' : ''}`}
+        onClick={() => onPausedChange(!paused)}
+      >
+        {paused ? `Resume${pendingCount > 0 ? ` (${pendingCount})` : ''}` : 'Pause'}
+      </button>
+    </div>
+  );
+}
+

--- a/apps/factory/ui/settings/components/logs/LogRow.tsx
+++ b/apps/factory/ui/settings/components/logs/LogRow.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import type { LogEntry } from './types';
+import { serializedPayload } from './types';
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function statusLabel(entry: LogEntry): string {
+  if (entry.status === 'ok') return 'OK';
+  if (entry.status === 'error') return 'ERR';
+  if (entry.status === 'retry') return 'RETRY';
+  return 'WAIT';
+}
+
+export function LogRow({ entry }: { entry: LogEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const payload = serializedPayload(entry);
+  return (
+    <div className={`sw-log-row ${expanded ? 'expanded' : ''} ${entry.status}`}>
+      <button type="button" className="sw-log-summary" onClick={() => setExpanded(!expanded)}>
+        <span className={`sw-log-status ${entry.status}`}>{statusLabel(entry)}</span>
+        <span className="sw-log-time">{formatTime(entry.ts)}</span>
+        <span className="sw-log-source">{entry.source}</span>
+        <span className="sw-log-direction">{entry.direction}</span>
+        <span className="sw-log-method">{entry.method}</span>
+      </button>
+      {expanded && (
+        <div className="sw-log-detail">
+          {entry.error && (
+            <pre className="sw-log-error">{entry.error}</pre>
+          )}
+          <pre>{payload || '(empty payload)'}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/apps/factory/ui/settings/components/logs/LogsPanel.test.tsx
+++ b/apps/factory/ui/settings/components/logs/LogsPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { LogsPanel } from './LogsPanel';
+import { filterLogEntries, pendingLogCount, type LogEntry } from './types';
+
+const rows: LogEntry[] = [
+  {
+    id: 'one',
+    ts: 1000,
+    source: 'jsonrpc',
+    direction: 'outgoing',
+    method: 'fetchAllTerminals',
+    status: 'pending',
+    payload: { type: 'fetchAllTerminals' },
+  },
+  {
+    id: 'two',
+    ts: 2000,
+    source: 'oauth',
+    direction: 'step',
+    method: 'linear.auth.check',
+    status: 'ok',
+    payload: { connected: true },
+  },
+  {
+    id: 'three',
+    ts: 3000,
+    source: 'jsonrpc',
+    direction: 'incoming',
+    method: 'dispatch',
+    status: 'error',
+    error: 'Dispatch failed',
+  },
+];
+
+describe('filterLogEntries', () => {
+  test('filters by source, method/payload search, and errors-only', () => {
+    expect(filterLogEntries(rows, { source: 'oauth', query: '', errorsOnly: false }).map((row) => row.id)).toEqual(['two']);
+    expect(filterLogEntries(rows, { source: 'all', query: 'terminals', errorsOnly: false }).map((row) => row.id)).toEqual(['one']);
+    expect(filterLogEntries(rows, { source: 'all', query: '', errorsOnly: true }).map((row) => row.id)).toEqual(['three']);
+  });
+
+  test('counts pending rows independently from the capped visible buffer length', () => {
+    expect(pendingLogCount(625, 500)).toBe(125);
+    expect(pendingLogCount(500, 500)).toBe(0);
+  });
+});
+
+describe('LogsPanel', () => {
+  test('renders docked log rows and controls', () => {
+    const html = renderToStaticMarkup(<LogsPanel entries={rows} totalEntryCount={rows.length} />);
+
+    expect(html).toContain('JSON-RPC and OAuth logs');
+    expect(html).toContain('fetchAllTerminals');
+    expect(html).toContain('linear.auth.check');
+    expect(html).toContain('Errors only');
+    expect(html).toContain('Pause');
+  });
+});

--- a/apps/factory/ui/settings/components/logs/LogsPanel.tsx
+++ b/apps/factory/ui/settings/components/logs/LogsPanel.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { LogFilters } from './LogFilters';
+import { LogRow } from './LogRow';
+import type { LogEntry, LogFilterState } from './types';
+import { filterLogEntries, pendingLogCount } from './types';
+
+interface LogsPanelProps {
+  entries: LogEntry[];
+  totalEntryCount: number;
+}
+
+export function LogsPanel({ entries, totalEntryCount }: LogsPanelProps) {
+  const [filters, setFilters] = useState<LogFilterState>({ source: 'all', query: '', errorsOnly: false });
+  const [paused, setPaused] = useState(false);
+  const [visibleEntries, setVisibleEntries] = useState<LogEntry[]>(entries);
+  const [visibleTotalEntryCount, setVisibleTotalEntryCount] = useState(totalEntryCount);
+
+  useEffect(() => {
+    if (!paused) {
+      setVisibleEntries(entries);
+      setVisibleTotalEntryCount(totalEntryCount);
+    }
+  }, [entries, paused, totalEntryCount]);
+
+  const filtered = useMemo(() => filterLogEntries(visibleEntries, filters), [visibleEntries, filters]);
+  const pendingCount = pendingLogCount(totalEntryCount, visibleTotalEntryCount);
+
+  const handlePausedChange = (nextPaused: boolean) => {
+    if (!nextPaused) {
+      setVisibleEntries(entries);
+      setVisibleTotalEntryCount(totalEntryCount);
+    }
+    setPaused(nextPaused);
+  };
+
+  return (
+    <main className="sw-logs-panel">
+      <section className="sw-logs-head">
+        <div>
+          <div className="sw-logs-eyebrow">Live traffic</div>
+          <h1>JSON-RPC and OAuth logs</h1>
+        </div>
+        <div className="sw-logs-count">{filtered.length} rows</div>
+      </section>
+      <LogFilters
+        filters={filters}
+        paused={paused}
+        pendingCount={pendingCount}
+        onFiltersChange={setFilters}
+        onPausedChange={handlePausedChange}
+      />
+      <section className="sw-logs-table" aria-label="JSON-RPC and OAuth log rows">
+        {filtered.length === 0 ? (
+          <div className="sw-logs-empty">No log rows match the current filters.</div>
+        ) : (
+          filtered.map((entry) => <LogRow key={entry.id} entry={entry} />)
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/factory/ui/settings/components/logs/index.ts
+++ b/apps/factory/ui/settings/components/logs/index.ts
@@ -1,0 +1,6 @@
+export { LogsPanel } from './LogsPanel';
+export { LogRow } from './LogRow';
+export { LogFilters } from './LogFilters';
+export type { LogEntry, LogFilterState } from './types';
+export { filterLogEntries, serializedPayload } from './types';
+

--- a/apps/factory/ui/settings/components/logs/types.ts
+++ b/apps/factory/ui/settings/components/logs/types.ts
@@ -1,0 +1,52 @@
+export type LogSource = 'jsonrpc' | 'oauth';
+export type LogDirection = 'outgoing' | 'incoming' | 'step';
+export type LogStatus = 'pending' | 'ok' | 'error' | 'retry';
+
+export interface LogEntry {
+  id: string;
+  ts: number;
+  source: LogSource;
+  direction: LogDirection;
+  method: string;
+  status: LogStatus;
+  payload?: unknown;
+  error?: string;
+}
+
+export interface LogFilterState {
+  source: 'all' | LogSource;
+  query: string;
+  errorsOnly: boolean;
+}
+
+export function serializedPayload(entry: LogEntry): string {
+  if (entry.payload === undefined) return '';
+  if (typeof entry.payload === 'string') return entry.payload;
+  try {
+    return JSON.stringify(entry.payload, null, 2);
+  } catch {
+    return String(entry.payload);
+  }
+}
+
+export function filterLogEntries(entries: LogEntry[], filters: LogFilterState): LogEntry[] {
+  const needle = filters.query.trim().toLowerCase();
+  return entries.filter((entry) => {
+    if (filters.source !== 'all' && entry.source !== filters.source) return false;
+    if (filters.errorsOnly && entry.status !== 'error') return false;
+    if (!needle) return true;
+    const haystack = [
+      entry.source,
+      entry.direction,
+      entry.method,
+      entry.status,
+      entry.error ?? '',
+      serializedPayload(entry),
+    ].join('\n').toLowerCase();
+    return haystack.includes(needle);
+  });
+}
+
+export function pendingLogCount(totalEntryCount: number, visibleTotalEntryCount: number): number {
+  return Math.max(0, totalEntryCount - visibleTotalEntryCount);
+}

--- a/apps/factory/ui/settings/components/mission-control/TopBar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/TopBar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Icon } from './icons'
 import { ThroughputCounter } from './UnifiedAgentsPane'
 
-export type TabKey = 'floor' | 'bench' | 'resources' | 'panel'
+export type TabKey = 'floor' | 'bench' | 'resources' | 'logs' | 'panel'
 
 interface TopBarProps {
   version?: string
@@ -76,6 +76,13 @@ export function TopBar({
           onClick={() => onTabChange('resources')}
         >
           Resources
+        </button>
+        <button
+          data-foreman-id="tab-logs"
+          className={`sw-tab ${activeTab === 'logs' ? 'active' : ''}`}
+          onClick={() => onTabChange('logs')}
+        >
+          Logs
         </button>
         <button
           data-foreman-id="tab-panel"

--- a/apps/factory/ui/settings/index.css
+++ b/apps/factory/ui/settings/index.css
@@ -678,4 +678,235 @@ input[type="number"]::-webkit-inner-spin-button {
   color: var(--ds-text-muted);
   font-family: var(--font-mono);
   font-size: 12px;
+.swarmify-root .sw-logs-panel {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 10px;
+  height: calc(100vh - 68px);
+  padding: 14px;
+  background: var(--ds-bg);
+  color: var(--ds-text);
+  min-width: 0;
+}
+
+.swarmify-root .sw-logs-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.swarmify-root .sw-logs-eyebrow {
+  color: var(--ds-text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.swarmify-root .sw-logs-head h1 {
+  font-size: 18px;
+  line-height: 1.2;
+  margin: 2px 0 0;
+}
+
+.swarmify-root .sw-logs-count {
+  color: var(--ds-text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.swarmify-root .sw-logs-filters {
+  display: grid;
+  grid-template-columns: minmax(120px, 160px) minmax(180px, 1fr) auto auto;
+  gap: 8px;
+  align-items: end;
+  padding: 10px;
+  border: 1px solid var(--ds-border);
+  border-radius: var(--r-md);
+  background: var(--ds-bg-panel);
+}
+
+.swarmify-root .sw-logs-control {
+  display: grid;
+  gap: 4px;
+  color: var(--ds-text-muted);
+  font-size: 11px;
+  min-width: 0;
+}
+
+.swarmify-root .sw-logs-control select,
+.swarmify-root .sw-logs-control input {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  border: 1px solid var(--ds-border-strong);
+  border-radius: var(--r-sm);
+  background: var(--ds-bg-sunken);
+  color: var(--ds-text);
+  font: inherit;
+  font-size: 12px;
+  padding: 0 8px;
+}
+
+.swarmify-root .sw-logs-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 30px;
+  color: var(--ds-text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.swarmify-root .sw-logs-pause {
+  height: 30px;
+  border: 1px solid var(--ds-border-strong);
+  border-radius: var(--r-sm);
+  background: var(--ds-bg-sunken);
+  color: var(--ds-text);
+  font: inherit;
+  font-size: 12px;
+  padding: 0 10px;
+  white-space: nowrap;
+}
+
+.swarmify-root .sw-logs-pause.paused {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+.swarmify-root .sw-logs-table {
+  overflow: auto;
+  min-height: 0;
+  border: 1px solid var(--ds-border);
+  border-radius: var(--r-md);
+  background: var(--ds-bg-panel);
+}
+
+.swarmify-root .sw-logs-empty {
+  display: grid;
+  place-items: center;
+  min-height: 160px;
+  color: var(--ds-text-muted);
+  font-size: 13px;
+}
+
+.swarmify-root .sw-log-row {
+  border-bottom: 1px solid var(--ds-border);
+}
+
+.swarmify-root .sw-log-row:last-child {
+  border-bottom: 0;
+}
+
+.swarmify-root .sw-log-summary {
+  display: grid;
+  grid-template-columns: 54px 78px 76px 76px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 0;
+  background: transparent;
+  color: var(--ds-text);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+}
+
+.swarmify-root .sw-log-summary:hover {
+  background: var(--ds-bg-hover);
+}
+
+.swarmify-root .sw-log-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 18px;
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.swarmify-root .sw-log-status.ok {
+  color: var(--status-running);
+  background: var(--status-running-bg);
+}
+
+.swarmify-root .sw-log-status.error {
+  color: var(--status-failed);
+  background: var(--status-failed-bg);
+}
+
+.swarmify-root .sw-log-status.pending,
+.swarmify-root .sw-log-status.retry {
+  color: var(--status-pending);
+  background: var(--status-pending-bg);
+}
+
+.swarmify-root .sw-log-time,
+.swarmify-root .sw-log-source,
+.swarmify-root .sw-log-direction {
+  color: var(--ds-text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.swarmify-root .sw-log-method {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+}
+
+.swarmify-root .sw-log-detail {
+  display: grid;
+  gap: 8px;
+  padding: 0 10px 10px 154px;
+}
+
+.swarmify-root .sw-log-detail pre {
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid var(--ds-border);
+  border-radius: var(--r-sm);
+  background: var(--ds-bg-sunken);
+  color: var(--ds-text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  padding: 9px;
+}
+
+.swarmify-root .sw-log-detail .sw-log-error {
+  color: var(--status-failed);
+  background: var(--status-failed-bg);
+  border-color: color-mix(in srgb, var(--status-failed) 35%, transparent);
+}
+
+@media (max-width: 760px) {
+  .swarmify-root .sw-logs-filters {
+    grid-template-columns: 1fr;
+  }
+
+  .swarmify-root .sw-log-summary {
+    grid-template-columns: 48px 1fr;
+    row-gap: 2px;
+    padding: 8px 10px;
+  }
+
+  .swarmify-root .sw-log-time,
+  .swarmify-root .sw-log-source,
+  .swarmify-root .sw-log-direction {
+    display: none;
+  }
+
+  .swarmify-root .sw-log-detail {
+    padding-left: 10px;
+  }
 }

--- a/apps/factory/ui/settings/index.css
+++ b/apps/factory/ui/settings/index.css
@@ -678,6 +678,8 @@ input[type="number"]::-webkit-inner-spin-button {
   color: var(--ds-text-muted);
   font-family: var(--font-mono);
   font-size: 12px;
+}
+
 .swarmify-root .sw-logs-panel {
   display: grid;
   grid-template-rows: auto auto 1fr;


### PR DESCRIPTION
Implements a net-new live debug log panel in Factory for JSON-RPC-style webview traffic and OAuth auth checks.

Changes:
- Adds an in-memory debug log stream for dashboard request/response rows and OAuth auth-check steps.
- Adds a docked Logs tab with source filtering, method/payload search, errors-only filtering, row expansion, and pause/resume.
- Reconciles on top of the merged Resources tab so both Resources and Logs tabs coexist.
- Fixes duplicate JSON-RPC response delivery by relying on recordJsonRpcResponse subscriber publication only.
- Tracks paused pending rows independently from the capped visible buffer.
- Adds GitHub OAuth instrumentation alongside the existing Linear auth logging.

Verification:
- `cd apps/factory && TMPDIR=/tmp XDG_CACHE_HOME=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-cache BUN_INSTALL=/tmp/bun-install bun run compile:ext` passed.
- `cd apps/factory && TMPDIR=/tmp XDG_CACHE_HOME=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-cache BUN_INSTALL=/tmp/bun-install bun run compile:ui` passed.
- `cd apps/factory && TMPDIR=/tmp XDG_CACHE_HOME=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-cache BUN_INSTALL=/tmp/bun-install bun test src/core/debugLogs.test.ts ui/settings/components/logs/LogsPanel.test.tsx` passed.
- Full `cd apps/factory && TMPDIR=/tmp XDG_CACHE_HOME=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-cache BUN_INSTALL=/tmp/bun-install bun test` was run and failed in unrelated existing live-service/session suites: `draftDispatchPrompt`, `agentsBin`, `session-read`, `agentModels`, `commitgen`, `labelgen`, and missing exports in `session.summary.test.ts` / `session.activity.test.ts`. The changed RUSH-1013 tests passed inside that full run.

Notes:
- `apps/factory/ui/.gitignore` has a broad `logs` ignore rule, so `apps/factory/ui/settings/components/logs/*` is intentionally force-added as source.