### PR TITLE
docs(cli): Droid Factory Missions are invoke-only — leave workflows false (RUSH-1864)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1864.md
+++ b/apps/cli/.changelog/next/RUSH-1864.md
@@ -1,0 +1,7 @@
+- **Document that Droid Factory Missions are invoke-only (RUSH-1864).** Probed
+  droid v0.177.0 (self-updating; ticket cited v0.161.0) and Factory docs:
+  Missions run via `/missions` or `droid exec --mission` (optional `-f` is a
+  prompt file, not a named template). `~/.factory/missions/<sessionId>/` is
+  runtime state only — no auto-discovery dir agents-cli can populate — so
+  `workflows` stays `false` with an evidence comment rather than inventing a
+  writer target. Source: `apps/cli/src/lib/agents.ts`, `apps/cli/tests/agents.test.ts`.

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -606,6 +606,24 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
   // `.factory-plugin/` (it also reads `.claude-plugin/` for compatibility) — set
   // pluginManifestDir so syncPluginToVersion mirrors the manifest into it, the
   // same pattern codex uses with `.codex-plugin`.
+  //
+  // Workflows / Factory Missions (RUSH-1864, probed droid v0.177.0; ticket cited
+  // v0.161.0 — self-updating, no pinnable semver): Factory ships genuine multi-
+  // step orchestration ("Missions") via `/missions` (interactive) and
+  // `droid exec --mission` (headless; optional `-f <prompt.md>` is a *prompt*
+  // file, not a named mission template). Docs:
+  // https://docs.factory.ai/cli/features/missions and
+  // https://docs.factory.ai/docs/droid-exec/overview (Mission Mode).
+  //
+  // Mission state may land under `~/.factory/missions/<sessionId>/` at runtime
+  // (`getMissionsDir` = join(home, ".factory", "missions") + per-session
+  // mission.md / features.json / progress_log.jsonl) — that is **session
+  // runtime state**, not a discovery directory of installable named workflows.
+  // There is no discoverMission / template registry, and a cold install has no
+  // `~/.factory/missions/` until a mission is run. agents-cli's workflows
+  // capability means "sync WORKFLOW.md into an auto-discovered dir" — Droid
+  // has no such dir, so workflows stays false (invoke-only; do not fabricate a
+  // writer target).
   droid: {
     id: 'droid',
     name: 'Droid',
@@ -638,6 +656,7 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
       plugins: true,
       subagents: true,
       rules: { file: 'AGENTS.md' },
+      // Factory Missions are invoke-only — no installable discovery dir (RUSH-1864).
       workflows: false,
       memory: false,
       modes: ['plan', 'edit', 'auto', 'skip'],

--- a/apps/cli/tests/agents.test.ts
+++ b/apps/cli/tests/agents.test.ts
@@ -59,9 +59,14 @@ describe('droid (Factory AI)', () => {
     expect(capableAgents('hooks')).toContain('droid');
     expect(capableAgents('plugins')).toContain('droid');
     expect(capableAgents('skills')).toContain('droid');
-    // No Droid equivalent for workflows — keep it false so the registry
-    // assertion doesn't demand a writer we can't provide.
+    // RUSH-1864: Factory Missions (`/missions`, `droid exec --mission`) are a
+    // real multi-step orchestrator, but they are invoke-only. There is no
+    // auto-discovered install dir for named mission templates (cold install has
+    // no ~/.factory/missions/; that path is per-session runtime state only).
+    // Keep workflows:false so the registry never demands a writer we can't
+    // provide — do not fabricate a discovery dir.
     expect(capableAgents('workflows')).not.toContain('droid');
+    expect(AGENTS.droid.capabilities.workflows).toBe(false);
   });
 
   it('resolves MCP config to ~/.factory/mcp.json and parses the written shape back', () => {


### PR DESCRIPTION
## Summary

RUSH-1864 asked to wire `workflows` for Droid if Factory Missions are installable into an auto-discovered directory. After probing droid **v0.177.0** and Factory docs, **they are not**.

### What Missions are

- Interactive: `/missions`
- Headless: `droid exec --mission` (requires `--auto high` or `--skip-permissions-unsafe`)
- `-f <path>` is a **prompt file**, not a named mission template from a registry

Docs: https://docs.factory.ai/cli/features/missions · https://docs.factory.ai/docs/droid-exec/overview

### Why workflows stays false

agents-cli's `workflows` capability means: install `WORKFLOW.md` into a dir the harness **auto-discovers**. Droid has no such dir.

- Cold install: **no** `~/.factory/missions/`
- Binary `getMissionsDir` → `~/.factory/missions/<sessionId>/` is **runtime state** for an active mission (`mission.md`, `features.json`, …), created when a mission is accepted — not a catalog of installable templates
- No `discoverMission` / template registry in the binary

Per the ticket: if missions are pass-by-path / invoke-only, leave `workflows: false` with a precise evidence comment — **do not fabricate a discovery dir**.

### Changes

- Evidence comment on the droid block in `apps/cli/src/lib/agents.ts` (RUSH-1864)
- Strengthen the droid capability test to assert `workflows: false` with the same rationale
- Changelog fragment `.changelog/next/RUSH-1864.md`

## Test plan

- [x] `bun install && bun run build` (tsc) in worktree
- [x] `bun run test tests/agents.test.ts src/lib/workflows.test.ts src/lib/__tests__/capabilities.test.ts` (121 pass)
- [x] Worktree `node dist/index.js inspect droid` → `workflows  ✗ (unsupported)`
- [x] Probed: no `~/.factory/missions`; `droid exec --mission` is mode-flag only

## Verification

Probed install: droid v0.177.0 (self-updating; ticket cited v0.161.0).

```
$ test ! -e ~/.factory/missions && echo "no ~/.factory/missions"
no ~/.factory/missions

$ droid exec --help | grep -A2 -- '--mission'
  --mission                   Run in mission mode (orchestrate a multi-agent mission)
  --worker-model <id>         Model ID used by mission workers (only valid with --mission)

$ node dist/index.js inspect droid  # worktree build
Capabilities
  ...
  workflows  ✗ (unsupported)

$ node -e "const {AGENTS}=require('./dist/lib/agents.js'); const {capableAgents}=require('./dist/lib/capabilities.js'); console.log(AGENTS.droid.capabilities.workflows, capableAgents('workflows').includes('droid'))"
false false
```

Binary evidence: `getMissionsDir` = join(home, ".factory", "missions") is **per-session runtime state** (`mission.md` / `features.json` under session id), not a template discovery dir. No `discoverMission` in the droid binary.

Tests (worktree):
```
bun run build  # tsc OK
bun run test tests/agents.test.ts src/lib/workflows.test.ts src/lib/__tests__/capabilities.test.ts
# 3 files, 121 tests passed
```

Linear: https://linear.app/getrush/issue/RUSH-1864