### PR TITLE
feat(cli): agents send + agents notify — unified channel-send primitive

### DIFF
--- a/apps/cli/src/commands/send.ts
+++ b/apps/cli/src/commands/send.ts
@@ -1,0 +1,92 @@
+/**
+ * `agents send <text> --channel <name> --to <target>` — deliver a message over
+ * any registered channel (mailbox, telegram, imessage, slack, discord, apps).
+ *
+ * `agents notify <text>` — owner-facing alias. Fills channel + target from the
+ * `notify.owner` block in agents.yaml when not passed, so routines/agents ping
+ * the owner without hardcoding a chat id / host / account.
+ *
+ * Both go through one `doSend()` seam: resolve the provider for the channel
+ * (notify.transports picks the transport per host) and call provider.send().
+ * The agent mailbox is just one channel; `agents message` stays the richer
+ * agent-control command (feed-claim / identity / PTY / resume) on the same spool.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { die } from '../lib/format.js';
+import { readMeta } from '../lib/state.js';
+import { registerBuiltinProviders } from '../lib/channels/providers/index.js';
+import { resolveTransport } from '../lib/channels/resolve.js';
+import type { SendResult } from '../lib/channels/registry.js';
+
+interface SendCliOpts {
+  channel?: string;
+  to?: string;
+  thread?: string;
+  attachment?: string[];
+  from?: string;
+  json?: boolean;
+  dryRun?: boolean;
+}
+
+async function doSend(text: string, channel: string, to: string, opts: SendCliOpts): Promise<void> {
+  registerBuiltinProviders();
+  const provider = resolveTransport(channel, readMeta());
+  const result: SendResult = await provider.send(text, {
+    target: to,
+    thread: opts.thread,
+    attachments: opts.attachment,
+    from: opts.from,
+    dryRun: opts.dryRun,
+  });
+
+  if (opts.json) {
+    console.log(JSON.stringify(result));
+    if (!result.ok) process.exit(1);
+    return;
+  }
+  if (!result.ok) {
+    die(`send failed [${result.channel} → ${result.id}]: ${result.error ?? 'unknown error'}`);
+  }
+  const suffix = result.msgId ? chalk.dim(` (${result.msgId})`) : '';
+  const dry = opts.dryRun ? chalk.dim(' [dry-run]') : '';
+  console.log(chalk.green(`Sent via ${result.channel} → ${result.id}`) + suffix + dry);
+}
+
+export function registerSendCommand(program: Command): void {
+  program
+    .command('send <text>')
+    .description('Send a message through a channel provider (mailbox, telegram, imessage, slack, discord).')
+    .requiredOption('--channel <name>', 'channel / provider name')
+    .requiredOption('--to <target>', 'channel-specific recipient id')
+    .option('--thread <id>', 'channel thread id / timestamp')
+    .option('--attachment <path...>', 'file attachment path (repeatable)')
+    .option('--from <who>', 'sender label (mailbox)')
+    .option('--json', 'output JSON')
+    .option('--dry-run', 'resolve + build but do not send')
+    .action(async (text: string, opts: SendCliOpts) => {
+      await doSend(text, opts.channel!, opts.to!, opts);
+    });
+
+  program
+    .command('notify <text>')
+    .description('Notify the owner (channel + target default to notify.owner in agents.yaml).')
+    .option('--channel <name>', 'override owner channel')
+    .option('--to <target>', 'override owner target')
+    .option('--thread <id>', 'channel thread id / timestamp')
+    .option('--attachment <path...>', 'file attachment path (repeatable)')
+    .option('--json', 'output JSON')
+    .option('--dry-run', 'resolve + build but do not send')
+    .action(async (text: string, opts: SendCliOpts) => {
+      const owner = readMeta().notify?.owner;
+      const channel = opts.channel ?? owner?.channel;
+      const to = opts.to ?? owner?.to;
+      if (!channel || !to) {
+        die(
+          'notify: no --channel/--to given and no notify.owner.{channel,to} in agents.yaml. ' +
+            'Set notify.owner or pass --channel/--to.',
+        );
+      }
+      await doSend(text, channel, to, opts);
+    });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -147,6 +147,7 @@ import {
   loadSetup,
   loadUninstall,
   loadShare,
+  loadSend,
   loadHq,
   loadFeed,
   loadMailboxes,
@@ -821,6 +822,7 @@ async function registerEagerForRequest(name: string): Promise<boolean> {
 async function registerAllEagerCommands(): Promise<void> {
   await reg(loadView);
   await reg(loadShare);
+  await reg(loadSend);
   await reg(loadInspect);
   await reg(loadResources);
   await reg(loadFeedback);

--- a/apps/cli/src/lib/channels/providers/index.ts
+++ b/apps/cli/src/lib/channels/providers/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Provider barrel — importing this registers every built-in channel provider.
+ * "App" providers register themselves the same way (registerChannelProvider),
+ * so nothing here is privileged over an extension.
+ */
+import { registerChannelProvider } from '../registry.js';
+import { mailboxProvider } from './mailbox.js';
+import { rushProviders } from './rush.js';
+import { openclawTelegramProvider } from './openclaw-telegram.js';
+
+let registered = false;
+
+/** Register all built-in providers once (idempotent). */
+export function registerBuiltinProviders(): void {
+  if (registered) return;
+  registered = true;
+  registerChannelProvider(mailboxProvider);
+  for (const p of rushProviders) registerChannelProvider(p);
+  registerChannelProvider(openclawTelegramProvider);
+}

