### PR TITLE
Fix repo refresh plugin skill shadows

### DIFF
--- a/apps/cli/.changelog/next/rush-1639-plugin-skill-refresh.md
+++ b/apps/cli/.changelog/next/rush-1639-plugin-skill-refresh.md
@@ -1,0 +1,1 @@
+- **Fix `agents repo refresh` for stale plugin skill shadows.** Full refresh now forces a materialization pass, copies trusted plugin-bundled skills into legacy top-level agent-home skill dirs when those names already matter to the agent, and prunes orphaned top-level skill dirs whose source no longer exists.

--- a/apps/cli/docs/02-resource-sync.md
+++ b/apps/cli/docs/02-resource-sync.md
@@ -267,6 +267,12 @@ Behavior rules, per `src/lib/plugins.ts:379` and `src/lib/plugin-marketplace.ts`
    `.user-config.json` so each version sees its resolved values. `${CLAUDE_PLUGIN_ROOT}`
    and `${CLAUDE_PLUGIN_DATA}` are left for Claude to expand at runtime.
 
+   Full refresh also treats trusted plugin `skills/<name>/` directories as
+   authoritative sources for top-level materialized skill homes. That reconciles
+   older homes that still have a legacy `.<agent>/skills/<name>/` copy of a
+   plugin-only skill, and prunes stale top-level skill dirs whose source no
+   longer exists.
+
 3. **Synthetic marketplace per version.** `syncMarketplaceManifest()` writes a
    `marketplace.json` listing every discovered plugin, and
    `registerMarketplace()` adds `agents-cli` to `known_marketplaces.json` so

