### PR TITLE
feat(fleet): redesign fleet status output — rollup + NEEDS ATTENTION, quiet-when-healthy (RUSH-1966)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,8 @@ agents sync --host gpu-box              # make the remote machine current
 agents doctor --devices                 # readiness matrix for every registered device
 agents doctor --devices --json          # machine-readable fleet readiness
 agents doctor --device mac-mini         # same matrix, scoped to one device
-agents fleet status                     # warnings rollup + health/sync/version/Auth matrix (cache-first)
+agents fleet status                     # online/offline rollup + NEEDS ATTENTION + OS-grouped rows (cache-first)
+agents fleet status --verbose           # full per-device auth/CLI/sync/version grid
 agents fleet status --live              # force a live resource probe (alias of --refresh)
 agents fleet status --json --strict     # scriptable fleet health gate
 agents check --devices                  # CI drift gate across every registered device
@@ -473,13 +474,21 @@ this machine locally plus any device missing from the cache; pass `--refresh` (o
 shorter `--live`) to force a full live probe of every box. Cache-served output notes its
 age (`updated 2m ago — pass --refresh (--live) for a live probe`).
 
-`agents fleet status` adds an **Auth column** — which agent accounts are actually
-logged in, per device, read from the auth-health cache (no network). Four buckets keep
-it from crying wolf: `●live` (verified), `·present` (signed in but the agent has no
-live-probe endpoint — e.g. codex/grok — benign), `◐degraded` (soft/self-healing:
-expired-but-refreshing, rate-limited), and `○revoked` (server rejected — re-login now).
-Only `○` means a real re-login is needed. Run `agents fleet ping` to force a live
-re-verification across the fleet.
+`agents fleet status` answers "is my fleet OK?" at a glance: a one-line rollup
+(`● N online · ○ M offline`), a short **NEEDS ATTENTION** list where every item names
+the command that fixes it (offline → `check the box`, config drift or a stark CLI gap →
+`agents apply <box>`, version skew → `agents upgrade --fleet`), then quiet per-device
+rows grouped by OS (macOS / Linux / Windows) showing just `name · capacity · load/mem ·
+version`, with this machine flagged `▸ … ← this machine`. A healthy fleet reads in a few
+lines; orphaned versions are demoted to a one-line `agents prune` nudge in the footer.
+
+Pass `--verbose` for the full per-device grid — the **Auth column** (which agent accounts
+are actually logged in, per device, read from the auth-health cache — no network), plus
+the CLI-readiness and sync-drift columns. The Auth column has four buckets so it never
+cries wolf: `●live` (verified), `·present` (signed in but the agent has no live-probe
+endpoint — e.g. codex/grok — benign), `◐degraded` (soft/self-healing: expired-but-refreshing,
+rate-limited), and `○revoked` (server rejected — re-login now). Only `○` means a real
+re-login is needed. Run `agents fleet ping` to force a live re-verification across the fleet.
 
 **Hosts** (`agents hosts`) are git-synced dispatch targets in `agents.yaml`; **devices** (`agents devices`) are your Tailscale machines in a local registry. Both ride SSH and feed one host pool: devices appear in `agents hosts list` and capability routing without a second enrollment. On `--host` runs every `agents run` option is either forwarded (`--effort --env --timeout --loop …`), rejected loud (`--secrets` never crosses SSH implicitly), or consumed locally — nothing silently drops. See [docs/00-concepts.md](apps/cli/docs/00-concepts.md#devices--hosts).
 

--- a/apps/cli/.changelog/next/RUSH-1966.md
+++ b/apps/cli/.changelog/next/RUSH-1966.md
@@ -1,0 +1,16 @@
+- **`agents fleet status` output redesigned — rollup + NEEDS ATTENTION, quiet when healthy
+  (RUSH-1966).** The old grid buried "is my fleet OK?" under duplicated columns and glyph
+  soup (a "Health" column that just repeated Load/Mem, `stale · cold` counts across every
+  orphan version, an `●5 ·8 ◐3` auth cell, and warnings that re-listed all 12 devices three
+  times). The default view now leads with a one-line rollup (`● N online · ○ M offline`),
+  then a short **NEEDS ATTENTION** list where every item names its fix command — offline →
+  `check the box`, config drift or a stark CLI gap → `agents apply <box>`, version skew →
+  `agents upgrade --fleet` — then quiet per-device rows grouped by OS (macOS / Linux /
+  Windows) showing `name · capacity · load/mem · version`, with this machine flagged
+  `▸ … ← this machine`. Drift is reported on the active version only (not orphan versions);
+  orphaned versions are demoted to a one-line `agents prune` nudge in the footer; the
+  freshness footer names the cache age and what `--live` / `--verbose` add. A healthy fleet
+  reads in a few lines. The full per-device auth/CLI/sync/version grid moves behind the new
+  `--verbose` flag; `--json` is unchanged. Source: `apps/cli/src/lib/devices/health-report.ts`
+  (`renderFleetSummary`, `buildFleetAttentionItems`), `apps/cli/src/commands/ssh.ts`
+  (`runFleetStatus`).

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -79,6 +79,7 @@ import {
 import {
   buildFleetHealthReport,
   renderFleetMatrix,
+  renderFleetSummary,
   renderFleetWarnings,
   type FleetHealthRow,
 } from '../lib/devices/health-report.js';
@@ -452,7 +453,7 @@ async function probeRemoteHealth(target: FleetStatusTarget): Promise<Omit<FleetH
   };
 }
 
