### PR TITLE
agents sessions migrate — relocate a live session across machines (RUSH-1977)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,19 @@
   machine/source, ranked by platform-match, warm-worker-over-fresh-box, then live headroom),
   `--host <name>` names a target, and `--lease` provisions a fresh box. It wraps up a dirty
   working tree into a draft WIP PR (or, with `--agent-wrapup`, delegates that to the running
-  agent), ships the transcript over the same `sessions export --stdout | sessions import -`
-  pipeline, resumes on the target via the same `sessions resume --host` path, and only then
-  kills the source (`--keep` copies instead of moving). `--mode resume|rehydrate` picks a
-  faithful `--resume` vs a fresh agent reading the transcript; the non-resumable agents
-  (gemini, antigravity, openclaw, rush, hermes, grok, kimi, droid) transparently fall to
-  `rehydrate` — never a silent skip. Invariant: the source is never stopped before the
-  transcript + branch are confirmed on the target. Source:
-  `apps/cli/src/commands/sessions-migrate.ts`, `apps/cli/src/lib/session/migrate-targets.ts`,
+  agent), ships the transcript to the target's live agent dir (same path under the shared
+  `$HOME`), resumes on the target in a detached tmux session, confirms the pane is live, and
+  only then kills the source (`--keep` copies instead of moving). `--mode rehydrate` (default)
+  starts the target agent with a prompt to read the transported session via `agents sessions
+  <id>` (its own `--last`/`--include` judgment so long tool output can't blow context) and
+  continue — robust across every harness; `--mode resume` attempts a best-effort native
+  `<agent> --resume` and falls back to rehydrate when the target can't register the session.
+  Every migrate is recorded in an append-only ledger at `~/.agents/.history/migrations.jsonl`,
+  viewable with **`agents sessions migrations`** (the border tracker: `from → to`, mode,
+  move-vs-copy, status; a session that hops A→B→C leaves its full lineage). Invariant: the
+  source is never stopped before the transcript is on the target and its session is confirmed
+  live. Source: `apps/cli/src/commands/sessions-migrate.ts`,
+  `apps/cli/src/lib/session/migrate-targets.ts`, `apps/cli/src/lib/session/migrations.ts`,
   `apps/cli/src/commands/sessions.ts`, `apps/cli/docs/05-sessions.md`.
 
 - **The configured model now shows wherever an agent is displayed.** `agents view`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- **`agents sessions migrate` (alias `detach`) relocates a RUNNING session onto another
+  machine, then stops the source here (RUSH-1977).** Move the live agent — not just its
+  transcript — off the interactive laptop and onto a fleet worker, a registered device, or
+  a warm/fresh ephemeral crabbox box, so the interactive machine reclaims its compute. With
+  no `[session-id]` it resolves the session in THIS tmux pane (`$TMUX_PANE` matched against
+  `provenance.mux.pane`); `--auto` scores the fleet (reachable + dispatchable + not this
+  machine/source, ranked by platform-match, warm-worker-over-fresh-box, then live headroom),
+  `--host <name>` names a target, and `--lease` provisions a fresh box. It wraps up a dirty
+  working tree into a draft WIP PR (or, with `--agent-wrapup`, delegates that to the running
+  agent), ships the transcript over the same `sessions export --stdout | sessions import -`
+  pipeline, resumes on the target via the same `sessions resume --host` path, and only then
+  kills the source (`--keep` copies instead of moving). `--mode resume|rehydrate` picks a
+  faithful `--resume` vs a fresh agent reading the transcript; the non-resumable agents
+  (gemini, antigravity, openclaw, rush, hermes, grok, kimi, droid) transparently fall to
+  `rehydrate` — never a silent skip. Invariant: the source is never stopped before the
+  transcript + branch are confirmed on the target. Source:
+  `apps/cli/src/commands/sessions-migrate.ts`, `apps/cli/src/lib/session/migrate-targets.ts`,
+  `apps/cli/src/commands/sessions.ts`, `apps/cli/docs/05-sessions.md`.
+
 - **The configured model now shows wherever an agent is displayed.** `agents view`,
   `agents view <agent>@<version>`, `agents use`, `agents add`, `agents status`, and
   `agents inspect` now surface the model a given agent+version is actually set to run

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -139,7 +139,7 @@ src/
     hooks/match.ts     # `matches:` predicate evaluator
     monitors/          # `agents monitors` — event-triggered watchers (source→condition→action); native state-diff store; MonitorEngine runs in the daemon beside the cron scheduler. See docs/10-monitors.md
     migrate.ts         # One-shot idempotent migrations
-    session/           # `agents sessions` READER — discovery/parse/render of agent transcripts
+    session/           # `agents sessions` READER — discovery/parse/render of agent transcripts; also `migrate-targets.ts` (the `sessions migrate` target scorer)
     terminal/          # Terminal launch engine — tab/split in iTerm/Ghostty/tmux, local or --host
     cloud/             # Provider registry (Rush / Codex / Factory / Antigravity)
     teams/             # `agents teams` orchestration

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -366,25 +366,38 @@ The flow reuses existing primitives rather than reinventing transport or resume:
 4. **Wrap up the working tree.** Dirty → commit to a branch, push, open a **draft
    (WIP) PR** (mechanical by default). `--agent-wrapup` instead injects a wrap-up turn
    into the running agent (same tmux reply rail as `sessions inject`). Clean-but-ahead → push.
-5. **Ship the transcript** with the same bundle pipeline as
-   `sessions export --stdout | sessions import -`, over SSH.
-6. **Resume on the target** through the same host path as `sessions resume --host`
-   (`openSurfaces({ backend: 'tmux', host })`). For an ephemeral box, migrate git-clones
-   the repo and checks out the (WIP) branch first so the cwd resolves.
-7. **Stop the source** (`killSession`) — but only after the target's prompt is confirmed
+5. **Ship the transcript** to the target's live agent dir: the transcript file is copied
+   to the same path on the target (identical under the shared fleet `$HOME`), streamed
+   over the same `sshExec` transport, so the agent finds it where it reads sessions.
+   (`sessions import` lands bundles in the browsable history mirror — right for reading a
+   transcript elsewhere, wrong for continuing it.)
+6. **Resume on the target** in a detached tmux session (`tmux new-session -d`, which
+   starts the server a fresh worker/box lacks — the generic `new-window` backend needs a
+   live server), then confirm the pane is *live* (not merely created) before proceeding.
+   For an ephemeral box, migrate git-clones the repo and checks out the (WIP) branch first
+   so the cwd resolves.
+7. **Stop the source** (`killSession`) — but only after the target session is confirmed
    live. `--keep` skips this (copy, not move).
 
-**`--mode resume | rehydrate`** (default `resume`) chooses between a faithful
-`--resume` and a fresh agent that reads the transcript. **Harness parity:**
+**`--mode rehydrate | resume`** (default `rehydrate`). Rehydrate ships the transcript and
+starts the agent on the target with a prompt telling it to read the session
+(`agents sessions <id>` — its own judgment on `--last`/`--include` so large tool output
+can't blow context) and continue; robust across every harness. `--mode resume` attempts a
+native `<agent> --resume` — faithful, but best-effort: the target agent must have the
+session registered, so migrate falls back to rehydrate when it can't. **Harness parity:**
 `buildResumeCommand` returns null for the non-resumable agents (gemini, antigravity,
-openclaw, rush, hermes, grok, kimi, droid) — for those a faithful resume is impossible,
-so migrate transparently falls to `rehydrate` and prints a notice (it never silently
-skips an agent). The same fallback applies when the requested agent isn't installed on
-the target.
+openclaw, rush, hermes, grok, kimi, droid); a resume request for those transparently
+becomes rehydrate with a printed notice — never a silent skip.
 
-**Invariant:** the source is never killed before the transcript + branch are confirmed
-on the target. Source: `src/commands/sessions-migrate.ts`,
-`src/lib/session/migrate-targets.ts`.
+**Invariant:** the source is never killed before the transcript is on the target and its
+session is confirmed live.
+
+**Tracking handoffs.** Every migrate appends to an append-only ledger at
+`~/.agents/.history/migrations.jsonl` (synced with the rest of `.history`, so source and
+target converge). `agents sessions migrations` prints it — the border tracker showing each
+session's `from → to`, mode, move-vs-copy, and status; a session that hops A→B→C leaves
+three lines, its lineage. Source: `src/commands/sessions-migrate.ts`,
+`src/lib/session/migrate-targets.ts`, `src/lib/session/migrations.ts`.
 
 ## Cross-machine sync (R2 + CRDT)
 

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -327,6 +327,65 @@ disk is skipped; a file that differs is a conflict, kept local unless `--overwri
 Source: `src/lib/session/bundle.ts`, `src/lib/session/remote-bundle.ts`,
 `src/commands/sessions-export.ts`, `src/commands/sessions-import.ts`.
 
+## Migration (relocate a live session)
+
+`agents sessions migrate` (alias `detach`) **moves a RUNNING session onto another
+machine** — a fleet worker, a registered device, or a warm/fresh ephemeral crabbox
+box — then stops the source so the interactive machine reclaims its compute. Where
+export/import carry a *transcript* between machines, migrate carries the *live agent*:
+it ships the transcript, resumes the agent on the target, confirms its prompt is live,
+and only then kills the source.
+
+```bash
+# Move the session in THIS tmux pane onto the least-busy fleet worker
+agents sessions migrate --auto
+
+# Move a specific session onto a named host / device / warm box slug
+agents sessions migrate a1b2c3d4 --host yosemite-s1
+
+# Provision a fresh ephemeral box and move onto it
+agents sessions migrate --lease
+
+# Copy (don't stop the source), and let the running agent wrap up its own dirty tree
+agents sessions migrate --host box-a --keep --agent-wrapup
+```
+
+The flow reuses existing primitives rather than reinventing transport or resume:
+
+1. **Resolve the source.** With no `[session-id]`, migrate matches the current tmux
+   pane (`$TMUX_PANE`) against a live session's `provenance.mux.pane` via
+   `getActiveSessions()`. Pass an explicit id when you're not inside the session's pane.
+2. **Resolve the target.** `--auto` picks the best machine with the pure scorer
+   (`src/lib/session/migrate-targets.ts`): eligible = reachable, dispatchable, not this
+   machine and not the source; ranked by platform-match-with-source, then a warm fleet
+   worker over a fresh box, then live headroom (idle > light > busy > loaded, from the
+   `agents devices` stats cache). `--host <name>` names one; `--lease` provisions a
+   fresh box (`crabboxWarmup`).
+3. **Verify + bootstrap.** `readyProbe()` checks the target can run the session's
+   agent+version; a missing agents-cli is bootstrapped (`bootstrapAgentsCli`).
+4. **Wrap up the working tree.** Dirty → commit to a branch, push, open a **draft
+   (WIP) PR** (mechanical by default). `--agent-wrapup` instead injects a wrap-up turn
+   into the running agent (same tmux reply rail as `sessions inject`). Clean-but-ahead → push.
+5. **Ship the transcript** with the same bundle pipeline as
+   `sessions export --stdout | sessions import -`, over SSH.
+6. **Resume on the target** through the same host path as `sessions resume --host`
+   (`openSurfaces({ backend: 'tmux', host })`). For an ephemeral box, migrate git-clones
+   the repo and checks out the (WIP) branch first so the cwd resolves.
+7. **Stop the source** (`killSession`) — but only after the target's prompt is confirmed
+   live. `--keep` skips this (copy, not move).
+
+**`--mode resume | rehydrate`** (default `resume`) chooses between a faithful
+`--resume` and a fresh agent that reads the transcript. **Harness parity:**
+`buildResumeCommand` returns null for the non-resumable agents (gemini, antigravity,
+openclaw, rush, hermes, grok, kimi, droid) — for those a faithful resume is impossible,
+so migrate transparently falls to `rehydrate` and prints a notice (it never silently
+skips an agent). The same fallback applies when the requested agent isn't installed on
+the target.
+
+**Invariant:** the source is never killed before the transcript + branch are confirmed
+on the target. Source: `src/commands/sessions-migrate.ts`,
+`src/lib/session/migrate-targets.ts`.
+
 ## Cross-machine sync (R2 + CRDT)
 
 > **Opt-in beta, off by default — a backup fabric, not the primary recall path.**

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -16,7 +16,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Version management](01-version-management.md) | Installing, pinning, switching, and isolating agent CLI versions. |
 | [Self-healing installs](self-healing.md) | Detect, surface, and repair a broken agent binary (gutted install / `ENOENT`) instead of dying cryptically. |
 | [Resource sync](02-resource-sync.md) | How rules, commands, skills, hooks, etc. land in each version home. |
-| [Sessions](05-sessions.md) | Unified transcript discovery across Claude, Codex, Gemini, OpenCode. |
+| [Sessions](05-sessions.md) | Unified transcript discovery across Claude, Codex, Gemini, OpenCode; resume, export/import, and migrate a live session across machines. |
 | [Observability](06-observability.md) | The three `--json` sources (sessions / cloud / teams) as a fleet view, plus `agents mailboxes` fleet comms. |
 | [SSH transport](09-ssh-transport.md) | The one multiplexed engine every `--host` command rides — default connection reuse, keepalive, one-round-trip follow. |
 | [Optimizations](99-optimizations.md) | Sync manifest, SSH transport, startup profiling, hot-path notes. |

--- a/apps/cli/src/commands/sessions-migrate.test.ts
+++ b/apps/cli/src/commands/sessions-migrate.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { effectiveMode } from './sessions-migrate.js';
+import { effectiveMode, rehydrateCommand } from './sessions-migrate.js';
 import { buildResumeCommand } from './sessions.js';
+import { AGENTS } from '../lib/agents.js';
+import type { AgentId } from '../lib/types.js';
 import { SESSION_AGENTS, type SessionMeta, type SessionAgentId } from '../lib/session/types.js';
 
 /** Minimal SessionMeta with a resolvable version, for the harness-parity gate. */
@@ -35,6 +37,18 @@ describe('effectiveMode — harness parity gate', () => {
   it('honors an explicit rehydrate request for a resumable agent (no forced downgrade flag)', () => {
     const r = effectiveMode(meta('claude'), 'rehydrate');
     expect(r).toEqual({ mode: 'rehydrate', downgraded: false });
+  });
+
+  it('rehydrateCommand uses each agent\'s real binary (cliCommand), not the session-agent id', () => {
+    // antigravity's executable is `agy`, not `antigravity` — launching the raw id
+    // on the target would fail with a shell error instead of rehydrating.
+    expect(rehydrateCommand(meta('antigravity'))[0]).toBe('agy');
+    expect(rehydrateCommand(meta('claude'))[0]).toBe('claude');
+    // Pin the whole set to the registry so a renamed binary can't drift silently.
+    for (const agent of SESSION_AGENTS) {
+      const expected = AGENTS[agent as AgentId]?.cliCommand ?? agent;
+      expect(rehydrateCommand(meta(agent))[0]).toBe(expected);
+    }
   });
 
   it('stays in lockstep with buildResumeCommand for EVERY session agent (the parity invariant)', () => {

--- a/apps/cli/src/commands/sessions-migrate.test.ts
+++ b/apps/cli/src/commands/sessions-migrate.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveMode } from './sessions-migrate.js';
+import { buildResumeCommand } from './sessions.js';
+import { SESSION_AGENTS, type SessionMeta, type SessionAgentId } from '../lib/session/types.js';
+
+/** Minimal SessionMeta with a resolvable version, for the harness-parity gate. */
+function meta(agent: SessionAgentId): SessionMeta {
+  return {
+    id: '2026-07-31T00-00-00-000Z',
+    shortId: 'abcd1234',
+    agent,
+    timestamp: '2026-07-31T00:00:00.000Z',
+    filePath: `/tmp/${agent}.jsonl`,
+    version: '1.0.0',
+    cwd: '/tmp',
+  };
+}
+
+describe('effectiveMode — harness parity gate', () => {
+  it('keeps resume for agents buildResumeCommand can resume (claude, codex, opencode)', () => {
+    for (const agent of ['claude', 'codex', 'opencode'] as SessionAgentId[]) {
+      const r = effectiveMode(meta(agent), 'resume');
+      expect(r).toEqual({ mode: 'resume', downgraded: false });
+    }
+  });
+
+  it('downgrades resume→rehydrate for every non-resumable agent (no silent skip)', () => {
+    const nonResumable: SessionAgentId[] = ['gemini', 'antigravity', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid'];
+    for (const agent of nonResumable) {
+      const r = effectiveMode(meta(agent), 'resume');
+      expect(r).toEqual({ mode: 'rehydrate', downgraded: true });
+    }
+  });
+
+  it('honors an explicit rehydrate request for a resumable agent (no forced downgrade flag)', () => {
+    const r = effectiveMode(meta('claude'), 'rehydrate');
+    expect(r).toEqual({ mode: 'rehydrate', downgraded: false });
+  });
+
+  it('stays in lockstep with buildResumeCommand for EVERY session agent (the parity invariant)', () => {
+    // The gate must downgrade exactly when buildResumeCommand returns null — if a
+    // new agent gains/loses resume support, this pins the two together.
+    for (const agent of SESSION_AGENTS) {
+      const m = meta(agent);
+      const resumable = buildResumeCommand(m) !== null;
+      const { mode, downgraded } = effectiveMode(m, 'resume');
+      if (resumable) {
+        expect(mode).toBe('resume');
+        expect(downgraded).toBe(false);
+      } else {
+        expect(mode).toBe('rehydrate');
+        expect(downgraded).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -24,6 +24,7 @@
  */
 import * as os from 'os';
 import * as fs from 'fs';
+import * as path from 'path';
 import chalk from 'chalk';
 import simpleGit from 'simple-git';
 import type { Command } from 'commander';
@@ -34,9 +35,10 @@ import type { ActiveSession } from '../lib/session/active.js';
 import { getActiveSessions } from '../lib/session/active.js';
 import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
 import { buildResumeCommand } from './sessions.js';
-import { openSurfaces } from '../lib/terminal/index.js';
 import { injectTargetFromReplyRail } from '../lib/session/inject.js';
 import { injectIntoTerminal } from '../lib/terminal/index.js';
+import { iLoginShell } from '../lib/terminal/shell.js';
+import { shellQuote as quoteArg } from '../lib/terminal/quote.js';
 import { killSession } from '../lib/tmux/session.js';
 
 import { listAllHosts, resolveHost } from '../lib/hosts/registry.js';
@@ -65,6 +67,7 @@ import {
 import { itemPicker } from '../lib/picker.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
+import { recordMigration, readMigrations, type MigrationRecord } from '../lib/session/migrations.js';
 
 /** Agents whose sessions cannot be faithfully --resume'd (buildResumeCommand → null). */
 type MigrateMode = 'resume' | 'rehydrate';
@@ -86,7 +89,7 @@ export function registerSessionsMigrateCommand(sessionsCmd: Command): void {
     .option('--auto', 'Pick the best target host automatically (idle fleet worker preferred)')
     .option('--host <name>', 'Explicit target: an enrolled host, a device, or a warm ephemeral box slug')
     .option('--lease', 'Provision a fresh ephemeral crabbox box as the target')
-    .option('--mode <mode>', 'resume (faithful --resume) or rehydrate (fresh agent reads the transcript)', 'resume')
+    .option('--mode <mode>', 'rehydrate (default: the target agent reads the transported transcript) or resume (best-effort native --resume)', 'rehydrate')
     .option('--keep', 'Copy, not move — do NOT stop the source after resuming on the target')
     .option('--agent-wrapup', 'Delegate the dirty-tree wrap-up to the running agent instead of a mechanical WIP-PR');
 
@@ -106,16 +109,27 @@ export function registerSessionsMigrateCommand(sessionsCmd: Command): void {
     `,
     notes: `
       - Without a [session-id], migrate resolves the session running in THIS tmux pane ($TMUX_PANE).
-      - The source is stopped only AFTER the target's prompt is confirmed live; --keep skips the stop.
-      - Non-resumable agents (gemini, antigravity, openclaw, rush, hermes, grok, kimi, droid) cannot be
-        faithfully --resume'd, so migrate uses --mode rehydrate for them and says so.
-      - Transport reuses the same bundle pipeline as 'sessions export --stdout | sessions import -', over SSH.
-      - Resume reuses the same host path as 'sessions resume --host' (tmux backend).
+      - Default --mode rehydrate: the transcript is shipped to the target and the agent reads it there
+        with 'agents sessions <id>' (its own judgment on --last/--include so long tool output can't
+        blow context), then continues. Robust across every harness.
+      - --mode resume attempts a native '<agent> --resume' on the target — faithful, but best-effort:
+        the target agent must have the session registered, so migrate falls back to rehydrate when it can't.
+      - The source is stopped only AFTER the target's session is confirmed live; --keep skips the stop (copy).
+      - Every migrate appends to the ledger — see 'agents sessions migrations' for where each session went.
     `,
   });
 
