### PR TITLE
fix(release): wait on the resharded test checks, not the removed `test` job

### DIFF
--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -562,9 +562,13 @@ fi
 # exit 0 on a partial set. This loop waits until every expected context is
 # present AND terminal (capped at 60m), then re-asserts each is a pass and dies
 # otherwise. NOTE: these names are the job/matrix labels of ci.yml (the build
-# matrix), tests.yml (test), and secret-scan.yml (gitleaks) -- a rename there
-# must be mirrored here, or the release times out (fail-closed, never publishes).
-EXPECTED_CHECKS=(test gitleaks \
+# matrix), tests.yml (test-shard 1..3 + typecheck + compiled-smoke), and
+# secret-scan.yml (gitleaks) -- a rename/reshard there must be mirrored here, or
+# the release times out (fail-closed, never publishes). tests.yml was resharded
+# from a single `test` job into `test-shard (N)` + `typecheck` + `compiled-smoke`;
+# the stale `test` name here hung every release for the full 60m before failing
+# (found + fixed 2026-07-29 cutting 1.20.73).
+EXPECTED_CHECKS=("test-shard (1)" "test-shard (2)" "test-shard (3)" typecheck compiled-smoke gitleaks \
   "build (ubuntu-latest, 22)"  "build (ubuntu-latest, 24)" \
   "build (macos-latest, 22)"   "build (macos-latest, 24)")
 # The Windows build jobs gate the release by default. Set RELEASE_REQUIRE_WINDOWS=0 to


### PR DESCRIPTION
## Problem

Cutting `1.20.73` hung the release. `apps/cli/scripts/release.sh`'s `EXPECTED_CHECKS` waited for a check literally named **`test`**, but `tests.yml` was resharded into **`test-shard (1)` / `(2)` / `(3)` + `typecheck` + `compiled-smoke`** — there is no `test` job anymore.

Because `ci.yml`'s full cross-platform matrix runs **only on `release/**` branches**, this never surfaces on normal PRs. But every release: `wait_for_ci_green` treats `test` as forever-`missing`, spins to the **60-minute** deadline, then dies `CI not all-green -- PR left OPEN`, publishing nothing.

## Fix

Update `EXPECTED_CHECKS` to the current `tests.yml` job names (`test-shard (1..3)`, `typecheck`, `compiled-smoke`) alongside the unchanged `gitleaks` + build matrix. Comment updated so the next reshard mirrors here. No change to the wait/merge/publish flow.

## Validation

- `bash -n scripts/release.sh` passes.
- **Empirically proven:** the `1.20.73` release was published using exactly this `EXPECTED_CHECKS` set (applied as a local patch during the release) — it correctly waited on the real checks, saw macOS green, and merged + published. This PR just lands that same set on `main`.

Without this, the next release repeats the 60-minute hang.
