### PR TITLE
feat(isolation): enforce the boundary in the primitives, and give it a supported way in

### DIFF
--- a/apps/cli/.changelog/next/import-isolated.md
+++ b/apps/cli/.changelog/next/import-isolated.md
@@ -1,0 +1,13 @@
+- **`agents import <agent> --isolated` — bring your existing setup into a sandbox.**
+  Isolation was a cold start: a new isolated copy began empty, and the only way to get
+  settings into it was by hand. A plain `agents import` is the opposite of what is
+  wanted here — it *adopts*, moving `~/.<agent>` into a version home, symlinking the
+  original away, setting the global default and creating a shim (and is now refused
+  outright for an isolated-only agent). `--isolated` copies instead: your settings land
+  in the isolated home, your real config stays exactly where it is, and the version is
+  finalized the way `agents add --isolated` does — versioned alias and marker, no
+  default, no bare shim, no config symlink. Credentials are skipped by default and
+  named in the output rather than silently included, since an isolated copy signs in as
+  its own principal; `--with-auth` opts in. Symlinks into `~/.agents` are dropped so the
+  copy does not depend on the CLI's tree. Source: `apps/cli/src/lib/import.ts`,
+  `apps/cli/src/commands/import.ts`.

--- a/apps/cli/.changelog/next/isolation-boundary.md
+++ b/apps/cli/.changelog/next/isolation-boundary.md
@@ -1,0 +1,19 @@
+- **An isolated-only agent can no longer be adopted by anything.** `--isolated` used to
+  be defined by what it *doesn't* do — no global default, no bare shim, no config
+  symlink, no PATH edit — which meant every code path that could adopt an agent had to
+  remember to check first. It leaked three times that way. Protection is now derived
+  from the `.isolated` markers on disk (`isIsolationProtected`: at least one installed
+  version, and every one isolated) and enforced inside the five primitives that can
+  cross the boundary — `setGlobalDefault`, `createShim`, `switchConfigSymlink`,
+  `switchHomeFileSymlinks`, `adoptShadowingLauncher` — so refusal is a property of the
+  code rather than a convention. There is no mode to set and none to forget: installing
+  with `--isolated` *is* the opt-in, it is per-agent, and the escape hatch is inherent
+  (remove the isolated copies and the agent is ordinary again). `agents add`,
+  `agents import` and `doctor --adopt` refuse with guidance rather than a stack trace —
+  `import` is additionally checked at its entry point, because it registers the adopted
+  install as a normal version *before* adopting, which would otherwise un-protect the
+  agent underneath the primitive gate. Clearing a global default stays allowed, since
+  removal legitimately clears one as an agent becomes isolated-only. A completeness test
+  pins the primitive list and scans for any new ungated mutator. Source:
+  `apps/cli/src/lib/shims.ts`, `apps/cli/src/lib/versions.ts`,
+  `apps/cli/src/lib/isolation-boundary-report.ts`.

--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -247,6 +247,54 @@ removal and is restored intact. Two consequences follow from the marker:
 `--isolated` cannot be combined with `--project` (an isolated copy is
 global-but-separate; a project pin selects a shared install for one directory).
 
+### The isolation boundary
+
+Once an agent is installed **only** as isolated copies, nothing the framework does
+can adopt it. Protection is derived from the `.isolated` markers already on disk —
+there is no mode to set, and none to forget:
+
+```ts
+isIsolationProtected(agent)   // >=1 installed version, and every one is isolated
+```
+
+Two properties fall out of deriving it that way:
+
+- **Per-agent.** An isolated codex constrains nothing about claude.
+- **The escape hatch is inherent.** Remove the isolated copies and the agent is
+  ordinary again — the state that grants protection is the state you delete to drop
+  it. No `--force` flag, nothing to leave switched off.
+
+Five primitives can carry an agent across the boundary. Each calls
+`assertIsolationBoundary` before doing any work, so the refusal is a property of the
+code rather than a check every future call site must remember:
+
+| Primitive | What it would do |
+|-----------|------------------|
+| `setGlobalDefault` | records the default that owns the launcher and arms `shadowing` |
+| `createShim` | puts a bare `<cli>` shim first on PATH |
+| `switchConfigSymlink` | moves the real `~/.<agent>` aside and symlinks it into a version home |
+| `switchHomeFileSymlinks` | the same for `~/.claude.json` and friends |
+| `adoptShadowingLauncher` | repoints the user's own launcher symlink at our shim |
+
+Clearing a global default is always allowed — `removeVersion` clears one as the last
+non-isolated version goes away, which is the moment an agent *becomes* isolated-only.
+
+`agents add` (without `--isolated`) and `agents import` additionally check the
+boundary at the command entry point. That is not redundant: **import registers the
+adopted install as a normal version first**, so by the time it reaches
+`setGlobalDefault` the agent already has a non-isolated version and the primitive
+gate — which reads state at call time — would let the adoption through. The boundary
+has to be evaluated against the state before the command mutates it.
+
+`doctor --adopt` is the one operation with no isolated-scoped equivalent: hijacking
+PATH is its entire purpose, and isolated copies are deliberately absent from PATH.
+It refuses and explains.
+
+`src/lib/isolation-boundary.test.ts` pins the primitive list and scans `shims.ts` for
+any other exported function that both resolves the real config dir and mutates the
+filesystem without the gate — so a sixth way in fails there rather than silently
+reopening the hole.
+
 ### The isolated default
 
 `agents use <agent>@<isolated-version>` records which isolated copy a bare

--- a/apps/cli/docs/01-version-management.md
+++ b/apps/cli/docs/01-version-management.md
@@ -295,6 +295,28 @@ any other exported function that both resolves the real config dir and mutates t
 filesystem without the gate — so a sixth way in fails there rather than silently
 reopening the hole.
 
+### Bringing an existing install into the sandbox
+
+`agents import <agent> --isolated` is the mirror of a plain import. Where the latter
+*adopts* — moving `~/.<agent>` into a version home, symlinking the original away,
+setting the global default and creating a shim — `--isolated` **copies**:
+
+```
+~/.codex  ──copy──▶  versions/codex/1.2.3/home/.codex     (original untouched)
+```
+
+and finalizes the way `agents add --isolated` does: versioned alias plus the
+`.isolated` marker, no default, no bare shim, no config symlink.
+
+This is the supported way in while an agent is protected — plain `import` is refused
+there precisely because adoption is its purpose.
+
+Credentials are **skipped by default and reported**, not silently included. An
+isolated copy is a separate principal that signs in on its own, so copying tokens
+into it should be a choice rather than a side effect of wanting your settings.
+`--with-auth` opts in. Symlinks into `~/.agents` are dropped, as with `agents export`,
+so the copied config does not depend on the CLI's own tree.
+
 ### The isolated default
 
 `agents use <agent>@<isolated-version>` records which isolated copy a bare

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -22,6 +22,8 @@
  * apply pending sync.
  */
 import type { Command } from 'commander';
+import { IsolationBoundaryError } from '../lib/shims.js';
+import { explainIsolationBoundary } from '../lib/isolation-boundary-report.js';
 import { addHostOption } from '../lib/hosts/option.js';
 import { buildRemoteAgentsInvocation } from '../lib/hosts/remote-cmd.js';
 import { loadDevices, isControlDevice } from '../lib/devices/registry.js';
