### PR TITLE
docs(changelog): queue 5 missing fragments for 1.20.75

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1970-devices-touchid.md
+++ b/apps/cli/.changelog/next/RUSH-1970-devices-touchid.md
@@ -1,0 +1,9 @@
+- **`agents devices` no longer forces a Touch ID prompt on a password-auth box
+  (RUSH-1970).** The read-only stats probe's live SSH to an uncached
+  `auth.method === 'password'` device used to drive the askpass shim to resolve
+  the SSH password through the biometry-gated Keychain sheet under a TTY, popping
+  Touch ID during what should be a silent probe. The probe now threads a
+  broker-only signal (`AGENTS_SSH_AGENT_ONLY`) so it resolves from an
+  already-unlocked broker or degrades to an unreachable row — never a biometric
+  prompt. Source: `apps/cli/src/commands/ssh.ts`,
+  `apps/cli/src/lib/devices/health.ts`, `apps/cli/src/lib/devices/connect.ts`.

--- a/apps/cli/.changelog/next/RUSH-1977-sessions-migrate.md
+++ b/apps/cli/.changelog/next/RUSH-1977-sessions-migrate.md
@@ -1,4 +1,4 @@
-- **`agents sessions migrate` (alias `detach`) relocates a RUNNING session onto
+- **`agents sessions migrate` (alias `relocate`) relocates a RUNNING session onto
   another machine, then stops the source here (RUSH-1977).** `--auto` scores the
   fleet and picks a target, `--host <name>` names one explicitly, and `--lease`
   provisions a fresh ephemeral box; `--mode resume|rehydrate` chooses whether the
@@ -6,6 +6,8 @@
   migration is written to an append-only ledger, viewable with `agents sessions
   migrations`. Load-bearing invariant: the source session is never stopped until
   the transcript is confirmed live on the target, so a failed hop leaves the
-  original running. Source: `apps/cli/src/commands/sessions-migrate.ts`,
+  original running. (Not to be confused with `agents sessions detach`/`attach`,
+  the unrelated background/foreground pair.) Source:
+  `apps/cli/src/commands/sessions-migrate.ts`,
   `apps/cli/src/lib/session/migrate-targets.ts`,
   `apps/cli/src/lib/session/migrations.ts`.

--- a/apps/cli/.changelog/next/RUSH-1977-sessions-migrate.md
+++ b/apps/cli/.changelog/next/RUSH-1977-sessions-migrate.md
@@ -1,0 +1,11 @@
+- **`agents sessions migrate` (alias `detach`) relocates a RUNNING session onto
+  another machine, then stops the source here (RUSH-1977).** `--auto` scores the
+  fleet and picks a target, `--host <name>` names one explicitly, and `--lease`
+  provisions a fresh ephemeral box; `--mode resume|rehydrate` chooses whether the
+  target resumes the native transcript or replays it via `/continue`. Every
+  migration is written to an append-only ledger, viewable with `agents sessions
+  migrations`. Load-bearing invariant: the source session is never stopped until
+  the transcript is confirmed live on the target, so a failed hop leaves the
+  original running. Source: `apps/cli/src/commands/sessions-migrate.ts`,
+  `apps/cli/src/lib/session/migrate-targets.ts`,
+  `apps/cli/src/lib/session/migrations.ts`.

--- a/apps/cli/.changelog/next/devices-sharee-nodes.md
+++ b/apps/cli/.changelog/next/devices-sharee-nodes.md
@@ -1,0 +1,10 @@
+- **`agents devices sync` no longer auto-registers tailnet nodes another user
+  shared into the tailnet.** `tailscale status` includes ShareeNode peers (for
+  example a tagged relay shared in by a teammate); the parser ignored that flag,
+  so bootstrap registered them as your own boxes and they surfaced in `agents
+  fleet ls`. Parsing now carries a `sharee` flag, `runDeviceSync` filters those
+  peers out of auto-registration and suggestions, and the interactive picker
+  leaves them unchecked (labeled `shared`). Deliberate paths — `devices
+  register`/`add` and a `fleet:` manifest — still reach shared nodes when you name
+  them. Source: `apps/cli/src/lib/devices/sync.ts`,
+  `apps/cli/src/lib/devices/tailscale.ts`.

--- a/apps/cli/.changelog/next/model-display.md
+++ b/apps/cli/.changelog/next/model-display.md
@@ -1,0 +1,8 @@
+- **The configured model now shows wherever an agent is displayed.** `agents
+  view`, `use`, `add`, `status`, and `inspect` surface the model an agent+version
+  actually runs with, beside the version (the identity cluster reads `agent ·
+  version · model · account`). The model is resolved agents.yaml `run.defaults` →
+  the native `settings.json` → the built-in default, and `agents view --json`
+  gains a `configuredModel { model, source }` field so downstream tools can read
+  both the value and where it came from. Source: `apps/cli/src/lib/models.ts`,
+  `apps/cli/src/commands/view.ts`.

--- a/apps/cli/.changelog/next/sessions-browser-preview-links.md
+++ b/apps/cli/.changelog/next/sessions-browser-preview-links.md
@@ -1,0 +1,9 @@
+- **Interactive session browser: preview-by-default with clickable ticket + PR
+  links.** In `agents sessions` / `agents sessions --active`, the highlighted
+  row's preview is now open by default (`tab` toggles it off), and the preview's
+  links line renders the ticket and PR as OSC 8 terminal hyperlinks — the ticket
+  resolves to its Linear URL (workspace slug resolved config-first) and `PR#`
+  resolves to its GitHub URL — so they are click-through in terminals that support
+  them. Source: `apps/cli/src/lib/picker.ts`,
+  `apps/cli/src/commands/sessions-browser.ts`,
+  `apps/cli/src/lib/session/render.ts`.


### PR DESCRIPTION
## What

Five user-visible changes shipped since v1.20.74 have **no `.changelog/next/` fragment**, so `release.sh` would fold an incomplete changelog for 1.20.75. Three of them were only hand-written into `CHANGELOG.md`'s `## Unreleased` section — but `gen-changelog.ts` regenerates `CHANGELOG.md` from released-version files only and **wipes that block at release**, so those features would ship with zero release notes.

## Fragments added

| Fragment | Covers |
|---|---|
| `RUSH-1977-sessions-migrate.md` | `agents sessions migrate` (alias `detach`) + `sessions migrations` — new command |
| `model-display.md` | configured-model shown across `view`/`use`/`add`/`status`/`inspect` (+ `view --json configuredModel`) |
| `sessions-browser-preview-links.md` | interactive browser preview-by-default + clickable Linear/GitHub OSC 8 links |
| `RUSH-1970-devices-touchid.md` | `agents devices` read-only probe no longer pops Touch ID on a password-auth box |
| `devices-sharee-nodes.md` | `devices sync` no longer auto-registers ShareeNode tailnet peers |

## Verification

Source paths in each fragment verified to exist on `main`. Fold checked with `bun scripts/release-changelog.ts 1.20.75` (parses cleanly). Docs-only change; no code touched.

Gate for the 1.20.75 release — merge before cutting the release so the queue is complete.