### PR TITLE
feat(sessions): preview-by-default in the browser + clickable ticket/PR links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- **Interactive session browser: preview-by-default with clickable ticket + PR links.**
+  The `agents sessions` / `--active` browser now shows the highlighted row's preview
+  pane **open by default** (matching the static picker) instead of hiding it behind
+  `tab` — arrow through rows and read prompt/activity/last-response inline; `tab`
+  toggles it off. The preview gains a **links line**: the worked-on ticket and the PR
+  the session opened render as **OSC 8 hyperlinks** (clickable in supporting
+  terminals) — the ticket to Linear, the `PR#` to GitHub. The Linear workspace slug is
+  resolved config-first (`LINEAR_WORKSPACE` env, else the linear-cli config's
+  `workspaceUrlKey`), never hardcoded, so tickets stay plain text when it's unknown.
+  Source: `apps/cli/src/lib/picker.ts`, `apps/cli/src/commands/sessions-picker.ts`,
+  `apps/cli/src/commands/sessions-browser.ts`, `apps/cli/src/lib/session/render.ts`,
+  `apps/cli/src/lib/session/linear.ts`.
 - **`agents resources --merged` shows the effective DotAgents resource surface (RUSH-1770).**
   The command lists the merged skills, commands, MCP servers, hooks, rules, plugins,
   workflows, and subagents resolved through project > user > system > extras, with

--- a/README.md
+++ b/README.md
@@ -270,10 +270,11 @@ On a terminal, `agents sessions --active` (and a bare `agents sessions`) open th
 | `d` | device (cycles) | `--device` |
 | `p` | this repo ↔ all dirs | `--all` |
 | `w` | time window | `--since` |
+| `tab` | toggle the preview pane | — |
 | `⏎` | resume / attach | `resume` / `focus` |
 | `y` | copy the equivalent command | `--print-cmd` |
 
