### PR TITLE
feat(profiles): agents harness — name a (host + model) as a runnable agent type

### DIFF
--- a/apps/cli/.changelog/next/harness-command.md
+++ b/apps/cli/.changelog/next/harness-command.md
@@ -1,0 +1,20 @@
+- **`agents harness` — name a (host CLI + model) combo and run it like a native agent
+  type.** `agents harness add spark --host opencode --model meta/muse-spark-1.1` writes
+  `~/.agents/profiles/spark.yml`, and `agents run spark` then dispatches OpenCode pinned to
+  that model; `--model` at run time still overrides it. A harness is a profile under the
+  hood (same YAML, same run resolution, same `agents repo push user` device sync), so
+  `agents profiles` is unchanged; `harness` adds the host+model one-shot (no preset
+  required), owns its own `--host` (never remote-routed, unlike `profiles --host`), and
+  `agents harness list` shows custom harnesses, addable presets, and the native harness
+  registry in one view. The model lands on the host's model env var
+  (`OPENCODE_MODEL`/`ANTHROPIC_MODEL`/`GROK_MODEL`/`GEMINI_MODEL`). Source:
+  `apps/cli/src/commands/harness.ts`, `apps/cli/src/lib/profiles.ts`,
+  `apps/cli/src/lib/hosts/passthrough.ts`.
+- **Fixed the Spark presets, which never ran.** `claude-spark`, `opencode-spark`, and the
+  `opencode` preset help all named `meta/claude-spark-1.1` — a model neither OpenRouter nor
+  OpenCode serves; the live id is `meta/muse-spark-1.1`. Separately, an `authOptional`
+  preset (opencode) still wrote a keychain `auth` block that `resolveProfileEnv` always
+  read, so `agents run opencode-spark` died with "Keychain item not found" even though
+  OpenCode uses its own login. `resolveProfileEnv` now skips optional auth when no token is
+  stored, so those presets run on the host's own credentials. Source:
+  `apps/cli/src/lib/profiles-presets.ts`, `apps/cli/src/lib/profiles.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -109,6 +109,28 @@
   hook state files read-only, so old installed hooks and a new CLI coexist safely. Source:
   `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/session/{pid-registry,hook-sessions,active}.ts`.
 
+- **`agents harness` — name a (host CLI + model) combo and run it like a native agent
+  type.** `agents harness add spark --host opencode --model meta/muse-spark-1.1` writes
+  `~/.agents/profiles/spark.yml` and `agents run spark` then dispatches OpenCode pinned to
+  that model; `--model` at run time still overrides it. A harness is a profile under the
+  hood (same YAML, same run resolution, same `agents repo push user` device sync), so
+  `agents profiles` is unchanged; `harness` adds the host+model one-shot (no preset
+  required), owns its own `--host` (never remote-routed, unlike `profiles --host`), and
+  `agents harness list` shows custom harnesses, addable presets, and the native harness
+  registry in one view. The model lands on the host's model env var
+  (`OPENCODE_MODEL`/`ANTHROPIC_MODEL`/`GROK_MODEL`/`GEMINI_MODEL`). Source:
+  `apps/cli/src/commands/harness.ts`, `apps/cli/src/lib/profiles.ts`,
+  `apps/cli/src/lib/hosts/passthrough.ts`.
+
+- **Fixed the Spark presets, which never ran.** `claude-spark`, `opencode-spark`, and the
+  `opencode` preset help all named `meta/claude-spark-1.1` — a model neither OpenRouter nor
+  OpenCode serves; the live id is `meta/muse-spark-1.1`. Separately, an `authOptional`
+  preset (opencode) still wrote a keychain `auth` block that `resolveProfileEnv` always
+  read, so `agents run opencode-spark` died with "Keychain item not found" even though
+  OpenCode uses its own login. `resolveProfileEnv` now skips optional auth when no token is
+  stored, so those presets run on the host's own credentials. Source:
+  `apps/cli/src/lib/profiles-presets.ts`, `apps/cli/src/lib/profiles.ts`.
+
 ## 1.20.73
 
 - **`agents cli install <binary-cli>` no longer hardcodes `/usr/local/bin` (#1103).**

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -109,28 +109,6 @@
   hook state files read-only, so old installed hooks and a new CLI coexist safely. Source:
   `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/session/{pid-registry,hook-sessions,active}.ts`.
 
-- **`agents harness` — name a (host CLI + model) combo and run it like a native agent
-  type.** `agents harness add spark --host opencode --model meta/muse-spark-1.1` writes
-  `~/.agents/profiles/spark.yml` and `agents run spark` then dispatches OpenCode pinned to
-  that model; `--model` at run time still overrides it. A harness is a profile under the
-  hood (same YAML, same run resolution, same `agents repo push user` device sync), so
-  `agents profiles` is unchanged; `harness` adds the host+model one-shot (no preset
-  required), owns its own `--host` (never remote-routed, unlike `profiles --host`), and
-  `agents harness list` shows custom harnesses, addable presets, and the native harness
-  registry in one view. The model lands on the host's model env var
-  (`OPENCODE_MODEL`/`ANTHROPIC_MODEL`/`GROK_MODEL`/`GEMINI_MODEL`). Source:
-  `apps/cli/src/commands/harness.ts`, `apps/cli/src/lib/profiles.ts`,
-  `apps/cli/src/lib/hosts/passthrough.ts`.
-
-- **Fixed the Spark presets, which never ran.** `claude-spark`, `opencode-spark`, and the
-  `opencode` preset help all named `meta/claude-spark-1.1` — a model neither OpenRouter nor
-  OpenCode serves; the live id is `meta/muse-spark-1.1`. Separately, an `authOptional`
-  preset (opencode) still wrote a keychain `auth` block that `resolveProfileEnv` always
-  read, so `agents run opencode-spark` died with "Keychain item not found" even though
-  OpenCode uses its own login. `resolveProfileEnv` now skips optional auth when no token is
-  stored, so those presets run on the host's own credentials. Source:
-  `apps/cli/src/lib/profiles-presets.ts`, `apps/cli/src/lib/profiles.ts`.
-
 ## 1.20.73
 
 - **`agents cli install <binary-cli>` no longer hardcodes `/usr/local/bin` (#1103).**

--- a/apps/cli/docs/profiles.md
+++ b/apps/cli/docs/profiles.md
@@ -10,6 +10,28 @@ Built-in presets cover the top open-weight models via OpenRouter (one shared key
 
 > **Status:** Profiles are experimental, but available by default — no enable step needed.
 
+## Custom harnesses (`agents harness`)
+
+A custom harness is a profile you create from a host CLI + model in one command, so a model like Meta Muse Spark 1.1 runs like a native agent type:
+
+```sh
+# OpenCode pinned to Muse Spark, named `spark`
+agents harness add spark --host opencode --model meta/muse-spark-1.1
+agents run spark "refactor api/handlers/checkout.py"
+
+# per-run model override still wins over the profile
+agents run spark --model opencode/big-pickle "quick pass"
+
+# private OpenAI/Anthropic-compatible endpoint with a keychain-backed key
+agents harness add corp --host claude --model gpt-x --base-url https://gw.corp/v1 --auth-provider corp
+```
+
+The model is written to the host's model env var — `OPENCODE_MODEL` for opencode, `ANTHROPIC_MODEL` for claude, `GROK_MODEL` for grok, `GEMINI_MODEL` for gemini. Hosts that manage their own login (e.g. opencode) need no `--auth-provider`; omit it and no auth block is written.
+
+`agents harness list` shows three groups: your custom harnesses, the addable built-in presets, and the native harness registry. `agents harness view <name>` and `agents harness remove <name>` round it out.
+
+A harness *is* a profile — same `~/.agents/profiles/<name>.yml`, same `agents run` resolution, same device sync via `agents repo push user`. The difference from `agents profiles add`: `harness add` takes the host+model one-shot (no preset needed) and owns its own `--host` flag, whereas `agents profiles --host <device>` is reserved for running the profiles command on a remote device.
+
 ## Top-level resource profiles
 
 `agents profile use <name>` activates a resource profile from `agents.yaml`.

--- a/apps/cli/src/commands/harness.test.ts
+++ b/apps/cli/src/commands/harness.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as state from '../lib/state.js';
+import { addProfile } from './profiles.js';
+import { readProfile } from '../lib/profiles.js';
+
+let TEST_ROOT: string;
+let USER_DIR: string;
+
+beforeEach(() => {
+  TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-test-'));
+  USER_DIR = path.join(TEST_ROOT, '.agents');
+  fs.mkdirSync(path.join(USER_DIR, 'profiles'), { recursive: true });
+  vi.spyOn(state, 'getUserAgentsDir').mockReturnValue(USER_DIR);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('addProfile — host + model one-shot (custom harness)', () => {
+  it('writes a profile with the model on the host env var and no auth block', async () => {
+    await addProfile('spark', { host: 'opencode', model: 'meta/muse-spark-1.1' }, 'Harness');
+    const p = readProfile('spark');
+    expect(p.host.agent).toBe('opencode');
+    expect(p.env.OPENCODE_MODEL).toBe('meta/muse-spark-1.1');
+    expect(p.auth).toBeUndefined();
+  });
+
+  it('rejects --host without --model', async () => {
+    await expect(addProfile('x', { host: 'opencode' })).rejects.toThrow(/both --host .* and --model/i);
+  });
+
+  it('rejects an unknown host', async () => {
+    await expect(addProfile('x', { host: 'not-an-agent', model: 'm' })).rejects.toThrow(/unknown host/i);
+  });
+
+  it('refuses to overwrite an existing harness without --force', async () => {
+    await addProfile('spark', { host: 'opencode', model: 'meta/muse-spark-1.1' });
+    await expect(addProfile('spark', { host: 'claude', model: 'x' })).rejects.toThrow(/already exists/i);
+    // --force overwrites
+    await addProfile('spark', { host: 'claude', model: 'claude-x', force: true });
+    expect(readProfile('spark').env.ANTHROPIC_MODEL).toBe('claude-x');
+  });
+});

--- a/apps/cli/src/commands/harness.ts
+++ b/apps/cli/src/commands/harness.ts
@@ -1,0 +1,173 @@
+/**
+ * Custom harness commands (`agents harness`).
+ *
+ * A "custom harness" is a named (host CLI + model) combo — e.g. OpenCode pinned
+ * to meta/muse-spark-1.1, called `spark`. It runs like a native agent type
+ * (`agents run spark`) and syncs across devices via `agents repo push user`.
+ *
+ * Mechanism: harnesses ARE profiles (same ~/.agents/profiles/*.yml, same run
+ * resolution). This command group is the harness-flavored surface over that
+ * layer + a discovery `list` spanning custom harnesses, addable presets, and the
+ * native harness registry. The `agents profiles` tree stays unchanged.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { addProfile, type AddProfileOptions } from './profiles.js';
+import {
+  listProfiles,
+  readProfile,
+  deleteProfile,
+  profileHostLabel,
+  profileProviderLabel,
+  profileModelLabel,
+  profileAuthLabel,
+  getProfilePath,
+} from '../lib/profiles.js';
+import { listPresets } from '../lib/profiles-presets.js';
+import { AGENTS, ALL_AGENT_IDS } from '../lib/agents.js';
+
+/** Short capability summary for a native harness — its supported run modes. */
+function nativeModes(id: (typeof ALL_AGENT_IDS)[number]): string {
+  const modes = AGENTS[id]?.capabilities?.modes ?? [];
+  return modes.length ? modes.join('/') : '-';
+}
+
+export function registerHarnessCommands(program: Command): void {
+  const cmd = program
+    .command('harness')
+    .alias('harnesses')
+    .description('Custom harnesses — name a (host CLI + model) combo and run it like a native agent type.')
+    .addHelpText(
+      'after',
+      `
+A custom harness pins a host CLI (opencode, claude, codex, grok, gemini, ...) to a
+model and gives it a name. 'agents run <name>' then behaves like a native agent
+type, and 'agents repo push user' syncs it to every device.
+
+Examples:
+  # Meta Muse Spark 1.1 through OpenCode, called 'spark'
+  agents harness add spark --host opencode --model meta/muse-spark-1.1
+  agents run spark "refactor api/handlers/checkout.py"
+
+  # Per-run model override still wins
+  agents run spark --model opencode/big-pickle "quick pass"
+
+  # See custom harnesses, addable presets, and native harnesses
+  agents harness list
+
+  # Private OpenAI/Anthropic-compatible endpoint (stores a keychain key)
+  agents harness add corp --host claude --model gpt-x --base-url https://gw.corp/v1 --auth-provider corp
+
+  # Custom harnesses are just profiles — this also works via 'agents profiles'
+`,
+    );
+
+  cmd
+    .command('add <name>')
+    .description('Create a custom harness from a host + model (or apply a built-in preset).')
+    .option('--host <agent>', 'Host CLI to run under (opencode, claude, codex, grok, gemini, ...) — pair with --model')
+    .option('--model <id>', 'Model id to pin on the host (e.g., meta/muse-spark-1.1) — pair with --host')
+    .option('--base-url <url>', 'Custom endpoint base URL (claude/codex hosts)')
+    .option('--auth-provider <provider>', 'Attach a keychain-backed API key under this provider (for private endpoints)')
+    .option('--preset <preset>', 'Apply a built-in preset instead of --host/--model')
+    .option('--version <version>', 'Pin the host CLI version (e.g., 1.16.0)')
+    .option('--key-stdin', 'Read API key from stdin instead of prompting (for scripts/CI)')
+    .option('--force', 'Overwrite an existing harness with the same name')
+    .action(async (name: string, opts: AddProfileOptions) => {
+      try {
+        await addProfile(name, opts, 'Harness');
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('list')
+    .alias('ls')
+    .description('List custom harnesses, addable presets, and native harnesses.')
+    .option('--json', 'Emit JSON instead of a table')
+    .action((opts: { json?: boolean }) => {
+      const custom = listProfiles();
+      const presets = listPresets();
+      const native = ALL_AGENT_IDS.map((id) => ({ id, name: AGENTS[id].name, modes: nativeModes(id) }));
+
+      if (opts.json) {
+        console.log(
+          JSON.stringify(
+            {
+              custom: custom.map((p) => ({
+                name: p.name,
+                host: p.host.agent,
+                model: profileModelLabel(p),
+                provider: profileProviderLabel(p),
+              })),
+              presets: presets.map((p) => ({ name: p.name, provider: p.provider, description: p.description })),
+              native,
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      console.log(chalk.bold('Custom harnesses') + chalk.gray('  (yours — agents run <name>)'));
+      if (custom.length === 0) {
+        console.log(chalk.gray('  none yet — try: agents harness add spark --host opencode --model meta/muse-spark-1.1'));
+      } else {
+        for (const p of custom) {
+          console.log(
+            `  ${chalk.cyan(p.name.padEnd(16))} ${profileHostLabel(p).padEnd(14)} ${chalk.gray(profileModelLabel(p))}`,
+          );
+        }
+      }
+
+      console.log('');
+      console.log(chalk.bold('Presets') + chalk.gray('  (addable — agents harness add <name>)'));
+      for (const p of presets) {
+        console.log(`  ${chalk.cyan(p.name.padEnd(16))} ${p.provider.padEnd(12)} ${chalk.gray(p.description.slice(0, 70))}`);
+      }
+
+      console.log('');
+      console.log(chalk.bold('Native harnesses') + chalk.gray('  (built-in — agents run <id>)'));
+      for (const n of native) {
+        console.log(`  ${chalk.cyan(n.id.padEnd(16))} ${n.name.padEnd(14)} ${chalk.gray('modes: ' + n.modes)}`);
+      }
+    });
+
+  cmd
+    .command('view <name>')
+    .alias('show')
+    .description('Show one custom harness (host, model, provider, auth, path).')
+    .action((name: string) => {
+      try {
+        const p = readProfile(name);
+        console.log(chalk.bold(p.name));
+        if (p.description) console.log(chalk.gray(p.description));
+        console.log('');
+        console.log(`Host:     ${profileHostLabel(p)}`);
+        console.log(`Model:    ${profileModelLabel(p)}`);
+        console.log(`Provider: ${profileProviderLabel(p)}`);
+        console.log(`Auth:     ${profileAuthLabel(p)}`);
+        console.log(chalk.gray(getProfilePath(p.name)));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('remove <name>')
+    .alias('rm')
+    .description('Delete a custom harness (keychain token is kept).')
+    .action((name: string) => {
+      const existed = deleteProfile(name);
+      if (!existed) {
+        console.error(chalk.red(`Harness '${name}' not found.`));
+        process.exit(1);
+      }
+      console.log(chalk.green(`Harness '${name}' removed.`));
+    });
+}

--- a/apps/cli/src/commands/profiles.ts
+++ b/apps/cli/src/commands/profiles.ts
@@ -18,11 +18,15 @@ import {
   deleteProfile,
   profileExists,
   profileFromPreset,
+  profileFromHostModel,
+  baseUrlEnvKeyForHost,
+  authEnvKeyForHost,
   validateProfileName,
   getPresetForProfile,
   type Profile,
 } from '../lib/profiles.js';
 import { getPreset, listPresets, expandPreset, type Preset } from '../lib/profiles-presets.js';
+import type { AgentId } from '../lib/types.js';
 import {
   hasKeychainToken,
   keychainItemName,
@@ -40,7 +44,7 @@ import {
   validateResourceProfileName,
   type PatternedProfileKind,
 } from '../lib/resource-profiles.js';
-import { AGENTS } from '../lib/agents.js';
+import { AGENTS, ALL_AGENT_IDS } from '../lib/agents.js';
 import { listInstalledVersions, syncResourcesToVersion } from '../lib/versions.js';
 import type { ResourceProfilePreset } from '../lib/types.js';
 
@@ -63,6 +67,7 @@ export function buildProfileFromCollection(
       envVar: preset.authEnvVar,
       keychainItem: keychainItemName(preset.provider),
     },
+    authOptional: preset.authOptional,
     description: preset.description,
     preset: preset.name,
     provider: preset.provider,
@@ -98,6 +103,85 @@ async function ensureProviderToken(provider: string, signupUrl?: string, fromStd
   }
   setKeychainToken(item, token);
   console.log(chalk.green(`Stored in keychain: ${item}`));
+}
+
+/** Options accepted by {@link addProfile} — shared by `agents profiles add` and `agents harness add`. */
+export interface AddProfileOptions {
+  preset?: string;
+  host?: string;
+  model?: string;
+  baseUrl?: string;
+  authProvider?: string;
+  version?: string;
+  keyStdin?: boolean;
+  force?: boolean;
+}
+
+/**
+ * Create a profile ("custom harness"). Two paths:
+ *  - `--host <agent> --model <id>`: one-shot custom harness from a host + model
+ *    (no preset needed). This is what makes a model like Muse Spark a named,
+ *    runnable harness.
+ *  - otherwise: apply a built-in preset (existing behavior).
+ * `label` only tunes the success wording (Profile vs Harness). Throws on error.
+ */
+export async function addProfile(name: string, opts: AddProfileOptions, label: 'Profile' | 'Harness' = 'Profile'): Promise<void> {
+  validateProfileName(name);
+  if (profileExists(name) && !opts.force) {
+    throw new Error(`${label} '${name}' already exists. Use --force to overwrite.`);
+  }
+
+  // One-shot host + model → custom harness, no preset required.
+  if (opts.host || opts.model) {
+    if (!opts.host || !opts.model) {
+      throw new Error('Both --host <agent> and --model <id> are required to build a harness from a host + model.');
+    }
+    if (!ALL_AGENT_IDS.includes(opts.host as AgentId)) {
+      throw new Error(`Unknown host '${opts.host}'. Valid hosts: ${ALL_AGENT_IDS.join(', ')}`);
+    }
+    const host = opts.host as AgentId;
+    if (opts.baseUrl && !baseUrlEnvKeyForHost(host)) {
+      console.error(chalk.yellow(`Note: --base-url has no known env var for host '${host}'; ignoring it.`));
+    }
+
+    let authEnvVar: string | undefined;
+    if (opts.authProvider) {
+      const key = authEnvKeyForHost(host);
+      if (!key) {
+        throw new Error(`--auth-provider is set but host '${host}' has no known auth env var. Use a preset or a hand-written profile YAML.`);
+      }
+      authEnvVar = key;
+      await ensureProviderToken(opts.authProvider, undefined, opts.keyStdin);
+    }
+
+    const profile = profileFromHostModel(name, host, opts.model, {
+      version: opts.version,
+      baseUrl: opts.baseUrl,
+      provider: opts.authProvider,
+      authEnvVar,
+    });
+    writeProfile(profile);
+    console.log(chalk.green(`${label} '${name}' added — ${host} + ${opts.model}.`));
+    console.log(chalk.gray(`Try: agents run ${name} "hello"`));
+    return;
+  }
+
+  // Preset path.
+  const presetName = opts.preset || name;
+  const preset = getPreset(presetName);
+  if (!preset) {
+    throw new Error(
+      `No preset '${presetName}'.\nAvailable presets: ${listPresets().map((p) => p.name).join(', ')}\n` +
+        'Or build a custom harness: --host <agent> --model <id>.',
+    );
+  }
+  if (!preset.authOptional) {
+    await ensureProviderToken(preset.provider, preset.signupUrl, opts.keyStdin);
+  }
+  const profile = profileFromPreset(name, preset, opts.version);
+  writeProfile(profile);
+  console.log(chalk.green(`${label} '${name}' added.`));
+  console.log(chalk.gray(`Try: agents run ${name} "hello"`));
 }
 
 /** Format a single profile as a table row for the `profiles list` output. */
@@ -524,30 +608,13 @@ Examples:
     .option('--version <version>', 'Pin the host CLI version (e.g., 2.1.113)')
     .option('--key-stdin', 'Read API key from stdin instead of prompting (for scripts/CI)')
     .option('--force', 'Overwrite an existing profile with the same name')
-    .action(async (name: string, opts: { preset?: string; version?: string; keyStdin?: boolean; force?: boolean }) => {
+    .addHelpText('after', '\nTo build a custom harness from a host CLI + model in one shot, use `agents harness add`.\n')
+    .action(async (name: string, opts: AddProfileOptions) => {
+      // Preset-only surface here — `--host` on `profiles` is reserved for remote
+      // device routing (see lib/hosts/passthrough.ts). The host+model one-shot
+      // lives on `agents harness add`, which owns its own `--host`.
       try {
-        if (profileExists(name) && !opts.force) {
-          console.error(chalk.red(`Profile '${name}' already exists. Use --force to overwrite.`));
-          process.exit(1);
-        }
-
-        const presetName = opts.preset || name;
-        const preset = getPreset(presetName);
-        if (!preset) {
-          console.error(chalk.red(`No preset '${presetName}'.`));
-          console.error(chalk.gray('Available presets: ' + listPresets().map((p) => p.name).join(', ')));
-          console.error(chalk.gray('Or pass --preset <name> to pick explicitly.'));
-          process.exit(1);
-        }
-
-        if (!preset.authOptional) {
-          await ensureProviderToken(preset.provider, preset.signupUrl, opts.keyStdin);
-        }
-
-        const profile = profileFromPreset(name, preset, opts.version);
-        writeProfile(profile);
-        console.log(chalk.green(`Profile '${name}' added.`));
-        console.log(chalk.gray(`Try: agents run ${name} "hello"`));
+        await addProfile(name, { preset: opts.preset, version: opts.version, keyStdin: opts.keyStdin, force: opts.force }, 'Profile');
       } catch (err) {
         console.error(chalk.red((err as Error).message));
         process.exit(1);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -157,6 +157,7 @@ import {
   loadCheck,
   loadStatus,
   loadProfiles,
+  loadHarness,
   loadSecrets,
   loadLogin,
   loadWallet,
@@ -936,6 +937,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadStatus);
   registerExecAliasCommand(program);
   await reg(loadProfiles);
+  await reg(loadHarness);
   await reg(loadSecrets);
   await reg(loadLogin);
   await reg(loadWallet);

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -112,6 +112,8 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
 const OWN_HOST_COMMANDS = new Set([
   'run',
   'exec', // deprecated alias of run
+  'harness', // `--host <agent>` names the host CLI to run under, not a remote device
+  'harnesses',
   'sessions',
   'feed',
   'computer',

--- a/apps/cli/src/lib/profiles-presets.test.ts
+++ b/apps/cli/src/lib/profiles-presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { expandPreset, getPreset, listProviders } from './profiles-presets.js';
+import { PRESETS, expandPreset, getPreset, listProviders } from './profiles-presets.js';
 
 describe('profiles-presets', () => {
   it('truefoundry preset carries Bedrock-strict-validation env vars', () => {
@@ -58,6 +58,19 @@ describe('profiles-presets', () => {
   it('grok presets have verified 2026 model IDs', () => {
     expect(getPreset('grok-fast')?.env.GROK_MODEL).toBe('grok-build-0.1');
     expect(getPreset('grok-heavy')?.env.GROK_MODEL).toBe('grok-4.3');
+  });
+
+  it('spark presets carry the live Muse Spark id (meta/muse-spark-1.1)', () => {
+    expect(getPreset('claude-spark')?.env.ANTHROPIC_MODEL).toBe('meta/muse-spark-1.1');
+    expect(getPreset('opencode-spark')?.env.OPENCODE_MODEL).toBe('meta/muse-spark-1.1');
+  });
+
+  it('no preset references the never-served meta/claude-spark-1.1 id', () => {
+    const stale = PRESETS.filter((p) =>
+      Object.values(p.env).some((v) => v.includes('claude-spark-1.1')) ||
+      p.description.includes('claude-spark-1.1'),
+    );
+    expect(stale.map((p) => p.name)).toEqual([]);
   });
 
   it('proxy preset is on claude host with two prompts', () => {

--- a/apps/cli/src/lib/profiles-presets.ts
+++ b/apps/cli/src/lib/profiles-presets.ts
@@ -37,7 +37,9 @@ export interface Preset {
   docPath?: string;
 }
 
-// Model IDs verified against openrouter.ai/api/v1/models on 2026-04-20.
+// Model IDs verified against openrouter.ai/api/v1/models on 2026-07-31
+// (spark presets corrected from the never-served meta/claude-spark-1.1 to the
+// live meta/muse-spark-1.1, confirmed on both OpenRouter and OpenCode id:meta).
 // Presets target the top-ranked open-source model per provider based on
 // SWE-bench Verified, LiveCodeBench, HumanEval, and Chatbot Arena rankings.
 //
@@ -135,18 +137,18 @@ export const PRESETS: Preset[] = [
   },
   {
     name: 'claude-spark',
-    description: 'Meta Claude Spark 1.1 via OpenRouter inside Claude Code (open alternative). Model: meta/claude-spark-1.1 — free via opencode, now usable in Claude Code UI. HEADLESS-SAFE. For open-claude spark usage.',
+    description: 'Meta Muse Spark 1.1 via OpenRouter inside Claude Code (open alternative). Model: meta/muse-spark-1.1 — now usable in the Claude Code UI. HEADLESS-SAFE. For open-claude spark usage.',
     ...OPENROUTER_AUTH,
     env: {
       ANTHROPIC_BASE_URL: OPENROUTER_BASE,
-      ANTHROPIC_MODEL: 'meta/claude-spark-1.1',
-      ANTHROPIC_SMALL_FAST_MODEL: 'meta/claude-spark-1.1',
+      ANTHROPIC_MODEL: 'meta/muse-spark-1.1',
+      ANTHROPIC_SMALL_FAST_MODEL: 'meta/muse-spark-1.1',
     },
   },
   // ----- OpenCode CLI (open-claude harness) -----
   {
     name: 'opencode',
-    description: 'OpenCode default — uses your configured model via opencode auth. Run `opencode auth` to login, then `agents run opencode --model meta/claude-spark-1.1 "prompt"` for spark usage.',
+    description: 'OpenCode default — uses your configured model via opencode auth. Run `opencode auth` to login, then `agents run opencode --model meta/muse-spark-1.1 "prompt"` for spark usage.',
     provider: 'opencode',
     host: 'opencode',
     authEnvVar: 'OPENCODE_API_KEY',
@@ -155,13 +157,13 @@ export const PRESETS: Preset[] = [
   },
   {
     name: 'opencode-spark',
-    description: 'Meta Claude Spark 1.1 via OpenCode (free, headless-safe). Pinned to meta/claude-spark-1.1 — best for open-claude usage with opencode harness.',
+    description: 'Meta Muse Spark 1.1 via OpenCode (free, headless-safe). Pinned to meta/muse-spark-1.1 — best for open-claude usage with opencode harness.',
     provider: 'opencode',
     host: 'opencode',
     authEnvVar: 'OPENCODE_API_KEY',
     authOptional: true,
     env: {
-      OPENCODE_MODEL: 'meta/claude-spark-1.1',
+      OPENCODE_MODEL: 'meta/muse-spark-1.1',
     },
   },
   {

--- a/apps/cli/src/lib/profiles.test.ts
+++ b/apps/cli/src/lib/profiles.test.ts
@@ -145,6 +145,18 @@ describe('resolveProfileEnv honors authOptional', () => {
     expect(env.OPENCODE_MODEL).toBe('meta/muse-spark-1.1');
     expect(env.OPENCODE_API_KEY).toBeUndefined();
   });
+
+  it('STILL throws for REQUIRED auth with a missing token (the load-bearing safety property)', () => {
+    // authOptional omitted (required). A missing keychain item must hard-fail —
+    // the authOptional skip must never leak into the required-auth path.
+    const p: Profile = {
+      name: 'corp',
+      host: { agent: 'claude' },
+      env: { ANTHROPIC_MODEL: 'gpt-x' },
+      auth: { envVar: 'ANTHROPIC_AUTH_TOKEN', keychainItem: 'agents-cli.no-such-provider-xyz.token' },
+    };
+    expect(() => resolveProfileEnv(p)).toThrow(/not found/i);
+  });
 });
 
 describe('resolveProfileForRun surfaces fallback_model as an env-swap', () => {

--- a/apps/cli/src/lib/profiles.test.ts
+++ b/apps/cli/src/lib/profiles.test.ts
@@ -5,6 +5,9 @@ import * as path from 'path';
 import * as state from './state.js';
 import {
   profileModelEnvKey,
+  profileFromHostModel,
+  modelEnvKeyForHost,
+  resolveProfileEnv,
   readProfile,
   resolveProfileForRun,
   writeProfile,
@@ -96,6 +99,51 @@ describe('profileModelEnvKey', () => {
       env: { ANTHROPIC_BASE_URL: 'https://x' },
     };
     expect(profileModelEnvKey(p)).toBeNull();
+  });
+});
+
+describe('profileFromHostModel (custom harness from host + model)', () => {
+  it('pins the model on the host-appropriate env key', () => {
+    expect(modelEnvKeyForHost('opencode')).toBe('OPENCODE_MODEL');
+    expect(modelEnvKeyForHost('claude')).toBe('ANTHROPIC_MODEL');
+    expect(modelEnvKeyForHost('grok')).toBe('GROK_MODEL');
+
+    const spark = profileFromHostModel('spark', 'opencode', 'meta/muse-spark-1.1');
+    expect(spark.host.agent).toBe('opencode');
+    expect(spark.env.OPENCODE_MODEL).toBe('meta/muse-spark-1.1');
+    // No provider/authEnvVar → no auth block; the host uses its own login.
+    expect(spark.auth).toBeUndefined();
+  });
+
+  it('sets ANTHROPIC_BASE_URL for a claude host when --base-url is given', () => {
+    const p = profileFromHostModel('corp', 'claude', 'gpt-x', { baseUrl: 'https://gw.corp/v1' });
+    expect(p.env.ANTHROPIC_MODEL).toBe('gpt-x');
+    expect(p.env.ANTHROPIC_BASE_URL).toBe('https://gw.corp/v1');
+  });
+
+  it('attaches a keychain auth block only when provider + authEnvVar are supplied', () => {
+    const p = profileFromHostModel('corp', 'claude', 'gpt-x', {
+      provider: 'corp',
+      authEnvVar: 'ANTHROPIC_AUTH_TOKEN',
+    });
+    expect(p.auth?.envVar).toBe('ANTHROPIC_AUTH_TOKEN');
+    expect(p.auth?.keychainItem).toContain('corp');
+    expect(p.authOptional).toBe(false);
+  });
+});
+
+describe('resolveProfileEnv honors authOptional', () => {
+  it('does not throw and injects no auth env when auth is optional and no token is stored', () => {
+    const p: Profile = {
+      name: 'spark',
+      host: { agent: 'opencode' },
+      env: { OPENCODE_MODEL: 'meta/muse-spark-1.1' },
+      auth: { envVar: 'OPENCODE_API_KEY', keychainItem: 'agents-cli.no-such-provider-xyz.token' },
+      authOptional: true,
+    };
+    const env = resolveProfileEnv(p);
+    expect(env.OPENCODE_MODEL).toBe('meta/muse-spark-1.1');
+    expect(env.OPENCODE_API_KEY).toBeUndefined();
   });
 });
 

--- a/apps/cli/src/lib/profiles.ts
+++ b/apps/cli/src/lib/profiles.ts
@@ -26,6 +26,13 @@ export interface Profile {
     envVar: string;
     keychainItem: string;
   };
+  /**
+   * When true, the host manages its own login and the keychain token named by
+   * `auth` is optional: if it is not stored, no auth env var is injected and the
+   * run proceeds on the host's own credentials (e.g. `opencode auth`). Without
+   * this flag a missing keychain item is a hard error at exec time.
+   */
+  authOptional?: boolean;
   description?: string;
   preset?: string;
   provider?: string;
@@ -277,10 +284,92 @@ export function profileFromPreset(profileName: string, preset: Preset, version?:
       envVar: preset.authEnvVar,
       keychainItem: keychainItemName(preset.provider),
     },
+    authOptional: preset.authOptional,
     description: preset.description,
     preset: preset.name,
     provider: preset.provider,
   };
+}
+
+/**
+ * Env var each host CLI reads to override its model. Mirror of the read-side
+ * `MODEL_ENV_KEYS` above, keyed by host so a one-shot `--host <agent> --model
+ * <id>` writes the model onto the var that host actually honors.
+ */
+const MODEL_ENV_KEY_BY_HOST: Partial<Record<AgentId, string>> = {
+  claude: 'ANTHROPIC_MODEL',
+  opencode: 'OPENCODE_MODEL',
+  grok: 'GROK_MODEL',
+  gemini: 'GEMINI_MODEL',
+  codex: 'OPENAI_MODEL',
+};
+
+/** Base-URL env var per host, for the OpenAI/Anthropic-compatible hosts where it applies. */
+const BASE_URL_ENV_KEY_BY_HOST: Partial<Record<AgentId, string>> = {
+  claude: 'ANTHROPIC_BASE_URL',
+  codex: 'OPENAI_BASE_URL',
+};
+
+/** Return the model-override env var for a host (known hosts mapped; else `<HOST>_MODEL`). */
+export function modelEnvKeyForHost(host: AgentId): string {
+  return MODEL_ENV_KEY_BY_HOST[host] ?? `${host.toUpperCase()}_MODEL`;
+}
+
+/** Return the base-URL env var for a host, or null when the host has no known override var. */
+export function baseUrlEnvKeyForHost(host: AgentId): string | null {
+  return BASE_URL_ENV_KEY_BY_HOST[host] ?? null;
+}
+
+/** Env var each host reads its auth token from, for custom-endpoint (`--auth-provider`) harnesses. */
+const AUTH_ENV_KEY_BY_HOST: Partial<Record<AgentId, string>> = {
+  claude: 'ANTHROPIC_AUTH_TOKEN',
+  codex: 'OPENAI_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  grok: 'XAI_API_KEY',
+  opencode: 'OPENCODE_API_KEY',
+};
+
+/** Return the auth-token env var for a host, or null when unknown. */
+export function authEnvKeyForHost(host: AgentId): string | null {
+  return AUTH_ENV_KEY_BY_HOST[host] ?? null;
+}
+
+/** Options for {@link profileFromHostModel}. */
+export interface HostModelOptions {
+  version?: string;
+  /** Base URL for OpenAI/Anthropic-compatible hosts (claude, codex). Ignored for hosts without a known var. */
+  baseUrl?: string;
+  /** Provider label + keychain namespace; only needed when the host requires a token. */
+  provider?: string;
+  /** Env var the host reads its auth token from; pair with `provider` to attach keychain auth. */
+  authEnvVar?: string;
+  description?: string;
+}
+
+/**
+ * Build a custom-harness profile from a host CLI + model in one shot, without a
+ * preset. The model lands on the host's model env var ({@link modelEnvKeyForHost});
+ * auth is attached only when both `provider` and `authEnvVar` are supplied
+ * (hosts that manage their own login — e.g. opencode — need neither).
+ */
+export function profileFromHostModel(name: string, host: AgentId, model: string, opts: HostModelOptions = {}): Profile {
+  const env: Record<string, string> = { [modelEnvKeyForHost(host)]: model };
+  if (opts.baseUrl) {
+    const key = baseUrlEnvKeyForHost(host);
+    if (key) env[key] = opts.baseUrl;
+  }
+  const profile: Profile = {
+    name,
+    host: { agent: host, version: opts.version },
+    env,
+    description: opts.description ?? `Custom harness: ${host} + ${model}`,
+    provider: opts.provider ?? host,
+  };
+  if (opts.provider && opts.authEnvVar) {
+    profile.auth = { envVar: opts.authEnvVar, keychainItem: keychainItemName(opts.provider) };
+    profile.authOptional = false;
+  }
+  return profile;
 }
 
 /**
@@ -291,6 +380,12 @@ export function profileFromPreset(profileName: string, preset: Preset, version?:
 export function resolveProfileEnv(profile: Profile): Record<string, string> {
   const env: Record<string, string> = { ...profile.env };
   if (profile.auth) {
+    // Optional auth (host manages its own login) with no stored token: inject
+    // nothing and let the host use its own credentials. Only required auth
+    // hard-fails on a missing keychain item.
+    if (profile.authOptional && !hasKeychainToken(profile.auth.keychainItem)) {
+      return env;
+    }
     const token = getKeychainToken(profile.auth.keychainItem);
     env[profile.auth.envVar] = token;
   }

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -63,6 +63,7 @@ export const loadApply: ModuleLoader = async () => (await import('../../commands
 export const loadCheck: ModuleLoader = async () => (await import('../../commands/check.js')).registerCheckCommand;
 export const loadStatus: ModuleLoader = async () => (await import('../../commands/status.js')).registerStatusCommand;
 export const loadProfiles: ModuleLoader = async () => (await import('../../commands/profiles.js')).registerProfilesCommands;
+export const loadHarness: ModuleLoader = async () => (await import('../../commands/harness.js')).registerHarnessCommands;
 export const loadSecrets: ModuleLoader = async () => (await import('../../commands/secrets.js')).registerSecretsCommands;
 export const loadLogin: ModuleLoader = async () => (await import('../../commands/login.js')).registerLoginCommands;
 export const loadWallet: ModuleLoader = async () => (await import('../../commands/wallet.js')).registerWalletCommands;
@@ -176,6 +177,8 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   status: [loadStatus],
   profile: [loadProfiles],
   profiles: [loadProfiles],
+  harness: [loadHarness],
+  harnesses: [loadHarness],
   secrets: [loadSecrets],
   login: [loadLogin],
   logout: [loadLogin],


### PR DESCRIPTION
## What

Adds `agents harness` — name a **(host CLI + model)** combo and run it like a native agent type. The motivating case: run Meta Muse Spark 1.1 (`meta/muse-spark-1.1`) through OpenCode as a first-class `spark` you can `agents run spark`.

A harness is a **profile under the hood** — same `~/.agents/profiles/<name>.yml`, same `agents run` resolution ladder, same `agents repo push user` cross-device sync. `agents profiles` is unchanged; `harness` is the harness-flavored surface plus a one-shot creator and a discovery `list`.

## Commands

```
agents harness add spark --host opencode --model meta/muse-spark-1.1   # one-shot, no preset
agents run spark "refactor checkout.py"                                 # runs OpenCode + Muse Spark
agents run spark --model opencode/big-pickle "..."                      # per-run override wins
agents harness list                                                     # custom + presets + native
agents harness view spark / agents harness remove spark
```

- The model lands on the host's model env var: `OPENCODE_MODEL` / `ANTHROPIC_MODEL` / `GROK_MODEL` / `GEMINI_MODEL`.
- `--base-url` + `--auth-provider` cover private OpenAI/Anthropic-compatible endpoints (keychain-backed key).
- `harness` owns its `--host` flag (added to `OWN_HOST_COMMANDS`), so it is never remote-routed — unlike `agents profiles --host <device>`, which is why the one-shot lives on `harness` and not `profiles add`.

## Also fixes the Spark presets (they never ran)

- `claude-spark` / `opencode-spark` / the `opencode` preset help all named `meta/claude-spark-1.1` — a model **neither OpenRouter nor OpenCode serves**. Corrected to the live `meta/muse-spark-1.1` (verified against both providers on 2026-07-31).
- An `authOptional` preset (opencode) still wrote a keychain `auth` block that `resolveProfileEnv` always read, so `agents run opencode-spark` died with **"Keychain item not found"** even though OpenCode uses its own login. `resolveProfileEnv` now skips optional auth when no token is stored.

## Files

`commands/harness.ts` (new group), `commands/profiles.ts` (shared `addProfile` helper), `lib/profiles.ts` (`profileFromHostModel`, host→model-env map, optional-auth resolve), `lib/profiles-presets.ts` (id fix), `lib/hosts/passthrough.ts` (`--host` ownership), registry + index wiring, `CHANGELOG.md`, `docs/profiles.md`.

## Verification (end-to-end, built CLI)

```
$ agents harness add spark-e2e --host opencode --model meta/muse-spark-1.1
Harness 'spark-e2e' added — opencode + meta/muse-spark-1.1.

