### PR TITLE
feat(watchdog): run the always-on watchdog as a daemon routine

### DIFF
--- a/apps/cli/.changelog/next/watchdog-routine.md
+++ b/apps/cli/.changelog/next/watchdog-routine.md
@@ -1,0 +1,12 @@
+- **The always-on watchdog is now a daemon-fired routine, not a hand-rolled loop + sentinel.**
+  `agents watchdog enable` used to flip a private `~/.agents/.cache/state/watchdog/enabled`
+  sentinel that only meant anything to a manually-launched `agents watchdog --watch` loop —
+  so the auto-nudge only ran while some shell was babysitting it. It now creates and enables a
+  plain `watchdog` command routine (`agents watchdog --nudge`, every 2 minutes) and reloads
+  the daemon, so the always-on watchdog is fired by the same scheduler that runs every other
+  routine: it survives reboots, catches up if the daemon was down, and shows up in
+  `agents routines list`. `disable` pauses that routine; `status` reports whether it is
+  enabled. The Swift menu-bar toggle and `watchdog status --json` are unchanged. Bare
+  `agents watchdog` (dry) and `agents watchdog --watch` (now dry unless `--nudge`) still work
+  for ad-hoc runs. Source: `apps/cli/src/lib/watchdog/routine.ts`,
+  `apps/cli/src/commands/watchdog.ts`.

--- a/apps/cli/.changelog/next/watchdog-routine.md
+++ b/apps/cli/.changelog/next/watchdog-routine.md
@@ -8,5 +8,7 @@
   `agents routines list`. `disable` pauses that routine; `status` reports whether it is
   enabled. The Swift menu-bar toggle and `watchdog status --json` are unchanged. Bare
   `agents watchdog` (dry) and `agents watchdog --watch` (now dry unless `--nudge`) still work
-  for ad-hoc runs. Source: `apps/cli/src/lib/watchdog/routine.ts`,
-  `apps/cli/src/commands/watchdog.ts`.
+  for ad-hoc runs. If you had already opted in under the old build, a one-shot migration
+  folds that state forward — you stay enabled, now as the routine. Source:
+  `apps/cli/src/lib/watchdog/routine.ts`, `apps/cli/src/commands/watchdog.ts`,
+  `apps/cli/src/lib/migrate.ts`.

--- a/apps/cli/src/commands/watchdog.test.ts
+++ b/apps/cli/src/commands/watchdog.test.ts
@@ -47,7 +47,7 @@ describe('watchdog status --json', () => {
     const lines = await runWatchdog(['status']);
     expect(lines.length).toBeGreaterThanOrEqual(1);
     // The human path is two lines starting with the enable-state label.
-    expect(lines[0]).toContain('global auto-nudge');
+    expect(lines[0]).toContain('always-on watchdog');
     expect(() => JSON.parse(lines[0])).toThrow();
   });
 });

--- a/apps/cli/src/commands/watchdog.ts
+++ b/apps/cli/src/commands/watchdog.ts
@@ -8,19 +8,31 @@
  *
  *   agents watchdog                    one tick, dry — prints what it WOULD nudge/skip and why
  *   agents watchdog --nudge            one tick, actually injects (explicit opt-in)
- *   agents watchdog --watch            daemon loop (poll every --interval)
+ *   agents watchdog --watch            manual poll loop (dry unless --nudge)
  *   agents watchdog --json             machine-readable tick output (for the menu-bar)
- *   agents watchdog enable|disable     flip the global auto-nudge sentinel (default OFF)
+ *   agents watchdog enable|disable     turn the always-on watchdog routine on/off
  *   agents watchdog policy <id> <p>    per-session policy: off | keep | handsoff
+ *
+ * The always-on watchdog is a daemon-fired ROUTINE, not a private sentinel + a
+ * hand-rolled loop: `enable` creates/enables a `watchdog` command routine
+ * (`agents watchdog --nudge` every couple of minutes) and reloads the daemon;
+ * `disable` pauses it. See ../lib/watchdog/routine.ts.
  */
 
 import type { Command } from 'commander';
 import chalk from 'chalk';
-import * as fs from 'fs';
 import * as path from 'path';
 import { setHelpSections } from '../lib/help.js';
 import { parseDuration } from '../lib/hooks/cache.js';
 import { getRuntimeStateDir } from '../lib/state.js';