-Filters **stack** (they AND together), the active set shows in the header, and the highlighted row previews below. Because every hotkey has a flag, the view you build by hand is a real command: press `y` (or run `--print-cmd`) to get the exact `ag sessions …` line — explore interactively, hand the line to an agent. Piped output, `--json`, or `--no-interactive` keep the plain listing for scripts. Peek without opening the pager with `agents sessions <id> --preview`.
+Filters **stack** (they AND together), the active set shows in the header, and the highlighted row **previews below by default** (`tab` hides it) — prompt, activity, last response, plus a links line where the worked-on ticket and the PR the session opened are **clickable** (OSC 8 hyperlinks: the ticket jumps to Linear, the `PR#` to GitHub, in terminals that support them). The Linear workspace is resolved from `LINEAR_WORKSPACE` or the linear-cli config, so tickets stay plain text when it's unknown. Because every hotkey has a flag, the view you build by hand is a real command: press `y` (or run `--print-cmd`) to get the exact `ag sessions …` line — explore interactively, hand the line to an agent. Piped output, `--json`, or `--no-interactive` keep the plain listing for scripts. Peek without opening the pager with `agents sessions <id> --preview`.
 
 Each live session resolves to `working`, `waiting_input` (with why -- a question, a plan review, or a permission prompt), or `idle`, alongside badges for the PR it opened, the worktree it sits in, and the ticket it's working. `agents sessions focus [id]` attaches the live pane in place -- the tmux split locally or over SSH, or its Ghostty tab -- and falls back to a fresh tab + resume when the terminal is gone.
 

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -263,7 +263,7 @@ function helpFor(_f: BrowserFilter, mode: 'nav' | 'search'): string {
   if (mode === 'search') {
     return 'type to filter · ↑↓ navigate · esc exit search · ⏎ resume';
   }
-  return 's search · r running · c teams · a agent · d device · p project · w window · y copy-cmd · ⏎ resume · esc quit';
+  return 's search · r running · c teams · a agent · d device · p project · w window · tab preview · y copy-cmd · ⏎ resume · esc quit';
 }
 
 /**

--- a/apps/cli/src/commands/sessions-picker.test.ts
+++ b/apps/cli/src/commands/sessions-picker.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The session preview header surfaces the worked-on ticket and the PR the
+ * session opened, so a reviewer can jump straight to Linear / GitHub from the
+ * browser. Both are rendered by `buildPreview` (via `formatHeader`); we assert
+ * the labels appear rather than the OSC 8 escape, which is TTY-gated.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { stripVTControlCharacters } from 'node:util';
+import { buildPreview } from './sessions-picker.js';
+import { _resetLinearWorkspaceCache } from '../lib/session/linear.js';
+import type { SessionMeta } from '../lib/session/types.js';
+
+function mk(overrides: Partial<SessionMeta>): SessionMeta {
+  return {
+    id: 'link-test-' + Math.random().toString(36).slice(2),
+    shortId: 'linktest',
+    agent: 'claude',
+    // No filePath → buildPreview takes the metadata-only branch, which still
+    // renders the header (and thus the ticket/PR line) without parsing a file.
+    ...overrides,
+  } as SessionMeta;
+}
+
+describe('buildPreview — ticket + PR links line', () => {
+  const savedEnv = process.env.LINEAR_WORKSPACE;
+  beforeEach(() => {
+    _resetLinearWorkspaceCache();
+    process.env.LINEAR_WORKSPACE = 'acme';
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.LINEAR_WORKSPACE;
+    else process.env.LINEAR_WORKSPACE = savedEnv;
+    _resetLinearWorkspaceCache();
+  });
+
+  it('shows the ticket id and PR number in the preview', () => {
+    const preview = stripVTControlCharacters(
+      buildPreview(mk({ ticketId: 'RUSH-1864', prUrl: 'https://github.com/o/r/pull/42', prNumber: 42 })),
+    );
+    expect(preview).toContain('RUSH-1864');
+    expect(preview).toContain('PR#42');
+  });
+
+  it('embeds the canonical Linear + GitHub URLs as OSC 8 hyperlink targets when linkable', () => {
+    // The raw preview (escapes intact) should carry the hyperlink targets IF the
+    // terminal supports OSC 8. In a non-TTY test env it degrades to plain text, so
+    // we only assert the target is present when an escape was actually emitted.
+    const raw = buildPreview(
+      mk({ ticketId: 'RUSH-1864', prUrl: 'https://github.com/o/r/pull/42', prNumber: 42 }),
+    );
+    if (raw.includes('\x1b]8;;')) {
+      expect(raw).toContain('https://linear.app/acme/issue/RUSH-1864');
+      expect(raw).toContain('https://github.com/o/r/pull/42');
+    } else {
+      expect(stripVTControlCharacters(raw)).toContain('RUSH-1864');
+    }
+  });
+
+  it('omits the links line entirely when the session has neither', () => {
+    const preview = stripVTControlCharacters(buildPreview(mk({})));
+    expect(preview).not.toContain('PR#');
+    expect(preview).not.toContain('issue/');
+  });
+});

--- a/apps/cli/src/commands/sessions-picker.ts
+++ b/apps/cli/src/commands/sessions-picker.ts
@@ -11,7 +11,8 @@ import { truncate, humanDuration } from '../lib/format.js';
 import type { SessionEvent, SessionMeta } from '../lib/session/types.js';
 import { parseSession, sanitizeForTerminal } from '../lib/session/parse.js';
 import { cleanSessionPrompt, extractSessionTopic } from '../lib/session/prompt.js';
-import { linkPath, relativeToCwd } from '../lib/session/render.js';
+import { linkPath, linkUrl, relativeToCwd } from '../lib/session/render.js';
+import { linearIssueUrl } from '../lib/session/linear.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { itemPicker } from '../lib/picker.js';
 import { classifyFileChanges, changeCounts, toolHistogram, detectTestResult } from '../lib/session/digest.js';
@@ -44,6 +45,8 @@ function sanitizeMeta(s: SessionMeta): SessionMeta {
     account: clean(s.account),
     topic: clean(s.topic),
     label: clean(s.label),
+    ticketId: clean(s.ticketId),
+    prUrl: clean(s.prUrl),
   };
 }
 
@@ -152,10 +155,23 @@ function formatHeader(session: SessionMeta, events: SessionEvent[]): string {
   if (session.label) line3.push(chalk.white(session.label));
   line3.push(chalk.gray(linkPath(session.filePath, session.id)));
 
+  // Line 4: ticket + PR — clickable when a URL is resolvable (OSC 8 hyperlink),
+  // plain text otherwise. Only rendered when the session carries either.
+  const line4: string[] = [];
+  if (session.ticketId) {
+    const url = linearIssueUrl(session.ticketId);
+    line4.push(chalk.blue(url ? linkUrl(url, session.ticketId) : session.ticketId));
+  }
+  if (session.prUrl) {
+    const label = session.prNumber ? `PR#${session.prNumber}` : 'PR';
+    line4.push(chalk.blue(linkUrl(session.prUrl, label)));
+  }
+
   return [
     line1.join(DOT),
     line2.join(DOT),
     line3.join(DOT),
+    ...(line4.length ? [line4.join(DOT)] : []),
   ].join('\n');
 }
 

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -493,7 +493,10 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
     const [loading, setLoading] = useState(true);
     const [query, setQuery] = useState('');
     const [mode, setMode] = useState<'nav' | 'search'>('nav');
-    const [previewOpen, setPreviewOpen] = useState(false);
+    // Default the preview pane open when the caller supplies a preview builder —
+    // matches the static `itemPicker`, so the session browser shows a live preview
+    // as you arrow through rows instead of hiding it behind `tab`.
+    const [previewOpen, setPreviewOpen] = useState(Boolean(cfg.buildPreview));
     const [active, setActive] = useState(0);
     const [flash, setFlash] = useState('');
     const prefix = usePrefix({ status, theme });

--- a/apps/cli/src/lib/session/linear.test.ts
+++ b/apps/cli/src/lib/session/linear.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { linearIssueUrl, linearWorkspace, _resetLinearWorkspaceCache } from './linear.js';
+
+describe('linearIssueUrl — config-driven, workspace-scoped, never hardcoded', () => {
+  const savedEnv = process.env.LINEAR_WORKSPACE;
+
+  beforeEach(() => {
+    _resetLinearWorkspaceCache();
+    process.env.LINEAR_WORKSPACE = 'acme';
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.LINEAR_WORKSPACE;
+    else process.env.LINEAR_WORKSPACE = savedEnv;
+    _resetLinearWorkspaceCache();
+  });
+
+  it('builds the canonical URL from the env workspace + a valid key', () => {
+    expect(linearWorkspace()).toBe('acme');
+    expect(linearIssueUrl('RUSH-1864')).toBe('https://linear.app/acme/issue/RUSH-1864');
+  });
+
+  it('only links strings shaped like a Linear key (TEAM-N)', () => {
+    expect(linearIssueUrl('GPT-5')).toBe('https://linear.app/acme/issue/GPT-5'); // valid shape
+    expect(linearIssueUrl('PR#123')).toBeUndefined(); // '#' → not a key
+    expect(linearIssueUrl('rush-1')).toBeUndefined(); // must be uppercase
+    expect(linearIssueUrl('RUSH-1234567')).toBeUndefined(); // >6 digits
+    expect(linearIssueUrl('')).toBeUndefined();
+    expect(linearIssueUrl(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when no workspace is configured (ticket stays plain text)', () => {
+    delete process.env.LINEAR_WORKSPACE;
+    _resetLinearWorkspaceCache();
+    // With no env override and (in CI) no linear-cli config, the key can't be linked.
+    // We assert the shape: either a real config resolves it, or it's undefined — never a throw.
+    const url = linearIssueUrl('RUSH-1');
+    expect(url === undefined || url === 'https://linear.app/' + linearWorkspace() + '/issue/RUSH-1').toBe(true);
+  });
+});

--- a/apps/cli/src/lib/session/linear.ts
+++ b/apps/cli/src/lib/session/linear.ts
@@ -1,0 +1,60 @@
+/**
+ * Resolve a clickable Linear issue URL for a tracker key (e.g. `RUSH-1234`).
+ *
+ * Linear issue URLs are workspace-scoped — `https://linear.app/<workspace>/issue/<KEY>`
+ * — so a bare key can't be linked without knowing the workspace slug (Linear's
+ * `organization.urlKey`). That slug is resolved config-first, never hardcoded:
+ *
+ *   1. `LINEAR_WORKSPACE` env var — explicit override, else
+ *   2. `workspaceUrlKey` in the linear-cli config (`~/.linear-cli/config.json`).
+ *
+ * When neither is set the ticket stays plain text — it's still shown, just not
+ * linked. This keeps the OSS CLI free of any Rush/workspace-specific string.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** A Linear tracker key: `TEAM-N`, e.g. `RUSH-1234`. Mirrors the detector's shape. */
+const LINEAR_KEY_RE = /^[A-Z]{2,6}-\d{1,6}$/;
+
+// `undefined` = not yet resolved; `null` = resolved-but-unknown (skip re-reading).
+let workspaceCache: string | null | undefined;
+
+/** The configured Linear workspace slug, or undefined when unknown. Cached per process. */
+export function linearWorkspace(): string | undefined {
+  if (workspaceCache !== undefined) return workspaceCache ?? undefined;
+
+  const env = process.env.LINEAR_WORKSPACE?.trim();
+  if (env) {
+    workspaceCache = env;
+    return env;
+  }
+
+  try {
+    const cfgPath = path.join(os.homedir(), '.linear-cli', 'config.json');
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8')) as { workspaceUrlKey?: string };
+    const ws = cfg.workspaceUrlKey?.trim();
+    if (ws) {
+      workspaceCache = ws;
+      return ws;
+    }
+  } catch {
+    // no linear-cli config (or unreadable) — leave tickets unlinked
+  }
+
+  workspaceCache = null;
+  return undefined;
+}
+
+/** Canonical Linear issue URL for a tracker key, or undefined if unresolvable. */
+export function linearIssueUrl(ticketId?: string): string | undefined {
+  if (!ticketId || !LINEAR_KEY_RE.test(ticketId)) return undefined;
+  const ws = linearWorkspace();
+  return ws ? `https://linear.app/${ws}/issue/${ticketId}` : undefined;
+}
+
+/** Clear the cached workspace lookup. Tests only. */
+export function _resetLinearWorkspaceCache(): void {
+  workspaceCache = undefined;
+}

