### PR TITLE
fix(routines): rotated-account auth, device-pin reload, and --active --json join keys (RUSH-1979/1980/1981)

### DIFF
--- a/apps/cli/.changelog/next/active-json-join-keys.md
+++ b/apps/cli/.changelog/next/active-json-join-keys.md
@@ -1,0 +1,9 @@
+- **`agents sessions --active --json` now emits flat `ticketId` and `project`
+  keys on every row.** A supervising watcher joins active sessions on ticket +
+  project, but the raw row nested the ticket under `ticket.id` and carried no
+  `project` at all, so a naive join silently dropped every session. Each row now
+  carries top-level `ticketId` (from the detected ticket) and `project` (the
+  basename of the session's cwd — the same derivation the historical `--json`
+  listing uses), both always present and `null` when unknown. The existing raw
+  fields are unchanged. Source: `apps/cli/src/commands/sessions.ts`
+  (`serializeActiveSessionsForJson`).

--- a/apps/cli/.changelog/next/repo-pull-reloads-daemon.md
+++ b/apps/cli/.changelog/next/repo-pull-reloads-daemon.md
@@ -1,0 +1,9 @@
+- **`agents repo pull` now reloads the routines daemon so device pins refresh.**
+  The scheduler froze each routine's config — device pins included — in memory at
+  daemon start. A `repo pull` rewrites the synced routine YAML on disk (a routine
+  re-pinned to another host, say), but without a reload the daemon kept firing the
+  pre-pull pins, so a routine moved to another device still fired on the old host
+  too — a phantom double-fire across the fleet. A successful pull now SIGHUPs the
+  running daemon (`scheduler.reloadAll()`), re-reading the YAML so pins refresh. A
+  no-op when the daemon isn't running or on Windows (no SIGHUP). Source:
+  `apps/cli/src/commands/repo.ts`.

