### PR TITLE
fix(permissions): emit Edit(path) instead of Write(path) in Claude settings

### DIFF
--- a/apps/cli/src/lib/permissions.ts
+++ b/apps/cli/src/lib/permissions.ts
@@ -490,13 +490,27 @@ export function removePermissionSet(name: string): { success: boolean; error?: s
 // ============================================================================
 
 /**
+ * Map a canonical rule to Claude settings.json syntax.
+ * Claude's file-permission checks only match Edit(path) rules — an Edit rule
+ * covers every file-editing tool (Write, Edit, NotebookEdit) — and Claude
+ * warns at startup about unmatched Write(path) rules. Canonical Write(path)
+ * stays for other agents' converters; for Claude it is emitted as Edit(path).
+ */
+function canonicalToClaudeRule(perm: string): string {
+  if (perm.startsWith('Write(')) {
+    return perm.replace(/^Write/, 'Edit');
+  }
+  return perm;
+}
+
+/**
  * Convert canonical permission set to Claude format.
  * Claude uses: { permissions: { allow: ["Bash(*)", "Read(**)"], deny: [] } }
  */
 export function convertToClaudeFormat(set: PermissionSet): ClaudePermissions {
   const permissions: ClaudePermissions['permissions'] = {
-    allow: [...set.allow],
-    deny: set.deny ? [...set.deny] : [],
+    allow: [...new Set(set.allow.map(canonicalToClaudeRule))],
+    deny: set.deny ? [...new Set(set.deny.map(canonicalToClaudeRule))] : [],
   };
   if (set.additionalDirectories?.length) {
     permissions.additionalDirectories = [...set.additionalDirectories];
@@ -1452,8 +1466,9 @@ export function applyClaudePermissions(
 
     if (merge && config.permissions) {
       const existing = config.permissions as { allow?: string[]; deny?: string[] };
-      const mergedAllow = new Set([...(existing.allow || []), ...newPermissions.permissions.allow]);
-      const mergedDeny = new Set([...(existing.deny || []), ...newPermissions.permissions.deny]);
+      // Rewrite stale Write(path) rules already installed in settings.json too.
+      const mergedAllow = new Set([...(existing.allow || []).map(canonicalToClaudeRule), ...newPermissions.permissions.allow]);
+      const mergedDeny = new Set([...(existing.deny || []).map(canonicalToClaudeRule), ...newPermissions.permissions.deny]);
       config.permissions = {
         allow: [...mergedAllow],
         deny: [...mergedDeny],
@@ -1650,8 +1665,9 @@ export function applyPermissionsToVersion(
 
       if (merge && config.permissions) {
         const existing = config.permissions as { allow?: string[]; deny?: string[]; additionalDirectories?: string[] };
-        const mergedAllow = new Set([...(existing.allow || []), ...newPermissions.permissions.allow]);
-        const mergedDeny = new Set([...(existing.deny || []), ...newPermissions.permissions.deny]);
+        // Rewrite stale Write(path) rules already installed in settings.json too.
+        const mergedAllow = new Set([...(existing.allow || []).map(canonicalToClaudeRule), ...newPermissions.permissions.allow]);
+        const mergedDeny = new Set([...(existing.deny || []).map(canonicalToClaudeRule), ...newPermissions.permissions.deny]);
         const mergedDirs = new Set([...(existing.additionalDirectories || []), ...(newPermissions.permissions.additionalDirectories || [])]);
         const perms: Record<string, unknown> = {
           allow: [...mergedAllow],

--- a/apps/cli/src/lib/resources/permissions.test.ts
+++ b/apps/cli/src/lib/resources/permissions.test.ts
@@ -249,7 +249,9 @@ describe('PermissionsHandler', () => {
       expect(config.permissions.allow).toContain('Read(**)');
       expect(config.permissions.allow).toContain('Bash(git *)');
       expect(config.permissions.allow).toContain('Bash(npm *)');
-      expect(config.permissions.allow).toContain('Write(**)');
+      // Claude only matches Edit(path) rules; canonical Write(path) is emitted as Edit(path).
+      expect(config.permissions.allow).toContain('Edit(**)');
+      expect(config.permissions.allow).not.toContain('Write(**)');
       expect(config.permissions.deny).toContain('Bash(rm -rf *)');
     });
 

--- a/apps/cli/tests/permissions.test.ts
+++ b/apps/cli/tests/permissions.test.ts
@@ -172,6 +172,18 @@ describe('convertToClaudeFormat', () => {
     expect(result.permissions.allow).toEqual(['Bash(git *)']);
     expect(result.permissions.deny).toEqual([]);
   });
+
+  it('rewrites Write(path) rules to Edit(path) and dedupes against Edit twins', () => {
+    const set: PermissionSet = {
+      name: 'test',
+      allow: ['Write(~/.claude/**)', 'Edit(~/.claude/**)', 'Write(/tmp/*)', 'Write'],
+      deny: ['Write(~/.ssh/**)', 'Edit(~/.ssh/**)'],
+    };
+
+    const result = convertToClaudeFormat(set);
+    expect(result.permissions.allow).toEqual(['Edit(~/.claude/**)', 'Edit(/tmp/*)', 'Write']);
+    expect(result.permissions.deny).toEqual(['Edit(~/.ssh/**)']);
+  });
 });
 
 describe('convertToOpenCodeFormat', () => {
@@ -695,6 +707,32 @@ describe('applyPermissionsToVersion', () => {
     expect(settings.permissions.allow).toContain('Bash(git *)'); // new
     expect(settings.permissions.deny).toContain('Bash(rm *)');
     expect(settings.otherSetting).toBe('preserved');
+  });
+
+  it('migrates stale Write(path) rules in existing Claude settings on merge', () => {
+    const versionHome = join(testDir, 'claude-version-migrate');
+    const claudeDir = join(versionHome, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+
+    const existing = {
+      permissions: {
+        allow: ['Write(~/.claude/**)', 'Edit(~/.claude/**)'],
+        deny: ['Write(~/.ssh/**)', 'Edit(~/.ssh/**)'],
+      },
+    };
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify(existing, null, 2));
+
+    const set: PermissionSet = {
+      name: 'test',
+      allow: ['Bash(git *)'],
+    };
+
+    const result = applyPermissionsToVersion('claude', set, versionHome, true);
+    expect(result.success).toBe(true);
+
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+    expect(settings.permissions.allow).toEqual(['Edit(~/.claude/**)', 'Bash(git *)']);
+    expect(settings.permissions.deny).toEqual(['Edit(~/.ssh/**)']);
   });
 
   it('preserves env, hooks, mcpServers, and custom top-level keys (regression #137)', () => {


### PR DESCRIPTION
## Problem

Claude Code's file-permission checks only match `Edit(path)` rules — an Edit rule covers every file-editing tool (Write, Edit, NotebookEdit). Recent Claude Code versions (2.1.x) warn at startup about every unmatched `Write(path)` rule, so any install synced from the standard permission sets prints a wall of warnings on launch:

```
Permission allow rule (.../settings.json): Write(~/.claude/**) is not matched by file permission
checks — only Edit(path) rules are. Use Edit(~/.claude/**) instead (Edit rules cover all
file-editing tools).
```

The system permission fragments (`.agents-system/permissions/groups/30-paths.yaml`, `99-deny.yaml`) ship `Write(path)` rules, and `convertToClaudeFormat` copies canonical rules verbatim into Claude's `settings.json`.

## Why not drop Write from the canonical sets

Canonical `Write(path)` rules are consumed by other agents' converters (OpenCode maps Write to `write_file`, Grok to its `edit` tool, Cursor rewrites Edit to Write) — so the fix belongs in the Claude emitter, not the fragments.

## Fix

- `canonicalToClaudeRule` rewrites `Write(path)` → `Edit(path)`; `convertToClaudeFormat` applies it with dedupe against existing Edit twins. Bare `Write` (tool-level rule, no path) is left untouched.
- Both `settings.json` merge paths (`applyClaudePermissions`, `applyPermissionsToVersion`) apply the same rewrite to rules already installed, so existing installs self-heal on their next sync instead of keeping the stale rules forever.

Deny protections are unchanged: every rewritten deny rule (e.g. `Write(~/.ssh/**)`) lands on its `Edit(~/.ssh/**)` twin, which Claude actually enforces for all file-editing tools.

## Testing

- New converter test: rewrite + dedupe + bare `Write` passthrough.
- New end-to-end migration test through the real `applyPermissionsToVersion` against a version home with stale rules.
- Updated the resource-sync expectation in `src/lib/resources/permissions.test.ts` to the new intended output.
- Both permissions test files green (98/98). Full suite run compared against a pristine `origin/main` baseline: identical pre-existing failures (exec/models/crabbox/serve, environment-dependent), zero new failures from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)