### PR TITLE
fix(secrets): store bundle metadata no-ACL at every tier (RUSH-1759)

### DIFF
--- a/apps/cli/.changelog/next/rush-1759-metadata-noacl.md
+++ b/apps/cli/.changelog/next/rush-1759-metadata-noacl.md
@@ -1,0 +1,15 @@
+- **No more Touch ID prompt on every new agent session.** Bundle metadata (names,
+  descriptions, variable names + references, and non-sensitive `--value` literals)
+  is now stored WITHOUT the biometry ACL at every prompt-policy tier, not just
+  `never`. Metadata is non-sensitive by contract — real secret values live in
+  separate `agents-cli.secrets.*` items that keep the bundle's policy ACL — so
+  enumerating bundles no longer needs a keychain unlock. This kills the recurring
+  Touch ID prompt that fired on every new Claude/agent terminal: a SessionStart
+  hook runs `agents devices list`, which scans bundle metadata through crabbox, and
+  that scan used to pop Touch ID once per broker window (~7 days) on every cold
+  launch. `agents secrets list` is now silent too. Reading a bundle's actual
+  values (run injection, `view --reveal`) still prompts. Existing bundles are
+  migrated automatically and once: the first metadata scan after upgrade re-homes
+  each bundle's metadata item no-ACL (reusing the read it already did, so it adds
+  no extra prompt), and every scan after that is prompt-free. Source:
+  `apps/cli/src/lib/secrets/bundles.ts`, `apps/cli/src/lib/secrets/index.ts`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -69,7 +69,7 @@ Variable kinds (stored in bundle metadata, resolved at inject time):
 
 Source: `src/lib/secrets/index.ts:43` (`REF_PATTERN`), `src/lib/secrets/bundles.ts:57-71` (`SecretsBundle`).
 
