### PR TITLE
docs: CLI/extension architecture overview + fix session-doc drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ native/
 packages/
   session-tracker/  @agents/session-tracker — SessionStart hook that WRITES live-session state
   swarmify-mirror/  legacy npm-redirect stub (@companion/agents-cli → @phnx-labs/agents-cli)
-docs/         Source-grounded design reference (start: docs/00-concepts.md)
+docs/         Repo-root design notes (docs/design/); the full CLI design reference is apps/cli/docs/ (start: apps/cli/docs/architecture.md)
 assets/ demo/ website/   Brand, launch demo, landing (repo-root, not shipped in any tarball)
 ```
 
@@ -101,6 +101,7 @@ and reread this block.
 
 ## Detailed design
 
-[`docs/`](docs/README.md) is source-grounded reference. Start with
-[`00-concepts.md`](docs/00-concepts.md) for the full mental model and resolution
-semantics of the CLI.
+[`apps/cli/docs/`](apps/cli/docs/README.md) is the source-grounded reference. Start
+with [`architecture.md`](apps/cli/docs/architecture.md) for the CLI/extension layering
+and the session mechanisms, then [`00-concepts.md`](apps/cli/docs/00-concepts.md) for
+the resource model and resolution semantics of the CLI.

--- a/README.md
+++ b/README.md
@@ -1219,7 +1219,7 @@ Agents are defined in [src/lib/agents.ts](apps/cli/src/lib/agents.ts) -- each is
 | [`apps/cli`](apps/cli) | **The CLI** (this README) — version management, config sync, sessions, teams, cloud, browser, computer, secrets. |
 | [`apps/factory`](apps/factory) | **Factory** — a VS Code extension that spawns agent terminals as tabs and adds the Factory Floor dashboard. A separate product with its own publish identity. |
 | [`native/computer-mac`](native/computer-mac) · [`native/computer-win`](native/computer-win) | Native backends behind `agents computer` — Swift (macOS Accessibility + screen capture) and C#/.NET (Windows UI Automation). |
-| [`packages/session-tracker`](packages/session-tracker) | The `SessionStart` hook that writes live-session state the CLI reads back. |
+| [`packages/session-tracker`](packages/session-tracker) | The `SessionStart` hook that writes live-session state the **Factory extension** reads back (`apps/factory/src/core/liveSession.ts`) — not the CLI, which reads transcripts. |
 
 ## Contributing
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -87,10 +87,11 @@ it is NOT a global-binary agent and is left uncollapsed. (RUSH-1321)
 
 ## Supported harnesses
 
-14 harnesses ship support today. The full id list is `AgentId`
-([`src/lib/types.ts`](src/lib/types.ts)); per-harness config + capabilities live in the
-`AGENTS` registry ([`src/lib/agents.ts`](src/lib/agents.ts)) and are gated through
-`supports()`. **Prioritized (first-class):** Claude Code, Codex CLI, Kimi CLI,
+The supported harnesses are the entries in the `AGENTS` registry
+([`src/lib/agents.ts`](src/lib/agents.ts)) — the canonical list, gated through
+`supports()`; the full id union is `AgentId` ([`src/lib/types.ts`](src/lib/types.ts)).
+The table below is a snapshot of their per-harness capabilities — keep it in sync
+with the registry. **Prioritized (first-class):** Claude Code, Codex CLI, Kimi CLI,
 Antigravity CLI, Grok CLI, OpenCode — features target these six first.
 
 | Harness | `id` | hooks | mcp | allowlist | skills | commands | plugins | subagents | workflows |
@@ -286,5 +287,7 @@ Bumping it would un-deprecate a retired package.
 
 ## Detailed design
 
-[`../../docs/`](../../docs/README.md) is source-grounded reference. Start with
-[`00-concepts.md`](../../docs/00-concepts.md) for the full mental model.
+[`docs/`](docs/README.md) is the source-grounded reference. Start with
+[`architecture.md`](docs/architecture.md) for the CLI/extension layering and the
+session mechanisms, then [`00-concepts.md`](docs/00-concepts.md) for the resource
+model.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -90,6 +90,28 @@ See [01-version-management.md](01-version-management.md) for install and switchi
 
 ---
 
+## Two application layers
+
+agents-cli is two application-layer surfaces over one shared set of on-disk state.
+**`apps/cli`** (the `agents` / `ag` CLI) is the framework: it owns the SQLite session
+index, `sessions` / `teams` / `run` / `cloud`, the pid→id registry, the audit log,
+and the SSH fan-out to peers. **`apps/factory`** (the Factory VS Code extension) is a
+consumer: it spawns agent terminals and renders the Factory Floor, but for live state
+it shells out to `agents sessions --active --json` and reshapes the JSON — it holds no
+data models of its own. Fix a mechanism in the CLI and every consumer benefits. Full
+detail in [architecture.md](architecture.md).
+
+## Two kinds of "session"
+
+"Session" names two unrelated things. A **transcript** is the conversation on disk,
+indexed in `sessions.db` and read by `agents sessions` (see [05-sessions.md](05-sessions.md)).
+A **live identity** is which running pid is which session right now, held in per-pid
+cache files and read by `--active` and the extension. The transcript is durable; the
+identity is ephemeral. [architecture.md](architecture.md) covers both, including the
+two `pid → id` writers (the CLI's registry vs the SessionStart hook).
+
+---
+
 ## Devices & Hosts
 
 agents-cli can run commands on **other machines**, not just the local one. Two

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -1,12 +1,14 @@
 # Sessions
 
 Unified discovery, search, and rendering of agent conversation transcripts across
-Claude, Codex, Gemini, OpenCode, and OpenClaw.
+the session-discoverable harnesses — Claude, Codex, Gemini, Antigravity, OpenCode,
+OpenClaw, Rush, Hermes, Grok, Kimi, and Droid (the `SESSION_AGENTS` set in
+`src/lib/session/types.ts`).
 
 ## Architecture
 
 ```
