### PR TITLE
feat(watchdog): watchdog v2 — judgment + correct VS Codium delivery

### DIFF
--- a/apps/cli/.changelog/next/watchdog-brain-v2.md
+++ b/apps/cli/.changelog/next/watchdog-brain-v2.md
@@ -1,0 +1,29 @@
+- **Watchdog v2 — the always-on watchdog now has judgment and delivers correctly
+  into VS Codium.** The 2-minute `agents watchdog --nudge` routine no longer
+  hard-skips a session that stopped to ask a question. The deterministic pass is
+  now a cheap pre-filter (clearly-complete → skip, clear promise-without-toolcall →
+  nudge) that ESCALATES the judgment-heavy cases — a session parked on a question,
+  or an ambiguous stall — to a smart brain. The brain drives the agent to finish
+  end-to-end when it asked a needless / already-authorized question or paused with
+  work left, and leaves it for the human only for genuine cases (credentials/auth,
+  an irreversible or outward-facing action, a real ambiguous product decision, or a
+  finished task). Nudge messages restate the goal, tell the agent to use best
+  judgment, and give one concrete next step. The brain is a customizable
+  `watchdog` workflow: drop a `watchdog` WORKFLOW.md in your project or user
+  `workflows/` to override the prompt and pick the `model:`; absent one, the
+  improved built-in prompt runs via `agents run … --mode plan`. Source:
+  `apps/cli/src/lib/watchdog/watchdog.ts`, `apps/cli/src/lib/watchdog/runner.ts`.
+- **Watchdog delivery routes through the answer-router with the VS Codium rail
+  working.** A running agent is steered via its mailbox; a parked-on-question agent
+  is answered into its EXACT split — including a VS Codium / Cursor / VS Code
+  integrated terminal, which the answer-router's own resolver could not address —
+  or, when headless, re-entered via resume; a parked agent with no addressable rail
+  is flagged, never a guessed target.
+- **Watchdog precedence + concurrency fixes.** A long-idle (>15m) open question is
+  no longer blindly force-nudged — waiting-on-user and completion now win over the
+  15-minute force-review short-circuit. The per-session cooldown ledger is written
+  under a file lock (fresh-read + merge + atomic write), closing a lost-update race
+  between concurrent ticks.
+- **Watchdog decisions are logged to `~/.agents/.cache/logs/watchdog.log`** in the
+  JSONL shape the Factory Floor watchdog card reads, so it keeps working after the
+  extension-side watchdog is retired.

--- a/apps/cli/src/commands/watchdog.ts
+++ b/apps/cli/src/commands/watchdog.ts
@@ -198,15 +198,24 @@ export function registerWatchdogCommand(program: Command): void {
       agents watchdog policy <sessionId> handsoff
     `,
     notes: `
-      Decision path (default, deterministic): a session is nudged only when its
-      transcript tail shows it ANNOUNCED an action but no tool call followed
-      (promise-without-toolcall) AND it is not waiting on the user. Completions and
-      open questions are skipped.
+      Decision path: a cheap deterministic pre-filter resolves the obvious cases
+      (clearly complete -> skip; a clear promise-without-toolcall -> nudge) and
+      ESCALATES the judgment-heavy cases -- a session parked on a question, or an
+      ambiguous stall -- to a smart brain. The brain drives the agent to finish
+      end-to-end when it asked a needless / already-authorized question or paused
+      with work left, and leaves it for the human on genuine cases (credentials,
+      an irreversible or outward-facing action, a real ambiguous decision, or a
+      completed task). The brain is a customizable 'watchdog' workflow (drop a
+      WORKFLOW.md in project/user workflows/ to override the prompt + model);
+      absent one, the built-in prompt runs via 'agents run --mode plan'. Pass
+      --smart to force every stalled candidate through the brain.
 
-      Safety gate: a nudge is delivered ONLY when the resolver can name the EXACT
-      split the agent lives in (tmux / iTerm / IDE terminal). Un-addressable stalls
-      (e.g. Ghostty with no tmux) are flagged for the menu-bar and SKIPPED — never
-      a guessed or frontmost target.
+      Delivery (answer-router): a running agent is steered via its mailbox; a
+      parked-on-question agent is answered into its EXACT split -- tmux / iTerm /
+      an IDE integrated terminal (VS Codium / Cursor / VS Code) -- or re-entered
+      via resume when headless. A parked agent with no addressable rail (e.g.
+      Ghostty with no tmux) is flagged for the menu-bar and SKIPPED -- never a
+      guessed or frontmost target.
 
       Always-on: 'agents watchdog enable' creates + enables a 'watchdog' command
       routine ('${WATCHDOG_ROUTINE_SCHEDULE}' -> agents watchdog --nudge) and reloads the

--- a/apps/cli/src/lib/watchdog/log.test.ts
+++ b/apps/cli/src/lib/watchdog/log.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the canonical watchdog.log writer (watchdog-brain-v2).
+ *
+ * The Factory Floor card reads this JSONL feed with the parser in
+ * apps/factory/src/core/watchdogLog.ts. No cross-app import is allowed, so these
+ * tests pin the SHAPE that reader consumes: one JSON object per line, a numeric
+ * `ts`, a known `kind`, a string `message`, and the optional context fields —
+ * plus the line-cap trim so the file never grows unbounded.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { appendWatchdogEvents, trimToLast, formatEvent, type WatchdogEvent } from './log.js';
+
+const KNOWN_KINDS = new Set(['tick', 'decision', 'nudge', 'rotate', 'error']);
+
+let dir: string;
+let logPath: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'watchdog-log-'));
+  logPath = path.join(dir, 'watchdog.log');
+});
+afterEach(() => {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function readLines(): Record<string, unknown>[] {
+  const raw = fs.readFileSync(logPath, 'utf8');
+  return raw.split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l));
+}
+
+describe('appendWatchdogEvents', () => {
+  it('writes one Factory-shaped JSON object per line and appends across calls', () => {
+    appendWatchdogEvents([
+      { ts: 1, kind: 'decision', terminalId: 'CC-1', agentType: 'claude', message: 'parked on a question', reason: 'parked', stalledForMs: 360_000, nudgeText: 'Finish it.', tailLines: ['{"a":1}'] },
+    ], { logPath });
+    appendWatchdogEvents([
+      { ts: 2, kind: 'nudge', terminalId: 'CC-1', message: 'nudged via inject (vscodium)', nudgeText: 'Finish it.' },
+      { ts: 3, kind: 'tick', message: '1 live · 1 stalled · 1 nudged · 0 un-addressable' },
+    ], { logPath });
+
+    const lines = readLines();
+    expect(lines).toHaveLength(3);
+    for (const row of lines) {
+      expect(typeof row.ts).toBe('number');
+      expect(KNOWN_KINDS.has(row.kind as string)).toBe(true);
+      expect(typeof row.message).toBe('string');
+    }
+    // Context fields survive the round-trip so the card can render them.
+    expect(lines[0]).toMatchObject({ kind: 'decision', terminalId: 'CC-1', stalledForMs: 360_000, nudgeText: 'Finish it.' });
+    expect((lines[0].tailLines as string[])[0]).toBe('{"a":1}');
+    expect(lines[1]).toMatchObject({ kind: 'nudge', terminalId: 'CC-1' });
+  });
+
+  it('trims to the last maxLines so the file never grows unbounded', () => {
+    const many: WatchdogEvent[] = Array.from({ length: 10 }, (_, i) => ({ ts: i, kind: 'tick', message: `t${i}` }));
+    appendWatchdogEvents(many, { logPath, maxLines: 4 });
+    const lines = readLines();
+    expect(lines).toHaveLength(4);
+    // The most-recent events are kept.
+    expect(lines.map((l) => l.message)).toEqual(['t6', 't7', 't8', 't9']);
+  });
+
+  it('is a no-op for an empty event list', () => {
+    appendWatchdogEvents([], { logPath });
+    expect(fs.existsSync(logPath)).toBe(false);
+  });
+});
+
+describe('trimToLast / formatEvent', () => {
+  it('formatEvent emits compact single-line JSON', () => {
+    const line = formatEvent({ ts: 1, kind: 'tick', message: 'hi' });
+    expect(line).toBe('{"ts":1,"kind":"tick","message":"hi"}');
+    expect(line).not.toContain('\n');
+  });
+
+  it('trimToLast keeps a trailing newline and caps the body', () => {
+    const body = ['{"ts":1}', '{"ts":2}', '{"ts":3}'].join('\n') + '\n';
+    expect(trimToLast(body, 2)).toBe('{"ts":2}\n{"ts":3}\n');
+    expect(trimToLast(body, 10)).toBe('{"ts":1}\n{"ts":2}\n{"ts":3}\n');
+  });
+});

