### PR TITLE
feat(versions): isolated default — make `agents run <agent>` reach an isolated copy

### DIFF
--- a/apps/cli/.changelog/next/isolated-default.md
+++ b/apps/cli/.changelog/next/isolated-default.md
@@ -1,0 +1,15 @@
+- **`agents use <agent>@<isolated>` now works, and a bare `agents run <agent>` reaches
+  your isolated copy.** Isolated installs were unreachable by name: `resolveVersion`
+  ended at the global default, and an isolated install deliberately never becomes one —
+  so `agents use` refused, and an isolated-only user had to type the full
+  `agents run codex@0.144.6` every time while a bare `agents run codex` fell through to
+  whatever `codex` meant on PATH. `use` now records an **isolated default** instead of
+  refusing, and resolution falls back to it (`project pin -> global default -> isolated
+  default`). Strictly a fallback, so nothing changes for anyone who has a global
+  default. The pointer lives in `isolatedAgents:` in `agents.yaml`, never in the global
+  `agents:` map — that separation is what keeps `getGlobalDefault` incapable of
+  returning an isolated version, and with it the launcher, bare shim, config symlink and
+  self-heal `shadowing` check all stay out of reach. It is verified on read and
+  re-pointed (or cleared) on removal, so it can never resolve to a version that is gone.
+  `agents view` labels it `(isolated default)`. Source: `apps/cli/src/lib/versions.ts`,
+  `apps/cli/src/commands/versions.ts`, `apps/cli/src/commands/view.ts`.

--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -247,6 +247,41 @@ removal and is restored intact. Two consequences follow from the marker:
 `--isolated` cannot be combined with `--project` (an isolated copy is
 global-but-separate; a project pin selects a shared install for one directory).
 
+### The isolated default
+
+`agents use <agent>@<isolated-version>` records which isolated copy a bare
+`agents run <agent>` should reach. It is scoped to the sandbox: unlike a normal
+`use` it sets no global default, creates no bare shim, and never repoints the real
+`~/.<agent>` config symlink.
+
+```yaml
+# ~/.agents/agents.yaml
+agents:                 # global defaults — own the launcher, shim and config symlink
+  claude: 2.1.220
+isolatedAgents:         # sandbox pointers — own nothing
+  codex: 0.144.6
+```
+
+The two maps are kept separate deliberately. An entry under `agents:` arms the
+self-heal `shadowing` check and is what `getGlobalDefault` returns; an isolated
+copy must never acquire that, so it is recorded somewhere `getGlobalDefault`
+cannot see.
+
+Resolution order for a bare agent name (`resolveVersion`):
+
+```
+project pin  ->  global default  ->  isolated default
+```
+
+Strictly a fallback, so nothing changes for anyone who has a global default.
+Without it an isolated-only user could not reach their installs by bare name at
+all — the chain ended at the global default, so `agents run codex` fell through to
+whatever `codex` meant on PATH and only `agents run codex@<version>` worked.
+
+The pointer is verified on read (installed *and* still isolated), and `removeVersion`
+re-points it at the newest surviving isolated copy — or clears it — so it can never
+resolve to a directory that is not there.
+
 ## Resource Syncing
 
 `syncResourcesToVersion()` copies user/system resources into version homes and

--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -255,12 +255,16 @@ global-but-separate; a project pin selects a shared install for one directory).
 `~/.<agent>` config symlink.
 
 ```yaml
-# ~/.agents/agents.yaml
+# ~/.agents/devices/<machine>/agents.yaml   (device-local, never synced)
 agents:                 # global defaults — own the launcher, shim and config symlink
   claude: 2.1.220
 isolatedAgents:         # sandbox pointers — own nothing
   codex: 0.144.6
 ```
+
+Both maps are device-local for the same reason: each names a version installed on
+*this* machine, so syncing either would hand another machine a pointer to a copy it
+does not have.
 
 The two maps are kept separate deliberately. An entry under `agents:` arms the
 self-heal `shadowing` check and is what `getGlobalDefault` returns; an isolated

