### PR TITLE
fix(bench): point sessions-perf at the real index path

### DIFF
--- a/apps/cli/bench/sessions-perf.ts
+++ b/apps/cli/bench/sessions-perf.ts
@@ -2,40 +2,33 @@
 // Benchmark harness for the sessions indexing pipeline.
 //
 // Measures:
-//   A. Cold discover (index files removed before the run)
-//   B. Warm discover (index files present from a prior run)
+//   A. Cold discover (index removed before the run)
+//   B. Warm discover (index present from a prior run)
 //   C. Picker keystroke (filterSessionsByQuery) — single call
 //   D. Picker keystroke — 10 successive queries (simulates typing)
-//   E. loadBM25Index alone (the per-keystroke bottleneck)
+//   E. searchContentIndex alone (the per-keystroke bottleneck)
+//
+// Corpus: the index is whatever $HOME holds, so CI's `HOME="$(mktemp -d)"` run
+// measures an EMPTY index — a floor for A/B, not a real-world number. Set
+// BENCH_CORPUS=real (with BENCH_MODE=warm) to copy this machine's live index
+// into a throwaway HOME and measure B/C/D/E against a populated one.
 //
 // Output: JSON on stdout. Intended to be run before and after the refactor
 // so the numbers can be diffed directly.
 
+import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
 import { discoverSessions, searchContentIndex } from '../src/lib/session/discover.js';
 import { filterSessionsByQuery } from '../src/commands/sessions.js';
+import { getSessionsDbPath, getSessionsDir } from '../src/lib/state.js';
 
-const HOME = os.homedir();
-const SESSIONS_DIR = path.join(HOME, '.agents', 'sessions');
-const INDEX_PATH = path.join(SESSIONS_DIR, 'index.jsonl');
-const CONTENT_INDEX_PATH = path.join(SESSIONS_DIR, 'content_index.jsonl');
-const DB_PATH = path.join(SESSIONS_DIR, 'sessions.db');
-
-const QUERIES = [
-  'rush',
-  'rush deploy',
-  'group chat bill',
-  'session search',
-  'sqlite',
-  'benchmark',
-  'openclaw',
-  'phoenix cli',
-  'deploy a2a endpoint',
-  'yaml agent',
-];
+// Resolved through the same helpers the CLI itself uses. Re-deriving the path
+// here is what let this benchmark drift onto a directory that no longer exists.
+const SESSIONS_DIR = getSessionsDir();
+const DB_PATH = getSessionsDbPath();
 
 async function time<T>(fn: () => Promise<T> | T): Promise<{ ms: number; value: T }> {
   const t0 = performance.now();
@@ -60,23 +53,62 @@ function removeIfExists(p: string): void {
   }
 }
 
