### PR TITLE
Clarify OpenCode hook capability

### DIFF
--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -335,7 +335,9 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     skillsDir: path.join(HOME, '.opencode', 'skills'),
     // Plugins: TS/JS modules auto-loaded from ~/.config/opencode/plugins/ (global)
     // and .opencode/plugins/ (project). Not Claude marketplace format — see
-    // installOpenCodePlugin in plugins.ts. No native shell hooks (plugins only).
+    // installOpenCodePlugin in plugins.ts. OpenCode v1.18.4 exposes lifecycle
+    // hooks through plugin modules (event/tool/etc. functions), not a native
+    // opencode.json shell-command hooks block.
     hooksDir: 'hooks',
     instructionsFile: 'AGENTS.md',
     format: 'markdown',

--- a/apps/cli/tests/agents.test.ts
+++ b/apps/cli/tests/agents.test.ts
@@ -350,6 +350,12 @@ describe('grok subagents (Claude-compatible agent defs)', () => {
 
 
 describe('opencode allowlist (permission in opencode.jsonc)', () => {
+  it('does not advertise native shell hooks because OpenCode hooks are plugin modules', () => {
+    expect(capableAgents('hooks')).not.toContain('opencode');
+    expect(AGENTS.opencode.supportsHooks).toBe(false);
+    expect(AGENTS.opencode.capabilities.hooks).toBe(false);
+  });
+
   it('is capable of allowlist since 1.1.1', () => {
     expect(capableAgents('allowlist')).toContain('opencode');
     expect(supports('opencode', 'allowlist', '1.1.0').ok).toBe(false);


### PR DESCRIPTION
## Summary
- Verified OpenCode v1.18.4 from the upstream tag `49c69c5ed3ccf706b61b3febb43c8aaff7f8325e`; native shell-command lifecycle hooks are not present in `opencode.json`.
- Kept OpenCode `hooks: false`, replaced the stale comment with the plugin-hook mechanism, and added a regression test that `capableAgents('hooks')` excludes OpenCode.

## Evidence
- Official docs describe plugins as the extension path: local JS/TS plugins in `.opencode/plugins/` and `~/.config/opencode/plugins/`, npm packages in config under `plugin`, and plugin-returned hook objects such as `event`, `tool.execute.before`, `shell.env`, and `tool.execute.after`: https://opencode.ai/docs/plugins/
- Upstream config schema `ConfigV1.Info` includes `plugin`, `permission`, and `mcp`, but no top-level `hooks` field: https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/core/src/v1/config/config.ts#L32-L178
- Upstream config loader reads global `config.json`/`opencode.json`/`opencode.jsonc` and project `opencode.json`/`opencode.jsonc`: https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/opencode/src/config/config.ts#L139-L160 and https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/opencode/src/config/config.ts#L258-L260 and https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/opencode/src/config/config.ts#L407-L429
- Upstream plugin runtime stores plugin-returned hooks and dispatches events to `hook.event`: https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/opencode/src/plugin/index.ts#L35-L36 and https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/opencode/src/plugin/index.ts#L110-L119 and https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/opencode/src/plugin/index.ts#L251-L255
- Upstream public hook interface is plugin functions, not shell-command config entries: https://github.com/sst/opencode/blob/49c69c5ed3ccf706b61b3febb43c8aaff7f8325e/packages/plugin/src/index.ts#L224-L281

## Verification
- `bun run test tests/agents.test.ts` passed: 1 file, 34 tests.
- `bun run build` passed.
- GitHub CI passed: bench, gitleaks, test-windows, typecheck, compiled-smoke, test-shard (1), test-shard (2), test-shard (3), and aggregate test.

## Notes
- `prix/code-reviewer` is configured in `.github/rush.yml`, but no `prix-cloud` comment/review had posted after CI settled plus an additional wait.