### PR TITLE
fix(devices): read-only `agents devices` never pops Touch ID (RUSH-1970)

### DIFF
--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -50,6 +50,7 @@ import { hostNameFor, renderSshConfig } from '../lib/devices/ssh-config.js';
 import {
   ASKPASS_BUNDLE_ENV,
   ASKPASS_KEY_ENV,
+  ASKPASS_AGENT_ONLY_ENV,
   buildSshInvocation,
   fleetDialTarget,
   writeAskpassShim,
@@ -1195,8 +1196,13 @@ async function runAskpass(): Promise<void> {
     console.error(`askpass: ${ASKPASS_BUNDLE_ENV} not set`);
     process.exit(1);
   }
+  // A read-only stats probe sets ASKPASS_AGENT_ONLY_ENV to force a broker-only
+  // resolve even under a TTY — so `agents devices` never pops Touch ID just to
+  // render load/mem for an uncached password-auth device (RUSH-1970). Otherwise
+  // fall back to the headless-context heuristic.
+  const agentOnly = process.env[ASKPASS_AGENT_ONLY_ENV] === '1' || isHeadlessSecretsContext();
   try {
-    const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents ssh', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+    const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents ssh', keys: [key], keyMode: 'storage', agentOnly });
     const value = env[key];
     if (value === undefined) {
       console.error(`askpass: key '${key}' not found in bundle '${bundle}'`);

--- a/apps/cli/src/lib/devices/connect.test.ts
+++ b/apps/cli/src/lib/devices/connect.test.ts
@@ -9,7 +9,7 @@
  * injection guard.
  */
 import { describe, expect, it } from 'vitest';
-import { buildAskpassShimBody, buildSshInvocation, fleetDialTarget, sshTargetFor, wrapRemoteCommand, ASKPASS_BUNDLE_ENV, ASKPASS_KEY_ENV } from './connect.js';
+import { buildAskpassShimBody, buildSshInvocation, fleetDialTarget, sshTargetFor, wrapRemoteCommand, ASKPASS_BUNDLE_ENV, ASKPASS_KEY_ENV, ASKPASS_AGENT_ONLY_ENV } from './connect.js';
 import type { DeviceProfile } from './registry.js';
 
 function decodePowerShell(cmd: string): string {
@@ -92,6 +92,40 @@ describe('buildSshInvocation', () => {
     expect(args).toContain('PubkeyAuthentication=no');
     expect(args).toContain('NumberOfPasswordPrompts=1');
     expect(args).not.toContain('BatchMode=yes');
+    // A normal (non-probe) connect must NOT force broker-only: an interactive
+    // `agents ssh` still resolves the password via the usual TTY/headless path.
+    expect(env[ASKPASS_AGENT_ONLY_ENV]).toBeUndefined();
+  });
+
+  // RUSH-1970: a read-only stats probe (the load/mem columns of `agents devices`)
+  // must resolve a password bundle broker-only, so it never pops a Touch ID sheet
+  // just to render a row. probeDeviceStats (health.ts) calls buildSshInvocation with
+  // agentOnly:true; the askpass subprocess reads ASKPASS_AGENT_ONLY_ENV and forces
+  // a broker-only resolve regardless of TTY.
+  it('agentOnly stats probe of a password device forces a broker-only askpass resolve', () => {
+    const { env } = buildSshInvocation(
+      dev({ name: 'pinnacles', user: 'muqsit', auth: { method: 'password', bundle: 'muqsit', bundleKey: 'password' } }),
+      ['uptime'],
+      '/shim/askpass.sh',
+      {},
+      { agentOnly: true },
+    );
+    expect(env[ASKPASS_AGENT_ONLY_ENV]).toBe('1');
+    // still the normal password wiring — the probe just adds the broker-only flag
+    expect(env[ASKPASS_BUNDLE_ENV]).toBe('muqsit');
+    expect(env.SSH_ASKPASS).toBe('/shim/askpass.sh');
+  });
+
+  it('agentOnly on a key-auth device is a no-op (no bundle, no broker flag)', () => {
+    const { env } = buildSshInvocation(
+      dev({ name: 'k', user: 'me', auth: { method: 'key' } }),
+      ['uptime'],
+      '/shim',
+      {},
+      { agentOnly: true },
+    );
+    expect(env[ASKPASS_AGENT_ONLY_ENV]).toBeUndefined();
+    expect(env.SSH_ASKPASS).toBeUndefined();
   });
 
   it('Windows password device wraps the command AND keeps the shim', () => {

--- a/apps/cli/src/lib/devices/connect.ts
+++ b/apps/cli/src/lib/devices/connect.ts
@@ -27,6 +27,14 @@ import { type DeviceProfile } from './registry.js';
 export const ASKPASS_BUNDLE_ENV = 'AGENTS_SSH_BUNDLE';
 /** Env var the askpass shim reads to know which key in the bundle is the password. */
 export const ASKPASS_KEY_ENV = 'AGENTS_SSH_KEY';
+/**
+ * Env var that forces the askpass bundle resolve to be broker-only (`agentOnly`)
+ * regardless of TTY. A read-only stats probe (`agents devices` load/mem columns)
+ * sets this so an uncached password-auth device resolves from the already-unlocked
+ * secrets broker or degrades to an unreachable row — never a foreground Touch ID
+ * sheet. See {@link buildSshInvocation}'s `agentOnly` option and `runAskpass`. (RUSH-1970)
+ */
+export const ASKPASS_AGENT_ONLY_ENV = 'AGENTS_SSH_AGENT_ONLY';
 
 /**
  * Build the `user@host` (or bare `host`) ssh target for a device and validate
@@ -101,12 +109,17 @@ export interface SshHostKeyOptions {
  * Host-key checking runs against the CLI-managed known_hosts store (never the
  * user's `~/.ssh/known_hosts`): strict once `hostKey.pinned` is set, else
  * `accept-new` to learn+pin the key on first connect (RUSH-1767).
+ *
+ * `opts.agentOnly` marks the connection as a read-only probe: for password auth
+ * it sets {@link ASKPASS_AGENT_ONLY_ENV} in the overlay so the askpass resolve
+ * stays broker-only and never pops a foreground biometric (RUSH-1970).
  */
 export function buildSshInvocation(
   device: DeviceProfile,
   cmd: string[],
   askpassShimPath: string,
   hostKey: SshHostKeyOptions = {},
+  opts: { agentOnly?: boolean } = {},
 ): { args: string[]; env: Record<string, string> } {
   const target = sshTargetFor(device);
   const remote = wrapRemoteCommand(device, cmd);
@@ -124,6 +137,7 @@ export function buildSshInvocation(
     env.SSH_ASKPASS_REQUIRE = 'force';
     env[ASKPASS_BUNDLE_ENV] = device.auth.bundle;
     env[ASKPASS_KEY_ENV] = device.auth.bundleKey ?? 'password';
+    if (opts.agentOnly) env[ASKPASS_AGENT_ONLY_ENV] = '1';
     args.push('-o', 'PreferredAuthentications=password', '-o', 'PubkeyAuthentication=no', '-o', 'NumberOfPasswordPrompts=1');
   } else {
     args.push('-o', 'BatchMode=yes');

--- a/apps/cli/src/lib/devices/health.ts
+++ b/apps/cli/src/lib/devices/health.ts
@@ -221,7 +221,10 @@ export function probeDeviceStats(
     // remote login shell, which evaluates the snippet's `;`/`||` directly — no
     // `sh -c` wrapper needed (and a wrapper would only re-quote the first token).
     // For powershell devices it base64-encodes the snippet instead.
-    ({ args, env } = buildSshInvocation(device, [isWin ? WIN_PROBE_SNIPPET : PROBE_SNIPPET], shim));
+    // agentOnly: this is a read-only stats probe. A password-auth device must
+    // resolve its bundle broker-only — never force a foreground Touch ID sheet
+    // just to render the load/mem columns of `agents devices` (RUSH-1970).
+    ({ args, env } = buildSshInvocation(device, [isWin ? WIN_PROBE_SNIPPET : PROBE_SNIPPET], shim, {}, { agentOnly: true }));
   } catch {
     return Promise.resolve({ host, reachable: false, fetchedAt });
   }


### PR DESCRIPTION
## RUSH-1970 — read-only `agents devices` list must never force a Touch ID sheet

Running `agents devices` triggered a macOS biometric ("Unlock agents-cli secrets") whenever an **uncached password-auth device** (e.g. `pinnacles`) was present. A read-only list rendering load/mem columns must never pop a foreground biometric.

### Root cause (traced, file:line)

- `loadFleetStats` (`apps/cli/src/commands/ssh.ts:744`) live-SSH-probes any device missing from the warm cache (`apps/cli/src/lib/devices/stats-cache.ts:128`) through `probeDeviceStats` (`apps/cli/src/lib/devices/health.ts:209-243`).
- For `auth.method==='password'`, `buildSshInvocation` forces the askpass shim — `SSH_ASKPASS_REQUIRE=force` at the device's Keychain bundle (`apps/cli/src/lib/devices/connect.ts:119-127`) → `agents ssh __askpass`.
- `runAskpass` → `readAndResolveBundleEnv` with `agentOnly: isHeadlessSecretsContext()` (`apps/cli/src/commands/ssh.ts:1199`). Under a TTY `isHeadlessSecretsContext()` is `false` (`apps/cli/src/lib/secrets/bundles.ts:1119`), so the resolve is **not** broker-only and pops the biometry sheet (`keychain-helper.swift:174`). The daemon avoids it only because it runs headless.

### Fix — thread a "read-only probe → broker-only" signal

The stats probe now marks its SSH invocation as broker-only, so the askpass resolve stays `agentOnly` regardless of TTY:

- **`apps/cli/src/lib/devices/connect.ts`** — new `ASKPASS_AGENT_ONLY_ENV` (`AGENTS_SSH_AGENT_ONLY`, `connect.ts:31-38`) and an `opts.agentOnly` on `buildSshInvocation`; for password auth it sets the env var in the overlay (`connect.ts:135`).
- **`apps/cli/src/lib/devices/health.ts`** — `probeDeviceStats` builds the invocation with `agentOnly: true` (`health.ts:224`).
- **`apps/cli/src/commands/ssh.ts`** — `runAskpass` reads `ASKPASS_AGENT_ONLY_ENV` and forces `agentOnly: true`, falling back to `isHeadlessSecretsContext()` otherwise (`ssh.ts:1195-1199`).

An uncached password-auth device now resolves from the broker if already unlocked, else degrades to an unreachable row — **no Touch ID**. Online/offline precedence, the daemon cache-warm path, and `reachability.ts` are untouched (scoped narrowly for a clean rebase against RUSH-1964/1965).

### Tests (real-path, no mocking)

Added to `apps/cli/src/lib/devices/connect.test.ts` (the pure seam `probeDeviceStats` calls):

- `agentOnly` stats probe of a password device → env carries `AGENTS_SSH_AGENT_ONLY=1` alongside the normal bundle wiring.
- A normal (non-probe) password connect → env does **not** carry the flag (interactive resolve unchanged).
- `agentOnly` on a key-auth device is a no-op (no bundle, no flag).

```
src/lib/devices/connect.test.ts  18 passed
devices + ssh suites             44 passed (connect, health, ssh)
bun run build (tsc)              clean, exit 0
```

Full `bun run test`: 6775 passed. The 6 failures (`exec.test.ts`, `session/discover.test.ts`, `__tests__/models.test.ts`, `tmux/session.test.ts`, `tests/non-interactive.test.ts`) are pre-existing environmental flakes — they reproduce on the untouched `main` checkout and none touch the devices/ssh path.