### PR TITLE
fix(fleet): agents fleet ping stops crying wolf on healthy accounts

### DIFF
--- a/apps/cli/.changelog/next/fleet-ping-cry-wolf.md
+++ b/apps/cli/.changelog/next/fleet-ping-cry-wolf.md
@@ -1,0 +1,16 @@
+- **`agents fleet ping` stops crying wolf on healthy accounts.** The auth matrix
+  painted a fully-logged-in fleet as half-broken: `codex`/`grok` (which have no
+  in-repo live-probe endpoint) rolled up as an alarming yellow `0/N`, and the
+  `--verbose` per-account list painted `expired` **red** — lumped with a real
+  `revoked` — even though `expired` is soft and self-refreshes on the CLI's next
+  launch (kimi/droid). Both renderers now share one truthful color model
+  (`verdictColor` / `authCellColor`): red is reserved for `revoked` (the only
+  "re-login now"); `unverified` reads as neutral **gray** "signed in
+  (unverifiable)"; `expired`/`rate_limited`/`error` are soft **yellow**; and the
+  cell numerator counts signed-in accounts (`live + present`) so a logged-in codex
+  fleet reads `1/1`, not `0/1`. Separately, `fleet ping --verbose` now actually
+  emits the per-account breakdown: the root program's global `--verbose` was
+  shadowing the subcommand flag, so the breakdown was silently unreachable — the
+  action now reads the effective value from the merged globals. Source:
+  `apps/cli/src/lib/auth-health.ts`, `apps/cli/src/commands/ssh.ts`,
+  `apps/cli/src/lib/auth-health.test.ts`.

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -88,14 +88,17 @@ import { ALL_AGENT_IDS } from '../lib/agents.js';
 import { crabboxList, crabboxFind, crabboxSshArgv, type CrabboxBox } from '../lib/crabbox/cli.js';
 import { boxAddress, boxStatus, fmtIdleShort, fmtExpiresShort } from './lease.js';
 import {
+  authCellColor,
   formatCheckedAge,
   isDeadVerdict,
   probeLocalFleetAuth,
   readAuthHealthCache,
   summarizeHostAuth,
   summarizeVerdicts,
+  verdictColor,
   verdictLabel,
   writeFleetAuthRows,
+  type AuthCellColor,
   type AuthProbeRow,
   type VerdictSummary,
 } from '../lib/auth-health.js';
