### PR TITLE
fix(sessions): bind named parameters under bun so the session index writes

### DIFF
--- a/apps/cli/.changelog/next/bun-sqlite-named-params.md
+++ b/apps/cli/.changelog/next/bun-sqlite-named-params.md
@@ -9,5 +9,7 @@
   listed only rows indexed earlier by the Node entrypoint. The suite runs under
   Node (vitest), where `node:sqlite` accepts bare keys, which is why CI stayed
   green. `apps/cli/src/lib/sqlite.ts` now opens the DB with `strict: true` under
-  Bun so both runtimes take the same bind shape, and `sqlite.test.ts` exercises
-  the named bind in a real `bun` subprocess.
+  Bun, so the bare-key call shape this codebase uses works on both runtimes (the
+  edges still differ — the module doc lists what strict changes). `sqlite.test.ts`
+  covers both the bind and a full `agents sessions` scan in a real `bun`
+  subprocess.

--- a/apps/cli/.changelog/next/bun-sqlite-named-params.md
+++ b/apps/cli/.changelog/next/bun-sqlite-named-params.md
@@ -1,0 +1,13 @@
+- **`agents sessions` indexes again from the standalone binary.** Every session
+  write went through a named-parameter bind (`INSERT ... VALUES (@id, @short_id,
+  ...)` in `apps/cli/src/lib/session/db.ts`), and `bun:sqlite` matches such an
+  object only when its keys carry the SQL sigil — bare keys bound nothing, so all
+  columns landed NULL and `sessions.short_id` (NOT NULL) rejected the row. The
+  shims exec the Bun-compiled `dist/bin/agents`, so no session reached the index
+  from the CLI: `agents sessions` printed `Warning: skipped unindexable session
+  <id>: NOT NULL constraint failed: sessions.short_id` per session and then
+  listed only rows indexed earlier by the Node entrypoint. The suite runs under
+  Node (vitest), where `node:sqlite` accepts bare keys, which is why CI stayed
+  green. `apps/cli/src/lib/sqlite.ts` now opens the DB with `strict: true` under
+  Bun so both runtimes take the same bind shape, and `sqlite.test.ts` exercises
+  the named bind in a real `bun` subprocess.

--- a/apps/cli/src/lib/hosts/session-index.test.ts
+++ b/apps/cli/src/lib/hosts/session-index.test.ts
@@ -8,9 +8,7 @@ import type { HostTask } from './tasks.js';
 
 // Isolate the sessions DB under a temp HOME. db.js reads its base dir lazily
 // (at getDB() time), so setting HOME here — before any test calls getDB — is
-// enough. Use STATIC imports, matching session/__tests__/db.test.ts: a dynamic
-// `await import()` of the native better-sqlite3 addon mis-binds named params
-// under bun (every insert lands NULLs → NOT NULL constraint failures).
+// enough. Use STATIC imports, matching session/__tests__/db.test.ts.
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-hostsession-'));
 process.env.HOME = TEST_HOME;
 

--- a/apps/cli/src/lib/session/__tests__/fork.test.ts
+++ b/apps/cli/src/lib/session/__tests__/fork.test.ts
@@ -5,8 +5,8 @@ import * as path from 'path';
 
 // Set HOME (and AGENTS_REAL_HOME) before db.js / fork.js load so their
 // module-level base dirs resolve inside an isolated temp HOME. Running
-// in-process under vitest uses the same node:sqlite driver as the real CLI
-// (a `bun --eval` subprocess would use bun:sqlite, which binds differently).
+// in-process under vitest uses node:sqlite; the shipped standalone binary runs
+// bun:sqlite, whose named binds are covered by src/lib/sqlite.test.ts.
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'fork-test-'));
 process.env.HOME = TEST_HOME;
 process.env.AGENTS_REAL_HOME = TEST_HOME;

--- a/apps/cli/src/lib/sqlite.test.ts
+++ b/apps/cli/src/lib/sqlite.test.ts
@@ -58,6 +58,48 @@ describe('sqlite shim named-parameter binds', () => {
     db.close();
   });
 
