### PR TITLE
Expose routine runs in sessions

### DIFF
--- a/apps/cli/.changelog/next/routine-sessions.md
+++ b/apps/cli/.changelog/next/routine-sessions.md
@@ -1,0 +1,1 @@
+- `agents sessions` now indexes routine-run transcripts from durable run history; use `agents sessions --routine --all` or `agents sessions <run-id>` to inspect a routine run with the existing summary view.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -239,7 +239,7 @@ Job 'drain' can only run on: yosemite-s0, mac-mini
 Each job runs with `HOME` set to an overlay directory:
 
 ```
-~/.agents/routines-sandbox/daily-review-<timestamp>/
+~/.agents/routines/daily-review/home/
   .claude/
     settings.json             # Generated with allow.tools permissions
   projects -> ~/projects      # Symlink from allow.dirs
@@ -249,6 +249,19 @@ The agent can only:
 - See directories listed in `allow.dirs`
 - Use tools listed in `allow.tools`
 - Cannot access `~/.ssh`, `~/.gitconfig`, etc.
+
+When an agent routine finishes, agents-cli copies the agent transcript out of
+the overlay before the next run recreates it. The durable copy lives beside the
+run metadata:
+
+```
+~/.agents/.history/runs/<routine>/<run-id>/sessions/<agent>/...
+```
+
+Those archives are indexed by `agents sessions` with `origin: "routine"`,
+`routineName`, and `routineRunId`. Use `agents sessions --routine --all` to list
+them, or `agents sessions <run-id>` to render the existing session summary view
+for a specific routine run.
 
 ### Headless claude auth
 
@@ -492,6 +505,7 @@ agents routines logs <name>           # Show stdout from latest run
 agents routines logs <name> --run <id>  # Show specific run
 agents routines report <name>         # Show report from latest run
 agents routines report <name> --run <id>  # Show specific run report
+agents sessions <run-id>              # Show the archived agent transcript summary
 
 # Scheduler (auto-starts on first `routines add`; these are manual controls)
 agents routines start                 # Start the background scheduler

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -17,6 +17,9 @@ Per-agent on-disk session files (not owned by agents-cli, read-only):
 ~/.gemini/tmp/<project>/chats/session-*.json              # Gemini
 ~/.local/share/opencode/project/*/storage/session/...     # OpenCode
 ~/Library/Application Support/OpenClaw/sessions/*.json    # OpenClaw
+
+Routine archives (owned by agents-cli, durable):
+~/.agents/.history/runs/<routine>/<run-id>/sessions/<agent>/...
 ```
 
 ## Discovery Flow
@@ -53,6 +56,9 @@ active sessions get refreshed each call because their mtime keeps advancing.
   "id": "c07ec355-d841-45fc-b2eb-f500355e15c6",
   "shortId": "c07ec355",
   "agent": "claude",
+  "origin": "cli",
+  "routineName": null,
+  "routineRunId": null,
   "version": "2.1.112",
   "account": "you@example.com",
   "timestamp": "2026-04-22T13:37:14.047Z",
@@ -77,6 +83,9 @@ Fields:
 | `id` | Agent-native UUID | Primary key; stable across reloads |
 | `shortId` | First 8 chars of `id` | For human matching in CLI output |
 | `agent` | One of 5 formats | See SessionAgentId union |
+| `origin` | `cli` or `routine` | Routine rows are archived from a run directory and can be filtered with `--routine` |
+| `routineName` | Routine name | Present when `origin` is `routine` |
+| `routineRunId` | Routine run id | Present when `origin` is `routine`; `agents sessions <runId>` resolves it |
 | `timestamp` | Session start | ISO 8601 |
 | `project` | Derived from `cwd` | Basename of the working directory |
 | `cwd` | Recorded at spawn | Normalized absolute path |
@@ -155,6 +164,10 @@ agents sessions "auth refactor"
 
 # Include team-spawned sessions (hidden by default)
 agents sessions --teams
+
+# Show routine-run sessions, then open one by routine run id
+agents sessions --routine --all
+agents sessions 2026-07-21T10-30-00-000Z
 
 # Sort the list by cost or duration (default: recent)
 agents sessions --sort cost --limit 10

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -60,6 +60,7 @@ interface SessionFilterOptions {
   project?: string;
   all?: boolean;
   teams?: boolean;
+  routine?: boolean;
   since?: string;
   until?: string;
 }
