### PR TITLE
fix(routines): detect and surface agent auth-failures instead of failing silently

### DIFF
--- a/apps/cli/.changelog/next/auth-failure-detection.md
+++ b/apps/cli/.changelog/next/auth-failure-detection.md
@@ -8,10 +8,11 @@
   is `"completed"` on a logged-out run. Rate-limit still classifies first, so a 429 keeps
   triggering failover rather than being mistaken for an auth failure. Source:
   `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/runner.ts`, `apps/cli/src/lib/routines.ts`.
-- **`agents routines run` now exits non-zero on failure.** A failed run (including an auth
-  failure) returns exit code 1 and `--json { "ok": false, … }` with the reason, instead of
-  exiting 0 with `ok:true` — so cron wrappers, `&&` chains, and `--json` consumers actually
-  see the failure. Source: `apps/cli/src/commands/routines.ts`.
+- **`agents routines run` now exits non-zero when a run doesn't complete.** A run that ends
+  in `failed`, `timeout`, or an auth failure returns exit code 1 and `--json { "ok": false, … }`
+  with the reason, instead of exiting 0 with `ok:true` — so cron wrappers, `&&` chains, and
+  `--json` consumers actually see the failure. (Exit code is set via `process.exitCode` so the
+  JSON payload flushes fully to a pipe first.) Source: `apps/cli/src/commands/routines.ts`.
 - **Auth preflight before dispatch.** A routine whose (agent, version) has a cached
   `revoked` auth verdict fails fast with `auth_preflight: revoked` without spawning a
   doomed agent. Fails open on any other verdict, so a stale/absent probe or a network blip

