### PR TITLE
fix(session): never index an empty shortId (bare-prefix ids corrupted the picker)

### DIFF
--- a/apps/cli/.changelog/next/session-shortid-never-empty.md
+++ b/apps/cli/.changelog/next/session-shortid-never-empty.md
@@ -1,0 +1,13 @@
+- **`agents sessions` no longer corrupts the index with empty `shortId` rows.**
+  Session ids that are only a known prefix — a bare `session_` Rush directory, an
+  id of exactly `api-` (Hermes) or `ses_` (OpenCode) — used to strip to `''`
+  (`'session_'.replace(/^session_/, '').slice(0, 8) === ''`). An empty `shortId`
+  passes the `short_id TEXT NOT NULL` constraint (empty string is not NULL) yet
+  matches nothing in the `short_id LIKE ?` picker lookups, so the row was silently
+  unaddressable. All shortId derivation is now routed through one helper,
+  `deriveShortId`, that guarantees a non-empty result by falling back to the
+  unstripped id when the strip empties it. Every producer — the twelve parsers in
+  `discover.ts`, `session/cloud.ts`, `cloud/session-index.ts`, `hosts/session-index.ts`,
+  `session/fork.ts`, and `commands/go.ts` — uses it, replacing the duplicated inline
+  `.slice(0, 8)` (some with a `.replace(prefix, '')`). Source:
+  `apps/cli/src/lib/session/short-id.ts`.

--- a/apps/cli/src/commands/go.ts
+++ b/apps/cli/src/commands/go.ts
@@ -22,6 +22,7 @@ import { promisify } from 'util';
 import { getActiveSessions, findSessionFileForKind, type ActiveSession } from '../lib/session/active.js';
 import { gatherRemoteActive } from '../lib/session/remote-active.js';
 import { discoverSessions } from '../lib/session/discover.js';
+import { deriveShortId } from '../lib/session/short-id.js';
 import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
 import { dedupeByMachineSession, mergeLocalFirst, pickSessionInteractive } from './sessions.js';
 import { focusAction } from './focus.js';
