### PR TITLE
Fix piped CLI JSON mode

### DIFF
--- a/apps/cli/.changelog/next/rush-1831-json-mode.md
+++ b/apps/cli/.changelog/next/rush-1831-json-mode.md
@@ -1,0 +1,1 @@
+- Keep piped CLI output human-readable unless `--json` is passed.

--- a/apps/cli/src/commands/teams.test.ts
+++ b/apps/cli/src/commands/teams.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+
+let testHome: string;
+
+afterEach(() => {
+  if (testHome) fs.rmSync(testHome, { recursive: true, force: true });
+});
+
+function guardedHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-teams-home-'));
+  const systemDir = path.join(home, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+  testHome = home;
+  return home;
+}
+
+function run(args: string[]): { stdout: string; status: number | null } {
+  const home = guardedHome();
+  const r = spawnSync('bun', [INDEX, ...args], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: home,
+      AGENTS_NO_UPDATE_CHECK: '1',
+      AGENTS_NO_USAGE_TRACK: '1',
+      AGENTS_SKIP_MIGRATION: '1',
+    },
+  });
+  return { stdout: r.stdout ?? '', status: r.status };
+}
+
+describe('teams list output modes', () => {
+  it('keeps piped stdout human-readable unless --json is passed', () => {
+    const { stdout, status } = run(['teams', 'list']);
+    expect(status).toBe(0);
+    expect(stdout).toContain("You haven't started any teams yet.");
+    expect(() => JSON.parse(stdout)).toThrow();
+  });
+
+  it('emits JSON when --json is passed', () => {
+    const { stdout, status } = run(['teams', 'list', '--json']);
+    expect(status).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({ teams: [] });
+  });
+});

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -110,8 +110,6 @@ const VALID_CLOUD_PROVIDERS = ['rush', 'codex', 'factory'] as const satisfies re
 type Mode = (typeof VALID_MODES)[number];
 type Effort = (typeof VALID_EFFORTS)[number];
 
-// Auto-enable JSON mode when piped / not a TTY so AI agent consumers get
-// parseable output by default.
 function statusColor(status: string): (s: string) => string {
   switch (status) {
     case 'pending': return chalk.blue;

--- a/apps/cli/src/lib/format.test.ts
+++ b/apps/cli/src/lib/format.test.ts
@@ -73,6 +73,11 @@ describe('isJsonMode', () => {
   it('is true when json flag is set', () => {
     expect(isJsonMode({ json: true })).toBe(true);
   });
+
+  it('is false without --json even when stdout is not a TTY', () => {
+    expect(process.stdout.isTTY).not.toBe(true);
+    expect(isJsonMode({})).toBe(false);
+  });
 });
 
 describe('termLink', () => {

--- a/apps/cli/src/lib/format.ts
+++ b/apps/cli/src/lib/format.ts
@@ -117,9 +117,9 @@ export function padVisible(s: string, width: number): string {
   return w >= width ? s : s + ' '.repeat(width - w);
 }
 
-/** True when `--json` was passed or stdout is not a TTY. */
+/** True when `--json` was passed. Piped stdout stays human-readable unless requested. */
 export function isJsonMode(opts: { json?: boolean }): boolean {
-  return Boolean(opts.json) || !process.stdout.isTTY;
+  return Boolean(opts.json);
 }
 
 /** Read all of stdin synchronously and return it UTF-8 decoded and trimmed. */

--- a/apps/cli/tests/teams-events.test.ts
+++ b/apps/cli/tests/teams-events.test.ts
@@ -94,7 +94,7 @@ describe('team lifecycle audit events', () => {
 
   it('does NOT emit teams.disband when the team does not exist', () => {
     const home = makeTempHome();
-    const res = runCli(home, ['teams', 'disband', 'never-existed']);
+    const res = runCli(home, ['teams', 'disband', 'never-existed', '--json']);
     // The command reports existed:false (no real removal), so no semantic
     // teams.disband event fires — only the generic command.* pair.
     expect(res.stdout).toContain('"existed": false');


### PR DESCRIPTION
## Summary
- Make shared isJsonMode explicit: only --json enables JSON output.
- Add regression coverage for non-TTY/piped teams list output and explicit --json output.
- Add the requested bullet-only changelog fragment.

## Evidence
- apps/cli/src/lib/format.ts:120 now documents piped stdout stays human-readable unless requested.
- apps/cli/src/lib/format.test.ts:77 asserts non-TTY stdout without --json is not JSON mode.
- apps/cli/src/commands/teams.test.ts:45 drives the real CLI command tree and asserts piped teams list stays human-readable.
- apps/cli/src/commands/teams.test.ts:52 asserts teams list --json still emits JSON.
- apps/cli/tests/teams-events.test.ts:97 now requests --json explicitly where the test asserts JSON stdout.

## Verification
- TMPDIR=/tmp/bun-tmp TEMP=/tmp/bun-tmp TMP=/tmp/bun-tmp BUN_TMPDIR=/tmp/bun-tmp XDG_CACHE_HOME=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-cache bun install
- bun run test src/lib/format.test.ts src/commands/teams.test.ts tests/teams-events.test.ts
- bunx tsc --noEmit
- bun run dev teams list > /tmp/rush-1831-teams-list.txt; parsed check confirmed output is not JSON
- bun run dev teams list --json > /tmp/rush-1831-teams-list-json.txt; parsed check confirmed .teams is an array

Session transcript: omitted because this is a public repository; local Codex thread id CODEX_THREAD_ID=019f87f3-45c3-7572-bfdf-e732198ada4b.