### PR TITLE
perf(session): incremental Codex + Kimi transcript parse

### DIFF
--- a/apps/cli/.changelog/next/incremental-codex-kimi-parse.md
+++ b/apps/cli/.changelog/next/incremental-codex-kimi-parse.md
@@ -1,0 +1,20 @@
+- **Incremental Codex + Kimi transcript parsing on the live scan path.** Following
+  the Claude incremental parse, the Codex rollout scanner and the Kimi wire.jsonl
+  scanner now re-parse only the newly-appended bytes when an active session grows,
+  instead of re-reading the whole file from the top every scan (`agents sessions`
+  and every consumer that scans: `output` / `view` / `teams` / the watcher). Each
+  persists a resumable continuation in the `scan_ledger` (`parser_state`, reusing
+  the schema v15 columns): the next scan resumes from the saved byte offset when
+  the file merely grew and its mtime did not go backwards, and falls back to a full
+  reparse from byte 0 on a cold start, a truncation / rewrite (size shrank), or a
+  clock rewind. Both branches run through one shared reducer per scanner, so the
+  indexed row an append produces is identical, field for field, to a from-scratch
+  full reparse. For Codex that covers messageCount, the last-wins cumulative token
+  snapshot (tokenCount / outputTokens / cost), duration, topic, and PR + ticket +
+  team signals that straddle two scans (a `gh pr create` function_call in one write
+  and its URL in the next). For Kimi it covers the additive message + token
+  counters. Both incremental paths apply only newline-terminated lines and defer a
+  complete-but-unterminated trailing record to the next pass, so a record written
+  before its `'\n'` is flushed is never double-counted. Grok is out of scope (it
+  reads a whole `summary.json`, not an append-only JSONL); Claude / Gemini and the
+  shared helpers are unchanged. Source: `apps/cli/src/lib/session/discover.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -42,8 +42,8 @@ agents sessions [query] [--json] [--since 1h] [--all]
 │       Else -> readdir + stat each file:                             │
 │         If unchanged since last scan -> skip (DB row is fresh)      │
 │         Else -> parse file, upsert sessions row + FTS5 content row  │
-│           (Claude: resume from the saved byte offset & parse only   │
-│            the appended lines when the file merely grew)            │
+│           (Claude/Codex/Kimi: resume from the saved byte offset &   │
+│            parse only the appended lines when the file merely grew) │
 │                                                                     │
 │  3. SQL query with filters (agent, cwd, since, project, limit)      │
 │     FTS5 search if [query] given, BM25 ranked                       │
@@ -63,18 +63,23 @@ create / delete / rename bumps the dir mtime and forces a full re-walk of that d
 Set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to disable the short-circuit and force the old
 full per-file walk.
 
-When a **Claude** transcript that already has an index row grows, the scan does
-not re-read it from the top. The `scan_ledger` stores a resumable continuation
-(`parser_state` — a byte offset plus an accumulator snapshot — and `content_text`,
-the accumulated user doc); the next scan resumes from that offset and folds in only
-the newly-appended lines. It falls back to a **full reparse from byte 0** when the
-file has no prior continuation (cold start), shrank at or below the saved offset
-(truncation / rewrite), or its mtime went backwards (clock rewind / restore). Full
-and incremental parses run through the same reducer, so the indexed row an append
-produces — token counts, cost, duration, topic/title, PR + ticket refs, FTS content
-— is identical to a from-scratch full reparse, even when a signal straddles two
-scans. Only the Claude scanner is incremental today; the other agents still full-parse
-each changed file.
+When a **Claude**, **Codex**, or **Kimi** transcript that already has an index row
+grows, the scan does not re-read it from the top. The `scan_ledger` stores a
+resumable continuation (`parser_state` — a byte offset plus an accumulator snapshot,
+plus `content_text`, the accumulated user doc, for Claude/Codex); the next scan
+resumes from that offset and folds in only the newly-appended lines. (Kimi's
+counters come from a sibling `agents/main/wire.jsonl`, so its continuation tracks
+that file's offset + the three additive counter bases.) It falls back to a **full
+reparse from byte 0** when the file has no prior continuation (cold start), shrank
+at or below the saved offset (truncation / rewrite), or its mtime went backwards
+(clock rewind / restore). Full and incremental parses run through the same reducer
+per scanner, so the indexed row an append produces — token counts, cost, duration,
+topic/title, and (Claude/Codex) PR + ticket refs + FTS content — is identical to a
+from-scratch full reparse, even when a signal straddles two scans. Both incremental
+paths apply only newline-terminated lines and defer a complete-but-unterminated
+trailing record to the next pass, so a record written before its `'\n'` is flushed
+is never double-counted. Grok is not incremental — it reads a whole `summary.json`,
+not an append-only JSONL; Gemini still full-parses each changed file.
 
 ## SessionMeta (list output)
 

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -63,11 +63,14 @@ The **transcript** side is a SQLite index (`~/.agents/.history/sessions/sessions
 `scan_ledger` that re-reads a file only when its `mtime`/`size` changed, a
 `dir_ledger` that skips the per-file `stat` of a leaf transcript directory whose
 `(mtime, entry_count)` is unchanged, plus a `session_text` FTS5 table for search.
-For **Claude**, a changed file that merely grew is parsed **incrementally**: the
-`scan_ledger` also stores a resumable continuation (`parser_state` + `content_text`)
-so the next scan resumes from the saved byte offset and folds in only the appended
-lines — falling back to a full reparse on a truncation / rewrite or a clock rewind.
-Both paths share one reducer, so the incremental row is identical to a full reparse.
+For **Claude**, **Codex**, and **Kimi**, a changed file that merely grew is parsed
+**incrementally**: the `scan_ledger` also stores a resumable continuation
+(`parser_state`, plus `content_text` for Claude/Codex) so the next scan resumes
+from the saved byte offset and folds in only the appended lines — falling back to
+a full reparse on a truncation / rewrite or a clock rewind. (Kimi's continuation
+tracks its `agents/main/wire.jsonl` offset + the additive counters.) Grok is not
+incremental — it reads a whole `summary.json`, not an append-only JSONL.
+Both paths share one reducer per scanner, so the incremental row is identical to a full reparse.
 Listing is a DB read; only opening one session fully re-parses its transcript.
 Detail in [05-sessions.md](05-sessions.md).
 

