### PR TITLE
fix(import): make the version flag reachable (`--as`), and force overwrites under Bun

### DIFF
--- a/apps/cli/.changelog/next/import-as-flag.md
+++ b/apps/cli/.changelog/next/import-as-flag.md
@@ -1,0 +1,13 @@
+- **`agents import <agent> --as <version>` — the version flag now actually works.** The
+  option was declared as `--version <version>`, which the program-level `.version(VERSION)`
+  claims globally: `agents import codex --version 1.2.3` printed the CLI's own version and
+  exited without importing. It had been unreachable since it was introduced, and the
+  "could not determine version" error advised passing it. Renamed to `--as`, which reaches
+  the command. This also makes `agents import <agent> --isolated --as <version>` re-seed an
+  *existing* isolated copy from your current local config, instead of only ever creating a
+  new copy at whatever version happens to be installed locally.
+- **Fixed a silent no-op in config copying under the compiled binary.** `fs.cpSync` defaults
+  to `force: true`, but Bun drops that default when a `filter` is supplied — so copies that
+  strip symlinks left existing destination files untouched. `dist/bin/agents` is
+  bun-compiled, so this affected a shipped path, not just tests. Now passed explicitly in
+  `config-transfer.ts` and `import.ts`.

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -47,9 +47,10 @@ import {
 import { isPromptCancelled, isInteractiveTerminal } from './utils.js';
 
 interface ImportOptions {
+  /** Version label to import as. Named `--as`, not `--version`: see registerImportCommand. */
+  as?: string;
   isolated?: boolean;
   withAuth?: boolean;
-  version?: string;
   fromPath?: string;
   yes?: boolean;
 }
@@ -157,7 +158,7 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
     }
   }
 
