### PR TITLE
perf(session): incremental Claude transcript parse on the live scan path

### DIFF
--- a/apps/cli/.changelog/next/incremental-claude-parse.md
+++ b/apps/cli/.changelog/next/incremental-claude-parse.md
@@ -1,0 +1,15 @@
+- **Incremental Claude transcript parsing on the live scan path.** When an active
+  Claude session grows, `agents sessions` (and every consumer that scans:
+  `output` / `view` / `teams` / the watcher) now re-parses only the newly-appended
+  bytes instead of re-reading the whole transcript from the top. The scan persists
+  a resumable continuation (`parser_state` + `content_text`, schema v15) in the
+  `scan_ledger`; the next scan resumes from the saved byte offset when the file
+  merely grew and its mtime did not go backwards, and falls back to a full reparse
+  from byte 0 on a cold start, a truncation / rewrite (size shrank), or a clock
+  rewind. Both paths run through one shared reducer, so the indexed row an append
+  produces is identical, field for field, to a from-scratch full reparse — token
+  counts, cost, duration, topic/title, PR + ticket refs, and FTS content all match
+  even when a signal straddles two scans (a `gh pr create` in one write and its URL
+  in the next). Only the Claude scanner is wired for now (Codex / Kimi are
+  follow-ups); the other scanners are unchanged. Source:
+  `apps/cli/src/lib/session/discover.ts`, `apps/cli/src/lib/session/db.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -42,6 +42,8 @@ agents sessions [query] [--json] [--since 1h] [--all]
 │       Else -> readdir + stat each file:                             │
 │         If unchanged since last scan -> skip (DB row is fresh)      │
 │         Else -> parse file, upsert sessions row + FTS5 content row  │
+│           (Claude: resume from the saved byte offset & parse only   │
+│            the appended lines when the file merely grew)            │
 │                                                                     │
 │  3. SQL query with filters (agent, cwd, since, project, limit)      │
 │     FTS5 search if [query] given, BM25 ranked                       │
@@ -60,6 +62,19 @@ was scanned within the last 10 minutes, so an in-place append is never missed. A
 create / delete / rename bumps the dir mtime and forces a full re-walk of that dir.
 Set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to disable the short-circuit and force the old
 full per-file walk.
+
+When a **Claude** transcript that already has an index row grows, the scan does
+not re-read it from the top. The `scan_ledger` stores a resumable continuation
+(`parser_state` — a byte offset plus an accumulator snapshot — and `content_text`,
+the accumulated user doc); the next scan resumes from that offset and folds in only
+the newly-appended lines. It falls back to a **full reparse from byte 0** when the
+file has no prior continuation (cold start), shrank at or below the saved offset
+(truncation / rewrite), or its mtime went backwards (clock rewind / restore). Full
+and incremental parses run through the same reducer, so the indexed row an append
+produces — token counts, cost, duration, topic/title, PR + ticket refs, FTS content
+— is identical to a from-scratch full reparse, even when a signal straddles two
+scans. Only the Claude scanner is incremental today; the other agents still full-parse
+each changed file.
 
 ## SessionMeta (list output)
 

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -63,6 +63,11 @@ The **transcript** side is a SQLite index (`~/.agents/.history/sessions/sessions
 `scan_ledger` that re-reads a file only when its `mtime`/`size` changed, a
 `dir_ledger` that skips the per-file `stat` of a leaf transcript directory whose
 `(mtime, entry_count)` is unchanged, plus a `session_text` FTS5 table for search.
+For **Claude**, a changed file that merely grew is parsed **incrementally**: the
+`scan_ledger` also stores a resumable continuation (`parser_state` + `content_text`)
+so the next scan resumes from the saved byte offset and folds in only the appended
+lines — falling back to a full reparse on a truncation / rewrite or a clock rewind.
+Both paths share one reducer, so the incremental row is identical to a full reparse.
 Listing is a DB read; only opening one session fully re-parses its transcript.
 Detail in [05-sessions.md](05-sessions.md).
 

