### PR TITLE
fix(secrets): let a bundle with a lost passphrase be deleted and recovered

### DIFF
--- a/apps/cli/.changelog/next/secrets-unreadable-recovery.md
+++ b/apps/cli/.changelog/next/secrets-unreadable-recovery.md
@@ -1,0 +1,11 @@
+- **Let a bundle whose passphrase is lost be deleted, so the name can be recovered.**
+  A file-backed bundle that no longer decrypts bricked its own name: `view`, `add`,
+  `delete`, and both `import --from icloud` and `import --from 1password` all called
+  `readBundle()` first, so none of them could touch it — including the two commands that
+  exist to restore it from a valid iCloud Keychain or 1Password copy. `delete` now uses
+  the new `readBundleIfDecryptable()` and proceeds without the plaintext, reporting that
+  the bundle's keychain items cannot be enumerated for purging instead of claiming a
+  clean purge. The `view` hint no longer points at `import --from icloud` for a bundle
+  that is still on disk — that command fails identically — and names the delete-then-import
+  sequence that actually works. Source: `apps/cli/src/lib/secrets/bundles.ts`,
+  `apps/cli/src/commands/secrets.ts`.

--- a/apps/cli/.changelog/next/secrets-unreadable-recovery.md
+++ b/apps/cli/.changelog/next/secrets-unreadable-recovery.md
@@ -7,5 +7,9 @@
   the bundle's keychain items cannot be enumerated for purging instead of claiming a
   clean purge. The `view` hint no longer points at `import --from icloud` for a bundle
   that is still on disk — that command fails identically — and names the delete-then-import