--- a/apps/cli/src/lib/channels/providers/mailbox.test.ts
+++ b/apps/cli/src/lib/channels/providers/mailbox.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import * as fs from 'fs';
+import { mailboxProvider } from './mailbox.js';
+import { mailboxDir, peek } from '../../mailbox.js';
+
+// Unique throwaway box in the real spool (repo rule: real services, no mocking).
+const BOX = `agents-send-test-${process.pid}`;
+
+afterEach(() => {
+  try {
+    fs.rmSync(mailboxDir(BOX), { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('mailbox provider', () => {
+  it('enqueues a real message into the box inbox and returns msgId', async () => {
+    const res = await mailboxProvider.send('hello mailbox', { target: BOX, from: 'send-test' });
+    expect(res.ok).toBe(true);
+    expect(res.channel).toBe('mailbox');
+    expect(res.msgId).toBeTruthy();
+
+    const pending = peek(mailboxDir(BOX), BOX);
+    expect(pending.map((m) => m.text)).toContain('hello mailbox');
+    expect(pending.find((m) => m.text === 'hello mailbox')?.from).toBe('send-test');
+  });
+
+  it('rejects an invalid mailbox id without throwing', async () => {
+    const res = await mailboxProvider.send('x', { target: '../etc/passwd' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/invalid mailbox id/i);
+  });
+
+  it('dry-run does not write', async () => {
+    const res = await mailboxProvider.send('nope', { target: BOX, dryRun: true });
+    expect(res.ok).toBe(true);
+    expect(res.msgId).toBeUndefined();
+    expect(peek(mailboxDir(BOX), BOX)).toHaveLength(0);
+  });
+});

--- a/apps/cli/src/lib/channels/providers/mailbox.ts
+++ b/apps/cli/src/lib/channels/providers/mailbox.ts
@@ -1,0 +1,27 @@
+/**
+ * Mailbox channel provider — delivers to an agent's file-based mailbox.
+ *
+ * The mailbox is one channel among many. This provider is a thin wrapper over
+ * the same `enqueue` seam that `agents message` uses (commands/message.ts), so
+ * both callers share one spool at ~/.agents/.history/mailbox/<id>/.
+ */
+import { mailboxDir, enqueue, isValidMailboxId } from '../../mailbox.js';
+import type { ChannelProvider, SendOptions, SendResult } from '../registry.js';
+
+export const mailboxProvider: ChannelProvider = {
+  name: 'mailbox',
+  async send(text: string, opts: SendOptions): Promise<SendResult> {
+    if (!isValidMailboxId(opts.target)) {
+      return { ok: false, channel: 'mailbox', id: opts.target, error: `invalid mailbox id '${opts.target}'` };
+    }
+    if (opts.dryRun) {
+      return { ok: true, channel: 'mailbox', id: opts.target };
+    }
+    try {
+      const msgId = enqueue(mailboxDir(opts.target), { to: opts.target, text, from: opts.from });
+      return { ok: true, channel: 'mailbox', id: opts.target, msgId };
+    } catch (err) {
+      return { ok: false, channel: 'mailbox', id: opts.target, error: (err as Error).message };
+    }
+  },
+};

--- a/apps/cli/src/lib/channels/providers/openclaw-telegram.ts
+++ b/apps/cli/src/lib/channels/providers/openclaw-telegram.ts
@@ -1,0 +1,35 @@
+/**
+ * OpenClaw Telegram provider — the mac-mini path.
+ *
+ * A DISTINCT provider from the rush-backed `telegram` (not a fallback): it
+ * reuses the existing openclaw argv builder (lib/notify.ts). Hosts that have
+ * openclaw on PATH (mac-mini) can map `transports.telegram: openclaw-telegram`;
+ * hosts with a live rush daemon (zion) map `transports.telegram: telegram`.
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { buildOpenClawNotifyArgs } from '../../notify.js';
+import type { ChannelProvider, SendOptions, SendResult } from '../registry.js';
+
+const execFileAsync = promisify(execFile);
+
+export const openclawTelegramProvider: ChannelProvider = {
+  name: 'openclaw-telegram',
+  async send(text: string, opts: SendOptions): Promise<SendResult> {
+    const name = 'openclaw-telegram';
+    if (opts.dryRun) {
+      return { ok: true, channel: name, id: opts.target };
+    }
+    try {
+      await execFileAsync('which', ['openclaw']);
+    } catch {
+      return { ok: false, channel: name, id: opts.target, error: 'openclaw CLI not found on PATH' };
+    }
+    try {
+      await execFileAsync('openclaw', buildOpenClawNotifyArgs(text, { channel: 'telegram', target: opts.target }));
+      return { ok: true, channel: name, id: opts.target };
+    } catch (err) {
+      return { ok: false, channel: name, id: opts.target, error: (err as Error).message };
+    }
+  },
+};

--- a/apps/cli/src/lib/channels/providers/rush.test.ts
+++ b/apps/cli/src/lib/channels/providers/rush.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildRushSendArgs, rushProviders, RUSH_CHANNELS } from './rush.js';
+
+describe('buildRushSendArgs', () => {
+  it('builds the rush send argv with required channel/id and --json', () => {
+    const args = buildRushSendArgs('telegram', 'hello', { target: '6078999250' });
+    expect(args).toEqual(['send', 'hello', '--channel', 'telegram', '--id', '6078999250', '--json']);
+  });
+
+  it('appends --thread and repeatable --attachment', () => {
+    const args = buildRushSendArgs('slack', 'hi', {
+      target: 'C0123',
+      thread: '1712345678.000100',
+      attachments: ['/a.pdf', '/b.png'],
+    });
+    expect(args).toContain('--thread');
+    expect(args[args.indexOf('--thread') + 1]).toBe('1712345678.000100');
+    expect(args.filter((a) => a === '--attachment')).toHaveLength(2);
+    expect(args).toContain('/a.pdf');
+    expect(args).toContain('/b.png');
+  });
+});
+
+describe('rushProviders', () => {
+  it('exposes one provider per rush channel, named by channel', () => {
+    expect(rushProviders.map((p) => p.name).sort()).toEqual([...RUSH_CHANNELS].sort());
+  });
+
+  it('dry-run short-circuits without shelling out', async () => {
+    const tg = rushProviders.find((p) => p.name === 'telegram')!;
+    const res = await tg.send('hi', { target: '6078999250', dryRun: true });
+    expect(res.ok).toBe(true);
+    expect(res.channel).toBe('telegram');
+    expect(res.id).toBe('6078999250');
+  });
+});

--- a/apps/cli/src/lib/channels/providers/rush.ts
+++ b/apps/cli/src/lib/channels/providers/rush.ts
@@ -1,0 +1,58 @@
+/**
+ * Rush-daemon channel providers — telegram / imessage / slack / discord.
+ *
+ * These shell out to the already-built `rush send` CLI, which routes through the
+ * rush daemon's live channel gateways over ~/.rush/daemon.sock. We do NOT import
+ * rush's Go internals (different repo, internal package) — the CLI boundary is
+ * the contract. `rush send --json` prints {"ok":true,"channel":..,"id":..}.
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { ChannelProvider, SendOptions, SendResult } from '../registry.js';
+
+const execFileAsync = promisify(execFile);
+
+export type RushChannel = 'telegram' | 'imessage' | 'slack' | 'discord';
+export const RUSH_CHANNELS: RushChannel[] = ['telegram', 'imessage', 'slack', 'discord'];
+
+/** Build the `rush send` argv (exported for tests). */
+export function buildRushSendArgs(channel: RushChannel, text: string, opts: SendOptions): string[] {
+  const args = ['send', text, '--channel', channel, '--id', opts.target, '--json'];
+  if (opts.thread) args.push('--thread', opts.thread);
+  for (const a of opts.attachments ?? []) args.push('--attachment', a);
+  return args;
+}
+
+function rushProvider(channel: RushChannel): ChannelProvider {
+  return {
+    name: channel,
+    async send(text: string, opts: SendOptions): Promise<SendResult> {
+      if (opts.dryRun) {
+        return { ok: true, channel, id: opts.target, attachments: opts.attachments };
+      }
+      // Preflight: rush must be on PATH (mirrors notify.ts's openclaw check).
+      try {
+        await execFileAsync('which', ['rush']);
+      } catch {
+        return { ok: false, channel, id: opts.target, error: 'rush CLI not found on PATH' };
+      }
+      try {
+        const { stdout } = await execFileAsync('rush', buildRushSendArgs(channel, text, opts));
+        const parsed = JSON.parse(stdout) as { ok?: boolean; attachments?: string[] };
+        return {
+          ok: parsed.ok === true,
+          channel,
+          id: opts.target,
+          attachments: parsed.attachments,
+          error: parsed.ok === true ? undefined : 'rush send returned ok=false',
+        };
+      } catch (err) {
+        // Daemon down surfaces here as the exec error (ErrDaemonDown), as does a
+        // non-JSON stdout (parse throw). Fail loud — never silently reroute.
+        return { ok: false, channel, id: opts.target, error: (err as Error).message };
+      }
+    },
+  };
+}
+
+export const rushProviders: ChannelProvider[] = RUSH_CHANNELS.map(rushProvider);

--- a/apps/cli/src/lib/channels/registry.test.ts
+++ b/apps/cli/src/lib/channels/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  registerChannelProvider,
+  resolveChannelProvider,
+  listChannelProviders,
+  type ChannelProvider,
+} from './registry.js';
+
+const stub = (name: string): ChannelProvider => ({
+  name,
+  async send() {
+    return { ok: true, channel: name, id: 'x' };
+  },
+});
+
+describe('channel registry', () => {
+  it('registers and resolves a provider by name', () => {
+    registerChannelProvider(stub('reg-test-a'));
+    expect(resolveChannelProvider('reg-test-a')?.name).toBe('reg-test-a');
+  });
+
+  it('returns undefined for an unregistered provider', () => {
+    expect(resolveChannelProvider('reg-test-nope')).toBeUndefined();
+  });
+
+  it('lists registered providers sorted', () => {
+    registerChannelProvider(stub('reg-test-z'));
+    registerChannelProvider(stub('reg-test-m'));
+    const names = listChannelProviders().filter((n) => n.startsWith('reg-test-'));
+    expect(names).toEqual([...names].sort());
+    expect(names).toContain('reg-test-m');
+    expect(names).toContain('reg-test-z');
+  });
+});

--- a/apps/cli/src/lib/channels/registry.ts
+++ b/apps/cli/src/lib/channels/registry.ts
@@ -1,0 +1,56 @@
+/**
+ * Channel-provider registry for `agents send` / `agents notify`.
+ *
+ * One primitive, many channels. A provider knows how to deliver a message over
+ * exactly one channel — the agent mailbox, a rush-daemon gateway (telegram /
+ * imessage / slack / discord), openclaw, or a future "app". Providers register
+ * themselves at module load; the command layer only ever calls
+ * `resolveChannelProvider(name).send(...)` — no channel is special-cased above
+ * this seam, so new channels (apps) slot in without touching the command.
+ */
+
+export interface SendOptions {
+  /** Channel-specific recipient id: a chat id, a mailbox/agent id, a Slack C0…, etc. */
+  target: string;
+  /** Channel thread id / timestamp (slack/telegram threads). */
+  thread?: string;
+  /** Absolute paths to file attachments. */
+  attachments?: string[];
+  /** Sender label (used by the mailbox provider). */
+  from?: string;
+  /** Resolve + build the delivery but do not actually send. */
+  dryRun?: boolean;
+}
+
+export interface SendResult {
+  ok: boolean;
+  /** Channel/provider name as surfaced back to the caller. */
+  channel: string;
+  /** Resolved recipient id, echoed for --json parity with `rush send`. */
+  id: string;
+  error?: string;
+  /** Echoed attachment paths (rush shape parity). */
+  attachments?: string[];
+  /** Mailbox provider returns the enqueued message id. */
+  msgId?: string;
+}
+
+export interface ChannelProvider {
+  /** Stable name used in `--channel` and as a `notify.transports` value. */
+  name: string;
+  send(text: string, opts: SendOptions): Promise<SendResult>;
+}
+
+const REGISTRY = new Map<string, ChannelProvider>();
+
+export function registerChannelProvider(p: ChannelProvider): void {
+  REGISTRY.set(p.name, p);
+}
+
+export function resolveChannelProvider(name: string): ChannelProvider | undefined {
+  return REGISTRY.get(name);
+}
+
+export function listChannelProviders(): string[] {
+  return [...REGISTRY.keys()].sort();
+}

--- a/apps/cli/src/lib/channels/resolve.test.ts
+++ b/apps/cli/src/lib/channels/resolve.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { registerChannelProvider, type ChannelProvider } from './registry.js';
+import { resolveTransport } from './resolve.js';
+import type { Meta } from '../types.js';
+
+const stub = (name: string): ChannelProvider => ({
+  name,
+  async send() {
+    return { ok: true, channel: name, id: 'x' };
+  },
+});
+
+// Providers used by these cases.
+registerChannelProvider(stub('telegram'));
+registerChannelProvider(stub('openclaw-telegram'));
+registerChannelProvider(stub('slack'));
+
+const emptyMeta = {} as Meta;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('resolveTransport', () => {
+  it('uses notify.transports mapping when present (telegram -> openclaw-telegram)', () => {
+    const meta = { notify: { transports: { telegram: 'openclaw-telegram' } } } as Meta;
+    expect(resolveTransport('telegram', meta).name).toBe('openclaw-telegram');
+  });
+
+  it('defaults to name-identity when no mapping (channel slack -> provider slack)', () => {
+    expect(resolveTransport('slack', emptyMeta).name).toBe('slack');
+  });
+
+  it('dies loud on an unregistered provider — never silently reroutes', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as typeof process.exit);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => resolveTransport('nonexistent-channel', emptyMeta)).toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/lib/channels/resolve.ts
+++ b/apps/cli/src/lib/channels/resolve.ts
@@ -1,0 +1,24 @@
+/**
+ * Transport resolution: map a user-facing channel name to the provider that
+ * actually delivers it, using `notify.transports` from agents.yaml.
+ *
+ * Default is name-identity (`--channel slack` -> `slack` provider) — NOT a
+ * fallback to a different transport. Only telegram is dual-homed (rush vs
+ * openclaw-telegram); config picks. An unmapped-to-unregistered name dies loud.
+ */
+import type { Meta } from '../types.js';
+import { die } from '../format.js';
+import { resolveChannelProvider, listChannelProviders, type ChannelProvider } from './registry.js';
+
+export function resolveTransport(channel: string, meta: Meta): ChannelProvider {
+  const providerName = meta.notify?.transports?.[channel] ?? channel;
+  const provider = resolveChannelProvider(providerName);
+  if (!provider) {
+    die(
+      `No channel provider '${providerName}'` +
+        (providerName === channel ? '' : ` (mapped from channel '${channel}' via notify.transports)`) +
+        `. Registered: ${listChannelProviders().join(', ')}.`,
+    );
+  }
+  return provider;
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -97,6 +97,7 @@ export const loadSessions: ModuleLoader = async () => (await import('../../comma
 export const loadTeams: ModuleLoader = async () => (await import('../../commands/teams.js')).registerTeamsCommands;
 export const loadCloud: ModuleLoader = async () => (await import('../../commands/cloud.js')).registerCloudCommands;
 export const loadMessage: ModuleLoader = async () => (await import('../../commands/message.js')).registerMessageCommand;
+export const loadSend: ModuleLoader = async () => (await import('../../commands/send.js')).registerSendCommand;
 export const loadHq: ModuleLoader = async () => (await import('../../commands/hq.js')).registerHqCommand;
 export const loadFeed: ModuleLoader = async () => (await import('../../commands/feed.js')).registerFeedCommand;
 export const loadMailboxes: ModuleLoader = async () => (await import('../../commands/mailboxes.js')).registerMailboxesCommand;
@@ -216,6 +217,8 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   teams: [loadTeams],
   cloud: [loadCloud],
   message: [loadMessage],
+  send: [loadSend],
+  notify: [loadSend],
   hq: [loadHq],
   feed: [loadFeed],
   mailboxes: [loadMailboxes],

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -843,6 +843,17 @@ export interface Meta {
     /** Cloudflare Web Analytics token injected into published HTML pages. */
     analyticsToken?: string;
   };
+  /**
+   * Owner/channel notification config for `agents send` / `agents notify`.
+   * `owner` is the default recipient for `agents notify` (channel + target).
+   * `transports` maps a user-facing channel name to the provider that actually
+   * delivers it — explicit, one provider per channel, no fallback. Omitted keys
+   * default to name-identity (channel `slack` -> provider `slack`).
+   */
+  notify?: {
+    owner?: { channel: string; to: string };
+    transports?: Record<string, string>;
+  };
 }
 
 /** Persisted agent-host entry in agents.yaml (overlay or inline). */


### PR DESCRIPTION
## What

Adds `agents send` (umbrella) and `agents notify` (owner-facing alias) — one primitive to deliver a message over any channel, with the agent **mailbox as just one channel** among many (telegram/imessage/slack/discord, and future apps). Unifies three things that already existed but weren't connected: `rush send` (daemon gateways), `notify.ts`'s openclaw argv, and the `agents message` mailbox.

## Design

- **Pluggable provider registry** (`lib/channels/registry.ts`): `ChannelProvider {name, send()}`; `register/resolve/list`. No channel is special-cased above this seam — apps register the same way.
- **Providers** (`lib/channels/providers/`): `mailbox` (reuses the existing `enqueue` seam), `rush` factory → telegram/imessage/slack/discord (shells out to the already-built `rush send --json`), `openclaw-telegram` (reuses `buildOpenClawNotifyArgs`).
- **Explicit transport selection, no fallback** (`lib/channels/resolve.ts`): `notify.transports` maps a channel name → provider; default is name-identity; an unregistered mapping **dies loud** (never silently reroutes).
- **Config**: `Meta.notify { owner, transports }` (`types.ts`) — carried free by `readMeta`'s spread-merge; per-device via the machine-local overlay.
- **`agents message` untouched** — it stays the richer agent-control command (feed-claim / identity / PTY / resume) on the *same* mailbox spool.

## Verified

- `bun run build` (tsc) clean; **13 unit tests pass** (registry / rush argv+dry-run / resolve map+identity+die-loud / mailbox real-fs round-trip).
- `agents send --help` + `agents notify --help` render.
- Dry-run resolves (`{"ok":true,"channel":"telegram",...}`); unregistered channel dies loud listing providers; **real mailbox round-trip** (enqueued → read back from `inbox/` → cleaned up).

## Honest gap (Risk R1 from the plan — infra, not this code)

The consented live Telegram test **revealed that rush-native telegram is not wired on zion**: zion's rush daemon has `imessage` + `slack` registered but **no telegram**; zion has no `openclaw`; mac-mini runs an older `rush` without `--channel`. So today the only working owner-Telegram path is openclaw@mac-mini (the SSH hack this is meant to replace). **No live Telegram was sent** — I won't claim one I didn't achieve, and I won't guess an iMessage number.

To make `agents notify` fully local on zion (decision #1's intent), a **follow-up** wires a telegram gateway into zion's rush daemon (bot token in `~/.rush/user.yaml` + daemon restart); until then, config maps `transports.telegram: openclaw-telegram` on a host with openclaw. iMessage + slack are live on zion via rush now.

## Follow-up (separate PR, per plan)

Migrate the 14+ routines + `ci-heartbeat.sh` off `ssh mac-mini "openclaw message send … --target 6078999250"` to `agents notify`, dropping the 20+ hardcoded chat ids — once an owner transport is proven live on the running host.

Session transcript: zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/6e79ff16-1362-41b9-a5b8-ca37857624bb.jsonl