### PR TITLE
feat: detach/attach — background a running agent (CLI + Factory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ agents sessions resume --host zion --tmux  # resume on another machine over SSH
 
 `agents sessions resume` reopens sessions in whatever terminal you're in -- auto-detected across iTerm, Ghostty, tmux, and the VSCodium agent-terminal, or forced with `--iterm` / `--ghostty` / `--tmux` / `--vscodium`. Back them with **tmux** and the runs turn durable: detach, close your editor, reboot the GUI -- the session is still alive to `agents tmux attach`. The whole `agents tmux` subsystem (persistent multiplexer sessions that survive editor restarts and can be shared with other tools) sits underneath.
 
+### Send an agent to the background — and bring it back
+
+Running 30 agents and drowning in terminal tabs? `agents detach <id>` stops a session's interactive process and keeps it working **headless** in the background -- it drives its task to done unattended, no tab, lower cost. `agents attach <id>` brings it back: version-pinned resume into a live TUI, the same session and full history (including whatever it did while backgrounded).
+
+```
+agents detach a1b2c3d4     # go headless in the background, keep working
+agents attach a1b2c3d4     # resume it interactively, right here
+```
+
+Both are agent-agnostic -- they route through the same `agents run --resume` path (native resume for Claude/Codex, `/continue` replay for the rest). `agents sessions --active` marks each session's `presence` -- `attached` (you're watching it), `background` (running headless), or `parked` (its background run finished) -- so the menu bar and Factory show where every agent is.
+
 ---
 
 ## Control the fleet

--- a/apps/cli/.changelog/next/detach-attach.md
+++ b/apps/cli/.changelog/next/detach-attach.md
@@ -1,0 +1,16 @@
+- **`agents detach` / `agents attach` — send a running agent to the background and
+  back.** `agents detach <id>` stops a live session's interactive process (killing
+  the tmux session when tmux-hosted, else SIGTERM'ing the pid) and continues it
+  **headless**, detached, via the existing version-pinned `agents run --resume`
+  path — so it drives its task to completion without holding a terminal. The
+  resumed run carries a nudge that tells the now-unwatched agent it is headless and
+  to make the call rather than stall on a confirmation nobody can answer.
+  `agents attach <id>` stops that headless continuation and **resumes the session
+  interactively** in the current terminal (`resumeSessionInPlace`) — the same
+  session and full history, including whatever the background run did. Both verbs
+  are agent-agnostic (native resume for Claude/Codex, `/continue` replay for the
+  rest). `agents sessions --active --json` now carries a `presence` field
+  (`attached` / `background` / `parked`), folded onto every row from a per-session
+  detach record, so the menu bar and Factory show where each agent is. Source:
+  `apps/cli/src/commands/detach.ts`, `apps/cli/src/commands/attach.ts`,
+  `apps/cli/src/lib/session/detached.ts`.

--- a/apps/cli/.changelog/next/detach-attach.md
+++ b/apps/cli/.changelog/next/detach-attach.md
@@ -9,7 +9,12 @@
   interactively** in the current terminal (`resumeSessionInPlace`) — the same
   session and full history, including whatever the background run did. Both verbs
   are agent-agnostic (native resume for Claude/Codex, `/continue` replay for the
-  rest). `agents sessions --active --json` now carries a `presence` field
+  rest). A session on **another host** is detached there over SSH rather than
+  killed locally; **cloud and team sessions are refused** (they have their own
+  lifecycles); the interactive process is fully awaited before the headless resume
+  starts (no transcript race); and the background run's output is captured to
+  `~/.agents/.cache/logs/detach-<shortid>.log` so a crash after detach is
+  debuggable. `agents sessions --active --json` now carries a `presence` field
   (`attached` / `background` / `parked`), folded onto every row from a per-session
   detach record, so the menu bar and Factory show where each agent is. Source:
   `apps/cli/src/commands/detach.ts`, `apps/cli/src/commands/attach.ts`,

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,21 +1,5 @@
 # Changelog
 
-## 1.20.75
-
-- **`agents detach` / `agents attach` — send a running agent to the background and
-  back.** `agents detach <id>` stops a live session's interactive process and
-  continues it headless, unattended, so it drives its task to completion without
-  holding a terminal; `agents attach <id>` stops that headless continuation and
-  resumes the session interactively — version-pinned native resume (Claude/Codex)
-  or a `/continue` replay (others), the same session and full history. Both are
-  agent-agnostic, routing through the existing `agents run --resume` path. The
-  backgrounded run resumes with a nudge that tells the agent it is unattended and
-  to drive to done rather than stall on a confirmation nobody can answer.
-  `agents sessions --active --json` now carries a `presence` field (`attached` /
-  `background` / `parked`) so the menu bar and Factory show where each agent is.
-  Source: `apps/cli/src/commands/detach.ts`, `apps/cli/src/commands/attach.ts`,
-  `apps/cli/src/lib/session/detached.ts`.
-
 ## 1.20.74
 
 - **Project resource manifests are now portable across Windows and POSIX.** The

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.20.75
+
+- **`agents detach` / `agents attach` — send a running agent to the background and
+  back.** `agents detach <id>` stops a live session's interactive process and
+  continues it headless, unattended, so it drives its task to completion without
+  holding a terminal; `agents attach <id>` stops that headless continuation and
+  resumes the session interactively — version-pinned native resume (Claude/Codex)
+  or a `/continue` replay (others), the same session and full history. Both are
+  agent-agnostic, routing through the existing `agents run --resume` path. The
+  backgrounded run resumes with a nudge that tells the agent it is unattended and
+  to drive to done rather than stall on a confirmation nobody can answer.
+  `agents sessions --active --json` now carries a `presence` field (`attached` /
+  `background` / `parked`) so the menu bar and Factory show where each agent is.
+  Source: `apps/cli/src/commands/detach.ts`, `apps/cli/src/commands/attach.ts`,
+  `apps/cli/src/lib/session/detached.ts`.
+
 ## 1.20.74
 
 - **Project resource manifests are now portable across Windows and POSIX.** The

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -290,11 +290,21 @@ they are agent-agnostic (native resume for Claude/Codex, `/continue` replay for 
 rest), not a per-agent special case.
 
 - **detach**: stop the interactive process (kill the tmux session when tmux-hosted,
-  else SIGTERM the pid), then spawn a detached, version-pinned
-  `agents run <agent> --resume <id> --headless "<nudge>"`. The nudge tells the now-
-  unwatched agent it is headless and to drive its task to completion rather than
-  stall on a confirmation nobody can answer. The continuation runs until the task is
-  done, then exits.
+  else SIGTERM the pid) and **wait for it to actually exit** before spawning a
+  detached, version-pinned `agents run <agent> --resume <id> --headless "<nudge>"`,
+  so the two never race over the same transcript. The nudge tells the now-unwatched
+  agent it is headless and to drive its task to completion rather than stall on a
+  confirmation nobody can answer. The continuation runs until the task is done, then
+  exits; its output is written to `~/.agents/.cache/logs/detach-<shortid>.log`
+  (printed on detach) so a background run that crashes leaves a trail.
+  - **Remote sessions** (matched via the cross-host sweep) are detached **on their
+    own host over SSH** — `agents detach <id> --local` runs there — since a pid and
+    tmux socket only mean something on the machine the session runs on. Use `--local`
+    to skip the sweep and only consider this machine.
+  - **Cloud and team sessions are refused**: cloud runs have their own lifecycle, and
+    a `teams` session must be stopped through `agents teams` so the team supervisor's
+    PID-reuse-safe stop path and bookkeeping stay in sync — `detach` won't SIGTERM a
+    teammate out from under it.
 - **attach**: stop the headless continuation (if any), then `resumeSessionInPlace`
   the session interactively in the current terminal — the same session, full history,
   including whatever the background run did.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -281,6 +281,39 @@ Scope: v1 supports **Claude** (single-file transcript, native `--resume`). Codex
 agents (opencode) need per-agent handling and are refused up front with a clear
 message.
 