--- a/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
@@ -1,0 +1,372 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// End-to-end parity for the LIVE Claude scan path (B-2). Proves that wiring
+// scanClaudeSessionIncremental into discoverSessions produces a DB row that is
+// IDENTICAL, field for field, to a from-scratch FULL reparse — even when PR /
+// ticket / title signals STRADDLE two scans, and that a truncation forces a full
+// reparse. Real fs, real sqlite, real discovery under a throwaway HOME. No mocks.
+//
+// The from-scratch ground truth is computed inside the SAME DB by writing the
+// final file content to a DIFFERENT session id (no prior ledger row → the code
+// takes the FULL path for it) and comparing its row to the incrementally-scanned
+// session's row. Every field except the id/short-id/filePath must match.
+
+const REAL_HOME = process.env.HOME;
+const REAL_USERPROFILE = process.env.USERPROFILE;
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-inc-e2e-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+type Discover = typeof import('../discover.js');
+type DB = typeof import('../db.js');
+
+let discover: Discover;
+let db: DB;
+
+// The live Claude root — the only tree Claude appends to in place, so every file
+// under it is treated as hot and an in-place append is always re-detected.
+const LIVE_PROJECTS = path.join(tmpHome, '.claude', 'projects');
+const PROJECT_DIR = path.join(LIVE_PROJECTS, '-home-u-repo');
+
+function line(obj: object): string {
+  return JSON.stringify(obj);
+}
+
+/** Path of a session's transcript file under the live project dir. */
+function sessionFile(id: string): string {
+  return path.join(PROJECT_DIR, `${id}.jsonl`);
+}
+
+/** Write a whole transcript (array of events) as newline-terminated JSONL. */
+function writeTranscript(id: string, events: object[]): string {
+  fs.mkdirSync(PROJECT_DIR, { recursive: true });
+  const fp = sessionFile(id);
+  fs.writeFileSync(fp, events.map(line).join('\n') + '\n', 'utf-8');
+  bumpMtimeToNow(fp, 0);
+  return fp;
+}
+
+/** Append more events (newline-terminated) to an existing transcript. */
+function appendTranscript(id: string, events: object[]): void {
+  fs.appendFileSync(sessionFile(id), events.map(line).join('\n') + '\n', 'utf-8');
+}
+
+/**
+ * Push a file's mtime forward by `plusSeconds` past now so an append is never
+ * seen as a clock-rewind, and so the ledger stamp actually changes (a second
+ * write inside the same wall-clock second can leave mtime identical, which the
+ * ledger reads as "unchanged" and skips).
+ */
+function bumpMtimeToNow(fp: string, plusSeconds: number): void {
+  const t = Math.floor(Date.now() / 1000) + plusSeconds;
+  fs.utimesSync(fp, t, t);
+}
+
+/**
+ * Push every ledger row's scanned_at back past the 5s active-append debounce so a
+ * grown file re-scanned in the same test tick is NOT deferred by
+ * shouldDeferRecentAppend. Real appends arrive seconds apart; the test compresses
+ * that by aging the stamp instead of sleeping. Run before every scan — harmless
+ * on a cold ledger (no rows to age).
+ */
+function agePriorScans(): void {
+  db.getDB().prepare('UPDATE scan_ledger SET scanned_at = ?').run(Date.now() - 60_000);
+}
+
+async function runScan(): Promise<void> {
+  agePriorScans();
+  await discover.discoverSessions({ agent: 'claude', all: true });
+}
+
+/** The set of session-row fields that MUST match between incremental + full. */
+const PARITY_FIELDS = [
+  'agent', 'timestamp', 'lastActivity', 'project', 'cwd', 'gitBranch', 'version',
+  'topic', 'messageCount', 'tokenCount', 'outputTokens', 'costUsd', 'durationMs',
+  'isTeamOrigin', 'prUrl', 'prNumber', 'worktreeSlug', 'ticketId', 'createdTickets',
+  'spawnedTeam', 'plan',
+] as const;
+
+function assertRowParity(incId: string, fullId: string): void {
+  const inc = db.getSessionById(incId);
+  const full = db.getSessionById(fullId);
+  expect(inc, `incremental row ${incId} exists`).not.toBeNull();
+  expect(full, `full-reparse row ${fullId} exists`).not.toBeNull();
+  for (const f of PARITY_FIELDS) {
+    expect((inc as any)[f], `field ${f}`).toEqual((full as any)[f]);
+  }
+}
+
+/**
+ * Compute the from-scratch ground truth for a set of events: write them to a
+ * brand-new id (no prior ledger continuation → FULL parse), scan, and return
+ * that id so its row can be compared field-for-field.
+ */
+let groundTruthCounter = 0;
+async function groundTruth(events: object[]): Promise<string> {
+  const id = `ground-truth-${groundTruthCounter++}`;
+  writeTranscript(id, events);
+  await runScan();
+  return id;
+}
+
+beforeAll(async () => {
+  db = await import('../db.js');
+  discover = await import('../discover.js');
+  db.getDB(); // create schema
+});
+
+beforeEach(() => {
+  discover.__resetClaudeScanBranchCountsForTest();
+});
+
+afterAll(() => {
+  if (REAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = REAL_HOME;
+  if (REAL_USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = REAL_USERPROFILE;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// A field-rich first chunk: a user turn, assistant events with usage/cost, a plan.
+function baseEvents(id: string): object[] {
+  return [
+    { type: 'user', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/home/u/repo', gitBranch: 'RUSH-42-fix', version: '2.1.0', entrypoint: 'cli', message: { role: 'user', content: `investigate flaky exec test for ${id}` } },
+    { type: 'assistant', timestamp: '2026-06-28T00:01:00.000Z', uuid: `${id}-a1`, message: { id: `${id}-msg1`, model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'looking' }], usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5, cache_creation_input_tokens: 3 } } },
+    { type: 'assistant', timestamp: '2026-06-28T00:02:00.000Z', uuid: `${id}-a2`, message: { id: `${id}-msg2`, model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: `${id}-plan1`, name: 'ExitPlanMode', input: { plan: '# Plan\n- step one' } }], usage: { input_tokens: 50, output_tokens: 10 } } },
+  ];
+}
+
+// The appended chunk: a second user turn, a title, more assistant tokens.
+function appendedEvents(id: string): object[] {
+  return [
+    { type: 'user', timestamp: '2026-06-28T00:03:00.000Z', message: { role: 'user', content: 'yes go ahead and ship it' } },
+    { type: 'ai-title', aiTitle: 'Flaky exec test fix', sessionId: id },
+    { type: 'assistant', timestamp: '2026-06-28T00:04:00.000Z', uuid: `${id}-a3`, message: { id: `${id}-msg3`, model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 30, output_tokens: 40 } } },
+  ];
+}
+
+describe('B-2 live incremental scan parity', () => {
+  it('CORE: an appended session, re-scanned incrementally, equals a from-scratch full reparse for every field', async () => {
+    const id = 'core-session';
+
+    // First scan: cold → FULL parse of the seed.
+    writeTranscript(id, baseEvents(id));
+    await runScan();
+    expect(discover.__claudeScanBranchCountsForTest().full).toBeGreaterThanOrEqual(1);
+
+    // Append + re-scan → INCREMENTAL branch must be taken for this file.
+    discover.__resetClaudeScanBranchCountsForTest();
+    appendTranscript(id, appendedEvents(id));
+    bumpMtimeToNow(sessionFile(id), 1);
+    await runScan();
+    const counts = discover.__claudeScanBranchCountsForTest();
+    expect(counts.incremental, 'incremental branch exercised on 2nd scan').toBeGreaterThanOrEqual(1);
+
+    // Ground truth: the FINAL content parsed from scratch under a fresh id.
+    const gtId = await groundTruth([...baseEvents(id), ...appendedEvents(id)]);
+
+    assertRowParity(id, gtId);
+
+    // Spot-check the incrementally-scanned row carries the appended-chunk signals.
+    const inc = db.getSessionById(id)!;
+    expect(inc.topic).toBe('Flaky exec test fix'); // ai-title came in the append
+    expect(inc.messageCount).toBe(5);
+    // outputTokens = 20 + 10 + 40 across all three assistant events.
+    expect(inc.outputTokens).toBe(70);
+  });
+
+  it('STRADDLED PR: gh pr create tool_use in the first write, its URL in the append → correct prUrl/prNumber', async () => {
+    const id = 'straddle-pr';
+    writeTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T01:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'open a pr' } },
+      { type: 'assistant', timestamp: '2026-06-28T01:01:00.000Z', uuid: `${id}-a1`, message: { id: `${id}-m1`, model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: `${id}-t1`, name: 'Bash', input: { command: 'gh pr create --title x --body y' } }], usage: { input_tokens: 10, output_tokens: 5 } } },
+    ]);
+    await runScan();
+    // No URL yet.
+    expect(db.getSessionById(id)!.prUrl ?? null).toBeNull();
+
+    // The tool_result URL lands in the appended chunk.
+    appendTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T01:02:00.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `${id}-t1`, content: 'https://github.com/acme/repo/pull/4242' }] } },
+    ]);
+    bumpMtimeToNow(sessionFile(id), 1);
+    await runScan();
+    expect(discover.__claudeScanBranchCountsForTest().incremental).toBeGreaterThanOrEqual(1);
+
+    const inc = db.getSessionById(id)!;
+    expect(inc.prUrl).toBe('https://github.com/acme/repo/pull/4242');
+    expect(inc.prNumber).toBe(4242);
+
+    // Full-reparse parity.
+    const gtId = await groundTruth([
+      { type: 'user', timestamp: '2026-06-28T01:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'open a pr' } },
+      { type: 'assistant', timestamp: '2026-06-28T01:01:00.000Z', uuid: `${id}-a1`, message: { id: `${id}-m1`, model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: `${id}-t1`, name: 'Bash', input: { command: 'gh pr create --title x --body y' } }], usage: { input_tokens: 10, output_tokens: 5 } } },
+      { type: 'user', timestamp: '2026-06-28T01:02:00.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `${id}-t1`, content: 'https://github.com/acme/repo/pull/4242' }] } },
+    ]);
+    assertRowParity(id, gtId);
+  });
+
+  it('STRADDLED ticket: create_issue tool_use first, its ref in the append → correct createdTickets', async () => {
+    const id = 'straddle-ticket';
+    writeTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T02:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'file a ticket' } },
+      { type: 'assistant', timestamp: '2026-06-28T02:01:00.000Z', uuid: `${id}-a1`, message: { id: `${id}-m1`, model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: `${id}-t1`, name: 'Bash', input: { command: 'gh issue create --title bug' } }], usage: { input_tokens: 8, output_tokens: 4 } } },
+    ]);
+    await runScan();
+
+    appendTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T02:02:00.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `${id}-t1`, content: 'https://github.com/acme/repo/issues/77' }] } },
+    ]);
+    bumpMtimeToNow(sessionFile(id), 1);
+    await runScan();
+    expect(discover.__claudeScanBranchCountsForTest().incremental).toBeGreaterThanOrEqual(1);
+
+    const gtId = await groundTruth([
+      { type: 'user', timestamp: '2026-06-28T02:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'file a ticket' } },
+      { type: 'assistant', timestamp: '2026-06-28T02:01:00.000Z', uuid: `${id}-a1`, message: { id: `${id}-m1`, model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: `${id}-t1`, name: 'Bash', input: { command: 'gh issue create --title bug' } }], usage: { input_tokens: 8, output_tokens: 4 } } },
+      { type: 'user', timestamp: '2026-06-28T02:02:00.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `${id}-t1`, content: 'https://github.com/acme/repo/issues/77' }] } },
+    ]);
+    assertRowParity(id, gtId);
+  });
+
+  it('STRADDLED title: an ai-title appearing only in the appended chunk becomes the topic', async () => {
+    const id = 'straddle-title';
+    writeTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T03:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'do the thing please' } },
+    ]);
+    await runScan();
+    // Topic is the first-prompt fallback before the title arrives.
+    const before = db.getSessionById(id)!;
+    expect(before.topic).not.toBe('Rename me later');
+
+    appendTranscript(id, [
+      { type: 'custom-title', customTitle: 'Rename me later', sessionId: id },
+      { type: 'user', timestamp: '2026-06-28T03:01:00.000Z', message: { role: 'user', content: 'thanks' } },
+    ]);
+    bumpMtimeToNow(sessionFile(id), 1);
+    await runScan();
+    expect(discover.__claudeScanBranchCountsForTest().incremental).toBeGreaterThanOrEqual(1);
+    expect(db.getSessionById(id)!.topic).toBe('Rename me later');
+
+    const gtId = await groundTruth([
+      { type: 'user', timestamp: '2026-06-28T03:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'do the thing please' } },
+      { type: 'custom-title', customTitle: 'Rename me later', sessionId: id },
+      { type: 'user', timestamp: '2026-06-28T03:01:00.000Z', message: { role: 'user', content: 'thanks' } },
+    ]);
+    assertRowParity(id, gtId);
+  });
+
+  it('FALLBACK-ID: assistant events sharing a timestamp with no id, split across scans, keep messageCount parity', async () => {
+    const id = 'fallback-id';
+    const ts = '2026-06-28T04:00:00.000Z';
+    // No message.id / uuid → logical id falls back to `${ts}:${seenSize}`, which
+    // depends on the hydrated set's exact size across the scan boundary.
+    writeTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T03:59:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'start' } },
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'one' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'two' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]);
+    await runScan();
+
+    appendTranscript(id, [
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'three' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'four' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]);
+    bumpMtimeToNow(sessionFile(id), 1);
+    await runScan();
+    expect(discover.__claudeScanBranchCountsForTest().incremental).toBeGreaterThanOrEqual(1);
+
+    const gtId = await groundTruth([
+      { type: 'user', timestamp: '2026-06-28T03:59:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'start' } },
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'one' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'two' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'three' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+      { type: 'assistant', timestamp: ts, message: { model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'four' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+    ]);
+    // 1 user + 4 distinct assistant events → 5 messages (no double-count).
+    expect(db.getSessionById(id)!.messageCount).toBe(5);
+    assertRowParity(id, gtId);
+  });
+
+  it('TRUNCATION: rewriting the file smaller forces a FULL reparse with no stale/doubled counters', async () => {
+    const id = 'truncation';
+    writeTranscript(id, [...baseEvents(id), ...appendedEvents(id)]);
+    await runScan();
+    const long = db.getSessionById(id)!;
+    expect(long.messageCount).toBe(5);
+
+    // Rewrite the file with LESS content (a different, shorter session). Its size
+    // shrinks below the persisted offset → the decision must fall back to FULL.
+    discover.__resetClaudeScanBranchCountsForTest();
+    const rewritten = [
+      { type: 'user', timestamp: '2026-06-29T00:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'fresh short session' } },
+    ];
+    fs.writeFileSync(sessionFile(id), rewritten.map(line).join('\n') + '\n', 'utf-8');
+    bumpMtimeToNow(sessionFile(id), 2);
+    await runScan();
+    const counts = discover.__claudeScanBranchCountsForTest();
+    expect(counts.full, 'truncation forces a full reparse').toBeGreaterThanOrEqual(1);
+    expect(counts.incremental, 'truncation must NOT go incremental').toBe(0);
+
+    const short = db.getSessionById(id)!;
+    // No stale/doubled counters: exactly the one message of the rewritten file.
+    expect(short.messageCount).toBe(1);
+    expect(short.tokenCount ?? null).toBeNull();
+    expect(short.topic).toBe('fresh short session');
+
+    const gtId = await groundTruth(rewritten);
+    assertRowParity(id, gtId);
+  });
+
+  it('FTS: a content search finds the session by a term that appears only in the appended chunk', async () => {
+    const id = 'fts-append';
+    writeTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T05:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'initial prompt about apples' } },
+    ]);
+    await runScan();
+    // The distinctive term is NOT present yet.
+    expect(db.ftsSearch('zorptastic').some(h => h.sessionId === id)).toBe(false);
+
+    appendTranscript(id, [
+      { type: 'user', timestamp: '2026-06-28T05:01:00.000Z', message: { role: 'user', content: 'now a message with the zorptastic keyword' } },
+    ]);
+    bumpMtimeToNow(sessionFile(id), 1);
+    await runScan();
+    expect(discover.__claudeScanBranchCountsForTest().incremental).toBeGreaterThanOrEqual(1);
+
+    const hits = db.ftsSearch('zorptastic');
+    expect(hits.some(h => h.sessionId === id), 'FTS finds appended-only text').toBe(true);
+  });
+
+  it('LEDGER: parser_state + content_text are persisted after a scan, and rewritten after truncation', async () => {
+    const id = 'ledger-persist';
+    const fp = writeTranscript(id, baseEvents(id));
+    await runScan();
+
+    const states = db.getParserStatesForPaths([fp]);
+    const row = states.get(fp);
+    expect(row, 'ledger row exists for the scanned file').toBeDefined();
+    expect(row!.parserState, 'parser_state persisted').not.toBeNull();
+    expect(row!.contentText, 'content_text persisted').not.toBeNull();
+    const parsed = JSON.parse(row!.parserState!);
+    expect(parsed.v).toBe(1);
+    expect(typeof parsed.offset).toBe('number');
+    const offsetAfterFirst = parsed.offset;
+
+    // Append → offset must advance (state rewritten).
+    appendTranscript(id, appendedEvents(id));
+    bumpMtimeToNow(fp, 1);
+    await runScan();
+    const afterAppend = JSON.parse(db.getParserStatesForPaths([fp]).get(fp)!.parserState!);
+    expect(afterAppend.offset).toBeGreaterThan(offsetAfterFirst);
+
+    // Truncate → offset must reset to the (smaller) rewritten file's byte length.
+    fs.writeFileSync(fp, line({ type: 'user', timestamp: '2026-06-30T00:00:00.000Z', cwd: '/home/u/repo', message: { role: 'user', content: 'tiny' } }) + '\n', 'utf-8');
+    bumpMtimeToNow(fp, 2);
+    await runScan();
+    const afterTrunc = JSON.parse(db.getParserStatesForPaths([fp]).get(fp)!.parserState!);
+    expect(afterTrunc.offset).toBeLessThan(afterAppend.offset);
+    expect(afterTrunc.offset).toBe(fs.statSync(fp).size);
+  });
+});

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -577,6 +577,78 @@ export function getScanStampsForPaths(filePaths: string[]): Map<string, ScanStam
 }
 
 /**
+ * A file's persisted resumable-parse continuation, read back from scan_ledger.
+ * `parserState` is the serialized {@link ClaudeParserState} JSON blob (offset +
+ * accumulator snapshot); `contentText` is the accumulated user doc. Both are
+ * written by the Claude scan (B-2) and consumed on the next scan to decide
+ * full-vs-incremental and to hydrate the resume.
+ */
+export interface ParserStateRow {
+  parserState: string | null;
+  contentText: string | null;
+  fileMtimeMs: number;
+  fileSize: number;
+  scannedAt: number;
+}
+
+/**
+ * Bulk-load the resumable-parse continuation (parser_state + content_text) plus
+ * the stamp for a set of file paths in a single chunked query. Mirrors
+ * {@link getScanStampsForPaths}: keys by canonical path and fans results back to
+ * every original alias so callers can `.get(filePath)` with the path they passed.
+ * The Claude incremental scan uses this to fetch each changed file's prior
+ * continuation without an N+1 of {@link getScanStampByPath}.
+ */
+export function getParserStatesForPaths(filePaths: string[]): Map<string, ParserStateRow> {
+  const result = new Map<string, ParserStateRow>();
+  if (filePaths.length === 0) return result;
+  const db = getDB();
+
+  const canonicalToOriginals = new Map<string, string[]>();
+  for (const fp of filePaths) {
+    const canonical = canonicalLedgerKey(fp);
+    const aliases = canonicalToOriginals.get(canonical);
+    if (aliases) aliases.push(fp);
+    else canonicalToOriginals.set(canonical, [fp]);
+  }
+
+  const canonicalKeys = [...canonicalToOriginals.keys()];
+  const CHUNK = 500;
+  for (let i = 0; i < canonicalKeys.length; i += CHUNK) {
+    const chunk = canonicalKeys.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = db
+      .prepare(`
+        SELECT file_path, file_mtime_ms, file_size, scanned_at, parser_state, content_text
+        FROM scan_ledger
+        WHERE file_path IN (${placeholders})
+      `)
+      .all(...chunk) as Array<{
+        file_path: string;
+        file_mtime_ms: number;
+        file_size: number;
+        scanned_at: number;
+        parser_state: string | null;
+        content_text: string | null;
+      }>;
+
+    for (const row of rows) {
+      const state: ParserStateRow = {
+        parserState: row.parser_state,
+        contentText: row.content_text,
+        fileMtimeMs: row.file_mtime_ms,
+        fileSize: row.file_size,
+        scannedAt: row.scanned_at,
+      };
+      for (const original of canonicalToOriginals.get(row.file_path) || []) {
+        result.set(original, state);
+      }
+    }
+  }
+  return result;
+}
+
+/**
  * Record scan stamps for files we've looked at. Covers both files that produced
  * a session and files we looked at but chose not to index (e.g. malformed).
  */
