### PR TITLE
fix(session): heal pre-existing empty-shortId rows on upgrade (v16 migration)

### DIFF
--- a/apps/cli/.changelog/next/heal-empty-shortid.md
+++ b/apps/cli/.changelog/next/heal-empty-shortid.md
@@ -1,0 +1,8 @@
+- **`agents sessions` now heals any pre-existing empty-`shortId` rows on upgrade.**
+  The prior fix stopped *producing* empty shortIds (bare-prefix ids like a `session_`
+  directory stripped to `''`), but a row already poisoned in the index did not
+  self-heal — an empty shortId is not re-parsed unless its transcript changes, and an
+  orphaned row whose file is gone never re-parses at all, so it stayed unaddressable in
+  the `short_id LIKE ?` picker lookups. A one-time schema migration (v16) repairs every
+  such row in place (`short_id = substr(id, 1, 8)`), so upgrading users get a clean
+  index without a full rescan. Source: `apps/cli/src/lib/session/db.ts`.

--- a/apps/cli/src/lib/session/__tests__/db.migrations.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.migrations.test.ts
@@ -1,0 +1,44 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Set HOME before db.js loads so its module-level DB path picks up the override.
+// (Plain top-level statements run before the dynamic `await import` below.)
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-db-migrations-'));
+process.env.HOME = TEST_HOME;
+
+const { getDB, closeDB, upsertSession, getSessionById } = await import('../db.js');
+type SessionMeta = import('../types.js').SessionMeta;
+
+afterAll(() => {
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('empty-shortId repair migration (v16)', () => {
+  it('heals a row the pre-fix parser left with an empty short_id', () => {
+    // Reproduce the corruption: a bare-prefix id whose shortId stripped to ''.
+    // upsertSession binds meta.shortId verbatim (deriveShortId lives in the
+    // parsers, not here), so '' lands in the index exactly as the old code did.
+    const corrupt = {
+      id: 'session_',
+      shortId: '',
+      agent: 'rush',
+      timestamp: '2026-07-31T20:00:00.000Z',
+      filePath: '/tmp/gone/session_/messages.jsonl',
+    } as SessionMeta;
+    upsertSession(corrupt, 'hello bare prefix');
+    expect(getSessionById('session_')?.shortId).toBe(''); // corruption reproduced
+
+    // Simulate an un-migrated (pre-v16) DB and reopen so migrateSchema runs.
+    const db = getDB();
+    db.prepare(`INSERT OR REPLACE INTO meta(key, value) VALUES ('schema_version', '15')`).run();
+    closeDB();
+
+    getDB(); // reopen -> currentVersion 15 < SCHEMA_VERSION -> v16 repair runs
+    const healed = getSessionById('session_');
+    expect(healed?.shortId).toBe('session_'); // substr(id,1,8), non-empty + addressable
+    expect(healed?.shortId).not.toBe('');
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -141,7 +141,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('15');
+    expect(row.value).toBe('16');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {

--- a/apps/cli/src/lib/session/db.migrate-v14.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v14.test.ts
@@ -98,7 +98,7 @@ describe('schema migration v13 -> current (dir_ledger + resumable parser)', () =
   it('bumps the recorded schema version to the current version', () => {
     const db = getDB();
     const v = (db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string }).value;
-    expect(v).toBe('15');
+    expect(v).toBe('16');
   });
 
   it('preserves existing session rows through the migration', () => {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -17,7 +17,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 15;
+const SCHEMA_VERSION = 16;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -370,6 +370,20 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     if (!cols.some(c => c.name === 'parser_state')) db.exec(`ALTER TABLE scan_ledger ADD COLUMN parser_state TEXT`);
     if (!cols.some(c => c.name === 'content_text')) db.exec(`ALTER TABLE scan_ledger ADD COLUMN content_text TEXT`);
     db.exec(`DELETE FROM scan_ledger;`);
+  }
+
+  if (fromVersion < 16) {
+    // v15 → v16: repair rows poisoned by the empty-shortId bug (now fixed at the
+    // source in deriveShortId). A session id that was only a known prefix — a bare
+    // `session_` dir, an id of exactly `api-` or `ses_` — derived to '' via
+    // `id.replace(prefix, '').slice(0, 8)`, passed the `short_id TEXT NOT NULL`
+    // column (empty string is not NULL), yet matched nothing in the
+    // `short_id LIKE ?` picker lookups. The parser no longer produces '', but
+    // existing rows don't self-heal: an empty short_id is not re-parsed unless its
+    // file changes, and an orphaned row (file gone) never re-parses at all. Repair
+    // in place — `substr(id, 1, 8)` is non-empty because `id` is the non-empty
+    // primary key — so every corrupt row becomes addressable. No rescan needed.
+    db.exec(`UPDATE sessions SET short_id = substr(id, 1, 8) WHERE short_id IS NULL OR short_id = ''`);
   }
 }
 


### PR DESCRIPTION
## Why (thinking about users, not just my box)

PR #1514 fixed the **producer** — parsers no longer derive an empty `shortId` for bare-prefix ids (`session_`, `api-`, `ses_`). But that doesn't help a user whose index is **already** poisoned:

- An empty `short_id` row is **not re-parsed** unless its transcript file changes (the scan ledger skips unchanged files).
- An **orphaned** row (transcript deleted) never re-parses at all.

So after upgrading, those rows stay `short_id = ''` — present in the table but matching nothing in the `short_id LIKE ?` picker lookups. The code fix alone leaves them broken.

## Fix

A one-time schema migration (**v15 → v16**) that repairs every poisoned row in place:

```sql
UPDATE sessions SET short_id = substr(id, 1, 8) WHERE short_id IS NULL OR short_id = '';
```

`substr(id, 1, 8)` is guaranteed non-empty because `id` is the non-empty primary key, and it matches what the fixed `deriveShortId` returns for a bare-prefix id (its fallback is the unstripped id). Runs once on the next `getDB()` after upgrade, no full rescan, orphaned rows included. Fresh DBs skip it (they have no corrupt rows).

## Verification

- **Real path, no mocking** — `db.migrations.test.ts` reproduces the corruption via the real `upsertSession` (inserts `short_id = ''`), downgrades the DB to `schema_version = 15`, reopens through the real `getDB()` so `migrateSchema` runs, and asserts the row healed to `'session_'` (non-empty, addressable). 1/1.
- Full db suite green (41/41; updated the `schema_version is recorded as the current version` assertion `15 → 16`). `tsc --noEmit`: 0 errors.
- **My own live index** was also cleaned directly (2 stale test-fixture rows removed; `empty_short` now 0) — this migration is the shippable equivalent for everyone else.

## Companion

Builds on #1514 (the producer fix, already merged). Separate follow-up still open: `discover.test.ts`'s routine-archive test writes to the real `sessions.db`, which is how those fixture rows leaked into a live index in the first place — test-HOME isolation is the fix for that.

Transcript: yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/52652bb6-04a2-4208-9cf4-f74a43369b13.jsonl