+## Background & foreground (detach / attach)
+
+`agents detach <id>` sends a live agent session to the background; `agents attach <id>`
+brings it back. They are the foreground/background axis over a session, and route
+through the same version-pinned `agents run --resume` path everything else uses — so
+they are agent-agnostic (native resume for Claude/Codex, `/continue` replay for the
+rest), not a per-agent special case.
+
+- **detach**: stop the interactive process (kill the tmux session when tmux-hosted,
+  else SIGTERM the pid), then spawn a detached, version-pinned
+  `agents run <agent> --resume <id> --headless "<nudge>"`. The nudge tells the now-
+  unwatched agent it is headless and to drive its task to completion rather than
+  stall on a confirmation nobody can answer. The continuation runs until the task is
+  done, then exits.
+- **attach**: stop the headless continuation (if any), then `resumeSessionInPlace`
+  the session interactively in the current terminal — the same session, full history,
+  including whatever the background run did.
+
+The record `detach` writes (`~/.agents/.system/detached/<id>.json`, one file per
+session; see `lib/session/detached.ts`) is the source of truth for **presence**, which
+`getActiveSessions` folds onto every row and `agents sessions --active --json` emits:
+
+| presence | meaning |
+| --- | --- |
+| `attached` | live interactive TUI you're watching |
+| `background` | detached: the headless continuation is running (its pid is alive) |
+| `parked` | the headless continuation has exited; the transcript is durable, `attach` resumes it |
+
+Presence is **derived, never asserted**: a record only says "this session was detached";
+whether it is `background` or `parked` is decided live from the recorded pid plus its
+start-time fingerprint (which defeats PID reuse). Ad-hoc headless runs and cloud/team
+rows carry no presence — they are not on this axis.
+
 ## Export / Import (portable bundles)
 
 `agents sessions export` bundles selected sessions into a portable, self-describing

--- a/apps/cli/src/commands/attach.ts
+++ b/apps/cli/src/commands/attach.ts
@@ -1,0 +1,52 @@
+/**
+ * `agents attach <id>` — bring a backgrounded (or parked) agent session back to
+ * the foreground: stop its headless continuation, then resume it interactively
+ * in this terminal. The resume is version-pinned native resume (claude/codex) or
+ * a `/continue` replay (others) — the same session, full history, the exact
+ * inverse of `agents detach`.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { discoverSessions } from '../lib/session/discover.js';
+import { resumeSessionInPlace } from './sessions.js';
+import { readDetachRecord, clearDetachRecord, isHeadlessAlive } from '../lib/session/detached.js';
+
+export function registerAttachCommand(program: Command): void {
+  program
+    .command('attach')
+    .argument('<id>', 'Short or full id of the backgrounded/parked session to resume interactively')
+    .description('Bring a backgrounded agent to the foreground — resume it interactively here')
+    .action(async (id: string) => {
+      await attachAction(id);
+    });
+}
+
+export async function attachAction(id: string): Promise<void> {
+  const q = id.toLowerCase();
+  // Rich meta carries the pinned version + origin cwd the resume needs.
+  const metas = await discoverSessions({ all: true, since: '90d', limit: 2000 });
+  const meta = metas.find((m) => m.id === id) ?? metas.find((m) => m.id.toLowerCase().startsWith(q));
+  if (!meta) {
+    console.error(chalk.red(`No session matching "${id}".`));
+    console.error(chalk.gray('  See your sessions: agents sessions'));
+    process.exitCode = 1;
+    return;
+  }
+
+  // If it's backgrounded, stop the headless continuation first so two processes
+  // don't resume the same transcript at once.
+  const rec = readDetachRecord(meta.id);
+  if (rec) {
+    if (isHeadlessAlive(rec)) {
+      try {
+        process.kill(rec.headlessPid, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+    }
+    clearDetachRecord(meta.id);
+  }
+
+  console.log(chalk.gray(`Attaching ${meta.agent} ${meta.id.slice(0, 8)} — resuming interactively…`));
+  await resumeSessionInPlace(meta);
+}

--- a/apps/cli/src/commands/detach-core.ts
+++ b/apps/cli/src/commands/detach-core.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure core of `agents detach` — the nudge, the resumed-run argv, and the id
+ * resolver. Kept import-light (only a type import) so it is unit-tested without
+ * loading the live-session discovery graph.
+ */
+import type { ActiveSession } from '../lib/session/active.js';
+
+/**
+ * The prompt the backgrounded run resumes with. Its whole job is to stop a
+ * now-unwatched agent from stalling on a confirmation nobody will answer: it
+ * tells the agent it is headless and to drive to done, or to stop and state a
+ * blocker (which surfaces as a waiting session the user can `attach`).
+ */
+export const BACKGROUND_NUDGE =
+  "You've been sent to the background — nobody is watching this session now. " +
+  'Continue the current task and drive it to completion end-to-end. ' +
+  "Don't ask for confirmation; make the reasonable call and keep going. " +
+  'If you genuinely cannot proceed safely, stop and state the blocker plainly in one message.';
+
+/**
+ * Build the argv for the headless continuation `detach` spawns. Agent-agnostic
+ * and version-pinned by construction — it goes through the same `agents run
+ * --resume` path `attach` reverses.
+ */
+export function buildBackgroundArgv(agent: string, sessionId: string, cwd?: string): string[] {
+  const argv = ['run', agent, BACKGROUND_NUDGE, '--resume', sessionId, '--headless'];
+  if (cwd) argv.push('--cwd', cwd);
+  return argv;
+}
+
+/**
+ * Resolve `<id>` to exactly one live session by prefix. Mirrors `focus`'s match
+ * so the two verbs accept the same ids.
+ */
+export function resolveOne(
+  activeById: Map<string, ActiveSession>,
+  id: string,
+): ActiveSession | { error: string } {
+  const q = id.toLowerCase();
+  const matches = [...activeById.values()].filter((s) => (s.sessionId ?? '').toLowerCase().startsWith(q));
+  if (matches.length === 0) return { error: `No live session matching "${id}".` };
+  if (matches.length > 1) {
+    return { error: `"${id}" is ambiguous (${matches.length} live matches). Use more of the id.` };
+  }
+  return matches[0];
+}

--- a/apps/cli/src/commands/detach-core.ts
+++ b/apps/cli/src/commands/detach-core.ts
@@ -28,6 +28,39 @@ export function buildBackgroundArgv(agent: string, sessionId: string, cwd?: stri
   return argv;
 }
 
