### PR TITLE
feat(secrets): support account-suffixed bundle keys

### DIFF
--- a/apps/cli/.changelog/next/RUSH-668.md
+++ b/apps/cli/.changelog/next/RUSH-668.md
@@ -1,0 +1,1 @@
+- **Support multiple accounts per secrets bundle (RUSH-668).** Secrets bundle keys now accept `BASE.account` names such as `GITHUB_USERNAME.personal`; selected account variants inject as the base env key and conflicting variants fail loud unless narrowed with `--keys`. Source: `apps/cli/src/lib/secrets/bundles.ts`, `apps/cli/docs/secrets.md`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -141,7 +141,8 @@ swallows the positional bundle name: `unlock <bundle> --host <machine>`.
 
 Source: `src/lib/secrets/remote.ts` (transport + resolve), wired into `list` /
 `view` / `exec` in `src/commands/secrets.ts` and the `--secrets` loop in
-`src/commands/exec.ts`. The lossless wire format is `secrets export --format json`.
+`src/commands/exec.ts`. The machine-readable wire format is
+`secrets export --format json`.
 The Windows push bridge is `buildWindowsStdinImportCommand` in
 `src/lib/hosts/remote-cmd.ts`.
 

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -259,6 +259,7 @@ last_used: "2026-06-01T08:00:00Z"   # ISO 8601 UTC — stamped on env resolution
 
 vars:
   STRIPE_API_KEY: "keychain:STRIPE_API_KEY"   # keychain-backed (default for `add`)
+  GITHUB_USERNAME.personal: { value: "muqsit" } # account-suffixed variant; injects as GITHUB_USERNAME when selected
   LOG_LEVEL: { value: "info" }                # literal (--value flag; avoids ref parsing)
   CI_TOKEN: "env:CI_TOKEN"                    # env: ref — reads from parent process.env
   CERT_PEM: "file:~/.certs/prod.pem"          # file: ref — reads file at run time
@@ -379,29 +380,27 @@ eval "$(agents secrets export prod --plaintext)"
 
 ### 7. Website logins with multiple accounts
 
-Name the bundle after the domain and group keys by account handle — one bundle per site, any number of accounts inside. Per-key `--note` records when to use each account; `view` prints notes in the clear while values stay masked, so an agent can pick the right account without revealing anything:
+Name the bundle after the domain and suffix each base key with the account handle — one bundle per site, any number of accounts inside. Per-key `--note` records when to use each account; `view` prints notes in the clear while values stay masked, so an agent can pick the right account without revealing anything:
 
 ```bash
 agents secrets create x.com --description "X/Twitter accounts. Read key notes to pick the right one."
 
-agents secrets add x.com ZEFFMUKS_USERNAME --value zeffmuks \
+agents secrets add x.com X_USERNAME.personal --value zeffmuks \
   --note "Personal account. Casual engagement, memes."
-agents secrets add x.com ZEFFMUKS_PASSWORD --type password \
+agents secrets add x.com X_PASSWORD.personal --type password \
   --note "Password for @zeffmuks"
-agents secrets add x.com SOCIAL_GETRUSH_USERNAME --value social@getrush.ai \
+agents secrets add x.com X_USERNAME.work --value social@getrush.ai \
   --note "Official Rush brand account. Marketing, announcements."
-agents secrets add x.com SOCIAL_GETRUSH_PASSWORD --type password \
+agents secrets add x.com X_PASSWORD.work --type password \
   --note "Password for social@getrush.ai"
 
-# Pick an account by reading notes, then reveal just that account's pair
+# Pick an account by reading notes, then inject just that account's pair.
+# The selected suffix is stripped, so the command sees X_USERNAME and X_PASSWORD.
 agents secrets view x.com
-agents secrets export x.com --plaintext | grep '^SOCIAL_GETRUSH_'
-
-# Or bind the bundle to a browser profile so it injects at browser start
-agents browser profiles create x --browser chrome --secrets x.com
+agents secrets exec x.com --keys X_USERNAME.work,X_PASSWORD.work -- ./login-helper
 ```
 
-Key naming: uppercase the handle, replace non-alphanumerics with `_`, suffix `_USERNAME` / `_PASSWORD` (plus `_TOTP_SECRET` for 2FA accounts).
+Key naming: use `BASE.account`, where `BASE` is the environment variable the child process expects and `account` is a short label such as `personal` or `work`. If two selected keys map to the same base name, injection fails and tells you to narrow with `--keys`.
 
 ### 8. Headless release on a remote Mac
 

