### PR TITLE
feat(sessions): real Grok transcript parser (replace stub)

### DIFF
--- a/apps/cli/.changelog/next/grok-session-parser.md
+++ b/apps/cli/.changelog/next/grok-session-parser.md
@@ -1,0 +1,13 @@
+- **`agents sessions` now classifies Grok transcripts into real events, not a
+  one-line stub.** Grok sessions were indexed (title, timestamps, message count)
+  but opening one showed a single placeholder `session_start` event — `parseGrok`
+  was a stub. It now reads the session's `chat_history.jsonl` and normalizes every
+  line into the shared `SessionEvent` shape: `user`/`assistant` messages,
+  `reasoning` → thinking, `assistant.tool_calls[]` → tool_use (with `path` and
+  `command` surfaced), and `tool_result` correlated back to its call by
+  `tool_call_id` (an `Error:`-prefixed result becomes an error event). The scanner
+  records `summary.json` as the session path, so the parser resolves
+  `chat_history.jsonl` beside it; per-line timestamps aren't stored, so each event
+  carries the session's `created_at` (falling back to the transcript mtime).
+  Verified end-to-end against a real Grok session (30 events: messages + thinking +
+  tool_use + tool_result). Source: `apps/cli/src/lib/session/parse.ts`.

--- a/apps/cli/src/lib/session/__tests__/parse-grok.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-grok.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Verifies parseGrok normalizes Grok's chat_history.jsonl transcript into the
+ * shared SessionEvent shape (user/assistant/tool_use/thinking/tool_result), and
+ * that detectAgent routes Grok session paths correctly.
+ */
+
+import { describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parseGrok, detectAgent } from '../parse.js';
+
+/**
+ * Build a Grok session dir (summary.json + chat_history.jsonl) and return the
+ * summary.json path — that is what the scanner records as the session filePath,
+ * and what parseSession hands the parser.
+ */
+function makeGrokSession(historyLines: object[]): string {
+  const dir = path.join(
+    os.tmpdir(),
+    '.grok', 'sessions', '%2Ftmp%2Fproj',
+    `grok-parse-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'summary.json'), JSON.stringify({ created_at: '2026-07-31T00:00:00.000Z' }));
+  fs.writeFileSync(path.join(dir, 'chat_history.jsonl'), historyLines.map(o => JSON.stringify(o)).join('\n'));
+  return path.join(dir, 'summary.json');
+}
+
+describe('parseGrok', () => {
+  test('classifies user/assistant/tool_use/thinking/tool_result and skips system', () => {
+    const summaryPath = makeGrokSession([
+      { type: 'system', content: 'You are Grok.' },
+      { type: 'user', content: [{ type: 'text', text: 'list the files' }] },
+      { type: 'reasoning', id: 'r1', summary: [{ type: 'summary_text', text: 'need to run ls' }], status: 'done' },
+      {
+        type: 'assistant',
+        content: 'Running ls now.',
+        tool_calls: [{ id: 'call_1', name: 'bash', arguments: JSON.stringify({ command: 'ls -la' }) }],
+      },
+      { type: 'tool_result', tool_call_id: 'call_1', content: 'file_a\nfile_b' },
+    ]);
+
+    const events = parseGrok(summaryPath);
+
+    // system is intentionally dropped.
+    expect(events.find(e => (e as any).content === 'You are Grok.')).toBeUndefined();
+
+    const user = events.find(e => e.type === 'message' && e.role === 'user');
+    expect(user?.content).toBe('list the files');
+
+    const thinking = events.find(e => e.type === 'thinking');
+    expect(thinking?.content).toBe('need to run ls');
+
+    const assistant = events.find(e => e.type === 'message' && e.role === 'assistant');
+    expect(assistant?.content).toBe('Running ls now.');
+
+    const toolUse = events.find(e => e.type === 'tool_use');
+    expect(toolUse?.tool).toBe('bash');
+    expect(toolUse?.args?.command).toBe('ls -la');
+    expect(toolUse?.command).toBe('ls -la');
+
+    const toolResult = events.find(e => e.type === 'tool_result');
+    // tool name is correlated back from the earlier tool_call id.
+    expect(toolResult?.tool).toBe('bash');
+    expect(toolResult?.success).toBe(true);
+    expect(toolResult?.output).toBe('file_a\nfile_b');
+
+    // Every event carries the session's created_at timestamp.
+    expect(events.every(e => e.timestamp === '2026-07-31T00:00:00.000Z')).toBe(true);
+    // Every event is tagged as grok.
+    expect(events.every(e => e.agent === 'grok')).toBe(true);
+  });
+
+  test('maps a tool_result whose content starts with "Error:" to an error event', () => {
+    const summaryPath = makeGrokSession([
+      {
+        type: 'assistant',
+        content: '',
+        tool_calls: [{ id: 'call_err', name: 'read_file', arguments: JSON.stringify({ path: '/nope' }) }],
+      },
+      { type: 'tool_result', tool_call_id: 'call_err', content: 'Error: no such file' },
+    ]);
+
+    const events = parseGrok(summaryPath);
+    const errored = events.find(e => e.type === 'error');
+    expect(errored?.tool).toBe('read_file');
+    expect(errored?.success).toBe(false);
+    // An assistant turn with empty text emits only the tool_use, no empty message.
+    expect(events.some(e => e.type === 'message')).toBe(false);
+    const toolUse = events.find(e => e.type === 'tool_use');
+    expect(toolUse?.path).toBe('/nope');
+  });
+
+  test('returns no events when chat_history.jsonl is absent', () => {
+    const dir = path.join(os.tmpdir(), '.grok', 'sessions', 'x', `empty-${Date.now()}`);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'summary.json'), JSON.stringify({ created_at: '2026-07-31T00:00:00.000Z' }));
+    expect(parseGrok(path.join(dir, 'summary.json'))).toEqual([]);
+  });
+
+  test('detectAgent routes a Grok session path to grok', () => {
+    expect(detectAgent('/home/u/.grok/sessions/%2Ftmp/abc/chat_history.jsonl')).toBe('grok');
+    expect(detectAgent('/home/u/.grok/sessions/%2Ftmp/abc/summary.json')).toBe('grok');
+  });
+});

--- a/apps/cli/src/lib/session/parse.ts
+++ b/apps/cli/src/lib/session/parse.ts
@@ -1051,42 +1051,124 @@ export function parseAntigravity(dbPath: string): SessionEvent[] {
  * Messages have role (user/assistant) and metadata.
  * Parts contain the actual content: text, tool, reasoning, patch, step-start/finish.
  */
+/**
+ * Parse a Grok (xAI CLI) session into normalized events.
+ *
+ * A Grok session dir holds several files; the conversation transcript is
+ * `chat_history.jsonl`, one JSON object per line with a `type`:
+ *   - `system`       — the system prompt (skipped; not conversational)
+ *   - `user`         — `content` is an array of `{ type: 'text', text }` blocks
+ *   - `assistant`    — `content` is a string, plus a `tool_calls[]` array of
+ *                      `{ id, name, arguments }` (arguments is a JSON string)
+ *   - `reasoning`    — chain-of-thought; text (when present) lives in `summary`
+ *   - `tool_result`  — `{ tool_call_id, content }`, correlated back to the call
+ *
+ * The scanner records `summary.json` as the session's filePath (see
+ * `readGrokMeta` in discover.ts), so resolve `chat_history.jsonl` from the same
+ * dir; also accept being handed the transcript file directly. Per-line
+ * timestamps aren't stored, so every event carries the session's `created_at`
+ * (from summary.json), falling back to the transcript's mtime.
+ */
 export function parseGrok(filePath: string): SessionEvent[] {
-  // Grok sessions are rich (summary.json + events.jsonl + chat_history.jsonl + updates.jsonl)
-  // This is a minimal stub for now so grok appears in `agents sessions`.
-  // Full parser (with subagents, tool calls, etc.) can be expanded later.
+  const sessionDir = path.dirname(filePath);
+  const historyPath = filePath.endsWith('chat_history.jsonl')
+    ? filePath
+    : path.join(sessionDir, 'chat_history.jsonl');
+  if (!fs.existsSync(historyPath)) return [];
+
+  let timestamp: string | undefined;
   try {
-    const content = fs.readFileSync(filePath, 'utf-8');
-    // If it's a summary.json, create a basic event
-    if (filePath.endsWith('summary.json')) {
-      const summary = JSON.parse(content);
-      return [{
-        timestamp: summary.created_at || new Date().toISOString(),
-        type: 'session_start',
-        content: summary.session_summary || 'Grok session',
-        agent: 'grok',
-        metadata: { sessionId: summary.id, cwd: summary.cwd },
-      } as any];
+    const summaryPath = filePath.endsWith('summary.json')
+      ? filePath
+      : path.join(sessionDir, 'summary.json');
+    if (fs.existsSync(summaryPath)) {
+      const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'));
+      if (typeof summary?.created_at === 'string') timestamp = summary.created_at;
     }
-    // For JSONL files (events, chat_history, updates), return basic parsed lines
-    if (filePath.endsWith('.jsonl')) {
-      const lines = content.trim().split('\n').filter(Boolean);
-      return lines.slice(0, 50).map((line, i) => {
-        try {
-          const obj = JSON.parse(line);
-          return {
-            timestamp: obj.timestamp || obj.ts || new Date().toISOString(),
-            type: obj.type || obj.method || 'grok_event',
-            content: typeof obj.content === 'string' ? obj.content : JSON.stringify(obj).slice(0, 200),
-            agent: 'grok',
-          } as any;
-        } catch {
-          return { timestamp: new Date().toISOString(), type: 'raw', content: line.slice(0, 200), agent: 'grok' } as any;
+  } catch { /* fall back to mtime below */ }
+  if (!timestamp) {
+    let mtime: Date | null = null;
+    try { mtime = fs.statSync(historyPath).mtime; } catch { mtime = null; }
+    timestamp = (mtime ?? new Date()).toISOString();
+  }
+
+  const content = safeReadSessionFile(historyPath);
+  const lines = content.split('\n').filter(l => l.trim());
+  const events: SessionEvent[] = [];
+  const toolCallMap = new Map<string, string>();
+
+  // Grok text is either a plain string (assistant) or an array of typed blocks
+  // (user: `{ type: 'text', text }`; reasoning summary: `{ text | summary_text }`).
+  const extractText = (raw: any): string => {
+    if (typeof raw === 'string') return raw.trim();
+    if (Array.isArray(raw)) {
+      return raw
+        .map((part: any) =>
+          typeof part?.text === 'string'
+            ? part.text
+            : typeof part?.summary_text === 'string'
+              ? part.summary_text
+              : '')
+        .join('')
+        .trim();
+    }
+    return '';
+  };
+
+  for (const line of lines) {
+    let msg: any;
+    try { msg = JSON.parse(line); } catch { continue; }
+    const type = msg?.type;
+
+    if (type === 'user') {
+      const text = extractText(msg.content);
+      if (text) events.push({ type: 'message', agent: 'grok', timestamp, role: 'user', content: text });
+    } else if (type === 'assistant') {
+      const text = extractText(msg.content);
+      if (text) events.push({ type: 'message', agent: 'grok', timestamp, role: 'assistant', content: text });
+
+      const calls = Array.isArray(msg.tool_calls) ? msg.tool_calls : [];
+      for (const call of calls) {
+        const toolName = typeof call?.name === 'string' ? call.name : 'unknown';
+        let args: Record<string, any> = {};
+        if (call?.arguments && typeof call.arguments === 'object') {
+          args = call.arguments;
+        } else if (typeof call?.arguments === 'string') {
+          try { args = JSON.parse(call.arguments); } catch { args = { _raw: call.arguments }; }
         }
+        if (typeof call?.id === 'string') toolCallMap.set(call.id, toolName);
+        events.push({
+          type: 'tool_use',
+          agent: 'grok',
+          timestamp,
+          tool: toolName,
+          args,
+          path: args.path || args.file_path || undefined,
+          command: typeof args.command === 'string' ? args.command : undefined,
+        });
+      }
+    } else if (type === 'reasoning') {
+      const text = extractText(msg.summary);
+      if (text) events.push({ type: 'thinking', agent: 'grok', timestamp, content: text });
+    } else if (type === 'tool_result') {
+      const callId = typeof msg.tool_call_id === 'string' ? msg.tool_call_id : undefined;
+      const toolName = (callId && toolCallMap.get(callId)) || 'unknown';
+      const output = typeof msg.content === 'string' ? msg.content : extractText(msg.content);
+      const isError = typeof output === 'string' && output.startsWith('Error:');
+      events.push({
+        type: isError ? 'error' : 'tool_result',
+        agent: 'grok',
+        timestamp,
+        tool: toolName,
+        success: !isError,
+        output: output.length > 500 ? output.slice(0, 497) + '...' : output,
       });
+      if (callId) toolCallMap.delete(callId);
     }
-  } catch {}
-  return [];
+    // `system` lines are the system prompt — intentionally skipped.
+  }
+
+  return events;
 }
 
 export function parseOpenCode(filePath: string): SessionEvent[] {


### PR DESCRIPTION
## What

`parseGrok` was a stub — Grok sessions were indexed (title, timestamps, count via `scanGrokIncremental`), but opening one in `agents sessions` showed a single placeholder `session_start` event. This replaces it with a real classifier.

## How

Grok stores each session as a dir; the transcript is `chat_history.jsonl`, one JSON object per line. The parser normalizes each line into the shared `SessionEvent` shape:

| Grok line `type` | Normalized event |
|---|---|
| `user` (`content: {type:'text'}[]`) | `message` (role user) |
| `assistant` (`content: string`) | `message` (role assistant) |
| `assistant.tool_calls[]` (`{id,name,arguments}`) | `tool_use` (`tool`, `args`, `path`, `command`) |
| `reasoning` (text in `summary`) | `thinking` |
| `tool_result` (`{tool_call_id, content}`) | `tool_result`, correlated to its call; `Error:`-prefixed → `error` |
| `system` | skipped (system prompt) |

The scanner records `summary.json` as the session `filePath` (see `readGrokMeta`), so the parser resolves `chat_history.jsonl` beside it and also accepts the transcript file directly. Grok doesn't store per-line timestamps, so every event carries the session's `created_at` (fallback: transcript mtime). Tool calls are correlated to results via a `tool_call_id → name` map, mirroring `parseKimi`.

## Verification

- **Real end-to-end** — ran `parseGrok` against an actual on-disk Grok session: **30 events** (8 `message`, 6 `thinking`, 8 `tool_use`, 8 `tool_result`), correct fields per type, **no stub artifacts** (`session_start`/`raw`/`grok_event` gone).
- **Unit** — new `parse-grok.test.ts`, real on-disk fixture (temp session dir with `summary.json` + `chat_history.jsonl`), 4 tests covering user/assistant/tool_use/thinking/tool_result correlation, the `Error:`→error mapping, empty-assistant (tool-only) turns, the missing-transcript case, and `detectAgent` routing. **4/4 pass.**

## Scope / follow-up

Per the harness-parity convention: this fixes the one remaining *stubbed* session parser (Grok). **Cursor** is the other unindexed harness; its parser is deliberately **not** in this PR — Cursor stores chats as JSON blobs in a SQLite `store.db`, but message ordering lives only in an opaque `meta` blob (protobuf-ish; the message blobs themselves carry no timestamp/sequence). Shipping a scrambled-order transcript would be worse than none, so Cursor is a tracked follow-up once the ordering index is decoded. Kimi/Codex/Claude/etc. already have full parsers.
