### PR TITLE
feat(cli): expose implied resource surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **`agents resources --merged` shows the effective DotAgents resource surface (RUSH-1770).**
+  The command lists the merged skills, commands, MCP servers, hooks, rules, plugins,
+  workflows, and subagents resolved through project > user > system > extras, with
+  each row tagged by its winning layer. Bare `agents devices` now runs the same list
+  view as `agents devices list`, and `agents plugins add <spec>` aliases
+  `agents plugins install <spec>`. Source: `apps/cli/src/commands/resources.ts`,
+  `apps/cli/src/commands/ssh.ts`, `apps/cli/src/commands/plugins.ts`.
+
 ### Security
 
 - **`agents plugins update` no longer silently executes a compromised upstream (RUSH-1757).**

--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ Bundle skills, commands, hooks, MCP servers, settings, and permissions under a s
 # Install from a git URL or local path
 agents plugins install hivemind@https://github.com/activeloopai/hivemind.git
 agents plugins install ./my-plugin
+agents plugins add ./my-plugin
 
 # Apply to one agent (default version) or all supported
 agents plugins sync rush-toolkit claude
@@ -924,7 +925,7 @@ Two repos with the same shape, different roles:
 
 **Version pinning:** `agents.yaml` at project root pins which agent version to use (like `.nvmrc` for Node).
 
-**Resource resolution:** When syncing resources (commands, skills, rules, hooks, MCP, permissions), the order is **project > user > system**. A `.agents/` directory at project root wins, then `~/.agents/`, then `~/.agents-system/`. Same-named resources higher in the chain override lower ones; everything else unions in.
+**Resource resolution:** When syncing resources (commands, skills, rules, hooks, MCP, permissions), the order is **project > user > system**. A `.agents/` directory at project root wins, then `~/.agents/`, then `~/.agents-system/`. Same-named resources higher in the chain override lower ones; everything else unions in. Run `agents resources --merged` to see the effective skills, commands, MCP servers, hooks, rules, plugins, workflows, and subagents, with each row tagged by its winning layer.
 
 See [docs/00-concepts.md](apps/cli/docs/00-concepts.md) for the full mental model: DotAgents repos, resource kinds, and how resolution works end-to-end.
 

--- a/apps/cli/src/commands/plugins.test.ts
+++ b/apps/cli/src/commands/plugins.test.ts
@@ -1,11 +1,15 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { inspectPluginCapabilities } from '../lib/plugins.js';
 import { shouldRefusePluginInstall, collectMarketplaceRows } from './plugins.js';
 import { discoverMarketplaces } from '../lib/plugin-marketplace.js';
 
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
 const tempDirs: string[] = [];
 
 function makePluginRoot(): string {
@@ -17,6 +21,26 @@ function makePluginRoot(): string {
     JSON.stringify({ name: 'risky-plugin', version: '1.0.0', description: 'test' })
   );
   return dir;
+}
+
+function makeHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-plugin-home-'));
+  tempDirs.push(home);
+  const systemDir = path.join(home, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+  return home;
+}
+
+function runCli(home: string, args: string[]): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('bun', [INDEX, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home, AGENTS_NO_UPDATE_CHECK: '1' },
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status };
 }
 
 afterEach(() => {
@@ -34,6 +58,19 @@ describe('plugins install trust gate', () => {
 
     expect(shouldRefusePluginInstall(capabilities, false)).toBe(true);
     expect(shouldRefusePluginInstall(capabilities, true)).toBe(false);
+  });
+});
+
+describe('plugins add alias', () => {
+  it('installs through the add alias', () => {
+    const home = makeHome();
+    const root = makePluginRoot();
+
+    const { stdout, stderr, status } = runCli(home, ['plugins', 'add', root]);
+
+    expect(status).toBe(0);
+    expect(stdout + stderr).toContain('Installed risky-plugin v1.0.0');
+    expect(fs.existsSync(path.join(home, '.agents', 'plugins', 'risky-plugin', '.claude-plugin', 'plugin.json'))).toBe(true);
   });
 });
 

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -584,6 +584,7 @@ Examples:
   // agents plugins install <spec>
   pluginsCmd
     .command('install <spec>')
