### PR TITLE
docs(changelog): note Droid usage bars

### DIFF
--- a/apps/cli/.changelog/next/droid-usage-bars.md
+++ b/apps/cli/.changelog/next/droid-usage-bars.md
@@ -1,0 +1,3 @@
+- **Show live Droid quota bars in `agents view` (RUSH-1357).** Factory billing
+  limits now render as `S`/`W`/`M` windows for Droid, matching Claude's live-usage
+  display. Source: `apps/cli/src/lib/usage.ts`.


### PR DESCRIPTION
## Summary

Adds the generated changelog fragment for the Droid usage-bars behavior.

## Evidence

- `apps/cli/.changelog/next/droid-usage-bars.md:1`-`3` says: `- **Show live Droid quota bars in `agents view` (RUSH-1357).** Factory billing limits now render as `S`/`W`/`M` windows for Droid, matching Claude's live-usage display. Source: `apps/cli/src/lib/usage.ts`.`
- `apps/cli/src/lib/usage.ts:213` routes `droid` through `getDroidUsageInfo(options)`.
- `apps/cli/src/lib/usage.ts:331`-`332` includes `input.agentId === 'droid'` in the network usage SWR gate.
- `apps/cli/src/lib/usage.ts:842` reads Droid auth via `decryptDroidAuthPayload(options?.home || os.homedir())`.
- `apps/cli/src/lib/usage.ts:848`-`850` returns no live snapshot when the Droid JWT is expired, so this read-only path does not refresh tokens.
- `apps/cli/src/lib/usage.ts:853`-`859` fetches Factory billing limits with the decrypted bearer.
- `apps/cli/src/lib/usage.ts:997`-`1000` maps `fiveHour`, `weekly`, and `monthly` to `S`, `W`, and `M` windows.
- `apps/cli/src/lib/__tests__/usage.test.ts:548`-`561` defines the captured Droid billing-limits payload shape.
- `apps/cli/src/lib/__tests__/usage.test.ts:563`-`574` asserts Droid windows normalize to `S`, `W`, and `M`.
- `apps/cli/src/lib/__tests__/usage.test.ts:601`-`619` asserts the month window appears in the compact summary and can drive `rate_limited` status.
- `apps/cli/docs/06-observability.md:374` documents `GET /api/billing/limits` as the Droid usage source.
- `apps/cli/docs/06-observability.md:385`-`389` documents that Kimi and Droid usage never refresh tokens and fall back to cached snapshots when expired.

## Verification

- `BUN_INSTALL_CACHE_DIR=/tmp/bun-cache TMPDIR=/tmp TEMP=/tmp TMP=/tmp bun install` passed in `apps/cli`.
- `HOME=/tmp/rush-1357-pr-home AGENTS_REAL_HOME=/home/muqsit BUN_INSTALL_CACHE_DIR=/tmp/bun-cache TMPDIR=/tmp TEMP=/tmp TMP=/tmp bun test scripts/gen-changelog.test.ts` passed: `5 pass`, `0 fail`.
- `HOME=/tmp/rush-1357-pr-home AGENTS_REAL_HOME=/home/muqsit BUN_INSTALL_CACHE_DIR=/tmp/bun-cache TMPDIR=/tmp TEMP=/tmp TMP=/tmp bun run test src/lib/usage.test.ts src/lib/__tests__/usage.test.ts` passed: `Test Files  2 passed (2)`, `Tests  36 passed (36)`.
- `HOME=/tmp/rush-1357-pr-home AGENTS_REAL_HOME=/home/muqsit BUN_INSTALL_CACHE_DIR=/tmp/bun-cache TMPDIR=/tmp TEMP=/tmp TMP=/tmp bunx tsc --noEmit` passed.
- Endpoint probe with the decrypted local Droid bearer: `/api/usage` returned `404`, `/api/quota` returned `404`, `/api/billing/limits` returned `401` because the local WorkOS token is expired.
- Built CLI user-visible check from this PR worktree: `NO_COLOR=1 node dist/index.js view droid` rendered `0.167.1  muqsit@getrush.ai  S: ░░░░░ 0% (now)  W: █░░░░ 5% (2d)  M: █░░░░ 20% (9d)`.

Repository is public, so no session transcript is attached.
