### PR TITLE
menu bar: prune ghost sentinels, group NEEDS YOU, end silent truncation

### DIFF
--- a/apps/cli/.changelog/next/menubar-prune-and-collapse.md
+++ b/apps/cli/.changelog/next/menubar-prune-and-collapse.md
@@ -1,0 +1,16 @@
+- **Menu bar: prune orphan attention sentinels; group `NEEDS YOU`; end silent
+  truncation.** `LocalState.attentionMarks` now takes the caller's live-session
+  set and unlinks sentinels whose `sessionId` is not alive — the
+  `06-attention-sentinel.sh` hook already clears on `Stop`/`UserPromptSubmit`,
+  but leaks when a terminal is killed hard, a Claude version has no hook, or the
+  `sessionId` doesn't round-trip; the reader is the only layer with `pidAlive`
+  ground truth. Verified on mac-mini: 6 stale sentinels aged 1–22 days pruned to
+  0 on one dump run. `addNeedsAttention` groups blocked sessions by
+  `(agent, repo)` and collapses groups of 2+ into a single
+  `<Agent> · <repo> · N waiting · oldest <t> ›` row + submenu, dropping the
+  generic `— Claude is waiting for your input` filler when the Notification
+  message is empty. `addActive` collapses the `"other"` bucket to a single
+  clickable `ACTIVE · other · N idle ›` row when idle-only, and replaces the
+  silent 3-cap on idle rows with an explicit `+ N more idle ›` row + submenu so
+  the header count always matches visible + explicit-hidden. No new session
+  state — closed = hidden, as before.

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -75,14 +75,22 @@ One rule shapes the menu: **attention floats up, context groups down.**
 ```
 
 - **⚠ NEEDS YOU** — the triage strip, pinned on top and never nested in a project
-  group. Blocked sessions sorted by wait-time (most-stalled first, regardless of
-  repo), each showing the actual question it's waiting on (attention-sentinel
-  content) and elapsed wait (sentinel mtime). Failed / overdue routines and a
-  stopped scheduler append here. Empty when nothing needs attention.
+  group. Blocked sessions are grouped by (agent, repo): a group of 1 renders
+  inline with the actual question it's waiting on (or bare when the Notification
+  hook wrote no message); a group of 2+ collapses to one
+  `<Agent> · <repo> · N waiting · oldest <elapsed> ›` row with a submenu that
+  lists each session (oldest first). Groups themselves sort by their oldest
+  wait. Failed / overdue routines and a stopped scheduler append here. Empty
+  when nothing needs attention.
 - **New Session** — launches `agents run <agent>` in a new Terminal window.
 - **ACTIVE · \<repo\>** — live work grouped by repo. A session is *running* if
   its transcript was written in the last 2 minutes, else *idle*. Rich rows show
-  the session's title inline; the row's submenu reveals the working dir.
+  the session's title inline; the row's submenu reveals the working dir. Idle
+  rows cap at 3 per repo; if the cap hides any, a `+ N more idle ›` row exposes
+  the hidden count and opens the rest in a submenu — the header count always
+  matches what's visible + explicit hidden. The `"other"` bucket (sessions with
+  no repo — a dumping-ground group whose rows carry no per-row signal) collapses
+  to a single `ACTIVE · other · N idle ›` row + submenu when it's idle-only.
 - **ROUTINES** — kept glanceable: the next few upcoming plus any failed, timed-out,
   or overdue routine inline. Failed and timed-out routines include the latest
   failure reason when available; overdue routines are labeled `overdue` even when
@@ -122,7 +130,7 @@ The helper assembles the menu by reading these directly — no CLI, no re-index:
 | Active sessions | `agents sessions --active --local --json` (warm cache, 30s TTL) | every local session (tmux / IDE / headless) with running-vs-idle — feeds triage + ACTIVE once loaded |
 | Teams | `~/.agents/.history/teams/agents/<id>/meta.json` | running teammate agents |
 | Cloud | `~/.agents/.cache/cloud/tasks.db` (SQLite) | cloud tasks, incl. `input_required` or `needs_review` → "awaiting input" |
-| Attention sentinels | `~/.agents/.cache/state/attention/<sessionId>` | terminal sessions awaiting input — mtime = wait start, content = the awaiting message (written by the Notification hook; empty content renders "awaiting input") |
+| Attention sentinels | `~/.agents/.cache/state/attention/<sessionId>` | terminal sessions awaiting input — mtime = wait start, content = the awaiting message (written by the Notification hook). On read, sentinels whose sessionId is not in the current live-terminals set are unlinked as orphans (defense against sessions killed hard, hookless Claude versions, or sessionId mismatches). |
 | Installed agents | `~/.agents/.history/versions/<agent>/` | the agent roster |
 
 Liveness is a `kill(pid, 0)` check; running-vs-idle is the transcript file's

--- a/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
@@ -123,12 +123,24 @@ enum LocalState {
     // name = sessionId, mtime = when flagged, content = the notification message
     // (newer hooks write it; empty for the touch-only contract). One stat + one
     // tiny read per blocked session — stays cheap on the badge poll path.
-    static func attentionMarks() -> [String: AttentionMark] {
+    //
+    // liveSessionIds prunes orphans on read: a sentinel whose sessionId is not in
+    // the caller's live set (pid alive) gets unlinked. The write-side hook already
+    // clears on Stop/UserPromptSubmit, but it leaks when the terminal is killed
+    // hard, a Claude version has no hook installed, or the sessionId doesn't
+    // round-trip. The reader is the only layer with ground truth (pidAlive), so
+    // it's the choke point that keeps NEEDS YOU honest. When nil, keep the old
+    // behavior (no prune) — that's the callers that don't yet know a live set.
+    static func attentionMarks(liveSessionIds: Set<String>? = nil) -> [String: AttentionMark] {
         let dir = "\(home)/.agents/.cache/state/attention"
         let names = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
         var out: [String: AttentionMark] = [:]
         for name in names where !name.hasPrefix(".") {
             let path = "\(dir)/\(name)"
+            if let live = liveSessionIds, !live.contains(name) {
+                try? fm.removeItem(atPath: path)
+                continue
+            }
             let attrs = try? fm.attributesOfItem(atPath: path)
             let since = (attrs?[.modificationDate] as? Date).map { $0.timeIntervalSince1970 * 1000 }
             let raw = (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
@@ -136,6 +148,24 @@ enum LocalState {
                                       text: raw.trimmingCharacters(in: .whitespacesAndNewlines))
         }
         return out
+    }
+
+    // Live terminal sessionIds — pid-alive, non-empty. Used to prune orphan
+    // attention sentinels on the cheap poll path.
+    private static func liveTerminalSessionIds() -> Set<String> {
+        let path = "\(home)/.agents/.cache/terminals/live-terminals.json"
+        guard let data = fm.contents(atPath: path),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
+        var ids: Set<String> = []
+        for (_, window) in root {
+            guard let w = window as? [String: Any],
+                  let entries = w["entries"] as? [[String: Any]] else { continue }
+            for e in entries {
+                guard let pid = e["pid"] as? Int, pidAlive(pid) else { continue }
+                if let sid = e["sessionId"] as? String, !sid.isEmpty { ids.insert(sid) }
+            }
+        }
+        return ids
     }
 
     // MARK: Pending devices (written by the daemon device probe)
@@ -158,7 +188,8 @@ enum LocalState {
     // local files still contribute what the engine payload lacks: the terminal
     // label (title) and the attention sentinel (question + wait-start).
     static func sessions(fromActive active: [ActiveSession]) -> [Session] {
-        let attention = attentionMarks()
+        let liveIds = Set(active.compactMap { $0.sessionId }.filter { !$0.isEmpty })
+        let attention = attentionMarks(liveSessionIds: liveIds)
         let titles = terminalTitles()
         var out: [Session] = []
         for a in active {
@@ -204,7 +235,8 @@ enum LocalState {
     // scanning it every few seconds is too costly. Terminals + cloud + attention
     // are cheap. The full scan (with teams) runs only when the menu opens.
     static func sessions(includeTeams: Bool = true) -> [Session] {
-        let attention = attentionMarks()
+        let liveIds = liveTerminalSessionIds()
+        let attention = attentionMarks(liveSessionIds: liveIds)
         var all = terminals(attention: attention) + cloud()
         if includeTeams { all += teams() }
         return all

--- a/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
@@ -124,13 +124,14 @@ enum LocalState {
     // (newer hooks write it; empty for the touch-only contract). One stat + one
     // tiny read per blocked session — stays cheap on the badge poll path.
     //
-    // liveSessionIds prunes orphans on read: a sentinel whose sessionId is not in
-    // the caller's live set (pid alive) gets unlinked. The write-side hook already
-    // clears on Stop/UserPromptSubmit, but it leaks when the terminal is killed
-    // hard, a Claude version has no hook installed, or the sessionId doesn't
-    // round-trip. The reader is the only layer with ground truth (pidAlive), so
-    // it's the choke point that keeps NEEDS YOU honest. When nil, keep the old
-    // behavior (no prune) — that's the callers that don't yet know a live set.
+    // liveSessionIds prunes orphans on read: a sentinel whose sessionId is not
+    // in the caller's live set (pid alive) gets unlinked. The write-side hook
+    // already clears on Stop/UserPromptSubmit, but it leaks when the terminal
+    // is killed hard, a Claude version has no hook installed, or the sessionId
+    // doesn't round-trip. When nil, keep sentinels intact — pruning against a
+    // partial live set (e.g. IDE-extension terminals only) would wipe live
+    // headless/tmux/SSH sentinels within one poll. Only the engine's full
+    // active-list (sessions(fromActive:)) is broad enough to safely prune.
     static func attentionMarks(liveSessionIds: Set<String>? = nil) -> [String: AttentionMark] {
         let dir = "\(home)/.agents/.cache/state/attention"
         let names = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
@@ -148,24 +149,6 @@ enum LocalState {
                                       text: raw.trimmingCharacters(in: .whitespacesAndNewlines))
         }
         return out
-    }
-
-    // Live terminal sessionIds — pid-alive, non-empty. Used to prune orphan
-    // attention sentinels on the cheap poll path.
-    private static func liveTerminalSessionIds() -> Set<String> {
-        let path = "\(home)/.agents/.cache/terminals/live-terminals.json"
-        guard let data = fm.contents(atPath: path),
-              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
-        var ids: Set<String> = []
-        for (_, window) in root {
-            guard let w = window as? [String: Any],
-                  let entries = w["entries"] as? [[String: Any]] else { continue }
-            for e in entries {
-                guard let pid = e["pid"] as? Int, pidAlive(pid) else { continue }
-                if let sid = e["sessionId"] as? String, !sid.isEmpty { ids.insert(sid) }
-            }
-        }
-        return ids
     }
 
     // MARK: Pending devices (written by the daemon device probe)
@@ -235,8 +218,15 @@ enum LocalState {
     // scanning it every few seconds is too costly. Terminals + cloud + attention
     // are cheap. The full scan (with teams) runs only when the menu opens.
     static func sessions(includeTeams: Bool = true) -> [Session] {
-        let liveIds = liveTerminalSessionIds()
-        let attention = attentionMarks(liveSessionIds: liveIds)
+        // Cheap path: read attention sentinels WITHOUT pruning. live-terminals.json
+        // only carries IDE-extension terminals (VS Code / Cursor / Codium via the
+        // agents-cli extension) — a strict subset of live sessions. A pid-alive
+        // Claude in a plain Terminal / tmux / SSH shell isn't in it, so pruning
+        // against this narrow set would delete live, genuinely-waiting sentinels
+        // within one badge tick (10s). Pruning only happens on the warm-cache
+        // path (sessions(fromActive:)) where the engine active-list gives full
+        // coverage across tmux / IDE / headless.
+        let attention = attentionMarks()
         var all = terminals(attention: attention) + cloud()
         if includeTeams { all += teams() }
         return all

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -399,21 +399,46 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
 
     // Returns true if anything was rendered (caller adds the trailing separator).
-    // Triage strip: blocked sessions sorted by wait-time (most-stalled first,
-    // regardless of repo), each carrying the actual question it's waiting on
-    // plus how long it's been waiting. Waiting first, then failed.
+    // Triage strip: blocked sessions grouped by (agent, repo). A group with 2+
+    // blocked sessions collapses to one row + submenu — walls of identical
+    // "Claude · muqsitnawaz — Claude is waiting for your input" rows were the
+    // single biggest source of noise. Groups of 1 render inline as before; the
+    // generic "awaiting input" filler drops when the Notification message is
+    // empty (the ⚠ glyph + section header already convey it). Failing routines
+    // follow.
     private func addNeedsAttention(_ menu: NSMenu, sessions: [Session],
                                    routines: [Routine], daemonPid: Int?, rich: Bool) -> Bool {
         var rows: [(String, NSColor, String, NSMenu?)] = []   // glyph, color, text, submenu
 
-        let blocked = sessions.filter { $0.status == .attention }.sorted {
-            ($0.attentionSinceMs ?? .greatestFiniteMagnitude) < ($1.attentionSinceMs ?? .greatestFiniteMagnitude)
+        let blocked = sessions.filter { $0.status == .attention }
+        let groups = Dictionary(grouping: blocked) { s in "\(s.agent)\u{0000}\(s.repo)" }
+        // Sort each group oldest-first, then order groups by their oldest wait.
+        let sortedGroups = groups.values.map { group -> [Session] in
+            group.sorted { ($0.attentionSinceMs ?? .greatestFiniteMagnitude) < ($1.attentionSinceMs ?? .greatestFiniteMagnitude) }
+        }.sorted { (a, b) in
+            (a.first?.attentionSinceMs ?? .greatestFiniteMagnitude) < (b.first?.attentionSinceMs ?? .greatestFiniteMagnitude)
         }
-        for s in blocked {
-            let q = s.question.isEmpty ? "awaiting input" : trim(s.question, rich ? 48 : 34)
-            var text = "\(LocalState.agentLabel(s.agent)) · \(s.repo) — \(q)"
-            if let since = s.attentionSinceMs { text += "  ·  \(elapsedShort(since))" }
-            rows.append(("⚠", wait, text, s.cwd.map { revealSubmenu($0) }))
+
+        for group in sortedGroups {
+            guard let first = group.first else { continue }
+            let agentLabel = LocalState.agentLabel(first.agent)
+            let repo = first.repo
+            if group.count == 1 {
+                // Inline: skip the generic filler when the hook wrote no message.
+                var text = "\(agentLabel) · \(repo)"
+                if !first.question.isEmpty {
+                    text += " — \(trim(first.question, rich ? 48 : 34))"
+                }
+                if let since = first.attentionSinceMs { text += "  ·  \(elapsedShort(since))" }
+                rows.append(("⚠", wait, text, first.cwd.map { revealSubmenu($0) }))
+            } else {
+                // Collapsed: N waiting · oldest elapsed. Submenu lists each session.
+                var text = "\(agentLabel) · \(repo) · \(group.count) waiting"
+                if let since = first.attentionSinceMs {
+                    text += "  ·  oldest \(elapsedShort(since))"
+                }
+                rows.append(("⚠", wait, text, groupedWaitersSubmenu(group)))
+            }
         }
 
         if daemonPid == nil && !routines.isEmpty {
@@ -436,13 +461,40 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
 
         if rows.isEmpty { return false }
-        addSectionTitle(menu, "⚠ NEEDS YOU (\(rows.count))", color: wait)
+        // Title carries both the group count and the true blocked-session count so
+        // the badge / header math stays legible when grouping is in play.
+        let blockedTotal = blocked.count
+        let groupCount = sortedGroups.count
+        let title: String
+        if groupCount == blockedTotal {
+            title = "⚠ NEEDS YOU (\(rows.count))"
+        } else {
+            title = "⚠ NEEDS YOU (\(groupCount) groups · \(blockedTotal) sessions)"
+        }
+        addSectionTitle(menu, title, color: wait)
         for (glyph, color, text, sub) in rows {
             let it = statusRow(glyph, color, text)
             it.submenu = sub
             menu.addItem(it)
         }
         return true
+    }
+
+    // Submenu listing every blocked session in a grouped (agent, repo) waiter.
+    // Sorted oldest-first (most stalled at the top). Row = session title (or a
+    // "session" fallback when no title) with the elapsed wait as the trailing chip.
+    private func groupedWaitersSubmenu(_ group: [Session]) -> NSMenu {
+        let sub = NSMenu()
+        for s in group {
+            let label = s.title.isEmpty ? "session" : trim(s.title, 36)
+            var text = label
+            if !s.question.isEmpty { text += " — \(trim(s.question, 34))" }
+            if let since = s.attentionSinceMs { text += "  ·  \(elapsedShort(since))" }
+            let it = statusRow("⚠", wait, text)
+            if let cwd = s.cwd { it.submenu = revealSubmenu(cwd) }
+            sub.addItem(it)
+        }
+        return sub
     }
 
     // Returns true if anything was rendered (caller adds the trailing separator).
@@ -485,11 +537,33 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // Live work grouped by repo: one `ACTIVE · <repo>` header per project, the
     // repo's sessions clustered under it. Rich rows carry the session's own
     // title inline (the repo lives in the header, so rows don't repeat it).
+    //
+    // Two rendering rules keep the section from walling the menu:
+    //   • The "other" bucket (sessions with no repo) collapses to a single
+    //     clickable section header + submenu when it's idle-only. That's a
+    //     dumping-ground group whose individual rows don't repay their space.
+    //   • Idle rows cap at 3 per repo, but the 4th+ never disappears silently:
+    //     an explicit "+ N more idle" row shows the count with a submenu of
+    //     the rest, so the header count always matches what's on screen.
+    private let idlePerRepoCap = 3
+
     private func addActive(_ menu: NSMenu, live: [Session], browserTasks: [BrowserTask], rich: Bool) {
         let groups = Dictionary(grouping: live) { $0.repo.isEmpty ? "other" : $0.repo }
         for (repo, group) in groups.sorted(by: { $0.key.lowercased() < $1.key.lowercased() }) {
             let running = group.filter { $0.status == .running }.count
             let idle = group.count - running
+
+            // Collapsed "other" bucket: idle-only groups render as one
+            // interactive section header. No fake ◐ session row — the header
+            // itself carries the count and opens the submenu.
+            if repo == "other" && running == 0 && idle > 0 {
+                let title = "ACTIVE · other  ·  \(idle) idle"
+                let item = statusRow("", .secondaryLabelColor, title)
+                item.submenu = collapsedIdleSubmenu(group, rich: rich)
+                menu.addItem(item)
+                continue
+            }
+
             var title = "ACTIVE · \(repo)"
             var counts: [String] = []
             if running > 0 { counts.append("\(running) running") }
@@ -497,16 +571,20 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             if !counts.isEmpty { title += "  ·  " + counts.joined(separator: " · ") }
             addSectionTitle(menu, title, color: .secondaryLabelColor)
 
-            // Running rows always render; idle rows cap at 3 per repo (the
-            // header carries the true counts) so a big idle fleet can't wall
-            // the menu.
+            // Running rows always render; idle rows cap at idlePerRepoCap. If
+            // the cap hides any, an explicit "+ N more idle" row exposes the
+            // hidden count and opens the rest in a submenu.
             let ordered = group.sorted { a, b in
                 (a.status == .running ? 0 : 1) < (b.status == .running ? 0 : 1)
             }
             var idleShown = 0
+            var hiddenIdle: [Session] = []
             for s in ordered {
                 if s.status != .running {
-                    if idleShown >= 3 { continue }
+                    if idleShown >= idlePerRepoCap {
+                        hiddenIdle.append(s)
+                        continue
+                    }
                     idleShown += 1
                 }
                 let glyph = s.status == .running ? "●" : "◐"
@@ -515,6 +593,12 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 let row = statusRow(glyph, color, "\(LocalState.agentLabel(s.agent))\(detail)")
                 if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
                 menu.addItem(row)
+            }
+            if !hiddenIdle.isEmpty {
+                let moreLabel = "+ \(hiddenIdle.count) more idle"
+                let more = statusRow("", info, moreLabel)
+                more.submenu = collapsedIdleSubmenu(hiddenIdle, rich: rich)
+                menu.addItem(more)
             }
         }
         if !browserTasks.isEmpty {
@@ -526,6 +610,19 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 menu.addItem(row)
             }
         }
+    }
+
+    // Submenu for the "+N more idle" row and the collapsed "other" section
+    // header — every hidden session gets a row with agent · title.
+    private func collapsedIdleSubmenu(_ sessions: [Session], rich: Bool) -> NSMenu {
+        let sub = NSMenu()
+        for s in sessions {
+            let detail = (rich && !s.title.isEmpty) ? " — \(trim(s.title, 36))" : ""
+            let row = statusRow("◐", idleC, "\(LocalState.agentLabel(s.agent))\(detail)")
+            if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
+            sub.addItem(row)
+        }
+        return sub
     }
 
     private func addRecent(_ menu: NSMenu, recentSessions: [RecentSession], rich: Bool) {

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -461,17 +461,13 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
 
         if rows.isEmpty { return false }
-        // Title carries both the group count and the true blocked-session count so
-        // the badge / header math stays legible when grouping is in play.
-        let blockedTotal = blocked.count
-        let groupCount = sortedGroups.count
-        let title: String
-        if groupCount == blockedTotal {
-            title = "⚠ NEEDS YOU (\(rows.count))"
-        } else {
-            title = "⚠ NEEDS YOU (\(groupCount) groups · \(blockedTotal) sessions)"
-        }
-        addSectionTitle(menu, title, color: wait)
+        // Title reflects the count of rendered rows in this section — always.
+        // Any grouped-session count lives in the row text itself ("N waiting"),
+        // so the header stays a simple 1:1 with what's visible below. This keeps
+        // it consistent with the ACTIVE section's "header count = visible rows"
+        // invariant, and never drops the failing-routines / scheduler-stopped
+        // rows from the header count when grouping is in play.
+        addSectionTitle(menu, "⚠ NEEDS YOU (\(rows.count))", color: wait)
         for (glyph, color, text, sub) in rows {
             let it = statusRow(glyph, color, text)
             it.submenu = sub


### PR DESCRIPTION
## Why

The menu-bar dropdown was showing an unusable session list on this fleet:

- **NEEDS YOU (11)** with 11 identical `⚠ Claude · muqsitnawaz — Claude is waiting for your input` rows aged 1d / 2h25m / 1h54m / 1h51m. Every row said the same thing; the *only* varying signal was the elapsed timer.
- **ACTIVE · other · 21 idle** header advertising 21 rows but rendering 3, with the other 18 dropped silently by the cap in `StatusItemController.swift`.
- Live evidence of the root cause: `~/.agents/.cache/state/attention/` on mac-mini held **6 sentinel files aged Jul 8, 9, 15, 24, 27, 29** — days-stale ghosts. The `06-attention-sentinel.sh` write path clears on `Stop`/`UserPromptSubmit`, but leaks whenever a terminal is killed hard, a Claude version lacks the hook, or the sessionId doesn't round-trip. There's no reader-side liveness check.

## What

Three focused changes, one commit each; no new state, no new dependencies.

- **`fix(menubar)`: prune orphan attention sentinels on read.** `LocalState.attentionMarks()` now takes the caller's live-session set (from `live-terminals.json` on the badge path, from `--active --local --json` on the menu-open path) and unlinks sentinels whose sessionId isn't in it. The reader is the only layer with `pidAlive` ground truth.
- **`refactor(menubar)`: group NEEDS YOU, collapse "other", end silent truncation.**
  - `addNeedsAttention`: groups blocked sessions by `(agent, repo)`; groups of 2+ collapse to one row + submenu; groups of 1 inline as before. Generic `— Claude is waiting for your input` filler drops when the Notification hook wrote no message.
  - `addActive`: the `"other"` bucket collapses to a single row + submenu when idle-only. The 3-cap on idle rows now renders an explicit `+ N more idle ›` instead of silently dropping.
- **`docs(menubar)`**: `apps/cli/docs/menubar.md` updated to document all of the above; `apps/cli/.changelog/next/menubar-prune-and-collapse.md` added.

## Evidence (end-to-end, real flow)

Before: `ls ~/.agents/.cache/state/attention/ | wc -l` = **6** (aged Jul 8 through Jul 29).

After: built the helper in this worktree (`swift build`, clean), ran `MENUBAR_DUMP=1 .build/debug/MenubarHelper`, then re-checked disk:

- `~/.agents/.cache/state/attention/` = **0 files** — every ghost pruned on read.
- `⚠ NEEDS YOU (1)` — only the genuine `✕ 15 routines failing` row (which is real, not sentinel-driven).
- ACTIVE section: each repo header count matches visible rows exactly (`ACTIVE · muqsit · 3 idle` → 3 ◐ rows; `ACTIVE · .openclaw · 2 idle` → 2 rows; `ACTIVE · publish3 · 1 idle` → 1 row). No silent drops.
- No `ACTIVE · other` bucket appeared on this run because no live sessions had empty repos.

## Mockup

Full before/after mockup at menu-bar dimensions with the four rules applied (opens locally): `mac-mini:/tmp/menu-mockup.html`.

## Not touched

- `06-attention-sentinel.sh` — writer already handles the happy path; failure modes are outside its control.
- `packages/session-tracker/` — sentinel writing isn't its job.
- The `SessionStatus` enum stays at 3 cases (`running / idle / attention / queued`). No new `.closed` case; closed = hidden, as before.

## Test plan

- [x] `swift build` clean.
- [x] `MENUBAR_DUMP=1` against live fleet state — 6 ghosts pruned to 0.
- [x] ACTIVE header counts match visible rows on live fleet.
- [ ] Restart the installed helper (`agents menubar restart` — separate, disruptive step) and confirm interactively.
- [ ] Trigger a real Notification-hook attention on a live session; confirm inline row appears; answer it; confirm it disappears within one poll cycle.
- [ ] Multi-waiter case: 3+ blocked Claudes in same repo → confirm the grouped row + submenu; then add a 4th with a specific question → confirm it renders inline next to the group.
- [ ] `+ N more idle ›` case: a repo with ≥ 4 idle Claudes → confirm the "+N more idle ›" row + submenu.