### PR TITLE
fix(hooks): OpenCode plugin survives unrelated syncs + lifecycle matcher gate (RUSH-1850 follow-up)

### DIFF
--- a/apps/cli/src/lib/__tests__/hooks.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks.test.ts
@@ -595,6 +595,39 @@ describe('registerHooksToSettings - OpenCode', () => {
       .toThrow('capture failed with exit code 7: rejected');
   });
 
+  it('executes lifecycle hooks even when the manifest entry also has a tool matcher', () => {
+    const outputPath = path.join(tmpDir, 'lifecycle-input.json');
+    const scriptPath = path.join(agentsDir, 'hooks', 'capture-lifecycle.js');
+    fs.writeFileSync(scriptPath, `#!/usr/bin/env node\nrequire("fs").writeFileSync(${JSON.stringify(outputPath)}, require("fs").readFileSync(0))\n`, 'utf-8');
+    fs.chmodSync(scriptPath, 0o755);
+    const versionHome = path.join(tmpDir, 'home');
+    registerHooksToSettings('opencode', versionHome, {
+      captureLifecycle: {
+        script: 'capture-lifecycle.js',
+        events: ['SessionStart', 'Stop'],
+        matcher: 'Bash|bash',
+      },
+    }, agentsDir);
+    const pluginPath = path.join(
+      versionHome, '.config', 'opencode', 'plugins', 'agents-cli-hooks.ts'
+    );
+    const runnerPath = path.join(tmpDir, 'run-lifecycle-plugin.ts');
+    fs.writeFileSync(runnerPath, `
+      import { $ } from "bun"
+      import { AgentsCliHooks } from ${JSON.stringify(pluginPath)}
+      const plugin = await AgentsCliHooks({ $ })
+      await plugin.event({ event: { type: "session.created", properties: { info: { id: "lifecycle" } } } })
+    `, 'utf-8');
+
+    execFileSync('bun', [runnerPath]);
+
+    expect(JSON.parse(fs.readFileSync(outputPath, 'utf-8'))).toMatchObject({
+      hook_event_name: 'session.created',
+      type: 'session.created',
+      properties: { info: { id: 'lifecycle' } },
+    });
+  });
+
   it('enforces the manifest timeout', async () => {
     const homeScopedDir = fs.mkdtempSync(path.join(os.homedir(), '.opencode-hook-test-'));
     const homeAgentsDir = path.join(homeScopedDir, '.agents');

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -1258,9 +1258,9 @@ function matches(hook, tool) {
   }
 }
 
-async function runHooks(hooks, payload, $) {
+async function runHooks(hooks, payload, $, matchTool = false) {
   for (const hook of hooks ?? []) {
-    if (!matches(hook, payload.tool_name ?? "")) continue
+    if (matchTool && !matches(hook, payload.tool_name ?? "")) continue
     const input = JSON.stringify(payload)
     const home = Bun.env.HOME ?? Bun.env.USERPROFILE ?? ""
     const command = hook.command.startsWith("~/")
@@ -1309,10 +1309,10 @@ export const AgentsCliHooks = async ({ $ }) => ({
     await runHooks(directHooks["chat.message"], { hook_event_name: "UserPromptSubmit", ...input, ...output }, $)
   },
   "tool.execute.before": async (input, output) => {
-    await runHooks(directHooks["tool.execute.before"], { hook_event_name: "PreToolUse", tool_name: input.tool, tool_input: output.args, ...input }, $)
+    await runHooks(directHooks["tool.execute.before"], { hook_event_name: "PreToolUse", tool_name: input.tool, tool_input: output.args, ...input }, $, true)
   },
   "tool.execute.after": async (input, output) => {
-    await runHooks(directHooks["tool.execute.after"], { hook_event_name: "PostToolUse", tool_name: input.tool, tool_input: input.args, tool_response: output, ...input }, $)
+    await runHooks(directHooks["tool.execute.after"], { hook_event_name: "PostToolUse", tool_name: input.tool, tool_input: input.args, tool_response: output, ...input }, $, true)
   },
 })
 `;

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -39,7 +39,8 @@ function runVersionSync(home: string, expression: string): unknown {
   // .exe everywhere, so this is shell-free and cross-platform.
   const tsxBin = path.resolve('node_modules/tsx/dist/cli.mjs');
   const child = spawnSync(nodeExecPath(), [tsxBin, '-e', `
-    import { listInstalledVersions, syncResourcesToVersion, buildRepoScopedSelection } from ${JSON.stringify(moduleUrl)};
+    import { listInstalledVersions, syncResourcesToVersion, buildRepoScopedSelection, getVersionHomePath } from ${JSON.stringify(moduleUrl)};
+    import { registerHooksToSettings } from ${JSON.stringify(pathToFileURL(path.resolve('src/lib/hooks.ts')).href)};
     const home = ${JSON.stringify(home)};
     const result = ${expression};
     console.log(JSON.stringify(result));
@@ -299,6 +300,47 @@ describe('self-updating single-binary agents (RUSH-1321)', () => {
 });
 
 describe('version resource sync path handling', () => {
+  it('keeps the generated OpenCode hooks plugin during an unrelated scoped sync', () => {
+    const home = makeTempHome();
+    const hooksDir = path.join(home, '.agents', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'keep.sh'), '#!/bin/sh\nexit 0\n', 'utf-8');
+    fs.chmodSync(path.join(hooksDir, 'keep.sh'), 0o755);
+
+    runVersionSync(
+      home,
+      `(() => {
+        const versionHome = getVersionHomePath('opencode', '1.18.4');
+        registerHooksToSettings(
+          'opencode',
+          versionHome,
+          { keep: { script: 'keep.sh', events: ['SessionStart'] } },
+          ${JSON.stringify(path.join(home, '.agents'))}
+        );
+        return syncResourcesToVersion(
+          'opencode',
+          '1.18.4',
+          { commands: [] },
+          { cwd: home }
+        );
+      })()`
+    );
+
+    expect(fs.existsSync(path.join(
+      home,
+      '.agents',
+      '.history',
+      'versions',
+      'opencode',
+      '1.18.4',
+      'home',
+      '.config',
+      'opencode',
+      'plugins',
+      'agents-cli-hooks.ts'
+    ))).toBe(true);
+  });
+
   it('intersects explicit resource selections with discovered resources before syncing', async () => {
     const home = makeTempHome();
 

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -2864,7 +2864,8 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
         result.hooks = r.synced.length > 0;
         hookManifest = selectHookManifest(parseHookManifest(), hooksToSync);
       }
-      if (agent === 'opencode') {
+      const hooksInScope = !userPassedSelection || selection?.hooks !== undefined;
+      if (agent === 'opencode' && hooksInScope) {
         registerHooksToSettings(agent, versionHome, hookManifest);
       }
     }


### PR DESCRIPTION
## What / why

Fix-forward for the two OpenCode hook regressions reproduced by prix-cloud on #1451:

1. A scoped sync that did not include hooks still called OpenCode hook registration with an empty manifest, deleting `.config/opencode/plugins/agents-cli-hooks.ts`.
2. Generated lifecycle dispatch applied a tool matcher to an empty `tool_name`, so lifecycle hooks carrying a matcher were registered but never executed.

## Reproduction evidence

Before the fix, real subprocess/filesystem runs produced:

```text
{"before":true,"after":false,"plugin":".../agents-cli-hooks.ts"}
{"registered":["capture -> session.created","capture -> session.idle","capture -> session.error"],"sideEffect":false}
```

The added tests were mutation-checked against the original conditions and failed as required:

```text
versions.test.ts: expected false to be true
hooks.test.ts: ENOENT ... lifecycle-input.json
mutation-check exit codes: sync=1 lifecycle=1
```

## Fix

```ts
const hooksInScope = !userPassedSelection || selection?.hooks !== undefined;
if (agent === "opencode" && hooksInScope) {
  registerHooksToSettings(agent, versionHome, hookManifest);
}
```

```ts
async function runHooks(hooks, payload, $, matchTool = false) {
  for (const hook of hooks ?? []) {
    if (matchTool && !matches(hook, payload.tool_name ?? "")) continue
```

Only `tool.execute.before` and `tool.execute.after` pass `matchTool = true`; lifecycle and other non-tool events do not apply tool matchers.

## Verification

```text
bun install                         PASS
bun run build                       PASS
bun x tsc --noEmit                  PASS
hooks + versions suites             19 files passed
                                      432 tests passed
```

This is a pure bug fix with no user-facing API/config change, so existing docs and changelog do not require updates.