### PR TITLE
docs(sessions): drop two comments still describing the removed /continue fallback

### DIFF
--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1960,8 +1960,8 @@ export async function handlePickedSession(picked: PickedSession): Promise<void> 
  * Resume a session in the current terminal — a foreground takeover of this
  * process. Used by the single-select picker and by `sessions resume` when the
  * chosen destination is "in place" (unknown emulator / off-macOS, single pick).
- * Falls back to the current version via `/continue` when the version-pinned
- * binary is missing (ENOENT).
+ * Falls back to the same resume invocation against the current version when the
+ * version-pinned launcher is genuinely missing.
  */
 export async function resumeSessionInPlace(session: SessionMeta): Promise<void> {
   const cwd = session.cwd && fs.existsSync(session.cwd)
@@ -1983,7 +1983,7 @@ export async function resumeSessionInPlace(session: SessionMeta): Promise<void> 
   // agent shim is a `.cmd`/`.ps1` and, under the shell needed to run it (see
   // spawnResumeCommand), a missing command exits non-zero rather than emitting
   // an ENOENT `error` event — so detect a removed version here instead of
-  // relying on that event, keeping the /continue fallback working on every OS.
+  // relying on that event, keeping the fallback working on every OS.
   // `resume[0]` is an absolute alias path when one exists on disk, so only a bare
   // name still needs a PATH lookup. Checking existsSync first is what keeps an
   // isolated install (shims deliberately off PATH) out of the fallback.


### PR DESCRIPTION
Follow-up to #1459, which replaced the `/continue` resume fallback with the agent's real resume verb.

Two comments still described the old behavior as current:

```
 * Falls back to the current version via `/continue` when the version-pinned
 * binary is missing (ENOENT).                          ← resumeSessionInPlace docstring

 // relying on that event, keeping the /continue fallback working on every OS.
```

Neither is true any more — the fallback is now `<cli> resume <id>` against the current version. Both updated to describe what the code does.

The three remaining `/continue` mentions are deliberate: they explain *why* the fallback is built from the shared `resumeArgv` helper, which is what stopped the pinned and fallback paths drifting apart in the first place. Removing that context would invite the same bug back.

Caught by grepping the compiled `dist/` after installing #1459 — the source comments were stale even though the behavior was fixed. Comments describing removed behavior are worse than no comment: the next reader trusts them over the code.

Comment-only; `sessions.test.ts` 21/21 and `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)