--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -46,6 +46,7 @@ import {
   getGlobalDefault,
   setGlobalDefault,
   markVersionIsolated,
+  setIsolatedDefault,
   isVersionIsolated,
   getVersionHomePath,
   getVersionDir,
@@ -835,10 +836,26 @@ export function registerVersionsCommands(program: Command): void {
         // Refuse for both the explicit `use <agent>@<isolated>` path (the picker
         // above already filters isolated versions out of the interactive path).
         // Isolated copies are launched explicitly via `agents run <agent>@<v>`.
+        // ...so `use` is scoped to the sandbox rather than refused. Setting the
+        // ISOLATED default records which copy a bare `agents run <agent>` should
+        // reach, and touches none of the five adopting side effects above. The
+        // pointer lives in `meta.isolatedAgents`, never in `meta.agents`, so
+        // `getGlobalDefault` still cannot return an isolated version.
         if (isVersionIsolated(agentId, finalVersion)) {
-          console.log(chalk.red(`${agentLabel(agentConfig.id)}@${finalVersion} is an isolated install and can't be set as your active version.`));
-          console.log(chalk.gray(`Isolated copies stay walled off from your real ${agentConfig.configDir}. Run it directly: agents run ${agentId}@${finalVersion}`));
-          console.log(chalk.gray(`To install this version normally: agents add ${agentId}@${finalVersion}`));
+          if (options.project) {
+            console.log(chalk.yellow(`${agentLabel(agentConfig.id)}@${finalVersion} is an isolated install; --project pins are for shared versions.`));
+            console.log(chalk.gray(`Run it directly instead: agents run ${agentId}@${finalVersion}`));
+            return;
+          }
+          setIsolatedDefault(agentId, finalVersion);
+          console.log(chalk.green(`Set ${agentLabel(agentConfig.id)}@${finalVersion} as your default ISOLATED copy.`));
+          console.log(chalk.gray(`  agents run ${agentId}   now reaches it (no @version needed).`));
+          const globalDefault = getGlobalDefault(agentId);
+          if (globalDefault) {
+            console.log(chalk.gray(`  Your default ${agentConfig.cliCommand} is still ${globalDefault}; ${agentConfig.configDir} is untouched.`));
+          } else {
+            console.log(chalk.gray(`  ${agentConfig.configDir} and your ${agentConfig.cliCommand} launcher are untouched.`));
+          }
           return;
         }
 

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -573,7 +573,14 @@ async function showInstalledVersions(
 	      const runStrategy = getConfiguredRunStrategy(agentId);
 
 	      const strategyLabel = chalk.gray(` (${runStrategy})`);
-	      const noDefaultLabel = !globalDefault ? chalk.yellow(' (no default)') : '';
+	      // `(no default)` is a nudge to go set one. It would read as a contradiction
+	      // directly above a row tagged `(isolated default)`, and it would be bad
+	      // advice besides: for an isolated-only agent the pointer below IS how a
+	      // bare `agents run <agent>` resolves, and setting a global default is
+	      // precisely what `--isolated` exists to avoid.
+	      const noDefaultLabel = !globalDefault && !getIsolatedDefault(agentId)
+	        ? chalk.yellow(' (no default)')
+	        : '';
 	      console.log(`  ${chalk.bold(agentLabel(agentId))}${strategyLabel}${noDefaultLabel}`);
 
 	      // Sort versions with default first, then by semver descending

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -63,6 +63,7 @@ import {
   isGlobalBinaryAgent,
   getLiveVersion,
   isVersionIsolated,
+  getIsolatedDefault,
 } from '../lib/versions.js';
 import {
   getShimsDir,
@@ -509,7 +510,13 @@ async function showInstalledVersions(
   const versionRowLabel = (agentId: AgentId, version: string, globalDefault: string | null): string => {
     const shown = displayVersion(agentId, version);
     if (version === globalDefault) return `${shown} (default)`;
-    if (isVersionIsolated(agentId, version)) return `${shown} (isolated)`;
+    if (isVersionIsolated(agentId, version)) {
+      // The isolated default is what a bare `agents run <agent>` reaches, so it is
+      // worth distinguishing from the other isolated copies sitting beside it.
+      return getIsolatedDefault(agentId) === version
+        ? `${shown} (isolated default)`
+        : `${shown} (isolated)`;
+    }
     return shown;
   };
 
@@ -579,13 +586,14 @@ async function showInstalledVersions(
       for (const version of sortedVersions) {
         const isDefault = version === globalDefault;
         const isolated = !isDefault && isVersionIsolated(agentId, version);
+        const isolatedTag = getIsolatedDefault(agentId) === version ? ' (isolated default)' : ' (isolated)';
         const shown = displayVersion(agentId, version);
         const base = versionRowLabel(agentId, version, globalDefault);
         const tagPad = ' '.repeat(maxVerLabel - base.length);
         const label = isDefault
           ? `${shown}${chalk.green(' (default)')}${tagPad}`
           : isolated
-            ? `${shown}${chalk.gray(' (isolated)')}${tagPad}`
+            ? `${shown}${chalk.gray(isolatedTag)}${tagPad}`
             : base.padEnd(maxVerLabel);
         const rawInfo = infoMap.get(`${agentId}:${version}`);
         const vInfo = rawInfo ? mergeCanonical(rawInfo) : undefined;

--- a/apps/cli/src/lib/isolated-default.integration.test.ts
+++ b/apps/cli/src/lib/isolated-default.integration.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Isolated copies used to be unreachable by bare name: `resolveVersion` ended at the
+// global default, and an isolated install deliberately never becomes one. So an
+// isolated-only user had to type the full `agents run codex@0.144.6` every time —
+// `agents run codex` fell through to whatever `codex` meant on PATH.
+//
+// `agents use <agent>@<isolated>` now records an ISOLATED default instead of refusing,
+// and `resolveVersion` falls back to it. The pointer lives in `meta.isolatedAgents`,
+// never `meta.agents`, so it cannot leak into launcher/shim/config-symlink territory.
+describe.skipIf(process.platform === 'win32')('isolated default', () => {
+  let home: string;
+  const A = '9.9.4';
+  const B = '9.9.5';
+
+  const versionDir = (v: string) => path.join(home, '.agents', '.history', 'versions', 'codex', v);
+  const metaPath = () => path.join(home, '.agents', 'agents.yaml');
+  const shimsDir = () => path.join(home, '.agents', '.cache', 'shims');
+
+  function plant(v: string, { isolated = true } = {}) {
+    const binDir = path.join(versionDir(v), 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'codex'), '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(path.join(binDir, 'codex'), 0o755);
+    fs.mkdirSync(path.join(versionDir(v), 'home', '.codex'), { recursive: true });
+    if (isolated) fs.writeFileSync(path.join(versionDir(v), '.isolated'), '2026-07-30T00:00:00.000Z\n');
+  }
+
+  function run(...args: string[]): { out: string; status: number } {
+    try {
+      const out = execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), ...args], {
+        cwd: process.cwd(),
+        env: { ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash', AGENTS_NO_NUDGE: '1', FORCE_COLOR: '0' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString('utf-8');
+      return { out, status: 0 };
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer; status?: number };
+      return { out: `${err.stdout ?? ''}${err.stderr ?? ''}`, status: err.status ?? 1 };
+    }
+  }
+
+  /** Ask the library directly what a bare `agents run codex` would resolve to. */
+  function resolved(): string | null {
+    const script = `
+      import { resolveVersion } from ${JSON.stringify(path.resolve(process.cwd(), 'src/lib/versions.ts'))};
+      console.log('__R__' + JSON.stringify(resolveVersion('codex')));
+    `;
+    const out = execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash' },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString();
+    return JSON.parse(out.split('__R__')[1]);
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'isolated-default-'));
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('a bare agent name resolves to nothing until an isolated default is set', () => {
+    plant(A);
+    expect(resolved()).toBeNull();
+
+    expect(run('use', `codex@${A}`).status).toBe(0);
+    expect(resolved()).toBe(A);
+  }, 120_000);
+
+  it('sets the pointer WITHOUT adopting: no global default, no bare shim, no config symlink', () => {
+    plant(A);
+    expect(run('use', `codex@${A}`).status).toBe(0);
+
+    const meta = fs.readFileSync(metaPath(), 'utf-8');
+    // Recorded under isolatedAgents, never under the global `agents:` map.
+    expect(meta).toContain('isolatedAgents');
+    // The five adopting side effects of a normal `use` are all absent.
+    const shims = fs.existsSync(shimsDir()) ? fs.readdirSync(shimsDir()) : [];
+    expect(shims).not.toContain('codex');
+    expect(fs.existsSync(path.join(home, '.codex'))).toBe(false);
+    // ...and no global default was recorded for codex.
+    expect(meta).not.toMatch(/^agents:\s*\n\s+codex:/m);
+  }, 120_000);
+
+  it('a global default still wins — the isolated pointer is only a fallback', () => {
+    plant(A);                       // isolated
+    plant(B, { isolated: false });  // normal
+    expect(run('use', `codex@${A}`).status).toBe(0);   // isolated pointer
+    expect(run('use', `codex@${B}`).status).toBe(0);   // real global default
+    expect(resolved()).toBe(B);
+  }, 120_000);
+
+  it('a removed isolated default falls back to a surviving isolated copy', () => {
+    plant(A);
+    plant(B);
+    expect(run('use', `codex@${B}`).status).toBe(0);
+    expect(resolved()).toBe(B);
+
+    expect(run('remove', `codex@${B}`, '--isolated').status).toBe(0);
+    expect(resolved()).toBe(A);
+  }, 180_000);
+
+  it('a dangling pointer never resolves to a missing install', () => {
+    plant(A);
+    expect(run('use', `codex@${A}`).status).toBe(0);
+    // Simulate the version disappearing without going through `remove`.
+    fs.rmSync(versionDir(A), { recursive: true, force: true });
+    expect(resolved()).toBeNull();
+  }, 120_000);
+
+  it('agents view labels which isolated copy is the default', () => {
+    plant(A);
+    plant(B);
+    expect(run('use', `codex@${B}`).status).toBe(0);
+    const out = run('view', 'codex').out;
+    expect(out).toContain(`${B} (isolated default)`);
+    expect(out).toContain(`${A} (isolated)`);
+  }, 120_000);
+
+  it('refuses to pin an isolated copy as a --project version', () => {
+    plant(A);
+    const r = run('use', `codex@${A}`, '--project');
+    expect(r.out).toContain('--project pins are for shared versions');
+  }, 120_000);
+});

--- a/apps/cli/src/lib/isolated-default.integration.test.ts
+++ b/apps/cli/src/lib/isolated-default.integration.test.ts
@@ -18,7 +18,12 @@ describe.skipIf(process.platform === 'win32')('isolated default', () => {
   const B = '9.9.5';
 
   const versionDir = (v: string) => path.join(home, '.agents', '.history', 'versions', 'codex', v);
-  const metaPath = () => path.join(home, '.agents', 'agents.yaml');
+  /** The pointer is device-local, like global pins: ~/.agents/devices/<id>/agents.yaml */
+  const devicePins = () => {
+    const dir = path.join(home, '.agents', 'devices');
+    const ids = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+    return ids.length ? path.join(dir, ids[0], 'agents.yaml') : '';
+  };
   const shimsDir = () => path.join(home, '.agents', '.cache', 'shims');
 
   function plant(v: string, { isolated = true } = {}) {
@@ -78,9 +83,13 @@ describe.skipIf(process.platform === 'win32')('isolated default', () => {
     plant(A);
     expect(run('use', `codex@${A}`).status).toBe(0);
 
-    const meta = fs.readFileSync(metaPath(), 'utf-8');
-    // Recorded under isolatedAgents, never under the global `agents:` map.
+    // Recorded device-locally under isolatedAgents — a pointer to a version
+    // installed on THIS machine, so it must not sync, exactly like a global pin.
+    const meta = fs.readFileSync(devicePins(), 'utf-8');
     expect(meta).toContain('isolatedAgents');
+    // ...and never in the central doc that syncs across machines.
+    expect(fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8'))
+      .not.toContain('isolatedAgents');
     // The five adopting side effects of a normal `use` are all absent.
     const shims = fs.existsSync(shimsDir()) ? fs.readdirSync(shimsDir()) : [];
     expect(shims).not.toContain('codex');

--- a/apps/cli/src/lib/isolated-default.integration.test.ts
+++ b/apps/cli/src/lib/isolated-default.integration.test.ts
@@ -127,10 +127,15 @@ describe.skipIf(process.platform === 'win32')('isolated default', () => {
   it('agents view labels which isolated copy is the default', () => {
     plant(A);
     plant(B);
+    expect(run('view', 'codex').out).toContain('(no default)');
+
     expect(run('use', `codex@${B}`).status).toBe(0);
     const out = run('view', 'codex').out;
     expect(out).toContain(`${B} (isolated default)`);
     expect(out).toContain(`${A} (isolated)`);
+    // The `(no default)` nudge would contradict the row below it, and would be bad
+    // advice: setting a global default is what --isolated exists to avoid.
+    expect(out).not.toContain('(no default)');
   }, 120_000);
 
   it('refuses to pin an isolated copy as a --project version', () => {

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -691,18 +691,24 @@ function writeIfChanged(filePath: string, content: string): void {
  * `agents:` / `versions:` are not written (no empty committed files).
  */
 function writeMetaUnlocked(meta: Meta): void {
-  const { agents, versions, defaultBrowserProfile, ...central } = meta;
+  const { agents, isolatedAgents, versions, defaultBrowserProfile, ...central } = meta;
 
   // Write the machine-local files FIRST, then strip central — so a crash mid-write
   // never removes pins/versions from central before they're persisted elsewhere.
   const devicePath = getDeviceMetaPath();
   const hasAgents = !!agents && Object.keys(agents).length > 0;
+  // The isolated pointer names a version installed on THIS machine, exactly like a
+  // global pin, so it belongs beside `agents:` in the device file rather than in the
+  // central doc that syncs — otherwise another machine inherits a pointer to a copy
+  // it does not have.
+  const hasIsolatedAgents = !!isolatedAgents && Object.keys(isolatedAgents).length > 0;
   const hasDefaultBrowser = !!defaultBrowserProfile;
-  if (hasAgents || hasDefaultBrowser) {
+  if (hasAgents || hasIsolatedAgents || hasDefaultBrowser) {
     // Device-local doc carries `agents:` pins and `defaultBrowserProfile:` — both
     // are per-machine and must never land in central agents.yaml (which syncs).
     const deviceDoc: Partial<Meta> = {};
     if (hasAgents) deviceDoc.agents = agents;
+    if (hasIsolatedAgents) deviceDoc.isolatedAgents = isolatedAgents;
     if (hasDefaultBrowser) deviceDoc.defaultBrowserProfile = defaultBrowserProfile;
     fs.mkdirSync(path.dirname(devicePath), { recursive: true });
     writeIfChanged(devicePath, META_HEADER + yaml.stringify(deviceDoc));
@@ -726,8 +732,9 @@ function writeMetaUnlocked(meta: Meta): void {
 
 /**
  * Overlay this machine's local state onto a central-portable Meta:
- *   - `agents:` from the device file (device wins; the union both preserves the
- *     one-level merge and self-heals a pre-migration central that still has pins)
+ *   - `agents:` and `isolatedAgents:` from the device file (device wins; the union
+ *     both preserves the one-level merge and self-heals a pre-migration central that
+ *     still has pins)
  *   - `defaultBrowserProfile:` from the device file (device is the sole source;
  *     the field is stripped from central on write, so nothing to merge against)
  *   - `versions:` from the history JSON (wholesale replace; falls back to
@@ -739,6 +746,7 @@ function overlayMachineLocal(meta: Meta): Meta {
     try {
       const dm = yaml.parse(fs.readFileSync(devicePath, 'utf-8')) as Meta;
       if (dm?.agents) meta.agents = { ...meta.agents, ...dm.agents };
+      if (dm?.isolatedAgents) meta.isolatedAgents = { ...meta.isolatedAgents, ...dm.isolatedAgents };
       if (dm?.defaultBrowserProfile) meta.defaultBrowserProfile = dm.defaultBrowserProfile;
     } catch { /* ignore malformed device file */ }
   }

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -756,6 +756,17 @@ export interface BrandConfig {
 /** Top-level structure of ~/.agents/.system/agents.yaml -- the CLI's persistent state. */
 export interface Meta {
   agents?: Partial<Record<AgentId, string>>;
+  /**
+   * Per-agent preferred ISOLATED version — which copy a bare `agents run <agent>`
+   * resolves to when the agent has no global default.
+   *
+   * Kept separate from `agents` on purpose. An entry there is the global default,
+   * which owns the launcher, the bare shim and the real `~/.<agent>` config
+   * symlink, and arms the self-heal `shadowing` check. An isolated copy must never
+   * acquire any of that, so it cannot be recorded in the same place — the
+   * separation is what keeps `getGlobalDefault` incapable of returning one.
+   */
+  isolatedAgents?: Partial<Record<AgentId, string>>;
   run?: RunConfig;
   /**
    * `agents run --lease` config. `secretsBundle` names the keychain secrets bundle

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1298,6 +1298,35 @@ export function setGlobalDefault(agent: AgentId, version: string | undefined): v
 }
 
 /**
+ * Get the preferred ISOLATED version for an agent — the copy a bare
+ * `agents run <agent>` falls back to when there is no global default.
+ */
+export function getIsolatedDefault(agent: AgentId): string | null {
+  const meta = readMeta();
+  return meta.isolatedAgents?.[agent] || null;
+}
+
+/**
+ * Set (or clear, with `undefined`) the preferred isolated version.
+ *
+ * Deliberately does NOT touch the launcher, the bare shim, the `~/.<agent>` config
+ * symlink or the global default — the five things `setDefaultVersion` does. This is
+ * a pointer inside the sandbox, so it stays inside the sandbox.
+ */
+export function setIsolatedDefault(agent: AgentId, version: string | undefined): void {
+  const meta = readMeta();
+  if (!meta.isolatedAgents) {
+    meta.isolatedAgents = {};
+  }
+  if (version === undefined) {
+    delete meta.isolatedAgents[agent];
+  } else {
+    meta.isolatedAgents[agent] = version;
+  }
+  writeMeta(meta);
+}
+
+/**
  * Path to the sentinel file that marks a version as an isolated install.
  *
  * It lives at the version-dir root (a sibling of `home/`), so it is carried
@@ -1924,6 +1953,14 @@ export function removeVersion(agent: AgentId, version: string): boolean {
     }
   }
 
+  // Same for the isolated pointer: a removed version must not stay the answer to a
+  // bare `agents run <agent>`. Prefer the newest remaining isolated copy so removing
+  // one of several does not silently drop the user back to their PATH binary.
+  if (getIsolatedDefault(agent) === version) {
+    const survivors = listInstalledVersions(agent).filter((v) => isVersionIsolated(agent, v));
+    setIsolatedDefault(agent, survivors.length > 0 ? survivors[survivors.length - 1] : undefined);
+  }
+
   // Clean up dangling config symlink if it pointed to the removed version
   const symlinkVersion = getConfigSymlinkVersion(agent);
   if (symlinkVersion === version) {
@@ -2000,7 +2037,23 @@ export function resolveVersion(agent: AgentId, projectPath?: string): string | n
   }
 
   // Fall back to global default
-  return getGlobalDefault(agent);
+  const globalDefault = getGlobalDefault(agent);
+  if (globalDefault) return globalDefault;
+
+  // Last resort: the preferred isolated copy. Strictly a fallback — a global
+  // default always wins, so nothing changes for anyone who has one. Without this,
+  // an isolated-only user cannot reach their installs by bare name at all: the
+  // resolution chain ended here, so `agents run codex` fell through to whatever
+  // `codex` meant on PATH, and only `agents run codex@<version>` worked.
+  //
+  // The pointer is verified on read. It survives in agents.yaml across a trash +
+  // restore cycle, but a version removed for good would otherwise leave a dangling
+  // pin that resolves to a directory that is not there.
+  const isolated = getIsolatedDefault(agent);
+  if (isolated && isVersionInstalled(agent, isolated) && isVersionIsolated(agent, isolated)) {
+    return isolated;
+  }
+  return null;
 }
 
 /**

--- a/apps/cli/tests/non-interactive.test.ts
+++ b/apps/cli/tests/non-interactive.test.ts
@@ -465,13 +465,14 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
     expect(fs.lstatSync(codexSymlink).isSymbolicLink()).toBe(true);
   });
 
-  it('refuses to `use` an isolated install as the active version (never repoints the real config)', () => {
+  it('`use` on an isolated install sets the ISOLATED default and never repoints the real config', () => {
     const home = makeTempHome();
     tempHomes.push(home);
     writeFakeManagedVersion(home, 'codex', '0.1.0', 'codex');
     // Mark it isolated the way `agents add --isolated` does: a `.isolated` marker
-    // in the version dir. `agents use codex@0.1.0` must refuse it rather than
-    // repoint the real ~/.codex at (and carry settings into) an isolated home.
+    // in the version dir. `use` records which isolated copy a bare `agents run
+    // codex` should reach — it must NOT repoint the real ~/.codex at (or carry
+    // settings into) an isolated home, nor pin it as the global default.
     fs.writeFileSync(
       path.join(home, '.agents', '.history', 'versions', 'codex', '0.1.0', '.isolated'),
       '',
@@ -481,11 +482,16 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
     const codexSymlink = path.join(home, '.codex');
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('isolated install');
-    // The isolation guarantee: the real ~/.codex is never created/repointed and
-    // no default pin is written for the isolated version.
+    expect(result.stdout).toContain('default ISOLATED copy');
+    // The isolation guarantee, unchanged: the real ~/.codex is never created or
+    // repointed...
     expect(fs.existsSync(codexSymlink)).toBe(false);
-    expect(fs.existsSync(devicePinsPath(home))).toBe(false);
+    // ...and the pointer is recorded under `isolatedAgents:`, never as a global
+    // `agents:` pin — the separation that keeps getGlobalDefault unable to return
+    // an isolated version.
+    const pins = fs.readFileSync(devicePinsPath(home), 'utf-8');
+    expect(pins).toContain('isolatedAgents');
+    expect(pins).not.toMatch(/^agents:\s*\n\s+codex:/m);
   });
 
   it('does not switch an existing default during non-interactive add', () => {


### PR DESCRIPTION
Second PR from #1444. Independent of #1445.

## Problem

Isolated installs are unreachable by name. `resolveVersion` is:

```
project pin -> global default
```

and an isolated install deliberately never becomes a global default — so the chain ends with nothing. `agents use <agent>@<isolated>` refused outright, and a bare `agents run codex` fell through to whatever `codex` meant on PATH. Only the fully qualified `agents run codex@0.144.6` ever reached the sandbox. Every invocation, forever.

That makes isolated copies second-class for a reason unrelated to safety. There's no reason the sandbox shouldn't have its own notion of *"the one I mean."*

## Change

`use` records an **isolated default** instead of refusing, and resolution gains a final fallback:

```
project pin -> global default -> isolated default
```

Strictly a fallback — a global default still wins, so nothing changes for anyone who has one.

```
$ agents use codex@0.144.6
Set Codex@0.144.6 as your default ISOLATED copy.
  agents run codex   now reaches it (no @version needed).
  ~/.codex and your codex launcher are untouched.
```

## The separation is the mechanism

```yaml
agents:                 # global defaults — own the launcher, shim, config symlink
  claude: 2.1.220
isolatedAgents:         # sandbox pointers — own nothing
  codex: 0.144.6
```

The pointer lives in `meta.isolatedAgents`, never `meta.agents`. `getGlobalDefault` reads only `meta.agents`, so it stays **structurally incapable** of returning an isolated version — and with it the launcher, the bare shim, the `~/.<agent>` config symlink, and the self-heal `shadowing` check all stay out of reach. Setting an isolated default performs none of the five adopting side effects of `setDefaultVersion`.

That's a property of where the data lives, not a check someone has to remember — which is the point argued in #1444.

## Staleness, both directions

- **Verified on read** — must still be installed *and* still isolated.
- **`removeVersion` re-points** it at the newest surviving isolated copy, or clears it, so removing one of several doesn't silently drop the user back to their PATH binary.

`--project` with an isolated version is still refused — a project pin selects a *shared* install for a directory, the opposite of what an isolated copy is.

`agents view` labels it `(isolated default)` to distinguish it from the other isolated copies beside it.

## Tests

7/7, real CLI against a throwaway `HOME`, no mocking:

- bare-name resolution is `null` before, the version after
- **no adoption**: recorded under `isolatedAgents`, no global default for the agent, no bare shim, no `~/.<agent>` created
- a global default still wins — the pointer is only a fallback
- removal re-points to the surviving isolated copy
- a hand-deleted version never resolves (dangling pointer closed)
- `agents view` shows `(isolated default)` vs `(isolated)`
- `--project` refused

Plus `self-heal/`, `versions`, `versions.isolation`, `view.account` — 46 green.

Exercised on a real machine: `resolveVersion(codex)` went `null` → `0.144.6`, `globalDefault` stayed `null`, and an independent launcher/config-dir/PATH audit reported no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)