-  let version = opts.version;
+  let version = opts.as;
   if (!version) {
     if (!useDirectBinaryImport && globalPath) {
       try {
@@ -180,7 +181,7 @@ async function runImport(agentArg: string, opts: ImportOptions): Promise<void> {
 
   if (!version) {
     console.error(chalk.red(`Could not determine version for ${agentLabel(agentId)}.`));
-    console.error(chalk.gray('Pass --version <version> explicitly.'));
+    console.error(chalk.gray('Pass --as <version> explicitly.'));
     process.exit(1);
   }
   if (!isValidImportVersion(version)) {
@@ -321,7 +322,13 @@ export function registerImportCommand(program: Command): void {
     .command('import')
     .argument('<agent>', 'Agent id (e.g. openclaw, claude, codex)')
     .description('Import an existing unmanaged agent install into agents-cli')
-    .option('--version <version>', 'Pin a version label (otherwise read from package.json)')
+    // NOT `--version`. The program declares `.version(VERSION)` (src/index.ts), which
+    // claims `-V, --version` globally and wins over a subcommand option of the same
+    // name — so `agents import codex --version 1.2.3` printed the CLI's own version
+    // and exited without importing anything. The flag had been unreachable since it
+    // was introduced, and the "could not determine version" error even advised using
+    // it. Renamed so it actually reaches the command.
+    .option('--as <version>', 'Version label to import as (otherwise read from package.json)')
     .option('--from-path <path>', 'Path to the npm package dir (otherwise auto-detected from PATH)')
     .option('--isolated', 'Copy the install into a self-contained isolated version instead of adopting it')
     .option('--with-auth', 'With --isolated, also copy credentials into the sandbox (skipped by default)')
@@ -329,7 +336,7 @@ export function registerImportCommand(program: Command): void {
     .addHelpText('after', `
 Examples:
   $ agents import openclaw                          Auto-detect via PATH
-  $ agents import openclaw --version 2026.3.8       Pin a version label
+  $ agents import openclaw --as 2026.3.8            Pin a version label
   $ agents import openclaw --from-path /opt/homebrew/lib/node_modules/openclaw
 
   # installScript-based agents (curl/brew installers, no npm package):
@@ -337,6 +344,11 @@ Examples:
   $ agents import antigravity                       Adopt ~/.local/bin/agy
   $ agents import cursor                            Adopt ~/.local/bin/cursor-agent
   $ agents import antigravity --from-path ~/.local/bin/agy
+
+  # Copy your setup into a sandbox instead of adopting it:
+  $ agents import codex --isolated                  New isolated copy at the local version
+  $ agents import codex --isolated --as 0.146.0     Re-seed an EXISTING isolated copy
+  $ agents import codex --isolated --with-auth      ...and share credentials with it
 
 When to use:
   When an agent CLI is already installed globally and you want to bring it

--- a/apps/cli/src/lib/config-transfer.ts
+++ b/apps/cli/src/lib/config-transfer.ts
@@ -38,6 +38,10 @@ export function copyDirStrippingAgentsSymlinks(source: string, dest: string, age
   const inside = agentsDir + path.sep;
   fs.cpSync(source, dest, {
     recursive: true,
+    // `force: true` is Node's default, but Bun drops it when a `filter` is supplied —
+    // existing files are then silently left alone. `dist/bin/agents` is bun-compiled,
+    // so this is a production path, not just a test artifact. State it explicitly.
+    force: true,
     filter: (src) => {
       try {
         const st = fs.lstatSync(src);

--- a/apps/cli/src/lib/import-version-flag.integration.test.ts
+++ b/apps/cli/src/lib/import-version-flag.integration.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// `agents import <agent> --version <v>` was unreachable from the day it was added.
+// The program declares `.version(VERSION)`, which claims `-V, --version` globally and
+// wins over a same-named subcommand option — so the command printed the CLI's own
+// version and exited without importing. The "could not determine version" error even
+// advised passing the flag that could not work.
+//
+// Renamed to `--as`. These tests assert the flag actually reaches the command, which
+// is the part that silently regressed before.
+describe.skipIf(process.platform === 'win32')('agents import --as', () => {
+  let home: string;
+
+  const versionsRoot = () => path.join(home, '.agents', '.history', 'versions', 'codex');
+  const realConfig = () => path.join(home, '.codex');
+
+  function run(...args: string[]): { out: string; status: number } {
+    try {
+      const out = execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), ...args], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash',
+          AGENTS_NO_NUDGE: '1', FORCE_COLOR: '0',
+          PATH: `${path.join(home, 'npm-global', 'bin')}:${process.env.PATH}`,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString('utf-8');
+      return { out, status: 0 };
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer; status?: number };
+      return { out: `${err.stdout ?? ''}${err.stderr ?? ''}`, status: err.status ?? 1 };
+    }
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'import-as-'));
+    const pkgDir = path.join(home, 'npm-global', 'lib', 'node_modules', '@openai', 'codex');
+    fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true });
+    fs.mkdirSync(path.join(home, 'npm-global', 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+      name: '@openai/codex', version: '0.144.6', bin: { codex: 'bin/codex.js' },
+    }));
+    fs.writeFileSync(path.join(pkgDir, 'bin', 'codex.js'), '#!/bin/sh\necho LOCAL\n');
+    fs.chmodSync(path.join(pkgDir, 'bin', 'codex.js'), 0o755);
+    fs.symlinkSync('../lib/node_modules/@openai/codex/bin/codex.js',
+      path.join(home, 'npm-global', 'bin', 'codex'));
+    fs.mkdirSync(realConfig(), { recursive: true });
+    fs.writeFileSync(path.join(realConfig(), 'config.toml'), 'model = "my-local-setting"\n');
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('reaches the command instead of printing the CLI version', () => {
+    const r = run('import', 'codex', '--isolated', '--as', '9.9.9', '-y');
+    // The regression: this used to be the CLI's own version and nothing else.
+    expect(r.out).not.toMatch(/^\d+\.\d+\.\d+\s*$/);
+    expect(fs.existsSync(path.join(versionsRoot(), '9.9.9'))).toBe(true);
+  }, 180_000);
+
+  it('imports under the given label rather than the detected one', () => {
+    expect(run('import', 'codex', '--isolated', '--as', '9.9.9', '-y').status).toBe(0);
+    // Local package.json says 0.144.6; --as wins.
+    expect(fs.readdirSync(versionsRoot())).toEqual(['9.9.9']);
+  }, 180_000);
+
+  it('re-seeds an EXISTING isolated copy at a different version than the local one', () => {
+    // The case this unblocks: a sandbox on 0.146.0 while the local install is 0.144.6.
+    //
+    // Doubles as the regression test for a Bun quirk: `fs.cpSync` drops its default
+    // `force: true` when a `filter` is supplied, so the seed silently left existing
+    // files alone. It only shows up here because this test spawns the CLI under bun
+    // (and `dist/bin/agents` is bun-compiled) — vitest itself runs on node, where the
+    // default holds and a unit test would pass either way.
+    const target = path.join(versionsRoot(), '0.146.0');
+    fs.mkdirSync(path.join(target, 'node_modules', '.bin'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'home', '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(target, 'package.json'), '{}');
+    fs.writeFileSync(path.join(target, 'node_modules', '.bin', 'codex'), '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(path.join(target, 'node_modules', '.bin', 'codex'), 0o755);
+    fs.writeFileSync(path.join(target, '.isolated'), 'x\n');
+    fs.writeFileSync(path.join(target, 'home', '.codex', 'config.toml'), 'model = "stale"\n');
+
+    expect(run('import', 'codex', '--isolated', '--as', '0.146.0', '-y').status).toBe(0);
+
+    // The existing sandbox picked up the local settings...
+    expect(fs.readFileSync(path.join(target, 'home', '.codex', 'config.toml'), 'utf-8'))
+      .toContain('my-local-setting');
+    // ...no second copy was created at the local version...
+    expect(fs.readdirSync(versionsRoot()).sort()).toEqual(['0.146.0']);
+    // ...and the real config is still a real directory, untouched.
+    expect(fs.lstatSync(realConfig()).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(realConfig(), 'config.toml'), 'utf-8')).toContain('my-local-setting');
+  }, 180_000);
+
+  it('still auto-detects the version when --as is omitted', () => {
+    expect(run('import', 'codex', '--isolated', '-y').status).toBe(0);
+    expect(fs.readdirSync(versionsRoot())).toEqual(['0.144.6']);
+  }, 180_000);
+});

--- a/apps/cli/src/lib/import.ts
+++ b/apps/cli/src/lib/import.ts
@@ -361,6 +361,10 @@ export function seedIsolatedConfigFromLocal(
     const inside = agentsDir + path.sep;
     fs.cpSync(configDir, dest, {
       recursive: true,
+      // `force: true` is Node's default, but Bun drops it when a `filter` is supplied —
+      // existing files are then silently left alone. `dist/bin/agents` is bun-compiled,
+      // so this is a production path, not just a test artifact. State it explicitly.
+      force: true,
       filter: (src) => {
         const rel = path.relative(configDir, src);
         if (!opts.withAuth && rel && (authRel.has(rel) || rel.startsWith('credentials' + path.sep))) {


### PR DESCRIPTION
Two bugs, both found while checking whether a gap I'd assumed existed actually did. It didn't — the flag was there, just broken.

## 1. `agents import <agent> --version <v>` never worked

The program declares `.version(VERSION)` (`src/index.ts`), which claims `-V, --version` globally and wins over a same-named subcommand option:

```
$ agents import codex --version 9.9.9
1.20.73
```

It prints the CLI's own version and exits without importing. The option has been there since `26a70b0f` and has been unreachable the entire time — and the "could not determine version" error advises passing it:

```ts
console.error(chalk.gray('Pass --version <version> explicitly.'));   // cannot work
```

Renamed to `--as <version>`, with the reason recorded at the declaration so it doesn't get renamed back.

The resolution logic already honoured an explicit version — it simply never received one. So this also unblocks:

```
agents import codex --isolated --as 0.146.0
```

which re-seeds an **existing** isolated copy from your current local config, instead of only ever creating a new copy at whatever version is installed locally. That's the case that matters when the sandbox is deliberately on a different version from the local install.

**Alternative considered:** `program.enablePositionalOptions()` + `passThroughOptions()` is commander's general fix for this class, and would repair any other shadowed subcommand option too. I didn't take it — it changes parsing behaviour for every command in the CLI, and I couldn't validate that blast radius with confidence. Renaming is contained. Happy to do the general fix instead if you'd prefer it.

## 2. `fs.cpSync` silently skips overwrites under Bun

`force: true` is Node's default, but **Bun drops it when a `filter` is supplied**:

```
bun:   cpSync(src, dst, {recursive, filter}) -> destination unchanged
node:  same call                             -> destination overwritten
```

This is not a test-only concern: `dist/bin/agents` is bun-compiled, so it's a shipped path. Config copies that strip `~/.agents` symlinks were leaving existing destination files untouched.

Passed explicitly at both filtered call sites — `copyDirStrippingAgentsSymlinks` (`config-transfer.ts`) and `seedIsolatedConfigFromLocal` (`import.ts`).

## Tests

`import-version-flag.integration.test.ts`, 4/4:

- `--as` reaches the command instead of printing the CLI version
- imports under the given label rather than the detected one
- **re-seeds an existing isolated copy** at a version different from the local install, creating no second copy, with the real config left a real directory
- still auto-detects when `--as` is omitted

The re-seed case is the regression test for (2) as well as the feature test for (1) — it spawns the CLI under bun, which is the only place the quirk appears. A unit test would have passed either way, since vitest runs on node. That's also why (2) went unnoticed: everything green, wrong behaviour in the compiled binary.

Full suite: 6613 pass. The 4 failures are pre-existing codex `exec`/`models` tests that read real local state and pass with a clean `HOME` — present on `main`, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)