### PR TITLE
RUSH-1808: agents repo pull fast-forwards after fetch

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1808.md
+++ b/apps/cli/.changelog/next/RUSH-1808.md
@@ -1,0 +1,4 @@
+- `agents repo pull` now fast-forwards the local checkout after fetch
+  (`--ff-only` semantics) and reports when it is blocked by local changes or
+  local commits instead of leaving the checkout behind origin. The system repo
+  uses the same fast-forward path as user and extra repos.

--- a/apps/cli/.changelog/next/RUSH-1808.md
+++ b/apps/cli/.changelog/next/RUSH-1808.md
@@ -2,3 +2,4 @@
   (`--ff-only` semantics) and reports when it is blocked by local changes or
   local commits instead of leaving the checkout behind origin. The system repo
   uses the same fast-forward path as user and extra repos.
+

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import simpleGit from 'simple-git';
-import { confirm, input } from '@inquirer/prompts';
+import { input } from '@inquirer/prompts';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 import { itemPicker } from '../lib/picker.js';
@@ -967,54 +967,8 @@ export function registerRepoCommands(program: Command): void {
             continue;
           }
         }
-        if (t.alias === 'system') {
+        if (t.alias === 'system' && alias !== 'system') {
           // Skip system repo unless explicitly requested
-          if (alias !== 'system') continue;
-
-          // User explicitly asked for system repo — show status and offer to pull
-          try {
-            const git = simpleGit(t.dir);
-            await git.fetch();
-            const status = await git.status();
-            const behind = status.behind ?? 0;
-            if (behind === 0) {
-              console.log(chalk.green('Up to date'));
-            } else {
-              // Count changed resources by type
-              const diff = await git.diff(['--name-only', 'HEAD..@{upstream}']);
-              const files = diff.split('\n').filter(Boolean);
-              const counts: Record<string, number> = {};
-              for (const f of files) {
-                if (f.startsWith('skills/')) counts['skills'] = (counts['skills'] || 0) + 1;
-                else if (f.startsWith('commands/')) counts['commands'] = (counts['commands'] || 0) + 1;
-                else if (f.startsWith('hooks/')) counts['hooks'] = (counts['hooks'] || 0) + 1;
-                else if (f.startsWith('rules/')) counts['rules'] = (counts['rules'] || 0) + 1;
-                else counts['other'] = (counts['other'] || 0) + 1;
-              }
-              const parts: string[] = [];
-              if (counts['skills']) parts.push(`${counts['skills']} skill${counts['skills'] > 1 ? 's' : ''}`);
-              if (counts['commands']) parts.push(`${counts['commands']} command${counts['commands'] > 1 ? 's' : ''}`);
-              if (counts['hooks']) parts.push(`${counts['hooks']} hook${counts['hooks'] > 1 ? 's' : ''}`);
-              if (counts['rules']) parts.push(`${counts['rules']} rule${counts['rules'] > 1 ? 's' : ''}`);
-              if (counts['other']) parts.push(`${counts['other']} other`);
-              const summary = parts.length > 0 ? parts.join(', ') : `${behind} update${behind > 1 ? 's' : ''}`;
-              console.log(chalk.yellow(`${summary} available`));
-
-              if (isInteractiveTerminal()) {
-                const doPull = await confirm({ message: 'Pull now?', default: true });
-                if (doPull) {
-                  const result = await pullRepo(t.dir);
-                  if (result.success) {
-                    console.log(chalk.green('Updated'));
-                  } else {
-                    console.log(chalk.red(result.error || 'Pull failed'));
-                  }
-                }
-              }
-            }
-          } catch (err) {
-            console.log(chalk.red((err as Error).message));
-          }
           continue;
         }
         const spinner = ora(`Pulling ${formatRepoTarget(t.alias, t.dir)}...`).start();

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -290,7 +290,7 @@ describe('pullRepo dirty-tree hint', () => {
     const res = await pullRepo(repo);
 
     expect(res.success).toBe(false);
-    expect(res.error).toContain('Working tree has uncommitted changes');
+    expect(res.error).toContain('Blocked by local changes');
     // The hint must reference this repo's own directory ...
     expect(res.error).toContain(path.basename(repo));
     expect(res.error).toContain(`cd ${displayHomePath(repo)} && git status`);
@@ -398,7 +398,7 @@ describe('commitAndPush (clean-but-ahead + dirty)', () => {
   });
 });
 
-describe('pullRepo divergent rebase', () => {
+describe('pullRepo fast-forward only', () => {
   let root: string;
   let remote: string;
   let local: string;
@@ -440,19 +440,45 @@ describe('pullRepo divergent rebase', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  it('rebases local commits onto divergent upstream instead of failing', async () => {
+  it('fast-forwards when the local branch is behind origin', async () => {
+    await commitFile(author, 'up.txt', 'from-author\n', 'author commit');
+    await simpleGit(author).push('origin', 'main');
+
+    const before = await simpleGit(local).revparse(['HEAD']);
+    const res = await pullRepo(local);
+    const after = await simpleGit(local).revparse(['HEAD']);
+
+    expect(res.success).toBe(true);
+    expect(res.branch).toBe('main');
+    expect(res.commit).toMatch(/^[0-9a-f]{7,8}$/);
+    expect(after).not.toBe(before);
+    expect(fs.existsSync(path.join(local, 'up.txt'))).toBe(true);
+  });
+
+  it('reports already up to date when local matches origin', async () => {
+    const before = await simpleGit(local).revparse(['HEAD']);
+    const res = await pullRepo(local);
+    const after = await simpleGit(local).revparse(['HEAD']);
+
+    expect(res.success).toBe(true);
+    expect(res.branch).toBe('main');
+    expect(after).toBe(before);
+  });
+
+  it('refuses to fast-forward when local commits diverge from origin', async () => {
     // Upstream and local each add a different file → diverged histories.
     await commitFile(author, 'up.txt', 'from-author\n', 'author commit');
     await simpleGit(author).push('origin', 'main');
     await commitFile(local, 'down.txt', 'from-local\n', 'local commit');
 
+    const before = await simpleGit(local).revparse(['HEAD']);
     const res = await pullRepo(local);
-    expect(res.success).toBe(true);
-    expect(res.branch).toBe('main');
-    expect(res.commit).toMatch(/^[0-9a-f]{7,8}$/);
-    // Both sides' files present after rebase.
-    expect(fs.existsSync(path.join(local, 'up.txt'))).toBe(true);
-    expect(fs.existsSync(path.join(local, 'down.txt'))).toBe(true);
+    const after = await simpleGit(local).revparse(['HEAD']);
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Blocked by local commits');
+    expect(after).toBe(before);
+    expect(fs.existsSync(path.join(local, 'up.txt'))).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -893,13 +893,50 @@ export async function pullRepo(
       return {
         success: false,
         commit: '',
-        error: `Working tree has uncommitted changes. Commit or discard them before pulling.\n\n  cd ${displayHomePath(dir)} && git status`,
+        error: `Blocked by local changes. Commit or discard them before pulling.\n\n  cd ${displayHomePath(dir)} && git status`,
       };
     }
 
     const branch = status.current || 'main';
     await git.fetch('origin');
-    await git.pull('origin', branch, { '--rebase': 'true' });
+
+    // Resolve the upstream ref to fast-forward against. Prefer the local
+    // branch's tracking config; otherwise ask origin for its default branch.
+    let tracking = status.tracking;
+    if (!tracking) {
+      try {
+        await git.raw(['remote', 'set-head', 'origin', '--auto']);
+        const sym = await git.raw(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
+        tracking = sym.trim();
+      } catch {
+        tracking = `origin/${branch}`;
+      }
+    }
+
+    const localRef = await git.revparse(['HEAD']);
+    const remoteRef = await git.revparse([tracking]).catch(() => null);
+    if (!remoteRef) {
+      return { success: false, commit: '', error: `Could not resolve upstream ref ${tracking}` };
+    }
+
+    if (localRef === remoteRef) {
+      const log = await git.log({ maxCount: 1 });
+      return {
+        success: true,
+        commit: log.latest?.hash.slice(0, 8) || 'unknown',
+        branch,
+      };
+    }
+
+    try {
+      await git.merge(['--ff-only', tracking]);
+    } catch {
+      return {
+        success: false,
+        commit: '',
+        error: `Blocked by local commits. Push or reset them before pulling.\n\n  cd ${displayHomePath(dir)} && git log --oneline HEAD...${tracking}`,
+      };
+    }
 
     installGithooksSymlinks(dir);
 

--- a/apps/cli/tests/git.test.ts
+++ b/apps/cli/tests/git.test.ts
@@ -32,17 +32,34 @@ describe('pullRepo', () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it('pulls successfully when working tree is clean', async () => {
+  it('fast-forwards when local is behind origin', async () => {
     // Push a new commit to remote so there's something to pull
     writeFileSync(join(REMOTE_DIR, 'new-file.md'), '# New');
     const remoteGit = simpleGit(REMOTE_DIR);
     await remoteGit.add('.');
     await remoteGit.commit('add new file');
 
+    const before = await simpleGit(LOCAL_DIR).revparse(['HEAD']);
     const result = await pullRepo(LOCAL_DIR);
+    const after = await simpleGit(LOCAL_DIR).revparse(['HEAD']);
+
     expect(result.success).toBe(true);
     expect(result.commit).toBeTruthy();
     expect(result.error).toBeUndefined();
+    expect(after).not.toBe(before);
+    expect(
+      await simpleGit(LOCAL_DIR).revparse(['HEAD']),
+    ).toBe(await remoteGit.revparse(['HEAD']));
+  });
+
+  it('reports success when already up to date', async () => {
+    const before = await simpleGit(LOCAL_DIR).revparse(['HEAD']);
+    const result = await pullRepo(LOCAL_DIR);
+    const after = await simpleGit(LOCAL_DIR).revparse(['HEAD']);
+
+    expect(result.success).toBe(true);
+    expect(result.commit).toBeTruthy();
+    expect(after).toBe(before);
   });
 
   it('refuses to pull when working tree has uncommitted changes', async () => {
@@ -51,7 +68,7 @@ describe('pullRepo', () => {
 
     const result = await pullRepo(LOCAL_DIR);
     expect(result.success).toBe(false);
-    expect(result.error).toContain('uncommitted changes');
+    expect(result.error).toContain('Blocked by local changes');
   });
 
   it('refuses to pull when tracked files are modified', async () => {
@@ -60,6 +77,30 @@ describe('pullRepo', () => {
 
     const result = await pullRepo(LOCAL_DIR);
     expect(result.success).toBe(false);
-    expect(result.error).toContain('uncommitted changes');
+    expect(result.error).toContain('Blocked by local changes');
+  });
+
+  it('refuses to fast-forward when local commits diverge from origin', async () => {
+    // Commit on remote, then commit locally on a divergent line.
+    writeFileSync(join(REMOTE_DIR, 'remote-only.txt'), 'remote');
+    const remoteGit = simpleGit(REMOTE_DIR);
+    await remoteGit.add('.');
+    await remoteGit.commit('remote commit');
+
+    writeFileSync(join(LOCAL_DIR, 'local-only.txt'), 'local');
+    const localGit = simpleGit(LOCAL_DIR);
+    await localGit.add('.');
+    await localGit.commit('local commit');
+
+    const before = await localGit.revparse(['HEAD']);
+    const result = await pullRepo(LOCAL_DIR);
+    const after = await localGit.revparse(['HEAD']);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Blocked by local commits');
+    expect(after).toBe(before);
+    expect(
+      await localGit.revparse(['HEAD']),
+    ).not.toBe(await remoteGit.revparse(['HEAD']));
   });
 });

--- a/apps/cli/tests/git.test.ts
+++ b/apps/cli/tests/git.test.ts
@@ -26,6 +26,9 @@ describe('pullRepo', () => {
     // Clone it to local
     mkdirSync(LOCAL_DIR, { recursive: true });
     await simpleGit().clone(REMOTE_DIR, LOCAL_DIR);
+    const localGit = simpleGit(LOCAL_DIR);
+    await localGit.addConfig('user.name', 'Test User');
+    await localGit.addConfig('user.email', 'test@example.com');
   });
 
   afterEach(() => {


### PR DESCRIPTION
Closes #1253

`agents repo pull` now fetches origin and fast-forwards the local checkout (`--ff-only` semantics). It reports when it is blocked by local changes or local commits instead of leaving the checkout behind origin. The system repo uses the same fast-forward path as user and extra repos.

Changes:
- `pullRepo` in `apps/cli/src/lib/git.ts` resolves the upstream ref and merges `--ff-only`.
- `repo pull` command handling no longer shows an interactive "available" prompt for the system repo.
- Updated unit tests (`src/lib/git.test.ts`) and integration tests (`tests/git.test.ts`) for fast-forward, up-to-date, dirty-tree, and divergent-history cases.
- Added changelog fragment `apps/cli/.changelog/next/RUSH-1808.md`.