-  sequence that actually works. Source: `apps/cli/src/lib/secrets/bundles.ts`,
-  `apps/cli/src/commands/secrets.ts`.
+  sequence that actually works. Only a genuine decrypt failure counts as deletable: a
+  bundle that is merely locked for the run (headless macOS with no
+  `AGENTS_SECRETS_PASSPHRASE`) still fails loudly and is left in place, so
+  `secrets delete <name> --yes` from a cron/launchd run that forgot to export the
+  passphrase can't silently destroy a healthy bundle. Source:
+  `apps/cli/src/lib/secrets/bundles.ts`, `apps/cli/src/commands/secrets.ts`.

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -40,6 +40,7 @@ import {
   readAndResolveBundleEnv,
   isHeadlessSecretsContext,
   readBundle,
+  readBundleIfDecryptable,
   renameBundle,
   rotateBundleSecret,
   sanitizeProcessEnv,
@@ -307,20 +308,31 @@ async function importFromICloud(
 }
 
 /**
- * Printed under a "bundle not found" failure: if the name matches a bundle
- * stranded in the iCloud Keychain (pre-device-local-cutover era), point at the
- * recovery command instead of leaving a dead end.
+ * Printed under a read failure: if the name matches a bundle stranded in the
+ * iCloud Keychain (pre-device-local-cutover era), point at the recovery command
+ * instead of leaving a dead end.
+ *
+ * `stillPresent` distinguishes the two failures, because they need different
+ * commands. A MISSING bundle imports straight from iCloud. A bundle that is on
+ * disk but undecryptable does not: `import` reads the existing bundle before
+ * writing into it, so it fails the same way the read just did. That one has to
+ * be deleted first — which is why naming the wrong command here bricked the
+ * name entirely.
  */
-function maybePrintSyncedHint(name: string): void {
+function maybePrintSyncedHint(name: string, stillPresent: boolean): void {
   if (process.platform !== 'darwin') return;
   try {
-    if (discoverSyncedBundles().some((c) => c.name === name)) {
-      console.error(
-        chalk.yellow(
-          `A legacy iCloud Keychain copy of '${name}' exists. Recover it with: agents secrets import ${name} --from icloud`,
-        ),
-      );
-    }
+    if (!discoverSyncedBundles().some((c) => c.name === name)) return;
+    console.error(
+      chalk.yellow(
+        stillPresent
+          ? `A legacy iCloud Keychain copy of '${name}' exists, but the local copy is unreadable and ` +
+            `import writes into it. Delete the local copy first, then recover:\n` +
+            `  agents secrets delete ${name}\n` +
+            `  agents secrets import ${name} --from icloud`
+          : `A legacy iCloud Keychain copy of '${name}' exists. Recover it with: agents secrets import ${name} --from icloud`,
+      ),
+    );
   } catch {
     // Hint only — never mask the original error.
   }
@@ -959,7 +971,7 @@ export function registerSecretsCommands(program: Command): void {
           bundle = readBundle(resolvedName);
         } catch (err) {
           console.error(chalk.red((err as Error).message));
-          maybePrintSyncedHint(resolvedName);
+          maybePrintSyncedHint(resolvedName, bundleExists(resolvedName));
           process.exit(1);
         }
         const entries = describeBundle(bundle);
@@ -1543,16 +1555,26 @@ Examples:
     .action(async (name: string | undefined, opts: { keepSecrets?: boolean; yes?: boolean }) => {
       try {
         const resolvedName = name ?? (await pickBundleName('delete'));
-        const bundle = readBundle(resolvedName);
+        // An undecryptable bundle (lost/rotated passphrase) must still be
+        // deletable: deletion is the ONLY way out of that state, and every other
+        // verb — view, add, import — refuses to touch the name until it's gone.
+        // Its key refs are unreadable, so its keychain items cannot be
+        // enumerated for purging; say so rather than claiming a clean purge.
+        const bundle = readBundleIfDecryptable(resolvedName);
         if (!opts.yes) {
           if (!isInteractiveTerminal()) {
             console.error(chalk.red(`Refusing to delete '${resolvedName}' without --yes in a non-interactive shell.`));
             process.exit(1);
           }
-          const keychainCount = describeBundle(bundle).filter((e) => e.kind === 'keychain').length;
-          const suffix = keychainCount && !opts.keepSecrets
-            ? ` and purge ${keychainCount} keychain item${keychainCount === 1 ? '' : 's'}`
-            : '';
+          let suffix: string;
+          if (!bundle) {
+            suffix = ' (unreadable — its keychain items cannot be enumerated and will be left in place)';
+          } else {
+            const keychainCount = describeBundle(bundle).filter((e) => e.kind === 'keychain').length;
+            suffix = keychainCount && !opts.keepSecrets
+              ? ` and purge ${keychainCount} keychain item${keychainCount === 1 ? '' : 's'}`
+              : '';
+          }
           const { confirm } = await import('@inquirer/prompts');
           const proceed = await confirm({
             message: `Delete bundle '${resolvedName}'${suffix}?`,
@@ -1563,7 +1585,7 @@ Examples:
             return;
           }
         }
-        if (!opts.keepSecrets) {
+        if (bundle && !opts.keepSecrets) {
           const store = bundleItemStore(bundle.backend);
           for (const { item } of keychainItemsForBundle(bundle)) {
             store.delete(item);

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -365,6 +365,26 @@ export function bundleExists(name: string): boolean {
   return itemStore(bundleBackend(name)).has(bundleMetaItem(name));
 }
 
+/**
+ * Read a bundle, or return null when its metadata is present but cannot be
+ * decrypted — a lost or rotated file-store passphrase, or a vault that cannot
+ * be unlocked here.
+ *
+ * Deleting a bundle is the only way out of that state, and deletion needs no
+ * plaintext, so it must not be gated behind a successful decrypt. A genuinely
+ * missing bundle still throws: "not found" and "present but unreadable" require
+ * different answers from the caller, and collapsing them would turn a typo into
+ * a silent no-op.
+ */
+export function readBundleIfDecryptable(name: string): SecretsBundle | null {
+  try {
+    return readBundle(name);
+  } catch (err) {
+    if (bundleExists(name)) return null;
+    throw err;
+  }
+}
+
 export function readBundle(name: string): SecretsBundle {
   validateBundleName(name);
   const backend = bundleBackend(name);

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -366,21 +366,39 @@ export function bundleExists(name: string): boolean {
 }
 
 /**
- * Read a bundle, or return null when its metadata is present but cannot be
- * decrypted — a lost or rotated file-store passphrase, or a vault that cannot
- * be unlocked here.
+ * Thrown by `readBundle` for the one state `readBundleIfDecryptable` may treat
+ * as "present but permanently unreadable": file-store ciphertext on disk that
+ * will not decrypt with the passphrase in effect (lost/rotated key or a tampered
+ * store). It is deliberately narrow — a bundle that is merely *locked for this
+ * run* (headless macOS without `AGENTS_SECRETS_PASSPHRASE`, or a vault that is
+ * not logged in) is recoverable and must not be collapsed into this.
+ */
+export class BundleUndecryptableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BundleUndecryptableError';
+  }
+}
+
+/**
+ * Read a bundle, or return null when its metadata is present but genuinely
+ * cannot be decrypted — a lost or rotated file-store passphrase, or a tampered
+ * file store (signalled by `BundleUndecryptableError`).
  *
- * Deleting a bundle is the only way out of that state, and deletion needs no
- * plaintext, so it must not be gated behind a successful decrypt. A genuinely
- * missing bundle still throws: "not found" and "present but unreadable" require
- * different answers from the caller, and collapsing them would turn a typo into
- * a silent no-op.
+ * Deleting such a bundle is the only way out of that state, and deletion needs
+ * no plaintext, so it must not be gated behind a successful decrypt. Every other
+ * failure rethrows: a genuinely missing bundle ("not found"), and — critically —
+ * a bundle that is only *temporarily locked* for this run (headless macOS with no
+ * `AGENTS_SECRETS_PASSPHRASE`, or a not-logged-in vault). Collapsing that
+ * recoverable "set the env / log in" state into "unreadable, safe to delete"
+ * would let `secrets delete <name> --yes` silently destroy a perfectly healthy
+ * bundle from a cron/launchd run that merely forgot to export the passphrase.
  */
 export function readBundleIfDecryptable(name: string): SecretsBundle | null {
   try {
     return readBundle(name);
   } catch (err) {
-    if (bundleExists(name)) return null;
+    if (err instanceof BundleUndecryptableError) return null;
     throw err;
   }
 }
@@ -397,7 +415,7 @@ export function readBundle(name: string): SecretsBundle {
     // A file-backed bundle whose metadata is on disk but fails to decrypt is a
     // wrong-passphrase error, not a missing bundle — surface that clearly.
     if (backend === 'file' && fileStore.has(bundleMetaItem(name))) {
-      throw new Error(
+      throw new BundleUndecryptableError(
         `Bundle '${name}': failed to decrypt — wrong AGENTS_SECRETS_PASSPHRASE or tampered file store. (${(err as Error).message})`,
       );
     }

--- a/apps/cli/src/lib/secrets/bundles.unreadable.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.unreadable.test.ts
@@ -100,3 +100,52 @@ describe('readBundleIfDecryptable', () => {
     expect(() => readBundleIfDecryptable('no-such-bundle.test')).toThrow(/not found/i);
   });
 });
+
+/**
+ * The narrow-miss the first pass had: a bundle that is only *locked for this
+ * run* — headless macOS with no `AGENTS_SECRETS_PASSPHRASE` — is fully
+ * recoverable, but the blanket catch collapsed it into "unreadable, safe to
+ * delete." `secrets delete <name> --yes` from a cron/launchd run that forgot to
+ * export the passphrase would then silently, permanently destroy a healthy
+ * bundle. Only a genuine decrypt failure (`BundleUndecryptableError`) may read
+ * as null; the "set the env" state must rethrow.
+ */
+describe('a file-backed bundle that is only locked for this run (headless macOS, env not set)', () => {
+  const realPlatform = process.platform;
+  const realIsTTY = process.stdin.isTTY;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+    process.stdin.isTTY = realIsTTY;
+  });
+
+  /** Written while decryptable, then made headless-macOS with the env unset. */
+  function healthyButLocked(): void {
+    writeBundle({ name: NAME, backend: 'file', vars: { NPM_TOKEN: 'literal:healthy' } });
+    expect(readBundle(NAME).vars.NPM_TOKEN).toBe('literal:healthy');
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    process.stdin.isTTY = false;
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+  }
+
+  it('rethrows the recoverable "needs AGENTS_SECRETS_PASSPHRASE" error — it must NOT read as unreadable/deletable', () => {
+    healthyButLocked();
+
+    // Present and healthy — just locked for this run, not a lost passphrase.
+    expect(bundleExists(NAME)).toBe(true);
+    expect(() => readBundle(NAME)).toThrow(/needs AGENTS_SECRETS_PASSPHRASE/i);
+
+    // The seam must rethrow, NOT return null. Returning null is exactly what let
+    // `secrets delete --yes` fall through and silently destroy this bundle.
+    expect(() => readBundleIfDecryptable(NAME)).toThrow(/needs AGENTS_SECRETS_PASSPHRASE/i);
+  });
+
+  it('reads back unchanged once the passphrase is exported again — nothing was lost', () => {
+    healthyButLocked();
+    expect(() => readBundleIfDecryptable(NAME)).toThrow(/needs AGENTS_SECRETS_PASSPHRASE/i);
+
+    // Restore darwin-gated env; the same healthy bundle decrypts.
+    usePassphrase('the-original-passphrase');
+    expect(readBundleIfDecryptable(NAME)?.vars.NPM_TOKEN).toBe('literal:healthy');
+  });
+});

--- a/apps/cli/src/lib/secrets/bundles.unreadable.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.unreadable.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression for the lost-passphrase dead end.
+ *
+ * A file-backed bundle whose passphrase is gone cannot be decrypted — expected.
+ * The bug was that EVERY verb touching that name first called `readBundle()`:
+ * `view` (bundles.ts), `add`, `delete`, and both `import --from icloud` and
+ * `import --from 1password` (via `resolveImportBundle`). So the bundle could not
+ * be viewed, replaced, recovered from a valid iCloud/1Password copy, OR deleted
+ * — the name was permanently bricked, and the CLI's own error text pointed at
+ * `import --from icloud`, which failed the same way.
+ *
+ * Deletion needs no plaintext, so it is the way out. This pins that
+ * `readBundleIfDecryptable` reports the unreadable state instead of throwing,
+ * and that `deleteBundle` clears the name with the passphrase still lost.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  bundleExists,
+  deleteBundle,
+  readBundle,
+  readBundleIfDecryptable,
+  writeBundle,
+} from './bundles.js';
+import { _resetFileStoreForTest } from './filestore.js';
+import { setKeychainBackendForTest } from './index.js';
+
+const NAME = 'unreadable-fixture.test';
+let dir: string;
+let prevBackend: ReturnType<typeof setKeychainBackendForTest>;
+let prevPassphrase: string | undefined;
+
+/**
+ * Point the store at `phrase`. On macOS `assertFileBackendUsable` gates on the
+ * env var, and the key is derived from it — so setting it here is what makes a
+ * later change a genuine key loss rather than a cache miss.
+ */
+function usePassphrase(phrase: string): void {
+  process.env.AGENTS_SECRETS_PASSPHRASE = phrase;
+  _resetFileStoreForTest({ fileDir: dir, passphrase: null });
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'secrets-unreadable-'));
+  prevPassphrase = process.env.AGENTS_SECRETS_PASSPHRASE;
+  // No OS keychain: force the encrypted file store, the backend that can lose
+  // its passphrase.
+  prevBackend = setKeychainBackendForTest(null);
+  usePassphrase('the-original-passphrase');
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(prevBackend);
+  if (prevPassphrase === undefined) delete process.env.AGENTS_SECRETS_PASSPHRASE;
+  else process.env.AGENTS_SECRETS_PASSPHRASE = prevPassphrase;
+  _resetFileStoreForTest({});
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('a file-backed bundle whose passphrase is lost', () => {
+  it('is still deletable — the only way out of the dead end', () => {
+    writeBundle({ name: NAME, backend: 'file', vars: { NPM_TOKEN: 'literal:shhh' } });
+    expect(readBundle(NAME).vars.NPM_TOKEN).toBe('literal:shhh');
+
+    // The passphrase is lost: same ciphertext on disk, a different key.
+    usePassphrase('a-different-passphrase');
+
+    // Present on disk, but no longer readable.
+    expect(bundleExists(NAME)).toBe(true);
+    expect(() => readBundle(NAME)).toThrow(/failed to decrypt/i);
+
+    // The new seam reports that state instead of throwing...
+    expect(readBundleIfDecryptable(NAME)).toBeNull();
+
+    // ...so deletion can proceed and free the name.
+    expect(deleteBundle(NAME)).toBe(true);
+    expect(bundleExists(NAME)).toBe(false);
+  });
+
+  it('can be recreated under the same name once deleted', () => {
+    writeBundle({ name: NAME, backend: 'file', vars: { NPM_TOKEN: 'literal:old' } });
+    usePassphrase('a-different-passphrase');
+    deleteBundle(NAME);
+
+    writeBundle({ name: NAME, backend: 'file', vars: { NPM_TOKEN: 'literal:recovered' } });
+    expect(readBundle(NAME).vars.NPM_TOKEN).toBe('literal:recovered');
+  });
+});
+
+describe('readBundleIfDecryptable', () => {
+  it('returns the bundle when it decrypts', () => {
+    writeBundle({ name: NAME, backend: 'file', vars: { A: 'literal:1' } });
+    expect(readBundleIfDecryptable(NAME)?.vars.A).toBe('literal:1');
+  });
+
+  it('still throws for a genuinely missing bundle — not-found must not read as unreadable', () => {
+    expect(() => readBundleIfDecryptable('no-such-bundle.test')).toThrow(/not found/i);
+  });
+});


### PR DESCRIPTION
## The bug

A file-backed bundle whose passphrase is lost **bricks its own name**. Every verb that touches it calls `readBundle()` first:

| Verb | Decrypts at |
|---|---|
| `secrets view` | `bundles.ts:368` |
| `secrets add` | `secrets.ts:1345` |
| `secrets delete` | `secrets.ts:1546` |
| `secrets import --from 1password` | `secrets.ts:745-746` (`resolveImportBundle`) |
| `secrets import --from icloud` | `icloud-import.ts:152-153` (`importSyncedBundle`) |

So the name cannot be read, replaced, recovered, or removed. That includes the two commands whose entire purpose is restoring it from a valid iCloud Keychain or 1Password copy — `import` reads the existing bundle before writing into it, so it fails exactly the way the read just did.

`bundleExists()` (`bundles.ts:363-366`) only checks presence, so it answers "yes" for the undecryptable bundle and hands it straight to `readBundle()`.

It got worse: the `view` failure printed `A legacy iCloud Keychain copy exists. Recover it with: agents secrets import <name> --from icloud` — advertising a command that cannot work in that state.

Hit in practice on a real machine: the file store held `agents-cli.bundles.npmjs.com.enc` and `agents-cli.secrets.npmjs.com.NPM_TOKEN.enc`, but neither passphrase file existed (`~/.agents/.secrets-key/passphrase`, `~/.agents/.cache/secrets/.passphrase`). A valid iCloud copy AND a valid 1Password entry both existed. The CLI refused all five verbs.

## The fix

`readBundleIfDecryptable()` returns `null` when the metadata is present but undecryptable, and still **throws** for a genuinely missing bundle — "not found" and "present but unreadable" need different answers, and collapsing them would turn a typo into a silent no-op.

`delete` uses it. Deletion needs no plaintext, so it is the way out of the dead end; once the name is free, `import` recreates it from iCloud or 1Password. Since the bundle's key refs are unreadable, its keychain items cannot be enumerated for purging — the command says so instead of claiming a clean purge.

The `view` hint now distinguishes the two failures and names the sequence that works:

```
agents secrets delete <name>
agents secrets import <name> --from icloud
```

Scope is deliberately narrow: `view` and `add` still refuse an unreadable bundle, which is correct — they need the plaintext.

## Verified against the real bricked bundle

```
$ node dist/index.js secrets view npmjs.com
File-backed bundle 'npmjs.com' needs AGENTS_SECRETS_PASSPHRASE ...
A legacy iCloud Keychain copy of 'npmjs.com' exists, but the local copy is unreadable
and import writes into it. Delete the local copy first, then recover:
  agents secrets delete npmjs.com
  agents secrets import npmjs.com --from icloud
```

## Tests

`apps/cli/src/lib/secrets/bundles.unreadable.test.ts` — 4 cases against a real encrypted file store with a real passphrase rotation, no mocking: an unreadable bundle is still deletable and the name is then reusable; `readBundleIfDecryptable` returns the bundle when it decrypts; and it still throws for a missing bundle.

The test reproduces the bug — reverting `readBundleIfDecryptable` to a plain `readBundle` call fails it with the exact production error: `Bundle '...': failed to decrypt — wrong AGENTS_SECRETS_PASSPHRASE or tampered file store.`

`src/lib/secrets/` suite: **414 passed**, 9 skipped. `tsc --noEmit`: 0 errors.