### PR TITLE
feat: add share publish endpoint seam

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1794.md
+++ b/apps/cli/.changelog/next/RUSH-1794.md
@@ -1,3 +1,1 @@
-## Added
-
-- Add the `agents share <file>` publish path, sending an authenticated PUT to the configured share endpoint with `--slug` and `--expire` support.
+- **Extract a reusable share-publish endpoint seam (RUSH-1794).** `agents share <file>` now delegates its authenticated PUT (bearer token, `--slug`, `--expire`) through `publishToEndpoint`, decoupled from config/keychain loading, with a real-HTTP test asserting the wire contract. Source: `apps/cli/src/lib/share/publish.ts`.

--- a/apps/cli/.changelog/next/RUSH-1794.md
+++ b/apps/cli/.changelog/next/RUSH-1794.md
@@ -1,0 +1,3 @@
+## Added
+
+- Add the `agents share <file>` publish path, sending an authenticated PUT to the configured share endpoint with `--slug` and `--expire` support.

--- a/apps/cli/src/lib/share/publish.test.ts
+++ b/apps/cli/src/lib/share/publish.test.ts
@@ -1,8 +1,9 @@
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { parseExpire, slugify, detectProject, defaultSlug, attachOgCover } from './publish.js';
+import { parseExpire, slugify, detectProject, defaultSlug, attachOgCover, publishToEndpoint } from './publish.js';
 import { renderWorkerScript } from './worker-template.js';
 
 describe('attachOgCover', () => {
@@ -56,6 +57,79 @@ describe('attachOgCover', () => {
       }),
     );
     expect(r.coverUrl).toBeUndefined();
+  });
+});
+
+describe('publishToEndpoint', () => {
+  it('PUTs the HTML body to <base>/<slug> with bearer auth, expiry, and content type', async () => {
+    const htmlPath = join(mkdtempSync(join(tmpdir(), 'agents-share-publish-')), 'plan.html');
+    writeFileSync(htmlPath, '<!doctype html><title>Plan</title><main>done</main>');
+
+    let seen: {
+      method?: string;
+      url?: string;
+      authorization?: string;
+      contentType?: string;
+      expiresAt?: string;
+      body?: string;
+    } = {};
+
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        seen = {
+          method: req.method,
+          url: req.url,
+          authorization: req.headers.authorization,
+          contentType: req.headers['content-type'],
+          expiresAt: req.headers['x-share-expires-at'],
+          body: Buffer.concat(chunks).toString('utf8'),
+        };
+        res.writeHead(201).end('ok');
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      const result = await publishToEndpoint(
+        htmlPath,
+        { baseUrl: `${baseUrl}/`, token: 'secret-token' },
+        { slug: '/ticket-plan', expire: '2030-01-01', cover: false },
+      );
+
+      expect(result.url).toBe(`${baseUrl}/ticket-plan`);
+      expect(result.expiresAt).toBe(new Date('2030-01-01').toISOString());
+      expect(seen).toEqual({
+        method: 'PUT',
+        url: '/ticket-plan',
+        authorization: 'Bearer secret-token',
+        contentType: 'text/html; charset=utf-8',
+        expiresAt: new Date('2030-01-01').toISOString(),
+        body: '<!doctype html><title>Plan</title><main>done</main>',
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('throws with the failed status when the endpoint rejects the publish', async () => {
+    const htmlPath = join(mkdtempSync(join(tmpdir(), 'agents-share-reject-')), 'plan.html');
+    writeFileSync(htmlPath, '<h1>nope</h1>');
+    await expect(
+      publishToEndpoint(
+        htmlPath,
+        { baseUrl: 'https://share.example.test', token: 'secret-token' },
+        {
+          slug: 'denied',
+          cover: false,
+          uploader: async () => ({ ok: false, status: 403 }),
+        },
+      ),
+    ).rejects.toThrow("Publish failed (403) for https://share.example.test/denied");
   });
 });
 

--- a/apps/cli/src/lib/share/publish.ts
+++ b/apps/cli/src/lib/share/publish.ts
@@ -14,11 +14,16 @@ import { readShareConfig, readWriteToken } from './config.js';
 import { captureCover, OG_WIDTH, OG_HEIGHT, OG_SCALE } from './capture.js';
 import { deriveMeta, injectOgMeta } from './og.js';
 
-type PutFn = (
+export type PutFn = (
   url: string,
   body: Buffer,
   headers: Record<string, string>,
 ) => Promise<{ ok: boolean; status: number; url?: string }>;
+
+export interface PublishEndpoint {
+  baseUrl: string;
+  token: string;
+}
 
 export interface PublishOptions {
   slug?: string;
@@ -28,11 +33,7 @@ export interface PublishOptions {
   /** Generate + attach an OG cover for HTML pages (default true). */
   cover?: boolean;
   /** DI seam for tests — override the real HTTP PUT. */
-  uploader?: (
-    url: string,
-    body: Buffer,
-    headers: Record<string, string>,
-  ) => Promise<{ ok: boolean; status: number; url?: string }>;
+  uploader?: PutFn;
   /** DI seam for tests — override cover capture (returns a PNG buffer or null). */
   capturer?: (htmlPath: string) => Promise<Buffer | null>;
 }
@@ -148,9 +149,17 @@ export async function publishFile(
     );
   }
   const token = readWriteToken();
+  return publishToEndpoint(filePath, { baseUrl: cfg.baseUrl, token }, opts);
+}
+
+export async function publishToEndpoint(
+  filePath: string,
+  endpoint: PublishEndpoint,
+  opts: PublishOptions = {},
+): Promise<{ url: string; expiresAt?: string; coverUrl?: string }> {
   const slug = (opts.slug ?? defaultSlug(filePath)).replace(/^\/+/, '');
   const expiresAt = parseExpire(opts.expire);
-  const pageUrl = `${cfg.baseUrl}/${slug}`;
+  const pageUrl = `${endpoint.baseUrl.replace(/\/+$/, '')}/${slug}`;
 
   const put =
     opts.uploader ??
@@ -159,7 +168,7 @@ export async function publishFile(
       return { ok: res.ok, status: res.status, url: u };
     });
   const authHeaders = (contentType: string): Record<string, string> => {
-    const h: Record<string, string> = { authorization: `Bearer ${token}`, 'content-type': contentType };
+    const h: Record<string, string> = { authorization: `Bearer ${endpoint.token}`, 'content-type': contentType };
     if (expiresAt) h['x-share-expires-at'] = expiresAt;
     return h;
   };


### PR DESCRIPTION
## Summary
- Split the existing `agents share <file>` publish path so saved config/token loading calls a reusable endpoint publisher.
- Added coverage for the real PUT contract: `<base>/<slug>`, bearer token, HTML content type, expiry header, and body.
- Added the RUSH-1794 changelog fragment under `.changelog/next/`.

## Evidence
- `apps/cli/src/lib/share/publish.ts:17` exports the `PutFn` uploader seam.
- `apps/cli/src/lib/share/publish.ts:23` defines the endpoint input (`baseUrl`, `token`).
- `apps/cli/src/lib/share/publish.ts:151` reads the stored write token and delegates to the endpoint publisher.
- `apps/cli/src/lib/share/publish.ts:155` implements `publishToEndpoint`.
- `apps/cli/src/lib/share/publish.ts:162` builds `<base>/<slug>`.
- `apps/cli/src/lib/share/publish.ts:167` performs the authed PUT via `fetch` when no uploader is injected.
- `apps/cli/src/lib/share/publish.ts:170` sends `Authorization: Bearer <token>`, `content-type`, and optional `x-share-expires-at`.
- `apps/cli/src/lib/share/publish.test.ts:63` starts a local HTTP service and asserts the received method, path, headers, expiry, and HTML body.

## Verification
- `BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache TMPDIR=/tmp bun install`
- `BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache TMPDIR=/tmp bun run test src/lib/share/publish.test.ts` (18 passed)
- `BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache TMPDIR=/tmp bunx tsc --noEmit`
