### PR TITLE
fix(view): stop isolated installs from hiding the user's own CLI

### DIFF
--- a/apps/cli/.changelog/next/view-isolated-installs.md
+++ b/apps/cli/.changelog/next/view-isolated-installs.md
@@ -1,0 +1,12 @@
+- **`agents view` no longer hides your own CLI behind an isolated install.** The listing
+  was either/or per agent: any managed version at all suppressed the "Not Managed by
+  Agents CLI" block, so a single `agents add <agent>@<v> --isolated` made the user's
+  globally-installed CLI disappear from the one command they'd run to confirm
+  `--isolated` had left it alone. Nothing on disk was ever touched — the isolation
+  boundary holds — but the report read exactly like the damage it was supposed to rule
+  out. Isolated copies now render alongside the global install and are tagged
+  `9.9.4 (isolated)`; a normal (non-isolated) version still takes the launcher over and
+  still suppresses the global row, since that row would just be our own shim. The global
+  row is also resolved from PATH now (`getUnmanagedCliState`) instead of from the version
+  dirs, which could otherwise report an isolated copy — deliberately unreachable from
+  PATH — as `(global)`. Source: `apps/cli/src/commands/view.ts`, `apps/cli/src/lib/agents.ts`.

--- a/apps/cli/src/commands/view.isolated.integration.test.ts
+++ b/apps/cli/src/commands/view.isolated.integration.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// `agents view` used to be either/or per agent: the moment ANY managed version
+// existed, the "Not Managed by Agents CLI" block stopped rendering. An
+// isolated-only install therefore made the user's own globally-installed CLI
+// vanish from the listing — the one command they'd run to confirm `--isolated`
+// left it alone reported it as gone. Nothing on disk was touched (the isolation
+// boundary holds); the report was simply wrong, which reads exactly like damage.
+//
+// Real CLI, real filesystem, no mocking: drive the built entrypoint against a
+// throwaway HOME and read what a user would actually see.
+describe.skipIf(process.platform === 'win32')('agents view — isolated installs vs the global CLI', () => {
+  let home: string;
+  const GLOBAL_VERSION = '0.55.0';
+
+  const versionDir = (v: string) => path.join(home, '.agents', '.history', 'versions', 'codex', v);
+
+  function plantVersion(version: string, { isolated }: { isolated: boolean }) {
+    const binDir = path.join(versionDir(version), 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(path.join(versionDir(version), 'home', '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'codex'), `#!/bin/sh\necho "codex-cli ${version}"\n`);
+    fs.chmodSync(path.join(binDir, 'codex'), 0o755);
+    if (isolated) fs.writeFileSync(path.join(versionDir(version), '.isolated'), `${new Date().toISOString()}\n`);
+  }
+
+  function view(): string {
+    return execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), 'view', 'codex'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${path.join(home, 'npm-global', 'bin')}:${process.env.PATH}`,
+        SHELL: '/bin/bash',
+        AGENTS_NO_NUDGE: '1',
+        FORCE_COLOR: '0',
+      },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString('utf-8');
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'view-isolated-'));
+    // The user's own globally-installed codex, laid out the way npm does it.
+    const pkgBin = path.join(home, 'npm-global', 'lib', 'node_modules', '@openai', 'codex', 'bin');
+    fs.mkdirSync(pkgBin, { recursive: true });
+    fs.mkdirSync(path.join(home, 'npm-global', 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(pkgBin, 'codex.js'), `#!/bin/sh\necho "codex-cli ${GLOBAL_VERSION}"\n`);
+    fs.chmodSync(path.join(pkgBin, 'codex.js'), 0o755);
+    fs.symlinkSync('../lib/node_modules/@openai/codex/bin/codex.js', path.join(home, 'npm-global', 'bin', 'codex'));
+    // `agents view` refuses to run before setup; the gate is just "is ~/.agents/.system a git repo".
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('lists an isolated copy AND the untouched global install, tagging the isolated one', () => {
+    plantVersion('9.9.4', { isolated: true });
+    const out = view();
+
+    // The isolated copy is listed, and labelled so it can't be mistaken for the
+    // install that owns the launcher.
+    expect(out).toContain('9.9.4');
+    expect(out).toContain('(isolated)');
+    // ...and the user's own CLI is still reported, in its own section.
+    expect(out).toContain('Not Managed by Agents CLI');
+    expect(out).toContain(`${GLOBAL_VERSION} (global)`);
+  }, 120_000);
+
+  it('still hides the global row once a NORMAL version takes over the launcher', () => {
+    plantVersion('9.9.4', { isolated: false });
+    const out = view();
+
+    expect(out).toContain('9.9.4');
+    // A non-isolated install DOES own the launcher, so the "global" row would just
+    // be our own shim reported back — keep suppressing it, as before this change.
+    expect(out).not.toContain('Not Managed by Agents CLI');
+    expect(out).not.toContain('(isolated)');
+  }, 120_000);
+
+  it('reports the global install alone when nothing is managed', () => {
+    const out = view();
+
+    expect(out).toContain('Not Managed by Agents CLI');
+    expect(out).toContain(`${GLOBAL_VERSION} (global)`);
+    expect(out).not.toContain('(isolated)');
+  }, 120_000);
+});

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -20,13 +20,14 @@ import {
   ALL_AGENT_IDS,
   accountDisplayLabel,
   getAllCliStates,
+  getUnmanagedCliState,
   getAccountInfo,
   resolveAgentName,
   formatAgentError,
   agentLabel,
   colorAgent,
 } from '../lib/agents.js';
-import type { AccountInfo } from '../lib/agents.js';
+import type { AccountInfo, CliState } from '../lib/agents.js';
 import { loginHint } from '../lib/signin-badge.js';
 import type { AgentId } from '../lib/types.js';
 import { machineId } from '../lib/machine-id.js';
@@ -61,6 +62,7 @@ import {
   reconcileStaleLatestForAgent,
   isGlobalBinaryAgent,
   getLiveVersion,
+  isVersionIsolated,
 } from '../lib/versions.js';
 import {
   getShimsDir,
@@ -327,7 +329,15 @@ async function showInstalledVersions(
     ? `Checking ${agentLabel(filterAgentId)} agents...`
     : 'Checking installed agents...';
   const spinner = ora({ text: spinnerText, isSilent: !process.stdout.isTTY }).start();
-  const cliStates = await getAllCliStates();
+  // Every `cliStates` read in this function feeds the "Not Managed by Agents CLI"
+  // block, so resolve it the way that block means it: the user's own CLI on PATH.
+  // `getCliState` would answer with a version-dir install — including an isolated
+  // copy that is deliberately absent from PATH — and print it as "(global)".
+  const cliStates = Object.fromEntries(
+    await Promise.all(
+      ALL_AGENT_IDS.map(async (agentId) => [agentId, await getUnmanagedCliState(agentId)] as const)
+    )
+  ) as Partial<Record<AgentId, CliState>>;
   spinner.stop();
 
   const agentsToShow = filterAgentId ? [filterAgentId] : ALL_AGENT_IDS;
@@ -361,24 +371,33 @@ async function showInstalledVersions(
   // Read the auth-health cache once (not per version row — see the batching note above).
   const authCache = readAuthHealthCache();
 
+  // A globally-installed CLI is superseded only by a NORMAL managed version — that
+  // is when agents-cli owns the launcher and a "global" row would just be our own
+  // shim reported back. `--isolated` promises the opposite: no default, no bare
+  // shim, no adopted launcher, the user's own `~/.<agent>` untouched. So an
+  // isolated-only install must not make that still-live global CLI disappear from
+  // `agents view` — the two are genuinely separate installs and both get listed.
+  const hasNonIsolatedVersion = (agentId: AgentId): boolean =>
+    listInstalledVersions(agentId).some((v) => !isVersionIsolated(agentId, v));
+
   // Pre-fetch account info for all versions in parallel
   const infoFetches: Promise<{ agentId: AgentId; version: string; home: string; info: AccountInfo }>[] = [];
   const globalInfoFetches: Promise<{ agentId: AgentId; cliVersion: string | null; info: AccountInfo }>[] = [];
   for (const agentId of agentsToShow) {
-    const versions = listInstalledVersions(agentId);
-    if (versions.length > 0) {
-      for (const ver of versions) {
-        const home = getVersionHomePath(agentId, ver);
-        infoFetches.push(
-          getAccountInfo(agentId, home).then((info) => ({
-            agentId,
-            version: ver,
-            home,
-            info,
-          }))
-        );
-      }
-    } else {
+    for (const ver of listInstalledVersions(agentId)) {
+      const home = getVersionHomePath(agentId, ver);
+      infoFetches.push(
+        getAccountInfo(agentId, home).then((info) => ({
+          agentId,
+          version: ver,
+          home,
+          info,
+        }))
+      );
+    }
+    // Mirrors the classification below: fetch the global account whenever the
+    // global install will still be rendered (no versions at all, or isolated-only).
+    if (!hasNonIsolatedVersion(agentId)) {
       globalInfoFetches.push(
         getAccountInfo(agentId).then((info) => ({
           agentId,
@@ -451,9 +470,11 @@ async function showInstalledVersions(
 
     if (versions.length > 0) {
       versionManaged.push(agentId);
-    } else if (cliState?.installed) {
-      globallyInstalled.push(agentId);
-    } else if (hasProfiles) {
+    }
+    if (cliState?.installed) {
+      // Isolated-only installs sit alongside the global CLI rather than replacing it.
+      if (!hasNonIsolatedVersion(agentId)) globallyInstalled.push(agentId);
+    } else if (versions.length === 0 && hasProfiles) {
       profileOnly.push(agentId);
     }
   }
@@ -474,6 +495,16 @@ async function showInstalledVersions(
   const displayVersion = (agentId: AgentId, dirVersion: string): string =>
     liveVersionByAgent.get(agentId) ?? dirVersion;
 
+  // Uncolored row label, shared by the width pass and the render so padding lines
+  // up. An isolated copy is never the global default (installing one deliberately
+  // records no default), so the two tags can't collide.
+  const versionRowLabel = (agentId: AgentId, version: string, globalDefault: string | null): string => {
+    const shown = displayVersion(agentId, version);
+    if (version === globalDefault) return `${shown} (default)`;
+    if (isVersionIsolated(agentId, version)) return `${shown} (isolated)`;
+    return shown;
+  };
+
   // Show version-managed agents
   if (versionManaged.length > 0) {
     // Calculate column widths across all agents for alignment
@@ -486,9 +517,7 @@ async function showInstalledVersions(
       const versions = listInstalledVersions(agentId);
       const globalDefault = getGlobalDefault(agentId);
       for (const v of versions) {
-        const shown = displayVersion(agentId, v);
-        const label = v === globalDefault ? `${shown} (default)` : shown;
-        maxVerLabel = Math.max(maxVerLabel, label.length);
+        maxVerLabel = Math.max(maxVerLabel, versionRowLabel(agentId, v, globalDefault).length);
         const rawInfo = infoMap.get(`${agentId}:${v}`);
         const info = rawInfo ? mergeCanonical(rawInfo) : undefined;
         const accountLabel = accountColumnLabel(info);
@@ -541,10 +570,15 @@ async function showInstalledVersions(
 
       for (const version of sortedVersions) {
         const isDefault = version === globalDefault;
+        const isolated = !isDefault && isVersionIsolated(agentId, version);
         const shown = displayVersion(agentId, version);
-        const base = isDefault ? `${shown} (default)` : shown;
-        const padded = base.padEnd(maxVerLabel);
-        const label = isDefault ? `${shown}${chalk.green(' (default)')}${' '.repeat(maxVerLabel - base.length)}` : padded;
+        const base = versionRowLabel(agentId, version, globalDefault);
+        const tagPad = ' '.repeat(maxVerLabel - base.length);
+        const label = isDefault
+          ? `${shown}${chalk.green(' (default)')}${tagPad}`
+          : isolated
+            ? `${shown}${chalk.gray(' (isolated)')}${tagPad}`
+            : base.padEnd(maxVerLabel);
         const rawInfo = infoMap.get(`${agentId}:${version}`);
         const vInfo = rawInfo ? mergeCanonical(rawInfo) : undefined;
         const usageKey = getUsageLookupKey(vInfo);
@@ -682,7 +716,9 @@ async function showInstalledVersions(
       // Profile rows under a globally-installed harness. Use a simpler
       // alignment here since this section doesn't share column state with
       // the version-managed block.
-      const profilesHere = profilesByAgent.get(agentId) ?? [];
+      // An isolated-only agent now appears in BOTH blocks; its profiles already
+      // rendered under the version-managed one, so don't print them twice.
+      const profilesHere = versionManaged.includes(agentId) ? [] : (profilesByAgent.get(agentId) ?? []);
       if (profilesHere.length > 0) {
         const nameWidth = Math.max(globalMaxVerLabel, ...profilesHere.map((p) => p.name.length));
         const authWidth = Math.max(...profilesHere.map((p) => p.auth.length));

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -329,18 +329,35 @@ async function showInstalledVersions(
     ? `Checking ${agentLabel(filterAgentId)} agents...`
     : 'Checking installed agents...';
   const spinner = ora({ text: spinnerText, isSilent: !process.stdout.isTTY }).start();
+
+  const agentsToShow = filterAgentId ? [filterAgentId] : ALL_AGENT_IDS;
+
+  // A globally-installed CLI is superseded only by a NORMAL managed version — that
+  // is when agents-cli owns the launcher and a "global" row would just be our own
+  // shim reported back. `--isolated` promises the opposite: no default, no bare
+  // shim, no adopted launcher, the user's own `~/.<agent>` untouched. So an
+  // isolated-only install must not make that still-live global CLI disappear from
+  // `agents view` — the two are genuinely separate installs and both get listed.
+  const hasNonIsolatedVersion = (agentId: AgentId): boolean =>
+    listInstalledVersions(agentId).some((v) => !isVersionIsolated(agentId, v));
+
   // Every `cliStates` read in this function feeds the "Not Managed by Agents CLI"
   // block, so resolve it the way that block means it: the user's own CLI on PATH.
   // `getCliState` would answer with a version-dir install — including an isolated
   // copy that is deliberately absent from PATH — and print it as "(global)".
+  //
+  // Resolved only for agents that can actually reach that block. `getCliState`
+  // deliberately avoids subprocesses for a version-managed agent, and PATH
+  // resolution costs a `<cli> --version` spawn on a cold cache — so probing an
+  // agent whose global row is suppressed anyway would be pure added latency.
   const cliStates = Object.fromEntries(
     await Promise.all(
-      ALL_AGENT_IDS.map(async (agentId) => [agentId, await getUnmanagedCliState(agentId)] as const)
+      agentsToShow
+        .filter((agentId) => !hasNonIsolatedVersion(agentId))
+        .map(async (agentId) => [agentId, await getUnmanagedCliState(agentId)] as const)
     )
   ) as Partial<Record<AgentId, CliState>>;
   spinner.stop();
-
-  const agentsToShow = filterAgentId ? [filterAgentId] : ALL_AGENT_IDS;
   const showPaths = !!filterAgentId;
   const profilesByAgent = getProfilesByAgent(filterAgentId);
   const profileSummaries = [...profilesByAgent.values()].flat();
@@ -370,15 +387,6 @@ async function showInstalledVersions(
   const selfHost = machineId();
   // Read the auth-health cache once (not per version row — see the batching note above).
   const authCache = readAuthHealthCache();
-
-  // A globally-installed CLI is superseded only by a NORMAL managed version — that
-  // is when agents-cli owns the launcher and a "global" row would just be our own
-  // shim reported back. `--isolated` promises the opposite: no default, no bare
-  // shim, no adopted launcher, the user's own `~/.<agent>` untouched. So an
-  // isolated-only install must not make that still-live global CLI disappear from
-  // `agents view` — the two are genuinely separate installs and both get listed.
-  const hasNonIsolatedVersion = (agentId: AgentId): boolean =>
-    listInstalledVersions(agentId).some((v) => !isVersionIsolated(agentId, v));
 
   // Pre-fetch account info for all versions in parallel
   const infoFetches: Promise<{ agentId: AgentId; version: string; home: string; info: AccountInfo }>[] = [];

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -892,7 +892,21 @@ export async function getCliState(agentId: AgentId): Promise<CliState> {
     }
   }
 
-  // Non-version-managed: single PATH lookup + cached version read
+  return getUnmanagedCliState(agentId);
+}
+
+/**
+ * Resolve the agent's OWN install — the one agents-cli does not manage — by plain
+ * PATH lookup, ignoring the version dirs entirely.
+ *
+ * Callers that specifically mean "the user's own globally-installed CLI" must use
+ * this rather than `getCliState`, whose managed fast path reports an installed
+ * version (any version dir, in readdir order) and would therefore hand back an
+ * isolated copy — a copy that is deliberately unreachable from PATH — labelled as
+ * the global install.
+ */
+export async function getUnmanagedCliState(agentId: AgentId): Promise<CliState> {
+  const agent = AGENTS[agentId];
   // Special case for grok: it manages its own binaries in ~/.grok/downloads/
   if (agentId === 'grok') {
     const grokBin = resolveGrokBinary();


### PR DESCRIPTION
## Problem

`agents view` is either/or per agent — any managed version at all suppresses the **Not Managed by Agents CLI** block:

```js
// view.ts
if (versions.length > 0) versionManaged.push(agentId);
else if (cliState?.installed) globallyInstalled.push(agentId);
```

`listInstalledVersions` doesn't filter isolated versions, so a single `agents add codex@<v> --isolated` makes the user's globally-installed codex **disappear** from the listing — the one command they'd run to confirm `--isolated` had left it alone.

Nothing on disk is touched; #1412 and #1423 hold, and the launcher symlink, `~/.<agent>`, shims and PATH all stay put. But the report reads exactly like the damage those PRs rule out.

**Before** (one isolated copy + a real global codex 0.55.0):

```
Installed Agent CLIs

  Codex (balanced) (no default)
    9.9.4  (logged out — log in with: codex login)
```

**After:**

```
Installed Agent CLIs

  Codex (balanced) (no default)
    9.9.4 (isolated)  (logged out — log in with: codex login)

Not Managed by Agents CLI

  Codex
    0.55.0 (global)
    Manage: agents add codex@0.55.0 -y
```

`view.ts` previously contained zero references to `isolat` — the mutating paths (`refresh.ts:304`, `heal.ts:388`, `versions.ts:758`, `self-heal/checks/*`) all learned the isolation boundary; the display path never did.

## Change

**1. Classification.** An isolated-only install no longer removes the agent from `globallyInstalled`. Only a *normal* version does — that's when agents-cli owns the launcher and the "global" row would just be our own shim reported back. The account-info prefetch mirrors the same condition so the global row has account data.

**2. Labelling.** Isolated rows render as `9.9.4 (isolated)`, via a `versionRowLabel` helper shared with the column-width pass so padding still lines up. An isolated copy never holds the global default, so `(default)` and `(isolated)` can't collide.

**3. Global-row resolution.** The block now resolves the user's CLI from PATH via a new `getUnmanagedCliState`, extracted verbatim from the tail of `getCliState`.

This third part is a real bug the first two surfaced. `getCliState`'s managed fast path returns a version-dir install — and its fallback walks `readdir` order — so once an isolated-only agent reached this block it printed the isolated copy, deliberately unreachable from PATH, as `(global)`:

```
  Codex
    9.9.4 (global)
      …/versions/codex/9.9.4/node_modules/.bin/codex     # wrong
```

`getCliState` itself is **unchanged** (pure extraction), so no other caller shifts. Every `cliStates` read inside `showInstalledVersions` feeds that one block, so the swap is local to it.

Also guards profile rows against double-render, since an agent can now appear in both blocks.

## Test

`view.isolated.integration.test.ts` drives the real CLI against a throwaway `HOME` with a real npm-layout global install — no mocking — and asserts what a user would actually see:

- isolated copy **and** global install both listed, isolated one tagged
- a **non-isolated** version still suppresses the global row (guards against just always-rendering it)
- global-only still renders, untagged

Also re-ran `self-heal/` (incl. the `isolated-soak` regression), `view.account`, `view.resources`, `resource-view`, `agents`, `sessions.overview` — 95 passed, plus 3 new.

Display-only change; the isolation boundary itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)