### PR TITLE
fix(usage): never rotate the single-use Claude token to read usage (RUSH-1822)

### DIFF
--- a/apps/cli/.changelog/next/claude-usage-no-rotate.md
+++ b/apps/cli/.changelog/next/claude-usage-no-rotate.md
@@ -1,0 +1,14 @@
+- **Reading Claude usage no longer rotates the token and logs your fleet out.**
+  `getClaudeUsageInfo` refreshed the OAuth token just to read the usage endpoint
+  (`getClaudeAccessToken`, `usage.ts`) — and Claude's refresh token is single-use
+  and rotates server-side, so with one account signed into several machines that
+  background refresh (fired by the stale-while-revalidate usage cache and by
+  `agents run`'s default "balanced" rotation on every unpinned run) invalidated
+  every other box's copy, dropping the fleet to "run /login". This is the
+  RUSH-1822 stampede, which was fixed for the 3-minute health probe but left live
+  in the usage/run hot path. Usage reads are now strictly read-only: a new pure
+  `claudeUsageAccessTokenNoRefresh` uses the stored access token and, when it is
+  within the refresh leeway, reports "no usage right now" instead of rotating —
+  exactly mirroring `probeClaudeStatus`. The single legitimate refresh stays on
+  the real `claude` run, never a usage read. Source: `apps/cli/src/lib/usage.ts`,
+  `apps/cli/src/lib/usage.test.ts`.

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { claudeAccessTokenNeedsRefresh } from './usage.js';
+import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh } from './usage.js';
 
 const LEEWAY_MS = 5 * 60 * 1000;
 const NOW = 1_800_000_000_000; // fixed epoch ms so the tests are deterministic
@@ -29,5 +29,35 @@ describe('claudeAccessTokenNeedsRefresh', () => {
 
   it('is true for an already-expired token', () => {
     expect(claudeAccessTokenNeedsRefresh(NOW - 60_000, NOW)).toBe(true);
+  });
+});
+
+describe('claudeUsageAccessTokenNoRefresh', () => {
+  // Uses the real Date.now() internally (via claudeAccessTokenNeedsRefresh), so
+  // express expiries relative to now.
+  const now = Date.now();
+
+  it('returns the token when it is comfortably fresh', () => {
+    expect(claudeUsageAccessTokenNoRefresh({ accessToken: 'tok-abc', expiresAt: now + 60 * 60 * 1000 })).toBe('tok-abc');
+  });
+
+  it('returns the token when the expiry is unknown (never forces a refresh)', () => {
+    expect(claudeUsageAccessTokenNoRefresh({ accessToken: 'tok-abc', expiresAt: null })).toBe('tok-abc');
+  });
+
+  it('returns null (NOT a rotating refresh) for a near-expiry token', () => {
+    // The regression this guards: a usage read must never rotate Claude's
+    // single-use refresh token. A token within the 5-min leeway yields "no usage
+    // now" (null) instead of refreshing and logging every other fleet box out.
+    expect(claudeUsageAccessTokenNoRefresh({ accessToken: 'tok-abc', expiresAt: now + 60_000 })).toBeNull();
+  });
+
+  it('returns null for an already-expired token (still never refreshes)', () => {
+    expect(claudeUsageAccessTokenNoRefresh({ accessToken: 'tok-abc', expiresAt: now - 60_000 })).toBeNull();
+  });
+
+  it('returns null for a missing/empty access token', () => {
+    expect(claudeUsageAccessTokenNoRefresh({ accessToken: '', expiresAt: now + 60 * 60 * 1000 })).toBeNull();
+    expect(claudeUsageAccessTokenNoRefresh({ accessToken: '   ', expiresAt: now + 60 * 60 * 1000 })).toBeNull();
   });
 });

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -572,6 +572,29 @@ async function getCodexUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   }
 }
 