-  cmd.action(async (sessionId: string | undefined, options: MigrateOptions) => {
-    await sessionsMigrateAction(sessionId, options);
+  cmd.action(async (sessionId: string | undefined, options: MigrateOptions, command: Command) => {
+    // commander 15: the parent `sessions` command owns a global `-H, --host` (the
+    // listing fan-out), which shadows this subcommand's own --host — the value
+    // lands in the merged globals, not `options.host`. Read it from there so
+    // `agents sessions migrate --host <name>` binds.
+    const globals = command.optsWithGlobals() as { host?: string[] | string };
+    const hosts = Array.isArray(globals.host) ? globals.host : globals.host ? [globals.host] : [];
+    if (hosts.length > 1) {
+      console.error(chalk.yellow(`Multiple --host values given; migrating to the first (${hosts[0]}).`));
+    }
+    await sessionsMigrateAction(sessionId, { ...options, host: hosts[0] });
   });
 }
 
@@ -410,28 +424,29 @@ async function delegateWrapupToAgent(source: SessionMeta, active: ActiveSession 
 }
 
 /**
- * Ship the transcript to the target with the SAME bundle pipeline as
- * `sessions export --stdout | sessions import -`: export the one session's bundle
- * locally, pipe it into `agents sessions import -` on the target over SSH.
+ * Ship the transcript to the target so `<agent> --resume` can find it there.
+ *
+ * The live transcript (`SessionMeta.filePath`) is copied to the SAME absolute
+ * path on the target: claude/codex/opencode resolve a resumable session by the
+ * cwd-derived project dir under $HOME, which is identical across the shared fleet
+ * home, so a same-path copy is exactly what `--resume` reads. (`sessions import`
+ * deliberately lands bundles in the browsable history mirror, not the agent's
+ * live dir — right for reading a transcript on another box, wrong for resuming
+ * it.) Reuses the same `sshExec` transport, streaming the file over stdin.
  */
-function shipTranscript(sshTarget: string, source: SessionMeta, remoteOs?: string): void {
-  const local = spawnSync(
-    process.execPath,
-    [process.argv[1], 'sessions', 'export', source.id, '--stdout'],
-    { encoding: 'utf-8', maxBuffer: 256 * 1024 * 1024 },
-  );
-  if (local.status !== 0 || !local.stdout) {
-    fail(`Failed to export the transcript locally: ${(local.stderr || '').trim().split('\n').pop() || 'export error'}`);
+function shipTranscript(sshTarget: string, source: SessionMeta): void {
+  const file = source.filePath;
+  if (!file || !fs.existsSync(file)) {
+    fail(`Cannot locate the local transcript for ${source.shortId} to ship (${file ?? 'no path'}).`);
   }
-  const importCmd =
-    remoteOs && remoteOs.toLowerCase().includes('win')
-      ? 'agents sessions import -'
-      : `bash -lc ${shellQuote('agents sessions import -')}`;
-  const res = sshExec(sshTarget, importCmd, { input: local.stdout, timeoutMs: 120000 });
+  const content = fs.readFileSync(file, 'utf8');
+  const parent = path.dirname(file);
+  const remoteCmd = `mkdir -p ${shellQuote(parent)} && cat > ${shellQuote(file)}`;
+  const res = sshExec(sshTarget, remoteCmd, { input: content, timeoutMs: 120000 });
   if (res.code !== 0) {
-    fail(`Failed to import the transcript on ${sshTarget}: ${res.stderr.trim().split('\n').pop() || 'import error'}`);
+    fail(`Failed to ship the transcript to ${sshTarget}: ${res.stderr.trim().split('\n').pop() || `ssh exited ${res.code}`}`);
   }
-  console.log(chalk.green('  Transcript shipped to the target.'));
+  console.log(chalk.green(`  Transcript shipped to the target (${file}).`));
 }
 
 /** Git-clone + checkout the (WIP) branch on an ephemeral box so the cwd resolves. */
@@ -467,17 +482,42 @@ async function resumeOnTarget(
   if (!command) {
     fail(`Cannot build a resume command for ${source.agent} (mode ${mode}).`);
   }
-  const cwd = remoteCwd ?? source.cwd ?? '~';
-  const results = await openSurfaces(
-    [{ cwd, command: command! }],
-    { backend: 'tmux', host: sshTarget, packing: 'tabs' },
-  );
-  const r = results[0];
-  if (!r || !r.ok) {
-    console.log(chalk.red(`  Resume on ${sshTarget} failed: ${r?.error ?? 'unknown'}`));
+  // Start a DETACHED tmux session on the target. The generic engine tmux backend
+  // uses `new-window`, which needs a live server — a fresh worker or ephemeral
+  // box has none ("no server running"), so we create the session (and thus the
+  // server) directly with `new-session -d`, mirroring the local `createSession`
+  // helper (remain-on-exit keeps the pane inspectable if the agent exits), over
+  // the same SSH transport as `sessions resume --host`.
+  //
+  // Each argv element is quoted BEFORE the zsh -ilc wrapper so a command that
+  // carries spaces or backticks (the rehydrate prompt) reaches the agent as one
+  // clean argument — an unquoted join would let the target shell split it and
+  // run its backticks.
+  const sessionName = `migrate-${source.shortId}`;
+  const inner = iLoginShell(`exec ${command!.map(quoteArg).join(' ')}`);
+  const argv = ['tmux', 'set-option', '-g', 'remain-on-exit', 'on', ';', 'new-session', '-d', '-s', sessionName];
+  const cwd = remoteCwd ?? source.cwd;
+  if (cwd && cwd !== '~') argv.push('-c', cwd);
+  argv.push(inner);
+  const launch = sshExec(sshTarget, argv.map(shellQuote).join(' '), { timeoutMs: 60000 });
+  if (launch.code !== 0) {
+    console.log(chalk.red(`  Resume on ${sshTarget} failed: ${launch.stderr.trim().split('\n').pop() || `tmux exited ${launch.code}`}`));
     return false;
   }
-  console.log(chalk.green(`  Resumed on the target (${command!.join(' ')}).`));
+  // Liveness gate for the invariant: give the agent a moment to boot, then require
+  // the pane to be ALIVE (not merely the session to exist) before the caller may
+  // stop the source. An agent that dies on launch → we refuse to move.
+  const q = shellQuote(sessionName);
+  const probe = `sleep 3; tmux has-session -t ${q} 2>/dev/null || exit 3; test "$(tmux list-panes -t ${q} -F '#{pane_dead}' 2>/dev/null | head -n1)" = 0 || exit 4`;
+  const check = sshExec(sshTarget, probe, { timeoutMs: 30000 });
+  if (check.code !== 0) {
+    const why = check.code === 4 ? 'the agent exited immediately on the target'
+      : check.code === 3 ? 'the session did not start'
+      : (check.stderr.trim().split('\n').pop() || `liveness probe exited ${check.code}`);
+    console.log(chalk.red(`  Resume on ${sshTarget} is not live: ${why}.`));
+    return false;
+  }
+  console.log(chalk.green(`  Resumed on the target in tmux session ${sessionName} (${command!.join(' ')}).`));
   return true;
 }
 
@@ -487,7 +527,14 @@ async function resumeOnTarget(
  * a prompt pointing it at the imported transcript path.
  */
 function rehydrateCommand(source: SessionMeta): string[] {
-  const prompt = `You are resuming a prior session (id ${source.id}). Read its transcript at the imported path under ~/.agents/.history and continue where it left off.`;
+  const origin = source.machine ? ` from ${source.machine}` : '';
+  const prompt = [
+    `You are continuing session ${source.shortId}, migrated to this machine${origin}.`,
+    `Its full transcript is here — read it with \`agents sessions ${source.shortId}\`.`,
+    `It supports --markdown, role filters (e.g. --include user,assistant), and --last N;`,
+    `use them so large tool outputs don't blow your context — skim the recent turns first,`,
+    `widen only if you need to, then continue the work where it left off.`,
+  ].join(' ');
   return [source.agent, prompt];
 }
 
@@ -510,8 +557,9 @@ async function sessionsMigrateAction(sessionId: string | undefined, options: Mig
   // 4. Wrap up the working dir (WIP PR by default, or delegate to the agent).
   const branch = await wrapUpWorkingTree(source, active, options);
 
-  // 5. Transport the transcript to the target (portable export/import over SSH).
-  shipTranscript(sshTarget, source, target.host?.os);
+  // 5. Transport the transcript to the target's live agent dir (same path) so
+  //    `<agent> --resume` finds it.
+  shipTranscript(sshTarget, source);
 
   // 6. For an ephemeral box, clone + checkout the branch so the cwd resolves.
   const remoteCwd =
@@ -519,19 +567,40 @@ async function sessionsMigrateAction(sessionId: string | undefined, options: Mig
 
   // 7. Resume on the target.
   const resumed = await resumeOnTarget(sshTarget, source, remoteCwd, mode);
+
+  // Ledger stub shared by the success and failure records (RUSH-1977). `at` is
+  // stamped from the CLI's real clock.
+  const base: Omit<MigrationRecord, 'status' | 'error'> = {
+    sessionId: source.id,
+    shortId: source.shortId,
+    agent: source.agent,
+    mode,
+    move: !options.keep,
+    from: { host: os.hostname(), cwd: source.cwd, pane: active?.provenance?.mux?.pane },
+    to: { host: target.name, cwd: remoteCwd, box: target.box?.slug },
+    branch,
+    at: new Date().toISOString(),
+  };
+
   if (!resumed) {
+    recordMigration({ ...base, status: 'failed', error: 'resume did not launch on the target' });
     fail('Resume on the target did not launch — the source is left running (nothing was stopped).');
   }
 
-  // 8. INVARIANT: only now that the transcript + branch are confirmed on the
-  //    target and the resume launched, stop the source. --keep skips this.
+  // 8. INVARIANT: only now that the transcript is on the target and the session
+  //    is confirmed live, stop the source. --keep skips this (copy, not move).
   if (options.keep) {
     console.log(chalk.gray('--keep: the source session is left running (copy, not move).'));
   } else {
     await stopSource(source, active);
   }
 
-  console.log(chalk.green(`\nMigrated ${source.shortId} to ${target.name}${options.keep ? ' (copy)' : ''}.`));
+  // 9. Record the handoff so the session stays trackable (agents sessions migrations).
+  recordMigration({ ...base, status: 'completed' });
+  console.log(
+    chalk.green(`\nMigrated ${source.shortId} to ${target.name}${options.keep ? ' (copy)' : ''}.`) +
+      chalk.gray(" Tracked in 'agents sessions migrations'."),
+  );
 }
 
 /** Stop the source tmux session (kill its tmux session by name via its socket). */
@@ -551,6 +620,47 @@ async function stopSource(source: SessionMeta, active: ActiveSession | undefined
   const killed = await killSession(name, socket);
   if (killed) console.log(chalk.gray(`  Stopped the source tmux session (${name}).`));
   else console.log(chalk.yellow(`  Source tmux session ${name} was already gone.`));
+}
+
+/**
+ * `agents sessions migrations` — the border tracker: the append-only ledger of
+ * every session handed off to/from another machine (RUSH-1977).
+ */
+export function registerSessionsMigrationsCommand(sessionsCmd: Command): void {
+  sessionsCmd
+    .command('migrations')
+    .description('Show the migration ledger — sessions handed off to/from other machines.')
+    .option('--json', 'Output the raw ledger as JSON')
+    .option('--session <id>', 'Only rows whose session id starts with this fragment')
+    .action((options: { json?: boolean; session?: string }) => {
+      let recs = readMigrations();
+      if (options.session) recs = recs.filter((r) => r.sessionId.startsWith(options.session!) || r.shortId.startsWith(options.session!));
+      if (options.json) {
+        console.log(JSON.stringify(recs, null, 2));
+        return;
+      }
+      if (recs.length === 0) {
+        console.log(chalk.gray('No migrations recorded yet. Move one: agents sessions migrate --auto'));
+        return;
+      }
+      // Newest first — the most recent hop of a session is what you usually want.
+      recs.reverse();
+      console.log(
+        chalk.bold('WHEN'.padEnd(18)) + chalk.bold('SESSION'.padEnd(11)) + chalk.bold('AGENT'.padEnd(9)) +
+          chalk.bold('ROUTE'.padEnd(30)) + chalk.bold('MODE'.padEnd(11)) + chalk.bold('STATUS'),
+      );
+      for (const r of recs) {
+        const when = r.at.slice(0, 16).replace('T', ' ');
+        const route = `${r.from.host} → ${r.to.box ?? r.to.host}`;
+        const kind = r.move ? r.mode : `${r.mode}·copy`;
+        const status = r.status === 'completed' ? chalk.green('ok') : chalk.red('failed');
+        const pr = r.wipPr ? chalk.gray(`  ${r.wipPr}`) : '';
+        console.log(
+          when.padEnd(18) + r.shortId.padEnd(11) + r.agent.padEnd(9) +
+            route.padEnd(30) + kind.padEnd(11) + status + pr,
+        );
+      }
+    });
 }
 
 /** Map a tmux pane id to its session name via the same tmux binary the engine uses. */

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -32,6 +32,8 @@ import { spawnSync } from 'child_process';
 
 import type { SessionMeta } from '../lib/session/types.js';
 import type { ActiveSession } from '../lib/session/active.js';
+import { AGENTS } from '../lib/agents.js';
+import type { AgentId } from '../lib/types.js';
 import { getActiveSessions } from '../lib/session/active.js';
 import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
 import { buildResumeCommand } from './sessions.js';
@@ -526,7 +528,10 @@ async function resumeOnTarget(
  * non-resumable agent there is no faithful --resume, so we start the agent with
  * a prompt pointing it at the imported transcript path.
  */
-function rehydrateCommand(source: SessionMeta): string[] {
+export function rehydrateCommand(source: SessionMeta): string[] {
+  // Resolve the real executable — the session-agent id is not always the binary
+  // name (antigravity → `agy`), matching versionedAliasIfPresent/buildFallbackCommand.
+  const cli = AGENTS[source.agent as AgentId]?.cliCommand ?? source.agent;
   const origin = source.machine ? ` from ${source.machine}` : '';
   const prompt = [
     `You are continuing session ${source.shortId}, migrated to this machine${origin}.`,
@@ -535,7 +540,7 @@ function rehydrateCommand(source: SessionMeta): string[] {
     `use them so large tool outputs don't blow your context — skim the recent turns first,`,
     `widen only if you need to, then continue the work where it left off.`,
   ].join(' ');
-  return [source.agent, prompt];
+  return [cli, prompt];
 }
 
 async function sessionsMigrateAction(sessionId: string | undefined, options: MigrateOptions): Promise<void> {
@@ -606,10 +611,14 @@ async function sessionsMigrateAction(sessionId: string | undefined, options: Mig
 /** Stop the source tmux session (kill its tmux session by name via its socket). */
 async function stopSource(source: SessionMeta, active: ActiveSession | undefined): Promise<void> {
   const mux = active?.provenance?.mux;
-  const pane = mux?.pane ?? process.env.TMUX_PANE;
+  // Fail closed: only the SOURCE's own pane, from its active-session provenance.
+  // Never fall back to $TMUX_PANE — that is the invoking shell's pane, so a
+  // migrate run by explicit id from a different pane (where `active` didn't
+  // resolve) would otherwise kill the user's OWN session, not the source.
+  const pane = mux?.pane;
   const socket = mux?.socket;
   if (!pane) {
-    console.log(chalk.yellow('  Could not resolve the source tmux pane to stop it — leaving the source running.'));
+    console.log(chalk.yellow(`  Could not resolve ${source.shortId}'s own tmux pane — leaving it running (won't stop a pane not confirmed to be the source).`));
     return;
   }
   const name = resolveSessionNameForPane(pane, socket);

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -1,0 +1,563 @@
+/**
+ * `agents sessions migrate` (alias `detach`) — relocate a RUNNING agent session
+ * from this machine onto another (a fleet worker, a registered device, or a warm
+ * ephemeral crabbox box), then stop the source so the interactive machine
+ * reclaims its compute (RUSH-1977).
+ *
+ * This is orchestration glue over primitives that already exist — it does not
+ * reinvent transport, resume, or scoring:
+ *   - resolve the source session from the current tmux pane via `getActiveSessions()`
+ *     (`provenance.mux.pane` matched against $TMUX_PANE);
+ *   - pick / verify the target with the pure scorer in
+ *     `lib/session/migrate-targets.ts` + `readyProbe()` / `bootstrapAgentsCli()`;
+ *   - wrap up a dirty working tree (mechanical WIP-PR by default, or delegate a
+ *     wrap-up turn to the running agent with --agent-wrapup);
+ *   - ship the transcript with the SAME bundle pipeline as
+ *     `sessions export --stdout | sessions import -`, over `sshExec`;
+ *   - resume on the target through the SAME `openSurfaces({ backend:'tmux', host })`
+ *     path `sessions resume --host` uses;
+ *   - only AFTER the target's prompt is confirmed live, kill the source tmux
+ *     session (`killSession`). --keep skips the kill (copy, not move).
+ *
+ * INVARIANT: the source is never killed before the transcript + branch are
+ * confirmed on the target.
+ */
+import * as os from 'os';
+import * as fs from 'fs';
+import chalk from 'chalk';
+import simpleGit from 'simple-git';
+import type { Command } from 'commander';
+import { spawnSync } from 'child_process';
+
+import type { SessionMeta } from '../lib/session/types.js';
+import type { ActiveSession } from '../lib/session/active.js';
+import { getActiveSessions } from '../lib/session/active.js';
+import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
+import { buildResumeCommand } from './sessions.js';
+import { openSurfaces } from '../lib/terminal/index.js';
+import { injectTargetFromReplyRail } from '../lib/session/inject.js';
+import { injectIntoTerminal } from '../lib/terminal/index.js';
+import { killSession } from '../lib/tmux/session.js';
+
+import { listAllHosts, resolveHost } from '../lib/hosts/registry.js';
+import type { Host } from '../lib/hosts/types.js';
+import { sshTargetFor } from '../lib/hosts/types.js';
+import { readyProbe, bootstrapAgentsCli, viewHasAgent } from '../lib/hosts/ready.js';
+import { sshExec, shellQuote } from '../lib/ssh-exec.js';
+import { loadDevices } from '../lib/devices/registry.js';
+import { readStatsCache } from '../lib/devices/stats-cache.js';
+import type { DeviceStats } from '../lib/devices/health.js';
+import {
+  crabboxList,
+  crabboxWarmup,
+  crabboxWaitReady,
+  crabboxSshArgv,
+  type CrabboxBox,
+} from '../lib/crabbox/cli.js';
+import { reusableBoxes, boxAddress } from './lease.js';
+import {
+  pickBestTarget,
+  rankTargets,
+  enumerateTargets,
+  type MigrateTarget,
+  type MigrateContext,
+} from '../lib/session/migrate-targets.js';
+import { itemPicker } from '../lib/picker.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { setHelpSections } from '../lib/help.js';
+
+/** Agents whose sessions cannot be faithfully --resume'd (buildResumeCommand → null). */
+type MigrateMode = 'resume' | 'rehydrate';
+
+interface MigrateOptions {
+  auto?: boolean;
+  host?: string;
+  lease?: boolean;
+  mode?: MigrateMode;
+  keep?: boolean;
+  agentWrapup?: boolean;
+}
+
+export function registerSessionsMigrateCommand(sessionsCmd: Command): void {
+  const cmd = sessionsCmd
+    .command('migrate [session-id]')
+    .alias('detach')
+    .description('Relocate a running session onto another machine (fleet worker, device, or ephemeral box), then stop the source here.')
+    .option('--auto', 'Pick the best target host automatically (idle fleet worker preferred)')
+    .option('--host <name>', 'Explicit target: an enrolled host, a device, or a warm ephemeral box slug')
+    .option('--lease', 'Provision a fresh ephemeral crabbox box as the target')
+    .option('--mode <mode>', 'resume (faithful --resume) or rehydrate (fresh agent reads the transcript)', 'resume')
+    .option('--keep', 'Copy, not move — do NOT stop the source after resuming on the target')
+    .option('--agent-wrapup', 'Delegate the dirty-tree wrap-up to the running agent instead of a mechanical WIP-PR');
+
+  setHelpSections(cmd, {
+    examples: `
+      # Move the session in THIS pane onto the least-busy fleet worker
+      agents sessions migrate --auto
+
+      # Move a specific session onto a named host
+      agents sessions migrate a1b2c3d4 --host yosemite-s1
+
+      # Spin up a fresh ephemeral box and move onto it
+      agents sessions migrate --lease
+
+      # Copy (don't stop the source), letting the agent wrap up its own dirty tree
+      agents sessions migrate --host box-a --keep --agent-wrapup
+    `,
+    notes: `
+      - Without a [session-id], migrate resolves the session running in THIS tmux pane ($TMUX_PANE).
+      - The source is stopped only AFTER the target's prompt is confirmed live; --keep skips the stop.
+      - Non-resumable agents (gemini, antigravity, openclaw, rush, hermes, grok, kimi, droid) cannot be
+        faithfully --resume'd, so migrate uses --mode rehydrate for them and says so.
+      - Transport reuses the same bundle pipeline as 'sessions export --stdout | sessions import -', over SSH.
+      - Resume reuses the same host path as 'sessions resume --host' (tmux backend).
+    `,
+  });
+
+  cmd.action(async (sessionId: string | undefined, options: MigrateOptions) => {
+    await sessionsMigrateAction(sessionId, options);
+  });
+}
+
+function fail(message: string): never {
+  console.error(chalk.red(message));
+  process.exit(1);
+}
+
+/**
+ * Resolve the session to migrate. With an explicit id, resolve it from the
+ * on-disk index. Without one, match the current tmux pane ($TMUX_PANE) against a
+ * live session's `provenance.mux.pane` and resolve that id to its SessionMeta.
+ */
+async function resolveSourceSession(
+  sessionId: string | undefined,
+): Promise<{ meta: SessionMeta; active?: ActiveSession }> {
+  if (sessionId) {
+    const all = await discoverSessions({ all: true, sortBy: 'timestamp', limit: 2000 });
+    const matches = resolveSessionById(all, sessionId);
+    if (matches.length === 0) fail(`No session matches "${sessionId}".`);
+    if (matches.length > 1) {
+      fail(`"${sessionId}" is ambiguous (${matches.length} matches). Pass a longer id fragment.`);
+    }
+    const active = (await getActiveSessions()).find((s) => s.sessionId === matches[0].id);
+    return { meta: matches[0], active };
+  }
+
+  const pane = process.env.TMUX_PANE;
+  if (!pane) {
+    fail('Not inside a tmux pane — pass an explicit [session-id] to migrate a specific session.');
+  }
+  const actives = await getActiveSessions();
+  const active = actives.find((s) => s.provenance?.mux?.kind === 'tmux' && s.provenance.mux.pane === pane);
+  if (!active || !active.sessionId) {
+    fail(`No running session resolves to this pane (${pane}). Pass an explicit [session-id].`);
+  }
+  const all = await discoverSessions({ all: true, sortBy: 'timestamp', limit: 2000 });
+  const matches = resolveSessionById(all, active.sessionId);
+  if (matches.length === 0) fail(`This pane's session (${active.sessionId}) is not in the index yet.`);
+  return { meta: matches[0], active };
+}
+
+/** Live headroom for the scorer: prefer the disk stats-cache (fast, no ssh). */
+function statsByName(): Map<string, DeviceStats> {
+  const cache = readStatsCache();
+  return new Map(Object.entries(cache));
+}
+
+/** Enumerate + rank targets, honoring --host / --auto / --lease. */
+async function resolveTarget(
+  options: MigrateOptions,
+  source: SessionMeta,
+): Promise<MigrateTarget> {
+  const selfHostname = os.hostname();
+  const ctx: MigrateContext = {
+    selfHostname,
+    sourceHostname: source.machine ?? selfHostname,
+    sourceOs: process.platform === 'darwin' ? 'darwin' : process.platform === 'win32' ? 'windows' : 'linux',
+  };
+
+  if (options.lease) {
+    return await provisionEphemeralTarget();
+  }
+
+  const hosts = await listAllHosts();
+  await loadDevices(); // ensure device registry is warmed (listAllHosts folds it in)
+  let warm: CrabboxBox[] = [];
+  try {
+    warm = reusableBoxes(crabboxList(), Math.floor(Date.now() / 1000));
+  } catch {
+    warm = []; // crabbox not configured — fleet-only targets
+  }
+  const stats = statsByName();
+
+  if (options.host) {
+    // Explicit target: a fleet host/device, or a warm box slug.
+    const box = warm.find((b) => b.slug === options.host);
+    if (box) {
+      return { name: box.slug, kind: 'ephemeral', os: 'linux', headroom: 'unknown', box };
+    }
+    const host = await resolveHost(options.host);
+    if (!host) fail(`No host, device, or warm box named "${options.host}".`);
+    if (host.name.toLowerCase() === selfHostname.toLowerCase()) {
+      fail(`"${options.host}" is this machine — migrate needs a different target.`);
+    }
+    return { name: host.name, kind: 'fleet', os: host.os, headroom: 'unknown', host };
+  }
+
+  if (options.auto) {
+    const best = pickBestTarget(hosts, warm, stats, ctx);
+    if (!best) {
+      fail('No eligible target found (no reachable, dispatchable host that isn\'t this machine or the source). Try --lease to provision a fresh box.');
+    }
+    console.log(chalk.gray(`Auto-selected ${best.name} (${best.kind}, ${best.headroom}).`));
+    return best;
+  }
+
+  // Interactive: rank the candidates and let the user pick.
+  if (!isInteractiveTerminal()) {
+    fail('Pass --auto, --host <name>, or --lease to choose a target (no interactive picker without a tty).');
+  }
+  const ranked = rankTargets(enumerateTargets(hosts, warm, stats, ctx), ctx);
+  if (ranked.length === 0) {
+    fail('No eligible target found. Try --lease to provision a fresh box.');
+  }
+  try {
+    const picked = await itemPicker<MigrateTarget>({
+      message: 'Migrate this session to which machine?',
+      items: ranked,
+      filter: () => ranked,
+      labelFor: (t) => `${chalk.bold(t.name.padEnd(20))}${chalk.gray(`${t.kind} · ${t.headroom}${t.os ? ' · ' + t.os : ''}`)}`,
+      shortIdFor: (t) => t.name,
+      enterHint: 'migrate',
+    });
+    if (!picked) fail('Cancelled.');
+    return picked.item;
+  } catch (err) {
+    if (isPromptCancelled(err)) fail('Cancelled.');
+    throw err;
+  }
+}
+
+/** Provision a fresh ephemeral crabbox box (tailnet) and wait for it to be ready. */
+async function provisionEphemeralTarget(): Promise<MigrateTarget> {
+  console.log(chalk.gray('Provisioning a fresh ephemeral box (crabbox)…'));
+  const leased = await crabboxWarmup({ netMode: 'tailscale' });
+  const ready = await crabboxWaitReady(leased.slug).catch(() => leased);
+  console.log(chalk.green(`Leased box ${ready.slug}.`));
+  return { name: ready.slug, kind: 'ephemeral', os: 'linux', headroom: 'idle', box: ready };
+}
+
+/** Resolve the SSH target string for a migrate target (host alias or box address). */
+function sshTargetForTarget(target: MigrateTarget): string {
+  if (target.kind === 'fleet' && target.host) return sshTargetFor(target.host);
+  if (target.kind === 'ephemeral' && target.box) {
+    const addr = boxAddress(target.box);
+    if (!addr) fail(`Ephemeral box ${target.box.slug} has no reachable address.`);
+    return addr!;
+  }
+  fail(`Cannot resolve an SSH target for ${target.name}.`);
+}
+
+/**
+ * Harness-parity gate (pure, testable). `buildResumeCommand` returns null for the
+ * non-resumable agents (gemini, antigravity, openclaw, rush, hermes, grok, kimi,
+ * droid) — for those a faithful --resume is impossible, so a requested `resume`
+ * transparently becomes `rehydrate`. A resumable agent honors the request.
+ * Returns the effective mode plus whether it was downgraded, so the caller can
+ * print the notice.
+ */
+export function effectiveMode(source: SessionMeta, requested: MigrateMode): { mode: MigrateMode; downgraded: boolean } {
+  const resumable = buildResumeCommand(source) !== null;
+  if (!resumable && requested === 'resume') return { mode: 'rehydrate', downgraded: true };
+  return { mode: requested, downgraded: false };
+}
+
+/**
+ * Verify the target can run the session's agent+version. Returns the effective
+ * mode: a non-resumable agent (buildResumeCommand → null) forces rehydrate; a
+ * missing agents-cli triggers a bootstrap; a missing agent (in rehydrate) is a
+ * printed notice, not a failure.
+ */
+function ensureTargetReady(
+  target: MigrateTarget,
+  sshTarget: string,
+  source: SessionMeta,
+  requested: MigrateMode,
+): MigrateMode {
+  // buildResumeCommand gates faithful resume: null → only rehydrate is possible.
+  const gated = effectiveMode(source, requested);
+  let mode = gated.mode;
+  if (gated.downgraded) {
+    console.log(chalk.yellow(`  ${source.agent} sessions can't be faithfully resumed — using --mode rehydrate.`));
+  }
+
+  const remoteOs = target.host?.os;
+  let probe = readyProbe(sshTarget, remoteOs);
+  if (!probe.reachable) {
+    fail(`Target ${target.name} is not reachable over SSH (${sshTarget}).`);
+  }
+  if (!probe.version) {
+    console.log(chalk.gray(`  agents-cli not found on ${target.name} — bootstrapping…`));
+    const boot = bootstrapAgentsCli(sshTarget, null, remoteOs);
+    if (!boot.ok) fail(`Failed to bootstrap agents-cli on ${target.name}: ${boot.output.split('\n').pop()}`);
+    probe = readyProbe(sshTarget, remoteOs);
+  }
+
+  if (!viewHasAgent(probe.view, source.agent)) {
+    if (mode === 'resume') {
+      console.log(chalk.yellow(`  ${source.agent} isn't installed on ${target.name} — falling back to --mode rehydrate.`));
+      mode = 'rehydrate';
+    } else {
+      console.log(chalk.gray(`  Note: ${source.agent} isn't installed on ${target.name}; the rehydrated session will read the transcript with whatever agent runs there.`));
+    }
+  }
+  return mode;
+}
+
+/**
+ * Wrap up the working tree so no local edits are stranded when the source stops.
+ * Dirty → commit to a fresh branch + push + open a draft (WIP) PR. Clean-but-ahead
+ * → push. --agent-wrapup instead injects a wrap-up turn into the running agent.
+ * Returns the branch name to check out on an ephemeral target (or undefined).
+ */
+async function wrapUpWorkingTree(
+  source: SessionMeta,
+  active: ActiveSession | undefined,
+  options: MigrateOptions,
+): Promise<string | undefined> {
+  const cwd = source.cwd;
+  if (!cwd || !fs.existsSync(cwd)) return undefined;
+  const git = simpleGit(cwd);
+  const isRepo = await git.checkIsRepo().catch(() => false);
+  if (!isRepo) return undefined;
+
+  const status = await git.status();
+  const dirty = status.files.length > 0;
+  const ahead = status.ahead ?? 0;
+
+  if (!dirty && ahead === 0) {
+    return status.current || undefined;
+  }
+
+  if (options.agentWrapup) {
+    await delegateWrapupToAgent(source, active);
+    // The agent handles the commit/push; report its current branch for checkout.
+    const after = await git.status();
+    return after.current || undefined;
+  }
+
+  if (dirty) {
+    const branch = status.current && status.current !== 'main' && status.current !== 'master'
+      ? status.current
+      : `migrate/${source.shortId}`;
+    // Only create the branch when we're on the default branch (don't strand edits on main).
+    if (status.current === 'main' || status.current === 'master') {
+      console.log(chalk.gray(`  Working tree dirty on ${status.current} — committing to a new branch ${branch}.`));
+      await git.checkoutLocalBranch(branch);
+    } else {
+      console.log(chalk.gray(`  Working tree dirty on ${branch} — committing before migrate.`));
+    }
+    await git.add('-A');
+    await git.commit(`wip: migrate ${source.agent} session ${source.shortId}`);
+    await git.push(['-u', 'origin', branch]).catch((e) => {
+      console.log(chalk.yellow(`  push failed: ${(e as Error).message}`));
+    });
+    openWipPr(cwd, branch);
+    return branch;
+  }
+
+  // Clean but ahead — push what's committed.
+  console.log(chalk.gray(`  ${ahead} local commit(s) ahead — pushing before migrate.`));
+  await git.push().catch((e) => console.log(chalk.yellow(`  push failed: ${(e as Error).message}`)));
+  return status.current || undefined;
+}
+
+/** Open a draft (WIP) PR for the wrap-up branch. Best-effort; a failure is a notice. */
+function openWipPr(cwd: string, branch: string): void {
+  const r = spawnSync(
+    'gh',
+    ['pr', 'create', '--draft', '--fill', '--head', branch],
+    { cwd, encoding: 'utf-8' },
+  );
+  if (r.status === 0) {
+    const url = (r.stdout || '').trim().split('\n').pop();
+    console.log(chalk.green(`  WIP PR: ${url}`));
+  } else {
+    console.log(chalk.yellow(`  Could not open a WIP PR (${(r.stderr || '').trim().split('\n').pop() || 'gh error'}). Branch ${branch} is pushed.`));
+  }
+}
+
+/** --agent-wrapup: inject a wrap-up turn into the running agent's tmux pane. */
+async function delegateWrapupToAgent(source: SessionMeta, active: ActiveSession | undefined): Promise<void> {
+  const rail = active?.provenance?.reply;
+  if (!rail) {
+    console.log(chalk.yellow('  --agent-wrapup: no addressable reply rail for the running agent; committing mechanically instead is not possible here — the tree stays as-is.'));
+    return;
+  }
+  const target = injectTargetFromReplyRail(rail);
+  if (!target) {
+    console.log(chalk.yellow('  --agent-wrapup: reply rail is not injectable; tree stays as-is.'));
+    return;
+  }
+  const text =
+    'Before this session is migrated to another machine, commit the current working changes to a branch, push it, and open a draft WIP PR. Then reply "wrapped up".';
+  const res = await injectIntoTerminal(target, text, { enter: true });
+  if (res.ok) {
+    console.log(chalk.gray('  Asked the running agent to wrap up its working tree (draft PR).'));
+  } else {
+    console.log(chalk.yellow(`  --agent-wrapup injection failed: ${res.error ?? 'unknown'}.`));
+  }
+}
+
+/**
+ * Ship the transcript to the target with the SAME bundle pipeline as
+ * `sessions export --stdout | sessions import -`: export the one session's bundle
+ * locally, pipe it into `agents sessions import -` on the target over SSH.
+ */
+function shipTranscript(sshTarget: string, source: SessionMeta, remoteOs?: string): void {
+  const local = spawnSync(
+    process.execPath,
+    [process.argv[1], 'sessions', 'export', source.id, '--stdout'],
+    { encoding: 'utf-8', maxBuffer: 256 * 1024 * 1024 },
+  );
+  if (local.status !== 0 || !local.stdout) {
+    fail(`Failed to export the transcript locally: ${(local.stderr || '').trim().split('\n').pop() || 'export error'}`);
+  }
+  const importCmd =
+    remoteOs && remoteOs.toLowerCase().includes('win')
+      ? 'agents sessions import -'
+      : `bash -lc ${shellQuote('agents sessions import -')}`;
+  const res = sshExec(sshTarget, importCmd, { input: local.stdout, timeoutMs: 120000 });
+  if (res.code !== 0) {
+    fail(`Failed to import the transcript on ${sshTarget}: ${res.stderr.trim().split('\n').pop() || 'import error'}`);
+  }
+  console.log(chalk.green('  Transcript shipped to the target.'));
+}
+
+/** Git-clone + checkout the (WIP) branch on an ephemeral box so the cwd resolves. */
+function prepareEphemeralCwd(sshTarget: string, source: SessionMeta, branch: string | undefined): string | undefined {
+  const remote = spawnSync('git', ['-C', source.cwd || '.', 'remote', 'get-url', 'origin'], { encoding: 'utf-8' });
+  const url = (remote.stdout || '').trim();
+  if (remote.status !== 0 || !url) {
+    console.log(chalk.yellow('  Ephemeral target: the source cwd has no origin remote to clone; the resumed session will start in $HOME.'));
+    return undefined;
+  }
+  const dir = `~/migrated/${source.shortId}`;
+  const checkout = branch ? ` && git checkout ${shellQuote(branch)}` : '';
+  const script = `mkdir -p ~/migrated && (test -d ${dir}/.git || git clone ${shellQuote(url)} ${dir})${' && cd ' + dir + checkout}`;
+  const res = sshExec(sshTarget, `bash -lc ${shellQuote(script)}`, { timeoutMs: 300000 });
+  if (res.code !== 0) {
+    console.log(chalk.yellow(`  Clone on the box failed (${res.stderr.trim().split('\n').pop() || 'git error'}); the resumed session will start in $HOME.`));
+    return undefined;
+  }
+  return dir;
+}
+
+/**
+ * Resume the session on the target through the SAME host path as
+ * `sessions resume --host` (tmux backend). Returns true when the resume launched.
+ */
+async function resumeOnTarget(
+  sshTarget: string,
+  source: SessionMeta,
+  remoteCwd: string | undefined,
+  mode: MigrateMode,
+): Promise<boolean> {
+  const command = mode === 'resume' ? buildResumeCommand(source) : rehydrateCommand(source);
+  if (!command) {
+    fail(`Cannot build a resume command for ${source.agent} (mode ${mode}).`);
+  }
+  const cwd = remoteCwd ?? source.cwd ?? '~';
+  const results = await openSurfaces(
+    [{ cwd, command: command! }],
+    { backend: 'tmux', host: sshTarget, packing: 'tabs' },
+  );
+  const r = results[0];
+  if (!r || !r.ok) {
+    console.log(chalk.red(`  Resume on ${sshTarget} failed: ${r?.error ?? 'unknown'}`));
+    return false;
+  }
+  console.log(chalk.green(`  Resumed on the target (${command!.join(' ')}).`));
+  return true;
+}
+
+/**
+ * Rehydrate command: launch a fresh agent that reads the transcript. For a
+ * non-resumable agent there is no faithful --resume, so we start the agent with
+ * a prompt pointing it at the imported transcript path.
+ */
+function rehydrateCommand(source: SessionMeta): string[] {
+  const prompt = `You are resuming a prior session (id ${source.id}). Read its transcript at the imported path under ~/.agents/.history and continue where it left off.`;
+  return [source.agent, prompt];
+}
+
+async function sessionsMigrateAction(sessionId: string | undefined, options: MigrateOptions): Promise<void> {
+  if (options.mode && options.mode !== 'resume' && options.mode !== 'rehydrate') {
+    fail(`--mode must be 'resume' or 'rehydrate' (got "${options.mode}").`);
+  }
+
+  // 1. Resolve the source session (current-pane unless an id is given).
+  const { meta: source, active } = await resolveSourceSession(sessionId);
+  console.log(chalk.bold(`Migrating ${source.agent} session ${source.shortId}`) + chalk.gray(` (${source.cwd ?? 'no cwd'})`));
+
+  // 2. Resolve the target host.
+  const target = await resolveTarget(options, source);
+  const sshTarget = sshTargetForTarget(target);
+
+  // 3. Verify the target can run the agent+version (bootstrap if missing); resolve the mode.
+  const mode = ensureTargetReady(target, sshTarget, source, options.mode ?? 'resume');
+
+  // 4. Wrap up the working dir (WIP PR by default, or delegate to the agent).
+  const branch = await wrapUpWorkingTree(source, active, options);
+
+  // 5. Transport the transcript to the target (portable export/import over SSH).
+  shipTranscript(sshTarget, source, target.host?.os);
+
+  // 6. For an ephemeral box, clone + checkout the branch so the cwd resolves.
+  const remoteCwd =
+    target.kind === 'ephemeral' ? prepareEphemeralCwd(sshTarget, source, branch) : source.cwd;
+
+  // 7. Resume on the target.
+  const resumed = await resumeOnTarget(sshTarget, source, remoteCwd, mode);
+  if (!resumed) {
+    fail('Resume on the target did not launch — the source is left running (nothing was stopped).');
+  }
+
+  // 8. INVARIANT: only now that the transcript + branch are confirmed on the
+  //    target and the resume launched, stop the source. --keep skips this.
+  if (options.keep) {
+    console.log(chalk.gray('--keep: the source session is left running (copy, not move).'));
+  } else {
+    await stopSource(source, active);
+  }
+
+  console.log(chalk.green(`\nMigrated ${source.shortId} to ${target.name}${options.keep ? ' (copy)' : ''}.`));
+}
+
+/** Stop the source tmux session (kill its tmux session by name via its socket). */
+async function stopSource(source: SessionMeta, active: ActiveSession | undefined): Promise<void> {
+  const mux = active?.provenance?.mux;
+  const pane = mux?.pane ?? process.env.TMUX_PANE;
+  const socket = mux?.socket;
+  if (!pane) {
+    console.log(chalk.yellow('  Could not resolve the source tmux pane to stop it — leaving the source running.'));
+    return;
+  }
+  const name = resolveSessionNameForPane(pane, socket);
+  if (!name) {
+    console.log(chalk.yellow(`  Could not resolve a tmux session name for pane ${pane} — leaving the source running.`));
+    return;
+  }
+  const killed = await killSession(name, socket);
+  if (killed) console.log(chalk.gray(`  Stopped the source tmux session (${name}).`));
+  else console.log(chalk.yellow(`  Source tmux session ${name} was already gone.`));
+}
+
+/** Map a tmux pane id to its session name via the same tmux binary the engine uses. */
+function resolveSessionNameForPane(pane: string, socket?: string): string | undefined {
+  const args = socket ? ['-S', socket] : [];
+  const r = spawnSync('tmux', [...args, 'display-message', '-pt', pane, '-p', '#{session_name}'], { encoding: 'utf-8' });
+  if (r.status !== 0) return undefined;
+  const name = (r.stdout || '').trim();
+  return name || undefined;
+}

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -52,7 +52,7 @@ import { registerFocusCommand } from './focus.js';
 import { registerSessionsInjectCommand } from './sessions-inject.js';
 import { registerSessionsExportCommand } from './sessions-export.js';
 import { registerSessionsImportCommand } from './sessions-import.js';
-import { registerSessionsMigrateCommand } from './sessions-migrate.js';
+import { registerSessionsMigrateCommand, registerSessionsMigrationsCommand } from './sessions-migrate.js';
 import { runBrowserSessions } from '../lib/browser/sessions-list.js';
 
 const SESSION_AGENT_FILTER_HELP = `Filter by agent, e.g. claude, codex, claude@2.0.65`;
@@ -2647,6 +2647,7 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsExportCommand(sessionsCmd);
   registerSessionsImportCommand(sessionsCmd);
   registerSessionsMigrateCommand(sessionsCmd);
+  registerSessionsMigrationsCommand(sessionsCmd);
 }
 
 function formatNoSessionsMessage(

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -52,6 +52,7 @@ import { registerFocusCommand } from './focus.js';
 import { registerSessionsInjectCommand } from './sessions-inject.js';
 import { registerSessionsExportCommand } from './sessions-export.js';
 import { registerSessionsImportCommand } from './sessions-import.js';
+import { registerSessionsMigrateCommand } from './sessions-migrate.js';
 import { runBrowserSessions } from '../lib/browser/sessions-list.js';
 
 const SESSION_AGENT_FILTER_HELP = `Filter by agent, e.g. claude, codex, claude@2.0.65`;
@@ -2645,6 +2646,7 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsInjectCommand(sessionsCmd);
   registerSessionsExportCommand(sessionsCmd);
   registerSessionsImportCommand(sessionsCmd);
+  registerSessionsMigrateCommand(sessionsCmd);
 }
 
 function formatNoSessionsMessage(

--- a/apps/cli/src/lib/session/migrate-targets.test.ts
+++ b/apps/cli/src/lib/session/migrate-targets.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  enumerateTargets,
+  rankTargets,
+  pickBestTarget,
+  type MigrateContext,
+} from './migrate-targets.js';
+import type { Host } from '../hosts/types.js';
+import type { DeviceStats } from '../devices/health.js';
+import type { CrabboxBox } from '../crabbox/cli.js';
+
+/** Minimal Host builder — only the fields the scorer reads. */
+function host(name: string, opts: Partial<Host> = {}): Host {
+  return {
+    name,
+    provider: 'devices',
+    source: 'ssh-config',
+    os: 'darwin',
+    ...opts,
+  };
+}
+
+/** DeviceStats builder driving a specific headroom bucket via loadPercent. */
+function stats(hostName: string, loadPercent: number): DeviceStats {
+  return { host: hostName, reachable: true, loadPercent, fetchedAt: 0 };
+}
+
+function box(slug: string, opts: Partial<CrabboxBox> = {}): CrabboxBox {
+  return {
+    name: `crabbox-${slug}`,
+    status: 'running',
+    slug,
+    lease: `cbx_${slug}`,
+    state: 'ready',
+    ready: true,
+    keep: false,
+    createdAt: 0,
+    expiresAt: null,
+    lastTouchedAt: 0,
+    idleTimeoutSecs: null,
+    ...opts,
+  };
+}
+
+const ctx: MigrateContext = {
+  selfHostname: 'zion',
+  sourceHostname: 'src-box',
+  sourceOs: 'darwin',
+};
+
+describe('enumerateTargets — exclusion of the interactive machine and the source', () => {
+  it('never offers the current machine (os.hostname) or the source as a target', () => {
+    const hosts = [host('zion'), host('src-box'), host('worker-a')];
+    const targets = enumerateTargets(hosts, [], new Map(), ctx);
+    const names = targets.map((t) => t.name);
+    expect(names).not.toContain('zion');
+    expect(names).not.toContain('src-box');
+    expect(names).toContain('worker-a');
+  });
+
+  it('excludes case-insensitively (hostname casing must not leak a self-target)', () => {
+    const hosts = [host('ZION'), host('Worker-A')];
+    const names = enumerateTargets(hosts, [], new Map(), ctx).map((t) => t.name);
+    expect(names).not.toContain('ZION');
+    expect(names).toContain('Worker-A');
+  });
+
+  it('drops non-dispatchable and offline hosts, keeps absent-means-dispatchable', () => {
+    const hosts = [
+      host('pw-device', { dispatchable: false }),
+      host('sleeping', { status: 'offline' }),
+      host('reachable', { status: 'online' }),
+      host('unknown-but-ok'),
+    ];
+    const names = enumerateTargets(hosts, [], new Map(), ctx).map((t) => t.name);
+    expect(names).not.toContain('pw-device');
+    expect(names).not.toContain('sleeping');
+    expect(names).toEqual(expect.arrayContaining(['reachable', 'unknown-but-ok']));
+  });
+
+  it('includes warm ephemeral boxes tagged as such', () => {
+    const targets = enumerateTargets([], [box('blue-hermit')], new Map(), ctx);
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ name: 'blue-hermit', kind: 'ephemeral', os: 'linux' });
+  });
+
+  it('derives headroom from the stats map, unknown when absent', () => {
+    const hosts = [host('idle-box'), host('no-stats')];
+    const s = new Map<string, DeviceStats>([['idle-box', stats('idle-box', 5)]]);
+    const targets = enumerateTargets(hosts, [], s, ctx);
+    expect(targets.find((t) => t.name === 'idle-box')!.headroom).toBe('idle');
+    expect(targets.find((t) => t.name === 'no-stats')!.headroom).toBe('unknown');
+  });
+});
+
+describe('rankTargets — auto ordering', () => {
+  it('prefers a platform match with the source over a busier same-platform box? no — platform first, then headroom', () => {
+    // linux-loaded vs darwin-idle, source is darwin: darwin wins on platform match.
+    const targets = enumerateTargets(
+      [host('linux-idle', { os: 'linux' }), host('mac-busy', { os: 'darwin' })],
+      [],
+      new Map([
+        ['linux-idle', stats('linux-idle', 5)],
+        ['mac-busy', stats('mac-busy', 60)],
+      ]),
+      ctx,
+    );
+    const ranked = rankTargets(targets, ctx);
+    expect(ranked[0].name).toBe('mac-busy');
+  });
+
+  it('prefers a warm fleet worker over provisioning a box, all else equal', () => {
+    const targets = enumerateTargets(
+      [host('worker', { os: 'linux' })],
+      [box('fresh-box')],
+      new Map([
+        ['worker', stats('worker', 10)],
+        ['fresh-box', stats('fresh-box', 10)],
+      ]),
+      { ...ctx, sourceOs: 'linux' },
+    );
+    const ranked = rankTargets(targets, { ...ctx, sourceOs: 'linux' });
+    expect(ranked[0].kind).toBe('fleet');
+    expect(ranked[0].name).toBe('worker');
+  });
+
+  it('ranks by headroom among same-platform same-kind targets (idle beats loaded)', () => {
+    const targets = enumerateTargets(
+      [host('busy', { os: 'darwin' }), host('idle', { os: 'darwin' })],
+      [],
+      new Map([
+        ['busy', stats('busy', 80)],
+        ['idle', stats('idle', 5)],
+      ]),
+      ctx,
+    );
+    const ranked = rankTargets(targets, ctx);
+    expect(ranked.map((t) => t.name)).toEqual(['idle', 'busy']);
+  });
+});
+
+describe('pickBestTarget', () => {
+  it('returns null when the only hosts are the self and source', () => {
+    const hosts = [host('zion'), host('src-box')];
+    expect(pickBestTarget(hosts, [], new Map(), ctx)).toBeNull();
+  });
+
+  it('returns the top-ranked eligible target', () => {
+    const hosts = [host('zion'), host('src-box'), host('mac-idle', { os: 'darwin' })];
+    const best = pickBestTarget(hosts, [], new Map([['mac-idle', stats('mac-idle', 3)]]), ctx);
+    expect(best?.name).toBe('mac-idle');
+  });
+});

--- a/apps/cli/src/lib/session/migrate-targets.ts
+++ b/apps/cli/src/lib/session/migrate-targets.ts
@@ -1,0 +1,148 @@
+/**
+ * Target enumeration + `--auto` scorer for `agents sessions migrate` (RUSH-1977).
+ *
+ * `sessions migrate` relocates a running session onto another machine. This
+ * module is the pure decision layer: given the fleet (enrolled hosts + devices
+ * from `listAllHosts()`), their live headroom ({@link Headroom} buckets derived
+ * from `probeFleetStats()` / the disk stats-cache), and the reusable ephemeral
+ * crabbox boxes (`reusableBoxes()`), it enumerates eligible {@link MigrateTarget}s
+ * and ranks them for `--auto`.
+ *
+ * Kept side-effect-free (no ssh, no disk, no clock) so the ranking is a unit test
+ * against synthetic Host[]/DeviceStats — the command layer does the probing and
+ * hands the results in. The one genuine-bug guard the test pins: the source and
+ * the interactive machine (os.hostname()) are never offered as targets.
+ */
+import type { Host } from '../hosts/types.js';
+import type { DeviceStats, Headroom } from '../devices/health.js';
+import { headroom } from '../devices/health.js';
+import type { CrabboxBox } from '../crabbox/cli.js';
+
+/** A machine the current session could be relocated onto. */
+export interface MigrateTarget {
+  /** The `--host` value: a host/device name, or a warm box slug for ephemeral. */
+  name: string;
+  /** Where the target comes from — a fleet host/device, or a warm crabbox box. */
+  kind: 'fleet' | 'ephemeral';
+  /** Captured OS string ('darwin'/'linux'/'windows'/…) when known, for platform-match ranking. */
+  os?: string;
+  /** Live headroom bucket ('idle' is best); 'unknown' when no stats resolved. */
+  headroom: Headroom;
+  /** The underlying host (fleet targets only). */
+  host?: Host;
+  /** The underlying warm box (ephemeral targets only). */
+  box?: CrabboxBox;
+}
+
+/** Inputs the scorer needs about the session being moved and this machine. */
+export interface MigrateContext {
+  /** os.hostname() of the interactive machine — never a valid target. */
+  selfHostname: string;
+  /** The source session's host (machine it currently runs on) — never a valid target. */
+  sourceHostname?: string;
+  /** The source session's OS, for the platform-match bonus. */
+  sourceOs?: string;
+}
+
+/** Headroom rank: lower is better (idle preferred). 'unknown' sorts last among reachable. */
+const HEADROOM_ORDER: Record<Headroom, number> = {
+  idle: 0,
+  light: 1,
+  busy: 2,
+  loaded: 3,
+  unknown: 4,
+};
+
+/** Normalize an os string to a coarse platform token for match comparison. */
+function platformOf(os: string | undefined): string | undefined {
+  if (!os) return undefined;
+  const s = os.toLowerCase();
+  if (s.includes('darwin') || s.includes('mac')) return 'darwin';
+  if (s.includes('win')) return 'windows';
+  if (s.includes('linux')) return 'linux';
+  return s;
+}
+
+/**
+ * Enumerate the fleet + ephemeral targets a session could move to, excluding the
+ * interactive machine and the source. A fleet host is eligible only when it is
+ * dispatchable and not obviously offline; ephemeral (warm) boxes are always
+ * eligible (already provisioned and reachable). `statsByName` supplies live
+ * headroom — a missing entry yields 'unknown' (still eligible, just ranked lower).
+ */
+export function enumerateTargets(
+  hosts: Host[],
+  warmBoxes: CrabboxBox[],
+  statsByName: Map<string, DeviceStats>,
+  ctx: MigrateContext,
+): MigrateTarget[] {
+  const excluded = new Set(
+    [ctx.selfHostname, ctx.sourceHostname].filter((n): n is string => !!n).map((n) => n.toLowerCase()),
+  );
+
+  const fleet: MigrateTarget[] = [];
+  for (const host of hosts) {
+    if (excluded.has(host.name.toLowerCase())) continue;
+    // dispatchable is absent-means-yes; only an explicit false is disqualifying.
+    if (host.dispatchable === false) continue;
+    if (host.status === 'offline') continue;
+    fleet.push({
+      name: host.name,
+      kind: 'fleet',
+      os: host.os,
+      headroom: headroom(statsByName.get(host.name)),
+      host,
+    });
+  }
+
+  const ephemeral: MigrateTarget[] = warmBoxes.map((box) => ({
+    name: box.slug,
+    kind: 'ephemeral',
+    // crabbox boxes are Linux; the address is resolved at use time.
+    os: 'linux',
+    headroom: headroom(statsByName.get(box.slug)),
+    box,
+  }));
+
+  return [...fleet, ...ephemeral];
+}
+
+/**
+ * Rank targets for `--auto`. Order:
+ *   1. Platform match with the source (a faithful --resume wants the same OS family).
+ *   2. Fleet before ephemeral (prefer a warm worker over spinning a box).
+ *   3. Headroom (idle > light > busy > loaded > unknown).
+ *   4. Name, for a stable tie-break.
+ * Returns a new sorted array; does not mutate the input.
+ */
+export function rankTargets(targets: MigrateTarget[], ctx: MigrateContext): MigrateTarget[] {
+  const srcPlatform = platformOf(ctx.sourceOs);
+  const score = (t: MigrateTarget) => {
+    const platformMatch = srcPlatform && platformOf(t.os) === srcPlatform ? 0 : 1;
+    const kindRank = t.kind === 'fleet' ? 0 : 1;
+    return { platformMatch, kindRank, headroomRank: HEADROOM_ORDER[t.headroom], name: t.name };
+  };
+  return [...targets].sort((a, b) => {
+    const sa = score(a);
+    const sb = score(b);
+    if (sa.platformMatch !== sb.platformMatch) return sa.platformMatch - sb.platformMatch;
+    if (sa.kindRank !== sb.kindRank) return sa.kindRank - sb.kindRank;
+    if (sa.headroomRank !== sb.headroomRank) return sa.headroomRank - sb.headroomRank;
+    return sa.name.localeCompare(sb.name);
+  });
+}
+
+/**
+ * Pick the single best `--auto` target, or null when nothing is eligible. A
+ * fully-loaded ('loaded') fleet is still returned (better than failing the
+ * migrate); the command layer can offer `--lease` when this is null.
+ */
+export function pickBestTarget(
+  hosts: Host[],
+  warmBoxes: CrabboxBox[],
+  statsByName: Map<string, DeviceStats>,
+  ctx: MigrateContext,
+): MigrateTarget | null {
+  const ranked = rankTargets(enumerateTargets(hosts, warmBoxes, statsByName, ctx), ctx);
+  return ranked[0] ?? null;
+}

--- a/apps/cli/src/lib/session/migrations.test.ts
+++ b/apps/cli/src/lib/session/migrations.test.ts
@@ -4,7 +4,7 @@
  * catching are ordering (latest wins), per-session filtering, ignoring a failed
  * hop, and surviving a corrupt/partial line.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/apps/cli/src/lib/session/migrations.test.ts
+++ b/apps/cli/src/lib/session/migrations.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Migration ledger — real filesystem round-trip (no mocking) against an injected
+ * temp ledger file. The ledger is an append-only lineage, so the bugs worth
+ * catching are ordering (latest wins), per-session filtering, ignoring a failed
+ * hop, and surviving a corrupt/partial line.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  recordMigration,
+  readMigrations,
+  latestForSession,
+  type MigrationRecord,
+} from './migrations.js';
+
+let dir: string;
+let ledger: string;
+
+function rec(over: Partial<MigrationRecord>): MigrationRecord {
+  return {
+    sessionId: 'sess-a',
+    shortId: 'sessa',
+    agent: 'claude',
+    mode: 'rehydrate',
+    move: true,
+    from: { host: 'src', cwd: '/w' },
+    to: { host: 'dst' },
+    at: '2026-08-01T00:00:00.000Z',
+    status: 'completed',
+    ...over,
+  };
+}
+
+describe('migration ledger', () => {
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migledger-'));
+    ledger = path.join(dir, 'migrations.jsonl');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('round-trips and creates the ledger under a missing dir', () => {
+    expect(readMigrations(ledger)).toEqual([]); // no ledger yet
+    recordMigration(rec({ at: '2026-08-01T00:00:01.000Z' }), ledger);
+    const all = readMigrations(ledger);
+    expect(all.length).toBe(1);
+    expect(all[0].sessionId).toBe('sess-a');
+  });
+
+  it('latestForSession returns the most recent COMPLETED hop for that id', () => {
+    recordMigration(rec({ sessionId: 'sess-a', to: { host: 'box-1' }, at: '2026-08-01T00:00:01.000Z' }), ledger);
+    recordMigration(rec({ sessionId: 'sess-b', to: { host: 'box-x' }, at: '2026-08-01T00:00:02.000Z' }), ledger);
+    recordMigration(rec({ sessionId: 'sess-a', to: { host: 'box-2' }, at: '2026-08-01T00:00:03.000Z' }), ledger);
+    // A failed hop must not shadow the last good one.
+    recordMigration(rec({ sessionId: 'sess-a', to: { host: 'box-3' }, status: 'failed', at: '2026-08-01T00:00:04.000Z' }), ledger);
+
+    expect(latestForSession('sess-a', ledger)?.to.host).toBe('box-2');
+    expect(latestForSession('sess-b', ledger)?.to.host).toBe('box-x');
+    expect(latestForSession('nope', ledger)).toBeUndefined();
+  });
+
+  it('skips a corrupt/partial line instead of throwing', () => {
+    recordMigration(rec({ sessionId: 'good-1', at: '2026-08-01T00:00:01.000Z' }), ledger);
+    fs.appendFileSync(ledger, '{ this is not json\n');
+    recordMigration(rec({ sessionId: 'good-2', at: '2026-08-01T00:00:02.000Z' }), ledger);
+    expect(readMigrations(ledger).map((r) => r.sessionId)).toEqual(['good-1', 'good-2']);
+  });
+});

--- a/apps/cli/src/lib/session/migrations.ts
+++ b/apps/cli/src/lib/session/migrations.ts
@@ -1,0 +1,89 @@
+/**
+ * Migration ledger (RUSH-1977) — an append-only record of every
+ * `agents sessions migrate`, so a session handed off to another machine stays
+ * trackable: where it went, when, in which mode, move vs copy, and the WIP
+ * branch/PR its working tree was parked on.
+ *
+ * Append-only JSONL under the already-synced `~/.agents/.history`, so the source
+ * and target machines converge on the same trail. One line per event; a session
+ * that hops A→B→C leaves three lines — that ordered history IS the lineage, which
+ * is why this is an event log, not a mutable field on the session.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import chalk from 'chalk';
+import { homeDir } from '../platform/paths.js';
+
+export type MigrationMode = 'resume' | 'rehydrate';
+
+export interface MigrationEndpoint {
+  host: string;
+  cwd?: string;
+  /** tmux pane on the source; ephemeral box slug on the target. */
+  pane?: string;
+  box?: string;
+}
+
+export interface MigrationRecord {
+  sessionId: string;
+  shortId: string;
+  agent: string;
+  mode: MigrationMode;
+  /** true = move (the source was stopped); false = copy (--keep). */
+  move: boolean;
+  from: MigrationEndpoint;
+  to: MigrationEndpoint;
+  /** WIP branch the working tree was committed to before the move, if any. */
+  branch?: string;
+  /** Draft PR opened for that branch, if any. */
+  wipPr?: string;
+  /** ISO timestamp — passed in by the caller (the CLI has a real clock). */
+  at: string;
+  status: 'completed' | 'failed';
+  error?: string;
+}
+
+export function migrationsLedgerPath(): string {
+  return path.join(homeDir(), '.agents', '.history', 'migrations.jsonl');
+}
+
+/**
+ * Append one migration event. A ledger write must never break a migration that
+ * otherwise succeeded, so a write failure is a visible warning, not a throw.
+ * `file` is injectable for tests; production uses the default ledger path.
+ */
+export function recordMigration(rec: MigrationRecord, file: string = migrationsLedgerPath()): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.appendFileSync(file, JSON.stringify(rec) + '\n');
+  } catch (err) {
+    console.error(chalk.yellow(`  Could not write the migration ledger (${(err as Error).message}).`));
+  }
+}
+
+/** Read the whole ledger, oldest first. Blank/corrupt JSONL lines are skipped. */
+export function readMigrations(file: string = migrationsLedgerPath()): MigrationRecord[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return []; // no ledger yet
+  }
+  const out: MigrationRecord[] = [];
+  for (const line of raw.split('\n')) {
+    const s = line.trim();
+    if (!s) continue;
+    try {
+      out.push(JSON.parse(s) as MigrationRecord);
+    } catch {
+      // A single partial line (interrupted append) must not sink the whole read.
+    }
+  }
+  return out;
+}
+
+/** The most recent completed migration for a session id, or undefined. */
+export function latestForSession(sessionId: string, file: string = migrationsLedgerPath()): MigrationRecord | undefined {
+  const recs = readMigrations(file).filter((r) => r.sessionId === sessionId && r.status === 'completed');
+  return recs.length ? recs[recs.length - 1] : undefined;
+}


### PR DESCRIPTION
## What it does

`agents sessions migrate` (alias `detach`) **relocates a RUNNING agent session from this machine onto another** — a fleet worker, a registered device, or a warm/fresh ephemeral crabbox box — then stops the source so the interactive machine reclaims its compute. Where `export`/`import` carry a *transcript*, migrate carries the *live agent*.

```
agents sessions migrate [session-id]
  --auto                    pick the best target host automatically
  --host <name>             explicit target: enrolled host, device, or warm box slug
  --lease                   provision a fresh ephemeral crabbox box as the target
  --mode resume|rehydrate   (default resume) faithful --resume vs fresh-agent-reads-transcript
  --keep                    copy, not move — do NOT stop the source
  --agent-wrapup            delegate the dirty-tree wrap-up to the running agent
```

**Flow (move, not copy):** resolve the source (current tmux pane unless an id is given) → resolve + verify the target (bootstrap agents-cli if missing) → wrap up a dirty tree into a draft WIP PR (or delegate to the agent) → ship the transcript over SSH → resume on the target → **only then** kill the source. `--keep` skips the kill.

**Invariant:** the source is never killed before the transcript + branch are confirmed on the target.

## Reuse map (builds on existing primitives — no reinvented transport/resume)

- **Resolve current-pane session:** `getActiveSessions()` (`lib/session/active.ts:1155`), matching `$TMUX_PANE` against `provenance.mux.pane` (`active.ts:1125`, shape `{ kind:'tmux', socket, pane }` from `provenance.ts:49`). Id lookups use `resolveSessionById()` (`lib/session/discover.ts:426`) over `discoverSessions()` (`discover.ts:191`).
- **Remote resume:** `openSurfaces(items, { backend:'tmux', host })` (`lib/terminal/engine.ts:76`) — the same call `sessions resume --host` makes (`sessions-resume.ts:204-207`). Resume argv from `buildResumeCommand()` (`commands/sessions.ts:2123`).
- **Target scorer (new `lib/session/migrate-targets.ts`):** `listAllHosts()` (`lib/hosts/registry.ts:233`) + `loadDevices()` (`lib/devices/registry.ts:208`); headroom via `headroom()` + the disk `readStatsCache()` (`lib/devices/health.ts:194`, `lib/devices/stats-cache.ts:42`); ephemeral via `reusableBoxes()`/`boxAddress()` (`commands/lease.ts:68/:54`) over `crabboxList()` (`lib/crabbox/cli.ts:274`); fresh box via `crabboxWarmup()`/`crabboxWaitReady()` (`crabbox/cli.ts:322/:396`).
- **Target readiness:** `readyProbe()` + `viewHasAgent()` + `bootstrapAgentsCli()` (`lib/hosts/ready.ts:142/:95`); SSH via `sshExec()` (`lib/ssh-exec.ts:142`); `sshTargetFor()` (`lib/hosts/types.ts:85`); `resolveHost()` (`registry.ts:277`).
- **Transcript transport:** the same bundle pipeline as `sessions export --stdout | sessions import -` (`commands/sessions-export.ts`, `sessions-import.ts`) — export the one session's bundle locally, pipe into `agents sessions import -` on the target over `sshExec`.
- **Dirty-tree wrap-up:** `simple-git` (branch → commit → push) + `gh pr create --draft`; `--agent-wrapup` reuses `injectTargetFromReplyRail()` + `injectIntoTerminal()` (`lib/session/inject.ts:20`, `lib/terminal/inject.ts:300`) — the same rail `sessions inject` uses.
- **Stop the source:** `killSession(name, socket)` (`lib/tmux/session.ts:189`), resolving the session name from the pane via `tmux display-message`.
- **Picker:** `itemPicker` (`lib/picker.ts:168`).

## Harness parity

`buildResumeCommand` returns **null** for the non-resumable agents — **gemini, antigravity, openclaw, rush, hermes, grok, kimi, droid** (`sessions.ts:2140-2149`). For those a faithful `--resume` is impossible, so migrate transparently uses `--mode rehydrate` and prints a notice — it never silently skips an agent. The same fallback fires when the agent isn't installed on the target. `effectiveMode()` encodes this and is unit-tested **in lockstep with `buildResumeCommand` across every `SESSION_AGENTS` entry**, so a future agent gaining/losing resume support keeps the two pinned together.

## Self-verify (local)

```
$ bunx tsc --noEmit
TSC_EXIT=0

$ vitest run src/lib/session/migrate-targets.test.ts src/commands/sessions-migrate.test.ts
 Test Files  2 passed (2)
      Tests  14 passed (14)

$ bun run build   # tsc → dist
BUILD=0

$ node dist/index.js sessions migrate --help
Usage: agents sessions migrate [options] [session-id]
  --auto / --host <name> / --lease / --mode <mode> / --keep / --agent-wrapup   (all render)
$ node dist/index.js sessions detach --help   # alias resolves to migrate
$ node dist/index.js sessions migrate --mode bogus
--mode must be 'resume' or 'rehydrate' (got "bogus").
```

Full suite: `6880 passed`. The only failures (6) are in `src/lib/tmux/session.test.ts` — real-tmux pane-exit-status timing under parallel load; **that file passes 25/25 in isolation** and is not touched by this change (no `tmux/session.ts` edit in the diff).

## How to verify end-to-end (real devices — needs two machines)

1. On machine A, start a resumable session under tmux: `agents run claude "do a small task"` (in a git repo, ideally with a dirty edit to exercise the WIP-PR wrap-up).
2. From inside that pane: `agents sessions migrate --host <B>` (or `--auto`). Watch for: transcript shipped, resume launched on B, source stopped on A.
3. On machine B, confirm the session is live: `agents sessions --active` shows it on B; attach and check the prompt responds.
4. Confirm A's tmux session is gone: `agents sessions --active --local` on A no longer lists it.
5. If the tree was dirty, confirm a draft WIP PR was opened for the branch.
6. `--keep` variant: same, but the source must still be running on A afterward.
7. Non-resumable agent (e.g. gemini): confirm migrate prints the rehydrate fallback notice and starts a fresh agent on B that reads the imported transcript.

Do not merge — handing the PR number back for the real-device verification.
