### PR TITLE
fix(hosts): unify host/device resolution into one merged resolver (RUSH-1967)

### DIFF
--- a/apps/cli/.changelog/next/rush-1967-unified-resolver.md
+++ b/apps/cli/.changelog/next/rush-1967-unified-resolver.md
@@ -1,0 +1,16 @@
+- **One resolver for `--host` / `--device` — every subcommand now dials the same box
+  (RUSH-1967).** A host token used to resolve through two disagreeing code paths:
+  `run --host` (and the generic passthrough, teams placement, doctor, funnel, remote
+  secrets) let a `~/.ssh/config` stanza win and dialed its bare name, while
+  `sessions --host`, session bundles, and `agents ssh` dialed the device Tailscale
+  `user@dnsName`. The same name could reach two different machines, and because the two
+  emitted different target strings they never shared a multiplexed SSH connection.
+  Resolution is now a single merged lookup (`matchHost`): the live devices registry
+  supplies address/OS/presence, the agents.yaml overlay supplies capability tags, and
+  ssh_config supplies hosts Tailscale has never seen — merged per-field, not one
+  shadowing another. Fallout fixed with it: an enrolled device address always comes from
+  the live registry (so `agents devices sync` takes effect without re-enrolling, no more
+  frozen route), an enrolled device keeps its presence and `dispatchable` flags, a
+  password-auth device cannot be made dispatchable by shadowing it with an inline entry,
+  and a host present only in `~/.ssh/config` is now visible to the `sessions --host`
+  fan-out.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,25 +2,6 @@
 
 ## 1.20.74
 
-- **One resolver for `--host` / `--device` — every subcommand now dials the same
-  box (RUSH-1967).** A host token used to resolve through two disagreeing code
-  paths: `run --host` (and the generic passthrough, teams placement, doctor,
-  funnel, remote secrets) let a `~/.ssh/config` stanza win and dialed its bare
-  name, while `sessions --host`, session bundles, and `agents ssh` dialed the
-  device's Tailscale `user@dnsName`. The same name could reach two different
-  machines, and because the two emitted different target strings they never
-  shared a multiplexed SSH connection. Resolution is now a single merged lookup
-  (`matchHost`): the live devices registry supplies address/OS/presence, the
-  agents.yaml overlay supplies capability tags, and ssh_config supplies hosts
-  Tailscale has never seen — merged per-field, not one shadowing another. Fallout
-  fixed for free: an enrolled device's address always comes from the live
-  registry (so `agents devices sync` takes effect without re-enrolling, no more
-  frozen route), an enrolled device keeps its presence and `dispatchable` flags,
-  a password-auth device can't be made dispatchable by shadowing it with an
-  inline entry, and a host present only in `~/.ssh/config` is now visible to the
-  `sessions --host` fan-out. Source: `apps/cli/src/lib/hosts/registry.ts`,
-  `apps/cli/src/lib/devices/resolve-target.ts`.
-
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 1.20.74
 
+- **One resolver for `--host` / `--device` — every subcommand now dials the same
+  box (RUSH-1967).** A host token used to resolve through two disagreeing code
+  paths: `run --host` (and the generic passthrough, teams placement, doctor,
+  funnel, remote secrets) let a `~/.ssh/config` stanza win and dialed its bare
+  name, while `sessions --host`, session bundles, and `agents ssh` dialed the
+  device's Tailscale `user@dnsName`. The same name could reach two different
+  machines, and because the two emitted different target strings they never
+  shared a multiplexed SSH connection. Resolution is now a single merged lookup
+  (`matchHost`): the live devices registry supplies address/OS/presence, the
+  agents.yaml overlay supplies capability tags, and ssh_config supplies hosts
+  Tailscale has never seen — merged per-field, not one shadowing another. Fallout
+  fixed for free: an enrolled device's address always comes from the live
+  registry (so `agents devices sync` takes effect without re-enrolling, no more
+  frozen route), an enrolled device keeps its presence and `dispatchable` flags,
+  a password-auth device can't be made dispatchable by shadowing it with an
+  inline entry, and a host present only in `~/.ssh/config` is now visible to the
+  `sessions --host` fan-out. Source: `apps/cli/src/lib/hosts/registry.ts`,
+  `apps/cli/src/lib/devices/resolve-target.ts`.
+
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/docs/09-ssh-transport.md
+++ b/apps/cli/docs/09-ssh-transport.md
@@ -123,6 +123,40 @@ which still use OpenSSH default `~/.ssh/known_hosts`, not the managed store, so
 they neither pin into it nor verify against it. Wiring those call sites onto the
 managed store (so they verify strictly too) is follow-up.
 
