### PR TITLE
perf(sessions): gate Codex title-index re-read + syncTopics on the ledger

### DIFF
--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -1062,12 +1062,20 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
   const changed = filterChangedFiles(filePaths);
 
   // Codex keeps human-readable titles (`thread_name`) in `session_index.jsonl`,
-  // which updates independently of the rollout files — apply them by id on every
-  // scan so a title that lands after a session was first indexed still surfaces.
+  // which updates independently of the rollout files. Stat each index against the
+  // ledger *without reading it*; only read + re-apply titles when the index (or a
+  // rollout) actually changed. On a fully unchanged scan this collapses to a
+  // couple of stat() calls instead of a full read + a `syncTopics` DB pass.
+  const titleIndex = diffCodexTitleIndexes();
+
+  if (changed.length === 0 && !titleIndex.changed) return;
+
   const titles = readCodexThreadNames();
 
   if (changed.length === 0) {
+    // No rollouts changed, but the title index did — apply the new titles.
     syncTopics(titles);
+    recordScans(titleIndex.stamps);
     return;
   }
 
@@ -1098,9 +1106,11 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
 
   upsertSessionsBatch(entries);
   recordScans(touched);
-  // Catch sessions whose rollout file was unchanged but gained a title since the
-  // last scan (the index changed, the transcript did not).
-  syncTopics(titles);
+  // Only when the title index changed can an *unchanged* rollout have gained a
+  // title since the last scan; the inline titles applied above already cover
+  // every changed session, so skip the extra sync when the index is untouched.
+  if (titleIndex.changed) syncTopics(titles);
+  recordScans(titleIndex.stamps);
 }
 
 /** Parse the lines of a Codex `session_index.jsonl` into a session id -> title map. */
@@ -1118,6 +1128,35 @@ export function parseCodexThreadNameIndex(raw: string): Map<string, string> {
     }
   }
   return titles;
+}
+
+/**
+ * Stat every Codex `session_index.jsonl` and diff it against the scan ledger
+ * *without reading it*. Returns the fresh stamps (persisted only after a
+ * successful title sync) and whether any index changed since the last scan — the
+ * signal that lets a no-op scan skip the file read + `syncTopics` entirely.
+ *
+ * The index path is a sibling of `sessions/` (never inside it), so it is never
+ * walked as a rollout and its ledger row can't collide with a transcript's.
+ */
+function diffCodexTitleIndexes(): {
+  stamps: Array<{ filePath: string; scan: ScanStamp }>;
+  changed: boolean;
+} {
+  const stamps: Array<{ filePath: string; scan: ScanStamp }> = [];
+  let changed = false;
+  for (const sessionsDir of getAgentSessionDirs('codex', 'sessions')) {
+    const indexPath = path.join(path.dirname(sessionsDir), 'session_index.jsonl');
+    const stat = safeStatSync(indexPath);
+    if (!stat) continue; // no index in this home
+    const scan: ScanStamp = { fileMtimeMs: Math.floor(stat.mtimeMs), fileSize: stat.size };
+    const prev = getScanStampByPath(indexPath);
+    if (!prev || prev.fileMtimeMs !== scan.fileMtimeMs || prev.fileSize !== scan.fileSize) {
+      changed = true;
+    }
+    stamps.push({ filePath: indexPath, scan });
+  }
+  return { stamps, changed };
 }
 
 /**


### PR DESCRIPTION
## What

`scanCodexIncremental` re-read the entire `session_index.jsonl` and ran a `syncTopics` DB pass on **every** scan — including a no-op scan where neither the rollout files nor the title index had changed. On a machine with a large Codex thread index, that's a full file read + parse plus a chunked `SELECT` over every titled id, on every `agents sessions` invocation.

This gates that work on the scan ledger: `diffCodexTitleIndexes()` stats each `session_index.jsonl` against the ledger **without reading it**, and titles are read + re-applied only when the index (or a rollout) actually changed. A fully unchanged scan now collapses to a couple of `stat()` calls.

## Why it's safe

- Reuses the exact `getScanStampByPath` / `recordScans` ledger the OpenCode scanner already uses for its single-DB gate (`discover.ts`).
- The `session_index.jsonl` path is a **sibling** of `sessions/`, never inside it, so it's never walked as a rollout and its ledger row can't collide with a transcript's.
- The one correctness property preserved: a title that lands in the index *after* a session was already indexed (rollout unchanged) still surfaces on the next scan — that path runs `syncTopics` whenever `titleIndex.changed`.

## Verification (real flow, this box)

- `tsc --noEmit` clean.
- `29/29` session tests pass (`discover.test.ts` + `active.pickfile.test.ts`).
- **Byte-identical output**: built origin/main and this branch, ran `agents sessions --json --all --limit 3000` against real transcripts through the same shared `sessions.db` — identical id/agent/topic sets (268 rows), stable across repeated runs.
- No latency regression (~0.67s both, warm). This box has no `~/.codex/session_index.jsonl`, so the skip has nothing to skip here — parity is the point; the win lands where a Codex index with many titled threads exists.

Session transcript (public repo, referenced not attached): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit/14567b8a-db63-4e27-9867-4846813157cc.jsonl`