### PR TITLE
fix(fleet): gate version+doctor dials on reachability on the default path (RUSH-1964)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1964.md
+++ b/apps/cli/.changelog/next/RUSH-1964.md
@@ -1,0 +1,11 @@
+- **`agents fleet status` no longer hangs on an unreachable box (RUSH-1964).** The cheap
+  stats probe (~2.5s) already learns whether each box is reachable, but the dead-box skip
+  that spares the expensive `agents --version` (15s) + `agents doctor --json` (30s) dials
+  was gated behind `--refresh` — so a default run still spent up to 45s per genuinely
+  unreachable box, and one down box could stall the whole matrix. The default path now
+  gates those dials on the same reachability verdict: a box the stats probe found
+  unreachable short-circuits straight to an `unreachable` row with zero further SSH
+  round-trips. Measured on a single blackholed target, `fleet status` dropped from 22.8s
+  to 2.8s. (VPN-first transport and SSH key provisioning remain deferred.) Source:
+  `apps/cli/src/lib/devices/fleet.ts` (`fleetHealthSkip`), `apps/cli/src/commands/ssh.ts`
+  (`runFleetStatus`).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 1.20.74
 
+- **`agents fleet status` no longer hangs on an unreachable box (RUSH-1964).** The
+  cheap stats probe (~2.5s) already learns whether each box is reachable, but the
+  dead-box skip that spares the expensive `agents --version` (15s) + `agents doctor
+  --json` (30s) dials was gated behind `--refresh` — so a default run still spent up
+  to 45s per genuinely-unreachable box, and one down box could stall the whole
+  matrix. The default path now gates those dials on the same reachability verdict: a
+  box the stats probe found unreachable short-circuits straight to an `unreachable`
+  row with zero further SSH round-trips. Measured on a single blackholed target,
+  `fleet status` dropped from 22.8s to 2.8s. (VPN-first transport and SSH key
+  provisioning remain deferred.) Source: `apps/cli/src/lib/devices/fleet.ts`
+  (`fleetHealthSkip`), `apps/cli/src/commands/ssh.ts` (`runFleetStatus`).
+
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## 1.20.74
 
