### PR TITLE
feat: star-us nudge, README Quickstart, npm alias deprecation prep

### DIFF
--- a/NPM_CONSOLIDATION.md
+++ b/NPM_CONSOLIDATION.md
@@ -1,0 +1,42 @@
+# npm consolidation — deprecate the alias packages
+
+The download signal for this CLI is currently split across three npm packages:
+
+| Package | Role | Action |
+| --- | --- | --- |
+| **`@phnx-labs/agents-cli`** | Canonical package — the real CLI | Keep. Do **not** deprecate. |
+| `@phnx-labs/agi-cli` | Front-brand alias (`packages/agi-cli`) — re-exports the canonical CLI | Deprecate. |
+| `@companion/agents-cli` | Legacy redirect stub (`packages/swarmify-mirror`) — re-exports the canonical CLI | Deprecate. |
+
+Deprecating the two aliases points every `npm install` at the canonical package, so downloads, GitHub stars, and search rank concentrate on one listing instead of three. `npm deprecate` is non-destructive: the packages stay installable (existing installs keep working), npm just prints a deprecation warning on install and greys the listing.
+
+## What Muqsit needs to run
+
+These commands require npm **publish auth** for the `@phnx-labs` and `@companion` scopes, so they are **not** run by the agent — run them yourself once logged in (`npm whoami` to confirm):
+
+```bash
+# Deprecate every version of the agi-cli alias.
+npm deprecate "@phnx-labs/agi-cli@*" \
+  "Deprecated: install @phnx-labs/agents-cli instead (same CLI). See https://github.com/phnx-labs/agents-cli"
+
+# Deprecate every version of the legacy @companion redirect stub.
+npm deprecate "@companion/agents-cli@*" \
+  "Deprecated: install @phnx-labs/agents-cli instead. See https://github.com/phnx-labs/agents-cli"
+```
+
+Notes:
+
+- The `@*` range deprecates **all** published versions. To deprecate only a specific range, pass e.g. `"@phnx-labs/agi-cli@<=1.20.70"`.
+- To **undo** a deprecation, re-run `npm deprecate` with an empty message string: `npm deprecate "@phnx-labs/agi-cli@*" ""`.
+- Do **not** `npm unpublish` the aliases — that breaks existing installs and the 24h-old unpublish window rules. Deprecation is the safe path.
+- Leave `@phnx-labs/agents-cli` untouched; it is the destination.
+
+## Verify
+
+```bash
+npm view @phnx-labs/agi-cli deprecated
+npm view @companion/agents-cli deprecated
+npm view @phnx-labs/agents-cli deprecated   # should print nothing (not deprecated)
+```
+
+The package.json `description` and `README.md` for both aliases (`packages/agi-cli`, `packages/swarmify-mirror`) already state the deprecation and name `@phnx-labs/agents-cli` as canonical — those ship on the next publish of each alias so the npm listing pages match the deprecation warning.

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ https://agents-cli.sh/demo.mp4
 ## Quickstart
 
 ```bash
-curl -fsSL agi-cli.sh | sh          # install (or: npm i -g @phnx-labs/agents-cli)
-agents setup                        # first-time setup -- config + pick your agents
-agents run claude "explain this repo"   # run any agent on your existing subscription
+npm install -g @phnx-labs/agents-cli   # or: curl -fsSL agi-cli.sh | sh
+agents setup                           # first-time setup -- config + pick your agents
+agents run claude "explain this repo"  # run any agent on your existing subscription
 ```
 
-`agents setup` is interactive and idempotent -- safe to re-run on a new machine.
+`agents setup` is interactive and idempotent -- safe to re-run on a new machine. The `agi-cli.sh` one-liner installs this same canonical `@phnx-labs/agents-cli` package.
 
 ```bash
 npm install -g @phnx-labs/agents-cli

--- a/README.md
+++ b/README.md
@@ -43,13 +43,7 @@ agents setup                           # first-time setup -- config + pick your 
 agents run claude "explain this repo"  # run any agent on your existing subscription
 ```
 
-`agents setup` is interactive and idempotent -- safe to re-run on a new machine. The `agi-cli.sh` one-liner installs this same canonical `@phnx-labs/agents-cli` package.
-
-```bash
-npm install -g @phnx-labs/agents-cli
-# or
-bun install -g @phnx-labs/agents-cli
-```
+`agents setup` is interactive and idempotent -- safe to re-run on a new machine. The `agi-cli.sh` one-liner installs this same canonical `@phnx-labs/agents-cli` package. Prefer bun? `bun install -g @phnx-labs/agents-cli` works too.
 
 Already installed? `agents upgrade` updates agents-cli itself to the latest version (`agents upgrade 1.2.3` for a specific version or dist-tag, `-y` to skip the confirm prompt). The command is `upgrade` on every platform -- there is no `agents update` (on macOS, `agents helper update` is a different command that reinstalls the keychain helper, not agents-cli).
 