@@ -783,8 +785,6 @@ export function registerDoctorCommand(program: Command): void {
         // adoptShadowingLauncher resolves the launcher itself (PATH shadow, then
         // the durable ~/.local/bin symlink), so it forces the take-over even when
         // this shell's PATH already has the shim first.
-        const { IsolationBoundaryError } = await import('../lib/shims.js');
-        const { explainIsolationBoundary } = await import('../lib/isolation-boundary-report.js');
         let result;
         try {
           result = adoptShadowingLauncher(agent);

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -783,7 +783,15 @@ export function registerDoctorCommand(program: Command): void {
         // adoptShadowingLauncher resolves the launcher itself (PATH shadow, then
         // the durable ~/.local/bin symlink), so it forces the take-over even when
         // this shell's PATH already has the shim first.
-        const result = adoptShadowingLauncher(agent);
+        const { IsolationBoundaryError } = await import('../lib/shims.js');
+        const { explainIsolationBoundary } = await import('../lib/isolation-boundary-report.js');
+        let result;
+        try {
+          result = adoptShadowingLauncher(agent);
+        } catch (err) {
+          if (err instanceof IsolationBoundaryError) { explainIsolationBoundary(err); process.exit(1); }
+          throw err;
+        }
         if (result.adopted) {
           console.log(chalk.green(`Adopted ${AGENTS[agent].cliCommand} launcher (${result.launcher} -> shim). Original recorded for --release; version management now wins regardless of PATH order.`));
         } else if (result.reason === 'already-adopted') {

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -22,6 +22,8 @@
  */
 
 import type { Command } from 'commander';
+import { withIsolationBoundary } from '../lib/isolation-boundary-report.js';
+import { assertIsolationBoundary } from '../lib/shims.js';
 import chalk from 'chalk';
 import ora from 'ora';
 import * as fs from 'fs';
@@ -56,6 +58,13 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     process.exit(1);
   }
   const agent = AGENTS[agentId];
+
+  // Import registers the adopted install as a NORMAL version and only then sets the
+  // default / creates the shim / repoints the config. By that point the agent has a
+  // non-isolated version, so it is no longer protected and the primitive gates —
+  // which read the state as it is at call time — would let the adoption through.
+  // The boundary has to be checked against the state BEFORE the import mutates it.
+  assertIsolationBoundary(agentId, 'adopt your existing install');
 
   // installScript-based agents (Grok, Antigravity, Cursor, Kiro, Goose, Roo)
   // don't have an npm package; their binary lives wherever the curl/brew
@@ -295,5 +304,6 @@ When to use:
   npm-style packages (claude, codex, gemini, opencode, openclaw) and
   installScript-based agents (grok, antigravity, cursor, kiro, goose).
 `)
-    .action(runImport);
+    .action((...args: Parameters<typeof runImport>) =>
+      withIsolationBoundary(() => runImport(...args)));
 }

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -23,7 +23,8 @@
 
 import type { Command } from 'commander';
 import { withIsolationBoundary } from '../lib/isolation-boundary-report.js';
-import { assertIsolationBoundary } from '../lib/shims.js';
+import { assertIsolationBoundary, createVersionedAlias } from '../lib/shims.js';
+import { markVersionIsolated } from '../lib/versions.js';
 import chalk from 'chalk';
 import ora from 'ora';
 import * as fs from 'fs';
@@ -39,12 +40,15 @@ import {
   importAgentBinary,
   importAgentConfig,
   importInstallScriptBinary,
+  seedIsolatedConfigFromLocal,
   isValidImportVersion,
   resolvePackageDirFromBinary,
 } from '../lib/import.js';
 import { isPromptCancelled, isInteractiveTerminal } from './utils.js';
 
 interface ImportOptions {
+  isolated?: boolean;
+  withAuth?: boolean;
   version?: string;
   fromPath?: string;
   yes?: boolean;
@@ -64,7 +68,11 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   // non-isolated version, so it is no longer protected and the primitive gates —
   // which read the state as it is at call time — would let the adoption through.
   // The boundary has to be checked against the state BEFORE the import mutates it.
-  assertIsolationBoundary(agentId, 'adopt your existing install');
+  // --isolated adopts nothing, so the boundary does not apply to it — it is in fact
+  // the supported way to bring a local install in while protection is on.
+  if (!opts.isolated) {
+    assertIsolationBoundary(agentId, 'adopt your existing install');
+  }
 
   // installScript-based agents (Grok, Antigravity, Cursor, Kiro, Goose, Roo)
   // don't have an npm package; their binary lives wherever the curl/brew
@@ -221,7 +229,25 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   // user-visible side effect (renaming ~/.<agent>/), so if it fails we don't
   // want a stranded symlink farm. Binary registration is cheap and reversible
   // — if it fails after config, the next `agents import` call retries cleanly.
-  const willImportConfig = configDirExists && !configAlreadyManaged;
+  const willImportConfig = configDirExists && !configAlreadyManaged && !opts.isolated;
+  if (opts.isolated && configDirExists) {
+    // COPY the user's settings in; never move, never symlink. The original stays
+    // exactly where it is — that is what separates this from adoption.
+    const seedSpinner = ora(`Copying ${agent.configDir} into the isolated copy...`).start();
+    const seed = seedIsolatedConfigFromLocal(agentId, version, { withAuth: opts.withAuth });
+    if (seed.error) {
+      seedSpinner.fail(`Config: ${seed.error}`);
+      process.exit(1);
+    } else if (seed.seeded) {
+      seedSpinner.succeed(`Settings copied (${seed.from} -> ${seed.to}); your original is untouched`);
+      if (seed.skippedAuth.length > 0) {
+        console.log(chalk.gray(`  Credentials NOT copied: ${seed.skippedAuth.join(', ')}`));
+        console.log(chalk.gray('  The copy signs in separately. Use --with-auth to copy them too.'));
+      }
+    } else {
+      seedSpinner.info('No existing config to copy.');
+    }
+  }
   if (willImportConfig) {
     const cfgSpinner = ora(`Importing config dir for ${agentLabel(agentId)} v${version}...`).start();
     const cfgResult = await importAgentConfig(agentId, version);
@@ -262,6 +288,20 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
   // Wire the imported version into the resolver: global default, main shim,
   // versioned alias, home-file symlinks. Idempotent — safe to call even if
   // importAgentConfig already set the global default.
+  if (opts.isolated) {
+    // The isolated finalizer: launchable alias + marker, and nothing else. No global
+    // default, no bare shim, no config symlink — the same shape as
+    // `agents add --isolated`.
+    createVersionedAlias(agentId, version);
+    markVersionIsolated(agentId, version);
+    console.log();
+    console.log(chalk.green(`${agentLabel(agentId)} v${version} imported as an isolated copy.`));
+    console.log(chalk.gray(`  Your ${agent.configDir} and ${agent.cliCommand} launcher are untouched.`));
+    console.log(chalk.gray(`  Run it:  agents run ${agentId}@${version}`));
+    console.log(chalk.gray(`  Or make it the default isolated copy:  agents use ${agentId}@${version}`));
+    return;
+  }
+
   const finalizeSpinner = ora(`Wiring ${agentLabel(agentId)} v${version} as the active version...`).start();
   try {
     finalizeImport(agentId, version);
@@ -283,6 +323,8 @@ export function registerImportCommand(program: Command): void {
     .description('Import an existing unmanaged agent install into agents-cli')
     .option('--version <version>', 'Pin a version label (otherwise read from package.json)')
     .option('--from-path <path>', 'Path to the npm package dir (otherwise auto-detected from PATH)')
+    .option('--isolated', 'Copy the install into a self-contained isolated version instead of adopting it')
+    .option('--with-auth', 'With --isolated, also copy credentials into the sandbox (skipped by default)')
     .option('-y, --yes', 'Skip the confirmation prompt')
     .addHelpText('after', `
 Examples:

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -19,7 +19,7 @@ import { isGitRepo, cloneIntoExisting, pullRepo } from '../lib/git.js';
 import { isPromptCancelled, isInteractiveTerminal } from './utils.js';
 import { AGENTS, agentConfigDirName, getUnmanagedAgentInstalls, countSessionFiles, agentLabel } from '../lib/agents.js';
 import { setGlobalDefault } from '../lib/versions.js';
-import { ensureShimCurrent, switchHomeFileSymlinks, isShimsInPath, addShimsToPath, getPathSetupInstructions } from '../lib/shims.js';
+import { ensureShimCurrent, switchHomeFileSymlinks, isShimsInPath, addShimsToPath, getPathSetupInstructions, assertIsolationBoundary } from '../lib/shims.js';
 import { setHelpSections } from '../lib/help.js';
 import { registerSetupBrowserCommand, runBrowserWizard } from './setup-browser.js';
 import { registerSetupComputerCommand, runComputerWizard } from './setup-computer.js';
@@ -34,6 +34,11 @@ const HOME = os.homedir();
  */
 async function importAgent(agentId: AgentId, version: string): Promise<{ success: boolean; skipped?: boolean; error?: string }> {
   const agent = AGENTS[agentId];
+  // setup has its own hand-rolled adoption (rename + symlink inline, rather than
+  // calling switchConfigSymlink), so the primitive gates never see it. Check the
+  // boundary here, before the first mkdirSync — which would otherwise create the
+  // scaffolding this very check reads.
+  assertIsolationBoundary(agentId, 'adopt your existing install');
   const configDir = agent.configDir;
   const versionsDir = getVersionsDir();
   const versionHome = path.join(versionsDir, agentId, version, 'home');

--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -68,6 +68,7 @@ import {
   createShim,
   createVersionedAlias,
   supportsIsolatedInstall,
+  isIsolationProtected,
   CONFIG_ENV_ISOLATED_AGENTS,
   removeShim,
   shimExists,
@@ -441,6 +442,21 @@ export function registerVersionsCommands(program: Command): void {
         // from the user's real ~/.<agent>. Agents without one isolate only by
         // adopting ~/.<agent> (which --isolated skips), so an isolated copy
         // would silently read/write the real config. Refuse rather than lie.
+        // A normal install of a currently isolated-only agent would adopt it: set the
+        // global default, create the bare shim, and repoint the real ~/.<agent>. The
+        // primitives refuse that outright, so catch it here — before spending a
+        // network install on something that cannot finish — and say what to do.
+        if (!isIsolated && isIsolationProtected(agent)) {
+          console.log(chalk.red(`${agentLabel(agentConfig.id)} is installed only as isolated copies.`));
+          console.log(chalk.gray(`  A normal install would adopt ${agentConfig.configDir} and your ${agentConfig.cliCommand} launcher.`));
+          console.log(chalk.gray(`  Keep the sandbox:  agents add ${agent}@${version ?? 'latest'} --isolated`));
+          console.log(chalk.gray('  Or manage it normally by removing the isolated copies first:'));
+          for (const v of listInstalledVersions(agent)) {
+            console.log(chalk.gray(`    agents remove ${agent}@${v} --isolated`));
+          }
+          continue;
+        }
+
         if (isIsolated && !supportsIsolatedInstall(agent)) {
           console.log(chalk.red(`${agentLabel(agentConfig.id)} does not support --isolated installs.`));
           console.log(chalk.gray(`  It has no config-directory env var, so it can only isolate by adopting ${agentConfig.configDir} — which --isolated deliberately avoids.`));

--- a/apps/cli/src/lib/import-isolated.integration.test.ts
+++ b/apps/cli/src/lib/import-isolated.integration.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// `agents import` adopts: it MOVES ~/.<agent> into a version home, symlinks the
+// original away, sets the global default and creates a shim. That is the opposite of
+// isolation, so with the boundary in place it is refused for an isolated-only agent —
+// and there was no way to bring an existing setup into a sandbox at all. A new
+// isolated copy started empty.
+//
+// `--isolated` copies instead: settings in, original untouched, nothing adopted.
+describe.skipIf(process.platform === 'win32')('agents import --isolated', () => {
+  let home: string;
+
+  const versionsRoot = () => path.join(home, '.agents', '.history', 'versions', 'codex');
+  const realConfig = () => path.join(home, '.codex');
+  const shimsDir = () => path.join(home, '.agents', '.cache', 'shims');
+  const launcher = () => path.join(home, 'npm-global', 'bin', 'codex');
+
+  function run(...args: string[]): { out: string; status: number } {
+    try {
+      const out = execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), ...args], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash',
+          AGENTS_NO_NUDGE: '1', FORCE_COLOR: '0',
+          PATH: `${path.join(home, 'npm-global', 'bin')}:${process.env.PATH}`,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString('utf-8');
+      return { out, status: 0 };
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer; status?: number };
+      return { out: `${err.stdout ?? ''}${err.stderr ?? ''}`, status: err.status ?? 1 };
+    }
+  }
+
+  const importedVersion = () => {
+    const vs = fs.existsSync(versionsRoot()) ? fs.readdirSync(versionsRoot()) : [];
+    return vs[0];
+  };
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'import-isolated-'));
+    // A real npm-layout codex install with a package.json carrying a version.
+    const pkgDir = path.join(home, 'npm-global', 'lib', 'node_modules', '@openai', 'codex');
+    fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true });
+    fs.mkdirSync(path.join(home, 'npm-global', 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+      name: '@openai/codex', version: '1.2.3', bin: { codex: 'bin/codex.js' },
+    }));
+    fs.writeFileSync(path.join(pkgDir, 'bin', 'codex.js'), '#!/bin/sh\necho LOCAL-CODEX\n');
+    fs.chmodSync(path.join(pkgDir, 'bin', 'codex.js'), 0o755);
+    fs.symlinkSync('../lib/node_modules/@openai/codex/bin/codex.js', launcher());
+
+    // The user's real config: a setting worth keeping, plus a credential.
+    fs.mkdirSync(path.join(realConfig(), 'prompts'), { recursive: true });
+    fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "my-setting"\n');
+    fs.writeFileSync(path.join(realConfig(), 'prompts', 'review.md'), '# mine\n');
+    fs.writeFileSync(path.join(realConfig(), 'auth.json'), '{"token":"SECRET"}\n');
+
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('copies settings in and leaves the original exactly where it was', () => {
+    const r = run('import', 'codex', '--isolated', '-y');
+    expect(r.status).toBe(0);
+    const v = importedVersion();
+    expect(v).toBeTruthy();
+
+    // Settings landed in the sandbox...
+    const seeded = path.join(versionsRoot(), v, 'home', '.codex');
+    expect(fs.readFileSync(path.join(seeded, 'config.toml'), 'utf-8')).toContain('my-setting');
+    expect(fs.readFileSync(path.join(seeded, 'prompts', 'review.md'), 'utf-8')).toContain('# mine');
+
+    // ...and the user's real config is still a REAL directory with its contents,
+    // not moved and not replaced by a symlink into the version home.
+    expect(fs.lstatSync(realConfig()).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('my-setting');
+  }, 180_000);
+
+  it('adopts nothing: no default, no bare shim, launcher untouched', () => {
+    expect(run('import', 'codex', '--isolated', '-y').status).toBe(0);
+    const v = importedVersion();
+
+    expect(fs.existsSync(path.join(versionsRoot(), v, '.isolated'))).toBe(true);
+    expect(fs.readlinkSync(launcher())).toBe('../lib/node_modules/@openai/codex/bin/codex.js');
+    const shims = fs.existsSync(shimsDir()) ? fs.readdirSync(shimsDir()) : [];
+    expect(shims).not.toContain('codex');          // no bare shim...
+    expect(shims).toContain(`codex@${v}`);          // ...only the versioned alias
+    // No global default recorded anywhere.
+    const devices = path.join(home, '.agents', 'devices');
+    const pins = fs.existsSync(devices)
+      ? fs.readdirSync(devices).map((d) => fs.readFileSync(path.join(devices, d, 'agents.yaml'), 'utf-8')).join('')
+      : '';
+    expect(pins).not.toMatch(/^agents:\s*\n\s+codex:/m);
+  }, 180_000);
+
+  it('skips credentials by default and says so', () => {
+    const r = run('import', 'codex', '--isolated', '-y');
+    const v = importedVersion();
+    const seeded = path.join(versionsRoot(), v, 'home', '.codex');
+
+    expect(fs.existsSync(path.join(seeded, 'auth.json'))).toBe(false);
+    expect(r.out).toContain('Credentials NOT copied');
+    expect(r.out).toContain('auth.json');
+    // The user's own credential is of course untouched.
+    expect(fs.readFileSync(path.join(realConfig(), 'auth.json'), 'utf-8')).toContain('SECRET');
+  }, 180_000);
+
+  it('--with-auth opts in explicitly', () => {
+    expect(run('import', 'codex', '--isolated', '--with-auth', '-y').status).toBe(0);
+    const v = importedVersion();
+    const seeded = path.join(versionsRoot(), v, 'home', '.codex');
+    expect(fs.readFileSync(path.join(seeded, 'auth.json'), 'utf-8')).toContain('SECRET');
+  }, 180_000);
+
+  it('is allowed while the agent is isolation-protected — plain import is not', () => {
+    // First isolated import makes codex isolated-only, hence protected.
+    expect(run('import', 'codex', '--isolated', '-y').status).toBe(0);
+    // Plain import would adopt: refused.
+    expect(run('import', 'codex', '-y').out).toContain('installed only as isolated copies');
+    // Another isolated import is still fine — it adopts nothing.
+    const again = run('import', 'codex', '--isolated', '-y');
+    expect(again.out).not.toContain('installed only as isolated copies');
+  }, 180_000);
+});

