### PR TITLE
fix(menubar): re-sign the helper on install so macOS 26 stops SIGKILLing it

### DIFF
--- a/apps/cli/.changelog/next/menubar-signature-selfheal.md
+++ b/apps/cli/.changelog/next/menubar-signature-selfheal.md
@@ -1,0 +1,12 @@
+- **The menu-bar helper no longer crash-loops on macOS 26.** npm's pack/extract
+  strips the ad-hoc signature the release bakes into `MenubarHelper.app`, leaving
+  it `code object is not signed at all`. macOS 26's code-signing monitor SIGKILLs
+  an unsigned binary at launch (`SIGKILL (Code Signature Invalid)`), so under the
+  launchd `KeepAlive` service it restarted forever, and its unstable identity made
+  the Accessibility grant (needed for the clip→paste keystroke in `Clip.swift`)
+  re-prompt every time. The install path now re-signs the copied bundle ad-hoc and
+  verifies it before bootstrapping the service, so every machine gets a valid
+  signature the kernel accepts — and a bundle that can't be made valid is skipped
+  instead of spun in a crash loop. A Developer-ID-signed helper (which survives
+  npm) is left untouched. Source: `apps/cli/src/lib/menubar/install-menubar.ts`,
+  `apps/cli/menubar/scripts/build.sh`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,19 +1,6 @@
 # Changelog
 
-## 1.20.75
-
-- **The menu-bar helper no longer crash-loops on macOS 26.** npm's pack/extract
-  strips the ad-hoc signature the release bakes into `MenubarHelper.app`, leaving
-  it `code object is not signed at all`. macOS 26's code-signing monitor SIGKILLs
-  an unsigned binary at launch (`SIGKILL (Code Signature Invalid)`), so under the
-  launchd `KeepAlive` service it restarted forever, and its unstable identity made
-  the Accessibility grant (needed for the clip→paste keystroke) re-prompt every
-  time. The install path now re-signs the copied bundle ad-hoc and verifies it
-  before bootstrapping the service, so every machine gets a valid signature the
-  kernel accepts — and a bundle that can't be made valid is skipped instead of
-  spun in a crash loop. A Developer-ID-signed helper (which survives npm) is left
-  untouched. Source: `apps/cli/src/lib/menubar/install-menubar.ts`,
-  `apps/cli/menubar/scripts/build.sh`.
+## 1.20.74
 
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## 1.20.74
+## 1.20.75
+
+- **The menu-bar helper no longer crash-loops on macOS 26.** npm's pack/extract
+  strips the ad-hoc signature the release bakes into `MenubarHelper.app`, leaving
+  it `code object is not signed at all`. macOS 26's code-signing monitor SIGKILLs
+  an unsigned binary at launch (`SIGKILL (Code Signature Invalid)`), so under the
+  launchd `KeepAlive` service it restarted forever, and its unstable identity made
+  the Accessibility grant (needed for the clip→paste keystroke) re-prompt every
+  time. The install path now re-signs the copied bundle ad-hoc and verifies it
+  before bootstrapping the service, so every machine gets a valid signature the
+  kernel accepts — and a bundle that can't be made valid is skipped instead of
+  spun in a crash loop. A Developer-ID-signed helper (which survives npm) is left
+  untouched. Source: `apps/cli/src/lib/menubar/install-menubar.ts`,
+  `apps/cli/menubar/scripts/build.sh`.
 
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the

--- a/apps/cli/menubar/scripts/build.sh
+++ b/apps/cli/menubar/scripts/build.sh
@@ -30,9 +30,13 @@ DEST="$DEST_DIR/menubar-helper-mac"
 cp "$SRC" "$DEST"
 
 # .app bundle. LSUIElement=true keeps it out of the Dock and the ⌘-Tab
-# switcher — it lives only in the menu bar. Unlike the computer helper, the
-# status item needs no TCC grant, so ad-hoc signing is fine and we skip
-# notarization entirely.
+# switcher — it lives only in the menu bar. We skip notarization (a status item
+# has no Keychain ACL), but the helper DOES need a stable code identity: its
+# clip→paste feature (Clip.swift) synthesizes a ⌘-V keystroke, which requires an
+# Accessibility (TCC) grant, and macOS 26+ SIGKILLs an unsigned/invalid binary
+# at launch. Prefer a Developer ID identity — it survives npm's tarball
+# round-trip (an ad-hoc/linker signature gets stripped to "not signed at all",
+# which the install-time re-sign in install-menubar.ts then heals per machine).
 APP="$DEST_DIR/MenubarHelper.app"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS"
@@ -64,7 +68,13 @@ SIGN_ID="${MENUBAR_HELPER_SIGN_ID:-}"
 if [ -z "$SIGN_ID" ]; then
     SIGN_ID=$(security find-identity -v -p codesigning 2>/dev/null | grep -oE '"Developer ID Application: [^"]+"' | head -1 | tr -d '"')
 fi
