### PR TITLE
feat(sessions): index Grok sessions (add scanGrokIncremental)

### DIFF
--- a/apps/cli/src/lib/session/__tests__/discover.test.ts
+++ b/apps/cli/src/lib/session/__tests__/discover.test.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import Database from '../../sqlite.js';
 import { buildFtsQuery, getDB } from '../db.js';
-import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile, discoverSessions, resolveSessionById } from '../discover.js';
+import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile, discoverSessions, resolveSessionById, readGrokMeta } from '../discover.js';
 import { machineId } from '../sync/config.js';
 import { getHistoryDir } from '../../state.js';
 
@@ -287,5 +287,80 @@ describe('shouldDeferRecentAppend', () => {
       fileMtimeMs: now - 500,
       fileSize: 1_000,
     }, now, 5_000)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grok stores one directory per session with a structured summary.json. The
+// scanner reads that (not the JSONL event streams) for metadata. Fixture shape
+// mirrors a real ~/.grok/sessions/<enc-cwd>/<uuid>/summary.json.
+// ---------------------------------------------------------------------------
+
+describe('readGrokMeta', () => {
+  let dir: string;
+  const uuid = '019f86cf-9d1d-7621-b80a-1e6d801904ce';
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-grok-'));
+    fs.mkdirSync(path.join(dir, uuid), { recursive: true });
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeSummary(summary: object): string {
+    const fp = path.join(dir, uuid, 'summary.json');
+    fs.writeFileSync(fp, JSON.stringify(summary));
+    return fp;
+  }
+
+  it('maps id, cwd, title, timestamps, message count and version from summary.json', () => {
+    const fp = writeSummary({
+      info: { id: uuid, cwd: '/Users/muqsit/src/github.com/muqsitnawaz' },
+      session_summary: 'a summary',
+      generated_title: 'Minecraft Installation and Play',
+      created_at: '2026-07-21T22:33:01.057529Z',
+      updated_at: '2026-07-21T22:44:05.605009Z',
+      last_active_at: '2026-07-21T22:44:05.605009Z',
+      num_messages: 152,
+      num_chat_messages: 51,
+      grok_home: '/Users/muqsit/.agents/.history/versions/grok/0.2.101/home/.grok',
+    });
+    const r = readGrokMeta(fp);
+    expect(r).not.toBeNull();
+    expect(r!.meta.id).toBe(uuid);
+    expect(r!.meta.agent).toBe('grok');
+    expect(r!.meta.topic).toBe('Minecraft Installation and Play'); // generated_title wins over session_summary
+    expect(r!.meta.cwd).toBe('/Users/muqsit/src/github.com/muqsitnawaz');
+    expect(r!.meta.project).toBe('muqsitnawaz');
+    expect(r!.meta.timestamp).toBe('2026-07-21T22:33:01.057529Z'); // created_at = start
+    expect(r!.meta.lastActivity).toBe('2026-07-21T22:44:05.605009Z'); // last_active_at
+    expect(r!.meta.messageCount).toBe(51); // num_chat_messages preferred over num_messages
+    expect(r!.meta.version).toBe('0.2.101'); // parsed from grok_home path
+    expect(r!.meta.shortId).toBe(uuid.slice(0, 8));
+  });
+
+  it('falls back to session_summary when no generated_title, and to the dir uuid when info.id is absent', () => {
+    const fp = writeSummary({
+      info: { cwd: '/tmp/x' },
+      session_summary: 'fallback topic',
+      created_at: '2026-07-21T00:00:00.000Z',
+    });
+    const r = readGrokMeta(fp);
+    expect(r!.meta.id).toBe(uuid); // recovered from the directory name
+    expect(r!.meta.topic).toBe('fallback topic');
+  });
+
+  it('coerces a missing timestamp to the file mtime (NOT NULL column safety)', () => {
+    const fp = writeSummary({ info: { id: uuid, cwd: '/tmp/x' } });
+    const r = readGrokMeta(fp);
+    expect(r!.meta.timestamp).toBeTruthy();
+    expect(() => new Date(r!.meta.timestamp).toISOString()).not.toThrow();
+  });
+
+  it('returns null for malformed json', () => {
+    const fp = path.join(dir, uuid, 'summary.json');
+    fs.writeFileSync(fp, '{ not valid json');
+    expect(readGrokMeta(fp)).toBeNull();
   });
 });

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -300,6 +300,7 @@ function dispatchAgentScan(
     case 'hermes': return scanHermesIncremental(onProgress);
     case 'kimi': return scanKimiIncremental(onProgress);
     case 'droid': return scanDroidIncremental(onProgress);
+    case 'grok': return scanGrokIncremental(onProgress);
     default: return Promise.resolve();
   }
 }
