### PR TITLE
fix(sessions): exact session id for non-Claude + user-typed agents via launchId join

### DIFF
--- a/apps/cli/.changelog/1.20.74.md
+++ b/apps/cli/.changelog/1.20.74.md
@@ -91,3 +91,16 @@
   row is also resolved from PATH now (`getUnmanagedCliState`) instead of from the version
   dirs, which could otherwise report an isolated copy — deliberately unreachable from
   PATH — as `(global)`. Source: `apps/cli/src/commands/view.ts`, `apps/cli/src/lib/agents.ts`.
+
+- **`agents sessions --active` now resolves the exact session id for non-Claude and
+  user-typed agents.** Previously only Claude (launched with a known `--session-id`) got an
+  exact id; every other agent fell back to "newest `.jsonl` in the cwd", which collapses
+  co-located agents onto one row. `ag run` now mints a launch id and exports it as
+  `AGENT_LAUNCH_ID` on every launch path (bare spawn, tmux, and the Windows shim); the
+  agent's own SessionStart hook already records that id, so the active-scan reconciles a
+  `ps`-discovered process to the hook's authoritative session id by `launchId` (robust even
+  when the hook runs under a different pid — a tmux pane leaf or `cmd.exe` wrapper), falling
+  back to `terminalId` and pid. This also attributes agents `ag run` never launched (you
+  typing `claude` in a terminal). No on-disk directory moved — the CLI reads the existing
+  hook state files read-only, so old installed hooks and a new CLI coexist safely. Source:
+  `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/session/{pid-registry,hook-sessions,active}.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -96,6 +96,19 @@
   dirs, which could otherwise report an isolated copy — deliberately unreachable from
   PATH — as `(global)`. Source: `apps/cli/src/commands/view.ts`, `apps/cli/src/lib/agents.ts`.
 
+- **`agents sessions --active` now resolves the exact session id for non-Claude and
+  user-typed agents.** Previously only Claude (launched with a known `--session-id`) got an
+  exact id; every other agent fell back to "newest `.jsonl` in the cwd", which collapses
+  co-located agents onto one row. `ag run` now mints a launch id and exports it as
+  `AGENT_LAUNCH_ID` on every launch path (bare spawn, tmux, and the Windows shim); the
+  agent's own SessionStart hook already records that id, so the active-scan reconciles a
+  `ps`-discovered process to the hook's authoritative session id by `launchId` (robust even
+  when the hook runs under a different pid — a tmux pane leaf or `cmd.exe` wrapper), falling
+  back to `terminalId` and pid. This also attributes agents `ag run` never launched (you
+  typing `claude` in a terminal). No on-disk directory moved — the CLI reads the existing
+  hook state files read-only, so old installed hooks and a new CLI coexist safely. Source:
+  `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/session/{pid-registry,hook-sessions,active}.ts`.
+
 ## 1.20.73
 
 - **`agents cli install <binary-cli>` no longer hardcodes `/usr/local/bin` (#1103).**

--- a/apps/cli/src/lib/exec-launchid.test.ts
+++ b/apps/cli/src/lib/exec-launchid.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import { buildExecEnv } from './exec.js';
+
+// The launchId join only works if AGENT_LAUNCH_ID actually reaches the agent
+// process (so its SessionStart hook records the same id). spawnAgent injects it
+// into options.env before every env build; buildExecEnv must therefore carry it
+// through into the child's environment — for BOTH the bare spawn and the tmux
+// `env KEY=VAL` prefix (which is built from this same map). This exercises the
+// real cross-process delivery, not a mock.
+describe('AGENT_LAUNCH_ID propagation', () => {
+  it('carries options.env.AGENT_LAUNCH_ID into a spawned child', () => {
+    const env = buildExecEnv({
+      agent: 'codex',
+      cwd: process.cwd(),
+      mode: 'auto',
+      effort: 'auto',
+      env: { AGENT_LAUNCH_ID: 'LID-test-abc' },
+    });
+    const r = spawnSync(
+      process.execPath,
+      ['-e', 'process.stdout.write(process.env.AGENT_LAUNCH_ID || "MISSING")'],
+      { env, encoding: 'utf8' },
+    );
+    expect(r.stdout).toBe('LID-test-abc');
+  });
+});

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -994,9 +994,15 @@ export async function execShimPassthrough(
 
   // The only flag the bash shim injects (codex); everything else is transparent.
   const launchArgs = agent === 'codex' ? ['-c', 'check_for_update_on_startup=false'] : [];
+  // Mint a launch id and export it as AGENT_LAUNCH_ID so the agent's SessionStart
+  // hook records the same id — the join key that maps this launch to its exact
+  // session even though the recorded pid here is the cmd.exe wrapper (Windows) or
+  // a shell, while the hook runs under the agent descendant. This is the primary
+  // attribution path on Windows (no lsof), so the launchId join matters most here.
+  const launchId = randomUUID();
   // mode/effort are required by ExecOptions but unused by buildExecEnv (which only
   // derives the per-version config-dir env); pass the agent's default to satisfy the type.
-  const env = buildExecEnv({ agent, version, cwd, mode: defaultModeFor(agent), effort: 'auto' });
+  const env = buildExecEnv({ agent, version, cwd, mode: defaultModeFor(agent), effort: 'auto', env: { AGENT_LAUNCH_ID: launchId } });
   const { command, args, shell } = resolveShimSpawn(process.platform, binary, [...launchArgs, ...rawArgs]);
 
   return new Promise((resolve) => {
@@ -1013,6 +1019,8 @@ export async function execShimPassthrough(
         agent,
         sessionId: extractSessionIdArg(rawArgs),
         cwd,
+        launchId,
+        terminalId: process.env.AGENT_TERMINAL_ID,
         startedAtMs: Date.now(),
       });
     }
@@ -1195,6 +1203,12 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
       agent: options.agent,
       sessionId: options.sessionId,
       cwd,
+      // spawnAgent injected AGENT_LAUNCH_ID into options.env before delegating
+      // here; record the same id so the hook (running under the pane-leaf agent
+      // pid) reconciles by launchId. This pane's pid usually IS the agent pid,
+      // but the launchId join is robust even when it isn't.
+      launchId: options.env?.AGENT_LAUNCH_ID,
+      terminalId: process.env.AGENT_TERMINAL_ID,
       tmuxPane: pane,
       startedAtMs: Date.now(),
     });
@@ -1295,7 +1309,17 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
   // timeout. Spend is recorded to the shared ledger in the close handler. The
   // watcher is dormant (and zero-cost) when no caps are configured.
   const cwd = options.cwd || process.cwd();
-  const runId = randomUUID();
+  // Mint the launch id once. It doubles as the budget watcher's run id AND is
+  // exported to the child as AGENT_LAUNCH_ID, so the agent's SessionStart hook
+  // records the SAME id in its own state file (terminals/sessions/<pid>.json).
+  // That id is the join key that reconciles this launch's pid-registry entry
+  // with the hook's authoritative session id even when the hook runs under a
+  // different pid (tmux pane leaf / cmd.exe wrapper) — see pid-registry.ts and
+  // session/hook-sessions.ts. Injected into options.env so every downstream env
+  // build (the bare spawn below AND the tmux env prefix in runInTmux) carries it.
+  const launchId = randomUUID();
+  const runId = launchId;
+  options = { ...options, env: { ...options.env, AGENT_LAUNCH_ID: launchId } };
   const watcherState = await setupBudgetWatcher(options, cwd, runId);
 
   maybeRotate();
@@ -1375,6 +1399,8 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
       agent: options.agent,
       sessionId: options.sessionId,
       cwd: options.cwd || process.cwd(),
+      launchId,
+      terminalId: process.env.AGENT_TERMINAL_ID,
       tmuxPane: process.env.TMUX_PANE,
       startedAtMs: Date.now(),
     });

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -924,19 +924,25 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
   // of one simultaneous system-wide burst that behavioral EDR flags as recon.
   const cwds = await resolveCwds(kept.map(c => c.pid));
 
-  // Invert the ppid map once so the hook resolver can check a recorded pid's
-  // immediate children (the hook records under the agent pid; a wrapper/shell pid
-  // we recorded has the agent as a child).
-  const childrenByParent = new Map<number, number[]>();
-  for (const [childPid, parentPid] of ppidMap) {
-    const arr = childrenByParent.get(parentPid);
-    if (arr) arr.push(childPid);
-    else childrenByParent.set(parentPid, [childPid]);
-  }
-  // The hook state dir is scanned at most ONCE per active-scan (built lazily, only
-  // when a candidate lacks an exact launch-time id — skipped entirely for an
-  // all-Claude set). The ~3s poll must not re-read the dir per candidate.
+  // The hook state dir is scanned at most ONCE per active-scan, and the ppid map
+  // is inverted at most once — both built lazily on the first candidate that
+  // lacks an exact launch-time id, so an all-Claude set does neither. The ~3s
+  // poll must not re-read the dir (or re-invert the map) per candidate.
   let hookIndex: HookSessionIndex | undefined;
+  let childrenByParent: Map<number, number[]> | undefined;
+  const ensureChildren = (): Map<number, number[]> => {
+    if (childrenByParent) return childrenByParent;
+    const m = new Map<number, number[]>();
+    // The hook records under the agent pid; a wrapper/shell pid we recorded has
+    // the agent as a child, so we resolve via a recorded pid's immediate children.
+    for (const [childPid, parentPid] of ppidMap) {
+      const arr = m.get(parentPid);
+      if (arr) arr.push(childPid);
+      else m.set(parentPid, [childPid]);
+    }
+    childrenByParent = m;
+    return m;
+  };
 
   const out: ActiveSession[] = [];
   for (let i = 0; i < kept.length; i++) {
@@ -960,7 +966,7 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
         kind,
         launchId: entry?.launchId,
         terminalId: entry?.terminalId,
-        childPids: childrenByParent.get(pid),
+        childPids: ensureChildren().get(pid),
       });
     }
     const cwd = cwds[i] ?? entry?.cwd ?? undefined;

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -26,7 +26,7 @@ import type { CloudTaskStatus } from '../cloud/types.js';
 import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
 import { readPidSessionEntry, prunePidSessionRegistry, type PidSessionEntry } from './pid-registry.js';
-import { readHookSessionByPid, findHookSessionByLaunchId, findHookSessionByTerminalId } from './hook-sessions.js';
+import { loadHookSessionIndex, resolveHookSessionId, type HookSessionIndex } from './hook-sessions.js';
 import { buildClaudeLabelMap } from './discover.js';
 import { buildRunNameMap } from './run-names.js';
 import { latestSessionFileForCwd } from './db.js';
@@ -897,43 +897,6 @@ export function foldSubordinateAgents(
  * helper, terminal-app, or multiplexer) means `terminal`; nothing of the
  * sort means `headless` (daemon, launchd-spawned, orphan).
  */
-/**
- * Resolve an agent's OWN authoritative session id from the SessionStart hook's
- * state files (`terminals/sessions/<pid>.json`, written by @agents/session-tracker).
- * This is how a pid whose launch-time id we DON'T know — every non-Claude agent,
- * and anything we didn't launch (you typing `claude`) — gets an exact id at
- * listing time instead of the newest-jsonl heuristic.
- *
- * Priority mirrors the session-tracker's own getLiveSession: launchId join
- * (survives pid divergence — the hook runs under the agent pid, our registry
- * entry may sit on a tmux pane leaf or cmd.exe wrapper) → terminalId join →
- * direct pid → the recorded pid's immediate children (the hook records under its
- * $PPID, so for a wrapper/shell pid the agent is a child). Undefined until the
- * hook lands (it can lag the spawn by a few seconds) or for hookless harnesses.
- */
-function readHookSessionId(
-  pid: number,
-  entry: PidSessionEntry | undefined,
-  ppidMap: Map<number, number>,
-): string | undefined {
-  if (entry?.launchId) {
-    const r = findHookSessionByLaunchId(entry.launchId);
-    if (r?.session_id) return r.session_id;
-  }
-  if (entry?.terminalId) {
-    const r = findHookSessionByTerminalId(entry.terminalId);
-    if (r?.session_id) return r.session_id;
-  }
-  const direct = readHookSessionByPid(pid);
-  if (direct?.session_id) return direct.session_id;
-  for (const [childPid, parentPid] of ppidMap) {
-    if (parentPid !== pid) continue;
-    const r = readHookSessionByPid(childPid);
-    if (r?.session_id) return r.session_id;
-  }
-  return undefined;
-}
-
 export async function listUnattributedActive(attributed: Set<number>): Promise<ActiveSession[]> {
   const table = await readProcessTable();
   const procByPid = new Map<number, ProcRow>();
@@ -961,6 +924,20 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
   // of one simultaneous system-wide burst that behavioral EDR flags as recon.
   const cwds = await resolveCwds(kept.map(c => c.pid));
 
+  // Invert the ppid map once so the hook resolver can check a recorded pid's
+  // immediate children (the hook records under the agent pid; a wrapper/shell pid
+  // we recorded has the agent as a child).
+  const childrenByParent = new Map<number, number[]>();
+  for (const [childPid, parentPid] of ppidMap) {
+    const arr = childrenByParent.get(parentPid);
+    if (arr) arr.push(childPid);
+    else childrenByParent.set(parentPid, [childPid]);
+  }
+  // The hook state dir is scanned at most ONCE per active-scan (built lazily, only
+  // when a candidate lacks an exact launch-time id — skipped entirely for an
+  // all-Claude set). The ~3s poll must not re-read the dir per candidate.
+  let hookIndex: HookSessionIndex | undefined;
+
   const out: ActiveSession[] = [];
   for (let i = 0; i < kept.length; i++) {
     const { pid, kind } = kept[i];
@@ -971,12 +948,21 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
     // path). Absent entirely (direct launch outside agents-cli) → heuristic.
     const entry = readPidSessionEntry(pid) ?? readAncestorSessionEntry(pid, ppidMap, kind);
     // Exact session id, in priority: (1) the id we recorded at launch (Claude,
-    // known up front via --session-id); (2) the agent's OWN SessionStart hook —
-    // authoritative for non-Claude AND for agents we didn't launch — joined by
-    // launchId/terminalId/pid; (3) the newest-jsonl heuristic (sessionIdFromFile,
-    // below). Skip the hook scan when we already have an exact id (the Claude case).
-    const hookSessionId = entry?.sessionId ? undefined : readHookSessionId(pid, entry, ppidMap);
-    const exactId = entry?.sessionId ?? hookSessionId;
+    // known up front via --session-id); (2) the agent's OWN SessionStart hook,
+    // authoritative for non-Claude and for agents we didn't launch, joined by
+    // launchId/terminalId/pid and kind-guarded against a stale reused-pid file;
+    // (3) the newest-jsonl heuristic (sessionIdFromFile, below).
+    let exactId = entry?.sessionId;
+    if (!exactId) {
+      hookIndex ??= loadHookSessionIndex();
+      exactId = resolveHookSessionId(hookIndex, {
+        pid,
+        kind,
+        launchId: entry?.launchId,
+        terminalId: entry?.terminalId,
+        childPids: childrenByParent.get(pid),
+      });
+    }
     const cwd = cwds[i] ?? entry?.cwd ?? undefined;
     const sessionFile = findSessionFileForKind(kind, cwd, exactId);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -26,6 +26,7 @@ import type { CloudTaskStatus } from '../cloud/types.js';
 import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
 import { readPidSessionEntry, prunePidSessionRegistry, type PidSessionEntry } from './pid-registry.js';
+import { readHookSessionByPid, findHookSessionByLaunchId, findHookSessionByTerminalId } from './hook-sessions.js';
 import { buildClaudeLabelMap } from './discover.js';
 import { buildRunNameMap } from './run-names.js';
 import { latestSessionFileForCwd } from './db.js';
@@ -896,6 +897,43 @@ export function foldSubordinateAgents(
  * helper, terminal-app, or multiplexer) means `terminal`; nothing of the
  * sort means `headless` (daemon, launchd-spawned, orphan).
  */
+/**
+ * Resolve an agent's OWN authoritative session id from the SessionStart hook's
+ * state files (`terminals/sessions/<pid>.json`, written by @agents/session-tracker).
+ * This is how a pid whose launch-time id we DON'T know — every non-Claude agent,
+ * and anything we didn't launch (you typing `claude`) — gets an exact id at
+ * listing time instead of the newest-jsonl heuristic.
+ *
+ * Priority mirrors the session-tracker's own getLiveSession: launchId join
+ * (survives pid divergence — the hook runs under the agent pid, our registry
+ * entry may sit on a tmux pane leaf or cmd.exe wrapper) → terminalId join →
+ * direct pid → the recorded pid's immediate children (the hook records under its
+ * $PPID, so for a wrapper/shell pid the agent is a child). Undefined until the
+ * hook lands (it can lag the spawn by a few seconds) or for hookless harnesses.
+ */
+function readHookSessionId(
+  pid: number,
+  entry: PidSessionEntry | undefined,
+  ppidMap: Map<number, number>,
+): string | undefined {
+  if (entry?.launchId) {
+    const r = findHookSessionByLaunchId(entry.launchId);
+    if (r?.session_id) return r.session_id;
+  }
+  if (entry?.terminalId) {
+    const r = findHookSessionByTerminalId(entry.terminalId);
+    if (r?.session_id) return r.session_id;
+  }
+  const direct = readHookSessionByPid(pid);
+  if (direct?.session_id) return direct.session_id;
+  for (const [childPid, parentPid] of ppidMap) {
+    if (parentPid !== pid) continue;
+    const r = readHookSessionByPid(childPid);
+    if (r?.session_id) return r.session_id;
+  }
+  return undefined;
+}
+
 export async function listUnattributedActive(attributed: Set<number>): Promise<ActiveSession[]> {
   const table = await readProcessTable();
   const procByPid = new Map<number, ProcRow>();
@@ -932,8 +970,15 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
     // .jsonl. The shim's entry may sit on a wrapper ancestor (Windows .cmd
     // path). Absent entirely (direct launch outside agents-cli) → heuristic.
     const entry = readPidSessionEntry(pid) ?? readAncestorSessionEntry(pid, ppidMap, kind);
+    // Exact session id, in priority: (1) the id we recorded at launch (Claude,
+    // known up front via --session-id); (2) the agent's OWN SessionStart hook —
+    // authoritative for non-Claude AND for agents we didn't launch — joined by
+    // launchId/terminalId/pid; (3) the newest-jsonl heuristic (sessionIdFromFile,
+    // below). Skip the hook scan when we already have an exact id (the Claude case).
+    const hookSessionId = entry?.sessionId ? undefined : readHookSessionId(pid, entry, ppidMap);
+    const exactId = entry?.sessionId ?? hookSessionId;
     const cwd = cwds[i] ?? entry?.cwd ?? undefined;
-    const sessionFile = findSessionFileForKind(kind, cwd, entry?.sessionId);
+    const sessionFile = findSessionFileForKind(kind, cwd, exactId);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
     const host = detectHost(pid, procByPid);
     const context: ActiveContext = host && UI_HOSTS.has(host) ? 'terminal' : 'headless';
@@ -945,7 +990,7 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
       tty: procByPid.get(pid)?.tty,
       pid,
       cwd,
-      sessionId: entry?.sessionId ?? sessionIdFromFile(sessionFile),
+      sessionId: exactId ?? sessionIdFromFile(sessionFile),
       topic,
       tokPerSec,
       sessionFile,

--- a/apps/cli/src/lib/session/hook-sessions.test.ts
+++ b/apps/cli/src/lib/session/hook-sessions.test.ts
@@ -2,12 +2,13 @@ import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { getTerminalsDir } from '../state.js';
-import { readHookSessionByPid, findHookSessionByLaunchId, findHookSessionByTerminalId } from './hook-sessions.js';
+import { loadHookSessionIndex, resolveHookSessionId } from './hook-sessions.js';
 
 // Fake pids far above any real process, so the test never reads or clobbers a
 // live hook state file.
 const P1 = 999_100_001;
 const P2 = 999_100_002;
+const P3 = 999_100_003;
 const SESSIONS_DIR = path.join(getTerminalsDir(), 'sessions');
 
 function writeRecord(pid: number, rec: Record<string, unknown>): void {
@@ -16,39 +17,71 @@ function writeRecord(pid: number, rec: Record<string, unknown>): void {
 }
 
 afterEach(() => {
-  for (const pid of [P1, P2]) {
+  for (const pid of [P1, P2, P3]) {
     try { fs.unlinkSync(path.join(SESSIONS_DIR, `${pid}.json`)); } catch { /* absent */ }
   }
 });
 
-describe('hook session reader', () => {
-  it('reads the authoritative id under a direct pid', () => {
+describe('hook session index + resolver', () => {
+  it('resolves the authoritative id under a direct pid', () => {
     writeRecord(P1, { session_id: 'sess-direct', agent: 'codex', pid: P1, ts: 10 });
-    expect(readHookSessionByPid(P1)?.session_id).toBe('sess-direct');
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: P1, kind: 'codex' })).toBe('sess-direct');
   });
 
   it('joins by launchId even when the hook pid differs from the recorded pid', () => {
     // The hook runs under the agent pid (P2); `ag run` recorded a different pid
     // (a tmux pane leaf / cmd.exe wrapper) but the SAME launchId in options.env.
     writeRecord(P2, { session_id: 'sess-join', agent: 'codex', pid: P2, launch_id: 'L-xyz', ts: 20 });
-    expect(findHookSessionByLaunchId('L-xyz')?.session_id).toBe('sess-join');
-    expect(findHookSessionByLaunchId('L-nope')).toBeUndefined();
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: 999_999_998, kind: 'codex', launchId: 'L-xyz' })).toBe('sess-join');
+    expect(resolveHookSessionId(idx, { pid: 999_999_998, kind: 'codex', launchId: 'L-nope' })).toBeUndefined();
   });
 
   it('joins by terminalId (Factory VS Code tab)', () => {
     writeRecord(P1, { session_id: 'sess-term', agent: 'claude', pid: P1, terminal_id: 'CL-1-1', ts: 5 });
-    expect(findHookSessionByTerminalId('CL-1-1')?.session_id).toBe('sess-term');
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: 42, kind: 'claude', terminalId: 'CL-1-1' })).toBe('sess-term');
+  });
+
+  it('resolves via an immediate child pid (wrapper/shell recorded, agent is a child)', () => {
+    writeRecord(P2, { session_id: 'sess-child', agent: 'codex', pid: P2, ts: 7 });
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: P1, kind: 'codex', childPids: [P2] })).toBe('sess-child');
   });
 
   it('prefers the newest record on a launchId collision (pid reuse)', () => {
     writeRecord(P1, { session_id: 'old', pid: P1, launch_id: 'L-dup', ts: 100 });
     writeRecord(P2, { session_id: 'new', pid: P2, launch_id: 'L-dup', ts: 200 });
-    expect(findHookSessionByLaunchId('L-dup')?.session_id).toBe('new');
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: 1, kind: 'claude', launchId: 'L-dup' })).toBe('new');
+  });
+
+  it('kind-guards a stale reused-pid file: a live codex must NOT inherit a dead claude session', () => {
+    // A dead claude left sessions/P1.json; pid P1 is now a live codex we did not
+    // launch (no launchId). The kind mismatch must reject the stale record.
+    writeRecord(P1, { session_id: 'stale-claude', agent: 'claude', pid: P1, ts: 1 });
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: P1, kind: 'codex' })).toBeUndefined();
+    // Same-kind read is still allowed.
+    expect(resolveHookSessionId(idx, { pid: P1, kind: 'claude' })).toBe('stale-claude');
+  });
+
+  it('normalizes cursor: ps kind `cursor-agent` matches a hook record agent `cursor`', () => {
+    writeRecord(P1, { session_id: 'sess-cursor', agent: 'cursor', pid: P1, ts: 3 });
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: P1, kind: 'cursor-agent' })).toBe('sess-cursor');
+  });
+
+  it('is permissive when the record omits agent (legacy/unknown)', () => {
+    writeRecord(P1, { session_id: 'sess-legacy', pid: P1, ts: 2 });
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: P1, kind: 'gemini' })).toBe('sess-legacy');
   });
 
   it('ignores a record missing session_id', () => {
     writeRecord(P1, { agent: 'codex', pid: P1, launch_id: 'L-empty', ts: 1 });
-    expect(readHookSessionByPid(P1)).toBeUndefined();
-    expect(findHookSessionByLaunchId('L-empty')).toBeUndefined();
+    const idx = loadHookSessionIndex();
+    expect(resolveHookSessionId(idx, { pid: P1, kind: 'codex', launchId: 'L-empty' })).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/session/hook-sessions.test.ts
+++ b/apps/cli/src/lib/session/hook-sessions.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { getTerminalsDir } from '../state.js';
+import { readHookSessionByPid, findHookSessionByLaunchId, findHookSessionByTerminalId } from './hook-sessions.js';
+
+// Fake pids far above any real process, so the test never reads or clobbers a
+// live hook state file.
+const P1 = 999_100_001;
+const P2 = 999_100_002;
+const SESSIONS_DIR = path.join(getTerminalsDir(), 'sessions');
+
+function writeRecord(pid: number, rec: Record<string, unknown>): void {
+  fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(SESSIONS_DIR, `${pid}.json`), JSON.stringify(rec), 'utf8');
+}
+
+afterEach(() => {
+  for (const pid of [P1, P2]) {
+    try { fs.unlinkSync(path.join(SESSIONS_DIR, `${pid}.json`)); } catch { /* absent */ }
+  }
+});
+
+describe('hook session reader', () => {
+  it('reads the authoritative id under a direct pid', () => {
+    writeRecord(P1, { session_id: 'sess-direct', agent: 'codex', pid: P1, ts: 10 });
+    expect(readHookSessionByPid(P1)?.session_id).toBe('sess-direct');
+  });
+
+  it('joins by launchId even when the hook pid differs from the recorded pid', () => {
+    // The hook runs under the agent pid (P2); `ag run` recorded a different pid
+    // (a tmux pane leaf / cmd.exe wrapper) but the SAME launchId in options.env.
+    writeRecord(P2, { session_id: 'sess-join', agent: 'codex', pid: P2, launch_id: 'L-xyz', ts: 20 });
+    expect(findHookSessionByLaunchId('L-xyz')?.session_id).toBe('sess-join');
+    expect(findHookSessionByLaunchId('L-nope')).toBeUndefined();
+  });
+
+  it('joins by terminalId (Factory VS Code tab)', () => {
+    writeRecord(P1, { session_id: 'sess-term', agent: 'claude', pid: P1, terminal_id: 'CL-1-1', ts: 5 });
+    expect(findHookSessionByTerminalId('CL-1-1')?.session_id).toBe('sess-term');
+  });
+
+  it('prefers the newest record on a launchId collision (pid reuse)', () => {
+    writeRecord(P1, { session_id: 'old', pid: P1, launch_id: 'L-dup', ts: 100 });
+    writeRecord(P2, { session_id: 'new', pid: P2, launch_id: 'L-dup', ts: 200 });
+    expect(findHookSessionByLaunchId('L-dup')?.session_id).toBe('new');
+  });
+
+  it('ignores a record missing session_id', () => {
+    writeRecord(P1, { agent: 'codex', pid: P1, launch_id: 'L-empty', ts: 1 });
+    expect(readHookSessionByPid(P1)).toBeUndefined();
+    expect(findHookSessionByLaunchId('L-empty')).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/session/hook-sessions.ts
+++ b/apps/cli/src/lib/session/hook-sessions.ts
@@ -16,6 +16,10 @@
  * hand-copied reader in apps/factory/src/core/liveSession.ts. It only READS the
  * existing dir/schema; it never writes or moves anything, so it is safe across a
  * fleet where old hooks and a new CLI coexist.
+ *
+ * The whole state dir is scanned ONCE per active-scan into an index (the listing
+ * path polls every ~3s), and every lookup keys the pre-built maps — never a
+ * re-scan per candidate.
  */
 import fs from 'fs';
 import path from 'path';
@@ -30,6 +34,13 @@ export interface HookSessionRecord {
   launch_id?: string;
   terminal_id?: string;
   ts?: number;
+}
+
+/** Pre-built lookup maps over one scan of the hook state dir. */
+export interface HookSessionIndex {
+  byLaunchId: Map<string, HookSessionRecord>;
+  byTerminalId: Map<string, HookSessionRecord>;
+  byPid: Map<number, HookSessionRecord>;
 }
 
 function hookSessionsDir(): string {
@@ -50,57 +61,92 @@ function parseRecord(raw: string): HookSessionRecord | undefined {
   return undefined;
 }
 
-/** Read the hook record written under a specific pid. Undefined if absent/corrupt. */
-export function readHookSessionByPid(pid: number): HookSessionRecord | undefined {
-  if (!pid || pid < 1) return undefined;
-  try {
-    return parseRecord(fs.readFileSync(path.join(hookSessionsDir(), `${pid}.json`), 'utf8'));
-  } catch {
-    return undefined;
-  }
+/** Keep the newest record (by `ts`) when two collide on the same key. */
+function keepNewest(map: Map<string | number, HookSessionRecord>, key: string | number, rec: HookSessionRecord): void {
+  const prev = map.get(key);
+  if (!prev || (rec.ts ?? 0) >= (prev.ts ?? 0)) map.set(key, rec);
 }
 
-function scanAll(): HookSessionRecord[] {
+/**
+ * Scan the hook state dir once and index every record by launch_id, terminal_id,
+ * and pid. Returns empty maps if the dir is absent. Newest-by-`ts` wins a key
+ * collision (pid reuse, or a launch id lingering from a since-dead process).
+ */
+export function loadHookSessionIndex(): HookSessionIndex {
+  const byLaunchId = new Map<string, HookSessionRecord>();
+  const byTerminalId = new Map<string, HookSessionRecord>();
+  const byPid = new Map<number, HookSessionRecord>();
   let files: string[];
   try {
     files = fs.readdirSync(hookSessionsDir()).filter(f => f.endsWith('.json'));
   } catch {
-    return [];
+    return { byLaunchId, byTerminalId, byPid };
   }
-  const out: HookSessionRecord[] = [];
   for (const f of files) {
+    let rec: HookSessionRecord | undefined;
     try {
-      const r = parseRecord(fs.readFileSync(path.join(hookSessionsDir(), f), 'utf8'));
-      if (r) out.push(r);
+      rec = parseRecord(fs.readFileSync(path.join(hookSessionsDir(), f), 'utf8'));
     } catch {
       /* raced with the hook / pruner — skip */
     }
+    if (!rec) continue;
+    if (typeof rec.pid === 'number') keepNewest(byPid as Map<string | number, HookSessionRecord>, rec.pid, rec);
+    if (rec.launch_id) keepNewest(byLaunchId as Map<string | number, HookSessionRecord>, rec.launch_id, rec);
+    if (rec.terminal_id) keepNewest(byTerminalId as Map<string | number, HookSessionRecord>, rec.terminal_id, rec);
   }
-  return out;
-}
-
-function newestMatching(pred: (r: HookSessionRecord) => boolean): HookSessionRecord | undefined {
-  let best: HookSessionRecord | undefined;
-  for (const r of scanAll()) {
-    if (!pred(r)) continue;
-    if (!best || (r.ts ?? 0) > (best.ts ?? 0)) best = r;
-  }
-  return best;
+  return { byLaunchId, byTerminalId, byPid };
 }
 
 /**
- * The join key. Matches the hook record whose `launch_id` equals the launchId
- * `ag run` minted for this launch — reconciles across pid divergence (the hook
- * runs under the agent pid, our pid-registry entry may sit on a tmux pane leaf
- * or a cmd.exe wrapper). Newest-by-`ts` on the rare pid-reuse collision.
+ * True if a hook record's `agent` is compatible with a `ps`-detected kind. Guards
+ * the weak pid/children lookups against a STALE file at a reused pid (a dead
+ * hooked agent's `<pid>.json` inherited by a live hookless agent at the same pid).
+ * Permissive when the record's agent is absent/legacy-`unknown` (never reject on
+ * missing metadata). Normalizes the one known naming gap: `ps` reports Cursor as
+ * `cursor-agent`, the hook records it as `cursor`.
  */
-export function findHookSessionByLaunchId(launchId: string): HookSessionRecord | undefined {
-  if (!launchId) return undefined;
-  return newestMatching(r => r.launch_id === launchId);
+function kindMatches(recordAgent: string | undefined, kind: string): boolean {
+  if (!recordAgent || recordAgent === 'unknown') return true;
+  const norm = (k: string) => (k === 'cursor-agent' ? 'cursor' : k);
+  return norm(recordAgent) === norm(kind);
 }
 
-/** Secondary join key: a Factory VS Code tab's `AGENT_TERMINAL_ID`. */
-export function findHookSessionByTerminalId(terminalId: string): HookSessionRecord | undefined {
-  if (!terminalId) return undefined;
-  return newestMatching(r => r.terminal_id === terminalId);
+export interface ResolveOpts {
+  pid: number;
+  kind: string;
+  launchId?: string;
+  terminalId?: string;
+  /** Immediate child pids of `pid` — the hook records under the agent pid, which
+   *  for a wrapper/shell pid we recorded is a child. */
+  childPids?: number[];
+}
+
+/**
+ * Resolve an agent's OWN authoritative session id from the hook index. Priority
+ * mirrors the session-tracker's getLiveSession: launchId join (survives pid
+ * divergence — the hook runs under the agent pid, our registry entry may sit on a
+ * tmux pane leaf or cmd.exe wrapper) → terminalId join → direct pid → children.
+ * Every hit is kind-guarded so a stale file at a reused pid can't cross agents.
+ * Undefined until the hook lands (it can lag the spawn) or for hookless harnesses.
+ */
+export function resolveHookSessionId(index: HookSessionIndex, opts: ResolveOpts): string | undefined {
+  const { pid, kind, launchId, terminalId, childPids } = opts;
+  const take = (rec: HookSessionRecord | undefined): string | undefined =>
+    rec?.session_id && kindMatches(rec.agent, kind) ? rec.session_id : undefined;
+
+  if (launchId) {
+    const hit = take(index.byLaunchId.get(launchId));
+    if (hit) return hit;
+  }
+  if (terminalId) {
+    const hit = take(index.byTerminalId.get(terminalId));
+    if (hit) return hit;
+  }
+  const direct = take(index.byPid.get(pid));
+  if (direct) return direct;
+  for (const c of childPids ?? []) {
+    const hit = take(index.byPid.get(c));
+    if (hit) return hit;
+  }
+  return undefined;
 }

--- a/apps/cli/src/lib/session/hook-sessions.ts
+++ b/apps/cli/src/lib/session/hook-sessions.ts
@@ -61,10 +61,11 @@ function parseRecord(raw: string): HookSessionRecord | undefined {
   return undefined;
 }
 
-/** Keep the newest record (by `ts`) when two collide on the same key. */
+/** Keep the newest record (by `ts`) when two collide on the same key. Uses the
+ *  same strict `>` tie-break as the session-tracker's own reader (reader.ts). */
 function keepNewest(map: Map<string | number, HookSessionRecord>, key: string | number, rec: HookSessionRecord): void {
   const prev = map.get(key);
-  if (!prev || (rec.ts ?? 0) >= (prev.ts ?? 0)) map.set(key, rec);
+  if (!prev || (rec.ts ?? 0) > (prev.ts ?? 0)) map.set(key, rec);
 }
 
 /**

--- a/apps/cli/src/lib/session/hook-sessions.ts
+++ b/apps/cli/src/lib/session/hook-sessions.ts
@@ -1,0 +1,106 @@
+/**
+ * Read-only view of the SessionStart hook's live-session state files.
+ *
+ * The `@agents/session-tracker` hook (installed into each agent's own config)
+ * writes `~/.agents/.cache/terminals/sessions/<pid>.json` AFTER an agent boots,
+ * carrying the agent's OWN authoritative session id (from its SessionStart
+ * payload) plus the join keys `launch_id` / `terminal_id`. It is the only writer
+ * that sees agents `ag run` did NOT launch (you typing `claude` in a terminal),
+ * and the only source of an exact id for non-Claude agents (whose id we can't
+ * know at spawn).
+ *
+ * This module lets `sessions --active` reconcile a `ps`-discovered pid to that
+ * authoritative id. It is deliberately a small hand-rolled reader — the CLI does
+ * NOT import the session-tracker package (a separate, workspace-less package;
+ * see packages/session-tracker/CLAUDE.md) — mirroring the Factory extension's own
+ * hand-copied reader in apps/factory/src/core/liveSession.ts. It only READS the
+ * existing dir/schema; it never writes or moves anything, so it is safe across a
+ * fleet where old hooks and a new CLI coexist.
+ */
+import fs from 'fs';
+import path from 'path';
+import { getTerminalsDir } from '../state.js';
+
+/** The subset of the hook's on-disk record this reader relies on. Extra fields are ignored. */
+export interface HookSessionRecord {
+  session_id: string;
+  agent?: string;
+  cwd?: string;
+  pid: number;
+  launch_id?: string;
+  terminal_id?: string;
+  ts?: number;
+}
+
+function hookSessionsDir(): string {
+  // Sibling of the pid-registry's by-pid/ dir. The hook hardcodes this same path
+  // (packages/session-tracker/src/hook.sh); we read it, never move it.
+  return path.join(getTerminalsDir(), 'sessions');
+}
+
+function parseRecord(raw: string): HookSessionRecord | undefined {
+  try {
+    const o = JSON.parse(raw);
+    if (o && typeof o === 'object' && typeof o.session_id === 'string' && o.session_id) {
+      return o as HookSessionRecord;
+    }
+  } catch {
+    /* unparseable — treat as absent */
+  }
+  return undefined;
+}
+
+/** Read the hook record written under a specific pid. Undefined if absent/corrupt. */
+export function readHookSessionByPid(pid: number): HookSessionRecord | undefined {
+  if (!pid || pid < 1) return undefined;
+  try {
+    return parseRecord(fs.readFileSync(path.join(hookSessionsDir(), `${pid}.json`), 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function scanAll(): HookSessionRecord[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(hookSessionsDir()).filter(f => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const out: HookSessionRecord[] = [];
+  for (const f of files) {
+    try {
+      const r = parseRecord(fs.readFileSync(path.join(hookSessionsDir(), f), 'utf8'));
+      if (r) out.push(r);
+    } catch {
+      /* raced with the hook / pruner — skip */
+    }
+  }
+  return out;
+}
+
+function newestMatching(pred: (r: HookSessionRecord) => boolean): HookSessionRecord | undefined {
+  let best: HookSessionRecord | undefined;
+  for (const r of scanAll()) {
+    if (!pred(r)) continue;
+    if (!best || (r.ts ?? 0) > (best.ts ?? 0)) best = r;
+  }
+  return best;
+}
+
+/**
+ * The join key. Matches the hook record whose `launch_id` equals the launchId
+ * `ag run` minted for this launch — reconciles across pid divergence (the hook
+ * runs under the agent pid, our pid-registry entry may sit on a tmux pane leaf
+ * or a cmd.exe wrapper). Newest-by-`ts` on the rare pid-reuse collision.
+ */
+export function findHookSessionByLaunchId(launchId: string): HookSessionRecord | undefined {
+  if (!launchId) return undefined;
+  return newestMatching(r => r.launch_id === launchId);
+}
+
+/** Secondary join key: a Factory VS Code tab's `AGENT_TERMINAL_ID`. */
+export function findHookSessionByTerminalId(terminalId: string): HookSessionRecord | undefined {
+  if (!terminalId) return undefined;
+  return newestMatching(r => r.terminal_id === terminalId);
+}

--- a/apps/cli/src/lib/session/pid-registry.test.ts
+++ b/apps/cli/src/lib/session/pid-registry.test.ts
@@ -12,12 +12,14 @@ afterEach(() => {
 });
 
 describe('pid session registry', () => {
-  it('round-trips a written entry with its exact session id', () => {
+  it('round-trips a written entry with its exact session id and join keys', () => {
     writePidSessionEntry({
       pid: FAKE_PID,
       agent: 'claude',
       sessionId: 'abc-123-uuid',
       cwd: '/home/x/repo',
+      launchId: 'launch-abc',
+      terminalId: 'CL-1700000000000-1',
       tmuxPane: '%18',
       startedAtMs: 1_700_000_000_000,
     });
@@ -25,6 +27,10 @@ describe('pid session registry', () => {
     expect(got?.sessionId).toBe('abc-123-uuid');
     expect(got?.agent).toBe('claude');
     expect(got?.cwd).toBe('/home/x/repo');
+    // The join keys must survive the round-trip — active.ts reconciles the hook's
+    // authoritative id to this entry via launchId (and terminalId).
+    expect(got?.launchId).toBe('launch-abc');
+    expect(got?.terminalId).toBe('CL-1700000000000-1');
     expect(got?.tmuxPane).toBe('%18');
   });
 

--- a/apps/cli/src/lib/session/pid-registry.ts
+++ b/apps/cli/src/lib/session/pid-registry.ts
@@ -31,7 +31,8 @@ export interface PidSessionEntry {
    * `AGENT_LAUNCH_ID`. The agent's SessionStart hook records the SAME id in its
    * own state file (`terminals/sessions/<pid>.json`, `launch_id`), so the two
    * records reconcile by this key even when the hook runs under a DIFFERENT pid
-   * (tmux pane leaf, cmd.exe wrapper) — see readHookSessionId in active.ts. This
+   * (tmux pane leaf, cmd.exe wrapper) — see resolveHookSessionId in
+   * session/hook-sessions.ts. This
    * is how a non-Claude launch (whose id we don't know at spawn) gets an exact
    * session id at listing time instead of the newest-jsonl heuristic.
    */

--- a/apps/cli/src/lib/session/pid-registry.ts
+++ b/apps/cli/src/lib/session/pid-registry.ts
@@ -27,6 +27,22 @@ export interface PidSessionEntry {
   sessionId?: string;
   cwd?: string;
   /**
+   * The launch id minted by `ag run` and exported to the child as
+   * `AGENT_LAUNCH_ID`. The agent's SessionStart hook records the SAME id in its
+   * own state file (`terminals/sessions/<pid>.json`, `launch_id`), so the two
+   * records reconcile by this key even when the hook runs under a DIFFERENT pid
+   * (tmux pane leaf, cmd.exe wrapper) — see readHookSessionId in active.ts. This
+   * is how a non-Claude launch (whose id we don't know at spawn) gets an exact
+   * session id at listing time instead of the newest-jsonl heuristic.
+   */
+  launchId?: string;
+  /**
+   * `AGENT_TERMINAL_ID` when the launch inherited one (a Factory VS Code tab).
+   * A secondary join key to the hook's `terminal_id`, for agents the extension
+   * spawned. Best-effort — undefined outside the extension.
+   */
+  terminalId?: string;
+  /**
    * `$TMUX_PANE` at launch — stored for diagnostics and possible future
    * disambiguation. NOT currently consulted on read: the listing path keys
    * purely on pid (stale entries are pruned when the pid dies), so this is


### PR DESCRIPTION
## What & why

`agents sessions --active` gave an **exact** session id only for Claude (launched with a known `--session-id`). Every other agent — and any agent you started yourself (`claude` typed in a terminal) — fell back to "newest `.jsonl` in the cwd", which **collapses co-located agents onto one row** (same topic/preview/id).

This wires the join key the SessionStart hook has always been waiting for. `ag run` now mints a **launch id** and exports it as `AGENT_LAUNCH_ID`; the hook already records that id (`hook.sh:89,106`), so the active-scan reconciles a `ps`-discovered process to the hook's **authoritative** session id by `launchId` — robust even when the hook runs under a different pid (a tmux pane leaf or `cmd.exe` wrapper), with a `terminalId` and pid/children fallback.

## Deliberately NOT a directory/schema merge

An earlier plan was to collapse the two pid→id registries into one dir. Two blast-radius audits showed that's a big, **fleet-unsafe** refactor: the hook path is an absolute path baked into external agent configs (`~/.claude/settings.json` …) by a manually-run installer with no re-install-on-upgrade, no version sentinel, and no dual-read; `migrate.ts` deliberately refuses to move `terminals/`. Moving the dir would silently blind live-session detection until every box re-ran `install-hook`.

So this PR **moves nothing on disk** — it reads the existing hook state files read-only, exactly like the extension already does. **Old installed hooks and a new CLI coexist safely.** The dir merge is left as a separate, migration-gated ticket.

## Changes

- `exec.ts` — mint `launchId` (reuses the existing `runId`); inject `AGENT_LAUNCH_ID` into the child env on all three launch paths (bare spawn, tmux `env` prefix, Windows shim); record `launchId`/`terminalId` in the pid-registry.
- `pid-registry.ts` — additive `launchId?`/`terminalId?` on `PidSessionEntry`. No field rename, no dir change.
- `hook-sessions.ts` (new) — small hand-rolled, read-only reader of `terminals/sessions/<pid>.json` (honors the "CLI does not import the session-tracker package" boundary).
- `active.ts` — `readHookSessionId` reconciles by `launchId → terminalId → pid/children`; keeps the ppid-walk fallbacks (`:803`/`:833`) for hookless/pre-hook/`/clear` cases.

## Verification

- **Unit (26 pass):** `pid-registry.test.ts` (launchId/terminalId round-trip), `hook-sessions.test.ts` (join by launchId across differing pids, terminalId, newest-on-collision, missing-id ignored), `active.test.ts`.
- **Real cross-process:** proved `AGENT_LAUNCH_ID` reaches a spawned child through the actual `buildExecEnv` + `spawn` path (committed as `exec-launchid.test.ts`).
- **Real `agents sessions --active --json`** on this box: runs the new reader path on live `ps` data, lists exact ids, no crash, correct fallback with no hook files present.
- **Typecheck clean.** The 3 `exec.test.ts` failures are **pre-existing on `origin/main`** (model-default drift, unrelated) — verified against a pristine `origin/main` worktree.

## Needs a Windows check before merge

The **shim passthrough is the primary Windows attribution path** and I verified on macOS. The launchId injection there is wired and unit-covered, but the live cross-process hook join on Windows (and on any box with the session-tracker hook installed) should be confirmed on a real box. Flagging explicitly.

Session transcript (public repo — local path, not attached): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/9753db68-8b73-4b1a-bd0b-46b6130709bb.jsonl`
