### PR TITLE
feat(feed): agents feed post for deliberate status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ agents feed --flat                  # one row per agent (legacy)
 agents feed --host mac-mini         # scope the view to one or more hosts
 agents feed --local                 # skip the SSH fan-out
 agents feed --json                  # blocks stamped with their outcome key
+agents feed post "halfway done"     # agent status post (auto session identity)
 ```
 
 Top-level questions and waiting notifications publish one atomic open-block record per session, including the mailbox id, host, runtime, and every answer option. The default view collapses agents under the **outcome** they serve (Linear ticket, PR, worktree slug, or Unassigned) so a 1,100-agent fleet reads as dozens of deliverables. Answered, resumed, and stopped blocks clear automatically; Task subagents are excluded. The rendered reply command uses the same mailbox id with `agents message`, so the decision routes back to the agent that asked it.

--- a/apps/cli/.changelog/next/feed-post-status.md
+++ b/apps/cli/.changelog/next/feed-post-status.md
@@ -1,0 +1,9 @@
+- **`agents feed post` — agents announce progress without opening a “needs you”
+  block.** Free-text status posts append a `status.posted` milestone to the
+  per-session activity log (same stream as `agents activity` and the feed’s
+  recent-activity lane). Session/agent/host/runtime/pid/launch identity is
+  auto-stamped from the process env and the per-pid launch registry — no
+  domain-specific flags (tickets, URLs). Managed runs export `AGENT_SESSION_ID`
+  / `AGENTS_AGENT_NAME` / `AGENTS_CWD` so a Bash tool call needs no extra
+  wiring. Source: `apps/cli/src/lib/feed-post.ts`, `apps/cli/src/commands/feed.ts`,
+  `apps/cli/src/lib/activity.ts`, `apps/cli/src/lib/exec.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 ## 1.20.74
 
-- **`agents feed post` — agents announce progress without opening a “needs you”
-  block.** Free-text status posts append a `status.posted` milestone to the
-  per-session activity log (same stream as `agents activity` and the feed’s
-  recent-activity lane). Session/agent/host/runtime/pid/launch identity is
-  auto-stamped from the process env and the per-pid launch registry — no
-  domain-specific flags (tickets, URLs). Managed runs export `AGENT_SESSION_ID`
-  / `AGENTS_AGENT_NAME` / `AGENTS_CWD` so a Bash tool call needs no extra
-  wiring. Source: `apps/cli/src/lib/feed-post.ts`, `apps/cli/src/commands/feed.ts`,
-  `apps/cli/src/lib/activity.ts`, `apps/cli/src/lib/exec.ts`.
-
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 1.20.74
 
