### PR TITLE
perf(session): actually stream the Kimi wire.jsonl delta (finish #1513's Kimi half)

### DIFF
--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -4251,25 +4251,46 @@ export function parseKimiWireMetricsIncremental(
     : { messageCount: 0, tokenCount: 0, outputTokens: 0 };
 
   let consumedBytes = 0;
+  let fd: number | undefined;
   try {
-    const buf = fs.readFileSync(wirePath);
-    const appended = buf.subarray(fromOffset);
-    // Bytes up to AND INCLUDING the last '\n' are the committed, complete-line run.
-    const lastNl = appended.lastIndexOf(0x0a);
-    consumedBytes = lastNl === -1 ? 0 : lastNl + 1;
-    if (consumedBytes > 0) {
-      for (const line of appended.subarray(0, consumedBytes).toString('utf-8').split('\n')) {
-        if (!line.trim()) continue;
-        try {
-          applyKimiWireEvent(acc, JSON.parse(line));
-        } catch {
-          // Malformed line, skip
+    // Read ONLY the appended byte range [fromOffset, stat.size) — not the whole
+    // file. readSync from an explicit position keeps this function synchronous
+    // (its callers are sync) while making the disk read + allocation scale with
+    // the appended delta, not total file size, matching scanCodexSessionIncremental
+    // / scanClaudeSessionIncremental. Bytes past the stat'd size are a concurrent
+    // append and are deferred to the next scan.
+    const bytesToRead = Math.max(0, stat.size - fromOffset);
+    const appended = Buffer.allocUnsafe(bytesToRead);
+    if (bytesToRead > 0) {
+      fd = fs.openSync(wirePath, 'r');
+      let read = 0;
+      while (read < bytesToRead) {
+        const n = fs.readSync(fd, appended, read, bytesToRead - read, fromOffset + read);
+        if (n <= 0) break;
+        read += n;
+      }
+      const chunk = read === bytesToRead ? appended : appended.subarray(0, read);
+      // Bytes up to AND INCLUDING the last '\n' are the committed, complete-line run.
+      const lastNl = chunk.lastIndexOf(0x0a);
+      consumedBytes = lastNl === -1 ? 0 : lastNl + 1;
+      if (consumedBytes > 0) {
+        for (const line of chunk.subarray(0, consumedBytes).toString('utf-8').split('\n')) {
+          if (!line.trim()) continue;
+          try {
+            applyKimiWireEvent(acc, JSON.parse(line));
+          } catch {
+            // Malformed line, skip
+          }
         }
       }
     }
   } catch {
     // If wire.jsonl can't be read, keep the accumulated counters (0s on a cold
     // parse) — graceful degradation, matching the pre-incremental behavior.
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch { /* already closed / gone */ }
+    }
   }
 
   return {


### PR DESCRIPTION
## What

Follow-up to **#1513** (incremental Codex + Kimi transcript parse). #1513's Kimi half didn't fully deliver the streaming it claimed: `parseKimiWireMetricsIncremental` resumed from the persisted offset but still `fs.readFileSync`'d the **entire** `wire.jsonl` and sliced to `fromOffset` in memory. That only saved the `JSON.parse` cost — the disk read + allocation still scaled with total file size, not the appended delta.

Flagged by prix-cloud on #1513 (its "Changes requested" verdict landed ~3 min **after** the PR merged, so it was never addressed).

## The discrepancy it fixes

#1513's own claims were inaccurate for the I/O dimension:
- PR body: "Converted ... to an incremental byte-range parse, resolving the `// TODO: optimize to stream`."
- Changelog fragment: "the Kimi wire.jsonl scanner now re-parse only the newly-appended bytes ... instead of re-reading the whole file from the top every scan."

Both are now **true** with this change (before, the whole file was read every scan).

## The fix

Read only `[fromOffset, stat.size)` via `fs.openSync` + `fs.readSync` at an explicit position. `parseKimiWireMetricsIncremental` is synchronous and its caller (`readKimiMeta`) is sync, so a `createReadStream` would force an async ripple; `readSync` at a position keeps the signature and makes the read scale with the delta — same intent as `scanCodexSessionIncremental` (`createReadStream({ start: fromOffset })`) and `scanClaudeSessionIncremental`. The trailing-`\n` commit/defer discipline and line application are unchanged.

## Correctness / tests

Behavior is identical — same bytes parsed, same counters — so the existing `kimi-incremental-parity.test.ts` (asserts incremental === full parse for message/token counts across boundary sweeps, straddles, truncation, and the complete-but-unterminated trailing line) is the correctness gate and still passes. No new test: the change is a read-*mechanism* swap with no observable behavior change, and asserting "reads only N bytes" would require mocking `fs` (banned by repo convention). Docs/changelog need no change — this makes their existing claim accurate.

## Verification
- `npx tsc --noEmit` — clean (rc=0)
- `npx vitest run src/lib/session/` — **745 passed (69 files)**, 0 failures
- Kimi suites (`kimi-incremental-parity`, `parse-kimi`) — 25/25