@@ -830,19 +902,26 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
 
 /** Batch-upsert sessions with their FTS5 content and scan stamps in a single transaction. */
 export function upsertSessionsBatch(
-  entries: Array<{ meta: SessionMeta; content: string; scan?: ScanStamp }>,
+  entries: Array<{ meta: SessionMeta; content: string; scan?: ScanStamp; parserState?: string; contentText?: string }>,
 ): void {
   if (entries.length === 0) return;
   const db = getDB();
   const { upsert, delText, insText, readLabel } = stmts(db);
   const now = Date.now();
+  // Persist the Claude resumable-parse continuation (parser_state + content_text)
+  // alongside the stamp. On a full/incremental Claude parse the caller passes the
+  // serialized newState + accumulated user doc so the NEXT scan can resume from
+  // the persisted offset (B-2). Other scanners pass neither, leaving both columns
+  // NULL exactly as before — their ledger rows are unaffected.
   const ledger = db.prepare(`
-    INSERT INTO scan_ledger (file_path, file_mtime_ms, file_size, scanned_at)
-    VALUES (?, ?, ?, ?)
+    INSERT INTO scan_ledger (file_path, file_mtime_ms, file_size, scanned_at, parser_state, content_text)
+    VALUES (?, ?, ?, ?, ?, ?)
     ON CONFLICT(file_path) DO UPDATE SET
       file_mtime_ms = excluded.file_mtime_ms,
       file_size = excluded.file_size,
-      scanned_at = excluded.scanned_at
+      scanned_at = excluded.scanned_at,
+      parser_state = excluded.parser_state,
+      content_text = excluded.content_text
   `);
 
   // Build a lookup from canonical file path → entry, used inside the write
@@ -877,7 +956,7 @@ export function upsertSessionsBatch(
       }
     }
 