--- a/apps/cli/src/lib/session/render.ts
+++ b/apps/cli/src/lib/session/render.ts
@@ -33,21 +33,36 @@ export function relativeToCwd(absPath: string, cwd?: string): string {
   return absPath;
 }
 
+/** Best-effort feature-detect for OSC 8 hyperlink support in the current TTY. */
+function supportsHyperlinks(): boolean {
+  return Boolean(
+    process.stdout.isTTY &&
+      (process.env.TERM_PROGRAM ||
+        process.env.WT_SESSION ||
+        process.env.KITTY_WINDOW_ID ||
+        process.env.WEZTERM_PANE),
+  );
+}
+
+/** Wrap `label` in an OSC 8 hyperlink to `target`. Callers gate on {@link supportsHyperlinks}. */
+function osc8(target: string, label: string): string {
+  return `\x1b]8;;${target}\x1b\\${label}\x1b]8;;\x1b\\`;
+}
+
 /**
- * Wrap label in an OSC 8 hyperlink when the terminal supports it.
- * Degrades to plain label otherwise.
+ * Wrap a filesystem path label in an OSC 8 `file://` hyperlink when the terminal
+ * supports it. Degrades to the plain label otherwise.
  */
 export function linkPath(absPath: string, label: string): string {
-  if (
-    process.stdout.isTTY &&
-    (process.env.TERM_PROGRAM ||
-      process.env.WT_SESSION ||
-      process.env.KITTY_WINDOW_ID ||
-      process.env.WEZTERM_PANE)
-  ) {
-    return `\x1b]8;;file://${absPath}\x1b\\${label}\x1b]8;;\x1b\\`;
-  }
-  return label;
+  return supportsHyperlinks() ? osc8(`file://${absPath}`, label) : label;
+}
+
+/**
+ * Wrap a label in an OSC 8 hyperlink to an arbitrary URL (a PR on GitHub, a Linear
+ * issue, …) when the terminal supports it. Degrades to the plain label otherwise.
+ */
+export function linkUrl(url: string, label: string): string {
+  return supportsHyperlinks() ? osc8(url, label) : label;
 }
 
 // ── Command grouping ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Two fixes to the interactive `agents sessions` / `--active` browser:

