### PR TITLE
fix(menubar): resolve helper bundle + version from the Bun single-file binary

### DIFF
--- a/apps/cli/.changelog/next/menubar-bun-bundle-resolve.md
+++ b/apps/cli/.changelog/next/menubar-bun-bundle-resolve.md
@@ -1,0 +1,10 @@
+- **`agents menubar` now works from the Bun single-file binary.** When the CLI runs
+  as the compiled Bun executable, `import.meta.url` points inside the virtual
+  `/$bunfs/` bundle, so the menu-bar helper couldn't find the shipped
+  `MenubarHelper.app` on disk (`bundle source: missing (cannot enable)`) or read its
+  own `package.json` (`current version: unknown`, and a perpetual "stale" warning).
+  `enable` refused with "no menu-bar helper bundle ships with this install." Version
+  and bundle resolution now fall back to the real on-disk install, located by
+  following the `agents` launcher symlink, so `enable`/`disable`/`status` behave the
+  same whether the CLI runs under Node or the Bun binary. Source:
+  `apps/cli/src/lib/version.ts`, `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getRuntimeStateDir, getHelpersDir } from '../state.js';
-import { getCliVersion } from '../version.js';
+import { getCliVersion, resolveAgentsBin, resolveInstalledLayout } from '../version.js';
 
 const APP_BUNDLE_NAME = 'MenubarHelper.app';
 const INSTALL_DIR_NAME = 'agents-cli';
@@ -90,6 +90,10 @@ export function menubarServiceInstalled(): boolean {
  *   1. dist/lib/menubar/MenubarHelper.app — npm install layout (sibling of this file)
  *   2. <repo>/bin/MenubarHelper.app       — raw working tree (tsx/dev)
  *   3. apps/cli/menubar/dist/MenubarHelper.app — fresh local build
+ *   4. <on-disk install>/dist/lib/menubar/MenubarHelper.app — Bun single-file
+ *      binary: `import.meta.url` is a virtual `/$bunfs/` path, so the sibling
+ *      candidates above can't see the on-disk bundle; recover it via the
+ *      `agents` launcher symlink.
  */
 function sourceAppPath(): string | null {
   const candidates: string[] = [];
@@ -103,28 +107,12 @@ function sourceAppPath(): string | null {
   } catch {
     /* import.meta.url unavailable */
   }
+  const layout = resolveInstalledLayout();
+  if (layout) {
+    candidates.push(path.join(layout.distDir, 'lib', 'menubar', APP_BUNDLE_NAME));
+  }
   for (const c of candidates) {
     if (fs.existsSync(c)) return c;
-  }
-  return null;
-}
-
-/** Resolve the `agents` launcher binary on PATH-less GUI processes. */
-function resolveAgentsBin(): string | null {
-  const home = os.homedir();
-  const candidates = [
-    path.join(home, '.local', 'bin', 'agents'),
-    '/opt/homebrew/bin/agents',
-    '/usr/local/bin/agents',
-    path.join(home, '.npm-global', 'bin', 'agents'),
-  ];
-  for (const c of candidates) {
-    try {
-      fs.accessSync(c, fs.constants.X_OK);
-      return c;
-    } catch {
-      /* try next */
-    }
   }
   return null;
 }

--- a/apps/cli/src/lib/version.test.ts
+++ b/apps/cli/src/lib/version.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCliVersion, getCliVersionFresh } from './version.js';
+import { getCliVersion, getCliVersionFresh, installLayoutFromBin } from './version.js';
 
 describe('version', () => {
   it('getCliVersion returns a non-empty version string', () => {
@@ -20,5 +20,32 @@ describe('version', () => {
     const b = getCliVersionFresh();
     expect(a).toBe(b);
     expect(a).not.toBe('');
+  });
+});
+
+// Regression guard for the Bun single-file binary: `import.meta.url` is a virtual
+// `/$bunfs/` path there, so version + menu-bar-bundle resolution must fall back to
+// the on-disk install found via the `agents` launcher symlink. This locks the
+// dirname chain (`<pkg>/dist/bin/agents` -> `<pkg>/dist`) that the fallback rides.
+describe('installLayoutFromBin', () => {
+  it('derives dist/, entry, and package.json from an nvm launcher path', () => {
+    const bin =
+      '/Users/me/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli/dist/bin/agents';
+    const pkg = '/Users/me/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli';
+    expect(installLayoutFromBin(bin)).toEqual({
+      distDir: `${pkg}/dist`,
+      entryPath: `${pkg}/dist/index.js`,
+      pkgJsonPath: `${pkg}/package.json`,
+    });
+  });
+
+  it('derives the layout from a bun-global launcher path', () => {
+    const bin = '/Users/me/.bun/install/global/node_modules/@phnx-labs/agents-cli/dist/bin/agents';
+    const pkg = '/Users/me/.bun/install/global/node_modules/@phnx-labs/agents-cli';
+    expect(installLayoutFromBin(bin)).toEqual({
+      distDir: `${pkg}/dist`,
+      entryPath: `${pkg}/dist/index.js`,
+      pkgJsonPath: `${pkg}/package.json`,
+    });
   });
 });

--- a/apps/cli/src/lib/version.ts
+++ b/apps/cli/src/lib/version.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -7,22 +8,114 @@ const __dirname = path.dirname(__filename);
 
 let cached: string | null = null;
 
+/** Read a `version` string from a package.json, or null if unreadable. */
+function readVersionAt(pkgPath: string): string | null {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return String(pkg.version || '') || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Well-known locations of the `agents` launcher for PATH-less GUI/launchd
+ * processes (the menu-bar helper inherits no login PATH). Also the anchor for
+ * recovering the on-disk install layout when the CLI runs as a Bun single-file
+ * binary — see {@link resolveInstalledLayout}.
+ */
+export function resolveAgentsBin(): string | null {
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, '.local', 'bin', 'agents'),
+    '/opt/homebrew/bin/agents',
+    '/usr/local/bin/agents',
+    path.join(home, '.npm-global', 'bin', 'agents'),
+  ];
+  for (const c of candidates) {
+    try {
+      fs.accessSync(c, fs.constants.X_OK);
+      return c;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+export interface InstallLayout {
+  /** The install's `dist/` directory (holds `index.js` + `lib/`). */
+  distDir: string;
+  /** The compiled CLI entry, `dist/index.js`. */
+  entryPath: string;
+  /** The shipping `package.json`, `dist/../package.json`. */
+  pkgJsonPath: string;
+}
+
+/**
+ * Pure derivation (no I/O) of an install's on-disk layout from the realpath of
+ * its `agents` launcher. A launcher lives at `<pkg>/dist/bin/agents`, so two
+ * levels up is `<pkg>/dist`. Exported for unit testing so the dirname chain the
+ * Bun-binary fallback depends on stays locked.
+ */
+export function installLayoutFromBin(realBin: string): InstallLayout {
+  const distDir = path.dirname(path.dirname(realBin)); // <pkg>/dist/bin/agents -> <pkg>/dist
+  return {
+    distDir,
+    entryPath: path.join(distDir, 'index.js'),
+    pkgJsonPath: path.join(distDir, '..', 'package.json'),
+  };
+}
+
+/**
+ * Resolve the on-disk install layout of the running CLI by following the
+ * `agents` launcher symlink.
+ *
+ * When the CLI runs as a Bun single-file executable, `import.meta.url` points
+ * inside the virtual bundle (`/$bunfs/…`), so sibling-relative resolution can't
+ * see the shipped `package.json`, `dist/index.js`, or `MenubarHelper.app` on
+ * disk. The launcher symlink points at the real files; walk up from it. Returns
+ * null when no launcher is found (dev/tsx runs, or a box without the helper) —
+ * callers keep their in-bundle resolution as the primary path and use this only
+ * as the fallback.
+ */
+export function resolveInstalledLayout(): InstallLayout | null {
+  const bin = resolveAgentsBin();
+  if (!bin) return null;
+  try {
+    const layout = installLayoutFromBin(fs.realpathSync(bin));
+    // Validate we landed on a real dist (guards an unexpected launcher layout).
+    if (fs.existsSync(layout.entryPath)) return layout;
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
 /**
  * Resolve the CLI version from the shipping package.json. Used by the daemon
  * to answer `IPCAction: 'version'` and by the client to detect daemon drift —
  * a dev-build CLI talking to a launchd-managed registry daemon would silently
  * get stale behavior without this check.
+ *
+ * Primary read is relative to this module; when that fails (the Bun single-file
+ * binary can't read its own bundled package.json), fall back to the on-disk
+ * install found via the launcher symlink so callers like the menu bar don't see
+ * a bogus `unknown`.
  */
 export function getCliVersion(): string {
   if (cached) return cached;
-  try {
-    const pkgPath = path.join(__dirname, '..', '..', 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-    cached = String(pkg.version || 'unknown');
-  } catch {
-    cached = 'unknown';
-  }
+  cached =
+    readVersionAt(path.join(__dirname, '..', '..', 'package.json')) ??
+    readInstalledPackageVersion() ??
+    'unknown';
   return cached;
+}
+
+/** Version from the on-disk install (Bun-binary fallback). */
+function readInstalledPackageVersion(): string | null {
+  const layout = resolveInstalledLayout();
+  return layout ? readVersionAt(layout.pkgJsonPath) : null;
 }
 
 /**
@@ -36,11 +129,9 @@ export function getCliVersion(): string {
  * 'unknown' on any error.
  */
 export function getCliVersionFresh(): string {
-  try {
-    const pkgPath = path.join(__dirname, '..', '..', 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-    return String(pkg.version || 'unknown');
-  } catch {
-    return 'unknown';
-  }
+  return (
+    readVersionAt(path.join(__dirname, '..', '..', 'package.json')) ??
+    readInstalledPackageVersion() ??
+    'unknown'
+  );
 }


### PR DESCRIPTION
## Problem

`agents menubar` is broken when the CLI runs as the **Bun single-file executable**
(the published `dist/bin/agents`). In that runtime `import.meta.url` resolves inside
the virtual `/$bunfs/` bundle, so the menu-bar code can't:

- find the shipped `MenubarHelper.app` on disk → **`bundle source: missing (cannot enable)`**
- read its own `package.json` → **`current version: unknown`** + a perpetual **`Installed helper is stale`**

`agents menubar enable` then refuses with *"no menu-bar helper bundle ships with this
install."* — even though the helper is fully installed and correct. Only the resolver
was blind. (`--version` works because `build-bin.sh` bakes it as a constant; the
runtime `package.json` read is what fails.)

## Fix

Add an on-disk fallback that follows the `agents` launcher symlink to recover the
real install layout (`<pkg>/dist/bin/agents` → `<pkg>/dist`), used **only when the
in-bundle primary path fails** — Node runs are unchanged:

- **`version.ts`** — `resolveInstalledLayout()` + pure, unit-tested `installLayoutFromBin()`; `getCliVersion`/`getCliVersionFresh` fall back to the on-disk `package.json`. (`resolveAgentsBin` moved here as the canonical install-location resolver; menubar imports it.)
- **`install-menubar.ts`** — `sourceAppPath()` gains the on-disk `MenubarHelper.app` as a 4th candidate.

`resolveCliEntry()` / `AGENTS_ENTRY` is **deliberately unchanged**: under Bun,
`process.execPath` is the compiled binary (not node), so the plist correctly degrades
to `AGENTS_BIN=<self-contained binary>` (confirmed against `AgentsCLI.swift argv()`).
Baking `AGENTS_ENTRY` there would produce a broken `<bun-binary> index.js` invocation.

## Verification (end-to-end from the real Bun runtime)

Compiled a Bun binary from the patched source (`scripts/build-bin.sh`) and ran it:

**Before** (current published binary):
```
bundle source      missing (cannot enable)
current version    unknown
Installed helper is stale
```

**After** (patched binary):
```
running            yes
installed version  1.20.72
current version    1.20.72
bundle source      /Users/…/@phnx-labs/agents-cli/dist/lib/menubar/MenubarHelper.app
```

- `tsc --noEmit`: clean
- `version.test.ts` + `install-menubar.test.ts`: **16/16 pass** (adds `installLayoutFromBin` derivation guards for nvm + bun-global launcher paths)
- Full `src/lib` suite: the pre-existing env failures (locked native credential store, session-db SQLite fixtures) are unrelated — no failing file imports the changed modules.

Session transcript (confidential — not uploaded): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/a179cdb9-046b-4d56-8dcc-7da3fe11b34b.jsonl`
