### PR TITLE
feat(routines): pin a routine to a Claude account by identity (RUSH-1957)

### DIFF
--- a/apps/cli/.changelog/next/routine-account-pin.md
+++ b/apps/cli/.changelog/next/routine-account-pin.md
@@ -1,0 +1,16 @@
+- **Routines can pin a Claude account by identity to stop the OAuth-rotation
+  logout storm.** Unpinned `claude` routines pick an account with the default
+  `balanced` (stateless weighted-random) strategy, so two concurrent unattended
+  runs — on one box or across the fleet — can land on the same account; Claude's
+  refresh token is single-use and rotates server-side, so the second refresh
+  revokes the first run's token mid-flight (`401 OAuth access token has been
+  revoked`). Across ~20 routines waking in one morning window that is a
+  self-inflicted logout storm (RUSH-1957). A routine may now set `account:` (a
+  login email or account key) to pin the run to the version slot holding that
+  account — no rotation, no usage-read refresh, no failover onto other accounts —
+  so each routine (or each device's routines) refreshes one credential nobody else
+  touches. Prefer it over `version:`, which pins a version *number* that is GC'd on
+  the next upgrade, silently dropping the routine back to `balanced`. An account
+  that is not signed in on the box warns and falls back to the strategy rather than
+  refusing to run. Source: `apps/cli/src/lib/routines.ts`,
+  `apps/cli/src/lib/rotate.ts`, `apps/cli/src/lib/runner.ts`.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -43,7 +43,8 @@ agents routines add cleanup --schedule "0 3 * * *" --agent claude \
 name: daily-review
 schedule: "0 9 * * *"         # 9am daily (cron syntax)
 agent: claude
-version: 2.0.65               # Optional, uses global default if omitted
+account: muqsit@trp.so        # Optional: pin to a signed-in account by identity (see "Pinning an account")
+version: 2.0.65               # Optional: pin to an exact version; uses global default if omitted
 mode: auto                    # auto (default), plan (read-only), edit, or skip
 effort: default               # fast, default, or detailed
 timeout: 10m
@@ -317,6 +318,43 @@ agents secrets set claude CLAUDE_CODE_OAUTH_TOKEN <token>
 # Restart the daemon so the updated token is baked into its environment:
 agents routines stop && agents routines start
 ```
