### PR TITLE
fix(hosts,cloud): relate the remote-created session id back to the launcher for every agent

### DIFF
--- a/apps/cli/.changelog/next/host-cloud-session-id-reconcile.md
+++ b/apps/cli/.changelog/next/host-cloud-session-id-reconcile.md
@@ -1,0 +1,26 @@
+- **Host and cloud runs are now mappable in `agents sessions` for every agent, not
+  just Claude.** A `--host` dispatch forced a session id only for Claude (the sole
+  agent that accepts `--session-id`); every other agent's remote run coined its own
+  id that the launcher never learned, so the run was orphaned in `agents sessions`
+  and couldn't be resumed by id. The remote run now prints its resolved session id
+  as a one-line stdout sentinel (via a new internal `--emit-session-id` flag the
+  dispatch forwards); the launcher parses it out of the followed log and stamps it
+  on the host task, so `agents sessions`/resume-by-id work for Codex, Gemini, and
+  the rest. Source: `apps/cli/src/lib/hosts/session-marker.ts`,
+  `apps/cli/src/lib/hosts/session-index.ts`, `apps/cli/src/lib/hosts/run-target.ts`,
+  `apps/cli/src/lib/exec.ts`.
+
+- **`agents cloud run` reconciles into the session index at dispatch.** The cloud
+  task store (`tasks.db`) and the session index were disjoint: a cloud run wrote only
+  the store, and `agents sessions` learned of it only later, via a proxy discovery.
+  Now every cloud dispatch (and every status poll) registers a session row keyed by
+  the real execution id with a `[cloud/<status>]` label, so a launch is mappable to a
+  session immediately. Source: `apps/cli/src/lib/cloud/session-index.ts`,
+  `apps/cli/src/lib/cloud/store.ts`.
+
+- **Codex Cloud dispatch no longer fabricates a task id.** When `codex cloud exec`
+  didn't print a parseable id, the provider minted a synthetic `codex-<timestamp>` —
+  an id that could never match the real execution, silently breaking status, list,
+  and session reconcile. It now also scans stderr for the id and, on a genuine miss,
+  fails loud pointing at `agents cloud list` rather than persisting a bogus id.
+  Source: `apps/cli/src/lib/cloud/codex.ts`.

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -89,6 +89,7 @@ interface ExecCommandActionOptions {
   tailscale?: boolean; // --tailscale / --no-tailscale: tri-state net-mode override
   secretsKeys?: string; // --secrets-keys: comma-separated key subset for --secrets bundles
   allowExpired?: boolean; // --allow-expired: skip expiry pre-run abort for secrets
+  emitSessionId?: boolean; // internal: forwarded by --host dispatch so the remote run prints its session id (hosts/session-marker.ts)
 }
 
 export interface RunAccountPickerRequest {
@@ -622,6 +623,12 @@ export function registerRunCommand(program: Command): void {
   // `--on` and `--computer` are hidden aliases of `--host` — same behavior.
   runCmd.addOption(new Option('--on <name>', 'Alias of --host.').hideHelp());
   runCmd.addOption(new Option('--computer <name>', 'Alias of --host.').hideHelp());
+
+  // Internal: the `--host` dispatch forwards this so the REMOTE run prints its
+  // resolved session id as a one-line stdout sentinel (hosts/session-marker.ts),
+  // letting the launcher relate the remote-created session back to itself for
+  // every agent — not just Claude, whose id it forces up front.
+  runCmd.addOption(new Option('--emit-session-id', 'internal: print the resolved session id for a --host launcher to capture').hideHelp());
 
   // Required for the documented `agents run <agent> [prompt] -- <native flags>`
   // passthrough: commander >=13 rejects excess operands by default, so any
@@ -2219,6 +2226,10 @@ export function registerRunCommand(program: Command): void {
         toolsRestrict: workflowToolsRestrict,
         mcpConfigPath: workflowMcpConfigPath,
         passthroughArgs,
+        // Set only on the REMOTE side of a `--host` dispatch (the launcher
+        // forwards `--emit-session-id`): print the resolved session id as a
+        // stdout sentinel so the launcher captures the id this run coined.
+        emitSessionId: options.emitSessionId === true,
       };
 
       if (options.interactive && options.headless) {

--- a/apps/cli/src/lib/cloud/codex.test.ts
+++ b/apps/cli/src/lib/cloud/codex.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { extractTaskId } from './codex.js';
+
+// The dispatch path keys everything (status, list, session reconcile) on the id
+// extractTaskId returns. The old fallback minted a synthetic `codex-<ts>` when
+// this returned undefined — an id that could never match the real execution — so
+// these pin the parser AND the fact that a genuine miss yields undefined (which
+// dispatch now turns into a loud error, never a fabricated id).
+describe('extractTaskId', () => {
+  it('reads the id from JSON output', () => {
+    expect(extractTaskId('{"id":"task_abc123","status":"queued"}')).toBe('task_abc123');
+    expect(extractTaskId('{"task_id":"019fb-real-exec"}')).toBe('019fb-real-exec');
+  });
+
+  it('reads a UUID printed in free text', () => {
+    expect(extractTaskId('Started execution 3bc93e7d-390e-4126-b0cb-f668a6d63bd8 on env foo'))
+      .toBe('3bc93e7d-390e-4126-b0cb-f668a6d63bd8');
+  });
+
+  it('reads a task_/id: key line', () => {
+    expect(extractTaskId('task_id: task_9f3axyz')).toBe('task_9f3axyz');
+    expect(extractTaskId('  id = codex_run_42  ')).toBe('codex_run_42');
+  });
+
+  it('returns undefined when no id is present — dispatch must fail loud, not fabricate one', () => {
+    expect(extractTaskId('dispatched, see the web UI')).toBeUndefined();
+    expect(extractTaskId('')).toBeUndefined();
+  });
+
+  it('never invents a codex-<timestamp> id', () => {
+    // The removed synthetic fallback returned `codex-<Date.now()>`; a genuine
+    // miss must be undefined so dispatch fails loud, never a fabricated id.
+    const out = extractTaskId('no id here');
+    expect(out).toBeUndefined();
+    expect(out === undefined || !/^codex-\d+$/.test(out)).toBe(true);
+  });
+});

--- a/apps/cli/src/lib/cloud/codex.ts
+++ b/apps/cli/src/lib/cloud/codex.ts
@@ -154,8 +154,21 @@ export class CodexCloudProvider implements CloudProvider {
       throw new Error(`codex cloud exec failed: ${stderr || stdout}`);
     }
 
-    // Parse task ID from output. Codex typically prints the task ID.
-    const taskId = extractTaskId(stdout) ?? `codex-${Date.now()}`;
+    // The task id is the ONLY handle to the just-created execution — status,
+    // list, and the session-index reconcile all key on it. Codex prints it to
+    // stdout (JSON or a task_/id: line); some builds route it to stderr, so scan
+    // both. A synthetic `codex-<ts>` id was the old fallback here — it can never
+    // match the real execution, so it silently broke every follow-up. If the id
+    // genuinely can't be parsed, fail loudly and point at `agents cloud list`
+    // (which recovers the newest execution) rather than persist a bogus id.
+    const taskId = extractTaskId(stdout) ?? extractTaskId(stderr);
+    if (!taskId) {
+      throw new Error(
+        'codex cloud exec did not report a task id — the run may have dispatched, but ' +
+          'without the id it cannot be tracked. Find it with `agents cloud list --provider codex`, ' +
+          `then \`agents cloud status <id>\`.\nRaw output: ${(stdout || stderr).trim().slice(0, 400)}`,
+      );
+    }
     const now = new Date().toISOString();
 
     return {
@@ -268,7 +281,7 @@ export class CodexCloudProvider implements CloudProvider {
 }
 
 /** Extract a task ID from codex CLI output (JSON field, key:value line, or UUID pattern). */
-function extractTaskId(output: string): string | undefined {
+export function extractTaskId(output: string): string | undefined {
   // Try JSON first
   try {
     const data = JSON.parse(output);

--- a/apps/cli/src/lib/cloud/session-index.ts
+++ b/apps/cli/src/lib/cloud/session-index.ts
@@ -1,0 +1,68 @@
+/**
+ * Register cloud-dispatched tasks into the LOCAL session index, keyed by the
+ * real execution id, so a launch is mappable to a session immediately.
+ *
+ * The cloud store (`tasks.db`) and the session index (`sessions` table) were two
+ * disjoint stores: a `agents cloud run` wrote only the store, and the session
+ * index learned about the run only later, via `discoverCloudSessions` hitting the
+ * proxy. Until that discovery ran there was no launch→session mapping at all —
+ * the run was orphaned in `agents sessions` exactly like the non-Claude host runs.
+ *
+ * This mirrors hosts/session-index.ts: the transcript is remote (fetched on
+ * demand by session/cloud.ts), so the row is registered with an EMPTY `file_path`
+ * — the sentinel db.js's stale-row filter treats as "always live" — and a
+ * `[cloud/<status>]` label. The row is written at dispatch and refreshed on every
+ * status poll so the label tracks the task's lifecycle. Non-session-agent cloud
+ * providers (a task whose agent has no transcript format) are skipped: there is
+ * nothing to resolve or resume by id.
+ */
+
+import { upsertSession } from '../session/db.js';
+import type { SessionAgentId } from '../session/types.js';
+import { SESSION_AGENTS } from '../session/types.js';
+import type { CloudTask } from './types.js';
+
+/** The execution-id charset the session index will accept as a row id. */
+const EXECUTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/;
+
+/** Context a cloud task needs to become a session row — the LOCAL dir it was launched from. */
+export interface CloudSessionContext {
+  /** Local directory `agents cloud run` was invoked from. Defaults to process.cwd(). */
+  cwd?: string;
+}
+
+/**
+ * Register (or refresh) a cloud task in the local session index. No-op when the
+ * task's agent isn't a known session agent, or its id isn't a usable execution id
+ * (never a fabricated `codex-<ts>` — codex.ts fails loud instead of minting one,
+ * but guard here too so a bad id can never seed a bogus row). Best-effort: a
+ * failed index write must never break the dispatch/poll it rides on.
+ */
+export function registerCloudSession(task: CloudTask, ctx: CloudSessionContext = {}): void {
+  if (!SESSION_AGENTS.includes(task.agent as SessionAgentId)) return;
+  if (!task.id || !EXECUTION_ID_RE.test(task.id)) return;
+  try {
+    upsertSession(
+      {
+        id: task.id,
+        shortId: task.id.slice(0, 8),
+        agent: task.agent as SessionAgentId,
+        timestamp: task.createdAt,
+        lastActivity: task.updatedAt,
+        cwd: ctx.cwd ?? process.cwd(),
+        project: task.repo ?? task.repos?.[0],
+        // Remote transcript — no local file yet. Empty file_path is the sentinel
+        // the DB stale-filter treats as "always live" (see hosts/session-index.ts).
+        filePath: '',
+        topic: task.prompt.split('\n')[0]?.slice(0, 120) || undefined,
+        // Mirrors session/cloud.ts's discovered label, so the dispatch-time row and
+        // a later proxy-discovered row read the same in `agents sessions`.
+        label: `[cloud/${task.status}]${task.branch ? ` ${task.branch}` : ''}`,
+        prUrl: task.prUrl,
+      },
+      '',
+    );
+  } catch {
+    /* index write is best-effort; the task is already persisted in the cloud store */
+  }
+}

--- a/apps/cli/src/lib/cloud/store.test.ts
+++ b/apps/cli/src/lib/cloud/store.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate BOTH stores under a temp HOME before any import touches them: the cloud
+// tasks.db and the sessions index db read their base dir lazily at first use.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-cloudstore-'));
+process.env.HOME = TEST_HOME;
+
+import { insertTask, updateTaskStatus, getTaskById } from './store.js';
+import { registerCloudSession } from './session-index.js';
+import { findSessionsById, closeDB } from '../session/db.js';
+import type { CloudTask } from './types.js';
+
+function cloudTask(overrides: Partial<CloudTask> = {}): CloudTask {
+  return {
+    id: '019fb-exec-codex-1',
+    provider: 'codex',
+    status: 'queued',
+    agent: 'codex',
+    prompt: 'refactor the parser\nsecond line',
+    repo: 'phnx-labs/agents-cli',
+    branch: 'feat/x',
+    createdAt: '2026-07-04T00:00:00.000Z',
+    updatedAt: '2026-07-04T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('insertTask reconciles the cloud store into the session index', () => {
+  it('registers a session row keyed by the real execution id at dispatch', () => {
+    insertTask(cloudTask());
+
+    const byId = findSessionsById('019fb-exec-codex-1');
+    expect(byId).toHaveLength(1);
+    expect(byId[0].agent).toBe('codex');
+    expect(byId[0].label).toBe('[cloud/queued] feat/x');
+    expect(byId[0].filePath).toBe(''); // remote transcript sentinel
+    expect(byId[0].topic).toBe('refactor the parser');
+  });
+
+  it('refreshes the [cloud/<status>] label on a status poll', () => {
+    insertTask(cloudTask({ id: '019fb-exec-codex-2', status: 'queued' }));
+    updateTaskStatus('019fb-exec-codex-2', 'running');
+    expect(findSessionsById('019fb-exec-codex-2')[0].label).toBe('[cloud/running] feat/x');
+
+    updateTaskStatus('019fb-exec-codex-2', 'completed', { prUrl: 'https://github.com/o/r/pull/9' });
+    const done = findSessionsById('019fb-exec-codex-2')[0];
+    expect(done.label).toBe('[cloud/completed] feat/x');
+    expect(done.prUrl).toBe('https://github.com/o/r/pull/9');
+    // The store row itself carries the PR url the poll wrote.
+    expect(getTaskById('019fb-exec-codex-2')!.prUrl).toBe('https://github.com/o/r/pull/9');
+  });
+});
+
+describe('registerCloudSession guards', () => {
+  it('skips a provider whose agent is not session-tracked (nothing to resolve by id)', () => {
+    registerCloudSession({ ...cloudTask({ id: 'factory-run-1' }), provider: 'factory', agent: 'factory' });
+    expect(findSessionsById('factory-run-1')).toHaveLength(0);
+  });
+
+  it('never seeds a row for a fabricated codex-<ts> id', () => {
+    // Belt-and-suspenders: codex.ts fails loud instead of minting one, but the
+    // charset guard here also rejects an id that isn't a usable execution id.
+    registerCloudSession(cloudTask({ id: 'codex-1720000000000 not valid' }));
+    expect(findSessionsById('codex-1720000000000 not valid')).toHaveLength(0);
+
+    closeDB();
+  });
+});

--- a/apps/cli/src/lib/cloud/store.ts
+++ b/apps/cli/src/lib/cloud/store.ts
@@ -12,6 +12,7 @@ import * as os from 'os';
 import Database from '../sqlite.js';
 import type { CloudTask, CloudProviderId, CloudTaskStatus } from './types.js';
 import { getCloudDir } from '../state.js';
+import { registerCloudSession } from './session-index.js';
 
 const CLOUD_DIR = getCloudDir();
 const DB_PATH = path.join(CLOUD_DIR, 'tasks.db');
@@ -66,6 +67,11 @@ export function insertTask(task: CloudTask): void {
     task.createdAt,
     task.updatedAt,
   );
+  // Every cloud dispatch flows through here, so this is the one chokepoint that
+  // reconciles the cloud store with the session index: register a session row
+  // keyed by the real execution id so the launch is mappable to a session
+  // immediately, not only after a later proxy discovery (see session-index.ts).
+  registerCloudSession(task);
 }
 
 /** Update a task's status and optionally patch summary, PR URL, or branch. */
@@ -89,6 +95,12 @@ export function updateTaskStatus(id: string, status: CloudTaskStatus, extra?: Pa
   params.push(id);
 
   db().prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = ?`).run(...params);
+  // Keep the session index in lockstep with the store on every poll: refresh the
+  // row so its `[cloud/<status>]` label tracks the task's lifecycle (and picks up
+  // a newly-opened PR url). Reads the just-written row so the label reflects the
+  // update we just made, not a stale snapshot.
+  const updated = getTaskById(id);
+  if (updated) registerCloudSession(updated);
 }
 
 /** Fetch a single task by its provider-assigned ID, or null if not found locally. */

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -20,6 +20,8 @@ import { getShimsDir, getHistoryDir } from './state.js';
 import { resolveCodexHome } from './codex-home.js';
 import { readCodexConfiguredModel } from './shims.js';
 import { writePidSessionEntry, extractSessionIdArg } from './session/pid-registry.js';
+import { loadHookSessionIndex, resolveHookSessionId } from './session/hook-sessions.js';
+import { sessionIdMarkerLine } from './hosts/session-marker.js';
 import { recordRunName } from './session/run-names.js';
 import { mailboxDir, isValidMailboxId } from './mailbox.js';
 import { composeWin32CommandLine } from './platform/index.js';
@@ -223,6 +225,15 @@ export interface ExecOptions {
    * (output is mirrored to the parent's stdout exactly like stdio:'inherit').
    */
   captureStdoutTail?: boolean;
+  /**
+   * Print the run's resolved session id to stdout as a one-line sentinel once the
+   * child exits (see hosts/session-marker.ts). Set by the `--host` dispatch so the
+   * LAUNCHER can relate the remote-created session back to itself — Claude's id is
+   * forced up front, but every other agent coins its own id on the remote box, and
+   * this marker is how that id rides the followed log home. Headless-only and inert
+   * for interactive runs (no combined log to parse).
+   */
+  emitSessionId?: boolean;
   /**
    * Escape hatch for the interactive tmux spawn-wrap (see shouldWrapInTmux):
    * when true, spawn the agent directly instead of inside a shared-socket tmux
@@ -1276,6 +1287,35 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
 }
 
 /**
+ * Print the run's resolved session id as a one-line stdout sentinel so a `--host`
+ * launcher can relate the remote-created session back to itself (see the
+ * `emitSessionId` option and hosts/session-marker.ts).
+ *
+ * For Claude the id was forced up front (`options.sessionId`, wired as
+ * `--session-id`), so it's authoritative with no lookup. Every other agent coined
+ * its OWN id, which its SessionStart hook recorded under this run's launchId — the
+ * exact join key `agents sessions --active` uses — so we read it back from the hook
+ * index by launchId (falling back to the child pid the hook may have recorded
+ * under). Nothing to emit when the hook hasn't landed an id (hookless harness):
+ * the launcher simply keeps the un-mapped task, never a fabricated id.
+ */
+function emitResolvedSessionId(options: ExecOptions, launchId: string, childPid: number | undefined): void {
+  let sessionId = options.sessionId;
+  if (!sessionId) {
+    try {
+      sessionId = resolveHookSessionId(loadHookSessionIndex(), {
+        pid: childPid ?? 0,
+        kind: options.agent,
+        launchId,
+      });
+    } catch {
+      /* hook index unreadable — emit nothing rather than a guess */
+    }
+  }
+  if (sessionId) process.stdout.write(sessionIdMarkerLine(sessionId));
+}
+
+/**
  * Spawn an agent process and return its exit code plus a tee'd copy of stderr.
  *
  * Stderr is always piped so the caller can inspect it (e.g., for rate-limit
@@ -1488,6 +1528,11 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
       // Budget kill resolves with a DISTINCT non-zero exit so CI/headless and
       // teams/cloud can tell a budget termination apart from a normal failure.
       const exitCode = budgetKilled ? BUDGET_KILL_EXIT_CODE : (code ?? 0);
+      // Relate the session id back to a `--host` launcher (see the emitSessionId
+      // doc). Claude's id is the one we forced; every other agent coined its own,
+      // which the SessionStart hook recorded under this run's launchId — resolve
+      // and print it as a one-line sentinel that rides the followed log home.
+      if (options.emitSessionId) emitResolvedSessionId(options, launchId, child.pid);
       timer.end({ exitCode, status: budgetKilled ? 'budget_killed' : code === 0 ? 'success' : 'failed' });
       resolve({ exitCode, stderr: stderrBuffer, stdout: stdoutTail });
     });

--- a/apps/cli/src/lib/hosts/dispatch.ts
+++ b/apps/cli/src/lib/hosts/dispatch.ts
@@ -335,6 +335,13 @@ export interface DispatchOptions {
   name?: string;
   /** Resume an existing session on the host by id (via `agents run --resume`). */
   resume?: string;
+  /**
+   * Forward `--emit-session-id` so the remote run prints its resolved session id
+   * as a stdout sentinel (hosts/session-marker.ts). The launcher parses that id
+   * out of the followed log and stamps it on the task — the join that maps a
+   * remote-created session back home for agents that don't take `--session-id`.
+   */
+  emitSessionId?: boolean;
   /** Stream progress and block until completion (default true). */
   follow?: boolean;
   timeoutMs?: number;
@@ -378,6 +385,7 @@ export function buildRunForwardedArgs(opts: DispatchOptions): string[] {
   if (opts.name) args.push('--name', opts.name);
   if (opts.resume) args.push('--resume', opts.resume);
   else if (opts.sessionId) args.push('--session-id', opts.sessionId);
+  if (opts.emitSessionId) args.push('--emit-session-id');
   if (opts.passthroughArgs && opts.passthroughArgs.length > 0) args.push('--', ...opts.passthroughArgs);
   return args;
 }

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -107,6 +107,7 @@ export const RUN_OPTION_FORWARDING: Record<string, RunOptionForwarding> = {
   yes: 'forward', // a detached remote run can't answer the budget-confirm prompt
   acp: 'forward', // the remote CLI routes through ACP on ITS side of the wire
   autoSecrets: 'forward', // workflow frontmatter secrets resolve on the REMOTE keychain
+  emitSessionId: 'forward', // remote prints its session id as a stdout sentinel the launcher captures (session-marker.ts)
 
   // rejected — cannot cross the SSH boundary; fail loud, never degrade
   secrets: 'reject',

--- a/apps/cli/src/lib/hosts/run-target.ts
+++ b/apps/cli/src/lib/hosts/run-target.ts
@@ -20,7 +20,7 @@ import type { Host } from './types.js';
 import { resolveHost, resolveHostByCap } from './registry.js';
 import { dispatchToHost } from './dispatch.js';
 import type { DispatchResult } from './dispatch.js';
-import { registerHostSession } from './session-index.js';
+import { registerHostSession, captureRemoteSessionId } from './session-index.js';
 import type { HostCredentials } from './credentials.js';
 
 /**
@@ -99,14 +99,26 @@ export interface HostPromptRun {
 }
 
 /**
- * Dispatch a headless prompt run onto a resolved host: mint the forced session
- * id (Claude is the only agent that accepts `--session-id`; on resume the
- * remote session keeps its id), launch detached over SSH, and register the run
- * in the LOCAL session index. Returns the task record and the remote exit code
- * (`-1` = follow window closed while the run continues).
+ * Dispatch a headless prompt run onto a resolved host, then relate the run's
+ * session id back to this launcher for EVERY agent — not just Claude.
+ *
+ * Claude is the only agent that accepts a forced `--session-id`, so we mint one
+ * up front and know it immediately. For every other agent the remote run coins
+ * its OWN id; we forward `--emit-session-id` so the remote prints that id as a
+ * stdout sentinel (hosts/session-marker.ts), and once the follow returns we parse
+ * it out of the mirrored local log and stamp it on the task before registering —
+ * so `agents sessions`/resume-by-id can map the discovered session home. On
+ * resume the remote session keeps its existing id (passed through, no capture).
+ *
+ * Returns the task record and the remote exit code (`-1` = follow window closed
+ * while the run continues).
  */
 export async function dispatchPromptToHost(host: Host, opts: HostPromptRun): Promise<DispatchResult> {
-  const sessionId = opts.agent === 'claude' && !opts.resume ? randomUUID() : undefined;
+  const forcedSessionId = opts.agent === 'claude' && !opts.resume ? randomUUID() : undefined;
+  // Ask the remote to print its resolved id whenever we did NOT force one (every
+  // non-Claude agent, and Claude-on-resume where the id is already known). No-op
+  // when the run isn't followed — nothing tails the log to catch the marker.
+  const emitSessionId = !forcedSessionId && !opts.resume && opts.follow !== false;
   const result = await dispatchToHost(host, {
     agent: opts.agent,
     prompt: opts.prompt,
@@ -114,7 +126,8 @@ export async function dispatchPromptToHost(host: Host, opts: HostPromptRun): Pro
     mode: opts.mode,
     model: opts.model,
     remoteCwd: opts.remoteCwd,
-    sessionId,
+    sessionId: forcedSessionId,
+    emitSessionId,
     name: opts.name,
     resume: opts.resume,
     follow: opts.follow !== false,
@@ -139,6 +152,9 @@ export async function dispatchPromptToHost(host: Host, opts: HostPromptRun): Pro
     passthroughArgs: opts.passthroughArgs,
     copyCreds: opts.copyCreds,
   });
-  registerHostSession(result.task, { cwd: opts.cwd ?? process.cwd(), prompt: opts.prompt });
-  return result;
+  // Capture the remote-coined id from the followed log (non-Claude); harmlessly a
+  // no-op when the task already carries a forced/resumed id or no marker landed.
+  const task = emitSessionId ? captureRemoteSessionId(result.task) ?? result.task : result.task;
+  registerHostSession(task, { cwd: opts.cwd ?? process.cwd(), prompt: opts.prompt });
+  return { ...result, task };
 }

--- a/apps/cli/src/lib/hosts/session-index.test.ts
+++ b/apps/cli/src/lib/hosts/session-index.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { hostSessionMeta, registerHostSession, registerInteractiveHostSession } from './session-index.js';
+import { hostSessionMeta, registerHostSession, registerInteractiveHostSession, captureRemoteSessionId } from './session-index.js';
 import { findSessionsById, querySessions, closeDB } from '../session/db.js';
-import type { HostTask } from './tasks.js';
+import { saveTask, loadTask, localLogPath, hostsCacheDir, type HostTask } from './tasks.js';
+import { sessionIdMarkerLine } from './session-marker.js';
 
 // Isolate the sessions DB under a temp HOME. db.js reads its base dir lazily
 // (at getDB() time), so setting HOME here — before any test calls getDB — is
@@ -98,6 +99,51 @@ describe('registerHostSession', () => {
     // real local session with a missing file would be dropped here.
     const all = querySessions({ idPrefix: 'aaaaaaaa' });
     expect(all).toHaveLength(1);
+
+    closeDB();
+  });
+});
+
+describe('captureRemoteSessionId', () => {
+  // The full non-Claude host path: a run that took no forced --session-id, whose
+  // remote coined its own id and printed it via --emit-session-id into the log.
+  function writeLog(id: string, marker: string): void {
+    fs.mkdirSync(hostsCacheDir(), { recursive: true });
+    fs.writeFileSync(localLogPath(id), `booting codex...\ndid the work\n${marker}exited 0\n`);
+  }
+
+  it('captures the remote-coined id from the followed log and stamps it on the task', () => {
+    const t = task({ id: 'feed0001', agent: 'codex', sessionId: undefined });
+    saveTask(t);
+    writeLog('feed0001', sessionIdMarkerLine('codex-real-9f3a'));
+
+    const updated = captureRemoteSessionId(t);
+    expect(updated).not.toBeNull();
+    expect(updated!.sessionId).toBe('codex-real-9f3a');
+    // Persisted, not just returned — so findTaskBySessionId works after this.
+    expect(loadTask('feed0001')!.sessionId).toBe('codex-real-9f3a');
+
+    // And the captured id makes the run registerable + resolvable by id.
+    registerHostSession(updated!, { cwd: '/home/me/proj', prompt: 'do it' });
+    expect(findSessionsById('codex-real-9f3a')).toHaveLength(1);
+  });
+
+  it('is a no-op when the task already carries a forced id (never overwrites Claude/resume)', () => {
+    const t = task({ id: 'feed0002', agent: 'claude', sessionId: 'forced-claude-id' });
+    saveTask(t);
+    // Even if a stray marker sat in the log, the authoritative forced id wins.
+    writeLog('feed0002', sessionIdMarkerLine('should-be-ignored'));
+    expect(captureRemoteSessionId(t)).toBeNull();
+    expect(loadTask('feed0002')!.sessionId).toBe('forced-claude-id');
+  });
+
+  it('returns null when the log carries no marker (hookless remote agent)', () => {
+    const t = task({ id: 'feed0003', agent: 'codex', sessionId: undefined });
+    saveTask(t);
+    fs.mkdirSync(hostsCacheDir(), { recursive: true });
+    fs.writeFileSync(localLogPath('feed0003'), 'ran, but printed no session marker\n');
+    expect(captureRemoteSessionId(t)).toBeNull();
+    expect(loadTask('feed0003')!.sessionId).toBeUndefined();
 
     closeDB();
   });

--- a/apps/cli/src/lib/hosts/session-index.ts
+++ b/apps/cli/src/lib/hosts/session-index.ts
@@ -13,10 +13,12 @@
  * `[cloud/<status>]` convention.
  */
 
+import * as fs from 'fs';
 import { upsertSession } from '../session/db.js';
 import type { SessionMeta, SessionAgentId } from '../session/types.js';
 import { SESSION_AGENTS } from '../session/types.js';
-import type { HostTask } from './tasks.js';
+import { localLogPath, updateTask, type HostTask } from './tasks.js';
+import { parseSessionIdMarker } from './session-marker.js';
 
 export interface HostSessionContext {
   /** Local directory the `agents run --host` was invoked from. */
@@ -65,6 +67,35 @@ export function registerHostSession(task: HostTask, ctx: HostSessionContext): vo
   } catch {
     /* index write is best-effort; the run is already live on the host */
   }
+}
+
+/**
+ * Relate a remote-created session id back to a followed host dispatch.
+ *
+ * The remote run (dispatched with `--emit-session-id`) prints its resolved id as
+ * a stdout sentinel (see session-marker.ts) that rides the followed log into the
+ * task's local mirror. Read that mirror, parse the id, and stamp it on the task
+ * so `findTaskBySessionId` and the session-index registration work for agents
+ * that never take a forced `--session-id` — closing the gap where every
+ * non-Claude host run was orphaned.
+ *
+ * Returns the updated task when an id was captured (and differs from what's on
+ * the record), else null. A task that already carries an id (Claude's forced id,
+ * a resume) is left untouched — the marker only fills a genuinely empty slot, so
+ * it can never overwrite an authoritative id with a stale echo. Best-effort: a
+ * missing/unreadable mirror or absent marker yields null, never an exception.
+ */
+export function captureRemoteSessionId(task: HostTask): HostTask | null {
+  if (task.sessionId) return null;
+  let text: string;
+  try {
+    text = fs.readFileSync(localLogPath(task.id), 'utf8');
+  } catch {
+    return null; // no local mirror (unfollowed run, or read raced the follow)
+  }
+  const captured = parseSessionIdMarker(text);
+  if (!captured) return null;
+  return updateTask(task.id, { sessionId: captured });
 }
 
 export interface InteractiveHostSessionContext {

--- a/apps/cli/src/lib/hosts/session-marker.test.ts
+++ b/apps/cli/src/lib/hosts/session-marker.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { sessionIdMarkerLine, parseSessionIdMarker } from './session-marker.js';
+
+describe('sessionIdMarkerLine', () => {
+  it('frames the id on its own line so it lands cleanly after any agent output', () => {
+    const line = sessionIdMarkerLine('abc-123');
+    expect(line).toBe('\n@@AGENTS_SESSION_ID abc-123@@\n');
+  });
+
+  it('round-trips through the parser', () => {
+    const id = '11111111-2222-3333-4444-555555555555';
+    expect(parseSessionIdMarker(sessionIdMarkerLine(id))).toBe(id);
+  });
+});
+
+describe('parseSessionIdMarker', () => {
+  it('extracts the id from a chunk of surrounding log output', () => {
+    const log =
+      'booting codex...\nrunning tools\n' +
+      sessionIdMarkerLine('01JABCDXYZ_session-9') +
+      'done\n';
+    expect(parseSessionIdMarker(log)).toBe('01JABCDXYZ_session-9');
+  });
+
+  it('returns null when no marker is present', () => {
+    expect(parseSessionIdMarker('plain output with no marker\n')).toBeNull();
+  });
+
+  it('takes the LAST marker so an id echoed earlier cannot mask the real trailing one', () => {
+    // An agent that literally echoes the sentinel token in its own output must
+    // never fool the parser — the real id the run prints comes last.
+    const log =
+      '@@AGENTS_SESSION_ID echoed-fake@@ (agent quoted this)\n' +
+      sessionIdMarkerLine('real-final-id');
+    expect(parseSessionIdMarker(log)).toBe('real-final-id');
+  });
+
+  it('rejects a malformed frame rather than returning a bogus id', () => {
+    // A space in the token can't be a session id — better null than a fabricated id.
+    expect(parseSessionIdMarker('@@AGENTS_SESSION_ID not a real id@@\n')).toBeNull();
+    // Missing suffix → incomplete frame.
+    expect(parseSessionIdMarker('@@AGENTS_SESSION_ID dangling\n')).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/hosts/session-marker.ts
+++ b/apps/cli/src/lib/hosts/session-marker.ts
@@ -1,0 +1,52 @@
+/**
+ * Relate a remote-created session id back to the launching agent.
+ *
+ * A host dispatch (`agents run --host`) launches `agents run` on the remote box.
+ * Only Claude accepts a forced `--session-id`, so for every OTHER agent the
+ * remote run coins its OWN session id (via its SessionStart hook) and the
+ * launcher never learns it — the run is orphaned in `agents sessions`.
+ *
+ * This module closes that gap without an extra SSH round-trip: the dispatch
+ * forwards `--emit-session-id`, which makes the remote `agents run` print its
+ * resolved session id as a stable one-line sentinel to stdout. That line rides
+ * the same combined log the follow already mirrors locally, so the launcher
+ * parses the id straight out of the streamed output and stamps it on the task.
+ *
+ * The marker is a fixed ASCII frame with the id on its own line. A real session
+ * id (`[A-Za-z0-9._-]`) never contains the marker's own bytes, so the parser can
+ * scan for the LAST occurrence and stay robust to an agent echoing the token in
+ * its own output.
+ */
+
+const MARKER_PREFIX = '@@AGENTS_SESSION_ID ';
+const MARKER_SUFFIX = '@@';
+
+/** Only characters a real agent session id can hold — no marker bytes, no spaces. */
+const SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/;
+
+/**
+ * The single line the remote run prints to stdout so the launcher can capture
+ * the session id the remote coined. Newline-framed on both sides so it lands on
+ * its own line regardless of what the agent last wrote.
+ */
+export function sessionIdMarkerLine(sessionId: string): string {
+  return `\n${MARKER_PREFIX}${sessionId}${MARKER_SUFFIX}\n`;
+}
+
+/**
+ * Extract the session id from a chunk of followed remote output, or null when no
+ * marker is present. Scans for the LAST marker (so an id echoed into the log
+ * earlier can never mask the real trailing sentinel) and validates the captured
+ * token against the session-id charset — a malformed frame yields null rather
+ * than a bogus id that could never match a real session.
+ */
+export function parseSessionIdMarker(text: string): string | null {
+  const last = text.lastIndexOf(MARKER_PREFIX);
+  if (last === -1) return null;
+  const start = last + MARKER_PREFIX.length;
+  const end = text.indexOf(MARKER_SUFFIX, start);
+  if (end === -1) return null;
+  const id = text.slice(start, end).trim();
+  if (!SESSION_ID_RE.test(id)) return null;
+  return id;
+}

--- a/apps/cli/src/lib/hosts/tasks.ts
+++ b/apps/cli/src/lib/hosts/tasks.ts
@@ -30,10 +30,14 @@ export interface HostTask {
    */
   name?: string;
   /**
-   * The agent session id the remote run was launched with (Claude only — the
-   * only agent that accepts `--session-id` to force a NEW session's id). Lets
-   * `agents sessions`/resume-by-id map a discovered session back to the host it
-   * lives on. Absent for agents that don't take an explicit session id.
+   * The remote run's agent session id, so `agents sessions`/resume-by-id can map
+   * a discovered session back to the host it lives on. Two sources: for Claude
+   * (the only agent that accepts `--session-id`) it's the id we FORCED at
+   * dispatch; for every other agent it's the id the remote COINED, captured from
+   * the run's stdout sentinel (`--emit-session-id`, see session-marker.ts) once
+   * the follow returns and stamped on the record via `captureRemoteSessionId`.
+   * Absent only until that capture lands — e.g. an unfollowed (`--no-follow`)
+   * non-Claude run whose id the reconcile path fills in later.
    */
   sessionId?: string;
   /** Remote paths (under the host's ~/.agents/.cache/hosts/). */

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -379,6 +379,11 @@ export function closeDB(): void {
   if (dbInstance) {
     dbInstance.close();
     dbInstance = null;
+    // Closing the connection finalizes every prepared statement it owns. Drop
+    // the cached upsert/FTS statements too, so the next getDB() rebuilds them
+    // against the fresh connection instead of re-running a finalized statement
+    // (which throws "statement has been finalized" on the first upsert).
+    cachedStmts = {};
   }
 }
 


### PR DESCRIPTION
## Problem

When an agent is dispatched to a picked host (SSH) or to the cloud, the launcher could not relate the remote-created session back to itself for anything but Claude.

- **Host runs:** a `--host` dispatch forced a session id only for Claude — the sole agent that accepts `--session-id` (`run-target.ts`, `dispatch.ts:380`/`:504`). Every other agent's remote run coined its own id that the launcher never learned, so `session-index.ts` no-op'd (`if (!id) return null`) and the run was orphaned in `agents sessions`, unresumable by id.
- **Cloud runs:** the cloud task store (`tasks.db`) and the session index (`sessions` table) were disjoint. `agents cloud run` wrote only the store (`insertTask`), so a launch had no session mapping until a later proxy discovery — orphaned exactly like the non-Claude host runs.
- **Codex Cloud:** on a missing task id, `codex.ts` fabricated a synthetic `codex-${Date.now()}` id that could never match the real execution, silently breaking status, list, and reconcile.

## What changed

**1. Capture the remote session id for every agent (host).**
The remote run now prints its resolved session id as a one-line stdout sentinel when the dispatch forwards a new internal `--emit-session-id` flag (`hosts/session-marker.ts`). For non-Claude agents the id comes from the SessionStart hook via the launchId join — the same authoritative source `agents sessions --active` uses, not a guess. That line rides the followed log into the task's local mirror, where `captureRemoteSessionId` parses it and stamps it on the `HostTask`, so `registerHostSession`/`findTaskBySessionId` work for all agents. Claude keeps its forced id; a resume keeps the resumed id. `RUN_OPTION_FORWARDING` gains `emitSessionId: 'forward'` so the completeness test stays green.

**2. No fabricated codex id.** `extractTaskId` now scans stderr too; a genuine miss throws a loud error pointing at `agents cloud list` instead of persisting a bogus `codex-<ts>` id.

**3. Reconcile cloud tasks into the session index.** `insertTask` (every dispatch) and `updateTaskStatus` (every poll) register a session row keyed by the real execution id with a `[cloud/<status>]` label (`cloud/session-index.ts`), so launch→session is mappable immediately and the label tracks the lifecycle.

Interactive host runs (TTY-forwarded, no combined log to parse) still capture only Claude's forced id — that's inherent to interactive dispatch, which has no detached log for the sentinel to ride.

## Tests

New: `hosts/session-marker.test.ts` (marker emit/parse, last-wins, malformed-frame rejection), extended `hosts/session-index.test.ts` (`captureRemoteSessionId`: non-Claude capture + register + resolve-by-id, never overwrites a forced id, hookless no-op), `cloud/codex.test.ts` (`extractTaskId` never invents `codex-<ts>`), `cloud/store.test.ts` (dispatch + poll register into the session index, guards).

```
Test Files  4 passed (4)      # the new/extended suites
     Tests  25 passed (25)

# full affected surface
Test Files  31 passed (31)    # src/lib/hosts + src/lib/cloud + commands/exec.test + gen-changelog
     Tests  359 passed | 1 skipped (360)

tsc --noEmit: clean
```

Session transcript (confidential — private repo): zion:/home/muqsit/.agents/.history — reference by path per repo policy.