-The batch-read design means `agents secrets list` pops Touch ID once for all bundles, not once per bundle. Source: `src/lib/secrets/bundles.ts:269-271`.
+Bundle metadata (names, descriptions, variable names + references, and any non-sensitive `--value` literals) is stored WITHOUT the biometry ACL — it is non-sensitive by contract, since real secret values live in the separate `agents-cli.secrets.*` items that keep the bundle's policy ACL. So enumerating bundles is fully silent: `agents secrets list` — and every internal metadata scan, including crabbox's `agents devices list` at session start — reads with no Touch ID prompt. Only reading a bundle's actual values (injection, `view --reveal`) pops the prompt. Source: `src/lib/secrets/bundles.ts` (`writeBundle` / `writeBundleWithItems`).
 
 ## File-backed bundles (headless / remote)
 

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -10,6 +10,8 @@ import {
   readBundle,
   shouldEvictAfterBundleWrite,
   writeBundle,
+  writeBundleWithItems,
+  healKeychainBundleMetadata,
   type SecretsBundle,
 } from './bundles.js';
 import {
@@ -422,5 +424,88 @@ describe('durable session read fallback', () => {
     const { bundle, env } = seed('stale', { T: 'x' });
     saveSession('stale', { bundle, env, expiresAt: Date.now() - 1000, sleepPersist: true });
     expect(() => readAndResolveBundleEnv('stale', { agentOnly: true })).toThrow(/not unlocked/);
+  });
+});
+
+// RUSH-1759: bundle metadata (names, policy, refs, non-sensitive literals) is
+// non-sensitive by contract, so it is written WITHOUT the biometry ACL at every
+// tier — that is what lets `secrets list` / crabbox's `agents devices list`
+// enumerate bundles with no Touch ID. Real secret VALUE items still carry the
+// bundle's policy ACL. These tests pin that split at the write path, plus the
+// one-time heal for metadata that predates the change.
+describe('metadata is stored no-ACL at every tier (RUSH-1759)', () => {
+  class RecordingBackend implements KeychainBackend {
+    store = new Map<string, string>();
+    /** Per item: did its last write take the no-ACL (`set-no-acl`) path? */
+    noAcl = new Map<string, boolean>();
+    has(item: string) { return this.store.has(item); }
+    get(item: string) {
+      const v = this.store.get(item);
+      if (v === undefined) throw new Error(`missing ${item}`);
+      return v;
+    }
+    set(item: string, value: string, opts?: { noAcl?: boolean }) {
+      this.store.set(item, value);
+      this.noAcl.set(item, Boolean(opts?.noAcl));
+    }
+    delete(item: string) { this.noAcl.delete(item); return this.store.delete(item); }
+    list(prefix: string) { return [...this.store.keys()].filter((k) => k.startsWith(prefix)); }
+  }
+
+  let mem: RecordingBackend;
+  let prev: KeychainBackend | null = null;
+  const prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+  const prevNoUsage = process.env.AGENTS_NO_USAGE_TRACK;
+  const META = (name: string) => `agents-cli.bundles.${name}`;
+
+  beforeEach(() => {
+    mem = new RecordingBackend();
+    // Cleartext names (no hashing seam) so items are asserted by their plain name.
+    prev = setKeychainBackendForTest(mem);
+    process.env.AGENTS_SECRETS_NO_AGENT = '1';
+    process.env.AGENTS_NO_USAGE_TRACK = '1';
+  });
+  afterEach(() => {
+    setKeychainBackendForTest(prev);
+    if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+    else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
+    if (prevNoUsage === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+    else process.env.AGENTS_NO_USAGE_TRACK = prevNoUsage;
+  });
+
+  it("writeBundle stores a daily/always bundle's metadata without the biometry ACL", () => {
+    writeBundle({ name: 'prod', policy: 'always', vars: { NOTE: { value: 'hello' } } });
+    expect(mem.noAcl.get(META('prod'))).toBe(true);
+  });
+
+  it('writeBundleWithItems: metadata always no-ACL; value items keep their per-policy ACL', () => {
+    writeBundleWithItems(
+      { name: 'prod', policy: 'daily', vars: { API_KEY: 'keychain:API_KEY' } },
+      new Map([[secretsKeychainItem('prod', 'API_KEY'), 'sk-1']]),
+    );
+    expect(mem.noAcl.get(META('prod'))).toBe(true); // metadata: no-ACL
+    expect(mem.noAcl.get(secretsKeychainItem('prod', 'API_KEY'))).toBe(false); // value: ACL'd (daily)
+
+    writeBundleWithItems(
+      { name: 'cron', policy: 'never', vars: { TOKEN: 'keychain:TOKEN' } },
+      new Map([[secretsKeychainItem('cron', 'TOKEN'), 't']]),
+    );
+    expect(mem.noAcl.get(META('cron'))).toBe(true); // metadata: no-ACL
+    expect(mem.noAcl.get(secretsKeychainItem('cron', 'TOKEN'))).toBe(true); // value: no-ACL (never)
+  });
+
+  it('healKeychainBundleMetadata re-homes each legacy metadata item no-ACL', () => {
+    // Simulate metadata written ACL'd by an older CLI.
+    for (const name of ['old1', 'old2']) {
+      mem.store.set(META(name), JSON.stringify({ name, vars: {} }));
+      mem.noAcl.set(META(name), false);
+    }
+    const healed = healKeychainBundleMetadata(new Map([
+      ['old1', mem.get(META('old1'))],
+      ['old2', mem.get(META('old2'))],
+    ]));
+    expect(healed).toBe(2);
+    expect(mem.noAcl.get(META('old1'))).toBe(true);
+    expect(mem.noAcl.get(META('old2'))).toBe(true);
   });
 });

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -54,7 +54,7 @@ import {
   vaultSetItem,
 } from './vault.js';
 import { emit } from '../events.js';
-import { readMeta } from '../state.js';
+import { readMeta, getHelpersDir } from '../state.js';
 import { assertNameActiveInResourceProfile, filterNamesForActiveResourceProfile } from '../resource-profiles.js';
 import { agentGetSync, agentAutoLoadSync, agentGetMetaSync, agentAutoLoadMetaSync, agentEvictSync, secretsAgentAutoEnabled, secretsHoldMs } from './agent.js';
 import { loadSession, deleteSession } from './session-store.js';
@@ -563,11 +563,15 @@ function finishBundleWrite(bundle: SecretsBundle, opts: WriteBundleOptions): voi
 
 export function writeBundle(bundle: SecretsBundle, opts: WriteBundleOptions = {}): void {
   const prepared = prepareBundleWrite(bundle);
-  // A `never` bundle's metadata is stored without the biometry ACL too, so
-  // `view` and the metadata half of a read resolve silently — the whole point
-  // of the tier. On an un-updated pinned helper this write fails loudly (the
-  // no-ACL command is missing) rather than silently landing an ACL'd item.
-  itemStore(prepared.backend).set(prepared.metadataItem, prepared.metadataJson, { noAcl: bundle.policy === 'never' });
+  // Bundle metadata (name, description, policy, var names + refs, and any
+  // non-sensitive `--value` literals) is stored WITHOUT the biometry ACL at
+  // EVERY tier. It is non-sensitive by contract — the real secret values live in
+  // separate agents-cli.secrets.* items that keep the bundle's policy ACL — so a
+  // no-ACL metadata item is what lets `secrets list` and crabbox's `agents
+  // devices list` enumerate bundles with no Touch ID prompt (RUSH-1759). On an
+  // un-updated pinned helper this write fails loudly (the no-ACL command is
+  // missing) rather than silently landing an ACL'd item.
+  itemStore(prepared.backend).set(prepared.metadataItem, prepared.metadataJson, { noAcl: true });
   finishBundleWrite(bundle, opts);
 }
 
@@ -577,9 +581,26 @@ export function writeBundleWithItems(
   opts: WriteBundleOptions = {},
 ): void {
   const prepared = prepareBundleWrite(bundle);
-  const batch = new Map(items);
-  batch.set(prepared.metadataItem, prepared.metadataJson);
-  itemStore(prepared.backend).setBatch(batch, { noAcl: bundle.policy === 'never' });
+  const store = itemStore(prepared.backend);
+  if (prepared.backend === 'keychain') {
+    // Only the keychain backend has a biometry ACL. Secret VALUE items carry the
+    // bundle's policy ACL (`never` ⇒ no-ACL); the metadata item is ALWAYS no-ACL
+    // (see writeBundle). The two must NOT ride one batch flag — a single noAcl
+    // over both would either strip biometry off the real secrets or re-ACL the
+    // metadata. Write the values first, then the metadata last: bundle discovery
+    // keys on the metadata item's presence, so metadata-last means a partial
+    // write reads as "no bundle yet", never as a bundle with missing values.
+    if (items.size > 0) {
+      store.setBatch(new Map(items), { noAcl: bundle.policy === 'never' });
+    }
+    store.set(prepared.metadataItem, prepared.metadataJson, { noAcl: true });
+  } else {
+    // file / vault: no ACL concept (noAcl is ignored), so one batched write is
+    // both correct and cheaper — e.g. a single age re-encrypt for the vault.
+    const batch = new Map(items);
+    batch.set(prepared.metadataItem, prepared.metadataJson);
+    store.setBatch(batch, { noAcl: bundle.policy === 'never' });
+  }
   finishBundleWrite(bundle, opts);
 }
 
@@ -637,6 +658,76 @@ function parseBundleMeta(nameHint: string | undefined, json: string, backend: Se
   return bundle;
 }
 
+// Sentinel marking the one-time RUSH-1759 metadata-ACL heal as done. Lives under
+// the regenerable helpers dir (same tree as the secrets-agent runtime state), so
+// a cache wipe just re-runs the heal — harmless, since it is idempotent.
+const METADATA_NOACL_SENTINEL = 'bundles-metadata-noacl-healed';
+
+function metadataNoAclSentinelPath(): string {
+  return path.join(getHelpersDir(), 'secrets-agent', METADATA_NOACL_SENTINEL);
+}
+
+function bundleMetadataAclHealed(): boolean {
+  try {
+    return fs.existsSync(metadataNoAclSentinelPath());
+  } catch {
+    return false;
+  }
+}
+
+function markBundleMetadataAclHealed(): void {
+  try {
+    const file = metadataNoAclSentinelPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '', 'utf8');
+  } catch {
+    // Best effort — a missing sentinel just means the (idempotent) heal re-runs
+    // on the next broker-miss listing.
+  }
+}
+
+/**
+ * Re-write already-read keychain bundle metadata items WITHOUT the biometry ACL.
+ * `metaJsonByName` maps bundle name → the exact metadata JSON listBundles just
+ * batch-read, so writing it back only flips the ACL (via the helper's
+ * delete-then-add `set-no-acl`) — contents and updated_at are preserved and no
+ * extra keychain read is issued. Exported for tests. Returns the count healed.
+ */
+export function healKeychainBundleMetadata(metaJsonByName: Map<string, string>): number {
+  let healed = 0;
+  for (const [name, json] of metaJsonByName) {
+    try {
+      // Cleartext meta-item name → hashed by keychainStore.set (#316) to the same
+      // service the read enumerated, so this overwrites the existing item in
+      // place, no-ACL. A per-item failure (e.g. a pinned helper without
+      // set-no-acl) must not abort the rest.
+      keychainStore.set(bundleMetaItem(name), json, { noAcl: true });
+      healed++;
+    } catch {
+      /* keep healing the remaining items */
+    }
+  }
+  return healed;
+}
+
+/**
+ * One-time driver around healKeychainBundleMetadata (RUSH-1759). macOS + real
+ * keychain only — libsecret/CredMan have no biometry ACL to shed, and a test
+ * backend has no real keychain — and gated by a sentinel so it runs at most
+ * once. Best-effort: a heal failure never breaks bundle listing.
+ */
+function healKeychainBundleMetadataAclOnce(metaJsonByName: Map<string, string>): void {
+  if (metaJsonByName.size === 0) return;
+  if (process.platform !== 'darwin') return;
+  if (isKeychainBackendOverridden()) return;
+  if (bundleMetadataAclHealed()) return;
+  try {
+    if (healKeychainBundleMetadata(metaJsonByName) > 0) markBundleMetadataAclHealed();
+  } catch {
+    /* never let a heal failure break `secrets list` */
+  }
+}
+
 export function listBundles(): SecretsBundle[] {
   const out: SecretsBundle[] = [];
 
@@ -691,6 +782,7 @@ export function listBundles(): SecretsBundle[] {
       } else {
         const fetched = getKeychainTokens(keychainServices);
         const keychainBundles: SecretsBundle[] = [];
+        const metaJsonByName = new Map<string, string>();
         for (const service of keychainServices) {
           const json = fetched.get(service);
           if (json === undefined) continue;
@@ -698,7 +790,10 @@ export function listBundles(): SecretsBundle[] {
             ? service.slice(BUNDLE_META_PREFIX.length)
             : undefined;
           const bundle = parseBundleMeta(nameHint, json, 'keychain');
-          if (bundle) keychainBundles.push(bundle);
+          if (bundle) {
+            keychainBundles.push(bundle);
+            metaJsonByName.set(bundle.name, json);
+          }
         }
         for (const bundle of keychainBundles) out.push(bundle);
         // Populate the broker for the rest of the hold window (fire-and-forget).
@@ -708,6 +803,13 @@ export function listBundles(): SecretsBundle[] {
         if (useAgent && keychainBundles.length > 0) {
           agentAutoLoadMetaSync(nameSetHash, keychainBundles, secretsHoldMs());
         }
+        // One-time RUSH-1759 heal: bundles written before the metadata-no-ACL
+        // change carry an ACL'd metadata item, so this fresh read (a broker miss)
+        // popped Touch ID just to enumerate them. Re-home each metadata item
+        // no-ACL now — reusing the JSON we just read, so the heal adds no extra
+        // prompt — and every later enumeration is silent. Runs at most once (a
+        // sentinel under the regenerable helpers dir).
+        healKeychainBundleMetadataAclOnce(metaJsonByName);
       }
     }
   }

--- a/apps/cli/src/lib/secrets/index.test.ts
+++ b/apps/cli/src/lib/secrets/index.test.ts
@@ -271,7 +271,7 @@ describe('service-name hashing through the primitives', () => {
 describe('computeRekeyPlan', () => {
   const key = randomBytes(32);
 
-  it('preserves the no-ACL tier for never-policy bundles and injects the name into metadata', () => {
+  it('stores ALL bundle metadata no-ACL (non-sensitive) while value items keep their per-tier ACL', () => {
     const services = [
       'agents-cli.bundles.autobot',
       'agents-cli.secrets.autobot.CRON_TOKEN',
@@ -293,9 +293,12 @@ describe('computeRekeyPlan', () => {
     const { items, unreadable } = computeRekeyPlan(services, values, key);
     expect(unreadable).toEqual([]);
     const byOld = Object.fromEntries(items.map((i) => [i.oldService, i]));
+    // Metadata is no-ACL at every tier now (RUSH-1759): a `never` bundle (autobot)
+    // AND a daily/`session` bundle (prod) both re-home their metadata no-ACL, so
+    // enumeration never prompts. The secret VALUE items still split by tier.
     expect(byOld['agents-cli.bundles.autobot'].noAcl).toBe(true);
     expect(byOld['agents-cli.secrets.autobot.CRON_TOKEN'].noAcl).toBe(true);
-    expect(byOld['agents-cli.bundles.prod'].noAcl).toBe(false);
+    expect(byOld['agents-cli.bundles.prod'].noAcl).toBe(true);
     expect(byOld['agents-cli.secrets.prod.API_KEY'].noAcl).toBe(false);
     expect(byOld['agents-cli.anthropic.token'].noAcl).toBe(false);
     // Correction D: durable session items must stay no-ACL through a rekey, or

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -565,8 +565,12 @@ export function computeRekeyPlan(
     try {
       const parsed = JSON.parse(value) as Record<string, unknown> | null;
       if (parsed && typeof parsed === 'object') {
-        const tier = parsed.tier;
-        noAcl = tier === 'none' || tier === 'never';
+        // Bundle metadata is non-sensitive by contract and stored no-ACL at
+        // EVERY tier (matches writeBundle in bundles.ts), so `secrets list` /
+        // crabbox's `agents devices list` enumerate bundles with no Touch ID
+        // (RUSH-1759). Re-home metadata no-ACL regardless of the bundle's policy;
+        // the real secret values (second loop) still carry their per-bundle ACL.
+        noAcl = true;
         payload = JSON.stringify({ ...parsed, name });
       }
     } catch {


### PR DESCRIPTION
## Problem (RUSH-1759)

A Touch ID prompt fired on **every new Claude/agent terminal**. Root cause, traced end-to-end:

`inject-device-topology` SessionStart hook → `agents devices list` → crabbox `listBundles()` → a **batch read of bundle metadata items** that were stored **with the biometry ACL**. On every cold launch (first list per ~7-day broker window, or after sleep/lock/upgrade) that read popped Touch ID — just to *enumerate* bundles, before reading any secret value.

## Why metadata doesn't need the ACL

Bundle metadata is the name, description, variable names + references, and any non-sensitive `--value` literals (the `--value` help text already says "non-sensitive values only"). **Real secret values live in separate `agents-cli.secrets.*` items** that keep the bundle's policy ACL. So the metadata blob is non-sensitive by contract — gating it behind biometry bought nothing but the prompt. The `never` policy tier already stored metadata no-ACL; this generalizes that to every tier.

## The fix

Store metadata **no-ACL at every prompt-policy tier**, at all three write loci — value items are unchanged:

- `writeBundle` — metadata `{ noAcl: true }`.
- `writeBundleWithItems` — **split** the metadata write from the secret-value batch (keychain only), so values keep their per-policy ACL (`never` ⇒ no-ACL) while metadata is always no-ACL. A single shared `noAcl` flag would otherwise strip biometry off the real secrets. file/vault have no ACL concept, so they stay a single batched write (keeps the vault at one age re-encrypt).
- `computeRekeyPlan` (index.ts) — re-home metadata no-ACL regardless of tier.

**Existing bundles migrate automatically and once:** the first cold metadata scan after upgrade re-homes each bundle's metadata item no-ACL, reusing the JSON it just read (no extra prompt), gated by a sentinel under the regenerable helpers dir. macOS + real-keychain only. The helper's `set-no-acl` already does delete-then-add, so it removes the existing item's ACL cleanly.

Reading a bundle's actual values (run injection, `view --reveal`) still pops Touch ID.

## Tests

New/updated in `bundles.test.ts` + `index.test.ts`:
- `writeBundle` stores a daily/always bundle's metadata no-ACL.
- `writeBundleWithItems`: metadata no-ACL; value items keep the per-policy ACL (`daily` ACL'd, `never` no-ACL).
- `healKeychainBundleMetadata` re-homes each legacy metadata item no-ACL.
- `computeRekeyPlan` now stores all metadata no-ACL while values split by tier.

```
Test Files  27 passed | 1 skipped (28)
     Tests  455 passed | 13 skipped (468)
```
`tsc --noEmit` clean.

## Docs

- `apps/cli/docs/secrets.md` — metadata is no-ACL; `secrets list` / crabbox enumeration is silent, only value reads prompt.
- `apps/cli/.changelog/next/rush-1759-metadata-noacl.md`.

Session transcript (public repo, referenced not attached): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit/feff8f41-ca57-479d-8b78-0d7237618d1b.jsonl`