-~/.agents/
+~/.agents/.history/
   sessions/
     sessions.db                 # SQLite + FTS5 index
     sessions.db-wal             # Write-ahead log (WAL mode)
@@ -82,7 +84,7 @@ Fields:
 |---|---|---|
 | `id` | Agent-native UUID | Primary key; stable across reloads |
 | `shortId` | First 8 chars of `id` | For human matching in CLI output |
-| `agent` | One of 5 formats | See SessionAgentId union |
+| `agent` | One of 11 formats | See the `SessionAgentId` / `SESSION_AGENTS` union |
 | `origin` | `cli` or `routine` | Routine rows are archived from a run directory and can be filtered with `--routine` |
 | `routineName` | Routine name | Present when `origin` is `routine` |
 | `routineRunId` | Routine run id | Present when `origin` is `routine`; `agents sessions <runId>` resolves it |
@@ -416,10 +418,14 @@ generating the encryption key if absent.
 
 ## Schema Version
 
-Schema version is currently `6`. Migrations run on connection open; old DBs
-get upgraded in place. The `meta` table tracks `schema_version`. The `v5 → v6`
-migration adds the `cost_usd` and `duration_ms` columns and forces a full
-rescan so every existing session is re-priced.
+Schema version is currently `13` (`SCHEMA_VERSION` in
+[`src/lib/session/db.ts`](../src/lib/session/db.ts)). Migrations run on connection
+open; old DBs get upgraded in place. The `meta` table tracks `schema_version`.
+Later migrations added, among others, `cost_usd` / `duration_ms` (pricing), the
+work-signal columns `pr_url` / `pr_number` / `worktree_slug` / `ticket_id`, the
+`plan` markdown, `output_tokens`, and `is_team_origin`. A migration that changes how
+a column is derived forces a full rescan so every existing session is re-derived
+(as the pricing columns once did).
 
 ## Related
 

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -170,7 +170,7 @@ Each source answers a different question:
 
 | Source | Question | Coverage | Misses |
 |---|---|---|---|
