### PR TITLE
fix(session): guard incremental Claude parse against in-place session rewrite

### DIFF
--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -69,7 +69,10 @@ not re-read it from the top. The `scan_ledger` stores a resumable continuation
 the accumulated user doc); the next scan resumes from that offset and folds in only
 the newly-appended lines. It falls back to a **full reparse from byte 0** when the
 file has no prior continuation (cold start), shrank at or below the saved offset
-(truncation / rewrite), or its mtime went backwards (clock rewind / restore). Full
+(truncation / rewrite), its mtime went backwards (clock rewind / restore), or it
+grew but its re-derived first-event identity no longer matches the prior
+continuation — an in-place rewrite or restore that dropped a different session at
+the same path, which size + mtime alone cannot tell from an append. Full
 and incremental parses run through the same reducer, so the indexed row an append
 produces — token counts, cost, duration, topic/title, PR + ticket refs, FTS content
 — is identical to a from-scratch full reparse, even when a signal straddles two

--- a/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
@@ -319,6 +319,47 @@ describe('B-2 live incremental scan parity', () => {
     assertRowParity(id, gtId);
   });
 
+  it('IN-PLACE REWRITE: replacing the path with a DIFFERENT, LARGER session forces FULL (no cross-session corruption)', async () => {
+    const id = 'inplace-rewrite';
+
+    // Seed + scan session A → FULL, persisting a continuation whose offset is A's
+    // byte length.
+    const fp = writeTranscript(id, baseEvents(id));
+    await runScan();
+    const priorOffset = JSON.parse(db.getParserStatesForPaths([fp]).get(fp)!.parserState!).offset as number;
+
+    // Replace the path IN PLACE with a DIFFERENT session (distinct first
+    // timestamp) whose byte length is LARGER than the stored offset and whose
+    // mtime moves forward — the exact shape metadata cannot tell from an append.
+    // Size-grew + mtime-forward alone would wrongly resume from priorOffset and
+    // fold session B's bytes into session A's hydrated accumulator; the identity
+    // re-check must catch the session change and force FULL.
+    discover.__resetClaudeScanBranchCountsForTest();
+    const sessionB = [
+      { type: 'user', timestamp: '2026-07-01T09:00:00.000Z', cwd: '/home/u/other', gitBranch: 'PROJ-7', version: '2.2.0', message: { role: 'user', content: `restored different session ${'x'.repeat(400)}` } },
+      { type: 'assistant', timestamp: '2026-07-01T09:01:00.000Z', uuid: `${id}-b1`, message: { id: `${id}-bmsg1`, model: 'claude-sonnet-4-5', content: [{ type: 'text', text: `restored reply ${'y'.repeat(200)}` }], usage: { input_tokens: 200, output_tokens: 60 } } },
+      { type: 'assistant', timestamp: '2026-07-01T09:02:00.000Z', uuid: `${id}-b2`, message: { id: `${id}-bmsg2`, model: 'claude-sonnet-4-5', content: [{ type: 'text', text: 'more restored content' }], usage: { input_tokens: 90, output_tokens: 30 } } },
+    ];
+    fs.writeFileSync(fp, sessionB.map(line).join('\n') + '\n', 'utf-8');
+    bumpMtimeToNow(fp, 3);
+
+    // Precondition — this is the trap: the new file is LARGER than the stored
+    // offset, so the size gate that the old logic relied on does NOT fire.
+    expect(fs.statSync(fp).size, 'rewritten file must exceed the prior offset to exercise the guard').toBeGreaterThan(priorOffset);
+
+    await runScan();
+    const counts = discover.__claudeScanBranchCountsForTest();
+    expect(counts.full, 'in-place rewrite to a different session must force FULL').toBeGreaterThanOrEqual(1);
+    expect(counts.incremental, 'must NOT resume incrementally across a session boundary').toBe(0);
+
+    // No cross-session corruption: the row equals a from-scratch parse of session B.
+    const row = db.getSessionById(id)!;
+    expect(row.messageCount).toBe(3);
+    expect(row.timestamp).toBe('2026-07-01T09:00:00.000Z');
+    const gtId = await groundTruth(sessionB);
+    assertRowParity(id, gtId);
+  });
+
   it('FTS: a content search finds the session by a term that appears only in the appended chunk', async () => {
     const id = 'fts-append';
     writeTranscript(id, [

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -3150,18 +3150,66 @@ async function scanClaudeSessionResumable(
   currentFileSize: number,
   priorFileMtimeMs?: number,
 ): Promise<{ scan: ClaudeSessionScan; newState: ClaudeParserState; newOffset: number; mode: 'full' | 'incremental' }> {
-  const canIncrement =
+  // File size + mtime cannot distinguish an APPEND from an in-place rewrite or a
+  // restore that dropped DIFFERENT, larger content at the same path: both grow
+  // the file and move mtime forward. Resuming from the stored offset across that
+  // boundary would fold the new file's bytes into an accumulator hydrated from
+  // the OLD session, so the persisted row silently diverges from a full reparse.
+  // So the metadata gate below only makes a file ELIGIBLE; before trusting the
+  // offset we re-read the transcript's first user/assistant timestamp and require
+  // it to still match the prior continuation's. An append keeps that identity
+  // byte-for-byte; a rewrite/restore of a different session changes it. A
+  // mismatch — or an identity we cannot derive — falls back to a FULL parse,
+  // which is always correct. (A shrink is already handled: currentFileSize is not
+  // > prior.offset, so it takes the FULL branch.)
+  let canIncrement = false;
+  if (
     prior !== null &&
     currentFileSize > prior.offset &&
-    (priorFileMtimeMs === undefined || currentFileMtimeMs >= priorFileMtimeMs);
+    (priorFileMtimeMs === undefined || currentFileMtimeMs >= priorFileMtimeMs) &&
+    prior.timestamp !== undefined
+  ) {
+    canIncrement = (await claudeSessionIdentityAt(filePath)) === prior.timestamp;
+  }
 
-  if (canIncrement) {
+  if (canIncrement && prior !== null) {
     const result = await scanClaudeSessionIncremental(filePath, prior.offset, prior);
     return { ...result, mode: 'incremental' };
   }
 
   const result = await scanClaudeSessionIncremental(filePath, 0, freshClaudeParserState());
   return { ...result, mode: 'full' };
+}
+
+/**
+ * Cheaply derive a Claude transcript's session identity — the first
+ * user/assistant event `timestamp` — by streaming only the START of the file
+ * (at most `maxBytes`) and stopping at the first such event. Used by
+ * {@link scanClaudeSessionResumable} to confirm a grown file is still the SAME
+ * session before resuming from a stored parse offset. Returns undefined when no
+ * user/assistant event appears within the budget, which forces a FULL parse.
+ */
+async function claudeSessionIdentityAt(filePath: string, maxBytes = 1_048_576): Promise<string | undefined> {
+  const state = initClaudeParseState();
+  const stream = fs.createReadStream(filePath, { start: 0, end: maxBytes - 1, encoding: 'utf-8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      applyClaudeLine(state, parsed);
+      if (state.timestamp !== undefined) break;
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+  return state.timestamp;
 }
 
 /**


### PR DESCRIPTION
## What

Follow-up correctness fix to **#1511** (B-2, incremental Claude transcript parse on the live scan path). Closes a latent bug where an in-place rewrite / restore of a **different, larger** transcript at the same path would be resumed incrementally, silently corrupting the persisted session row.

## The bug

`scanClaudeSessionResumable`'s guard was metadata-only:

```ts
const canIncrement =
  prior !== null &&
  currentFileSize > prior.offset &&
  (priorFileMtimeMs === undefined || currentFileMtimeMs >= priorFileMtimeMs);
```

Size-grew + mtime-not-backwards **cannot distinguish an append from an in-place rewrite** — both grow the file and move mtime forward. When a path was replaced in place with a different, larger session (restore / rsync / backup-over-live-path / path-reuse), the parser resumed from the stored offset and folded the *new* file's bytes into an accumulator hydrated from the *old* session. The persisted row then diverged from a full reparse — breaking B-2's core `incremental === full` invariant, on the live scan path.

Metadata alone can't detect this (verified: `prior.offset` equals the prior file size for a clean parse, so the size check is true for both append and in-place-grow), so the obvious `priorFileSize === prior.offset` clause does **not** close it. A content signal is required.

## The fix

Before trusting the stored offset, re-read the transcript's **first user/assistant `timestamp`** (a bounded read that stops at the first such event) and require it to still match the prior continuation's. An append keeps that identity byte-for-byte; a rewrite/restore of a different session changes it. A mismatch — or an identity that can't be derived within the budget — falls back to a **FULL** parse (always correct). A shrink already took the FULL branch (size not `>` offset).

Cost: one small, bounded read on the incremental path (stops at the first user/assistant event, ~first record) — negligible versus re-reading the whole transcript, which incremental exists to avoid.

## Test

Adds an e2e regression test: seed session A → scan; replace the path in place with a **different, larger** session B (distinct first timestamp, forward mtime, byte length `>` the stored offset — the exact metadata trap); rescan and assert **FULL** (not incremental) with row parity to a from-scratch parse of B. Verified it **fails on the old metadata-only guard** (goes incremental, `full=0`) and **passes with the identity re-check**.

## Verification

- `npx tsc --noEmit` — clean (rc=0)
- `npx vitest run src/lib/session/` — 707 passed; the sole failure is the pre-existing `getSessionRoots > never throws` shared-machine env race (unrelated; passes 3/3 in isolation)
- New `incremental-scan-e2e.test.ts` — 9/9

## Notes

- No separate CHANGELOG fragment: this is a correctness fix to the **unreleased** incremental-parse feature; `.changelog/next/incremental-claude-parse.md` (from #1511) covers the feature.
- Found by an independent review of #1511 after it merged; prix-cloud's pass did not flag it.