--- a/apps/cli/src/lib/import.ts
+++ b/apps/cli/src/lib/import.ts
@@ -22,7 +22,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { AgentId } from './types.js';
 import { AGENTS } from './agents.js';
-import { getVersionsDir } from './state.js';
+import { getUserAgentsDir, getVersionsDir } from './state.js';
 import { setGlobalDefault } from './versions.js';
 import { createShim, createVersionedAlias, ensureShimCurrent, switchHomeFileSymlinks } from './shims.js';
 
@@ -308,4 +308,74 @@ export function resolvePackageDirFromBinary(binaryPath: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Seed an ISOLATED version's home from the user's real `~/.<agent>` — the mirror of
+ * {@link importAgentConfig}, which adopts.
+ *
+ * The difference is the whole point: this COPIES and leaves the original in place,
+ * never symlinks it, never sets a default, never creates a shim. So an isolated copy
+ * can start from the setup the user already has instead of from nothing, which was
+ * the only way to get a working sandbox before.
+ *
+ * Credentials are skipped by default and reported, not silently included. An isolated
+ * copy is a separate principal — `agents add --isolated` already tells the user to
+ * sign in on first run — and copying tokens into it should be a choice, not a side
+ * effect of wanting your settings. `--with-auth` opts in.
+ */
+export function seedIsolatedConfigFromLocal(
+  agentId: AgentId,
+  version: string,
+  opts: { withAuth?: boolean } = {},
+): { seeded: boolean; from: string; to: string; skippedAuth: string[]; error?: string } {
+  const agent = AGENTS[agentId];
+  const configDir = agent.configDir;
+  const versionHome = path.join(getVersionsDir(), agentId, version, 'home');
+  // Mirror importAgentConfig's derivation so nested config dirs (e.g. Antigravity's
+  // ~/.gemini/antigravity-cli) land where the shim expects them.
+  const dest = path.join(versionHome, path.relative(os.homedir(), configDir));
+  const result = { seeded: false, from: configDir, to: dest, skippedAuth: [] as string[] };
+
+  if (!fs.existsSync(configDir)) return result;
+
+  // Known credential paths, relative to the config dir. `authFiles` covers the agents
+  // that declare them for cross-version carry; the rest are verified filenames for
+  // agents that do not declare any (codex `auth.json`, claude `.credentials.json`).
+  const authRel = new Set<string>([
+    ...(agent.authFiles ?? []),
+    'auth.json',
+    '.credentials.json',
+    'credentials.json',
+  ]);
+
+  try {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    const agentsDir = getUserAgentsDir();
+    const inside = agentsDir + path.sep;
+    fs.cpSync(configDir, dest, {
+      recursive: true,
+      filter: (src) => {
+        const rel = path.relative(configDir, src);
+        if (!opts.withAuth && rel && (authRel.has(rel) || rel.startsWith('credentials' + path.sep))) {
+          result.skippedAuth.push(rel);
+          return false;
+        }
+        // Same rule as the export path: a link into ~/.agents would dangle for a copy
+        // that is supposed to stand on its own.
+        try {
+          const st = fs.lstatSync(src);
+          if (st.isSymbolicLink()) {
+            const tgt = path.resolve(path.dirname(src), fs.readlinkSync(src));
+            if (tgt === agentsDir || tgt.startsWith(inside)) return false;
+          }
+        } catch { /* let cpSync surface unreadable entries */ }
+        return true;
+      },
+    });
+    result.seeded = true;
+  } catch (err) {
+    return { ...result, error: (err as Error).message };
+  }
+  return result;
 }

--- a/apps/cli/src/lib/import.ts
+++ b/apps/cli/src/lib/import.ts
@@ -24,7 +24,7 @@ import type { AgentId } from './types.js';
 import { AGENTS } from './agents.js';
 import { getUserAgentsDir, getVersionsDir } from './state.js';
 import { setGlobalDefault } from './versions.js';
-import { createShim, createVersionedAlias, ensureShimCurrent, switchHomeFileSymlinks } from './shims.js';
+import { createShim, createVersionedAlias, ensureShimCurrent, switchHomeFileSymlinks, assertIsolationBoundary } from './shims.js';
 
 export interface ImportConfigResult {
   success: boolean;
@@ -61,6 +61,12 @@ export async function importAgentConfig(
     return { success: false, error: `Invalid version: ${JSON.stringify(version)}` };
   }
 
+  // Adoption, done inline rather than via switchConfigSymlink — so it needs the gate
+  // directly. commands/import.ts checks at its entry point too (it must: it registers
+  // a normal version first, which would un-protect the agent before this runs), but
+  // an exported function that moves the user's real config must not depend on every
+  // future caller remembering.
+  assertIsolationBoundary(agentId, 'adopt your existing install');
   const agent = AGENTS[agentId];
   const configDir = agent.configDir;
   const versionsDir = getVersionsDir();

--- a/apps/cli/src/lib/isolation-boundary-report.ts
+++ b/apps/cli/src/lib/isolation-boundary-report.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+import { IsolationBoundaryError } from './shims.js';
+import { listInstalledVersions } from './versions.js';
+
+/**
+ * Turn an {@link IsolationBoundaryError} into guidance. The boundary is enforced by a
+ * throw so it cannot be forgotten; this is what keeps that from surfacing as a stack
+ * trace. The remedy is always the same shape, because the protection is derived from
+ * the isolated copies themselves: drop them and the agent is ordinary again.
+ */
+export function explainIsolationBoundary(err: IsolationBoundaryError): void {
+  const versions = listInstalledVersions(err.agent);
+  console.error(chalk.red(`\n${err.agent} is installed only as isolated copies.`));
+  console.error(chalk.gray(`  Refused: ${err.operation} — that is exactly what --isolated promises not to do.`));
+  console.error(chalk.gray('\n  To keep the sandbox and act inside it:'));
+  console.error(chalk.gray(`    agents add ${err.agent}@<version> --isolated    # another isolated copy`));
+  console.error(chalk.gray(`    agents use ${err.agent}@<version>               # pick which one 'agents run ${err.agent}' uses`));
+  console.error(chalk.gray(`    agents export ${err.agent}                      # copy its config out to your real config dir`));
+  console.error(chalk.gray('\n  To manage this agent normally instead, remove the isolated copies first:'));
+  for (const v of versions) {
+    console.error(chalk.gray(`    agents remove ${err.agent}@${v} --isolated`));
+  }
+}
+
+/** Run `fn`, converting a boundary refusal into guidance + a non-zero exit. */
+export async function withIsolationBoundary<T>(fn: () => Promise<T> | T): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof IsolationBoundaryError) {
+      explainIsolationBoundary(err);
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/apps/cli/src/lib/isolation-boundary.integration.test.ts
+++ b/apps/cli/src/lib/isolation-boundary.integration.test.ts
@@ -122,6 +122,25 @@ describe.skipIf(process.platform === 'win32')('isolation boundary', () => {
     expect(r.out).not.toContain('installed only as isolated copies');
   }, 180_000);
 
+  it("setup's own hand-rolled adoption is closed too — and scaffolding can't disarm the check", () => {
+    plant('codex', V, 'codex');
+    // The real unmanaged config is still there: isolated installs never touch it,
+    // so this is the ordinary state, and it is what setup offers to adopt.
+    fs.mkdirSync(realConfig(), { recursive: true });
+    fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "mine"\n');
+
+    // setup adopts inline (rename + symlink) without calling switchConfigSymlink, and
+    // its FIRST action creates <version>/home — which, if bare dirs counted as
+    // non-isolated installs, would flip protection off before any gate is reached.
+    const r = run('setup', '--force');
+    expect(r.out).not.toContain('is now managed');
+
+    // The real config is still a real directory holding the user's content.
+    expect(fs.lstatSync(realConfig()).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('mine');
+    expect(fs.readlinkSync(launcher())).toBe('../lib/node_modules/@openai/codex/bin/codex.js');
+  }, 180_000);
+
   it('removing the isolated copies drops protection — the inherent escape hatch', () => {
     plant('codex', V, 'codex');
     expect(run('import', 'codex').status).not.toBe(0);

--- a/apps/cli/src/lib/isolation-boundary.integration.test.ts
+++ b/apps/cli/src/lib/isolation-boundary.integration.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// The guarantee: once an agent is installed only as isolated copies, nothing the
+// framework does can adopt it. Previously `--isolated` was defined by a list of
+// things it doesn't do, which had to be re-checked at every new call site — and
+// leaked three times that way. Protection is now derived from the `.isolated`
+// markers on disk and enforced inside the primitives themselves.
+describe.skipIf(process.platform === 'win32')('isolation boundary', () => {
+  let home: string;
+  const V = '9.9.4';
+
+  const versionDir = (agent: string, v: string) =>
+    path.join(home, '.agents', '.history', 'versions', agent, v);
+  const shimsDir = () => path.join(home, '.agents', '.cache', 'shims');
+  const realConfig = (agent = '.codex') => path.join(home, agent);
+  const launcher = () => path.join(home, 'npm-global', 'bin', 'codex');
+
+  function plant(agent: string, v: string, cli: string, { isolated = true } = {}) {
+    const binDir = path.join(versionDir(agent, v), 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, cli), '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(path.join(binDir, cli), 0o755);
+    fs.mkdirSync(path.join(versionDir(agent, v), 'home', `.${agent}`), { recursive: true });
+    if (isolated) fs.writeFileSync(path.join(versionDir(agent, v), '.isolated'), 'x\n');
+  }
+
+  function run(...args: string[]): { out: string; status: number } {
+    try {
+      const out = execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), ...args], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash',
+          AGENTS_NO_NUDGE: '1', FORCE_COLOR: '0',
+          PATH: `${path.join(home, 'npm-global', 'bin')}:${process.env.PATH}`,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString('utf-8');
+      return { out, status: 0 };
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer; status?: number };
+      return { out: `${err.stdout ?? ''}${err.stderr ?? ''}`, status: err.status ?? 1 };
+    }
+  }
+
+  /** Nothing that can be hijacked has moved. */
+  function assertNothingAdopted() {
+    expect(fs.readlinkSync(launcher())).toBe('../lib/node_modules/@openai/codex/bin/codex.js');
+    expect(fs.existsSync(realConfig())).toBe(false);
+    const shims = fs.existsSync(shimsDir()) ? fs.readdirSync(shimsDir()) : [];
+    expect(shims).not.toContain('codex');
+    expect(fs.readFileSync(path.join(home, '.bashrc'), 'utf-8')).not.toContain('.agents/.cache/shims');
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'isolation-boundary-'));
+    const pkgBin = path.join(home, 'npm-global', 'lib', 'node_modules', '@openai', 'codex', 'bin');
+    fs.mkdirSync(pkgBin, { recursive: true });
+    fs.mkdirSync(path.join(home, 'npm-global', 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(pkgBin, 'codex.js'), '#!/bin/sh\necho LOCAL-CODEX\n');
+    fs.chmodSync(path.join(pkgBin, 'codex.js'), 0o755);
+    fs.symlinkSync('../lib/node_modules/@openai/codex/bin/codex.js', launcher());
+    fs.writeFileSync(path.join(home, '.bashrc'), '# user rc\n');
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('refuses `add` of a normal version — before spending a network install', () => {
+    plant('codex', V, 'codex');
+    const r = run('add', 'codex@9.9.9');
+    expect(r.out).toContain('installed only as isolated copies');
+    expect(r.out).toContain('--isolated');
+    // Refused up front: no new version dir was created.
+    expect(fs.existsSync(versionDir('codex', '9.9.9'))).toBe(false);
+    assertNothingAdopted();
+  }, 180_000);
+
+  it('refuses `import`, which exists to adopt', () => {
+    plant('codex', V, 'codex');
+    const r = run('import', 'codex');
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain('installed only as isolated copies');
+    assertNothingAdopted();
+  }, 180_000);
+
+  it('refuses `doctor --adopt`, the launcher hijack itself', () => {
+    plant('codex', V, 'codex');
+    const r = run('doctor', '--adopt', 'codex');
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain('installed only as isolated copies');
+    assertNothingAdopted();
+  }, 180_000);
+
+  it('the refusal explains both ways out', () => {
+    plant('codex', V, 'codex');
+    const out = run('import', 'codex').out;
+    expect(out).toContain(`agents add codex@<version> --isolated`);
+    expect(out).toContain(`agents export codex`);
+    expect(out).toContain(`agents remove codex@${V} --isolated`);
+  }, 180_000);
+
+  it('protection is PER-AGENT — an isolated codex constrains nothing about claude', () => {
+    plant('codex', V, 'codex');
+    plant('claude', '1.2.3', 'claude', { isolated: false });
+    // claude has a normal install, so it is not protected: setting its default works.
+    const r = run('use', 'claude@1.2.3');
+    expect(r.status).toBe(0);
+    expect(r.out).not.toContain('installed only as isolated copies');
+  }, 180_000);
+
+  it('an agent with any NORMAL version is not protected', () => {
+    plant('codex', V, 'codex');
+    plant('codex', '9.9.5', 'codex', { isolated: false });
+    // Mixed installs: codex already has an adopting install, so there is no
+    // boundary left to defend and `use` behaves normally.
+    const r = run('use', 'codex@9.9.5');
+    expect(r.out).not.toContain('installed only as isolated copies');
+  }, 180_000);
+
+  it('removing the isolated copies drops protection — the inherent escape hatch', () => {
+    plant('codex', V, 'codex');
+    expect(run('import', 'codex').status).not.toBe(0);
+
+    expect(run('remove', `codex@${V}`, '--isolated').status).toBe(0);
+    // No isolated copies left => not protected => the refusal no longer fires.
+    // (import still fails here for unrelated reasons — no package to adopt — but
+    // it must no longer be the BOUNDARY that stops it.)
+    expect(run('import', 'codex').out).not.toContain('installed only as isolated copies');
+  }, 180_000);
+});

--- a/apps/cli/src/lib/isolation-boundary.test.ts
+++ b/apps/cli/src/lib/isolation-boundary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Completeness guard for the isolation boundary.
+ *
+ * The boundary used to be a convention: every code path that could adopt an agent had
+ * to remember to check `isVersionIsolated` first. It leaked three times that way
+ * (#1412, #1423, #1439) — three different call sites, one root cause. Enforcing it
+ * inside the primitives makes it a property of the code instead.
+ *
+ * That only holds while the primitive list is complete. This test pins the list, so
+ * adding a seventh way to reach the user's launcher/config without a gate fails here
+ * rather than silently reopening the hole a year from now.
+ */
+describe('isolation boundary — the gate is on every adopting primitive', () => {
+  const read = (p: string) => fs.readFileSync(path.resolve(process.cwd(), p), 'utf-8');
+
+  // Every primitive that can carry an agent across the boundary, and the file it
+  // lives in. Adding one here without a gate fails the assertion below.
+  const GATED: Array<{ fn: string; file: string }> = [
+    { fn: 'createShim', file: 'src/lib/shims.ts' },
+    { fn: 'switchConfigSymlink', file: 'src/lib/shims.ts' },
+    { fn: 'switchHomeFileSymlinks', file: 'src/lib/shims.ts' },
+    { fn: 'adoptShadowingLauncher', file: 'src/lib/shims.ts' },
+    { fn: 'setGlobalDefault', file: 'src/lib/versions.ts' },
+  ];
+
+  it.each(GATED)('$fn calls assertIsolationBoundary before doing anything', ({ fn, file }) => {
+    const src = read(file);
+    const start = src.indexOf(`export function ${fn}`) >= 0
+      ? src.indexOf(`export function ${fn}`)
+      : src.indexOf(`export async function ${fn}`);
+    expect(start, `${fn} not found in ${file}`).toBeGreaterThan(-1);
+    // Look only at the function's opening stretch — the gate must come before work.
+    const head = src.slice(start, start + 1400);
+    expect(head).toContain('assertIsolationBoundary');
+  });
+
+  it('no OTHER exported function in shims.ts writes to the real config dir ungated', () => {
+    const src = read('src/lib/shims.ts');
+    // getAgentConfigPath() resolves the user's real ~/.<agent>. Any exported function
+    // that both resolves it and mutates the filesystem is a boundary crossing.
+    const MUTATORS = /\b(symlinkSync|renameSync|rmSync|unlinkSync|cpSync|writeFileSync)\s*\(/;
+    // Bound each body at the next function declaration of ANY kind. Slicing only to
+    // the next EXPORTED one swallows the private helpers in between and pins their
+    // mutations on whichever export happened to precede them — which reported
+    // `getConfigSymlinkVersion` (lstat + readlink, no writes) as an offender.
+    const decls = [...src.matchAll(/^(?:export )?(?:async )?function (\w+)/gm)];
+    const offenders: string[] = [];
+    for (let i = 0; i < decls.length; i++) {
+      const name = decls[i][1];
+      if (!decls[i][0].startsWith('export')) continue;
+      const body = src.slice(decls[i].index!, decls[i + 1]?.index ?? src.length);
+      if (!body.includes('getAgentConfigPath(')) continue;
+      if (!MUTATORS.test(body)) continue;
+      if (body.includes('assertIsolationBoundary')) continue;
+      offenders.push(name);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the predicate is derived from the .isolated markers, not from stored config', () => {
+    // Protection must not depend on a setting someone can leave in the wrong state —
+    // it is computed from what is actually installed.
+    const src = read('src/lib/shims.ts');
+    const start = src.indexOf('export function isIsolationProtected');
+    const body = src.slice(start, src.indexOf('\n}', start));
+    expect(body).toContain('isInstalledVersionIsolated');
+    expect(body).not.toContain('readMeta');
+  });
+});

--- a/apps/cli/src/lib/isolation-boundary.test.ts
+++ b/apps/cli/src/lib/isolation-boundary.test.ts
@@ -61,6 +61,49 @@ describe('isolation boundary — the gate is on every adopting primitive', () =>
     expect(offenders).toEqual([]);
   });
 
+  it('no file outside the gated primitives hand-rolls config-dir adoption', () => {
+    // The first version of this test scanned only shims.ts — which is exactly why
+    // setup.ts's second, hand-rolled adoption (rename + symlink inline, never calling
+    // switchConfigSymlink) went unnoticed: it bypassed every primitive gate. Scan the
+    // whole command/lib surface for the adoption SHAPE instead of trusting that all
+    // adoption goes through the primitives.
+    const roots = ['src/commands', 'src/lib'];
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of fs.readdirSync(path.resolve(process.cwd(), dir), { withFileTypes: true })) {
+        const rel = `${dir}/${e.name}`;
+        if (e.isDirectory()) walk(rel);
+        else if (e.name.endsWith('.ts') && !e.name.includes('.test.')) files.push(rel);
+      }
+    };
+    roots.forEach(walk);
+
+    const offenders: string[] = [];
+    for (const f of files) {
+      const src = read(f);
+      // Adoption's signature is precise: MOVE the user's real config dir somewhere
+      // else. Matching "renames something, and mentions configDir" is too loose — it
+      // flagged migrate.ts, which only repoints an already-symlinked config for an
+      // agent that has a recorded default pin (something a protected agent cannot
+      // have) and never moves a real directory. Match the move itself.
+      if (!/renameSync\(\s*(configDir|getAgentConfigPath\()/.test(src)) continue;
+      if (src.includes('assertIsolationBoundary')) continue;
+      offenders.push(f);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the predicate ignores scaffolding, so an adopting path cannot disarm it', () => {
+    // `isIsolationProtected` reads the versions dir. An adopting path that creates
+    // `<version>/home` before adopting would, if bare dirs counted, flip protection
+    // off with its own first line and then sail through every gate. Counting only
+    // real installs (node_modules/ or package.json present) closes that.
+    const src = read('src/lib/shims.ts');
+    const start = src.indexOf('export function isIsolationProtected');
+    const body = src.slice(start, src.indexOf('\n}', start));
+    expect(body).toMatch(/node_modules|package\.json/);
+  });
+
   it('the predicate is derived from the .isolated markers, not from stored config', () => {
     // Protection must not depend on a setting someone can leave in the wrong state —
     // it is computed from what is actually installed.

--- a/apps/cli/src/lib/shims.ts
+++ b/apps/cli/src/lib/shims.ts
@@ -2641,8 +2641,18 @@ export function isIsolationProtected(agent: AgentId): boolean {
   } catch {
     return false;
   }
-  if (dirs.length === 0) return false;
-  return dirs.every((v) => isInstalledVersionIsolated(agent, v));
+  // Count only directories that are actually an install. A bare version dir is
+  // scaffolding, not a non-isolated version — and treating it as one would disable
+  // protection at exactly the wrong moment: an adopting path that does
+  // `mkdirSync(<version>/home)` before adopting would flip this to false with its own
+  // first line and then walk straight through the gates. Ignoring scaffolding biases
+  // the predicate toward protecting, which is the safe direction to fail in.
+  const installed = dirs.filter((v) => {
+    const dir = path.join(agentVersionsDir, v);
+    return fs.existsSync(path.join(dir, 'node_modules')) || fs.existsSync(path.join(dir, 'package.json'));
+  });
+  if (installed.length === 0) return false;
+  return installed.every((v) => isInstalledVersionIsolated(agent, v));
 }
 
 /** Refuse `operation` when `agent` is isolated-only. */

--- a/apps/cli/src/lib/shims.ts
+++ b/apps/cli/src/lib/shims.ts
@@ -700,6 +700,9 @@ export function shimTargetsFor(platform: NodeJS.Platform): { bash: boolean; cmd:
  * Create a shim for an agent.
  */
 export function createShim(agent: AgentId): string {
+  // A bare shim puts agents-cli first on PATH for this agent — the opposite of what
+  // an isolated-only install promises.
+  assertIsolationBoundary(agent, 'create the bare shim');
   ensureAgentsDir();
   const shimsDir = getShimsDir();
   const agentConfig = AGENTS[agent];
@@ -1394,6 +1397,8 @@ export async function switchConfigSymlink(
   agent: AgentId,
   version: string
 ): Promise<{ success: boolean; backupPath?: string; error?: string }> {
+  // Moves the user's real ~/.<agent> aside and symlinks it into a version home.
+  assertIsolationBoundary(agent, 'repoint your real config directory');
   const configPath = getAgentConfigPath(agent);
   const versionConfigPath = getVersionConfigPath(agent, version);
 
@@ -1509,6 +1514,8 @@ export function switchHomeFileSymlinks(
   agent: AgentId,
   version: string
 ): { switched: string[]; errors: string[] } {
+  // Same, for home-level files such as ~/.claude.json.
+  assertIsolationBoundary(agent, 'repoint your home-level config files');
   const agentConfig = AGENTS[agent];
   const homeFiles = agentConfig.homeFiles;
   if (!homeFiles || homeFiles.length === 0) return { switched: [], errors: [] };
@@ -2189,6 +2196,9 @@ export function adoptShadowingLauncher(
   agent: AgentId,
   overrides?: { shadowedBy?: string; shimsDir?: string; historyDir?: string },
 ): AdoptResult {
+  // Repoints the user's OWN launcher symlink at our shim — the most invasive thing
+  // in the codebase, and the one with no isolated-scoped equivalent at all.
+  assertIsolationBoundary(agent, 'adopt your launcher');
   const shimsDir = overrides?.shimsDir ?? getShimsDir();
   const shimPath = path.join(shimsDir, AGENTS[agent].cliCommand);
   const shimReal = canonical(shimPath);
@@ -2592,6 +2602,52 @@ export function listAgentsWithInstalledVersions(): AgentId[] {
 
 function isInstalledVersionIsolated(agent: AgentId, version: string): boolean {
   return fs.existsSync(path.join(getVersionsDir(), agent, version, '.isolated'));
+}
+
+/**
+ * Thrown when an operation would carry an isolated-only agent across the isolation
+ * boundary. Callers that can explain the situation catch it and print guidance; the
+ * throw is what makes the boundary a property of the code rather than a convention
+ * every future call site has to remember.
+ */
+export class IsolationBoundaryError extends Error {
+  constructor(readonly agent: AgentId, readonly operation: string) {
+    super(
+      `${agent} is installed only as isolated copies; "${operation}" would adopt it into your local setup.`,
+    );
+    this.name = 'IsolationBoundaryError';
+  }
+}
+
+/**
+ * True when EVERY installed version of `agent` is isolated (and at least one is).
+ *
+ * This is the switch: installing with `--isolated` is itself the act of opting in,
+ * so there is no mode to set and none to forget. It is per-agent, so an isolated
+ * codex constrains nothing about claude. And the escape hatch is inherent — remove
+ * the isolated copies and the agent is ordinary again, which means the state that
+ * grants protection is the same state you delete to drop it.
+ *
+ * An agent with any NORMAL version is not protected: that install already owns the
+ * launcher and the real `~/.<agent>`, so there is no boundary left to defend.
+ */
+export function isIsolationProtected(agent: AgentId): boolean {
+  const agentVersionsDir = path.join(getVersionsDir(), agent);
+  let dirs: string[];
+  try {
+    dirs = fs.readdirSync(agentVersionsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return false;
+  }
+  if (dirs.length === 0) return false;
+  return dirs.every((v) => isInstalledVersionIsolated(agent, v));
+}
+
+/** Refuse `operation` when `agent` is isolated-only. */
+export function assertIsolationBoundary(agent: AgentId, operation: string): void {
+  if (isIsolationProtected(agent)) throw new IsolationBoundaryError(agent, operation);
 }
 
 export function listAgentsWithNonIsolatedInstalledVersions(): AgentId[] {

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -36,7 +36,14 @@ import { AGENTS, agentConfigDirName, getAccountEmail, getMcpConfigPathForHome, p
 import { getDefaultPermissionSet, applyPermissionsToVersion as applyPermsToVersion, discoverPermissionGroups, getTotalPermissionRuleCount, buildPermissionsFromGroups, CODEX_RULES_FILENAME, getActivePermissionPresetName, readPermissionPresetRecipe, PERMISSION_PRESET_ENV_VAR } from './permissions.js';
 import { installMcpServers, parseMcpServerConfig, isProjectMcpTrusted } from './mcp.js';
 import { markdownToToml } from './convert.js';
-import { createVersionedAlias, removeVersionedAlias, switchConfigSymlink, getConfigSymlinkVersion, ensureClaudeInsideSymlink } from './shims.js';
+import {
+  createVersionedAlias,
+  removeVersionedAlias,
+  switchConfigSymlink,
+  getConfigSymlinkVersion,
+  ensureClaudeInsideSymlink,
+  assertIsolationBoundary,
+} from './shims.js';
 import { importInstallScriptBinary } from './import.js';
 import { IS_WINDOWS, composeWin32CommandLine } from './platform/index.js';
 import { listInstalledSubagents, transformSubagentForClaude, syncSubagentToOpenclaw } from './subagents.js';
@@ -1284,6 +1291,14 @@ export function getGlobalDefault(agent: AgentId): string | null {
  * Set the global default version for an agent.
  */
 export function setGlobalDefault(agent: AgentId, version: string | undefined): void {
+  // A global default is what owns the launcher and arms the self-heal `shadowing`
+  // check, so recording one for an isolated-only agent is the root of the original
+  // breach. Clearing is always allowed — `removeVersion` legitimately clears a
+  // default as the last non-isolated version goes away, which is the very moment
+  // an agent BECOMES isolated-only.
+  if (version !== undefined) {
+    assertIsolationBoundary(agent, 'set a global default');
+  }
   const meta = readMeta();
   if (!meta.agents) {
     meta.agents = {};


### PR DESCRIPTION
Closes the main items of #1444. Independent of #1445/#1446 (both merged).

Two commits, shipped together because the second exists to answer a gap the first creates.

---

# 1. The boundary

## Problem

`--isolated` is defined by what it *doesn't* do — no global default, no bare shim, no config symlink, no PATH edit, no launcher adoption. A definition of that shape can't be shown to be complete: every code path that could adopt an agent has to independently remember to check. It leaked three times, in three different call sites, from that one cause — #1412, #1423, #1439.

## Change

Protection is derived from state that already exists on disk:

```ts
isIsolationProtected(agent)   // >=1 installed version, and every one is isolated
```

No mode to set and none to forget — installing with `--isolated` **is** the opt-in. Per-agent, so an isolated codex constrains nothing about claude. And the escape hatch is inherent: remove the isolated copies and the agent is ordinary again, so the state that grants protection is the state you delete to drop it. No `--force` flag, nothing left switched off.

Five primitives can carry an agent across the boundary. Each calls `assertIsolationBoundary` before doing any work:

| Primitive | What it would do |
|---|---|
| `setGlobalDefault` | records the default that owns the launcher and arms `shadowing` |
| `createShim` | puts a bare `<cli>` first on PATH |
| `switchConfigSymlink` | moves the real `~/.<agent>` aside, symlinks it into a version home |
| `switchHomeFileSymlinks` | same for `~/.claude.json` and friends |
| `adoptShadowingLauncher` | repoints the user's own launcher symlink at our shim |

Clearing a global default stays allowed — `removeVersion` clears one as the last non-isolated version goes away, which is the moment an agent *becomes* protected.

**Verified the gate can't misfire on automatic paths:** every self-heal, `refresh`, prune-survivor and `ensureAgentRunnable` caller already filters isolated versions, so it only ever fires on deliberate adoption.

## Why the command-level checks are not redundant

`add` and `import` also check at their entry points, and one of them is load-bearing.

**`import` registers the adopted install as a NORMAL version and only then sets the default.** By the time it reaches `setGlobalDefault` the agent has a non-isolated version and is no longer protected — the primitive gate reads state at call time and let the whole adoption through. The integration test caught it doing exactly that (`Codex vLOCAL-CODEX is now managed.` on a protected agent).

A boundary has to be evaluated against the state *before* the command mutates it. That's the argument for both layers, and I'd rather state it than have it look like belt-and-braces.

`doctor --adopt` is the one operation with no isolated-scoped equivalent — hijacking PATH is its entire purpose, and isolated copies are deliberately absent from PATH. It refuses and explains.

---

# 2. The supported way in

The boundary closes `agents import` for a protected agent — correctly, since adoption is its purpose. But isolation was already a cold start (a new isolated copy begins empty), so that removes the one command that could have carried an existing setup across.

`agents import <agent> --isolated` is the mirror. Where a plain import MOVES `~/.<agent>` into a version home, symlinks the original away, sets the default and creates a shim, this COPIES:

```
~/.codex  ──copy──▶  versions/codex/1.2.3/home/.codex     (original untouched)
```

and finalizes the way `agents add --isolated` does — versioned alias plus marker, nothing else. It reuses `importAgentBinary`, which was already non-adopting; only `importAgentConfig`/`finalizeImport` adopt, so the seam existed.

**Credentials are skipped by default and named in the output**, not silently included. An isolated copy is a separate principal that signs in on its own — `agents add --isolated` already tells users that — so copying tokens in should be a choice, not a side effect of wanting your settings. `--with-auth` opts in.

The credential list is the union of the agent's declared `authFiles` and verified filenames for agents that declare none (codex `auth.json`, claude `.credentials.json`, plus a `credentials/` prefix). `authFiles` alone is not an inventory: only three agents declare it, and for a different purpose — carrying sign-in across version homes.

---

## Tests

**`isolation-boundary.integration.test.ts`** (7/7) — real CLI, throwaway `HOME` with an npm-layout local install. Every case asserts the launcher symlink, `~/.codex`, the shims dir and `.bashrc` are untouched:
- `add` of a normal version refused *before* the network install (no version dir created)
- `import` and `doctor --adopt` refused
- the refusal names both ways out
- **per-agent**: an isolated codex doesn't block `use claude@…`
- an agent with any normal version is *not* protected
- removing the isolated copies drops protection — the escape hatch works

**`import-isolated.integration.test.ts`** (5/5) — settings copied in while the real config stays a real directory with its contents; nothing adopted (no default, no bare shim, launcher untouched, only the versioned alias); credentials skipped and reported; `--with-auth` opts in; allowed while protected where plain import is refused.

**`isolation-boundary.test.ts`** (7/7) — completeness guard. Pins the primitive list and scans `shims.ts` for any *other* exported function that both resolves the real config dir and mutates the filesystem without the gate, so a sixth way in fails here rather than reopening the hole later. Also asserts the predicate is computed from the `.isolated` markers rather than stored config, since a setting could be left in the wrong state.

One note on that scanner: its first draft reported `getConfigSymlinkVersion` (lstat + readlink, no writes). Slicing each body to the next *exported* function swallowed the private helpers between and pinned their mutations on whichever export preceded them. Bounded at the next declaration of any kind.

Full suite: **6606 pass**. The 4 failures are pre-existing codex `exec`/`models` tests that read real local state and pass with a clean `HOME` — unrelated to this diff, and present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)