### PR TITLE
Factory: fleet-aware Launch Matrix — spawn agents on a device or balanced across the fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@
   view as `agents devices list`, and `agents plugins add <spec>` aliases
   `agents plugins install <spec>`. Source: `apps/cli/src/commands/resources.ts`,
   `apps/cli/src/commands/ssh.ts`, `apps/cli/src/commands/plugins.ts`.
+- **Factory: fleet-aware Launch Matrix — spawn a Quick Launch agent on a specific
+  device or balanced across the fleet.** Each Quick Launch slot (⌘⇧0–9) gains a
+  **Run on** target: this Mac (default), a registered device (offloaded over SSH via
+  `agents run --host`), or ⚖ Balanced — auto-pick the least-busy online device, with
+  an optional pool restriction. The collapsed row shows the target (`↗ <device>` /
+  `⚖ balanced`). New optional chord **⌘⌥⇧0–9** fires a slot but prompts for the host
+  once. Every non-shell agent (Claude, Codex, Gemini, OpenCode, Cursor, Antigravity,
+  Grok, Kimi, Droid) also gains palette commands mirroring the version triad on a
+  host axis: **(Pick Host)**, **(Pick Version & Host)**, **(Auto Host)**, plus generic
+  `New Agent (Pick Host)` / `(Pick Version & Host)`. Balanced picks by fewest running
+  agents, excluding the local interactive machine. Source: `apps/factory/src/core/settings.ts`,
+  `apps/factory/src/core/launchHost.ts`, `apps/factory/src/vscode/extension.ts`,
+  `apps/factory/ui/settings/components/panel/LaunchMatrix.tsx`, `apps/factory/package.json`.
 
 ### Security
 

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -549,6 +549,270 @@
       {
         "command": "agents.spawnWithContext",
         "title": "Agents: Spawn with Context"
+      },
+      {
+        "command": "agents.newClaudePickHost",
+        "title": "Agents: New Claude (Pick Host)",
+        "icon": {
+          "light": "assets/claude.png",
+          "dark": "assets/claude.png"
+        }
+      },
+      {
+        "command": "agents.newClaudePickVersionHost",
+        "title": "Agents: New Claude (Pick Version & Host)",
+        "icon": {
+          "light": "assets/claude.png",
+          "dark": "assets/claude.png"
+        }
+      },
+      {
+        "command": "agents.newClaudeAutoHost",
+        "title": "Agents: New Claude (Auto Host)",
+        "icon": {
+          "light": "assets/claude.png",
+          "dark": "assets/claude.png"
+        }
+      },
+      {
+        "command": "agents.newCodexPickHost",
+        "title": "Agents: New Codex (Pick Host)",
+        "icon": {
+          "light": "assets/chatgpt.png",
+          "dark": "assets/chatgpt.png"
+        }
+      },
+      {
+        "command": "agents.newCodexPickVersionHost",
+        "title": "Agents: New Codex (Pick Version & Host)",
+        "icon": {
+          "light": "assets/chatgpt.png",
+          "dark": "assets/chatgpt.png"
+        }
+      },
+      {
+        "command": "agents.newCodexAutoHost",
+        "title": "Agents: New Codex (Auto Host)",
+        "icon": {
+          "light": "assets/chatgpt.png",
+          "dark": "assets/chatgpt.png"
+        }
+      },
+      {
+        "command": "agents.newGeminiPickHost",
+        "title": "Agents: New Gemini (Pick Host)",
+        "icon": {
+          "light": "assets/gemini.png",
+          "dark": "assets/gemini.png"
+        }
+      },
+      {
+        "command": "agents.newGeminiPickVersionHost",
+        "title": "Agents: New Gemini (Pick Version & Host)",
+        "icon": {
+          "light": "assets/gemini.png",
+          "dark": "assets/gemini.png"
+        }
+      },
+      {
+        "command": "agents.newGeminiAutoHost",
+        "title": "Agents: New Gemini (Auto Host)",
+        "icon": {
+          "light": "assets/gemini.png",
+          "dark": "assets/gemini.png"
+        }
+      },
+      {
+        "command": "agents.newOpenCodePickHost",
+        "title": "Agents: New OpenCode (Pick Host)",
+        "icon": {
+          "light": "assets/opencode.png",
+          "dark": "assets/opencode.png"
+        }
+      },
+      {
+        "command": "agents.newOpenCodePickVersionHost",
+        "title": "Agents: New OpenCode (Pick Version & Host)",
+        "icon": {
+          "light": "assets/opencode.png",
+          "dark": "assets/opencode.png"
+        }
+      },
+      {
+        "command": "agents.newOpenCodeAutoHost",
+        "title": "Agents: New OpenCode (Auto Host)",
+        "icon": {
+          "light": "assets/opencode.png",
+          "dark": "assets/opencode.png"
+        }
+      },
+      {
+        "command": "agents.newCursorPickHost",
+        "title": "Agents: New Cursor (Pick Host)",
+        "icon": {
+          "light": "assets/cursor.png",
+          "dark": "assets/cursor.png"
+        }
+      },
+      {
+        "command": "agents.newCursorPickVersionHost",
+        "title": "Agents: New Cursor (Pick Version & Host)",
+        "icon": {
+          "light": "assets/cursor.png",
+          "dark": "assets/cursor.png"
+        }
+      },
+      {
+        "command": "agents.newCursorAutoHost",
+        "title": "Agents: New Cursor (Auto Host)",
+        "icon": {
+          "light": "assets/cursor.png",
+          "dark": "assets/cursor.png"
+        }
+      },
+      {
+        "command": "agents.newAntigravityPickHost",
+        "title": "Agents: New Antigravity (Pick Host)",
+        "icon": {
+          "light": "assets/antigravity.png",
+          "dark": "assets/antigravity.png"
+        }
+      },
+      {
+        "command": "agents.newAntigravityPickVersionHost",
+        "title": "Agents: New Antigravity (Pick Version & Host)",
+        "icon": {
+          "light": "assets/antigravity.png",
+          "dark": "assets/antigravity.png"
+        }
+      },
+      {
+        "command": "agents.newAntigravityAutoHost",
+        "title": "Agents: New Antigravity (Auto Host)",
+        "icon": {
+          "light": "assets/antigravity.png",
+          "dark": "assets/antigravity.png"
+        }
+      },
+      {
+        "command": "agents.newGrokPickHost",
+        "title": "Agents: New Grok (Pick Host)",
+        "icon": {
+          "light": "assets/grok.png",
+          "dark": "assets/grok.png"
+        }
+      },
+      {
+        "command": "agents.newGrokPickVersionHost",
+        "title": "Agents: New Grok (Pick Version & Host)",
+        "icon": {
+          "light": "assets/grok.png",
+          "dark": "assets/grok.png"
+        }
+      },
+      {
+        "command": "agents.newGrokAutoHost",
+        "title": "Agents: New Grok (Auto Host)",
+        "icon": {
+          "light": "assets/grok.png",
+          "dark": "assets/grok.png"
+        }
+      },
+      {
+        "command": "agents.newKimiPickHost",
+        "title": "Agents: New Kimi (Pick Host)",
+        "icon": {
+          "light": "assets/kimi.png",
+          "dark": "assets/kimi.png"
+        }
+      },
+      {
+        "command": "agents.newKimiPickVersionHost",
+        "title": "Agents: New Kimi (Pick Version & Host)",
+        "icon": {
+          "light": "assets/kimi.png",
+          "dark": "assets/kimi.png"
+        }
+      },
+      {
+        "command": "agents.newKimiAutoHost",
+        "title": "Agents: New Kimi (Auto Host)",
+        "icon": {
+          "light": "assets/kimi.png",
+          "dark": "assets/kimi.png"
+        }
+      },
+      {
+        "command": "agents.newDroidPickHost",
+        "title": "Agents: New Droid (Pick Host)",
+        "icon": {
+          "light": "assets/droid.png",
+          "dark": "assets/droid.png"
+        }
+      },
+      {
+        "command": "agents.newDroidPickVersionHost",
+        "title": "Agents: New Droid (Pick Version & Host)",
+        "icon": {
+          "light": "assets/droid.png",
+          "dark": "assets/droid.png"
+        }
+      },
+      {
+        "command": "agents.newDroidAutoHost",
+        "title": "Agents: New Droid (Auto Host)",
+        "icon": {
+          "light": "assets/droid.png",
+          "dark": "assets/droid.png"
+        }
+      },
+      {
+        "command": "agents.newAgentPickHost",
+        "title": "Agents: New Agent (Pick Host)"
+      },
+      {
+        "command": "agents.newAgentPickVersionHost",
+        "title": "Agents: New Agent (Pick Version & Host)"
+      },
+      {
+        "command": "agents.quickLaunch0PickHost",
+        "title": "Agents: Quick Launch 0 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch1PickHost",
+        "title": "Agents: Quick Launch 1 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch2PickHost",
+        "title": "Agents: Quick Launch 2 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch3PickHost",
+        "title": "Agents: Quick Launch 3 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch4PickHost",
+        "title": "Agents: Quick Launch 4 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch5PickHost",
+        "title": "Agents: Quick Launch 5 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch6PickHost",
+        "title": "Agents: Quick Launch 6 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch7PickHost",
+        "title": "Agents: Quick Launch 7 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch8PickHost",
+        "title": "Agents: Quick Launch 8 (Pick Host)"
+      },
+      {
+        "command": "agents.quickLaunch9PickHost",
+        "title": "Agents: Quick Launch 9 (Pick Host)"
       }
     ],
     "configuration": {
@@ -936,6 +1200,56 @@
         "command": "agents.cyclePrevTerminal",
         "key": "ctrl+e",
         "mac": "cmd+e"
+      },
+      {
+        "command": "agents.quickLaunch0PickHost",
+        "key": "ctrl+alt+shift+0",
+        "mac": "cmd+alt+shift+0"
+      },
+      {
+        "command": "agents.quickLaunch1PickHost",
+        "key": "ctrl+alt+shift+1",
+        "mac": "cmd+alt+shift+1"
+      },
+      {
+        "command": "agents.quickLaunch2PickHost",
+        "key": "ctrl+alt+shift+2",
+        "mac": "cmd+alt+shift+2"
+      },
+      {
+        "command": "agents.quickLaunch3PickHost",
+        "key": "ctrl+alt+shift+3",
+        "mac": "cmd+alt+shift+3"
+      },
+      {
+        "command": "agents.quickLaunch4PickHost",
+        "key": "ctrl+alt+shift+4",
+        "mac": "cmd+alt+shift+4"
+      },
+      {
+        "command": "agents.quickLaunch5PickHost",
+        "key": "ctrl+alt+shift+5",
+        "mac": "cmd+alt+shift+5"
+      },
+      {
+        "command": "agents.quickLaunch6PickHost",
+        "key": "ctrl+alt+shift+6",
+        "mac": "cmd+alt+shift+6"
+      },
+      {
+        "command": "agents.quickLaunch7PickHost",
+        "key": "ctrl+alt+shift+7",
+        "mac": "cmd+alt+shift+7"
+      },
+      {
+        "command": "agents.quickLaunch8PickHost",
+        "key": "ctrl+alt+shift+8",
+        "mac": "cmd+alt+shift+8"
+      },
+      {
+        "command": "agents.quickLaunch9PickHost",
+        "key": "ctrl+alt+shift+9",
+        "mac": "cmd+alt+shift+9"
       }
     ]
   },