-| `agents sessions --json` | What local CLI and team-spawned agents have run recently? | Claude, Codex, Gemini, OpenCode, OpenClaw on this laptop | Pure-cloud runs with no local file |
+| `agents sessions --json` | What local CLI and team-spawned agents have run recently? | The `SESSION_AGENTS` harnesses on this laptop (Claude, Codex, Gemini, Antigravity, OpenCode, OpenClaw, Rush, Hermes, Grok, Kimi, Droid) | Pure-cloud runs with no local file |
 | `agents cloud list --json` | What am I running on remote VMs right now? | Rush Cloud, Codex Cloud, Factory | Local sessions |
 | `agents teams list --json` | What multi-agent DAGs are active? | All team-coordinated runs | Standalone agents |
 
@@ -350,7 +350,7 @@ dumps the edge list, and `--watch` streams NDJSON.
 
 Every session is priced at scan time: `cost_usd = Σ tokens × per-model price`
 and `duration_ms = lastTs − firstTs` are persisted on the session row (schema
-v6). The price table is offline and versioned — no API calls, no telemetry —
+v13). The price table is offline and versioned — no API calls, no telemetry —
 covering current Claude, OpenAI, and Gemini models. Unknown/unpriced models
 contribute `$0`, never `NaN`.
 

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -1,0 +1,211 @@
+# Architecture
+
+How the parts fit together: **two application layers** (the `agents` CLI and the
+Factory extension), **two meanings of "session"** (a transcript vs a live identity),
+and the on-disk stores that connect them. Read this once and the rest of the docs
+(`05-sessions.md`, `06-observability.md`, `teams.md`) slot into place.
+
+Everything here is read from source — file references are `path:line` at the time of
+writing; treat them as pointers, not guarantees.
+
+---
+
+## 1. Two application layers
+
+`agents-cli` is two application-layer surfaces over one shared set of on-disk state:
+
+- **`apps/cli` — the `agents` / `ag` CLI. The framework.** It owns the durable
+  state and every mechanism: the SQLite transcript index, `sessions` / `teams` /
+  `run` / `cloud`, the CLI-side pid→id registry, the audit log, and the SSH fan-out
+  to peer machines.
+- **`apps/factory` — the Factory VS Code extension. A consumer.** It spawns agent
+  terminals as tabs and renders the Factory Floor dashboard, but it holds **no data
+  models of its own** beyond the live-session state file. For "what's running", it
+  shells out to the CLI (`agents sessions --active --json`) and reshapes the JSON.
+
+```mermaid
+flowchart LR
+  subgraph machine["one machine"]
+    CLI["apps/cli — the agents CLI<br/><b>the framework</b><br/>sessions index · teams · run · cloud<br/>pid-registry · events.jsonl · SSH fan-out"]
+    FAC["apps/factory — Factory extension<br/><b>a consumer</b><br/>terminal tabs · Factory Floor<br/>file-watcher · watchdog socket"]
+    CLI -- "exposes: agents sessions --active --json" --> FAC
+  end
+  CLI --> DB[("sessions.db<br/>SQLite + FTS5")]
+  CLI --> BYPID["terminals/by-pid/&lt;pid&gt;.json<br/>CLI pid→id"]
+  FAC --> SESS["terminals/sessions/&lt;pid&gt;.json<br/>hook pid→id"]
+  CLI --> EV["events.jsonl<br/>locked audit log"]
+```
+
+The important consequence: **the CLI is where the mechanisms live**, so a change to
+how live state is computed (or cached) benefits every consumer — a terminal, the
+extension, another machine — at once. The extension is a thin reshaping layer.
+
+> The Factory extension is a **separate product** with its own publish identity
+> (publisher `swarmify`, name `swarm-ext`). See [`apps/factory/AGENTS.md`](../../factory/AGENTS.md).
+
+---
+
+## 2. Two meanings of "session"
+
+The word "session" names two unrelated things. Keeping them apart removes most of the
+confusion in this codebase.
+
+| | Transcript | Live identity |
+|---|---|---|
+| **What it is** | the conversation on disk (one file/row per session) | which running **pid** is which session, right now |
+| **Where** | agent-native files → indexed in `sessions.db` | `terminals/*/<pid>.json` cache files |
+| **Read by** | `agents sessions` (the CLI) | the CLI (`--active`) and the extension |
+| **Lifetime** | durable (survives reboot) | ephemeral (deleted with the pid) |
+| **Covered in** | [05-sessions.md](05-sessions.md) | §3 below |
+
+The **transcript** side is a SQLite index (`~/.agents/.history/sessions/sessions.db`,
+`SCHEMA_VERSION` in [`src/lib/session/db.ts`](../src/lib/session/db.ts)) with a
+`scan_ledger` that re-reads a file only when its `mtime`/`size` changed, plus a
+`session_text` FTS5 table for search. Listing is a DB read; only opening one session
+fully re-parses its transcript. Detail in [05-sessions.md](05-sessions.md).
+
+The **live identity** side is the rest of this document.
+
+---
+
+## 3. Live identity: two `pid → id` writers
+
+An agent is one OS process with a pid. To say "this terminal is running session
+`4d…`", something must map that pid to a session id and store it in a file **named
+after the pid** — never the database, because a pid is an OS-recycled number
+(a saved `pid 1234 → session-abc` row becomes a lie the moment 1234 is reused).
+
+There are **two** such writers, and they fire at different moments:
+
+```mermaid
+sequenceDiagram
+  participant Launcher as ag run / shim (CLI)
+  participant Agent as the agent process
+  participant Hook as SessionStart hook
+  participant ByPid as terminals/by-pid/&lt;pid&gt;.json
+  participant Sess as terminals/sessions/&lt;pid&gt;.json
+  Launcher->>ByPid: write pid + cwd (+ id if known) at spawn
+  Note over Launcher,ByPid: claude: id known up front (we mint the UUID)
+  Launcher->>Agent: exec the harness
+  Agent->>Hook: emit SessionStart
+  Hook->>Sess: write authoritative pid → id after boot
+  Note over Hook,Sess: covers agents we never launched
+```
+
+- **CLI pid-registry — `terminals/by-pid/<pid>.json`.** Written by `ag run` / the
+  shim at spawn ([`src/lib/session/pid-registry.ts`](../src/lib/session/pid-registry.ts),
+  `writePidSessionEntry`, interface `PidSessionEntry`). Immediate, but covers only
+  launches **we** make, and the id is exact only when known at launch (see §4).
+- **session-tracker — `terminals/sessions/<pid>.json`.** Written by the polyglot
+  `SessionStart` hook after the agent boots
+  ([`packages/session-tracker`](../../../packages/session-tracker), `STATE_DIR` in
+  `src/state-file.ts`, interface `SessionState`). Authoritative (reads the agent's
+  own payload) and covers **any** start — including a user typing `claude` in a
+  terminal, which the CLI never launched — for harnesses that expose a hook.
+
+**Reader split:** the CLI reads `by-pid/`; the **extension** reads `sessions/`
+(`apps/factory/src/core/liveSession.ts`). Same pid→id data, two writers, two readers.
+The join key already exists — the hook records `terminal_id` / `launch_id` from the
+env the launcher sets (`AGENT_TERMINAL_ID`, `AGENT_LAUNCH_ID`) — so the two files can
+be merged behind one path later; today both exist because neither subsumes the other
+(immediate-but-ours vs delayed-but-any).
+
+---
+
+## 4. Who assigns the session id — it differs per harness
+
+This is the crux of "why isn't it uniform." The dividing line is **who names the
+session**:
+
+- **`claude`** — *we* do. `ag run` generates a UUID and passes `--session-id`
+  ([`src/lib/exec.ts`](../src/lib/exec.ts), `spawnAgent`), so the id is known before
+  the process runs and the pid-registry entry is exact immediately.
+- **every other harness** — the *agent* owns the id, and we discover it: from its
+  `SessionStart` hook payload if it has one, else by reading it out of the transcript
+  later. Until then the pid-registry entry records pid + cwd + agent so `--active`
+  can correlate by folder.
+
+Two formats trip people up (both handled in [`src/lib/session/discover.ts`](../src/lib/session/discover.ts)):
+
+- **Codex** — the file is `rollout-<timestamp>-<uuid>.jsonl`, but the id is **not**
+  that filename; it's a separate UUID read from `session_meta.payload.id` inside the
+  file.
+- **OpenCode** — ids are `ses_<…>` and live in a SQLite database
+  (`~/.local/share/opencode/opencode.db`), pointed at by a synthetic
+  `opencode.db#<id>` path.
+
+**Which harnesses are session-tracked** is a distinct set from which the CLI can
+*run*. The run set is the `AGENTS` registry ([`src/lib/agents.ts`](../src/lib/agents.ts));
+the **session-discoverable** set is `SESSION_AGENTS`
+([`src/lib/session/types.ts`](../src/lib/session/types.ts)): `claude`, `codex`,
+`gemini`, `antigravity`, `opencode`, `openclaw`, `rush`, `hermes`, `grok`, `kimi`,
+`droid`. `cursor` and `copilot` are runnable but not session-discoverable.
+
+---
+
+## 5. Storage map
+
+Everything the two layers share lives in one of a few stores, each chosen for how
+long it must live and how it's read back:
+
+| Store | Path | Kind | Written / read |
+|---|---|---|---|
+| Sessions index | `~/.agents/.history/sessions/sessions.db` | SQLite + FTS5 | CLI scans transcripts → rows; `agents sessions` reads |
+| Transcripts | `~/.claude/projects/…`, `~/.codex/sessions/…`, … | agent-native files (read-only) | the raw truth; parsed on demand |
+| CLI pid-registry | `~/.agents/.cache/terminals/by-pid/<pid>.json` | ephemeral file | `ag run`/shim write; CLI reads (§3) |
+| Live-session state | `~/.agents/.cache/terminals/sessions/<pid>.json` | ephemeral file | hook writes; extension reads (§3) |
+| Audit log | `~/.agents/events.jsonl` | locked shared log | `emit()` in [`src/lib/events.ts`](../src/lib/events.ts); `agents events` reads |
+| Teams sentinels | `…/agents/<uuid>/exit_code`, `hosts/<id>.log` + `.exit` | ephemeral files | teammate writes exit code; supervisor reads (§6) |
+| Mailbox spool | `~/.agents/.history/mailbox/<id>/…` | append-only dirs | `agents message` / feed; `agents mailboxes` reads |
+
+There is **one** audit log (`events.jsonl`), shared and file-locked because many
+processes append to it. It is the single choke point for "who did what" — see
+[06-observability.md](06-observability.md).
+
+---
+
+## 6. Teams & remote execution
+
+Teams and `run` share code through the `agents run` **command line**, not a shared
+function — on purpose.
+
+- **Launch.** A team builds an `agents run …` argv (`buildRunArgv` in
+  [`src/lib/teams/agents.ts`](../src/lib/teams/agents.ts)) and runs it — locally as a
+  background shell, remotely over SSH. Any new `run` flag works in teams for free.
+- **Completion.** Each teammate runs `<cmd>; echo $? > exit_code` (`buildSentinelCommand`);
+  the supervisor polls that `exit_code` sentinel (locally, or by tailing the log +
+  reading the remote file over SSH, batched one SSH per host), flips the status, then
+  `startReady` launches whatever was waiting on it. The signal is a file with an exit
+  code — no live connection is held.
+- **Placement.** The scheduler ([`src/lib/teams/scheduler.ts`](../src/lib/teams/scheduler.ts),
+  `pickLeastLoaded`) picks a pinned host → the only host in the pool → the host
+  running the **fewest teammates** (a count, not real CPU/memory) → this machine.
+
+Detail in [teams.md](teams.md); the SSH transport is [09-ssh-transport.md](09-ssh-transport.md).
+
+---
+
+## 7. Live state is computed on demand
+
+`agents sessions --active` re-derives state on every call — it re-reads the **tail**
+of each live transcript, infers `working` / `waiting_input` / `idle`, and computes
+tokens/sec ([`src/lib/session/active.ts`](../src/lib/session/active.ts),
+`readSessionTailWithRaw` → `inferSessionState` → `computeTokPerSec`). There is no
+resident cache: each call pays the recompute, and the Factory extension polls it
+(local sessions ~3s, remote peers ~45s, `apps/factory/ui/.../UnifiedAgentsPane.tsx`).
+Other machines are reached by running the same command over SSH per peer.
+
+This is deliberately simple and correct; the "compute once, subscribe" direction (a
+resident process that parses each file once and emits only what changed) is the
+optimization pattern tracked in [99-optimizations.md](99-optimizations.md). Describe
+current behavior against this doc; that file owns the proposals.
+
+---
+
+## Related
+
+- [00-concepts.md](00-concepts.md) — DotAgents repos, resources, resolution, version homes
+- [05-sessions.md](05-sessions.md) — the transcript index in depth
+- [06-observability.md](06-observability.md) — events, feed, mailboxes, cost
+- [teams.md](teams.md) · [hosts.md](hosts.md) · [09-ssh-transport.md](09-ssh-transport.md)
+- [`packages/session-tracker/README.md`](../../../packages/session-tracker/README.md) — the live-state writer (hook)

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -82,8 +82,8 @@ sequenceDiagram
   participant Launcher as ag run / shim (CLI)
   participant Agent as the agent process
   participant Hook as SessionStart hook
