### PR TITLE
perf(session): reuse walk stat in filterChangedFiles (eliminate double stat)

### DIFF
--- a/apps/cli/src/lib/fs-walk.test.ts
+++ b/apps/cli/src/lib/fs-walk.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { walkForFiles, latestFileMtimeMs } from './fs-walk.js';
+import { walkForFiles, walkForFilesWithStat, latestFileMtimeMs } from './fs-walk.js';
 
 const tempDirs: string[] = [];
 
@@ -63,6 +63,40 @@ describe('walkForFiles', () => {
 
     const found = walkForFiles(dir, '.jsonl', 10).map((p) => path.basename(p));
     expect(found).toEqual(['reachable.jsonl']);
+  });
+});
+
+describe('walkForFilesWithStat', () => {
+  it('returns the same paths in the same order as walkForFiles', () => {
+    const dir = makeTempDir();
+    writeFileAt(path.join(dir, 'a', 'old.jsonl'), 1_000);
+    writeFileAt(path.join(dir, 'b', 'newest.jsonl'), 3_000);
+    writeFileAt(path.join(dir, 'mid.jsonl'), 2_000);
+    writeFileAt(path.join(dir, 'ignored.txt'), 4_000);
+
+    const paths = walkForFiles(dir, '.jsonl', 10);
+    const withStat = walkForFilesWithStat(dir, '.jsonl', 10);
+    expect(withStat.map((r) => r.path)).toEqual(paths);
+
+    // The limit applies to the same newest-first ordering.
+    const limitedPaths = walkForFiles(dir, '.jsonl', 2);
+    const limitedWithStat = walkForFilesWithStat(dir, '.jsonl', 2);
+    expect(limitedWithStat.map((r) => r.path)).toEqual(limitedPaths);
+  });
+
+  it('reports each entry mtime and size matching a fresh statSync', () => {
+    const dir = makeTempDir();
+    fs.mkdirSync(path.join(dir, 'p'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'p', 'one.jsonl'), 'hello world', 'utf-8');
+    fs.utimesSync(path.join(dir, 'p', 'one.jsonl'), 1_000, 1_000);
+    fs.writeFileSync(path.join(dir, 'two.jsonl'), 'x', 'utf-8');
+    fs.utimesSync(path.join(dir, 'two.jsonl'), 2_000, 2_000);
+
+    for (const entry of walkForFilesWithStat(dir, '.jsonl', 10)) {
+      const fresh = fs.statSync(entry.path);
+      expect(entry.mtimeMs).toBe(fresh.mtimeMs);
+      expect(entry.size).toBe(fresh.size);
+    }
   });
 });
 

--- a/apps/cli/src/lib/fs-walk.ts
+++ b/apps/cli/src/lib/fs-walk.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
  * directories are classified for free. On large session trees this roughly
  * halves the syscall count versus stat-per-entry.
  */