--- a/apps/factory/src/core/launchHost.test.ts
+++ b/apps/factory/src/core/launchHost.test.ts
@@ -1,0 +1,81 @@
+import { test, expect } from 'bun:test';
+import { pickLeastBusyDevice, resolveBalancePool, DeviceLoad } from './launchHost';
+
+test('pickLeastBusyDevice: returns null when nothing is online', () => {
+  expect(pickLeastBusyDevice([])).toBeNull();
+  expect(
+    pickLeastBusyDevice([
+      { name: 's0', online: false, running: 0 },
+      { name: 's1', online: false, running: 0 },
+    ]),
+  ).toBeNull();
+});
+
+test('pickLeastBusyDevice: single online device wins', () => {
+  expect(
+    pickLeastBusyDevice([
+      { name: 's0', online: false, running: 0 },
+      { name: 's1', online: true, running: 5 },
+    ]),
+  ).toBe('s1');
+});
+
+test('pickLeastBusyDevice: fewest running agents wins', () => {
+  expect(
+    pickLeastBusyDevice([
+      { name: 'mac-mini', online: true, running: 5 },
+      { name: 's0', online: true, running: 2 },
+      { name: 's1', online: true, running: 0 },
+    ]),
+  ).toBe('s1');
+});
+
+test('pickLeastBusyDevice: ties break by input order (first wins)', () => {
+  expect(
+    pickLeastBusyDevice([
+      { name: 's0', online: true, running: 1 },
+      { name: 's1', online: true, running: 1 },
+    ]),
+  ).toBe('s0');
+});
+
+test('pickLeastBusyDevice: a busy offline box never beats an online one', () => {
+  // offline s1 has 0 running but is skipped; online s0 (3 running) is the pick.
+  expect(
+    pickLeastBusyDevice([
+      { name: 's0', online: true, running: 3 },
+      { name: 's1', online: false, running: 0 },
+    ]),
+  ).toBe('s0');
+});
+
+const FLEET: DeviceLoad[] = [
+  { name: 'zion', online: true, running: 4 },
+  { name: 'yosemite-s0', online: true, running: 0 },
+  { name: 'yosemite-s1', online: true, running: 2 },
+  { name: 'mac-mini', online: false, running: 0 },
+];
+
+test('resolveBalancePool: excludes the local machine by default', () => {
+  const pool = resolveBalancePool(FLEET, { localName: 'zion' });
+  expect(pool.map((d) => d.name)).toEqual(['yosemite-s0', 'yosemite-s1', 'mac-mini']);
+});
+
+test('resolveBalancePool: restricts to an explicit pool (and drops unknowns)', () => {
+  const pool = resolveBalancePool(FLEET, {
+    localName: 'zion',
+    pool: ['yosemite-s0', 'ghost-box'],
+  });
+  expect(pool.map((d) => d.name)).toEqual(['yosemite-s0']);
+});
+
+test('resolveBalancePool + pickLeastBusyDevice: end-to-end least-busy of the pool', () => {
+  const pool = resolveBalancePool(FLEET, { localName: 'zion' });
+  // mac-mini is offline, so the least-busy ONLINE of the pool is s0 (0 running).
+  expect(pickLeastBusyDevice(pool)).toBe('yosemite-s0');
+});
+
+test('resolveBalancePool: local-name match is case/space-insensitive', () => {
+  const pool = resolveBalancePool(FLEET, { localName: '  ZION ' });
+  expect(pool.some((d) => d.name === 'zion')).toBe(false);
+});