+/** What to do with a resolved session, given which machine we're on. */
+export type DetachTarget =
+  | { kind: 'local'; sessionId: string }
+  | { kind: 'remote'; machine: string; sessionId: string }
+  | { kind: 'refuse'; reason: string };
+
+/**
+ * Decide how to detach a resolved session. Cloud and team sessions are refused
+ * (they have their own lifecycles); a session on another machine is delegated to
+ * that host over SSH — never stopped/resumed locally, since its pid and tmux
+ * socket only mean something where it actually runs. Pure, so every branch is
+ * unit-tested without a live pool. Mirrors `focus`/`jumpTo`'s remote branch.
+ */
+export function resolveDetachTarget(s: ActiveSession, self: string): DetachTarget {
+  if (s.context === 'cloud') {
+    return { kind: 'refuse', reason: 'Cloud sessions run remotely and cannot be detached from here.' };
+  }
+  if (s.context === 'teams') {
+    return {
+      kind: 'refuse',
+      reason: 'That session is managed by its team — stop it with `agents teams`, not `detach`.',
+    };
+  }
+  const sessionId = s.sessionId ?? '';
+  if (!sessionId) {
+    return { kind: 'refuse', reason: 'That session has no id to resume, so it cannot be detached.' };
+  }
+  if (s.machine && s.machine !== self) {
+    return { kind: 'remote', machine: s.machine, sessionId };
+  }
+  return { kind: 'local', sessionId };
+}
+
 /**
  * Resolve `<id>` to exactly one live session by prefix. Mirrors `focus`'s match
  * so the two verbs accept the same ids.

--- a/apps/cli/src/commands/detach.test.ts
+++ b/apps/cli/src/commands/detach.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildBackgroundArgv, resolveOne, BACKGROUND_NUDGE } from './detach-core.js';
+import { buildBackgroundArgv, resolveDetachTarget, resolveOne, BACKGROUND_NUDGE } from './detach-core.js';
 import type { ActiveSession } from '../lib/session/active.js';
 
 function session(sessionId: string): ActiveSession {
@@ -63,5 +63,47 @@ describe('resolveOne', () => {
   it('errors (none) when nothing matches', () => {
     const r = resolveOne(map, 'zzz');
     expect('error' in r && r.error).toMatch(/no live session/i);
+  });
+});
+
+describe('resolveDetachTarget', () => {
+  it('detaches a local session (same machine) locally', () => {
+    const s = { context: 'terminal', kind: 'claude', sessionId: 'abc-1', machine: 'zion' } as ActiveSession;
+    expect(resolveDetachTarget(s, 'zion')).toEqual({ kind: 'local', sessionId: 'abc-1' });
+  });
+
+  it('treats a session with no machine as local', () => {
+    const s = { context: 'terminal', kind: 'claude', sessionId: 'abc-2' } as ActiveSession;
+    expect(resolveDetachTarget(s, 'zion')).toEqual({ kind: 'local', sessionId: 'abc-2' });
+  });
+
+  it('delegates a session on another host to that host over SSH', () => {
+    const s = { context: 'terminal', kind: 'claude', sessionId: 'abc-3', machine: 'yosemite-s0' } as ActiveSession;
+    expect(resolveDetachTarget(s, 'zion')).toEqual({
+      kind: 'remote',
+      machine: 'yosemite-s0',
+      sessionId: 'abc-3',
+    });
+  });
+
+  it('refuses cloud sessions (they run remotely with their own lifecycle)', () => {
+    const s = { context: 'cloud', kind: 'claude', sessionId: 'abc-4' } as ActiveSession;
+    const t = resolveDetachTarget(s, 'zion');
+    expect(t.kind).toBe('refuse');
+    expect(t.kind === 'refuse' && t.reason).toMatch(/cloud/i);
+  });
+
+  it('refuses team sessions so it can\'t bypass the team stop path', () => {
+    const s = { context: 'teams', kind: 'claude', sessionId: 'abc-5', pid: 4321 } as ActiveSession;
+    const t = resolveDetachTarget(s, 'zion');
+    expect(t.kind).toBe('refuse');
+    expect(t.kind === 'refuse' && t.reason).toMatch(/team/i);
+  });
+
+  it('refuses a session with no id to resume', () => {
+    const s = { context: 'terminal', kind: 'claude', sessionId: '' } as ActiveSession;
+    const t = resolveDetachTarget(s, 'zion');
+    expect(t.kind).toBe('refuse');
+    expect(t.kind === 'refuse' && t.reason).toMatch(/no id/i);
   });
 });

--- a/apps/cli/src/commands/detach.test.ts
+++ b/apps/cli/src/commands/detach.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { buildBackgroundArgv, resolveOne, BACKGROUND_NUDGE } from './detach-core.js';
+import type { ActiveSession } from '../lib/session/active.js';
+
+function session(sessionId: string): ActiveSession {
+  return { context: 'terminal', kind: 'claude', sessionId, status: 'running' } as ActiveSession;
+}
+
+describe('buildBackgroundArgv', () => {
+  it('resumes the session headless with the nudge, agent-agnostic', () => {
+    expect(buildBackgroundArgv('codex', 'sess-123', '/repo')).toEqual([
+      'run',
+      'codex',
+      BACKGROUND_NUDGE,
+      '--resume',
+      'sess-123',
+      '--headless',
+      '--cwd',
+      '/repo',
+    ]);
+  });
+
+  it('omits --cwd when the session has none', () => {
+    expect(buildBackgroundArgv('claude', 'sess-9')).toEqual([
+      'run',
+      'claude',
+      BACKGROUND_NUDGE,
+      '--resume',
+      'sess-9',
+      '--headless',
+    ]);
+  });
+
+  it('the nudge tells the agent it is unattended and not to ask', () => {
+    expect(BACKGROUND_NUDGE).toMatch(/background/i);
+    expect(BACKGROUND_NUDGE).toMatch(/don'?t ask/i);
+  });
+});
+
+describe('resolveOne', () => {
+  const map = new Map<string, ActiveSession>([
+    ['1', session('abc12345-aaaa')],
+    ['2', session('abc99999-bbbb')],
+    ['3', session('def00000-cccc')],
+  ]);
+
+  it('resolves a unique prefix to that session', () => {
+    const r = resolveOne(map, 'def');
+    expect('error' in r).toBe(false);
+    expect((r as ActiveSession).sessionId).toBe('def00000-cccc');
+  });
+
+  it('is case-insensitive', () => {
+    const r = resolveOne(map, 'DEF0');
+    expect((r as ActiveSession).sessionId).toBe('def00000-cccc');
+  });
+
+  it('errors (ambiguous) when a prefix matches more than one', () => {
+    const r = resolveOne(map, 'abc');
+    expect('error' in r && r.error).toMatch(/ambiguous/i);
+  });
+
+  it('errors (none) when nothing matches', () => {
+    const r = resolveOne(map, 'zzz');
+    expect('error' in r && r.error).toMatch(/no live session/i);
+  });
+});

--- a/apps/cli/src/commands/detach.ts
+++ b/apps/cli/src/commands/detach.ts
@@ -1,0 +1,113 @@
+/**
+ * `agents detach <id>` — send a live agent session to the background: stop its
+ * interactive process and continue it headless, unattended, so it drives its
+ * task to completion without holding a terminal. Bring it back with
+ * `agents attach`.
+ *
+ * Agent-agnostic and version-pinned by construction: it re-invokes
+ * `agents run <agent> "<nudge>" --resume <id> --headless`, which resolves the
+ * session's originating version and uses the agent's native resume (claude/codex)
+ * or a `/continue` replay (others) — the same path `attach` reverses.
+ */
+import { spawn } from 'node:child_process';
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { gatherLiveTargets } from './go.js';
+import type { ActiveSession } from '../lib/session/active.js';
+import { killSession } from '../lib/tmux/index.js';
+import { getDefaultSocketPath } from '../lib/tmux/paths.js';
+import { getAgentsInvocation } from '../lib/daemon.js';
+import { captureProcessStartTime } from '../lib/pty-server.js';
+import { writeDetachRecord } from '../lib/session/detached.js';
+import { buildBackgroundArgv, resolveOne } from './detach-core.js';
+
+export function registerDetachCommand(program: Command): void {
+  program
+    .command('detach')
+    .argument('<id>', 'Short or full id of the live session to background')
+    .option('--local', 'Only this machine (skip the cross-host sweep)')
+    .description('Send a live agent to the background — stop its terminal, keep it working headless')
+    .action(async (id: string, opts: { local?: boolean }) => {
+      await detachAction(id, opts);
+    });
+}
+
+/**
+ * Stop the interactive process so it can't fight the headless resume over the
+ * same transcript. tmux-hosted sessions are killed by session (closes the pane
+ * and ends the agent); a plain process is SIGTERM'd by pid.
+ */
+async function stopInteractive(s: ActiveSession): Promise<void> {
+  if (s.tmuxTarget) {
+    const name = s.tmuxTarget.split(':')[0];
+    await killSession(name, getDefaultSocketPath());
+    return;
+  }
+  if (s.pid && s.pid > 0) {
+    try {
+      process.kill(s.pid, 'SIGTERM');
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+/** Spawn the headless continuation detached, resolving to its pid for tracking. */
+function spawnHeadless(command: string, args: string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { detached: true, stdio: 'ignore', env: process.env });
+    child.once('spawn', () => {
+      const pid = child.pid ?? 0;
+      child.unref();
+      resolve(pid);
+    });
+    child.once('error', (err) => reject(err instanceof Error ? err : new Error(String(err))));
+  });
+}
+
+export async function detachAction(id: string, opts: { local?: boolean } = {}): Promise<void> {
+  const { activeById } = await gatherLiveTargets(!!opts.local);
+  const resolved = resolveOne(activeById, id);
+  if ('error' in resolved) {
+    console.error(chalk.red(resolved.error));
+    process.exitCode = 1;
+    return;
+  }
+  const s = resolved;
+  const sessionId = s.sessionId ?? '';
+  const agent = s.kind;
+
+  if (s.context === 'cloud') {
+    console.error(chalk.red('Cloud sessions run remotely and cannot be detached from here.'));
+    process.exitCode = 1;
+    return;
+  }
+  if (!sessionId) {
+    console.error(chalk.red('That session has no id to resume, so it cannot be detached.'));
+    process.exitCode = 1;
+    return;
+  }
+
+  // 1) Stop the interactive process.
+  await stopInteractive(s);
+
+  // 2) Continue it headless, detached — version-pinned via the existing resume path.
+  const inv = getAgentsInvocation(buildBackgroundArgv(agent, sessionId, s.cwd));
+  const pid = await spawnHeadless(inv.command, inv.args);
+
+  // 3) Record it so `attach` and `agents ls --active` know it's backgrounded.
+  writeDetachRecord({
+    sessionId,
+    agent,
+    cwd: s.cwd,
+    headlessPid: pid,
+    headlessStartTime: captureProcessStartTime(pid),
+    detachedAtMs: Date.now(),
+  });
+
+  const short = sessionId.slice(0, 8);
+  console.log(
+    chalk.green(`◒ Backgrounded ${agent} ${short}`) +
+      chalk.gray(` — running headless (pid ${pid}). Bring it back: agents attach ${short}`),
+  );
+}