@@ -601,14 +604,28 @@ async function runFleetPing(opts: { json?: boolean; local?: boolean; verbose?: b
   if (opts.strict && anyBad) process.exitCode = 1;
 }
 
-/** Color a per-host×agent cell: green all-live, red any revoked/expired, yellow degraded. */
+/** Resolve an {@link AuthCellColor} to a chalk painter. Single map for cells + labels. */
+const CELL_PAINT: Record<AuthCellColor, (s: string) => string> = {
+  green: chalk.green,
+  yellow: chalk.yellow,
+  red: chalk.red,
+  gray: chalk.gray,
+  dim: chalk.dim,
+};
+
+/**
+ * Color a per-host×agent cell. The numerator counts accounts that are usable
+ * right now — live-verified PLUS signed-in-but-unverifiable (codex/grok) — over
+ * the total, so a logged-in codex fleet reads "1/1", not a scary "0/1". Color is
+ * the shared {@link authCellColor}: red only for revoked (re-login), yellow for
+ * soft/expired (self-refreshes), gray for present-but-unverifiable, green when
+ * all live.
+ */
 function authCell(summary: VerdictSummary, width: number): string {
   if (summary.total === 0) return chalk.dim('·'.padEnd(width));
-  const text = `${summary.live}/${summary.total}`;
-  const padded = text.padEnd(width);
-  if (summary.bad > 0) return chalk.red(padded);
-  if (summary.warn > 0) return chalk.yellow(padded);
-  return chalk.green(padded);
+  const ok = summary.live + summary.present;
+  const padded = `${ok}/${summary.total}`.padEnd(width);
+  return CELL_PAINT[authCellColor(summary)](padded);
 }
 
 /** Render the fleet auth matrix (device rows × agent columns) plus an optional per-account breakdown. */
@@ -640,7 +657,7 @@ function renderAuthMatrix(results: FleetPingHostResult[], opts?: { verbose?: boo
   }
 
   lines.push('');
-  lines.push(chalk.gray('  cell = live/total accounts · green all live · red revoked (re-login) · yellow expired/unverified/limited'));
+  lines.push(chalk.gray('  cell = signed-in/total accounts · green live · gray signed-in (unverifiable: codex/grok) · yellow expired (self-refreshes) · red revoked (re-login)'));
 
   if (opts?.verbose) {
     lines.push('');
@@ -649,9 +666,7 @@ function renderAuthMatrix(results: FleetPingHostResult[], opts?: { verbose?: boo
       if (r.rows.length === 0) continue;
       for (const row of r.rows.slice().sort((x, y) => (x.agent + x.version).localeCompare(y.agent + y.version))) {
         const v = row.health.verdict;
-        const label = v === 'live' ? chalk.green(verdictLabel(v))
-          : (v === 'revoked' || v === 'expired') ? chalk.red(verdictLabel(v))
-          : chalk.yellow(verdictLabel(v));
+        const label = CELL_PAINT[verdictColor(v)](verdictLabel(v));
         const acctRaw = row.account ?? '—';
         const acct = row.account ? chalk.cyan(acctRaw.padEnd(28)) : chalk.dim(acctRaw.padEnd(28));
         const detail = row.health.detail ? chalk.dim(` ${row.health.detail}`) : '';
@@ -873,8 +888,14 @@ Typical workflow:
     .option('--local', 'probe only this host (used internally for fan-out)')
     .option('--verbose', 'show a per-account breakdown, not just the per-host rollup')
     .option('--strict', 'exit non-zero when any account is revoked (expired is soft — it self-refreshes)')
-    .action(async (opts: { json?: boolean; local?: boolean; verbose?: boolean; strict?: boolean }) => {
-      await runFleetPing(opts);
+    .action(async (opts: { json?: boolean; local?: boolean; verbose?: boolean; strict?: boolean }, cmd: Command) => {
+      // The root program also defines a global `--verbose` (startup self-heal
+      // detail), and commander binds a shared long flag to the program, not the
+      // leaf — so `fleet ping --verbose` never set opts.verbose and the
+      // per-account breakdown was silently unreachable. Read the effective value
+      // from the merged globals so the flag works at either level.
+      const verbose = opts.verbose ?? Boolean(cmd.optsWithGlobals().verbose);
+      await runFleetPing({ ...opts, verbose });
     });
 
   devicesCmd

--- a/apps/cli/src/lib/auth-health.test.ts
+++ b/apps/cli/src/lib/auth-health.test.ts
@@ -3,12 +3,14 @@ import { describe, it, expect } from 'vitest';
 import {
   authAccountLabel,
   authCacheKey,
+  authCellColor,
   classifyHttpStatus,
   mergeAuthHealthEntries,
   formatCheckedAge,
   probeDetail,
   summarizeHostAuth,
   summarizeVerdicts,
+  verdictColor,
   verdictFromProbe,
   verdictGlyph,
   verdictLabel,
@@ -102,12 +104,50 @@ describe('authCacheKey', () => {
 });
 
 describe('summarizeVerdicts', () => {
-  it('counts live, bad (revoked/expired), and warn (everything else)', () => {
-    expect(summarizeVerdicts(['live', 'live', 'live', 'live'])).toEqual({ live: 4, bad: 0, warn: 0, total: 4 });
-    // only revoked is "bad"; expired is soft (kimi/droid self-refresh on launch) -> warn
-    expect(summarizeVerdicts(['live', 'revoked', 'expired', 'unverified'])).toEqual({ live: 1, bad: 1, warn: 2, total: 4 });
-    expect(summarizeVerdicts(['rate_limited', 'error'])).toEqual({ live: 0, bad: 0, warn: 2, total: 2 });
-    expect(summarizeVerdicts([])).toEqual({ live: 0, bad: 0, warn: 0, total: 0 });
+  it('counts live, present (unverified), bad (revoked), and warn (soft)', () => {
+    expect(summarizeVerdicts(['live', 'live', 'live', 'live'])).toEqual({ live: 4, present: 0, bad: 0, warn: 0, total: 4 });
+    // only revoked is "bad"; expired is soft -> warn; unverified is benign signed-in -> present
+    expect(summarizeVerdicts(['live', 'revoked', 'expired', 'unverified'])).toEqual({ live: 1, present: 1, bad: 1, warn: 1, total: 4 });
+    // unverified (codex/grok signed in, no probe) must NOT land in warn — it's `present`
+    expect(summarizeVerdicts(['unverified', 'unverified'])).toEqual({ live: 0, present: 2, bad: 0, warn: 0, total: 2 });
+    expect(summarizeVerdicts(['rate_limited', 'error'])).toEqual({ live: 0, present: 0, bad: 0, warn: 2, total: 2 });
+    expect(summarizeVerdicts([])).toEqual({ live: 0, present: 0, bad: 0, warn: 0, total: 0 });
+  });
+});
+
+describe('verdictColor', () => {
+  it('reserves red for revoked; expired is soft yellow, never red', () => {
+    // the exact regression: the ping verbose list painted `expired` red (lumped with revoked)
+    expect(verdictColor('revoked')).toBe('red');
+    expect(verdictColor('expired')).toBe('yellow');
+    expect(verdictColor('rate_limited')).toBe('yellow');
+    expect(verdictColor('error')).toBe('yellow');
+  });
+  it('unverified (signed in, no probe) is neutral gray, not an alarm', () => {
+    expect(verdictColor('unverified')).toBe('gray');
+    expect(verdictColor('live')).toBe('green');
+    expect(verdictColor('unconfigured')).toBe('dim');
+  });
+});
+
+describe('authCellColor', () => {
+  const s = (o: Partial<ReturnType<typeof summarizeVerdicts>>) =>
+    ({ live: 0, present: 0, bad: 0, warn: 0, total: 0, ...o });
+  it('red only when a token is genuinely revoked', () => {
+    expect(authCellColor(s({ bad: 1, total: 1 }))).toBe('red');
+    // revoked wins even alongside live accounts
+    expect(authCellColor(s({ live: 2, bad: 1, total: 3 }))).toBe('red');
+  });
+  it('expired-only cell is soft yellow, NOT red (kimi/droid self-refresh)', () => {
+    expect(authCellColor(s({ warn: 1, total: 1 }))).toBe('yellow');
+  });
+  it('all-unverified cell (codex/grok signed in) is neutral gray, NOT yellow', () => {
+    // this is the "cry wolf" fix: a fully-logged-in codex fleet must not read as degraded
+    expect(authCellColor(s({ present: 1, total: 1 }))).toBe('gray');
+  });
+  it('all-live cell is green; empty cell is dim', () => {
+    expect(authCellColor(s({ live: 3, total: 3 }))).toBe('green');
+    expect(authCellColor(s({ total: 0 }))).toBe('dim');
   });
 });
 

--- a/apps/cli/src/lib/auth-health.ts
+++ b/apps/cli/src/lib/auth-health.ts
@@ -119,13 +119,21 @@ export function verdictLabel(verdict: AuthVerdict): string {
 /** Roll a set of verdicts (one host×agent's installs) into counts for a matrix cell. */
 export interface VerdictSummary {
   live: number;
+  /**
+   * unverified — signed in, but this agent has no in-repo live-probe endpoint
+   * (codex/grok). A benign, neutral state: the account is present and usable, we
+   * just can't complete a 2xx to prove it. It must NOT be lumped with the soft
+   * `warn` bucket, or a fully-logged-in codex/grok fleet reads as half-degraded
+   * (the exact "cry wolf" the ping matrix used to produce).
+   */
+  present: number;
   /** revoked — the server rejected the token (401/403). Genuinely needs re-login. */
   bad: number;
   /**
-   * expired / rate_limited / unverified / error — degraded or unknown, but NOT
-   * "re-login now". `expired` is soft for kimi/droid (their CLIs refresh the
-   * token on next launch; we don't refresh on the read path), so it must not be
-   * lumped with revoked or we'd cry wolf on a self-healing token.
+   * expired / rate_limited / error — degraded or unknown, but NOT "re-login now".
+   * `expired` is soft for kimi/droid (their CLIs refresh the token on next launch;
+   * we don't refresh on the read path), so it must not be lumped with revoked or
+   * we'd cry wolf on a self-healing token.
    */
   warn: number;
   total: number;
@@ -133,14 +141,53 @@ export interface VerdictSummary {
 
 export function summarizeVerdicts(verdicts: AuthVerdict[]): VerdictSummary {
   let live = 0;
+  let present = 0;
   let bad = 0;
   let warn = 0;
   for (const v of verdicts) {
     if (v === 'live') live++;
+    else if (v === 'unverified') present++;
     else if (v === 'revoked') bad++;
     else warn++;
   }
-  return { live, bad, warn, total: verdicts.length };
+  return { live, present, bad, warn, total: verdicts.length };
+}
+
+/** A resolved display color; the caller maps it to chalk. Pure, so it's unit-tested. */
+export type AuthCellColor = 'green' | 'yellow' | 'red' | 'gray' | 'dim';
+
+/**
+ * Color for a single verdict in the per-account (`--verbose`) breakdown. This is
+ * the one source of truth shared with {@link authCellColor} so the matrix and the
+ * account list can never drift — they did: the matrix painted `expired` yellow
+ * while the verbose list painted it *red* (lumped with revoked), directly against
+ * the {@link VerdictSummary} contract. Red is reserved for `revoked` (the only
+ * "re-login now"); `unverified` is a neutral signed-in state (gray);
+ * `expired`/`rate_limited`/`error` are soft (yellow).
+ */
+export function verdictColor(verdict: AuthVerdict): AuthCellColor {
+  switch (verdict) {
+    case 'live': return 'green';
+    case 'revoked': return 'red';
+    case 'unverified': return 'gray';
+    case 'unconfigured': return 'dim';
+    default: return 'yellow'; // expired / rate_limited / error — soft, self-healing/indeterminate
+  }
+}
+
+/**
+ * Color for a matrix cell that rolls up several accounts. Red only when a token
+ * was genuinely rejected (`revoked`); yellow for soft/expired; green when at least
+ * one account is live-verified and none are soft/revoked; gray when accounts are
+ * present but unverifiable (codex/grok) — never the alarming yellow the old
+ * renderer used, which made a fully-logged-in fleet read as half-broken.
+ */
+export function authCellColor(summary: VerdictSummary): AuthCellColor {
+  if (summary.total === 0) return 'dim';
+  if (summary.bad > 0) return 'red';
+  if (summary.warn > 0) return 'yellow';
+  if (summary.live > 0) return 'green';
+  return 'gray'; // all present/unverifiable — signed in, neutral
 }
 
 /** Verdicts that mean "this token was rejected by the server — re-login required". */


### PR DESCRIPTION
## Problem

`agents fleet ping` reported a **fully-logged-in fleet as half-broken**, which triggered a whole session of false-alarm auth firefighting. Two renderer bugs, both contradicting `auth-health.ts`'s own stated verdict model:

1. **`codex`/`grok` rolled up as an alarming yellow `0/N`.** They have no in-repo live-probe endpoint (usage.ts reads codex from local session logs; grok has none), so they always return the benign `unverified` verdict — "signed in, can't 2xx-verify." The matrix lumped that into the `warn` bucket and painted it yellow with a `0/N` numerator, so a healthy signed-in codex/grok fleet read as degraded.
2. **`--verbose` painted `expired` RED** — lumped with a genuine `revoked` — even though `expired` is soft and self-refreshes on the CLI's next launch (kimi/droid). This directly violated the `VerdictSummary` doc ("expired… must not be lumped with revoked or we'd cry wolf").
3. **`fleet ping --verbose` silently emitted no per-account breakdown at all** — the root program's global `--verbose` (startup self-heal detail) shadowed the subcommand flag, so `opts.verbose` was never set and the breakdown was unreachable.

Verified against the live fleet: real headless prompts (`agents run <agent>`) confirmed `claude`/`codex`/`grok`/`kimi`/`droid` are **all live** on zion + workers s1/m1 — the "outages" were entirely a display artifact.

## Fix

One truthful color model shared by the matrix and the verbose list (`verdictColor` / `authCellColor` in `auth-health.ts`), so they can never drift again:

- **red** — `revoked` only (the sole "re-login now").
- **gray** — `unverified` (signed in, unverifiable: codex/grok) — neutral, not an alarm.
- **yellow** — `expired`/`rate_limited`/`error` — soft, self-refreshes.
- **green** — `live`.
- Cell numerator counts signed-in accounts (`live + present`), so a logged-in codex fleet reads `1/1`, not `0/1`.

Plus: the ping action now reads the effective `--verbose` from merged globals, so the per-account breakdown actually renders.

## Before → After (zion, real `fleet ping`)

```
BEFORE   codex 0/1 (yellow)   grok 0/2 (yellow)   kimi 0/2   droid 0/1
         verbose: droid/kimi "expired" printed RED
         fleet ping --verbose printed NO Accounts breakdown

AFTER    claude 4/4 (green)  codex 1/1 (gray)  opencode 1/1 (gray)
         antigravity 1/1 (gray)  grok 2/2 (gray)  kimi 0/2 (yellow)  droid 0/1 (yellow)
         legend: green live · gray signed-in (unverifiable: codex/grok) · yellow expired (self-refreshes) · red revoked
         verbose: expired now YELLOW; per-account breakdown renders
```

## Tests

`auth-health.test.ts`: new `verdictColor` / `authCellColor` cases pin the exact regression (expired must be yellow not red; all-unverified cell gray not yellow; red only for revoked). `bun test` green for `auth-health` + `ssh`; `tsc --noEmit` clean. Verified end-to-end by running the patched `fleet ping --local --verbose` (output above).