--- a/apps/cli/src/commands/browser.ts
+++ b/apps/cli/src/commands/browser.ts
@@ -1557,7 +1557,7 @@ function registerTaskCommands(browser: Command): void {
           process.exit(1);
         }
         try {
-          const { env } = readAndResolveBundleEnv(parsed.bundle, { caller: 'browser type', keys: [parsed.key], agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(parsed.bundle, { caller: 'browser type', keys: [parsed.key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           if (!(parsed.key in env)) {
             console.error(`Key "${parsed.key}" not in bundle "${parsed.bundle}".`);
             process.exit(1);

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -164,6 +164,7 @@ describe('bundleEnvToDotenv', () => {
       WITH_SPACES: '  padded value  ',
       WITH_EQUALS: 'key=val=ue',
       WITH_HASH: 'token#frag',
+      'GITHUB_USERNAME.personal': 'muqsit',
       EMPTY: '',
     };
     const dotenv = bundleEnvToDotenv(env);

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -177,6 +177,41 @@ describe('bundleEnvToDotenv', () => {
   });
 });
 
+describe('secrets export --format json', () => {
+  function runSecrets(home: string, args: string[]): ReturnType<typeof spawnSync> {
+    return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'secrets', ...args], {
+      cwd: path.resolve(__dirname, '../..'),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: home,
+        AGENTS_SECRETS_PASSPHRASE: 'rush-668-test',
+        AGENTS_NO_USAGE_TRACK: '1',
+      },
+    });
+  }
+
+  it('prints injected process env keys for account-suffixed bundle keys', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-secrets-json-'));
+    try {
+      fs.mkdirSync(path.join(home, '.agents/.system'), { recursive: true });
+      spawnSync('git', ['init', '--quiet'], {
+        cwd: path.join(home, '.agents/.system'),
+        encoding: 'utf-8',
+      });
+      expect(runSecrets(home, ['create', 'github.com', '--backend', 'file']).status).toBe(0);
+      expect(runSecrets(home, ['add', 'github.com', 'GITHUB_USERNAME.work', '--value', 'workbot']).status).toBe(0);
+
+      const exported = runSecrets(home, ['export', 'github.com', '--plaintext', '--format', 'json']);
+
+      expect(exported.status, exported.stderr).toBe(0);
+      expect(JSON.parse(exported.stdout)).toEqual({ GITHUB_USERNAME: 'workbot' });
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('buildSecretsExecEnv', () => {
   it('strips AGENTS_SECRETS_PASSPHRASE and loader-hijack vars from the child env', () => {
     const parent = {

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -1049,7 +1049,7 @@ export function registerSecretsCommands(program: Command): void {
         // `secrets get` is the scriptable automation primitive ($(agents secrets
         // get bundle KEY)); when embedded in a headless routine/CI script it must
         // not pop an unwatched Touch ID prompt. Interactive use still prompts.
-        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], agentOnly: isHeadlessSecretsContext() });
+        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
         if (!(key in env)) {
           console.error(chalk.red(`Key '${key}' not in bundle '${item}'.`));
           process.exit(1);
@@ -1639,7 +1639,7 @@ Examples:
               'Set it for this command, then supply the same value when importing.'
             );
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           exportBundleToFile(env, opts.toFile, passphrase);
           console.log(chalk.green(`Exported ${Object.keys(env).length} key(s) to ${opts.toFile}`));
           return;
@@ -1668,7 +1668,7 @@ Examples:
               );
             }
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           const dotenv = bundleEnvToDotenv(env);
           const keyCount = Object.keys(env).length;
           // Drive the remote's own `agents secrets import --from -` so the values
@@ -1736,7 +1736,7 @@ Examples:
         if (opts.to1password) {
           assertOpAvailable();
           const vault = await resolveVault(opts.vault);
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           let created = 0;
           let overwritten = 0;
           let skipped = 0;
@@ -1778,6 +1778,7 @@ Examples:
         // terminal stdin, so it is not headless and still prompts.
         const { env } = readAndResolveBundleEnv(resolvedBundleName, {
           caller: `export to shell`,
+          keyMode: opts.format === 'json' ? 'storage' : 'process',
           agentOnly: isHeadlessSecretsContext(),
         });
         if (opts.format === 'json') {
@@ -2042,7 +2043,7 @@ Examples:
         try {
           // noAgent: read the real keychain (one Touch ID) rather than the
           // agent we're about to populate.
-          const { bundle, env } = readAndResolveBundleEnv(name, { noAgent: true, caller: 'unlock' });
+          const { bundle, env } = readAndResolveBundleEnv(name, { noAgent: true, caller: 'unlock', keyMode: 'storage' });
           if (await agentLoad(name, bundle, env, ttlMs)) {
             loaded++;
             // Persist a durable session snapshot so the unlock survives a daemon

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -1778,12 +1778,12 @@ Examples:
         // terminal stdin, so it is not headless and still prompts.
         const { env } = readAndResolveBundleEnv(resolvedBundleName, {
           caller: `export to shell`,
-          keyMode: opts.format === 'json' ? 'storage' : 'process',
+          keyMode: 'process',
           agentOnly: isHeadlessSecretsContext(),
         });
         if (opts.format === 'json') {
-          // Lossless, machine-readable form consumed by `remoteResolveEnv` over
-          // SSH. Single object of KEY -> value; values verbatim (newlines, quotes).
+          // Machine-readable form consumed by `remoteResolveEnv` over SSH.
+          // Single object of injected env KEY -> value; values verbatim.
           process.stdout.write(JSON.stringify(env));
           return;
         }

--- a/apps/cli/src/commands/ssh.test.ts
+++ b/apps/cli/src/commands/ssh.test.ts
@@ -25,12 +25,18 @@ function guardedHome(): void {
   );
 }
 
-function run(args: string[]): { stdout: string; status: number | null } {
+function run(args: string[], extraEnv: Record<string, string> = {}): { stdout: string; stderr: string; status: number | null } {
   const r = spawnSync('bun', [INDEX, ...args], {
     encoding: 'utf-8',
-    env: { ...process.env, HOME: testHome, AGENTS_NO_UPDATE_CHECK: '1' },
+    env: {
+      ...process.env,
+      HOME: testHome,
+      AGENTS_NO_UPDATE_CHECK: '1',
+      AGENTS_NO_USAGE_TRACK: '1',
+      ...extraEnv,
+    },
   });
-  return { stdout: r.stdout ?? '', status: r.status };
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status };
 }
 
 describe('devices command', () => {
@@ -41,5 +47,24 @@ describe('devices command', () => {
     expect(status).toBe(0);
     expect(stdout).toContain("No devices. Run 'agents devices sync'");
     expect(stdout).not.toContain('Usage: agents devices');
+  });
+});
+
+describe('ssh askpass', () => {
+  it('resolves an account-suffixed bundle key by exact storage name', () => {
+    guardedHome();
+    const env = { AGENTS_SECRETS_PASSPHRASE: 'rush-668-test' };
+
+    expect(run(['secrets', 'create', 'github.com', '--backend', 'file'], env).status).toBe(0);
+    expect(run(['secrets', 'add', 'github.com', 'password.work', '--value', 'secret-pass'], env).status).toBe(0);
+
+    const askpass = run(['ssh', '__askpass'], {
+      ...env,
+      AGENTS_SSH_BUNDLE: 'github.com',
+      AGENTS_SSH_KEY: 'password.work',
+    });
+
+    expect(askpass.status, askpass.stderr).toBe(0);
+    expect(askpass.stdout).toBe('secret-pass');
   });
 });

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -1029,7 +1029,7 @@ async function runAskpass(): Promise<void> {
     process.exit(1);
   }
   try {
-    const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents ssh', agentOnly: isHeadlessSecretsContext() });
+    const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents ssh', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
     const value = env[key];
     if (value === undefined) {
       console.error(`askpass: key '${key}' not found in bundle '${bundle}'`);

--- a/apps/cli/src/lib/secrets/__tests__/bundles-file-backend.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/bundles-file-backend.test.ts
@@ -108,6 +108,36 @@ describe('file-backed bundle routing', () => {
     expect(env.API_KEY).toBe('shh');
   });
 
+  it('round-trips account-suffixed keys and injects a selected variant as the base env name', () => {
+    createFileBundle('github.com', 'GITHUB_USERNAME.personal', 'muqsit');
+    const exact = readBundle('github.com');
+    expect(exact.vars['GITHUB_USERNAME.personal']).toBe('keychain:GITHUB_USERNAME.personal');
+
+    const { env } = readAndResolveBundleEnv('github.com', {
+      caller: 'test',
+      keys: ['GITHUB_USERNAME.personal'],
+    });
+    expect(env).toEqual({ GITHUB_USERNAME: 'muqsit' });
+
+    const storage = readAndResolveBundleEnv('github.com', {
+      caller: 'test',
+      keys: ['GITHUB_USERNAME.personal'],
+      keyMode: 'storage',
+    });
+    expect(storage.env).toEqual({ 'GITHUB_USERNAME.personal': 'muqsit' });
+  });
+
+  it('rejects injecting multiple account variants that target the same env key', () => {
+    createFileBundle('github.com', 'GITHUB_USERNAME.personal', 'muqsit');
+    const bundle = readBundle('github.com');
+    bundleItemStore('file').set(secretsKeychainItem('github.com', 'GITHUB_USERNAME.work'), 'workbot');
+    bundle.vars['GITHUB_USERNAME.work'] = keychainRef('GITHUB_USERNAME.work');
+    writeBundle(bundle);
+
+    expect(() => readAndResolveBundleEnv('github.com', { caller: 'test' }))
+      .toThrow(/maps multiple keys to 'GITHUB_USERNAME'/);
+  });
+
   it('resolution fails clearly when the passphrase is wrong', () => {
     createFileBundle('rel', 'TOKEN', 'sealed-value');
     process.env.AGENTS_SECRETS_PASSPHRASE = 'wrong';

--- a/apps/cli/src/lib/secrets/__tests__/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/bundles.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
   bundleToEnvPrefix,
+  bundleKeyToEnvKey,
   describeBundle,
   isLoaderOrInterpreterEnv,
   isReservedEnvName,
@@ -35,11 +36,15 @@ describe('validation', () => {
     expect(() => validateBundleName('_bad')).toThrow();
   });
 
-  it('validateEnvKey matches parseExecEnv conventions', () => {
+  it('validateEnvKey accepts env keys and one optional account suffix', () => {
     expect(() => validateEnvKey('MY_KEY')).not.toThrow();
     expect(() => validateEnvKey('_private')).not.toThrow();
+    expect(() => validateEnvKey('GITHUB_USERNAME.personal')).not.toThrow();
+    expect(() => validateEnvKey('GITHUB_USERNAME.work-1')).not.toThrow();
     expect(() => validateEnvKey('1starts_with_digit')).toThrow();
     expect(() => validateEnvKey('KEY-WITH-DASH')).toThrow();
+    expect(() => validateEnvKey('KEY.')).toThrow();
+    expect(() => validateEnvKey('KEY.personal.extra')).toThrow();
   });
 
   it('validateEnvKey rejects reserved loader and interpreter env vars', () => {
@@ -51,6 +56,13 @@ describe('validation', () => {
     expect(() => validateEnvKey('DYLD_INSERT_LIBRARIES')).toThrow(/reserved/);
     expect(() => validateEnvKey('NODE_OPTIONS')).toThrow(/reserved/);
     expect(() => validateEnvKey('path')).toThrow(/reserved/);
+    expect(() => validateEnvKey('PATH.personal')).toThrow(/reserved/);
+    expect(() => validateEnvKey('NODE_OPTIONS.work')).toThrow(/reserved/);
+  });
+
+  it('bundleKeyToEnvKey strips only the account suffix', () => {
+    expect(bundleKeyToEnvKey('GITHUB_USERNAME.personal')).toBe('GITHUB_USERNAME');
+    expect(bundleKeyToEnvKey('API_KEY')).toBe('API_KEY');
   });
 
   it('bundleToEnvPrefix converts bundle names to valid env prefixes', () => {
@@ -80,6 +92,14 @@ describe('parseDotenv', () => {
 
   it('skips comments and blank lines', () => {
     expect(parseDotenv('# comment\n\nA=1\n')).toEqual({ A: '1' });
+  });
+
+  it('parses account-suffixed keys', () => {
+    expect(parseDotenv('GITHUB_USERNAME.personal=muqsit\nGITHUB_USERNAME.work=workbot'))
+      .toEqual({
+        'GITHUB_USERNAME.personal': 'muqsit',
+        'GITHUB_USERNAME.work': 'workbot',
+      });
   });
 
   it('strips matching quotes around values', () => {
@@ -133,6 +153,34 @@ describe('describeBundle + resolveBundleEnv', () => {
     } finally {
       delete process.env.__AGENTS_RESOLVE_TEST;
     }
+  });
+
+  it('projects one selected account-suffixed key to the base env name', () => {
+    const bundle = b({
+      'GITHUB_USERNAME.personal': { value: 'muqsit' },
+      'GITHUB_USERNAME.work': { value: 'workbot' },
+    });
+    expect(resolveBundleEnv(bundle, { keys: ['GITHUB_USERNAME.personal'] }))
+      .toEqual({ GITHUB_USERNAME: 'muqsit' });
+  });
+
+  it('can preserve exact storage keys for direct lookups and backups', () => {
+    const bundle = b({
+      'GITHUB_USERNAME.personal': { value: 'muqsit' },
+    });
+    expect(resolveBundleEnv(bundle, { keys: ['GITHUB_USERNAME.personal'], keyMode: 'storage' }))
+      .toEqual({ 'GITHUB_USERNAME.personal': 'muqsit' });
+  });
+
+  it('fails loudly when multiple selected keys project to the same env name', () => {
+    const bundle = b({
+      'GITHUB_USERNAME.personal': { value: 'muqsit' },
+      'GITHUB_USERNAME.work': { value: 'workbot' },
+    });
+    expect(() => resolveBundleEnv(bundle)).toThrow(/maps multiple keys to 'GITHUB_USERNAME'/);
+    expect(() => resolveBundleEnv(bundle, {
+      keys: ['GITHUB_USERNAME.personal', 'GITHUB_USERNAME.work'],
+    })).toThrow(/Select one account variant with --keys/);
   });
 
   it('keychainItemsForBundle enumerates keychain-backed keys only', () => {

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -74,6 +74,33 @@ describe('filterAgentHitBySubsetAndExpiry (agent fast-path gate)', () => {
     expect(out.env.SLACK_TOKEN).toBeUndefined();
   });
 
+  it('projects a selected account-suffixed key from the cached snapshot', () => {
+    const hit = agentHit({
+      'GITHUB_USERNAME.personal': 'k',
+      'GITHUB_USERNAME.work': 'k',
+    });
+    const out = filterAgentHitBySubsetAndExpiry(hit, { keys: ['GITHUB_USERNAME.personal'] });
+    expect(out.env).toEqual({ GITHUB_USERNAME: 'v-GITHUB_USERNAME.personal' });
+  });
+
+  it('preserves exact account-suffixed keys when storage mode is requested', () => {
+    const hit = agentHit({ 'GITHUB_USERNAME.personal': 'k' });
+    const out = filterAgentHitBySubsetAndExpiry(hit, {
+      keys: ['GITHUB_USERNAME.personal'],
+      keyMode: 'storage',
+    });
+    expect(out.env).toEqual({ 'GITHUB_USERNAME.personal': 'v-GITHUB_USERNAME.personal' });
+  });
+
+  it('fails loudly when cached account variants collide in process env mode', () => {
+    const hit = agentHit({
+      'GITHUB_USERNAME.personal': 'k',
+      'GITHUB_USERNAME.work': 'k',
+    });
+    expect(() => filterAgentHitBySubsetAndExpiry(hit, {}))
+      .toThrow(/maps multiple keys to 'GITHUB_USERNAME'/);
+  });
+
   it('throws a fail-loud error if a requested key is not in the bundle', () => {
     const hit = agentHit({ API_KEY: 'k' });
     expect(() => filterAgentHitBySubsetAndExpiry(hit, { keys: ['GHOST'] }))

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -75,6 +75,13 @@ describe('filterAgentHitBySubsetAndExpiry (agent fast-path gate)', () => {
     expect(out.env.SLACK_TOKEN).toBeUndefined();
   });
 
+  it('does not return a same-size partial cached env for a different requested subset', () => {
+    const hit = agentHit({ API_KEY: 'k', DB_URL: 'k' });
+    hit.env = { API_KEY: 'v-API_KEY' };
+    const out = filterAgentHitBySubsetAndExpiry(hit, { keys: ['DB_URL'] });
+    expect(out.env).toEqual({});
+  });
+
   it('projects a selected account-suffixed key from the cached snapshot', () => {
     const hit = agentHit({
       'GITHUB_USERNAME.personal': 'k',

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import {
   filterAgentHitBySubsetAndExpiry,
   assertRemoteBundleFlagsUnsupported,
+  canCacheResolvedEnv,
   isHeadlessSecretsContext,
   listBundles,
   readAndResolveBundleEnv,
@@ -139,6 +140,28 @@ describe('filterAgentHitBySubsetAndExpiry (agent fast-path gate)', () => {
     );
     const out = filterAgentHitBySubsetAndExpiry(hit, { keys: ['API_KEY'] });
     expect(out.env).toEqual({ API_KEY: 'v-API_KEY' });
+  });
+});
+
+describe('canCacheResolvedEnv (broker cache shape)', () => {
+  const bundle: SecretsBundle = {
+    name: 'github.com',
+    vars: {
+      'GITHUB_USERNAME.personal': 'keychain:GITHUB_USERNAME.personal',
+      'GITHUB_USERNAME.work': 'keychain:GITHUB_USERNAME.work',
+    },
+  };
+
+  it('does not cache partial storage reads because the broker expects a full bundle env', () => {
+    expect(canCacheResolvedEnv(bundle, new Set(['GITHUB_USERNAME.personal']), 'storage')).toBe(false);
+  });
+
+  it('allows a full storage snapshot because later reads can project from exact keys', () => {
+    expect(canCacheResolvedEnv(bundle, new Set(Object.keys(bundle.vars)), 'storage')).toBe(true);
+  });
+
+  it('does not cache process-mode env when account suffixes would be stripped', () => {
+    expect(canCacheResolvedEnv(bundle, new Set(Object.keys(bundle.vars)), 'process')).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -214,6 +214,7 @@ const LAST_USED_THROTTLE_MS = 60_000;
 
 export const BUNDLE_NAME_PATTERN = /^[a-z0-9][a-z0-9\-_.]{0,48}$/i;
 export const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+export const BUNDLE_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_-]+)?$/;
 export const BUNDLE_META_PREFIX = 'agents-cli.bundles.';
 const SECRETS_ITEM_PREFIX = 'agents-cli.secrets.';
 
@@ -229,6 +230,11 @@ export function bundleToEnvPrefix(name: string): string {
 
 export function isReservedEnvName(key: string): boolean {
   return RESERVED_ENV_NAMES.has(key.toUpperCase());
+}
+
+export function bundleKeyToEnvKey(key: string): string {
+  const dot = key.indexOf('.');
+  return dot === -1 ? key : key.slice(0, dot);
 }
 
 export function isLoaderOrInterpreterEnv(name: string): boolean {
@@ -267,10 +273,11 @@ export function validateBundleName(name: string): void {
 }
 
 export function validateEnvKey(key: string): void {
-  if (!ENV_KEY_PATTERN.test(key)) {
-    throw new Error(`Invalid environment variable name '${key}'. Must match [A-Za-z_][A-Za-z0-9_]*.`);
+  if (!BUNDLE_KEY_PATTERN.test(key)) {
+    throw new Error(`Invalid bundle key '${key}'. Must match [A-Za-z_][A-Za-z0-9_]* with optional .account suffix.`);
   }
-  if (isLoaderOrInterpreterEnv(key) || isReservedEnvName(key)) {
+  const envKey = bundleKeyToEnvKey(key);
+  if (isLoaderOrInterpreterEnv(envKey) || isReservedEnvName(envKey)) {
     throw new Error(`Env key "${key}" is reserved — cannot be used in a secrets bundle. Reserved keys include PATH, HOME, USER, and dynamic-loader/interpreter vars (LD_*, DYLD_*, NODE_OPTIONS, etc.).`);
   }
 }
@@ -539,7 +546,7 @@ function parseBundleMeta(nameHint: string | undefined, json: string, backend: Se
   if (typeof parsed.last_used === 'string') bundle.last_used = parsed.last_used;
   if (parsed.meta && typeof parsed.meta === 'object') bundle.meta = parsed.meta;
   for (const key of Object.keys(bundle.vars)) {
-    if (!ENV_KEY_PATTERN.test(key)) return null;
+    if (!BUNDLE_KEY_PATTERN.test(key)) return null;
   }
   return bundle;
 }
@@ -726,6 +733,12 @@ export interface ResolveBundleOptions {
    * bundle-level expiry has passed) aborts the run before Touch ID is popped.
    */
   allowExpired?: boolean;
+  /**
+   * `process` projects dotted account keys like `GITHUB_USERNAME.personal` to
+   * the shell-safe base env name (`GITHUB_USERNAME`). Direct value lookups and
+   * backup/export flows use `storage` to preserve the exact bundle key names.
+   */
+  keyMode?: 'process' | 'storage';
 }
 
 /**
@@ -771,6 +784,78 @@ function selectRequestedKeys(bundle: SecretsBundle, requested: string[] | undefi
   return new Set(req ?? Object.keys(bundle.vars));
 }
 
+function assignResolvedEnvValue(
+  env: Record<string, string>,
+  bundle: SecretsBundle,
+  storageKey: string,
+  value: string,
+  keyMode: ResolveBundleOptions['keyMode'],
+  owners: Map<string, string>,
+): void {
+  const envKey = keyMode === 'storage' ? storageKey : bundleKeyToEnvKey(storageKey);
+  const previous = owners.get(envKey);
+  if (previous && previous !== storageKey) {
+    throw new Error(
+      `Bundle '${bundle.name}' maps multiple keys to '${envKey}': ${previous}, ${storageKey}. ` +
+      `Select one account variant with --keys.`,
+    );
+  }
+  owners.set(envKey, storageKey);
+  env[envKey] = value;
+}
+
+function projectResolvedEnv(
+  bundle: SecretsBundle,
+  env: Record<string, string>,
+  selectedKeys: Set<string>,
+  keyMode: ResolveBundleOptions['keyMode'],
+): Record<string, string> {
+  if (keyMode === 'storage') {
+    const out: Record<string, string> = {};
+    for (const key of selectedKeys) {
+      if (key in env) out[key] = env[key];
+    }
+    return out;
+  }
+
+  let needsProjection = false;
+  const owners = new Map<string, string>();
+  for (const key of selectedKeys) {
+    const envKey = bundleKeyToEnvKey(key);
+    if (envKey !== key) needsProjection = true;
+    const previous = owners.get(envKey);
+    if (previous && previous !== key) {
+      throw new Error(
+        `Bundle '${bundle.name}' maps multiple keys to '${envKey}': ${previous}, ${key}. ` +
+        `Select one account variant with --keys.`,
+      );
+    }
+    owners.set(envKey, key);
+  }
+  if (!needsProjection) {
+    if (selectedKeys.size === Object.keys(env).length) return env;
+    const out: Record<string, string> = {};
+    for (const key of selectedKeys) {
+      if (key in env) out[key] = env[key];
+    }
+    return out;
+  }
+
+  const out: Record<string, string> = {};
+  for (const key of selectedKeys) {
+    if (key in env) out[bundleKeyToEnvKey(key)] = env[key];
+  }
+  return out;
+}
+
+function canCacheResolvedEnv(selectedKeys: Set<string>, keyMode: ResolveBundleOptions['keyMode']): boolean {
+  if (keyMode === 'storage') return true;
+  for (const key of selectedKeys) {
+    if (bundleKeyToEnvKey(key) !== key) return false;
+  }
+  return true;
+}
+
 /**
  * Apply the --keys subset + expiry gate to an already-resolved snapshot from
  * the secrets-agent fast-path. The agent stores the FULL bundle env, so a
@@ -787,13 +872,10 @@ export function filterAgentHitBySubsetAndExpiry(
 ): { bundle: SecretsBundle; env: Record<string, string> } {
   const selectedKeys = selectRequestedKeys(hit.bundle, opts.keys);
   assertNotExpired(hit.bundle, [...selectedKeys], opts.allowExpired ?? false);
-  // When no subset was requested, return the cached env untouched — same
-  // reference the agent handed back, so no per-call allocation on the hot path.
-  if (!opts.keys?.length) return hit;
-  const env: Record<string, string> = {};
-  for (const key of selectedKeys) {
-    if (key in hit.env) env[key] = hit.env[key];
-  }
+  const env = projectResolvedEnv(hit.bundle, hit.env, selectedKeys, opts.keyMode);
+  // When no subset/projection was requested, return the cached env untouched —
+  // same reference the agent handed back, so no per-call allocation on the hot path.
+  if (env === hit.env) return hit;
   return { bundle: hit.bundle, env };
 }
 
@@ -853,11 +935,12 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
     : new Map<string, string>();
 
   const env: Record<string, string> = {};
+  const owners = new Map<string, string>();
   for (const [key, raw] of Object.entries(bundle.vars)) {
     if (!selectedKeys.has(key)) continue;
     const parsed = parsedByKey.get(key)!;
     if ('literal' in parsed) {
-      env[key] = parsed.literal;
+      assignResolvedEnvValue(env, bundle, key, parsed.literal, _opts.keyMode, owners);
       continue;
     }
     if (parsed.ref.provider === 'keychain') {
@@ -869,14 +952,15 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
           `Run: agents secrets add ${bundle.name} ${key}`
         );
       }
-      env[key] = value;
+      assignResolvedEnvValue(env, bundle, key, value, _opts.keyMode, owners);
       continue;
     }
     try {
-      env[key] = resolveRef(parsed.ref, {
+      const value = resolveRef(parsed.ref, {
         allowExec: bundle.allow_exec,
         keychainItemFor: (shortId: string) => secretsKeychainItem(bundle.name, shortId),
       });
+      assignResolvedEnvValue(env, bundle, key, value, _opts.keyMode, owners);
     } catch (err) {
       throw new Error(`Bundle '${bundle.name}' key '${key}': ${(err as Error).message}`);
     }
@@ -1110,11 +1194,12 @@ export function readAndResolveBundleEnv(
 
   try {
     const env: Record<string, string> = {};
+    const owners = new Map<string, string>();
     for (const [key] of Object.entries(bundle.vars)) {
       if (!selectedKeys.has(key)) continue;
       const p = parsedByKey.get(key)!;
       if ('literal' in p) {
-        env[key] = p.literal;
+        assignResolvedEnvValue(env, bundle, key, p.literal, opts.keyMode, owners);
         continue;
       }
       if (p.ref.provider === 'keychain') {
@@ -1129,14 +1214,15 @@ export function readAndResolveBundleEnv(
             `Run: agents secrets add ${bundle.name} ${key}`,
           );
         }
-        env[key] = value;
+        assignResolvedEnvValue(env, bundle, key, value, opts.keyMode, owners);
         continue;
       }
       try {
-        env[key] = resolveRef(p.ref, {
+        const value = resolveRef(p.ref, {
           allowExec: bundle.allow_exec,
           keychainItemFor: (shortId: string) => secretsKeychainItem(bundle.name, shortId),
         });
+        assignResolvedEnvValue(env, bundle, key, value, opts.keyMode, owners);
       } catch (err) {
         throw new Error(`Bundle '${bundle.name}' key '${key}': ${(err as Error).message}`);
       }
@@ -1155,7 +1241,8 @@ export function readAndResolveBundleEnv(
       !opts.noAgent &&
       process.env.AGENTS_SECRETS_NO_AGENT !== '1' &&
       bundlePolicy(bundle) === 'daily' &&
-      secretsAgentAutoEnabled()
+      secretsAgentAutoEnabled() &&
+      canCacheResolvedEnv(selectedKeys, opts.keyMode)
     ) {
       agentAutoLoadSync(name, bundle, env, secretsHoldMs());
     }
@@ -1344,7 +1431,7 @@ export function parseDotenv(content: string): Record<string, string> {
     ) {
       value = value.slice(1, -1);
     }
-    if (ENV_KEY_PATTERN.test(key)) {
+    if (BUNDLE_KEY_PATTERN.test(key)) {
       out[key] = value;
     }
   }

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -848,7 +848,8 @@ function projectResolvedEnv(
   return out;
 }
 
-function canCacheResolvedEnv(selectedKeys: Set<string>, keyMode: ResolveBundleOptions['keyMode']): boolean {
+export function canCacheResolvedEnv(bundle: SecretsBundle, selectedKeys: Set<string>, keyMode: ResolveBundleOptions['keyMode']): boolean {
+  if (selectedKeys.size !== Object.keys(bundle.vars).length) return false;
   if (keyMode === 'storage') return true;
   for (const key of selectedKeys) {
     if (bundleKeyToEnvKey(key) !== key) return false;
@@ -1242,7 +1243,7 @@ export function readAndResolveBundleEnv(
       process.env.AGENTS_SECRETS_NO_AGENT !== '1' &&
       bundlePolicy(bundle) === 'daily' &&
       secretsAgentAutoEnabled() &&
-      canCacheResolvedEnv(selectedKeys, opts.keyMode)
+      canCacheResolvedEnv(bundle, selectedKeys, opts.keyMode)
     ) {
       agentAutoLoadSync(name, bundle, env, secretsHoldMs());
     }

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -833,7 +833,8 @@ function projectResolvedEnv(
     owners.set(envKey, key);
   }
   if (!needsProjection) {
-    if (selectedKeys.size === Object.keys(env).length) return env;
+    const envKeys = Object.keys(env);
+    if (selectedKeys.size === envKeys.length && envKeys.every((key) => selectedKeys.has(key))) return env;
     const out: Record<string, string> = {};
     for (const key of selectedKeys) {
       if (key in env) out[key] = env[key];

--- a/apps/cli/src/lib/secrets/icloud-import.test.ts
+++ b/apps/cli/src/lib/secrets/icloud-import.test.ts
@@ -258,6 +258,32 @@ describe('importSyncedBundle', () => {
     ]);
   });
 
+  it('reserved account-suffixed keys are reported unimportable without aborting the bundle', () => {
+    synced.store.set(
+      'agents-cli.bundles.legacy',
+      JSON.stringify({
+        vars: {
+          GOOD_KEY: 'keychain:GOOD_KEY',
+          'PATH.personal': 'keychain:PATH.personal',
+          'NODE_OPTIONS.work': { value: '--require ./evil.js' },
+        },
+      }),
+    );
+    synced.store.set('agents-cli.secrets.legacy.GOOD_KEY', 'good-v');
+    synced.store.set('agents-cli.secrets.legacy.PATH.personal', '/evil/bin');
+    const [candidate] = discoverSyncedBundles();
+
+    const result = importSyncedBundle(candidate, { purge: true });
+    expect(result.added).toBe(1);
+    expect(result.unimportable.sort()).toEqual(['NODE_OPTIONS.work', 'PATH.personal']);
+    expect(readBundle('legacy').vars.GOOD_KEY).toBe('keychain:GOOD_KEY');
+    expect(result.purged).toBe(1);
+    expect([...synced.store.keys()].sort()).toEqual([
+      'agents-cli.bundles.legacy',
+      'agents-cli.secrets.legacy.PATH.personal',
+    ]);
+  });
+
   it('all-plaintext stores values as literals without touching the local keychain', () => {
     synced.store.set('agents-cli.secrets.lit.ONLY_KEY', 'plain');
     const [candidate] = discoverSyncedBundles();

--- a/apps/cli/src/lib/secrets/icloud-import.ts
+++ b/apps/cli/src/lib/secrets/icloud-import.ts
@@ -11,8 +11,8 @@
  *
  * The item-name scheme is the same one the modern store uses (see bundles.ts):
  * metadata under `agents-cli.bundles.<name>`, one value per key under
- * `agents-cli.secrets.<bundle>.<key>`. Env keys can never contain a dot
- * (ENV_KEY_PATTERN), so splitting a secret service at its LAST dot recovers
+ * `agents-cli.secrets.<bundle>.<key>`. Legacy env keys never contained a dot,
+ * so metadata-less synced secret services split at their LAST dot to recover
  * the bundle/key boundary even for dotted bundle names like `hetzner.com`.
  */
 
@@ -30,6 +30,7 @@ import {
 import {
   BUNDLE_META_PREFIX,
   BUNDLE_NAME_PATTERN,
+  BUNDLE_KEY_PATTERN,
   ENV_KEY_PATTERN,
   bundleExists,
   bundleItemStore,
@@ -220,7 +221,7 @@ export function importSyncedBundle(
   // carry everything they need; a keychain ref without its synced item is
   // unrecoverable.
   for (const [key, raw] of Object.entries(metaVars)) {
-    if (!ENV_KEY_PATTERN.test(key)) continue;
+    if (!BUNDLE_KEY_PATTERN.test(key)) continue;
     if (candidate.keys.includes(key)) continue; // the secret item already covered it
     if (rejectedByPolicy(key)) {
       if (!unimportable.includes(key)) unimportable.push(key);

--- a/apps/cli/src/lib/secrets/icloud-import.ts
+++ b/apps/cli/src/lib/secrets/icloud-import.ts
@@ -32,6 +32,7 @@ import {
   BUNDLE_NAME_PATTERN,
   BUNDLE_KEY_PATTERN,
   ENV_KEY_PATTERN,
+  bundleKeyToEnvKey,
   bundleExists,
   bundleItemStore,
   bundlePolicy,
@@ -187,7 +188,10 @@ export function importSyncedBundle(
   // these may be purged; a missing or unimportable key's iCloud item is its
   // only copy and must survive.
   const purgeable = new Set<string>();
-  const rejectedByPolicy = (key: string) => isLoaderOrInterpreterEnv(key) || isReservedEnvName(key);
+  const rejectedByPolicy = (key: string) => {
+    const envKey = bundleKeyToEnvKey(key);
+    return isLoaderOrInterpreterEnv(envKey) || isReservedEnvName(envKey);
+  };
 
   // Keys with a synced secret item: re-store the value device-locally.
   for (const key of candidate.keys) {

--- a/apps/cli/src/lib/secrets/mcp.ts
+++ b/apps/cli/src/lib/secrets/mcp.ts
@@ -111,7 +111,7 @@ export function resolveSecret(bundle: string, key: string): string {
   }
   // The MCP get_secret tool is typically served by a background/headless agent
   // process; resolve broker-only there so it never raises an unwatched prompt.
-  const { env } = readAndResolveBundleEnv(bundle, { caller: 'secrets-mcp', agentOnly: isHeadlessSecretsContext() });
+  const { env } = readAndResolveBundleEnv(bundle, { caller: 'secrets-mcp', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
   const value = env[key];
   if (value === undefined) {
     throw new Error(`Key '${key}' in bundle '${bundle}' could not be resolved.`);


### PR DESCRIPTION
## Evidence
- `apps/cli/src/lib/secrets/bundles.ts:217`: `export const BUNDLE_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_-]+)?$/;`
- `apps/cli/src/lib/secrets/bundles.ts:235`: `export function bundleKeyToEnvKey(key: string): string {`
- `apps/cli/src/lib/secrets/bundles.ts:237`: `return dot === -1 ? key : key.slice(0, dot);`
- `apps/cli/src/lib/secrets/bundles.ts:275`: `export function validateEnvKey(key: string): void {`
- `apps/cli/src/lib/secrets/bundles.ts:276`: `if (!BUNDLE_KEY_PATTERN.test(key)) {`
- `apps/cli/src/lib/secrets/bundles.ts:279`: `const envKey = bundleKeyToEnvKey(key);`
- `apps/cli/src/lib/secrets/bundles.ts:737`: `` * `process` projects dotted account keys like `GITHUB_USERNAME.personal` to``
- `apps/cli/src/lib/secrets/bundles.ts:741`: `keyMode?: 'process' | 'storage';`
- `apps/cli/src/lib/secrets/bundles.ts:795`: `const envKey = keyMode === 'storage' ? storageKey : bundleKeyToEnvKey(storageKey);`
- `apps/cli/src/lib/secrets/bundles.ts:799`: `` `Bundle '${bundle.name}' maps multiple keys to '${envKey}': ${previous}, ${storageKey}. ` +``
- `apps/cli/src/lib/secrets/bundles.ts:800`: `` `Select one account variant with --keys.`,``
- `apps/cli/src/lib/secrets/bundles.ts:813`: `if (keyMode === 'storage') {`
- `apps/cli/src/lib/secrets/bundles.ts:837`: `if (selectedKeys.size === envKeys.length && envKeys.every((key) => selectedKeys.has(key))) return env;`
- `apps/cli/src/lib/secrets/bundles.ts:847`: `if (key in env) out[bundleKeyToEnvKey(key)] = env[key];`
- `apps/cli/src/lib/secrets/bundles.ts:852`: `export function canCacheResolvedEnv(bundle: SecretsBundle, selectedKeys: Set<string>, keyMode: ResolveBundleOptions['keyMode']): boolean {`
- `apps/cli/src/lib/secrets/bundles.ts:853`: `if (selectedKeys.size !== Object.keys(bundle.vars).length) return false;`
- `apps/cli/src/lib/secrets/bundles.ts:854`: `if (keyMode === 'storage') return true;`
- `apps/cli/src/lib/secrets/bundles.ts:877`: `const env = projectResolvedEnv(hit.bundle, hit.env, selectedKeys, opts.keyMode);`
- `apps/cli/src/lib/secrets/bundles.ts:945`: `assignResolvedEnvValue(env, bundle, key, parsed.literal, _opts.keyMode, owners);`
- `apps/cli/src/lib/secrets/bundles.ts:957`: `assignResolvedEnvValue(env, bundle, key, value, _opts.keyMode, owners);`
- `apps/cli/src/lib/secrets/bundles.ts:1204`: `assignResolvedEnvValue(env, bundle, key, p.literal, opts.keyMode, owners);`
- `apps/cli/src/lib/secrets/bundles.ts:1219`: `assignResolvedEnvValue(env, bundle, key, value, opts.keyMode, owners);`
- `apps/cli/src/lib/secrets/bundles.ts:1247`: `canCacheResolvedEnv(bundle, selectedKeys, opts.keyMode)`
- `apps/cli/src/lib/secrets/bundles.ts:1436`: `if (BUNDLE_KEY_PATTERN.test(key)) {`
- `apps/cli/src/commands/secrets.ts:1052`: `const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });`
- `apps/cli/src/commands/secrets.ts:1642`: `const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });`
- `apps/cli/src/commands/secrets.ts:1671`: `const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });`
- `apps/cli/src/commands/secrets.ts:1739`: `const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });`
- `apps/cli/src/commands/secrets.ts:1781`: `keyMode: 'process',`
- `apps/cli/src/commands/secrets.ts:1785`: `// Machine-readable form consumed by `remoteResolveEnv` over SSH.`
- `apps/cli/src/commands/secrets.ts:1786`: `// Single object of injected env KEY -> value; values verbatim.`
- `apps/cli/src/commands/secrets.ts:2046`: `const { bundle, env } = readAndResolveBundleEnv(name, { noAgent: true, caller: 'unlock', keyMode: 'storage' });`
- `apps/cli/src/commands/browser.ts:1560`: `const { env } = readAndResolveBundleEnv(parsed.bundle, { caller: 'browser type', keys: [parsed.key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });`
- `apps/cli/src/commands/ssh.ts:1032`: `const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents ssh', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });`
- `apps/cli/src/commands/ssh.ts:1033`: `const value = env[key];`
- `apps/cli/src/lib/secrets/mcp.ts:114`: `const { env } = readAndResolveBundleEnv(bundle, { caller: 'secrets-mcp', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });`
- `apps/cli/src/lib/secrets/icloud-import.ts:35`: `bundleKeyToEnvKey,`
- `apps/cli/src/lib/secrets/icloud-import.ts:192`: `const envKey = bundleKeyToEnvKey(key);`
- `apps/cli/src/lib/secrets/icloud-import.ts:193`: `return isLoaderOrInterpreterEnv(envKey) || isReservedEnvName(envKey);`
- `apps/cli/src/lib/secrets/icloud-import.ts:224`: `if (!BUNDLE_KEY_PATTERN.test(key)) continue;`
- `apps/cli/src/lib/secrets/__tests__/bundles.test.ts:39`: `it('validateEnvKey accepts env keys and one optional account suffix', () => {`
- `apps/cli/src/lib/secrets/__tests__/bundles.test.ts:97`: `it('parses account-suffixed keys', () => {`
- `apps/cli/src/lib/secrets/__tests__/bundles.test.ts:158`: `it('projects one selected account-suffixed key to the base env name', () => {`
- `apps/cli/src/lib/secrets/__tests__/bundles.test.ts:167`: `it('can preserve exact storage keys for direct lookups and backups', () => {`
- `apps/cli/src/lib/secrets/__tests__/bundles.test.ts:175`: `it('fails loudly when multiple selected keys project to the same env name', () => {`
- `apps/cli/src/lib/secrets/bundles.test.ts:78`: `it('does not return a same-size partial cached env for a different requested subset', () => {`
- `apps/cli/src/lib/secrets/bundles.test.ts:82`: `expect(out.env).toEqual({});`
- `apps/cli/src/lib/secrets/bundles.test.ts:85`: `it('projects a selected account-suffixed key from the cached snapshot', () => {`
- `apps/cli/src/lib/secrets/bundles.test.ts:94`: `it('preserves exact account-suffixed keys when storage mode is requested', () => {`
- `apps/cli/src/lib/secrets/bundles.test.ts:103`: `it('fails loudly when cached account variants collide in process env mode', () => {`
- `apps/cli/src/lib/secrets/bundles.test.ts:162`: `it('does not cache partial storage reads because the broker expects a full bundle env', () => {`
- `apps/cli/src/lib/secrets/__tests__/bundles-file-backend.test.ts:111`: `it('round-trips account-suffixed keys and injects a selected variant as the base env name', () => {`
- `apps/cli/src/lib/secrets/__tests__/bundles-file-backend.test.ts:130`: `it('rejects injecting multiple account variants that target the same env key', () => {`
- `apps/cli/src/lib/secrets/icloud-import.test.ts:261`: `it('reserved account-suffixed keys are reported unimportable without aborting the bundle', () => {`
- `apps/cli/src/lib/secrets/icloud-import.test.ts:278`: `expect(result.unimportable.sort()).toEqual(['NODE_OPTIONS.work', 'PATH.personal']);`
- `apps/cli/src/commands/secrets.test.ts:194`: `it('prints injected process env keys for account-suffixed bundle keys', () => {`
- `apps/cli/src/commands/secrets.test.ts:208`: `expect(JSON.parse(exported.stdout)).toEqual({ GITHUB_USERNAME: 'workbot' });`
- `apps/cli/src/commands/ssh.test.ts:53`: `describe('ssh askpass', () => {`
- `apps/cli/src/commands/ssh.test.ts:64`: `AGENTS_SSH_KEY: 'password.work',`
- `apps/cli/src/commands/ssh.test.ts:68`: `expect(askpass.stdout).toBe('secret-pass');`
- `apps/cli/docs/secrets.md:144`: `` `src/commands/exec.ts`. The machine-readable wire format is``
- `apps/cli/docs/secrets.md:263`: `GITHUB_USERNAME.personal: { value: "muqsit" } # account-suffixed variant; injects as GITHUB_USERNAME when selected`
- `apps/cli/docs/secrets.md:384`: `Name the bundle after the domain and suffix each base key with the account handle — one bundle per site, any number of accounts inside. Per-key `--note` records when to use each account; `view` prints notes in the clear while values stay masked, so an agent can pick the right account without revealing anything:`
- `apps/cli/docs/secrets.md:401`: `agents secrets exec x.com --keys X_USERNAME.work,X_PASSWORD.work -- ./login-helper`
- `apps/cli/.changelog/next/RUSH-668.md:1`: `- **Support multiple accounts per secrets bundle (RUSH-668).** Secrets bundle keys now accept `BASE.account` names such as `GITHUB_USERNAME.personal`; selected account variants inject as the base env key and conflicting variants fail loud unless narrowed with `--keys`. Source: `apps/cli/src/lib/secrets/bundles.ts`, `apps/cli/docs/secrets.md`.`

## Verification
- `bun install` in `apps/cli`: `201 packages installed [37.93s]`
- Focused tests after configured-reviewer fixes: `Test Files 9 passed (9)` / `Tests 171 passed (171)`
- `bunx tsc --noEmit`: exit 0
- `bun run test` with isolated `/dev/shm` home/tmp after configured-reviewer fixes: `Test Files 477 passed | 5 skipped (482)` / `Tests 6252 passed | 87 skipped (6339)`
- `bun run build`: exit 0
- Built CLI e2e selected account: `selected=muqsit`
- Built CLI e2e exact key lookup: `get-work=workbot`
- Built CLI e2e JSON export: `{"GITHUB_USERNAME":"workbot"}`
- Built CLI e2e SSH askpass: `askpass=secret-pass`
- Built CLI e2e collision: `collision-status=1 Bundle 'github.com' maps multiple keys to 'GITHUB_USERNAME': GITHUB_USERNAME.personal, GITHUB_USERNAME.work. Select one account variant with --keys.`
