### PR TITLE
refactor: move detach/attach under the sessions group (agents sessions detach/attach)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,14 +299,14 @@ agents sessions resume --host zion --tmux  # resume on another machine over SSH
 
 ### Send an agent to the background — and bring it back
 
-Running 30 agents and drowning in terminal tabs? `agents detach <id>` stops a session's interactive process and keeps it working **headless** in the background -- it drives its task to done unattended, no tab, lower cost. `agents attach <id>` brings it back: version-pinned resume into a live TUI, the same session and full history (including whatever it did while backgrounded).
+Running 30 agents and drowning in terminal tabs? `agents sessions detach <id>` stops a session's interactive process and keeps it working **headless** in the background -- it drives its task to done unattended, no tab, lower cost. `agents sessions attach <id>` brings it back: version-pinned resume into a live TUI, the same session and full history (including whatever it did while backgrounded).
 
 ```
-agents detach a1b2c3d4     # go headless in the background, keep working
-agents attach a1b2c3d4     # resume it interactively, right here
+agents sessions detach a1b2c3d4     # go headless in the background, keep working
+agents sessions attach a1b2c3d4     # resume it interactively, right here
 ```
 
-Both are agent-agnostic -- they route through the same `agents run --resume` path (native resume for Claude/Codex, `/continue` replay for the rest). `agents sessions --active` marks each session's `presence` -- `attached` (you're watching it), `background` (running headless), or `parked` (its background run finished) -- so the menu bar and Factory show where every agent is.
+Both are agent-agnostic -- they route through the same `agents run --resume` path (native resume for Claude/Codex, `/continue` replay for the rest). `agents sessions --active` marks each session's `presence` -- `attached` (you're watching it), `background` (running headless), or `parked` (its background run finished) -- so the menu bar and Factory show where every agent is. In the Factory extension, **Agents: Detach** (`Cmd/Ctrl+K B`) and **Agents: Attach** (`Cmd/Ctrl+K A`) do the same over the focused terminal.
 
 ---
 

--- a/apps/cli/.changelog/next/detach-attach.md
+++ b/apps/cli/.changelog/next/detach-attach.md
@@ -1,15 +1,17 @@
-- **`agents detach` / `agents attach` — send a running agent to the background and
-  back.** `agents detach <id>` stops a live session's interactive process (killing
-  the tmux session when tmux-hosted, else SIGTERM'ing the pid) and continues it
-  **headless**, detached, via the existing version-pinned `agents run --resume`
-  path — so it drives its task to completion without holding a terminal. The
-  resumed run carries a nudge that tells the now-unwatched agent it is headless and
-  to make the call rather than stall on a confirmation nobody can answer.
-  `agents attach <id>` stops that headless continuation and **resumes the session
-  interactively** in the current terminal (`resumeSessionInPlace`) — the same
-  session and full history, including whatever the background run did. Both verbs
-  are agent-agnostic (native resume for Claude/Codex, `/continue` replay for the
-  rest). A session on **another host** is detached there over SSH rather than
+- **`agents sessions detach` / `agents sessions attach` — send a running agent to the
+  background and back.** `agents sessions detach <id>` stops a live session's
+  interactive process (killing the tmux session when tmux-hosted, else SIGTERM'ing the
+  pid) and continues it **headless**, detached, via the existing version-pinned
+  `agents run --resume` path — so it drives its task to completion without holding a
+  terminal. The resumed run carries a nudge that tells the now-unwatched agent it is
+  headless and to make the call rather than stall on a confirmation nobody can answer.
+  `agents sessions attach <id>` stops that headless continuation and **resumes the
+  session interactively** in the current terminal (`resumeSessionInPlace`) — the same
+  session and full history, including whatever the background run did. They sit under
+  `sessions` next to `focus`/`resume` (the session-lifecycle verbs); the Factory
+  extension exposes them as **Agents: Detach** (`Cmd/Ctrl+K B`) and **Agents: Attach**
+  (`Cmd/Ctrl+K A`). Both verbs are agent-agnostic (native resume for Claude/Codex,
+  `/continue` replay for the rest). A session on **another host** is detached there over SSH rather than
   killed locally; **cloud and team sessions are refused** (they have their own
   lifecycles); the interactive process is fully awaited before the headless resume
   starts (no transcript race); and the background run's output is captured to
