### PR TITLE
docs(plans): archive curated 2026-07-30 agents-cli plan docs

### DIFF
--- a/docs/plans/2026-07-30/agents-cli-architecture-v1.html
+++ b/docs/plans/2026-07-30/agents-cli-architecture-v1.html
@@ -1,0 +1,543 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents-cli — system design (v1)</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e8ebe6; --ink-dim:#9aa295;
+    --line:#242724; --lime:#a3e635; --lime-dim:#6f9e26; --amber:#f4bf4f; --red:#ff6b5e;
+    --cyan:#5ec7d6; --violet:#b08cff; --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;
+    --code-bg:#0d0f0d; --chip:#1a1d19; --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 30px rgba(0,0,0,.5);
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f4; --panel:#ffffff; --panel-2:#fbfcfa; --ink:#16180f; --ink-dim:#5c6356;
+    --line:#e2e6dc; --lime:#5c8a13; --lime-dim:#7fae2c; --amber:#9a6a00; --red:#c23b2e;
+    --cyan:#0f7d8c; --violet:#6d45c9; --code-bg:#f1f3ec; --chip:#eef1e8; --shadow:0 1px 0 rgba(0,0,0,.02),0 10px 30px rgba(0,0,0,.08);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;font-size:16px;-webkit-font-smoothing:antialiased}
+  a{color:var(--lime);text-decoration:none}a:hover{text-decoration:underline}
+  code,kbd,.mono{font-family:var(--mono)}
+  .wrap{max-width:1120px;margin:0 auto;padding:0 24px}
+  .topbar{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 88%,transparent);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .brand{font-family:var(--mono);font-weight:700;letter-spacing:.02em;font-size:15px}
+  .brand .dot{color:var(--lime)}
+  .vtag{font-family:var(--mono);font-size:11px;color:var(--amber);border:1px solid var(--amber);border-radius:5px;padding:1px 7px;margin-left:8px}
+  .toggle{font-family:var(--mono);font-size:13px;color:var(--ink-dim);background:var(--chip);border:1px solid var(--line);border-radius:8px;padding:6px 12px;cursor:pointer}
+  .toggle:hover{color:var(--ink);border-color:var(--lime-dim)}
+  .hero{padding:60px 0 38px;border-bottom:1px solid var(--line)}
+  .kicker{font-family:var(--mono);font-size:12.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--lime);margin-bottom:18px}
+  h1{font-size:clamp(30px,4.4vw,48px);line-height:1.07;margin:0 0 18px;letter-spacing:-.02em;font-weight:800}
+  h1 .g{color:var(--lime)}
+  .lede{font-size:18.5px;color:var(--ink-dim);max-width:820px;margin:0 0 24px}
+  .lede b{color:var(--ink);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:9px}
+  .chip{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--chip);border:1px solid var(--line);border-radius:999px;padding:5px 12px}
+  .chip b{color:var(--lime);font-weight:600}
+  .toc{margin:30px 0 0;padding:18px 20px;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow)}
+  .toc h4{margin:0 0 12px;font-family:var(--mono);font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-dim)}
+  .toc ol{margin:0;padding:0;list-style:none;display:grid;grid-template-columns:1fr 1fr;gap:6px 26px;counter-reset:toc}
+  .toc li{counter-increment:toc;font-size:14.5px;display:flex;gap:10px;align-items:baseline}
+  .toc li::before{content:counter(toc,decimal-leading-zero);font-family:var(--mono);font-size:12px;color:var(--lime-dim);min-width:22px}
+  @media(max-width:720px){.toc ol{grid-template-columns:1fr}}
+  section{padding:50px 0;border-bottom:1px solid var(--line)}
+  .sec-num{font-family:var(--mono);font-size:13px;color:var(--lime);letter-spacing:.1em}
+  h2{font-size:clamp(21px,2.9vw,29px);margin:8px 0 6px;letter-spacing:-.015em;font-weight:750}
+  h3{font-size:17.5px;margin:28px 0 8px;font-weight:650}
+  .sub{color:var(--ink-dim);font-size:15.5px;max-width:850px}
+  p{max-width:850px}
+  ul.tight{max-width:850px;padding-left:18px}ul.tight li{margin:6px 0}
+  .fl{font-family:var(--mono);font-size:12.5px;color:var(--cyan);background:var(--code-bg);border:1px solid var(--line);border-radius:5px;padding:1px 6px;white-space:nowrap}
+  b.k{color:var(--lime)}
+  .badge{font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.06em;padding:2px 7px;border-radius:5px;vertical-align:middle;margin-left:8px;border:1px solid;white-space:nowrap}
+  .badge.cli{color:var(--lime);border-color:var(--lime-dim)}
+  .badge.ext{color:var(--violet);border-color:var(--violet)}
+  .badge.hook{color:var(--amber);border-color:var(--amber)}
+  h2 .badge{font-size:11px}
+  .call{margin:22px 0;padding:16px 18px 16px 20px;border-radius:12px;border:1px solid var(--line);background:var(--panel);position:relative;box-shadow:var(--shadow)}
+  .call::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;border-radius:12px 0 0 12px}
+  .call.correct::before{background:var(--lime)}.call.warn::before{background:var(--amber)}.call.hot::before{background:var(--red)}
+  .call .tag{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;font-weight:700;margin-bottom:6px;display:block}
+  .call.correct .tag{color:var(--lime)}.call.warn .tag{color:var(--amber)}.call.hot .tag{color:var(--red)}
+  .call p{margin:2px 0;max-width:none}
+  pre{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;padding:14px 16px;overflow:auto;font-family:var(--mono);font-size:12.7px;line-height:1.6;box-shadow:var(--shadow)}
+  pre .c{color:var(--ink-dim)}pre .g{color:var(--lime)}pre .a{color:var(--amber)}pre .cy{color:var(--cyan)}pre .kw{color:var(--violet)}pre .r{color:var(--red)}
+  table{width:100%;border-collapse:collapse;margin:18px 0;font-size:13.6px}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-dim);font-weight:600}
+  td code{font-size:12px;color:var(--cyan)}
+  figure{margin:24px 0}
+  figure svg{width:100%;height:auto;display:block;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow)}
+  figcaption{font-size:12.5px;color:var(--ink-dim);margin-top:10px;font-family:var(--mono)}
+  /* system-design svg vocabulary */
+  .s-l{font-family:var(--mono);font-size:12px;fill:var(--ink)}
+  .s-s{font-family:var(--mono);font-size:10.3px;fill:var(--ink-dim)}
+  .s-t{font-family:var(--mono);font-size:10.5px;fill:var(--ink-dim)}
+  .stereo{font-family:var(--mono);font-size:9px;fill:var(--ink-dim);letter-spacing:.04em}
+  .actor{fill:var(--panel-2);stroke:var(--ink);stroke-width:1.4}
+  .sysbound{fill:none;stroke:var(--lime-dim);stroke-width:1.4;stroke-dasharray:6 4}
+  .comp{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.3}
+  .ext{fill:var(--panel);stroke:var(--ink-dim);stroke-width:1.2;stroke-dasharray:2 2}
+  .node{fill:none;stroke:var(--cyan);stroke-width:1.4}
+  .proc{fill:var(--panel-2);stroke:var(--ink-dim);stroke-width:1.2}
+  .ds-t{fill:var(--panel-2);stroke:var(--cyan);stroke-width:1.4}
+  .ds-b{fill:var(--panel-2);stroke:var(--cyan);stroke-width:1.4}
+  .life{stroke:var(--line);stroke-width:1.2;stroke-dasharray:3 3}
+  .act{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1}
+  .frag{fill:none;stroke:var(--amber);stroke-width:1;stroke-dasharray:4 3}
+  .msg{stroke:var(--ink);stroke-width:1.3;fill:none}
+  .msg-a{stroke:var(--ink-dim);stroke-width:1.2;fill:none;stroke-dasharray:5 3}
+  .flow{stroke:var(--ink-dim);stroke-width:1.4;fill:none}
+  .flow-hot{stroke:var(--red);stroke-width:1.7;fill:none}
+  .flow-lime{stroke:var(--lime);stroke-width:1.6;fill:none}
+  .foot{padding:38px 0 70px;color:var(--ink-dim);font-size:13px;font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div class="topbar"><div class="wrap">
+  <div class="brand">agents<span class="dot">·</span>cli <span style="color:var(--ink-dim)">/ system design</span><span class="vtag">v1</span></div>
+  <button class="toggle" id="tg">◐ theme</button>
+</div></div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="kicker">Design doc · the whole system, not just sessions</div>
+  <h1>What <span class="g">agents-cli</span> is, what it must do, and how it's built</h1>
+  <p class="lede">A technical overview for someone reviewing the design cold: <b>what the system is</b> and the
+    problem it solves, its <b>core features</b>, the <b>requirements</b> it has to meet, the <b>execution scenarios</b>
+    it supports (interactive · headless · teams · across machines · cloud), and then the internals — the
+    <b>distributed execution engine</b> and the <b>session subsystem</b> — with the slow spots and the fix. Diagrams use
+    standard notation (C4 context/component, deployment, UML sequence). Every claim points at a file and line.</p>
+  <div class="chips">
+    <span class="chip">repo <b>agents-cli</b> @ dfe9f011</span>
+    <span class="chip">two programs: <b>CLI</b> + <b>Factory extension</b></span>
+    <span class="chip">supersedes <b>v0</b> (session-focused)</span>
+    <span class="chip">read from source</span>
+  </div>
+  <nav class="toc">
+    <h4>Contents</h4>
+    <ol>
+      <li><a href="#s1">What agents-cli is (system context)</a></li>
+      <li><a href="#s2">Core features</a></li>
+      <li><a href="#s3">Requirements &amp; design goals</a></li>
+      <li><a href="#s4">Execution scenarios</a></li>
+      <li><a href="#s5">Two programs + the CLI's components</a></li>
+      <li><a href="#s6">Distributed execution (topology + sequence)</a></li>
+      <li><a href="#s7">Session identity (three writers)</a></li>
+      <li><a href="#s8">Storage model</a></li>
+      <li><a href="#s9">Reading &amp; indexing: three walkthroughs</a></li>
+      <li><a href="#s10">Live status &amp; the event logs</a></li>
+      <li><a href="#s11">Slow spots &amp; the fix</a></li>
+      <li><a href="#s12">Scope of this doc</a></li>
+    </ol>
+  </nav>
+</header>
+
+<!-- 1 · WHAT IT IS -->
+<section id="s1">
+  <div class="sec-num">01</div>
+  <h2>What agents-cli is</h2>
+  <p class="sub">One command-line program to <b>install, configure, run, and orchestrate many AI coding agents</b>
+  (Claude, Codex, Gemini, Cursor, OpenCode, Grok, Droid, …) — on one machine or across a fleet — plus a separate
+  VS Code extension (Factory) that drives the same engine through a GUI.</p>
+
+<figure>
+<svg viewBox="0 0 1080 470" role="img" aria-label="system context diagram">
+  <defs><marker id="a1" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--ink-dim)"/></marker></defs>
+  <text x="24" y="26" class="stereo">C4 — SYSTEM CONTEXT</text>
+
+  <!-- actor -->
+  <circle cx="90" cy="150" r="16" class="actor"/><line x1="90" y1="166" x2="90" y2="200" class="actor"/><line x1="70" y1="180" x2="110" y2="180" class="actor"/><line x1="90" y1="200" x2="74" y2="222" class="actor"/><line x1="90" y1="200" x2="106" y2="222" class="actor"/>
+  <text x="90" y="244" text-anchor="middle" class="s-l">Developer</text>
+  <text x="90" y="260" text-anchor="middle" class="s-s">terminal · IDE</text>
+
+  <!-- system boundary -->
+  <rect x="360" y="60" width="360" height="350" rx="16" class="sysbound"/>
+  <text x="540" y="86" text-anchor="middle" class="stereo">«system»</text>
+  <text x="540" y="104" text-anchor="middle" class="s-l" style="font-size:14px">agents-cli</text>
+  <rect x="392" y="124" width="296" height="52" rx="8" class="comp"/><text x="540" y="146" text-anchor="middle" class="s-l">agents CLI</text><text x="540" y="162" text-anchor="middle" class="s-s">the engine — run, sessions, teams…</text>
+  <rect x="392" y="188" width="296" height="46" rx="8" class="ext"/><text x="540" y="208" text-anchor="middle" class="s-l">Factory VS Code extension</text><text x="540" y="223" text-anchor="middle" class="s-s">separate app · runs the CLI as a subprocess</text>
+  <rect x="392" y="246" width="142" height="44" rx="8" class="comp"/><text x="463" y="266" text-anchor="middle" class="s-s">SessionStart hook</text><text x="463" y="280" text-anchor="middle" class="s-s">installed shell script</text>
+  <rect x="546" y="246" width="142" height="44" rx="8" class="comp"/><text x="617" y="266" text-anchor="middle" class="s-s">local stores</text><text x="617" y="280" text-anchor="middle" class="s-s">sqlite · logs · cache</text>
+  <text x="540" y="326" text-anchor="middle" class="s-s">one machine of a fleet →</text>
+  <text x="540" y="342" text-anchor="middle" class="s-s">each peer runs its own agents-cli</text>
+
+  <!-- external systems -->
+  <rect x="792" y="70" width="264" height="52" rx="8" class="ext"/><text x="924" y="90" text-anchor="middle" class="stereo">«external»</text><text x="924" y="106" text-anchor="middle" class="s-l">Agent harnesses (Claude/Codex/…)</text>
+  <rect x="792" y="134" width="264" height="52" rx="8" class="ext"/><text x="924" y="154" text-anchor="middle" class="stereo">«external»</text><text x="924" y="170" text-anchor="middle" class="s-l">Other machines (the fleet)</text>
+  <rect x="792" y="198" width="264" height="52" rx="8" class="ext"/><text x="924" y="218" text-anchor="middle" class="stereo">«external»</text><text x="924" y="234" text-anchor="middle" class="s-l">Cloud (Rush / Codex / Factory)</text>
+  <rect x="792" y="262" width="264" height="52" rx="8" class="ext"/><text x="924" y="282" text-anchor="middle" class="stereo">«external»</text><text x="924" y="298" text-anchor="middle" class="s-l">GitHub · Linear</text>
+  <rect x="792" y="326" width="264" height="52" rx="8" class="ext"/><text x="924" y="346" text-anchor="middle" class="stereo">«external»</text><text x="924" y="362" text-anchor="middle" class="s-l">OS Keychain (secrets)</text>
+
+  <!-- edges -->
+  <path class="flow" marker-end="url(#a1)" d="M118,180 C240,180 250,150 358,150"/><text x="238" y="142" text-anchor="middle" class="s-t">runs commands</text>
+  <path class="flow" marker-end="url(#a1)" d="M688,150 C740,150 745,96 790,96"/><text x="742" y="128" class="s-t">spawn (subprocess)</text>
+  <path class="flow" marker-end="url(#a1)" d="M688,170 C742,170 748,160 790,160"/><text x="748" y="184" class="s-t">SSH / Tailscale</text>
+  <path class="flow" marker-end="url(#a1)" d="M688,220 C742,222 748,224 790,224"/><text x="742" y="216" class="s-t">dispatch (API)</text>
+  <path class="flow" marker-end="url(#a1)" d="M688,262 C742,275 748,286 790,288"/><text x="742" y="258" class="s-t">PRs · tickets</text>
+  <path class="flow" marker-end="url(#a1)" d="M688,300 C742,330 748,348 790,350"/><text x="742" y="322" class="s-t">get/set (keychain)</text>
+</svg>
+<figcaption>Fig 1 — system context. The developer (or the Factory extension) drives the agents CLI; the CLI drives agent harnesses as subprocesses, reaches other machines over SSH/Tailscale, dispatches to cloud providers, and reads secrets from the OS keychain.</figcaption>
+</figure>
+</section>
+
+<!-- 2 · CORE FEATURES -->
+<section id="s2">
+  <div class="sec-num">02</div>
+  <h2>Core features</h2>
+  <p class="sub">The command surface groups into eight capabilities. All are one CLI over many agent harnesses.</p>
+  <table>
+    <tr><th>Capability</th><th>What it does</th><th>Commands</th></tr>
+    <tr><td><b class="k">Install &amp; versions</b></td><td>install agent CLIs, pin/switch versions, isolated per-version homes, sync config across the fleet</td><td><code>setup</code> · <code>versions</code> · <code>use</code> · <code>upgrade</code> · <code>pull</code>/<code>push</code>/<code>sync</code> · <code>plugins</code> · <code>mcp</code></td></tr>
+    <tr><td><b class="k">Run one agent</b></td><td>launch any harness — interactive or headless — with mode/effort/model, rate-limit fallback, tmux wrap</td><td><code>run</code> · <code>exec</code> · <code>go</code> · <code>profiles</code> · <code>models</code></td></tr>
+    <tr><td><b class="k">Sessions</b></td><td>index + full-text search transcripts, inspect one, live <code>--active</code> status, cross-machine, fork/resume</td><td><code>sessions</code> (+ <code>-tail</code>/<code>-resume</code>/<code>-export</code>/…) · <code>fork</code> · <code>focus</code></td></tr>
+    <tr><td><b class="k">Teams</b></td><td>orchestrate many agents on a dependency DAG, in waves — local, remote, or cloud teammates</td><td><code>teams</code></td></tr>
+    <tr><td><b class="k">Distributed / fleet</b></td><td>run on other machines over SSH/Tailscale; register devices; leases &amp; locks for coordination</td><td><code>ssh</code> · <code>hosts</code> · <code>fleet-capture</code> · <code>lease</code> · <code>lock</code> · <code>serve</code></td></tr>
+    <tr><td><b class="k">Cloud dispatch</b></td><td>hand a task to a cloud provider that clones, works, and opens a PR</td><td><code>cloud</code> · <code>factory</code></td></tr>
+    <tr><td><b class="k">Secrets</b></td><td>OS-keychain-backed bundles, never on disk, injectable into runs across the fleet</td><td><code>secrets</code> (+ <code>-import</code>/<code>-migrate</code>/<code>-sync</code>)</td></tr>
+    <tr><td><b class="k">Automation &amp; observability</b></td><td>drive a browser / native app; event + activity logs; monitors; cost/usage; nudge stuck agents</td><td><code>browser</code> · <code>computer</code> · <code>pty</code> · <code>events</code>/<code>feed</code>/<code>activity</code> · <code>monitors</code> · <code>watchdog</code> · <code>output</code>/<code>cost</code></td></tr>
+  </table>
+</section>
+
+<!-- 3 · REQUIREMENTS -->
+<section id="s3">
+  <div class="sec-num">03</div>
+  <h2>Requirements &amp; design goals</h2>
+  <p class="sub">What the framework has to satisfy — and where it does (all met, except showing live status cheaply — the last row).</p>
+  <table>
+    <tr><th>Requirement</th><th>How it's met</th><th>Status</th></tr>
+    <tr><td><b class="k">Unified interface</b> — one CLI to launch any agent (Claude, Codex, Gemini, …)</td><td>a single table maps each agent to how it's launched, so the command is the same whichever agent you pick (<span class="fl">exec.ts:463</span> <code>AGENT_COMMANDS</code>)</td><td>met</td></tr>
+    <tr><td><b class="k">Same run path everywhere</b> — interactive, headless, teams, remote</td><td>everything funnels through the <code>agents run</code> argv; teams &amp; remote build the same command line (<span class="fl">teams/agents.ts:2219</span>)</td><td>met</td></tr>
+    <tr><td><b class="k">Distributed by default</b> — a fleet, not one box</td><td>one reused SSH connection; detached remote launch with log+exit mirroring (<span class="fl">hosts/dispatch.ts:202</span>, <span class="fl">ssh-exec.ts:76</span>)</td><td>met</td></tr>
+    <tr><td><b class="k">Cross-platform</b> — macOS, Linux, Windows</td><td>POSIX exec vs Windows <code>.cmd</code> shim path split (<span class="fl">exec.ts:947</span>); native computer helpers per-OS</td><td>met</td></tr>
+    <tr><td><b class="k">Isolated config per version</b></td><td>per-agent config dirs pinned in the run env (<span class="fl">exec.ts:325</span>); <code>import --isolated</code> sandboxes a setup</td><td>met</td></tr>
+    <tr><td><b class="k">Secure secrets</b> — never on disk</td><td>OS-keychain-backed bundles, metadata only in config (<span class="fl">share/config.ts:78</span>, <code>secrets</code>)</td><td>met</td></tr>
+    <tr><td><b class="k">Observable</b> — what ran, what's running</td><td>indexed session history (SQLite+FTS5) + append-only event/activity logs</td><td>met</td></tr>
+    <tr><td><b class="k">Checking "what's running" must be cheap</b></td><td>today it isn't: every time you ask, the CLI re-reads and re-parses the session files from scratch, instead of computing the answer once and reusing it (§11)</td><td style="color:var(--red)">unmet — §11</td></tr>
+  </table>
+</section>
+
+<!-- 4 · SCENARIOS -->
+<section id="s4">
+  <div class="sec-num">04</div>
+  <h2>Execution scenarios</h2>
+  <p class="sub">Five ways an agent gets launched. They all reduce to the same <code>agents run</code> core, wrapped differently.</p>
+<figure>
+<svg viewBox="0 0 1080 300" role="img" aria-label="scenario routing">
+  <defs><marker id="a4" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--ink-dim)"/></marker></defs>
+  <text x="24" y="24" class="stereo">HOW EACH SCENARIO REACHES THE SHARED CORE</text>
+  <!-- scenarios left -->
+  <rect x="20" y="44" width="230" height="40" rx="8" class="proc"/><text x="34" y="69" class="s-s">① interactive — the shim / <tspan class="s-l">agents run</tspan></text>
+  <rect x="20" y="92" width="230" height="40" rx="8" class="proc"/><text x="34" y="117" class="s-s">② headless — <tspan class="s-l">run --headless</tspan></text>
+  <rect x="20" y="140" width="230" height="40" rx="8" class="proc"/><text x="34" y="165" class="s-s">③ teams — <tspan class="s-l">teams start</tspan> (DAG)</text>
+  <rect x="20" y="188" width="230" height="40" rx="8" class="proc"/><text x="34" y="213" class="s-s">④ remote — <tspan class="s-l">--host</tspan> / a peer teammate</text>
+  <rect x="20" y="236" width="230" height="40" rx="8" class="proc"/><text x="34" y="261" class="s-s">⑤ cloud — <tspan class="s-l">cloud run</tspan></text>
+  <!-- middle: build argv -->
+  <rect x="410" y="120" width="220" height="72" rx="10" class="comp"/><text x="520" y="150" text-anchor="middle" class="s-l">buildRunArgv()</text><text x="520" y="167" text-anchor="middle" class="s-s">agents run &lt;agent&gt; …</text><text x="520" y="182" text-anchor="middle" class="s-s">teams/agents.ts:2219</text>
+  <!-- right: exec -->
+  <rect x="790" y="120" width="230" height="72" rx="10" class="comp"/><text x="905" y="150" text-anchor="middle" class="s-l">spawnAgent()</text><text x="905" y="167" text-anchor="middle" class="s-s">buildExecCommand + spawn</text><text x="905" y="182" text-anchor="middle" class="s-s">exec.ts:1268</text>
+  <!-- edges ①② go straight to spawn; ③④ via argv; ⑤ diverges -->
+  <path class="flow" marker-end="url(#a4)" d="M250,64 C620,64 700,140 788,150"/>
+  <path class="flow" marker-end="url(#a4)" d="M250,112 C500,112 640,150 788,156"/>
+  <path class="flow" marker-end="url(#a4)" d="M250,160 L408,158"/>
+  <path class="flow" marker-end="url(#a4)" d="M250,208 C330,208 340,175 408,172"/>
+  <path class="flow" marker-end="url(#a4)" d="M630,158 L788,158"/>
+  <path class="flow-lime" marker-end="url(#a4)" d="M250,256 C560,256 900,256 905,196"/>
+  <text x="470" y="250" class="s-t" fill="var(--lime)">⑤ cloud diverges — provider API, not local spawn</text>
+  <text x="300" y="150" class="s-t">③④ build the same argv</text>
+</svg>
+<figcaption>Fig 2 — scenario routing. ①–④ all end at the same local spawn via the shared <code>agents run</code> argv (teams/remote wrap it detached); only ⑤ cloud leaves the machine to a provider API.</figcaption>
+</figure>
+  <table>
+    <tr><th>Scenario</th><th>Wrapper</th><th>Where it runs</th><th>How it's tracked</th></tr>
+    <tr><td>① interactive</td><td>foreground TTY (opt. tmux)</td><td>this machine</td><td>pid-registry + hook (§7)</td></tr>
+    <tr><td>② headless</td><td>detached, one-shot</td><td>this machine</td><td>pid-registry + session file</td></tr>
+    <tr><td>③ teams</td><td>sentinel-wrapped <code>/bin/sh</code>, in DAG waves</td><td>this machine</td><td><code>&lt;uuid&gt;/meta.json</code> + <code>.exit</code></td></tr>
+    <tr><td>④ remote</td><td>SSH → detached <code>nohup</code></td><td>a peer</td><td>remote <code>.log</code>/<code>.exit</code>, byte-tailed</td></tr>
+    <tr><td>⑤ cloud</td><td>provider API</td><td>the provider</td><td>provider task id → PR</td></tr>
+  </table>
+</section>
+
+<!-- 5 · TWO PROGRAMS + COMPONENTS -->
+<section id="s5">
+  <div class="sec-num">05</div>
+  <h2>Two programs, and the CLI's components <span class="badge cli">CLI</span> <span class="badge ext">EXT</span></h2>
+  <p class="sub">agents-cli is <b>two separate programs</b>: the <code>agents</code> CLI (<code>apps/cli</code>) and the Factory
+  VS Code extension (<code>apps/factory</code>). They share no memory and no code — the extension runs the CLI as a
+  <b>subprocess</b> and parses its JSON. The <b>hook</b> is a shell script the CLI installs into each agent's config.
+  This doc is about the CLI.</p>
+<figure>
+<svg viewBox="0 0 1080 430" role="img" aria-label="component diagram">
+  <defs><marker id="a5" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--ink-dim)"/></marker></defs>
+  <text x="24" y="24" class="stereo">C4 — COMPONENTS (apps/cli)</text>
+
+  <!-- extension container (left) -->
+  <rect x="20" y="70" width="180" height="120" rx="12" class="ext"/><text x="110" y="92" text-anchor="middle" class="stereo">«separate app»</text><text x="110" y="110" text-anchor="middle" class="s-l">Factory extension</text><text x="110" y="132" text-anchor="middle" class="s-s">watcher · webview</text><text x="110" y="150" text-anchor="middle" class="s-s">runs the CLI as</text><text x="110" y="165" text-anchor="middle" class="s-s">a subprocess</text>
+
+  <!-- CLI boundary -->
+  <rect x="250" y="52" width="600" height="330" rx="14" class="sysbound"/><text x="550" y="74" text-anchor="middle" class="stereo">«process» agents CLI</text>
+  <rect x="272" y="90" width="556" height="34" rx="7" class="comp"/><text x="550" y="112" text-anchor="middle" class="s-l">command router (index.ts)</text>
+
+  <rect x="272" y="140" width="172" height="66" rx="8" class="comp"/><text x="358" y="164" text-anchor="middle" class="s-l">exec engine</text><text x="358" y="180" text-anchor="middle" class="s-s">run · shim · env</text><text x="358" y="195" text-anchor="middle" class="s-s">exec.ts</text>
+  <rect x="454" y="140" width="172" height="66" rx="8" class="comp"/><text x="540" y="164" text-anchor="middle" class="s-l">teams orchestrator</text><text x="540" y="180" text-anchor="middle" class="s-s">DAG · scheduler</text><text x="540" y="195" text-anchor="middle" class="s-s">teams/agents.ts</text>
+  <rect x="636" y="140" width="192" height="66" rx="8" class="comp"/><text x="732" y="164" text-anchor="middle" class="s-l">SSH layer</text><text x="732" y="180" text-anchor="middle" class="s-s">mux · dispatch</text><text x="732" y="195" text-anchor="middle" class="s-s">ssh-exec · dispatch</text>
+
+  <rect x="272" y="220" width="172" height="66" rx="8" class="comp"/><text x="358" y="244" text-anchor="middle" class="s-l">sessions engine</text><text x="358" y="260" text-anchor="middle" class="s-s">discover·parse·active</text><text x="358" y="275" text-anchor="middle" class="s-s">lib/session/*</text>
+  <rect x="454" y="220" width="172" height="66" rx="8" class="comp"/><text x="540" y="244" text-anchor="middle" class="s-l">event bus</text><text x="540" y="260" text-anchor="middle" class="s-s">events + activity</text><text x="540" y="275" text-anchor="middle" class="s-s">events.ts</text>
+  <rect x="636" y="220" width="192" height="66" rx="8" class="comp"/><text x="732" y="244" text-anchor="middle" class="s-l">secrets · cloud</text><text x="732" y="260" text-anchor="middle" class="s-s">keychain · providers</text>
+
+  <!-- datastores row -->
+  <g transform="translate(300,312)"><ellipse cx="34" cy="10" rx="34" ry="8" class="ds-t"/><path d="M0,10 v34 a34,8 0 0 0 68,0 v-34" class="ds-b"/><text x="34" y="30" text-anchor="middle" class="s-s">sessions.db</text></g>
+  <rect x="410" y="316" width="130" height="42" rx="6" class="proc"/><text x="475" y="342" text-anchor="middle" class="s-s">events / activity</text>
+  <rect x="556" y="316" width="150" height="42" rx="6" class="proc" stroke-dasharray="4 3"/><text x="631" y="342" text-anchor="middle" class="s-s">pid files (cache)</text>
+
+  <!-- external harnesses (right) -->
+  <rect x="892" y="140" width="168" height="66" rx="8" class="ext"/><text x="976" y="166" text-anchor="middle" class="stereo">«external»</text><text x="976" y="184" text-anchor="middle" class="s-s">agent harness procs</text>
+
+  <!-- edges -->
+  <path class="flow" marker-end="url(#a5)" d="M200,130 C230,130 240,106 270,106"/><text x="205" y="120" class="s-t">exec()</text>
+  <path class="flow" marker-end="url(#a5)" d="M444,173 L452,173"/>
+  <path class="flow" marker-end="url(#a5)" d="M626,173 L634,173"/>
+  <path class="flow" marker-end="url(#a5)" d="M828,173 L890,173"/><text x="838" y="164" class="s-t">spawn</text>
+  <path class="flow" marker-end="url(#a5)" d="M358,286 L350,310"/>
+  <path class="flow" marker-end="url(#a5)" d="M470,286 C475,296 475,300 476,314"/>
+</svg>
+<figcaption>Fig 3 — the CLI's components. The router dispatches to the exec engine (which owns all harness knowledge), the teams orchestrator, the SSH layer, the sessions engine, the event bus, and secrets/cloud. Datastores are the SQLite index, the flat event logs, and the temporary pid files.</figcaption>
+</figure>
+</section>
+
+<!-- 6 · DISTRIBUTED EXECUTION -->
+<section id="s6">
+  <div class="sec-num">06</div>
+  <h2>Distributed execution <span class="badge cli">CLI</span></h2>
+  <p class="sub">The design's real spine: run agents on any machine in the fleet, without holding a live connection.
+  Three shared primitives — <code>buildRunArgv</code> (the command), <code>ssh-exec</code> (transport), <code>launchDetached</code>
+  (fire-and-forget) — carry every remote run and every remote teammate.</p>
+
+  <h3>Topology — how work spreads across the fleet</h3>
+<figure>
+<svg viewBox="0 0 1080 380" role="img" aria-label="deployment topology">
+  <defs><marker id="a6" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--cyan)"/></marker></defs>
+  <text x="24" y="24" class="stereo">DEPLOYMENT — the fleet over one Tailscale network</text>
+  <rect x="20" y="40" width="1040" height="320" rx="14" class="frag" stroke="var(--violet)"/>
+  <text x="40" y="60" class="stereo" fill="var(--violet)">«network» Tailscale · SSH (ControlMaster reused)</text>
+
+  <!-- orchestrator node -->
+  <rect x="50" y="90" width="250" height="230" rx="10" class="node"/><text x="175" y="112" text-anchor="middle" class="stereo">«device» zion (interactive)</text>
+  <rect x="72" y="130" width="206" height="46" rx="7" class="comp"/><text x="175" y="150" text-anchor="middle" class="s-l">orchestrator</text><text x="175" y="165" text-anchor="middle" class="s-s">AgentManager · supervisor</text>
+  <rect x="72" y="188" width="206" height="40" rx="7" class="proc"/><text x="175" y="212" text-anchor="middle" class="s-s">local teammate (foreground)</text>
+  <g transform="translate(120,244)"><ellipse cx="28" cy="8" rx="28" ry="6" class="ds-t"/><path d="M0,8 v22 a28,6 0 0 0 56,0 v-22" class="ds-b"/><text x="28" y="24" text-anchor="middle" class="s-s">local mirror</text></g>
+
+  <!-- worker node A -->
+  <rect x="410" y="90" width="290" height="230" rx="10" class="node"/><text x="555" y="112" text-anchor="middle" class="stereo">«device» yosemite-s0 (worker)</text>
+  <rect x="432" y="132" width="246" height="42" rx="7" class="proc"/><text x="555" y="150" text-anchor="middle" class="s-s">detached: nohup agents run …</text><text x="555" y="165" text-anchor="middle" class="s-s">stdio → files, no live conn</text>
+  <rect x="432" y="186" width="118" height="40" rx="6" class="proc" stroke-dasharray="4 3"/><text x="491" y="210" text-anchor="middle" class="s-s">&lt;id&gt;.log</text>
+  <rect x="560" y="186" width="118" height="40" rx="6" class="proc" stroke-dasharray="4 3"/><text x="619" y="210" text-anchor="middle" class="s-s">&lt;id&gt;.exit</text>
+  <rect x="432" y="238" width="246" height="40" rx="7" class="ext"/><text x="555" y="262" text-anchor="middle" class="s-s">agent harness (its own agents-cli)</text>
+
+  <!-- worker node B -->
+  <rect x="770" y="90" width="270" height="230" rx="10" class="node"/><text x="905" y="112" text-anchor="middle" class="stereo">«device» mac-mini (worker)</text>
+  <rect x="792" y="132" width="226" height="42" rx="7" class="proc"/><text x="905" y="150" text-anchor="middle" class="s-s">detached teammate</text><text x="905" y="165" text-anchor="middle" class="s-s">+ .log / .exit</text>
+  <rect x="792" y="238" width="226" height="40" rx="7" class="ext"/><text x="905" y="262" text-anchor="middle" class="s-s">agent harness</text>
+
+  <!-- ssh edges -->
+  <path class="node" marker-end="url(#a6)" d="M278,150 C360,150 360,150 430,150"/><text x="330" y="142" text-anchor="middle" class="s-t" fill="var(--cyan)">launch (1 SSH)</text>
+  <path class="node" stroke-dasharray="4 3" marker-end="url(#a6)" d="M430,206 C360,206 360,206 300,200"/><text x="360" y="222" text-anchor="middle" class="s-t" fill="var(--cyan)">poll: tail log + read exit</text>
+  <path class="node" marker-end="url(#a6)" d="M278,160 C520,90 700,110 792,150"/>
+</svg>
+<figcaption>Fig 4 — deployment. The orchestrator on zion launches a detached process on each worker with <em>one</em> SSH call, then polls by copying new log bytes + reading the <code>.exit</code> sentinel. No live SSH is held open. Every device runs its own agents-cli.</figcaption>
+</figure>
+
+  <h3>Sequence — a remote teammate, start to done</h3>
+<figure>
+<svg viewBox="0 0 1080 400" role="img" aria-label="uml sequence remote dispatch">
+  <defs><marker id="am" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--ink)"/></marker>
+    <marker id="amd" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--ink-dim)"/></marker></defs>
+  <text x="24" y="22" class="stereo">UML — SEQUENCE (teams remote teammate)</text>
+  <!-- lifelines -->
+  <g class="s-s">
+    <rect x="40" y="40" width="120" height="34" rx="6" class="comp"/><text x="100" y="61" text-anchor="middle" class="s-l">Developer</text><line x1="100" y1="74" x2="100" y2="370" class="life"/>
+    <rect x="230" y="40" width="140" height="34" rx="6" class="comp"/><text x="300" y="61" text-anchor="middle" class="s-l">AgentManager</text><line x1="300" y1="74" x2="300" y2="370" class="life"/>
+    <rect x="470" y="40" width="120" height="34" rx="6" class="comp"/><text x="530" y="61" text-anchor="middle" class="s-l">ssh-exec</text><line x1="530" y1="74" x2="530" y2="370" class="life"/>
+    <rect x="690" y="40" width="150" height="34" rx="6" class="comp"/><text x="765" y="61" text-anchor="middle" class="s-l">remote host</text><line x1="765" y1="74" x2="765" y2="370" class="life"/>
+    <rect x="930" y="40" width="120" height="34" rx="6" class="ext"/><text x="990" y="61" text-anchor="middle" class="s-l">agent proc</text><line x1="990" y1="74" x2="990" y2="370" class="life"/>
+  </g>
+  <!-- messages -->
+  <path class="msg" marker-end="url(#am)" d="M100,96 L298,96"/><text x="120" y="90" class="s-t">teams start</text>
+  <rect x="296" y="96" width="8" height="250" class="act"/>
+  <path class="msg" marker-end="url(#am)" d="M304,120 L528,120"/><text x="330" y="114" class="s-t">launchDetached(argv)</text>
+  <path class="msg" marker-end="url(#am)" d="M530,140 L763,140"/><text x="560" y="134" class="s-t">nohup agents run … &gt; .log; echo $? &gt; .exit</text>
+  <path class="msg" marker-end="url(#am)" d="M765,160 L988,160"/><text x="790" y="154" class="s-t">spawn harness</text>
+  <path class="msg-a" marker-end="url(#amd)" d="M763,180 L306,180"/><text x="430" y="174" class="s-t">pgid pid (returns immediately)</text>
+  <!-- loop fragment -->
+  <rect x="270" y="200" width="540" height="120" rx="6" class="frag"/><text x="286" y="216" class="stereo" fill="var(--amber)">loop [each supervisor wave, until .exit is set]</text>
+  <path class="msg" marker-end="url(#am)" d="M304,240 L528,240"/><text x="330" y="234" class="s-t">tail .log (byte offset) + read .exit</text>
+  <path class="msg-a" marker-end="url(#amd)" d="M528,262 L306,262"/><text x="360" y="256" class="s-t">new bytes → local mirror</text>
+  <path class="msg" marker-end="url(#am)" d="M304,292 L528,292"/><text x="330" y="286" class="s-t">prefetchRemoteStatus: kill -0, one SSH/host</text>
+  <!-- completion -->
+  <path class="msg-a" marker-end="url(#amd)" d="M763,344 L306,344"/><text x="420" y="338" class="s-t" fill="var(--lime)">.exit = 0 → COMPLETED → startReady next wave</text>
+</svg>
+<figcaption>Fig 5 — the remote teammate lifecycle. Launch returns immediately (the process is detached); the supervisor polls each wave by tailing the log and reading the exit sentinel, batching liveness to one SSH per host. A parsed exit code flips the status and releases the next DAG wave.</figcaption>
+</figure>
+
+  <ul class="tight">
+    <li><b class="k">Shared command</b> — teams &amp; <code>--host</code> both build an <code>agents run …</code> argv (<span class="fl">teams/agents.ts:2219</span>); teams never call the internal spawn.</li>
+    <li><b class="k">Shared transport</b> — one SSH primitive with connection reuse (<span class="fl">ssh-exec.ts:76</span>), one detached-launch helper for both <code>run --host</code> and teams (<span class="fl">hosts/dispatch.ts:189</span>, "lives in exactly one place").</li>
+    <li><b class="k">Placement</b> — pin → pool-of-one → fewest-running-teammates → local (<span class="fl">scheduler.ts:76</span>). <span style="color:var(--amber)">Counts teammates, not real CPU/mem</span> — a known gap.</li>
+  </ul>
+</section>
+
+<!-- 7 · SESSION IDENTITY (carried, condensed) -->
+<section id="s7">
+  <div class="sec-num">07</div>
+  <h2>Session identity — three writers <span class="badge cli">CLI</span> <span class="badge hook">HOOK</span></h2>
+  <p class="sub">"Which running process is which session?" A pid → session-id pointer, written to a file (never the DB — a pid is reused, so a saved row goes stale; <span class="fl">reader.ts:113</span>). Three things can write it, at different moments.</p>
+<figure>
+<svg viewBox="0 0 1080 250" role="img" aria-label="identity writers">
+  <defs><marker id="a7" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 z" fill="var(--ink-dim)"/></marker></defs>
+  <text x="24" y="22" class="stereo">WRITERS → FILES → READERS</text>
+  <rect x="20" y="40" width="300" height="44" rx="8" class="comp"/><text x="34" y="60" class="s-l">① ag run — generates UUID (Claude)</text><text x="34" y="76" class="s-s">at launch · exact · exec.ts:1193</text>
+  <rect x="20" y="96" width="300" height="44" rx="8" class="comp"/><text x="34" y="116" class="s-l">② shim — captures passed --session-id</text><text x="34" y="132" class="s-s">at launch · if present · exec.ts:1011</text>
+  <rect x="20" y="164" width="300" height="44" rx="8" class="proc"/><text x="34" y="184" class="s-l">③ SessionStart hook</text><text x="34" y="200" class="s-s">after boot · agent's own payload · hook.sh</text>
+  <rect x="470" y="66" width="220" height="50" rx="8" class="proc" stroke-dasharray="4 3" stroke="var(--lime-dim)"/><text x="580" y="88" text-anchor="middle" class="s-l">by-pid/&lt;pid&gt;.json</text><text x="580" y="104" text-anchor="middle" class="s-s">the CLI's file</text>
+  <rect x="470" y="150" width="220" height="50" rx="8" class="proc" stroke-dasharray="4 3"/><text x="580" y="172" text-anchor="middle" class="s-l">terminals/sessions/&lt;pid&gt;.json</text><text x="580" y="188" text-anchor="middle" class="s-s">the extension's file</text>
+  <rect x="820" y="66" width="200" height="50" rx="8" class="comp"/><text x="920" y="88" text-anchor="middle" class="s-l">CLI · sessions --active</text><text x="920" y="104" text-anchor="middle" class="s-s">active.ts:28</text>
+  <rect x="820" y="150" width="200" height="50" rx="8" class="ext"/><text x="920" y="172" text-anchor="middle" class="s-l">the extension</text><text x="920" y="188" text-anchor="middle" class="s-s">factory/core/liveSession.ts</text>
+  <path class="flow-lime" marker-end="url(#a7)" d="M320,62 C400,62 410,86 468,88"/>
+  <path class="flow-lime" marker-end="url(#a7)" d="M320,118 C400,118 410,98 468,96"/>
+  <path class="flow" marker-end="url(#a7)" d="M320,186 C400,186 410,178 468,176"/>
+  <path class="flow" marker-end="url(#a7)" d="M690,90 L818,90"/>
+  <path class="flow" marker-end="url(#a7)" d="M690,175 L818,175"/>
+</svg>
+<figcaption>Fig 6 — three writers, two files, two programs. ①② (CLI, immediate, exact only for Claude) write the CLI's file; ③ (the agent's own hook, delayed but authoritative, and the only one that sees agents we didn't launch) writes the extension's file.</figcaption>
+</figure>
+  <p><b class="k">Who assigns the id differs per harness:</b> Claude — we do (generate a UUID, pass <code>--session-id</code>, exact at launch). Codex/Cursor/Grok — the agent does; we learn it from its hook (stdin JSON, or env for Grok). Gemini/Antigravity — best-effort. OpenCode/others — no hook; discovered from the file. <b>In teams,</b> a Claude teammate's <code>agent_id</code> <em>is</em> its session id (<span class="fl">agents.ts:1610</span>); others stay split until discovered. <b>Headless</b> uses the same path. The two files hold the same data and could be one (two writers, one file) — joined by <code>terminal_id</code>/<code>launch_id</code>.</p>
+</section>
+
+<!-- 8 · STORAGE -->
+<section id="s8">
+  <div class="sec-num">08</div>
+  <h2>Storage model <span class="badge cli">CLI</span></h2>
+  <p class="sub">Five kinds of store, chosen by how long the data must live, who writes it, and how it's read. Box shape = kind.</p>
+<figure>
+<svg viewBox="0 0 1080 300" role="img" aria-label="storage map">
+  <g transform="translate(24,14)">
+    <ellipse cx="10" cy="8" rx="10" ry="4" class="ds-t"/><path d="M0,8 v10 a10,4 0 0 0 20,0 v-10" class="ds-b"/><text x="26" y="15" class="s-s">SQLite</text>
+    <rect x="110" y="2" width="18" height="15" rx="2" class="proc" stroke="var(--amber)"/><text x="134" y="15" class="s-s">flat log/json</text>
+    <rect x="270" y="2" width="18" height="15" rx="2" class="proc" stroke-dasharray="4 3"/><text x="294" y="15" class="s-s">temp (per-pid)</text>
+    <rect x="430" y="2" width="18" height="15" rx="8" class="proc" stroke="var(--violet)"/><text x="454" y="15" class="s-s">socket</text>
+  </g>
+  <text x="24" y="52" class="stereo" fill="var(--lime)">KEPT — survives reboot</text>
+  <g transform="translate(24,64)"><ellipse cx="110" cy="14" rx="110" ry="13" class="ds-t"/><path d="M0,14 v78 a110,13 0 0 0 220,0 v-78" class="ds-b"/><text x="110" y="10" text-anchor="middle" class="s-l">sessions.db</text><text x="110" y="40" text-anchor="middle" class="s-s">sessions · session_text(fts5)</text><text x="110" y="56" text-anchor="middle" class="s-s">scan_ledger · meta</text><text x="110" y="76" text-anchor="middle" class="s-s">~/.agents/.history/sessions/</text></g>
+  <path d="M270,74 h50 l9,11 h101 v78 h-160 z" class="proc" stroke="var(--lime-dim)"/><text x="350" y="104" text-anchor="middle" class="s-l">transcripts</text><text x="350" y="122" text-anchor="middle" class="s-s">~/.claude, ~/.codex, …</text><text x="350" y="138" text-anchor="middle" class="s-s">read on demand</text>
+  <rect x="500" y="76" width="150" height="46" rx="6" class="proc" stroke="var(--amber)"/><text x="575" y="98" text-anchor="middle" class="s-l">events.jsonl</text><text x="575" y="114" text-anchor="middle" class="s-s">one shared · locked</text>
+  <path d="M672,80 h34 l7,9 h61 v40 h-102 z" class="proc" stroke="var(--amber)"/><text x="723" y="104" text-anchor="middle" class="s-s">activity/&lt;id&gt;.jsonl</text><text x="723" y="120" text-anchor="middle" class="s-s">per session · lock-free</text>
+  <ellipse cx="905" cy="90" rx="70" ry="12" class="ds-t"/><path d="M835,90 v34 a70,12 0 0 0 140,0 v-34" class="ds-b"/><text x="905" y="88" text-anchor="middle" class="s-s">opencode.db · antigravity.db</text>
+
+  <text x="24" y="182" class="stereo">TEMPORARY — ~/.agents/.cache · dies with the pid</text>
+  <rect x="24" y="194" width="210" height="44" rx="6" class="proc" stroke-dasharray="4 3"/><text x="129" y="214" text-anchor="middle" class="s-s">by-pid/&lt;pid&gt;.json (CLI)</text><text x="129" y="230" text-anchor="middle" class="s-s">terminals/sessions/ (ext)</text>
+  <rect x="250" y="194" width="200" height="44" rx="6" class="proc" stroke-dasharray="4 3"/><text x="350" y="214" text-anchor="middle" class="s-s">agents/&lt;uuid&gt;/meta.json</text><text x="350" y="230" text-anchor="middle" class="s-s">one per teammate</text>
+  <rect x="466" y="194" width="210" height="44" rx="6" class="proc" stroke-dasharray="4 3"/><text x="571" y="214" text-anchor="middle" class="s-s">hosts/&lt;id&gt;.log + .exit</text><text x="571" y="230" text-anchor="middle" class="s-s">remote output + exit code</text>
+  <rect x="692" y="194" width="210" height="44" rx="14" class="proc" stroke="var(--violet)"/><text x="797" y="214" text-anchor="middle" class="s-s">watchdog.sock</text><text x="797" y="230" text-anchor="middle" class="s-s">live nudges (extension)</text>
+  <text x="24" y="272" class="s-s">Rule: keep &amp; search → SQLite · a shared growing log → flat file · tied to one process → temp file · a live poke → socket.</text>
+</svg>
+<figcaption>Fig 7 — storage map. Durable, searchable data is SQLite; append-only streams are flat files; per-process runtime state is temporary cache files; live pokes go over a socket.</figcaption>
+</figure>
+</section>
+
+<!-- 9 · WALKTHROUGHS -->
+<section id="s9">
+  <div class="sec-num">09</div>
+  <h2>Reading &amp; indexing: three walkthroughs <span class="badge cli">CLI</span></h2>
+  <p class="sub">The three things you do most. The chip on the right answers "re-parse a file, or just read the database?"</p>
+  <ul class="tight">
+    <li><b class="k">List / search</b> — a SQLite read; only files whose size/mtime changed get re-scanned (<span class="fl">db.ts:103</span> <code>scan_ledger</code>). Not a re-parse.</li>
+    <li><b class="k"><code>sessions --active</code></b> — scans <code>ps</code> for live agents, maps pid→session, then <b>re-reads the tail</b> of each to infer working/waiting + tokens/sec (<span class="fl">active.ts:389</span>). Per <em>machine</em>, not per session; SSH fan-out for the fleet.</li>
+    <li><b class="k"><code>sessions &lt;id&gt;</code></b> — DB lookup for the file path, then a <b>full parse</b> of the whole transcript (<span class="fl">sessions.ts:1634</span>). The DB never stores the body.</li>
+  </ul>
+  <div class="call correct"><span class="tag">The exact answer</span>
+    <p>Listing = indexed DB read. Live status = re-parse the tail, per machine, every call. Reading one session = full re-parse. Only the last two touch a raw file.</p></div>
+</section>
+
+<!-- 10 · LIVE + EVENTS -->
+<section id="s10">
+  <div class="sec-num">10</div>
+  <h2>Live status &amp; the event logs <span class="badge cli">CLI</span></h2>
+  <p class="sub">Two ways the CLI records "what's happening" — and neither is how the live "is it working / waiting?" view is produced (that's the on-demand re-parse in §9 / §11).</p>
+  <table>
+    <tr><th></th><th>events.ts</th><th>activity.ts</th></tr>
+    <tr><td>records</td><td>things the <b>tool</b> does (ran a command, made a team)</td><td>things the <b>agent</b> does (made a plan, opened a PR)</td></tr>
+    <tr><td>where</td><td>one shared <code>events.jsonl</code></td><td>one file per session <code>activity/&lt;id&gt;.jsonl</code></td></tr>
+    <tr><td>volume / lock</td><td>low · <b>locked</b></td><td>high · <b>lock-free</b> (one writer per file)</td></tr>
+  </table>
+  <p><b class="k">activity is events</b> — same record shape, read together by <span class="fl">event-stream.ts:57</span>. The split is only to avoid lock contention. Key point: activity is <em>already a push feed</em> written at hook time — yet the live view (<code>--active</code>) ignores it and re-parses tails instead.</p>
+</section>
+
+<!-- 11 · BOTTLENECKS + FIX -->
+<section id="s11">
+  <div class="sec-num">11</div>
+  <h2>Slow spots &amp; the fix <span class="badge cli">CLI</span></h2>
+  <p class="sub">The distributed and session engines are well-factored. The cost is in <b>producing the live "what's running" view</b> — the code behind <code>sessions --active</code> — and it's in the CLI itself.</p>
+  <table>
+    <tr><th>#</th><th>Slow spot</th><th>Fix</th></tr>
+    <tr><td>1</td><td>the CLI recomputes live state on every call — and the extension polls it every 3s, per machine, spawning a fresh process each time (<span class="fl">active.ts:389</span>, <span class="fl">remoteSessions.vscode.ts:211</span>)</td><td>a resident CLI process holds state and pushes changes; consumers subscribe</td></tr>
+    <tr><td>2</td><td>fleet <code>--active</code> spawns a fresh process on each peer per tick</td><td>each peer pushes deltas; caller subscribes once</td></tr>
+    <tr><td>3</td><td>the same harness-parsing logic is written in ~5 places</td><td>one adapter per harness, used everywhere</td></tr>
+    <tr><td>4</td><td>the index only updates when asked, behind one lock, up to 5s late</td><td>let the watcher update the index on file change</td></tr>
+    <tr><td>5</td><td>the event logs have no DB and nothing pushes them</td><td>back them with SQLite + a change feed</td></tr>
+  </table>
+<figure>
+<svg viewBox="0 0 1080 250" role="img" aria-label="before after">
+  <defs><marker id="a11" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 z" fill="var(--lime)"/></marker></defs>
+  <text x="24" y="24" class="stereo" fill="var(--red)">NOW — ask, re-parse, discard · every 3s, per machine</text>
+  <text x="560" y="24" class="stereo" fill="var(--lime)">FIX — parse once, push changes, subscribe</text>
+  <line x1="530" y1="36" x2="530" y2="240" class="life"/>
+  <rect x="24" y="50" width="150" height="40" rx="7" class="proc"/><text x="99" y="74" text-anchor="middle" class="s-s">session files</text>
+  <rect x="24" y="120" width="150" height="42" rx="7" class="proc" stroke="var(--red)"/><text x="99" y="140" text-anchor="middle" class="s-s">fresh CLI process</text><text x="99" y="155" text-anchor="middle" class="s-s">(start-up + scan)</text>
+  <rect x="24" y="190" width="150" height="40" rx="7" class="proc"/><text x="99" y="214" text-anchor="middle" class="s-s">the UI</text>
+  <rect x="230" y="120" width="160" height="42" rx="7" class="proc" stroke="var(--red)"/><text x="310" y="140" text-anchor="middle" class="s-s">peers × SSH</text><text x="310" y="155" text-anchor="middle" class="s-s">(fresh proc each)</text>
+  <path class="flow" d="M99,90 L99,118"/><path class="flow-hot" marker-end="url(#a11)" d="M99,162 L99,188"/><path class="flow-hot" marker-end="url(#a11)" d="M174,141 L228,141"/>
+  <text x="60" y="248" class="s-t" fill="var(--red)">many short-lived processes × 3s</text>
+  <rect x="560" y="50" width="150" height="40" rx="7" class="proc"/><text x="635" y="74" text-anchor="middle" class="s-s">session files</text>
+  <rect x="560" y="108" width="190" height="42" rx="7" class="comp"/><text x="655" y="128" text-anchor="middle" class="s-s">one watcher process</text><text x="655" y="143" text-anchor="middle" class="s-s">parse once, emit changes</text>
+  <g transform="translate(560,172)"><ellipse cx="95" cy="10" rx="95" ry="9" class="ds-t"/><path d="M0,10 v22 a95,9 0 0 0 190,0 v-22" class="ds-b"/><text x="95" y="28" text-anchor="middle" class="s-s">store + change feed (SQLite)</text></g>
+  <rect x="790" y="60" width="120" height="34" rx="6" class="proc"/><text x="850" y="82" text-anchor="middle" class="s-s">CLI</text>
+  <rect x="790" y="104" width="120" height="34" rx="6" class="proc"/><text x="850" y="126" text-anchor="middle" class="s-s">extension</text>
+  <rect x="790" y="148" width="120" height="34" rx="6" class="proc"/><text x="850" y="170" text-anchor="middle" class="s-s">other machines</text>
+  <rect x="930" y="104" width="126" height="42" rx="7" class="comp"/><text x="993" y="124" text-anchor="middle" class="s-s">harness adapter</text><text x="993" y="139" text-anchor="middle" class="s-s">(format lives here)</text>
+  <path class="flow-lime" marker-end="url(#a11)" d="M635,90 L650,106"/><path class="flow-lime" marker-end="url(#a11)" d="M655,150 L655,170"/>
+  <path class="flow-lime" marker-end="url(#a11)" d="M750,188 L770,188 L850,142 L850,140"/>
+  <path class="flow-lime" marker-end="url(#a11)" d="M750,188 L770,188 L850,96 L850,96"/>
+  <path class="flow-lime" marker-end="url(#a11)" d="M750,190 L850,190 L850,184"/>
+  <path class="flow-lime" marker-end="url(#a11)" d="M930,125 L752,125"/>
+  <text x="600" y="238" class="s-t" fill="var(--lime)">parse once · readers get only what changed</text>
+</svg>
+<figcaption>Fig 8 — the fix. One long-running process parses each file once and writes changes to a store others subscribe to; per-harness format lives in one adapter. Two of the five "what's happening" paths (poll + event log) collapse into one.</figcaption>
+</figure>
+</section>
+
+<!-- 12 · SCOPE -->
+<section id="s12">
+  <div class="sec-num">12</div>
+  <h2>Scope of this doc</h2>
+  <ul class="tight">
+    <li><b class="k">Covered in depth:</b> the distributed execution engine (§6), session identity/storage/reading (§7–9), and the live-status + event system with its bottlenecks (§10–11) — the parts that carry the "run agents anywhere, see what they're doing" promise.</li>
+    <li><b class="k">Overviewed:</b> version management, config sync, secrets, cloud dispatch, browser/computer automation (§2) — named and placed, not traced line-by-line.</li>
+    <li><b class="k">Deliberately out of scope:</b> the Factory extension's internal UI, and the agent harnesses themselves (external systems in Fig 1).</li>
+  </ul>
+</section>
+
+<div class="foot wrap">agents-cli @ dfe9f011 · v1 (system design) · supersedes v0 (session-focused) · every file:line read from source.</div>
+</div>
+<script>
+  (function(){var root=document.documentElement,btn=document.getElementById('tg');
+    try{var p=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;root.setAttribute('data-theme',p?'light':'dark');}catch(e){}
+    btn.addEventListener('click',function(){root.setAttribute('data-theme',root.getAttribute('data-theme')==='dark'?'light':'dark');});})();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/agents-cli-architecture.html
+++ b/docs/plans/2026-07-30/agents-cli-architecture.html
@@ -1,0 +1,854 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents-cli — the distributed core</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e8ebe6; --ink-dim:#9aa295;
+    --line:#242724; --lime:#a3e635; --lime-dim:#6f9e26; --amber:#f4bf4f; --red:#ff6b5e;
+    --cyan:#5ec7d6; --violet:#b08cff; --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;
+    --code-bg:#0d0f0d; --chip:#1a1d19; --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 30px rgba(0,0,0,.5);
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f4; --panel:#ffffff; --panel-2:#fbfcfa; --ink:#16180f; --ink-dim:#5c6356;
+    --line:#e2e6dc; --lime:#5c8a13; --lime-dim:#7fae2c; --amber:#9a6a00; --red:#c23b2e;
+    --cyan:#0f7d8c; --violet:#6d45c9; --code-bg:#f1f3ec; --chip:#eef1e8; --shadow:0 1px 0 rgba(0,0,0,.02),0 10px 30px rgba(0,0,0,.08);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
+    font-size:16px;-webkit-font-smoothing:antialiased}
+  a{color:var(--lime);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code,kbd,.mono{font-family:var(--mono)}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+
+  .topbar{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 88%,transparent);
+    backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .brand{font-family:var(--mono);font-weight:700;letter-spacing:.02em;font-size:15px}
+  .brand .dot{color:var(--lime)}
+  .toggle{font-family:var(--mono);font-size:13px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:8px;padding:6px 12px;cursor:pointer}
+  .toggle:hover{color:var(--ink);border-color:var(--lime-dim)}
+
+  .hero{padding:64px 0 40px;border-bottom:1px solid var(--line)}
+  .kicker{font-family:var(--mono);font-size:12.5px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--lime);margin-bottom:18px}
+  h1{font-size:clamp(30px,4.6vw,50px);line-height:1.06;margin:0 0 20px;letter-spacing:-.02em;font-weight:800}
+  h1 .g{color:var(--lime)}
+  .lede{font-size:19px;color:var(--ink-dim);max-width:770px;margin:0 0 26px}
+  .lede b{color:var(--ink);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:9px;margin-bottom:8px}
+  .chip{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:999px;padding:5px 12px}
+  .chip b{color:var(--lime);font-weight:600}
+
+  .toc{margin:30px 0 0;padding:18px 20px;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  .toc h4{margin:0 0 12px;font-family:var(--mono);font-size:12px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink-dim)}
+  .toc ol{margin:0;padding:0;list-style:none;display:grid;grid-template-columns:1fr 1fr;gap:6px 26px;
+    counter-reset:toc}
+  .toc li{counter-increment:toc;font-size:14.5px;display:flex;gap:10px;align-items:baseline}
+  .toc li::before{content:counter(toc,decimal-leading-zero);font-family:var(--mono);font-size:12px;
+    color:var(--lime-dim);min-width:22px}
+  @media(max-width:720px){.toc ol{grid-template-columns:1fr}}
+
+  section{padding:52px 0;border-bottom:1px solid var(--line)}
+  .sec-num{font-family:var(--mono);font-size:13px;color:var(--lime);letter-spacing:.1em}
+  h2{font-size:clamp(22px,3vw,30px);margin:8px 0 6px;letter-spacing:-.015em;font-weight:750}
+  h3{font-size:18px;margin:30px 0 8px;font-weight:650}
+  .sub{color:var(--ink-dim);font-size:15.5px;max-width:830px}
+  p{max-width:830px}
+  ul.tight{max-width:830px;padding-left:18px}
+  ul.tight li{margin:6px 0}
+  .fl{font-family:var(--mono);font-size:12.5px;color:var(--cyan);background:var(--code-bg);
+    border:1px solid var(--line);border-radius:5px;padding:1px 6px;white-space:nowrap}
+  b.k{color:var(--lime)}
+
+  .call{margin:22px 0;padding:16px 18px 16px 20px;border-radius:12px;border:1px solid var(--line);
+    background:var(--panel);position:relative;box-shadow:var(--shadow)}
+  .call::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;border-radius:12px 0 0 12px}
+  .call.correct::before{background:var(--lime)}
+  .call.warn::before{background:var(--amber)}
+  .call.hot::before{background:var(--red)}
+  .call .tag{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+    font-weight:700;margin-bottom:6px;display:block}
+  .call.correct .tag{color:var(--lime)}
+  .call.warn .tag{color:var(--amber)}
+  .call.hot .tag{color:var(--red)}
+  .call p{margin:2px 0;max-width:none}
+
+  pre{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;padding:14px 16px;
+    overflow:auto;font-family:var(--mono);font-size:12.7px;line-height:1.6;box-shadow:var(--shadow)}
+  pre b.cap{display:block;color:var(--ink-dim);font-weight:400;font-size:11.5px;margin-bottom:8px;
+    letter-spacing:.04em;border-bottom:1px dashed var(--line);padding-bottom:6px}
+  pre b.cap .t{color:var(--amber)}
+  pre b.cap .s{color:var(--lime)}
+  pre .c{color:var(--ink-dim)}
+  pre .g{color:var(--lime)}
+  pre .a{color:var(--amber)}
+  pre .r{color:var(--red)}
+  pre .cy{color:var(--cyan)}
+  pre .kw{color:var(--violet)}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:820px){.grid2{grid-template-columns:1fr}}
+
+  table{width:100%;border-collapse:collapse;margin:20px 0;font-size:13.6px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;
+    color:var(--ink-dim);font-weight:600}
+  td .fl{white-space:normal}
+  td code{font-size:12px;color:var(--cyan)}
+  .tagp{font-family:var(--mono);font-size:10.5px;padding:1px 7px;border-radius:999px;border:1px solid var(--line);color:var(--amber);border-color:var(--amber)}
+
+  figure{margin:26px 0}
+  figure svg{width:100%;height:auto;display:block;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  figcaption{font-size:13px;color:var(--ink-dim);margin-top:10px;font-family:var(--mono)}
+  .svg-l{font-family:var(--mono);font-size:12px;fill:var(--ink)}
+  .svg-s{font-family:var(--mono);font-size:10.5px;fill:var(--ink-dim)}
+  .svg-t{font-family:var(--mono);font-size:11px;fill:var(--ink-dim)}
+  .box{fill:var(--panel-2);stroke:var(--line);stroke-width:1.2}
+  .box-hot{fill:var(--panel-2);stroke:var(--red);stroke-width:1.6}
+  .box-lime{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.4}
+  .edge{stroke:var(--ink-dim);stroke-width:1.4;fill:none}
+  .edge-hot{stroke:var(--red);stroke-width:1.8;fill:none}
+  .edge-lime{stroke:var(--lime);stroke-width:1.6;fill:none}
+  .cyl-top{fill:var(--panel-2);stroke:var(--cyan);stroke-width:1.5}
+  .cyl-body{fill:var(--panel-2);stroke:var(--cyan);stroke-width:1.5}
+  .cyl-line{stroke:var(--cyan);stroke-width:1.1;opacity:.5}
+  .file{fill:var(--panel-2);stroke:var(--amber);stroke-width:1.4}
+  .file-eph{fill:var(--panel-2);stroke:var(--ink-dim);stroke-width:1.3;stroke-dasharray:5 3}
+  .folder{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.4}
+  .sock{fill:var(--panel-2);stroke:var(--violet);stroke-width:1.5}
+  .arrow{stroke:var(--ink-dim);stroke-width:1.4;fill:none;marker-end:url(#ah)}
+
+  .rank{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);
+    font-weight:700;font-size:13px;width:26px;height:26px;border-radius:7px;margin-right:10px}
+  .rank.p1{background:var(--red);color:#160a08}
+  .rank.p2{background:var(--amber);color:#1a1200}
+  .rank.p3{background:var(--lime);color:#0c1400}
+  .bn{margin:18px 0;padding:16px 18px;background:var(--panel);border:1px solid var(--line);
+    border-radius:12px;box-shadow:var(--shadow)}
+  .bn h4{margin:0 0 6px;font-size:16.5px;display:flex;align-items:center}
+  .bn .ev{font-family:var(--mono);font-size:12px;color:var(--ink-dim);margin:8px 0}
+  .bn .fix{border-top:1px dashed var(--line);margin-top:12px;padding-top:10px;font-size:14.5px}
+  .bn .fix b{color:var(--lime)}
+
+  .foot{padding:40px 0 70px;color:var(--ink-dim);font-size:13px;font-family:var(--mono)}
+
+  .badge{font-family:var(--mono);font-size:10px;font-weight:700;letter-spacing:.06em;padding:2px 7px;
+    border-radius:5px;vertical-align:middle;margin-left:10px;border:1px solid;white-space:nowrap}
+  .badge.cli{color:var(--lime);border-color:var(--lime-dim)}
+  .badge.ext{color:var(--violet);border-color:var(--violet)}
+  .badge.hook{color:var(--amber);border-color:var(--amber)}
+  h2 .badge{font-size:11px}
+  .boundary{margin:24px 0 0;display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  @media(max-width:720px){.boundary{grid-template-columns:1fr}}
+  .boundary .col{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px 16px;
+    box-shadow:var(--shadow)}
+  .boundary .col.cli{border-left:4px solid var(--lime)}
+  .boundary .col.ext{border-left:4px solid var(--violet)}
+  .boundary h5{margin:0 0 8px;font-family:var(--mono);font-size:12px;letter-spacing:.06em}
+  .boundary .col.cli h5{color:var(--lime)}
+  .boundary .col.ext h5{color:var(--violet)}
+  .boundary ul{margin:0;padding-left:16px;font-size:13.5px}
+  .boundary li{margin:4px 0}
+  .boundary .foc{font-family:var(--mono);font-size:10.5px;color:var(--ink-dim);float:right}
+</style>
+</head>
+<body>
+<div class="topbar"><div class="wrap">
+  <div class="brand">agents<span class="dot">·</span>cli <span style="color:var(--ink-dim)">/ architecture</span></div>
+  <button class="toggle" id="tg">◐ theme</button>
+</div></div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="kicker">Codebase onboarding · the distributed core</div>
+  <h1>How <span class="g">agents-cli</span> runs, watches, and shows agents across a fleet</h1>
+  <p class="lede">A plain-language tour of the parts that matter for scale — every claim points at the exact
+    file and line: the <b>data structures</b>, <b>session ids per harness</b>, <b>where things are stored</b>,
+    <b>what actually runs</b> on the common commands, and <b>teams / running agents on other machines</b>.
+    Then the slow spots, and the one change that fixes most of them.</p>
+  <div class="chips">
+    <span class="chip">repo <b>agents-cli</b> @ dfe9f011</span>
+    <span class="chip">apps <b>cli</b> · <b>factory</b></span>
+    <span class="chip">pkg <b>session-tracker</b></span>
+    <span class="chip">every claim has a <b>file:line</b></span>
+    <span class="chip">read from source, not guessed</span>
+  </div>
+
+  <p style="font-size:14.5px;color:var(--ink-dim);margin:22px 0 4px">agents-cli is <b style="color:var(--ink)">two
+    separate programs</b>, not one: the <code>agents</code> command-line tool (<code>apps/cli</code>) and the Factory
+    VS Code extension (<code>apps/factory</code>). They share no memory and no code — the extension launches the CLI
+    as a <b style="color:var(--ink)">subprocess</b> and parses its JSON output. A third piece, the <b style="color:var(--ink)">hook</b>,
+    is a shell script the CLI installs into each agent's own config; it runs inside the agent process. This doc is about the CLI.</p>
+  <div class="boundary">
+    <div class="col cli">
+      <h5>CLI <span class="foc">apps/cli — the focus</span></h5>
+      <ul>
+        <li>the index + parsers (<code>db.ts</code>, <code>discover.ts</code>, <code>parse.ts</code>)</li>
+        <li>live state on demand (<code>active.ts</code>, <code>sessions --active</code>)</li>
+        <li>its own pid→id file (<code>pid-registry</code>, <code>by-pid/</code>)</li>
+        <li>the event + activity logs; <code>agents feed</code></li>
+        <li>teams, <code>run</code>, SSH to other machines</li>
+      </ul>
+    </div>
+    <div class="col ext">
+      <h5>EXTENSION <span class="foc">apps/factory — runs the CLI as a subprocess</span></h5>
+      <ul>
+        <li>polls <code>agents sessions --active --json</code> every 3s</li>
+        <li>the machine-wide file-watcher + "which window" matching</li>
+        <li>its own pid→id read (<code>session-tracker</code>, <code>terminals/sessions/</code>)</li>
+        <li>the watchdog socket (nudges)</li>
+        <li>reshapes CLI JSON into the Floor UI — no data models of its own</li>
+      </ul>
+    </div>
+  </div>
+  <p style="font-size:13.5px;color:var(--ink-dim);margin-top:12px">Every heading below is tagged
+    <span class="badge cli">CLI</span> <span class="badge ext">EXT</span> or <span class="badge hook">HOOK</span>
+    so it's clear which program writes or reads it. If you're optimizing, the CLI is where it counts — the extension
+    is just a client that calls it.</p>
+
+  <nav class="toc">
+    <h4>What's inside</h4>
+    <ol>
+      <li><a href="#s1">Session identity: who assigns the id, who records it</a></li>
+      <li><a href="#s2">The data structures (3 CLI, 1 extension)</a></li>
+      <li><a href="#s3">Session ids, per harness</a></li>
+      <li><a href="#s4">Where each thing is stored</a></li>
+      <li><a href="#s5">Listing = a SQLite index, updated only for changed files</a></li>
+      <li><a href="#s6">Three walkthroughs: what actually runs</a></li>
+      <li><a href="#s7">The extension asks the CLI every 3s; it doesn't get pushed to</a></li>
+      <li><a href="#s8">One file-watcher for the whole machine</a></li>
+      <li><a href="#s9">events vs activity: two logs, one shape</a></li>
+      <li><a href="#s10">Teams &amp; running agents on other machines</a></li>
+      <li><a href="#s11">"What's happening": 3 CLI channels + 2 extension</a></li>
+      <li><a href="#s12">The slow spots, ranked</a></li>
+      <li><a href="#s13">The fix: compute once, hand it out</a></li>
+    </ol>
+  </nav>
+</header>
+
+<!-- 1 -->
+<section id="s1">
+  <div class="sec-num">01</div>
+  <h2>Session identity: who assigns the id, who records it, when <span class="badge cli">CLI</span> <span class="badge hook">HOOK</span> <span class="badge ext">EXT</span></h2>
+  <p class="sub">"Session" means two things. A <b>transcript</b> (the conversation on disk — everything from §2 on) and an
+  <b>identity</b> (which running process is which session). This section is the identity half, because it's the part
+  people find confusing — three different things can write "pid → session id", and which one fires depends on the
+  harness and how the agent was launched.</p>
+
+  <h3>Start here: an agent is a process, and we need to name it</h3>
+  <p>An agent is one OS process with a pid. To say "this terminal is running session <code>4d…</code>" something has to
+  map that pid to a session id, and store it in a file named after the pid (never the database — a pid is an
+  OS-recycled number, so a saved <code>pid 1234 → session-abc</code> row becomes a lie the moment 1234 is reused; a file
+  named <code>1234.json</code> is overwritten by the next agent and deleted when the pid dies — <span class="fl">reader.ts:113</span>).
+  The twist: <b>the id doesn't come from one place.</b> Depending on the harness, either <em>we</em> pick it, or the
+  <em>agent</em> picks it and we find out later.</p>
+
+  <h3>Three writers put "pid → id" on disk — and they fire at different moments</h3>
+<figure>
+<svg viewBox="0 0 1040 340" role="img" aria-label="session identity write paths">
+  <defs>
+    <marker id="ah2" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 z" fill="var(--ink-dim)"/></marker>
+  </defs>
+  <text x="20" y="26" class="svg-t">WRITERS (when they fire)</text>
+  <text x="470" y="26" class="svg-t">FILES</text>
+  <text x="820" y="26" class="svg-t">READERS</text>
+
+  <!-- writers -->
+  <rect x="20" y="42" width="300" height="52" rx="8" class="box-lime"/>
+  <text x="34" y="63" class="svg-l">① ag run — generates a UUID (Claude)</text>
+  <text x="34" y="81" class="svg-s">at launch · exact · exec.ts:1276,1193</text>
+  <rect x="20" y="106" width="300" height="52" rx="8" class="box-lime"/>
+  <text x="34" y="127" class="svg-l">② the shim — captures a passed --session-id</text>
+  <text x="34" y="145" class="svg-s">at launch · if present · exec.ts:1011</text>
+  <rect x="20" y="182" width="300" height="52" rx="8" class="box"/>
+  <text x="34" y="203" class="svg-l">③ the agent's SessionStart hook</text>
+  <text x="34" y="221" class="svg-s">after start · reads the agent's payload · hook.sh</text>
+
+  <!-- files -->
+  <rect x="470" y="70" width="230" height="60" rx="8" class="file-eph" stroke="var(--lime-dim)"/>
+  <text x="585" y="94" text-anchor="middle" class="svg-l">pid-registry</text>
+  <text x="585" y="112" text-anchor="middle" class="svg-s">by-pid/&lt;pid&gt;.json</text>
+  <rect x="470" y="176" width="230" height="60" rx="8" class="file-eph"/>
+  <text x="585" y="200" text-anchor="middle" class="svg-l">session-tracker</text>
+  <text x="585" y="218" text-anchor="middle" class="svg-s">terminals/sessions/&lt;pid&gt;.json</text>
+
+  <!-- readers -->
+  <rect x="820" y="70" width="200" height="60" rx="8" class="box"/>
+  <text x="920" y="94" text-anchor="middle" class="svg-l">CLI</text>
+  <text x="920" y="112" text-anchor="middle" class="svg-s">sessions --active · active.ts:28</text>
+  <rect x="820" y="176" width="200" height="60" rx="8" class="box"/>
+  <text x="920" y="200" text-anchor="middle" class="svg-l">the extension</text>
+  <text x="920" y="218" text-anchor="middle" class="svg-s">factory/core/liveSession.ts</text>
+
+  <!-- edges writers->files -->
+  <path d="M320,68 C400,68 410,96 468,98" class="edge-lime" marker-end="url(#ah2)"/>
+  <path d="M320,132 C400,132 410,112 468,110" class="edge-lime" marker-end="url(#ah2)"/>
+  <path d="M320,208 L468,206" class="edge" marker-end="url(#ah2)"/>
+  <!-- files->readers -->
+  <path d="M700,100 L818,100" class="edge" marker-end="url(#ah2)"/>
+  <path d="M700,206 L818,206" class="edge" marker-end="url(#ah2)"/>
+
+  <text x="360" y="270" class="svg-s"><tspan fill="var(--lime)">①②</tspan> write the CLI's file the instant the process spawns.  <tspan fill="var(--ink-dim)">③</tspan> writes the extension's file once the agent boots and emits its hook.</text>
+  <text x="360" y="288" class="svg-s">Same data (pid → id), two files, two programs. The join key already exists: the hook records terminal_id / launch_id (env the launcher sets).</text>
+</svg>
+<figcaption>Fig 2 — three writers, two files, two readers. ①② are the CLI's launcher/shim (immediate, exact-only-for-Claude); ③ is the agent's own hook (delayed, authoritative, covers agents we never launched).</figcaption>
+</figure>
+  <ul class="tight">
+    <li><b class="k">① <code>ag run</code></b> <span class="badge cli">CLI</span> — for Claude it <em>generates</em> the id (a UUID) and passes <code>--session-id</code>, which Claude uses to create the session with exactly that id (<span class="fl">exec.ts:1276</span>, <span class="fl">:821</span>). So the id is known before the process runs → written immediately, exact (<span class="fl">exec.ts:1193</span>).</li>
+    <li><b class="k">② the shim</b> <span class="badge cli">CLI</span> — the transparent wrapper (<code>execShimPassthrough</code>, <span class="fl">exec.ts:976</span>) forwards raw args untouched. It doesn't invent an id, but if a caller (Claude Code background jobs, an IDE) passed <code>--session-id</code>, it records that exact id via <code>extractSessionIdArg</code> (<span class="fl">exec.ts:1014</span>). Vital on Windows, where there's no <code>lsof</code> to recover a process's cwd afterwards.</li>
+    <li><b class="k">③ the SessionStart hook</b> <span class="badge hook">HOOK</span> — a polyglot shell hook installed in each agent's own config. It reads the id from the agent's own payload and writes the extension's file, <em>after</em> the agent boots. It's the only writer that sees agents <b>we never launched</b> (you typing <code>claude</code> in a terminal) — but only for harnesses that expose a hook, and only after a short lag (<code>trackSpawn</code> polls up to 5s — <span class="fl">index.ts:40</span>).</li>
+  </ul>
+
+  <h3>Who assigns the id — it differs per harness</h3>
+  <p>This is the crux of "why isn't it uniform." The dividing line is <b>who names the session</b>:</p>
+  <table>
+    <tr><th>Harness</th><th>Who assigns the id</th><th>How the CLI knows it at launch</th><th>Hook payload (③)</th></tr>
+    <tr><td><b class="k">claude</b></td><td><b>we do</b> — generate a UUID, pass <code>--session-id</code></td><td><b>exact, immediately</b> (pid-registry)</td><td>stdin JSON <code>session_id</code></td></tr>
+    <tr><td><b class="k">codex</b></td><td>the agent</td><td>not known at launch → learned from ③ or the file (id is <em>inside</em> the <code>rollout-…</code> file)</td><td>stdin JSON <code>session_id</code></td></tr>
+    <tr><td><b class="k">cursor</b></td><td>the agent</td><td>from ③</td><td>stdin JSON <code>session_id</code> / <code>conversation_id</code></td></tr>
+    <tr><td><b class="k">grok</b></td><td>the agent</td><td>from ③</td><td><b>env</b> <code>GROK_SESSION_ID</code> (method <code>hook-env</code>)</td></tr>
+    <tr><td><b class="k">gemini · antigravity</b></td><td>the agent</td><td>best-effort ③, else the file scan</td><td>stdin JSON, best-effort (payload TBD upstream)</td></tr>
+    <tr><td><b class="k">opencode · others</b></td><td>the agent</td><td>only from the file scan; cwd-correlation until then</td><td><b>no hook</b> — <code>hook.sh</code> exits</td></tr>
+  </table>
+  <p>So Claude is the only harness where the id is <em>ours</em> and known up front. For everyone else the agent owns the
+  id and we discover it — via its hook (if it has one) or by reading it out of the transcript later. That's why the
+  pid-registry's <code>sessionId</code> is often empty for non-Claude at launch: the entry still records pid + cwd + agent
+  so <code>--active</code> can correlate by folder until the real id shows up.</p>
+
+  <h3>The two files, and can it be one?</h3>
+  <table>
+    <tr><th></th><th>pid-registry <span class="badge cli">CLI</span></th><th>session-tracker <span class="badge hook">HOOK</span>→<span class="badge ext">EXT</span></th></tr>
+    <tr><td><b>Written by</b></td><td>① <code>ag run</code> / ② the shim</td><td>③ the agent's hook</td></tr>
+    <tr><td><b>When</b></td><td>at launch (immediate)</td><td>after the agent boots (delayed)</td></tr>
+    <tr><td><b>Covers</b></td><td>only launches <b>we</b> make</td><td><b>any</b> start, incl. user-typed / IDE — if the harness has a hook</td></tr>
+    <tr><td><b>Exact id?</b></td><td>only when known at launch (Claude, or a passed <code>--session-id</code>)</td><td>authoritative, from the agent's own payload</td></tr>
+    <tr><td><b>Read by</b></td><td>the CLI (<span class="fl">active.ts:28</span>)</td><td>the extension (<span class="fl">factory/core/liveSession.ts</span>)</td></tr>
+  </table>
+  <div class="call warn"><span class="tag">Can we collapse to one? — yes</span>
+    <p>Neither file subsumes the other today (immediate-but-our-launches-only vs delayed-but-any-launch), which is why
+    both exist. But they hold the <b>same</b> data and can be merged: <b>one <code>pid → id</code> file, two writers</b> — the
+    launcher writes it at spawn (pid + cwd + any id it knows), the hook fills in the authoritative id once the agent
+    emits it. The join already exists — the hook records <code>terminal_id</code> / <code>launch_id</code> from env
+    (<code>AGENT_TERMINAL_ID</code> set by the extension, <code>AGENT_LAUNCH_ID</code> by the launcher). Both the CLI and the
+    extension then read the one file. This is the real "one file, two writers" fix — not "put it in the database."</p></div>
+
+  <h3>In teams and headless runs</h3>
+  <ul class="tight">
+    <li><b class="k">Teams · Claude teammate</b> — the team generates one UUID as the teammate's <code>agentId</code> and passes it as <code>--session-id</code>, so <b>the agent_id and the Claude session id are the same string</b> (one identity for the teammate) — <span class="fl">agents.ts:1610</span>, <span class="fl">:2288</span>.</li>
+    <li><b class="k">Teams · non-Claude teammate</b> — "other agents don't expose a launch-time" id (<span class="fl">agents.ts:1668</span>), so the <code>agentId</code> and the session id stay separate until ③ / the file reveals it.</li>
+    <li><b class="k">Teams · remote teammate</b> — the teammate runs <code>agents run …</code> over SSH, so its pid-registry entry lives on the <b>remote</b> box. The supervisor doesn't use it — it tracks completion via the <code>.log</code>/<code>.exit</code> files (§6C, §10).</li>
+    <li><b class="k">Headless</b> (<code>ag run --headless</code>) — same run path as interactive: still writes the pid-registry (<span class="fl">exec.ts:1373</span>), Claude still gets a generated <code>--session-id</code>, and ③ still fires if the harness supports it. Only the TTY is missing.</li>
+  </ul>
+
+  <h3>The other meaning: a session's <em>transcript</em></h3>
+  <p>Everything from §2 on is about the other "session" — the conversation on disk (one file or DB row per session):
+  its id format, indexing, storage, and reading.</p>
+</section>
+
+<!-- 2 · DATA MODELS -->
+<section id="s2">
+  <div class="sec-num">02</div>
+  <h2>The data structures <span class="badge cli">CLI</span></h2>
+  <p class="sub">Four record types. <b>Three belong to the CLI</b> (the DB row, the CLI's pid→id, the event log).
+  The fourth, <code>SessionState</code>, is the <b>extension's</b> pid→id — I include it so the pair is complete, but
+  the extension owns no models beyond it; it reshapes the CLI's JSON into a view. Two are temporary (deleted when the
+  process exits); two are saved to disk.</p>
+
+  <div class="grid2">
+    <pre><b class="cap"><span class="t">TEMPORARY · EXTENSION reads this</span> · session-tracker/src/types.ts:29</b><span class="kw">interface</span> SessionState {   <span class="c">// pid → session id (hook writes; extension reads)</span>
+  session_id: <span class="cy">string</span>;
+  agent: <span class="cy">'claude'|'codex'|'gemini'|'cursor'</span>
+       <span class="cy">|'grok'|'antigravity'|'opencode'</span>;
+  cwd: <span class="cy">string</span>;
+  pid: <span class="cy">number</span>;
+  terminal_id?: <span class="cy">string</span>;   <span class="c">// VS Code tab</span>
+  launch_id?: <span class="cy">string</span>;     <span class="c">// ag run tag</span>
+  ts: <span class="cy">number</span>;
+  method: <span class="cy">'hook-stdin'|'hook-env'</span>
+        <span class="cy">|'fs-watch'|'stdout-banner'</span>;
+}</pre>
+    <pre><b class="cap"><span class="t">TEMPORARY · the CLI's pid→id</span> · pid-registry.ts:23</b><span class="kw">interface</span> PidSessionEntry {  <span class="c">// ag run's exact map</span>
+  pid: <span class="cy">number</span>;
+  agent: <span class="cy">string</span>;
+  sessionId?: <span class="cy">string</span>;  <span class="c">// exact, from --session-id</span>
+  cwd?: <span class="cy">string</span>;
+  tmuxPane?: <span class="cy">string</span>; <span class="c">// diagnostics only</span>
+  startedAtMs: <span class="cy">number</span>;
+}</pre>
+  </div>
+
+  <pre><b class="cap"><span class="s">SAVED ON DISK</span> · lib/session/db.ts:47 — the `sessions` table (SQLite), one row per transcript</b><span class="g">CREATE TABLE sessions</span> (
+  id <span class="a">TEXT PRIMARY KEY</span>,     <span class="c">-- the session id (each harness names it differently — see §3)</span>
+  short_id TEXT, agent TEXT, origin TEXT <span class="c">DEFAULT 'cli'</span>,  routine_name, routine_run_id,
+  version, account, timestamp TEXT, last_activity TEXT,
+  project, cwd, git_branch, topic, label,                <span class="c">-- who / where / what it's called</span>
+  message_count, token_count, output_tokens, cost_usd, duration_ms,   <span class="c">-- counts</span>
+  file_path <span class="a">TEXT NOT NULL</span>, file_mtime_ms, file_size, scanned_at,   <span class="c">-- where the file is + when we last read it</span>
+  is_team_origin, pr_url, pr_number, worktree_slug, ticket_id, plan   <span class="c">-- work it produced</span>
+);
+<span class="c">-- fast lookups on: timestamp · cwd · agent · file_path · short_id</span>
+<span class="g">CREATE VIRTUAL TABLE session_text USING fts5</span>(session_id, label, topic, project, content);  <span class="c">-- text search</span></pre>
+
+  <pre><b class="cap"><span class="s">SAVED ON DISK</span> · events.ts:160 — one log line = EventMeta &amp; EventPayload</b><span class="kw">interface</span> EventMeta {   <span class="c">// stamped on every line automatically</span>
+  ts, tz, tzName, hostname, platform, arch, pid, ppid,
+  event: <span class="cy">EventType</span>, level: <span class="cy">'audit'|'warn'|'info'|'debug'</span>,
+  caller, session?, osUser, transport: <span class="cy">'local'|'ssh'</span>, sshClientIp?
+}
+<span class="kw">interface</span> EventPayload {   <span class="c">// varies by event</span>
+  agent?, version?, sessionId?, cwd?, module?, command?, args?,
+  input?, output?, <span class="r">prompt_length? / prompt_sha256?</span>  <span class="c">// the raw prompt is NEVER saved — people paste secrets into it</span>,
+  durationMs?, startupMs?, exitCode?, status?, error?, errorStack?
+}</pre>
+  <p>The two temporary records are named by <b>pid</b>. The saved row is named by <b>session id</b> and found by
+  <b>file path</b> — there is no pid column. A pid never reaches permanent storage, for the reuse reason in §1.</p>
+</section>
+
+<!-- 3 · SESSION IDENTITY -->
+<section id="s3">
+  <div class="sec-num">03</div>
+  <h2>Session ids, per harness <span class="badge cli">CLI</span></h2>
+  <p class="sub">Every harness names its sessions differently. In the database, <code>id</code> is whatever that harness
+  uses; <code>short_id</code> is the first 8 characters, for typing. Two harnesses add a prefix — and for Codex the
+  file name and the id are not the same string.</p>
+  <table>
+    <tr><th>Harness</th><th>What <code>id</code> is</th><th>Where it lives · format</th><th>short_id</th></tr>
+    <tr><td><b class="k">claude</b></td><td>the file name (a UUID)</td><td><code>~/.claude/projects/&lt;slug&gt;/&lt;uuid&gt;.jsonl</code></td><td><code>id.slice(0,8)</code></td></tr>
+    <tr><td><b class="k">codex</b> <span class="tagp">prefix</span></td><td>a UUID from <b>inside</b> the file (<code>session_meta.payload.id</code>) — <span class="fl">discover.ts:2536</span></td><td><code>~/.codex/sessions/YYYY/MM/DD/</code><br><code>rollout-&lt;timestamp&gt;-&lt;uuid&gt;.jsonl</code></td><td><code>id.slice(0,8)</code> — <span class="fl">:1053</span></td></tr>
+    <tr><td><b class="k">opencode</b> <span class="tagp">prefix</span></td><td><code>ses_&lt;…&gt;</code>, stored in a SQLite file</td><td><code>opencode.db#ses_&lt;id&gt;</code> (made-up path pointing into the db)</td><td>strip <code>ses_</code>, then first 8 — <span class="fl">:1581</span></td></tr>
+    <tr><td><b class="k">gemini</b></td><td>a <code>sessionId</code> inside the JSON</td><td><code>~/.gemini/tmp/&lt;projectHash&gt;/…</code></td><td><code>id.slice(0,8)</code></td></tr>
+    <tr><td><b class="k">antigravity</b></td><td>the file name minus <code>.db</code> — <span class="fl">:1414</span></td><td><code>…/conversations/&lt;id&gt;.db</code> — a SQLite file, protobuf inside</td><td><code>id.slice(0,8)</code></td></tr>
+    <tr><td><b class="k">droid</b> (Factory)</td><td>the file name (a UUID) — <span class="fl">:2056</span></td><td><code>…/sessions/&lt;uuid&gt;.jsonl</code> + a <code>.settings.json</code> next to it</td><td><code>id.slice(0,8)</code></td></tr>
+    <tr><td><b class="k">kimi</b></td><td>the <em>folder</em> name — <span class="fl">:2932</span></td><td><code>…/sessions/&lt;id&gt;/agents/main/wire.jsonl</code></td><td><code>id.slice(0,8)</code></td></tr>
+    <tr><td><b class="k">grok · rush · hermes · openclaw</b></td><td>a folder or file id</td><td>mixed JSON/JSONL bundles</td><td><code>id.slice(0,8)</code></td></tr>
+  </table>
+  <div class="call warn"><span class="tag">The two that trip people up</span>
+    <p><b>Codex:</b> the file is called <code>rollout-&lt;timestamp&gt;-&lt;uuid&gt;.jsonl</code>, but the id is <em>not</em> that
+    file name — it's a separate UUID read from the first record inside the file. <b>OpenCode:</b> ids start with
+    <code>ses_</code> and live in a SQLite database, pointed at by a made-up path <code>opencode.db#&lt;id&gt;</code>.
+    The full list of 11 harnesses is <span class="fl">SESSION_AGENTS</span> in <span class="fl">types.ts:14</span>.</p></div>
+</section>
+
+<!-- 4 · STORAGE MAP -->
+<section id="s4">
+  <div class="sec-num">04</div>
+  <h2>Where each thing is stored <span class="badge cli">CLI</span> <span class="badge ext">EXT</span></h2>
+  <p class="sub">Five different places, each chosen for three reasons: how long it must live, who writes it, and how
+  it's read back. The shape of each box tells you the kind of store; almost everything here is <b>CLI-owned</b> — the
+  only extension-specific store is <code>terminals/sessions/</code> (the extension's pid→id, §1).</p>
+
+<figure>
+<svg viewBox="0 0 1040 560" role="img" aria-label="storage map">
+  <g transform="translate(20,16)">
+    <ellipse cx="10" cy="8" rx="10" ry="4" class="cyl-top"/><path d="M0,8 v10 a10,4 0 0 0 20,0 v-10" class="cyl-body"/><text x="26" y="16" class="svg-s">SQLite database</text>
+    <rect x="140" y="2" width="20" height="16" rx="2" class="file"/><path d="M154,2 v6 h6" fill="none" stroke="var(--amber)" stroke-width="1.2"/><text x="166" y="16" class="svg-s">flat file (a growing log / json)</text>
+    <rect x="380" y="2" width="20" height="16" rx="2" class="file-eph"/><text x="406" y="16" class="svg-s">temporary file (deleted with the pid)</text>
+    <path d="M642,4 h9 l3,4 h9 v10 h-21 z" class="folder"/><text x="666" y="16" class="svg-s">folder of transcripts</text>
+    <rect x="820" y="2" width="20" height="16" rx="8" class="sock"/><text x="846" y="16" class="svg-s">socket</text>
+  </g>
+  <line x1="20" y1="42" x2="1020" y2="42" stroke="var(--line)"/>
+
+  <text x="20" y="70" class="svg-t" fill="var(--lime)">KEPT — survives a reboot (~/.agents/.history and the agent home dirs)</text>
+
+  <g transform="translate(30,86)">
+    <ellipse cx="120" cy="14" rx="120" ry="14" class="cyl-top"/>
+    <path d="M0,14 v104 a120,14 0 0 0 240,0 v-104" class="cyl-body"/>
+    <text x="120" y="10" text-anchor="middle" class="svg-l">sessions.db</text>
+    <text x="120" y="40" text-anchor="middle" class="svg-s">~/.agents/.history/sessions/</text>
+    <line x1="18" y1="52" x2="222" y2="52" class="cyl-line"/>
+    <text x="120" y="70" text-anchor="middle" class="svg-s">sessions  (one row per transcript)</text>
+    <text x="120" y="88" text-anchor="middle" class="svg-s">session_text  (text search)</text>
+    <text x="120" y="106" text-anchor="middle" class="svg-s">scan_ledger  (file mtime/size)</text>
+    <text x="120" y="124" text-anchor="middle" class="svg-s">meta  (schema version, scan lock)</text>
+  </g>
+
+  <g transform="translate(300,86)">
+    <path d="M0,10 h60 l10,12 h130 v118 h-200 z" class="folder"/>
+    <text x="100" y="40" text-anchor="middle" class="svg-l">the transcripts</text>
+    <text x="100" y="62" text-anchor="middle" class="svg-s">~/.claude/projects/**.jsonl</text>
+    <text x="100" y="80" text-anchor="middle" class="svg-s">~/.codex/sessions/**rollout-*.jsonl</text>
+    <text x="100" y="98" text-anchor="middle" class="svg-s">~/.gemini/tmp/&lt;hash&gt;/…</text>
+    <text x="100" y="116" text-anchor="middle" class="svg-s">the raw truth · read on demand</text>
+  </g>
+
+  <g transform="translate(540,90)">
+    <ellipse cx="70" cy="12" rx="70" ry="11" class="cyl-top"/><path d="M0,12 v42 a70,11 0 0 0 140,0 v-42" class="cyl-body"/>
+    <text x="70" y="9" text-anchor="middle" class="svg-l">opencode.db</text>
+    <text x="70" y="40" text-anchor="middle" class="svg-s">ses_ ids inside</text>
+  </g>
+  <g transform="translate(540,158)">
+    <ellipse cx="70" cy="12" rx="70" ry="11" class="cyl-top"/><path d="M0,12 v34 a70,11 0 0 0 140,0 v-34" class="cyl-body"/>
+    <text x="70" y="9" text-anchor="middle" class="svg-l">antigravity .db</text>
+    <text x="70" y="36" text-anchor="middle" class="svg-s">one per session</text>
+  </g>
+
+  <g transform="translate(710,90)">
+    <rect x="0" y="0" width="150" height="52" rx="6" class="file"/><path d="M138,0 v8 h12" fill="none" stroke="var(--amber)" stroke-width="1.3"/>
+    <text x="75" y="24" text-anchor="middle" class="svg-l">teams/registry.json</text>
+    <text x="75" y="42" text-anchor="middle" class="svg-s">team name · devices · repo</text>
+  </g>
+  <g transform="translate(710,158)">
+    <rect x="0" y="0" width="150" height="46" rx="6" class="file"/><path d="M138,0 v8 h12" fill="none" stroke="var(--amber)" stroke-width="1.3"/>
+    <text x="75" y="22" text-anchor="middle" class="svg-l">events.jsonl</text>
+    <text x="75" y="38" text-anchor="middle" class="svg-s">one shared log · locked</text>
+  </g>
+  <g transform="translate(875,90)">
+    <path d="M0,10 h40 l8,10 h72 v34 h-120 z" class="folder" stroke="var(--amber)"/>
+    <text x="60" y="34" text-anchor="middle" class="svg-l" font-size="11">activity/&lt;id&gt;.jsonl</text>
+    <text x="60" y="50" text-anchor="middle" class="svg-s">one per session</text>
+  </g>
+
+  <line x1="20" y1="240" x2="1020" y2="240" stroke="var(--line)" stroke-dasharray="3 3"/>
+  <text x="20" y="268" class="svg-t" fill="var(--ink-dim)">TEMPORARY — under ~/.agents/.cache · deleted when the process (or the machine) restarts</text>
+
+  <g transform="translate(30,284)">
+    <rect x="0" y="0" width="220" height="60" rx="6" class="file-eph"/>
+    <text x="110" y="24" text-anchor="middle" class="svg-l">terminals/sessions/&lt;pid&gt;.json</text>
+    <text x="110" y="44" text-anchor="middle" class="svg-s">pid → id · written by the hook</text>
+  </g>
+  <g transform="translate(270,284)">
+    <rect x="0" y="0" width="220" height="60" rx="6" class="file-eph"/>
+    <text x="110" y="24" text-anchor="middle" class="svg-l">terminals/by-pid/&lt;pid&gt;.json</text>
+    <text x="110" y="44" text-anchor="middle" class="svg-s">pid → id · written by ag run</text>
+  </g>
+  <g transform="translate(510,284)">
+    <rect x="0" y="0" width="220" height="60" rx="6" class="file-eph"/>
+    <text x="110" y="24" text-anchor="middle" class="svg-l">agents/&lt;uuid&gt;/meta.json</text>
+    <text x="110" y="44" text-anchor="middle" class="svg-s">one per teammate in a team</text>
+  </g>
+  <g transform="translate(750,284)">
+    <rect x="0" y="0" width="220" height="60" rx="6" class="file-eph"/>
+    <text x="110" y="24" text-anchor="middle" class="svg-l">hosts/&lt;id&gt;.log + .exit</text>
+    <text x="110" y="44" text-anchor="middle" class="svg-s">a remote agent's output + exit code</text>
+  </g>
+
+  <line x1="20" y1="370" x2="1020" y2="370" stroke="var(--line)" stroke-dasharray="3 3"/>
+  <text x="20" y="398" class="svg-t" fill="var(--violet)">LIVE — in memory, one process talking to another</text>
+  <g transform="translate(30,414)">
+    <rect x="0" y="0" width="260" height="52" rx="14" class="sock"/>
+    <text x="130" y="24" text-anchor="middle" class="svg-l">~/.agents/.tmp/watchdog.sock</text>
+    <text x="130" y="42" text-anchor="middle" class="svg-s">poke an agent: nudge / message</text>
+  </g>
+  <g transform="translate(310,414)">
+    <rect x="0" y="0" width="300" height="52" rx="8" class="box"/>
+    <text x="150" y="24" text-anchor="middle" class="svg-l">SSH (one connection, reused)</text>
+    <text x="150" y="42" text-anchor="middle" class="svg-s">run --host · teams · asking peers</text>
+  </g>
+  <g transform="translate(630,414)">
+    <rect x="0" y="0" width="300" height="52" rx="8" class="box"/>
+    <text x="150" y="24" text-anchor="middle" class="svg-l">in-app messages</text>
+    <text x="150" y="42" text-anchor="middle" class="svg-s">watcher → windows · host → React UI</text>
+  </g>
+
+  <text x="20" y="512" class="svg-s">Picking one: need to keep it and search it → SQLite. A growing log many processes append to → a flat file.</text>
+  <text x="20" y="528" class="svg-s">Tied to one running process → a temporary file named by its pid. A live poke to another process → a socket.</text>
+</svg>
+<figcaption>Fig 3 — where each thing lives. The box shape is the kind of store: cylinder = SQLite, folded corner = flat log/json, dashed = temporary file, folder = transcripts, rounded pill = socket.</figcaption>
+</figure>
+</section>
+
+<!-- 5 -->
+<section id="s5">
+  <div class="sec-num">05</div>
+  <h2>Listing sessions reads a SQLite index — and only re-reads files that changed <span class="badge cli">CLI</span></h2>
+  <p class="sub">A fair worry: agents write to their transcript fast, so does listing them re-read everything each time? No.</p>
+  <ul class="tight">
+    <li>A table called <b class="k">scan_ledger</b> (<span class="fl">db.ts:103</span>) remembers each file's size and modified-time. On a scan, a file is only re-read if those changed. <code>agents sessions</code> then reads rows from the database, not the raw files.</li>
+    <li>The scanners (<span class="fl">discover.ts:2227</span>, <span class="fl">:2458</span>) read a changed file line by line and pull out <em>metadata only</em> (topic, counts, PR url) — never the full conversation.</li>
+  </ul>
+  <div class="call correct"><span class="tag">So, to be exact</span>
+    <p>Listing and searching = a database read, and only changed files get re-read into it. The <b>only</b> time the
+    whole conversation is parsed is when you open one specific session to read it (§6, walkthrough B).</p></div>
+</section>
+
+<!-- 6 · WALKTHROUGHS -->
+<section id="s6">
+  <div class="sec-num">06</div>
+  <h2>Three walkthroughs: what actually runs <span class="badge cli">CLI</span></h2>
+  <p class="sub">All three are CLI commands (the extension just calls the first one). The chip on the right answers
+  "does it re-parse, or just read the database?"</p>
+
+<figure>
+<svg viewBox="0 0 1040 470" role="img" aria-label="three workflows">
+  <defs>
+    <marker id="ah" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 z" fill="var(--ink-dim)"/>
+    </marker>
+  </defs>
+
+  <!-- Row A -->
+  <text x="20" y="30" class="svg-l" fill="var(--ink)">A · agents sessions --active</text>
+  <text x="20" y="48" class="svg-s">"which agents are running, and are they working or waiting?"</text>
+  <g font-family="var(--mono)">
+    <rect x="20" y="60" width="132" height="48" rx="8" class="box"/><text x="86" y="80" text-anchor="middle" class="svg-s">scan `ps` for</text><text x="86" y="95" text-anchor="middle" class="svg-s">agent processes</text>
+    <path class="arrow" d="M154,84 H186"/>
+    <rect x="188" y="60" width="132" height="48" rx="8" class="box"/><text x="254" y="80" text-anchor="middle" class="svg-s">pid → session id</text><text x="254" y="95" text-anchor="middle" class="svg-s">(pid file, else cwd)</text>
+    <path class="arrow" d="M322,84 H354"/>
+    <rect x="356" y="60" width="150" height="48" rx="8" class="box-hot"/><text x="431" y="80" text-anchor="middle" class="svg-s">read the TAIL of</text><text x="431" y="95" text-anchor="middle" class="svg-s">each transcript</text>
+    <path class="arrow" d="M508,84 H540"/>
+    <rect x="542" y="60" width="150" height="48" rx="8" class="box"/><text x="617" y="80" text-anchor="middle" class="svg-s">working/waiting/idle</text><text x="617" y="95" text-anchor="middle" class="svg-s">+ tokens/sec</text>
+    <path class="arrow" d="M694,84 H726"/>
+    <rect x="728" y="60" width="120" height="48" rx="8" class="box"/><text x="788" y="80" text-anchor="middle" class="svg-s">SSH each peer,</text><text x="788" y="95" text-anchor="middle" class="svg-s">same command</text>
+    <path class="arrow" d="M850,84 H882"/>
+    <rect x="884" y="60" width="120" height="48" rx="8" class="box"/><text x="944" y="87" text-anchor="middle" class="svg-s">print / to UI</text>
+  </g>
+  <rect x="20" y="118" width="360" height="22" rx="11" fill="none" stroke="var(--red)" stroke-width="1.2"/>
+  <text x="30" y="133" class="svg-s" fill="var(--red)">re-parses the tail of every live session, every call</text>
+  <text x="410" y="133" class="svg-s">DB used only to find a file for a folder (active.ts:389)</text>
+
+  <line x1="20" y1="158" x2="1020" y2="158" stroke="var(--line)" stroke-dasharray="3 3"/>
+
+  <!-- Row B -->
+  <text x="20" y="188" class="svg-l" fill="var(--ink)">B · agents sessions &lt;id&gt;</text>
+  <text x="20" y="206" class="svg-s">"show me this one conversation"</text>
+  <g font-family="var(--mono)">
+    <rect x="20" y="218" width="170" height="48" rx="8" class="box"/><text x="105" y="238" text-anchor="middle" class="svg-s">quick scan (skips</text><text x="105" y="253" text-anchor="middle" class="svg-s">unchanged files)</text>
+    <path class="arrow" d="M192,242 H224"/>
+    <rect x="226" y="218" width="210" height="48" rx="8" class="box-lime"/><text x="331" y="238" text-anchor="middle" class="svg-s">DB: id → file path + metadata</text><text x="331" y="253" text-anchor="middle" class="svg-s">(topic, tokens, cwd…)</text>
+    <path class="arrow" d="M438,242 H470"/>
+    <rect x="472" y="218" width="210" height="48" rx="8" class="box-hot"/><text x="577" y="238" text-anchor="middle" class="svg-s">open the file, FULLY parse</text><text x="577" y="253" text-anchor="middle" class="svg-s">the whole conversation</text>
+    <path class="arrow" d="M684,242 H716"/>
+    <rect x="718" y="218" width="150" height="48" rx="8" class="box"/><text x="793" y="245" text-anchor="middle" class="svg-s">render markdown</text>
+  </g>
+  <rect x="20" y="276" width="470" height="22" rx="11" fill="none" stroke="var(--amber)" stroke-width="1.2"/>
+  <text x="30" y="291" class="svg-s" fill="var(--amber)">the DB locates it; the conversation body is re-parsed from the raw file in full</text>
+  <text x="510" y="291" class="svg-s">the DB never stores the body — only prompt text, for search (sessions.ts:1634)</text>
+
+  <line x1="20" y1="318" x2="1020" y2="318" stroke="var(--line)" stroke-dasharray="3 3"/>
+
+  <!-- Row C -->
+  <text x="20" y="348" class="svg-l" fill="var(--ink)">C · a teammate in a team finishes</text>
+  <text x="20" y="366" class="svg-s">"how does the team know a step is done, and start the next?"</text>
+  <g font-family="var(--mono)">
+    <rect x="20" y="378" width="200" height="48" rx="8" class="box"/><text x="120" y="398" text-anchor="middle" class="svg-s">teammate runs as:</text><text x="120" y="413" text-anchor="middle" class="svg-s">cmd; echo $? &gt; .exit</text>
+    <path class="arrow" d="M222,402 H254"/>
+    <rect x="256" y="378" width="190" height="48" rx="8" class="box"/><text x="351" y="398" text-anchor="middle" class="svg-s">supervisor poll reads</text><text x="351" y="413" text-anchor="middle" class="svg-s">.exit (local / over SSH)</text>
+    <path class="arrow" d="M448,402 H480"/>
+    <rect x="482" y="378" width="210" height="48" rx="8" class="box-lime"/><text x="587" y="398" text-anchor="middle" class="svg-s">exit code present →</text><text x="587" y="413" text-anchor="middle" class="svg-s">COMPLETED / FAILED</text>
+    <path class="arrow" d="M694,402 H726"/>
+    <rect x="728" y="378" width="140" height="48" rx="8" class="box"/><text x="798" y="398" text-anchor="middle" class="svg-s">startReady: launch</text><text x="798" y="413" text-anchor="middle" class="svg-s">the next wave</text>
+    <path class="arrow" d="M870,402 H902"/>
+    <rect x="904" y="378" width="110" height="48" rx="8" class="box"/><text x="959" y="398" text-anchor="middle" class="svg-s">DAG empty →</text><text x="959" y="413" text-anchor="middle" class="svg-s">teams.complete</text>
+  </g>
+  <rect x="20" y="436" width="420" height="22" rx="11" fill="none" stroke="var(--lime-dim)" stroke-width="1.2"/>
+  <text x="30" y="451" class="svg-s" fill="var(--lime)">the signal is a file with the exit code — no live connection is held</text>
+  <text x="460" y="451" class="svg-s">remote checks batched to one SSH call per host (agents.ts:861)</text>
+</svg>
+<figcaption>Fig 4 — the three common paths. Red step = re-parses a file. Green step = a plain database or file read.</figcaption>
+</figure>
+
+  <ul class="tight">
+    <li><b class="k">A (--active)</b> re-reads the tail of every live session on each call — <span class="fl">active.ts:389</span> <code>readSessionTailWithRaw</code>, state from <span class="fl">state.ts</span>, tokens/sec from <span class="fl">throughput.ts</span>. Other machines: one SSH per peer running the same command with <code>--local</code>.</li>
+    <li><b class="k">B (one session)</b> looks the id up in the DB for the file path, then fully parses that file — <span class="fl">sessions.ts:1634</span> <code>parseSession</code> → <span class="fl">render.ts</span>. Reading the same session twice parses it twice.</li>
+    <li><b class="k">C (teammate done)</b> each teammate writes its exit code to a <code>.exit</code> file; the supervisor reads it (locally via <code>reapProcess</code>, remotely by tailing the log + reading the remote <code>.exit</code>, batched one SSH per host), flips the status, then <code>startReady</code> launches whatever was waiting on it — <span class="fl">agents.ts:180</span>, <span class="fl">:861</span>, <span class="fl">teams.ts:361</span>.</li>
+  </ul>
+</section>
+
+<!-- 7 -->
+<section id="s7">
+  <div class="sec-num">07</div>
+  <h2>The Factory extension asks the CLI every 3 seconds — nothing pushes to it <span class="badge ext">EXT</span></h2>
+  <p class="sub">This is the extension's behavior — but note the root cause is the CLI's: <code>sessions --active</code>
+  recomputes state on every call (§6A), so any poller pays for it. The extension just multiplies that cost. Fix it at
+  the CLI and every consumer benefits.</p>
+  <pre><span class="c">// apps/factory/src/vscode/remoteSessions.vscode.ts</span>
+runs <span class="g">agents sessions --active --json</span> as a subprocess  <span class="c">// :211</span>
+<span class="a">every ~3 seconds</span> (:55) · three modes: this machine only · every machine over SSH · one machine on demand (:281)
+<span class="c">// then reshapes the JSON and hands it to the React UI</span></pre>
+  <div class="call hot"><span class="tag">The expensive path</span>
+    <p>Every 3 seconds, <b>for each machine</b>, the extension starts a whole new <code>agents</code> process,
+    which does the scan and re-parses the tails (walkthrough A), prints JSON, and exits. That work is thrown away
+    and redone 3 seconds later. It <b>never reads the event logs</b> — the ready-made stream of "what happened"
+    (§9) is sitting right there, unused by the live view.</p></div>
+</section>
+
+<!-- 8 -->
+<section id="s8">
+  <div class="sec-num">08</div>
+  <h2>One file-watcher for the whole machine <span class="badge ext">EXT</span></h2>
+  <p class="sub">This one is <b>entirely in the extension</b> (the CLI has no resident watcher — it scans on demand, §5).
+  Inside Factory, one process is elected "leader" and watches all the session folders so each editor window doesn't have to.</p>
+  <ul class="tight">
+    <li><span class="fl">monitor/sessionWatcher.ts:70</span> sets up <b class="k">one recursive watch per session folder</b>, waits 300ms after a change, reads only the first 100 lines to figure out which window a new file belongs to, and tells the windows.</li>
+    <li>It asks the CLI where the folders are — <code>agents sessions --roots --json</code> (<span class="fl">sessionParse.ts:202</span>) — so it stays in sync when a harness moves its files.</li>
+  </ul>
+</section>
+
+<!-- 9 · EVENTS VS ACTIVITY -->
+<section id="s9">
+  <div class="sec-num">09</div>
+  <h2>events vs activity: two logs, one shape, no database <span class="badge cli">CLI</span></h2>
+  <p class="sub">You asked why both exist. They're the same idea — a log of "X happened at time T" — split only by <b>who writes it</b> and <b>how often</b>.</p>
+  <table>
+    <tr><th></th><th>events.ts</th><th>activity.ts</th></tr>
+    <tr><td><b>What it records</b></td><td>things the <b>tool</b> does: ran a command, made a team, fetched a secret</td><td>things the <b>agent</b> does: made a plan, opened a PR, edited a file</td></tr>
+    <tr><td><b>Where</b></td><td>one shared file <code>~/.agents/events.jsonl</code></td><td>one file per session <code>activity/&lt;id&gt;.jsonl</code></td></tr>
+    <tr><td><b>How often</b></td><td>rarely (low volume)</td><td>constantly (high volume)</td></tr>
+    <tr><td><b>Locking</b></td><td><b>locked</b> — many processes share one file</td><td><b>no lock</b> — each session owns its own file</td></tr>
+    <tr><td><b>Written by</b></td><td><code>emit()</code> in the CLI — <span class="fl">events.ts:464</span></td><td>the agent's hook (and <code>appendActivityEvent</code>) — <span class="fl">activity.ts:108</span></td></tr>
+  </table>
+  <p><b class="k">So: activity <em>is</em> events.</b> Same record names (<code>plan.created</code>, <code>pr.opened</code>,
+  <code>file.edited</code>), read back together by one function, <span class="fl">event-stream.ts:57</span> <code>readUnifiedEvents</code>.
+  The split exists for one reason: if every high-frequency agent event also went into the single locked file, agents
+  would fight over that lock constantly. Per-session files remove the fight.</p>
+  <div class="call warn"><span class="tag">The part that matters for your optimization</span>
+    <p>The activity log is <b>already a push feed</b> — the hook writes "made a plan / opened a PR" the moment it
+    happens, and <code>agents feed</code> shows it <em>without re-parsing any transcript</em>. But walkthrough A
+    (<code>--active</code>) ignores this and re-parses tails anyway. There's no database behind these logs and nothing
+    pushes them to the live UI — that's the gap your "one stream → database → adapters" idea closes.</p></div>
+</section>
+
+<!-- 10 -->
+<section id="s10">
+  <div class="sec-num">10</div>
+  <h2>Teams &amp; running agents on other machines <span class="badge cli">CLI</span></h2>
+  <p class="sub">The well-built part. <code>run</code> and <code>teams</code> share code through the <code>agents run</code> command line, not a shared function — on purpose.</p>
+  <table>
+    <tr><th>Layer</th><th>What it does</th><th>Key file:line</th></tr>
+    <tr><td><b class="k">agents run</b></td><td>knows how to start every harness; sets its env; starts it</td><td><span class="fl">exec.ts:463</span> the command table · <span class="fl">:1268</span> spawnAgent</td></tr>
+    <tr><td><b class="k">AgentManager</b></td><td>builds an <code>agents run</code> command line; runs teammates in dependency order; local, remote, or cloud</td><td><span class="fl">teams/agents.ts:2219</span> buildRunArgv · <span class="fl">:2143</span> startReady</td></tr>
+    <tr><td><b class="k">SSH helper</b></td><td>one reused SSH connection for all remote calls; blocks bad hostnames</td><td><span class="fl">ssh-exec.ts:76</span> · <span class="fl">:24</span></td></tr>
+    <tr><td><b class="k">detached launch</b></td><td>start-and-forget on a host, write output + exit code to files (shared by <code>run --host</code> and teams)</td><td><span class="fl">hosts/dispatch.ts:202</span> launchDetached</td></tr>
+  </table>
+  <ul class="tight">
+    <li><b>Teams don't call the internal start function.</b> They build an <code>agents run …</code> command line and run it — locally as a background shell, remotely over SSH. So any new <code>run</code> flag works in teams for free.</li>
+    <li>The supervisor reads a remote teammate's output by copying new bytes from its log file over SSH (<span class="fl">agents.ts:819</span>), and checks all teammates on a host in one SSH call.</li>
+    <li>Picking a machine (<span class="fl">scheduler.ts:76</span>): a pinned one → the only one in the pool → the one running the fewest teammates (<b>a count, not real CPU/memory</b>) → this machine.</li>
+  </ul>
+  <div class="call warn"><span class="tag">Small duplications</span>
+    <p><code>resolveMode()</code> is written twice (<span class="fl">exec.ts:100</span> vs <span class="fl">teams/agents.ts:319</span>); the "write the exit code to a file" trick is written twice (<span class="fl">agents.ts:180</span>, <span class="fl">dispatch.ts:218</span>).</p></div>
+</section>
+
+<!-- 11 -->
+<section id="s11">
+  <div class="sec-num">11</div>
+  <h2>Ways the system reports "what's happening" — 3 in the CLI, 2 in the extension <span class="badge cli">CLI</span> <span class="badge ext">EXT</span></h2>
+  <p class="sub">The core issue, and it's <b>inside the CLI itself</b>: even in just the CLI there are three separate ways to
+  answer "what's happening" that don't share a channel. The extension then adds two more.</p>
+  <table>
+    <tr><th>#</th><th>Layer</th><th>Channel</th><th>How it works</th></tr>
+    <tr><td>1</td><td><span class="badge cli">CLI</span></td><td><b class="k">poll + re-parse</b></td><td><code>sessions --active</code> re-derives state on demand (the extension is what polls it)</td></tr>
+    <tr><td>2</td><td><span class="badge cli">CLI</span></td><td><b class="k">the event logs</b></td><td>shared <code>events.jsonl</code> + per-session <code>activity</code> files → <code>agents events</code></td></tr>
+    <tr><td>3</td><td><span class="badge cli">CLI</span></td><td><b class="k">the mailbox</b></td><td>"this agent is waiting on you" → <code>agents feed</code> (<span class="fl">feed.ts</span>)</td></tr>
+    <tr><td>4</td><td><span class="badge ext">EXT</span></td><td><b class="k">the watchdog</b></td><td>notices a stuck agent, pokes it over the socket (<span class="fl">watchdog-server.ts:11</span>)</td></tr>
+    <tr><td>5</td><td><span class="badge ext">EXT</span></td><td><b class="k">the file-watcher</b></td><td>notices new session files, tells the editor windows</td></tr>
+  </table>
+  <p>Focus on the CLI's three: <b>1 recomputes on demand, 2 is a written-down log, 3 is a mailbox</b> — three answers
+  to one question, no shared channel. Fixing that at the CLI (§13) is what makes the extension's job trivial.</p>
+</section>
+
+<!-- BEFORE/AFTER DIAGRAM -->
+<figure>
+<svg viewBox="0 0 1040 400" role="img" aria-label="current vs proposed">
+  <text x="20" y="26" class="svg-l" fill="var(--red)">NOW — ask, re-parse, throw away · every 3s, per machine</text>
+  <text x="540" y="26" class="svg-l" fill="var(--lime)">BETTER — write it down once, everyone reads</text>
+  <line x1="510" y1="40" x2="510" y2="380" stroke="var(--line)" stroke-width="1.2" stroke-dasharray="4 4"/>
+  <rect x="20" y="50" width="150" height="46" rx="8" class="box"/><text x="95" y="78" text-anchor="middle" class="svg-s">session files</text>
+  <rect x="20" y="150" width="150" height="46" rx="8" class="box-hot"/><text x="95" y="170" text-anchor="middle" class="svg-s">new CLI process</text><text x="95" y="185" text-anchor="middle" class="svg-s">(start-up + scan)</text>
+  <rect x="20" y="250" width="150" height="46" rx="8" class="box"/><text x="95" y="278" text-anchor="middle" class="svg-s">the UI</text>
+  <rect x="300" y="150" width="170" height="46" rx="8" class="box-hot"/><text x="385" y="170" text-anchor="middle" class="svg-s">each peer over SSH</text><text x="385" y="185" text-anchor="middle" class="svg-s">(its own new process)</text>
+  <path class="edge" d="M95,96 L95,148"/>
+  <path class="edge-hot" d="M95,196 L95,248"/>
+  <path class="edge-hot" d="M170,173 L298,173"/>
+  <text x="55" y="322" class="svg-s" fill="var(--red)">many new processes × every 3s</text>
+  <rect x="545" y="50" width="150" height="46" rx="8" class="box"/><text x="620" y="78" text-anchor="middle" class="svg-s">session files</text>
+  <rect x="545" y="120" width="200" height="46" rx="8" class="box-lime"/><text x="645" y="140" text-anchor="middle" class="svg-s">one watcher process</text><text x="645" y="155" text-anchor="middle" class="svg-s">parse once, write changes</text>
+  <rect x="545" y="196" width="200" height="46" rx="8" class="box-lime"/><text x="645" y="216" text-anchor="middle" class="svg-s">one store (SQLite)</text><text x="645" y="231" text-anchor="middle" class="svg-s">with a "what changed" feed</text>
+  <rect x="545" y="272" width="130" height="46" rx="8" class="box"/><text x="610" y="300" text-anchor="middle" class="svg-s">CLI</text>
+  <rect x="695" y="272" width="130" height="46" rx="8" class="box"/><text x="760" y="300" text-anchor="middle" class="svg-s">extension</text>
+  <rect x="845" y="272" width="130" height="46" rx="8" class="box"/><text x="910" y="300" text-anchor="middle" class="svg-s">other machines</text>
+  <path class="edge-lime" d="M620,96 L640,118"/>
+  <path class="edge-lime" d="M645,166 L645,194"/>
+  <path class="edge-lime" d="M645,242 L645,258 L610,258 L610,270"/>
+  <path class="edge-lime" d="M645,242 L645,258 L760,258 L760,270"/>
+  <path class="edge-lime" d="M645,242 L645,258 L910,258 L910,270"/>
+  <text x="600" y="352" class="svg-s" fill="var(--lime)">parse once · readers get only what changed · no per-poll processes</text>
+  <rect x="775" y="120" width="200" height="46" rx="8" class="box-lime"/><text x="875" y="140" text-anchor="middle" class="svg-s">one adapter per harness</text><text x="875" y="155" text-anchor="middle" class="svg-s">(where the format lives)</text>
+  <path class="edge-lime" d="M775,143 L747,143"/>
+</svg>
+<figcaption>Fig 5 — the fix. One long-running process parses each file once and writes changes to a store others subscribe to. Each harness's format lives in one adapter.</figcaption>
+</figure>
+
+<!-- 12 -->
+<section id="s12">
+  <div class="sec-num">12</div>
+  <h2>The slow spots, ranked</h2>
+  <p class="sub">Each one points at the code above. Ordered by how much it costs.</p>
+
+  <div class="bn">
+    <h4><span class="rank p1">1</span>The CLI recomputes live state on every call — and the poller does it every 3s <span class="badge cli">CLI</span> <span class="badge ext">EXT</span></h4>
+    <p class="ev">Root cause is <span class="badge cli">CLI</span>: <code>sessions --active</code> re-derives everything from scratch each call (re-parses tails, §6A) — there's no resident state. Multiplier is <span class="badge ext">EXT</span>: <span class="fl">remoteSessions.vscode.ts:211</span> runs it every ~3s (<span class="fl">:55</span>), so a whole new process pays start-up + scan + parse, then exits.</p>
+    <p>Even without the extension — just you running <code>agents sessions --active</code> in a terminal — you pay the recompute every time. Several windows and machines only multiply it.</p>
+    <div class="fix"><b>Fix (at the CLI):</b> a resident CLI process holds current state in memory and emits what changed; every consumer (a terminal, the extension, another machine) reads that instead of triggering a fresh recompute.</div>
+  </div>
+  <div class="bn">
+    <h4><span class="rank p1">2</span>Asking the fleet starts one process per machine, per poll</h4>
+    <p class="ev">Where: <span class="fl">sessions.ts:28–36</span>; each peer runs its own full <code>agents sessions --local</code>. The reused SSH connection (<span class="fl">ssh-exec.ts:76</span>) saves the handshake but not the remote start-up + scan.</p>
+    <div class="fix"><b>Fix:</b> each machine runs a small resident process that pushes only changes; the caller subscribes once instead of starting a process per poll.</div>
+  </div>
+  <div class="bn">
+    <h4><span class="rank p2">3</span>The same parsing logic is written in five places</h4>
+    <p class="ev">Where: full parser <span class="fl">parse.ts:143</span>; the index scanner <span class="fl">discover.ts:2227/2458</span>; the Factory "which window" parser <span class="fl">sessionParse.ts:46</span>; the Factory activity-line parser <span class="fl">session.activity.ts:93</span>; the live tail renderer <span class="fl">stream-render.ts:116</span>. Each knows the harness formats separately.</p>
+    <div class="fix"><b>Fix:</b> one adapter per harness — <code>{ where the files are, parse the head, parse it all, read the id }</code> — used by all five. Adding a harness (or fixing the Codex file-vs-id split) becomes one file, not five.</div>
+  </div>
+  <div class="bn">
+    <h4><span class="rank p2">4</span>The index only updates when someone asks, behind one lock, up to 5s late</h4>
+    <p class="ev">Where: the scan runs on every <code>agents sessions</code> call, and only one process may scan at a time; a still-writing session's index can be up to 5s behind (<span class="fl">discover.ts:65</span>).</p>
+    <div class="fix"><b>Fix:</b> let the watcher (§8) update the index the moment a file changes, so reads are just database reads.</div>
+  </div>
+  <div class="bn">
+    <h4><span class="rank p3">5</span>The event logs have no database and nothing pushes them</h4>
+    <p class="ev">Where: <span class="fl">event-stream.ts:57</span> reads and sorts the file in memory; the shared log takes a lock on every write (<span class="fl">events.ts:464</span>).</p>
+    <div class="fix"><b>Fix:</b> put the events in SQLite (same trick as sessions) with a "what changed" feed. Now you get time-range queries, a subscribe channel, and no shared write lock.</div>
+  </div>
+  <div class="bn">
+    <h4><span class="rank p3">6</span>Two pid files, whole-file reads, and small copy-pastes</h4>
+    <p class="ev">Where: the pid→id pointer is written twice (§1); <span class="fl">parse.ts:130</span> reads whole files; <code>resolveMode</code> and the exit-file trick are each written twice (§10).</p>
+    <div class="fix"><b>Fix:</b> one pid file with two writers; read transcripts in pages instead of whole; move the duplicated helpers into one place.</div>
+  </div>
+</section>
+
+<!-- 13 -->
+<section id="s13">
+  <div class="sec-num">13</div>
+  <h2>The fix: compute once, hand it out — in the CLI <span class="badge cli">CLI</span></h2>
+  <p class="sub">Slow spots 1, 2, 4 and 5 are one problem: the live data is fetched and recomputed on every request,
+  instead of computed once and handed to whoever asks. <b>The fix belongs in the CLI</b> — once the CLI can produce and
+  push state, the extension "just groups and displays," which is the easy part.</p>
+  <ul class="tight">
+    <li><b class="k">One process parses each file once.</b> The machine-wide watcher (§8) already watches every folder — let it be the one that reads and understands the files, and let the CLI use it too (today they're separate).</li>
+    <li><b class="k">Write the result to one store others can subscribe to.</b> Use the same SQLite trick sessions already use, with a "what changed" feed. The event names (<span class="fl">events.ts:68</span>) are already the vocabulary.</li>
+    <li><b class="k">Readers subscribe; they don't start a process.</b> The CLI, the extension, and other machines all read the same feed. The 3-second poll and the per-machine process both go away.</li>
+    <li><b class="k">Each harness's format lives in one adapter.</b> The store stays format-agnostic; one adapter per harness feeds it — your "different adapters per harness" — which also removes the five-places duplication and the Codex/OpenCode id quirks.</li>
+  </ul>
+  <div class="call correct"><span class="tag">What it buys</span>
+    <p>Cost drops from "many short-lived processes re-parsing, per window, per machine, every 3s" to "parse once, then
+    everyone reads what changed." Channels 1 and 2 (§11) become one. Teams and SSH (§10) don't change — they're already fine.</p></div>
+</section>
+
+<div class="foot wrap">
+  From agents-cli @ dfe9f011 · apps/cli · apps/factory · packages/session-tracker. Every file:line was read, not guessed.
+</div>
+</div>
+
+<script>
+  (function(){
+    var root=document.documentElement, btn=document.getElementById('tg');
+    try{var pref=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;
+      root.setAttribute('data-theme', pref?'light':'dark');}catch(e){}
+    btn.addEventListener('click',function(){
+      root.setAttribute('data-theme', root.getAttribute('data-theme')==='dark'?'light':'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/agents-cli-audit.html
+++ b/docs/plans/2026-07-30/agents-cli-audit.html
@@ -438,13 +438,13 @@
       <b>duplicate <code>/etc/machine-id</code> is real and still present</b>:
       <pre style="margin:8px 0"><span class="c">$</span> ssh yosemite-s0 'hostname; cat /etc/machine-id; ip -4 addr show tailscale0'
 <span class="g">yosemite-s0</span>
-<span class="r">7af66f30966a49b6886e00e2fce4b42f</span>
-inet <span class="g">100.125.135.113</span>
+<span class="r">[redacted-machine-id]</span>
+inet <span class="g">100.x.x.x</span>
 
 <span class="c">$</span> ssh yosemite-s1 '…'
 <span class="g">yosemite-s1</span>
-<span class="r">7af66f30966a49b6886e00e2fce4b42f</span>   <span class="c">← identical</span>
-inet <span class="g">100.93.177.123</span></pre>
+<span class="r">[redacted-machine-id]</span>   <span class="c">← identical</span>
+inet <span class="g">100.x.x.x</span></pre>
       So the clone origin is confirmed and the SSH-misrouting symptom is not current — either it was transient or
       it has since been fixed. <b>The live defect is anything that keys on machine-id conflating the two boxes</b>
       (the session index carries a machine identity per transcript — see <code>machineForSessionFile</code>).

--- a/docs/plans/2026-07-30/agents-cli-audit.html
+++ b/docs/plans/2026-07-30/agents-cli-audit.html
@@ -1,0 +1,561 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents-cli — the real audit</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e8ebe6; --ink-dim:#9aa295;
+    --line:#242724; --lime:#a3e635; --lime-dim:#6f9e26; --amber:#f4bf4f; --red:#ff6b5e;
+    --cyan:#5ec7d6; --violet:#b08cff; --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;
+    --code-bg:#0d0f0d; --chip:#1a1d19; --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 30px rgba(0,0,0,.5);
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f4; --panel:#ffffff; --panel-2:#fbfcfa; --ink:#16180f; --ink-dim:#5c6356;
+    --line:#e2e6dc; --lime:#5c8a13; --lime-dim:#7fae2c; --amber:#9a6a00; --red:#c23b2e;
+    --cyan:#0f7d8c; --violet:#6d45c9; --code-bg:#f1f3ec; --chip:#eef1e8; --shadow:0 1px 0 rgba(0,0,0,.02),0 10px 30px rgba(0,0,0,.08);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
+    font-size:16px;-webkit-font-smoothing:antialiased}
+  a{color:var(--lime);text-decoration:none}
+  code,kbd,.mono{font-family:var(--mono)}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+
+  .topbar{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 88%,transparent);
+    backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .brand{font-family:var(--mono);font-weight:700;letter-spacing:.02em;font-size:15px}
+  .brand .dot{color:var(--lime)}
+  .toggle{font-family:var(--mono);font-size:13px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:8px;padding:6px 12px;cursor:pointer}
+
+  .hero{padding:58px 0 36px;border-bottom:1px solid var(--line)}
+  .kicker{font-family:var(--mono);font-size:12.5px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--lime);margin-bottom:18px}
+  h1{font-size:clamp(28px,4.3vw,46px);line-height:1.07;margin:0 0 20px;letter-spacing:-.02em;font-weight:800}
+  h1 .g{color:var(--lime)} h1 .r{color:var(--red)}
+  .lede{font-size:19px;color:var(--ink-dim);max-width:810px;margin:0 0 24px}
+  .lede b{color:var(--ink);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:9px}
+  .chip{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:999px;padding:5px 12px}
+  .chip b{color:var(--lime);font-weight:600}
+  .chip.hot b{color:var(--red)}
+
+  .alert{margin:28px 0 0;padding:20px 22px;border-radius:14px;border:1.5px solid var(--red);
+    background:color-mix(in srgb,var(--red) 8%,var(--panel));box-shadow:var(--shadow)}
+  .alert .tag{font-family:var(--mono);font-size:11.5px;letter-spacing:.14em;text-transform:uppercase;
+    font-weight:700;color:var(--red);display:block;margin-bottom:8px}
+  .alert h3{margin:0 0 8px;font-size:19px}
+  .alert p{margin:6px 0;max-width:none}
+
+  section{padding:48px 0;border-bottom:1px solid var(--line)}
+  .sec-num{font-family:var(--mono);font-size:13px;color:var(--lime);letter-spacing:.1em}
+  h2{font-size:clamp(21px,2.9vw,29px);margin:8px 0 6px;letter-spacing:-.015em;font-weight:750}
+  h3{font-size:17.5px;margin:26px 0 8px;font-weight:650}
+  .sub{color:var(--ink-dim);font-size:15.5px;max-width:850px}
+  p{max-width:850px}
+  ul.tight{max-width:850px;padding-left:18px}
+  ul.tight li{margin:7px 0}
+  .fl{font-family:var(--mono);font-size:12.5px;color:var(--cyan);background:var(--code-bg);
+    border:1px solid var(--line);border-radius:5px;padding:1px 6px;white-space:nowrap}
+  b.k{color:var(--lime)}
+
+  .call{margin:22px 0;padding:16px 18px 16px 20px;border-radius:12px;border:1px solid var(--line);
+    background:var(--panel);position:relative;box-shadow:var(--shadow)}
+  .call::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;border-radius:12px 0 0 12px}
+  .call.correct::before{background:var(--lime)}
+  .call.warn::before{background:var(--amber)}
+  .call.hot::before{background:var(--red)}
+  .call .tag{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+    font-weight:700;margin-bottom:6px;display:block}
+  .call.correct .tag{color:var(--lime)}
+  .call.warn .tag{color:var(--amber)}
+  .call.hot .tag{color:var(--red)}
+  .call p{margin:2px 0;max-width:none}
+
+  pre{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;padding:14px 16px;
+    overflow:auto;font-family:var(--mono);font-size:12.6px;line-height:1.6;box-shadow:var(--shadow)}
+  pre .c{color:var(--ink-dim)} pre .g{color:var(--lime)} pre .a{color:var(--amber)}
+  pre .r{color:var(--red)} pre .cy{color:var(--cyan)}
+
+  .scroller{overflow-x:auto}
+  table{width:100%;border-collapse:collapse;margin:18px 0;font-size:14px}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;
+    color:var(--ink-dim);font-weight:600}
+  td.n{font-family:var(--mono);text-align:right;white-space:nowrap}
+  td.n.bad{color:var(--red)} td.n.good{color:var(--lime)} td.n.mid{color:var(--amber)}
+  tr.sum td{font-weight:700;border-bottom:2px solid var(--line)}
+
+  figure{margin:26px 0}
+  figure svg{width:100%;height:auto;display:block;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  figcaption{font-size:13px;color:var(--ink-dim);margin-top:10px;font-family:var(--mono)}
+  .svg-l{font-family:var(--mono);font-size:12px;fill:var(--ink)}
+  .svg-s{font-family:var(--mono);font-size:10.5px;fill:var(--ink-dim)}
+  .box{fill:var(--panel-2);stroke:var(--line);stroke-width:1.2}
+  .box-hot{fill:var(--panel-2);stroke:var(--red);stroke-width:1.6}
+  .box-lime{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.4}
+  .edge-hot{stroke:var(--red);stroke-width:1.8;fill:none}
+
+  .fix{margin:16px 0;padding:16px 18px;background:var(--panel);border:1px solid var(--line);
+    border-radius:12px;box-shadow:var(--shadow)}
+  .fix h4{margin:0 0 6px;font-size:16.5px;display:flex;align-items:center;gap:10px}
+  .num{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);
+    font-weight:700;font-size:13px;width:26px;height:26px;border-radius:7px;flex:none}
+  .num.a{background:var(--red);color:#160a08}
+  .num.b{background:var(--amber);color:#1a1200}
+  .num.c{background:var(--lime);color:#0c1400}
+  .fix .why{font-size:14px;color:var(--ink-dim);margin:6px 0 0}
+
+  .foot{padding:36px 0 70px;color:var(--ink-dim);font-size:13px;font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div class="topbar"><div class="wrap">
+  <div class="brand">agents<span class="dot">·</span>cli <span style="color:var(--ink-dim)">/ the real audit</span></div>
+  <button class="toggle" id="tg">◐ theme</button>
+</div></div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="kicker">Five parallel audits · 5,204 runs · 1,256 transcripts · all four hosts</div>
+  <h1><span class="r">44.1%</span> of your routine runs fail. <span class="r">80.6%</span> of those failures are one thing: auth.</h1>
+  <p class="lede">You said routines fail because agents aren't logged in on other computers. That is confirmed,
+  counted, and <b>understated</b>. Across 5,204 runs on four hosts, <b>2,297 failed</b> — and
+  <b>1,742 of them (75.8%)</b> are an agent unauthenticated on a machine you don't sit at. mac-mini fails
+  <b>93.6%</b> of its runs. It fired again today at 15:00 and 16:00. <b>Nothing told you.</b></p>
+  <div class="chips">
+    <span class="chip hot">routine failures <b>2,297 / 5,204</b></span>
+    <span class="chip hot">auth share <b>80.6%</b></span>
+    <span class="chip hot">mac-mini <b>93.6% fail</b></span>
+    <span class="chip">teammate records lost <b>93.8%</b></span>
+    <span class="chip">retry logic <b>none</b></span>
+  </div>
+
+  <div class="alert">
+    <span class="tag">Live right now — verified on this machine</span>
+    <h3>Your running daemon has no Claude token. Every routine it fires today will fail.</h3>
+    <pre style="margin:10px 0 6px"><span class="c">$</span> rg -c "Loaded Claude OAuth token" ~/.agents/.cache/helpers/daemon/logs.jsonl
+<span class="r">0</span>
+<span class="c">$</span> ps -eo pid,lstart,command | grep __daemon-run
+<span class="a">24971  Thu Jul 30 17:06:44 2026  …/agents __daemon-run</span>
+<span class="c">$</span> agents secrets list | grep '^claude '
+<span class="g">claude   1   never · no prompt   2w   2h</span>   <span class="c">← the token exists. It was never loaded.</span></pre>
+    <p>The daemon reads that bundle <b>best-effort and never blocks</b> (<span class="fl">daemon.ts:315-321</span>).
+    On macOS the read “resolves broker-only from an unlocked secrets-agent and is otherwise absent”
+    (<span class="fl">daemon.ts:311-314</span>) — so a locked keychain at daemon start silently produces a
+    token-less daemon, and <b>every routine it spawns for the rest of the day dies</b> with
+    <code>"apiKeySource":"none"</code>. Restarting the daemon with the keychain unlocked is the immediate
+    unblock.</p>
+  </div>
+
+  <div class="alert" style="border-color:var(--amber);background:color-mix(in srgb,var(--amber) 8%,var(--panel))">
+    <span class="tag" style="color:var(--amber)">Needs your action — verified first-hand, keys not reproduced here</span>
+    <h3>Three live Linear API keys are sitting in 67 transcript files, on at least two machines.</h3>
+    <pre style="margin:10px 0 6px"><span class="c">$</span> rg -uu -l 'lin_api_[A-Za-z0-9_-]{20,60}' ~/.agents ~/.claude ~/.codex | wc -l
+<span class="r">67</span>      <span class="c">3 distinct keys, 48 chars each — none match PLACEHOLDER/EXAMPLE/REDACT</span>
+
+  48  .agents/.history/<b>trash</b>/versions/claude/…      <span class="c">← deleted versions, retained forever</span>
+  10  .agents/.history/versions/claude/2.1.187/…    <span class="c">← LIVE home</span>
+   3  .agents/.history/versions/claude/2.1.181/…    <span class="c">← LIVE home</span>
+   2  .agents/.history/versions/claude/2.1.207/…    <span class="c">← LIVE home</span>
+   1  .agents/.history/trash/versions/codex/…
+   1  .agents/.history/backups/claude/<b>yosemite-s1</b>/…  <span class="c">← replicated to another host</span></pre>
+    <p><b>Rotate all three in Linear.</b> That is your call, not something I should do unilaterally — and note the
+    keys are already replicated to yosemite-s1's mirror, so deleting them locally is not sufficient.</p>
+    <p style="margin-top:10px"><b class="k">This reframes the retention finding.</b> I opened this audit talking
+    about 46 GB of trash and you correctly told me storage is cheap. It is. But <b>48 of those 67 exposures are in
+    trash</b> — version homes that were deleted months ago and still hold live credentials, because nothing ever
+    reaps them. Retention is not a disk-space feature. It is a <b>credential-lifetime</b> feature.</p>
+  </div>
+</header>
+
+<!-- 1 -->
+<section id="s1">
+  <div class="sec-num">01</div>
+  <h2>The number, per host</h2>
+  <p class="sub">Every <code>meta.json</code> under <code>~/.agents/.history/runs/</code>, aggregated locally and
+  over <code>agents ssh</code> on all four scheduler hosts.</p>
+  <div class="scroller">
+  <table>
+    <tr><th>Host</th><th>Runs</th><th>Completed</th><th>Failed</th><th>Fail rate</th><th>Of failures, auth</th></tr>
+    <tr><td>mac-mini</td><td class="n">264</td><td class="n">17</td><td class="n bad">247</td><td class="n bad">93.6%</td><td class="n bad">61.1%</td></tr>
+    <tr><td>yosemite-s0</td><td class="n">2,723</td><td class="n">1,264</td><td class="n bad">1,453</td><td class="n bad">53.4%</td><td class="n bad">91.0%</td></tr>
+    <tr><td>zion (your laptop)</td><td class="n">553</td><td class="n">323</td><td class="n mid">226</td><td class="n mid">40.9%</td><td class="n mid">48.7%</td></tr>
+    <tr><td>yosemite-s1</td><td class="n">1,664</td><td class="n">1,289</td><td class="n mid">371</td><td class="n mid">22.3%</td><td class="n bad">72.5%</td></tr>
+    <tr class="sum"><td>fleet</td><td class="n">5,204</td><td class="n">2,893</td><td class="n bad">2,297</td><td class="n bad">44.1%</td><td class="n bad">80.6%</td></tr>
+  </table>
+  </div>
+
+  <h3>What the 2,297 failures actually say</h3>
+  <pre><span class="r">1002</span>  Failed to authenticate. API Error: 401 OAuth access token has been revoked.   <span class="c">43.6%</span>
+<span class="r"> 422</span>  Not logged in · Please run /login                                            <span class="c">18.4%</span>
+<span class="r"> 354</span>  Failed to authenticate. API Error: 401 Invalid authentication credentials    <span class="c">15.4%</span>
+<span class="r">  57</span>  Failed to authenticate: OAuth session expired and could not be refreshed      <span class="c"> 2.5%</span>
+<span class="r">  17</span>  Your organization has disabled Claude subscription access                     <span class="c"> 0.7%</span>
+      <b>AUTH SUBTOTAL 1852 — 80.6% of all failures</b>
+<span class="a"> 193</span>  You've hit your weekly limit                                                  <span class="c"> 8.4%</span>
+  ~52  connection closed / ECONNRESET / 500 / 529                                     <span class="c"> 2.3%</span>
+   38  no version of claude configured · version not installed · entrypoint missing   <span class="c"> 1.7%</span></pre>
+
+  <p>They fire in <b>synchronized bursts</b> — every routine scheduled in a given minute dying identically:</p>
+  <pre>2026-07-22T16-00-00  review-open-prs           exit 1
+2026-07-22T16-00-00  harness-capability-watch  exit 1
+2026-07-22T16-00-00  git-hygiene               exit 1
+2026-07-22T16-00-00  linkedin-scout            exit 1</pre>
+  <p>66 of zion's 107 login failures happened since 2026-07-20. It is getting worse.</p>
+</section>
+
+<!-- 2 -->
+<section id="s2">
+  <div class="sec-num">02</div>
+  <h2>The causal chain</h2>
+  <p class="sub">Four independent design gaps compose. Any one of them alone would be survivable.</p>
+
+  <figure>
+  <svg viewBox="0 0 1040 380" role="img" aria-label="the auth failure chain">
+    <text x="20" y="26" class="svg-l" fill="var(--red)">How one logged-out box becomes 1,742 silent failures</text>
+
+    <rect x="20" y="50" width="228" height="70" rx="9" class="box-hot"/>
+    <text x="134" y="74" text-anchor="middle" class="svg-s">1 · CREDENTIAL IS SCOPED</text>
+    <text x="134" y="90" text-anchor="middle" class="svg-s">CLAUDE_CONFIG_DIR per version</text>
+    <text x="134" y="105" text-anchor="middle" class="svg-s">→ hashed Keychain item</text>
+
+    <rect x="272" y="50" width="228" height="70" rx="9" class="box-hot"/>
+    <text x="386" y="74" text-anchor="middle" class="svg-s">2 · NOTHING CARRIES IT</text>
+    <text x="386" y="90" text-anchor="middle" class="svg-s">carryForwardAuthFiles skips claude</text>
+    <text x="386" y="105" text-anchor="middle" class="svg-s">shims.ts never touches Keychain</text>
+
+    <rect x="524" y="50" width="228" height="70" rx="9" class="box-hot"/>
+    <text x="638" y="74" text-anchor="middle" class="svg-s">3 · NO PREFLIGHT</text>
+    <text x="638" y="90" text-anchor="middle" class="svg-s">no dispatch path imports</text>
+    <text x="638" y="105" text-anchor="middle" class="svg-s">auth-health — ever</text>
+
+    <rect x="776" y="50" width="228" height="70" rx="9" class="box-hot"/>
+    <text x="890" y="74" text-anchor="middle" class="svg-s">4 · NO DETECTION</text>
+    <text x="890" y="90" text-anchor="middle" class="svg-s">runner/scheduler match</text>
+    <text x="890" y="105" text-anchor="middle" class="svg-s">zero on /login|auth/</text>
+
+    <path class="edge-hot" d="M248,85 L270,85"/>
+    <path class="edge-hot" d="M500,85 L522,85"/>
+    <path class="edge-hot" d="M752,85 L774,85"/>
+
+    <rect x="272" y="160" width="480" height="58" rx="9" class="box"/>
+    <text x="512" y="182" text-anchor="middle" class="svg-s">the agent DOES emit a machine-readable marker:</text>
+    <text x="512" y="200" text-anchor="middle" class="svg-l" fill="var(--amber)">"error":"authentication_failed"  ·  "terminal_reason":"api_error"</text>
+    <path class="edge-hot" d="M890,120 L890,190 L754,190"/>
+    <text x="770" y="150" class="svg-s" fill="var(--red)">discarded</text>
+
+    <rect x="272" y="248" width="480" height="46" rx="9" class="box-hot"/>
+    <text x="512" y="268" text-anchor="middle" class="svg-s">status = exitCode === 0 ? 'completed' : 'failed'   (runner.ts:539)</text>
+    <text x="512" y="284" text-anchor="middle" class="svg-s">a logged-out agent is byte-identical to a crash</text>
+    <path class="edge-hot" d="M512,218 L512,246"/>
+
+    <rect x="180" y="322" width="300" height="42" rx="9" class="box-hot"/>
+    <text x="330" y="342" text-anchor="middle" class="svg-s">no retry exists — anywhere</text>
+    <text x="330" y="357" text-anchor="middle" class="svg-s">only a rate-limit cascade, foreground-only</text>
+    <rect x="544" y="322" width="300" height="42" rx="9" class="box-hot"/>
+    <text x="694" y="342" text-anchor="middle" class="svg-s">no alert — daemon logs only 'spawned'</text>
+    <text x="694" y="357" text-anchor="middle" class="svg-s">1 failure line in a 1.9 MB log, from May</text>
+    <path class="edge-hot" d="M420,294 L330,320"/>
+    <path class="edge-hot" d="M604,294 L694,320"/>
+  </svg>
+  <figcaption>Fig 1 — the chain. The agent reports its own auth failure in structured form; the runner throws it away and records an exit code.</figcaption>
+  </figure>
+
+  <h3>Gap 1+2 — why the credential vanishes</h3>
+  <p><span class="fl">shims.ts:281-284</span> scopes <code>CLAUDE_CONFIG_DIR</code> to the selected version home,
+  deliberately, "so switching versions also switches the live Claude account."
+  <span class="fl">usage.ts:1259-1267</span> then derives the Keychain service by hashing that directory:
+  <code>Claude Code-credentials-&lt;sha256(configDir)[0:8]&gt;</code>. And
+  <span class="fl">shims.ts:1326-1328</span> <code>carryForwardAuthFiles</code> only acts on agents declaring
+  <code>authFiles</code> — antigravity, kimi, droid. <b>Claude is not one</b>, asserted by its own test
+  (<span class="fl">shims.auth-carry.test.ts:309-315</span>). <code>shims.ts</code> never touches the Keychain at all.</p>
+  <div class="call hot"><span class="tag">The unprovoked logouts</span>
+    <p><span class="fl">versions.ts:2254-2261</span>: when the health check finds no runnable version it installs
+    <code>latest</code> and calls <code>setGlobalDefault</code>. That runs unattended <b>every 6 hours</b>
+    (<span class="fl">daemon.ts:614-615</span>). New version dir → new empty home → new Keychain scope. You get
+    logged out by a background process at a time uncorrelated with anything you did.</p></div>
+
+  <h3>Gap 3 — the sandbox has no credential to give</h3>
+  <p>Routines run in a sandbox overlay HOME by default (<span class="fl">runner.ts:612</span>). Building it,
+  <code>generateClaudeConfig</code> (<span class="fl">sandbox.ts:174-251</span>) writes <b>only</b>
+  <code>settings.json</code> — no <code>.credentials.json</code>, no <code>oauthAccount</code>. <code>HOME</code>
+  is replaced (<span class="fl">sandbox.ts:74-76</span>) and the env is stripped to an allowlist whose single
+  credential entry is <code>CLAUDE_CODE_OAUTH_TOKEN</code> (<span class="fl">sandbox.ts:50-55</span>) — the token
+  your daemon never loaded. <b>22 of your 27 zion routine YAMLs now carry <code>sandbox: false</code></b> as a
+  workaround, which inherits the same problem plus the expiry the source itself names.</p>
+
+  <h3>It is not only Claude — the same mechanism in three more CLIs</h3>
+  <p>The fifth audit found the identical <b>single-use refresh-token rotation</b> failure outside Claude, which
+  makes it a systemic pattern rather than a Claude quirk:</p>
+  <ul class="tight">
+    <li><b class="k">Codex</b>, mac-mini — <code>"Your refresh token has already been used to generate a new
+      access token." code: refresh_token_reused</code>, which broke every hourly OpenClaw cron. With a telling
+      nuance on recurrence: <em>"standalone codex CLI auth is healthy… openclaw's own codex auth is broken — it
+      uses a separate codex auth inside the openclaw home."</em> Same credential, two homes, one rotates the
+      other out.</li>
+    <li><b class="k">Droid</b>, zion, <b>still open</b> — <code>WorkOS token refresh failed permanently …
+      {"error":"invalid_grant","error_description":"Refresh token already exchanged."}</code></li>
+    <li><b class="k">Grok and Kimi are logged out on m1–m6 and mac-mini</b> — <code>Waiting for
+      authorization...</code> and <code>No model configured. Run `kimi` and use /login</code>. These keep no
+      transcripts of their own, so their failures are recorded in the <em>dispatching</em> Claude session — which
+      is why a naive search of <code>~/.grok</code> and <code>~/.kimi-code</code> finds nothing and reads as
+      "clean." The audit caught and corrected that error in its own earlier pass.</li>
+    <li><b class="k">68 <code>Claude Code-credentials-&lt;hash&gt;</code> keychain slots exist; 22 of 73
+      host×agent×version slots are currently expired.</b> That is the per-version scoping problem from Gap 1,
+      measured directly.</li>
+  </ul>
+  <div class="call warn"><span class="tag">Adjacent, currently broken, worth knowing</span>
+    <p><code>npm whoami</code> fails on <b>all four hosts</b> (<code>ENEEDAUTH</code> on zion/s0/s1,
+    <code>E401</code> on mac-mini) with <code>agents secrets list</code> showing <code>npmjs.com 0 keys</code> —
+    the bundle whose passphrase was lost. <code>~/.rush/user.yaml</code> had an <code>expires_at</code> ~51
+    minutes in the past with no auto-refresh, while <code>rush daemon status</code> still reported <em>"running,
+    uptime 11h 42m, DB ok"</em> — the same healthy-while-dead reporting pattern as §03. And <b>hivemind fired
+    4,230 times and failed every one</b>; <code>hivemind login</code> was never executed once in the entire
+    archive.</p></div>
+  <div class="call correct"><span class="tag">Two fixes that provably worked headlessly — reuse these</span>
+    <p><code>agents secrets exec github.com --keys GH_TOKEN -- … | gh auth login --with-token</code> per host
+    fixed <code>gh</code> across m0–m6. And <code>agents apply --only login -f fleet_droid.yaml -y</code>
+    produced <em>"10/10 raw-droid PONG"</em>. Both are headless, no biometric — evidence that the fleet auth
+    problem is largely automatable with tools that already exist.</p></div>
+
+  <h3>Gap 4 — nothing looks</h3>
+  <p><code>rg -i -E "login|auth" lib/runner.ts lib/scheduler.ts lib/overdue.ts</code> returns <b>zero hits</b>.
+  The only stdout scan on failure is <code>detectRateLimit</code>. And no dispatch path — <code>exec.ts</code>,
+  <code>hosts/*</code>, <code>teams/*</code>, <code>runner.ts</code> — imports <code>auth-health</code> at all.
+  The remote gate (<span class="fl">ready.ts:155-158</span>) checks the agent is <em>installed</em> with a bare
+  <code>new RegExp(\`\\b${agent}\\b\`,'i')</code> against <code>agents view</code> output. It reads the word
+  “claude”, not its sign-in state.</p>
+</section>
+
+<!-- 3 -->
+<section id="s3">
+  <div class="sec-num">03</div>
+  <h2>Why you never found out</h2>
+  <ul class="tight">
+    <li><b class="k">The daemon never logs a failed run.</b> One failure line in a 1.9 MB log, a spawn
+      <code>ENOEXEC</code> from May. <span class="fl">daemon.ts:361-367</span> wraps only the spawn. No feed
+      entry, no mailbox, no notification — <code>lib/feed.ts</code> is not imported by <code>runner.ts</code>,
+      <code>routines.ts</code>, <code>scheduler.ts</code>, or <code>daemon.ts</code>.</li>
+    <li><b class="k"><code>agents routines run</code> exits 0 on failure</b>
+      (<span class="fl">commands/routines.ts:878-892</span>), and <code>--json</code> returns
+      <code>ok: true</code> regardless (<span class="fl">:867-875</span>).</li>
+    <li><b class="k">The one visible signal reads the wrong machine.</b> The <code>Last Status</code> column comes
+      from <code>getLatestRun</code> → <code>getJobRunsDir</code> → <b>the local archive only</b>
+      (<span class="fl">routines.ts:769-772, 802</span>). Proven divergence in both directions: zion shows
+      <code>security-sweep … failed</code> while its real last run on yosemite-s0 completed with exit 0; and
+      <code>review-open-prs</code> genuinely failed on yosemite-s0 at 16:00 today — invisible from zion.</li>
+    <li><b class="k">The failure becomes the report, then the next prompt.</b>
+      <code>extractAndSaveReport</code> runs on the failure branch too (<span class="fl">runner.ts:774</span>) and
+      takes the last assistant text unconditionally, never checking <code>is_error</code>
+      (<span class="fl">:1156-1199</span>). <b>107 zion <code>report.md</code> files literally contain
+      “Not logged in · Please run /login” as the routine's report</b> — and that string is then substituted into
+      the <em>next</em> run's prompt via <code>{last_report}</code> (<span class="fl">routines.ts:712-723</span>)
+      with no status gate.</li>
+    <li><b class="k">No retry, and catchup can't help.</b> The only cascade is rate-limit-gated and
+      foreground-only (<span class="fl">runner.ts:744-748</span>); the detached daemon path says so outright
+      (<span class="fl">:969-971</span>). Catchup compares <code>startedAt</code> only and never reads
+      <code>status</code> (<span class="fl">overdue.ts:79-83</span>) — a run that started and died counts as “ran”.</li>
+  </ul>
+  <div class="call warn"><span class="tag">You already built the missing piece</span>
+    <p>mac-mini output contains <code>[watchdog] PROBLEM doc-gaps-agents: last run FAILED on yosemite-s0</code>
+    — a hand-rolled watchdog doing the alerting the CLI does not do. That is the feature request, already
+    specified by you, in production.</p></div>
+</section>
+
+<!-- 4 -->
+<section id="s4">
+  <div class="sec-num">04</div>
+  <h2>Teams: the agents work, the bookkeeping loses them</h2>
+  <p class="sub">Teammates are not the problem — <b>87% reach a clean terminal state</b>. The orchestration layer
+  destroys the record of it.</p>
+  <ul class="tight">
+    <li><b class="k">93.8% of teammate records are zero bytes</b> — 152 of 162 <code>meta.json</code>. And
+      meta.json is newer than stdout.log in <b>152 of 152</b> cases, so truncation happens on the <em>read</em>
+      path, after the work finished. The only 3 non-empty records were written by the auditor's own
+      <code>agents teams status</code> calls. <b>The record exists only while you are looking at it.</b></li>
+    <li>It cascades: <span class="fl">agents.ts:1477-1478</span> skips cleanup for a null record (86 MB accreted,
+      median age 56 days against a 7-day policy); 17 of 20 teams render <code>(no teammates yet)</code>; and the
+      scheduler's load counter reads 0.</li>
+    <li><b class="k">Completion is stamped when you look, not when it happens.</b>
+      <span class="fl">tasks.ts:89-95</span> sets <code>finishedAt</code> at reconcile time — <b>214 dispatches
+      all “finished” in the same minute</b>, top-10 minutes = 71.4% of all finishes.
+      <span class="fl">reconcile.ts:4-11</span> documents the bug in its own header.</li>
+    <li><b class="k">17 zombie records</b>, up to 18.2 days; 5 probed, all dead. Your live
+      <code>agentscli-w1</code> reports <b>RUNNING · 13,257 minutes</b> with <code>pid = None</code>.</li>
+    <li><b class="k">71.5% of teams declare no device pool</b> → <span class="fl">scheduler.ts:87</span> returns
+      local → they run on your laptop. When a pool exists, <code>pickLeastLoaded</code> counts roster entries
+      (which load as null), so load reads 0 and <code>devices[0]</code> wins repeatedly. No interactive-device
+      exclusion exists.</li>
+    <li><b class="k">Spin-up is strictly sequential</b> — <span class="fl">agents.ts:2151/2173</span> awaits a
+      full SSH chain per teammate. Measured launch gaps <b>24.5s–1,680s</b>; median start → first PR
+      <b>21 minutes</b>; <b>17.9 <code>teams status</code> polls per run</b>, babysitting up to 21.2 hours.</li>
+    <li>Of 63 classifiable remote dispatch failures, <b>24 (38.1%) died on credentials, not the task</b>.</li>
+  </ul>
+  <div class="call correct"><span class="tag">Three of my own premises were wrong</span>
+    <p>The “11 teammates, all PRs unmerged” incident <b>does not exist</b> — every hit was your own CLAUDE.md
+    rule text being injected into sessions. Stranded PRs are a <em>single-agent</em> problem (32 Stop-hook fires
+    across 9 sessions, none of which ran a teams command; 3 still open). Worktree collisions are 1 in 182.
+    Teams merge fine: <b>65 MERGED / 1 OPEN</b> of 77 PRs in one cut, 159/0 in another.</p></div>
+</section>
+
+<!-- 5 -->
+<section id="s5">
+  <div class="sec-num">05</div>
+  <h2>Fleet: registered ≠ reachable ≠ usable</h2>
+  <ul class="tight">
+    <li><b class="k">A healthy box can be a hole in the fleet.</b> <code>yosemite-s1</code> showed claude
+      <code>0/4</code> while <code>up 38 days, load average 0.20</code>. Not down — <b>logged out</b>. Blast
+      radius: 15 routines showing <code>failed</code>, appearing intermittent only because the pool
+      round-robins. <code>m1</code>–<code>m6</code> carry exactly one working harness (codex); claude was never
+      configured on any of them.</li>
+    <li><b class="k">The cost is irreducible and large.</b> <span class="fl">remote-login.ts:4-7</span>: copying
+      one OAuth file across N boxes is <em>“fatal — a shared refresh token rotates server-side on first refresh
+      and invalidates the other copies (droid collapsed 10 boxes → 1 overnight)”</em>. So the real requirement is
+      one interactive login per <b>(agent × box)</b> — up to 63 for the yosemite subset.</li>
+    <li><b class="k">The command that makes that bearable is invisible.</b> <code>agents devices login</code>
+      drives every box's device-code flow over SSH and collects the codes into one browser page. It has
+      <b>0 uses across 1,256 transcripts</b>, because <code>agents --help</code> lists none of
+      <code>devices</code>/<code>ssh</code>/<code>hosts</code>/<code>apply</code>. The <code>fleet:onboard</code>
+      skill's first instruction is “read <code>agents --help</code>” — a map with no onboarding command on it.</li>
+    <li><b class="k">Actively harmful path:</b> droid is in <code>FLEET_AUTH_FILES</code>
+      (<span class="fl">auth-sync.ts:39-42</span>) but absent from <code>apply.ts</code> — so
+      <code>agents apply</code> will copy the exact credential class that collapsed 10 boxes. Filed RUSH-1958.</li>
+    <li><b class="k">Never automated, though it could be:</b> SSH key push (no <code>authorized_keys</code> code
+      anywhere in <code>apps/cli/src</code>; 86 failures across 40 sessions on 30 consecutive days) and config
+      drift (detected 407 times across 160 sessions, up to 304 commits behind, acted on never — your
+      <code>~/.agents</code> is 4 commits behind as I write this).</li>
+    <li><b class="k">Duplicate machine-id — verified, but narrower than the audit claimed.</b> I probed both boxes
+      directly. The audit's headline (“<code>ssh yosemite-s0</code> lands on s1 — you never leave s1”)
+      <b>does not reproduce today</b>: hostnames and Tailscale IPs are distinct and SSH routes correctly. But the
+      <b>duplicate <code>/etc/machine-id</code> is real and still present</b>:
+      <pre style="margin:8px 0"><span class="c">$</span> ssh yosemite-s0 'hostname; cat /etc/machine-id; ip -4 addr show tailscale0'
+<span class="g">yosemite-s0</span>
+<span class="r">7af66f30966a49b6886e00e2fce4b42f</span>
+inet <span class="g">100.125.135.113</span>
+
+<span class="c">$</span> ssh yosemite-s1 '…'
+<span class="g">yosemite-s1</span>
+<span class="r">7af66f30966a49b6886e00e2fce4b42f</span>   <span class="c">← identical</span>
+inet <span class="g">100.93.177.123</span></pre>
+      So the clone origin is confirmed and the SSH-misrouting symptom is not current — either it was transient or
+      it has since been fixed. <b>The live defect is anything that keys on machine-id conflating the two boxes</b>
+      (the session index carries a machine identity per transcript — see <code>machineForSessionFile</code>).
+      Worth a <code>systemd-machine-id-setup --commit</code> on one of them regardless.</li>
+    <li><b class="k">Reachability is genuinely flaky, independently observed.</b> Your session-start context listed
+      <code>yosemite-s1</code> as <b>offline</b>, and my first blocking SSH probe timed out on both boxes past
+      2 minutes — yet a bounded retry minutes later reached both instantly. That intermittency is itself the
+      mechanism that makes routine failures look random.</li>
+  </ul>
+</section>
+
+<!-- 6 -->
+<section id="s6">
+  <div class="sec-num">06</div>
+  <h2>Performance, correctly ranked</h2>
+  <p class="sub">You were right that I started on the wrong axis. Here is the latency work, in its proper place —
+  real, worth fixing, and second to correctness.</p>
+  <div class="scroller">
+  <table>
+    <tr><th>Finding</th><th>Measured</th><th>Fix</th></tr>
+    <tr><td><code>--active</code> is <b>not</b> re-parsing your corpus</td><td class="n good">128 KB<br>tail/session</td><td>none needed — <code>tail.ts:69</code> is well built</td></tr>
+    <tr><td><code>--active</code> imports <code>discover.ts</code> (3,038 lines) it never calls, for one 28-line helper</td><td class="n bad">123 ms<br>every call</td><td>move <code>buildClaudeLabelMap</code> out — one import</td></tr>
+    <tr><td><code>getSessionRoots()</code> stats 26 roots, 14 of them stale version homes</td><td class="n bad">127 ms<br>every call</td><td>memoize on versions-dir mtime</td></tr>
+    <tr><td>Eager module load before argv dispatch — <code>run --help</code> prints a string</td><td class="n bad">0.57–0.97 s<br>per spawn</td><td>lazy <code>import()</code> per subcommand</td></tr>
+    <tr><td>SQLite</td><td class="n good">3.5 ms</td><td>not a problem — stop blaming it</td></tr>
+    <tr><td>Search returns nothing: <code>MATCH 'login'</code> = 1,247 hits in SQL, 0 through the CLI</td><td class="n bad">760 MB<br>index, dead</td><td><code>searchContentIndex</code> (<code>discover.ts:351</code>) intersects with a pre-computed page — let search drive the query</td></tr>
+  </table>
+  </div>
+  <p>Note the convergence: version-home sprawl causes the 127 ms roots walk, the 26 FSEvents watchers,
+  <em>and</em> the Keychain-scope logout. And the daemon's 6-hourly auto-install <b>creates more version homes</b>.
+  The performance problem and the auth problem are the same root cause feeding each other.</p>
+</section>
+
+<!-- 7 -->
+<section id="s7">
+  <div class="sec-num">07</div>
+  <h2>What to fix, in order</h2>
+
+  <div class="fix"><h4><span class="num a">0</span>Rotate the three exposed Linear keys — then make retention a security control</h4>
+    <p class="why">67 files, two machines, 48 of them in trash that nothing reaps. Rotation is yours to do.
+    The systemic fix is the reaper I argued for on disk-space grounds and should have argued for here: a
+    retention policy on <code>trash/</code> and <code>versions/</code> bounds how long a leaked credential
+    survives. Consider also a secret-scrub on transcript write — the agent's own output is the leak vector.</p></div>
+
+  <div class="fix"><h4><span class="num a">1</span>Restart the daemon with the keychain unlocked</h4>
+    <p class="why">Today, one command. Your routines are failing right now for this reason. Then make it
+    non-silent: if <code>readDaemonClaudeOAuthToken()</code> returns nothing, <b>log an ERROR and notify</b>
+    rather than starting a daemon that will fail every job it launches.</p></div>
+
+  <div class="fix"><h4><span class="num a">2</span>Detect auth failure — the agent already tells you</h4>
+    <p class="why">The runner receives <code>"error":"authentication_failed"</code> and
+    <code>"terminal_reason":"api_error"</code> and discards both. Classify them next to
+    <code>detectRateLimit</code>, mark the run <code>failed:auth</code>, and <b>stop writing the login prompt into
+    <code>report.md</code> and the next run's prompt</b>. Smallest change with the largest blast radius.</p></div>
+
+  <div class="fix"><h4><span class="num a">3</span>Auth preflight before dispatch</h4>
+    <p class="why">Add a gate to <code>ensureHostReady</code> — the remote
+    <code>agents fleet ping --local --json</code> already returns exactly the rows needed
+    (<code>commands/ssh.ts:467-472</code>), and <code>ready.ts</code> already makes an SSH round-trip. Fail loudly
+    on <code>revoked</code>. Extend to teams dispatch and routines, and remove the <code>!hostName</code> skip at
+    <code>teams.ts:1437</code>. This converts 1,742 silent failures into one actionable message.</p></div>
+
+  <div class="fix"><h4><span class="num b">4</span>Alert on failure, and read the right machine's status</h4>
+    <p class="why">Wire <code>feed.ts</code> (or your Telegram path) into the failure branch, and make
+    <code>Last Status</code> query the host the routine actually ran on rather than the local archive. You already
+    hand-rolled this watchdog on mac-mini — promote it into the product.</p></div>
+
+  <div class="fix"><h4><span class="num b">5</span>One Claude credential scope per account, not per version</h4>
+    <p class="why">Either stop scoping <code>CLAUDE_CONFIG_DIR</code> per version for the <em>credential</em>
+    (keep per-version config, share one credential scope — the correct model), or add a Keychain carry beside
+    <code>carryForwardAuthFiles</code>. And delete the <code>latest</code> auto-install branch at
+    <code>versions.ts:2254-2261</code> so a background heal can never re-point your default.</p></div>
+
+  <div class="fix"><h4><span class="num b">6</span>Fix the teammate record write, then the placement</h4>
+    <p class="why">The zero-byte truncation on the read path invalidates cleanup, display, <em>and</em> the
+    scheduler's load counter. Fixing it fixes three symptoms. Then add an interactive-device exclusion so 71.5%
+    of teams stop landing on your laptop.</p></div>
+
+  <div class="fix"><h4><span class="num c">7</span>Surface the fleet commands, then the latency work</h4>
+    <p class="why"><code>devices</code>/<code>ssh</code>/<code>hosts</code>/<code>apply</code> in
+    <code>agents --help</code> — a command with 0 uses in 1,256 transcripts is a discoverability bug, not a
+    missing feature. Then §06: the two import fixes, the roots memoization, and the search intersection.</p></div>
+</section>
+
+<div class="foot wrap">
+  Five parallel audits against the live system on zion, 2026-07-30, agents-cli @ 827565549.
+  5,204 routine runs across four hosts · 1,256 transcripts · 162 teammate records · 77 PRs state-checked.
+  <b>Where the audits disagree, and a methodology warning.</b> The routines audit counts terminal signals in run
+  <code>meta.json</code> across four hosts (422 <code>Not logged in</code> of 2,297 failures = 18.4%). The
+  session-mining audit counts deduped <em>sessions</em> over the transcript corpus (387 sessions, 118 routine
+  runs, "51% of routine failures"). Those denominators are not the same population and should not be blended —
+  prefer the run-archive figure for fleet failure <em>rate</em>, the session figure for how often you
+  <em>encountered</em> it. Both agree on the cause. Separately:
+  <code>~/.agents/.gitignore</code> contains <code>.history/</code>, and ripgrep honors it even with no
+  <code>.git</code> present — so any search of <code>~/.agents</code> without <code>-uu</code> silently skips the
+  entire corpus and returns a confident zero. That trap produced a wrong "0 exposed keys" in my own first-pass
+  verification before I caught it. It applies to the CLI's own tooling too.
+  All five audits reported.
+  The s0/s1 machine-id duplication in §05 was verified first-hand; the audit's stronger SSH-misrouting claim did
+  not reproduce and has been corrected in place.
+</div>
+</div>
+<script>
+  (function(){
+    var root=document.documentElement, btn=document.getElementById('tg');
+    try{var pref=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;
+      root.setAttribute('data-theme', pref?'light':'dark');}catch(e){}
+    btn.addEventListener('click',function(){
+      root.setAttribute('data-theme', root.getAttribute('data-theme')==='dark'?'light':'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/agents-cli-auth-plan.html
+++ b/docs/plans/2026-07-30/agents-cli-auth-plan.html
@@ -1,0 +1,518 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents-cli — credential subsystem remediation plan</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e8ebe6; --ink-dim:#9aa295;
+    --line:#242724; --lime:#a3e635; --lime-dim:#6f9e26; --amber:#f4bf4f; --red:#ff6b5e;
+    --cyan:#5ec7d6; --violet:#b08cff; --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;
+    --code-bg:#0d0f0d; --chip:#1a1d19; --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 30px rgba(0,0,0,.5);
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f4; --panel:#ffffff; --panel-2:#fbfcfa; --ink:#16180f; --ink-dim:#5c6356;
+    --line:#e2e6dc; --lime:#5c8a13; --lime-dim:#7fae2c; --amber:#9a6a00; --red:#c23b2e;
+    --cyan:#0f7d8c; --violet:#6d45c9; --code-bg:#f1f3ec; --chip:#eef1e8; --shadow:0 1px 0 rgba(0,0,0,.02),0 10px 30px rgba(0,0,0,.08);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
+    font-size:16px;-webkit-font-smoothing:antialiased}
+  a{color:var(--lime);text-decoration:none}
+  code,kbd,.mono{font-family:var(--mono)}
+  .wrap{max-width:1100px;margin:0 auto;padding:0 24px}
+
+  .topbar{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 88%,transparent);
+    backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .brand{font-family:var(--mono);font-weight:700;letter-spacing:.02em;font-size:15px}
+  .brand .dot{color:var(--lime)}
+  .toggle{font-family:var(--mono);font-size:13px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:8px;padding:6px 12px;cursor:pointer}
+
+  .hero{padding:58px 0 34px;border-bottom:1px solid var(--line)}
+  .kicker{font-family:var(--mono);font-size:12.5px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--lime);margin-bottom:18px}
+  h1{font-size:clamp(28px,4.2vw,44px);line-height:1.08;margin:0 0 18px;letter-spacing:-.02em;font-weight:800}
+  h1 .g{color:var(--lime)} h1 .r{color:var(--red)}
+  .lede{font-size:18.5px;color:var(--ink-dim);max-width:840px;margin:0 0 22px}
+  .lede b{color:var(--ink);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:9px}
+  .chip{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:999px;padding:5px 12px}
+  .chip b{color:var(--lime);font-weight:600}
+  .chip.hot b{color:var(--red)}
+
+  section{padding:46px 0;border-bottom:1px solid var(--line)}
+  .sec-num{font-family:var(--mono);font-size:13px;color:var(--lime);letter-spacing:.1em}
+  h2{font-size:clamp(21px,2.8vw,28px);margin:8px 0 6px;letter-spacing:-.015em;font-weight:750}
+  h3{font-size:17px;margin:26px 0 8px;font-weight:650}
+  .sub{color:var(--ink-dim);font-size:15.5px;max-width:860px}
+  p{max-width:860px}
+  ul.tight{max-width:860px;padding-left:18px}
+  ul.tight li{margin:7px 0}
+  .fl{font-family:var(--mono);font-size:12.5px;color:var(--cyan);background:var(--code-bg);
+    border:1px solid var(--line);border-radius:5px;padding:1px 6px;white-space:nowrap}
+  b.k{color:var(--lime)}
+
+  .call{margin:20px 0;padding:16px 18px 16px 20px;border-radius:12px;border:1px solid var(--line);
+    background:var(--panel);position:relative;box-shadow:var(--shadow)}
+  .call::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;border-radius:12px 0 0 12px}
+  .call.correct::before{background:var(--lime)}
+  .call.warn::before{background:var(--amber)}
+  .call.hot::before{background:var(--red)}
+  .call .tag{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+    font-weight:700;margin-bottom:6px;display:block}
+  .call.correct .tag{color:var(--lime)}
+  .call.warn .tag{color:var(--amber)}
+  .call.hot .tag{color:var(--red)}
+  .call p{margin:2px 0;max-width:none}
+
+  pre{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;padding:14px 16px;
+    overflow:auto;font-family:var(--mono);font-size:12.6px;line-height:1.6;box-shadow:var(--shadow)}
+  pre .c{color:var(--ink-dim)} pre .g{color:var(--lime)} pre .a{color:var(--amber)}
+  pre .r{color:var(--red)} pre .cy{color:var(--cyan)}
+
+  .scroller{overflow-x:auto}
+  table{width:100%;border-collapse:collapse;margin:18px 0;font-size:13.6px}
+  th,td{text-align:left;padding:9px 11px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;
+    color:var(--ink-dim);font-weight:600}
+  td.n{font-family:var(--mono);text-align:right;white-space:nowrap}
+  .v-proven{color:var(--lime);font-family:var(--mono);font-size:11.5px;font-weight:700}
+  .v-retract{color:var(--red);font-family:var(--mono);font-size:11.5px;font-weight:700}
+  .v-untested{color:var(--amber);font-family:var(--mono);font-size:11.5px;font-weight:700}
+
+  figure{margin:26px 0}
+  figure svg{width:100%;height:auto;display:block;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  figcaption{font-size:13px;color:var(--ink-dim);margin-top:10px;font-family:var(--mono)}
+  .svg-l{font-family:var(--mono);font-size:12px;fill:var(--ink)}
+  .svg-s{font-family:var(--mono);font-size:10.5px;fill:var(--ink-dim)}
+  .box{fill:var(--panel-2);stroke:var(--line);stroke-width:1.2}
+  .box-hot{fill:var(--panel-2);stroke:var(--red);stroke-width:1.6}
+  .box-lime{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.4}
+  .edge{stroke:var(--ink-dim);stroke-width:1.3;fill:none}
+  .edge-hot{stroke:var(--red);stroke-width:1.8;fill:none}
+  .edge-lime{stroke:var(--lime);stroke-width:1.6;fill:none}
+
+  .fix{margin:16px 0;padding:16px 18px;background:var(--panel);border:1px solid var(--line);
+    border-radius:12px;box-shadow:var(--shadow)}
+  .fix h4{margin:0 0 6px;font-size:16px;display:flex;align-items:center;gap:10px}
+  .num{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);
+    font-weight:700;font-size:13px;width:26px;height:26px;border-radius:7px;flex:none}
+  .num.a{background:var(--red);color:#160a08}
+  .num.b{background:var(--amber);color:#1a1200}
+  .num.c{background:var(--lime);color:#0c1400}
+  .fix .why{font-size:14px;color:var(--ink-dim);margin:6px 0 0;max-width:none}
+
+  .ask{border:1.5px solid var(--violet);background:color-mix(in srgb,var(--violet) 8%,var(--panel));
+    border-radius:14px;padding:18px 20px;margin:18px 0;box-shadow:var(--shadow)}
+  .ask h4{margin:0 0 6px;font-size:16.5px;color:var(--violet)}
+  .ask p{margin:4px 0;max-width:none}
+
+  .foot{padding:36px 0 70px;color:var(--ink-dim);font-size:13px;font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div class="topbar"><div class="wrap">
+  <div class="brand">agents<span class="dot">·</span>cli <span style="color:var(--ink-dim)">/ credential subsystem — remediation plan</span></div>
+  <button class="toggle" id="tg">◐ theme</button>
+</div></div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="kicker">Remediation plan · every claim carries the command that proves it</div>
+  <h1>Three independent defects, one symptom cluster — and the remediations are <span class="g">two PRs you already wrote</span></h1>
+  <p class="lede">The reported symptoms — repeated Touch ID authorization, fleet-wide logout, and a
+  <b>44.1%</b> routine failure rate — are not one fault. They are three defects in the credential path with
+  distinct mechanisms, distinct blast radii, and distinct fixes. Two are addressed by open pull requests
+  authored by you (<b>#1457</b>, <b>#1449</b>). The third is an unconditional probe loop. Critically:
+  <b>every prior remediation attempt amplified the fault</b>, because the two remedies applied — minting a new
+  token and propagating a credential file — are themselves the failure mechanism.</p>
+  <div class="chips">
+    <span class="chip hot">routine failure rate <b>44.1%</b></span>
+    <span class="chip hot">auth share of failures <b>80.6%</b></span>
+    <span class="chip">PR <b>#1457</b> open</span>
+    <span class="chip">PR <b>#1449</b> open</span>
+    <span class="chip">fleet-cache warms logged <b>3,244</b></span>
+  </div>
+</header>
+
+<!-- 0 · VERIFICATION LEDGER -->
+<section id="s0">
+  <div class="sec-num">00</div>
+  <h2>Verification ledger</h2>
+  <p class="sub">A prior agent's remediation degraded the system. Accordingly, every assertion below is labelled
+  with its evidentiary status and the exact command or source location that establishes it. Assertions marked
+  <span class="v-untested">UNTESTED</span> must not be acted on without executing the stated check first.</p>
+
+  <div class="scroller">
+  <table>
+    <tr><th>Assertion</th><th>Status</th><th>Evidence</th></tr>
+    <tr><td>The synchronous secrets-broker clients fail on the shipped macOS binary</td>
+        <td><span class="v-proven">PROVEN</span></td>
+        <td><code>agents -e 'console.log(1)'</code> → <code>error: unknown option '-e'</code>, executed on this host</td></tr>
+    <tr><td>Three call sites are affected</td><td><span class="v-proven">PROVEN</span></td>
+        <td><span class="fl">lib/secrets/agent.ts:799 · :849 · :893</span> — <code>spawnSync(process.execPath, ['-e', …])</code></td></tr>
+    <tr><td>PR #1457 targets exactly this defect</td><td><span class="v-proven">PROVEN</span></td>
+        <td><code>gh pr view 1457</code> → <code>OPEN</code>, <code>mergedAt: null</code></td></tr>
+    <tr><td>Reading Claude usage rotates the refresh token</td><td><span class="v-proven">PROVEN</span></td>
+        <td><span class="fl">usage.ts:589</span> → <span class="fl">:1416</span> refresh predicate → <span class="fl">:1424</span> token POST → <span class="fl">:1430</span> persist</td></tr>
+    <tr><td>PR #1449 targets exactly this defect</td><td><span class="v-proven">PROVEN</span></td>
+        <td><code>gh pr view 1449</code> → <code>OPEN</code>, <code>mergedAt: null</code></td></tr>
+    <tr><td>The 3-minute fleet-auth probe <em>no longer</em> rotates the token</td><td><span class="v-proven">PROVEN</span></td>
+        <td>#1335 is an ancestor of HEAD; <span class="fl">usage.ts:920-922</span> returns <code>expired</code> before any refresh</td></tr>
+    <tr><td>3,244 fleet-cache warm cycles have executed</td><td><span class="v-proven">PROVEN</span></td>
+        <td><code>rg -uu -c "fleet cache warm" …/daemon/logs.jsonl</code> → 3244</td></tr>
+    <tr><td>The daemon currently holds no Claude OAuth token</td><td><span class="v-proven">PROVEN</span></td>
+        <td><code>rg -c "Loaded Claude OAuth token"</code> → 0; daemon PID 24971</td></tr>
+    <tr><td>73 keychain items; 11 resolve to an extant home; 62 orphaned; <code>$HOME</code> has none</td>
+        <td><span class="v-proven">PROVEN</span></td>
+        <td><code>security dump-keychain</code> (metadata only) + recomputed <code>sha256(home + '/.claude')</code></td></tr>
+    <tr><td>Prior remediations minted tokens / propagated credential files</td><td><span class="v-proven">PROVEN</span></td>
+        <td>transcript commands with timestamps: 06-24, 07-13, 07-19, 07-20, 07-21</td></tr>
+    <tr><td>The Jul 17 revocation originated server-side, not from a local mutation</td>
+        <td><span class="v-proven">PROVEN</span></td>
+        <td>7,705 tool invocations scanned across the Jul 16–17 window; zero auth-mutating commands</td></tr>
+    <tr><td>The daemon token gap caused the Jul 17 cliff</td><td><span class="v-retract">RETRACTED</span></td>
+        <td>First <code>401 revoked</code> (Jul 17 00:13) precedes the routine cliff (14:03). I asserted this earlier; the ordering refutes it</td></tr>
+    <tr><td>Any remediation below restores the pre-July baseline</td><td><span class="v-untested">UNTESTED</span></td>
+        <td>No remedy has been executed or measured. §05 is the gate</td></tr>
+  </table>
+  </div>
+</section>
+
+<!-- 1 · DEFECT A -->
+<section id="s1">
+  <div class="sec-num">01</div>
+  <h2>Defect A — broker cache bypass causes unconditional Touch ID authorization</h2>
+  <p class="sub">Mechanism: an ABI assumption invalidated by a build-system change, with a swallowed failure and a
+  fallback that reaches the Keychain directly.</p>
+
+  <p>The secrets broker exists so that a bundle read is served from a cached, agent-held unlock rather than a
+  Keychain access. Its three synchronous clients spawn an inline Node program:</p>
+
+  <pre><span class="c">// lib/secrets/agent.ts:799 · :849 · :893</span>
+spawnSync(process.execPath, [<span class="r">'-e'</span>, SYNC_GET_PROGRAM,  socketPath(), name, tokenPath()])
+spawnSync(process.execPath, [<span class="r">'-e'</span>, SYNC_PING_PROGRAM, socketPath()])
+spawnSync(process.execPath, [<span class="r">'-e'</span>, SYNC_LOCK_PROGRAM, socketPath(), name, tokenPath()])</pre>
+
+  <p><code>process.execPath</code> resolves to the Node executable <em>only when the CLI runs as a Node script</em>.
+  Since <b>1.20.53</b> the macOS <code>agents</code> artifact is a Bun-compiled Mach-O executable, so
+  <code>process.execPath</code> is the CLI itself and the invocation degenerates to <code>agents -e …</code>,
+  which Commander rejects. Reproduced on this host:</p>
+
+  <pre><span class="c">$</span> agents -e 'console.log(1)'
+<span class="r">error: unknown option '-e'</span></pre>
+
+  <p><code>agentGetSync</code> returns <code>null</code> on non-zero exit; <code>agentReachableSync</code> returns
+  <code>false</code>; <code>agentEvictSync</code> no-ops. Each caller interprets those return values as
+  <em>“broker unavailable”</em> and falls through to a direct Keychain read — which raises an authorization
+  sheet. The <code>daily</code> policy's one-authorization-per-interval guarantee is therefore never in effect.</p>
+
+  <figure>
+  <svg viewBox="0 0 1040 300" role="img" aria-label="broker cache bypass path">
+    <text x="20" y="26" class="svg-l">Intended path (Node entry) vs. actual path (Bun-compiled Mach-O)</text>
+    <line x1="520" y1="42" x2="520" y2="282" stroke="var(--line)" stroke-width="1.2" stroke-dasharray="4 4"/>
+    <text x="20" y="60" class="svg-s" fill="var(--lime)">INTENDED — process.execPath === node</text>
+    <text x="540" y="60" class="svg-s" fill="var(--red)">ACTUAL — process.execPath === agents (Mach-O)</text>
+
+    <rect x="20" y="74" width="200" height="40" rx="7" class="box"/>
+    <text x="120" y="99" text-anchor="middle" class="svg-s">bundle read requested</text>
+    <rect x="20" y="130" width="200" height="46" rx="7" class="box-lime"/>
+    <text x="120" y="150" text-anchor="middle" class="svg-s">spawn node -e SYNC_GET</text>
+    <text x="120" y="166" text-anchor="middle" class="svg-s">→ unix socket → broker</text>
+    <rect x="20" y="192" width="200" height="46" rx="7" class="box-lime"/>
+    <text x="120" y="212" text-anchor="middle" class="svg-s">cached unlock returned</text>
+    <text x="120" y="228" text-anchor="middle" class="svg-s">no authorization sheet</text>
+    <path class="edge-lime" d="M120,114 L120,128"/>
+    <path class="edge-lime" d="M120,176 L120,190"/>
+    <text x="20" y="264" class="svg-s" fill="var(--lime)">1 authorization per policy interval</text>
+
+    <rect x="540" y="74" width="200" height="40" rx="7" class="box"/>
+    <text x="640" y="99" text-anchor="middle" class="svg-s">bundle read requested</text>
+    <rect x="540" y="130" width="240" height="46" rx="7" class="box-hot"/>
+    <text x="660" y="150" text-anchor="middle" class="svg-s">spawn agents -e SYNC_GET</text>
+    <text x="660" y="166" text-anchor="middle" class="svg-s">exit ≠ 0 · error swallowed</text>
+    <rect x="540" y="192" width="240" height="46" rx="7" class="box-hot"/>
+    <text x="660" y="212" text-anchor="middle" class="svg-s">interpreted as "broker down"</text>
+    <text x="660" y="228" text-anchor="middle" class="svg-s">→ direct Keychain read</text>
+    <path class="edge-hot" d="M640,114 L640,128"/>
+    <path class="edge-hot" d="M660,176 L660,190"/>
+
+    <rect x="812" y="192" width="200" height="46" rx="7" class="box-hot"/>
+    <text x="912" y="212" text-anchor="middle" class="svg-l" fill="var(--red)">Touch ID sheet</text>
+    <text x="912" y="228" text-anchor="middle" class="svg-s">every read, every bundle</text>
+    <path class="edge-hot" d="M780,215 L810,215"/>
+    <text x="540" y="264" class="svg-s" fill="var(--red)">cache never hit → policy never applied</text>
+  </svg>
+  <figcaption>Fig 1 — Defect A. The failure is silent: a non-zero exit is indistinguishable from a genuinely unavailable broker, so the fallback is taken rather than an error raised.</figcaption>
+  </figure>
+
+  <div class="call warn"><span class="tag">Class defect, not instance defect</span>
+    <p>A helper that resolves this correctly already exists — <span class="fl">lib/cli-entry.ts:111-123</span>
+    <code>getCliLaunch()</code>, which branches on <code>isNodeScriptEntry(bin)</code> and returns either
+    <code>{node, [script, …]}</code> or <code>{bin, […]}</code>. The three broker clients were never migrated
+    onto it. Remediating only these three call sites leaves the class open.</p></div>
+</section>
+
+<!-- 2 · DEFECT B -->
+<section id="s2">
+  <div class="sec-num">02</div>
+  <h2>Defect B — unconditional fleet-auth probe on a wall-clock interval</h2>
+  <p class="sub">Mechanism: a cache warmed on a metronome rather than on cache-miss, with no TTL in the auth path.</p>
+
+  <pre><span class="c">// lib/daemon.ts:649-650</span>
+setInterval(() =&gt; { void runFleetCacheWarm(); }, <span class="a">3 * 60_000</span>);
+setTimeout (() =&gt; { void runFleetCacheWarm(); }, 60_000);
+
+<span class="c">// each cycle: probeLocalFleetAuth() enumerates every installed (agent, version) on THIS host</span>
+<span class="c">// measured: </span>rg -uu -c "fleet cache warm" …/daemon/logs.jsonl  →  <span class="a">3244</span></pre>
+
+  <p>Each enumerated tuple performs a Keychain read and an authenticated HTTPS request. Two consequences follow,
+  and they must be stated separately because they have different severities:</p>
+  <ul class="tight">
+    <li><b class="k">It multiplies Defect A.</b> While the broker cache is bypassed, every probe cycle is a
+      further set of direct Keychain accesses. Defect B is an <em>amplifier</em> of the Touch ID symptom, not its
+      cause.</li>
+    <li><b class="k">It does not, at present, rotate the token.</b> This corrects an assertion made by one of my
+      own investigations. <span class="fl">usage.ts:920-922</span> returns <code>{ token: 'expired' }</code>
+      before reaching any refresh, per PR #1335, which is an ancestor of HEAD. Any analysis claiming the
+      3-minute timer is currently rotating credentials describes the pre-#1335 state.</li>
+  </ul>
+
+  <div class="call warn"><span class="tag">Design defect beneath the bug</span>
+    <p>The warm loop was introduced to make <code>agents devices list</code> render instantly. That is a
+    reasonable objective, but the implementation inverts the cost model: the probe cost is now paid
+    unconditionally rather than on read. A cache should be refreshed <b>on cache-miss by an arriving reader,
+    governed by a TTL enforced inside the probe</b>, so that no call site can bypass it. The usage cache has a
+    TTL; the auth path has none.</p></div>
+</section>
+
+<!-- 3 · DEFECT C -->
+<section id="s3">
+  <div class="sec-num">03</div>
+  <h2>Defect C — refresh-token rotation stampede</h2>
+  <p class="sub">Mechanism: a single-use, server-rotating refresh token held concurrently by N processes across M
+  hosts, with no mutual exclusion around the refresh operation.</p>
+
+  <p>Anthropic's OAuth refresh token is single-use: exchanging it invalidates it and issues a replacement.
+  <code>getClaudeAccessToken</code> (<span class="fl">usage.ts:1410-1433</span>) exchanges whenever the access
+  token is within the refresh leeway, then persists the result. It is reached from
+  <code>getClaudeUsageInfo</code> at <span class="fl">usage.ts:589</span> — i.e. from usage rendering and from
+  <code>agents run</code> balanced rotation on every unpinned invocation.</p>
+
+  <figure>
+  <svg viewBox="0 0 1040 320" role="img" aria-label="refresh token rotation stampede">
+    <text x="20" y="26" class="svg-l">Single-use refresh token, four concurrent holders</text>
+
+    <rect x="420" y="52" width="200" height="46" rx="8" class="box"/>
+    <text x="520" y="72" text-anchor="middle" class="svg-s">Anthropic token endpoint</text>
+    <text x="520" y="88" text-anchor="middle" class="svg-s">refresh_token = R₀</text>
+
+    <rect x="30"  y="180" width="180" height="52" rx="8" class="box"/>
+    <text x="120" y="200" text-anchor="middle" class="svg-s">zion</text>
+    <text x="120" y="216" text-anchor="middle" class="svg-s">holds R₀</text>
+    <rect x="240" y="180" width="180" height="52" rx="8" class="box"/>
+    <text x="330" y="200" text-anchor="middle" class="svg-s">mac-mini</text>
+    <text x="330" y="216" text-anchor="middle" class="svg-s">holds R₀</text>
+    <rect x="450" y="180" width="180" height="52" rx="8" class="box"/>
+    <text x="540" y="200" text-anchor="middle" class="svg-s">yosemite-s0</text>
+    <text x="540" y="216" text-anchor="middle" class="svg-s">holds R₀</text>
+    <rect x="660" y="180" width="180" height="52" rx="8" class="box"/>
+    <text x="750" y="200" text-anchor="middle" class="svg-s">yosemite-s1</text>
+    <text x="750" y="216" text-anchor="middle" class="svg-s">holds R₀</text>
+
+    <path class="edge-lime" d="M120,178 C120,140 420,120 470,98"/>
+    <text x="150" y="140" class="svg-s" fill="var(--lime)">1. exchange R₀ → R₁  ✓ wins</text>
+    <path class="edge-hot" d="M330,178 C330,150 460,120 500,98"/>
+    <path class="edge-hot" d="M540,178 C540,150 545,120 545,98"/>
+    <path class="edge-hot" d="M750,178 C750,150 600,120 570,98"/>
+    <text x="600" y="150" class="svg-s" fill="var(--red)">2. exchange R₀ → 401 invalid_grant</text>
+
+    <rect x="240" y="256" width="600" height="46" rx="8" class="box-hot"/>
+    <text x="540" y="276" text-anchor="middle" class="svg-s">three holders now carry a dead R₀ · next run reports "Not logged in · Please run /login"</text>
+    <text x="540" y="292" text-anchor="middle" class="svg-s">no error surfaces at rotation time — the failure is observed only at next use</text>
+
+    <text x="30" y="292" class="svg-s" fill="var(--lime)">1 winner</text>
+  </svg>
+  <figcaption>Fig 2 — Defect C. Any operation that triggers a refresh on one host invalidates every other host's stored credential. Concurrency, not correctness, is the fault.</figcaption>
+  </figure>
+
+  <p>The invariant that prevents this — <em>refresh only from the single legitimate path</em> — is presently
+  maintained by convention, not by construction. There is no mutual exclusion:
+  <code>proper-lockfile</code> is already a dependency (<span class="fl">fs-atomic.ts:4</span>) but
+  <code>usage.ts</code> does not import it; <span class="fl">lib/lock.ts</span> is a manifest hasher, not a
+  mutex; the only deduplication is an in-process <code>Map</code> (<span class="fl">usage.ts:303</span>)
+  covering the background SWR path exclusively.</p>
+</section>
+
+<!-- 4 · WHY PRIOR REMEDIATIONS FAILED -->
+<section id="s4">
+  <div class="sec-num">04</div>
+  <h2>Why prior remediations amplified the fault</h2>
+  <p class="sub">This section is the most operationally important in the document. Each item is a remediation that
+  was actually applied and is documented degrading the system.</p>
+
+  <div class="call hot"><span class="tag">The controlling observation</span>
+    <p>The fleet auth-health monitor — <code>8c80c522</code>, <code>9d5a8fe0</code>, <code>893f80d9</code>,
+    <code>6e6b6a94</code> (2026-07-18) — <b>was itself an agent's remediation for the logout fault</b>. Three days
+    later your own <code>1a4d5693</code> had to disable its refresh behavior, stating:
+    <em>“This was the dominant amplifier of the fleet-logout loop.”</em> <b>The diagnostic caused the condition it
+    was built to diagnose.</b></p></div>
+
+  <h3>Prohibited operations</h3>
+  <ol class="tight">
+    <li><b class="k">Do not execute or recommend <code>claude setup-token</code>.</b> It mints a credential and
+      rotates the shared refresh token. Prescribed 2026-06-24, 07-13, 07-20, 07-21; the failure rate increased
+      monotonically across all four. One agent characterised it as <em>“safe, additive… does not log out or
+      invalidate your existing accounts”</em> — directly contradicted by <code>1a4d5693</code>.</li>
+    <li><b class="k">Do not execute <code>agents apply</code> with <code>login: sync</code>,
+      <code>--only …,login</code>, or <code>--copy-creds</code>.</b>
+      <span class="fl">fleet/remote-login.ts:4-6</span>: <em>“copying one OAuth credential file across N boxes is
+      fatal — droid collapsed 10 boxes → 1 overnight.”</em> Executed 2026-07-19 against win-mini
+      (<code>✓ push-login</code>).</li>
+    <li><b class="k">Do not introduce any periodic process that <em>refreshes</em> a Claude token</b> — health
+      check, canary, ping, usage-bar warmer. A non-refreshing read is acceptable; an exchange is not.</li>
+    <li><b class="k">Do not widen the set of hosts holding this account</b> until Defect C is remediated
+      fleet-wide. On 2026-07-30 an agent set eight routines to <code>--set yosemite-s0,yosemite-s1</code>,
+      adding two additional refreshers to the stampede.</li>
+    <li><b class="k">Do not remove and re-add an agent CLI as an auth remedy</b> — it discards the credential it
+      is intended to repair.</li>
+    <li><b class="k">Do not invoke an interactive login on a headless host</b> — the OAuth URL was dispatched to
+      <code>xdg-open</code> and opened in LibreOffice, leaving orphaned processes on yosemite-s0.</li>
+    <li><b class="k"><code>agents fleet login</code> cannot remediate Claude</b> — <code>CHANGELOG.md:88</code>
+      classifies claude as non-remotable; only device-code flows (droid, codex, kimi) are drivable.</li>
+  </ol>
+</section>
+
+<!-- 5 · REMEDIATION -->
+<section id="s5">
+  <div class="sec-num">05</div>
+  <h2>Remediation sequence</h2>
+  <p class="sub">Ordered by blast-radius reduction per unit of risk. Each step lands independently and is
+  independently revertible. No step mutates a credential.</p>
+
+  <div class="fix"><h4><span class="num a">1</span>Capture a pre-change baseline</h4>
+    <p class="why">Required so that "worse" is measurable rather than anecdotal — the failure mode of every prior
+    attempt. Record: per-day routine outcome distribution from
+    <code>~/.agents/.history/runs/*/*/meta.json</code>; the Keychain item inventory (73 items, metadata only);
+    <code>rg -c "Loaded Claude OAuth token"</code>; and the current fleet-warm count (3,244).</p></div>
+
+  <div class="fix"><h4><span class="num a">2</span>Merge PR #1457 — terminates Defect A</h4>
+    <p class="why">Restores the broker cache, which restores the <code>daily</code> policy's
+    one-authorization-per-interval guarantee. This is the remediation for the Touch ID symptom.
+    <b>Then eliminate the class:</b> migrate the three clients at
+    <span class="fl">lib/secrets/agent.ts:799 · :849 · :893</span> onto the existing
+    <code>getCliLaunch()</code> (<span class="fl">cli-entry.ts:111</span>), and add a lint or unit test
+    prohibiting bare <code>process.execPath</code> self-spawns.</p></div>
+
+  <div class="fix"><h4><span class="num a">3</span>Merge PR #1449, then propagate to every host — terminates Defect C</h4>
+    <p class="why">Removes the token exchange from the usage/run hot path.
+    <b>Propagation is the step that determines success or failure:</b> a partially-upgraded fleet still
+    stampedes, because a single un-upgraded host continues to invalidate the upgraded ones. All four hosts
+    running <code>agents run</code> against this account must be upgraded — zion, mac-mini, yosemite-s0,
+    yosemite-s1.</p></div>
+
+  <div class="fix"><h4><span class="num b">4</span>Establish mutual exclusion around refresh — makes Defect C structurally impossible</h4>
+    <p class="why">Route every refresh through one function guarded by a cross-process lock
+    (<code>proper-lockfile</code>, already a dependency at <span class="fl">fs-atomic.ts:4</span>). Make
+    <code>saveClaudeOauth</code> (<span class="fl">usage.ts:1221-1248</span>) atomic — it currently performs a
+    read-modify-delete-write, so a losing racer can overwrite the winner's live credential with a dead one. Add a
+    test asserting no call site outside that function invokes <code>refreshClaudeToken</code>.</p></div>
+
+  <div class="fix"><h4><span class="num b">5</span>Convert the fleet-auth cache to read-triggered — terminates Defect B</h4>
+    <p class="why">Remove <span class="fl">daemon.ts:649-650</span>. Refresh on cache-miss by an arriving reader,
+    with a TTL enforced <em>inside</em> <code>probeLocalFleetAuth</code> so no caller can bypass it. Separate
+    "is this credential valid" (local, cheap, no network) from "is this agent reachable" (explicit, on demand) —
+    they are currently conflated under one label.</p></div>
+
+  <div class="fix"><h4><span class="num c">6</span>Restore failure detection</h4>
+    <p class="why">On 2026-06-24 an agent created an <code>auth-canary</code> routine and removed it 94 seconds
+    later; it would have detected the July 17 cliff on the day it occurred rather than twelve days later.
+    Reinstate a canary that <em>reads without refreshing</em> (mirroring the guard at
+    <span class="fl">usage.ts:920-922</span>) and alerts out-of-band. Separately, add the missing failure branch
+    at <span class="fl">daemon.ts:315-321</span>, where a null token read currently produces no log line — the
+    reason this condition persisted undetected.</p></div>
+
+  <h3>Explicitly out of scope</h3>
+  <ul class="tight">
+    <li>Reverting <code>1e910372</code>. Removing a plaintext credential from the service manifest is correct.</li>
+    <li>The 62 orphaned Keychain items and the absent <code>$HOME</code> item. Real, but folding them in would
+      confound measurement of whether the stampede remediation succeeded.</li>
+    <li>Any credential mutation whatsoever during diagnosis.</li>
+  </ul>
+</section>
+
+<!-- 6 · VERIFICATION -->
+<section id="s6">
+  <div class="sec-num">06</div>
+  <h2>Verification protocol</h2>
+  <p class="sub">Remediation efficacy is currently unestablished. This protocol is the acceptance gate.</p>
+  <ol class="tight">
+    <li><b>Defect A, direct:</b> after #1457, execute a bundle read and assert the broker socket is contacted and
+      no authorization sheet is raised. Then execute a second read within the policy interval and assert the same.</li>
+    <li><b>Defect C, mechanism-level, before any code change:</b> on one host, with an access token inside the
+      refresh leeway, render a usage bar and observe whether the stored credential's <code>expiresAt</code>
+      changes. This converts the rotation from inferred to observed.</li>
+    <li><b>Defect C, post-change:</b> repeat (2) on all four upgraded hosts and assert the stored credential is
+      unchanged by a usage read.</li>
+    <li><b>System-level, 48 h:</b> zion's daily routine failure rate should return toward its pre-July-17
+      baseline of 11–33%, not 75–100%. mac-mini, at 93.6% failure, is the highest-signal host.</li>
+    <li><b>Defect B:</b> assert the fleet-warm counter stops advancing and that <code>agents devices list</code>
+      still renders within an acceptable latency budget from a read-triggered refresh.</li>
+    <li><b>Rollback discipline:</b> one change at a time. If the failure rate degrades after any single change,
+      revert that change before proceeding to the next.</li>
+  </ol>
+</section>
+
+<!-- 7 · DECISIONS -->
+<section id="s7">
+  <div class="sec-num">07</div>
+  <h2>Decisions required from you</h2>
+  <p class="sub">These are not implementation details. Each is a judgement I should not make unilaterally.</p>
+
+  <div class="ask"><h4>1 · Authorization to merge two of your own open PRs</h4>
+    <p>#1457 (Defect A) and #1449 (Defect C) are open, authored by you, and each targets a defect verified above.
+    Merging is an outward-facing action on your repository. Confirm before I proceed, and confirm whether the
+    fleet-wide upgrade that must follow #1449 is in scope for me.</p></div>
+
+  <div class="ask"><h4>2 · Should the auth probe ever contact the network unattended?</h4>
+    <p>Defect B's remediation depends on this. If the answer is "only on explicit <code>fleet ping</code> or
+    immediately prior to a dispatch," the timer is deleted outright. If unattended freshness has a real
+    requirement I am not seeing, the remediation becomes a TTL rather than a removal.</p></div>
+
+  <div class="ask"><h4>3 · Is a single Anthropic identity across the fleet intentional?</h4>
+    <p>Defect C's stampede scales with the number of concurrent holders of one refresh token. Per-machine
+    credentials would eliminate it structurally rather than by mutual exclusion —
+    <span class="fl">remote-login.ts:4-10</span> already reaches this conclusion:
+    <em>“The durable fix is a per-machine credential: an interactive login per (agent × box).”</em> This is an
+    account-topology decision with cost and administrative implications that are yours.</p></div>
+
+  <div class="ask"><h4>4 · Three exposed Linear API keys remain unrotated</h4>
+    <p>Verified: 67 files, three distinct 48-character keys, replicated to yosemite-s1's mirror. Rotation is
+    yours to perform. Independent of the auth work above, but unresolved.</p></div>
+</section>
+
+<div class="foot wrap">
+  Verified against agents-cli @ 82756554 and the live system on zion. Timings and counts from the run archive,
+  the daemon log, and <code>security dump-keychain</code> metadata. Two assertions from subordinate
+  investigations were tested and rejected; one earlier assertion of my own is marked RETRACTED in §00.
+</div>
+</div>
+<script>
+  (function(){
+    var root=document.documentElement, btn=document.getElementById('tg');
+    try{var pref=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;
+      root.setAttribute('data-theme', pref?'light':'dark');}catch(e){}
+    btn.addEventListener('click',function(){
+      root.setAttribute('data-theme', root.getAttribute('data-theme')==='dark'?'light':'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/agents-cli-ideas.html
+++ b/docs/plans/2026-07-30/agents-cli-ideas.html
@@ -1,0 +1,479 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents-cli — six architectural moves</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e8ebe6; --ink-dim:#9aa295;
+    --line:#242724; --lime:#a3e635; --lime-dim:#6f9e26; --amber:#f4bf4f; --red:#ff6b5e;
+    --cyan:#5ec7d6; --violet:#b08cff; --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;
+    --code-bg:#0d0f0d; --chip:#1a1d19; --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 30px rgba(0,0,0,.5);
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f4; --panel:#ffffff; --panel-2:#fbfcfa; --ink:#16180f; --ink-dim:#5c6356;
+    --line:#e2e6dc; --lime:#5c8a13; --lime-dim:#7fae2c; --amber:#9a6a00; --red:#c23b2e;
+    --cyan:#0f7d8c; --violet:#6d45c9; --code-bg:#f1f3ec; --chip:#eef1e8; --shadow:0 1px 0 rgba(0,0,0,.02),0 10px 30px rgba(0,0,0,.08);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
+    font-size:16px;-webkit-font-smoothing:antialiased}
+  a{color:var(--lime);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code,kbd,.mono{font-family:var(--mono)}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+
+  .topbar{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 88%,transparent);
+    backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .brand{font-family:var(--mono);font-weight:700;letter-spacing:.02em;font-size:15px}
+  .brand .dot{color:var(--lime)}
+  .toggle{font-family:var(--mono);font-size:13px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:8px;padding:6px 12px;cursor:pointer}
+  .toggle:hover{color:var(--ink);border-color:var(--lime-dim)}
+
+  .hero{padding:64px 0 40px;border-bottom:1px solid var(--line)}
+  .kicker{font-family:var(--mono);font-size:12.5px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--lime);margin-bottom:18px}
+  h1{font-size:clamp(30px,4.6vw,50px);line-height:1.06;margin:0 0 20px;letter-spacing:-.02em;font-weight:800}
+  h1 .g{color:var(--lime)}
+  .lede{font-size:19px;color:var(--ink-dim);max-width:780px;margin:0 0 26px}
+  .lede b{color:var(--ink);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:9px;margin-bottom:8px}
+  .chip{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:999px;padding:5px 12px}
+  .chip b{color:var(--lime);font-weight:600}
+
+  .toc{margin:30px 0 0;padding:18px 20px;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  .toc h4{margin:0 0 12px;font-family:var(--mono);font-size:12px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink-dim)}
+  .toc ol{margin:0;padding:0;list-style:none;display:grid;grid-template-columns:1fr 1fr;gap:6px 26px;
+    counter-reset:toc}
+  .toc li{counter-increment:toc;font-size:14.5px;display:flex;gap:10px;align-items:baseline}
+  .toc li::before{content:counter(toc,decimal-leading-zero);font-family:var(--mono);font-size:12px;
+    color:var(--lime-dim);min-width:22px}
+  @media(max-width:720px){.toc ol{grid-template-columns:1fr}}
+
+  section{padding:52px 0;border-bottom:1px solid var(--line)}
+  .sec-num{font-family:var(--mono);font-size:13px;color:var(--lime);letter-spacing:.1em}
+  h2{font-size:clamp(22px,3vw,30px);margin:8px 0 6px;letter-spacing:-.015em;font-weight:750}
+  h3{font-size:18px;margin:30px 0 8px;font-weight:650}
+  .sub{color:var(--ink-dim);font-size:15.5px;max-width:840px}
+  p{max-width:840px}
+  ul.tight{max-width:840px;padding-left:18px}
+  ul.tight li{margin:6px 0}
+  .fl{font-family:var(--mono);font-size:12.5px;color:var(--cyan);background:var(--code-bg);
+    border:1px solid var(--line);border-radius:5px;padding:1px 6px;white-space:nowrap}
+  b.k{color:var(--lime)}
+
+  .call{margin:22px 0;padding:16px 18px 16px 20px;border-radius:12px;border:1px solid var(--line);
+    background:var(--panel);position:relative;box-shadow:var(--shadow)}
+  .call::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;border-radius:12px 0 0 12px}
+  .call.correct::before{background:var(--lime)}
+  .call.warn::before{background:var(--amber)}
+  .call.hot::before{background:var(--red)}
+  .call .tag{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+    font-weight:700;margin-bottom:6px;display:block}
+  .call.correct .tag{color:var(--lime)}
+  .call.warn .tag{color:var(--amber)}
+  .call.hot .tag{color:var(--red)}
+  .call p{margin:2px 0;max-width:none}
+
+  pre{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;padding:14px 16px;
+    overflow:auto;font-family:var(--mono);font-size:12.7px;line-height:1.6;box-shadow:var(--shadow)}
+  pre .c{color:var(--ink-dim)}
+  pre .g{color:var(--lime)}
+  pre .a{color:var(--amber)}
+  pre .r{color:var(--red)}
+  pre .cy{color:var(--cyan)}
+
+  .scroller{overflow-x:auto}
+  table{width:100%;border-collapse:collapse;margin:20px 0;font-size:14px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;
+    color:var(--ink-dim);font-weight:600}
+  td .fl{white-space:normal}
+  .yes{color:var(--lime);font-family:var(--mono)}
+  .no{color:var(--red);font-family:var(--mono)}
+  .na{color:var(--ink-dim);font-family:var(--mono)}
+
+  figure{margin:26px 0}
+  figure svg{width:100%;height:auto;display:block;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  figcaption{font-size:13px;color:var(--ink-dim);margin-top:10px;font-family:var(--mono)}
+  .svg-l{font-family:var(--mono);font-size:12px;fill:var(--ink)}
+  .svg-s{font-family:var(--mono);font-size:10.5px;fill:var(--ink-dim)}
+  .svg-t{font-family:var(--mono);font-size:11px;fill:var(--ink-dim)}
+  .box{fill:var(--panel-2);stroke:var(--line);stroke-width:1.2}
+  .box-hot{fill:var(--panel-2);stroke:var(--red);stroke-width:1.6}
+  .box-lime{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.4}
+  .edge{stroke:var(--ink-dim);stroke-width:1.4;fill:none}
+  .edge-hot{stroke:var(--red);stroke-width:1.8;fill:none}
+  .edge-lime{stroke:var(--lime);stroke-width:1.6;fill:none}
+
+  .idea{margin:22px 0;padding:18px 20px;background:var(--panel);border:1px solid var(--line);
+    border-radius:12px;box-shadow:var(--shadow)}
+  .idea h4{margin:0 0 8px;font-size:17px;display:flex;align-items:center}
+  .num{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);
+    font-weight:700;font-size:13px;width:26px;height:26px;border-radius:7px;margin-right:10px;
+    background:var(--lime);color:#0c1400}
+  .idea .row{border-top:1px dashed var(--line);margin-top:12px;padding-top:10px;font-size:14.5px}
+  .idea .row b{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase}
+  .idea .row.up b{color:var(--lime)}
+  .idea .row.down b{color:var(--amber)}
+  .effort{font-family:var(--mono);font-size:11px;padding:2px 9px;border-radius:999px;
+    border:1px solid var(--line);color:var(--ink-dim);margin-left:auto;font-weight:400}
+
+  .foot{padding:40px 0 70px;color:var(--ink-dim);font-size:13px;font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div class="topbar"><div class="wrap">
+  <div class="brand">agents<span class="dot">·</span>cli <span style="color:var(--ink-dim)">/ ideas</span></div>
+  <button class="toggle" id="tg">◐ theme</button>
+</div></div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="kicker">Companion to “the distributed core” · brainstorm, verified</div>
+  <h1>Six moves — and three things the <span class="g">report</span> got vague or wrong</h1>
+  <p class="lede">The original report's headline (poll → push) is right but it's the <b>expensive</b> fix.
+    Underneath it sits a cheaper, more damaging problem the report only gestures at: <b>nobody agrees where a
+    transcript lives.</b> Four separate tables answer that question, they cover different agent sets, and for
+    OpenCode all three answers are different paths. That is the bug factory, and it's a week of typing, not an
+    architecture rewrite.</p>
+  <div class="chips">
+    <span class="chip">verified @ <b>827565549</b></span>
+    <span class="chip">every claim re-read from <b>source</b></span>
+    <span class="chip">4 location tables · <b>11</b> session agents</span>
+    <span class="chip">2 SQLite libraries in <b>one monorepo</b></span>
+  </div>
+
+  <nav class="toc">
+    <h4>What's inside</h4>
+    <ol>
+      <li><a href="#s0">Your three questions, answered from source</a></li>
+      <li><a href="#s1">The location-table drift (the real bug factory)</a></li>
+      <li><a href="#s2">Move 1 — one harness manifest, with a <code>locate()</code></a></li>
+      <li><a href="#s3">Move 2 — four storage shapes, not eleven harnesses</a></li>
+      <li><a href="#s4">Move 3 — one SQLite, in <code>packages/</code></a></li>
+      <li><a href="#s5">Move 4 — the extension stops touching transcripts</a></li>
+      <li><a href="#s6">Move 5 — stream the SSH fan-out before building a daemon</a></li>
+      <li><a href="#s7">Move 6 — session identity isn't a file path</a></li>
+      <li><a href="#s8">Order of operations</a></li>
+    </ol>
+  </nav>
+</header>
+
+<!-- 0 -->
+<section id="s0">
+  <div class="sec-num">00</div>
+  <h2>Your three questions, answered from source</h2>
+
+  <h3>“Why does the report say <em>stack</em>?”</h3>
+  <p>Because at that point the report was hand-waving. §1(b) says transcripts are “parsed by a completely
+  separate stack” and never names it. Concretely, that “stack” is:</p>
+  <ul class="tight">
+    <li><b class="k">Indexer</b> — <span class="fl">apps/cli/src/lib/session/discover.ts</span> (3038 lines), one
+      <code>scan&lt;Harness&gt;Incremental</code> per agent, dispatched by a switch at <span class="fl">discover.ts:234</span>.</li>
+    <li><b class="k">Full parser</b> — <span class="fl">apps/cli/src/lib/session/parse.ts</span> (1653 lines), on-demand, whole-file.</li>
+    <li><b class="k">Factory head parser</b> — <span class="fl">apps/factory/src/monitor/sessionParse.ts</span> (240 lines), first 100 lines only.</li>
+    <li><b class="k">Factory preview parser</b> — <span class="fl">apps/factory/src/vscode/sessions.vscode.ts</span> (800 lines), including its own SQLite reader.</li>
+  </ul>
+  <p>Four parsers, two apps, no shared interface. “Stack” was doing a lot of work in that sentence.</p>
+
+  <h3>“Are different packages or libraries being used?”</h3>
+  <p><b>Yes — two different SQLite implementations in the same monorepo.</b></p>
+  <pre><span class="c">// CLI — deliberately no native addon, no prebuild</span>
+apps/cli/src/lib/sqlite.ts:22   <span class="g">bun:sqlite</span> under Bun · <span class="g">node:sqlite</span> under Node ≥22.5
+                                <span class="c">"Avoids the native better-sqlite3 addon entirely"</span>
+
+<span class="c">// Factory — WebAssembly SQLite, a separate npm dependency</span>
+apps/factory/package.json:1278  <span class="a">"sql.js": "^1.13.0"</span>
+sessions.vscode.ts:18           <span class="a">initSqlJs()</span>  → reads Cursor's store.db
+sessions.vscode.ts:731          <span class="r">await fs.readFile(dbPath)</span>  <span class="c">// entire DB into a Buffer</span></pre>
+  <div class="call warn"><span class="tag">But it isn't arbitrary</span>
+    <p>The split is defensible: the VS Code extension host pins its own Node, may predate <code>node:sqlite</code>
+    (needs ≥22.5), and can't ship a native addon across platforms. <b>sql.js was the right call for that constraint.</b>
+    The problem is that it's an <em>undeclared</em> fork — nothing says “extension host uses the WASM driver,”
+    so the two will drift on schema, BLOB handling, and error semantics. And <code>readFile</code>-the-whole-DB is
+    fine for a Cursor chat, fatal the day it points at OpenCode's global <code>opencode.db</code>.</p></div>
+
+  <h3>“Session transcripts have no standardized place”</h3>
+  <p>Correct, and it's worse than “no standard” — it's <b>four tables that disagree</b>. See §01.</p>
+</section>
+
+<!-- 1 -->
+<section id="s1">
+  <div class="sec-num">01</div>
+  <h2>The location-table drift — the actual bug factory</h2>
+  <p class="sub">“Where does agent X keep its transcripts” is answered independently in four places, over three
+  different agent sets. None of them is complete.</p>
+
+  <div class="scroller">
+  <table>
+    <tr><th>Table</th><th>File:line</th><th>Agents covered</th><th>Consumers</th></tr>
+    <tr><td><b class="k">SESSION_ROOT_SPECS</b><br><span class="na">claims to be “the single source of truth”</span></td>
+        <td><span class="fl">discover.ts:479</span></td>
+        <td class="mono">claude · codex · gemini · antigravity · droid · kimi <span class="no">(6 of 11)</span></td>
+        <td><code>agents sessions --roots --json</code></td></tr>
+    <tr><td><b class="k">getSessionDir</b></td>
+        <td><span class="fl">agents.ts:1783</span></td>
+        <td class="mono">claude · codex · gemini · grok · copilot · droid <span class="no">(different 6)</span></td>
+        <td>agent freshness / session counts</td></tr>
+    <tr><td><b class="k">agentSessionRoots</b></td>
+        <td><span class="fl">sessionParse.ts:146</span></td>
+        <td class="mono">claude · codex · gemini · opencode · cursor <span class="no">(5, incl. one the CLI has never heard of)</span></td>
+        <td>factory fast-path + locate</td></tr>
+    <tr><td><b class="k">watcherRoots</b></td>
+        <td><span class="fl">sessionParse.ts:170</span></td>
+        <td class="mono">claude · codex · gemini · opencode <span class="no">(4)</span></td>
+        <td>fs.watch fallback</td></tr>
+  </table>
+  </div>
+
+  <p>And there's a fifth: <code>SESSION_AGENTS</code> (<span class="fl">types.ts:14</span>) declares <b>11</b>
+  session agents — claude, codex, gemini, antigravity, opencode, openclaw, rush, hermes, grok, kimi, droid. The
+  “source of truth” table publishes six of them. Rush and Hermes get hardcoded constants of their own
+  (<span class="fl">discover.ts:60–61</span>), OpenCode gets a global-DB constant
+  (<span class="fl">discover.ts:1451</span>).</p>
+
+  <h3>OpenCode is the proof</h3>
+  <pre><span class="c">// three answers, same repo, same agent</span>
+discover.ts:1451       <span class="cy">~/.local/share/opencode/opencode.db</span>        <span class="c">// CLI: a global SQLite DB</span>
+sessionParse.ts:155    <span class="a">~/.local/share/opencode/storage/message</span>    <span class="c">// factory fast-path</span>
+sessionParse.ts:179    <span class="r">~/.local/share/opencode/storage/session</span>    <span class="c">// factory watcher</span></pre>
+
+  <div class="call hot"><span class="tag">The report is wrong here</span>
+    <p>The comment at <span class="fl">sessionParse.ts:~196</span> justifies the hardcoded OpenCode path with
+    “<em>the CLI does not scan opencode transcripts, so it never appears in --roots</em>.” It does —
+    <code>scanOpenCodeIncremental()</code> is dispatched at <span class="fl">discover.ts:240</span> and reads
+    <span class="fl">opencode.db</span>. OpenCode is absent from <code>--roots</code> not because it's unscanned
+    but because <code>SESSION_ROOT_SPECS</code> only models <em>directory</em> roots and OpenCode is a
+    <em>file</em>. The extension then worked around a wrong diagnosis with two more wrong paths.</p></div>
+
+  <div class="call warn"><span class="tag">This class already bit you once</span>
+    <p>The source records it: “<em>the hardcoded list kept watching ~/.gemini/sessions after gemini moved its
+    transcripts to ~/.gemini/tmp</em>” (<span class="fl">sessionParse.ts:~193</span>). That's the whole failure
+    mode — a vendor moves a directory, one table learns, three don't, and a surface goes quietly blind. The fix
+    (<code>watcherRootsFromCli()</code>) was right in shape and incomplete in coverage.</p></div>
+</section>
+
+<!-- DIAGRAM -->
+<figure>
+<svg viewBox="0 0 1040 360" role="img" aria-label="location tables today vs one manifest">
+  <text x="20" y="26" class="svg-l" fill="var(--red)">TODAY — four tables, three agent sets, no arbiter</text>
+  <text x="560" y="26" class="svg-l" fill="var(--lime)">PROPOSED — one manifest, published, everyone reads it</text>
+  <line x1="530" y1="40" x2="530" y2="340" stroke="var(--line)" stroke-width="1.2" stroke-dasharray="4 4"/>
+
+  <!-- today -->
+  <rect x="20" y="56" width="220" height="42" rx="8" class="box-hot"/>
+  <text x="130" y="73" text-anchor="middle" class="svg-s">SESSION_ROOT_SPECS · 6</text>
+  <text x="130" y="88" text-anchor="middle" class="svg-s">discover.ts:479</text>
+
+  <rect x="270" y="56" width="220" height="42" rx="8" class="box-hot"/>
+  <text x="380" y="73" text-anchor="middle" class="svg-s">getSessionDir · 6 (other 6)</text>
+  <text x="380" y="88" text-anchor="middle" class="svg-s">agents.ts:1783</text>
+
+  <rect x="20" y="118" width="220" height="42" rx="8" class="box-hot"/>
+  <text x="130" y="135" text-anchor="middle" class="svg-s">agentSessionRoots · 5</text>
+  <text x="130" y="150" text-anchor="middle" class="svg-s">sessionParse.ts:146</text>
+
+  <rect x="270" y="118" width="220" height="42" rx="8" class="box-hot"/>
+  <text x="380" y="135" text-anchor="middle" class="svg-s">watcherRoots · 4</text>
+  <text x="380" y="150" text-anchor="middle" class="svg-s">sessionParse.ts:170</text>
+
+  <rect x="145" y="210" width="220" height="42" rx="8" class="box"/>
+  <text x="255" y="227" text-anchor="middle" class="svg-s">SESSION_AGENTS · 11</text>
+  <text x="255" y="242" text-anchor="middle" class="svg-s">types.ts:14 — the real set</text>
+
+  <path class="edge-hot" d="M130,98 L130,116"/>
+  <path class="edge-hot" d="M380,98 L380,116"/>
+  <path class="edge-hot" d="M130,160 L130,190 L255,190 L255,208"/>
+  <path class="edge-hot" d="M380,160 L380,190 L255,190"/>
+  <text x="120" y="290" class="svg-s" fill="var(--red)">5 of 11 agents are invisible to --roots</text>
+  <text x="120" y="308" class="svg-s" fill="var(--red)">opencode has 3 different paths</text>
+
+  <!-- proposed -->
+  <rect x="560" y="56" width="290" height="60" rx="8" class="box-lime"/>
+  <text x="705" y="78" text-anchor="middle" class="svg-s">HARNESSES[] — one manifest</text>
+  <text x="705" y="94" text-anchor="middle" class="svg-s">{ id, shape, locate(), fields }</text>
+  <text x="705" y="109" text-anchor="middle" class="svg-s">all 11 + cursor</text>
+
+  <rect x="560" y="146" width="290" height="42" rx="8" class="box-lime"/>
+  <text x="705" y="163" text-anchor="middle" class="svg-s">agents sessions --roots --json</text>
+  <text x="705" y="178" text-anchor="middle" class="svg-s">versioned · the only publisher</text>
+
+  <rect x="560" y="222" width="130" height="42" rx="8" class="box"/>
+  <text x="625" y="248" text-anchor="middle" class="svg-s">indexer</text>
+  <rect x="705" y="222" width="130" height="42" rx="8" class="box"/>
+  <text x="770" y="248" text-anchor="middle" class="svg-s">watcher</text>
+  <rect x="850" y="222" width="140" height="42" rx="8" class="box"/>
+  <text x="920" y="248" text-anchor="middle" class="svg-s">extension</text>
+
+  <path class="edge-lime" d="M705,116 L705,144"/>
+  <path class="edge-lime" d="M705,188 L705,206 L625,206 L625,220"/>
+  <path class="edge-lime" d="M705,188 L705,206 L770,206 L770,220"/>
+  <path class="edge-lime" d="M705,188 L705,206 L920,206 L920,220"/>
+  <text x="600" y="298" class="svg-s" fill="var(--lime)">a vendor moves a directory → one line changes → every surface follows</text>
+</svg>
+<figcaption>Fig 1 — the drift, and the shape that removes it. Not a rewrite: one table plus a publisher.</figcaption>
+</figure>
+
+<!-- 2 -->
+<section id="s2">
+  <div class="sec-num">02</div>
+  <h2>The six moves</h2>
+  <p class="sub">Each with what it buys and — more usefully — what it costs. Ordered by leverage-per-risk, not by ambition.</p>
+
+  <div class="idea" id="s2i">
+    <h4><span class="num">1</span>One harness manifest — but it needs a <code>locate()</code>, not a path string
+      <span class="effort">small · high leverage</span></h4>
+    <p>Collapse the four tables into one <code>HARNESSES[]</code> entry per agent, covering all 11 (+ cursor), and
+    make <code>agents sessions --roots --json</code> the only publisher. The plumbing already exists —
+    <code>watcherRootsFromCli()</code> proved the pattern; it just reads from a table that's missing half the agents.</p>
+    <div class="row up"><b>Buys</b> — the gemini-moved-directory bug becomes structurally impossible. Adding a
+      harness becomes one entry instead of four edits in two apps. <code>--roots</code> stops lying by omission.</div>
+    <div class="row down"><b>Costs / watch out</b> — a naive <code>{agent, subdir}</code> manifest is exactly what
+      exists today and it's <em>why</em> OpenCode fell out: it can't express “one global DB file,” “one
+      <code>.db</code> per trajectory” (antigravity), “dir-per-session with messages.jsonl” (rush), or claude's
+      project-hashed dirs. Model it as a small <code>locate()</code> capability returning
+      <code>{kind: 'dir'|'file'|'glob', path}[]</code>. If you ship a path-string manifest plus five exceptions,
+      you've rebuilt today's problem with more ceremony.</div>
+  </div>
+
+  <div class="idea">
+    <h4><span class="num">2</span>Four storage shapes, not eleven harnesses
+      <span class="effort">medium · kills the 4× parser dup</span></h4>
+    <p>The report proposes one <code>HarnessAdapter</code> per harness. Go one level more abstract first: there are
+    only about <b>four physical shapes</b> in play.</p>
+    <ul class="tight">
+      <li><b class="k">Append-only NDJSON</b> — claude, codex, droid, grok, copilot, rush/<code>messages.jsonl</code></li>
+      <li><b class="k">One JSON doc per session</b> — gemini</li>
+      <li><b class="k">SQLite, one DB per session</b> — antigravity (<code>conversations/&lt;uuid&gt;.db</code>), cursor (<code>store.db</code>)</li>
+      <li><b class="k">SQLite, one global DB</b> — opencode</li>
+    </ul>
+    <p>Write four readers. A harness then declares <code>(shape, locate, fieldMap)</code> — data, not code.</p>
+    <div class="row up"><b>Buys</b> — new harness = a data entry, reviewed in a minute. The tail-read, head-read
+      and full-read strategies get written once per shape instead of once per harness per call site (today: ~4× × 11).</div>
+    <div class="row down"><b>Costs / watch out</b> — two real limits. (a) <b>Field mapping is lossy</b>; keep a raw
+      passthrough on every normalized event or you'll silently drop the harness-specific detail some surface
+      depends on. (b) <b>SQLite sources can't be tailed like NDJSON</b> — WAL page writes don't map onto
+      “bytes appended since offset,” so incremental reads need <code>data_version</code>/rowid watermarks, not
+      byte offsets. Your unification will have a seam there no matter what; name it deliberately rather than
+      discovering it at implementation time.</div>
+  </div>
+
+  <div class="idea">
+    <h4><span class="num">3</span>One SQLite surface, hoisted into <code>packages/</code>
+      <span class="effort">small · removes a silent fork</span></h4>
+    <p>Move <span class="fl">apps/cli/src/lib/sqlite.ts</span> into a shared package and add a third backend:
+    <code>bun:sqlite</code> → <code>node:sqlite</code> → <code>sql.js</code>. Factory imports the package instead
+    of <code>sql.js</code> directly.</p>
+    <div class="row up"><b>Buys</b> — one BLOB/param/error contract instead of two that will drift. Factory gets
+      the fast native path automatically when the extension host's Node is ≥22.5, and keeps working when it isn't.
+      Also fixes the load-whole-DB-into-a-Buffer read at <span class="fl">sessions.vscode.ts:731</span> for free
+      on the native path.</div>
+    <div class="row down"><b>Costs / watch out</b> — <code>sql.js</code> genuinely can't do everything the native
+      drivers can (no incremental BLOB I/O, no real WAL, whole-file-in-memory). A “unified” shim that pretends
+      otherwise is worse than two honest ones. Make the capability explicit —
+      <code>db.capabilities.streaming</code> — and let callers degrade, rather than papering over it.</div>
+  </div>
+
+  <div class="idea">
+    <h4><span class="num">4</span>The extension stops touching transcripts at all
+      <span class="effort">medium · the biggest dup deletion</span></h4>
+    <p>Today factory has its own roots tables, its own head parser, its own activity parser, and its own SQLite
+    reader — while <em>also</em> shelling out to the CLI every 3s. Pick one. Make the CLI the only thing that
+    knows a transcript format; the extension becomes a pure consumer of normalized rows.</p>
+    <div class="row up"><b>Buys</b> — deletes ~2 of the 4 parsers and 2 of the 4 roots tables outright. The whole
+      class of “factory sees a different set of sessions than the CLI does” disappears. It also makes move 5
+      trivial, because there's then exactly one producer to stream from.</div>
+    <div class="row down"><b>Costs / watch out</b> — this hard-couples the extension to a compatible agents-cli
+      version, and <code>agents use</code> switches version homes underneath it. You need (a) a declared protocol
+      version on <code>--roots</code>/<code>--active</code> output and (b) a degraded mode when the CLI is absent
+      or too old — <code>watcherRootsFromCli()</code>'s try/fallback is the right pattern, generalize it rather
+      than dropping it. Do <b>not</b> delete the fallback in the name of purity; a VS Code extension that
+      hard-fails on a stale CLI is a worse product than one that shows less.</div>
+  </div>
+
+  <div class="idea">
+    <h4><span class="num">5</span>Stream the fan-out before you build a daemon
+      <span class="effort">small · ~80% of the daemon's win</span></h4>
+    <p>The report's headline is “resident daemon + push bus.” Right direction, but there's a much cheaper step
+    that captures most of it: keep the SSH fan-out, make the remote side <b>long-lived</b> —
+    <code>agents sessions --active --watch --json</code> streaming NDJSON deltas over a single ControlMaster
+    channel (<span class="fl">ssh-exec.ts:76</span>) that stays open.</p>
+    <div class="row up"><b>Buys</b> — kills the per-poll Node cold start and rescan on every peer, which is the
+      dominant cost the report identifies (bottlenecks 1 and 2) — <em>without</em> inventing daemon lifecycle,
+      leader election, or inbound connectivity. One process per host per subscriber, not one per host per 3s.</div>
+    <div class="row down"><b>Costs / watch out</b> — long-lived SSH channels need reconnect/backoff and orphan
+      reaping (a dropped VS Code window must not leave a watcher running on yosemite-s0). And it moves cost from
+      CPU to open FDs and idle processes across the fleet. Still far less new state than a daemon. The real
+      argument for doing this <em>first</em> is that it forces you to define the delta format — which is the
+      daemon's actual hard part, learned cheaply.</div>
+  </div>
+
+  <div class="idea">
+    <h4><span class="num">6</span>Session identity is not a file path
+      <span class="effort">small · unblocks moves 1–2</span></h4>
+    <p>The index is keyed on <code>file_path</code> (<span class="fl">db.ts:103</span> <code>scan_ledger</code>),
+    which assumes one file per session. Row-backed harnesses already break it — OpenCode sessions get a synthetic
+    <code>opencode.db#&lt;id&gt;</code> composite key (<span class="fl">discover.ts:1587</span>). And
+    <code>canonicalLedgerKey</code> (<span class="fl">db.ts:28</span>) exists purely to realpath version-home
+    symlinks so <code>agents use</code> doesn't bust the cache — a second identity patch on the same assumption.</p>
+    <div class="row up"><b>Buys</b> — a real <code>SessionRef {harness, sessionId, source}</code> makes SQLite
+      harnesses first-class instead of hacks, and makes the “where do transcripts live” question answerable
+      uniformly across dir-, file-, and row-backed sources. Both existing patches collapse into it.</div>
+    <div class="row down"><b>Costs / watch out</b> — this is a schema migration on a live DB
+      (<code>SCHEMA_VERSION</code> is already at 13, so the machinery exists, but every machine on the fleet
+      re-indexes on upgrade — a visible one-time stall). Do it <em>before</em> moves 1–2 or you'll build the
+      manifest against an identity model that can't hold it.</div>
+  </div>
+</section>
+
+<!-- 3 -->
+<section id="s8">
+  <div class="sec-num">03</div>
+  <h2>Order of operations</h2>
+  <p class="sub">If you only do part of this, do the top half — it's most of the value at a fraction of the risk.</p>
+  <ul class="tight">
+    <li><b class="k">First</b> — move 6 (identity), then move 1 (manifest). Small, mechanical, and they delete a
+      live class of bug rather than optimizing a hot path.</li>
+    <li><b class="k">Then</b> — move 3 (one SQLite package) and move 4 (extension stops parsing). These are the
+      dup deletions; they get easier once the manifest exists.</li>
+    <li><b class="k">Then</b> — move 5 (streaming fan-out). Measure after this. It may well be enough.</li>
+    <li><b class="k">Only then</b> — the daemon + event bus the report proposes. It's the right end state, but it
+      introduces lifecycle, leader election, crash recovery, and version-skew problems that the current
+      zero-background-state design deliberately avoids. Build it as an <em>optional accelerator</em> with the
+      poll path retained as the fallback, so a dead daemon degrades to “slower” rather than “blind.”</li>
+  </ul>
+  <div class="call correct"><span class="tag">Note</span>
+    <p>Nothing here touches §7 of the report — the teams / SSH / detached-launch layering. That part is genuinely
+    well-factored (<code>launchDetached</code> “lives in exactly one place”), and the argv-level coupling between
+    <code>run</code> and <code>teams</code> is a feature, not debt. Leave it alone.</p>
+  </div>
+</section>
+
+<div class="foot wrap">
+  Verified against agents-cli @ 827565549 — apps/cli, apps/factory, packages/session-tracker.
+  Every file:line above was re-read from source, not carried over from the original report.
+</div>
+</div>
+
+<script>
+  (function(){
+    var root=document.documentElement, btn=document.getElementById('tg');
+    try{var pref=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;
+      root.setAttribute('data-theme', pref?'light':'dark');}catch(e){}
+    btn.addEventListener('click',function(){
+      root.setAttribute('data-theme', root.getAttribute('data-theme')==='dark'?'light':'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/agents-cli-measured.html
+++ b/docs/plans/2026-07-30/agents-cli-measured.html
@@ -1,0 +1,476 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents-cli — measured</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e8ebe6; --ink-dim:#9aa295;
+    --line:#242724; --lime:#a3e635; --lime-dim:#6f9e26; --amber:#f4bf4f; --red:#ff6b5e;
+    --cyan:#5ec7d6; --violet:#b08cff; --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;
+    --code-bg:#0d0f0d; --chip:#1a1d19; --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 30px rgba(0,0,0,.5);
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f4; --panel:#ffffff; --panel-2:#fbfcfa; --ink:#16180f; --ink-dim:#5c6356;
+    --line:#e2e6dc; --lime:#5c8a13; --lime-dim:#7fae2c; --amber:#9a6a00; --red:#c23b2e;
+    --cyan:#0f7d8c; --violet:#6d45c9; --code-bg:#f1f3ec; --chip:#eef1e8; --shadow:0 1px 0 rgba(0,0,0,.02),0 10px 30px rgba(0,0,0,.08);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
+    font-size:16px;-webkit-font-smoothing:antialiased}
+  a{color:var(--lime);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code,kbd,.mono{font-family:var(--mono)}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+
+  .topbar{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 88%,transparent);
+    backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .brand{font-family:var(--mono);font-weight:700;letter-spacing:.02em;font-size:15px}
+  .brand .dot{color:var(--lime)}
+  .toggle{font-family:var(--mono);font-size:13px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:8px;padding:6px 12px;cursor:pointer}
+  .toggle:hover{color:var(--ink);border-color:var(--lime-dim)}
+
+  .hero{padding:64px 0 40px;border-bottom:1px solid var(--line)}
+  .kicker{font-family:var(--mono);font-size:12.5px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--lime);margin-bottom:18px}
+  h1{font-size:clamp(30px,4.6vw,50px);line-height:1.06;margin:0 0 20px;letter-spacing:-.02em;font-weight:800}
+  h1 .g{color:var(--lime)}
+  h1 .r{color:var(--red)}
+  .lede{font-size:19px;color:var(--ink-dim);max-width:790px;margin:0 0 26px}
+  .lede b{color:var(--ink);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:9px;margin-bottom:8px}
+  .chip{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:999px;padding:5px 12px}
+  .chip b{color:var(--lime);font-weight:600}
+  .chip.hot b{color:var(--red)}
+
+  .toc{margin:30px 0 0;padding:18px 20px;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  .toc h4{margin:0 0 12px;font-family:var(--mono);font-size:12px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink-dim)}
+  .toc ol{margin:0;padding:0;list-style:none;display:grid;grid-template-columns:1fr 1fr;gap:6px 26px;
+    counter-reset:toc}
+  .toc li{counter-increment:toc;font-size:14.5px;display:flex;gap:10px;align-items:baseline}
+  .toc li::before{content:counter(toc,decimal-leading-zero);font-family:var(--mono);font-size:12px;
+    color:var(--lime-dim);min-width:22px}
+  @media(max-width:720px){.toc ol{grid-template-columns:1fr}}
+
+  section{padding:52px 0;border-bottom:1px solid var(--line)}
+  .sec-num{font-family:var(--mono);font-size:13px;color:var(--lime);letter-spacing:.1em}
+  h2{font-size:clamp(22px,3vw,30px);margin:8px 0 6px;letter-spacing:-.015em;font-weight:750}
+  h3{font-size:18px;margin:30px 0 8px;font-weight:650}
+  .sub{color:var(--ink-dim);font-size:15.5px;max-width:840px}
+  p{max-width:840px}
+  ul.tight{max-width:840px;padding-left:18px}
+  ul.tight li{margin:6px 0}
+  .fl{font-family:var(--mono);font-size:12.5px;color:var(--cyan);background:var(--code-bg);
+    border:1px solid var(--line);border-radius:5px;padding:1px 6px;white-space:nowrap}
+  b.k{color:var(--lime)}
+
+  .call{margin:22px 0;padding:16px 18px 16px 20px;border-radius:12px;border:1px solid var(--line);
+    background:var(--panel);position:relative;box-shadow:var(--shadow)}
+  .call::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;border-radius:12px 0 0 12px}
+  .call.correct::before{background:var(--lime)}
+  .call.warn::before{background:var(--amber)}
+  .call.hot::before{background:var(--red)}
+  .call .tag{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+    font-weight:700;margin-bottom:6px;display:block}
+  .call.correct .tag{color:var(--lime)}
+  .call.warn .tag{color:var(--amber)}
+  .call.hot .tag{color:var(--red)}
+  .call p{margin:2px 0;max-width:none}
+
+  pre{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;padding:14px 16px;
+    overflow:auto;font-family:var(--mono);font-size:12.7px;line-height:1.6;box-shadow:var(--shadow)}
+  pre .c{color:var(--ink-dim)}
+  pre .g{color:var(--lime)}
+  pre .a{color:var(--amber)}
+  pre .r{color:var(--red)}
+  pre .cy{color:var(--cyan)}
+
+  .scroller{overflow-x:auto}
+  table{width:100%;border-collapse:collapse;margin:20px 0;font-size:14px}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;
+    color:var(--ink-dim);font-weight:600}
+  td.n{font-family:var(--mono);text-align:right;white-space:nowrap}
+  td.n.bad{color:var(--red)}
+  td.n.good{color:var(--lime)}
+  tr.sum td{font-weight:700;border-bottom:2px solid var(--line)}
+  td .fl{white-space:normal}
+
+  figure{margin:26px 0}
+  figure svg{width:100%;height:auto;display:block;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  figcaption{font-size:13px;color:var(--ink-dim);margin-top:10px;font-family:var(--mono)}
+  .svg-l{font-family:var(--mono);font-size:12px;fill:var(--ink)}
+  .svg-s{font-family:var(--mono);font-size:10.5px;fill:var(--ink-dim)}
+  .svg-t{font-family:var(--mono);font-size:11px;fill:var(--ink-dim)}
+  .box{fill:var(--panel-2);stroke:var(--line);stroke-width:1.2}
+  .box-hot{fill:var(--panel-2);stroke:var(--red);stroke-width:1.6}
+  .box-lime{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.4}
+
+  .bn{margin:20px 0;padding:18px 20px;background:var(--panel);border:1px solid var(--line);
+    border-radius:12px;box-shadow:var(--shadow)}
+  .bn h4{margin:0 0 8px;font-size:17px;display:flex;align-items:center;gap:2px}
+  .rank{display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);
+    font-weight:700;font-size:13px;width:26px;height:26px;border-radius:7px;margin-right:10px;flex:none}
+  .rank.p1{background:var(--red);color:#160a08}
+  .rank.p2{background:var(--amber);color:#1a1200}
+  .rank.p3{background:var(--lime);color:#0c1400}
+  .bn .ev{font-family:var(--mono);font-size:12px;color:var(--ink-dim);margin:8px 0}
+  .bn .fix{border-top:1px dashed var(--line);margin-top:12px;padding-top:10px;font-size:14.5px}
+  .bn .fix b{color:var(--lime)}
+  .was{font-family:var(--mono);font-size:11px;padding:2px 9px;border-radius:999px;
+    border:1px solid var(--line);color:var(--ink-dim);margin-left:auto;font-weight:400;flex:none}
+
+  .foot{padding:40px 0 70px;color:var(--ink-dim);font-size:13px;font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div class="topbar"><div class="wrap">
+  <div class="brand">agents<span class="dot">·</span>cli <span style="color:var(--ink-dim)">/ measured</span></div>
+  <button class="toggle" id="tg">◐ theme</button>
+</div></div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="kicker">Third pass · numbers, not reasoning</div>
+  <h1>The bottleneck isn't the poll. It's <span class="r">80 GB</span> of data nothing ever deletes.</h1>
+  <p class="lede">Both previous passes reasoned about performance from source. This one <b>measures</b> it — and the
+  measurements reorder the whole list. The database is <b>1 ms</b>. Cold start is <b>0.09 s</b>. Neither is the
+  problem. Meanwhile <b>505 MB</b> of the index is a copy of text that is written and never read, <b>68%</b> of
+  the index rows are dead, and <code>~/.agents</code> has grown to <b>80 GB</b> with no retention policy anywhere.</p>
+  <div class="chips">
+    <span class="chip">measured on <b>zion</b> · 2026-07-30</span>
+    <span class="chip">sessions.db <b>813 MB</b></span>
+    <span class="chip hot">~/.agents <b>80 GB</b></span>
+    <span class="chip">index rows <b>12,180</b></span>
+    <span class="chip hot">dead rows <b>68%</b></span>
+  </div>
+
+  <nav class="toc">
+    <h4>What's inside</h4>
+    <ol>
+      <li><a href="#s1">The measurements</a></li>
+      <li><a href="#s2">Where 813 MB actually went</a></li>
+      <li><a href="#s3">The 80 GB — and why it's immortal</a></li>
+      <li><a href="#s4">Bottlenecks, re-ranked by measurement</a></li>
+      <li><a href="#s5">Where the report is mis-aimed</a></li>
+      <li><a href="#s6">The architecture call</a></li>
+      <li><a href="#s7">What I could not determine</a></li>
+    </ol>
+  </nav>
+</header>
+
+<!-- 1 -->
+<section id="s1">
+  <div class="sec-num">01</div>
+  <h2>The measurements</h2>
+  <p class="sub">Every number below was produced on this machine, just now. The bisect is the important part:
+  each row isolates one more layer.</p>
+
+  <div class="scroller">
+  <table>
+    <tr><th>What</th><th>Measured</th><th>Reading</th></tr>
+    <tr><td><code>agents --version</code></td><td class="n good">0.09 s</td>
+        <td>Binary cold start. The installed CLI is a <b>Bun-compiled single-file binary</b> (<code>__BUN</code> segment), not Node — so “Node cold-start” is not a cost that exists here.</td></tr>
+    <tr><td><code>sessions --roots --json</code></td><td class="n good">0.14 s</td>
+        <td>Start + roots resolution, no DB touched.</td></tr>
+    <tr><td>raw <code>node:sqlite</code> open of the 813 MB db</td><td class="n good">~0 ms</td>
+        <td>Opening it is free. WAL + page cache; nothing is read on open.</td></tr>
+    <tr><td>raw query <code>SELECT … LIMIT 1</code></td><td class="n good">1 ms</td><td>The database is not slow. At all.</td></tr>
+    <tr><td><code>sessions --local --limit 1 --json</code></td><td class="n bad">0.56 s</td>
+        <td rowspan="2"><b>The key result.</b> Identical cost for 1 row and 500 rows → the ~0.42 s is a <b>fixed per-invocation cost</b>, not per-row work, and not the database.</td></tr>
+    <tr><td><code>sessions --local --limit 500 --json</code></td><td class="n bad">0.58 s</td></tr>
+    <tr class="sum"><td><code>sessions --active --json --local</code></td><td class="n bad">1.04–1.17 s</td>
+        <td>The 3-second poll. <b>151 MB peak RSS</b>, 4,111 involuntary context switches, 21 live rows returned.</td></tr>
+  </table>
+  </div>
+
+  <div class="call hot"><span class="tag">Attribution, corrected</span>
+    <p>The report attributes the poll cost to “Node cold-start + <code>discoverSessions</code> scan.” Measured, the
+    binary starts in <b>0.09 s</b> and SQLite answers in <b>1 ms</b>. Roughly <b>0.45 s of fixed setup</b> and
+    <b>~0.6 s of active-specific work</b> account for essentially all of it. Building a daemon to avoid a
+    0.09 s cold start would be optimizing the one part that is already fast.</p></div>
+
+  <p>For scale: at a 3 s poll, 1.1 s of work is a <b>~35% duty cycle of one core, per host, per window</b>, plus
+  151 MB resident each cycle. That is the real steady-state cost — and it is worth fixing. But the fix follows
+  from what the 0.45 s <em>is</em>, which nobody has profiled yet (§07).</p>
+</section>
+
+<!-- 2 -->
+<section id="s2">
+  <div class="sec-num">02</div>
+  <h2>Where 813 MB actually went</h2>
+  <p class="sub">The report says the index holds “metadata only.” Per-table <code>dbstat</code> says otherwise.</p>
+
+  <pre><span class="c">SELECT name, SUM(pgsize) FROM dbstat GROUP BY name ORDER BY 2 DESC</span>
+
+<span class="r">  504.9 MB</span>   session_text_content    <span class="c">← FTS5's stored copy of the text</span>
+<span class="a">  255.8 MB</span>   session_text_data       <span class="c">← the inverted index (this is the feature)</span>
+<span class="g">    7.6 MB</span>   sessions                <span class="c">← the actual metadata</span>
+      2.0 MB   idx_sessions_file_path
+      0.8 MB   scan_ledger  ·  0.8 MB session_text_idx  ·  &lt;1 MB each: 8 more indexes</pre>
+
+  <p><b class="k">99% of the database is the search feature, and 62% of it is a second copy of text that already
+  exists on disk in the transcripts.</b></p>
+
+  <h3>That copy is write-only</h3>
+  <p>FTS5 stores the source text by default so you can <code>SELECT</code> it back for
+  <code>snippet()</code>/<code>highlight()</code>. This codebase never does:</p>
+  <pre><span class="c">// the ONLY write — db.ts:598</span>
+INSERT INTO session_text (session_id, label, topic, project, <span class="r">content</span>) VALUES (?,?,?,?,?)
+
+<span class="c">// the ONLY read — db.ts:1313-1319</span>
+SELECT <span class="g">session_id</span>, <span class="g">bm25</span>(session_text, 5.0, 2.0, 1.5, 1.0) AS rank
+FROM session_text WHERE session_text <span class="g">MATCH</span> ? ORDER BY rank ASC LIMIT ?
+
+<span class="c">// no snippet(), no highlight(), no SELECT content — anywhere</span></pre>
+
+  <div class="call correct"><span class="tag">Highest value per line changed in the codebase</span>
+    <p>Declare the FTS table <code>content=''</code> (contentless) with <code>contentless_delete=1</code>.
+    Ranking, <code>MATCH</code>, and BM25 weights behave identically — the only thing you lose is the ability to
+    select the text back, which nothing does. <b>−505 MB, ~62% smaller database</b>, plus faster inserts and a far
+    cheaper <code>VACUUM</code>. <code>contentless_delete</code> needs SQLite ≥ 3.43; this machine reports
+    <b>3.53.2</b>, and the existing <code>DELETE FROM session_text WHERE session_id = ?</code> (db.ts:596) keeps
+    working with it. It's a schema-version bump (already at 13) and a rebuild.</p></div>
+</section>
+
+<!-- 3 -->
+<section id="s3">
+  <div class="sec-num">03</div>
+  <h2>The 80 GB — and the line of code that makes it immortal</h2>
+  <p class="sub">This is the finding neither pass had, and it dwarfs everything else.</p>
+
+  <pre><span class="c">du -sh ~/.agents</span>                          <span class="r">80 GB</span>
+  ~/.agents/.history/trash               <span class="r">46 GB</span>   <span class="c">← soft-deleted agent version homes</span>
+  ~/.agents/.history/versions            <span class="a">12 GB</span>   <span class="c">← live version homes (13 claude, 4 codex, 5 grok…)</span>
+  ~/.agents/.history/sessions            <span class="a">790 MB</span>  <span class="c">← the index</span>
+  ~/.agents/.history/backups             346 MB
+
+<span class="c">individual claude version homes:</span>
+  2.1.187/home/.claude/projects          <span class="r">1.3 GB</span>
+  2.1.207/…                              679 MB      2.1.181/… 638 MB      2.1.220/… 354 MB</pre>
+
+  <p>Every agent version upgrade snapshots a <b>complete home directory, transcripts included</b>. Thirteen live
+  claude homes and twelve trashed ones, each carrying its own copy of that version's session history. Nothing
+  reaps them — there is no retention policy in the codebase for either <code>versions/</code> or
+  <code>trash/</code>.</p>
+
+  <h3>Why the index rows are immortal too</h3>
+  <p>When a version is removed, <span class="fl">db.ts:1349</span> <code>updateSessionFilePaths</code> repoints
+  its sessions at the trash copy so reads keep working — and, in the same transaction, <b>deletes their
+  <code>scan_ledger</code> entry</b>:</p>
+  <pre>UPDATE sessions SET file_path = ? WHERE id = ?            <span class="c">// → …/.history/trash/…</span>
+<span class="r">DELETE FROM scan_ledger WHERE file_path = ?</span>               <span class="c">// db.ts:1367</span></pre>
+  <p>The intent is sound (“session reads still work from the trash path”). The consequence is not: trash is not a
+  scan root, so those rows are never revisited, never refreshed, and never removed. Each version removal
+  permanently deposits its sessions into the index.</p>
+
+  <h3>The index, audited row by row</h3>
+  <div class="scroller">
+  <table>
+    <tr><th>Bucket</th><th>Rows</th><th>Share</th><th>Meaning</th></tr>
+    <tr><td>points into <code>.history/trash/</code></td><td class="n bad">4,426</td><td class="n">36%</td><td>readable, but in a graveyard nothing scans</td></tr>
+    <tr><td>points into a version home</td><td class="n">2,327</td><td class="n">19%</td><td>duplicated history from old installs</td></tr>
+    <tr><td>points at a live agent home</td><td class="n good">4,890</td><td class="n">40%</td><td>the sessions you actually have</td></tr>
+    <tr><td>backups mirror / other</td><td class="n">447</td><td class="n">4%</td><td>fleet sync</td></tr>
+    <tr><td><code>file_path = ''</code></td><td class="n bad">90</td><td class="n">1%</td><td>claude rows that can never be opened — a data-quality bug</td></tr>
+    <tr class="sum"><td>total</td><td class="n">12,180</td><td class="n">100%</td><td></td></tr>
+  </table>
+  </div>
+
+  <p>Cross-checked against the filesystem, independent of bucket:</p>
+  <ul class="tight">
+    <li><b class="k">4,853 rows (40%) point at a file that no longer exists.</b> Nothing ever garbage-collects them.</li>
+    <li><b class="k">Only 3,753 of 12,090 paths (31%) have a <code>scan_ledger</code> entry</b> — so the
+      incremental mtime/size skip, which the report presents as the reason scans are cheap, covers under a third
+      of the index.</li>
+    <li>Of the existing-but-unledgered files, a sampled check found 331 were realpath aliases (a false alarm I
+      ruled out) and <b>3,421 genuinely unledgered</b> — all in trashed version homes, exactly as the
+      <code>updateSessionFilePaths</code> path predicts.</li>
+  </ul>
+
+  <div class="call hot"><span class="tag">Net</span>
+    <p>Roughly <b>68% of the index is dead weight</b> — gone or trashed. Every BM25 query ranks against it, every
+    list carries it, and it is holding a proportional share of that 505 MB of write-only text.</p></div>
+</section>
+
+<!-- DIAGRAM -->
+<figure>
+<svg viewBox="0 0 1040 300" role="img" aria-label="database composition today vs after">
+  <text x="20" y="26" class="svg-l" fill="var(--red)">TODAY — 813 MB</text>
+  <text x="560" y="26" class="svg-l" fill="var(--lime)">AFTER contentless FTS + GC — ~95 MB</text>
+  <line x1="530" y1="40" x2="530" y2="280" stroke="var(--line)" stroke-width="1.2" stroke-dasharray="4 4"/>
+
+  <!-- today bar -->
+  <rect x="20" y="60" width="300" height="46" rx="6" class="box-hot"/>
+  <text x="170" y="80" text-anchor="middle" class="svg-s">session_text_content</text>
+  <text x="170" y="96" text-anchor="middle" class="svg-s">504.9 MB · never read back</text>
+
+  <rect x="20" y="116" width="152" height="46" rx="6" class="box"/>
+  <text x="96" y="136" text-anchor="middle" class="svg-s">session_text_data</text>
+  <text x="96" y="152" text-anchor="middle" class="svg-s">255.8 MB</text>
+
+  <rect x="20" y="172" width="30" height="46" rx="6" class="box-lime"/>
+  <text x="60" y="192" class="svg-s">sessions — 7.6 MB</text>
+  <text x="60" y="208" class="svg-s">the actual metadata</text>
+
+  <text x="20" y="252" class="svg-s" fill="var(--red)">62% is a duplicate of text already on disk</text>
+  <text x="20" y="270" class="svg-s" fill="var(--red)">68% of rows describe files that are gone or trashed</text>
+
+  <!-- after bar -->
+  <rect x="560" y="60" width="96" height="46" rx="6" class="box-lime"/>
+  <text x="608" y="80" text-anchor="middle" class="svg-s">fts index</text>
+  <text x="608" y="96" text-anchor="middle" class="svg-s">~82 MB</text>
+
+  <rect x="560" y="116" width="14" height="46" rx="4" class="box-lime"/>
+  <text x="584" y="136" class="svg-s">sessions — ~2.5 MB (live rows only)</text>
+  <text x="584" y="152" class="svg-s">+ indexes</text>
+
+  <text x="560" y="200" class="svg-s" fill="var(--lime)">content='' + contentless_delete=1  →  −505 MB</text>
+  <text x="560" y="218" class="svg-s" fill="var(--lime)">GC dead rows (68%)                 →  −~215 MB more</text>
+  <text x="560" y="236" class="svg-s" fill="var(--lime)">retention on trash/versions        →  −46 GB on disk</text>
+  <text x="560" y="270" class="svg-s">no feature removed · no architecture changed</text>
+</svg>
+<figcaption>Fig 1 — the size problem is two config changes and a reaper, not a redesign. Post-GC figures are projections from the measured composition, not measurements.</figcaption>
+</figure>
+
+<!-- 4 -->
+<section id="s4">
+  <div class="sec-num">04</div>
+  <h2>Bottlenecks, re-ranked by measurement</h2>
+  <p class="sub">The badge on the right is where the original report ranked each one.</p>
+
+  <div class="bn">
+    <h4><span class="rank p1">1</span>505 MB of write-only text in the index <span class="was">report: unlisted</span></h4>
+    <p class="ev">dbstat: <code>session_text_content</code> 504.9 MB. Written at db.ts:598, read nowhere — the sole FTS query selects <code>session_id</code> and <code>bm25()</code> only (db.ts:1313).</p>
+    <div class="fix"><b>Fix:</b> <code>content=''</code> + <code>contentless_delete=1</code>. Identical search behavior, −62% database. One DDL change plus a schema-version bump. Do this first — it is the cheapest large win available.</div>
+  </div>
+
+  <div class="bn">
+    <h4><span class="rank p1">2</span>No retention policy anywhere — 46 GB of trash, 12 GB of version homes <span class="was">report: unlisted</span></h4>
+    <p class="ev">Measured <code>du</code>: 80 GB total under <code>~/.agents</code>. Individual claude version homes at 1.3 GB / 679 MB / 638 MB. No prune/reap/retention code path exists for <code>versions/</code> or <code>trash/</code>.</p>
+    <div class="fix"><b>Fix:</b> a reaper with an explicit policy — keep N most-recent version homes and M days of trash; on eviction, delete the directory <em>and</em> its index rows. Ship it with an <code>agents doctor</code> line that reports the number so it can't silently regrow. Note the real design question underneath: a version home does not need to carry transcripts at all — separating “the agent install” from “the conversations it produced” removes the duplication at the source.</div>
+  </div>
+
+  <div class="bn">
+    <h4><span class="rank p1">3</span>68% of index rows are dead; the ledger covers 31% <span class="was">report: partially, as #4</span></h4>
+    <p class="ev">4,853 of 12,090 paths do not exist on disk; 4,426 point into trash; 3,753 have a ledger entry; 90 rows have <code>file_path = ''</code>. <code>updateSessionFilePaths</code> (db.ts:1349) deletes the ledger entry by design, and nothing re-creates it.</p>
+    <div class="fix"><b>Fix:</b> a GC pass (drop rows whose file is gone, unless deliberately retained), and stop treating <code>file_path</code> as both the identity and the location. Once a session has a stable ref independent of which copy of the file you happened to scan, the trash-repoint hack and the empty-path rows both stop existing.</div>
+  </div>
+
+  <div class="bn">
+    <h4><span class="rank p2">4</span>~0.45 s of fixed per-invocation cost that is neither startup nor SQL <span class="was">report: #1, mis-attributed</span></h4>
+    <p class="ev">Bisect: start 0.09 s · roots 0.14 s · <code>--limit 1</code> 0.56 s · <code>--limit 500</code> 0.58 s · raw DB open+query ~1 ms. Cost is flat in row count, so it is setup, not query.</p>
+    <div class="fix"><b>Fix:</b> <em>profile it before designing around it.</em> Flat-in-N and non-SQL points at module-graph init, roots resolution across 13+ version homes, or the scan-claim path. If it is the version-home walk, fixing #2 fixes this too. Removing 0.45 s from every invocation takes the 3 s poll from ~35% to ~20% duty cycle without any new architecture.</div>
+  </div>
+
+  <div class="bn">
+    <h4><span class="rank p2">5</span>The 3 s poll itself — 1.1 s and 151 MB, × windows × hosts <span class="was">report: #1</span></h4>
+    <p class="ev">Measured 1.04–1.17 s wall, 151 MB peak RSS, for 21 live rows.</p>
+    <div class="fix"><b>Fix:</b> still real, still worth fixing — but it is <em>fourth</em>, and the honest sequence is: fix #4 first, re-measure, then decide between a streaming fan-out and a full daemon. If #4 takes <code>--active</code> to ~0.3 s, a long-lived stream is plenty and the daemon never needs to be built.</div>
+  </div>
+
+  <div class="bn">
+    <h4><span class="rank p3">6</span>Four parsers / four location tables / two SQLite drivers <span class="was">report: #3</span></h4>
+    <p class="ev">Carried over from the previous pass; unchanged and still verified.</p>
+    <div class="fix"><b>Fix:</b> as before — one manifest with a <code>locate()</code>, four storage-shape readers, one SQLite package. This is a correctness and maintenance win, not a performance one; rank it accordingly.</div>
+  </div>
+</section>
+
+<!-- 5 -->
+<section id="s5">
+  <div class="sec-num">05</div>
+  <h2>Where the report is mis-aimed</h2>
+  <ul class="tight">
+    <li><b class="k">“Node cold-start.”</b> The shipped binary is Bun-compiled and starts in 0.09 s. This cost does
+      not exist, and it is the stated justification for the daemon.</li>
+    <li><b class="k">“The index holds metadata only.”</b> The metadata table is 7.6 MB of an 813 MB file. The other
+      99% is search, and most of that is redundant.</li>
+    <li><b class="k">“scan_ledger means only changed files are re-read.”</b> True for the 31% of rows that have a
+      ledger entry. The mechanism is right; its coverage is not.</li>
+    <li><b class="k">Bottleneck #5, “back the event stream with SQLite.”</b> Measured, <code>events.jsonl</code> is
+      1.9 MB / 5,431 lines. A linear scan of that is sub-millisecond. Migrating it to a database is not a
+      performance fix — argue for it on the subscribe surface if you want it, not on speed.</li>
+    <li><b class="k">Bottleneck #6, “full-transcript render reads the whole file.”</b> Correct, and it matters more
+      than the ranking suggests now that we know claude transcripts total 354 MB in the live home alone — but the
+      live path (<code>readSessionTailWithRaw</code>, tail.ts) is already bounded to a 128 KB
+      <code>pread</code> tail. That part is well built; leave it alone.</li>
+  </ul>
+  <div class="call correct"><span class="tag">Credit where due</span>
+    <p>The bounded tail read, the WAL + ledger design, the <code>launchDetached</code> single-implementation rule,
+    and the argv-level coupling between <code>run</code> and <code>teams</code> are all genuinely good. The problems
+    found here are accumulation and bookkeeping problems, not design failures in the hot path.</p></div>
+</section>
+
+<!-- 6 -->
+<section id="s6">
+  <div class="sec-num">06</div>
+  <h2>The architecture call</h2>
+  <p class="sub">You asked for “highly performant, best architecture.” On the evidence, the best architecture here
+  is mostly <em>less</em>, not more.</p>
+  <ul class="tight">
+    <li><b class="k">Do first — two config changes and a reaper.</b> Contentless FTS (−505 MB), a GC pass for dead
+      rows (−68% of the index), a retention policy for <code>trash/</code> and <code>versions/</code> (−46 GB).
+      No architecture changes, no new components, no new failure modes. This is the entire size problem.</li>
+    <li><b class="k">Then profile the 0.45 s.</b> It is the only unexplained cost left, it is on every single
+      invocation, and it is very likely tied to walking 13+ version homes — i.e. the same root cause as the
+      retention problem. Measure, then decide.</li>
+    <li><b class="k">Then, and only then, consider the transport.</b> If <code>--active</code> lands near 0.3 s, a
+      long-lived <code>--watch</code> stream over the existing ControlMaster channel is sufficient and adds no
+      daemon lifecycle. Build the emit → DB → subscribe bus only if the numbers still justify it after the above.</li>
+    <li><b class="k">Fix identity as the enabler, not as cleanup.</b> A <code>SessionRef</code> that is stable
+      across copies is what makes the GC safe, makes the trash-repoint hack unnecessary, and makes the harness
+      manifest expressible. It is small, and three other fixes depend on it.</li>
+    <li><b class="k">Question the version-home snapshot.</b> The deepest fix: an agent version home should not
+      contain the conversations. If transcripts lived in one canonical store and version homes carried only
+      config, there would be no 46 GB, no duplicate indexing, no trash-repointing, and no ledger gap. That is the
+      one change worth calling architectural.</li>
+  </ul>
+</section>
+
+<!-- 7 -->
+<section id="s7">
+  <div class="sec-num">07</div>
+  <h2>What I could not determine</h2>
+  <ul class="tight">
+    <li><b>The composition of the 0.45 s fixed cost.</b> I bisected to it but could not profile inside it — the
+      installed binary is a Bun single-file executable, so <code>node --cpu-prof</code> does not apply and DTrace
+      is blocked by SIP on this machine. To get it: build from source and run
+      <code>bun --inspect apps/cli/src/index.ts sessions --local --limit 1</code>, or add a
+      <code>--timing</code> flag that stamps the phase boundaries. That is the single highest-value next
+      measurement.</li>
+    <li><b>Whether these ratios hold on other fleet hosts.</b> Everything here is zion, which has 13 claude
+      version homes and 12,180 indexed sessions. A worker box with two versions and 400 sessions will show a very
+      different balance — worth running the same bisect on <code>yosemite-s0</code> before committing to the
+      ordering.</li>
+    <li><b>Post-fix sizes are projections.</b> The ~95 MB figure in Fig 1 is arithmetic from the measured
+      composition, not a rebuilt database. Verify by building the contentless schema against a copy.</li>
+  </ul>
+</section>
+
+<div class="foot wrap">
+  Measured on zion, 2026-07-30, against agents-cli @ 827565549 and the live ~/.agents on this machine.
+  Timings are wall-clock from <code>/usr/bin/time</code>; sizes from <code>du</code> and SQLite <code>dbstat</code>.
+</div>
+</div>
+
+<script>
+  (function(){
+    var root=document.documentElement, btn=document.getElementById('tg');
+    try{var pref=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;
+      root.setAttribute('data-theme', pref?'light':'dark');}catch(e){}
+    btn.addEventListener('click',function(){
+      root.setAttribute('data-theme', root.getAttribute('data-theme')==='dark'?'light':'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/agents-cli-timeline.html
+++ b/docs/plans/2026-07-30/agents-cli-timeline.html
@@ -1,0 +1,443 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents-cli — where the milliseconds go</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e8ebe6; --ink-dim:#9aa295;
+    --line:#242724; --lime:#a3e635; --lime-dim:#6f9e26; --amber:#f4bf4f; --red:#ff6b5e;
+    --cyan:#5ec7d6; --violet:#b08cff; --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',ui-sans-serif,system-ui,-apple-system,sans-serif;
+    --code-bg:#0d0f0d; --chip:#1a1d19; --shadow:0 1px 0 rgba(255,255,255,.03),0 8px 30px rgba(0,0,0,.5);
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f4; --panel:#ffffff; --panel-2:#fbfcfa; --ink:#16180f; --ink-dim:#5c6356;
+    --line:#e2e6dc; --lime:#5c8a13; --lime-dim:#7fae2c; --amber:#9a6a00; --red:#c23b2e;
+    --cyan:#0f7d8c; --violet:#6d45c9; --code-bg:#f1f3ec; --chip:#eef1e8; --shadow:0 1px 0 rgba(0,0,0,.02),0 10px 30px rgba(0,0,0,.08);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
+    font-size:16px;-webkit-font-smoothing:antialiased}
+  a{color:var(--lime);text-decoration:none}
+  code,kbd,.mono{font-family:var(--mono)}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+
+  .topbar{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 88%,transparent);
+    backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .brand{font-family:var(--mono);font-weight:700;letter-spacing:.02em;font-size:15px}
+  .brand .dot{color:var(--lime)}
+  .toggle{font-family:var(--mono);font-size:13px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:8px;padding:6px 12px;cursor:pointer}
+
+  .hero{padding:60px 0 38px;border-bottom:1px solid var(--line)}
+  .kicker{font-family:var(--mono);font-size:12.5px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--lime);margin-bottom:18px}
+  h1{font-size:clamp(28px,4.4vw,46px);line-height:1.07;margin:0 0 20px;letter-spacing:-.02em;font-weight:800}
+  h1 .g{color:var(--lime)} h1 .r{color:var(--red)}
+  .lede{font-size:19px;color:var(--ink-dim);max-width:800px;margin:0 0 24px}
+  .lede b{color:var(--ink);font-weight:600}
+  .chips{display:flex;flex-wrap:wrap;gap:9px}
+  .chip{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--chip);
+    border:1px solid var(--line);border-radius:999px;padding:5px 12px}
+  .chip b{color:var(--lime);font-weight:600}
+  .chip.hot b{color:var(--red)}
+
+  section{padding:48px 0;border-bottom:1px solid var(--line)}
+  .sec-num{font-family:var(--mono);font-size:13px;color:var(--lime);letter-spacing:.1em}
+  h2{font-size:clamp(21px,2.9vw,29px);margin:8px 0 6px;letter-spacing:-.015em;font-weight:750}
+  h3{font-size:17.5px;margin:28px 0 8px;font-weight:650}
+  .sub{color:var(--ink-dim);font-size:15.5px;max-width:850px}
+  p{max-width:850px}
+  ul.tight{max-width:850px;padding-left:18px}
+  ul.tight li{margin:6px 0}
+  .fl{font-family:var(--mono);font-size:12.5px;color:var(--cyan);background:var(--code-bg);
+    border:1px solid var(--line);border-radius:5px;padding:1px 6px;white-space:nowrap}
+  b.k{color:var(--lime)}
+
+  .call{margin:22px 0;padding:16px 18px 16px 20px;border-radius:12px;border:1px solid var(--line);
+    background:var(--panel);position:relative;box-shadow:var(--shadow)}
+  .call::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;border-radius:12px 0 0 12px}
+  .call.correct::before{background:var(--lime)}
+  .call.warn::before{background:var(--amber)}
+  .call.hot::before{background:var(--red)}
+  .call .tag{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+    font-weight:700;margin-bottom:6px;display:block}
+  .call.correct .tag{color:var(--lime)}
+  .call.warn .tag{color:var(--amber)}
+  .call.hot .tag{color:var(--red)}
+  .call p{margin:2px 0;max-width:none}
+
+  pre{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;padding:14px 16px;
+    overflow:auto;font-family:var(--mono);font-size:12.7px;line-height:1.6;box-shadow:var(--shadow)}
+  pre .c{color:var(--ink-dim)} pre .g{color:var(--lime)} pre .a{color:var(--amber)}
+  pre .r{color:var(--red)} pre .cy{color:var(--cyan)}
+
+  .scroller{overflow-x:auto}
+  table{width:100%;border-collapse:collapse;margin:18px 0;font-size:14px}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;
+    color:var(--ink-dim);font-weight:600}
+  td.n{font-family:var(--mono);text-align:right;white-space:nowrap}
+  td.n.bad{color:var(--red)} td.n.good{color:var(--lime)} td.n.mid{color:var(--amber)}
+  tr.sum td{font-weight:700;border-bottom:2px solid var(--line)}
+
+  figure{margin:26px 0}
+  figure svg{width:100%;height:auto;display:block;background:var(--panel);border:1px solid var(--line);
+    border-radius:14px;box-shadow:var(--shadow)}
+  figcaption{font-size:13px;color:var(--ink-dim);margin-top:10px;font-family:var(--mono)}
+  .svg-l{font-family:var(--mono);font-size:12px;fill:var(--ink)}
+  .svg-s{font-family:var(--mono);font-size:10.5px;fill:var(--ink-dim)}
+  .svg-t{font-family:var(--mono);font-size:11px;fill:var(--ink-dim)}
+  .box{fill:var(--panel-2);stroke:var(--line);stroke-width:1.2}
+  .box-hot{fill:var(--panel-2);stroke:var(--red);stroke-width:1.6}
+  .box-lime{fill:var(--panel-2);stroke:var(--lime-dim);stroke-width:1.4}
+  .edge{stroke:var(--ink-dim);stroke-width:1.3;fill:none}
+  .edge-hot{stroke:var(--red);stroke-width:1.7;fill:none}
+  .edge-lime{stroke:var(--lime);stroke-width:1.5;fill:none}
+  .bar-imp{fill:var(--red)} .bar-walk{fill:var(--amber)} .bar-db{fill:var(--lime)}
+  .bar-work{fill:var(--violet)} .bar-idle{fill:var(--line)}
+
+  .foot{padding:36px 0 70px;color:var(--ink-dim);font-size:13px;font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div class="topbar"><div class="wrap">
+  <div class="brand">agents<span class="dot">·</span>cli <span style="color:var(--ink-dim)">/ milliseconds</span></div>
+  <button class="toggle" id="tg">◐ theme</button>
+</div></div>
+
+<div class="wrap">
+<header class="hero">
+  <div class="kicker">Fourth pass · the latency path, profiled</div>
+  <h1>No, it is <span class="g">not</span> re-parsing your sessions. It spends <span class="r">271 ms</span> loading code and <span class="r">127 ms</span> asking where files live.</h1>
+  <p class="lede">Profiled from source, phase by phase. <code>sessions --active</code> costs <b>1.04–1.17 s</b>.
+  The database is <b>3.5 ms</b> of that. It never calls <code>discoverSessions</code> and never re-parses the
+  corpus — it reads a bounded <b>128 KB</b> tail per live session. The time is going somewhere much dumber:
+  <b>module loading</b> and <b>statting 26 directory roots</b>, 14 of which are copies from old version homes.</p>
+  <div class="chips">
+    <span class="chip">profiled with <b>bun</b> from source</span>
+    <span class="chip hot">fixed cost <b>428 ms</b></span>
+    <span class="chip">db <b>3.5 ms</b></span>
+    <span class="chip hot">watch roots <b>26</b></span>
+    <span class="chip hot">search returns <b>0 of 1,247</b></span>
+  </div>
+</header>
+
+<!-- 1 -->
+<section id="s1">
+  <div class="sec-num">01</div>
+  <h2>Where the milliseconds go</h2>
+  <p class="sub">Phase timings, measured by importing the real modules from source and stamping
+  <code>performance.now()</code> between them.</p>
+
+  <pre><span class="c">$ bun prof.ts   # imports the real apps/cli/src/lib/session modules</span>
+<span class="r">    120.1 ms</span>  import db.ts
+<span class="r">    122.5 ms</span>  import discover.ts        <span class="c">// 3,038 lines</span>
+<span class="a">     28.5 ms</span>  import active.ts
+<span class="g">      3.5 ms</span>  getDB()  open + migrate   <span class="c">// the 813 MB database</span>
+<span class="r">    127.0 ms</span>  getSessionRoots()         <span class="c">// stat every version home</span>
+<span class="a">     26.7 ms</span>  ftsSearch('login')
+    --------
+    <b>428.3 ms</b>  TOTAL — matches the measured fixed cost exactly</pre>
+
+  <figure>
+  <svg viewBox="0 0 1040 300" role="img" aria-label="latency waterfall for sessions --active">
+    <text x="20" y="24" class="svg-l">One <tspan class="mono">agents sessions --active --local</tspan> invocation — 1,100 ms</text>
+
+    <!-- axis -->
+    <line x1="20" y1="250" x2="1000" y2="250" stroke="var(--line)"/>
+    <g class="svg-s" fill="var(--ink-dim)">
+      <text x="20" y="268">0</text><text x="196" y="268">200 ms</text><text x="374" y="268">400</text>
+      <text x="552" y="268">600</text><text x="730" y="268">800</text><text x="908" y="268">1000</text>
+    </g>
+    <!-- 0.89 px per ms; x0=20 -->
+    <line x1="20" y1="46" x2="20" y2="250" stroke="var(--line)" stroke-dasharray="2 3"/>
+    <line x1="401" y1="46" x2="401" y2="250" stroke="var(--red)" stroke-dasharray="3 3"/>
+    <text x="406" y="60" class="svg-s" fill="var(--red)">428 ms gone before any session is looked at</text>
+
+    <!-- bars -->
+    <rect x="20"  y="76"  width="107" height="26" rx="4" class="bar-imp"/>
+    <text x="133" y="94" class="svg-s">import db.ts — 120 ms</text>
+
+    <rect x="127" y="108" width="109" height="26" rx="4" class="bar-imp"/>
+    <text x="242" y="126" class="svg-s">import discover.ts — 123 ms  (3,038 lines, not used by --active)</text>
+
+    <rect x="236" y="140" width="25" height="26" rx="4" class="bar-imp"/>
+    <text x="267" y="158" class="svg-s">import active.ts — 29 ms</text>
+
+    <rect x="261" y="172" width="3" height="26" rx="1" class="bar-db"/>
+    <text x="270" y="190" class="svg-s" fill="var(--lime)">getDB() — 3.5 ms   ← the database is not the problem</text>
+
+    <rect x="264" y="204" width="113" height="26" rx="4" class="bar-walk"/>
+    <text x="383" y="222" class="svg-s">getSessionRoots() — 127 ms  (stat 26 roots across 13 version homes)</text>
+
+    <rect x="401" y="76" width="598" height="26" rx="4" class="bar-work"/>
+    <text x="700" y="94" text-anchor="middle" class="svg-s" fill="#fff">actual work — ~600 ms: process table, 21 × 128 KB tails, teams + cloud state</text>
+  </svg>
+  <figcaption>Fig 1 — the waterfall. Red = module import. Amber = directory statting. Green = SQLite. Violet = the work you actually asked for.</figcaption>
+  </figure>
+
+  <div class="call correct"><span class="tag">Your question, answered</span>
+    <p><b>“Is it re-parsing all sessions?” No.</b> <span class="fl">active.ts</span> does not import
+    <code>discoverSessions</code> — I checked its import list. It reads a bounded tail per live session:
+    <code>readSessionTailWithRaw</code> (<span class="fl">tail.ts:69</span>) does a <code>pread</code> of the last
+    <b>128 KB</b> and keeps the last <b>60 events</b>. On this machine that is 21 sessions × 128 KB ≈ 2.7 MB.
+    That part is well built. The “loading sessions” you see is the <b>428 ms of setup before it starts</b>.</p></div>
+
+  <div class="call hot"><span class="tag">The dumbest 123 ms</span>
+    <p><code>--active</code> pays <b>123 ms to import <span class="fl">discover.ts</span></b> — 3,038 lines of
+    incremental-scanner code it never calls. It is pulled in transitively for
+    <code>buildClaudeLabelMap</code> (<span class="fl">active.ts:29</span>), a 28-line function that reads four
+    small JSON files. Splitting that one function out of the module is a <b>~123 ms</b> win on every
+    <code>--active</code>, for a one-line import change.</p></div>
+</section>
+
+<!-- 2 -->
+<section id="s2">
+  <div class="sec-num">02</div>
+  <h2>The 127 ms: asking where files live, 26 times</h2>
+  <p class="sub">This is where the version-home sprawl stops being a disk-space story and becomes a latency story.</p>
+
+  <pre><span class="c">$ agents sessions --roots --json</span>
+  16  claude          <span class="c">← 1 live home + 15 version-home copies</span>
+   4  codex
+   2  gemini · 1 antigravity · 1 droid · 2 kimi
+  --
+  <b>26</b>  total recursive fs.watch roots on this machine
+  <b>14</b>  of them are version-home copies</pre>
+
+  <p>Each root is a real directory that <code>getSessionRoots()</code> must <code>stat</code> on every CLI
+  invocation — hence 127 ms. And each is also a root that the Factory monitor mounts a
+  <b>recursive <code>fs.watch</code></b> on, which on macOS is an FSEvents stream over the whole subtree. The
+  claude version homes are <b>1.3 GB, 679 MB, 638 MB, 354 MB</b>. You are running FSEvents over multiple
+  gigabytes of transcripts that no one will ever open again.</p>
+
+  <div class="call warn"><span class="tag">Same root cause, different symptom</span>
+    <p>I framed version homes as an 80 GB disk problem last pass and you were right to push back — disk is cheap.
+    But the same sprawl is what makes <code>getSessionRoots()</code> cost <b>127 ms per invocation</b> and what
+    multiplies your FSEvents watchers from 12 to 26. <b>Pruning version homes is a latency fix.</b> That is the
+    argument I should have made.</p></div>
+</section>
+
+<!-- 3 -->
+<section id="s3">
+  <div class="sec-num">03</div>
+  <h2>The monitors — how many, and what happens with 10 agents</h2>
+  <p class="sub">You asked how many file monitors are connected. The good news: this layer is the best-engineered
+  part of the system. Watchers scale with <b>roots</b>, not with agents.</p>
+
+  <figure>
+  <svg viewBox="0 0 1040 470" role="img" aria-label="watcher and poll topology across a fleet">
+    <text x="20" y="24" class="svg-l">Data collection topology — 10 agents across 3 machines</text>
+
+    <!-- machine A -->
+    <rect x="20" y="44" width="320" height="250" rx="10" class="box"/>
+    <text x="180" y="66" text-anchor="middle" class="svg-l">zion (interactive)</text>
+    <text x="180" y="82" text-anchor="middle" class="svg-s">4 agents · 2 VS Code windows</text>
+
+    <rect x="40" y="96" width="130" height="34" rx="6" class="box"/>
+    <text x="105" y="112" text-anchor="middle" class="svg-s">agent 1..4</text>
+    <text x="105" y="125" text-anchor="middle" class="svg-s">write jsonl</text>
+
+    <rect x="190" y="96" width="130" height="34" rx="6" class="box"/>
+    <text x="255" y="112" text-anchor="middle" class="svg-s">SessionStart hook</text>
+    <text x="255" y="125" text-anchor="middle" class="svg-s">pid → id</text>
+
+    <rect x="40" y="148" width="280" height="44" rx="6" class="box-hot"/>
+    <text x="180" y="166" text-anchor="middle" class="svg-s">26 recursive fs.watch roots (FSEvents)</text>
+    <text x="180" y="181" text-anchor="middle" class="svg-s">1 leader · refcounted singletons · 14 are stale version homes</text>
+
+    <rect x="40" y="204" width="130" height="38" rx="6" class="box-lime"/>
+    <text x="105" y="220" text-anchor="middle" class="svg-s">leader window</text>
+    <text x="105" y="234" text-anchor="middle" class="svg-s">broadcasts</text>
+
+    <rect x="190" y="204" width="130" height="38" rx="6" class="box"/>
+    <text x="255" y="220" text-anchor="middle" class="svg-s">follower windows</text>
+    <text x="255" y="234" text-anchor="middle" class="svg-s">subscribe, no watch</text>
+
+    <rect x="40" y="252" width="280" height="30" rx="6" class="box-hot"/>
+    <text x="180" y="271" text-anchor="middle" class="svg-s">every 3 s: spawn `agents sessions --active` — 1.1 s, 151 MB</text>
+
+    <path class="edge" d="M105,130 L105,146"/>
+    <path class="edge" d="M255,130 L255,146"/>
+    <path class="edge-lime" d="M105,192 L105,202"/>
+    <path class="edge-lime" d="M170,223 L188,223"/>
+
+    <!-- remote machines -->
+    <rect x="380" y="44" width="250" height="180" rx="10" class="box"/>
+    <text x="505" y="66" text-anchor="middle" class="svg-l">yosemite-s0</text>
+    <text x="505" y="82" text-anchor="middle" class="svg-s">3 agents · headless</text>
+    <rect x="400" y="96" width="210" height="34" rx="6" class="box-hot"/>
+    <text x="505" y="112" text-anchor="middle" class="svg-s">its own ~26 fs.watch roots</text>
+    <text x="505" y="125" text-anchor="middle" class="svg-s">nobody subscribes to them</text>
+    <rect x="400" y="146" width="210" height="56" rx="6" class="box-hot"/>
+    <text x="505" y="166" text-anchor="middle" class="svg-s">per poll: a FRESH</text>
+    <text x="505" y="180" text-anchor="middle" class="svg-s">`agents sessions --local`</text>
+    <text x="505" y="194" text-anchor="middle" class="svg-s">428 ms setup + work, then exits</text>
+
+    <rect x="670" y="44" width="250" height="180" rx="10" class="box"/>
+    <text x="795" y="66" text-anchor="middle" class="svg-l">mac-mini</text>
+    <text x="795" y="82" text-anchor="middle" class="svg-s">3 agents · headless</text>
+    <rect x="690" y="96" width="210" height="34" rx="6" class="box-hot"/>
+    <text x="795" y="112" text-anchor="middle" class="svg-s">its own ~26 fs.watch roots</text>
+    <text x="795" y="125" text-anchor="middle" class="svg-s">nobody subscribes to them</text>
+    <rect x="690" y="146" width="210" height="56" rx="6" class="box-hot"/>
+    <text x="795" y="166" text-anchor="middle" class="svg-s">per poll: a FRESH</text>
+    <text x="795" y="180" text-anchor="middle" class="svg-s">`agents sessions --local`</text>
+    <text x="795" y="194" text-anchor="middle" class="svg-s">428 ms setup + work, then exits</text>
+
+    <!-- ssh edges -->
+    <path class="edge-hot" d="M320,267 C360,267 380,220 460,204"/>
+    <path class="edge-hot" d="M320,267 C400,290 640,250 700,204"/>
+    <text x="360" y="310" class="svg-s" fill="var(--red)">SSH fan-out — one fresh subprocess per host, per 3 s tick</text>
+
+    <!-- the asymmetry callout -->
+    <rect x="20" y="330" width="900" height="106" rx="10" class="box-lime"/>
+    <text x="40" y="354" class="svg-l" fill="var(--lime)">The asymmetry</text>
+    <text x="40" y="378" class="svg-s">Every machine already runs a full push-based watcher tree — leader-elected, deduped, refcounted, correct.</text>
+    <text x="40" y="396" class="svg-s">It is consumed ONLY by the local VS Code windows. The fleet view never subscribes to it.</text>
+    <text x="40" y="414" class="svg-s" fill="var(--lime)">The push infrastructure you need already exists on every box. It just has no remote subscriber.</text>
+  </svg>
+  <figcaption>Fig 2 — watchers scale with roots per machine (~26), not with agents. The cost that scales with the fleet is the 3-second SSH subprocess fan-out.</figcaption>
+  </figure>
+
+  <h3>The counting rules</h3>
+  <div class="scroller">
+  <table>
+    <tr><th>Dimension</th><th>Watchers</th><th>Why</th></tr>
+    <tr><td>+1 agent on the same machine</td><td class="n good">+0</td><td>Roots are shared. <span class="fl">terminalReadiness.ts:73</span> refcounts a singleton per root — added precisely because “with 20+ terminals open, the duplication caused observable system load.”</td></tr>
+    <tr><td>+1 VS Code window</td><td class="n good">+0</td><td>Leader election: one leader watches, followers subscribe (<span class="fl">monitor/follower.ts:3</span>).</td></tr>
+    <tr><td>+1 agent <em>version</em> installed</td><td class="n bad">+1 or more</td><td>Each version home is a new root. <b>This is the only thing that actually grows the watcher count.</b></td></tr>
+    <tr><td>+1 machine in the fleet</td><td class="n mid">+26 (on that box)</td><td>Plus one fresh subprocess per 3 s poll from every watching window.</td></tr>
+    <tr class="sum"><td>10 agents, 3 machines, today</td><td class="n bad">~78</td><td>≈26 per box — of which ~42 fleet-wide are stale version homes.</td></tr>
+  </table>
+  </div>
+
+  <div class="call correct"><span class="tag">Credit</span>
+    <p>The dedup, refcounting, and leader election here are genuinely well done — someone already found and fixed
+    the N-terminals-N-watchers bug. The watcher layer is not your problem. <b>The problem is that this good push
+    layer stops at the machine boundary</b>, so cross-machine state falls back to spawning a process every 3 s.</p></div>
+
+  <h3>But watching 10 agents is the cheap half</h3>
+  <p>Everything above is the cost of <em>observing</em> agents. The cost of <b>running</b> them is separate, and
+  it is worse — because it is paid per spawn, serially, before any agent does any work.</p>
+
+  <pre><span class="c">$ agents run --help        # prints help text. Starts no agent. Does no I/O.</span>
+  <span class="r">0.57 – 0.97 s</span>
+
+<span class="c">$ agents --version         # early-exits before the module graph loads</span>
+  <span class="g">0.09 s</span>  <span class="c">(clean box)</span></pre>
+
+  <p>Printing a help string costs <b>6–10×</b> what <code>--version</code> costs. Nothing in
+  <code>run --help</code> touches the database, the roots, or the disk — so that gap is <b>eager module loading
+  at CLI startup, before argument dispatch</b>. It is the same 271 ms of imports from §01, plus the
+  <code>teams</code>/<code>exec</code>/<code>hosts</code> graph, paid on <em>every</em> invocation of
+  <em>every</em> subcommand.</p>
+
+  <div class="call hot"><span class="tag">The execution-path multiplier</span>
+    <p>That overhead is per <code>agents run</code>. Spinning up a 10-teammate team means the orchestrator
+    assembles and launches ten <code>agents run</code> argv lines
+    (<span class="fl">teams/agents.ts:2219</span> <code>buildRunArgv</code> → <span class="fl">:1799</span>
+    <code>launchProcess</code>), so you pay it <b>ten times</b> — and for remote teammates it is paid <em>on the
+    remote box</em>, after the SSH round-trip, inside the detached launch. Roughly <b>6–10 s of pure harness
+    overhead</b> before the first token of real work, growing linearly with team size.</p></div>
+
+  <p>The fix is §05 item 5, and it pays off far more here than on the status path: <b>lazy-load the command
+  modules</b> so a subcommand imports only what it uses — resolve the subcommand first, then dynamic
+  <code>import()</code> its handler. That turns a 10-teammate spin-up from ~10 × 0.9 s of import tax into
+  ~10 × 0.1 s.</p>
+
+  <div class="call warn"><span class="tag">Measurement caveat — read this</span>
+    <p>The <code>run --help</code> numbers above, and a <b>7.55 s</b> reading for <code>agents devices</code>,
+    were taken while this machine sat at <b>load average 27</b> — my own five background audits saturated it.
+    Treat those absolutes as inflated upper bounds. The <em>ratio</em> to <code>--version</code> under identical
+    load is still the real signal, and <code>devices</code> being an order of magnitude slower than every other
+    subcommand deserves a re-measure on a quiet box — it is the command you run to see your fleet, and it should
+    be instant. The §01 waterfall was taken before the audits started and is independently corroborated by the
+    limit-1 vs limit-500 bisect, so it stands.</p></div>
+</section>
+
+<!-- 4 -->
+<section id="s4">
+  <div class="sec-num">04</div>
+  <h2>Search is broken — and it is a one-line bug</h2>
+  <p class="sub">Found while scoping the session audit. This one probably costs you more daily friction than the
+  latency does.</p>
+
+  <pre><span class="c">// at the SQL layer, the index is perfect:</span>
+SELECT COUNT(*) FROM session_text WHERE session_text MATCH 'login'   → <span class="g">1,247 hits</span>
+                                                          'logged'   → <span class="g">  950 hits</span>
+                                                          'auth'     → <span class="g">1,845 hits</span>
+11,685 rows carry content · average <span class="g">42.7 KB</span> each
+
+<span class="c">// at the CLI:</span>
+$ agents sessions "login" --all --teams --limit 3
+<span class="r">0 sessions.</span></pre>
+
+  <p>The break is in <span class="fl">discover.ts:351</span> <code>searchContentIndex</code>:</p>
+  <pre>export function searchContentIndex(sessions: SessionMeta[], query: string) {
+  const hits = <span class="g">ftsSearch(query)</span>;            <span class="c">// top 200 by BM25, across all 12,180 rows</span>
+  const byId = new Map(sessions.map(s =&gt; [s.id, s]));  <span class="c">// ← the ALREADY-FILTERED, ALREADY-LIMITED page</span>
+  for (const hit of hits) {
+    const session = byId.get(hit.sessionId);
+    <span class="r">if (!session) continue;</span>                     <span class="c">// ← silently dropped</span>
+  }
+}</pre>
+
+  <p>Search results are <b>intersected with a page that was computed independently</b>. <code>ftsSearch</code>
+  ranks the top 200 across the whole corpus; if none of those 200 happen to be in the current window, you get zero
+  — even though 1,247 sessions match. <b>The direction is backwards:</b> the query should drive the result set
+  (push the filter into the SQL and page the FTS output), not be filtered by a page chosen before the search ran.</p>
+
+  <div class="call hot"><span class="tag">Consequence</span>
+    <p>You are carrying a <b>760 MB</b> full-text index (505 MB stored content + 256 MB inverted index) that
+    answers correctly in SQL and returns nothing through the CLI. Fixing the intersection is a small change and
+    turns a dead 760 MB into the feature it was supposed to be.</p></div>
+</section>
+
+<!-- 5 -->
+<section id="s5">
+  <div class="sec-num">05</div>
+  <h2>The ms-ordered fix list</h2>
+  <div class="scroller">
+  <table>
+    <tr><th>#</th><th>Fix</th><th>Saves</th><th>Size</th></tr>
+    <tr><td>1</td><td>Move <code>buildClaudeLabelMap</code> out of <code>discover.ts</code> so <code>--active</code> stops importing 3,038 unused lines</td><td class="n good">~123 ms<br>every call</td><td>one import</td></tr>
+    <tr><td>2</td><td>Cache <code>getSessionRoots()</code> — the answer changes on install/upgrade, not per invocation. Memoize to a cache file keyed on the versions dir mtime.</td><td class="n good">~127 ms<br>every call</td><td>small</td></tr>
+    <tr><td>3</td><td>Fix <code>searchContentIndex</code> — push filters into SQL, let search drive the page</td><td class="n good">unlocks<br>760 MB</td><td>small</td></tr>
+    <tr><td>4</td><td>Prune version homes → 26 roots down to ~12. Fewer stats, fewer FSEvents streams over multi-GB trees.</td><td class="n good">~60 ms<br>+ watcher load</td><td>a reaper</td></tr>
+    <tr><td>5</td><td>Lazy-load <code>db.ts</code> (120 ms) — only commands that touch the DB should pay for it</td><td class="n mid">~120 ms<br>on non-DB cmds</td><td>medium</td></tr>
+    <tr class="sum"><td></td><td>1+2+4 together</td><td class="n good">1.1 s → ~0.4 s</td><td>no new components</td></tr>
+  </table>
+  </div>
+  <p>Only after that does the transport question deserve an answer. At ~0.4 s per poll the 3-second cycle costs
+  ~13% of a core instead of ~35%, and the honest next step is a long-lived <code>--watch</code> stream over the
+  ControlMaster channel you already have — <b>giving the good local push layer a remote subscriber</b> — rather
+  than a new daemon with its own lifecycle, election, and failure modes.</p>
+  <div class="call warn"><span class="tag">Still open</span>
+    <p>Five audits are running right now against the real session corpus — auth/logout failures, routine
+    failures, fleet onboarding friction, teams spin-up failures, and the auth architecture in source. Those
+    target the problems you actually named. This page is the latency half only.</p></div>
+</section>
+
+<div class="foot wrap">
+  Measured on zion, 2026-07-30, against agents-cli @ 827565549. Phase timings from `bun` importing the real
+  source modules; watcher counts from `agents sessions --roots --json`; FTS counts from direct SQL against the live index.
+</div>
+</div>
+<script>
+  (function(){
+    var root=document.documentElement, btn=document.getElementById('tg');
+    try{var pref=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;
+      root.setAttribute('data-theme', pref?'light':'dark');}catch(e){}
+    btn.addEventListener('click',function(){
+      root.setAttribute('data-theme', root.getAttribute('data-theme')==='dark'?'light':'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/fleet-status-redesign.html
+++ b/docs/plans/2026-07-30/fleet-status-redesign.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agents fleet status — redesign</title>
+<style>
+  :root{
+    --bg:#0b0e14; --panel:#11151f; --panel2:#0d1119; --ink:#e6e9ef; --muted:#8a93a6;
+    --line:#212838; --accent:#7cc4ff; --green:#54d18c; --yellow:#f0c674; --red:#f07178;
+    --gray:#5b6675; --mono:"SF Mono",ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,system-ui,sans-serif;
+  }
+  html[data-theme="light"]{
+    --bg:#f6f7f9; --panel:#ffffff; --panel2:#f0f2f5; --ink:#1a1f2b; --muted:#5c6675;
+    --line:#e3e7ee; --accent:#2f6fed; --green:#1a9d5a; --yellow:#a9791b; --red:#c8384a; --gray:#8a93a6;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1180px;margin:0 auto;padding:40px 28px 96px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--accent);margin:0 0 10px}
+  h1{font-size:30px;line-height:1.15;margin:0 0 12px;letter-spacing:-.02em}
+  .lede{color:var(--muted);font-size:16px;max-width:70ch;margin:0 0 20px}
+  .chips{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 8px}
+  .chip{font-family:var(--mono);font-size:12px;padding:5px 10px;border:1px solid var(--line);border-radius:999px;color:var(--muted);background:var(--panel)}
+  .toggle{position:fixed;top:16px;right:16px;z-index:10;font-family:var(--mono);font-size:13px;padding:7px 12px;border:1px solid var(--line);border-radius:8px;background:var(--panel);color:var(--ink);cursor:pointer}
+  h2{font-size:20px;margin:44px 0 6px;letter-spacing:-.01em;display:flex;align-items:center;gap:10px}
+  h2 .n{font-family:var(--mono);font-size:13px;color:var(--accent);border:1px solid var(--line);border-radius:6px;padding:2px 8px}
+  h3{font-size:15px;margin:24px 0 8px;color:var(--ink)}
+  p{color:var(--muted)}
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:14px}
+  @media(max-width:900px){.grid{grid-template-columns:1fr}}
+  .term{background:var(--panel2);border:1px solid var(--line);border-radius:12px;overflow:hidden}
+  .term .bar{display:flex;align-items:center;gap:8px;padding:9px 13px;border-bottom:1px solid var(--line);background:var(--panel)}
+  .dot{width:11px;height:11px;border-radius:50%}
+  .dot.r{background:#ff5f56}.dot.y{background:#ffbd2e}.dot.g{background:#27c93f}
+  .term .lbl{font-family:var(--mono);font-size:11px;color:var(--muted);margin-left:6px}
+  pre{margin:0;padding:15px 16px;font-family:var(--mono);font-size:12px;line-height:1.55;white-space:pre;overflow-x:auto;color:var(--ink)}
+  .g{color:var(--green)}.y{color:var(--yellow)}.r{color:var(--red)}.m{color:var(--muted)}.a{color:var(--accent)}.gr{color:var(--gray)}
+  .b{font-weight:700}
+  .tag{display:inline-block;font-family:var(--mono);font-size:10px;font-weight:700;padding:2px 7px;border-radius:5px;vertical-align:middle;margin-right:8px}
+  .tag.before{background:rgba(240,113,120,.15);color:var(--red);border:1px solid rgba(240,113,120,.35)}
+  .tag.after{background:rgba(84,209,140,.15);color:var(--green);border:1px solid rgba(84,209,140,.35)}
+  .note{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:0 10px 10px 0;padding:14px 16px;margin:16px 0}
+  .note .h{font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);margin-bottom:6px}
+  table{width:100%;border-collapse:collapse;margin:14px 0;font-size:14px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted)}
+  td code,p code,li code{font-family:var(--mono);font-size:12px;background:var(--panel);border:1px solid var(--line);border-radius:5px;padding:1px 6px;color:var(--ink)}
+  td .why{color:var(--muted);font-size:13px}
+  ul{color:var(--muted);padding-left:20px}li{margin:5px 0}
+  .decision{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px;margin:12px 0}
+  .decision .q{font-weight:700;color:var(--ink);margin-bottom:4px}
+  .decision .rec{color:var(--green);font-family:var(--mono);font-size:12px;margin-top:6px}
+  .rule{height:1px;background:var(--line);border:0;margin:40px 0}
+  .ticketcard{background:linear-gradient(180deg,var(--panel),var(--panel2));border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin:12px 0}
+  .ticketcard .id{font-family:var(--mono);font-size:12px;color:var(--accent)}
+  .ticketcard h4{margin:6px 0 8px;font-size:16px}
+  .foot{color:var(--muted);font-size:13px;margin-top:8px}
+  svg{max-width:100%;height:auto}
+</style>
+</head>
+<body>
+<button class="toggle" onclick="var h=document.documentElement;h.dataset.theme=h.dataset.theme==='dark'?'light':'dark'">◐ theme</button>
+<div class="wrap">
+
+  <p class="kicker">agents-cli · fleet UX + performance</p>
+  <h1><code style="font-size:.8em">agents fleet status</code> — legible in a glance, fast by default</h1>
+  <p class="lede">The command tries to answer "is my fleet OK?" but buries the answer under duplicated columns, glyph soup, jargon (<code>stale</code>/<code>cold</code>), and a ~60&nbsp;second live-SSH hang it doesn't admit to. This is the before/after and the reasoning behind every change — for your approval before I file.</p>
+  <div class="chips">
+    <span class="chip">12 devices</span>
+    <span class="chip">~60s → instant (cache-first)</span>
+    <span class="chip">9 columns → quiet-when-healthy</span>
+    <span class="chip">no dupe in Linear</span>
+  </div>
+
+  <h2><span class="n">1</span> The two problems, side by side</h2>
+
+  <h3><span class="tag before">BEFORE</span>what you ran tonight</h3>
+  <div class="term">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="lbl">muqsit@zion — agents fleet status — ~60s to render</span></div>
+<pre><span class="b">Fleet warnings (3)</span>
+  <span class="y">drift</span>        12 devices have sync drift <span class="m">(zion, mac-mini, win-mini, yosemite-m0, yosemite-m1,</span>
+  <span class="m">yosemite-m2, yosemite-m3, yosemite-m4, yosemite-m5, yosemite-m6, yosemite-s0, yosemite-s1)</span>
+  <span class="y">cli</span>          11 devices are missing one or more agent CLIs <span class="m">(zion, mac-mini, win-mini,</span>
+  <span class="m">yosemite-m0, yosemite-m1, yosemite-m2, yosemite-m3, yosemite-m4, yosemite-m5, yosemite-m6, yosemite-s1)</span>
+  <span class="y">version-skew</span> agents-cli version skew: 0.0.0-dev.867dea00-dirty, 1.20.73, 1.20.74 <span class="m">(...)</span>
+
+<span class="b">Fleet status</span>
+   <span class="m">Device        OS       Health   Sync            CLI     Auth       Version    Load/Mem  Note</span>
+ <span class="y">◐</span> <span class="b">zion</span>          macos    <span class="y">busy</span>     8 stale · 3 cold  7/9   <span class="g">●5</span> <span class="m">·8</span> <span class="y">◐3</span>    1.20.74    23%/49%   <span class="m">12 orphaned versions</span>
+ <span class="y">◐</span> mac-mini      macos    <span class="y">busy</span>     6 stale · 6 cold  7/9   <span class="m">·4</span> <span class="y">◐4</span>       1.20.73    27%/57%   <span class="m">10 orphaned versions</span>
+ <span class="y">◐</span> win-mini      windows  <span class="y">busy</span>     4 cold            1/9   —          1.20.73    1%/54%    <span class="m">4 orphaned versions</span>
+ <span class="y">◐</span> yosemite-m0   linux    <span class="g">idle</span>     1 stale · 10 cold 6/9   <span class="m">·3</span> <span class="y">◐4</span>       1.20.74    5%/15%    <span class="m">10 orphaned versions</span>
+ <span class="y">◐</span> yosemite-m1   linux    <span class="g">idle</span>     6 stale · 5 cold  6/9   <span class="m">·2</span> <span class="y">◐2</span>       1.20.73    0%/7%     <span class="m">11 orphaned versions</span>
+ <span class="y">◐</span> yosemite-m2   linux    <span class="g">idle</span>     5 cold            6/9   <span class="m">·3</span> <span class="y">◐1</span>       1.20.73    0%/9%     <span class="m">11 orphaned versions</span>
+ <span class="m">...  (m3–m6 identical)</span>
+ <span class="y">◐</span> yosemite-s0   linux    <span class="g">light</span>    4 stale · 1 cold  9/9   <span class="g">●4</span> <span class="m">·6</span> <span class="y">◐3</span>    0.0.0-dev.867…  3%/20% <span class="m">9 orphaned versions</span>
+ <span class="y">◐</span> yosemite-s1   linux    <span class="g">light</span>    3 stale · 4 cold  7/9   <span class="g">●3</span> <span class="m">·5</span> <span class="y">◐3</span>    1.20.73    1%/16%    <span class="m">11 orphaned versions</span>
+ <span class="m">● fresh · ◐ drift · ○ unreachable/skipped · Auth ●live ·present ◐degraded ○revoked</span>
+ <span class="m">updated stats 2m ago · auth 7d ago — pass --refresh (--live) for a live probe</span></pre>
+  </div>
+
+  <div class="note">
+    <div class="h">the tells</div>
+    <ul style="margin:0">
+      <li><span class="r b">"Health" = busy/idle</span> is not health — it's the <em>same load/mem numbers</em> two columns over, relabelled. <code>health.ts:194</code></li>
+      <li><span class="r b">"8 stale · 3 cold"</span> counts <em>every</em> installed version incl. old orphans; your active install is likely fine. <code>drift.ts:59</code></li>
+      <li><span class="r b">Auth <code>●5 ·8 ◐3</code></span> — the biggest number (<code>·8</code>) is the <em>most benign</em> state (present, not probed). <code>auth-health.ts:189</code></li>
+      <li><span class="r b">Warnings re-list all 12 devices</span> three times — if everything drifts, the list carries no signal.</li>
+      <li><span class="r b">"orphaned versions"</span> owns the rightmost column but is a <code>prune</code> housekeeping stat, not a health signal. <code>drift.ts:126</code></li>
+      <li><span class="r b">~60s hang</span> — SSHes every box live even though the footer implies cached; dead boxes aren't skipped. <code>ssh.ts:394,398</code></li>
+    </ul>
+  </div>
+
+  <h3><span class="tag after">AFTER</span>proposed — cache-first, quiet-when-healthy, grouped by OS</h3>
+  <div class="term">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="lbl">muqsit@zion — agents fleet status — instant (served from cache)</span></div>
+<pre><span class="b">Fleet</span>   <span class="g">● 11 online</span>   <span class="gr">○ 1 offline</span>                          <span class="m">zion · cached 2m ago</span>
+
+<span class="y b">NEEDS ATTENTION (3)</span>
+  <span class="gr">○</span>  yosemite-s1    <span class="gr">offline</span> · last seen 3d ago            <span class="m">→ check the box</span>
+  <span class="y">⚠</span>  win-mini       only <span class="y">1 of 9</span> agent CLIs installed       <span class="m">→ agents apply win-mini</span>
+  <span class="y">⚠</span>  version skew   9× 1.20.73 · 2× 1.20.74 · zion dev  <span class="m">→ agents upgrade --fleet</span>
+
+<span class="m">macOS</span>
+ <span class="a b">▸ zion</span>         <span class="y">busy</span>     23% / 49%    1.20.74                <span class="a">← this machine</span>
+   mac-mini     <span class="y">busy</span>     27% / 57%    1.20.73
+
+<span class="m">Linux</span>
+   yosemite-m0  <span class="g">idle</span>      5% / 15%    1.20.74
+   yosemite-m1  <span class="g">idle</span>      0% /  7%    1.20.73
+   yosemite-m2  <span class="g">idle</span>      0% /  9%    1.20.73
+   yosemite-m3  <span class="g">idle</span>      2% /  7%    1.20.73
+   yosemite-m4  <span class="g">idle</span>      0% /  6%    1.20.73
+   yosemite-m5  <span class="g">idle</span>      0% /  6%    1.20.73
+   yosemite-m6  <span class="g">idle</span>      1% /  5%    1.20.73
+   yosemite-s0  <span class="g">light</span>     3% / 20%    <span class="m">dev-dirty</span>
+   yosemite-s1  <span class="gr">offline</span>     —           —           <span class="m">last seen 3d ago</span>
+
+<span class="m">Windows</span>
+   win-mini     <span class="y">busy</span>      1% / 54%    1.20.73    <span class="y">⚠ CLIs 1/9</span>
+
+<span class="m">9 devices carry orphaned versions · run  </span><span class="a">agents prune</span><span class="m">  to reclaim disk</span>
+<span class="m">cached 2m ago · </span><span class="a">--live</span><span class="m"> to re-probe auth + reachability · </span><span class="a">--verbose</span><span class="m"> for auth/CLI/sync columns</span></pre>
+  </div>
+
+  <div class="note">
+    <div class="h">the idea in one line</div>
+    <p style="margin:0;color:var(--ink)">A healthy device is <strong>quiet</strong> — name, capacity, version, done. Everything that needs your hands is pulled up into <strong>NEEDS ATTENTION</strong> with the exact command to fix it. You read the top three lines and you're done.</p>
+  </div>
+
+  <h2><span class="n">2</span> Every change, and why</h2>
+  <table>
+    <tr><th>Change</th><th>Before → After</th><th>Why</th></tr>
+    <tr>
+      <td class="b">Kill the "Health" column</td>
+      <td><code>Health: busy</code> + <code>Load/Mem: 23%/49%</code> → one <code>Capacity</code> cell: <code>busy 23% / 49%</code></td>
+      <td class="why">"Health" was headroom = the worst of load%/mem% — the identical numbers shown twice. One column, one truth.</td>
+    </tr>
+    <tr>
+      <td class="b">Retire <code>stale</code>/<code>cold</code> jargon</td>
+      <td><code>8 stale · 3 cold</code> (all versions) → drift on the <em>active</em> version only, surfaced in NEEDS ATTENTION as <code>config drift → agents apply</code></td>
+      <td class="why">Counting every old orphaned version manufactures scary numbers. Users care whether the install they run is in sync.</td>
+    </tr>
+    <tr>
+      <td class="b">De-glyph Auth</td>
+      <td><code>●5 ·8 ◐3</code> → <code>auth ok</code>, or <code class="y">⚠ 3 degraded</code> / <code class="r">✗ 2 revoked</code> only when it's real</td>
+      <td class="why">"present but unprobed" is benign; showing it as a big number reads as a problem. Show exceptions, not inventory.</td>
+    </tr>
+    <tr>
+      <td class="b">Lead with a rollup + NEEDS ATTENTION</td>
+      <td>3 warnings that re-list all 12 devices → one status line + a short actionable list, each with the fix command</td>
+      <td class="why">"12 devices have drift (list of 12)" is noise. Tell me what's wrong and what to type.</td>
+    </tr>
+    <tr>
+      <td class="b">Group by OS, highlight this machine</td>
+      <td>flat alphabetical → <code>macOS / Linux / Windows</code> sections; <code class="a">▸ zion ← this machine</code></td>
+      <td class="why">Matches how you reason about the fleet; fixes the "OS is just a string" flatness. Parity with <code>agents devices</code> self-marker.</td>
+    </tr>
+    <tr>
+      <td class="b">Demote "orphaned versions"</td>
+      <td>rightmost column on every row → one footer nudge to <code>agents prune</code></td>
+      <td class="why">The code itself says orphans are a prune concern, not drift. It doesn't belong in the health matrix.</td>
+    </tr>
+    <tr>
+      <td class="b">Cache-first, fast by default</td>
+      <td>~60s live SSH every run → instant from cache; <code>--live</code> re-probes; dead boxes always skipped</td>
+      <td class="why">The matrix should mirror the stats cache (already warmed every 3&nbsp;min by the daemon). SSH only on demand.</td>
+    </tr>
+    <tr>
+      <td class="b">Honest freshness footer</td>
+      <td>"updated stats 2m ago" (implies whole view is 2m) → states cache age <em>and</em> that auth/reachability need <code>--live</code></td>
+      <td class="why">Today the footer describes only the stats cache while the matrix silently blocks on live SSH.</td>
+    </tr>
+  </table>
+
+  <h2><span class="n">3</span> Where the render pipeline changes</h2>
+  <div class="term" style="margin-top:8px">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="lbl">data path — file:line from tonight's investigation</span></div>
+<pre><span class="a">runFleetStatus</span>            <span class="m">apps/cli/src/commands/ssh.ts:365</span>   entry
+  <span class="r">└ fanOutDevices(probeRemoteHealth)  ssh.ts:398</span>   <span class="r">← SSH every box, UNGATED  (the hang)</span>
+  <span class="r">└ dead-box skip gated on forceRefresh  ssh.ts:394</span>  <span class="r">← so offline boxes still time out</span>
+<span class="a">buildFleetHealthReport</span>    <span class="m">lib/devices/health-report.ts:69</span>   warnings + skew
+<span class="a">renderFleetMatrix</span>         <span class="m">lib/devices/health-report.ts:242</span>  table + legend
+  <span class="y">├ headroomLabel (=="Health")     health-report.ts:135  → merge into Capacity</span>
+  <span class="y">├ driftLabel (stale/cold)        health-report.ts:151  → active-version only</span>
+  <span class="y">├ authLabel (glyph soup)         health-report.ts:188  → ok / ⚠N / ✗N</span>
+  <span class="y">└ Note = orphaned versions       health-report.ts:248  → footer nudge</span></pre>
+  </div>
+
+  <h2><span class="n">4</span> Three calls I made — flag any you'd flip</h2>
+
+  <div class="decision">
+    <div class="q">A · Keep <code>fleet status</code> and <code>devices</code> separate?</div>
+    <p style="margin:4px 0 0">They overlap (both show device/OS/load/mem). <code>devices</code> = "live capacity right now"; <code>fleet status</code> = "is the fleet healthy + in sync." I'd keep them separate but make <code>fleet status</code> cache-first so both are fast.</p>
+    <div class="rec">▸ recommend: keep separate, share the cache</div>
+  </div>
+
+  <div class="decision">
+    <div class="q">B · Quiet-when-healthy, or always show every column?</div>
+    <p style="margin:4px 0 0">Proposal hides <code>auth ok</code> / <code>CLIs 9/9</code> on healthy rows and only marks exceptions. Some people like an explicit wall of green for reassurance.</p>
+    <div class="rec">▸ recommend: quiet by default, <code>--verbose</code> brings every column back</div>
+  </div>
+
+  <div class="decision">
+    <div class="q">C · Add a live "sessions running" count per device?</div>
+    <p style="margin:4px 0 0">You mentioned wanting "how many agents are running." That's a genuinely new signal (the current command never shows it) — would answer "where's my capacity actually being used."</p>
+    <div class="rec">▸ recommend: yes, but as a fast-follow ticket — needs a session-count source</div>
+  </div>
+
+  <hr class="rule">
+
+  <h2><span class="n">5</span> The "offline" lie — and a unified transport</h2>
+  <p>You SSH into <code>yosemite-s1</code> every day, yet <code>fleet status</code> calls it offline. I probed it live tonight — it's fine. This is a whole class of bug, and it exposes that there's no real connection protocol underneath.</p>
+
+  <div class="note">
+    <div class="h">proof — yosemite-s1 is online right now</div>
+    <ul style="margin:0">
+      <li><code>ssh yosemite-s1</code> → <code class="g">OK from yosemite-s1</code>, tailscale <code>1.98.4</code> installed</li>
+      <li><code>tailscale status</code> → <code class="g">yosemite-s1 ... active; direct 192.168.1.80</code></li>
+      <li>cached <code>registry.json</code> entry: <code>via:"manual"</code>, <code class="r">no tailscale field</code>, <code>updatedAt</code> = 9 days ago</li>
+    </ul>
+  </div>
+
+  <table>
+    <tr><th>What's actually wrong</th><th>Evidence</th></tr>
+    <tr>
+      <td class="b">Online = a stale cache, not live truth</td>
+      <td class="why">The label reads the cached <code>tailscale.online</code> field only. A live SSH probe runs (<code>health.ts:207</code>, 2.5s) — that's the "1% load" the snapshot showed — but it's <strong>display-only and never writes back</strong>. So a reachable box shows offline. That's the contradiction: "offline · 1% load / 16% mem."</td>
+    </tr>
+    <tr>
+      <td class="b">Manual devices never get a tailscale field</td>
+      <td class="why"><code>via:"manual"</code> entries are added without <code>tailscale.online</code>, and refresh-mode sync skips nodes it doesn't already track (<code>sync.ts:130</code>). So they stay "offline forever" until a manual <code>agents devices sync</code>.</td>
+    </tr>
+    <tr>
+      <td class="b"><code>--host</code> and <code>--device</code> are the same flag</td>
+      <td class="why"><code>--device</code> is a documented alias of <code>--host</code> (<code>exec.ts:508</code>). And <code>--device(s)</code> is <em>also</em> used for "config scope" in <code>routines/monitors/apply/doctor</code> — same word, two meanings.</td>
+    </tr>
+    <tr>
+      <td class="b">No VPN-first transport, no key provisioning</td>
+      <td class="why">Tailscale is <strong>probe-only</strong> — it just supplies the <code>.ts.net</code> address + a liveness snapshot. All execution is raw SSH (<code>ssh-exec.ts</code>). No <code>ssh-copy-id</code> anywhere; <code>auth.method:"key"</code> assumes keys were authorized out-of-band.</td>
+    </tr>
+  </table>
+
+  <h3>Proposed: one <code>connect(device)</code> layer — VPN-first, keyed-SSH fallback, provision if missing</h3>
+  <div class="term" style="margin-top:8px">
+    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="lbl">connection protocol — resolved once, used by every command</span></div>
+    <svg viewBox="0 0 860 300" xmlns="http://www.w3.org/2000/svg" style="display:block;padding:14px">
+      <defs>
+        <marker id="ar" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#8a93a6"/></marker>
+      </defs>
+      <style>
+        .bx{fill:#11151f;stroke:#212838;stroke-width:1.5;rx:10}
+        .lb{font-family:var(--mono, monospace);font-size:13px;fill:#e6e9ef}
+        .sm{font-family:var(--mono, monospace);font-size:11px;fill:#8a93a6}
+        .ok{fill:#54d18c}.warn{fill:#f0c674}.bad{fill:#f07178}.ac{fill:#7cc4ff}
+        .ln{stroke:#8a93a6;stroke-width:1.5;fill:none;marker-end:url(#ar)}
+      </style>
+      <rect class="bx" x="20" y="120" width="150" height="54" rx="10"/>
+      <text class="lb" x="95" y="143" text-anchor="middle">connect(device)</text>
+      <text class="sm" x="95" y="161" text-anchor="middle">any command</text>
+
+      <path class="ln" d="M170,147 L215,147"/>
+
+      <rect class="bx" x="220" y="40" width="220" height="60" rx="10"/>
+      <text class="lb ac" x="330" y="64" text-anchor="middle">1 · Tailscale (VPN)</text>
+      <text class="sm" x="330" y="83" text-anchor="middle">peer active? → *.ts.net, encrypted</text>
+
+      <rect class="bx" x="220" y="120" width="220" height="60" rx="10"/>
+      <text class="lb" x="330" y="144" text-anchor="middle">2 · Keyed SSH (LAN/manual)</text>
+      <text class="sm" x="330" y="163" text-anchor="middle">no peer? → direct ip, BatchMode key</text>
+
+      <rect class="bx" x="220" y="200" width="220" height="60" rx="10"/>
+      <text class="lb warn" x="330" y="224" text-anchor="middle">3 · Provision key</text>
+      <text class="sm" x="330" y="243" text-anchor="middle">auth fails? → ssh-copy-id, retry</text>
+
+      <path class="ln" d="M215,140 L215,70 L218,70"/>
+      <path class="ln" d="M215,150 L215,150"/>
+      <path class="ln" d="M440,70 L470,70 L470,147 L505,147"/>
+      <path class="ln" d="M440,150 L505,150"/>
+      <path class="ln" d="M440,230 L470,230 L470,153 L505,153"/>
+
+      <rect class="bx" x="510" y="120" width="150" height="54" rx="10"/>
+      <text class="lb g" x="585" y="143" text-anchor="middle">live probe</text>
+      <text class="sm" x="585" y="161" text-anchor="middle">reachable = truth</text>
+
+      <path class="ln" d="M660,147 L700,147"/>
+      <rect class="bx" x="705" y="120" width="135" height="54" rx="10"/>
+      <text class="lb" x="772" y="143" text-anchor="middle">write back</text>
+      <text class="sm" x="772" y="161" text-anchor="middle">→ registry.online</text>
+    </svg>
+  </div>
+  <ul>
+    <li><span class="b" style="color:var(--ink)">Reachability = live truth.</span> Prefer the live probe over the cached flag; write the result back to the registry so "offline" is never a 9-day-old guess. Fixes the whole class, not just s1.</li>
+    <li><span class="b" style="color:var(--ink)">VPN-first.</span> If the tailscale peer is up, go over the encrypted <code>.ts.net</code> path; else fall back to direct keyed SSH; else provision the key and retry — one ordered policy, at the resolver seam.</li>
+    <li><span class="b" style="color:var(--ink)">Real provisioning.</span> <code>agents devices add/provision</code> runs an <code>ssh-copy-id</code> equivalent so <code>auth.method:"key"</code> is set up by the tool, not by hand.</li>
+    <li><span class="b" style="color:var(--ink)">Collapse the flags.</span> One addressing flag (keep <code>--device</code> as the alias); rename the config-scope <code>--device(s)</code> collision to <code>--on</code>/<code>--scope</code>.</li>
+  </ul>
+
+  <hr class="rule">
+
+  <h2><span class="n">6</span> How I'd file it — four tickets</h2>
+  <p>Each has an isolated root cause and is independently mergeable. The two bugs can ship fast; the redesign and the transport layer are spec-driven.</p>
+
+  <div class="ticketcard">
+    <div class="id">RUSH-XXXX · Bug · repo:agents-cli · High</div>
+    <h4>Reachable devices render "offline" — online is a stale cache the live probe never corrects</h4>
+    <p style="margin:0">Prefer the live SSH/tailscale probe over the cached <code>tailscale.online</code> and write it back to the registry; give <code>via:"manual"</code> entries a tailscale field on sync. Repro: <code>yosemite-s1</code> shows offline while SSH + <code>tailscale status</code> confirm it's active. Root cause <code>health.ts:207</code> (probe never writes back), <code>sync.ts:130</code> (refresh skips untracked).</p>
+  </div>
+
+  <div class="ticketcard">
+    <div class="id">RUSH-XXXX · Bug · repo:agents-cli · High</div>
+    <h4><code>fleet status</code> hangs ~60s: live-SSHes every device on the default path</h4>
+    <p style="margin:0">Gate the <code>probeRemoteHealth</code> fan-out behind <code>--live</code>/<code>--refresh</code> (mirror the stats cache); always skip cache-known-dead boxes; shrink default timeouts; fix the footer to state real freshness. Root cause <code>ssh.ts:394,398</code>.</p>
+  </div>
+
+  <div class="ticketcard">
+    <div class="id">RUSH-XXXX · Feature · repo:agents-cli · Medium</div>
+    <h4>Redesign <code>fleet status</code> output: rollup + NEEDS ATTENTION, OS grouping, drop glyph soup</h4>
+    <p style="margin:0">The spec above — kill the Health column, retire stale/cold, de-glyph auth, group by OS, highlight this machine, demote orphans to a footer, quiet-when-healthy + <code>--verbose</code>. Before/after in this doc is the acceptance target. Depends on the reachability fix so "offline" in NEEDS ATTENTION is trustworthy.</p>
+  </div>
+
+  <div class="ticketcard">
+    <div class="id">RUSH-XXXX · Feature / Epic · repo:agents-cli · Medium</div>
+    <h4>Unified fleet connection protocol: VPN-first, keyed-SSH fallback, key provisioning</h4>
+    <p style="margin:0">One <code>connect(device)</code> policy at the resolver seam (<code>hostNameFor</code>/<code>resolveHost</code> + <code>ssh-exec.ts</code>): prefer Tailscale, fall back to direct keyed SSH, provision the key if auth fails. Collapse <code>--host</code>/<code>--device</code>; rename the config-scope <code>--device(s)</code> collision. The larger architectural change the other three lean on.</p>
+  </div>
+
+  <p class="foot">Still nothing filed. Confirm the connection-protocol shape (the diagram) and the 4-ticket split — flip anything — and I'll file them with this spec + file:line evidence attached.</p>
+
+</div>
+</body>
+</html>

--- a/docs/plans/2026-07-30/index.md
+++ b/docs/plans/2026-07-30/index.md
@@ -1,0 +1,71 @@
+# agents-cli plans — 2026-07-30
+
+Curated snapshot of the HTML plan/design docs a fleet of agents produced against
+agents-cli on 2026-07-30. Originals live in `/tmp`; these are point-in-time copies
+(byte-identical to source at copy time). 13 kept out of ~16 produced — duplicates
+and superseded intermediates were dropped (see the bottom section).
+
+Provenance note: these files were still being rewritten while curated. Where two
+cuts of the same plan existed, the newer one was kept and the older left in `/tmp`.
+
+---
+
+## 1. System architecture & onboarding
+
+- **agents-cli-architecture-v1.html** — *system design (v1)*. The design doc:
+  what agents-cli is, what it must do, and how it's built — the whole system, not
+  just sessions. Newest architecture doc.
+- **agents-cli-architecture.html** — *the distributed core*. Codebase onboarding:
+  how agents-cli runs, watches, and shows agents across a fleet. Complements v1 as
+  the as-built view.
+
+## 2. Performance & reliability audit — four escalating research passes
+
+- **agents-cli-ideas.html** — *six architectural moves*. Brainstorm companion to
+  "the distributed core": six moves, plus three things the onboarding report got
+  vague or wrong.
+- **agents-cli-measured.html** — *measured (3rd pass)*. Numbers, not reasoning: the
+  bottleneck isn't the poll — it's 80 GB of data nothing ever deletes.
+- **agents-cli-timeline.html** — *where the milliseconds go (4th pass)*. The latency
+  path profiled: it is not re-parsing your sessions — 271 ms loading code + 127 ms
+  resolving where files live.
+- **agents-cli-audit.html** — *the real audit* (capstone). Five parallel audits over
+  5,204 runs / 1,256 transcripts / all four hosts: 44.1% of routine runs fail, and
+  80.6% of those failures are one thing — auth.
+
+> `measured` and `timeline` are the 3rd/4th passes that fed the audit capstone;
+> kept because their raw profiling numbers (the 80 GB bloat, the 271/127 ms
+> breakdown) are not fully reproduced inside `audit`.
+
+## 3. Auth / credentials
+
+- **agents-cli-auth-plan.html** — *credential subsystem remediation plan*. Three
+  independent defects, one symptom cluster; the remediations are two PRs already
+  written. Every claim carries the command that proves it. This is the actionable
+  follow-through on the audit's auth finding.
+
+## 4. Implementation plans — discrete, actionable
+
+- **plan-configured-model-205039.html** — show the configured model everywhere
+  agents-cli displays an agent. Newer of two cuts; supersedes `plan-configured-model.html`.
+- **plan-watchdog-daemon.html** — *the watchdog is glue*. Treat the watchdog as
+  composition, not a subsystem — bury it in the daemon as just another agent.
+  (Rewritten at 22:12 from an earlier "Watchdog into the daemon" cut.)
+- **plan-menubar-prune.html** — prune ghost sentinels and collapse the "other"
+  bucket in the menu-bar helper.
+- **plan-inspect-version-picker.html** — ask which version to inspect when many
+  are installed.
+
+## 5. UI redesigns / mockups
+
+- **fleet-status-redesign.html** — fleet status, legible in a glance and fast by
+  default (fleet UX + performance).
+- **menu-mockup.html** — menu bar before/after, v3 (interactive). Pairs with
+  `plan-menubar-prune.html`.
+
+---
+
+## Left in /tmp (superseded / dup / trivial)
+
+- **plan-configured-model.html** — older cut; superseded by `-205039`.
+- **agents-cli.sh.html**, **agi-cli.sh.html** — ~1 KB stubs, not plans.

--- a/docs/plans/2026-07-30/menu-mockup.html
+++ b/docs/plans/2026-07-30/menu-mockup.html
@@ -1,0 +1,432 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Menu Bar · Before / After (v3, interactive)</title>
+<style>
+  :root{
+    --page:#1e1f22; --page2:#111312; --ink:#e7ece8; --dim:#8b938c;
+    --menu-bg:rgba(46,48,52,0.98); --menu-line:rgba(255,255,255,0.08);
+    --menu-hl:#1163cf; --menu-hl-ink:#ffffff;
+    --accent:#a3e635; --amber:#f5c451; --red:#ff6b6b; --cyan:#5ad6c0; --blue:#5aa6ff;
+    --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"]{
+    --page:#faf9f6; --page2:#ffffff; --ink:#1a1c1a; --dim:#5c655c;
+    --menu-bg:rgba(245,245,245,0.98); --menu-line:rgba(0,0,0,0.08);
+    --menu-hl:#0064e0; --menu-hl-ink:#ffffff;
+    --accent:#4d7c0f; --amber:#b45309; --red:#dc2626; --cyan:#0e7490; --blue:#0064e0;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--page);color:var(--ink);font-family:var(--sans);
+    font-size:15px;line-height:1.5;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1300px;margin:0 auto;padding:40px 24px 100px}
+  h1{font-size:26px;margin:0 0 8px;font-weight:700;letter-spacing:-.01em}
+  h1 .accent{color:var(--accent)}
+  .sub{color:var(--dim);margin:0 0 26px;max-width:78ch}
+  .hint{font-family:var(--mono);font-size:11px;color:var(--blue);margin:0 0 26px;
+    display:inline-block;padding:6px 12px;border:1px dashed var(--blue);border-radius:6px}
+
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:44px;align-items:start}
+  @media(max-width:1000px){.grid{grid-template-columns:1fr}}
+  .col h2{font-family:var(--mono);font-size:12px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--dim);margin:0 0 12px}
+  .col.before h2{color:var(--red)}
+  .col.after h2{color:var(--accent)}
+  .stat{font-family:var(--mono);font-size:11px;color:var(--dim);margin-bottom:14px;line-height:1.7}
+  .stat b.red{color:var(--red)}
+  .stat b.grn{color:var(--accent)}
+
+  .menu-wrap{position:relative}
+  .menu{width:340px;background:var(--menu-bg);border:0.5px solid var(--menu-line);
+    border-radius:10px;box-shadow:0 12px 40px rgba(0,0,0,0.5),0 0 0 0.5px rgba(255,255,255,0.05) inset;
+    padding:6px 0;font-size:13px;backdrop-filter:blur(30px);position:relative;z-index:2}
+  :root[data-theme="light"] .menu{box-shadow:0 12px 40px rgba(0,0,0,0.18)}
+
+  /* Section header (title, non-interactive) */
+  .sec{font-family:var(--mono);font-size:10.5px;letter-spacing:.06em;color:var(--dim);
+    padding:8px 14px 4px;font-weight:500;display:flex;justify-content:space-between;align-items:center}
+  .sec.warn{color:var(--amber)}
+  .sec.info{color:var(--blue)}
+
+  /* Interactive section header — the collapsed "other" pattern.
+     Same font size/weight as a plain .sec so it doesn't masquerade as a row. */
+  .sec-btn{font-family:var(--mono);font-size:10.5px;letter-spacing:.06em;color:var(--dim);
+    padding:8px 14px;font-weight:500;display:flex;justify-content:space-between;align-items:center;
+    cursor:default;border-radius:5px;margin:0 6px}
+  .sec-btn:hover, .sec-btn.hi{background:var(--menu-hl);color:#fff}
+  .sec-btn .chev{opacity:.65}
+  .sec-btn:hover .chev, .sec-btn.hi .chev{opacity:1}
+
+  .row{padding:5px 14px;display:flex;align-items:center;gap:9px;line-height:1.35;
+    font-size:13px;position:relative;cursor:default}
+  .row .g{font-family:var(--mono);width:14px;text-align:center;display:inline-block;flex-shrink:0}
+  .row .t{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .row .r{color:var(--dim);font-family:var(--mono);font-size:11px;flex-shrink:0;margin-left:6px}
+  .row .chev{color:var(--dim);margin-left:6px;font-size:11px}
+  .row.hi, .row:hover{background:var(--menu-hl);color:var(--menu-hl-ink);border-radius:5px;margin:0 6px;padding:5px 8px}
+  .row.hi .r, .row:hover .r{color:rgba(255,255,255,0.75)}
+  .row.hi .g, .row:hover .g{color:#ffffff}
+  .row.hi .chev, .row:hover .chev{color:rgba(255,255,255,0.75)}
+  .row .g.warn{color:var(--amber)}
+  .row .g.run{color:var(--accent)}
+  .row .g.idle{color:var(--dim)}
+  .row .g.fail{color:var(--red)}
+  .row .g.info{color:var(--blue)}
+  .row.dead .g,.row.dead .t{color:var(--red);opacity:.7}
+  .row.more{color:var(--blue)}
+  .row.more .g{color:var(--blue)}
+  .row.no-hover:hover{background:transparent;color:inherit;margin:0;padding:5px 14px}
+  .row.no-hover:hover .g,.row.no-hover:hover .r,.row.no-hover:hover .chev{color:inherit}
+  .row.no-hover:hover .g.run{color:var(--accent)}
+  .row.no-hover:hover .g.idle{color:var(--dim)}
+  .row.no-hover:hover .g.warn{color:var(--amber)}
+  .row.no-hover:hover .g.info{color:var(--blue)}
+  .row.no-hover:hover .g.fail{color:var(--red)}
+
+  .sep{height:1px;background:var(--menu-line);margin:6px 10px}
+  .new{padding:5px 14px;font-size:13px;display:flex;justify-content:space-between;align-items:center;
+    cursor:default;border-radius:5px;margin:0 6px}
+  .new:hover{background:var(--menu-hl);color:#fff}
+  .new:hover .chev{color:rgba(255,255,255,0.75)}
+  .head-row{padding:0 14px 6px;font-family:var(--mono);font-size:10.5px;
+    color:var(--dim);letter-spacing:.04em;display:flex;justify-content:space-between}
+
+  /* Submenu popover — appears on hover of a row/section-btn with data-sub */
+  .popover{position:absolute;left:calc(100% + 6px);width:280px;
+    background:var(--menu-bg);border:0.5px solid var(--menu-line);border-radius:10px;
+    box-shadow:0 12px 40px rgba(0,0,0,0.5);padding:6px 0;font-size:13px;backdrop-filter:blur(30px);
+    display:none;z-index:3}
+  :root[data-theme="light"] .popover{box-shadow:0 12px 40px rgba(0,0,0,0.18)}
+  .popover.show{display:block}
+
+  /* Cross-check math cards */
+  .math{margin-top:36px;background:var(--page2);border:1px solid var(--menu-line);border-radius:10px;
+    padding:16px 18px;font-family:var(--mono);font-size:12.5px;color:var(--dim);line-height:1.9}
+  .math .k{color:var(--ink);font-weight:600}
+  .math .grn{color:var(--accent)}
+  .math .red{color:var(--red)}
+  .math .cyan{color:var(--cyan)}
+
+  .callout{background:var(--page2);border:1px solid var(--menu-line);border-radius:10px;
+    padding:14px 18px;margin-top:26px}
+  .callout .lbl{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;
+    color:var(--accent);display:block;margin-bottom:6px}
+  code{font-family:var(--mono);font-size:.86em;background:var(--page2);border:1px solid var(--menu-line);
+    border-radius:5px;padding:1px 6px;color:var(--cyan)}
+  .themebtn{position:fixed;top:16px;right:16px;z-index:9;font-family:var(--mono);font-size:12px;
+    color:var(--dim);background:var(--page2);border:1px solid var(--menu-line);border-radius:999px;
+    padding:6px 13px;cursor:pointer}
+
+  .rules{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-top:36px}
+  @media(max-width:900px){.rules{grid-template-columns:1fr}}
+  .rule{border:1px solid var(--menu-line);border-radius:12px;padding:16px 18px;background:var(--page2)}
+  .rule .n{font-family:var(--mono);font-size:11px;color:var(--accent);letter-spacing:.1em}
+  .rule h3{margin:6px 0 8px;font-size:15.5px}
+  .rule p{margin:0;color:var(--dim);font-size:14px}
+  .rule code{color:var(--cyan)}
+
+  .glossary{margin-top:36px}
+  .glossary table{width:100%;border-collapse:collapse;font-size:13.5px}
+  .glossary td,.glossary th{padding:9px 12px;border-bottom:1px solid var(--menu-line);
+    text-align:left;vertical-align:top}
+  .glossary th{font-family:var(--mono);font-size:10.5px;text-transform:uppercase;color:var(--dim);
+    letter-spacing:.06em;font-weight:500}
+  .glyph-b{font-family:var(--mono);font-size:16px;width:22px;display:inline-block;text-align:center}
+  .glyph-b.run{color:var(--accent)}
+  .glyph-b.idle{color:var(--dim)}
+  .glyph-b.attn{color:var(--amber)}
+  .glyph-b.gone{color:var(--red);opacity:.6}
+</style>
+</head>
+<body>
+<button class="themebtn" onclick="tt()" id="tb">◐ light</button>
+<script>
+  var r=document.documentElement;
+  function set(t){r.setAttribute('data-theme',t);document.getElementById('tb').textContent=(t==='light'?'◑ dark':'◐ light')}
+  set(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');
+  function tt(){set(r.getAttribute('data-theme')==='light'?'dark':'light')}
+</script>
+<div class="wrap">
+  <h1>Menu bar — <span class="accent">before &amp; after (v3, interactive)</span></h1>
+  <p class="sub">Fixed two things you flagged: the collapsed <code>ACTIVE · other</code> is now a proper section header
+    (no fake <code>◐</code> glyph), and submenus actually open — hover any row with a <code>›</code>.
+    Math cross-check at the bottom of each column.</p>
+  <p class="hint">→ hover a row or section header with <b>›</b> to open its submenu</p>
+
+<div class="grid">
+
+  <!-- ============ BEFORE ============ -->
+  <div class="col before">
+    <h2>Before — today, mac-mini</h2>
+    <div class="stat">
+      NEEDS YOU (12) · 11 <b class="red">identical</b> "waiting for your input" rows<br>
+      ACTIVE · muqsitnawaz · <b class="red">4 idle</b> advertised → <b class="red">3</b> shown, 1 silently dropped<br>
+      ACTIVE · other · <b class="red">21 idle</b> → 3 shown, 18 silently dropped (some with dead pids)
+    </div>
+    <div class="menu-wrap">
+    <div class="menu">
+      <div class="head-row"><span>agents-cli</span><span style="color:var(--amber)">⚠ 12 needs you</span></div>
+      <div class="sep"></div>
+
+      <div class="sec warn">⚠ NEEDS YOU (12)</div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">1d</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">1d</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">3h 16m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">2h 15m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">2h 5m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">1h 45m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">1h 42m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">1h 17m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">54m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">49m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz — Claude is waiting for your input</span><span class="r">8m</span></div>
+      <div class="row"><span class="g fail">✕</span><span class="t">15 routines failing</span><span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="sec info">◆ NEW DEVICES (1)</div>
+      <div class="row"><span class="g info">◆</span><span class="t">pinnacles — macos</span><span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="new">New Session<span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="sec">ACTIVE · muqsitnawaz &nbsp;·&nbsp; 4 idle</div>
+      <div class="row no-hover"><span class="g idle">◐</span><span class="t">Claude — muqsitnawaz-e0</span></div>
+      <div class="row no-hover"><span class="g idle">◐</span><span class="t">Claude — Disambiguate Duplicate Session…</span></div>
+      <div class="row no-hover"><span class="g idle">◐</span><span class="t">Claude — muqsitnawaz-03</span></div>
+      <div class="row no-hover" style="color:var(--red);font-style:italic;opacity:.8"><span class="g" style="opacity:0">·</span><span class="t">✕ 4th idle row: silently dropped</span></div>
+
+      <div class="sec">ACTIVE · other &nbsp;·&nbsp; 21 idle</div>
+      <div class="row dead no-hover"><span class="g">✕</span><span class="t">Claude (dead pid)</span></div>
+      <div class="row dead no-hover"><span class="g">✕</span><span class="t">Claude (dead pid)</span></div>
+      <div class="row dead no-hover"><span class="g">✕</span><span class="t">Claude (dead pid)</span></div>
+      <div class="row no-hover" style="color:var(--red);font-style:italic;opacity:.8"><span class="g" style="opacity:0">·</span><span class="t">✕ 18 more: silently dropped</span></div>
+
+      <div class="sep"></div>
+      <div class="sec">ACTIVE · Browser</div>
+      <div class="row"><span class="g run">●</span><span class="t">phx-proto — comet-local · 1 tab</span><span class="chev">›</span></div>
+    </div>
+    </div>
+
+    <div class="math">
+      <span class="k">math check — ACTIVE · muqsitnawaz</span><br>
+      header: <span class="red">4 idle</span> &nbsp;/&nbsp; visible: <span class="red">3</span> &nbsp;/&nbsp; hidden: <span class="red">1</span> &nbsp;→&nbsp; <span class="red">MISMATCH</span> (no "+N more" indicator)<br><br>
+      <span class="k">math check — ACTIVE · other</span><br>
+      header: <span class="red">21 idle</span> &nbsp;/&nbsp; visible: <span class="red">3</span> (of which some are dead pids) &nbsp;/&nbsp; hidden: <span class="red">18</span> &nbsp;→&nbsp; <span class="red">MISMATCH</span>
+    </div>
+  </div>
+
+  <!-- ============ AFTER ============ -->
+  <div class="col after">
+    <h2>After — with all four rules applied</h2>
+    <div class="stat">
+      NEEDS YOU · <b class="grn">grouped by (agent, repo)</b> · filler dropped · specific questions kept inline<br>
+      ACTIVE · muqsitnawaz · header <b class="grn">1 running · 4 idle</b> · visible: 1 <b class="grn">●</b> + 3 <b class="grn">◐</b> + <b class="grn">+ 1 more idle ›</b> = 5<br>
+      ACTIVE · other · rendered as its own <b class="grn">section header</b>, not a fake session row
+    </div>
+    <div class="menu-wrap">
+    <div class="menu">
+      <div class="head-row"><span>agents-cli</span><span style="color:var(--amber)">⚠ 6 needs you</span></div>
+      <div class="sep"></div>
+
+      <div class="sec warn">⚠ NEEDS YOU (2 groups · 6 total)</div>
+
+      <!-- grouped, hoverable → opens submenu #g1 -->
+      <div class="row" data-sub="g1"><span class="g warn">⚠</span><span class="t">Claude · muqsitnawaz · 5 waiting</span><span class="r">oldest 49m</span><span class="chev">›</span></div>
+
+      <!-- single blocked session with a specific question → inline -->
+      <div class="row"><span class="g warn">⚠</span><span class="t">Claude · agents-cli — approve tool: Bash</span><span class="r">3m</span></div>
+
+      <div class="row" data-sub="g2"><span class="g fail">✕</span><span class="t">15 routines failing</span><span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="sec info">◆ NEW DEVICES (1)</div>
+      <div class="row" data-sub="g3"><span class="g info">◆</span><span class="t">pinnacles — macos</span><span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="new" data-sub="g4">New Session<span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="sec">ACTIVE · muqsitnawaz &nbsp;·&nbsp; 1 running · 4 idle</div>
+      <div class="row no-hover"><span class="g run">●</span><span class="t">Claude — muqsitnawaz-e0</span></div>
+      <div class="row no-hover"><span class="g idle">◐</span><span class="t">Claude — Disambiguate Duplicate Session…</span></div>
+      <div class="row no-hover"><span class="g idle">◐</span><span class="t">Claude — muqsitnawaz-03</span></div>
+      <div class="row no-hover"><span class="g idle">◐</span><span class="t">Claude — dep-graph-cleanup</span></div>
+      <!-- explicit +N more, hoverable → opens submenu #g5 -->
+      <div class="row more" data-sub="g5"><span class="g">+</span><span class="t">1 more idle</span><span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <!-- COLLAPSED SECTION — rendered as an interactive section header, NOT a fake row.
+           Section-header font weight, no session glyph. -->
+      <div class="sec-btn" data-sub="g6"><span>ACTIVE · other  ·  3 idle</span><span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="sec">ACTIVE · Browser</div>
+      <div class="row" data-sub="g7"><span class="g run">●</span><span class="t">phx-proto — comet-local · 1 tab</span><span class="chev">›</span></div>
+
+      <div class="sep"></div>
+      <div class="sec">ROUTINES 26 · next Mon 8:00 AM · 2 paused</div>
+      <div class="row no-hover"><span class="g idle">◔</span><span class="t">sandbox-tests</span><span class="r">tomorrow 7:00 AM</span></div>
+    </div>
+
+    <!-- Interactive submenus — hidden until hover -->
+    <div class="popover" id="g1">
+      <div class="sec">Claude · muqsitnawaz · 5 waiting</div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">session e0</span><span class="r">49m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">session 03</span><span class="r">54m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">session 8a</span><span class="r">1h 17m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">session 12</span><span class="r">1h 42m</span></div>
+      <div class="row"><span class="g warn">⚠</span><span class="t">session c4</span><span class="r">2h 5m</span></div>
+    </div>
+    <div class="popover" id="g2">
+      <div class="sec">Failed routines (15)</div>
+      <div class="row"><span class="g fail">✕</span><span class="t">agents-cli-update</span></div>
+      <div class="row"><span class="g fail">✕</span><span class="t">crm-pipeline-brief</span></div>
+      <div class="row"><span class="g fail">✕</span><span class="t">doc-gaps-agents-cli</span></div>
+      <div class="row"><span class="g fail">✕</span><span class="t">... 12 more</span></div>
+    </div>
+    <div class="popover" id="g3">
+      <div class="sec">pinnacles — macos</div>
+      <div class="row"><span class="t">Register</span></div>
+      <div class="row"><span class="t">Ignore</span></div>
+    </div>
+    <div class="popover" id="g4">
+      <div class="sec">New Session</div>
+      <div class="row"><span class="t">Claude</span></div>
+      <div class="row"><span class="t">Codex</span></div>
+      <div class="row"><span class="t">Grok-Cli</span></div>
+      <div class="row"><span class="t">Kimi-Cli</span></div>
+      <div class="row"><span class="t">Antigravity</span></div>
+      <div class="row"><span class="t">Droid</span></div>
+      <div class="row"><span class="t">OpenCode</span></div>
+    </div>
+    <div class="popover" id="g5">
+      <div class="sec">Idle sessions · muqsitnawaz · 1 more</div>
+      <div class="row"><span class="g idle">◐</span><span class="t">Claude — feature-x-followup</span></div>
+    </div>
+    <div class="popover" id="g6">
+      <div class="sec">ACTIVE · other · 3 idle</div>
+      <div class="row"><span class="g idle">◐</span><span class="t">Claude — /tmp scratch</span></div>
+      <div class="row"><span class="g idle">◐</span><span class="t">Claude — home-dir session</span></div>
+      <div class="row"><span class="g idle">◐</span><span class="t">Claude — ~ shell session</span></div>
+    </div>
+    <div class="popover" id="g7">
+      <div class="sec">phx-proto — comet-local</div>
+      <div class="row"><span class="t">Focus tab</span></div>
+      <div class="row"><span class="t">Close browser</span></div>
+    </div>
+    </div>
+
+    <div class="math">
+      <span class="k">math check — NEEDS YOU</span><br>
+      badge: <span class="grn">6 needs you</span> = 5 (grouped muqsitnawaz) + 1 (inline agents-cli) &nbsp;→&nbsp; <span class="grn">MATCHES</span><br>
+      section: <span class="cyan">2 groups · 6 total</span> = both counts explicit<br><br>
+      <span class="k">math check — ACTIVE · muqsitnawaz</span><br>
+      header: <span class="grn">1 running · 4 idle</span> = 5 sessions<br>
+      visible: 1 <span class="grn">●</span> + 3 <span class="grn">◐</span> + "+ 1 more idle" = 5 &nbsp;→&nbsp; <span class="grn">MATCHES</span><br><br>
+      <span class="k">math check — ACTIVE · other</span><br>
+      header: <span class="grn">3 idle</span> (in the section-header line itself)<br>
+      visible in main menu: 0 &nbsp;→&nbsp; submenu carries all 3 &nbsp;→&nbsp; <span class="grn">MATCHES</span>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  // Hover-to-open submenu. Each element with data-sub="ID" reveals #ID
+  // to its right, and hides it on leave. Simple, no library.
+  var subs = {};
+  document.querySelectorAll('.popover').forEach(function(p){ subs[p.id] = p; });
+
+  document.querySelectorAll('[data-sub]').forEach(function(el){
+    var pop = subs[el.getAttribute('data-sub')];
+    if (!pop) return;
+
+    function show(){
+      // Hide all others first
+      Object.values(subs).forEach(function(o){ o.classList.remove('show'); });
+      // Position vertically to align with the hovered element's top,
+      // relative to the .menu-wrap container.
+      var wrap = el.closest('.menu-wrap');
+      if (!wrap) return;
+      var wrapBox = wrap.getBoundingClientRect();
+      var elBox = el.getBoundingClientRect();
+      pop.style.top = (elBox.top - wrapBox.top - 6) + 'px';
+      pop.classList.add('show');
+    }
+    function hide(){ pop.classList.remove('show'); }
+
+    el.addEventListener('mouseenter', show);
+    el.addEventListener('mouseleave', function(e){
+      // If moving into the popover itself, keep it open
+      var to = e.relatedTarget;
+      if (to && (to === pop || pop.contains(to))) return;
+      setTimeout(function(){
+        if (!pop.matches(':hover') && !el.matches(':hover')) hide();
+      }, 100);
+    });
+    pop.addEventListener('mouseleave', function(e){
+      var to = e.relatedTarget;
+      if (to && (to === el || el.contains(to))) return;
+      hide();
+    });
+  });
+</script>
+
+<div class="callout">
+  <span class="lbl">what changed vs. v2</span>
+  <b>1. `ACTIVE · other` is now a section HEADER, not a row.</b> No fake <code>◐</code> glyph pretending to be a session.
+  The header itself is clickable (uppercased mono font matching every other section title) and shows its count inline.
+  Math is now unambiguous: no row = no addition. &nbsp;
+  <b>2. Submenus actually open.</b> Hover any element with <code>›</code> — the grouped waiter, the +N more, the
+  collapsed section, even routines failing, New Session, and the Browser row all pop out their real submenu to the right.
+</div>
+
+<h2 style="margin-top:44px;font-size:18px">The four design rules</h2>
+<div class="rules">
+  <div class="rule"><div class="n">RULE 01 · reader-side</div>
+    <h3>Prune orphan sentinels on read</h3>
+    <p>Cross-check attention sentinels against the live session set. Unlink orphans found during the read.
+      Kills the 1d / 2h / 1h ghost rows at the source.</p>
+  </div>
+  <div class="rule"><div class="n">RULE 02 · rendering</div>
+    <h3>Collapse "ACTIVE · other" as a section header</h3>
+    <p>When the <code>"other"</code> group is idle-only, render it as an interactive <em>section header</em>
+      (not a row with a session glyph). Header carries the count; submenu carries the sessions.</p>
+  </div>
+  <div class="rule"><div class="n">RULE 03 · rendering</div>
+    <h3>Group NEEDS YOU by (agent, repo); drop generic filler</h3>
+    <p>Multiple waiters in one repo → one row + submenu. Rows with a specific Notification message stay inline.
+      Drop the generic <code>— Claude is waiting for your input</code> tail entirely.</p>
+  </div>
+  <div class="rule"><div class="n">RULE 04 · rendering</div>
+    <h3>Explicit truncation, never silent</h3>
+    <p>Header count = visible glyphs + explicit "+N more" count. If the 3-cap hides idle rows, render
+      <code>+ N more idle ›</code> with a submenu. "N running · M idle" both show when non-zero.</p>
+  </div>
+</div>
+
+<div class="glossary">
+  <h2 style="font-size:16px;margin:0 0 10px">Row-glyph legend — the single answer to "running vs idle"</h2>
+  <table>
+    <thead><tr><th>Glyph</th><th>State</th><th>Definition (pid alive assumed)</th></tr></thead>
+    <tbody>
+      <tr><td><span class="glyph-b run">●</span></td><td><b>Running</b></td>
+        <td>Transcript mtime &lt; 2 min. Agent is producing output right now.</td></tr>
+      <tr><td><span class="glyph-b idle">◐</span></td><td><b>Idle</b></td>
+        <td>Transcript mtime ≥ 2 min AND no attention sentinel. Turn is complete — sitting at the prompt.</td></tr>
+      <tr><td><span class="glyph-b attn">⚠</span></td><td><b>Awaiting input</b></td>
+        <td>Attention sentinel present. Notification hook fired — progress halted until you answer.</td></tr>
+      <tr><td><span class="glyph-b gone">✕</span></td><td><b>Closed</b> (hidden)</td>
+        <td>pid dead. Never rendered. Extending today's <code>pidAlive</code> guard to the attention path removes
+          the ✕ rows from the BEFORE column.</td></tr>
+    </tbody>
+  </table>
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/plans/2026-07-30/plan-configured-model-205039.html
+++ b/docs/plans/2026-07-30/plan-configured-model-205039.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Plan · Show the configured model everywhere agents-cli shows an agent</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111211; --panel-2:#161816; --ink:#e7e9e4; --muted:#9aa196;
+    --line:#26291f; --lime:#a3e635; --lime-dim:#7fb52a; --amber:#f5c451; --red:#f27c7c;
+    --cyan:#63b3d6; --code-bg:#0c0d0b; --chip:#1b1e17;
+    --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:'Inter',system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+  }
+  html[data-theme="light"]{
+    --bg:#f7f8f4; --panel:#ffffff; --panel-2:#f1f3ec; --ink:#1b1d18; --muted:#5c6357;
+    --line:#e0e4d6; --lime:#5f8a12; --lime-dim:#6f9a1e; --amber:#a9791a; --red:#c0392b;
+    --cyan:#2b6d8c; --code-bg:#f2f4ea; --chip:#eaeee0;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
+    line-height:1.6;-webkit-font-smoothing:antialiased;}
+  a{color:var(--lime);text-decoration:none}
+  .wrap{max-width:860px;margin:0 auto;padding:48px 24px 96px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.22em;text-transform:uppercase;
+    color:var(--lime);margin:0 0 14px}
+  h1{font-size:34px;line-height:1.18;margin:0 0 18px;letter-spacing:-.01em;font-weight:700}
+  .lede{font-size:17px;color:var(--muted);margin:0 0 26px;max-width:70ch}
+  .chips{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 30px}
+  .chip{font-family:var(--mono);font-size:11.5px;background:var(--chip);border:1px solid var(--line);
+    color:var(--ink);padding:5px 10px;border-radius:6px}
+  .chip b{color:var(--lime);font-weight:600}
+  .toc{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 20px;margin:0 0 42px}
+  .toc h4{margin:0 0 10px;font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted)}
+  .toc ol{margin:0;padding-left:20px;columns:2;column-gap:32px}
+  .toc li{margin:4px 0;font-size:14px}
+  section{margin:0 0 40px}
+  h2{font-size:13px;font-family:var(--mono);letter-spacing:.12em;text-transform:uppercase;
+    color:var(--lime);border-bottom:1px solid var(--line);padding-bottom:8px;margin:0 0 18px}
+  h2 .n{color:var(--muted);margin-right:10px}
+  h3{font-size:16px;margin:26px 0 8px}
+  p{margin:0 0 14px}
+  code{font-family:var(--mono);font-size:12.5px;background:var(--code-bg);border:1px solid var(--line);
+    padding:1.5px 6px;border-radius:5px;color:var(--ink)}
+  pre{font-family:var(--mono);font-size:12.5px;background:var(--code-bg);border:1px solid var(--line);
+    border-radius:10px;padding:16px 18px;overflow:auto;margin:0 0 18px;line-height:1.5}
+  pre code{background:none;border:none;padding:0}
+  .cmt{color:var(--muted)}
+  .kw{color:var(--lime)}
+  .str{color:var(--amber)}
+  .callout{border:1px solid var(--line);border-left:3px solid var(--lime);background:var(--panel);
+    border-radius:8px;padding:14px 18px;margin:0 0 18px}
+  .callout.warn{border-left-color:var(--amber)}
+  .callout .t{font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--muted);margin:0 0 6px}
+  table{width:100%;border-collapse:collapse;margin:0 0 18px;font-size:13.5px}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+  td code{font-size:11.5px}
+  .tag{font-family:var(--mono);font-size:10.5px;padding:2px 7px;border-radius:20px;border:1px solid var(--line)}
+  .tag.new{color:var(--lime);border-color:var(--lime-dim)}
+  .tag.edit{color:var(--amber);border-color:var(--amber)}
+  .src{font-family:var(--mono);color:var(--muted)}
+  .diagram{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:24px;margin:0 0 20px}
+  .theme-toggle{position:fixed;top:18px;right:18px;font-family:var(--mono);font-size:18px;
+    background:var(--panel);border:1px solid var(--line);color:var(--ink);width:40px;height:40px;
+    border-radius:50%;cursor:pointer;line-height:1;display:flex;align-items:center;justify-content:center}
+  .foot{color:var(--muted);font-size:12.5px;font-family:var(--mono);border-top:1px solid var(--line);
+    padding-top:18px;margin-top:48px}
+  ul.tight{margin:0 0 14px;padding-left:20px} ul.tight li{margin:5px 0}
+  .out{color:var(--muted)} .out .m{color:var(--lime)} .out .s{color:var(--amber)}
+  /* terminal mockups */
+  .term{background:var(--code-bg);border:1px solid var(--line);border-radius:10px;overflow:hidden;margin:0 0 4px}
+  .term .bar{display:flex;align-items:center;gap:6px;padding:8px 12px;border-bottom:1px solid var(--line);background:var(--panel-2)}
+  .term .bar i{width:11px;height:11px;border-radius:50%;display:inline-block}
+  .term .bar .r{background:var(--red)} .term .bar .y{background:var(--amber)} .term .bar .g{background:var(--lime)}
+  .term .bar span{font-family:var(--mono);font-size:11px;color:var(--muted);margin-left:6px}
+  .term pre{background:none;border:none;border-radius:0;margin:0;padding:14px 16px;font-size:12px;line-height:1.7;white-space:pre}
+  .ba{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin:0 0 8px}
+  @media(max-width:760px){.ba{grid-template-columns:1fr}}
+  .lbl{font-family:var(--mono);font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  .lbl.aft{color:var(--lime)}
+  .v{color:var(--lime)} .e{color:var(--cyan)} .g2{color:var(--muted)} .pct{color:var(--amber)}
+  .mdl{color:var(--lime)} .add{color:var(--lime);font-weight:600} .prompt{color:var(--muted)}
+</style>
+</head>
+<body>
+<button class="theme-toggle" onclick="(function(){var h=document.documentElement;h.dataset.theme=h.dataset.theme==='dark'?'light':'dark';})()">◐</button>
+<div class="wrap">
+
+  <p class="kicker">agents-cli · implementation plan</p>
+  <h1>Show the configured model wherever <code>agents</code> displays an agent</h1>
+  <p class="lede">Every place we already surface an agent+version — <code>agents view</code>,
+  the <code>agent@version</code> detail, <code>use</code>, <code>add</code>, <code>status</code>,
+  <code>inspect</code> — should tell the user <em>which model that agent is set to use right now</em>,
+  with a short label saying where the selection comes from. Usage/limit windows already look good and
+  stay exactly as they are.</p>
+
+  <div class="chips">
+    <span class="chip">scope · <b>configured model only</b></span>
+    <span class="chip">limits · <b>unchanged</b></span>
+    <span class="chip">surfaces · <b>6</b></span>
+    <span class="chip">new helper · <b>resolveConfiguredModel()</b></span>
+    <span class="chip">files · <b>5</b></span>
+    <span class="chip">repo · <b>phnx-labs/agents-cli</b></span>
+  </div>
+
+  <div class="toc">
+    <h4>Contents</h4>
+    <ol>
+      <li><a href="#ctx">The gap today</a></li>
+      <li><a href="#look">What it will look like</a></li>
+      <li><a href="#resolve">One shared resolver</a></li>
+      <li><a href="#surfaces">Wiring the surfaces</a></li>
+      <li><a href="#files">Files &amp; tests</a></li>
+      <li><a href="#verify">Verification</a></li>
+    </ol>
+  </div>
+
+  <section id="ctx">
+    <h2><span class="n">01</span>The gap today</h2>
+    <p>A user inspecting an agent sees version, account, and usage windows — but the model is
+    effectively invisible. The only model hint is a gray <code>run model:&lt;x&gt;</code> suffix on
+    <code>agents view</code> rows, and it appears <b>only if</b> the user manually set an
+    <code>agents.yaml</code> <code>run.defaults</code> entry (<span class="src">view.ts:621-651</span>).
+    The <code>agent@version</code> detail view shows <b>no model at all</b>
+    (<span class="src">view.ts:1026-1049</span>). Yet the agent always runs with <em>some</em>
+    model — its native <code>settings.json</code> model, or the CLI's built-in default.</p>
+
+    <div class="callout">
+      <p class="t">Outcome the user wants</p>
+      <p style="margin:0">"The user is trying to see what an agent has." One glance answers
+      <em>what model is this agent+version set to, and why.</em></p>
+    </div>
+
+    <div class="diagram">
+      <svg viewBox="0 0 760 250" width="100%" role="img" aria-label="Model resolution precedence">
+        <defs>
+          <marker id="ar" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+            <path d="M0,0 L7,3 L0,6 Z" fill="#a3e635"/>
+          </marker>
+          <style>
+            .bx{fill:#161816;stroke:#26291f} .lb{fill:#e7e9e4;font-family:'JetBrains Mono',monospace;font-size:12px}
+            .sub{fill:#9aa196;font-family:'JetBrains Mono',monospace;font-size:10.5px}
+            .hd{fill:#a3e635;font-family:'JetBrains Mono',monospace;font-size:11px;letter-spacing:.1em}
+            .fl{stroke:#a3e635;stroke-width:1.4;fill:none}
+          </style>
+        </defs>
+        <text x="0" y="16" class="hd">RESOLVE CONFIGURED MODEL — FIRST HIT WINS</text>
+
+        <rect x="0" y="36" width="210" height="60" rx="8" class="bx"/>
+        <text x="16" y="62" class="lb">1 · run default</text>
+        <text x="16" y="80" class="sub">agents.yaml run.defaults</text>
+
+        <rect x="0" y="106" width="210" height="60" rx="8" class="bx"/>
+        <text x="16" y="132" class="lb">2 · config</text>
+        <text x="16" y="150" class="sub">agent's settings.json "model"</text>
+
+        <rect x="0" y="176" width="210" height="60" rx="8" class="bx"/>
+        <text x="16" y="202" class="lb">3 · cli default</text>
+        <text x="16" y="220" class="sub">catalog isDefault (binary)</text>
+
+        <path class="fl" d="M210,66 C300,66 300,133 360,133" marker-end="url(#ar)"/>
+        <path class="fl" d="M210,136 L360,133" marker-end="url(#ar)"/>
+        <path class="fl" d="M210,206 C300,206 300,133 360,133" marker-end="url(#ar)"/>
+
+        <rect x="362" y="103" width="200" height="60" rx="8" class="bx" style="stroke:#a3e635"/>
+        <text x="378" y="129" class="lb">ConfiguredModel</text>
+        <text x="378" y="147" class="sub">{ model, source }</text>
+
+        <path class="fl" d="M562,133 L610,133" marker-end="url(#ar)"/>
+        <rect x="612" y="103" width="148" height="60" rx="8" class="bx"/>
+        <text x="628" y="126" class="lb" style="fill:#a3e635">opus</text>
+        <text x="628" y="147" class="sub">(run default)</text>
+      </svg>
+    </div>
+  </section>
+
+  <section id="look">
+    <h2><span class="n">02</span>What it will look like</h2>
+    <div class="callout">
+      <p class="t">Design principle</p>
+      <p style="margin:0">The model gets the <b>same treatment and priority as the version</b> —
+      it sits <em>right next to it</em>, everywhere, and is <b>never its own row or label</b>.
+      Wherever a version shows, the model shows beside it: <b>agent · version · model · account</b>.
+      The source (<code>run default</code> / <code>config</code> / <code>cli default</code>) is
+      resolved but kept out of the human views — it's available in <code>agents view --json</code>.
+      Usage windows are untouched.</p>
+    </div>
+
+    <h3>A · <code>agents view claude</code> — the version list</h3>
+    <div class="ba">
+      <div>
+        <p class="lbl">before</p>
+        <div class="term"><div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>agents view claude</span></div><pre><span class="g2">Installed Agent CLIs</span>
+
+  <span style="font-weight:600">Claude</span> <span class="g2">(balanced)</span>
+    <span class="v">2.1.186 (default)</span>  <span class="e">you@rush.dev</span>   <span class="g2">S</span> ███░░ <span class="pct">58%</span>  <span class="g2">W</span> █░░░░ <span class="pct">12%</span>   <span class="g2">2h ago</span>
+    <span class="v">2.1.112</span>            <span class="e">you@rush.dev</span>   <span class="g2">S</span> █░░░░ <span class="pct"> 9%</span>              <span class="g2">1d ago</span></pre></div>
+      </div>
+      <div>
+        <p class="lbl aft">after</p>
+        <div class="term"><div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>agents view claude</span></div><pre><span class="g2">Installed Agent CLIs</span>
+
+  <span style="font-weight:600">Claude</span> <span class="g2">(balanced)</span>
+    <span class="v">2.1.186 (default)</span>  <span class="mdl add">opus  </span>  <span class="e">you@rush.dev</span>   <span class="g2">S</span> ███░░ <span class="pct">58%</span>  <span class="g2">W</span> █░░░░ <span class="pct">12%</span>   <span class="g2">2h ago</span>
+    <span class="v">2.1.112</span>            <span class="mdl add">sonnet</span>  <span class="e">you@rush.dev</span>   <span class="g2">S</span> █░░░░ <span class="pct"> 9%</span>              <span class="g2">1d ago</span></pre></div>
+      </div>
+    </div>
+    <p class="lbl" style="margin-top:2px">the new column is the only difference — bare model id, aligned right after the version</p>
+
+    <h3>B · <code>agents view claude@2.1.186</code> — the detail view</h3>
+    <div class="ba">
+      <div>
+        <p class="lbl">before</p>
+        <div class="term"><div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>agents view claude@2.1.186</span></div><pre><span class="g2">Agent CLIs</span>
+
+  <span style="font-weight:600">Claude</span>          <span class="v">2.1.186</span>  <span class="e">you@rush.dev</span>  <span class="g2">Pro</span>
+
+  <span class="g2">Usage</span>
+
+    <span style="font-weight:600">Current session</span>       ███░░ <span class="pct">58%</span> used
+    <span class="g2">Resets in 3 hours</span>
+    <span style="font-weight:600">Current week (all)</span>    █░░░░ <span class="pct">12%</span> used
+    <span class="g2">Resets in 6 days</span></pre></div>
+      </div>
+      <div>
+        <p class="lbl aft">after</p>
+        <div class="term"><div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>agents view claude@2.1.186</span></div><pre><span class="g2">Agent CLIs</span>
+
+  <span style="font-weight:600">Claude</span>          <span class="v">2.1.186</span>  <span class="mdl add">opus</span>  <span class="e">you@rush.dev</span>  <span class="g2">Pro</span>
+
+  <span class="g2">Usage</span>
+
+    <span style="font-weight:600">Current session</span>       ███░░ <span class="pct">58%</span> used
+    <span class="g2">Resets in 3 hours</span>
+    <span style="font-weight:600">Current week (all)</span>    █░░░░ <span class="pct">12%</span> used
+    <span class="g2">Resets in 6 days</span></pre></div>
+      </div>
+    </div>
+    <p class="lbl" style="margin-top:2px">model folds into the header line between version and account — no separate line, no "Model" label</p>
+
+    <h3>C · Confirmations &amp; status — one identity cluster</h3>
+    <p><code>agent@version · model · account</code> from the shared formatter. No "model" keyword.</p>
+    <div class="term"><div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>after</span></div><pre><span class="prompt">$</span> agents use claude@2.1.186
+Set <span class="v">Claude@2.1.186</span> <span class="g2">·</span> <span class="mdl">opus</span> <span class="g2">·</span> <span class="e">you@rush.dev</span> as global default
+
+<span class="prompt">$</span> agents add claude@2.1.187
+Installed <span class="v">Claude@2.1.187</span> <span class="g2">·</span> <span class="mdl">opus</span> <span class="g2">·</span> <span class="e">you@rush.dev</span>
+
+<span class="prompt">$</span> agents status
+  <span class="v">claude@2.1.186</span> <span class="g2">·</span> <span class="mdl">opus</span> <span class="g2">·</span> <span class="e">you@rush.dev</span>   <span class="g2">(default)   in sync</span></pre></div>
+
+    <h3>D · <code>agents inspect</code> — model sits with the version in the header</h3>
+    <div class="ba">
+      <div>
+        <p class="lbl">before</p>
+        <div class="term"><div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>agents inspect claude@2.1.186</span></div><pre><span style="font-weight:600">claude</span> <span class="g2">@</span> <span class="v">2.1.186</span>  <span style="color:var(--lime)">[default]</span>
+
+  <span class="g2">install </span>  ~/.agents/.history/versions/claude/2.1.186/home
+  <span class="g2">config  </span>  ~/.claude
+  <span class="g2">strategy</span>  balanced</pre></div>
+      </div>
+      <div>
+        <p class="lbl aft">after</p>
+        <div class="term"><div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>agents inspect claude@2.1.186</span></div><pre><span style="font-weight:600">claude</span> <span class="g2">@</span> <span class="v">2.1.186</span>  <span class="mdl add">opus</span>  <span style="color:var(--lime)">[default]</span>
+
+  <span class="g2">install </span>  ~/.agents/.history/versions/claude/2.1.186/home
+  <span class="g2">config  </span>  ~/.claude
+  <span class="g2">strategy</span>  balanced</pre></div>
+      </div>
+    </div>
+    <p class="lbl" style="margin-top:2px">model joins the header beside the version — no new row, no "model" label</p>
+  </section>
+
+  <section id="resolve">
+    <h2><span class="n">03</span>One shared resolver</h2>
+    <p>Add <code>resolveConfiguredModel(agent, version)</code> to
+    <code>apps/cli/src/lib/models.ts</code>, beside the existing <code>resolveEffectiveModel</code>
+    and <code>getModelCatalog</code>. Every surface calls this one function, so the display can
+    never drift between commands.</p>
+
+    <pre><code><span class="kw">export type</span> ConfiguredModelSource = <span class="str">'run-default'</span> | <span class="str">'config'</span> | <span class="str">'cli-default'</span>;
+
+<span class="kw">export interface</span> ConfiguredModel { model: <span class="kw">string</span>; source: ConfiguredModelSource; }
+
+<span class="kw">export function</span> resolveConfiguredModel(agent, version): ConfiguredModel | <span class="kw">null</span> {
+  <span class="cmt">// 1 · run default — resolveRunDefaults(agent, version).model      (lib/run-defaults.ts)</span>
+  <span class="cmt">// 2 · config      — read getVersionHomePath()/agentConfigDirName()/settings.json ."model"</span>
+  <span class="cmt">// 3 · cli default — resolveEffectiveModel(agent, version)          (catalog isDefault)</span>
+}</code></pre>
+
+    <table>
+      <thead><tr><th>Layer</th><th>Source of truth</th><th>Existing helper reused</th></tr></thead>
+      <tbody>
+        <tr><td><b>run-default</b></td><td><code>agents.yaml → run.defaults</code></td><td><code>resolveRunDefaults()</code> <span class="src">run-defaults.ts:178</span></td></tr>
+        <tr><td><b>config</b></td><td>agent-native <code>settings.json "model"</code></td><td><code>getVersionHomePath()</code> <span class="src">versions.ts:1054</span> · <code>agentConfigDirName()</code> <span class="src">agents.ts:1025</span></td></tr>
+        <tr><td><b>cli-default</b></td><td>catalog <code>isDefault</code> (from binary)</td><td><code>resolveEffectiveModel()</code> <span class="src">models.ts:940</span></td></tr>
+      </tbody>
+    </table>
+
+    <div class="callout warn">
+      <p class="t">Honest layering, not a fallback band-aid</p>
+      <p style="margin:0">Each layer is a real, distinct source the agent genuinely consults. The
+      config read is best-effort (Claude's <code>settings.json</code> has a top-level <code>"model"</code>;
+      agents without one fall through). A missing/malformed file is a fall-through, not a swallowed error.
+      Returns <code>null</code> only when the agent isn't model-capable. Callers holding
+      <code>'default'</code> resolve a concrete version first via <code>resolveVersion()</code>.</p>
+    </div>
+
+    <p>Two sibling formatters keep every surface consistent:</p>
+    <ul class="tight">
+      <li><code>formatAgentIdentity(agent, ver, {model, account})</code> → the cluster
+      <span class="out"><span class="v" style="color:var(--lime)">Claude@2.1.186</span> · <span class="m">opus</span> · <span class="e" style="color:var(--cyan)">you@rush.dev</span></span>,
+      reused by the view detail header and the use / add / status confirmations.</li>
+      <li><code>formatModelSource(source)</code> → <code>run default</code> / <code>config</code> /
+      <code>cli default</code>, emitted only in <code>agents view --json</code> (<code>configuredModel.source</code>).</li>
+    </ul>
+    <p>The bare model id (<code>opus</code>) comes straight off
+    <code>resolveConfiguredModel(...).model</code> and is placed beside the version; the source
+    word never appears in a human view.</p>
+  </section>
+
+  <section id="surfaces">
+    <h2><span class="n">04</span>Wiring the surfaces</h2>
+    <p>Same tiny pattern each place: resolve, then print one gray <code>model</code> bit. No emojis;
+    matches the existing subdued-metadata style.</p>
+    <table>
+      <thead><tr><th>Surface</th><th>Location</th><th>Change</th><th></th></tr></thead>
+      <tbody>
+        <tr><td><code>agents view</code> rows<br><span class="sub src">(&amp; <code>view &lt;agent&gt;</code>)</span></td><td><span class="src">view.ts:598-660</span></td><td>Insert an aligned <b>model column</b> right after the version (bare id, no source)</td><td><span class="tag edit">edit</span></td></tr>
+        <tr><td><code>agents view &lt;agent&gt;@&lt;ver&gt;</code></td><td><span class="src">view.ts:1040</span></td><td>Fold model <b>into</b> the header line, between version and account — no label</td><td><span class="tag edit">edit</span></td></tr>
+        <tr><td><code>agents use</code></td><td><span class="src">versions.ts:1028, 897</span></td><td>Rebuild line around <code>formatAgentIdentity()</code> (account moves into cluster)</td><td><span class="tag edit">edit</span></td></tr>
+        <tr><td><code>agents add</code></td><td><span class="src">versions.ts:517</span></td><td><code>Installed &lt;identity cluster&gt;</code></td><td><span class="tag edit">edit</span></td></tr>
+        <tr><td><code>agents status</code></td><td><span class="src">status.ts:91-93</span></td><td>Swap bare <code>agent@ver</code> for the identity cluster</td><td><span class="tag edit">edit</span></td></tr>
+        <tr><td><code>agents inspect</code></td><td><span class="src">inspect.ts:675</span></td><td>Add model to the <b>header</b> beside the version (no new row)</td><td><span class="tag edit">edit</span></td></tr>
+      </tbody>
+    </table>
+    <p>Optional JSON parity: add <code>configuredModel:{model,source}</code> to the per-version shape
+    in <code>collectAgentsJson</code> so <code>agents view --json</code> stays in sync.</p>
+  </section>
+
+  <section id="files">
+    <h2><span class="n">05</span>Files &amp; tests</h2>
+    <ul class="tight">
+      <li><code>lib/models.ts</code> <span class="tag new">new fns</span> — <code>resolveConfiguredModel</code> + <code>formatConfiguredModel</code></li>
+      <li><code>commands/view.ts</code> <span class="tag edit">edit</span> — overview rows + detail header (+ optional <code>--json</code>)</li>
+      <li><code>commands/versions.ts</code> <span class="tag edit">edit</span> — <code>use</code> + <code>add</code> confirmations</li>
+      <li><code>commands/status.ts</code> <span class="tag edit">edit</span> — per-version row</li>
+      <li><code>commands/inspect.ts</code> <span class="tag edit">edit</span> — rows array</li>
+    </ul>
+    <div class="callout">
+      <p class="t">Tests — real files, no mocking</p>
+      <p style="margin:0"><code>models.test.ts</code>: precedence over a temp <code>~/.agents</code> fixture —
+      (a) run default → <code>run-default</code>; (b) native <code>settings.json</code> only → <code>config</code>;
+      (c) neither → <code>cli-default</code>; (d) non-model-capable → <code>null</code>.
+      Extend <code>view.resources.test.ts</code> to assert the detail view prints the <code>Model</code> line.</p>
+    </div>
+  </section>
+
+  <section id="verify">
+    <h2><span class="n">06</span>Verification — run the real binary</h2>
+    <pre><code><span class="cmt"># build, then drive this machine's actual installed agents</span>
+cd apps/cli && bun run build
+
+node dist/index.js view claude              <span class="cmt"># each row → model:… (source)</span>
+node dist/index.js view claude@2.1.186      <span class="cmt"># new Model line; Usage section unchanged below</span>
+node dist/index.js defaults run set claude:* --model opus
+node dist/index.js view claude              <span class="cmt"># that version now → model:opus (run default)</span>
+node dist/index.js use claude@2.1.186       <span class="cmt"># confirmation echoes effective model</span>
+node dist/index.js status ; node dist/index.js inspect claude@2.1.186</code></pre>
+    <div class="callout">
+      <p class="t">Proof the limits stayed untouched</p>
+      <p style="margin:0">Diff the <code>Usage</code> section before/after — it must be byte-identical.
+      The change only <em>adds</em> a model line; it never edits usage-window rendering.</p>
+    </div>
+  </section>
+
+  <p class="foot">agents-cli · Phoenix Labs OSS · plan rendered for review — not yet executed</p>
+</div>
+<script>
+  (function(){var m=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;
+   if(m)document.documentElement.dataset.theme='light';})();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-07-30/plan-inspect-version-picker.html
+++ b/docs/plans/2026-07-30/plan-inspect-version-picker.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Plan · Inspect version picker</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111312; --panel2:#161a18; --ink:#e7ece8; --dim:#8b938c;
+    --line:#26302a; --accent:#a3e635; --amber:#f5c451; --red:#ff6b6b; --cyan:#5ad6c0;
+    --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"]{
+    --bg:#faf9f6; --panel:#ffffff; --panel2:#f2f4f0; --ink:#1a1c1a; --dim:#5c655c;
+    --line:#e2e6df; --accent:#4d7c0f; --amber:#b45309; --red:#dc2626; --cyan:#0e7490;
+  }
+  :root[data-theme="light"] .fig{background:#0e120f;border-color:#26302a}
+  :root[data-theme="light"] .fig figcaption{color:#8b938c}
+  :root[data-theme="light"] .fig figcaption b{color:#e7ece8}
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
+    font-size:16px;line-height:1.6;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1000px;margin:0 auto;padding:56px 28px 120px}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:28px;margin-bottom:40px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--accent);margin:0 0 14px}
+  h1{font-size:34px;line-height:1.15;margin:0 0 12px;font-weight:700;letter-spacing:-.01em}
+  h1 .accent{color:var(--accent)}
+  .sub{color:var(--dim);font-size:17px;max-width:70ch;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}
+  .chip{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);
+    border-radius:999px;padding:4px 11px;background:var(--panel)}
+  .chip b{color:var(--ink);font-weight:500}
+  h2{font-size:23px;margin:52px 0 8px;letter-spacing:-.01em;scroll-margin-top:20px}
+  h2 .n{font-family:var(--mono);color:var(--accent);font-size:15px;margin-right:10px;opacity:.85}
+  p{margin:10px 0}
+  .lead{color:var(--dim)}
+  code{font-family:var(--mono);font-size:.88em;background:var(--panel2);border:1px solid var(--line);
+    border-radius:5px;padding:1.5px 6px;color:var(--cyan)}
+  a{color:var(--accent);text-decoration:none}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:22px 24px;margin:18px 0}
+  .fig{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:26px 22px 18px;margin:22px 0;overflow-x:auto}
+  .fig figcaption{font-family:var(--mono);font-size:12px;color:var(--dim);margin-top:14px;text-align:center}
+  .fig figcaption b{color:var(--ink)}
+  svg{display:block;margin:0 auto;max-width:100%;height:auto}
+  table{width:100%;border-collapse:collapse;margin:16px 0;font-size:14.5px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--dim);font-weight:500}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:6px;font-weight:600}
+  .tag.a{background:rgba(163,230,53,.12);color:var(--accent);border:1px solid rgba(163,230,53,.3)}
+  .tag.b{background:rgba(90,214,192,.1);color:var(--cyan);border:1px solid rgba(90,214,192,.28)}
+  ul{margin:10px 0;padding-left:22px}li{margin:6px 0}
+  .callout{border-left:3px solid var(--accent);background:var(--panel2);border-radius:0 10px 10px 0;
+    padding:14px 18px;margin:18px 0}
+  .callout.warn{border-left-color:var(--amber)}
+  .callout .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;
+    color:var(--accent);display:block;margin-bottom:5px}
+  .callout.warn .lbl{color:var(--amber)}
+  .toc{font-family:var(--mono);font-size:13px;display:flex;flex-wrap:wrap;gap:6px 18px;margin-top:18px}
+  .toc a{color:var(--dim);border:0}
+  pre{font-family:var(--mono);font-size:13px;background:#0c0f0d;border:1px solid var(--line);
+    border-radius:12px;padding:16px 18px;overflow-x:auto;line-height:1.55;color:#e7ece8}
+  pre .c{color:#8b938c}pre .k{color:#a3e635}pre .s{color:#5ad6c0}
+  .foot{margin-top:60px;padding-top:22px;border-top:1px solid var(--line);color:var(--dim);
+    font-family:var(--mono);font-size:12px}
+  .themebtn{position:fixed;top:16px;right:16px;z-index:9;font-family:var(--mono);font-size:12px;
+    color:var(--dim);background:var(--panel);border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;cursor:pointer}
+</style>
+</head>
+<body>
+<button class="themebtn" onclick="tt()" id="tb">◐ light</button>
+<script>
+  var r=document.documentElement;
+  function set(t){r.setAttribute('data-theme',t);document.getElementById('tb').textContent=(t==='light'?'◑ dark':'◐ light')}
+  set(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');
+  function tt(){set(r.getAttribute('data-theme')==='light'?'dark':'light')}
+</script>
+<div class="wrap">
+<header class="hero">
+  <p class="kicker">agents-cli · plan mode · inspect UX</p>
+  <h1>Ask which version to<br><span class="accent">inspect</span> when many are installed</h1>
+  <p class="sub">Bare <code>agents inspect kimi</code> silently opens the configured default. On a TTY with multiple installs, show an interactive menu of version + account context.</p>
+  <div class="meta">
+    <span class="chip"><b>7</b>&nbsp;files touched</span>
+    <span class="chip"><b>1</b>&nbsp;new helper</span>
+    <span class="chip">status: <b>awaiting go</b></span>
+  </div>
+  <nav class="toc">
+    <a href="#s1">01 · problem</a>
+    <a href="#s2">02 · behavior</a>
+    <a href="#s3">03 · design</a>
+    <a href="#s4">04 · files</a>
+    <a href="#s5">05 · verify</a>
+  </nav>
+</header>
+<h2 id="s1"><span class="n">01</span>Problem</h2>
+<p class="lead">Screenshot: <code>agents inspect kimi</code> lands on <code>kimi 0.19.2 [default]</code> with no choice.</p>
+<div class="callout"><span class="lbl">Root cause</span>
+<code>resolveSingleAgentTarget</code> bare path is project pin → global default → sole. Correct for run/sync; wrong for exploratory detail.
+</div>
+<figure class="fig">
+  <svg viewBox="0 0 920 280" xmlns="http://www.w3.org/2000/svg" role="img">
+    <defs><marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#8b938c"/></marker></defs>
+    <text x="20" y="28" fill="#f5c451" font-family="monospace" font-size="13">BEFORE</text>
+    <rect x="20" y="44" width="160" height="44" rx="8" fill="#161a18" stroke="#26302a"/>
+    <text x="100" y="71" text-anchor="middle" fill="#e7ece8" font-family="monospace" font-size="12">inspect kimi</text>
+    <line x1="180" y1="66" x2="220" y2="66" stroke="#8b938c" stroke-width="1.5" marker-end="url(#arr)"/>
+    <rect x="224" y="44" width="200" height="44" rx="8" fill="#161a18" stroke="#26302a"/>
+    <text x="324" y="71" text-anchor="middle" fill="#5ad6c0" font-family="monospace" font-size="11">resolve → default</text>
+    <line x1="424" y1="66" x2="464" y2="66" stroke="#8b938c" stroke-width="1.5" marker-end="url(#arr)"/>
+    <rect x="468" y="44" width="220" height="44" rx="8" fill="#1a1210" stroke="#ff6b6b"/>
+    <text x="578" y="71" text-anchor="middle" fill="#ff6b6b" font-family="monospace" font-size="11">0.19.2 [default] only</text>
+    <text x="20" y="148" fill="#a3e635" font-family="monospace" font-size="13">AFTER</text>
+    <rect x="20" y="164" width="160" height="44" rx="8" fill="#161a18" stroke="#26302a"/>
+    <text x="100" y="191" text-anchor="middle" fill="#e7ece8" font-family="monospace" font-size="12">inspect kimi</text>
+    <line x1="180" y1="186" x2="220" y2="186" stroke="#8b938c" stroke-width="1.5" marker-end="url(#arr)"/>
+    <rect x="224" y="150" width="240" height="72" rx="8" fill="#121a12" stroke="#a3e635"/>
+    <text x="344" y="178" text-anchor="middle" fill="#a3e635" font-family="monospace" font-size="12">pickInstalledVersion</text>
+    <text x="344" y="198" text-anchor="middle" fill="#8b938c" font-family="monospace" font-size="11">TTY · multi · account rows</text>
+    <line x1="464" y1="186" x2="504" y2="186" stroke="#8b938c" stroke-width="1.5" marker-end="url(#arr)"/>
+    <rect x="508" y="164" width="220" height="44" rx="8" fill="#121a12" stroke="#a3e635"/>
+    <text x="618" y="191" text-anchor="middle" fill="#a3e635" font-family="monospace" font-size="11">chosen version summary</text>
+  </svg>
+  <figcaption><b>Decision gate</b> — only bare multi-version TTY detail commands open the picker</figcaption>
+</figure>
+<h2 id="s2"><span class="n">02</span>Desired behavior</h2>
+<table>
+  <thead><tr><th>Input</th><th>TTY + multi</th><th>Otherwise</th></tr></thead>
+  <tbody>
+    <tr><td><code>agents inspect kimi</code></td><td>Picker</td><td>Default / sole</td></tr>
+    <tr><td><code>agents inspect kimi@x.y.z</code></td><td>No picker</td><td>Explicit</td></tr>
+    <tr><td><code>agents view kimi</code></td><td>Unchanged list-all</td><td>Unchanged</td></tr>
+    <tr><td><code>agents view kimi --skills</code></td><td>Picker</td><td>Default</td></tr>
+  </tbody>
+</table>
+<div class="panel">
+  <strong>Row shape:</strong> version <code>(default)</code> · account · logged in/out · plan.
+  Default sorted first, labeled, not auto-selected. Logged-out rows stay selectable.
+</div>
+<h2 id="s3"><span class="n">03</span>Design</h2>
+<p>New <code>commands/version-picker.ts</code> — do not change agent-spec bare resolution for run/sync.</p>
+<pre><span class="k">export async function</span> pickInstalledVersion(agent): Promise&lt;string | null&gt;
+<span class="c">// inspect: bare + TTY + multi → pick; else resolveSingleAgentTarget</span>
+</pre>
+<div class="callout warn"><span class="lbl">Non-TTY</span>Keep default resolution so scripts never hang.</div>
+<h2 id="s4"><span class="n">04</span>Files</h2>
+<table>
+  <thead><tr><th>Tag</th><th>Path</th><th>Change</th></tr></thead>
+  <tbody>
+    <tr><td><span class="tag a">new</span></td><td><code>version-picker.ts</code></td><td>Shared picker</td></tr>
+    <tr><td><span class="tag b">edit</span></td><td><code>inspect.ts</code></td><td>Bare multi TTY → picker</td></tr>
+    <tr><td><span class="tag b">edit</span></td><td><code>view.ts</code></td><td>Section-filter bare multi</td></tr>
+    <tr><td><span class="tag b">edit</span></td><td>tests, docs, CHANGELOG</td><td>Coverage + ship notes</td></tr>
+  </tbody>
+</table>
+<h2 id="s5"><span class="n">05</span>Verify</h2>
+<pre>agents inspect kimi            <span class="c"># menu on TTY multi</span>
+agents inspect kimi@0.19.2     <span class="c"># no menu</span>
+agents view kimi               <span class="c"># list-all</span>
+agents inspect kimi &lt;/dev/null <span class="c"># default, no hang</span>
+</pre>
+<div class="foot">agents-cli · inspect version picker · next: go / reshape</div>
+</div>
+</body>
+</html>

--- a/docs/plans/2026-07-30/plan-menubar-prune.html
+++ b/docs/plans/2026-07-30/plan-menubar-prune.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Plan · Menu-bar: prune ghost sentinels + collapse the "other" bucket</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#111312; --panel2:#161a18; --ink:#e7ece8; --dim:#8b938c;
+    --line:#26302a; --accent:#a3e635; --amber:#f5c451; --red:#ff6b6b; --cyan:#5ad6c0;
+    --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"]{
+    --bg:#faf9f6; --panel:#ffffff; --panel2:#f2f4f0; --ink:#1a1c1a; --dim:#5c655c;
+    --line:#e2e6df; --accent:#4d7c0f; --amber:#b45309; --red:#dc2626; --cyan:#0e7490;
+  }
+  :root[data-theme="light"] .fig{background:#0e120f;border-color:#26302a}
+  :root[data-theme="light"] .fig figcaption{color:#8b938c}
+  :root[data-theme="light"] .fig figcaption b{color:#e7ece8}
+
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
+    font-size:16px;line-height:1.6;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1000px;margin:0 auto;padding:56px 28px 120px}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:28px;margin-bottom:40px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--accent);margin:0 0 14px}
+  h1{font-size:34px;line-height:1.15;margin:0 0 12px;font-weight:700;letter-spacing:-.01em}
+  h1 .accent{color:var(--accent)}
+  .sub{color:var(--dim);font-size:17px;max-width:70ch;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}
+  .chip{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);
+    border-radius:999px;padding:4px 11px;background:var(--panel)}
+  .chip b{color:var(--ink);font-weight:500}
+  h2{font-size:23px;margin:52px 0 8px;letter-spacing:-.01em;scroll-margin-top:20px}
+  h2 .n{font-family:var(--mono);color:var(--accent);font-size:15px;margin-right:10px;opacity:.85}
+  h3{font-size:16.5px;margin:26px 0 8px;color:var(--ink)}
+  p{margin:10px 0}
+  .lead{color:var(--dim)}
+  code{font-family:var(--mono);font-size:.88em;background:var(--panel2);border:1px solid var(--line);
+    border-radius:5px;padding:1.5px 6px;color:var(--cyan)}
+  a{color:var(--accent);text-decoration:none;border-bottom:1px solid transparent}
+  a:hover{border-bottom-color:var(--accent)}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:22px 24px;margin:18px 0}
+  .fig{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:26px 22px 18px;margin:22px 0;overflow-x:auto}
+  .fig figcaption{font-family:var(--mono);font-size:12px;color:var(--dim);margin-top:14px;text-align:center}
+  .fig figcaption b{color:var(--ink)}
+  svg{display:block;margin:0 auto;max-width:100%;height:auto}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:760px){.grid2{grid-template-columns:1fr}}
+  table{width:100%;border-collapse:collapse;margin:16px 0;font-size:14.5px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--dim);font-weight:500}
+  td code{font-size:.85em}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:6px;font-weight:600}
+  .tag.a{background:rgba(163,230,53,.12);color:var(--accent);border:1px solid rgba(163,230,53,.3)}
+  .tag.b{background:rgba(90,214,192,.1);color:var(--cyan);border:1px solid rgba(90,214,192,.28)}
+  .tag.c{background:rgba(245,196,81,.1);color:var(--amber);border:1px solid rgba(245,196,81,.28)}
+  ul{margin:10px 0;padding-left:22px}li{margin:6px 0}
+  .callout{border-left:3px solid var(--accent);background:var(--panel2);border-radius:0 10px 10px 0;
+    padding:14px 18px;margin:18px 0}
+  .callout.warn{border-left-color:var(--amber)}
+  .callout .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;
+    color:var(--accent);display:block;margin-bottom:5px}
+  .callout.warn .lbl{color:var(--amber)}
+  .toc{font-family:var(--mono);font-size:13px;display:flex;flex-wrap:wrap;gap:6px 18px;margin-top:18px}
+  .toc a{color:var(--dim);border:0}.toc a:hover{color:var(--accent)}
+  pre{font-family:var(--mono);font-size:13px;background:#0c0f0d;border:1px solid var(--line);
+    border-radius:12px;padding:16px 18px;overflow-x:auto;line-height:1.55;color:#e7ece8}
+  pre .c{color:#8b938c}pre .k{color:#a3e635}pre .s{color:#5ad6c0}pre .r{color:#ff6b6b}
+  .foot{margin-top:60px;padding-top:22px;border-top:1px solid var(--line);color:var(--dim);
+    font-family:var(--mono);font-size:12px}
+  .themebtn{position:fixed;top:16px;right:16px;z-index:9;font-family:var(--mono);font-size:12px;
+    color:var(--dim);background:var(--panel);border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;cursor:pointer}
+  .themebtn:hover{color:var(--accent);border-color:var(--accent)}
+  .state-row{display:flex;align-items:center;gap:14px;padding:12px 14px;border:1px solid var(--line);
+    border-radius:10px;background:var(--panel2);margin:8px 0}
+  .state-row .glyph{font-family:var(--mono);font-size:18px;width:22px;text-align:center}
+  .state-row .name{font-family:var(--mono);font-size:13px;color:var(--ink);width:130px}
+  .state-row .def{color:var(--dim);font-size:14px;flex:1}
+  .glyph.run{color:var(--accent)}
+  .glyph.idle{color:var(--dim)}
+  .glyph.attn{color:var(--amber)}
+  .glyph.closed{color:var(--red);opacity:.55}
+</style>
+</head>
+<body>
+<button class="themebtn" onclick="tt()" id="tb">◐ light</button>
+<script>
+  var r=document.documentElement;
+  function set(t){r.setAttribute('data-theme',t);document.getElementById('tb').textContent=(t==='light'?'◑ dark':'◐ light')}
+  set(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');
+  function tt(){set(r.getAttribute('data-theme')==='light'?'dark':'light')}
+</script>
+<div class="wrap">
+
+<header class="hero">
+  <p class="kicker">AGENTS-CLI · plan mode · MENUBAR HELPER</p>
+  <h1>Prune ghost sentinels,<br><span class="accent">collapse the "other" bucket</span></h1>
+  <p class="sub">The menu-bar dropdown shows "NEEDS YOU (11)" with entries aged 1d / 2h25m / 1h51m — ghosts from
+    sessions closed days ago whose attention sentinels never got cleaned up. Add reader-side liveness pruning,
+    collapse the noisy "ACTIVE · other" bucket, and clarify the state model at 3 states (not 4).</p>
+  <div class="meta">
+    <span class="chip"><b>2</b>&nbsp;Swift files touched</span>
+    <span class="chip"><b>1</b>&nbsp;doc + changelog</span>
+    <span class="chip"><b>0</b>&nbsp;new states</span>
+    <span class="chip">status: <b>awaiting go</b></span>
+  </div>
+  <nav class="toc">
+    <a href="#s1">01 · why the menu is unusable</a>
+    <a href="#s2">02 · state model (3, not 4)</a>
+    <a href="#s3">03 · what to change</a>
+    <a href="#s4">04 · files</a>
+    <a href="#s5">05 · verification</a>
+    <a href="#s6">06 · non-goals</a>
+  </nav>
+</header>
+
+<!-- ============ 01 ============ -->
+<h2 id="s1"><span class="n">01</span>Why the menu is unusable</h2>
+<p class="lead">Two root causes, both grounded in the code and the running filesystem on this machine.</p>
+
+<figure class="fig">
+<svg viewBox="0 0 900 260" role="img" aria-label="Sentinel write path with leak points">
+  <defs>
+    <marker id="ar" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0 L9 5 L0 10 z" fill="#a3e635"/></marker>
+    <marker id="rr" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0 L9 5 L0 10 z" fill="#ff6b6b"/></marker>
+  </defs>
+
+  <text x="450" y="24" fill="#8b938c" font-size="12" text-anchor="middle" font-family="var(--mono)">write path (works)                                                    clear paths (fragile)</text>
+
+  <rect x="30" y="60" width="180" height="52" rx="8" fill="#12160f" stroke="#a3e635"/>
+  <text x="120" y="82" fill="#a3e635" font-size="12.5" text-anchor="middle" font-family="var(--mono)">Notification hook</text>
+  <text x="120" y="100" fill="#8b938c" font-size="11" text-anchor="middle" font-family="var(--mono)">06-attention-sentinel.sh</text>
+
+  <path d="M210 86 L320 86" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="320" y="60" width="230" height="52" rx="8" fill="#161a18" stroke="#26302a"/>
+  <text x="435" y="80" fill="#e7ece8" font-size="12.5" text-anchor="middle" font-family="var(--mono)">state/attention/&lt;sid&gt;</text>
+  <text x="435" y="100" fill="#8b938c" font-size="11" text-anchor="middle" font-family="var(--mono)">mtime = flagged at · body = question</text>
+
+  <path d="M550 86 L680 86" stroke="#a3e635" fill="none" marker-end="url(#ar)"/>
+
+  <rect x="680" y="60" width="200" height="52" rx="8" fill="#12160f" stroke="#a3e635"/>
+  <text x="780" y="82" fill="#a3e635" font-size="12.5" text-anchor="middle" font-family="var(--mono)">menu bar reads</text>
+  <text x="780" y="100" fill="#8b938c" font-size="11" text-anchor="middle" font-family="var(--mono)">LocalState.attentionMarks</text>
+
+  <path d="M435 112 L435 170" stroke="#ff6b6b" fill="none" stroke-dasharray="4 3" marker-end="url(#rr)"/>
+  <text x="450" y="140" fill="#ff6b6b" font-size="11" font-family="var(--mono)">Stop / UserPromptSubmit → rm</text>
+  <text x="450" y="156" fill="#ff6b6b" font-size="11" font-family="var(--mono)">but fires only if...</text>
+
+  <rect x="60" y="180" width="230" height="60" rx="8" fill="#1a1010" stroke="#ff6b6b"/>
+  <text x="175" y="202" fill="#ff6b6b" font-size="12" text-anchor="middle" font-family="var(--mono)">terminal killed hard</text>
+  <text x="175" y="220" fill="#8b938c" font-size="11" text-anchor="middle" font-family="var(--mono)">Stop never runs → leak</text>
+
+  <rect x="335" y="180" width="230" height="60" rx="8" fill="#1a1010" stroke="#ff6b6b"/>
+  <text x="450" y="202" fill="#ff6b6b" font-size="12" text-anchor="middle" font-family="var(--mono)">version has no hook</text>
+  <text x="450" y="220" fill="#8b938c" font-size="11" text-anchor="middle" font-family="var(--mono)">Claude versions differ → leak</text>
+
+  <rect x="610" y="180" width="230" height="60" rx="8" fill="#1a1010" stroke="#ff6b6b"/>
+  <text x="725" y="202" fill="#ff6b6b" font-size="12" text-anchor="middle" font-family="var(--mono)">sessionId mismatch</text>
+  <text x="725" y="220" fill="#8b938c" font-size="11" text-anchor="middle" font-family="var(--mono)">write-id ≠ clear-id → leak</text>
+</svg>
+<figcaption><b>The write path works; three failure modes leak sentinels the reader trusts blindly.</b></figcaption>
+</figure>
+
+<div class="callout warn">
+  <span class="lbl">live evidence · mac-mini today</span>
+  <code>ls -la ~/.agents/.cache/state/attention/</code> returns <b>6 files</b> dated Jul 8, Jul 9, Jul 15, Jul 24,
+  Jul 27, Jul 29 — today is Jul 30. Those are the "1d / 2h / 1h51m" rows in the screenshot.
+</div>
+
+<p>Plus a third pain point in rendering: <code>addActive</code> in <code>StatusItemController.swift:488-490</code>
+buckets any session with an empty <code>repo</code> under <code>"other"</code>, advertises the full "21 idle" count in the
+header, then still renders up to 3 rows inline — big, misleading, and drowning the useful sections below.</p>
+
+<!-- ============ 02 ============ -->
+<h2 id="s2"><span class="n">02</span>State model — keep 3, don't add a 4th</h2>
+<p class="lead">The current enum (<code>running / idle / attention / queued</code>) is fine.
+  What was fuzzy is <em>what each means</em>. Documenting the exact semantics; no new cases.</p>
+
+<div class="state-row"><span class="glyph run">●</span><span class="name">running</span>
+  <span class="def">pid alive AND transcript mtime &lt; 2 min. Agent is actively producing output.</span></div>
+<div class="state-row"><span class="glyph idle">◐</span><span class="name">idle</span>
+  <span class="def">pid alive AND transcript mtime ≥ 2 min AND no attention sentinel. Turn is complete — terminal sitting at the prompt with nothing blocking. Non-urgent; you can send another message anytime.</span></div>
+<div class="state-row"><span class="glyph attn">⚠</span><span class="name">awaiting input</span>
+  <span class="def">pid alive AND attention sentinel present. Notification hook fired — permission / plan / tool-block halting progress until you answer.</span></div>
+<div class="state-row"><span class="glyph closed">✕</span><span class="name">closed</span>
+  <span class="def"><em>Not a visible state.</em> pid dead = hidden from the menu. That's how it works today for terminals (<code>LocalState.swift:245</code>); we extend the same guard to the attention path.</span></div>
+
+<div class="callout">
+  <span class="lbl">the takeaway</span>
+  <b>Idle ≠ awaiting input.</b> Idle = agent finished its turn, no blocker. Awaiting-input = the harness explicitly said
+  "I'm stuck, answer me." If that distinction doesn't hold in practice, the menu bar's <code>⚠ NEEDS YOU</code> badge is meaningless.
+</div>
+
+<!-- ============ 03 ============ -->
+<h2 id="s3"><span class="n">03</span>What to change</h2>
+
+<h3>3.1 &nbsp;Cross-check sentinels against live sessions in the reader</h3>
+<p><code>LocalState.attentionMarks()</code> (<code>LocalState.swift:126-139</code>) returns every sentinel on disk regardless of
+  whether its sessionId maps to a live process. Change it to accept an optional live-id set and drop marks whose id
+  isn't in it. Both call sites already know the live set:</p>
+<ul>
+  <li><code>terminals(attention:)</code> (<code>:234-263</code>) iterates <code>live-terminals.json</code> and already filters by
+    <code>pidAlive(pid)</code> — collect sessionIds while iterating, pass them in.</li>
+  <li><code>sessions(fromActive:)</code> (<code>:160-179</code>) iterates <code>[ActiveSession]</code> from
+    <code>agents sessions --active --local --json</code> — that IS the live set.</li>
+</ul>
+<p>Side effect: <code>unlink</code> orphan sentinels found during the read (wrap in <code>try?</code>). Called every 10s (badge)
+  and on every menu open — orphan cleanup happens without a separate cron.</p>
+
+<pre><span class="c">// LocalState.swift — attentionMarks with liveness cross-check</span>
+<span class="k">static func</span> attentionMarks(liveSessionIds: <span class="s">Set&lt;String&gt;?</span> = nil) -&gt; [String: AttentionMark] {
+  <span class="k">let</span> dir = <span class="s">"\(home)/.agents/.cache/state/attention"</span>
+  <span class="k">let</span> names = (<span class="k">try?</span> fm.contentsOfDirectory(atPath: dir)) ?? []
+  <span class="k">var</span> out: [String: AttentionMark] = [:]
+  <span class="k">for</span> name <span class="k">in</span> names <span class="k">where</span> !name.hasPrefix(<span class="s">"."</span>) {
+    <span class="k">let</span> path = <span class="s">"\(dir)/\(name)"</span>
+    <span class="c">// prune orphan: sentinel exists but sessionId isn't in the live set</span>
+    <span class="k">if let</span> live = liveSessionIds, !live.contains(name) {
+      <span class="k">try?</span> fm.removeItem(atPath: path); <span class="k">continue</span>
+    }
+    <span class="k">let</span> attrs = <span class="k">try?</span> fm.attributesOfItem(atPath: path)
+    <span class="k">let</span> since = (attrs?[.modificationDate] <span class="k">as?</span> Date).map { $0.timeIntervalSince1970 * 1000 }
+    <span class="k">let</span> raw = (<span class="k">try?</span> String(contentsOfFile: path, encoding: .utf8)) ?? <span class="s">""</span>
+    out[name] = AttentionMark(sinceMs: since, text: raw.trimmingCharacters(in: .whitespacesAndNewlines))
+  }
+  <span class="k">return</span> out
+}</pre>
+
+<h3>3.2 &nbsp;Collapse <code>ACTIVE · other</code> when idle-only</h3>
+<p><code>addActive</code> (<code>StatusItemController.swift:488-519</code>) groups by <code>repo</code>. If the
+  <code>"other"</code> group has <code>running == 0</code> and no attention rows, render a single collapsed line —
+  <code>ACTIVE · other · N idle ▸</code> with a submenu carrying the inline rows. Real repos keep today's rendering
+  (their idle sessions are load-bearing signal).</p>
+
+<figure class="fig">
+<svg viewBox="0 0 900 220" role="img" aria-label="Before and after menu layout for the other bucket">
+  <rect x="30" y="20" width="380" height="180" rx="10" fill="#161a18" stroke="#26302a"/>
+  <text x="220" y="42" fill="#8b938c" font-size="11" text-anchor="middle" font-family="var(--mono)">BEFORE — walls the menu</text>
+  <text x="46" y="70" fill="#e7ece8" font-size="12" font-family="var(--mono)">ACTIVE · other · 21 idle</text>
+  <text x="46" y="90" fill="#8b938c" font-size="12" font-family="var(--mono)">◐ Claude</text>
+  <text x="46" y="106" fill="#8b938c" font-size="12" font-family="var(--mono)">◐ Claude</text>
+  <text x="46" y="122" fill="#8b938c" font-size="12" font-family="var(--mono)">◐ Claude</text>
+  <text x="46" y="140" fill="#ff6b6b" font-size="11" font-family="var(--mono)">✕ Claude (dead pid, shows anyway)</text>
+  <text x="46" y="156" fill="#ff6b6b" font-size="11" font-family="var(--mono)">✕ Claude (dead pid, shows anyway)</text>
+  <text x="46" y="180" fill="#8b938c" font-size="11" font-family="var(--mono)">... 16 more truncated silently</text>
+
+  <rect x="490" y="20" width="380" height="180" rx="10" fill="#12160f" stroke="#a3e635"/>
+  <text x="680" y="42" fill="#a3e635" font-size="11" text-anchor="middle" font-family="var(--mono)">AFTER — one line, on-demand drill</text>
+  <text x="506" y="70" fill="#e7ece8" font-size="12" font-family="var(--mono)">ACTIVE · other · 3 idle ▸</text>
+  <text x="506" y="100" fill="#8b938c" font-size="11" font-family="var(--mono)">(count reflects live sessions only —</text>
+  <text x="506" y="116" fill="#8b938c" font-size="11" font-family="var(--mono)">orphan sentinels pruned by 3.1)</text>
+  <text x="506" y="150" fill="#a3e635" font-size="12" font-family="var(--mono)">→ real repos still render inline</text>
+  <text x="506" y="166" fill="#8b938c" font-size="11" font-family="var(--mono)">ACTIVE · agents-cli · 2 running</text>
+  <text x="506" y="182" fill="#8b938c" font-size="11" font-family="var(--mono)">ACTIVE · rush · 1 running · 1 idle</text>
+</svg>
+<figcaption><b>Before / after.</b> The "other" bucket collapses to a submenu when idle-only; real repos are untouched.</figcaption>
+</figure>
+
+<h3>3.3 &nbsp;Nothing on the state model</h3>
+<ul>
+  <li>Do <b>not</b> introduce a <code>.closed</code> case.</li>
+  <li>Do <b>not</b> add a "Recently closed" section.</li>
+  <li>Do document the three states in <code>apps/cli/docs/menubar.md</code>.</li>
+</ul>
+
+<!-- ============ 04 ============ -->
+<h2 id="s4"><span class="n">04</span>Files</h2>
+<table>
+  <thead><tr><th>Change</th><th>Path</th><th>What</th></tr></thead>
+  <tbody>
+    <tr><td><span class="tag b">edit</span></td>
+      <td><code>apps/cli/menubar/Sources/MenubarHelper/LocalState.swift</code></td>
+      <td><code>attentionMarks(liveSessionIds:)</code> optional set; prune orphans on read. Both callers pass their live set.</td></tr>
+    <tr><td><span class="tag b">edit</span></td>
+      <td><code>apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift</code></td>
+      <td><code>addActive</code> collapses <code>"other"</code> when idle-only into a one-line row with a submenu.</td></tr>
+    <tr><td><span class="tag c">docs</span></td>
+      <td><code>apps/cli/docs/menubar.md</code></td>
+      <td>3-state semantics table (running / idle / awaiting-input); note orphan-sentinel pruning.</td></tr>
+    <tr><td><span class="tag c">docs</span></td>
+      <td><code>apps/cli/.changelog/&lt;next&gt;.md</code></td>
+      <td>One line: "menu-bar: prune orphan attention sentinels; collapse ACTIVE · other."</td></tr>
+    <tr><td><span class="tag a">keep</span></td>
+      <td><code>~/.claude/hooks/06-attention-sentinel.sh</code></td>
+      <td><b>Unchanged.</b> Writer handles the happy path; failure modes are outside its control.</td></tr>
+    <tr><td><span class="tag a">keep</span></td>
+      <td><code>packages/session-tracker/</code></td>
+      <td><b>Unchanged.</b> Sentinel writing isn't its job.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ 05 ============ -->
+<h2 id="s5"><span class="n">05</span>Verification</h2>
+<ol>
+  <li><b>Baseline.</b> Photograph "NEEDS YOU" count; snapshot <code>ls -la ~/.agents/.cache/state/attention/</code>
+    — record today's 6 known ghosts (<code>05b17677…</code>, <code>0de88f4e…</code>, <code>2103d37c…</code>,
+    <code>61cf3f89…</code>, <code>7731a825…</code>, <code>f411d7e8…</code>).</li>
+  <li><b>Build in a worktree.</b> <code>agents-cli/.agents/worktrees/&lt;slug&gt;</code>, off <code>origin/main</code>.
+    <code>cd apps/cli/menubar && swift build</code>. Install the new MenubarHelper via the app's install script —
+    verify the <em>installed</em> binary carries the change (core-hard-lines #1), not the build dir.</li>
+  <li><b>Prune verification.</b> Restart the helper. Within one 10s badge tick,
+    <code>ls ~/.agents/.cache/state/attention/</code> should drop to only sentinels whose sessionId appears in
+    <code>agents sessions --active --local --json</code>.</li>
+  <li><b>UI verification.</b> Reopen the menu. Trigger a real permission prompt in a live Claude session; confirm
+    it appears in <code>⚠ NEEDS YOU</code>. Answer it; confirm it disappears within the next poll cycle. Screenshot
+    before/after and attach to the PR.</li>
+  <li><b>Collapse check.</b> Confirm <code>ACTIVE · other</code> renders as a single line with a submenu when idle-only;
+    real repos (<code>ACTIVE · agents-cli</code>, <code>ACTIVE · rush</code>) still inline.</li>
+  <li><b>No regression.</b> Attention rows for genuinely-blocked live sessions still surface at the top; routines /
+    new-devices / browser sections unchanged.</li>
+</ol>
+<div class="callout">
+  <span class="lbl">success criteria</span>
+  "NEEDS YOU" count on mac-mini drops from <b>11 → 0–2</b> (whatever's genuinely blocked right now). Menu fits on-screen without a scroll indicator.
+</div>
+
+<!-- ============ 06 ============ -->
+<h2 id="s6"><span class="n">06</span>Non-goals</h2>
+<ul>
+  <li>Not rewriting the snapshot model into an event bus. The bug is orphan data, not the transport.</li>
+  <li>Not filtering by user or by agent-cli version. All Claude versions on the machine keep contributing.</li>
+  <li>Not touching routines / new-devices / browser sections.</li>
+  <li>Not introducing a <code>.closed</code> state. Closed = hidden.</li>
+</ul>
+
+<div class="foot">
+  agents-cli · plan mode · rendered by plan-render &nbsp;·&nbsp; next: <span style="color:var(--accent)">go / reshape</span>
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/plans/2026-07-30/plan-watchdog-daemon.html
+++ b/docs/plans/2026-07-30/plan-watchdog-daemon.html
@@ -1,0 +1,317 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Plan · The watchdog is glue</title>
+<style>
+  :root{
+    --bg:#0a0a0a; --panel:#121011; --panel2:#1a1616; --ink:#efe9e9; --dim:#9a8f8f;
+    --line:#332727; --accent:#e85d5d; --amber:#f5c451; --red:#ff6b6b; --cyan:#5ad6c0;
+    --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  :root[data-theme="light"]{
+    --bg:#faf8f7; --panel:#ffffff; --panel2:#f5f0ef; --ink:#1c1717; --dim:#665c5c;
+    --line:#e8dede; --accent:#c23b3b; --amber:#b45309; --red:#dc2626; --cyan:#0e7490;
+  }
+  :root[data-theme="light"] .fig{background:#120e0e;border-color:#332727}
+  :root[data-theme="light"] .fig figcaption{color:#9a8f8f}
+  :root[data-theme="light"] .fig figcaption b{color:#efe9e9}
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
+    font-size:16px;line-height:1.6;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1000px;margin:0 auto;padding:56px 28px 120px}
+  header.hero{border-bottom:1px solid var(--line);padding-bottom:28px;margin-bottom:40px}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--accent);margin:0 0 14px}
+  h1{font-size:34px;line-height:1.15;margin:0 0 12px;font-weight:700;letter-spacing:-.01em}
+  h1 .accent{color:var(--accent)}
+  .sub{color:var(--dim);font-size:17px;max-width:72ch;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}
+  .chip{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);
+    border-radius:999px;padding:4px 11px;background:var(--panel)}
+  .chip b{color:var(--ink);font-weight:500}
+  h2{font-size:23px;margin:52px 0 8px;letter-spacing:-.01em;scroll-margin-top:20px}
+  h2 .n{font-family:var(--mono);color:var(--accent);font-size:15px;margin-right:10px;opacity:.85}
+  h3{font-size:16.5px;margin:26px 0 8px;color:var(--ink)}
+  p{margin:10px 0}
+  .lead{color:var(--dim)}
+  code{font-family:var(--mono);font-size:.88em;background:var(--panel2);border:1px solid var(--line);
+    border-radius:5px;padding:1.5px 6px;color:var(--cyan)}
+  a{color:var(--accent);text-decoration:none;border-bottom:1px solid transparent}
+  a:hover{border-bottom-color:var(--accent)}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:22px 24px;margin:18px 0}
+  .fig{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:26px 22px 18px;margin:22px 0;overflow-x:auto}
+  .fig figcaption{font-family:var(--mono);font-size:12px;color:var(--dim);margin-top:14px;text-align:center}
+  .fig figcaption b{color:var(--ink)}
+  svg{display:block;margin:0 auto;max-width:100%;height:auto}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:760px){.grid2{grid-template-columns:1fr}}
+  table{width:100%;border-collapse:collapse;margin:16px 0;font-size:14.5px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--dim);font-weight:500}
+  td code{font-size:.85em}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:6px;font-weight:600;white-space:nowrap}
+  .tag.a{background:rgba(232,93,93,.13);color:var(--accent);border:1px solid rgba(232,93,93,.32)}
+  .tag.b{background:rgba(90,214,192,.1);color:var(--cyan);border:1px solid rgba(90,214,192,.28)}
+  .tag.c{background:rgba(245,196,81,.1);color:var(--amber);border:1px solid rgba(245,196,81,.28)}
+  ul{margin:10px 0;padding-left:22px}li{margin:6px 0}
+  .callout{border-left:3px solid var(--accent);background:var(--panel2);border-radius:0 10px 10px 0;
+    padding:14px 18px;margin:18px 0}
+  .callout.warn{border-left-color:var(--amber)}
+  .callout .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;
+    color:var(--accent);display:block;margin-bottom:5px}
+  .callout.warn .lbl{color:var(--amber)}
+  .toc{font-family:var(--mono);font-size:13px;display:flex;flex-wrap:wrap;gap:6px 18px;margin-top:18px}
+  .toc a{color:var(--dim);border:0}.toc a:hover{color:var(--accent)}
+  pre{font-family:var(--mono);font-size:13px;background:#0c0a0a;border:1px solid var(--line);
+    border-radius:12px;padding:16px 18px;overflow-x:auto;line-height:1.55;color:#efe9e9}
+  pre .c{color:#9a8f8f}pre .k{color:#e85d5d}pre .s{color:#5ad6c0}pre .r{color:#ff6b6b}
+  .foot{margin-top:60px;padding-top:22px;border-top:1px solid var(--line);color:var(--dim);
+    font-family:var(--mono);font-size:12px}
+  .themebtn{position:fixed;top:16px;right:16px;z-index:9;font-family:var(--mono);font-size:12px;
+    color:var(--dim);background:var(--panel);border:1px solid var(--line);border-radius:999px;
+    padding:6px 13px;cursor:pointer}
+  .themebtn:hover{color:var(--accent);border-color:var(--accent)}
+</style>
+</head>
+<body>
+<button class="themebtn" onclick="tt()" id="tb">◐ light</button>
+<script>
+  var r=document.documentElement;
+  function set(t){r.setAttribute('data-theme',t);document.getElementById('tb').textContent=(t==='light'?'◑ dark':'◐ light')}
+  set(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');
+  function tt(){set(r.getAttribute('data-theme')==='light'?'dark':'light')}
+</script>
+<div class="wrap">
+
+<header class="hero">
+  <p class="kicker">AGENTS-CLI · design · WATCHDOG = COMPOSITION</p>
+  <h1>The watchdog is glue —<br><span class="accent">not a subsystem</span></h1>
+  <p class="sub">Everything the watchdog does already exists as a built-in: <b>routines</b> are
+  the loop, <b>agents sessions</b> is the detector, <b>sessions inject / answer-router</b> is the
+  delivery, a <b>built-in workflow</b> is the brains. So we don't build a watchdog — we
+  compose one from primitives, delete the bespoke <code>--nudge</code> loop, sentinel, and
+  hardcoded prompt, and keep only the two pieces that have no built-in: the cooldown ledger
+  and the stuck-decision.</p>
+  <div class="meta">
+    <span class="chip">reuses: <b>4 primitives</b></span>
+    <span class="chip">genuinely bespoke: <b>2</b></span>
+    <span class="chip">new concepts: <b>0</b></span>
+    <span class="chip">new rail: <b>kitty</b></span>
+    <span class="chip">status: <b>awaiting go</b></span>
+  </div>
+  <nav class="toc">
+    <a href="#s1">01 · what it really is</a>
+    <a href="#s2">02 · the composition</a>
+    <a href="#s3">03 · delivery accuracy</a>
+    <a href="#s4">04 · the brains</a>
+    <a href="#s5">05 · the bespoke 2 + fixes</a>
+    <a href="#s6">06 · files</a>
+    <a href="#s7">07 · verification</a>
+  </nav>
+</header>
+
+<!-- ============ 01 ============ -->
+<h2 id="s1"><span class="n">01</span>What the watchdog really is</h2>
+<p class="lead">Six capabilities. Four are already built-ins the watchdog either reuses or
+should reuse; only two are genuinely its own. <code>--nudge</code> isn't a feature — it's
+just the dry-run-vs-inject toggle on top of the generic <code>injectIntoTerminal</code>.</p>
+<table>
+  <thead><tr><th>Capability</th><th>Verdict</th><th>Built-in</th></tr></thead>
+  <tbody>
+    <tr><td>Detect active sessions + state</td><td><span class="tag b">reuses</span></td><td><code>getActiveSessions()</code> — same call <code>agents sessions</code> uses; <code>activity: working/waiting_input/idle</code></td></tr>
+    <tr><td>Deliver a message</td><td><span class="tag b">reuses</span></td><td><code>agents sessions inject &lt;id&gt; &lt;text&gt;</code> → <code>injectIntoTerminal</code></td></tr>
+    <tr><td>The loop</td><td><span class="tag c">duplicates</span></td><td>→ a <b>routine</b> (cron on the daemon scheduler)</td></tr>
+    <tr><td>Enable / disable</td><td><span class="tag c">duplicates</span></td><td>→ routine <code>enabled</code> / <code>pause</code> / <code>resume</code></td></tr>
+    <tr><td>Decision instructions</td><td><span class="tag c">hardcoded</span></td><td>→ a <b>built-in workflow</b>'s prompt (customizable, pick harness)</td></tr>
+    <tr><td>Cooldown ledger</td><td><span class="tag a">bespoke</span></td><td>none — <code>nudges.json</code> (keep, fix the race)</td></tr>
+    <tr><td>"Is it stuck?" heuristic</td><td><span class="tag a">bespoke</span></td><td>none — <code>isLikelyTrulyBlocked</code> (keep as a cheap pre-filter)</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ 02 ============ -->
+<h2 id="s2"><span class="n">02</span>The composition</h2>
+<p class="lead">One system routine on a sub-minute cron drives the whole thing. Detection and
+delivery are the same primitives the rest of the CLI uses; the decision is a built-in
+workflow. The daemon hosts nothing bespoke — it just fires the routine.</p>
+
+<figure class="fig">
+<svg viewBox="0 0 900 340" role="img" aria-label="watchdog composed from built-in primitives">
+  <defs>
+    <marker id="ar" markerWidth="9" markerHeight="9" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 z" fill="#e85d5d"/></marker>
+    <marker id="arc" markerWidth="9" markerHeight="9" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 z" fill="#5ad6c0"/></marker>
+  </defs>
+
+  <!-- routine -->
+  <rect x="30" y="140" width="150" height="70" rx="10" fill="#1a1616" stroke="#e85d5d"/>
+  <text x="105" y="166" fill="#e85d5d" font-size="12.5" text-anchor="middle" font-family="monospace">ROUTINE</text>
+  <text x="105" y="186" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">*/30 * * * * *</text>
+  <text x="105" y="200" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">(the loop)</text>
+
+  <!-- detect -->
+  <rect x="220" y="140" width="160" height="70" rx="10" fill="#12160f" stroke="#5ad6c0"/>
+  <text x="300" y="163" fill="#5ad6c0" font-size="12" text-anchor="middle" font-family="monospace">DETECT</text>
+  <text x="300" y="182" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">agents sessions</text>
+  <text x="300" y="196" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">activity: working/waiting</text>
+
+  <!-- pre-filter -->
+  <rect x="420" y="20" width="160" height="70" rx="10" fill="#1a1616" stroke="#f5c451"/>
+  <text x="500" y="43" fill="#f5c451" font-size="12" text-anchor="middle" font-family="monospace">PRE-FILTER</text>
+  <text x="500" y="62" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">isLikelyTrulyBlocked</text>
+  <text x="500" y="76" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">(cheap gate · bespoke)</text>
+
+  <!-- decide workflow -->
+  <rect x="420" y="140" width="160" height="70" rx="10" fill="#12160f" stroke="#5ad6c0"/>
+  <text x="500" y="163" fill="#5ad6c0" font-size="12" text-anchor="middle" font-family="monospace">DECIDE</text>
+  <text x="500" y="182" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">watchdog WORKFLOW</text>
+  <text x="500" y="196" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">customizable · pick harness</text>
+
+  <!-- deliver -->
+  <rect x="620" y="140" width="170" height="70" rx="10" fill="#12160f" stroke="#5ad6c0"/>
+  <text x="705" y="163" fill="#5ad6c0" font-size="12" text-anchor="middle" font-family="monospace">DELIVER</text>
+  <text x="705" y="182" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">answer-router →</text>
+  <text x="705" y="196" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">sessions inject / resume</text>
+
+  <!-- ledger -->
+  <rect x="620" y="250" width="170" height="56" rx="10" fill="#1a1616" stroke="#f5c451"/>
+  <text x="705" y="273" fill="#f5c451" font-size="11.5" text-anchor="middle" font-family="monospace">COOLDOWN LEDGER</text>
+  <text x="705" y="291" fill="#9a8f8f" font-size="9.5" text-anchor="middle" font-family="monospace">locked · bespoke</text>
+
+  <path d="M180 175 L220 175" stroke="#e85d5d" fill="none" marker-end="url(#ar)"/>
+  <path d="M380 165 L420 90" stroke="#f5c451" fill="none" marker-end="url(#ar)"/>
+  <path d="M500 90 L500 140" stroke="#e85d5d" fill="none" marker-end="url(#ar)"/>
+  <path d="M580 175 L620 175" stroke="#e85d5d" fill="none" marker-end="url(#ar)"/>
+  <path d="M705 250 L705 210" stroke="#f5c451" fill="none" marker-end="url(#ar)"/>
+
+  <text x="450" y="325" fill="#9a8f8f" font-size="10.5" text-anchor="middle" font-family="monospace">green = existing built-in reused · amber = the only two bespoke pieces</text>
+</svg>
+<figcaption><b>Compose, don't build.</b> The routine fires; detection + delivery are shared primitives; the decision is a workflow. Only the amber boxes are watchdog-specific.</figcaption>
+</figure>
+
+<!-- ============ 03 ============ -->
+<h2 id="s3"><span class="n">03</span>Delivery accuracy — pick the right channel, add kitty</h2>
+<p class="lead">"Injection can happen in so many ways" — and there's already a built-in that picks
+the right one by session state: <code>answer-router.ts</code>. The watchdog should route
+through it instead of blind terminal injection. The mailbox is <b>not</b> universal
+(pull-based, Claude-only, needs a live tool-calling agent), so it's the fast path, not the
+fallback.</p>
+
+<table>
+  <thead><tr><th>Session state</th><th>Channel</th><th>Why</th></tr></thead>
+  <tbody>
+    <tr><td>Running, still tool-calling (Claude)</td><td><code>mailbox</code></td><td>drained at next tool call — fast, in-context</td></tr>
+    <tr><td>Parked on a question, has a rail</td><td><code>keystroke inject</code></td><td>needs keys, not context; any harness</td></tr>
+    <tr><td>Parked headless, no rail</td><td><code>run --resume</code></td><td>no next tool call; universal <code>/continue</code></td></tr>
+    <tr><td>Parked, no rail, interactive</td><td><code>refuse</code></td><td>don't let it rot in the spool</td></tr>
+  </tbody>
+</table>
+
+<h3>Injection backends — kitty is the gap</h3>
+<table>
+  <thead><tr><th>Rail</th><th>Mechanism</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td><code>tmux</code></td><td><code>tmux send-keys</code> (local or SSH)</td><td><span class="tag b">have</span></td></tr>
+    <tr><td><code>iterm</code></td><td>AppleScript <code>write text</code>, no focus steal</td><td><span class="tag b">have</span></td></tr>
+    <tr><td><code>vscodium</code></td><td>editor <code>--open-url</code> inject scheme</td><td><span class="tag b">have</span></td></tr>
+    <tr><td><code>pty</code></td><td><code>agents pty write</code> sidecar</td><td><span class="tag b">have</span></td></tr>
+    <tr><td><code>ghostty</code></td><td>coarse — raises window, focus-steal, not split-precise</td><td><span class="tag c">coarse</span></td></tr>
+    <tr><td><code>kitty</code></td><td><code>kitty @ send-text</code> over its remote-control socket — <b>split-precise</b></td><td><span class="tag a">add</span></td></tr>
+  </tbody>
+</table>
+<div class="callout">
+  <span class="lbl">kitty slots in cleanly</span>
+  kitty is already detected as a host (<code>active.ts:622</code>) but has no inject backend.
+  Adding one is an <code>InjectTarget</code> variant + a <code>resolve.ts</code> case (like
+  ghostty's, keyed on <code>session.host === 'kitty'</code>) + a branch in the
+  <code>injectIntoTerminal</code> switch. Unlike ghostty, kitty's RC socket makes it a
+  first-class, split-precise rail — not a focus-steal.
+</div>
+
+<!-- ============ 04 ============ -->
+<h2 id="s4"><span class="n">04</span>The brains — a built-in workflow, not a hardcoded prompt</h2>
+<p class="lead">The decision instructions must not be hardcoded strings, and they're not a
+"playbook" either. They're the prompt body of a <b>built-in <code>watchdog</code> workflow</b>
+that ships by default, is customizable through the existing workflow layering
+(<code>project&nbsp;&gt;&nbsp;user&nbsp;&gt;&nbsp;system</code>), and lets the user pick the
+harness/agent — because that's what routines and workflows already let you do.</p>
+<div class="grid2">
+  <div class="panel">
+    <h3 style="color:var(--red)">Not this</h3>
+    <ul>
+      <li>Prompt hardcoded in <code>watchdog.ts</code></li>
+      <li>Model pinned <code>'haiku'</code> in a constant</li>
+      <li>A bespoke <code>playbooks/watchdog.md</code> concept</li>
+      <li>No way to change instructions per repo</li>
+    </ul>
+  </div>
+  <div class="panel">
+    <h3 style="color:var(--accent)">This</h3>
+    <ul>
+      <li>Ships as <code>.system/workflows/watchdog/</code></li>
+      <li>Instructions = the <code>WORKFLOW.md</code> body</li>
+      <li>Harness/model = frontmatter + routine <code>agent</code></li>
+      <li>Customize by overriding the workflow (user/project)</li>
+    </ul>
+  </div>
+</div>
+<div class="callout warn">
+  <span class="lbl">the one open knob</span>
+  Cost vs accuracy of the default. The cheap deterministic <code>isLikelyTrulyBlocked</code>
+  runs as a <b>pre-filter gate</b> every tick (no LLM). When it flags a candidate, the
+  <code>watchdog</code> workflow makes the accurate call. Open question for you: is the
+  workflow the <b>default</b> decider (accurate, spends tokens on flagged candidates), or
+  <b>opt-in</b> (deterministic ships the nudge; workflow only when enabled)?
+</div>
+
+<!-- ============ 05 ============ -->
+<h2 id="s5"><span class="n">05</span>The bespoke two + the fixes that come free</h2>
+<p class="lead">Making the routine the single owner deletes whole classes of bug. The two
+genuinely-bespoke pieces stay, hardened.</p>
+<table>
+  <thead><tr><th>Item</th><th>Action</th></tr></thead>
+  <tbody>
+    <tr><td>Two drifted detector copies (CLI + extension)</td><td>collapse to one shared module; extension consumes it (status view only)</td></tr>
+    <tr><td>Cooldown ledger race (no lock, in-mem on ext)</td><td>one lock-guarded ledger all injectors respect</td></tr>
+    <tr><td>MCP <code>send_nudge</code> bypasses the safety gate + fuzzy match</td><td>route through the same resolve + gate; exact id match</td></tr>
+    <tr><td>15-min force-review overrides waiting/completion</td><td>reorder: waiting/done win over the timer (kills the worst false-positive)</td></tr>
+    <tr><td>Dormant &gt;1h = abandoned forever</td><td>surface long-dormant instead of silently dropping</td></tr>
+    <tr><td>Split log ownership, swallowed errors</td><td>one canonical <code>watchdog.log</code>; <code>agents watchdog log --tail</code></td></tr>
+  </tbody>
+</table>
+
+<!-- ============ 06 ============ -->
+<h2 id="s6"><span class="n">06</span>Files touched</h2>
+<table>
+  <thead><tr><th>Path</th><th>What</th><th>Kind</th></tr></thead>
+  <tbody>
+    <tr><td><code>.system/routines/watchdog.yml</code></td><td>System routine: <code>command: agents watchdog --nudge</code>, sub-minute cron</td><td><span class="tag a">new</span></td></tr>
+    <tr><td><code>.system/workflows/watchdog/WORKFLOW.md</code></td><td>Default decider brains (instructions + harness/model)</td><td><span class="tag a">new</span></td></tr>
+    <tr><td><code>lib/watchdog/runner.ts</code></td><td>Route delivery via answer-router; resolve the workflow; locked ledger; canonical log</td><td><span class="tag b">edit</span></td></tr>
+    <tr><td><code>commands/watchdog.ts</code></td><td>Drop the <code>--watch</code> loop + <code>enabled</code> sentinel; add <code>log --tail</code></td><td><span class="tag c">remove</span></td></tr>
+    <tr><td><code>lib/terminal/inject.ts</code> + <code>resolve.ts</code></td><td>Add the <code>kitty</code> rail (RC socket, split-precise)</td><td><span class="tag a">new</span></td></tr>
+    <tr><td><code>commands/sessions-inject.ts</code></td><td>Reuse <code>resolveInjectTargetForSession</code> so it gets all rails too</td><td><span class="tag b">edit</span></td></tr>
+    <tr><td><code>factory/**/watchdog*.ts</code></td><td>Retire the extension tick loop + playbook loader; status view only</td><td><span class="tag c">remove</span></td></tr>
+    <tr><td><code>*.test.ts</code> beside each</td><td>routine fires the tick; channel selection; kitty inject; ledger lock; workflow resolution</td><td><span class="tag a">new</span></td></tr>
+  </tbody>
+</table>
+
+<!-- ============ 07 ============ -->
+<h2 id="s7"><span class="n">07</span>Verification — real flow, not proxies</h2>
+<ul>
+  <li><b>Routine is the loop:</b> enable the routine, park a real agent mid-promise, confirm the daemon-fired routine injects <code>Continue.</code> into its tmux split — quote the <code>watchdog.log</code> event.</li>
+  <li><b>Channel accuracy:</b> a live Claude → mailbox; a parked TUI on a question → keystroke; a headless parked run → <code>run --resume</code>; a no-rail interactive → refused (not rotting).</li>
+  <li><b>kitty:</b> a stuck agent in a kitty window gets a split-precise <code>kitty @ send-text</code> into the right split — no focus steal, verified by looking at the window.</li>
+  <li><b>Customizable brains:</b> override the <code>watchdog</code> workflow (different model/instructions) for a repo/user; confirm the routine's decider uses it; the harness/agent is user-selected.</li>
+  <li><b>No double-nudge:</b> extension no longer injects; concurrent MCP-bridge nudge + routine tick serialize on the locked ledger — one nudge.</li>
+</ul>
+
+<div class="foot">
+  agents-cli · design · rendered by plan-render &nbsp;·&nbsp; watchdog = routine + sessions + workflow + inject &nbsp;·&nbsp; next: <span style="color:var(--accent)">go / reshape</span>
+</div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Archives the curated set of HTML plan/design docs the agent fleet produced against agents-cli on **2026-07-30**, so the good ones persist and are reviewable instead of living only in `/tmp`.

## What's here — `docs/plans/2026-07-30/`
13 HTML docs + `index.md` (classifies them into 5 groups with a one-line summary each). Each HTML is self-contained — open it directly in a browser to read.

- **Architecture** — `agents-cli-architecture-v1.html` (system design), `agents-cli-architecture.html` (the distributed core / onboarding)
- **Perf & reliability audit** (4 escalating passes) — `agents-cli-ideas.html`, `agents-cli-measured.html` (80 GB bloat), `agents-cli-timeline.html` (271/127 ms latency), `agents-cli-audit.html` (capstone: 44% of routine runs fail, 80% auth)
- **Auth** — `agents-cli-auth-plan.html` (credential remediation, 3 defects / 2 PRs)
- **Implementation plans** — `plan-configured-model-205039.html`, `plan-watchdog-daemon.html`, `plan-menubar-prune.html`, `plan-inspect-version-picker.html`
- **UI** — `fleet-status-redesign.html`, `menu-mockup.html`

## Curation
Duplicates and superseded intermediate cuts were dropped (e.g. the older `plan-configured-model` cut; ~1 KB `*.sh.html` stubs). `measured`/`timeline` are the 3rd/4th audit passes, kept because their profiling numbers aren't fully reproduced in the audit capstone.

Docs-only change — adds a new `docs/plans/` directory, touches no code.