### PR TITLE
fix(cli): preserve routine device pins under project shadow

### DIFF
--- a/apps/cli/.changelog/next/rush-1825-routines-devices-project-shadow.md
+++ b/apps/cli/.changelog/next/rush-1825-routines-devices-project-shadow.md
@@ -1,0 +1,1 @@
+- Fix `agents routines list` and `agents routines view` so a project-layer routine with the same name no longer hides the user-layer `devices` allowlist written by `agents routines devices --set`.

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -12,26 +12,42 @@ import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { buildRunsJson } from './routines.js';
 import type { RunMeta } from '../lib/routines.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const require = createRequire(import.meta.url);
+const TSX_IMPORT = require.resolve('tsx');
+const CLI_ENTRYPOINT = path.join(REPO_ROOT, 'src', 'index.ts');
 
 /** Provision an isolated HOME with agents.yaml, .system/.git, and optional routines + device registry. */
 function makeHome(opts: {
   jobs?: Record<string, unknown>[];
+  projectJobs?: Record<string, unknown>[];
   registry?: Record<string, unknown>;
 } = {}): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-routines-test-'));
   const agentsDir = path.join(home, '.agents');
   const routinesDir = path.join(agentsDir, 'routines');
+  const projectDir = path.join(home, 'project');
+  const projectRoutinesDir = path.join(projectDir, '.agents', 'routines');
   fs.mkdirSync(routinesDir, { recursive: true });
+  fs.mkdirSync(projectRoutinesDir, { recursive: true });
+  fs.mkdirSync(path.join(projectDir, '.git'), { recursive: true });
   fs.writeFileSync(path.join(agentsDir, 'agents.yaml'), 'agents: {}\n');
   fs.mkdirSync(path.join(agentsDir, '.system', '.git'), { recursive: true });
 
   for (const job of opts.jobs ?? []) {
     fs.writeFileSync(
       path.join(routinesDir, `${job.name}.yml`),
+      yaml.stringify(job),
+    );
+  }
+
+  for (const job of opts.projectJobs ?? []) {
+    fs.writeFileSync(
+      path.join(projectRoutinesDir, `${job.name}.yml`),
       yaml.stringify(job),
     );
   }
