### PR TITLE
fix: resolve the running package root from execPath under the compiled binary

### DIFF
--- a/apps/cli/.changelog/next/bunfs-running-root.md
+++ b/apps/cli/.changelog/next/bunfs-running-root.md
@@ -1,0 +1,17 @@
+- **The compiled binary no longer reports itself as a phantom `/$bunfs` install, and can self-upgrade again.**
+  Since the standalone executable started shipping (1.20.53), the running copy located
+  its own package root as `<__dirname>/..`. Under a Bun standalone binary `__dirname`
+  is the embedded virtual filesystem, so that resolved to `/$bunfs` — a path that
+  exists nowhere. Two symptoms followed on every machine running the compiled binary:
+  the multi-install check reported one install as two (`/$bunfs (running)` alongside
+  the real npm root, with the misleading advice to uninstall a stale copy that did not
+  exist), and `agents upgrade` failed closed with `/$bunfs is not an npm-managed
+  install` because no global prefix can be derived from a virtual path. A new
+  `resolveRunningPackageRoot()` resolves the real on-disk root by walking up from
+  `process.execPath` to the directory whose `package.json` names this package, and
+  both sites use it. The PATH scan also recognizes `<root>/dist/bin/agents` as an
+  entrypoint, so a shim pointing at the compiled binary — typically first on PATH, and
+  the copy that actually runs — resolves to the same root as its sibling npm bin
+  instead of being invisible. Genuine multi-install warnings still fire, now naming a
+  real, actionable path. Source: `apps/cli/src/lib/self-update.ts`,
+  `apps/cli/src/index.ts`, `apps/cli/src/lib/self-update.test.ts`.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -159,6 +159,7 @@ import { applyGlobalHelpConventions } from './lib/help.js';
 import { renderWhatsNew } from './lib/whats-new.js';
 import type { AgentId } from './lib/types.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
+import { getCliLaunch } from './lib/cli-entry.js';
 import { emit, redactArgs } from './lib/events.js';
 
 // Transparent shim delegate: the generated Windows `.cmd` shims invoke
