### PR TITLE
fix(isolated): resume and agent-spec resolution assumed PATH-reachable versions

### DIFF
--- a/apps/cli/.changelog/next/isolated-parity.md
+++ b/apps/cli/.changelog/next/isolated-parity.md
@@ -1,0 +1,16 @@
+- **Isolated installs now resume sessions and resolve `@default` like any other install.**
+  Two places still assumed a managed version is reachable on PATH — which an isolated
+  install deliberately is not. (1) `agents sessions` resume looked up
+  `<cli>@<version>` with a plain PATH lookup, never found it (the shims dir is
+  intentionally off PATH under `--isolated`), concluded the version was uninstalled, and
+  fell back to spawning `<cli> "/continue <id>"` — a slash command neither CLI has, so
+  the session simply never resumed. It now resolves the versioned alias by absolute path,
+  the way `agents run` already did, and the fallback is the agent's real resume verb
+  against the current version rather than `/continue`. (2) The agent-spec resolver behind
+  `--agents` / `@default` / `@pinned` read only the global default, so an isolated-only
+  agent threw "No default version set" even after an explicit `agents use` —
+  `resolveVersion` had gained the isolated-default fallback but this resolver had not.
+  Both now consult it, and report `isolated-default` as the source rather than claiming a
+  global default. `opencode` resume stays deliberately un-pinned, since its sessions are
+  shared across versions. Source: `apps/cli/src/commands/sessions.ts`,
+  `apps/cli/src/lib/agent-spec/`.

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -37,7 +37,8 @@ import { runRemoteSessions, buildForwardedArgs, ensureWholeIndex } from '../lib/
 import { formatRelativeTime } from '../lib/session/relative-time.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, type FilterOptions } from '../lib/session/render.js';
 import { renderMarkdown } from '../lib/markdown.js';
-import { colorAgent, resolveAgentName } from '../lib/agents.js';
+import { AGENTS, colorAgent, resolveAgentName } from '../lib/agents.js';
+import { getShimsDir } from '../lib/state.js';
 import { fuzzyMatch, FUZZY_PRESETS } from '../lib/fuzzy.js';
 import { resolveVersionAliasLoose } from '../lib/versions.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
@@ -1983,11 +1984,17 @@ export async function resumeSessionInPlace(session: SessionMeta): Promise<void> 
   // spawnResumeCommand), a missing command exits non-zero rather than emitting
   // an ENOENT `error` event — so detect a removed version here instead of
   // relying on that event, keeping the /continue fallback working on every OS.
