### PR TITLE
fix(sessions): session label integrity + surfacing (Workstream C)

### DIFF
--- a/apps/cli/.changelog/next/session-label-integrity.md
+++ b/apps/cli/.changelog/next/session-label-integrity.md
@@ -1,0 +1,9 @@
+- **Session tab titles no longer go missing or stale.** A rescan that carried an
+  empty or whitespace-only label used to clobber a good stored label, because
+  `upsertSession`/`upsertSessionsBatch` wrote `label = excluded.label`
+  unconditionally on conflict. The `ON CONFLICT` clause now preserves an existing
+  non-empty label and only overwrites when a real label arrives, so a `/rename`,
+  agent-generated title, or `--name` handle survives later rescans. Headless runs
+  launched with `--name` now also surface that name as the session label (matching
+  the terminal path) instead of showing only the topic. Source:
+  `apps/cli/src/lib/session/db.ts`, `apps/cli/src/lib/session/active.ts`.

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -991,6 +991,11 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
   // poll must not re-read the dir (or re-invert the map) per candidate.
   let hookIndex: HookSessionIndex | undefined;
   let childrenByParent: Map<number, number[]> | undefined;
+  // Durable `agents run --name` handles keyed by session id — the same source the
+  // terminal path uses to name a row. Headless agents have no live-terminals
+  // label and no /rename, so without this a `--name`d headless run would surface
+  // with only a topic and no tab title. Built once per scan.
+  const runNameMap = buildRunNameMap();
   const ensureChildren = (): Map<number, number[]> => {
     if (childrenByParent) return childrenByParent;
     const m = new Map<number, number[]>();
@@ -1045,6 +1050,14 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
     // `unknown`, not a fake `idle`.
     const { state, tokPerSec } = computeLiveSignals(kind, sessionFile, cwd, true);
     const { birthtimeMs, mtimeMs } = sessionFileTimes(sessionFile);
+    // Durable run name from `agents run --name`, resolved by the run's session id
+    // — the tab-title handle for a run we launched by name. A headless row carries
+    // no /rename label and no live-terminals label, so this handle IS its label
+    // (mirrors listTeamsActive `label: a.name`). Absent a `--name`, label stays
+    // undefined and the display falls back to the topic on its own — no band-aid.
+    const resolvedId = exactId ?? sessionIdFromFile(sessionFile);
+    const name = resolvedId ? runNameMap.get(resolvedId) ?? undefined : undefined;
+    const label = name;
     out.push(applyState({
       context,
       kind,
@@ -1052,7 +1065,9 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
       tty: procByPid.get(pid)?.tty,
       pid,
       cwd,
-      sessionId: exactId ?? sessionIdFromFile(sessionFile),
+      sessionId: resolvedId,
+      label,
+      name,
       topic,
       tokPerSec,
       sessionFile,

--- a/apps/cli/src/lib/session/db.names.test.ts
+++ b/apps/cli/src/lib/session/db.names.test.ts
@@ -59,13 +59,18 @@ describe('--name seeds the unified session label', () => {
     expect(ftsSearch('my-seed').some(h => h.score >= 800_000)).toBe(false);
   });
 
-  it('the seed shows until a title exists, and re-applies across a bare rescan', () => {
+  it('the seed shows until a title exists, and survives a bare rescan', () => {
     upsertSession(meta('run-persist'), '');
     seedLabelsFromNames(new Map([['run-persist', 'keep-me']]));
     expect(getSessionById('run-persist')?.label).toBe('keep-me');
-    // A bare rescan re-upserts with no label (label = excluded.label clears it)...
+    // A bare rescan re-upserts with an EMPTY label. The upsert now PRESERVES the
+    // stored non-empty label instead of clearing it, so the handle stays
+    // resolvable even before the seed pass re-runs.
     upsertSession(meta('run-persist'), 'rescanned preview');
-    // ...and the seed pass restores it every scan, so the handle stays resolvable.
+    expect(getSessionById('run-persist')?.label).toBe('keep-me');
+    // The FTS label column stays consistent too — search still resolves the run.
+    expect(ftsSearch('keep-me')[0]?.sessionId).toBe('run-persist');
+    // The seed pass re-running is a harmless no-op (label already non-empty).
     seedLabelsFromNames(new Map([['run-persist', 'keep-me']]));
     expect(getSessionById('run-persist')?.label).toBe('keep-me');
     expect(ftsSearch('keep-me')[0]?.sessionId).toBe('run-persist');
@@ -75,5 +80,50 @@ describe('--name seeds the unified session label', () => {
     upsertSession(meta('run-plain'), '');
     expect(getSessionById('run-plain')?.label).toBeUndefined();
     expect(ftsSearch('run-plain').some(h => h.score >= 800_000)).toBe(false);
+  });
+});
+
+describe('upsertSession preserves a good label; a real one still wins (clobber fix)', () => {
+  it('an EMPTY incoming label does NOT overwrite a stored non-empty label', () => {
+    upsertSession(meta('clobber-empty'), '');
+    // Seed a good label (the --name seed path).
+    seedLabelsFromNames(new Map([['clobber-empty', 'good-label']]));
+    expect(getSessionById('clobber-empty')?.label).toBe('good-label');
+    // A later scan re-upserts with no label at all — must NOT erase the good one.
+    upsertSession(meta('clobber-empty'), 'preview text');
+    expect(getSessionById('clobber-empty')?.label).toBe('good-label');
+    // A whitespace-only incoming label counts as empty and must not clobber either.
+    upsertSession(meta('clobber-empty', { label: '   ' }), 'more preview');
+    expect(getSessionById('clobber-empty')?.label).toBe('good-label');
+    // FTS label stayed consistent through both blank rescans.
+    expect(ftsSearch('good-label')[0]?.sessionId).toBe('clobber-empty');
+  });
+
+  it('a REAL incoming label DOES win over the stored one', () => {
+    upsertSession(meta('clobber-real'), '');
+    seedLabelsFromNames(new Map([['clobber-real', 'old-label']]));
+    expect(getSessionById('clobber-real')?.label).toBe('old-label');
+    // An upsert carrying a genuine (non-empty) label overwrites — the /rename and
+    // agent-title paths that flow a real label through upsert must still change it.
+    upsertSession(meta('clobber-real', { label: 'new-real-label' }), '');
+    expect(getSessionById('clobber-real')?.label).toBe('new-real-label');
+    // The FTS index moved to the new label and dropped the old one.
+    expect(ftsSearch('new-real-label')[0]?.sessionId).toBe('clobber-real');
+    expect(ftsSearch('old-label').some(h => h.score >= 800_000)).toBe(false);
+  });
+
+  it('syncLabels can still CHANGE a label after the preserve fix', () => {
+    upsertSession(meta('sync-change', { label: 'first' }), '');
+    expect(getSessionById('sync-change')?.label).toBe('first');
+    // The agent-title / `/rename` diff path replaces the label outright.
+    syncLabels(new Map([['sync-change', 'renamed']]));
+    expect(getSessionById('sync-change')?.label).toBe('renamed');
+    expect(ftsSearch('renamed')[0]?.sessionId).toBe('sync-change');
+  });
+
+  it('the first upsert still sets a real label (INSERT path unaffected)', () => {
+    upsertSession(meta('first-real', { label: 'born-with-a-label' }), '');
+    expect(getSessionById('first-real')?.label).toBe('born-with-a-label');
+    expect(ftsSearch('born-with-a-label')[0]?.sessionId).toBe('first-real');
   });
 });

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -574,7 +574,15 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     cwd = excluded.cwd,
     git_branch = excluded.git_branch,
     topic = excluded.topic,
-    label = excluded.label,
+    -- Never let an empty/placeholder incoming label clobber a good stored one.
+    -- A real incoming label (non-empty after trim) still wins; a blank one keeps
+    -- the label seeded by --name (seedLabelsFromNames) or refined by an agent
+    -- title / rename (syncLabels). A bare rescan carries no label, so it must
+    -- preserve, not erase, the good one already stored.
+    label = CASE
+      WHEN excluded.label IS NULL OR trim(excluded.label) = '' THEN sessions.label
+      ELSE excluded.label
+    END,
     message_count = excluded.message_count,
     token_count = excluded.token_count,
     output_tokens = excluded.output_tokens,
@@ -596,11 +604,17 @@ const deleteTextStmt = (db: Database.Database) =>
   db.prepare(`DELETE FROM session_text WHERE session_id = ?`);
 const insertTextStmt = (db: Database.Database) =>
   db.prepare(`INSERT INTO session_text (session_id, label, topic, project, content) VALUES (?, ?, ?, ?, ?)`);
+// Read back the label the upsert actually stored (which may be the preserved
+// one, not the incoming blank) so the FTS label column stays consistent with
+// sessions.label after a bare rescan.
+const readLabelStmt = (db: Database.Database) =>
+  db.prepare(`SELECT label FROM sessions WHERE id = ?`);
 
 let cachedStmts: {
   upsert?: Database.Statement<SessionRow>;
   delText?: Database.Statement<unknown[]>;
   insText?: Database.Statement<unknown[]>;
+  readLabel?: Database.Statement<unknown[]>;
 } = {};
 
 function stmts(db: Database.Database) {
@@ -609,9 +623,21 @@ function stmts(db: Database.Database) {
       upsert: upsertSessionStmt(db) as Database.Statement<SessionRow>,
       delText: deleteTextStmt(db),
       insText: insertTextStmt(db),
+      readLabel: readLabelStmt(db),
     };
   }
   return cachedStmts as Required<typeof cachedStmts>;
+}
+
+/**
+ * Return the label stored for a session, as text for the FTS index (never NULL).
+ * Called inside the upsert transaction, AFTER the row upsert, so it reflects the
+ * preserve-non-empty-label rule in the ON CONFLICT clause rather than the raw
+ * incoming label.
+ */
+function storedFtsLabel(readLabel: Database.Statement<unknown[]>, id: string): string {
+  const row = readLabel.get(id) as { label: string | null } | undefined;
+  return row?.label ?? '';
 }
 
 /**
@@ -620,7 +646,7 @@ function stmts(db: Database.Database) {
  */
 export function upsertSession(meta: SessionMeta, content: string, scan?: ScanStamp): void {
   const db = getDB();
-  const { upsert, delText, insText } = stmts(db);
+  const { upsert, delText, insText, readLabel } = stmts(db);
   const row: SessionRow = {
     id: meta.id,
     short_id: meta.shortId,
@@ -659,7 +685,9 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     delText.run(meta.id);
     insText.run(
       meta.id,
-      meta.label ?? '',
+      // Use the label the upsert actually stored (preserve-non-empty rule),
+      // not the raw incoming one, so FTS label ranking survives a bare rescan.
+      storedFtsLabel(readLabel, meta.id),
       meta.topic ?? '',
       meta.project ?? '',
       content ?? '',
@@ -674,7 +702,7 @@ export function upsertSessionsBatch(
 ): void {
   if (entries.length === 0) return;
   const db = getDB();
-  const { upsert, delText, insText } = stmts(db);
+  const { upsert, delText, insText, readLabel } = stmts(db);
   const now = Date.now();
   const ledger = db.prepare(`
     INSERT INTO scan_ledger (file_path, file_mtime_ms, file_size, scanned_at)
@@ -762,7 +790,9 @@ export function upsertSessionsBatch(
       delText.run(meta.id);
       insText.run(
         meta.id,
-        meta.label ?? '',
+        // Mirror upsertSession: index the label the upsert actually stored
+        // (preserve-non-empty rule), not the raw incoming one.
+        storedFtsLabel(readLabel, meta.id),
         meta.topic ?? '',
         meta.project ?? '',
         content ?? '',


### PR DESCRIPTION
## Workstream C — session label integrity + surfacing

Session labels (tab titles) went missing or stale for cloud / pick-host and
headless sessions. Two root causes, both fixed here.

### Root cause 1 — the clobber bug (`db.ts`)

`upsertSession` and `upsertSessionsBatch` wrote `label = excluded.label`
unconditionally in the `ON CONFLICT(id) DO UPDATE`. Every scan re-upserts a
session; a scan that carries an empty/placeholder label therefore **erased** a
good label that had been seeded by `--name` (`seedLabelsFromNames`) or refined
by an agent title / rename (`syncLabels`). The seed only backfills EMPTY labels,
so once erased it could be re-seeded — but an agent-refined title had no such
backstop and was lost until the next title event.

**Fix:** guard the conflict update so a blank incoming label preserves the
stored one, while a real incoming label still wins:

```sql
label = CASE
  WHEN excluded.label IS NULL OR trim(excluded.label) = '' THEN sessions.label
  ELSE excluded.label
END
```

The FTS5 `session_text.label` column is rebuilt on every upsert
(delete+insert). It previously indexed the raw incoming label, so a blank
rescan would clear the FTS label even after the `sessions.label` was preserved —
breaking label search. The FTS insert now reads back the label the upsert
actually stored (`storedFtsLabel`) so the two stay consistent.

`syncLabels` (the rename / agent-title diff path) is untouched and still changes
a label; `seedLabelsFromNames` still only fills empties.

### Root cause 2 — headless rows had no label (`active.ts`)

`listUnattributedActive` set `topic` but never `label`/`name`, so a headless
run launched with `agents run --name <slug>` surfaced with only its topic and no
tab title. It now resolves the durable `--name` handle by session id
(`buildRunNameMap`, built once per scan) and sets it as the row's `label` +
`name`, mirroring the terminal path and `listTeamsActive` (`label: a.name`).

**No band-aid:** when there is no `--name`, `label` stays `undefined` and the
display's existing `label || topic` fallback (`commands/sessions.ts`) shows the
topic on its own. Setting `label = topic` here would duplicate that fallback, so
it is deliberately not done.

### Tests (`db.names.test.ts`) — real SQLite, no mocking

New tests prove: an empty (and a whitespace-only) incoming label does NOT
overwrite a stored non-empty label; a real incoming label DOES win; `syncLabels`
can still change a label; the first upsert still sets a real label; the seed
survives a bare rescan by preservation. The `--name` handle → label resolution
the headless path now reads is covered by `run-names.test.ts`.

```
$ node ./node_modules/typescript/bin/tsc --noEmit ; echo TSC_EXIT=$?
TSC_EXIT=0

$ node ./node_modules/vitest/vitest.mjs run \
    src/lib/session/db.names.test.ts src/lib/session/run-names.test.ts \
    src/lib/session/db.freshness.test.ts src/lib/session/db.migrate-v10.test.ts \
    src/lib/session/active.test.ts
 Test Files  5 passed (5)
      Tests  27 passed (27)

$ node ./node_modules/vitest/vitest.mjs run src/lib/session/db.names.test.ts --reporter=verbose
 ✓ upsertSession preserves a good label; a real one still wins (clobber fix) > an EMPTY incoming label does NOT overwrite a stored non-empty label
 ✓ upsertSession preserves a good label; a real one still wins (clobber fix) > a REAL incoming label DOES win over the stored one
 ✓ upsertSession preserves a good label; a real one still wins (clobber fix) > syncLabels can still CHANGE a label after the preserve fix
 ✓ upsertSession preserves a good label; a real one still wins (clobber fix) > the first upsert still sets a real label (INSERT path unaffected)
 ✓ --name seeds the unified session label > the seed shows until a title exists, and survives a bare rescan
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Note: `src/lib/session/discover.test.ts` fails on this dev box (its hardcoded
`KNOWN_AGENTS` set omits `cursor`/`grok`, which have config dirs on the host) —
pre-existing and unrelated to this diff (verified failing identically on
pristine `origin/main`); it passes in CI's clean environment.

### Files
- `apps/cli/src/lib/session/db.ts` — clobber fix + FTS label consistency
- `apps/cli/src/lib/session/db.names.test.ts` — tests
- `apps/cli/src/lib/session/active.ts` — headless label surfacing
