### PR TITLE
feat(secrets): add `rotate-passphrase` to re-key the encrypted file store (RUSH-1975)

### DIFF
--- a/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
+++ b/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
@@ -7,8 +7,12 @@
   exposure being fixed). The new command decrypts every `<item>.enc` under the
   current key, re-encrypts under a freshly generated one, and swaps both the
   ciphertext and the 0600 key file by directory rename after verifying every item
-  round-trips — a crash at any point leaves the old store intact and readable, and
-  no plaintext secret or passphrase is ever written to disk, argv, or a log. Items
+  round-trips. A crash at any point self-heals on the next run to a single readable
+  store — content-aware recovery probes which key actually decrypts the live store
+  (not merely which files are present) and either completes the rotation forward or
+  rolls back, so a crash between the store swap and the key swap can never orphan
+  the store under a mismatched key. No plaintext secret or passphrase is ever
+  written to disk, argv, or a log. Items
   that don't decrypt under the current key (orphan caches, stale test artifacts)
   are carried through verbatim, never re-keyed. Dry-run by default (`--commit` to
   apply); refuses while the secrets-agent holds live unlocks or while

--- a/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
+++ b/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
@@ -1,0 +1,17 @@
+- **New `agents secrets rotate-passphrase` re-keys the encrypted file store under
+  a new master passphrase, atomically (RUSH-1975).** Until now there was no
+  supported way to rotate the file-store passphrase — `rekey` only renames macOS
+  keychain service names and `rotate <bundle> <key>` replaces a single secret
+  value, so a leaked passphrase (RUSH-1968) could only be remediated by a
+  hand-rolled non-atomic script or an export-to-plaintext round-trip (the exact
+  exposure being fixed). The new command decrypts every `<item>.enc` under the
+  current key, re-encrypts under a freshly generated one, and swaps both the
+  ciphertext and the 0600 key file by directory rename after verifying every item
+  round-trips — a crash at any point leaves the old store intact and readable, and
+  no plaintext secret or passphrase is ever written to disk, argv, or a log. Items
+  that don't decrypt under the current key (orphan caches, stale test artifacts)
+  are carried through verbatim, never re-keyed. Dry-run by default (`--commit` to
+  apply); refuses while the secrets-agent holds live unlocks or while
+  `AGENTS_SECRETS_PASSPHRASE` is exported in the environment, unless `--force`.
+  Headless-safe and Linux-first. Source: `apps/cli/src/lib/secrets/filestore.ts`,
+  `apps/cli/src/commands/secrets-rotate-passphrase.ts`.

--- a/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
+++ b/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
@@ -7,12 +7,18 @@
   exposure being fixed). The new command decrypts every `<item>.enc` under the
   current key, re-encrypts under a freshly generated one, and swaps both the
   ciphertext and the 0600 key file by directory rename after verifying every item
-  round-trips. A crash at any point self-heals on the next run to a single readable
-  store — content-aware recovery probes which key actually decrypts the live store
-  (not merely which files are present) and either completes the rotation forward or
-  rolls back, so a crash between the store swap and the key swap can never orphan
-  the store under a mismatched key. No plaintext secret or passphrase is ever
-  written to disk, argv, or a log. Items
+  round-trips. A crash at any point self-heals on the next *rotate* run to a single
+  readable store — content-aware recovery probes which key actually decrypts the
+  live store (not merely which files are present) and classifies the WHOLE store:
+  it completes the rotation forward or rolls back only when one key opens every
+  item, and if a later `secrets set` contaminated a crashed rotation into a MIXED
+  store (items under two keys at once) it refuses with an actionable error and
+  preserves every recovery artifact rather than sweeping the only copy of a key —
+  so a crash between the store swap and the key swap can never orphan the store,
+  even when a write landed in between. The rotation and every store write run under
+  one cross-process lock, so a `secrets set` or a second rotation can never
+  interleave with a swap in the first place. No plaintext secret or passphrase is
+  ever written to disk, argv, or a log. Items
   that don't decrypt under the current key (orphan caches, stale test artifacts)
   are carried through verbatim, never re-keyed. Dry-run by default (`--commit` to
   apply); refuses while the secrets-agent holds live unlocks or while

--- a/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
+++ b/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
@@ -12,10 +12,12 @@
   live store (not merely which files are present) and classifies the WHOLE store:
   it completes the rotation forward or rolls back only when one key opens every
   item, and if a later `secrets set` contaminated a crashed rotation into a MIXED
-  store (items under two keys at once) it refuses with an actionable error and
-  preserves every recovery artifact rather than sweeping the only copy of a key —
-  so a crash between the store swap and the key swap can never orphan the store,
-  even when a write landed in between. The rotation and every store write run under
+  store (items under two keys at once, or a store dir recreated by an interstitial
+  write after the crash left it absent, so its backup holds items the live dir does
+  not) it refuses with an actionable error and preserves every recovery artifact
+  rather than sweeping the only copy of a key or the backed-up ciphertext — so a
+  crash anywhere in the swap can never orphan the store, even when a write landed in
+  between. The rotation and every store write run under
   one cross-process lock, so a `secrets set` or a second rotation can never
   interleave with a swap in the first place. No plaintext secret or passphrase is
   ever written to disk, argv, or a log. Items

--- a/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
+++ b/apps/cli/.changelog/next/rush-1975-rotate-passphrase.md
@@ -23,7 +23,10 @@
   ever written to disk, argv, or a log. Items
   that don't decrypt under the current key (orphan caches, stale test artifacts)
   are carried through verbatim, never re-keyed. Dry-run by default (`--commit` to
-  apply); refuses while the secrets-agent holds live unlocks or while
+  apply) and a dry run truly writes nothing — if a previous rotation was
+  interrupted, it reports the pending recovery rather than performing it, since
+  healing renames and removes files; the next `--commit` run heals first, then
+  rotates. Refuses while the secrets-agent holds live unlocks or while
   `AGENTS_SECRETS_PASSPHRASE` is exported in the environment, unless `--force`.
   Headless-safe and Linux-first. Source: `apps/cli/src/lib/secrets/filestore.ts`,
   `apps/cli/src/commands/secrets-rotate-passphrase.ts`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -606,12 +606,21 @@ agents secrets rotate-passphrase --commit   # re-encrypt the store under a fresh
 This decrypts every item under the current key, re-encrypts it under a newly
 generated one, and swaps both the ciphertext and the 0600 key file atomically —
 staged in a temp dir, verified (every item must round-trip under the new key),
-then swapped by directory rename. A crash at any point self-heals on the next run
-to a single readable store: recovery probes which key actually decrypts the live
-store rather than guessing from which files are present, and either completes the
-rotation forward or rolls back — so a crash in the gap between the store swap and
-the key swap can never strand the store under a mismatched key. No plaintext
-secret value or passphrase is ever written to
+then swapped by directory rename. A crash at any point self-heals on the next
+`rotate-passphrase` run to a single readable store (ordinary `secrets get` stays
+broken until that recovery runs — recovery only fires on the next rotate): it
+probes which key actually decrypts the live store rather than guessing from which
+files are present, classifies the whole store, and either completes the rotation
+forward or rolls back **only when one key opens every item** — so a crash in the
+gap between the store swap and the key swap can never strand the store under a
+mismatched key. If a `secrets set` slipped in between a crashed rotation and the
+recovery and left a **mixed** store (some items under the new key, some under the
+old), recovery refuses with an actionable error and preserves every recovery
+artifact rather than deleting the only copy of a key — so nothing is ever lost
+silently; you decrypt each item under whichever key opens it and re-run. Rotation
+and every store write take one cross-process lock, so a `secrets set` or a second
+rotation can never interleave with a swap to begin with. No plaintext secret value
+or passphrase is ever written to
 disk, argv, or a log. Items that don't decrypt under the current key (orphan
 caches, stale artifacts) are carried through untouched and reported. It refuses
 to run while the secrets-agent holds live unlocks, or while

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -614,10 +614,12 @@ files are present, classifies the whole store, and either completes the rotation
 forward or rolls back **only when one key opens every item** — so a crash in the
 gap between the store swap and the key swap can never strand the store under a
 mismatched key. If a `secrets set` slipped in between a crashed rotation and the
-recovery and left a **mixed** store (some items under the new key, some under the
-old), recovery refuses with an actionable error and preserves every recovery
-artifact rather than deleting the only copy of a key — so nothing is ever lost
-silently; you decrypt each item under whichever key opens it and re-run. Rotation
+recovery and left a **mixed** store — items under two keys at once, or a store dir
+an interstitial write recreated after the crash left it absent, so its backup holds
+items the live dir does not — recovery refuses with an actionable error and
+preserves every recovery artifact rather than deleting the only copy of a key or
+of the backed-up ciphertext — so nothing is ever lost silently; you merge or
+re-seal each item under whichever key opens it and re-run. Rotation
 and every store write take one cross-process lock, so a `secrets set` or a second
 rotation can never interleave with a swap to begin with. No plaintext secret value
 or passphrase is ever written to

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -606,8 +606,12 @@ agents secrets rotate-passphrase --commit   # re-encrypt the store under a fresh
 This decrypts every item under the current key, re-encrypts it under a newly
 generated one, and swaps both the ciphertext and the 0600 key file atomically —
 staged in a temp dir, verified (every item must round-trip under the new key),
