### PR TITLE
feat(cli): reuse warm crabbox boxes for run

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1609.md
+++ b/apps/cli/.changelog/next/RUSH-1609.md
@@ -1,0 +1,1 @@
+- **Reuse warm crabbox boxes from `agents run` (RUSH-1609).** `agents run <agent> "<task>" --box <slug>` now targets an existing warm crabbox box, runs the same bootstrap and credential provisioning as `--lease`, and leaves the box running for reuse across repositories. Source: `apps/cli/src/commands/exec.ts`, `apps/cli/src/lib/crabbox/lease.ts`.

--- a/apps/cli/docs/profiles.md
+++ b/apps/cli/docs/profiles.md
@@ -243,13 +243,16 @@ agents profiles logout openrouter
 
 ```bash
 agents run deepseek "summarize this repo" --lease hetzner
+agents run deepseek "summarize this repo" --box warm-one
 ```
 
 Leased profile runs install the profile's `host.agent` on the disposable box and
 materialize a temporary profile there for the duration of the run. Profiles with
 their own API key, such as OpenRouter-backed `kimi` and `deepseek`, ship that
 profile auth only; the base runtime's local OAuth credential is copied only when
-the profile has no auth env of its own.
+the profile has no auth env of its own. `--box <slug>` targets an existing warm
+crabbox box instead of provisioning a disposable lease, so the same box can serve
+profile runs from different repositories and remains running after the command.
 
 ## Demo
 