--- a/apps/cli/src/lib/watchdog/log.ts
+++ b/apps/cli/src/lib/watchdog/log.ts
@@ -1,0 +1,95 @@
+/**
+ * Canonical watchdog event log (watchdog-brain-v2).
+ *
+ * The Factory Floor renders a read-only "Watchdog activity" card from the JSONL
+ * feed at ~/.agents/.cache/logs/watchdog.log. That feed was historically written
+ * by the retired extension-side watchdog; now the always-on CLI watchdog owns it.
+ *
+ * The event SHAPE here is a deliberate, verbatim replica of the reader in
+ * apps/factory/src/core/watchdogLog.ts (WatchdogEvent / WatchdogEventKind /
+ * WATCHDOG_LOG_PATH / the trim cap). The repo forbids cross-app imports
+ * (CLAUDE.md repo map), so the two files are kept in sync by hand — a change to
+ * the Factory reader's shape must be mirrored here. There is no import between
+ * them.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { withFileLock, atomicWriteFileSync, ensureLockTarget } from '../fs-atomic.js';
+
+/** Same path the Factory reader pulls (apps/factory/src/core/watchdogLog.ts). */
+export const WATCHDOG_LOG_PATH = path.join(os.homedir(), '.agents', '.cache', 'logs', 'watchdog.log');
+
+/** Kinds the Factory reader accepts. Keep in lockstep with watchdogLog.ts. */
+export type WatchdogEventKind = 'tick' | 'decision' | 'nudge' | 'rotate' | 'error';
+
+/** JSONL row shape — a verbatim replica of the Factory reader's WatchdogEvent. */
+export interface WatchdogEvent {
+  ts: number;
+  kind: WatchdogEventKind;
+  terminalId?: string;
+  agentType?: string;
+  message: string;
+  reason?: string;
+  /** For 'tick' events: the session lines the watchdog actually read. */
+  tailLines?: string[];
+  /** For 'tick' / 'decision' events: how long the terminal had been stalled. */
+  stalledForMs?: number;
+  /** Carried so the UI can show what the agent was stuck on. */
+  lastUserMessage?: string;
+  lastAssistantMessage?: string;
+  /** For a 'decision'/'nudge' that injects: the exact text delivered. */
+  nudgeText?: string;
+}
+
+/** Serialize one event to a JSONL line (no trailing newline). */
+export function formatEvent(ev: WatchdogEvent): string {
+  return JSON.stringify(ev);
+}
+
+/**
+ * Cap on retained log lines. Mirrors the Factory reader's expectation that the
+ * writer trims (watchdogLog.ts trimToLast). Large enough to keep a useful
+ * history, small enough to bound the file the UI polls.
+ */
+export const WATCHDOG_LOG_MAX_LINES = 2000;
+
+/** Trim a JSONL body to the last `maxLines` events (same logic as the reader). */
+export function trimToLast(text: string, maxLines: number): string {
+  const lines = text.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length <= maxLines) return lines.join('\n') + (lines.length ? '\n' : '');
+  return lines.slice(lines.length - maxLines).join('\n') + '\n';
+}
+
+/**
+ * Append events to the log under a file lock, trimming to WATCHDOG_LOG_MAX_LINES
+ * so the file never grows unbounded. Concurrent watchdog ticks share the lock so
+ * their appends never interleave into a corrupt line. Best-effort: a filesystem
+ * error is swallowed (the Factory card tolerates a stale/missing log), never
+ * throwing into the tick.
+ */
+export function appendWatchdogEvents(
+  events: WatchdogEvent[],
+  opts: { logPath?: string; maxLines?: number } = {},
+): void {
+  if (events.length === 0) return;
+  const logPath = opts.logPath ?? WATCHDOG_LOG_PATH;
+  const maxLines = opts.maxLines ?? WATCHDOG_LOG_MAX_LINES;
+  const lockPath = path.join(path.dirname(logPath), '.watchdog.log.lock');
+  try {
+    ensureLockTarget(lockPath);
+    withFileLock(lockPath, () => {
+      let existing = '';
+      try {
+        existing = fs.readFileSync(logPath, 'utf8');
+      } catch {
+        /* first write — no file yet */
+      }
+      const appended = events.map(formatEvent).join('\n') + '\n';
+      const body = trimToLast(existing + appended, maxLines);
+      atomicWriteFileSync(logPath, body);
+    });
+  } catch {
+    /* best-effort: never let logging break a tick */
+  }
+}

--- a/apps/cli/src/lib/watchdog/runner.test.ts
+++ b/apps/cli/src/lib/watchdog/runner.test.ts
@@ -15,7 +15,29 @@ import * as os from 'os';
 import * as path from 'path';
 import type { ActiveSession } from '../session/active.js';
 import type { SessionProvenance, MuxLocation } from '../session/provenance.js';
-import { runWatchdogTick, DEFAULT_THRESHOLDS, type WatchdogPolicy } from './runner.js';
+import type { InjectTarget } from '../terminal/inject.js';
+import type { WatchdogCandidate } from './watchdog.js';
+import {
+  runWatchdogTick,
+  DEFAULT_THRESHOLDS,
+  type WatchdogPolicy,
+  type WatchdogTickOptions,
+  type SmartDecider,
+} from './runner.js';
+
+/**
+ * Every tick is run through this wrapper so no test touches real state: it pins
+ * the log to the tmp state dir (the writer would otherwise append to the real
+ * ~/.agents/.cache/logs/watchdog.log) and stubs the feed block reader off disk.
+ * Individual tests still override any field.
+ */
+function run(opts: WatchdogTickOptions) {
+  return runWatchdogTick({
+    logPath: path.join(stateDir, 'watchdog.log'),
+    openBlockFor: () => null,
+    ...opts,
+  });
+}
 
 const NOW = 1_700_000_000_000;
 const STALE_AGO = NOW - 6 * 60_000; // 6m ago: past the 5m stall, before the 1h dormant window.