+
+### Pinning an account (avoid the OAuth-rotation revocation storm)
+
+Left unpinned, a `claude` routine selects its account by the default `balanced`
+strategy — a stateless weighted-random roll (`rotate.ts`) that can land two
+concurrent runs, on one box or across the fleet, on the *same* account. Claude's
+OAuth refresh token is **single-use and rotates server-side on every refresh**, so
+when a second run refreshes an account the first is still holding, the first run's
+token is revoked mid-flight and the run dies with:
+
+```
+Failed to authenticate. API Error: 401 OAuth access token has been revoked.
+```
+
+Multiplied across ~20 unpinned routines that all wake in the same morning window,
+this is a self-inflicted logout storm (RUSH-1957).
+
+**The durable cure: give each routine (or each device's routines) its own
+account.** Pin by identity with `account:` — the login email, resolved at launch
+to whichever installed version holds that account, run pinned with no rotation and
+no failover onto other accounts:
+
+```yaml
+name: drain-prix
+schedule: "15,45 * * * *"
+agent: claude
+devices: [yosemite-s1]
+account: muqsit@trp.so      # this box's routines all refresh ONE account, no one else's
+```
+
+Prefer `account:` over `version:`: a `version:` pin names a version *number* that
+is garbage-collected on the next `claude` upgrade, after which the routine
+silently falls back to `balanced` and the storm returns. Pinning by account
+identity survives version churn. If the named account is not signed in on the box
+at fire time, the run warns and falls back to the strategy rather than refusing —
+so a stale pin degrades to "unpinned", never to "dead". List signed-in accounts
+with `agents view`.
 
 ## Execution Flow
 

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -223,6 +223,23 @@ describe('resolveRoutineLaunch (RUSH-1016 — pin + failover chain)', () => {
     expect(plan.chain).toEqual([]);
     expect(plan.pinned).toBe(false);
   });
+
+  it('an explicit version pin wins over an account pin (most specific)', async () => {
+    const plan = await resolveRoutineLaunch(
+      baseJob({ name: 'both-pins', version: '2.1.0', account: 'muqsit@trp.so', agent: 'claude' }),
+    );
+    expect(plan.pinned).toBe(true);
+    expect(plan.chain).toEqual([{ agent: 'claude', version: '2.1.0' }]);
+  });
+
+  it('an account pin that is not signed in on this box falls through unpinned, not stalled', async () => {
+    // No box has this identity signed in, so account resolution returns null and
+    // the routine still runs (via the configured strategy) rather than refusing.
+    const plan = await resolveRoutineLaunch(
+      baseJob({ name: 'ghost-account', account: 'nobody@nowhere.invalid', agent: 'claude' }),
+    );
+    expect(plan.pinned).toBe(false);
+  });
 });
 
 describe('buildRoutineSpawnEnv', () => {

--- a/apps/cli/src/lib/rotate.test.ts
+++ b/apps/cli/src/lib/rotate.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_ROTATION_FAILOVER_LIMIT,
   pickBalancedCandidate,
   readinessFromCandidate,
+  matchAccountVersion,
   type RotateCandidate,
   type RotateResult,
   type FailoverArmingContext,
@@ -41,6 +42,33 @@ function candidate(over: Partial<RotateCandidate> & { version: string }): Rotate
 function rotation(healthy: RotateCandidate[], pickedIdx = 0): RotateResult {
   return { picked: healthy[pickedIdx], healthy, excluded: [] };
 }
+
+describe('matchAccountVersion (RUSH-1957 — pin a routine to an account by identity)', () => {
+  const gmail = candidate({ version: '2.1.186', email: 'muqsitnawaz@gmail.com' });
+  const trp = candidate({ version: '2.1.207', email: 'muqsit@trp.so' });
+  const signedOut = candidate({ version: '2.1.180', email: 'stale@example.com', signedIn: false });
+  const pool = [gmail, trp, signedOut];
+
+  it('resolves a login email to its installed version slot (case-insensitive)', () => {
+    expect(matchAccountVersion(pool, 'muqsit@trp.so')).toBe('2.1.207');
+    expect(matchAccountVersion(pool, 'MUQSIT@TRP.SO')).toBe('2.1.207');
+    expect(matchAccountVersion(pool, '  muqsitnawaz@gmail.com  ')).toBe('2.1.186');
+  });
+
+  it('resolves an account key as well as an email', () => {
+    expect(matchAccountVersion(pool, 'claude:account=2.1.207')).toBe('2.1.207');
+  });
+
+  it('never returns a signed-out slot even when its identity matches', () => {
+    expect(matchAccountVersion(pool, 'stale@example.com')).toBeNull();
+  });
+
+  it('returns null for an unknown account or an empty string, so the caller falls back and warns', () => {
+    expect(matchAccountVersion(pool, 'nobody@nowhere.dev')).toBeNull();
+    expect(matchAccountVersion(pool, '   ')).toBeNull();
+    expect(matchAccountVersion([], 'muqsit@trp.so')).toBeNull();
+  });
+});
 
 describe('rotationFailoverChain (#348 — synthesize a same-agent failover chain)', () => {
   it('turns the other healthy accounts into fallback entries, skipping the picked one', () => {

--- a/apps/cli/src/lib/rotate.ts
+++ b/apps/cli/src/lib/rotate.ts
@@ -390,6 +390,44 @@ export async function collectRunCandidates(agent: AgentId): Promise<RotateCandid
 }
 
 /**
+ * Resolve an account identity to the installed version slot that holds it, over
+ * an already-collected candidate list. Pure — no I/O — so it is unit-tested
+ * directly. Matches, case-insensitively, against a candidate's login `email`
+ * (the usual form) or its `accountKey`, and only ever returns a signed-in slot.
+ * Returns null when nothing matches, so the caller can fall back and warn.
+ */
+export function matchAccountVersion(
+  candidates: RotateCandidate[],
+  account: string,
+): string | null {
+  const needle = account.trim().toLowerCase();
+  if (!needle) return null;
+  const match = candidates.find(
+    (c) =>
+      c.signedIn &&
+      (c.email?.toLowerCase() === needle || c.accountKey?.toLowerCase() === needle),
+  );
+  return match?.version ?? null;
+}
+
+/**
+ * Resolve a routine's `account:` pin (login email or account key) to the
+ * installed version currently holding that account. Thin I/O wrapper over
+ * {@link collectRunCandidates} + {@link matchAccountVersion}; returns null when
+ * no signed-in version matches. Pinning a routine to a distinct account is the
+ * durable cure for the shared-single-use-refresh-token revocation storm
+ * (RUSH-1957): the pinned run never rotates and never lands on another
+ * routine's credential.
+ */
+export async function resolveAccountVersion(
+  agent: AgentId,
+  account: string,
+): Promise<string | null> {
+  const candidates = await collectRunCandidates(agent);
+  return matchAccountVersion(candidates, account);
+}
+
+/**
  * Pick a healthy version for `agent` using weighted random by remaining
  * capacity. See `pickBalancedCandidate` for algorithm details.
  *

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -157,6 +157,25 @@ export interface JobConfig {
   allow?: JobAllowConfig;
   config?: Record<string, unknown>;
   version?: string;
+  /**
+   * Pin this routine to a signed-in account by identity (its login email, or its
+   * account key) instead of rotating. At launch it resolves to whichever
+   * installed version currently holds that account and runs pinned — no
+   * `balanced` rotation, no usage-read refresh, no failover onto other accounts.
+   *
+   * This is the durable way to keep concurrent unattended routines off a *shared*
+   * Claude OAuth credential: the refresh token is single-use and rotates
+   * server-side on every refresh, so two routines running the same account
+   * concurrently (on one box or across the fleet) mutually revoke each other —
+   * the `401 OAuth access token has been revoked` storm (RUSH-1957). Give each
+   * routine (or each device's routines) a distinct account and no run rotates a
+   * credential out from under another.
+   *
+   * Prefer this over `version:`, which pins a version *number* that is GC'd on
+   * the next agent upgrade — when the pinned version disappears the routine
+   * silently falls back to `balanced` and the stampede returns.
+   */
+  account?: string;
   runOnce?: boolean;
   // RFC3339 timestamp; routine auto-disables at the next fire on/after this time.
   endAt?: string;

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -54,6 +54,7 @@ import { getBinaryPath, isVersionInstalled, resolveVersion } from './versions.js
 import {
   getConfiguredRunStrategy,
   resolveRunVersion,
+  resolveAccountVersion,
   rotationFailoverChain,
   readinessFromCandidate,
   type RotateResult,
@@ -351,6 +352,22 @@ export async function resolveRoutineLaunch(
       rotation: null,
       pinned: true,
     };
+  }
+
+  // Account pin: resolve the login identity to the version slot that holds it and
+  // run pinned — no rotation, no failover onto other accounts — so concurrent
+  // unattended routines never share (and mutually revoke) one single-use OAuth
+  // credential (RUSH-1957). Falls through to the strategy only when the account
+  // is not signed in on this box, with a loud warning rather than a silent stall.
+  if (config.account) {
+    const version = await resolveAccountVersion(agent, config.account);
+    if (version) {
+      return { chain: [{ agent, version }], rotation: null, pinned: true };
+    }
+    process.stderr.write(
+      `[agents] routine ${config.name}: account '${config.account}' is not signed in for ${agent}; ` +
+        `falling back to strategy — pin a signed-in account to stop OAuth-rotation revocation\n`,
+    );
   }
 
   const strategy = getConfiguredRunStrategy(agent, cwd);


### PR DESCRIPTION
## Why

Scheduled `claude` routines fail intermittently with:

```
Failed to authenticate. API Error: 401 OAuth access token has been revoked.
```

Root cause (verified live on the fleet, 2026-07-31): all 18 `claude` routines are **unpinned**, so each run selects its account via the default `balanced` strategy — a stateless weighted-random roll (`rotate.ts`) with no reservation. Two concurrent unattended runs, on one box or across the fleet, can land on the **same** account. Claude's OAuth refresh token is **single-use and rotates server-side on every refresh**, so the second run's refresh revokes the first run's token mid-flight. Across ~20 routines waking in one morning window this is a self-inflicted logout storm (RUSH-1957).

`#1449` closed agents-cli's own usage-read rotation, but the spawned `claude` binary still refreshes uncoordinated (`rotate.ts:348` delegates refresh to the child; there is no cross-process lock). The durable operational cure is to stop concurrent runs from **sharing** an account — pin each routine (or each device's routines) to a distinct one.

## What

Add an `account:` field to routine `JobConfig`: a login email (or account key) that resolves at launch to whichever installed version currently holds that account, and runs **pinned** — no rotation, no usage-read refresh, no failover onto other accounts. Two routines pinned to different accounts never touch the same credential, so no run rotates a token out from under another.

Prefer `account:` over the existing `version:` pin: `version:` names a version *number* that is garbage-collected on the next `claude` upgrade, after which the routine silently drops back to `balanced` and the storm returns. Pinning by account identity survives version churn. An account that is not signed in on the box at fire time warns and **falls back to the strategy** rather than refusing — a stale pin degrades to "unpinned", never "dead".

```yaml
name: drain-prix
schedule: "15,45 * * * *"
agent: claude
devices: [yosemite-s1]
account: muqsit@trp.so   # this box's routines refresh ONE account, no one else's
```

## Changes

- `routines.ts` — `account?: string` on `JobConfig` (read/write pass-through; no key allowlist to update).
- `rotate.ts` — `matchAccountVersion` (pure identity→version match over collected candidates, unit-tested) + `resolveAccountVersion` (thin I/O wrapper over `collectRunCandidates`).
- `runner.ts` — honor `config.account` in `resolveRoutineLaunch`, after an explicit `version:` pin and before the strategy path.
- Tests — `matchAccountVersion` (email/key match, case-insensitive, excludes signed-out, null on miss) and `resolveRoutineLaunch` (version wins over account; unknown account falls through unpinned). 139/139 pass across the touched suites.
- Docs — `apps/cli/docs/03-routines.md` "Pinning an account" section + Job Config example.
- Changelog fragment.

## Scope note

This PR is the **durable, first-class primitive**. The live fleet is still on `1.20.74`, which predates both this change and `#1449`; the immediate operational cure (pinning the live routines) is applied out-of-band via the existing `version:` field until this ships. The structural companion — `agents apply` propagating `.claude/.credentials.json` across boxes (`auth-sync.ts:32-44`), which manufactures the shared credential in the first place and contradicts `remote-login.ts:4-6` — is RUSH-1958 and left for a separate PR.

RUSH-1918 ("daemon stops refreshing the session token") is a **different subsystem** (the Rush App's Supabase session in `~/.rush/user.yaml`, not agents-cli Claude OAuth) and is not addressed here.