### PR TITLE
fix(cli): type share config wiring

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1795.md
+++ b/apps/cli/.changelog/next/RUSH-1795.md
@@ -1,0 +1,1 @@
+- **Wire `agents share` config and secrets (RUSH-1795).** The share endpoint now has a typed `Meta.share` config surface, with regression coverage for fleet-synced endpoint metadata and the keychain-backed `share` secrets bundle token. Source: `apps/cli/src/lib/types.ts`, `apps/cli/src/lib/share/config.ts`.

--- a/apps/cli/src/lib/share/config.test.ts
+++ b/apps/cli/src/lib/share/config.test.ts
@@ -1,0 +1,132 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { KeychainBackend } from '../secrets/index.js';
+
+class MemBackend implements KeychainBackend {
+  store = new Map<string, string>();
+
+  has(item: string): boolean {
+    return this.store.has(item);
+  }
+
+  get(item: string): string {
+    const value = this.store.get(item);
+    if (value === undefined) throw new Error(`missing ${item}`);
+    return value;
+  }
+
+  getBatch(items: string[]): Map<string, string> {
+    const out = new Map<string, string>();
+    for (const item of items) {
+      const value = this.store.get(item);
+      if (value !== undefined) out.set(item, value);
+    }
+    return out;
+  }
+
+  set(item: string, value: string): void {
+    this.store.set(item, value);
+  }
+
+  delete(item: string): boolean {
+    return this.store.delete(item);
+  }
+
+  list(prefix: string): string[] {
+    return [...this.store.keys()].filter((item) => item.startsWith(prefix));
+  }
+}
+
+let originalHome: string | undefined;
+let home: string;
+let restoreBackend: KeychainBackend | null = null;
+
+async function loadShareConfig() {
+  const secrets = await import('../secrets/index.js');
+  const mem = new MemBackend();
+  restoreBackend = secrets.setKeychainBackendForTest(mem);
+  return {
+    ...(await import('./config.js')),
+    ...(await import('../secrets/bundles.js')),
+    ...(await import('../state.js')),
+    secrets,
+    mem,
+  };
+}
+
+describe('share config wiring', () => {
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-share-config-'));
+    process.env.HOME = home;
+    vi.resetModules();
+    restoreBackend = null;
+  });
+
+  afterEach(async () => {
+    const secrets = await import('../secrets/index.js');
+    secrets.setKeychainBackendForTest(restoreBackend);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(home, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('persists the endpoint in Meta.share and trims baseUrl on read', async () => {
+    const { writeShareConfig, readShareConfig, readMeta } = await loadShareConfig();
+
+    writeShareConfig({
+      baseUrl: 'https://share.example.com///',
+      accountId: 'acct-123',
+      workerName: 'agents-share',
+      bucketName: 'agents-share',
+      domain: 'share.example.com',
+    });
+
+    expect(readMeta().share).toEqual({
+      baseUrl: 'https://share.example.com///',
+      accountId: 'acct-123',
+      workerName: 'agents-share',
+      bucketName: 'agents-share',
+      domain: 'share.example.com',
+    });
+    expect(readShareConfig()).toEqual({
+      baseUrl: 'https://share.example.com',
+      accountId: 'acct-123',
+      workerName: 'agents-share',
+      bucketName: 'agents-share',
+      domain: 'share.example.com',
+    });
+  });
+
+  it('stores and reads the write token from the share secrets bundle', async () => {
+    const {
+      SHARE_BUNDLE,
+      SHARE_TOKEN_KEY,
+      readBundle,
+      readWriteToken,
+      secrets,
+      storeWriteToken,
+    } = await loadShareConfig();
+
+    storeWriteToken('token-123');
+
+    const bundle = readBundle(SHARE_BUNDLE);
+    expect(bundle.vars[SHARE_TOKEN_KEY]).toBe(`keychain:${SHARE_TOKEN_KEY}`);
+    expect(readWriteToken()).toBe('token-123');
+    expect(secrets.secretsKeychainItem(SHARE_BUNDLE, SHARE_TOKEN_KEY)).toBe(
+      'agents-cli.secrets.share.SHARE_WRITE_TOKEN',
+    );
+  });
+
+  it('returns null until all required Meta.share fields are present', async () => {
+    const { readShareConfig, updateMeta } = await loadShareConfig();
+
+    updateMeta((meta) => ({ ...meta, share: { baseUrl: 'https://share.example.com' } }));
+
+    expect(readShareConfig()).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -69,6 +69,20 @@ export interface BudgetConfig {
   require_confirm_over?: number;
 }
 
+/** Fleet-synced endpoint config for `agents share`. Secrets stay in the `share` bundle. */
+export interface ShareMeta {
+  /** Public base, e.g. `https://share.agents-cli.sh` or a `workers.dev` endpoint. */
+  baseUrl?: string;
+  /** Cloudflare account id that owns the Worker/R2 resources. */
+  accountId?: string;
+  /** Cloudflare Worker name. */
+  workerName?: string;
+  /** R2 bucket name. */
+  bucketName?: string;
+  /** Custom domain when mapped. */
+  domain?: string;
+}
+
 /** Preview features that users can opt into via `agents beta`. */
 export type BetaFeatureName = 'drive' | 'factory' | 'session-sync';
 
@@ -803,13 +817,7 @@ export interface Meta {
   /** `agents share` endpoint (Cloudflare R2 + Worker). Set by `agents share
    * setup`/`join`; syncs fleet-wide via `agents repo push/pull`. The write token
    * lives in the `share` secrets bundle, not here. */
-  share?: {
-    baseUrl?: string;
-    accountId?: string;
-    workerName?: string;
-    bucketName?: string;
-    domain?: string;
-  };
+  share?: ShareMeta;
 }
 
 /** Persisted agent-host entry in agents.yaml (overlay or inline). */


### PR DESCRIPTION
## Summary
- Add a named `ShareMeta` type and wire `Meta.share` to it for the existing `agents share` config surface.
- Add regression coverage for `readMeta().share` endpoint persistence, normalized reads, and the `share` secrets bundle `SHARE_WRITE_TOKEN` flow.
- Add a `.changelog/next` fragment for the user-visible share wiring.

## Verification
- `HOME=/tmp/bun-home BUN_INSTALL_CACHE_DIR=/tmp/bun-cache XDG_CACHE_HOME=/tmp/bun-cache TMPDIR=/tmp bun install`
- `HOME=/tmp/bun-home BUN_INSTALL_CACHE_DIR=/tmp/bun-cache XDG_CACHE_HOME=/tmp/bun-cache TMPDIR=/tmp bun run test src/lib/share/config.test.ts src/lib/share/publish.test.ts` -> 2 files, 19 tests passed
- `HOME=/tmp/bun-home BUN_INSTALL_CACHE_DIR=/tmp/bun-cache XDG_CACHE_HOME=/tmp/bun-cache TMPDIR=/tmp bunx tsc --noEmit`
- `HOME=/tmp/agents-share-e2e-rush-1795-pr-21364 node dist/index.js share status` -> `endpoint  https://share.example.com`, `worker agents-share · bucket agents-share · account acct-123`

Session transcript: omitted because this is a public repository.