# ~/.agents/profiles/spark-e2e.yml
name: spark-e2e
host: { agent: opencode }
env: { OPENCODE_MODEL: meta/muse-spark-1.1 }        # correct id, no auth block

$ agents run spark-e2e "say hi" --mode plan
Resolved profile 'spark-e2e' -> opencode
> plan · muse-spark-1.1                             # dispatched, no keychain error

$ agents run spark-e2e --model opencode/big-pickle "say hi" --mode plan
> plan · big-pickle                                 # per-run override wins
```

`agents harness list` renders three groups (custom harnesses / presets / native registry) with the corrected "Meta Muse Spark 1.1" preset descriptions.

## Tests

- `lib/profiles.test.ts` — `profileFromHostModel` host→model-env mapping; `resolveProfileEnv` tolerates optional auth with no stored token.
- `commands/harness.test.ts` — `addProfile` host+model path + validation (missing `--model`, unknown host, overwrite guard).
- `lib/profiles-presets.test.ts` — spark presets carry `meta/muse-spark-1.1`; guard that no preset references the stale id.

Touched-file suites pass (profiles/presets/harness 28/0, exec 16/0, hosts/passthrough 21/0). The 8 failures in the full local run are all in `DevicesHostProvider`/`LocalHostProvider` tests that read the live device registry on this machine (my real fleet), unrelated to this change — they pass on CI's device-less Linux runner.

Session transcript (public repo — local path, not attached): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/4b193f91-8993-4686-a99f-418b4688d693.jsonl`
