### PR TITLE
refactor(session): resumable Claude parser (reducer + incremental fn + parity harness)

### DIFF
--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -141,7 +141,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('14');
+    expect(row.value).toBe('15');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {

--- a/apps/cli/src/lib/session/__tests__/incremental-parity.test.ts
+++ b/apps/cli/src/lib/session/__tests__/incremental-parity.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  scanClaudeSession,
+  scanClaudeSessionIncremental,
+  initClaudeParseState,
+  serializeClaudeParserState,
+  type ClaudeParserState,
+} from '../discover.js';
+
+// Differential parity harness (B-1). Proves that resuming a Claude parse from a
+// persisted continuation and folding in appended lines is BYTE-FOR-BYTE
+// identical to a full parse of the whole file, for EVERY field of
+// ClaudeSessionScan. Real temp files, real fs, real sqlite-free path — no mocks.
+//
+// The invariant: full(all lines) === hydrate(state@k) + apply(k+1..n), because
+// applyClaudeLine is the single shared fold. Equality holds iff serialize /
+// hydrate round-trips the accumulator faithfully.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-inc-parity-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** Serialize an array of JSON objects into JSONL lines (no trailing newline). */
+function jsonl(lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n');
+}
+
+/**
+ * Write the first chunk, full-scan it to establish an offset + continuation,
+ * then for each subsequent chunk APPEND it to the same file and resume with
+ * scanClaudeSessionIncremental from the persisted offset. Return both the final
+ * incremental scan and the ground-truth full scan of the final file, so callers
+ * can assert deep equality (and per-field equality).
+ *
+ * `chunks[i]` is a complete-lines string (its own trailing '\n' is added here);
+ * the raw-partial test appends bytes directly and does not use this helper.
+ */
+async function replay(
+  chunks: string[],
+): Promise<{ inc: Awaited<ReturnType<typeof scanClaudeSession>>; full: Awaited<ReturnType<typeof scanClaudeSession>>; offsets: number[] }> {
+  const fp = path.join(dir, 'session.jsonl');
+  expect(chunks.length).toBeGreaterThan(0);
+
+  // Seed the file with chunk 0, then bootstrap a continuation from a full parse.
+  fs.writeFileSync(fp, chunks[0] + '\n');
+  // Bootstrap offset: the whole seed file is committed lines, so the initial
+  // resume offset is the file size (ends on a '\n'). Bootstrap the continuation
+  // by running the incremental fn once from offset 0 over an empty prior.
+  let prior: ClaudeParserState = serializeClaudeParserState(initClaudeParseState(), 0);
+  let step = await scanClaudeSessionIncremental(fp, 0, prior);
+  let inc = step.scan;
+  prior = step.newState;
+  const offsets: number[] = [step.newOffset];
+
+  for (let i = 1; i < chunks.length; i++) {
+    fs.appendFileSync(fp, chunks[i] + '\n');
+    step = await scanClaudeSessionIncremental(fp, prior.offset, prior);
+    inc = step.scan;
+    prior = step.newState;
+    offsets.push(step.newOffset);
+  }
+
+  const full = await scanClaudeSession(fp);
+  return { inc, full, offsets };
+}
+
+/** Assert two ClaudeSessionScan objects are equal on every field. */
+function expectScanParity(inc: any, full: any) {
+  expect(inc).toEqual(full);
+  // Belt-and-suspenders: name each field so a failure points at the culprit.
+  const fields = [
+    'timestamp', 'cwd', 'gitBranch', 'version', 'topic', 'entrypoint',
+    'messageCount', 'tokenCount', 'outputTokens', 'costUsd', 'durationMs',
+    'lastActivity', 'contentText', 'prUrl', 'prNumber', 'worktreeSlug',
+    'ticketId', 'createdTickets', 'spawnedTeam', 'plan',
+  ];
+  for (const f of fields) {
+    expect(inc[f], `field ${f}`).toEqual(full[f]);
+  }
+}
+
+// A representative, field-rich transcript. Two user turns, several assistant
+// events (some sharing a timestamp, some with usage/cost), a title, a plan.
+function richLines(): object[] {
+  return [
+    { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/home/u/repo', gitBranch: 'RUSH-42-fix', version: '2.1.0', entrypoint: 'cli', message: { role: 'user', content: 'investigate the flaky exec test' } },
+    { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', uuid: 'a-1', message: { id: 'msg_1', model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'looking' }], usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5, cache_creation_input_tokens: 3 } } },
+    { type: 'assistant', timestamp: '2026-06-28T00:02:00.000Z', uuid: 'a-2', message: { id: 'msg_2', model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: 'plan-1', name: 'ExitPlanMode', input: { plan: '# Plan\n- step one' } }], usage: { input_tokens: 50, output_tokens: 10 } } },
+    { type: 'user', timestamp: '2026-06-28T00:03:00.000Z', message: { role: 'user', content: 'yes go ahead' } },
+    { type: 'ai-title', aiTitle: 'Flaky exec test fix', sessionId: 's' },
+    { type: 'assistant', timestamp: '2026-06-28T00:04:00.000Z', uuid: 'a-3', message: { id: 'msg_3', model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 30, output_tokens: 40 } } },
+  ];
+}
+
+describe('incremental parity — boundary sweep', () => {
+  it('replaying across a split at EVERY line index equals a full parse', async () => {
+    const lines = richLines();
+    const fullSerialized = lines.map((l) => JSON.stringify(l));
+    // Split after each line index 1..n-1 (a two-chunk replay per boundary).
+    for (let k = 1; k < fullSerialized.length; k++) {
+      const chunkA = fullSerialized.slice(0, k).join('\n');
+      const chunkB = fullSerialized.slice(k).join('\n');
+      const { inc, full } = await replay([chunkA, chunkB]);
+      expectScanParity(inc, full);
+    }
+  });
+
+  it('replaying line-by-line (n chunks) equals a full parse', async () => {
+    const chunks = richLines().map((l) => JSON.stringify(l));
+    const { inc, full } = await replay(chunks);
+    expectScanParity(inc, full);
+  });
+});
+
+describe('incremental parity — fallback-id stress', () => {
+  it('assistant events sharing a timestamp with NO message.id/uuid keep messageCount/tokenCount parity across a boundary', async () => {
+    // Same timestamp, no id/uuid → logical id falls back to `${ts}:${size}`. If
+    // the hydrated set size is wrong, the dedup and thus messageCount diverges.
+    const ts = '2026-06-28T09:00:00.000Z';
+    const lines: object[] = [
+      { type: 'user', timestamp: '2026-06-28T08:59:00.000Z', cwd: '/x', message: { role: 'user', content: 'start' } },
+    ];
+    for (let i = 0; i < 12; i++) {
+      lines.push({ type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: `t${i}` }], usage: { input_tokens: 10, output_tokens: 2 } } });
+    }
+    const serialized = lines.map((l) => JSON.stringify(l));
+    for (let k = 1; k < serialized.length; k++) {
+      const { inc, full } = await replay([serialized.slice(0, k).join('\n'), serialized.slice(k).join('\n')]);
+      expect(inc.messageCount, `split@${k} messageCount`).toBe(full.messageCount);
+      expect(inc.tokenCount, `split@${k} tokenCount`).toBe(full.tokenCount);
+      expect(inc.outputTokens, `split@${k} outputTokens`).toBe(full.outputTokens);
+      expectScanParity(inc, full);
+    }
+  });
+
+  it('keeps size parity even when the recent-id window is smaller than the true count', async () => {
+    // > SEEN_IDS_RECENT_CAP (256) distinct assistant ids forces the FIFO window
+    // to drop older ids; the persisted seenIdsSize must still make the fallback
+    // `${ts}:${size}` line up after the boundary.
+    const lines: object[] = [
+      { type: 'user', timestamp: '2026-06-28T08:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'go' } },
+    ];
+    for (let i = 0; i < 300; i++) {
+      lines.push({ type: 'assistant', timestamp: '2026-06-28T09:00:00.000Z', message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: `x${i}` }], usage: { input_tokens: 1, output_tokens: 1 } } });
+    }
+    // Split AFTER the window would have overflowed, then append more fallback-id events.
+    const serialized = lines.map((l) => JSON.stringify(l));
+    const k = 280;
+    const { inc, full } = await replay([serialized.slice(0, k).join('\n'), serialized.slice(k).join('\n')]);
+    expect(inc.messageCount).toBe(full.messageCount);
+    expectScanParity(inc, full);
+  });
+});
+
+describe('incremental parity — straddled two-event patterns', () => {
+  it('PR create tool_use in chunk 1, tool_result URL in chunk 2 → prUrl/prNumber parity', async () => {
+    const chunkA = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'ship it' } },
+      { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', message: { id: 'm1', content: [{ type: 'tool_use', id: 'bash-1', name: 'Bash', input: { command: 'gh pr create --fill' } }] } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:02:00.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'bash-1', content: 'https://github.com/org/repo/pull/123' }] } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.prUrl).toBe('https://github.com/org/repo/pull/123');
+    expect(inc.prNumber).toBe(123);
+    expectScanParity(inc, full);
+  });
+
+  it('create_issue tool_use in chunk 1, result ref in chunk 2 → createdTickets parity', async () => {
+    const chunkA = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'open a ticket' } },
+      { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', message: { id: 'm1', content: [{ type: 'tool_use', id: 'tt-1', name: 'mcp__linear__create_issue', input: {} }] } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:02:00.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tt-1', content: 'Created RUSH-9001' }] } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.createdTickets).toEqual(['RUSH-9001']);
+    expectScanParity(inc, full);
+  });
+
+  it('spawnedTeam from a teams-create command straddling the boundary', async () => {
+    const chunkA = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'spin up a team' } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', message: { id: 'm1', content: [{ type: 'tool_use', id: 'b1', name: 'Bash', input: { command: 'agents teams create my-feature --enable-worktrees' } }] } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.spawnedTeam).toBe('my-feature');
+    expectScanParity(inc, full);
+  });
+});
+
+describe('incremental parity — title/plan after boundary', () => {
+  it('custom-title / ai-title / ExitPlanMode in the tail update topic + plan', async () => {
+    const chunkA = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'first prompt topic' } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', message: { id: 'm1', content: [{ type: 'tool_use', id: 'p1', name: 'ExitPlanMode', input: { plan: '# Tail plan' } }] } },
+      { type: 'custom-title', customTitle: 'renamed-in-tail', sessionId: 's' },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.topic).toBe('renamed-in-tail');
+    expect(inc.plan).toBe('# Tail plan');
+    expectScanParity(inc, full);
+  });
+
+  it('a title-less tail does NOT null a title established before the boundary', async () => {
+    const chunkA = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'start' } },
+      { type: 'custom-title', customTitle: 'set-early', sessionId: 's' },
+    ]);
+    const chunkB = jsonl([
+      { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', message: { id: 'm1', content: [{ type: 'text', text: 'more work, no new title' }] } },
+      { type: 'user', timestamp: '2026-06-28T00:02:00.000Z', message: { role: 'user', content: 'keep going' } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.topic).toBe('set-early');
+    expect(full.topic).toBe('set-early');
+    expectScanParity(inc, full);
+  });
+});
+
+describe('incremental parity — content_text', () => {
+  it('rebuilt content_text equals the full parse userTexts.join', async () => {
+    const lines = richLines();
+    const serialized = lines.map((l) => JSON.stringify(l));
+    for (let k = 1; k < serialized.length; k++) {
+      const { inc, full } = await replay([serialized.slice(0, k).join('\n'), serialized.slice(k).join('\n')]);
+      expect(inc.contentText, `split@${k} contentText`).toBe(full.contentText);
+      expectScanParity(inc, full);
+    }
+  });
+
+  it('the persisted continuation content_text round-trips the joined user doc', async () => {
+    const fp = path.join(dir, 'ct.jsonl');
+    fs.writeFileSync(fp, jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'alpha' } },
+      { type: 'user', timestamp: '2026-06-28T00:01:00.000Z', message: { role: 'user', content: 'beta' } },
+    ]) + '\n');
+    const step = await scanClaudeSessionIncremental(fp, 0, serializeClaudeParserState(initClaudeParseState(), 0));
+    expect(step.newState.contentText).toBe('alpha\nbeta');
+    expect(step.scan.contentText).toBe('alpha\nbeta');
+  });
+});
+
+describe('incremental parity — truncation → full reparse', () => {
+  it('when the file shrinks below the stored offset, the caller falls back to a full parse from offset 0', async () => {
+    const fp = path.join(dir, 'trunc.jsonl');
+    const original = jsonl([
+      { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'long original prompt one' } },
+      { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', message: { id: 'm1', content: [{ type: 'text', text: 'reply one' }], usage: { input_tokens: 9, output_tokens: 3 } } },
+    ]) + '\n';
+    fs.writeFileSync(fp, original);
+    const first = await scanClaudeSessionIncremental(fp, 0, serializeClaudeParserState(initClaudeParseState(), 0));
+    expect(first.newOffset).toBe(Buffer.byteLength(original, 'utf-8'));
+
+    // Rewrite the file SMALLER (a fresh, shorter session reusing the same path).
+    const rewritten = jsonl([
+      { type: 'user', timestamp: '2026-06-29T00:00:00.000Z', cwd: '/y', message: { role: 'user', content: 'brand new short session' } },
+    ]) + '\n';
+    fs.writeFileSync(fp, rewritten);
+    const newSize = Buffer.byteLength(rewritten, 'utf-8');
+
+    // The stored offset now exceeds the file size → truncation detected. The
+    // resumable contract (B-2 will wire this) is: on newSize < offset, discard
+    // the continuation and full-parse from scratch.
+    expect(newSize).toBeLessThan(first.newOffset);
+    const reparse = newSize < first.newOffset
+      ? await scanClaudeSessionIncremental(fp, 0, serializeClaudeParserState(initClaudeParseState(), 0))
+      : await scanClaudeSessionIncremental(fp, first.newOffset, first.newState);
+
+    const full = await scanClaudeSession(fp);
+    expectScanParity(reparse.scan, full);
+    expect(reparse.scan.topic).toBe('brand new short session');
+  });
+});
+
+describe('incremental parity — partial trailing line', () => {
+  it('a chunk ending mid-JSON (no trailing newline) is re-consumed on the next append', async () => {
+    const fp = path.join(dir, 'partial.jsonl');
+    const l1 = JSON.stringify({ type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'first complete line' } });
+    fs.writeFileSync(fp, l1 + '\n');
+    const step1 = await scanClaudeSessionIncremental(fp, 0, serializeClaudeParserState(initClaudeParseState(), 0));
+    // newOffset stops at the last '\n' — the full first line.
+    expect(step1.newOffset).toBe(Buffer.byteLength(l1 + '\n', 'utf-8'));
+
+    // Append a HALF-written second record (no trailing '\n').
+    const l2full = JSON.stringify({ type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', message: { id: 'm2', content: [{ type: 'text', text: 'second reply' }], usage: { input_tokens: 7, output_tokens: 4 } } });
+    const l2partial = l2full.slice(0, Math.floor(l2full.length / 2));
+    fs.appendFileSync(fp, l2partial);
+    const step2 = await scanClaudeSessionIncremental(fp, step1.newOffset, step1.newState);
+    // No new '\n' seen → offset must NOT advance past the last committed newline.
+    expect(step2.newOffset).toBe(step1.newOffset);
+    // The half-line must not have been parsed (JSON.parse would have thrown and
+    // been skipped anyway), so the assistant message is not yet counted.
+    expect(step2.scan.messageCount).toBe(1);
+
+    // Now complete the second record + a newline.
+    fs.appendFileSync(fp, l2full.slice(l2partial.length) + '\n');
+    const step3 = await scanClaudeSessionIncremental(fp, step2.newOffset, step2.newState);
+    expect(step3.newOffset).toBe(Buffer.byteLength(fs.readFileSync(fp)));
+
+    const full = await scanClaudeSession(fp);
+    expectScanParity(step3.scan, full);
+    expect(step3.scan.messageCount).toBe(2);
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/incremental-parity.test.ts
+++ b/apps/cli/src/lib/session/__tests__/incremental-parity.test.ts
@@ -316,4 +316,40 @@ describe('incremental parity — partial trailing line', () => {
     expectScanParity(step3.scan, full);
     expect(step3.scan.messageCount).toBe(2);
   });
+
+  it('a COMPLETE record missing only its trailing newline is deferred, then counted EXACTLY once', async () => {
+    // The non-atomic-append case prix-cloud caught: a writer appends a full,
+    // valid record and only later appends its '\n'. readline emits that
+    // unterminated line at EOF, so a naive pass applies it while the offset
+    // stops before it → the next pass re-reads and re-applies the SAME record.
+    // User events have no dedup (no seenAssistantIds), so the double-apply shows
+    // up as messageCount 2→3 and contentText carrying the second message twice.
+    const fp = path.join(dir, 'complete-unterminated.jsonl');
+    const l1 = JSON.stringify({ type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/x', message: { role: 'user', content: 'first message' } });
+    fs.writeFileSync(fp, l1 + '\n');
+    const step1 = await scanClaudeSessionIncremental(fp, 0, serializeClaudeParserState(initClaudeParseState(), 0));
+    expect(step1.scan.messageCount).toBe(1);
+    expect(step1.scan.contentText).toBe('first message');
+    expect(step1.newOffset).toBe(Buffer.byteLength(l1 + '\n', 'utf-8'));
+
+    // Append a COMPLETE, valid second record — but WITHOUT its trailing '\n' yet.
+    const l2 = JSON.stringify({ type: 'user', timestamp: '2026-06-28T00:01:00.000Z', message: { role: 'user', content: 'second message' } });
+    fs.appendFileSync(fp, l2);
+    const step2 = await scanClaudeSessionIncremental(fp, step1.newOffset, step1.newState);
+    // Deferred: the offset does NOT advance, and line2 is NOT yet counted.
+    expect(step2.newOffset).toBe(step1.newOffset);
+    expect(step2.scan.messageCount).toBe(1);
+    expect(step2.scan.contentText).toBe('first message');
+
+    // Now the writer flushes the terminating '\n'.
+    fs.appendFileSync(fp, '\n');
+    const step3 = await scanClaudeSessionIncremental(fp, step2.newOffset, step2.newState);
+    // Counted EXACTLY once — not twice.
+    expect(step3.scan.messageCount).toBe(2);
+    expect(step3.scan.contentText).toBe('first message\nsecond message');
+    expect(step3.newOffset).toBe(Buffer.byteLength(fs.readFileSync(fp)));
+
+    const full = await scanClaudeSession(fp);
+    expectScanParity(step3.scan, full);
+  });
 });

--- a/apps/cli/src/lib/session/db.migrate-v14.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v14.test.ts
@@ -75,11 +75,18 @@ const Database = (await import('../sqlite.js')).default;
 
 const { getDB, getSessionById } = await import('./db.js');
 
-describe('schema migration v13 -> v14 (dir_ledger)', () => {
-  it('creates the dir_ledger table with the expected columns', () => {
+describe('schema migration v13 -> current (dir_ledger + resumable parser)', () => {
+  it('creates the dir_ledger table with the expected columns (v14)', () => {
     const db = getDB();
     const cols = (db.prepare(`PRAGMA table_info(dir_ledger)`).all() as Array<{ name: string }>).map(c => c.name);
     expect(cols).toEqual(['dir_path', 'dir_mtime_ms', 'entry_count', 'scanned_at']);
+  });
+
+  it('adds parser_state + content_text to scan_ledger (v15)', () => {
+    const db = getDB();
+    const cols = (db.prepare(`PRAGMA table_info(scan_ledger)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toContain('parser_state');
+    expect(cols).toContain('content_text');
   });
 
   it('clears scan_ledger so the first post-upgrade scan does a clean full walk', () => {
@@ -88,10 +95,10 @@ describe('schema migration v13 -> v14 (dir_ledger)', () => {
     expect(n).toBe(0);
   });
 
-  it('bumps the recorded schema version to 14', () => {
+  it('bumps the recorded schema version to the current version', () => {
     const db = getDB();
     const v = (db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string }).value;
-    expect(v).toBe('14');
+    expect(v).toBe('15');
   });
 
   it('preserves existing session rows through the migration', () => {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -17,7 +17,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 14;
+const SCHEMA_VERSION = 15;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -104,7 +104,14 @@ CREATE TABLE IF NOT EXISTS scan_ledger (
   file_path TEXT PRIMARY KEY,
   file_mtime_ms INTEGER NOT NULL,
   file_size INTEGER NOT NULL,
-  scanned_at INTEGER NOT NULL
+  scanned_at INTEGER NOT NULL,
+  -- Resumable-parse cursor + continuation (B-1). parser_state is a JSON
+  -- ClaudeParserState blob (offset + accumulator snapshot) so a scan can pick
+  -- up where the last one stopped; content_text caches the accumulated user
+  -- doc so detectTicket + FTS can rebuild on append without re-reading the file.
+  -- Written by B-2; B-1 only defines + round-trips them.
+  parser_state TEXT,
+  content_text TEXT
 );
 
 -- Tracks the mtime + entry-count of every LEAF directory that directly holds
@@ -351,6 +358,18 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
       );
       DELETE FROM scan_ledger;
     `);
+  }
+
+  if (fromVersion < 15) {
+    // v14 → v15: the Claude scan becomes resumable (B-1). scan_ledger gains a
+    // `parser_state` continuation blob (offset + accumulator snapshot) and a
+    // `content_text` cache of the accumulated user doc. Add both columns, then
+    // clear scan_ledger so the first post-upgrade scan does a clean full walk
+    // that reseeds the cursor from byte 0.
+    const cols = db.prepare(`PRAGMA table_info(scan_ledger)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'parser_state')) db.exec(`ALTER TABLE scan_ledger ADD COLUMN parser_state TEXT`);
+    if (!cols.some(c => c.name === 'content_text')) db.exec(`ALTER TABLE scan_ledger ADD COLUMN content_text TEXT`);
+    db.exec(`DELETE FROM scan_ledger;`);
   }
 }
 

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -3015,27 +3015,37 @@ export async function scanClaudeSessionIncremental(
 ): Promise<{ scan: ClaudeSessionScan; newState: ClaudeParserState; newOffset: number }> {
   const state = hydrateClaudeParseState(prior);
 
-  // Count bytes UP TO AND INCLUDING the last newline consumed, so a partial
-  // trailing line (no terminating '\n') is re-read on the next append rather
-  // than parsed against a truncated record.
-  let bytesToLastNewline = 0;
-  let pendingBytes = 0;
-  const stream = fs.createReadStream(filePath, { start: fromOffset, encoding: 'utf-8' });
-  stream.on('data', (chunk: string | Buffer) => {
-    const buf = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : chunk;
-    // Walk the raw bytes; every 0x0A advances the committed offset to include it.
-    for (let i = 0; i < buf.length; i++) {
-      pendingBytes++;
-      if (buf[i] === 0x0a) {
-        bytesToLastNewline += pendingBytes;
-        pendingBytes = 0;
-      }
-    }
-  });
-  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-
+  // Read the appended byte range and apply ONLY newline-terminated lines. The
+  // applied lines and `newOffset` MUST stay consistent: readline (like the full
+  // parse) would emit a trailing UNTERMINATED final line at EOF, but `newOffset`
+  // stops before it — so the next pass, after that record's '\n' is flushed,
+  // would re-read and re-apply the same line and double-count it (user events
+  // have no dedup, unlike assistant `seenAssistantIds`). A record written
+  // non-atomically — bytes first, then '\n' in a second write — is exactly this
+  // case. So we slice at the last '\n' ourselves: everything up to and including
+  // it is a run of complete lines we apply and commit; any tail after it
+  // (syntactically broken OR complete-but-not-yet-terminated) is a still-being-
+  // written record we DEFER to the next pass, once its '\n' lands.
+  const chunks: Buffer[] = [];
+  const stream = fs.createReadStream(filePath, { start: fromOffset });
   try {
-    for await (const line of rl) {
+    for await (const chunk of stream) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : chunk as Buffer);
+    }
+  } finally {
+    stream.destroy();
+  }
+  const appended = Buffer.concat(chunks);
+
+  // Bytes up to AND INCLUDING the last '\n' are the committed, complete-line run.
+  const lastNl = appended.lastIndexOf(0x0a);
+  const consumedBytes = lastNl === -1 ? 0 : lastNl + 1;
+
+  if (consumedBytes > 0) {
+    // split('\n') on the committed run: the element after the final '\n' is ''
+    // (skipped by the trim guard). A stray '\r' from CRLF is tolerated by the
+    // JSON.parse below exactly as the full parse tolerates it.
+    for (const line of appended.subarray(0, consumedBytes).toString('utf-8').split('\n')) {
       if (!line.trim()) continue;
 
       let parsed: any;
@@ -3047,12 +3057,9 @@ export async function scanClaudeSessionIncremental(
 
       applyClaudeLine(state, parsed);
     }
-  } finally {
-    rl.close();
-    stream.destroy();
   }
 
-  const newOffset = fromOffset + bytesToLastNewline;
+  const newOffset = fromOffset + consumedBytes;
   return {
     scan: finalizeClaudeScan(state),
     newState: serializeClaudeParserState(state, newOffset),

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -2560,48 +2560,274 @@ function extractDroidMessageText(content: any): string {
     .trim();
 }
 
+/**
+ * Mutable accumulator for the Claude transcript reducer. One field per local
+ * that {@link scanClaudeSession} previously declared inline — the reducer
+ * mutates `state.*` instead of closure locals so the exact same logic can drive
+ * both a full parse and a resumable incremental parse (see
+ * {@link scanClaudeSessionIncremental}).
+ */
+export interface ClaudeParseState {
+  timestamp?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  topic?: string;
+  // Explicit session titles: `/rename` writes a `custom-title` event; Claude
+  // auto-generates an `ai-title`. Both can repeat across the file — last wins.
+  customTitle?: string;
+  aiTitle?: string;
+  entrypoint?: string;
+  messageCount: number;
+  tokenCount: number;
+  outputTokens: number;
+  sawTokenCount: boolean;
+  costUsd: number;
+  sawCost: boolean;
+  // Track the first and last timestamped event to derive wall-clock duration.
+  firstTsMs?: number;
+  lastTsMs?: number;
+  seenAssistantIds: Set<string>;
+  userTexts: string[];
+  // Durable PR signal: set only when an actual `gh pr create` Bash *command*
+  // runs (structural — the command field, not any prose mentioning it), then
+  // capture the pull URL from a later tool_result's output.
+  sawPrCreate: boolean;
+  prUrl?: string;
+  prNumber?: number;
+  // Artifacts the session PRODUCED: tracker refs it created and any team it spawned.
+  // Ticket creation spans two events — a create_issue tool_use, then the tool_result
+  // carrying the new id — so we hold the pending tool_use ids until their result lands.
+  createdTickets: Set<string>;
+  pendingTicketTools: Set<string>;
+  spawnedTeam?: string;
+  // The LAST ExitPlanMode plan wins so a re-planned session surfaces its most
+  // recent plan, matching the semantic the extension's re-parser relied on.
+  plan?: string;
+}
+
+/** Zero-value accumulator for a fresh (from-byte-0) Claude parse. */
+export function initClaudeParseState(): ClaudeParseState {
+  return {
+    timestamp: undefined,
+    cwd: undefined,
+    gitBranch: undefined,
+    version: undefined,
+    topic: undefined,
+    customTitle: undefined,
+    aiTitle: undefined,
+    entrypoint: undefined,
+    messageCount: 0,
+    tokenCount: 0,
+    outputTokens: 0,
+    sawTokenCount: false,
+    costUsd: 0,
+    sawCost: false,
+    firstTsMs: undefined,
+    lastTsMs: undefined,
+    seenAssistantIds: new Set<string>(),
+    userTexts: [],
+    sawPrCreate: false,
+    prUrl: undefined,
+    prNumber: undefined,
+    createdTickets: new Set<string>(),
+    pendingTicketTools: new Set<string>(),
+    spawnedTeam: undefined,
+    plan: undefined,
+  };
+}
+
+/**
+ * Fold one parsed transcript line into the accumulator. This is the exact loop
+ * body {@link scanClaudeSession} used to run inline — extracted verbatim,
+ * mutating `state.*` in place. `parsed` is the already-`JSON.parse`d line (the
+ * malformed-line skip happens in the caller, as before).
+ */
+export function applyClaudeLine(state: ClaudeParseState, parsed: any): void {
+  // entrypoint ships on the first envelope event (attachment/user/assistant)
+  // and is the clean structural signal for "was this a team spawn?"
+  if (!state.entrypoint && typeof parsed.entrypoint === 'string') {
+    state.entrypoint = parsed.entrypoint;
+  }
+
+  // Produced-artifact signals, structurally (independent of the PR gate below):
+  //   - a Bash `agents teams create/add` command → the team it spawned
+  //   - a Linear create_issue / `gh issue create` tool_use → its result carries
+  //     the new ticket ref, read from the matching tool_result.
+  if (parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
+    for (const b of parsed.message.content) {
+      if (b?.type !== 'tool_use') continue;
+      if (!state.spawnedTeam && typeof b?.input?.command === 'string') {
+        const team = detectSpawnedTeam(b.input.command);
+        if (team) state.spawnedTeam = team;
+      }
+      if (typeof b?.id === 'string' && isTicketCreateTool(b?.name, b?.input?.command)) {
+        state.pendingTicketTools.add(b.id);
+      }
+      // ExitPlanMode plan markdown — last one wins so a re-planned session
+      // reports its most recent plan.
+      if (b?.name === 'ExitPlanMode' && typeof b?.input?.plan === 'string') {
+        const p = b.input.plan.trim();
+        if (p) state.plan = b.input.plan;
+      }
+    }
+  }
+  if (state.pendingTicketTools.size > 0 && parsed.type === 'user' && Array.isArray(parsed.message?.content)) {
+    for (const b of parsed.message.content) {
+      if (b?.type !== 'tool_result' || typeof b?.tool_use_id !== 'string') continue;
+      if (!state.pendingTicketTools.has(b.tool_use_id)) continue;
+      state.pendingTicketTools.delete(b.tool_use_id);
+      const text = typeof b.content === 'string'
+        ? b.content
+        : Array.isArray(b.content) ? b.content.map((c: any) => c?.text || '').join('\n') : '';
+      const t = extractCreatedTicket(text);
+      if (t) state.createdTickets.add(t);
+    }
+  }
+
+  // PR signal, structurally: a Bash tool_use whose command is `gh pr create`
+  // marks intent; the pull URL is then read from a tool_result's output.
+  if (!state.prUrl) {
+    if (!state.sawPrCreate && parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
+      for (const b of parsed.message.content) {
+        if (b?.type === 'tool_use' && typeof b?.input?.command === 'string' && isPrCreateCommand(b.input.command)) {
+          state.sawPrCreate = true;
+        }
+      }
+    }
+    if (state.sawPrCreate && parsed.type === 'user' && Array.isArray(parsed.message?.content)) {
+      for (const b of parsed.message.content) {
+        if (b?.type !== 'tool_result') continue;
+        const text = typeof b.content === 'string'
+          ? b.content
+          : Array.isArray(b.content) ? b.content.map((c: any) => c?.text || '').join('\n') : '';
+        const pr = extractPrUrl(text);
+        if (pr) { state.prUrl = pr.url; state.prNumber = pr.number; }
+      }
+    }
+  }
+
+  // Track duration across every timestamped event, not just the first.
+  if (typeof parsed.timestamp === 'string') {
+    const ms = new Date(parsed.timestamp).getTime();
+    if (!Number.isNaN(ms)) {
+      if (state.firstTsMs === undefined || ms < state.firstTsMs) state.firstTsMs = ms;
+      if (state.lastTsMs === undefined || ms > state.lastTsMs) state.lastTsMs = ms;
+    }
+  }
+
+  if (!state.timestamp && (parsed.type === 'user' || parsed.type === 'assistant') && parsed.timestamp) {
+    state.timestamp = parsed.timestamp;
+    state.cwd = parsed.cwd || '';
+    state.gitBranch = parsed.gitBranch || undefined;
+    state.version = parsed.version || undefined;
+  }
+
+  if (parsed.type === 'custom-title') {
+    const t = typeof parsed.customTitle === 'string' ? parsed.customTitle.trim() : '';
+    if (t) state.customTitle = t;
+    return;
+  }
+  if (parsed.type === 'ai-title') {
+    const t = typeof parsed.aiTitle === 'string' ? parsed.aiTitle.trim() : '';
+    if (t) state.aiTitle = t;
+    return;
+  }
+
+  if (parsed.type === 'user') {
+    const text = extractClaudeUserText(parsed);
+    if (text) {
+      state.messageCount++;
+      state.userTexts.push(text);
+      if (!state.topic) state.topic = extractSessionTopic(text);
+    }
+    return;
+  }
+
+  if (parsed.type !== 'assistant') return;
+
+  const assistantId = typeof parsed.message?.id === 'string'
+    ? parsed.message.id
+    : typeof parsed.uuid === 'string'
+      ? parsed.uuid
+      : undefined;
+
+  const logicalId = assistantId || `${parsed.timestamp || ''}:${state.seenAssistantIds.size}`;
+  if (state.seenAssistantIds.has(logicalId)) return;
+  state.seenAssistantIds.add(logicalId);
+  state.messageCount++;
+
+  const usageObj = parsed.message?.usage || parsed.usage;
+  const usage = getClaudeUsageTotal(usageObj);
+  if (usage !== null) {
+    state.tokenCount += usage;
+    state.sawTokenCount = true;
+  }
+  if (typeof usageObj?.output_tokens === 'number') state.outputTokens += usageObj.output_tokens;
+  // Per-assistant-message cost: each event carries its own model, so we
+  // multiply that event's raw token directions by that model's price.
+  const model = parsed.message?.model;
+  if (model && usageObj && typeof usageObj === 'object') {
+    const eventCost = costOfUsage({
+      model,
+      inputTokens: usageObj.input_tokens,
+      outputTokens: usageObj.output_tokens,
+      cacheReadTokens: usageObj.cache_read_input_tokens,
+      cacheCreationTokens: usageObj.cache_creation_input_tokens,
+    });
+    if (eventCost > 0) {
+      state.costUsd += eventCost;
+      state.sawCost = true;
+    }
+  }
+}
+
+/**
+ * Build the {@link ClaudeSessionScan} return object from an accumulator. This is
+ * the exact return-building {@link scanClaudeSession} used to run inline.
+ */
+export function finalizeClaudeScan(state: ClaudeParseState): ClaudeSessionScan {
+  const durationMs =
+    state.firstTsMs !== undefined && state.lastTsMs !== undefined && state.lastTsMs > state.firstTsMs
+      ? state.lastTsMs - state.firstTsMs
+      : undefined;
+
+  // Prefer an explicit session title (user `/rename` > Claude auto-title) over
+  // the first-prompt topic.
+  const resolvedTopic = state.customTitle || state.aiTitle || state.topic;
+  const worktree = detectWorktree(state.cwd, state.gitBranch);
+  const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
+
+  return {
+    timestamp: state.timestamp,
+    cwd: state.cwd,
+    gitBranch: state.gitBranch,
+    version: state.version,
+    topic: resolvedTopic,
+    entrypoint: state.entrypoint,
+    messageCount: state.messageCount,
+    tokenCount: state.sawTokenCount ? state.tokenCount : undefined,
+    outputTokens: state.sawTokenCount ? state.outputTokens : undefined,
+    costUsd: state.sawCost ? state.costUsd : undefined,
+    durationMs,
+    lastActivity: state.lastTsMs !== undefined ? new Date(state.lastTsMs).toISOString() : undefined,
+    contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,
+    prUrl: state.prUrl,
+    prNumber: state.prNumber,
+    worktreeSlug: worktree?.slug,
+    ticketId: ticket?.id,
+    createdTickets: state.createdTickets.size > 0 ? [...state.createdTickets] : undefined,
+    spawnedTeam: state.spawnedTeam,
+    plan: state.plan,
+  };
+}
+
 /** Stream a Claude JSONL file and extract scan-level metadata (timestamp, cwd, topic, tokens). */
 export async function scanClaudeSession(filePath: string): Promise<ClaudeSessionScan> {
   const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
-  let timestamp: string | undefined;
-  let cwd: string | undefined;
-  let gitBranch: string | undefined;
-  let version: string | undefined;
-  let topic: string | undefined;
-  // Explicit session titles: `/rename` writes a `custom-title` event; Claude
-  // auto-generates an `ai-title`. Both can repeat across the file — last wins.
-  let customTitle: string | undefined;
-  let aiTitle: string | undefined;
-  let entrypoint: string | undefined;
-  let messageCount = 0;
-  let tokenCount = 0;
-  let outputTokens = 0;
-  let sawTokenCount = false;
-  let costUsd = 0;
-  let sawCost = false;
-  // Track the first and last timestamped event to derive wall-clock duration.
-  let firstTsMs: number | undefined;
-  let lastTsMs: number | undefined;
-  const seenAssistantIds = new Set<string>();
-  const userTexts: string[] = [];
-  // Durable PR signal: set only when an actual `gh pr create` Bash *command*
-  // runs (structural — the command field, not any prose mentioning it), then
-  // capture the pull URL from a later tool_result's output.
-  let sawPrCreate = false;
-  let prUrl: string | undefined;
-  let prNumber: number | undefined;
-
-  // Artifacts the session PRODUCED: tracker refs it created and any team it spawned.
-  // Ticket creation spans two events — a create_issue tool_use, then the tool_result
-  // carrying the new id — so we hold the pending tool_use ids until their result lands.
-  const createdTickets = new Set<string>();
-  const pendingTicketTools = new Set<string>();
-  let spawnedTeam: string | undefined;
-  // The LAST ExitPlanMode plan wins so a re-planned session surfaces its most
-  // recent plan, matching the semantic the extension's re-parser relied on.
-  let plan: string | undefined;
+  const state = initClaudeParseState();
 
   try {
     for await (const line of rl) {
@@ -2614,180 +2840,223 @@ export async function scanClaudeSession(filePath: string): Promise<ClaudeSession
         continue;
       }
 
-      // entrypoint ships on the first envelope event (attachment/user/assistant)
-      // and is the clean structural signal for "was this a team spawn?"
-      if (!entrypoint && typeof parsed.entrypoint === 'string') {
-        entrypoint = parsed.entrypoint;
-      }
-
-      // Produced-artifact signals, structurally (independent of the PR gate below):
-      //   - a Bash `agents teams create/add` command → the team it spawned
-      //   - a Linear create_issue / `gh issue create` tool_use → its result carries
-      //     the new ticket ref, read from the matching tool_result.
-      if (parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
-        for (const b of parsed.message.content) {
-          if (b?.type !== 'tool_use') continue;
-          if (!spawnedTeam && typeof b?.input?.command === 'string') {
-            const team = detectSpawnedTeam(b.input.command);
-            if (team) spawnedTeam = team;
-          }
-          if (typeof b?.id === 'string' && isTicketCreateTool(b?.name, b?.input?.command)) {
-            pendingTicketTools.add(b.id);
-          }
-          // ExitPlanMode plan markdown — last one wins so a re-planned session
-          // reports its most recent plan.
-          if (b?.name === 'ExitPlanMode' && typeof b?.input?.plan === 'string') {
-            const p = b.input.plan.trim();
-            if (p) plan = b.input.plan;
-          }
-        }
-      }
-      if (pendingTicketTools.size > 0 && parsed.type === 'user' && Array.isArray(parsed.message?.content)) {
-        for (const b of parsed.message.content) {
-          if (b?.type !== 'tool_result' || typeof b?.tool_use_id !== 'string') continue;
-          if (!pendingTicketTools.has(b.tool_use_id)) continue;
-          pendingTicketTools.delete(b.tool_use_id);
-          const text = typeof b.content === 'string'
-            ? b.content
-            : Array.isArray(b.content) ? b.content.map((c: any) => c?.text || '').join('\n') : '';
-          const t = extractCreatedTicket(text);
-          if (t) createdTickets.add(t);
-        }
-      }
-
-      // PR signal, structurally: a Bash tool_use whose command is `gh pr create`
-      // marks intent; the pull URL is then read from a tool_result's output.
-      if (!prUrl) {
-        if (!sawPrCreate && parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
-          for (const b of parsed.message.content) {
-            if (b?.type === 'tool_use' && typeof b?.input?.command === 'string' && isPrCreateCommand(b.input.command)) {
-              sawPrCreate = true;
-            }
-          }
-        }
-        if (sawPrCreate && parsed.type === 'user' && Array.isArray(parsed.message?.content)) {
-          for (const b of parsed.message.content) {
-            if (b?.type !== 'tool_result') continue;
-            const text = typeof b.content === 'string'
-              ? b.content
-              : Array.isArray(b.content) ? b.content.map((c: any) => c?.text || '').join('\n') : '';
-            const pr = extractPrUrl(text);
-            if (pr) { prUrl = pr.url; prNumber = pr.number; }
-          }
-        }
-      }
-
-      // Track duration across every timestamped event, not just the first.
-      if (typeof parsed.timestamp === 'string') {
-        const ms = new Date(parsed.timestamp).getTime();
-        if (!Number.isNaN(ms)) {
-          if (firstTsMs === undefined || ms < firstTsMs) firstTsMs = ms;
-          if (lastTsMs === undefined || ms > lastTsMs) lastTsMs = ms;
-        }
-      }
-
-      if (!timestamp && (parsed.type === 'user' || parsed.type === 'assistant') && parsed.timestamp) {
-        timestamp = parsed.timestamp;
-        cwd = parsed.cwd || '';
-        gitBranch = parsed.gitBranch || undefined;
-        version = parsed.version || undefined;
-      }
-
-      if (parsed.type === 'custom-title') {
-        const t = typeof parsed.customTitle === 'string' ? parsed.customTitle.trim() : '';
-        if (t) customTitle = t;
-        continue;
-      }
-      if (parsed.type === 'ai-title') {
-        const t = typeof parsed.aiTitle === 'string' ? parsed.aiTitle.trim() : '';
-        if (t) aiTitle = t;
-        continue;
-      }
-
-      if (parsed.type === 'user') {
-        const text = extractClaudeUserText(parsed);
-        if (text) {
-          messageCount++;
-          userTexts.push(text);
-          if (!topic) topic = extractSessionTopic(text);
-        }
-        continue;
-      }
-
-      if (parsed.type !== 'assistant') continue;
-
-      const assistantId = typeof parsed.message?.id === 'string'
-        ? parsed.message.id
-        : typeof parsed.uuid === 'string'
-          ? parsed.uuid
-          : undefined;
-
-      const logicalId = assistantId || `${parsed.timestamp || ''}:${seenAssistantIds.size}`;
-      if (seenAssistantIds.has(logicalId)) continue;
-      seenAssistantIds.add(logicalId);
-      messageCount++;
-
-      const usageObj = parsed.message?.usage || parsed.usage;
-      const usage = getClaudeUsageTotal(usageObj);
-      if (usage !== null) {
-        tokenCount += usage;
-        sawTokenCount = true;
-      }
-      if (typeof usageObj?.output_tokens === 'number') outputTokens += usageObj.output_tokens;
-      // Per-assistant-message cost: each event carries its own model, so we
-      // multiply that event's raw token directions by that model's price.
-      const model = parsed.message?.model;
-      if (model && usageObj && typeof usageObj === 'object') {
-        const eventCost = costOfUsage({
-          model,
-          inputTokens: usageObj.input_tokens,
-          outputTokens: usageObj.output_tokens,
-          cacheReadTokens: usageObj.cache_read_input_tokens,
-          cacheCreationTokens: usageObj.cache_creation_input_tokens,
-        });
-        if (eventCost > 0) {
-          costUsd += eventCost;
-          sawCost = true;
-        }
-      }
+      applyClaudeLine(state, parsed);
     }
   } finally {
     rl.close();
     stream.destroy();
   }
 
-  const durationMs =
-    firstTsMs !== undefined && lastTsMs !== undefined && lastTsMs > firstTsMs
-      ? lastTsMs - firstTsMs
-      : undefined;
+  return finalizeClaudeScan(state);
+}
 
-  // Prefer an explicit session title (user `/rename` > Claude auto-title) over
-  // the first-prompt topic.
-  const resolvedTopic = customTitle || aiTitle || topic;
-  const worktree = detectWorktree(cwd, gitBranch);
-  const ticket = detectTicket(userTexts.join('\n') || undefined, gitBranch);
+/**
+ * SERIALIZED continuation blob persisted in `scan_ledger.parser_state`. Carries
+ * everything {@link hydrateClaudeParseState} needs to resume a parse from
+ * `offset` such that resuming + applying the appended lines is byte-for-byte
+ * identical to a full parse of the whole file.
+ *
+ * `seenAssistantIds` is persisted as a size counter plus a bounded FIFO window
+ * of the most-recent ids: the fallback logical id `${ts}:${seenAssistantIds.size}`
+ * (see {@link applyClaudeLine}) depends on the set's *size*, so the size must be
+ * exact even when the recent window is smaller than the true count.
+ */
+export interface ClaudeParserState {
+  v: 1;
+  offset: number;
+  timestamp?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  entrypoint?: string;
+  firstTsMs?: number;
+  topic?: string;
+  customTitle?: string;
+  aiTitle?: string;
+  plan?: string;
+  lastTsMs?: number;
+  messageCount: number;
+  tokenCount: number;
+  outputTokens: number;
+  sawTokenCount: boolean;
+  sawCost: boolean;
+  costUsd: number;
+  seenIdsSize: number;
+  seenIdsRecent: string[];
+  sawPrCreate: boolean;
+  prUrl?: string;
+  prNumber?: number;
+  pendingTicketTools: string[];
+  createdTickets: string[];
+  spawnedTeam?: string;
+  ticketId?: string;
+  contentText?: string;
+}
 
+/** Cap on the FIFO window of recent assistant ids persisted in the continuation. */
+const SEEN_IDS_RECENT_CAP = 256;
+
+/**
+ * Snapshot a live {@link ClaudeParseState} into its serializable form at
+ * `offset` bytes consumed. Round-trips through {@link hydrateClaudeParseState}
+ * so incremental replay equals a full parse.
+ */
+export function serializeClaudeParserState(state: ClaudeParseState, offset: number): ClaudeParserState {
+  const allIds = [...state.seenAssistantIds];
+  const seenIdsRecent = allIds.length > SEEN_IDS_RECENT_CAP
+    ? allIds.slice(allIds.length - SEEN_IDS_RECENT_CAP)
+    : allIds;
+  const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
   return {
-    timestamp,
-    cwd,
-    gitBranch,
-    version,
-    topic: resolvedTopic,
-    entrypoint,
-    messageCount,
-    tokenCount: sawTokenCount ? tokenCount : undefined,
-    outputTokens: sawTokenCount ? outputTokens : undefined,
-    costUsd: sawCost ? costUsd : undefined,
-    durationMs,
-    lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
-    contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
-    prUrl,
-    prNumber,
-    worktreeSlug: worktree?.slug,
+    v: 1,
+    offset,
+    timestamp: state.timestamp,
+    cwd: state.cwd,
+    gitBranch: state.gitBranch,
+    version: state.version,
+    entrypoint: state.entrypoint,
+    firstTsMs: state.firstTsMs,
+    topic: state.topic,
+    customTitle: state.customTitle,
+    aiTitle: state.aiTitle,
+    plan: state.plan,
+    lastTsMs: state.lastTsMs,
+    messageCount: state.messageCount,
+    tokenCount: state.tokenCount,
+    outputTokens: state.outputTokens,
+    sawTokenCount: state.sawTokenCount,
+    sawCost: state.sawCost,
+    costUsd: state.costUsd,
+    seenIdsSize: state.seenAssistantIds.size,
+    seenIdsRecent,
+    sawPrCreate: state.sawPrCreate,
+    prUrl: state.prUrl,
+    prNumber: state.prNumber,
+    pendingTicketTools: [...state.pendingTicketTools],
+    createdTickets: [...state.createdTickets],
+    spawnedTeam: state.spawnedTeam,
+    // ticketId is derived at finalize time; persist it (and content_text) so a
+    // consumer (B-2) can rebuild the row + FTS doc on append without re-reading
+    // the whole file. worktreeSlug is re-derived from cwd/gitBranch, so it need
+    // not be persisted.
     ticketId: ticket?.id,
-    createdTickets: createdTickets.size > 0 ? [...createdTickets] : undefined,
-    spawnedTeam,
-    plan,
+    contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,
+  };
+}
+
+/**
+ * Rebuild a live {@link ClaudeParseState} from a persisted continuation so that
+ * applying the appended lines yields the same accumulator a full parse would.
+ *
+ * `seenAssistantIds` is rehydrated from the recent-id FIFO window, then padded
+ * with unique sentinel entries so its `.size` matches the true prior count
+ * (`seenIdsSize`) — the fallback id `${ts}:${size}` must line up with the full
+ * parse even when the window dropped older ids. Padding sentinels can never
+ * collide with a real logical id (real ids are message ids/uuids or
+ * `${ts}:${n}`; the sentinel prefix is not JSON-line-derived).
+ *
+ * `userTexts` is rehydrated as a single joined blob from `contentText`: only
+ * `userTexts.join('\n')` (detectTicket + contentText) and `userTexts.length > 0`
+ * are ever read downstream, and both are preserved by a one-element array
+ * holding the joined content.
+ */
+export function hydrateClaudeParseState(prior: ClaudeParserState): ClaudeParseState {
+  const seen = new Set<string>(prior.seenIdsRecent);
+  // Pad to the true prior size so `seenAssistantIds.size` (which feeds the
+  // fallback logical id) is exact even when older ids fell out of the window.
+  let pad = 0;
+  while (seen.size < prior.seenIdsSize) {
+    seen.add(` pad:${pad++}`);
+  }
+  return {
+    timestamp: prior.timestamp,
+    cwd: prior.cwd,
+    gitBranch: prior.gitBranch,
+    version: prior.version,
+    topic: prior.topic,
+    customTitle: prior.customTitle,
+    aiTitle: prior.aiTitle,
+    entrypoint: prior.entrypoint,
+    messageCount: prior.messageCount,
+    tokenCount: prior.tokenCount,
+    outputTokens: prior.outputTokens,
+    sawTokenCount: prior.sawTokenCount,
+    costUsd: prior.costUsd,
+    sawCost: prior.sawCost,
+    firstTsMs: prior.firstTsMs,
+    lastTsMs: prior.lastTsMs,
+    seenAssistantIds: seen,
+    userTexts: prior.contentText !== undefined && prior.contentText.length > 0 ? [prior.contentText] : [],
+    sawPrCreate: prior.sawPrCreate,
+    prUrl: prior.prUrl,
+    prNumber: prior.prNumber,
+    createdTickets: new Set<string>(prior.createdTickets),
+    pendingTicketTools: new Set<string>(prior.pendingTicketTools),
+    spawnedTeam: prior.spawnedTeam,
+    plan: prior.plan,
+  };
+}
+
+/**
+ * Resume a Claude parse from `fromOffset` bytes into the file, folding only the
+ * newly-appended lines into `prior`. Returns the finalized scan, the next
+ * serialized continuation, and the byte offset to resume from next time —
+ * `newOffset` stops at the last `'\n'` seen so a half-written trailing record is
+ * re-read (not lost) on the next append.
+ *
+ * NOT wired into the live scan path yet (that is B-2); {@link scanClaudeSession}
+ * remains the only caller-facing entry point. This exists so the parity harness
+ * can prove full === hydrate(state@k) + apply(k+1..n).
+ */
+export async function scanClaudeSessionIncremental(
+  filePath: string,
+  fromOffset: number,
+  prior: ClaudeParserState,
+): Promise<{ scan: ClaudeSessionScan; newState: ClaudeParserState; newOffset: number }> {
+  const state = hydrateClaudeParseState(prior);
+
+  // Count bytes UP TO AND INCLUDING the last newline consumed, so a partial
+  // trailing line (no terminating '\n') is re-read on the next append rather
+  // than parsed against a truncated record.
+  let bytesToLastNewline = 0;
+  let pendingBytes = 0;
+  const stream = fs.createReadStream(filePath, { start: fromOffset, encoding: 'utf-8' });
+  stream.on('data', (chunk: string | Buffer) => {
+    const buf = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : chunk;
+    // Walk the raw bytes; every 0x0A advances the committed offset to include it.
+    for (let i = 0; i < buf.length; i++) {
+      pendingBytes++;
+      if (buf[i] === 0x0a) {
+        bytesToLastNewline += pendingBytes;
+        pendingBytes = 0;
+      }
+    }
+  });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      applyClaudeLine(state, parsed);
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+
+  const newOffset = fromOffset + bytesToLastNewline;
+  return {
+    scan: finalizeClaudeScan(state),
+    newState: serializeClaudeParserState(state, newOffset),
+    newOffset,
   };
 }
 


### PR DESCRIPTION
## What

Make the Claude transcript parser **resumable**, with a **provable full-parse parity** harness — without changing the live scan path's behavior yet (that is B-2). This PR is a behavior-identical refactor plus new, unwired plumbing.

### 1. Pure-reducer refactor (behavior-identical)
`scanClaudeSession`'s inline accumulator + per-line loop body + return-building are extracted into:
- `initClaudeParseState()` — zero-value accumulator
- `applyClaudeLine(state, parsed)` — the loop body verbatim (locals -> `state.*`, logic unchanged)
- `finalizeClaudeScan(state)` — the return-building verbatim

`scanClaudeSession` is rebuilt on top: init -> stream -> apply each -> finalize. Output is byte-for-byte unchanged, which the entire existing session suite (green) confirms.

### 2. `scanClaudeSessionIncremental` (NOT wired into the scan path)
`scanClaudeSessionIncremental(filePath, fromOffset, prior)` drives the **same** reducer over `createReadStream({ start: fromOffset })` and returns `{ scan, newState, newOffset }`. `newOffset` stops at the last `'\n'` consumed, so a half-written trailing record is re-read on the next append rather than parsed truncated. It is **not** called from `filterChangedEntries` / `readClaudeMeta` / `scanClaudeIncremental` — the live path is untouched this PR.

The serialized `ClaudeParserState` continuation + `serializeClaudeParserState` / `hydrateClaudeParseState` round-trip everything parity needs: the `seenAssistantIds` size (a bounded ~256 recent-id FIFO **plus** a size counter, so the `${ts}:${size}` fallback logical id lines up even when older ids fall out of the window), open `pendingTicketTools`, `sawPrCreate`/`prUrl`/`prNumber`, last-wins `customTitle`/`aiTitle`/`plan`, first-wins `timestamp`/`cwd`/`entrypoint`, counter bases, and `content_text`.

### 3. Schema columns for B-2 (schema v15)
`SCHEMA_VERSION` 14 -> 15. `scan_ledger` gains `parser_state TEXT` (the JSON continuation: offset + accumulator snapshot) and `content_text TEXT` (the accumulated user doc so `detectTicket` + FTS can rebuild on append without re-reading the file). Added to the `SCHEMA` const (fresh DBs) and a `if (fromVersion < 15)` migration that ALTERs the columns (guarded by `PRAGMA table_info`) and `DELETE FROM scan_ledger;` so the first post-upgrade scan reseeds the cursor from byte 0. Columns are defined + round-tripped here; **B-2 writes them on the live path.**

### 4. Differential parity harness (the gate)
`__tests__/incremental-parity.test.ts` asserts incremental replay across real-file appends equals the full parse for **every** `ClaudeSessionScan` field. Matrix:
1. boundary sweep — split at every line index (+ line-by-line)
2. fallback-id stress — shared timestamp / no `message.id`/`uuid`, incl. > the 256 recent-id window so `seenIdsSize` carries the true count
3. straddled PR-create — `gh pr create` tool_use ch1, tool_result URL ch2 -> `prUrl`/`prNumber`
4. straddled ticket — `create_issue` tool_use ch1, result ref ch2 -> `createdTickets` (+ straddled `spawnedTeam`)
5. title/plan after the boundary -> `topic`/`plan`, and a title-less tail must **not** null a prior title
6. `content_text` parity + continuation round-trip
7. truncation (file shrinks below the stored offset) -> full reparse from offset 0
8. partial trailing line -> `newOffset` stops at the last `'\n'`, the half-line re-consumed on the next append

Real temp files, real fs, no mocks.

## Scan path is unchanged

Nothing in `filterChangedEntries` / `readClaudeMeta` / `scanClaudeIncremental` calls the incremental function. `scanClaudeSession` remains the only caller-facing entry point, and the existing session suite stays green — that is what proves the refactor is behavior-identical.

## Testing

```
cd apps/cli && bun install
npx tsc --noEmit            # clean
npx vitest run src/lib/session/
#   Test Files  62 passed (62)
#        Tests  698 passed (698)
```
Stable across 3 consecutive runs. The new parity harness is 13 tests; the schema bump adds one migration-column assertion. The 4 pre-existing repo-wide failures (exec/models/non-interactive tests) reproduce on clean origin/main, are outside `src/lib/session/`, and are unrelated to this change — not chased here.

## Notes

- No user-visible surface yet (internal plumbing for B-2), so a CHANGELOG fragment is optional/omitted; the **schema v15 bump** is noted here for reviewers.
- No mocking; real fs + real sqlite under temp HOME, following the existing migrate/discover test patterns.