### PR TITLE
fix(state): resolve seeded registries in memory, never write agents.yaml (RUSH-1925)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1925-seed-no-read-write.md
+++ b/apps/cli/.changelog/next/RUSH-1925-seed-no-read-write.md
@@ -1,0 +1,20 @@
+- **Reading state no longer writes `agents.yaml`, which silently deadlocked
+  `agents repo pull` (RUSH-1925).** Registry presets from `SEEDED_REGISTRIES` (today
+  `skill.hermes`) were seeded on the state **read** path, which wrote the registry entry
+  plus a `seededPresets` marker into `agents.yaml`. That file is git-tracked in the user's
+  DotAgents repo, so the write left the working tree dirty and every subsequent
+  `agents repo pull` aborted with `Working tree has uncommitted changes` — naming neither
+  the file nor the cause. Because *every* `agents` invocation reads state, the dirt
+  reappeared the instant it was cleared: `git checkout -- agents.yaml && agents repo pull`
+  re-seeded before the pull ran, so the loop could not be escaped through the CLI at all.
+  On a host with several live agent sessions even a raw `git pull --rebase` lost the race,
+  and one machine sat 27 commits behind for weeks as a result. Seeded presets are now
+  resolved in memory by `getRegistries` — the same way `DEFAULT_REGISTRIES` has always
+  worked — so nothing is written and no later write can flush them into the file.
+  `seededPresets` becomes a removal tombstone: `agents registry remove skill hermes`
+  records the key and the preset stops being offered, which is the behaviour the marker
+  existed to protect. Files seeded by the old code carry both the tombstone and an explicit
+  entry in their own `registries:` block, and the explicit entry still wins, so upgrading
+  changes nothing for them. Source: `apps/cli/src/lib/registry.ts`,
+  `apps/cli/src/lib/state.ts`, `apps/cli/src/lib/registry.seeds.test.ts`,
+  `apps/cli/src/lib/state.test.ts`.

--- a/apps/cli/.changelog/next/RUSH-1925-seed-no-read-write.md
+++ b/apps/cli/.changelog/next/RUSH-1925-seed-no-read-write.md
@@ -15,6 +15,9 @@
   records the key and the preset stops being offered, which is the behaviour the marker
   existed to protect. Files seeded by the old code carry both the tombstone and an explicit
   entry in their own `registries:` block, and the explicit entry still wins, so upgrading
-  changes nothing for them. Source: `apps/cli/src/lib/registry.ts`,
+  changes nothing for them. `setRegistry` also falls back to
+  `SEEDED_REGISTRIES` when merging a partial update, so `registry disable/enable/config`
+  on a never-materialized preset can no longer persist a stripped entry that drops `url`.
+  Source: `apps/cli/src/lib/registry.ts`,
   `apps/cli/src/lib/state.ts`, `apps/cli/src/lib/registry.seeds.test.ts`,
   `apps/cli/src/lib/state.test.ts`.

--- a/apps/cli/src/lib/registry.seeds.test.ts
+++ b/apps/cli/src/lib/registry.seeds.test.ts
@@ -85,6 +85,24 @@ describe('seeded registry presets', () => {
     expect(getRegistries('skill').hermes?.enabled).toBe(true);
   });
 