-  participant ByPid as terminals/by-pid/&lt;pid&gt;.json
-  participant Sess as terminals/sessions/&lt;pid&gt;.json
+  participant ByPid as terminals/by-pid/[pid].json
+  participant Sess as terminals/sessions/[pid].json
   Launcher->>ByPid: write pid + cwd (+ id if known) at spawn
   Note over Launcher,ByPid: claude: id known up front (we mint the UUID)
   Launcher->>Agent: exec the harness

--- a/packages/session-tracker/AGENTS.md
+++ b/packages/session-tracker/AGENTS.md
@@ -39,6 +39,14 @@ tests/scenarios/     cold-spawn (50×, ≥99%) + kill-restart (20×, stale-entry
 - **`STATE_DIR` is declared in two places** that must agree: `src/state-file.ts`
   (`STATE_DIR`) and `src/hook.sh` (`STATE_DIR="$HOME/.agents/.cache/terminals/sessions"`).
   Change one → change both.
+- **The CLI keeps its own sibling pid→id registry** at
+  `~/.agents/.cache/terminals/by-pid/<pid>.json`
+  (`apps/cli/src/lib/session/pid-registry.ts`, `writePidSessionEntry`), written by
+  `ag run` / the shim **at spawn**. It is the immediate, our-launches-only counterpart
+  to this package's hook-written `sessions/<pid>.json` (delayed, any-launch,
+  authoritative). Same pid→id data, two writers — the CLI reads `by-pid/`, the
+  extension reads `sessions/`. The full picture is in
+  [`apps/cli/docs/architecture.md`](../../apps/cli/docs/architecture.md).
 - **Files are keyed by the agent PID** (`<pid>.json`). Lookups from a terminal walk
   the descendant-pid tree from the shell pid to find the agent pid.
 - **Stale entries** — the spawn-time id goes stale after the user exits + reruns in