+### 2c. One resolver: a token → the same target string everywhere (RUSH-1967)
+
+Multiplexing (§2) only reuses a socket when two calls hand `ssh` the **same
+target string** — `%C` hashes local-host/remote/port/user, so `mac-mini`,
+`muqsit@mac-mini.<tailnet>.ts.net`, and a stale `~/.ssh/config` LAN IP for the
+same box each hash to a different `cm-%C` socket and never share the master. A
+`--host`/`--device` token therefore has to resolve to one canonical target no
+matter which subcommand typed it.
+
+It used to resolve through **two** disagreeing chains: a local-provider-first
+`resolveHost` (`run --host`, the generic passthrough, teams placement, doctor,
+funnel, remote secrets) and a devices-only `resolveSshTarget` (`sessions --host`,
+session bundles, `agents ssh`). They emitted different strings for the same
+machine — `resolveHost` let an ssh-config stanza win and dialed its bare name,
+while the devices chain dialed the Tailscale `user@dnsName` — so the two never
+shared a `%C` socket and could even dial two different boxes.
+
+Both are now one core, [`matchHost`](../src/lib/hosts/registry.ts). It merges the
+directories **per-field** instead of letting one provider shadow the other:
+
+| Field | Source of truth |
+|---|---|
+| address, OS, presence, dispatchable | the live **devices** registry |
+| capability tags, OS hint (when the device platform is unknown) | the agents.yaml **overlay** |
+| a host Tailscale never saw | **ssh_config** (dial the bare name; ssh applies the stanza) |
+
+One grammar for every caller — `name`, `user@name`, a tailnet FQDN, an ssh_config
+alias, and a literal `user@host` all resolve identically. `resolveHost` (dispatch),
+`resolveExplicitTargets` (fan-out), and `resolveDeviceTarget` (`agents ssh`) are
+thin wrappers that differ only in the shape they return and which literal
+fallbacks they permit. Because the address always comes from the live registry,
+`agents devices sync` takes effect without re-enrolling, and a password-auth
+device can't be made dispatchable by shadowing it with an inline entry.
+
 ### 3. The follow loop: one persistent stream (P1)
 
 The original loop made two calls per cycle — `tail -c +offset` for new log bytes,

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -201,7 +201,8 @@ is a fast-follow `HostProvider`, opt-in when logged in — not a v1 dependency.
 ```
 agents run <agent> ["<task>"] --host <host>
   │
-  ├─ resolveHost(name)         registry lookup in agents.yaml → {address,user,caps} [Phase 1]
+  ├─ resolveHost(name)         one merged lookup (devices registry ∪ agents.yaml
+  │                            overlay ∪ ssh_config) → {address,user,caps,os,…}   [Phase 1]
   │
   ├─ ensureHostReady(name)     lazy SSH probe (online?) + config + agent + branch  [Phase 1]
   │
@@ -312,9 +313,25 @@ agent routing a GPU eval to a host tagged `gpu`).
 - `agents hosts remove <name>` / `agents hosts import --from-tailscale` (opt-in:
   prefill entries from `tailscale status` names; reads only, connects to nothing).
 
-Resolution for an address: `hosts.<name>.address`, else error with the list of
-known names. (No tailnet lookup, no DNS guessing — a name is either registered or
-it isn't.)
+Resolution for an address goes through **one** resolver,
+[`matchHost`](../src/lib/hosts/registry.ts) (RUSH-1967), shared by every caller —
+`run --host`, the `sessions --host` fan-out, and `agents ssh` alike, so a token
+can never dial two different boxes depending on which subcommand typed it. It
+merges three directories **per-field**, it does not let one shadow another:
+
+- the **devices** registry (`agents devices`) supplies address, OS, and presence
+  — so the address is always live (`agents devices sync` takes effect without
+  re-enrolling) and a stale enrolled snapshot can't freeze the route;
+- the **agents.yaml** `hosts` overlay supplies capability tags and hints;
+- **`~/.ssh/config`** supplies hosts Tailscale has never seen (dialed by their
+  bare name, so ssh applies the stanza).
+
+One grammar for every caller: `name`, `user@name` (login user overridden, same
+box), a tailnet FQDN, an ssh_config alias, and an ad-hoc `user@host` all resolve
+identically. `dispatchable` follows the device's auth method, so a password-auth
+device can't be made dispatchable by shadowing it with an inline entry. A bare
+unknown name resolves to nothing, which keeps capability-tag routing
+(`--host gpu`) and the `agents ssh` "Unknown device" verdict reachable.
 
 ### 2. Transport — plain SSH (reuse, don't reinvent)
 

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1472,7 +1472,7 @@ export function registerRunCommand(program: Command): void {
         { ALL_AGENT_IDS, ACCOUNT_INSPECTION_AGENT_IDS, agentLabel, supportsAccountInspection },
         { profileExists, resolveProfileForRun },
         { readAndResolveBundleEnv, describeBundle, assertRemoteBundleFlagsUnsupported, isHeadlessSecretsContext },
-        { splitBundleRef, resolveSshTarget, remoteResolveEnv },
+        { splitBundleRef, resolveHostSshTarget, remoteResolveEnv },
         { getConfiguredRunStrategy, normalizeRunStrategy, resolveRunVersion, rotationFailoverChain, shouldArmRotationFailover, RUN_STRATEGIES },
         { getGlobalDefault, getVersionHomePath, resolveVersion, resolveVersionAlias, ensureAgentRunnable },
         { buildDiscoveredPlugin, loadPluginManifest, syncPluginToVersion },
@@ -2145,7 +2145,7 @@ export function registerRunCommand(program: Command): void {
             );
             // Remote bundle (`bundle@host`): resolve over SSH and inject
             // ephemerally — values never touch this machine's keychain or disk.
-            const target = await resolveSshTarget(host);
+            const target = await resolveHostSshTarget(host);
             const bundleEnv = await remoteResolveEnv(target, bundleName, { osLookupName: host });
             console.log(chalk.gray(`[secrets] Resolved ${bundleName}@${host}: ${Object.keys(bundleEnv).length} keys (remote, ephemeral)`));
             secretsEnv = { ...secretsEnv, ...bundleEnv };

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -21,7 +21,7 @@ import {
   remoteResolveEnv,
   remoteSecretsRaw,
   remoteSecretsStream,
-  resolveSshTarget,
+  resolveHostSshTarget,
 } from '../lib/secrets/remote.js';
 import { remoteShellFor, buildWindowsStdinImportCommand } from '../lib/hosts/remote-cmd.js';
 import { resolveRemoteOsSync } from '../lib/hosts/remote-os.js';
@@ -480,11 +480,11 @@ async function browseRemote(targets: string[], args: string[], tty: boolean): Pr
   };
   if (tty) {
     for (const t of targets) {
-      const target = await resolveSshTarget(t);
+      const target = await resolveHostSshTarget(t);
       render(t, remoteSecretsRaw(target, args, { tty: true, osLookupName: t }));
     }
   } else {
-    const resolved = await Promise.all(targets.map(async (t) => ({ name: t, target: await resolveSshTarget(t) })));
+    const resolved = await Promise.all(targets.map(async (t) => ({ name: t, target: await resolveHostSshTarget(t) })));
     const results = resolved.map(({ name, target }) => remoteSecretsRaw(target, args, { osLookupName: name }));
     targets.forEach((t, i) => render(t, results[i]));
   }
@@ -1676,7 +1676,7 @@ Examples:
           }
           assertValidSshTarget(opts.host);
           const resolvedBundleName = bundleName ?? (await pickBundleName('import into'));
-          const target = await resolveSshTarget(opts.host);
+          const target = await resolveHostSshTarget(opts.host);
           const env = await remoteResolveEnv(target, resolvedBundleName, { osLookupName: opts.host });
           const bundle = resolveImportBundle(resolvedBundleName, opts.backend, opts.synced);
           const { added, skipped } = applyEnvToBundle(bundle, env, opts);
@@ -1960,7 +1960,7 @@ Examples:
             { keys: keysSubset, allowExpired: execOpts.allowExpired },
             { keysFlag: '--keys', allowExpiredFlag: '--allow-expired' },
           );
-          secretEnv = await remoteResolveEnv(await resolveSshTarget(execOpts.host), bundleName, { osLookupName: execOpts.host });
+          secretEnv = await remoteResolveEnv(await resolveHostSshTarget(execOpts.host), bundleName, { osLookupName: execOpts.host });
         } else {
           const { readAndResolveBundleEnv } = await import('../lib/secrets/bundles.js');
           secretEnv = readAndResolveBundleEnv(bundleName, {
@@ -2172,7 +2172,7 @@ Examples:
         const unlockArgs = buildRemoteUnlockArgs(names, opts);
         let failures = 0;
         for (const h of hosts) {
-          const target = await resolveSshTarget(h);
+          const target = await resolveHostSshTarget(h);
           // FOREGROUND stream (stdio inherited), NOT the piped remoteSecretsRaw:
           // the remote's passphrase prompt only surfaces if the remote process
           // sees a real TTY, which requires our local terminal to pass straight

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -1125,7 +1125,7 @@ secrets bundle via an askpass shim — the password never touches argv.
       // `user@device` (same device, login user overridden — dialed via its
       // Tailscale route, not LAN DNS), or an ad-hoc `user@host`/`host` literal.
       // A bare unregistered alias still errors as "Unknown device".
-      const device = resolveDeviceTarget(name, await loadDevices());
+      const device = await resolveDeviceTarget(name);
       if (!device) {
         // Not a registered device — it may be a leased crabbox box slug. ssh into
         // it directly (crabbox@<tailnet|ip>:2222) before giving up.

--- a/apps/cli/src/lib/devices/__tests__/resolve-target.test.ts
+++ b/apps/cli/src/lib/devices/__tests__/resolve-target.test.ts
@@ -1,35 +1,65 @@
 /**
- * A `--host`/`--device` token must resolve to the SAME ssh target the
- * auto-discovery sweep uses — through the device registry — so an explicit host
- * and the fleet sweep never dial two different routes for one box. These tests
- * pin that: a bare alias dials the device's registry address (not the literal
- * alias), while a raw `user@host` stays literal.
+ * The fan-out (`resolveExplicitTargets`) and `agents ssh` (`resolveDeviceTarget`)
+ * adapters now share ONE core with `run --host` (RUSH-1967). These tests pin,
+ * against a REAL registry / overlay / ssh_config (no mocks — repo convention):
+ *   - a `--host` token dials the device's live Tailscale route, not the literal;
+ *   - the same token resolves to the SAME target string through `resolveHost`
+ *     (dispatch) and `resolveExplicitTargets` (fan-out) — one row per divergence
+ *     in the ticket table;
+ *   - an ssh_config-only alias is now visible to the fan-out;
+ *   - `agents ssh` keeps its stricter grammar (devices + literals only).
  */
-import { describe, it, expect } from 'vitest';
-import { resolveSshTarget, resolveDeviceTarget } from '../resolve-target.js';
-import type { DeviceRegistry, DeviceProfile } from '../registry.js';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
-function device(overrides: Partial<DeviceProfile>): DeviceProfile {
-  return {
-    name: 'yosemite-s0',
-    platform: 'linux',
-    shell: 'posix',
-    user: 'muqsit',
-    address: { via: 'tailscale', dnsName: 'yosemite-s0.tail1a85a1.ts.net' },
-    auth: { method: 'key' },
-    createdAt: '2026-01-01T00:00:00.000Z',
-    updatedAt: '2026-01-01T00:00:00.000Z',
-    ...overrides,
-  } as DeviceProfile;
+// HOME must be set before state.ts loads so the device registry, the agents.yaml
+// overlay, and ~/.ssh/config all resolve under the temp root.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-resolve-target-test-'));
+process.env.HOME = TEST_HOME;
+
+const { resolveExplicitTargets, resolveDeviceTarget } = await import('../resolve-target.js');
+const { resolveHost } = await import('../../hosts/registry.js');
+const { sshTargetFor } = await import('../../hosts/types.js');
+const { upsertDevice } = await import('../registry.js');
+
+function registryPath(): string {
+  return path.join(TEST_HOME, '.agents', '.history', 'devices', 'registry.json');
+}
+function metaPath(): string {
+  return path.join(TEST_HOME, '.agents', 'agents.yaml');
+}
+function writeSshConfig(text: string): void {
+  fs.mkdirSync(path.join(TEST_HOME, '.ssh'), { recursive: true });
+  fs.writeFileSync(path.join(TEST_HOME, '.ssh', 'config'), text);
 }
 
-const reg: DeviceRegistry = { 'yosemite-s0': device({}) };
+beforeEach(() => {
+  fs.rmSync(registryPath(), { force: true });
+  fs.rmSync(`${registryPath()}.lock`, { recursive: true, force: true });
+  fs.rmSync(metaPath(), { force: true });
+  fs.rmSync(path.join(TEST_HOME, '.ssh', 'config'), { force: true });
+});
 
-describe('resolveSshTarget', () => {
-  it('resolves a bare alias to the registry address, not the literal alias', () => {
-    const r = resolveSshTarget('yosemite-s0', reg);
-    // The bug: without this, target would be the bare `yosemite-s0` (a different
-    // route than the sweep's registry address, breaking socket reuse).
+afterAll(() => {
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+async function addDevice(name: string, over: Partial<Parameters<typeof upsertDevice>[1]> = {}): Promise<void> {
+  await upsertDevice(name, {
+    platform: 'linux',
+    user: 'muqsit',
+    address: { via: 'tailscale', dnsName: `${name}.tail1a85a1.ts.net` },
+    auth: { method: 'key' },
+    ...over,
+  });
+}
+
+describe('resolveExplicitTargets — fan-out through the unified core', () => {
+  it('dials a bare device name via its live Tailscale route, not the literal alias', async () => {
+    await addDevice('yosemite-s0');
+    const [r] = await resolveExplicitTargets(['yosemite-s0']);
     expect(r).toEqual({
       target: 'muqsit@yosemite-s0.tail1a85a1.ts.net',
       machine: 'yosemite-s0',
@@ -38,80 +68,125 @@ describe('resolveSshTarget', () => {
     });
   });
 
-  it('matches case/domain-insensitively via normalizeHost', () => {
-    expect(resolveSshTarget('YOSEMITE-S0.local', reg)?.target).toBe('muqsit@yosemite-s0.tail1a85a1.ts.net');
+  it('matches a tailnet FQDN / different case to the same device (normalized)', async () => {
+    await addDevice('yosemite-s0');
+    expect((await resolveExplicitTargets(['YOSEMITE-S0.tail1a85a1.ts.net']))[0]?.target).toBe(
+      'muqsit@yosemite-s0.tail1a85a1.ts.net',
+    );
   });
 
-  it('resolves user@device through the registry, overriding only the login user', () => {
-    // The fix: a `user@device` is the same box as `device` — it must dial the
-    // registry (Tailscale) route, NOT a bare `ssh root@yosemite-s0` (LAN DNS).
-    const r = resolveSshTarget('root@yosemite-s0', reg);
+  it('overrides only the login user for user@device (still the Tailscale route)', async () => {
+    await addDevice('yosemite-s0');
+    const [r] = await resolveExplicitTargets(['root@yosemite-s0']);
     expect(r?.target).toBe('root@yosemite-s0.tail1a85a1.ts.net');
     expect(r?.machine).toBe('yosemite-s0');
   });
 
-  it('keeps a user@host literal when the host matches no device', () => {
-    const r = resolveSshTarget('root@some-box', {});
+  it('keeps a user@host literal when the host matches no device', async () => {
+    const [r] = await resolveExplicitTargets(['root@some-box']);
     expect(r?.target).toBe('root@some-box');
     expect(r?.machine).toBe('some-box');
   });
 
-  it('falls back to a literal target for an unregistered host', () => {
-    const r = resolveSshTarget('some-box', {});
-    expect(r?.target).toBe('some-box');
-    expect(r?.machine).toBe('some-box');
+  it('makes an ssh_config-only alias visible to the fan-out (divergence #2)', async () => {
+    writeSshConfig('Host only-in-ssh\n  HostName 10.0.0.9\n');
+    const [r] = await resolveExplicitTargets(['only-in-ssh']);
+    expect(r?.target).toBe('only-in-ssh'); // bare name → ssh applies the stanza
+    expect(r?.machine).toBe('only-in-ssh');
   });
 
-  it('falls back to the literal token when the matched device has no address', () => {
-    const addressless: DeviceRegistry = { 'no-addr': device({ name: 'no-addr', address: { via: 'manual' } }) };
-    const r = resolveSshTarget('no-addr', addressless);
-    // sshTargetFor throws with no dnsName/ip — resolver degrades to the literal.
-    expect(r?.target).toBe('no-addr');
-    expect(r?.machine).toBe('no-addr');
+  it('skips an addressless device with a note rather than dialing a bad literal', async () => {
+    await addDevice('no-addr', { address: { via: 'manual' } });
+    expect(await resolveExplicitTargets(['no-addr'])).toEqual([]);
   });
 
-  it('returns undefined for a token that fails the ssh-target injection guard', () => {
-    expect(resolveSshTarget('bad;rm -rf', reg)).toBeUndefined();
+  it('skips a bare unknown word (a typo is not a literal to dial)', async () => {
+    expect(await resolveExplicitTargets(['definitely-not-here'])).toEqual([]);
+  });
+
+  it('skips an injection-unsafe token', async () => {
+    expect(await resolveExplicitTargets(['bad;rm -rf'])).toEqual([]);
   });
 });
 
-describe('resolveDeviceTarget', () => {
-  it('returns the full profile for a bare device name', () => {
-    const r = resolveDeviceTarget('yosemite-s0', reg);
+describe('run --host and sessions --host resolve to the SAME target (divergence table)', () => {
+  async function bothTargets(token: string): Promise<{ dispatch?: string; fanout?: string }> {
+    const host = await resolveHost(token);
+    const dispatch = host ? sshTargetFor(host) : undefined;
+    const fanout = (await resolveExplicitTargets([token]))[0]?.target;
+    return { dispatch, fanout };
+  }
+
+  it('#1 name in BOTH ssh_config and the device registry → device route wins for both', async () => {
+    await addDevice('mac-mini', { platform: 'macos', address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' } });
+    writeSshConfig('Host mac-mini\n  HostName 192.168.1.50\n'); // a stale LAN stanza
+    const { dispatch, fanout } = await bothTargets('mac-mini');
+    expect(dispatch).toBe('muqsit@mac-mini.tail1a85a1.ts.net');
+    expect(fanout).toBe(dispatch);
+  });
+
+  it('#3 user@device → both dial the Tailscale route with the user overridden', async () => {
+    await addDevice('mac-mini', { platform: 'macos', address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' } });
+    const { dispatch, fanout } = await bothTargets('muqsit@mac-mini');
+    expect(dispatch).toBe('muqsit@mac-mini.tail1a85a1.ts.net');
+    expect(fanout).toBe(dispatch);
+  });
+
+  it('#4 tailnet FQDN → both resolve to the same device route', async () => {
+    await addDevice('yosemite-s0');
+    const { dispatch, fanout } = await bothTargets('yosemite-s0.tail1a85a1.ts.net');
+    expect(dispatch).toBe('muqsit@yosemite-s0.tail1a85a1.ts.net');
+    expect(fanout).toBe(dispatch);
+  });
+
+  it('ad-hoc user@host → identical literal target for both', async () => {
+    const { dispatch, fanout } = await bothTargets('ubuntu@203.0.113.9');
+    expect(dispatch).toBe('ubuntu@203.0.113.9');
+    expect(fanout).toBe(dispatch);
+  });
+});
+
+describe('resolveDeviceTarget — agents ssh grammar', () => {
+  it('returns the full profile for a bare device name', async () => {
+    await addDevice('yosemite-s0');
+    const r = await resolveDeviceTarget('yosemite-s0');
     expect(r?.name).toBe('yosemite-s0');
     expect(r?.user).toBe('muqsit');
     expect(r?.address.dnsName).toBe('yosemite-s0.tail1a85a1.ts.net');
   });
 
-  it('overrides only the login user for user@device (same profile + Tailscale route)', () => {
-    const r = resolveDeviceTarget('root@yosemite-s0', reg);
+  it('overrides only the login user for user@device', async () => {
+    await addDevice('yosemite-s0');
+    const r = await resolveDeviceTarget('root@yosemite-s0');
     expect(r?.name).toBe('yosemite-s0');
-    expect(r?.user).toBe('root'); // overridden
-    expect(r?.address.dnsName).toBe('yosemite-s0.tail1a85a1.ts.net'); // still the registry address
+    expect(r?.user).toBe('root');
+    expect(r?.address.dnsName).toBe('yosemite-s0.tail1a85a1.ts.net');
     expect(r?.auth.method).toBe('key');
   });
 
-  it('synthesizes an ad-hoc profile for a user@host literal (unregistered)', () => {
-    const r = resolveDeviceTarget('ubuntu@203.0.113.9', {});
+  it('synthesizes an ad-hoc profile for a user@ip literal', async () => {
+    const r = await resolveDeviceTarget('ubuntu@203.0.113.9');
     expect(r?.user).toBe('ubuntu');
     expect(r?.address.ip).toBe('203.0.113.9');
     expect(r?.address.dnsName).toBeUndefined();
-    expect(r?.auth.method).toBe('key');
   });
 
-  it('synthesizes an ad-hoc profile for a dotted hostname literal', () => {
-    const r = resolveDeviceTarget('box.example.com', {});
+  it('synthesizes an ad-hoc profile for a dotted hostname literal', async () => {
+    const r = await resolveDeviceTarget('box.example.com');
     expect(r?.address.dnsName).toBe('box.example.com');
     expect(r?.user).toBeUndefined();
   });
 
-  it('returns undefined for a bare unregistered alias (so the caller says "Unknown device")', () => {
-    // A bare word with no @/dot is a typo, not an ad-hoc host — must NOT be dialed
-    // as a literal `foo`, preserving the strict "Unknown device" behaviour.
-    expect(resolveDeviceTarget('not-a-device', reg)).toBeUndefined();
+  it('returns undefined for a bare unregistered alias ("Unknown device")', async () => {
+    expect(await resolveDeviceTarget('not-a-device')).toBeUndefined();
   });
 
-  it('returns undefined for an injection-unsafe token', () => {
-    expect(resolveDeviceTarget('bad;rm -rf', reg)).toBeUndefined();
+  it('returns undefined for an ssh_config-only alias (agents ssh stays devices+literals only)', async () => {
+    writeSshConfig('Host only-in-ssh\n  HostName 10.0.0.9\n');
+    expect(await resolveDeviceTarget('only-in-ssh')).toBeUndefined();
+  });
+
+  it('returns undefined for an injection-unsafe token', async () => {
+    expect(await resolveDeviceTarget('bad;rm -rf')).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/devices/resolve-target.ts
+++ b/apps/cli/src/lib/devices/resolve-target.ts
@@ -1,31 +1,30 @@
 /**
- * The one place a `--host` / `--device` token becomes a real ssh target.
+ * Fan-out + `agents ssh` adapters over the single host/device resolver.
  *
- * A device and a host are the same thing addressed two ways, so resolution must
- * go through the device registry — the single source of truth. A token that
- * names a registered device dials that device's real address (its Tailscale
- * dnsName/ip + user, via `sshTargetFor`), *identical* to the auto-discovery
- * sweep and `agents ssh`. Before this module, the explicit `--host` fan-out
- * instead passed the bare token straight to `ssh`, so `--host yosemite-s0`
- * dialed whatever `~/.ssh/config`/LAN DNS resolved `yosemite-s0` to — a
- * different route than the sweep's `yosemite-s0.<tailnet>.ts.net`. That
- * divergence broke ControlMaster socket reuse (different target → different
- * `%C` hash → a cold dial every time) and could read a perfectly reachable box
- * as "unreachable" when only the non-Tailscale route was down.
+ * Every `--host` / `--device` token becomes a concrete target through one core,
+ * {@link matchHost} in ../hosts/registry.ts — the merged directory that reads the
+ * devices registry, the agents.yaml overlay, AND ssh_config (RUSH-1967). This
+ * module is only the two thin adapters the fan-out and interactive-ssh paths
+ * need on top of that core:
+ *   - {@link resolveExplicitTargets} — a token list → dialable `{target, machine,
+ *     name, os}` rows, so `sessions --host` / session bundles / remote agents-json
+ *     dial the exact same address (and machine id) `run --host` does.
+ *   - {@link resolveDeviceTarget} — a token → the full {@link DeviceProfile}
+ *     `agents ssh` needs (auth, shell, tailscale metadata), with the same
+ *     grammar; a bare unregistered alias returns undefined ("Unknown device").
  *
- * The grammar is uniform across the fleet: `mac-mini` (device name), and
- * `muqsit@mac-mini` (same device, login user overridden) both resolve through
- * the registry to the device's Tailscale route — the `user@` form no longer
- * short-circuits to a bare `ssh muqsit@mac-mini` (LAN DNS). A `user@host` that
- * matches no registered device falls back to a literal target so ad-hoc boxes
- * still work.
+ * The grammar is uniform across the fleet: `name`, `user@name` (same device,
+ * login user overridden), a tailnet FQDN, an ssh_config alias, and an ad-hoc
+ * `user@host` all resolve identically no matter which subcommand called.
  */
 import chalk from 'chalk';
-import { assertValidSshTarget } from '../ssh-exec.js';
+import { sshTargetFor } from '../hosts/types.js';
+import { matchHost, splitUserHost } from '../hosts/registry.js';
 import { normalizeHost } from '../machine-id.js';
 import { resolveRemoteOsSync } from '../hosts/remote-os.js';
-import { sshTargetFor } from './connect.js';
-import { loadDevices, type DeviceProfile, type DeviceRegistry } from './registry.js';
+import { type DeviceProfile } from './registry.js';
+
+export { splitUserHost };
 
 /** A dialable peer: the ssh target, the machine id used to tag its rows, a
  * display name, and the OS family that picks the remote shell dialect. */
@@ -36,63 +35,9 @@ export interface ResolvedSshTarget {
   os?: string;
 }
 
-/** Split a `user@host` / `host` token into its login user (if any) and host part. */
-export function splitUserHost(token: string): { user?: string; host: string } {
-  const at = token.indexOf('@');
-  return at === -1 ? { host: token } : { user: token.slice(0, at), host: token.slice(at + 1) };
-}
-
-/**
- * Match a host part (the piece after any `user@`) to a registered device: exact
- * registry key first, then a normalized-host match so `yosemite-s0` and
- * `yosemite-s0.<tailnet>.ts.net` land on the same profile. The single source of
- * truth both `resolveSshTarget` (fan-out) and `resolveDeviceTarget` (`agents
- * ssh`) share, so a `user@device` can never resolve two different routes.
- */
-function matchDevice(host: string, reg: DeviceRegistry): DeviceProfile | undefined {
-  return reg[host] ?? Object.values(reg).find((d) => normalizeHost(d.name) === normalizeHost(host));
-}
-
-/**
- * Resolve one `--host`/`--device` token to a concrete ssh target through the
- * registry. Registry hit → the device's real address + platform (so the machine
- * id, route, and OS all match the auto-discovery sweep), with any `user@`
- * overriding the login account. Miss → a literal `user@host` fallback, its OS
- * taken from the host overlay if enrolled. Returns undefined only when the token
- * fails the shared ssh-target injection guard.
- */
-export function resolveSshTarget(token: string, reg: DeviceRegistry): ResolvedSshTarget | undefined {
-  try {
-    assertValidSshTarget(token);
-  } catch {
-    return undefined;
-  }
-  const { user, host } = splitUserHost(token);
-  // A device and a `user@device` are the same box; resolve the host part through
-  // the registry so both dial the Tailscale route, and let an explicit `user@`
-  // override only the login account.
-  const device = matchDevice(host, reg);
-  if (device) {
-    try {
-      const effective = user ? { ...device, user } : device;
-      return { target: sshTargetFor(effective), machine: normalizeHost(device.name), name: device.name, os: device.platform };
-    } catch {
-      // Registered but has no address to dial — fall through to the literal token.
-    }
-  }
-  return { target: token, machine: normalizeHost(host), name: token, os: resolveRemoteOsSync(token) };
-}
-
 /** Timestamps for a synthesized ad-hoc profile — never persisted, so a constant
  * keeps the value deterministic (and side-effect free) without reading the clock. */
 const SYNTH_TS = '1970-01-01T00:00:00.000Z';
-
-/** True when a token is clearly a network target (a `user@`, or a dotted/IPv6
- * host / IP) rather than a bare alias. A bare unknown word is a typo, so `agents
- * ssh foo` still says "Unknown device" instead of dialing a literal `foo`. */
-function looksLikeHostLiteral(token: string): boolean {
-  return token.includes('@') || token.includes('.') || token.includes(':');
-}
 
 /** Synthesize a throwaway device profile for an ad-hoc `user@host` / `host`
  * literal so `agents ssh` can dial a box that was never registered. */
@@ -111,46 +56,64 @@ function adHocDevice(token: string, host: string, user?: string): DeviceProfile 
 }
 
 /**
- * Resolve a target token to a full {@link DeviceProfile} for `agents ssh`. Same
- * grammar as {@link resolveSshTarget}, but returns the whole profile (auth,
- * shell, tailscale metadata) `buildSshInvocation` needs — not just a target
- * string. A registered `name` or `user@device` yields that profile (with the
- * login user overridden by any `user@`); an ad-hoc `user@host`/`host` literal
- * yields a synthesized key-auth profile. A bare unregistered alias (no `@`/dot)
- * returns undefined so the caller reports "Unknown device" rather than dialing a
- * literal — the strict behaviour the interactive wrapper has always had.
+ * Resolve one token to a dialable {@link ResolvedSshTarget}, or undefined when it
+ * fails the injection guard or names nothing reachable. A registered device (or
+ * `user@device`) dials its live Tailscale route; an ssh_config-only alias dials
+ * by its bare name (ssh applies the stanza) — now visible to the fan-out too; an
+ * ad-hoc `user@host` dials the literal.
  */
-export function resolveDeviceTarget(token: string, reg: DeviceRegistry): DeviceProfile | undefined {
+async function toResolvedTarget(token: string): Promise<ResolvedSshTarget | undefined> {
+  const host = await matchHost(token);
+  if (!host) return undefined;
+  let target: string;
   try {
-    assertValidSshTarget(token);
+    target = sshTargetFor(host);
   } catch {
-    return undefined;
+    return undefined; // matched a device/host with no address to dial
   }
-  const { user, host } = splitUserHost(token);
-  const device = matchDevice(host, reg);
-  if (device) return user ? { ...device, user } : device;
-  if (looksLikeHostLiteral(token)) return adHocDevice(token, host, user);
+  const hostPart = host.device ? host.device.name : splitUserHost(host.name).host;
+  const name = host.device ? host.device.name : host.name;
+  return { target, machine: normalizeHost(hostPart), name, os: host.os ?? resolveRemoteOsSync(name) };
+}
+
+/**
+ * Resolve a target token to a full {@link DeviceProfile} for `agents ssh`. Same
+ * grammar as the fan-out, but returns the whole profile (auth, shell, tailscale
+ * metadata) `buildSshInvocation` needs. A registered `name` / `user@device`
+ * yields that profile (login user overridden by any `user@`); an ad-hoc
+ * `user@host` / IP / FQDN literal yields a synthesized key-auth profile. A bare
+ * unregistered alias (no `@`/dot) — or an ssh_config-only alias, which `agents
+ * ssh` has never dialed — returns undefined so the caller reports "Unknown
+ * device" rather than dialing a literal.
+ */
+export async function resolveDeviceTarget(token: string): Promise<DeviceProfile | undefined> {
+  const host = await matchHost(token, { allowBareLiteral: true });
+  if (!host) return undefined;
+  if (host.device) {
+    const { user } = splitUserHost(token);
+    return user ? { ...host.device, user } : host.device;
+  }
+  if (host.adhoc) {
+    const { user, host: hostPart } = splitUserHost(token);
+    return adHocDevice(token, hostPart, user);
+  }
+  // An overlay / ssh_config-only match is not a device — `agents ssh` stays
+  // devices-and-literals only, so report it as unknown.
   return undefined;
 }
 
 /**
- * Resolve an explicit `--host`/`--device` list to dialable targets, reading the
- * registry once. A token that fails the injection guard is skipped with a
- * stderr note (never fatal — one bad token must not blank the fan-out). Shared
- * by every cross-machine fan-out so they can never diverge onto two routes.
+ * Resolve an explicit `--host`/`--device` list to dialable targets. A token that
+ * fails the injection guard or names nothing reachable is skipped with a stderr
+ * note (never fatal — one bad token must not blank the fan-out). Shared by every
+ * cross-machine fan-out so they can never diverge onto two routes.
  */
 export async function resolveExplicitTargets(hosts: string[]): Promise<ResolvedSshTarget[]> {
-  let reg: DeviceRegistry;
-  try {
-    reg = await loadDevices();
-  } catch {
-    reg = {};
-  }
   const out: ResolvedSshTarget[] = [];
   for (const h of hosts) {
-    const resolved = resolveSshTarget(h, reg);
+    const resolved = await toResolvedTarget(h);
     if (!resolved) {
-      process.stderr.write(chalk.gray(`  ${h}: not a valid ssh target — skipped\n`));
+      process.stderr.write(chalk.gray(`  ${h}: not a resolvable ssh target — skipped\n`));
       continue;
     }
     out.push(resolved);

--- a/apps/cli/src/lib/hosts/providers/devices.test.ts
+++ b/apps/cli/src/lib/hosts/providers/devices.test.ts
@@ -91,7 +91,7 @@ describe('DevicesHostProvider.list', () => {
 });
 
 describe('devices in the unified pool', () => {
-  it('listAllHosts includes devices; a same-name enrolled host shadows the device', async () => {
+  it('listAllHosts merges a same-name enrolled host with the device, per-field', async () => {
     await upsertDevice('shared-name', {
       platform: 'linux',
       user: 'device-user',
@@ -106,9 +106,16 @@ describe('devices in the unified pool', () => {
     const all = await listAllHosts();
     const rows = all.filter((h) => h.name === 'shared-name');
     expect(rows).toHaveLength(1);
-    // local registers before devices — the enrolled entry wins.
+    // `local` registers first, so the enrolled overlay is still the BASE row —
+    // it keeps provider/source/caps/addedAt.
     expect(rows[0].provider).toBe('local');
-    expect(rows[0].address).toBe('10.0.0.9');
+    // …but the device owns the connection fields (RUSH-1967). This assertion used
+    // to expect the overlay's '10.0.0.9', which encoded the frozen-route bug as a
+    // contract: `agents devices sync` could move a device and the stale enrolled
+    // address would keep winning — and `resolveHostByCap` hands this very row to
+    // dispatch, so `--host <cap>` dialed the dead address.
+    expect(rows[0].address).toBe('shared.tail.ts.net');
+    expect(rows[0].user).toBe('device-user');
   });
 
   it('cap routing reaches a device enrolled with a tag (the hosts-add-from-device path)', async () => {

--- a/apps/cli/src/lib/hosts/registry.test.ts
+++ b/apps/cli/src/lib/hosts/registry.test.ts
@@ -23,17 +23,27 @@ import * as path from 'path';
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-host-resolve-test-'));
 process.env.HOME = TEST_HOME;
 
-const { resolveHost, DeviceOffloadUnsupportedError } = await import('./registry.js');
+const { resolveHost, listAllHosts, DeviceOffloadUnsupportedError } = await import('./registry.js');
 const { sshTargetFor } = await import('./types.js');
 const { upsertDevice } = await import('../devices/registry.js');
+const { updateMeta } = await import('../state.js');
 
 function registryPath(): string {
   return path.join(TEST_HOME, '.agents', '.history', 'devices', 'registry.json');
+}
+function metaPath(): string {
+  return path.join(TEST_HOME, '.agents', 'agents.yaml');
+}
+function writeSshConfig(text: string): void {
+  fs.mkdirSync(path.join(TEST_HOME, '.ssh'), { recursive: true });
+  fs.writeFileSync(path.join(TEST_HOME, '.ssh', 'config'), text);
 }
 
 beforeEach(async () => {
   fs.rmSync(registryPath(), { force: true });
   fs.rmSync(`${registryPath()}.lock`, { recursive: true, force: true });
+  fs.rmSync(metaPath(), { force: true });
+  fs.rmSync(path.join(TEST_HOME, '.ssh', 'config'), { force: true });
 });
 
 afterAll(() => {
@@ -102,5 +112,120 @@ describe('resolveHost — password-auth device', () => {
     // the raw stack trace at hosts/secrets call sites.
     const err = await resolveHost('win-mini').catch((e) => e as Error);
     expect(err.name).toBe('DeviceOffloadUnsupportedError');
+  });
+});
+
+describe('resolveHost — merge, not shadow (RUSH-1967)', () => {
+  it('an enrolled device dials the LIVE registry address, not the overlay snapshot (frozen-route fix)', async () => {
+    await upsertDevice('mac-mini', {
+      platform: 'macos',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' },
+      auth: { method: 'key' },
+    });
+    // `agents hosts add mac-mini --cap gpu` froze a stale address into the overlay.
+    updateMeta((m) => ({ ...m, hosts: { 'mac-mini': { source: 'inline', address: 'mac-mini.OLD.ts.net', user: 'muqsit', caps: ['gpu'] } } }));
+
+    const host = await resolveHost('mac-mini');
+    // Address comes from the live device registry, not the overlay snapshot…
+    expect(sshTargetFor(host!)).toBe('muqsit@mac-mini.tail1a85a1.ts.net');
+    // …while the overlay still contributes the capability tag.
+    expect(host!.caps).toEqual(['gpu']);
+  });
+
+  it('a device keeps its presence + dispatchable when an inline overlay shadows it', async () => {
+    await upsertDevice('yosemite-s0', {
+      platform: 'linux',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'yosemite-s0.tail1a85a1.ts.net' },
+      auth: { method: 'key' },
+      tailscale: { online: true, direct: true },
+    });
+    updateMeta((m) => ({ ...m, hosts: { 'yosemite-s0': { source: 'inline', address: 'yosemite-s0.tail1a85a1.ts.net', caps: ['builder'] } } }));
+
+    const host = await resolveHost('yosemite-s0');
+    expect(host!.status).toBe('online');
+    expect(host!.dispatchable).toBe(true);
+    expect(host!.caps).toEqual(['builder']);
+  });
+
+  it('an inline overlay cannot make a password-auth device dispatchable (guard-bypass fix)', async () => {
+    await upsertDevice('winbox', {
+      platform: 'windows',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'winbox.tail1a85a1.ts.net' },
+      auth: { method: 'password', bundle: 'muqsit' },
+    });
+    // `agents hosts add winbox muqsit@winbox` writes an inline entry that used to
+    // shadow the device and bypass the typed refusal — an ssh-layer hang.
+    updateMeta((m) => ({ ...m, hosts: { winbox: { source: 'inline', address: 'winbox', user: 'muqsit' } } }));
+
+    await expect(resolveHost('winbox')).rejects.toBeInstanceOf(DeviceOffloadUnsupportedError);
+  });
+
+  it('a device wins over a same-name ssh_config stanza (divergence #1)', async () => {
+    await upsertDevice('mac-mini', {
+      platform: 'macos',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' },
+      auth: { method: 'key' },
+    });
+    writeSshConfig('Host mac-mini\n  HostName 192.168.1.50\n'); // stale LAN route
+    const host = await resolveHost('mac-mini');
+    // Device Tailscale route wins — NOT the bare `mac-mini` (which ssh would map
+    // to 192.168.1.50 via the stanza).
+    expect(sshTargetFor(host!)).toBe('muqsit@mac-mini.tail1a85a1.ts.net');
+  });
+});
+
+describe('resolveHost — ssh_config grammar', () => {
+  it('resolves a bare ssh_config alias to its bare name (ssh applies the stanza)', async () => {
+    writeSshConfig('Host bastion\n  HostName 10.0.0.1\n  User ops\n');
+    const host = await resolveHost('bastion');
+    expect(host).not.toBeNull();
+    expect(sshTargetFor(host!)).toBe('bastion');
+  });
+
+  it('resolves user@device through the overlay/registry grammar the old exact-key chain lacked', async () => {
+    await upsertDevice('mac-mini', {
+      platform: 'macos',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' },
+      auth: { method: 'key' },
+    });
+    const host = await resolveHost('root@mac-mini');
+    expect(sshTargetFor(host!)).toBe('root@mac-mini.tail1a85a1.ts.net');
+  });
+});
+
+describe('listAllHosts — merge same-name rows (RUSH-1967)', () => {
+  it('keeps the device status + dispatchable on an enrolled row instead of dropping them', async () => {
+    await upsertDevice('yosemite-s0', {
+      platform: 'linux',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'yosemite-s0.tail1a85a1.ts.net' },
+      auth: { method: 'key' },
+      tailscale: { online: true, direct: true },
+    });
+    updateMeta((m) => ({ ...m, hosts: { 'yosemite-s0': { source: 'inline', address: 'yosemite-s0.tail1a85a1.ts.net', caps: ['builder'] } } }));
+
+    const rows = (await listAllHosts()).filter((h) => h.name === 'yosemite-s0');
+    expect(rows).toHaveLength(1); // not two rows, and not a dropped device row
+    expect(rows[0].caps).toEqual(['builder']); // overlay caps preserved
+    expect(rows[0].status).toBe('online'); // device presence adopted
+    expect(rows[0].dispatchable).toBe(true); // device dispatchable adopted
+  });
+
+  it('a password-auth device behind an inline overlay stays non-dispatchable in listings', async () => {
+    await upsertDevice('winbox', {
+      platform: 'windows',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'winbox.tail1a85a1.ts.net' },
+      auth: { method: 'password', bundle: 'muqsit' },
+    });
+    updateMeta((m) => ({ ...m, hosts: { winbox: { source: 'inline', address: 'winbox', user: 'muqsit', caps: ['gpu'] } } }));
+
+    const row = (await listAllHosts()).find((h) => h.name === 'winbox');
+    expect(row?.dispatchable).toBe(false);
   });
 });

--- a/apps/cli/src/lib/hosts/registry.test.ts
+++ b/apps/cli/src/lib/hosts/registry.test.ts
@@ -228,4 +228,44 @@ describe('listAllHosts — merge same-name rows (RUSH-1967)', () => {
     const row = (await listAllHosts()).find((h) => h.name === 'winbox');
     expect(row?.dispatchable).toBe(false);
   });
+
+  it('the LIVE device address wins over a stale enrolled overlay address', async () => {
+    // The frozen-route bug, via listAllHosts rather than resolveHost: enrol a
+    // device to tag it, then let `agents devices sync` move its address. The
+    // overlay keeps the OLD address forever (nothing rewrites it), so a merge
+    // that prefers the overlay serves a dead route. This matters beyond display
+    // because resolveHostByCap hands a listAllHosts() row straight to dispatch.
+    await upsertDevice('mac-mini', {
+      platform: 'macos',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'mac-mini.NEW.ts.net' },
+      auth: { method: 'key' },
+      tailscale: { online: true, direct: true },
+    });
+    updateMeta((m) => ({
+      ...m,
+      hosts: { 'mac-mini': { source: 'inline', address: 'mac-mini.OLD.ts.net', user: 'muqsit', caps: ['gpu'] } },
+    }));
+
+    const row = (await listAllHosts()).find((h) => h.name === 'mac-mini');
+    expect(row?.address).toBe('mac-mini.NEW.ts.net'); // live registry, not the snapshot
+    expect(row?.caps).toEqual(['gpu']); // overlay still owns capability tags
+  });
+
+  it('cap-tag routing dispatches to the live device address, not the stale overlay', async () => {
+    await upsertDevice('mac-mini', {
+      platform: 'macos',
+      user: 'muqsit',
+      address: { via: 'tailscale', dnsName: 'mac-mini.NEW.ts.net' },
+      auth: { method: 'key' },
+      tailscale: { online: true, direct: true },
+    });
+    updateMeta((m) => ({
+      ...m,
+      hosts: { 'mac-mini': { source: 'inline', address: 'mac-mini.OLD.ts.net', user: 'muqsit', caps: ['gpu'] } },
+    }));
+
+    const { resolveHostByCap } = await import('./registry.js');
+    expect(sshTargetFor(await resolveHostByCap('gpu'))).toBe('muqsit@mac-mini.NEW.ts.net');
+  });
 });

--- a/apps/cli/src/lib/hosts/registry.ts
+++ b/apps/cli/src/lib/hosts/registry.ts
@@ -1,17 +1,33 @@
 /**
- * Host provider registry.
+ * Host provider registry + the single host/device resolver.
  *
  * Mirrors the cloud provider registry: a Map of provider id → implementation,
- * instantiated once. Registers `local` then `devices` (order is precedence:
- * an enrolled host shadows a same-name device); adding `rush`/`crabbox` later
- * is a one-line `providers.set(...)` with no caller changes.
+ * instantiated once. Registers `local` then `devices`; adding `rush`/`crabbox`
+ * later is a one-line `providers.set(...)`.
+ *
+ * Resolution used to fork into two disagreeing chains — a local-provider-first
+ * `resolveHost` (this file) and a devices-only `resolveSshTarget`
+ * (`../devices/resolve-target.ts`). They dialed different boxes for the same
+ * token (RUSH-1967). Now every caller goes through one core, {@link matchHost}:
+ * it merges the two directories per-FIELD instead of letting one provider
+ * shadow the other — the live devices registry supplies address/OS/presence,
+ * the agents.yaml overlay supplies caps/hints, and ssh_config supplies hosts
+ * Tailscale has never seen. The typed wrappers below (`resolveHost`) and in
+ * resolve-target.ts (`resolveExplicitTargets`, `resolveDeviceTarget`) differ
+ * only in what shape they hand back and which literal fallbacks they permit.
  */
 
 import type { Host, HostProvider, HostProviderId } from './types.js';
+import type { HostEntry } from '../types.js';
 import { DeviceOffloadUnsupportedError } from './types.js';
 import { LocalHostProvider } from './providers/local.js';
 import { DevicesHostProvider } from './providers/devices.js';
 import { assertValidSshTarget } from '../ssh-exec.js';
+import { normalizeHost } from '../machine-id.js';
+import { readMeta } from '../state.js';
+import { isSshConfigHost } from './ssh-config.js';
+import { resolveRemoteOsSync } from './remote-os.js';
+import { loadDevices, isControlDevice, type DeviceProfile, type DeviceRegistry } from '../devices/registry.js';
 
 // Re-export so existing importers (tests, commands) keep their path; the class
 // itself lives in types.ts so providers can throw it without a circular import.
@@ -39,43 +55,237 @@ export function getAllProviders(): HostProvider[] {
   return [...providers.values()];
 }
 
-/** Every host across all registered providers, deduped by name (first wins). */
-export async function listAllHosts(): Promise<Host[]> {
-  const seen = new Set<string>();
-  const out: Host[] = [];
-  for (const provider of getAllProviders()) {
-    for (const host of await provider.list()) {
-      if (seen.has(host.name)) continue;
-      seen.add(host.name);
-      out.push(host);
-    }
-  }
-  return out;
+/**
+ * A resolved host, carrying the live {@link DeviceProfile} when the token
+ * matched a registered device (by normalized name). The device reference lets
+ * the `agents ssh` wrapper reach auth/shell/tailscale metadata a plain `Host`
+ * doesn't hold, and lets dispatch callers apply the device-only refusals
+ * (control device, password auth) without re-reading the registry.
+ */
+export interface ResolvedHost extends Host {
+  device?: DeviceProfile;
+  /** True when the host is a synthesized ad-hoc `user@host` / IP / FQDN literal
+   * (never registered) rather than a device or overlay/ssh-config match. Lets the
+   * strict `agents ssh` wrapper accept devices + literals but still report
+   * "Unknown device" for a bare ssh-config-only alias, as it always has. */
+  adhoc?: boolean;
+}
+
+/** Split a `user@host` / `host` token into its login user (if any) and host part. */
+export function splitUserHost(token: string): { user?: string; host: string } {
+  const at = token.indexOf('@');
+  return at === -1 ? { host: token } : { user: token.slice(0, at), host: token.slice(at + 1) };
+}
+
+/** True when a token is clearly a network target (a `user@`, or a dotted/IPv6
+ * host / IP) rather than a bare alias. A bare unknown word is a typo, so a
+ * strict caller (`agents ssh foo`) reports "Unknown device" instead of dialing
+ * a literal `foo`. */
+function looksLikeHostLiteral(token: string): boolean {
+  return token.includes('@') || token.includes('.') || token.includes(':');
 }
 
 /**
- * Resolve a host name to a single host, or null if unknown. Resolution order:
- *   1. host providers, in registration order — the `agents hosts` registry
- *      (`local`: agents.yaml overlay + ssh-config), then the devices registry
- *      (`devices`: a machine registered once with `agents devices sync` is
- *      reachable by `--host`/`--device` with no second enroll)
- *   2. an ad-hoc `user@host` (must contain `@`, validated) — nothing to register
- *
- * A bare unknown name returns null so capability-tag routing (`resolveHostByCap`)
- * stays reachable: `--host gpu` must fall through to a cap lookup, not be misread
- * as an ad-hoc target.
+ * Match a host part (the piece after any `user@`) to a registered device: exact
+ * registry key first, then a normalized-host match so `yosemite-s0` and
+ * `yosemite-s0.<tailnet>.ts.net` land on the same profile. This normalized
+ * grammar used to live only in the devices chain (RUSH-1967 divergence #3/#4);
+ * it is now shared by every caller.
  */
-export async function resolveHost(name: string): Promise<Host | null> {
-  for (const provider of getAllProviders()) {
-    const host = await provider.resolve(name);
-    if (host) return host;
-  }
-  if (name.includes('@')) {
+function matchDevice(host: string, reg: DeviceRegistry): DeviceProfile | undefined {
+  return reg[host] ?? Object.values(reg).find((d) => normalizeHost(d.name) === normalizeHost(host));
+}
+
+/** Tailscale's own presence bit for a device, when the sync captured one. */
+function deviceStatus(device: DeviceProfile): Host['status'] {
+  if (!device.tailscale) return 'unknown';
+  return device.tailscale.online ? 'online' : 'offline';
+}
+
+/**
+ * Merge a matched device with any same-name agents.yaml overlay into one Host,
+ * per-FIELD (the core of the RUSH-1967 fix). The live registry owns address, OS
+ * and presence — so `agents devices sync` takes effect without re-enrolling and
+ * an enrolled route can never freeze — while the overlay contributes capability
+ * tags (the reason to enroll at all) and an OS hint when the device platform is
+ * unknown. `dispatchable` follows the device's auth method, so a password-auth
+ * device can never be made dispatchable by shadowing it with an inline entry.
+ */
+function deviceHost(device: DeviceProfile, user: string | undefined, overlay?: HostEntry): ResolvedHost {
+  const address = device.address.dnsName ?? device.address.ip;
+  return {
+    name: device.name,
+    provider: 'devices',
+    source: 'inline',
+    ...(address ? { address } : {}),
+    user: user ?? device.user,
+    os: device.platform !== 'unknown' ? device.platform : overlay?.os,
+    ...(overlay?.caps?.length ? { caps: overlay.caps } : {}),
+    enrolled: true,
+    status: deviceStatus(device),
+    dispatchable: device.auth.method !== 'password',
+    device,
+  };
+}
+
+/** Build a Host from a bare overlay entry (inline or ssh-config), applying any
+ * `user@` override. Inline/ssh-config hosts authenticate over key / ssh-config,
+ * so they are dispatchable; presence is unknown without an explicit probe. */
+function overlayHost(name: string, entry: HostEntry, user?: string): ResolvedHost {
+  return {
+    name,
+    provider: 'local',
+    enrolled: true,
+    source: entry.source,
+    ...(entry.address ? { address: entry.address } : {}),
+    user: user ?? entry.user,
+    ...(entry.os ? { os: entry.os } : {}),
+    ...(entry.caps?.length ? { caps: entry.caps } : {}),
+    ...(entry.addedAt ? { addedAt: entry.addedAt } : {}),
+    status: 'unknown',
+    dispatchable: true,
+  };
+}
+
+/** Synthesize an ad-hoc inline Host for a `user@host` / `host` literal so a box
+ * that was never registered still dials. sshTargetFor emits `user@address`. */
+function literalHost(token: string, host: string, user?: string): ResolvedHost {
+  return {
+    name: token,
+    provider: 'local',
+    source: 'inline',
+    address: host,
+    ...(user ? { user } : {}),
+    status: 'unknown',
+    dispatchable: true,
+    adhoc: true,
+  };
+}
+
+/** Literal-fallback policy for {@link matchHost}. */
+export interface MatchHostOptions {
+  /**
+   * Also treat an unmatched dotted/colon host literal (a raw IP or FQDN with no
+   * `user@`) as an ad-hoc target. `agents ssh 1.2.3.4` sets this; dispatch and
+   * fan-out leave it off, so only a `user@host` is taken as an ad-hoc literal
+   * (a bare/dotted unknown is a miss, keeping capability-tag routing and the
+   * "Unknown device" verdict reachable).
+   */
+  allowBareLiteral?: boolean;
+}
+
+/**
+ * The one place a `--host` / `--device` token becomes a resolved host. Reads the
+ * devices registry, the agents.yaml overlay, and ssh_config, and merges them
+ * per-field (see {@link deviceHost}). One grammar for every caller: `name`,
+ * `user@name`, a tailnet FQDN, an ssh_config alias, and a literal `user@host`
+ * all resolve the same way regardless of which subcommand called.
+ *
+ * Non-throwing: returns null on an injection-guard failure or an unresolved bare
+ * token. Device-only refusals (control device, password auth) are NOT applied
+ * here — that is the dispatch wrapper's job ({@link resolveHost}), so the fan-out
+ * and `agents ssh` paths, which handle those cases differently, aren't forced
+ * into a dispatch verdict.
+ */
+export async function matchHost(name: string, opts: MatchHostOptions = {}): Promise<ResolvedHost | null> {
+  try {
     assertValidSshTarget(name);
-    const at = name.indexOf('@');
-    return { name, provider: 'local', source: 'inline', user: name.slice(0, at), address: name.slice(at + 1) };
+  } catch {
+    return null;
+  }
+  const { user, host } = splitUserHost(name);
+
+  let reg: DeviceRegistry;
+  try {
+    reg = await loadDevices();
+  } catch {
+    reg = {};
+  }
+  const overlay = readMeta().hosts?.[host];
+
+  // 1. A registered device (normalized match) — its live address/OS/presence win.
+  const device = matchDevice(host, reg);
+  if (device) return deviceHost(device, user, overlay);
+
+  // 2. An agents.yaml overlay entry keyed by the host part (inline or ssh-config).
+  if (overlay) return overlayHost(host, overlay, user);
+
+  // 3. A bare ssh_config alias Tailscale has never seen — dial by name (ssh
+  //    applies the stanza). A `user@alias` is handled as a literal below so the
+  //    `user@` reaches ssh, which overrides the stanza's User.
+  if (!user && isSshConfigHost(host)) {
+    return { name: host, provider: 'local', source: 'ssh-config', os: resolveRemoteOsSync(host), status: 'unknown', dispatchable: true };
+  }
+
+  // 4. An ad-hoc literal target. `user@host` always; a bare IP/FQDN only when the
+  //    caller opted in (`agents ssh`). A bare unknown word is a miss (null).
+  if (name.includes('@') || (opts.allowBareLiteral && looksLikeHostLiteral(name))) {
+    assertValidSshTarget(name);
+    return literalHost(name, host, user);
   }
   return null;
+}
+
+/** Every host across all registered providers, merged by name so a device's
+ * presence/dispatchable/address and an overlay's caps coexist on one row
+ * (RUSH-1967: first-wins dedup used to drop the device row, and its status/caps
+ * with it). Provider order still decides the base row (`local` first). */
+export async function listAllHosts(): Promise<Host[]> {
+  const byName = new Map<string, Host>();
+  for (const provider of getAllProviders()) {
+    for (const host of await provider.list()) {
+      const prev = byName.get(host.name);
+      if (!prev) {
+        byName.set(host.name, host);
+        continue;
+      }
+      // Same name from a later provider (a device behind an enrolled overlay):
+      // keep the overlay's caps/source but adopt the device's live presence,
+      // dispatchable bit, address, and OS so an enrolled device doesn't lose them.
+      byName.set(host.name, {
+        ...prev,
+        address: prev.address ?? host.address,
+        user: prev.user ?? host.user,
+        os: prev.os ?? host.os,
+        status: prev.status ?? host.status,
+        dispatchable: prev.dispatchable ?? host.dispatchable,
+      });
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Resolve a `--host`/`--device` token for DISPATCH — the shape every offload
+ * caller consumes (`run --host`, the generic passthrough, teams placement, the
+ * cloud host provider, doctor, funnel, remote secrets). Grammar and merge come
+ * from {@link matchHost}; on top, this layer applies the device-only dispatch
+ * refusals so they hold even when an inline overlay shadows the device:
+ *   - a control device (a paired iPhone) can never be a dispatch target;
+ *   - a password-auth device throws the typed {@link DeviceOffloadUnsupportedError}
+ *     (offload rides `BatchMode=yes` ssh, which can't answer a prompt);
+ *   - an addressless device has nothing to dial.
+ *
+ * A bare unknown name returns null so capability-tag routing (`resolveHostByCap`,
+ * e.g. `--host gpu`) stays reachable, and an ad-hoc `user@host` still resolves.
+ */
+export async function resolveHost(name: string): Promise<Host | null> {
+  const host = await matchHost(name);
+  if (!host) return null;
+  if (host.device) {
+    if (isControlDevice(host.device)) {
+      throw new Error(
+        `Device "${host.device.name}" is a control device (a cockpit), not an executor — it can't run agents. Dispatch to a worker device instead.`,
+      );
+    }
+    if (host.device.auth.method === 'password') {
+      throw new DeviceOffloadUnsupportedError(host.device.name);
+    }
+    if (!host.address) {
+      throw new Error(`Device "${host.device.name}" has no address (Tailscale DNS name or IP) to reach it by.`);
+    }
+  }
+  return host;
 }
 
 /**

--- a/apps/cli/src/lib/hosts/registry.ts
+++ b/apps/cli/src/lib/hosts/registry.ts
@@ -240,15 +240,20 @@ export async function listAllHosts(): Promise<Host[]> {
         continue;
       }
       // Same name from a later provider (a device behind an enrolled overlay):
-      // keep the overlay's caps/source but adopt the device's live presence,
-      // dispatchable bit, address, and OS so an enrolled device doesn't lose them.
+      // `prev` is the local/overlay row (`local` registers first), `host` is the
+      // live device row. Keep the overlay's caps/source/addedAt as the base, but
+      // the DEVICE wins every field it owns — address, user, OS, presence and
+      // dispatchable — so this matches `deviceHost()`'s per-field precedence and
+      // an enrolled device can never serve a frozen address. Getting this
+      // backwards reintroduced the frozen route through `resolveHostByCap`,
+      // which hands a `listAllHosts()` row straight to dispatch.
       byName.set(host.name, {
         ...prev,
-        address: prev.address ?? host.address,
-        user: prev.user ?? host.user,
-        os: prev.os ?? host.os,
-        status: prev.status ?? host.status,
-        dispatchable: prev.dispatchable ?? host.dispatchable,
+        address: host.address ?? prev.address,
+        user: host.user ?? prev.user,
+        os: host.os ?? prev.os,
+        status: host.status ?? prev.status,
+        dispatchable: host.dispatchable ?? prev.dispatchable,
       });
     }
   }

--- a/apps/cli/src/lib/secrets/remote.test.ts
+++ b/apps/cli/src/lib/secrets/remote.test.ts
@@ -30,7 +30,7 @@ vi.mock('../events.js', () => ({ emit: emitMock }));
 import {
   parseHostsOption,
   splitBundleRef,
-  resolveSshTarget,
+  resolveHostSshTarget,
   remoteSecretsRaw,
   remoteResolveEnv,
   isDangerousRemoteEnvKey,
@@ -84,20 +84,20 @@ describe('splitBundleRef', () => {
   });
 });
 
-describe('resolveSshTarget', () => {
+describe('resolveHostSshTarget', () => {
   it('resolves an enrolled host through the registry', async () => {
     resolveHostMock.mockResolvedValue({ source: 'ssh-config', name: 'yosemite-s1' });
-    expect(await resolveSshTarget('Y1')).toBe('yosemite-s1');
+    expect(await resolveHostSshTarget('Y1')).toBe('yosemite-s1');
   });
 
   it('falls back to a raw ssh target when the registry misses', async () => {
     resolveHostMock.mockResolvedValue(null);
-    expect(await resolveSshTarget('muqsit@box')).toBe('muqsit@box');
+    expect(await resolveHostSshTarget('muqsit@box')).toBe('muqsit@box');
   });
 
   it('rejects an injection-shaped raw target', async () => {
     resolveHostMock.mockResolvedValue(null);
-    await expect(resolveSshTarget('a;rm -rf /')).rejects.toThrow();
+    await expect(resolveHostSshTarget('a;rm -rf /')).rejects.toThrow();
   });
 });
 

--- a/apps/cli/src/lib/secrets/remote.ts
+++ b/apps/cli/src/lib/secrets/remote.ts
@@ -60,11 +60,14 @@ function osForTarget(target: string, lookupName?: string): string | undefined {
 }
 
 /**
- * Resolve a `--host` value to an ssh target string. Tries the `agents hosts`
- * registry first (enrolled name → ssh-config alias / `user@host`); on a miss,
- * treats the value as a raw ssh target and validates it against injection.
+ * Resolve a `--host` value to an ssh target STRING for the remote-secrets path.
+ * Delegates to the single host/device resolver (`resolveHost`, RUSH-1967) so a
+ * name here dials the exact same box `run --host` does; on a miss, treats the
+ * value as a raw ssh target and validates it against injection. Named distinctly
+ * from `../devices/resolve-target.ts` (which returns richer shapes) so importing
+ * the wrong one can't silently change which machine you dial.
  */
