### PR TITLE
feat(cli): ship resources --merged, devices default list, plugins add alias (RUSH-1770)

### DIFF
--- a/apps/cli/.changelog/next/cli-surfaces-resources-devices-plugins-add.md
+++ b/apps/cli/.changelog/next/cli-surfaces-resources-devices-plugins-add.md
@@ -1,0 +1,9 @@
+- **Ship the CLI surfaces the landing page implies.** Three commands now match the
+  natural interface the docs advertise: `agents resources [--merged]` prints the
+  merged resource surface (skills/commands/mcp/hooks/rules/plugins/workflows/subagents)
+  resolved across the four config layers (project > user > system > extras), each
+  row tagged with its winning layer (`--json` for machine-readable output); bare
+  `agents devices` now defaults to `list` instead of printing help; and
+  `agents plugins add` is a first-class alias of `agents plugins install`. Source:
+  `apps/cli/src/commands/resources.ts`, `apps/cli/src/commands/ssh.ts`,
+  `apps/cli/src/commands/plugins.ts`.

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -584,6 +584,7 @@ Examples:
   // agents plugins install <spec>
   pluginsCmd
     .command('install <spec>')
+    .alias('add')
     .description('Install a plugin from a git URL or local path (format: name@source or source)')
     .option('--allow-exec-surfaces', 'Allow installing plugins that ship executable surfaces')
     .addHelpText('after', `

--- a/apps/cli/src/commands/resources.ts
+++ b/apps/cli/src/commands/resources.ts
@@ -1,0 +1,73 @@
+/**
+ * `agents resources [--merged]` — print the merged resource surface across the
+ * four config layers (project > user > system > extras), each row tagged with the
+ * winning layer.
+ *
+ * The resolution already exists in `listResources()` (lib/resources.ts): it walks
+ * the ordered roots and returns a first-wins union annotated with its `source`
+ * layer. This command just loops the drillable kinds and renders that union — no
+ * new resolution logic. Where `agents inspect <target>` shows ONE layer/repo, this
+ * shows the resolved merged union.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { listResources, type ResourceKind } from '../lib/resources.js';
+
+/** Kinds that resolve across the four config layers, in display order. */
+const MERGED_KINDS: ResourceKind[] = [
+  'skills',
+  'commands',
+  'mcp',
+  'hooks',
+  'rules',
+  'plugins',
+  'workflows',
+  'subagents',
+];
+
+/** Colour a layer tag so the winning source reads at a glance. */
+function tagLayer(source: string): string {
+  switch (source) {
+    case 'project': return chalk.green(source);
+    case 'user': return chalk.cyan(source);
+    case 'system': return chalk.gray(source);
+    default: return chalk.magenta(source); // extra-repo alias
+  }
+}
+
+export function registerResourcesCommand(program: Command): void {
+  program
+    .command('resources')
+    .description('Print the merged resource surface (skills/commands/mcp/hooks/rules/plugins/workflows/subagents) resolved across the four config layers — project > user > system > extras — each row tagged with the winning layer.')
+    .option('--merged', 'resolve the merged union across all layers (default behaviour)')
+    .option('--json', 'emit machine-readable JSON')
+    .action((opts: { merged?: boolean; json?: boolean }) => {
+      const surface = MERGED_KINDS.map((kind) => ({ kind, items: listResources(kind) }));
+
+      if (opts.json) {
+        const out: Record<string, { name: string; source: string; path: string }[]> = {};
+        for (const { kind, items } of surface) {
+          out[kind] = items.map((r) => ({ name: r.name, source: r.source, path: r.path }));
+        }
+        console.log(JSON.stringify(out, null, 2));
+        return;
+      }
+
+      const total = surface.reduce((n, s) => n + s.items.length, 0);
+      if (total === 0) {
+        console.log(chalk.gray('No resources found across project, user, system, or extra repos.'));
+        return;
+      }
+
+      console.log(chalk.bold(`Merged resources (${total})`) + chalk.gray('  project > user > system > extras'));
+      for (const { kind, items } of surface) {
+        if (items.length === 0) continue;
+        console.log('\n' + chalk.bold(kind) + chalk.gray(` (${items.length})`));
+        const nameW = Math.max(...items.map((r) => r.name.length));
+        for (const r of items.sort((a, b) => a.name.localeCompare(b.name))) {
+          console.log(`  ${r.name.padEnd(nameW)}  ${tagLayer(r.source)}`);
+        }
+      }
+    });
+}

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -680,6 +680,57 @@ Typical workflow:
       console.log(chalk.green(`No longer ignoring '${name}'`) + chalk.gray(' — run `agents devices sync` to register it.'));
     });
 
+  const runDevicesList = async (opts: { json?: boolean; stats?: boolean; full?: boolean; refresh?: boolean; live?: boolean }): Promise<void> => {
+    const reg = await loadDevices();
+    const names = Object.keys(reg).sort();
+    if (opts.json) {
+      // Registry-only, always fast — the Factory extension polls this path.
+      process.stdout.write(JSON.stringify(names.map((n) => reg[n]), null, 2) + '\n');
+      return;
+    }
+    if (names.length === 0) {
+      console.log(chalk.gray("No devices. Run 'agents devices sync' or 'agents devices add <name> <user@host>'."));
+      return;
+    }
+    const self = machineId();
+    const forceRefresh = Boolean(opts.refresh || opts.live);
+
+    let statsMap: Map<string, DeviceStats> | undefined;
+    let freshness: { oldestFetchedAt: number | null; servedFromCache: boolean } | undefined;
+    if (opts.stats !== false) {
+      // Cache-first: serve remote devices from the daemon-warmed cache
+      // (instant), probe this machine locally, and only ssh out for missing or
+      // forced (--refresh/--live) rows — so a warm read never hangs on a box.
+      const probeable = planFleetTargets(reg)
+        .filter((t) => !t.skip)
+        .map((t) => t.device);
+      // Only spin when we'll actually ssh (forced, or a cold/partial cache).
+      const cache = readStatsCache();
+      const willSsh = forceRefresh || probeable.some((d) => d.name !== self && !cache[d.name]);
+      const spinner = willSsh && isInteractiveTerminal()
+        ? ora(`Probing ${probeable.length} device${probeable.length === 1 ? '' : 's'}…`).start()
+        : undefined;
+      try {
+        const res = await loadFleetStats(probeable, { forceRefresh, selfName: self });
+        statsMap = res.stats;
+        freshness = res;
+      } finally {
+        spinner?.stop();
+      }
+    }
+
+    console.log(chalk.bold(`Devices (${names.length})`));
+    for (const line of renderDeviceTable(reg, names, self, statsMap, opts.full)) console.log(line);
+    if (freshness?.servedFromCache && freshness.oldestFetchedAt != null) {
+      console.log(chalk.gray(`  updated ${formatCheckedAge(freshness.oldestFetchedAt)} — pass --refresh (--live) for a live probe`));
+    }
+  };
+
+  // Bare `agents devices` → same as `list`. (Flags live on the explicit `list`
+  // subcommand only; declaring them on both parent + child makes commander bind
+  // the flag to the parent, dropping it from the subcommand — see plugins.ts.)
+  devicesCmd.action(runDevicesList);
+
   devicesCmd
     .command('list')
     .alias('ls')
@@ -689,51 +740,7 @@ Typical workflow:
     .option('--refresh', 'force a live probe of every device, bypassing the cache')
     .option('--live', 'alias of --refresh (shorter to type)')
     .option('-f, --full', 'full mode: add per-device core count and free/total memory')
-    .action(async (opts: { json?: boolean; stats?: boolean; full?: boolean; refresh?: boolean; live?: boolean }) => {
-      const reg = await loadDevices();
-      const names = Object.keys(reg).sort();
-      if (opts.json) {
-        // Registry-only, always fast — the Factory extension polls this path.
-        process.stdout.write(JSON.stringify(names.map((n) => reg[n]), null, 2) + '\n');
-        return;
-      }
-      if (names.length === 0) {
-        console.log(chalk.gray("No devices. Run 'agents devices sync' or 'agents devices add <name> <user@host>'."));
-        return;
-      }
-      const self = machineId();
-      const forceRefresh = Boolean(opts.refresh || opts.live);
-
-      let statsMap: Map<string, DeviceStats> | undefined;
-      let freshness: { oldestFetchedAt: number | null; servedFromCache: boolean } | undefined;
-      if (opts.stats !== false) {
-        // Cache-first: serve remote devices from the daemon-warmed cache
-        // (instant), probe this machine locally, and only ssh out for missing or
-        // forced (--refresh/--live) rows — so a warm read never hangs on a box.
-        const probeable = planFleetTargets(reg)
-          .filter((t) => !t.skip)
-          .map((t) => t.device);
-        // Only spin when we'll actually ssh (forced, or a cold/partial cache).
-        const cache = readStatsCache();
-        const willSsh = forceRefresh || probeable.some((d) => d.name !== self && !cache[d.name]);
-        const spinner = willSsh && isInteractiveTerminal()
-          ? ora(`Probing ${probeable.length} device${probeable.length === 1 ? '' : 's'}…`).start()
-          : undefined;
-        try {
-          const res = await loadFleetStats(probeable, { forceRefresh, selfName: self });
-          statsMap = res.stats;
-          freshness = res;
-        } finally {
-          spinner?.stop();
-        }
-      }
-
-      console.log(chalk.bold(`Devices (${names.length})`));
-      for (const line of renderDeviceTable(reg, names, self, statsMap, opts.full)) console.log(line);
-      if (freshness?.servedFromCache && freshness.oldestFetchedAt != null) {
-        console.log(chalk.gray(`  updated ${formatCheckedAge(freshness.oldestFetchedAt)} — pass --refresh (--live) for a live probe`));
-      }
-    });
+    .action(runDevicesList);
 
   devicesCmd
     .command('status')

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -85,6 +85,7 @@ import {
   loadMcp,
   loadCli,
   loadSubagents,
+  loadResources,
   loadPlugins,
   loadWorkflows,
   loadWorktree,
@@ -815,6 +816,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadMcp);
   await reg(loadCli);
   await reg(loadSubagents);
+  await reg(loadResources);
   await reg(loadPlugins);
   await reg(loadWorkflows);
   await reg(loadWorktree);

--- a/apps/cli/src/lib/__tests__/resolve-resource.test.ts
+++ b/apps/cli/src/lib/__tests__/resolve-resource.test.ts
@@ -114,4 +114,35 @@ describe('listResources', () => {
       },
     ]);
   });
+
+  // RUSH-1770: `agents resources --merged` surfaces plugins and workflows, so
+  // listResources must resolve those kinds too (they were absent from
+  // ResourceKind before). Plugins live as directories, workflows as .yaml files.
+  it('merges the plugins kind (directories) across layers with layer tags', () => {
+    fs.mkdirSync(path.join(userAgentsDir, 'plugins', 'shared-plugin'), { recursive: true });
+    fs.mkdirSync(path.join(projectAgentsDir, 'plugins', 'shared-plugin'), { recursive: true });
+    fs.mkdirSync(path.join(systemAgentsDir, 'plugins', 'system-plugin'), { recursive: true });
+
+    const resources = listResources('plugins', tmpDir);
+
+    expect(resources).toEqual([
+      { name: 'shared-plugin', path: path.join(projectAgentsDir, 'plugins', 'shared-plugin'), source: 'project' },
+      { name: 'system-plugin', path: path.join(systemAgentsDir, 'plugins', 'system-plugin'), source: 'system' },
+    ]);
+  });
+
+  it('merges the workflows kind (.yaml files) across layers with layer tags', () => {
+    fs.mkdirSync(path.join(userAgentsDir, 'workflows'), { recursive: true });
+    fs.mkdirSync(path.join(systemAgentsDir, 'workflows'), { recursive: true });
+    fs.writeFileSync(path.join(userAgentsDir, 'workflows', 'deploy.yaml'), 'user');
+    fs.writeFileSync(path.join(systemAgentsDir, 'workflows', 'deploy.yaml'), 'system');
+    fs.writeFileSync(path.join(systemAgentsDir, 'workflows', 'audit.yaml'), 'system');
+
+    const resources = listResources('workflows', tmpDir);
+
+    expect(resources).toEqual([
+      { name: 'deploy', path: path.join(userAgentsDir, 'workflows', 'deploy.yaml'), source: 'user' },
+      { name: 'audit', path: path.join(systemAgentsDir, 'workflows', 'audit.yaml'), source: 'system' },
+    ]);
+  });
 });

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -35,7 +35,9 @@ export type ResourceKind =
   | 'permissions'
   | 'subagents'
   | 'profiles'
-  | 'secrets';
+  | 'secrets'
+  | 'plugins'
+  | 'workflows';
 
 /** A resource resolved with its origin. */
 export interface ResolvedResource {

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -41,6 +41,7 @@ export const loadPermissions: ModuleLoader = async () => (await import('../../co
 export const loadMcp: ModuleLoader = async () => (await import('../../commands/mcp.js')).registerMcpCommands;
 export const loadCli: ModuleLoader = async () => (await import('../../commands/cli.js')).registerCliCommands;
 export const loadSubagents: ModuleLoader = async () => (await import('../../commands/subagents.js')).registerSubagentsCommands;
+export const loadResources: ModuleLoader = async () => (await import('../../commands/resources.js')).registerResourcesCommand;
 export const loadPlugins: ModuleLoader = async () => (await import('../../commands/plugins.js')).registerPluginsCommands;
 export const loadWorkflows: ModuleLoader = async () => (await import('../../commands/workflows.js')).registerWorkflowsCommands;
 export const loadWorktree: ModuleLoader = async () => (await import('../../commands/worktree.js')).registerWorktreeCommands;
@@ -140,6 +141,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   mcp: [loadMcp],
   cli: [loadCli],
   subagents: [loadSubagents],
+  resources: [loadResources],
   plugins: [loadPlugins],
   workflows: [loadWorkflows],
   worktree: [loadWorktree],


### PR DESCRIPTION
## What
Close the gap between the landing-page/README command syntax and the real CLI — all three surfaces the docs imply now exist.

### 1. `agents resources [--merged]` (new)
Prints the **merged** resource surface (skills/commands/mcp/hooks/rules/plugins/workflows/subagents) resolved across the four config layers (project > user > system > extras), each row tagged with its winning layer. `--json` for machine-readable output.
- Reuses `listResources()` (`src/lib/resources.ts`, first-wins union with `source` tag) — no new resolution logic.
- Widens `ResourceKind` with `plugins`/`workflows` so those dirs resolve through the same layered union (`src/lib/resources.ts:28`). Verified no exhaustive Record/switch consumes that type.
- Where `agents inspect <target>` shows ONE layer, this shows the resolved union.

### 2. bare `agents devices` → `list` (was: help)
Extracts the list handler into `runDevicesList` and wires `devicesCmd.action(runDevicesList)`, mirroring `pluginsCmd.action(runList)` (`plugins.ts:134`). Flags stay on the `list` subcommand only, to avoid commander binding them to the parent. `src/commands/ssh.ts`.

### 3. `agents plugins add` alias
`.alias('add')` on `plugins install` (mirrors `.alias('view')` on `info`). `src/commands/plugins.ts:586`.

## Verified end-to-end (from source)
```
agents resources        -> Merged resources (148), layer-tagged (user/project/system/extras)
agents resources --json -> {"skills":[{name,source,path},...], ...}
agents devices          -> Devices (13)   (lists, no longer prints help)
agents devices list --json -> [ {...} ]   (subcommand intact)
agents plugins add --help  -> Usage: agents plugins install [options] <spec>
```

## Tests
`resolve-resource.test.ts` extended with plugins (dirs) + workflows (.yaml) merged-layer resolution — 6/6 pass. `tsc --noEmit` clean. Changelog via `.changelog/next/` fragment (not a CHANGELOG.md hand-edit).