+  // The shim-level tests above pin the binding; this one pins the bug that
+  // motivated the fix — `agents sessions` writing its index (upsertSessionsBatch
+  // in session/db.ts, the codebase's only named bind) from the runtime the
+  // shipped standalone binary embeds.
+  it('indexes a scanned session when `agents sessions` runs under bun', () => {
+    const home = path.join(dir, 'home');
+    const sessionId = 'aaaaaaaa-1111-2222-3333-444444444444';
+    const projectDir = path.join(home, '.claude', 'projects', '-tmp-demo');
+    fs.mkdirSync(projectDir, { recursive: true });
+    // ensureInitialized() gates every non-setup command on the system repo being
+    // a git checkout — seed it so `sessions` runs instead of erroring.
+    fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\n');
+    fs.writeFileSync(path.join(projectDir, `${sessionId}.jsonl`), [
+      JSON.stringify({
+        type: 'user', sessionId, cwd: '/tmp/demo', version: '2.1.220', gitBranch: 'main',
+        timestamp: '2026-07-31T10:00:00.000Z',
+        message: { role: 'user', content: 'index this session please' },
+      }),
+      JSON.stringify({
+        type: 'assistant', sessionId, cwd: '/tmp/demo', version: '2.1.220',
+        timestamp: '2026-07-31T10:00:05.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 10, output_tokens: 4 } },
+      }),
+    ].join('\n') + '\n');
+
+    const out = execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), 'sessions', '--all', '--local', '--json'], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home, AGENTS_REAL_HOME: home },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).toString('utf-8');
+    expect(JSON.parse(out).map((s: { id: string }) => s.id)).toContain(sessionId);
+
+    // The listing can be served from the scan itself, so assert the row actually
+    // landed in the index — that is what the failed bind used to swallow.
+    const db = new Database(path.join(home, '.agents', '.history', 'sessions', 'sessions.db'));
+    expect(db.prepare('SELECT id, short_id FROM sessions').all()).toEqual([
+      { id: sessionId, short_id: 'aaaaaaaa' },
+    ]);
+    db.close();
+  });
+
   it('still binds positional parameters on the current runtime', () => {
     const db = new Database(dbPath);
     db.exec(SCHEMA);

--- a/apps/cli/src/lib/sqlite.test.ts
+++ b/apps/cli/src/lib/sqlite.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The session index writes its rows with a named-parameter bind
+ * (`upsertSessionStmt` in session/db.ts). bun:sqlite only matches such an
+ * object when its keys carry the SQL sigil unless the DB is opened with
+ * `strict: true` — without it every parameter stays NULL and `sessions.short_id`
+ * (NOT NULL) rejects the row, so no session ever reaches the index when the CLI
+ * runs as the standalone Bun binary. The suite itself runs under Node, so the
+ * bun half has to be exercised in a real `bun` subprocess.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Database from './sqlite.js';
+
+const SCHEMA = 'CREATE TABLE t (id TEXT PRIMARY KEY, short_id TEXT NOT NULL, count INTEGER)';
+const INSERT = 'INSERT INTO t (id, short_id, count) VALUES (@id, @short_id, @count)';
+
+describe('sqlite shim named-parameter binds', () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-shim-test-'));
+    dbPath = path.join(dir, 'test.db');
+  });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  it('binds bare object keys on the current runtime', () => {
+    const db = new Database(dbPath);
+    db.exec(SCHEMA);
+    db.prepare(INSERT).run({ id: 'sess-1', short_id: 'sess-1'.slice(0, 4), count: 7 });
+    expect(db.prepare('SELECT id, short_id, count FROM t').all()).toEqual([
+      { id: 'sess-1', short_id: 'sess', count: 7 },
+    ]);
+    db.close();
+  });
+
+  it('binds bare object keys under bun, the runtime the standalone binary embeds', () => {
+    const modulePath = path.resolve(process.cwd(), 'src/lib/sqlite.ts');
+    const script = `
+      import Database from ${JSON.stringify(modulePath)};
+      const db = new Database(${JSON.stringify(dbPath)});
+      db.exec(${JSON.stringify(SCHEMA)});
+      db.prepare(${JSON.stringify(INSERT)}).run({ id: 'sess-1', short_id: 'sess', count: 7 });
+      db.close();
+    `;
+    execFileSync('bun', ['-e', script], { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'inherit'] });
+
+    // Read back from this (Node) process: the row must exist with real values,
+    // not the all-NULL row a silent bind failure would have produced.
+    const db = new Database(dbPath);
+    expect(db.prepare('SELECT id, short_id, count FROM t').all()).toEqual([
+      { id: 'sess-1', short_id: 'sess', count: 7 },
+    ]);
+    db.close();
+  });
+
+  it('still binds positional parameters on the current runtime', () => {
+    const db = new Database(dbPath);
+    db.exec(SCHEMA);
+    db.prepare('INSERT INTO t (id, short_id, count) VALUES (?, ?, ?)').run('sess-2', 'sess', 3);
+    expect(db.prepare('SELECT short_id FROM t WHERE id = ?').get('sess-2')).toEqual({ short_id: 'sess' });
+    db.close();
+  });
+});