--- a/apps/cli/src/commands/exec.test.ts
+++ b/apps/cli/src/commands/exec.test.ts
@@ -52,8 +52,9 @@ describe('trailing-@ account picker request', () => {
       strategy: 'balanced',
       balanced: true,
       lease: true,
+      box: 'warm-one',
       device: 'yosemite-s0',
-    })).toEqual(['--resume', '--strategy', '--balanced', '--lease', '--host/--device']);
+    })).toEqual(['--resume', '--strategy', '--balanced', '--lease', '--box', '--host/--device']);
     expect(runAccountPickerConflicts({})).toEqual([]);
   });
 });

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -78,6 +78,7 @@ interface ExecCommandActionOptions {
   any?: boolean;
   copyCreds?: boolean;
   lease?: string | boolean; // --lease [backend]: true when bare, backend string when given
+  box?: string; // --box <slug>: reuse an existing warm crabbox box
   keepBox?: boolean; // --keep-box: don't tear down the leased box after the run
   secretsKeys?: string; // --secrets-keys: comma-separated key subset for --secrets bundles
   allowExpired?: boolean; // --allow-expired: skip expiry pre-run abort for secrets
@@ -106,6 +107,7 @@ export function runAccountPickerConflicts(options: {
   strategy?: string;
   balanced?: boolean;
   lease?: string | boolean;
+  box?: string;
   host?: string;
   device?: string;
   on?: string;
@@ -116,6 +118,7 @@ export function runAccountPickerConflicts(options: {
   if (options.strategy !== undefined) conflicts.push('--strategy');
   if (options.balanced) conflicts.push('--balanced');
   if (options.lease) conflicts.push('--lease');
+  if (options.box) conflicts.push('--box');
   if (options.host || options.device || options.on || options.computer) conflicts.push('--host/--device');
   return conflicts;
 }
@@ -520,6 +523,10 @@ export function registerRunCommand(program: Command): void {
       '--lease [backend]',
       'Invent a disposable cloud box for this run and tear it down after (via crabbox). Optional backend selects the cloud (hetzner/aws/do). Unlike --host, no machine is registered.',
     )
+    .option(
+      '--box <slug>',
+      'Reuse an existing warm crabbox box for this run instead of provisioning a disposable --lease box.',
+    )
     .option('--keep-box', 'With --lease, keep the box after the run instead of stopping it.');
 
   // `--on` and `--computer` are hidden aliases of `--host` — same behavior.
@@ -639,10 +646,15 @@ export function registerRunCommand(program: Command): void {
       }
 
       // --lease: invent a disposable cloud box for this run (via crabbox), run
-      // the agent there, then tear it down. Unlike --host, nothing is registered.
-      if (options.lease) {
+      // the agent there, then tear it down. --box: reuse a named warm crabbox
+      // box, run the same bootstrap there, and leave the box running.
+      if (options.lease || options.box) {
         if (prompt === undefined) {
-          console.error(chalk.red('A prompt is required for leased runs: agents run <agent> "<task>" --lease'));
+          console.error(chalk.red(`A prompt is required for crabbox runs: agents run <agent> "<task>" ${options.box ? '--box <slug>' : '--lease'}`));
+          process.exit(1);
+        }
+        if (options.lease && options.box) {
+          console.error(chalk.red('Pass either --lease to provision a disposable box, or --box <slug> to reuse a warm box — not both.'));
           process.exit(1);
         }
         const backend = typeof options.lease === 'string' ? options.lease : undefined;
@@ -650,7 +662,7 @@ export function registerRunCommand(program: Command): void {
         // First-run: no provider credential resolves (no env var, no config, no
         // detectable bundle) → guide the user through one-time setup, then continue.
         const { resolveLeaseBundle } = await import('../lib/crabbox/cli.js');
-        if (!resolveLeaseBundle()) {
+        if (options.lease && !resolveLeaseBundle()) {
           const { runLeaseSetup } = await import('./lease.js');
           const ok = await runLeaseSetup({ provider: backend ?? 'hetzner' });
           if (!ok) {
@@ -743,9 +755,17 @@ export function registerRunCommand(program: Command): void {
             : dispatchProfile
               ? `profile '${dispatchProfile.name}'`
               : `${runtime} credentials`;
+        const boxLifecycle = options.box
+          ? `Reusing crabbox box ${options.box}`
+          : `Leasing a ${backend ?? 'hetzner'} box`;
+        const boxAfterRun = options.box
+          ? 'the box is kept after the run'
+          : options.keepBox
+            ? 'the box is kept after the run'
+            : 'the box is destroyed after the run';
         console.error(
           chalk.gray(
-            `Leasing a ${backend ?? 'hetzner'} box · shipping ${whatShips}${credentialRuntimes.length > 0 && leaseEmail ? ` (${leaseEmail})` : ''}; the box is destroyed after the run.`,
+            `${boxLifecycle} · shipping ${whatShips}${credentialRuntimes.length > 0 && leaseEmail ? ` (${leaseEmail})` : ''}; ${boxAfterRun}.`,
           ),
         );
 
@@ -780,7 +800,7 @@ export function registerRunCommand(program: Command): void {
           onSetupLine: (line) => spinner.update(`Setting up box — ${fit(line)}`),
           onAgentChunk: (chunk) => {
             // First agent byte: stop the setup spinner, THEN stream to stdout.
-            if (spinner.active) spinner.stopAndPersist('✔', chalk.gray(`Box provisioned — ${agentName} output:`));
+            if (spinner.active) spinner.stopAndPersist('✔', chalk.gray(`Box setup complete — ${agentName} output:`));
             process.stdout.write(chunk);
           },
         });
@@ -799,6 +819,7 @@ export function registerRunCommand(program: Command): void {
             claudeCredentialsJson,
             secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE,
             keep: options.keepBox,
+            reuseBox: options.box,
             onData: (chunk) => router.push(chunk),
             onPhase: (phase) => {
               if (phase.kind === 'warmup') {
@@ -806,6 +827,8 @@ export function registerRunCommand(program: Command): void {
                 spinner.start(`${label}…`);
                 const t0 = Date.now();
                 warmupTimer = setInterval(() => spinner.update(`${label}… (${Math.round((Date.now() - t0) / 1000)}s)`), 1000);
+              } else if (phase.kind === 'reuse') {
+                spinner.start(`Reusing crabbox box ${phase.slug}…`);
               } else if (phase.kind === 'ready') {
                 stopTimer();
                 spinner.stopAndPersist('✔', `Box ${phase.box.slug} ready${phase.box.ip ? ` (${phase.box.ip})` : ''} · ${Math.round(phase.elapsedMs / 1000)}s`);

--- a/apps/cli/src/lib/crabbox/lease.test.ts
+++ b/apps/cli/src/lib/crabbox/lease.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { buildBootstrapScript } from './lease.js';
+import { buildBootstrapScript, leaseAndRun } from './lease.js';
 import { LEASE_AGENT_MARKER } from './progress.js';
 import type { DetectedRuntime } from './runtimes.js';
 
@@ -177,5 +177,107 @@ describe('buildBootstrapScript', () => {
     });
     // The dangerous prompt is fully contained in a single-quoted argument.
     expect(script).toContain("'don'\\''t break; rm -rf /'");
+  });
+});
+
+describe('leaseAndRun reused crabbox boxes', () => {
+  const detected: DetectedRuntime[] = [
+    { id: 'claude', label: 'Claude Code', email: 'a@b.com', signedIn: true, credPath: null },
+  ];
+
+  function writeFakeCrabbox(tmpDir: string): { log: string; script: string; list: string } {
+    const bin = path.join(tmpDir, 'crabbox');
+    const log = path.join(tmpDir, 'crabbox.log');
+    const script = path.join(tmpDir, 'remote.sh');
+    const list = path.join(tmpDir, 'boxes.json');
+    fs.writeFileSync(
+      list,
+      JSON.stringify([
+        {
+          name: 'crabbox-warm-one',
+          status: 'running',
+          labels: {
+            slug: 'warm-one',
+            lease: 'cbx_warmone',
+            state: 'ready',
+            keep: 'true',
+            created_at: '1800000000',
+            expires_at: '1800003600',
+            last_touched_at: '1800000100',
+            idle_timeout_secs: '1800',
+          },
+          public_net: { ipv4: { ip: '203.0.113.10' } },
+        },
+      ]),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      bin,
+      [
+        '#!/bin/sh',
+        'printf "%s\\n" "$*" >> "$CRABBOX_LOG"',
+        'case "$1" in',
+        '  --help) exit 0 ;;',
+        '  list) cat "$CRABBOX_LIST"; exit 0 ;;',
+        '  run) cat > "$CRABBOX_SCRIPT"; printf "%s\\nagent ok\\n" "' + LEASE_AGENT_MARKER + '"; exit 7 ;;',
+        '  warmup) echo "unexpected warmup" >&2; exit 55 ;;',
+        '  stop) echo "unexpected stop" >&2; exit 66 ;;',
+        '  *) echo "unexpected command: $*" >&2; exit 1 ;;',
+        'esac',
+      ].join('\n'),
+      'utf-8',
+    );
+    fs.chmodSync(bin, 0o755);
+    return { log, script, list };
+  }
+
+  it('finds an existing warm box, runs the bootstrap script, and never warms or stops it', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-reuse-'));
+    const fake = writeFakeCrabbox(tmpDir);
+    const oldEnv = {
+      PATH: process.env.PATH,
+      CRABBOX_LOG: process.env.CRABBOX_LOG,
+      CRABBOX_LIST: process.env.CRABBOX_LIST,
+      CRABBOX_SCRIPT: process.env.CRABBOX_SCRIPT,
+    };
+    process.env.PATH = `${tmpDir}${path.delimiter}${oldEnv.PATH ?? ''}`;
+    process.env.CRABBOX_LOG = fake.log;
+    process.env.CRABBOX_LIST = fake.list;
+    process.env.CRABBOX_SCRIPT = fake.script;
+    const phases: string[] = [];
+    let output = '';
+
+    try {
+      const result = await leaseAndRun({
+        agent: 'claude',
+        prompt: 'reuse the box',
+        runtimes: ['claude'],
+        detected,
+        reuseBox: 'warm-one',
+        onData: (chunk) => { output += chunk; },
+        onPhase: (phase) => { phases.push(phase.kind); },
+      });
+
+      expect(result.box.slug).toBe('warm-one');
+      expect(result.exitCode).toBe(7);
+      expect(result.toreDown).toBe(false);
+      expect(phases).toEqual(['reuse', 'ready']);
+      expect(output).toContain('agent ok');
+
+      const calls = fs.readFileSync(fake.log, 'utf-8').trim().split('\n');
+      expect(calls).toContain('list --json');
+      expect(calls).toContain('run --id warm-one --reclaim --script-stdin');
+      expect(calls.some((line) => line.startsWith('warmup'))).toBe(false);
+      expect(calls.some((line) => line.startsWith('stop'))).toBe(false);
+
+      const remoteScript = fs.readFileSync(fake.script, 'utf-8');
+      expect(remoteScript).toContain("agents run 'claude' 'reuse the box' --quiet");
+    } finally {
+      for (const [key, value] of Object.entries(oldEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/lib/crabbox/lease.ts
+++ b/apps/cli/src/lib/crabbox/lease.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AgentId } from '../types.js';
-import { crabboxWarmup, crabboxWaitReady, crabboxRunScript, crabboxStop, type CrabboxBox } from './cli.js';
+import { crabboxFind, crabboxWarmup, crabboxWaitReady, crabboxRunScript, crabboxStop, type CrabboxBox } from './cli.js';
 import * as yaml from 'yaml';
 import { buildCredentialScript, buildHomeFileWriteScript, CLAUDE_TOKEN_REMOTE, type DetectedRuntime } from './runtimes.js';
 import { LEASE_AGENT_MARKER } from './progress.js';
@@ -16,6 +16,7 @@ import { LEASE_AGENT_MARKER } from './progress.js';
 /** Phase signal for a lease run, so the command layer can drive a progress UI. */
 export type LeasePhase =
   | { kind: 'warmup'; backend?: string }
+  | { kind: 'reuse'; slug: string }
   | { kind: 'ready'; box: CrabboxBox; elapsedMs: number }
   | { kind: 'teardown' };
 
@@ -42,6 +43,8 @@ export interface LeaseRunOptions {
   onPhase?: (phase: LeasePhase) => void;
   /** Keep the box after the run instead of stopping it. */
   keep?: boolean;
+  /** Existing warm crabbox slug to reuse instead of provisioning a new lease. */
+  reuseBox?: string;
   /**
    * Raw wrapped Claude OAuth payload (from `resolveClaudeCredentialsBlob`), written
    * to `~/.claude/.credentials.json` on the box. The command layer resolves it
@@ -177,14 +180,24 @@ export function buildBootstrapScript(opts: LeaseRunOptions): string {
 
 export async function leaseAndRun(opts: LeaseRunOptions): Promise<LeaseRunResult> {
   const startedAt = Date.now();
-  opts.onPhase?.({ kind: 'warmup', backend: opts.backend });
-  const box = await crabboxWarmup({
-    class: opts.boxClass,
-    profile: opts.profile,
-    provider: opts.backend,
-    secretsBundle: opts.secretsBundle,
-  });
-  await crabboxWaitReady(box.slug, { secretsBundle: opts.secretsBundle });
+  let box: CrabboxBox;
+  if (opts.reuseBox) {
+    opts.onPhase?.({ kind: 'reuse', slug: opts.reuseBox });
+    const found = crabboxFind(opts.reuseBox, { secretsBundle: opts.secretsBundle });
+    if (!found) throw new Error(`crabbox box "${opts.reuseBox}" was not found. Check \`crabbox list\` or pass a different --box slug.`);
+    box = found.ready
+      ? found
+      : await crabboxWaitReady(opts.reuseBox, { secretsBundle: opts.secretsBundle });
+  } else {
+    opts.onPhase?.({ kind: 'warmup', backend: opts.backend });
+    box = await crabboxWarmup({
+      class: opts.boxClass,
+      profile: opts.profile,
+      provider: opts.backend,
+      secretsBundle: opts.secretsBundle,
+    });
+    await crabboxWaitReady(box.slug, { secretsBundle: opts.secretsBundle });
+  }
   opts.onPhase?.({ kind: 'ready', box, elapsedMs: Date.now() - startedAt });
 
   const script = buildBootstrapScript(opts);
@@ -197,8 +210,8 @@ export async function leaseAndRun(opts: LeaseRunOptions): Promise<LeaseRunResult
     });
   } finally {
     // Always attempt teardown (bounds credential lifetime to the run) unless the
-    // caller explicitly asked to keep the box.
-    if (!opts.keep) {
+    // caller explicitly asked to keep the box or targeted an existing warm box.
+    if (!opts.keep && !opts.reuseBox) {
       opts.onPhase?.({ kind: 'teardown' });
       toreDown = crabboxStop(box.slug, { secretsBundle: opts.secretsBundle });
     }

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -131,6 +131,7 @@ export const RUN_OPTION_FORWARDING: Record<string, RunOptionForwarding> = {
   any: 'local-only',
   follow: 'local-only',
   lease: 'local-only',
+  box: 'local-only',
   keepBox: 'local-only',
   copyCreds: 'local-only', // copies creds TO the host before dispatch — local concern only
   authCheck: 'local-only', // --no-auth-check gates the local interactive login preflight; --host runs skip that preflight entirely


### PR DESCRIPTION
## Summary
- Add `agents run <agent> "<task>" --box <slug>` to reuse an existing warm crabbox box instead of provisioning a disposable `--lease` box.
- Reuse the existing lease bootstrap, runtime credential provisioning, profile materialization, and progress router; reused boxes are never stopped by the run.
- Document the profile/lease usage, classify the new option in the host-forwarding contract, and add the RUSH-1609 changelog fragment.

## Verification
- `TMPDIR=/tmp/agents-bun-tmp TEMP=/tmp/agents-bun-tmp TMP=/tmp/agents-bun-tmp BUN_INSTALL_CACHE_DIR=/tmp/agents-bun-cache XDG_CACHE_HOME=/tmp/agents-bun-cache bun install` (passes; includes postinstall build)
- `TMPDIR=/tmp/agents-bun-tmp TEMP=/tmp/agents-bun-tmp TMP=/tmp/agents-bun-tmp BUN_INSTALL_CACHE_DIR=/tmp/agents-bun-cache XDG_CACHE_HOME=/tmp/agents-bun-cache bun run build`
- `TMPDIR=/tmp/agents-bun-tmp TEMP=/tmp/agents-bun-tmp TMP=/tmp/agents-bun-tmp BUN_INSTALL_CACHE_DIR=/tmp/agents-bun-cache XDG_CACHE_HOME=/tmp/agents-bun-cache bun run test src/lib/hosts/run-forwarding.test.ts src/lib/crabbox/lease.test.ts src/commands/exec.test.ts` (3 files, 24 tests passed)
- `TMPDIR=/tmp/agents-bun-tmp TEMP=/tmp/agents-bun-tmp TMP=/tmp/agents-bun-tmp BUN_INSTALL_CACHE_DIR=/tmp/agents-bun-cache XDG_CACHE_HOME=/tmp/agents-bun-cache bunx tsc --noEmit`
- Built CLI smoke with a temporary HOME, fake Codex auth, and real temporary `crabbox` executable: `node dist/index.js run codex "box smoke" --box warm-one --mode plan` exited 0, printed `agent smoke ok`, called `crabbox list --json` and `crabbox run --id warm-one --reclaim --script-stdin`, and did not call `warmup` or `stop`.