-[ -z "$SIGN_ID" ] && SIGN_ID="-"
+if [ -z "$SIGN_ID" ]; then
+    SIGN_ID="-"
+    echo "  WARNING: no Developer ID identity found — signing ad-hoc." >&2
+    echo "  npm will strip this signature; machines self-heal via install-menubar.ts" >&2
+    echo "  but the Accessibility grant re-prompts each upgrade. Sign on a host with" >&2
+    echo "  the Developer ID cert (see remote-sign-mac.sh) for a stable identity." >&2
+fi
 echo "  signing with: $SIGN_ID"
 codesign --force --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.agents-menubar "$APP" 2>&1 | sed 's/^/  /'
 codesign --force --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.agents-menubar "$DEST" 2>&1 | sed 's/^/  /'

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
-import { isMenubarStale, menubarPlistNeedsRepoint, restartMenubarLaunchAgent } from './install-menubar.js';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  codesignVerifies,
+  ensureValidSignature,
+  isMenubarStale,
+  menubarPlistNeedsRepoint,
+  restartMenubarLaunchAgent,
+} from './install-menubar.js';
 
 // Regression guard for the upgrade self-heal: before this, the helper was only
 // (re)installed when no service existed, so `npm update` left the menu bar
@@ -83,5 +93,41 @@ describe('restartMenubarLaunchAgent', () => {
 
     expect(() => restartMenubarLaunchAgent(501, '/tmp/com.phnx-labs.agents-menubar.plist', exec)).not.toThrow();
     expect(calls).toHaveLength(3);
+  });
+});
+
+// Regression guard for the crash loop: npm strips the ad-hoc signature the
+// release bakes into MenubarHelper.app, leaving it "not signed at all" — which
+// macOS 26+ SIGKILLs on launch, spinning the launchd KeepAlive service forever.
+// ensureValidSignature must re-sign the copied bundle so codesign verifies.
+// Exercises the real `codesign` binary (no mocking), so it only runs on macOS.
+const darwinOnly = process.platform === 'darwin' ? describe : describe.skip;
+darwinOnly('ensureValidSignature (real codesign)', () => {
+  function makeUnsignedBundle(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'menubar-sig-'));
+    const app = path.join(dir, 'MenubarHelper.app');
+    fs.mkdirSync(path.join(app, 'Contents', 'MacOS'), { recursive: true });
+    // A real Mach-O so codesign has something to sign; /bin/echo is stable.
+    fs.copyFileSync('/bin/echo', path.join(app, 'Contents', 'MacOS', 'MenubarHelper'));
+    // Strip the inherited system signature -> "not signed at all", the exact
+    // state npm's tarball round-trip leaves the shipped ad-hoc bundle in.
+    spawnSync('codesign', ['--remove-signature', app], { stdio: 'ignore' });
+    return app;
+  }
+
+  it('heals an unsigned bundle so it passes codesign --verify', () => {
+    const app = makeUnsignedBundle();
+    expect(codesignVerifies(app)).toBe(false);
+    expect(ensureValidSignature(app)).toBe(true);
+    expect(codesignVerifies(app)).toBe(true);
+    fs.rmSync(path.dirname(app), { recursive: true, force: true });
+  });
+
+  it('leaves an already-valid signature untouched (idempotent)', () => {
+    const app = makeUnsignedBundle();
+    ensureValidSignature(app);
+    expect(ensureValidSignature(app)).toBe(true);
+    expect(codesignVerifies(app)).toBe(true);
+    fs.rmSync(path.dirname(app), { recursive: true, force: true });
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -146,6 +146,42 @@ function copyAppBundle(src: string, dest: string): void {
   }
 }
 
+/** True when the bundle carries a signature the kernel will accept at launch. */
+export function codesignVerifies(appPath: string): boolean {
+  const r = spawnSync('codesign', ['--verify', '--strict', appPath], { stdio: ['ignore', 'ignore', 'ignore'] });
+  return r.status === 0;
+}
+
+/**
+ * Guarantee the installed bundle has a valid signature on THIS machine.
+ *
+ * npm's pack/extract strips the ad-hoc/linker signature the release baked into
+ * the helper, leaving `code object is not signed at all`. On macOS 26+ the
+ * kernel's code-signing monitor SIGKILLs an unsigned/invalid binary at launch
+ * (`SIGKILL (Code Signature Invalid)`), so under the launchd `KeepAlive` service
+ * an ad-hoc release helper crash-loops forever and its unstable identity makes
+ * the Accessibility grant (needed for the clip→paste keystroke in Clip.swift)
+ * re-prompt every time. A fresh ad-hoc re-sign gives the on-disk bytes a
+ * matching cdhash, which the kernel accepts.
+ *
+ * A Developer-ID-signed helper survives npm untouched — its embedded signature
+ * still verifies — so we leave it alone and only re-sign when verification
+ * fails. Returns whether the bundle ends up validly signed. No-op cost on the
+ * common (already-valid) path is a single `codesign --verify`.
+ */
+export function ensureValidSignature(appPath: string): boolean {
+  if (codesignVerifies(appPath)) return true;
+  // Drop any quarantine/xattrs the tarball round-trip added (they can break
+  // codesign), then re-sign ad-hoc under the helper's stable bundle identifier.
+  spawnSync('xattr', ['-cr', appPath], { stdio: ['ignore', 'ignore', 'ignore'] });
+  spawnSync(
+    'codesign',
+    ['--force', '--sign', '-', '--identifier', SERVICE_LABEL, appPath],
+    { stdio: ['ignore', 'ignore', 'ignore'] }
+  );
+  return codesignVerifies(appPath);
+}
+
 /**
  * Copy the bundled `.app` to the stable user path (idempotent unless forced).
  * Returns the installed executable path, or null if no source bundle ships
@@ -156,8 +192,14 @@ export function ensureMenubarAppInstalled(opts: { forceReinstall?: boolean } = {
   const src = sourceAppPath();
   if (!src) return null;
   const dest = installedAppPath();
-  if (!opts.forceReinstall && fs.existsSync(dest)) return installedExecutablePath();
+  if (!opts.forceReinstall && fs.existsSync(dest)) {
+    // Self-heal an already-installed bundle whose signature npm stripped on a
+    // prior upgrade (macOS 26+ SIGKILLs it otherwise) without a forced recopy.
+    ensureValidSignature(dest);
+    return installedExecutablePath();
+  }
   copyAppBundle(src, dest);
+  ensureValidSignature(dest);
   return installedExecutablePath();
 }
 
@@ -248,6 +290,17 @@ export function enableMenubarService(opts: { clearOptOut?: boolean } = { clearOp
   if (!onDarwin()) return false;
   const exec = ensureMenubarAppInstalled({ forceReinstall: true });
   if (!exec) return false;
+
+  // Never bootstrap a helper the kernel will kill on launch: an invalid
+  // signature under launchd KeepAlive is an infinite crash loop. If the bundle
+  // can't be made valid (re-sign already attempted in ensureMenubarAppInstalled),
+  // skip the service rather than spin the loop.
+  if (!codesignVerifies(installedAppPath())) {
+    process.stderr.write(
+      'agents: menu-bar helper has no valid code signature; skipping launch to avoid a crash loop.\n'
+    );
+    return false;
+  }
 
   if (opts.clearOptOut) {
     try { fs.rmSync(disabledSentinelPath(), { force: true }); } catch { /* already gone */ }