@@ -46,9 +62,14 @@ function makeHome(opts: {
 }
 
 /** Run `agents routines <args>` against an isolated HOME. */
-function run(home: string, args: string[], extraEnv: Record<string, string> = {}): ReturnType<typeof spawnSync> {
-  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'routines', ...args], {
-    cwd: REPO_ROOT,
+function run(
+  home: string,
+  args: string[],
+  extraEnv: Record<string, string> = {},
+  cwd: string = REPO_ROOT,
+): ReturnType<typeof spawnSync> {
+  return spawnSync('node', ['--import', TSX_IMPORT, CLI_ENTRYPOINT, 'routines', ...args], {
+    cwd,
     env: {
       ...process.env,
       HOME: home,
@@ -383,6 +404,50 @@ describe('routines list --json has devices+runsHere, no device', () => {
       expect(typeof entry.runsHere).toBe('boolean');
       expect(entry.runsHere).toBe(true);
       expect('device' in entry).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('honors user-layer devices when a repo-bound project routine shadows the same name', () => {
+    const userJob = {
+      ...baseJob,
+      repo: 'phnx-labs/agents-cli',
+      devices: ['zion'],
+      prompt: 'user noop',
+    };
+    const projectJob = {
+      ...baseJob,
+      repo: 'phnx-labs/agents-cli',
+      prompt: 'project noop',
+    };
+    const home = makeHome({ jobs: [userJob], projectJobs: [projectJob], registry });
+    const projectDir = path.join(home, 'project');
+    try {
+      const remoteRes = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'yosemite-s0' }, projectDir);
+      expect(remoteRes.status).toBe(0);
+      const remoteParsed = JSON.parse(remoteRes.stdout.trim());
+      const remoteEntry = remoteParsed.find((j: Record<string, unknown>) => j.name === 'test-job');
+      expect(remoteEntry).toBeDefined();
+      expect(remoteEntry.repo).toBe('phnx-labs/agents-cli');
+      expect(remoteEntry.devices).toEqual(['zion']);
+      expect(remoteEntry.runsHere).toBe(false);
+      expect(remoteEntry.nextRun).toBeNull();
+
+      const localRes = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'zion' }, projectDir);
+      expect(localRes.status).toBe(0);
+      const localParsed = JSON.parse(localRes.stdout.trim());
+      const localEntry = localParsed.find((j: Record<string, unknown>) => j.name === 'test-job');
+      expect(localEntry).toBeDefined();
+      expect(localEntry.devices).toEqual(['zion']);
+      expect(localEntry.runsHere).toBe(true);
+      expect(localEntry.nextRun).not.toBeNull();
+
+      const viewRes = run(home, ['view', 'test-job'], { AGENTS_SYNC_MACHINE_ID: 'zion' }, projectDir);
+      expect(viewRes.status).toBe(0);
+      const viewDoc = yaml.parse(viewRes.stdout.replace(/^Job: test-job\s*/m, ''));
+      expect(viewDoc.prompt).toBe('project noop');
+      expect(viewDoc.devices).toEqual(['zion']);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/lib/__tests__/routines.project-discovery.test.ts
+++ b/apps/cli/src/lib/__tests__/routines.project-discovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as yaml from 'yaml';
 import * as state from '../state.js';
 import { listJobs, readJob } from '../routines.js';
 
@@ -13,10 +14,7 @@ let systemRoutinesDir = '';
 
 function writeRoutine(dir: string, name: string, body: Record<string, unknown>): void {
   fs.mkdirSync(dir, { recursive: true });
-  const yaml = Object.entries(body)
-    .map(([k, v]) => `${k}: ${typeof v === 'string' ? JSON.stringify(v) : v}`)
-    .join('\n');
-  fs.writeFileSync(path.join(dir, `${name}.yml`), yaml, 'utf-8');
+  fs.writeFileSync(path.join(dir, `${name}.yml`), yaml.stringify(body), 'utf-8');
 }
 
 beforeEach(() => {
@@ -103,6 +101,27 @@ describe('listJobs project discovery', () => {
     expect(jobs).toHaveLength(1);
     expect(jobs[0].prompt).toBe('project-version');
   });
+
+  it('keeps a user-layer devices allowlist when a repo-bound project routine has the same name', () => {
+    writeRoutine(userRoutinesDir, 'shared', {
+      schedule: '0 9 * * *',
+      agent: 'claude',
+      prompt: 'user-version',
+      repo: 'phnx-labs/agents-cli',
+      devices: ['zion'],
+    });
+    writeRoutine(projectRoutinesDir, 'shared', {
+      schedule: '0 10 * * *',
+      agent: 'claude',
+      prompt: 'project-version',
+      repo: 'phnx-labs/agents-cli',
+    });
+
+    const jobs = listJobs(projectDir);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].prompt).toBe('project-version');
+    expect(jobs[0].devices).toEqual(['zion']);
+  });
 });
 
 describe('readJob project discovery', () => {
@@ -133,6 +152,27 @@ describe('readJob project discovery', () => {
     const job = readJob('shared', projectDir);
     expect(job).not.toBeNull();
     expect(job!.prompt).toBe('project-version');
+  });
+
+  it('overlays user-layer devices onto a project routine of the same name', () => {
+    writeRoutine(userRoutinesDir, 'shared', {
+      schedule: '0 9 * * *',
+      agent: 'claude',
+      prompt: 'user-version',
+      repo: 'phnx-labs/agents-cli',
+      devices: ['zion'],
+    });
+    writeRoutine(projectRoutinesDir, 'shared', {
+      schedule: '0 10 * * *',
+      agent: 'claude',
+      prompt: 'project-version',
+      repo: 'phnx-labs/agents-cli',
+    });
+
+    const job = readJob('shared', projectDir);
+    expect(job).not.toBeNull();
+    expect(job!.prompt).toBe('project-version');
+    expect(job!.devices).toEqual(['zion']);
   });
 
   it('returns null when neither layer has the routine', () => {

--- a/apps/cli/src/lib/__tests__/routines.project-discovery.test.ts
+++ b/apps/cli/src/lib/__tests__/routines.project-discovery.test.ts
@@ -122,6 +122,25 @@ describe('listJobs project discovery', () => {
     expect(jobs[0].prompt).toBe('project-version');
     expect(jobs[0].devices).toEqual(['zion']);
   });
+
+  it('keeps project-layer devices when same-name user routine has no devices', () => {
+    writeRoutine(userRoutinesDir, 'shared', {
+      schedule: '0 9 * * *',
+      agent: 'claude',
+      prompt: 'user-version',
+    });
+    writeRoutine(projectRoutinesDir, 'shared', {
+      schedule: '0 10 * * *',
+      agent: 'claude',
+      prompt: 'project-version',
+      devices: ['ci-runner'],
+    });
+
+    const jobs = listJobs(projectDir);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].prompt).toBe('project-version');
+    expect(jobs[0].devices).toEqual(['ci-runner']);
+  });
 });
 
 describe('readJob project discovery', () => {
@@ -173,6 +192,25 @@ describe('readJob project discovery', () => {
     expect(job).not.toBeNull();
     expect(job!.prompt).toBe('project-version');
     expect(job!.devices).toEqual(['zion']);
+  });
+
+  it('keeps project-layer devices when same-name user routine has no devices', () => {
+    writeRoutine(userRoutinesDir, 'shared', {
+      schedule: '0 9 * * *',
+      agent: 'claude',
+      prompt: 'user-version',
+    });
+    writeRoutine(projectRoutinesDir, 'shared', {
+      schedule: '0 10 * * *',
+      agent: 'claude',
+      prompt: 'project-version',
+      devices: ['ci-runner'],
+    });
+
+    const job = readJob('shared', projectDir);
+    expect(job).not.toBeNull();
+    expect(job!.prompt).toBe('project-version');
+    expect(job!.devices).toEqual(['ci-runner']);
   });
 
   it('returns null when neither layer has the routine', () => {

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -275,6 +275,7 @@ const JOB_DEFAULTS: Partial<JobConfig> = {
 };
 
 function overlayUserRoutineDevices(job: JobConfig, userJob: JobConfig | null): JobConfig {
+  if (job.devices !== undefined) return job;
   if (!userJob) return job;
   const merged = { ...job };
   if (userJob.devices && userJob.devices.length > 0) {
@@ -290,10 +291,10 @@ function overlayUserRoutineDevices(job: JobConfig, userJob: JobConfig | null): J
  * Higher layers shadow lower ones of the same name (first-seen wins): a project
  * routine shadows a user routine, and a user routine shadows a built-in system
  * routine (`~/.agents/.system/routines/`, shipped via gh:phnx-labs/.agents-system).
- * The user-layer `devices` allowlist is operational state written by
- * `routines devices --set`; when a same-name project routine wins for
- * inspection, that allowlist is overlaid so CWD project discovery cannot hide a
- * fleet pin.
+ * When a same-name project routine wins for inspection, the user-layer
+ * `devices` allowlist is overlaid only if the project routine does not declare
+ * its own allowlist, so CWD project discovery cannot hide an operational fleet
+ * pin or erase a project-authored one.
  * Project discovery is opt-in via `cwd`; the daemon (which calls `listJobs()`
  * with no argument) sees user + system routines, so a built-in routine fires for
  * every install unless the user overrides or disables it by name.
@@ -331,9 +332,9 @@ export function listJobs(cwd?: string): JobConfig[] {
 
 /**
  * Read a single job config by name, checking project > user > system.
- * Same-name project routines keep the user-layer `devices` allowlist for the
- * same reason as listJobs(): device pins are managed state, not routine body
- * content.
+ * Same-name project routines keep the user-layer `devices` allowlist only when
+ * the project routine does not declare its own allowlist, for the same reason
+ * as listJobs().
  * Project discovery is opt-in via `cwd`; daemon callers pass no argument and
  * resolve user + system routines (a user routine of the same name shadows a
  * built-in system routine).

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -274,11 +274,26 @@ const JOB_DEFAULTS: Partial<JobConfig> = {
   enabled: true,
 };
 
+function overlayUserRoutineDevices(job: JobConfig, userJob: JobConfig | null): JobConfig {
+  if (!userJob) return job;
+  const merged = { ...job };
+  if (userJob.devices && userJob.devices.length > 0) {
+    merged.devices = userJob.devices;
+  } else {
+    delete merged.devices;
+  }
+  return merged;
+}
+
 /**
  * List all job configs, scanning project > user > system routine dirs.
  * Higher layers shadow lower ones of the same name (first-seen wins): a project
  * routine shadows a user routine, and a user routine shadows a built-in system
  * routine (`~/.agents/.system/routines/`, shipped via gh:phnx-labs/.agents-system).
+ * The user-layer `devices` allowlist is operational state written by
+ * `routines devices --set`; when a same-name project routine wins for
+ * inspection, that allowlist is overlaid so CWD project discovery cannot hide a
+ * fleet pin.
  * Project discovery is opt-in via `cwd`; the daemon (which calls `listJobs()`
  * with no argument) sees user + system routines, so a built-in routine fires for
  * every install unless the user overrides or disables it by name.
@@ -288,20 +303,24 @@ export function listJobs(cwd?: string): JobConfig[] {
   const seen = new Set<string>();
   const jobs: JobConfig[] = [];
 
-  const dirs: string[] = [];
+  const userDir = getRoutinesDir();
+  const dirs: Array<{ scope: 'project' | 'user' | 'system'; path: string }> = [];
   if (cwd) {
     const projectDir = getProjectRoutinesDir(cwd);
-    if (projectDir) dirs.push(projectDir);
+    if (projectDir) dirs.push({ scope: 'project', path: projectDir });
   }
-  dirs.push(getRoutinesDir());
-  dirs.push(getSystemRoutinesDir());
+  dirs.push({ scope: 'user', path: userDir });
+  dirs.push({ scope: 'system', path: getSystemRoutinesDir() });
 
-  for (const dir of dirs) {
+  for (const { scope, path: dir } of dirs) {
     if (!fs.existsSync(dir)) continue;
     const files = fs.readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
     for (const file of files) {
-      const job = readJobFile(path.join(dir, file));
+      let job = readJobFile(path.join(dir, file));
       if (!job) continue;
+      if (scope === 'project') {
+        job = overlayUserRoutineDevices(job, readJobFromDir(userDir, job.name));
+      }
       if (seen.has(job.name)) continue;
       seen.add(job.name);
       jobs.push(job);
@@ -312,26 +331,39 @@ export function listJobs(cwd?: string): JobConfig[] {
 
 /**
  * Read a single job config by name, checking project > user > system.
+ * Same-name project routines keep the user-layer `devices` allowlist for the
+ * same reason as listJobs(): device pins are managed state, not routine body
+ * content.
  * Project discovery is opt-in via `cwd`; daemon callers pass no argument and
  * resolve user + system routines (a user routine of the same name shadows a
  * built-in system routine).
  */
 export function readJob(name: string, cwd?: string): JobConfig | null {
   ensureAgentsDir();
-  const dirs: string[] = [];
+  const userDir = getRoutinesDir();
+  const dirs: Array<{ scope: 'project' | 'user' | 'system'; path: string }> = [];
   if (cwd) {
     const projectDir = getProjectRoutinesDir(cwd);
-    if (projectDir) dirs.push(projectDir);
+    if (projectDir) dirs.push({ scope: 'project', path: projectDir });
   }
-  dirs.push(getRoutinesDir());
-  dirs.push(getSystemRoutinesDir());
+  dirs.push({ scope: 'user', path: userDir });
+  dirs.push({ scope: 'system', path: getSystemRoutinesDir() });
 
-  for (const dir of dirs) {
-    for (const ext of ['.yml', '.yaml']) {
-      const filePath = safeJoin(dir, name + ext);
-      if (fs.existsSync(filePath)) {
-        return readJobFile(filePath);
-      }
+  for (const { scope, path: dir } of dirs) {
+    const job = readJobFromDir(dir, name);
+    if (job) {
+      if (scope === 'project') return overlayUserRoutineDevices(job, readJobFromDir(userDir, name));
+      return job;
+    }
+  }
+  return null;
+}
+
+function readJobFromDir(dir: string, name: string): JobConfig | null {
+  for (const ext of ['.yml', '.yaml']) {
+    const filePath = safeJoin(dir, name + ext);
+    if (fs.existsSync(filePath)) {
+      return readJobFile(filePath);
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- Preserve the user-layer `devices` allowlist when `agents routines list` / `view` inspect a same-name project-layer routine.
- Add resolver and real CLI subprocess regressions for `repo` + `devices` shadowing.
- Add a bullet-only changelog fragment for the user-visible routines behavior fix.

## Evidence
- `bun install` from `apps/cli` completed and ran the package build (`tsc`).
- `bun run test src/lib/__tests__/routines.project-discovery.test.ts src/commands/routines.test.ts tests/jobs.test.ts` -> 3 files passed, 84 tests passed.
- `bunx tsc --noEmit` -> passed.
- Manual CLI flow from a temp project with user `repo-pinned.yml` containing `repo: phnx-labs/agents-cli` and `devices: [zion]`, plus a same-name project routine with no `devices`:
  - as `AGENTS_SYNC_MACHINE_ID=yosemite-s0`, `routines list --json` emitted `devices:["zion"]`, `runsHere:false`, `nextRun:null`.
  - as `AGENTS_SYNC_MACHINE_ID=zion`, `routines list --json` emitted `devices:["zion"]`, `runsHere:true`, and a concrete `nextRun`.
  - `routines view repo-pinned` emitted a `devices:` block containing `zion`.

## Transcript
Public repo: transcript not attached. Local session context remains on the agent host.
