### PR TITLE
fix(cli): keep isolated installs off bare shims

### DIFF
--- a/apps/cli/src/lib/self-heal/checks/path.ts
+++ b/apps/cli/src/lib/self-heal/checks/path.ts
@@ -8,13 +8,14 @@
 
 import type { HealCheck, HealCtx, CheckResult } from '../types.js';
 import { resultOf } from '../types.js';
-import { isShimsInPath, addShimsToPath } from '../../shims.js';
+import { isShimsInPath, addShimsToPath, listAgentsWithNonIsolatedInstalledVersions } from '../../shims.js';
 
 export const pathCheck: HealCheck = {
   id: 'path',
   title: 'Shims directory on PATH',
   cadence: 'startup',
   async run(ctx: HealCtx): Promise<CheckResult> {
+    if (listAgentsWithNonIsolatedInstalledVersions().length === 0) return resultOf([], []);
     if (isShimsInPath()) return resultOf([], []);
     if (ctx.dryRun) return resultOf(['add shims dir to PATH'], []);
 

--- a/apps/cli/src/lib/self-heal/checks/shims.ts
+++ b/apps/cli/src/lib/self-heal/checks/shims.ts
@@ -12,9 +12,12 @@ import {
   ensureVersionedAliasCurrent,
   isShimCurrent,
   isVersionedAliasCurrent,
+  removeShim,
+  shimExists,
   shimPointsAtLiveInstall,
   removeLegacyUserShim,
   listAgentsWithInstalledVersions,
+  listAgentsWithNonIsolatedInstalledVersions,
   listShimFileNames,
   pruneOrphanedCommandShim,
 } from '../../shims.js';
@@ -26,19 +29,25 @@ export const shimsCheck: HealCheck = {
   cadence: 'frequent',
   async run(ctx: HealCtx): Promise<CheckResult> {
     const fixed: string[] = [];
+    const agentsWithBareShims = new Set(listAgentsWithNonIsolatedInstalledVersions());
 
     for (const agent of listAgentsWithInstalledVersions()) {
       const cmd = AGENTS[agent].cliCommand;
 
-      if (!isShimCurrent(agent)) {
-        if (!ctx.dryRun) ensureShimCurrent(agent);
-        fixed.push(`${cmd} shim`);
-      } else if (!shimPointsAtLiveInstall(agent)) {
-        // Schema is current but the baked AGENTS_BIN points at a different, removed
-        // install (dev build, old npm-global, rotated version dir). ensureShimCurrent
-        // would no-op on a schema-current shim, so force a rewrite to the current install.
-        if (!ctx.dryRun) createShim(agent);
-        fixed.push(`${cmd} shim (repointed to current install)`);
+      if (agentsWithBareShims.has(agent)) {
+        if (!isShimCurrent(agent)) {
+          if (!ctx.dryRun) ensureShimCurrent(agent);
+          fixed.push(`${cmd} shim`);
+        } else if (!shimPointsAtLiveInstall(agent)) {
+          // Schema is current but the baked AGENTS_BIN points at a different, removed
+          // install (dev build, old npm-global, rotated version dir). ensureShimCurrent
+          // would no-op on a schema-current shim, so force a rewrite to the current install.
+          if (!ctx.dryRun) createShim(agent);
+          fixed.push(`${cmd} shim (repointed to current install)`);
+        }
+      } else if (shimExists(agent)) {
+        if (!ctx.dryRun) removeShim(agent);
+        fixed.push(`removed ${cmd} shim (isolated-only)`);
       }
 
       for (const version of listInstalledVersions(agent)) {

--- a/apps/cli/src/lib/self-heal/self-heal.integration.test.ts
+++ b/apps/cli/src/lib/self-heal/self-heal.integration.test.ts
@@ -86,6 +86,60 @@ describe.skipIf(process.platform === 'win32')('runSelfHeal — shims/shadowing/p
   });
 });
 
+describe.skipIf(process.platform === 'win32')('runSelfHeal — isolated-only installs', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'self-heal-isolated-'));
+    const versionDir = path.join(home, '.agents', '.history', 'versions', 'codex', '0.145.0');
+    fs.mkdirSync(path.join(versionDir, 'home'), { recursive: true });
+    const binPath = path.join(versionDir, 'node_modules', '.bin', 'codex');
+    fs.mkdirSync(path.dirname(binPath), { recursive: true });
+    fs.writeFileSync(binPath, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(binPath, 0o755);
+    fs.writeFileSync(path.join(versionDir, '.isolated'), `${new Date().toISOString()}\n`);
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('keeps isolated versions explicit and does not install bare shims or PATH entries', () => {
+    const modulePath = path.resolve(process.cwd(), 'src/lib/self-heal/registry.ts');
+    const statePath = path.resolve(process.cwd(), 'src/lib/state.ts');
+    const script = `
+      import { runSelfHeal } from ${JSON.stringify(modulePath)};
+      import { getShimsDir } from ${JSON.stringify(statePath)};
+      import fs from 'node:fs';
+      import path from 'node:path';
+      const report = await runSelfHeal({ checks: ['shims', 'path'], mode: 'safe' });
+      const shims = getShimsDir();
+      console.log(JSON.stringify({
+        report,
+        bareShim: fs.existsSync(path.join(shims, 'codex')),
+        versionedAlias: fs.existsSync(path.join(shims, 'codex@0.145.0')),
+        bashrc: fs.existsSync(${JSON.stringify(path.join(home, '.bashrc'))})
+          ? fs.readFileSync(${JSON.stringify(path.join(home, '.bashrc'))}, 'utf-8')
+          : '',
+      }));
+    `;
+    const out = execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home, SHELL: '/bin/bash' },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString('utf-8');
+    const result = JSON.parse(out) as {
+      report: Report;
+      bareShim: boolean;
+      versionedAlias: boolean;
+      bashrc: string;
+    };
+    const checks = byId(result.report);
+
+    expect(result.bareShim).toBe(false);
+    expect(result.versionedAlias).toBe(true);
+    expect(result.bashrc).not.toContain('.agents/.cache/shims');
+    expect(checks.path.fixed).toEqual([]);
+  });
+});
+
 interface CheckR { fixed: string[]; needsAttention: string[]; ok: boolean }
 interface Report { checks: { id: string; result: CheckR | null; error?: string }[] }
 

--- a/apps/cli/src/lib/shims.ts
+++ b/apps/cli/src/lib/shims.ts
@@ -2517,6 +2517,27 @@ export function listAgentsWithInstalledVersions(): AgentId[] {
     .filter((agent) => fs.readdirSync(path.join(versionsDir, agent), { withFileTypes: true }).some((entry) => entry.isDirectory()));
 }
 
+function isInstalledVersionIsolated(agent: AgentId, version: string): boolean {
+  return fs.existsSync(path.join(getVersionsDir(), agent, version, '.isolated'));
+}
+
+export function listAgentsWithNonIsolatedInstalledVersions(): AgentId[] {
+  const versionsDir = getVersionsDir();
+  if (!fs.existsSync(versionsDir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(versionsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory() && AGENTS[entry.name as AgentId])
+    .map((entry) => entry.name as AgentId)
+    .filter((agent) => {
+      const agentVersionsDir = path.join(versionsDir, agent);
+      return fs.readdirSync(agentVersionsDir, { withFileTypes: true })
+        .some((entry) => entry.isDirectory() && !isInstalledVersionIsolated(agent, entry.name));
+    });
+}
+
 /**
  * Create shims for all installed agents.
  */
@@ -2532,7 +2553,7 @@ function ensureAllShims(): void {
       const agent = entry.name as AgentId;
       const agentVersionsDir = path.join(versionsDir, agent);
       const versions = fs.readdirSync(agentVersionsDir, { withFileTypes: true })
-        .filter((e) => e.isDirectory());
+        .filter((e) => e.isDirectory() && !isInstalledVersionIsolated(agent, e.name));
 
       if (versions.length > 0 && !shimExists(agent)) {
         createShim(agent);


### PR DESCRIPTION
Fixes a regression where isolated-only installs could trigger startup self-heal to create bare dispatch shims and add the agents shim directory to PATH.

Isolated installs now remain explicit through versioned aliases only; non-isolated installs retain existing shim/PATH behavior.

## Testing
- Added regression coverage for isolated-only Codex installs.
- Verified isolated-only installs do not create a bare `codex` shim or a shell RC PATH entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