-function walkEntries(dir: string, ext: string, onFile: (filePath: string, mtimeMs: number) => void): void {
+function walkEntries(dir: string, ext: string, onFile: (filePath: string, mtimeMs: number, size: number) => void): void {
   function walk(d: string, depth: number) {
     if (depth > 5) return;
     let entries: fs.Dirent[];
@@ -35,7 +35,7 @@ function walkEntries(dir: string, ext: string, onFile: (filePath: string, mtimeM
         walk(full, depth + 1);
       } else if (entry.name.endsWith(ext)) {
         const stat = safeStatSync(full);
-        if (stat) onFile(full, stat.mtimeMs);
+        if (stat) onFile(full, stat.mtimeMs, stat.size);
       }
     }
   }
@@ -43,15 +43,32 @@ function walkEntries(dir: string, ext: string, onFile: (filePath: string, mtimeM
   walk(dir, 0);
 }
 
-/** Walk a directory recursively for files with a given extension, newest first. */
-export function walkForFiles(dir: string, ext: string, limit: number): string[] {
-  const results: { path: string; mtime: number }[] = [];
-  walkEntries(dir, ext, (filePath, mtimeMs) => {
-    results.push({ path: filePath, mtime: mtimeMs });
+/** A file surfaced by the walk, carrying the mtime+size from the walk's own stat. */
+export interface WalkedFile {
+  path: string;
+  mtimeMs: number;
+  size: number;
+}
+
+/**
+ * Walk a directory recursively for files with a given extension, newest first,
+ * keeping each match's mtime and size from the walk's own stat. Callers that
+ * then compare against the scan ledger reuse these instead of re-stat'ing every
+ * path — eliminating a second stat per file on the Codex/Droid/routine scans.
+ */
+export function walkForFilesWithStat(dir: string, ext: string, limit: number): WalkedFile[] {
+  const results: WalkedFile[] = [];
+  walkEntries(dir, ext, (filePath, mtimeMs, size) => {
+    results.push({ path: filePath, mtimeMs, size });
   });
 
-  results.sort((a, b) => b.mtime - a.mtime);
-  return results.slice(0, limit).map(r => r.path);
+  results.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return results.slice(0, limit);
+}
+
+/** Walk a directory recursively for files with a given extension, newest first. */
+export function walkForFiles(dir: string, ext: string, limit: number): string[] {
+  return walkForFilesWithStat(dir, ext, limit).map(r => r.path);
 }
 
 /**

--- a/apps/cli/src/lib/session/discover.filter-parity.test.ts
+++ b/apps/cli/src/lib/session/discover.filter-parity.test.ts
@@ -1,0 +1,130 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// db.ts resolves its sqlite path from HOME at module-import time. Point HOME at
+// a throwaway dir BEFORE importing so the whole parity test runs against a
+// clean, isolated ledger (no mocking — a real sqlite DB under a temp HOME).
+const REAL_HOME = process.env.HOME;
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-filter-parity-'));
+
+type Discover = typeof import('./discover.js');
+type DB = typeof import('./db.js');
+type Walk = typeof import('../fs-walk.js');
+
+let discover: Discover;
+let db: DB;
+let walk: Walk;
+
+const tempTrees: string[] = [];
+
+function makeTempTree(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-filter-tree-'));
+  tempTrees.push(dir);
+  return dir;
+}
+
+function writeFileAt(filePath: string, contents: string, mtimeSec: number): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents, 'utf-8');
+  fs.utimesSync(filePath, mtimeSec, mtimeSec);
+}
+
+/** Sort a changed-set into a stable comparable shape. */
+function normalize(changed: Array<{ filePath: string; scan: { fileMtimeMs: number; fileSize: number } }>) {
+  return changed
+    .map((c) => ({ filePath: c.filePath, fileMtimeMs: c.scan.fileMtimeMs, fileSize: c.scan.fileSize }))
+    .sort((a, b) => a.filePath.localeCompare(b.filePath));
+}
+
+beforeAll(async () => {
+  process.env.HOME = tmpHome;
+  db = await import('./db.js');
+  discover = await import('./discover.js');
+  walk = await import('../fs-walk.js');
+});
+
+afterAll(() => {
+  if (REAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = REAL_HOME;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  for (const dir of tempTrees.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('filterChangedFiles vs filterChangedEntries parity', () => {
+  it('returns the identical changed-set for the same tree and empty ledger', () => {
+    const dir = makeTempTree();
+    writeFileAt(path.join(dir, 'a', 'one.jsonl'), 'aaa', 1_000);
+    writeFileAt(path.join(dir, 'b', 'two.jsonl'), 'bbbb', 2_000);
+    writeFileAt(path.join(dir, 'three.jsonl'), 'c', 3_000);
+
+    const withStat = walk.walkForFilesWithStat(dir, '.jsonl', 100_000);
+    const paths = withStat.map((r) => r.path);
+    const prestat = withStat.map((r) => ({ filePath: r.path, fileMtimeMs: r.mtimeMs, fileSize: r.size }));
+
+    const viaStat = discover.filterChangedFiles(paths);
+    const viaPreStat = discover.filterChangedEntries(prestat);
+
+    // Every file is new (empty ledger) → both must surface all three, identically.
+    expect(normalize(viaPreStat)).toEqual(normalize(viaStat));
+    expect(viaStat.length).toBe(3);
+  });
+
+  it('floors mtime identically so a warm (unchanged) file is skipped by both', () => {
+    const dir = makeTempTree();
+    const warm = path.join(dir, 'warm.jsonl');
+    writeFileAt(warm, 'hello', 1_500);
+
+    const fresh = fs.statSync(warm);
+    // Seed the ledger with the floored mtime, exactly as a prior scan would.
+    db.recordScans([
+      { filePath: warm, scan: { fileMtimeMs: Math.floor(fresh.mtimeMs), fileSize: fresh.size } },
+    ]);
+
+    const withStat = walk.walkForFilesWithStat(dir, '.jsonl', 100_000);
+    const paths = withStat.map((r) => r.path);
+    const prestat = withStat.map((r) => ({ filePath: r.path, fileMtimeMs: r.mtimeMs, fileSize: r.size }));
+
+    const viaStat = discover.filterChangedFiles(paths);
+    const viaPreStat = discover.filterChangedEntries(prestat);
+
+    // Warm file matches the ledger → neither path re-parses it. If the pre-stat
+    // path failed to floor, a sub-millisecond mtime fraction would spuriously
+    // re-surface it and break this parity.
+    expect(viaStat).toEqual([]);
+    expect(normalize(viaPreStat)).toEqual(normalize(viaStat));
+  });
+
+  it('detects an append (grown file) identically on both paths', () => {
+    const dir = makeTempTree();
+    const grow = path.join(dir, 'grow.jsonl');
+    writeFileAt(grow, 'start', 2_000);
+
+    const before = fs.statSync(grow);
+    db.recordScans([
+      { filePath: grow, scan: { fileMtimeMs: Math.floor(before.mtimeMs), fileSize: before.size } },
+    ]);
+    // recordScans stamps scannedAt = now, which would trip the 5s append
+    // debounce. Backdate every ledger row so the append is detected, not
+    // deferred — this is the isolated temp DB, so a blanket update is safe.
+    db.getDB().prepare('UPDATE scan_ledger SET scanned_at = ?').run(0);
+
+    // Append content and bump mtime forward past the seeded stamp.
+    fs.appendFileSync(grow, '-more-more', 'utf-8');
+    fs.utimesSync(grow, 5_000, 5_000);
+
+    const withStat = walk.walkForFilesWithStat(dir, '.jsonl', 100_000);
+    const paths = withStat.map((r) => r.path);
+    const prestat = withStat.map((r) => ({ filePath: r.path, fileMtimeMs: r.mtimeMs, fileSize: r.size }));
+
+    const viaStat = discover.filterChangedFiles(paths);
+    const viaPreStat = discover.filterChangedEntries(prestat);
+
+    // The grown file must surface on both paths (append detected), with the same
+    // floored mtime + size.
+    expect(viaStat.length).toBe(1);
+    expect(viaStat[0].filePath).toBe(grow);
+    expect(normalize(viaPreStat)).toEqual(normalize(viaStat));
+  });
+});

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -22,7 +22,7 @@ const execFileAsync = promisify(execFile);
 import type { SessionAgentId, SessionMeta } from './types.js';
 import type { AgentId } from '../types.js';
 import { AGENTS, agentConfigDirName, getCliVersion } from '../agents.js';
-import { walkForFiles } from '../fs-walk.js';
+import { walkForFilesWithStat } from '../fs-walk.js';
 import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
 import { extractSessionTopic } from './prompt.js';
@@ -481,27 +481,50 @@ export function searchContentIndex(
  * growing transcript over and over. The cached row is good enough for a few
  * seconds; once writes settle or the debounce expires, the file is parsed once.
  */
-function filterChangedFiles(
+export function filterChangedFiles(
   filePaths: string[],
 ): Array<{ filePath: string; scan: ScanStamp }> {
-  const ledger = getScanStampsForPaths(filePaths);
-  const out: Array<{ filePath: string; scan: ScanStamp }> = [];
-  const now = Date.now();
+  const entries: PreStatEntry[] = [];
   for (const filePath of filePaths) {
     const stat = safeStatSync(filePath);
     if (!stat) continue;
+    entries.push({ filePath, fileMtimeMs: stat.mtimeMs, fileSize: stat.size });
+  }
+  return filterChangedEntries(entries);
+}
+
+/** A path already stat'd by the walk — mtime is the raw (unfloored) fs value. */
+export interface PreStatEntry {
+  filePath: string;
+  fileMtimeMs: number;
+  fileSize: number;
+}
+
+/**
+ * Ledger-compare pre-stat'd entries (from the walk's own stat) without a second
+ * stat. Same debounce and change-detection as filterChangedFiles; the raw
+ * mtime is floored here so warm files match the ledger exactly as the stat path
+ * does (Math.floor(stat.mtimeMs)).
+ */
+export function filterChangedEntries(
+  entries: PreStatEntry[],
+): Array<{ filePath: string; scan: ScanStamp }> {
+  const ledger = getScanStampsForPaths(entries.map(e => e.filePath));
+  const out: Array<{ filePath: string; scan: ScanStamp }> = [];
+  const now = Date.now();
+  for (const entry of entries) {
     const scan: ScanStamp = {
-      fileMtimeMs: Math.floor(stat.mtimeMs),
-      fileSize: stat.size,
+      fileMtimeMs: Math.floor(entry.fileMtimeMs),
+      fileSize: entry.fileSize,
     };
-    const prev = ledger.get(filePath);
+    const prev = ledger.get(entry.filePath);
     if (prev && prev.fileMtimeMs === scan.fileMtimeMs && prev.fileSize === scan.fileSize) {
       continue;
     }
     if (prev && shouldDeferRecentAppend(prev, scan, now)) {
       continue;
     }
-    out.push({ filePath, scan });
+    out.push({ filePath: entry.filePath, scan });
   }
   return out;
 }
@@ -706,12 +729,14 @@ async function scanRoutineArchivesIncremental(
   if (!subdir) return;
 
   const ext = agent === 'gemini' ? '.json' : '.jsonl';
-  const filePaths: string[] = [];
+  const prestat: PreStatEntry[] = [];
   for (const sessionsDir of getRoutineArchiveSessionDirs(agent, subdir)) {
-    for (const fp of walkForFiles(sessionsDir, ext, 100_000)) filePaths.push(fp);
+    for (const f of walkForFilesWithStat(sessionsDir, ext, 100_000)) {
+      prestat.push({ filePath: f.path, fileMtimeMs: f.mtimeMs, fileSize: f.size });
+    }
   }
 
-  const changed = filterChangedFiles(filePaths);
+  const changed = filterChangedEntries(prestat);
   if (changed.length === 0) return;
 
   onProgress?.({ agent, parsed: 0, total: changed.length });
@@ -1053,15 +1078,16 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
   // so a no-op scan (changed.length === 0) never touches the credential file.
   const currentVersion = await getCurrentAgentVersion('codex');
 
-  const filePaths: string[] = [];
+  const prestat: PreStatEntry[] = [];
   for (const sessionsDir of getAgentSessionDirs('codex', 'sessions')) {
-    // High limit: we only stat files here, parsing is gated by ledger match.
-    for (const fp of walkForFiles(sessionsDir, '.jsonl', 100_000)) {
-      filePaths.push(fp);
+    // High limit: the walk stats each file once here; parsing is gated by the
+    // ledger match below, which reuses that stat instead of re-stat'ing.
+    for (const f of walkForFilesWithStat(sessionsDir, '.jsonl', 100_000)) {
+      prestat.push({ filePath: f.path, fileMtimeMs: f.mtimeMs, fileSize: f.size });
     }
   }
 
-  const changed = filterChangedFiles(filePaths);
+  const changed = filterChangedEntries(prestat);
 
   // Codex keeps human-readable titles (`thread_name`) in `session_index.jsonl`,
   // which updates independently of the rollout files. Stat each index against the
@@ -2158,15 +2184,16 @@ interface DroidSessionScan {
 async function scanDroidIncremental(onProgress?: (p: ScanProgress) => void): Promise<void> {
   const currentVersion = await getCurrentAgentVersion('droid');
 
-  const filePaths: string[] = [];
+  const prestat: PreStatEntry[] = [];
   for (const sessionsDir of getAgentSessionDirs('droid', 'sessions')) {
-    // High limit: we only stat files here, parsing is gated by ledger match.
-    for (const fp of walkForFiles(sessionsDir, '.jsonl', 100_000)) {
-      filePaths.push(fp);
+    // High limit: the walk stats each file once here; parsing is gated by the
+    // ledger match below, which reuses that stat instead of re-stat'ing.
+    for (const f of walkForFilesWithStat(sessionsDir, '.jsonl', 100_000)) {
+      prestat.push({ filePath: f.path, fileMtimeMs: f.mtimeMs, fileSize: f.size });
     }
   }
 
-  const changed = filterChangedFiles(filePaths);
+  const changed = filterChangedEntries(prestat);
   if (changed.length === 0) return;
 
   onProgress?.({ agent: 'droid', parsed: 0, total: changed.length });


### PR DESCRIPTION
## What

Eliminates the redundant second `stat` per transcript file on the Codex, Droid, and routine-archive session scans that run on every `agents sessions` invocation.

## Before

Each of those three walkers stat'd every file **twice**:

1. `walkForFiles` → `walkEntries` already calls `safeStatSync(full)` for each matching file (`apps/cli/src/lib/fs-walk.ts`) but forwarded only `mtimeMs`, discarding `size`.
2. `filterChangedFiles` (`apps/cli/src/lib/session/discover.ts`) then called `safeStatSync(filePath)` **again** for every path to build `{ fileMtimeMs: Math.floor(stat.mtimeMs), fileSize: stat.size }`.

## After

- **`fs-walk.ts`** — `walkEntries`'s `onFile` now also passes `size`. New `walkForFilesWithStat(dir, ext, limit): Array<{ path, mtimeMs, size }>` mirrors `walkForFiles` (same newest-first sort, same `.slice(0, limit)`) but keeps mtime+size. `walkForFiles` is now a thin `.map(r => r.path)` wrapper — the other callers (`usage.ts`, `runner.ts`, `watchdog/read.ts`) and `latestFileMtimeMs` are unaffected.
- **`discover.ts`** — the ledger comparison is split into `filterChangedEntries(entries)`, which takes pre-stat'd `{ filePath, fileMtimeMs, fileSize }` and runs the identical compare + 5s append debounce **without** re-stat'ing. `scanCodexIncremental`, `scanDroidIncremental`, and `scanRoutineArchivesIncremental` now feed the walk's mtime+size straight in. `filterChangedFiles(paths)` still stats once (delegating to `filterChangedEntries`) for the Claude/Gemini readdir walkers that don't pre-stat.

### Parity detail

The stat path floored the mtime — `fileMtimeMs: Math.floor(stat.mtimeMs)`. The pre-stat path applies the **same** `Math.floor` to the walk's raw `mtimeMs`, so warm files match the ledger exactly and don't spuriously re-parse.

## Behavior-identical internal refactor

Same files surface, same change-detection, appends + the 5s debounce untouched. **No CHANGELOG entry and no docs update** — the repo's CHANGELOG/docs rules exempt pure internal refactors with no user-visible behavior change.

## Tests

- `apps/cli/src/lib/fs-walk.test.ts` — `walkForFilesWithStat` returns the same paths in the same order as `walkForFiles`, and each entry's `mtimeMs`/`size` equals a fresh `fs.statSync`.
- `apps/cli/src/lib/session/discover.filter-parity.test.ts` — proves `filterChangedEntries` (pre-stat) returns the identical changed-set as `filterChangedFiles` (stat-ing) against a real temp tree + real sqlite ledger under a temp `HOME`, covering: empty ledger (all new), a warm/unchanged file (floor parity — both skip it), and an appended/grown file (both detect it).

Targeted suites pass 11/11; `tsc --noEmit` is clean. The pre-existing failures in `exec.test.ts`, `models.test.ts`, `discover.test.ts` (getSessionRoots), and `tests/non-interactive.test.ts` are environment-dependent and reproduce on untouched `origin/main` — none touch `fs-walk` or `filterChangedFiles`.
