### PR TITLE
fix(lease): support profile dispatch runtimes

### DIFF
--- a/apps/cli/.changelog/next/rush-1725-lease-profiles.md
+++ b/apps/cli/.changelog/next/rush-1725-lease-profiles.md
@@ -1,0 +1,1 @@
+- `agents run <profile> --lease` now provisions the profile's host runtime and temporary profile config on the leased box without copying base-runtime OAuth credentials when the profile authenticates with its own API key.

--- a/apps/cli/.changelog/next/rush-1725-lease-profiles.md
+++ b/apps/cli/.changelog/next/rush-1725-lease-profiles.md
@@ -1,1 +1,1 @@
-- `agents run <profile> --lease` now provisions the profile's host runtime and temporary profile config on the leased box without copying base-runtime OAuth credentials when the profile authenticates with its own API key.
+- `agents run <profile> --lease` now provisions the profile's host runtime and temporary profile config on the leased box without copying base-runtime OAuth credentials when the profile authenticates with its own API key, including OpenCode and Antigravity-hosted profiles.

--- a/apps/cli/docs/profiles.md
+++ b/apps/cli/docs/profiles.md
@@ -202,6 +202,18 @@ agents profiles remove kimi
 agents profiles logout openrouter
 ```
 
+### 7. Run a profile on a leased box
+
+```bash
+agents run deepseek "summarize this repo" --lease hetzner
+```
+
+Leased profile runs install the profile's `host.agent` on the disposable box and
+materialize a temporary profile there for the duration of the run. Profiles with
+their own API key, such as OpenRouter-backed `kimi` and `deepseek`, ship that
+profile auth only; the base runtime's local OAuth credential is copied only when
+the profile has no auth env of its own.
+
 ## Demo
 
 <video autoplay loop muted playsinline width="100%" src="../assets/videos/profiles.mp4"></video>

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -659,24 +659,56 @@ export function registerRunCommand(program: Command): void {
           }
         }
 
-        const { detectSignedInRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime } = await import('../lib/crabbox/runtimes.js');
+        const { detectSignedInRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime, profileNeedsBaseRuntimeCredentials } = await import('../lib/crabbox/runtimes.js');
         const { leaseAndRun } = await import('../lib/crabbox/lease.js');
         const { getConfiguredRunStrategy, resolveRunVersion } = await import('../lib/rotate.js');
+        const { profileExists, readProfile, resolveProfileEnv } = await import('../lib/profiles.js');
 
         const detected = await detectSignedInRuntimes();
-        const agentName = normalizedAgentSpec.split('@')[0];
+        const [agentName, rawLeaseVersion] = normalizedAgentSpec.split('@');
         const leaseCwd = options.cwd ?? process.cwd();
+        let runtime: AgentId | null = null;
+        let credentialRuntimes: AgentId[] = [];
+        let dispatchProfile: import('../lib/crabbox/lease.js').LeaseDispatchProfile | undefined;
 
         // `--lease` requires a prompt (guarded above), so it is headless by
         // contract — never block on an interactive picker. Provision exactly the
         // one runtime this run needs, inferred from the agent, not every
         // signed-in CLI (which would ship unrelated tokens to a throwaway box).
-        const runtime = inferLeaseRuntime(agentName, detected);
+        if (profileExists(agentName)) {
+          try {
+            const profile = readProfile(agentName);
+            const profileEnv = resolveProfileEnv(profile);
+            runtime = profile.host.agent;
+            const profileNeedsCredentials = profileNeedsBaseRuntimeCredentials(runtime, profileEnv);
+            credentialRuntimes = profileNeedsCredentials ? [runtime] : [];
+            dispatchProfile = {
+              name: profile.name,
+              agent: profile.host.agent,
+              version: rawLeaseVersion || profile.host.version,
+              env: profileEnv,
+              description: profile.description,
+              preset: profile.preset,
+              provider: profile.provider,
+              fallbackModel: profile.fallback_model,
+            };
+          } catch (err) {
+            console.error(chalk.red((err as Error).message));
+            process.exit(1);
+          }
+        } else {
+          runtime = inferLeaseRuntime(agentName, detected);
+          if (runtime) credentialRuntimes = [runtime];
+        }
         if (!runtime) {
           console.error(chalk.yellow('No signed-in runtime to provision on the box. Sign into one locally (e.g. run `claude` once) then retry.'));
           process.exit(1);
         }
         const runtimes = [runtime];
+        if (credentialRuntimes.length > 0 && !detected.some((d) => d.id === runtime && d.signedIn && d.credPath)) {
+          console.error(chalk.yellow(`Profile '${agentName}' needs ${runtime} credentials, but ${runtime} is not signed in locally. Sign in locally, then retry.`));
+          process.exit(1);
+        }
 
         // Copy the account the run's OWN strategy would pick (default `balanced`:
         // a healthy, non-rate-limited account weighted by remaining headroom) —
@@ -690,7 +722,7 @@ export function registerRunCommand(program: Command): void {
         // the notice below would name a balanced-picked account that is NOT the one
         // actually shipped. Best-effort: fall back to the default account on error.
         let leaseEmail = detected.find((d) => d.id === runtime)?.email ?? null;
-        if (runtime === 'claude') {
+        if (credentialRuntimes.includes('claude')) {
           try {
             const strategy = getConfiguredRunStrategy(runtime, leaseCwd);
             const { rotation } = await resolveRunVersion(runtime, strategy, leaseCwd);
@@ -704,10 +736,16 @@ export function registerRunCommand(program: Command): void {
         // where — copying an auth token to a cloud box is a credential transfer.
         // The box is destroyed after the run, so the credential's lifetime is
         // bounded by the run.
-        const whatShips = runtime === 'claude' ? 'credentials + Claude OAuth token' : 'credentials';
+        const whatShips = credentialRuntimes.includes('claude')
+          ? `${dispatchProfile ? `profile '${dispatchProfile.name}', ` : ''}${runtime} credentials + Claude OAuth token`
+          : credentialRuntimes.length > 0
+            ? `${dispatchProfile ? `profile '${dispatchProfile.name}', ` : ''}${runtime} credentials`
+            : dispatchProfile
+              ? `profile '${dispatchProfile.name}'`
+              : `${runtime} credentials`;
         console.error(
           chalk.gray(
-            `Leasing a ${backend ?? 'hetzner'} box · shipping ${runtime}${leaseEmail ? ` (${leaseEmail})` : ''} ${whatShips}; the box is destroyed after the run.`,
+            `Leasing a ${backend ?? 'hetzner'} box · shipping ${whatShips}${credentialRuntimes.length > 0 && leaseEmail ? ` (${leaseEmail})` : ''}; the box is destroyed after the run.`,
           ),
         );
 
@@ -716,7 +754,7 @@ export function registerRunCommand(program: Command): void {
         // "Not logged in". `preferEmail` targets the strategy-picked account so the
         // token matches the account this run resolved to.
         let claudeCredentialsJson: string | null = null;
-        if (runtime === 'claude') {
+        if (credentialRuntimes.includes('claude')) {
           claudeCredentialsJson = await resolveClaudeCredentialsBlob({ preferEmail: leaseEmail });
           if (!claudeCredentialsJson) {
             console.error(chalk.yellow('Warning: could not read the local Claude OAuth token — the box may come up "Not logged in".'));
@@ -755,7 +793,9 @@ export function registerRunCommand(program: Command): void {
             model: options.model,
             backend,
             runtimes,
+            credentialRuntimes,
             detected,
+            dispatchProfile,
             claudeCredentialsJson,
             secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE,
             keep: options.keepBox,

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -680,7 +680,7 @@ export function registerRunCommand(program: Command): void {
             const profile = readProfile(agentName);
             const profileEnv = resolveProfileEnv(profile);
             runtime = profile.host.agent;
-            const profileNeedsCredentials = profileNeedsBaseRuntimeCredentials(runtime, profileEnv);
+            const profileNeedsCredentials = profileNeedsBaseRuntimeCredentials(runtime, profileEnv, profile.auth?.envVar);
             credentialRuntimes = profileNeedsCredentials ? [runtime] : [];
             dispatchProfile = {
               name: profile.name,

--- a/apps/cli/src/lib/crabbox/lease.test.ts
+++ b/apps/cli/src/lib/crabbox/lease.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { buildBootstrapScript } from './lease.js';
 import { LEASE_AGENT_MARKER } from './progress.js';
 import type { DetectedRuntime } from './runtimes.js';
@@ -66,6 +69,64 @@ describe('buildBootstrapScript', () => {
       // box body, not teardown — a kept box still loses the token).
       expect(script).toContain('rm -f "$HOME/.claude.json"');
       expect(script).toContain('rm -f "$HOME/.claude/.credentials.json"');
+    }
+  });
+
+  it('materializes a profile-dispatch run without copying Claude OAuth when the profile has its own auth', () => {
+    const script = buildBootstrapScript({
+      agent: 'kimi',
+      prompt: 'hi',
+      runtimes: ['claude'],
+      credentialRuntimes: [],
+      detected,
+      dispatchProfile: {
+        name: 'kimi',
+        agent: 'claude',
+        env: {
+          ANTHROPIC_BASE_URL: 'https://openrouter.ai/api',
+          ANTHROPIC_MODEL: 'moonshotai/kimi-k2.5',
+          ANTHROPIC_AUTH_TOKEN: 'sk-or-profile',
+        },
+        provider: 'openrouter',
+        preset: 'kimi',
+      },
+    });
+    expect(script).toContain("agents add 'claude'");
+    expect(script).toContain('cat > "$HOME/.agents/profiles/kimi.yml" <<');
+    expect(script).toContain('ANTHROPIC_AUTH_TOKEN: sk-or-profile');
+    expect(script).toContain("agents run 'kimi' 'hi' --quiet");
+    expect(script).not.toContain('cat > "$HOME/.claude.json"');
+    expect(script).not.toContain('cat > "$HOME/.claude/.credentials.json"');
+    expect(script).toContain('rm -f "$HOME/.agents/profiles/kimi.yml"');
+  });
+
+  it('copies base runtime credentials for a profile only when requested', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-profile-'));
+    const credPath = path.join(tmpDir, 'claude.json');
+    fs.writeFileSync(credPath, '{"oauthAccount":{"emailAddress":"a@b.com"}}');
+    const detectedWithCred: DetectedRuntime[] = [{ ...detected[0], credPath }];
+    const script = buildBootstrapScript({
+      agent: 'internal-claude',
+      prompt: 'hi',
+      runtimes: ['claude'],
+      credentialRuntimes: ['claude'],
+      detected: detectedWithCred,
+      claudeCredentialsJson: '{"claudeAiOauth":{"accessToken":"tok"}}',
+      dispatchProfile: {
+        name: 'internal-claude',
+        agent: 'claude',
+        env: {
+          ANTHROPIC_BASE_URL: 'https://gateway.example.test',
+          ANTHROPIC_MODEL: 'claude-sonnet-4-5',
+        },
+      },
+    });
+    try {
+      expect(script).toContain('cat > "$HOME/.claude/.credentials.json" <<');
+      expect(script).toContain('rm -f "$HOME/.claude/.credentials.json"');
+      expect(script).toContain('rm -f "$HOME/.agents/profiles/internal-claude.yml"');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/apps/cli/src/lib/crabbox/lease.test.ts
+++ b/apps/cli/src/lib/crabbox/lease.test.ts
@@ -100,6 +100,32 @@ describe('buildBootstrapScript', () => {
     expect(script).toContain('rm -f "$HOME/.agents/profiles/kimi.yml"');
   });
 
+  it('installs the pinned base runtime version for a profile-dispatch run', () => {
+    const script = buildBootstrapScript({
+      agent: 'kimi',
+      prompt: 'hi',
+      runtimes: ['claude'],
+      credentialRuntimes: [],
+      detected,
+      dispatchProfile: {
+        name: 'kimi',
+        agent: 'claude',
+        version: '2.1.113',
+        env: {
+          ANTHROPIC_BASE_URL: 'https://openrouter.ai/api',
+          ANTHROPIC_MODEL: 'moonshotai/kimi-k2.5',
+          ANTHROPIC_AUTH_TOKEN: 'sk-or-profile',
+        },
+      },
+    });
+    expect(script).toContain("agents add 'claude@2.1.113'");
+    expect(script).toContain('version: 2.1.113');
+    expect(script.indexOf("agents add 'claude@2.1.113'")).toBeLessThan(
+      script.indexOf('cat > "$HOME/.agents/profiles/kimi.yml"'),
+    );
+    expect(script).toContain("agents run 'kimi' 'hi' --quiet");
+  });
+
   it('copies base runtime credentials for a profile only when requested', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-profile-'));
     const credPath = path.join(tmpDir, 'claude.json');

--- a/apps/cli/src/lib/crabbox/lease.ts
+++ b/apps/cli/src/lib/crabbox/lease.ts
@@ -92,6 +92,13 @@ function buildProfileScript(profile: LeaseDispatchProfile): string {
   return buildHomeFileWriteScript(profileRemotePath(profile.name), body);
 }
 
+function runtimeInstallSpec(id: AgentId, dispatchProfile?: LeaseDispatchProfile): string {
+  if (dispatchProfile?.agent === id && dispatchProfile.version) {
+    return `${id}@${dispatchProfile.version}`;
+  }
+  return id;
+}
+
 /**
  * Bash snippet that guarantees `agents` is runnable on the box. Fresh crabbox
  * images ship without node, and the box user may not own the global npm prefix,
@@ -146,7 +153,9 @@ export function buildBootstrapScript(opts: LeaseRunOptions): string {
   if (opts.dispatchProfile) shredPaths.push(profileRemotePath(opts.dispatchProfile.name));
   const shred = shredPaths.map((p) => `rm -f "$HOME/${p}" 2>/dev/null || true`).join('\n');
 
-  const installRuntimes = opts.runtimes.map((id) => `agents add ${q(id)} >/dev/null 2>&1 || true`).join('\n');
+  const installRuntimes = opts.runtimes
+    .map((id) => `agents add ${q(runtimeInstallSpec(id, opts.dispatchProfile))} >/dev/null 2>&1 || true`)
+    .join('\n');
 
   return [
     'set -uo pipefail',

--- a/apps/cli/src/lib/crabbox/lease.ts
+++ b/apps/cli/src/lib/crabbox/lease.ts
@@ -9,7 +9,8 @@
 
 import type { AgentId } from '../types.js';
 import { crabboxWarmup, crabboxWaitReady, crabboxRunScript, crabboxStop, type CrabboxBox } from './cli.js';
-import { buildCredentialScript, CLAUDE_TOKEN_REMOTE, type DetectedRuntime } from './runtimes.js';
+import * as yaml from 'yaml';
+import { buildCredentialScript, buildHomeFileWriteScript, CLAUDE_TOKEN_REMOTE, type DetectedRuntime } from './runtimes.js';
 import { LEASE_AGENT_MARKER } from './progress.js';
 
 /** Phase signal for a lease run, so the command layer can drive a progress UI. */
@@ -27,9 +28,13 @@ export interface LeaseRunOptions {
   backend?: string;
   boxClass?: string;
   profile?: string;
-  /** Runtimes to install + authenticate on the box (from the picker). */
+  /** Runtimes to install on the box. */
   runtimes: AgentId[];
+  /** Runtime credentials to copy; defaults to `runtimes`. */
+  credentialRuntimes?: AgentId[];
   detected: DetectedRuntime[];
+  /** Profile-dispatch config to materialize on the leased box before the run. */
+  dispatchProfile?: LeaseDispatchProfile;
   /** Secrets bundle providing crabbox's provider token. */
   secretsBundle?: string;
   onData?: (s: string) => void;
@@ -45,6 +50,17 @@ export interface LeaseRunOptions {
   claudeCredentialsJson?: string | null;
 }
 
+export interface LeaseDispatchProfile {
+  name: string;
+  agent: AgentId;
+  version?: string;
+  env: Record<string, string>;
+  description?: string;
+  preset?: string;
+  provider?: string;
+  fallbackModel?: string;
+}
+
 export interface LeaseRunResult {
   box: CrabboxBox;
   exitCode: number | null;
@@ -54,6 +70,26 @@ export interface LeaseRunResult {
 /** POSIX single-quote for safe embedding in the generated bootstrap script. */
 function q(s: string): string {
   return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+function profileRemotePath(name: string): string {
+  return `.agents/profiles/${name}.yml`;
+}
+
+function buildProfileScript(profile: LeaseDispatchProfile): string {
+  const body = yaml.stringify({
+    name: profile.name,
+    ...(profile.description ? { description: profile.description } : {}),
+    host: {
+      agent: profile.agent,
+      ...(profile.version ? { version: profile.version } : {}),
+    },
+    env: profile.env,
+    ...(profile.fallbackModel ? { fallback_model: profile.fallbackModel } : {}),
+    ...(profile.preset ? { preset: profile.preset } : {}),
+    ...(profile.provider ? { provider: profile.provider } : {}),
+  });
+  return buildHomeFileWriteScript(profileRemotePath(profile.name), body);
 }
 
 /**
@@ -91,9 +127,11 @@ const ENSURE_AGENTS_CLI = [
  * the credential files. Best-effort install steps never abort the run.
  */
 export function buildBootstrapScript(opts: LeaseRunOptions): string {
-  const credScript = buildCredentialScript(opts.runtimes, opts.detected, {
+  const credentialRuntimes = opts.credentialRuntimes ?? opts.runtimes;
+  const credScript = buildCredentialScript(credentialRuntimes, opts.detected, {
     claudeCredentialsJson: opts.claudeCredentialsJson,
   });
+  const profileScript = opts.dispatchProfile ? buildProfileScript(opts.dispatchProfile) : '';
   const runParts = ['agents', 'run', q(opts.agent), q(opts.prompt), '--quiet'];
   if (opts.mode) runParts.push('--mode', q(opts.mode));
   if (opts.model) runParts.push('--model', q(opts.model));
@@ -101,10 +139,11 @@ export function buildBootstrapScript(opts: LeaseRunOptions): string {
   // Credential files to shred after the run (home-level paths written above).
   // Runs regardless of --keep-box (it's in the box body, not teardown), so a kept
   // box still loses the token after the run — minimizing the credential window.
-  const shredPaths = opts.runtimes.flatMap((id) => {
+  const shredPaths = credentialRuntimes.flatMap((id) => {
     const paths = { claude: ['.claude.json', CLAUDE_TOKEN_REMOTE], codex: ['.codex/auth.json'], gemini: ['.gemini/google_accounts.json'], grok: ['.grok/auth.json'] }[id as string];
     return paths ?? [];
   });
+  if (opts.dispatchProfile) shredPaths.push(profileRemotePath(opts.dispatchProfile.name));
   const shred = shredPaths.map((p) => `rm -f "$HOME/${p}" 2>/dev/null || true`).join('\n');
 
   const installRuntimes = opts.runtimes.map((id) => `agents add ${q(id)} >/dev/null 2>&1 || true`).join('\n');
@@ -114,6 +153,7 @@ export function buildBootstrapScript(opts: LeaseRunOptions): string {
     ENSURE_AGENTS_CLI,
     installRuntimes,
     credScript,
+    profileScript,
     // Marker on its own line: the command layer shows everything before this as
     // setup progress and everything after (the agent's output) verbatim.
     `echo ${q(LEASE_AGENT_MARKER)}`,

--- a/apps/cli/src/lib/crabbox/runtimes.test.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.test.ts
@@ -3,6 +3,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import { buildCredentialScript, pickRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime, profileNeedsBaseRuntimeCredentials, type DetectedRuntime } from './runtimes.js';
+import { getPreset } from '../profiles-presets.js';
+import { profileFromPreset } from '../profiles.js';
 
 describe('inferLeaseRuntime', () => {
   const signedIn = (id: DetectedRuntime['id'], email: string | null): DetectedRuntime => ({
@@ -121,6 +123,19 @@ describe('profileNeedsBaseRuntimeCredentials', () => {
       ANTHROPIC_AUTH_TOKEN: 'sk-or-profile',
       ANTHROPIC_MODEL: 'moonshotai/kimi-k2.5',
     })).toBe(false);
+  });
+
+  it('does not require Claude OAuth for the foundry preset auth env', () => {
+    const preset = getPreset('foundry')!;
+    const profile = profileFromPreset('foundry-work', preset);
+    const env = {
+      ...profile.env,
+      [profile.auth!.envVar]: 'foundry-profile-token',
+    };
+
+    expect(profile.host.agent).toBe('claude');
+    expect(profile.auth!.envVar).toBe('ANTHROPIC_FOUNDRY_API_KEY');
+    expect(profileNeedsBaseRuntimeCredentials(profile.host.agent, env, profile.auth!.envVar)).toBe(false);
   });
 
   it('requires base runtime credentials when the profile only changes endpoint/model', () => {

--- a/apps/cli/src/lib/crabbox/runtimes.test.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import { buildCredentialScript, pickRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime, type DetectedRuntime } from './runtimes.js';
+import { buildCredentialScript, pickRuntimes, resolveClaudeCredentialsBlob, inferLeaseRuntime, profileNeedsBaseRuntimeCredentials, type DetectedRuntime } from './runtimes.js';
 
 describe('inferLeaseRuntime', () => {
   const signedIn = (id: DetectedRuntime['id'], email: string | null): DetectedRuntime => ({
@@ -111,6 +111,29 @@ describe('buildCredentialScript', () => {
     ];
     expect(buildCredentialScript(['claude'], detected)).not.toContain('.credentials.json');
     expect(buildCredentialScript(['claude'], detected, { claudeCredentialsJson: null })).not.toContain('.credentials.json');
+  });
+});
+
+describe('profileNeedsBaseRuntimeCredentials', () => {
+  it('does not require Claude OAuth when a profile carries its own Anthropic-compatible token', () => {
+    expect(profileNeedsBaseRuntimeCredentials('claude', {
+      ANTHROPIC_BASE_URL: 'https://openrouter.ai/api',
+      ANTHROPIC_AUTH_TOKEN: 'sk-or-profile',
+      ANTHROPIC_MODEL: 'moonshotai/kimi-k2.5',
+    })).toBe(false);
+  });
+
+  it('requires base runtime credentials when the profile only changes endpoint/model', () => {
+    expect(profileNeedsBaseRuntimeCredentials('claude', {
+      ANTHROPIC_BASE_URL: 'https://proxy.example.test',
+      ANTHROPIC_MODEL: 'claude-sonnet-4-5',
+    })).toBe(true);
+  });
+
+  it('recognizes host-specific API keys for non-Claude profile hosts', () => {
+    expect(profileNeedsBaseRuntimeCredentials('codex', { OPENAI_API_KEY: 'sk-profile' })).toBe(false);
+    expect(profileNeedsBaseRuntimeCredentials('grok', { XAI_API_KEY: 'xai-profile' })).toBe(false);
+    expect(profileNeedsBaseRuntimeCredentials('gemini', { GOOGLE_API_KEY: 'google-profile' })).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/crabbox/runtimes.test.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.test.ts
@@ -135,6 +135,11 @@ describe('profileNeedsBaseRuntimeCredentials', () => {
     expect(profileNeedsBaseRuntimeCredentials('grok', { XAI_API_KEY: 'xai-profile' })).toBe(false);
     expect(profileNeedsBaseRuntimeCredentials('gemini', { GOOGLE_API_KEY: 'google-profile' })).toBe(false);
   });
+
+  it('does not require base credentials for profile hosts with no lease credential to copy', () => {
+    expect(profileNeedsBaseRuntimeCredentials('opencode', { OPENCODE_API_KEY: 'sk-profile' })).toBe(false);
+    expect(profileNeedsBaseRuntimeCredentials('antigravity', { ANTIGRAVITY_API_KEY: 'ag-profile' })).toBe(false);
+  });
 });
 
 describe('resolveClaudeCredentialsBlob', () => {

--- a/apps/cli/src/lib/crabbox/runtimes.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.ts
@@ -149,6 +149,7 @@ const PROFILE_AUTH_ENV_KEYS_BY_RUNTIME: Partial<Record<AgentId, readonly string[
 
 /** True when a profile already carries auth for its host runtime via env. */
 export function profileNeedsBaseRuntimeCredentials(agent: AgentId, env: Record<string, string>): boolean {
+  if (!LEASE_RUNTIMES.some((c) => c.id === agent)) return false;
   const keys = PROFILE_AUTH_ENV_KEYS_BY_RUNTIME[agent] ?? [];
   return !keys.some((key) => typeof env[key] === 'string' && env[key].trim() !== '');
 }

--- a/apps/cli/src/lib/crabbox/runtimes.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.ts
@@ -141,6 +141,7 @@ const PROFILE_AUTH_ENV_KEYS_BY_RUNTIME: Partial<Record<AgentId, readonly string[
     'AWS_BEARER_TOKEN_BEDROCK',
     'GOOGLE_APPLICATION_CREDENTIALS',
     'GOOGLE_CLOUD_PROJECT',
+    'ANTHROPIC_FOUNDRY_API_KEY',
   ],
   codex: ['OPENAI_API_KEY'],
   gemini: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
@@ -148,8 +149,9 @@ const PROFILE_AUTH_ENV_KEYS_BY_RUNTIME: Partial<Record<AgentId, readonly string[
 };
 
 /** True when a profile already carries auth for its host runtime via env. */
-export function profileNeedsBaseRuntimeCredentials(agent: AgentId, env: Record<string, string>): boolean {
+export function profileNeedsBaseRuntimeCredentials(agent: AgentId, env: Record<string, string>, authEnvVar?: string): boolean {
   if (!LEASE_RUNTIMES.some((c) => c.id === agent)) return false;
+  if (authEnvVar && typeof env[authEnvVar] === 'string' && env[authEnvVar].trim() !== '') return false;
   const keys = PROFILE_AUTH_ENV_KEYS_BY_RUNTIME[agent] ?? [];
   return !keys.some((key) => typeof env[key] === 'string' && env[key].trim() !== '');
 }

--- a/apps/cli/src/lib/crabbox/runtimes.ts
+++ b/apps/cli/src/lib/crabbox/runtimes.ts
@@ -132,10 +132,41 @@ export function inferLeaseRuntime(agentName: string, detected: DetectedRuntime[]
   return signedIn.find((d) => d.id === 'claude')?.id ?? signedIn[0]?.id ?? null;
 }
 
+const PROFILE_AUTH_ENV_KEYS_BY_RUNTIME: Partial<Record<AgentId, readonly string[]>> = {
+  claude: [
+    'ANTHROPIC_AUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_PROFILE',
+    'AWS_BEARER_TOKEN_BEDROCK',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'GOOGLE_CLOUD_PROJECT',
+  ],
+  codex: ['OPENAI_API_KEY'],
+  gemini: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+  grok: ['XAI_API_KEY', 'GROK_API_KEY'],
+};
+
+/** True when a profile already carries auth for its host runtime via env. */
+export function profileNeedsBaseRuntimeCredentials(agent: AgentId, env: Record<string, string>): boolean {
+  const keys = PROFILE_AUTH_ENV_KEYS_BY_RUNTIME[agent] ?? [];
+  return !keys.some((key) => typeof env[key] === 'string' && env[key].trim() !== '');
+}
+
 // A long random sentinel makes an accidental (or malicious) collision with a
 // token's contents effectively impossible, so the quoted heredoc can never be
 // closed early by the credential body.
 const CRED_EOF = 'AGENTS_LEASE_CRED_EOF_9f3c1a7b5e2d4068';
+
+/** Build a quoted heredoc write to a path under the remote user's home. */
+export function buildHomeFileWriteScript(remote: string, contents: string): string {
+  const dir = path.posix.dirname(remote);
+  const mkdir = dir && dir !== '.' ? `mkdir -p "$HOME/${dir}"\n` : '';
+  return (
+    `${mkdir}cat > "$HOME/${remote}" <<'${CRED_EOF}'\n${contents}${contents.endsWith('\n') ? '' : '\n'}${CRED_EOF}\n` +
+    `chmod 600 "$HOME/${remote}"`
+  );
+}
 
 /**
  * Where Claude Code reads its OAuth token on the box. `.claude.json` (the file
@@ -250,14 +281,6 @@ export function buildCredentialScript(
 ): string {
   const byId = new Map(detected.map((d) => [d.id, d]));
   const parts: string[] = [];
-  const writeFile = (remote: string, contents: string): string => {
-    const dir = path.posix.dirname(remote);
-    const mkdir = dir && dir !== '.' ? `mkdir -p "$HOME/${dir}"\n` : '';
-    return (
-      `${mkdir}cat > "$HOME/${remote}" <<'${CRED_EOF}'\n${contents}${contents.endsWith('\n') ? '' : '\n'}${CRED_EOF}\n` +
-      `chmod 600 "$HOME/${remote}"`
-    );
-  };
   for (const id of picked) {
     const d = byId.get(id);
     const cred = LEASE_RUNTIMES.find((c) => c.id === id);
@@ -268,11 +291,11 @@ export function buildCredentialScript(
     } catch {
       continue;
     }
-    parts.push(writeFile(cred.remote, contents));
+    parts.push(buildHomeFileWriteScript(cred.remote, contents));
     // For claude the file above is config/state only; the OAuth token is a
     // second artifact — without it the box comes up "Not logged in".
     if (id === 'claude' && extras?.claudeCredentialsJson) {
-      parts.push(writeFile(CLAUDE_TOKEN_REMOTE, extras.claudeCredentialsJson));
+      parts.push(buildHomeFileWriteScript(CLAUDE_TOKEN_REMOTE, extras.claudeCredentialsJson));
     }
   }
   return parts.join('\n');


### PR DESCRIPTION
## Summary
- `apps/cli/src/commands/exec.ts:678-689`: `if (profileExists(agentName)) {` / `runtime = profile.host.agent;` / `credentialRuntimes = profileNeedsCredentials ? [runtime] : [];` / `env: profileEnv,`
- `apps/cli/src/lib/crabbox/lease.ts:129-147`: `const credentialRuntimes = opts.credentialRuntimes ?? opts.runtimes;` / `const profileScript = opts.dispatchProfile ? buildProfileScript(opts.dispatchProfile) : '';` / `if (opts.dispatchProfile) shredPaths.push(profileRemotePath(opts.dispatchProfile.name));`
- `apps/cli/src/lib/crabbox/runtimes.ts:150-153`: `export function profileNeedsBaseRuntimeCredentials(agent: AgentId, env: Record<string, string>): boolean {` / `return !keys.some((key) => typeof env[key] === 'string' && env[key].trim() !== '');`

## Evidence
- `apps/cli/src/lib/crabbox/lease.test.ts:75-100`: profile-dispatch bootstrap installs `claude`, writes `.agents/profiles/kimi.yml`, runs `agents run 'kimi'`, and does not write `.claude.json` or `.claude/.credentials.json` when `ANTHROPIC_AUTH_TOKEN` is present.
- `apps/cli/src/lib/crabbox/lease.test.ts:103-127`: profile-dispatch bootstrap writes and shreds Claude OAuth only when `credentialRuntimes: ['claude']` is requested.
- `apps/cli/src/lib/crabbox/runtimes.test.ts:117-137`: auth-env detection returns `false` for profile-owned auth and `true` when a Claude profile only changes endpoint/model.
- `apps/cli/docs/profiles.md:205-215`: docs include `agents run deepseek "summarize this repo" --lease hetzner` and state the base runtime OAuth credential is copied only when the profile has no auth env.
- `apps/cli/.changelog/next/rush-1725-lease-profiles.md:1`: changelog fragment documents profile `--lease` behavior.

## Verification
- `bun install`
- `bun run test src/lib/crabbox/runtimes.test.ts src/lib/crabbox/lease.test.ts`
- `bunx tsc --noEmit`
- `bun run test` was attempted; this harness has a read-only `/tmp/.agents` mount that makes `tests/project-resources-pipeline.test.ts:103` discover `/tmp/.agents` instead of `null`.