--- a/apps/cli/src/lib/refresh.ts
+++ b/apps/cli/src/lib/refresh.ts
@@ -202,14 +202,10 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
 
     try {
       let selection: ResourceSelection | undefined;
+      let forceFullSync = false;
 
       if (skipPrompts) {
-        if (!hasAnySynced || hasNewResources(newResources, agentId)) {
-          selection = {
-            commands: 'all', skills: 'all', hooks: 'all', memory: 'all',
-            mcp: 'all', permissions: 'all', subagents: 'all', plugins: 'all',
-          };
-        }
+        forceFullSync = true;
       } else if (!hasAnySynced) {
         console.log(chalk.yellow(`\n${agentLabel(agentId)}@${defaultVer} has no synced resources.`));
         const userSelection = await promptResourceSelection(agentId);
@@ -218,10 +214,17 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
         console.log(chalk.cyan(`\n${agentLabel(agentId)}@${defaultVer}:`));
         const userSelection = await promptNewResourceSelection(agentId, newResources, defaultVer);
         if (userSelection) selection = userSelection;
+      } else {
+        forceFullSync = true;
       }
 
-      if (selection && Object.keys(selection).length > 0) {
-        const syncResult = syncResourcesToVersion(agentId, defaultVer, selection);
+      if (forceFullSync || (selection && Object.keys(selection).length > 0)) {
+        const syncResult = syncResourcesToVersion(
+          agentId,
+          defaultVer,
+          selection,
+          forceFullSync ? { force: true } : undefined,
+        );
         const synced: string[] = [];
         if (syncResult.commands) synced.push('commands');
         if (syncResult.skills) synced.push('skills');

--- a/apps/cli/src/lib/staleness/writers/skills.ts
+++ b/apps/cli/src/lib/staleness/writers/skills.ts
@@ -56,7 +56,7 @@ function buildSkillsWriter(agent: AgentId): ResourceWriter<string[]> {
 
       const synced: string[] = [];
       for (const skill of selection) {
-        const srcDir = resolveSkillSource(skill);
+        const srcDir = resolveSkillSource(skill, { agent });
         if (!srcDir) continue;
         const destDir = safeJoin(skillsTarget, skill);
         removePath(destDir);

--- a/apps/cli/src/lib/staleness/writers/sources.ts
+++ b/apps/cli/src/lib/staleness/writers/sources.ts
@@ -9,6 +9,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import type { AgentId, PluginManifest } from '../../types.js';
 import { getUserAgentsDir, getAgentsDir, getEnabledExtraRepos, getCommandsDir, getSkillsDir, getHooksDir } from '../../state.js';
 import { safeJoin } from '../../paths.js';
 
@@ -39,6 +40,45 @@ function isLiveDir(p: string): boolean {
   }
 }
 
+function readPluginManifest(pluginRoot: string): PluginManifest | null {
+  const manifestPath = path.join(pluginRoot, '.claude-plugin', 'plugin.json');
+  if (!isLiveFile(manifestPath)) return null;
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as PluginManifest;
+    if (!manifest.name || !manifest.version) return null;
+    return manifest;
+  } catch {
+    return null;
+  }
+}
+
+function pluginSupportsAgent(manifest: PluginManifest, agent?: AgentId): boolean {
+  if (!agent) return true;
+  return !manifest.agents || manifest.agents.length === 0 || manifest.agents.includes(agent);
+}
+
+function pluginSkillDirs(options: { agent?: AgentId; plugins?: Set<string> } = {}): string[] {
+  const dirs: string[] = [];
+  for (const base of trustedSourceBases()) {
+    const pluginsDir = path.join(base.dir, 'plugins');
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      if (options.plugins && !options.plugins.has(entry.name)) continue;
+      const pluginRoot = path.join(pluginsDir, entry.name);
+      const manifest = readPluginManifest(pluginRoot);
+      if (!manifest || !pluginSupportsAgent(manifest, options.agent)) continue;
+      dirs.push(path.join(pluginRoot, 'skills'));
+    }
+  }
+  return dirs;
+}
+
 /** Find the trusted source for a command markdown by name. */
 export function resolveCommandSource(name: string): string | null {
   const candidates = [
@@ -50,13 +90,34 @@ export function resolveCommandSource(name: string): string | null {
 }
 
 /** Find the trusted source directory for a skill by name. */
-export function resolveSkillSource(name: string): string | null {
+export function resolveSkillSource(name: string, options: { agent?: AgentId; plugins?: Set<string> } = {}): string | null {
   const candidates = [
     safeJoin(path.join(getUserAgentsDir(), 'skills'), name),
     safeJoin(getSkillsDir(), name),
     ...getEnabledExtraRepos().map((e) => safeJoin(path.join(e.dir, 'skills'), name)),
+    ...pluginSkillDirs(options).map((skillsDir) => safeJoin(skillsDir, name)),
   ];
   return candidates.find(isLiveDir) ?? null;
+}
+
+/** List trusted plugin-bundled skill names, filtered to an optional plugin/agent scope. */
+export function listPluginSkillNames(options: { agent?: AgentId; plugins?: Set<string> } = {}): string[] {
+  const names = new Set<string>();
+  for (const skillsDir of pluginSkillDirs(options)) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      if (isLiveFile(path.join(skillsDir, entry.name, 'SKILL.md'))) {
+        names.add(entry.name);
+      }
+    }
+  }
+  return Array.from(names);
 }
 
 /** Find the trusted source file for a hook by name. */
@@ -75,5 +136,6 @@ export function trustedSkillRoots(): string[] {
     path.join(getUserAgentsDir(), 'skills'),
     getSkillsDir(),
     ...getEnabledExtraRepos().map((e) => path.join(e.dir, 'skills')),
+    ...pluginSkillDirs(),
   ];
 }

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -419,6 +419,58 @@ describe('version resource sync path handling', () => {
     expect(second.skills).toBe(false);
   });
 
+  it('force-refreshes plugin-only skills into top-level skill homes and prunes stale orphans', async () => {
+    const home = makeTempHome();
+    const pluginRoot = path.join(home, '.agents', 'plugins', 'agents');
+    const pluginSkillDir = path.join(pluginRoot, 'skills', 'routines');
+    const versionSkillRoot = path.join(home, '.agents', '.history', 'versions', 'claude', '2.0.65', 'home', '.claude', 'skills');
+
+    fs.mkdirSync(path.join(pluginRoot, '.claude-plugin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'agents', version: '1.0.0', description: 'Fixture plugin' }),
+      'utf-8'
+    );
+    fs.mkdirSync(pluginSkillDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginSkillDir, 'SKILL.md'), 'fresh continuous ticket drain recipe\n', 'utf-8');
+    fs.mkdirSync(path.join(versionSkillRoot, 'routines'), { recursive: true });
+    fs.writeFileSync(path.join(versionSkillRoot, 'routines', 'SKILL.md'), 'stale routines body\n', 'utf-8');
+    fs.mkdirSync(path.join(versionSkillRoot, 'old-shadow'), { recursive: true });
+    fs.writeFileSync(path.join(versionSkillRoot, 'old-shadow', 'SKILL.md'), 'orphaned body\n', 'utf-8');
+
+    const result = runVersionSync(
+      home,
+      "syncResourcesToVersion('claude', '2.0.65', undefined, { cwd: home, force: true })"
+    ) as { skills: boolean; plugins: string[] };
+
+    const refreshed = fs.readFileSync(path.join(versionSkillRoot, 'routines', 'SKILL.md'), 'utf-8');
+    const marketplaceSkill = path.join(
+      home,
+      '.agents',
+      '.history',
+      'versions',
+      'claude',
+      '2.0.65',
+      'home',
+      '.claude',
+      'plugins',
+      'marketplaces',
+      'agents-cli',
+      'plugins',
+      'agents',
+      'skills',
+      'routines',
+      'SKILL.md'
+    );
+
+    expect(result.skills).toBe(true);
+    expect(result.plugins).toEqual(['agents']);
+    expect(refreshed).toContain('fresh continuous ticket drain recipe');
+    expect(refreshed).not.toContain('stale routines body');
+    expect(fs.existsSync(path.join(versionSkillRoot, 'old-shadow'))).toBe(false);
+    expect(fs.existsSync(marketplaceSkill)).toBe(true);
+  });
+
   it('does not sync project MCP servers under the default user-only MCP policy', async () => {
     const home = makeTempHome();
     const project = path.join(home, 'repo');
@@ -1050,4 +1102,3 @@ describe('removeVersion — default reassignment when removing the pinned defaul
     expect(defaultAfter).toBe(null);
   });
 });
-

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -50,6 +50,7 @@ import { safeJoin } from './paths.js';
 import { installCommandSkillToVersion, listCommandSkillsInVersion, readSkillSourceCommandMarker, shouldInstallCommandAsSkill } from './command-skills.js';
 import { getWriter, getDetector } from './staleness/registry.js';
 import { syncMemoryToVersionHome } from './memory.js';
+import { listPluginSkillNames } from './staleness/writers/sources.js';
 
 /** Promisified exec for running shell commands. */
 const execAsync = promisify(exec);
@@ -281,6 +282,9 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
   // Plugins (directories with .claude-plugin/plugin.json)
   const allPlugins = discoverPlugins();
   result.plugins = allPlugins.map(p => p.name);
+  for (const name of listPluginSkillNames()) {
+    if (!skillNames.has(name)) result.skills.push(name);
+  }
 
   // Promptcuts — present if either layer exists. Reads merge user + system
   // with user precedence (see readMergedPromptcuts); writes always go to user.
@@ -2568,9 +2572,17 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   // ~/.agents/skills/ (Gemini) are not registered; we clear the version-home
   // skills dir for them so a stale per-version copy never shadows central.
   const skillsWriter = getWriter('skills', agent);
-  let skillsToSync = selection
+  const pluginsWriter = getWriter('plugins', agent);
+  const pluginsToSync = selection
+    ? resolveSelection(selection.plugins, available.plugins)
+    : (pluginsWriter ? available.plugins : []);
+  const pluginSkillsToSync = listPluginSkillNames({ agent, plugins: new Set(pluginsToSync) });
+  const selectedSkillsToSync = selection
     ? resolveSelection(selection.skills, available.skills)
     : available.skills;
+  let skillsToSync = userPassedSelection
+    ? selectedSkillsToSync
+    : Array.from(new Set([...selectedSkillsToSync, ...pluginSkillsToSync]));
   if (commandsAsSkills && commandsToSync.length > 0 && skillsToSync.length > 0) {
     const commandNames = new Set(commandsToSync);
     const skillRoots = [
@@ -2786,11 +2798,6 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   }
 
   // Sync plugins — dispatch through WRITERS.plugins.
-  const pluginsWriter = getWriter('plugins', agent);
-  const pluginsToSync = selection
-    ? resolveSelection(selection.plugins, available.plugins)
-    : (pluginsWriter ? available.plugins : []);
-
   if (pluginsToSync.length > 0 && pluginsWriter) {
     const r = pluginsWriter.write({ version, versionHome, selection: pluginsToSync, cwd });
     result.plugins.push(...r.synced);


### PR DESCRIPTION
## Summary
- Force `agents repo refresh` through a full materialization pass when prompts are skipped or no interactive selection is needed, so home-side stale files are reconciled instead of being skipped by the source staleness manifest.
- Treat trusted plugin-bundled `skills/<name>/` directories as authoritative skill sources for top-level agent-home skill copies, then keep the existing full-sync orphan sweep pruning stale top-level skill dirs.

## Evidence
- `apps/cli/src/lib/refresh.ts:207` `if (skipPrompts) {`
- `apps/cli/src/lib/refresh.ts:208` `forceFullSync = true;`
- `apps/cli/src/lib/refresh.ts:221` `if (forceFullSync || (selection && Object.keys(selection).length > 0)) {`
- `apps/cli/src/lib/refresh.ts:226` `forceFullSync ? { force: true } : undefined,`
- `apps/cli/src/lib/staleness/writers/sources.ts:60` `function pluginSkillDirs(options: { agent?: AgentId; plugins?: Set<string> } = {}): string[] {`
- `apps/cli/src/lib/staleness/writers/sources.ts:74` `const manifest = readPluginManifest(pluginRoot);`
- `apps/cli/src/lib/staleness/writers/sources.ts:75` `if (!manifest || !pluginSupportsAgent(manifest, options.agent)) continue;`
- `apps/cli/src/lib/staleness/writers/sources.ts:93` `export function resolveSkillSource(name: string, options: { agent?: AgentId; plugins?: Set<string> } = {}): string | null {`
- `apps/cli/src/lib/staleness/writers/sources.ts:98` `...pluginSkillDirs(options).map((skillsDir) => safeJoin(skillsDir, name)),`
- `apps/cli/src/lib/staleness/writers/sources.ts:104` `export function listPluginSkillNames(options: { agent?: AgentId; plugins?: Set<string> } = {}): string[] {`
- `apps/cli/src/lib/staleness/writers/skills.ts:59` `const srcDir = resolveSkillSource(skill, { agent });`
- `apps/cli/src/lib/versions.ts:285` `for (const name of listPluginSkillNames()) {`
- `apps/cli/src/lib/versions.ts:286` `if (!skillNames.has(name)) result.skills.push(name);`
- `apps/cli/src/lib/versions.ts:2579` `const pluginSkillsToSync = listPluginSkillNames({ agent, plugins: new Set(pluginsToSync) });`
- `apps/cli/src/lib/versions.ts:2583` `let skillsToSync = userPassedSelection`
- `apps/cli/src/lib/versions.ts:2585` `: Array.from(new Set([...selectedSkillsToSync, ...pluginSkillsToSync]));`
- `apps/cli/src/lib/versions.test.ts:422` `it('force-refreshes plugin-only skills into top-level skill homes and prunes stale orphans', async () => {`
- `apps/cli/src/lib/versions.test.ts:435` `fs.writeFileSync(path.join(pluginSkillDir, 'SKILL.md'), 'fresh continuous ticket drain recipe\n', 'utf-8');`
- `apps/cli/src/lib/versions.test.ts:437` `fs.writeFileSync(path.join(versionSkillRoot, 'routines', 'SKILL.md'), 'stale routines body\n', 'utf-8');`
- `apps/cli/src/lib/versions.test.ts:468` `expect(refreshed).toContain('fresh continuous ticket drain recipe');`
- `apps/cli/src/lib/versions.test.ts:469` `expect(refreshed).not.toContain('stale routines body');`
- `apps/cli/src/lib/versions.test.ts:470` `expect(fs.existsSync(path.join(versionSkillRoot, 'old-shadow'))).toBe(false);`
- `apps/cli/docs/02-resource-sync.md:270` `Full refresh also treats trusted plugin `skills/<name>/` directories as`
- `apps/cli/.changelog/next/rush-1639-plugin-skill-refresh.md:1` `- **Fix `agents repo refresh` for stale plugin skill shadows.** Full refresh now forces a materialization pass, copies trusted plugin-bundled skills into legacy top-level agent-home skill dirs when those names already matter to the agent, and prunes orphaned top-level skill dirs whose source no longer exists.`

## Verification
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp XDG_RUNTIME_DIR=/tmp/agents-cli-bun-runtime BUN_INSTALL_CACHE_DIR=/tmp/agents-cli-bun-cache bun install` passed; postinstall ran `bun run build` successfully.
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp XDG_RUNTIME_DIR=/tmp/agents-cli-bun-runtime BUN_INSTALL_CACHE_DIR=/tmp/agents-cli-bun-cache bun run test src/lib/versions.test.ts` passed: 1 file, 48 tests.
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp XDG_RUNTIME_DIR=/tmp/agents-cli-bun-runtime BUN_INSTALL_CACHE_DIR=/tmp/agents-cli-bun-cache bunx tsc --noEmit` passed.
- `bun run test` did not pass in this sandbox. First run failed with many `EROFS: read-only file system` writes under `/home/muqsit/.agents/...`; isolated retry avoided that but still hit host/tooling-sensitive failures, including tmux lifecycle failures and Node 24 ESM fake-binary failures (`ReferenceError: require is not defined in ES module scope`). CI should provide the authoritative full-suite result in its normal environment.