1. **Preview shows by default.** The browser is built on `dynamicPicker`, which
   initialized its preview pane **closed** — so the highlighted row's preview only
   appeared after pressing `tab`, unlike the static `itemPicker` (used elsewhere),
   which opens it by default. `dynamicPicker` now defaults the preview open whenever a
   preview builder is supplied, matching the static picker. `tab` still toggles it,
   and the browser's help legend now advertises `tab preview`.

2. **Ticket + PR links are clickable.** The preview header gains a links line where
   the worked-on ticket and the PR the session opened render as **OSC 8 hyperlinks**
   (clickable in supporting terminals) — the ticket jumps to Linear, the `PR#` to
   GitHub. A new `linkUrl` helper (factored out of `linkPath`) wraps arbitrary URLs.

## Why

`dynamicPicker` is used **only** by the sessions browser, so the preview-default
change is perfectly scoped to it. Before, users didn't even know a preview existed
here (the legend never mentioned `tab`).

## Linear workspace resolution (no hardcoding)

Linear issue URLs are workspace-scoped (`https://linear.app/<workspace>/issue/<KEY>`),
so a bare key can't be linked without the workspace slug. It's resolved **config-first,
never hardcoded** (this is Phoenix OSS, brand-separate from Rush):

1. `LINEAR_WORKSPACE` env var, else
2. `workspaceUrlKey` in the linear-cli config (`~/.linear-cli/config.json`).