### PR DESCRIPTION
## Problem

On macOS 26.4, `MenubarHelper` crash-loops and the OS re-prompts for Accessibility every launch.

Root cause chain (verified on this machine — 23 crash reports since 07-26):

1. `menubar/scripts/build.sh` signs with a Developer ID **only if one is in the keychain**, else falls back to **ad-hoc** (`SIGN_ID="-"`). `@phnx-labs/agents-cli@1.20.74` shipped the ad-hoc variant.
2. **npm's pack/extract strips the ad-hoc/linker signature entirely** → the installed bundle is `code object is not signed at all`. (The keychain helper survives npm only because it's Developer-ID signed with an embedded CMS blob.)
3. macOS 26's code-signing monitor **SIGKILLs an unsigned binary at launch** (`SIGKILL (Code Signature Invalid)`, exception `0x32`). With launchd `KeepAlive=true`, that's an infinite crash loop.
4. The killed/unstable identity is why the Accessibility grant — genuinely needed, since `Clip.swift` synthesizes a ⌘-V keystroke for the clip→paste feature — never sticks and re-prompts forever.

The `prepack` `codesign --verify` gate passes because it runs on the sign host **before** npm mangles the bytes.

## Fix

- `ensureMenubarAppInstalled` re-signs the copied bundle ad-hoc and verifies it (`ensureValidSignature`), self-healing whatever npm did — on both fresh install and the already-installed path. A Developer-ID signature (which survives npm) already verifies, so it's left untouched; the cost on that path is a single `codesign --verify`.
- `enableMenubarService` refuses to bootstrap a bundle that still fails `codesign --verify`, so a broken helper is **skipped instead of spun in a crash loop**.
- `build.sh`: corrected the stale "status item needs no TCC grant, so ad-hoc is fine" comment (false — the clip feature needs Accessibility), and the ad-hoc fallback now warns loudly instead of silently shipping an unsignable helper.

## Verification (end-to-end, against the real broken artifact)

Compiled self-heal run against the actual unsigned `1.20.74` npm bundle:

```
--- before (as npm ships it) ---
/tmp/menubar-e2e/MenubarHelper.app: code object is not signed at all   (rc=1)
before codesignVerifies: false
ensureValidSignature returned: true
after  codesignVerifies: true
--- after (independent check) ---
/tmp/menubar-e2e/MenubarHelper.app: valid on disk                       (rc=0)
```

On this machine, after applying the same re-sign the helper launches and stays up (pid stable, zero new crash reports).

New darwin-gated test (`install-menubar.test.ts`) exercises the real `codesign` path — strips a bundle's signature, asserts `ensureValidSignature` heals it. Full menubar suite: 13 passed.

## Follow-up (not in this PR)

Make the release **require** a non-adhoc signature for the menu-bar helper (like the keychain helper). Ad-hoc re-sign gives a stable-per-version cdhash, so the Accessibility grant still re-prompts once per upgrade; a Developer-ID identity would make it fully durable.

Transcript: zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/e426b6ba-305c-40ce-beac-d60a62d53a85.jsonl