### PR TITLE
Surface routine failure reasons in menubar

### DIFF
--- a/apps/cli/.changelog/next/rush-1284-routine-failures.md
+++ b/apps/cli/.changelog/next/rush-1284-routine-failures.md
@@ -1,1 +1,1 @@
-- Menu bar routines now include latest run `exitCode` and `failureReason` from `agents routines list --json`, show failed routine reasons inline, and open the concise logs summary instead of a raw Terminal dump.
+- Menu bar routines now include latest run `exitCode` and `failureReason` from `agents routines list --json`, show failed routine reasons inline, label healthy-but-overdue routines as `overdue` instead of `exit 0`, and open the concise logs summary instead of a raw Terminal dump.

--- a/apps/cli/.changelog/next/rush-1284-routine-failures.md
+++ b/apps/cli/.changelog/next/rush-1284-routine-failures.md
@@ -1,0 +1,1 @@
+- Menu bar routines now include latest run `exitCode` and `failureReason` from `agents routines list --json`, show failed routine reasons inline, and open the concise logs summary instead of a raw Terminal dump.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -488,8 +488,9 @@ agents routines run <name>            # Run immediately in foreground
 agents routines run <name> --host yosemite-s0  # Run on a specific remote device
 agents routines view <name>           # Show job config
 agents routines runs <name>           # View execution history (last 10)
-agents routines logs <name>           # Show stdout from latest run
+agents routines logs <name>           # Show concise summary from latest run
 agents routines logs <name> --run <id>  # Show specific run
+agents routines logs <name> --full    # Show raw stdout from latest run
 agents routines report <name>         # Show report from latest run
 agents routines report <name> --run <id>  # Show specific run report
 

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -83,10 +83,11 @@ One rule shapes the menu: **attention floats up, context groups down.**
 - **ACTIVE · \<repo\>** — live work grouped by repo. A session is *running* if
   its transcript was written in the last 2 minutes, else *idle*. Rich rows show
   the session's title inline; the row's submenu reveals the working dir.
-- **ROUTINES** — kept glanceable: the next few upcoming plus any failing routine
-  inline with its failure reason when available (Run now / Pause / Logs in each
-  submenu), `All routines…` for the rest. Logs opens the concise routine summary
-  in a text viewer.
+- **ROUTINES** — kept glanceable: the next few upcoming plus any failed, timed-out,
+  or overdue routine inline. Failed and timed-out routines include the latest
+  failure reason when available; overdue routines are labeled `overdue` even when
+  their previous run succeeded. Each submenu has Run now / Pause / Logs, and Logs
+  opens the concise routine summary in a text viewer.
 - **RECENT TICKETS / RECENT** — tickets filed via quick dispatch and recent
   sessions, unchanged dedicated sections.
 - **System** — setup staleness + the auto-nudge watchdog collapsed into one row;

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -84,7 +84,9 @@ One rule shapes the menu: **attention floats up, context groups down.**
   its transcript was written in the last 2 minutes, else *idle*. Rich rows show
   the session's title inline; the row's submenu reveals the working dir.
 - **ROUTINES** — kept glanceable: the next few upcoming plus any failing routine
