### PR TITLE
perf(session): dir_ledger short-circuit to skip walk/stat of unchanged dirs

### DIFF
--- a/apps/cli/.changelog/next/dir-ledger-scan-shortcircuit.md
+++ b/apps/cli/.changelog/next/dir-ledger-scan-shortcircuit.md
@@ -1,0 +1,17 @@
+- **Faster `agents sessions` on large / unchanged session trees.** Session
+  discovery re-walked and re-`stat`'d every transcript directory on every
+  `agents sessions` / `output` / `view` / `teams` call — for a heavy user the
+  immutable version-home and backup roots dominated the cost yet never changed. A
+  new `dir_ledger` (SQLite, schema v14) caches each leaf transcript directory's
+  `(mtime, entry_count)`; when both match, the per-file `stat` of that directory
+  is skipped and its unchanged files are served straight from the DB, so those
+  immutable roots cost one dir stat each instead of hundreds of per-file stats.
+  Append safety is preserved: a file under the agent's live `~/.<agent>` root, or
+  scanned within the last 10 minutes, is always re-`stat`'d (a parent-dir mtime
+  bumps on create/delete/rename but NOT on an in-place append), so a growing live
+  session is never missed; a create / delete / rename bumps the dir mtime and
+  forces a full re-walk of that dir exactly as before. Wired into the Claude and
+  Gemini scanners (the biggest win); the other scanners keep the existing
+  per-file path. Set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to disable the
+  short-circuit and force the old full per-file walk. Source:
+  `apps/cli/src/lib/session/db.ts`, `apps/cli/src/lib/session/discover.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -34,10 +34,14 @@ agents sessions [query] [--json] [--since 1h] [--all]
 │  1. Open ~/.agents/.history/sessions/sessions.db (cached connection)       │
 │                                                                     │
 │  2. Parallel incremental scan per agent:                            │
-│     For each on-disk session file:                                  │
-│       stat() -> (mtime, size)                                       │
-│       If unchanged since last scan -> skip (DB row is fresh)        │
-│       Else -> parse file, upsert sessions row + FTS5 content row    │
+│     For each leaf transcript dir:                                   │
+│       stat() the dir -> (mtime, entry_count)                        │
+│       If it matches the dir_ledger -> no create/delete/rename;      │
+│         skip the per-file stat, serve unchanged files from the DB   │
+│         (only "hot" files are re-stat'd — see below)                │
+│       Else -> readdir + stat each file:                             │
+│         If unchanged since last scan -> skip (DB row is fresh)      │
+│         Else -> parse file, upsert sessions row + FTS5 content row  │
 │                                                                     │
 │  3. SQL query with filters (agent, cwd, since, project, limit)      │
 │     FTS5 search if [query] given, BM25 ranked                       │
@@ -46,8 +50,16 @@ agents sessions [query] [--json] [--since 1h] [--all]
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-Cold run re-parses everything. Warm run is mostly DB-only with a stat() per file;
-active sessions get refreshed each call because their mtime keeps advancing.
+Cold run re-parses everything. Warm run is mostly DB-only; a directory whose
+`(mtime, entry_count)` matches the `dir_ledger` is served entirely from the DB
+without stat'ing its files, so the immutable version-home and backup roots — which
+dominate a heavy user's tree — cost one dir stat each instead of hundreds of
+per-file stats. Active sessions still refresh: a file is "hot" (always re-stat'd,
+even in an unchanged dir) when it lives under the agent's live `~/.<agent>` root or
+was scanned within the last 10 minutes, so an in-place append is never missed. A
+create / delete / rename bumps the dir mtime and forces a full re-walk of that dir.
+Set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to disable the short-circuit and force the old
+full per-file walk.
 
 ## SessionMeta (list output)
 

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -60,9 +60,11 @@ confusion in this codebase.
 
 The **transcript** side is a SQLite index (`~/.agents/.history/sessions/sessions.db`,
 `SCHEMA_VERSION` in [`src/lib/session/db.ts`](../src/lib/session/db.ts)) with a
-`scan_ledger` that re-reads a file only when its `mtime`/`size` changed, plus a
-`session_text` FTS5 table for search. Listing is a DB read; only opening one session
-fully re-parses its transcript. Detail in [05-sessions.md](05-sessions.md).
+`scan_ledger` that re-reads a file only when its `mtime`/`size` changed, a
+`dir_ledger` that skips the per-file `stat` of a leaf transcript directory whose
+`(mtime, entry_count)` is unchanged, plus a `session_text` FTS5 table for search.
+Listing is a DB read; only opening one session fully re-parses its transcript.
+Detail in [05-sessions.md](05-sessions.md).
 
 The **live identity** side is the rest of this document.
 

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -141,7 +141,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('13');
+    expect(row.value).toBe('14');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {

--- a/apps/cli/src/lib/session/db.migrate-v14.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v14.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate a fresh HOME BEFORE importing state/db so the sessions DB path they
+// capture at import time points at our temp dir. Real sqlite, no mocking.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-migv14-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+// Build a v13-shaped DB on disk (sessions + scan_ledger populated, no
+// dir_ledger), then let db.js's getDB() upgrade it to v14 on first open. Locks
+// the load-bearing invariants: dir_ledger is created, scan_ledger is cleared so
+// the first post-upgrade scan does a clean full walk, and existing session rows
+// survive the migration.
+const { getSessionsDir, getSessionsDbPath } = await import('../state.js');
+fs.mkdirSync(getSessionsDir(), { recursive: true });
+
+const Database = (await import('../sqlite.js')).default;
+{
+  const seed = new Database(getSessionsDbPath());
+  seed.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      short_id TEXT NOT NULL,
+      agent TEXT NOT NULL,
+      origin TEXT DEFAULT 'cli',
+      routine_name TEXT,
+      routine_run_id TEXT,
+      version TEXT,
+      account TEXT,
+      timestamp TEXT NOT NULL,
+      last_activity TEXT,
+      project TEXT,
+      cwd TEXT,
+      git_branch TEXT,
+      topic TEXT,
+      label TEXT,
+      message_count INTEGER,
+      token_count INTEGER,
+      output_tokens INTEGER,
+      cost_usd REAL,
+      duration_ms INTEGER,
+      file_path TEXT NOT NULL,
+      file_mtime_ms INTEGER,
+      file_size INTEGER,
+      scanned_at INTEGER,
+      is_team_origin INTEGER DEFAULT 0,
+      pr_url TEXT,
+      pr_number INTEGER,
+      worktree_slug TEXT,
+      ticket_id TEXT,
+      plan TEXT
+    );
+    CREATE VIRTUAL TABLE session_text USING fts5(
+      session_id UNINDEXED, label, topic, project, content,
+      tokenize = 'unicode61 remove_diacritics 2'
+    );
+    CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+    CREATE TABLE scan_ledger (
+      file_path TEXT PRIMARY KEY, file_mtime_ms INTEGER NOT NULL,
+      file_size INTEGER NOT NULL, scanned_at INTEGER NOT NULL
+    );
+    INSERT INTO meta(key, value) VALUES ('schema_version', '13');
+  `);
+  seed.prepare(`INSERT INTO sessions (id, short_id, agent, timestamp, file_path)
+                VALUES ('v14-1', 'v14-1', 'claude', '2026-07-01T00:00:00Z', '/tmp/x.jsonl')`).run();
+  seed.prepare(`INSERT INTO session_text (session_id, label, topic, project, content)
+                VALUES ('v14-1', '', '', '', 'hello world')`).run();
+  seed.prepare(`INSERT INTO scan_ledger (file_path, file_mtime_ms, file_size, scanned_at)
+                VALUES ('/tmp/x.jsonl', 111, 222, 333)`).run();
+  seed.close();
+}
+
+const { getDB, getSessionById } = await import('./db.js');
+
+describe('schema migration v13 -> v14 (dir_ledger)', () => {
+  it('creates the dir_ledger table with the expected columns', () => {
+    const db = getDB();
+    const cols = (db.prepare(`PRAGMA table_info(dir_ledger)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toEqual(['dir_path', 'dir_mtime_ms', 'entry_count', 'scanned_at']);
+  });
+
+  it('clears scan_ledger so the first post-upgrade scan does a clean full walk', () => {
+    const db = getDB();
+    const n = (db.prepare(`SELECT COUNT(*) AS c FROM scan_ledger`).get() as { c: number }).c;
+    expect(n).toBe(0);
+  });
+
+  it('bumps the recorded schema version to 14', () => {
+    const db = getDB();
+    const v = (db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string }).value;
+    expect(v).toBe('14');
+  });
+
+  it('preserves existing session rows through the migration', () => {
+    expect(getSessionById('v14-1')?.agent).toBe('claude');
+  });
+});

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -17,7 +17,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 13;
+const SCHEMA_VERSION = 14;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -104,6 +104,20 @@ CREATE TABLE IF NOT EXISTS scan_ledger (
   file_path TEXT PRIMARY KEY,
   file_mtime_ms INTEGER NOT NULL,
   file_size INTEGER NOT NULL,
+  scanned_at INTEGER NOT NULL
+);
+
+-- Tracks the mtime + entry-count of every LEAF directory that directly holds
+-- transcripts (a Claude project dir, a Gemini chats dir). A dir's mtime bumps
+-- on create/delete/rename of its entries but NOT on an in-place append, so a
+-- match here means the dir gained/lost/renamed no files: we can skip the
+-- readdir + per-file stat and serve unchanged files from the DB (append-safety
+-- is preserved by re-stat'ing only the "hot set" — see discover.ts). Keyed by
+-- canonicalLedgerKey, same as scan_ledger.
+CREATE TABLE IF NOT EXISTS dir_ledger (
+  dir_path TEXT PRIMARY KEY,
+  dir_mtime_ms INTEGER NOT NULL,
+  entry_count INTEGER NOT NULL,
   scanned_at INTEGER NOT NULL
 );
 `;
@@ -319,6 +333,24 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     if (!cols.some(c => c.name === 'routine_run_id')) db.exec(`ALTER TABLE sessions ADD COLUMN routine_run_id TEXT`);
     db.exec(`UPDATE sessions SET origin = 'cli' WHERE origin IS NULL OR origin = ''`);
     db.exec(`DELETE FROM scan_ledger;`);
+  }
+
+  if (fromVersion < 14) {
+    // v13 → v14: the discovery scan now short-circuits the readdir + per-file
+    // stat of leaf transcript dirs whose (mtime, entry_count) is unchanged,
+    // caching that snapshot in the new `dir_ledger` table. Create it, and clear
+    // scan_ledger so the first post-upgrade scan does a clean full walk — that
+    // walk seeds BOTH ledgers correctly, so a cold/empty dir_ledger degrades to
+    // today's full behavior.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS dir_ledger (
+        dir_path TEXT PRIMARY KEY,
+        dir_mtime_ms INTEGER NOT NULL,
+        entry_count INTEGER NOT NULL,
+        scanned_at INTEGER NOT NULL
+      );
+      DELETE FROM scan_ledger;
+    `);
   }
 }
 
@@ -544,6 +576,82 @@ export function recordScans(entries: Array<{ filePath: string; scan: ScanStamp }
   const txn = db.transaction((items: typeof entries) => {
     for (const { filePath, scan } of items) {
       stmt.run(canonicalLedgerKey(filePath), scan.fileMtimeMs, scan.fileSize, now);
+    }
+  });
+  txn(entries);
+}
+
+/** Snapshot of a leaf transcript directory used to detect create/delete/rename. */
+export interface DirStamp {
+  dirMtimeMs: number;
+  entryCount: number;
+}
+
+/**
+ * Bulk-load the dir ledger for a set of leaf directories in a single SQL query.
+ * Mirrors {@link getScanStampsForPaths}: keys by canonical path (so a dir
+ * reachable via a symlinked version home and its realpath collapse to one row)
+ * and fans the result back out to every original alias so callers can
+ * `.get(dirPath)` with the path they passed in.
+ */
+export function getDirLedgerForPaths(dirs: string[]): Map<string, DirStamp> {
+  const result = new Map<string, DirStamp>();
+  if (dirs.length === 0) return result;
+  const db = getDB();
+
+  const canonicalToOriginals = new Map<string, string[]>();
+  for (const d of dirs) {
+    const canonical = canonicalLedgerKey(d);
+    const aliases = canonicalToOriginals.get(canonical);
+    if (aliases) aliases.push(d);
+    else canonicalToOriginals.set(canonical, [d]);
+  }
+
+  const canonicalKeys = [...canonicalToOriginals.keys()];
+  const CHUNK = 500;
+  for (let i = 0; i < canonicalKeys.length; i += CHUNK) {
+    const chunk = canonicalKeys.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = db
+      .prepare(`
+        SELECT dir_path, dir_mtime_ms, entry_count
+        FROM dir_ledger
+        WHERE dir_path IN (${placeholders})
+      `)
+      .all(...chunk) as Array<{ dir_path: string; dir_mtime_ms: number; entry_count: number }>;
+
+    for (const row of rows) {
+      const stamp: DirStamp = { dirMtimeMs: row.dir_mtime_ms, entryCount: row.entry_count };
+      for (const original of canonicalToOriginals.get(row.dir_path) || []) {
+        result.set(original, stamp);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Upsert dir-scan stamps. Recorded after a full readdir of a leaf transcript
+ * dir so the next scan can skip that dir when its (mtime, entry_count) is
+ * unchanged. Mirrors {@link recordScans}.
+ */
+export function recordDirScans(
+  entries: Array<{ dirPath: string; dirMtimeMs: number; entryCount: number }>,
+): void {
+  if (entries.length === 0) return;
+  const db = getDB();
+  const stmt = db.prepare(`
+    INSERT INTO dir_ledger (dir_path, dir_mtime_ms, entry_count, scanned_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(dir_path) DO UPDATE SET
+      dir_mtime_ms = excluded.dir_mtime_ms,
+      entry_count = excluded.entry_count,
+      scanned_at = excluded.scanned_at
+  `);
+  const now = Date.now();
+  const txn = db.transaction((items: typeof entries) => {
+    for (const { dirPath, dirMtimeMs, entryCount } of items) {
+      stmt.run(canonicalLedgerKey(dirPath), dirMtimeMs, entryCount, now);
     }
   });
   txn(entries);

--- a/apps/cli/src/lib/session/discover.dir-ledger.test.ts
+++ b/apps/cli/src/lib/session/discover.dir-ledger.test.ts
@@ -1,0 +1,266 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// ESM module namespaces are non-configurable, so `vi.spyOn(fs, 'statSync')`
+// throws "Cannot redefine property". The repo's established way to instrument
+// fs (see src/commands/__tests__/sessions-tail.test.ts) is to replace the whole
+// module with a wrapper that delegates to `node:fs` and hooks one method — here
+// `statSync`, so we can count the per-file stats the dir_ledger short-circuit is
+// supposed to elide. The counting state is a top-level const captured by the
+// factory closure (Bun's runner does not hoist vi.mock; a plain const works in
+// both runners without vi.hoisted).
+const statCounter: { watchPath: string | null; count: number } = { watchPath: null, count: 0 };
+
+vi.mock('fs', () => {
+  const actual = require('node:fs') as typeof import('fs');
+  return {
+    ...actual,
+    default: actual,
+    statSync: ((p: fs.PathLike, ...rest: any[]) => {
+      if (statCounter.watchPath !== null && typeof p === 'string' && p === statCounter.watchPath) {
+        statCounter.count++;
+      }
+      return (actual.statSync as any)(p, ...rest);
+    }) as typeof actual.statSync,
+  };
+});
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// db.ts + state.ts resolve their paths from HOME at module-import time. Point
+// HOME at a throwaway dir BEFORE importing so the whole suite runs against a
+// clean, isolated sqlite DB and session tree (real fs via node:fs, real sqlite,
+// all under a temp HOME).
+const REAL_HOME = process.env.HOME;
+const REAL_USERPROFILE = process.env.USERPROFILE;
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-dirledger-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+type Discover = typeof import('./discover.js');
+type DB = typeof import('./db.js');
+
+let discover: Discover;
+let db: DB;
+
+// The live Claude root (the only tree Claude appends to in place) and an
+// immutable "backup-style" root under ~/.agents/.history/backups/claude/<ts>.
+const LIVE_PROJECTS = path.join(tmpHome, '.claude', 'projects');
+const BACKUP_PROJECTS = path.join(tmpHome, '.agents', '.history', 'backups', 'claude', '2026-01-01', 'projects');
+
+function claudeLine(ts: string, cwd: string, text: string): string {
+  return JSON.stringify({ type: 'user', timestamp: ts, cwd, message: { content: text } });
+}
+
+/** Write a Claude .jsonl transcript with one user turn. */
+function writeSession(dir: string, id: string, ts: string, cwd: string, text: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const fp = path.join(dir, `${id}.jsonl`);
+  fs.writeFileSync(fp, claudeLine(ts, cwd, text) + '\n', 'utf-8');
+  return fp;
+}
+
+async function discoverIds(): Promise<Set<string>> {
+  const sessions = await discover.discoverSessions({ agent: 'claude', all: true });
+  return new Set(sessions.map(s => s.id));
+}
+
+/** All Claude sessions (cwd-unfiltered) as SessionMeta. */
+async function discoverAll() {
+  return discover.discoverSessions({ agent: 'claude', all: true });
+}
+
+/** Bump a file's mtime a whole second into the future (deterministic ordering). */
+function bumpMtime(fp: string, seconds: number): void {
+  fs.utimesSync(fp, seconds, seconds);
+}
+
+beforeAll(async () => {
+  db = await import('./db.js');
+  discover = await import('./discover.js');
+  db.getDB(); // create schema
+});
+
+afterEach(() => {
+  statCounter.watchPath = null;
+  statCounter.count = 0;
+});
+
+afterAll(() => {
+  if (REAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = REAL_HOME;
+  if (REAL_USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = REAL_USERPROFILE;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('dir_ledger short-circuit (A-2)', () => {
+  it('T2: an unchanged backup dir does ZERO per-file stats on the second run', async () => {
+    // Two sessions in the live root, one in an immutable backup dir.
+    writeSession(path.join(LIVE_PROJECTS, '-proj-a'), 'live-1', '2026-07-01T00:00:00Z', '/proj/a', 'live one');
+    writeSession(path.join(LIVE_PROJECTS, '-proj-b'), 'live-2', '2026-07-01T00:01:00Z', '/proj/b', 'live two');
+    const backupFile = writeSession(path.join(BACKUP_PROJECTS, '-proj-c'), 'bkup-1', '2026-06-01T00:00:00Z', '/proj/c', 'backup one');
+
+    const run1 = await discoverIds();
+    expect(run1.has('live-1')).toBe(true);
+    expect(run1.has('live-2')).toBe(true);
+    expect(run1.has('bkup-1')).toBe(true);
+
+    // Age the backup file's ledger stamp past the 10-minute hot window so it is
+    // cold — a real immutable backup was last scanned long ago, not seconds
+    // earlier. (A file scanned within HOT_FILE_WINDOW_MS is deliberately re-stat'd
+    // even in an unchanged dir; T9 covers that path.) Only the backup file is
+    // aged; the live-root files stay hot regardless.
+    db.getDB().prepare('UPDATE scan_ledger SET scanned_at = ? WHERE file_path = ?')
+      .run(Date.now() - 20 * 60_000, fs.realpathSync(backupFile));
+
+    // Count per-file stats of the backup file on the second run.
+    statCounter.watchPath = backupFile;
+    statCounter.count = 0;
+
+    const run2 = await discoverIds();
+
+    // (a) the SAME session set surfaces both runs
+    expect(run2).toEqual(run1);
+    // (b) the unchanged backup dir's file is NEVER stat'd on the 2nd run — the
+    //     dir_ledger match collapses it to a single dir stat, zero per-file stats.
+    expect(statCounter.count).toBe(0);
+  });
+
+  it('T3: an in-place append under the live root is still caught (dir mtime unchanged)', async () => {
+    const dir = path.join(LIVE_PROJECTS, '-append');
+    const fp = writeSession(dir, 'append-1', '2026-07-02T00:00:00Z', '/proj/app', 'first turn');
+
+    const before = (await discoverAll()).find(s => s.id === 'append-1');
+    expect(before).toBeDefined();
+    const countBefore = before!.messageCount;
+
+    // Append a second user turn WITHOUT touching the parent dir (an in-place
+    // append does not bump the dir's mtime). Advance the FILE mtime forward.
+    fs.appendFileSync(fp, claudeLine('2026-07-02T00:05:00Z', '/proj/app', 'second turn') + '\n', 'utf-8');
+    bumpMtime(fp, Math.floor(Date.now() / 1000) + 10);
+
+    // Advance the clock past the 5s active-append debounce so the grown file is
+    // parsed, not deferred.
+    db.getDB().prepare('UPDATE scan_ledger SET scanned_at = 0').run();
+
+    const after = (await discoverAll()).find(s => s.id === 'append-1');
+    expect(after).toBeDefined();
+    // The append was caught: message_count grew from 1 to 2.
+    expect((after!.messageCount ?? 0)).toBeGreaterThan(countBefore ?? 0);
+  });
+
+  it('T4: the append debounce is preserved (grown live file NOT re-parsed within 5s)', async () => {
+    const dir = path.join(LIVE_PROJECTS, '-debounce');
+    const fp = writeSession(dir, 'debounce-1', '2026-07-03T00:00:00Z', '/proj/deb', 'only turn');
+
+    const before = (await discoverAll()).find(s => s.id === 'debounce-1');
+    const countBefore = before!.messageCount;
+
+    // Append + bump the file mtime, but LEAVE scanned_at = now (fresh) so the
+    // append lands inside the debounce window.
+    fs.appendFileSync(fp, claudeLine('2026-07-03T00:01:00Z', '/proj/deb', 'sneaky turn') + '\n', 'utf-8');
+    bumpMtime(fp, Math.floor(Date.now() / 1000) + 1);
+    db.getDB().prepare('UPDATE scan_ledger SET scanned_at = ?').run(Date.now());
+
+    const after = (await discoverAll()).find(s => s.id === 'debounce-1');
+    // Within the debounce, the cached row is served — message_count unchanged.
+    expect(after!.messageCount).toBe(countBefore);
+  });
+
+  it('T5: a NEW file dropped into a previously-unchanged dir surfaces (dir mtime+count bump)', async () => {
+    const dir = path.join(LIVE_PROJECTS, '-newfile');
+    writeSession(dir, 'new-a', '2026-07-04T00:00:00Z', '/proj/new', 'existing');
+    let ids = await discoverIds();
+    expect(ids.has('new-a')).toBe(true);
+    expect(ids.has('new-b')).toBe(false);
+
+    // Dropping a new file bumps the dir mtime + entry_count → dir treated as
+    // changed → full re-walk → the new session surfaces.
+    writeSession(dir, 'new-b', '2026-07-04T00:02:00Z', '/proj/new', 'brand new');
+    ids = await discoverIds();
+    expect(ids.has('new-b')).toBe(true);
+  });
+
+  it('T6: deleting a file drops the session (no crash)', async () => {
+    const dir = path.join(LIVE_PROJECTS, '-delete');
+    const fp = writeSession(dir, 'del-a', '2026-07-05T00:00:00Z', '/proj/del', 'to be deleted');
+    let ids = await discoverIds();
+    expect(ids.has('del-a')).toBe(true);
+
+    fs.rmSync(fp);
+    ids = await discoverIds();
+    expect(ids.has('del-a')).toBe(false);
+  });
+
+  it('T7: renaming a file within a dir drops the old id and surfaces the new one', async () => {
+    const dir = path.join(LIVE_PROJECTS, '-rename');
+    const oldFp = writeSession(dir, 'ren-old', '2026-07-06T00:00:00Z', '/proj/ren', 'renamed');
+    let ids = await discoverIds();
+    expect(ids.has('ren-old')).toBe(true);
+
+    // Rename the transcript file. The session id comes from the filename, so a
+    // rename = old id drops, new id surfaces.
+    fs.renameSync(oldFp, path.join(dir, 'ren-new.jsonl'));
+    ids = await discoverIds();
+    expect(ids.has('ren-old')).toBe(false);
+    expect(ids.has('ren-new')).toBe(true);
+  });
+
+  it('T8: a cold/wiped ledger yields the identical session set', async () => {
+    const before = await discoverIds();
+    expect(before.size).toBeGreaterThan(0);
+
+    db.getDB().prepare('DELETE FROM dir_ledger').run();
+    db.getDB().prepare('DELETE FROM scan_ledger').run();
+
+    const after = await discoverIds();
+    expect(after).toEqual(before);
+  });
+
+  it('T9: a hot-window file OUTSIDE the live root, appended with dir mtime unchanged, is still re-stat\'d + updated', async () => {
+    // Seed a session in the immutable backup root and scan it.
+    const dir = path.join(BACKUP_PROJECTS, '-hot');
+    const fp = writeSession(dir, 'hot-1', '2026-06-02T00:00:00Z', '/proj/hot', 'first');
+    const before = (await discoverAll()).find(s => s.id === 'hot-1');
+    expect(before).toBeDefined();
+    const countBefore = before!.messageCount;
+
+    // Append in place (dir mtime unchanged), bump the file mtime. Force the
+    // ledger's scanned_at RECENT so the file is inside HOT_FILE_WINDOW_MS (it is
+    // not a live-root file, so only the hot window keeps it eligible), but past
+    // the 5s append debounce.
+    fs.appendFileSync(fp, claudeLine('2026-06-02T00:05:00Z', '/proj/hot', 'grown') + '\n', 'utf-8');
+    bumpMtime(fp, Math.floor(Date.now() / 1000) + 20);
+    // scanned_at within the 10min hot window but older than the 5s debounce.
+    db.getDB().prepare('UPDATE scan_ledger SET scanned_at = ?').run(Date.now() - 60_000);
+
+    const after = (await discoverAll()).find(s => s.id === 'hot-1');
+    expect((after!.messageCount ?? 0)).toBeGreaterThan(countBefore ?? 0);
+  });
+
+  it('kill-switch: AGENTS_SESSIONS_NO_DIR_LEDGER=1 forces the full walk (dir_ledger not consulted), identical results', async () => {
+    // Fresh isolated backup file so we can watch its per-file stats.
+    const dir = path.join(BACKUP_PROJECTS, '-killswitch');
+    const backupFile = writeSession(dir, 'ks-1', '2026-06-03T00:00:00Z', '/proj/ks', 'kill switch');
+
+    // Warm both ledgers.
+    const warm = await discoverIds();
+    expect(warm.has('ks-1')).toBe(true);
+
+    const prevEnv = process.env.AGENTS_SESSIONS_NO_DIR_LEDGER;
+    process.env.AGENTS_SESSIONS_NO_DIR_LEDGER = '1';
+    statCounter.watchPath = backupFile;
+    statCounter.count = 0;
+
+    const withKill = await discoverIds();
+
+    if (prevEnv === undefined) delete process.env.AGENTS_SESSIONS_NO_DIR_LEDGER;
+    else process.env.AGENTS_SESSIONS_NO_DIR_LEDGER = prevEnv;
+
+    // Full-walk path ran: the backup file WAS stat'd even though its dir was
+    // unchanged (the dir_ledger short-circuit was skipped)...
+    expect(statCounter.count).toBeGreaterThan(0);
+    // ...and the results are identical to the short-circuited run.
+    expect(withKill).toEqual(warm);
+  });
+});

--- a/apps/cli/src/lib/session/discover.dir-ledger.test.ts
+++ b/apps/cli/src/lib/session/discover.dir-ledger.test.ts
@@ -263,4 +263,57 @@ describe('dir_ledger short-circuit (A-2)', () => {
     // ...and the results are identical to the short-circuited run.
     expect(withKill).toEqual(warm);
   });
+
+  it('cross-root precedence: a NEW backup snapshot of a COLD live session never flips file_path off the live copy', async () => {
+    // The live copy of a session is indexed and then goes cold (unchanged).
+    const liveDir = path.join(LIVE_PROJECTS, '-xroot');
+    const liveFp = writeSession(liveDir, 'xroot-1', '2026-07-08T00:00:00Z', '/proj/xr', 'the live session');
+
+    let sessions = await discoverAll();
+    let row = sessions.find(s => s.id === 'xroot-1');
+    expect(row).toBeDefined();
+    expect(row!.filePath).toBe(liveFp);
+
+    // A backup snapshot of that same session id is written to a fresh backup dir
+    // (new leaf dir -> full walk -> the backup copy is "changed" this run). The
+    // live copy is COLD: its content is untouched, so it is NOT in the changed
+    // set. Pre-fix, the backup copy would win the dedup and overwrite the row's
+    // file_path with the frozen backup path.
+    const backupDir = path.join(BACKUP_PROJECTS, '-xroot');
+    const backupFp = writeSession(backupDir, 'xroot-1', '2026-07-08T00:00:00Z', '/proj/xr', 'the live session');
+    expect(backupFp).not.toBe(liveFp);
+
+    sessions = await discoverAll();
+    row = sessions.find(s => s.id === 'xroot-1');
+    // (a) still surfaces, (b) file_path is the LIVE path (never the backup),
+    // (c) not dropped.
+    expect(row).toBeDefined();
+    expect(row!.filePath).toBe(liveFp);
+    expect(fs.existsSync(row!.filePath)).toBe(true);
+  });
+
+  it('cross-root precedence: when BOTH the live and backup copies change, the live path still wins', async () => {
+    const liveDir = path.join(LIVE_PROJECTS, '-xroot2');
+    const backupDir = path.join(BACKUP_PROJECTS, '-xroot2');
+    const liveFp = writeSession(liveDir, 'xroot-2', '2026-07-09T00:00:00Z', '/proj/xr2', 'live v1');
+    const backupFp = writeSession(backupDir, 'xroot-2', '2026-07-09T00:00:00Z', '/proj/xr2', 'backup v1');
+
+    let sessions = await discoverAll();
+    expect(sessions.find(s => s.id === 'xroot-2')?.filePath).toBe(liveFp);
+
+    // Both copies grow (dir mtime + count unchanged, but the files change) and
+    // both fall outside the append debounce.
+    fs.appendFileSync(liveFp, claudeLine('2026-07-09T00:05:00Z', '/proj/xr2', 'live v2') + '\n', 'utf-8');
+    fs.appendFileSync(backupFp, claudeLine('2026-07-09T00:05:00Z', '/proj/xr2', 'backup v2') + '\n', 'utf-8');
+    const future = Math.floor(Date.now() / 1000) + 30;
+    bumpMtime(liveFp, future);
+    bumpMtime(backupFp, future);
+    db.getDB().prepare('UPDATE scan_ledger SET scanned_at = 0').run();
+
+    sessions = await discoverAll();
+    const row = sessions.find(s => s.id === 'xroot-2');
+    // Even with both copies in the changed set, the live path wins (winner is the
+    // first occurrence in live-first order).
+    expect(row?.filePath).toBe(liveFp);
+  });
 });

--- a/apps/cli/src/lib/session/discover.test.ts
+++ b/apps/cli/src/lib/session/discover.test.ts
@@ -95,13 +95,13 @@ describe('scanAgentsBounded (mitigation 3 — no simultaneous multi-dotfile burs
 });
 
 describe('getSessionRoots (the `agents sessions --roots --json` payload, issue #741)', () => {
-  const KNOWN_AGENTS = new Set(['claude', 'codex', 'gemini', 'antigravity', 'droid', 'kimi']);
+  const KNOWN_AGENTS = new Set(['claude', 'codex', 'gemini', 'antigravity', 'droid', 'kimi', 'grok']);
   // The subdir each agent's roots must end with — the discovery contract external
   // watchers depend on. A drift here (e.g. gemini → 'sessions' instead of 'tmp')
   // would silently point the extension's fs.watch at the wrong directory.
   const EXPECTED_SUBDIR: Record<string, string> = {
     claude: 'projects', codex: 'sessions', gemini: 'tmp',
-    antigravity: 'conversations', droid: 'sessions', kimi: 'sessions',
+    antigravity: 'conversations', droid: 'sessions', kimi: 'sessions', grok: 'sessions',
   };
 
   it('never throws and returns a well-formed SessionRoots[]', () => {

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -35,6 +35,8 @@ import {
   getDB,
   getScanStampByPath,
   getScanStampsForPaths,
+  getDirLedgerForPaths,
+  recordDirScans,
   recordScans,
   syncLabels,
   seedLabelsFromNames,
@@ -46,6 +48,7 @@ import {
   tryClaimScan,
   releaseScan,
   type ScanStamp,
+  type DirStamp,
   type QueryOptions,
 } from './db.js';
 import { buildRunNameMap } from './run-names.js';
@@ -64,6 +67,28 @@ const HERMES_SESSIONS_DIR = path.join(HOME, '.hermes', 'sessions');
 /** How long OpenClaw channel/cron snapshots stay valid before we re-shell-out. */
 const OPENCLAW_TTL_MS = 60_000;
 const ACTIVE_APPEND_RESCAN_DEBOUNCE_MS = 5_000;
+
+/**
+ * How recently a file must have been scanned to be treated as "hot" — a
+ * candidate for an in-place append even when its parent dir's mtime hasn't
+ * moved. A dir-ledger match lets us skip the per-file stat of everything in a
+ * leaf dir EXCEPT its hot set; a file is hot if it lives under the agent's live
+ * `~/.<agent>` root (the only tree an agent appends to live) or was scanned
+ * within this window. 10 minutes comfortably covers a session that paused
+ * between `agents sessions` calls but is still being written to.
+ */
+const HOT_FILE_WINDOW_MS = 600_000;
+
+/**
+ * Kill-switch: set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to force the old full-walk
+ * path (readdir + per-file stat every dir, every run — the pre-A-2 behavior),
+ * skipping the dir_ledger short-circuit entirely. One env var reverts a field
+ * regression to today's behavior.
+ */
+function dirLedgerDisabled(): boolean {
+  const v = process.env.AGENTS_SESSIONS_NO_DIR_LEDGER;
+  return v === '1' || v === 'true';
+}
 
 let cachedOpenClawWorkspaces: Map<string, string> | null = null;
 
@@ -542,6 +567,122 @@ export function shouldDeferRecentAppend(
 }
 
 // ---------------------------------------------------------------------------
+// Directory-ledger short-circuit (A-2)
+// ---------------------------------------------------------------------------
+
+/** One leaf directory of transcripts to change-detect, plus its live-root flag. */
+export interface LeafDir {
+  /** Absolute path to the directory that directly holds transcript files. */
+  dirPath: string;
+  /**
+   * True if this dir is under the agent's LIVE `~/.<agent>` root — the only tree
+   * an agent process appends to live. Every file in such a dir is treated as
+   * hot (always re-stat'd), so an in-place append is never missed there.
+   */
+  isLiveRoot: boolean;
+}
+
+/** The changed files a leaf-dir walk surfaced, ready to parse + upsert. */
+export interface LeafDirScan {
+  /** Files whose (mtime, size) changed vs the ledger — the parse set. */
+  changed: Array<{ filePath: string; scan: ScanStamp }>;
+  /** Every transcript file seen across all leaf dirs (changed or not). */
+  allFiles: string[];
+}
+
+/**
+ * Walk a set of leaf transcript directories and return the files that changed,
+ * skipping the per-file `stat` of directories whose (mtime, entry_count) matches
+ * the dir_ledger.
+ *
+ * Per leaf dir:
+ *   - `stat` the dir once and `readdir` it (one cheap syscall) to get the entry
+ *     count and the file list.
+ *   - If the dir matches the dir_ledger (floored mtime AND entry_count), no file
+ *     was created / deleted / renamed since we last walked it. We then stat ONLY
+ *     the hot files (live-root files, or files scanned within HOT_FILE_WINDOW_MS)
+ *     and run just those through the ledger compare — so an in-place append to a
+ *     still-live session is still caught, while immutable backup/version dirs
+ *     collapse to a single dir stat and zero per-file stats.
+ *   - Else (changed dir, or no ledger row) we stat every file (today's full
+ *     walk) and record the fresh dir stamp so the next run can short-circuit.
+ *
+ * The kill-switch (`AGENTS_SESSIONS_NO_DIR_LEDGER=1`) forces the full-walk branch
+ * for every dir and never consults or records the dir_ledger.
+ */
+export function collectChangedFilesInLeafDirs(
+  leafDirs: LeafDir[],
+  ext: string,
+): LeafDirScan {
+  const disabled = dirLedgerDisabled();
+  const dirStamps = disabled ? new Map<string, DirStamp>() : getDirLedgerForPaths(leafDirs.map(d => d.dirPath));
+  const now = Date.now();
+
+  // Files whose per-file stat we still need to ledger-compare this run.
+  const toCompare: PreStatEntry[] = [];
+  const allFiles: string[] = [];
+  const dirScansToRecord: Array<{ dirPath: string; dirMtimeMs: number; entryCount: number }> = [];
+
+  for (const { dirPath, isLiveRoot } of leafDirs) {
+    const dirStat = safeStatSync(dirPath);
+    if (!dirStat?.isDirectory()) continue;
+
+    let names: string[];
+    try {
+      names = fs.readdirSync(dirPath).filter(f => f.endsWith(ext));
+    } catch {
+      continue;
+    }
+    const files = names.map(f => path.join(dirPath, f));
+    allFiles.push(...files);
+
+    const dirMtimeMs = Math.floor(dirStat.mtimeMs);
+    const entryCount = names.length;
+    const prevDir = dirStamps.get(dirPath);
+    const dirUnchanged =
+      !disabled && prevDir !== undefined && prevDir.dirMtimeMs === dirMtimeMs && prevDir.entryCount === entryCount;
+
+    if (dirUnchanged) {
+      // Contents did not change (no create/delete/rename). Stat only the hot
+      // files; the rest are served from the DB with no stat. An immutable backup
+      // dir (not a live root, nothing recently scanned) does zero per-file stats.
+      //
+      // A live-root dir treats every file as hot — that is the tree an agent
+      // appends to live, and an append does NOT bump the parent-dir mtime, so
+      // without this a growing session would be silently skipped. A non-live
+      // file is hot only if it was scanned within HOT_FILE_WINDOW_MS (bulk ledger
+      // lookup), covering a session under a version/backup path that is somehow
+      // still being written.
+      const stamps = isLiveRoot ? null : getScanStampsForPaths(files);
+      for (const filePath of files) {
+        let hot = isLiveRoot;
+        if (!hot && stamps) {
+          const s = stamps.get(filePath);
+          hot = s?.scannedAt !== undefined && now - s.scannedAt <= HOT_FILE_WINDOW_MS;
+        }
+        if (!hot) continue;
+        const stat = safeStatSync(filePath);
+        if (!stat) continue;
+        toCompare.push({ filePath, fileMtimeMs: stat.mtimeMs, fileSize: stat.size });
+      }
+      // No dir stamp to record — nothing about the dir changed.
+    } else {
+      // Changed dir (or cold ledger): full per-file stat, exactly as today.
+      for (const filePath of files) {
+        const stat = safeStatSync(filePath);
+        if (!stat) continue;
+        toCompare.push({ filePath, fileMtimeMs: stat.mtimeMs, fileSize: stat.size });
+      }
+      if (!disabled) dirScansToRecord.push({ dirPath, dirMtimeMs, entryCount });
+    }
+  }
+
+  const changed = filterChangedEntries(toCompare);
+  if (dirScansToRecord.length > 0) recordDirScans(dirScansToRecord);
+  return { changed, allFiles };
+}
+
+// ---------------------------------------------------------------------------
 // Multi-version directory scanning
 // ---------------------------------------------------------------------------
 
@@ -850,39 +991,45 @@ export function buildClaudeLabelMap(): Map<string, string | null> {
 async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Promise<void> {
   const account = getClaudeAccount();
   const labelMap = buildClaudeLabelMap();
-  const filePaths: string[] = [];
-  const seen = new Set<string>();
 
-  for (const projectsDir of getAgentSessionDirs('claude', 'projects')) {
+  // Enumerate every leaf project dir across all Claude roots. The FIRST root
+  // returned by getAgentSessionDirs is the agent's live `~/.claude/projects` —
+  // the only tree Claude appends to in place, so its project dirs are live roots
+  // (every file hot). Version-home + backup roots are immutable: their dirs
+  // short-circuit to a single dir stat when unchanged.
+  const roots = getAgentSessionDirs('claude', 'projects');
+  const leafDirs: LeafDir[] = [];
+  const seenLeaf = new Set<string>();
+  roots.forEach((projectsDir, rootIdx) => {
+    const isLiveRoot = rootIdx === 0;
     let projectDirs: string[];
     try {
       projectDirs = fs.readdirSync(projectsDir);
     } catch {
-      continue;
+      return;
     }
-
     for (const dirName of projectDirs) {
       const dirPath = path.join(projectsDir, dirName);
-      const stat = safeStatSync(dirPath);
-      if (!stat?.isDirectory()) continue;
-
-      let files: string[];
-      try {
-        files = fs.readdirSync(dirPath).filter(f => f.endsWith('.jsonl'));
-      } catch {
-        continue;
-      }
-
-      for (const file of files) {
-        const sessionId = file.replace('.jsonl', '');
-        if (seen.has(sessionId)) continue;
-        seen.add(sessionId);
-        filePaths.push(path.join(dirPath, file));
-      }
+      const key = safeRealpathSync(dirPath) || dirPath;
+      if (seenLeaf.has(key)) continue;
+      seenLeaf.add(key);
+      leafDirs.push({ dirPath, isLiveRoot });
     }
-  }
+  });
 
-  const changed = filterChangedFiles(filePaths);
+  const { changed: changedAll } = collectChangedFilesInLeafDirs(leafDirs, '.jsonl');
+  // De-dup by sessionId across roots, keeping the first occurrence. leafDirs is
+  // ordered live-root-first, so a session present in both the live root and a
+  // backup/version home is scanned from its live path — the same precedence the
+  // pre-A-2 `seen` set gave, so `file_path` stays stable.
+  const seenSession = new Set<string>();
+  const changed: Array<{ filePath: string; scan: ScanStamp }> = [];
+  for (const entry of changedAll) {
+    const sessionId = path.basename(entry.filePath).replace('.jsonl', '');
+    if (seenSession.has(sessionId)) continue;
+    seenSession.add(sessionId);
+    changed.push(entry);
+  }
 
   if (changed.length > 0) {
     onProgress?.({ agent: 'claude', parsed: 0, total: changed.length });
@@ -1283,34 +1430,32 @@ async function scanGeminiIncremental(onProgress?: (p: ScanProgress) => void): Pr
   const currentVersion = await getCurrentAgentVersion('gemini');
   const projectMap = buildGeminiProjectMap();
 
-  const filePaths: Array<{ filePath: string; hashDir: string }> = [];
-  for (const tmpDir of getAgentSessionDirs('gemini', 'tmp')) {
+  // Each `<tmpDir>/<hashDir>/chats` is a leaf dir of Gemini transcripts. The
+  // FIRST tmp root is the live `~/.gemini/tmp` — its chats dirs are live roots;
+  // version-home + backup roots are immutable and short-circuit when unchanged.
+  const tmpRoots = getAgentSessionDirs('gemini', 'tmp');
+  const leafDirs: LeafDir[] = [];
+  const seenLeaf = new Set<string>();
+  tmpRoots.forEach((tmpDir, rootIdx) => {
+    const isLiveRoot = rootIdx === 0;
     let hashDirs: string[];
     try {
       hashDirs = fs.readdirSync(tmpDir);
     } catch {
-      continue;
+      return;
     }
-
     for (const hashDir of hashDirs) {
       const chatsDir = path.join(tmpDir, hashDir, 'chats');
       if (!fs.existsSync(chatsDir)) continue;
-
-      let chatFiles: string[];
-      try {
-        chatFiles = fs.readdirSync(chatsDir).filter(f => f.endsWith('.json'));
-      } catch {
-        continue;
-      }
-
-      for (const file of chatFiles) {
-        filePaths.push({ filePath: path.join(chatsDir, file), hashDir });
-      }
+      const key = safeRealpathSync(chatsDir) || chatsDir;
+      if (seenLeaf.has(key)) continue;
+      seenLeaf.add(key);
+      leafDirs.push({ dirPath: chatsDir, isLiveRoot });
     }
-  }
+  });
 
-  const changedPaths = filterChangedFiles(filePaths.map(f => f.filePath));
-  const changedByPath = new Map(changedPaths.map(c => [c.filePath, c.scan]));
+  const { changed } = collectChangedFilesInLeafDirs(leafDirs, '.json');
+  const changedByPath = new Map(changed.map(c => [c.filePath, c.scan]));
   if (changedByPath.size === 0) return;
 
   onProgress?.({ agent: 'gemini', parsed: 0, total: changedByPath.size });
@@ -1319,9 +1464,9 @@ async function scanGeminiIncremental(onProgress?: (p: ScanProgress) => void): Pr
   const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
   const seen = new Set<string>();
   let parsed = 0;
-  for (const { filePath, hashDir } of filePaths) {
-    const scan = changedByPath.get(filePath);
-    if (!scan) continue;
+  for (const { filePath, scan } of changed) {
+    // The hashDir is the directory two levels up: <hashDir>/chats/<file>.json.
+    const hashDir = path.basename(path.dirname(path.dirname(filePath)));
     try {
       const result = readGeminiMeta(filePath, hashDir, projectMap, currentVersion);
       if (result && !seen.has(result.meta.id)) {

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -586,8 +586,14 @@ export interface LeafDir {
 export interface LeafDirScan {
   /** Files whose (mtime, size) changed vs the ledger — the parse set. */
   changed: Array<{ filePath: string; scan: ScanStamp }>;
-  /** Every transcript file seen across all leaf dirs (changed or not). */
-  allFiles: string[];
+  /**
+   * Every transcript file seen across all leaf dirs (changed or not), in
+   * live-root-first order, each tagged with whether its dir is a live root.
+   * Lets a caller restore cross-root, session-id precedence (prefer the live
+   * copy of a session over a frozen backup copy) independent of which copy
+   * happened to be flagged "changed" this run.
+   */
+  allFiles: Array<{ filePath: string; isLiveRoot: boolean }>;
 }
 
 /**
@@ -620,7 +626,7 @@ export function collectChangedFilesInLeafDirs(
 
   // Files whose per-file stat we still need to ledger-compare this run.
   const toCompare: PreStatEntry[] = [];
-  const allFiles: string[] = [];
+  const allFiles: Array<{ filePath: string; isLiveRoot: boolean }> = [];
   const dirScansToRecord: Array<{ dirPath: string; dirMtimeMs: number; entryCount: number }> = [];
 
   for (const { dirPath, isLiveRoot } of leafDirs) {
@@ -634,7 +640,7 @@ export function collectChangedFilesInLeafDirs(
       continue;
     }
     const files = names.map(f => path.join(dirPath, f));
-    allFiles.push(...files);
+    for (const filePath of files) allFiles.push({ filePath, isLiveRoot });
 
     const dirMtimeMs = Math.floor(dirStat.mtimeMs);
     const entryCount = names.length;
@@ -1017,19 +1023,29 @@ async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Pr
     }
   });
 
-  const { changed: changedAll } = collectChangedFilesInLeafDirs(leafDirs, '.jsonl');
-  // De-dup by sessionId across roots, keeping the first occurrence. leafDirs is
-  // ordered live-root-first, so a session present in both the live root and a
-  // backup/version home is scanned from its live path — the same precedence the
-  // pre-A-2 `seen` set gave, so `file_path` stays stable.
-  const seenSession = new Set<string>();
-  const changed: Array<{ filePath: string; scan: ScanStamp }> = [];
-  for (const entry of changedAll) {
-    const sessionId = path.basename(entry.filePath).replace('.jsonl', '');
-    if (seenSession.has(sessionId)) continue;
-    seenSession.add(sessionId);
-    changed.push(entry);
+  const { changed: changedAll, allFiles } = collectChangedFilesInLeafDirs(leafDirs, '.jsonl');
+  // Restore the pre-A-2 cross-root precedence: a session id present in multiple
+  // roots is ALWAYS served from its live path, never a frozen backup/version
+  // copy. Pre-A-2, dedup happened at enumeration time via a live-first `seen`
+  // set, so a non-live copy was never even stat'd when a live copy existed. This
+  // PR must not regress that to "whichever copy changed this run wins" — a cold
+  // (unchanged) live copy paired with a freshly-written backup snapshot would
+  // otherwise flip the row's file_path to the backup path.
+  //
+  // allFiles is every transcript file across all roots in live-first order, so
+  // the FIRST occurrence of each session id is its live (or highest-precedence)
+  // path — the durable winner, independent of which copy was flagged changed.
+  const sessionIdOf = (fp: string) => path.basename(fp).replace('.jsonl', '');
+  const winnerBySession = new Map<string, string>();
+  for (const { filePath } of allFiles) {
+    const id = sessionIdOf(filePath);
+    if (!winnerBySession.has(id)) winnerBySession.set(id, filePath);
   }
+  // Keep a changed entry only if it is its session's winner. A changed non-live
+  // copy is dropped whenever a live copy exists anywhere; the winning path is
+  // parsed only when it itself changed (a cold winner needs no re-parse — its DB
+  // row already points at the live path).
+  const changed = changedAll.filter(e => winnerBySession.get(sessionIdOf(e.filePath)) === e.filePath);
 
   if (changed.length > 0) {
     onProgress?.({ agent: 'claude', parsed: 0, total: changed.length });


### PR DESCRIPTION
## What & why

Session discovery (`discoverSessions`, discover.ts) re-walks and re-`stat`s the
**whole** transcript tree on every `agents sessions` / `output` / `view` /
`teams` call. Each agent's scan enumerates files and runs them through
`filterChangedFiles`/`filterChangedEntries`, which `stat`s every file. The SQLite
`scan_ledger` only gates *parsing*, not *discovery* — so for a heavy user the
IMMUTABLE version-home + backup roots (from `getAgentSessionDirs`) dominate and
are re-stat'd every single time, hundreds-to-thousands of sync stats per call.

This adds a **directory-level ledger** so an unchanged leaf transcript directory
is served from the DB without stat'ing its files.

### Before → after (warm scan)

- **Before:** every leaf dir → `readdir` + one `stat` per file, every call.
  Immutable backup/version dirs pay the full per-file `stat` cost forever.
- **After:** every leaf dir → one `stat` of the dir. If its `(floored mtime,
  entry_count)` matches the new `dir_ledger`, no file was created/deleted/renamed
  → skip the per-file `stat`, serve unchanged files from the DB. An immutable
  backup/version leaf dir collapses to **one dir stat, zero per-file stats**.

## Append-safety (the load-bearing correctness argument)

A parent-dir mtime bumps on file **create / delete / rename** but **NOT** on an
in-place **append**. So skipping a dir purely on an mtime match *would* miss a
live session growing in place — unless that file is in the **hot set** and gets
re-`stat`'d anyway. A file is HOT iff:

- it is under the agent's **live `~/.<agent>` root** (the first
  `getAgentSessionDirs` entry — the only tree an agent process appends to live), OR
- its `scan_ledger.scannedAt` is within **`HOT_FILE_WINDOW_MS` (10 min)**.

Hot files are always re-`stat`'d and run back through `filterChangedEntries`, so
the existing append detection **and** the 5s `ACTIVE_APPEND_RESCAN_DEBOUNCE_MS`
are fully preserved. Immutable backup/version leaf dirs have zero hot files → the
collapse above. Deletes/renames still bump the dir mtime → full re-walk → the row
is dropped by `querySessions`'s `existsSync` filter exactly as today (delete
handling was **not** moved into the walk). Dir mtime is floored with `Math.floor`
for parity with the file-ledger convention.

## Scanners covered

- **Wired:** `scanClaudeIncremental` and `scanGeminiIncremental` — the
  readdir-per-project/chats-dir scanners where the structure is explicit and the
  win is biggest, via a shared `collectChangedFilesInLeafDirs` helper.
- **Left on the A-1 single-stat path (unchanged):** the recursive
  `walkForFilesWithStat` scanners (Codex, Droid, routine archives). Applying a
  dir-gate there cleanly is a follow-up; Claude/Gemini are the dominant cost, and
  keeping the recursive walkers as-is avoids risk. The DB-backed scanners
  (opencode, antigravity) stat a single DB file, not a tree — untouched.
- `getSessionRoots` / `SESSION_ROOT_SPECS` / `getAgentSessionDirs` are untouched,
  so the `agents sessions --roots --json` payload the Factory watcher depends on
  is unchanged.

## Kill-switch

`AGENTS_SESSIONS_NO_DIR_LEDGER=1` forces the old full per-file walk (the
dir_ledger is never consulted or recorded) — a field regression is one env var
from today's behavior.

## Schema

`SCHEMA_VERSION` 13 → 14. New `dir_ledger(dir_path PK, dir_mtime_ms, entry_count,
scanned_at)`, keyed by `canonicalLedgerKey` like the file ledger. The v13→v14
migration creates the table and `DELETE FROM scan_ledger` so the first
post-upgrade scan does a clean full walk that seeds **both** ledgers. A
cold/empty dir_ledger degrades to today's full walk.

## Tests (real fs + real sqlite under a temp HOME — no mocking)

`discover.dir-ledger.test.ts`:

- **T2** nothing-changed is cheap: an immutable backup dir does **0** per-file
  stats on the 2nd run, same session set both runs.
- **T3** append caught: live-root in-place append (size grows, dir mtime
  unchanged) updates the row after the 5s debounce.
- **T4** debounce preserved: same append within the 5s window → NOT re-parsed.
- **T5** new file: a new `.jsonl` in a previously-unchanged dir surfaces.
- **T6** delete: file removed → session drops, no crash.
- **T7** rename: within a dir → old id drops, new id surfaces.
- **T8** cold/wiped ledger: `DELETE FROM dir_ledger + scan_ledger` → identical
  session set.
- **T9** hot-window fallback: a file OUTSIDE the live root with a recent
  `scannedAt`, appended with dir mtime unchanged → still re-`stat`'d + updated.
- **Kill-switch:** with the flag set, the backup file IS stat'd (full walk ran)
  and results are identical.

`db.migrate-v14.test.ts`: seed a v13 DB with rows + populated scan_ledger →
`getDB()` migration → dir_ledger exists, scan_ledger cleared, version bumped,
rows preserved.

Also: `__tests__/db.test.ts` schema_version assertion bumped 13→14; a pre-existing
`getSessionRoots` staleness (missing the already-shipped `grok` root, fired only
on machines with `~/.grok/sessions`) fixed in `discover.test.ts`.

## Verification

`cd apps/cli && npx tsc --noEmit` clean. `npx vitest run src/lib/session/` →
**59 files, 669 tests passed** (includes discover.test.ts, both discover.*.test.ts,
db.freshness.test.ts, the v14 migration, and the getSessionRoots payload test).
The 4 repo-wide failures (`exec.test.ts`, `models.test.ts`,
`non-interactive.test.ts`) reproduce identically on a clean `origin/main`
checkout — pre-existing, environment-dependent, unrelated to this change.