### PR TITLE
RUSH-1535: compact live session tails

### DIFF
--- a/apps/cli/.changelog/next/rush-1535-compact-live-tail.md
+++ b/apps/cli/.changelog/next/rush-1535-compact-live-tail.md
@@ -1,1 +1,2 @@
 - Make live session follows compact by default: `agents sessions tail` now prints low-noise message/tool/result lines unless `--json` is passed, and `agents logs -f <id>` keeps raw transcript streaming behind `--full`.
+

--- a/apps/cli/.changelog/next/rush-1535-compact-live-tail.md
+++ b/apps/cli/.changelog/next/rush-1535-compact-live-tail.md
@@ -1,2 +1,3 @@
 - Make live session follows compact by default: `agents sessions tail` now prints low-noise message/tool/result lines unless `--json` is passed, and `agents logs -f <id>` keeps raw transcript streaming behind `--full`.
 
+

--- a/apps/cli/.changelog/next/rush-1535-compact-live-tail.md
+++ b/apps/cli/.changelog/next/rush-1535-compact-live-tail.md
@@ -1,0 +1,1 @@
+- Make live session follows compact by default: `agents sessions tail` now prints low-noise message/tool/result lines unless `--json` is passed, and `agents logs -f <id>` keeps raw transcript streaming behind `--full`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -181,7 +181,19 @@ agents sessions c07ec355 --json --last 30
 
 # Role filtering
 agents sessions c07ec355 --json --include tools,assistant --last 20
+
+# Follow a live Claude/Codex session with compact lines by default
+agents sessions tail c07ec355
+
+# Opt in to raw JSONL when piping the live stream
+agents sessions tail c07ec355 --json | jq 'select(.type == "user")'
 ```
+
+`agents sessions tail` and `agents logs -f <id>` render compact live lines by
+default, even when stdout is piped. They show messages, tool calls, elided tool
+results, and errors; thinking, usage, init, and result metadata are hidden. Use
+`agents sessions tail --json` for the raw JSONL stream, or `agents logs -f --full`
+for the raw transcript follow.
 
 ## BM25 Column Weights
 

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -84,7 +84,7 @@ async function showSession(session: SessionMeta, follow: boolean, full: boolean,
       console.error(chalk.red(`Tailing is supported for claude and codex sessions only (got ${session.agent}).`));
       process.exit(2);
     }
-    await streamSessionTail(session, {});
+    await streamSessionTail(session, { raw: full });
     return;
   }
   await renderSessionLog(session, full ? 'markdown' : 'summary');

--- a/apps/cli/src/commands/sessions-tail.ts
+++ b/apps/cli/src/commands/sessions-tail.ts
@@ -3,7 +3,8 @@
  *
  * Implements `agents sessions tail` — position-tracked reader on the session
  * JSONL, driven by an fs.watch on the parent directory. Claude and Codex
- * only for v1 (both use append-only JSONL).
+ * only for v1 (both use append-only JSONL). Output is compact by default;
+ * --json keeps the raw JSONL stream.
  */
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
@@ -13,6 +14,7 @@ import type { Command } from 'commander';
 import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
 import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
 import { setHelpSections } from '../lib/help.js';
+import { makeStreamRenderer } from '../lib/session/stream-render.js';
 
 const TAIL_SUPPORTED: SessionAgentId[] = ['claude', 'codex'];
 
@@ -145,6 +147,7 @@ export async function tailFile(
 interface TailOptions {
   latest?: boolean;
   fromStart?: boolean;
+  json?: boolean;
 }
 
 async function findLatestTailable(): Promise<SessionMeta | undefined> {
@@ -195,7 +198,7 @@ async function runTail(sessionId: string | undefined, options: TailOptions): Pro
     session = resolved;
   }
 
-  await streamSessionTail(session, { fromStart: options.fromStart });
+  await streamSessionTail(session, { fromStart: options.fromStart, raw: options.json });
 }
 
 /**
@@ -204,9 +207,10 @@ async function runTail(sessionId: string | undefined, options: TailOptions): Pro
  */
 export async function streamSessionTail(
   session: SessionMeta,
-  options: { fromStart?: boolean } = {},
+  options: { fromStart?: boolean; raw?: boolean } = {},
 ): Promise<void> {
   const filePath = session.filePath.split('#')[0];
+  const render = options.raw ? undefined : makeStreamRenderer(session.agent, session.cwd);
 
   if (process.stderr.isTTY) {
     process.stderr.write(
@@ -222,7 +226,12 @@ export async function streamSessionTail(
 
   try {
     await tailFile(filePath, (line) => {
-      process.stdout.write(line + '\n');
+      if (!render) {
+        process.stdout.write(line + '\n');
+        return;
+      }
+      const out = render(line);
+      if (out) process.stdout.write(out + '\n');
     }, ac, { fromStart: options.fromStart });
   } finally {
     process.off('SIGINT', onSig);
@@ -234,9 +243,10 @@ export async function streamSessionTail(
 export function registerSessionsTailCommand(sessionsCmd: Command): void {
   const tailCmd = sessionsCmd
     .command('tail [sessionId]')
-    .description('Stream JSONL events from a session file as they are written, one event per line. Long-running: Ctrl+C to stop. Claude and Codex only.')
+    .description('Stream compact live lines from a session file as events are written. Long-running: Ctrl+C to stop. Claude and Codex only.')
     .option('--latest', 'Tail the most recent tailable session (claude or codex)')
-    .option('--from-start', 'Emit the full file first, then follow (default: start at EOF)');
+    .option('--from-start', 'Emit the full file first, then follow (default: start at EOF)')
+    .option('--json', 'Emit raw JSONL events instead of compact live lines');
 
   setHelpSections(tailCmd, {
     examples: `
