### PR TITLE
test(session): harden session-index isolation + regression-test the closeDB fix

### DIFF
--- a/apps/cli/src/lib/cloud/store.test.ts
+++ b/apps/cli/src/lib/cloud/store.test.ts
@@ -1,17 +1,27 @@
-import { describe, it, expect } from 'vitest';
+import { afterAll, describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import type { CloudTask } from './types.js';
 
-// Isolate BOTH stores under a temp HOME before any import touches them: the cloud
-// tasks.db and the sessions index db read their base dir lazily at first use.
+// Isolate BOTH stores under a temp HOME. state.js/db.js freeze their base dir
+// from HOME at *import* time (state.ts:34,107; db.ts:15-16), not lazily — and
+// static top-level imports are ESM-hoisted, so they'd run those module bodies
+// BEFORE this HOME assignment and bind to the runner's real HOME. Set HOME with a
+// plain statement first, then pull the stores in via top-level `await import`
+// (which runs after it), so both DBs resolve under TEST_HOME. Same hermetic
+// pattern as session/__tests__/db.test.ts.
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-cloudstore-'));
 process.env.HOME = TEST_HOME;
 
-import { insertTask, updateTaskStatus, getTaskById } from './store.js';
-import { registerCloudSession } from './session-index.js';
-import { findSessionsById, closeDB } from '../session/db.js';
-import type { CloudTask } from './types.js';
+const { insertTask, updateTaskStatus, getTaskById } = await import('./store.js');
+const { registerCloudSession } = await import('./session-index.js');
+const { findSessionsById, closeDB } = await import('../session/db.js');
+
+afterAll(() => {
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
 
 function cloudTask(overrides: Partial<CloudTask> = {}): CloudTask {
   return {
@@ -65,7 +75,5 @@ describe('registerCloudSession guards', () => {
     // charset guard here also rejects an id that isn't a usable execution id.
     registerCloudSession(cloudTask({ id: 'codex-1720000000000 not valid' }));
     expect(findSessionsById('codex-1720000000000 not valid')).toHaveLength(0);
-
-    closeDB();
   });
 });

--- a/apps/cli/src/lib/hosts/session-index.test.ts
+++ b/apps/cli/src/lib/hosts/session-index.test.ts
@@ -1,17 +1,34 @@
-import { describe, it, expect } from 'vitest';
+import { afterAll, describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { hostSessionMeta, registerHostSession, registerInteractiveHostSession, captureRemoteSessionId } from './session-index.js';
-import { findSessionsById, querySessions, closeDB } from '../session/db.js';
-import { saveTask, loadTask, localLogPath, hostsCacheDir, type HostTask } from './tasks.js';
-import { sessionIdMarkerLine } from './session-marker.js';
+import type { HostTask } from './tasks.js';
 
-// Isolate the sessions DB under a temp HOME. db.js reads its base dir lazily
-// (at getDB() time), so setting HOME here — before any test calls getDB — is
-// enough. Use STATIC imports, matching session/__tests__/db.test.ts.
+// Isolate the sessions DB under a temp HOME. state.js freezes its base dir at
+// module load (state.ts:34,107 — `HOME = process.env.HOME ?? os.homedir()`,
+// then `SESSIONS_DIR = ...`), and db.js binds DB_PATH from it at db.ts:15-16,
+// both at *import* time — not lazily. Static top-level imports are hoisted, so
+// they would run the state.js/db.js module bodies BEFORE the HOME assignment
+// below and bind DB_PATH to the runner's real HOME, breaking isolation under
+// CI sharding. So set HOME with a plain statement first, then pull in the
+// modules via a top-level `await import` (which runs after it) — the same
+// hermetic pattern as session/__tests__/db.test.ts.
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-hostsession-'));
 process.env.HOME = TEST_HOME;
+
+const { hostSessionMeta, registerHostSession, registerInteractiveHostSession, captureRemoteSessionId } =
+  await import('./session-index.js');
+const { findSessionsById, querySessions, closeDB } = await import('../session/db.js');
+const { saveTask, loadTask, localLogPath, hostsCacheDir } = await import('./tasks.js');
+const { sessionIdMarkerLine } = await import('./session-marker.js');
+
+// Close the DB singleton and tear down the temp HOME exactly once, at the end —
+// not scattered mid-file inside individual `it` blocks, which order-couples the
+// tests. Matches the single-teardown shape of db.test.ts:100-102.
+afterAll(() => {
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
 
 function task(overrides: Partial<HostTask> = {}): HostTask {
   return {
@@ -99,8 +116,6 @@ describe('registerHostSession', () => {
     // real local session with a missing file would be dropped here.
     const all = querySessions({ idPrefix: 'aaaaaaaa' });
     expect(all).toHaveLength(1);
-
-    closeDB();
   });
 });
 
@@ -144,7 +159,5 @@ describe('captureRemoteSessionId', () => {
     fs.writeFileSync(localLogPath('feed0003'), 'ran, but printed no session marker\n');
     expect(captureRemoteSessionId(t)).toBeNull();
     expect(loadTask('feed0003')!.sessionId).toBeUndefined();
-
-    closeDB();
   });
 });

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -472,3 +472,45 @@ describe('upsertSessionsBatch per-row guard', () => {
     expect(ids).not.toContain('batch-bad-00000-4000-8000-000000000002');
   });
 });
+
+describe('closeDB drops the cached prepared statements', () => {
+  // Regression for the "statement has been finalized" bug: closeDB() finalizes
+  // every prepared statement the connection owns, but the module-level
+  // cachedStmts (upsert/FTS) used to survive the close. The next getDB() opened a
+  // fresh connection while stmts() handed back the stale, finalized statements —
+  // so the first upsertSession() after a closeDB() threw. In host-session
+  // registration (which swallows write errors) that silently dropped the row.
+  it('lets upsertSession run again after closeDB without throwing a finalized statement', () => {
+    const fileA = path.join(SEED_FILES_DIR, 'reopen-a.jsonl');
+    const fileB = path.join(SEED_FILES_DIR, 'reopen-b.jsonl');
+    fs.writeFileSync(fileA, '');
+    fs.writeFileSync(fileB, '');
+
+    // A first upsert POPULATES cachedStmts with statements bound to this
+    // connection. Without that priming, stmts() would just rebuild fresh after
+    // the close and the bug wouldn't reproduce — the finalized statement only
+    // bites when the cache already holds statements from the closed connection.
+    upsertSession(
+      { id: 'reopen00-0000-4000-8000-00000000000a', shortId: 'reopen00',
+        agent: 'claude', timestamp: '2026-07-05T00:00:00.000Z', cwd: '/x',
+        filePath: fileA } as SessionMeta,
+      '',
+    );
+
+    // Close finalizes those cached statements. Pre-fix, cachedStmts survived and
+    // pointed at the finalized handles.
+    closeDB();
+
+    // The upsert that used to throw "statement has been finalized": getDB() opens
+    // a fresh connection, but stmts() must NOT hand back the stale cache.
+    const meta: SessionMeta = {
+      id: 'reopen00-0000-4000-8000-00000000000b', shortId: 'reopen00',
+      agent: 'claude', timestamp: '2026-07-05T00:00:01.000Z', cwd: '/x',
+      filePath: fileB,
+    } as SessionMeta;
+    expect(() => upsertSession(meta, '')).not.toThrow();
+
+    // And the row actually landed against the reopened connection.
+    expect(findSessionsById('reopen00-0000-4000-8000-00000000000b')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fast-follow to #1499 (merged). Three test-only hardening changes the prix-cloud
review on #1499 called out as fast-follows, now that #1499 has landed.

## 1. `session-index.test.ts` was writing to the real sessions DB

The test set `process.env.HOME = TEST_HOME` and then used **static** top-level
imports of `session-index.js` / `db.js`. ESM hoists those imports, so the
modules' bodies ran *before* the HOME assignment. `state.ts:34,107` and
`db.ts:15-16` freeze the sessions base dir from HOME at import time (not lazily),
so `getDBPath()` bound to the developer's/runner's **real**
`~/.agents/.history/sessions/sessions.db` (probe: `underTestHome=false`). It only
appeared to pass because writes and reads hit the same real DB — and it flaked
under CI sharding (the `expected [] to have a length of 1` failure on #1499).
Switching to `HOME = ...` then top-level `await import(...)` makes the base dir
resolve to `TEST_HOME` (`underTestHome: true`).

## 2. `cloud/store.test.ts` had the identical defect

The review named this file as raising the collision surface under `pool:'forks'`.
Same static-import-after-HOME pattern, same real-DB binding (probe:
`underTestHome=false`). Fixed the same way.

## 3. The closeDB cache-reset fix had no regression test

`0de93447` (fix: drop cached prepared statements on closeDB) shipped without a
test that reproduces the bug — the review flagged this. Added one that primes
`cachedStmts` with an upsert, calls `closeDB()` (finalizing those statements),
then upserts again.

Verified it actually catches the bug:
- With the fix present: **passes**.
- With `cachedStmts = {}` reverted in `db.ts`: **fails** with
  `Error: statement has been finalized` — the exact production symptom.

## Verification

- `bun run build` (tsc): clean, exit 0.
- Changed suites (`session-index`, `store`, `db`): all pass.
- Hermeticity probes on both fixed files: `underTestHome: true`.
- Regression test: fails on reverted fix, passes on fix.

Test-only; no product code touched (`db.ts` unchanged from main).