--- a/apps/factory/src/core/launchHost.ts
+++ b/apps/factory/src/core/launchHost.ts
@@ -1,0 +1,48 @@
+// Pure host-selection logic for the fleet-aware Launch Matrix (no VS Code deps).
+//
+// A Quick Launch slot (and the per-agent "(Auto Host)" commands) can target a
+// pool of devices and let the launcher pick the least-busy one at fire time.
+// `agents run` has no cross-host balancer of its own, so the extension resolves
+// the target here and passes it as `--host <device>`. This mirrors the CLI
+// teams scheduler's pickLeastLoaded (apps/cli/src/lib/teams/scheduler.ts).
+
+export interface DeviceLoad {
+  name: string;
+  online: boolean;
+  running: number; // running agent count on the device; higher = busier
+}
+
+// Pick the least-busy online device — fewest running agents, ties broken by
+// input order (first declared wins), offline devices skipped. Returns null when
+// no candidate is online, so the caller can fall back to the local machine.
+export function pickLeastBusyDevice(candidates: DeviceLoad[]): string | null {
+  const online = candidates.filter((c) => c.online);
+  if (online.length === 0) return null;
+  let best = online[0];
+  for (const c of online) {
+    if (c.running < best.running) best = c;
+  }
+  return best.name;
+}
+
+// Narrow a device fleet to the eligible candidate pool for a balanced launch:
+// online devices, excluding the local machine, optionally restricted to an
+// explicit pool. An explicit pool entry that is not in the fleet is dropped.
+export function resolveBalancePool(
+  fleet: DeviceLoad[],
+  opts: { localName?: string; pool?: string[] } = {},
+): DeviceLoad[] {
+  const local = opts.localName ? normalize(opts.localName) : undefined;
+  const allow = opts.pool && opts.pool.length > 0
+    ? new Set(opts.pool.map(normalize))
+    : undefined;
+  return fleet.filter((d) => {
+    if (local && normalize(d.name) === local) return false;
+    if (allow && !allow.has(normalize(d.name))) return false;
+    return true;
+  });
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase();
+}

