### PR TITLE
fix(sessions): collapse indistinguishable worker processes into one active row

### DIFF
--- a/apps/cli/.changelog/next/floor-dedupe-unattributed.md
+++ b/apps/cli/.changelog/next/floor-dedupe-unattributed.md
@@ -1,0 +1,8 @@
+- **Collapse indistinguishable worker processes into one active-session row.** A daemon
+  that spawns many agent binaries (an OpenClaw gateway running `codex app-server`) produced
+  one `sessions --active` row per process, because a row with no session id and no
+  transcript file skipped dedupe entirely — the Factory Floor showed ~40 identical
+  `.openclaw · bg · 0s ago` rows that buried every real session. Dedupe now falls back to
+  the cloud/run handle and then to the worker's identity (agent binary + context + working
+  directory), so N indistinguishable workers become one row carrying `pidCount: N`.
+  Source: `apps/cli/src/lib/session/active.ts`.

--- a/apps/cli/src/lib/session/active.dedupe.test.ts
+++ b/apps/cli/src/lib/session/active.dedupe.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { dedupeBySession } from './active.js';
+import type { ActiveSession } from './active.js';
+
+// Regression for the "Factory Floor is flooded with identical .openclaw rows" bug.
+// An OpenClaw gateway on mac-mini spawns N `codex` worker processes. The process
+// scan (listUnattributedActive) picks each one up, but none carries a session id,
+// transcript file, or cloud handle — so every worker used to skip dedupe entirely
+// and render as its own row: N copies of ".openclaw · bg · 0s ago". At the time
+// this was reported there were ~40 of them, burying every real session.
+
+const worker = (pid: number, cwd = '/Users/muqsit/.agents/openclaw/home/.openclaw'): ActiveSession => ({
+  context: 'headless',
+  kind: 'codex',
+  pid,
+  cwd,
+  status: 'idle',
+} as ActiveSession);
+
+describe('dedupeBySession', () => {
+  it('collapses indistinguishable worker processes into one row with a pidCount', () => {
+    const out = dedupeBySession([worker(1), worker(2), worker(3), worker(4)]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].pidCount).toBe(4);
+    expect(out[0].pid).toBe(1); // first row wins
+  });
+
+  it('keeps workers in different working directories apart', () => {
+    const out = dedupeBySession([
+      worker(1, '/Users/muqsit/.agents/openclaw/home/.openclaw'),
+      worker(2, '/Users/muqsit/src/github.com/muqsitnawaz'),
+    ]);
+
+    expect(out).toHaveLength(2);
+    expect(out.map((s) => s.pidCount)).toEqual([1, 1]);
+  });
+
+  it('keeps different agent binaries in one directory apart', () => {
+    const a = worker(1);
+    const b = { ...worker(2), kind: 'claude' };
+    expect(dedupeBySession([a, b])).toHaveLength(2);
+  });
+
+  it('still folds fork pids of one real session onto its session id', () => {
+    const forks = [1, 2, 3].map((pid) => ({
+      context: 'terminal',
+      kind: 'claude',
+      pid,
+      sessionId: 'abc-123',
+      cwd: '/repo',
+    })) as ActiveSession[];
+
+    const out = dedupeBySession(forks);
+    expect(out).toHaveLength(1);
+    expect(out[0].pidCount).toBe(3);
+  });
+
+  it('never folds two distinct cloud tasks that share a working directory', () => {
+    const cloud = (id: string): ActiveSession => ({
+      context: 'cloud',
+      kind: 'claude',
+      cwd: '/repo',
+      cloudTaskId: id,
+    } as ActiveSession);
+
+    expect(dedupeBySession([cloud('task-a'), cloud('task-b')])).toHaveLength(2);
+  });
+
+  it('passes through a row with no identity at all rather than folding it', () => {
+    const bare = { context: 'headless', kind: 'codex', pid: 9 } as ActiveSession;
+    const out = dedupeBySession([bare, { ...bare, pid: 10 }]);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -1189,17 +1189,33 @@ async function enrichProvenance(sessions: ActiveSession[]): Promise<void> {
 }
 
 /**
+ * Identity for a row the scan could not tie to a session: a daemon's worker
+ * processes (an OpenClaw gateway spawning `codex`, a supervisor pool) have no
+ * session id, no transcript file, and no cloud/run handle — nothing tells two of
+ * them apart, because nothing distinguishes them. Same binary + same working
+ * directory + same context IS the identity, so N indistinguishable workers
+ * collapse to one row carrying `pidCount: N`.
+ *
+ * Returns undefined with no cwd: without it there is no stable identity, and
+ * keying on kind alone would fold unrelated agents onto one row.
+ */
+function anonymousWorkerKey(s: ActiveSession): string | undefined {
+  if (!s.cwd) return undefined;
+  return `anon\0${s.kind}\0${s.context}\0${s.cwd}`;
+}
+
+/**
  * Collapse rows that resolve to the *same* session — a session with many
  * subagent/fork PIDs (all matched to one transcript file) would otherwise print
- * dozens of identical rows. Keyed by session id (falling back to the file), the
- * first row wins and carries a `pidCount`. Rows with no session identity (cloud,
- * unresolved headless) pass through untouched.
+ * dozens of identical rows. Keyed by session id, falling back to the transcript
+ * file, then the cloud/run handle, then {@link anonymousWorkerKey}. The first row
+ * wins and carries a `pidCount`.
  */
-function dedupeBySession(sessions: ActiveSession[]): ActiveSession[] {
+export function dedupeBySession(sessions: ActiveSession[]): ActiveSession[] {
   const out: ActiveSession[] = [];
   const byKey = new Map<string, ActiveSession>();
   for (const s of sessions) {
-    const key = s.sessionId || s.sessionFile;
+    const key = s.sessionId || s.sessionFile || s.cloudTaskId || s.agentId || anonymousWorkerKey(s);
     if (!key) { out.push(s); continue; }
     const existing = byKey.get(key);
     if (existing) {


### PR DESCRIPTION
## The bug

The Factory Floor was flooded with ~40 identical rows: `.openclaw · bg · 0s ago`, burying every real session.

They are not sessions. They are the OpenClaw gateway's worker processes on `mac-mini` — `codex app-server --listen stdio://`, cwd `~/.agents/.history/versions/openclaw/2026.3.8/home/.openclaw`. The process scan (`listUnattributedActive`) correctly picks them up as agent binaries, but:

```
active.ts:1202   const key = s.sessionId || s.sessionFile;
active.ts:1203   if (!key) { out.push(s); continue; }
```

None of them carries a `sessionId` or a `sessionFile` (verified against the live payload: 0 of them have a session id, topic, label, or `startedAtMs`), so every one **skipped dedupe entirely** and became its own row. N workers rendered as N indistinguishable rows.

The empty look follows from the same cause: no session id, so the name falls back to the cwd basename (`.openclaw`); `context: "headless"` gives the `bg` chip; no `startedAtMs` gives `0s ago`.

## The fix

Dedupe falls back through the remaining identities before giving up: cloud/run handle, then the worker's own identity (agent binary + context + working directory). Nothing distinguishes two such workers — because nothing *can* — so N of them collapse to one row carrying `pidCount: N`.

A row with no cwd still passes through untouched rather than folding onto an unrelated agent.

## Verified on the real host

Built this branch on `mac-mini` and ran both binaries against its live worker processes, six consecutive samples:

```
before (installed 1.20.74):  8 rows,  2 openclaw rows, pidCounts [1, 1]
after  (this branch):        7 rows,  1 openclaw row,  pidCounts [2]
```

OpenClaw had 2 workers alive at measurement time; it had ~40 when the flooding was reported.

The new test reproduces the bug — reverting the one-line key change fails it with `expected [...] to have a length of 1 but got 4`, the exact N-identical-rows behavior.

## Tests

`apps/cli/src/lib/session/active.dedupe.test.ts` — 6 cases, real `ActiveSession` records, no mocking: workers collapse with a `pidCount`; different cwds stay apart; different agent binaries stay apart; fork pids of a real session still fold onto their session id; two cloud tasks sharing a cwd never fold; an identity-less row still passes through.

`src/lib/session/` suite: 639 passed. The one failure (`discover.test.ts > getSessionRoots`) is pre-existing on clean `origin/main` — verified in a separate worktree.