### PR TITLE
Implement share Cloudflare provisioning

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1792.md
+++ b/apps/cli/.changelog/next/RUSH-1792.md
@@ -1,0 +1,1 @@
+- **Provision share workers completely (RUSH-1792).** `agents share setup` now configures the R2 lifecycle rule and sets the Worker `WRITE_TOKEN` through Cloudflare's Workers Secrets API after deploying the R2-bound Worker. Source: `apps/cli/src/lib/share/provision.ts`.

--- a/apps/cli/docs/share.md
+++ b/apps/cli/docs/share.md
@@ -14,7 +14,8 @@ agents share status                             # show the configured endpoint
 ```
 
 `setup` reads a Cloudflare API token from your `cloudflare.com` secrets bundle (or pass
-`--token`), creates an R2 bucket, uploads the Worker, and enables the free
+`--token`), creates an R2 bucket, installs the share lifecycle rule, uploads the Worker, sets
+the `WRITE_TOKEN` Worker secret, and enables the free
 `*.workers.dev` subdomain. If the token owns a zone, `--domain share.example.com` maps a
 custom domain. Then `agents share <file>` does an authed `PUT` and prints the link.
 
@@ -39,7 +40,8 @@ agent makes plan.html
   `SHARE_WRITE_TOKEN`, and `agents share join <baseUrl>` still joins an explicit
   endpoint without provisioning.
 - **Expiry.** `--expire 30d|12h|2026-08-01` writes `expires-at` into the object's metadata;
-  the Worker `410`s and lazily deletes past that instant.
+  the Worker `410`s and lazily deletes past that instant. Setup also installs a bucket
+  lifecycle rule that deletes share objects after 90 days as the durable cleanup floor.
 - **Preview cards (OG images).** Publishing an HTML page screenshots its own hero at
   1200×630 and attaches it as `og:image` + `twitter:card`, so the link unfurls into a
   rich card in Slack, iMessage, Twitter/X, and Discord. Capture is client-side (headless

--- a/apps/cli/src/commands/share.ts
+++ b/apps/cli/src/commands/share.ts
@@ -19,10 +19,12 @@ import {
 } from '../lib/share/config.js';
 import {
   addCustomDomain,
+  configureBucketLifecycle,
   createBucket,
   deployWorker,
   enableWorkersDev,
   findZoneId,
+  setWorkerSecret,
 } from '../lib/share/provision.js';
 import { publishFile } from '../lib/share/publish.js';
 import { renderWorkerScript } from '../lib/share/worker-template.js';
@@ -136,8 +138,12 @@ export async function runShareProvision(opts: {
   try {
     await createBucket(apiToken, accountId, bucketName);
     spin.text = `R2 bucket '${bucketName}' ready`;
-    await deployWorker(apiToken, accountId, workerName, renderWorkerScript(), bucketName, token);
+    await configureBucketLifecycle(apiToken, accountId, bucketName);
+    spin.text = `R2 bucket '${bucketName}' lifecycle ready`;
+    await deployWorker(apiToken, accountId, workerName, renderWorkerScript(), bucketName);
     spin.text = `Worker '${workerName}' deployed`;
+    await setWorkerSecret(apiToken, accountId, workerName, token);
+    spin.text = `Worker '${workerName}' write token set`;
     const subdomain = await enableWorkersDev(apiToken, accountId, workerName);
     let baseUrl = `https://${workerName}.${subdomain}.workers.dev`;
     let domain: string | undefined;

--- a/apps/cli/src/lib/share/provision.test.ts
+++ b/apps/cli/src/lib/share/provision.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   addCustomDomain,
+  configureBucketLifecycle,
   createBucket,
   deployWorker,
   enableWorkersDev,
   findZoneId,
+  setWorkerSecret,
+  SHARE_LIFECYCLE_DELETE_AFTER_SECONDS,
+  SHARE_LIFECYCLE_RULE_ID,
   type CloudflareRequest,
   type CloudflareRequester,
 } from './provision.js';
@@ -29,9 +33,63 @@ describe('share Cloudflare provisioning request shape', () => {
     ]);
   });
 