-    for (const { meta, content, scan } of items) {
+    for (const { meta, content, scan, parserState, contentText } of items) {
       if (alreadyIndexed.has(meta.id)) continue;
       // Per-row guard: one malformed session (e.g. a required field that resolves to
       // NULL) must not abort the whole batch and take down the entire `agents sessions`
@@ -930,7 +1009,14 @@ export function upsertSessionsBatch(
         content ?? '',
       );
       if (scan && meta.filePath) {
-        ledger.run(canonicalLedgerKey(meta.filePath), scan.fileMtimeMs, scan.fileSize, now);
+        ledger.run(
+          canonicalLedgerKey(meta.filePath),
+          scan.fileMtimeMs,
+          scan.fileSize,
+          now,
+          parserState ?? null,
+          contentText ?? null,
+        );
       }
       } catch (err) {
         if (process.stderr.isTTY) {

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -35,6 +35,7 @@ import {
   getDB,
   getScanStampByPath,
   getScanStampsForPaths,
+  getParserStatesForPaths,
   getDirLedgerForPaths,
   recordDirScans,
   recordScans,
@@ -201,6 +202,15 @@ interface ScanEntry {
   meta: SessionMeta;
   content: string;
   scan: ScanStamp;
+  /**
+   * Serialized {@link ClaudeParserState} continuation to persist in
+   * scan_ledger.parser_state (Claude only). Carries the offset + accumulator so
+   * the NEXT scan of this file resumes from where this parse stopped. Absent for
+   * non-Claude scanners, which leave the column NULL.
+   */
+  parserState?: string;
+  /** Accumulated user doc to persist in scan_ledger.content_text for the next hydrate (Claude only). */
+  contentText?: string;
 }
 
 /**
@@ -856,7 +866,13 @@ async function readRoutineArchiveMeta(
 
   if (agent === 'claude') {
     const sessionId = path.basename(filePath).replace(/\.jsonl$/, '');
-    const result = await readClaudeMeta(filePath, sessionId);
+    // Routine archives are finalized, immutable transcripts — no live append, so
+    // no continuation to resume. A FULL parse (undefined prior) is correct here;
+    // the returned continuation is unused by this archive path.
+    const stat = safeStatSync(filePath);
+    if (!stat) return null;
+    const scanStamp: ScanStamp = { fileMtimeMs: Math.floor(stat.mtimeMs), fileSize: stat.size };
+    const result = await readClaudeMeta(filePath, sessionId, scanStamp, undefined);
     return result ? { ...result, meta: decorateRoutineSession(result.meta, info) } : null;
   }
 
@@ -1050,6 +1066,13 @@ async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Pr
   if (changed.length > 0) {
     onProgress?.({ agent: 'claude', parsed: 0, total: changed.length });
 
+    // Bulk-fetch each changed file's prior resumable continuation. A file with a
+    // usable prior state + growth goes incremental (re-parse only the appended
+    // bytes); everything else does a FULL from-offset-0 parse. The decision + the
+    // parse both live in scanClaudeSessionResumable so full and incremental share
+    // one reducer and produce identical rows.
+    const priorStates = getParserStatesForPaths(changed.map(c => c.filePath));
+
     const entries: ScanEntry[] = [];
     const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
     let parsed = 0;
@@ -1057,9 +1080,16 @@ async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Pr
       try {
         const sessionId = path.basename(filePath).replace('.jsonl', '');
         const label = labelMap.get(sessionId) ?? undefined;
-        const result = await readClaudeMeta(filePath, sessionId, account, label);
+        const priorRow = priorStates.get(filePath);
+        const result = await readClaudeMeta(filePath, sessionId, scan, priorRow, account, label);
         if (result) {
-          entries.push({ meta: result.meta, content: result.content, scan });
+          entries.push({
+            meta: result.meta,
+            content: result.content,
+            scan,
+            parserState: result.parserState,
+            contentText: result.contentText,
+          });
         } else {
           touched.push({ filePath, scan });
         }
@@ -1079,14 +1109,31 @@ async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Pr
   if (labelMap.size > 0) syncLabels(labelMap);
 }
 
-/** Stream-parse a single Claude JSONL file to extract session metadata. */
+/**
+ * Stream-parse a single Claude JSONL file to extract session metadata, resuming
+ * from the persisted continuation when the file merely grew (see
+ * {@link scanClaudeSessionResumable}). Returns the row's meta + FTS content plus
+ * the serialized continuation (parser_state + content_text) to persist for the
+ * next scan.
+ */
 async function readClaudeMeta(
   filePath: string,
   sessionId: string,
+  scanStamp: ScanStamp,
+  priorRow: { parserState: string | null; fileMtimeMs: number } | undefined,
   account?: string,
   label?: string,
-): Promise<{ meta: SessionMeta; content: string } | null> {
-  const scan = await scanClaudeSession(filePath);
+): Promise<{ meta: SessionMeta; content: string; parserState: string; contentText?: string } | null> {
+  const prior = parsePriorClaudeState(priorRow);
+  const { scan, newState, mode } = await scanClaudeSessionResumable(
+    filePath,
+    prior,
+    scanStamp.fileMtimeMs,
+    scanStamp.fileSize,
+    priorRow?.fileMtimeMs,
+  );
+  if (mode === 'incremental') claudeIncrementalScanCount++;
+  else claudeFullScanCount++;
   const isTeamOrigin = scan.entrypoint === 'sdk-cli';
 
   let meta: SessionMeta;
@@ -1148,7 +1195,15 @@ async function readClaudeMeta(
     };
   }
 
-  return { meta, content: scan.contentText || '' };
+  return {
+    meta,
+    content: scan.contentText || '',
+    // Persist the continuation so the next scan of this file can resume from the
+    // offset instead of a full reparse. content_text is the same accumulated user
+    // doc, cached so the resume can hydrate userTexts without re-reading the file.
+    parserState: JSON.stringify(newState),
+    contentText: newState.contentText,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -3065,6 +3120,81 @@ export async function scanClaudeSessionIncremental(
     newState: serializeClaudeParserState(state, newOffset),
     newOffset,
   };
+}
+
+/** Serialized zero-value continuation: a fresh accumulator at offset 0, used to drive a FULL parse from the start through the same resumable path. */
+function freshClaudeParserState(): ClaudeParserState {
+  return serializeClaudeParserState(initClaudeParseState(), 0);
+}
+
+/**
+ * Decide full-vs-incremental for one Claude file and parse it uniformly, always
+ * returning a finalized scan plus the continuation to persist. Both branches run
+ * through the SAME reducer (via {@link scanClaudeSessionIncremental}), so the row
+ * an append produces is identical to a from-scratch full reparse by construction
+ * (the B-1 parity harness proves this at the function level).
+ *
+ * INCREMENTAL when a prior continuation exists AND the file grew past the
+ * persisted offset AND its mtime did not go backwards — an in-place append.
+ * FULL (from byte 0, fresh state) otherwise: cold start (no prior), truncation /
+ * rewrite (size shrank to at or below the offset), or a clock rewind / restore
+ * (mtime older than the last parse). A FULL parse still produces a continuation,
+ * so the file's very next append can go incremental.
+ *
+ * `mode` is returned so the caller (and tests) can confirm which branch ran.
+ */
+async function scanClaudeSessionResumable(
+  filePath: string,
+  prior: ClaudeParserState | null,
+  currentFileMtimeMs: number,
+  currentFileSize: number,
+  priorFileMtimeMs?: number,
+): Promise<{ scan: ClaudeSessionScan; newState: ClaudeParserState; newOffset: number; mode: 'full' | 'incremental' }> {
+  const canIncrement =
+    prior !== null &&
+    currentFileSize > prior.offset &&
+    (priorFileMtimeMs === undefined || currentFileMtimeMs >= priorFileMtimeMs);
+
+  if (canIncrement) {
+    const result = await scanClaudeSessionIncremental(filePath, prior.offset, prior);
+    return { ...result, mode: 'incremental' };
+  }
+
+  const result = await scanClaudeSessionIncremental(filePath, 0, freshClaudeParserState());
+  return { ...result, mode: 'full' };
+}
+
+/**
+ * Parse the prior continuation blob for a changed file into a usable
+ * {@link ClaudeParserState}, or null when there is none / it is unusable. A blob
+ * from a different serialization version is treated as absent so the file falls
+ * back to a clean FULL parse rather than resuming against a stale shape.
+ */
+function parsePriorClaudeState(row: { parserState: string | null } | undefined): ClaudeParserState | null {
+  if (!row?.parserState) return null;
+  try {
+    const parsed = JSON.parse(row.parserState) as ClaudeParserState;
+    if (parsed?.v !== 1 || typeof parsed.offset !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Test seam: how many times the incremental (append-resume) branch was taken since the last reset. */
+let claudeIncrementalScanCount = 0;
+/** Test seam: how many times a full (from-offset-0) Claude parse ran since the last reset. */
+let claudeFullScanCount = 0;
+
+/** Test seam: read the (incremental, full) Claude parse counters. */
+export function __claudeScanBranchCountsForTest(): { incremental: number; full: number } {
+  return { incremental: claudeIncrementalScanCount, full: claudeFullScanCount };
+}
+
+/** Test seam: reset the Claude parse-branch counters to observe a scan from a clean slate. */
+export function __resetClaudeScanBranchCountsForTest(): void {
+  claudeIncrementalScanCount = 0;
+  claudeFullScanCount = 0;
 }
 
 /** Stream a Codex JSONL file and extract scan-level metadata (session ID, cwd, topic, tokens). */


### PR DESCRIPTION
## What changed

Wires the already-shipped-but-unused `scanClaudeSessionIncremental` into the **live** Claude scan path. When an active Claude transcript grows, `agents sessions` (and every consumer that scans — `output` / `view` / `teams` / the watcher) now re-parses **only the newly-appended bytes** instead of re-reading the whole file from the top. Only Claude is wired; Codex/Kimi are follow-ups (B-3/B-4).

## Full-vs-incremental decision + fallback

A new `scanClaudeSessionResumable(filePath, prior)` decides per changed file and drives **both** branches through the same reducer (`scanClaudeSessionIncremental`), so results match by construction:

- **INCREMENTAL** — a prior `parser_state` continuation exists **AND** the file grew past the saved offset **AND** its mtime did not go backwards. Resumes from `prior.offset`.
- **FULL from byte 0** — no prior state (cold start), size shrank at/below the offset (**truncation / rewrite**), or mtime older than the last parse (**clock rewind / restore**). A full parse still emits a continuation, so the very next append can go incremental.

## Persistence

`scan_ledger` gained `parser_state` + `content_text` in B-1 (schema v15) but was written nowhere. This PR writes them: `upsertSessionsBatch` now persists the serialized continuation + accumulated user doc alongside the mtime/size stamp when the Claude caller supplies them; other scanners pass neither, so their ledger rows are unchanged (columns stay NULL). A new bulk `getParserStatesForPaths` loads each changed file's prior continuation in one chunked, canonical-keyed query.

## The invariant + tests

The hard invariant: **the row an incremental append produces is identical, field for field, to a from-scratch full reparse.** `__tests__/incremental-scan-e2e.test.ts` proves it end-to-end through `discoverSessions` (real fs + real sqlite, no mocks):

- **CORE** — index, append, re-index (incremental), assert the row equals a from-scratch full reparse for every field.
- **STRADDLED** — `gh pr create` in one write + its URL in the append → correct `prUrl`/`prNumber`; same for `create_issue`→ticket and an `ai-title`/`custom-title` appearing only in the appended chunk.
- **FALLBACK-ID** — id-less assistant events sharing a timestamp split across scans → `messageCount` parity (no double-count).
- **TRUNCATION** — rewrite the file smaller → next scan does a FULL reparse, no stale/doubled counters.
- **FTS** — after an incremental scan, a content search finds the session by a term that appears only in the appended chunk.
- **LEDGER** — after the scan, `parser_state` + `content_text` are non-null; the offset advances on append and resets on truncation.

The incremental branch being exercised is confirmed via a spy counter (`__claudeScanBranchCountsForTest`): every straddle/core test asserts `incremental >= 1` on the 2nd scan. Two mutation checks confirmed the parity tests genuinely fail if the decision is forced always-full (6 fail) or the resume starts at offset 0 / double-counts (5 fail).

## Scope preserved

- Shared `filterChangedEntries`/`filterChangedFiles` return shape **untouched** — Gemini/Codex/Droid/routine are unaffected (a Claude-specific ledger lookup was added instead).
- A-2 cross-root precedence (`winnerBySession` over `allFiles`) and the 5s append debounce (`shouldDeferRecentAppend`) are intact.

## Verification

- `npx tsc --noEmit` clean.
- `npx vitest run src/lib/session/` → **706 passed, 1 failed** — the single red is the **known pre-existing flake** (`getSessionRoots "never throws"`, reddened by `db.migrate-v14.test.ts` leaking `process.env.HOME` into reused vitest forks; being fixed in a separate PR). It passes clean in isolation and reproduces on origin/main. The 4 pre-existing repo-wide exec/models/non-interactive failures likewise reproduce on clean origin/main.
- New e2e file run 3× in isolation → 8/8 each time, no flake.

## Docs + changelog

`.changelog/next/incremental-claude-parse.md`, plus notes in `docs/05-sessions.md` and `docs/architecture.md`.
