### PR TITLE
feat(cli): machine-readable --json for monitors/routines/secrets read commands (RUSH-1831/1832/1833/1834)

### DIFF
--- a/apps/cli/.changelog/next/json-pipe-help-doc.md
+++ b/apps/cli/.changelog/next/json-pipe-help-doc.md
@@ -1,0 +1,5 @@
+- **`--json` help text now notes that piping stdout also forces JSON.** For commands
+  that resolve output mode via `isJsonMode()` (teams, cloud), machine-readable JSON is
+  emitted whenever `--json` is passed **or** stdout is not a TTY — the help strings now
+  say so, so the pipe-triggers-JSON behavior is discoverable. Source:
+  `apps/cli/src/commands/teams.ts`, `apps/cli/src/commands/cloud.ts`. (RUSH-1831)

--- a/apps/cli/.changelog/next/monitors-json-output.md
+++ b/apps/cli/.changelog/next/monitors-json-output.md
@@ -1,0 +1,6 @@
+- **`agents monitors test` and `agents monitors view` now support `--json`.** The
+  dry-run oracle (`test`) and config inspector (`view`) were human-text only, so an
+  agent couldn't parse "would this fire?" or a monitor's state. Both emit a
+  structured payload on stdout under `--json`; not-found errors emit `{"error":…}`
+  and exit non-zero, and human error/diagnostic output was moved off stdout to
+  stderr. Source: `apps/cli/src/commands/monitors.ts`. (RUSH-1832)

--- a/apps/cli/.changelog/next/routines-json-output.md
+++ b/apps/cli/.changelog/next/routines-json-output.md
@@ -1,0 +1,7 @@
+- **`agents routines add`, `run`, and `runs` now support `--json`.** Previously only
+  `list`/`status` emitted JSON, so an agent creating a routine or triggering a run
+  had to scrape human strings for the job name / run id. `add` emits
+  `{ ok, added, job }`, `run` emits `{ ok, job, runId, logDir }`, and `runs` emits an
+  array of run records — all on stdout, with the scheduler-start banner suppressed so
+  it never pollutes the JSON stream. Source: `apps/cli/src/commands/routines.ts`.
+  (RUSH-1833)

--- a/apps/cli/.changelog/next/secrets-json-output.md
+++ b/apps/cli/.changelog/next/secrets-json-output.md
@@ -1,0 +1,5 @@
+- **`agents secrets list` and `agents secrets view` now support `--json`.** An agent
+  could inject a bundle but couldn't first discover which bundles/keys exist without
+  parsing column-aligned text. Both emit metadata only — bundle/key names, policy,
+  presence, expiry — never secret values (reveal still gated behind `--reveal`).
+  Source: `apps/cli/src/commands/secrets.ts`. (RUSH-1834)

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -224,7 +224,7 @@ Examples:
       '--upload-account-tokens',
       'Upload Claude OAuth credentials to Rush Cloud on first dispatch (consent recorded for future runs).',
     )