--- a/apps/cli/src/commands/detach.ts
+++ b/apps/cli/src/commands/detach.ts
@@ -10,6 +10,8 @@
  * or a `/continue` replay (others) — the same path `attach` reverses.
  */
 import { spawn } from 'node:child_process';
+import { openSync, closeSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { gatherLiveTargets } from './go.js';
@@ -19,7 +21,9 @@ import { getDefaultSocketPath } from '../lib/tmux/paths.js';
 import { getAgentsInvocation } from '../lib/daemon.js';
 import { captureProcessStartTime } from '../lib/pty-server.js';
 import { writeDetachRecord } from '../lib/session/detached.js';
-import { buildBackgroundArgv, resolveOne } from './detach-core.js';
+import { getLogsDir } from '../lib/state.js';
+import { runOnPeer } from '../lib/session/remote-list.js';
+import { buildBackgroundArgv, resolveDetachTarget, resolveOne } from './detach-core.js';
 
 export function registerDetachCommand(program: Command): void {
   program
@@ -35,38 +39,84 @@ export function registerDetachCommand(program: Command): void {
 /**
  * Stop the interactive process so it can't fight the headless resume over the
  * same transcript. tmux-hosted sessions are killed by session (closes the pane
- * and ends the agent); a plain process is SIGTERM'd by pid.
+ * and ends the agent); a plain process is SIGTERM'd by pid. Either way we then
+ * wait for the process to actually exit before returning, so the headless
+ * continuation never starts writing the transcript while the old process is
+ * still flushing it.
  */
 async function stopInteractive(s: ActiveSession): Promise<void> {
   if (s.tmuxTarget) {
     const name = s.tmuxTarget.split(':')[0];
     await killSession(name, getDefaultSocketPath());
-    return;
-  }
-  if (s.pid && s.pid > 0) {
+  } else if (s.pid && s.pid > 0) {
     try {
       process.kill(s.pid, 'SIGTERM');
     } catch {
-      /* already gone */
+      return; /* already gone — nothing to wait on */
     }
+  }
+  if (s.pid && s.pid > 0) await waitForExit(s.pid);
+}
+
+/**
+ * Poll until `pid` is gone (SIGTERM already sent), escalating to SIGKILL past the
+ * deadline so a stuck process can't wedge the detach. Bounded so `detach` never
+ * hangs waiting on a process that ignores signals.
+ */
+async function waitForExit(pid: number, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return; /* gone */
+    }
+    if (Date.now() >= deadline) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        /* raced to exit */
+      }
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 100));
   }
 }
 
-/** Spawn the headless continuation detached, resolving to its pid for tracking. */
-function spawnHeadless(command: string, args: string[]): Promise<number> {
+/**
+ * Where a backgrounded continuation's stdout/stderr lands, by convention, so a
+ * crash after detach is debuggable — there is no terminal watching it, and
+ * presence only tells you the pid is gone, not whether the run finished or died.
+ */
+function backgroundLogPath(sessionId: string): string {
+  return path.join(getLogsDir(), `detach-${sessionId.slice(0, 8)}.log`);
+}
+
+/**
+ * Spawn the headless continuation detached, resolving to its pid for tracking.
+ * Its output is redirected to `logFile` rather than discarded, so a fast-failing
+ * background run leaves a trail.
+ */
+function spawnHeadless(command: string, args: string[], logFile: string): Promise<number> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { detached: true, stdio: 'ignore', env: process.env });
+    mkdirSync(path.dirname(logFile), { recursive: true });
+    const fd = openSync(logFile, 'a');
+    const child = spawn(command, args, { detached: true, stdio: ['ignore', fd, fd], env: process.env });
     child.once('spawn', () => {
       const pid = child.pid ?? 0;
       child.unref();
+      try { closeSync(fd); } catch { /* fd handed to the child */ }
       resolve(pid);
     });