--- a/apps/factory/src/core/settings.ts
+++ b/apps/factory/src/core/settings.ts
@@ -32,6 +32,14 @@ export interface QuickLaunchSlot {
   modelAlias?: string;    // Agents-cli alias (e.g., "opus", "haiku") — resolved to a concrete id on first launch
   extraFlags?: string;    // Free-form CLI flags appended last (e.g., "--reasoning high")
   label?: string;         // Display label for dashboard
+  // Where ⌘⇧<n> spawns this agent. Omitted or 'local' = this machine (today's
+  // behavior). A registered device name = offload onto that host over SSH via
+  // `agents run --host`. 'balanced' = pick the least-busy online device at
+  // launch time (see balancePool).
+  runOn?: string;
+  // When runOn === 'balanced', restrict the candidate pool to these device
+  // names. Empty/undefined = all online devices (minus the local machine).
+  balancePool?: string[];
 }
 
 // Quick launch slots configuration. New shape uses `slots` keyed by digit "0".."9".

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -10,7 +10,10 @@ import {
 import * as claudemd from './claudemd.vscode';
 import { AgentsMarkdownEditorProvider, swarmCurrentDocument } from './customEditor';
 import * as git from './git.vscode';
-import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot } from '../core/settings';
+import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot, QuickLaunchSlotKey } from '../core/settings';
+import { listRegisteredDevices, countRunningAgents } from './deviceHealth.vscode';
+import { normalizeHost } from '../core/remoteSessions';
+import { pickLeastBusyDevice, resolveBalancePool } from '../core/launchHost';
 import * as settings from './settings.vscode';
 import * as swarm from './swarm.vscode';
 import {
@@ -177,17 +180,30 @@ type LaunchableAgent = 'claude' | 'codex' | 'gemini' | 'opencode' | 'cursor' | '
 // strategy.) The CLI ignores --strategy when an @version is pinned.
 type RunStrategy = 'pinned' | 'available' | 'balanced';
 
+// Shell-quote a token (device names come from the registry; quote defensively so
+// a stray character can never break out of the `agents run … --host <x>` string).
+function shquote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
 function buildAgentLaunchCommand(
-  agentKey: LaunchableAgent,
+  agentKey: string,
   sessionId: string | null,
   defaultModel?: string,
   additionalFlags?: string,
   pinnedVersion?: string,
   strategy?: RunStrategy,
   mode?: AgentLaunchMode,
+  host?: string,
 ): string {
   const agentSpec = pinnedVersion ? `${agentKey}@${pinnedVersion}` : agentKey;
   let command = `agents run ${agentSpec} --interactive`;
+  // Offload onto another machine over SSH — the CLI resolves the device from
+  // `agents devices` and runs interactive-on-host. Emitted for ANY agent so
+  // grok/kimi/droid (which launch as raw binaries locally) get host parity.
+  if (host) {
+    command += ` --host ${shquote(host)}`;
+  }
   if (sessionId && agentKey === 'claude') {
     command += ` --session-id ${sessionId}`;
   }
@@ -275,6 +291,75 @@ function buildClaudeLaunchCommand(
   mode?: AgentLaunchMode,
 ): string {
   return buildAgentLaunchCommand('claude', sessionId, defaultModel, additionalFlags, undefined, undefined, mode);
+}
+
+// --- Fleet-aware launch: host targeting -----------------------------------
+// Sentinel a QuickPick/slot uses to mean "auto-pick the least-busy device".
+const BALANCED_HOST = 'balanced';
+
+// Resolve the least-busy online device for a balanced launch. `pool` restricts
+// the candidate set (undefined/empty = every online device except this machine).
+// Probes running-agent counts behind a progress spinner. Returns undefined when
+// no device is eligible, so the caller falls back to the local machine.
+async function resolveBalancedHost(pool?: string[]): Promise<string | undefined> {
+  const localName = normalizeHost(os.hostname());
+  const devices = await listRegisteredDevices();
+  const fleet = devices.map(d => ({ name: d.name, online: !!d.online, running: 0 }));
+  const online = resolveBalancePool(fleet, { localName, pool }).filter(c => c.online);
+  if (online.length === 0) {
+    vscode.window.showInformationMessage('Balanced launch: no online device available — running locally.');
+    return undefined;
+  }
+  const loaded = await vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Window, title: 'Picking least-busy host…' },
+    () => Promise.all(online.map(async c => ({
+      ...c,
+      running: await countRunningAgents(c.name, { isLocal: false }),
+    }))),
+  );
+  return pickLeastBusyDevice(loaded) ?? undefined;
+}
+
+// Resolve a Quick Launch slot's Run-on target to a device name (undefined =
+// local). 'balanced' -> least-busy of the pool; a device name -> that host if
+// still online, else local with a nudge.
+async function resolveSlotHost(slot: QuickLaunchSlot): Promise<string | undefined> {
+  const target = slot.runOn?.trim();
+  if (!target || target === 'local') return undefined;
+  if (target === BALANCED_HOST) return resolveBalancedHost(slot.balancePool);
+  const devices = await listRegisteredDevices();
+  const dev = devices.find(d => normalizeHost(d.name) === normalizeHost(target));
+  if (!dev) {
+    vscode.window.showWarningMessage(`Launch host "${target}" is not a registered device — running locally.`);
+    return undefined;
+  }
+  if (!dev.online) {
+    vscode.window.showWarningMessage(`Launch host "${target}" is offline — running locally.`);
+    return undefined;
+  }
+  return dev.name;
+}
+
+// Interactive host picker (This Mac / a device / Balanced) for the per-agent
+// "(Pick Host)" commands and the ⌘⌥⇧n override. Returns { cancelled } if the
+// user dismissed it; host === undefined means "this Mac".
+async function pickLaunchHost(title = 'Run on…'): Promise<{ host?: string; cancelled: boolean }> {
+  const devices = await listRegisteredDevices();
+  const sorted = [...devices].sort((a, b) => Number(b.online) - Number(a.online));
+  const BALANCE_ID = ' balanced';
+  const items: (vscode.QuickPickItem & { hostId?: string })[] = [
+    { label: '$(vm) This Mac', description: 'Run locally', hostId: undefined },
+    { label: '$(sync) Balanced (least-busy)', description: 'Auto-pick the least-busy online device', hostId: BALANCE_ID },
+    ...sorted.map(d => ({
+      label: `${d.online ? '$(radio-tower)' : '$(circle-slash)'} ${d.name}`,
+      description: d.online ? 'online' : 'offline',
+      hostId: d.name,
+    })),
+  ];
+  const pick = await vscode.window.showQuickPick(items, { placeHolder: title, title });
+  if (!pick) return { cancelled: true };
+  if (pick.hostId === BALANCE_ID) return { host: await resolveBalancedHost(undefined), cancelled: false };
+  return { host: pick.hostId, cancelled: false };
 }
 
 // Terminal readiness detection moved to src/vscode/terminalReadiness.ts.