-    .option('--json', 'Structured JSON output')
+    .option('--json', 'Structured JSON output, or when stdout is piped')
     .option('--no-follow', 'Dispatch and exit without streaming output')
     .addHelpText('after', `
 Examples:
@@ -473,7 +473,7 @@ Examples:
     .option('--provider <id>', 'Filter by provider')
     .option('--status <status>', 'Filter by status')
     .option('--limit <n>', 'Max results', '20')
-    .option('--json', 'JSON output')
+    .option('--json', 'JSON output, or when stdout is piped')
     .action(async (options: Record<string, unknown>) => {
       const json = isJsonMode(options as { json?: boolean });
       const providerId = options.provider as CloudProviderId | undefined;
@@ -554,7 +554,7 @@ Examples:
   cloud
     .command('status <id>')
     .description('Show task detail and latest status.')
-    .option('--json', 'JSON output')
+    .option('--json', 'JSON output, or when stdout is piped')
     .action(async (id: string, options: Record<string, unknown>) => {
       const json = isJsonMode(options as { json?: boolean });
 
@@ -598,7 +598,7 @@ Examples:
     .command('logs <id>')
     .description('Stream live output from a cloud task.')
     .option('-f, --follow', 'Follow output (default for running tasks)', true)
-    .option('--json', 'JSON event stream')
+    .option('--json', 'JSON event stream, or when stdout is piped')
     .action(async (id: string, options: Record<string, unknown>) => {
       const json = isJsonMode(options as { json?: boolean });
 
@@ -677,7 +677,7 @@ Examples:
   cloud
     .command('providers')
     .description('List available cloud providers and their status.')
-    .option('--json', 'JSON output')
+    .option('--json', 'JSON output, or when stdout is piped')
     .action((options: Record<string, unknown>) => {
       const json = isJsonMode(options as { json?: boolean });
       const providers = getAllProviders();
@@ -713,7 +713,7 @@ Examples:
     .alias('targets')
     .description('List the pre-provisioned targets (Codex environments / Droid Computers) you can dispatch into.')
     .option('--provider <id>', 'Only this provider (codex, factory, ...)')
-    .option('--json', 'JSON output')
+    .option('--json', 'JSON output, or when stdout is piped')
     .action(async (options: Record<string, unknown>) => {
       const json = isJsonMode(options as { json?: boolean });
       const only = options.provider as CloudProviderId | undefined;

--- a/apps/cli/src/commands/monitors.test.ts
+++ b/apps/cli/src/commands/monitors.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { buildMonitorViewJson } from './monitors.js';
+import type { MonitorConfig } from '../lib/monitors/config.js';
+import type { MonitorState, FireRecord } from '../lib/monitors/state.js';
+
+const config: MonitorConfig = {
+  name: 'ci',
+  enabled: true,
+  source: { type: 'poll', command: 'gh pr checks', interval: '30s' } as MonitorConfig['source'],
+  condition: { mode: 'match', match: 'fail' } as MonitorConfig['condition'],
+  action: { type: 'notify', notifyChannel: 'telegram' } as MonitorConfig['action'],
+};
+
+const state: MonitorState = {
+  monitorName: 'ci',
+  lastHash: 'abc',
+  lastValue: 'all green',
+  lastSeenAt: '2026-07-21T00:00:00Z',
+  lastFiredAt: '2026-07-20T00:00:00Z',
+};
+
+function fire(n: number): FireRecord {
+  return { monitorName: 'ci', firedAt: `2026-07-2${n}T00:00:00Z`, summary: `fire ${n}`, payload: {} };
+}
+
+describe('buildMonitorViewJson', () => {
+  it('carries the config, state, and the most recent fires verbatim', () => {
+    const payload = buildMonitorViewJson('ci', config, state, [fire(1), fire(2)]);
+    expect(payload.name).toBe('ci');
+    expect(payload.config).toBe(config);
+    expect(payload.state).toBe(state);
+    expect(payload.recentFires).toEqual([fire(1), fire(2)]);
+  });
+
+  it('keeps only the last five fires', () => {
+    const fires = [1, 2, 3, 4, 5, 6, 7].map(fire);
+    const payload = buildMonitorViewJson('ci', config, state, fires);
+    expect(payload.recentFires).toHaveLength(5);
+    expect(payload.recentFires.map((f) => f.summary)).toEqual([
+      'fire 3', 'fire 4', 'fire 5', 'fire 6', 'fire 7',
+    ]);
+  });
+
+  it('normalizes a missing state to null', () => {
+    const payload = buildMonitorViewJson('ci', config, null, []);
+    expect(payload.state).toBeNull();
+    expect(payload.recentFires).toEqual([]);
+  });
+});

--- a/apps/cli/src/commands/monitors.ts
+++ b/apps/cli/src/commands/monitors.ts
@@ -36,7 +36,7 @@ import {
   type MonitorWebhookSource,
 } from '../lib/monitors/config.js';
 import { evaluateMonitorOnce } from '../lib/monitors/engine.js';
-import { listFires, readState } from '../lib/monitors/state.js';
+import { listFires, readState, type MonitorState, type FireRecord } from '../lib/monitors/state.js';
 import { listRuns, getLatestRun, getRunDir } from '../lib/routines.js';
 import { getMonitorsDir } from '../lib/state.js';
 import { IS_WINDOWS } from '../lib/platform/index.js';
@@ -245,6 +245,19 @@ async function pickMonitor(message: string, alternatives: string[] = []): Promis
   }
 }
 
+/**
+ * Shape the `monitors view --json` payload. Pure — takes the already-read config,
+ * watched-state, and fire history so it is unit-testable without touching disk.
+ */
+export function buildMonitorViewJson(
+  name: string,
+  config: MonitorConfig,
+  state: MonitorState | null,
+  fires: FireRecord[],
+): { name: string; config: MonitorConfig; state: MonitorState | null; recentFires: FireRecord[] } {
+  return { name, config, state: state ?? null, recentFires: fires.slice(-5) };
+}
+
 /** Register the `agents monitors` command tree. */
 export function registerMonitorsCommands(program: Command): void {
   const monitorsCmd = program
@@ -414,8 +427,8 @@ export function registerMonitorsCommands(program: Command): void {
 
       const errors = validateMonitor(config);
       if (errors.length > 0) {
-        console.log(chalk.red('Validation errors:'));
-        for (const err of errors) console.log(chalk.red(`  - ${err}`));
+        console.error(chalk.red('Validation errors:'));
+        for (const err of errors) console.error(chalk.red(`  - ${err}`));
         process.exit(1);
       }
 
@@ -478,15 +491,25 @@ export function registerMonitorsCommands(program: Command): void {
   monitorsCmd
     .command('view [name]')
     .description('Show a monitor’s full YAML config plus its current watched-state and recent fires.')
-    .action(async (name: string | undefined) => {
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async (name: string | undefined, options: { json?: boolean }) => {
       if (!name) {
         name = (await pickMonitor('Select monitor to view', ['agents monitors view <name>'])) ?? undefined;
         if (!name) return;
       }
       const monitor = readMonitor(name);
       if (!monitor) {
-        console.log(chalk.red(`Monitor '${name}' not found`));
+        if (options.json) {
+          process.stdout.write(JSON.stringify({ error: `Monitor '${name}' not found` }) + '\n');
+          process.exit(1);
+        }
+        console.error(chalk.red(`Monitor '${name}' not found`));
         process.exit(1);
+      }
+      if (options.json) {
+        const payload = buildMonitorViewJson(name, monitor, readState(name), listFires(name));
+        process.stdout.write(JSON.stringify(payload) + '\n');
+        return;
       }
       console.log(chalk.bold(`Monitor: ${name}\n`));
       console.log(yaml.stringify(monitor));
@@ -510,20 +533,42 @@ export function registerMonitorsCommands(program: Command): void {
   monitorsCmd
     .command('test [name]')
     .description('DRY-RUN: evaluate the source once and print the emitted event + whether it would fire. No action is taken.')
-    .action(async (name: string | undefined) => {
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async (name: string | undefined, options: { json?: boolean }) => {
       if (!name) {
         name = (await pickMonitor('Select monitor to test', ['agents monitors test <name>'])) ?? undefined;
         if (!name) return;
       }
       const monitor = readMonitor(name);
       if (!monitor) {
-        console.log(chalk.red(`Monitor '${name}' not found`));
+        if (options.json) {
+          process.stdout.write(JSON.stringify({ error: `Monitor '${name}' not found` }) + '\n');
+          process.exit(1);
+        }
+        console.error(chalk.red(`Monitor '${name}' not found`));
         process.exit(1);
       }
+
+      const { observation, decision } = await evaluateMonitorOnce(monitor);
+      const wouldFire = Boolean(decision?.fire);
+
+      if (options.json) {
+        const payload = {
+          name,
+          source: monitor.source,
+          condition: monitor.condition,
+          action: monitor.action,
+          observation: observation ? { raw: observation.raw, meta: observation.meta ?? null } : null,
+          wouldFire,
+          event: decision?.event ?? null,
+        };
+        process.stdout.write(JSON.stringify(payload) + '\n');
+        return;
+      }
+
       console.log(chalk.bold(`Dry-run: ${name}\n`));
       console.log(chalk.gray(`  ${sourceLabel(monitor.source)}  ·  [${monitor.condition.mode}]  ·  ${actionLabel(monitor.action)}\n`));
 
-      const { observation, decision } = await evaluateMonitorOnce(monitor);
       if (!observation) {
         console.log(chalk.yellow('No observation — this source is push-only (ws/webhook) or produced nothing this tick.'));
         return;
@@ -532,7 +577,6 @@ export function registerMonitorsCommands(program: Command): void {
       console.log(observation.raw.split('\n').slice(0, 20).map((l) => `  ${l}`).join('\n'));
       if (observation.meta) console.log(chalk.gray(`  meta: ${JSON.stringify(observation.meta)}`));
 
-      const wouldFire = Boolean(decision?.fire);
       console.log('');
       console.log(`Would fire: ${wouldFire ? chalk.green('yes') : chalk.gray('no')}`);
       if (decision?.event) {

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -12,6 +12,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import { fileURLToPath } from 'url';
+import { buildRunsJson } from './routines.js';
+import type { RunMeta } from '../lib/routines.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -720,5 +722,32 @@ describe('routines run --host SELF follows the normal local eligibility path', (
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
+  });
+});
+
+describe('buildRunsJson', () => {
+  const meta = (runId: string, status: RunMeta['status'], startedAt: string): RunMeta => ({
+    jobName: 'test-job',
+    runId,
+    pid: null,
+    status,
+    startedAt,
+    completedAt: null,
+    exitCode: null,
+  });
+
+  it('projects each run to the same fields the human table row shows', () => {
+    const runs = [
+      meta('r1', 'completed', '2026-07-20T00:00:00Z'),
+      meta('r2', 'failed', '2026-07-21T00:00:00Z'),
+    ];
+    expect(buildRunsJson(runs)).toEqual([
+      { runId: 'r1', status: 'completed', startedAt: '2026-07-20T00:00:00Z' },
+      { runId: 'r2', status: 'failed', startedAt: '2026-07-21T00:00:00Z' },
+    ]);
+  });
+
+  it('returns an empty array for no runs', () => {
+    expect(buildRunsJson([])).toEqual([]);
   });
 });

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -40,7 +40,7 @@ import {
   checkJobDeviceEligibility,
   normalizeTriggerEvent,
 } from '../lib/routines.js';
-import type { JobConfig, JobTrigger, LinearTriggerEvent } from '../lib/routines.js';
+import type { JobConfig, JobTrigger, LinearTriggerEvent, RunMeta } from '../lib/routines.js';
 import { fireWebhookJobs, matchJobsToWebhook, type IncomingWebhook, type WebhookSource } from '../lib/triggers/webhook.js';
 import { getRoutinesDir } from '../lib/state.js';
 import { IS_WINDOWS } from '../lib/platform/index.js';
@@ -124,13 +124,16 @@ function parseRoutineTrigger(options: Record<string, unknown>): JobTrigger | und
 }
 
 /** Start or reload the background scheduler so newly-added jobs fire on time. */
-function ensureSchedulerRunning(): void {
+// `quiet` suppresses the human status lines (used by --json callers so the
+// scheduler-start banner never pollutes the machine-readable stdout stream).
+function ensureSchedulerRunning(opts: { quiet?: boolean } = {}): void {
   if (isDaemonRunning()) {
     signalDaemonReload();
-    console.log(chalk.gray('Scheduler reloaded'));
+    if (!opts.quiet) console.log(chalk.gray('Scheduler reloaded'));
     return;
   }
   const result = startDaemon();
+  if (opts.quiet) return;
   if (result.pid) {
     console.log(chalk.green(`Scheduler started (PID: ${result.pid}). It will run in the background and fire routines on schedule.`));
     console.log(chalk.gray(`Stop anytime with: agents routines stop`));
@@ -219,6 +222,15 @@ async function parseAndValidateDevices(raw: string): Promise<string[]> {
     process.exit(1);
   }
   return names;
+}
+
+/**
+ * Shape the `routines runs --json` payload from a job's run history. Pure — takes
+ * the already-read {@link RunMeta} list so it is unit-testable without disk I/O.
+ * Mirrors the human table row: run id, status, and start time.
+ */
+export function buildRunsJson(runs: RunMeta[]): Array<{ runId: string; status: RunMeta['status']; startedAt: string }> {
+  return runs.map((r) => ({ runId: r.runId, status: r.status, startedAt: r.startedAt }));
 }
 
 /** Register the `agents routines` command tree. */
@@ -461,6 +473,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
     .option('--resume <sessionId>', 'At fire time, resume this existing session id (via `agents run <agent> --resume`) instead of starting fresh — the actual session reopens with full context and the prompt becomes its next turn. Powers self-scheduled wake-ups (e.g. /hibernate). Requires --agent claude or codex; runs un-sandboxed (the session store lives in the real home, not the job overlay).')
+    .option('--json', 'Emit machine-readable JSON')
     .action(async (nameOrPath: string | undefined, options) => {
       // Check if inline mode (has flags) or file mode
       const hasInlineFlags = options.schedule || options.agent || options.workflow || options.command || options.prompt || options.at || options.on;
@@ -468,14 +481,14 @@ export function registerRoutinesCommands(program: Command): void {
       if (hasInlineFlags) {
         // Inline mode: create job from flags
         if (!nameOrPath) {
-          console.log(chalk.red('Job name is required'));
-          console.log(chalk.gray('Usage: agents routines add <name> --schedule "..." --agent <agent> --prompt "..."'));
+          console.error(chalk.red('Job name is required'));
+          console.error(chalk.gray('Usage: agents routines add <name> --schedule "..." --agent <agent> --prompt "..."'));
           process.exit(1);
         }
 
         // Validate mutually exclusive --agent / --workflow / --command
         if ([options.agent, options.workflow, options.command].filter(Boolean).length > 1) {
-          console.log(chalk.red('--agent, --workflow, and --command are mutually exclusive; specify exactly one'));
+          console.error(chalk.red('--agent, --workflow, and --command are mutually exclusive; specify exactly one'));
           process.exit(1);
         }
 
@@ -485,7 +498,7 @@ export function registerRoutinesCommands(program: Command): void {
         try {
           trigger = parseRoutineTrigger(options);
         } catch (err) {
-          console.log(chalk.red((err as Error).message));
+          console.error(chalk.red((err as Error).message));
           process.exit(1);
         }
 
@@ -493,8 +506,8 @@ export function registerRoutinesCommands(program: Command): void {
         if (options.at) {
           const parsed = parseAtTime(options.at);
           if (!parsed) {
-            console.log(chalk.red(`Invalid --at format: ${options.at}`));
-            console.log(chalk.gray('Supported formats: "14:30" or "2026-02-24 09:00"'));
+            console.error(chalk.red(`Invalid --at format: ${options.at}`));
+            console.error(chalk.gray('Supported formats: "14:30" or "2026-02-24 09:00"'));
             process.exit(1);
           }
           schedule = parsed.schedule;
@@ -502,18 +515,18 @@ export function registerRoutinesCommands(program: Command): void {
         }
 
         if (!schedule && !trigger) {
-          console.log(chalk.red('Schedule or trigger is required (use --schedule, --at, or --on)'));
+          console.error(chalk.red('Schedule or trigger is required (use --schedule, --at, or --on)'));
           process.exit(1);
         }
 
         if (!options.agent && !options.workflow && !options.command) {
-          console.log(chalk.red('An agent, workflow, or command is required (use --agent, --workflow, or --command)'));
+          console.error(chalk.red('An agent, workflow, or command is required (use --agent, --workflow, or --command)'));
           process.exit(1);
         }
 
         // Command routines run a plain shell and take no prompt; agent/workflow routines require one.
         if (!options.command && !options.prompt) {
-          console.log(chalk.red('Prompt is required (use --prompt)'));
+          console.error(chalk.red('Prompt is required (use --prompt)'));
           process.exit(1);
         }
 
@@ -554,14 +567,19 @@ export function registerRoutinesCommands(program: Command): void {
 
         const errors = validateJob(config);
         if (errors.length > 0) {
-          console.log(chalk.red('Validation errors:'));
+          console.error(chalk.red('Validation errors:'));
           for (const err of errors) {
-            console.log(chalk.red(`  - ${err}`));
+            console.error(chalk.red(`  - ${err}`));
           }
           process.exit(1);
         }
 
         writeJob(config);
+        if (options.json) {
+          process.stdout.write(JSON.stringify({ ok: true, added: nameOrPath, job: config }) + '\n');
+          ensureSchedulerRunning({ quiet: true });
+          return;
+        }
         console.log(chalk.green(`Job '${nameOrPath}' added`));
         if (runOnce) {
           console.log(chalk.gray(`One-shot job scheduled for: ${options.at}`));
@@ -571,15 +589,15 @@ export function registerRoutinesCommands(program: Command): void {
       } else {
         // File mode: load from YAML file
         if (!nameOrPath) {
-          console.log(chalk.red('File path or job name with flags is required'));
-          console.log(chalk.gray('Usage: agents routines add <path-to-job.yml>'));
-          console.log(chalk.gray('   or: agents routines add <name> --schedule "..." --agent <agent> --prompt "..."'));
+          console.error(chalk.red('File path or job name with flags is required'));
+          console.error(chalk.gray('Usage: agents routines add <path-to-job.yml>'));
+          console.error(chalk.gray('   or: agents routines add <name> --schedule "..." --agent <agent> --prompt "..."'));
           process.exit(1);
         }
 
         const resolved = path.resolve(nameOrPath);
         if (!fs.existsSync(resolved)) {
-          console.log(chalk.red(`File not found: ${resolved}`));
+          console.error(chalk.red(`File not found: ${resolved}`));
           process.exit(1);
         }
 
@@ -588,7 +606,7 @@ export function registerRoutinesCommands(program: Command): void {
         try {
           parsed = yaml.parse(content);
         } catch (err) {
-          console.log(chalk.red(`Invalid YAML: ${(err as Error).message}`));
+          console.error(chalk.red(`Invalid YAML: ${(err as Error).message}`));
           process.exit(1);
         }
 
@@ -597,9 +615,9 @@ export function registerRoutinesCommands(program: Command): void {
 
         const errors = validateJob(parsed);
         if (errors.length > 0) {
-          console.log(chalk.red('Validation errors:'));
+          console.error(chalk.red('Validation errors:'));
           for (const err of errors) {
-            console.log(chalk.red(`  - ${err}`));
+            console.error(chalk.red(`  - ${err}`));
           }
           process.exit(1);
         }
@@ -620,6 +638,11 @@ export function registerRoutinesCommands(program: Command): void {
         }
 
         writeJob(config);
+        if (options.json) {
+          process.stdout.write(JSON.stringify({ ok: true, added: name, job: config }) + '\n');
+          ensureSchedulerRunning({ quiet: true });
+          return;
+        }
         console.log(chalk.green(`Job '${name}' added`));
 
         ensureSchedulerRunning();
@@ -730,13 +753,18 @@ export function registerRoutinesCommands(program: Command): void {
   routinesCmd
     .command('runs [name]')
     .description('See execution history: run IDs, completion status, and start times (up to last 10 runs)')
-    .action(async (name: string | undefined) => {
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async (name: string | undefined, options: { json?: boolean }) => {
       if (!name) {
         name = await pickJob('Select job to view runs', undefined, ['agents routines runs <name>']) ?? undefined;
         if (!name) return;
       }
 
       const runs = listRuns(name);
+      if (options.json) {
+        process.stdout.write(JSON.stringify(buildRunsJson(runs.slice(-10))) + '\n');
+        return;
+      }
       if (runs.length === 0) {
         console.log(chalk.yellow(`No runs found for job '${name}'`));
         return;
@@ -756,7 +784,8 @@ export function registerRoutinesCommands(program: Command): void {
   routinesCmd
     .command('run [name]')
     .description('Execute a routine right now in the foreground. Ignores the schedule; useful for testing before enabling.')
-    .action(async (name: string | undefined) => {
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async (name: string | undefined, options: { json?: boolean }) => {
       if (!name) {
         name = await pickJob('Select job to run', undefined, ['agents routines run <name>']) ?? undefined;
         if (!name) return;
@@ -770,29 +799,47 @@ export function registerRoutinesCommands(program: Command): void {
       // the trusted user layer.
       const job = readJob(name);
       if (!job) {
-        console.log(chalk.red(`Job '${name}' not found`));
+        if (options.json) {
+          process.stdout.write(JSON.stringify({ error: `Job '${name}' not found` }) + '\n');
+          process.exit(1);
+        }
+        console.error(chalk.red(`Job '${name}' not found`));
         process.exit(1);
       }
 
       const eligibility = checkJobDeviceEligibility(job);
       if (eligibility) {
-        console.log(chalk.red(eligibility.message));
-        console.log(chalk.gray(`  ${eligibility.suggestion}`));
+        if (options.json) {
+          process.stdout.write(JSON.stringify({ error: eligibility.message, hint: eligibility.suggestion }) + '\n');
+          process.exit(1);
+        }
+        console.error(chalk.red(eligibility.message));
+        console.error(chalk.gray(`  ${eligibility.suggestion}`));
         process.exit(1);
       }
 
       const runLabel = job.command ? 'command' : job.workflow ? `workflow: ${job.workflow}` : `agent: ${job.agent}`;
-      console.log(chalk.bold(`Running job '${name}' (${runLabel}, mode: ${job.mode})\n`));
-      const spinner = ora('Executing...').start();
+      // A spinner writes to stderr but its human framing is noise for a JSON consumer.
+      const spinner = options.json ? null : ora('Executing...').start();
+      if (!options.json) console.log(chalk.bold(`Running job '${name}' (${runLabel}, mode: ${job.mode})\n`));
 
       try {
         const result = await executeJob(job);
+        if (options.json) {
+          process.stdout.write(JSON.stringify({
+            ok: true,
+            job: name,
+            runId: result.meta.runId,
+            logDir: getRunDir(name, result.meta.runId),
+          }) + '\n');
+          return;
+        }
         if (result.meta.status === 'completed') {
-          spinner.succeed(`Job completed (exit code: ${result.meta.exitCode})`);
+          spinner!.succeed(`Job completed (exit code: ${result.meta.exitCode})`);
         } else if (result.meta.status === 'timeout') {
-          spinner.warn(`Job timed out after ${job.timeout}`);
+          spinner!.warn(`Job timed out after ${job.timeout}`);
         } else {
-          spinner.fail(`Job failed (exit code: ${result.meta.exitCode})`);
+          spinner!.fail(`Job failed (exit code: ${result.meta.exitCode})`);
         }
 
         console.log(chalk.gray(`  Run: ${result.meta.runId}`));
@@ -803,7 +850,11 @@ export function registerRoutinesCommands(program: Command): void {
           console.log(fs.readFileSync(result.reportPath, 'utf-8'));
         }
       } catch (err) {
-        spinner.fail('Execution failed');
+        if (options.json) {
+          process.stdout.write(JSON.stringify({ error: (err as Error).message }) + '\n');
+          process.exit(1);
+        }
+        spinner!.fail('Execution failed');
         console.error(chalk.red((err as Error).message));
         process.exit(1);
       }

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -8,6 +8,8 @@ import {
   assertNeverPolicyAcknowledged,
   buildRemoteUnlockArgs,
   buildSecretsExecEnv,
+  buildSecretsListJson,
+  buildSecretsViewJson,
   bundleEnvToDotenv,
   exportBundleToFile,
   formatHoldWindow,
@@ -18,7 +20,7 @@ import {
   readImportDotenv,
   renderPolicyCol,
 } from './secrets.js';
-import { parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
+import { describeBundle, parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
 
 describe('parseImportSource', () => {
   it('treats a plain value as a .env path, including stdin', () => {
@@ -448,5 +450,77 @@ describe('exportBundleToFile / importBundleFromFile file round-trip', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('buildSecretsListJson', () => {
+  const bundle = (name: string, vars: Record<string, string>, policy?: SecretsBundle['policy']): SecretsBundle => ({
+    name,
+    vars,
+    ...(policy ? { policy } : {}),
+  });
+
+  it('emits key names, policy, and hold expiry — never values', () => {
+    const bundles = [
+      bundle('prod', { API_KEY: 'keychain:API_KEY', REGION: 'us-east-1' }, 'always'),
+      bundle('daily', { TOKEN: 'keychain:TOKEN' }),
+    ];
+    const held = new Map<string, number>([['daily', 123456]]);
+    const json = buildSecretsListJson(bundles, held);
+    expect(json).toEqual([
+      { name: 'prod', keys: ['API_KEY', 'REGION'], policy: 'always', expiry: null },
+      { name: 'daily', keys: ['TOKEN'], policy: 'daily', expiry: 123456 },
+    ]);
+    // The literal value 'us-east-1' must never surface in the payload.
+    expect(JSON.stringify(json)).not.toContain('us-east-1');
+  });
+
+  it('returns an empty array for no bundles', () => {
+    expect(buildSecretsListJson([])).toEqual([]);
+  });
+});
+
+describe('buildSecretsViewJson', () => {
+  const bundle: SecretsBundle = {
+    name: 'prod',
+    description: 'production creds',
+    policy: 'always',
+    created_at: '2026-01-01T00:00:00Z',
+    vars: {
+      API_KEY: 'keychain:API_KEY',
+      MISSING: 'keychain:MISSING',
+      REGION: 'us-east-1',
+    },
+    meta: {
+      API_KEY: { type: 'api_key', expires: '2026-12-31', note: 'rotate me' },
+    },
+  };
+
+  it('emits per-key metadata and presence, never values by default', () => {
+    const entries = describeBundle(bundle);
+    const present = (e: (typeof entries)[number]) => e.detail !== 'MISSING';
+    const json = buildSecretsViewJson(bundle, entries, present);
+    expect(json.name).toBe('prod');
+    expect(json.policy).toBe('always');
+    expect(json.backend).toBe('keychain');
+    expect(json.keys).toEqual([
+      { name: 'API_KEY', kind: 'keychain', present: true, type: 'api_key', expires: '2026-12-31', note: 'rotate me' },
+      { name: 'MISSING', kind: 'keychain', present: false },
+      { name: 'REGION', kind: 'literal', present: true },
+    ]);
+    // No value fields when not revealing.
+    expect(json.keys.every((k) => !('value' in k))).toBe(true);
+    expect(JSON.stringify(json)).not.toContain('us-east-1');
+  });
+
+  it('includes plaintext values only when a revealed map is passed', () => {
+    const entries = describeBundle(bundle);
+    const revealed = new Map<string, string>([['API_KEY', 'sk-secret'], ['REGION', 'us-east-1']]);
+    const json = buildSecretsViewJson(bundle, entries, () => true, revealed);
+    const byName = Object.fromEntries(json.keys.map((k) => [k.name, k]));
+    expect(byName.API_KEY.value).toBe('sk-secret');
+    expect(byName.REGION.value).toBe('us-east-1');
+    // A key with no revealed entry stays value-less.
+    expect('value' in byName.MISSING).toBe(false);
   });
 });

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -52,6 +52,7 @@ import {
   type SecretsBundle,
   type SecretsPolicy,
   type VarMeta,
+  type BundleEntryInfo,
 } from '../lib/secrets/bundles.js';
 import { encryptForFallback, decryptForFallback, type EncFile } from '../lib/secrets/filestore.js';
 import {
@@ -541,6 +542,93 @@ export function renderPolicyCol(b: SecretsBundle, held?: Map<string, number>): s
   return exp ? chalk.green(`daily · held ${compactRemaining(exp)}`) : chalk.gray('daily');
 }
 
+/** One bundle summary for `secrets list --json`. Metadata only — never a value. */
+export interface SecretsListJsonEntry {
+  name: string;
+  /** Key names in the bundle (no values). */
+  keys: string[];
+  policy: SecretsPolicy;
+  /** Broker hold expiry (epoch-ms) when the secrets-agent is caching this bundle, else null. */
+  expiry: number | null;
+}
+
+/**
+ * Shape the `secrets list --json` payload. Pure — takes the already-read bundles
+ * and the broker `held` map so it is unit-testable. Emits key *names* and policy
+ * metadata only; secret values are never included.
+ */
+export function buildSecretsListJson(
+  bundles: SecretsBundle[],
+  held?: Map<string, number>,
+): SecretsListJsonEntry[] {
+  return bundles.map((b) => ({
+    name: b.name,
+    keys: describeBundle(b).map((e) => e.key),
+    policy: bundlePolicy(b),
+    expiry: held?.get(b.name) ?? null,
+  }));
+}
+
+/** One key's metadata for `secrets view --json` — never a plaintext value unless
+ * `value` is populated by an explicit `--reveal`. */
+export interface SecretsViewJsonKey {
+  name: string;
+  kind: BundleEntryInfo['kind'];
+  /** For keychain-backed keys: whether the item is actually stored. */
+  present: boolean;
+  type?: VarMeta['type'];
+  expires?: VarMeta['expires'];
+  note?: VarMeta['note'];
+  /** Present ONLY when the caller passed --reveal (gated exactly like the human view). */
+  value?: string;
+}
+
+/**
+ * Shape the `secrets view --json` payload. Pure — takes the already-read bundle,
+ * its described entries, a `present` predicate for keychain items, and an
+ * optional map of revealed values (populated only under `--reveal`). Values are
+ * omitted unless explicitly revealed.
+ */
+export function buildSecretsViewJson(
+  bundle: SecretsBundle,
+  entries: BundleEntryInfo[],
+  isPresent: (entry: BundleEntryInfo) => boolean,
+  revealed?: Map<string, string>,
+): {
+  name: string;
+  description?: string;
+  policy: SecretsPolicy;
+  backend: SecretsBackend;
+  created_at?: string;
+  updated_at?: string;
+  last_used?: string;
+  keys: SecretsViewJsonKey[];
+} {
+  const keys: SecretsViewJsonKey[] = entries.map((e) => {
+    const meta = bundle.meta?.[e.key];
+    const key: SecretsViewJsonKey = {
+      name: e.key,
+      kind: e.kind,
+      present: e.kind === 'keychain' ? isPresent(e) : true,
+    };
+    if (meta?.type) key.type = meta.type;
+    if (meta?.expires) key.expires = meta.expires;
+    if (meta?.note) key.note = meta.note;
+    if (revealed?.has(e.key)) key.value = revealed.get(e.key);
+    return key;
+  });
+  return {
+    name: bundle.name,
+    ...(bundle.description ? { description: bundle.description } : {}),
+    policy: bundlePolicy(bundle),
+    backend: bundle.backend ?? 'keychain',
+    ...(bundle.created_at ? { created_at: bundle.created_at } : {}),
+    ...(bundle.updated_at ? { updated_at: bundle.updated_at } : {}),
+    ...(bundle.last_used ? { last_used: bundle.last_used } : {}),
+    keys,
+  };
+}
+
 /** Human-readable hold window for `secrets status`. Sub-hour values render in
  * minutes (so a near-floor `holdMs` never shows a confusing "0 hours"), whole
  * hours up to 2 days, whole days beyond. Pure — unit-tested. */
@@ -853,18 +941,14 @@ export function registerSecretsCommands(program: Command): void {
     .description('List configured secrets bundles (use --host/--hosts to list bundles on other machines over SSH)')
     .option('--host <target>', 'List bundles on a remote host over SSH (enrolled `agents hosts` name, ssh-config alias, or user@host)')
     .option('--hosts <list>', 'Comma-separated hosts to list in one shot, e.g. yosemite-s0,yosemite-s1')
-    .action(async (opts: { host?: string; hosts?: string }) => {
+    .option('--json', 'Emit machine-readable JSON (metadata only — never secret values)')
+    .action(async (opts: { host?: string; hosts?: string; json?: boolean }) => {
       const targets = parseHostsOption(opts);
       if (targets.length > 0) {
         await browseRemote(targets, ['list'], false);
         return;
       }
       const bundles = listBundles();
-      if (bundles.length === 0) {
-        console.log(chalk.gray('No secrets bundles configured.'));
-        console.log(chalk.gray('Try: agents secrets create <name>'));
-        return;
-      }
       // Cross-reference the secrets-agent so `daily` bundles that are currently
       // held can show "· held Nh". Soft-fails to no hint if the broker is down.
       const held = new Map<string, number>();
@@ -874,6 +958,15 @@ export function registerSecretsCommands(program: Command): void {
         } catch {
           /* broker not running — render policy without the countdown */
         }
+      }
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(buildSecretsListJson(bundles, held)) + '\n');
+        return;
+      }
+      if (bundles.length === 0) {
+        console.log(chalk.gray('No secrets bundles configured.'));
+        console.log(chalk.gray('Try: agents secrets create <name>'));
+        return;
       }
       const cols = terminalWidth();
       if (cols >= SECRETS_WIDE) {
@@ -898,7 +991,8 @@ export function registerSecretsCommands(program: Command): void {
     .option('--plaintext', 'Allow --reveal in non-interactive shells (use with care)')
     .option('--host <target>', 'Show a bundle on a remote host over SSH (enrolled `agents hosts` name, ssh-config alias, or user@host)')
     .option('--hosts <list>', 'Comma-separated hosts to show in one shot, e.g. yosemite-s0,yosemite-s1')
-    .action(async (name: string | undefined, opts: { reveal?: boolean; plaintext?: boolean; host?: string; hosts?: string }) => {
+    .option('--json', 'Emit machine-readable JSON (metadata only unless --reveal)')
+    .action(async (name: string | undefined, opts: { reveal?: boolean; plaintext?: boolean; host?: string; hosts?: string; json?: boolean }) => {
       try {
         const targets = parseHostsOption(opts);
         if (targets.length > 0) {
@@ -926,6 +1020,66 @@ export function registerSecretsCommands(program: Command): void {
           process.exit(1);
         }
         const entries = describeBundle(bundle);
+
+        if (opts.json) {
+          const revealJson = Boolean(opts.reveal);
+          if (revealJson && !isInteractiveTerminal() && !opts.plaintext) {
+            process.stdout.write(JSON.stringify({ error: '--reveal in a non-TTY requires --plaintext.' }) + '\n');
+            process.exit(1);
+          }
+          // Map is keyed by bundle key (not keychain item) for the payload builder.
+          const revealedByKey = new Map<string, string>();
+          if (revealJson) {
+            const keychainEntries = entries.filter((e) => e.kind === 'keychain');
+            const itemToKey = new Map<string, string>();
+            const items: string[] = [];
+            for (const e of keychainEntries) {
+              const item = secretsKeychainItem(bundle.name, e.detail);
+              itemToKey.set(item, e.key);
+              items.push(item);
+            }
+            try {
+              for (const [item, value] of getKeychainTokens(items)) {
+                const key = itemToKey.get(item);
+                if (key) revealedByKey.set(key, value);
+              }
+            } catch {
+              /* cancellation / batch failure → omit values, keep metadata */
+            }
+            // Literals are always exposed under --reveal, same as the human view.
+            for (const e of entries) {
+              if (e.kind !== 'literal') continue;
+              const raw = bundle.vars[e.key];
+              revealedByKey.set(
+                e.key,
+                typeof raw === 'string'
+                  ? raw
+                  : (raw && typeof raw === 'object' && 'value' in raw ? (raw as any).value : ''),
+              );
+            }
+            // Same audit chokepoint as the human --reveal path: a reveal exposes
+            // real values and must land in `agents events --module secrets`.
+            if (revealedByKey.size > 0) {
+              emit('secrets.get', {
+                module: 'secrets',
+                bundle: bundle.name,
+                operation: 'view --reveal --json',
+                source: 'reveal',
+                status: 'success',
+                keyCount: revealedByKey.size,
+              });
+            }
+          }
+          const payload = buildSecretsViewJson(
+            bundle,
+            entries,
+            (e) => hasKeychainToken(secretsKeychainItem(bundle.name, e.detail)),
+            revealJson ? revealedByKey : undefined,
+          );
+          process.stdout.write(JSON.stringify(payload) + '\n');
+          return;
+        }
+
         console.log(chalk.bold(bundle.name));
         if (bundle.description) console.log(chalk.gray(safePrint(bundle.description)));
         if (bundle.allow_exec) console.log(chalk.yellow('allow_exec: true'));

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -1077,7 +1077,7 @@ export function registerTeamsCommands(program: Command): void {
     .option('--since <time>', 'Filter: teams active after this time (e.g. "2h", "7d", or ISO date)')
     .option('--until <time>', 'Filter: teams active before this time (e.g. "30d", or ISO date)')
     .option('-n, --limit <n>', 'Show at most this many teams (default: 20)', '20')
-    .option('--json', 'Output machine-readable JSON instead of formatted table')
+    .option('--json', 'Output machine-readable JSON instead of formatted table, or when stdout is piped')
     .action(async (query: string | undefined, opts: {
       agent?: string; status?: string; since?: string; until?: string;
       limit: string; json?: boolean;
@@ -1203,7 +1203,7 @@ export function registerTeamsCommands(program: Command): void {
     .option('--devices <list>', 'Pool of machines this team may run teammates on (comma-separated). Enables distributed auto-scheduling.')
     .option('--hosts <list>', 'Alias for --devices.')
     .option('--repo <urlOrPath>', 'How each remote (--device) teammate gets the code — ONE git URL/path for the whole team (existing checkout reused, else cloned). A team is single-repo; for work across repos, make one team per repo. Defaults to this checkout origin.')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string, opts: { description?: string; enableWorktrees?: boolean; useWorktree?: string; devices?: string; hosts?: string; repo?: string; json?: boolean }) => {
       try {
         // --devices / --hosts are aliases; commander can't express a two-name
@@ -1298,7 +1298,7 @@ export function registerTeamsCommands(program: Command): void {
     .option('--repo <owner/repo>', 'GitHub repository (required for --cloud rush)')
     .option('--branch <name>', 'Target git branch for cloud dispatch')
     .option('--force', "Skip the advisory 'may not be signed in' / 'account throttled' warnings")
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string, teammate: string, task: string, opts: {
       name?: string; mode: string; effort: string; model?: string; env: string[];
       cwd?: string; worktree?: string; after?: string; json?: boolean;
@@ -1690,7 +1690,7 @@ export function registerTeamsCommands(program: Command): void {
     .option('-s, --since <iso>', 'Cursor from a previous status call; only show updates after this timestamp (enables efficient polling)')
     .option('--agent-id <id>', 'Show only this one teammate (by UUID or UUID prefix)')
     .option('-v, --verbose', 'Emit the full per-teammate detail (prompt, all file paths, all messages). Default is a compact summary.')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string | undefined, opts: {
       filter: string; since?: string; agentId?: string; json?: boolean; verbose?: boolean;
     }) => {
@@ -1742,7 +1742,7 @@ export function registerTeamsCommands(program: Command): void {
   teams
     .command('active')
     .description('List every teammate running right now, across all teams (PID-alive check).')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (opts: { json?: boolean }) => {
       const mgr = mkManager();
       const running = await mgr.listRunning();
@@ -1793,7 +1793,7 @@ export function registerTeamsCommands(program: Command): void {
   // start — fire any staged teammates whose --after deps have all completed
   addHostOption(teams.command('start [team]'))
     .description('Launch any pending teammates whose --after dependencies are satisfied. Use --watch to keep draining the DAG as teammates finish and as new tasks are added mid-flight.')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .option('--watch', 'Keep running: poll every --interval seconds, fire new waves, exit when the DAG drains.')
     .option('--interval <seconds>', 'Seconds between waves in --watch mode (default 8)', '8')
     .option('--max-waves <n>', 'Safety cap on waves in --watch mode (default 1000)', '1000')
@@ -1991,7 +1991,7 @@ export function registerTeamsCommands(program: Command): void {
   // stop
   addHostOption(teams.command('stop [team] [teammate]'))
     .description('Stop a running teammate. Resume it later with `agents teams resume`. Cleans up worktree if no uncommitted changes.')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string | undefined, ref: string | undefined, opts: { json?: boolean }) => {
       const mgr = mkManager();
 
@@ -2157,7 +2157,7 @@ export function registerTeamsCommands(program: Command): void {
   addHostOption(teams.command('message <team> <teammate> <message>'))
     .description('Send a follow-up message to a teammate. A running teammate is steered via its mailbox; a stopped one is resumed — re-entering its own session with the message.')
     .option('--from <who>', 'Label recorded as the sender of this message')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string, ref: string, message: string, opts: { json?: boolean; from?: string }) => {
       await teamMessageAction(team, ref, message, opts);
     });
@@ -2165,7 +2165,7 @@ export function registerTeamsCommands(program: Command): void {
   addHostOption(teams.command('resume <team> <teammate> [message]'))
     .description("Resume a stopped teammate (completed/failed/stopped) by re-entering its own session with a message as the next user turn. If the teammate is still running, the message is steered via its mailbox instead.")
     .option('--from <who>', 'Label recorded as the sender of this message')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string, ref: string, message: string | undefined, opts: { json?: boolean; from?: string }) => {
       await teamMessageAction(team, ref, message, opts);
     });
@@ -2176,7 +2176,7 @@ export function registerTeamsCommands(program: Command): void {
     .alias('rm')
     .description("Remove a stopped teammate's logs and metadata. Use 'stop' first to end a running teammate.")
     .option('--keep-logs', 'Keep their log files on disk (default: delete them)')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string | undefined, ref: string | undefined, opts: { keepLogs?: boolean; json?: boolean }) => {
       const mgr = mkManager();
 
@@ -2243,7 +2243,7 @@ export function registerTeamsCommands(program: Command): void {
     .alias('d')
     .description('Disband the team. Stops all teammates cleanly and removes the team registry entry.')
     .option('--keep-logs', 'Keep all teammate logs on disk (default: delete them)')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (team: string | undefined, opts: { keepLogs?: boolean; json?: boolean }) => {
       const mgr = mkManager();
 
@@ -2392,7 +2392,7 @@ export function registerTeamsCommands(program: Command): void {
     .command('doctor')
     .alias('dr')
     .description('Check which agents are installed and available to join a team. Verifies CLI paths and shows an advisory sign-in hint.')
-    .option('--json', 'Output machine-readable JSON')
+    .option('--json', 'Output machine-readable JSON, or when stdout is piped')
     .action(async (opts: { json?: boolean }) => {
       const data = await collectTeamsDoctorData();
 


### PR DESCRIPTION
Closes RUSH-1832, RUSH-1833, RUSH-1834, RUSH-1831 (epic RUSH-1828).

Machine-readable `--json` for the agent-driven read commands so an autonomous agent can parse output instead of scraping human text. Mirrors the existing `monitors list --json` pattern (JSON to stdout via `process.stdout.write(JSON.stringify(payload) + '\n')`, errors to stderr).

## Changes

**RUSH-1832 — `monitors test` / `monitors view` `--json`** (`monitors.ts`)
- `test` (the dry-run "would this fire?" oracle) and `view` were human-text only. Both now emit structured payloads under `--json`. Pure builder `buildMonitorViewJson()` is unit-tested.
- Bug fix: not-found errors used `console.log` (stdout) — routed to `console.error`; `--json` not-found emits `{"error":…}` + exit 1.

**RUSH-1833 — `routines add` / `run` / `runs` `--json`** (`routines.ts`)
- `add` → `{ ok, added, job }`, `run` → `{ ok, job, runId, logDir }`, `runs` → array of run records. Scheduler-start banner suppressed under `--json` so it never pollutes the stream. Pure builder `buildRunsJson()` unit-tested.

**RUSH-1834 — `secrets list` / `view` `--json`** (`secrets.ts`)
- Metadata only (bundle/key names, policy, presence, expiry) — never secret values; reveal stays gated behind `--reveal`. Pure builders `buildSecretsListJson()` / `buildSecretsViewJson()` unit-tested (assert no value leakage).

**RUSH-1831 — document pipe→JSON** (`teams.ts`, `cloud.ts`)
- `isJsonMode()` forces JSON when `--json` is passed **or** stdout is piped; the `--json` help strings now say so. Behavior unchanged (the menubar helper relies on pipe→JSON).

## Verification

Real-flow, from source:
```
monitors list --json            → []
monitors test __nope__ --json   → {"error":"Monitor '__nope__' not found"}  rc=1
routines runs somejob --json    → []
routines run __nope__ --json    → {"error":"Job '__nope__' not found"}  rc=1
secrets list --json             → valid JSON array
```
`tsc --noEmit` clean; 4 new pure-builder test suites pass (93 passed). The single failing test (`secrets export --format json`) is pre-existing and env-driven — it needs the signed native keychain helper absent from an unbuilt worktree, and fails identically on branches that don't touch `secrets.ts`.