-    child.once('error', (err) => reject(err instanceof Error ? err : new Error(String(err))));
+    child.once('error', (err) => {
+      try { closeSync(fd); } catch { /* never opened for the child */ }
+      reject(err instanceof Error ? err : new Error(String(err)));
+    });
   });
 }
 
 export async function detachAction(id: string, opts: { local?: boolean } = {}): Promise<void> {
-  const { activeById } = await gatherLiveTargets(!!opts.local);
+  const { self, activeById } = await gatherLiveTargets(!!opts.local, { includeCloud: true });
   const resolved = resolveOne(activeById, id);
   if ('error' in resolved) {
     console.error(chalk.red(resolved.error));
@@ -74,28 +124,41 @@ export async function detachAction(id: string, opts: { local?: boolean } = {}): 
     return;
   }
   const s = resolved;
-  const sessionId = s.sessionId ?? '';
+  const target = resolveDetachTarget(s, self);
+
+  // Cloud, team, and id-less sessions can't be backgrounded from here.
+  if (target.kind === 'refuse') {
+    console.error(chalk.red(target.reason));
+    process.exitCode = 1;
+    return;
+  }
+
+  const short = target.sessionId.slice(0, 8);
+
+  // A session on another host: its pid and tmux socket only mean something where
+  // it runs, so detach it *there* over SSH — never kill/resume locally. Mirrors
+  // focus/jumpTo's remote branch.
+  if (target.kind === 'remote') {
+    console.log(chalk.gray(`${short} lives on ${target.machine} — detaching it there over SSH…`));
+    const rc = await runOnPeer(['detach', target.sessionId, '--local'], target.machine);
+    if (rc === 'no-target') {
+      console.error(chalk.red(`Can't reach ${target.machine} to detach ${short}.`));
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  // Local: stop the interactive process, then continue it headless, detached —
+  // version-pinned via the existing `agents run --resume` path.
+  const sessionId = target.sessionId;
   const agent = s.kind;
-
-  if (s.context === 'cloud') {
-    console.error(chalk.red('Cloud sessions run remotely and cannot be detached from here.'));
-    process.exitCode = 1;
-    return;
-  }
-  if (!sessionId) {
-    console.error(chalk.red('That session has no id to resume, so it cannot be detached.'));
-    process.exitCode = 1;
-    return;
-  }
-
-  // 1) Stop the interactive process.
   await stopInteractive(s);
 
-  // 2) Continue it headless, detached — version-pinned via the existing resume path.
+  const logFile = backgroundLogPath(sessionId);
   const inv = getAgentsInvocation(buildBackgroundArgv(agent, sessionId, s.cwd));
-  const pid = await spawnHeadless(inv.command, inv.args);
+  const pid = await spawnHeadless(inv.command, inv.args, logFile);
 
-  // 3) Record it so `attach` and `agents ls --active` know it's backgrounded.
+  // Record it so `attach` and `agents ls --active` know it's backgrounded.
   writeDetachRecord({
     sessionId,
     agent,
@@ -105,9 +168,9 @@ export async function detachAction(id: string, opts: { local?: boolean } = {}): 
     detachedAtMs: Date.now(),
   });
 
-  const short = sessionId.slice(0, 8);
   console.log(
     chalk.green(`◒ Backgrounded ${agent} ${short}`) +
       chalk.gray(` — running headless (pid ${pid}). Bring it back: agents attach ${short}`),
   );
+  console.log(chalk.gray(`  logs: ${logFile}`));
 }

--- a/apps/cli/src/commands/go.ts
+++ b/apps/cli/src/commands/go.ts
@@ -45,8 +45,16 @@ export function registerGoCommand(program: Command): void {
     });
 }
 
-/** Live jump targets (local + remote), keyed by session id. Cloud excluded (no pid). */
-export async function gatherLiveTargets(local: boolean): Promise<{ self: string; activeById: Map<string, ActiveSession> }> {
+/**
+ * Live jump targets (local + remote), keyed by session id. Cloud is excluded by
+ * default (it has no local pid to attach), but `detach` opts in with
+ * `includeCloud` so it can resolve a cloud id and refuse it with a clear message
+ * instead of a bare "no live session".
+ */
+export async function gatherLiveTargets(
+  local: boolean,
+  opts: { includeCloud?: boolean } = {},
+): Promise<{ self: string; activeById: Map<string, ActiveSession> }> {
   const self = machineId();
   const localActive = await getActiveSessions();
   for (const s of localActive) if (!s.machine) s.machine = self;
@@ -58,7 +66,11 @@ export async function gatherLiveTargets(local: boolean): Promise<{ self: string;
     } catch { /* remote sweep is best-effort */ }
   }
   const activeById = new Map<string, ActiveSession>();
-  for (const s of active) if (s.context !== 'cloud' && s.sessionId) activeById.set(s.sessionId, s);
+  for (const s of active) {
+    if (!s.sessionId) continue;
+    if (s.context === 'cloud' && !opts.includeCloud) continue;
+    activeById.set(s.sessionId, s);
+  }
   return { self, activeById };
 }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -176,6 +176,8 @@ import {
   loadAlias,
   loadMine,
   loadPty,
+  loadDetach,
+  loadAttach,
   loadTmux,
   loadWatchdog,
   loadBrowser,
@@ -968,6 +970,8 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadAlias);
   await reg(loadMine);
   await reg(loadPty);
+  await reg(loadDetach);
+  await reg(loadAttach);
   await reg(loadTmux);
   await reg(loadWatchdog);
   await reg(loadBrowser);

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -36,6 +36,7 @@ import { computeTokPerSec } from './throughput.js';
 import { inferSessionState, type SessionState, type SessionActivity, type AwaitingReason, type StructuredQuestion, type TodoProgress, type DetectedPr, type DetectedWorktree, type DetectedTicket } from './state.js';
 import type { SessionAttachment } from './types.js';
 import { detectProvenance, type SessionProvenance } from './provenance.js';
+import { presenceFromStore, type Presence } from './detached.js';
 import { mapBounded } from '../concurrency.js';
 
 const execFileAsync = promisify(execFile);