@@ -104,7 +105,7 @@ function synthMeta(s: ActiveSession, self: string): SessionMeta {
   const filePath = remote ? '' : (findSessionFileForKind(s.kind, s.cwd, s.sessionId) ?? '');
   return {
     id: s.sessionId!,
-    shortId: s.sessionId!.slice(0, 8),
+    shortId: deriveShortId(s.sessionId!),
     agent: s.kind as SessionAgentId,
     timestamp: new Date(s.startedAtMs ?? Date.now()).toISOString(),
     filePath,

--- a/apps/cli/src/lib/cloud/session-index.ts
+++ b/apps/cli/src/lib/cloud/session-index.ts
@@ -20,6 +20,7 @@
 import { upsertSession } from '../session/db.js';
 import type { SessionAgentId } from '../session/types.js';
 import { SESSION_AGENTS } from '../session/types.js';
+import { deriveShortId } from '../session/short-id.js';
 import type { CloudTask } from './types.js';
 
 /** The execution-id charset the session index will accept as a row id. */
@@ -45,7 +46,7 @@ export function registerCloudSession(task: CloudTask, ctx: CloudSessionContext =
     upsertSession(
       {
         id: task.id,
-        shortId: task.id.slice(0, 8),
+        shortId: deriveShortId(task.id),
         agent: task.agent as SessionAgentId,
         timestamp: task.createdAt,
         lastActivity: task.updatedAt,

--- a/apps/cli/src/lib/hosts/session-index.ts
+++ b/apps/cli/src/lib/hosts/session-index.ts
@@ -19,6 +19,7 @@ import type { SessionMeta, SessionAgentId } from '../session/types.js';
 import { SESSION_AGENTS } from '../session/types.js';
 import { localLogPath, updateTask, type HostTask } from './tasks.js';
 import { parseSessionIdMarker } from './session-marker.js';
+import { deriveShortId } from '../session/short-id.js';
 
 export interface HostSessionContext {
   /** Local directory the `agents run --host` was invoked from. */
@@ -39,7 +40,7 @@ export function hostSessionMeta(task: HostTask, ctx: HostSessionContext): Sessio
 
   return {
     id,
-    shortId: id.slice(0, 8),
+    shortId: deriveShortId(id),
     agent: task.agent as SessionAgentId,
     timestamp: task.createdAt,
     cwd: ctx.cwd,
@@ -119,7 +120,7 @@ export function registerInteractiveHostSession(ctx: InteractiveHostSessionContex
     upsertSession(
       {
         id: ctx.sessionId,
-        shortId: ctx.sessionId.slice(0, 8),
+        shortId: deriveShortId(ctx.sessionId),
         agent: ctx.agent as SessionAgentId,
         timestamp: ctx.createdAt ?? new Date().toISOString(),
         cwd: ctx.cwd,

--- a/apps/cli/src/lib/session/cloud.ts
+++ b/apps/cli/src/lib/session/cloud.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
 import type { SessionAgentId, SessionMeta } from './types.js';
+import { deriveShortId } from './short-id.js';
 import { getCacheDir } from '../state.js';
 
 const PROXY_BASE = process.env.RUSH_PROXY_BASE ?? 'https://api.prix.dev';
@@ -124,7 +125,7 @@ export async function discoverCloudSessions(options?: {
 
     out.push({
       id,
-      shortId: id.slice(0, 8),
+      shortId: deriveShortId(id),
       agent,
       timestamp,
       project,

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -25,6 +25,7 @@ import { AGENTS, agentConfigDirName, getCliVersion } from '../agents.js';
 import { walkForFilesWithStat } from '../fs-walk.js';
 import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
+import { deriveShortId } from './short-id.js';
 import { extractSessionTopic } from './prompt.js';
 import { parseAntigravity } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand, detectSpawnedTeam, isTicketCreateTool, extractCreatedTicket } from './state.js';
@@ -1141,7 +1142,7 @@ async function readClaudeMeta(
     const cwd = normalizeCwd(scan.cwd || '');
     meta = {
       id: sessionId,
-      shortId: sessionId.slice(0, 8),
+      shortId: deriveShortId(sessionId),
       agent: 'claude',
       timestamp: scan.timestamp,
       lastActivity: scan.lastActivity,
@@ -1171,7 +1172,7 @@ async function readClaudeMeta(
     const stat = safeStatSync(filePath);
     meta = {
       id: sessionId,
-      shortId: sessionId.slice(0, 8),
+      shortId: deriveShortId(sessionId),
       agent: 'claude',
       timestamp: stat ? stat.mtime.toISOString() : new Date().toISOString(),
       lastActivity: scan.lastActivity,
@@ -1443,7 +1444,7 @@ export async function readCodexMeta(
   const cwd = normalizeCwd(scan.cwd || '');
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'codex',
     // Codex `session_meta` only carries the start time; use file mtime when
     // it's newer so long-running sessions register as recently active.
@@ -1668,7 +1669,7 @@ function readGeminiMeta(
 
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'gemini',
     timestamp: startTime || (stat ? stat.mtime.toISOString() : new Date().toISOString()),
     lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
@@ -1822,7 +1823,7 @@ function readAntigravityMeta(
   const stat = safeStatSync(filePath);
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'antigravity',
     timestamp: stat ? stat.mtime.toISOString() : new Date().toISOString(),
     project: normalizedCwd ? path.basename(normalizedCwd) : undefined,
@@ -1969,7 +1970,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
 
       const meta: SessionMeta = {
         id,
-        shortId: id.replace(/^ses_/, '').slice(0, 8),
+        shortId: deriveShortId(id, /^ses_/),
         agent: 'opencode',
         timestamp,
         lastActivity,
@@ -2040,7 +2041,7 @@ async function scanOpenClawIncremental(): Promise<void> {
       entries.push({
         meta: {
           id: `openclaw-${agentId}`,
-          shortId: agentId.slice(0, 8),
+          shortId: deriveShortId(agentId),
           agent: 'openclaw',
           timestamp: new Date().toISOString(),
           project: name,
@@ -2078,7 +2079,7 @@ async function scanOpenClawIncremental(): Promise<void> {
       entries.push({
         meta: {
           id: `openclaw-cron-${jobId}`,
-          shortId: jobId.slice(0, 8),
+          shortId: deriveShortId(jobId),
           agent: 'openclaw',
           timestamp: new Date().toISOString(),
           project: `${jobName} (${agentId || 'unknown'})`,
@@ -2175,7 +2176,7 @@ async function readRushMeta(
   const timestamp = scan.timestamp
     || (stat ? stat.mtime.toISOString() : new Date().toISOString());
 
-  const shortId = sessionId.replace(/^session_/, '').slice(0, 8);
+  const shortId = deriveShortId(sessionId, /^session_/);
 
   const meta: SessionMeta = {
     id: sessionId,
@@ -2341,7 +2342,7 @@ function readHermesMeta(filePath: string): { meta: SessionMeta; content: string 
       ? session.session_start
       : stat ? stat.mtime.toISOString() : new Date().toISOString();
 
-  const shortId = sessionId.replace(/^api-/, '').slice(0, 8);
+  const shortId = deriveShortId(sessionId, /^api-/);
   const model = typeof session.model === 'string' ? session.model : undefined;
   const platform = typeof session.platform === 'string' ? session.platform : undefined;
 
@@ -2466,7 +2467,7 @@ async function readDroidMeta(
   const cwd = normalizeCwd(scan.cwd || '');
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'droid',
     timestamp: scan.timestamp || (stat ? stat.mtime.toISOString() : new Date().toISOString()),
     lastActivity: scan.lastActivity,
@@ -3690,7 +3691,7 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
   const timestamp = updatedAt || createdAt
     || (stat ? stat.mtime.toISOString() : new Date().toISOString());
 
-  const shortId = sessionId.replace(/^session_/, '').slice(0, 8);
+  const shortId = deriveShortId(sessionId, /^session_/);
 
   // Try to infer project from session directory path
   // ~/.kimi-code/sessions/<workdir_hash>/session_<uuid>/
@@ -3880,7 +3881,7 @@ export function readGrokMeta(
 
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'grok',
     timestamp,
     lastActivity,

--- a/apps/cli/src/lib/session/fork.ts
+++ b/apps/cli/src/lib/session/fork.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import type { SessionMeta } from './types.js';
 import { upsertSession } from './db.js';
 import { recordRunName } from './run-names.js';
+import { deriveShortId } from './short-id.js';
 
 /** Agents that `fork` can branch today (see the module doc for why). */
 export const FORKABLE_AGENTS = ['claude'] as const;
@@ -85,7 +86,7 @@ export function forkSession(source: SessionMeta, opts: { name?: string; now?: st
   }
 
   const newId = randomUUID();
-  const shortId = newId.slice(0, 8);
+  const shortId = deriveShortId(newId);
   const dir = path.dirname(source.filePath);
   const filePath = path.join(dir, `${newId}.jsonl`);
 

--- a/apps/cli/src/lib/session/short-id.test.ts
+++ b/apps/cli/src/lib/session/short-id.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { deriveShortId } from './short-id';
+
+describe('deriveShortId', () => {
+  it('slices a plain UUID to 8 chars', () => {
+    expect(deriveShortId('05479a92-cbf0-4395-adb2-8e1437e0c206')).toBe('05479a92');
+  });
+
+  it('strips a known prefix before slicing', () => {
+    expect(deriveShortId('session_77e466b2-d222-4fc1-900d', /^session_/)).toBe('77e466b2');
+    expect(deriveShortId('api-abcdef012345', /^api-/)).toBe('abcdef01');
+    expect(deriveShortId('ses_zyxwvu987654', /^ses_/)).toBe('zyxwvu98');
+  });
+
+  // The regression: an id that is *only* its prefix strips to '' and used to
+  // corrupt the NOT NULL short_id index. It must never return empty.
+  it('never returns empty when the strip empties the id', () => {
+    expect(deriveShortId('session_', /^session_/)).toBe('session_');
+    expect(deriveShortId('api-', /^api-/)).toBe('api-');
+    expect(deriveShortId('ses_', /^ses_/)).toBe('ses_');
+  });
+
+  it('falls back to the raw id when it is shorter than 8 chars after strip', () => {
+    expect(deriveShortId('session_ab', /^session_/)).toBe('ab');
+  });
+
+  it('is non-empty for every non-empty id', () => {
+    for (const id of ['x', 'session_', 'api-', 'ses_', 'wd_muqsit', 'a-b-c']) {
+      expect(deriveShortId(id, /^(session_|api-|ses_)/)).not.toBe('');
+    }
+  });
+});

--- a/apps/cli/src/lib/session/short-id.ts
+++ b/apps/cli/src/lib/session/short-id.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical derivation of a session's 8-char `shortId`.
+ *
+ * Every session parser used to inline `id.slice(0, 8)` — some with a
+ * `.replace(prefix, '')` strip first (`session_`, `api-`, `ses_`). That strip is
+ * the bug: an id that is *only* its prefix (a bare `session_` directory, an id of
+ * exactly `api-`) strips to `''`, and `''.slice(0, 8)` is still `''`. An empty
+ * shortId then passes the `short_id TEXT NOT NULL` constraint (empty string is not
+ * NULL) yet matches nothing in the `short_id LIKE ?` picker lookups — a silently
+ * corrupt index row.
+ *
+ * This helper is the single source of truth: it strips the optional prefix, takes
+ * the first 8 chars, and — the whole point — guarantees a NON-EMPTY result by
+ * falling back to the unstripped id when the strip empties it, so a row always
+ * stays addressable by its shortId.
+ */
+export function deriveShortId(id: string, stripPrefix?: RegExp): string {
+  const stripped = stripPrefix ? id.replace(stripPrefix, '') : id;
+  return stripped.slice(0, 8) || id.slice(0, 8) || id;
+}


### PR DESCRIPTION
## Problem

`agents sessions` can index rows with an **empty `shortId`**, which silently corrupts the picker. Session ids that are *only* a known prefix strip to `''`:

```
'session_'.replace(/^session_/, '').slice(0, 8) === ''   // Rush
'api-'.replace(/^api-/, '').slice(0, 8)         === ''   // Hermes
'ses_'.replace(/^ses_/, '').slice(0, 8)         === ''   // OpenCode
```

An empty string **passes** the `short_id TEXT NOT NULL` constraint (empty is not NULL), so the row lands in the index — but it then matches nothing in the `short_id LIKE ?` picker lookups, so the session is unaddressable by its shortId. The existing per-row guard in `db.ts` only skips genuine NULLs, not `''`.

## Fix

One canonical derivation, `deriveShortId` (`apps/cli/src/lib/session/short-id.ts`), that **guarantees a non-empty result** by falling back to the unstripped id when the strip empties it. Every producer now routes through it, replacing the duplicated inline `.slice(0, 8)`:

- the twelve parsers in `session/discover.ts`
- `session/cloud.ts`, `cloud/session-index.ts`, `hosts/session-index.ts`, `session/fork.ts`, `commands/go.ts`

This is the "standardize at the source" + "harness parity" pattern — a single helper covering every harness, not a patch on the three prefix-strip parsers.

## Verification

- **Unit** — `short-id.test.ts` reproduces the bug input directly: `deriveShortId('session_', /^session_/)` used to be `''`, now `'session_'`. 5/5 pass.
- **End-to-end (real flow, no mocking)** — ran the real `discoverSessions` scan on a bare-`session_` Rush fixture under an isolated `HOME`; the real index row came back `short_id="session_"` (len 8, non-empty) instead of `''`:

  ```
  RUSH_ROWS=[{"id":"session_","shortId":"session_"}]
  DB_ROW=[{"id":"session_","short_id":"session_","len":8}]
  ```
- `tsc --noEmit`: 0 errors. Session/hosts/cloud test suites: green (the one flake seen locally was an `afterEach` DB-contention timeout in `discover.test.ts`, passes in isolation — unrelated to this change; it stems from that test writing to the real `sessions.db`, tracked separately).

## Follow-ups (not in this PR)

- `discover.test.ts` "routine archive discovery" writes to the **real** `sessions.db` (`getDB()`), which is both the flake source and the same class as the leftover test-fixture rows (`aaaaaaaa-…`, `bbbbbbbb-…`) polluting the production index. Test isolation under a temp `HOME` is the fix.

Transcript: yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/52652bb6-04a2-4208-9cf4-f74a43369b13.jsonl