@@ -1190,6 +1184,8 @@ The installer tries Bun first (faster), falls back to npm. Node 22.5+ required a
 Yes -- `agents run` is non-interactive by default. `--yes` auto-accepts prompts, `--json` for structured output. Pass explicit names and IDs instead of relying on interactive pickers.
 
 The auto-update prompt is suppressed automatically when stdin or stdout isn't a TTY. For headless environments where TTY detection misfires (k8s pods that allocate a PTY for stdout, cloud sandbox factories), set `AGENTS_CLI_DISABLE_AUTO_UPDATE=1` to skip the update check entirely -- no prompt, no network call.
+
+agents-cli also prints a one-time "star us on GitHub" line after your first successful `agents run`/`agents teams`. It's already skipped in CI, non-TTY, `--json`, and `--quiet` runs; set `AGENTS_NO_NUDGE=1` to suppress it everywhere.
 
 To update on demand instead of waiting for the prompt, run `agents upgrade` (add `-y` to skip the confirmation, or pass a version/dist-tag to install something other than latest).
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@
 
 https://agents-cli.sh/demo.mp4
 
+## Quickstart
+
+```bash
+curl -fsSL agi-cli.sh | sh          # install (or: npm i -g @phnx-labs/agents-cli)
+agents setup                        # first-time setup -- config + pick your agents
+agents run claude "explain this repo"   # run any agent on your existing subscription
+```
+
+`agents setup` is interactive and idempotent -- safe to re-run on a new machine.
+
 ```bash
 npm install -g @phnx-labs/agents-cli
 # or

--- a/apps/cli/.changelog/next/star-us-nudge.md
+++ b/apps/cli/.changelog/next/star-us-nudge.md
@@ -1,0 +1,9 @@
+- **One-time "star us on GitHub" nudge after your first successful run.** After a
+  user's first successful `agents run` or `agents teams`, agents-cli prints a
+  single plain inline line pointing at the repo. Shown at most once ever (claimed
+  with an atomic O_EXCL sentinel so concurrent `agents teams` processes can't
+  double-print), and skipped for non-TTY, CI, `--json`/`--quiet`, or
+  `AGENTS_NO_NUDGE=1`. The `agents teams` call site only nudges on a clean drain
+  (no failed teammates). Source: `apps/cli/src/lib/star-nudge.ts`,
+  `apps/cli/src/commands/exec.ts`, `apps/cli/src/commands/teams.ts`,
+  `apps/cli/src/lib/teams/supervisor.ts`.

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -18,6 +18,7 @@ import { parseLoopInterval } from '../lib/loop.js';
 import type { RotateResult } from '../lib/rotate.js';
 import { AGENTS } from '../lib/agents.js';
 import { recordDispatchedRun } from '../lib/audit/log.js';
+import { maybeShowStarNudge } from '../lib/star-nudge.js';
 import { warnUnpushedWork, shouldWarnUnpushed } from '../lib/warn-unpushed.js';
 import { isHostPinned, pinHostKey, managedKnownHostsPath } from '../lib/devices/known-hosts.js';
 import { sshResolve, type SshGResult } from '../lib/hosts/ssh-config.js';
@@ -2376,6 +2377,9 @@ export function registerRunCommand(program: Command): void {
         // Governance chokepoint (#347): every dispatched run finalizes here.
         // ONE tamper-evident audit record per run — non-fatal by contract.
         recordDispatchedRun({ agent: ranAgent, version: ranVersion ?? 'unknown', mode, cwd, exitCode });
+        // First-successful-run star nudge (one-time, non-nagging). Only on a
+        // clean run, and never when output is machine-readable/quiet.
+        if (exitCode === 0) maybeShowStarNudge({ quiet: options.json || options.quiet });
         process.exit(exitCode);
       } catch (err) {
         cleanupWorkflowMcpConfig();

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -26,6 +26,7 @@ import { mailboxDir, enqueue } from '../lib/mailbox.js';
 import { resolveProvider } from '../lib/cloud/registry.js';
 import type { CloudProviderId, DispatchOptions } from '../lib/cloud/types.js';
 import { emit } from '../lib/events.js';
+import { maybeShowStarNudge } from '../lib/star-nudge.js';
 import { shareRuntimeEnv } from '../lib/share/config.js';
 import { runSupervisor } from '../lib/teams/supervisor.js';
 import { debug } from '../lib/teams/debug.js';
@@ -1864,6 +1865,8 @@ export function registerTeamsCommands(program: Command): void {
 
       if (result.stoppedBy === 'drained') {
         console.log(chalk.green(`Factory drained in ${elapsed}s (${result.waves} waves).`));
+        // First-successful-team star nudge (one-time, non-nagging).
+        maybeShowStarNudge({ quiet: opts.json });
       } else if (result.stoppedBy === 'max-waves') {
         console.error(chalk.yellow(`Hit --max-waves=${maxWaves}; stopping. Re-run to continue.`));
       } else if (result.stoppedBy === 'signal') {

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -1865,8 +1865,13 @@ export function registerTeamsCommands(program: Command): void {
 
       if (result.stoppedBy === 'drained') {
         console.log(chalk.green(`Factory drained in ${elapsed}s (${result.waves} waves).`));
-        // First-successful-team star nudge (one-time, non-nagging).
-        maybeShowStarNudge({ quiet: opts.json });
+        // First-successful-team star nudge (one-time, non-nagging). "drained"
+        // only means nothing is pending/running — teammates may have failed — so
+        // gate on a clean drain (failed === 0). A team where every teammate
+        // failed is not the success this nudge celebrates.
+        if ((result.failed ?? 0) === 0) {
+          maybeShowStarNudge({ quiet: opts.json });
+        }
       } else if (result.stoppedBy === 'max-waves') {
         console.error(chalk.yellow(`Hit --max-waves=${maxWaves}; stopping. Re-run to continue.`));
       } else if (result.stoppedBy === 'signal') {

--- a/apps/cli/src/lib/star-nudge.test.ts
+++ b/apps/cli/src/lib/star-nudge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { shouldShowStarNudge } from './star-nudge.js';
+
+/** A fully "green light" context; override one field per case to prove the gate. */
+function ctx(over: Partial<Parameters<typeof shouldShowStarNudge>[0]> = {}) {
+  return {
+    quiet: false,
+    isTTY: true,
+    ci: false,
+    optedOut: false,
+    alreadyShown: false,
+    ...over,
+  };
+}
+
+describe('shouldShowStarNudge gate', () => {
+  it('shows when interactive, first time, not quiet/CI/opted-out', () => {
+    expect(shouldShowStarNudge(ctx())).toBe(true);
+  });
+
+  it('skips quiet/JSON output', () => {
+    expect(shouldShowStarNudge(ctx({ quiet: true }))).toBe(false);
+  });
+
+  it('skips non-interactive terminals (pipes, redirects)', () => {
+    expect(shouldShowStarNudge(ctx({ isTTY: false }))).toBe(false);
+  });
+
+  it('skips under CI', () => {
+    expect(shouldShowStarNudge(ctx({ ci: true }))).toBe(false);
+  });
+
+  it('skips when opted out via AGENTS_NO_NUDGE', () => {
+    expect(shouldShowStarNudge(ctx({ optedOut: true }))).toBe(false);
+  });
+
+  it('skips once already shown (one-time)', () => {
+    expect(shouldShowStarNudge(ctx({ alreadyShown: true }))).toBe(false);
+  });
+});
+
+describe('maybeShowStarNudge one-time behavior', () => {
+  const saved = { HOME: process.env.HOME, CI: process.env.CI, NO: process.env.AGENTS_NO_NUDGE };
+
+  afterEach(() => {
+    process.env.HOME = saved.HOME;
+    if (saved.CI === undefined) delete process.env.CI; else process.env.CI = saved.CI;
+    if (saved.NO === undefined) delete process.env.AGENTS_NO_NUDGE; else process.env.AGENTS_NO_NUDGE = saved.NO;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('writes the sentinel once and never prints twice', async () => {
+    // Pin HOME to a scratch dir so the sentinel lands in a throwaway ~/.agents.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-nudge-test-'));
+    process.env.HOME = home;
+    delete process.env.CI;
+    delete process.env.AGENTS_NO_NUDGE;
+    // Force the TTY gate on for the test process.
+    const stdoutTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+    // Fresh module graph so state.ts re-reads the pinned HOME.
+    vi.resetModules();
+    const mod = await import('./star-nudge.js');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mod.maybeShowStarNudge();
+    mod.maybeShowStarNudge();
+    mod.maybeShowStarNudge();
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(mod.hasShownStarNudge()).toBe(true);
+    expect(log.mock.calls[0][0]).toContain('github.com/phnx-labs/agents-cli');
+
+    // Restore the real isTTY descriptor.
+    if (stdoutTTY) Object.defineProperty(process.stdout, 'isTTY', stdoutTTY);
+  });
+});

--- a/apps/cli/src/lib/star-nudge.test.ts
+++ b/apps/cli/src/lib/star-nudge.test.ts
@@ -1,82 +1,93 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { shouldShowStarNudge } from './star-nudge.js';
+
+// star-nudge.ts -> state.ts resolves HOME at import time, so pin HOME to a
+// throwaway dir BEFORE the module is ever loaded. Done at top-level module
+// scope (runs after the hoisted imports above, none of which load state.ts),
+// then the single dynamic import below picks it up — no vi.resetModules needed,
+// which keeps this compatible with both vitest and `bun test`.
+const savedHome = process.env.HOME;
+const savedCI = process.env.CI;
+const savedOptOut = process.env.AGENTS_NO_NUDGE;
+const savedTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+const TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-nudge-test-'));
+process.env.HOME = TMP_HOME;
+delete process.env.CI;
+delete process.env.AGENTS_NO_NUDGE;
+
+type Mod = typeof import('./star-nudge.js');
+let mod: Mod;
+
+beforeAll(async () => {
+  mod = await import('./star-nudge.js');
+});
+
+afterAll(() => {
+  if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+  if (savedCI === undefined) delete process.env.CI; else process.env.CI = savedCI;
+  if (savedOptOut === undefined) delete process.env.AGENTS_NO_NUDGE; else process.env.AGENTS_NO_NUDGE = savedOptOut;
+  if (savedTTY) Object.defineProperty(process.stdout, 'isTTY', savedTTY);
+});
 
 /** A fully "green light" context; override one field per case to prove the gate. */
-function ctx(over: Partial<Parameters<typeof shouldShowStarNudge>[0]> = {}) {
-  return {
-    quiet: false,
-    isTTY: true,
-    ci: false,
-    optedOut: false,
-    alreadyShown: false,
-    ...over,
-  };
+function ctx(over: Partial<Parameters<Mod['shouldShowStarNudge']>[0]> = {}) {
+  return { quiet: false, isTTY: true, ci: false, optedOut: false, alreadyShown: false, ...over };
 }
 
 describe('shouldShowStarNudge gate', () => {
   it('shows when interactive, first time, not quiet/CI/opted-out', () => {
-    expect(shouldShowStarNudge(ctx())).toBe(true);
+    expect(mod.shouldShowStarNudge(ctx())).toBe(true);
   });
 
   it('skips quiet/JSON output', () => {
-    expect(shouldShowStarNudge(ctx({ quiet: true }))).toBe(false);
+    expect(mod.shouldShowStarNudge(ctx({ quiet: true }))).toBe(false);
   });
 
   it('skips non-interactive terminals (pipes, redirects)', () => {
-    expect(shouldShowStarNudge(ctx({ isTTY: false }))).toBe(false);
+    expect(mod.shouldShowStarNudge(ctx({ isTTY: false }))).toBe(false);
   });
 
   it('skips under CI', () => {
-    expect(shouldShowStarNudge(ctx({ ci: true }))).toBe(false);
+    expect(mod.shouldShowStarNudge(ctx({ ci: true }))).toBe(false);
   });
 
   it('skips when opted out via AGENTS_NO_NUDGE', () => {
-    expect(shouldShowStarNudge(ctx({ optedOut: true }))).toBe(false);
+    expect(mod.shouldShowStarNudge(ctx({ optedOut: true }))).toBe(false);
   });
 
   it('skips once already shown (one-time)', () => {
-    expect(shouldShowStarNudge(ctx({ alreadyShown: true }))).toBe(false);
+    expect(mod.shouldShowStarNudge(ctx({ alreadyShown: true }))).toBe(false);
   });
 });
 
+/** Run a thunk with console.log captured; returns every logged line. Portable — no vi mocks. */
+function captureLog(fn: () => void): string[] {
+  const lines: string[] = [];
+  const orig = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  try { fn(); } finally { console.log = orig; }
+  return lines;
+}
+
 describe('maybeShowStarNudge one-time behavior', () => {
-  const saved = { HOME: process.env.HOME, CI: process.env.CI, NO: process.env.AGENTS_NO_NUDGE };
-
-  afterEach(() => {
-    process.env.HOME = saved.HOME;
-    if (saved.CI === undefined) delete process.env.CI; else process.env.CI = saved.CI;
-    if (saved.NO === undefined) delete process.env.AGENTS_NO_NUDGE; else process.env.AGENTS_NO_NUDGE = saved.NO;
-    vi.restoreAllMocks();
-    vi.resetModules();
-  });
-
-  it('writes the sentinel once and never prints twice', async () => {
-    // Pin HOME to a scratch dir so the sentinel lands in a throwaway ~/.agents.
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-nudge-test-'));
-    process.env.HOME = home;
-    delete process.env.CI;
-    delete process.env.AGENTS_NO_NUDGE;
-    // Force the TTY gate on for the test process.
-    const stdoutTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+  it('prints exactly once, writes the sentinel, then stays silent', () => {
+    // Force the TTY gate on for this non-interactive test process.
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
 
-    // Fresh module graph so state.ts re-reads the pinned HOME.
-    vi.resetModules();
-    const mod = await import('./star-nudge.js');
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    expect(mod.hasShownStarNudge()).toBe(false);
+    const first = captureLog(() => mod.maybeShowStarNudge());
+    const second = captureLog(() => mod.maybeShowStarNudge());
+    const third = captureLog(() => mod.maybeShowStarNudge());
 
-    mod.maybeShowStarNudge();
-    mod.maybeShowStarNudge();
-    mod.maybeShowStarNudge();
-
-    expect(log).toHaveBeenCalledTimes(1);
+    expect(first).toHaveLength(1);
+    expect(first[0]).toContain('github.com/phnx-labs/agents-cli');
+    expect(second).toHaveLength(0);
+    expect(third).toHaveLength(0);
     expect(mod.hasShownStarNudge()).toBe(true);
-    expect(log.mock.calls[0][0]).toContain('github.com/phnx-labs/agents-cli');
-
-    // Restore the real isTTY descriptor.
-    if (stdoutTTY) Object.defineProperty(process.stdout, 'isTTY', stdoutTTY);
+    // Sentinel really landed under the pinned throwaway HOME.
+    expect(fs.existsSync(path.join(TMP_HOME, '.agents', '.cache', 'state', 'star-nudge-shown'))).toBe(true);
   });
 });

--- a/apps/cli/src/lib/star-nudge.test.ts
+++ b/apps/cli/src/lib/star-nudge.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
 
 // star-nudge.ts -> state.ts resolves HOME at import time, so pin HOME to a
 // throwaway dir BEFORE the module is ever loaded. Done at top-level module
@@ -90,4 +92,42 @@ describe('maybeShowStarNudge one-time behavior', () => {
     // Sentinel really landed under the pinned throwaway HOME.
     expect(fs.existsSync(path.join(TMP_HOME, '.agents', '.cache', 'state', 'star-nudge-shown'))).toBe(true);
   });
+});
+
+// The real reason the guard uses an atomic O_EXCL create: `agents teams` spawns
+// many processes that finish near-simultaneously, and an existsSync+write pair
+// is a cross-process TOCTOU race (a reviewer saw 3 of 5 procs double-print). An
+// in-process test can't reproduce that — it needs genuinely concurrent
+// processes — so we spawn N children against one shared HOME and assert the
+// nudge is printed exactly once. Skipped on Windows (subprocess/tsx-shim churn).
+describe('maybeShowStarNudge is race-safe across concurrent processes', () => {
+  const tsxBin = fileURLToPath(new URL('../../node_modules/.bin/tsx', import.meta.url));
+  const starNudgeSrc = fileURLToPath(new URL('./star-nudge.ts', import.meta.url));
+  const runnable = process.platform !== 'win32' && fs.existsSync(tsxBin);
+
+  it.skipIf(!runnable)('prints exactly once when 8 processes finish at once', async () => {
+    const raceHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-nudge-race-'));
+    const fixture = path.join(raceHome, 'child.mts');
+    fs.writeFileSync(
+      fixture,
+      `import { maybeShowStarNudge } from ${JSON.stringify(starNudgeSrc)};\n` +
+        `Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });\n` +
+        `maybeShowStarNudge();\n`,
+    );
+
+    const runChild = () =>
+      new Promise<string>((resolve, reject) => {
+        const child = spawn(tsxBin, [fixture], {
+          env: { ...process.env, HOME: raceHome, CI: '', AGENTS_NO_NUDGE: '' },
+        });
+        let out = '';
+        child.stdout.on('data', (d) => { out += d.toString(); });
+        child.on('error', reject);
+        child.on('close', () => resolve(out));
+      });
+
+    const outputs = await Promise.all(Array.from({ length: 8 }, runChild));
+    const prints = outputs.filter((o) => o.includes('Give it a star')).length;
+    expect(prints).toBe(1);
+  }, 30000);
 });

--- a/apps/cli/src/lib/star-nudge.ts
+++ b/apps/cli/src/lib/star-nudge.ts
@@ -1,0 +1,96 @@
+/**
+ * One-time "star us on GitHub" nudge.
+ *
+ * Printed a single time, ever, after a user's first *successful* headline run
+ * (`agents run` / `agents teams`). Modelled on the existing warn-once sentinel
+ * pattern (see maybeWarnMultiInstall in src/index.ts): a marker under the
+ * regenerable runtime-state dir records that the hint was shown so it never
+ * repeats. It is a plain inline line — not a toast, not a nag — and stays out
+ * of the way of non-interactive, CI, quiet, and JSON output.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import chalk from 'chalk';
+import { getRuntimeStateDir } from './state.js';
+
+/** Canonical GitHub repo the nudge points at. */
+export const REPO_URL = 'https://github.com/phnx-labs/agents-cli';
+
+/** Sentinel written the first (and only) time the nudge is shown. */
+function nudgeSentinelPath(): string {
+  return path.join(getRuntimeStateDir(), 'star-nudge-shown');
+}
+
+/** Has the star nudge already been shown on this machine? */
+export function hasShownStarNudge(): boolean {
+  try {
+    return fs.existsSync(nudgeSentinelPath());
+  } catch {
+    return false;
+  }
+}
+
+/** Inputs to the pure show/skip decision (kept side-effect free for testing). */
+export interface StarNudgeContext {
+  /** Caller asked for quiet / JSON output. */
+  quiet?: boolean;
+  /** stdout is attached to an interactive terminal. */
+  isTTY: boolean;
+  /** CI is set in the environment. */
+  ci: boolean;
+  /** User opted out via AGENTS_NO_NUDGE=1. */
+  optedOut: boolean;
+  /** The one-time sentinel already exists. */
+  alreadyShown: boolean;
+}
+
+/**
+ * Pure decision: should the one-time star nudge be shown? Skipped for
+ * quiet/JSON output, non-interactive terminals (pipes, redirects), CI, an
+ * explicit opt-out, or once it has already been shown.
+ */
+export function shouldShowStarNudge(ctx: StarNudgeContext): boolean {
+  if (ctx.quiet) return false;
+  if (!ctx.isTTY) return false;
+  if (ctx.ci) return false;
+  if (ctx.optedOut) return false;
+  if (ctx.alreadyShown) return false;
+  return true;
+}
+
+/**
+ * Show the one-time star nudge if it hasn't been shown yet and the context is
+ * appropriate. Best-effort by contract: never throws, never blocks the run it
+ * follows.
+ *
+ * Skipped when: the caller asked for quiet/JSON output, stdout is not an
+ * interactive terminal (pipes, redirects), CI is set, or the user opted out
+ * with AGENTS_NO_NUDGE=1.
+ */
+export function maybeShowStarNudge(opts: { quiet?: boolean } = {}): void {
+  try {
+    const show = shouldShowStarNudge({
+      quiet: opts.quiet,
+      isTTY: Boolean(process.stdout.isTTY),
+      ci: Boolean(process.env.CI),
+      optedOut: process.env.AGENTS_NO_NUDGE === '1',
+      alreadyShown: hasShownStarNudge(),
+    });
+    if (!show) return;
+
+    // Write the sentinel BEFORE printing so two runs finishing at once still
+    // show the hint at most once.
+    const sentinel = nudgeSentinelPath();
+    fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+    fs.writeFileSync(sentinel, new Date().toISOString());
+
+    console.log(
+      '\n' +
+        chalk.gray('Enjoying agents-cli? Give it a star to help others find it: ') +
+        chalk.cyan(REPO_URL),
+    );
+  } catch {
+    /* best-effort: a nudge must never break a successful run */
+  }
+}

--- a/apps/cli/src/lib/star-nudge.ts
+++ b/apps/cli/src/lib/star-nudge.ts
@@ -79,11 +79,20 @@ export function maybeShowStarNudge(opts: { quiet?: boolean } = {}): void {
     });
     if (!show) return;
 
-    // Write the sentinel BEFORE printing so two runs finishing at once still
-    // show the hint at most once.
+    // Claim the one-time slot with an ATOMIC exclusive create (O_EXCL). The
+    // hasShownStarNudge() check above is only a cheap fast-path; the existsSync
+    // + write pair is a TOCTOU race across processes, and `agents teams` spawns
+    // many at once. The `wx` flag makes the create itself the arbiter: exactly
+    // one process succeeds, every other gets EEXIST and stays silent — so the
+    // hint prints at most once even under concurrent completions.
     const sentinel = nudgeSentinelPath();
     fs.mkdirSync(path.dirname(sentinel), { recursive: true });
-    fs.writeFileSync(sentinel, new Date().toISOString());
+    try {
+      fs.writeFileSync(sentinel, new Date().toISOString(), { flag: 'wx' });
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'EEXIST') return; // another process won the race
+      throw e; // real write failure -> caught by the outer best-effort guard
+    }
 
     console.log(
       '\n' +

--- a/apps/cli/src/lib/teams/__tests__/supervisor.test.ts
+++ b/apps/cli/src/lib/teams/__tests__/supervisor.test.ts
@@ -207,6 +207,33 @@ describe('runSupervisor', () => {
     expect(seenNames.has('seed')).toBe(true);
   });
 
+  it('reports failed count on drain: a failed teammate drains with failed >= 1', async () => {
+    // A "drained" DAG only means nothing is pending/running — a failed teammate
+    // still drains. The result must surface that so callers (e.g. the star
+    // nudge) can distinguish a clean drain from a failed one.
+    await plantAgent('mixed', { name: 'ok', status: AgentStatus.COMPLETED, taskType: 'implement' });
+    await plantAgent('mixed', { name: 'boom', status: AgentStatus.FAILED, taskType: 'implement' });
+    const result = await runSupervisor(mgr, {
+      team: 'mixed',
+      intervalMs: 50,
+      onWave: () => {},
+    });
+    expect(result.stoppedBy).toBe('drained');
+    expect(result.failed).toBe(1);
+  });
+
+  it('a fully-successful drain reports failed === 0', async () => {
+    await plantAgent('allok', { name: 'a', status: AgentStatus.COMPLETED, taskType: 'implement' });
+    await plantAgent('allok', { name: 'b', status: AgentStatus.COMPLETED, taskType: 'test', after: ['a'] });
+    const result = await runSupervisor(mgr, {
+      team: 'allok',
+      intervalMs: 50,
+      onWave: () => {},
+    });
+    expect(result.stoppedBy).toBe('drained');
+    expect(result.failed).toBe(0);
+  });
+
   it('stops at --max-waves if the DAG never drains', async () => {
     await plantAgent('t1', { name: 'running', status: AgentStatus.RUNNING, taskType: 'implement' });
     const result = await runSupervisor(mgr, {

--- a/apps/cli/src/lib/teams/supervisor.ts
+++ b/apps/cli/src/lib/teams/supervisor.ts
@@ -54,6 +54,13 @@ export interface SupervisorResult {
   waves: number;
   stoppedBy: 'drained' | 'max-waves' | 'signal' | 'callback' | 'budget';
   elapsed_ms: number;
+  /**
+   * Number of teammates in the `failed` state when the team drained. Only set
+   * for `stoppedBy === 'drained'`. A drained DAG means nothing is pending or
+   * running — NOT that everything succeeded — so callers that treat "drained"
+   * as success (e.g. a completion nudge) must check `failed === 0` first.
+   */
+  failed?: number;
   /** Set when `stoppedBy === 'budget'` — the breach that terminated the team. */
   budgetBreach?: BreachInfo;
 }
@@ -145,7 +152,8 @@ export async function runSupervisor(
         (a) => a.status === 'pending' || a.status === 'running'
       );
       if (!stillLive) {
-        return { waves: wave, stoppedBy: 'drained', elapsed_ms: Date.now() - startedAt };
+        const failed = afterCallback.filter((a) => a.status === 'failed').length;
+        return { waves: wave, stoppedBy: 'drained', failed, elapsed_ms: Date.now() - startedAt };
       }
       if (stopSignal) {
         return { waves: wave, stoppedBy: 'signal', elapsed_ms: Date.now() - startedAt };

--- a/packages/agi-cli/README.md
+++ b/packages/agi-cli/README.md
@@ -1,25 +1,22 @@
-# @phnx-labs/agi-cli
+# @phnx-labs/agi-cli — deprecated alias
 
-**agi-cli — one CLI for every coding agent.** Your agents, your subscription, ten at once.
+> **Deprecated.** Install the canonical package instead:
+>
+> ```bash
+> npm install -g @phnx-labs/agents-cli
+> ```
+>
+> The canonical package is **[`@phnx-labs/agents-cli`](https://www.npmjs.com/package/@phnx-labs/agents-cli)**.
 
-This is the front-brand alias of [`@phnx-labs/agents-cli`](https://www.npmjs.com/package/@phnx-labs/agents-cli). Installing it gives you the exact same tool, exposed as three interchangeable commands: `agents`, `ag`, and `agi`.
+This package exists only as a thin front-brand alias of `@phnx-labs/agents-cli`. Installing it gives you the exact same tool, exposed as three interchangeable commands: `agents`, `ag`, and `agi`. It is kept published so existing `@phnx-labs/agi-cli` installs keep working, but it lags the canonical package and receives no independent development.
+
+New installs and all documentation should use `@phnx-labs/agents-cli`. If you already installed this alias, nothing breaks — but prefer the canonical package going forward:
 
 ```bash
