### PR TITLE
fix(floor): show real start + last-activity time on running agents (kill '0s ago')

### DIFF
--- a/apps/cli/.changelog/next/floor-session-liveness.md
+++ b/apps/cli/.changelog/next/floor-session-liveness.md
@@ -1,0 +1,9 @@
+- **`sessions --active` now stamps a start and last-activity time on every
+  interactive session.** Terminal, tmux, and headless agents discovered by the
+  process scan carried no `startedAtMs` — so the Factory Floor rendered every
+  running agent as "0s ago" even when its transcript, topic, and progress had
+  resolved. The scan now stamps `startedAtMs` (the SessionStart hook's own
+  timestamp, else the transcript's creation time) and a new `lastActivityMs` (the
+  transcript's last-write) on each row, and the Floor renders "Xs ago" off the
+  real last-activity instead of the session's age. Source:
+  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/lib/session/hook-sessions.ts`.

--- a/apps/cli/src/lib/session/active.times.test.ts
+++ b/apps/cli/src/lib/session/active.times.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { sessionFileTimes } from './active.js';
+
+// Regression for the "every running agent shows 0s ago" bug: the process-scan and
+// tmux-scan paths stamped no startedAtMs / lastActivityMs, so the Floor rendered every
+// interactive session as "0s ago" even when its transcript was fully resolved.
+// sessionFileTimes is the single stat that feeds both stamps — it must return a real
+// last-write (mtime) for a live transcript, and NOTHING (not epoch 0) for an absent one.
+
+let dir: string;
+let file: string;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sesstimes-'));
+  file = path.join(dir, 'session.jsonl');
+  fs.writeFileSync(file, '{"first":1}\n');
+});
+
+afterAll(() => {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('sessionFileTimes', () => {
+  it('returns a real last-write (mtime) for a live transcript', () => {
+    const before = Date.now() + 1000; // allow for fs mtime granularity/skew
+    const { mtimeMs, birthtimeMs } = sessionFileTimes(file);
+    expect(typeof mtimeMs).toBe('number');
+    expect(mtimeMs!).toBeGreaterThan(0);
+    expect(mtimeMs!).toBeLessThanOrEqual(before);
+    // birthtime is filesystem-dependent; when present it must be a real epoch, never 0.
+    if (birthtimeMs !== undefined) expect(birthtimeMs).toBeGreaterThan(0);
+  });
+
+  it('tracks the last write — a later append moves mtime forward', () => {
+    const first = sessionFileTimes(file).mtimeMs!;
+    const past = new Date(Date.now() - 120_000);
+    fs.utimesSync(file, past, past);
+    const rewound = sessionFileTimes(file).mtimeMs!;
+    expect(rewound).toBeLessThan(first);
+    fs.appendFileSync(file, '{"second":2}\n');
+    const bumped = sessionFileTimes(file).mtimeMs!;
+    expect(bumped).toBeGreaterThan(rewound);
+  });
+
+  it('returns nothing (never epoch 0) for an absent or undefined file', () => {
+    expect(sessionFileTimes(undefined)).toEqual({});
+    expect(sessionFileTimes(path.join(dir, 'does-not-exist.jsonl'))).toEqual({});
+  });
+});

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -26,7 +26,7 @@ import type { CloudTaskStatus } from '../cloud/types.js';
 import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
 import { readPidSessionEntry, prunePidSessionRegistry, type PidSessionEntry } from './pid-registry.js';
-import { loadHookSessionIndex, resolveHookSessionId, type HookSessionIndex } from './hook-sessions.js';
+import { loadHookSessionIndex, resolveHookSessionRecord, type HookSessionIndex, type HookSessionRecord } from './hook-sessions.js';
 import { buildClaudeLabelMap } from './discover.js';
 import { buildRunNameMap } from './run-names.js';
 import { latestSessionFileForCwd } from './db.js';
@@ -112,6 +112,13 @@ export interface ActiveSession {
   attachments?: SessionAttachment[];
   sessionFile?: string;
   startedAtMs?: number;
+  /**
+   * Last-activity epoch — the transcript's last write (mtime). Distinct from
+   * {@link startedAtMs} (session START): a session begun 3h ago but last touched
+   * 20s ago has an old start and a fresh last-activity. The Floor renders "Xs ago"
+   * off this so an idle-but-old session doesn't read as freshly active.
+   */
+  lastActivityMs?: number;
   status: ActiveStatus;
   /** How many live PIDs resolve to this same session (subagents/forks). 1 unless collapsed. */
   pidCount?: number;
@@ -336,6 +343,22 @@ export function pickSessionFile(projectDir: string, sessionId?: string): string 
   return best?.path;
 }
 
+/**
+ * One `stat` → the transcript's creation (≈ session start) and last-write (≈ last
+ * activity) epochs. Both `undefined` when the file can't be stat'd (vanished /
+ * unresolved). `birthtimeMs` can be 0 on filesystems without creation time — coerce
+ * that to `undefined` so callers fall through to a real signal instead of epoch 0.
+ */
+export function sessionFileTimes(sessionFile: string | undefined): { birthtimeMs?: number; mtimeMs?: number } {
+  if (!sessionFile) return {};
+  try {
+    const st = fs.statSync(sessionFile);
+    return { birthtimeMs: st.birthtimeMs || undefined, mtimeMs: st.mtimeMs || undefined };
+  } catch {
+    return {};
+  }
+}
+
 function classifyActivity(sessionFile: string | undefined): 'running' | 'idle' {
   // No resolvable transcript is NOT evidence of activity — default to idle. (Before
   // the no-borrow fix in pickSessionFile this rarely fired because every terminal
@@ -522,6 +545,7 @@ export async function listTeamsActive(): Promise<ActiveSession[]> {
       tokPerSec,
       sessionFile,
       startedAtMs: a.startedAt.getTime(),
+      lastActivityMs: sessionFileTimes(sessionFile).mtimeMs,
       teamName: a.taskName,
       agentId: a.agentId,
     }, state, sessionFile);
@@ -577,6 +601,7 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
       tokPerSec,
       sessionFile,
       startedAtMs: t.startedAtMs,
+      lastActivityMs: sessionFileTimes(sessionFile).mtimeMs,
       windowId: t.windowId,
     }, state, sessionFile);
   });
@@ -959,15 +984,20 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
     // launchId/terminalId/pid and kind-guarded against a stale reused-pid file;
     // (3) the newest-jsonl heuristic (sessionIdFromFile, below).
     let exactId = entry?.sessionId;
+    // The hook record (when we fall to it) also carries the SessionStart `ts` — the
+    // real session-start epoch. Capture it so terminal/headless rows get a
+    // `startedAtMs` instead of rendering "0s ago" (they set none before this).
+    let hookRec: HookSessionRecord | undefined;
     if (!exactId) {
       hookIndex ??= loadHookSessionIndex();
-      exactId = resolveHookSessionId(hookIndex, {
+      hookRec = resolveHookSessionRecord(hookIndex, {
         pid,
         kind,
         launchId: entry?.launchId,
         terminalId: entry?.terminalId,
         childPids: ensureChildren().get(pid),
       });
+      exactId = hookRec?.session_id;
     }
     const cwd = cwds[i] ?? entry?.cwd ?? undefined;
     const sessionFile = findSessionFileForKind(kind, cwd, exactId);
@@ -975,6 +1005,7 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
     const host = detectHost(pid, procByPid);
     const context: ActiveContext = host && UI_HOSTS.has(host) ? 'terminal' : 'headless';
     const { state, tokPerSec } = computeLiveSignals(kind, sessionFile, cwd, true);
+    const { birthtimeMs, mtimeMs } = sessionFileTimes(sessionFile);
     out.push(applyState({
       context,
       kind,
@@ -986,6 +1017,10 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
       topic,
       tokPerSec,
       sessionFile,
+      // Session start: the hook's authoritative SessionStart `ts`, else the
+      // transcript's creation time. Last activity: the transcript's last write.
+      startedAtMs: hookRec?.ts ?? birthtimeMs,
+      lastActivityMs: mtimeMs,
       pidCount: 1 + (foldedByRoot.get(pid) ?? 0),
     }, state, sessionFile));
   }
@@ -1041,6 +1076,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
     const sessionFile = findSessionFileForKind(agent, cwd, sessionId);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
     const { state, tokPerSec } = computeLiveSignals(agent, sessionFile, cwd, pid ? isPidAlive(pid) : true);
+    const { birthtimeMs, mtimeMs } = sessionFileTimes(sessionFile);
     // Provenance is known exactly here (the pane IS a tmux pane) — set it so
     // enrichProvenance skips it and the locator/reply rails resolve off the pane.
     const provenance: SessionProvenance = {
@@ -1059,6 +1095,10 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
       topic,
       tokPerSec,
       sessionFile,
+      // tmux panes carry no start timestamp; derive both from the transcript
+      // (creation ≈ start, last write ≈ last activity).
+      startedAtMs: birthtimeMs,
+      lastActivityMs: mtimeMs,
       provenance,
     }, state, sessionFile));
   }

--- a/apps/cli/src/lib/session/hook-sessions.test.ts
+++ b/apps/cli/src/lib/session/hook-sessions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { getTerminalsDir } from '../state.js';
-import { loadHookSessionIndex, resolveHookSessionId } from './hook-sessions.js';
+import { loadHookSessionIndex, resolveHookSessionId, resolveHookSessionRecord } from './hook-sessions.js';
 
 // Fake pids far above any real process, so the test never reads or clobbers a
 // live hook state file.
@@ -27,6 +27,18 @@ describe('hook session index + resolver', () => {
     writeRecord(P1, { session_id: 'sess-direct', agent: 'codex', pid: P1, ts: 10 });
     const idx = loadHookSessionIndex();
     expect(resolveHookSessionId(idx, { pid: P1, kind: 'codex' })).toBe('sess-direct');
+  });
+
+  it('resolveHookSessionRecord returns the full record incl. ts (the startedAtMs source)', () => {
+    // active.ts stamps startedAtMs from this ts; resolving only the id (the old
+    // resolveHookSessionId) is why terminal/headless rows had no start time.
+    writeRecord(P1, { session_id: 'sess-ts', agent: 'claude', pid: P1, ts: 1785544530059 });
+    const idx = loadHookSessionIndex();
+    const rec = resolveHookSessionRecord(idx, { pid: P1, kind: 'claude' });
+    expect(rec?.session_id).toBe('sess-ts');
+    expect(rec?.ts).toBe(1785544530059);
+    // kind guard still applies: a mismatched kind resolves nothing.
+    expect(resolveHookSessionRecord(idx, { pid: P1, kind: 'codex' })).toBeUndefined();
   });
 
   it('joins by launchId even when the hook pid differs from the recorded pid', () => {

--- a/apps/cli/src/lib/session/hook-sessions.ts
+++ b/apps/cli/src/lib/session/hook-sessions.ts
@@ -130,10 +130,10 @@ export interface ResolveOpts {
  * Every hit is kind-guarded so a stale file at a reused pid can't cross agents.
  * Undefined until the hook lands (it can lag the spawn) or for hookless harnesses.
  */
-export function resolveHookSessionId(index: HookSessionIndex, opts: ResolveOpts): string | undefined {
+export function resolveHookSessionRecord(index: HookSessionIndex, opts: ResolveOpts): HookSessionRecord | undefined {
   const { pid, kind, launchId, terminalId, childPids } = opts;
-  const take = (rec: HookSessionRecord | undefined): string | undefined =>
-    rec?.session_id && kindMatches(rec.agent, kind) ? rec.session_id : undefined;
+  const take = (rec: HookSessionRecord | undefined): HookSessionRecord | undefined =>
+    rec?.session_id && kindMatches(rec.agent, kind) ? rec : undefined;
 
   if (launchId) {
     const hit = take(index.byLaunchId.get(launchId));
@@ -150,4 +150,10 @@ export function resolveHookSessionId(index: HookSessionIndex, opts: ResolveOpts)
     if (hit) return hit;
   }
   return undefined;
+}
+
+/** The session id alone — see {@link resolveHookSessionRecord} for the full record
+ *  (which also carries the SessionStart `ts` used to stamp `startedAtMs`). */
+export function resolveHookSessionId(index: HookSessionIndex, opts: ResolveOpts): string | undefined {
+  return resolveHookSessionRecord(index, opts)?.session_id;
 }

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -296,6 +296,8 @@ export interface RawActiveSession {
   topic?: string;
   sessionFile?: string;
   startedAtMs?: number;
+  /** Transcript last-write epoch (ms) stamped by the CLI — the real activity signal. */
+  lastActivityMs?: number;
   status?: string;
   teamName?: string;
   agentId?: string;
@@ -586,9 +588,11 @@ export function normalizeActiveSession(
     worktreePath: asStr(raw.worktree?.path) || (worktreeSlug ? cwd : ''),
     sinceMs: startedAtMs > 0 ? Math.max(0, fetchedAt - startedAtMs) : 0,
     startedAtMs,
-    // 0 = no activity signal yet; the fan-out sets the real file mtime for file-backed
-    // sessions. Deliberately NOT startedAtMs — start time is not activity.
-    lastActivityMs: 0,
+    // The CLI stamps the transcript's last-write epoch (`active.ts` sessionFileTimes)
+    // on every file-backed session — the real activity signal, present for remote
+    // hosts too. The local fan-out still re-stats as a fallback. Deliberately NOT
+    // startedAtMs — start time is not activity.
+    lastActivityMs: typeof raw.lastActivityMs === 'number' ? raw.lastActivityMs : 0,
     topic: asStr(raw.topic) || asStr(raw.label),
     label: asStr(raw.label),
     sessionFile: asStr(raw.sessionFile),

--- a/apps/factory/src/vscode/remoteSessions.vscode.ts
+++ b/apps/factory/src/vscode/remoteSessions.vscode.ts
@@ -249,14 +249,15 @@ async function fetchActiveForHost(sshTarget: string, isLocal: boolean, hostKey: 
     for (let session of unique) {
       // Activity / throughput / waiting now arrive on the CLI payload itself
       // (ActiveSession.activity / tokPerSec / awaitingReason, issue #741) — no
-      // transcript-tail re-parse here. The one thing the payload does not carry
-      // is the file's last-write time, so stat THIS machine's own session files
-      // (remote rows have no local file) to stamp the staleness signal.
+      // transcript-tail re-parse here. The CLI payload now also carries the file's
+      // last-write time (ActiveSession.lastActivityMs); re-stat THIS machine's own
+      // files to refresh it to the instant of render (remote rows keep the payload
+      // value — no local file to stat).
       if (session.host === LOCAL_LABEL && session.sessionFile) {
         try {
           const stat = await fs.promises.stat(session.sessionFile);
           session = { ...session, lastActivityMs: stat.mtimeMs };
-        } catch { /* file gone/rotated — leave the no-signal 0 */ }
+        } catch { /* file gone/rotated — keep the payload's lastActivityMs */ }
       }
       sessions.push(session);
     }

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -425,10 +425,46 @@ describe('toFloorAgentFromRemote', () => {
     expect(a.createdTickets).toEqual(['RUSH-901'])
     expect(a.spawnedTeam).toBe('rate-limiter')
     expect(a.question?.kind).toBe('confirm')
-    // remote carries only session-start; heartbeat anchors to it until backend adds a stamp.
+    // No lastActivityMs on the payload → heartbeat falls back to session-start.
     expect(a.lastActivityMs).toBe(NOW - 42_000)
     // a genuinely-remote host is already its real name — no display override.
     expect(a.hostLabel).toBeUndefined()
+  })
+
+  test('prefers the CLI lastActivityMs stamp over startedAtMs for the heartbeat', () => {
+    // The CLI now stamps the transcript last-write on active sessions (active.ts
+    // sessionFileTimes), so a session started long ago but touched seconds ago reads
+    // as freshly active — not "started 1h ago".
+    const r: RemoteSessionLike = {
+      host: 'yosemite-s0',
+      sessionId: 'live999',
+      agentType: 'claude',
+      cwd: '/Users/muqsit/src/github.com/muqsitnawaz',
+      project: 'muqsitnawaz',
+      phase: 'running',
+      activity: 'working',
+      tokPerSec: 40,
+      waitingForInput: false,
+      lastResponse: 'editing files',
+      prUrl: null,
+      ticket: null,
+      branch: '',
+      sinceMs: 3_600_000,
+      startedAtMs: NOW - 3_600_000, // started 1h ago
+      lastActivityMs: NOW - 20_000, // but last wrote 20s ago
+      topic: 'Long-running interactive session',
+      context: 'terminal',
+      cloudTaskId: '',
+      cloudProvider: '',
+      teamName: '',
+      pid: 999,
+      transport: 'ssh',
+      replyRail: '',
+      replyMuxTarget: '',
+      replyMuxSocket: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set())
+    expect(a.lastActivityMs).toBe(NOW - 20_000)
   })
 
   test('detects remote plan artifacts from output and attachment refs', () => {

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -614,10 +614,11 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     target,
     tok: r.tokPerSec,
     since: sinceFromMs(r.sinceMs),
-    // Remote sessions only carry a wall-clock START (startedAtMs); there is no distinct
-    // last-activity epoch yet, so the heartbeat anchors to start until backend-data adds
-    // one. 0 (unknown) disables the heartbeat rather than raising a false stall.
-    lastActivityMs: r.startedAtMs > 0 ? r.startedAtMs : 0,
+    // Prefer the CLI's real last-activity epoch (transcript last-write, now stamped on
+    // active sessions too — active.ts sessionFileTimes) so "Xs ago" tracks the last
+    // turn, not the session's age. Fall back to start when no file signal exists; 0
+    // (unknown) disables the heartbeat rather than raising a false stall.
+    lastActivityMs: r.lastActivityMs && r.lastActivityMs > 0 ? r.lastActivityMs : (r.startedAtMs > 0 ? r.startedAtMs : 0),
     files: 0,
     tools: 0,
     needs,


### PR DESCRIPTION
## Problem

The Factory Floor rendered every running agent as a bare **"Claude session — 0s ago"** with no progress. Investigation (live `agents sessions --active --json`) found it is **not** a stale DB — the Floor shells out live each poll. The real cause is upstream in the CLI payload:

- The two scan paths — `listUnattributedActive` (process scan) and `listTmuxAgentSessions` — built their rows with **no `startedAtMs` at all**. Even a session whose transcript, topic, and progress fully resolved came back with no start time, so the extension's `sinceMs` defaulted to 0 → **"0s ago"** on every row.
- No path emitted a real **last-activity** epoch. The transcript mtime was computed (for the running/idle classifier) then discarded, so the Floor had nothing to anchor "Xs ago" to and backfilled it from `startedAtMs` (session age, not freshness).

## Fix

**CLI (`apps/cli`)**
- `resolveHookSessionRecord` returns the full SessionStart-hook record (it already carries `ts`); `resolveHookSessionId` delegates to it.
- A single `sessionFileTimes` stat yields the transcript's creation (≈ start) and last-write (≈ last activity).
- All scan paths now stamp `startedAtMs` (hook `ts`, else transcript birthtime) and a new `lastActivityMs` (transcript mtime). Both serialize on `--active --json` and flow across the SSH fan-out.

**Extension (`apps/factory`)**
- The active-session normalizer reads `raw.lastActivityMs` instead of hardcoding 0.
- `floorAdapter` prefers the real `lastActivityMs` over `startedAtMs` for the heartbeat and the "Xs ago" stamp, falling back to start when no file signal exists.

## Verification (live, `--local`)

Before: local tmux rows returned `startedAtMs: None` even when they had a topic.

After — resolved sessions now carry real times:
```
[claude|tmux] started 31m50s ago, active 11m12s ago :: Hey Claude, check out the various agent-cli co
[claude|tmux] started  3h30m ago, active    1m9s ago :: Check all the work we were doing with the
[claude|tmux] started 12m29s ago, active     15s ago :: Let's fix this: [Image #1] ...
```
(`startedAtMs>0`: 9/14, `lastActivityMs>0`: 7/14 — the rest are the deliberately-unresolvable `/`-cwd / pre-hook sessions the no-borrow design intentionally leaves blank.)

## Tests
- `active.times.test.ts` (new) — `sessionFileTimes` returns a real mtime, tracks a later append, and returns nothing (never epoch 0) for an absent file.
- `hook-sessions.test.ts` — `resolveHookSessionRecord` recovers the full record incl. `ts`, kind-guard preserved.
- `floorAdapter.test.ts` — prefers `lastActivityMs` over `startedAtMs`; existing start-fallback assertion still holds.

CLI + factory: `tsc --noEmit` clean (0 errors), all touched suites green.

## Scope
This is the session-liveness (Layer 1) fix — it makes running agents show real names, start times, and freshness. Follow-ups: surfacing needs-you / plan-ready / done as at-a-glance Floor cues, and the group-count header (`GROUPED BY OUTCOME · 0` vs the total badge).

Session transcript (this box): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz/bed37b71-6eea-424e-b92f-66ae3d334937.jsonl`