@@ -249,16 +259,17 @@ export function registerSessionsTailCommand(sessionsCmd: Command): void {
       # Replay from the beginning, then follow
       agents sessions tail a1b2c3d4 --from-start
 
-      # Pipe through jq to extract just user messages
-      agents sessions tail --latest | jq 'select(.type == "user")'
+      # Pipe raw events through jq to extract just user messages
+      agents sessions tail --latest --json | jq 'select(.type == "user")'
     `,
     notes: `
       - Only Claude and Codex sessions are tailable — they append JSONL one event per line.
+      - Live tail is compact by default; pass --json for the raw JSONL stream.
       - Gemini, OpenCode, and OpenClaw use formats that rewrite the file or store state elsewhere.
     `,
   });
 
-  tailCmd.action(async (sessionId: string | undefined, options: TailOptions) => {
-    await runTail(sessionId, options);
+  tailCmd.action(async (sessionId: string | undefined, _options: TailOptions, command: Command) => {
+    await runTail(sessionId, command.optsWithGlobals() as TailOptions);
   });
 }

--- a/apps/cli/src/lib/session/stream-render.test.ts
+++ b/apps/cli/src/lib/session/stream-render.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { makeStreamRenderer } from './stream-render.js';
+
+describe('makeStreamRenderer', () => {
+  it('renders Claude messages, tool uses, and elided tool results as compact lines', () => {
+    const render = makeStreamRenderer('claude', '/repo');
+
+    const msg = render(JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-07-22T14:32:07.000',
+      message: { content: [{ type: 'text', text: 'Let me check the follow paths...' }] },
+    }));
+    expect(msg).toContain('14:32:07');
+    expect(msg).toContain('· claude');
+    expect(msg).toContain('Let me check the follow paths...');
+
+    const use = render(JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-07-22T14:32:08.000',
+      message: { content: [{ type: 'tool_use', id: 'toolu_1', name: 'Bash', input: { command: 'rg -n "follow" src/' } }] },
+    }));
+    expect(use).toContain('14:32:08');
+    expect(use).toContain('→');
+    expect(use).toContain('Bash');
+    expect(use).toContain('rg -n "follow" src/');
+
+    const result = render(JSON.stringify({
+      type: 'user',
+      timestamp: '2026-07-22T14:32:14.000',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'one\ntwo\nthree' }] },
+    }));
+    expect(result).toContain('14:32:14');
+    expect(result).toContain('✓');
+    expect(result).toContain('Bash');
+    expect(result).toContain('(result elided — 3 lines)');
+    expect(result).not.toContain('one');
+    expect(result).not.toContain('two');
+  });
+
+  it('renders Codex tool calls and hides reasoning/init events', () => {
+    const render = makeStreamRenderer('codex', '/repo');
+
+    expect(render(JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-07-22T14:32:00.000',
+      payload: { cli_version: '0.134.0', cwd: '/repo' },
+    }))).toBeNull();
+
+    expect(render(JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-07-22T14:32:01.000',
+      payload: { type: 'reasoning', summary: [{ text: 'private chain' }] },
+    }))).toBeNull();
+
+    const use = render(JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-07-22T14:32:09.000',
+      payload: {
+        type: 'custom_tool_call',
+        name: 'apply_patch',
+        call_id: 'call_1',
+        input: '*** Begin Patch\n*** Update File: apps/cli/src/commands/sessions-tail.ts\n@@\n-old\n+new\n*** End Patch',
+      },
+    }));
+    expect(use).toContain('14:32:09');
+    expect(use).toContain('→');
+    expect(use).toContain('Edit');
+    expect(use).toContain('apps/cli/src/commands/sessions-tail.ts');
+
+    const result = render(JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-07-22T14:32:15.000',
+      payload: { type: 'custom_tool_call_output', call_id: 'call_1', output: 'patched\nwith details' },
+    }));
+    expect(result).toContain('14:32:15');
+    expect(result).toContain('✓');
+    expect(result).toContain('Edit');
+    expect(result).toContain('(result elided — 2 lines)');
+    expect(result).not.toContain('patched');
+  });
+
+  it('renders user messages distinctly and hides usage/result events', () => {
+    const render = makeStreamRenderer('claude');
+
+    const user = render(JSON.stringify({
+      type: 'user',
+      timestamp: '2026-07-22T14:32:06.000',
+      message: { content: 'Please inspect the live tail path.' },
+    }));
+    expect(user).toContain('14:32:06');
+    expect(user).toContain('» you');
+    expect(user).toContain('Please inspect the live tail path.');
+
+    expect(render(JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-07-22T14:32:07.000',
+      message: {
+        content: [],
+        usage: { input_tokens: 10, output_tokens: 2 },
+      },
+    }))).toBeNull();
+
+    expect(render(JSON.stringify({
+      type: 'result',
+      timestamp: '2026-07-22T14:32:08.000',
+      subtype: 'success',
+    }))).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/session/stream-render.ts
+++ b/apps/cli/src/lib/session/stream-render.ts
@@ -1,0 +1,134 @@
+import chalk from 'chalk';
+import { truncate } from '../format.js';
+import { parseClaudeContent, parseCodexContent, sanitizeEvents, summarizeToolUse } from './parse.js';
+import { linkPath, relativeToCwd } from './render.js';
+import type { SessionAgentId, SessionEvent } from './types.js';
+
+const LINE_MAX = 120;
+
+export type StreamLineRenderer = (line: string) => string | null;
+
+function timeOf(event: SessionEvent): string {
+  const d = new Date(event.timestamp);
+  if (Number.isNaN(d.getTime())) return '00:00:00';
+  return d.toTimeString().slice(0, 8);
+}
+
+function paintTool(tool: string): string {
+  const label = tool.padEnd(10);
+  if (tool === 'Bash' || tool === 'exec_command') return chalk.yellow(label);
+  if (tool === 'Edit' || tool === 'Write' || tool === 'Read') return chalk.cyan(label);
+  if (tool === 'Agent') return chalk.magenta(label);
+  return chalk.cyan(label);
+}
+
+function formatPath(absPath: string, cwd?: string): string {
+  const label = relativeToCwd(absPath, cwd);
+  return absPath.startsWith('/') ? linkPath(absPath, label) : label;
+}
+
+function splitToolSummary(tool: string, summary: string, event: SessionEvent, cwd?: string): string {
+  if (event.path) return formatPath(event.path, cwd);
+
+  const prefix = `${tool}: `;
+  if (summary.startsWith(prefix)) return summary.slice(prefix.length);
+
+  const spacedPrefix = `${tool} `;
+  if (summary.startsWith(spacedPrefix)) return summary.slice(spacedPrefix.length);
+
+  return summary === tool ? '' : summary;
+}
+
+function lineCount(text: string): number {
+  if (!text) return 0;
+  return text.split(/\r?\n/).length;
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? '' : 's'}`;
+}
+
+function claudeToolResultLines(raw: any): number | undefined {
+  if (raw?.type !== 'user' || !Array.isArray(raw?.message?.content)) return undefined;
+  const block = raw.message.content.find((b: any) => b?.type === 'tool_result');
+  if (!block) return undefined;
+  if (typeof block.content === 'string') return lineCount(block.content);
+  if (Array.isArray(block.content)) {
+    const text = block.content
+      .filter((c: any) => c?.type === 'text')
+      .map((c: any) => c.text || '')
+      .join('\n');
+    return lineCount(text);
+  }
+  return 0;
+}
+
+function codexToolResultLines(raw: any): number | undefined {
+  if (raw?.type !== 'response_item') return undefined;
+  const ptype = raw?.payload?.type;
+  if (ptype !== 'function_call_output' && ptype !== 'custom_tool_call_output') return undefined;
+  return lineCount(String(raw.payload.output || ''));
+}
+
+function rawToolResultLines(line: string, agent: SessionAgentId): number | undefined {
+  try {
+    const raw = JSON.parse(line);
+    return agent === 'codex' ? codexToolResultLines(raw) : claudeToolResultLines(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function renderEvent(event: SessionEvent, cwd: string | undefined, lastTool: string | undefined, resultLines: number | undefined): string | null {
+  const prefix = chalk.dim(`${timeOf(event)}  `);
+
+  switch (event.type) {
+    case 'message': {
+      const marker = event.role === 'user' ? chalk.blue('» you       ') : chalk.green(`· ${event.agent.padEnd(9)}`);
+      return prefix + marker + truncate((event.content || '').replace(/\s+/g, ' ').trim(), LINE_MAX);
+    }
+    case 'tool_use': {
+      const tool = event.tool || 'unknown';
+      const summary = summarizeToolUse(tool, event.args);
+      const detail = splitToolSummary(tool, summary, event, cwd);
+      return prefix + chalk.yellow('→ ') + paintTool(tool) + chalk.gray(truncate(detail.replace(/\s+/g, ' ').trim(), LINE_MAX));
+    }
+    case 'tool_result': {
+      const tool = event.tool || lastTool || 'tool';
+      const count = resultLines ?? lineCount(event.output || '');
+      const status = event.success === false ? chalk.red('✗ ') : chalk.green('✓ ');
+      return prefix + status + paintTool(tool) + chalk.dim(`(result elided — ${plural(count, 'line')})`);
+    }
+    case 'error': {
+      const label = event.tool ? `${event.tool}: ` : '';
+      return prefix + chalk.red('✗ Error     ') + chalk.gray(truncate((label + (event.content || '')).replace(/\s+/g, ' ').trim(), LINE_MAX));
+    }
+    case 'thinking':
+    case 'usage':
+    case 'init':
+    case 'result':
+      return null;
+    default:
+      return null;
+  }
+}
+
+export function makeStreamRenderer(agent: SessionAgentId, cwd?: string): StreamLineRenderer {
+  const parse = agent === 'codex' ? parseCodexContent : parseClaudeContent;
+  let lastTool: string | undefined;
+
+  return (line: string): string | null => {
+    const events = parse(line);
+    sanitizeEvents(events);
+    if (events.length === 0) return null;
+
+    const resultLines = rawToolResultLines(line, agent);
+    const rendered: string[] = [];
+    for (const event of events) {
+      const out = renderEvent(event, cwd, lastTool, resultLines);
+      if (event.type === 'tool_use' && event.tool) lastTool = event.tool;
+      if (out) rendered.push(out);
+    }
+    return rendered.length ? rendered.join('\n') : null;
+  };
+}


### PR DESCRIPTION
## Summary
- Add a compact live stream renderer for Claude/Codex JSONL events that shows messages, tool calls, elided tool results, and errors while hiding thinking/usage/init/result noise.
- Wire `agents sessions tail` to compact by default with raw behind `--json`, and wire `agents logs -f` to compact by default with raw behind `--full`.
- Update session docs and add a bullet-only changelog fragment.

## Verification
- `node ./node_modules/vitest/vitest.mjs run src/lib/session/stream-render.test.ts` -> 1 file passed, 3 tests passed.
- `bunx tsc --noEmit` -> exit 0.
- `bun run build` -> exit 0.
- Real copied Claude JSONL through built CLI in isolated HOME: `sessions tail 049d5377 --from-start` produced 2,729 bytes; `sessions tail 049d5377 --from-start --json` produced 120,346 bytes.
- Live follow smoke: `logs -f 049d5377` emitted `14:32:07  · claude   live compact follow smoke` when a JSONL event was appended.
- Raw follow smoke: `logs -f --full 049d5377` emitted the appended raw JSONL line unchanged.
- Pipe smoke: `sessions tail 049d5377 --from-start --json | jq -c 'select(.type == "user") | .type' | head -3` returned three `"user"` rows.

## Notes
- Full `bun run test` is not green in this sandbox because many unrelated suites write to the real `~/.agents` / `~/.agents/.history` paths mounted read-only here, or require local tmux/agent binaries. Example failures include `EROFS: read-only file system, open '/home/muqsit/.agents/.cache/helpers/daemon/daemon.pid'` and tmux meta writes under `/home/muqsit/.agents/.cache/helpers/tmux/*.json`.
- Public repo: session transcript omitted; local operator can find this run by Codex thread `019f8911-37c6-7f40-a435-3d514b76a9e9` on `yosemite-s0` if needed.