@@ -593,6 +594,7 @@ const SESSION_ROOT_SPECS: ReadonlyArray<{ agent: SessionAgentId; subdir: string 
   { agent: 'antigravity', subdir: 'conversations' },
   { agent: 'droid', subdir: 'sessions' },
   { agent: 'kimi', subdir: 'sessions' },
+  { agent: 'grok', subdir: 'sessions' },
 ];
 
 function sessionRootSubdir(agent: SessionAgentId): string | null {
@@ -3163,6 +3165,140 @@ function parseKimiWireMetrics(sessionDir: string): { messageCount: number; token
   }
 
   return { messageCount, tokenCount, outputTokens };
+}
+
+/**
+ * Scan Grok sessions. Grok stores one directory per session under
+ * ~/.grok/sessions/<url-encoded-cwd>/<uuid>/, each holding a summary.json with
+ * structured metadata (id, cwd, title, timestamps, message count). Same
+ * dir-per-session (L3) shape as Kimi, so it walks two levels and gates the
+ * summary.json read through the scan ledger. Before this, Grok had a type slot
+ * and a placeholder parser but no scanner, so `agents sessions` never indexed it.
+ */
+async function scanGrokIncremental(onProgress?: (p: ScanProgress) => void): Promise<void> {
+  const currentVersion = await getCurrentAgentVersion('grok');
+
+  const filePaths: string[] = [];
+  for (const sessionsDir of getAgentSessionDirs('grok', 'sessions')) {
+    if (!fs.existsSync(sessionsDir)) continue;
+    let cwdDirNames: string[];
+    try {
+      cwdDirNames = fs.readdirSync(sessionsDir);
+    } catch {
+      continue;
+    }
+    for (const cwdDirName of cwdDirNames) {
+      const cwdDir = path.join(sessionsDir, cwdDirName);
+      const stat = safeStatSync(cwdDir);
+      if (!stat?.isDirectory()) continue;
+      let sessionNames: string[];
+      try {
+        sessionNames = fs.readdirSync(cwdDir);
+      } catch {
+        continue;
+      }
+      for (const sessionName of sessionNames) {
+        const summaryPath = path.join(cwdDir, sessionName, 'summary.json');
+        if (!fs.existsSync(summaryPath)) continue;
+        filePaths.push(summaryPath);
+      }
+    }
+  }
+
+  const changed = filterChangedFiles(filePaths);
+  if (changed.length === 0) return;
+
+  onProgress?.({ agent: 'grok', parsed: 0, total: changed.length });
+
+  const scanEntries: ScanEntry[] = [];
+  const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
+  const seen = new Set<string>();
+  let parsed = 0;
+  for (const { filePath, scan } of changed) {
+    try {
+      const result = readGrokMeta(filePath, currentVersion);
+      if (result && !seen.has(result.meta.id)) {
+        seen.add(result.meta.id);
+        scanEntries.push({ meta: result.meta, content: result.content, scan });
+      } else {
+        touched.push({ filePath, scan });
+      }
+    } catch {
+      touched.push({ filePath, scan });
+    }
+    parsed++;
+    onProgress?.({ agent: 'grok', parsed, total: changed.length });
+  }
+
+  upsertSessionsBatch(scanEntries);
+  recordScans(touched);
+}
+
+/** Parse a single Grok session summary.json into session metadata. */
+export function readGrokMeta(
+  filePath: string,
+  currentVersion?: string,
+): { meta: SessionMeta; content: string } | null {
+  let summary: any;
+  try {
+    summary = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  const sessionDir = path.dirname(filePath);
+  // The uuid directory name is the canonical id; summary.info.id mirrors it.
+  const sessionId =
+    (typeof summary?.info?.id === 'string' && summary.info.id) || path.basename(sessionDir);
+  if (!sessionId) return null;
+
+  const cwd = normalizeCwd(typeof summary?.info?.cwd === 'string' ? summary.info.cwd : '');
+  const topic =
+    (typeof summary?.generated_title === 'string' && summary.generated_title.trim()) ||
+    (typeof summary?.session_summary === 'string' && summary.session_summary.trim()) ||
+    undefined;
+
+  // created_at is the session start; last_active_at/updated_at is the latest
+  // activity. Coerce timestamp to never-null (NOT NULL column) via the file mtime,
+  // matching how the other dir-per-session parsers (Kimi) fall back.
+  const createdAt = typeof summary?.created_at === 'string' ? summary.created_at : undefined;
+  const lastActivity =
+    (typeof summary?.last_active_at === 'string' && summary.last_active_at) ||
+    (typeof summary?.updated_at === 'string' && summary.updated_at) ||
+    undefined;
+  const stat = safeStatSync(filePath);
+  const timestamp =
+    createdAt || lastActivity || (stat ? stat.mtime.toISOString() : new Date().toISOString());
+
+  const messageCount =
+    typeof summary?.num_chat_messages === 'number'
+      ? summary.num_chat_messages
+      : typeof summary?.num_messages === 'number'
+        ? summary.num_messages
+        : undefined;
+
+  // Grok records its managed home in summary.grok_home
+  // (…/versions/grok/<version>/home/.grok) — recover the version from it.
+  let embeddedVersion: string | undefined;
+  if (typeof summary?.grok_home === 'string') {
+    embeddedVersion = summary.grok_home.match(/versions\/grok\/([^/]+)\//)?.[1];
+  }
+
+  const meta: SessionMeta = {
+    id: sessionId,
+    shortId: sessionId.slice(0, 8),
+    agent: 'grok',
+    timestamp,
+    lastActivity,
+    project: cwd ? path.basename(cwd) : undefined,
+    cwd: cwd || undefined,
+    filePath,
+    version: resolveSessionVersion('grok', filePath, embeddedVersion, currentVersion),
+    topic,
+    messageCount,
+  };
+
+  return { meta, content: topic || '' };
 }
 
 /** Parse a time filter string (relative like '7d' or ISO timestamp) into epoch milliseconds. */


### PR DESCRIPTION
## What

Grok is in `SESSION_AGENTS` and has a placeholder transcript parser (`parse.ts` `parseGrok`), but `dispatchAgentScan` had **no `case 'grok'`** — it fell through to `default: return Promise.resolve()`. So Grok sessions never entered the index and were **invisible to `agents sessions`**. (This is the "real hole" flagged in the session-tracking reference doc.)

## Change

- Add `scanGrokIncremental` + `readGrokMeta` (`discover.ts`). Grok uses the same **dir-per-session (L3)** layout as Kimi: `~/.grok/sessions/<url-encoded-cwd>/<uuid>/`, with a structured `summary.json`. The scanner walks two levels, gates each `summary.json` through the existing scan ledger, and upserts — mirroring `scanKimiIncremental`.
- `readGrokMeta` maps `summary.json` → `SessionMeta`: `info.id` (id), `info.cwd` (cwd/project), `generated_title` ‖ `session_summary` (topic), `created_at` (timestamp), `last_active_at` ‖ `updated_at` (lastActivity), `num_chat_messages` (messageCount), and the version parsed from the `grok_home` path. Timestamp coerces to the file mtime when absent (NOT-NULL column safety, same as Kimi).
- Register `grok` in `SESSION_ROOT_SPECS` so `agents sessions --roots` reports its dirs.

## Verification (real flow)

- **End-to-end on real Grok data**: on a box with real `~/.grok/sessions`, `agents sessions --json` went from **0 → 41** Grok rows. Spot-checked one against its `summary.json`: `id 019f86cf-…`, topic "Minecraft Installation and Play…", `cwd /Users/muqsit/src/github.com/muqsitnawaz`, `timestamp`=created_at, `lastActivity`=last_active_at, `messageCount 51` (= `num_chat_messages`), `version 0.2.101` (parsed from `grok_home`), `project muqsitnawaz`.
- **Baseline** (origin/main) lists no Grok agent at all — confirmed against the `default:` no-op.
- **24/24** `discover.test.ts` pass, including 4 new `readGrokMeta` cases on a real-shaped `summary.json` fixture (title precedence, id fallback to dir name, mtime timestamp coercion, malformed-json → null). `tsc` clean.

Session transcript (public repo, referenced not attached): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit/14567b8a-db63-4e27-9867-4846813157cc.jsonl`