### PR TITLE
feat(doctor): flag credentials exported from shell rc files (RUSH-1968)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1968.md
+++ b/apps/cli/.changelog/next/RUSH-1968.md
@@ -1,0 +1,14 @@
+- **`agents doctor` now flags credentials exported from shell rc files (RUSH-1968).** A
+  secret exported from `~/.zshenv`/`~/.zshrc`/`~/.bashrc`/`~/.profile` is inherited by every
+  process the login shell spawns and is readable from `/proc/<pid>/environ` by any same-user
+  process — `.zshenv` is sourced even by non-interactive `ssh host 'cmd'`, so the value lands
+  in essentially everything the box runs. The doctor overview now scans the current user's rc
+  files and prints a `Secrets in shell config` warning that names each credential-shaped
+  export by `file:line` and variable name (never the value), with the file-store master key
+  `AGENTS_SECRETS_PASSPHRASE` called out separately — its off-env home is
+  `~/.agents/.secrets-key/passphrase` (chmod 600), and other credentials should move to
+  `agents secrets` and inject via `agents secrets exec`. The scanner reads only the variable
+  name and line number, so a finding is safe to print or log. Source:
+  `apps/cli/src/lib/secrets/rc-hygiene.ts` (`scanUserRcFiles`, `scanRcExports`,
+  `rcSecretWarningLines`), wired into `apps/cli/src/commands/doctor.ts`
+  (`renderRcHygieneAdvisory`).

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -59,6 +59,7 @@ import { listCliStatus } from '../lib/cli-resources.js';
 import { setHelpSections } from '../lib/help.js';
 import { heal, healChangedAnything, type HealResult } from '../lib/heal.js';
 import { blocksLocalScripts, getEffectiveExecutionPolicy } from '../lib/platform/winpath.js';
+import { scanUserRcFiles, rcSecretWarningLines } from '../lib/secrets/rc-hygiene.js';
 import { terminalWidth, truncateToWidth, stringWidth, padToWidth } from '../lib/session/width.js';
 import * as fs from 'fs';
 
@@ -232,6 +233,11 @@ function renderOverviewText(
   // generated `agents.ps1` launcher — postinstall diagnoses it interactively,
   // but a non-interactive install never sees that. Surface it here too.
   renderExecPolicyAdvisory();
+
+  // Credentials exported from a shell rc file leak into every process's
+  // environment (readable via /proc/<pid>/environ) — the RUSH-1968 class. Flag
+  // them here so the master passphrase never silently lives in `~/.zshenv` again.
+  renderRcHygieneAdvisory();
 }
 
 // ─── windows execution-policy advisory ─────────────────────────────────────────
@@ -253,6 +259,19 @@ export function execPolicyWarningLines(platform: NodeJS.Platform, policy: string
     'Fix: Set-ExecutionPolicy -Scope CurrentUser RemoteSigned',
     'The agents.cmd shim still works regardless of the policy.',
   ];