-- **`agents fleet status` no longer hangs on an unreachable box (RUSH-1964).** The
-  cheap stats probe (~2.5s) already learns whether each box is reachable, but the
-  dead-box skip that spares the expensive `agents --version` (15s) + `agents doctor
-  --json` (30s) dials was gated behind `--refresh` — so a default run still spent up
-  to 45s per genuinely-unreachable box, and one down box could stall the whole
-  matrix. The default path now gates those dials on the same reachability verdict: a
-  box the stats probe found unreachable short-circuits straight to an `unreachable`
-  row with zero further SSH round-trips. Measured on a single blackholed target,
-  `fleet status` dropped from 22.8s to 2.8s. (VPN-first transport and SSH key
-  provisioning remain deferred.) Source: `apps/cli/src/lib/devices/fleet.ts`
-  (`fleetHealthSkip`), `apps/cli/src/commands/ssh.ts` (`runFleetStatus`).
-
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -61,6 +61,7 @@ import { ensureManagedKnownHostsDir, isHostPinned } from '../lib/devices/known-h
 import { shouldSyncTerminfo, syncTerminfoToDevice, terminfoHostKey } from '../lib/devices/terminfo.js';
 import {
   fanOutDevices,
+  fleetHealthSkip,
   planFleetTargets,
   remoteFleetTargets,
   runFleet,
@@ -474,21 +475,14 @@ async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: 
     .map((t) => ({
       name: t.device.name,
       platform: t.device.platform,
-      skip: t.skip,
+      // Fail fast: gate the expensive version+doctor dials on the reachability
+      // verdict the cheap stats probe already computed one step earlier. A box
+      // it found unreachable skips straight to an `unreachable` row instead of
+      // burning 15s+30s per box — so one genuinely-offline device can't stall
+      // the matrix for ~60s (RUSH-1964). See {@link fleetHealthSkip} for why
+      // this is trusted on the default path, not just under `--refresh`.
+      skip: fleetHealthSkip(t.skip, statsMap.get(t.device.name)),
       dialTarget: fleetDialTarget(t.device),
-      // Fail fast: the stats probe already tried this box with the same
-      // (registry) address. If it came back unreachable, don't spend another
-      // 15s+30s on version+doctor — skip straight to an unreachable row so one
-      // genuinely-offline device can't stall the whole matrix.
-      //
-      // Only trust this on a FRESH probe (`--refresh`/`--live`). loadFleetStats
-      // is cache-first (daemon-warmed ~3min), so a box that came back online
-      // since the last warm would otherwise be skipped to "unreachable" without
-      // a live attempt — a false negative. On a default run we still do the live
-      // probe (fast now that it dials the registry address).
-      ...(forceRefresh && statsMap.get(t.device.name)?.reachable === false && !t.skip
-        ? { skip: 'unreachable' }
-        : {}),
     }));
   const remote = await fanOutDevices(remoteTargets, probeRemoteHealth);
   for (const result of remote) {

--- a/apps/cli/src/lib/devices/fleet.test.ts
+++ b/apps/cli/src/lib/devices/fleet.test.ts
@@ -3,12 +3,18 @@ import {
   planFleetTargets,
   remoteFleetTargets,
   fanOutDevices,
+  fleetHealthSkip,
   runFleet,
   skipLabel,
   upgradeCommand,
   type FleetTarget,
 } from './fleet.js';
 import type { DeviceProfile, DeviceRegistry } from './registry.js';
+import type { DeviceStats } from './health.js';
+
+function stats(host: string, reachable: boolean): DeviceStats {
+  return { host, reachable, fetchedAt: 0 };
+}
 
 function device(overrides: Partial<DeviceProfile> & { name: string }): DeviceProfile {
   const now = '2026-07-14T00:00:00.000Z';
@@ -80,6 +86,49 @@ describe('remoteFleetTargets (fleet health/drift gate targeting)', () => {
     expect(byName.zion).toBeUndefined(); // self is probed in-process, not fanned out
     expect(byName.worker.skip).toBeUndefined(); // a real probe target
     expect(byName.dead.skip).toBe('offline'); // genuine fault — kept, surfaces as unreachable
+  });
+});
+
+describe('fleetHealthSkip (gate version+doctor dials on the reachability verdict)', () => {
+  it('skips a box the stats probe found unreachable — on the DEFAULT path, no --refresh', () => {
+    // The regression this pins: before RUSH-1964 the skip was gated behind
+    // --refresh, so a default `fleet status` still spent 15s+30s per offline box.
+    expect(fleetHealthSkip(undefined, stats('dead', false))).toBe('unreachable');
+  });
+
+  it('does not skip a reachable box — it still gets its version/doctor dial', () => {
+    expect(fleetHealthSkip(undefined, stats('alive', true))).toBeUndefined();
+  });
+
+  it('leaves a box with no stats (never probed) to be dialed live', () => {
+    expect(fleetHealthSkip(undefined, undefined)).toBeUndefined();
+  });
+
+  it('keeps a pre-classified skip (offline/no-address/control) untouched', () => {
+    expect(fleetHealthSkip('offline', stats('x', true))).toBe('offline');
+    expect(fleetHealthSkip('no-address', undefined)).toBe('no-address');
+    // Even if the stats probe reached it, an existing skip reason wins.
+    expect(fleetHealthSkip('control', stats('cockpit', true))).toBe('control');
+  });
+
+  it('an unreachable-planned target never triggers a version/doctor probe', async () => {
+    // Full chain: fleetHealthSkip marks the row skip, fanOutDevices then returns
+    // it as skipped WITHOUT invoking the probe — so no ssh dial happens for a box
+    // already known unreachable (the 45s-per-box hang is never paid).
+    const dialed: string[] = [];
+    const targets = [
+      { name: 'alive', skip: fleetHealthSkip(undefined, stats('alive', true)) },
+      { name: 'dead', skip: fleetHealthSkip(undefined, stats('dead', false)) },
+    ];
+    const results = await fanOutDevices(targets, async (t) => {
+      dialed.push(t.name); // stands in for the version+doctor round-trips
+      return t.name;
+    });
+    expect(dialed).toEqual(['alive']); // 'dead' was never dialed
+    expect(results.map((r) => [r.name, r.status, r.reason])).toEqual([
+      ['alive', 'ok', undefined],
+      ['dead', 'skipped', 'unreachable'],
+    ]);
   });
 });
 

--- a/apps/cli/src/lib/devices/fleet.ts
+++ b/apps/cli/src/lib/devices/fleet.ts
@@ -11,6 +11,7 @@
 import { spawnSync } from 'child_process';
 import { isControlDevice, type DeviceProfile, type DeviceRegistry } from './registry.js';
 import { buildSshInvocation, sshTargetFor, writeAskpassShim } from './connect.js';
+import type { DeviceStats } from './health.js';
 
 export type FleetSkipReason = 'offline' | 'no-address' | 'control';
 
@@ -86,6 +87,34 @@ export function planFleetTargets(reg: DeviceRegistry): FleetTarget[] {
  */
 export function remoteFleetTargets(planned: FleetTarget[], self: string): FleetTarget[] {
   return planned.filter((t) => t.device.name !== self && t.skip !== 'control');
+}
+
+/**
+ * Decide whether a fleet-health target should skip the expensive version+doctor
+ * dials (`agents fleet status`). The cheap stats probe (~2.5s, same registry
+ * address) has already tried this box one step earlier. If it came back
+ * unreachable, dialing `agents --version` (15s) + `agents doctor --json` (30s)
+ * would almost certainly fail the same way — just 45s slower — so one
+ * genuinely-offline box would stall the whole matrix (the ~60s hang, RUSH-1964).
+ *
+ * We trust the stats verdict on the DEFAULT path, not only under
+ * `--refresh`/`--live`: `probeDeviceStats` and the version/doctor dials share
+ * one ssh path (`fleetDialTarget`), so reachability is not per-probe. The
+ * verdict is either freshly probed this run or daemon-warmed (~3min) with the
+ * live write-back from RUSH-1965, so a box that came online in the last few
+ * minutes is the only false-negative window — it renders `unreachable` until the
+ * next stats warm, which beats letting it hang the status glance for 45s.
+ *
+ * An existing skip (control/offline/no-address from {@link planFleetTargets})
+ * always wins — those are classified before any probe.
+ */
+export function fleetHealthSkip(
+  currentSkip: FleetSkipReason | string | undefined,
+  stats: DeviceStats | undefined,
+): FleetSkipReason | string | undefined {
+  if (currentSkip) return currentSkip;
+  if (stats?.reachable === false) return 'unreachable';
+  return undefined;
 }
 
 /** Human label for a skip reason. */


### PR DESCRIPTION
## RUSH-1964 (reduced scope) — fix the ~60s `agents fleet status` hang

Gate the expensive per-device `agents --version` (15s) + `agents doctor --json`
(30s) SSH dials on the reachability verdict the cheap stats probe already computed,
**on the default path** — not only under `--refresh`.

Out of scope (siblings, per the ticket's scope-reconciliation comment): reachability
write-back + prefer-live (RUSH-1965 #1480, merged) and `--host`/`--device`
unification (RUSH-1967 #1477, open). **Deferred** (larger follow-up, noted in ticket):
VPN-first transport + `ssh-copy-id` key provisioning.

### The bug

`runFleetStatus` computes each box's reachability one step earlier via the ~2.5s
stats probe, but the skip that spares the 15s+30s version+doctor dials was gated
behind `--refresh`/`--live`:

- Before, `apps/cli/src/commands/ssh.ts` (worktree base `origin/main` @ 2c60129b):
  ```
  ...(forceRefresh && statsMap.get(t.device.name)?.reachable === false && !t.skip
    ? { skip: 'unreachable' }
    : {}),
  ```
  On a normal run `forceRefresh` is false, so a genuinely-unreachable box was still
  dialed for up to 45s — and because the dials fan out in parallel, one down box that
  blackholes its SSH connect stalls the whole matrix for that long.

### The fix

- New pure helper, `apps/cli/src/lib/devices/fleet.ts:91` `fleetHealthSkip(currentSkip, stats)`:
  returns the existing skip if already classified (control/offline/no-address), else
  `'unreachable'` when `stats?.reachable === false`, else `undefined`. Docstring at
  `fleet.ts:78-90` explains why the stats verdict is trusted on the default path
  (same ssh path via `fleetDialTarget`; verdict is this run's probe or the
  daemon-warmed ~3min cache carrying the RUSH-1965 live write-back).
- `apps/cli/src/commands/ssh.ts:473-482` (`runFleetStatus`) now sets
  `skip: fleetHealthSkip(t.skip, statsMap.get(t.device.name))` — applied unconditionally,
  no `forceRefresh` gate. A box the stats probe found unreachable short-circuits to an
  `unreachable` row with zero further SSH round-trips.

### Test (real path, no mocking)

`apps/cli/src/lib/devices/fleet.test.ts:87-129` — `describe('fleetHealthSkip …')`:
- `reachable:false` → `'unreachable'` **on the default path** (pins the exact regression).
- reachable / no-stats → `undefined` (still dialed live).
- pre-classified skip (offline/no-address/control) is preserved.
- full chain: `fanOutDevices` returns the unreachable target as `skipped` **without
  invoking the probe** — proving no version/doctor dial happens.

```
Test Files  1 passed (1)
     Tests  18 passed (18)   # 13 existing + 5 new
```
Broader affected suites green: `src/lib/devices/` + `ssh.test.ts` → 16 files, 171 tests passed. `tsc --noEmit` clean, `npm run build` clean.

### Timing — built binary vs the previous build, same fresh registry

Wall-clock is a **parallel** fan-out, so it is floored by the single slowest dial.
To measure the fix's actual mechanism I isolated one unreachable-but-routable box
(`deadbox` → `100.127.255.254`, an unassigned Tailscale-CGNAT address whose SYN
blackholes, so its version+doctor dials hang the full timeout) as the sole remote
target, on a fresh HOME each run:

```
trial 1:  OLD=22.81s   NEW=2.78s
trial 2:  OLD=22.81s   NEW=2.76s
```

Row-level, on the real fleet (built binary), the unreachable boxes now short-circuit:
```
OLD:  ○ deadbox   ... probe failed   ssh: connec…      # dialed, waited for the SSH failure
NEW:  ○ deadbox   ... unreachable     unreachable       # skipped, zero version/doctor dials
```

**Honest note on the live fleet's wall clock:** a plain `fleet status` on this fleet
still takes ~64s because `zion` (a *reachable* macOS box) has a `doctor` dial that
times out over the Tailscale relay (~45s) and sets the parallel floor. That box is
reachable, so it is correctly dialed — lowering its cost is the **deferred**
VPN-first transport work, not this ticket. This fix removes genuinely-unreachable
boxes from the critical path (proven above); it cannot lower a floor set by a
reachable-but-slow box.

Refs RUSH-1964.