@@ -602,9 +603,11 @@ async function promptUpgrade(latestVersion: string): Promise<void> {
       console.log();
       // Re-exec the verified install's entrypoint and exit. PATH lookup of
       // `agents` could resolve a different copy (dev build, another prefix)
-      // than the one that was just upgraded.
-      const entrypoint = path.resolve(__dirname, '..', 'dist', 'index.js');
-      const result = spawnSync(process.execPath, [entrypoint, ...process.argv.slice(2)], {
+      // than the one that was just upgraded. getCliLaunch resolves the JS-vs-
+      // standalone shape — never hand-roll `[process.execPath, entrypoint]`,
+      // which hands the bun virtual entry to a compiled binary as a bogus arg.
+      const { command, args } = getCliLaunch(process.argv.slice(2));
+      const result = spawnSync(command, args, {
         stdio: 'inherit',
         shell: false,
       });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -410,6 +410,7 @@ import {
   dismissUpdateVersion,
   shouldPromptUpgrade,
   findAgentsCliInstalls,
+  resolveRunningPackageRoot,
   type UpdateCheckCache,
 } from './lib/self-update.js';
 const UPDATE_CHECK_FILE = getUpdateCheckPath();
@@ -424,7 +425,15 @@ const UPDATE_CHECK_FILE = getUpdateCheckPath();
  */
 function maybeWarnMultiInstall(): void {
   const sentinel = path.join(getRuntimeStateDir(), 'multi-install-warned');
-  const runningRoot = path.resolve(__dirname, '..');
+  let runningRoot: string;
+  try {
+    runningRoot = resolveRunningPackageRoot(__dirname);
+  } catch {
+    // Without a real root for the running copy there is nothing to compare
+    // against, and a guess here is exactly what produced the phantom
+    // "/$bunfs" install. This warning is advisory — stay silent instead.
+    return;
+  }
   const byRoot = new Map<string, { version: string; note: string }>();
   byRoot.set(runningRoot, { version: VERSION, note: 'running' });
   for (const install of findAgentsCliInstalls(process.env.PATH || '')) {
@@ -495,7 +504,7 @@ function printResolvedPackage(metadata: NpmPackageMetadata): void {
 }
 
 async function installResolvedPackage(metadata: NpmPackageMetadata): Promise<void> {
-  const packageRoot = path.resolve(__dirname, '..');
+  const packageRoot = resolveRunningPackageRoot(__dirname);
   // Download the published tarball and prove its bytes match the registry
   // integrity BEFORE installing anything. A `name@version` spec would let the
   // package manager fetch and install whatever the registry serves with no

--- a/apps/cli/src/lib/self-update.test.ts
+++ b/apps/cli/src/lib/self-update.test.ts
@@ -16,6 +16,7 @@ import {
   installPackageIntoPrefix,
   readInstalledVersion,
   readUpdateCache,
+  resolveRunningPackageRoot,
   saveUpdateCheck,
   shouldPromptUpgrade,
   verifyInstalledVersion,
@@ -34,6 +35,62 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe('resolveRunningPackageRoot', () => {
+  /** An npm-global-shaped install carrying both shipped entrypoints. */
+  function makeCompiledInstall(label: string) {
+    // realpath the base: on macOS the tmpdir lives under /var -> /private/var,
+    // and resolveRunningPackageRoot resolves without canonicalizing symlinks.
+    const base = fs.realpathSync(makeTempDir(label));
+    const packageRoot = path.join(base, 'lib', 'node_modules', '@phnx-labs', 'agents-cli');
+    fs.mkdirSync(path.join(packageRoot, 'dist', 'bin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({ name: '@phnx-labs/agents-cli', version: '1.20.73' }),
+    );
+    fs.writeFileSync(path.join(packageRoot, 'dist', 'index.js'), '// entrypoint\n');
+    const execPath = path.join(packageRoot, 'dist', 'bin', 'agents');
+    fs.writeFileSync(execPath, 'MZ-not-really\n', { mode: 0o755 });
+    return { packageRoot: fs.realpathSync(packageRoot), execPath };
+  }
+
+  it('returns the parent of __dirname for an ordinary JS install', () => {
+    // dist/index.js runs with __dirname = <packageRoot>/dist.
+    const { packageRoot } = makeCompiledInstall('js-install');
+    expect(resolveRunningPackageRoot(path.join(packageRoot, 'dist'), '/usr/local/bin/node')).toBe(
+      packageRoot,
+    );
+  });
+
+  it('maps the Bun virtual __dirname to the real root via process.execPath', () => {
+    // The reported bug: under the compiled standalone binary Bun sets
+    // __dirname to /$bunfs/root, so <__dirname>/.. was "/$bunfs" — a path that
+    // exists nowhere. It was then reported as a phantom second install and
+    // rejected by deriveGlobalPrefix, so every self-upgrade failed.
+    const { packageRoot, execPath } = makeCompiledInstall('bunfs');
+
+    const resolved = resolveRunningPackageRoot('/$bunfs/root', execPath);
+
+    expect(resolved).toBe(packageRoot);
+    // The whole point: the result is a real, installable npm prefix.
+    expect(fs.existsSync(resolved)).toBe(true);
+    expect(() => deriveGlobalPrefix(resolved)).not.toThrow();
+  });
+
+  it('throws when execPath is itself virtual rather than guessing a prefix', () => {
+    expect(() => resolveRunningPackageRoot('/$bunfs/root', '/$bunfs/root/agents')).toThrow(
+      /Cannot locate the running agents-cli install/,
+    );
+  });
+
+  it('throws when no agents-cli package.json sits above execPath', () => {
+    const stray = path.join(makeTempDir('stray'), 'agents');
+    fs.writeFileSync(stray, 'binary\n', { mode: 0o755 });
+    expect(() => resolveRunningPackageRoot('/$bunfs/root', stray)).toThrow(
+      /no @phnx-labs\/agents-cli package.json above/,
+    );
+  });
 });
 
 describe('deriveGlobalPrefix', () => {
@@ -357,6 +414,33 @@ describe.skipIf(process.platform === 'win32')('findAgentsCliInstalls', () => {
     expect(installs).toHaveLength(1);
     expect(installs[0].packageRoot).toBe(real.packageRoot);
     expect(installs[0].version).toBe('0.0.0-dev.abc123');
+  });
+
+  it('resolves a shim pointing at the compiled binary to the same root as the JS entry', () => {
+    // The reported false positive: ~/.local/bin/agents -> dist/bin/agents is
+    // first on PATH and is the copy that runs, but the scan only recognized
+    // dist/index.js. The running copy was invisible here while its sibling
+    // npm bin was reported — one install looked like two.
+    const base = makeTempDir('compiled');
+    const real = makeInstall(base, 'npm-prefix', '1.20.73');
+    const compiled = path.join(real.packageRoot, 'dist', 'bin', 'agents');
+    fs.mkdirSync(path.dirname(compiled), { recursive: true });
+    fs.writeFileSync(compiled, 'compiled standalone\n', { mode: 0o755 });
+    const localBin = path.join(base, 'local-bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.symlinkSync(compiled, path.join(localBin, 'agents'));
+
+    // A compiled shim on its own must resolve — before the fix this was [],
+    // i.e. the copy that actually runs was invisible to the scan entirely.
+    const compiledOnly = findAgentsCliInstalls(localBin);
+    expect(compiledOnly).toHaveLength(1);
+    expect(compiledOnly[0].packageRoot).toBe(real.packageRoot);
+    expect(compiledOnly[0].version).toBe('1.20.73');
+
+    // And alongside the sibling npm bin it dedups to one install, not two.
+    const both = findAgentsCliInstalls([localBin, real.binDir].join(path.delimiter));
+    expect(both).toHaveLength(1);
+    expect(both[0].binPath).toBe(path.join(localBin, 'agents'));
   });
 
   it('skips unrelated binaries, foreign packages, and missing entries', () => {

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -135,6 +135,75 @@ export function shouldPromptUpgrade(cache: UpdateCheckCache | null, currentVersi
 }
 
 /**
+ * Whether `p` is Bun's embedded virtual filesystem — where a standalone
+ * executable exposes its bundled sources. Nothing there exists on disk: it
+ * cannot be stat'd, installed into, or compared against a real install path.
+ *
+ * Matches the root itself (`/$bunfs`) as well as paths under it, because
+ * `<__dirname>/..` from the embedded entry produces exactly that bare root.
+ * daemon.ts carries a narrower under-the-root-only guard for deciding what may
+ * be supervised; the two are deliberately not shared.
+ */
+function isBunVirtualPath(p: string): boolean {
+  return /(^|[/\\])\$bunfs([/\\]|$)/.test(p);
+}
+
+/** Whether `dir` is the root of an installed copy of this package. */
+function isPackageRoot(dir: string): boolean {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'));
+    return pkg.name === NPM_PACKAGE_NAME;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The on-disk package root of the copy that is currently running.
+ *
+ * For a plain JS install this is just `<__dirname>/..`. Under the compiled
+ * standalone binary (shipped since 1.20.53) it is not: Bun sets `__dirname` to
+ * its embedded virtual FS, so `<__dirname>/..` yields `/$bunfs` — a path that
+ * exists nowhere. That phantom value was reported as a second install by the
+ * multi-install check, and rejected by deriveGlobalPrefix as "not an
+ * npm-managed install", so every self-upgrade from a compiled copy failed.
+ *
+ * The physical executable is `process.execPath`, which ships inside the
+ * package (`<packageRoot>/dist/bin/agents`). Walk up from it to the directory
+ * whose package.json actually names this package rather than assuming a fixed
+ * depth, so a change to the dist layout surfaces as a clear throw here instead
+ * of a wrong prefix that npm would happily install into.
+ */
+export function resolveRunningPackageRoot(
+  dirname: string,
+  execPath: string = process.execPath,
+): string {
+  const fromDirname = path.resolve(dirname, '..');
+  if (!isBunVirtualPath(fromDirname)) return fromDirname;
+
+  if (!execPath || isBunVirtualPath(execPath)) {
+    throw new Error(
+      `Cannot locate the running agents-cli install: __dirname is the Bun virtual path ${fromDirname} ` +
+        `and process.execPath (${execPath || '(empty)'}) is not a real file. ` +
+        `Reinstall with: npm install -g ${NPM_PACKAGE_NAME}`,
+    );
+  }
+
+  let dir = path.dirname(path.resolve(execPath));
+  for (;;) {
+    if (isPackageRoot(dir)) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(
+        `Cannot locate the running agents-cli install: no ${NPM_PACKAGE_NAME} package.json above ` +
+          `${execPath}. Reinstall with: npm install -g ${NPM_PACKAGE_NAME}`,
+      );
+    }
+    dir = parent;
+  }
+}
+
+/**
  * Derive the npm global prefix that owns the install at `packageRoot`.
  *
  * npm's global layout for a scoped package:
@@ -285,6 +354,27 @@ export function refreshAliasShims(packageRoot: string): void {
   });
 }
 
+/**
+ * The package root a resolved `agents` entrypoint belongs to, or null when the
+ * path is not an agents-cli entry at all. Two shipped shapes:
+ *   <packageRoot>/dist/index.js    — the JS entry npm links as `agents`
+ *   <packageRoot>/dist/bin/agents  — the compiled standalone executable
+ */
+function packageRootForEntry(real: string): string | null {
+  const distDir = path.dirname(real);
+  if (path.basename(real) === 'index.js' && path.basename(distDir) === 'dist') {
+    return path.dirname(distDir);
+  }
+  if (
+    path.basename(real) === 'agents' &&
+    path.basename(distDir) === 'bin' &&
+    path.basename(path.dirname(distDir)) === 'dist'
+  ) {
+    return path.dirname(path.dirname(distDir));
+  }
+  return null;
+}
+
 export interface AgentsCliInstall {
   /** The PATH entry (`<dir>/agents`) that resolves to this install. */
   binPath: string;
@@ -301,8 +391,12 @@ export interface AgentsCliInstall {
  *
  * npm bin entries are symlinks that resolve to `<packageRoot>/dist/index.js`
  * (the dev install's `~/.local/bin/agents` chains through the dev prefix to
- * the same shape). Anything that doesn't resolve to a dist/index.js inside a
- * package named @phnx-labs/agents-cli is some other tool and is skipped.
+ * the same shape). A shim pointed at the compiled standalone binary resolves
+ * to `<packageRoot>/dist/bin/agents` instead; that shape counts too, otherwise
+ * the copy that actually runs — the compiled one is typically first on PATH —
+ * is invisible to this scan and its root looks like a separate install.
+ * Anything that resolves to neither shape inside a package named
+ * @phnx-labs/agents-cli is some other tool and is skipped.
  * POSIX-only: Windows npm bins are .cmd wrappers, not symlinks.
  */
 export function findAgentsCliInstalls(pathEnv: string): AgentsCliInstall[] {
@@ -317,10 +411,8 @@ export function findAgentsCliInstalls(pathEnv: string): AgentsCliInstall[] {
     } catch {
       continue; // missing or dangling symlink
     }
-    if (path.basename(real) !== 'index.js' || path.basename(path.dirname(real)) !== 'dist') {
-      continue;
-    }
-    const packageRoot = path.dirname(path.dirname(real));
+    const packageRoot = packageRootForEntry(real);
+    if (!packageRoot) continue;
     if (seenRoots.has(packageRoot)) continue;
     let pkg: { name?: unknown; version?: unknown };
     try {


### PR DESCRIPTION
## The bug

On any machine where `agents` resolves to the compiled standalone binary (shipped since 1.20.53), every invocation printed a false warning and every self-upgrade failed:

```
Multiple agents-cli installs detected:
  /$bunfs  1.20.72  (running)
  /Users/…/lib/node_modules/@phnx-labs/agents-cli  1.20.72  (agents on PATH: …/bin/agents)
Upgrades apply to the running copy. Remove a stale copy with: npm uninstall -g --prefix <prefix> @phnx-labs/agents-cli

✖ Upgrade failed: /$bunfs is not an npm-managed install; reinstall with: npm install -g @phnx-labs/agents-cli
```

There was only ever **one** install. Both symptoms trace to a single bad value.

## Root cause

Two sites computed the running copy's package root the same way:

- `index.ts` `maybeWarnMultiInstall()` — `const runningRoot = path.resolve(__dirname, '..')`
- `index.ts` `installResolvedPackage()` — `const packageRoot = path.resolve(__dirname, '..')`

Under a Bun standalone executable `__dirname` is the embedded virtual filesystem (`/$bunfs/root`), so both produced `/$bunfs` — a path that exists nowhere on disk.

- The multi-install map keyed the running copy under `/$bunfs`, which never matches the real root found on PATH, so one install was always reported as two — with the misleading advice to uninstall a stale copy that does not exist.
- `deriveGlobalPrefix('/$bunfs')` correctly refuses to guess a prefix, so the upgrade failed closed.

A second, compounding factor: `findAgentsCliInstalls()` only recognized `<root>/dist/index.js`. The shim that actually runs (`~/.local/bin/agents -> <root>/dist/bin/agents`, typically first on PATH) resolved to neither shape and was skipped entirely, so the running copy was invisible to the scan while its sibling npm bin was reported.

## The fix

`resolveRunningPackageRoot()` in `self-update.ts` returns the real on-disk root: `<__dirname>/..` for a plain JS install, and for the virtual case it walks up from `process.execPath` (the physical executable, shipped at `<root>/dist/bin/agents`) to the directory whose `package.json` names this package. It walks rather than assuming a fixed depth, so a dist layout change surfaces as a clear throw instead of a wrong prefix npm would happily install into. Both call sites use it.

`maybeWarnMultiInstall()` stays silent if the root can't be resolved — it is advisory, and guessing there is what produced the phantom entry. `installResolvedPackage()` lets the throw propagate (fail closed, consistent with the rest of the module).

The PATH scan now also accepts `<root>/dist/bin/agents`, so a compiled shim resolves to the same root as its sibling npm bin and dedups against it.

## Verification

End-to-end against an npm-layout fixture, running the **actual compiled binary** built from this branch, compared side by side with the shipped 1.20.73 binary on the identical fixture.

False warning — gone:

```
=== FIXED binary ===            === SHIPPED 1.20.73 (control) ===
Devices (14)                    Multiple agents-cli installs detected:
                                  /$bunfs  1.20.73  (running)
                                  …/e2e/lib/node_modules/@phnx-labs/agents-cli  1.20.73
```

Upgrade — the exact reported failure, then fixed:

```
=== CONTROL: shipped 1.20.73 ===
✖ Upgrade failed: /$bunfs is not an npm-managed install

=== FIXED, same fixture ===
✔ Downgraded to 1.20.72
fixture version after: 1.20.72      <- installed into the correct prefix
real install untouched: 1.20.73
```

Non-regression — two genuinely distinct roots on PATH still warn, now naming a real, actionable path instead of `/$bunfs`:

```
Multiple agents-cli installs detected:
  …/e2e/lib/node_modules/@phnx-labs/agents-cli  1.20.73  (running)
  /Users/…/.nvm/…/@phnx-labs/agents-cli  1.20.73  (agents on PATH: …/bin/agents)
```

Unit tests: 4 new for `resolveRunningPackageRoot` (JS install, bunfs mapping, virtual execPath throws, no package.json above throws) and 1 for the compiled-shim scan. The scan test was confirmed to fail against the pre-fix logic (`expected [] to have length 1`), not just pass after it. `self-update.test.ts` is 32/32; `tsc --noEmit` clean.

### Blast radius

`self-update.ts` is imported by exactly one file — `src/index.ts` — and no test imports the CLI root entry (no test file lives directly in `src/`; every `./index.js` / `../index.js` in a test resolves to a `secrets`/`wallet`/`terminal` barrel). So this diff is reachable from `self-update.test.ts` only.

The local full-suite run shows 18 pre-existing failures in 6 unrelated files. Spot-checked `src/lib/crabbox/setup-copy.test.ts` on a pristine `origin/main` worktree: same 4 failures, same `withFakeTransport` signature, unrelated to this change (it fails loading a secrets bundle from the local keychain).

## Not changed

`pty-client.ts` and `version.ts` also derive paths from `__dirname`, but both guard with an existence check / `??` chain and degrade to a working fallback rather than break. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
