### PR TITLE
fix(usage): cache Claude OAuth token no-ACL to end the macOS Touch ID storm

### DIFF
--- a/apps/cli/.changelog/next/claude-usage-touchid-cache.md
+++ b/apps/cli/.changelog/next/claude-usage-touchid-cache.md
@@ -1,0 +1,11 @@
+- **No more Touch ID storm from the usage view.** On macOS, rendering usage bars
+  (`agents view`, and the Factory watchdog that polls `agents view --json` every
+  60s per agent) read Claude's own ACL-bound `Claude Code-credentials-<hash>`
+  keychain item on every refresh past the 2-minute usage cache — each read popping
+  a Touch ID prompt, so several running Claude agents meant a biometric prompt
+  every couple of minutes. `loadClaudeOauth` now caches the access token in a
+  device-local no-ACL keychain item (the prompt-free mechanism
+  `secrets/session-store.ts` uses for unlocked bundles), bounded by the token's own
+  expiry, so the ACL-gated read happens at most once per token lifetime and every
+  agent process reads the cache silently. Only the short-lived access token is
+  cached, never the refresh token. Source: `apps/cli/src/lib/usage.ts`.

--- a/apps/cli/.changelog/next/claude-usage-touchid-cache.md
+++ b/apps/cli/.changelog/next/claude-usage-touchid-cache.md
@@ -1,11 +1,14 @@
-- **No more Touch ID storm from the usage view.** On macOS, rendering usage bars
-  (`agents view`, and the Factory watchdog that polls `agents view --json` every
-  60s per agent) read Claude's own ACL-bound `Claude Code-credentials-<hash>`
-  keychain item on every refresh past the 2-minute usage cache — each read popping
-  a Touch ID prompt, so several running Claude agents meant a biometric prompt
-  every couple of minutes. `loadClaudeOauth` now caches the access token in a
-  device-local no-ACL keychain item (the prompt-free mechanism
-  `secrets/session-store.ts` uses for unlocked bundles), bounded by the token's own
-  expiry, so the ACL-gated read happens at most once per token lifetime and every
-  agent process reads the cache silently. Only the short-lived access token is
-  cached, never the refresh token. Source: `apps/cli/src/lib/usage.ts`.
+- **No more Touch ID storm from the usage view.** On macOS, the usage-bar fetch
+  (`agents view`, the Factory watchdog that polls `agents view --json` every 60s
+  per agent) and the daemon's every-3-min auth-health probe each read Claude's own
+  ACL-bound `Claude Code-credentials-<hash>` keychain item on every refresh — each
+  read popping a Touch ID prompt, so several running Claude agents meant a
+  biometric prompt every couple of minutes. Those two access-token-only, high-
+  frequency callers now opt into a device-local **no-ACL** access-token cache (the
+  prompt-free mechanism `secrets/session-store.ts` uses for unlocked bundles),
+  bounded by the token's own expiry, so the ACL-gated read happens at most once per
+  token lifetime and every agent process reads the cache silently. The cache is
+  opt-in and caches only the short-lived access token — callers that need the full
+  credential (`isClaudeAuthValid`'s refresh, `readClaudeCredentialsBlob`'s Rush
+  Cloud export) still take the ACL read with the refresh token intact. Source:
+  `apps/cli/src/lib/usage.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.20.75
+
+- **No more Touch ID storm from the usage view.** On macOS, rendering usage bars
+  (`agents view`, and the Factory watchdog that polls `agents view --json` every
+  60s per agent) read Claude's own ACL-bound `Claude Code-credentials-<hash>`
+  keychain item on every refresh past the 2-minute usage cache — each read popping
+  a Touch ID prompt. With several Claude agents and accounts running, that was a
+  biometric prompt every couple of minutes. `loadClaudeOauth` now caches the
+  access token in a device-local **no-ACL** keychain item (the same prompt-free
+  mechanism `secrets/session-store.ts` uses for unlocked bundles), bounded by the
+  token's own expiry, so the ACL-gated read happens at most once per token
+  lifetime and every agent process reads the cache silently. Only the short-lived
+  access token is cached, never the refresh token. Source:
+  `apps/cli/src/lib/usage.ts`.
+
 ## 1.20.74
 
 - **Project resource manifests are now portable across Windows and POSIX.** The

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,20 +1,5 @@
 # Changelog
 
-## 1.20.75
-
-- **No more Touch ID storm from the usage view.** On macOS, rendering usage bars
-  (`agents view`, and the Factory watchdog that polls `agents view --json` every
-  60s per agent) read Claude's own ACL-bound `Claude Code-credentials-<hash>`
-  keychain item on every refresh past the 2-minute usage cache — each read popping
-  a Touch ID prompt. With several Claude agents and accounts running, that was a
-  biometric prompt every couple of minutes. `loadClaudeOauth` now caches the
-  access token in a device-local **no-ACL** keychain item (the same prompt-free
-  mechanism `secrets/session-store.ts` uses for unlocked bundles), bounded by the
-  token's own expiry, so the ACL-gated read happens at most once per token
-  lifetime and every agent process reads the cache silently. Only the short-lived
-  access token is cached, never the refresh token. Source:
-  `apps/cli/src/lib/usage.ts`.
-
 ## 1.20.74
 
 - **Project resource manifests are now portable across Windows and POSIX.** The

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
-import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh } from './usage.js';
+import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, getClaudeKeychainService } from './usage.js';
+import { setKeychainToken, setKeychainBackendForTest, type KeychainBackend } from './secrets/index.js';
 
 const LEEWAY_MS = 5 * 60 * 1000;
 const NOW = 1_800_000_000_000; // fixed epoch ms so the tests are deterministic
@@ -59,5 +60,86 @@ describe('claudeUsageAccessTokenNoRefresh', () => {
   it('returns null for a missing/empty access token', () => {
     expect(claudeUsageAccessTokenNoRefresh({ accessToken: '', expiresAt: now + 60 * 60 * 1000 })).toBeNull();
     expect(claudeUsageAccessTokenNoRefresh({ accessToken: '   ', expiresAt: now + 60 * 60 * 1000 })).toBeNull();
+  });
+});
+
+/**
+ * The Touch ID storm fix: `loadClaudeOauth` reads Claude's ACL-bound keychain item
+ * (one prompt per read on macOS). We cache the access token in a no-ACL item so the
+ * source read happens at most once per token lifetime, shared across processes.
+ * Here the in-memory keychain backend (the sanctioned test seam) counts source reads
+ * by payload shape — the source item wraps `claudeAiOauth`, the cache item does not.
+ */
+describe('loadClaudeOauth no-ACL access-token cache', () => {
+  /** Counting backend: tracks reads of the source (ACL) item and no-ACL cache writes,
+   *  identified by value shape so the test is agnostic to keychain name hashing. */
+  class CountingBackend implements KeychainBackend {
+    store = new Map<string, string>();
+    sourceReads = 0;
+    noAclCacheWrites = 0;
+    has(item: string) { return this.store.has(item); }
+    get(item: string) {
+      const v = this.store.get(item);
+      if (v === undefined) throw new Error(`missing ${item}`);
+      if (v.includes('"claudeAiOauth"')) this.sourceReads += 1;
+      return v;
+    }
+    set(item: string, value: string, opts?: { noAcl?: boolean }) {
+      if (opts?.noAcl && value.includes('"cacheExpiresAt"')) this.noAclCacheWrites += 1;
+      this.store.set(item, value);
+    }
+    delete(item: string) { return this.store.delete(item); }
+    list(prefix: string) { return [...this.store.keys()].filter((k) => k.startsWith(prefix)); }
+  }
+
+  const HOME = '/tmp/agents-cli-usage-cache-test';
+  const service = getClaudeKeychainService(HOME);
+  const seedSource = (expiresAt: number) =>
+    setKeychainToken(
+      service,
+      JSON.stringify({
+        organizationUuid: 'org-1',
+        claudeAiOauth: { accessToken: 'tok-live', refreshToken: 'refresh-secret', expiresAt, scopes: ['user:inference'] },
+      })
+    );
+
+  it('reads the ACL source once, then serves the no-ACL cache (no repeat prompt)', async () => {
+    const mem = new CountingBackend();
+    const prev = setKeychainBackendForTest(mem);
+    try {
+      seedSource(Date.now() + 60 * 60 * 1000); // fresh: 1h out
+
+      const first = await loadClaudeOauth(HOME);
+      const second = await loadClaudeOauth(HOME);
+
+      expect(first?.accessToken).toBe('tok-live');
+      expect(second?.accessToken).toBe('tok-live');
+      // The source (prompting) item is read exactly once across both loads.
+      expect(mem.sourceReads).toBe(1);
+      // The cache was populated via the no-ACL write path.
+      expect(mem.noAclCacheWrites).toBe(1);
+      // The cache deliberately omits the refresh token (minimal no-ACL exposure);
+      // the first read comes straight from source and still carries it.
+      expect(first?.refreshToken).toBe('refresh-secret');
+      expect(second?.refreshToken).toBeNull();
+    } finally {
+      setKeychainBackendForTest(prev);
+    }
+  });
+
+  it('re-reads the source when the cached token has expired (never serves a stale token)', async () => {
+    const mem = new CountingBackend();
+    const prev = setKeychainBackendForTest(mem);
+    try {
+      seedSource(Date.now() - 60 * 1000); // already expired
+
+      await loadClaudeOauth(HOME);
+      await loadClaudeOauth(HOME);
+
+      // Every load evicts the expired cache entry and reads the source again.
+      expect(mem.sourceReads).toBe(2);
+    } finally {
+      setKeychainBackendForTest(prev);
+    }
   });
 });

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, getClaudeKeychainService } from './usage.js';
+import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService } from './usage.js';
 import { setKeychainToken, setKeychainBackendForTest, type KeychainBackend } from './secrets/index.js';
 
 const LEEWAY_MS = 5 * 60 * 1000;
@@ -162,6 +162,32 @@ describe('loadClaudeOauth no-ACL access-token cache', () => {
       expect(mem.noAclCacheWrites).toBe(0);
       // Every default read goes to the ACL source (no cache short-circuit).
       expect(mem.sourceReads).toBe(2);
+    } finally {
+      setKeychainBackendForTest(prev);
+    }
+  });
+
+  it('evicts the no-ACL cache when the source credential is rotated', async () => {
+    // A refresh (getClaudeAccessToken -> saveClaudeOauth) writes a new source token.
+    // The cache must be invalidated so the next cached caller sees the rotated token,
+    // not the stale cached access token.
+    const mem = new CountingBackend();
+    const prev = setKeychainBackendForTest(mem);
+    try {
+      seedSource(Date.now() + 60 * 60 * 1000);
+
+      const first = await loadClaudeOauth(HOME, { accessTokenCache: true });
+      expect(first?.accessToken).toBe('tok-live');
+
+      await saveClaudeOauth(HOME, {
+        accessToken: 'tok-rotated',
+        refreshToken: 'refresh-secret',
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        scopes: ['user:inference'],
+      });
+
+      const second = await loadClaudeOauth(HOME, { accessTokenCache: true });
+      expect(second?.accessToken).toBe('tok-rotated');
     } finally {
       setKeychainBackendForTest(prev);
     }

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -109,8 +109,8 @@ describe('loadClaudeOauth no-ACL access-token cache', () => {
     try {
       seedSource(Date.now() + 60 * 60 * 1000); // fresh: 1h out
 
-      const first = await loadClaudeOauth(HOME);
-      const second = await loadClaudeOauth(HOME);
+      const first = await loadClaudeOauth(HOME, { accessTokenCache: true });
+      const second = await loadClaudeOauth(HOME, { accessTokenCache: true });
 
       expect(first?.accessToken).toBe('tok-live');
       expect(second?.accessToken).toBe('tok-live');
@@ -133,10 +133,34 @@ describe('loadClaudeOauth no-ACL access-token cache', () => {
     try {
       seedSource(Date.now() - 60 * 1000); // already expired
 
-      await loadClaudeOauth(HOME);
-      await loadClaudeOauth(HOME);
+      await loadClaudeOauth(HOME, { accessTokenCache: true });
+      await loadClaudeOauth(HOME, { accessTokenCache: true });
 
       // Every load evicts the expired cache entry and reads the source again.
+      expect(mem.sourceReads).toBe(2);
+    } finally {
+      setKeychainBackendForTest(prev);
+    }
+  });
+
+  it('without the opt-in, returns the full credential and never caches (cloud-export contract)', async () => {
+    // readClaudeCredentialsBlob / isClaudeAuthValid call loadClaudeOauth WITHOUT
+    // the cache flag: they must always get the ACL-read credential WITH the refresh
+    // token. Regression guard for the Rush Cloud token-export path.
+    const mem = new CountingBackend();
+    const prev = setKeychainBackendForTest(mem);
+    try {
+      seedSource(Date.now() + 60 * 60 * 1000);
+
+      const first = await loadClaudeOauth(HOME); // default: no cache
+      const second = await loadClaudeOauth(HOME);
+
+      // Full refresh token every time — never dropped.
+      expect(first?.refreshToken).toBe('refresh-secret');
+      expect(second?.refreshToken).toBe('refresh-secret');
+      // No no-ACL cache is ever written on the default path.
+      expect(mem.noAclCacheWrites).toBe(0);
+      // Every default read goes to the ACL source (no cache short-circuit).
       expect(mem.sourceReads).toBe(2);
     } finally {
       setKeychainBackendForTest(prev);

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -599,7 +599,9 @@ export function claudeUsageAccessTokenNoRefresh(
 /** Fetch Claude usage via the Anthropic OAuth usage API. */
 async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
-    const oauth = await loadClaudeOauth(options?.home);
+    // Opt into the no-ACL access-token cache: this is the every-60s watchdog hot
+    // path and usage needs only the access token, so it kills the Touch ID storm.
+    const oauth = await loadClaudeOauth(options?.home, { accessTokenCache: true });
     if (!oauth?.accessToken) {
       return { snapshot: null, error: null };
     }
@@ -930,7 +932,10 @@ export interface ProviderProbe {
 
 /** Probe Claude's OAuth token against the usage endpoint. Never refreshes — reports `expired` for a near-expiry token; see the comment below (RUSH-1822). */
 export async function probeClaudeStatus(home?: string, cliVersion?: string | null): Promise<ProviderProbe> {
-  const oauth = await loadClaudeOauth(home);
+  // Opt into the no-ACL access-token cache: the daemon warms this probe every ~3
+  // min per account and it never refreshes (access token only), so caching is safe
+  // and stops it from adding to the Touch ID storm.
+  const oauth = await loadClaudeOauth(home, { accessTokenCache: true });
   const accessToken = oauth?.accessToken?.trim();
   if (!accessToken) return { status: null, token: 'missing' };
   // Never refresh from a health probe. Claude's refresh token is single-use and
@@ -1300,17 +1305,29 @@ function writeCachedClaudeOauth(service: string, creds: ClaudeOauthCredentials):
  * Without step 2 the live usage fetch got no token on Linux, so `agents view`
  * (run remotely over SSH by `--host`) rendered no usage bars even though the
  * account + plan — read from the plaintext `.claude.json` — showed fine.
+ *
+ * `opts.accessTokenCache` opts INTO the no-ACL access-token cache (the Touch ID
+ * storm fix, see the cache helpers above). It is OFF by default so every caller
+ * keeps the full ACL-read credential — the cached copy deliberately omits the
+ * refresh token, so callers that refresh (`isClaudeAuthValid` ->
+ * `getClaudeAccessToken`) or export the full blob (`readClaudeCredentialsBlob`
+ * for Rush Cloud dispatch) must NOT pass it. Only the read-only, high-frequency
+ * access-token-only consumers (the usage fetch and the auth-health probe) opt in.
  */
-export async function loadClaudeOauth(home?: string): Promise<ClaudeOauthCredentials | null> {
+export async function loadClaudeOauth(
+  home?: string,
+  opts?: { accessTokenCache?: boolean }
+): Promise<ClaudeOauthCredentials | null> {
   // The OS keychain/keyring step is macOS/Linux-only. Windows skips straight
   // to the .credentials.json fallback — the Claude CLI has no keychain
   // integration there and stores its OAuth token in that file too.
   if (process.platform === 'darwin' || process.platform === 'linux') {
     const service = getClaudeKeychainService(home);
-    // Serve the no-ACL cache first (macOS/test only) so the ACL-gated read below —
-    // the one that pops Touch ID — happens at most once per token lifetime instead
-    // of on every usage refresh. See the cache helpers above.
-    const cacheActive = claudeOauthCacheActive();
+    // Serve the no-ACL cache first (opt-in, macOS/test only) so the ACL-gated read
+    // below — the one that pops Touch ID — happens at most once per token lifetime
+    // instead of on every usage refresh. Off unless the caller opts in, because the
+    // cached copy drops the refresh token (see the doc comment above).
+    const cacheActive = opts?.accessTokenCache === true && claudeOauthCacheActive();
     if (cacheActive) {
       const cached = readCachedClaudeOauth(service);
       if (cached) return cached;

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -22,6 +22,7 @@ import {
   getKeychainToken,
   setKeychainToken,
   deleteKeychainToken,
+  isKeychainBackendOverridden,
 } from './secrets/index.js';
 import { getCacheDir } from './state.js';
 import type { AgentId } from './types.js';
@@ -1182,6 +1183,107 @@ function parseClaudeOauthPayload(raw: string): ClaudeOauthCredentials | null {
   }
 }
 
+// ── No-ACL cache for Claude's OAuth token (kills the macOS Touch ID storm) ──
+//
+// The source item `Claude Code-credentials-<hash>` is ACL-bound to Claude Code's
+// own process, so every read agents-cli makes (via `/usr/bin/security`) pops
+// Touch ID. The Factory watchdog polls `agents view --json` every 60s per agent,
+// and each poll that crosses the 2-minute usage cache fires a background refresh
+// -> loadClaudeOauth -> keychain read -> a biometric prompt. With many agents and
+// accounts that is a prompt every couple of minutes, per account.
+//
+// Fix: after one real (prompting) read, cache the ACCESS token in a device-local
+// NO-ACL keychain item — the same `set-no-acl` mechanism secrets/session-store.ts
+// uses for unlocked bundles, whose reads never prompt — and serve every later read
+// from it until the token's own `expiresAt`. The ACL read then happens at most once
+// per token lifetime (~a few times a day), shared across every agent process.
+//
+// Security posture: only the short-lived access token is cached, never the refresh
+// token, and the entry dies at the token's expiry (capped below). This mirrors the
+// no-ACL posture session-store.ts already accepts for held bundles.
+const CLAUDE_OAUTH_CACHE_PREFIX = 'agents-cli.claude-oauth-cache.';
+/** Hard cap so a token with a distant or absent `expiresAt` can't pin a stale entry. */
+const CLAUDE_OAUTH_CACHE_MAX_TTL_MS = 8 * 60 * 60 * 1000;
+
+/** One cached access token, stored as a no-ACL keychain item (prompt-free reads). */
+interface CachedClaudeOauthEntry {
+  accessToken: string;
+  expiresAt?: number | null;
+  scopes?: string[] | null;
+  subscriptionType?: string | null;
+  rateLimitTier?: string | null;
+  organizationUuid?: string | null;
+  /** epoch ms; the entry is dead once Date.now() passes this. */
+  cacheExpiresAt: number;
+}
+
+/** The no-ACL cache item name for a Claude keychain service (hashed to stay tidy). */
+function claudeOauthCacheItem(service: string): string {
+  const hash = createHash('sha256').update(service).digest('hex').slice(0, 16);
+  return `${CLAUDE_OAUTH_CACHE_PREFIX}${hash}`;
+}
+
+/** Whether the no-ACL cache is meaningful: macOS (where the source read prompts) or
+ * whenever a test keychain backend is installed, so the path is exercisable on CI.
+ * Off macOS in production the source read is prompt-free, so there is nothing to cache. */
+function claudeOauthCacheActive(): boolean {
+  return process.platform === 'darwin' || isKeychainBackendOverridden();
+}
+
+/** Read the cached access token (prompt-free). Null on miss, or when the cache entry
+ * or the token itself has expired — in which case the stale entry is dropped. */
+function readCachedClaudeOauth(service: string): ClaudeOauthCredentials | null {
+  try {
+    const entry = JSON.parse(getKeychainToken(claudeOauthCacheItem(service))) as CachedClaudeOauthEntry;
+    if (!entry || typeof entry.accessToken !== 'string' || !entry.accessToken) return null;
+    const now = Date.now();
+    const tokenExpired = typeof entry.expiresAt === 'number' && entry.expiresAt > 0 && now >= entry.expiresAt;
+    if (now >= entry.cacheExpiresAt || tokenExpired) {
+      try {
+        deleteKeychainToken(claudeOauthCacheItem(service));
+      } catch {
+        /* best-effort eviction */
+      }
+      return null;
+    }
+    return {
+      accessToken: entry.accessToken,
+      refreshToken: null,
+      expiresAt: entry.expiresAt ?? null,
+      scopes: entry.scopes ?? null,
+      subscriptionType: entry.subscriptionType ?? null,
+      rateLimitTier: entry.rateLimitTier ?? null,
+      organizationUuid: entry.organizationUuid ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Populate the no-ACL cache after a real (prompting) source read. Best-effort — the
+ * cache is an optimization, so any failure just means the next read prompts again. */
+function writeCachedClaudeOauth(service: string, creds: ClaudeOauthCredentials): void {
+  if (!creds.accessToken) return;
+  try {
+    const now = Date.now();
+    const cap = now + CLAUDE_OAUTH_CACHE_MAX_TTL_MS;
+    const tokenExp =
+      typeof creds.expiresAt === 'number' && creds.expiresAt > now ? creds.expiresAt : cap;
+    const entry: CachedClaudeOauthEntry = {
+      accessToken: creds.accessToken,
+      expiresAt: creds.expiresAt ?? null,
+      scopes: creds.scopes ?? null,
+      subscriptionType: creds.subscriptionType ?? null,
+      rateLimitTier: creds.rateLimitTier ?? null,
+      organizationUuid: creds.organizationUuid ?? null,
+      cacheExpiresAt: Math.min(tokenExp, cap),
+    };
+    setKeychainToken(claudeOauthCacheItem(service), JSON.stringify(entry), { noAcl: true });
+  } catch {
+    /* best-effort — cache is an optimization */
+  }
+}
+
 /**
  * Load a version home's Claude OAuth credential from the two stores Claude Code
  * uses, tried in order:
@@ -1204,9 +1306,21 @@ export async function loadClaudeOauth(home?: string): Promise<ClaudeOauthCredent
   // to the .credentials.json fallback — the Claude CLI has no keychain
   // integration there and stores its OAuth token in that file too.
   if (process.platform === 'darwin' || process.platform === 'linux') {
+    const service = getClaudeKeychainService(home);
+    // Serve the no-ACL cache first (macOS/test only) so the ACL-gated read below —
+    // the one that pops Touch ID — happens at most once per token lifetime instead
+    // of on every usage refresh. See the cache helpers above.
+    const cacheActive = claudeOauthCacheActive();
+    if (cacheActive) {
+      const cached = readCachedClaudeOauth(service);
+      if (cached) return cached;
+    }
     try {
-      const fromKeychain = parseClaudeOauthPayload(getKeychainToken(getClaudeKeychainService(home)));
-      if (fromKeychain) return fromKeychain;
+      const fromKeychain = parseClaudeOauthPayload(getKeychainToken(service));
+      if (fromKeychain) {
+        if (cacheActive) writeCachedClaudeOauth(service, fromKeychain);
+        return fromKeychain;
+      }
     } catch {
       // No keychain item, or no reachable keyring (headless Linux) — fall through.
     }

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1289,6 +1289,15 @@ function writeCachedClaudeOauth(service: string, creds: ClaudeOauthCredentials):
   }
 }
 
+/** Evict the no-ACL cache so a source rotation or sign-out is reflected immediately. */
+function deleteCachedClaudeOauth(service: string): void {
+  try {
+    deleteKeychainToken(claudeOauthCacheItem(service));
+  } catch {
+    /* best-effort — cache is an optimization */
+  }
+}
+
 /**
  * Load a version home's Claude OAuth credential from the two stores Claude Code
  * uses, tried in order:
@@ -1340,6 +1349,8 @@ export async function loadClaudeOauth(
       }
     } catch {
       // No keychain item, or no reachable keyring (headless Linux) — fall through.
+      // Evict any stale no-ACL cache so a sign-out/deletion isn't masked.
+      if (cacheActive) deleteCachedClaudeOauth(service);
     }
   }
 
@@ -1357,8 +1368,9 @@ export async function loadClaudeOauth(
 /**
  * Save Claude OAuth credentials to the system keychain/keyring.
  * Reads the existing payload, merges the new OAuth fields, and writes back.
+ * Exported for regression tests; not part of the public command surface.
  */
-async function saveClaudeOauth(
+export async function saveClaudeOauth(
   home: string | undefined,
   credentials: ClaudeOauthCredentials
 ): Promise<boolean> {
@@ -1401,6 +1413,8 @@ async function saveClaudeOauth(
     }
 
     setKeychainToken(service, payloadJson);
+    // A new credential rotation means any cached access token is stale.
+    deleteCachedClaudeOauth(service);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Problem

On macOS, with several Claude agents/accounts running, Touch ID prompts fire **every ~2 minutes** — unusable. This is not benign.

## Root cause (traced with file:line)

- The Factory watchdog polls `agents view <agent> --json` **every 60s per agent** (`apps/factory/src/monitor/watchdogDetector.ts:31`, `WATCHDOG_VIEW_POLL_MS = 60_000`).
- `view --json` → `getUsageInfoByIdentity` (`apps/cli/src/commands/view.ts:437`). The usage cache is fresh for 2 min (`usage.ts:299`, `USAGE_CACHE_FRESH_MS`); the first poll past that fires a background refresh (`usage.ts:356,389`).
- The refresh calls `loadClaudeOauth` (`usage.ts:1202`) → `getKeychainToken(getClaudeKeychainService(home))` (`usage.ts:1208`), reading Claude Code's **own** ACL-bound `Claude Code-credentials-<hash>` item. `getKeychainToken` is documented "On macOS this triggers Touch ID" (`secrets/index.ts:791-798`), and because agents-cli isn't in that item's ACL, **every** read prompts.

Net: one biometric prompt per account every ~2 min, forever. The long-lived `claude setup-token` can't substitute — the usage endpoint (`/api/oauth/usage`) needs the per-account `claudeAiOauth.accessToken`, a different token type.

## Fix (standardize at the source)

Cache the access token in a device-local **no-ACL** keychain item — the same prompt-free `set-no-acl` mechanism `secrets/session-store.ts` already uses for unlocked bundles — bounded by the token's own `expiresAt` (capped at 8h). `loadClaudeOauth` serves the cache first, so the ACL-gated read happens **at most once per token lifetime**, shared across every agent process. Fixes it for all callers (watchdog, `agents view`, menubar), not just one.

**Security posture:** only the short-lived access token is cached, **never** the refresh token; the entry dies at the token's expiry. This mirrors the no-ACL posture `session-store.ts` already ships for held bundles. Off macOS the source read is prompt-free, so the cache is a no-op there.

## Test

`apps/cli/src/lib/usage.test.ts` — exercises the real `loadClaudeOauth` path via the sanctioned in-memory keychain backend (`setKeychainBackendForTest`), no mocking of the logic:
- source (prompting) read happens **once** across repeated loads (cache hit on the second);
- the cache is written via the **no-ACL** path;
- the cache omits the refresh token (first load carries it from source, second load returns it null);
- an **expired** cached token is evicted and the source is re-read (never serves a stale token).

Local: `bun run test usage.test.ts` → 48 passed. `tsc --noEmit` → 0 errors. `bun run build` → exit 0.

## Verification note

On-device confirmation (one prompt, then silent across many agents) to be observed after install; the no-ACL prompt-free read primitive itself is production-proven via `session-store.ts`.