+- **`agents feed post` — agents announce progress without opening a “needs you”
+  block.** Free-text status posts append a `status.posted` milestone to the
+  per-session activity log (same stream as `agents activity` and the feed’s
+  recent-activity lane). Session/agent/host/runtime/pid/launch identity is
+  auto-stamped from the process env and the per-pid launch registry — no
+  domain-specific flags (tickets, URLs). Managed runs export `AGENT_SESSION_ID`
+  / `AGENTS_AGENT_NAME` / `AGENTS_CWD` so a Bash tool call needs no extra
+  wiring. Source: `apps/cli/src/lib/feed-post.ts`, `apps/cli/src/commands/feed.ts`,
+  `apps/cli/src/lib/activity.ts`, `apps/cli/src/lib/exec.ts`.
+
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -305,6 +305,32 @@ agents feed --pause <id>   # SIGSTOP a local process; cloud tasks are cancelled
 agents feed --kill <id>    # SIGTERM a local process; cloud tasks are cancelled
 ```
 
+### Status posts (`agents feed post`) — agent progress, not “needs you”
+
+Agents can deliberately announce progress without opening a feed block. The
+command is free-text and domain-agnostic; session/agent/host/runtime/pid
+identity is stamped automatically from the process env and the per-pid launch
+registry (`lib/session/pid-registry.ts`).
+
+```bash
+# Inside an agents-cli run (AGENT_SESSION_ID / AGENTS_MAILBOX_DIR already set):
+agents feed post "CHANGELOG pushed; watching CI and mac-mini E2E"
+agents feed post "ready for review" --json
+
+# Escape hatch when not in a managed run:
+agents feed post "note" --session <session-id>
+```
+
+Each post appends a `status.posted` **milestone** to
+`~/.agents/.history/activity/<sessionId>.jsonl` — the same activity stream
+`agents activity` and the feed’s recent-activity lane already read. It does
+**not** create a feed block. Domain facts (tickets, PRs) are not CLI flags;
+join them from the session index / live session enrichment at read time.
+
+Identity resolution order: `--session` → `AGENT_SESSION_ID` /
+`AGENTS_SESSION_ID` / mailbox basename → `AGENT_LAUNCH_ID` match in the pid
+registry → parent-pid walk through `by-pid/<pid>.json`.
+
 ### Live tail (`--watch`, `-f`) — the money shot
 
 ```bash

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -1,6 +1,7 @@
 /**
- * `agents feed` -- list open blocks (decisions agents are waiting on).
+ * `agents feed` -- operator inbox + agent status posts.
  *
+ * Default (`agents feed`): list open blocks (decisions agents are waiting on).
  * Aggregates block records from the local feed store and, with --host, from
  * reachable remote hosts via SSH passthrough. Each block carries enough
  * identity for `agents message` to route a reply back to the right agent.
@@ -8,11 +9,17 @@
  * Default view groups by **outcome** (ticket / PR / worktree / Unassigned) so
  * an operator sees dozens of deliverables, not ~1,100 agents. Pass `--flat`
  * for the legacy per-agent list.
+ *
+ * `agents feed post`: agent-callable free-text progress into the activity
+ * stream (milestone `status.posted`). Session/agent/host/runtime/pid identity
+ * is auto-stamped from env + the pid registry — no domain-specific flags.
+ * Humans watch via the feed activity lane / `agents activity`.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { ensureFeedPublishHook, listAskStats, listBlocks, recordNotified, type OpenBlock } from '../lib/feed.js';
 import { ensureActivityLogHook, readRecentActivity, formatActivityLine } from '../lib/activity.js';
+import { postFeedStatus } from '../lib/feed-post.js';
 import {
   enrichBlocksFromSessions,
   groupBlocksByOutcome,
@@ -274,9 +281,9 @@ export function sessionHintsFromActive(
 }
 
 export function registerFeedCommand(program: Command): void {
-  program
+  const feed = program
     .command('feed')
-    .description('List open blocks -- decisions agents are waiting on (grouped by outcome)')
+    .description('Open blocks (needs you) + agent status posts (feed post)')
     .option('--json', 'Output as JSON (each block stamped with its outcome + ask class)')
     .option('--flat', 'List one block per agent instead of grouping by outcome')
     .option('--all', 'Include stalls/FYIs that policy would suppress (default: hide them)')
@@ -285,8 +292,55 @@ export function registerFeedCommand(program: Command): void {
     .option('--device <target...>', 'Alias for --host; repeatable')
     .option('--dispatch', 'Run stall suppression + default-on-no-answer policy and urgent notifications')
     .option('--pause <id>', 'Pause a runaway/needy local process (SIGSTOP) or cancel a cloud task')
-    .option('--kill <id>', 'Kill a runaway/needy local process (SIGTERM) or cancel a cloud task')
-    .action(async (opts: {
+    .option('--kill <id>', 'Kill a runaway/needy local process (SIGTERM) or cancel a cloud task');
+
+  feed
+    .command('post')
+    .description('Post a status update to the fleet activity stream (for agents)')
+    .argument('<text...>', 'What just happened — one short human line')
+    .option('--session <id>', 'Session id escape hatch (default: auto from env / pid registry)')
+    .option('--json', 'Emit the written event as JSON')
+    .addHelpText('after', `
+Examples:
+  # Inside an agents-cli run (session identity is already in the env):
+  agents feed post "CHANGELOG pushed; watching CI and mac-mini E2E"
+  agents feed post "ready for review" --json
+
+  # Outside a run, pass the session explicitly:
+  agents feed post "manual note" --session 00998b0e-2d15-4d2f-a58b-974a886c9b47
+
+Identity (session, agent, host, runtime, pid, launchId) is stamped automatically.
+Domain facts (tickets, PRs) are not CLI flags — join them on the session at read time.
+`)
+    .action((
+      textParts: string[],
+      opts: { session?: string; json?: boolean },
+      cmd?: { opts: () => { session?: string; json?: boolean }; parent?: { opts: () => { json?: boolean } } },
+    ) => {
+      // Parent `feed` also declares `--json` (for the list view). Commander
+      // binds the flag on the parent, so a `feed post … --json` lands on
+      // parent.opts().json — not the child. Read both.
+      const flags = {
+        session: opts?.session ?? cmd?.opts?.()?.session,
+        json: Boolean(opts?.json ?? cmd?.opts?.()?.json ?? cmd?.parent?.opts?.()?.json),
+      };
+      try {
+        const { event } = postFeedStatus({
+          text: Array.isArray(textParts) ? textParts.join(' ') : String(textParts ?? ''),
+          sessionId: flags.session,
+        });
+        if (flags.json) {
+          console.log(JSON.stringify(event, null, 2));
+          return;
+        }
+        console.log(formatActivityLine(event, { showHost: true }).trimStart());
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exitCode = 1;
+      }
+    });
+
+  feed.action(async (opts: {
       json?: boolean;
       flat?: boolean;
       all?: boolean;

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -80,8 +80,38 @@ describe('activity log store (TS)', () => {
   it('classifies tiers correctly', () => {
     expect(tierForEvent('pr.opened')).toBe('milestone');
     expect(tierForEvent('subagent.spawned')).toBe('milestone');
+    expect(tierForEvent('status.posted')).toBe('milestone');
     expect(tierForEvent('file.edited')).toBe('activity');
     expect(tierForEvent('unknown.thing')).toBe('activity');
+  });
+
+  it('round-trips status.posted identity fields through the activity log', () => {
+    const dir = tmpActivityDir();
+    appendActivityEvent({
+      ts: '2026-07-31T12:00:00.000Z',
+      event: 'status.posted',
+      sessionId: 's-status',
+      mailboxId: 's-status',
+      host: 'zion',
+      runtime: 'teams',
+      agent: 'grok',
+      tool: 'feed.post',
+      detail: 'halfway',
+      pid: 99,
+      launchId: 'L1',
+      tmuxPane: '%2',
+    }, dir);
+    const events = readSessionActivity('s-status', dir);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: 'status.posted',
+      tier: 'milestone',
+      detail: 'halfway',
+      pid: 99,
+      launchId: 'L1',
+      tmuxPane: '%2',
+      agent: 'grok',
+    });
   });
 });
 

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -37,7 +37,9 @@ export type MilestoneEvent =
   | 'commit.created'
   | 'pushed'
   | 'subagent.spawned'
-  | 'artifact.created';
+  | 'artifact.created'
+  /** Deliberate agent-authored progress post (`agents feed post`). */
+  | 'status.posted';
 
 /** Routine activity events, collapsed to counts by readers. */
 export type ActivityKind = 'file.edited';
