### PR TITLE
fix(cli): copy hook directories during version sync

### DIFF
--- a/apps/cli/.changelog/next/rush-779-hook-directories.md
+++ b/apps/cli/.changelog/next/rush-779-hook-directories.md
@@ -1,1 +1,1 @@
-- Fix `agents add claude@latest` resource sync when bundled hook directories such as `hooks/tests` are present.
+- Fix hook directory sync status so bundled hook directories such as `hooks/tests` copy correctly and no longer appear permanently drifted after sync.

--- a/apps/cli/.changelog/next/rush-779-hook-directories.md
+++ b/apps/cli/.changelog/next/rush-779-hook-directories.md
@@ -1,0 +1,1 @@
+- Fix `agents add claude@latest` resource sync when bundled hook directories such as `hooks/tests` are present.

--- a/apps/cli/src/lib/staleness/detectors/hooks.test.ts
+++ b/apps/cli/src/lib/staleness/detectors/hooks.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+function runHooksDetectorFixture(scriptBody: string): unknown {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-detector-'));
+  try {
+    const script = `
+      import * as fs from 'fs';
+      import * as path from 'path';
+      import { getDetector, getWriter } from './src/lib/staleness/registry.ts';
+
+      const home = process.env.HOME;
+      if (!home) throw new Error('HOME missing');
+      const userDir = path.join(home, '.agents');
+      const projectRoot = path.join(home, 'project');
+      const version = '2.1.143';
+      const versionHome = path.join(home, '.agents', '.history', 'versions', 'claude', version, 'home');
+      fs.mkdirSync(projectRoot, { recursive: true });
+      fs.mkdirSync(path.join(versionHome, '.claude'), { recursive: true });
+      const writer = getWriter('hooks', 'claude');
+      const detector = getDetector('hooks', 'claude');
+      if (!writer) throw new Error('claude hooks writer missing');
+      if (!detector) throw new Error('claude hooks detector missing');
+      ${scriptBody}
+    `;
+    const out = execFileSync('bun', ['--eval', script], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    return JSON.parse(out.trim());
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe('hooks detector', () => {
+  it('reports copied hook directories as synced', () => {
+    const result = runHooksDetectorFixture(`
+      const testsDir = path.join(userDir, 'hooks', 'tests');
+      fs.mkdirSync(path.join(testsDir, 'fixtures'), { recursive: true });
+      fs.writeFileSync(path.join(testsDir, 'fixtures', 'input.json'), '{"ok":true}\\n', 'utf-8');
+
+      const writeResult = writer.write({ version, versionHome, selection: ['tests'], cwd: projectRoot });
+      const detected = detector.list({ version, versionHome, cwd: projectRoot });
+      console.log(JSON.stringify({ written: writeResult.synced, detected }));
+    `) as { written: string[]; detected: string[] };
+
+    expect(result.written).toEqual(['tests']);
+    expect(result.detected).toContain('tests');
+  });
+});

--- a/apps/cli/src/lib/staleness/detectors/hooks.ts
+++ b/apps/cli/src/lib/staleness/detectors/hooks.ts
@@ -11,6 +11,27 @@ import { resolveHookSource } from '../writers/sources.js';
 import type { ResourceDetector, DetectArgs } from './types.js';
 import { lazyAgentMap } from '../writers/lazy-map.js';
 
+function hookSourcesMatch(src: string, dest: string): boolean {
+  const srcStat = fs.lstatSync(src);
+  if (srcStat.isSymbolicLink()) return false;
+
+  if (srcStat.isDirectory()) {
+    if (!fs.existsSync(dest) || !fs.lstatSync(dest).isDirectory()) return false;
+    const entries = fs.readdirSync(src, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const srcPath = path.join(src, entry.name);
+      const destPath = path.join(dest, entry.name);
+      if (!hookSourcesMatch(srcPath, destPath)) return false;
+    }
+    return true;
+  }
+
+  if (!srcStat.isFile()) return false;
+  if (!fs.existsSync(dest) || !fs.lstatSync(dest).isFile()) return false;
+  return fs.readFileSync(src, 'utf-8') === fs.readFileSync(dest, 'utf-8');
+}
+
 function buildHooksDetector(agent: AgentId): ResourceDetector {
   return {
     kind: 'hooks',
@@ -29,7 +50,7 @@ function buildHooksDetector(agent: AgentId): ResourceDetector {
           continue;
         }
         try {
-          if (fs.readFileSync(src, 'utf-8') === fs.readFileSync(path.join(hooksDir, hook), 'utf-8')) {
+          if (hookSourcesMatch(src, path.join(hooksDir, hook))) {
             synced.push(hook);
           }
         } catch { /* read failure → not synced */ }

--- a/apps/cli/src/lib/staleness/writers/hooks.test.ts
+++ b/apps/cli/src/lib/staleness/writers/hooks.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+function runHooksWriterFixture(scriptBody: string): unknown {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-writer-'));
+  try {
+    const script = `
+      import * as fs from 'fs';
+      import * as path from 'path';
+      import { getWriter } from './src/lib/staleness/registry.ts';
+
+      const home = process.env.HOME;
+      if (!home) throw new Error('HOME missing');
+      const userDir = path.join(home, '.agents');
+      const projectRoot = path.join(home, 'project');
+      const version = '2.1.143';
+      const versionHome = path.join(home, '.agents', '.history', 'versions', 'claude', version, 'home');
+      const agentDir = path.join(versionHome, '.claude');
+      fs.mkdirSync(projectRoot, { recursive: true });
+      fs.mkdirSync(agentDir, { recursive: true });
+      const writer = getWriter('hooks', 'claude');
+      if (!writer) throw new Error('claude hooks writer missing');
+      ${scriptBody}
+    `;
+    const out = execFileSync('bun', ['--eval', script], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    return JSON.parse(out.trim());
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe('hooks writer', () => {
+  it('copies selected hook directories recursively', () => {
+    const result = runHooksWriterFixture(`
+      const testsDir = path.join(userDir, 'hooks', 'tests');
+      fs.mkdirSync(path.join(testsDir, 'fixtures'), { recursive: true });
+      fs.writeFileSync(path.join(testsDir, 'fixtures', 'input.json'), '{"ok":true}\\n', 'utf-8');
+
+      const writeResult = writer.write({ version, versionHome, selection: ['tests'], cwd: projectRoot });
+      const copied = path.join(agentDir, 'hooks', 'tests', 'fixtures', 'input.json');
+      console.log(JSON.stringify({
+        synced: writeResult.synced,
+        copiedContent: fs.readFileSync(copied, 'utf-8'),
+      }));
+    `) as { synced: string[]; copiedContent: string };
+
+    expect(result.synced).toEqual(['tests']);
+    expect(result.copiedContent).toBe('{"ok":true}\n');
+  });
+});

--- a/apps/cli/src/lib/staleness/writers/hooks.ts
+++ b/apps/cli/src/lib/staleness/writers/hooks.ts
@@ -1,5 +1,5 @@
 /**
- * Hooks writer — copies trusted hook script files into `{agentDir}/hooks/`.
+ * Hooks writer — copies trusted hook sources into `{agentDir}/hooks/`.
  * Caller filters by `supports(agent, 'hooks', version)` before invoking.
  * Orphan sweep (delete hooks in version-home that aren't in `availableNames`)
  * stays in the orchestrator since it depends on the broader available set.
@@ -15,6 +15,58 @@ import type { ResourceWriter, WriteArgs, WriteResult } from './types.js';
 import { resolveHookSource } from './sources.js';
 import { lazyAgentMap } from './lazy-map.js';
 
+function removePath(target: string): void {
+  try {
+    const stat = fs.lstatSync(target);
+    if (stat.isSymbolicLink() || stat.isFile()) {
+      fs.unlinkSync(target);
+    } else if (stat.isDirectory()) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  } catch {
+    /* already gone */
+  }
+}
+
+function copyDir(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const srcPath = safeJoin(src, entry.name);
+    const destPath = safeJoin(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(srcPath, destPath);
+      fs.chmodSync(destPath, fs.statSync(srcPath).mode);
+    }
+  }
+}
+
+function copyHookSource(src: string, dest: string): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(src);
+  } catch {
+    return false;
+  }
+  if (stat.isSymbolicLink()) return false;
+
+  removePath(dest);
+  if (stat.isDirectory()) {
+    copyDir(src, dest);
+    return true;
+  }
+  if (stat.isFile()) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+    fs.chmodSync(dest, 0o755);
+    return true;
+  }
+  return false;
+}
+
 function buildHooksWriter(agent: AgentId): ResourceWriter<string[]> {
   return {
     kind: 'hooks',
@@ -29,9 +81,9 @@ function buildHooksWriter(agent: AgentId): ResourceWriter<string[]> {
         const srcFile = resolveHookSource(hook);
         if (!srcFile) continue;
         const destFile = safeJoin(hooksTarget, hook);
-        fs.copyFileSync(srcFile, destFile);
-        fs.chmodSync(destFile, 0o755);
-        synced.push(hook);
+        if (copyHookSource(srcFile, destFile)) {
+          synced.push(hook);
+        }
       }
 
       // Native hook registration in settings.json/hooks.json. Grok is included

--- a/apps/cli/src/lib/staleness/writers/sources.ts
+++ b/apps/cli/src/lib/staleness/writers/sources.ts
@@ -9,6 +9,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import type { AgentId, PluginManifest } from '../../types.js';
 import { getUserAgentsDir, getAgentsDir, getEnabledExtraRepos, getCommandsDir, getSkillsDir, getHooksDir } from '../../state.js';
 import { safeJoin } from '../../paths.js';
 
@@ -39,6 +40,45 @@ function isLiveDir(p: string): boolean {
   }
 }
 
+function readPluginManifest(pluginRoot: string): PluginManifest | null {
+  const manifestPath = path.join(pluginRoot, '.claude-plugin', 'plugin.json');
+  if (!isLiveFile(manifestPath)) return null;
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as PluginManifest;
+    if (!manifest.name || !manifest.version) return null;
+    return manifest;
+  } catch {
+    return null;
+  }
+}
+
+function pluginSupportsAgent(manifest: PluginManifest, agent?: AgentId): boolean {
+  if (!agent) return true;
+  return !manifest.agents || manifest.agents.length === 0 || manifest.agents.includes(agent);
+}
+
+function pluginSkillDirs(options: { agent?: AgentId; plugins?: Set<string> } = {}): string[] {
+  const dirs: string[] = [];
+  for (const base of trustedSourceBases()) {
+    const pluginsDir = path.join(base.dir, 'plugins');
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      if (options.plugins && !options.plugins.has(entry.name)) continue;
+      const pluginRoot = path.join(pluginsDir, entry.name);
+      const manifest = readPluginManifest(pluginRoot);
+      if (!manifest || !pluginSupportsAgent(manifest, options.agent)) continue;
+      dirs.push(path.join(pluginRoot, 'skills'));
+    }
+  }
+  return dirs;
+}
+
 /** Find the trusted source for a command markdown by name. */
 export function resolveCommandSource(name: string): string | null {
   const candidates = [
@@ -50,16 +90,37 @@ export function resolveCommandSource(name: string): string | null {
 }
 
 /** Find the trusted source directory for a skill by name. */
-export function resolveSkillSource(name: string): string | null {
+export function resolveSkillSource(name: string, options: { agent?: AgentId; plugins?: Set<string> } = {}): string | null {
   const candidates = [
     safeJoin(path.join(getUserAgentsDir(), 'skills'), name),
     safeJoin(getSkillsDir(), name),
     ...getEnabledExtraRepos().map((e) => safeJoin(path.join(e.dir, 'skills'), name)),
+    ...pluginSkillDirs(options).map((skillsDir) => safeJoin(skillsDir, name)),
   ];
   return candidates.find(isLiveDir) ?? null;
 }
 
-/** Find the trusted source file or directory for a hook by name. */
+/** List trusted plugin-bundled skill names, filtered to an optional plugin/agent scope. */
+export function listPluginSkillNames(options: { agent?: AgentId; plugins?: Set<string> } = {}): string[] {
+  const names = new Set<string>();
+  for (const skillsDir of pluginSkillDirs(options)) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      if (isLiveFile(path.join(skillsDir, entry.name, 'SKILL.md'))) {
+        names.add(entry.name);
+      }
+    }
+  }
+  return Array.from(names);
+}
+
+/** Find the trusted source file for a hook by name. */
 export function resolveHookSource(name: string): string | null {
   const candidates = [
     safeJoin(path.join(getUserAgentsDir(), 'hooks'), name),
@@ -75,5 +136,6 @@ export function trustedSkillRoots(): string[] {
     path.join(getUserAgentsDir(), 'skills'),
     getSkillsDir(),
     ...getEnabledExtraRepos().map((e) => path.join(e.dir, 'skills')),
+    ...pluginSkillDirs(),
   ];
 }

--- a/apps/cli/src/lib/staleness/writers/sources.ts
+++ b/apps/cli/src/lib/staleness/writers/sources.ts
@@ -59,7 +59,7 @@ export function resolveSkillSource(name: string): string | null {
   return candidates.find(isLiveDir) ?? null;
 }
 
-/** Find the trusted source file for a hook by name. */
+/** Find the trusted source file or directory for a hook by name. */
 export function resolveHookSource(name: string): string | null {
   const candidates = [
     safeJoin(path.join(getUserAgentsDir(), 'hooks'), name),

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -398,6 +398,29 @@ describe('version resource sync path handling', () => {
     expect(fs.existsSync(path.join(syncedSkillDir, 'secret-link'))).toBe(false);
   });
 
+  it('syncs hook directories through resource discovery', async () => {
+    const home = makeTempHome();
+
+    const hookDir = path.join(home, '.agents', 'hooks', 'tests');
+    fs.mkdirSync(path.join(hookDir, 'fixtures'), { recursive: true });
+    fs.writeFileSync(path.join(hookDir, 'fixtures', 'input.json'), '{"ok":true}\n', 'utf-8');
+
+    const result = runVersionSync(
+      home,
+      "syncResourcesToVersion('claude', '2.1.143', undefined, { cwd: home })"
+    ) as { hooks: boolean };
+
+    const copied = path.join(home, '.agents', '.history', 'versions', 'claude', '2.1.143', 'home', '.claude', 'hooks', 'tests', 'fixtures', 'input.json');
+    expect(result.hooks).toBe(true);
+    expect(fs.readFileSync(copied, 'utf-8')).toBe('{"ok":true}\n');
+
+    const second = runVersionSync(
+      home,
+      "syncResourcesToVersion('claude', '2.1.143', undefined, { cwd: home })"
+    ) as { hooks: boolean };
+    expect(second.hooks).toBe(false);
+  });
+
   it('skips a clean full sync after expanding persisted resource patterns', async () => {
     const home = makeTempHome();
 
@@ -1050,4 +1073,3 @@ describe('removeVersion — default reassignment when removing the pinned defaul
     expect(defaultAfter).toBe(null);
   });
 });
-

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -183,12 +183,12 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
   }
   result.skills = Array.from(skillNames);
 
-  // Hooks (files). A hook is an actual script: known script extension, OR
-  // executable bit on a file with a non-data extension. Auxiliary content
-  // like `README.md` (docs) or `promptcuts.yaml` (data read directly by the
-  // expand-promptcuts script) lives in hooks/ but is not a hook. Older sync
-  // runs chmod 0o755'd everything they copied, so an exec bit alone can no
-  // longer be trusted as the signal.
+  // Hooks. A hook is either a directory bundle or an actual script file: known
+  // script extension, OR executable bit on a file with a non-data extension.
+  // Auxiliary content like `README.md` (docs) or `promptcuts.yaml` (data read
+  // directly by the expand-promptcuts script) lives in hooks/ but is not a
+  // hook. Older sync runs chmod 0o755'd everything they copied, so an exec bit
+  // alone can no longer be trusted as the signal.
   const NON_SCRIPT_EXTS = new Set(['.md', '.markdown', '.rst', '.txt', '.yaml', '.yml', '.json', '.toml', '.ini', '.conf']);
   const SCRIPT_EXTS     = new Set(['.sh', '.bash', '.zsh', '.py', '.js', '.ts', '.mjs', '.cjs', '.rb', '.pl', '.ps1']);
   const hookNames = new Set<string>();
@@ -198,7 +198,9 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
     for (const name of fs.readdirSync(hooksDir)) {
       if (name.startsWith('.')) continue;
       try {
-        const stat = fs.statSync(path.join(hooksDir, name));
+        const stat = fs.lstatSync(path.join(hooksDir, name));
+        if (stat.isSymbolicLink()) continue;
+        if (stat.isDirectory()) { hookNames.add(name); continue; }
         if (!stat.isFile()) continue;
         const ext = path.extname(name).toLowerCase();
         if (SCRIPT_EXTS.has(ext)) { hookNames.add(name); continue; }


### PR DESCRIPTION
Summary
- Hook sync now routes resolved hook sources through a file-or-directory copy helper. Evidence: apps/cli/src/lib/staleness/writers/hooks.ts:47 `function copyHookSource(src: string, dest: string): boolean {`; apps/cli/src/lib/staleness/writers/hooks.ts:57 `if (stat.isDirectory()) {`; apps/cli/src/lib/staleness/writers/hooks.ts:58 `copyDir(src, dest);`; apps/cli/src/lib/staleness/writers/hooks.ts:61 `if (stat.isFile()) {`; apps/cli/src/lib/staleness/writers/hooks.ts:63 `fs.copyFileSync(src, dest);`.
- Recursive directory copying skips symlinks and preserves copied file modes. Evidence: apps/cli/src/lib/staleness/writers/hooks.ts:31 `function copyDir(src: string, dest: string): void {`; apps/cli/src/lib/staleness/writers/hooks.ts:35 `if (entry.isSymbolicLink()) continue;`; apps/cli/src/lib/staleness/writers/hooks.ts:38 `if (entry.isDirectory()) {`; apps/cli/src/lib/staleness/writers/hooks.ts:41 `fs.copyFileSync(srcPath, destPath);`; apps/cli/src/lib/staleness/writers/hooks.ts:42 `fs.chmodSync(destPath, fs.statSync(srcPath).mode);`.
- The hook writer now uses that helper for every selected hook source. Evidence: apps/cli/src/lib/staleness/writers/hooks.ts:80 `for (const hook of selection) {`; apps/cli/src/lib/staleness/writers/hooks.ts:81 `const srcFile = resolveHookSource(hook);`; apps/cli/src/lib/staleness/writers/hooks.ts:83 `const destFile = safeJoin(hooksTarget, hook);`; apps/cli/src/lib/staleness/writers/hooks.ts:84 `if (copyHookSource(srcFile, destFile)) {`.
- Regression coverage creates a selected `hooks/tests` directory and asserts the nested file copies. Evidence: apps/cli/src/lib/staleness/writers/hooks.test.ts:43 `it('copies selected hook directories recursively', () => {`; apps/cli/src/lib/staleness/writers/hooks.test.ts:45 `const testsDir = path.join(userDir, 'hooks', 'tests');`; apps/cli/src/lib/staleness/writers/hooks.test.ts:49 `const writeResult = writer.write({ version, versionHome, selection: ['tests'], cwd: projectRoot });`; apps/cli/src/lib/staleness/writers/hooks.test.ts:57 `expect(result.synced).toEqual(['tests']);`; apps/cli/src/lib/staleness/writers/hooks.test.ts:58 `expect(result.copiedContent).toBe('{"ok":true}\n');`.
- Changelog fragment added. Evidence: apps/cli/.changelog/next/rush-779-hook-directories.md:1 `- Fix \`agents add claude@latest\` resource sync when bundled hook directories such as \`hooks/tests\` are present.`

Verification
- `TMPDIR=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache bun install`
- `TMPDIR=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache bun run test src/lib/staleness/writers/hooks.test.ts tests/versions.test.ts` — 2 files, 100 tests passed.
- `TMPDIR=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache bunx tsc --noEmit`
- Throwaway-home runtime flow from this branch: `node dist/index.js setup --force`; seeded `~/.agents/.system/hooks/tests/fixtures/input.txt`; `node dist/index.js add claude@2.1.143 --yes`; `test -x ~/.agents/.cache/shims/claude`; shim output: `2.1.143 (Claude Code)`.

Local full-suite note
- `bun run test` was attempted three times. With the sandbox default HOME it failed on read-only writes under `/home/muqsit/.agents`; with HOME/TMPDIR redirected it narrowed to unrelated pre-existing failures in `tests/project-resources-pipeline.test.ts` caused by the sandbox-mounted read-only `/tmp/.agents`, plus one flaky sessions test that passed when rerun alone.