-async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: boolean; refresh?: boolean; live?: boolean }): Promise<void> {
+async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: boolean; refresh?: boolean; live?: boolean; verbose?: boolean }): Promise<void> {
   const reg = await loadDevices();
   const self = machineId();
   const forceRefresh = Boolean(opts.refresh || opts.live);
@@ -521,15 +522,27 @@ async function runFleetStatus(opts: { json?: boolean; strict?: boolean; stats?: 
   const authCache = readAuthHealthCache();
   for (const row of rows) {
     if (!row.auth) row.auth = summarizeHostAuth(authCache, row.name);
+    // Resolve the online/offline verdict and last-seen once (RUSH-1966) so the
+    // summary view reads one truth — the same `deviceOnlineState` ordering the
+    // registry write-back uses — instead of re-deriving it from error/skipped.
+    const profile = reg[row.name];
+    if (profile) {
+      row.online = deviceOnlineState(profile, statsMap.get(row.name));
+      row.lastSeen = profile.tailscale?.lastSeen ?? profile.reachability?.checkedAt;
+    }
   }
 
   const report = buildFleetHealthReport(rows);
   if (opts.json) {
     console.log(JSON.stringify(report, null, 2));
-  } else {
+  } else if (opts.verbose) {
+    // Full grid: the auth/CLI/sync/version columns and the warnings rollup.
     for (const line of renderFleetWarnings(report)) console.log(line);
     console.log();
     for (const line of renderFleetMatrix(report)) console.log(line);
+  } else {
+    // Default: rollup + NEEDS ATTENTION + OS-grouped quiet rows + footer.
+    for (const line of renderFleetSummary(report, { self })) console.log(line);
   }
   if (opts.strict && report.hasWarnings) process.exitCode = 1;
 }
@@ -892,14 +905,20 @@ Typical workflow:
 
   devicesCmd
     .command('status')
-    .description('Show fleet health: warnings rollup, per-device sync drift, CLI readiness, version skew, and resource headroom.')
+    .description('Fleet health at a glance: online/offline rollup, a NEEDS ATTENTION list (each with its fix command), and quiet per-device rows grouped by OS. Use --verbose for the full auth/CLI/sync grid.')
     .option('--json', 'output machine-readable JSON')
     .option('--strict', 'exit non-zero when any device has drift or is unreachable')
     .option('--no-stats', 'skip the live resource probe')
     .option('--refresh', 'force a live probe of every device, bypassing the cache')
     .option('--live', 'alias of --refresh (shorter to type)')
-    .action(async (opts: { json?: boolean; strict?: boolean; stats?: boolean; refresh?: boolean; live?: boolean }) => {
-      await runFleetStatus(opts);
+    .option('--verbose', 'show the full per-device auth/CLI/sync/version grid instead of the summary')
+    .action(async (opts: { json?: boolean; strict?: boolean; stats?: boolean; refresh?: boolean; live?: boolean; verbose?: boolean }, cmd: Command) => {
+      // The root program also defines a global `--verbose`; commander binds a
+      // shared long flag to the program, not the leaf. Read the effective value
+      // from the merged globals so `fleet status --verbose` works at either level
+      // (same pattern as `fleet ping --verbose`).
+      const verbose = opts.verbose ?? Boolean(cmd.optsWithGlobals().verbose);
+      await runFleetStatus({ ...opts, verbose });
     });
 
   devicesCmd

--- a/apps/cli/src/lib/devices/health-report.test.ts
+++ b/apps/cli/src/lib/devices/health-report.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildFleetAttentionItems,
   buildFleetHealthReport,
   freshnessFooter,
+  platformGroupLabel,
   renderFleetMatrix,
+  renderFleetSummary,
   renderFleetWarnings,
+  shortVersion,
   type FleetHealthRow,
 } from './health-report.js';
 import { stripAnsi } from '../session/width.js';
@@ -24,7 +28,18 @@ function row(overrides: Partial<FleetHealthRow> & { name: string }): FleetHealth
     ],
     orphans: overrides.orphans ?? [],
     auth: overrides.auth,
+    online: overrides.online,
+    lastSeen: overrides.lastSeen,
   };
+}
+
+/** N of the known CLIs installed, out of `total` — for stark-gap tests. */
+function clis(installed: number, total: number): FleetHealthRow['clis'] {
+  const out: FleetHealthRow['clis'] = {};
+  for (let i = 0; i < total; i++) {
+    out[`agent${i}`] = { installed: i < installed, path: i < installed ? '/bin/x' : null, error: null };
+  }
+  return out;
 }
 
 describe('buildFleetHealthReport', () => {
@@ -137,5 +152,125 @@ describe('Auth column + freshness', () => {
 
   it('freshnessFooter returns null when no row carries a timestamp', () => {
     expect(freshnessFooter([row({ name: 'a' })])).toBeNull();
+  });
+});
+
+describe('summary view helpers (RUSH-1966)', () => {
+  it('shortVersion collapses dev builds and passes released semver through', () => {
+    expect(shortVersion('0.0.0-dev.867dea00-dirty')).toBe('dev-dirty');
+    expect(shortVersion('0.0.0-dev.867dea00')).toBe('dev');
+    expect(shortVersion('1.20.74')).toBe('1.20.74');
+    expect(shortVersion(null)).toBe('—');
+    expect(shortVersion(undefined)).toBe('—');
+  });
+
+  it('platformGroupLabel buckets by OS family', () => {
+    expect(platformGroupLabel('macos')).toBe('macOS');
+    expect(platformGroupLabel('darwin')).toBe('macOS');
+    expect(platformGroupLabel('linux')).toBe('Linux');
+    expect(platformGroupLabel('windows')).toBe('Windows');
+    expect(platformGroupLabel('win32')).toBe('Windows');
+    expect(platformGroupLabel(undefined)).toBe('Other');
+  });
+});
+
+describe('buildFleetAttentionItems (only real, actionable problems)', () => {
+  const stale = [{ agent: 'codex', version: '0.1.0', status: 'stale' as const, isDefault: true }];
+
+  it('flags a genuinely-offline box, but NOT an unknown/unconfigured one', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'down', online: 'offline', lastSeen: '2026-07-28T00:00:00.000Z' }),
+      row({ name: 'never-set-up', online: 'unknown' }), // registered, never addressed
+      row({ name: 'up', online: 'online' }),
+    ]);
+    const items = buildFleetAttentionItems(report, Date.parse('2026-07-31T00:00:00.000Z'));
+    const offline = items.filter((i) => i.glyph === 'offline');
+    expect(offline.map((i) => i.subject)).toEqual(['down']); // not 'never-set-up', not 'up'
+    expect(offline[0].detail).toContain('last seen');
+    expect(offline[0].fix).toBe('check the box');
+  });
+
+  it('merges config drift and a stark CLI gap into one `agents apply` item per box', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'multi', online: 'online', sync: stale, clis: clis(1, 9) }),
+    ]);
+    const items = buildFleetAttentionItems(report);
+    const apply = items.filter((i) => i.fix === 'agents apply multi');
+    expect(apply).toHaveLength(1); // one line, not two
+    expect(apply[0].detail).toContain('config drift');
+    expect(apply[0].detail).toContain('only 1 of 9');
+  });
+
+  it('does not flag a normal partial CLI install (6 of 9) — only a stark gap', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'normal', online: 'online', clis: clis(6, 9) }), // no drift, benign CLI count
+    ]);
+    expect(buildFleetAttentionItems(report)).toEqual([]);
+  });
+
+  it('summarizes version skew as one line with per-version counts', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'a', online: 'online', version: '1.20.73' }),
+      row({ name: 'b', online: 'online', version: '1.20.73' }),
+      row({ name: 'c', online: 'online', version: '1.20.74' }),
+    ]);
+    const skew = buildFleetAttentionItems(report).find((i) => i.subject === 'version skew')!;
+    expect(skew.detail).toBe('2× 1.20.73 · 1× 1.20.74');
+    expect(skew.fix).toBe('agents upgrade --fleet');
+  });
+
+  it('a fully-healthy fleet has zero attention items', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'a', online: 'online', version: '1.20.74', clis: clis(9, 9) }),
+      row({ name: 'b', online: 'online', version: '1.20.74', clis: clis(9, 9) }),
+    ]);
+    expect(buildFleetAttentionItems(report)).toEqual([]);
+  });
+});
+
+describe('renderFleetSummary (default view)', () => {
+  it('leads with the online/offline rollup and groups rows by OS, highlighting this machine', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'zion', platform: 'macos', online: 'online', version: '1.20.74',
+        stats: { host: 'zion', reachable: true, loadPercent: 23, memPercent: 49, fetchedAt: 1000 } as never }),
+      row({ name: 'linux-box', platform: 'linux', online: 'online', version: '1.20.74',
+        stats: { host: 'linux-box', reachable: true, loadPercent: 2, memPercent: 15, fetchedAt: 1000 } as never }),
+      row({ name: 'down', platform: 'linux', online: 'offline', version: '1.20.74', lastSeen: '2026-07-28T00:00:00.000Z' }),
+    ]);
+    const lines = renderFleetSummary(report, { self: 'zion', now: 2000 }).map(stripAnsi);
+    const text = lines.join('\n');
+    expect(text).toContain('2 online');
+    expect(text).toContain('1 offline');
+    expect(text).toContain('macOS');
+    expect(text).toContain('Linux');
+    // this machine's row is prefixed and annotated (not the rollup line, which
+    // also names self in its right-aligned suffix)
+    const selfLine = lines.find((l) => l.includes('← this machine'))!;
+    expect(selfLine).toContain('▸');
+    expect(selfLine).toContain('zion');
+    // an offline row shows a dash for load/mem and version, and its last-seen
+    const downLine = lines.find((l) => l.includes('down'))!;
+    expect(downLine).toContain('offline');
+    expect(downLine).toContain('last seen');
+    // footer nudges toward --verbose for the full grid
+    expect(text).toContain('--verbose');
+  });
+
+  it('a healthy fleet reads short: rollup + an all-clear line, no NEEDS ATTENTION block', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'a', online: 'online', version: '1.20.74', clis: clis(9, 9) }),
+    ]);
+    const text = renderFleetSummary(report, { self: 'a' }).map(stripAnsi).join('\n');
+    expect(text).toContain('Everything looks healthy.');
+    expect(text).not.toContain('NEEDS ATTENTION');
+  });
+
+  it('demotes orphaned versions to a single footer nudge toward prune, not a per-row column', () => {
+    const report = buildFleetHealthReport([
+      row({ name: 'a', online: 'online', orphans: [{ agent: 'codex', version: '0.1.0', commands: 1, skills: 0, hooks: 0 }] }),
+    ]);
+    const text = renderFleetSummary(report, {}).map(stripAnsi).join('\n');
+    expect(text).toContain('1 device carries orphaned versions');
+    expect(text).toContain('agents prune');
   });
 });

