### PR TITLE
fix(cloud): machine-readable failures under --json (die() json-aware) (RUSH-1830)

### DIFF
--- a/apps/cli/.changelog/next/die-json-aware.md
+++ b/apps/cli/.changelog/next/die-json-aware.md
@@ -1,0 +1,8 @@
+- **`agents cloud run --json` now emits machine-readable failures.** `die()` — the
+  shared fatal-exit path — always wrote red text to stderr and left stdout empty,
+  so an agent parsing `--json` output saw nothing plus a bare nonzero exit with no
+  reason. `die()` gains an optional `{ json, hint }` and, in json mode, prints
+  `{"error", "hint"?}` to stdout; a pure `formatDie()` makes the human/agent split
+  unit-testable. Every failure path in `cloud run` now threads the resolved
+  `--json` flag. Source: `apps/cli/src/lib/format.ts`, `apps/cli/src/commands/cloud.ts`.
+  (RUSH-1830)

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -250,7 +250,7 @@ Examples:
 
       // Resolve prompt: --prompt flag, positional arg, or file
       let prompt = (options.prompt as string) || positionalPrompt;
-      if (!prompt) die('Prompt is required. Pass it as an argument or with --prompt.');
+      if (!prompt) die('Prompt is required. Pass it as an argument or with --prompt.', 1, { json, hint: 'agents cloud run "<task>" --repo <owner/repo>' });
 
       // If prompt is a file path, read it and tell the user
       if (fs.existsSync(prompt) && fs.statSync(prompt).isFile()) {
@@ -267,7 +267,7 @@ Examples:
       // something to the host provider, so it implies --provider host rather
       // than silently riding along to a cloud backend that would ignore it.
       if (options.host && options.provider && options.provider !== 'host') {
-        die(`--host targets your own machines (--provider host), not ${options.provider}. Drop --host, or use --provider host.`);
+        die(`--host targets your own machines (--provider host), not ${options.provider}. Drop --host, or use --provider host.`, 1, { json });
       }
       const explicitProvider = (options.provider as string | undefined) ?? (options.host ? 'host' : undefined);
 
@@ -318,7 +318,7 @@ Examples:
       if (options.on) {
         const event = normalizeTriggerEvent(options.on as string);
         if (!event) {
-          die(`Unknown --on event "${options.on}". Use one of: ${GITHUB_TRIGGER_EVENTS.join(', ')} (aliases: pr, comment, workflow).`);
+          die(`Unknown --on event "${options.on}". Use one of: ${GITHUB_TRIGGER_EVENTS.join(', ')} (aliases: pr, comment, workflow).`, 1, { json });
         }
         const trigger: JobTrigger = { type: 'github_event', event: event! };
         if (repoValues[0]) trigger.repo = repoValues[0];
@@ -327,14 +327,14 @@ Examples:
         if (options.label) trigger.label = options.label as string;
 
         const triggerErrors = validateTrigger(trigger);
-        if (triggerErrors.length > 0) die(`Invalid trigger: ${triggerErrors.join(', ')}`);
+        if (triggerErrors.length > 0) die(`Invalid trigger: ${triggerErrors.join(', ')}`, 1, { json });
 
         dispatchOptions.trigger = trigger;
 
         const routineName = (options.name as string | undefined)
           || `cloud-${event}-${(repoValues[0] || 'any').replace(/[^a-z0-9]+/gi, '-')}`.toLowerCase();
         if (jobExists(routineName)) {
-          die(`A routine named "${routineName}" already exists. Pass --name to register under a different name.`);
+          die(`A routine named "${routineName}" already exists. Pass --name to register under a different name.`, 1, { json });
         }
 
         const routine: JobConfig = {
@@ -376,14 +376,14 @@ Examples:
       const skillIds = Array.isArray(options.skill) ? (options.skill as string[]) : [];
       const caps = provider.capabilities();
       if (imagePaths.length > 0) {
-        if (!caps.images) die(`${provider.name} does not support image attachments.`);
+        if (!caps.images) die(`${provider.name} does not support image attachments.`, 1, { json });
         if (imagePaths.length > MAX_IMAGES_PER_DISPATCH) {
-          die(`Too many images: ${imagePaths.length}. Max is ${MAX_IMAGES_PER_DISPATCH} per dispatch.`);
+          die(`Too many images: ${imagePaths.length}. Max is ${MAX_IMAGES_PER_DISPATCH} per dispatch.`, 1, { json });
         }
         dispatchOptions.images = imagePaths.map(readImageAttachment);
       }
       if (skillIds.length > 0) {
-        if (!caps.skills) die(`${provider.name} does not support ride-along skills.`);
+        if (!caps.skills) die(`${provider.name} does not support ride-along skills.`, 1, { json });
         dispatchOptions.skills = skillIds.map(parseSkillRef);
       }
 
@@ -408,16 +408,16 @@ Examples:
         if (err instanceof MissingTargetError) {
           const picked = await pickMissingTarget(provider, err, json);
           if (!picked) {
-            die(err.guidance ? `${err.message}\n\n${err.guidance}` : err.message);
+            die(err.guidance ? `${err.message}\n\n${err.guidance}` : err.message, 1, { json });
           }
           dispatchOptions.providerOptions![err.kind] = picked;
           try {
             task = await dispatchOnce();
           } catch (err2) {
-            die((err2 as Error).message);
+            die((err2 as Error).message, 1, { json });
           }
         } else {
-          die((err as Error).message);
+          die((err as Error).message, 1, { json });
         }
       }
 

--- a/apps/cli/src/lib/format.test.ts
+++ b/apps/cli/src/lib/format.test.ts
@@ -8,6 +8,7 @@ import {
   padVisible,
   isJsonMode,
   termLink,
+  formatDie,
 } from './format.js';
 
 describe('truncate', () => {
@@ -81,5 +82,39 @@ describe('termLink', () => {
   });
   it('returns plain text when filePath is empty', () => {
     expect(termLink('label', '')).toBe('label');
+  });
+});
+
+describe('formatDie (RUSH-1830 — machine-readable failures for --json callers)', () => {
+  it('emits a parseable {"error"} on stdout in json mode', () => {
+    const out = formatDie('Prompt is required.', { json: true });
+    expect(out.stream).toBe('stdout');
+    expect(JSON.parse(out.text)).toEqual({ error: 'Prompt is required.' });
+  });
+
+  it('includes the hint in the json payload when provided', () => {
+    const out = formatDie('Prompt is required.', { json: true, hint: 'agents cloud run "<task>"' });
+    expect(out.stream).toBe('stdout');
+    expect(JSON.parse(out.text)).toEqual({ error: 'Prompt is required.', hint: 'agents cloud run "<task>"' });
+  });
+
+  it('writes red text to stderr for humans (default, no json)', () => {
+    const out = formatDie('Boom');
+    expect(out.stream).toBe('stderr');
+    // chalk may be disabled in CI (no color) — assert the message survives either way.
+    expect(out.text).toContain('Boom');
+  });
+
+  it('appends the hint as a second stderr line for humans', () => {
+    const out = formatDie('Boom', { hint: 'try --help' });
+    expect(out.stream).toBe('stderr');
+    expect(out.text).toContain('Boom');
+    expect(out.text).toContain('try --help');
+    expect(out.text.split('\n')).toHaveLength(2);
+  });
+
+  it('omits an absent hint from the json payload (no null/undefined key)', () => {
+    const out = formatDie('nope', { json: true });
+    expect(out.text).not.toContain('hint');
   });
 });

--- a/apps/cli/src/lib/format.ts
+++ b/apps/cli/src/lib/format.ts
@@ -10,9 +10,48 @@
 import chalk from 'chalk';
 import { readSync } from 'node:fs';
 
-/** Print `msg` in red to stderr and exit the process with `code`. */
-export function die(msg: string, code = 1): never {
-  console.error(chalk.red(msg));
+/** Options for {@link die} — opt into machine-readable failure output. */
+export interface DieOptions {
+  /**
+   * Emit a machine-readable `{"error", "hint"?}` object to **stdout** instead of
+   * red text on stderr. Pass `isJsonMode(options)` from a `--json` command so an
+   * agent parsing stdout gets a structured reason instead of an empty stream and
+   * a bare nonzero exit (RUSH-1830).
+   */
+  json?: boolean;
+  /** Optional recovery hint — the command to run instead. Included in both modes. */
+  hint?: string;
+}
+
+/**
+ * Render a fatal error to the right stream. Pure — no I/O, no `process.exit` — so
+ * the human-vs-agent split is unit-testable. A `--json` caller gets
+ * `{"error","hint"?}` on **stdout** (where a JSON consumer reads); a human gets
+ * red text (plus a gray hint line) on **stderr**.
+ */
+export function formatDie(
+  msg: string,
+  opts: DieOptions = {},
+): { stream: 'stdout' | 'stderr'; text: string } {
+  if (opts.json) {
+    const payload: { error: string; hint?: string } = { error: msg };
+    if (opts.hint) payload.hint = opts.hint;
+    return { stream: 'stdout', text: JSON.stringify(payload) };
+  }
+  const lines = [chalk.red(msg)];
+  if (opts.hint) lines.push(chalk.gray(opts.hint));
+  return { stream: 'stderr', text: lines.join('\n') };
+}
+
+/**
+ * Print `msg` and exit the process with `code`. Humans get red text on stderr;
+ * a `--json` caller (pass `{ json: true }`) gets `{"error","hint"?}` on stdout so
+ * an agent has a parseable reason. Backward-compatible: `die(msg)` / `die(msg, code)`
+ * keep the original red-stderr behavior.
+ */
+export function die(msg: string, code = 1, opts: DieOptions = {}): never {
+  const { stream, text } = formatDie(msg, opts);
+  (stream === 'stdout' ? process.stdout : process.stderr).write(`${text}\n`);
   process.exit(code);
 }
 

--- a/apps/cli/src/lib/format.ts
+++ b/apps/cli/src/lib/format.ts
@@ -51,7 +51,10 @@ export function formatDie(
  */
 export function die(msg: string, code = 1, opts: DieOptions = {}): never {
   const { stream, text } = formatDie(msg, opts);
-  (stream === 'stdout' ? process.stdout : process.stderr).write(`${text}\n`);
+  // Keep console.* (not process.std*.write): the suite spies on console.error /
+  // console.log to capture command output, and fd-level writes bypass those spies.
+  if (stream === 'stdout') console.log(text);
+  else console.error(text);
   process.exit(code);
 }
 


### PR DESCRIPTION
Closes RUSH-1830.

## Problem (agent footgun)

`die()` — the shared fatal-exit path used across `cloud`, `teams`, etc. — always writes red text to stderr and leaves stdout empty:

```ts
export function die(msg: string, code = 1): never {
  console.error(chalk.red(msg));
  process.exit(code);
}
```

So `agents cloud run --json` failing on a missing prompt (or any of its guards) exits with **empty stdout** and a bare nonzero code — an agent parsing the JSON stream sees nothing and has no machine-readable reason.

## Fix

- `die()` gains an optional `{ json, hint }` (backward-compatible — `die(msg)` / `die(msg, code)` unchanged). In json mode it prints `{"error","hint"?}` to **stdout** (where a JSON consumer reads); humans still get red stderr plus an optional gray hint line.
- Extracted a **pure** `formatDie(msg, opts)` returning `{ stream, text }` so the human/agent split is unit-tested without touching `process.exit`.
- Threaded the already-resolved `--json` flag through **every** failure path in the `cloud run` action (11 `die()` sites).

Example — `agents cloud run --json` with no prompt now yields on stdout:
```json
{"error":"Prompt is required. Pass it as an argument or with --prompt.","hint":"agents cloud run \"<task>\" --repo <owner/repo>"}
```

## Tests

`formatDie` unit tests (`format.test.ts`): json→stdout `{error}`, hint included/omitted correctly, human→stderr red text + second hint line. 15/15 pass; typecheck clean.

## Scope

This lands the reusable json-aware primitive and wires the highest-value agent surface (`cloud run`). Propagating `{ json }` to the remaining `teams`/`monitors`/`routines` failure paths is follow-up under the same epic (RUSH-1828).