--- a/skills/sessions/SKILL.md
+++ b/skills/sessions/SKILL.md
@@ -2,7 +2,7 @@
 name: sessions
 description: "Search, browse, and read agent conversation transcripts across Claude, Codex, Gemini, and OpenCode. Use this skill to find previous sessions, recover context, or inspect what agents have done."
 argument-hint: "[search query or session ID]"
-allowed-tools: Bash(agents sessions*), Bash(agents cost*)
+allowed-tools: Bash(agents sessions*), Bash(agents cost*), Bash(agents logs*)
 user-invocable: true
 ---
 


### PR DESCRIPTION
## What & why

The docs never stated that the repo has **two application-layer surfaces** — the
`agents` CLI (`apps/cli`, the framework) and the Factory VS Code extension
(`apps/factory`, a *consumer* that polls the CLI) — and described the session
mechanisms only in pieces. This adds one new architecture doc, threads a pointer
through the existing docs, and fixes the load-bearing factual drift. Every claim was
verified against current source (`main` @ `8cc72a37`).

## Changes (1 new, 8 edited)

| File | Change |
|---|---|
| **`apps/cli/docs/architecture.md`** (NEW) | Two application layers; two meanings of "session" (transcript index vs live pid→id identity); the two pid→id writers (`by-pid/` registry vs the SessionStart hook); storage map; teams/live-state mechanics. Two Mermaid figures (C4-style container + a pid→id sequence). |
| `apps/cli/docs/00-concepts.md` | Adds "Two application layers" + "Two kinds of session" pointer sections (it never mentioned the extension or session tracking). |
| `apps/cli/docs/05-sessions.md` | Schema `v6 → v13` (`SCHEMA_VERSION` in `db.ts`); tracked harnesses `5 → 11` (`SESSION_AGENTS`); `sessions.db` path corrected to `~/.agents/.history/…`. |
| `apps/cli/docs/06-observability.md` | Coverage list `5 → 11` harnesses; `(schema v6) → (schema v13)`. |
| `AGENTS.md`, `apps/cli/AGENTS.md` | The "Detailed design" links pointed at a repo-root `docs/00-concepts.md` / `docs/README.md` that don't exist (the corpus is under `apps/cli/docs/`); now resolve and lead with `architecture.md`. Dropped the brittle "14 harnesses" count (the `AGENTS` registry has 16) for a canonical-registry reference. |
| `README.md` | session-tracker state is read by the **Factory extension** (`liveSession.ts`), not "the CLI". |
| `packages/session-tracker/AGENTS.md` | Names the CLI's sibling `by-pid/` pid-registry (the second live-identity writer) it never mentioned. |
| `skills/sessions/SKILL.md` | Adds `Bash(agents logs*)` to `allowed-tools` — the skill teaches `agents logs` but the gate omitted it. |