@@ -19,3 +21,6 @@
   detach record, so the menu bar and Factory show where each agent is. Source:
   `apps/cli/src/commands/detach.ts`, `apps/cli/src/commands/attach.ts`,
   `apps/cli/src/lib/session/detached.ts`.
+  (`agents sessions migrate`'s old `detach` alias is renamed to `relocate` to free
+  the `detach` name for the background/foreground verb — `migrate` and `relocate`
+  both still work.)

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -322,11 +322,13 @@ message.
 
 ## Background & foreground (detach / attach)
 
-`agents detach <id>` sends a live agent session to the background; `agents attach <id>`
-brings it back. They are the foreground/background axis over a session, and route
-through the same version-pinned `agents run --resume` path everything else uses — so
-they are agent-agnostic (native resume for Claude/Codex, `/continue` replay for the
-rest), not a per-agent special case.
+`agents sessions detach <id>` sends a live agent session to the background;
+`agents sessions attach <id>` brings it back. They live under `sessions` alongside
+`focus`/`resume` — the session-lifecycle axis — and route through the same
+version-pinned `agents run --resume` path everything else uses, so they are
+agent-agnostic (native resume for Claude/Codex, `/continue` replay for the rest),
+not a per-agent special case. (In the Factory extension: **Agents: Detach**
+`Cmd/Ctrl+K B`, **Agents: Attach** `Cmd/Ctrl+K A`.)
 
 - **detach**: stop the interactive process (kill the tmux session when tmux-hosted,
   else SIGTERM the pid) and **wait for it to actually exit** before spawning a
@@ -337,9 +339,9 @@ rest), not a per-agent special case.
   exits; its output is written to `~/.agents/.cache/logs/detach-<shortid>.log`
   (printed on detach) so a background run that crashes leaves a trail.
   - **Remote sessions** (matched via the cross-host sweep) are detached **on their
-    own host over SSH** — `agents detach <id> --local` runs there — since a pid and
-    tmux socket only mean something on the machine the session runs on. Use `--local`
-    to skip the sweep and only consider this machine.
+    own host over SSH** — `agents sessions detach <id> --local` runs there — since a
+    pid and tmux socket only mean something on the machine the session runs on. Use
+    `--local` to skip the sweep and only consider this machine.
   - **Cloud and team sessions are refused**: cloud runs have their own lifecycle, and
     a `teams` session must be stopped through `agents teams` so the team supervisor's
     PID-reuse-safe stop path and bookkeeping stay in sync — `detach` won't SIGTERM a

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -413,7 +413,7 @@ Source: `src/lib/session/bundle.ts`, `src/lib/session/remote-bundle.ts`,
 
 ## Migration (relocate a live session)
 
-`agents sessions migrate` (alias `detach`) **moves a RUNNING session onto another
+`agents sessions migrate` (alias `relocate`) **moves a RUNNING session onto another
 machine** — a fleet worker, a registered device, or a warm/fresh ephemeral crabbox
 box — then stops the source so the interactive machine reclaims its compute. Where
 export/import carry a *transcript* between machines, migrate carries the *live agent*:

--- a/apps/cli/src/commands/attach.ts
+++ b/apps/cli/src/commands/attach.ts
@@ -1,9 +1,9 @@
 /**
- * `agents attach <id>` — bring a backgrounded (or parked) agent session back to
- * the foreground: stop its headless continuation, then resume it interactively
- * in this terminal. The resume is version-pinned native resume (claude/codex) or
- * a `/continue` replay (others) — the same session, full history, the exact
- * inverse of `agents detach`.
+ * `agents sessions attach <id>` — bring a backgrounded (or parked) agent session
+ * back to the foreground: stop its headless continuation, then resume it
+ * interactively in this terminal. The resume is version-pinned native resume
+ * (claude/codex) or a `/continue` replay (others) — the same session, full
+ * history, the exact inverse of `agents sessions detach`.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';

--- a/apps/cli/src/commands/detach-core.ts
+++ b/apps/cli/src/commands/detach-core.ts
@@ -1,5 +1,5 @@
 /**
- * Pure core of `agents detach` — the nudge, the resumed-run argv, and the id
+ * Pure core of `agents sessions detach` — the nudge, the resumed-run argv, and the id
  * resolver. Kept import-light (only a type import) so it is unit-tested without
  * loading the live-session discovery graph.
  */

--- a/apps/cli/src/commands/detach.ts
+++ b/apps/cli/src/commands/detach.ts
@@ -1,8 +1,9 @@
 /**
- * `agents detach <id>` — send a live agent session to the background: stop its
- * interactive process and continue it headless, unattended, so it drives its
- * task to completion without holding a terminal. Bring it back with
- * `agents attach`.
+ * `agents sessions detach <id>` — send a live agent session to the background:
+ * stop its interactive process and continue it headless, unattended, so it drives
+ * its task to completion without holding a terminal. Bring it back with
+ * `agents sessions attach`. A sibling of `sessions focus`/`resume` on the session
+ * lifecycle axis.
  *
  * Agent-agnostic and version-pinned by construction: it re-invokes
  * `agents run <agent> "<nudge>" --resume <id> --headless`, which resolves the
@@ -140,7 +141,7 @@ export async function detachAction(id: string, opts: { local?: boolean } = {}): 
   // focus/jumpTo's remote branch.
   if (target.kind === 'remote') {
     console.log(chalk.gray(`${short} lives on ${target.machine} — detaching it there over SSH…`));
-    const rc = await runOnPeer(['detach', target.sessionId, '--local'], target.machine);
+    const rc = await runOnPeer(['sessions', 'detach', target.sessionId, '--local'], target.machine);
     if (rc === 'no-target') {
       console.error(chalk.red(`Can't reach ${target.machine} to detach ${short}.`));
       process.exitCode = 1;
@@ -170,7 +171,7 @@ export async function detachAction(id: string, opts: { local?: boolean } = {}): 
 
   console.log(
     chalk.green(`◒ Backgrounded ${agent} ${short}`) +
-      chalk.gray(` — running headless (pid ${pid}). Bring it back: agents attach ${short}`),
+      chalk.gray(` — running headless (pid ${pid}). Bring it back: agents sessions attach ${short}`),
   );
   console.log(chalk.gray(`  logs: ${logFile}`));
 }

--- a/apps/cli/src/commands/sessions-lifecycle.test.ts
+++ b/apps/cli/src/commands/sessions-lifecycle.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The session-lifecycle verbs (`focus`/`resume`/`detach`/`attach`/`migrate`) all
+ * live under the `sessions` group, not as top-level commands. This pins the
+ * grouping introduced when `detach`/`attach` (background/foreground) moved off the
+ * top level — and the `migrate` alias rename that freed the `detach` name.
+ */
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { registerSessionsCommands } from './sessions.js';
+
+function sessionsGroup(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerSessionsCommands(program);
+  const sessions = program.commands.find((c) => c.name() === 'sessions');
+  if (!sessions) throw new Error('sessions command not registered');
+  return sessions;
+}
+
+describe('sessions lifecycle verbs are grouped under `sessions`', () => {
+  const sessions = sessionsGroup();
+  const names = sessions.commands.map((c) => c.name());
+
+  it('hosts detach and attach as `sessions` subcommands (not top-level)', () => {
+    expect(names).toContain('detach');
+    expect(names).toContain('attach');
+  });
+
+  it('keeps them alongside the sibling lifecycle verbs', () => {
+    expect(names).toContain('focus');
+    expect(names).toContain('resume');
+    expect(names).toContain('migrate');
+  });
+
+  it("renames migrate's old `detach` alias to `relocate` so it can't collide with the new verb", () => {
+    const migrate = sessions.commands.find((c) => c.name() === 'migrate');
+    expect(migrate).toBeDefined();
+    expect(migrate!.aliases()).toContain('relocate');
+    expect(migrate!.aliases()).not.toContain('detach');
+  });
+});

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -86,7 +86,7 @@ interface MigrateOptions {
 export function registerSessionsMigrateCommand(sessionsCmd: Command): void {
   const cmd = sessionsCmd
     .command('migrate [session-id]')
-    .alias('detach')
+    .alias('relocate')
     .description('Relocate a running session onto another machine (fleet worker, device, or ephemeral box), then stop the source here.')
     .option('--auto', 'Pick the best target host automatically (idle fleet worker preferred)')
     .option('--host <name>', 'Explicit target: an enrolled host, a device, or a warm ephemeral box slug')

--- a/apps/cli/src/commands/sessions-migrate.ts
+++ b/apps/cli/src/commands/sessions-migrate.ts
@@ -1,5 +1,5 @@
 /**
- * `agents sessions migrate` (alias `detach`) — relocate a RUNNING agent session
+ * `agents sessions migrate` (alias `relocate`) — relocate a RUNNING agent session
  * from this machine onto another (a fleet worker, a registered device, or a warm
  * ephemeral crabbox box), then stop the source so the interactive machine
  * reclaims its compute (RUSH-1977).

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -49,6 +49,8 @@ import { registerSessionsSyncCommand } from './sessions-sync.js';
 import { registerSessionsResumeCommand } from './sessions-resume.js';
 import { registerGoCommand } from './go.js';
 import { registerFocusCommand } from './focus.js';
+import { registerDetachCommand } from './detach.js';
+import { registerAttachCommand } from './attach.js';
 import { registerSessionsInjectCommand } from './sessions-inject.js';
 import { registerSessionsExportCommand } from './sessions-export.js';
 import { registerSessionsImportCommand } from './sessions-import.js';
@@ -2662,6 +2664,8 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsResumeCommand(sessionsCmd);
   registerGoCommand(sessionsCmd);
   registerFocusCommand(sessionsCmd);
+  registerDetachCommand(sessionsCmd);
+  registerAttachCommand(sessionsCmd);
   registerSessionsInjectCommand(sessionsCmd);
   registerSessionsExportCommand(sessionsCmd);
   registerSessionsImportCommand(sessionsCmd);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -176,8 +176,6 @@ import {
   loadAlias,
   loadMine,
   loadPty,
-  loadDetach,
-  loadAttach,
   loadTmux,
   loadWatchdog,
   loadBrowser,
@@ -970,8 +968,6 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadAlias);
   await reg(loadMine);
   await reg(loadPty);
-  await reg(loadDetach);
-  await reg(loadAttach);
   await reg(loadTmux);
   await reg(loadWatchdog);
   await reg(loadBrowser);

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -142,7 +142,7 @@ export interface ActiveSession {
   /**
    * Foreground/background presence for the detach/attach model:
    *   `attached`   — live interactive TUI you're watching;
-   *   `background` — detached: running headless, unattended (via `agents detach`);
+   *   `background` — detached: running headless, unattended (via `agents sessions detach`);
    *   `parked`     — the headless continuation has exited; the transcript is durable.
    * Absent for ad-hoc headless runs and cloud/team rows, which aren't on the
    * foreground/background axis. Folded on at the end of {@link getActiveSessions}

--- a/apps/cli/src/lib/session/detached.ts
+++ b/apps/cli/src/lib/session/detached.ts
@@ -1,6 +1,6 @@
 /**
- * Detached-session store — the record `agents detach` writes and both
- * `agents attach` and the active-session scan read to know an agent is
+ * Detached-session store — the record `agents sessions detach` writes and both
+ * `agents sessions attach` and the active-session scan read to know an agent is
  * "backgrounded": running headless with no terminal, continuing its task
  * unattended.
  *
@@ -23,7 +23,7 @@ export interface DetachRecord {
   sessionId: string;
   agent: string;
   cwd?: string;
-  /** pid of the detached headless continuation `agents detach` spawned. */
+  /** pid of the detached headless continuation `agents sessions detach` spawned. */
   headlessPid: number;
   /**
    * Start-time fingerprint of {@link headlessPid} at spawn, so a liveness check

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -82,8 +82,6 @@ export const loadBudget: ModuleLoader = async () => (await import('../../command
 export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
 export const loadMine: ModuleLoader = async () => (await import('../../commands/mine.js')).registerMineCommand;
 export const loadPty: ModuleLoader = async () => (await import('../../commands/pty.js')).registerPtyCommands;
-export const loadDetach: ModuleLoader = async () => (await import('../../commands/detach.js')).registerDetachCommand;
-export const loadAttach: ModuleLoader = async () => (await import('../../commands/attach.js')).registerAttachCommand;
 export const loadTmux: ModuleLoader = async () => (await import('../../commands/tmux.js')).registerTmuxCommands;
 export const loadWatchdog: ModuleLoader = async () => (await import('../../commands/watchdog.js')).registerWatchdogCommand;
 export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
@@ -201,8 +199,6 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   alias: [loadAlias],
   mine: [loadMine],
   pty: [loadPty],
-  detach: [loadDetach],
-  attach: [loadAttach],
   tmux: [loadTmux],
   watchdog: [loadWatchdog],
   browser: [loadBrowser],

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -49,11 +49,11 @@ All notable changes to the Factory extension are documented here. Format follows
 - **Detach / Attach — send a running agent to the background from the editor.**
   Two commands: **Agents: Detach (Send to Background)** (`agents.detach`,
   `cmd+k cmd+b` on a focused agent terminal, also in the terminal right-click menu)
-  sends the active agent's session to the background via `agents detach <id>` —
+  sends the active agent's session to the background via `agents sessions detach <id>` —
   the interactive process stops, the tab closes, and the agent keeps working
   headless. **Agents: Attach (Bring to Foreground)** (`agents.attach`,
   `cmd+k cmd+a`) picks a backgrounded/parked agent and resumes it interactively in
-  a new terminal via `agents attach <id>`. The Floor session model now carries the
+  a new terminal via `agents sessions attach <id>`. The Floor session model now carries the
   CLI's `presence` (`attached` / `background` / `parked`). Source:
   `apps/factory/src/vscode/extension.ts`, `apps/factory/src/core/remoteSessions.ts`,
   `apps/factory/package.json`.

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -274,9 +274,9 @@ export function runHeadlessAgent(
 // background/headless run reopens in a new tab and resumes; a live terminal session is
 // attached). It auto-resolves the surface (no interactive picker), so it's safe to run
 // detached from the extension host.
-// Send the active agent terminal to the background: `agents detach <id>` stops its
-// interactive process and continues it headless, then we close the tab. When the
-// active terminal isn't an agent, fall back to a picker over the live agent tabs.
+// Send the active agent terminal to the background: `agents sessions detach <id>`
+// stops its interactive process and continues it headless, then we close the tab.
+// When the active terminal isn't an agent, fall back to a picker over the live agent tabs.
 async function detachAgentToBackground(): Promise<void> {
   const active = vscode.window.activeTerminal;
   let sessionId: string | undefined;
@@ -308,7 +308,7 @@ async function detachAgentToBackground(): Promise<void> {
     void vscode.window.showWarningMessage('That agent has no resolved session id yet — try again once it has started.');
     return;
   }
-  const child = spawn('agents', ['detach', sessionId], {
+  const child = spawn('agents', ['sessions', 'detach', sessionId], {
     detached: true,
     stdio: 'ignore',
     env: agentsSpawnEnv(),
@@ -322,7 +322,7 @@ async function detachAgentToBackground(): Promise<void> {
 
 // Bring a backgrounded/parked agent to the foreground: pick from the CLI's
 // active-session list (presence background/parked) and open a terminal running
-// `agents attach <id>`, which resumes the session interactively in that tab.
+// `agents sessions attach <id>`, which resumes the session interactively in that tab.
 async function attachAgentFromBackground(): Promise<void> {
   const { sessions } = await fetchLocalSessions();
   const backgrounded = sessions.filter((s) => s.presence === 'background' || s.presence === 'parked');
@@ -342,7 +342,7 @@ async function attachAgentFromBackground(): Promise<void> {
   if (!pick?.sessionId) return;
   const term = vscode.window.createTerminal({ name: `attach ${pick.sessionId.slice(0, 8)}`, env: agentsSpawnEnv() });
   term.show();
-  term.sendText(`agents attach ${pick.sessionId}`);
+  term.sendText(`agents sessions attach ${pick.sessionId}`);
 }
 
 export function focusSessionInTerminal(sessionId: string): void {


### PR DESCRIPTION
## What

`detach`/`attach` were top-level commands (`agents detach`/`agents attach`). They're session-lifecycle verbs, so this moves them under the `sessions` group next to `focus`/`resume`:

```
agents sessions detach <id>    # background it, headless (was: agents detach)
agents sessions attach <id>    # bring back to foreground (was: agents attach)
```

## Why / the collision it resolves

`agents sessions detach` already existed as an **alias for `sessions migrate`** (relocate a session to another host + stop the source). That name is a poor fit for "relocate" and collides with the more literal "detach from the terminal" meaning. So: the background/foreground verb takes `detach`/`attach`, and `migrate`'s alias is renamed `detach` → **`relocate`** (`migrate` and `relocate` both still work).

## Changes

- **CLI registration** (`sessions.ts`): `registerDetachCommand`/`registerAttachCommand` now attach to the `sessions` group; removed the top-level `loadDetach`/`loadAttach` wiring from `command-registry.ts` + `index.ts`.
- **Alias rename** (`sessions-migrate.ts`): `.alias('detach')` → `.alias('relocate')`.
- **Remote delegation** (`detach.ts`): the SSH call now runs `agents sessions detach <id> --local` on the owning host (was `agents detach`); success message points at `agents sessions attach`.
- **Factory extension** (`extension.ts`): `Agents: Detach`/`Agents: Attach` now spawn `agents sessions detach/attach`. Command ids + keybindings (`Cmd+K B` / `Cmd+K A`) unchanged.
- **Docs**: README, `apps/cli/docs/05-sessions.md`, CLI changelog fragment, and the Factory `[Unreleased]` changelog all updated to the grouped path; internal header/store comments too.

## Tests

New `sessions-lifecycle.test.ts` builds the real `sessions` group and pins it:
- `detach` and `attach` are `sessions` subcommands (not top-level)
- `focus`/`resume`/`migrate` still present
- `migrate` carries `relocate`, **not** `detach`

```
$ vitest run sessions-lifecycle.test.ts detach.test.ts detached.test.ts
Test Files  3 passed (3)   Tests  27 passed (27)
```

CLI `tsc --noEmit` clean; Factory extension `tsc -p ./` clean.

Note: no release has shipped `agents detach`/`agents attach`, so there's no back-compat surface to preserve — the changelog entry that introduced them is still `[Unreleased]` and now describes the grouped names.