-curl -fsSL agi-cli.sh | sh
-# or
-npm install -g @phnx-labs/agi-cli
+npm uninstall -g @phnx-labs/agi-cli
+npm install -g @phnx-labs/agents-cli
 ```
 
-Then run any of:
-
-```bash
-agi --help
-ag --help
-agents --help
-```
-
-Run Claude Code, Codex, Gemini and every coding agent from one place — on the subscription you already pay for. Parallel teams, browser & desktop control, Touch ID secrets, routines, monitors.
-
-Docs and source: <https://agi-cli.sh> · <https://github.com/phnx-labs/agents-cli>
+Docs and source: <https://github.com/phnx-labs/agents-cli>
 
 Apache-2.0 © Phoenix Labs

--- a/packages/agi-cli/package.json
+++ b/packages/agi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phnx-labs/agi-cli",
   "version": "1.20.70",
-  "description": "agi-cli — one CLI for every coding agent. Front-brand alias of @phnx-labs/agents-cli; installs the same tool as agents, ag, and agi.",
+  "description": "DEPRECATED alias — install @phnx-labs/agents-cli instead. This package only re-exports the canonical @phnx-labs/agents-cli CLI (commands: agents, ag, agi) and is no longer the recommended install.",
   "type": "module",
   "bin": {
     "agents": "bin/cli.js",

--- a/packages/swarmify-mirror/README.md
+++ b/packages/swarmify-mirror/README.md
@@ -1,7 +1,18 @@
-# @companion/agents-cli
+# @companion/agents-cli — deprecated redirect
 
-> This package has moved to [@phnx-labs/agents-cli](https://www.npmjs.com/package/@phnx-labs/agents-cli).
+> **Deprecated.** This package has moved to **[`@phnx-labs/agents-cli`](https://www.npmjs.com/package/@phnx-labs/agents-cli)** — the canonical package. Install that instead:
+>
+> ```bash
+> npm install -g @phnx-labs/agents-cli
+> ```
+
+This is a legacy redirect stub for old `@companion/agents-cli` installs. It only depends on the canonical `@phnx-labs/agents-cli` and re-exports its `agents` / `ag` commands. It receives no independent development and should not be used for new installs.
+
+Already on this package? Switch to the canonical one:
 
 ```bash