@@ -57,6 +59,7 @@ export const MILESTONE_EVENTS: readonly MilestoneEvent[] = [
   'pushed',
   'subagent.spawned',
   'artifact.created',
+  'status.posted',
 ];
 
 const MILESTONE_SET = new Set<string>(MILESTONE_EVENTS);
@@ -86,12 +89,20 @@ export interface ActivityEvent {
   cwd?: string;
   /** Agent that produced the event (claude, codex, ...). */
   agent?: string;
-  /** Tool that triggered the event (Bash, Task, ExitPlanMode, ...). */
+  /** Tool that triggered the event (Bash, Task, ExitPlanMode, feed.post, ...). */
   tool?: string;
-  /** One-line human summary (plan title, PR command, sub-agent role). */
+  /** One-line human summary (plan title, PR command, sub-agent role, status text). */
   detail?: string;
   /** Extracted URL when the event has one (e.g. the opened PR). */
   url?: string;
+  /** Auto-stamped process identity for deliberate posts (from pid registry / env). */
+  pid?: number;
+  /** Spawn-time join key (`AGENT_LAUNCH_ID`) when known. */
+  launchId?: string;
+  /** Factory terminal id when the launch inherited one. */
+  terminalId?: string;
+  /** `$TMUX_PANE` at launch when recorded. */
+  tmuxPane?: string;
 }
 
 function activityPath(root: string, sessionId: string): string {
@@ -139,6 +150,10 @@ function parseLine(line: string): ActivityEvent | undefined {
       tool: parsed.tool,
       detail: parsed.detail,
       url: parsed.url,
+      pid: typeof parsed.pid === 'number' ? parsed.pid : undefined,
+      launchId: parsed.launchId,
+      terminalId: parsed.terminalId,
+      tmuxPane: parsed.tmuxPane,
     };
   } catch {
     return undefined; // skip corrupt / partial lines (fail-open reader)
@@ -267,11 +282,11 @@ export function activityEventToRecord(ev: ActivityEvent): EventRecord {
     hostname: ev.host,
     platform: process.platform,
     arch: process.arch,
-    pid: 0,
+    pid: ev.pid ?? 0,
     ppid: 0,
     event: ev.event as EventRecord['event'],
     level: 'info',
-    caller: 'hook',
+    caller: ev.tool === 'feed.post' ? 'agent' : 'hook',
     session: ev.sessionId,
     osUser: ev.agent ?? 'agent',
     transport: 'local',
@@ -284,6 +299,9 @@ export function activityEventToRecord(ev: ActivityEvent): EventRecord {
     detail: ev.detail,
     url: ev.url,
     tier: ev.tier,
+    ...(ev.launchId ? { launchId: ev.launchId } : {}),
+    ...(ev.terminalId ? { terminalId: ev.terminalId } : {}),
+    ...(ev.tmuxPane ? { tmuxPane: ev.tmuxPane } : {}),
   } as EventRecord;
 }
 
@@ -307,6 +325,7 @@ export const EVENT_STYLE: Record<string, { glyph: string; color: (s: string) => 
   'pushed': { glyph: '↥', color: chalk.yellow, label: 'pushed' },
   'subagent.spawned': { glyph: '⑂', color: chalk.magenta, label: 'sub-agent spawned' },
   'artifact.created': { glyph: '▤', color: chalk.cyan, label: 'artifact' },
+  'status.posted': { glyph: '▸', color: chalk.white, label: 'status' },
   'file.edited': { glyph: '·', color: chalk.gray, label: 'file edited' },
 };
 
@@ -319,10 +338,13 @@ export function formatActivityLine(ev: ActivityEvent, opts: { showHost?: boolean
   const s = styleForEvent(ev.event);
   const host = opts.showHost && ev.host && ev.host !== 'unknown' ? chalk.gray(`[${ev.host}] `) : '';
   const label = s.color(`${s.glyph} ${s.label}`);
-  const detail = ev.detail ? ` ${truncate(ev.detail, 60)}` : '';
+  // Status posts are the message; allow a longer snippet than tool-derived detail.
+  const detailLimit = ev.event === 'status.posted' ? 100 : 60;
+  const detail = ev.detail ? ` ${truncate(ev.detail, detailLimit)}` : '';
   const url = ev.url ? chalk.gray(` ${ev.url}`) : '';
+  const agent = ev.event === 'status.posted' && ev.agent ? chalk.gray(` · ${ev.agent}`) : '';
   const when = chalk.gray(relTime(ev.ts).padStart(7));
-  return `  ${when}  ${host}${label}${detail}${url}`;
+  return `  ${when}  ${host}${label}${detail}${agent}${url}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -362,7 +384,7 @@ MAX_LOG_BYTES = 5 * 1024 * 1024  # cap a pathological session's log
 MILESTONE_EVENTS = {
     "plan.created", "pr.opened", "pr.merged", "worktree.created",
     "worktree.removed", "commit.created", "pushed", "subagent.spawned",
-    "artifact.created",
+    "artifact.created", "status.posted",
 }
 
 # Deliverable file types + locations -- a Write here is a recognizable artifact

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -131,6 +131,7 @@ export type EventType =
   | 'pushed'
   | 'subagent.spawned'
   | 'artifact.created'
+  | 'status.posted'
   | 'file.edited'
   // Generic
   | 'error'

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -136,11 +136,16 @@ describe('buildExecEnv — AGENTS_MAILBOX_DIR wiring (mailbox loop-closer)', () 
     const sid = '96aa7271-0c8f-4ed7-8811-1ad1d305e46e';
     const env = buildExecEnv(execOpts({ agent: 'claude', sessionId: sid }));
     expect(env.AGENTS_MAILBOX_DIR).toBe(mailboxDir(sid));
+    // Session id is exported so agent tools (`agents feed post`) auto-attribute.
+    expect(env.AGENT_SESSION_ID).toBe(sid);
+    expect(env.AGENTS_SESSION_ID).toBe(sid);
+    expect(env.AGENTS_AGENT_NAME).toBe('claude');
   });
 
   it('sets nothing when there is no session id (nothing to key a box on)', () => {
     const env = buildExecEnv(execOpts({ agent: 'claude' }));
     expect(env.AGENTS_MAILBOX_DIR).toBeUndefined();
+    expect(env.AGENT_SESSION_ID).toBeUndefined();
   });
 
   it('lets a caller override the box via options.env (how the loop pins the run-level box)', () => {

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -422,8 +422,18 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
   // iterations share one inbox.
   if (options.sessionId && isValidMailboxId(options.sessionId)) {
     result.AGENTS_MAILBOX_DIR = mailboxDir(options.sessionId);
+    // Full session id for agent-callable tools (`agents feed post`, etc.).
+    result.AGENT_SESSION_ID = options.sessionId;
+    result.AGENTS_SESSION_ID = options.sessionId;
   }
   result.AGENTS_RUNTIME = resolveInteractive(options) ? 'terminal' : 'headless';
+  // So activity / feed posts stamp the right harness without re-detecting.
+  if (options.agent) {
+    result.AGENTS_AGENT_NAME = options.agent;
+  }
+  if (options.cwd) {
+    result.AGENTS_CWD = options.cwd;
+  }
 
   // Export the run's durable name (companion to AGENT_SESSION_ID) so a
   // SessionStart hook / the agent can associate its transcript with the handle

--- a/apps/cli/src/lib/feed-post.test.ts
+++ b/apps/cli/src/lib/feed-post.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  normalizeStatusText,
+  postFeedStatus,
+  resolvePostIdentity,
+  walkPidRegistry,
+  STATUS_POST_MAX_CHARS,
+} from './feed-post.js';
+import { readSessionActivity, tierForEvent } from './activity.js';
+import type { PidSessionEntry } from './session/pid-registry.js';
+
+function tmpActivityDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-post-'));
+}
+
+describe('normalizeStatusText', () => {
+  it('collapses whitespace and rejects empty', () => {
+    expect(normalizeStatusText('  hello   world  ')).toBe('hello world');
+    expect(normalizeStatusText(' \n\t ')).toBe('');
+  });
+
+  it('caps length with an ellipsis', () => {
+    const long = 'x'.repeat(STATUS_POST_MAX_CHARS + 50);
+    const out = normalizeStatusText(long);
+    expect(out.length).toBe(STATUS_POST_MAX_CHARS);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});
+
+describe('resolvePostIdentity', () => {
+  it('prefers explicit session over env', () => {
+    const id = resolvePostIdentity({
+      sessionId: 'sess-explicit',
+      env: {
+        AGENT_SESSION_ID: 'sess-env',
+        AGENTS_AGENT_NAME: 'claude',
+        AGENTS_RUNTIME: 'teams',
+        AGENTS_SYNC_MACHINE_ID: 'zion',
+      },
+    });
+    expect(id?.sessionId).toBe('sess-explicit');
+    expect(id?.agent).toBe('claude');
+    expect(id?.runtime).toBe('teams');
+    expect(id?.host).toBe('zion');
+  });
+
+  it('resolves session from AGENTS_MAILBOX_DIR basename', () => {
+    const id = resolvePostIdentity({
+      env: {
+        AGENTS_MAILBOX_DIR: '/home/u/.agents/.history/mailbox/sess-from-box',
+        AGENTS_AGENT_NAME: 'grok',
+      },
+    });
+    expect(id?.sessionId).toBe('sess-from-box');
+    expect(id?.mailboxId).toBe('sess-from-box');
+    expect(id?.agent).toBe('grok');
+  });
+
+  it('matches AGENT_LAUNCH_ID in the pid registry', () => {
+    const entries: PidSessionEntry[] = [
+      {
+        pid: 4242,
+        agent: 'claude',
+        sessionId: 'sess-launch',
+        launchId: 'launch-abc',
+        cwd: '/repo',
+        tmuxPane: '%3',
+        startedAtMs: 1,
+      },
+    ];
+    const id = resolvePostIdentity({
+      env: { AGENT_LAUNCH_ID: 'launch-abc' },
+      listEntries: () => entries,
+      readEntry: () => undefined,
+      startPid: 1,
+    });
+    expect(id?.sessionId).toBe('sess-launch');
+    expect(id?.pid).toBe(4242);
+    expect(id?.launchId).toBe('launch-abc');
+    expect(id?.tmuxPane).toBe('%3');
+    expect(id?.cwd).toBe('/repo');
+  });
+
+  it('walks parent pids to find a registry entry', () => {
+    const entries = new Map<number, PidSessionEntry>([
+      [100, { pid: 100, agent: 'codex', sessionId: 'sess-parent', cwd: '/w', startedAtMs: 1 }],
+    ]);
+    const parents = new Map<number, number>([[200, 100], [100, 1]]);
+    const id = resolvePostIdentity({
+      env: {},
+      startPid: 200,
+      getParentPid: (p) => parents.get(p),
+      readEntry: (p) => entries.get(p),
+      listEntries: () => [],
+    });
+    expect(id?.sessionId).toBe('sess-parent');
+    expect(id?.agent).toBe('codex');
+    expect(id?.pid).toBe(100);
+  });
+
+  it('returns undefined when nothing resolves', () => {
+    expect(resolvePostIdentity({
+      env: {},
+      startPid: 1,
+      getParentPid: () => undefined,
+      readEntry: () => undefined,
+      listEntries: () => [],
+    })).toBeUndefined();
+  });
+});
+
+describe('walkPidRegistry', () => {
+  it('returns the first ancestor with a sessionId', () => {
+    const entries = new Map<number, PidSessionEntry>([
+      [50, { pid: 50, agent: 'claude', startedAtMs: 1 }],
+      [10, { pid: 10, agent: 'claude', sessionId: 's10', startedAtMs: 1 }],
+    ]);
+    const parents = new Map<number, number>([[90, 50], [50, 10], [10, 1]]);
+    const hit = walkPidRegistry(90, (p) => parents.get(p), (p) => entries.get(p));
+    expect(hit?.sessionId).toBe('s10');
+  });
+});
+
+describe('postFeedStatus', () => {
+  it('writes a status.posted milestone with auto identity', () => {
+    const dir = tmpActivityDir();
+    const { event } = postFeedStatus({
+      text: '  Track complete  ',
+      sessionId: 'sess-post-1',
+      activityRoot: dir,
+      env: {
+        AGENTS_AGENT_NAME: 'grok',
+        AGENTS_RUNTIME: 'teams',
+        AGENTS_SYNC_MACHINE_ID: 'yosemite-s1',
+        AGENTS_CWD: '/repo/foreman',
+        AGENT_LAUNCH_ID: 'launch-1',
+      },
+      ts: '2026-07-31T12:00:00.000Z',
+      listEntries: () => [],
+      readEntry: () => undefined,
+      startPid: 1,
+    });
+
+    expect(event.event).toBe('status.posted');
+    expect(tierForEvent(event.event)).toBe('milestone');
+    expect(event.detail).toBe('Track complete');
+    expect(event.sessionId).toBe('sess-post-1');
+    expect(event.agent).toBe('grok');
+    expect(event.runtime).toBe('teams');
+    expect(event.host).toBe('yosemite-s1');
+    expect(event.cwd).toBe('/repo/foreman');
+    expect(event.tool).toBe('feed.post');
+    expect(event.launchId).toBe('launch-1');
+    expect(event.tier).toBe('milestone');
+
+    const stored = readSessionActivity('sess-post-1', dir);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].event).toBe('status.posted');
+    expect(stored[0].detail).toBe('Track complete');
+    expect(stored[0].agent).toBe('grok');
+    expect(stored[0].launchId).toBe('launch-1');
+  });
+
+  it('throws on empty text', () => {
+    expect(() => postFeedStatus({
+      text: '   ',
+      sessionId: 's',
+      activityRoot: tmpActivityDir(),
+    })).toThrow(/empty/i);
+  });
+
+  it('throws when session cannot be resolved', () => {
+    expect(() => postFeedStatus({
+      text: 'hello',
+      activityRoot: tmpActivityDir(),
+      env: {},
+      startPid: 1,
+      getParentPid: () => undefined,
+      readEntry: () => undefined,
+      listEntries: () => [],
+    })).toThrow(/No session id/i);
+  });
+
+  it('does not invent domain-specific meta fields', () => {
+    const dir = tmpActivityDir();
+    const { event } = postFeedStatus({
+      text: 'done',
+      sessionId: 'sess-no-meta',
+      activityRoot: dir,
+      env: { AGENTS_AGENT_NAME: 'claude' },
+      listEntries: () => [],
+      readEntry: () => undefined,
+      startPid: 1,
+    });
+    expect(event).not.toHaveProperty('meta');
+    expect(event).not.toHaveProperty('ticket');
+    expect(event).not.toHaveProperty('url');
+  });
+});

--- a/apps/cli/src/lib/feed-post.ts
+++ b/apps/cli/src/lib/feed-post.ts
@@ -1,0 +1,271 @@
+/**
+ * Agent status posts — deliberate progress messages into the activity stream.
+ *
+ * Surface: `agents feed post <text>` (agent-callable; humans watch via
+ * `agents feed` / `agents activity` / `agents events --module activity`).
+ *
+ * Identity is automatic: session id, agent, cwd, launch/pid/tmux provenance
+ * are resolved from the process environment and the per-pid launch registry
+ * (`lib/session/pid-registry.ts`). The agent only authors free-form text —
+ * no domain-specific flags (tickets, URLs, tracks).
+ *
+ * Storage: append-only activity log as a `status.posted` milestone. Does NOT
+ * open a feed block (blocks remain "needs you" state only).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import {
+  appendActivityEvent,
+  type ActivityEvent,
+} from './activity.js';
+import { machineId } from './machine-id.js';
+import { isValidMailboxId } from './mailbox.js';
+import {
+  listPidSessionEntries,
+  readPidSessionEntry,
+  type PidSessionEntry,
+} from './session/pid-registry.js';
+
+/** Soft cap so a runaway agent can't flood the activity lane with essays. */
+export const STATUS_POST_MAX_CHARS = 500;
+
+export interface FeedPostInput {
+  /** Human-readable progress text (required). Domain-agnostic free text. */
+  text: string;
+  /** Override session id (escape hatch for scripts/tests). Prefer auto-resolve. */
+  sessionId?: string;
+  /** Override activity root (tests). */
+  activityRoot?: string;
+  /** Override env for identity resolution (tests). */
+  env?: NodeJS.ProcessEnv;
+  /** Override cwd stamp (defaults to process.cwd() / env). */
+  cwd?: string;
+  /** Fixed timestamp (tests). */
+  ts?: string;
+  /**
+   * Starting pid for registry ancestor walk (defaults to process.ppid so the
+   * walk begins at the parent of this CLI process — usually the agent/shell).
+   * Tests inject a fake pid here.
+   */
+  startPid?: number;
+  /** Override parent-pid lookup (tests). */
+  getParentPid?: (pid: number) => number | undefined;
+  /** Override registry read (tests). */
+  readEntry?: (pid: number) => PidSessionEntry | undefined;
+  /** Override full registry list for launchId match (tests). */
+  listEntries?: () => PidSessionEntry[];
+}
+
+export interface FeedPostResult {
+  event: ActivityEvent;
+}
+
+export interface PostIdentity {
+  sessionId: string;
+  mailboxId: string;
+  host: string;
+  runtime: string;
+  agent?: string;
+  cwd?: string;
+  pid?: number;
+  launchId?: string;
+  terminalId?: string;
+  tmuxPane?: string;
+}
+
+/**
+ * Resolve who is posting. Order:
+ *  1. Explicit --session flag
+ *  2. Env: AGENT_SESSION_ID / AGENTS_SESSION_ID / basename(AGENTS_MAILBOX_DIR)
+ *  3. Env AGENT_LAUNCH_ID → match in pid registry
+ *  4. Walk parent PIDs from startPid (default process.ppid) through by-pid registry
+ */
+export function resolvePostIdentity(
+  input: Pick<FeedPostInput, 'sessionId' | 'env' | 'cwd' | 'startPid' | 'getParentPid' | 'readEntry' | 'listEntries'>,
+): PostIdentity | undefined {
+  const env = input.env ?? process.env;
+  const readEntry = input.readEntry ?? readPidSessionEntry;
+  const listEntries = input.listEntries ?? listPidSessionEntries;
+  const getParent = input.getParentPid ?? parentPidOf;
+
+  const envSession = firstValidId([
+    input.sessionId,
+    env.AGENT_SESSION_ID,
+    env.AGENTS_SESSION_ID,
+    mailboxIdFromEnv(env),
+  ]);
+
+  const launchId = env.AGENT_LAUNCH_ID?.trim() || undefined;
+  let registry: PidSessionEntry | undefined;
+
+  if (launchId) {
+    registry = listEntries().find((e) => e.launchId === launchId);
+  }
+
+  if (!registry) {
+    const start = input.startPid ?? (typeof process.ppid === 'number' ? process.ppid : undefined);
+    if (start && start > 1) {
+      registry = walkPidRegistry(start, getParent, readEntry);
+    }
+  }
+
+  // Prefer env session (explicit + managed run), fill gaps from registry.
+  const sessionId = envSession ?? registry?.sessionId;
+  if (!sessionId || !isValidMailboxId(sessionId)) return undefined;
+
+  const mailboxFromEnv = mailboxIdFromEnv(env);
+  const mailboxId = mailboxFromEnv && isValidMailboxId(mailboxFromEnv)
+    ? mailboxFromEnv
+    : sessionId;
+
+  return {
+    sessionId,
+    mailboxId,
+    host: machineIdFromEnv(env),
+    runtime: env.AGENTS_RUNTIME?.trim() || 'headless',
+    agent: env.AGENTS_AGENT_NAME?.trim()
+      || registry?.agent
+      || detectAgentKind(env),
+    cwd: input.cwd
+      ?? (env.AGENTS_CWD?.trim() || registry?.cwd || process.cwd()),
+    pid: registry?.pid,
+    launchId: launchId || registry?.launchId,
+    terminalId: env.AGENT_TERMINAL_ID?.trim() || registry?.terminalId,
+    tmuxPane: env.TMUX_PANE?.trim() || registry?.tmuxPane,
+  };
+}
+
+function firstValidId(candidates: Array<string | undefined>): string | undefined {
+  for (const raw of candidates) {
+    const id = (raw ?? '').trim();
+    if (id && isValidMailboxId(id)) return id;
+  }
+  return undefined;
+}
+
+function mailboxIdFromEnv(env: NodeJS.ProcessEnv): string | undefined {
+  const dir = env.AGENTS_MAILBOX_DIR?.trim();
+  if (!dir) return undefined;
+  const base = path.basename(dir.replace(/[/\\]+$/, ''));
+  return base || undefined;
+}
+
+/** Walk up to 16 ancestors looking for a by-pid registry entry with a session. */
+export function walkPidRegistry(
+  startPid: number,
+  getParent: (pid: number) => number | undefined,
+  readEntry: (pid: number) => PidSessionEntry | undefined,
+): PidSessionEntry | undefined {
+  let pid: number | undefined = startPid;
+  const seen = new Set<number>();
+  let firstHit: PidSessionEntry | undefined;
+  for (let i = 0; i < 16 && pid && pid > 1 && !seen.has(pid); i++) {
+    seen.add(pid);
+    const entry = readEntry(pid);
+    if (entry) {
+      if (entry.sessionId && isValidMailboxId(entry.sessionId)) return entry;
+      if (!firstHit) firstHit = entry;
+    }
+    pid = getParent(pid);
+  }
+  // Entry without sessionId still carries agent/cwd/launchId — usable when
+  // session id comes from env.
+  return firstHit;
+}
+
+/** Best-effort parent pid of `pid` (Linux /proc, else `ps`). */
+export function parentPidOf(pid: number): number | undefined {
+  if (!Number.isInteger(pid) || pid <= 1) return undefined;
+  if (process.platform === 'linux') {
+    try {
+      const status = fs.readFileSync(`/proc/${pid}/status`, 'utf8');
+      const m = status.match(/^PPid:\s*(\d+)/m);
+      if (m) {
+        const pp = Number(m[1]);
+        return Number.isInteger(pp) && pp > 0 ? pp : undefined;
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  try {
+    const r = spawnSync('ps', ['-o', 'ppid=', '-p', String(pid)], {
+      encoding: 'utf8',
+      timeout: 1000,
+    });
+    if (r.status === 0) {
+      const pp = Number((r.stdout || '').trim());
+      return Number.isInteger(pp) && pp > 0 ? pp : undefined;
+    }
+  } catch {
+    /* best-effort */
+  }
+  return undefined;
+}
+
+export function normalizeStatusText(text: string): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return '';
+  if (collapsed.length <= STATUS_POST_MAX_CHARS) return collapsed;
+  return `${collapsed.slice(0, STATUS_POST_MAX_CHARS - 1)}…`;
+}
+
+/**
+ * Append a `status.posted` milestone for the calling agent.
+ * Throws if text is empty or session identity cannot be resolved.
+ */
+export function postFeedStatus(input: FeedPostInput): FeedPostResult {
+  const detail = normalizeStatusText(input.text);
+  if (!detail) {
+    throw new Error('Status text is empty. Usage: agents feed post "what just happened"');
+  }
+
+  const identity = resolvePostIdentity(input);
+  if (!identity) {
+    throw new Error(
+      'No session id. Run from an agents-cli session '
+      + '(AGENT_SESSION_ID / AGENTS_MAILBOX_DIR / pid registry), or pass --session <id>.',
+    );
+  }
+
+  const event: Omit<ActivityEvent, 'v' | 'tier'> = {
+    ts: input.ts ?? new Date().toISOString(),
+    event: 'status.posted',
+    sessionId: identity.sessionId,
+    mailboxId: identity.mailboxId,
+    host: identity.host,
+    runtime: identity.runtime,
+    cwd: identity.cwd,
+    agent: identity.agent,
+    tool: 'feed.post',
+    detail,
+    ...(identity.pid !== undefined ? { pid: identity.pid } : {}),
+    ...(identity.launchId ? { launchId: identity.launchId } : {}),
+    ...(identity.terminalId ? { terminalId: identity.terminalId } : {}),
+    ...(identity.tmuxPane ? { tmuxPane: identity.tmuxPane } : {}),
+  };
+
+  appendActivityEvent(event, input.activityRoot);
+  return {
+    event: {
+      v: 1,
+      tier: 'milestone',
+      ...event,
+    },
+  };
+}
+
+function machineIdFromEnv(env: NodeJS.ProcessEnv): string {
+  const raw = env.AGENTS_SYNC_MACHINE_ID || undefined;
+  if (raw) {
+    return raw.split('.')[0].trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+  }
+  return machineId();
+}
+
+function detectAgentKind(env: NodeJS.ProcessEnv): string {
+  if (env.CLAUDECODE === '1') return 'claude';
+  if (env.CODEX_CI || env.CODEX_HOME) return 'codex';
+  return 'agent';
+}


### PR DESCRIPTION
## Summary

Agents can announce progress without opening a “needs you” block.

- **`agents feed post "<text>"`** appends a `status.posted` milestone to the per-session activity log (same stream as `agents activity` and the feed’s recent-activity lane).
- **Identity is automatic** — session id, agent, host, runtime, cwd, pid, launchId, tmuxPane — from process env + the per-pid launch registry (`lib/session/pid-registry.ts`). No software-engineering-specific flags (`--ticket`, `--url`, …).
- Managed runs export `AGENT_SESSION_ID` / `AGENTS_SESSION_ID` / `AGENTS_AGENT_NAME` / `AGENTS_CWD` so a Bash tool call works with no extra flags.
- Does **not** create a feed block. Domain facts (tickets, PRs) stay on the session index and are joined at read time.

### API (agent tool call)

```bash
agents feed post "CHANGELOG pushed; watching CI and mac-mini E2E"
agents feed post "ready for review" --json
# escape hatch:
agents feed post "note" --session <id>
```

### Identity resolution order

1. `--session` (escape hatch)
2. `AGENT_SESSION_ID` / `AGENTS_SESSION_ID` / basename(`AGENTS_MAILBOX_DIR`)
3. `AGENT_LAUNCH_ID` → match in `by-pid` registry
4. Parent-pid walk through `~/.agents/.cache/terminals/by-pid/<pid>.json`

## Test plan

- [x] Unit tests: `feed-post.test.ts`, `activity.test.ts` (status.posted round-trip), `exec.test.ts` (session env export)
- [x] E2E: `tsx src/index.ts feed post … --json` writes activity JSONL; env identity; missing session errors; appears in `agents activity --milestones`
- [ ] CI green
- [ ] Non-author review

## Test results

### Unit tests (worktree `apps/cli`)

```
bunx vitest run src/lib/feed-post.test.ts src/lib/activity.test.ts src/lib/exec.test.ts

 ✓ src/lib/feed-post.test.ts (12 tests)
 ✓ src/lib/activity.test.ts (16 tests)
 ✓ src/lib/exec.test.ts (67 tests)

 Test Files  3 passed (3)
      Tests  95 passed (95)
```

### E2E (CLI via tsx)

```
agents feed post "e2e smoke: halfway done" --session <sid> --json
→ writes status.posted with host/runtime/cwd/tool=feed.post

AGENT_SESSION_ID=<sid> AGENTS_AGENT_NAME=grok AGENTS_RUNTIME=teams \
  agents feed post "second post via env identity"
→ agent/runtime stamped from env; appears in agents activity --milestones

agents feed post "orphan"   # no session
→ exit 1: No session id. … or pass --session <id>.
```

## Files

- `apps/cli/src/lib/feed-post.ts` (+ tests)
- `apps/cli/src/commands/feed.ts` — `feed post` subcommand
- `apps/cli/src/lib/activity.ts` — `status.posted` milestone + identity fields
- `apps/cli/src/lib/exec.ts` — export session/agent/cwd env on managed runs
- `apps/cli/docs/06-observability.md`, `README.md`, `CHANGELOG.md`

## Out of scope

- Fixing sparse/empty `agents activity` fleet-wide (broader classifier + multi-host merge)
- MCP tool wrapper (CLI is the agent-callable tool for now)
- Auto-post from teams lifecycle events