-  inline (Run now / Pause / Logs in each submenu), `All routines…` for the rest.
+  inline with its failure reason when available (Run now / Pause / Logs in each
+  submenu), `All routines…` for the rest. Logs opens the concise routine summary
+  in a text viewer.
 - **RECENT TICKETS / RECENT** — tickets filed via quick dispatch and recent
   sessions, unchanged dedicated sections.
 - **System** — setup staleness + the auto-nudge watchdog collapsed into one row;

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -113,9 +113,14 @@ enum AgentsCLI {
     static func routinePause(_ name: String) { runDetached(argv(["routines", "pause", name])) }
     static func routineResume(_ name: String) { runDetached(argv(["routines", "resume", name])) }
     static func routineLogs(_ name: String) {
-        let cmd = "\(shellQuote(binary)) routines logs \(shellQuote(name))"
-        let script = "tell application \"Terminal\"\nactivate\ndo script \"\(cmd)\"\nend tell"
-        runDetached(["/usr/bin/osascript", "-e", script])
+        runMonitored(argv(["routines", "logs", name])) { text, ok in
+            let safeName = name.replacingOccurrences(of: "[^A-Za-z0-9._-]", with: "-", options: .regularExpression)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agents-routine-\(safeName)-logs.txt")
+            let body = ok ? text : (text.isEmpty ? "Unable to load logs for routine '\(name)'.\n" : text)
+            try? body.write(to: url, atomically: true, encoding: .utf8)
+            runDetached(["/usr/bin/open", url.path])
+        }
     }
 
     static func openPath(_ path: String) { runDetached(["/usr/bin/open", path]) }

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -19,6 +19,7 @@ enum IssueSelfTest {
         testQuickDispatchRoster()
         testRecentTicketsMerge()
         testDraftPreservation()
+        testRoutineFailureReason()
         if failures == 0 {
             print("\nALL PASS")
             exit(0)
@@ -227,6 +228,37 @@ enum IssueSelfTest {
               (cleared?.selectedAgents ?? []).isEmpty)
     }
 
+    // Overdue is a current scheduler condition, not proof that the previous run
+    // failed. A last-successful routine with exitCode 0 must render as overdue,
+    // not "exit 0", across summary, submenu header, and all-routines rows.
+    private static func testRoutineFailureReason() {
+        let succeededButOverdue = routine(
+            lastStatus: "completed",
+            exitCode: 0,
+            failureReason: nil,
+            overdue: true
+        )
+        check("overdue successful routine summary says overdue",
+              routineFailureSummary(succeededButOverdue, max: 48) == "overdue",
+              detail: routineFailureSummary(succeededButOverdue, max: 48))
+        check("overdue successful routine detail says overdue",
+              routineFailureDetail(succeededButOverdue, max: 72) == "overdue",
+              detail: routineFailureDetail(succeededButOverdue, max: 72) ?? "nil")
+        check("overdue successful routine all-row detail says overdue",
+              routineFailureDetail(succeededButOverdue, max: 52) == "overdue",
+              detail: routineFailureDetail(succeededButOverdue, max: 52) ?? "nil")
+
+        let failed = routine(
+            lastStatus: "failed",
+            exitCode: 2,
+            failureReason: nil,
+            overdue: false
+        )
+        check("failed routine still falls back to exit code",
+              routineFailureDetail(failed, max: 72) == "exit 2",
+              detail: routineFailureDetail(failed, max: 72) ?? "nil")
+    }
+
     // MARK: helpers
 
     private static func write(_ dir: URL, _ name: String, modified offset: TimeInterval) {
@@ -252,5 +284,30 @@ enum IssueSelfTest {
             .split(separator: ",")
             .map { LocalState.normalizeAgent(String($0).trimmingCharacters(in: .whitespacesAndNewlines)) }
             .filter { visible.contains($0) && seen.insert($0).inserted } ?? []
+    }
+
+    private static func routine(
+        lastStatus: String?,
+        exitCode: Int?,
+        failureReason: String?,
+        overdue: Bool
+    ) -> Routine {
+        Routine(
+            name: "nightly",
+            agent: "claude",
+            workflow: nil,
+            repo: nil,
+            schedule: "0 3 * * *",
+            scheduleHuman: nil,
+            enabled: true,
+            overdue: overdue,
+            nextRun: nil,
+            nextRunHuman: "tomorrow",
+            lastStatus: lastStatus,
+            exitCode: exitCode,
+            failureReason: failureReason,
+            lastRunStartedAt: "2026-07-20T03:00:00.000Z",
+            lastRunCompletedAt: "2026-07-20T03:00:05.000Z"
+        )
     }
 }

--- a/apps/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -14,6 +14,8 @@ struct Routine: Decodable {
     let nextRun: String?
     let nextRunHuman: String?
     let lastStatus: String?            // completed | failed | timeout | running | null
+    let exitCode: Int?
+    let failureReason: String?
     let lastRunStartedAt: String?
     let lastRunCompletedAt: String?
 }

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -922,22 +922,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         return String(value.prefix(max - 1)) + "…"
     }
 
-    private func routineFailureSummary(_ r: Routine, max: Int) -> String {
-        if let detail = routineFailureDetail(r, max: max) { return detail }
-        return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
-    }
-
-    private func routineFailureDetail(_ r: Routine, max: Int) -> String? {
-        guard r.lastStatus == "failed" || r.lastStatus == "timeout" || r.overdue else { return nil }
-        if let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {
-            return trim(reason.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression), max)
-        }
-        if let code = r.exitCode {
-            return "exit \(code)"
-        }
-        return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
-    }
-
     // "3m" / "1h 12m" / "2d" — how long a session has been waiting (sentinel mtime).
     private func elapsedShort(_ sinceMs: Double) -> String {
         let mins = max(0, Int((LocalState.nowMs() - sinceMs) / 60_000))
@@ -983,4 +967,26 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             FileHandle.standardError.write("  \(kind)\(sub)\n".data(using: .utf8)!)
         }
     }
