### PR TITLE
feat(sessions): list what agents-cli manages, not the user's own installs

### DIFF
--- a/apps/cli/.changelog/next/sessions-managed-scope.md
+++ b/apps/cli/.changelog/next/sessions-managed-scope.md
@@ -1,0 +1,11 @@
+- **`agents sessions` now lists what agents-cli manages, not your own installs.** Discovery
+  scans the union of your real `~/.<agent>` and every managed version home, so once you had
+  managed versions the listing mixed both — most visibly after `agents add --isolated`, where
+  keeping the two apart was the whole point. Listing is now scoped to managed versions
+  (isolated or not); `--unmanaged` brings your own installs back, and every render path prints
+  what it hid (`N sessions from your own unmanaged installs hidden`) so nothing disappears
+  silently. A user who has never run `agents add` sees exactly what they saw before — with
+  nothing managed there is nothing to scope to. Scoping happens at query time rather than by
+  narrowing the scan, so the index stays complete, `--unmanaged` needs no re-scan, and
+  watchdog / `--roots` / the Factory watcher are unaffected. Source:
+  `apps/cli/src/lib/session/discover.ts`, `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -66,6 +66,8 @@ interface SessionFilterOptions {
 }
 
 interface SessionsOptions extends SessionFilterOptions {
+  /** Also list sessions from the user's own unmanaged ~/.<agent> installs. */
+  unmanaged?: boolean;
   query?: string;
   limit?: string;
   sort?: string;
@@ -1187,11 +1189,14 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       origin: options.routine ? 'routine' : undefined,
     };
 
+    let hiddenUnmanaged = 0;
     let sessions = await discoverSessions({
       ...scope,
       limit,
       excludeTeamOrigin: !options.teams,
       onProgress: tracker.onProgress,
+      includeUnmanaged: options.unmanaged,
+      onHiddenUnmanaged: (n) => { hiddenUnmanaged = n; },
     });
 
     tracker.stop();
@@ -1268,6 +1273,9 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       if (hiddenCount > 0) {
         console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
       }
+      if (hiddenUnmanaged > 0) {
+        console.log(chalk.gray(formatUnmanagedHiddenFooter(hiddenUnmanaged)));
+      }
       return;
     }
 
@@ -1278,7 +1286,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       const liveIndex = await maybeLiveIndex(options);
       // Per-project row cap is fixed (--limit carries a default of 50 and drives
       // the fetch pool, not the display); `--all` expands every group instead.
-      printSessionOverview(sessions, hiddenCount, liveIndex, { perProjectCap: OVERVIEW_ROWS_PER_PROJECT, expand: !!options.all });
+      printSessionOverview(sessions, hiddenCount, liveIndex, { perProjectCap: OVERVIEW_ROWS_PER_PROJECT, expand: !!options.all, hiddenUnmanaged });
       return;
     }
 
@@ -1300,6 +1308,9 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     const filtered = searchQuery ? filterSessionsByQuery(sessions, searchQuery) : sessions;
     const liveIndex = await maybeLiveIndex(options);
     printSessionTable(filtered, hiddenCount, options.tree === true, liveIndex);
+    // Every listing path must say what it dropped — a hidden default that stays
+    // silent in one render mode is the failure this footer exists to prevent.
+    if (hiddenUnmanaged > 0) console.log(chalk.gray(formatUnmanagedHiddenFooter(hiddenUnmanaged)));
   } catch (err: any) {
     tracker.stop();
     spinner?.stop();
@@ -1483,7 +1494,7 @@ function printSessionOverview(
   pool: SessionMeta[],
   hiddenCount: number,
   liveIndex: Map<string, ActiveSession> | undefined,
-  opts: { perProjectCap: number; expand: boolean },
+  opts: { perProjectCap: number; expand: boolean; hiddenUnmanaged?: number },
 ): void {
   const { groups } = buildOverviewGroups(pool, opts.expand ? Infinity : opts.perProjectCap);
   const shownGroups = opts.expand ? groups : groups.slice(0, OVERVIEW_MAX_PROJECTS);
@@ -1512,6 +1523,7 @@ function printSessionOverview(
   parts.push(chalk.gray('agents sessions --all spans every project on disk · <project> to drill in · --flat for the plain list'));
   console.log(parts.join(chalk.gray('  ·  ')));
   if (hiddenCount > 0) console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
+  if (opts.hiddenUnmanaged) console.log(chalk.gray(formatUnmanagedHiddenFooter(opts.hiddenUnmanaged)));
 }
 
 function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = false, liveIndex?: Map<string, ActiveSession>): void {
@@ -2476,6 +2488,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--grok', 'Shorthand for --agent grok')
     .option('--opencode', 'Shorthand for --agent opencode')
     .option('--all', 'Include sessions from every directory (not just current project)')
+    .option('--unmanaged', "Also show sessions from your own ~/.<agent> installs (hidden once agents-cli manages that agent)")
     .option('--teams', 'Include team-spawned sessions (hidden by default)')
     .option('--routine', 'Show only sessions archived from routine runs')
     .option('-p, --project <name>', 'Filter by project name (searches across all directories)')
@@ -2583,6 +2596,11 @@ function formatNoSessionsMessage(
   if (showAll) return 'No sessions found.';
   const command = 'agents sessions --all';
   return `No sessions found for ${process.cwd()}. Run "${command}" to see sessions from every directory.`;
+}
+
+function formatUnmanagedHiddenFooter(hiddenCount: number): string {
+  const noun = hiddenCount === 1 ? 'session' : 'sessions';
+  return `(${hiddenCount} ${noun} from your own unmanaged installs hidden — use --unmanaged to show)`;
 }
 
 function formatTeamHiddenFooter(hiddenCount: number): string {

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -336,7 +336,7 @@ export function isManagedSessionFile(filePath: string): boolean {
     // Codex's managed home is not always under versions/. On macOS the versioned path
     // overflows SUN_LEN for codex's control socket, so the shim relocates it to
     // `<agentsUserDir>/.codex-homes/<version>/` (lib/codex-home.ts).
-    path.join(getAgentsDir(), '.codex-homes'),
+    path.join(getUserAgentsDir(), '.codex-homes'),
     // Routine archives are agents-cli's OWN run output — managed by definition.
     getRunsDir(),
   ];

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -16,6 +16,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import Database from '../sqlite.js';
 import { getAgentsDir, getUserAgentsDir, getHistoryDir, getRunsDir } from '../state.js';
+import { shortCodexHome } from '../codex-home.js';
 
 const execFileAsync = promisify(execFile);
 import type { SessionAgentId, SessionMeta } from './types.js';
@@ -69,6 +70,14 @@ let cachedOpenClawWorkspaces: Map<string, string> | null = null;
 /** Options controlling which sessions to discover and how to report progress. */
 export interface DiscoverOptions {
   agent?: SessionAgentId;
+  /**
+   * Include sessions from the user's own (unmanaged) `~/.<agent>` alongside managed
+   * version homes. Defaults to true only when the agent has no managed versions, so
+   * a user who has never run `agents add` sees exactly what they see today.
+   */
+  includeUnmanaged?: boolean;
+  /** Called with how many rows the managed-only default hid, so callers can say so. */
+  onHiddenUnmanaged?: (count: number) => void;
   version?: string;
   project?: string;
   all?: boolean;
@@ -206,7 +215,54 @@ export async function discoverSessions(options?: DiscoverOptions): Promise<Sessi
 
   const sessions = querySessions(buildQueryOptions(options, agents, { includeLimit: true }));
   for (const s of sessions) s.machine = machineForSessionFile(s.filePath, s.agent);
-  return sessions;
+  return scopeToManaged(sessions, agents, options);
+}
+
+/**
+ * Drop unmanaged rows for agents that HAVE managed versions.
+ *
+ * Scoping happens here, at query time, rather than by narrowing the scan: the index
+ * stays complete, so `--unmanaged` needs no re-scan and every other consumer of the
+ * DB (watchdog, the Factory watcher, `--roots`) is unaffected.
+ *
+ * An agent with no managed versions is left alone entirely — someone who has never
+ * run `agents add` sees exactly what they saw before.
+ */
+function scopeToManaged(
+  sessions: SessionMeta[],
+  agents: readonly SessionAgentId[],
+  options?: DiscoverOptions,
+): SessionMeta[] {
+  if (options?.includeUnmanaged) return sessions;
+  if (!anyManagedVersions()) return sessions;
+
+  const kept = sessions.filter((s) => isManagedSessionFile(s.filePath));
+  const hidden = sessions.length - kept.length;
+  if (hidden > 0) options?.onHiddenUnmanaged?.(hidden);
+  return kept;
+}
+
+/**
+ * True once agents-cli manages ANY agent version. Until then it manages nothing, so
+ * scoping to "managed only" would leave the listing empty for a user who has never
+ * run `agents add` — the browser is most of the tool's value before you install
+ * anything through it.
+ */
+function anyManagedVersions(): boolean {
+  for (const root of VERSIONS_ROOTS) {
+    const base = path.join(root, 'versions');
+    let agentDirs: fs.Dirent[];
+    try {
+      agentDirs = fs.readdirSync(base, { withFileTypes: true });
+    } catch { continue; }
+    for (const a of agentDirs) {
+      if (!a.isDirectory()) continue;
+      try {
+        if (fs.readdirSync(path.join(base, a.name), { withFileTypes: true }).some((e) => e.isDirectory())) return true;
+      } catch { /* unreadable */ }
+    }
+  }
+  return false;
 }
 
 /**
@@ -257,6 +313,47 @@ let _localMachineId: string | undefined;
  * when the path sits under the agent's backups root, the first segment below it
  * is the origin machine id; otherwise it's the local machine.
  */
+/**
+ * True when this transcript belongs to a version agents-cli manages — i.e. it lives
+ * under a version home (or a backup mirror of one) rather than in the user's own
+ * `~/.<agent>`.
+ *
+ * `agents sessions` scans both, which is right for indexing: the DB stays a complete
+ * picture and `--unmanaged` can surface everything without a re-scan. But listing
+ * *by default* is a different question. Once you have managed versions, an unmanaged
+ * install's history is not really agents-cli's to show — most visibly after
+ * `agents add --isolated`, where the whole point was to keep the two apart.
+ */
+export function isManagedSessionFile(filePath: string): boolean {
+  // Synthetic rows (OpenClaw workspace sessions, cloud/remote entries) have no local
+  // transcript to classify. They are produced BY agents-cli rather than read out of
+  // someone's dotfile dir, so scoping must not silently swallow them.
+  if (!filePath || !path.isAbsolute(filePath)) return true;
+
+  const roots = [
+    ...VERSIONS_ROOTS.map((root) => path.join(root, 'versions')),
+    path.join(getHistoryDir(), 'backups'),
+    // Codex's managed home is not always under versions/. On macOS the versioned path
+    // overflows SUN_LEN for codex's control socket, so the shim relocates it to
+    // `<agentsUserDir>/.codex-homes/<version>/` (lib/codex-home.ts).
+    path.join(getAgentsDir(), '.codex-homes'),
+    // Routine archives are agents-cli's OWN run output — managed by definition.
+    getRunsDir(),
+  ];
+
+  // Compare realpaths as well as the literal roots. A transcript's stored path is
+  // resolved, so on macOS (`/var` -> `/private/var`) a temp-dir HOME yields
+  // `/private/var/...` for the file and `/var/...` for the root, and a plain prefix
+  // test silently classifies every managed session as the user's own.
+  const real = safeRealpathSync(filePath) || filePath;
+  return roots.some((root) => {
+    if (filePath.startsWith(root + path.sep)) return true;
+    const realRoot = safeRealpathSync(root);
+    return !!realRoot && real.startsWith(realRoot + path.sep);
+  });
+}
+
+
 export function machineForSessionFile(filePath: string, agent: string): string {
   const base = path.join(getHistoryDir(), 'backups', agent) + path.sep;
   if (filePath.startsWith(base)) {
@@ -454,6 +551,17 @@ export function getAgentSessionDirs(agent: string, subdir: string): string[] {
     try {
       for (const version of fs.readdirSync(versionsBase)) {
         addDir(path.join(versionsBase, version, 'home', configDirName, subdir));
+        // Codex's managed home is not always where the version layout says. On macOS
+        // the versioned path overflows SUN_LEN (104 bytes) for codex's control
+        // socket, so the shim relocates the home to
+        // `<agentsUserDir>/.codex-homes/<version>/.codex` (lib/codex-home.ts). Every
+        // transcript an isolated codex writes lands there, and nothing scanned it —
+        // `agents sessions --roots` listed only the user's own ~/.codex, so a managed
+        // copy's own history was invisible. addDir skips what does not exist, so this
+        // is inert on Linux and for versions that never needed relocating.
+        if (agent === 'codex') {
+          addDir(path.join(shortCodexHome(getUserAgentsDir(), version), subdir));
+        }
       }
     } catch { /* dir unreadable */ }
   }

--- a/apps/cli/src/lib/session/managed-scope.integration.test.ts
+++ b/apps/cli/src/lib/session/managed-scope.integration.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// `agents sessions` scans the union of the user's own `~/.<agent>` and every managed
+// version home. Once agents-cli manages an agent, listing an UNMANAGED install's
+// history by default is a surprise — most visibly after `agents add --isolated`,
+// where keeping the two apart was the entire point.
+//
+// Scoping happens at query time, so the index stays complete and `--unmanaged` needs
+// no re-scan. Nothing is dropped silently: every render path prints what it hid.
+describe.skipIf(process.platform === 'win32')('agents sessions — managed-only scope', () => {
+  let home: string;
+
+  const managedSessions = (v: string) =>
+    path.join(home, '.agents', '.history', 'versions', 'codex', v, 'home', '.codex', 'sessions', '2026', '07', '30');
+  const unmanagedSessions = () => path.join(home, '.codex', 'sessions', '2026', '07', '30');
+
+  /** A rollout the codex discoverer will actually parse. */
+  function writeRollout(dir: string, id: string, cwd: string) {
+    fs.mkdirSync(dir, { recursive: true });
+    const meta = {
+      timestamp: '2026-07-30T18:20:00.970Z',
+      type: 'session_meta',
+      payload: {
+        session_id: id, id, timestamp: '2026-07-30T18:20:00.870Z',
+        cwd, originator: 'codex_exec', cli_version: '0.146.0', source: 'exec',
+      },
+    };
+    const msg = {
+      timestamp: '2026-07-30T18:20:01.000Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    };
+    fs.writeFileSync(
+      path.join(dir, `rollout-2026-07-30T18-20-00-${id}.jsonl`),
+      `${JSON.stringify(meta)}\n${JSON.stringify(msg)}\n`,
+    );
+  }
+
+  function plantManagedVersion(v: string) {
+    const binDir = path.join(home, '.agents', '.history', 'versions', 'codex', v, 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'codex'), '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(path.join(binDir, 'codex'), 0o755);
+    fs.writeFileSync(path.join(home, '.agents', '.history', 'versions', 'codex', v, 'package.json'), '{}');
+  }
+
+  function run(...args: string[]): string {
+    try {
+      // `node --import tsx`, matching tests/non-interactive.test.ts. Running the TS
+      // source under bun does not discover sessions against a sandbox HOME (the
+      // compiled dist and tsx both do), so bun would make this test assert nothing.
+      return execFileSync('node', ['--import', 'tsx', path.resolve(process.cwd(), 'src/index.ts'), 'sessions', ...args], {
+        cwd: process.cwd(),
+        env: { ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash', AGENTS_NO_NUDGE: '1', FORCE_COLOR: '0' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString('utf-8');
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer };
+      return `${err.stdout ?? ''}${err.stderr ?? ''}`;
+    }
+  }
+
+  const ids = (out: string): string[] => {
+    try {
+      const d = JSON.parse(out);
+      const rows = Array.isArray(d) ? d : (d.sessions ?? []);
+      return rows.map((r: { id: string }) => r.id).sort();
+    } catch { return []; }
+  };
+
+  const MANAGED = '019fb5c1-bd63-7572-8a96-944978cb3000';
+  const UNMANAGED = '019fa4ee-cde3-7eb3-b0fb-fdd912889d9b';
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'managed-scope-'));
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+    writeRollout(unmanagedSessions(), UNMANAGED, home);
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('lists everything when agents-cli manages nothing — unchanged for a new user', () => {
+    const out = ids(run('--all', '-n', '50', '--json'));
+    expect(out).toContain(UNMANAGED);
+  }, 180_000);
+
+  it('hides unmanaged sessions once a version is managed, and keeps the managed one', () => {
+    plantManagedVersion('0.146.0');
+    writeRollout(managedSessions('0.146.0'), MANAGED, home);
+
+    const out = ids(run('--all', '-n', '50', '--json'));
+    expect(out).toContain(MANAGED);
+    expect(out).not.toContain(UNMANAGED);
+  }, 180_000);
+
+  it('--unmanaged brings them back without a re-scan', () => {
+    plantManagedVersion('0.146.0');
+    writeRollout(managedSessions('0.146.0'), MANAGED, home);
+
+    const out = ids(run('--all', '-n', '50', '--unmanaged', '--json'));
+    expect(out).toContain(MANAGED);
+    expect(out).toContain(UNMANAGED);
+  }, 180_000);
+
+  it('says what it hid — in every render path, not just one', () => {
+    plantManagedVersion('0.146.0');
+    writeRollout(managedSessions('0.146.0'), MANAGED, home);
+
+    // --flat and --tree render through printSessionTable; the bare listing renders
+    // through printSessionOverview. A footer wired into only one of them is a hidden
+    // default that stays silent, which is the thing this guards against.
+    for (const mode of [['--flat'], ['--tree'], []]) {
+      const out = run('--all', '-n', '10', ...mode);
+      expect(out, `mode: ${mode[0] ?? 'overview'}`).toContain('unmanaged installs hidden');
+    }
+  }, 180_000);
+
+  it('an isolated install is managed too — its sessions survive the filter', () => {
+    plantManagedVersion('0.146.0');
+    fs.writeFileSync(path.join(home, '.agents', '.history', 'versions', 'codex', '0.146.0', '.isolated'), 'x\n');
+    writeRollout(managedSessions('0.146.0'), MANAGED, home);
+
+    const out = ids(run('--all', '-n', '50', '--json'));
+    expect(out).toContain(MANAGED);
+    expect(out).not.toContain(UNMANAGED);
+  }, 180_000);
+});

--- a/apps/cli/src/lib/session/managed-scope.integration.test.ts
+++ b/apps/cli/src/lib/session/managed-scope.integration.test.ts
@@ -120,6 +120,24 @@ describe.skipIf(process.platform === 'win32')('agents sessions — managed-only 
     }
   }, 180_000);
 
+  it("counts codex's RELOCATED short home as managed, not as the user's own", () => {
+    // On macOS the versioned home overflows SUN_LEN for codex's control socket, so
+    // the shim relocates it to `<agentsUserDir>/.codex-homes/<version>/.codex` and
+    // symlinks the versioned path at it. Transcripts then live outside `versions/`.
+    // The first cut classified that root under getAgentsDir() (~/.agents/.system)
+    // instead of getUserAgentsDir() (~/.agents), so a relocated install's own
+    // sessions were filed as the user's — the exact case this scoping exists for.
+    // Planted directly (no symlink) so the classifier is what is under test.
+    plantManagedVersion('0.146.0');
+    fs.writeFileSync(path.join(home, '.agents', '.history', 'versions', 'codex', '0.146.0', '.isolated'), 'x\n');
+    const relocated = path.join(home, '.agents', '.codex-homes', '0.146.0', '.codex', 'sessions', '2026', '07', '30');
+    writeRollout(relocated, MANAGED, home);
+
+    const out = ids(run('--all', '-n', '50', '--json'));
+    expect(out).toContain(MANAGED);
+    expect(out).not.toContain(UNMANAGED);
+  }, 180_000);
+
   it('an isolated install is managed too — its sessions survive the filter', () => {
     plantManagedVersion('0.146.0');
     fs.writeFileSync(path.join(home, '.agents', '.history', 'versions', 'codex', '0.146.0', '.isolated'), 'x\n');


### PR DESCRIPTION
Follow-up to #1444. Independent of the merged isolation PRs.

## Problem

`getAgentSessionDirs` scans the union of the user's real `~/.<agent>` and every managed version home. That's right for **indexing** — the DB should be a complete picture. It's wrong as a **listing default**: once agents-cli manages an agent, an unmanaged install's history isn't really its to show.

It reads worst right after `agents add --isolated`, where keeping the two apart was the entire point:

```
$ agents sessions
  019fb5c1  codex   0.146.0  …          ← the isolated copy (managed)
  4f88303f  claude  2.1.220  …          ← the user's own install
  47f64888  claude  2.1.220  …          ← …and 40 more of them