-export async function resolveSshTarget(nameOrAlias: string): Promise<string> {
+export async function resolveHostSshTarget(nameOrAlias: string): Promise<string> {
   const host = await resolveHost(nameOrAlias);
   if (host) return sshTargetFor(host);
   assertValidSshTarget(nameOrAlias);


### PR DESCRIPTION
Closes RUSH-1967.

## Problem

A `--host` / `--device` token became an ssh target through **two independent chains that disagreed**, so which machine a name meant depended on which subcommand you typed.

- **Chain 1 — `resolveHost`** (`apps/cli/src/lib/hosts/registry.ts:68`), local-provider-first. Used by `run --host` (`commands/exec.ts`), the generic passthrough (`lib/hosts/passthrough.ts:155`), teams placement (`lib/teams/agents.ts:1917,2030`), the cloud host provider, doctor, funnel, and remote secrets (`lib/secrets/remote.ts:68`).
- **Chain 2 — `resolveSshTarget`/`resolveDeviceTarget`** (`apps/cli/src/lib/devices/resolve-target.ts:64,123`), devices-registry only. Used by `sessions --host` (`lib/session/remote-list.ts:130`), session bundles (`lib/session/remote-bundle.ts:45`), `lib/remote-agents-json.ts:72`, and `agents ssh` (`commands/ssh.ts:1128`).

`resolve-target.ts:1-3` claimed to be *"the one place a `--host` / `--device` token becomes a real ssh target."* It wasn't. Because the two chains emitted different strings for the same box, they also produced different OpenSSH `ControlPath` `%C` hashes and never shared a multiplexed connection.

### The four divergences (each now has a test)

| # | Input | Chain 1 did | Chain 2 did |
|---|---|---|---|
| 1 | name in **both** ssh_config and the device registry | `local` won → bare stanza name (`hosts/types.ts:85-91`) → LAN IP / stale route | dialed the device Tailscale `user@dnsName` (`devices/connect.ts:35`) |
| 2 | name **only** in ssh_config | resolved fine | invisible to the fan-out |
| 3 | `muqsit@mac-mini` | `getDevice` exact-key miss (`devices/registry.ts:234`) → literal → LAN DNS | normalized match → registry route, user overridden (`resolve-target.ts:74-78`) |
| 4 | `yosemite-s0.<tailnet>.ts.net` | exact-key miss → literal | `matchDevice` normalized → the profile (`resolve-target.ts:52-54`) |

Plus the secondary bugs from the same root (local shadows devices): enrolling froze the route (`commands/hosts.ts:141-149`), dropped presence/`dispatchable` (`lib/hosts/providers/local.ts:19-31`), let an inline entry bypass the password-auth `DeviceOffloadUnsupportedError` (`commands/hosts.ts:126-130`), and dropped the device row from `hosts list` (first-wins dedup, `registry.ts:48`). Two exported functions were both named `resolveSshTarget` with opposite semantics (`devices/resolve-target.ts:64` vs `secrets/remote.ts:67`).

## Design — merge, don't shadow

One core resolver, `matchHost` (`apps/cli/src/lib/hosts/registry.ts`), returns a merged `ResolvedHost` (a `Host` carrying the live `DeviceProfile` when the token matched a device). Precedence is **per-field**, not per-provider:

| Field | Source of truth |
|---|---|
| address, OS, presence, `dispatchable` | the live **devices** registry |
| capability tags, OS hint (device platform unknown) | the agents.yaml **overlay** (`Meta.hosts`) |
| a host Tailscale never saw | **ssh_config** (bare name; ssh applies the stanza) |

One grammar for every caller — `name`, `user@name`, a tailnet FQDN, an ssh_config alias, and a literal `user@host` resolve identically, with the normalized/suffix matching that only chain 2 had. Because the address always comes from the live registry, the frozen-route bug is fixed for free; because `dispatchable` follows the device auth method, an inline entry can no longer shadow a password device into being dispatchable.

### Call-site migration map

| Caller | Before | After |
|---|---|---|
| `run --host`, passthrough, teams, cloud, doctor, funnel | `resolveHost(name): Host` | **unchanged signature** — now merge-based + normalized; keeps the control/password refusals |
| `sessions --host`, session bundles, remote agents-json | `resolveExplicitTargets` over devices-only `resolveSshTarget` | delegates to `matchHost`; gains ssh_config visibility + shared grammar |
| `agents ssh` | `resolveDeviceTarget(token, reg)` (sync) | `await resolveDeviceTarget(token)` — devices + literals only, still "Unknown device" for a bare alias |
| remote secrets | `resolveSshTarget` (secrets/remote.ts) | renamed `resolveHostSshTarget`, delegates to `resolveHost` |
| `listAllHosts` | first-wins dedup (dropped the device row) | merges same-name rows (device presence/dispatchable + overlay caps) |

The devices-side `resolveSshTarget` is removed; the secrets-side one is renamed — the duplicate-name trap is gone.

## Testing

Real registries / overlay / `~/.ssh/config`, no mocks (repo convention). New/updated tests cover each divergence row, run-vs-sessions target parity, ssh_config-only fan-out visibility, the enroll-freezes-the-route case, the password-auth-shadow case, and the `listAllHosts` merge (`registry.test.ts`, `devices/__tests__/resolve-target.test.ts`, `secrets/remote.test.ts`).

- `bun test` on the touched files: **58 passed**. `tsc --noEmit`: clean.
- Full suite: the only failures are `session/sync/config.test.ts` (13, time/keychain-state dependent) — pre-existing, fails identically in isolation, imports nothing in this change.

### End-to-end parity (real fleet, this machine)

`run --host X`, `sessions --host X`, and `agents ssh X` resolve to the **same** target for every grammar form against the live device registry:

```
yosemite-s0                     run/sessions/ssh -> muqsit@yosemite-s0.tail1a85a1.ts.net   MATCH
yosemite-s0.tail1a85a1.ts.net   run/sessions/ssh -> muqsit@yosemite-s0.tail1a85a1.ts.net   MATCH
muqsit@yosemite-s0              run/sessions/ssh -> muqsit@yosemite-s0.tail1a85a1.ts.net   MATCH
mac-mini                        run/sessions/ssh -> muqsit@mac-mini.tail1a85a1.ts.net      MATCH
```

Before this change, `muqsit@yosemite-s0` and the tailnet FQDN resolved to a bare-literal LAN route on chain 1 and the Tailscale route on chain 2 (divergences #3/#4).

## Acceptance criteria

- [x] Exactly one exported resolver (`matchHost`); `resolveHost`, devices `resolveSshTarget`, and `resolveDeviceTarget` unified behind it.
- [x] The duplicate `resolveSshTarget` in `secrets/remote.ts` renamed to `resolveHostSshTarget`.
- [x] `run --host X` and `sessions --host X` resolve to the same target for bare name, `user@name`, tailnet FQDN, ssh_config alias, and ad-hoc `user@host`.
- [x] A host only in `~/.ssh/config` is visible to the fan-out.
- [x] An enrolled device's address comes from the live registry; `agents devices sync` takes effect without re-enrolling.
- [x] An enrolled device keeps `status`/`dispatchable`; a password device can't be shadowed into dispatchable.
- [x] Tests cover each divergence row (real registries, no mocks).
- [x] `docs/09-ssh-transport.md` and `docs/hosts.md` updated.

Session transcript (public repo — referenced by path, not attached): `yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz-agents-cli/366addba-b12c-4340-8dae-b3621bf17993.jsonl`