--- a/apps/cli/.changelog/next/auth-failure-detection.md
+++ b/apps/cli/.changelog/next/auth-failure-detection.md
@@ -1,0 +1,23 @@
+- **Routine auth-failures are now detected, not silent.** When a routine's agent is logged
+  out or its token is revoked, the run is classified `failed` with an `auth_failed:` /
+  `auth_preflight:` reason instead of a generic non-zero exit. The login-error text is no
+  longer written into `report.md`, and `{last_report}` now only injects the last *completed*
+  run's report — so a single logged-out run can no longer poison every subsequent run's
+  prompt. Classification uses the Claude stream-json markers (`error:"authentication_failed"`
+  and a `result` event with `is_error:true`), which is the reliable signal — `terminal_reason`
+  is `"completed"` on a logged-out run. Rate-limit still classifies first, so a 429 keeps
+  triggering failover rather than being mistaken for an auth failure. Source:
+  `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/runner.ts`, `apps/cli/src/lib/routines.ts`.
+- **`agents routines run` now exits non-zero on failure.** A failed run (including an auth
+  failure) returns exit code 1 and `--json { "ok": false, … }` with the reason, instead of
+  exiting 0 with `ok:true` — so cron wrappers, `&&` chains, and `--json` consumers actually
+  see the failure. Source: `apps/cli/src/commands/routines.ts`.
+- **Auth preflight before dispatch.** A routine whose (agent, version) has a cached
+  `revoked` auth verdict fails fast with `auth_preflight: revoked` without spawning a
+  doomed agent. Fails open on any other verdict, so a stale/absent probe or a network blip
+  never blocks a run, and agents with no live probe (codex/gemini/grok) are never blocked.
+  Source: `apps/cli/src/lib/runner.ts`, reusing `apps/cli/src/lib/auth-health.ts`.
+- **The routines daemon no longer starts silently token-less.** When no Claude OAuth token
+  is available (e.g. a headless macOS daemon whose keychain was locked at start), the daemon
+  now logs a `WARN` and fires a desktop notification instead of quietly spawning Claude
+  routines that all fail auth. Source: `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -876,8 +876,10 @@ export function registerRoutinesCommands(program: Command): void {
           });
           // A failed run must exit non-zero so cron wrappers, `&&` chains, and
           // `--json` consumers actually see the failure (a logged-out agent used
-          // to exit 0 with ok:true, hiding the whole auth-failure epidemic).
-          if (!succeeded) process.exit(1);
+          // to exit 0 with ok:true, hiding the whole auth-failure epidemic). Set
+          // exitCode rather than process.exit() so the JSON payload is fully
+          // flushed to a pipe before the process ends.
+          if (!succeeded) process.exitCode = 1;
           return;
         }
         if (succeeded) {
@@ -899,7 +901,7 @@ export function registerRoutinesCommands(program: Command): void {
           console.log(fs.readFileSync(result.reportPath, 'utf-8'));
         }
 
-        if (!succeeded) process.exit(1);
+        if (!succeeded) process.exitCode = 1;
       } catch (err) {
         if (options.json) {
           writeJson({ error: (err as Error).message });

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -864,18 +864,23 @@ export function registerRoutinesCommands(program: Command): void {
       try {
         const result = await executeJob(job);
         const logPath = `${getRunDir(name, result.meta.runId)}/stdout.log`;
+        const succeeded = result.meta.status === 'completed';
         if (options.json) {
           writeJson({
-            ok: true,
+            ok: succeeded,
             job: name,
             logDir: getRunDir(name, result.meta.runId),
             ...runMetaJson(result.meta),
             logPath,
             reportPath: result.reportPath ?? null,
           });
+          // A failed run must exit non-zero so cron wrappers, `&&` chains, and
+          // `--json` consumers actually see the failure (a logged-out agent used
+          // to exit 0 with ok:true, hiding the whole auth-failure epidemic).
+          if (!succeeded) process.exit(1);
           return;
         }
-        if (result.meta.status === 'completed') {
+        if (succeeded) {
           spinner!.succeed(`Job completed (exit code: ${result.meta.exitCode})`);
         } else if (result.meta.status === 'timeout') {
           spinner!.warn(`Job timed out after ${job.timeout}`);
@@ -885,11 +890,16 @@ export function registerRoutinesCommands(program: Command): void {
 
         console.log(chalk.gray(`  Run: ${result.meta.runId}`));
         console.log(chalk.gray(`  Log: ${logPath}`));
+        if (result.meta.errorMessage) {
+          console.log(chalk.gray(`  Reason: ${result.meta.errorMessage}`));
+        }
 
         if (result.reportPath) {
           console.log(chalk.bold('\nReport:\n'));
           console.log(fs.readFileSync(result.reportPath, 'utf-8'));
         }
+
+        if (!succeeded) process.exit(1);
       } catch (err) {
         if (options.json) {
           writeJson({ error: (err as Error).message });

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -17,7 +17,7 @@ import { listJobs as listAllJobs } from './routines.js';
 import { JobScheduler } from './scheduler.js';
 import { MonitorEngine } from './monitors/engine.js';
 import { executeJobDetached, monitorRunningJobs } from './runner.js';
-import { detectOverdueJobs, notifyOverdue } from './overdue.js';
+import { detectOverdueJobs, notifyOverdue, notifyDesktop } from './overdue.js';
 import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
 import { readAndResolveBundleEnv } from './secrets/bundles.js';
@@ -317,6 +317,20 @@ export async function runDaemon(): Promise<void> {
     if (oauthToken) {
       process.env.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;
       log('INFO', 'Loaded Claude OAuth token from secrets bundle for routine runs');
+    } else {
+      // No token available (e.g. a headless macOS daemon whose keychain was
+      // locked at start resolves broker-only and gets nothing). Historically
+      // this was silent, so every Claude routine the daemon spawned failed auth
+      // with no signal. Make it loud: WARN in the log and fire a desktop alert.
+      log(
+        'WARN',
+        'No Claude OAuth token available — Claude routine runs will fail auth on this host. ' +
+          'Restart the daemon with the keychain unlocked, or unlock the `claude` secrets bundle.',
+      );
+      notifyDesktop(
+        'agents daemon: no Claude credential',
+        'Claude routines will fail auth on this host. Restart the daemon with the keychain unlocked.',
+      );
     }
   }
 

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, detectRateLimit, detectAuthFailure, detectAuthFailureEvent, authFailureReason, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, detectRateLimit, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { mailboxDir } from './mailbox.js';
 
@@ -82,6 +82,30 @@ describe('rate-limit vs auth precedence', () => {
   it('a logged-out log is auth true, rate-limit false', () => {
     expect(detectAuthFailureEvent(LOGGED_OUT_CLAUDE_LOG, 'claude')).toBe(true);
     expect(detectRateLimit(LOGGED_OUT_CLAUDE_LOG)).toBe(false);
+  });
+});
+
+describe('isAuthFailureFromLog — the shared foreground/detached decision', () => {
+  it('classifies a real logged-out log regardless of process exit code', () => {
+    // Structural marker is authoritative even on a clean (exit 0) process.
+    expect(isAuthFailureFromLog(LOGGED_OUT_CLAUDE_LOG, 'claude', { processFailed: false })).toBe(true);
+    expect(isAuthFailureFromLog(LOGGED_OUT_CLAUDE_LOG, 'claude', { processFailed: true })).toBe(true);
+  });
+
+  it('does NOT classify a completed run that merely mentions an auth phrase (the false-positive bug)', () => {
+    // is_error:false → structural false; and processFailed:false → raw text is
+    // not consulted. This is the exact case that used to suppress a good report.
+    expect(isAuthFailureFromLog(HEALTHY_LOG_MENTIONING_LOGIN, 'claude', { processFailed: false })).toBe(false);
+  });
+
+  it('falls back to raw text ONLY when the process actually failed (died mid-stream, no result event)', () => {
+    const midStreamDeath = '{"type":"assistant","message":{"content":[{"type":"text","text":"Failed to authenticate. API Error: 401 OAuth access token has been revoked."}]}}';
+    expect(isAuthFailureFromLog(midStreamDeath, 'claude', { processFailed: false })).toBe(false);
+    expect(isAuthFailureFromLog(midStreamDeath, 'claude', { processFailed: true })).toBe(true);
+  });
+
+  it('never classifies a rate-limit failure as auth', () => {
+    expect(isAuthFailureFromLog(RATE_LIMITED_CLAUDE_LOG, 'claude', { processFailed: true })).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -2,9 +2,100 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, detectRateLimit, detectAuthFailure, detectAuthFailureEvent, authFailureReason, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { mailboxDir } from './mailbox.js';
+
+// Real logged-out Claude stream-json tail, captured from an actual failed
+// routine run on disk (drain-linear-cli, 2026-07-27). Ground truth: `terminal_reason`
+// is "completed", so only the `error:"authentication_failed"` marker and the
+// `result`+`is_error` text can classify it.
+const LOGGED_OUT_CLAUDE_LOG = [
+  '{"type":"system","subtype":"init","session_id":"x"}',
+  '{"type":"system","subtype":"api_retry","attempt":1,"max_retries":10,"error_status":401,"error":"authentication_failed","session_id":"x"}',
+  '{"type":"assistant","message":{"content":[{"type":"text","text":""}]},"error":"authentication_failed","session_id":"x"}',
+  '{"type":"result","subtype":"success","is_error":true,"api_error_status":401,"terminal_reason":"completed","result":"Failed to authenticate. API Error: 401 OAuth access token has been revoked.","num_turns":1}',
+].join('\n');
+
+const RATE_LIMITED_CLAUDE_LOG = [
+  '{"type":"system","subtype":"init","session_id":"x"}',
+  '{"type":"result","subtype":"error","is_error":true,"result":"You have hit your 5-hour limit. Try again later.","num_turns":1}',
+].join('\n');
+
+// A COMPLETED run whose report text merely mentions the phrase "Not logged in"
+// (e.g. a routine summarizing an auth doc). Must NOT be classified as an auth
+// failure — the structural signal is is_error:false.
+const HEALTHY_LOG_MENTIONING_LOGIN = [
+  '{"type":"assistant","message":{"content":[{"type":"text","text":"The onboarding doc explains what to do when Not logged in appears."}]},"session_id":"x"}',
+  '{"type":"result","subtype":"success","is_error":false,"terminal_reason":"completed","result":"Documented the Not logged in flow. Please run /login is covered.","num_turns":3}',
+].join('\n');
+
+describe('detectAuthFailure — user-visible auth strings', () => {
+  it('matches every observed corpus phrase', () => {
+    for (const s of [
+      'Failed to authenticate. API Error: 401 OAuth access token has been revoked.',
+      'Not logged in · Please run /login',
+      'API Error: 401 Invalid authentication credentials',
+      'OAuth session expired and could not be refreshed',
+      "Your organization has disabled Claude subscription access",
+    ]) {
+      expect(detectAuthFailure(s)).toBe(true);
+    }
+  });
+
+  it('does not match ordinary text or a bare 401 without an auth keyword', () => {
+    expect(detectAuthFailure('the server returned 401 rows from the query')).toBe(false);
+    expect(detectAuthFailure('completed the refactor, all tests pass')).toBe(false);
+  });
+
+  it('does not match rate-limit text (kept a separate class)', () => {
+    expect(detectAuthFailure('You have hit your 5-hour limit')).toBe(false);
+  });
+});
+
+describe('detectAuthFailureEvent — Claude stream-json structural signal', () => {
+  it('is true for a real logged-out Claude log', () => {
+    expect(detectAuthFailureEvent(LOGGED_OUT_CLAUDE_LOG, 'claude')).toBe(true);
+  });
+
+  it('is false for a completed run that merely mentions the phrase', () => {
+    expect(detectAuthFailureEvent(HEALTHY_LOG_MENTIONING_LOGIN, 'claude')).toBe(false);
+  });
+
+  it('is false for a rate-limit failure', () => {
+    expect(detectAuthFailureEvent(RATE_LIMITED_CLAUDE_LOG, 'claude')).toBe(false);
+  });
+
+  it('is false for non-claude agents (they do not emit these markers)', () => {
+    expect(detectAuthFailureEvent(LOGGED_OUT_CLAUDE_LOG, 'codex')).toBe(false);
+    expect(detectAuthFailureEvent(LOGGED_OUT_CLAUDE_LOG, 'gemini')).toBe(false);
+  });
+});
+
+describe('rate-limit vs auth precedence', () => {
+  it('a rate-limited log is rate-limit true, auth false — failover, not an auth failure', () => {
+    expect(detectRateLimit(RATE_LIMITED_CLAUDE_LOG)).toBe(true);
+    expect(detectAuthFailureEvent(RATE_LIMITED_CLAUDE_LOG, 'claude')).toBe(false);
+    expect(detectAuthFailure(RATE_LIMITED_CLAUDE_LOG)).toBe(false);
+  });
+
+  it('a logged-out log is auth true, rate-limit false', () => {
+    expect(detectAuthFailureEvent(LOGGED_OUT_CLAUDE_LOG, 'claude')).toBe(true);
+    expect(detectRateLimit(LOGGED_OUT_CLAUDE_LOG)).toBe(false);
+  });
+});
+
+describe('authFailureReason', () => {
+  it('extracts a short human phrase from the log (most specific match wins)', () => {
+    // The log contains both "Failed to authenticate" and "OAuth access token has
+    // been revoked"; the more specific revoked phrase is preferred (pattern order).
+    expect(authFailureReason(LOGGED_OUT_CLAUDE_LOG)).toBe('OAuth access token has been revoked');
+  });
+
+  it('returns null when no user-visible phrase is present', () => {
+    expect(authFailureReason('all good here')).toBeNull();
+  });
+});
 
 /** Minimal ExecOptions with required fields, overridable per test. */
 function execOpts(over: Partial<ExecOptions> & { agent: ExecOptions['agent'] }): ExecOptions {

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -1648,6 +1648,30 @@ export function authFailureReason(text: string): string | null {
   return null;
 }
 
+/**
+ * Decide whether a run's stream-json log is an authentication failure. The
+ * single source of truth for both the foreground and detached run paths.
+ *
+ * The structural marker (`detectAuthFailureEvent`, gated on `is_error:true`) is
+ * authoritative and safe on ANY exit — it catches a logged-out Claude that exits
+ * 0 (its `result` event carries `is_error:true` while `terminal_reason` is
+ * "completed"). The raw user-visible string (`detectAuthFailure`) is only
+ * consulted when the process actually FAILED, as a fallback for a run that died
+ * mid-stream before emitting a `result` event. That gate is what prevents a
+ * genuinely-completed run whose output merely *mentions* an auth phrase (e.g. a
+ * routine documenting a login flow) from being misclassified and having its
+ * legitimate report suppressed.
+ */
+export function isAuthFailureFromLog(
+  logText: string,
+  agent: AgentId,
+  opts: { processFailed: boolean },
+): boolean {
+  if (detectAuthFailureEvent(logText, agent)) return true;
+  if (opts.processFailed && detectAuthFailure(logText)) return true;
+  return false;
+}
+
 /** An agent (with optional pinned version) in a fallback chain. */
 export interface FallbackEntry {
   agent: AgentId;

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -1565,6 +1565,89 @@ export function detectRateLimit(text: string): boolean {
   return RATE_LIMIT_PATTERNS.some(pattern => pattern.test(text));
 }
 
+/**
+ * Patterns that indicate an authentication failure — the agent is logged out,
+ * its token was revoked, or the session expired. These are the user-visible
+ * strings a logged-out agent surfaces (observed across the routine-run corpus).
+ * Unlike a rate limit, an auth failure is NOT self-healing by failover — every
+ * chain entry on the same account fails identically — so it is classified
+ * separately and never triggers a fallback attempt.
+ *
+ * The bare `401` is deliberately paired with an auth keyword: a plain "401" can
+ * appear in legitimate output (an HTTP-status table, a log line), so it only
+ * counts when it co-occurs with OAuth/authentication/credentials/Unauthorized.
+ */
+export const AUTH_FAILURE_PATTERNS: RegExp[] = [
+  /OAuth (?:access token has been revoked|session expired)/i,
+  /(?:Please run|run) \/login/i,
+  /\bNot logged in\b/i,
+  /Invalid authentication credentials/i,
+  /Failed to authenticate/i,
+  /organization has (?:disabled|revoked) .*(?:subscription|access)/i,
+  /401\b[^\n]*(?:OAuth|authenticat|credential|Unauthorized)/i,
+];
+
+/**
+ * Return true if the text contains any known authentication-failure indicator.
+ * Agent-agnostic: matches the user-visible error string wherever it surfaces
+ * (stdout tail, a captured error message, a plain-text agent's output).
+ */
+export function detectAuthFailure(text: string): boolean {
+  return AUTH_FAILURE_PATTERNS.some(pattern => pattern.test(text));
+}
+
+/**
+ * Return true if a stream-json log carries the structural markers of an auth
+ * failure. This is the authoritative signal for Claude: a logged-out run emits
+ *   {"type":"system","subtype":"api_retry","error":"authentication_failed",…}
+ *   {"type":"assistant",…,"error":"authentication_failed"}
+ *   {"type":"result","is_error":true,"result":"Failed to authenticate…"}
+ * Note `terminal_reason` is "completed" on such a run, so exit-code / terminal-
+ * reason logic can never catch it — the `error:"authentication_failed"` marker
+ * and the `result`+`is_error` text are the reliable signals.
+ *
+ * Gated on the Claude stream-json shape; other agents don't emit these fields,
+ * so callers pass their agent and this returns false for non-claude.
+ */
+export function detectAuthFailureEvent(logText: string, agent: AgentId): boolean {
+  if (agent !== 'claude') return false;
+  const lines = logText.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed[0] !== '{') continue;
+    let parsed: any;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (parsed?.error === 'authentication_failed') return true;
+    if (
+      parsed?.type === 'result' &&
+      parsed?.is_error === true &&
+      typeof parsed?.result === 'string' &&
+      detectAuthFailure(parsed.result)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Return the first human-readable auth-failure phrase found in the text, for use
+ * as a stable, short run `errorMessage` reason. Falls back to null when the only
+ * signal was the structural `error:"authentication_failed"` marker with no
+ * user-visible string.
+ */
+export function authFailureReason(text: string): string | null {
+  for (const pattern of AUTH_FAILURE_PATTERNS) {
+    const m = text.match(pattern);
+    if (m) return m[0];
+  }
+  return null;
+}
+
 /** An agent (with optional pinned version) in a fallback chain. */
 export interface FallbackEntry {
   agent: AgentId;

--- a/apps/cli/src/lib/overdue.ts
+++ b/apps/cli/src/lib/overdue.ts
@@ -90,20 +90,12 @@ export function detectOverdueJobs(now: Date = new Date()): OverdueJob[] {
   return overdue;
 }
 
-/** Fire a native desktop notification listing the overdue jobs. Best-effort —
- *  failures (missing `osascript`/`notify-send`, no display) are swallowed. */
-export function notifyOverdue(jobs: OverdueJob[]): void {
-  if (jobs.length === 0) return;
-
-  const title =
-    jobs.length === 1
-      ? `Routine overdue: ${jobs[0].name}`
-      : `${jobs.length} routines overdue`;
-  const body =
-    jobs.length === 1
-      ? `Missed ${jobs[0].expectedAt.toLocaleString()}. Run: agents routines catchup`
-      : `${jobs.map((j) => j.name).join(', ')} — agents routines catchup`;
-
+/**
+ * Fire a native desktop notification. Best-effort — failures (missing
+ * `osascript`/`notify-send`, no display, headless box) are swallowed so a
+ * notification attempt can never take the daemon down.
+ */
+export function notifyDesktop(title: string, body: string): void {
   const platform = os.platform();
   try {
     if (platform === 'darwin') {
@@ -135,4 +127,20 @@ export function notifyOverdue(jobs: OverdueJob[]): void {
   } catch {
     // Notification is best-effort; nothing to do.
   }
+}
+
+/** Fire a native desktop notification listing the overdue jobs. Best-effort. */
+export function notifyOverdue(jobs: OverdueJob[]): void {
+  if (jobs.length === 0) return;
+
+  const title =
+    jobs.length === 1
+      ? `Routine overdue: ${jobs[0].name}`
+      : `${jobs.length} routines overdue`;
+  const body =
+    jobs.length === 1
+      ? `Missed ${jobs[0].expectedAt.toLocaleString()}. Run: agents routines catchup`
+      : `${jobs.map((j) => j.name).join(', ')} — agents routines catchup`;
+
+  notifyDesktop(title, body);
 }

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, getJobRunsDir, getRunDir, finalizeRunMeta, type JobConfig, type RunMeta } from './routines.js';
+import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, getJobRunsDir, getRunDir, finalizeRunMeta, writeRunMeta, resolveJobPrompt, getLatestCompletedRun, type JobConfig, type RunMeta } from './routines.js';
 import { getRoutinesDir, getSystemRoutinesDir, getRunsDir, ensureAgentsDir } from './state.js';
 
 /** Minimal valid schedule-based job. */
@@ -571,5 +571,66 @@ describe('finalizeRunMeta', () => {
     const meta = makeMeta('not-a-date');
     finalizeRunMeta(meta, 'failed', 1);
     expect(meta.duration).toBe(0);
+  });
+});
+
+describe('getLatestCompletedRun / {last_report} poison-stop', () => {
+  // Unique job name under the real runs dir; cleaned up after each test. runIds
+  // are chosen so the FAILED run sorts LAST (most recent) — the exact shape that
+  // used to poison the next prompt.
+  const jobName = `__authtest_poison_${process.pid}`;
+
+  function seedRun(runId: string, status: RunMeta['status'], report: string): void {
+    const meta: RunMeta = {
+      jobName,
+      runId,
+      agent: 'claude',
+      pid: null,
+      status,
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      exitCode: status === 'completed' ? 0 : 1,
+      ...(status !== 'completed' ? { errorMessage: 'auth_failed: Failed to authenticate' } : {}),
+    };
+    writeRunMeta(meta);
+    fs.writeFileSync(path.join(getRunDir(jobName, runId), 'report.md'), report, 'utf-8');
+  }
+
+  afterEach(() => {
+    fs.rmSync(getJobRunsDir(jobName), { recursive: true, force: true });
+  });
+
+  it('returns the latest COMPLETED run, skipping a later failed run', () => {
+    seedRun('2026-01-01T00-00-00-000Z', 'completed', 'GOOD REPORT');
+    seedRun('2026-01-02T00-00-00-000Z', 'failed', 'Not logged in · Please run /login');
+
+    const latest = getLatestCompletedRun(jobName);
+    expect(latest?.runId).toBe('2026-01-01T00-00-00-000Z');
+  });
+
+  it('returns null when no run has completed', () => {
+    seedRun('2026-01-01T00-00-00-000Z', 'failed', 'Failed to authenticate');
+    expect(getLatestCompletedRun(jobName)).toBeNull();
+  });
+
+  it('{last_report} injects the completed report, never the failed auth text', () => {
+    seedRun('2026-01-01T00-00-00-000Z', 'completed', 'GOOD REPORT');
+    seedRun('2026-01-02T00-00-00-000Z', 'failed', 'Not logged in · Please run /login');
+
+    const config = {
+      name: jobName,
+      agent: 'claude',
+      schedule: '0 3 * * *',
+      prompt: 'Previous: {last_report}',
+      mode: 'auto',
+      effort: 'auto',
+      timeout: '10m',
+      enabled: true,
+    } as JobConfig;
+
+    const resolved = resolveJobPrompt(config);
+    expect(resolved).toContain('GOOD REPORT');
+    expect(resolved).not.toContain('Not logged in');
+    expect(resolved).not.toContain('/login');
   });
 });

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -708,8 +708,11 @@ export function resolveJobPrompt(config: JobConfig): string {
     }
   }
 
-  // Last report (special handling)
-  const latestRun = getLatestRun(config.name);
+  // Last report (special handling). Only a COMPLETED run's report is injected —
+  // a failed run's report.md is the agent's error text (e.g. a login prompt on
+  // an auth failure), and feeding that into the next prompt poisons every
+  // subsequent run until a human intervenes.
+  const latestRun = getLatestCompletedRun(config.name);
   if (latestRun) {
     const reportPath = path.join(getJobRunsDir(config.name), latestRun.runId, 'report.md');
     if (fs.existsSync(reportPath)) {
@@ -769,6 +772,20 @@ export function listRuns(jobName: string): RunMeta[] {
 export function getLatestRun(jobName: string): RunMeta | null {
   const runs = listRuns(jobName);
   return runs.length > 0 ? runs[runs.length - 1] : null;
+}
+
+/**
+ * Get the most recent COMPLETED run for a job, or null if none has completed.
+ * Used to resolve `{last_report}` so a failed run's error text (e.g. an auth
+ * login prompt written into report.md) can never be injected into the next
+ * run's prompt.
+ */
+export function getLatestCompletedRun(jobName: string): RunMeta | null {
+  const runs = listRuns(jobName);
+  for (let i = runs.length - 1; i >= 0; i--) {
+    if (runs[i].status === 'completed') return runs[i];
+  }
+  return null;
 }
 
 /** Persist run metadata to its run directory as meta.json. */

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -38,6 +38,9 @@ import {
   resolveHeadlessMode,
   buildExecEnv,
   detectRateLimit,
+  detectAuthFailure,
+  detectAuthFailureEvent,
+  authFailureReason,
   type ExecOptions,
   type ExecEffort,
   type FallbackEntry,
@@ -55,6 +58,8 @@ import {
   readinessFromCandidate,
   type RotateResult,
 } from './rotate.js';
+import { readAuthHealth, isDeadVerdict } from './auth-health.js';
+import { machineId } from './machine-id.js';
 
 /** Result of a completed job execution, including metadata and optional report. */
 export interface RunResult {
@@ -638,6 +643,28 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
   };
   writeRunMeta(meta);
 
+  // Auth preflight: if the last live probe rejected this (agent, version)'s
+  // token (verdict `revoked`), the run is guaranteed to fail auth — fail fast
+  // before spawning instead of producing a doomed run + poisoned report. Cache-
+  // only (the daemon refreshes it periodically); fail OPEN on any non-revoked or
+  // missing verdict so a stale/absent probe or a network blip never blocks a
+  // run, and agents with no live probe (codex/gemini/grok) are never blocked.
+  const preflightVersion = launch.chain[0]?.version;
+  if (preflightVersion) {
+    const health = readAuthHealth(machineId(), effectiveAgent, preflightVersion);
+    if (health && isDeadVerdict(health.verdict)) {
+      const reason = `auth_preflight: ${health.verdict}`;
+      process.stderr.write(
+        `[agents] routine ${config.name}: ${effectiveAgent}@${preflightVersion} token ${health.verdict} — skipping run (re-login required)\n`,
+      );
+      finalizeRunMeta(meta, 'failed', 1, { errorMessage: reason });
+      writeRunMeta(meta);
+      timer.end({ status: 'failed', exitCode: 1, runId, error: reason });
+      archiveRoutineTranscripts(meta, runDir, overlayHome);
+      return { meta, reportPath: null };
+    }
+  }
+
   const timeoutMs = parseTimeout(config.timeout) || 10 * 60 * 1000;
 
   // Loop path: delegate to runLoop (same driver as `agents run --loop` / workflow loop:).
@@ -757,21 +784,44 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
       continue;
     }
 
+    // Auth failure — the agent is logged out / token revoked. Unlike a rate
+    // limit it is not self-healing by failover (every chain entry on the same
+    // account fails identically), so rate-limit is classified first (above) and
+    // auth only when NOT rate-limited. Classified so the failure is visible and,
+    // critically, so the login-error text is never persisted as the report.
+    const authFailed = !rateLimited && (
+      detectAuthFailureEvent(attempt.logText, effectiveAgent) ||
+      detectAuthFailure(attempt.logText) ||
+      (attempt.error ? detectAuthFailure(attempt.error) : false)
+    );
+
     if (attempt.error) {
       process.stderr.write(
         `[agents] routine ${config.name}: spawn failed for ${label}: ${attempt.error}\n`,
       );
     }
 
-    finalizeRunMeta(meta, 'failed', attempt.exitCode ?? 1, attempt.error ? { errorMessage: attempt.error } : undefined);
+    const authReason = authFailed
+      ? (authFailureReason(attempt.logText)
+          ?? (attempt.error ? authFailureReason(attempt.error) : null)
+          ?? 'authentication_failed')
+      : null;
+    const failureErrorMessage = authReason
+      ? `auth_failed: ${authReason}`
+      : (attempt.error ?? undefined);
+
+    finalizeRunMeta(meta, 'failed', attempt.exitCode ?? 1, failureErrorMessage ? { errorMessage: failureErrorMessage } : undefined);
     writeRunMeta(meta);
     timer.end({
       status: 'failed',
       exitCode: meta.exitCode ?? undefined,
       runId,
-      ...(attempt.error ? { error: attempt.error } : {}),
+      ...(failureErrorMessage ? { error: failureErrorMessage } : {}),
     });
-    const reportPath = extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
+    // On auth failure the last assistant text IS the login error — never persist
+    // it as report.md; it would otherwise be injected into the next run's prompt
+    // via {last_report}.
+    const reportPath = authFailed ? null : extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
     archiveRoutineTranscripts(meta, runDir, overlayHome);
     return { meta, reportPath };
   }
@@ -1034,10 +1084,20 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
     finalizeRunMeta(meta, status, exitCode, errorMessage ? { errorMessage } : undefined);
     writeRunMeta(meta);
     archiveRoutineTranscripts(meta, runDir, overlayHome);
-    if (status !== 'timeout') extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
+    // Never persist the report on an auth failure — the last assistant text is
+    // the login error, which would poison the next run's {last_report} prompt.
+    const isAuthFailure = !!errorMessage && errorMessage.startsWith('auth_failed:');
+    if (status !== 'timeout' && !isAuthFailure) extractAndSaveReport(stdoutPath, effectiveAgent, runDir);
   };
 
   child.on('exit', (code) => {
+    let logText = '';
+    try { logText = fs.readFileSync(stdoutPath, 'utf-8'); } catch { /* log unreadable */ }
+    if (detectAuthFailureEvent(logText, effectiveAgent) || detectAuthFailure(logText)) {
+      const reason = authFailureReason(logText) ?? 'authentication_failed';
+      settle('failed', code ?? 1, `auth_failed: ${reason}`);
+      return;
+    }
     const inferred = inferFinalStatusFromLog(stdoutPath, effectiveAgent);
     if (inferred) {
       settle(inferred.status, inferred.exitCode);

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -39,7 +39,7 @@ import {
   buildExecEnv,
   detectRateLimit,
   detectAuthFailure,
-  detectAuthFailureEvent,
+  isAuthFailureFromLog,
   authFailureReason,
   type ExecOptions,
   type ExecEffort,
@@ -760,6 +760,21 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     }
 
     if (attempt.status === 'completed') {
+      // Exit code alone is unreliable for auth: a logged-out Claude can exit 0
+      // with a `result` event carrying is_error:true (terminal_reason
+      // "completed"). Consult the SAME structural signal the detached path uses
+      // so both paths agree — raw text is deliberately NOT used here, so a
+      // genuinely-completed run that merely mentions an auth phrase stays a
+      // success (processFailed:false).
+      if (isAuthFailureFromLog(attempt.logText, effectiveAgent, { processFailed: false })) {
+        const reason = authFailureReason(attempt.logText) ?? 'authentication_failed';
+        finalizeRunMeta(meta, 'failed', attempt.exitCode ?? 1, { errorMessage: `auth_failed: ${reason}` });
+        writeRunMeta(meta);
+        timer.end({ status: 'failed', exitCode: meta.exitCode ?? undefined, runId, error: `auth_failed: ${reason}` });
+        // Never persist the login-error text as the report.
+        archiveRoutineTranscripts(meta, runDir, overlayHome);
+        return { meta, reportPath: null };
+      }
       finalizeRunMeta(meta, 'completed', 0);
       writeRunMeta(meta);
       timer.end({ status: 'completed', exitCode: 0, runId });
@@ -790,8 +805,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     // auth only when NOT rate-limited. Classified so the failure is visible and,
     // critically, so the login-error text is never persisted as the report.
     const authFailed = !rateLimited && (
-      detectAuthFailureEvent(attempt.logText, effectiveAgent) ||
-      detectAuthFailure(attempt.logText) ||
+      isAuthFailureFromLog(attempt.logText, effectiveAgent, { processFailed: true }) ||
       (attempt.error ? detectAuthFailure(attempt.error) : false)
     );
 
@@ -1093,7 +1107,10 @@ export async function executeJobDetached(config: JobConfig): Promise<RunMeta> {
   child.on('exit', (code) => {
     let logText = '';
     try { logText = fs.readFileSync(stdoutPath, 'utf-8'); } catch { /* log unreadable */ }
-    if (detectAuthFailureEvent(logText, effectiveAgent) || detectAuthFailure(logText)) {
+    // processFailed gates the raw-text fallback so a COMPLETED run (exit 0) that
+    // merely mentions an auth phrase is never misclassified; the structural
+    // marker still catches an exit-0 auth failure on its own.
+    if (isAuthFailureFromLog(logText, effectiveAgent, { processFailed: (code ?? 1) !== 0 })) {
       const reason = authFailureReason(logText) ?? 'authentication_failed';
       settle('failed', code ?? 1, `auth_failed: ${reason}`);
       return;


### PR DESCRIPTION
## Why

A fleet audit (5,204 routine runs across 4 hosts) found **44.1% of scheduled routine runs fail, and 80.6% of those failures are the underlying Claude agent being logged out / token-revoked** on a machine the user doesn't sit at. They were invisible because:

1. A logged-out run is byte-identical to a crash — collapsed to a generic `failed`.
2. The agent's login-error text was written into `report.md`…
3. …and that report was injected into the **next** run's `{last_report}` prompt — one revoked token became a self-perpetuating poison loop.
4. `agents routines run` even exited `0` / `--json ok:true` on failure.

This is **Half A** of the fix (detection & visibility). Half B (credential durability — stop the per-version credential scoping that causes the silent logout) follows in a separate PR.

## Ground-truth correction

The audit suggested classifying on `terminal_reason:"api_error"`. A **real** logged-out Claude run on disk emits:

```json
{"type":"system","subtype":"api_retry","error":"authentication_failed",...}
{"type":"assistant",...,"error":"authentication_failed"}
{"type":"result","subtype":"success","is_error":true,"api_error_status":401,
   "terminal_reason":"completed",   // <-- NOT "api_error"
   "result":"Failed to authenticate. API Error: 401 OAuth access token has been revoked."}
