### PR TITLE
fix(rotate): treat a blanked claude credential file as signed out

### DIFF
--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -15,6 +15,7 @@ import {
   deprecationNotice,
   formatClaudeOrgLabel,
   getAccountInfo,
+  isClaudeCredentialFileBlank,
   resolveAgentName,
   resolveLastActive,
   supportsAccountInspection,
@@ -750,6 +751,112 @@ describe('getAccountInfo — OpenCode provider credentials', () => {
     const info = await getAccountInfo('opencode', home);
     expect(info.signedIn).toBe(false);
   });
+});
+
+describe('getAccountInfo — claude credential floor (blanked .credentials.json)', () => {
+  // A failed OAuth refresh rewrites .claude/.credentials.json with empty
+  // accessToken/refreshToken and expiresAt 0, keeping only the descriptive
+  // fields — while .claude.json keeps a full oauthAccount. Before the floor,
+  // that home reported signedIn:true with usage bars, and balanced rotation kept
+  // routing runs into it; each spawn died on "OAuth session expired and could
+  // not be refreshed".
+  function writeClaudeHome(
+    home: string,
+    oauth: Record<string, unknown> | null,
+  ): void {
+    fs.writeFileSync(
+      path.join(home, '.claude.json'),
+      JSON.stringify({
+        oauthAccount: {
+          emailAddress: 'dev@example.com',
+          accountUuid: 'acct-1',
+          organizationUuid: 'org-1',
+          organizationType: 'claude_max',
+        },
+      }),
+      'utf-8',
+    );
+    if (!oauth) return;
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.claude', '.credentials.json'),
+      JSON.stringify({ claudeAiOauth: oauth }),
+      'utf-8',
+    );
+  }
+
+  const blanked = {
+    accessToken: '',
+    refreshToken: '',
+    expiresAt: 0,
+    scopes: ['user:inference'],
+    subscriptionType: 'max',
+    rateLimitTier: 'default_claude_max_20x',
+    refreshTokenExpiresAt: 1787558041028,
+  };
+
+  it('treats an emptied token pair as signed out off macOS', () => {
+    const home = makeTempDir();
+    writeClaudeHome(home, blanked);
+    expect(isClaudeCredentialFileBlank(home, 'linux')).toBe(true);
+  });
+
+  it('keeps a home with real tokens usable', () => {
+    const home = makeTempDir();
+    writeClaudeHome(home, { ...blanked, accessToken: 'at-real', refreshToken: 'rt-real', expiresAt: 1 });
+    expect(isClaudeCredentialFileBlank(home, 'linux')).toBe(false);
+  });
+
+  it('keeps a home usable when only the refresh token survives, so a refresh can still recover it', () => {
+    const home = makeTempDir();
+    writeClaudeHome(home, { ...blanked, refreshToken: 'rt-real' });
+    expect(isClaudeCredentialFileBlank(home, 'linux')).toBe(false);
+  });
+
+  it('stays silent when there is no credential file to judge', () => {
+    const home = makeTempDir();
+    writeClaudeHome(home, null);
+    expect(isClaudeCredentialFileBlank(home, 'linux')).toBe(false);
+  });
+
+  it('never judges from the file on macOS, where the login Keychain is canonical', () => {
+    const home = makeTempDir();
+    writeClaudeHome(home, blanked);
+    expect(isClaudeCredentialFileBlank(home, 'darwin')).toBe(false);
+  });
+
+  it('does not mistake a corrupt credential file for a blank one', () => {
+    const home = makeTempDir();
+    writeClaudeHome(home, blanked);
+    fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), '{not json', 'utf-8');
+    expect(isClaudeCredentialFileBlank(home, 'linux')).toBe(false);
+  });
+
+  it('surfaces the account for a home whose tokens are intact', async () => {
+    const home = makeTempDir();
+    writeClaudeHome(home, { ...blanked, accessToken: 'at-real', refreshToken: 'rt-real', expiresAt: 1 });
+
+    const info = await getAccountInfo('claude', home);
+    expect(info.signedIn).toBe(true);
+    expect(info.email).toBe('dev@example.com');
+  });
+
+  // The wiring assertion is only meaningful where the file is the authoritative
+  // store; on macOS getAccountInfo deliberately declines to judge from it.
+  it.skipIf(process.platform === 'darwin')(
+    'reports a blanked home as signed out, so rotation cannot pick it',
+    async () => {
+      const home = makeTempDir();
+      writeClaudeHome(home, blanked);
+
+      const info = await getAccountInfo('claude', home);
+      expect(info.signedIn).toBe(false);
+      // email is what rotation reads as `authValid` — it must not survive.
+      expect(info.email).toBeNull();
+      expect(info.plan).toBeNull();
+      expect(info.usageStatus).toBeNull();
+    },
+  );
 });
 
 describe('agent deprecation warnings', () => {

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1417,6 +1417,51 @@ function isValidOpenCodeCredential(value: unknown): boolean {
   }
 }
 
+/**
+ * Whether a Claude version home's credential file is present but carries no
+ * token — the "must have a real credential" floor (see
+ * `isValidOpenCodeCredential`) applied to claude.
+ *
+ * A FAILED OAuth refresh leaves exactly this state behind: Claude Code rewrites
+ * `.claude/.credentials.json` with `accessToken: ""`, `refreshToken: ""` and
+ * `expiresAt: 0`, keeping only the descriptive fields (`subscriptionType`,
+ * `rateLimitTier`, `refreshTokenExpiresAt`). Everything we derive from
+ * `.claude.json` — email, plan — still looks healthy, so the install reported
+ * `signedIn: true`, `agents view` drew usage bars for it, and balanced rotation
+ * (whose `authValid` is just "email present") kept picking it — every pick dying
+ * at spawn on "OAuth session expired and could not be refreshed".
+ *
+ * Only decidable off macOS: there the login Keychain is the canonical store and
+ * this file is not authoritative, and probing the Keychain would raise an
+ * authorization sheet per installed version on every `agents run` — the reason
+ * rotation stopped calling `isClaudeAuthValid` at all. Off macOS the file IS the
+ * only store, so a token-less file is proof of signed-out. `platform` is a
+ * parameter so both branches are testable on any host.
+ *
+ * Sync, no Keychain, no network — safe on the `agents run` hot path.
+ */
+export function isClaudeCredentialFileBlank(
+  base: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (platform === 'darwin') return false;
+  try {
+    const raw = fs.readFileSync(path.join(base, '.claude', '.credentials.json'), 'utf-8');
+    const oauth = (JSON.parse(raw) as {
+      claudeAiOauth?: { accessToken?: unknown; refreshToken?: unknown };
+    }).claudeAiOauth;
+    if (!oauth) return false;
+    const nonEmpty = (v: unknown): v is string => typeof v === 'string' && v.trim().length > 0;
+    return !nonEmpty(oauth.accessToken) && !nonEmpty(oauth.refreshToken);
+  } catch {
+    // No file (a Keychain-backed home, or never logged in here) or an
+    // unreadable/corrupt one: not positive evidence of a blank credential, so
+    // leave the existing signal alone rather than declaring a working install
+    // signed out.
+    return false;
+  }
+}
+
 export async function getAccountInfo(
   agentId: AgentId,
   home?: string
@@ -1458,6 +1503,15 @@ export async function getAccountInfo(
         const accountId = normalizeIdentityPart(oa?.accountUuid);
         const organizationId = normalizeIdentityPart(oa?.organizationUuid);
         const email = oa?.emailAddress || null;
+
+        // Credential floor: a blanked credential file means this home cannot
+        // authenticate, whatever `.claude.json` still says. Report it signed out
+        // so `agents view` prompts a re-login and rotation routes around it,
+        // instead of handing runs to an install that dies at spawn.
+        if (email && isClaudeCredentialFileBlank(base)) {
+          return { ...empty, lastActive };
+        }
+
         const accountKey = buildIdentityKey(agentId, [
           ['account', accountId],
           ['org', organizationId],


### PR DESCRIPTION
## Problem

A failed OAuth refresh leaves a claude version home in a state that reads as perfectly healthy but cannot authenticate. Claude Code rewrites `.claude/.credentials.json` with the token strings emptied:

```
2.1.218  accessToken= len=0    refreshToken= len=0    expiresAt= 0     refreshTokenExpiresAt= 1787558041028
2.1.219  accessToken= len=0    refreshToken= len=0    expiresAt= 0     refreshTokenExpiresAt= 1787562595672
2.1.220  accessToken= len=108  refreshToken= len=108  expiresAt= 1785373121284
```

`.claude.json` keeps its full `oauthAccount`, so every signal we derive from it stays healthy: `getAccountInfo` reports `signedIn: true` with a plan, `agents view` draws usage bars, and balanced rotation — whose `authValid` is just `info.email != null` (`rotate.ts`) — keeps picking that install. Every pick dies at spawn:

```
[agents] balanced picked … · claude@2.1.218 (2 of 3 healthy)
Failed to authenticate: OAuth session expired and could not be refreshed
```

Observed on a headless Linux host running scheduled work. Two of three installs had been blanked by a refresh failure the previous day; the rotator kept routing runs into them, and the one install that could actually authenticate was the one it excluded (`healthy=2, excluded=1`).

## Fix

Apply claude the same "must have a real credential" floor grok, antigravity and opencode already have (`isValidOpenCodeCredential`): a credential file present with **both** tokens empty means signed out, whatever `.claude.json` says.

Scoped to non-darwin, where the file is the only credential store. On macOS the login Keychain is canonical and the file is not authoritative — and probing the Keychain there raises an authorization sheet per installed version on every `agents run`, which is why rotation stopped calling `isClaudeAuthValid` in the first place. `platform` is a parameter so both branches are testable on any host.

Deliberately narrow:
- missing file (Keychain-backed home, or never logged in here) → unchanged
- corrupt/unreadable file → unchanged; not positive evidence
- blank access token but surviving refresh token → unchanged, so refresh-recovery still works
- only an empty token **pair** flips the verdict

## Verification

`apps/cli`, macOS: `vitest run src/lib/agents.test.ts` 66 passed / 1 skipped (the wiring assertion is darwin-skipped by design), `src/lib/rotate.test.ts` + `src/lib/__tests__/usage.test.ts` 54 passed, `tsc --noEmit` clean.

On the affected Linux host, `vitest run src/lib/agents.test.ts` → **67 passed** (the skipped assertion runs there), and probing the real version homes through the actual rotation path:

```
2.1.218  signedIn=false  email=null  plan=null  usageStatus=null  blankCredFile=true
2.1.219  signedIn=false  email=null  plan=null  usageStatus=null  blankCredFile=true
2.1.220  signedIn=true   email=…     plan=Max   usageStatus=available  blankCredFile=false
picks over 20 balanced rotations: {"2.1.220":20}
healthy: 2.1.220
excluded: 2.1.218,2.1.219
```

Before the change the same host picked `2.1.218`. Rotation now routes around both dead installs, and `agents view` reports them signed out so the re-login is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)