+npm uninstall -g @companion/agents-cli
 npm install -g @phnx-labs/agents-cli
 ```
+
+Docs and source: <https://github.com/phnx-labs/agents-cli>

--- a/packages/swarmify-mirror/package.json
+++ b/packages/swarmify-mirror/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@companion/agents-cli",
   "version": "1.14.0",
-  "description": "This package has moved to @phnx-labs/agents-cli. Install that instead.",
+  "description": "DEPRECATED redirect — this package moved to @phnx-labs/agents-cli. Install the canonical @phnx-labs/agents-cli instead; this stub only re-exports it for legacy @companion/agents-cli users.",
   "dependencies": {
     "@phnx-labs/agents-cli": ">=1.13.4"
   },


### PR DESCRIPTION
Three visibility/adoption improvements from the discoverability audit (goal: adoption + discoverability of the free CLI). No behavior change to any existing command path.

## What changed

**1. One-time, race-safe "star us" nudge.** After a user's first *successful* `agents run` or `agents teams`, print a single plain inline line pointing to the repo:

```
Enjoying agents-cli? Give it a star to help others find it: https://github.com/phnx-labs/agents-cli
```

- **At most once, ever** — claimed with an **atomic exclusive create** (`fs.writeFileSync(sentinel, ..., { flag: 'wx' })`, O_EXCL) at `~/.agents/.cache/state/star-nudge-shown`. This is deliberately not `existsSync`+`write`: that pair is a cross-process TOCTOU race, and `agents teams` spawns many processes that finish at once (a reviewer reproduced 3/5 double-printing). With `wx`, exactly one process wins; the rest get `EEXIST` and stay silent.
- **Hooks the real success points**: the run finalize chokepoint in `exec.ts` (only when `exitCode === 0`) and the `drained` success branch in `teams.ts`.
- **Skipped** for non-TTY (pipes/redirects), `CI`, `--json`/`--quiet`, or `AGENTS_NO_NUDGE=1`. Color via `chalk` (auto-respects `NO_COLOR`). Best-effort — never throws, never blocks the run.

**2. README Quickstart.** Added a `## Quickstart` at the top (after the intro/demo, before feature sections): install → `agents setup` → first run. Leads with `npm install -g @phnx-labs/agents-cli` and notes the `agi-cli.sh` one-liner installs the same canonical package.

