### PR TITLE
fix(daemon): stop unattended default-version repoint that causes silent Claude logouts

### DIFF
--- a/apps/cli/.changelog/next/daemon-no-unattended-default-switch.md
+++ b/apps/cli/.changelog/next/daemon-no-unattended-default-switch.md
@@ -1,0 +1,11 @@
+- **The daemon no longer silently repoints your default agent version.** The unattended
+  6-hourly launch-health pass (`healBrokenDefaultLaunches` → `ensureAgentRunnable`) now runs
+  with `allowDefaultSwitch: false`: it still repairs the *current* default in place, but if
+  that default can't be repaired it no longer adopts another installed version or installs
+  `latest` and pins it. A background default switch installs a fresh version home, which for
+  Claude is a fresh, empty credential scope (macOS keychain keyed off `CLAUDE_CONFIG_DIR`;
+  Linux per-version token file) — i.e. an "unprovoked logout" at a time uncorrelated with
+  anything you did, and a leading cause of routine auth-failures on unattended machines. The
+  daemon now logs a `WARN` naming the version to pick instead; interactive callers
+  (`agents run`, `agents add`) are unchanged and still repoint as before. Source:
+  `apps/cli/src/lib/versions.ts`, `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -613,7 +613,7 @@ export async function runDaemon(): Promise<void> {
       );
       if (repaired.length) log('INFO', `launch-health: repaired ${repaired.join(', ')}`);
       if (unhealed.length) {
-        log('WARN', `launch-health: ${unhealed.join(', ')} won't launch and was NOT auto-switched — choose a version with \`agents use <agent> <version>\` or \`agents add <agent>@latest\``);
+        log('WARN', `launch-health: ${unhealed.join(', ')} won't launch and will not be auto-switched — choose a version with \`agents use <agent> <version>\` or \`agents add <agent>@latest\``);
       }
     } catch (err) {
       log('ERROR', `launch-health check failed: ${(err as Error).message}`);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -603,8 +603,18 @@ export async function runDaemon(): Promise<void> {
     checkingLaunchHealth = true;
     try {
       const { healBrokenDefaultLaunches } = await import('./versions.js');
-      const repaired = await healBrokenDefaultLaunches((m) => log('INFO', `launch-health: ${m}`));
+      // Unattended pass: repair the current default in place, but NEVER repoint
+      // the global default (allowDefaultSwitch: false). A background default
+      // switch installs a fresh version home → a fresh empty Claude credential
+      // scope, i.e. a silent logout uncorrelated with anything the user did.
+      const { repaired, unhealed } = await healBrokenDefaultLaunches(
+        (m) => log('INFO', `launch-health: ${m}`),
+        { allowDefaultSwitch: false },
+      );
       if (repaired.length) log('INFO', `launch-health: repaired ${repaired.join(', ')}`);
+      if (unhealed.length) {
+        log('WARN', `launch-health: ${unhealed.join(', ')} won't launch and was NOT auto-switched — choose a version with \`agents use <agent> <version>\` or \`agents add <agent>@latest\``);
+      }
     } catch (err) {
       log('ERROR', `launch-health check failed: ${(err as Error).message}`);
     } finally {

--- a/apps/cli/src/lib/versions.isolation.integration.test.ts
+++ b/apps/cli/src/lib/versions.isolation.integration.test.ts
@@ -45,13 +45,18 @@ describe.skipIf(process.platform === 'win32')('ensureAgentRunnable — isolation
     stillIsolated: boolean;
   }
 
-  function runEnsure(target: string, probeIsolationOf: string): Outcome {
+  function runEnsure(
+    target: string,
+    probeIsolationOf: string,
+    opts?: { allowDefaultSwitch?: boolean },
+  ): Outcome {
     const versionsPath = path.resolve(process.cwd(), 'src/lib/versions.ts');
+    const optsArg = opts ? `, undefined, ${JSON.stringify(opts)}` : '';
     const script = `
       import {
         ensureAgentRunnable, getGlobalDefault, listInstalledVersions, isVersionIsolated,
       } from ${JSON.stringify(versionsPath)};
-      const healed = await ensureAgentRunnable('codex', ${JSON.stringify(target)});
+      const healed = await ensureAgentRunnable('codex', ${JSON.stringify(target)}${optsArg});
       console.log('__RESULT__' + JSON.stringify({
         healed,
         defaultAfter: getGlobalDefault('codex'),
@@ -108,6 +113,42 @@ describe.skipIf(process.platform === 'win32')('ensureAgentRunnable — isolation
     expect(r.defaultAfter).not.toBe('9.9.9');
     // The isolated copy is untouched and still isolated.
     expect(r.stillIsolated).toBe(true);
+  }, 180_000);
+
+  // The daemon's unattended 6-hourly launch-health pass runs with
+  // allowDefaultSwitch:false. A broken default that can't be repaired IN PLACE
+  // must NOT be silently swapped to another installed version — repointing the
+  // default installs/points at a different version home, which for Claude is a
+  // fresh empty credential scope (the "unprovoked logout"). It must fail closed
+  // and leave the default for the user to choose.
+  it('does not repoint the default in unattended mode (allowDefaultSwitch: false)', () => {
+    plant('9.9.1', { runnable: false });   // broken normal default
+    plant('9.9.3', { runnable: true });    // a healthy normal version it COULD adopt
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents:\n  codex: "9.9.1"\n');
+
+    const r = runEnsure('9.9.1', '9.9.3', { allowDefaultSwitch: false });
+
+    // In-place repair fails (synthetic 9.9.1 → npm 404) and, crucially, the
+    // healthy 9.9.3 is NOT adopted: the default pointer stays put and the failure
+    // is surfaced (null) so the daemon can alert instead of silently switching.
+    // (The failed clean-reinstall guts 9.9.1's node_modules so it drops off the
+    // installed list — orthogonal to the point here, which is the DEFAULT pointer.)
+    expect(r.healed).toBeNull();
+    expect(r.defaultAfter).toBe('9.9.1');
+    expect(r.defaultAfter).not.toBe('9.9.3');
+  }, 180_000);
+
+  // Control: the SAME broken default, with the default (interactive) behavior,
+  // DOES adopt the healthy version — proving the flag is what changes it.
+  it('still repoints the default in interactive mode (default behavior unchanged)', () => {
+    plant('9.9.1', { runnable: false });   // broken normal default
+    plant('9.9.3', { runnable: true });    // a healthy normal version
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents:\n  codex: "9.9.1"\n');
+
+    const r = runEnsure('9.9.1', '9.9.3');
+
+    expect(r.healed).toBe('9.9.3');
+    expect(r.defaultAfter).toBe('9.9.3');
   }, 180_000);
 
   // The last-resort step ("install latest and pin it") reuses the version dir of

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -2318,7 +2318,18 @@ export async function ensureAgentRunnable(
   agent: AgentId,
   version: string,
   log?: (message: string) => void,
+  opts?: { allowDefaultSwitch?: boolean },
 ): Promise<string | null> {
+  // Whether this heal may REPOINT the global default (adopt another version, or
+  // install `latest` and pin it). Interactive callers (`agents run`, `agents
+  // add`) allow it. The daemon's unattended 6-hourly launch-health pass sets
+  // this false: a background pass that silently switches the default installs a
+  // fresh version home → a fresh, empty Claude credential scope (macOS keychain
+  // keyed off CLAUDE_CONFIG_DIR; Linux per-version token file), i.e. an
+  // "unprovoked logout" at a time uncorrelated with anything the user did. In
+  // refuse-mode we still repair the CURRENT default in place (no scope change),
+  // but never repoint — we return null so the caller can alert instead.
+  const allowDefaultSwitch = opts?.allowDefaultSwitch ?? true;
   const cfg = AGENTS[agent];
   if (!cfg?.npmPackage) return version;
 
@@ -2340,6 +2351,15 @@ export async function ensureAgentRunnable(
   // switch — surface the failure and let the caller tell the user.
   if (targetIsolated) {
     log?.(`${cfg.name}@${version} is an isolated install and could not be repaired — leaving your default ${cfg.name} untouched.`);
+    return null;
+  }
+
+  // In-place repair failed → normally adopt another installed version and repoint
+  // the default. When default-switching is disallowed (unattended daemon pass),
+  // refuse: repointing would swap the live credential scope out from under the
+  // user with no signal. Surface it so the caller can notify.
+  if (!allowDefaultSwitch) {
+    log?.(`${cfg.name}@${version} won't launch and could not be repaired in place — NOT repointing your default ${cfg.name} unattended. Run \`agents use ${agent} <version>\` or \`agents add ${agent}@latest\` to choose one.`);
     return null;
   }
 
@@ -2402,8 +2422,12 @@ export async function ensureAgentRunnable(
 const failedRepairAt = new Map<string, number>();
 const REPAIR_COOLDOWN_MS = 24 * 60 * 60_000;
 
-export async function healBrokenDefaultLaunches(log?: (m: string) => void): Promise<string[]> {
+export async function healBrokenDefaultLaunches(
+  log?: (m: string) => void,
+  opts?: { allowDefaultSwitch?: boolean },
+): Promise<{ repaired: string[]; unhealed: string[] }> {
   const repaired: string[] = [];
+  const unhealed: string[] = [];
   for (const agent of Object.keys(AGENTS) as AgentId[]) {
     if (!AGENTS[agent].npmPackage) continue; // native/global agents have no gutted-tarball failure mode
     const version = getGlobalDefault(agent);
@@ -2420,15 +2444,16 @@ export async function healBrokenDefaultLaunches(log?: (m: string) => void): Prom
       continue;
     }
     log?.(`${AGENTS[agent].name}@${version} won't launch — repairing…`);
-    const healed = await ensureAgentRunnable(agent, version, log);
+    const healed = await ensureAgentRunnable(agent, version, log, opts);
     if (healed) {
       failedRepairAt.delete(key);
       repaired.push(`${agent}@${version}${healed === version ? '' : `→${healed}`}`);
     } else {
       failedRepairAt.set(key, Date.now());
+      unhealed.push(key);
     }
   }
-  return repaired;
+  return { repaired, unhealed };
 }
 
 async function getCliVersionFromPath(agent: AgentId): Promise<string | null> {

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -2415,9 +2415,12 @@ export async function ensureAgentRunnable(
  * `agents run` hits a raw ENOENT — the run-time heal (ensureAgentRunnable) only
  * fires once a run is already starting; this catches it in the background.
  *
- * Returns a label (`agent@broken→healed`) for each version actually repaired, so
- * the daemon can log/notify. A version that already launches costs one cheap
- * `--version` probe and is left untouched.
+ * Returns `{ repaired, unhealed }`: `repaired` is a label (`agent@broken→healed`)
+ * for each version actually fixed; `unhealed` is `agent@version` for each broken
+ * default that could not be fixed (including, under `allowDefaultSwitch:false`,
+ * one that was deliberately not repointed), so the daemon can log/notify. A
+ * version that already launches costs one cheap `--version` probe and is left
+ * untouched.
  */
 const failedRepairAt = new Map<string, number>();
 const REPAIR_COOLDOWN_MS = 24 * 60 * 60_000;


### PR DESCRIPTION
## Why

Part of the routine auth-failure remediation (audit finding #5, the safe root-cause half). The audit found that Claude routines silently fail because the credential gets logged out at times uncorrelated with anything the user did. The trigger:

The daemon's unattended **6-hourly launch-health pass** (`healBrokenDefaultLaunches` → `ensureAgentRunnable`), when the default version's binary is broken, would **adopt another installed version or install `latest` and `setGlobalDefault` it** — all in the background. For Claude, repointing the default installs a **fresh version home = a fresh, empty credential scope** (macOS keychain is keyed off `CLAUDE_CONFIG_DIR`; Linux uses a per-version token file). That is the "unprovoked logout."

## What changes

- `ensureAgentRunnable` gains `allowDefaultSwitch` (**default `true`** — interactive `agents run` / `agents add` are unchanged).
- The daemon's unattended pass passes **`false`**: it still repairs the current default **in place** (no scope change), but never repoints — it fails closed and logs a `WARN` naming the version to pick.
- `healBrokenDefaultLaunches` returns `{ repaired, unhealed }` so the daemon can surface what it refused to heal.

## Scope note

This is the **safe, root-cause half** of audit fix #5 — it removes the *trigger* of the logout without touching where the credential is stored. The deeper credential-store change (one keychain scope **per account** instead of per version) is **deferred**: it changes where the external Claude Code binary finds its credential and needs **macOS validation** before it's safe to ship (this work was done on a Linux box). Detection/visibility (audit #2–4) ships in #1468.

## Testing

Extends the `ensureAgentRunnable` isolation integration harness (real subprocess, planted temp HOME, no mocks):
- A broken default with a healthy alternative is **NOT** repointed under `allowDefaultSwitch:false` — the default pointer stays put and it returns `null`.
- A control case proves interactive mode (default) still adopts the healthy version — so the flag is demonstrably what changes behavior.

Full local run: `versions.isolation.integration.test.ts` 5/5 pass, `daemon.test.ts` 41/41 pass, `tsc --noEmit` clean.

Audit source: `zion:/private/tmp/agents-cli-audit.html`.