## Verification

- **Numbers match source:** `SESSION_AGENTS` = 11 (`types.ts:14`), `SCHEMA_VERSION` = 13 (`db.ts:20`).
- **No residual stale strings:** grep for `schema v6` / `One of 5 formats` / the 5-harness list is empty.
- **Links:** 113 local links checked; every link I added/changed resolves. The ex-broken `docs/` links now point at existing files.

## Notes

- **Two pre-existing broken links** (not touched here): `apps/cli/README.md` and `website/` are referenced by memory files but don't exist in the tree — flagged for a separate pass.
- **Out of scope (deliberate):** cross-doc capability-table reconciliation (00-concepts's 16-row matrix vs `apps/cli/AGENTS.md`'s 15-row snapshot missing `forge`), the README compatibility matrix, and Gemini-deprecation stragglers.
- A scratch architecture write-up used as the source brief was itself stale in two spots vs HEAD — it described a two-tier `events`/`activity` model (`activity.ts`, `readUnifiedEvents`) that **doesn't exist** (the single locked `events.jsonl` is correct), and called the teams sentinel `.exit` (the code uses `exit_code`). This PR follows the code, not that brief.
- Session transcript (public repo, path only): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/2c2c78eb-b60b-4561-8bb4-3a9293755bbb.jsonl`
