### PR TITLE
feat(export): agents export — take an isolated install's config with you

### DIFF
--- a/apps/cli/.changelog/next/isolated-export.md
+++ b/apps/cli/.changelog/next/isolated-export.md
@@ -1,0 +1,12 @@
+- **`agents export <agent>[@<version>]` — take an isolated install's config with you.**
+  `--isolated` was a one-way door: it builds a self-contained home under the version
+  dir and nothing ever brings that work back, so a user who configured a sandboxed copy
+  for a week had to copy files by hand to promote it — or to leave. Export copies the
+  isolated config dir out to the real `~/.<agent>`, stripping symlinks that point back
+  into `~/.agents` so the result keeps working after agents-cli is gone. An existing
+  real config is moved to `backups/<agent>/<ts>` rather than overwritten, a `~/.<agent>`
+  that agents-cli already adopted is refused (writing there would mutate that version's
+  home instead of the user's config), and `--dry-run` prints the exact plan. Only
+  isolated versions are exportable — a normal install's config dir already *is*
+  `~/.<agent>` via the adoption symlink. Source: `apps/cli/src/lib/export.ts`,
+  `apps/cli/src/commands/export.ts`, `apps/cli/src/lib/config-transfer.ts`.

--- a/apps/cli/.changelog/next/isolated-export.md
+++ b/apps/cli/.changelog/next/isolated-export.md
@@ -1,12 +1,19 @@
 - **`agents export <agent>[@<version>]` — take an isolated install's config with you.**
   `--isolated` was a one-way door: it builds a self-contained home under the version
   dir and nothing ever brings that work back, so a user who configured a sandboxed copy
-  for a week had to copy files by hand to promote it — or to leave. Export copies the
-  isolated config dir out to the real `~/.<agent>`, stripping symlinks that point back
-  into `~/.agents` so the result keeps working after agents-cli is gone. An existing
-  real config is moved to `backups/<agent>/<ts>` rather than overwritten, a `~/.<agent>`
-  that agents-cli already adopted is refused (writing there would mutate that version's
-  home instead of the user's config), and `--dry-run` prints the exact plan. Only
-  isolated versions are exportable — a normal install's config dir already *is*
-  `~/.<agent>` via the adoption symlink. Source: `apps/cli/src/lib/export.ts`,
+  for a week had to copy files by hand to promote it — or to leave. Export is additive
+  by default: it copies only paths you don't already have, and a collision is **not**
+  silently skipped — the incoming file is written beside yours as
+  `<name>.from-agents-cli` so you can `--diff` it and take the parts you want. Your
+  files are never modified. `--replace` promotes a sandbox wholesale (yours is moved to
+  `backups/<agent>/<ts>`, and it is the only mode that asks for confirmation);
+  `--staged` dumps the tree into `~/.<agent>/.agents-export-<ts>/` and activates
+  nothing. Every mode strips symlinks pointing back into `~/.agents` so the result
+  keeps working after agents-cli is gone, keeps your own symlinks, and writes a receipt
+  to `~/.<agent>/.agents-cli-export.json` recording exactly what came from the export —
+  which makes "which of these files are mine?" answerable and the whole thing
+  reversible. A `~/.<agent>` that agents-cli already adopted is refused, since writing
+  there would mutate that version's home rather than your config. File *contents* are
+  never auto-merged: the TOML parser here drops comments across parse+stringify, so
+  unioning keys would silently delete them. Source: `apps/cli/src/lib/export.ts`,
   `apps/cli/src/commands/export.ts`, `apps/cli/src/lib/config-transfer.ts`.

--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -254,29 +254,43 @@ install's config dir out to the user's real `~/.<agent>` — promoting a sandbox
 setup to the normal one, or taking the settings and dropping agents-cli entirely.
 
 ```
-agents export codex@0.144.6 --dry-run   # show what would change
-agents export codex                     # version optional when only one is isolated
-```
-
-```
 versions/codex/0.144.6/home/.codex  ──copy──▶  ~/.codex
 ```
 
-Three properties make it safe to run:
+| Mode | Behavior |
+|------|----------|
+| **merge** (default) | Additive. Copies only paths the user doesn't have. A collision is **not** silently skipped — the incoming file is written beside theirs as `<name>.from-agents-cli`. Their file is never modified. |
+| `--replace` | The isolated config becomes `~/.<agent>`; theirs moves to `backups/<agent>/<ts>`. The only mode that requires confirmation. |
+| `--staged` | Writes the tree to `~/.<agent>/.agents-export-<ts>/` and activates nothing. |
 
-- **Symlinks into `~/.agents` are stripped** (`copyDirStrippingAgentsSymlinks`).
-  Synced resources live in a version home as links back into `~/.agents`; copying
-  them verbatim would leave the exported config full of links that dangle the
-  moment `~/.agents` is removed. What lands in `~/.<agent>` stands alone.
-- **An existing real `~/.<agent>` is moved to `backups/<agent>/<ts>`**, never
-  deleted. Export replaces rather than merges, so `--dry-run` first is worthwhile
-  when the destination already holds a config you care about.
+```
+agents export codex --dry-run     # show the plan
+agents export codex --diff        # ...and the delta on every colliding file
+agents export codex               # additive; nothing of yours changes
+```
+
+Properties that hold in every mode:
+
+- **Symlinks into `~/.agents` are stripped.** Synced resources live in a version
+  home as links back into `~/.agents`; copying them verbatim would leave the
+  exported config full of links that dangle the moment `~/.agents` is removed.
+  What lands in `~/.<agent>` stands alone. The user's own symlinks survive.
+- **A receipt is written to `~/.<agent>/.agents-cli-export.json`** recording the
+  source version, mode, files `written`, and `conflicts` (with the path of each
+  incoming sibling). This is what makes provenance answerable — which files are
+  the user's and which came from the CLI — and the export reversible.
 - **A `~/.<agent>` that agents-cli already adopted is refused.** That path is a
   symlink into some version's home, so writing there would silently mutate that
   install instead of the user's real config. `agents uninstall` un-adopts.
 
 Only isolated versions can be exported. A normal install's config dir already IS
 `~/.<agent>` by way of the adoption symlink, so there is nothing to copy.
+
+File **contents** are never auto-merged. `smol-toml` does not preserve comments
+across parse+stringify, so unioning keys into a user's `config.toml` would delete
+every comment in it. Export hands over both files and a diff instead. A
+format-preserving TOML editor would be the prerequisite for real key-level
+merging; that is a dependency decision, not a detail of this command.
 
 ## Resource Syncing
 

--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -247,6 +247,37 @@ removal and is restored intact. Two consequences follow from the marker:
 `--isolated` cannot be combined with `--project` (an isolated copy is
 global-but-separate; a project pin selects a shared install for one directory).
 
+### Exporting an isolated config back out
+
+`agents export <agent>[@<version>]` is the exit door. It copies an isolated
+install's config dir out to the user's real `~/.<agent>` — promoting a sandboxed
+setup to the normal one, or taking the settings and dropping agents-cli entirely.
+
+```
+agents export codex@0.144.6 --dry-run   # show what would change
+agents export codex                     # version optional when only one is isolated
+```
+
+```
+versions/codex/0.144.6/home/.codex  ──copy──▶  ~/.codex
+```
+
+Three properties make it safe to run:
+
+- **Symlinks into `~/.agents` are stripped** (`copyDirStrippingAgentsSymlinks`).
+  Synced resources live in a version home as links back into `~/.agents`; copying
+  them verbatim would leave the exported config full of links that dangle the
+  moment `~/.agents` is removed. What lands in `~/.<agent>` stands alone.
+- **An existing real `~/.<agent>` is moved to `backups/<agent>/<ts>`**, never
+  deleted. Export replaces rather than merges, so `--dry-run` first is worthwhile
+  when the destination already holds a config you care about.
+- **A `~/.<agent>` that agents-cli already adopted is refused.** That path is a
+  symlink into some version's home, so writing there would silently mutate that
+  install instead of the user's real config. `agents uninstall` un-adopts.
+
+Only isolated versions can be exported. A normal install's config dir already IS
+`~/.<agent>` by way of the adoption symlink, so there is nothing to copy.
+
 ## Resource Syncing
 
 `syncResourcesToVersion()` copies user/system resources into version homes and

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -2,20 +2,21 @@
  * `agents export <agent>[@<version>]` — copy an isolated install's config out to the
  * user's real `~/.<agent>`.
  *
- * The exit door for `--isolated`. Configure a sandboxed copy, then promote that
- * config to your normal setup — or take it with you and delete agents-cli. The copy
- * strips symlinks into `~/.agents`, so what lands in `~/.<agent>` keeps working with
- * no trace of this CLI.
+ * The exit door for `--isolated`. Default is additive: your files are never modified,
+ * and anything that collides is written beside yours so you can diff and take what you
+ * want. A receipt records what came from the export, so "which of these are mine?" has
+ * an answer and the whole thing can be undone.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
+import { execFileSync } from 'child_process';
 import { confirm, select } from '@inquirer/prompts';
 
 import { AGENTS, agentLabel, formatAgentError, resolveAgentName } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import { listInstalledVersions, isVersionIsolated } from '../lib/versions.js';
-import { planExport, executeExport } from '../lib/export.js';
-import type { ExportPlan } from '../lib/export.js';
+import { planExport, executeExport, CONFLICT_SUFFIX } from '../lib/export.js';
+import type { ExportPlan, ExportMode } from '../lib/export.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
 function isolatedVersions(agent: AgentId): string[] {
@@ -48,57 +49,102 @@ function reportBlocker(plan: ExportPlan): void {
   }
 }
 
-function printPlan(plan: ExportPlan): void {
+/** Unified diff between the user's file and the incoming one, via git. */
+function printDiff(existing: string, incoming: string): void {
+  try {
+    execFileSync('git', ['diff', '--no-index', '--color', '--', existing, incoming], {
+      stdio: ['ignore', 'inherit', 'ignore'],
+    });
+  } catch {
+    // git diff --no-index exits 1 when files differ; output already streamed.
+  }
+}
+
+function printPlan(plan: ExportPlan, opts: { diff?: boolean }): void {
   const label = agentLabel(plan.agent);
-  console.log(chalk.bold(`Export ${label}@${plan.version} -> ${plan.dest}\n`));
+  console.log(chalk.bold(`Export ${label}@${plan.version} -> ${plan.dest}  ${chalk.gray(`[${plan.mode}]`)}\n`));
   console.log(`  ${chalk.gray('from')}  ${plan.source}`);
-  console.log(`  ${chalk.gray('to')}    ${plan.dest}`);
-  if (plan.entries.length > 0) {
-    const shown = plan.entries.slice(0, 12).join(', ');
-    const more = plan.entries.length > 12 ? `, +${plan.entries.length - 12} more` : '';
-    console.log(`  ${chalk.gray('items')} ${shown}${more}`);
-  }
+  console.log(`  ${chalk.gray('to')}    ${plan.stagedPath ?? plan.dest}`);
   console.log();
-  switch (plan.destKind) {
-    case 'real-dir':
-      console.log(chalk.yellow(`  ${plan.dest} already exists and will be REPLACED.`));
-      console.log(chalk.gray(`  Your current config is moved to: ${plan.backupPath}`));
-      break;
-    case 'foreign-symlink':
+
+  if (plan.mode === 'replace') {
+    console.log(chalk.yellow(`  Replacing ${plan.dest} wholesale — ${plan.writes.length} file(s).`));
+    if (plan.backupPath) console.log(chalk.gray(`  Your current config moves to: ${plan.backupPath}`));
+    else if (plan.destKind === 'foreign-symlink') {
       console.log(chalk.yellow(`  ${plan.dest} is a symlink agents-cli does not own; it will be removed.`));
-      console.log(chalk.gray('  Its target is left untouched — inspect it first if you are unsure.'));
-      break;
-    case 'absent':
-      console.log(chalk.gray(`  ${plan.dest} does not exist yet; it will be created.`));
-      break;
+      console.log(chalk.gray('  Its target is left untouched.'));
+    }
+  } else if (plan.mode === 'staged') {
+    console.log(chalk.gray(`  Writing ${plan.writes.length} file(s) into ${plan.stagedPath}.`));
+    console.log(chalk.gray('  Nothing is activated — your config is untouched.'));
+  } else {
+    if (plan.writes.length > 0) {
+      console.log(chalk.green(`  ${plan.writes.length} new file(s) will be added:`));
+      for (const w of plan.writes.slice(0, 15)) console.log(chalk.gray(`      + ${w.rel}`));
+      if (plan.writes.length > 15) console.log(chalk.gray(`      + ${plan.writes.length - 15} more`));
+    } else {
+      console.log(chalk.gray('  No new files to add.'));
+    }
+    if (plan.conflicts.length > 0) {
+      console.log();
+      console.log(chalk.yellow(`  ${plan.conflicts.length} file(s) you already have — YOURS ARE NOT MODIFIED.`));
+      console.log(chalk.gray(`  The incoming version is written beside each as *${CONFLICT_SUFFIX}:`));
+      for (const c of plan.conflicts.slice(0, 15)) console.log(chalk.gray(`      ~ ${c.rel}`));
+      if (plan.conflicts.length > 15) console.log(chalk.gray(`      ~ ${plan.conflicts.length - 15} more`));
+    }
   }
-  console.log(chalk.gray('\n  Symlinks into ~/.agents are stripped, so the result stands alone.'));
+
+  if (opts.diff && plan.conflicts.length > 0) {
+    for (const c of plan.conflicts) {
+      console.log(chalk.bold(`\n─── ${c.rel} ───`));
+      printDiff(c.existing!, c.source);
+    }
+  }
+
+  console.log(chalk.gray(`\n  Receipt: ${plan.receiptPath}`));
 }
 
 export function registerExportCommand(program: Command): void {
   program
     .command('export <spec>')
     .description('Copy an isolated install\'s config out to your real ~/.<agent>')
+    .option('--replace', 'Replace your config wholesale (yours is backed up) instead of merging')
+    .option('--staged', 'Write into ~/.<agent>/.agents-export-<ts>/ and activate nothing')
+    .option('--diff', 'Show a unified diff for each file you already have')
     .option('--dry-run', 'Show what would change without writing anything')
     .option('-y, --yes', 'Skip the confirmation prompt')
     .addHelpText(
       'after',
       `
+Modes:
+  (default)   merge   — additive. Your files are NEVER modified. Anything that
+                        collides is written beside yours as <name>${CONFLICT_SUFFIX}
+                        so you can diff and take the parts you want.
+  --replace           — the isolated config becomes ~/.<agent>; yours is moved to
+                        backups/<agent>/<ts>. For promoting a sandbox wholesale.
+  --staged            — dump the tree into ~/.<agent>/.agents-export-<ts>/ and
+                        activate nothing. For inspecting first.
+
+Every mode writes a receipt to ~/.<agent>/.agents-cli-export.json listing exactly
+what came from the export — so you can tell your settings from the CLI's, and undo it.
+
 Examples:
-  # Promote an isolated copy's config to your normal setup
-  agents export codex@0.144.6
+  agents export codex --dry-run          # see the plan
+  agents export codex --diff             # ...and the deltas on colliding files
+  agents export codex                    # additive; nothing of yours changes
+  agents export codex@0.144.6 --replace  # promote the sandbox wholesale
 
-  # Only one isolated copy? The version can be omitted
-  agents export codex
-
-  # See exactly what would change first
-  agents export codex --dry-run
-
-Leaving agents-cli entirely: export each agent you care about, then uninstall.
-The exported config contains no links back into ~/.agents.
+Note: file CONTENTS are never auto-merged. The TOML parser here does not preserve
+comments, so merging keys would silently delete them. You get both files and a diff.
 `,
     )
-    .action(async (spec: string, options: { dryRun?: boolean; yes?: boolean }) => {
+    .action(async (spec: string, options: { replace?: boolean; staged?: boolean; diff?: boolean; dryRun?: boolean; yes?: boolean }) => {
+      if (options.replace && options.staged) {
+        console.error(chalk.red('--replace and --staged are mutually exclusive; pass only one.'));
+        process.exit(1);
+      }
+      const mode: ExportMode = options.replace ? 'replace' : options.staged ? 'staged' : 'merge';
+
       const [rawAgent, rawVersion] = spec.split('@');
       const agent = resolveAgentName(rawAgent);
       if (!agent) {
@@ -131,26 +177,29 @@ The exported config contains no links back into ~/.agents.
         }
       }
 
-      const plan = planExport(agent, version!, Date.now());
+      const timestamp = Date.now();
+      const plan = planExport(agent, version!, timestamp, mode);
       if (plan.blocker) {
         reportBlocker(plan);
         process.exit(1);
       }
 
-      printPlan(plan);
+      printPlan(plan, { diff: options.diff });
 
       if (options.dryRun) {
         console.log(chalk.gray('\nDry run — nothing was written.'));
         return;
       }
 
-      if (!options.yes) {
+      // Only `--replace` can destroy anything, so it is the only mode that demands
+      // confirmation. merge and staged are additive by construction.
+      if (mode === 'replace' && !options.yes) {
         if (!isInteractiveTerminal()) {
-          console.error(chalk.red('\nRefusing to overwrite without confirmation in a non-interactive shell.'));
+          console.error(chalk.red('\nRefusing to replace your config without confirmation in a non-interactive shell.'));
           console.error(chalk.gray('  Re-run with --yes once you have checked --dry-run.'));
           process.exit(1);
         }
-        const ok = await confirm({ message: `Write ${plan.dest}?`, default: false }).catch((err) => {
+        const ok = await confirm({ message: `Replace ${plan.dest}?`, default: false }).catch((err) => {
           if (isPromptCancelled(err)) process.exit(130);
           throw err;
         });
@@ -160,15 +209,23 @@ The exported config contains no links back into ~/.agents.
         }
       }
 
-      const result = executeExport(plan);
+      const result = executeExport(plan, timestamp);
       if (!result.exported) {
         console.error(chalk.red(`Export failed: ${result.errors.join('; ')}`));
         process.exit(1);
       }
-      console.log(chalk.green(`\nExported to ${result.dest}`));
-      if (result.backupPath) {
-        console.log(chalk.gray(`  Previous config kept at: ${result.backupPath}`));
+
+      console.log();
+      if (result.written.length > 0) console.log(chalk.green(`Added ${result.written.length} file(s) to ${result.dest}`));
+      if (result.conflicts.length > 0) {
+        console.log(chalk.yellow(`${result.conflicts.length} of your file(s) were left untouched; incoming copies written as *${CONFLICT_SUFFIX}`));
+        console.log(chalk.gray(`  Compare them with: agents export ${agent}@${version} --diff --dry-run`));
       }
-      console.log(chalk.gray(`  ${AGENTS[plan.agent].cliCommand} now reads this config directly.`));
+      if (result.backupPath) console.log(chalk.gray(`Previous config kept at: ${result.backupPath}`));
+      if (result.stagedPath) console.log(chalk.gray(`Staged (nothing activated): ${result.stagedPath}`));
+      console.log(chalk.gray(`Receipt: ${result.receiptPath}`));
+      if (mode !== 'staged') {
+        console.log(chalk.gray(`  ${AGENTS[plan.agent].cliCommand} reads this config directly.`));
+      }
     });
 }

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1,0 +1,174 @@
+/**
+ * `agents export <agent>[@<version>]` — copy an isolated install's config out to the
+ * user's real `~/.<agent>`.
+ *
+ * The exit door for `--isolated`. Configure a sandboxed copy, then promote that
+ * config to your normal setup — or take it with you and delete agents-cli. The copy
+ * strips symlinks into `~/.agents`, so what lands in `~/.<agent>` keeps working with
+ * no trace of this CLI.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { confirm, select } from '@inquirer/prompts';
+
+import { AGENTS, agentLabel, formatAgentError, resolveAgentName } from '../lib/agents.js';
+import type { AgentId } from '../lib/types.js';
+import { listInstalledVersions, isVersionIsolated } from '../lib/versions.js';
+import { planExport, executeExport } from '../lib/export.js';
+import type { ExportPlan } from '../lib/export.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+
+function isolatedVersions(agent: AgentId): string[] {
+  return listInstalledVersions(agent).filter((v) => isVersionIsolated(agent, v));
+}
+
+/** Explain a blocker in terms of what the user should do instead. */
+function reportBlocker(plan: ExportPlan): void {
+  const label = agentLabel(plan.agent);
+  const b = plan.blocker!;
+  switch (b.kind) {
+    case 'not-installed':
+      console.log(chalk.red(`${label}@${plan.version} is not installed.`));
+      console.log(chalk.gray(`  Installed: ${listInstalledVersions(plan.agent).join(', ') || 'none'}`));
+      break;
+    case 'not-isolated':
+      console.log(chalk.yellow(`${label}@${plan.version} is not an isolated install.`));
+      console.log(chalk.gray(`  A normal install's config already IS ${plan.dest} (adoption symlinks it),`));
+      console.log(chalk.gray('  so there is nothing to export. To un-adopt it, use: agents uninstall'));
+      break;
+    case 'no-config':
+      console.log(chalk.yellow(`${label}@${plan.version} has no config to export yet (${b.source} is empty).`));
+      console.log(chalk.gray(`  Run it once first: agents run ${plan.agent}@${plan.version}`));
+      break;
+    case 'dest-adopted':
+      console.log(chalk.red(`${b.realPath} is managed by agents-cli (adopted by ${label}@${b.adoptedVersion}).`));
+      console.log(chalk.gray('  Exporting would write into that version\'s home, not your real config.'));
+      console.log(chalk.gray(`  Release it first: agents uninstall  (or agents remove ${plan.agent}@${b.adoptedVersion})`));
+      break;
+  }
+}
+
+function printPlan(plan: ExportPlan): void {
+  const label = agentLabel(plan.agent);
+  console.log(chalk.bold(`Export ${label}@${plan.version} -> ${plan.dest}\n`));
+  console.log(`  ${chalk.gray('from')}  ${plan.source}`);
+  console.log(`  ${chalk.gray('to')}    ${plan.dest}`);
+  if (plan.entries.length > 0) {
+    const shown = plan.entries.slice(0, 12).join(', ');
+    const more = plan.entries.length > 12 ? `, +${plan.entries.length - 12} more` : '';
+    console.log(`  ${chalk.gray('items')} ${shown}${more}`);
+  }
+  console.log();
+  switch (plan.destKind) {
+    case 'real-dir':
+      console.log(chalk.yellow(`  ${plan.dest} already exists and will be REPLACED.`));
+      console.log(chalk.gray(`  Your current config is moved to: ${plan.backupPath}`));
+      break;
+    case 'foreign-symlink':
+      console.log(chalk.yellow(`  ${plan.dest} is a symlink agents-cli does not own; it will be removed.`));
+      console.log(chalk.gray('  Its target is left untouched — inspect it first if you are unsure.'));
+      break;
+    case 'absent':
+      console.log(chalk.gray(`  ${plan.dest} does not exist yet; it will be created.`));
+      break;
+  }
+  console.log(chalk.gray('\n  Symlinks into ~/.agents are stripped, so the result stands alone.'));
+}
+
+export function registerExportCommand(program: Command): void {
+  program
+    .command('export <spec>')
+    .description('Copy an isolated install\'s config out to your real ~/.<agent>')
+    .option('--dry-run', 'Show what would change without writing anything')
+    .option('-y, --yes', 'Skip the confirmation prompt')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  # Promote an isolated copy's config to your normal setup
+  agents export codex@0.144.6
+
+  # Only one isolated copy? The version can be omitted
+  agents export codex
+
+  # See exactly what would change first
+  agents export codex --dry-run
+
+Leaving agents-cli entirely: export each agent you care about, then uninstall.
+The exported config contains no links back into ~/.agents.
+`,
+    )
+    .action(async (spec: string, options: { dryRun?: boolean; yes?: boolean }) => {
+      const [rawAgent, rawVersion] = spec.split('@');
+      const agent = resolveAgentName(rawAgent);
+      if (!agent) {
+        console.error(chalk.red(formatAgentError(rawAgent)));
+        process.exit(1);
+      }
+
+      let version = rawVersion;
+      if (!version) {
+        const candidates = isolatedVersions(agent);
+        if (candidates.length === 0) {
+          console.log(chalk.yellow(`No isolated ${agentLabel(agent)} installs to export.`));
+          console.log(chalk.gray(`  Create one with: agents add ${agent}@<version> --isolated`));
+          return;
+        }
+        if (candidates.length === 1) {
+          version = candidates[0];
+        } else if (isInteractiveTerminal()) {
+          version = await select({
+            message: `Which isolated ${agentLabel(agent)} version?`,
+            choices: candidates.map((v) => ({ name: v, value: v })),
+          }).catch((err) => {
+            if (isPromptCancelled(err)) process.exit(130);
+            throw err;
+          });
+        } else {
+          console.error(chalk.red(`${agentLabel(agent)} has several isolated installs; name one.`));
+          console.error(chalk.gray(`  ${candidates.map((v) => `agents export ${agent}@${v}`).join('\n  ')}`));
+          process.exit(1);
+        }
+      }
+
+      const plan = planExport(agent, version!, Date.now());
+      if (plan.blocker) {
+        reportBlocker(plan);
+        process.exit(1);
+      }
+
+      printPlan(plan);
+
+      if (options.dryRun) {
+        console.log(chalk.gray('\nDry run — nothing was written.'));
+        return;
+      }
+
+      if (!options.yes) {
+        if (!isInteractiveTerminal()) {
+          console.error(chalk.red('\nRefusing to overwrite without confirmation in a non-interactive shell.'));
+          console.error(chalk.gray('  Re-run with --yes once you have checked --dry-run.'));
+          process.exit(1);
+        }
+        const ok = await confirm({ message: `Write ${plan.dest}?`, default: false }).catch((err) => {
+          if (isPromptCancelled(err)) process.exit(130);
+          throw err;
+        });
+        if (!ok) {
+          console.log(chalk.gray('Aborted.'));
+          return;
+        }
+      }
+
+      const result = executeExport(plan);
+      if (!result.exported) {
+        console.error(chalk.red(`Export failed: ${result.errors.join('; ')}`));
+        process.exit(1);
+      }
+      console.log(chalk.green(`\nExported to ${result.dest}`));
+      if (result.backupPath) {
+        console.log(chalk.gray(`  Previous config kept at: ${result.backupPath}`));
+      }
+      console.log(chalk.gray(`  ${AGENTS[plan.agent].cliCommand} now reads this config directly.`));
+    });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -98,6 +98,7 @@ import {
   loadWorktree,
   loadVersions,
   loadImport,
+  loadExport,
   loadPackages,
   loadRoutines,
   loadMonitors,
@@ -875,6 +876,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadWorktree);
   await reg(loadVersions);
   await reg(loadImport);
+  await reg(loadExport);
   await reg(loadPackages);
   await reg(loadRoutines);
   await reg(loadMonitors);

--- a/apps/cli/src/lib/config-transfer.ts
+++ b/apps/cli/src/lib/config-transfer.ts
@@ -1,0 +1,54 @@
+/**
+ * Primitives for moving an agent config directory across the agents-cli boundary.
+ *
+ * Both helpers were part of {@link ./uninstall.ts} and are unchanged — teardown was
+ * simply the first caller. `agents export` needs the same two operations (relocate a
+ * directory that may sit on another volume; copy one without dragging `~/.agents`
+ * symlinks along), so they live here rather than being duplicated or imported out of
+ * a module named for teardown.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Move `source` onto `dest` across possibly-different volumes. `renameSync` is
+ * atomic but throws EXDEV when `~/.agents` lives on a different filesystem than
+ * `$HOME`; fall back to copy-then-remove so the restore still completes. The
+ * source is removed only after the copy succeeds, so a mid-copy failure never
+ * destroys the sole surviving copy.
+ */
+export function moveDirCrossDevice(source: string, dest: string): void {
+  try {
+    fs.renameSync(source, dest);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    fs.cpSync(source, dest, { recursive: true });
+    fs.rmSync(source, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Copy `source` to `dest`, dropping any symlink whose target resolves back into
+ * `~/.agents`. Managed resources (skills/commands) are synced into a version home
+ * as symlinks into `~/.agents`; copying them verbatim would leave the result full
+ * of links that dangle the moment `~/.agents` is disposed. Stripping them yields a
+ * clean, self-contained copy — which is the entire point of an export.
+ */
+export function copyDirStrippingAgentsSymlinks(source: string, dest: string, agentsDir: string): void {
+  const inside = agentsDir + path.sep;
+  fs.cpSync(source, dest, {
+    recursive: true,
+    filter: (src) => {
+      try {
+        const st = fs.lstatSync(src);
+        if (st.isSymbolicLink()) {
+          const tgt = path.resolve(path.dirname(src), fs.readlinkSync(src));
+          if (tgt === agentsDir || tgt.startsWith(inside)) return false;
+        }
+      } catch {
+        /* unreadable entry — let cpSync surface it on the real copy */
+      }
+      return true;
+    },
+  });
+}

--- a/apps/cli/src/lib/export.integration.test.ts
+++ b/apps/cli/src/lib/export.integration.test.ts
@@ -7,14 +7,18 @@ import path from 'node:path';
 // `agents export` is the exit door for `--isolated`: it copies a sandboxed install's
 // config out to the user's real ~/.<agent> so they can keep their settings and delete
 // agents-cli. Drives the real CLI against a throwaway HOME — no mocking — because the
-// whole feature is filesystem behavior (backup, replace, symlink stripping).
-describe.skipIf(process.platform === 'win32')('agents export — isolated config out to the real config dir', () => {
+// whole feature is filesystem behavior (additive merge, conflict siblings, receipt).
+describe.skipIf(process.platform === 'win32')('agents export', () => {
   let home: string;
   const V = '9.9.4';
+  const RECEIPT = '.agents-cli-export.json';
+  const SUFFIX = '.from-agents-cli';
 
   const versionDir = (v = V) => path.join(home, '.agents', '.history', 'versions', 'codex', v);
   const isolatedConfig = (v = V) => path.join(versionDir(v), 'home', '.codex');
   const realConfig = () => path.join(home, '.codex');
+  const read = (...p: string[]) => fs.readFileSync(path.join(...p), 'utf-8');
+  const receipt = () => JSON.parse(read(realConfig(), RECEIPT));
 
   function plantIsolated(v = V, { isolated = true } = {}) {
     const binDir = path.join(versionDir(v), 'node_modules', '.bin');
@@ -22,8 +26,9 @@ describe.skipIf(process.platform === 'win32')('agents export — isolated config
     // isVersionInstalled resolves the launch binary, so the fixture needs a real file.
     fs.writeFileSync(path.join(binDir, 'codex'), '#!/bin/sh\nexit 0\n');
     fs.chmodSync(path.join(binDir, 'codex'), 0o755);
-    fs.mkdirSync(isolatedConfig(v), { recursive: true });
+    fs.mkdirSync(path.join(isolatedConfig(v), 'prompts'), { recursive: true });
     fs.writeFileSync(path.join(isolatedConfig(v), 'config.toml'), 'model = "sandboxed"\n');
+    fs.writeFileSync(path.join(isolatedConfig(v), 'prompts', 'review.md'), '# review\n');
     if (isolated) fs.writeFileSync(path.join(versionDir(v), '.isolated'), '2026-07-30T00:00:00.000Z\n');
   }
 
@@ -49,85 +54,142 @@ describe.skipIf(process.platform === 'win32')('agents export — isolated config
   });
   afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
 
-  it('creates the real config dir when the user has none', () => {
-    plantIsolated();
-    const r = run('export', `codex@${V}`, '--yes');
-    expect(r.status).toBe(0);
-    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
-  }, 120_000);
+  describe('merge (default)', () => {
+    it('NEVER modifies a file the user already has — writes the incoming copy beside it', () => {
+      plantIsolated();
+      fs.mkdirSync(realConfig(), { recursive: true });
+      fs.writeFileSync(path.join(realConfig(), 'config.toml'), '# my note\nmodel = "mine"\n');
 
-  it('backs up an existing real config instead of destroying it', () => {
-    plantIsolated();
-    fs.mkdirSync(realConfig(), { recursive: true });
-    fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "my-original"\n');
+      const r = run('export', `codex@${V}`);
+      expect(r.status).toBe(0);
 
-    const r = run('export', `codex@${V}`, '--yes');
-    expect(r.status).toBe(0);
-    // New config landed...
-    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
-    // ...and the original survives somewhere under the backups dir.
-    const backupsRoot = path.join(home, '.agents', '.history', 'backups', 'codex');
-    const stamps = fs.existsSync(backupsRoot) ? fs.readdirSync(backupsRoot) : [];
-    expect(stamps.length).toBeGreaterThan(0);
-    const restored = path.join(backupsRoot, stamps[0], 'config.toml');
-    expect(fs.readFileSync(restored, 'utf-8')).toContain('my-original');
-  }, 120_000);
+      // The user's file is byte-identical, comment and all.
+      expect(read(realConfig(), 'config.toml')).toBe('# my note\nmodel = "mine"\n');
+      // ...and the incoming one sits next to it for them to diff.
+      expect(read(realConfig(), `config.toml${SUFFIX}`)).toContain('sandboxed');
+      // A non-colliding file lands normally.
+      expect(read(realConfig(), 'prompts', 'review.md')).toContain('# review');
+    }, 120_000);
 
-  it('strips symlinks into ~/.agents so the export stands alone', () => {
-    plantIsolated();
-    // Managed resources are synced into a version home as links into ~/.agents.
-    const skillsSrc = path.join(home, '.agents', 'skills');
-    fs.mkdirSync(skillsSrc, { recursive: true });
-    fs.writeFileSync(path.join(skillsSrc, 'SKILL.md'), '# managed\n');
-    fs.symlinkSync(skillsSrc, path.join(isolatedConfig(), 'skills'));
-    // A link to something OUTSIDE ~/.agents is the user's own and must survive.
-    const mine = path.join(home, 'my-notes');
-    fs.mkdirSync(mine, { recursive: true });
-    fs.symlinkSync(mine, path.join(isolatedConfig(), 'notes'));
+    it('records provenance in the receipt: what was added vs what was left alone', () => {
+      plantIsolated();
+      fs.mkdirSync(realConfig(), { recursive: true });
+      fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "mine"\n');
 
-    expect(run('export', `codex@${V}`, '--yes').status).toBe(0);
-    expect(fs.existsSync(path.join(realConfig(), 'skills'))).toBe(false);
-    expect(fs.existsSync(path.join(realConfig(), 'notes'))).toBe(true);
-    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
-  }, 120_000);
+      expect(run('export', `codex@${V}`).status).toBe(0);
+      const rec = receipt();
+      expect(rec.mode).toBe('merge');
+      expect(rec.from).toContain(`codex@${V}`);
+      expect(rec.written).toContain(path.join('prompts', 'review.md'));
+      expect(rec.written).not.toContain('config.toml');
+      expect(rec.conflicts.map((c: { path: string }) => c.path)).toContain('config.toml');
+    }, 120_000);
 
-  it('--dry-run writes nothing', () => {
-    plantIsolated();
-    fs.mkdirSync(realConfig(), { recursive: true });
-    fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "my-original"\n');
+    it('adds everything when the user has no config at all', () => {
+      plantIsolated();
+      expect(run('export', `codex@${V}`).status).toBe(0);
+      expect(read(realConfig(), 'config.toml')).toContain('sandboxed');
+      expect(read(realConfig(), 'prompts', 'review.md')).toContain('# review');
+      expect(receipt().conflicts).toEqual([]);
+    }, 120_000);
 
-    const r = run('export', `codex@${V}`, '--dry-run');
-    expect(r.status).toBe(0);
-    expect(r.out).toContain('Dry run');
-    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('my-original');
-  }, 120_000);
+    it('strips symlinks into ~/.agents but keeps the user\'s own', () => {
+      plantIsolated();
+      const managed = path.join(home, '.agents', 'skills');
+      fs.mkdirSync(managed, { recursive: true });
+      fs.symlinkSync(managed, path.join(isolatedConfig(), 'skills'));
+      const mine = path.join(home, 'my-notes');
+      fs.mkdirSync(mine, { recursive: true });
+      fs.symlinkSync(mine, path.join(isolatedConfig(), 'notes'));
 
-  it('refuses a NON-isolated version and changes nothing', () => {
-    plantIsolated(V, { isolated: false });
-    const r = run('export', `codex@${V}`, '--yes');
-    expect(r.status).not.toBe(0);
-    expect(r.out).toContain('not an isolated install');
-    expect(fs.existsSync(realConfig())).toBe(false);
-  }, 120_000);
+      expect(run('export', `codex@${V}`).status).toBe(0);
+      expect(fs.existsSync(path.join(realConfig(), 'skills'))).toBe(false);
+      expect(fs.existsSync(path.join(realConfig(), 'notes'))).toBe(true);
+    }, 120_000);
+  });
 
-  it('refuses when the real config is a symlink agents-cli already adopted', () => {
-    plantIsolated();
-    // Another version adopted ~/.codex — writing there would mutate ITS home.
-    plantIsolated('9.9.5', { isolated: false });
-    fs.symlinkSync(isolatedConfig('9.9.5'), realConfig());
+  describe('--replace', () => {
+    it('replaces wholesale and backs up the previous config', () => {
+      plantIsolated();
+      fs.mkdirSync(realConfig(), { recursive: true });
+      fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "my-original"\n');
 
-    const r = run('export', `codex@${V}`, '--yes');
-    expect(r.status).not.toBe(0);
-    expect(r.out).toContain('managed by agents-cli');
-    // The adopted target is untouched.
-    expect(fs.readFileSync(path.join(isolatedConfig('9.9.5'), 'config.toml'), 'utf-8')).toContain('sandboxed');
-    expect(fs.lstatSync(realConfig()).isSymbolicLink()).toBe(true);
-  }, 120_000);
+      expect(run('export', `codex@${V}`, '--replace', '--yes').status).toBe(0);
+      expect(read(realConfig(), 'config.toml')).toContain('sandboxed');
 
-  it('resolves the version when exactly one isolated copy exists', () => {
-    plantIsolated();
-    const r = run('export', 'codex', '--yes');
-    expect(r.status).toBe(0);
-    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
-  }, 120_000);
+      const backupsRoot = path.join(home, '.agents', '.history', 'backups', 'codex');
+      const stamps = fs.readdirSync(backupsRoot);
+      expect(stamps.length).toBeGreaterThan(0);
+      expect(read(backupsRoot, stamps[0], 'config.toml')).toContain('my-original');
+      expect(receipt().mode).toBe('replace');
+    }, 120_000);
+
+    it('refuses without confirmation in a non-interactive shell', () => {
+      plantIsolated();
+      fs.mkdirSync(realConfig(), { recursive: true });
+      fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "mine"\n');
+
+      const r = run('export', `codex@${V}`, '--replace');
+      expect(r.status).not.toBe(0);
+      expect(read(realConfig(), 'config.toml')).toContain('mine');
+    }, 120_000);
+  });
+
+  describe('--staged', () => {
+    it('activates nothing — the real config is untouched', () => {
+      plantIsolated();
+      fs.mkdirSync(realConfig(), { recursive: true });
+      fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "mine"\n');
+
+      expect(run('export', `codex@${V}`, '--staged').status).toBe(0);
+      expect(read(realConfig(), 'config.toml')).toContain('mine');
+      const staged = fs.readdirSync(realConfig()).find((n) => n.startsWith('.agents-export-'));
+      expect(staged).toBeTruthy();
+      expect(read(realConfig(), staged!, 'config.toml')).toContain('sandboxed');
+      expect(receipt().mode).toBe('staged');
+    }, 120_000);
+  });
+
+  describe('refusals and resolution', () => {
+    it('--dry-run writes nothing at all, not even a receipt', () => {
+      plantIsolated();
+      const r = run('export', `codex@${V}`, '--dry-run');
+      expect(r.status).toBe(0);
+      expect(r.out).toContain('Dry run');
+      expect(fs.existsSync(realConfig())).toBe(false);
+    }, 120_000);
+
+    it('refuses a NON-isolated version and changes nothing', () => {
+      plantIsolated(V, { isolated: false });
+      const r = run('export', `codex@${V}`);
+      expect(r.status).not.toBe(0);
+      expect(r.out).toContain('not an isolated install');
+      expect(fs.existsSync(realConfig())).toBe(false);
+    }, 120_000);
+
+    it('refuses when the real config is a symlink agents-cli already adopted', () => {
+      plantIsolated();
+      plantIsolated('9.9.5', { isolated: false });
+      fs.symlinkSync(isolatedConfig('9.9.5'), realConfig());
+
+      const r = run('export', `codex@${V}`);
+      expect(r.status).not.toBe(0);
+      expect(r.out).toContain('managed by agents-cli');
+      expect(read(isolatedConfig('9.9.5'), 'config.toml')).toContain('sandboxed');
+      expect(fs.lstatSync(realConfig()).isSymbolicLink()).toBe(true);
+    }, 120_000);
+
+    it('rejects --replace together with --staged', () => {
+      plantIsolated();
+      const r = run('export', `codex@${V}`, '--replace', '--staged');
+      expect(r.status).not.toBe(0);
+      expect(r.out).toContain('mutually exclusive');
+    }, 120_000);
+
+    it('resolves the version when exactly one isolated copy exists', () => {
+      plantIsolated();
+      expect(run('export', 'codex').status).toBe(0);
+      expect(read(realConfig(), 'config.toml')).toContain('sandboxed');
+    }, 120_000);
+  });
 });

--- a/apps/cli/src/lib/export.integration.test.ts
+++ b/apps/cli/src/lib/export.integration.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// `agents export` is the exit door for `--isolated`: it copies a sandboxed install's
+// config out to the user's real ~/.<agent> so they can keep their settings and delete
+// agents-cli. Drives the real CLI against a throwaway HOME — no mocking — because the
+// whole feature is filesystem behavior (backup, replace, symlink stripping).
+describe.skipIf(process.platform === 'win32')('agents export — isolated config out to the real config dir', () => {
+  let home: string;
+  const V = '9.9.4';
+
+  const versionDir = (v = V) => path.join(home, '.agents', '.history', 'versions', 'codex', v);
+  const isolatedConfig = (v = V) => path.join(versionDir(v), 'home', '.codex');
+  const realConfig = () => path.join(home, '.codex');
+
+  function plantIsolated(v = V, { isolated = true } = {}) {
+    const binDir = path.join(versionDir(v), 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    // isVersionInstalled resolves the launch binary, so the fixture needs a real file.
+    fs.writeFileSync(path.join(binDir, 'codex'), '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(path.join(binDir, 'codex'), 0o755);
+    fs.mkdirSync(isolatedConfig(v), { recursive: true });
+    fs.writeFileSync(path.join(isolatedConfig(v), 'config.toml'), 'model = "sandboxed"\n');
+    if (isolated) fs.writeFileSync(path.join(versionDir(v), '.isolated'), '2026-07-30T00:00:00.000Z\n');
+  }
+
+  function run(...args: string[]): { out: string; status: number } {
+    try {
+      const out = execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), ...args], {
+        cwd: process.cwd(),
+        env: { ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash', AGENTS_NO_NUDGE: '1', FORCE_COLOR: '0' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString('utf-8');
+      return { out, status: 0 };
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer; status?: number };
+      return { out: `${err.stdout ?? ''}${err.stderr ?? ''}`, status: err.status ?? 1 };
+    }
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-export-'));
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('creates the real config dir when the user has none', () => {
+    plantIsolated();
+    const r = run('export', `codex@${V}`, '--yes');
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
+  }, 120_000);
+
+  it('backs up an existing real config instead of destroying it', () => {
+    plantIsolated();
+    fs.mkdirSync(realConfig(), { recursive: true });
+    fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "my-original"\n');
+
+    const r = run('export', `codex@${V}`, '--yes');
+    expect(r.status).toBe(0);
+    // New config landed...
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
+    // ...and the original survives somewhere under the backups dir.
+    const backupsRoot = path.join(home, '.agents', '.history', 'backups', 'codex');
+    const stamps = fs.existsSync(backupsRoot) ? fs.readdirSync(backupsRoot) : [];
+    expect(stamps.length).toBeGreaterThan(0);
+    const restored = path.join(backupsRoot, stamps[0], 'config.toml');
+    expect(fs.readFileSync(restored, 'utf-8')).toContain('my-original');
+  }, 120_000);
+
+  it('strips symlinks into ~/.agents so the export stands alone', () => {
+    plantIsolated();
+    // Managed resources are synced into a version home as links into ~/.agents.
+    const skillsSrc = path.join(home, '.agents', 'skills');
+    fs.mkdirSync(skillsSrc, { recursive: true });
+    fs.writeFileSync(path.join(skillsSrc, 'SKILL.md'), '# managed\n');
+    fs.symlinkSync(skillsSrc, path.join(isolatedConfig(), 'skills'));
+    // A link to something OUTSIDE ~/.agents is the user's own and must survive.
+    const mine = path.join(home, 'my-notes');
+    fs.mkdirSync(mine, { recursive: true });
+    fs.symlinkSync(mine, path.join(isolatedConfig(), 'notes'));
+
+    expect(run('export', `codex@${V}`, '--yes').status).toBe(0);
+    expect(fs.existsSync(path.join(realConfig(), 'skills'))).toBe(false);
+    expect(fs.existsSync(path.join(realConfig(), 'notes'))).toBe(true);
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
+  }, 120_000);
+
+  it('--dry-run writes nothing', () => {
+    plantIsolated();
+    fs.mkdirSync(realConfig(), { recursive: true });
+    fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "my-original"\n');
+
+    const r = run('export', `codex@${V}`, '--dry-run');
+    expect(r.status).toBe(0);
+    expect(r.out).toContain('Dry run');
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('my-original');
+  }, 120_000);
+
+  it('refuses a NON-isolated version and changes nothing', () => {
+    plantIsolated(V, { isolated: false });
+    const r = run('export', `codex@${V}`, '--yes');
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain('not an isolated install');
+    expect(fs.existsSync(realConfig())).toBe(false);
+  }, 120_000);
+
+  it('refuses when the real config is a symlink agents-cli already adopted', () => {
+    plantIsolated();
+    // Another version adopted ~/.codex — writing there would mutate ITS home.
+    plantIsolated('9.9.5', { isolated: false });
+    fs.symlinkSync(isolatedConfig('9.9.5'), realConfig());
+
+    const r = run('export', `codex@${V}`, '--yes');
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain('managed by agents-cli');
+    // The adopted target is untouched.
+    expect(fs.readFileSync(path.join(isolatedConfig('9.9.5'), 'config.toml'), 'utf-8')).toContain('sandboxed');
+    expect(fs.lstatSync(realConfig()).isSymbolicLink()).toBe(true);
+  }, 120_000);
+
+  it('resolves the version when exactly one isolated copy exists', () => {
+    plantIsolated();
+    const r = run('export', 'codex', '--yes');
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('sandboxed');
+  }, 120_000);
+});

--- a/apps/cli/src/lib/export.ts
+++ b/apps/cli/src/lib/export.ts
@@ -1,0 +1,146 @@
+/**
+ * `agents export` — copy an ISOLATED install's config back out to the user's real
+ * `~/.<agent>`, so they can keep their settings and delete agents-cli entirely.
+ *
+ * Isolation is currently a one-way door: `agents add <agent>@<v> --isolated` builds a
+ * self-contained home under the version dir, and nothing ever brings that work back.
+ * A user who configures an isolated copy for a week and then wants it as their normal
+ * setup has to copy files by hand. Reversibility is what makes a sandbox safe to try.
+ *
+ * Scope is deliberately isolated installs only. A NORMAL install's config dir is
+ * already the user's `~/.<agent>` (adoption replaces it with a symlink into the
+ * version home), so "exporting" one would copy a directory onto itself. `agents
+ * uninstall` is the right tool there — it un-adopts.
+ *
+ * Split into a read-only {@link planExport} and a mutating {@link executeExport} so
+ * `--dry-run` and the real run share one code path, mirroring `lib/uninstall.ts`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { AGENTS } from './agents.js';
+import type { AgentId } from './types.js';
+import { getAgentConfigPath, getConfigSymlinkVersion } from './shims.js';
+import { getVersionHomePath, isVersionIsolated, isVersionInstalled } from './versions.js';
+import { getUserAgentsDir, getBackupsDir } from './state.js';
+import { copyDirStrippingAgentsSymlinks, moveDirCrossDevice } from './config-transfer.js';
+
+/** Why an export cannot proceed. Each maps to a distinct user-facing remedy. */
+export type ExportBlocker =
+  | { kind: 'not-installed' }
+  | { kind: 'not-isolated' }
+  | { kind: 'no-config'; source: string }
+  | { kind: 'dest-adopted'; realPath: string; adoptedVersion: string };
+
+/** What the destination `~/.<agent>` currently is. Decides whether we back it up. */
+export type DestKind = 'absent' | 'real-dir' | 'foreign-symlink';
+
+/** Read-only description of what an export would change. */
+export interface ExportPlan {
+  agent: AgentId;
+  version: string;
+  /** The isolated config dir, e.g. `<versionDir>/home/.codex`. */
+  source: string;
+  /** The user's real config dir, e.g. `~/.codex`. */
+  dest: string;
+  destKind: DestKind;
+  /** Where `dest` gets moved before being replaced, or null when nothing is there. */
+  backupPath: string | null;
+  /** Top-level entry names being exported — enough to show without walking the tree. */
+  entries: string[];
+  blocker: ExportBlocker | null;
+}
+
+export interface ExportResult {
+  exported: boolean;
+  dest: string;
+  backupPath: string | null;
+  errors: string[];
+}
+
+/** The config dir's basename (`.codex`), used to locate it inside a version home. */
+function configBasename(agent: AgentId): string {
+  return path.basename(AGENTS[agent].configDir);
+}
+
+/**
+ * Build a read-only plan. Performs no mutations, so `--dry-run` prints exactly what
+ * the real run would do.
+ */
+export function planExport(agent: AgentId, version: string, timestamp: number): ExportPlan {
+  const source = path.join(getVersionHomePath(agent, version), configBasename(agent));
+  const dest = getAgentConfigPath(agent);
+
+  const base: Omit<ExportPlan, 'blocker'> = {
+    agent,
+    version,
+    source,
+    dest,
+    destKind: 'absent',
+    backupPath: null,
+    entries: [],
+  };
+
+  if (!isVersionInstalled(agent, version)) return { ...base, blocker: { kind: 'not-installed' } };
+  if (!isVersionIsolated(agent, version)) return { ...base, blocker: { kind: 'not-isolated' } };
+  if (!fs.existsSync(source)) return { ...base, blocker: { kind: 'no-config', source } };
+
+  // Refuse when `~/.<agent>` is a symlink agents-cli owns: the agent has a normal
+  // install that adopted it, so writing there would land inside a version home
+  // rather than in the user's real config, and silently mutate that other install.
+  const adopted = getConfigSymlinkVersion(agent);
+  if (adopted !== null) {
+    return { ...base, blocker: { kind: 'dest-adopted', realPath: dest, adoptedVersion: adopted } };
+  }
+
+  let destKind: DestKind = 'absent';
+  try {
+    destKind = fs.lstatSync(dest).isSymbolicLink() ? 'foreign-symlink' : 'real-dir';
+  } catch {
+    destKind = 'absent';
+  }
+
+  // Only a real directory is ours to move aside. A foreign symlink belongs to some
+  // other tool; replacing it silently would be a surprise, so it is surfaced and
+  // requires the caller to decide.
+  const backupPath =
+    destKind === 'real-dir' ? path.join(getBackupsDir(), agent, String(timestamp)) : null;
+
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(source).sort();
+  } catch {
+    entries = [];
+  }
+
+  return { ...base, destKind, backupPath, entries, blocker: null };
+}
+
+/**
+ * Execute a plan from {@link planExport}: move any existing real config aside, then
+ * copy the isolated config out with `~/.agents` symlinks stripped so the result keeps
+ * working after agents-cli is gone.
+ */
+export function executeExport(plan: ExportPlan): ExportResult {
+  const result: ExportResult = { exported: false, dest: plan.dest, backupPath: null, errors: [] };
+  if (plan.blocker) {
+    result.errors.push(`refusing to export: ${plan.blocker.kind}`);
+    return result;
+  }
+
+  try {
+    if (plan.backupPath) {
+      fs.mkdirSync(path.dirname(plan.backupPath), { recursive: true });
+      moveDirCrossDevice(plan.dest, plan.backupPath);
+      result.backupPath = plan.backupPath;
+    } else if (plan.destKind === 'foreign-symlink') {
+      // Not ours to back up, but it must go or cpSync would write through it.
+      fs.unlinkSync(plan.dest);
+    }
+    copyDirStrippingAgentsSymlinks(plan.source, plan.dest, getUserAgentsDir());
+    result.exported = true;
+  } catch (err) {
+    result.errors.push(err instanceof Error ? err.message : String(err));
+  }
+  return result;
+}

--- a/apps/cli/src/lib/export.ts
+++ b/apps/cli/src/lib/export.ts
@@ -4,13 +4,29 @@
  *
  * Isolation is currently a one-way door: `agents add <agent>@<v> --isolated` builds a
  * self-contained home under the version dir, and nothing ever brings that work back.
- * A user who configures an isolated copy for a week and then wants it as their normal
- * setup has to copy files by hand. Reversibility is what makes a sandbox safe to try.
+ * Reversibility is what makes a sandbox safe to try.
  *
- * Scope is deliberately isolated installs only. A NORMAL install's config dir is
- * already the user's `~/.<agent>` (adoption replaces it with a symlink into the
- * version home), so "exporting" one would copy a directory onto itself. `agents
- * uninstall` is the right tool there — it un-adopts.
+ * Three modes, because "export" means different things depending on which config you
+ * consider authoritative:
+ *
+ *   merge (default) — additive. Copy only paths the user doesn't already have. A
+ *                     collision is NOT silently skipped: the incoming file is written
+ *                     beside theirs as `<name>.from-agents-cli` so they can diff and
+ *                     take the parts they want. Nothing of theirs is ever modified.
+ *   replace         — the isolated config becomes `~/.<agent>`; theirs moves to
+ *                     `backups/<agent>/<ts>`. For when you've been living in the
+ *                     sandbox and want to promote it wholesale.
+ *   staged          — write the whole tree to `~/.<agent>/.agents-export-<ts>/` and
+ *                     activate nothing. For inspecting first.
+ *
+ * Every mode leaves a receipt at `~/.<agent>/.agents-cli-export.json` recording what
+ * came from the export. That is what makes provenance answerable ("which of these
+ * files are mine?") and the whole operation reversible.
+ *
+ * Deliberately NOT implemented: key-level merging of file *contents*. The TOML
+ * library here does not preserve comments across parse+stringify, so auto-merging a
+ * `config.toml` would silently delete the user's comments. Handing over both files
+ * and a diff is honest; rewriting their config behind a "merge" flag is not.
  *
  * Split into a read-only {@link planExport} and a mutating {@link executeExport} so
  * `--dry-run` and the real run share one code path, mirroring `lib/uninstall.ts`.
@@ -25,6 +41,14 @@ import { getVersionHomePath, isVersionIsolated, isVersionInstalled } from './ver
 import { getUserAgentsDir, getBackupsDir } from './state.js';
 import { copyDirStrippingAgentsSymlinks, moveDirCrossDevice } from './config-transfer.js';
 
+export type ExportMode = 'merge' | 'replace' | 'staged';
+
+/** Filename of the provenance receipt written into the agent's config dir. */
+export const RECEIPT_NAME = '.agents-cli-export.json';
+
+/** Suffix for the incoming copy of a file the user already has. */
+export const CONFLICT_SUFFIX = '.from-agents-cli';
+
 /** Why an export cannot proceed. Each maps to a distinct user-facing remedy. */
 export type ExportBlocker =
   | { kind: 'not-installed' }
@@ -32,29 +56,53 @@ export type ExportBlocker =
   | { kind: 'no-config'; source: string }
   | { kind: 'dest-adopted'; realPath: string; adoptedVersion: string };
 
-/** What the destination `~/.<agent>` currently is. Decides whether we back it up. */
+/** What the destination `~/.<agent>` currently is. */
 export type DestKind = 'absent' | 'real-dir' | 'foreign-symlink';
 
-/** Read-only description of what an export would change. */
+/** One file the export would place, relative to the config dir root. */
+export interface ExportEntry {
+  /** Path relative to the config dir, e.g. `prompts/review.md`. */
+  rel: string;
+  /** Absolute source file inside the isolated home. */
+  source: string;
+  /** Absolute path this file will be written to. */
+  target: string;
+  /**
+   * Set when the user already has `rel`. `target` then points at the
+   * `.from-agents-cli` sibling, and `existing` is the untouched original.
+   */
+  existing?: string;
+}
+
 export interface ExportPlan {
   agent: AgentId;
   version: string;
+  mode: ExportMode;
   /** The isolated config dir, e.g. `<versionDir>/home/.codex`. */
   source: string;
   /** The user's real config dir, e.g. `~/.codex`. */
   dest: string;
   destKind: DestKind;
-  /** Where `dest` gets moved before being replaced, or null when nothing is there. */
+  /** Files with no counterpart in `dest` — written in place. */
+  writes: ExportEntry[];
+  /** Files the user already has — written alongside, never over. */
+  conflicts: ExportEntry[];
+  /** replace mode only: where `dest` gets moved first. */
   backupPath: string | null;
-  /** Top-level entry names being exported — enough to show without walking the tree. */
-  entries: string[];
+  /** staged mode only: the subdirectory receiving the whole tree. */
+  stagedPath: string | null;
+  receiptPath: string;
   blocker: ExportBlocker | null;
 }
 
 export interface ExportResult {
   exported: boolean;
   dest: string;
+  written: string[];
+  conflicts: Array<{ path: string; theirs: string }>;
   backupPath: string | null;
+  stagedPath: string | null;
+  receiptPath: string | null;
   errors: string[];
 }
 
@@ -64,21 +112,64 @@ function configBasename(agent: AgentId): string {
 }
 
 /**
- * Build a read-only plan. Performs no mutations, so `--dry-run` prints exactly what
- * the real run would do.
+ * Every regular file under `root`, as paths relative to it. Symlinks pointing back
+ * into `~/.agents` are omitted for the same reason `copyDirStrippingAgentsSymlinks`
+ * drops them: they dangle the moment `~/.agents` is disposed, and an export that
+ * leaves dangling links is not an export.
  */
-export function planExport(agent: AgentId, version: string, timestamp: number): ExportPlan {
+function walkFiles(root: string, agentsDir: string, rel = ''): string[] {
+  const inside = agentsDir + path.sep;
+  const out: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(path.join(root, rel), { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const childRel = rel ? path.join(rel, entry.name) : entry.name;
+    const abs = path.join(root, childRel);
+    if (entry.isSymbolicLink()) {
+      try {
+        const tgt = path.resolve(path.dirname(abs), fs.readlinkSync(abs));
+        if (tgt === agentsDir || tgt.startsWith(inside)) continue;
+      } catch {
+        continue;
+      }
+      out.push(childRel);
+      continue;
+    }
+    if (entry.isDirectory()) {
+      out.push(...walkFiles(root, agentsDir, childRel));
+      continue;
+    }
+    out.push(childRel);
+  }
+  return out;
+}
+
+/** Build a read-only plan. Performs no mutations. */
+export function planExport(
+  agent: AgentId,
+  version: string,
+  timestamp: number,
+  mode: ExportMode = 'merge',
+): ExportPlan {
   const source = path.join(getVersionHomePath(agent, version), configBasename(agent));
   const dest = getAgentConfigPath(agent);
 
   const base: Omit<ExportPlan, 'blocker'> = {
     agent,
     version,
+    mode,
     source,
     dest,
     destKind: 'absent',
+    writes: [],
+    conflicts: [],
     backupPath: null,
-    entries: [],
+    stagedPath: null,
+    receiptPath: path.join(dest, RECEIPT_NAME),
   };
 
   if (!isVersionInstalled(agent, version)) return { ...base, blocker: { kind: 'not-installed' } };
@@ -100,44 +191,147 @@ export function planExport(agent: AgentId, version: string, timestamp: number): 
     destKind = 'absent';
   }
 
-  // Only a real directory is ours to move aside. A foreign symlink belongs to some
-  // other tool; replacing it silently would be a surprise, so it is surfaced and
-  // requires the caller to decide.
-  const backupPath =
-    destKind === 'real-dir' ? path.join(getBackupsDir(), agent, String(timestamp)) : null;
+  const agentsDir = getUserAgentsDir();
+  const rels = walkFiles(source, agentsDir).sort();
 
-  let entries: string[] = [];
-  try {
-    entries = fs.readdirSync(source).sort();
-  } catch {
-    entries = [];
+  if (mode === 'staged') {
+    const stagedPath = path.join(dest, `.agents-export-${timestamp}`);
+    return {
+      ...base,
+      destKind,
+      stagedPath,
+      writes: rels.map((rel) => ({
+        rel,
+        source: path.join(source, rel),
+        target: path.join(stagedPath, rel),
+      })),
+      blocker: null,
+    };
   }
 
-  return { ...base, destKind, backupPath, entries, blocker: null };
+  if (mode === 'replace') {
+    return {
+      ...base,
+      destKind,
+      backupPath: destKind === 'real-dir' ? path.join(getBackupsDir(), agent, String(timestamp)) : null,
+      writes: rels.map((rel) => ({
+        rel,
+        source: path.join(source, rel),
+        target: path.join(dest, rel),
+      })),
+      blocker: null,
+    };
+  }
+
+  // merge: additive. Anything the user already has becomes a conflict written
+  // alongside, so their file is never the thing that changes.
+  const writes: ExportEntry[] = [];
+  const conflicts: ExportEntry[] = [];
+  for (const rel of rels) {
+    const target = path.join(dest, rel);
+    let exists = false;
+    try {
+      fs.lstatSync(target);
+      exists = true;
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      conflicts.push({
+        rel,
+        source: path.join(source, rel),
+        target: target + CONFLICT_SUFFIX,
+        existing: target,
+      });
+    } else {
+      writes.push({ rel, source: path.join(source, rel), target });
+    }
+  }
+  return { ...base, destKind, writes, conflicts, blocker: null };
 }
 
-/**
- * Execute a plan from {@link planExport}: move any existing real config aside, then
- * copy the isolated config out with `~/.agents` symlinks stripped so the result keeps
- * working after agents-cli is gone.
- */
-export function executeExport(plan: ExportPlan): ExportResult {
-  const result: ExportResult = { exported: false, dest: plan.dest, backupPath: null, errors: [] };
+/** Copy one file, creating parent dirs. Symlinks are recreated, not followed. */
+function placeFile(entry: ExportEntry): void {
+  fs.mkdirSync(path.dirname(entry.target), { recursive: true });
+  const st = fs.lstatSync(entry.source);
+  if (st.isSymbolicLink()) {
+    const link = fs.readlinkSync(entry.source);
+    try {
+      fs.unlinkSync(entry.target);
+    } catch {
+      /* nothing there */
+    }
+    fs.symlinkSync(link, entry.target);
+    return;
+  }
+  fs.copyFileSync(entry.source, entry.target);
+}
+
+function writeReceipt(plan: ExportPlan, result: ExportResult, timestamp: number): void {
+  const receipt = {
+    exportedAt: new Date(timestamp).toISOString(),
+    from: `${plan.agent}@${plan.version} (isolated)`,
+    mode: plan.mode,
+    written: result.written,
+    conflicts: result.conflicts,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+    ...(result.stagedPath ? { stagedAt: result.stagedPath } : {}),
+    note:
+      plan.mode === 'merge'
+        ? `Files under "written" came from this export. Paths under "conflicts" already existed and were NOT modified — the incoming version sits beside yours with the ${CONFLICT_SUFFIX} suffix.`
+        : plan.mode === 'replace'
+          ? 'This config was replaced wholesale by the export; the previous one is at backupPath.'
+          : 'Nothing was activated — the exported tree sits under stagedAt.',
+  };
+  fs.mkdirSync(path.dirname(plan.receiptPath), { recursive: true });
+  fs.writeFileSync(plan.receiptPath, JSON.stringify(receipt, null, 2) + '\n');
+}
+
+/** Execute a plan from {@link planExport}. */
+export function executeExport(plan: ExportPlan, timestamp: number): ExportResult {
+  const result: ExportResult = {
+    exported: false,
+    dest: plan.dest,
+    written: [],
+    conflicts: [],
+    backupPath: null,
+    stagedPath: null,
+    receiptPath: null,
+    errors: [],
+  };
   if (plan.blocker) {
     result.errors.push(`refusing to export: ${plan.blocker.kind}`);
     return result;
   }
 
   try {
-    if (plan.backupPath) {
-      fs.mkdirSync(path.dirname(plan.backupPath), { recursive: true });
-      moveDirCrossDevice(plan.dest, plan.backupPath);
-      result.backupPath = plan.backupPath;
-    } else if (plan.destKind === 'foreign-symlink') {
-      // Not ours to back up, but it must go or cpSync would write through it.
-      fs.unlinkSync(plan.dest);
+    if (plan.mode === 'replace') {
+      if (plan.backupPath) {
+        fs.mkdirSync(path.dirname(plan.backupPath), { recursive: true });
+        moveDirCrossDevice(plan.dest, plan.backupPath);
+        result.backupPath = plan.backupPath;
+      } else if (plan.destKind === 'foreign-symlink') {
+        // Not ours to back up, but it must go or cpSync would write through it.
+        fs.unlinkSync(plan.dest);
+      }
+      copyDirStrippingAgentsSymlinks(plan.source, plan.dest, getUserAgentsDir());
+      result.written = plan.writes.map((w) => w.rel);
+    } else {
+      // merge and staged both place individual files; neither disturbs anything
+      // the user already has.
+      for (const entry of plan.writes) {
+        placeFile(entry);
+        result.written.push(entry.rel);
+      }
+      for (const entry of plan.conflicts) {
+        placeFile(entry);
+        result.conflicts.push({ path: entry.rel, theirs: entry.target });
+      }
+      if (plan.stagedPath) result.stagedPath = plan.stagedPath;
     }
-    copyDirStrippingAgentsSymlinks(plan.source, plan.dest, getUserAgentsDir());
+
+    writeReceipt(plan, result, timestamp);
+    result.receiptPath = plan.receiptPath;
     result.exported = true;
   } catch (err) {
     result.errors.push(err instanceof Error ? err.message : String(err));

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -47,6 +47,7 @@ export const loadWorkflows: ModuleLoader = async () => (await import('../../comm
 export const loadWorktree: ModuleLoader = async () => (await import('../../commands/worktree.js')).registerWorktreeCommands;
 export const loadVersions: ModuleLoader = async () => (await import('../../commands/versions.js')).registerVersionsCommands;
 export const loadImport: ModuleLoader = async () => (await import('../../commands/import.js')).registerImportCommand;
+export const loadExport: ModuleLoader = async () => (await import('../../commands/export.js')).registerExportCommand;
 export const loadPackages: ModuleLoader = async () => (await import('../../commands/packages.js')).registerPackagesCommands;
 export const loadRoutines: ModuleLoader = async () => (await import('../../commands/routines.js')).registerRoutinesCommands;
 export const loadMonitors: ModuleLoader = async () => (await import('../../commands/monitors.js')).registerMonitorsCommands;
@@ -157,6 +158,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   purge: [loadVersions],
   prune: [loadVersions, loadPrune],
   import: [loadImport],
+  export: [loadExport],
   registry: [loadPackages],
   search: [loadPackages],
   install: [loadPackages],

--- a/apps/cli/src/lib/uninstall.ts
+++ b/apps/cli/src/lib/uninstall.ts
@@ -27,6 +27,7 @@ import {
   stripShimPathLines,
   releaseAdoptedLauncher,
 } from './shims.js';
+import { moveDirCrossDevice, copyDirStrippingAgentsSymlinks } from './config-transfer.js';
 import {
   getUserAgentsDir,
   getBackupsDir,
@@ -114,49 +115,6 @@ function symlinkTarget(p: string): string | null {
  */
 function removeLink(p: string): void {
   fs.unlinkSync(p);
-}
-
-/**
- * Move `source` onto `dest` across possibly-different volumes. `renameSync` is
- * atomic but throws EXDEV when `~/.agents` lives on a different filesystem than
- * `$HOME`; fall back to copy-then-remove so the restore still completes. The
- * source (a backup inside `~/.agents`) is removed only after the copy succeeds,
- * so a mid-copy failure never destroys the sole surviving copy.
- */
-function moveDirCrossDevice(source: string, dest: string): void {
-  try {
-    fs.renameSync(source, dest);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
-    fs.cpSync(source, dest, { recursive: true });
-    fs.rmSync(source, { recursive: true, force: true });
-  }
-}
-
-/**
- * Copy `source` to `dest`, dropping any symlink whose target resolves back into
- * `~/.agents`. Adoption syncs managed resources (skills/commands) into the
- * version home as symlinks into `~/.agents`; copying them verbatim would leave
- * the restored config full of links that dangle the moment `~/.agents` is
- * disposed. Stripping them yields a clean, self-contained restore.
- */
-function copyDirStrippingAgentsSymlinks(source: string, dest: string, agentsDir: string): void {
-  const inside = agentsDir + path.sep;
-  fs.cpSync(source, dest, {
-    recursive: true,
-    filter: (src) => {
-      try {
-        const st = fs.lstatSync(src);
-        if (st.isSymbolicLink()) {
-          const tgt = path.resolve(path.dirname(src), fs.readlinkSync(src));
-          if (tgt === agentsDir || tgt.startsWith(inside)) return false;
-        }
-      } catch {
-        /* unreadable entry — let cpSync surface it on the real copy */
-      }
-      return true;
-    },
-  });
 }
 
 /** Classify one agent's config dir without mutating anything. */


### PR DESCRIPTION
First PR from #1444. Stands alone — useful regardless of whether the broader isolation redesign lands.

## Problem

`--isolated` is a one-way door. It builds a self-contained home under the version dir, and nothing ever brings that work back. Configure a sandboxed copy for a week and you have two bad options: copy files by hand to promote it, or throw the work away.

Reversibility is what makes a sandbox safe to try. "Try this, and if you don't like it keep your config and delete the CLI" is a stronger argument for `--isolated` than any promise about what it won't touch.

## Change

```
versions/codex/0.144.6/home/.codex  ──copy──▶  ~/.codex
```

| Mode | Behavior |
|------|----------|
| **merge** (default) | Additive. Copies only paths you don't have. A collision is **not** silently skipped — the incoming file is written beside yours as `<name>.from-agents-cli`. **Your files are never modified.** |
| `--replace` | The isolated config becomes `~/.<agent>`; yours moves to `backups/<agent>/<ts>`. The only mode that asks to confirm, because it's the only one that can destroy anything. |
| `--staged` | Writes to `~/.<agent>/.agents-export-<ts>/` and activates nothing. |

```
agents export codex --dry-run     # the plan
agents export codex --diff        # ...and the delta on every colliding file
agents export codex               # additive; nothing of yours changes
```

Additive is the default because the safe operation should be what you get without thinking. Replacing someone's real config — built over months — with an hour-old sandbox, leaving only a backup dir as consolation, is not a good default.

## The receipt

Every mode writes `~/.<agent>/.agents-cli-export.json`:

```json
{
  "from": "codex@0.144.6 (isolated)",
  "mode": "merge",
  "written": ["prompts/review.md"],
  "conflicts": [{ "path": "config.toml", "theirs": "…/config.toml.from-agents-cli" }]
}
```

That makes *"which of these files are mine and which came from the CLI?"* answerable, and the export reversible — the receipt lists precisely what to delete to undo it.

## Invariants in every mode

- **Symlinks into `~/.agents` are stripped.** Synced resources live in a version home as links back into `~/.agents`; copying them verbatim would leave the export full of links that dangle the moment `~/.agents` is disposed. What lands in `~/.<agent>` stands alone. The user's own symlinks survive — tested both directions.
- **An adopted `~/.<agent>` is refused.** That path is a symlink into some version's home, so writing there would silently mutate *that install* rather than the user's real config.
- Only isolated versions are exportable — a normal install's config dir already *is* `~/.<agent>` via the adoption symlink. `agents uninstall` is what un-adopts.

## Why file contents are never auto-merged

Verified rather than assumed:

```
your config.toml                    after smol-toml parse+stringify
# my important note                 model = "gpt-5"
model = "gpt-5"  # inline comment
```

The TOML library in this repo drops comments on round-trip, so unioning keys into a user's `config.toml` would silently delete every comment in it. Handing over both files and a diff is honest; rewriting their config behind a "merge" flag is not.

Real key-level merging needs a format-preserving TOML editor (CST-style, à la `taplo`). That's a dependency decision for this repo, not something to slip into this PR — noted in the docs and in #1444 as a follow-up.

## Refactor note

`moveDirCrossDevice` and `copyDirStrippingAgentsSymlinks` move **verbatim** from `lib/uninstall.ts` into a new `lib/config-transfer.ts`. Teardown was simply their first caller; export needs the same two operations, and neither should be imported out of a module named for teardown. Pure move — uninstall's tests unchanged and passing.

Split into read-only `planExport` + mutating `executeExport` so `--dry-run` and the real run share one code path, mirroring `lib/uninstall.ts`.

## Tests

`export.integration.test.ts` drives the real CLI against a throwaway `HOME` — no mocking, per the repo convention. 12/12:

**merge** — a user's file is **byte-identical** after export (comment included) while the incoming copy lands as a sibling; the receipt separates `written` from `conflicts`; everything is added when the user has no config; managed symlinks stripped while the user's own survive.
**--replace** — replaces and backs up; refuses without confirmation in a non-interactive shell.
**--staged** — activates nothing; real config untouched.
**refusals** — `--dry-run` writes nothing at all (not even a receipt); non-isolated version refused; adopted destination refused with its target intact; `--replace --staged` rejected; single-candidate version resolution.

Also re-ran `uninstall` and `self-heal/` — 27 total green — since the helpers moved.

Smoke-tested on a real machine with a live isolated install: merge reported *1 file to add, 0 conflicts*, where the earlier replace-only version would have swapped out a 31-entry config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)