@@ -928,6 +929,7 @@ function canonicalSessionsCommand(query: string | undefined, options: SessionsOp
   const a = ['sessions'];
   if (options.active) a.push('--active');
   if (options.teams) a.push('--teams');
+  if (options.routine) a.push('--routine');
   if (options.agent) a.push('-a', options.agent);
   for (const h of options.host ?? []) a.push('--device', h);
   if (options.project) a.push('--project', options.project);
@@ -1071,6 +1073,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   if (
     useInteractiveBrowser(options) &&
     !query &&
+    !options.routine &&
     !options.flat &&
     !options.tree &&
     !options.markdown &&
@@ -1181,6 +1184,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       since,
       until: options.until,
       sortBy,
+      origin: options.routine ? 'routine' : undefined,
     };
 
     let sessions = await discoverSessions({
@@ -1315,6 +1319,11 @@ function teamTag(session: SessionMeta): string {
   return parts ? `[${parts}] ` : '[team] ';
 }
 
+function originTag(session: SessionMeta): string {
+  if (session.origin !== 'routine') return '';
+  return `[routine${session.routineName ? ` · ${session.routineName}` : ''}] `;
+}
+
 /** Adapt a SessionMeta's persisted signals to the badge renderer's shape. */
 function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
   return {
@@ -1334,7 +1343,7 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.lastActivity ?? session.timestamp);
   const project = session.project || '-';
-  const tag = teamTag(session);
+  const tag = originTag(session) || teamTag(session);
   const label = (session as any).label;
   const { glyph, preview } = liveGlyphAndPreview(live);
   // A running session's live preview says what the agent is doing now; a
@@ -1378,7 +1387,7 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
 function treeSessionRow(session: SessionMeta, live?: ActiveSession): string {
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.lastActivity ?? session.timestamp);
-  const tag = teamTag(session);
+  const tag = originTag(session) || teamTag(session);
   const label = (session as any).label;
   const { glyph, preview } = liveGlyphAndPreview(live);
   const topic = (preview || (tag ? `${tag}${session.topic ?? ''}` : session.topic)) || '-';
@@ -1803,7 +1812,7 @@ export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerCol
   const agentColor = colorAgent(s.agent);
   const when = formatRelativeTime(s.lastActivity ?? s.timestamp);
   const project = s.project || '-';
-  const tag = teamTag(s);
+  const tag = originTag(s) || teamTag(s);
   const label = (s as any).label;
   const topic = tag ? `${tag}${s.topic ?? ''}` : s.topic;
   const versionStr = s.version || '-';
@@ -2468,6 +2477,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--opencode', 'Shorthand for --agent opencode')
     .option('--all', 'Include sessions from every directory (not just current project)')
     .option('--teams', 'Include team-spawned sessions (hidden by default)')
+    .option('--routine', 'Show only sessions archived from routine runs')
     .option('-p, --project <name>', 'Filter by project name (searches across all directories)')
     .option('--since <time>', 'Only sessions newer than this (e.g., 2h, 7d, 4w, or ISO date)')
     .option('--until <time>', 'Only sessions older than this (ISO timestamp)')
@@ -2518,6 +2528,10 @@ export function registerSessionsCommands(program: Command): void {
       # Search across every directory, not just this project
       agents sessions "topic" --all
 
+      # Show routine-run sessions and open one by routine run id
+      agents sessions --routine --all
+      agents sessions 2026-07-21T10-30-00-000Z
+
       # Export for analysis
       agents sessions --since 30d --limit 200 --json > sessions.json
 
@@ -2534,6 +2548,7 @@ export function registerSessionsCommands(program: Command): void {
       - --first and --last are mutually exclusive.
       - A filter flag (--include/--exclude/--first/--last) without --markdown/--json defaults to --markdown output.
       - --cloud sources from Rush Cloud captured runs instead of local disk.
+      - --routine shows only transcripts archived from routine run directories; routine rows also resolve by run id.
       - Without --teams, team-spawned sessions are hidden by default.
     `,
   });
@@ -2786,5 +2801,3 @@ function formatAbsoluteTime(isoTimestamp: string): string {
   const mm = String(d.getMinutes()).padStart(2, '0');
   return `${months[d.getMonth()]} ${d.getDate()} ${hh}:${mm}`;
 }
-
-

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { executeJob, executeJobDetached, monitorRunningJobs } from './runner.js';
+import { archiveRoutineTranscripts, executeJob, executeJobDetached, monitorRunningJobs } from './runner.js';
 import { getRunDir, writeRunMeta } from './routines.js';
 import type { JobConfig, RunMeta } from './routines.js';
 import { saveTask, hostsCacheDir } from './hosts/tasks.js';
@@ -110,6 +110,30 @@ describe('runner host placement', () => {
       fs.rmSync(path.dirname(runDir), { recursive: true, force: true });
       fs.rmSync(path.join(hostsCacheDir(), `${taskId}.json`), { force: true });
     }
+  });
+});
+
+describe('routine transcript archiving', () => {
+  const jobName = 'archive-routine-test';
+  const runId = 'run-archive-1';
+
+  afterEach(() => {
+    cleanupJobRuns(jobName);
+  });
+
+  it('copies sandboxed agent transcripts into the stable run directory', () => {
+    const overlayHome = path.join(getRunDir(jobName, runId), 'overlay-home');
+    const sourceDir = path.join(overlayHome, '.claude', 'projects', 'tmp-project');
+    const sourcePath = path.join(sourceDir, 'sess-archive.jsonl');
+    const runDir = getRunDir(jobName, runId);
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '{"type":"user","message":{"content":"hi"}}\n', 'utf-8');
+
+    archiveRoutineTranscripts({ jobName, runId, agent: 'claude' }, runDir, overlayHome);
+    fs.rmSync(overlayHome, { recursive: true, force: true });
+
+    const archived = path.join(runDir, 'sessions', 'claude', 'projects', 'tmp-project', 'sess-archive.jsonl');
+    expect(fs.readFileSync(archived, 'utf-8')).toContain('"content":"hi"');
   });
 });
 

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -30,7 +30,7 @@ import {
 } from './routines.js';
 import { getRunsDir } from './state.js';
 import type { AgentId } from './types.js';
-import { prepareJobHome, buildSpawnEnv } from './sandbox.js';
+import { prepareJobHome, buildSpawnEnv, getJobHomePath } from './sandbox.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { createTimer, maybeRotate, redactPrompt } from './events.js';
 import {
@@ -46,6 +46,7 @@ import type { LoopDeps } from './loop.js';
 import { loadTask as loadHostTask } from './hosts/tasks.js';
 import { reconcileTask as reconcileHostTask } from './hosts/reconcile.js';
 import { backgroundSpawnOptions } from './platform/process.js';
+import { walkForFiles } from './fs-walk.js';
 import { getBinaryPath, isVersionInstalled, resolveVersion } from './versions.js';
 import {
   getConfiguredRunStrategy,
@@ -68,6 +69,11 @@ const AGENT_COMMANDS: Record<string, string[]> = {
   gemini: ['gemini', '{prompt}', '--output-format', 'stream-json'],
   kimi: ['kimi', '--prompt', '{prompt}', '--output-format', 'stream-json'],
   droid: ['droid', 'exec', '{prompt}', '-o', 'stream-json'],
+};
+
+const ROUTINE_TRANSCRIPT_SPECS: Partial<Record<AgentId, Array<{ root: string[]; ext: string }>>> = {
+  claude: [{ root: ['.claude', 'projects'], ext: '.jsonl' }],
+  codex: [{ root: ['.codex', 'sessions'], ext: '.jsonl' }],
 };
 
 /** Build the full CLI argv for executing a job, applying mode, model, and permission flags. */
@@ -223,6 +229,36 @@ function appendModelAndReasoning(cmd: string[], config: JobConfig): void {
 
 function generateRunId(): string {
   return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+export function archiveRoutineTranscripts(
+  meta: Pick<RunMeta, 'jobName' | 'runId' | 'agent'>,
+  runDir: string,
+  overlayHome?: string,
+): void {
+  if (!meta.agent) return;
+  const specs = ROUTINE_TRANSCRIPT_SPECS[meta.agent];
+  if (!specs) return;
+
+  const home = overlayHome ?? getJobHomePath(meta.jobName);
+  for (const spec of specs) {
+    const sourceRoot = path.join(home, ...spec.root);
+    if (!fs.existsSync(sourceRoot)) continue;
+    const destRoot = path.join(runDir, 'sessions', meta.agent, spec.root[spec.root.length - 1]);
+    for (const sourcePath of walkForFiles(sourceRoot, spec.ext, 100_000)) {
+      const rel = path.relative(sourceRoot, sourcePath);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) continue;
+      const destPath = path.join(destRoot, rel);
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      try {
+        fs.copyFileSync(sourcePath, destPath);
+        fs.chmodSync(destPath, 0o600);
+      } catch {
+        // The process already reached a terminal state; a concurrently removed
+        // transcript should not rewrite that outcome.
+      }
+    }
+  }
 }
 
 /**
@@ -639,6 +675,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     );
     writeRunMeta(meta);
     timer.end({ status: meta.status, exitCode: meta.exitCode ?? undefined, runId });
+    archiveRoutineTranscripts(meta, runDir, overlayHome);
     return { meta, reportPath: null };
   }
 
@@ -691,6 +728,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
       writeRunMeta(meta);
       timer.end({ status: 'timeout', runId });
       const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
+      archiveRoutineTranscripts(meta, runDir, overlayHome);
       return { meta, reportPath };
     }
 
@@ -699,6 +737,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
       writeRunMeta(meta);
       timer.end({ status: 'completed', exitCode: 0, runId });
       const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
+      archiveRoutineTranscripts(meta, runDir, overlayHome);
       return { meta, reportPath };
     }
 
@@ -733,6 +772,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
       ...(attempt.error ? { error: attempt.error } : {}),
     });
     const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
+    archiveRoutineTranscripts(meta, runDir, overlayHome);
     return { meta, reportPath };
   }
 
@@ -987,10 +1027,28 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
     env: spawnEnv,
   });
 
+  let settled = false;
+  const settle = (status: RunMeta['status'], exitCode: number | null, errorMessage?: string) => {
+    if (settled) return;
+    settled = true;
+    finalizeRunMeta(meta, status, exitCode, errorMessage ? { errorMessage } : undefined);
+    writeRunMeta(meta);
+    archiveRoutineTranscripts(meta, runDir, overlayHome);
+    if (status !== 'timeout') extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
+  };
+
+  child.on('exit', (code) => {
+    const inferred = inferFinalStatusFromLog(stdoutPath, effectiveAgent);
+    if (inferred) {
+      settle(inferred.status, inferred.exitCode);
+    } else {
+      settle(code === 0 ? 'completed' : 'failed', code ?? 1);
+    }
+  });
+
   child.on('error', (err) => {
     try { fs.closeSync(stdoutFd); } catch { /* fd already closed */ }
-    finalizeRunMeta(meta, 'failed', 1, { errorMessage: err.message });
-    writeRunMeta(meta);
+    settle('failed', 1, err.message);
     process.stderr.write(`[agents] daemon: spawn failed for job "${config.name}": ${err.message}\n`);
   });
 
@@ -1270,7 +1328,10 @@ export function monitorRunningJobs(): void {
         if (Number.isFinite(wallClockMs) && wallClockMs > MAX_WALL_CLOCK_MS) {
           finalizeRunMeta(meta, 'timeout', null, { errorMessage: 'exceeded max wall clock' });
           writeRunMeta(meta);
-          if (!isCommandRun) extractAndSaveReport(stdoutPath, meta.agent!, runDirPath);
+          if (!isCommandRun) {
+            extractAndSaveReport(stdoutPath, meta.agent!, runDirPath);
+            archiveRoutineTranscripts(meta, runDirPath);
+          }
           continue;
         }
 
@@ -1293,7 +1354,10 @@ export function monitorRunningJobs(): void {
           }
           writeRunMeta(meta);
 
-          if (!isCommandRun) extractAndSaveReport(stdoutPath, meta.agent!, runDirPath);
+          if (!isCommandRun) {
+            extractAndSaveReport(stdoutPath, meta.agent!, runDirPath);
+            archiveRoutineTranscripts(meta, runDirPath);
+          }
         }
       } catch { /* corrupt or unreadable meta.json */ }
     }

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -141,7 +141,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('12');
+    expect(row.value).toBe('13');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {
@@ -170,6 +170,14 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
     const db = getDB();
     const cols = (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
     expect(cols).toContain('plan');
+  });
+
+  it('v13 adds routine-origin linkage columns', () => {
+    const db = getDB();
+    const cols = (db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toContain('origin');
+    expect(cols).toContain('routine_name');
+    expect(cols).toContain('routine_run_id');
   });
 });
 

--- a/apps/cli/src/lib/session/__tests__/discover.test.ts
+++ b/apps/cli/src/lib/session/__tests__/discover.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import Database from '../../sqlite.js';
-import { buildFtsQuery } from '../db.js';
-import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile } from '../discover.js';
+import { buildFtsQuery, getDB } from '../db.js';
+import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile, discoverSessions, resolveSessionById } from '../discover.js';
 import { machineId } from '../sync/config.js';
 import { getHistoryDir } from '../../state.js';
 
@@ -22,6 +22,62 @@ describe('machineForSessionFile', () => {
   it('falls back to the local machine for live-home (non-mirror) files', () => {
     const p = path.join(os.homedir(), '.claude', 'projects', 'foo', 'sess.jsonl');
     expect(machineForSessionFile(p, 'claude')).toBe(machineId());
+  });
+});
+
+describe('routine archive discovery', () => {
+  const jobName = '__test_routine_sessions__';
+  const runId = '2026-07-21T10-30-00-000Z';
+  const sessionId = '11111111-2222-4333-8444-555555555555';
+  const runDir = path.join(getHistoryDir(), 'runs', jobName, runId);
+
+  afterEach(() => {
+    fs.rmSync(path.join(getHistoryDir(), 'runs', jobName), { recursive: true, force: true });
+    const db = getDB();
+    db.prepare(`DELETE FROM sessions WHERE id = ?`).run(sessionId);
+    db.prepare(`DELETE FROM session_text WHERE session_id = ?`).run(sessionId);
+    db.prepare(`DELETE FROM scan_ledger WHERE file_path LIKE ?`).run(`${runDir}%`);
+  });
+
+  it('indexes archived routine transcripts and resolves them by routine run id', async () => {
+    const transcriptDir = path.join(runDir, 'sessions', 'claude', 'projects', 'routine-project');
+    fs.mkdirSync(transcriptDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(transcriptDir, `${sessionId}.jsonl`),
+      [
+        JSON.stringify({
+          type: 'user',
+          timestamp: '2026-07-21T10:30:00.000Z',
+          cwd: '/tmp/routine-project',
+          sessionId,
+          message: { role: 'user', content: 'summarize routine result' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          timestamp: '2026-07-21T10:31:00.000Z',
+          cwd: '/tmp/routine-project',
+          sessionId,
+          message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] },
+        }),
+      ].join('\n') + '\n',
+      'utf-8',
+    );
+
+    const sessions = await discoverSessions({
+      agent: 'claude',
+      origin: 'routine',
+      all: true,
+      limit: 100,
+    });
+    const hit = sessions.find((s) => s.id === sessionId);
+
+    expect(hit).toBeDefined();
+    expect(hit!.origin).toBe('routine');
+    expect(hit!.routineName).toBe(jobName);
+    expect(hit!.routineRunId).toBe(runId);
+    expect(hit!.project).toBe(jobName);
+    expect(hit!.label).toBe(jobName);
+    expect(resolveSessionById(sessions, runId).map((s) => s.id)).toContain(sessionId);
   });
 });
 

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -17,7 +17,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 12;
+const SCHEMA_VERSION = 13;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -48,6 +48,9 @@ CREATE TABLE IF NOT EXISTS sessions (
   id TEXT PRIMARY KEY,
   short_id TEXT NOT NULL,
   agent TEXT NOT NULL,
+  origin TEXT DEFAULT 'cli',
+  routine_name TEXT,
+  routine_run_id TEXT,
   version TEXT,
   account TEXT,
   timestamp TEXT NOT NULL,
@@ -110,6 +113,9 @@ export interface SessionRow {
   id: string;
   short_id: string;
   agent: string;
+  origin: string | null;
+  routine_name: string | null;
+  routine_run_id: string | null;
   version: string | null;
   account: string | null;
   timestamp: string;
@@ -147,6 +153,7 @@ export interface ScanStamp {
 export interface QueryOptions {
   agent?: SessionAgentId;
   agents?: SessionAgentId[];
+  origin?: 'cli' | 'routine';
   version?: string;
   cwd?: string;
   /** Match any session whose cwd equals this or is a descendant of it. */
@@ -301,6 +308,18 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     if (!cols.some(c => c.name === 'output_tokens')) db.exec(`ALTER TABLE sessions ADD COLUMN output_tokens INTEGER`);
     db.exec(`DELETE FROM scan_ledger;`);
   }
+
+  if (fromVersion < 13) {
+    // v12 → v13: routine runs archive their sandboxed transcript into the run
+    // directory and get indexed as origin='routine', linked by routine_name and
+    // routine_run_id. Existing rows are normal CLI-origin sessions.
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'origin')) db.exec(`ALTER TABLE sessions ADD COLUMN origin TEXT DEFAULT 'cli'`);
+    if (!cols.some(c => c.name === 'routine_name')) db.exec(`ALTER TABLE sessions ADD COLUMN routine_name TEXT`);
+    if (!cols.some(c => c.name === 'routine_run_id')) db.exec(`ALTER TABLE sessions ADD COLUMN routine_run_id TEXT`);
+    db.exec(`UPDATE sessions SET origin = 'cli' WHERE origin IS NULL OR origin = ''`);
+    db.exec(`DELETE FROM scan_ledger;`);
+  }
 }
 
 /** Open (or return the cached) sessions database, applying migrations as needed. */
@@ -334,6 +353,8 @@ export function getDB(): Database.Database {
   // run. It must NOT live in SCHEMA (executed before migration) or an existing
   // DB would fail the index build on a column it doesn't have yet.
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity DESC)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_origin ON sessions(origin)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_routine_run_id ON sessions(routine_run_id)`);
 
   // One-shot cleanup of the pre-SQLite JSONL indexes. Safe — nothing reads
   // them anymore. Guarded by a meta flag so we only try once.
@@ -525,13 +546,15 @@ export function recordScans(entries: Array<{ filePath: string; scan: ScanStamp }
 
 const upsertSessionStmt = (db: Database.Database) => db.prepare(`
   INSERT INTO sessions (
-    id, short_id, agent, version, account, timestamp, last_activity,
+    id, short_id, agent, origin, routine_name, routine_run_id,
+    version, account, timestamp, last_activity,
     project, cwd, git_branch, topic, label, message_count, token_count,
     output_tokens, cost_usd, duration_ms,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id, plan
   ) VALUES (
-    @id, @short_id, @agent, @version, @account, @timestamp, @last_activity,
+    @id, @short_id, @agent, @origin, @routine_name, @routine_run_id,
+    @version, @account, @timestamp, @last_activity,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
     @output_tokens, @cost_usd, @duration_ms,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
@@ -540,6 +563,9 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
   ON CONFLICT(id) DO UPDATE SET
     short_id = excluded.short_id,
     agent = excluded.agent,
+    origin = excluded.origin,
+    routine_name = excluded.routine_name,
+    routine_run_id = excluded.routine_run_id,
     version = excluded.version,
     account = excluded.account,
     timestamp = excluded.timestamp,
@@ -599,6 +625,9 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     id: meta.id,
     short_id: meta.shortId,
     agent: meta.agent,
+    origin: meta.origin ?? 'cli',
+    routine_name: meta.routineName ?? null,
+    routine_run_id: meta.routineRunId ?? null,
     version: meta.version ?? null,
     account: meta.account ?? null,
     timestamp: meta.timestamp,
@@ -702,6 +731,9 @@ export function upsertSessionsBatch(
         id: meta.id,
         short_id: meta.shortId,
         agent: meta.agent,
+        origin: meta.origin ?? 'cli',
+        routine_name: meta.routineName ?? null,
+        routine_run_id: meta.routineRunId ?? null,
         version: meta.version ?? null,
         account: meta.account ?? null,
         timestamp: meta.timestamp,
@@ -890,6 +922,9 @@ function rowToMeta(row: SessionRow): SessionMeta {
     id: row.id,
     shortId: row.short_id,
     agent: row.agent as SessionAgentId,
+    origin: (row.origin === 'routine' ? 'routine' : 'cli'),
+    routineName: row.routine_name ?? undefined,
+    routineRunId: row.routine_run_id ?? undefined,
     timestamp: row.timestamp,
     lastActivity: row.last_activity ?? undefined,
     project: row.project ?? undefined,
@@ -981,6 +1016,11 @@ function buildSessionWhere(options: QueryOptions): { clause: string; params: any
     params.push(options.version);
   }
 
+  if (options.origin) {
+    where.push("IFNULL(origin, 'cli') = ?");
+    params.push(options.origin);
+  }
+
   if (options.cwd) {
     where.push('cwd = ?');
     params.push(options.cwd);
@@ -1004,12 +1044,12 @@ function buildSessionWhere(options: QueryOptions): { clause: string; params: any
   // for the same reason. short_id carries its own index (idx_sessions_short_id);
   // id is the PRIMARY KEY.
   if (options.idExact) {
-    where.push('(id = ? COLLATE NOCASE OR short_id = ? COLLATE NOCASE)');
-    params.push(options.idExact, options.idExact);
+    where.push('(id = ? COLLATE NOCASE OR short_id = ? COLLATE NOCASE OR routine_run_id = ? COLLATE NOCASE)');
+    params.push(options.idExact, options.idExact, options.idExact);
   }
   if (options.idPrefix) {
-    where.push('(id LIKE ? OR short_id LIKE ?)');
-    params.push(`${options.idPrefix}%`, `${options.idPrefix}%`);
+    where.push('(id LIKE ? OR short_id LIKE ? OR routine_run_id LIKE ?)');
+    params.push(`${options.idPrefix}%`, `${options.idPrefix}%`, `${options.idPrefix}%`);
   }
 
   if (typeof options.sinceMs === 'number') {

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -15,7 +15,7 @@ import * as readline from 'readline';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import Database from '../sqlite.js';
-import { getAgentsDir, getUserAgentsDir, getHistoryDir } from '../state.js';
+import { getAgentsDir, getUserAgentsDir, getHistoryDir, getRunsDir } from '../state.js';
 
 const execFileAsync = promisify(execFile);
 import type { SessionAgentId, SessionMeta } from './types.js';
@@ -84,6 +84,8 @@ export interface DiscoverOptions {
   excludeTeamOrigin?: boolean;
   /** Keep only team-spawned sessions (used for hidden-count queries). */
   onlyTeamOrigin?: boolean;
+  /** Keep only sessions from this source. */
+  origin?: 'cli' | 'routine';
   /** Column to order results by (all descending): 'timestamp' (default), 'cost', or 'duration'. */
   sortBy?: 'timestamp' | 'cost' | 'duration';
   /** Called as each agent makes parsing progress. Totals count only files that need re-parsing (cache misses). */
@@ -191,6 +193,7 @@ export async function discoverSessions(options?: DiscoverOptions): Promise<Sessi
       // reads to behavioral EDR (CrowdStrike Falcon) as a ransomware-style bulk
       // file-enumeration sweep. Same dirs, same results — just not all at once.
       await scanAgentsBounded(agents, agent => dispatchAgentScan(agent, onProgress));
+      await scanAgentsBounded(agents, agent => scanRoutineArchivesIncremental(agent, onProgress));
       // Seed labels from `agents run --name` handles onto the freshly-scanned
       // rows by id. Runs AFTER the per-agent scans (which applied agent-generated
       // titles via syncLabels), so a real title always wins and the seed only
@@ -305,6 +308,7 @@ function buildQueryOptions(
     limit: opts.includeLimit ? (options?.limit ?? 50) : undefined,
     excludeTeamOrigin: options?.excludeTeamOrigin,
     onlyTeamOrigin: options?.onlyTeamOrigin,
+    origin: options?.origin,
     sortBy: options?.sortBy,
   };
 }
@@ -324,11 +328,15 @@ function normalizeCwd(cwd?: string): string {
 export function resolveSessionById(sessions: SessionMeta[], idQuery: string): SessionMeta[] {
   const query = idQuery.toLowerCase();
   const exact = sessions.filter(s =>
-    s.id.toLowerCase() === query || s.shortId.toLowerCase() === query,
+    s.id.toLowerCase() === query ||
+    s.shortId.toLowerCase() === query ||
+    s.routineRunId?.toLowerCase() === query,
   );
   if (exact.length > 0) return exact;
   return sessions.filter(s =>
-    s.id.toLowerCase().startsWith(query) || s.shortId.toLowerCase().startsWith(query),
+    s.id.toLowerCase().startsWith(query) ||
+    s.shortId.toLowerCase().startsWith(query) ||
+    s.routineRunId?.toLowerCase().startsWith(query),
   );
 }
 
@@ -479,6 +487,10 @@ const SESSION_ROOT_SPECS: ReadonlyArray<{ agent: SessionAgentId; subdir: string 
   { agent: 'kimi', subdir: 'sessions' },
 ];
 
+function sessionRootSubdir(agent: SessionAgentId): string | null {
+  return SESSION_ROOT_SPECS.find((spec) => spec.agent === agent)?.subdir ?? null;
+}
+
 /** A session-agent's on-disk watch roots (every version home + backup mirror). */
 export interface SessionRoots {
   agent: SessionAgentId;
@@ -496,9 +508,121 @@ export function getSessionRoots(): SessionRoots[] {
   const out: SessionRoots[] = [];
   for (const { agent, subdir } of SESSION_ROOT_SPECS) {
     const dirs = getAgentSessionDirs(agent, subdir);
+    dirs.push(...getRoutineArchiveSessionDirs(agent, subdir));
     if (dirs.length > 0) out.push({ agent, dirs });
   }
   return out;
+}
+
+function getRoutineArchiveSessionDirs(agent: SessionAgentId, subdir: string): string[] {
+  const runsDir = getRunsDir();
+  if (!fs.existsSync(runsDir)) return [];
+  const dirs: string[] = [];
+
+  let jobDirs: fs.Dirent[];
+  try {
+    jobDirs = fs.readdirSync(runsDir, { withFileTypes: true });
+  } catch {
+    return dirs;
+  }
+
+  for (const jobDir of jobDirs) {
+    if (!jobDir.isDirectory()) continue;
+    const jobRunsDir = path.join(runsDir, jobDir.name);
+    let runDirs: fs.Dirent[];
+    try {
+      runDirs = fs.readdirSync(jobRunsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const runDir of runDirs) {
+      if (!runDir.isDirectory()) continue;
+      const dir = path.join(jobRunsDir, runDir.name, 'sessions', agent, subdir);
+      if (fs.existsSync(dir)) dirs.push(dir);
+    }
+  }
+
+  return dirs;
+}
+
+function routineArchiveInfo(filePath: string): { jobName: string; runId: string } | null {
+  const rel = path.relative(getRunsDir(), filePath);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  const parts = rel.split(path.sep);
+  if (parts.length < 6 || parts[2] !== 'sessions') return null;
+  return { jobName: parts[0], runId: parts[1] };
+}
+
+function decorateRoutineSession(
+  meta: SessionMeta,
+  info: { jobName: string; runId: string },
+): SessionMeta {
+  return {
+    ...meta,
+    origin: 'routine',
+    routineName: info.jobName,
+    routineRunId: info.runId,
+    project: info.jobName,
+    label: info.jobName,
+  };
+}
+
+async function readRoutineArchiveMeta(
+  agent: SessionAgentId,
+  filePath: string,
+): Promise<{ meta: SessionMeta; content: string } | null> {
+  const info = routineArchiveInfo(filePath);
+  if (!info) return null;
+
+  if (agent === 'claude') {
+    const sessionId = path.basename(filePath).replace(/\.jsonl$/, '');
+    const result = await readClaudeMeta(filePath, sessionId);
+    return result ? { ...result, meta: decorateRoutineSession(result.meta, info) } : null;
+  }
+
+  if (agent === 'codex') {
+    const result = await readCodexMeta(filePath);
+    return result ? { ...result, meta: decorateRoutineSession(result.meta, info) } : null;
+  }
+
+  return null;
+}
+
+async function scanRoutineArchivesIncremental(
+  agent: SessionAgentId,
+  onProgress?: (p: ScanProgress) => void,
+): Promise<void> {
+  const subdir = sessionRootSubdir(agent);
+  if (!subdir) return;
+
+  const ext = agent === 'gemini' ? '.json' : '.jsonl';
+  const filePaths: string[] = [];
+  for (const sessionsDir of getRoutineArchiveSessionDirs(agent, subdir)) {
+    for (const fp of walkForFiles(sessionsDir, ext, 100_000)) filePaths.push(fp);
+  }
+
+  const changed = filterChangedFiles(filePaths);
+  if (changed.length === 0) return;
+
+  onProgress?.({ agent, parsed: 0, total: changed.length });
+
+  const entries: ScanEntry[] = [];
+  const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
+  let parsed = 0;
+  for (const { filePath, scan } of changed) {
+    try {
+      const result = await readRoutineArchiveMeta(agent, filePath);
+      if (result) entries.push({ meta: result.meta, content: result.content, scan });
+      else touched.push({ filePath, scan });
+    } catch {
+      touched.push({ filePath, scan });
+    }
+    parsed++;
+    onProgress?.({ agent, parsed, total: changed.length });
+  }
+
+  upsertSessionsBatch(entries);
+  recordScans(touched);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -86,6 +86,12 @@ export interface SessionMeta {
   id: string;
   shortId: string;
   agent: SessionAgentId;
+  /** Where the indexed transcript came from. Routine rows are archived from a run directory. */
+  origin?: 'cli' | 'routine';
+  /** Routine name for transcripts archived from ~/.agents/.history/runs/<name>/<runId>/. */
+  routineName?: string;
+  /** Routine run id for transcripts archived from ~/.agents/.history/runs/<name>/<runId>/. */
+  routineRunId?: string;
   timestamp: string;
   /**
    * Last-activity time (ISO): the last message timestamp when a parser computed


### PR DESCRIPTION
## Summary

- Routine transcripts are now archived from the sandbox overlay into the durable run directory. Evidence: `apps/cli/src/lib/runner.ts:74` `const ROUTINE_TRANSCRIPT_SPECS: Partial<Record<AgentId, Array<{ root: string[]; ext: string }>>> = {`; `apps/cli/src/lib/runner.ts:247` `const destRoot = path.join(runDir, 'sessions', meta.agent, spec.root[spec.root.length - 1]);`; `apps/cli/src/lib/runner.ts:254` `fs.copyFileSync(sourcePath, destPath);`.
- Finished routine paths call transcript archiving. Evidence: `apps/cli/src/lib/runner.ts:678` `archiveRoutineTranscripts(meta, runDir, overlayHome);`; `apps/cli/src/lib/runner.ts:740` `archiveRoutineTranscripts(meta, runDir, overlayHome);`; `apps/cli/src/lib/runner.ts:1036` `archiveRoutineTranscripts(meta, runDir, overlayHome);`; `apps/cli/src/lib/runner.ts:1359` `archiveRoutineTranscripts(meta, runDirPath);`.
- Session metadata and the SQLite ledger now store routine origin fields. Evidence: `apps/cli/src/lib/session/types.ts:90` `origin?: 'cli' | 'routine';`; `apps/cli/src/lib/session/types.ts:92` `routineName?: string;`; `apps/cli/src/lib/session/types.ts:94` `routineRunId?: string;`; `apps/cli/src/lib/session/db.ts:51` `origin TEXT DEFAULT 'cli',`; `apps/cli/src/lib/session/db.ts:53` `routine_run_id TEXT,`.
- Session discovery scans durable routine archives and decorates indexed rows with routine metadata. Evidence: `apps/cli/src/lib/session/discover.ts:196` `await scanAgentsBounded(agents, agent => scanRoutineArchivesIncremental(agent, onProgress));`; `apps/cli/src/lib/session/discover.ts:540` `const dir = path.join(jobRunsDir, runDir.name, 'sessions', agent, subdir);`; `apps/cli/src/lib/session/discover.ts:562` `origin: 'routine',`; `apps/cli/src/lib/session/discover.ts:564` `routineRunId: info.runId,`.
- `agents sessions` now has a routine filter and routine run-id lookup. Evidence: `apps/cli/src/commands/sessions.ts:1187` `origin: options.routine ? 'routine' : undefined,`; `apps/cli/src/commands/sessions.ts:1324` `return `[routine${session.routineName ? ` · ${session.routineName}` : ''}] `;`; `apps/cli/src/commands/sessions.ts:2480` `.option('--routine', 'Show only sessions archived from routine runs')`; `apps/cli/src/lib/session/db.ts:1047` `where.push('(id = ? COLLATE NOCASE OR short_id = ? COLLATE NOCASE OR routine_run_id = ? COLLATE NOCASE)');`.
- Docs and changelog cover the user-visible command. Evidence: `apps/cli/docs/03-routines.md:252` `~/.agents/.history/runs/<routine>/<run-id>/sessions/<agent>/...`; `apps/cli/docs/05-sessions.md:86` `| `origin` | `cli` or `routine` | Routine rows are archived from a run directory and can be filtered with `--routine` |`; `apps/cli/.changelog/next/routine-sessions.md:1` `- `agents sessions` now indexes routine-run transcripts from durable run history; use `agents sessions --routine --all` or `agents sessions <run-id>` to inspect a routine run with the existing summary view.`.

## Tests

- `HOME=/dev/shm/acli-rush1283-tmpwt-home-install TMPDIR=/dev/shm/acli-rush1283-tmpwt-tmp-install bun install`
- `HOME=/dev/shm/acli-rush1283-tmpwt-home-target TMPDIR=/dev/shm/acli-rush1283-tmpwt-tmp-target AGENTS_SKIP_MIGRATION=1 bun run test src/lib/session/__tests__/discover.test.ts src/lib/session/__tests__/db.test.ts src/lib/runner.test.ts`
- `HOME=/dev/shm/acli-rush1283-tmpwt-home-cmd TMPDIR=/dev/shm/acli-rush1283-tmpwt-tmp-cmd AGENTS_SKIP_MIGRATION=1 bun run test src/commands/__tests__/sessions.test.ts src/lib/session/db.migrate-v10.test.ts`
- `HOME=/dev/shm/acli-rush1283-tmpwt-home-tsc TMPDIR=/dev/shm/acli-rush1283-tmpwt-tmp-tsc bunx tsc --noEmit`
- Real CLI smoke: archived a Claude JSONL under `~/.agents/.history/runs/daily-review/2026-07-21T10-30-00-000Z/sessions/claude/projects/routine-project/`, then verified `agents sessions --routine --all --json` exposes `origin === "routine"` and `agents sessions 2026-07-21T10-30-00-000Z --all` renders the summary text.