+}
+
+func routineFailureSummary(_ r: Routine, max: Int) -> String {
+    if let detail = routineFailureDetail(r, max: max) { return detail }
+    return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+}
+
+func routineFailureDetail(_ r: Routine, max: Int) -> String? {
+    let lastRunFailed = r.lastStatus == "failed" || r.lastStatus == "timeout"
+    guard lastRunFailed || r.overdue else { return nil }
+    if let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {
+        return trimText(reason.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression), max)
+    }
+    if lastRunFailed, let code = r.exitCode {
+        return "exit \(code)"
+    }
+    return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+}
+
+private func trimText(_ value: String, _ max: Int) -> String {
+    if value.count <= max { return value }
+    return String(value.prefix(max - 1)) + "…"
 }

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -616,7 +616,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             menu.addItem(row)
         }
         for r in failing {
-            let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+            let why = routineFailureSummary(r, max: 48)
             let row = statusRow("✕", fail, "\(r.name)  \(why)")
             row.submenu = routineSubmenu(r)
             menu.addItem(row)
@@ -724,6 +724,11 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
     private func routineSubmenu(_ r: Routine) -> NSMenu {
         let sub = NSMenu()
+        if let failure = routineFailureDetail(r, max: 72) {
+            sub.addItem(disabled(failure))
+            sub.addItem(.separator())
+        }
+
         let run = NSMenuItem(title: "Run now", action: #selector(onRoutineRun(_:)), keyEquivalent: "")
         run.target = self
         run.representedObject = r.name
@@ -748,7 +753,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         for r in routines {
             let mark = r.lastStatus == "failed" || r.lastStatus == "timeout" || r.overdue ? "! "
                 : (r.enabled ? "  " : "· ")
-            let when = r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused"
+            let when = routineFailureDetail(r, max: 52) ?? (r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused")
             let item = NSMenuItem(title: "\(mark)\(r.name)  \(when)", action: nil, keyEquivalent: "")
             item.submenu = routineSubmenu(r)
             sub.addItem(item)
@@ -915,6 +920,22 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func trim(_ value: String, _ max: Int) -> String {
         if value.count <= max { return value }
         return String(value.prefix(max - 1)) + "…"
+    }
+
+    private func routineFailureSummary(_ r: Routine, max: Int) -> String {
+        if let detail = routineFailureDetail(r, max: max) { return detail }
+        return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
+    }
+
+    private func routineFailureDetail(_ r: Routine, max: Int) -> String? {
+        guard r.lastStatus == "failed" || r.lastStatus == "timeout" || r.overdue else { return nil }
+        if let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {
+            return trim(reason.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression), max)
+        }
+        if let code = r.exitCode {
+            return "exit \(code)"
+        }
+        return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
     }
 
     // "3m" / "1h 12m" / "2d" — how long a session has been waiting (sentinel mtime).

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -65,6 +65,12 @@ function readRoutineYaml(home: string, name: string): Record<string, unknown> | 
   return yaml.parse(fs.readFileSync(p, 'utf-8'));
 }
 
+function writeRunMeta(home: string, jobName: string, runId: string, meta: Record<string, unknown>): void {
+  const runDir = path.join(home, '.agents', '.history', 'runs', jobName, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.writeFileSync(path.join(runDir, 'meta.json'), JSON.stringify(meta));
+}
+
 function daemonPidPath(home: string): string {
   return path.join(home, '.agents', '.cache', 'helpers', 'daemon', 'daemon.pid');
 }
@@ -346,6 +352,34 @@ describe('routines list --json has devices+runsHere, no device', () => {
       expect(entry).toBeDefined();
       expect(entry.devices).toEqual([]);
       expect(entry.runsHere).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('includes latest run exitCode and failureReason', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      writeRunMeta(home, 'test-job', '2026-07-21T10-00-00-000Z', {
+        jobName: 'test-job',
+        runId: '2026-07-21T10-00-00-000Z',
+        agent: 'claude',
+        pid: null,
+        status: 'failed',
+        startedAt: '2026-07-21T10:00:00.000Z',
+        completedAt: '2026-07-21T10:00:05.000Z',
+        exitCode: 2,
+        errorMessage: 'command exited with code 2',
+      });
+
+      const res = run(home, ['list', '--json']);
+      expect(res.status).toBe(0);
+
+      const parsed = JSON.parse(res.stdout.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === 'test-job');
+      expect(entry).toBeDefined();
+      expect(entry.exitCode).toBe(2);
+      expect(entry.failureReason).toBe('command exited with code 2');
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -384,6 +384,38 @@ describe('routines list --json has devices+runsHere, no device', () => {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
+
+  it('can report overdue independently of a completed zero-exit latest run', () => {
+    const home = makeHome({
+      jobs: [{ ...baseJob, schedule: '* * * * *' }],
+      registry,
+    });
+    try {
+      writeRunMeta(home, 'test-job', '2026-07-20T03-00-00-000Z', {
+        jobName: 'test-job',
+        runId: '2026-07-20T03-00-00-000Z',
+        agent: 'claude',
+        pid: null,
+        status: 'completed',
+        startedAt: '2026-07-20T03:00:00.000Z',
+        completedAt: '2026-07-20T03:00:05.000Z',
+        exitCode: 0,
+      });
+
+      const res = run(home, ['list', '--json']);
+      expect(res.status).toBe(0);
+
+      const parsed = JSON.parse(res.stdout.trim());
+      const entry = parsed.find((j: Record<string, unknown>) => j.name === 'test-job');
+      expect(entry).toBeDefined();
+      expect(entry.overdue).toBe(true);
+      expect(entry.lastStatus).toBe('completed');
+      expect(entry.exitCode).toBe(0);
+      expect(entry.failureReason).toBeNull();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('routines list table has Devices column with bounded ellipsis', () => {

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -329,6 +329,8 @@ export function registerRoutinesCommands(program: Command): void {
             nextRun: nextRun ? nextRun.toISOString() : null,
             nextRunHuman: humanizeNextRun(nextRun ?? null, nowJson, job.timezone),
             lastStatus: latestRun?.status ?? null,
+            exitCode: latestRun?.exitCode ?? null,
+            failureReason: latestRun?.errorMessage ?? null,
             lastRunStartedAt: latestRun?.startedAt ?? null,
             lastRunCompletedAt: latestRun?.completedAt ?? null,
           };


### PR DESCRIPTION
## Summary
- Add latest run `exitCode` and `failureReason` to `agents routines list --json` for menu-bar consumers.
- Decode and show failed routine reasons inline in the macOS menu-bar helper.
- Change the menu-bar `Logs` action to capture the concise `agents routines logs <name>` output into a text file and open it, instead of opening Terminal.

## Evidence
- `apps/cli/src/commands/routines.ts:331` `lastStatus: latestRun?.status ?? null,`
- `apps/cli/src/commands/routines.ts:332` `exitCode: latestRun?.exitCode ?? null,`
- `apps/cli/src/commands/routines.ts:333` `failureReason: latestRun?.errorMessage ?? null,`
- `apps/cli/menubar/Sources/MenubarHelper/Models.swift:16` `let lastStatus: String?            // completed | failed | timeout | running | null`
- `apps/cli/menubar/Sources/MenubarHelper/Models.swift:17` `let exitCode: Int?`
- `apps/cli/menubar/Sources/MenubarHelper/Models.swift:18` `let failureReason: String?`
- `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift:619` `let why = routineFailureSummary(r, max: 48)`
- `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift:727` `if let failure = routineFailureDetail(r, max: 72) {`
- `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift:756` `let when = routineFailureDetail(r, max: 52) ?? (r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused")`
- `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift:930` `private func routineFailureDetail(_ r: Routine, max: Int) -> String? {`
- `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift:932` `if let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {`
- `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift:935` `if let code = r.exitCode {`
- `apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift:116` `runMonitored(argv(["routines", "logs", name])) { text, ok in`
- `apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift:121` `try? body.write(to: url, atomically: true, encoding: .utf8)`
- `apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift:122` `runDetached(["/usr/bin/open", url.path])`
- `apps/cli/src/commands/routines.test.ts:360` `it('includes latest run exitCode and failureReason', () => {`
- `apps/cli/src/commands/routines.test.ts:381` `expect(entry.exitCode).toBe(2);`
- `apps/cli/src/commands/routines.test.ts:382` `expect(entry.failureReason).toBe('command exited with code 2');`
- `apps/cli/docs/03-routines.md:491` `agents routines logs <name>           # Show concise summary from latest run`
- `apps/cli/docs/menubar.md:86` `- **ROUTINES** — kept glanceable: the next few upcoming plus any failing routine`

## Verification
- `bun install` passed in `apps/cli` with `TMPDIR=/tmp/bun-tmp BUN_TMPDIR=/tmp/bun-tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-cache`.
- `bun run test src/commands/routines.test.ts` passed: `Test Files  1 passed (1)` and `Tests  26 passed (26)`.
- `bunx tsc --noEmit` passed.
- Isolated real-flow probe printed `"lastStatus":"failed","exitCode":2,"failureReason":"command exited with code 2"` from `routines list --json` and the concise `routines logs` output with `Failure summary: command exited with code 2.` plus `(pass --full for the raw stdout stream)`.
- macOS Swift compile on `zion` passed with `swift build` from `/tmp/rush-1284-menubar/menubar`: `Build complete! (27.36s)`.
- Full `bun run test` was attempted twice. The first run failed because the sandbox home is read-only, for example `EROFS: read-only file system, open '/home/muqsit/.agents/.cache/helpers/daemon/daemon.pid'`. The second run used an isolated writable `HOME`; it still hit the sandbox's read-only `/tmp/.agents` mount for `tests/project-resources-pipeline.test.ts` (`expected '/tmp/.agents' to be null`) and then hung after integration tests, so it was not counted as green.

Transcript: local Codex thread `019f869b-5c30-7d90-8ef6-85bbc60931a2`; transcript file was not visible under `~/.codex/sessions` in this sandbox.