```

A classifier built on `terminal_reason` would miss every real case. The reliable signals are `error:"authentication_failed"` on any event and a `result` event with `is_error:true` + auth text. The tests encode this exact fixture.

## What changes

- **Classifier** (`exec.ts`): `detectAuthFailure` / `detectAuthFailureEvent` / `authFailureReason` beside `detectRateLimit`. Rate-limit still classifies **first** (a 429 keeps triggering failover, never mistaken for auth).
- **Runner** (`runner.ts`): classify auth failures, mark the run `failed` with an `auth_failed:` reason, and **never** write the login error into `report.md`. Mirrored on the detached daemon path.
- **Poison-stop** (`routines.ts`): `{last_report}` resolves the latest **completed** run (`getLatestCompletedRun`) — a failed run's report can never feed the next prompt. Also neutralizes the existing backlog.
- **Exit codes** (`commands/routines.ts`): `agents routines run` exits non-zero + `ok:false` on failure.
- **Preflight** (`runner.ts`): a cached `revoked` verdict fails fast (`auth_preflight: revoked`) without spawning. Cache-only, **fails open** on any non-revoked/missing verdict; reuses `auth-health.ts`. Non-live-probe agents (codex/gemini/grok) are never blocked.
- **Daemon** (`daemon.ts`): no Claude token → `WARN` + desktop notification instead of silently spawning doomed routines. Shared `notifyDesktop` extracted from `notifyOverdue` (no duplicated notifier).

## Testing

- `exec.test.ts`: real logged-out Claude stream-json fixture; classifier true; rate-limit-vs-auth precedence; a **completed** run merely mentioning "Not logged in" stays auth-false; non-claude agents return false.
- `routines.test.ts`: `{last_report}` injects the completed report, never the failed auth text.
- Full suite: **6717 passed** (the one `models.test.ts` codex-catalog failure is environmental — reads the local codex catalog, unrelated to this change). `tsc --noEmit` clean.

Audit source: `zion:/private/tmp/agents-cli-audit.html`.