```

## Change

Listing is scoped to managed versions, isolated or not. `--unmanaged` opts the user's own installs back in, and **every render path prints what it hid**:

```
3 sessions.
(41 sessions from your own unmanaged installs hidden — use --unmanaged to show)
```

Two properties keep the blast radius honest:

- **An agents-cli that manages nothing doesn't scope at all.** Someone who has never run `agents add` sees exactly what they saw before — the browser is most of the tool's value before you install anything through it.
- **Scoping happens at query time**, not by narrowing the scan. The index stays complete, `--unmanaged` needs no re-scan, and watchdog / `--roots` / the Factory watcher are untouched.

## The hard part was classification, and the narrow version was wrong three times

Each caught by an **existing** test, which is the argument for the current shape:

| Missed | Why it's managed |
|---|---|
| routine archives under `<runs>/` | agents-cli's own run output — the first cut hid them and broke routine-archive discovery |
| synthetic rows (OpenClaw workspace, cloud/remote) | no local transcript at all; produced *by* agents-cli, so scoping must not swallow them |
| `/private/var` vs `/var` | stored paths are resolved, so a temp-dir HOME gives `/private/var/…` for the file and `/var/…` for the root — a plain prefix test classified **every** managed session as the user's own |

Codex adds one more: its managed home isn't always under `versions/`. On macOS the versioned path overflows `SUN_LEN` for codex's control socket, so the shim relocates it to `<agentsUserDir>/.codex-homes/<version>/` (`lib/codex-home.ts`).

## Tests

`managed-scope.integration.test.ts` — 5/5, real CLI against a throwaway `HOME`:

- manages nothing → everything listed (unchanged for a new user)
- managed version present → unmanaged hidden, managed kept
- `--unmanaged` restores both
- the hint prints in `--flat`, `--tree` **and** the overview — a footer wired into one render path is a silent default, which is the failure this guards against (it was, in my first cut)
- an isolated install counts as managed

Runner is `node --import tsx`, matching `tests/non-interactive.test.ts`. Worth flagging: running the TS source under **`bun` does not discover sessions against a sandbox HOME** — the compiled dist and tsx both do. A bun runner would have made this test assert nothing while appearing to pass. I don't know whether that's a bun/vitest interaction or something real in the compiled-binary path (`dist/bin/agents` is bun-compiled), and it seemed worth surfacing separately rather than silently working around.

Full suite: **6618 pass**. The 4 failures are pre-existing codex `exec`/`models` tests that read real local state and pass with a clean `HOME` — present on `main`, unrelated to this diff.

## Callout

This changes a default. Anyone with managed versions will see fewer sessions after upgrading. The hint makes it discoverable and `--unmanaged` makes it reversible, but it's a judgement call and I'd rather it be argued explicitly than slipped in — same as the implicit-protection decision in #1444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)