+/**
+ * The access token to use for a READ-ONLY Claude usage fetch, or null when the
+ * stored token is within the refresh leeway.
+ *
+ * Returns null instead of refreshing on purpose. Claude's refresh token is
+ * single-use and rotates server-side on every refresh; with one account signed
+ * into several machines, refreshing here would stampede that one token and
+ * silently invalidate every other holder — the RUSH-1822 failure, except in the
+ * usage path (fired in the background by the SWR cache and by `agents run`'s
+ * default "balanced" rotation on every unpinned run) rather than the health
+ * probe. So a usage read must never rotate: a near-expiry token yields "no usage
+ * right now" instead of a fleet-wide logout. Mirrors {@link probeClaudeStatus};
+ * the single legitimate refresh belongs to the actual claude run, never a read.
+ * Pure — unit-tested.
+ */
+export function claudeUsageAccessTokenNoRefresh(
+  oauth: Pick<ClaudeOauthCredentials, 'accessToken' | 'expiresAt'>,
+): string | null {
+  if (claudeAccessTokenNeedsRefresh(oauth.expiresAt ?? null)) return null;
+  const token = oauth.accessToken?.trim();
+  return token ? token : null;
+}
+
 /** Fetch Claude usage via the Anthropic OAuth usage API. */
 async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
@@ -586,7 +609,8 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       return { snapshot: null, error: null };
     }
 
-    const accessToken = await getClaudeAccessToken(oauth, options?.home);
+    // Read-only: never refresh a single-use token just to read usage (RUSH-1822).
+    const accessToken = claudeUsageAccessTokenNoRefresh(oauth);
     if (!accessToken) {
       return { snapshot: null, error: null };
     }


### PR DESCRIPTION
## Problem — the "wake up logged out on every machine" bug

With one Claude account shared across a fleet, users wake to Claude logged out on **every** box at once. Investigation (3 parallel agents + overnight forensics on this fleet) traced it to a two-stage failure:

1. **8h access-token TTL + overnight idle** → every box's token time-expires (soft; would self-refresh).
2. **Single-use refresh-token rotation** → the *hard* `run /login` everywhere. When boxes wake, unpinned routines fire `agents run claude` on the default **balanced** strategy, which reads usage to load-pick. Reading usage called `getClaudeAccessToken` → **refreshed** the OAuth token. Claude's refresh token is single-use and rotates server-side, so the first box to refresh **invalidates every other box** sharing that account.

**Forensic smoking gun:** on this fleet, `yosemite-s1`'s `getrush.ai` token showed **revoked while its access token was still time-valid** — because another box refreshed the same account and rotated s1's refresh token out. Invalidation-by-rotation, provably not time expiry.

This is the **RUSH-1822 stampede** — already fixed for the 3-minute daemon health probe (`probeClaudeStatus` never refreshes), but the same rotating refresh was left live in the usage/run hot path.

## Root chokepoint

`getClaudeAccessToken` (the rotating refresh) has exactly two callers: `getClaudeUsageInfo:589` (the live usage/selection path, fired by the SWR cache + balanced rotation) and `isClaudeAuthValid` (dead — zero live callers; removed from `collectRunCandidates` per `rotate.ts:348`). So a single spot rotates the token for reads. The actual `claude` run doesn't use it — the binary manages its own auth.

## Fix

Usage reads are now strictly read-only, mirroring the blessed `probeClaudeStatus` pattern. New pure, unit-tested `claudeUsageAccessTokenNoRefresh(oauth)`:
- token comfortably fresh (or unknown expiry) → returns it, usage fetch proceeds as before;
- within the 5-min refresh leeway / expired → returns `null` → `getClaudeUsageInfo` reports "no usage right now" **instead of rotating**.

The single legitimate refresh stays on the real `claude` run, never a usage read. agents-cli no longer rotates Claude tokens for usage at all.

## Tests

`usage.test.ts` — 6 new cases pin the invariant: near-expiry and expired tokens return `null` (no rotation), fresh/unknown-expiry return the token, empty token → null. All deterministic, no mocks (no-mock policy), reusing the already-tested `claudeAccessTokenNeedsRefresh` predicate. `tsc` clean; `usage.test.ts` 10/10; `rotate.test.ts` 23/23.

## Scope note

This removes the *code-level* rotation trigger. The complementary operational fix (put every run on the non-rotating `claude setup-token` and stop sharing the rotating per-account OAuth) is a fleet-config change, separate from this PR.
