### PR TITLE
fix(run): fail fast instead of hanging when 'agents run' has no prompt in a non-TTY (RUSH-1829)

### DIFF
--- a/apps/cli/.changelog/next/run-no-tty-repl-guard.md
+++ b/apps/cli/.changelog/next/run-no-tty-repl-guard.md
@@ -1,0 +1,8 @@
+- **`agents run <agent>` no longer hangs when launched headless without a prompt.**
+  A run with no prompt and no explicit `--interactive` resolves to interactive
+  intent — but in a non-TTY shell (a headless agent, a pipe, CI) there is no
+  terminal to host the REPL, so it attached a TUI to dead stdin and hung forever.
+  It now fails fast with the headless alternatives (`agents run <agent> "<task>"`
+  or `agents run <agent> --headless` to read the prompt from stdin). An explicit
+  `--interactive` is still honored. Source: `apps/cli/src/commands/exec.ts`,
+  `apps/cli/src/lib/exec.ts` (`inferredInteractiveWithoutTty`). (RUSH-1829)

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -2278,6 +2278,11 @@ export function registerRunCommand(program: Command): void {
       // the TUI attaches to dead stdin and hangs forever. Fail fast with the
       // headless alternatives instead of launching a doomed interactive session.
       if (inferredInteractiveWithoutTty(execOptions, isInteractiveTerminal())) {
+        // Tear down the workflow MCP config + subagents staged above before we
+        // exit — same as every sibling exit path; requireInteractiveSelection
+        // process.exits, so cleanup must happen first or it leaks.
+        cleanupWorkflowMcpConfig();
+        cleanupWorkflowSubagents();
         requireInteractiveSelection(`Launching ${agent} interactively`, [
           `agents run ${agent} "<your task>"   # headless: prints the agent's result`,
           `agents run ${agent} --headless        # headless: reads the prompt from stdin`,

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1229,7 +1229,7 @@ export function registerRunCommand(program: Command): void {
       }
 
       const [
-        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, headlessPlanStallCommand, nativeResume, resolveInteractive },
+        { buildExecCommand, parseExecEnv, execAgent, runWithFallback, normalizeMode, resolveMode, headlessPlanStallCommand, nativeResume, resolveInteractive, inferredInteractiveWithoutTty },
         { ALL_AGENT_IDS, ACCOUNT_INSPECTION_AGENT_IDS, agentLabel, supportsAccountInspection },
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle, assertRemoteBundleFlagsUnsupported, isHeadlessSecretsContext },
@@ -2270,6 +2270,18 @@ export function registerRunCommand(program: Command): void {
           console.error(chalk.red(`Loop failed for ${agent}: ${(err as Error).message}`));
           process.exit(1);
         }
+      }
+
+      // Agent footgun (RUSH-1829): a run with no prompt and no explicit
+      // --interactive resolves to interactive intent, but in a non-TTY shell
+      // (a headless agent, a pipe, CI) there is no terminal to host the REPL —
+      // the TUI attaches to dead stdin and hangs forever. Fail fast with the
+      // headless alternatives instead of launching a doomed interactive session.
+      if (inferredInteractiveWithoutTty(execOptions, isInteractiveTerminal())) {
+        requireInteractiveSelection(`Launching ${agent} interactively`, [
+          `agents run ${agent} "<your task>"   # headless: prints the agent's result`,
+          `agents run ${agent} --headless        # headless: reads the prompt from stdin`,
+        ]);
       }
 
       try {

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { shouldTapStdout, resolveInteractive, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { mailboxDir } from './mailbox.js';
 
@@ -248,6 +248,22 @@ describe('resolveInteractive (sanity for the gating inputs above)', () => {
   });
   it('--headless forces non-interactive even without a prompt', () => {
     expect(resolveInteractive({ headless: true, prompt: undefined })).toBe(false);
+  });
+});
+
+describe('inferredInteractiveWithoutTty (RUSH-1829 no-TTY REPL guard)', () => {
+  it('blocks a prompt-less run in a non-TTY shell (the footgun: would hang on dead stdin)', () => {
+    expect(inferredInteractiveWithoutTty({ prompt: undefined }, false)).toBe(true);
+  });
+  it('allows a prompt-less run at a real terminal (a normal interactive launch)', () => {
+    expect(inferredInteractiveWithoutTty({ prompt: undefined }, true)).toBe(false);
+  });
+  it('never blocks a headless run — it has no prompt-less REPL to attach', () => {
+    expect(inferredInteractiveWithoutTty({ prompt: 'do the thing' }, false)).toBe(false);
+    expect(inferredInteractiveWithoutTty({ headless: true, prompt: undefined }, false)).toBe(false);
+  });
+  it('honors an explicit --interactive even without a TTY (caller may drive a PTY we can\'t detect)', () => {
+    expect(inferredInteractiveWithoutTty({ interactive: true, prompt: undefined }, false)).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -245,6 +245,24 @@ export function resolveInteractive(
 }
 
 /**
+ * True when a run resolved to *inferred* interactive intent — no prompt and no
+ * explicit `--interactive` — but there is no terminal to host the REPL. Launching
+ * would attach a TUI to a dead stdin and hang forever, so the caller should fail
+ * fast with the headless alternatives instead (RUSH-1829).
+ *
+ * An explicit `--interactive` is the caller's deliberate choice and is never
+ * blocked (they may be driving a PTY we can't detect). Pure — the TTY state is a
+ * parameter so this is unit-testable without touching `process.std*`.
+ */
+export function inferredInteractiveWithoutTty(
+  options: Pick<ExecOptions, 'interactive' | 'headless' | 'prompt'>,
+  isTty: boolean,
+): boolean {
+  if (options.interactive === true) return false;
+  return resolveInteractive(options) && !isTty;
+}
+
+/**
  * Decide whether spawnAgent must capture (PIPE + tee) the child's stdout so the
  * live budget watcher can parse it (issue #346, FIX 3).
  *


### PR DESCRIPTION
Closes RUSH-1829.

## Problem (agent footgun)

`agents run <agent>` with no prompt and no explicit `--interactive` resolves to **interactive** intent (`resolveInteractive`, `exec.ts`). In a non-TTY shell — a headless agent driving the CLI as a tool, a pipe, or CI — there is no terminal to host the REPL, so the TUI attaches to dead stdin and **hangs forever** instead of erroring. This is one of the top ways an autonomous agent gets stuck on agents-cli.

## Fix

- New pure predicate `inferredInteractiveWithoutTty(options, isTty)` in `lib/exec.ts`: true only when interactivity was *inferred* (no prompt, no `--interactive`) and there's no TTY. An explicit `--interactive` is the caller's choice and is never blocked (they may drive a PTY we can't detect).
- The `run` command guards on it just before launch and fails fast via the existing `requireInteractiveSelection()` pattern, naming the recovery commands:
  ```
  Launching claude interactively requires an interactive terminal.
  Run one of these non-interactive forms instead:
    agents run claude "<your task>"   # headless: prints the agent's result
    agents run claude --headless        # headless: reads the prompt from stdin
  ```

## Tests

`inferredInteractiveWithoutTty` unit tests (`exec.test.ts`): blocks prompt-less non-TTY, allows prompt-less at a real terminal, never blocks headless, honors explicit `--interactive`. Full typecheck clean.

Note: 3 pre-existing `buildExecEnv`/`buildExecCommand` tests fail *locally* only because this dev shell injects `DISABLE_AUTOUPDATER`/`AGENTS_MAILBOX_DIR` (the tests assert their absence) — they pass in CI's clean env and are untouched by this change.

Part of the agents-cli agent-UX sweep (epic RUSH-1828).