-  it('deploys a module worker with R2 and WRITE_TOKEN bindings', async () => {
+  it('merges the share lifecycle rule without dropping existing bucket rules', async () => {
+    const seen: CloudflareRequest[] = [];
+    const existingRule = {
+      id: 'keep-logs',
+      conditions: { prefix: 'logs/' },
+      enabled: true,
+      deleteObjectsTransition: { condition: { type: 'Age' as const, maxAge: 7 * 24 * 60 * 60 } },
+    };
+    const request: CloudflareRequester = async (req) => {
+      seen.push(req);
+      if (req.method === 'GET') {
+        return {
+          rules: [
+            existingRule,
+            {
+              id: SHARE_LIFECYCLE_RULE_ID,
+              conditions: { prefix: '' },
+              enabled: false,
+            },
+          ],
+        };
+      }
+      return {};
+    };
+
+    await configureBucketLifecycle('cf-token', 'acct_1', 'agents-share', { request });
+
+    expect(seen).toEqual([
+      {
+        apiToken: 'cf-token',
+        method: 'GET',
+        pathname: '/accounts/acct_1/r2/buckets/agents-share/lifecycle',
+      },
+      {
+        apiToken: 'cf-token',
+        method: 'PUT',
+        pathname: '/accounts/acct_1/r2/buckets/agents-share/lifecycle',
+        body: {
+          rules: [
+            existingRule,
+            {
+              id: SHARE_LIFECYCLE_RULE_ID,
+              conditions: { prefix: '' },
+              enabled: true,
+              deleteObjectsTransition: {
+                condition: { type: 'Age', maxAge: SHARE_LIFECYCLE_DELETE_AFTER_SECONDS },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('deploys a module worker with the R2 bucket binding', async () => {
     let upload: CloudflareRequest | undefined;
-    await deployWorker('cf-token', 'acct_1', 'worker-one', 'export default {}', 'bucket-one', 'write-token', {
+    await deployWorker('cf-token', 'acct_1', 'worker-one', 'export default {}', 'bucket-one', {
       request: async (req) => {
         upload = req;
         return {};
@@ -47,10 +105,28 @@ describe('share Cloudflare provisioning request shape', () => {
       compatibility_date: '2024-11-06',
       bindings: [
         { type: 'r2_bucket', name: 'BUCKET', bucket_name: 'bucket-one' },
-        { type: 'secret_text', name: 'WRITE_TOKEN', text: 'write-token' },
       ],
     });
     expect(await (upload?.form?.get('worker.js') as File).text()).toBe('export default {}');
+  });
+
+  it('sets WRITE_TOKEN through the Workers Secrets API', async () => {
+    const seen: CloudflareRequest[] = [];
+    await setWorkerSecret('cf-token', 'acct_1', 'worker-one', 'write-token', {
+      request: async (req) => {
+        seen.push(req);
+        return {};
+      },
+    });
+
+    expect(seen).toEqual([
+      {
+        apiToken: 'cf-token',
+        method: 'PUT',
+        pathname: '/accounts/acct_1/workers/scripts/worker-one/secrets',
+        body: { name: 'WRITE_TOKEN', text: 'write-token', type: 'secret_text' },
+      },
+    ]);
   });
 
   it('enables workers.dev and returns the account subdomain', async () => {

--- a/apps/cli/src/lib/share/provision.ts
+++ b/apps/cli/src/lib/share/provision.ts
@@ -1,9 +1,12 @@
 // Cloudflare provisioning for `agents share setup` — plain `fetch` against the CF
-// REST API (the repo has no CF wrapper). Creates the R2 bucket, uploads the Worker
-// (with an R2 binding + the WRITE_TOKEN as an inline secret), enables the free
+// REST API (the repo has no CF wrapper). Creates the R2 bucket, configures its
+// lifecycle, uploads the Worker (with an R2 binding), sets the WRITE_TOKEN secret,
+// enables the free
 // `*.workers.dev` subdomain, and — when the token owns the zone — maps a custom domain.
 
 const CF_API = 'https://api.cloudflare.com/client/v4';
+export const SHARE_LIFECYCLE_RULE_ID = 'agents-share-expire-90d';
+export const SHARE_LIFECYCLE_DELETE_AFTER_SECONDS = 90 * 24 * 60 * 60;
 
 interface CfError {
   code?: number;
@@ -57,6 +60,18 @@ interface ProvisionOptions {
   request?: CloudflareRequester;
 }
 
+interface R2LifecycleRule {
+  id: string;
+  conditions: { prefix: string };
+  enabled: boolean;
+  abortMultipartUploadsTransition?: { condition?: { maxAge: number; type: 'Age' } };
+  deleteObjectsTransition?: { condition?: { maxAge: number; type: 'Age' } | { date: string; type: 'Date' } };
+  storageClassTransitions?: Array<{
+    condition: { maxAge: number; type: 'Age' } | { date: string; type: 'Date' };
+    storageClass: 'InfrequentAccess';
+  }>;
+}
+
 /** True if the CF error looks like "the thing already exists" (idempotent create). */
 function isAlreadyExists(e: unknown): boolean {
   return /already exists|duplicate|10004|10014/i.test(String(e));
@@ -82,14 +97,46 @@ export async function createBucket(
   }
 }
 
-/** Upload the module Worker with an R2 binding (`BUCKET`) + inline `WRITE_TOKEN` secret. */
+/** Add/update the share bucket lifecycle rule while preserving unrelated rules. */
+export async function configureBucketLifecycle(
+  apiToken: string,
+  accountId: string,
+  bucketName: string,
+  opts: ProvisionOptions = {},
+): Promise<void> {
+  const request = opts.request ?? defaultCloudflareRequester;
+  const existing = await request<{ rules?: R2LifecycleRule[] }>({
+    apiToken,
+    method: 'GET',
+    pathname: `/accounts/${accountId}/r2/buckets/${bucketName}/lifecycle`,
+  });
+  const shareRule: R2LifecycleRule = {
+    id: SHARE_LIFECYCLE_RULE_ID,
+    conditions: { prefix: '' },
+    enabled: true,
+    deleteObjectsTransition: {
+      condition: { type: 'Age', maxAge: SHARE_LIFECYCLE_DELETE_AFTER_SECONDS },
+    },
+  };
+  const rules = [
+    ...(existing.rules ?? []).filter((rule) => rule.id !== SHARE_LIFECYCLE_RULE_ID),
+    shareRule,
+  ];
+  await request({
+    apiToken,
+    method: 'PUT',
+    pathname: `/accounts/${accountId}/r2/buckets/${bucketName}/lifecycle`,
+    body: { rules },
+  });
+}
+
+/** Upload the module Worker with an R2 binding (`BUCKET`). Secrets are set via the Workers Secrets API. */
 export async function deployWorker(
   apiToken: string,
   accountId: string,
   workerName: string,
   script: string,
   bucketName: string,
-  writeToken: string,
   opts: ProvisionOptions = {},
 ): Promise<void> {
   const request = opts.request ?? defaultCloudflareRequester;
@@ -98,7 +145,6 @@ export async function deployWorker(
     compatibility_date: '2024-11-06',
     bindings: [
       { type: 'r2_bucket', name: 'BUCKET', bucket_name: bucketName },
-      { type: 'secret_text', name: 'WRITE_TOKEN', text: writeToken },
     ],
   };
   const form = new FormData();
@@ -113,6 +159,23 @@ export async function deployWorker(
     method: 'PUT',
     pathname: `/accounts/${accountId}/workers/scripts/${workerName}`,
     form,
+  });
+}
+
+/** Add/update the WRITE_TOKEN binding using Cloudflare's Workers Secrets API. */
+export async function setWorkerSecret(
+  apiToken: string,
+  accountId: string,
+  workerName: string,
+  writeToken: string,
+  opts: ProvisionOptions = {},
+): Promise<void> {
+  const request = opts.request ?? defaultCloudflareRequester;
+  await request({
+    apiToken,
+    method: 'PUT',
+    pathname: `/accounts/${accountId}/workers/scripts/${workerName}/secrets`,
+    body: { name: 'WRITE_TOKEN', text: writeToken, type: 'secret_text' },
   });
 }
 


### PR DESCRIPTION
## Summary
- Add the missing Cloudflare provisioning steps for `agents share setup`: merge/install the R2 lifecycle rule and set `WRITE_TOKEN` through the Workers Secrets API.
- Keep Worker upload focused on the module script plus R2 binding, then enable workers.dev as before.
- Document the 90-day durable cleanup floor and add the RUSH-1792 changelog fragment.

## Evidence
- `bun install --cache-dir .bun-cache --backend copyfile` from `apps/cli` completed and ran the package build.
- `bun run test src/lib/share/provision.test.ts` passed: 1 file, 7 tests.
- `bun run test src/lib/share/*.test.ts` passed: 6 files, 47 tests.
- `bunx tsc --noEmit` passed.
- `node dist/index.js share setup --help` exited 0 and rendered the setup command help.

## Review
- Automated non-author reviewer configured in `.github/rush.yml` as `prix/code-reviewer` for PRs to `main`.

## Transcript
- Public repo: transcript omitted. Local pointer: `yosemite-s0:/home/muqsit/.agents/.../codex/019f87af-1036-7993-bfa9-24fc6442802a.jsonl`.