@@ -1356,6 +1441,70 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  // Register the per-agent HOST launch trio (the host axis, mirroring the
+  // version triad above) for EVERY non-shell agent — full parity across
+  // claude/codex/gemini/opencode/cursor/antigravity/grok/kimi/droid:
+  //   (Pick Host)          -> choose a device (or Balanced), default version
+  //   (Pick Version & Host)-> pick an exact version, then a device
+  //   (Auto Host)          -> least-busy online device, no prompt
+  // All route through openSingleAgent's host path (`agents run --host`).
+  for (const def of BUILT_IN_AGENTS) {
+    if (def.key === 'shell') continue;
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(`${def.commandId}PickHost`, async () => {
+        const picked = await pickLaunchHost(`New ${def.title} — run on…`);
+        if (picked.cancelled) return;
+        const agentConfig = getBuiltInByTitle(context.extensionPath, def.title);
+        if (agentConfig) openSingleAgent(context, agentConfig, undefined, undefined, undefined, picked.host);
+      })
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(`${def.commandId}PickVersionHost`, async () => {
+        const version = await pickAgentVersion(def.key);
+        if (!version) return;
+        const picked = await pickLaunchHost(`New ${def.title} v${version.version} — run on…`);
+        if (picked.cancelled) return;
+        const agentConfig = getBuiltInByTitle(context.extensionPath, def.title);
+        if (agentConfig) openSingleAgent(context, agentConfig, undefined, version.version, undefined, picked.host);
+      })
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(`${def.commandId}AutoHost`, async () => {
+        const host = await resolveBalancedHost(undefined);
+        const agentConfig = getBuiltInByTitle(context.extensionPath, def.title);
+        if (agentConfig) openSingleAgent(context, agentConfig, undefined, undefined, undefined, host);
+      })
+    );
+  }
+
+  // Generic host pickers (any agent in one flow).
+  context.subscriptions.push(
+    vscode.commands.registerCommand('agents.newAgentPickHost', async () => {
+      const agentItems = BUILT_IN_AGENTS.filter(d => d.key !== 'shell').map(d => ({ label: d.title, key: d.key, def: d }));
+      const agentPick = await vscode.window.showQuickPick(agentItems, { placeHolder: 'New agent — pick agent, then host', title: 'New Agent (Pick Host)' });
+      if (!agentPick) return;
+      const picked = await pickLaunchHost(`New ${agentPick.def.title} — run on…`);
+      if (picked.cancelled) return;
+      const agentConfig = getBuiltInByTitle(context.extensionPath, agentPick.def.title);
+      if (agentConfig) openSingleAgent(context, agentConfig, undefined, undefined, undefined, picked.host);
+    })
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('agents.newAgentPickVersionHost', async () => {
+      const result = await pickAnyAgentVersion(context.extensionPath);
+      if (!result) return;
+      const def = getBuiltInByKey(result.agentKey);
+      if (!def) return;
+      const picked = await pickLaunchHost(`New ${def.title} v${result.version} — run on…`);
+      if (picked.cancelled) return;
+      const agentConfig = getBuiltInByTitle(context.extensionPath, def.title);
+      if (agentConfig) openSingleAgent(context, agentConfig, undefined, result.version, undefined, picked.host);
+    })
+  );
+
   // Dynamically register custom agent commands
   const customAgentSettings = settings.getSettings(context);
   for (const custom of customAgentSettings.custom) {
@@ -1444,35 +1593,52 @@ export async function activate(context: vscode.ExtensionContext) {
   // Register quick launch commands (Cmd+Shift+0..9). Always register all ten so
   // keybindings stay valid even before the user assigns a slot — unassigned
   // shortcuts silently no-op.
+  // Launch a configured slot. `forceHostPick` (⌘⌥⇧n) overrides the slot's baked
+  // Run-on target with an interactive host pick for this one launch.
+  const launchQuickSlot = async (digit: QuickLaunchSlotKey, forceHostPick: boolean) => {
+    // Re-read settings on every press so newly saved slots take effect
+    // without reloading the window.
+    const fresh = settings.getSettings(context);
+    const slot: QuickLaunchSlot | undefined = getQuickLaunchSlot(fresh.quickLaunch, digit);
+    if (!slot) return;
+
+    const builtInDef = getBuiltInByKey(slot.agent);
+    if (!builtInDef) return;
+
+    const agentConfig = getBuiltInByTitle(context.extensionPath, builtInDef.title);
+    if (!agentConfig) return;
+
+    let modelId = slot.model;
+    if (!modelId && slot.modelAlias) {
+      modelId = (await resolveAlias(slot.agent, slot.modelAlias)) ?? undefined;
+    }
+
+    const parts: string[] = [];
+    if (modelId) parts.push(`--model ${modelId}`);
+    if (slot.mode) parts.push(`--mode ${slot.mode}`);
+    if (slot.extraFlags && slot.extraFlags.trim()) parts.push(slot.extraFlags.trim());
+    const flags = parts.length ? parts.join(' ') : undefined;
+
+    let host: string | undefined;
+    if (forceHostPick) {
+      const picked = await pickLaunchHost(`Run ${slot.label || builtInDef.title} on…`);
+      if (picked.cancelled) return;
+      host = picked.host;
+    } else {
+      host = await resolveSlotHost(slot);
+    }
+
+    openSingleAgent(context, agentConfig, flags, slot.version || undefined, undefined, host);
+  };
+
   for (const digit of QUICK_LAUNCH_SLOT_KEYS) {
-    const command = `agents.quickLaunch${digit}`;
+    // ⌘⇧n — fire the slot on its baked Run-on target.
     context.subscriptions.push(
-      vscode.commands.registerCommand(command, async () => {
-        // Re-read settings on every press so newly saved slots take effect
-        // without reloading the window.
-        const fresh = settings.getSettings(context);
-        const slot: QuickLaunchSlot | undefined = getQuickLaunchSlot(fresh.quickLaunch, digit);
-        if (!slot) return;
-
-        const builtInDef = getBuiltInByKey(slot.agent);
-        if (!builtInDef) return;
-
-        const agentConfig = getBuiltInByTitle(context.extensionPath, builtInDef.title);
-        if (!agentConfig) return;
-
-        let modelId = slot.model;
-        if (!modelId && slot.modelAlias) {
-          modelId = (await resolveAlias(slot.agent, slot.modelAlias)) ?? undefined;
-        }
-
-        const parts: string[] = [];
-        if (modelId) parts.push(`--model ${modelId}`);
-        if (slot.mode) parts.push(`--mode ${slot.mode}`);
-        if (slot.extraFlags && slot.extraFlags.trim()) parts.push(slot.extraFlags.trim());
-        const flags = parts.length ? parts.join(' ') : undefined;
-
-        openSingleAgent(context, agentConfig, flags, slot.version || undefined);
-      })
+      vscode.commands.registerCommand(`agents.quickLaunch${digit}`, () => launchQuickSlot(digit, false)),
+    );
+    // ⌘⌥⇧n — fire the slot but pick the host this once.
+    context.subscriptions.push(
+      vscode.commands.registerCommand(`agents.quickLaunch${digit}PickHost`, () => launchQuickSlot(digit, true)),
     );
   }
 
@@ -1636,8 +1802,13 @@ async function openSingleAgent(
   agentConfig: Omit<AgentConfig, 'count'>,
   additionalFlags?: string,
   pinnedVersion?: string,
-  strategy?: RunStrategy
+  strategy?: RunStrategy,
+  host?: string
 ) {
+  // A host target ('local'/undefined = this machine) always routes through
+  // `agents run <agent> --host <device>` so the CLI does the SSH offload —
+  // including agents that launch as raw binaries locally.
+  const targetHost = host && host !== 'local' ? host : undefined;
   const config = vscode.workspace.getConfiguration('agents');
   const terminalMode = normalizeTerminalMode(config.get('terminalMode'));
   // 'auto' (default) and 'tmux' both need the availability probe; 'native' skips it.
@@ -1688,12 +1859,17 @@ async function openSingleAgent(
   // Claude's session is generated up-front for the resume flow; other agents
   // detect their session post-spawn.
   const LAUNCHABLE: ReadonlySet<string> = new Set(['claude', 'codex', 'gemini', 'opencode', 'cursor', 'antigravity']);
-  if (agentKey && LAUNCHABLE.has(agentKey)) {
-    if (agentKey === 'claude') {
+  // Local: only LAUNCHABLE agents route through `agents run`; others use their
+  // raw command. Remote (targetHost): ALL agents route through `agents run
+  // --host` so every agent can be offloaded onto a device.
+  if (agentKey && (LAUNCHABLE.has(agentKey) || targetHost)) {
+    // Claude's up-front session id is for the LOCAL resume flow; a remote run
+    // manages its own session on the target host, so skip it when offloading.
+    if (agentKey === 'claude' && !targetHost) {
       sessionId = generateClaudeSessionId();
       console.log(`[SESSION] Claude using on-demand session ID: ${sessionId}`);
     }
-    command = buildAgentLaunchCommand(agentKey as LaunchableAgent, sessionId, defaultModel, additionalFlags, pinnedVersion, strategy);
+    command = buildAgentLaunchCommand(agentKey, sessionId, defaultModel, additionalFlags, pinnedVersion, strategy, undefined, targetHost);
   }
 
   if (tmuxOk) {

--- a/apps/factory/ui/settings/components/panel/LaunchMatrix.tsx
+++ b/apps/factory/ui/settings/components/panel/LaunchMatrix.tsx
@@ -1,16 +1,35 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { ChevronDown, ChevronUp, X } from 'lucide-react'
 import { AgentAvatar } from '../mission-control/AgentAvatar'
-import {
+import { postMessage } from '../../hooks'
+import type {
   AgentInventory,
   AgentSettings,
   BuiltInAgentConfig,
   QuickLaunchSlot,
-  QUICK_LAUNCH_SLOT_KEYS,
   QuickLaunchSlotKey,
+} from '../../types'
+import {
+  QUICK_LAUNCH_SLOT_KEYS,
   getQuickLaunchSlot,
   setQuickLaunchSlotInConfig,
 } from '../../types'
+
+interface FleetDevice { name: string; online: boolean }
+
+const normHost = (s: string) => s.trim().toLowerCase()
+
+// Colored host token shown in a slot's subtitle + badge. Returns null for a
+// local (this-Mac) target so unconfigured slots look exactly as before.
+function hostTokenFor(slot: QuickLaunchSlot): { text: string; color: string } | null {
+  const t = slot.runOn?.trim()
+  if (!t || t === 'local') return null
+  if (t === 'balanced') {
+    const n = slot.balancePool?.length
+    return { text: n ? `⚖ balanced · ${n}` : '⚖ balanced', color: '#a78bfa' }
+  }
+  return { text: `↗ ${t}`, color: '#67e8f9' }
+}
 
 interface LaunchMatrixProps {
   settings: AgentSettings
@@ -35,6 +54,23 @@ export function LaunchMatrix({
   onSaveSettings,
 }: LaunchMatrixProps) {
   const [expanded, setExpanded] = useState<QuickLaunchSlotKey | null>(null)
+  const [devices, setDevices] = useState<FleetDevice[]>([])
+  const [localHost, setLocalHost] = useState<string>('')
+
+  // Cheap fleet fetch (no SSH) so the Run-on picker + balanced pool list are
+  // populated. Same message the Floor uses (listDevices -> devicesData).
+  useEffect(() => {
+    postMessage({ type: 'listDevices' })
+    const onMsg = (e: MessageEvent) => {
+      const m = e.data
+      if (m?.type === 'devicesData' && Array.isArray(m.devices)) {
+        setDevices((m.devices as Array<{ name: string; online?: boolean }>).map(d => ({ name: d.name, online: !!d.online })))
+        if (typeof m.local === 'string' && m.local) setLocalHost(m.local)
+      }
+    }
+    window.addEventListener('message', onMsg)
+    return () => window.removeEventListener('message', onMsg)
+  }, [])
 
   const assignable = builtInAgents.filter(a => a.key !== 'shell')
 
@@ -62,6 +98,7 @@ export function LaunchMatrix({
         const modelOptions = slot?.agent ? (agentModels[slot.agent] || []) : []
         const aliasOptions = slot?.agent === 'claude' ? CLAUDE_ALIASES : []
         const modelLabel = slot?.model || (slot?.modelAlias ? `${slot.modelAlias} (alias)` : '')
+        const hostToken = slot ? hostTokenFor(slot) : null
 
         return (
           <div
@@ -86,10 +123,17 @@ export function LaunchMatrix({
                         ]
                           .filter(Boolean)
                           .join(' · ') || 'auto'}
+                        {hostToken && (
+                          <span style={{ color: hostToken.color }}> · {hostToken.text}</span>
+                        )}
                       </div>
                     </div>
                   </div>
-                  {slot.extraFlags ? (
+                  {hostToken ? (
+                    <span className="sw-launch-flags-badge" style={{ color: hostToken.color }} title={hostToken.text}>
+                      {hostToken.text}
+                    </span>
+                  ) : slot.extraFlags ? (
                     <span className="sw-launch-flags-badge" title={slot.extraFlags}>
                       {slot.extraFlags.length > 24 ? slot.extraFlags.slice(0, 24) + '…' : slot.extraFlags}
                     </span>
@@ -221,6 +265,65 @@ export function LaunchMatrix({
                     onChange={(e) => patchSlot(digit, { label: e.target.value || undefined })}
                   />
                 </label>
+
+                <label className="sw-panel-select" style={{ gridColumn: 'span 2' }}>
+                  <span>Run on</span>
+                  <select
+                    value={slot.runOn && slot.runOn !== 'local' ? slot.runOn : ''}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      patchSlot(digit, {
+                        runOn: v || undefined,
+                        balancePool: v === 'balanced' ? slot.balancePool : undefined,
+                      })
+                    }}
+                  >
+                    <option value="">This Mac</option>
+                    <option value="balanced">⚖ Balanced (least-busy)</option>
+                    {devices.length > 0 && (
+                      <optgroup label="Devices">
+                        {devices.map(d => (
+                          <option key={d.name} value={d.name} disabled={!d.online}>
+                            {d.name}{d.online ? '' : ' (offline)'}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+                  </select>
+                </label>
+
+                {slot.runOn === 'balanced' && (
+                  <div className="sw-panel-select" style={{ gridColumn: 'span 2' }}>
+                    <span>Pool <span style={{ opacity: 0.55 }}>— empty = all online</span></span>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, marginTop: 4 }}>
+                      {devices.filter(d => normHost(d.name) !== normHost(localHost)).map(d => {
+                        const checked = slot.balancePool?.includes(d.name) ?? false
+                        return (
+                          <label
+                            key={d.name}
+                            style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, opacity: d.online ? 1 : 0.5 }}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              disabled={!d.online}
+                              onChange={(e) => {
+                                const cur = new Set(slot.balancePool || [])
+                                if (e.target.checked) cur.add(d.name)
+                                else cur.delete(d.name)
+                                patchSlot(digit, { balancePool: cur.size ? Array.from(cur) : undefined })
+                              }}
+                            />
+                            {d.name}{d.online ? '' : ' (offline)'}
+                          </label>
+                        )
+                      })}
+                      {devices.filter(d => normHost(d.name) !== normHost(localHost)).length === 0 && (
+                        <span style={{ fontSize: 12, opacity: 0.55 }}>No registered devices</span>
+                      )}
+                    </div>
+                  </div>
+                )}
 
                 <div className="sw-launch-editor-foot" style={{ gridColumn: 'span 2' }}>
                   <button

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -27,6 +27,17 @@ import { TerminalExpandedDetail } from '../components/mission-control/TerminalDe
 import { AgentDecision } from '../components/mission-control/AgentDecision'
 import { ticketWorkers, type FloorAgent, type FloorTicket, type StructuredQuestion, type FloorGroupBy, type FloorSort, type TicketGroupBy, type TicketSort, type CenterMode, type ManagedProject, type LinearProjectLite } from '../components/mission-control/floorModel'
 import { RecapPane } from '../components/mission-control/RecapPane'
+import { LaunchMatrix } from '../components/panel/LaunchMatrix'
+import type { BuiltInAgentConfig, AgentInventory, AgentSettings } from '../types'
+
+// The preview harness runs in a bare browser with no VS Code / Electron host, so
+// components that post messages (e.g. LaunchMatrix's device fetch) would throw in
+// resolveBridge. Stub acquireVsCodeApi so the HostBridge resolves to a no-op.
+if (typeof (window as unknown as { acquireVsCodeApi?: unknown }).acquireVsCodeApi === 'undefined') {
+  ;(window as unknown as { acquireVsCodeApi: () => unknown }).acquireVsCodeApi = () => ({
+    postMessage: () => {}, getState: () => undefined, setState: () => {},
+  })
+}
 import { buildRecap } from '../components/mission-control/recapModel'
 import type { RemoteSessionLike } from '../components/mission-control/floorAdapter'
 import type { UnifiedTask, TerminalDetail } from '../types'
@@ -720,11 +731,82 @@ function Recap() {
   return <div className="feed-col"><RecapPane days={days} loading={false} onOpenUrl={noop} /></div>
 }
 
+class PreviewErrorBoundary extends React.Component<{ children: React.ReactNode }, { err: string | null }> {
+  constructor(p: { children: React.ReactNode }) { super(p); this.state = { err: null } }
+  static getDerivedStateFromError(e: unknown) { return { err: (e as Error)?.stack || String(e) } }
+  render() {
+    if (this.state.err) return <pre style={{ color: '#f87171', padding: 20, whiteSpace: 'pre-wrap', fontSize: 12 }}>{this.state.err}</pre>
+    return this.props.children
+  }
+}
+
+// ?view=launch — the fleet-aware Launch Matrix (Panel tab) with mock fleet data.
+function LaunchMatrixPreview() {
+  const LM_AGENTS: BuiltInAgentConfig[] = [
+    { key: 'claude', name: 'Claude', icon: 'claude.png' },
+    { key: 'codex', name: 'Codex', icon: 'chatgpt.png' },
+    { key: 'gemini', name: 'Gemini', icon: 'gemini.png' },
+    { key: 'grok', name: 'Grok', icon: 'grok.png' },
+    { key: 'kimi', name: 'Kimi', icon: 'kimi.png' },
+    { key: 'droid', name: 'Droid', icon: 'droid.png' },
+    { key: 'opencode', name: 'OpenCode', icon: 'opencode.png' },
+  ]
+  const inv = (v: string): AgentInventory => ({
+    agent: 'claude', strategy: 'balanced', defaultVersion: v, defaultAccount: null, defaultPlan: null,
+    signedInCount: 1, healthyCount: 1, canRotate: true,
+    versions: [{ version: v, isDefault: true, signedIn: true, email: null, plan: null, usageStatus: 'available', sessionUsedPercent: 0, lastActive: null, path: '' }],
+  })
+  const seed = {
+    quickLaunch: {
+      slots: {
+        '1': { agent: 'claude', version: '2.1.170', mode: 'edit', modelAlias: 'opus', runOn: 'yosemite-s0', label: 'CC · s0' },
+        '2': { agent: 'claude', modelAlias: 'haiku', runOn: 'balanced', label: 'CC balanced' },
+        '3': { agent: 'grok', runOn: 'balanced', balancePool: ['yosemite-s0', 'yosemite-s1'], label: 'Grok pool' },
+        '4': { agent: 'gemini', mode: 'edit' },
+      },
+    },
+  } as unknown as AgentSettings
+  const [settings, setSettings] = useState<AgentSettings>(seed)
+  React.useEffect(() => {
+    const t = setTimeout(() => window.postMessage({
+      type: 'devicesData', local: 'zion',
+      devices: [
+        { name: 'zion', online: true }, { name: 'yosemite-s0', online: true },
+        { name: 'yosemite-s1', online: true }, { name: 'mac-mini', online: false },
+      ],
+    }, '*'), 60)
+    return () => clearTimeout(t)
+  }, [])
+  return (
+    <div className="feed-col" style={{ maxWidth: 640, padding: 24 }}>
+      <div className="sw-panel-column">
+        <section className="sw-panel-section">
+          <div className="sw-panel-section-head">Launch Matrix</div>
+          <LaunchMatrix
+            settings={settings}
+            builtInAgents={LM_AGENTS}
+            agentModels={{ claude: ['claude-opus-4-7-20260115', 'claude-haiku-4-5-20251001'] }}
+            agentInventories={{ claude: inv('2.1.170'), gemini: inv('1.16.0'), grok: inv('1.0.0'), codex: inv('1.16.0'), kimi: inv('1.0.0'), droid: inv('1.0.0'), opencode: inv('1.16.0') }}
+            onSaveSettings={setSettings}
+          />
+        </section>
+      </div>
+    </div>
+  )
+}
+
 function Preview() {
   const params = new URLSearchParams(location.search)
   const theme = params.get('theme') === 'light' ? 'theme-light' : 'theme-dark'
   const view = params.get('view') ?? 'feed'
   const [dispatchOpen] = useState(view === 'dispatch')
+  if (view === 'launch') {
+    return (
+      <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
+        <div className="sw-floor-dashboard"><PreviewErrorBoundary><LaunchMatrixPreview /></PreviewErrorBoundary></div>
+      </div>
+    )
+  }
   return (
     <div className={`swarmify-root ${theme}`} style={{ minHeight: '100vh' }}>
       <div className="sw-floor-dashboard" style={{ padding: 0 }}>

--- a/apps/factory/ui/settings/types/index.ts
+++ b/apps/factory/ui/settings/types/index.ts
@@ -27,6 +27,14 @@ export interface QuickLaunchSlot {
   modelAlias?: string
   extraFlags?: string
   label?: string
+  // Where ⌘⇧<n> spawns this agent. Omitted or 'local' = this machine; a device
+  // name = offload onto that host via `agents run --host`; 'balanced' = pick the
+  // least-busy online device at launch (see balancePool). Kept in sync with the
+  // host copy in src/core/settings.ts.
+  runOn?: string
+  // When runOn === 'balanced', restrict the pool to these device names. Empty =
+  // all online devices (minus the local machine).
+  balancePool?: string[]
 }
 
 export interface QuickLaunchConfig {


### PR DESCRIPTION
## What

Makes the Factory **Launch Matrix** fleet-aware: each Quick Launch slot (⌘⇧0–9) and
per-agent palette commands can now spawn an agent on a **specific device** or
**balanced across the fleet**, not just the local machine. The extension is a thin
wrapper — it appends `--host <device>` to the `agents run … --interactive` command it
already builds, and the CLI does the SSH offload (`runInteractiveOnHost`).

## Why

Run one keystroke to launch a heavy agent on an idle worker box (keeping the
interactive machine responsive), or "just run it somewhere idle" via balancing —
reusing the muscle memory of ⌘⇧n rather than re-picking a host each time.

## Design

- **Run on** target per slot: `This Mac` (default, unchanged) · a registered device
  (pin) · `⚖ Balanced` (auto-pick least-busy online device, optional pool subset).
  Collapsed rows show the target (`↗ <device>` cyan / `⚖ balanced` violet).
- **No new required keybindings.** ⌘⇧0–9 stay the launcher; one *optional* new chord
  **⌘⌥⇧0–9** fires a slot but prompts for the host once.
- **Full agent parity** — every non-shell agent (Claude, Codex, Gemini, OpenCode,
  Cursor, Antigravity, Grok, Kimi, Droid) gets a host axis mirroring the version triad:
  **(Pick Host)**, **(Pick Version & Host)**, **(Auto Host)** — all thin entry points
  into one shared host-aware `openSingleAgent` path (grok/kimi/droid launch as raw
  binaries locally, so a host target routes them through `agents run --host` for parity).
- **Balanced** picks the online device with the fewest running agents (mirrors the CLI
  teams scheduler's `pickLeastLoaded`), excluding the local interactive machine.
- Back-compat: no `runOn` ⇒ local (today's behavior); no storage migration.

## Verify

- Unit: `apps/factory` `bun test` — new `src/core/launchHost.test.ts` (9 tests) green;
  full suite 1329/1330 (the one failure, `resolveAlias … opus/haiku`, is a pre-existing
  live-network test in `agentModels.test.ts`, untouched by this PR).
- Build: `bun run compile` clean (tsc + both UI builds).
- UI: rendered the real `LaunchMatrix` via a new `?view=launch` preview harness and
  visually verified every state — collapsed device/balanced badges, the **Run on**
  control in the slot editor, and the **Balanced** pool checklist (offline devices
  disabled, local machine excluded).

Design doc: https://share.agents-cli.sh/factory-fleet-launch-matrix