+}
+
+function renderRcHygieneAdvisory(): void {
+  const findings = scanUserRcFiles();
+  const lines = rcSecretWarningLines(findings);
+  if (lines.length === 0) return;
+  console.log();
+  console.log(chalk.bold('Secrets in shell config'));
+  const [headline, ...rest] = lines;
+  console.log(`  ${chalk.yellow('warn ')}  ${headline}`);
+  for (const line of rest) {
+    console.log(chalk.gray(`           ${line}`));
+  }
 }
 
 function renderExecPolicyAdvisory(): void {

--- a/apps/cli/src/lib/secrets/rc-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/rc-hygiene.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  isCredentialName,
+  scanRcExports,
+  scanUserRcFiles,
+  rcSecretWarningLines,
+} from './rc-hygiene.js';
+
+describe('isCredentialName', () => {
+  it('flags the file-store master passphrase', () => {
+    expect(isCredentialName('AGENTS_SECRETS_PASSPHRASE')).toBe(true);
+  });
+
+  it('flags credential-shaped names by their final segment', () => {
+    for (const n of [
+      'ANTHROPIC_API_KEY',
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'SUPABASE_SERVICE_ROLE_KEY',
+      'DB_PASSWORD',
+      'X_CLIENT_SECRET',
+      'NPM_TOKEN',
+      'GITHUB_PAT',
+      'AWS_SECRET_ACCESS_KEY',
+      'PASSWORD',
+      'SECRET',
+      'APIKEY',
+    ]) {
+      expect(isCredentialName(n), n).toBe(true);
+    }
+  });
+
+  it('does NOT flag PATH-like or config vars that merely contain a secret word', () => {
+    for (const n of [
+      'PATH',
+      'BUN_INSTALL',
+      'PYENV_ROOT',
+      'SSH_AUTH_SOCK',
+      'GPG_TTY',
+      'SOME_KEY_PATH', // ends PATH, not KEY
+      'SSH_KEY_FILE', // ends FILE
+      'TOKEN_DIR', // ends DIR
+      'TOKENIZERS_PARALLELISM', // ML knob, ends PARALLELISM; TOKENIZERS is not the final segment
+      'MONKEY', // single segment, not equal to KEY
+      'CLIENT_ID', // ends ID
+      'BUCKET_NAME', // ends NAME
+    ]) {
+      expect(isCredentialName(n), n).toBe(false);
+    }
+  });
+});
+
+describe('scanRcExports', () => {
+  it('catches an export of the master passphrase and marks it', () => {
+    const content = [
+      '. "$HOME/.cargo/env"',
+      'export PATH="$HOME/.local/bin:$PATH"',
+      'export AGENTS_SECRETS_PASSPHRASE=deadbeefdeadbeefdeadbeefdeadbeef',
+    ].join('\n');
+    const found = scanRcExports('.zshenv', content);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ file: '.zshenv', line: 3, name: 'AGENTS_SECRETS_PASSPHRASE', isMasterPassphrase: true });
+  });
+
+  it('NEVER captures the value — only the name and line', () => {
+    const secret = 'super-secret-value-1234567890';
+    const found = scanRcExports('.zshrc', `export API_TOKEN=${secret}`);
+    expect(found).toHaveLength(1);
+    // The finding must not carry the value anywhere in its serialized form.
+    expect(JSON.stringify(found[0])).not.toContain(secret);
+    expect(Object.values(found[0])).not.toContain(secret);
+  });
+
+  it('catches typeset -x / declare -x export-attribute forms', () => {
+    expect(scanRcExports('.bashrc', 'typeset -x GITHUB_TOKEN=abc')).toHaveLength(1);
+    expect(scanRcExports('.bashrc', 'declare -x DB_PASSWORD=abc')).toHaveLength(1);
+  });
+
+  it('ignores commented-out exports', () => {
+    expect(scanRcExports('.zshenv', '# export API_KEY=abc')).toEqual([]);
+    expect(scanRcExports('.zshenv', '   #export SECRET=abc')).toEqual([]);
+  });
+
+  it('does not flag PATH or other non-credential exports', () => {
+    const content = [
+      'export PATH="$HOME/.local/bin:$PATH"',
+      'export BUN_INSTALL="$HOME/.bun"',
+      'export EDITOR=vim',
+    ].join('\n');
+    expect(scanRcExports('.zshrc', content)).toEqual([]);
+  });
+
+  it('reports multiple findings with correct line numbers', () => {
+    const content = [
+      'export PATH=/usr/bin', // 1
+      'export ANTHROPIC_API_KEY=x', // 2
+      '# comment', // 3
+      'export NPM_TOKEN=y', // 4
+    ].join('\n');
+    const found = scanRcExports('.zprofile', content);
+    expect(found.map((f) => [f.line, f.name])).toEqual([
+      [2, 'ANTHROPIC_API_KEY'],
+      [4, 'NPM_TOKEN'],
+    ]);
+    expect(found.every((f) => f.isMasterPassphrase === false)).toBe(true);
+  });
+
+  it('flags a value sourced from a command substitution — it still lands in the env', () => {
+    const found = scanRcExports('.zshenv', 'export AGENTS_SECRETS_PASSPHRASE="$(cat ~/.pass)"');
+    expect(found).toHaveLength(1);
+    expect(found[0].isMasterPassphrase).toBe(true);
+  });
+});
+
+describe('scanUserRcFiles', () => {
+  it('aggregates findings across a real home dir of rc files', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rc-hygiene-'));
+    try {
+      fs.writeFileSync(path.join(dir, '.zshenv'), 'export AGENTS_SECRETS_PASSPHRASE=abc\nexport PATH=/x\n');
+      fs.writeFileSync(path.join(dir, '.zshrc'), 'export OPENAI_API_KEY=xyz\n');
+      // a benign file with no secrets
+      fs.writeFileSync(path.join(dir, '.profile'), 'export PATH=/y\n');
+      const found = scanUserRcFiles(dir);
+      expect(found.map((f) => `${f.file}:${f.name}`).sort()).toEqual([
+        '.zshenv:AGENTS_SECRETS_PASSPHRASE',
+        '.zshrc:OPENAI_API_KEY',
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns [] for a home dir with no rc files', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rc-hygiene-empty-'));
+    try {
+      expect(scanUserRcFiles(dir)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('rcSecretWarningLines', () => {
+  it('is silent with no findings', () => {
+    expect(rcSecretWarningLines([])).toEqual([]);
+  });
+
+  it('calls out the master passphrase with the off-env remediation', () => {
+    const lines = rcSecretWarningLines([
+      { file: '.zshenv', line: 3, name: 'AGENTS_SECRETS_PASSPHRASE', isMasterPassphrase: true },
+    ]);
+    expect(lines[0]).toContain('1 credential-shaped export');
+    expect(lines.some((l) => l.includes('AGENTS_SECRETS_PASSPHRASE') && l.includes('.secrets-key/passphrase'))).toBe(true);
+  });
+
+  it('points non-master credentials at `agents secrets exec`', () => {
+    const lines = rcSecretWarningLines([
+      { file: '.zshrc', line: 5, name: 'NPM_TOKEN', isMasterPassphrase: false },
+    ]);
+    expect(lines.some((l) => l.includes('NPM_TOKEN') && l.includes('agents secrets exec'))).toBe(true);
+  });
+
+  it('never echoes a value (there is none to echo) and pluralizes correctly', () => {
+    const lines = rcSecretWarningLines([
+      { file: '.zshenv', line: 3, name: 'AGENTS_SECRETS_PASSPHRASE', isMasterPassphrase: true },
+      { file: '.zshrc', line: 5, name: 'NPM_TOKEN', isMasterPassphrase: false },
+    ]);
+    expect(lines[0]).toContain('2 credential-shaped exports');
+  });
+});

--- a/apps/cli/src/lib/secrets/rc-hygiene.ts
+++ b/apps/cli/src/lib/secrets/rc-hygiene.ts
@@ -1,0 +1,179 @@
+/**
+ * Detect credentials exported from shell rc files.
+ *
+ * A secret exported from `~/.zshenv`, `~/.zshrc`, `~/.bashrc`, `~/.profile`, …
+ * is inherited by every process the login shell spawns and is readable from
+ * `/proc/<pid>/environ` by any same-user process — the master passphrase leak
+ * behind RUSH-1968. `.zshenv` in particular is sourced by *every* zsh
+ * invocation, including non-interactive `ssh host 'cmd'`, so the value lands in
+ * the environment of essentially everything the box runs.
+ *
+ * The keychain-backed store (`agents secrets`) is the sanctioned home for
+ * credentials; the file-store master passphrase belongs in the off-env 0600 key
+ * file (`~/.agents/.secrets-key/passphrase`), never a shell rc export.
+ *
+ * This scanner powers a warn-level advisory in `agents doctor`. It reads only
+ * the exported variable *name* and its line number — never the value — so a
+ * finding can be printed, logged, or shipped without leaking the secret.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** Shell rc files sourced at login/startup, in the order a report lists them. */
+export const RC_FILENAMES = [
+  '.zshenv',
+  '.zprofile',
+  '.zshrc',
+  '.zlogin',
+  '.bash_profile',
+  '.bash_login',
+  '.bashrc',
+  '.profile',
+  '.kshrc',
+] as const;
+
+/**
+ * A single credential-shaped export found in an rc file. Carries the variable
+ * NAME and location only — the value is never captured.
+ */
+export interface RcSecretFinding {
+  /** Basename of the rc file, e.g. `.zshenv`. */
+  file: string;
+  /** 1-based line number of the export. */
+  line: number;
+  /** The exported variable name (e.g. `AGENTS_SECRETS_PASSPHRASE`). Never the value. */
+  name: string;
+  /** The file-store master passphrase gets called out separately — it is the highest-severity case. */
+  isMasterPassphrase: boolean;
+}
+
+/** The file-store master key. Its own resolution prefers an off-env 0600 file, so
+ *  a shell-rc export is always wrong once the store exists (RUSH-1968). */
+const MASTER_PASSPHRASE = 'AGENTS_SECRETS_PASSPHRASE';
+
+/**
+ * Last `_`-delimited segment values that mark a variable as credential-shaped.
+ * Matched against the FINAL segment (segment equality, not substring) so
+ * `X_API_KEY` fires on `KEY` while `SOME_KEY_PATH` (ends `PATH`) and `MONKEY`
+ * (single segment, not equal to `KEY`) do not.
+ */
+const CREDENTIAL_SEGMENTS = new Set([
+  'PASSPHRASE',
+  'PASSWORD',
+  'PASSWD',
+  'SECRET',
+  'SECRETS',
+  'TOKEN',
+  'KEY',
+  'APIKEY',
+  'PAT',
+  'CREDENTIAL',
+  'CREDENTIALS',
+]);
+
+/**
+ * Final segments that look credential-shaped but name a file path, socket, or
+ * config knob rather than a secret value — excluded to cut false positives.
+ * Applied to the whole name's final segment before the credential check.
+ */
+const BENIGN_FINAL_SEGMENTS = new Set([
+  'PATH',
+  'FILE',
+  'DIR',
+  'SOCK',
+  'SOCKET',
+  'ID',
+  'NAME',
+  'PARALLELISM', // TOKENIZERS_PARALLELISM and friends
+]);
+
+/** True if a variable name looks like it holds a credential value. */
+export function isCredentialName(name: string): boolean {
+  if (name === MASTER_PASSPHRASE) return true;
+  const segments = name.toUpperCase().split('_');
+  const last = segments[segments.length - 1];
+  if (BENIGN_FINAL_SEGMENTS.has(last)) return false;
+  return CREDENTIAL_SEGMENTS.has(last);
+}
+
+// Matches an env assignment that puts a value in the environment:
+//   export NAME=...            (sh/bash/zsh)
+//   typeset -x NAME=... / declare -x NAME=...   (bash/zsh export-attribute form)
+const EXPORT_RE =
+  /^\s*(?:export\s+|(?:typeset|declare)\s+-[A-Za-z]*x[A-Za-z]*\s+)([A-Za-z_][A-Za-z0-9_]*)\s*=/;
+
+/**
+ * Scan one rc file's contents for credential-shaped exports. Pure — takes the
+ * text, returns findings (names + line numbers only, never values). A trailing
+ * `# comment` is stripped before matching so a commented-out export is ignored;
+ * the variable name always precedes any inline `#`, so stripping never loses it.
+ */
+export function scanRcExports(basename: string, content: string): RcSecretFinding[] {
+  const out: RcSecretFinding[] = [];
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const code = lines[i].replace(/#.*$/, '');
+    const m = EXPORT_RE.exec(code);
+    if (!m) continue;
+    const name = m[1];
+    if (!isCredentialName(name)) continue;
+    out.push({
+      file: basename,
+      line: i + 1,
+      name,
+      isMasterPassphrase: name === MASTER_PASSPHRASE,
+    });
+  }
+  return out;
+}
+
+/**
+ * Scan the current user's shell rc files. Reads each file that exists under
+ * `homeDir` (default `os.homedir()`) and aggregates the findings. Missing or
+ * unreadable files are skipped silently — an advisory, not a hard requirement.
+ */
+export function scanUserRcFiles(homeDir: string = os.homedir()): RcSecretFinding[] {
+  const out: RcSecretFinding[] = [];
+  for (const name of RC_FILENAMES) {
+    const fp = path.join(homeDir, name);
+    let content: string;
+    try {
+      content = fs.readFileSync(fp, 'utf8');
+    } catch {
+      continue; // absent or unreadable — nothing to report
+    }
+    out.push(...scanRcExports(name, content));
+  }
+  return out;
+}
+
+/**
+ * Build the advisory lines for `agents doctor` from a set of findings. Returns
+ * `[]` when there is nothing to report. The first line is the headline; the
+ * rest are indented detail. Names only — never values.
+ */
+export function rcSecretWarningLines(findings: RcSecretFinding[]): string[] {
+  if (findings.length === 0) return [];
+  const lines: string[] = [];
+  const master = findings.filter((f) => f.isMasterPassphrase);
+  const others = findings.filter((f) => !f.isMasterPassphrase);
+
+  const total = findings.length;
+  lines.push(
+    `${total} credential-shaped export${total === 1 ? '' : 's'} found in shell rc files — ` +
+    `readable from /proc/<pid>/environ by any same-user process.`,
+  );
+  for (const f of master) {
+    lines.push(
+      `${f.file}:${f.line} ${f.name} — the file-store master key. Move it off-env to ` +
+      `~/.agents/.secrets-key/passphrase (chmod 600) and delete the export.`,
+    );
+  }
+  for (const f of others) {
+    lines.push(`${f.file}:${f.line} ${f.name} — move to \`agents secrets\` and inject via \`agents secrets exec\`.`);
+  }
+  lines.push('Rule: no credentials in env vars or shell config. Use the keychain-backed store.');
+  return lines;
+}


### PR DESCRIPTION
## What

`agents doctor` now scans the current user's shell rc files and warns about credentials exported from them — the recurrence-prevention piece of **RUSH-1968** (item 5).

The root cause of RUSH-1968: `AGENTS_SECRETS_PASSPHRASE` — the file-store master key — sat exported in plaintext from `~/.zshenv` on `yosemite-s0` and `s1`. A secret exported from a shell rc file is inherited by every process the login shell spawns and is readable from `/proc/<pid>/environ` by any same-user process; `.zshenv` is sourced even by non-interactive `ssh host 'cmd'`, so the value lands in essentially everything the box runs. (The operational remediation — moving the passphrase to the off-env `~/.agents/.secrets-key/passphrase` 0600 key file and deleting the export on both boxes — was applied and verified separately; this PR is the guard so it can't silently recur.)

## Behavior

The doctor overview prints a `Secrets in shell config` warning that names each credential-shaped export by `file:line` and variable name, with the master key called out separately. **It reads only the variable name and line number — never the value** — so a finding is safe to print or log.

```
Secrets in shell config
  warn   1 credential-shaped export found in shell rc files — readable from /proc/<pid>/environ by any same-user process.
           .zshrc:155 RUSH1968_DEMO_API_TOKEN — move to `agents secrets` and inject via `agents secrets exec`.
           Rule: no credentials in env vars or shell config. Use the keychain-backed store.
```

Credential detection matches the final `_`-delimited segment (segment equality, not substring), so `X_API_KEY` fires while `SOME_KEY_PATH`, `TOKENIZERS_PARALLELISM`, and `MONKEY` do not. `AGENTS_SECRETS_PASSPHRASE` gets a dedicated call-out pointing at its off-env home.

## Evidence (end-to-end, real `agents doctor`)

- Planted a benign fake export in `~/.zshrc` → doctor rendered the block above; a grep for the fake value across full output returned **0** (name-only, no leak). Planted line removed.
- On a clean box (no rc secret) doctor shows **no** such warning — no false positive.
- `rc-hygiene.test.ts`: 16/16 pass. `doctor.test.ts` regression: 7/7 pass. `tsc --noEmit`: clean.

## Files

- `apps/cli/src/lib/secrets/rc-hygiene.ts` — pure scanner (`scanRcExports`, `scanUserRcFiles`, `isCredentialName`, `rcSecretWarningLines`)
- `apps/cli/src/lib/secrets/rc-hygiene.test.ts` — 1:1 tests
- `apps/cli/src/commands/doctor.ts` — `renderRcHygieneAdvisory` wired into the overview next to the exec-policy advisory
- `apps/cli/.changelog/next/RUSH-1968.md`

Session transcript (confidential; not attached): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.170/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz-agents-cli/028abe35-866f-412d-af95-ee31b99f6f52.jsonl`