-then swapped by directory rename, so a crash at any point leaves the old store
-intact and readable. No plaintext secret value or passphrase is ever written to
+then swapped by directory rename. A crash at any point self-heals on the next run
+to a single readable store: recovery probes which key actually decrypts the live
+store rather than guessing from which files are present, and either completes the
+rotation forward or rolls back — so a crash in the gap between the store swap and
+the key swap can never strand the store under a mismatched key. No plaintext
+secret value or passphrase is ever written to
 disk, argv, or a log. Items that don't decrypt under the current key (orphan
 caches, stale artifacts) are carried through untouched and reported. It refuses
 to run while the secrets-agent holds live unlocks, or while

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -270,6 +270,7 @@ See [The secrets-agent](#the-secrets-agent-macos) below for the model and the se
 | `secrets migrate` | Interactively migrate legacy YAML bundles into Keychain | `agents secrets migrate` |
 | `secrets migrate-acl` | Upgrade legacy keychain items to the biometry ACL (macOS) | `agents secrets migrate-acl` |
 | `secrets import-keyring` | Migrate secrets out of the OS keyring / Credential Manager into the encrypted file store (Linux/Windows). Dry-run by default; `--commit` to write | `agents secrets import-keyring --commit` |
+| `secrets rotate-passphrase` | Re-key the whole encrypted file store under a new machine-local passphrase, atomically (see [File store](#linux-headless-servers-and-the-encrypted-file-fallback)). Dry-run by default; `--commit` to write | `agents secrets rotate-passphrase --commit` |
 | `secrets openclaw-keychain migrate [config]` | Move supported OpenClaw plaintext credentials into macOS Keychain and rewrite them as exec SecretRefs | `agents secrets openclaw-keychain migrate ~/.openclaw/openclaw.json` |
 
 `secrets openclaw-keychain migrate` targets OpenClaw surfaces that accept
@@ -592,8 +593,27 @@ private key, and identical to the common `export AGENTS_SECRETS_PASSPHRASE=… `
 exposure (backups, accidental commits, `.env` leaks), not against another
 process running as the same user. For a key held **off disk**, set
 `AGENTS_SECRETS_PASSPHRASE` (it always takes precedence) or unlock the keyring
-(e.g. configure `pam_gnome_keyring` for SSH login). To rotate, set a new
-`AGENTS_SECRETS_PASSPHRASE`, re-add the secrets, and delete `.passphrase`.
+(e.g. configure `pam_gnome_keyring` for SSH login).
+
+**Rotating the passphrase.** When the machine-local key is compromised (e.g. it
+was exported into the process environment and captured), rotate it with:
+
+```bash
+agents secrets rotate-passphrase            # dry-run: report the item count + round-trip
+agents secrets rotate-passphrase --commit   # re-encrypt the store under a fresh key
+```
+
+This decrypts every item under the current key, re-encrypts it under a newly
+generated one, and swaps both the ciphertext and the 0600 key file atomically —
+staged in a temp dir, verified (every item must round-trip under the new key),
+then swapped by directory rename, so a crash at any point leaves the old store
+intact and readable. No plaintext secret value or passphrase is ever written to
+disk, argv, or a log. Items that don't decrypt under the current key (orphan
+caches, stale artifacts) are carried through untouched and reported. It refuses
+to run while the secrets-agent holds live unlocks, or while
+`AGENTS_SECRETS_PASSPHRASE` is exported in the environment (that stale export
+would shadow the new key), unless you pass `--force`. Any process still holding
+the old passphrase in its environment must be restarted afterward.
 
 ## See Also
 

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -603,6 +603,11 @@ agents secrets rotate-passphrase            # dry-run: report the item count + r
 agents secrets rotate-passphrase --commit   # re-encrypt the store under a fresh key
 ```
 
+The dry run writes nothing at all. If a previous rotation was interrupted, it
+reports that a recovery is pending instead of performing one — healing renames and
+removes files, which a dry run must not do. The next `--commit` run heals the
+store first, then rotates.
+
 This decrypts every item under the current key, re-encrypts it under a newly
 generated one, and swaps both the ciphertext and the 0600 key file atomically —
 staged in a temp dir, verified (every item must round-trip under the new key),

--- a/apps/cli/src/commands/secrets-rotate-passphrase.ts
+++ b/apps/cli/src/commands/secrets-rotate-passphrase.ts
@@ -29,9 +29,10 @@ export function registerSecretsRotatePassphraseCommand(secrets: Command): void {
     .addHelpText('after', `
 Rotates the auto-provisioned file-store key at ~/.agents/.secrets-key/passphrase:
 decrypts every item under the current key, re-encrypts under a new one, verifies
-every item round-trips, then swaps the store and key file atomically. A crash at
-any point leaves the old store readable with the old key. No plaintext secret
-value or passphrase is ever written to disk, argv, or a log.
+every item round-trips, then swaps the store and key file atomically. A crash
+before the swap leaves the old store readable with the old key; a crash inside the
+swap self-heals on the next rotate-passphrase run (not on an ordinary get). No
+plaintext secret value or passphrase is ever written to disk, argv, or a log.
 
 Examples:
   # Report what would rotate (no writes)

--- a/apps/cli/src/commands/secrets-rotate-passphrase.ts
+++ b/apps/cli/src/commands/secrets-rotate-passphrase.ts
@@ -1,0 +1,100 @@
+/**
+ * `agents secrets rotate-passphrase` — rotate the encrypted file store's
+ * machine-local master passphrase (RUSH-1975).
+ *
+ * Re-encrypts every `<item>.enc` under a freshly generated key and rewrites the
+ * 0600 key file in place, atomically: the new store is staged, verified
+ * (round-trip + count), fsync'd, then swapped by directory rename, so a crash
+ * leaves the old store intact and readable. Headless-safe and Linux-first — the
+ * remediation path for a compromised passphrase (RUSH-1968), where the two
+ * supported alternatives are unacceptable (a hand-rolled non-atomic script, or
+ * export-to-plaintext which is the exposure being fixed).
+ *
+ * Dry-run by default, matching `import-keyring`; `--commit` performs the swap.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { machinePassphraseExists, rotatePassphrase } from '../lib/secrets/filestore.js';
+import { agentStatus } from '../lib/secrets/agent.js';
+
+/** Register `agents secrets rotate-passphrase` on the parent secrets Command. */
+export function registerSecretsRotatePassphraseCommand(secrets: Command): void {
+  secrets
+    .command('rotate-passphrase')
+    .description('Re-key the encrypted file store under a new machine-local passphrase (atomic, headless-safe). Dry-run by default.')
+    .option('--commit', 'Perform the rotation (default is dry-run reporting only)')
+    .option('--dry-run', 'Report bundle count and round-trip result without writing (the default)')
+    .option('--force', 'Override the safety refusals (held broker unlocks, or a passphrase exported in the environment)')
+    .addHelpText('after', `
+Rotates the auto-provisioned file-store key at ~/.agents/.secrets-key/passphrase:
+decrypts every item under the current key, re-encrypts under a new one, verifies
+every item round-trips, then swaps the store and key file atomically. A crash at
+any point leaves the old store readable with the old key. No plaintext secret
+value or passphrase is ever written to disk, argv, or a log.
+
+Examples:
+  # Report what would rotate (no writes)
+  agents secrets rotate-passphrase
+
+  # Perform the rotation
+  agents secrets rotate-passphrase --commit`)
+    .action(async (opts: { commit?: boolean; dryRun?: boolean; force?: boolean }) => {
+      try {
+        if (opts.commit && opts.dryRun) {
+          throw new Error('--commit and --dry-run are mutually exclusive.');
+        }
+        const dryRun = !opts.commit;
+
+        if (!machinePassphraseExists()) {
+          throw new Error(
+            'No machine-local passphrase is provisioned on this box, so there is nothing to rotate. ' +
+            'This command re-keys the file store\'s auto-provisioned key at ~/.agents/.secrets-key/passphrase.',
+          );
+        }
+
+        // Guard 1: refuse while the secrets-agent holds live unlocks (macOS), so a
+        // concurrent read cannot land against a half-swapped store. --force overrides.
+        if (!dryRun && !opts.force) {
+          const held = await agentStatus();
+          if (held.length > 0) {
+            throw new Error(
+              `The secrets-agent is holding ${held.length} unlocked bundle(s) (${held.map((e) => e.name).join(', ')}). ` +
+              'Lock them first (`agents secrets lock --all`) so no concurrent read races the rotation, or pass --force.',
+            );
+          }
+        }
+
+        // Guard 2: a passphrase exported in the environment shadows the on-disk key
+        // file with a now-stale value after the rotation, breaking every read. This
+        // is the exact RUSH-1968 footgun — refuse the commit and point at the fix.
+        if (!dryRun && !opts.force && (process.env.AGENTS_SECRETS_PASSPHRASE ?? '').length > 0) {
+          throw new Error(
+            'AGENTS_SECRETS_PASSPHRASE is set in this environment; it would shadow the rotated key file ' +
+            'with a stale value and break every read. Unset it (this is the RUSH-1968 fix) before rotating, or pass --force.',
+          );
+        }
+
+        const report = rotatePassphrase({ dryRun });
+
+        console.log(
+          `${chalk.bold(String(report.bundleCount))} item(s) decrypt under the current key and ` +
+          `${report.roundTripOk ? chalk.green('round-trip cleanly') : chalk.red('failed to round-trip')} under a new key.`,
+        );
+        if (report.skipped.length > 0) {
+          console.log(chalk.gray(`skipped ${report.skipped.length} orphan file(s) (not re-keyed):`));
+          for (const s of report.skipped) console.log(chalk.gray(`  - ${s}`));
+        }
+
+        if (report.dryRun) {
+          console.log(chalk.gray(`Dry-run: nothing written. Pass --commit to re-encrypt the store and swap the key file (${report.keyFilePath}).`));
+          return;
+        }
+        console.log(chalk.green(`Rotated: re-encrypted ${report.bundleCount} item(s) and rewrote ${report.keyFilePath} (mode 0600).`));
+        console.log(chalk.gray('The previous key and ciphertext were removed. Any process still holding the old passphrase in its environment must be restarted.'));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/apps/cli/src/commands/secrets-rotate-passphrase.ts
+++ b/apps/cli/src/commands/secrets-rotate-passphrase.ts
@@ -88,6 +88,12 @@ Examples:
         }
 
         if (report.dryRun) {
+          if (report.recoveryPending) {
+            console.log(chalk.yellow(
+              'A previous rotation left artifacts on disk. Dry-run does not heal them; ' +
+              'the next --commit run will recover the store before rotating.',
+            ));
+          }
           console.log(chalk.gray(`Dry-run: nothing written. Pass --commit to re-encrypt the store and swap the key file (${report.keyFilePath}).`));
           return;
         }

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -100,6 +100,7 @@ import { getVaultSession, vaultExists } from '../lib/secrets/vault.js';
 import { registerSecretsSyncCommands } from './secrets-sync.js';
 import { registerSecretsMigrateAclCommand } from './secrets-migrate.js';
 import { registerSecretsImportKeyringCommand } from './secrets-import.js';
+import { registerSecretsRotatePassphraseCommand } from './secrets-rotate-passphrase.js';
 
 /** Prompt the user for a secret value with masked input. Requires an interactive TTY. */
 async function promptForSecret(message: string): Promise<string> {
@@ -2408,6 +2409,7 @@ Examples:
   registerSecretsSyncCommands(cmd);
   registerSecretsMigrateAclCommand(cmd);
   registerSecretsImportKeyringCommand(cmd);
+  registerSecretsRotatePassphraseCommand(cmd);
 }
 
 /** Validate a prompt-policy value, throwing a clear message on a bad one (the

--- a/apps/cli/src/lib/fs-atomic.test.ts
+++ b/apps/cli/src/lib/fs-atomic.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the cross-process file lock's synchronous heartbeat (RUSH-1975).
+ *
+ * proper-lockfile keeps a held lock alive by refreshing its lockfile mtime on a
+ * setTimeout every `stale/2` — but that timer only fires when the event loop gets a
+ * turn, so a fully synchronous critical section that outlives the stale window (the
+ * scrypt-bound secrets rotation) would age past `stale` mid-hold and a peer could
+ * break the lock as "stale" and interleave. `withFileLock` hands `fn` a `heartbeat()`
+ * that bumps the lockfile mtime synchronously to close that window.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import lockfile from 'proper-lockfile';
+import { withFileLock, ensureLockTarget, sleepSync } from './fs-atomic.js';
+
+describe('withFileLock heartbeat', () => {
+  it('a synchronous hold that outlives the stale window stays un-stealable when it heartbeats', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-atomic-hb-'));
+    const target = path.join(dir, 'target');
+    ensureLockTarget(target);
+    try {
+      let stole = false;
+      let blocked = false;
+      withFileLock(target, (heartbeat) => {
+        // Hold ~125ms — well past the 50ms stale window — refreshing every 25ms.
+        // Without the heartbeat the lock would age past `stale` and the peer below
+        // would break it; with it, the peer must still see the lock HELD (fresh).
+        for (let i = 0; i < 5; i++) { heartbeat(); sleepSync(25); }
+        try {
+          const release = lockfile.lockSync(target, { stale: 50 });
+          release();
+          stole = true;
+        } catch {
+          blocked = true;
+        }
+      }, { staleMs: 50, acquireTimeoutMs: 100 });
+      expect(stole).toBe(false);
+      expect(blocked).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a short hold needs no heartbeat — the lock is held for the whole critical section', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-atomic-short-'));
+    const target = path.join(dir, 'target');
+    ensureLockTarget(target);
+    try {
+      let blocked = false;
+      withFileLock(target, () => {
+        // A single fast read-modify-write, well inside the stale window: a peer must
+        // find the lock held even though this callback never touches the heartbeat.
+        try { const release = lockfile.lockSync(target, { stale: 5_000 }); release(); }
+        catch { blocked = true; }
+      });
+      expect(blocked).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/lib/fs-atomic.test.ts
+++ b/apps/cli/src/lib/fs-atomic.test.ts
@@ -16,32 +16,90 @@ import * as path from 'path';
 import lockfile from 'proper-lockfile';
 import { withFileLock, ensureLockTarget, sleepSync } from './fs-atomic.js';
 
+/**
+ * proper-lockfile silently raises any `stale` below this floor:
+ *   node_modules/proper-lockfile/lib/lockfile.js:219 (and :304)
+ *     options.stale = Math.max(options.stale || 0, 2000);
+ *
+ * Every stale window in this file MUST sit above it. A test written with
+ * `stale: 50` does not test a 50ms window — it tests a 2000ms one, so a hold
+ * shorter than 2s blocks a peer whether or not the heartbeat does anything,
+ * and the test passes against a no-op heartbeat.
+ */
+const PROPER_LOCKFILE_MIN_STALE_MS = 2_000;
+const STALE_MS = PROPER_LOCKFILE_MIN_STALE_MS + 500;
+/** Long enough that an un-refreshed lock is comfortably past STALE_MS. */
+const HOLD_MS = STALE_MS + 1_500;
+
+/** Hold the lock for HOLD_MS, optionally heartbeating, and report what a peer saw. */
+function peerVerdictAfterSyncHold(beat: ((heartbeat: () => void) => void) | null): 'stole' | 'blocked' {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-atomic-hb-'));
+  const target = path.join(dir, 'target');
+  ensureLockTarget(target);
+  try {
+    let verdict: 'stole' | 'blocked' = 'blocked';
+    try {
+      withFileLock(target, (heartbeat) => {
+        // A fully synchronous hold: sleepSync blocks the event loop, so
+        // proper-lockfile's own setTimeout-based refresher never gets a turn.
+        // The only thing that can keep the lock fresh is the sync heartbeat.
+        const deadline = Date.now() + HOLD_MS;
+        while (Date.now() < deadline) {
+          if (beat) beat(heartbeat);
+          sleepSync(250);
+        }
+        try {
+          const release = lockfile.lockSync(target, { stale: STALE_MS });
+          release();
+          verdict = 'stole';
+        } catch {
+          verdict = 'blocked';
+        }
+      }, { staleMs: STALE_MS, acquireTimeoutMs: 100 });
+    } catch (err) {
+      // Once the peer breaks the lock as stale, withFileLock's own `release()`
+      // throws ENOTACQUIRED — the holder no longer owns what it is releasing.
+      // That only happens in the stolen case, so it corroborates the verdict
+      // rather than being an error to hide.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOTACQUIRED') throw err;
+      expect(verdict).toBe('stole');
+    }
+    return verdict;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 describe('withFileLock heartbeat', () => {
-  it('a synchronous hold that outlives the stale window stays un-stealable when it heartbeats', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-atomic-hb-'));
+  it('pins the proper-lockfile stale floor these tests depend on', () => {
+    // If a dependency bump changes this floor, the windows below stop meaning
+    // what they say and the heartbeat tests silently go vacuous. Fail loudly here
+    // instead: a sub-floor stale must NOT be honoured.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-atomic-floor-'));
     const target = path.join(dir, 'target');
     ensureLockTarget(target);
     try {
-      let stole = false;
-      let blocked = false;
-      withFileLock(target, (heartbeat) => {
-        // Hold ~125ms — well past the 50ms stale window — refreshing every 25ms.
-        // Without the heartbeat the lock would age past `stale` and the peer below
-        // would break it; with it, the peer must still see the lock HELD (fresh).
-        for (let i = 0; i < 5; i++) { heartbeat(); sleepSync(25); }
-        try {
-          const release = lockfile.lockSync(target, { stale: 50 });
-          release();
-          stole = true;
-        } catch {
-          blocked = true;
-        }
-      }, { staleMs: 50, acquireTimeoutMs: 100 });
-      expect(stole).toBe(false);
-      expect(blocked).toBe(true);
+      const release = lockfile.lockSync(target, { stale: 50 });
+      // Age well past the *requested* 50ms but far short of the 2000ms floor.
+      sleepSync(400);
+      let peerSawStale = false;
+      try { lockfile.lockSync(target, { stale: 50 })(); peerSawStale = true; } catch { /* held */ }
+      release();
+      expect(peerSawStale).toBe(false);
+      expect(STALE_MS).toBeGreaterThan(PROPER_LOCKFILE_MIN_STALE_MS);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it('a synchronous hold that outlives the stale window stays un-stealable when it heartbeats', () => {
+    expect(peerVerdictAfterSyncHold((heartbeat) => heartbeat())).toBe('blocked');
+  });
+
+  it('the same hold IS stolen without the heartbeat — proving the test can fail', () => {
+    // Negative control. Without this, the assertion above passes against a no-op
+    // heartbeat and proves nothing about the data-loss window it guards.
+    expect(peerVerdictAfterSyncHold(null)).toBe('stole');
   });
 
   it('a short hold needs no heartbeat — the lock is held for the whole critical section', () => {

--- a/apps/cli/src/lib/fs-atomic.ts
+++ b/apps/cli/src/lib/fs-atomic.ts
@@ -59,13 +59,26 @@ export function atomicWriteFileSync(filePath: string, content: string, options: 
  * releases the lock. Retries with capped linear back-off until either the lock
  * is acquired or LOCK_ACQUIRE_TIMEOUT_MS elapses. Breaks stale locks older than
  * LOCK_STALE_MS, so a crashed holder never blocks past the stale window.
+ *
+ * `fn` is handed a `heartbeat()` it can call during a long, fully SYNCHRONOUS
+ * critical section. proper-lockfile keeps a held lock "alive" by refreshing its
+ * lockfile mtime on a `setTimeout` every `stale/2` — but that timer only fires
+ * when the event loop gets a turn. A synchronous hold that outruns `stale`
+ * (e.g. the scrypt-bound rotation loop in filestore.ts, ~16s on a real store)
+ * never yields, so the timer cannot run: the lock ages past `stale` mid-hold and a
+ * peer contending for it treats the live holder as crashed, breaks the lock, and
+ * interleaves — corrupting the invariant the lock exists to protect, with no crash
+ * involved. `heartbeat()` drives the same refresh synchronously (bumps the lockfile
+ * mtime), so a long sync holder stays fresh while the short `stale` window still
+ * detects a genuinely crashed holder within LOCK_STALE_MS. Callers whose critical
+ * section is short (a single read-modify-write) can ignore it.
  */
 export interface FileLockOptions {
   staleMs?: number;
   acquireTimeoutMs?: number;
 }
 
-export function withFileLock<T>(filePath: string, fn: () => T, opts: FileLockOptions = {}): T {
+export function withFileLock<T>(filePath: string, fn: (heartbeat: () => void) => T, opts: FileLockOptions = {}): T {
   let release: (() => void) | null = null;
   let lastError: unknown;
   const staleMs = opts.staleMs ?? LOCK_STALE_MS;
@@ -88,8 +101,16 @@ export function withFileLock<T>(filePath: string, fn: () => T, opts: FileLockOpt
       `Could not acquire lock for ${filePath} after ${acquireTimeoutMs}ms: ${message}`,
     );
   }
+  // proper-lockfile's lock dir is `<filePath>.lock`; touching its mtime is exactly
+  // what proper-lockfile's own async updater does, so the staleness check keys off
+  // a fresh mtime. Best-effort: a failed touch just leaves the async updater's
+  // behaviour unchanged (no worse than before this heartbeat existed).
+  const lockDir = `${filePath}.lock`;
+  const heartbeat = (): void => {
+    try { const now = new Date(); fs.utimesSync(lockDir, now, now); } catch { /* best effort */ }
+  };
   try {
-    return fn();
+    return fn(heartbeat);
   } finally {
     release();
   }

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -417,3 +417,140 @@ describe('rotatePassphrase (RUSH-1975)', () => {
     expect(() => rotatePassphrase()).toThrow(/machine-local passphrase/i);
   });
 });
+
+/**
+ * Co-located legacy key layout (pre-#479): the machine-local key lives INSIDE the
+ * store dir as `.passphrase`, so `keyColocated` is true and the swap is a single
+ * directory rename that carries both ciphertext and key. Every fixture in the
+ * block above puts the key in a separate `keyDir`, so that path had zero coverage.
+ */
+describe('rotatePassphrase — co-located legacy key layout (RUSH-1975)', () => {
+  let tmpRoot: string;
+  let storeDir: string;
+  let emptyKeyDir: string;
+  let keyFile: string; // storeDir/.passphrase — the co-located legacy key
+  const OLD_KEY = 'old-colocated-key-value';
+  let prevTty: boolean | undefined;
+
+  function seed(bundle: string, key: string, value: string): string {
+    const item = `agents-cli.secrets.${bundle}.${key}`;
+    fileStore.set(item, value);
+    return `${item}.enc`;
+  }
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-rotate-colo-'));
+    storeDir = path.join(tmpRoot, 'store');
+    emptyKeyDir = path.join(tmpRoot, 'key'); // canonical passphrase dir, kept empty
+    keyFile = path.join(storeDir, '.passphrase');
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    prevTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    // Provision the key at the legacy co-located path (inside the store dir) and
+    // point the canonical passphrase dir at an empty dir, so the source resolves the
+    // key to storeDir/.passphrase and `dirname(keyPath) === fileDir()` (colocated).
+    fs.mkdirSync(storeDir, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(emptyKeyDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(keyFile, OLD_KEY, { mode: 0o600 });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: emptyKeyDir });
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
+    _resetFileStoreForTest();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('re-keys through a single directory rename and rewrites the co-located key in place', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    // Prove the fixture actually exercises the colocated path (dirname === storeDir).
+    expect(machinePassphraseSourcePath()).toBe(keyFile);
+    expect(path.dirname(keyFile)).toBe(storeDir);
+
+    const rep = rotatePassphrase({ newPassphrase: 'colo-new' });
+    expect(rep.committed).toBe(true);
+    expect(rep.bundleCount).toBe(2);
+    expect(rep.roundTripOk).toBe(true);
+
+    // The key file INSIDE the swapped store dir now holds the NEW passphrase, 0600.
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe('colo-new');
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(keyFile).mode & 0o777).toBe(0o600);
+    }
+    // Values still resolve after the rotation, under the new key and not the old.
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
+    const encA = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encA, 'colo-new')).toBe('value-a');
+    expect(() => decryptForFallback(encA, OLD_KEY)).toThrow();
+
+    // No stray rotate artifacts, and the key stayed co-located (never leaked to keyDir).
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+    expect(fs.readdirSync(emptyKeyDir)).toEqual([]);
+  });
+
+  it('crash in the single-rename window (store dir absent) recovers to the old store+key, then a retry rotates cleanly', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    const beforeStore = fs.readdirSync(storeDir).sort()
+      .map((f) => [f, fs.readFileSync(path.join(storeDir, f), 'utf8')]);
+
+    // Crash after the live store is moved aside but before the staged store lands —
+    // the store dir is absent, the old store+key sit in `store.rotate-old-*`, the new
+    // store+key sit in the staging dir. This is the ONLY crash window for a colocated
+    // key: one rename carries both, so there is no NEW-store/OLD-key mismatch to leave.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'colo-crash',
+      onStoreMovedAsideBeforeSwap: () => { throw new Error('crash in single-rename window'); },
+    })).toThrow(/single-rename window/);
+
+    // Prove the crashed on-disk state: store dir gone, backup present, key file gone
+    // (it travelled into the backup with the store), no partial NEW/OLD split.
+    expect(fs.existsSync(storeDir)).toBe(false);
+    expect(fs.existsSync(keyFile)).toBe(false);
+    const bakName = fs.readdirSync(tmpRoot).find((e) => e.startsWith('store.rotate-old-'));
+    expect(bakName).toBeTruthy();
+    expect(fs.readFileSync(path.join(tmpRoot, bakName!, '.passphrase'), 'utf8')).toBe(OLD_KEY);
+
+    // Next run recovers: the backup (old store + old key) is restored intact, so the
+    // store is readable under the OLD key again — strictly safer than the four-rename
+    // non-colocated path, which can strand a NEW-key store beside an OLD key file.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: emptyKeyDir });
+    const rep = rotatePassphrase({ newPassphrase: 'colo-final' });
+    expect(rep.committed).toBe(true);
+
+    // Old ciphertext survived the round trip byte-for-byte through the backup, and the
+    // retry re-keyed cleanly to the final key.
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe('colo-final');
+    const encAfter = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encAfter, 'colo-final')).toBe('value-a');
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+    // The store held the same item set before the crash and after recovery+retry.
+    expect(fs.readdirSync(storeDir).filter((f) => f.endsWith('.enc')).sort())
+      .toEqual(beforeStore.map(([f]) => f).filter((f) => f.endsWith('.enc')).sort());
+  });
+
+  it('copies a non-UTF-8 file through the rotation byte-for-byte (no U+FFFD corruption)', () => {
+    seed('prod', 'A', 'value-a');
+    // A raw binary blob with byte sequences that are not valid UTF-8 (0xff/0xfe are
+    // never legal UTF-8 lead bytes; the lone 0x80 continuation is invalid too). A
+    // decode/re-encode round-trip would replace each with U+FFFD and corrupt it.
+    const rawName = 'not-utf8.bin';
+    const rawBytes = Buffer.from([0x00, 0xff, 0xfe, 0x80, 0x41, 0xc3, 0x28, 0x99]);
+    fs.writeFileSync(path.join(storeDir, rawName), rawBytes, { mode: 0o600 });
+
+    const rep = rotatePassphrase({ newPassphrase: 'colo-bin' });
+    expect(rep.committed).toBe(true);
+
+    // The blob survived the whole-store rewrite byte-for-byte.
+    const after = fs.readFileSync(path.join(storeDir, rawName));
+    expect(Buffer.compare(after, rawBytes)).toBe(0);
+    // And the real item was still re-keyed.
+    const encA = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encA, 'colo-bin')).toBe('value-a');
+  });
+});

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -540,6 +540,111 @@ describe('rotatePassphrase (RUSH-1975)', () => {
     expect(machinePassphraseSourcePath()).toBeNull();
     expect(() => rotatePassphrase()).toThrow(/machine-local passphrase/i);
   });
+
+  it('Window M (non-co-located): crash after the store dir is moved aside, before the staged store lands — next run restores the backup and the OLD key opens the whole store', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    const beforeEnc = fs.readdirSync(storeDir).filter((f) => f.endsWith('.enc')).sort();
+
+    // Crash at `onStoreMovedAsideBeforeSwap` on the canonical layout: the live store
+    // dir has just been renamed to `store.rotate-old-*` (so `storeDir` is ABSENT) and
+    // the staged NEW-key store has NOT yet landed. Unlike the co-located single-rename
+    // window, the key file lives in its OWN dir, so it is NOT carried into the backup:
+    // it stays untouched at OLD_KEY. This is the exact window `filestore.test.ts:506`
+    // (the co-located test) exercises, now for the layout every non-legacy machine
+    // (incl. yosemite-s0/s1) actually runs.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'winM-crash',
+      onStoreMovedAsideBeforeSwap: () => { throw new Error('crash before staged store lands'); },
+    })).toThrow(/before staged store lands/);
+
+    // Crashed on-disk state: store dir ABSENT, `store.rotate-old-*` backup PRESENT,
+    // key file UNTOUCHED (still OLD_KEY, in its own dir — never swept into the backup).
+    expect(fs.existsSync(storeDir)).toBe(false);
+    const bakName = fs.readdirSync(tmpRoot).find((e) => e.startsWith('store.rotate-old-'));
+    expect(bakName).toBeTruthy();
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe(OLD_KEY);
+    // The old ciphertext rode into the backup intact, still under the OLD key.
+    const encABak = JSON.parse(fs.readFileSync(path.join(tmpRoot, bakName!, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encABak, OLD_KEY)).toBe('value-a');
+
+    // A dry-run rotation triggers recovery WITHOUT re-keying: it must restore the
+    // backup over the absent store dir, and the OLD key must then open the WHOLE
+    // restored store. Every `.rotate-*` artifact is swept only once that is proven.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    const dry = rotatePassphrase({ dryRun: true, newPassphrase: 'winM-probe' });
+    expect(dry.committed).toBe(false);
+    expect(fs.existsSync(storeDir)).toBe(true);
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe(OLD_KEY);
+    for (const [item, want] of [
+      ['agents-cli.secrets.prod.A', 'value-a'],
+      ['agents-cli.secrets.prod.B', 'value-b'],
+    ] as const) {
+      const enc = JSON.parse(fs.readFileSync(path.join(storeDir, `${item}.enc`), 'utf8')) as EncFile;
+      expect(decryptForFallback(enc, OLD_KEY)).toBe(want);
+    }
+    // No `.rotate-*` artifact left behind once recovery completes.
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+
+    // Every seeded value reads back through the live resolver under the restored key.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir, passphrase: OLD_KEY });
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
+
+    // A real rotation now completes cleanly to a fresh key, values intact.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    const rep = rotatePassphrase({ newPassphrase: 'winM-final' });
+    expect(rep.committed).toBe(true);
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe('winM-final');
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+    // Same item set before the crash and after recovery + retry — nothing dropped.
+    expect(fs.readdirSync(storeDir).filter((f) => f.endsWith('.enc')).sort()).toEqual(beforeEnc);
+  });
+
+  it('MIXED/split store (Window M crash + an interstitial write) is REFUSED, not swept — no silent loss', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+
+    // Crash in the move-aside window: the store dir is renamed to `store.rotate-old-*`
+    // (so `storeDir` is ABSENT) and the staged store has not landed. The OLD key file
+    // and `.rotate-new` (the incoming key) are on disk; A and B live ONLY in the backup.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'winM-newkey',
+      onStoreMovedAsideBeforeSwap: () => { throw new Error('crash before staged store lands'); },
+    })).toThrow(/before staged store lands/);
+    expect(fs.existsSync(storeDir)).toBe(false);
+
+    // With the store dir gone but the OLD key file intact, an ordinary `secrets set`
+    // recreates the dir and seals C under the OLD key. The live dir now holds ONLY C —
+    // A and B survive solely in the `store.rotate-old-*` backup. A presence/"any item
+    // opens" recovery would see "the live key opens the whole (C-only) store", call it
+    // consistent, and sweep the backup — permanently orphaning A and B (silent loss).
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    fileStore.set('agents-cli.secrets.prod.C', 'value-c', { allowAutoProvision: true });
+
+    // Recovery must detect that the backup holds items absent from the live dir and
+    // REFUSE, preserving every artifact — never report success over a store it would
+    // be corrupting.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    expect(() => rotatePassphrase({ newPassphrase: 'winM-again' })).toThrow(/MIXED/i);
+
+    // Every recovery artifact survived: the new-key temp and the old-store backup.
+    expect(fs.readFileSync(`${keyFile}.rotate-new`, 'utf8')).toBe('winM-newkey');
+    const bakName = fs.readdirSync(tmpRoot).find((e) => e.startsWith('store.rotate-old-'));
+    expect(bakName).toBeTruthy();
+
+    // And every pre-rotation secret is still recoverable off disk: A and B under the
+    // OLD key in the preserved backup, C under the OLD key in the live dir. Under the
+    // old "any item opens" sweep, A and B were unreadable under every key left on disk.
+    const encABak = JSON.parse(fs.readFileSync(path.join(tmpRoot, bakName!, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    const encBBak = JSON.parse(fs.readFileSync(path.join(tmpRoot, bakName!, 'agents-cli.secrets.prod.B.enc'), 'utf8')) as EncFile;
+    const encC = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.C.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encABak, OLD_KEY)).toBe('value-a');
+    expect(decryptForFallback(encBBak, OLD_KEY)).toBe('value-b');
+    expect(decryptForFallback(encC, OLD_KEY)).toBe('value-c');
+  });
 });
 
 /**

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -23,11 +23,13 @@ vi.mock('child_process', async () => {
   return { ...actual, spawnSync: spawnSyncMock };
 });
 
+import lockfile from 'proper-lockfile';
 import { execSync } from 'child_process';
+import { sleepSync } from '../fs-atomic.js';
 import {
   fileStore, getPassphrase, disableTtyEchoOrThrow, _resetFileStoreForTest,
   rotatePassphrase, machinePassphraseSourcePath, encryptForFallback, decryptForFallback,
-  _setFileStoreLockTimeoutForTest,
+  _setFileStoreLockTimeoutForTest, _setFileStoreLockStaleMsForTest, _fileStoreLockPathForTest,
   type EncFile,
 } from './filestore.js';
 
@@ -644,6 +646,41 @@ describe('rotatePassphrase (RUSH-1975)', () => {
     expect(decryptForFallback(encABak, OLD_KEY)).toBe('value-a');
     expect(decryptForFallback(encBBak, OLD_KEY)).toBe('value-b');
     expect(decryptForFallback(encC, OLD_KEY)).toBe('value-c');
+  });
+
+  it('rotation heartbeats the store lock so a long synchronous hold is not stolen as stale', () => {
+    seed('prod', 'A', 'value-a');
+    // Shrink the 5s stale window so the assertion runs in ms. A real rotation is
+    // scrypt-bound and outlives the production window; here we simulate a hold that
+    // outlives the (tiny) window while the rotation keeps the lock fresh.
+    _setFileStoreLockStaleMsForTest(60);
+
+    let stole = false;
+    let blocked = false;
+    const rep = rotatePassphrase({
+      newPassphrase: 'hb-key',
+      // Fires mid-swap with the store lock held. Hold ~150ms — well past the 60ms
+      // stale window — calling the rotation's own heartbeat every 30ms. A peer's
+      // lock attempt must still find the lock HELD (fresh), not stale-and-stealable.
+      // Without the heartbeat the lock would age out and this steal would succeed.
+      onStoreSwappedBeforeKeySwap: (heartbeat) => {
+        for (let i = 0; i < 5; i++) { heartbeat(); sleepSync(30); }
+        try {
+          const release = lockfile.lockSync(_fileStoreLockPathForTest(), { stale: 60 });
+          release();
+          stole = true;
+        } catch {
+          blocked = true;
+        }
+      },
+    });
+
+    expect(rep.committed).toBe(true);
+    expect(stole).toBe(false);
+    expect(blocked).toBe(true);
+    // The rotation still committed cleanly with the value intact.
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe('hb-key');
   });
 });
 

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -297,6 +297,82 @@ describe('rotatePassphrase (RUSH-1975)', () => {
     expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
   });
 
+  it('Window A: crash after the store swap, before the key swap — next run recovers a readable store instead of sweeping the artifacts', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+
+    // Crash in Window A: the NEW-key store is live, the OLD key file is still in
+    // place, and both recovery artifacts (`.rotate-new` = new key, `.rotate-old-*`
+    // = old store) are on disk. The presence-based recovery would see store+key
+    // both present and sweep both artifacts, orphaning every secret permanently.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'winA-key',
+      onStoreSwappedBeforeKeySwap: () => { throw new Error('crash in Window A'); },
+    })).toThrow(/Window A/);
+
+    // Prove the dangerous on-disk state the crash left: store is NEW-key, key file
+    // is still OLD (a mismatch), and neither artifact has been swept.
+    const encCrash = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encCrash, 'winA-key')).toBe('value-a');
+    expect(() => decryptForFallback(encCrash, OLD_KEY)).toThrow();
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe(OLD_KEY);
+    expect(fs.existsSync(`${keyFile}.rotate-new`)).toBe(true);
+    expect(fs.readdirSync(tmpRoot).some((e) => e.startsWith('store.rotate-old-'))).toBe(true);
+
+    // Next run recovers. Under the old presence-based code this second rotation
+    // would abort ("No item decrypted under the current machine-local key") with
+    // every secret unreadable; content-aware recovery installs the new key first.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    const rep = rotatePassphrase({ newPassphrase: 'winA-final' });
+    expect(rep.committed).toBe(true);
+
+    // Store and key are paired again (no mismatch), every value survived, and the
+    // artifacts are gone only now that a forward decrypt was proven.
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe('winA-final');
+    const encAfter = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encAfter, 'winA-final')).toBe('value-a');
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+    expect(fs.readdirSync(keyDir).sort()).toEqual(['passphrase']);
+  });
+
+  it('Window B: crash after the old key is moved aside, before the new key lands — next run recovers forward, not onto the wrong key', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+
+    // Crash in Window B: the NEW-key store is live, the key file is ABSENT (moved to
+    // `.rotate-oldkey`), and `.rotate-new` holds the new key. The presence-based code
+    // restores the OLD key from `.rotate-oldkey` onto the NEW store (wrong key), then
+    // sweeps `.rotate-new` + the old-store backup, orphaning every secret.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'winB-key',
+      onKeyBackedUpBeforeNewKey: () => { throw new Error('crash in Window B'); },
+    })).toThrow(/Window B/);
+
+    // Prove the on-disk state the crash left.
+    const encCrash = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encCrash, 'winB-key')).toBe('value-a');
+    expect(fs.existsSync(keyFile)).toBe(false);
+    expect(fs.readFileSync(`${keyFile}.rotate-oldkey`, 'utf8')).toBe(OLD_KEY);
+    expect(fs.readFileSync(`${keyFile}.rotate-new`, 'utf8')).toBe('winB-key');
+    expect(fs.readdirSync(tmpRoot).some((e) => e.startsWith('store.rotate-old-'))).toBe(true);
+
+    // Next run must finish the rotation forward — install the NEW key from
+    // `.rotate-new` — not restore the OLD key onto the NEW store.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    const rep = rotatePassphrase({ newPassphrase: 'winB-final' });
+    expect(rep.committed).toBe(true);
+
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe('winB-final');
+    const encAfter = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encAfter, 'winB-final')).toBe('value-a');
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+    expect(fs.readdirSync(keyDir).sort()).toEqual(['passphrase']);
+  });
+
   it('aborts (writing nothing) when a re-encrypted item fails to round-trip under the new key', () => {
     seed('prod', 'A', 'value-a');
     seed('prod', 'B', 'value-b');

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -24,7 +24,11 @@ vi.mock('child_process', async () => {
 });
 
 import { execSync } from 'child_process';
-import { fileStore, getPassphrase, disableTtyEchoOrThrow, _resetFileStoreForTest } from './filestore.js';
+import {
+  fileStore, getPassphrase, disableTtyEchoOrThrow, _resetFileStoreForTest,
+  rotatePassphrase, machinePassphraseSourcePath, encryptForFallback, decryptForFallback,
+  type EncFile,
+} from './filestore.js';
 
 describe('disableTtyEchoOrThrow (RUSH-1764: fail closed so a passphrase never echoes)', () => {
   it('throws (fail closed) when echo cannot be disabled — never falls through', () => {
@@ -171,5 +175,169 @@ describe('filestore win32 interactive passphrase branch', () => {
       status: 1, stdout: Buffer.from(''), stderr: Buffer.from(''), error: new Error('spawn ENOENT'),
     }));
     expect(() => getPassphrase()).toThrow(/AGENTS_SECRETS_PASSPHRASE/);
+  });
+});
+
+// RUSH-1975: rotate the file store's machine-local master passphrase. The
+// catastrophic failure this guards is a half-re-keyed store (every secret lost),
+// so these pin the atomic contract: verify before swap, a crash leaves the old
+// store readable, a bad round-trip aborts, and dry-run writes nothing.
+describe('rotatePassphrase (RUSH-1975)', () => {
+  let tmpRoot: string;
+  let storeDir: string;
+  let keyDir: string;
+  let keyFile: string;
+  const OLD_KEY = 'old-machine-key-value';
+  let prevTty: boolean | undefined;
+
+  /** Seed a keychain-named item into the file store under the current key. */
+  function seed(bundle: string, key: string, value: string): string {
+    const item = `agents-cli.secrets.${bundle}.${key}`;
+    fileStore.set(item, value);
+    return `${item}.enc`;
+  }
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-rotate-'));
+    storeDir = path.join(tmpRoot, 'store');
+    keyDir = path.join(tmpRoot, 'key');
+    keyFile = path.join(keyDir, 'passphrase');
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    prevTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    // Provision a known machine-local key so the store is encrypted under a value
+    // the test controls (rather than an auto-generated one).
+    fs.mkdirSync(keyDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(keyFile, OLD_KEY, { mode: 0o600 });
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
+    _resetFileStoreForTest();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('happy path: re-encrypts every item under a new key and rewrites the 0600 key file', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    seed('daily', 'C', 'value-c');
+
+    const rep = rotatePassphrase({ newPassphrase: 'brand-new-key' });
+    expect(rep.committed).toBe(true);
+    expect(rep.dryRun).toBe(false);
+    expect(rep.bundleCount).toBe(3);
+    expect(rep.roundTripOk).toBe(true);
+    expect(rep.skipped).toEqual([]);
+
+    // Key file rewritten in place with the new value, still 0600.
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe('brand-new-key');
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(keyFile).mode & 0o777).toBe(0o600);
+    }
+
+    // Every item now decrypts under the NEW key and NOT the old one.
+    for (const [item, want] of [
+      ['agents-cli.secrets.prod.A', 'value-a'],
+      ['agents-cli.secrets.prod.B', 'value-b'],
+      ['agents-cli.secrets.daily.C', 'value-c'],
+    ] as const) {
+      const enc = JSON.parse(fs.readFileSync(path.join(storeDir, `${item}.enc`), 'utf8')) as EncFile;
+      expect(decryptForFallback(enc, 'brand-new-key')).toBe(want);
+      expect(() => decryptForFallback(enc, OLD_KEY)).toThrow();
+    }
+    // The live resolver reads the rotated values transparently.
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+
+    // No staging/backup dirs or key temp files left behind.
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+    expect(fs.readdirSync(keyDir)).toEqual(['passphrase']);
+  });
+
+  it('dry-run reports the count and round-trip but writes nothing', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    const beforeStore = fs.readdirSync(storeDir).sort().map((f) => [f, fs.readFileSync(path.join(storeDir, f), 'utf8')]);
+    const beforeKey = fs.readFileSync(keyFile, 'utf8');
+
+    const rep = rotatePassphrase({ dryRun: true, newPassphrase: 'unused' });
+    expect(rep.dryRun).toBe(true);
+    expect(rep.committed).toBe(false);
+    expect(rep.bundleCount).toBe(2);
+    expect(rep.roundTripOk).toBe(true);
+
+    // Byte-for-byte unchanged: no ciphertext rewritten, key file untouched.
+    expect(fs.readdirSync(storeDir).sort().map((f) => [f, fs.readFileSync(path.join(storeDir, f), 'utf8')])).toEqual(beforeStore);
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe(beforeKey);
+  });
+
+  it('a crash mid-run (after staging, before the swap) leaves the old store readable under the old key', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    const beforeStore = fs.readdirSync(storeDir).sort().map((f) => [f, fs.readFileSync(path.join(storeDir, f), 'utf8')]);
+
+    expect(() => rotatePassphrase({
+      newPassphrase: 'never-lands',
+      onStagedBeforeCommit: () => { throw new Error('simulated crash'); },
+    })).toThrow(/simulated crash/);
+
+    // The live store and key file are exactly as they were — old key still works.
+    expect(fs.readdirSync(storeDir).sort().map((f) => [f, fs.readFileSync(path.join(storeDir, f), 'utf8')])).toEqual(beforeStore);
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe(OLD_KEY);
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    const enc = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(() => decryptForFallback(enc, 'never-lands')).toThrow();
+
+    // A subsequent rotation recovers past the abandoned staging dir and succeeds.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir, passphrase: OLD_KEY });
+    const rep = rotatePassphrase({ newPassphrase: 'clean-key' });
+    expect(rep.committed).toBe(true);
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+    expect(fileStore.get('agents-cli.secrets.prod.B')).toBe('value-b');
+  });
+
+  it('aborts (writing nothing) when a re-encrypted item fails to round-trip under the new key', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    const beforeStore = fs.readdirSync(storeDir).sort().map((f) => [f, fs.readFileSync(path.join(storeDir, f), 'utf8')]);
+
+    expect(() => rotatePassphrase({ newPassphrase: 'nk', tamperStaged: true }))
+      .toThrow(/verify|round-trip/i);
+
+    // Verify-before-swap: nothing was written, key file untouched.
+    expect(fs.readdirSync(storeDir).sort().map((f) => [f, fs.readFileSync(path.join(storeDir, f), 'utf8')])).toEqual(beforeStore);
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe(OLD_KEY);
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+  });
+
+  it('re-keys valid items and copies through an orphan encrypted under a different key', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+    // An orphan: valid EncFile JSON, but sealed under a key the store does not use.
+    const orphanEnc = encryptForFallback('orphan-secret', 'some-other-key');
+    const orphanName = 'agents-cli.secrets.orphan.X.enc';
+    fs.writeFileSync(path.join(storeDir, orphanName), JSON.stringify(orphanEnc), { mode: 0o600});
+    const orphanBefore = fs.readFileSync(path.join(storeDir, orphanName), 'utf8');
+
+    const rep = rotatePassphrase({ newPassphrase: 'nk' });
+    expect(rep.committed).toBe(true);
+    expect(rep.bundleCount).toBe(2);
+    expect(rep.skipped.length).toBe(1);
+    expect(rep.skipped[0]).toContain('orphan.X');
+
+    // The orphan is carried through byte-identical (never re-keyed, never dropped).
+    expect(fs.readFileSync(path.join(storeDir, orphanName), 'utf8')).toBe(orphanBefore);
+    // The real items are re-keyed.
+    const encA = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encA, 'nk')).toBe('value-a');
+  });
+
+  it('throws when there is no machine-local passphrase to rotate', () => {
+    seed('prod', 'A', 'value-a');
+    fs.rmSync(keyFile);
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    expect(machinePassphraseSourcePath()).toBeNull();
+    expect(() => rotatePassphrase()).toThrow(/machine-local passphrase/i);
   });
 });

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -27,6 +27,7 @@ import { execSync } from 'child_process';
 import {
   fileStore, getPassphrase, disableTtyEchoOrThrow, _resetFileStoreForTest,
   rotatePassphrase, machinePassphraseSourcePath, encryptForFallback, decryptForFallback,
+  _setFileStoreLockTimeoutForTest,
   type EncFile,
 } from './filestore.js';
 