--- a/apps/cli/src/lib/devices/health-report.ts
+++ b/apps/cli/src/lib/devices/health-report.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { padToWidth, stringWidth, terminalWidth, truncateToWidth } from '../session/width.js';
 import { fmtBytes, headroom, type DeviceStats } from './health.js';
 import { formatCheckedAge, type HostAuthSummary } from '../auth-health.js';
+import type { OnlineState } from './reachability.js';
 
 export interface FleetCliStatus {
   installed: boolean;
@@ -38,6 +39,13 @@ export interface FleetHealthRow {
   /** Cached auth-health rollup for this host (the Auth column). Undefined when
    *  the host has never been probed (`agents fleet ping`) or the cache is cold. */
   auth?: HostAuthSummary;
+  /** Resolved online/offline verdict (from {@link deviceOnlineState}). Populated
+   *  by `runFleetStatus` for the summary view; undefined in the raw grid. */
+  online?: OnlineState;
+  /** When this box was last seen reachable (ISO), for the "last seen …" note on
+   *  an offline row. Sourced from the registry's tailscale snapshot / reachability
+   *  verdict. Undefined when never recorded. */
+  lastSeen?: string;
 }
 
 export interface FleetWarning {
@@ -278,4 +286,234 @@ export function freshnessFooter(rows: FleetHealthRow[], now: number = Date.now()
   if (oldestAuth != null) parts.push(`auth ${formatCheckedAge(oldestAuth, now)}`);
   if (parts.length === 0) return null;
   return `  updated ${parts.join(' · ')} — pass --refresh (--live) for a live probe`;
+}
+
+// ---------------------------------------------------------------------------
+// Summary view (default): rollup + NEEDS ATTENTION + OS groups + footer.
+// The full grid above is kept for `--verbose`. (RUSH-1966)
+// ---------------------------------------------------------------------------
+
+/** Collapse a long dev build (`0.0.0-dev.<sha>[-dirty]`) to `dev`/`dev-dirty`;
+ *  released semver is shown verbatim. Keeps the version column narrow and stops
+ *  a single dev box from widening every row. */
+export function shortVersion(version: string | null | undefined): string {
+  if (!version) return '—';
+  const m = version.match(/-dev\b/);
+  if (m) return /dirty/.test(version) ? 'dev-dirty' : 'dev';
+  return version;
+}
+
+/** OS bucket label for grouping. Anything unrecognized falls under "Other". */
+export function platformGroupLabel(platform: string | undefined): 'macOS' | 'Linux' | 'Windows' | 'Other' {
+  const p = (platform ?? '').toLowerCase();
+  if (p === 'macos' || p === 'darwin') return 'macOS';
+  if (p === 'linux') return 'Linux';
+  if (p.startsWith('win')) return 'Windows';
+  return 'Other';
+}
+
+const GROUP_ORDER: Array<'macOS' | 'Linux' | 'Windows' | 'Other'> = ['macOS', 'Linux', 'Windows', 'Other'];
+
+/** Non-fresh sync rows for the ACTIVE (default) version only — the drift that a
+ *  running install actually feels, not stale/cold counts across old orphans. */
+function activeDriftRows(row: FleetHealthRow): FleetSyncStatus[] {
+  return row.sync.filter((s) => s.isDefault && s.status !== 'fresh');
+}
+
+function isOffline(row: FleetHealthRow): boolean {
+  // Prefer the resolved verdict; fall back to a probe error/skip when the caller
+  // didn't populate it (e.g. a raw report). Only a positive 'online' is "up".
+  if (row.online) return row.online !== 'online';
+  return Boolean(row.error || row.skipped);
+}
+
+/** A box with a real offline verdict — as opposed to `unknown` (registered but
+ *  never addressed/probed). Only a genuine offline is a "check the box" item;
+ *  an unknown box is unconfigured, not down. */
+function isGenuinelyOffline(row: FleetHealthRow): boolean {
+  return row.online === 'offline' || (!row.online && Boolean(row.error || row.skipped));
+}
+
+/** A CLI count is only worth flagging when it's stark — the box is missing more
+ *  than two-thirds of the known agent CLIs (e.g. 1/9), which signals a
+ *  broken/half-set-up box. A normal partial install (a box that just doesn't run
+ *  every agent) is not a problem, so this deliberately does NOT fire at 4/9 or
+ *  6/9. The full count stays visible under `--verbose`. */
+function starkCliGap(row: FleetHealthRow): { installed: number; total: number } | null {
+  const { installed, total } = installedCliCount(row);
+  return total > 0 && installed * 3 < total ? { installed, total } : null;
+}
+
+export interface FleetAttentionItem {
+  /** Leading mark: `○` offline, `⚠` config/CLI/version issue. */
+  glyph: 'offline' | 'warn';
+  subject: string;
+  detail: string;
+  /** The exact command (or instruction) that fixes it. */
+  fix: string;
+}
+
+/**
+ * The actionable problems only — each with the command that fixes it. Order:
+ * offline boxes, CLI gaps, active-version config drift, then version skew.
+ * A healthy fleet returns `[]` (the caller prints an all-clear line).
+ */
+export function buildFleetAttentionItems(report: FleetHealthReport, now: number = Date.now()): FleetAttentionItem[] {
+  const items: FleetAttentionItem[] = [];
+  // 1) Genuinely-offline boxes (not `unknown`/unconfigured), each individually.
+  for (const row of report.devices) {
+    if (!isGenuinelyOffline(row)) continue;
+    const seen = row.lastSeen ? ` · last seen ${formatCheckedAge(Date.parse(row.lastSeen), now)}` : '';
+    items.push({ glyph: 'offline', subject: row.name, detail: `offline${seen}`, fix: 'check the box' });
+  }
+  // 2) Boxes that need `agents apply` — merge config drift and a stark CLI gap
+  // into ONE item per box (both are fixed by the same command, so don't
+  // double-list). An offline box's config/CLI is unknowable, so skip it.
+  for (const row of report.devices) {
+    if (isOffline(row)) continue;
+    const reasons: string[] = [];
+    if (activeDriftRows(row).length > 0) reasons.push('config drift');
+    const stark = starkCliGap(row);
+    if (stark) reasons.push(`only ${stark.installed} of ${stark.total} agent CLIs installed`);
+    if (reasons.length > 0) {
+      items.push({ glyph: 'warn', subject: row.name, detail: reasons.join(' · '), fix: `agents apply ${row.name}` });
+    }
+  }
+  // 3) Version skew across the fleet — one line.
+  const skew = report.warnings.find((w) => w.kind === 'version-skew');
+  if (skew) {
+    const counts = new Map<string, number>();
+    for (const row of report.devices) {
+      if (!row.version) continue;
+      const v = shortVersion(row.version);
+      counts.set(v, (counts.get(v) ?? 0) + 1);
+    }
+    const summary = Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([v, n]) => `${n}× ${v}`)
+      .join(' · ');
+    items.push({ glyph: 'warn', subject: 'version skew', detail: summary, fix: 'agents upgrade --fleet' });
+  }
+  return items;
+}
+
+/** Right-aligned `<content>` on the same line as `left`, clamped so it never
+ *  overlaps the left text on a narrow terminal. */
+function alignRight(left: string, right: string, width: number): string {
+  const gap = width - stringWidth(left) - stringWidth(right);
+  return gap > 1 ? `${left}${' '.repeat(gap)}${right}` : `${left}  ${right}`;
+}
+
+function headroomWord(row: FleetHealthRow): string {
+  if (isOffline(row)) return chalk.gray(row.online === 'unknown' ? 'unknown' : 'offline');
+  return headroomLabel(row);
+}
+
+function loadMemCell(row: FleetHealthRow): string {
+  if (isOffline(row) || !row.stats?.reachable) return chalk.gray('—');
+  const load = row.stats.loadPercent === undefined ? '—' : `${Math.round(row.stats.loadPercent)}%`;
+  const mem = row.stats.memPercent === undefined ? '—' : `${Math.round(row.stats.memPercent)}%`;
+  return `${load} / ${mem}`;
+}
+
+function versionCell(row: FleetHealthRow): string {
+  if (isOffline(row)) return chalk.gray('—');
+  return shortVersion(row.version);
+}
+
+/**
+ * The default `agents fleet status` view (RUSH-1966): a one-line rollup, a
+ * NEEDS ATTENTION list of only the actionable problems (each with its fix
+ * command), quiet per-device rows grouped by OS, and an honest footer. The full
+ * auth/CLI/sync grid moves behind `--verbose` ({@link renderFleetMatrix}).
+ */
+export function renderFleetSummary(
+  report: FleetHealthReport,
+  opts: { self?: string; now?: number } = {},
+): string[] {
+  const now = opts.now ?? Date.now();
+  const width = terminalWidth();
+  const rows = report.devices;
+  if (rows.length === 0) return [chalk.gray('No registered devices. Run `agents devices` to register some.')];
+
+  const online = rows.filter((r) => !isOffline(r)).length;
+  const offline = rows.length - online;
+  const oldestStats = oldestAcross(rows, (r) => r.stats?.fetchedAt);
+  const cachedAge = oldestStats != null ? `cached ${formatCheckedAge(oldestStats, now)}` : null;
+  const rollupRight = [opts.self, cachedAge].filter(Boolean).join(' · ');
+  const rollupLeft = `${chalk.bold('Fleet')}   ${chalk.green('●')} ${online} online   ${chalk.gray('○')} ${offline} offline`;
+  const lines: string[] = [rollupRight ? alignRight(rollupLeft, chalk.gray(rollupRight), width) : rollupLeft, ''];
+
+  const items = buildFleetAttentionItems(report, now);
+  if (items.length === 0) {
+    lines.push(chalk.green('Everything looks healthy.'), '');
+  } else {
+    lines.push(chalk.bold(`NEEDS ATTENTION (${items.length})`));
+    const subjW = Math.max(...items.map((i) => i.subject.length));
+    const detailW = Math.max(...items.map((i) => stringWidth(i.detail)));
+    for (const it of items) {
+      const glyph = it.glyph === 'offline' ? chalk.gray('○') : chalk.yellow('⚠');
+      const subject = it.glyph === 'offline' ? chalk.gray(it.subject) : it.subject;
+      lines.push(
+        `  ${glyph}  ${padToWidth(subject, subjW)}   ${padToWidth(it.detail, detailW)}   ${chalk.cyan(`→ ${it.fix}`)}`,
+      );
+    }
+    lines.push('');
+  }
+
+  // Per-device rows, grouped by OS. Within a group, this machine floats to the
+  // top; the rest stay alphabetical.
+  const nameW = Math.min(18, Math.max(6, ...rows.map((r) => r.name.length)));
+  const headW = Math.max(...rows.map((r) => stringWidth(headroomWord(r))));
+  const loadW = Math.max(...rows.map((r) => stringWidth(loadMemCell(r))));
+  const verW = Math.max(7, ...rows.map((r) => stringWidth(versionCell(r))));
+  const grouped = new Map<string, FleetHealthRow[]>();
+  for (const r of rows) {
+    const g = platformGroupLabel(r.platform);
+    (grouped.get(g) ?? grouped.set(g, []).get(g)!).push(r);
+  }
+  for (const group of GROUP_ORDER) {
+    const members = grouped.get(group);
+    if (!members || members.length === 0) continue;
+    members.sort((a, b) =>
+      (a.name === opts.self ? -1 : b.name === opts.self ? 1 : 0) || a.name.localeCompare(b.name),
+    );
+    lines.push(chalk.bold(group));
+    for (const row of members) {
+      const isSelf = row.name === opts.self;
+      const prefix = isSelf ? chalk.cyan('▸') : ' ';
+      const marks: string[] = [];
+      if (!isOffline(row)) {
+        const stark = starkCliGap(row);
+        if (stark) marks.push(chalk.yellow(`⚠ CLIs ${stark.installed}/${stark.total}`));
+      } else if (isGenuinelyOffline(row) && row.lastSeen) {
+        marks.push(chalk.gray(`last seen ${formatCheckedAge(Date.parse(row.lastSeen), now)}`));
+      }
+      if (isSelf) marks.push(chalk.cyan('← this machine'));
+      const note = marks.length ? `   ${marks.join('   ')}` : '';
+      lines.push(
+        ` ${prefix} ${padToWidth(truncateToWidth(row.name, nameW), nameW)}  ` +
+        `${padToWidth(headroomWord(row), headW)}  ` +
+        `${padToWidth(loadMemCell(row), loadW)}  ` +
+        `${padToWidth(versionCell(row), verW)}` +
+        note,
+      );
+    }
+    lines.push('');
+  }
+
+  // Footer: orphan-version nudge (a `prune` concern, not drift), then an honest
+  // freshness line naming the cache age and what --live/--verbose add.
+  const orphaned = rows.filter((r) => r.orphans.length > 0).length;
+  if (orphaned > 0) {
+    const subject = orphaned === 1 ? '1 device carries' : `${orphaned} devices carry`;
+    lines.push(chalk.gray(`${subject} orphaned versions · run  ${chalk.cyan('agents prune')}  to reclaim disk`));
+  }
+  const freshBits = [
+    cachedAge,
+    'pass --live to re-probe auth + reachability',
+    'pass --verbose for the auth/CLI/sync columns',
+  ].filter(Boolean);
+  lines.push(chalk.gray(freshBits.join(' · ')));
+  return lines;
 }


### PR DESCRIPTION
## RUSH-1966 — redesign `agents fleet status` output

The old grid buried "is my fleet OK?" under duplicated columns, glyph soup, and jargon: a
"Health" column that just repeated Load/Mem, `stale · cold` counts across every orphan
version, an `●5 ·8 ◐3` auth cell, warnings that re-listed every device three times, and
"orphaned versions" (a `prune` concern) owning the rightmost column. This lands the AFTER
mockup from the ticket doc.

### New default view

Lands on top of RUSH-1965's reachability so "offline" is trustworthy. Rendered by the
built binary against the live fleet:

```
Fleet   ● 11 online   ○ 9 offline                                        yosemite-s1 · cached 3m ago

NEEDS ATTENTION (15)
  ○  bismas-macbook-pro   offline · last seen 9d ago               → check the box
  ○  box                  offline · last seen 3m ago               → check the box
  ○  fakebox              offline · last seen 3m ago               → check the box
  ○  win-mini             offline · last seen 31d ago              → check the box
  ⚠  yosemite-s1          config drift                             → agents apply yosemite-s1
  ⚠  mac-mini             config drift                             → agents apply mac-mini
  ⚠  yosemite-m0 … m6     config drift                             → agents apply <box>
  ⚠  yosemite-s0          config drift                             → agents apply yosemite-s0
  ⚠  version skew         7× 1.20.73 · 3× 1.20.74 · 1× dev-dirty   → agents upgrade --fleet

macOS
   bismas-macbook-pro  offline  —          —           last seen 9d ago
   mac-mini            busy     38% / 63%  1.20.73
   zion                busy     67% / 54%  —

Linux
 ▸ yosemite-s1         light    4% / 18%   1.20.74     ← this machine
   alpha               unknown  —          —
   box                 offline  —          —           last seen 3m ago
   … (bravo/charlie/delta/echo unknown; fakebox offline)
   yosemite-m0         idle     1% / 14%   1.20.74
   yosemite-m1 … m6    idle     0-1% / 5-9% 1.20.73
   yosemite-s0         light    2% / 22%   dev-dirty

Windows
   win-mini            offline  —          —           last seen 31d ago

11 devices carry orphaned versions · run  agents prune  to reclaim disk
cached 3m ago · pass --live to re-probe auth + reachability · pass --verbose for the auth/CLI/sync columns
```

A **healthy** fleet reads in a few lines (curated demo, `--no-stats`):

```
Fleet   ● 3 online   ○ 0 offline                          yosemite-s1

Everything looks healthy.

macOS
   mac-box      unknown  —  —
Linux
 ▸ yosemite-s1  unknown  —  1.20.74   ← this machine
   yosemite-s0  unknown  —  —

pass --live to re-probe auth + reachability · pass --verbose for the auth/CLI/sync columns
```

### What changed (file:line)

- **`apps/cli/src/lib/devices/health-report.ts`**
  - `renderFleetSummary` — the whole default view: rollup (`● N online · ○ M offline` +
    self + cache age), NEEDS ATTENTION, OS-grouped quiet rows (`name · capacity · load/mem
    · version`, this machine `▸ … ← this machine`), orphan-`prune` footer, freshness footer.
  - `buildFleetAttentionItems` — only real, actionable items, each with its fix command:
    genuinely-offline boxes (`isGenuinelyOffline` excludes `unknown`/unconfigured, so
    alpha/bravo/… don't cry "offline"); config drift on the **active version only**
    (`activeDriftRows` = `isDefault && !fresh`, not stale/cold across orphans) **merged**
    with a stark CLI gap (`starkCliGap`, missing >2/3 — so a normal 6-of-9 install is not
    flagged) into ONE `agents apply <box>` item; version skew as one counted line.
  - `shortVersion` (dev builds → `dev`/`dev-dirty`), `platformGroupLabel` (macOS/Linux/Windows).
  - `FleetHealthRow` gains `online?` + `lastSeen?`; the old `renderFleetMatrix` /
    `renderFleetWarnings` are untouched and now drive `--verbose`.
- **`apps/cli/src/commands/ssh.ts`** — `runFleetStatus` resolves each row's `online`/
  `lastSeen` once via `deviceOnlineState` (RUSH-1965's one ordering), then branches:
  `--json` unchanged · `--verbose` → old grid · default → `renderFleetSummary`. New
  `--verbose` option (read via `optsWithGlobals`, same pattern as `fleet ping --verbose`).

### Tests / docs / changelog

- `apps/cli/src/lib/devices/health-report.test.ts` — 11 new cases: `shortVersion`,
  `platformGroupLabel`, `buildFleetAttentionItems` (offline-only not unknown; merged apply
  item; **no** false-flag at 4/9 or 6/9; skew line; healthy → `[]`), and `renderFleetSummary`
  (rollup, OS groups, this-machine highlight, prune footer, "Everything looks healthy").
  Full suite green: `src/lib/devices/` + `ssh.test.ts` + `gen-changelog.test.ts` → 17 files,
  187 tests passed. `tsc --noEmit` clean; `npm run build` clean.
- `README.md` — fleet-status section rewritten for the summary view + the new `--verbose` grid.
- `apps/cli/.changelog/next/RUSH-1966.md` — user-visible changelog fragment (CHANGELOG.md is
  generated; the fragment folds in at release).

Refs RUSH-1966. Related root: RUSH-1964 (#1482).