@@ -138,6 +139,16 @@ export interface ActiveSession {
    */
   lastActivityMs?: number;
   status: ActiveStatus;
+  /**
+   * Foreground/background presence for the detach/attach model:
+   *   `attached`   — live interactive TUI you're watching;
+   *   `background` — detached: running headless, unattended (via `agents detach`);
+   *   `parked`     — the headless continuation has exited; the transcript is durable.
+   * Absent for ad-hoc headless runs and cloud/team rows, which aren't on the
+   * foreground/background axis. Folded on at the end of {@link getActiveSessions}
+   * from the detach store — never asserted by a source.
+   */
+  presence?: Presence;
   /** How many live PIDs resolve to this same session (subagents/forks). 1 unless collapsed. */
   pidCount?: number;
   /**
@@ -1258,7 +1269,23 @@ export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<
 
   const merged = dedupeBySession([...tmuxAgents, ...teams, ...terminals, ...cloud, ...unattributed]);
   await enrichProvenance(merged);
+  foldPresence(merged);
   return merged;
+}
+
+/**
+ * Fold detach/attach presence onto each row from the detach store. A stored
+ * record wins (`background`/`parked`); otherwise a live terminal session is
+ * `attached`. Ad-hoc headless runs and cloud/team rows stay unmarked — they are
+ * not on the foreground/background axis.
+ */
+function foldPresence(rows: ActiveSession[]): void {
+  for (const s of rows) {
+    if (!s.sessionId) continue;
+    const stored = presenceFromStore(s.sessionId);
+    if (stored) s.presence = stored;
+    else if (s.context === 'terminal') s.presence = 'attached';
+  }
 }
 
 /**

--- a/apps/cli/src/lib/session/detached.test.ts
+++ b/apps/cli/src/lib/session/detached.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterAll, afterEach } from 'vitest';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+// Sandbox the store under a temp HOME BEFORE importing the module (state.ts
+// captures HOME at load). Dynamic import below evaluates it under the temp home.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'detach-store-'));
+const savedHome = process.env.HOME;
+process.env.HOME = TMP;
+
+const {
+  writeDetachRecord,
+  readDetachRecord,
+  clearDetachRecord,
+  listDetachRecords,
+  isHeadlessAlive,
+  presenceFromStore,
+} = await import('./detached.js');
+const { captureProcessStartTime } = await import('../pty-server.js');
+
+const children: ChildProcess[] = [];
+function longRunningChild(): ChildProcess {
+  // A real process we can check liveness against — no mocks.
+  const child = spawn('sleep', ['30'], { stdio: 'ignore' });
+  children.push(child);
+  return child;
+}
+
+afterEach(() => {
+  for (const rec of listDetachRecords()) clearDetachRecord(rec.sessionId);
+});
+afterAll(() => {
+  for (const c of children) {
+    try {
+      if (c.pid) process.kill(c.pid, 'SIGKILL');
+    } catch {
+      /* gone */
+    }
+  }
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+describe('detach store', () => {
+  it('write → read round-trips a record', () => {
+    const rec = {
+      sessionId: 'sess-aaa',
+      agent: 'claude',
+      cwd: '/tmp/work',
+      headlessPid: 424242,
+      headlessStartTime: 'fingerprint',
+      detachedAtMs: 1000,
+    };
+    writeDetachRecord(rec);
+    expect(readDetachRecord('sess-aaa')).toEqual(rec);
+  });
+
+  it('clear removes the record; read returns undefined', () => {
+    writeDetachRecord({ sessionId: 'sess-bbb', agent: 'codex', headlessPid: 1, headlessStartTime: null, detachedAtMs: 0 });
+    clearDetachRecord('sess-bbb');
+    expect(readDetachRecord('sess-bbb')).toBeUndefined();
+  });
+
+  it('list returns every written record', () => {
+    writeDetachRecord({ sessionId: 's1', agent: 'claude', headlessPid: 1, headlessStartTime: null, detachedAtMs: 0 });
+    writeDetachRecord({ sessionId: 's2', agent: 'claude', headlessPid: 2, headlessStartTime: null, detachedAtMs: 0 });
+    expect(listDetachRecords().map((r) => r.sessionId).sort()).toEqual(['s1', 's2']);
+  });
+
+  it('read on an unknown id is undefined, not a throw', () => {
+    expect(readDetachRecord('never')).toBeUndefined();
+  });
+});
+
+describe('isHeadlessAlive', () => {
+  it('is true for a live pid whose start-time still matches', () => {
+    const child = longRunningChild();
+    const rec = {
+      sessionId: 'live',
+      agent: 'claude',
+      headlessPid: child.pid!,
+      headlessStartTime: captureProcessStartTime(child.pid!),
+      detachedAtMs: Date.now(),
+    };
+    expect(isHeadlessAlive(rec)).toBe(true);
+  });
+
+  it('is false once the process has exited (awaits reap)', async () => {
+    const child = longRunningChild();
+    const pid = child.pid!;
+    const start = captureProcessStartTime(pid);
+    // Await 'exit' so the child is reaped — otherwise it lingers as a zombie
+    // and kill(pid, 0) still succeeds.
+    await new Promise<void>((resolve) => {
+      child.once('exit', () => resolve());
+      child.kill('SIGKILL');
+    });
+    expect(isHeadlessAlive({ sessionId: 'dead', agent: 'claude', headlessPid: pid, headlessStartTime: start, detachedAtMs: 0 })).toBe(false);
+  });
+
+  it('is false when the start-time fingerprint no longer matches (PID reuse)', () => {
+    const child = longRunningChild();
+    // Live pid, but a stale fingerprint — this is not the process we launched.
+    expect(
+      isHeadlessAlive({ sessionId: 'reused', agent: 'claude', headlessPid: child.pid!, headlessStartTime: 'stale-fingerprint', detachedAtMs: 0 }),
+    ).toBe(false);
+  });
+
+  it('is false for a bogus pid', () => {
+    expect(isHeadlessAlive({ sessionId: 'x', agent: 'claude', headlessPid: 0, headlessStartTime: null, detachedAtMs: 0 })).toBe(false);
+  });
+});
+
+describe('presenceFromStore', () => {
+  it('undefined when there is no record', () => {
+    expect(presenceFromStore('absent')).toBeUndefined();
+  });
+
+  it('background while the headless continuation is alive', () => {
+    const child = longRunningChild();
+    writeDetachRecord({
+      sessionId: 'bg',
+      agent: 'claude',
+      headlessPid: child.pid!,
+      headlessStartTime: captureProcessStartTime(child.pid!),
+      detachedAtMs: Date.now(),
+    });
+    expect(presenceFromStore('bg')).toBe('background');
+  });
+
+  it('parked once the headless continuation has exited', () => {
+    writeDetachRecord({ sessionId: 'pk', agent: 'claude', headlessPid: 0, headlessStartTime: null, detachedAtMs: 0 });
+    expect(presenceFromStore('pk')).toBe('parked');
+  });
+});