**3. npm consolidation prep (docs only — no publish).** The download signal is split across 3 packages. Marked the two aliases deprecated in their `description` + `README`, pointing at canonical **`@phnx-labs/agents-cli`**:
- `@phnx-labs/agi-cli` (`packages/agi-cli`)
- `@companion/agents-cli` (`packages/swarmify-mirror`)

Added `NPM_CONSOLIDATION.md` with the exact `npm deprecate` commands. **Not run here** — they need publish auth.

## New / changed code
- `apps/cli/src/lib/star-nudge.ts` (new) — `maybeShowStarNudge()` (atomic-claim + gates), `shouldShowStarNudge()` (pure gate), `hasShownStarNudge()` (cheap fast-path).
- `apps/cli/src/lib/star-nudge.test.ts` (new) — 6 pure-gate cases, an in-process once-only test, and an **8-process concurrency test** (spawns tsx children against one shared HOME, asserts exactly one print; verified to catch the pre-fix double-print).
- `apps/cli/src/commands/exec.ts`, `apps/cli/src/commands/teams.ts` — call sites at the two success points.

## Verification
- `npm run build` (tsc) green.
- Vitest `src/lib/star-nudge.test.ts` — 8/8 pass (incl. the concurrency test).
- Drove the compiled `dist/` end-to-end: prints once, writes the sentinel, silent thereafter; CI/non-TTY skip without even writing the sentinel.

## Handoff
Owner: **Muqsit** — do not merge without your review. `prix-cloud` (non-author) + green CI is the gate; the two `npm deprecate` commands in `NPM_CONSOLIDATION.md` still need your publish auth.