--- a/apps/cli/.changelog/next/routine-rotated-account-auth.md
+++ b/apps/cli/.changelog/next/routine-rotated-account-auth.md
@@ -1,0 +1,12 @@
+- **Balanced account rotation now works for scheduled Claude routines.** The
+  routines daemon injects one `CLAUDE_CODE_OAUTH_TOKEN` into its environment so a
+  token-less default account still authenticates (RUSH-1759). But Claude — and the
+  Linux shim's own `-z CLAUDE_CODE_OAUTH_TOKEN` guard — both prefer that env var
+  over a pinned account's `CLAUDE_CONFIG_DIR`, so once balanced rotation pinned a
+  specific account the injected token shadowed it: the whole pool was inert and
+  every fire authenticated as (and eventually 401'd on) the one token. A routine
+  spawn now drops the injected token when the rotated account holds its own on-disk
+  credential, so it authenticates as that account; when the account has no on-disk
+  credential (the RUSH-1759 default) the injected token is kept. Source:
+  `apps/cli/src/lib/runner.ts` (`buildRoutineSpawnEnv`),
+  `apps/cli/src/lib/agents.ts` (`claudeHomeHasOwnCredential`).

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -180,6 +180,12 @@ contains `path`, `name`, `mediaType`, and `sizeBytes` so consumers such as Facto
 can render thumbnails and open the original attachment without re-reading the raw
 agent transcript.
 
+Every row also carries flat top-level `ticketId` and `project` keys — always
+present, `null` when unknown — so a watcher can join active sessions on ticket and
+project without reaching into the nested `ticket` object. `project` is the
+basename of the session's cwd, the same derivation the historical `--json`
+listing uses, so the active and recent views join identically.
+
 Some sessions appear in multiple sources:
 
 - **Local CLI**: `sessions` only

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -937,6 +937,7 @@ export function registerRepoCommands(program: Command): void {
         console.log(chalk.gray('No repos to pull.'));
         return;
       }
+      let anyPulled = false;
       for (const t of targets) {
         if (!fs.existsSync(t.dir) || !isGitRepo(t.dir)) {
           // A plain (never-cloned) user repo — setup makes ~/.agents a bare dir and
@@ -975,8 +976,22 @@ export function registerRepoCommands(program: Command): void {
         const result = await pullRepo(t.dir);
         if (result.success) {
           spinner.succeed(`${formatRepoTarget(t.alias, t.dir, result.branch)}: ${result.commit}`);
+          anyPulled = true;
         } else {
           spinner.fail(`${formatRepoTarget(t.alias, t.dir)}: ${result.error}`);
+        }
+      }
+
+      // RUSH-1980: a pull rewrites the routine YAML on disk, but the daemon's
+      // scheduler froze its JobConfigs (device pins included) at load. Without a
+      // reload it keeps firing the pre-pull pins — a routine re-pinned to another
+      // host still fires here, double-firing across the fleet. SIGHUP the daemon
+      // so scheduler.reloadAll() re-reads the synced YAML and device pins refresh.
+      // No-op when the daemon isn't running (or on Windows, which has no SIGHUP).
+      if (anyPulled) {
+        const { isDaemonRunning, signalDaemonReload } = await import('../lib/daemon.js');
+        if (isDaemonRunning() && signalDaemonReload()) {
+          console.log(chalk.gray('Reloaded the routines daemon (device pins refreshed).'));
         }
       }
     });

--- a/apps/cli/src/commands/sessions.serialize.test.ts
+++ b/apps/cli/src/commands/sessions.serialize.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { serializeSessionsJson } from './sessions.js';
+import { serializeSessionsJson, serializeActiveSessionsForJson } from './sessions.js';
 import type { SessionMeta } from '../lib/session/types.js';
+import type { ActiveSession } from '../lib/session/active.js';
 
 /**
  * `serializeSessionsJson` is the single seam both the local `agents sessions
@@ -63,5 +64,45 @@ describe('serializeSessionsJson', () => {
     const out = serializeSessionsJson([meta()]);
     expect(out.endsWith('\n')).toBe(true);
     expect(out.endsWith('\n\n')).toBe(false);
+  });
+});
+
+/**
+ * RUSH-1981: `agents sessions --active --json` is what a supervising watcher
+ * joins on. The raw ActiveSession nests the ticket (`ticket.id`) and carries no
+ * `project`, so a naive join on ticketId+project drops every row. The serializer
+ * must add both as flat, always-present top-level keys.
+ */
+describe('serializeActiveSessionsForJson (RUSH-1981 — join keys)', () => {
+  function active(over: Partial<ActiveSession> = {}): ActiveSession {
+    return { context: 'terminal', kind: 'agent', status: 'running', ...over } as ActiveSession;
+  }
+
+  it('emits flat ticketId (from ticket.id) and project (basename of cwd)', () => {
+    const [row] = serializeActiveSessionsForJson([
+      active({ cwd: '/home/u/src/github.com/acme/widget', ticket: { id: 'RUSH-1981' } as ActiveSession['ticket'] }),
+    ]);
+    expect(row.ticketId).toBe('RUSH-1981');
+    expect(row.project).toBe('widget');
+  });
+
+  it('emits both keys as null (never absent) when the session has no ticket or cwd', () => {
+    const [row] = serializeActiveSessionsForJson([active()]);
+    // The keys must EXIST so a `.ticketId`/`.project` join never throws — a
+    // missing property and an explicit null are not the same to a consumer.
+    expect(Object.prototype.hasOwnProperty.call(row, 'ticketId')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(row, 'project')).toBe(true);
+    expect(row.ticketId).toBeNull();
+    expect(row.project).toBeNull();
+  });
+
+  it('preserves the raw ActiveSession fields alongside the join keys', () => {
+    const [row] = serializeActiveSessionsForJson([
+      active({ sessionId: 'sess-1', machine: 'yosemite-s1', cwd: '/a/b/repo' }),
+    ]);
+    expect(row.sessionId).toBe('sess-1');
+    expect(row.machine).toBe('yosemite-s1');
+    expect(row.ticket).toBeUndefined();
+    expect(row.project).toBe('repo');
   });
 });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -401,6 +401,25 @@ export function ticketLabel(s: Pick<SessionMeta, 'ticketId' | 'prNumber'>): stri
 }
 
 /**
+ * The row shape `agents sessions --active --json` emits. RUSH-1981: a watcher
+ * joins active sessions on ticketId + project, but the raw ActiveSession nests
+ * the ticket (`ticket.id`) and carries no `project` at all — so a naive join
+ * silently drops every row. Emit both as flat, always-present top-level keys
+ * (null when unknown) alongside the raw fields, so every active row is joinable.
+ * `project` uses the same derivation SessionMeta does — basename(cwd) (see
+ * discover.ts) — so the active view and the history view join identically.
+ */
+export function serializeActiveSessionsForJson(
+  sessions: ActiveSession[],
+): Array<ActiveSession & { ticketId: string | null; project: string | null }> {
+  return sessions.map((s) => ({
+    ...s,
+    ticketId: s.ticket?.id ?? null,
+    project: s.cwd ? path.basename(s.cwd) : null,
+  }));
+}
+
+/**
  * Compact, colour-coded badges for the durable/awaiting signals. Text-only (no
  * emoji, per repo convention): `plan` / `ask` / `perm` for why it's waiting,
  * `PR#N`, `wt:slug`, `TICKET-123`.
@@ -878,7 +897,7 @@ async function renderActiveSessions(
   const sessions = waitingOnly ? merged.filter(s => s.status === 'input_required') : merged;
 
   if (asJson) {
-    process.stdout.write(JSON.stringify(sessions, null, 2) + '\n');
+    process.stdout.write(JSON.stringify(serializeActiveSessionsForJson(sessions), null, 2) + '\n');
     if (waitingOnly && sessions.length > 0) process.exitCode = 1;
     return;
   }

--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -12,7 +12,7 @@ import {
 import { readRunMeta } from '../routines.js';
 import { getRunsDir } from '../state.js';
 import type { JobConfig } from '../routines.js';
-import { getBinaryPath, getVersionDir } from '../versions.js';
+import { getBinaryPath, getVersionDir, getVersionHomePath } from '../versions.js';
 import { rotationFailoverChain, type RotateCandidate, type RotateResult } from '../rotate.js';
 import { detectRateLimit } from '../exec.js';
 
@@ -254,6 +254,54 @@ describe('buildRoutineSpawnEnv', () => {
     expect(env.CLAUDE_CONFIG_DIR).toContain(path.join('claude', '2.1.0'));
     expect(env.CLAUDE_CONFIG_DIR).toContain('.claude');
     expect(env.HOME).toBe('/tmp/overlay');
+  });
+
+  // RUSH-1979: the routines daemon injects one ambient CLAUDE_CODE_OAUTH_TOKEN so
+  // a token-less default account still authenticates. When rotation pins a
+  // specific account whose config dir holds its OWN credential, that ambient
+  // token would shadow the account (Claude and the Linux shim both prefer the env
+  // var) — leaving the balanced pool inert and 401ing on the one stale token.
+  describe('RUSH-1979 — drops the ambient CLAUDE_CODE_OAUTH_TOKEN for a rotated account', () => {
+    // Use a throwaway version slot so we never touch a real installed version.
+    const VER = '9.9.9-rush1979-test';
+    const home = getVersionHomePath('claude', VER);
+    const credFile = path.join(home, '.claude', '.credentials.json');
+
+    afterEach(() => {
+      try {
+        fs.rmSync(getVersionDir('claude', VER), { recursive: true, force: true });
+      } catch { /* best effort */ }
+    });
+
+    it.skipIf(process.platform === 'darwin')(
+      'drops the injected token when the pinned account home has its own credential',
+      () => {
+        fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+        fs.writeFileSync(
+          credFile,
+          JSON.stringify({ claudeAiOauth: { accessToken: 'at-account', refreshToken: 'rt-account' } }),
+          'utf-8',
+        );
+        const env = buildRoutineSpawnEnv(
+          { HOME: '/tmp/overlay', PATH: '/usr/bin', CLAUDE_CODE_OAUTH_TOKEN: 'daemon-injected-stale' },
+          'claude',
+          VER,
+        );
+        expect(env.CLAUDE_CONFIG_DIR).toContain(path.join('claude', VER));
+        expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      },
+    );
+
+    it('keeps the injected token when the pinned account has no on-disk credential (RUSH-1759 default)', () => {
+      // No credential written under `home`, so the account cannot self-authenticate
+      // — the daemon-injected token must survive so the run still authenticates.
+      const env = buildRoutineSpawnEnv(
+        { HOME: '/tmp/overlay', PATH: '/usr/bin', CLAUDE_CODE_OAUTH_TOKEN: 'daemon-injected' },
+        'claude',
+        VER,
+      );
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('daemon-injected');
+    });
   });
 });
 

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -12,6 +12,7 @@ import {
   __resetAntigravityKeychainCacheForTest,
   accountOrgBadge,
   antigravityOsKeyringProbe,
+  claudeHomeHasOwnCredential,
   deprecationNotice,
   formatClaudeOrgLabel,
   getAccountInfo,
@@ -857,6 +858,68 @@ describe('getAccountInfo — claude credential floor (blanked .credentials.json)
       expect(info.usageStatus).toBeNull();
     },
   );
