### PR TITLE
fix(cli): keep automatic self-heal inside the --isolated boundary

### DIFF
--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -432,6 +432,9 @@ async function runDevicesDoctor(opts: DoctorOptions): Promise<void> {
 interface ResolvedTarget {
   agent: AgentId;
   versions: string[];
+  /** Did the user name a concrete VERSION (`codex@1.2.3`), or just the agent?
+   *  Only the former is explicit consent to heal an isolated copy — see runFix. */
+  versionExplicit: boolean;
 }
 
 function parseTargetArg(arg: string): ResolvedTarget | { error: string } {
@@ -445,13 +448,13 @@ function parseTargetArg(arg: string): ResolvedTarget | { error: string } {
   if (!versionPart) {
     const versions = listInstalledVersions(agent);
     if (versions.length === 0) return { error: `${AGENTS[agent].name} has no installed versions. Run \`agents add ${agent}@<version>\` first.` };
-    return { agent, versions };
+    return { agent, versions, versionExplicit: false };
   }
 
   if (versionPart === 'default') {
     const def = getGlobalDefault(agent);
     if (!def) return { error: `${AGENTS[agent].name} has no default version pinned. Run \`agents use ${agent}@<version>\`.` };
-    return { agent, versions: [def] };
+    return { agent, versions: [def], versionExplicit: true };
   }
 
   const spec = parseAgentSpec(`${agent}@${versionPart}`);
@@ -459,7 +462,7 @@ function parseTargetArg(arg: string): ResolvedTarget | { error: string } {
   if (!isVersionInstalled(agent, versionPart)) {
     return { error: `${AGENTS[agent].name}@${versionPart} is not installed. Installed: ${listInstalledVersions(agent).join(', ') || '(none)'}` };
   }
-  return { agent, versions: [versionPart] };
+  return { agent, versions: [versionPart], versionExplicit: true };
 }
 
 function parseKindFilter(arg: string | undefined): DoctorKind[] | { error: string } {
@@ -682,14 +685,18 @@ function renderHealText(result: HealResult): void {
   }
 }
 
-async function runFix(parsed: { agent: AgentId; versions: string[] } | null, opts: DoctorOptions): Promise<void> {
+async function runFix(parsed: ResolvedTarget | null, opts: DoctorOptions): Promise<void> {
   // Heal targets the global install — project layer is irrelevant, so cwd is
   // left to heal's neutral default rather than process.cwd().
   if (!opts.json) console.log(chalk.bold('Healing…'));
+  // `agents doctor <agent> --fix` is a SWEEP, same as the bare form — leave the
+  // version list to heal() so it applies its isolated-copy filter. Passing the
+  // enumerated list here would smuggle isolated versions past that filter.
+  // A named version (`<agent>@<version>`) is explicit consent and is passed through.
   const result = await heal({
     mode: 'full',
     agent: parsed?.agent,
-    versions: parsed?.versions,
+    versions: parsed?.versionExplicit ? parsed.versions : undefined,
   });
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2));
@@ -794,7 +801,7 @@ export function registerDoctorCommand(program: Command): void {
       // --fix turns the read-only diagnosis into a heal. With no target it heals
       // every installed version; with a target it scopes to that agent.
       if (opts.fix) {
-        let scope: { agent: AgentId; versions: string[] } | null = null;
+        let scope: ResolvedTarget | null = null;
         if (target) {
           const parsed = parseTargetArg(target);
           if ('error' in parsed) {

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1754,7 +1754,14 @@ export function registerRunCommand(program: Command): void {
             options.quiet ? undefined : (m) => process.stderr.write(chalk.yellow(`[agents] ${m}\n`)),
           );
           if (healed === null) {
-            console.error(chalk.red(`agents: ${agent}@${launchTarget} is not runnable and could not be repaired. Try: agents add ${agent}@latest`));
+            // An isolated copy is never repaired by adopting another version, so
+            // `add <agent>@latest` would build an unrelated NORMAL install rather
+            // than fix what the user asked to run. Point at the isolated re-add.
+            const { isVersionIsolated } = await import('../lib/versions.js');
+            const hint = isVersionIsolated(agent, launchTarget)
+              ? `agents add ${agent}@${launchTarget} --isolated`
+              : `agents add ${agent}@latest`;
+            console.error(chalk.red(`agents: ${agent}@${launchTarget} is not runnable and could not be repaired. Try: ${hint}`));
             process.exit(1);
           }
           // Always adopt the healed version explicitly. In the version-undefined

--- a/apps/cli/src/lib/heal.ts
+++ b/apps/cli/src/lib/heal.ts
@@ -28,6 +28,7 @@ import type { AgentId } from './types.js';
 import {
   syncResourcesToVersion,
   listInstalledVersions,
+  isVersionIsolated,
   getVersionHomePath,
   getActuallySyncedResources,
   compareVersions,
@@ -377,9 +378,17 @@ export async function heal(opts: HealOptions): Promise<HealResult> {
     ...refreshed.map((r) => r.plugin),
   ]);
 
+  // Isolated copies are excluded from every SWEEP. `agents add --isolated`
+  // promises "no settings carry-over, no resource sync", and this engine runs
+  // unattended from the daemon (~30s after start, then every ~6h) — a sweep that
+  // walked into an isolated home would quietly refill it with shared commands,
+  // skills, hooks, MCP config and permissions. Explicitly NAMED versions
+  // (`agents doctor <agent>@<version> --fix`) are honoured as-is: naming the
+  // version is the operator's consent.
+  const sweep = (a: AgentId) => listInstalledVersions(a).filter((v) => !isVersionIsolated(a, v));
   const targets: Array<{ agent: AgentId; versions: string[] }> = opts.agent
-    ? [{ agent: opts.agent, versions: opts.versions ?? listInstalledVersions(opts.agent) }]
-    : ALL_AGENT_IDS.map((a) => ({ agent: a, versions: listInstalledVersions(a) }));
+    ? [{ agent: opts.agent, versions: opts.versions ?? sweep(opts.agent) }]
+    : ALL_AGENT_IDS.map((a) => ({ agent: a, versions: sweep(a) }));
 
   const versions: VersionHealResult[] = [];
   for (const t of targets) {

--- a/apps/cli/src/lib/refresh.ts
+++ b/apps/cli/src/lib/refresh.ts
@@ -27,6 +27,7 @@ import type { AgentId } from './types.js';
 import {
   installVersion,
   listInstalledVersions,
+  isVersionIsolated,
   getGlobalDefault,
   setGlobalDefault,
   getVersionHomePath,
@@ -297,7 +298,11 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
     const selectedVersions: Array<{ agentId: AgentId; version: string }> = [];
 
     for (const agentId of agentsNeedingDefault) {
-      const versions = listInstalledVersions(agentId);
+      // Isolated copies are not default-eligible — `agents use` refuses them and
+      // setting one here would also switch the config symlink, pointing the user's
+      // real ~/.<agent> at an isolated home. Keep them out of the picker entirely.
+      const versions = listInstalledVersions(agentId).filter((v) => !isVersionIsolated(agentId, v));
+      if (versions.length === 0) continue;
       const agent = AGENTS[agentId];
 
       const shouldSwitch = await select({

--- a/apps/cli/src/lib/self-heal/checks/shadowing.ts
+++ b/apps/cli/src/lib/self-heal/checks/shadowing.ts
@@ -10,7 +10,7 @@ import { AGENTS } from '../../agents.js';
 import {
   getPathShadowingExecutable,
   adoptShadowingLauncher,
-  listAgentsWithInstalledVersions,
+  listAgentsWithNonIsolatedInstalledVersions,
 } from '../../shims.js';
 import { getGlobalDefault } from '../../versions.js';
 
@@ -23,7 +23,15 @@ export const shadowingCheck: HealCheck = {
     const fixed: string[] = [];
     const needsAttention: string[] = [];
 
-    for (const agent of listAgentsWithInstalledVersions()) {
+    // Isolated-only agents are skipped outright. Adoption repoints the user's OWN
+    // launcher (e.g. the npm symlink ~/.npm-global/bin/codex) at our shim — the most
+    // invasive thing self-heal does, and the exact opposite of what `--isolated`
+    // promises. The `getGlobalDefault` guard below already blocked this in practice,
+    // since an isolated install never sets a default; but that made the boundary
+    // depend on an invariant enforced elsewhere. Any path that pins a default from
+    // an isolated copy would silently re-arm the adoption. Gate on the installs
+    // themselves so it cannot happen regardless of how a default got recorded.
+    for (const agent of listAgentsWithNonIsolatedInstalledVersions()) {
       if (!getGlobalDefault(agent)) continue; // only default agents, like the interactive flow
       const cmd = AGENTS[agent].cliCommand;
       const shadowedBy = getPathShadowingExecutable(agent);

--- a/apps/cli/src/lib/self-heal/isolated-soak.integration.test.ts
+++ b/apps/cli/src/lib/self-heal/isolated-soak.integration.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Regression for a REAL user report: "one of the self-heal mechanisms messed up my
+// local installation." Reproduced end-to-end from isolated-only usage, no misuse.
+//
+// The chain:
+//   1. `agents run <agent>@<isolated>` finds the copy broken (partial npm extraction).
+//   2. The in-place repair fails (registry unreachable).
+//   3. Launch-path self-heal adopts ANOTHER installed version and pins it as the
+//      global default.
+//   4. That default is the only thing gating the `shadowing` check
+//      (`if (!getGlobalDefault(agent)) continue`), which now fires and ADOPTS the
+//      user's own launcher — repointing ~/.npm-global/bin/<cli>, an npm-created
+//      symlink, at our shim.
+//   5. `shims` + `path` then add a bare shim and a PATH entry.
+//
+// Net effect on the reporter's machine: the globally installed CLI stopped working.
+// Every link in that chain has to stay broken, so this test asserts the whole
+// pipeline is inert — not just the one step that happened to be patched.
+//
+// POSIX-only: `shadowing` is gated to darwin/linux, and the npm bin-symlink layout
+// and PATH-order problem are POSIX concerns (Windows resolves via the registry).
+describe.skipIf(process.platform === 'win32')('isolated-only usage never disturbs a local install', () => {
+  let home: string;
+  const GOOD = '9.9.4';
+  const BROKEN = '9.9.5';
+
+  const versionDir = (v: string) => path.join(home, '.agents', '.history', 'versions', 'codex', v);
+  const globalBin = () => path.join(home, 'npm-global', 'bin', 'codex');
+  const shimsDir = () => path.join(home, '.agents', '.cache', 'shims');
+
+  function plantIsolated(version: string, { runnable }: { runnable: boolean }) {
+    const binDir = path.join(versionDir(version), 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(path.join(versionDir(version), 'home', '.codex'), { recursive: true });
+    if (runnable) {
+      fs.writeFileSync(path.join(binDir, 'codex'), '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(path.join(binDir, 'codex'), 0o755);
+    }
+    fs.writeFileSync(path.join(versionDir(version), '.isolated'), `${new Date().toISOString()}\n`);
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'isolated-soak-'));
+    // The user's own globally-installed CLI, laid out the way npm does it: a bin
+    // symlink into lib/node_modules. This symlink is what adoption would hijack.
+    const pkgBin = path.join(home, 'npm-global', 'lib', 'node_modules', '@openai', 'codex', 'bin');
+    fs.mkdirSync(pkgBin, { recursive: true });
+    fs.mkdirSync(path.join(home, 'npm-global', 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(pkgBin, 'codex.js'), '#!/bin/sh\necho LOCAL-GLOBAL-CODEX\n');
+    fs.chmodSync(path.join(pkgBin, 'codex.js'), 0o755);
+    fs.symlinkSync('../lib/node_modules/@openai/codex/bin/codex.js', globalBin());
+    fs.writeFileSync(path.join(home, '.bashrc'), '# user rc\n');
+    // Two isolated copies; the newer one is gutted (wrapper dir, no launch binary).
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    plantIsolated(GOOD, { runnable: true });
+    plantIsolated(BROKEN, { runnable: false });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('survives a failed isolated repair plus repeated daemon self-heal passes', () => {
+    const versionsPath = path.resolve(process.cwd(), 'src/lib/versions.ts');
+    const registryPath = path.resolve(process.cwd(), 'src/lib/self-heal/registry.ts');
+    const script = `
+      import { ensureAgentRunnable, getGlobalDefault, isVersionIsolated } from ${JSON.stringify(versionsPath)};
+      import { runSelfHeal } from ${JSON.stringify(registryPath)};
+      // Step 1-2: run the broken isolated copy; the repair cannot succeed.
+      const healed = await ensureAgentRunnable('codex', ${JSON.stringify(BROKEN)});
+      // Steps 3-5: the daemon's periodic passes, many times over.
+      for (let i = 0; i < 6; i++) await runSelfHeal({ mode: 'safe' });
+      console.log('__RESULT__' + JSON.stringify({
+        healed,
+        defaultAfter: getGlobalDefault('codex'),
+        goodStillIsolated: isVersionIsolated('codex', ${JSON.stringify(GOOD)}),
+        brokenStillIsolated: isVersionIsolated('codex', ${JSON.stringify(BROKEN)}),
+      }));
+    `;
+    const out = execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: home,
+        // The user's own launcher is FIRST on PATH — the shadowing condition.
+        PATH: `${path.join(home, 'npm-global', 'bin')}:${process.env.PATH}`,
+        SHELL: '/bin/bash',
+        // Force every npm operation to fail, so the in-place repair cannot recover
+        // and self-heal is pushed onto its mutating fallback paths.
+        npm_config_registry: 'http://127.0.0.1:9/',
+      },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString('utf-8');
+    const r = JSON.parse(out.split('__RESULT__')[1]) as {
+      healed: string | null; defaultAfter: string | null;
+      goodStillIsolated: boolean; brokenStillIsolated: boolean;
+    };
+
+    // The failure is surfaced, not worked around with someone else's install.
+    expect(r.healed).toBeNull();
+    // No default is recorded — which is also what keeps `shadowing` disarmed.
+    expect(r.defaultAfter).toBeNull();
+    // Neither copy was demoted by the repair attempt.
+    expect(r.goodStillIsolated).toBe(true);
+    expect(r.brokenStillIsolated).toBe(true);
+
+    // The user's own launcher still points where npm put it.
+    expect(fs.readlinkSync(globalBin())).toBe('../lib/node_modules/@openai/codex/bin/codex.js');
+    expect(execFileSync(globalBin()).toString()).toContain('LOCAL-GLOBAL-CODEX');
+
+    // No bare shim, no PATH entry — only the explicit versioned aliases.
+    const shims = fs.existsSync(shimsDir()) ? fs.readdirSync(shimsDir()).sort() : [];
+    expect(shims).not.toContain('codex');
+    expect(fs.readFileSync(path.join(home, '.bashrc'), 'utf-8')).not.toContain('.agents/.cache/shims');
+    // And the real config dir was never created or adopted.
+    expect(fs.existsSync(path.join(home, '.codex'))).toBe(false);
+  }, 300_000);
+});

--- a/apps/cli/src/lib/self-heal/self-heal.integration.test.ts
+++ b/apps/cli/src/lib/self-heal/self-heal.integration.test.ts
@@ -140,6 +140,75 @@ describe.skipIf(process.platform === 'win32')('runSelfHeal — isolated-only ins
   });
 });
 
+// The `resources` check runs UNATTENDED from the daemon (~30s after start, then every
+// ~6h) and reconciles every installed version home against the shared DotAgents
+// definitions. `agents add --isolated` promises the opposite — "no settings carry-over,
+// no resource sync" — so the sweep must walk straight past an isolated home while still
+// healing the normal one beside it.
+describe.skipIf(process.platform === 'win32')('runSelfHeal — resources never sync into isolated homes', () => {
+  let home: string;
+
+  const versionHome = (version: string) =>
+    path.join(home, '.agents', '.history', 'versions', 'claude', version, 'home');
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'self-heal-iso-resources-'));
+    for (const version of ['9.9.1', '9.9.2']) {
+      const versionDir = path.join(home, '.agents', '.history', 'versions', 'claude', version);
+      const binPath = path.join(versionDir, 'node_modules', '.bin', 'claude');
+      fs.mkdirSync(path.dirname(binPath), { recursive: true });
+      fs.writeFileSync(binPath, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(binPath, 0o755);
+      // A real version home with the agent config dir already materialized, so the
+      // only thing separating the two is the marker.
+      fs.mkdirSync(path.join(versionDir, 'home', '.claude'), { recursive: true });
+    }
+    fs.writeFileSync(
+      path.join(home, '.agents', '.history', 'versions', 'claude', '9.9.2', '.isolated'),
+      `${new Date().toISOString()}\n`,
+    );
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('heals the normal version home and leaves the isolated one empty', () => {
+    const modulePath = path.resolve(process.cwd(), 'src/lib/self-heal/registry.ts');
+    const statePath = path.resolve(process.cwd(), 'src/lib/state.ts');
+    const script = `
+      import { runSelfHeal } from ${JSON.stringify(modulePath)};
+      import { getCommandsDir } from ${JSON.stringify(statePath)};
+      import fs from 'node:fs';
+      import path from 'node:path';
+      // A shared command present centrally but in NEITHER version home.
+      const commands = getCommandsDir();
+      fs.mkdirSync(commands, { recursive: true });
+      fs.writeFileSync(path.join(commands, 'leak-probe.md'), '# leak-probe\\n\\nshared\\n');
+      const report = await runSelfHeal({ checks: ['resources'], mode: 'safe' });
+      const cmd = (v) => path.join(${JSON.stringify(path.join(home, '.agents', '.history', 'versions', 'claude'))},
+        v, 'home', '.claude', 'commands', 'leak-probe.md');
+      console.log('__RESULT__' + JSON.stringify({
+        report,
+        normalHealed: fs.existsSync(cmd('9.9.1')),
+        isolatedHealed: fs.existsSync(cmd('9.9.2')),
+      }));
+    `;
+    const out = execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString('utf-8');
+    const result = JSON.parse(out.split('__RESULT__')[1]) as {
+      report: Report; normalHealed: boolean; isolatedHealed: boolean;
+    };
+
+    // The sweep still does its job on normal installs…
+    expect(result.normalHealed).toBe(true);
+    expect(byId(result.report).resources.fixed.join(' ')).toContain('resource');
+    // …and never crosses the isolation boundary.
+    expect(result.isolatedHealed).toBe(false);
+    expect(fs.readdirSync(versionHome('9.9.2'), { recursive: true })).toEqual(['.claude']);
+  }, 120_000);
+});
+
 interface CheckR { fixed: string[]; needsAttention: string[]; ok: boolean }
 interface Report { checks: { id: string; result: CheckR | null; error?: string }[] }
 

--- a/apps/cli/src/lib/versions.isolation.integration.test.ts
+++ b/apps/cli/src/lib/versions.isolation.integration.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// End-to-end isolation boundary for the LAUNCH-path self-heal (ensureAgentRunnable).
+// `agents run <agent>@<version>` calls it on every dispatch (commands/exec.ts) and the
+// daemon calls it unattended every ~6h (healBrokenDefaultLaunches), so its two mutating
+// steps — "adopt another installed version as the default" and "install latest and pin
+// it" — are the places where an isolated copy can bleed into the user's normal setup.
+//
+// Driven in a subprocess with a planted temp HOME: state paths resolve from
+// process.env.HOME at module-eval, the pattern used by self-heal.integration.test.ts.
+// No mocks — the repair genuinely calls npm (which fails on these synthetic versions,
+// whether by 404 online or by network error offline; both land on the same branch).
+
+// POSIX-only: the launch probe resolves node_modules/.bin/<cli> directly on POSIX but
+// the `.cmd` wrapper on Windows, where a missing wrapper is deliberately treated as
+// healthy — so a "gutted install" can't be planted the same way.
+describe.skipIf(process.platform === 'win32')('ensureAgentRunnable — isolation boundary', () => {
+  let home: string;
+
+  const versionDir = (version: string) =>
+    path.join(home, '.agents', '.history', 'versions', 'codex', version);
+
+  /** Plant a codex version. `runnable: false` = gutted install (wrapper dir, no binary). */
+  function plant(version: string, opts: { runnable: boolean; isolated?: boolean }) {
+    const dir = versionDir(version);
+    const binDir = path.join(dir, 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(path.join(dir, 'home'), { recursive: true });
+    if (opts.runnable) {
+      const bin = path.join(binDir, 'codex');
+      fs.writeFileSync(bin, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(bin, 0o755);
+    }
+    if (opts.isolated) fs.writeFileSync(path.join(dir, '.isolated'), `${new Date().toISOString()}\n`);
+  }
+
+  interface Outcome {
+    healed: string | null;
+    defaultAfter: string | null;
+    installedAfter: string[];
+    stillIsolated: boolean;
+  }
+
+  function runEnsure(target: string, probeIsolationOf: string): Outcome {
+    const versionsPath = path.resolve(process.cwd(), 'src/lib/versions.ts');
+    const script = `
+      import {
+        ensureAgentRunnable, getGlobalDefault, listInstalledVersions, isVersionIsolated,
+      } from ${JSON.stringify(versionsPath)};
+      const healed = await ensureAgentRunnable('codex', ${JSON.stringify(target)});
+      console.log('__RESULT__' + JSON.stringify({
+        healed,
+        defaultAfter: getGlobalDefault('codex'),
+        installedAfter: listInstalledVersions('codex'),
+        stillIsolated: isVersionIsolated('codex', ${JSON.stringify(probeIsolationOf)}),
+      }));
+    `;
+    const out = execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString('utf-8');
+    return JSON.parse(out.split('__RESULT__')[1]);
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-runnable-iso-'));
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('leaves the normal default alone when an ISOLATED target cannot be repaired', () => {
+    plant('9.9.1', { runnable: true });                    // the user's normal default
+    plant('9.9.3', { runnable: true });                    // a healthy normal version
+    plant('9.9.2', { runnable: false, isolated: true });   // broken isolated copy
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents:\n  codex: "9.9.1"\n');
+
+    const r = runEnsure('9.9.2', '9.9.2');
+
+    // Failure is surfaced, not papered over with someone else's install.
+    expect(r.healed).toBeNull();
+    // The normal default is untouched — this is the whole point of --isolated.
+    expect(r.defaultAfter).toBe('9.9.1');
+    // No silent adoption of 9.9.3, and no `latest` materialized behind the user's back.
+    expect(r.installedAfter.sort()).toEqual(['9.9.1', '9.9.3']);
+    // The clean reinstall must not strip the marker: losing it would demote the copy
+    // to a normal install, which shim self-heal would then hand a bare `codex` shim.
+    expect(r.stillIsolated).toBe(true);
+  }, 180_000);
+
+  it('never adopts an ISOLATED version as the fallback default, but still adopts a normal one', () => {
+    plant('9.9.1', { runnable: false });                   // broken normal default
+    plant('9.9.9', { runnable: true, isolated: true });     // healthy — but isolated
+    plant('9.9.3', { runnable: true });                    // healthy normal
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents:\n  codex: "9.9.1"\n');
+
+    const r = runEnsure('9.9.1', '9.9.9');
+
+    // Candidates are tried newest-first, so the isolated 9.9.9 is what an unfiltered
+    // fallback would reach for. Only the isolation filter keeps it out — promoting it
+    // is exactly what `agents use` refuses and what removeVersion excludes.
+    expect(r.healed).toBe('9.9.3');
+    expect(r.defaultAfter).toBe('9.9.3');
+    expect(r.defaultAfter).not.toBe('9.9.9');
+    // The isolated copy is untouched and still isolated.
+    expect(r.stillIsolated).toBe(true);
+  }, 180_000);
+});

--- a/apps/cli/src/lib/versions.isolation.integration.test.ts
+++ b/apps/cli/src/lib/versions.isolation.integration.test.ts
@@ -109,4 +109,30 @@ describe.skipIf(process.platform === 'win32')('ensureAgentRunnable — isolation
     // The isolated copy is untouched and still isolated.
     expect(r.stillIsolated).toBe(true);
   }, 180_000);
+
+  // The last-resort step ("install latest and pin it") reuses the version dir of
+  // whatever `latest` resolves to. If the user already holds THAT version as an
+  // isolated copy, installing would commandeer it and pinning would hand an
+  // isolated install the global default — the leak the candidate filter above
+  // blocks, arriving through a different door.
+  it('refuses to pin `latest` when the user holds that exact version as an isolated copy', () => {
+    const versionsPath = path.resolve(process.cwd(), 'src/lib/versions.ts');
+    const latest = execFileSync('npm', ['view', '@openai/codex', 'version'], { encoding: 'utf-8' }).trim();
+    expect(latest).toMatch(/^\d+\.\d+\.\d+/);
+
+    plant('9.9.1', { runnable: false });        // broken normal default
+    plant(latest, { runnable: true, isolated: true }); // the ONLY other install — isolated
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents:\n  codex: "9.9.1"\n');
+
+    const before = fs.readFileSync(path.join(versionDir(latest), '.isolated'), 'utf-8');
+    const r = runEnsure('9.9.1', latest);
+
+    // No default is better than an isolated default; the caller reports the failure.
+    expect(r.healed).toBeNull();
+    expect(r.defaultAfter).toBe('9.9.1');
+    expect(r.defaultAfter).not.toBe(latest);
+    // Resolved before installing, so the isolated copy was not even rebuilt.
+    expect(r.stillIsolated).toBe(true);
+    expect(fs.readFileSync(path.join(versionDir(latest), '.isolated'), 'utf-8')).toBe(before);
+  }, 300_000);
 });

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -2287,9 +2287,29 @@ export async function ensureAgentRunnable(
   }
 
   // Nothing runnable installed → last resort: install latest and pin it.
+  //
+  // …unless `latest` is a version the user already holds as an ISOLATED copy. A
+  // normal and an isolated install of the same version share one on-disk dir
+  // (see the coexistence refusal in commands/versions.ts), so installing would
+  // commandeer that copy and pinning it would hand an isolated install the
+  // global default — the same breach the candidate filter above prevents.
+  // Resolved BEFORE installing so the isolated copy is not even rebuilt.
+  const latestVersion = await getLatestNpmVersion(agent);
+  if (latestVersion && isVersionIsolated(agent, latestVersion)) {
+    log?.(`no runnable ${cfg.name} version installed — ${cfg.name}@${latestVersion} is the latest, but you hold it as an isolated copy, so it can't become your default.`);
+    log?.(`install one explicitly: agents add ${agent}@latest`);
+    return null;
+  }
+
   log?.(`no runnable ${cfg.name} version installed — installing ${cfg.name}@latest…`);
   const latest = await installVersion(agent, 'latest', undefined, { clean: true });
   if (latest.success) {
+    // Belt-and-braces: `latest` could have moved between the probe above and the
+    // install. Never pin an isolated version, whatever the resolution said.
+    if (isVersionIsolated(agent, latest.installedVersion)) {
+      log?.(`${cfg.name}@${latest.installedVersion} is an isolated copy and can't be set as your default.`);
+      return null;
+    }
     setGlobalDefault(agent, latest.installedVersion);
     log?.(`installed ${cfg.name}@${latest.installedVersion} and set it as the default.`);
     return latest.installedVersion;

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1799,9 +1799,12 @@ async function reconcileGlobalBinaryVersions(agent: AgentId): Promise<void> {
 
   if (foldedAny) {
     invalidateInstalledVersionsCache(agent);
-    // Keep the recorded default pointing at a dir that still exists on disk.
+    // Keep the recorded default pointing at a dir that still exists on disk —
+    // but never promote an isolated copy into the default slot (same rule as the
+    // post-removal promotion filter and `agents use`). Leaving it unset is right:
+    // an isolated-only agent has no default by design.
     const def = getGlobalDefault(agent);
-    if (!def || !fs.existsSync(getVersionDir(agent, def))) {
+    if ((!def || !fs.existsSync(getVersionDir(agent, def))) && !isVersionIsolated(agent, survivor)) {
       setGlobalDefault(agent, survivor);
     }
   }

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1671,16 +1671,24 @@ export async function installVersion(
   }
 }
 
+// Version-dir entries that are STATE, not install output, and so must survive a
+// clean reinstall: `home/`, and the `.isolated` marker that is the single source
+// of truth for "this copy is walled off". Losing the marker would silently demote
+// an isolated copy to a normal one on its first repair — after which shim
+// self-heal would hand it a bare `<agent>` shim and a PATH entry.
+const PRESERVED_ON_CLEAN_REINSTALL = new Set(['home', '.isolated']);
+
 /**
  * Remove install artifacts from a version directory, preserving `home/` which
  * contains the user's conversation history, sessions, history.jsonl, tasks,
- * todos, file-history, etc. Used by the install pipeline (NOT by removeVersion)
- * to clean up staging artifacts when a fresh install collides with an existing
- * dir. removeVersion uses soft-delete instead.
+ * todos, file-history, etc. (and the `.isolated` marker — see
+ * PRESERVED_ON_CLEAN_REINSTALL). Used by the install pipeline (NOT by
+ * removeVersion) to clean up staging artifacts when a fresh install collides
+ * with an existing dir. removeVersion uses soft-delete instead.
  */
 function removeInstallArtifacts(versionDir: string): void {
   for (const entry of fs.readdirSync(versionDir)) {
-    if (entry === 'home') continue;
+    if (PRESERVED_ON_CLEAN_REINSTALL.has(entry)) continue;
     fs.rmSync(path.join(versionDir, entry), { recursive: true, force: true });
   }
 }
@@ -2219,6 +2227,17 @@ export async function verifyInstalledBinaryLaunches(
  *   4. Nothing runnable installed → install `latest`, pin it, return it.
  *   5. Give up → return null (caller surfaces a clear error).
  *
+ * Isolation boundary (both directions — steps 3/4 are the only mutating ones):
+ *   - An ISOLATED target gets step 2 and nothing else. Falling back would let
+ *     `agents run <agent>@<isolated>` silently repoint the user's NORMAL default,
+ *     and installing `latest` would materialize a version they never asked for.
+ *     A failed repair returns null so the caller says so plainly.
+ *   - An isolated version is never a fallback CANDIDATE either, whatever the
+ *     target is: promoting one to the global default is exactly what `agents use`
+ *     refuses and what removeVersion's promotion filter excludes, so it must not
+ *     happen here by the back door (the daemon's launch-health pass calls this
+ *     unattended every ~6h).
+ *
  * Gated to npm-package agents: their native binary ships as an optional per-arch
  * dependency whose tarball can extract partially (interrupted/raced install) —
  * the exact failure this repairs. Agents with a global/native binary (grok,
@@ -2234,6 +2253,10 @@ export async function ensureAgentRunnable(
 
   if ((await verifyInstalledBinaryLaunches(agent, version)).ok) return version;
 
+  // Read the marker BEFORE the repair: the reinstall rewrites the version dir,
+  // so isolation must be decided from the pre-repair state, not re-read after.
+  const targetIsolated = isVersionIsolated(agent, version);
+
   log?.(`${cfg.name}@${version} is broken (platform binary missing) — repairing…`);
   const repair = await installVersion(agent, version, undefined, { clean: true });
   if (repair.success && (await verifyInstalledBinaryLaunches(agent, version)).ok) {
@@ -2241,8 +2264,20 @@ export async function ensureAgentRunnable(
     return version;
   }
 
+  // An isolated copy is walled off from the rest of the setup: repairing it in
+  // place is the ONLY thing we may do. No fallback, no install, no default
+  // switch — surface the failure and let the caller tell the user.
+  if (targetIsolated) {
+    log?.(`${cfg.name}@${version} is an isolated install and could not be repaired — leaving your default ${cfg.name} untouched.`);
+    return null;
+  }
+
   // In-place repair failed → adopt another installed version that launches.
-  const others = listInstalledVersions(agent).filter(v => v !== version).sort(compareVersions).reverse();
+  // Isolated copies are excluded: they are deliberately not promotable.
+  const others = listInstalledVersions(agent)
+    .filter(v => v !== version && !isVersionIsolated(agent, v))
+    .sort(compareVersions)
+    .reverse();
   for (const cand of others) {
     if ((await verifyInstalledBinaryLaunches(agent, cand)).ok) {
       setGlobalDefault(agent, cand);


### PR DESCRIPTION
Follow-up to #1412 (`d6c17469`). That fix stopped isolated installs from getting a bare shim or a PATH entry. Four more automatic-repair paths still crossed the `--isolated` boundary — all reachable from the daemon with **no user action**.

Every claim below was reproduced by running the code against a planted temp `HOME`, not by reading it.

## 1. `ensureAgentRunnable` mutated the global default for an isolated target

`apps/cli/src/lib/versions.ts` — `commands/exec.ts:1751` calls this on every dispatch, so `agents run codex@<isolated>` reaches it. Broken isolated version + failed in-place repair → it adopted another installed version and re-pinned it as the default:

```
default BEFORE : 9.9.1
  Codex@9.9.2 could not be repaired — using Codex@9.9.3 instead (now the default).
default AFTER  : 9.9.3     ← isolated invocation repointed the NORMAL default
```

An isolated target now gets the in-place repair and nothing else — no fallback, no `install latest`, no `setGlobalDefault`. A failed repair returns `null` so the caller says so plainly.

## 2. The same fallback could promote an isolated copy **to** the default

The candidate list came straight from `listInstalledVersions()`, which includes isolated versions. Broken normal default + healthy isolated copy:

```
default BEFORE : 9.9.1   (normal, gutted)
  Codex@9.9.1 could not be repaired — using Codex@9.9.3 instead (now the default).
VERDICT isolated-promoted-to-default: true
```

Plain `codex` then resolves to the isolated copy. This is exactly what `agents use` refuses (`commands/versions.ts:838`) and what `removeVersion`'s promotion filter excludes (`versions.ts:1905`) — the back door bypassed both. Candidates are now filtered regardless of the target, because `healBrokenDefaultLaunches` (`daemon.ts:604`) drives this unattended 90s after daemon start and every ~6h.

## 3. `removeInstallArtifacts` deleted the `.isolated` marker

A clean repair reinstall preserved only `home/`. So the *first* repair of an isolated copy demoted it to a normal install — after which shim self-heal handed it a bare `<agent>` shim and a PATH entry, undoing #1412 entirely. This is also why the guard in (1) initially didn't fire: the marker was already gone by the time it was read. Fixed in two places — the marker is preserved as state rather than install output, and `ensureAgentRunnable` reads it *before* the repair.

## 4. Background resource self-heal wrote into isolated homes

`heal()` (`lib/heal.ts`) built targets from `listInstalledVersions()` with no isolation filter, and `daemon.ts:488` runs `runSelfHeal({mode:'safe'})` ~30s after startup and every ~6h. Running the daemon's exact call:

```
BEFORE isolated home: []
AFTER  isolated home: [".claude/commands/leak-probe.md",
                       ".claude/memory/.agents-cli-memory.json",
                       ".claude/memory/MEMORY.md"]
```

Directly contradicts `commands/versions.ts:509` — *"no settings carry-over, no resource sync"*.

Sweeps now skip isolated versions. **Explicitly named versions are still honoured** — `agents doctor <agent>@<version> --fix` works unchanged, because naming the version is the operator's consent. That avoids a new flag and keeps the escape hatch. The explicit `syncResourcesToVersion` callers (`sync`, `profiles`, `commands`) are deliberately untouched.

## Testing

Regression coverage asserts the **buggy** behaviour, not just the fix. Reverting `versions.ts` (keeping the tests) fails both new launch-path tests with the original symptoms:

```
× leaves the normal default alone when an ISOLATED target cannot be repaired
  AssertionError: expected '9.9.3' to be null
× never adopts an ISOLATED version as the fallback default…
  AssertionError: expected '9.9.9' to be '9.9.3'
```

Reverting `heal.ts` fails the resources test (`expected true to be false`). Tests are subprocess-driven against a temp `HOME` (the `self-heal.integration.test.ts` pattern) with no mocks — the repair genuinely calls npm, which fails on these synthetic versions whether online (404) or offline (network error), landing on the same branch either way.

- New/changed tests: **9 passed**
- Related suites (`src/lib/self-heal`, `versions`, `doctor-diff`, `shims`): **92 passed / 1 skipped**
- `tsc --noEmit`: clean
- Full `src/lib`: **5269 passed / 3 failed** — the 3 are `exec.test.ts` codex-command failures, verified pre-existing on unmodified `upstream/main` (identical 3 on a clean tree)

POSIX-only (`skipIf(win32)`): the launch probe resolves `node_modules/.bin/<cli>` on POSIX but the `.cmd` wrapper on Windows, where a missing wrapper is deliberately treated as healthy — so a "gutted install" can't be planted the same way.

## Not changed

The `commands/exec.ts` login preflight uses an account-global credential probe on isolated launches. It is read-only, and the comment there explains a per-version home would false-negative for HOME-global credential agents (codex/grok). Changing it trades a real bug for a cosmetic one, so it's left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