+    .alias('add')
     .description('Install a plugin from a git URL or local path (format: name@source or source)')
     .option('--allow-exec-surfaces', 'Allow installing plugins that ship executable surfaces')
     .addHelpText('after', `

--- a/apps/cli/src/commands/resources.test.ts
+++ b/apps/cli/src/commands/resources.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-resources-home-'));
+  tempDirs.push(home);
+  const systemDir = path.join(home, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+  return home;
+}
+
+function makeProject(): string {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-resources-project-'));
+  tempDirs.push(project);
+  return project;
+}
+
+function run(home: string, cwd: string, args: string[]): { stdout: string; status: number | null } {
+  const r = spawnSync('bun', [INDEX, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home, AGENTS_NO_UPDATE_CHECK: '1' },
+  });
+  return { stdout: r.stdout ?? '', status: r.status };
+}
+
+describe('resources command', () => {
+  it('prints the merged resource union with the winning layer for duplicates', () => {
+    const home = makeHome();
+    const project = makeProject();
+    fs.mkdirSync(path.join(home, '.agents', 'skills'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.agents', '.system', 'skills'), { recursive: true });
+    fs.mkdirSync(path.join(project, '.agents', 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.agents', '.system', 'skills', 'shared.md'), 'system');
+    fs.writeFileSync(path.join(home, '.agents', 'skills', 'shared.md'), 'user');
+    fs.writeFileSync(path.join(project, '.agents', 'skills', 'shared.md'), 'project');
+    fs.writeFileSync(path.join(home, '.agents', '.system', 'skills', 'system-only.md'), 'system');
+
+    const { stdout, status } = run(home, project, ['resources', '--merged']);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('Resources (2 merged)');
+    expect(stdout).toContain('Skills (2)');
+    expect(stdout).toMatch(/shared\s+project/);
+    expect(stdout).toMatch(/system-only\s+system/);
+    expect(stdout).not.toMatch(/shared\s+user/);
+  });
+});

--- a/apps/cli/src/commands/resources.ts
+++ b/apps/cli/src/commands/resources.ts
@@ -1,0 +1,120 @@
+/**
+ * `agents resources` — show the merged DotAgents resource surface.
+ */
+
+import * as path from 'path';
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { listResources, type ResolvedResource, type ResourceKind } from '../lib/resources.js';
+import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
+
+const DRILLABLE_KINDS = [
+  'skills',
+  'commands',
+  'mcp',
+  'hooks',
+  'rules',
+  'plugins',
+  'workflows',
+  'subagents',
+] as const;
+
+type DrillableKind = typeof DRILLABLE_KINDS[number];
+
+const KIND_LABELS: Record<DrillableKind, string> = {
+  skills: 'Skills',
+  commands: 'Commands',
+  mcp: 'MCP',
+  hooks: 'Hooks',
+  rules: 'Rules',
+  plugins: 'Plugins',
+  workflows: 'Workflows',
+  subagents: 'Subagents',
+};
+
+interface ResourceGroup {
+  kind: DrillableKind;
+  rows: ResolvedResource[];
+}
+
+interface ResourcesOptions {
+  merged?: boolean;
+}
+
+export function registerResourcesCommand(program: Command): void {
+  program
+    .command('resources')
+    .description('Show the merged DotAgents resources resolved across project, user, system, and extras')
+    .option('--merged', 'Show the merged first-wins resource surface (default)')
+    .addHelpText('after', `
+Examples:
+  agents resources
+  agents resources --merged
+`)
+    .action((options: ResourcesOptions) => {
+      void options;
+      renderMergedResources();
+    });
+}
+
+function renderMergedResources(): void {
+  const groups: ResourceGroup[] = DRILLABLE_KINDS.map((kind) => ({
+    kind,
+    rows: listResources(kind as ResourceKind),
+  }));
+  const total = groups.reduce((sum, group) => sum + group.rows.length, 0);
+
+  if (total === 0) {
+    console.log(chalk.gray('No merged resources found.'));
+    return;
+  }
+
+  console.log(chalk.bold(`Resources (${total} merged)`));
+  for (const group of groups) {
+    console.log();
+    console.log(chalk.bold(`${KIND_LABELS[group.kind]} (${group.rows.length})`));
+    if (group.rows.length === 0) {
+      console.log(chalk.gray('  none'));
+      continue;
+    }
+    for (const line of renderResourceRows(group.rows)) console.log(line);
+  }
+}
+
+function renderResourceRows(rows: ResolvedResource[]): string[] {
+  const nameW = Math.min(28, Math.max('Name'.length, ...rows.map((row) => stringWidth(row.name))));
+  const layerW = Math.min(16, Math.max('Layer'.length, ...rows.map((row) => stringWidth(row.source))));
+  const prefixW = 2 + nameW + 2 + layerW + 2;
+  const pathW = Math.max(12, terminalWidth() - prefixW);
+
+  const lines = [
+    `  ${chalk.bold(pad(row('Name', nameW), nameW))}  ${chalk.bold(pad(row('Layer', layerW), layerW))}  ${chalk.bold('Path')}`,
+    `  ${chalk.gray(`${'-'.repeat(nameW)}  ${'-'.repeat(layerW)}  ${'-'.repeat(Math.min(pathW, 40))}`)}`,
+  ];
+
+  for (const resource of rows) {
+    lines.push(
+      `  ${chalk.cyan(pad(truncateToWidth(resource.name, nameW), nameW))}  ${pad(resource.source, layerW)}  ${chalk.gray(truncateToWidth(formatPath(resource.path), pathW))}`,
+    );
+  }
+
+  return lines;
+}
+
+function row(value: string, width: number): string {
+  return truncateToWidth(value, width);
+}
+
+function pad(value: string, width: number): string {
+  return value + ' '.repeat(Math.max(0, width - stringWidth(value)));
+}
+
+function formatPath(value: string): string {
+  const home = process.env.HOME;
+  if (home) {
+    const rel = path.relative(home, value);
+    if (rel === '') return '~';
+    if (!rel.startsWith('..') && !path.isAbsolute(rel)) return `~/${rel}`;
+  }
+  return value;
+}

--- a/apps/cli/src/commands/ssh.test.ts
+++ b/apps/cli/src/commands/ssh.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+
+let testHome = '';
+
+afterEach(() => {
+  if (testHome) fs.rmSync(testHome, { recursive: true, force: true });
+  testHome = '';
+});
+
+function guardedHome(): void {
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-home-'));
+  const systemDir = path.join(testHome, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+}
+
+function run(args: string[]): { stdout: string; status: number | null } {
+  const r = spawnSync('bun', [INDEX, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: testHome, AGENTS_NO_UPDATE_CHECK: '1' },
+  });
+  return { stdout: r.stdout ?? '', status: r.status };
+}
+
+describe('devices command', () => {
+  it('runs the list action when invoked without a subcommand', () => {
+    guardedHome();
+    const { stdout, status } = run(['devices']);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("No devices. Run 'agents devices sync'");
+    expect(stdout).not.toContain('Usage: agents devices');
+  });
+});

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -680,6 +680,54 @@ Typical workflow:
       console.log(chalk.green(`No longer ignoring '${name}'`) + chalk.gray(' — run `agents devices sync` to register it.'));
     });
 
+  const runList = async (opts: { json?: boolean; stats?: boolean; full?: boolean; refresh?: boolean; live?: boolean } = {}) => {
+    const reg = await loadDevices();
+    const names = Object.keys(reg).sort();
+    if (opts.json) {
+      // Registry-only, always fast — the Factory extension polls this path.
+      process.stdout.write(JSON.stringify(names.map((n) => reg[n]), null, 2) + '\n');
+      return;
+    }
+    if (names.length === 0) {
+      console.log(chalk.gray("No devices. Run 'agents devices sync' or 'agents devices add <name> <user@host>'."));
+      return;
+    }
+    const self = machineId();
+    const forceRefresh = Boolean(opts.refresh || opts.live);
+
+    let statsMap: Map<string, DeviceStats> | undefined;
+    let freshness: { oldestFetchedAt: number | null; servedFromCache: boolean } | undefined;
+    if (opts.stats !== false) {
+      // Cache-first: serve remote devices from the daemon-warmed cache
+      // (instant), probe this machine locally, and only ssh out for missing or
+      // forced (--refresh/--live) rows — so a warm read never hangs on a box.
+      const probeable = planFleetTargets(reg)
+        .filter((t) => !t.skip)
+        .map((t) => t.device);
+      // Only spin when we'll actually ssh (forced, or a cold/partial cache).
+      const cache = readStatsCache();
+      const willSsh = forceRefresh || probeable.some((d) => d.name !== self && !cache[d.name]);
+      const spinner = willSsh && isInteractiveTerminal()
+        ? ora(`Probing ${probeable.length} device${probeable.length === 1 ? '' : 's'}…`).start()
+        : undefined;
+      try {
+        const res = await loadFleetStats(probeable, { forceRefresh, selfName: self });
+        statsMap = res.stats;
+        freshness = res;
+      } finally {
+        spinner?.stop();
+      }
+    }
+
+    console.log(chalk.bold(`Devices (${names.length})`));
+    for (const line of renderDeviceTable(reg, names, self, statsMap, opts.full)) console.log(line);
+    if (freshness?.servedFromCache && freshness.oldestFetchedAt != null) {
+      console.log(chalk.gray(`  updated ${formatCheckedAge(freshness.oldestFetchedAt)} — pass --refresh (--live) for a live probe`));
+    }
+  };
+
+  devicesCmd.action(runList);
+
   devicesCmd
     .command('list')
     .alias('ls')
@@ -689,51 +737,7 @@ Typical workflow:
     .option('--refresh', 'force a live probe of every device, bypassing the cache')
     .option('--live', 'alias of --refresh (shorter to type)')
     .option('-f, --full', 'full mode: add per-device core count and free/total memory')
-    .action(async (opts: { json?: boolean; stats?: boolean; full?: boolean; refresh?: boolean; live?: boolean }) => {
-      const reg = await loadDevices();
-      const names = Object.keys(reg).sort();
-      if (opts.json) {
-        // Registry-only, always fast — the Factory extension polls this path.
-        process.stdout.write(JSON.stringify(names.map((n) => reg[n]), null, 2) + '\n');
-        return;
-      }
-      if (names.length === 0) {
-        console.log(chalk.gray("No devices. Run 'agents devices sync' or 'agents devices add <name> <user@host>'."));
-        return;
-      }
-      const self = machineId();
-      const forceRefresh = Boolean(opts.refresh || opts.live);
-
-      let statsMap: Map<string, DeviceStats> | undefined;
-      let freshness: { oldestFetchedAt: number | null; servedFromCache: boolean } | undefined;
-      if (opts.stats !== false) {
-        // Cache-first: serve remote devices from the daemon-warmed cache
-        // (instant), probe this machine locally, and only ssh out for missing or
-        // forced (--refresh/--live) rows — so a warm read never hangs on a box.
-        const probeable = planFleetTargets(reg)
-          .filter((t) => !t.skip)
-          .map((t) => t.device);
-        // Only spin when we'll actually ssh (forced, or a cold/partial cache).
-        const cache = readStatsCache();
-        const willSsh = forceRefresh || probeable.some((d) => d.name !== self && !cache[d.name]);
-        const spinner = willSsh && isInteractiveTerminal()
-          ? ora(`Probing ${probeable.length} device${probeable.length === 1 ? '' : 's'}…`).start()
-          : undefined;
-        try {
-          const res = await loadFleetStats(probeable, { forceRefresh, selfName: self });
-          statsMap = res.stats;
-          freshness = res;
-        } finally {
-          spinner?.stop();
-        }
-      }
-
-      console.log(chalk.bold(`Devices (${names.length})`));
-      for (const line of renderDeviceTable(reg, names, self, statsMap, opts.full)) console.log(line);
-      if (freshness?.servedFromCache && freshness.oldestFetchedAt != null) {
-        console.log(chalk.gray(`  updated ${formatCheckedAge(freshness.oldestFetchedAt)} — pass --refresh (--live) for a live probe`));
-      }
-    });
+    .action(runList);
 
   devicesCmd
     .command('status')

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -75,6 +75,7 @@ import {
   LAZY_COMMAND_NAMES,
   loadView,
   loadInspect,
+  loadResources,
   loadFeedback,
   loadCommands,
   loadHooks,
@@ -253,6 +254,7 @@ Agent versions:
   trash                           Inspect and restore soft-deleted version directories
   view [agent[@version]]          List versions, or inspect one in detail
   inspect <target>                Deep details for one agent+version, or a DotAgents repo (user|system|project|alias|path)
+  resources                       Show merged DotAgents resources with their winning layer
 
 Agent configuration (synced across versions):
   rules                           Instructions given to agents (CLAUDE.md, etc.)
@@ -804,6 +806,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadView);
   await reg(loadShare);
   await reg(loadInspect);
+  await reg(loadResources);
   await reg(loadFeedback);
   await reg(loadCommands);
   await reg(loadHooks);

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -31,6 +31,7 @@ export type ModuleLoader = () => Promise<Registrar>;
 // them into the exact main-branch registration order for the slow path.
 export const loadView: ModuleLoader = async () => (await import('../../commands/view.js')).registerViewCommand;
 export const loadInspect: ModuleLoader = async () => (await import('../../commands/inspect.js')).registerInspectCommand;
+export const loadResources: ModuleLoader = async () => (await import('../../commands/resources.js')).registerResourcesCommand;
 export const loadFeedback: ModuleLoader = async () => (await import('../../commands/feedback.js')).registerFeedbackCommand;
 export const loadCommands: ModuleLoader = async () => (await import('../../commands/commands.js')).registerCommandsCommands;
 export const loadHooks: ModuleLoader = async () => (await import('../../commands/hooks.js')).registerHooksCommands;
@@ -130,6 +131,7 @@ export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set(['sessions', 'tea
 export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   view: [loadView],
   inspect: [loadInspect],
+  resources: [loadResources],
   feedback: [loadFeedback],
   commands: [loadCommands],
   hooks: [loadHooks],


### PR DESCRIPTION
## Summary
- Add `agents resources [--merged]` to print the merged DotAgents resource surface across skills, commands, MCP, hooks, rules, plugins, workflows, and subagents with the winning layer per row.
- Make bare `agents devices` run the existing list action, and add `agents plugins add <spec>` as an alias for `agents plugins install <spec>`.
- Update README and CHANGELOG for the user-visible command surfaces.

## Verification
- `env TMPDIR=/tmp BUN_TMPDIR=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache XDG_CACHE_HOME=/tmp/.cache bun run build` passed.
- `env TMPDIR=/tmp BUN_TMPDIR=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache XDG_CACHE_HOME=/tmp/.cache bun test src/commands/resources.test.ts src/commands/ssh.test.ts src/commands/plugins.test.ts` passed: 7 tests, 29 assertions.
- Built CLI smoke checks passed from this branch:
  - `node apps/cli/dist/index.js resources --merged` exited 0 and printed `shared project` plus `system-only system` in the merged table.
  - `node apps/cli/dist/index.js devices` exited 0 and printed `No devices. Run 'agents devices sync'...` instead of help.
  - `node apps/cli/dist/index.js plugins add /tmp/agents-pr-e2e-plugin-*` exited 0 and installed `e2e-plugin v1.0.0`; the copied manifest existed at `~/.agents/plugins/e2e-plugin/.claude-plugin/plugin.json` in the isolated HOME.

## Broad Suite Note
- I started `bun test` for the full CLI suite and stopped it after it entered repeated unrelated environment failures against this sandbox, including read-only writes under `/home/muqsit/.agents`, missing local agent binaries, stale global mailbox state, and older Vitest API incompatibilities. The focused command tests above passed on the latest-main PR worktree.

## Transcript
- Public repo: transcript content omitted. Local transcript JSONL path was not available in this runner.