+import { setJobEnabled } from '../lib/routines.js';
+import {
+  ensureWatchdogRoutine,
+  isWatchdogRoutineEnabled,
+  watchdogRoutineExists,
+  WATCHDOG_ROUTINE_NAME,
+  WATCHDOG_ROUTINE_SCHEDULE,
+} from '../lib/watchdog/routine.js';
 import {
   runWatchdogTick,
   writePolicySentinel,
@@ -36,21 +48,18 @@ function stateDir(): string {
   return path.join(getRuntimeStateDir(), 'watchdog');
 }
 
-/** Global auto-nudge sentinel — present = enabled. Default OFF (opt-in). */
-function enabledSentinelPath(): string {
-  return path.join(stateDir(), 'enabled');
-}
-function isGloballyEnabled(): boolean {
-  return fs.existsSync(enabledSentinelPath());
-}
-function setGloballyEnabled(on: boolean): void {
-  const p = enabledSentinelPath();
-  if (on) {
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.writeFileSync(p, 'enabled\n');
-  } else {
-    try { fs.rmSync(p); } catch { /* already off */ }
+/**
+ * (Re)load the daemon so a just-changed routine takes effect without a restart.
+ * Best-effort: enabling starts the daemon if it is not running, then SIGHUPs it.
+ * Dynamic import keeps daemon.ts's heavy deps off the watchdog command's load path.
+ */
+async function reloadDaemonForRoutine(startIfStopped: boolean): Promise<void> {
+  const { isDaemonRunning, ensureDaemonStarted, signalDaemonReload } = await import('../lib/daemon.js');
+  if (isDaemonRunning()) {
+    signalDaemonReload();
+    return;
   }
+  if (startIfStopped) ensureDaemonStarted();
 }
 
 /** Parse a duration flag ("60s", "5m", "1h") to ms, or fall back to `fallbackMs`. */
@@ -124,13 +133,11 @@ export function registerWatchdogCommand(program: Command): void {
         cooldownMs: durationMsOr(opts.cooldown, DEFAULT_THRESHOLDS.cooldownMs),
         dormantMs: durationMsOr(opts.dormant, DEFAULT_THRESHOLDS.dormantMs),
       };
-      // Injection gate: --nudge is the explicit per-run opt-in; the global sentinel
-      // enables the automatic daemon. Default OFF: bare `agents watchdog` is dry.
-      // Re-read the sentinel every tick so a running `--watch` daemon reflects a
-      // later `agents watchdog enable`/`disable` (or the Swift menu-bar toggle)
-      // from another shell without a restart.
-      const computeWillInject = (): boolean =>
-        opts.nudge === true || (opts.watch === true && isGloballyEnabled());
+      // Injection gate: --nudge is the explicit opt-in to actually inject. Bare
+      // `agents watchdog` (and `--watch` without `--nudge`) is dry. The always-on
+      // path is the daemon routine, which runs `agents watchdog --nudge` — so the
+      // routine's enabled state IS the on/off switch, not a flag read here.
+      const computeWillInject = (): boolean => opts.nudge === true;
 
       const tickOnce = async (willInject: boolean): Promise<WatchdogTickResult> =>
         runWatchdogTick({
@@ -151,12 +158,12 @@ export function registerWatchdogCommand(program: Command): void {
         return;
       }
 
-      // Daemon loop.
+      // Manual poll loop (for ad-hoc use; the always-on path is `enable`'s routine).
       const intervalMs = durationMsOr(opts.interval, 30_000);
       if (!computeWillInject() && !opts.json) {
         console.log(chalk.yellow(
-          `watchdog --watch is DETECT-ONLY (global auto-nudge is ${isGloballyEnabled() ? 'on' : 'off'}). ` +
-          `Pass --nudge or run 'agents watchdog enable' to inject.`,
+          `watchdog --watch is DETECT-ONLY. Pass --nudge to inject, ` +
+          `or run 'agents watchdog enable' for the always-on daemon routine.`,
         ));
       }
       // eslint-disable-next-line no-constant-condition
@@ -178,13 +185,13 @@ export function registerWatchdogCommand(program: Command): void {
       # One tick, actually inject "Continue." into stalled+addressable splits
       agents watchdog --nudge
 
-      # Watch loop every 30s, tighter stall threshold
-      agents watchdog --watch --interval 30s --stall 60s --cooldown 5m
+      # Manual watch loop every 30s, tighter stall threshold (ad-hoc; dry unless --nudge)
+      agents watchdog --watch --nudge --interval 30s --stall 60s --cooldown 5m
 
       # Machine-readable for the menu-bar
       agents watchdog --json
 
-      # Turn on the global auto-nudge (so --watch injects without --nudge)
+      # Turn on the ALWAYS-ON watchdog (a daemon-fired routine)
       agents watchdog enable
 
       # Leave one session detected-but-untouched
@@ -201,31 +208,41 @@ export function registerWatchdogCommand(program: Command): void {
       (e.g. Ghostty with no tmux) are flagged for the menu-bar and SKIPPED — never
       a guessed or frontmost target.
 
-      Policy: global auto-nudge defaults OFF (opt-in via 'enable' or --nudge).
-      Per-session: off (ignore), keep (default), handsoff (detect + flag, never inject).
+      Always-on: 'agents watchdog enable' creates + enables a 'watchdog' command
+      routine ('${WATCHDOG_ROUTINE_SCHEDULE}' -> agents watchdog --nudge) and reloads the
+      daemon; 'disable' pauses it. Inspect it with 'agents routines list'. Defaults
+      OFF. Per-session policy: off (ignore), keep (default), handsoff (detect + flag).
 
       State (tray-readable): ${path.join('~/.agents/.cache/state/watchdog', '{nudges,flags,last-tick}.json')}
     `,
   });
 
-  // --- global enable/disable/status -----------------------------------------
+  // --- always-on enable/disable/status (backed by the daemon routine) --------
 
   cmd.command('enable')
-    .description('Turn ON global auto-nudge (so `agents watchdog --watch` injects without --nudge).')
-    .action(() => {
-      setGloballyEnabled(true);
-      console.log(chalk.green('watchdog: global auto-nudge ENABLED'));
+    .description('Turn ON the always-on watchdog: create/enable the `watchdog` routine and (re)load the daemon.')
+    .action(async () => {
+      ensureWatchdogRoutine(true);
+      await reloadDaemonForRoutine(true);
+      console.log(chalk.green(
+        `watchdog: ENABLED — routine '${WATCHDOG_ROUTINE_NAME}' fires ${WATCHDOG_ROUTINE_SCHEDULE} (agents watchdog --nudge)`,
+      ));
     });
 
   cmd.command('disable')
-    .description('Turn OFF global auto-nudge (back to detect-only unless --nudge is passed).')
-    .action(() => {
-      setGloballyEnabled(false);
-      console.log(chalk.yellow('watchdog: global auto-nudge DISABLED'));
+    .description('Turn OFF the always-on watchdog (pause the `watchdog` routine).')
+    .action(async () => {
+      if (!watchdogRoutineExists()) {
+        console.log(chalk.dim('watchdog: already off (no routine)'));
+        return;
+      }
+      setJobEnabled(WATCHDOG_ROUTINE_NAME, false);
+      await reloadDaemonForRoutine(false);
+      console.log(chalk.yellow('watchdog: DISABLED (routine paused)'));
     });
 
   cmd.command('status')
-    .description('Show whether global auto-nudge is on and where state is written.')
+    .description('Show whether the always-on watchdog routine is enabled and where state is written.')
     .option('--json', 'Emit status as JSON (for the menu-bar / scripts)')
     .action((_opts, command) => {
       // The parent `watchdog` command also declares --json and greedily parses it
@@ -233,12 +250,12 @@ export function registerWatchdogCommand(program: Command): void {
       // parent, not this subcommand. optsWithGlobals() merges both levels, so we
       // read it correctly regardless of which command commander bound it to.
       const json = command.optsWithGlobals().json === true;
-      const on = isGloballyEnabled();
+      const on = isWatchdogRoutineEnabled();
       if (json) {
-        console.log(JSON.stringify({ enabled: on, stateDir: stateDir() }));
+        console.log(JSON.stringify({ enabled: on, routine: WATCHDOG_ROUTINE_NAME, stateDir: stateDir() }));
         return;
       }
-      console.log(`global auto-nudge: ${on ? chalk.green('ON') : chalk.dim('off')}`);
+      console.log(`always-on watchdog: ${on ? chalk.green('ON') : chalk.dim('off')} (routine '${WATCHDOG_ROUTINE_NAME}')`);
       console.log(`state dir: ${chalk.dim(stateDir())}`);
     });
 

--- a/apps/cli/src/commands/watchdog.ts
+++ b/apps/cli/src/commands/watchdog.ts
@@ -117,7 +117,7 @@ export function registerWatchdogCommand(program: Command): void {
     .command('watchdog')
     .description('Auto-nudge stalled agent terminals: detect stalls, resolve the exact split, inject "Continue." — no menu-bar needed.')
     .option('--nudge', 'Actually inject (default is a dry run that only reports what it would do)')
-    .option('--watch', 'Daemon loop: run a tick every --interval until interrupted')
+    .option('--watch', 'Manual poll loop: run a tick every --interval (dry unless --nudge; the always-on path is `watchdog enable`)')
     .option('--interval <dur>', 'Poll interval in --watch mode (e.g. 30s, 1m)', '30s')
     .option('--stall <dur>', 'Idle time before a session counts as stalled', humanMs(DEFAULT_THRESHOLDS.stallMs))
     .option('--cooldown <dur>', 'Minimum time between nudges to the same session', humanMs(DEFAULT_THRESHOLDS.cooldownMs))

--- a/apps/cli/src/lib/migrate.test.ts
+++ b/apps/cli/src/lib/migrate.test.ts
@@ -5,7 +5,7 @@ import { spawnSync, spawn } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'url';
 
-import { migrateExtrasExtrasToAgentsExtras, migrateRoutineDeviceToDevices, repairSelfReferentialBinShims } from './migrate.js';
+import { migrateExtrasExtrasToAgentsExtras, migrateRoutineDeviceToDevices, migrateWatchdogSentinelToRoutine, repairSelfReferentialBinShims } from './migrate.js';
 import { toPosix } from './platform/index.js';
 import * as yaml from 'yaml';
 
@@ -596,5 +596,35 @@ describe('v12 device migration scheduler startup failure (POSIX)', () => {
         expect(isProcessAlive(pid)).toBe(false);
       }
     }
+  });
+});
+
+describe('migrateWatchdogSentinelToRoutine', () => {
+  it('no sentinel on disk -> no-op (never ensures a routine)', () => {
+    const dir = makeTempHistoryDir();
+    const sentinel = path.join(dir, 'enabled'); // deliberately not created
+    let called = false;
+    migrateWatchdogSentinelToRoutine(sentinel, () => { called = true; });
+    expect(called).toBe(false);
+  });
+
+  it('sentinel present -> ensures the routine ENABLED and deletes the sentinel', () => {
+    const dir = makeTempHistoryDir();
+    const sentinel = path.join(dir, 'enabled');
+    fs.writeFileSync(sentinel, 'enabled\n');
+    const calls: boolean[] = [];
+    migrateWatchdogSentinelToRoutine(sentinel, (en) => { calls.push(en); });
+    // Opted-in state is carried forward, and the one-shot marker is consumed.
+    expect(calls).toEqual([true]);
+    expect(fs.existsSync(sentinel)).toBe(false);
+  });
+
+  it('leaves the sentinel in place if ensuring the routine throws (retry next run)', () => {
+    const dir = makeTempHistoryDir();
+    const sentinel = path.join(dir, 'enabled');
+    fs.writeFileSync(sentinel, 'enabled\n');
+    migrateWatchdogSentinelToRoutine(sentinel, () => { throw new Error('routines dir unwritable'); });
+    // Never silently lose the opt-in — the sentinel survives for a later attempt.
+    expect(fs.existsSync(sentinel)).toBe(true);
   });
 });

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -15,6 +15,7 @@ import type { AgentId } from './types.js';
 import { machineId } from './machine-id.js';
 import { AGENTS, agentConfigDirName, findInPath } from './agents.js';
 import { createLink } from './platform/index.js';
+import { ensureWatchdogRoutine } from './watchdog/routine.js';
 
 const HOME = process.env.HOME ?? os.homedir();
 const USER_DIR = path.join(HOME, '.agents');
@@ -1834,6 +1835,38 @@ export function migrateRoutineDeviceToDevices(routinesDir?: string): void {
   }
 }
 
+/**
+ * Fold the legacy watchdog enable sentinel into the watchdog routine.
+ *
+ * The always-on watchdog used to be gated by a presence sentinel at
+ * `<runtime-state>/watchdog/enabled`; it is now a daemon routine. A user who had
+ * run `agents watchdog enable` under the old build has that file on disk — without
+ * this, upgrading would silently drop them back to OFF (the always-on nudge just
+ * stops), the worst failure mode for a "survives reboots" feature. If the sentinel
+ * exists, ensure the `watchdog` routine exists AND is enabled, then delete the
+ * sentinel so this runs exactly once. If ensuring the routine fails, the sentinel
+ * is left in place so a later run retries rather than silently losing the opt-in.
+ *
+ * Both seams are injectable so the migration is unit-testable without touching the
+ * real routines dir (and without racing the routine module's own tests).
+ */
+export function migrateWatchdogSentinelToRoutine(
+  sentinelPath: string = path.join(CACHE_DIR, 'state', 'watchdog', 'enabled'),
+  ensure: (enabled: boolean) => void = ensureWatchdogRoutine,
+): void {
+  if (!fs.existsSync(sentinelPath)) return;
+  try {
+    ensure(true);
+  } catch (err) {
+    console.error(
+      `watchdog sentinel migration: could not create the routine (${(err as Error).message}); leaving the sentinel for a later retry`,
+    );
+    return;
+  }
+  try { fs.rmSync(sentinelPath); } catch { /* already gone */ }
+  console.error('Migrated watchdog: legacy enable sentinel → watchdog routine (kept enabled)');
+}
+
 /** Run all idempotent migrations. Safe to call multiple times. */
 export async function runMigration(): Promise<void> {
   // MUST run first: every other migrator reads SYSTEM_DIR (the new path).
@@ -1895,6 +1928,11 @@ export async function runMigration(): Promise<void> {
 
   // Rewrite routine YAML files: singular `device:` -> plural `devices: []`.
   migrateRoutineDeviceToDevices();
+
+  // Fold the legacy watchdog enable sentinel into the watchdog routine so a user
+  // who opted in under the old build stays opted in after upgrading. After the
+  // routine rewrites above so the routines dir is in its canonical shape.
+  migrateWatchdogSentinelToRoutine();
 
   // Symlink repair runs LAST so it can find the post-move version homes.
   repairAgentConfigSymlinks();

--- a/apps/cli/src/lib/watchdog/routine.test.ts
+++ b/apps/cli/src/lib/watchdog/routine.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the watchdog-as-a-routine wiring.
+ *
+ * The pure builder is checked against the real routine validator (the scheduler's
+ * gate), and the disk path is exercised against the real routines dir — with a
+ * save/restore guard so a developer's actual `watchdog` routine is never clobbered.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { validateJob, readJob, writeJob, deleteJob, type JobConfig } from '../routines.js';
+import {
+  buildWatchdogRoutine,
+  ensureWatchdogRoutine,
+  isWatchdogRoutineEnabled,
+  watchdogRoutineExists,
+  WATCHDOG_ROUTINE_NAME,
+  WATCHDOG_ROUTINE_COMMAND,
+  WATCHDOG_ROUTINE_SCHEDULE,
+} from './routine.js';
+
+describe('buildWatchdogRoutine (pure)', () => {
+  it('produces a command routine the scheduler accepts (validateJob is the gate)', () => {
+    const job = buildWatchdogRoutine(false);
+    expect(validateJob(job)).toEqual([]);
+    expect(job.command).toBe(WATCHDOG_ROUTINE_COMMAND);
+    expect(job.schedule).toBe(WATCHDOG_ROUTINE_SCHEDULE);
+    // A command routine — never an agent/workflow run (deterministic, no LLM).
+    expect(job.agent).toBeUndefined();
+    expect(job.workflow).toBeUndefined();
+  });
+
+  it('ships disabled by default (opt-in), matching the old sentinel default', () => {
+    expect(buildWatchdogRoutine(false).enabled).toBe(false);
+    expect(buildWatchdogRoutine(true).enabled).toBe(true);
+  });
+
+  it('fires every 2 minutes — inside the 5m stall threshold', () => {
+    expect(WATCHDOG_ROUTINE_SCHEDULE).toBe('*/2 * * * *');
+  });
+});
+
+describe('ensureWatchdogRoutine (disk, idempotent)', () => {
+  // Preserve any real user `watchdog` routine so the test never clobbers it.
+  let saved: JobConfig | null = null;
+  beforeEach(() => {
+    saved = readJob(WATCHDOG_ROUTINE_NAME);
+    deleteJob(WATCHDOG_ROUTINE_NAME);
+  });
+  afterEach(() => {
+    deleteJob(WATCHDOG_ROUTINE_NAME);
+    if (saved) writeJob(saved);
+  });
+
+  it('creates the routine (disabled) when absent', () => {
+    expect(watchdogRoutineExists()).toBe(false);
+    ensureWatchdogRoutine(false);
+    expect(watchdogRoutineExists()).toBe(true);
+    expect(isWatchdogRoutineEnabled()).toBe(false);
+  });
+
+  it('enables then disables idempotently', () => {
+    ensureWatchdogRoutine(true);
+    expect(isWatchdogRoutineEnabled()).toBe(true);
+    ensureWatchdogRoutine(true); // no-op second call
+    expect(isWatchdogRoutineEnabled()).toBe(true);
+    ensureWatchdogRoutine(false);
+    expect(isWatchdogRoutineEnabled()).toBe(false);
+  });
+
+  it('preserves a user-tuned schedule when only toggling enabled', () => {
+    writeJob({ ...buildWatchdogRoutine(false), schedule: '*/5 * * * *' });
+    ensureWatchdogRoutine(true);
+    const job = readJob(WATCHDOG_ROUTINE_NAME);
+    expect(job?.schedule).toBe('*/5 * * * *'); // not reset to the default
+    expect(job?.enabled).toBe(true);
+  });
+});

--- a/apps/cli/src/lib/watchdog/routine.ts
+++ b/apps/cli/src/lib/watchdog/routine.ts
@@ -1,0 +1,76 @@
+/**
+ * The watchdog, expressed as a routine.
+ *
+ * The always-on watchdog is not a bespoke subsystem — it is a plain `command`
+ * routine the daemon's existing scheduler fires: `agents watchdog --nudge`, once
+ * every couple of minutes. Enabling / disabling the watchdog is enabling /
+ * disabling that routine, so there is ONE durable, inspectable concept
+ * (`agents routines list` shows it; the scheduler catches it up if the daemon was
+ * down) instead of a private sentinel file and a hand-rolled `--watch` loop.
+ *
+ * A `command` routine — not `agent`/`workflow` — because the tick is deterministic
+ * housekeeping: no LLM, no auth, no sandbox. Each fire runs ONE bounded tick (the
+ * cron is the loop), so the daemon's per-fire model fits without a long-lived
+ * process.
+ */
+import { readJob, writeJob, setJobEnabled, type JobConfig } from '../routines.js';
+
+/** The routine name. `agents routines list` / `readJob` key on this. */
+export const WATCHDOG_ROUTINE_NAME = 'watchdog';
+
+/**
+ * Fire every 2 minutes. Mirrors the extension's 120s tick, and is well inside the
+ * 5m stall threshold and 20m nudge cooldown, so a stall is noticed promptly
+ * without the daemon spawning a tick more often than the cooldown can matter.
+ */
+export const WATCHDOG_ROUTINE_SCHEDULE = '*/2 * * * *';
+
+/** The plain shell each fire runs: one bounded, deterministic nudge tick. */
+export const WATCHDOG_ROUTINE_COMMAND = 'agents watchdog --nudge';
+
+/**
+ * Build the watchdog routine config. Pure — touches no disk. `mode`/`effort`/
+ * `timeout` are required by JobConfig but ignored for `command` routines;
+ * writeJob() drops the default ('auto'/'10m') values so the on-disk file stays
+ * to the point (name + schedule + command + enabled).
+ */
+export function buildWatchdogRoutine(enabled: boolean): JobConfig {
+  return {
+    name: WATCHDOG_ROUTINE_NAME,
+    schedule: WATCHDOG_ROUTINE_SCHEDULE,
+    command: WATCHDOG_ROUTINE_COMMAND,
+    enabled,
+    mode: 'auto',
+    effort: 'auto',
+    timeout: '10m',
+    prompt: '',
+  };
+}
+
+/** Is the watchdog routine present on disk (user or system layer)? */
+export function watchdogRoutineExists(): boolean {
+  return readJob(WATCHDOG_ROUTINE_NAME) !== null;
+}
+
+/** Is the watchdog routine present AND enabled? */
+export function isWatchdogRoutineEnabled(): boolean {
+  const job = readJob(WATCHDOG_ROUTINE_NAME);
+  return job !== null && job.enabled === true;
+}
+
+/**
+ * Ensure the watchdog routine exists with the requested enabled state, preserving
+ * any user edits. Absent → create it; present → only flip `enabled` (never clobber
+ * a schedule or command the user tuned). Idempotent: calling it twice with the
+ * same state is a no-op after the first.
+ */
+export function ensureWatchdogRoutine(enabled: boolean): void {
+  const existing = readJob(WATCHDOG_ROUTINE_NAME);
+  if (existing === null) {
+    writeJob(buildWatchdogRoutine(enabled));
+    return;
+  }
+  if (existing.enabled !== enabled) {
+    setJobEnabled(WATCHDOG_ROUTINE_NAME, enabled);
+  }
+}


### PR DESCRIPTION
## Watchdog as a daemon routine (composition, not a subsystem)

The always-on watchdog was a hand-rolled `while(true)` loop in `agents watchdog --watch`
gated by a private `~/.agents/.cache/state/watchdog/enabled` sentinel — so auto-nudge only
ran while some shell was babysitting it, and died on reboot. This makes the always-on
watchdog a plain **`command` routine** the daemon's existing scheduler fires, reusing the
one durable, inspectable primitive the CLI already has for "run X on a schedule."

### What changes
- New `lib/watchdog/routine.ts` — builds/ensures a `watchdog` command routine
  (`agents watchdog --nudge`, `*/2 * * * *`). A `command` routine because the tick is
  deterministic housekeeping (no LLM, no auth, no sandbox); each fire is one bounded tick,
  so the cron is the loop. Idempotent, preserves user edits, ships **disabled** (opt-in).
- `agents watchdog enable` → creates + enables the routine and reloads the daemon;
  `disable` → pauses it; `status` → reports the routine's enabled state. The old `enabled`
  sentinel is gone (no other consumer read it — the Swift menu-bar toggles via these same
  commands and reads `status --json`, whose `{enabled}` contract is preserved).
- `--watch` is now dry unless `--nudge`; the always-on path is the routine.

### Why it's better
Survives reboots, catches up if the daemon was down, and shows up in `agents routines list`
— all for free from the scheduler. No bespoke loop, no private sentinel.

### End-to-end verification (against the live daemon)
```
$ agents watchdog enable
watchdog: ENABLED — routine 'watchdog' fires */2 * * * * (agents watchdog --nudge)
$ agents watchdog status --json
{"enabled":true,"routine":"watchdog","stateDir":".../state/watchdog"}
$ agents routines list | grep watchdog
  watchdog   command   -   all   every 2 minutes   yes   today 2:02 AM   ...   # scheduler scheduled it
$ agents watchdog disable
watchdog: DISABLED (routine paused)
```
The daemon's real scheduler accepted and scheduled the routine (Next Run computed).
Tests: `bun run build` clean; `routine.test.ts` + `watchdog.test.ts` + `routines.test.ts` — 131 passed.

### Scope
First of a staged series consolidating the watchdog onto built-ins. Follow-ups (separate PRs):
the decision brains as a customizable built-in **workflow** (pick harness/model, per-repo
override), delivery via `answer-router` (mailbox/inject/resume) + a first-class **kitty** rail,
retiring the Factory extension watchdog to sole-owner, and a lock-guarded cooldown ledger.

Session transcript (private, not attached — public repo): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.170/home/.claude/projects/-home-muqsit/a83a607c-eb4b-416f-a89f-fdf15f781a16.jsonl`