--- a/apps/cli/src/lib/sqlite.ts
+++ b/apps/cli/src/lib/sqlite.ts
@@ -33,9 +33,20 @@ const NativeDatabase: new (filename: string, options?: { strict: boolean }) => N
  * sigil (`{ '@id': … }` for `VALUES (@id)`); bare keys (`{ id: … }`) match
  * nothing and every parameter stays NULL, so the first NOT NULL column raises a
  * constraint error and the write is lost. node:sqlite accepts the bare keys.
- * `strict: true` makes bun accept them too, so one call shape works on both
- * runtimes. node:sqlite has no such option and rejects a second argument that
- * isn't an object, so the argument list is built per runtime.
+ * `strict: true` makes bun accept them too, so the bare-key call shape this
+ * codebase uses works on both runtimes. node:sqlite has no such option and
+ * rejects a second argument that isn't an object, so the argument list is built
+ * per runtime.
+ *
+ * The two runtimes are still not interchangeable at the edges, and only bun's
+ * half is exercised by the shipped binary rather than by vitest — so keep binds
+ * inside the intersection:
+ *   - omit a named key: bun throws `Missing parameter "x"`, node binds NULL.
+ *   - pass an extra named key: bun accepts it, node throws `Unknown named
+ *     parameter`.
+ *   - use sigil keys (`{'@id': …}`): node accepts them, strict bun rejects them.
+ *   - a single non-plain object positional arg (e.g. `run(new Date())`) reaches
+ *     the named path via bindArgs below and throws under strict bun.
  */
 const NATIVE_ARGS: [] | [{ strict: boolean }] = isBun ? [{ strict: true }] : [];
 

--- a/apps/cli/src/lib/sqlite.ts
+++ b/apps/cli/src/lib/sqlite.ts
@@ -3,8 +3,9 @@
  *
  * Picks `bun:sqlite` under Bun and `node:sqlite` under Node (>=22.5). Avoids
  * the native `better-sqlite3` addon entirely so there is no prebuild compile
- * and no Node/Bun ABI mismatch when the same source runs in tests (Bun) and
- * production (Node).
+ * and no Node/Bun ABI mismatch. Both runtimes are production: `dist/index.js`
+ * runs under Node, while the signed standalone `dist/bin/agents` (what the
+ * shims exec) embeds Bun.
  *
  * Exposes the small better-sqlite3-shaped surface area the rest of the
  * codebase already uses: `prepare/exec/pragma/transaction/close` on the DB,
@@ -23,9 +24,20 @@ const sqliteMod = isBun
   : require('node:sqlite');
 
 // bun:sqlite exports `Database`; node:sqlite exports `DatabaseSync`.
-const NativeDatabase: new (filename: string) => NativeDb =
+const NativeDatabase: new (filename: string, options?: { strict: boolean }) => NativeDb =
   (sqliteMod as { Database?: unknown; DatabaseSync?: unknown }).Database as never
   ?? (sqliteMod as { DatabaseSync?: unknown }).DatabaseSync as never;
