### PR TITLE
Route specialized ssh spawns through baseline

### DIFF
--- a/apps/cli/.changelog/next/rush-1406-ssh-baseline.md
+++ b/apps/cli/.changelog/next/rush-1406-ssh-baseline.md
@@ -1,0 +1,1 @@
+Fix: route remaining specialized direct SSH spawns through the shared hardened SSH baseline.

--- a/apps/cli/docs/09-ssh-transport.md
+++ b/apps/cli/docs/09-ssh-transport.md
@@ -216,6 +216,7 @@ is that remote commands are faster and dead connections self-terminate.
 Follow-ups (non-blocking):
 
 - Remove the now-unused `sshReachable` export.
-- Route the remaining specialized direct-`ssh` sites (browser CDP, cloud
-  `ProxyCommand`, drive-sync) through the shared baseline.
+- Keep any future specialized direct-`ssh` sites (for example `-L`/`-N` tunnels
+  or `ProxyCommand` relays) composed from `sshConnectOpts(...)` so they inherit
+  the shared baseline while preserving their required extra flags.
 - Evaluate the persistent `tail -f` streaming follow.

--- a/apps/cli/src/lib/browser/drivers/ssh.test.ts
+++ b/apps/cli/src/lib/browser/drivers/ssh.test.ts
@@ -290,6 +290,10 @@ describe('raw-ssh spawns reuse SSH_OPTS so unreachable hosts fail fast (#746)', 
     // ConnectTimeout is present and bounds the connect.
     expect(args).toContain('ConnectTimeout=10');
     expect(args).toContain('BatchMode=yes');
+    if (process.platform !== 'win32') {
+      expect(args).toContain('ControlMaster=auto');
+      expect(args).toContain('ControlPersist=60s');
+    }
     // Every hardened option (an `-o` and its value) precedes the target — on
     // BSD getopt (macOS) an option after the target is swallowed into the
     // remote command instead of applied.
@@ -297,6 +301,9 @@ describe('raw-ssh spawns reuse SSH_OPTS so unreachable hosts fail fast (#746)', 
     const batchIdx = args.indexOf('BatchMode=yes');
     expect(optValueIdx).toBeLessThan(targetIdx);
     expect(batchIdx).toBeLessThan(targetIdx);
+    if (process.platform !== 'win32') {
+      expect(args.indexOf('ControlMaster=auto')).toBeLessThan(targetIdx);
+    }
     // The remote command is the LAST arg (after the target).
     expect(targetIdx).toBe(args.length - 2);
   };

--- a/apps/cli/src/lib/browser/drivers/ssh.ts
+++ b/apps/cli/src/lib/browser/drivers/ssh.ts
@@ -6,11 +6,8 @@ import { parseEndpointUrl } from '../profiles.js';
 import { writeProfileRuntime, clearProfileRuntime } from '../runtime-state.js';
 import type { BrowserProfile } from '../types.js';
 // shellQuote lives in the shared ssh-exec helper (single choke point); re-export
-// so existing importers of `shellQuote` from this module keep working. SSH_OPTS
-// is the shared hardened baseline (BatchMode + ConnectTimeout + keepalive) —
-// reuse it so the raw-ssh spawns below fail fast on an unreachable host instead
-// of hanging on the default ~127s TCP timeout, rather than re-listing options.
-import { shellQuote, SSH_OPTS, assertValidSshTarget } from '../../ssh-exec.js';
+// so existing importers of `shellQuote` from this module keep working.
+import { shellQuote, assertValidSshTarget, controlOpts, sshConnectOpts } from '../../ssh-exec.js';
 export { shellQuote };
 // The `ssh -L` tunnel spawn is shared with `agents computer --host`; it lives in
 // the single ssh-tunnel helper. Calling it with no options preserves this
@@ -368,7 +365,7 @@ export async function ensureRemoteBrowser(
     const child = spawn(
       'ssh',
       [
-        ...SSH_OPTS,
+        ...sshConnectOpts(controlOpts()),
         `${user}@${host}`,
         remoteCmd,
       ],
@@ -463,7 +460,7 @@ function runSSHCommand(user: string, host: string, cmd: string): Promise<void> {
     // host is bounded by ConnectTimeout (the local 3s kill below only bounds a
     // connected-but-slow command, not the connect itself). Options precede the
     // target — see ensureRemoteBrowser.
-    const child = spawn('ssh', [...SSH_OPTS, `${user}@${host}`, cmd], {
+    const child = spawn('ssh', [...sshConnectOpts(controlOpts()), `${user}@${host}`, cmd], {
       stdio: 'ignore',
       windowsHide: true,
     });

--- a/apps/cli/src/lib/browser/service.logs.test.ts
+++ b/apps/cli/src/lib/browser/service.logs.test.ts
@@ -5,6 +5,15 @@ import { tmpdir } from 'os';
 import * as state from '../state.js';
 import * as profiles from './profiles.js';
 
+const { sshExecAsyncMock } = vi.hoisted(() => ({
+  sshExecAsyncMock: vi.fn(),
+}));
+
+vi.mock('../ssh-exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../ssh-exec.js')>('../ssh-exec.js');
+  return { ...actual, sshExecAsync: sshExecAsyncMock };
+});
+
 const TEST_HOME = path.join(tmpdir(), 'agents-cli-browser-logs-test');
 const TEST_AGENTS_DIR = path.join(TEST_HOME, '.agents');
 const TEST_LOG_DIR = path.join(TEST_HOME, 'logs');
@@ -15,8 +24,7 @@ vi.spyOn(state, 'getAgentsDir').mockReturnValue(TEST_AGENTS_DIR);
 // Spy on the single profile lookup we want to override instead of mocking
 // the whole module — the other profiles.js exports (getProfileRuntimeDir,
 // listProfiles, …) keep their real implementations and service.js loads
-// without missing-export errors. This avoids needing vi.hoisted /
-// vi.importActual, neither of which Bun's native test runner supports.
+// without missing-export errors.
 vi.spyOn(profiles, 'getProfile').mockImplementation(async (name: string) => {
   if (name === 'rush-with-logs') {
     return {
@@ -31,6 +39,15 @@ vi.spyOn(profiles, 'getProfile').mockImplementation(async (name: string) => {
       name,
       browser: 'chrome',
       endpoints: ['cdp://localhost:9223'],
+    };
+  }
+  if (name === 'rush-remote-logs') {
+    return {
+      name,
+      browser: 'chrome',
+      endpoints: ['cdp://localhost:9224'],
+      logDir: TEST_LOG_DIR,
+      logHost: 'logger-host',
     };
   }
   return null;
@@ -50,6 +67,7 @@ function reset(): void {
     // ignore
   }
   fs.mkdirSync(TEST_LOG_DIR, { recursive: true });
+  sshExecAsyncMock.mockReset();
 }
 
 function writeJsonl(filename: string, entries: Array<Record<string, unknown>>): void {
@@ -202,5 +220,22 @@ describe('BrowserService.getAppLogs', () => {
     expect(entries).toHaveLength(2);
     expect(entries[0].message).toBe('agent_ready');
     expect(entries[1].message).toBe('drift');
+  });
+
+  it('reads remote logs through sshExecAsync with the hardened SSH baseline', async () => {
+    const line = JSON.stringify({ timestamp: `${APP_DATE}T12:04:00Z`, level: 'info', message: 'remote' });
+    sshExecAsyncMock.mockResolvedValue({ code: 0, stdout: `${line}\n`, stderr: '', timedOut: false });
+    const service = new BrowserService();
+    injectTask(service, 'rush-remote-logs', 't1');
+
+    const entries = await service.getAppLogs('t1', { source: 'rush-app', lines: 1 });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toBe('remote');
+    expect(sshExecAsyncMock).toHaveBeenCalledWith(
+      'logger-host',
+      readNewestMatchingRemoteFileCommand(TEST_LOG_DIR, 'rush-app-', 1),
+      { timeoutMs: 10_000 },
+    );
   });
 });

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -1,8 +1,6 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import {
   BrowserCdpConnectionError,
   CDPClient,
@@ -47,6 +45,7 @@ import {
   uploadViaFileChooser,
 } from './upload.js';
 import { emit } from '../events.js';
+import { sshExecAsync } from '../ssh-exec.js';
 import type { TargetFilter } from './types.js';
 
 export type UploadMode = 'auto' | 'input' | 'drop' | 'chooser';
@@ -185,8 +184,6 @@ export function pickWindowTarget<T extends { type: string; url?: string; title?:
   return pages[0];
 }
 
-const execFileP = promisify(execFile);
-
 /**
  * Parse a `--since`/`--until` value. Accepts ISO-8601 absolute timestamps
  * or relative offsets like `30s`, `5m`, `2h`, `1d`.
@@ -202,11 +199,11 @@ export function parseSinceUntil(s: string): Date {
 }
 
 async function execSSH(host: string, cmd: string): Promise<string> {
-  const { stdout } = await execFileP('ssh', [host, cmd], {
-    timeout: 10_000,
-    maxBuffer: 10_000_000,
-  });
-  return stdout;
+  const res = await sshExecAsync(host, cmd, { timeoutMs: 10_000 });
+  if (res.code !== 0) {
+    throw new Error(`ssh ${host} failed${res.stderr.trim() ? `: ${res.stderr.trim()}` : ''}`);
+  }
+  return res.stdout;
 }
 
 export function readNewestMatchingRemoteFileCommand(

--- a/apps/cli/src/lib/cloud/factory.test.ts
+++ b/apps/cli/src/lib/cloud/factory.test.ts
@@ -8,6 +8,7 @@ import {
   parseComputerList,
   FactoryCloudProvider,
 } from './factory.js';
+import { SSH_OPTS } from '../ssh-exec.js';
 
 describe('resolveAutonomy', () => {
   it('passes through valid levels', () => {
@@ -52,8 +53,17 @@ describe('buildSshArgs', () => {
     // ProxyCommand routes through the relay for the named computer.
     expect(args).toContain('-o');
     expect(args.some((a) => a.startsWith('ProxyCommand=/usr/bin/droid computer ssh cloud-vm-1 --proxy'))).toBe(true);
+    // The relay ssh still composes the canonical hardened baseline.
+    for (const opt of SSH_OPTS) expect(args).toContain(opt);
+    if (process.platform !== 'win32') {
+      expect(args).toContain('ControlMaster=auto');
+      expect(args).toContain('ControlPersist=60s');
+    }
+    const targetIdx = args.indexOf('droid@cloud-vm-1');
+    expect(args.indexOf('ProxyCommand=/usr/bin/droid computer ssh cloud-vm-1 --proxy --port %p')).toBeLessThan(targetIdx);
+    expect(args.indexOf('ConnectTimeout=10')).toBeLessThan(targetIdx);
     // Connects as user@computer.
-    expect(args).toContain('droid@cloud-vm-1');
+    expect(targetIdx).toBeGreaterThanOrEqual(0);
     // The remote command is a single shell-quoted string ending the argv.
     expect(args[args.length - 1]).toBe(
       `'droid' 'exec' '--auto' 'high' '--output-format' 'stream-json' 'do a thing'`,

--- a/apps/cli/src/lib/cloud/factory.ts
+++ b/apps/cli/src/lib/cloud/factory.ts
@@ -33,6 +33,7 @@ import type {
   ProviderCapabilities,
   DroidAutonomy,
 } from './types.js';
+import { controlOpts, sshConnectOpts } from '../ssh-exec.js';
 import { MissingTargetError } from './types.js';
 import { getShimsDir } from '../state.js';
 
@@ -127,8 +128,7 @@ export function buildSshArgs(
   const remoteCmd = [remoteBin, ...remoteArgv].map(shellQuote).join(' ');
   const proxy = `ProxyCommand=${opts.droidBin} computer ssh ${computer} --proxy --port %p`;
   return [
-    '-o', proxy,
-    '-o', 'StrictHostKeyChecking=accept-new',
+    ...sshConnectOpts(controlOpts(), ['-o', proxy]),
     '-p', opts.port ?? '22',
     `${opts.user}@${computer}`,
     remoteCmd,

--- a/apps/cli/src/lib/drive-sync.test.ts
+++ b/apps/cli/src/lib/drive-sync.test.ts
@@ -172,7 +172,13 @@ describe.skipIf(process.platform === 'win32')('drive sync remote validation', ()
     expect(outcome.ok, outcome.error).toBe(true);
     const log = fs.readFileSync(logPath, 'utf-8');
     // ssh gets the remote as a bare argv element and the mkdir command as a
-    // single positional string — no local shell sees either.
+    // single positional string through sshExec's hardened baseline — no local
+    // shell sees either.
+    expect(log).toContain('ARG:BatchMode=yes');
+    expect(log).toContain('ARG:ConnectTimeout=10');
+    expect(log).toContain('ARG:ServerAliveInterval=15');
+    expect(log).toContain('ARG:ServerAliveCountMax=3');
+    expect(log).toContain('ARG:ControlMaster=auto');
     expect(log).toContain('ARG:user@host');
     expect(log).toContain('ARG:mkdir -p ~/.agents/drive');
     expect(log).toContain('ARG:user@host:~/.agents/drive/');

--- a/apps/cli/src/lib/drive-sync.ts
+++ b/apps/cli/src/lib/drive-sync.ts
@@ -14,6 +14,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { getDriveDir } from './state.js';
 import { AGENTS } from './agents.js';
+import { sshExec } from './ssh-exec.js';
 import type { AgentId } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -117,9 +118,11 @@ export async function push(): Promise<void> {
   const localDir = getDriveDir() + '/';
   const remoteSpec = `${config.remote}:~/.agents/drive/`;
 
-  // Ensure remote directory exists. ssh's command argument is one positional
-  // string; we hand it as a single argv element so no local shell sees it.
-  await execFileAsync('ssh', [config.remote, 'mkdir -p ~/.agents/drive']);
+  // Ensure remote directory exists via the shared hardened SSH primitive.
+  const mkdir = sshExec(config.remote, 'mkdir -p ~/.agents/drive', { timeoutMs: 30_000 });
+  if (mkdir.code !== 0) {
+    throw new Error(`Failed to prepare remote drive directory on ${config.remote}${mkdir.stderr.trim() ? `: ${mkdir.stderr.trim()}` : ''}`);
+  }
   await execFileAsync('rsync', ['-az', '--exclude=config.json', localDir, remoteSpec]);
 
   config.lastPush = new Date().toISOString();


### PR DESCRIPTION
## Summary
- Routed the remaining specialized SSH call sites through the shared hardened SSH baseline and control socket composition.
- Kept special flags intact: browser raw spawns still place options before target, Factory keeps its Droid `ProxyCommand`, and drive push still runs `rsync` after preparing the remote directory.
- Updated the SSH transport doc future-work note and added a generated changelog fragment.

## File:line evidence
- `apps/cli/src/lib/browser/drivers/ssh.ts:10` imports `controlOpts` and `sshConnectOpts`; `apps/cli/src/lib/browser/drivers/ssh.ts:368` and `apps/cli/src/lib/browser/drivers/ssh.ts:463` compose raw browser SSH spawns from `sshConnectOpts(controlOpts())` before the target.
- `apps/cli/src/lib/browser/service.ts:48` imports `sshExecAsync`; `apps/cli/src/lib/browser/service.ts:201` routes remote log reads through `sshExecAsync(host, cmd, { timeoutMs: 10_000 })`.
- `apps/cli/src/lib/cloud/factory.ts:36` imports `controlOpts` and `sshConnectOpts`; `apps/cli/src/lib/cloud/factory.ts:131` prepends the Droid `ProxyCommand` while still composing the shared baseline and control options.
- `apps/cli/src/lib/drive-sync.ts:17` imports `sshExec`; `apps/cli/src/lib/drive-sync.ts:122` prepares the remote drive directory through `sshExec(config.remote, 'mkdir -p ~/.agents/drive', { timeoutMs: 30_000 })`.
- Tests assert the baseline and option ordering at `apps/cli/src/lib/browser/drivers/ssh.test.ts:291`, `apps/cli/src/lib/browser/service.logs.test.ts:225`, `apps/cli/src/lib/cloud/factory.test.ts:56`, and `apps/cli/src/lib/drive-sync.test.ts:177`.
- `apps/cli/docs/09-ssh-transport.md:219` now documents that future specialized direct SSH sites must compose from `sshConnectOpts(...)`.

## Verification
- `HOME=/tmp/rush-1406-bun-home BUN_INSTALL_CACHE_DIR=/tmp/rush-1406-bun-cache bun install` succeeded in the PR clone.
- `HOME=/tmp/rush-1406-bun-home BUN_INSTALL_CACHE_DIR=/tmp/rush-1406-bun-cache bun run build` passed.
- `HOME=/tmp/rush-1406-bun-home BUN_INSTALL_CACHE_DIR=/tmp/rush-1406-bun-cache bun run test -- src/lib/browser/drivers/ssh.test.ts src/lib/browser/service.logs.test.ts src/lib/cloud/factory.test.ts src/lib/drive-sync.test.ts` passed: 4 files, 85 tests.
- `HOME=/tmp/rush-1406-bun-home BUN_INSTALL_CACHE_DIR=/tmp/rush-1406-bun-cache bunx tsc --noEmit` passed.
- Real browser CDP over SSH: direct `connectSSH('ssh://muqsit@mac-mini?port=9222', ...)` returned `{"connected":true,"port":9222,"pid":15,"product":"Chrome/142.0.7444.265"...}` and cleanup ran.
- Real drive sync: temp HOME `agents drive push` to `muqsit@yosemite-m0` completed, and `cat ~/.agents/drive/rush-1406/proof.txt` returned `ssh baseline proof`; the proof path was removed and cleanup returned `cleaned`.
- Factory/Droid real env is not authenticated here: `cloud envs --provider factory` returned `targets: []` with `Failed to list: No authenticated user with organization available`; `droid computer list` returned `Failed to list: Missing authentication`; a minimal Factory dispatch failed before a usable target with `Factory dispatch failed: Connection closed by UNKNOWN port 65535`.

Transcript: omitted from public PR; local session is available in the harness history on yosemite-s0.
