### PR TITLE
fix(codex): make codex-home SUN_LEN tests robust to a long tmp base

### DIFF
--- a/apps/cli/src/lib/__tests__/codex-home.test.ts
+++ b/apps/cli/src/lib/__tests__/codex-home.test.ts
@@ -47,6 +47,14 @@ describe('resolveCodexHome', () => {
   let agentsUserDir: string;
   let versionedHome: string;
 
+  // A short tmp base so shortCodexHome() paths stay under SUN_LEN in-test. Unlike
+  // os.tmpdir() — long on macOS/Windows CI (/var/folders/… , D:\a\_temp\…), long
+  // enough that even the migrated "short" home overflows — /tmp keeps the derived
+  // socket path under the 104-byte cap, matching a real short ~/.agents. POSIX-only:
+  // SUN_LEN is a darwin constraint and Windows has no comparably short base, so the
+  // callers skip win32.
+  const shortTmpRoot = () => fs.mkdtempSync(path.join('/tmp', 'cx-'));
+
   beforeEach(() => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
     agentsUserDir = path.join(root, '.agents');
@@ -72,31 +80,47 @@ describe('resolveCodexHome', () => {
     expect(fs.lstatSync(versionedHome).isSymbolicLink()).toBe(false);
   });
 
-  it('leaves a short-enough home untouched even on darwin', () => {
-    const shortHome = path.join(root, '.codex');
-    fs.mkdirSync(shortHome, { recursive: true });
-    const out = resolveCodexHome(shortHome, agentsUserDir, '0.143.0', 'darwin');
-    expect(out).toBe(shortHome);
+  it.skipIf(process.platform === 'win32')('leaves a short-enough home untouched even on darwin', () => {
+    const shortRoot = shortTmpRoot();
+    try {
+      const shortHome = path.join(shortRoot, '.codex');
+      fs.mkdirSync(shortHome, { recursive: true });
+      expect(codexHomeOverflowsSunLen(shortHome)).toBe(false); // the base really is short
+      const out = resolveCodexHome(shortHome, path.join(shortRoot, '.agents'), '0.143.0', 'darwin');
+      expect(out).toBe(shortHome);
+    } finally {
+      fs.rmSync(shortRoot, { recursive: true, force: true });
+    }
   });
 
-  // Skipped on Windows: this asserts the migrated short home fits under SUN_LEN,
-  // which assumes a short tmp base — true on macOS/Linux CI, but Windows runners
-  // use a long `D:\a\_temp\...` prefix that itself overflows. SUN_LEN is a
-  // macOS-only Unix-socket constraint and resolveCodexHome no-ops off darwin, so
-  // there is nothing Windows-specific to cover here.
+  // Skipped on Windows: SUN_LEN is a macOS-only Unix-socket constraint and
+  // resolveCodexHome no-ops off darwin, so there is nothing Windows-specific to
+  // cover. Uses a short tmp base (shortTmpRoot) because os.tmpdir() on macOS/Windows
+  // CI is itself long enough that the migrated "short" home would still overflow —
+  // a test-env artifact, not a resolver bug.
   it.skipIf(process.platform === 'win32')('migrates an overflowing home to a short real dir and symlinks the old path', () => {
-    const out = resolveCodexHome(versionedHome, agentsUserDir, '0.143.0', 'darwin');
-    const expectedShort = shortCodexHome(agentsUserDir, '0.143.0');
+    const shortRoot = shortTmpRoot();
+    try {
+      const userDir = path.join(shortRoot, '.agents');
+      const vHome = path.join(userDir, '.history/versions/codex/0.143.0', 'p'.repeat(80), 'home/.codex');
+      fs.mkdirSync(vHome, { recursive: true });
+      fs.writeFileSync(path.join(vHome, 'auth.json'), '{"token":"real"}');
 
-    expect(out).toBe(expectedShort);
-    expect(codexHomeOverflowsSunLen(out)).toBe(false);
-    // The real home moved; its socket dir will now bind under SUN_LEN.
-    expect(fs.lstatSync(expectedShort).isDirectory()).toBe(true);
-    expect(fs.existsSync(path.join(expectedShort, 'auth.json'))).toBe(true);
-    expect(fs.readFileSync(path.join(expectedShort, 'auth.json'), 'utf8')).toContain('real');
-    // The versioned path is now a symlink to the short real home.
-    expect(fs.lstatSync(versionedHome).isSymbolicLink()).toBe(true);
-    expect(fs.realpathSync(versionedHome)).toBe(fs.realpathSync(expectedShort));
+      const out = resolveCodexHome(vHome, userDir, '0.143.0', 'darwin');
+      const expectedShort = shortCodexHome(userDir, '0.143.0');
+
+      expect(out).toBe(expectedShort);
+      expect(codexHomeOverflowsSunLen(out)).toBe(false);
+      // The real home moved; its socket dir will now bind under SUN_LEN.
+      expect(fs.lstatSync(expectedShort).isDirectory()).toBe(true);
+      expect(fs.existsSync(path.join(expectedShort, 'auth.json'))).toBe(true);
+      expect(fs.readFileSync(path.join(expectedShort, 'auth.json'), 'utf8')).toContain('real');
+      // The versioned path is now a symlink to the short real home.
+      expect(fs.lstatSync(vHome).isSymbolicLink()).toBe(true);
+      expect(fs.realpathSync(vHome)).toBe(fs.realpathSync(expectedShort));
+    } finally {
+      fs.rmSync(shortRoot, { recursive: true, force: true });
+    }
   });
 
   it('is idempotent: a second call returns the short home without error', () => {


### PR DESCRIPTION
## Problem

Cutting `1.20.73` surfaced a latent **macOS** failure in the release CI matrix (`ci.yml` runs the full cross-platform matrix only on `release/**` branches, so it never shows on normal PRs): `src/lib/__tests__/codex-home.test.ts` failed 2 assertions on macOS (6549 other tests passed), while the ubuntu `test-shard` was green.

The two darwin `SUN_LEN` tests build paths under `os.tmpdir()`. On macOS CI that's `/var/folders/…/T` (~52 chars), on Windows `D:\a\_temp\…` — both long enough that even the migrated *short* codex home overflows the 104-byte Unix-socket cap (`SUN_LEN`). They passed only on the ubuntu `test-shard`, where `os.tmpdir()` is a short `/tmp`. `resolveCodexHome` is correct; the test environment is the problem.

## Fix

Root the two darwin/`SUN_LEN` tests under a short `/tmp` base (matching a real short `~/.agents`) so the assertions hold, and skip them on win32 — no comparably short base exists there and `SUN_LEN` is a darwin-only no-op (same rationale already applied to the migrate test). `resolveCodexHome` itself is unchanged.

## Verification (zion, macOS — long `os.tmpdir()` reproduces the CI failure)

Before:
```
❯ src/lib/__tests__/codex-home.test.ts (10 tests | 2 failed)
  × leaves a short-enough home untouched even on darwin
  × migrates an overflowing home to a short real dir and symlinks the old path
 Tests  2 failed | 8 passed (10)
```
After:
```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

`tsc --noEmit` clean. Unblocks the `1.20.73` release (macOS build matrix).