-  if (!findExecutable(resume[0]) && session.version) {
+  // `resume[0]` is an absolute alias path when one exists on disk, so only a bare
+  // name still needs a PATH lookup. Checking existsSync first is what keeps an
+  // isolated install (shims deliberately off PATH) out of the fallback.
+  const launcherFound = path.isAbsolute(resume[0])
+    ? fs.existsSync(resume[0])
+    : !!findExecutable(resume[0]);
+  if (!launcherFound && session.version) {
     const fallback = buildFallbackCommand(session);
     if (fallback) {
       console.log(chalk.gray(
-        `Version ${session.version} is not installed. Falling back to current version via /continue...`
+        `Version ${session.version} is not installed. Resuming with the current version instead...`
       ));
       await spawnResumeCommand(fallback, cwd);
       return;
@@ -2071,16 +2078,56 @@ function spawnResumeCommand(cmd: string[], cwd: string): Promise<void> {
  * If the versioned binary is missing (version was removed), the ENOENT
  * handler in handlePickedSession retries via buildFallbackCommand.
  */
+/**
+ * The agent's own resume invocation, given whichever launcher we resolved.
+ * Keeping the verb in one place is what lets the version-pinned and fallback
+ * paths stay in agreement — they previously drifted into `/continue`, which is
+ * not a command either CLI has.
+ */
+function resumeArgv(agent: SessionMeta['agent'], id: string, launcher: string): string[] | null {
+  switch (agent) {
+    case 'claude': return [launcher, '--resume', id];
+    case 'codex': return [launcher, 'resume', id];
+    case 'opencode': return [launcher, '--session', id];
+    default: return null;
+  }
+}
+
+/**
+ * Absolute path of the on-disk versioned alias, or null when it isn't there.
+ *
+ * Resume must not resolve `<cli>@<version>` by bare name. The shims directory is
+ * deliberately absent from PATH for an isolated install — that is precisely what
+ * `--isolated` promises — so a PATH lookup can never find the alias, and resume
+ * degraded to the fallback 100% of the time for isolated copies. Mirrors the
+ * resolution `buildExecCommand` already does for `agents run`.
+ */
+function versionedAliasIfPresent(agent: SessionMeta['agent'], version: string): string | null {
+  const cli = AGENTS[agent as AgentId]?.cliCommand ?? agent;
+  const base = path.join(getShimsDir(), `${cli}@${version}`);
+  if (process.platform === 'win32' && fs.existsSync(`${base}.cmd`)) return `${base}.cmd`;
+  if (fs.existsSync(base)) return base;
+  return null;
+}
+
 export function buildResumeCommand(session: SessionMeta): string[] | null {
   switch (session.agent) {
-    case 'claude':
-      if (session.version) return [`claude@${session.version}`, '--resume', session.id];
-      return ['claude', '--resume', session.id];
-    case 'codex':
-      if (session.version) return [`codex@${session.version}`, 'resume', session.id];
-      return ['codex', 'resume', session.id];
+    // opencode sessions are shared across versions, so resume is deliberately NOT
+    // version-pinned — it always goes through the plain launcher.
     case 'opencode':
-      return ['opencode', '--session', session.id];
+      return resumeArgv('opencode', session.id, 'opencode');
+
+    case 'claude':
+    case 'codex': {
+      const cli = AGENTS[session.agent as AgentId]?.cliCommand ?? session.agent;
+      if (session.version) {
+        const alias = versionedAliasIfPresent(session.agent, session.version);
+        // Absolute path when the alias exists; otherwise the bare versioned name,
+        // which still resolves for a non-isolated install whose shims are on PATH.
+        return resumeArgv(session.agent, session.id, alias ?? `${cli}@${session.version}`);
+      }
+      return resumeArgv(session.agent, session.id, cli);
+    }
     case 'gemini':
     case 'antigravity':
     case 'openclaw':
@@ -2094,13 +2141,18 @@ export function buildResumeCommand(session: SessionMeta): string[] | null {
   }
 }
 
-/** Fallback resume command when the versioned binary is unavailable (ENOENT). */
+/**
+ * Fallback when the pinned version really is gone: the same resume invocation
+ * against the current version.
+ *
+ * This used to spawn `<cli> "/continue <id>"`, feeding a slash command into the
+ * TUI as a prompt. Neither CLI has `/continue` — codex documents `/resume` — so
+ * the agent received an unrecognised command and the session was not resumed at
+ * all. Reusing resumeArgv keeps the two paths from drifting apart again.
+ */
 function buildFallbackCommand(session: SessionMeta): string[] | null {
-  switch (session.agent) {
-    case 'claude': return ['claude', `/continue ${session.id}`];
-    case 'codex':  return ['codex', `/continue ${session.id}`];
-    default: return null;
-  }
+  const cli = AGENTS[session.agent as AgentId]?.cliCommand ?? session.agent;
+  return resumeArgv(session.agent, session.id, cli);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/lib/agent-spec/provider.ts
+++ b/apps/cli/src/lib/agent-spec/provider.ts
@@ -4,6 +4,7 @@
 import {
   listInstalledVersions,
   getGlobalDefault,
+  getIsolatedDefault,
   getProjectVersion,
   isVersionInstalled,
 } from '../versions.js';
@@ -13,5 +14,6 @@ export const defaultVersionProvider: VersionProvider = {
   listInstalled: (agent) => listInstalledVersions(agent),
   getProjectVersion: (agent, cwd) => getProjectVersion(agent, cwd),
   getGlobalDefault: (agent) => getGlobalDefault(agent),
+  getIsolatedDefault: (agent) => getIsolatedDefault(agent),
   isInstalled: (agent, version) => isVersionInstalled(agent, version),
 };

--- a/apps/cli/src/lib/agent-spec/resolve.test.ts
+++ b/apps/cli/src/lib/agent-spec/resolve.test.ts
@@ -9,17 +9,53 @@ function providerOf(state: {
   installed?: Partial<Record<string, string[]>>;
   project?: Partial<Record<string, string>>;
   global?: Partial<Record<string, string>>;
+  isolated?: Partial<Record<string, string>>;
 }): VersionProvider {
   const installed = state.installed ?? {};
   return {
     listInstalled: (a) => (installed[a] ?? []).slice().sort(compareVersions),
     getProjectVersion: (a) => state.project?.[a] ?? null,
     getGlobalDefault: (a) => state.global?.[a] ?? null,
+    getIsolatedDefault: (a) => state.isolated?.[a] ?? null,
     isInstalled: (a, v) => (installed[a] ?? []).includes(v),
   };
 }
 
 const CLAUDE = 'claude' as AgentId;
+
+describe('isolated default', () => {
+  // An isolated-only agent never has a global default — that is what --isolated
+  // guarantees — so the chain has to keep going or `--agents codex` throws at a user
+  // who has explicitly run `agents use`. resolveVersion already did this; the two
+  // resolvers had drifted, and only this one still threw.
+  it('bare resolves to the isolated default when there is no global one', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] }, isolated: { claude: '2.1.0' } });
+    expect(resolveSingleAgentTarget('claude', p)).toEqual({ agent: CLAUDE, version: '2.1.0', source: 'isolated-default' });
+  });
+
+  it('a global default still wins — the isolated one is only a fallback', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] }, global: { claude: '2.1.1' }, isolated: { claude: '2.1.0' } });
+    expect(resolveSingleAgentTarget('claude', p).version).toBe('2.1.1');
+  });
+
+  it('a project pin still wins over both', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] }, project: { claude: '2.1.1' }, isolated: { claude: '2.1.0' } });
+    expect(resolveSingleAgentTarget('claude', p).source).toBe('project-pin');
+  });
+
+  it('@default and @pinned reach it too, and report it as isolated', () => {
+    const p = providerOf({ installed: { claude: ['2.1.0'] }, isolated: { claude: '2.1.0' } });
+    for (const spec of ['claude@default', 'claude@pinned']) {
+      expect(resolveSingleAgentTarget(spec, p)).toEqual({ agent: CLAUDE, version: '2.1.0', source: 'isolated-default' });
+    }
+  });
+
+  it('ambiguity is resolved by the isolated default rather than throwing', () => {
+    // Two isolated copies and no global default used to be a hard error.
+    const p = providerOf({ installed: { claude: ['2.1.0', '2.1.1'] }, isolated: { claude: '2.1.1' } });
+    expect(() => resolveSingleAgentTarget('claude', p)).not.toThrow();
+  });
+});
 
 describe('bare resolution chain', () => {
   it('project pin wins over global default', () => {

--- a/apps/cli/src/lib/agent-spec/resolve.ts
+++ b/apps/cli/src/lib/agent-spec/resolve.ts
@@ -81,6 +81,12 @@ export function resolveAgentTargets(
       if (proj) { push(agent, proj, 'project-pin'); continue; }
       const glob = provider.getGlobalDefault(agent);
       if (glob) { push(agent, glob, 'global-default'); continue; }
+      // An isolated-only agent never has a global default — that is the point — so
+      // without this step `--agents codex` threw "No default version set" at a user
+      // who had explicitly run `agents use codex@<v>`. resolveVersion already had
+      // this fallback; the two resolvers had drifted apart.
+      const iso = provider.getIsolatedDefault(agent);
+      if (iso) { push(agent, iso, 'isolated-default'); continue; }
       const installed = provider.listInstalled(agent);
       if (installed.length === 0) { push(agent, null, 'none'); continue; }
       if (installed.length === 1) { push(agent, installed[0], 'sole-installed'); continue; }
@@ -91,16 +97,20 @@ export function resolveAgentTargets(
       );
     }
 
-    // ----- @pinned / @default: the configured global default -----
+    // ----- @pinned / @default: the configured default (global, else isolated) -----
     if (qualifier === 'pinned' || qualifier === 'default') {
-      const def = provider.getGlobalDefault(agent);
+      const glob = provider.getGlobalDefault(agent);
+      // Report which kind it was: an isolated default owns none of the launcher /
+      // shim / config-symlink machinery a global default does, and callers that log
+      // the source shouldn't claim otherwise.
+      const def = glob ?? provider.getIsolatedDefault(agent);
       if (!def) {
         throw new AgentSpecError(
           `No default version set for ${name}. Run: agents use ${agent}@<version>`,
           'no-default', agent, provider.listInstalled(agent),
         );
       }
-      push(agent, def, 'global-default(@pinned)');
+      push(agent, def, glob ? 'global-default(@pinned)' : 'isolated-default');
       continue;
     }
 
@@ -197,6 +207,8 @@ export function resolveListFilter(
 ): string | undefined {
   const q = qualifier?.trim();
   if (!q || q === 'any') return undefined;
-  if (q === 'default' || q === 'pinned') return provider.getGlobalDefault(agent) ?? undefined;
+  if (q === 'default' || q === 'pinned') {
+    return provider.getGlobalDefault(agent) ?? provider.getIsolatedDefault(agent) ?? undefined;
+  }
   return resolveSingleAgentTarget(`${agent}@${q}`, provider, { ...opts, availableAgents: [agent] }).version;
 }

--- a/apps/cli/src/lib/agent-spec/types.ts
+++ b/apps/cli/src/lib/agent-spec/types.ts
@@ -5,6 +5,7 @@ export type VersionSource =
   | 'explicit'                // @x.y.z or a concrete pass-through
   | 'project-pin'             // a project-root agents.yaml pin
   | 'global-default'          // the configured global default (bare spec)
+  | 'isolated-default'        // the preferred ISOLATED copy, when there is no global default
   | 'global-default(@pinned)' // @pinned / @default asked for the global default explicitly
   | 'sole-installed'          // no pin/default, exactly one installed
   | 'newest-installed'        // bare + ambiguous, onAmbiguous:'newest' picked the newest
@@ -59,6 +60,14 @@ export interface VersionProvider {
   getProjectVersion(agent: AgentId, cwd: string): string | null;
   /** The configured global default version, or null. */
   getGlobalDefault(agent: AgentId): string | null;
+  /**
+   * The preferred isolated copy. Kept separate from getGlobalDefault on purpose: a
+   * global default owns the launcher, the bare shim and the real ~/.<agent> config
+   * symlink, and an isolated version must never acquire any of those. Folding the
+   * two together here would hand an isolated version back to every caller that
+   * reasonably assumes a global default means "the one that owns the launcher".
+   */
+  getIsolatedDefault(agent: AgentId): string | null;
   /** Whether an exact version is installed. */
   isInstalled(agent: AgentId, version: string): boolean;
 }

--- a/apps/cli/src/lib/isolated-resume.integration.test.ts
+++ b/apps/cli/src/lib/isolated-resume.integration.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Resuming a session from an ISOLATED install was broken 100% of the time.
+//
+// `buildResumeCommand` returns `<cli>@<version> resume <id>`, and the guard checked
+// for that launcher with `findExecutable` — a plain PATH lookup. But the shims
+// directory is deliberately absent from PATH for an isolated install, which is the
+// whole promise of `--isolated`. So the alias was never found, the guard concluded
+// the version was uninstalled, and it fell back to spawning `<cli> "/continue <id>"`
+// — feeding a slash command into the TUI as a prompt. Neither CLI has `/continue`
+// (codex documents `/resume`), so the session simply never resumed.
+describe.skipIf(process.platform === 'win32')('resuming an isolated session', () => {
+  let home: string;
+  const V = '9.9.4';
+
+  const shimsDir = () => path.join(home, '.agents', '.cache', 'shims');
+
+  function plantIsolated() {
+    const vdir = path.join(home, '.agents', '.history', 'versions', 'codex', V);
+    fs.mkdirSync(path.join(vdir, 'node_modules', '.bin'), { recursive: true });
+    fs.mkdirSync(path.join(vdir, 'home', '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(vdir, 'package.json'), '{}');
+    fs.writeFileSync(path.join(vdir, 'node_modules', '.bin', 'codex'), '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(path.join(vdir, 'node_modules', '.bin', 'codex'), 0o755);
+    fs.writeFileSync(path.join(vdir, '.isolated'), 'x\n');
+    // The versioned alias, exactly where `agents add --isolated` puts it: on disk,
+    // NOT on PATH.
+    fs.mkdirSync(shimsDir(), { recursive: true });
+    const alias = path.join(shimsDir(), `codex@${V}`);
+    fs.writeFileSync(alias, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(alias, 0o755);
+  }
+
+  /** Ask the CLI's own builder what it would spawn. */
+  function resumeCmd(version?: string): string[] | null {
+    const script = `
+      import { buildResumeCommand } from ${JSON.stringify(path.resolve(process.cwd(), 'src/commands/sessions.ts'))};
+      console.log('__R__' + JSON.stringify(buildResumeCommand(
+        { agent: 'codex', id: 'sess-123', version: ${version ? JSON.stringify(version) : 'undefined'} }
+      )));
+    `;
+    const out = execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash' },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString();
+    return JSON.parse(out.split('__R__')[1]);
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'isolated-resume-'));
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('resolves the versioned alias by absolute path, not through PATH', () => {
+    plantIsolated();
+    const cmd = resumeCmd(V);
+    expect(cmd).not.toBeNull();
+    // Absolute path into the shims dir — a bare `codex@9.9.4` would be unresolvable.
+    expect(path.isAbsolute(cmd![0])).toBe(true);
+    expect(cmd![0]).toBe(path.join(shimsDir(), `codex@${V}`));
+    // ...and it is genuinely not on PATH, which is the whole reason this matters.
+    expect((process.env.PATH ?? '').split(path.delimiter)).not.toContain(shimsDir());
+  }, 120_000);
+
+  it('uses codex\'s real resume verb, never a /continue slash command', () => {
+    plantIsolated();
+    expect(resumeCmd(V)!.slice(1)).toEqual(['resume', 'sess-123']);
+    // Unversioned form too.
+    expect(resumeCmd()).toEqual(['codex', 'resume', 'sess-123']);
+  }, 120_000);
+
+  it('falls back to a real resume against the current version, not /continue', () => {
+    // No alias on disk and nothing on PATH: the pinned version really is gone.
+    const cmd = resumeCmd('0.0.0-missing');
+    expect(cmd).toEqual(['codex@0.0.0-missing', 'resume', 'sess-123']);
+    // The point: no argument anywhere is a slash command.
+    expect(cmd!.some((a) => a.startsWith('/'))).toBe(false);
+  }, 120_000);
+});


### PR DESCRIPTION
Reported from real use: picking a codex session in `agents sessions` produced this inside the codex TUI —

```
› /continue 019fb5c0-cfd2-7bf2-9d9d-5b059ab96ebf
```

`/continue` is not a command codex has. The session was never resumed; the agent went off and downloaded the official manual to work out that the verb is `/resume`.

Two independent gaps, both from one assumption: **that a managed version can be found on PATH.** An isolated install deliberately is not on PATH — that's the guarantee.

## 1. `agents sessions` resume

`buildResumeCommand` returns `<cli>@<version> resume <id>`, and the guard checked that launcher with `findExecutable` — a plain `which`. The versioned alias lives in the shims dir, which `--isolated` deliberately keeps **off PATH**, so the lookup always failed for an isolated copy:

```
alias exists and runs:  ~/.agents/.cache/shims/codex@0.146.0  →  codex-cli 0.146.0
which codex@0.146.0  →  NOT FOUND
```

The guard concluded the version was uninstalled and took the fallback:

```ts
['codex', `/continue ${id}`]     // spawns codex with a slash command as its prompt
```

Neither codex nor claude has `/continue`. **Isolated sessions failed to resume 100% of the time**, and silently — the CLI printed that it was resuming.

Now: resolve the versioned alias by absolute path when it's on disk — the same resolution `buildExecCommand` already does for `agents run` — and only fall back to a PATH lookup for a bare name. The fallback is the agent's **real** resume invocation against the current version, built from the same `resumeArgv` helper as the pinned path, which is what stops the two drifting into `/continue` again.

`opencode` keeps its deliberately un-pinned resume (its sessions are shared across versions). An existing test pins that and caught the refactor when it briefly regressed — good test.

## 2. The agent-spec resolver (`--agents`, `@default`, `@pinned`)

It read only `getGlobalDefault`, so an isolated-only agent threw `No default version set` — at a user who had explicitly run `agents use codex@<v>`. `resolveVersion` gained the isolated-default fallback when isolated defaults were introduced; this resolver didn't, and the two silently disagreed:

```
resolveVersion('codex')            -> 9.9.5
resolveSingleAgentTarget('codex')  -> throws no-default
```

`VersionProvider` gains `getIsolatedDefault`, kept **separate** from `getGlobalDefault` deliberately: a global default owns the launcher, the bare shim and the real `~/.<agent>` symlink, and folding the two together would hand an isolated version to every caller that reasonably assumes otherwise — the exact leak the isolation boundary exists to prevent. The resolution source reports `isolated-default` rather than claiming a global one.

Why this went unnoticed: the bare single-copy case already worked by falling through to `sole-installed`. It only bites with **two or more** isolated copies, or an explicit `@default`.

## Sweep

I checked the other places that could carry the same assumption:

- `findExecutable` callers — `teams/agents.ts` already prefers the shim path and falls back to PATH (correct); `sessions.ts` was the only one that didn't
- `getShimsDir()` consumers — `exec.ts` already resolves the alias absolutely, which is why `agents run` worked
- every other `getGlobalDefault` consumer — the rest are display/diagnostics where "no global default" is the truthful answer for an isolated agent

## Tests

`isolated-resume.integration.test.ts` (3) — the alias resolves to an absolute path (and asserts the shims dir really isn't on PATH, which is the premise); codex's real `resume` verb is used, never a slash command; the fallback contains no `/`-prefixed argument at all.

`agent-spec/resolve.test.ts` (+5) — bare resolves to the isolated default; a global default still wins; a project pin wins over both; `@default`/`@pinned` reach it and report `isolated-default`; two isolated copies no longer throw. The in-memory provider fixture gains `isolated`.

Full suite: **6648 pass**. The 4 failures are the pre-existing codex `exec`/`models` tests that read real local state and pass with a clean `HOME` — present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)