### PR TITLE
fix(session): guard pid liveness against pid reuse (zombie --active sessions)

### DIFF
--- a/apps/cli/.changelog/next/session-pid-reuse-liveness.md
+++ b/apps/cli/.changelog/next/session-pid-reuse-liveness.md
@@ -1,0 +1,11 @@
+- **`agents sessions --active` no longer shows zombie sessions from recycled pids.**
+  Liveness was a bare `process.kill(pid, 0)` existence check, so once the OS handed a
+  dead session's pid to an unrelated process, that session kept showing as alive — and
+  the registry GC never pruned it. `isPidAlive` now takes the session's recorded
+  `startedAtMs` and, when a start time is available, verifies the process at that pid did
+  not begin meaningfully after the session started (a 60s window): a process that started
+  later is a reused pid, so the session is dead. The start time is read once via
+  `ps -o lstart=` (macOS + Linux); Windows and any unreadable start time fall back to the
+  existence check, never worse than before. Applied to every registry-backed liveness
+  path — the live-terminals filter, the terminal listing, the tmux-pane resolver, and the
+  pid-registry prune. Source: `apps/cli/src/lib/session/active.ts`.

--- a/apps/cli/src/lib/session/active.liveness.test.ts
+++ b/apps/cli/src/lib/session/active.liveness.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { isPidAlive } from './active';
+
+const posixOnly = process.platform === 'win32' ? it.skip : it;
+
+describe('isPidAlive pid-reuse guard', () => {
+  it('reports a live process as alive (bare existence check)', () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it('rejects an invalid pid', () => {
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+  });
+
+  it('reports a non-existent pid as dead', () => {
+    // 2^31-ish: above any real pid, so process.kill throws ESRCH.
+    expect(isPidAlive(2_000_000_000)).toBe(false);
+  });
+
+  it('keeps a live process alive when its recorded start matches now', () => {
+    expect(isPidAlive(process.pid, Date.now())).toBe(true);
+  });
+
+  it('keeps a live process alive within the reuse tolerance', () => {
+    // Session recorded 30s ago, process is still that one — under the 60s window.
+    expect(isPidAlive(process.pid, Date.now() - 30_000)).toBe(true);
+  });
+
+  // The zombie: the pid is alive, but its process began long AFTER the session's
+  // recorded start — i.e. the OS recycled the pid. Passing an ancient startedAtMs
+  // against our own (just-started) process reproduces exactly that shape.
+  // Skipped on Windows, where processStartMs returns null and we fall back to a
+  // bare existence check by design.
+  posixOnly('reports a reused pid as dead (process far newer than recorded start)', () => {
+    expect(isPidAlive(process.pid, 1000)).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -19,7 +19,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { execFile } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import { listActiveTasks } from '../cloud/store.js';
 import type { CloudTaskStatus } from '../cloud/types.js';
@@ -275,14 +275,68 @@ export function agentKindFromComm(commRaw: string): string | undefined {
   return AGENT_CLI_NAMES[key];
 }
 
-function isPidAlive(pid: number): boolean {
+/**
+ * A process that began more than this long AFTER a session's recorded
+ * `startedAtMs` cannot be that session's process — the OS handed its pid to
+ * something newer. The window absorbs clock granularity (`ps -o lstart=` reports
+ * whole seconds) and the gap between a process spawning and the SessionStart
+ * hook recording `startedAtMs`; it is far below the minutes-to-hours it takes the
+ * pid space to wrap and actually recycle a pid, so it never false-kills a live
+ * session.
+ */
+const PID_REUSE_TOLERANCE_MS = 60_000;
+
+/**
+ * Epoch-ms start time of the process at `pid`, or null if unknowable.
+ *
+ * Distinct from teams/agents.ts's `captureProcessStartTime`, which returns an
+ * opaque token only meaningful for equality against a prior capture of the SAME
+ * pid. Here we need a value comparable to a session's `startedAtMs`, so we read
+ * `ps -o lstart=` — a ctime string on both macOS and Linux — and parse it to
+ * epoch ms. Windows and any exec/parse failure return null, so the caller falls
+ * back to a bare existence check (never worse than before).
+ */
+function processStartMs(pid: number): number | null {
+  if (process.platform === 'win32') return null;
+  try {
+    const out = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!out) return null;
+    const ms = Date.parse(out);
+    return Number.isFinite(ms) ? ms : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `pid` names a live process AND — when a session's recorded
+ * `startedAtMs` is supplied — that process is plausibly the SAME one, not a later
+ * process that recycled the pid. The OS reuses pids, so a bare
+ * `process.kill(pid, 0)` existence check reports a dead session as alive (a
+ * "zombie") once its pid is handed to an unrelated process. A genuine session
+ * process starts at or before its own recorded start, so a process that began
+ * meaningfully AFTER `startedAtMs` is a reused pid and the session is dead. When
+ * the start time can't be read, we keep the existence answer.
+ */
+export function isPidAlive(pid: number, startedAtMs?: number): boolean {
   if (!pid || pid < 1) return false;
   try {
     process.kill(pid, 0);
-    return true;
   } catch (err: any) {
-    return err?.code === 'EPERM';
+    // EPERM means the pid exists but is owned by another user — still "alive",
+    // fall through to the identity check. Any other error means no such process.
+    if (err?.code !== 'EPERM') return false;
   }
+  if (startedAtMs && startedAtMs > 0) {
+    const procStartMs = processStartMs(pid);
+    if (procStartMs !== null && procStartMs > startedAtMs + PID_REUSE_TOLERANCE_MS) {
+      return false; // pid recycled by a newer process — this session is gone
+    }
+  }
+  return true;
 }
 
 interface LiveTerminalEntry {
@@ -315,7 +369,7 @@ function readLiveTerminals(): LiveTerminalEntry[] {
   const merged = new Map<string, LiveTerminalEntry>();
   for (const [windowId, slice] of Object.entries(parsed) as [string, any][]) {
     for (const e of (slice?.entries ?? []) as LiveTerminalEntry[]) {
-      if (!e?.sessionId || !isPidAlive(e.pid)) continue;
+      if (!e?.sessionId || !isPidAlive(e.pid, e.startedAtMs)) continue;
       merged.set(e.sessionId, { ...e, windowId });
     }
   }
@@ -631,7 +685,7 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
     const name = resolvedId ? runNameMap.get(resolvedId) ?? undefined : undefined;
     // Extract topic from session file (first meaningful user message)
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
-    const pidAlive = isPidAlive(t.pid);
+    const pidAlive = isPidAlive(t.pid, t.startedAtMs);
     const { state, tokPerSec } = computeLiveSignals(t.kind, sessionFile, t.cwd ?? undefined, pidAlive);
     return applyState({
       context: 'terminal',
@@ -1182,7 +1236,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
   // only live pids count — a dead agent's stale entry can't light up its old pane.
   const liveByPane = new Map<string, PidSessionEntry>();
   for (const e of listPidSessionEntries()) {
-    if (!e.tmuxPane || !isPidAlive(e.pid)) continue;
+    if (!e.tmuxPane || !isPidAlive(e.pid, e.startedAtMs)) continue;
     const prev = liveByPane.get(e.tmuxPane);
     if (!prev || e.startedAtMs > prev.startedAtMs) liveByPane.set(e.tmuxPane, e);
   }
@@ -1214,7 +1268,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
     const cwd = liveEntry?.cwd ?? meta?.cwd ?? (curPath || undefined);
     const sessionFile = findSessionFileForKind(id.agent, cwd, id.sessionId);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
-    const pidAlive = pid ? isPidAlive(pid) : true;
+    const pidAlive = pid ? isPidAlive(pid, liveEntry?.startedAtMs) : true;
     const { state, tokPerSec } = computeLiveSignals(id.agent, sessionFile, cwd, pidAlive);
     const { birthtimeMs, mtimeMs } = sessionFileTimes(sessionFile);
     // Provenance is known exactly here (the pane IS a tmux pane) — set it so

--- a/apps/cli/src/lib/session/pid-registry.ts
+++ b/apps/cli/src/lib/session/pid-registry.ts
@@ -141,8 +141,15 @@ export function listPidSessionEntries(): PidSessionEntry[] {
   return out;
 }
 
-/** Remove entries whose pid is no longer alive. Best-effort housekeeping. */
-export function prunePidSessionRegistry(isAlive: (pid: number) => boolean): void {
+/**
+ * Remove entries whose pid is no longer alive. Best-effort housekeeping.
+ *
+ * `isAlive` receives the entry's recorded `startedAtMs` so it can reject a pid
+ * that a newer process recycled (a "zombie" registry entry), not just one that
+ * no longer exists. An unreadable/corrupt entry falls back to the pid-only
+ * check.
+ */
+export function prunePidSessionRegistry(isAlive: (pid: number, startedAtMs?: number) => boolean): void {
   let files: string[];
   try {
     files = fs.readdirSync(pidRegistryDir()).filter(f => f.endsWith('.json'));
@@ -151,7 +158,15 @@ export function prunePidSessionRegistry(isAlive: (pid: number) => boolean): void
   }
   for (const f of files) {
     const pid = Number(f.slice(0, -'.json'.length));
-    if (!Number.isInteger(pid) || isAlive(pid)) continue;
+    if (!Number.isInteger(pid)) continue;
+    let startedAtMs: number | undefined;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(path.join(pidRegistryDir(), f), 'utf8'));
+      if (typeof parsed?.startedAtMs === 'number') startedAtMs = parsed.startedAtMs;
+    } catch {
+      /* unreadable/corrupt — fall back to the pid-only liveness check */
+    }
+    if (isAlive(pid, startedAtMs)) continue;
     try {
       fs.unlinkSync(path.join(pidRegistryDir(), f));
     } catch {


### PR DESCRIPTION
## Problem (#2 from the session-index bug list)

`agents sessions --active` lies about which sessions are alive. Liveness was a bare existence check:

```ts
function isPidAlive(pid: number): boolean {
  try { process.kill(pid, 0); return true; } catch (err) { return err?.code === 'EPERM'; }
}
```

The OS recycles pids. Once a dead session's pid is handed to an unrelated process, `process.kill(pid, 0)` succeeds, so the session keeps showing as **alive** — and the pid-registry GC (`prunePidSessionRegistry`) never removes it, because it also just asks "does this pid exist?". Result: zombie cards that never clear.

## Fix

Turn "does this pid exist?" into "is this the **same** process?" using the `startedAtMs` both registries already store. A genuine session's process starts at (or just before) its own recorded start; a process that began meaningfully **after** `startedAtMs` is a reused pid.

```ts
export function isPidAlive(pid: number, startedAtMs?: number): boolean {
  if (!pid || pid < 1) return false;
  try { process.kill(pid, 0); }
  catch (err) { if (err?.code !== 'EPERM') return false; }
  if (startedAtMs && startedAtMs > 0) {
    const procStartMs = processStartMs(pid);
    if (procStartMs !== null && procStartMs > startedAtMs + PID_REUSE_TOLERANCE_MS) return false;
  }
  return true;
}
```

- `processStartMs` reads the process start time once via `ps -o lstart=` (a ctime string on **both** macOS and Linux) and parses it to epoch ms. Windows and any unreadable start time return `null` → fall back to the bare existence check, **never worse than before**.
- 60s tolerance absorbs `lstart`'s whole-second granularity and the spawn→hook gap, and sits far below the minutes-to-hours it takes the pid space to actually wrap — so it never false-kills a live session (a genuine process's start is always ≤ its recorded start).
- Wired into **every registry-backed liveness path**: the live-terminals filter, the terminal listing, the tmux-pane resolver, and the pid-registry prune. (Teams' path reads a live `AgentManager` poll, not a stale registry, so it isn't a zombie source and stays existence-only.)
- Distinct from `teams/agents.ts`'s `captureProcessStartTime`, which returns an opaque token only good for equality against a prior capture of the same pid — here we need a value comparable to `startedAtMs`, hence epoch ms.

## Verification

- **Unit (real `ps`, no mocking)** — `active.liveness.test.ts` calls `isPidAlive` against our own live process: alive bare, alive when recorded-start≈now, alive within tolerance, and — the zombie repro — **dead when the recorded start is ancient** (`isPidAlive(process.pid, 1000) === false`), plus invalid/non-existent pids. 6/6 (reuse case skipped on Windows by design).
- **End-to-end GC (real registry + real prune + real `ps`)** — wrote a pid-registry entry for a live pid with an ancient `startedAtMs`; the real `prunePidSessionRegistry(isPidAlive)` deleted it (`ZOMBIE_PRUNED=true`), while a fresh entry survived (`LIVE_SURVIVES=true`). Before this change the zombie survived.
- `tsc --noEmit`: 0 errors. pid-registry + active suites: 65/65.

Companion to the shortId fixes (#1514, #1515) from the same session-index bug list.

Transcript: yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.181/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/52652bb6-04a2-4208-9cf4-f74a43369b13.jsonl