@@ -65,6 +87,31 @@ const PROMISE_TAIL = [
 const DONE_TAIL = [
   '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The feature is finished and pushed."}]}}',
 ];
+// The agent asked a needless permission question — the parked-on-question case.
+const ASK_TAIL = [
+  '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Should I proceed with running the tests?"}]}}',
+];
+// A stall with no promise, no completion, no waiting hint — ambiguous → escalate.
+const AMBIGUOUS_TAIL = [
+  '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The config has three sections."}]}}',
+];
+
+/** A VS Codium (IDE) session parked on a question — the vscodium inject rail. */
+function vscodiumSession(over: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    context: 'terminal',
+    kind: 'claude',
+    host: 'codium',
+    sessionId: over.sessionId ?? 'sess-codium',
+    status: 'input_required',
+    activity: 'waiting_input',
+    awaitingReason: 'question',
+    tty: '/dev/ttys009',
+    startedAtMs: STALE_AGO,
+    provenance: { host: 'zion', transport: 'local', reply: null },
+    ...over,
+  };
+}
 
 let stateDir: string;
 beforeEach(() => {
@@ -84,7 +131,7 @@ function readFlags(): Record<string, { reason: string; host?: string; atMs: numb
 describe('runWatchdogTick — nudge fires', () => {
   it('injects on promise-without-toolcall + addressable, and records the cooldown', async () => {
     const s = tmuxSession();
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL,
     });
@@ -102,7 +149,7 @@ describe('runWatchdogTick — nudge fires', () => {
   });
 
   it('honors a custom nudge text', async () => {
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       nudgeText: 'Keep going.', tailFor: () => PROMISE_TAIL,
     });
@@ -111,22 +158,58 @@ describe('runWatchdogTick — nudge fires', () => {
   });
 });
 
-describe('runWatchdogTick — skips (no nudge)', () => {
-  it('SKIPS a session waiting on the user (AskUserQuestion), even if stalled', async () => {
-    const s = tmuxSession({ activity: 'waiting_input', awaitingReason: 'question' });
-    const result = await runWatchdogTick({
-      sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
-      tailFor: () => PROMISE_TAIL, // promise present, but activity=waiting_input wins
+describe('runWatchdogTick — parked-on-question escalates to the brain', () => {
+  // A session parked on a question is no longer HARD-SKIPPED (the old v1 behavior).
+  // It ESCALATES to the smart brain, which classifies drive-forward vs leave-for-human.
+  const parked = () => tmuxSession({ activity: 'waiting_input', awaitingReason: 'question' });
+
+  it('escalates a waiting_input session and DRIVES FORWARD when the brain says nudge', async () => {
+    let sawEscalation: WatchdogCandidate | null = null;
+    const smartDecider: SmartDecider = async (_s, candidate) => {
+      sawEscalation = candidate;
+      return { nudge: true, reason: 'needless question — proceed with the obvious next step', text: 'Use best judgment and finish end-to-end; run the tests without asking.' };
+    };
+    const result = await run({
+      sessions: [parked()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => ASK_TAIL, smartDecider,
+    });
+    // The brain was consulted (not dropped deterministically).
+    expect(sawEscalation).not.toBeNull();
+    const o = result.outcomes[0];
+    expect(o.decision).toBe('nudge');
+    expect(o.injected).toBe(true);
+    expect(o.rail).toBe('tmux');
+    expect(o.nudgeText).toMatch(/best judgment/i);
+    expect(readLedger()['sess-tmux']).toBe(NOW);
+  });
+
+  it('escalates a waiting_input session and LEAVES FOR HUMAN when the brain says skip', async () => {
+    const smartDecider: SmartDecider = async () => ({ nudge: false, reason: 'credentials required — needs the human' });
+    const result = await run({
+      sessions: [parked()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => ASK_TAIL, smartDecider,
     });
     const o = result.outcomes[0];
     expect(o.decision).toBe('skip');
     expect(o.injected).toBeUndefined();
-    expect(o.reason).toMatch(/waiting on user/i);
+    expect(o.reason).toMatch(/human/i);
     expect(readLedger()['sess-tmux']).toBeUndefined();
   });
 
+  it('an ambiguous stall (no promise, no completion, not waiting) also escalates', async () => {
+    let escalated = false;
+    const smartDecider: SmartDecider = async () => { escalated = true; return { nudge: false, reason: 'unclear' }; };
+    await run({
+      sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
+      tailFor: () => AMBIGUOUS_TAIL, smartDecider,
+    });
+    expect(escalated).toBe(true);
+  });
+});
+
+describe('runWatchdogTick — skips (no nudge)', () => {
   it('SKIPS a completed session (no promise-without-toolcall)', async () => {
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => DONE_TAIL,
     });
@@ -143,7 +226,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     // path must screen completions out itself. This session is idle 20m with a
     // "finished" tail — it must still be skipped, not injected with "Continue.".
     const s = tmuxSession({ startedAtMs: FORCE_REVIEW_AGO });
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => DONE_TAIL,
     });
@@ -158,7 +241,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
   });
 
   it('SKIPS and FLAGS an un-addressable stall (ghostty, no tmux) — never injects a guessed target', async () => {
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [ghosttySession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL,
     });
@@ -179,7 +262,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
   it('SKIPS within cooldown (rate-limited by a recent nudge)', async () => {
     // Seed a nudge 1 minute ago — inside the 20m default cooldown.
     fs.writeFileSync(path.join(stateDir, 'nudges.json'), JSON.stringify({ 'sess-tmux': NOW - 60_000 }));
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL,
     });
@@ -193,7 +276,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
 
   it('handsoff policy: detects + flags a nudge-worthy stall but NEVER injects', async () => {
     const policyFor = (): WatchdogPolicy => 'handsoff';
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL, policyFor,
     });
@@ -212,7 +295,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
   });
 
   it('policy off: fully opted out, not even classified as stalled', async () => {
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL, policyFor: () => 'off',
     });
@@ -225,7 +308,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
 
 describe('runWatchdogTick — dry run (default, no --nudge)', () => {
   it('reports WOULD-nudge without injecting or touching the cooldown', async () => {
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: false, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL,
     });
@@ -242,7 +325,7 @@ describe('runWatchdogTick — dry run (default, no --nudge)', () => {
 describe('runWatchdogTick — active / not-yet-stalled', () => {
   it('SKIPS an active session (recent activity)', async () => {
     const s = tmuxSession({ startedAtMs: NOW - 5_000 }); // 5s ago — well under the stall threshold
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL,
     });
@@ -256,11 +339,63 @@ describe('runWatchdogTick — active / not-yet-stalled', () => {
 
   it('SKIPS a session with no session id (cannot address or track)', async () => {
     const s = tmuxSession({ sessionId: undefined });
-    const result = await runWatchdogTick({
+    const result = await run({
       sessions: [s], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
       tailFor: () => PROMISE_TAIL,
     });
     expect(result.outcomes[0].decision).toBe('skip');
     expect(result.outcomes[0].reason).toMatch(/no session id/i);
+  });
+});
+
+describe('runWatchdogTick — delivery routing (answer-router + vscodium)', () => {
+  it('routes an IDE (VS Codium) parked session to the vscodium inject rail, targeting the EXACT terminal', async () => {
+    // answer-router's own resolver cannot build a vscodium target; the tick must
+    // pre-resolve via resolveInjectTargetForSession (vscodium-aware) and inject
+    // into the precise integrated terminal keyed by the session id.
+    let captured: InjectTarget | null = null;
+    const injectFn = async (target: InjectTarget, _text: string, _o: { dryRun?: boolean }) => {
+      captured = target;
+      return { ok: true as const, backend: target.backend, writes: 2 };
+    };
+    // Brain drives the parked question forward.
+    const smartDecider: SmartDecider = async () => ({ nudge: true, reason: 'proceed', text: 'Finish it; use the sensible default.' });
+    const result = await run({
+      sessions: [vscodiumSession()], nowMs: NOW, nudge: true, stateDir,
+      tailFor: () => ASK_TAIL, smartDecider, injectFn,
+    });
+    const o = result.outcomes[0];
+    expect(o.decision).toBe('nudge');
+    expect(o.rail).toBe('vscodium');
+    expect(o.via).toBe('inject');
+    expect(o.injected).toBe(true);
+    expect(captured).not.toBeNull();
+    expect(captured!).toMatchObject({ backend: 'vscodium', terminalId: 'sess-codium', cli: 'codium', scheme: 'vscodium' });
+    expect(result.counts.nudged).toBe(1);
+    expect(readLedger()['sess-codium']).toBe(NOW);
+  });
+});
+
+describe('runWatchdogTick — the cooldown ledger is lock-serialized (no lost updates)', () => {
+  it('two concurrent ticks nudging different sessions both persist their timestamps', async () => {
+    // Reproduces the lost-update race: the OLD unlocked read-at-start/write-at-end
+    // let two interleaved ticks each write only their own session, dropping the
+    // other. The locked fresh-read + merge keeps both.
+    const a = tmuxSession({ sessionId: 'sess-a' });
+    const b = tmuxSession({ sessionId: 'sess-b' });
+    const shared = fs.mkdtempSync(path.join(os.tmpdir(), 'watchdog-lock-'));
+    const common = {
+      nowMs: NOW, nudge: true, injectDryRun: true, stateDir: shared,
+      logPath: path.join(shared, 'watchdog.log'), openBlockFor: () => null,
+      tailFor: () => PROMISE_TAIL,
+    };
+    await Promise.all([
+      runWatchdogTick({ ...common, sessions: [a] }),
+      runWatchdogTick({ ...common, sessions: [b] }),
+    ]);
+    const ledger = JSON.parse(fs.readFileSync(path.join(shared, 'nudges.json'), 'utf8'));
+    expect(ledger['sess-a']).toBe(NOW);
+    expect(ledger['sess-b']).toBe(NOW);
+    fs.rmSync(shared, { recursive: true, force: true });
   });
 });

--- a/apps/cli/src/lib/watchdog/runner.ts
+++ b/apps/cli/src/lib/watchdog/runner.ts
@@ -35,10 +35,9 @@ import type { ActiveSession } from '../session/active.js';
 import { getActiveSessions } from '../session/active.js';
 import {
   resolveInjectTargetForSession,
-  type InjectResolution,
   type InjectRail,
 } from '../terminal/resolve.js';
-import { injectIntoTerminal, type InjectResult } from '../terminal/inject.js';
+import { injectIntoTerminal, type InjectResult, type InjectTarget } from '../terminal/inject.js';
 import {
   classifyTerminal,
   isLikelyTrulyBlocked,
@@ -55,6 +54,13 @@ import {
   WATCHDOG_TAIL_LINES,
 } from './read.js';
 import { getRuntimeStateDir } from '../state.js';
+import { withFileLock, atomicWriteFileSync, ensureLockTarget } from '../fs-atomic.js';
+import { resolveAnswerRoute, isOpenQuestionBlock } from '../answer-router.js';
+import { enqueue, mailboxDir } from '../mailbox.js';
+import { mailboxIdForActiveSession } from '../mailbox-target.js';
+import { readBlock, blockIdForSession, type OpenBlock } from '../feed.js';
+import { summarizeWatchdogTail } from './watchdogTail.js';
+import { appendWatchdogEvents, type WatchdogEvent } from './log.js';
 
 /** Per-session policy sentinel. `keep` is the default (watchdog may nudge). */
 export type WatchdogPolicy = 'off' | 'keep' | 'handsoff';
@@ -81,12 +87,15 @@ export interface WatchdogTickOptions {
   /** Nudge text delivered into the terminal. Default "Continue." */
   nudgeText?: string;
   /**
-   * Use the LLM decider (`agents run`) to decide + choose nudge text instead of
-   * the deterministic promise-without-toolcall path. Default false so ticks are
-   * reproducible. Best-effort: a decider failure falls back to skip.
+   * Force the LLM decider (`agents run`) on EVERY stalled candidate instead of the
+   * hybrid path. Default false. Even when false the tick still ESCALATES the
+   * judgment-heavy cases (parked-on-question, ambiguous stalls) to the smart brain
+   * — `smart: true` additionally routes the obvious promise-without-toolcall
+   * nudges through it. Non-reproducible; the deterministic pre-filter is the
+   * reproducible default.
    */
   smart?: boolean;
-  /** Agent the smart decider runs as. Default 'claude'. */
+  /** Agent the smart decider runs as (and the built-in fallback prompt). Default 'claude'. */
   smartAgent?: string;
   /** Threshold overrides. Missing fields fall back to DEFAULT_THRESHOLDS. */
   thresholds?: Partial<WatchdogThresholds>;
@@ -108,7 +117,24 @@ export interface WatchdogTickOptions {
   tailFor?: (s: ActiveSession) => string[];
   /** Per-session policy. Default = the on-disk sentinel. */
   policyFor?: (s: ActiveSession) => WatchdogPolicy;
+  /**
+   * The smart brain: given a stalled candidate, decide drive-forward vs
+   * leave-for-human and craft the message. Default resolves a `watchdog` workflow
+   * (repo/user override + `model:` frontmatter) and, failing that, the improved
+   * built-in prompt — both via `agents run … --mode plan`. Tests inject a
+   * synthetic decider so escalation is exercised without shelling out.
+   */
+  smartDecider?: SmartDecider;
+  /** Open feed block for a session (parked-on-question detection). Default reads the feed. */
+  openBlockFor?: (s: ActiveSession) => OpenBlock | null;
+  /** Inject primitive. Default injectIntoTerminal — tests capture the resolved target. */
+  injectFn?: (target: InjectTarget, text: string, opts: { dryRun?: boolean }) => Promise<InjectResult>;
+  /** Override the canonical watchdog.log path (tests point at a tmp file). */
+  logPath?: string;
 }
+
+/** The smart brain seam: a stalled candidate in, a nudge decision out. */
+export type SmartDecider = (session: ActiveSession, candidate: WatchdogCandidate) => Promise<NudgeDecision>;
 
 /** What the tick decided for a single session — the row `--json` / the tray reads. */
 export interface SessionOutcome {
@@ -124,15 +150,20 @@ export interface SessionOutcome {
   policy: WatchdogPolicy;
   decision: 'nudge' | 'skip';
   reason: string;
-  /** The resolved rail, when addressable. */
+  /** The resolved rail, when delivered by injecting into a terminal split. */
   rail?: InjectRail;
+  /** How the nudge was (or would be) delivered: inject | mailbox | resume. */
+  via?: NudgeVia;
   /** True when resolveInjectTarget said addressable (only meaningful once we'd nudge). */
   addressable?: boolean;
-  /** True when a nudge was actually delivered this tick. */
+  /** True when a nudge was actually delivered this tick (any mechanism). */
   injected?: boolean;
   /** The text that was (or would be) delivered. */
   nudgeText?: string;
 }
+
+/** Delivery mechanism the answer-router picked for a nudge. */
+export type NudgeVia = 'inject' | 'mailbox' | 'resume';
 
 export interface WatchdogTickResult {
   atMs: number;
@@ -212,27 +243,31 @@ function defaultLastActivity(s: ActiveSession): number | undefined {
   return s.startedAtMs;
 }
 
-/**
- * The deterministic v1 decision: nudge only when the tail shows a
- * promise-without-toolcall (isLikelyTrulyBlocked) AND the session is not waiting
- * on the user. isLikelyTrulyBlocked already refuses on WAITING/COMPLETION hints;
- * the state engine's `waiting_input` activity is an extra, stronger guard against
- * typing over an open AskUserQuestion.
- */
 /** A decide result shared by the deterministic and smart paths. `text` overrides the default nudge text. */
-interface NudgeDecision {
+export interface NudgeDecision {
   nudge: boolean;
   reason: string;
   text?: string;
 }
 
 /**
- * Minimal local mirror of COMPLETION_HINTS in watchdog.ts:42-47. We cannot lean
- * on isLikelyTrulyBlocked to screen completions out: its FORCE_REVIEW_STALL_MS
- * short-circuit (watchdog.ts:171 — `stalledForMs >= 15m` returns true) fires
- * BEFORE its own COMPLETION_HINTS check (watchdog.ts:176), so a session idle
- * 15m-60m whose tail says "done"/"finished" would be reported as blocked. Keep
- * this list in sync with the core.
+ * The deterministic PRE-FILTER outcome. It resolves only the two obvious cases
+ * cheaply — a clearly-complete session (`skip`) and a clear promise-without-
+ * toolcall stall (`nudge`) — and ESCALATES the judgment-heavy cases (parked on a
+ * question, or an ambiguous stall) to the smart brain, which decides drive-forward
+ * vs leave-for-human and crafts the message. This is the shift Muqsit asked for:
+ * a parked-on-question is no longer hard-skipped, it is evaluated.
+ */
+type DetOutcome =
+  | { kind: 'nudge'; reason: string }
+  | { kind: 'skip'; reason: string }
+  | { kind: 'escalate'; reason: string };
+
+/**
+ * COMPLETION_HINTS mirror of watchdog.ts. The deterministic pre-filter screens
+ * completions to `skip` before the promise check so a finished-but-idle session
+ * is never nudged. (isLikelyTrulyBlocked also guards completion now that its 15m
+ * precedence is fixed; this explicit check keeps the pre-filter self-contained.)
  */
 const COMPLETION_HINTS = ['done', 'completed', 'all set', 'finished'];
 
@@ -245,48 +280,149 @@ function tailShowsCompletion(candidate: WatchdogCandidate): boolean {
 function deterministicDecision(
   session: ActiveSession,
   candidate: WatchdogCandidate,
-): NudgeDecision {
+): DetOutcome {
+  // Parked on a question — the case Muqsit cares about most. Do NOT drop it:
+  // escalate to the brain, which decides drive-forward vs leave-for-human.
   if (session.activity === 'waiting_input') {
-    return { nudge: false, reason: `waiting on user${session.awaitingReason ? ` (${session.awaitingReason})` : ''}` };
+    return {
+      kind: 'escalate',
+      reason: `parked on a question${session.awaitingReason ? ` (${session.awaitingReason})` : ''} — escalate to the brain`,
+    };
   }
-  // Completion is checked EXPLICITLY here — never nudge a finished session, even
-  // past the 15m force-review window where isLikelyTrulyBlocked would return true
-  // before reaching its completion check (see COMPLETION_HINTS note above).
+  // Clearly complete — cheap skip, no LLM.
   if (tailShowsCompletion(candidate)) {
-    return { nudge: false, reason: 'tail shows completion (done / finished / all set) — skip regardless of stall age' };
+    return { kind: 'skip', reason: 'tail shows completion (done / finished / all set) — skip' };
   }
+  // Clear promise-without-toolcall — cheap nudge, no LLM.
   if (isLikelyTrulyBlocked(candidate)) {
-    return { nudge: true, reason: 'stalled after announcing an action with no follow-through' };
+    return { kind: 'nudge', reason: 'stalled after announcing an action with no follow-through' };
   }
-  return { nudge: false, reason: 'no promise-without-toolcall signal in tail (completion / question / unclear)' };
+  // Ambiguous stall — let the brain judge rather than blindly skip.
+  return { kind: 'escalate', reason: 'ambiguous stall — escalate to the brain' };
 }
 
 /**
- * The optional LLM decider. Shells out to `agents run <agent>` with the watchdog
- * prompt and parses its JSON verdict. Best-effort and NON-deterministic — the
- * default path is deterministicDecision. Isolated here so the tick stays pure
- * over its seams; the command layer opts in with --smart.
+ * The smart brain. Resolves a `watchdog` workflow for the session's cwd
+ * (project > user > system precedence, via resolveWorkflowRef) so a repo/user
+ * override AND `model:` frontmatter come for free; when a workflow resolves it
+ * runs `agents run watchdog --mode plan <prompt>`, else it falls back to the
+ * improved built-in prompt via `agents run <agent> --mode plan <prompt>`. Plan
+ * mode keeps the decider read-only. Best-effort and NON-deterministic: any
+ * failure (decider unavailable, no verdict) returns a SAFE skip — a parked
+ * question we cannot judge is left for the human, never blindly nudged.
  */
-async function smartDecision(
-  candidate: WatchdogCandidate,
-  agent: string,
-): Promise<NudgeDecision> {
-  const prompt = renderWatchdogPrompt([candidate]);
+export function makeDefaultSmartDecider(agent: string): SmartDecider {
+  return async (session, candidate) => {
+    const prompt = renderWatchdogPrompt([candidate]);
+    try {
+      const [{ resolveWorkflowRef }, { execFile }, { promisify }] = await Promise.all([
+        import('../workflows.js'),
+        import('child_process'),
+        import('util'),
+      ]);
+      const cwd = session.cwd || process.cwd();
+      const workflowPath = resolveWorkflowRef('watchdog', cwd);
+      // A resolved `watchdog` workflow runs by name so its WORKFLOW.md body + model
+      // frontmatter apply; otherwise the bare agent runs the built-in prompt.
+      const runTarget = workflowPath ? 'watchdog' : agent;
+      const execFileAsync = promisify(execFile);
+      const { stdout } = await execFileAsync('agents', ['run', runTarget, '--mode', 'plan', prompt], {
+        encoding: 'utf8',
+        maxBuffer: 4 * 1024 * 1024,
+        timeout: 120_000,
+      });
+      const decisions = parseWatchdogResponse(stdout);
+      const d = decisions.find((x) => x.terminalId === candidate.terminalId) ?? decisions[0];
+      if (!d) return { nudge: false, reason: 'smart decider returned no verdict' };
+      return { nudge: d.action === 'nudge', reason: d.reason || `smart: ${d.action}`, text: d.text || undefined };
+    } catch (err) {
+      return { nudge: false, reason: `smart decider unavailable: ${err instanceof Error ? err.message : String(err)}` };
+    }
+  };
+}
+
+// --- delivery planning ------------------------------------------------------
+
+/**
+ * How a decided nudge should be delivered. The four outcomes mirror the
+ * answer-router contract: a running/looping agent gets the message in its mailbox
+ * (seen at the next tool call); a parked-on-question agent gets it typed into the
+ * EXACT split (inject) or, when headless, re-entered via resume; and a parked
+ * agent with no addressable rail is refused (flagged, never a guessed target).
+ */
+type DeliveryPlan =
+  | { via: 'inject'; rail: InjectRail; target: InjectTarget }
+  | { via: 'resume' }
+  | { via: 'mailbox'; mailboxId: string }
+  | { via: 'refuse'; reason: string };
+
+/**
+ * Pick the delivery mechanism. resolveAnswerRoute (answer-router.ts) chooses
+ * mailbox vs resume vs refuse; resolveInjectTargetForSession (resolve.ts) supplies
+ * the precise inject target — CRUCIALLY it handles the vscodium rail that the
+ * answer-router's own resolver cannot, so an IDE-terminal (VS Codium / Cursor /
+ * VS Code) session parked on a question is injected into its exact terminal rather
+ * than being downgraded to resume/refuse. When a precise rail exists it wins
+ * (that includes a stalled non-parked agent, so the v1 terminal-inject path is
+ * preserved and no nudge is stranded in a mailbox the agent will never poll).
+ */
+function planDelivery(
+  session: ActiveSession,
+  chosenText: string,
+  block: OpenBlock | null,
+  allowGhosttyFocus: boolean | undefined,
+): DeliveryPlan {
+  const sessionId = session.sessionId ?? '';
+  const mailboxId = mailboxIdForActiveSession(session) ?? sessionId;
+  const resolution = resolveInjectTargetForSession(session, { allowGhosttyFocus });
+  const route = resolveAnswerRoute({ mailboxId, answer: chosenText, session, block });
+
+  // A precise split (tmux / iTerm / vscodium / pty) is the authoritative target.
+  if (resolution.addressable) {
+    return { via: 'inject', rail: resolution.rail, target: resolution.target };
+  }
+  // No precise rail: honor the answer-router's parked-agent decision.
+  if (route.kind === 'resume') return { via: 'resume' };
+  // Mailbox is correct ONLY for a still-looping agent that has an OPEN question
+  // block — it is seen at the next tool call. A stalled agent that simply stopped
+  // (no open block) would never poll the mailbox, so it is flagged instead of
+  // silently dropping a nudge into a spool it will never read.
+  if (route.kind === 'mailbox' && isOpenQuestionBlock(block)) return { via: 'mailbox', mailboxId };
+  return { via: 'refuse', reason: route.kind === 'refuse' ? route.reason : resolution.reason };
+}
+
+/** Default open-block reader — the same lookup `agents message` uses. */
+function defaultOpenBlockFor(session: ActiveSession): OpenBlock | null {
+  const id = mailboxIdForActiveSession(session) ?? session.sessionId;
+  if (!id) return null;
+  const direct = readBlock(blockIdForSession(id));
+  if (direct && direct.mailboxId === id) return direct;
+  return null;
+}
+
+/** Enqueue a nudge into a session's mailbox (running agent, seen at next tool call). */
+function deliverViaMailbox(mailboxId: string, text: string, block: OpenBlock | null): void {
+  enqueue(mailboxDir(mailboxId), { to: mailboxId, text, from: 'watchdog', blockId: block?.blockId });
+}
+
+/** Re-enter a parked headless agent with the nudge as its next user turn. */
+async function deliverViaResume(session: ActiveSession, text: string): Promise<{ ok: boolean; error?: string }> {
+  const sid = session.sessionId;
+  if (!sid) return { ok: false, error: 'no session id to resume' };
   try {
-    const { execFile } = await import('child_process');
-    const { promisify } = await import('util');
-    const execFileAsync = promisify(execFile);
-    const { stdout } = await execFileAsync('agents', ['run', agent, '--mode', 'plan', prompt], {
-      encoding: 'utf8',
-      maxBuffer: 4 * 1024 * 1024,
-      timeout: 120_000,
+    const [{ getAgentsInvocation }, { spawn }] = await Promise.all([
+      import('../daemon.js'),
+      import('child_process'),
+    ]);
+    const inv = getAgentsInvocation(['run', session.kind, '--resume', sid, '--', text]);
+    const code: number = await new Promise((resolve) => {
+      const child = spawn(inv.command, inv.args, { stdio: 'ignore', env: process.env, detached: false });
+      child.on('exit', (c) => resolve(c ?? 1));
+      child.on('error', () => resolve(1));
     });
-    const decisions = parseWatchdogResponse(stdout);
-    const d = decisions.find((x) => x.terminalId === candidate.terminalId) ?? decisions[0];
-    if (!d) return { nudge: false, reason: 'smart decider returned no verdict' };
-    return { nudge: d.action === 'nudge', reason: d.reason || `smart: ${d.action}`, text: d.text || undefined };
+    return code === 0 ? { ok: true } : { ok: false, error: `resume exited ${code}` };
   } catch (err) {
-    return { nudge: false, reason: `smart decider unavailable: ${err instanceof Error ? err.message : String(err)}` };
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
 
@@ -306,11 +442,20 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
   const lastActivityFor = opts.lastActivityFor ?? defaultLastActivity;
   const tailFor = opts.tailFor ?? ((s) => (s.sessionId ? readWatchdogTail(s.sessionId, s.kind, WATCHDOG_TAIL_LINES) : []));
   const policyFor = opts.policyFor ?? ((s) => (s.sessionId ? readPolicySentinel(dir, s.sessionId) : 'keep'));
+  const smartDecider = opts.smartDecider ?? makeDefaultSmartDecider(opts.smartAgent ?? 'claude');
+  const openBlockFor = opts.openBlockFor ?? defaultOpenBlockFor;
+  const injectFn = opts.injectFn ?? injectIntoTerminal;
 
   const sessions = opts.sessions ?? (await getActiveSessions());
   const ledger = readNudgeLedger(dir);
+  // Cooldown timestamps this tick decided to (re)start — merged into the ledger
+  // under a lock at the end so a concurrent tick's updates are never lost.
+  const ledgerUpdates: Record<string, number> = {};
   const flags: Record<string, { reason: string; host?: string; atMs: number }> = {};
   const outcomes: SessionOutcome[] = [];
+  const logEvents: WatchdogEvent[] = [];
+  const viaLabel = (plan: DeliveryPlan): string =>
+    plan.via === 'inject' ? `inject (${plan.rail})` : plan.via;
 
   for (const session of sessions) {
     const policy = policyFor(session);
@@ -378,43 +523,70 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
       stalledForMs: status.stalledForMs,
     };
 
-    const decision: NudgeDecision = opts.smart
-      ? await smartDecision(candidate, opts.smartAgent ?? 'claude')
-      : deterministicDecision(session, candidate);
+    // The brain. The cheap deterministic pre-filter resolves the obvious cases;
+    // parked-on-question and ambiguous stalls ESCALATE to the smart brain. `smart`
+    // forces every stalled candidate through the brain.
+    let decision: NudgeDecision;
+    if (opts.smart) {
+      decision = await smartDecider(session, candidate);
+    } else {
+      const det = deterministicDecision(session, candidate);
+      decision = det.kind === 'escalate'
+        ? await smartDecider(session, candidate)
+        : { nudge: det.kind === 'nudge', reason: det.reason };
+    }
     const chosenText = decision.text ?? nudgeText;
+
+    // Log the decision for the Factory watchdog card.
+    const summary = summarizeWatchdogTail(tailLines, candidate.agentType);
+    logEvents.push({
+      ts: nowMs,
+      kind: 'decision',
+      terminalId: session.sessionId,
+      agentType: candidate.agentType,
+      message: decision.reason,
+      reason: decision.reason,
+      stalledForMs: status.stalledForMs,
+      tailLines,
+      nudgeText: decision.nudge ? chosenText : undefined,
+      lastUserMessage: summary.lastUserMessage,
+      lastAssistantMessage: summary.lastAssistantMessage,
+    });
 
     if (!decision.nudge) {
       outcomes.push({ ...base, decision: 'skip', reason: decision.reason });
       continue;
     }
 
-    // A nudge is warranted — run it past the safety gate BEFORE any delivery.
-    const resolution: InjectResolution = resolveInjectTargetForSession(session, {
-      allowGhosttyFocus: opts.allowGhosttyFocus,
-    });
+    // A nudge is warranted — plan delivery (answer-router picks mailbox/resume/
+    // refuse; resolveInjectTargetForSession supplies the vscodium-aware inject
+    // target) BEFORE any side effect.
+    const block = openBlockFor(session);
+    const plan = planDelivery(session, chosenText, block, opts.allowGhosttyFocus);
+    const rail = plan.via === 'inject' ? plan.rail : undefined;
+    const addressable = plan.via === 'inject' ? true : undefined;
 
-    if (!resolution.addressable) {
-      // Flag the un-addressable stall for the tray; NEVER guess a target.
-      flags[session.sessionId] = { reason: resolution.reason, host: session.host, atMs: nowMs };
+    if (plan.via === 'refuse') {
+      // No addressable rail and not headless-resumable — flag, NEVER guess.
+      flags[session.sessionId] = { reason: plan.reason, host: session.host, atMs: nowMs };
       outcomes.push({
         ...base, decision: 'skip', addressable: false,
-        reason: `nudge-worthy but un-addressable — ${resolution.reason}`,
+        reason: `nudge-worthy but un-addressable — ${plan.reason}`,
         nudgeText: chosenText,
       });
       continue;
     }
 
-    // handsoff = detect + flag, but never inject. Record a flag so the tray can
-    // surface "would-nudge but hands-off" alongside the un-addressable flags.
+    // handsoff = detect + flag, but never deliver.
     if (policy === 'handsoff') {
       flags[session.sessionId] = {
-        reason: `handsoff: would nudge via ${resolution.rail} but policy is hands-off`,
+        reason: `handsoff: would nudge via ${viaLabel(plan)} but policy is hands-off`,
         host: session.host,
         atMs: nowMs,
       };
       outcomes.push({
-        ...base, decision: 'nudge', addressable: true, rail: resolution.rail, injected: false,
-        reason: `handsoff: flagged, not injected (would nudge via ${resolution.rail})`,
+        ...base, decision: 'nudge', addressable, rail, via: plan.via, injected: false,
+        reason: `handsoff: flagged, not delivered (would nudge via ${viaLabel(plan)})`,
         nudgeText: chosenText,
       });
       continue;
@@ -423,39 +595,71 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
     // Dry status (no --nudge): report what WOULD happen, deliver nothing.
     if (!opts.nudge) {
       outcomes.push({
-        ...base, decision: 'nudge', addressable: true, rail: resolution.rail, injected: false,
-        reason: `would nudge via ${resolution.rail} (dry — pass --nudge to inject)`,
+        ...base, decision: 'nudge', addressable, rail, via: plan.via, injected: false,
+        reason: `would nudge via ${viaLabel(plan)} (dry — pass --nudge)`,
         nudgeText: chosenText,
       });
       continue;
     }
 
-    // Deliver into the EXACT resolved split.
-    let result: InjectResult;
-    try {
-      result = await injectIntoTerminal(resolution.target, chosenText, { dryRun: opts.injectDryRun });
-    } catch (err) {
-      result = { ok: false, backend: resolution.target.backend, writes: 0, error: err instanceof Error ? err.message : String(err) };
+    // Deliver. injectDryRun exercises the path without a real side effect: inject
+    // still calls injectFn (which honors dryRun), mailbox/resume are short-circuited.
+    let delivered: { ok: boolean; error?: string };
+    if (plan.via === 'inject') {
+      try {
+        const r = await injectFn(plan.target, chosenText, { dryRun: opts.injectDryRun });
+        delivered = { ok: r.ok, error: r.error };
+      } catch (err) {
+        delivered = { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    } else if (plan.via === 'mailbox') {
+      if (opts.injectDryRun) {
+        delivered = { ok: true };
+      } else {
+        try { deliverViaMailbox(plan.mailboxId, chosenText, block); delivered = { ok: true }; }
+        catch (err) { delivered = { ok: false, error: err instanceof Error ? err.message : String(err) }; }
+      }
+    } else {
+      delivered = opts.injectDryRun ? { ok: true } : await deliverViaResume(session, chosenText);
     }
 
-    if (result.ok) {
-      ledger[session.sessionId] = nowMs; // start the cooldown clock
+    if (delivered.ok) {
+      ledgerUpdates[session.sessionId] = nowMs; // start the cooldown clock
+      logEvents.push({
+        ts: nowMs, kind: 'nudge', terminalId: session.sessionId, agentType: candidate.agentType,
+        message: `nudged via ${viaLabel(plan)}`, reason: decision.reason, nudgeText: chosenText,
+      });
       outcomes.push({
-        ...base, decision: 'nudge', addressable: true, rail: resolution.rail, injected: true,
-        reason: `nudged via ${resolution.rail}`,
+        ...base, decision: 'nudge', addressable, rail, via: plan.via, injected: true,
+        reason: `nudged via ${viaLabel(plan)}`,
         nudgeText: chosenText,
       });
     } else {
       outcomes.push({
-        ...base, decision: 'skip', addressable: true, rail: resolution.rail, injected: false,
-        reason: `inject failed via ${resolution.rail}: ${result.error ?? 'unknown error'}`,
+        ...base, decision: 'skip', addressable, rail, via: plan.via, injected: false,
+        reason: `nudge via ${viaLabel(plan)} failed: ${delivered.error ?? 'unknown error'}`,
         nudgeText: chosenText,
       });
     }
   }
 
-  // Persist the tray-readable state.
-  writeJsonFile(path.join(dir, 'nudges.json'), ledger);
+  // Persist the cooldown ledger under a lock: fresh-read + merge this tick's
+  // updates + atomic write, so a concurrent tick's timestamps are never lost
+  // (the old unlocked read-at-start / write-at-end was a lost-update race).
+  if (Object.keys(ledgerUpdates).length > 0) {
+    const nudgesPath = path.join(dir, 'nudges.json');
+    const ledgerLock = path.join(dir, '.ledger.lock');
+    try {
+      ensureLockTarget(ledgerLock);
+      withFileLock(ledgerLock, () => {
+        const current = readNudgeLedger(dir);
+        for (const [sid, ts] of Object.entries(ledgerUpdates)) current[sid] = ts;
+        atomicWriteFileSync(nudgesPath, JSON.stringify(current, null, 2));
+      });
+    } catch {
+      /* best-effort: a lock failure must not throw out of a tick */
+    }
+  }
   writeJsonFile(path.join(dir, 'flags.json'), flags);
 
   const counts = {
@@ -467,5 +671,15 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
   };
   const result: WatchdogTickResult = { atMs: nowMs, didNudge: opts.nudge === true, outcomes, counts };
   writeJsonFile(path.join(dir, 'last-tick.json'), result);
+
+  // Heartbeat + decision/nudge events to the canonical watchdog.log the Factory
+  // Floor reads. Best-effort; never throws into the tick.
+  logEvents.push({
+    ts: nowMs,
+    kind: 'tick',
+    message: `${counts.total} live · ${counts.stalled} stalled · ${counts.nudged} nudged · ${counts.unaddressable} un-addressable`,
+  });
+  appendWatchdogEvents(logEvents, { logPath: opts.logPath });
+
   return result;
 }

--- a/apps/cli/src/lib/watchdog/watchdog.test.ts
+++ b/apps/cli/src/lib/watchdog/watchdog.test.ts
@@ -299,4 +299,57 @@ describe('isLikelyTrulyBlocked', () => {
       })
     ).toBe(false);
   });
+
+  // Precedence fix (watchdog-brain-v2): the 15m FORCE_REVIEW short-circuit used to
+  // fire BEFORE the waiting/completion checks, so a long-idle OPEN QUESTION was
+  // blindly force-nudged. Now waiting/completion win and it defers.
+  it('a long-idle (>15m) WAITING-on-user session is NOT force-nudged (defers, was a bug)', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 20 * 60_000, // 20m — past FORCE_REVIEW_STALL_MS
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"Waiting on user to choose an option."}]}}'],
+      })
+    ).toBe(false);
+  });
+
+  it('a long-idle (>15m) COMPLETED session is NOT force-nudged (defers, was a bug)', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 20 * 60_000,
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"All done, the task is finished."}]}}'],
+      })
+    ).toBe(false);
+  });
+
+  it('a long-idle (>15m) session with a neutral tail still force-reviews as blocked', () => {
+    expect(
+      isLikelyTrulyBlocked({
+        terminalId: 'CC-1',
+        agentType: 'claude',
+        stalledForMs: 20 * 60_000,
+        tailLines: ['{"type":"assistant","message":{"content":[{"type":"text","text":"thinking about the approach"}]}}'],
+      })
+    ).toBe(true);
+  });
+});
+
+describe('WATCHDOG_SYSTEM_PROMPT — drive-to-completion judgment', () => {
+  it('instructs NUDGE on needless questions and SKIP on genuine human-only cases', () => {
+    const p = WATCHDOG_SYSTEM_PROMPT;
+    // Drive-forward framing.
+    expect(p).toMatch(/NUDGE/);
+    expect(p).toMatch(/best judgment/i);
+    expect(p).toMatch(/should I proceed/i);
+    expect(p).toMatch(/end-to-end/i);
+    // Leave-for-human framing.
+    expect(p).toMatch(/SKIP/);
+    expect(p).toMatch(/credentials|2fa|biometric/i);
+    expect(p).toMatch(/publish\/release|force-push|irreversible/i);
+    // The verdict shape parseWatchdogResponse consumes is still specified.
+    expect(p).toContain('"action":"nudge"|"skip"');
+  });
 });

--- a/apps/cli/src/lib/watchdog/watchdog.ts
+++ b/apps/cli/src/lib/watchdog/watchdog.ts
@@ -95,22 +95,31 @@ export function classifyTerminal(input: ClassifyInput): StallStatus {
   return { kind: 'stalled', stalledForMs: age };
 }
 
-export const WATCHDOG_SYSTEM_PROMPT = `You are a watchdog monitoring AI coding agents that run in terminals.
-For each stalled terminal below, decide: NUDGE (send a short message to unstick it) or SKIP.
+export const WATCHDOG_SYSTEM_PROMPT = `You are the watchdog for AI coding agents running in terminals. These agents are
+expected to DRIVE TO COMPLETION end-to-end. They too often stop to ask a needless
+question or pause with the task unfinished. For each stalled terminal below, decide
+NUDGE (send a message that unsticks it and pushes it to finish) or SKIP (it genuinely
+needs the human).
 
-Nudge when:
-- The last assistant turn announced an action ("I'll write X", "let me run Y")
-  but no matching tool call followed.
-- The agent appears stuck mid-task with no recent progress and the task is incomplete.
+NUDGE when the agent could have continued on its own:
+- It asked permission for an obvious or already-authorized next step
+  ("should I proceed?", "want me to continue?", "shall I run the tests?").
+- It asked a question it could answer itself from the available context or a
+  reasonable default.
+- It announced an action ("I'll run X", "let me write Y") but no tool call followed.
+- It paused with the task incomplete and no real blocker.
+The nudge text MUST: restate the goal, tell it to use best judgment and finish
+end-to-end WITHOUT asking again, and give ONE concrete hint — the specific next
+step, a tool it forgot, or the sensible default to take. Imperative, 1-2 sentences,
+no emojis, under 200 characters.
 
-Skip when:
-- The agent asked the user a direct question (waiting on human input).
-- The task looks complete.
+SKIP when the agent genuinely needs the human:
+- Credentials, auth, login, 2FA, or biometric.
+- An irreversible or outward-facing action that needs sign-off (force-push, delete
+  prod data, publish/release, spend money, send an external message).
+- A real product or intent decision with genuine ambiguity (not a trivial default).
+- The task is actually complete.
 - You cannot tell what the agent is doing.
-
-Nudge text must be:
-- One sentence, imperative ("Show me the file.", "Run the tests.").
-- No emojis. No apologies. Under 120 characters.
 
 Respond with ONLY a JSON array (no prose, no code fence):
 [{"terminalId":"<id>","action":"nudge"|"skip","text":"<message or empty>","reason":"<brief>"}]`;
@@ -168,12 +177,18 @@ export function parseWatchdogResponse(stdout: string): Decision[] {
 }
 
 export function isLikelyTrulyBlocked(candidate: WatchdogCandidate): boolean {
-  if (candidate.stalledForMs >= FORCE_REVIEW_STALL_MS) return true;
-  if (candidate.tailLines.length === 0) return false;
+  // With no tail to reason over, only a very long stall counts as blocked.
+  if (candidate.tailLines.length === 0) return candidate.stalledForMs >= FORCE_REVIEW_STALL_MS;
 
   const lowerTail = candidate.tailLines.join('\n').toLowerCase();
+  // Waiting-on-user and completion hints are checked BEFORE the 15m force-review
+  // short-circuit — a long-idle OPEN QUESTION must defer (not be blindly
+  // force-nudged) and a finished task is done. The old order tested stall age
+  // first, so a 15m-60m idle session whose tail said "waiting on user" / "done"
+  // was force-nudged anyway. Precedence fixed here (watchdog-brain-v2).
   if (WAITING_HINTS.some((hint) => lowerTail.includes(hint))) return false;
   if (COMPLETION_HINTS.some((hint) => lowerTail.includes(hint))) return false;
+  if (candidate.stalledForMs >= FORCE_REVIEW_STALL_MS) return true;
   if (BLOCKED_HINTS.some((hint) => lowerTail.includes(hint))) return true;
 
   let sawToolAfter = false;


### PR DESCRIPTION
## Watchdog v2 — good judgment + correct VS Codium delivery

Upgrades what the always-on `agents watchdog --nudge` routine (PR #1467) DOES each tick. Two real problems: agents stop to ask needless questions instead of driving to completion, and the old extension-side watchdog failed to inject the right message at the right time into VS Codium.

### 1. Smarter judgment — escalate instead of hard-skip
The deterministic pass was hard-skipping any session parked on a question — the exact case to evaluate. It is now a cheap pre-filter that ESCALATES the judgment-heavy cases to a smart brain:
- `apps/cli/src/lib/watchdog/runner.ts` `deterministicDecision` — `waiting_input` → **escalate** (was skip); clear completion → skip; clear promise-without-toolcall → nudge; ambiguous stall → escalate.
- `apps/cli/src/lib/watchdog/watchdog.ts:98` `WATCHDOG_SYSTEM_PROMPT` rewritten: NUDGE (restate goal, use best judgment, finish end-to-end, one concrete hint) when the agent asked a needless/authorized question or paused with work left; SKIP for credentials/auth, irreversible or outward-facing actions, genuinely ambiguous product decisions, or a completed task.
- The LLM only fires on actual stalled candidates per 2‑minute tick.

### 2. Brain is a customizable `watchdog` workflow
`runner.ts` `makeDefaultSmartDecider` resolves `resolveWorkflowRef('watchdog', session.cwd)` (`apps/cli/src/lib/workflows.ts:731`); when present it runs `agents run watchdog --mode plan`, so a repo/user override + `model:` frontmatter come for free; else the improved built-in prompt via `agents run <agent> --mode plan`.

**Follow-up (out of this repo):** the default `watchdog` WORKFLOW.md seeds `~/.agents/.system/workflows/`, which ships from `phnx-labs/.agents-system` (`apps/cli/src/lib/state.ts:81`,`:84`), not this package — so this PR ships the improved built-in prompt + the resolution hook, and the system-repo default workflow is a documented follow-up (does not block).

### 3. 15-minute precedence bug fixed
`watchdog.ts` `isLikelyTrulyBlocked`: `FORCE_REVIEW_STALL_MS` used to short-circuit BEFORE the waiting/completion checks, so a long-idle open question was blindly force-nudged. Waiting-on-user and completion now win over the 15m review window.

### 4. Correct delivery via the answer-router, with VS Codium working
`runner.ts` `planDelivery` routes through `resolveAnswerRoute` (`apps/cli/src/lib/answer-router.ts:132`) for mailbox (running) / resume (parked headless) / refuse (no rail — flagged, never guessed), and takes the inject target from `resolveInjectTargetForSession` (`apps/cli/src/lib/terminal/resolve.ts:62`), which handles the **vscodium** rail the answer-router's own resolver cannot. A VS Codium / Cursor / VS Code parked session is injected into its EXACT integrated terminal via `inject.ts` (`--open-url` swarm-ext `/inject`).

### 5. Cooldown ledger is lock-serialized
`runner.ts` collects this tick's updates and does a single `withFileLock` fresh-read + merge + `atomicWriteFileSync` (`apps/cli/src/lib/fs-atomic.ts`) on `nudges.json`, closing the unlocked read-at-start/write-at-end lost-update race.

### 6. Canonical `watchdog.log`
New `apps/cli/src/lib/watchdog/log.ts` writes `~/.agents/.cache/logs/watchdog.log` in the same `WatchdogEvent` JSONL shape as `apps/factory/src/core/watchdogLog.ts` (replicated, no cross-app import), so the Factory Floor card keeps working after the extension watchdog retires.

Out of scope (noted): kitty rail, autoRotate, MCP `send_nudge` cooldown bypass.

### Tests & build
`bunx tsc --noEmit` clean; `bun run build` green. All 82 `src/lib/watchdog/` tests pass, including new: parked-on-question escalation, drive-forward vs leave-for-human, ambiguous-stall escalation, VS Codium inject to the exact terminal, locked-ledger concurrency (two ticks, no lost update), 15m precedence, and the log writer/rotation. Full `apps/cli` suite is green except 15 pre-existing env-only failures (keychain R2 sync, codex exec wiring, postinstall shims, package.json walk-up, models catalog) that **reproduce identically on `origin/main`** in this Linux environment — unrelated to this change.

End-to-end VS Codium injection will be verified by the orchestrator on zion.
