### PR TITLE
fix(daemon): don't crash-loop on headless Linux when a routine is overdue

### DIFF
--- a/apps/cli/.changelog/next/fix-daemon-notify-crash.md
+++ b/apps/cli/.changelog/next/fix-daemon-notify-crash.md
@@ -1,0 +1,11 @@
+- **The daemon no longer crash-loops on headless Linux when a routine is overdue.**
+  On an overdue routine the daemon fires a best-effort desktop notification via
+  `notify-send` (Linux) / `osascript` (macOS). A missing notifier binary — the
+  default on a headless box without `libnotify-bin` — surfaces as an asynchronous
+  `spawn` `'error'` event, not the synchronous throw the surrounding `try/catch`
+  expected, so Node re-threw it as an uncaught exception and killed the daemon.
+  systemd then restart-looped it every ~10s, which also tore down the browser IPC
+  socket (`agents browser start` failed with "Timeout waiting for browser daemon
+  socket"). Both notifier spawns now carry an `'error'` listener so the failure is
+  swallowed as the "best-effort" contract already promised. Source:
+  `apps/cli/src/lib/overdue.ts`, `apps/cli/src/lib/overdue.test.ts`.

--- a/apps/cli/src/lib/overdue.test.ts
+++ b/apps/cli/src/lib/overdue.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { notifyOverdue, type OverdueJob } from './overdue.js';
+
+function overdueJob(partial: Partial<OverdueJob> = {}): OverdueJob {
+  return {
+    name: 'demo-overdue',
+    expectedAt: new Date(Date.now() - 3_600_000),
+    lastRanAt: null,
+    ...partial,
+  };
+}
+
+describe('notifyOverdue — missing desktop notifier must not crash the daemon', () => {
+  const origPath = process.env.PATH;
+  afterEach(() => {
+    process.env.PATH = origPath;
+  });
+
+  // Regression: the desktop notifier (`osascript` on macOS, `notify-send` on
+  // Linux) is absent on headless boxes. spawn() reports that as an ASYNC 'error'
+  // event, not a synchronous throw — so the surrounding try/catch never saw it,
+  // Node re-threw it as an uncaught exception, and the daemon died on every
+  // overdue routine (systemd then restart-looped it, tearing down the browser
+  // IPC socket). Emptying PATH guarantees ENOENT on every platform, so this
+  // exercises the real spawn path. If the 'error' listener is removed, the async
+  // ENOENT crashes this test process instead of being swallowed.
+  it('swallows the notifier ENOENT and lets the process survive', async () => {
+    process.env.PATH = '';
+
+    notifyOverdue([overdueJob()]);
+    // Let the async spawn 'error' event fire on the next libuv turn.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // Reaching this line means the async ENOENT did not abort the process.
+    expect(true).toBe(true);
+  });
+
+  it('is a no-op for an empty job list (no spawn attempted)', () => {
+    process.env.PATH = '';
+    expect(() => notifyOverdue([])).not.toThrow();
+  });
+});

--- a/apps/cli/src/lib/overdue.ts
+++ b/apps/cli/src/lib/overdue.ts
@@ -114,12 +114,22 @@ export function notifyOverdue(jobs: OverdueJob[]): void {
         ['-e', `display notification "${safeBody}" with title "${safeTitle}"`],
         { detached: true, stdio: 'ignore' }
       );
+      // A missing binary surfaces as an async 'error' event, NOT a synchronous
+      // throw the try/catch would catch. Without a listener Node re-throws it as
+      // an uncaught exception and takes the whole daemon down. Swallow it — the
+      // notification is best-effort.
+      child.on('error', () => {});
       child.unref();
     } else if (platform === 'linux') {
       const child = spawn('notify-send', [title, body], {
         detached: true,
         stdio: 'ignore',
       });
+      // Headless Linux boxes have no `notify-send` (libnotify-bin); its ENOENT
+      // arrives as an async 'error' event, not a throw. Without this listener
+      // the daemon crashes on every overdue routine and systemd restart-loops it
+      // (which also tears down the browser IPC socket). Swallow — best-effort.
+      child.on('error', () => {});
       child.unref();
     }
   } catch {


### PR DESCRIPTION
## What

The `agents-daemon` systemd user service crash-loops on **headless Linux** whenever a routine is overdue, which also takes down the browser IPC socket — `agents browser start` then fails with `Error: Timeout waiting for browser daemon socket`.

## Root cause

On startup the daemon detects overdue routines and fires a best-effort desktop notification (`notifyOverdue` in `apps/cli/src/lib/overdue.ts`) via `notify-send` on Linux / `osascript` on macOS. A headless box has no `notify-send` (no `libnotify-bin`), so the spawn fails with `ENOENT`.

`spawn()` reports a missing binary as an **asynchronous `'error'` event**, not the synchronous throw the surrounding `try/catch` was written to catch. With no `'error'` listener, Node re-throws it as an uncaught exception and the **whole daemon exits (status=1)**. systemd `Restart=` brings it back every ~10s, it re-detects the same overdue routine, and crashes again — a permanent loop. The daemon never lives long enough to bind `browser.sock`.

Observed on `yosemite-m0` (Ubuntu 24.04, headless):

```
Error: spawn notify-send ENOENT
  syscall: 'spawn notify-send'
  spawnargs: ['Routine overdue: check-updates', 'Missed 7/20/2026, 9:00:00 AM...']
agents-daemon.service: Main process exited, code=exited, status=1/FAILURE
agents-daemon.service: Scheduled restart job, restart counter is at 13.
```

## Fix

Attach an `'error'` listener to both notifier spawns so the failure is swallowed — which is exactly what the function's `Best-effort … failures … are swallowed` doc comment already promised. The macOS branch had the same latent flaw (never hit because `osascript` always exists there).

## Test

`apps/cli/src/lib/overdue.test.ts` reproduces the crash by emptying `PATH` (deterministic `ENOENT` on every platform) and asserting the process survives. Verified it **fails without the fix** — the async `spawn osascript ENOENT` surfaces as an Uncaught Exception and the run exits non-zero — and **passes with it**.

## Notes

- Impacts every headless Linux box running the daemon (the whole `yosemite-*` worker fleet) once any routine goes overdue.
- A headless box driving a browser separately needs Chromium launched with `--no-sandbox` (Ubuntu 24.04 AppArmor blocks unprivileged user namespaces) — that's environment config, out of scope for this PR.