When neither is set, the ticket stays plain text — still shown, just not linked.

## Evidence — rendered preview with a hyperlink-capable TTY

`buildPreview` on a session with `ticketId` + `prUrl`, escapes made visible:

```
Claude v2.1.287
0 msgs · <id>
[OSC8-> https://linear.app/getrush/issue/RUSH-1864 ]RUSH-1864[ ] · [OSC8-> https://github.com/muqsitnawaz/agents-cli/pull/512 ]PR#512[ ]
```

The ticket wraps `RUSH-1864` → the canonical Linear URL; the `PR#512` wraps the GitHub
PR URL. Both are real OSC 8 hyperlinks.

## Tests

- `apps/cli/src/lib/session/linear.test.ts` — URL construction + key-shape gating.
- `apps/cli/src/commands/sessions-picker.test.ts` — preview surfaces ticket + PR,
  omits the line when neither is present.
- Typecheck clean (`tsc --noEmit`), 40 adjacent tests green (render / browser /
  live-preview + the 6 new).

## Docs + changelog

README session-browser section updated (new `tab` row + clickable-links note);
`CHANGELOG.md` Unreleased → Added entry.

---

Session transcript (public repo — referenced by path, not attached):
`yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit/9e8231f6-a3ea-4c45-8fc9-712eac541af8.jsonl`