+
+/**
+ * bun:sqlite binds a named-parameter object ONLY when its keys carry the SQL
+ * sigil (`{ '@id': … }` for `VALUES (@id)`); bare keys (`{ id: … }`) match
+ * nothing and every parameter stays NULL, so the first NOT NULL column raises a
+ * constraint error and the write is lost. node:sqlite accepts the bare keys.
+ * `strict: true` makes bun accept them too, so one call shape works on both
+ * runtimes. node:sqlite has no such option and rejects a second argument that
+ * isn't an object, so the argument list is built per runtime.
+ */
+const NATIVE_ARGS: [] | [{ strict: boolean }] = isBun ? [{ strict: true }] : [];
 
 interface NativeStmt {
   run(...args: unknown[]): RunResult;
@@ -46,7 +58,8 @@ export interface RunResult {
 
 function bindArgs(params: unknown[]): unknown[] {
   // Both bindings accept positional `(a, b, c)` and named `({ a, b, c })`
-  // forms. Pass an object through unchanged so callers using named binds work.
+  // forms — bun only under `strict: true` (see NATIVE_ARGS). Pass an object
+  // through unchanged so callers using named binds work.
   if (
     params.length === 1 &&
     params[0] !== null &&
@@ -79,7 +92,7 @@ class Database {
   private readonly inner: NativeDb;
 
   constructor(filename: string) {
-    this.inner = new NativeDatabase(filename);
+    this.inner = new NativeDatabase(filename, ...NATIVE_ARGS);
   }
 
   prepare<T = unknown>(sql: string): StatementImpl<T> {


### PR DESCRIPTION
## The bug

`agents sessions` writes its index with a named-parameter bind — `INSERT ... VALUES (@id, @short_id, ...)` bound from `{ id, short_id, ... }` (`apps/cli/src/lib/session/db.ts:556`, `:730`).

`bun:sqlite` matches a named-parameter object **only when its keys carry the SQL sigil** (`{ '@id': ... }`). The bare keys the code passes match nothing, every parameter stays NULL, and `short_id TEXT NOT NULL` (`db.ts:49`) rejects the row. `node:sqlite` accepts the bare keys, so the same code writes fine under Node.

The shims exec the Bun-compiled standalone `dist/bin/agents`, so **no session ever reached the index from the CLI**. What the user sees is one warning per session followed by a listing built from whatever an earlier Node-entrypoint run happened to index:

```
Warning: skipped unindexable session 505e4daf-08b8-46be-ba5d-d8737be038b8: NOT NULL constraint failed: sessions.short_id
Warning: skipped unindexable session df5d7c7e-e39a-472a-88d4-73d5b4cb8979: NOT NULL constraint failed: sessions.short_id
... (one per session)
```

On the reporting machine, `sessions --active --local` listed **1** session while 9 were live — the one row that predated the standalone binary.

Isolated repro, both runs against the same temp HOME holding one real Claude transcript:

```
$ HOME=<isolated> agents sessions --all --local   # installed dist/bin/agents (Bun 1.3.14)
No sessions found.
rows in the index it just wrote: 0

$ HOME=<isolated> bun src/index.ts sessions --all --local   # this branch, same Bun, same HOME
aaaaaaaa  claude   2.1.220 demo            index this session please                   14 hours ago

1 session.
rows in the index: 1  short_id=aaaaaaaa
```

Minimal proof of the binding semantics (bun 1.3.14):

```
bare keys      ERR: NOT NULL constraint failed: t.short_id
prefixed keys  OK
strict:true    OK with bare keys
```

## The fix

`apps/cli/src/lib/sqlite.ts` opens the DB with `strict: true` under Bun, which makes bun accept the same bare keys `node:sqlite` already accepts, so one call shape works on both runtimes. `node:sqlite` rejects a second argument that isn't an object, so the argument list is built per runtime rather than passing `undefined`.

The module doc claimed tests run under Bun and production under Node. It is the other way round — `npm test` is `vitest` under Node, and the signed standalone binary the shims exec embeds Bun. Corrected.

## Why CI stayed green

The suite runs under Node (`"test": "node ./node_modules/vitest/vitest.mjs run"`), where the bind always worked. The new `apps/cli/src/lib/sqlite.test.ts` drives the named bind through a real `bun -e` subprocess and reads the row back from Node, so the Bun half is actually covered. It fails on `main` with the production error and passes here:

```
FAIL  src/lib/sqlite.test.ts > binds bare object keys under bun, the runtime the standalone binary embeds
SQLiteError: NOT NULL constraint failed: t.short_id
```

`src/lib/session` is otherwise unchanged and green — the one failure there (`discover.test.ts > getSessionRoots`) reproduces on unmodified `main`.

## Not fixed here

`applyFilters` in `apps/cli/src/commands/sessions-browser.ts:246` intersects the live-process scan with the index (`if (f.running) out = out.filter(r => live.has(r.id))`), so a live session that is not yet an index row is dropped from the interactive `--active` view while `--json` still shows it. With the index writing again that window shrinks to "started since the last scan", but the two paths still answer the same question differently. Separate change.

Session transcript (local, not linked — public repo): `zion:~/.agents/.history/versions/claude/2.1.220/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/8a0452b8-1ee6-4a76-9b04-873fafd9ad73.jsonl`
