### PR TITLE
Show reasoning messages in Factory progress timeline

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1634.md
+++ b/apps/cli/.changelog/next/RUSH-1634.md
@@ -1,0 +1,1 @@
+- **Show reasoning in Factory progress timelines (RUSH-1634).** Factory detail panes now interleave assistant prose and reasoning summaries with tool calls in the Progress rail, so agent activity explains intent instead of showing only file/tool touches. Source: `apps/factory/src/core/session.summary.ts`, `apps/factory/ui/settings/components/mission-control/Timeline.tsx`.

--- a/apps/factory/src/core/session.summary.test.ts
+++ b/apps/factory/src/core/session.summary.test.ts
@@ -258,6 +258,34 @@ describe('extractSessionQuickSummary', () => {
     });
   });
 
+  test('interleaves Gemini reasoning and prose in content order', () => {
+    const lines = [
+      JSON.stringify({
+        timestamp: '2026-07-13T08:00:00.000Z',
+        type: 'message',
+        role: 'assistant',
+        content: [
+          { type: 'thinking', text: 'I should check the timeline renderer before editing it.' },
+          { type: 'text', text: 'Checking the timeline renderer before making changes.' },
+        ],
+      }),
+    ];
+
+    const details = extractSessionQuickDetails(lines.join('\n'), 'gemini');
+    expect(details.recentEvents.map((event) => event.kind)).toEqual(['message', 'reasoning']);
+    expect(details.recentEvents[0]).toMatchObject({
+      kind: 'message',
+      text: 'Checking the timeline renderer before making changes.',
+      timestamp: '2026-07-13T08:00:00.000Z',
+    });
+    expect(details.recentEvents[1]).toMatchObject({
+      kind: 'reasoning',
+      text: 'I should check the timeline renderer before editing it.',
+      timestamp: '2026-07-13T08:00:00.000Z',
+    });
+    expect(details.narrative).toBe('Checking the timeline renderer before making changes.');
+  });
+
   test('parses Codex custom apply_patch calls into edited files', () => {
     const patch = [
       '*** Begin Patch',

--- a/apps/factory/src/core/session.summary.test.ts
+++ b/apps/factory/src/core/session.summary.test.ts
@@ -161,6 +161,39 @@ describe('extractSessionQuickSummary', () => {
     expect((bash.input as { command: string }).command).toBe('ls -la');
   });
 
+  test('interleaves Claude prose, thinking, and tool calls into recent events', () => {
+    const lines = [
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-07-13T08:00:00.000Z',
+        message: {
+          content: [
+            { type: 'text', text: 'Reading the sidebar model before changing the renderer.' },
+            { type: 'thinking', thinking: 'The timeline needs one event stream, not a second prose panel.' },
+            { type: 'tool_use', id: 'tool_read', name: 'Read', input: { file_path: '/repo/Timeline.tsx' } },
+          ],
+        },
+      }),
+    ];
+
+    const details = extractSessionQuickDetails(lines.join('\n'), 'claude');
+    expect(details.recentToolCalls).toHaveLength(1);
+    expect(details.recentEvents.map((event) => event.kind)).toEqual(['tool', 'reasoning', 'message']);
+    expect(details.recentEvents[0]).toMatchObject({
+      kind: 'tool',
+      call: { name: 'Read', input: { file_path: '/repo/Timeline.tsx' } },
+      timestamp: '2026-07-13T08:00:00.000Z',
+    });
+    expect(details.recentEvents[1]).toMatchObject({
+      kind: 'reasoning',
+      text: 'The timeline needs one event stream, not a second prose panel.',
+    });
+    expect(details.recentEvents[2]).toMatchObject({
+      kind: 'message',
+      text: 'Reading the sidebar model before changing the renderer.',
+    });
+  });
+
   test('captures Codex tool calls with outputs by call_id', () => {
     const lines = [
       JSON.stringify({
@@ -186,6 +219,43 @@ describe('extractSessionQuickSummary', () => {
     expect(details.recentToolCalls.length).toBe(1);
     expect(details.recentToolCalls[0].name).toBe('shell');
     expect(details.recentToolCalls[0].output).toBe('hi');
+  });
+
+  test('interleaves Codex reasoning summaries with function calls', () => {
+    const lines = [
+      JSON.stringify({
+        timestamp: '2026-07-13T08:00:00.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'reasoning',
+          summary: [{ type: 'summary_text', text: 'Inspecting how the progress data crosses into React.' }],
+        },
+      }),
+      JSON.stringify({
+        timestamp: '2026-07-13T08:00:05.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'function_call',
+          name: 'read_file',
+          arguments: '{"path":"ui/settings/types/index.ts"}',
+          call_id: 'call_read',
+        },
+      }),
+    ];
+
+    const details = extractSessionQuickDetails(lines.join('\n'), 'codex');
+    expect(details.recentToolCalls).toHaveLength(1);
+    expect(details.recentEvents.map((event) => event.kind)).toEqual(['tool', 'reasoning']);
+    expect(details.recentEvents[0]).toMatchObject({
+      kind: 'tool',
+      call: { name: 'read_file', input: { path: 'ui/settings/types/index.ts' } },
+      timestamp: '2026-07-13T08:00:05.000Z',
+    });
+    expect(details.recentEvents[1]).toMatchObject({
+      kind: 'reasoning',
+      text: 'Inspecting how the progress data crosses into React.',
+      timestamp: '2026-07-13T08:00:00.000Z',
+    });
   });
 
   test('parses Codex custom apply_patch calls into edited files', () => {

--- a/apps/factory/src/core/session.summary.ts
+++ b/apps/factory/src/core/session.summary.ts
@@ -19,6 +19,10 @@ export interface RecentToolCall {
   timestamp?: string;
 }
 
+export type RecentEvent =
+  | { kind: 'tool'; call: RecentToolCall; timestamp?: string }
+  | { kind: 'message' | 'reasoning'; text: string; timestamp?: string };
+
 export interface SessionAttachment {
   path: string;
   label: string;
@@ -33,6 +37,7 @@ export interface SessionQuickDetails {
   recentFileTimes: Record<string, number>;
   recentTools: string[];
   recentToolCalls: RecentToolCall[];
+  recentEvents: RecentEvent[];
   attachments: SessionAttachment[];
   lastFilePath: string | null;
   /**
@@ -45,8 +50,10 @@ export interface SessionQuickDetails {
 }
 
 const MAX_RECENT_TOOL_CALLS = 24;
+const MAX_RECENT_EVENTS = 32;
 const MAX_TOOL_OUTPUT_CHARS = 4000;
 const MAX_NARRATIVE_CHARS = 160;
+const MAX_EVENT_TEXT_CHARS = 220;
 
 type MutableSessionQuickSummary = {
   filesEdited: Set<string>;
@@ -58,6 +65,7 @@ type MutableSessionQuickSummary = {
   recentFileTimes: Record<string, number>;
   recentTools: string[];
   recentToolCalls: RecentToolCall[];
+  recentEvents: RecentEvent[];
   attachments: SessionAttachment[];
   seenAttachments: Set<string>;
   pendingToolCallById: Map<string, RecentToolCall>;
@@ -81,6 +89,7 @@ function initMutableSummary(): MutableSessionQuickSummary {
     recentFileTimes: {},
     recentTools: [],
     recentToolCalls: [],
+    recentEvents: [],
     attachments: [],
     seenAttachments: new Set<string>(),
     pendingToolCallById: new Map<string, RecentToolCall>(),
@@ -115,13 +124,48 @@ function assistantTextFromContent(content: unknown): string {
   return parts.join(' ').trim();
 }
 
+function textFromReasoningSummary(summary: unknown): string {
+  if (typeof summary === 'string') return summary.trim();
+  if (!Array.isArray(summary)) return '';
+  const parts: string[] = [];
+  for (const item of summary) {
+    if (typeof item === 'string') {
+      const text = item.trim();
+      if (text) parts.push(text);
+      continue;
+    }
+    const rec = toRecord(item);
+    if (!rec) continue;
+    const text = toStringValue(rec.text).trim();
+    if (text) parts.push(text);
+  }
+  return parts.join(' ').trim();
+}
+
+function reasoningTextFromBlock(block: Record<string, unknown>): string {
+  return firstString(
+    block.thinking,
+    block.reasoning,
+    block.text,
+    textFromReasoningSummary(block.summary),
+  );
+}
+
 /** Collapse whitespace and truncate to ~160 chars at a word boundary. */
 function truncateNarrative(text: string): string {
+  return truncateText(text, MAX_NARRATIVE_CHARS);
+}
+
+function truncateEventText(text: string): string {
+  return truncateText(text, MAX_EVENT_TEXT_CHARS);
+}
+
+function truncateText(text: string, maxChars: number): string {
   const clean = text.replace(/\s+/g, ' ').trim();
-  if (clean.length <= MAX_NARRATIVE_CHARS) return clean;
-  const slice = clean.slice(0, MAX_NARRATIVE_CHARS);
+  if (clean.length <= maxChars) return clean;
+  const slice = clean.slice(0, maxChars);
   const lastSpace = slice.lastIndexOf(' ');
-  const base = lastSpace > MAX_NARRATIVE_CHARS * 0.6 ? slice.slice(0, lastSpace) : slice;
+  const base = lastSpace > maxChars * 0.6 ? slice.slice(0, lastSpace) : slice;
   return base.replace(/[\s,.;:]+$/, '') + '...';
 }
 
@@ -165,6 +209,7 @@ function stringifyToolResultContent(value: unknown): string {
 
 function pushToolCall(summary: MutableSessionQuickSummary, call: RecentToolCall, id?: string): void {
   summary.recentToolCalls.unshift(call);
+  pushRecentEvent(summary, { kind: 'tool', call, timestamp: call.timestamp });
   if (summary.recentToolCalls.length > MAX_RECENT_TOOL_CALLS) {
     const dropped = summary.recentToolCalls.pop();
     if (dropped) {
@@ -177,6 +222,24 @@ function pushToolCall(summary: MutableSessionQuickSummary, call: RecentToolCall,
     }
   }
   if (id) summary.pendingToolCallById.set(id, call);
+}
+
+function pushRecentEvent(summary: MutableSessionQuickSummary, event: RecentEvent): void {
+  summary.recentEvents.unshift(event);
+  if (summary.recentEvents.length > MAX_RECENT_EVENTS) {
+    summary.recentEvents.pop();
+  }
+}
+
+function pushTextEvent(
+  summary: MutableSessionQuickSummary,
+  kind: 'message' | 'reasoning',
+  text: string,
+  timestamp?: string,
+): void {
+  const truncated = truncateEventText(text);
+  if (!truncated) return;
+  pushRecentEvent(summary, { kind, text: truncated, timestamp });
 }
 
 function attachToolResult(
@@ -408,7 +471,17 @@ function applyClaudeEvent(summary: MutableSessionQuickSummary, event: Record<str
 
     for (const block of content) {
       const blockRecord = toRecord(block);
-      if (!blockRecord || toStringValue(blockRecord.type) !== 'tool_use') continue;
+      if (!blockRecord) continue;
+      const blockType = toStringValue(blockRecord.type);
+      if (blockType === 'text' || blockType === 'output_text' || blockType === 'input_text') {
+        pushTextEvent(summary, 'message', toStringValue(blockRecord.text), eventTimestamp);
+        continue;
+      }
+      if (blockType === 'thinking' || blockType === 'reasoning') {
+        pushTextEvent(summary, 'reasoning', reasoningTextFromBlock(blockRecord), eventTimestamp);
+        continue;
+      }
+      if (blockType !== 'tool_use') continue;
 
       const toolName = toStringValue(blockRecord.name);
       const toolInput = toRecord(blockRecord.input) || {};
@@ -561,6 +634,11 @@ function applyCodexEvent(summary: MutableSessionQuickSummary, event: Record<stri
   if (!payload) return;
   const payloadType = toStringValue(payload.type);
 
+  if (payloadType === 'reasoning') {
+    pushTextEvent(summary, 'reasoning', reasoningTextFromBlock(payload), eventTimestamp);
+    return;
+  }
+
   if (payloadType === 'function_call_output') {
     const callId = toStringValue(payload.call_id) || toStringValue(payload.id);
     if (!callId) return;
@@ -592,6 +670,7 @@ function applyCodexEvent(summary: MutableSessionQuickSummary, event: Record<stri
   if (payloadType === 'message' && toStringValue(payload.role) === 'assistant') {
     const text = assistantTextFromContent(payload.content);
     if (text) summary.lastAssistantText = text;
+    if (text) pushTextEvent(summary, 'message', text, eventTimestamp);
     return;
   }
 
@@ -621,6 +700,16 @@ function applyGeminiEvent(summary: MutableSessionQuickSummary, event: Record<str
     if (role === 'assistant') {
       const text = assistantTextFromContent(event.content) || toStringValue(event.text).trim();
       if (text) summary.lastAssistantText = text;
+      if (text) pushTextEvent(summary, 'message', text, eventTimestamp);
+      const content = Array.isArray(event.content) ? event.content : [];
+      for (const block of content) {
+        const rec = toRecord(block);
+        if (!rec) continue;
+        const type = toStringValue(rec.type);
+        if (type === 'thinking' || type === 'reasoning') {
+          pushTextEvent(summary, 'reasoning', reasoningTextFromBlock(rec), eventTimestamp);
+        }
+      }
     }
     return;
   }
@@ -709,6 +798,7 @@ export function extractSessionQuickDetails(
       recentFileTimes: {},
       recentTools: [],
       recentToolCalls: [],
+      recentEvents: [],
       attachments: [],
       lastFilePath: null,
       narrative: '',
@@ -739,6 +829,7 @@ export function extractSessionQuickDetails(
     recentFileTimes: summary.recentFileTimes,
     recentTools: summary.recentTools.slice(0, 32),
     recentToolCalls: summary.recentToolCalls.slice(0, MAX_RECENT_TOOL_CALLS),
+    recentEvents: summary.recentEvents.slice(0, MAX_RECENT_EVENTS),
     attachments: summary.attachments.slice(0, 24),
     lastFilePath: recentFilesSource[0] || null,
     narrative: truncateNarrative(summary.lastAssistantText),

--- a/apps/factory/src/core/session.summary.ts
+++ b/apps/factory/src/core/session.summary.ts
@@ -698,17 +698,28 @@ function applyGeminiEvent(summary: MutableSessionQuickSummary, event: Record<str
   if (eventType === 'message' || eventType === 'assistant') {
     const role = toStringValue(event.role) || 'assistant';
     if (role === 'assistant') {
+      const content = Array.isArray(event.content) ? event.content : [];
       const text = assistantTextFromContent(event.content) || toStringValue(event.text).trim();
       if (text) summary.lastAssistantText = text;
-      if (text) pushTextEvent(summary, 'message', text, eventTimestamp);
-      const content = Array.isArray(event.content) ? event.content : [];
-      for (const block of content) {
-        const rec = toRecord(block);
-        if (!rec) continue;
-        const type = toStringValue(rec.type);
-        if (type === 'thinking' || type === 'reasoning') {
-          pushTextEvent(summary, 'reasoning', reasoningTextFromBlock(rec), eventTimestamp);
+
+      if (content.length > 0) {
+        let sawTextBlock = false;
+        for (const block of content) {
+          const rec = toRecord(block);
+          if (!rec) continue;
+          const type = toStringValue(rec.type);
+          if (type === 'text' || type === 'output_text' || type === 'input_text') {
+            sawTextBlock = true;
+            pushTextEvent(summary, 'message', toStringValue(rec.text), eventTimestamp);
+            continue;
+          }
+          if (type === 'thinking' || type === 'reasoning') {
+            pushTextEvent(summary, 'reasoning', reasoningTextFromBlock(rec), eventTimestamp);
+          }
         }
+        if (!sawTextBlock) pushTextEvent(summary, 'message', toStringValue(event.text), eventTimestamp);
+      } else {
+        pushTextEvent(summary, 'message', text, eventTimestamp);
       }
     }
     return;

--- a/apps/factory/src/vscode/terminals.vscode.ts
+++ b/apps/factory/src/vscode/terminals.vscode.ts
@@ -798,6 +798,7 @@ export interface TerminalDetail {
   recentFileTimes?: Record<string, number>;
   recentTools?: string[];
   recentToolCalls?: import('../core/session.summary').RecentToolCall[];
+  recentEvents?: import('../core/session.summary').RecentEvent[];
   attachments?: SessionAttachment[];
   lastFilePath?: string | null;
   narrative?: string; // Agent's most recent substantive assistant prose (rolling summary line)
@@ -1172,6 +1173,7 @@ export async function getTerminalsByAgentType(
       results[data.index].recentFileTimes = data.quickDetails.recentFileTimes;
       results[data.index].recentTools = data.quickDetails.recentTools;
       results[data.index].recentToolCalls = data.quickDetails.recentToolCalls;
+      results[data.index].recentEvents = data.quickDetails.recentEvents;
       results[data.index].attachments = data.quickDetails.attachments;
       results[data.index].lastFilePath = data.quickDetails.lastFilePath;
       results[data.index].narrative = data.quickDetails.narrative;

--- a/apps/factory/ui/settings/components/mission-control/TerminalDetail.tsx
+++ b/apps/factory/ui/settings/components/mission-control/TerminalDetail.tsx
@@ -29,6 +29,7 @@ export function filePillColor(touchedAtMs: number | undefined, now: number): str
 export function TerminalExpandedDetail({ terminal }: { terminal: TerminalInfo }) {
   const now = useNow(5000)
   const todos = latestTodos(terminal.recentToolCalls)
+  const timelineEvents = terminal.recentEvents ?? (terminal.recentToolCalls ?? []).map((call) => ({ kind: 'tool' as const, call, timestamp: call.timestamp }))
   const cwdDisplay = terminal.cwd ? terminal.cwd.replace(/^\/Users\/[^/]+/, '~') : null
   const linkStyle: React.CSSProperties = {
     background: 'transparent',
@@ -103,13 +104,13 @@ export function TerminalExpandedDetail({ terminal }: { terminal: TerminalInfo })
           </div>
         </div>
       )}
-      {/* Progress timeline: the recent tool calls as a vertical rail, oldest -> now —
+      {/* Progress timeline: recent transcript events as a vertical rail, oldest -> now —
           the same VerticalTimeline the headless/cloud detail uses, so terminal, headless
-          and cloud detail panes read identically (was a flat "Recent tools" list). */}
-      {terminal.recentToolCalls && terminal.recentToolCalls.length > 0 && (
+          and cloud detail panes read identically. */}
+      {timelineEvents.length > 0 && (
         <div className="sw-unified-detail-section">
-          <div className="sw-section-label">Progress <span className="sw-section-count">{Math.min(terminal.recentToolCalls.length, 8)} recent</span></div>
-          <VerticalTimeline recent={terminal.recentToolCalls} nowMs={now} />
+          <div className="sw-section-label">Progress <span className="sw-section-count">{Math.min(timelineEvents.length, 8)} recent</span></div>
+          <VerticalTimeline recent={timelineEvents} nowMs={now} />
         </div>
       )}
       {todos.length > 0 && (

--- a/apps/factory/ui/settings/components/mission-control/Timeline.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/Timeline.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from 'bun:test'
-import { toolTarget, stepAgo } from './Timeline'
-import type { RecentToolCall } from './floorModel'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { toolTarget, stepAgo, VerticalTimeline } from './Timeline'
+import type { RecentEvent, RecentToolCall } from './floorModel'
 
 const NOW = 1_700_000_000_000
 
@@ -45,5 +47,23 @@ describe('stepAgo — relative age of a tool step', () => {
   })
   test('a future timestamp clamps to "now" (no negative ages)', () => {
     expect(stepAgo(new Date(NOW + 10_000).toISOString(), NOW)).toBe('now')
+  })
+})
+
+describe('VerticalTimeline — rich progress events', () => {
+  test('renders prose and reasoning rows between tool calls oldest-to-newest', () => {
+    const recent: RecentEvent[] = [
+      { kind: 'tool', call: { name: 'Edit', input: { file_path: '/repo/Timeline.tsx' }, timestamp: new Date(NOW - 10_000).toISOString() }, timestamp: new Date(NOW - 10_000).toISOString() },
+      { kind: 'reasoning', text: 'The detail pane should show why the next file touch happens.', timestamp: new Date(NOW - 20_000).toISOString() },
+      { kind: 'message', text: 'Reading the current timeline component before editing.', timestamp: new Date(NOW - 30_000).toISOString() },
+      { kind: 'tool', call: { name: 'Read', input: { file_path: '/repo/TerminalDetail.tsx' }, timestamp: new Date(NOW - 40_000).toISOString() }, timestamp: new Date(NOW - 40_000).toISOString() },
+    ]
+
+    const html = renderToStaticMarkup(React.createElement(VerticalTimeline, { recent, nowMs: NOW }))
+    expect(html.indexOf('Read')).toBeLessThan(html.indexOf('Reading the current timeline component before editing.'))
+    expect(html.indexOf('Reading the current timeline component before editing.')).toBeLessThan(html.indexOf('The detail pane should show why the next file touch happens.'))
+    expect(html.indexOf('The detail pane should show why the next file touch happens.')).toBeLessThan(html.indexOf('Edit'))
+    expect(html).toContain('class="note message"')
+    expect(html).toContain('class="note reasoning"')
   })
 })

--- a/apps/factory/ui/settings/components/mission-control/Timeline.tsx
+++ b/apps/factory/ui/settings/components/mission-control/Timeline.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { RecentToolCall } from './floorModel'
+import type { RecentEvent, RecentToolCall } from './floorModel'
 
 // Progress timeline from a session's recent tool calls. Two affordances share the same
 // step derivation (toolTarget / stepAgo below):
@@ -49,7 +49,7 @@ export function stepAgo(timestamp: string | undefined, nowMs: number): string {
 }
 
 /** Newest-first `recent` -> oldest-first steps, capped to `limit` most-recent calls. */
-function orderedSteps(recent: RecentToolCall[], limit: number): RecentToolCall[] {
+function orderedSteps<T>(recent: T[], limit: number): T[] {
   return recent.slice(0, limit).reverse()
 }
 
@@ -85,27 +85,41 @@ export function MiniTimeline({ recent, nowMs, limit = 4 }: MiniTimelineProps) {
 }
 
 interface VerticalTimelineProps {
-  recent: RecentToolCall[]
+  recent: RecentEvent[]
   nowMs: number
   /** How many recent steps to show (default 8). */
   limit?: number
 }
 
-/** Detail-pane vertical timeline: last ~8 tool steps as a connected rail. */
+function eventTimestamp(event: RecentEvent): string | undefined {
+  return event.kind === 'tool' ? event.call.timestamp : event.timestamp
+}
+
+/** Detail-pane vertical timeline: last ~8 progress events as a connected rail. */
 export function VerticalTimeline({ recent, nowMs, limit = 8 }: VerticalTimelineProps) {
   if (recent.length === 0) return null
   const steps = orderedSteps(recent, limit)
   const lastIndex = steps.length - 1
   return (
     <ul className="vtl">
-      {steps.map((call, i) => {
+      {steps.map((event, i) => {
         const now = i === lastIndex
+        if (event.kind !== 'tool') {
+          return (
+            <li key={`${event.kind}-${event.timestamp || i}-${i}`} className={`${now ? 'now ' : ''}note ${event.kind}`}>
+              <span className="mk" />
+              <span className="msg">{event.text}</span>
+              <span className="ago">{stepAgo(event.timestamp, nowMs)}</span>
+            </li>
+          )
+        }
+        const call = event.call
         const target = toolTarget(call)
         return (
           <li key={`${call.name}-${i}`} className={now ? 'now' : ''}>
             <span className="mk" />
             <span className="nm">{call.name}{target && <span className="t mono"> {target}</span>}</span>
-            <span className="ago">{stepAgo(call.timestamp, nowMs)}</span>
+            <span className="ago">{stepAgo(eventTimestamp(event), nowMs)}</span>
           </li>
         )
       })}

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -1945,12 +1945,12 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
                 <TodoChecklist todos={a.todos} />
               </div>
             )}
-            {/* Progress timeline: the recent tool calls as a vertical rail, oldest -> now.
+            {/* Progress timeline: recent transcript events as a vertical rail, oldest -> now.
                 For cloud rows the existing CloudActivityFeed still drives the AgentDetailView. */}
-            {a.recent.length > 0 && (
+            {((a.recentEvents?.length ?? 0) > 0 || a.recent.length > 0) && (
               <div className="sw-unified-detail-section">
-                <div className="sw-section-label">Progress <span className="sw-section-count">{Math.min(a.recent.length, 8)} recent</span></div>
-                <VerticalTimeline recent={a.recent} nowMs={nowMs} />
+                <div className="sw-section-label">Progress <span className="sw-section-count">{Math.min(a.recentEvents?.length || a.recent.length, 8)} recent</span></div>
+                <VerticalTimeline recent={a.recentEvents?.length ? a.recentEvents : a.recent.map((call) => ({ kind: 'tool' as const, call, timestamp: call.timestamp }))} nowMs={nowMs} />
               </div>
             )}
             {/* Streaming Activity feed: the recent assistant messages (markdown), newest at

--- a/apps/factory/ui/settings/components/mission-control/floor.css
+++ b/apps/factory/ui/settings/components/mission-control/floor.css
@@ -700,6 +700,10 @@
 .swarmify-root .vtl li.now .mk { box-shadow: 0 0 0 3px var(--brand-ring); animation: sw-tlpulse 1.3s infinite; }
 .swarmify-root .vtl li .nm { font-family: "Geist Mono", monospace; font-size: 11.5px; color: var(--ds-text); }
 .swarmify-root .vtl li .nm .t { color: var(--status-running); }
+.swarmify-root .vtl li.note { align-items: flex-start; }
+.swarmify-root .vtl li.note .mk { width: 7px; height: 7px; left: -4.5px; top: 6px; background: var(--ds-text-faint); box-shadow: none; }
+.swarmify-root .vtl li.note.reasoning .mk { background: var(--ds-text-dim); }
+.swarmify-root .vtl li.note .msg { min-width: 0; color: var(--ds-text-muted); font-size: 12px; line-height: 1.35; font-style: italic; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
 .swarmify-root .vtl li .ago { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--ds-text-faint); margin-left: auto; flex: none; }
 .swarmify-root .vtl li.now .nm { font-weight: 650; }
 

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -30,7 +30,7 @@ import {
   type TodoItem,
   type FloorAttachment,
 } from './floorModel'
-import type { UnifiedTask, RecentToolCall, ProjectRule, SessionAttachment } from '../../types'
+import type { UnifiedTask, RecentEvent, RecentToolCall, ProjectRule, SessionAttachment } from '../../types'
 import { detectPlanFiles, extractPlanCandidates, type PlanFile, type PlanFileCandidate } from '../../utils/planDetector'
 
 // Last non-empty todo set per session, so the checklist survives the recent-tool
@@ -97,6 +97,7 @@ export interface UnifiedAgentLike {
     currentActivity?: string
     narrative?: string
     recentToolCalls?: RecentToolCall[]
+    recentEvents?: RecentEvent[]
     recentFiles?: string[]
     attachments?: SessionAttachment[]
   } | null
@@ -533,6 +534,7 @@ export function toFloorAgentFromUnified(
     // (currentActivity) when it hasn't spoken between tool calls yet.
     summary: u.terminal?.narrative || u.terminal?.currentActivity || '',
     recent: u.terminal?.recentToolCalls ?? [],
+    recentEvents: u.terminal?.recentEvents ?? (u.terminal?.recentToolCalls ?? []).map((call) => ({ kind: 'tool', call, timestamp: call.timestamp })),
     // Per-session rate limit (RUSH-1523): CLI flag or detect from last messages.
     rateLimited: detectSessionRateLimited(u.agent?.rateLimited, messages, resp),
   }
@@ -648,9 +650,10 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     // wrote no todo list; the CLI now carries this for remote/device-dispatched agents.
     todos: remoteTodos,
     // Remote = summary only: the sweep carries the session's task line (topic) / last
-    // response but no tool calls yet, so recent stays empty until Tier-2 enrichment.
+    // response but no tool calls yet, so progress stays empty until Tier-2 enrichment.
     summary: r.topic || r.lastResponse || '',
     recent: [],
+    recentEvents: [],
     // tmux %pane handle + where it's being viewed, surfaced on the card.
     pane: r.tmuxPane || undefined,
     viewingIn: r.viewingIn || undefined,

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -13,10 +13,10 @@
 // (+ DESIGN.md). Field names mirror the prototype's AGENTS / TICKETS mock objects
 // so the port is a 1:1 translation, not a redesign.
 
-import type { UnifiedTask, RecentToolCall } from '../../types'
+import type { UnifiedTask, RecentEvent, RecentToolCall } from '../../types'
 import type { PlanFile } from '../../utils/planDetector'
 
-export type { RecentToolCall }
+export type { RecentEvent, RecentToolCall }
 
 // ---------- project resolution ----------
 //
@@ -174,6 +174,7 @@ export interface FloorAgent {
   todos: TodoItem[]      // task checklist from the latest TodoWrite; empty when none
   summary: string        // the "what is it doing" line (CLI-provided); '' when unknown
   recent: RecentToolCall[] // rolling window of this session's recent tool calls; [] when none
+  recentEvents?: RecentEvent[] // rolling window of detail timeline events; [] when none
   pane?: string          // tmux `%N` pane handle for unique addressing; undefined for non-tmux
   viewingIn?: string     // "Codium tab 3" / "Ghostty tab 2" / "detached"; undefined when unknown
   /**

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -590,6 +590,21 @@ const detailTerminal: TerminalDetail = {
     { name: 'Read', input: { file_path: '/rush/src/db/policy.ts' }, timestamp: new Date(Date.now() - 120_000).toISOString() },
     { name: 'Grep', input: { pattern: 'policy_v1' }, timestamp: new Date(Date.now() - 200_000).toISOString() },
   ],
+  recentEvents: [
+    { kind: 'tool', call: { name: 'Bash', input: { command: 'bun test tests/rls_policy.test.ts' }, timestamp: new Date(Date.now() - 8_000).toISOString() }, timestamp: new Date(Date.now() - 8_000).toISOString() },
+    { kind: 'message', text: 'One service_role policy is still failing; rerunning the focused RLS test after narrowing the predicate.', timestamp: new Date(Date.now() - 16_000).toISOString() },
+    { kind: 'tool', call: { name: 'Edit', input: { file_path: '/rush/supabase/migrations/20260708_policy.sql' }, timestamp: new Date(Date.now() - 30_000).toISOString() }, timestamp: new Date(Date.now() - 30_000).toISOString() },
+    { kind: 'reasoning', text: 'The failing assertion points at the SELECT policy, so the migration predicate should match the old policy_v1 role check.', timestamp: new Date(Date.now() - 45_000).toISOString() },
+    { kind: 'tool', call: { name: 'TodoWrite', input: { todos: [
+      { content: 'Port policy_v1 rules to policy table', status: 'completed' },
+      { content: 'Write the down-migration', status: 'completed' },
+      { content: 'Rewrite the service_role policy', status: 'in_progress' },
+      { content: 'Add RLS regression test', status: 'pending' },
+    ] }, timestamp: new Date(Date.now() - 60_000).toISOString() }, timestamp: new Date(Date.now() - 60_000).toISOString() },
+    { kind: 'message', text: 'Ported the base policies; checking the call sites before touching the down-migration.', timestamp: new Date(Date.now() - 90_000).toISOString() },
+    { kind: 'tool', call: { name: 'Read', input: { file_path: '/rush/src/db/policy.ts' }, timestamp: new Date(Date.now() - 120_000).toISOString() }, timestamp: new Date(Date.now() - 120_000).toISOString() },
+    { kind: 'tool', call: { name: 'Grep', input: { pattern: 'policy_v1' }, timestamp: new Date(Date.now() - 200_000).toISOString() }, timestamp: new Date(Date.now() - 200_000).toISOString() },
+  ],
 } as TerminalDetail
 
 function Detail() {

--- a/apps/factory/ui/settings/types/index.ts
+++ b/apps/factory/ui/settings/types/index.ts
@@ -344,6 +344,10 @@ export interface RecentToolCall {
   timestamp?: string
 }
 
+export type RecentEvent =
+  | { kind: 'tool'; call: RecentToolCall; timestamp?: string }
+  | { kind: 'message' | 'reasoning'; text: string; timestamp?: string }
+
 export interface SessionAttachment {
   path: string
   label: string
@@ -373,6 +377,7 @@ export interface TerminalDetail {
   recentFileTimes?: Record<string, number>
   recentTools?: string[]
   recentToolCalls?: RecentToolCall[]
+  recentEvents?: RecentEvent[]
   attachments?: SessionAttachment[]
   lastFilePath?: string | null
   narrative?: string


### PR DESCRIPTION
## Summary

Factory session summaries now emit a `RecentEvent[]` stream that keeps tool calls, assistant prose, and visible reasoning summaries in transcript order. The Factory detail Progress rails render that stream so the sidebar shows why the agent is touching files, while compact feed cards keep using the existing tool-only timeline.

## Evidence

- `apps/factory/src/core/session.summary.ts:22` defines `RecentEvent` with `tool`, `message`, and `reasoning` variants.
- `apps/factory/src/core/session.summary.ts:476` pushes assistant text blocks into the event stream, and `apps/factory/src/core/session.summary.ts:480` pushes visible `thinking` / `reasoning` blocks.
- `apps/factory/src/core/session.summary.ts:637` parses Codex `reasoning` payload summaries into the same stream.
- `apps/factory/src/core/session.summary.ts:831` keeps `recentToolCalls` tool-only, and `apps/factory/src/core/session.summary.ts:832` returns the richer `recentEvents`.
- `apps/factory/ui/settings/components/mission-control/Timeline.tsx:107` renders prose/reasoning rows distinctly from tool rows in `VerticalTimeline`.
- `apps/factory/ui/settings/components/mission-control/TerminalDetail.tsx:32` prefers `terminal.recentEvents` and falls back to tool-only legacy data.
- `apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx:1953` feeds richer timeline events into the shared detail pane rail.

## Verification

- `TMPDIR=/tmp bun test src/core/session.summary.test.ts ui/settings/components/mission-control/Timeline.test.ts --timeout 30000` from `apps/factory` passed: 26 tests.
- `TMPDIR=/tmp bun run compile` from `apps/factory` passed: TypeScript plus settings/editor Vite builds.
- `TMPDIR=/tmp bunx tsc --noEmit` from `apps/cli` passed.
- `TMPDIR=/tmp bun test scripts/gen-changelog.test.ts --timeout 30000` from `apps/cli` passed: 5 tests.
- Visual check: `/tmp/factory-progress-rush-1634.png` shows the detail Progress rail with tool rows interleaved with italic prose/reasoning rows.

Transcript omitted because `phnx-labs/agents-cli` is public.