+  it('keeps the preset url when a partial update disables it', async () => {
+    // A seeded preset has no stored entry to merge with, so setRegistry must fall
+    // back to SEEDED_REGISTRIES. Without that, `registry disable` persisted only
+    // {enabled:false}, dropping url — and since a stored entry outranks the
+    // in-memory seed, the preset stayed broken even after re-enabling.
+    writeMetaFile('registries:\n  mcp: {}\n  skill: {}\n');
+
+    const { getRegistries, setRegistry } = await freshRegistry();
+    const url = getRegistries('skill').hermes?.url;
+    expect(url).toContain('hermes-agent.nousresearch.com');
+
+    setRegistry('skill', 'hermes', { enabled: false });
+    expect(getRegistries('skill').hermes).toEqual({ url, enabled: false });
+
+    setRegistry('skill', 'hermes', { enabled: true });
+    expect(getRegistries('skill').hermes).toEqual({ url, enabled: true });
+  });
+
   it('lets a user override the preset config without being overwritten', async () => {
     writeMetaFile([
       'registries:',

--- a/apps/cli/src/lib/registry.seeds.test.ts
+++ b/apps/cli/src/lib/registry.seeds.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Seeded registry presets (SEEDED_REGISTRIES) are resolved in memory by
+// getRegistries rather than written into agents.yaml — writing them from the
+// read path dirtied that git-tracked file and deadlocked `agents repo pull`
+// (RUSH-1925). registry.ts and state.ts both resolve HOME at import time, so
+// each test points HOME at a throwaway dir and re-imports fresh. Real files,
+// real yaml, no mocks.
+let TMP = '';
+
+async function freshRegistry() {
+  vi.resetModules();
+  return import('./registry.js');
+}
+
+function metaPath() {
+  return path.join(TMP, '.agents', 'agents.yaml');
+}
+
+function writeMetaFile(yamlText: string) {
+  fs.mkdirSync(path.join(TMP, '.agents'), { recursive: true });
+  fs.writeFileSync(metaPath(), yamlText);
+}
+
+describe('seeded registry presets', () => {
+  beforeEach(() => {
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-registry-seeds-'));
+    process.env.HOME = TMP;
+    process.env.AGENTS_SYNC_MACHINE_ID = 'testbox';
+  });
+  afterEach(() => {
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+    try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('offers hermes without writing it to agents.yaml', async () => {
+    writeMetaFile('registries:\n  mcp: {}\n  skill: {}\n');
+    const before = fs.readFileSync(metaPath(), 'utf-8');
+
+    const { getRegistries } = await freshRegistry();
+    expect(getRegistries('skill').hermes?.enabled).toBe(true);
+    expect(fs.readFileSync(metaPath(), 'utf-8')).toBe(before);
+  });
+
+  it('stops offering a preset the user removed, and records the tombstone', async () => {
+    writeMetaFile('registries:\n  mcp: {}\n  skill: {}\n');
+
+    const { getRegistries, removeRegistry } = await freshRegistry();
+    expect(removeRegistry('skill', 'hermes')).toBe(true);
+    expect(fs.readFileSync(metaPath(), 'utf-8')).toContain('skill.hermes');
+    expect(getRegistries('skill').hermes).toBeUndefined();
+
+    // Sticky across a fresh process — the whole point of the tombstone.
+    const { getRegistries: again } = await freshRegistry();
+    expect(again('skill').hermes).toBeUndefined();
+  });
+
+  it('reports false when removing a preset that is already gone', async () => {
+    writeMetaFile('registries:\n  mcp: {}\n  skill: {}\nseededPresets:\n  - skill.hermes\n');
+
+    const { removeRegistry } = await freshRegistry();
+    expect(removeRegistry('skill', 'hermes')).toBe(false);
+  });
+
+  it('keeps a pre-RUSH-1925 seeded entry, tombstone and all', async () => {
+    // What the old read-path seeding left behind: the entry in the user's own
+    // registries block AND the key in seededPresets. The explicit entry wins, so
+    // upgrading must not make the registry vanish.
+    writeMetaFile([
+      'registries:',
+      '  mcp: {}',
+      '  skill:',
+      '    hermes:',
+      '      url: https://hermes-agent.nousresearch.com/docs/api/skills-index.json',
+      '      enabled: true',
+      'seededPresets:',
+      '  - skill.hermes',
+      '',
+    ].join('\n'));
+
+    const { getRegistries } = await freshRegistry();
+    expect(getRegistries('skill').hermes?.enabled).toBe(true);
+  });
+
+  it('lets a user override the preset config without being overwritten', async () => {
+    writeMetaFile([
+      'registries:',
+      '  mcp: {}',
+      '  skill:',
+      '    hermes:',
+      '      url: https://example.internal/skills.json',
+      '      enabled: false',
+      '',
+    ].join('\n'));
+
+    const { getRegistries } = await freshRegistry();
+    const hermes = getRegistries('skill').hermes;
+    expect(hermes?.url).toBe('https://example.internal/skills.json');
+    expect(hermes?.enabled).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/registry.ts
+++ b/apps/cli/src/lib/registry.ts
@@ -98,7 +98,15 @@ export function setRegistry(
     meta.registries[type] = {};
   }
 
-  const existing = meta.registries[type][name] || DEFAULT_REGISTRIES[type]?.[name];
+  // Seeded presets are resolved in memory and never materialized in agents.yaml
+  // (see offeredSeeds), so a partial update — `registry disable`, `enable`, or
+  // `config --api-key` — has nothing stored to merge with. Without the
+  // SEEDED_REGISTRIES fallback it would persist only the changed fields and drop
+  // `url`, and because userRegs wins over the in-memory seed in getRegistries the
+  // preset would stay broken even after re-enabling.
+  const existing = meta.registries[type][name]
+    || DEFAULT_REGISTRIES[type]?.[name]
+    || SEEDED_REGISTRIES[type]?.[name];
   meta.registries[type][name] = { ...existing, ...config } as RegistryConfig;
   writeMeta(meta);
 }

--- a/apps/cli/src/lib/registry.ts
+++ b/apps/cli/src/lib/registry.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
 import type {
+  Meta,
   RegistryType,
   RegistryConfig,
   McpServerEntry,
@@ -18,7 +19,7 @@ import type {
   RegistrySearchResult,
   ResolvedPackage,
 } from './types.js';
-import { DEFAULT_REGISTRIES } from './types.js';
+import { DEFAULT_REGISTRIES, SEEDED_REGISTRIES } from './types.js';
 import { readMeta, writeMeta } from './state.js';
 import { discoverSkillsFromRepo } from './skills.js';
 
@@ -40,6 +41,31 @@ export function validatedPyPISpec(spec: string): string {
   return spec;
 }
 
+/**
+ * Seeded presets offered for `type`, minus any the user has removed.
+ *
+ * These are resolved here rather than written into agents.yaml. Seeding used to
+ * happen on the state READ path and persisted the entry — but agents.yaml is
+ * git-tracked in the user's DotAgents repo, so that write left the working tree
+ * dirty and every `agents repo pull` aborted with "Working tree has uncommitted
+ * changes", naming neither the file nor the cause. Since every `agents`
+ * invocation reads state, the dirt returned the instant it was cleared, and the
+ * loop could not be escaped through the CLI at all (RUSH-1925).
+ *
+ * `seededPresets` is the removal tombstone: a key listed there means the user
+ * removed that preset, so it is not offered again. Users who were seeded under
+ * the old behaviour have the key listed *and* the entry in their own
+ * `registries:` block, which still wins below — so nothing disappears for them.
+ */
+function offeredSeeds(type: RegistryType, meta: Meta): Record<string, RegistryConfig> {
+  const removed = new Set(meta.seededPresets || []);
+  const offered: Record<string, RegistryConfig> = {};
+  for (const [name, config] of Object.entries(SEEDED_REGISTRIES[type] || {})) {
+    if (!removed.has(`${type}.${name}`)) offered[name] = { ...config };
+  }
+  return offered;
+}
+
 /** Get all registries of a given type, merging defaults with user overrides. */
 export function getRegistries(type: RegistryType): Record<string, RegistryConfig> {
   const meta = readMeta();
@@ -47,7 +73,7 @@ export function getRegistries(type: RegistryType): Record<string, RegistryConfig
   const userRegs = meta.registries?.[type] || {};
 
   // Merge defaults with user config (user overrides defaults)
-  return { ...defaultRegs, ...userRegs };
+  return { ...defaultRegs, ...offeredSeeds(type, meta), ...userRegs };
 }
 
 /** Get only the enabled registries of a given type. */
@@ -77,15 +103,21 @@ export function setRegistry(
   writeMeta(meta);
 }
 
-/** Remove a user-configured registry. Returns false if it did not exist. */
+/** Remove a user-configured or seeded registry. Returns false if it did not exist. */
 export function removeRegistry(type: RegistryType, name: string): boolean {
   const meta = readMeta();
-  if (meta.registries?.[type]?.[name]) {
-    delete meta.registries[type][name];
-    writeMeta(meta);
-    return true;
+  const inUserConfig = !!meta.registries?.[type]?.[name];
+  // A seeded preset has no entry in agents.yaml until the user edits it, so
+  // removal is recorded as a tombstone in seededPresets instead of a deletion.
+  const isOfferedSeed = !!offeredSeeds(type, meta)[name];
+  if (!inUserConfig && !isOfferedSeed) return false;
+
+  if (inUserConfig) delete meta.registries![type][name];
+  if (SEEDED_REGISTRIES[type]?.[name]) {
+    meta.seededPresets = [...new Set([...(meta.seededPresets || []), `${type}.${name}`])];
   }
-  return false;
+  writeMeta(meta);
+  return true;
 }
 
 /**

--- a/apps/cli/src/lib/share/config.test.ts
+++ b/apps/cli/src/lib/share/config.test.ts
@@ -107,7 +107,13 @@ describe('share config', () => {
     expect(readAndResolveBundleEnv(SHARE_BUNDLE, { caller: 'test' }).env).toEqual({
       WRITE_TOKEN: 'write-token-1',
     });
-    expect(fs.readFileSync(path.join(HOME, '.agents', 'agents.yaml'), 'utf8')).not.toContain('write-token-1');
+    // The token must never reach agents.yaml — it belongs in the keychain bundle.
+    // Reading state no longer creates that file (RUSH-1925), and a file that does
+    // not exist trivially satisfies the requirement, so treat absent as empty
+    // rather than crashing on ENOENT.
+    const metaPath = path.join(HOME, '.agents', 'agents.yaml');
+    const metaText = fs.existsSync(metaPath) ? fs.readFileSync(metaPath, 'utf8') : '';
+    expect(metaText).not.toContain('write-token-1');
   });
 
   it('prefers an injected SHARE_WRITE_TOKEN over the local bundle', () => {

--- a/apps/cli/src/lib/state.test.ts
+++ b/apps/cli/src/lib/state.test.ts
@@ -21,6 +21,14 @@ function devicePath() {
   return path.join(TMP, '.agents', 'devices', 'testbox', 'agents.yaml');
 }
 
+// agents.yaml is git-tracked in the user's DotAgents repo, so a read that
+// rewrites it dirties the working tree and blocks `agents repo pull`
+// ("Working tree has uncommitted changes"). Reads must not write.
+function writeCentral(yamlText: string) {
+  fs.mkdirSync(path.join(TMP, '.agents'), { recursive: true });
+  fs.writeFileSync(centralPath(), yamlText);
+}
+
 describe('defaultBrowserProfile is device-local', () => {
   beforeEach(() => {
     TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-state-test-'));
@@ -60,5 +68,42 @@ describe('defaultBrowserProfile is device-local', () => {
     expect(readMeta().defaultBrowserProfile).toBeUndefined();
     const device = fs.readFileSync(devicePath(), 'utf-8');
     expect(device).not.toContain('defaultBrowserProfile');
+  });
+});
+
+describe('reading state never writes a tracked agents.yaml (RUSH-1925)', () => {
+  beforeEach(() => {
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-state-seed-'));
+    process.env.HOME = TMP;
+    process.env.AGENTS_SYNC_MACHINE_ID = 'testbox';
+  });
+  afterEach(() => {
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+    try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('leaves the file byte-identical across repeated reads', async () => {
+    // The committed state that deadlocked zion: no hermes entry, so the old
+    // read path inserted one and wrote, dirtying a git-tracked file.
+    writeCentral('registries:\n  mcp: {}\n  skill: {}\nseededPresets: []\n');
+    const before = fs.readFileSync(centralPath(), 'utf-8');
+
+    const { readMeta } = await freshState();
+    readMeta();
+    readMeta();
+    expect(fs.readFileSync(centralPath(), 'utf-8')).toBe(before);
+  });
+
+  it('does not resurrect the seed through an unrelated write', async () => {
+    // A write for another reason must not flush a seeded registry into the file
+    // — that is how the in-memory-only first attempt at this fix still leaked.
+    writeCentral('registries:\n  mcp: {}\n  skill: {}\n');
+
+    const { updateMeta } = await freshState();
+    updateMeta((m) => ({ ...m, defaultAgent: 'claude' }));
+
+    const after = fs.readFileSync(centralPath(), 'utf-8');
+    expect(after).toContain('defaultAgent: claude');
+    expect(after).not.toContain('hermes-agent.nousresearch.com');
   });
 });

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -29,7 +29,6 @@ import * as os from 'os';
 import * as yaml from 'yaml';
 import { ensureLockTarget, atomicWriteFileSync, withFileLock } from './fs-atomic.js';
 import type { Meta, RegistryType } from './types.js';
-import { SEEDED_REGISTRIES } from './types.js';
 import { machineId } from './machine-id.js';
 
 const HOME = process.env.HOME ?? os.homedir();
@@ -752,29 +751,6 @@ function overlayMachineLocal(meta: Meta): Meta {
   return meta;
 }
 
-function applyRegistrySeeds(meta: Meta): boolean {
-  const seeded = new Set(meta.seededPresets || []);
-  let changed = false;
-
-  for (const [type, presets] of Object.entries(SEEDED_REGISTRIES) as Array<[RegistryType, Record<string, any>]>) {
-    for (const [name, config] of Object.entries(presets)) {
-      const key = `${type}.${name}`;
-      if (seeded.has(key)) continue;
-
-      if (!meta.registries) meta.registries = { mcp: {}, skill: {} };
-      if (!meta.registries[type]) meta.registries[type] = {};
-      if (!meta.registries[type][name]) {
-        meta.registries[type][name] = { ...config };
-      }
-      seeded.add(key);
-      changed = true;
-    }
-  }
-
-  if (changed) meta.seededPresets = [...seeded];
-  return changed;
-}
-
 /**
  * One-shot migration: move agents.yaml from system repo to user repo.
  * Idempotent — no-ops if user file already exists or system file absent.
@@ -888,18 +864,11 @@ export function readMeta(): Meta {
     }
 
     overlayMachineLocal(meta);
-    if (applyRegistrySeeds(meta)) {
-      writeMeta(meta);
-      return rememberMeta(meta);
-    }
     return rememberMeta(meta);
   }
 
   const meta = createDefaultMeta();
   overlayMachineLocal(meta);
-  if (applyRegistrySeeds(meta)) {
-    writeMeta(meta);
-  }
   return rememberMeta(meta);
 }
 

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -820,8 +820,17 @@ export interface Meta {
    */
   brands?: Record<string, BrandConfig>;
   /**
-   * Keys like `skill.hermes` — registries seeded from SEEDED_REGISTRIES exactly
-   * once. Tracked so a user `registry remove` won't silently re-seed.
+   * Removal tombstones for SEEDED_REGISTRIES presets, keyed like `skill.hermes`.
+   *
+   * Seeded presets are resolved in memory by `getRegistries` (see
+   * `offeredSeeds`) rather than written into agents.yaml — persisting them from
+   * the read path dirtied this git-tracked file and deadlocked
+   * `agents repo pull` (RUSH-1925). A key listed here means the user ran
+   * `registry remove` on that preset, so it is no longer offered.
+   *
+   * Entries written by the pre-RUSH-1925 seeding also appear here; those files
+   * carry the registry in their own `registries:` block too, which takes
+   * precedence, so the preset stays exactly as configured.
    */
   seededPresets?: string[];
   /**


### PR DESCRIPTION
Fixes RUSH-1925.

## The bug

Registry presets from `SEEDED_REGISTRIES` (today just `skill.hermes`) were seeded on the state **read** path, and the seed wrote the registry entry plus a `seededPresets` marker into `agents.yaml`. That file is git-tracked in the user's DotAgents repo, so the write left the working tree dirty and every subsequent `agents repo pull` aborted:

```
✖ user (~/.agents → origin): Working tree has uncommitted changes.
  Commit or discard them before pulling.
```

The error names neither the file nor the cause, so the natural response is to go hunting through your own uncommitted work.

Because *every* `agents` invocation reads state, the dirt reappeared the instant it was cleared — the obvious fix re-triggers the bug:

```
1. git checkout -- agents.yaml   → clean
2. agents repo pull user         → seeds hermes → dirty
3. same command                  → precondition fails → abort
4. goto 1
```

Inescapable through the CLI. On a host with several live agent sessions even raw git lost the race:

```
$ git -C ~/.agents checkout -- agents.yaml && git -C ~/.agents pull --rebase origin main
From github.com:muqsitnawaz/.agents
 * branch            main       -> FETCH_HEAD
error: cannot rebase: You have unstaged changes.
```

`pull --rebase` spends its first second fetching over the network; another session re-seeded the file before the rebase started. One machine sat **27 commits behind for weeks** on this.

## The fix

Seeded presets are now resolved **in memory** by `getRegistries`, exactly as `DEFAULT_REGISTRIES` always has been. Nothing is written, so no later write can flush them into the file.

`seededPresets` becomes a **removal tombstone**: `agents registry remove skill hermes` records the key and the preset stops being offered — the behaviour the marker existed to protect (`types.ts` doc updated to match).

### An intermediate attempt that did not work, for the reviewer's benefit

The first version kept seeding in `state.ts` but made it in-memory-only, leaving the marker on the returned meta to "ride along on the next write". That **still leaked**: commands write `agents.yaml` routinely, and an unrelated `updateMeta` flushed the seeded entry straight back into the file. Caught by end-to-end A/B, not by unit tests — which is why the seeding moved out of `state.ts` entirely. There is a regression test for exactly this (`does not resurrect the seed through an unrelated write`).

## Migration

Files seeded by the old code carry **both** the tombstone and an explicit entry in their own `registries:` block. The explicit entry wins in the merge, so upgrading changes nothing for existing users — covered by the test `keeps a pre-RUSH-1925 seeded entry, tombstone and all`.

## Verification

**End-to-end A/B against a real git repo** with a committed `agents.yaml` in the state that broke zion (`skill: {}`, `seededPresets: []`):

| | pre-fix build (`origin/main`) | this branch |
| -- | -- | -- |
| `agents registry list` ×2 | `M agents.yaml` | clean |
| restore file, run again | `M agents.yaml` (the loop) | clean |
| ×3 consecutive runs | dirty | clean |
| `hermes` still listed | yes | yes |

Also confirmed against the real `~/.agents`: the built CLI lists `hermes: enabled` with the correct URL and leaves `agents.yaml` alone.

**Test suite** — compared against a pristine `origin/main` baseline worktree, same machine:

```
baseline:  6 failed | 505 passed | 6 skipped   (16 failed tests)
this PR:   6 failed | 506 passed | 6 skipped   (16 failed tests)
failing file set: IDENTICAL — no regression
```

The 6 pre-existing failures are `crabbox/*`, `exec`, and `models` — all unrelated (SSH/box resolution and environment). `tsc --noEmit` clean.

Note `src/lib/share/config.test.ts` needed a one-line fix: it read `agents.yaml` assuming the old seed write had created it. Its intent — "the raw write token must never land in `agents.yaml`" — is preserved; a missing file trivially satisfies it, so absent is now treated as empty instead of throwing `ENOENT`.
