### PR TITLE
feat(factory): add MCP Resources tab

### DIFF
--- a/apps/factory/src/core/mcpResources.test.ts
+++ b/apps/factory/src/core/mcpResources.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { listMcpResources, readMcpResource } from './mcpResources';
+
+function makeWorkspace(): string {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'factory-mcp-resources-'));
+  const mcpDir = path.join(workspace, '.agents', 'mcp');
+  fs.mkdirSync(mcpDir, { recursive: true });
+  const serverPath = path.join(__dirname, 'testdata', 'mcp-resource-server.cjs');
+  fs.writeFileSync(
+    path.join(mcpDir, 'fixture.yaml'),
+    [
+      'name: fixture',
+      'transport: stdio',
+      `command: ${JSON.stringify(process.execPath)}`,
+      'args:',
+      `  - ${JSON.stringify(serverPath)}`,
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  return workspace;
+}
+
+test('listMcpResources lists resources from a real stdio MCP server', async () => {
+  const workspace = makeWorkspace();
+
+  const result = await listMcpResources(workspace);
+
+  expect(result.servers).toEqual([{ name: 'fixture', scope: 'project', connected: true }]);
+  expect(result.resources).toEqual([
+    {
+      serverName: 'fixture',
+      uri: 'fixture://config',
+      name: 'config',
+      description: 'Fixture JSON config',
+      mimeType: 'application/json',
+      size: undefined,
+      title: undefined,
+    },
+  ]);
+}, 15_000);
+
+test('readMcpResource reads selected resource content from a real stdio MCP server', async () => {
+  const workspace = makeWorkspace();
+
+  const result = await readMcpResource('fixture', 'fixture://config', workspace);
+
+  expect(result.serverName).toBe('fixture');
+  expect(result.uri).toBe('fixture://config');
+  expect(result.contents).toEqual([
+    { uri: 'fixture://config', mimeType: 'application/json', text: '{"ok":true}' },
+  ]);
+}, 15_000);

--- a/apps/factory/src/core/mcpResources.ts
+++ b/apps/factory/src/core/mcpResources.ts
@@ -1,0 +1,195 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { homedir } from 'os';
+import * as yaml from 'yaml';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Resource, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+
+export interface McpServerConfig {
+  name: string;
+  transport: 'stdio' | 'http' | 'sse';
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+}
+
+export interface McpServerEntry {
+  name: string;
+  path: string;
+  scope: 'project' | 'user' | 'system';
+  config: McpServerConfig;
+}
+
+export interface McpResourceItem {
+  serverName: string;
+  uri: string;
+  name: string;
+  title?: string;
+  description?: string;
+  mimeType?: string;
+  size?: number;
+}
+
+export interface McpResourceServerStatus {
+  name: string;
+  scope: 'project' | 'user' | 'system';
+  connected: boolean;
+  error?: string;
+}
+
+export interface McpResourceListResult {
+  servers: McpResourceServerStatus[];
+  resources: McpResourceItem[];
+}
+
+export interface McpResourceReadResult {
+  serverName: string;
+  uri: string;
+  contents: ReadResourceResult['contents'];
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return Object.values(value).every((item) => typeof item === 'string');
+}
+
+function mergeEnv(overrides?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === 'string') env[key] = value;
+  }
+  return { ...env, ...(overrides ?? {}) };
+}
+
+function parseMcpServerConfig(filePath: string): McpServerConfig | null {
+  let parsed: unknown;
+  try {
+    parsed = yaml.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const raw = parsed as Record<string, unknown>;
+  if (typeof raw.name !== 'string' || raw.name.trim().length === 0) return null;
+  if (raw.transport !== 'stdio' && raw.transport !== 'http' && raw.transport !== 'sse') return null;
+
+  const config: McpServerConfig = { name: raw.name, transport: raw.transport };
+  if (raw.transport === 'stdio') {
+    if (typeof raw.command !== 'string' || raw.command.trim().length === 0) return null;
+    config.command = raw.command;
+    if (Array.isArray(raw.args) && raw.args.every((arg) => typeof arg === 'string')) config.args = raw.args;
+    if (isStringRecord(raw.env)) config.env = raw.env;
+  } else {
+    if (typeof raw.url !== 'string' || raw.url.trim().length === 0) return null;
+    config.url = raw.url;
+    if (isStringRecord(raw.headers)) config.headers = raw.headers;
+  }
+  return config;
+}
+
+function listYamlConfigs(dir: string, scope: McpServerEntry['scope']): McpServerEntry[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const results: McpServerEntry[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || (!entry.name.endsWith('.yaml') && !entry.name.endsWith('.yml'))) continue;
+    const filePath = path.join(dir, entry.name);
+    const config = parseMcpServerConfig(filePath);
+    if (config) results.push({ name: config.name, path: filePath, scope, config });
+  }
+  return results;
+}
+
+export function listMcpServerEntries(workspacePath?: string): McpServerEntry[] {
+  const dirs: Array<{ dir: string; scope: McpServerEntry['scope'] }> = [];
+  if (workspacePath) dirs.push({ dir: path.join(workspacePath, '.agents', 'mcp'), scope: 'project' });
+  dirs.push({ dir: path.join(homedir(), '.agents', 'mcp'), scope: 'user' });
+  dirs.push({ dir: path.join(homedir(), '.agents', '.system', 'mcp'), scope: 'system' });
+
+  const byName = new Map<string, McpServerEntry>();
+  for (const { dir, scope } of dirs) {
+    for (const server of listYamlConfigs(dir, scope)) {
+      if (!byName.has(server.name)) byName.set(server.name, server);
+    }
+  }
+  return Array.from(byName.values());
+}
+
+async function withMcpClient<T>(server: McpServerEntry, fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ name: 'factory-resources', version: '0.1.0' });
+  const headers = server.config.headers ? { headers: server.config.headers } : undefined;
+  const transport = server.config.transport === 'stdio'
+    ? new StdioClientTransport({
+        command: server.config.command!,
+        args: server.config.args ?? [],
+        env: mergeEnv(server.config.env),
+        stderr: 'pipe',
+      })
+    : server.config.transport === 'sse'
+      ? new SSEClientTransport(new URL(server.config.url!), { requestInit: headers })
+      : new StreamableHTTPClientTransport(new URL(server.config.url!), { requestInit: headers });
+
+  try {
+    await client.connect(transport);
+    return await fn(client);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+function toResourceItem(serverName: string, resource: Resource): McpResourceItem {
+  return {
+    serverName,
+    uri: resource.uri,
+    name: resource.name,
+    title: resource.title,
+    description: resource.description,
+    mimeType: resource.mimeType,
+    size: resource.size,
+  };
+}
+
+export async function listMcpResources(workspacePath?: string): Promise<McpResourceListResult> {
+  const servers = listMcpServerEntries(workspacePath);
+  const statuses: McpResourceServerStatus[] = [];
+  const resources: McpResourceItem[] = [];
+
+  await Promise.all(servers.map(async (server) => {
+    try {
+      const listed = await withMcpClient(server, (client) => client.listResources({}, { timeout: 10_000 }));
+      resources.push(...listed.resources.map((resource) => toResourceItem(server.name, resource)));
+      statuses.push({ name: server.name, scope: server.scope, connected: true });
+    } catch (error) {
+      statuses.push({
+        name: server.name,
+        scope: server.scope,
+        connected: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }));
+
+  resources.sort((a, b) => `${a.serverName}:${a.name}`.localeCompare(`${b.serverName}:${b.name}`));
+  statuses.sort((a, b) => a.name.localeCompare(b.name));
+  return { servers: statuses, resources };
+}
+
+export async function readMcpResource(
+  serverName: string,
+  uri: string,
+  workspacePath?: string,
+): Promise<McpResourceReadResult> {
+  const server = listMcpServerEntries(workspacePath).find((entry) => entry.name === serverName);
+  if (!server) throw new Error(`MCP server not found: ${serverName}`);
+  const result = await withMcpClient(server, (client) => client.readResource({ uri }, { timeout: 10_000 }));
+  return { serverName, uri, contents: result.contents };
+}

--- a/apps/factory/src/core/testdata/mcp-resource-server.cjs
+++ b/apps/factory/src/core/testdata/mcp-resource-server.cjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const readline = require('node:readline')
+
+const rl = readline.createInterface({ input: process.stdin })
+
+function send(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n')
+}
+
+rl.on('line', (line) => {
+  const message = JSON.parse(line)
+  if (message.method === 'initialize') {
+    send(message.id, {
+      protocolVersion: message.params.protocolVersion,
+      capabilities: { resources: {} },
+      serverInfo: { name: 'fixture-resources', version: '1.0.0' },
+    })
+    return
+  }
+  if (message.method === 'resources/list') {
+    send(message.id, {
+      resources: [
+        {
+          uri: 'fixture://config',
+          name: 'config',
+          description: 'Fixture JSON config',
+          mimeType: 'application/json',
+        },
+      ],
+    })
+    return
+  }
+  if (message.method === 'resources/read') {
+    send(message.id, {
+      contents: [
+        {
+          uri: message.params.uri,
+          mimeType: 'application/json',
+          text: '{"ok":true}',
+        },
+      ],
+    })
+    return
+  }
+})

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -52,6 +52,7 @@ import { scanMemoryFiles } from './contextFiles';
 import { fetchAllAgentModels, checkInstalledAgentsViaCli, resolveAlias } from '../core/agentModels';
 import { fetchAgentInventories, writeAgentRunStrategy, AgentRunStrategy, AgentInventory, normalizeRunStrategy } from '../core/agentInventory';
 import { getAgentResources, invalidateAgentResourcesCache } from '../core/agentResources';
+import { listMcpResources, readMcpResource } from '../core/mcpResources';
 import * as workbench from './workbench.vscode';
 import * as theme from './theme.vscode';
 import { buildAgentTerminalEnv } from '../core/terminals';
@@ -1994,6 +1995,39 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         } catch (err) {
           console.error('[SETTINGS] Error fetching agent resources:', err);
           settingsPanel?.webview.postMessage({ type: 'agentResourcesData', repos: [] });
+        }
+        break;
+      }
+      case 'fetchMcpResources': {
+        const wsPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        try {
+          const result = await listMcpResources(wsPath);
+          settingsPanel?.webview.postMessage({ type: 'mcpResourcesData', ...result });
+        } catch (err) {
+          console.error('[SETTINGS] Error fetching MCP resources:', err);
+          settingsPanel?.webview.postMessage({ type: 'mcpResourcesData', servers: [], resources: [] });
+        }
+        break;
+      }
+      case 'readMcpResource': {
+        const wsPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const serverName = typeof message.serverName === 'string' ? message.serverName : '';
+        const uri = typeof message.uri === 'string' ? message.uri : '';
+        if (!serverName || !uri) {
+          settingsPanel?.webview.postMessage({ type: 'mcpResourceReadError', serverName, uri, error: 'Missing server or URI.' });
+          break;
+        }
+        try {
+          const result = await readMcpResource(serverName, uri, wsPath);
+          settingsPanel?.webview.postMessage({ type: 'mcpResourceReadData', ...result });
+        } catch (err) {
+          console.error('[SETTINGS] Error reading MCP resource:', err);
+          settingsPanel?.webview.postMessage({
+            type: 'mcpResourceReadError',
+            serverName,
+            uri,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
         break;
       }

--- a/apps/factory/ui/settings/App.tsx
+++ b/apps/factory/ui/settings/App.tsx
@@ -38,6 +38,7 @@ import type { TabKey } from './components/mission-control'
 // Tab components (legacy, for Bench and Panel)
 import { BenchTab } from './components/bench'
 import { PanelTab } from './components/panel'
+import { ResourcesTab } from './components/resources'
 import { GuideTab } from './components/tabs/GuideTab'
 import { ApiKeyDialog } from './components/common/OAuthDialog'
 import { ForemanOrb, ForemanCursor } from './components/foreman'
@@ -851,6 +852,10 @@ export default function App() {
           openBenchTaskId={openBenchTaskId}
           onOpenBenchTaskConsumed={() => setOpenBenchTaskId(null)}
         />
+      )}
+
+      {activeTab === 'resources' && (
+        <ResourcesTab />
       )}
 
       {/* Panel (settings - 2-column sidebar layout) */}

--- a/apps/factory/ui/settings/components/mission-control/TopBar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/TopBar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Icon } from './icons'
 import { ThroughputCounter } from './UnifiedAgentsPane'
 
-export type TabKey = 'floor' | 'bench' | 'panel'
+export type TabKey = 'floor' | 'bench' | 'resources' | 'panel'
 
 interface TopBarProps {
   version?: string
@@ -69,6 +69,13 @@ export function TopBar({
           onClick={() => onTabChange('bench')}
         >
           Bench
+        </button>
+        <button
+          data-foreman-id="tab-resources"
+          className={`sw-tab ${activeTab === 'resources' ? 'active' : ''}`}
+          onClick={() => onTabChange('resources')}
+        >
+          Resources
         </button>
         <button
           data-foreman-id="tab-panel"

--- a/apps/factory/ui/settings/components/resources/ResourceViewer.test.tsx
+++ b/apps/factory/ui/settings/components/resources/ResourceViewer.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+if (typeof (globalThis as { document?: unknown }).document === 'undefined') GlobalRegistrator.register()
+
+const React = require('react')
+const { act } = require('react')
+const { createRoot } = require('react-dom/client')
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+async function render(element: React.ReactElement) {
+  const rootElement = document.createElement('div')
+  document.body.appendChild(rootElement)
+  const root = createRoot(rootElement)
+  await act(async () => {
+    root.render(element)
+  })
+  return root
+}
+
+describe('ResourceViewer MIME rendering', () => {
+  test('pretty-prints JSON text resources', async () => {
+    const { ResourceViewer } = await import('./ResourceViewer')
+    const root = await render(React.createElement(ResourceViewer, {
+      selected: { serverName: 'demo', uri: 'demo://config', name: 'config', mimeType: 'application/json' },
+      contents: [{ uri: 'demo://config', text: '{"ok":true}', mimeType: 'application/json' }],
+      loading: false,
+      error: null,
+    }))
+
+    expect(document.body.textContent).toContain('"ok": true')
+    root.unmount()
+  })
+
+  test('renders image blobs as data URLs', async () => {
+    const { ResourceViewer } = await import('./ResourceViewer')
+    const root = await render(React.createElement(ResourceViewer, {
+      selected: { serverName: 'demo', uri: 'demo://image', name: 'image', mimeType: 'image/png' },
+      contents: [{ uri: 'demo://image', blob: 'iVBORw0KGgo=', mimeType: 'image/png' }],
+      loading: false,
+      error: null,
+    }))
+
+    const img = document.querySelector('img') as HTMLImageElement | null
+    expect(img?.src).toBe('data:image/png;base64,iVBORw0KGgo=')
+    root.unmount()
+  })
+
+  test('summarizes non-image blobs as binary byte counts', async () => {
+    const { ResourceViewer } = await import('./ResourceViewer')
+    const root = await render(React.createElement(ResourceViewer, {
+      selected: { serverName: 'demo', uri: 'demo://archive', name: 'archive', mimeType: 'application/octet-stream' },
+      contents: [{ uri: 'demo://archive', blob: 'AQIDBA==', mimeType: 'application/octet-stream' }],
+      loading: false,
+      error: null,
+    }))
+
+    expect(document.body.textContent).toContain('Binary 4 bytes')
+    root.unmount()
+  })
+})

--- a/apps/factory/ui/settings/components/resources/ResourceViewer.tsx
+++ b/apps/factory/ui/settings/components/resources/ResourceViewer.tsx
@@ -1,16 +1,49 @@
 import React from 'react'
 
 export interface ResourceViewerSelection {
+  serverName: string
   uri: string
   name?: string
   mimeType?: string
 }
 
+export type ResourceContent =
+  | { uri: string; text: string; mimeType?: string }
+  | { uri: string; blob: string; mimeType?: string }
+
 interface ResourceViewerProps {
   selected: ResourceViewerSelection | null
+  contents: ResourceContent[] | null
+  loading: boolean
+  error: string | null
 }
 
-export function ResourceViewer({ selected }: ResourceViewerProps) {
+function prettyJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2)
+  } catch {
+    return text
+  }
+}
+
+function blobBytes(base64: string): number {
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0
+  return Math.max(0, Math.floor(base64.length * 3 / 4) - padding)
+}
+
+export function ResourceContentBlock({ content }: { content: ResourceContent }) {
+  const mimeType = content.mimeType || 'application/octet-stream'
+  if ('text' in content) {
+    const display = mimeType.includes('json') ? prettyJson(content.text) : content.text
+    return <pre className="sw-resource-pre">{display}</pre>
+  }
+  if (mimeType.startsWith('image/')) {
+    return <img className="sw-resource-image" src={`data:${mimeType};base64,${content.blob}`} alt={content.uri} />
+  }
+  return <div className="sw-resource-binary">Binary {blobBytes(content.blob)} bytes</div>
+}
+
+export function ResourceViewer({ selected, contents, loading, error }: ResourceViewerProps) {
   if (!selected) {
     return (
       <section className="sw-resource-viewer">
@@ -25,7 +58,19 @@ export function ResourceViewer({ selected }: ResourceViewerProps) {
         <div className="sw-resource-title">{selected.name || selected.uri}</div>
         {selected.mimeType && <span className="sw-resource-mime">{selected.mimeType}</span>}
       </div>
-      <div className="sw-resource-empty">Resource reader wiring pending.</div>
+      {loading ? (
+        <div className="sw-resource-empty">Reading resource...</div>
+      ) : error ? (
+        <div className="sw-resource-error">{error}</div>
+      ) : contents && contents.length > 0 ? (
+        <div className="sw-resource-content">
+          {contents.map((content, index) => (
+            <ResourceContentBlock key={`${content.uri}-${index}`} content={content} />
+          ))}
+        </div>
+      ) : (
+        <div className="sw-resource-empty">No content returned.</div>
+      )}
     </section>
   )
 }

--- a/apps/factory/ui/settings/components/resources/ResourceViewer.tsx
+++ b/apps/factory/ui/settings/components/resources/ResourceViewer.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export interface ResourceViewerSelection {
+  uri: string
+  name?: string
+  mimeType?: string
+}
+
+interface ResourceViewerProps {
+  selected: ResourceViewerSelection | null
+}
+
+export function ResourceViewer({ selected }: ResourceViewerProps) {
+  if (!selected) {
+    return (
+      <section className="sw-resource-viewer">
+        <div className="sw-resource-empty">Select a resource to inspect its content.</div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="sw-resource-viewer">
+      <div className="sw-resource-viewer-head">
+        <div className="sw-resource-title">{selected.name || selected.uri}</div>
+        {selected.mimeType && <span className="sw-resource-mime">{selected.mimeType}</span>}
+      </div>
+      <div className="sw-resource-empty">Resource reader wiring pending.</div>
+    </section>
+  )
+}

--- a/apps/factory/ui/settings/components/resources/ResourcesList.tsx
+++ b/apps/factory/ui/settings/components/resources/ResourcesList.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react'
+import type { ResourceViewerSelection } from './ResourceViewer'
+
+interface ResourcesListProps {
+  onSelect: (resource: ResourceViewerSelection) => void
+}
+
+const SKELETON_RESOURCES: ResourceViewerSelection[] = []
+
+export function ResourcesList({ onSelect }: ResourcesListProps) {
+  const [resources] = useState(SKELETON_RESOURCES)
+
+  return (
+    <section className="sw-resources-list">
+      <div className="sw-resources-list-head">
+        <span>MCP Resources</span>
+        <button type="button" className="sw-resource-refresh" disabled>
+          Refresh
+        </button>
+      </div>
+      {resources.length === 0 ? (
+        <div className="sw-resource-empty">Connect an MCP server to browse resources.</div>
+      ) : (
+        <div className="sw-resource-items">
+          {resources.map((resource) => (
+            <button key={resource.uri} type="button" className="sw-resource-row" onClick={() => onSelect(resource)}>
+              <span>{resource.name || resource.uri}</span>
+              {resource.mimeType && <span>{resource.mimeType}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/factory/ui/settings/components/resources/ResourcesList.tsx
+++ b/apps/factory/ui/settings/components/resources/ResourcesList.tsx
@@ -1,33 +1,48 @@
-import React, { useState } from 'react'
+import React from 'react'
 import type { ResourceViewerSelection } from './ResourceViewer'
 
 interface ResourcesListProps {
+  resources: ResourceViewerSelection[]
+  servers: Array<{ name: string; scope: string; connected: boolean; error?: string }>
+  selected: ResourceViewerSelection | null
+  loading: boolean
   onSelect: (resource: ResourceViewerSelection) => void
+  onRefresh: () => void
 }
 
-const SKELETON_RESOURCES: ResourceViewerSelection[] = []
-
-export function ResourcesList({ onSelect }: ResourcesListProps) {
-  const [resources] = useState(SKELETON_RESOURCES)
+export function ResourcesList({ resources, servers, selected, loading, onSelect, onRefresh }: ResourcesListProps) {
+  const hasDisconnected = servers.some((server) => !server.connected)
 
   return (
     <section className="sw-resources-list">
       <div className="sw-resources-list-head">
         <span>MCP Resources</span>
-        <button type="button" className="sw-resource-refresh" disabled>
+        <button type="button" className="sw-resource-refresh" disabled={loading} onClick={onRefresh}>
           Refresh
         </button>
       </div>
-      {resources.length === 0 ? (
+      {loading ? (
+        <div className="sw-resource-empty">Loading MCP resources...</div>
+      ) : resources.length === 0 ? (
         <div className="sw-resource-empty">Connect an MCP server to browse resources.</div>
       ) : (
         <div className="sw-resource-items">
           {resources.map((resource) => (
-            <button key={resource.uri} type="button" className="sw-resource-row" onClick={() => onSelect(resource)}>
-              <span>{resource.name || resource.uri}</span>
-              {resource.mimeType && <span>{resource.mimeType}</span>}
+            <button
+              key={`${resource.serverName}:${resource.uri}`}
+              type="button"
+              className={`sw-resource-row ${selected?.serverName === resource.serverName && selected?.uri === resource.uri ? 'active' : ''}`}
+              onClick={() => onSelect(resource)}
+            >
+              <span className="sw-resource-row-name">{resource.name || resource.uri}</span>
+              <span className="sw-resource-row-meta">{resource.serverName}{resource.mimeType ? ` - ${resource.mimeType}` : ''}</span>
             </button>
           ))}
+        </div>
+      )}
+      {hasDisconnected && (
+        <div className="sw-resource-reconnect">
+          Reconnect the failed MCP server, then refresh this tab.
         </div>
       )}
     </section>

--- a/apps/factory/ui/settings/components/resources/ResourcesTab.tsx
+++ b/apps/factory/ui/settings/components/resources/ResourcesTab.tsx
@@ -1,0 +1,14 @@
+import React, { useState } from 'react'
+import { ResourcesList } from './ResourcesList'
+import { ResourceViewer, type ResourceViewerSelection } from './ResourceViewer'
+
+export function ResourcesTab() {
+  const [selected, setSelected] = useState<ResourceViewerSelection | null>(null)
+
+  return (
+    <main className="sw-resources-tab">
+      <ResourcesList onSelect={setSelected} />
+      <ResourceViewer selected={selected} />
+    </main>
+  )
+}

--- a/apps/factory/ui/settings/components/resources/ResourcesTab.tsx
+++ b/apps/factory/ui/settings/components/resources/ResourcesTab.tsx
@@ -1,14 +1,84 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import { postMessage } from '../../hooks'
 import { ResourcesList } from './ResourcesList'
-import { ResourceViewer, type ResourceViewerSelection } from './ResourceViewer'
+import { ResourceViewer, type ResourceContent, type ResourceViewerSelection } from './ResourceViewer'
+
+type ServerStatus = { name: string; scope: string; connected: boolean; error?: string }
 
 export function ResourcesTab() {
+  const [resources, setResources] = useState<ResourceViewerSelection[]>([])
+  const [servers, setServers] = useState<ServerStatus[]>([])
+  const [loading, setLoading] = useState(false)
   const [selected, setSelected] = useState<ResourceViewerSelection | null>(null)
+  const [contents, setContents] = useState<ResourceContent[] | null>(null)
+  const [reading, setReading] = useState(false)
+  const [readError, setReadError] = useState<string | null>(null)
+  const selectedRef = useRef<ResourceViewerSelection | null>(null)
+
+  const refresh = () => {
+    setLoading(true)
+    postMessage({ type: 'fetchMcpResources' })
+  }
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      const message = event.data
+      if (message?.type === 'mcpResourcesData') {
+        setServers(Array.isArray(message.servers) ? message.servers : [])
+        const nextResources = Array.isArray(message.resources) ? message.resources : []
+        setResources(nextResources)
+        const current = selectedRef.current
+        if (current && !nextResources.some((item) => item.serverName === current.serverName && item.uri === current.uri)) {
+          selectedRef.current = null
+          setSelected(null)
+          setContents(null)
+          setReadError(null)
+          setReading(false)
+        }
+        setLoading(false)
+      }
+      if (message?.type === 'mcpResourceReadData') {
+        const current = selectedRef.current
+        if (current && message.serverName === current.serverName && message.uri === current.uri) {
+          setContents(Array.isArray(message.contents) ? message.contents : [])
+          setReadError(null)
+          setReading(false)
+        }
+      }
+      if (message?.type === 'mcpResourceReadError') {
+        const current = selectedRef.current
+        if (current && message.serverName === current.serverName && message.uri === current.uri) {
+          setContents(null)
+          setReadError(typeof message.error === 'string' ? message.error : 'Failed to read resource.')
+          setReading(false)
+        }
+      }
+    }
+    window.addEventListener('message', onMessage)
+    refresh()
+    return () => window.removeEventListener('message', onMessage)
+  }, [])
+
+  const selectResource = (resource: ResourceViewerSelection) => {
+    selectedRef.current = resource
+    setSelected(resource)
+    setContents(null)
+    setReadError(null)
+    setReading(true)
+    postMessage({ type: 'readMcpResource', serverName: resource.serverName, uri: resource.uri })
+  }
 
   return (
     <main className="sw-resources-tab">
-      <ResourcesList onSelect={setSelected} />
-      <ResourceViewer selected={selected} />
+      <ResourcesList
+        resources={resources}
+        servers={servers}
+        selected={selected}
+        loading={loading}
+        onSelect={selectResource}
+        onRefresh={refresh}
+      />
+      <ResourceViewer selected={selected} contents={contents} loading={reading} error={readError} />
     </main>
   )
 }

--- a/apps/factory/ui/settings/components/resources/index.ts
+++ b/apps/factory/ui/settings/components/resources/index.ts
@@ -1,0 +1,4 @@
+export { ResourcesTab } from './ResourcesTab'
+export { ResourcesList } from './ResourcesList'
+export { ResourceViewer } from './ResourceViewer'
+export type { ResourceViewerSelection } from './ResourceViewer'

--- a/apps/factory/ui/settings/index.css
+++ b/apps/factory/ui/settings/index.css
@@ -541,3 +541,80 @@ input[type="number"]::-webkit-inner-spin-button {
     animation: none;
   }
 }
+
+.sw-resources-tab {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 1px;
+  height: calc(100vh - 64px);
+  background: var(--ds-border);
+  border-top: 1px solid var(--ds-border);
+}
+
+.sw-resources-list,
+.sw-resource-viewer {
+  min-width: 0;
+  background: var(--ds-bg-panel);
+  overflow: hidden;
+}
+
+.sw-resources-list-head,
+.sw-resource-viewer-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--ds-border);
+  color: var(--ds-text);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.sw-resource-refresh {
+  margin-left: auto;
+  border: 1px solid var(--ds-border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  color: var(--ds-text-muted);
+  background: var(--ds-bg);
+  font-size: 11px;
+}
+
+.sw-resource-empty {
+  padding: 16px;
+  color: var(--ds-text-muted);
+  font-size: 12px;
+}
+
+.sw-resource-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sw-resource-mime {
+  margin-left: auto;
+  border: 1px solid var(--ds-border);
+  border-radius: 999px;
+  padding: 2px 8px;
+  color: var(--ds-text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.sw-resource-items {
+  overflow: auto;
+}
+
+.sw-resource-row {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--ds-border);
+  color: var(--ds-text);
+  background: transparent;
+  text-align: left;
+}

--- a/apps/factory/ui/settings/index.css
+++ b/apps/factory/ui/settings/index.css
@@ -587,6 +587,17 @@ input[type="number"]::-webkit-inner-spin-button {
   font-size: 12px;
 }
 
+.sw-resource-error,
+.sw-resource-reconnect {
+  margin: 12px;
+  border: 1px solid color-mix(in srgb, var(--ds-danger, #c03030), transparent 65%);
+  border-radius: 6px;
+  padding: 10px;
+  color: var(--ds-danger, #c03030);
+  background: color-mix(in srgb, var(--ds-danger, #c03030), transparent 92%);
+  font-size: 12px;
+}
+
 .sw-resource-title {
   min-width: 0;
   overflow: hidden;
@@ -617,4 +628,54 @@ input[type="number"]::-webkit-inner-spin-button {
   color: var(--ds-text);
   background: transparent;
   text-align: left;
+}
+
+.sw-resource-row.active,
+.sw-resource-row:hover {
+  background: var(--ds-bg-hover);
+}
+
+.sw-resource-row-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sw-resource-row-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ds-text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.sw-resource-content {
+  height: calc(100% - 43px);
+  overflow: auto;
+  padding: 12px;
+}
+
+.sw-resource-pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--ds-text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.sw-resource-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.sw-resource-binary {
+  color: var(--ds-text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
 }


### PR DESCRIPTION
## Scope
- Adds the agents-dbg Resources tab for browsing MCP resources and selecting a resource to read.
- Wires VS Code webview messages to real MCP list/read calls for stdio, SSE, and Streamable HTTP server configs discovered from DotAgents MCP YAML.
- Renders text inline, pretty-prints JSON, renders image blobs as data URLs, and summarizes other blobs as binary byte counts.

## Verification
- PASS: bun run compile (apps/factory)
- PASS: bun test src/core/mcpResources.test.ts (apps/factory)
- PASS: bun test settings/components/resources/ResourceViewer.test.tsx (apps/factory/ui)
- ATTEMPTED: bun test --timeout 30000 (apps/factory). Stopped after unrelated pre-existing/live-integration failures outside this ticket: tmux pane-death expectation mismatch, draftPrompt live ticket draft null, agentsBin timeout, missing unrelated session summary/activity exports, live Claude session preview null, agent catalog/install assertions, and commitgen live Claude timeout.

## Notes
- Public repo: session transcript omitted from the PR body.