+// BENCH_CORPUS=real: copy this machine's live index into a throwaway HOME and
+// re-run there. Copying rather than measuring in place is what keeps discover's
+// writes off the index `agents sessions` is serving.
+function relaunchAgainstRealCorpusCopy(): never {
+  if (!fs.existsSync(DB_PATH)) {
+    console.error(`BENCH_CORPUS=real: no index at ${DB_PATH} — run \`agents sessions\` once to build one.`);
+    process.exit(1);
+  }
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sessions-perf-'));
+  const destDir = path.join(tmpHome, '.agents', '.history', 'sessions');
+  fs.mkdirSync(path.dirname(destDir), { recursive: true });
+
+  console.error(`copying ${(fileSize(DB_PATH) / 1e6).toFixed(0)}MB index -> ${destDir}`);
+  const copyStart = performance.now();
+  fs.cpSync(SESSIONS_DIR, destDir, { recursive: true });
+  console.error(`copied in ${((performance.now() - copyStart) / 1000).toFixed(1)}s`);
+
+  let status: number;
+  try {
+    const child = spawnSync(process.execPath, [process.argv[1]], {
+      stdio: 'inherit',
+      env: { ...process.env, HOME: tmpHome, BENCH_CORPUS: 'copied' },
+    });
+    status = child.status ?? 1;
+  } finally {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+  process.exit(status);
+}
+
 async function main() {
   const mode = (process.env.BENCH_MODE || 'full').toLowerCase();
 
+  if (process.env.BENCH_CORPUS === 'real') {
+    if (mode !== 'warm') {
+      console.error(
+        'BENCH_CORPUS=real supports BENCH_MODE=warm only. Cold mode rebuilds the index by ' +
+          'rescanning transcripts, which a copied index does not carry — measure first-run ' +
+          'cost against the default corpus instead.',
+      );
+      process.exit(1);
+    }
+    relaunchAgainstRealCorpusCopy();
+  }
+
   const pre = {
-    indexJsonlBytes: fileSize(INDEX_PATH),
-    contentIndexJsonlBytes: fileSize(CONTENT_INDEX_PATH),
     sessionsDbBytes: fileSize(DB_PATH),
+    walBytes: fileSize(DB_PATH + '-wal'),
   };
 
   // ------------------------------------------------------------------
   // A. Cold discover
   // ------------------------------------------------------------------
   if (mode === 'full' || mode === 'cold') {
-    // Backup and remove existing indexes (JSONL + SQLite + WAL/SHM) to simulate first-run cost.
+    // Backup and remove the existing index (SQLite + WAL/SHM) to simulate first-run cost.
     const COLD_PATHS = [
-      INDEX_PATH,
-      CONTENT_INDEX_PATH,
       DB_PATH,
       DB_PATH + '-wal',
       DB_PATH + '-shm',
@@ -163,14 +195,15 @@ async function main() {
   console.error(`E. searchContentIndex best of 5: ${contentBest.toFixed(1)}ms`);
 
   const post = {
-    indexJsonlBytes: fileSize(INDEX_PATH),
-    contentIndexJsonlBytes: fileSize(CONTENT_INDEX_PATH),
     sessionsDbBytes: fileSize(DB_PATH),
+    walBytes: fileSize(DB_PATH + '-wal'),
   };
 
   const result = {
     node: process.version,
     timestamp: new Date().toISOString(),
+    corpus: process.env.BENCH_CORPUS === 'copied' ? 'real (copied)' : 'whatever $HOME holds',
+    sessionsDbPath: DB_PATH,
     sessionsCount: warmSessions.length,
     pre,
     post,

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -443,7 +443,7 @@ export function getTrashDir(): string { return TRASH_DIR; }
 /** Path to local session indexer storage (~/.agents/.history/sessions/). */
 export function getSessionsDir(): string { return SESSIONS_DIR; }
 
-/** Path to the session index database (~/.agents/.history/sessions.db). */
+/** Path to the session index database (~/.agents/.history/sessions/sessions.db). */
 export function getSessionsDbPath(): string { return SESSIONS_DB_PATH; }
 
 /** Path to teams config + registry (~/.agents/teams/). */


### PR DESCRIPTION
## What was broken

`bench/sessions-perf.ts` re-derived the index location as `~/.agents/sessions/`. The index has lived at `~/.agents/.history/sessions/` since the `.history` bucket landed (`state.ts:107-108`).

Three consequences:

1. The cold-mode backup (`:84-87`) filtered on `fs.existsSync` and so renamed **nothing**. `A_coldDiscoverMs` has been timing a warm run.
2. `pre` / `post` byte fields always reported `0`.
3. `.github/workflows/bench.yml:51` runs the script as `HOME="$(mktemp -d)"`, so the stale path never surfaced as an error. **CI has been benchmarking an empty index** — `sessionsCount: 0`.

It also never got typechecked: `apps/cli/tsconfig.json` has `"include": ["src/**/*"]`, so `bench/` is outside the `typecheck` job. Nothing in CI could have caught this.

## What changed

- Resolve both paths through `getSessionsDir()` / `getSessionsDbPath()` so the benchmark cannot drift away from the CLI again.
- Add `BENCH_CORPUS=real`: copies the live index into a throwaway `HOME` and re-runs there. Copying rather than measuring in place keeps `discoverSessions`' writes off the index `agents sessions` is serving. Warm-only — cold rebuilds by rescanning transcripts, which a copied index does not carry, so that combination exits 1 with an explanation rather than silently reporting zero sessions.
- Report `corpus` and `sessionsDbPath` so a run states which index produced its numbers.
- Drop the `index.jsonl` / `content_index.jsonl` byte fields (SQLite replaced those at schema v13; the only live `*_index.jsonl` references are Codex's unrelated `session_index.jsonl`) and the unused `QUERIES` const.
- Fix the `getSessionsDbPath()` JSDoc, which was missing the `sessions/` path component.

## Evidence

Before — what CI measures, unchanged by this PR:

```
sessions: 0    A_cold: 638.7ms   B_warm: 300.4ms   sessionsDbBytes: 0
```

After — `BENCH_CORPUS=real BENCH_MODE=warm`, five consecutive runs against an 864 MB / ~3,500-session index:

| run | B_warmDiscoverMs | C_singleKeystrokeMs | E_searchContentBestMs | sessions |
|---|---|---|---|---|
| 1 | 331.1 | 339.8 | 18.4 | 3493 |
| 2 | 350.0 | 331.7 | 17.9 | 3493 |
| 3 | 352.1 | 335.7 | 17.8 | 3493 |
| 4 | 332.9 | 330.3 | 18.6 | 3493 |
| 5 | 350.9 | 345.3 | 17.8 | 3493 |

`pre.sessionsDbBytes: 864423936` — non-zero, which is the proof the path fix landed.

Worth flagging separately: `README.md` states session search does "warm reads in ~100ms". Warm discover on a real corpus of this size is **~350 ms**, and a single picker keystroke is **~336 ms**. That claim predates this fix and had no benchmark behind it; this PR does not change the README, it just makes the number measurable.

## Safety of `BENCH_CORPUS=real`

Every write in real mode is directed at the temp copy, which the emitted `sessionsDbPath` shows:

```
"sessionsDbPath": "/var/folders/.../T/sessions-perf-gLD017/.agents/.history/sessions/sessions.db"
```

The parent process only reads (`existsSync`, `fileSize`, `cpSync` source) before re-execing, and `dbInstance` in `session/db.ts:181` is lazy, so importing the module does not open the live DB. On APFS the copy is a copy-on-write clone and completes in ~0s.

Note for anyone verifying this by hand: comparing `sessions.db` checksums before and after a run proves nothing. The `agents __daemon-run` process rewrites that file on its own — measured here changing across 4 minutes of idle with no benchmark running.

## Scope

`bench/` is not in the published tarball (`package.json#files` is `dist/**` plus the signed helpers), so no CHANGELOG entry — no user-visible surface changes. The `state.ts` edit is a JSDoc correction with no behavior change.

Session transcript (local, this repo is public): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.220/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/83344c21-f09d-4b15-aab0-dfe487bbb23a.jsonl`