--- a/apps/cli/src/lib/session/detached.ts
+++ b/apps/cli/src/lib/session/detached.ts
@@ -1,0 +1,109 @@
+/**
+ * Detached-session store — the record `agents detach` writes and both
+ * `agents attach` and the active-session scan read to know an agent is
+ * "backgrounded": running headless with no terminal, continuing its task
+ * unattended.
+ *
+ * One file per detached session under `~/.agents/.system/detached/<id>.json`.
+ * Presence is DERIVED, never asserted: a record only means "this session was
+ * detached to a headless continuation"; whether it is still `background`
+ * (that continuation is alive) or `parked` (it has exited) is decided live from
+ * the recorded pid + its start-time fingerprint. That keeps the store honest
+ * even across a crash that never ran `attach`.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { getSystemAgentsDir } from '../state.js';
+import { captureProcessStartTime } from '../pty-server.js';
+
+/** A session's foreground/background presence. */
+export type Presence = 'attached' | 'background' | 'parked';
+
+export interface DetachRecord {
+  sessionId: string;
+  agent: string;
+  cwd?: string;
+  /** pid of the detached headless continuation `agents detach` spawned. */
+  headlessPid: number;
+  /**
+   * Start-time fingerprint of {@link headlessPid} at spawn, so a liveness check
+   * survives PID reuse: the pid is only "our" continuation if it still occupies
+   * the process we launched. Null when the platform capture failed.
+   */
+  headlessStartTime: string | null;
+  detachedAtMs: number;
+}
+
+function detachedDir(): string {
+  return path.join(getSystemAgentsDir(), 'detached');
+}
+
+function recordPath(sessionId: string): string {
+  return path.join(detachedDir(), `${sessionId}.json`);
+}
+
+export function writeDetachRecord(rec: DetachRecord): void {
+  fs.mkdirSync(detachedDir(), { recursive: true });
+  fs.writeFileSync(recordPath(rec.sessionId), JSON.stringify(rec, null, 2));
+}
+
+export function readDetachRecord(sessionId: string): DetachRecord | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(recordPath(sessionId), 'utf8')) as DetachRecord;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearDetachRecord(sessionId: string): void {
+  try {
+    fs.rmSync(recordPath(sessionId));
+  } catch {
+    /* already gone */
+  }
+}
+
+export function listDetachRecords(): DetachRecord[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(detachedDir());
+  } catch {
+    return [];
+  }
+  const out: DetachRecord[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const rec = readDetachRecord(name.slice(0, -'.json'.length));
+    if (rec) out.push(rec);
+  }
+  return out;
+}
+
+/** True while the recorded headless continuation is still the live process we spawned. */
+export function isHeadlessAlive(rec: DetachRecord): boolean {
+  if (!rec.headlessPid || rec.headlessPid <= 0) return false;
+  try {
+    process.kill(rec.headlessPid, 0);
+  } catch {
+    return false;
+  }
+  // Defeat PID reuse: if the pid now belongs to a different process, it is not ours.
+  if (rec.headlessStartTime !== null) {
+    const now = captureProcessStartTime(rec.headlessPid);
+    if (now !== null && now !== rec.headlessStartTime) return false;
+  }
+  return true;
+}
+
+/**
+ * Presence for a session id from the detach store alone:
+ *   - no record            -> undefined (caller decides: `attached` for a live
+ *                             interactive row, nothing for cloud/team rows)
+ *   - record + pid alive    -> `background` (headless continuation running)
+ *   - record + pid exited   -> `parked` (the run finished; transcript is durable)
+ */
+export function presenceFromStore(sessionId: string): Presence | undefined {
+  const rec = readDetachRecord(sessionId);
+  if (!rec) return undefined;
+  return isHeadlessAlive(rec) ? 'background' : 'parked';
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -82,6 +82,8 @@ export const loadBudget: ModuleLoader = async () => (await import('../../command
 export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
 export const loadMine: ModuleLoader = async () => (await import('../../commands/mine.js')).registerMineCommand;
 export const loadPty: ModuleLoader = async () => (await import('../../commands/pty.js')).registerPtyCommands;
+export const loadDetach: ModuleLoader = async () => (await import('../../commands/detach.js')).registerDetachCommand;
+export const loadAttach: ModuleLoader = async () => (await import('../../commands/attach.js')).registerAttachCommand;
 export const loadTmux: ModuleLoader = async () => (await import('../../commands/tmux.js')).registerTmuxCommands;
 export const loadWatchdog: ModuleLoader = async () => (await import('../../commands/watchdog.js')).registerWatchdogCommand;
 export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
@@ -199,6 +201,8 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   alias: [loadAlias],
   mine: [loadMine],
   pty: [loadPty],
+  detach: [loadDetach],
+  attach: [loadAttach],
   tmux: [loadTmux],
   watchdog: [loadWatchdog],
   browser: [loadBrowser],

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Detach / Attach — send a running agent to the background from the editor.**
+  Two commands: **Agents: Detach (Send to Background)** (`agents.detach`,
+  `cmd+k cmd+b` on a focused agent terminal, also in the terminal right-click menu)
+  sends the active agent's session to the background via `agents detach <id>` —
+  the interactive process stops, the tab closes, and the agent keeps working
+  headless. **Agents: Attach (Bring to Foreground)** (`agents.attach`,
+  `cmd+k cmd+a`) picks a backgrounded/parked agent and resumes it interactively in
+  a new terminal via `agents attach <id>`. The Floor session model now carries the
+  CLI's `presence` (`attached` / `background` / `parked`). Source:
+  `apps/factory/src/vscode/extension.ts`, `apps/factory/src/core/remoteSessions.ts`,
+  `apps/factory/package.json`.
+
 - **agents-dbg now has a 0.1.0 Mac release pipeline (RUSH-1015).** The standalone
   Electron app packages as `agents-dbg.app` with the `com.phnxlabs.agents-dbg`
   bundle id, hardened-runtime entitlements, Developer ID signing, and

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -519,6 +519,14 @@
         "title": "Agents: Reopen Last Session"
       },
       {
+        "command": "agents.detach",
+        "title": "Agents: Detach (Send to Background)"
+      },
+      {
+        "command": "agents.attach",
+        "title": "Agents: Attach (Bring to Foreground)"
+      },
+      {
         "command": "agents.continueInNew",
         "title": "Agents: Continue in New Session"
       },
@@ -948,6 +956,10 @@
         {
           "command": "agents.askAnotherAgent",
           "group": "agents@1"
+        },
+        {
+          "command": "agents.detach",
+          "group": "agents@2"
         }
       ],
       "commandPalette": [
@@ -1023,6 +1035,17 @@
         "command": "agents.autogit",
         "key": "ctrl+shift+g",
         "mac": "cmd+shift+g"
+      },
+      {
+        "command": "agents.detach",
+        "key": "ctrl+k ctrl+b",
+        "mac": "cmd+k cmd+b",
+        "when": "terminalFocus"
+      },
+      {
+        "command": "agents.attach",
+        "key": "ctrl+k ctrl+a",
+        "mac": "cmd+k cmd+a"
       },
       {
         "command": "agents.newAgent",

--- a/apps/factory/src/core/remoteSessions.test.ts
+++ b/apps/factory/src/core/remoteSessions.test.ts
@@ -219,6 +219,22 @@ describe('normalizeActiveSession — question + tail passthrough', () => {
   });
 });
 