+});
+
+// RUSH-1979: the daemon injects one ambient CLAUDE_CODE_OAUTH_TOKEN so a
+// token-less default account still authenticates; when balanced rotation pins a
+// specific account whose config dir carries its OWN credential, a routine spawn
+// must drop that ambient token (Claude and the Linux shim both prefer the env
+// var) so the pinned account authenticates itself. claudeHomeHasOwnCredential is
+// the signal that decides "this account has its own credential to fall back on".
+describe('claudeHomeHasOwnCredential (RUSH-1979 — rotated-account token drop)', () => {
+  function writeCred(home: string, oauth: Record<string, unknown> | null): void {
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+    if (oauth) {
+      fs.writeFileSync(
+        path.join(home, '.claude', '.credentials.json'),
+        JSON.stringify({ claudeAiOauth: oauth }),
+        'utf-8',
+      );
+    }
+  }
+
+  it('is true for a home with a live access token off macOS — drop the ambient token', () => {
+    const home = makeTempDir();
+    writeCred(home, { accessToken: 'at-real', refreshToken: 'rt-real', expiresAt: 1 });
+    expect(claudeHomeHasOwnCredential(home, 'linux')).toBe(true);
+  });
+
+  it('is true when only the refresh token survives (a refresh can still recover it)', () => {
+    const home = makeTempDir();
+    writeCred(home, { accessToken: '', refreshToken: 'rt-real', expiresAt: 0 });
+    expect(claudeHomeHasOwnCredential(home, 'linux')).toBe(true);
+  });
+
+  it('is true for a keychain-less .oauth_token fallback file', () => {
+    const home = makeTempDir();
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.claude', '.oauth_token'), 'sk-oauth-abc\n', 'utf-8');
+    expect(claudeHomeHasOwnCredential(home, 'linux')).toBe(true);
+  });
+
+  it('is false for a blanked credential pair — keep the ambient token', () => {
+    const home = makeTempDir();
+    writeCred(home, { accessToken: '', refreshToken: '', expiresAt: 0 });
+    expect(claudeHomeHasOwnCredential(home, 'linux')).toBe(false);
+  });
+
+  it('is false when the account home has no on-disk credential at all', () => {
+    const home = makeTempDir();
+    expect(claudeHomeHasOwnCredential(home, 'linux')).toBe(false);
+  });
+
+  it('does not treat a corrupt credential file as a usable credential', () => {
+    const home = makeTempDir();
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), '{not json', 'utf-8');
+    expect(claudeHomeHasOwnCredential(home, 'linux')).toBe(false);
+  });
+
+  it('never judges from the file on macOS, where the daemon injects no shadowing token', () => {
+    const home = makeTempDir();
+    writeCred(home, { accessToken: 'at-real', refreshToken: 'rt-real', expiresAt: 1 });
+    expect(claudeHomeHasOwnCredential(home, 'darwin')).toBe(false);
+  });
 });
 
 describe('agent deprecation warnings', () => {

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1503,6 +1503,45 @@ export function isClaudeCredentialFileBlank(
   }
 }
 
+/**
+ * Whether a Claude version home holds its OWN on-disk credential — a non-blank
+ * `.claude/.credentials.json` (the store Claude Code writes on login off macOS)
+ * or a `.claude/.oauth_token` file (the keychain-less shim fallback, shims.ts).
+ *
+ * RUSH-1979: the routines daemon injects one ambient `CLAUDE_CODE_OAUTH_TOKEN`
+ * (RUSH-1759) so a token-less default account still authenticates. But Claude —
+ * and the Linux shim's own `-z CLAUDE_CODE_OAUTH_TOKEN` guard — both prefer that
+ * env var over a pinned account's config dir, so when balanced rotation pins a
+ * specific account's `CLAUDE_CONFIG_DIR` the ambient token shadows it: the pool
+ * is inert and every fire 401s on the one stale token. A routine spawn drops the
+ * ambient token when the pinned account has its own credential (this returns
+ * true) so the account authenticates itself; when it does not (the RUSH-1759
+ * default), the injected token is kept.
+ *
+ * Off-darwin only, mirroring {@link isClaudeCredentialFileBlank}: on macOS the
+ * login Keychain is the canonical store and probing it raises an auth sheet, and
+ * there the daemon injects no token to shadow (broker-only, usually absent), so
+ * returning false changes nothing. Sync, no Keychain, no network.
+ */
+export function claudeHomeHasOwnCredential(
+  base: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (platform === 'darwin') return false;
+  if (fs.existsSync(path.join(base, '.claude', '.oauth_token'))) return true;
+  try {
+    const raw = fs.readFileSync(path.join(base, '.claude', '.credentials.json'), 'utf-8');
+    const oauth = (JSON.parse(raw) as {
+      claudeAiOauth?: { accessToken?: unknown; refreshToken?: unknown };
+    }).claudeAiOauth;
+    if (!oauth) return false;
+    const nonEmpty = (v: unknown): v is string => typeof v === 'string' && v.trim().length > 0;
+    return nonEmpty(oauth.accessToken) || nonEmpty(oauth.refreshToken);
+  } catch {
+    return false;
+  }
+}
+
 export async function getAccountInfo(
   agentId: AgentId,
   home?: string

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -50,7 +50,8 @@ import { loadTask as loadHostTask } from './hosts/tasks.js';
 import { reconcileTask as reconcileHostTask } from './hosts/reconcile.js';
 import { backgroundSpawnOptions } from './platform/process.js';
 import { walkForFiles } from './fs-walk.js';
-import { getBinaryPath, isVersionInstalled, resolveVersion } from './versions.js';
+import { getBinaryPath, getVersionHomePath, isVersionInstalled, resolveVersion } from './versions.js';
+import { claudeHomeHasOwnCredential } from './agents.js';
 import {
   getConfiguredRunStrategy,
   resolveRunVersion,
@@ -483,6 +484,21 @@ export function buildRoutineSpawnEnv(
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(execEnv)) {
     if (v !== undefined) out[k] = v;
+  }
+  // RUSH-1979: the daemon injects one ambient CLAUDE_CODE_OAUTH_TOKEN (RUSH-1759)
+  // so a token-less default account still authenticates. When balanced rotation
+  // pins THIS spawn to a specific account's CLAUDE_CONFIG_DIR that holds its own
+  // credential, that ambient token would shadow the account (Claude and the Linux
+  // shim both prefer the env var) — making the pool inert and 401ing on the one
+  // stale token. Drop it here so the pinned account authenticates itself; keep it
+  // when the account has no on-disk credential (the RUSH-1759 default).
+  if (
+    agent === 'claude' &&
+    version &&
+    out.CLAUDE_CONFIG_DIR &&
+    claudeHomeHasOwnCredential(getVersionHomePath('claude', version))
+  ) {
+    delete out.CLAUDE_CODE_OAUTH_TOKEN;
   }
   if (timezone) out.TZ = timezone;
   return out;

--- a/apps/cli/src/lib/scheduler.test.ts
+++ b/apps/cli/src/lib/scheduler.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { JobScheduler } from './scheduler.js';
+import { writeJob, deleteJob, type JobConfig } from './routines.js';
+
+/**
+ * RUSH-1980: the daemon's scheduler froze each routine's device pin at load
+ * (loadAll). `agents repo pull` rewrites the routine YAML on disk — including a
+ * moved device pin — but without a reload the scheduler keeps firing the old
+ * pin, so a routine re-pinned to another host still fires here too (a phantom
+ * double-fire across the fleet). reloadAll() must re-read the YAML so pins
+ * refresh. This drives the real reloadAll -> loadAll -> listJobs ->
+ * jobRunsOnThisDevice path against a routine rewritten on disk.
+ */
+describe('JobScheduler.reloadAll — device-pin refresh (RUSH-1980)', () => {
+  const name = 'rush1980-scheduler-test';
+  const SELF = 'rush1980-self';
+  let prevMachineId: string | undefined;
+
+  beforeEach(() => {
+    prevMachineId = process.env.AGENTS_SYNC_MACHINE_ID;
+    // Deterministic self-id so the pin comparison never depends on the CI host.
+    process.env.AGENTS_SYNC_MACHINE_ID = SELF;
+  });
+
+  afterEach(() => {
+    if (prevMachineId === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+    else process.env.AGENTS_SYNC_MACHINE_ID = prevMachineId;
+    try { deleteJob(name); } catch { /* best effort */ }
+  });
+
+  function pinnedJob(devices: string[]): JobConfig {
+    return {
+      name,
+      agent: 'claude',
+      prompt: 'do it',
+      schedule: '0 9 * * 1-5',
+      mode: 'plan',
+      effort: 'auto',
+      timeout: '10m',
+      enabled: true,
+      devices,
+    } as JobConfig;
+  }
+
+  it('picks up an on-disk re-pin on reload, so a routine moved to another host stops firing here', () => {
+    // Initially pinned to THIS device — the scheduler loads and schedules it.
+    writeJob(pinnedJob([SELF]));
+    const scheduler = new JobScheduler(async () => {});
+    scheduler.loadAll();
+    expect(scheduler.listScheduled().some((j) => j.name === name)).toBe(true);
+
+    // A pull rewrites the YAML, re-pinning the routine to another host. Before the
+    // fix the frozen in-memory pin kept this host firing it (the double-fire).
+    writeJob(pinnedJob(['rush1980-other-host']));
+    scheduler.reloadAll();
+    expect(scheduler.listScheduled().some((j) => j.name === name)).toBe(false);
+
+    // And the reverse refreshes too: re-pinned back here, reload re-schedules it.
+    writeJob(pinnedJob([SELF]));
+    scheduler.reloadAll();
+    expect(scheduler.listScheduled().some((j) => j.name === name)).toBe(true);
+
+    scheduler.stopAll();
+  });
+});


### PR DESCRIPTION
Three routines/sessions reliability fixes, each with a regression test and end-to-end verification.

## RUSH-1979 — rotated Claude account authenticates itself, not the injected token
The daemon injects one `CLAUDE_CODE_OAUTH_TOKEN` (RUSH-1759) so a token-less default account still authenticates. But Claude — and the Linux shim's own `-z CLAUDE_CODE_OAUTH_TOKEN` guard (`shims.ts:292`) — both prefer that env var over a pinned account's `CLAUDE_CONFIG_DIR`. So once balanced rotation pinned a specific account, the injected token shadowed it: the whole pool was inert and every fire authenticated as (and eventually 401'd on) the one stale token.

`buildRoutineSpawnEnv` (`runner.ts`) now drops the injected token when the rotated account holds its own on-disk credential (`claudeHomeHasOwnCredential`, `agents.ts`); when the account has none (the RUSH-1759 default) the token is kept.

**End-to-end:** a real routine fire with a garbage `CLAUDE_CODE_OAUTH_TOKEN` in env — balanced rotation picked `claude@2.1.170`, authenticated via that account's own credential, returned `OK`, exit 0, no 401 in the run log. Against real installed accounts, the token is dropped for `2.1.207` (has credential) and kept for `2.1.180` (no credential).

## RUSH-1980 — reload the daemon after `repo pull` so device pins refresh
The scheduler froze each routine's config (device pins included) in memory at daemon start. `agents repo pull` rewrites the synced routine YAML on disk, but without a reload the daemon kept firing the pre-pull pins — a routine re-pinned to another host still fired on the old host too (a phantom double-fire). A successful pull now SIGHUPs the running daemon (`scheduler.reloadAll()` already existed). No-op when the daemon isn't running or on Windows.

**Test:** `scheduler.test.ts` drives the real `reloadAll -> loadAll -> listJobs -> jobRunsOnThisDevice` path against a routine re-pinned on disk, asserting it stops (and resumes) firing here as the pin moves.

## RUSH-1981 — flat `ticketId` + `project` join keys in `--active --json`
A watcher joins active sessions on ticket + project, but the raw row nested the ticket under `ticket.id` and carried no `project`, so a naive join dropped every row. `serializeActiveSessionsForJson` adds top-level `ticketId` and `project` (basename of cwd — the same derivation the historical `--json` listing uses) to every row, always present and `null` when unknown.

**End-to-end:** a real `agents sessions --active --json` emits both keys on all 43 active rows (one with a real ticket id, this worktree's session with `project: cli-reliability`).

## Tests
`agents.test.ts`, both `runner` test files, `scheduler.test.ts`, `routines.test.ts`, `sessions.serialize.test.ts`, `repo.test.ts`, and the sessions command tests — **226 passing** across the touched files. Changelog fragments added under `.changelog/next/`.
