### PR TITLE
fix(factory): stop showing reachable devices as offline in the picker

### DIFF
--- a/apps/factory/src/core/deviceHealth.test.ts
+++ b/apps/factory/src/core/deviceHealth.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { parseUptime, parseVmStat, parseLinuxMemInfo } from './deviceHealth';
+import { parseUptime, parseVmStat, parseLinuxMemInfo, isDeviceOnline } from './deviceHealth';
 import { probeReachable } from '../vscode/deviceHealth.vscode';
 
 const UPTIME_MACOS = ` 2:49  up 1 day, 15:25, 24 users, load averages: 7.33 6.84 6.96
@@ -102,5 +102,23 @@ describe('parseLinuxMemInfo', () => {
 describe('probeReachable', () => {
   test('treats this-mac as reachable', async () => {
     expect(await probeReachable('this-mac')).toBe(true);
+  });
+});
+
+describe('isDeviceOnline', () => {
+  // Regression: a reachable box (manually registered, or on the sync ignore-list)
+  // has no tailscale block. The old `?? false` forced it offline in the picker while
+  // the CLI showed it online. It must be treated as online, matching the CLI.
+  test('missing tailscale block is online (matches CLI), not offline', () => {
+    expect(isDeviceOnline(undefined)).toBe(true);
+  });
+  test('tailscale online:true is online', () => {
+    expect(isDeviceOnline({ online: true })).toBe(true);
+  });
+  test('tailscale online:false is the only offline case', () => {
+    expect(isDeviceOnline({ online: false })).toBe(false);
+  });
+  test('present block with undefined online is offline (matches CLI truthiness)', () => {
+    expect(isDeviceOnline({})).toBe(false);
   });
 });

--- a/apps/factory/src/core/deviceHealth.ts
+++ b/apps/factory/src/core/deviceHealth.ts
@@ -43,3 +43,20 @@ export function parseLinuxMemInfo(out: string): { memPercent?: number } {
   const memPercent = Math.max(0, Math.min(100, raw))
   return { memPercent }
 }
+
+/**
+ * Whether a registry device should be treated as online for the "run on…" picker
+ * and host lists.
+ *
+ * Mirrors the CLI exactly (`apps/cli/src/commands/ssh.ts` renderDeviceTable:
+ * `offline = d.tailscale && !d.tailscale.online`): a device is offline ONLY when it
+ * carries a tailscale block reporting online:false. A device with NO tailscale block
+ * — e.g. one registered manually or on the `agents devices sync` ignore-list, which
+ * never gets tailscale metadata stamped — is unknown-not-offline, not offline.
+ *
+ * The previous `d.tailscale?.online ?? false` forced those to offline, diverging from
+ * the CLI and showing genuinely-reachable boxes as offline in the picker.
+ */
+export function isDeviceOnline(tailscale?: { online?: boolean }): boolean {
+  return !tailscale || Boolean(tailscale.online)
+}

--- a/apps/factory/src/vscode/deviceHealth.vscode.ts
+++ b/apps/factory/src/vscode/deviceHealth.vscode.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { createHash } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { DeviceStats, parseUptime, parseVmStat, parseLinuxMemInfo } from '../core/deviceHealth';
+import { DeviceStats, parseUptime, parseVmStat, parseLinuxMemInfo, isDeviceOnline } from '../core/deviceHealth';
 import { RepoSyncStatus, classifySync } from '../core/repoSync';
 import { resolveAgentsBin, bootstrapPath } from '../core/agentsBin';
 
@@ -33,8 +33,9 @@ interface AgentsDeviceEntry {
 
 // Source the device fleet from the canonical agents-cli registry
 // (`agents devices`, self-populated from Tailscale) rather than a hand-rolled
-// file. Online status comes from tailscale.online, the credential bundle from
-// auth.bundle, and the SSH address from address.dnsName.
+// file. Online status is derived by isDeviceOnline (matching the CLI: a missing
+// tailscale block is NOT offline), the credential bundle from auth.bundle, and the
+// SSH address from address.dnsName.
 export async function listRegisteredDevices(): Promise<Device[]> {
   try {
     const bin = await resolveAgentsBin();
@@ -50,7 +51,7 @@ export async function listRegisteredDevices(): Promise<Device[]> {
       user: d.user,
       secretRef: d.auth?.bundle,
       platform: d.platform,
-      online: d.tailscale?.online ?? false,
+      online: isDeviceOnline(d.tailscale),
       registeredAt: d.createdAt ? Date.parse(d.createdAt) || 0 : 0,
     }));
   } catch {


### PR DESCRIPTION
## Problem

In the "New CC — run on…" device picker, genuinely reachable machines showed **offline** even though `agents devices` (CLI) showed them **online** for the same registry data.

Root cause is a divergent default between the two renderers for a device that has **no `tailscale` block** in the registry:

- **CLI** — `apps/cli/src/commands/ssh.ts:170`: `const offline = d.tailscale && !d.tailscale.online` → a missing block is **not** offline.
- **Extension** — `apps/factory/src/vscode/deviceHealth.vscode.ts:53`: `online: d.tailscale?.online ?? false` → a missing block is forced to **offline**.

A device gets no `tailscale` block when it's registered manually or sits on the `agents devices sync` **ignore-list** — sync skips it and never stamps tailscale metadata. So an ignored-but-reachable worker showed offline in the picker **permanently**, and re-running `sync` could not fix it.

Observed live: `yosemite-s1` is on the ignore-list, its registry entry is manual-only with no `tailscale` field, ssh + ping succeed (up 39 days), Tailscale reports `Online:true` — yet the picker drew it offline.

## Fix

Extract the CLI's exact rule into a pure, tested `isDeviceOnline(tailscale?)` helper in `core/deviceHealth.ts` and use it in the registry mapper. A missing tailscale block is treated as **online** (unknown-not-offline); only a present block reporting `online:false` is offline.

```
isDeviceOnline(undefined)        => true    // manual / ignored device, matches CLI
isDeviceOnline({ online: true }) => true
isDeviceOnline({ online: false })=> false   // the only offline case
isDeviceOnline({})               => false   // present block, undefined online — matches CLI truthiness
```

## Verification

- `bun test src/core/deviceHealth.test.ts` — 10 pass, 0 fail (4 new cases for `isDeviceOnline`).
- `tsc -p ./` — 0 errors.
- Applied the new rule to the **live** `agents devices list --json` (what the extension reads):

```
device            before  after
yosemite-m0        online  online
yosemite-m4        online  online
yosemite-s0        online  online
yosemite-s1        offline online  <-- FIXED
```

## Scope / follow-up

This aligns the extension's default with the CLI and kills the persistent false-offline. A separate, deeper resilience item (out of scope here): relay-only peers (e.g. `yosemite-m4`, `direct:false`) can still momentarily flap to `online:false` because the registry branch trusts Tailscale's `Online` flag with no live-probe fallback — a "live-probe-wins" pass on the registry host-list branch would remove that class too.

Session transcript (private repo): zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/693d8003-5eba-4fe3-b214-b00a26b628d2.jsonl