+describe('normalizeActiveSession — presence passthrough (Attach picker)', () => {
+  test('carries the CLI presence value onto the RemoteSession', () => {
+    const base = ACTIVE.find((r) => r.context === 'terminal')!;
+    for (const presence of ['background', 'parked', 'attached']) {
+      const raw = { ...base, presence } as unknown as RawActiveSession;
+      const s = normalizeActiveSession(raw, 'this-mac', FETCHED_AT);
+      expect(s.presence).toBe(presence);
+    }
+  });
+  test('presence is "" when the CLI supplied none (not undefined — the extension filters on ===)', () => {
+    const base = ACTIVE.find((r) => r.context === 'terminal')!;
+    const s = normalizeActiveSession(base, 'this-mac', FETCHED_AT);
+    expect(s.presence).toBe('');
+  });
+});
+
 describe('normalizeActiveSession', () => {
   test('uses the queried host, not the payload host field', () => {
     // The terminal record carries host:"ghostty" (the emulator). Identity must

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -218,6 +218,10 @@ export interface RemoteSession {
   /** The CLI record's `context` ('terminal' | 'cloud' | 'teams' | ...). Lets the
    *  webview treat cloud rows differently from terminal-backed agents. */
   context: string;
+  /** Foreground/background presence from the CLI (`attached` | `background` |
+   *  `parked`), absent when the session isn't on that axis (cloud/team/ad-hoc
+   *  headless). Drives the detach/attach affordances. */
+  presence?: string;
   /** Cloud task id (`agents cloud message <id> <text>` is the reply channel for
    *  cloud rows). Empty for non-cloud sessions. */
   cloudTaskId: string;
@@ -288,6 +292,7 @@ export interface HostInfo {
  */
 export interface RawActiveSession {
   context?: string;
+  presence?: string;
   kind?: string;
   pid?: number;
   sessionId?: string;
@@ -597,6 +602,7 @@ export function normalizeActiveSession(
     label: asStr(raw.label),
     sessionFile: asStr(raw.sessionFile),
     context: asStr(raw.context),
+    presence: asStr(raw.presence),
     cloudTaskId: raw.cloudTaskId || '',
     cloudProvider: raw.cloudProvider || '',
     teamName: raw.teamName || '',

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -27,6 +27,7 @@ import { startWatchdogBridge } from '../mcp/watchdog-bridge';
 import { ensureWatchdogMcpInstalled } from '../mcp/watchdogInstall';
 import * as notifications from './notifications.vscode';
 import * as terminals from './terminals.vscode';
+import { fetchLocalSessions } from './remoteSessions.vscode';
 import * as sessionTracker from './sessionTracker';
 import { runRecapHeadless, isRecapSupported } from './recap.vscode';
 import { buildAgentTerminalEnv } from '../core/terminals';
@@ -270,6 +271,77 @@ export function runHeadlessAgent(
 // background/headless run reopens in a new tab and resumes; a live terminal session is
 // attached). It auto-resolves the surface (no interactive picker), so it's safe to run
 // detached from the extension host.
+// Send the active agent terminal to the background: `agents detach <id>` stops its
+// interactive process and continues it headless, then we close the tab. When the
+// active terminal isn't an agent, fall back to a picker over the live agent tabs.
+async function detachAgentToBackground(): Promise<void> {
+  const active = vscode.window.activeTerminal;
+  let sessionId: string | undefined;
+  let target: vscode.Terminal | undefined;
+  if (active && terminals.isAgentTerminal(active) && terminals.getSessionId(active)) {
+    sessionId = terminals.getSessionId(active);
+    target = active;
+  } else {
+    const candidates = vscode.window.terminals.filter(
+      (t) => terminals.isAgentTerminal(t) && terminals.getSessionId(t),
+    );
+    if (candidates.length === 0) {
+      void vscode.window.showInformationMessage('No live agent terminal to send to the background.');
+      return;
+    }
+    const pick = await vscode.window.showQuickPick(
+      candidates.map((t) => ({
+        label: `${terminals.getAgentType(t) ?? 'agent'} ${(terminals.getSessionId(t) ?? '').slice(0, 8)}`,
+        detail: t.name,
+        terminal: t,
+      })),
+      { placeHolder: 'Send which agent to the background?' },
+    );
+    if (!pick) return;
+    sessionId = terminals.getSessionId(pick.terminal);
+    target = pick.terminal;
+  }
+  if (!sessionId) {
+    void vscode.window.showWarningMessage('That agent has no resolved session id yet — try again once it has started.');
+    return;
+  }
+  const child = spawn('agents', ['detach', sessionId], {
+    detached: true,
+    stdio: 'ignore',
+    env: agentsSpawnEnv(),
+  });
+  child.unref();
+  target?.dispose();
+  void vscode.window.showInformationMessage(
+    `Sent ${sessionId.slice(0, 8)} to the background — running headless. Bring it back with “Agents: Attach”.`,
+  );
+}
+
+// Bring a backgrounded/parked agent to the foreground: pick from the CLI's
+// active-session list (presence background/parked) and open a terminal running
+// `agents attach <id>`, which resumes the session interactively in that tab.
+async function attachAgentFromBackground(): Promise<void> {
+  const { sessions } = await fetchLocalSessions();
+  const backgrounded = sessions.filter((s) => s.presence === 'background' || s.presence === 'parked');
+  if (backgrounded.length === 0) {
+    void vscode.window.showInformationMessage('No backgrounded agents to bring forward. Send one back with “Agents: Detach”.');
+    return;
+  }
+  const pick = await vscode.window.showQuickPick(
+    backgrounded.map((s) => ({
+      label: `${s.agentType || 'agent'} ${(s.sessionId || '').slice(0, 8)}`,
+      description: s.presence,
+      detail: s.topic || s.label,
+      sessionId: s.sessionId,
+    })),
+    { placeHolder: 'Bring which agent to the foreground?' },
+  );
+  if (!pick?.sessionId) return;
+  const term = vscode.window.createTerminal({ name: `attach ${pick.sessionId.slice(0, 8)}`, env: agentsSpawnEnv() });
+  term.show();
+  term.sendText(`agents attach ${pick.sessionId}`);
+}
+
 export function focusSessionInTerminal(sessionId: string): void {
   const child = spawn('agents', ['sessions', 'focus', sessionId], {
     detached: true,
@@ -1080,6 +1152,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('agents.reopenLastSession', () => reopenLastClosedSession(context))
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('agents.detach', () => detachAgentToBackground())
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('agents.attach', () => attachAgentFromBackground())
   );
 
   context.subscriptions.push(


### PR DESCRIPTION
## What

Add `agents detach <id>` / `agents attach <id>` — send a running agent session to the background and bring it back.

- **`agents detach <id>`** stops a live session's interactive process (kills the tmux session when tmux-hosted, else SIGTERM the pid) and continues it **headless**, detached, via the existing version-pinned `agents run --resume` path. The resumed run carries a nudge that tells the now-unwatched agent it is headless and to drive its task to completion rather than stall on a confirmation nobody can answer.
- **`agents attach <id>`** stops that headless continuation and **resumes the session interactively** in the current terminal (`resumeSessionInPlace`) — same session, full history, including whatever the background run did.
- Both are **agent-agnostic** — they route through the same resume machinery (native resume for Claude/Codex, `/continue` replay for the rest), so there is no per-agent branching.
- `agents sessions --active --json` now carries a **`presence`** field (`attached` / `background` / `parked`), folded onto every row from a per-session detach record. Presence is derived, never asserted: a record only means "this session was detached"; `background` vs `parked` is decided live from the recorded pid + its start-time fingerprint (which defeats PID reuse).

## Why

A user can run 30–40 agents at once; every interactive one holds a terminal tab and interactive resources even when nobody is watching it. `detach` frees the terminal and keeps the agent working headless; `attach` brings it back when you want to take over.

## Proven before building

The mechanism rests on faithfully continuing a session via `--resume`, pinned to the same agent version. Verified live (Claude 2.1.207): created a session, resumed it headless, and it recalled a codeword set in the original session; a fact added *during* a headless resume was recalled in the next one — state accretes across cycles. The wrapper resolved `~/.agents/.cache/shims/claude@2.1.207 --resume <uuid>` (`version 2.1.207 is pinned`, native resume). Attach is the same invocation minus the headless prompt.

## Tests

`apps/cli/src/lib/session/detached.test.ts` and `apps/cli/src/commands/detach.test.ts` — real-path, no mocks: the store round-trips under a temp HOME; `isHeadlessAlive` tracks a real child process and rejects a stale PID-reuse fingerprint; `presenceFromStore` maps a record to `background`/`parked`; `buildBackgroundArgv` + `resolveOne` cover argv shape and id matching. 18 tests pass; `tsc --noEmit` clean.

## Scope

CLI only. The Factory extension surface (a `Detach`/`Attach` command + keybinding + Floor presence chip that call these verbs) follows in a separate PR.

## Caveats (documented)

- Native full-fidelity resume is Claude/Codex; tier-2 agents fall back to a `/continue` replay that can lose context.
- Resume restores the session's origin cwd (Claude native resume resolves transcripts by cwd project-hash) — preserved by the detach record's `cwd`.

Session transcript (public repo — not attached): `yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.186/home/.claude/projects/-home-muqsit/43bf7ca1-1632-4bf4-88df-7c019fea97de.jsonl`
