### PR TITLE
refactor(menubar): resolve the Bun-binary bundle fallback lazily

### DIFF
--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -107,12 +107,17 @@ function sourceAppPath(): string | null {
   } catch {
     /* import.meta.url unavailable */
   }
-  const layout = resolveInstalledLayout();
-  if (layout) {
-    candidates.push(path.join(layout.distDir, 'lib', 'menubar', APP_BUNDLE_NAME));
-  }
   for (const c of candidates) {
     if (fs.existsSync(c)) return c;
+  }
+  // Candidate 4 — only reached when the sibling candidates miss (the Bun
+  // single-file binary, whose `import.meta.url` is a virtual `/$bunfs/` path).
+  // Resolve the launcher symlink lazily so the common Node path pays no extra
+  // filesystem probe.
+  const layout = resolveInstalledLayout();
+  if (layout) {
+    const p = path.join(layout.distDir, 'lib', 'menubar', APP_BUNDLE_NAME);
+    if (fs.existsSync(p)) return p;
   }
   return null;
 }


### PR DESCRIPTION
## What

Follow-up polish to #1415 (menubar Bun-binary bundle resolution). The reviewer noted
`sourceAppPath()` called `resolveInstalledLayout()` unconditionally, so the common Node
path paid a launcher-symlink probe (`accessSync` ×4 + `realpathSync`) on every call —
even though its own sibling bundle always wins the ordered candidate check first.

Move the on-disk fallback **after** the primary `existsSync` loop so it's computed only
on a miss (the Bun single-file binary, whose `import.meta.url` is a virtual `/$bunfs/`
path). Mirrors the lazy `??` pattern already used in `getCliVersion`.

## Not a behavior change

Candidate ordering and results are identical — candidate 4 (the symlink fallback) was
already checked last. This only skips computing it when an earlier candidate exists.
Internal refactor, no user-visible change → no changelog fragment (exempt).

## Verification

- Rebuilt the Bun binary from this branch: `menubar status` still resolves the on-disk
  bundle source + `current version 1.20.72` (the fallback still fires under Bun).
- `tsc --noEmit` clean; existing `version.test.ts` + `install-menubar.test.ts` — 16/16 pass.

Session transcript (confidential — not uploaded): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/a179cdb9-046b-4d56-8dcc-7da3fe11b34b.jsonl`
