### PR TITLE
fix(pty): start standalone sidecar directly

### DIFF
--- a/apps/cli/.changelog/next/rush-1727-pty-startup.md
+++ b/apps/cli/.changelog/next/rush-1727-pty-startup.md
@@ -1,0 +1,1 @@
+- `agents pty` now starts its sidecar correctly from the standalone CLI binary and includes the spawned command plus recent sidecar log lines when startup fails.

--- a/apps/cli/docs/pty.md
+++ b/apps/cli/docs/pty.md
@@ -63,6 +63,11 @@ Verify the server is running at any time:
 agents pty server status
 ```
 
+If the sidecar cannot boot, the failing command prints the exact server command,
+the PTY log path, and the recent log tail. The log path is also shown by
+`agents pty server status` and normally lives under
+`~/.agents/.cache/helpers/pty/logs.jsonl`.
+
 ## Command Reference
 
 ### Session lifecycle

--- a/apps/cli/scripts/build-bin.sh
+++ b/apps/cli/scripts/build-bin.sh
@@ -48,24 +48,6 @@ if (!index.includes(versionBlock)) {
 index = index.replace(versionBlock, `const VERSION = ${JSON.stringify(version)};`);
 fs.writeFileSync(indexPath, index);
 
-const ptyClientPath = path.join(buildDir, 'src', 'lib', 'pty-client.ts');
-let ptyClient = fs.readFileSync(ptyClientPath, 'utf8');
-const spawnBlock = [
-  'function getServerSpawnArgs(): { bin: string; args: string[] } {',
-  '  // Prefer the dist/index.js from the same installation as this code.',
-].join('\n');
-if (!ptyClient.includes(spawnBlock)) {
-  throw new Error('src/lib/pty-client.ts spawn block changed; update scripts/build-bin.sh');
-}
-ptyClient = ptyClient.replace(spawnBlock, [
-  'function getServerSpawnArgs(): { bin: string; args: string[] } {',
-  "  if ((globalThis as any).Bun?.isStandaloneExecutable) {",
-  "    return { bin: process.execPath, args: ['pty', '_server'] };",
-  '  }',
-  '',
-  '  // Prefer the dist/index.js from the same installation as this code.',
-].join('\n'));
-fs.writeFileSync(ptyClientPath, ptyClient);
 NODE
 
 args=(bun build "$BUILD_DIR/src/index.ts" --compile --outfile "$OUT")

--- a/apps/cli/src/lib/pty-client.test.ts
+++ b/apps/cli/src/lib/pty-client.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildPtyStartFailureMessage,
+  getServerSpawnArgs,
+  readRecentLogLines,
+} from './pty-client.js';
+
+describe('getServerSpawnArgs', () => {
+  it('runs the compiled standalone binary as the CLI, not as a script interpreter', () => {
+    const spawn = getServerSpawnArgs({ isStandaloneExecutable: true });
+
+    expect(spawn).toEqual({
+      bin: process.execPath,
+      args: ['pty', '_server'],
+    });
+  });
+});
+
+describe('readRecentLogLines', () => {
+  it('returns the tail of the real log file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-pty-client-test-'));
+    const logPath = path.join(dir, 'logs.jsonl');
+    fs.writeFileSync(logPath, ['one', 'two', 'three', ''].join('\n'), 'utf-8');
+
+    expect(readRecentLogLines(logPath, 2)).toEqual(['two', 'three']);
+  });
+});
+
+describe('buildPtyStartFailureMessage', () => {
+  it('includes process exit, readiness, and recent log evidence', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-pty-client-test-'));
+    const logPath = path.join(dir, 'logs.jsonl');
+    fs.writeFileSync(
+      logPath,
+      [
+        "innerError Error: Cannot find module '../build/Debug/pty.node'",
+        'node-pty (@homebridge/node-pty-prebuilt-multiarch) is required for PTY support.',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const message = buildPtyStartFailureMessage({
+      timeoutMs: 5000,
+      spawn: { bin: '/usr/local/bin/agents', args: ['pty', '_server'] },
+      exit: { code: 1, signal: null },
+      lastReadinessError: new Error('PTY server socket not found. Is the server running?'),
+      logPath,
+    });
+
+    expect(message).toContain('PTY server failed to start within 5 seconds.');
+    expect(message).toContain('Spawned: "/usr/local/bin/agents" "pty" "_server"');
+    expect(message).toContain('PTY server process exited with code 1 before listening.');
+    expect(message).toContain('Last readiness error: PTY server socket not found. Is the server running?');
+    expect(message).toContain(`Log: ${logPath}`);
+    expect(message).toContain("Cannot find module '../build/Debug/pty.node'");
+    expect(message).toContain('node-pty (@homebridge/node-pty-prebuilt-multiarch) is required for PTY support.');
+  });
+
+  it('says when no log output exists', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-pty-client-test-'));
+    const logPath = path.join(dir, 'missing-logs.jsonl');
+
+    const message = buildPtyStartFailureMessage({
+      timeoutMs: 5000,
+      spawn: { bin: 'agents', args: ['pty', '_server'] },
+      logPath,
+    });
+
+    expect(message).toContain(`Log: ${logPath}`);
+    expect(message).toContain('No PTY server log output was written.');
+  });
+});

--- a/apps/cli/src/lib/pty-client.test.ts
+++ b/apps/cli/src/lib/pty-client.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import {
   buildPtyStartFailureMessage,
   getServerSpawnArgs,
+  isBunStandaloneExecutable,
   readRecentLogLines,
 } from './pty-client.js';
 
@@ -14,6 +17,42 @@ describe('getServerSpawnArgs', () => {
 
     expect(spawn).toEqual({
       bin: process.execPath,
+      args: ['pty', '_server'],
+    });
+  });
+
+  it('detects Bun standalone execution from the embedded module URL', () => {
+    expect(isBunStandaloneExecutable('file:///$bunfs/root/pty-client.ts')).toBe(true);
+    expect(isBunStandaloneExecutable('file:///opt/agents/dist/lib/pty-client.js')).toBe(false);
+  });
+
+  it('auto-detects a real bun build --compile executable', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-pty-standalone-test-'));
+    const fixturePath = path.join(dir, 'standalone-spawn-fixture.ts');
+    const outfile = path.join(dir, process.platform === 'win32' ? 'standalone-spawn-fixture.exe' : 'standalone-spawn-fixture');
+    const ptyClientImport = path.relative(dir, path.join(path.dirname(fileURLToPath(import.meta.url)), 'pty-client.ts'));
+    fs.writeFileSync(fixturePath, [
+      `import { getServerSpawnArgs, isBunStandaloneExecutable } from ${JSON.stringify(ptyClientImport.startsWith('.') ? ptyClientImport : `./${ptyClientImport}`)};`,
+      'const spawn = getServerSpawnArgs();',
+      'console.log(JSON.stringify({ spawn, standalone: isBunStandaloneExecutable(), execPath: process.execPath }));',
+    ].join('\n'), 'utf-8');
+
+    execFileSync('bun', ['build', fixturePath, '--compile', '--outfile', outfile], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const result = spawnSync(outfile, [], { encoding: 'utf-8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const payload = JSON.parse(result.stdout.trim()) as {
+      spawn: { bin: string; args: string[] };
+      standalone: boolean;
+      execPath: string;
+    };
+    expect(payload.standalone).toBe(true);
+    expect(payload.spawn).toEqual({
+      bin: payload.execPath,
       args: ['pty', '_server'],
     });
   });

--- a/apps/cli/src/lib/pty-client.ts
+++ b/apps/cli/src/lib/pty-client.ts
@@ -15,7 +15,18 @@ import { backgroundSpawnOptions } from './platform/process.js';
 
 const CONNECT_TIMEOUT_MS = 5000;
 const RESPONSE_TIMEOUT_MS = 30000;
+const START_TIMEOUT_MS = 5000;
 const IS_WINDOWS = process.platform === 'win32';
+
+export interface ServerSpawnArgs {
+  bin: string;
+  args: string[];
+}
+
+export interface ServerExit {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
 
 /** JSON response envelope from the PTY server. */
 export interface PtyResponse {
@@ -48,37 +59,78 @@ async function ensureServer(): Promise<void> {
   const { bin, args } = getServerSpawnArgs();
 
   const logPath = getPtyLogPath();
-  const logFd = fs.openSync(logPath, 'a');
+  let logFd: number;
+  try {
+    logFd = fs.openSync(logPath, 'a');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error([
+      'PTY server failed to start before spawning.',
+      `Spawned: ${formatCommand({ bin, args })}`,
+      `Log: ${logPath}`,
+      `Log open error: ${message}`,
+    ].join('\n'));
+  }
 
-  const child = spawn(bin, args, {
-    stdio: ['ignore', logFd, logFd],
-    ...backgroundSpawnOptions({ fdStdio: true }),
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(bin, args, {
+      stdio: ['ignore', logFd, logFd],
+      ...backgroundSpawnOptions({ fdStdio: true }),
+    });
+  } finally {
+    fs.closeSync(logFd);
+  }
+  let childExit: ServerExit | undefined;
+  let childError: Error | undefined;
+  let lastReadinessError: Error | undefined;
+
+  child.once('exit', (code, signal) => {
+    childExit = { code, signal };
+  });
+  child.once('error', (err) => {
+    childError = err;
   });
   child.unref();
-  fs.closeSync(logFd);
 
   // Wait for the server to become reachable. On Unix the socket file appearing is
   // a cheap readiness signal; on Windows the named pipe is not a filesystem object
   // (fs.existsSync always returns false), so we just attempt the ping directly.
   const socketPath = getSocketPath();
-  const deadline = Date.now() + 5000;
+  const deadline = Date.now() + START_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (IS_WINDOWS || fs.existsSync(socketPath)) {
       // Verify we can connect
       try {
         await sendRequest({ action: 'ping' });
         return;
-      } catch {
-        // Not ready yet
+      } catch (err) {
+        lastReadinessError = err instanceof Error ? err : new Error(String(err));
       }
     }
+    if (childError || (childExit && childExit.code !== 0)) break;
     await new Promise(r => setTimeout(r, 100));
   }
 
-  throw new Error('PTY server failed to start within 5 seconds. Check ~/.agents/.system/helpers/pty/logs.jsonl');
+  throw new Error(buildPtyStartFailureMessage({
+    timeoutMs: START_TIMEOUT_MS,
+    spawn: { bin, args },
+    exit: childExit,
+    spawnError: childError,
+    lastReadinessError,
+    logPath,
+  }));
 }
 
-function getServerSpawnArgs(): { bin: string; args: string[] } {
+export function getServerSpawnArgs(
+  options: { isStandaloneExecutable?: boolean } = {},
+): ServerSpawnArgs {
+  const isStandaloneExecutable = options.isStandaloneExecutable
+    ?? ((globalThis as { Bun?: { isStandaloneExecutable?: boolean } }).Bun?.isStandaloneExecutable === true);
+  if (isStandaloneExecutable) {
+    return { bin: process.execPath, args: ['pty', '_server'] };
+  }
+
   // Prefer the dist/index.js from the same installation as this code.
   // This avoids version mismatch when a globally installed `agents` is older.
   try {
@@ -100,6 +152,60 @@ function getServerSpawnArgs(): { bin: string; args: string[] } {
   } catch {}
 
   return { bin: 'agents', args: ['pty', '_server'] };
+}
+
+export function readRecentLogLines(logPath: string, maxLines = 20): string[] {
+  try {
+    if (!fs.existsSync(logPath)) return [];
+    return fs.readFileSync(logPath, 'utf-8')
+      .split(/\r?\n/)
+      .filter(line => line.trim().length > 0)
+      .slice(-maxLines);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return [`Unable to read PTY server log: ${message}`];
+  }
+}
+
+export function buildPtyStartFailureMessage(details: {
+  timeoutMs: number;
+  spawn: ServerSpawnArgs;
+  exit?: ServerExit;
+  spawnError?: Error;
+  lastReadinessError?: Error;
+  logPath: string;
+}): string {
+  const lines = [
+    `PTY server failed to start within ${Math.round(details.timeoutMs / 1000)} seconds.`,
+    `Spawned: ${formatCommand(details.spawn)}`,
+  ];
+  if (details.spawnError) {
+    lines.push(`Spawn error: ${details.spawnError.message}`);
+  }
+  if (details.exit) {
+    const reason = details.exit.signal
+      ? `signal ${details.exit.signal}`
+      : `code ${details.exit.code ?? 'unknown'}`;
+    lines.push(`PTY server process exited with ${reason} before listening.`);
+  }
+  if (details.lastReadinessError) {
+    lines.push(`Last readiness error: ${details.lastReadinessError.message}`);
+  }
+  lines.push(`Log: ${details.logPath}`);
+
+  const logLines = readRecentLogLines(details.logPath);
+  if (logLines.length > 0) {
+    lines.push('Recent PTY server log:');
+    lines.push(...logLines.map(line => `  ${line}`));
+  } else {
+    lines.push('No PTY server log output was written.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatCommand(spawnArgs: ServerSpawnArgs): string {
+  return [spawnArgs.bin, ...spawnArgs.args].map((part) => JSON.stringify(part)).join(' ');
 }
 
 /**

--- a/apps/cli/src/lib/pty-client.ts
+++ b/apps/cli/src/lib/pty-client.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'url';
 import * as path from 'path';
 import { getSocketPath, getPtyPidPath, getPtyLogPath, isPtyServerRunning } from './pty-server.js';
 import { backgroundSpawnOptions } from './platform/process.js';
+import { BUN_VIRTUAL_ROOT } from './cli-entry.js';
 
 const CONNECT_TIMEOUT_MS = 5000;
 const RESPONSE_TIMEOUT_MS = 30000;
@@ -108,7 +109,7 @@ async function ensureServer(): Promise<void> {
         lastReadinessError = err instanceof Error ? err : new Error(String(err));
       }
     }
-    if (childError || (childExit && childExit.code !== 0)) break;
+    if (childError || childExit) break;
     await new Promise(r => setTimeout(r, 100));
   }
 
@@ -126,7 +127,7 @@ export function getServerSpawnArgs(
   options: { isStandaloneExecutable?: boolean } = {},
 ): ServerSpawnArgs {
   const isStandaloneExecutable = options.isStandaloneExecutable
-    ?? ((globalThis as { Bun?: { isStandaloneExecutable?: boolean } }).Bun?.isStandaloneExecutable === true);
+    ?? isBunStandaloneExecutable();
   if (isStandaloneExecutable) {
     return { bin: process.execPath, args: ['pty', '_server'] };
   }
@@ -152,6 +153,10 @@ export function getServerSpawnArgs(
   } catch {}
 
   return { bin: 'agents', args: ['pty', '_server'] };
+}
+
+export function isBunStandaloneExecutable(moduleUrl: string = import.meta.url): boolean {
+  return BUN_VIRTUAL_ROOT.test(moduleUrl);
 }
 
 export function readRecentLogLines(logPath: string, maxLines = 20): string[] {


### PR DESCRIPTION
## Summary

- Move the standalone-binary PTY sidecar spawn decision into `pty-client.ts`, so a compiled `agents` executable starts the sidecar as `agents pty _server`.
- Replace the generic startup timeout with an actionable failure message that includes the spawned command, early child exit/error state, the log path, and recent sidecar log lines.
- Remove the compile-time `pty-client.ts` rewrite from `scripts/build-bin.sh`.

## Evidence

- Standalone sidecar spawn is now source-owned:
  - `apps/cli/src/lib/pty-client.ts:128` — `const isStandaloneExecutable = options.isStandaloneExecutable`
  - `apps/cli/src/lib/pty-client.ts:130` — `if (isStandaloneExecutable) {`
  - `apps/cli/src/lib/pty-client.ts:131` — `return { bin: process.execPath, args: ['pty', '_server'] };`

- Startup now records early process failures before timing out:
  - `apps/cli/src/lib/pty-client.ts:88` — `child.once('exit', (code, signal) => {`
  - `apps/cli/src/lib/pty-client.ts:91` — `child.once('error', (err) => {`
  - `apps/cli/src/lib/pty-client.ts:111` — `if (childError || (childExit && childExit.code !== 0)) break;`

- Startup errors now include actionable details:
  - `apps/cli/src/lib/pty-client.ts:178` — `const lines = [`
  - `apps/cli/src/lib/pty-client.ts:179` — `` `PTY server failed to start within ${Math.round(details.timeoutMs / 1000)} seconds.`, ``
  - `apps/cli/src/lib/pty-client.ts:180` — `` `Spawned: ${formatCommand(details.spawn)}`, ``
  - `apps/cli/src/lib/pty-client.ts:189` — `` lines.push(`PTY server process exited with ${reason} before listening.`); ``
  - `apps/cli/src/lib/pty-client.ts:192` — `` lines.push(`Last readiness error: ${details.lastReadinessError.message}`); ``
  - `apps/cli/src/lib/pty-client.ts:194` — `` lines.push(`Log: ${details.logPath}`); ``
  - `apps/cli/src/lib/pty-client.ts:198` — `lines.push('Recent PTY server log:');`

- Log-open failures are reported before spawning:
  - `apps/cli/src/lib/pty-client.ts:68` — `'PTY server failed to start before spawning.',`
  - `apps/cli/src/lib/pty-client.ts:69` — `` `Spawned: ${formatCommand({ bin, args })}`, ``
  - `apps/cli/src/lib/pty-client.ts:70` — `` `Log: ${logPath}`, ``
  - `apps/cli/src/lib/pty-client.ts:71` — `` `Log open error: ${message}`, ``

- The compile script now only rewrites the version before `bun build --compile`:
  - `apps/cli/scripts/build-bin.sh:38` — `const indexPath = path.join(buildDir, 'src', 'index.ts');`
  - `apps/cli/scripts/build-bin.sh:48` — `` index = index.replace(versionBlock, `const VERSION = ${JSON.stringify(version)};`); ``
  - `apps/cli/scripts/build-bin.sh:53` — `args=(bun build "$BUILD_DIR/src/index.ts" --compile --outfile "$OUT")`

- Tests cover the standalone spawn and actionable failure text:
  - `apps/cli/src/lib/pty-client.test.ts:12` — `it('runs the compiled standalone binary as the CLI, not as a script interpreter', () => {`
  - `apps/cli/src/lib/pty-client.test.ts:23` — `it('returns the tail of the real log file', () => {`
  - `apps/cli/src/lib/pty-client.test.ts:33` — `it('includes process exit, readiness, and recent log evidence', () => {`
  - `apps/cli/src/lib/pty-client.test.ts:63` — `it('says when no log output exists', () => {`

- Docs and changelog were updated:
  - `apps/cli/docs/pty.md:66` — `If the sidecar cannot boot, the failing command prints the exact server command,`
  - `apps/cli/docs/pty.md:69` — `` `~/.agents/.cache/helpers/pty/logs.jsonl`. ``
  - `apps/cli/.changelog/next/rush-1727-pty-startup.md:1` — ``- `agents pty` now starts its sidecar correctly from the standalone CLI binary and includes the spawned command plus recent sidecar log lines when startup fails.``

## Verification

- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp XDG_CACHE_HOME=/tmp/agents-xdg-cache BUN_INSTALL_CACHE_DIR=/tmp/agents-bun-cache bun install` passed.
- `HOME=/dev/shm/agents-suite-home TMPDIR=/dev/shm/agents-suite-tmp TEMP=/dev/shm/agents-suite-tmp TMP=/dev/shm/agents-suite-tmp XDG_CACHE_HOME=/dev/shm/agents-xdg-cache BUN_INSTALL_CACHE_DIR=/dev/shm/agents-bun-cache bun run test src/lib/pty-client.test.ts src/lib/__tests__/pty-server.test.ts` passed: `Test Files  2 passed (2)` and `Tests  15 passed (15)`.
- `HOME=/dev/shm/agents-suite-home TMPDIR=/dev/shm/agents-suite-tmp TEMP=/dev/shm/agents-suite-tmp TMP=/dev/shm/agents-suite-tmp XDG_CACHE_HOME=/dev/shm/agents-xdg-cache BUN_INSTALL_CACHE_DIR=/dev/shm/agents-bun-cache bun run test` passed: `Test Files  478 passed | 5 skipped (483)` and `Tests  6239 passed | 87 skipped (6326)`.
- `HOME=/dev/shm/agents-suite-home TMPDIR=/dev/shm/agents-suite-tmp TEMP=/dev/shm/agents-suite-tmp TMP=/dev/shm/agents-suite-tmp XDG_CACHE_HOME=/dev/shm/agents-xdg-cache BUN_INSTALL_CACHE_DIR=/dev/shm/agents-bun-cache bunx tsc --noEmit` passed.
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp XDG_CACHE_HOME=/tmp/agents-xdg-cache BUN_INSTALL_CACHE_DIR=/tmp/agents-bun-cache BUN_COMPILE_TARGET=bun-darwin-arm64 bun run build:bin` passed: `compile  dist/bin/agents bun-darwin-aarch64-v1.3.14`.
- zion macOS arm64 standalone E2E passed with `/tmp/agents-rush-1727`: `pty start`, `pty exec "$SID" "echo hi"`, `pty screen "$SID"`, and `pty stop "$SID"` returned screen output containing `hi`.

Public repo: no confidential session transcript was uploaded or pasted.