@@ -407,6 +408,129 @@ describe('rotatePassphrase (RUSH-1975)', () => {
     // The real items are re-keyed.
     const encA = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
     expect(decryptForFallback(encA, 'nk')).toBe('value-a');
+  });
+
+  it('MIXED store (Window A crash + an interstitial write) is REFUSED, not swept — no silent loss', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+
+    // Crash in Window A: the NEW-key store is live, the OLD key file is still in
+    // place, `.rotate-new` (= new key) and the old-store backup are on disk.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'winA-newkey',
+      onStoreSwappedBeforeKeySwap: () => { throw new Error('crash in Window A'); },
+    })).toThrow(/Window A/);
+
+    // An ordinary `secrets set` now seals ONE item under the stale on-disk (OLD)
+    // key, INTO the already-NEW-key store dir. The store is now MIXED: A and B under
+    // the new key, C under the old key. This is exactly the reviewer's repro.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    fileStore.set('agents-cli.secrets.prod.C', 'value-c', { allowAutoProvision: true });
+
+    // The next rotate must NOT read "one item opens under the live key" as
+    // "consistent, sweep". It must detect the mixed store and refuse, preserving
+    // BOTH the only copy of the new key (`.rotate-new`) and the old-ciphertext
+    // backup — nothing reports success, no secret is destroyed.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    expect(() => rotatePassphrase({ newPassphrase: 'winA-again' })).toThrow(/MIXED/i);
+
+    // Every recovery artifact survived.
+    expect(fs.readFileSync(`${keyFile}.rotate-new`, 'utf8')).toBe('winA-newkey');
+    expect(fs.readdirSync(tmpRoot).some((e) => e.startsWith('store.rotate-old-'))).toBe(true);
+
+    // And every pre-rotation secret is still recoverable off disk: A and B under the
+    // preserved new key, C under the live old key. Under the old "any item opens"
+    // sweep, A and B were unreadable under every key left on disk.
+    const encA = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    const encB = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.B.enc'), 'utf8')) as EncFile;
+    const encC = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.C.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encA, 'winA-newkey')).toBe('value-a');
+    expect(decryptForFallback(encB, 'winA-newkey')).toBe('value-b');
+    expect(decryptForFallback(encC, OLD_KEY)).toBe('value-c');
+  });
+
+  it('MIXED store (Window B crash + an interstitial write under a fresh key) is REFUSED, not swept', () => {
+    seed('prod', 'A', 'value-a');
+    seed('prod', 'B', 'value-b');
+
+    // Crash in Window B: the NEW-key store is live, the key file is ABSENT (moved to
+    // `.rotate-oldkey`), `.rotate-new` holds the new key.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'winB-newkey',
+      onKeyBackedUpBeforeNewKey: () => { throw new Error('crash in Window B'); },
+    })).toThrow(/Window B/);
+    expect(fs.existsSync(keyFile)).toBe(false);
+
+    // With the key file gone, an ordinary `secrets set` auto-provisions a THIRD key
+    // and seals C under it — while A and B are still under the new key. Mixed store.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    fileStore.set('agents-cli.secrets.prod.C', 'value-c', { allowAutoProvision: true });
+    const thirdKey = fs.readFileSync(keyFile, 'utf8'); // the freshly provisioned key
+
+    // Recovery must refuse the mixed store rather than sweep the new key.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    expect(() => rotatePassphrase({ newPassphrase: 'winB-again' })).toThrow(/MIXED/i);
+
+    expect(fs.readFileSync(`${keyFile}.rotate-new`, 'utf8')).toBe('winB-newkey');
+    expect(fs.readFileSync(`${keyFile}.rotate-oldkey`, 'utf8')).toBe(OLD_KEY);
+    expect(fs.readdirSync(tmpRoot).some((e) => e.startsWith('store.rotate-old-'))).toBe(true);
+
+    const encA = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.A.enc'), 'utf8')) as EncFile;
+    const encC = JSON.parse(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.prod.C.enc'), 'utf8')) as EncFile;
+    expect(decryptForFallback(encA, 'winB-newkey')).toBe('value-a');
+    expect(decryptForFallback(encC, thirdKey)).toBe('value-c');
+  });
+
+  it('a store where no item opens under any candidate key is left intact (no sweep)', () => {
+    // Seed a store that decrypts under NO key on disk: one .enc sealed under a key
+    // that is neither the live key nor any rotation artifact.
+    const strayEnc = encryptForFallback('stray-secret', 'a-key-nobody-has');
+    fs.mkdirSync(storeDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(storeDir, 'agents-cli.secrets.gone.X.enc'), JSON.stringify(strayEnc), { mode: 0o600 });
+    // A dangling `.rotate-new` artifact (under yet another key) makes recovery run,
+    // but there is no backup dir, so neither forward nor rollback is provable.
+    fs.writeFileSync(`${keyFile}.rotate-new`, 'another-unrelated-key', { mode: 0o600 });
+    const encBefore = fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.gone.X.enc'), 'utf8');
+
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    // The rotation itself has nothing it can decrypt, so it aborts — but recovery
+    // must NOT have swept the artifacts on the way in.
+    expect(() => rotatePassphrase({ newPassphrase: 'nk' })).toThrow(/No item decrypted/i);
+
+    expect(fs.existsSync(`${keyFile}.rotate-new`)).toBe(true);
+    expect(fs.readFileSync(path.join(storeDir, 'agents-cli.secrets.gone.X.enc'), 'utf8')).toBe(encBefore);
+  });
+
+  it('the store lock serializes a concurrent write and a second rotation against a rotation in progress', () => {
+    seed('prod', 'A', 'value-a');
+    _setFileStoreLockTimeoutForTest(150); // fail fast instead of the 30s budget
+
+    let setError: unknown;
+    let rotError: unknown;
+    // The rotation holds the store lock for its whole run. Fire a competing write
+    // and a competing rotation from inside the mid-swap window: both must find the
+    // lock held and fail to acquire (rather than interleave into a mixed store).
+    const rep = rotatePassphrase({
+      newPassphrase: 'nk',
+      onStoreSwappedBeforeKeySwap: () => {
+        try { fileStore.set('agents-cli.secrets.prod.C', 'racer', { allowAutoProvision: true }); }
+        catch (e) { setError = e; }
+        try { rotatePassphrase({ newPassphrase: 'nk2' }); }
+        catch (e) { rotError = e; }
+      },
+    });
+
+    expect(rep.committed).toBe(true); // the holder finished; the challengers were blocked
+    expect((setError as Error)?.message).toMatch(/Could not acquire lock/);
+    expect((rotError as Error)?.message).toMatch(/Could not acquire lock/);
+    // The blocked write never landed — no stray item forged a mixed store.
+    expect(fs.existsSync(path.join(storeDir, 'agents-cli.secrets.prod.C.enc'))).toBe(false);
+
+    // With the lock free, a write and a rotation both succeed normally.
+    fileStore.set('agents-cli.secrets.prod.C', 'value-c', { allowAutoProvision: true });
+    expect(fileStore.get('agents-cli.secrets.prod.C')).toBe('value-c');
+    const rep2 = rotatePassphrase({ newPassphrase: 'nk3' });
+    expect(rep2.committed).toBe(true);
   });
 
   it('throws when there is no machine-local passphrase to rotate', () => {

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -340,6 +340,43 @@ describe('rotatePassphrase (RUSH-1975)', () => {
     expect(fs.readdirSync(keyDir).sort()).toEqual(['passphrase']);
   });
 
+  it('--dry-run does not heal an interrupted rotation — it writes nothing and reports the pending recovery', () => {
+    seed('prod', 'A', 'value-a');
+
+    // Leave the store in the same Window A crash state as the test above.
+    expect(() => rotatePassphrase({
+      newPassphrase: 'winA-key',
+      onStoreSwappedBeforeKeySwap: () => { throw new Error('crash in Window A'); },
+    })).toThrow(/Window A/);
+
+    const artifactsBefore = fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-')).sort();
+    const keyDirBefore = fs.readdirSync(keyDir).sort();
+    const storeBefore = fs.readdirSync(storeDir).sort();
+    const keyBytesBefore = fs.readFileSync(keyFile, 'utf8');
+    expect(artifactsBefore.length).toBeGreaterThan(0);
+
+    // A dry run is report-only. Recovery renames and removes files, so running it
+    // here would write to disk — the exact thing --dry-run promises not to do.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    const rep = rotatePassphrase({ dryRun: true, newPassphrase: 'unused' });
+
+    expect(rep.dryRun).toBe(true);
+    expect(rep.committed).toBe(false);
+    expect(rep.recoveryPending).toBe(true);
+
+    // Nothing on disk moved: same artifacts, same key bytes, same store contents.
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-')).sort()).toEqual(artifactsBefore);
+    expect(fs.readdirSync(keyDir).sort()).toEqual(keyDirBefore);
+    expect(fs.readdirSync(storeDir).sort()).toEqual(storeBefore);
+    expect(fs.readFileSync(keyFile, 'utf8')).toBe(keyBytesBefore);
+
+    // And the pending recovery still happens on the next real run.
+    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
+    expect(rotatePassphrase({ newPassphrase: 'winA-final' }).committed).toBe(true);
+    expect(fileStore.get('agents-cli.secrets.prod.A')).toBe('value-a');
+    expect(fs.readdirSync(tmpRoot).filter((e) => e.includes('.rotate-'))).toEqual([]);
+  });
+
   it('Window B: crash after the old key is moved aside, before the new key lands — next run recovers forward, not onto the wrong key', () => {
     seed('prod', 'A', 'value-a');
     seed('prod', 'B', 'value-b');

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -28,6 +28,7 @@ import * as os from 'os';
 import * as path from 'path';
 import type { KeychainBackend } from './index.js';
 import { encodePwshBase64 } from '../pwsh.js';
+import { withFileLock, ensureLockTarget } from '../fs-atomic.js';
 
 // ---------- file store location ----------
 
@@ -42,6 +43,33 @@ export function fileDir(): string {
 
 function ensureFileDir(): void {
   fs.mkdirSync(fileDir(), { recursive: true, mode: 0o700 });
+}
+
+// ---------- cross-process store lock (RUSH-1975) ----------
+
+// Every mutation of the store (a `secrets set`/`delete`) and every rotation runs
+// under one exclusive lock, so a write can never land in the store dir between a
+// rotation's store-swap and key-swap renames (which would forge a MIXED store —
+// items sealed under two keys at once — with no crash involved) and two rotations
+// can never run concurrently. The macOS-only broker-unlock guard (`agentStatus`)
+// does nothing on the Linux headless targets this command exists for, so this is
+// the real serialization. The lock target is a SIBLING of the store dir, never a
+// file inside it — so it is never copied through a rotation nor swept as a
+// `.rotate-*` artifact, and it stays put across a mid-swap store-dir rename.
+let lockAcquireTimeoutMsOverride: number | null = null;
+
+function fileStoreLockPath(): string {
+  return `${fileDir()}.lock`;
+}
+
+function withStoreLock<T>(fn: () => T): T {
+  const lock = fileStoreLockPath();
+  ensureLockTarget(lock);
+  return withFileLock(
+    lock,
+    fn,
+    lockAcquireTimeoutMsOverride != null ? { acquireTimeoutMs: lockAcquireTimeoutMsOverride } : {},
+  );
 }
 
 // ---------- passphrase ----------
@@ -323,15 +351,23 @@ function fileGet(item: string, opts: { allowAutoProvision?: boolean } = {}): str
 
 function fileSet(item: string, value: string, opts: { allowAutoProvision?: boolean } = {}): void {
   ensureFileDir();
-  const enc = encryptForFallback(value, getPassphrase(opts));
-  fs.writeFileSync(fileFor(item), JSON.stringify(enc), { mode: 0o600 });
+  // Under the store lock: a write must not interleave with a rotation's swap.
+  withStoreLock(() => {
+    const enc = encryptForFallback(value, getPassphrase(opts));
+    fs.writeFileSync(fileFor(item), JSON.stringify(enc), { mode: 0o600 });
+  });
 }
 
 function fileDelete(item: string): boolean {
   const fp = fileFor(item);
   if (!fs.existsSync(fp)) return true; // idempotent, matches secret-tool clear
-  fs.unlinkSync(fp);
-  return true;
+  return withStoreLock(() => {
+    // Re-check under the lock — a rotation may have swapped the dir since the
+    // pre-lock existence probe above.
+    if (!fs.existsSync(fp)) return true;
+    fs.unlinkSync(fp);
+    return true;
+  });
 }
 
 function fileList(prefix: string): string[] {
@@ -477,19 +513,52 @@ function fsyncDir(dir: string): void {
   }
 }
 
-/** True if any `.enc` item in `dir` decrypts under `keyVal`. A store may hold
- *  orphan items sealed under other keys, so "opens" means at least one item
- *  round-trips — enough to prove the key matches the store's live contents. */
-function storeOpensUnder(dir: string, keyVal: string | null): boolean {
-  if (keyVal == null) return false;
+/** True if `enc` decrypts (auth-tag verifies) under `keyVal`. */
+function opensUnder(enc: EncFile, keyVal: string): boolean {
+  try { decryptForFallback(enc, keyVal); return true; } catch { return false; }
+}
+
+/** How a candidate key relates to a store's `.enc` items. */
+type StoreKeyMatch = 'all' | 'some' | 'none';
+
+/**
+ * Classify how the `.enc` items in `dir` relate to `keyVal`, so recovery can tell
+ * a single-key store (safe to sweep) apart from a MIXED store (live data sealed
+ * under two keys at once — unsafe). `candidateKeys` is every key a mid-rotation
+ * crash could have left on disk: the live key file, `<key>.rotate-new` (the
+ * incoming key), and `<key>.rotate-oldkey` (the retired key). An item that opens
+ * under NONE of them is a genuine orphan — sealed under a third key and carried
+ * through a rotation verbatim — and is ignored: it neither proves nor disproves
+ * consistency. Among the remaining, non-orphan items:
+ *   'all'  — every one opens under `keyVal`  → `keyVal` is the store's one key
+ *   'some' — at least one opens under `keyVal` AND at least one does not → MIXED
+ *   'none' — none open under `keyVal`
+ *
+ * Only 'all' is safe to sweep against. The original "any one item opens" heuristic
+ * returned true for a mixed store — so a single stray item sealed under the live
+ * key (an interstitial `secrets set` after a mid-swap crash) made recovery sweep
+ * `<key>.rotate-new`, the only surviving copy of the key the *other* items need,
+ * destroying every one of them silently (RUSH-1975).
+ */
+function classifyStore(dir: string, keyVal: string | null, candidateKeys: (string | null)[]): StoreKeyMatch {
+  if (keyVal == null) return 'none';
   let names: string[];
-  try { names = fs.readdirSync(dir).filter((f) => f.endsWith('.enc')); } catch { return false; }
+  try { names = fs.readdirSync(dir).filter((f) => f.endsWith('.enc')); } catch { return 'none'; }
+  const otherKeys = candidateKeys.filter((k): k is string => k != null && k !== keyVal);
+  let nonOrphan = 0;
+  let openUnderKey = 0;
   for (const name of names) {
     let enc: EncFile;
     try { enc = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8')) as EncFile; } catch { continue; }
-    try { decryptForFallback(enc, keyVal); return true; } catch { /* try the next item */ }
+    const opensKey = opensUnder(enc, keyVal);
+    // Ignore genuine orphans (open under no candidate key) — a third-party cache
+    // carried through verbatim is not evidence of a mixed store.
+    if (!opensKey && !otherKeys.some((k) => opensUnder(enc, k))) continue;
+    nonOrphan++;
+    if (opensKey) openUnderKey++;
   }
-  return false;
+  if (openUnderKey === 0) return 'none';
+  return openUnderKey === nonOrphan ? 'all' : 'some';
 }
 
 /** True if `dir` holds at least one `.enc` item. */
@@ -507,27 +576,34 @@ function readKeyFile(fp: string): string | null {
  * Recover from a rotation that was interrupted mid-swap on a prior run, so the
  * store is always left in a single, self-consistent, readable state.
  *
- * Recovery is CONTENT-aware, not presence-aware. The mere existence of the store
- * dir and the key file does not prove they match (RUSH-1975 data-loss window): on
- * the non-co-located key path the swap is four renames, and a crash after the
- * store swap (`stageDir`->`dir`) but before the key swap (`keyTmp`->`keyPath`)
- * finishes leaves a NEW-key store next to the OLD key file, both present. A
- * presence check would see "both here" and wrongly sweep the only copies of the
- * old ciphertext (`<dir>.rotate-old-*`) and the new key (`<key>.rotate-new`),
- * permanently orphaning every secret. So we probe the actual ciphertext:
+ * Recovery is CONTENT-aware, not presence-aware, and it classifies the WHOLE
+ * store, not just one item. The mere existence of the store dir and the key file
+ * does not prove they match (RUSH-1975 data-loss window): on the non-co-located
+ * key path the swap is four renames, and a crash after the store swap
+ * (`stageDir`->`dir`) but before the key swap (`keyTmp`->`keyPath`) finishes
+ * leaves a NEW-key store next to the OLD key file, both present. A presence check
+ * would see "both here" and wrongly sweep the only copies of the old ciphertext
+ * (`<dir>.rotate-old-*`) and the new key (`<key>.rotate-new`), permanently
+ * orphaning every secret. So we probe the actual ciphertext with `classifyStore`,
+ * which distinguishes a store that opens fully under one key ('all') from one that
+ * is MIXED — some items under the live key, others under the incoming key ('some',
+ * e.g. after a mid-swap crash contaminated by a later `secrets set`):
  *
- *  1. If the live store decrypts under the live key file, the rotation is complete
- *     and consistent (or was never interrupted) — sweeping the `<dir>.rotate-*` /
- *     `<key>.rotate-*` artifacts is safe.
- *  2. Else, if it decrypts under `<key>.rotate-new`, the crash landed after the
- *     store swap but before the key swap finished — finish the rotation forward by
- *     installing `.rotate-new` as the live key, then sweep.
- *  3. Else roll back: restore the `<dir>.rotate-old-*` backup over `dir` and
- *     `<key>.rotate-oldkey` over the key file — but only once the backup is proven
- *     to decrypt under the old key.
- *  4. If neither forward nor rollback can be proven, leave every artifact in place;
- *     a leftover temp dir is recoverable, deleting the only copy of a key or
- *     ciphertext is not.
+ *  1. The live key opens EVERY non-orphan item ('all') → rotation complete and
+ *     consistent (or never interrupted); sweeping the `.rotate-*` artifacts is safe.
+ *  2. Else, if `<key>.rotate-new` opens every non-orphan item ('all'), the crash
+ *     landed after the store swap but before the key swap finished → finish the
+ *     rotation forward by installing `.rotate-new` as the live key, then sweep.
+ *  3. Else, if neither key opens any item, roll back: restore the
+ *     `<dir>.rotate-old-*` backup over `dir` and `<key>.rotate-oldkey` over the key
+ *     file — but only once the backup is proven to open fully under the old key.
+ *  4. If a key opens SOME but not all items ('some'), the store is MIXED — an
+ *     interrupted rotation contaminated by a later write, with live data under two
+ *     keys at once. Sweeping would delete the only copy of one of those keys, so we
+ *     REFUSE: throw an actionable error and preserve every recovery artifact for
+ *     out-of-band repair. Likewise, if neither forward nor rollback can be proven,
+ *     leave every artifact in place — a leftover temp dir is recoverable, deleting
+ *     the only copy of a key or ciphertext is not.
  *
  * A phase-marker / journal file was considered and deliberately skipped: the
  * AES-256-GCM auth tag already makes the decrypt probe an authoritative,
@@ -535,6 +611,7 @@ function readKeyFile(fp: string): string | null {
  * be a second source of truth that can disagree with reality — its own write has
  * crash windows, and a stale marker misleads — so it would weaken, not strengthen,
  * this guarantee. Idempotent; a no-op when no rotation artifacts are present.
+ * Callers run this under the store lock (see `withStoreLock`).
  */
 function recoverInterruptedRotation(keyPath: string): void {
   const dir = fileDir();
@@ -581,26 +658,53 @@ function recoverInterruptedRotation(keyPath: string): void {
     return;
   }
 
-  // 1. Live key opens the store -> rotation complete/consistent. Sweep is safe.
-  if (storeOpensUnder(dir, readKeyFile(keyPath))) { sweep(); return; }
+  const liveKey = readKeyFile(keyPath);
+  const newKey = readKeyFile(keyNew);
+  const oldKey = readKeyFile(keyOld);
+  const candidates = [liveKey, newKey, oldKey];
 
-  // 2. `.rotate-new` opens the store but the live key does not -> the crash landed
-  //    after the store swap, before the key swap finished. Finish the rotation
-  //    forward by installing the new key, then sweep.
-  if (fs.existsSync(keyNew) && storeOpensUnder(dir, readKeyFile(keyNew))) {
+  // A MIXED store cannot be swept safely: live data is sealed under two keys at
+  // once, so deleting either `.rotate-new` or the old-ciphertext backup destroys
+  // one class permanently. Refuse loudly and keep every artifact for out-of-band
+  // repair — never report success over a store we would be corrupting.
+  const refuseMixed = (label: string): never => {
+    throw new Error(
+      `Interrupted secrets rotation left a MIXED store at ${dir}: ${label}. This ` +
+      `happens when a \`secrets set\` landed between a crashed rotation and this ` +
+      `recovery. Refusing to sweep — every recovery artifact is preserved. Recover ` +
+      `out of band: for each ${dir}/*.enc, decrypt it under whichever of ${keyPath}` +
+      (fs.existsSync(keyNew) ? `, ${keyNew}` : '') +
+      (fs.existsSync(keyOld) ? `, ${keyOld}` : '') +
+      ` opens it, re-seal all items under one key, then re-run \`rotate-passphrase\`.`,
+    );
+  };
+
+  // 1. Live key opens the WHOLE store -> rotation complete/consistent. Sweep safe.
+  //    Opens only some items -> MIXED, refuse.
+  const liveMatch = classifyStore(dir, liveKey, candidates);
+  if (liveMatch === 'all') { sweep(); return; }
+  if (liveMatch === 'some') refuseMixed('some items open under the live key and others do not');
+
+  // 2. `.rotate-new` opens the whole store, the live key none of it -> the crash
+  //    landed after the store swap, before the key swap finished. Finish the
+  //    rotation forward by installing the new key, then sweep. Opens only some ->
+  //    MIXED, refuse.
+  const newMatch = classifyStore(dir, newKey, candidates);
+  if (newMatch === 'all') {
     try { fs.rmSync(keyPath, { force: true }); } catch { /* may be absent mid-key-swap */ }
     fs.renameSync(keyNew, keyPath);
     fsyncDir(path.dirname(keyPath));
     sweep();
     return;
   }
+  if (newMatch === 'some') refuseMixed('some items open under the incoming (.rotate-new) key and others do not');
 
-  // 3. Neither key opens the live store -> roll back to the pre-rotation state,
-  //    but only once the backup store is proven to decrypt under the old key.
-  const oldKey = readKeyFile(keyOld);
-  const rollbackKey = bakDir && storeOpensUnder(bakDir, oldKey)
+  // 3. Neither key opens the live store -> roll back to the pre-rotation state, but
+  //    only once the backup store is proven to open FULLY under the old key (or the
+  //    live key, when `.rotate-oldkey` was not written yet — Window A).
+  const rollbackKey = bakDir && classifyStore(bakDir, oldKey, candidates) === 'all'
     ? oldKey
-    : (bakDir && storeOpensUnder(bakDir, readKeyFile(keyPath)) ? readKeyFile(keyPath) : null);
+    : (bakDir && classifyStore(bakDir, liveKey, candidates) === 'all' ? liveKey : null);
   if (bakDir && fs.existsSync(bakDir) && rollbackKey != null) {
     fs.rmSync(dir, { recursive: true, force: true });
     fs.renameSync(bakDir, dir);
@@ -649,7 +753,7 @@ function recoverInterruptedRotation(keyPath: string): void {
  * point, and next-run recovery must heal it without data loss. `tamperStaged` forces
  * a staged item to fail its round-trip check, exercising the verify-before-swap abort.
  */
-export function rotatePassphrase(opts: {
+export interface RotatePassphraseOpts {
   dryRun?: boolean;
   newPassphrase?: string;
   onStagedBeforeCommit?: () => void;
@@ -657,7 +761,18 @@ export function rotatePassphrase(opts: {
   onStoreSwappedBeforeKeySwap?: () => void;
   onKeyBackedUpBeforeNewKey?: () => void;
   tamperStaged?: boolean;
-} = {}): RotatePassphraseReport {
+}
+
+/**
+ * Rotate under the exclusive store lock, so no `secrets set`/`delete` and no
+ * second rotation can interleave with the swap (see `withStoreLock`). The whole
+ * run — recovery, verify, swap — holds the lock; it is released on return or throw.
+ */
+export function rotatePassphrase(opts: RotatePassphraseOpts = {}): RotatePassphraseReport {
+  return withStoreLock(() => rotatePassphraseLocked(opts));
+}
+
+function rotatePassphraseLocked(opts: RotatePassphraseOpts): RotatePassphraseReport {
   const dryRun = opts.dryRun ?? false;
   // Resolve the key path. If the live key file is absent because a prior rotation
   // crashed mid-key-swap, fall back to the interrupted rotation's target so
@@ -820,4 +935,16 @@ export function _resetFileStoreForTest(opts: {
   }
   cachedPassphrase = opts.passphrase ?? null;
   warnedAutoPassphrase = false;
+  lockAcquireTimeoutMsOverride = null;
+}
+
+/** Test-only: shorten the store-lock acquire timeout so a contended-lock assertion
+ *  fails fast instead of waiting out the 30s production budget. */
+export function _setFileStoreLockTimeoutForTest(ms: number | null): void {
+  lockAcquireTimeoutMsOverride = ms;
+}
+
+/** Test-only: the cross-process store-lock target (sibling of the store dir). */
+export function _fileStoreLockPathForTest(): string {
+  return fileStoreLockPath();
 }

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -56,20 +56,26 @@ function ensureFileDir(): void {
 // the real serialization. The lock target is a SIBLING of the store dir, never a
 // file inside it — so it is never copied through a rotation nor swept as a
 // `.rotate-*` artifact, and it stays put across a mid-swap store-dir rename.
+//
+// A rotation's critical section is fully synchronous and scrypt-bound, so on a real
+// store it runs well past the lock's stale window. It calls `withFileLock`'s
+// `heartbeat()` through the re-encrypt and staging loops to keep the lockfile mtime
+// fresh — otherwise a peer would see the live holder as crashed, break the lock, and
+// interleave a write into the swap (a live lock-steal, no crash needed).
 let lockAcquireTimeoutMsOverride: number | null = null;
+let lockStaleMsOverride: number | null = null;
 
 function fileStoreLockPath(): string {
   return `${fileDir()}.lock`;
 }
 
-function withStoreLock<T>(fn: () => T): T {
+function withStoreLock<T>(fn: (heartbeat: () => void) => T): T {
   const lock = fileStoreLockPath();
   ensureLockTarget(lock);
-  return withFileLock(
-    lock,
-    fn,
-    lockAcquireTimeoutMsOverride != null ? { acquireTimeoutMs: lockAcquireTimeoutMsOverride } : {},
-  );
+  const opts: { acquireTimeoutMs?: number; staleMs?: number } = {};
+  if (lockAcquireTimeoutMsOverride != null) opts.acquireTimeoutMs = lockAcquireTimeoutMsOverride;
+  if (lockStaleMsOverride != null) opts.staleMs = lockStaleMsOverride;
+  return withFileLock(lock, fn, opts);
 }
 
 // ---------- passphrase ----------
@@ -800,7 +806,7 @@ export interface RotatePassphraseOpts {
   newPassphrase?: string;
   onStagedBeforeCommit?: () => void;
   onStoreMovedAsideBeforeSwap?: () => void;
-  onStoreSwappedBeforeKeySwap?: () => void;
+  onStoreSwappedBeforeKeySwap?: (heartbeat: () => void) => void;
   onKeyBackedUpBeforeNewKey?: () => void;
   tamperStaged?: boolean;
 }
@@ -811,10 +817,10 @@ export interface RotatePassphraseOpts {
  * run — recovery, verify, swap — holds the lock; it is released on return or throw.
  */
 export function rotatePassphrase(opts: RotatePassphraseOpts = {}): RotatePassphraseReport {
-  return withStoreLock(() => rotatePassphraseLocked(opts));
+  return withStoreLock((heartbeat) => rotatePassphraseLocked(opts, heartbeat));
 }
 
-function rotatePassphraseLocked(opts: RotatePassphraseOpts): RotatePassphraseReport {
+function rotatePassphraseLocked(opts: RotatePassphraseOpts, heartbeat: () => void = () => {}): RotatePassphraseReport {
   const dryRun = opts.dryRun ?? false;
   // Resolve the key path. If the live key file is absent because a prior rotation
   // crashed mid-key-swap, fall back to the interrupted rotation's target so
@@ -849,6 +855,11 @@ function rotatePassphraseLocked(opts: RotatePassphraseOpts): RotatePassphraseRep
   const staged: Array<{ name: string; enc: string }> = [];
   const skipped: string[] = [];
   for (const name of names) {
+    // Keep the store lock fresh across the scrypt-bound loop: each item runs the
+    // KDF three times (decrypt, re-encrypt, verify), so on a real store this loop
+    // outlives the lock's stale window — without this a peer could break the lock
+    // as "stale" mid-run and interleave a write (see `withFileLock`'s heartbeat).
+    heartbeat();
     const raw = fs.readFileSync(path.join(dir, name), 'utf8');
     let parsed: EncFile;
     try { parsed = JSON.parse(raw); } catch { skipped.push(`${name} (not valid EncFile JSON)`); continue; }
@@ -887,6 +898,7 @@ function rotatePassphraseLocked(opts: RotatePassphraseOpts): RotatePassphraseRep
   fs.mkdirSync(stageDir, { recursive: true, mode: 0o700 });
   const stagedNames = new Set(staged.map((s) => s.name));
   for (const { name, enc } of staged) {
+    heartbeat(); // each write is an fsync; keep the lock fresh across the batch
     writeFileFsync(path.join(stageDir, name), enc, 0o600);
   }
   for (const entry of fs.readdirSync(dir)) {
@@ -894,6 +906,7 @@ function rotatePassphraseLocked(opts: RotatePassphraseOpts): RotatePassphraseRep
     if (keyColocated && entry === path.basename(keyPath)) continue; // rewritten below, not copied
     const src = path.join(dir, entry);
     if (!fs.statSync(src).isFile()) continue;
+    heartbeat();
     // Copy through as raw bytes — reading as 'utf8' would decode any non-UTF-8
     // byte to U+FFFD and silently corrupt the file on the way through the swap.
     writeFileFsync(path.join(stageDir, entry), fs.readFileSync(src), 0o600);
@@ -929,7 +942,8 @@ function rotatePassphraseLocked(opts: RotatePassphraseOpts): RotatePassphraseRep
   const keyBak = `${keyPath}.rotate-oldkey`;
   if (!keyColocated) {
     // Test seam: crash after the store swap, before the key swap begins (Window A).
-    opts.onStoreSwappedBeforeKeySwap?.();
+    // Also receives the lock heartbeat so a test can prove a long hold stays fresh.
+    opts.onStoreSwappedBeforeKeySwap?.(heartbeat);
     fs.renameSync(keyPath, keyBak);
     // Test seam: crash after the old key is moved aside, before the new key lands (Window B).
     opts.onKeyBackedUpBeforeNewKey?.();
@@ -978,12 +992,19 @@ export function _resetFileStoreForTest(opts: {
   cachedPassphrase = opts.passphrase ?? null;
   warnedAutoPassphrase = false;
   lockAcquireTimeoutMsOverride = null;
+  lockStaleMsOverride = null;
 }
 
 /** Test-only: shorten the store-lock acquire timeout so a contended-lock assertion
  *  fails fast instead of waiting out the 30s production budget. */
 export function _setFileStoreLockTimeoutForTest(ms: number | null): void {
   lockAcquireTimeoutMsOverride = ms;
+}
+
+/** Test-only: shrink the store-lock stale window so a heartbeat/steal assertion runs
+ *  in milliseconds instead of the 5s production window. */
+export function _setFileStoreLockStaleMsForTest(ms: number | null): void {
+  lockStaleMsOverride = ms;
 }
 
 /** Test-only: the cross-process store-lock target (sibling of the store dir). */

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -408,6 +408,25 @@ function resolveInterruptedKeyPath(): string | null {
   for (const fp of [passphraseFilePath(), legacyPassphraseFilePath()]) {
     if (fs.existsSync(`${fp}.rotate-new`) || fs.existsSync(`${fp}.rotate-oldkey`)) return fp;
   }
+  // Co-located layout: the key lives inside the store dir and travels with it in a
+  // single rename, so no `.rotate-new`/`.rotate-oldkey` key artifacts are ever
+  // written. A crash in that rename leaves the store dir absent with its old store +
+  // co-located key sitting in the `<dir>.rotate-old-*` backup, and the canonical/
+  // legacy key files both gone — so the checks above return null and recovery would
+  // never run. If a backup holding a co-located `.passphrase` is present, the
+  // interrupted rotation's key target is that legacy co-located path; return it so
+  // recovery restores the backup (old store + old key) and heals the store.
+  const dir = fileDir();
+  if (!fs.existsSync(dir)) {
+    const parent = path.dirname(dir);
+    const base = path.basename(dir);
+    let entries: string[];
+    try { entries = fs.readdirSync(parent); } catch { return null; }
+    const bak = entries.find((e) => e.startsWith(`${base}.rotate-old-`));
+    if (bak && fs.existsSync(path.join(parent, bak, '.passphrase'))) {
+      return legacyPassphraseFilePath();
+    }
+  }
   return null;
 }
 
@@ -428,10 +447,13 @@ export interface RotatePassphraseReport {
 }
 
 /** Flush a file's data to disk (durability before the atomic swap). */
-function writeFileFsync(fp: string, data: string, mode: number): void {
+function writeFileFsync(fp: string, data: string | Buffer, mode: number): void {
   const fd = fs.openSync(fp, 'w', mode);
   try {
-    fs.writeSync(fd, data);
+    // Narrow to one of fs.writeSync's overloads: the string form encodes as UTF-8,
+    // the Buffer form writes raw bytes verbatim (binary-safe copy-through).
+    if (typeof data === 'string') fs.writeSync(fd, data);
+    else fs.writeSync(fd, data);
     fs.fsyncSync(fd);
   } finally {
     fs.closeSync(fd);
@@ -631,6 +653,7 @@ export function rotatePassphrase(opts: {
   dryRun?: boolean;
   newPassphrase?: string;
   onStagedBeforeCommit?: () => void;
+  onStoreMovedAsideBeforeSwap?: () => void;
   onStoreSwappedBeforeKeySwap?: () => void;
   onKeyBackedUpBeforeNewKey?: () => void;
   tamperStaged?: boolean;
@@ -714,7 +737,9 @@ export function rotatePassphrase(opts: {
     if (keyColocated && entry === path.basename(keyPath)) continue; // rewritten below, not copied
     const src = path.join(dir, entry);
     if (!fs.statSync(src).isFile()) continue;
-    writeFileFsync(path.join(stageDir, entry), fs.readFileSync(src, 'utf8'), 0o600);
+    // Copy through as raw bytes — reading as 'utf8' would decode any non-UTF-8
+    // byte to U+FFFD and silently corrupt the file on the way through the swap.
+    writeFileFsync(path.join(stageDir, entry), fs.readFileSync(src), 0o600);
   }
   // A co-located legacy key travels with the store: write the new value into the
   // staged dir so a single directory swap commits both ciphertext and key.
@@ -738,6 +763,10 @@ export function rotatePassphrase(opts: {
   // absent; recoverInterruptedRotation restores it from the backup on next run.
   const bakDir = `${dir}.rotate-old-${rand}`;
   fs.renameSync(dir, bakDir);
+  // Test seam: crash after the live store is moved aside, before the staged store
+  // lands (the store dir is absent). For a co-located key this is the ONLY swap
+  // window — the single rename carries both ciphertext and key.
+  opts.onStoreMovedAsideBeforeSwap?.();
   fs.renameSync(stageDir, dir);
   fsyncDir(path.dirname(dir));
   const keyBak = `${keyPath}.rotate-oldkey`;

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -395,6 +395,22 @@ export function machinePassphraseSourcePath(): string | null {
   return null;
 }
 
+/**
+ * Resolve the key path for a rotation that crashed mid-key-swap and left the live
+ * key file absent (Window B: `keyPath` moved to `<key>.rotate-oldkey`, the new key
+ * not yet landed). `machinePassphraseSourcePath` returns null in that state because
+ * neither canonical nor legacy file has content, so recovery would never run. If a
+ * rotation artifact (`.rotate-new` / `.rotate-oldkey`) exists for a canonical key
+ * path, that path is the interrupted rotation's target — return it so recovery can
+ * finish forward. Null when no such artifact is present.
+ */
+function resolveInterruptedKeyPath(): string | null {
+  for (const fp of [passphraseFilePath(), legacyPassphraseFilePath()]) {
+    if (fs.existsSync(`${fp}.rotate-new`) || fs.existsSync(`${fp}.rotate-oldkey`)) return fp;
+  }
+  return null;
+}
+
 /** Outcome of a `rotatePassphrase` run. Carries no secret material. */
 export interface RotatePassphraseReport {
   /** True when nothing was written (report-only). */
@@ -439,14 +455,64 @@ function fsyncDir(dir: string): void {
   }
 }
 
+/** True if any `.enc` item in `dir` decrypts under `keyVal`. A store may hold
+ *  orphan items sealed under other keys, so "opens" means at least one item
+ *  round-trips — enough to prove the key matches the store's live contents. */
+function storeOpensUnder(dir: string, keyVal: string | null): boolean {
+  if (keyVal == null) return false;
+  let names: string[];
+  try { names = fs.readdirSync(dir).filter((f) => f.endsWith('.enc')); } catch { return false; }
+  for (const name of names) {
+    let enc: EncFile;
+    try { enc = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8')) as EncFile; } catch { continue; }
+    try { decryptForFallback(enc, keyVal); return true; } catch { /* try the next item */ }
+  }
+  return false;
+}
+
+/** True if `dir` holds at least one `.enc` item. */
+function storeHasEnc(dir: string): boolean {
+  try { return fs.readdirSync(dir).some((f) => f.endsWith('.enc')); } catch { return false; }
+}
+
+/** Read a key file's trimmed contents, or null if absent/empty. */
+function readKeyFile(fp: string): string | null {
+  try { const v = fs.readFileSync(fp, 'utf8').trim(); return v.length > 0 ? v : null; }
+  catch { return null; }
+}
+
 /**
  * Recover from a rotation that was interrupted mid-swap on a prior run, so the
- * store is always left in a single, readable state. The swap sequence moves the
- * live store aside to a `<dir>.rotate-old-*` backup before moving the staged
- * store into place; a crash in the sub-millisecond gap between those two renames
- * would leave the store dir missing with its content safe in the backup. This
- * restores it, and sweeps abandoned `<dir>.rotate-*` staging/backup dirs and the
- * `<key>.rotate-*` temp files. Idempotent; a no-op when nothing was interrupted.
+ * store is always left in a single, self-consistent, readable state.
+ *
+ * Recovery is CONTENT-aware, not presence-aware. The mere existence of the store
+ * dir and the key file does not prove they match (RUSH-1975 data-loss window): on
+ * the non-co-located key path the swap is four renames, and a crash after the
+ * store swap (`stageDir`->`dir`) but before the key swap (`keyTmp`->`keyPath`)
+ * finishes leaves a NEW-key store next to the OLD key file, both present. A
+ * presence check would see "both here" and wrongly sweep the only copies of the
+ * old ciphertext (`<dir>.rotate-old-*`) and the new key (`<key>.rotate-new`),
+ * permanently orphaning every secret. So we probe the actual ciphertext:
+ *
+ *  1. If the live store decrypts under the live key file, the rotation is complete
+ *     and consistent (or was never interrupted) — sweeping the `<dir>.rotate-*` /
+ *     `<key>.rotate-*` artifacts is safe.
+ *  2. Else, if it decrypts under `<key>.rotate-new`, the crash landed after the
+ *     store swap but before the key swap finished — finish the rotation forward by
+ *     installing `.rotate-new` as the live key, then sweep.
+ *  3. Else roll back: restore the `<dir>.rotate-old-*` backup over `dir` and
+ *     `<key>.rotate-oldkey` over the key file — but only once the backup is proven
+ *     to decrypt under the old key.
+ *  4. If neither forward nor rollback can be proven, leave every artifact in place;
+ *     a leftover temp dir is recoverable, deleting the only copy of a key or
+ *     ciphertext is not.
+ *
+ * A phase-marker / journal file was considered and deliberately skipped: the
+ * AES-256-GCM auth tag already makes the decrypt probe an authoritative,
+ * self-validating record of which key matches the store. A separate marker would
+ * be a second source of truth that can disagree with reality — its own write has
+ * crash windows, and a stale marker misleads — so it would weaken, not strengthen,
+ * this guarantee. Idempotent; a no-op when no rotation artifacts are present.
  */
 function recoverInterruptedRotation(keyPath: string): void {
   const dir = fileDir();
@@ -454,18 +520,27 @@ function recoverInterruptedRotation(keyPath: string): void {
   const base = path.basename(dir);
   let entries: string[];
   try { entries = fs.readdirSync(parent); } catch { return; }
-  // If the live store dir vanished mid-swap, restore it from its backup.
-  if (!fs.existsSync(dir)) {
-    const bak = entries.find((e) => e.startsWith(`${base}.rotate-old-`));
-    if (bak) fs.renameSync(path.join(parent, bak), dir);
+
+  const keyNew = `${keyPath}.rotate-new`;
+  const keyOld = `${keyPath}.rotate-oldkey`;
+  const bakName = entries.find((e) => e.startsWith(`${base}.rotate-old-`));
+  let bakDir = bakName ? path.join(parent, bakName) : null;
+
+  // Nothing rotation-related on disk -> no interrupted rotation to recover.
+  const hasArtifacts = bakDir != null
+    || fs.existsSync(keyNew) || fs.existsSync(keyOld)
+    || entries.some((e) => e.startsWith(`${base}.rotate-`));
+  if (!hasArtifacts) return;
+
+  // If the live store dir vanished mid-swap (crash between the two store renames,
+  // before the new store landed), restore the old store from its backup — the key
+  // was not touched yet, so old store + old key is a consistent state.
+  if (!fs.existsSync(dir) && bakDir && fs.existsSync(bakDir)) {
+    fs.renameSync(bakDir, dir);
+    bakDir = null; // consumed
   }
-  // Restore the key file if it was moved aside but the new one never landed.
-  if (!fs.existsSync(keyPath) && fs.existsSync(`${keyPath}.rotate-oldkey`)) {
-    fs.renameSync(`${keyPath}.rotate-oldkey`, keyPath);
-  }
-  // Sweep abandoned staging/backup dirs and key temp files — only ever safe to
-  // drop once the live store + key file are both present again.
-  if (fs.existsSync(dir) && fs.existsSync(keyPath)) {
+
+  const sweep = (): void => {
     for (const e of fs.readdirSync(parent)) {
       if (e.startsWith(`${base}.rotate-`)) {
         try { fs.rmSync(path.join(parent, e), { recursive: true, force: true }); } catch { /* best effort */ }
@@ -474,7 +549,51 @@ function recoverInterruptedRotation(keyPath: string): void {
     for (const suffix of ['.rotate-new', '.rotate-oldkey']) {
       try { fs.rmSync(`${keyPath}${suffix}`, { force: true }); } catch { /* best effort */ }
     }
+  };
+
+  // An empty or unreadable store holds no ciphertext at risk. Only sweep once the
+  // live key file is present again; never delete recovery artifacts for a store we
+  // cannot probe.
+  if (!storeHasEnc(dir)) {
+    if (fs.existsSync(keyPath)) sweep();
+    return;
   }
+
+  // 1. Live key opens the store -> rotation complete/consistent. Sweep is safe.
+  if (storeOpensUnder(dir, readKeyFile(keyPath))) { sweep(); return; }
+
+  // 2. `.rotate-new` opens the store but the live key does not -> the crash landed
+  //    after the store swap, before the key swap finished. Finish the rotation
+  //    forward by installing the new key, then sweep.
+  if (fs.existsSync(keyNew) && storeOpensUnder(dir, readKeyFile(keyNew))) {
+    try { fs.rmSync(keyPath, { force: true }); } catch { /* may be absent mid-key-swap */ }
+    fs.renameSync(keyNew, keyPath);
+    fsyncDir(path.dirname(keyPath));
+    sweep();
+    return;
+  }
+
+  // 3. Neither key opens the live store -> roll back to the pre-rotation state,
+  //    but only once the backup store is proven to decrypt under the old key.
+  const oldKey = readKeyFile(keyOld);
+  const rollbackKey = bakDir && storeOpensUnder(bakDir, oldKey)
+    ? oldKey
+    : (bakDir && storeOpensUnder(bakDir, readKeyFile(keyPath)) ? readKeyFile(keyPath) : null);
+  if (bakDir && fs.existsSync(bakDir) && rollbackKey != null) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.renameSync(bakDir, dir);
+    fsyncDir(path.dirname(dir));
+    if (rollbackKey === oldKey && fs.existsSync(keyOld)) {
+      try { fs.rmSync(keyPath, { force: true }); } catch { /* may be absent */ }
+      fs.renameSync(keyOld, keyPath);
+      fsyncDir(path.dirname(keyPath));
+    }
+    sweep();
+    return;
+  }
+
+  // 4. Neither forward nor rollback is provable -> leave every artifact untouched
+  //    for out-of-band recovery. Do NOT sweep: that is the data-loss bug.
 }
 
 /**
@@ -498,20 +617,29 @@ function recoverInterruptedRotation(keyPath: string): void {
  *    artifacts written under another key) are copied through verbatim, never
  *    re-keyed, and reported in `skipped`.
  *
- * `newPassphrase` and `onStagedBeforeCommit` are test seams: the former pins the
- * generated key so a test can assert the swap; the latter fires after staging
- * but before any swap, so a test can throw to simulate a mid-run crash and prove
- * the old store survives. `tamperStaged` forces a staged item to fail its
- * round-trip check, exercising the verify-before-swap abort.
+ * `newPassphrase` and the `on*` callbacks are test seams. `newPassphrase` pins the
+ * generated key so a test can assert the swap. `onStagedBeforeCommit` fires after
+ * staging but before any swap (a crash here leaves the old store fully intact).
+ * `onStoreSwappedBeforeKeySwap` fires after the store swap but before the key swap
+ * begins (Window A: NEW-key store beside the OLD key file). `onKeyBackedUpBeforeNewKey`
+ * fires after the old key is moved aside but before the new key lands (Window B: NEW
+ * store, key file absent). Each throws to simulate a mid-swap crash at that exact
+ * point, and next-run recovery must heal it without data loss. `tamperStaged` forces
+ * a staged item to fail its round-trip check, exercising the verify-before-swap abort.
  */
 export function rotatePassphrase(opts: {
   dryRun?: boolean;
   newPassphrase?: string;
   onStagedBeforeCommit?: () => void;
+  onStoreSwappedBeforeKeySwap?: () => void;
+  onKeyBackedUpBeforeNewKey?: () => void;
   tamperStaged?: boolean;
 } = {}): RotatePassphraseReport {
   const dryRun = opts.dryRun ?? false;
-  const keyPath = machinePassphraseSourcePath();
+  // Resolve the key path. If the live key file is absent because a prior rotation
+  // crashed mid-key-swap, fall back to the interrupted rotation's target so
+  // recovery below can still run and heal the store (RUSH-1975 Window B).
+  const keyPath = machinePassphraseSourcePath() ?? resolveInterruptedKeyPath();
   if (!keyPath) {
     throw new Error(
       'No machine-local passphrase to rotate. `rotate-passphrase` re-keys the ' +
@@ -614,7 +742,11 @@ export function rotatePassphrase(opts: {
   fsyncDir(path.dirname(dir));
   const keyBak = `${keyPath}.rotate-oldkey`;
   if (!keyColocated) {
+    // Test seam: crash after the store swap, before the key swap begins (Window A).
+    opts.onStoreSwappedBeforeKeySwap?.();
     fs.renameSync(keyPath, keyBak);
+    // Test seam: crash after the old key is moved aside, before the new key lands (Window B).
+    opts.onKeyBackedUpBeforeNewKey?.();
     fs.renameSync(keyTmp, keyPath);
     fsyncDir(path.dirname(keyPath));
   }

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -377,6 +377,271 @@ export function resolvePassphraseDir(): string {
   return passphraseDir();
 }
 
+// ---------- passphrase rotation (RUSH-1975) ----------
+
+/**
+ * Path of the machine-local passphrase file that currently holds the file-store
+ * key, or null if none is provisioned. Prefers the canonical #479 location and
+ * falls back to the legacy co-located path, mirroring `readMachinePassphrase`.
+ */
+export function machinePassphraseSourcePath(): string | null {
+  for (const fp of [passphraseFilePath(), legacyPassphraseFilePath()]) {
+    try {
+      if (fs.readFileSync(fp, 'utf8').trim().length > 0) return fp;
+    } catch {
+      // try next location
+    }
+  }
+  return null;
+}
+
+/** Outcome of a `rotatePassphrase` run. Carries no secret material. */
+export interface RotatePassphraseReport {
+  /** True when nothing was written (report-only). */
+  dryRun: boolean;
+  /** True when the store was re-encrypted and the key file swapped. */
+  committed: boolean;
+  /** Encrypted items that decrypt under the current key and were (or would be) re-keyed. */
+  bundleCount: number;
+  /** `.enc` files that do NOT decrypt under the current key — left untouched, never re-keyed. */
+  skipped: string[];
+  /** Every re-keyed item round-tripped (decrypt) under the new key before any swap. */
+  roundTripOk: boolean;
+  /** The machine-local passphrase file that was (or would be) rewritten in place. */
+  keyFilePath: string;
+}
+
+/** Flush a file's data to disk (durability before the atomic swap). */
+function writeFileFsync(fp: string, data: string, mode: number): void {
+  const fd = fs.openSync(fp, 'w', mode);
+  try {
+    fs.writeSync(fd, data);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  // A freshly-created file needs its mode set explicitly — the open() mode is
+  // masked by the process umask, so 0600 is not guaranteed by the flag alone.
+  try { fs.chmodSync(fp, mode); } catch { /* best effort on platforms without chmod */ }
+}
+
+/** fsync a directory so a rename/create in it is durable. Best-effort: some
+ *  filesystems reject O_RDONLY fsync on a directory. */
+function fsyncDir(dir: string): void {
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(dir, 'r');
+    fs.fsyncSync(fd);
+  } catch {
+    // filesystem doesn't support directory fsync — the rename is still ordered
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
+
+/**
+ * Recover from a rotation that was interrupted mid-swap on a prior run, so the
+ * store is always left in a single, readable state. The swap sequence moves the
+ * live store aside to a `<dir>.rotate-old-*` backup before moving the staged
+ * store into place; a crash in the sub-millisecond gap between those two renames
+ * would leave the store dir missing with its content safe in the backup. This
+ * restores it, and sweeps abandoned `<dir>.rotate-*` staging/backup dirs and the
+ * `<key>.rotate-*` temp files. Idempotent; a no-op when nothing was interrupted.
+ */
+function recoverInterruptedRotation(keyPath: string): void {
+  const dir = fileDir();
+  const parent = path.dirname(dir);
+  const base = path.basename(dir);
+  let entries: string[];
+  try { entries = fs.readdirSync(parent); } catch { return; }
+  // If the live store dir vanished mid-swap, restore it from its backup.
+  if (!fs.existsSync(dir)) {
+    const bak = entries.find((e) => e.startsWith(`${base}.rotate-old-`));
+    if (bak) fs.renameSync(path.join(parent, bak), dir);
+  }
+  // Restore the key file if it was moved aside but the new one never landed.
+  if (!fs.existsSync(keyPath) && fs.existsSync(`${keyPath}.rotate-oldkey`)) {
+    fs.renameSync(`${keyPath}.rotate-oldkey`, keyPath);
+  }
+  // Sweep abandoned staging/backup dirs and key temp files — only ever safe to
+  // drop once the live store + key file are both present again.
+  if (fs.existsSync(dir) && fs.existsSync(keyPath)) {
+    for (const e of fs.readdirSync(parent)) {
+      if (e.startsWith(`${base}.rotate-`)) {
+        try { fs.rmSync(path.join(parent, e), { recursive: true, force: true }); } catch { /* best effort */ }
+      }
+    }
+    for (const suffix of ['.rotate-new', '.rotate-oldkey']) {
+      try { fs.rmSync(`${keyPath}${suffix}`, { force: true }); } catch { /* best effort */ }
+    }
+  }
+}
+
+/**
+ * Rotate the machine-local file-store passphrase: decrypt every `.enc` item
+ * under the current key and re-encrypt it under a freshly generated one, then
+ * swap both the ciphertext and the key file atomically.
+ *
+ * Safety contract (RUSH-1975):
+ *  - Verify before writing: every re-keyed item must round-trip decrypt under
+ *    the new key, and the re-keyed count must reconcile with the source, or the
+ *    run aborts having written nothing.
+ *  - Atomic: the new store is staged in a sibling temp dir, fsync'd, then swapped
+ *    into place by directory rename; the new key file is fsync'd and swapped the
+ *    same way. A crash before the swap leaves the old store and old key fully
+ *    intact and readable; a crash inside the swap self-heals on the next run
+ *    (see `recoverInterruptedRotation`). No half-re-keyed store is ever exposed.
+ *  - No plaintext (secret value or passphrase) is ever written to disk, argv, or
+ *    a log — only ciphertext is staged, and the new key lands only in the 0600
+ *    key file.
+ *  - Items that do not decrypt under the current key (orphan caches, stale test
+ *    artifacts written under another key) are copied through verbatim, never
+ *    re-keyed, and reported in `skipped`.
+ *
+ * `newPassphrase` and `onStagedBeforeCommit` are test seams: the former pins the
+ * generated key so a test can assert the swap; the latter fires after staging
+ * but before any swap, so a test can throw to simulate a mid-run crash and prove
+ * the old store survives. `tamperStaged` forces a staged item to fail its
+ * round-trip check, exercising the verify-before-swap abort.
+ */
+export function rotatePassphrase(opts: {
+  dryRun?: boolean;
+  newPassphrase?: string;
+  onStagedBeforeCommit?: () => void;
+  tamperStaged?: boolean;
+} = {}): RotatePassphraseReport {
+  const dryRun = opts.dryRun ?? false;
+  const keyPath = machinePassphraseSourcePath();
+  if (!keyPath) {
+    throw new Error(
+      'No machine-local passphrase to rotate. `rotate-passphrase` re-keys the ' +
+      'file store\'s auto-provisioned key; none is provisioned on this machine.',
+    );
+  }
+  recoverInterruptedRotation(keyPath);
+
+  const oldPass = fs.readFileSync(keyPath, 'utf8').trim();
+  if (!oldPass) throw new Error(`Machine-local passphrase file ${keyPath} is empty.`);
+  const newPass = opts.newPassphrase ?? randomBytes(32).toString('base64');
+  if (newPass === oldPass) throw new Error('New passphrase equals the current one — refusing a no-op rotation.');
+
+  const dir = fileDir();
+  let names: string[];
+  try {
+    names = fs.readdirSync(dir).filter((f) => f.endsWith('.enc'));
+  } catch {
+    names = [];
+  }
+  if (names.length === 0) {
+    throw new Error(`No encrypted items in ${dir} — nothing to rotate.`);
+  }
+
+  // Phase 1 — decrypt-all, re-encrypt, re-verify in memory. Nothing on disk is
+  // touched here, so any throw leaves the live store and key file untouched.
+  const staged: Array<{ name: string; enc: string }> = [];
+  const skipped: string[] = [];
+  for (const name of names) {
+    const raw = fs.readFileSync(path.join(dir, name), 'utf8');
+    let parsed: EncFile;
+    try { parsed = JSON.parse(raw); } catch { skipped.push(`${name} (not valid EncFile JSON)`); continue; }
+    let plain: string;
+    try { plain = decryptForFallback(parsed, oldPass); }
+    catch { skipped.push(`${name} (does not decrypt under the current key — orphan)`); continue; }
+    let reEnc = encryptForFallback(plain, newPass);
+    if (opts.tamperStaged) reEnc = { ...reEnc, ciphertext: `00${reEnc.ciphertext.slice(2)}` };
+    let check: string;
+    try { check = decryptForFallback(reEnc, newPass); }
+    catch { throw new Error(`Re-encryption of ${name} failed to verify under the new key — aborted, nothing written.`); }
+    if (check !== plain) throw new Error(`Round-trip mismatch on ${name} — aborted, nothing written.`);
+    staged.push({ name, enc: JSON.stringify(reEnc) });
+  }
+  if (staged.length === 0) {
+    throw new Error('No item decrypted under the current machine-local key — aborted, nothing written.');
+  }
+
+  const report: RotatePassphraseReport = {
+    dryRun,
+    committed: false,
+    bundleCount: staged.length,
+    skipped,
+    roundTripOk: true,
+    keyFilePath: keyPath,
+  };
+  if (dryRun) return report;
+
+  // Phase 2 — stage the complete replacement store in a sibling temp dir, fsync,
+  // then swap. Orphans and any non-.enc files are copied through verbatim so the
+  // swapped dir is a complete superset of the old one (nothing is dropped).
+  const keyColocated = path.dirname(keyPath) === dir;
+  const rand = randomBytes(6).toString('hex');
+  const stageDir = `${dir}.rotate-${rand}`;
+  fs.rmSync(stageDir, { recursive: true, force: true });
+  fs.mkdirSync(stageDir, { recursive: true, mode: 0o700 });
+  const stagedNames = new Set(staged.map((s) => s.name));
+  for (const { name, enc } of staged) {
+    writeFileFsync(path.join(stageDir, name), enc, 0o600);
+  }
+  for (const entry of fs.readdirSync(dir)) {
+    if (stagedNames.has(entry)) continue;
+    if (keyColocated && entry === path.basename(keyPath)) continue; // rewritten below, not copied
+    const src = path.join(dir, entry);
+    if (!fs.statSync(src).isFile()) continue;
+    writeFileFsync(path.join(stageDir, entry), fs.readFileSync(src, 'utf8'), 0o600);
+  }
+  // A co-located legacy key travels with the store: write the new value into the
+  // staged dir so a single directory swap commits both ciphertext and key.
+  if (keyColocated) writeFileFsync(path.join(stageDir, path.basename(keyPath)), newPass, 0o600);
+  fsyncDir(stageDir);
+
+  // Test seam: simulate a crash after staging but before the swap. The live store
+  // and key file are still untouched at this point.
+  opts.onStagedBeforeCommit?.();
+
+  // For a non-co-located key, stage the new key beside the old one first so the
+  // swap is two quick renames with no I/O between them.
+  const keyTmp = `${keyPath}.rotate-new`;
+  if (!keyColocated) {
+    writeFileFsync(keyTmp, newPass, 0o600);
+    fsyncDir(path.dirname(keyPath));
+  }
+
+  // Swap. Move the live store aside, then the staged store into place. The gap
+  // between these two renames is the only crash window that leaves the store dir
+  // absent; recoverInterruptedRotation restores it from the backup on next run.
+  const bakDir = `${dir}.rotate-old-${rand}`;
+  fs.renameSync(dir, bakDir);
+  fs.renameSync(stageDir, dir);
+  fsyncDir(path.dirname(dir));
+  const keyBak = `${keyPath}.rotate-oldkey`;
+  if (!keyColocated) {
+    fs.renameSync(keyPath, keyBak);
+    fs.renameSync(keyTmp, keyPath);
+    fsyncDir(path.dirname(keyPath));
+  }
+
+  // Verify a real read out of the now-live store under the new key. On failure,
+  // roll the store (and key) back to the backup — the old passphrase still works.
+  try {
+    const probe = JSON.parse(fs.readFileSync(path.join(dir, staged[0].name), 'utf8')) as EncFile;
+    decryptForFallback(probe, newPass);
+  } catch (err) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.renameSync(bakDir, dir);
+    if (!keyColocated && fs.existsSync(keyBak)) {
+      try { fs.rmSync(keyPath, { force: true }); } catch { /* may not exist */ }
+      fs.renameSync(keyBak, keyPath);
+    }
+    throw new Error(`Post-swap verification failed; rolled back to the old key. (${(err as Error).message})`);
+  }
+
+  // Committed. Drop the old ciphertext and old key — both hold the retired key.
+  fs.rmSync(bakDir, { recursive: true, force: true });
+  if (!keyColocated) fs.rmSync(keyBak, { force: true });
+  cachedPassphrase = newPass;
+  report.committed = true;
+  return report;
+}
+
 /** Test-only: reset module state (file dir + cached passphrase). */
 export function _resetFileStoreForTest(opts: {
   fileDir?: string | null;

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -566,6 +566,24 @@ function storeHasEnc(dir: string): boolean {
   try { return fs.readdirSync(dir).some((f) => f.endsWith('.enc')); } catch { return false; }
 }
 
+/**
+ * `.enc` basenames present in the `<dir>.rotate-old-*` backup but ABSENT from the
+ * live `dir` — ciphertext that lives ONLY in the backup. A genuine post-swap store
+ * is always a superset of the pre-swap store (rotation re-keys every item and copies
+ * orphans/non-.enc files through verbatim — nothing is dropped), so this set is empty
+ * for any real completed/interrupted rotation. It is non-empty only when the live
+ * `dir` is NOT the post-swap store: an interstitial `secrets set` recreated the store
+ * dir after a crash in the move-aside window left it absent (RUSH-1975). Sweeping the
+ * backup then destroys those items — so recovery refuses instead.
+ */
+function backupOnlyEnc(bak: string, dir: string): string[] {
+  let bakNames: string[];
+  try { bakNames = fs.readdirSync(bak).filter((f) => f.endsWith('.enc')); } catch { return []; }
+  let dirNames: Set<string>;
+  try { dirNames = new Set(fs.readdirSync(dir).filter((f) => f.endsWith('.enc'))); } catch { dirNames = new Set(); }
+  return bakNames.filter((n) => !dirNames.has(n));
+}
+
 /** Read a key file's trimmed contents, or null if absent/empty. */
 function readKeyFile(fp: string): string | null {
   try { const v = fs.readFileSync(fp, 'utf8').trim(); return v.length > 0 ? v : null; }
@@ -590,7 +608,11 @@ function readKeyFile(fp: string): string | null {
  * e.g. after a mid-swap crash contaminated by a later `secrets set`):
  *
  *  1. The live key opens EVERY non-orphan item ('all') → rotation complete and
- *     consistent (or never interrupted); sweeping the `.rotate-*` artifacts is safe.
+ *     consistent (or never interrupted); sweeping the `.rotate-*` artifacts is safe —
+ *     unless a `<dir>.rotate-old-*` backup still holds `.enc` items absent from the
+ *     live dir. That means the live dir is not the post-swap store but a fresh dir an
+ *     interstitial `secrets set` created after a crash in the move-aside window left
+ *     the store dir absent, so the backup is the only copy of those items → REFUSE.
  *  2. Else, if `<key>.rotate-new` opens every non-orphan item ('all'), the crash
  *     landed after the store swap but before the key swap finished → finish the
  *     rotation forward by installing `.rotate-new` as the live key, then sweep.
@@ -679,10 +701,30 @@ function recoverInterruptedRotation(keyPath: string): void {
     );
   };
 
-  // 1. Live key opens the WHOLE store -> rotation complete/consistent. Sweep safe.
-  //    Opens only some items -> MIXED, refuse.
+  // 1. Live key opens the WHOLE store -> rotation complete/consistent. Sweep safe,
+  //    UNLESS a `<dir>.rotate-old-*` backup still holds items absent from the live
+  //    dir: then the live dir is not the post-swap store but a fresh dir an
+  //    interstitial `secrets set` created after a crash in the move-aside window
+  //    (store dir absent), and the backup is the ONLY copy of those items. Sweeping
+  //    would destroy them, so refuse. Opens only some items -> MIXED, refuse.
   const liveMatch = classifyStore(dir, liveKey, candidates);
-  if (liveMatch === 'all') { sweep(); return; }
+  if (liveMatch === 'all') {
+    const orphaned = bakDir && fs.existsSync(bakDir) ? backupOnlyEnc(bakDir, dir) : [];
+    if (orphaned.length > 0) {
+      const shown = orphaned.slice(0, 3).join(', ') + (orphaned.length > 3 ? ', …' : '');
+      throw new Error(
+        `Interrupted secrets rotation left a MIXED (split) store: the live key opens ` +
+        `${dir}, but its backup ${bakDir} holds ${orphaned.length} item(s) absent from ` +
+        `the live store (${shown}) — so the live dir is not the whole store. This ` +
+        `happens when a \`secrets set\` recreated the store dir after a crash left it ` +
+        `absent. Refusing to sweep — every recovery artifact is preserved. Recover out ` +
+        `of band: merge ${bakDir}/*.enc into ${dir} (both open under ${keyPath}), then ` +
+        `re-run \`rotate-passphrase\`.`,
+      );
+    }
+    sweep();
+    return;
+  }
   if (liveMatch === 'some') refuseMixed('some items open under the live key and others do not');
 
   // 2. `.rotate-new` opens the whole store, the live key none of it -> the crash

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -486,6 +486,12 @@ export interface RotatePassphraseReport {
   roundTripOk: boolean;
   /** The machine-local passphrase file that was (or would be) rewritten in place. */
   keyFilePath: string;
+  /**
+   * A previous rotation left artifacts on disk. On a real run they were healed
+   * before this rotation proceeded; under `--dry-run` nothing was written, so the
+   * healing is still pending and will happen on the next real run.
+   */
+  recoveryPending: boolean;
 }
 
 /** Flush a file's data to disk (durability before the atomic swap). */
@@ -641,6 +647,22 @@ function readKeyFile(fp: string): string | null {
  * this guarantee. Idempotent; a no-op when no rotation artifacts are present.
  * Callers run this under the store lock (see `withStoreLock`).
  */
+/**
+ * Whether a previous rotation left artifacts on disk — i.e. whether
+ * {@link recoverInterruptedRotation} would do any work. Read-only, so `--dry-run`
+ * can report a pending recovery without performing (and thus writing) one.
+ */
+export function hasInterruptedRotationArtifacts(keyPath: string): boolean {
+  const dir = fileDir();
+  const parent = path.dirname(dir);
+  const base = path.basename(dir);
+  let entries: string[];
+  try { entries = fs.readdirSync(parent); } catch { return false; }
+  return entries.some((e) => e.startsWith(`${base}.rotate-`))
+    || fs.existsSync(`${keyPath}.rotate-new`)
+    || fs.existsSync(`${keyPath}.rotate-oldkey`);
+}
+
 function recoverInterruptedRotation(keyPath: string): void {
   const dir = fileDir();
   const parent = path.dirname(dir);
@@ -648,16 +670,11 @@ function recoverInterruptedRotation(keyPath: string): void {
   let entries: string[];
   try { entries = fs.readdirSync(parent); } catch { return; }
 
-  const keyNew = `${keyPath}.rotate-new`;
-  const keyOld = `${keyPath}.rotate-oldkey`;
   const bakName = entries.find((e) => e.startsWith(`${base}.rotate-old-`));
   let bakDir = bakName ? path.join(parent, bakName) : null;
 
   // Nothing rotation-related on disk -> no interrupted rotation to recover.
-  const hasArtifacts = bakDir != null
-    || fs.existsSync(keyNew) || fs.existsSync(keyOld)
-    || entries.some((e) => e.startsWith(`${base}.rotate-`));
-  if (!hasArtifacts) return;
+  if (!hasInterruptedRotationArtifacts(keyPath)) return;
 
   // If the live store dir vanished mid-swap (crash between the two store renames,
   // before the new store landed), restore the old store from its backup — the key
@@ -832,7 +849,10 @@ function rotatePassphraseLocked(opts: RotatePassphraseOpts, heartbeat: () => voi
       'file store\'s auto-provisioned key; none is provisioned on this machine.',
     );
   }
-  recoverInterruptedRotation(keyPath);
+  // `--dry-run` must not write, and recovery heals by renaming/removing files —
+  // so only detect it here and surface it in the report. A real run heals first.
+  const recoveryPending = hasInterruptedRotationArtifacts(keyPath);
+  if (!dryRun) recoverInterruptedRotation(keyPath);
 
   const oldPass = fs.readFileSync(keyPath, 'utf8').trim();
   if (!oldPass) throw new Error(`Machine-local passphrase file ${keyPath} is empty.`);
@@ -885,6 +905,7 @@ function rotatePassphraseLocked(opts: RotatePassphraseOpts, heartbeat: () => voi
     skipped,
     roundTripOk: true,
     keyFilePath: keyPath,
+    recoveryPending,
   };
   if (dryRun) return report;
 


### PR DESCRIPTION
## What

Adds `agents secrets rotate-passphrase` — the first supported way to rotate the encrypted **file store's** master passphrase. Unblocks **RUSH-1968** (a confirmed leak of that passphrase that today has no clean remediation).

Why the existing surface didn't cover this:
- `secrets rekey` only renames macOS keychain service names to opaque HMAC hashes — it does not touch the file store, and RUSH-1968 is on Linux boxes.
- `secrets rotate <bundle> <key>` rotates a single secret **value**, not the store's master passphrase.
- The only workarounds were a hand-rolled decrypt/re-encrypt script (no atomicity — a partial failure loses every secret) or export-to-plaintext then re-import (writes every secret to cleartext on disk, which is the exact exposure being fixed).

## How it works

`rotatePassphrase()` (`apps/cli/src/lib/secrets/filestore.ts`):
1. Reads the current machine-local key (`~/.agents/.secrets-key/passphrase`), generates a fresh one.
2. Decrypts every `<item>.enc`, re-encrypts under the new key, and **verifies every item round-trips under the new key in memory** before touching disk. Any failure aborts with nothing written.
3. Stages the complete replacement store in a sibling temp dir, `fsync`s files + dir, then **swaps by directory rename**; the 0600 key file is `fsync`'d and swapped the same way.
4. A crash **before** the swap leaves the old store + old key fully intact and readable; a crash **inside** the swap self-heals on the next run (`recoverInterruptedRotation`). No half-re-keyed store is ever exposed.
5. Items that don't decrypt under the current key (orphan caches, stale test artifacts) are carried through **verbatim**, never re-keyed, and reported.

No plaintext secret value or passphrase is ever written to disk, argv, or a log.

**Flags / guards** (`apps/cli/src/commands/secrets-rotate-passphrase.ts`):
- Dry-run by default (matches `import-keyring`); `--commit` performs the swap.
- Refuses while the secrets-agent holds live unlocks (macOS), or while `AGENTS_SECRETS_PASSPHRASE` is exported (a stale shadow would break every read after rotation) — `--force` overrides both.

## End-to-end proof (on an isolated **copy** of the real s0 store — live store never touched)

Ran the built command against a `HOME`-isolated copy of the real 55-item store:

```
before:  supabase.EMAIL ciphertext sha256=b6dea08e85c9eaf1...  key sha256=2f9606eadbeaed66...
         resolve supabase.EMAIL under OLD key -> <resolved OK: tech@***>   (baseline read works)

$ agents secrets rotate-passphrase            # dry-run
49 item(s) decrypt under the current key and round-trip cleanly under a new key.
skipped 6 orphan file(s) (not re-keyed):   # 3x Claude Code-credentials-*, 3x wt-hostflag-e2e
Dry-run: nothing written.

$ agents secrets rotate-passphrase --commit
Rotated: re-encrypted 49 item(s) and rewrote <key> (mode 0600).

after:   supabase.EMAIL ciphertext sha256=2ae4f540b9b57801...  (changed)  key sha256=ad83d9644c5979d8...  (changed)
         key file mode: 600 ; 55 .enc files preserved ; 0 .rotate-* leftovers

$ agents secrets get   agents-cli.secrets.supabase.EMAIL   ->  <resolved OK: tech@***>   (NEW key, no env passphrase)
$ agents secrets exec  agents-cli-supabase -- ...          ->  resolved 5 SUPABASE_* vars in the child env
```

Live store confirmed untouched throughout (55 files, key sha256 == baseline). The temp copy was shredded after.

## Tests

`apps/cli/src/lib/secrets/filestore.test.ts` (6 new, all green — 79/79 in the secrets area):
- happy path: re-encrypts every item, rewrites the 0600 key file, old key locked out
- dry-run writes nothing (byte-for-byte unchanged)
- mid-run crash (after staging, before swap) leaves the old store readable under the old key + a later rotation recovers
- verify-before-swap abort on a bad round-trip writes nothing
- orphan encrypted under a different key is carried through verbatim
- no machine-local passphrase -> clear error

## Scope / safety

- **Does not** rotate the live store — that is the operator's call (RUSH-1968 remediation), explicitly out of scope here. No npm release cut.
- Docs updated (`apps/cli/docs/secrets.md`: utilities table + file-store rotation section) and a `.changelog/next/` fragment added.

Transcript is confidential (it contains a resolved secret value) and is **not** attached — available on the fleet at `yosemite-s0:~/.agents/.history/versions/claude/2.1.170/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz-agents-cli/83879c90-9daa-419d-96b8-dd068372c061.jsonl`.

Closes RUSH-1975.