--- a/apps/cli/src/lib/session/__tests__/codex-incremental-parity.test.ts
+++ b/apps/cli/src/lib/session/__tests__/codex-incremental-parity.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  scanCodexSessionIncremental,
+  initCodexParseState,
+  serializeCodexParserState,
+  type CodexParserState,
+} from '../discover.js';
+
+// Differential parity harness (B-3, Codex). Proves that resuming a Codex parse
+// from a persisted continuation and folding in appended lines is BYTE-FOR-BYTE
+// identical to a full parse of the whole file, for EVERY field of
+// CodexSessionScan. Real temp files, real fs — no mocks.
+//
+// The full ground truth is computed by resuming from offset 0 over an empty
+// prior (a single incremental pass equals a full parse), so the harness needs no
+// import of the private scanCodexSession — scanCodexSessionIncremental(fp, 0,
+// fresh) IS a full parse.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-codex-inc-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function fresh(): CodexParserState {
+  return serializeCodexParserState(initCodexParseState(), 0);
+}
+
+/** A full parse of the whole file = resume from offset 0 over an empty prior. */
+async function fullScan(fp: string) {
+  return (await scanCodexSessionIncremental(fp, 0, fresh())).scan;
+}
+
+/** Serialize an array of JSON objects into JSONL lines (no trailing newline). */
+function jsonl(lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n');
+}
+
+/**
+ * Seed the file with chunk 0, bootstrap a continuation, then APPEND each
+ * subsequent chunk and resume from the persisted offset. Returns the final
+ * incremental scan and the ground-truth full scan of the final file.
+ */
+async function replay(chunks: string[]) {
+  const fp = path.join(dir, 'rollout.jsonl');
+  expect(chunks.length).toBeGreaterThan(0);
+
+  fs.writeFileSync(fp, chunks[0] + '\n');
+  let prior: CodexParserState = fresh();
+  let step = await scanCodexSessionIncremental(fp, 0, prior);
+  let inc = step.scan;
+  prior = step.newState;
+  const offsets: number[] = [step.newOffset];
+
+  for (let i = 1; i < chunks.length; i++) {
+    fs.appendFileSync(fp, chunks[i] + '\n');
+    step = await scanCodexSessionIncremental(fp, prior.offset, prior);
+    inc = step.scan;
+    prior = step.newState;
+    offsets.push(step.newOffset);
+  }
+
+  const full = await fullScan(fp);
+  return { inc, full, offsets };
+}
+
+/** Assert two CodexSessionScan objects are equal on every field. */
+function expectScanParity(inc: any, full: any) {
+  expect(inc).toEqual(full);
+  const fields = [
+    'sessionId', 'timestamp', 'cwd', 'gitBranch', 'version', 'topic',
+    'messageCount', 'tokenCount', 'outputTokens', 'costUsd', 'durationMs',
+    'lastActivity', 'contentText', 'prUrl', 'prNumber', 'worktreeSlug',
+    'ticketId', 'createdTickets', 'spawnedTeam',
+  ];
+  for (const f of fields) {
+    expect(inc[f], `field ${f}`).toEqual(full[f]);
+  }
+}
+
+// A representative, field-rich Codex transcript: session_meta, user + assistant
+// messages, cumulative token_count events (last wins), a PR straddle, a team.
+function richLines(): object[] {
+  return [
+    { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 'sess-1', timestamp: '2026-06-28T00:00:00.000Z', cwd: '/home/u/repo', git: { branch: 'RUSH-42-fix' }, cli_version: '0.9.0', model: 'gpt-5-codex' } },
+    { type: 'response_item', timestamp: '2026-06-28T00:00:30.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'investigate the flaky exec test' }] } },
+    { type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'looking into it' }] } },
+    { type: 'event_msg', timestamp: '2026-06-28T00:01:05.000Z', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 100, cached_input_tokens: 5, output_tokens: 20, reasoning_output_tokens: 4 } } } },
+    { type: 'response_item', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'yes go ahead' }] } },
+    { type: 'response_item', timestamp: '2026-06-28T00:03:00.000Z', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }] } },
+    { type: 'event_msg', timestamp: '2026-06-28T00:03:05.000Z', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 300, cached_input_tokens: 12, output_tokens: 60, reasoning_output_tokens: 8 } } } },
+  ];
+}
+
+describe('codex incremental parity — boundary sweep', () => {
+  it('replaying across a split at EVERY line index equals a full parse', async () => {
+    const lines = richLines();
+    const serialized = lines.map((l) => JSON.stringify(l));
+    for (let k = 1; k < serialized.length; k++) {
+      const chunkA = serialized.slice(0, k).join('\n');
+      const chunkB = serialized.slice(k).join('\n');
+      const { inc, full } = await replay([chunkA, chunkB]);
+      expectScanParity(inc, full);
+    }
+  });
+
+  it('replaying line-by-line (n chunks) equals a full parse', async () => {
+    const chunks = richLines().map((l) => JSON.stringify(l));
+    const { inc, full } = await replay(chunks);
+    expectScanParity(inc, full);
+  });
+});
+
+describe('codex incremental parity — last-wins token usage across a boundary', () => {
+  it('a later cumulative token_count snapshot in the tail wins (not summed)', async () => {
+    const chunkA = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's', cwd: '/x', model: 'gpt-5-codex' } },
+      { type: 'event_msg', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 50, output_tokens: 10, reasoning_output_tokens: 2 } } } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'event_msg', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 500, output_tokens: 100, reasoning_output_tokens: 20 } } } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    // LAST wins: 500 + 100 + 20 = 620 total, outputTokens = 100 + 20 = 120.
+    expect(inc.tokenCount).toBe(620);
+    expect(inc.outputTokens).toBe(120);
+    expectScanParity(inc, full);
+  });
+});
+
+describe('codex incremental parity — straddled two-event patterns', () => {
+  it('PR create function_call in chunk 1, URL in a function_call_output in chunk 2', async () => {
+    const chunkA = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's', cwd: '/x' } },
+      { type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'function_call', name: 'shell', call_id: 'c1', arguments: JSON.stringify({ command: 'gh pr create --fill' }) } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'response_item', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'function_call_output', call_id: 'c1', output: 'https://github.com/org/repo/pull/321' } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.prUrl).toBe('https://github.com/org/repo/pull/321');
+    expect(inc.prNumber).toBe(321);
+    expectScanParity(inc, full);
+  });
+
+  it('create_issue function_call in chunk 1, result ref in chunk 2 → createdTickets parity', async () => {
+    const chunkA = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's', cwd: '/x' } },
+      { type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'function_call', name: 'shell', call_id: 'tt1', arguments: JSON.stringify({ command: 'gh issue create --title bug' }) } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'response_item', timestamp: '2026-06-28T00:02:00.000Z', payload: { type: 'function_call_output', call_id: 'tt1', output: 'https://github.com/org/repo/issues/88' } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.createdTickets).toEqual(['#88']);
+    expectScanParity(inc, full);
+  });
+
+  it('spawnedTeam from a teams-create command straddling the boundary', async () => {
+    const chunkA = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's', cwd: '/x' } },
+    ]);
+    const chunkB = jsonl([
+      { type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'function_call', name: 'shell', call_id: 'c9', arguments: JSON.stringify({ command: 'agents teams create my-feature --enable-worktrees' }) } },
+    ]);
+    const { inc, full } = await replay([chunkA, chunkB]);
+    expect(inc.spawnedTeam).toBe('my-feature');
+    expectScanParity(inc, full);
+  });
+});
+
+describe('codex incremental parity — truncation → full reparse', () => {
+  it('when the file shrinks below the stored offset, a full parse from offset 0 matches a from-scratch parse', async () => {
+    const fp = path.join(dir, 'trunc.jsonl');
+    const original = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's1', cwd: '/x', model: 'gpt-5-codex' } },
+      { type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'long original prompt one' }] } },
+      { type: 'event_msg', timestamp: '2026-06-28T00:01:05.000Z', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 90, output_tokens: 30 } } } },
+    ]) + '\n';
+    fs.writeFileSync(fp, original);
+    const first = await scanCodexSessionIncremental(fp, 0, fresh());
+    expect(first.newOffset).toBe(Buffer.byteLength(original, 'utf-8'));
+
+    // Rewrite SMALLER (a fresh, shorter session reusing the same path).
+    const rewritten = jsonl([
+      { type: 'session_meta', timestamp: '2026-06-29T00:00:00.000Z', payload: { id: 's2', cwd: '/y' } },
+      { type: 'response_item', timestamp: '2026-06-29T00:00:30.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'brand new short session' }] } },
+    ]) + '\n';
+    fs.writeFileSync(fp, rewritten);
+    const newSize = Buffer.byteLength(rewritten, 'utf-8');
+    expect(newSize).toBeLessThan(first.newOffset);
+
+    // Truncation contract: on newSize < offset, discard the continuation and
+    // full-parse from scratch.
+    const reparse = newSize < first.newOffset
+      ? await scanCodexSessionIncremental(fp, 0, fresh())
+      : await scanCodexSessionIncremental(fp, first.newOffset, first.newState);
+
+    const full = await fullScan(fp);
+    expectScanParity(reparse.scan, full);
+    expect(reparse.scan.topic).toBe('brand new short session');
+    expect(reparse.scan.sessionId).toBe('s2');
+  });
+});
+
+describe('codex incremental parity — partial trailing line', () => {
+  it('a chunk ending mid-JSON (no trailing newline) is re-consumed on the next append', async () => {
+    const fp = path.join(dir, 'partial.jsonl');
+    const l1 = JSON.stringify({ type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: 's', cwd: '/x' } });
+    fs.writeFileSync(fp, l1 + '\n');
+    const step1 = await scanCodexSessionIncremental(fp, 0, fresh());
+    expect(step1.newOffset).toBe(Buffer.byteLength(l1 + '\n', 'utf-8'));
+
+    const l2full = JSON.stringify({ type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'a user message' }] } });
+    const l2partial = l2full.slice(0, Math.floor(l2full.length / 2));
+    fs.appendFileSync(fp, l2partial);
+    const step2 = await scanCodexSessionIncremental(fp, step1.newOffset, step1.newState);
+    // No new '\n' → offset must NOT advance; the half-line is not parsed.
+    expect(step2.newOffset).toBe(step1.newOffset);
+    expect(step2.scan.messageCount).toBe(0);
+
+    // Complete the record + newline.
+    fs.appendFileSync(fp, l2full.slice(l2partial.length) + '\n');
+    const step3 = await scanCodexSessionIncremental(fp, step2.newOffset, step2.newState);
+    expect(step3.newOffset).toBe(Buffer.byteLength(fs.readFileSync(fp)));
+
+    const full = await fullScan(fp);
+    expectScanParity(step3.scan, full);
+    expect(step3.scan.messageCount).toBe(1);
+  });
+
+  it('a COMPLETE record missing only its trailing newline is deferred, then counted EXACTLY once', async () => {
+    // The non-atomic-append bug class prix-cloud caught for Claude: a writer
+    // appends a full, valid record and only later appends its '\n'. Codex
+    // messageCount is additive with NO dedup, so a double-apply would show up as
+    // messageCount 1→2 and contentText carrying the message twice.
+    const fp = path.join(dir, 'complete-unterminated.jsonl');
+    const l1 = JSON.stringify({ type: 'response_item', timestamp: '2026-06-28T00:00:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'first message' }] } });
+    fs.writeFileSync(fp, l1 + '\n');
+    const step1 = await scanCodexSessionIncremental(fp, 0, fresh());
+    expect(step1.scan.messageCount).toBe(1);
+    expect(step1.scan.contentText).toBe('first message');
+    expect(step1.newOffset).toBe(Buffer.byteLength(l1 + '\n', 'utf-8'));
+
+    // Append a COMPLETE, valid second record — but WITHOUT its trailing '\n' yet.
+    const l2 = JSON.stringify({ type: 'response_item', timestamp: '2026-06-28T00:01:00.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'second message' }] } });
+    fs.appendFileSync(fp, l2);
+    const step2 = await scanCodexSessionIncremental(fp, step1.newOffset, step1.newState);
+    // Deferred: offset does NOT advance, line2 NOT yet counted.
+    expect(step2.newOffset).toBe(step1.newOffset);
+    expect(step2.scan.messageCount).toBe(1);
+    expect(step2.scan.contentText).toBe('first message');
+
+    // Writer flushes the terminating '\n'.
+    fs.appendFileSync(fp, '\n');
+    const step3 = await scanCodexSessionIncremental(fp, step2.newOffset, step2.newState);
+    // Counted EXACTLY once — not twice.
+    expect(step3.scan.messageCount).toBe(2);
+    expect(step3.scan.contentText).toBe('first message\nsecond message');
+    expect(step3.newOffset).toBe(Buffer.byteLength(fs.readFileSync(fp)));
+
+    const full = await fullScan(fp);
+    expectScanParity(step3.scan, full);
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/codex-incremental-scan-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/codex-incremental-scan-e2e.test.ts
@@ -1,0 +1,255 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// End-to-end parity for the LIVE Codex scan path (B-3). Proves that wiring
+// scanCodexSessionIncremental into discoverSessions produces a DB row IDENTICAL,
+// field for field, to a from-scratch FULL reparse — even when PR / ticket
+// signals STRADDLE two scans and the cumulative token_count updates across an
+// append — and that a truncation forces a full reparse. Real fs, real sqlite,
+// real discovery under a throwaway HOME. No mocks.
+//
+// The from-scratch ground truth is computed inside the SAME DB by writing the
+// final rollout content to a DIFFERENT session id (no prior ledger row → the
+// code takes the FULL path for it) and comparing its row.
+
+const REAL_HOME = process.env.HOME;
+const REAL_USERPROFILE = process.env.USERPROFILE;
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-codex-e2e-'));
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+
+type Discover = typeof import('../discover.js');
+type DB = typeof import('../db.js');
+
+let discover: Discover;
+let db: DB;
+
+const SESSIONS = path.join(tmpHome, '.codex', 'sessions');
+
+function line(obj: object): string {
+  return JSON.stringify(obj);
+}
+
+/** Path of a rollout file for a given session id under the live sessions dir. */
+function rolloutFile(id: string): string {
+  return path.join(SESSIONS, `rollout-${id}.jsonl`);
+}
+
+function writeRollout(id: string, events: object[]): string {
+  fs.mkdirSync(SESSIONS, { recursive: true });
+  const fp = rolloutFile(id);
+  fs.writeFileSync(fp, events.map(line).join('\n') + '\n', 'utf-8');
+  bumpMtimeToNow(fp, 0);
+  return fp;
+}
+
+function appendRollout(id: string, events: object[]): void {
+  fs.appendFileSync(rolloutFile(id), events.map(line).join('\n') + '\n', 'utf-8');
+}
+
+/** Push a file's mtime forward so an append isn't seen as a clock-rewind and the ledger stamp changes. */
+function bumpMtimeToNow(fp: string, plusSeconds: number): void {
+  const t = Math.floor(Date.now() / 1000) + plusSeconds;
+  fs.utimesSync(fp, t, t);
+}
+
+/** Age every ledger row past the 5s active-append debounce so a grown file re-scans this tick. */
+function agePriorScans(): void {
+  db.getDB().prepare('UPDATE scan_ledger SET scanned_at = ?').run(Date.now() - 60_000);
+}
+
+async function runScan(): Promise<void> {
+  agePriorScans();
+  await discover.discoverSessions({ agent: 'codex', all: true });
+}
+
+// `timestamp` and `lastActivity` are excluded: Codex's timestamp is
+// max(session_meta.timestamp, file.mtime) (see pickLatestCodexTimestamp), so two
+// SEPARATE files (the incremental session vs the from-scratch ground truth)
+// carry different mtimes and can never match on those two fields. Every other
+// field is a pure function of the parsed content and must match exactly.
+const PARITY_FIELDS = [
+  'agent', 'project', 'cwd', 'gitBranch', 'version',
+  'topic', 'messageCount', 'tokenCount', 'outputTokens', 'costUsd', 'durationMs',
+  'prUrl', 'prNumber', 'worktreeSlug', 'ticketId', 'createdTickets', 'spawnedTeam',
+] as const;
+
+function assertRowParity(incId: string, fullId: string): void {
+  const inc = db.getSessionById(incId);
+  const full = db.getSessionById(fullId);
+  expect(inc, `incremental row ${incId} exists`).not.toBeNull();
+  expect(full, `full-reparse row ${fullId} exists`).not.toBeNull();
+  for (const f of PARITY_FIELDS) {
+    expect((inc as any)[f], `field ${f}`).toEqual((full as any)[f]);
+  }
+}
+
+let groundTruthCounter = 0;
+/**
+ * Compute the from-scratch ground truth for a set of events: write them to a
+ * brand-new rollout file whose session_meta carries a fresh id (no prior ledger
+ * continuation → FULL parse). Returns the SESSION id (from session_meta), which
+ * is the DB row key — not the file name.
+ */
+async function groundTruth(events: object[], sessionId: string): Promise<string> {
+  const fileId = `ground-truth-${groundTruthCounter++}`;
+  writeRollout(fileId, events);
+  await runScan();
+  return sessionId;
+}
+
+beforeAll(async () => {
+  db = await import('../db.js');
+  discover = await import('../discover.js');
+  db.getDB();
+});
+
+beforeEach(() => {
+  discover.__resetCodexScanBranchCountsForTest();
+});
+
+afterAll(() => {
+  if (REAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = REAL_HOME;
+  if (REAL_USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = REAL_USERPROFILE;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+/**
+ * Field-rich base events. `sessionId` only sets session_meta.id (the DB row key);
+ * the user text is STABLE so topic/contentText parity holds between the
+ * incrementally-scanned session and a from-scratch ground truth under a different id.
+ */
+function baseEvents(sessionId: string): object[] {
+  return [
+    { type: 'session_meta', timestamp: '2026-06-28T00:00:00.000Z', payload: { id: sessionId, timestamp: '2026-06-28T00:00:00.000Z', cwd: '/home/u/repo', git: { branch: 'RUSH-42-fix' }, cli_version: '0.9.0', model: 'gpt-5-codex' } },
+    { type: 'response_item', timestamp: '2026-06-28T00:00:30.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'investigate the flaky exec test' }] } },
+    { type: 'event_msg', timestamp: '2026-06-28T00:01:05.000Z', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 100, output_tokens: 20, reasoning_output_tokens: 4 } } } },
+  ];
+}
+
+function appendedEvents(): object[] {
+  return [
+    { type: 'response_item', timestamp: '2026-06-28T00:03:00.000Z', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }] } },
+    { type: 'event_msg', timestamp: '2026-06-28T00:03:05.000Z', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 400, output_tokens: 80, reasoning_output_tokens: 10 } } } },
+  ];
+}
+
+describe('B-3 live incremental Codex scan parity', () => {
+  it('CORE: an appended rollout, re-scanned incrementally, equals a from-scratch full reparse for every field', async () => {
+    const id = 'core-session';
+
+    writeRollout(id, baseEvents(id));
+    await runScan();
+    expect(discover.__codexScanBranchCountsForTest().full).toBeGreaterThanOrEqual(1);
+
+    discover.__resetCodexScanBranchCountsForTest();
+    appendRollout(id, appendedEvents());
+    bumpMtimeToNow(rolloutFile(id), 1);
+    await runScan();
+    expect(discover.__codexScanBranchCountsForTest().incremental, 'incremental branch exercised on 2nd scan').toBeGreaterThanOrEqual(1);
+
+    // Ground truth: the FINAL content parsed from scratch under a fresh session id.
+    const gtBase = baseEvents('gt-core');
+    const gtId = await groundTruth([...gtBase, ...appendedEvents()], 'gt-core');
+    assertRowParity(id, gtId);
+
+    const inc = db.getSessionById(id)!;
+    // LAST-WINS token snapshot from the append: 400 + 80 + 10 = 490.
+    expect(inc.tokenCount).toBe(490);
+    expect(inc.outputTokens).toBe(90);
+    expect(inc.messageCount).toBe(2);
+  });
+
+  it('STRADDLED PR: gh pr create in the first write, its URL in the append → correct prUrl/prNumber', async () => {
+    const id = 'straddle-pr';
+    writeRollout(id, [
+      { type: 'session_meta', timestamp: '2026-06-28T01:00:00.000Z', payload: { id, cwd: '/home/u/repo' } },
+      { type: 'response_item', timestamp: '2026-06-28T01:01:00.000Z', payload: { type: 'function_call', name: 'shell', call_id: 't1', arguments: JSON.stringify({ command: 'gh pr create --title x --body y' }) } },
+    ]);
+    await runScan();
+    expect(db.getSessionById(id)!.prUrl ?? null).toBeNull();
+
+    appendRollout(id, [
+      { type: 'response_item', timestamp: '2026-06-28T01:02:00.000Z', payload: { type: 'function_call_output', call_id: 't1', output: 'https://github.com/acme/repo/pull/4242' } },
+    ]);
+    bumpMtimeToNow(rolloutFile(id), 1);
+    await runScan();
+    expect(discover.__codexScanBranchCountsForTest().incremental).toBeGreaterThanOrEqual(1);
+
+    const inc = db.getSessionById(id)!;
+    expect(inc.prUrl).toBe('https://github.com/acme/repo/pull/4242');
+    expect(inc.prNumber).toBe(4242);
+  });
+
+  it('STRADDLED ticket: gh issue create first, its ref in the append → correct createdTickets', async () => {
+    const id = 'straddle-ticket';
+    writeRollout(id, [
+      { type: 'session_meta', timestamp: '2026-06-28T02:00:00.000Z', payload: { id, cwd: '/home/u/repo' } },
+      { type: 'response_item', timestamp: '2026-06-28T02:01:00.000Z', payload: { type: 'function_call', name: 'shell', call_id: 't1', arguments: JSON.stringify({ command: 'gh issue create --title bug' }) } },
+    ]);
+    await runScan();
+
+    appendRollout(id, [
+      { type: 'response_item', timestamp: '2026-06-28T02:02:00.000Z', payload: { type: 'function_call_output', call_id: 't1', output: 'https://github.com/acme/repo/issues/77' } },
+    ]);
+    bumpMtimeToNow(rolloutFile(id), 1);
+    await runScan();
+    expect(discover.__codexScanBranchCountsForTest().incremental).toBeGreaterThanOrEqual(1);
+
+    const gtId = await groundTruth([
+      { type: 'session_meta', timestamp: '2026-06-28T02:00:00.000Z', payload: { id: 'gt-ticket', cwd: '/home/u/repo' } },
+      { type: 'response_item', timestamp: '2026-06-28T02:01:00.000Z', payload: { type: 'function_call', name: 'shell', call_id: 't1', arguments: JSON.stringify({ command: 'gh issue create --title bug' }) } },
+      { type: 'response_item', timestamp: '2026-06-28T02:02:00.000Z', payload: { type: 'function_call_output', call_id: 't1', output: 'https://github.com/acme/repo/issues/77' } },
+    ], 'gt-ticket');
+    // createdTickets is derived by the scan (asserted at function level in the
+    // parity harness) but not a persisted DB column, so row parity is the check
+    // here: the incremental row must not diverge from the full reparse row.
+    assertRowParity(id, gtId);
+  });
+
+  it('TRUNCATION: rewriting the rollout smaller forces a FULL reparse with no stale/doubled counters', async () => {
+    const id = 'truncation';
+    writeRollout(id, [...baseEvents(id), ...appendedEvents()]);
+    await runScan();
+    expect(db.getSessionById(id)!.messageCount).toBe(2);
+
+    discover.__resetCodexScanBranchCountsForTest();
+    const rewritten = [
+      { type: 'session_meta', timestamp: '2026-06-29T00:00:00.000Z', payload: { id, cwd: '/home/u/repo' } },
+      { type: 'response_item', timestamp: '2026-06-29T00:00:30.000Z', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'fresh short session' }] } },
+    ];
+    fs.writeFileSync(rolloutFile(id), rewritten.map(line).join('\n') + '\n', 'utf-8');
+    bumpMtimeToNow(rolloutFile(id), 2);
+    await runScan();
+    const counts = discover.__codexScanBranchCountsForTest();
+    expect(counts.full, 'truncation forces a full reparse').toBeGreaterThanOrEqual(1);
+    expect(counts.incremental, 'truncation must NOT go incremental').toBe(0);
+
+    const short = db.getSessionById(id)!;
+    expect(short.messageCount).toBe(1);
+    expect(short.tokenCount ?? null).toBeNull();
+    expect(short.topic).toBe('fresh short session');
+  });
+
+  it('LEDGER: parser_state is persisted after a scan, and its offset advances on append', async () => {
+    const id = 'ledger-persist';
+    const fp = writeRollout(id, baseEvents(id));
+    await runScan();
+
+    const row = db.getParserStatesForPaths([fp]).get(fp);
+    expect(row, 'ledger row exists').toBeDefined();
+    expect(row!.parserState, 'parser_state persisted').not.toBeNull();
+    const parsed = JSON.parse(row!.parserState!);
+    expect(parsed.v).toBe(1);
+    expect(typeof parsed.offset).toBe('number');
+    const offsetAfterFirst = parsed.offset;
+
+    appendRollout(id, appendedEvents());
+    bumpMtimeToNow(fp, 1);
+    await runScan();
+    const afterAppend = JSON.parse(db.getParserStatesForPaths([fp]).get(fp)!.parserState!);
+    expect(afterAppend.offset).toBeGreaterThan(offsetAfterFirst);
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/kimi-incremental-parity.test.ts
+++ b/apps/cli/src/lib/session/__tests__/kimi-incremental-parity.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseKimiWireMetricsIncremental,
+  type KimiParserState,
+} from '../discover.js';
+
+// Differential parity harness (B-4, Kimi). Kimi's wire.jsonl parse is pure
+// additive counters (messageCount, tokenCount, outputTokens) — no straddle, no
+// dedup. Proves that resuming from a persisted offset + counter bases and adding
+// the appended tail's deltas is IDENTICAL to a full parse of the whole
+// wire.jsonl, including the trailing-line discipline (a complete-but-not-yet-
+// terminated last record is deferred, never double-counted). Real temp files,
+// real fs — no mocks.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-kimi-inc-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** Create a session dir with an agents/main/ layout and return the session dir. */
+function makeSessionDir(): string {
+  const sessionDir = path.join(dir, 'session_x');
+  fs.mkdirSync(path.join(sessionDir, 'agents', 'main'), { recursive: true });
+  return sessionDir;
+}
+
+function wirePath(sessionDir: string): string {
+  return path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+}
+
+/** A full parse = incremental from a null prior (fresh counters at offset 0). */
+function fullMetrics(sessionDir: string) {
+  return parseKimiWireMetricsIncremental(sessionDir, null);
+}
+
+/** Serialize wire events into JSONL lines (no trailing newline). */
+function jsonl(lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n');
+}
+
+function richEvents(): object[] {
+  return [
+    { type: 'context.append_message', role: 'user' },
+    { type: 'usage.record', usage: { inputOther: 100, output: 20, inputCacheRead: 5, inputCacheCreation: 3 } },
+    { type: 'context.append_message', role: 'assistant' },
+    { type: 'something.else', ignored: true },
+    { type: 'context.append_message', role: 'user' },
+    { type: 'usage.record', usage: { inputOther: 200, output: 40, inputCacheRead: 10, inputCacheCreation: 1 } },
+  ];
+}
+
+describe('kimi incremental parity — boundary sweep', () => {
+  it('replaying across a split at EVERY line index equals a full parse', async () => {
+    const events = richEvents();
+    const serialized = events.map((e) => JSON.stringify(e));
+    for (let k = 1; k < serialized.length; k++) {
+      const sessionDir = path.join(dir, `s-${k}`);
+      fs.mkdirSync(path.join(sessionDir, 'agents', 'main'), { recursive: true });
+      const wp = wirePath(sessionDir);
+
+      // Seed with chunk A, parse (bootstrap continuation).
+      fs.writeFileSync(wp, serialized.slice(0, k).join('\n') + '\n');
+      let step = parseKimiWireMetricsIncremental(sessionDir, null);
+      let prior: KimiParserState = step.newState;
+
+      // Append chunk B, resume.
+      fs.appendFileSync(wp, serialized.slice(k).join('\n') + '\n');
+      step = parseKimiWireMetricsIncremental(sessionDir, prior);
+
+      const full = fullMetrics(sessionDir);
+      expect(step.messageCount, `split@${k} messageCount`).toBe(full.messageCount);
+      expect(step.tokenCount, `split@${k} tokenCount`).toBe(full.tokenCount);
+      expect(step.outputTokens, `split@${k} outputTokens`).toBe(full.outputTokens);
+      // Concrete counts: 3 messages, tokens = (100+20+5+3)+(200+40+10+1)=379, output=60.
+      expect(full.messageCount).toBe(3);
+      expect(full.tokenCount).toBe(379);
+      expect(full.outputTokens).toBe(60);
+    }
+  });
+});
+
+describe('kimi incremental parity — no wire.jsonl yet', () => {
+  it('a session with no wire.jsonl yields zero counters and an offset-0 continuation', () => {
+    const sessionDir = path.join(dir, 'no-wire');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const r = parseKimiWireMetricsIncremental(sessionDir, null);
+    expect(r.messageCount).toBe(0);
+    expect(r.tokenCount).toBe(0);
+    expect(r.outputTokens).toBe(0);
+    expect(r.newState.offset).toBe(0);
+  });
+});
+
+describe('kimi incremental parity — truncation → full reparse', () => {
+  it('when wire.jsonl shrinks below the stored offset, a fresh full parse (prior=null) matches', () => {
+    const sessionDir = makeSessionDir();
+    const wp = wirePath(sessionDir);
+    const original = jsonl(richEvents()) + '\n';
+    fs.writeFileSync(wp, original);
+    const first = parseKimiWireMetricsIncremental(sessionDir, null);
+    expect(first.newState.offset).toBe(Buffer.byteLength(original, 'utf-8'));
+
+    // Rewrite SMALLER (a fresh, shorter session reusing the same path).
+    const rewritten = jsonl([
+      { type: 'context.append_message', role: 'user' },
+      { type: 'usage.record', usage: { inputOther: 7, output: 3 } },
+    ]) + '\n';
+    fs.writeFileSync(wp, rewritten);
+    const newSize = Buffer.byteLength(rewritten, 'utf-8');
+    expect(newSize).toBeLessThan(first.newState.offset);
+
+    // The incremental fn detects the shrink (size <= offset) and full-parses.
+    const reparse = parseKimiWireMetricsIncremental(sessionDir, first.newState);
+    const full = fullMetrics(sessionDir);
+    expect(reparse.messageCount).toBe(full.messageCount);
+    expect(reparse.tokenCount).toBe(full.tokenCount);
+    expect(reparse.outputTokens).toBe(full.outputTokens);
+    expect(reparse.messageCount).toBe(1);
+    expect(reparse.tokenCount).toBe(10);
+    expect(reparse.outputTokens).toBe(3);
+  });
+});
+
+describe('kimi incremental parity — partial / complete-unterminated trailing line', () => {
+  it('a chunk ending mid-JSON (no trailing newline) is re-consumed on the next append', () => {
+    const sessionDir = makeSessionDir();
+    const wp = wirePath(sessionDir);
+    const l1 = JSON.stringify({ type: 'context.append_message', role: 'user' });
+    fs.writeFileSync(wp, l1 + '\n');
+    const step1 = parseKimiWireMetricsIncremental(sessionDir, null);
+    expect(step1.messageCount).toBe(1);
+    expect(step1.newState.offset).toBe(Buffer.byteLength(l1 + '\n', 'utf-8'));
+
+    const l2full = JSON.stringify({ type: 'usage.record', usage: { inputOther: 50, output: 12 } });
+    const l2partial = l2full.slice(0, Math.floor(l2full.length / 2));
+    fs.appendFileSync(wp, l2partial);
+    const step2 = parseKimiWireMetricsIncremental(sessionDir, step1.newState);
+    // No new '\n' → offset must NOT advance; the half-line is not parsed.
+    expect(step2.newState.offset).toBe(step1.newState.offset);
+    expect(step2.tokenCount).toBe(0);
+
+    fs.appendFileSync(wp, l2full.slice(l2partial.length) + '\n');
+    const step3 = parseKimiWireMetricsIncremental(sessionDir, step2.newState);
+    expect(step3.newState.offset).toBe(fs.statSync(wp).size);
+
+    const full = fullMetrics(sessionDir);
+    expect(step3.tokenCount).toBe(full.tokenCount);
+    expect(step3.tokenCount).toBe(62);
+  });
+
+  it('a COMPLETE record missing only its trailing newline is deferred, then counted EXACTLY once', () => {
+    // The non-atomic-append bug class: a writer appends a full, valid record and
+    // only later appends its '\n'. Kimi counters are additive with NO dedup, so a
+    // double-apply would show up as messageCount 1→2.
+    const sessionDir = makeSessionDir();
+    const wp = wirePath(sessionDir);
+    const l1 = JSON.stringify({ type: 'context.append_message', role: 'user' });
+    fs.writeFileSync(wp, l1 + '\n');
+    const step1 = parseKimiWireMetricsIncremental(sessionDir, null);
+    expect(step1.messageCount).toBe(1);
+    expect(step1.newState.offset).toBe(Buffer.byteLength(l1 + '\n', 'utf-8'));
+
+    // Append a COMPLETE, valid second record — WITHOUT its trailing '\n' yet.
+    const l2 = JSON.stringify({ type: 'context.append_message', role: 'assistant' });
+    fs.appendFileSync(wp, l2);
+    const step2 = parseKimiWireMetricsIncremental(sessionDir, step1.newState);
+    // Deferred: offset does NOT advance, line2 NOT yet counted.
+    expect(step2.newState.offset).toBe(step1.newState.offset);
+    expect(step2.messageCount).toBe(1);
+
+    // Writer flushes the terminating '\n'.
+    fs.appendFileSync(wp, '\n');
+    const step3 = parseKimiWireMetricsIncremental(sessionDir, step2.newState);
+    // Counted EXACTLY once — not twice.
+    expect(step3.messageCount).toBe(2);
+    expect(step3.newState.offset).toBe(fs.statSync(wp).size);
+
+    const full = fullMetrics(sessionDir);
+    expect(step3.messageCount).toBe(full.messageCount);
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/parse-kimi.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-kimi.test.ts
@@ -41,7 +41,12 @@ function makeKimiSession(wireContent: string): string {
     title: 'Test session',
     createdAt: '2026-06-24T00:00:00.000Z',
   }));
-  fs.writeFileSync(path.join(agentsDir, 'wire.jsonl'), wireContent);
+  // Real Kimi wire.jsonl is newline-terminated (see testdata/kimi-tool-args.jsonl,
+  // which ends in 0x0a). Terminate the fixture too so the incremental parse's
+  // trailing-line discipline (a complete-but-unterminated tail is DEFERRED, not
+  // applied — the double-count guard) sees the final record as committed.
+  const terminated = wireContent.endsWith('\n') || wireContent === '' ? wireContent : wireContent + '\n';
+  fs.writeFileSync(path.join(agentsDir, 'wire.jsonl'), terminated);
   return path.join(sessionDir, 'state.json');
 }
 

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -3980,16 +3980,21 @@ async function scanKimiIncremental(onProgress?: (p: ScanProgress) => void): Prom
 
   onProgress?.({ agent: 'kimi', parsed: 0, total: changed.length });
 
+  // Bulk-fetch each changed session's prior wire-parse continuation (offset +
+  // counter bases). A session whose wire.jsonl grew resumes from the offset;
+  // everything else (cold start, truncation) full-parses from byte 0.
+  const priorStates = getParserStatesForPaths(changed.map(c => c.filePath));
+
   const scanEntries: ScanEntry[] = [];
   const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
   const seen = new Set<string>();
   let parsed = 0;
   for (const { filePath, scan } of changed) {
     try {
-      const result = readKimiMeta(filePath);
+      const result = readKimiMeta(filePath, priorStates.get(filePath));
       if (result && !seen.has(result.meta.id)) {
         seen.add(result.meta.id);
-        scanEntries.push({ meta: result.meta, content: result.content, scan });
+        scanEntries.push({ meta: result.meta, content: result.content, scan, parserState: result.parserState });
       } else {
         touched.push({ filePath, scan });
       }
@@ -4005,7 +4010,10 @@ async function scanKimiIncremental(onProgress?: (p: ScanProgress) => void): Prom
 }
 
 /** Parse a single Kimi session state.json file to extract session metadata. */
-export function readKimiMeta(filePath: string): { meta: SessionMeta; content: string } | null {
+export function readKimiMeta(
+  filePath: string,
+  priorRow?: { parserState: string | null },
+): { meta: SessionMeta; content: string; parserState?: string } | null {
   let state: any;
   try {
     state = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
@@ -4045,8 +4053,11 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
     }
   }
 
-  // Parse wire.jsonl to extract message count and token usage
-  const { messageCount, tokenCount, outputTokens } = parseKimiWireMetrics(sessionDir);
+  // Parse wire.jsonl incrementally: resume from the persisted offset + counter
+  // bases when the wire grew, else full-parse from byte 0. The continuation is
+  // persisted on this session's state.json ledger row.
+  const prior = parsePriorKimiState(priorRow);
+  const { messageCount, tokenCount, outputTokens, newState } = parseKimiWireMetricsIncremental(sessionDir, prior);
 
   const meta: SessionMeta = {
     id: sessionId,
@@ -4061,46 +4072,120 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
     outputTokens: outputTokens > 0 ? outputTokens : undefined,
   };
 
-  return { meta, content: lastPrompt || '' };
+  return { meta, content: lastPrompt || '', parserState: JSON.stringify(newState) };
 }
 
-/** Parse Kimi's wire.jsonl to extract message count and token usage.
- * TODO: optimize to stream (like scanClaudeSession) to avoid loading large files into memory.
- * For now, synchronous readFileSync matches the pattern of reading state.json and is acceptable
- * since session dirs are usually fresh in FS cache during incremental scans. */
-function parseKimiWireMetrics(sessionDir: string): { messageCount: number; tokenCount: number; outputTokens: number } {
-  const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
-  let messageCount = 0;
-  let tokenCount = 0;
-  let outputTokens = 0;
+/**
+ * Kimi wire metrics are pure additive counters (messageCount, tokenCount,
+ * outputTokens) with NO straddle/dedup state, so the continuation is just those
+ * three bases plus the byte `offset` already consumed from wire.jsonl. Resuming
+ * from `offset` + adding the appended tail's deltas equals a full parse.
+ */
+export interface KimiParserState {
+  v: 1;
+  offset: number;
+  messageCount: number;
+  tokenCount: number;
+  outputTokens: number;
+}
 
-  if (!fs.existsSync(wirePath)) {
-    return { messageCount: 0, tokenCount: 0, outputTokens: 0 };
+/** Fold one parsed Kimi wire event into the additive counters, in place. */
+function applyKimiWireEvent(
+  acc: { messageCount: number; tokenCount: number; outputTokens: number },
+  event: any,
+): void {
+  if (event.type === 'context.append_message') {
+    acc.messageCount++;
+  } else if (event.type === 'usage.record' && event.usage) {
+    // Kimi usage structure: inputOther + output + inputCacheRead + inputCacheCreation
+    const u = event.usage;
+    acc.tokenCount += (u.inputOther || 0) + (u.output || 0) + (u.inputCacheRead || 0) + (u.inputCacheCreation || 0);
+    acc.outputTokens += (u.output || 0);
+  }
+}
+
+/**
+ * Incrementally parse Kimi's wire.jsonl for message-count and token counters,
+ * resuming from a persisted continuation instead of re-reading from byte 0 every
+ * scan. Returns the finalized counters and the next {@link KimiParserState} to
+ * persist (offset + the three counter bases).
+ *
+ * Same trailing-line discipline as {@link scanClaudeSessionIncremental}: read
+ * only the appended byte range from `prior.offset`, apply ONLY the run of
+ * newline-terminated lines (slice at the last `'\n'`), and advance the offset to
+ * `prior.offset + consumedBytes`. A complete-but-not-yet-terminated last record
+ * is DEFERRED to the next pass; because these counters are additive with no
+ * dedup, re-reading such a line would double-count it. FULL parse from byte 0
+ * (fresh counters) when there is no prior OR the file shrank below the stored
+ * offset (truncation/rewrite).
+ */
+export function parseKimiWireMetricsIncremental(
+  sessionDir: string,
+  prior: KimiParserState | null,
+): { messageCount: number; tokenCount: number; outputTokens: number; newState: KimiParserState } {
+  const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+
+  const stat = safeStatSync(wirePath);
+  if (!stat) {
+    // No wire.jsonl (yet): zero counters, offset 0 so a later append is a clean
+    // full parse.
+    return { messageCount: 0, tokenCount: 0, outputTokens: 0, newState: { v: 1, offset: 0, messageCount: 0, tokenCount: 0, outputTokens: 0 } };
   }
 
+  // INCREMENTAL only when a usable prior exists AND the file grew past its
+  // offset; otherwise FULL from byte 0 with fresh counters (cold start OR the
+  // file shrank to/below the offset — a truncation/rewrite).
+  const canIncrement = prior !== null && stat.size > prior.offset;
+  const fromOffset = canIncrement ? prior!.offset : 0;
+  const acc = canIncrement
+    ? { messageCount: prior!.messageCount, tokenCount: prior!.tokenCount, outputTokens: prior!.outputTokens }
+    : { messageCount: 0, tokenCount: 0, outputTokens: 0 };
+
+  let consumedBytes = 0;
   try {
-    const lines = fs.readFileSync(wirePath, 'utf-8').split('\n');
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        const event = JSON.parse(line);
-        if (event.type === 'context.append_message') {
-          messageCount++;
-        } else if (event.type === 'usage.record' && event.usage) {
-          // Kimi usage structure: inputOther + output + inputCacheRead + inputCacheCreation
-          const u = event.usage;
-          tokenCount += (u.inputOther || 0) + (u.output || 0) + (u.inputCacheRead || 0) + (u.inputCacheCreation || 0);
-          outputTokens += (u.output || 0);
+    const buf = fs.readFileSync(wirePath);
+    const appended = buf.subarray(fromOffset);
+    // Bytes up to AND INCLUDING the last '\n' are the committed, complete-line run.
+    const lastNl = appended.lastIndexOf(0x0a);
+    consumedBytes = lastNl === -1 ? 0 : lastNl + 1;
+    if (consumedBytes > 0) {
+      for (const line of appended.subarray(0, consumedBytes).toString('utf-8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          applyKimiWireEvent(acc, JSON.parse(line));
+        } catch {
+          // Malformed line, skip
         }
-      } catch {
-        // Malformed line, skip
       }
     }
   } catch {
-    // If wire.jsonl can't be read, return 0s (graceful degradation)
+    // If wire.jsonl can't be read, keep the accumulated counters (0s on a cold
+    // parse) — graceful degradation, matching the pre-incremental behavior.
   }
 
-  return { messageCount, tokenCount, outputTokens };
+  return {
+    messageCount: acc.messageCount,
+    tokenCount: acc.tokenCount,
+    outputTokens: acc.outputTokens,
+    newState: { v: 1, offset: fromOffset + consumedBytes, messageCount: acc.messageCount, tokenCount: acc.tokenCount, outputTokens: acc.outputTokens },
+  };
+}
+
+/**
+ * Parse the prior continuation blob for a changed Kimi session into a usable
+ * {@link KimiParserState}, or null when there is none / it is unusable. A blob
+ * from a different serialization version is treated as absent so the wire parse
+ * falls back to a clean FULL parse rather than resuming against a stale shape.
+ */
+function parsePriorKimiState(row: { parserState: string | null } | undefined): KimiParserState | null {
+  if (!row?.parserState) return null;
+  try {
+    const parsed = JSON.parse(row.parserState) as KimiParserState;
+    if (parsed?.v !== 1 || typeof parsed.offset !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -1327,19 +1327,33 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
 
   onProgress?.({ agent: 'codex', parsed: 0, total: changed.length });
 
+  // Bulk-fetch each changed rollout's prior resumable continuation. A file with
+  // a usable prior state + growth goes incremental (re-parse only the appended
+  // bytes); everything else does a FULL from-offset-0 parse. The decision + the
+  // parse both live in scanCodexSessionResumable so full and incremental share
+  // one reducer and produce identical rows.
+  const priorStates = getParserStatesForPaths(changed.map(c => c.filePath));
+
   const entries: ScanEntry[] = [];
   const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
   const seen = new Set<string>();
   let parsed = 0;
   for (const { filePath, scan } of changed) {
     try {
-      const result = await readCodexMeta(filePath, getCodexAccount, currentVersion);
+      const priorRow = priorStates.get(filePath);
+      const result = await readCodexMeta(filePath, getCodexAccount, currentVersion, scan, priorRow);
       if (result && !seen.has(result.meta.id)) {
         seen.add(result.meta.id);
         // Prefer the Codex-generated title over the first-prompt fallback.
         const title = titles.get(result.meta.id);
         if (title) result.meta.topic = title;
-        entries.push({ meta: result.meta, content: result.content, scan });
+        entries.push({
+          meta: result.meta,
+          content: result.content,
+          scan,
+          parserState: result.parserState,
+          contentText: result.contentText,
+        });
       } else {
         touched.push({ filePath, scan });
       }
@@ -1435,8 +1449,35 @@ export async function readCodexMeta(
   filePath: string,
   resolveAccount?: () => string | undefined,
   currentVersion?: string,
-): Promise<{ meta: SessionMeta; content: string } | null> {
-  const scan = await scanCodexSession(filePath);
+  scanStamp?: ScanStamp,
+  priorRow?: { parserState: string | null; fileMtimeMs: number },
+): Promise<{ meta: SessionMeta; content: string; parserState?: string; contentText?: string } | null> {
+  // Resume from the persisted continuation when the file merely grew; otherwise
+  // full-parse from byte 0. Both branches share one reducer, so an append yields
+  // a row identical to a from-scratch reparse. When no stamp is supplied (a
+  // caller outside the live scan path), fall back to a plain full parse with no
+  // continuation to persist.
+  let scan: CodexSessionScan;
+  let newState: CodexParserState | undefined;
+  let newOffset = 0;
+  if (scanStamp) {
+    const prior = parsePriorCodexState(priorRow);
+    const result = await scanCodexSessionResumable(
+      filePath,
+      prior,
+      scanStamp.fileMtimeMs,
+      scanStamp.fileSize,
+      priorRow?.fileMtimeMs,
+    );
+    if (result.mode === 'incremental') codexIncrementalScanCount++;
+    else codexFullScanCount++;
+    scan = result.scan;
+    newState = result.newState;
+    newOffset = result.newOffset;
+  } else {
+    scan = await scanCodexSession(filePath);
+  }
+
   const sessionId = scan.sessionId || '';
   if (!sessionId) return null;
 
@@ -1468,7 +1509,15 @@ export async function readCodexMeta(
     createdTickets: scan.createdTickets,
     spawnedTeam: scan.spawnedTeam,
   };
-  return { meta, content: scan.contentText || '' };
+  return {
+    meta,
+    content: scan.contentText || '',
+    // Persist the continuation so the next scan of this rollout resumes from the
+    // offset instead of a full reparse; content_text caches the accumulated user
+    // doc for the resume's hydrate. Absent when no stamp was supplied.
+    parserState: newState ? JSON.stringify(newState) : undefined,
+    contentText: newState?.contentText,
+  };
 }
 
 /**
@@ -3197,31 +3246,209 @@ export function __resetClaudeScanBranchCountsForTest(): void {
   claudeFullScanCount = 0;
 }
 
+/**
+ * Live (in-memory) accumulator for a Codex parse — the mutable state
+ * {@link scanCodexSession} used to hold in local `let`s, extracted so the same
+ * fold ({@link applyCodexLine}) runs for both a full parse and an incremental
+ * resume. Mirrors {@link ClaudeParseState}.
+ */
+export interface CodexParseState {
+  // First-wins session_meta fields.
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  model?: string;
+  topic?: string;
+  // Additive across every counted message (user + assistant).
+  messageCount: number;
+  // LAST-WINS cumulative token snapshots: Codex's token_count events carry a
+  // running total, so the final one wins (not a sum).
+  tokenCount?: number;
+  lastTotalTokenUsage?: any;
+  // Duration bounds across every timestamped event.
+  firstTsMs?: number;
+  lastTsMs?: number;
+  userTexts: string[];
+  // Straddle state: a `gh pr create` function_call marks intent; the pull URL
+  // arrives in a later function_call_output.
+  sawPrCreate: boolean;
+  prUrl?: string;
+  prNumber?: number;
+  // Ticket creation straddles a create_issue function_call and its output ref.
+  createdTickets: Set<string>;
+  pendingTicketTools: Set<string>;
+  spawnedTeam?: string;
+}
+
+/** Zero-value accumulator for a fresh (from-byte-0) Codex parse. */
+export function initCodexParseState(): CodexParseState {
+  return {
+    sessionId: undefined,
+    timestamp: undefined,
+    cwd: undefined,
+    gitBranch: undefined,
+    version: undefined,
+    model: undefined,
+    topic: undefined,
+    messageCount: 0,
+    tokenCount: undefined,
+    lastTotalTokenUsage: undefined,
+    firstTsMs: undefined,
+    lastTsMs: undefined,
+    userTexts: [],
+    sawPrCreate: false,
+    prUrl: undefined,
+    prNumber: undefined,
+    createdTickets: new Set<string>(),
+    pendingTicketTools: new Set<string>(),
+    spawnedTeam: undefined,
+  };
+}
+
+/**
+ * Fold one parsed Codex line into the accumulator — the exact loop body
+ * {@link scanCodexSession} used to run inline, extracted verbatim and mutating
+ * `state.*` in place. `parsed` is the already-`JSON.parse`d line (the
+ * malformed-line skip happens in the caller, as before).
+ */
+export function applyCodexLine(state: CodexParseState, parsed: any): void {
+  // PR signal, structurally: a Codex `function_call` whose command is
+  // `gh pr create`, then the pull URL from a `function_call_output`.
+  if (parsed.type === 'response_item') {
+    const p = parsed.payload || {};
+    if (p.type === 'function_call') {
+      let cmd = '';
+      try {
+        const args = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : (p.arguments || {});
+        cmd = String(args.command || args.cmd || '');
+      } catch { /* non-JSON args */ }
+      if (!state.prUrl && !state.sawPrCreate && isPrCreateCommand(cmd)) state.sawPrCreate = true;
+      if (!state.spawnedTeam) {
+        const team = detectSpawnedTeam(cmd);
+        if (team) state.spawnedTeam = team;
+      }
+      if (typeof p.call_id === 'string' && isTicketCreateTool(p.name, cmd)) {
+        state.pendingTicketTools.add(p.call_id);
+      }
+    }
+    if (p.type === 'function_call_output') {
+      if (!state.prUrl && state.sawPrCreate) {
+        const pr = extractPrUrl(String(p.output || ''));
+        if (pr) { state.prUrl = pr.url; state.prNumber = pr.number; }
+      }
+      if (typeof p.call_id === 'string' && state.pendingTicketTools.has(p.call_id)) {
+        state.pendingTicketTools.delete(p.call_id);
+        const t = extractCreatedTicket(String(p.output || ''));
+        if (t) state.createdTickets.add(t);
+      }
+    }
+  }
+
+  // Track duration across every timestamped event.
+  if (typeof parsed.timestamp === 'string') {
+    const ms = new Date(parsed.timestamp).getTime();
+    if (!Number.isNaN(ms)) {
+      if (state.firstTsMs === undefined || ms < state.firstTsMs) state.firstTsMs = ms;
+      if (state.lastTsMs === undefined || ms > state.lastTsMs) state.lastTsMs = ms;
+    }
+  }
+
+  if (parsed.type === 'session_meta') {
+    const payload = parsed.payload || {};
+    state.sessionId = payload.id || state.sessionId;
+    state.timestamp = payload.timestamp || parsed.timestamp || state.timestamp;
+    state.cwd = payload.cwd || state.cwd;
+    state.gitBranch = payload.git?.branch || state.gitBranch;
+    state.version = payload.cli_version || payload.version || state.version;
+    state.model = payload.model || state.model;
+    return;
+  }
+
+  if (parsed.type === 'response_item' && parsed.payload?.type === 'message') {
+    const role = parsed.payload.role === 'user' || parsed.payload.role === 'developer'
+      ? 'user'
+      : 'assistant';
+    const text = extractCodexMessageText(parsed.payload.content, role);
+    if (!text) return;
+    state.messageCount++;
+    if (role === 'user') {
+      state.userTexts.push(text);
+      if (!state.topic) state.topic = extractSessionTopic(text);
+    }
+    return;
+  }
+
+  if (parsed.type === 'event_msg' && parsed.payload?.type === 'token_count') {
+    const totalUsage = parsed.payload.info?.total_token_usage;
+    const total = getCodexTokenCount(totalUsage);
+    if (total !== null) state.tokenCount = total;
+    // token_count is cumulative — keep the latest snapshot and price it once
+    // after the stream, so we don't double-count across intermediate events.
+    if (totalUsage && typeof totalUsage === 'object') state.lastTotalTokenUsage = totalUsage;
+    // Codex also stamps the model on the rate_limits/token_count payload on
+    // some versions; prefer session_meta but fall back to it.
+    if (!state.model && typeof parsed.payload.info?.model === 'string') state.model = parsed.payload.info.model;
+  }
+}
+
+/**
+ * Build the {@link CodexSessionScan} return object from an accumulator — the
+ * exact return-building {@link scanCodexSession} used to run inline.
+ */
+export function finalizeCodexScan(state: CodexParseState): CodexSessionScan {
+  // Price the final cumulative token snapshot once, against the session model.
+  let costUsd: number | undefined;
+  if (state.model && state.lastTotalTokenUsage) {
+    const c = costOfUsage({
+      model: state.model,
+      inputTokens: state.lastTotalTokenUsage.input_tokens,
+      outputTokens: (state.lastTotalTokenUsage.output_tokens ?? 0) + (state.lastTotalTokenUsage.reasoning_output_tokens ?? 0),
+      cacheReadTokens: state.lastTotalTokenUsage.cached_input_tokens,
+    });
+    if (c > 0) costUsd = c;
+  }
+
+  const durationMs =
+    state.firstTsMs !== undefined && state.lastTsMs !== undefined && state.lastTsMs > state.firstTsMs
+      ? state.lastTsMs - state.firstTsMs
+      : undefined;
+
+  const worktree = detectWorktree(state.cwd, state.gitBranch);
+  const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
+
+  return {
+    sessionId: state.sessionId,
+    timestamp: state.timestamp,
+    cwd: state.cwd,
+    gitBranch: state.gitBranch,
+    version: state.version,
+    topic: state.topic,
+    messageCount: state.messageCount,
+    tokenCount: state.tokenCount,
+    outputTokens: state.lastTotalTokenUsage
+      ? (state.lastTotalTokenUsage.output_tokens ?? 0) + (state.lastTotalTokenUsage.reasoning_output_tokens ?? 0)
+      : undefined,
+    costUsd,
+    durationMs,
+    lastActivity: state.lastTsMs !== undefined ? new Date(state.lastTsMs).toISOString() : undefined,
+    contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,
+    prUrl: state.prUrl,
+    prNumber: state.prNumber,
+    worktreeSlug: worktree?.slug,
+    ticketId: ticket?.id,
+    createdTickets: state.createdTickets.size > 0 ? [...state.createdTickets] : undefined,
+    spawnedTeam: state.spawnedTeam,
+  };
+}
+
 /** Stream a Codex JSONL file and extract scan-level metadata (session ID, cwd, topic, tokens). */
 async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
   const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
-  let sessionId: string | undefined;
-  let timestamp: string | undefined;
-  let cwd: string | undefined;
-  let gitBranch: string | undefined;
-  let version: string | undefined;
-  let topic: string | undefined;
-  let messageCount = 0;
-  let tokenCount: number | undefined;
-  let model: string | undefined;
-  let lastTotalTokenUsage: any;
-  let firstTsMs: number | undefined;
-  let lastTsMs: number | undefined;
-  const userTexts: string[] = [];
-  let sawPrCreate = false;
-  let prUrl: string | undefined;
-  let prNumber: number | undefined;
-  // Produced artifacts (mirror of the Claude scan): created tracker refs + spawned team.
-  const createdTickets = new Set<string>();
-  const pendingTicketTools = new Set<string>();
-  let spawnedTeam: string | undefined;
+  const state = initCodexParseState();
 
   try {
     for await (const line of rl) {
@@ -3234,132 +3461,247 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
         continue;
       }
 
-      // PR signal, structurally: a Codex `function_call` whose command is
-      // `gh pr create`, then the pull URL from a `function_call_output`.
-      if (parsed.type === 'response_item') {
-        const p = parsed.payload || {};
-        if (p.type === 'function_call') {
-          let cmd = '';
-          try {
-            const args = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : (p.arguments || {});
-            cmd = String(args.command || args.cmd || '');
-          } catch { /* non-JSON args */ }
-          if (!prUrl && !sawPrCreate && isPrCreateCommand(cmd)) sawPrCreate = true;
-          if (!spawnedTeam) {
-            const team = detectSpawnedTeam(cmd);
-            if (team) spawnedTeam = team;
-          }
-          if (typeof p.call_id === 'string' && isTicketCreateTool(p.name, cmd)) {
-            pendingTicketTools.add(p.call_id);
-          }
-        }
-        if (p.type === 'function_call_output') {
-          if (!prUrl && sawPrCreate) {
-            const pr = extractPrUrl(String(p.output || ''));
-            if (pr) { prUrl = pr.url; prNumber = pr.number; }
-          }
-          if (typeof p.call_id === 'string' && pendingTicketTools.has(p.call_id)) {
-            pendingTicketTools.delete(p.call_id);
-            const t = extractCreatedTicket(String(p.output || ''));
-            if (t) createdTickets.add(t);
-          }
-        }
-      }
-
-      // Track duration across every timestamped event.
-      if (typeof parsed.timestamp === 'string') {
-        const ms = new Date(parsed.timestamp).getTime();
-        if (!Number.isNaN(ms)) {
-          if (firstTsMs === undefined || ms < firstTsMs) firstTsMs = ms;
-          if (lastTsMs === undefined || ms > lastTsMs) lastTsMs = ms;
-        }
-      }
-
-      if (parsed.type === 'session_meta') {
-        const payload = parsed.payload || {};
-        sessionId = payload.id || sessionId;
-        timestamp = payload.timestamp || parsed.timestamp || timestamp;
-        cwd = payload.cwd || cwd;
-        gitBranch = payload.git?.branch || gitBranch;
-        version = payload.cli_version || payload.version || version;
-        model = payload.model || model;
-        continue;
-      }
-
-      if (parsed.type === 'response_item' && parsed.payload?.type === 'message') {
-        const role = parsed.payload.role === 'user' || parsed.payload.role === 'developer'
-          ? 'user'
-          : 'assistant';
-        const text = extractCodexMessageText(parsed.payload.content, role);
-        if (!text) continue;
-        messageCount++;
-        if (role === 'user') {
-          userTexts.push(text);
-          if (!topic) topic = extractSessionTopic(text);
-        }
-        continue;
-      }
-
-      if (parsed.type === 'event_msg' && parsed.payload?.type === 'token_count') {
-        const totalUsage = parsed.payload.info?.total_token_usage;
-        const total = getCodexTokenCount(totalUsage);
-        if (total !== null) tokenCount = total;
-        // token_count is cumulative — keep the latest snapshot and price it once
-        // after the stream, so we don't double-count across intermediate events.
-        if (totalUsage && typeof totalUsage === 'object') lastTotalTokenUsage = totalUsage;
-        // Codex also stamps the model on the rate_limits/token_count payload on
-        // some versions; prefer session_meta but fall back to it.
-        if (!model && typeof parsed.payload.info?.model === 'string') model = parsed.payload.info.model;
-      }
+      applyCodexLine(state, parsed);
     }
   } finally {
     rl.close();
     stream.destroy();
   }
 
-  // Price the final cumulative token snapshot once, against the session model.
-  let costUsd: number | undefined;
-  if (model && lastTotalTokenUsage) {
-    const c = costOfUsage({
-      model,
-      inputTokens: lastTotalTokenUsage.input_tokens,
-      outputTokens: (lastTotalTokenUsage.output_tokens ?? 0) + (lastTotalTokenUsage.reasoning_output_tokens ?? 0),
-      cacheReadTokens: lastTotalTokenUsage.cached_input_tokens,
-    });
-    if (c > 0) costUsd = c;
+  return finalizeCodexScan(state);
+}
+
+/**
+ * SERIALIZED continuation blob persisted in `scan_ledger.parser_state` for a
+ * Codex rollout. Carries everything {@link hydrateCodexParseState} needs to
+ * resume a parse from `offset` such that resuming + applying the appended lines
+ * is byte-for-byte identical to a full parse of the whole file.
+ *
+ * Unlike Claude, Codex has NO per-message dedup set, so `messageCount` is a
+ * plain additive base with no recent-id window to persist. The `lastTotalTokenUsage`
+ * object is round-tripped whole so the last-wins cost/output-token pricing at
+ * finalize is identical after a resume.
+ */
+export interface CodexParserState {
+  v: 1;
+  offset: number;
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  model?: string;
+  topic?: string;
+  messageCount: number;
+  tokenCount?: number;
+  lastTotalTokenUsage?: any;
+  firstTsMs?: number;
+  lastTsMs?: number;
+  sawPrCreate: boolean;
+  prUrl?: string;
+  prNumber?: number;
+  pendingTicketTools: string[];
+  createdTickets: string[];
+  spawnedTeam?: string;
+  ticketId?: string;
+  contentText?: string;
+}
+
+/**
+ * Snapshot a live {@link CodexParseState} into its serializable form at `offset`
+ * bytes consumed. Round-trips through {@link hydrateCodexParseState} so
+ * incremental replay equals a full parse.
+ */
+export function serializeCodexParserState(state: CodexParseState, offset: number): CodexParserState {
+  const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
+  return {
+    v: 1,
+    offset,
+    sessionId: state.sessionId,
+    timestamp: state.timestamp,
+    cwd: state.cwd,
+    gitBranch: state.gitBranch,
+    version: state.version,
+    model: state.model,
+    topic: state.topic,
+    messageCount: state.messageCount,
+    tokenCount: state.tokenCount,
+    lastTotalTokenUsage: state.lastTotalTokenUsage,
+    firstTsMs: state.firstTsMs,
+    lastTsMs: state.lastTsMs,
+    sawPrCreate: state.sawPrCreate,
+    prUrl: state.prUrl,
+    prNumber: state.prNumber,
+    pendingTicketTools: [...state.pendingTicketTools],
+    createdTickets: [...state.createdTickets],
+    spawnedTeam: state.spawnedTeam,
+    // ticketId is derived at finalize time; persist it (and content_text) so a
+    // consumer can rebuild the row + FTS doc on append without re-reading the
+    // whole file. worktreeSlug is re-derived from cwd/gitBranch, so it need not
+    // be persisted.
+    ticketId: ticket?.id,
+    contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,
+  };
+}
+
+/**
+ * Rebuild a live {@link CodexParseState} from a persisted continuation so that
+ * applying the appended lines yields the same accumulator a full parse would.
+ *
+ * `userTexts` is rehydrated as a single joined blob from `contentText`: only
+ * `userTexts.join('\n')` (detectTicket + contentText) and `userTexts.length > 0`
+ * are ever read downstream, and both are preserved by a one-element array
+ * holding the joined content. Topic is first-wins and already persisted, so a
+ * collapsed userTexts never changes it.
+ */
+export function hydrateCodexParseState(prior: CodexParserState): CodexParseState {
+  return {
+    sessionId: prior.sessionId,
+    timestamp: prior.timestamp,
+    cwd: prior.cwd,
+    gitBranch: prior.gitBranch,
+    version: prior.version,
+    model: prior.model,
+    topic: prior.topic,
+    messageCount: prior.messageCount,
+    tokenCount: prior.tokenCount,
+    lastTotalTokenUsage: prior.lastTotalTokenUsage,
+    firstTsMs: prior.firstTsMs,
+    lastTsMs: prior.lastTsMs,
+    userTexts: prior.contentText !== undefined && prior.contentText.length > 0 ? [prior.contentText] : [],
+    sawPrCreate: prior.sawPrCreate,
+    prUrl: prior.prUrl,
+    prNumber: prior.prNumber,
+    createdTickets: new Set<string>(prior.createdTickets),
+    pendingTicketTools: new Set<string>(prior.pendingTicketTools),
+    spawnedTeam: prior.spawnedTeam,
+  };
+}
+
+/**
+ * Resume a Codex parse from `fromOffset` bytes into the file, folding only the
+ * newly-appended lines into `prior`. Returns the finalized scan, the next
+ * serialized continuation, and the byte offset to resume from next time.
+ *
+ * Same trailing-line discipline as {@link scanClaudeSessionIncremental}: apply
+ * ONLY the run of newline-terminated lines (slice at the last `'\n'`), and set
+ * `newOffset = fromOffset + consumedBytes`. Any tail after the last `'\n'` —
+ * syntactically broken OR a complete-but-not-yet-terminated record — is DEFERRED
+ * to the next pass once its `'\n'` lands. Codex `messageCount` is additive with
+ * NO dedup, so re-reading a still-unterminated complete line would double-count
+ * it; deferring prevents that (the bug class prix-cloud caught for Claude).
+ */
+export async function scanCodexSessionIncremental(
+  filePath: string,
+  fromOffset: number,
+  prior: CodexParserState,
+): Promise<{ scan: CodexSessionScan; newState: CodexParserState; newOffset: number }> {
+  const state = hydrateCodexParseState(prior);
+
+  const chunks: Buffer[] = [];
+  const stream = fs.createReadStream(filePath, { start: fromOffset });
+  try {
+    for await (const chunk of stream) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : chunk as Buffer);
+    }
+  } finally {
+    stream.destroy();
+  }
+  const appended = Buffer.concat(chunks);
+
+  // Bytes up to AND INCLUDING the last '\n' are the committed, complete-line run.
+  const lastNl = appended.lastIndexOf(0x0a);
+  const consumedBytes = lastNl === -1 ? 0 : lastNl + 1;
+
+  if (consumedBytes > 0) {
+    for (const line of appended.subarray(0, consumedBytes).toString('utf-8').split('\n')) {
+      if (!line.trim()) continue;
+
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      applyCodexLine(state, parsed);
+    }
   }
 
-  const durationMs =
-    firstTsMs !== undefined && lastTsMs !== undefined && lastTsMs > firstTsMs
-      ? lastTsMs - firstTsMs
-      : undefined;
-
-  const worktree = detectWorktree(cwd, gitBranch);
-  const ticket = detectTicket(userTexts.join('\n') || undefined, gitBranch);
-
+  const newOffset = fromOffset + consumedBytes;
   return {
-    sessionId,
-    timestamp,
-    cwd,
-    gitBranch,
-    version,
-    topic,
-    messageCount,
-    tokenCount,
-    outputTokens: lastTotalTokenUsage
-      ? (lastTotalTokenUsage.output_tokens ?? 0) + (lastTotalTokenUsage.reasoning_output_tokens ?? 0)
-      : undefined,
-    costUsd,
-    durationMs,
-    lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
-    contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
-    prUrl,
-    prNumber,
-    worktreeSlug: worktree?.slug,
-    ticketId: ticket?.id,
-    createdTickets: createdTickets.size > 0 ? [...createdTickets] : undefined,
-    spawnedTeam,
+    scan: finalizeCodexScan(state),
+    newState: serializeCodexParserState(state, newOffset),
+    newOffset,
   };
+}
+
+/** Serialized zero-value continuation: a fresh accumulator at offset 0, used to drive a FULL parse from the start through the same resumable path. */
+function freshCodexParserState(): CodexParserState {
+  return serializeCodexParserState(initCodexParseState(), 0);
+}
+
+/**
+ * Decide full-vs-incremental for one Codex rollout and parse it uniformly,
+ * always returning a finalized scan plus the continuation to persist. Both
+ * branches run through the SAME reducer (via {@link scanCodexSessionIncremental}),
+ * so an append produces a row identical to a from-scratch full reparse by
+ * construction. INCREMENTAL when a prior continuation exists AND the file grew
+ * past the persisted offset AND its mtime did not go backwards; FULL (from byte
+ * 0, fresh state) otherwise (cold start, truncation/rewrite, clock rewind).
+ */
+async function scanCodexSessionResumable(
+  filePath: string,
+  prior: CodexParserState | null,
+  currentFileMtimeMs: number,
+  currentFileSize: number,
+  priorFileMtimeMs?: number,
+): Promise<{ scan: CodexSessionScan; newState: CodexParserState; newOffset: number; mode: 'full' | 'incremental' }> {
+  const canIncrement =
+    prior !== null &&
+    currentFileSize > prior.offset &&
+    (priorFileMtimeMs === undefined || currentFileMtimeMs >= priorFileMtimeMs);
+
+  if (canIncrement) {
+    const result = await scanCodexSessionIncremental(filePath, prior.offset, prior);
+    return { ...result, mode: 'incremental' };
+  }
+
+  const result = await scanCodexSessionIncremental(filePath, 0, freshCodexParserState());
+  return { ...result, mode: 'full' };
+}
+
+/**
+ * Parse the prior continuation blob for a changed Codex file into a usable
+ * {@link CodexParserState}, or null when there is none / it is unusable. A blob
+ * from a different serialization version is treated as absent so the file falls
+ * back to a clean FULL parse rather than resuming against a stale shape.
+ */
+function parsePriorCodexState(row: { parserState: string | null } | undefined): CodexParserState | null {
+  if (!row?.parserState) return null;
+  try {
+    const parsed = JSON.parse(row.parserState) as CodexParserState;
+    if (parsed?.v !== 1 || typeof parsed.offset !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Test seam: how many times the incremental (append-resume) branch was taken since the last reset. */
+let codexIncrementalScanCount = 0;
+/** Test seam: how many times a full (from-offset-0) Codex parse ran since the last reset. */
+let codexFullScanCount = 0;
+
+/** Test seam: read the (incremental, full) Codex parse counters. */
+export function __codexScanBranchCountsForTest(): { incremental: number; full: number } {
+  return { incremental: codexIncrementalScanCount, full: codexFullScanCount };
+}
+
+/** Test seam: reset the Codex parse-branch counters to observe a scan from a clean slate. */
+export function __resetCodexScanBranchCountsForTest(): void {
+  codexIncrementalScanCount = 0;
+  codexFullScanCount = 0;
 }
 
 /** Resolve the working directory for an OpenClaw agent from its workspace config. */


### PR DESCRIPTION
## What

Extends the merged Claude incremental transcript parse (A-1..B-2) to the **Codex** rollout scanner and the **Kimi** `wire.jsonl` scanner — the two remaining append-only JSONL scanners that re-read from byte 0 on every scan. When an active session grows, `agents sessions` (and every scan consumer: `output` / `view` / `teams` / the watcher) now re-parses only the newly-appended bytes.

Two logical commits on one branch:
1. `perf(session): incremental Codex transcript parse on the live scan path`
2. `perf(session): incremental Kimi wire.jsonl parse + docs/changelog`

## Codex (`scanCodexSession`, discover.ts)

- Split into a reducer — `initCodexParseState` / `applyCodexLine` / `finalizeCodexScan` — with **byte-for-byte identical** `scanCodexSession` output (existing suite green).
- `scanCodexSessionIncremental(filePath, fromOffset, prior)` + a `CodexParserState` serialize/hydrate that round-trips **every** accumulator: the straddle state (`sawPrCreate`→`prUrl`/`prNumber`, `pendingTicketTools`→`createdTickets`, `spawnedTeam`), the additive `messageCount`, the **last-wins** `lastTotalTokenUsage` (cost + outputTokens), and the first-wins `session_meta` fields. Codex has **no per-message dedup set**, so `messageCount` is a plain additive base.
- `scanCodexSessionResumable` decides full-vs-incremental (resume when a prior continuation exists AND the file grew past the offset AND mtime did not go backwards; full from byte 0 otherwise). Wired through `readCodexMeta` → `scanCodexIncremental`, persisting `parser_state` on upsert.

## Kimi (`parseKimiWireMetrics`, discover.ts)

- Converted from `fs.readFileSync().split('\n')` to an incremental byte-range parse, resolving the `// TODO: optimize to stream`.
- Pure additive counters (`messageCount` / `tokenCount` / `outputTokens`), no straddle/dedup, so the continuation (`KimiParserState`) is just those 3 bases + the `wire.jsonl` offset. Resume when the wire grew; full-parse from byte 0 on cold start / truncation. Persisted on the session's `state.json` ledger row.

## Trailing-line discipline (mandatory, carried over)

Both `scanCodexSessionIncremental` and the Kimi incremental path use the **same** discipline as `scanClaudeSessionIncremental`: apply **only** newline-terminated lines (slice at the last `'\n'`, `newOffset = fromOffset + consumedBytes`) and **defer** any unterminated tail. This prevents the real double-count bug a prior review caught — a complete record whose `'\n'` wasn't yet flushed getting applied twice. Each scanner's parity harness includes that exact case.

## Tests / evidence

- `codex-incremental-parity.test.ts` — differential harness: boundary sweep, last-wins token usage across a boundary, straddled PR/ticket/team, truncation→full, and the complete-but-unterminated-trailing-line case.
- `codex-incremental-scan-e2e.test.ts` — through `discoverSessions` under a throwaway HOME, with a spy (`__codexScanBranchCountsForTest`) proving the **incremental** branch runs on the 2nd scan, and truncation forcing a full.
- `kimi-incremental-parity.test.ts` — boundary sweep, no-wire, truncation, partial + complete-unterminated trailing line, proving incremental counters === full counters.
- `parse-kimi.test.ts` fixture helper now newline-terminates its wire content (matching real Kimi `wire.jsonl`, which ends in `0x0a`).

Command: `npx vitest run src/lib/session/` — **726 passed (66 files)**. The 19 new tests run 3× in isolation with no flakiness. The intermittent `discover.test.ts > getSessionRoots "never throws"` redness is the **known pre-existing HOME-leak flake** (reproduced on clean `origin/main`: 706/707 with the identical single failure) — not touched here.

## Scope

Only **Codex + Kimi** are wired. **Grok is out of scope** — it reads a whole `summary.json`, not append-only JSONL. Claude / Gemini and the shared helpers (`filterChangedEntries`, db layer) are unchanged.

Docs: `apps/cli/docs/architecture.md`, `apps/cli/docs/05-sessions.md`, and a `.changelog/next/` fragment updated for the Codex + Kimi incremental model.