### PR TITLE
feat(fleet): agents apply --agent claude@all — replicate a machine's version set

### DIFF
--- a/apps/cli/.changelog/1.20.74.md
+++ b/apps/cli/.changelog/1.20.74.md
@@ -1,3 +1,15 @@
+- **`agents apply --agent claude@all --device <box>` — replicate this machine's
+  exact version set.** The fleet roster is agent-granular, so a fresh box only ever
+  got one `claude@latest` — losing a multi-version setup (e.g. several claude
+  versions, one per Max account, to spread rate-limit quota). The new `--agent
+  <specs...>` flag overrides the roster for the targeted device(s): `claude@all`
+  expands source-side to every version installed here (`claude@2.1.170`,
+  `claude@2.1.207`, …) and installs each missing one on the target; a pinned
+  `claude@2.1.207` installs that exact version even if another claude is present.
+  Version-pinned specs diff against a per-device `agents view --json` probe, so the
+  plan installs only what's missing and login still propagates once per agent.
+  Source: `apps/cli/src/commands/apply.ts`, `apps/cli/src/lib/fleet/apply.ts`.
+
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 1.20.74
 
+- **`agents apply --agent claude@all --device <box>` — replicate this machine's
+  exact version set.** The fleet roster is agent-granular, so a fresh box only ever
+  got one `claude@latest` — losing a multi-version setup (e.g. several claude
+  versions, one per Max account, to spread rate-limit quota). The new `--agent
+  <specs...>` flag overrides the roster for the targeted device(s): `claude@all`
+  expands source-side to every version installed here (`claude@2.1.170`,
+  `claude@2.1.207`, …) and installs each missing one on the target; a pinned
+  `claude@2.1.207` installs that exact version even if another claude is present.
+  Version-pinned specs diff against a per-device `agents view --json` probe, so the
+  plan installs only what's missing and login still propagates once per agent.
+  Source: `apps/cli/src/commands/apply.ts`, `apps/cli/src/lib/fleet/apply.ts`.
+
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/docs/fleet.md
+++ b/apps/cli/docs/fleet.md
@@ -88,7 +88,11 @@ For each targeted, reachable device `apply` probes state, then plans the minimal
 set of actions across four dimensions:
 
 - **agents-cli** — `install-cli` if absent, `upgrade-cli` on a version mismatch.
-- **agents** — `add-agent` for any profile agent not installed.
+- **agents** — `add-agent` for any profile agent not installed. A bare/`@latest`
+  spec diffs at agent granularity (install once, latest wins); a **version-pinned**
+  spec (`claude@2.1.207`) diffs per version — it installs when that exact version
+  is absent, even if some other claude is already there. Version-pinned specs
+  trigger a per-device `agents view --json` probe to read the installed version set.
 - **config** — `sync-config` for the declared `sync:` scopes.
 - **login** — `push-login` where a portable credential can be propagated;
   `needs-login` where the login is desired but genuinely can't be (see below).
@@ -141,8 +145,31 @@ every OS.
 | `--plan`, `--dry-run` | Show the reconcile plan and exit; change nothing. |
 | `-y, --yes` | Skip the confirmation prompt. |
 | `--device <name>` | Scope the apply to a single device. |
+| `--agent <specs...>` | Override the roster for the targeted device(s) — install exactly these specs instead of the manifest's. Pairs with `--device` to seed one box. See [§Replicating this machine's version set](#replicating-this-machines-version-set). |
 | `--only <dims>` | Limit to a comma list of `agents,config,login`. |
 | `--no-login` | Do not propagate logins (equivalent to `login: skip` everywhere). |
+
+## Replicating this machine's version set
+
+The manifest roster is agent-granular — a fresh box gets one `claude@latest`. When
+you keep **several claude versions** installed (e.g. one per Max account, to spread
+rate-limit quota), clone that exact set onto another device with `--agent`:
+
+```
+# Install every claude version on THIS machine onto yosemite-s0
+agents apply --agent claude@all --device yosemite-s0 -y
+
+# A specific pinned version
+agents apply --agent claude@2.1.207 --device yosemite-s0
+```
+
+`claude@all` expands **source-side** to one pinned spec per version installed here
+(`claude@2.1.170`, `claude@2.1.207`, …); `apply` then installs each missing version
+on the target and skips ones already present. `--agent` overrides the roster only
+for the run — it doesn't rewrite `agents.yaml`. Config sync and login propagation
+still run per the manifest (login is shared across a harness's versions, so it
+propagates once per agent, not once per version). Without `--device`, the override
+applies to every targeted device.
 
 ## Security
 

--- a/apps/cli/src/commands/apply.ts
+++ b/apps/cli/src/commands/apply.ts
@@ -26,9 +26,13 @@ import {
   runFleetApply,
   pool,
   sourceHome,
+  expandAllSpecs,
+  rosterNeedsVersions,
   type SourceAuth,
   type DeviceApplyResult,
 } from '../lib/fleet/apply.js';
+import { listInstalledVersions } from '../lib/versions.js';
+import type { AgentId } from '../lib/types.js';
 import type { DeviceDesired, DeviceProbe, DeviceDiff, FleetPlan } from '../lib/fleet/types.js';
 
 interface ApplyOptions {
@@ -37,6 +41,7 @@ interface ApplyOptions {
   dryRun?: boolean;
   yes?: boolean;
   device?: string;
+  agent?: string[]; // --agent claude@all codex@latest (variadic)
   only?: string;
   login?: boolean; // Commander sets false for --no-login
   recvAuth?: boolean; // hidden internal receiver
@@ -118,7 +123,7 @@ function renderPlan(plan: FleetPlan): void {
     const agentsCell = row.probe.reachable
       ? (() => {
         const add = row.actions.filter((a) => a.kind === 'add-agent');
-        return add.length === 0 ? chalk.green(`ok ${row.desired.agents.length}/${row.desired.agents.length}`) : chalk.cyan('+ ' + add.map((a) => a.agent).join(','));
+        return add.length === 0 ? chalk.green(`ok ${row.desired.agents.length}/${row.desired.agents.length}`) : chalk.cyan('+ ' + add.map((a) => a.spec ?? a.agent).join(','));
       })()
       : chalk.gray('-');
     const configCell = row.probe.reachable
@@ -207,6 +212,15 @@ async function runApply(opts: ApplyOptions): Promise<void> {
     desired = desired.filter((d) => d.device === opts.device);
     if (desired.length === 0) throw new Error(`Device '${opts.device}' is not a target in this manifest.`);
   }
+  // --agent overrides the roster for the targeted device(s): install exactly these
+  // specs instead of the manifest's. `claude@all` expands to every claude version
+  // installed on THIS machine, so a fresh box inherits the same version set. Pair
+  // with --device to seed one box; without it, every targeted device gets the set.
+  if (opts.agent && opts.agent.length > 0) {
+    const specs = expandAllSpecs(opts.agent, (id) => listInstalledVersions(id as AgentId));
+    desired = desired.map((d) => ({ ...d, agents: specs }));
+    console.log(chalk.gray(`Roster override (--agent): ${specs.join(', ')}`));
+  }
   if (opts.login === false) desired = desired.map((d) => ({ ...d, login: 'skip' as const }));
   if (desired.length === 0) {
     console.log(chalk.gray('No target devices — nothing to apply.'));
@@ -230,8 +244,9 @@ async function runApply(opts: ApplyOptions): Promise<void> {
 
   // Probe every target device in parallel.
   const nameToProfile = new Map<string, DeviceProfile>(desired.map((d) => [d.device, registry[d.device]!]));
+  const withVersions = rosterNeedsVersions(desired);
   console.log(chalk.gray(`Probing ${desired.length} device(s)…`));
-  const probeList = await pool(desired, 6, async (d) => probeDevice(nameToProfile.get(d.device)!));
+  const probeList = await pool(desired, 6, async (d) => probeDevice(nameToProfile.get(d.device)!, { withVersions }));
   const probes = new Map<string, DeviceProbe>(probeList.map((p) => [p.device, p]));
 
   const targetCliVersion = localCliVersion();
@@ -314,6 +329,7 @@ export function configureApplyCommand(cmd: Command): Command {
     .option('--dry-run', 'Alias for --plan')
     .option('-y, --yes', 'Skip the confirmation prompt')
     .option('--device <name>', 'Scope the apply to a single device')
+    .option('--agent <specs...>', 'Override the roster for targeted device(s): install these specs instead of the manifest\'s. Use `claude@all` to replicate every version installed on this machine.')
     .option('--only <dims>', 'Limit to dimensions: comma list of agents,config,login')
     .option('--no-login', 'Do not propagate logins')
     .addOption(new Option('--recv-auth', 'internal: receive an auth bundle on stdin').hideHelp())
@@ -343,6 +359,12 @@ export function registerApplyCommand(program: Command): void {
 
       # One device only
       agents apply --device yosemite-s1 -y
+
+      # Replicate every claude version on this machine onto a fresh box
+      agents apply --agent claude@all --device yosemite-s0 -y
+
+      # Install a specific pinned version on one device
+      agents apply --agent claude@2.1.207 --device yosemite-s0
     `,
   });
 }

--- a/apps/cli/src/lib/fleet/apply.test.ts
+++ b/apps/cli/src/lib/fleet/apply.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { agentIdOf, diffFleet, canPushLogin, type SourceAuth } from './apply.js';
+import {
+  agentIdOf,
+  diffFleet,
+  canPushLogin,
+  pinnedVersion,
+  rosterNeedsVersions,
+  expandAllSpecs,
+  parseInstalledVersions,
+  type SourceAuth,
+} from './apply.js';
 import type { DeviceDesired, DeviceProbe } from './types.js';
 
 function srcAuth(available: string[], bound: string[] = []): SourceAuth {
@@ -193,5 +202,124 @@ describe('diffFleet — secrets surfacing', () => {
       secretsBundles: ['attio'],
     });
     expect(plan.devices[0].secretsNeeded).toEqual([]);
+  });
+});
+
+describe('pinnedVersion', () => {
+  it('returns the explicit version', () => {
+    expect(pinnedVersion('claude@2.1.170')).toBe('2.1.170');
+  });
+  it('returns undefined for id-level / label specs', () => {
+    expect(pinnedVersion('claude')).toBeUndefined();
+    expect(pinnedVersion('claude@latest')).toBeUndefined();
+    expect(pinnedVersion('claude@oldest')).toBeUndefined();
+    expect(pinnedVersion('claude@all')).toBeUndefined();
+  });
+});
+
+describe('rosterNeedsVersions', () => {
+  it('is true when any device pins a version', () => {
+    expect(rosterNeedsVersions([
+      { device: 's0', agents: ['claude@latest'], sync: [], login: 'skip' },
+      { device: 's1', agents: ['claude@2.1.170'], sync: [], login: 'skip' },
+    ])).toBe(true);
+  });
+  it('is false for a purely id-level roster', () => {
+    expect(rosterNeedsVersions([
+      { device: 's0', agents: ['claude', 'codex@latest'], sync: [], login: 'skip' },
+    ])).toBe(false);
+  });
+});
+
+describe('expandAllSpecs', () => {
+  const versionsOf = (id: string) => (id === 'claude' ? ['2.1.170', '2.1.207'] : []);
+  it('expands @all into one pinned spec per source version', () => {
+    expect(expandAllSpecs(['claude@all'], versionsOf)).toEqual(['claude@2.1.170', 'claude@2.1.207']);
+  });
+  it('passes non-@all specs through and de-dups', () => {
+    expect(expandAllSpecs(['claude@all', 'claude@2.1.207', 'codex@latest'], versionsOf))
+      .toEqual(['claude@2.1.170', 'claude@2.1.207', 'codex@latest']);
+  });
+  it('throws when @all names an agent with no installed versions', () => {
+    expect(() => expandAllSpecs(['codex@all'], versionsOf)).toThrow(/no codex versions installed/);
+  });
+});
+
+describe('parseInstalledVersions', () => {
+  it('maps agent id -> versions from the view --json array', () => {
+    const json = JSON.stringify([
+      { agent: 'claude', versions: [{ version: '2.1.170' }, { version: '2.1.207' }], profiles: [] },
+      { agent: 'codex', versions: [{ version: '0.146.0' }], profiles: [] },
+    ]);
+    expect(parseInstalledVersions(json)).toEqual({ claude: ['2.1.170', '2.1.207'], codex: ['0.146.0'] });
+  });
+  it('returns undefined on malformed output', () => {
+    expect(parseInstalledVersions('not json')).toBeUndefined();
+    expect(parseInstalledVersions('{"not":"an array"}')).toBeUndefined();
+  });
+});
+
+describe('diffFleet — version-aware add-agent', () => {
+  const twoVersions: DeviceDesired[] = [
+    { device: 's0', agents: ['claude@2.1.170', 'claude@2.1.207'], sync: [], login: 'skip' },
+  ];
+
+  it('installs only the missing version when one is already present', () => {
+    const probes = new Map<string, DeviceProbe>([
+      ['s0', {
+        device: 's0', reachable: true, platform: 'linux', cliVersion: CLI,
+        installedAgents: ['claude'], installedVersions: { claude: ['2.1.207'] },
+      }],
+    ]);
+    const plan = diffFleet(twoVersions, probes, { targetCliVersion: CLI, sourceAuth: srcAuth([]) });
+    const adds = plan.actions.filter((a) => a.kind === 'add-agent');
+    expect(adds).toHaveLength(1);
+    expect(adds[0].spec).toBe('claude@2.1.170');
+    expect(adds[0].detail).toBe('install claude@2.1.170');
+  });
+
+  it('installs every version when the agent id is present but no versions match', () => {
+    const probes = new Map<string, DeviceProbe>([
+      ['s0', {
+        device: 's0', reachable: true, platform: 'linux', cliVersion: CLI,
+        installedAgents: ['claude'], installedVersions: { claude: ['2.1.100'] },
+      }],
+    ]);
+    const plan = diffFleet(twoVersions, probes, { targetCliVersion: CLI, sourceAuth: srcAuth([]) });
+    expect(plan.actions.filter((a) => a.kind === 'add-agent').map((a) => a.spec))
+      .toEqual(['claude@2.1.170', 'claude@2.1.207']);
+  });
+
+  it('nothing to add when both versions are already installed', () => {
+    const probes = new Map<string, DeviceProbe>([
+      ['s0', {
+        device: 's0', reachable: true, platform: 'linux', cliVersion: CLI,
+        installedAgents: ['claude'], installedVersions: { claude: ['2.1.170', '2.1.207'] },
+      }],
+    ]);
+    const plan = diffFleet(twoVersions, probes, { targetCliVersion: CLI, sourceAuth: srcAuth([]) });
+    expect(plan.actions.filter((a) => a.kind === 'add-agent')).toHaveLength(0);
+  });
+
+  it('a version-pinned spec installs when the probe has no version info (fallback)', () => {
+    const probes = new Map<string, DeviceProbe>([
+      ['s0', { device: 's0', reachable: true, platform: 'linux', cliVersion: CLI, installedAgents: ['claude'] }],
+    ]);
+    const plan = diffFleet(twoVersions, probes, { targetCliVersion: CLI, sourceAuth: srcAuth([]) });
+    expect(plan.actions.filter((a) => a.kind === 'add-agent')).toHaveLength(2);
+  });
+
+  it('propagates login once per id even when @all names claude many times', () => {
+    const roster: DeviceDesired[] = [
+      { device: 's0', agents: ['claude@2.1.170', 'claude@2.1.207'], sync: [], login: 'sync' },
+    ];
+    const probes = new Map<string, DeviceProbe>([
+      ['s0', {
+        device: 's0', reachable: true, platform: 'linux', cliVersion: CLI,
+        installedAgents: ['claude'], installedVersions: { claude: ['2.1.170', '2.1.207'] },
+      }],
+    ]);
+    const plan = diffFleet(roster, probes, { targetCliVersion: CLI, sourceAuth: srcAuth(['claude']) });
+    expect(plan.actions.filter((a) => a.kind === 'push-login')).toHaveLength(1);
   });
 });

--- a/apps/cli/src/lib/fleet/apply.ts
+++ b/apps/cli/src/lib/fleet/apply.ts
@@ -321,9 +321,10 @@ export function reconcileDevice(row: DeviceDiff, device: DeviceProfile, ctx: Exe
     ok = ok && r.ok;
   }
 
-  // 2. agents.
+  // 2. agents. Every add-agent action carries the full spec (set in diffFleet);
+  // install it directly rather than re-parsing the human-readable detail string.
   for (const a of row.actions.filter((x) => x.kind === 'add-agent')) {
-    const spec = a.detail.replace(/^install\s+/, '');
+    const spec = a.spec!;
     const r = sshAgents(['add', spec, '--yes']);
     steps.push({ kind: 'add-agent', ok: r.code === 0, detail: a.detail });
     ok = ok && r.code === 0;

--- a/apps/cli/src/lib/fleet/apply.ts
+++ b/apps/cli/src/lib/fleet/apply.ts
@@ -34,6 +34,75 @@ export function agentIdOf(spec: string): string {
   return spec.split('@')[0].trim();
 }
 
+/**
+ * The explicit pinned version of a spec, or undefined for an id-level spec.
+ * `claude@2.1.170` -> `2.1.170`; `claude`, `claude@latest`, `claude@oldest`, and
+ * `claude@all` all return undefined (the label channels install-latest / are
+ * expanded upstream, so they diff at id granularity, not per-version).
+ */
+export function pinnedVersion(spec: string): string | undefined {
+  const at = spec.indexOf('@');
+  if (at < 0) return undefined;
+  const v = spec.slice(at + 1).trim();
+  if (!v || v === 'latest' || v === 'oldest' || v === 'all') return undefined;
+  return v;
+}
+
+/** True when any spec in the roster pins an explicit version (needs a version probe). */
+export function rosterNeedsVersions(desired: DeviceDesired[]): boolean {
+  return desired.some((d) => d.agents.some((s) => pinnedVersion(s) !== undefined));
+}
+
+/**
+ * Expand any `<agent>@all` spec into one pinned spec per version installed on the
+ * source, so `--agent claude@all` replicates THIS machine's exact version set.
+ * `versionsOf` returns the source's installed versions for an agent id. Every
+ * other spec passes through unchanged; the result is de-duplicated in order.
+ * Throws if `@all` names an agent with no installed versions here (nothing to
+ * replicate — a clear misconfig, not a silent no-op).
+ */
+export function expandAllSpecs(specs: string[], versionsOf: (id: string) => string[]): string[] {
+  const out: string[] = [];
+  for (const spec of specs) {
+    const at = spec.indexOf('@');
+    const label = at >= 0 ? spec.slice(at + 1).trim() : '';
+    if (label !== 'all') {
+      out.push(spec);
+      continue;
+    }
+    const id = agentIdOf(spec);
+    const versions = versionsOf(id);
+    if (versions.length === 0) {
+      throw new Error(`--agent ${spec}: no ${id} versions installed on this machine to replicate.`);
+    }
+    for (const v of versions) out.push(`${id}@${v}`);
+  }
+  return [...new Set(out)];
+}
+
+/**
+ * Parse `agents view --json` (the all-agents array form) into a map of agent id
+ * -> installed version strings. Tolerant: returns undefined on any parse failure
+ * so a version-pinned spec falls back to id-level presence rather than crashing.
+ */
+export function parseInstalledVersions(stdout: string): Record<string, string[]> | undefined {
+  try {
+    const arr = JSON.parse(stdout) as Array<{ agent?: unknown; versions?: unknown }>;
+    if (!Array.isArray(arr)) return undefined;
+    const out: Record<string, string[]> = {};
+    for (const a of arr) {
+      if (a && typeof a.agent === 'string' && Array.isArray(a.versions)) {
+        out[a.agent] = (a.versions as Array<{ version?: unknown }>)
+          .map((v) => v?.version)
+          .filter((v): v is string => typeof v === 'string');
+      }
+    }
+    return out;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Source-side auth availability, computed once from `snapshotAuth`. */
 export interface SourceAuth {
   /** Agent ids the source has a readable, propagatable credential file for. */
@@ -89,21 +158,28 @@ export function diffFleet(desired: DeviceDesired[], probes: Map<string, DevicePr
       } else if (probe.cliVersion !== ctx.targetCliVersion) {
         rowActions.push({ device: d.device, kind: 'upgrade-cli', detail: `agents-cli ${probe.cliVersion} -> ${ctx.targetCliVersion}` });
       }
-      // agents.
+      // agents. A version-pinned spec (`claude@2.1.170`, or an expanded
+      // `claude@all` member) is present only when that exact version is on the
+      // device; a bare/latest spec diffs at id granularity. So `--agent claude@all`
+      // installs every missing version even when some claude is already there.
       for (const spec of d.agents) {
         const id = agentIdOf(spec);
-        if (!probe.installedAgents.includes(id)) {
-          rowActions.push({ device: d.device, kind: 'add-agent', agent: id, detail: `install ${spec}` });
+        const want = pinnedVersion(spec);
+        const present = want !== undefined
+          ? (probe.installedVersions?.[id]?.includes(want) ?? false)
+          : probe.installedAgents.includes(id);
+        if (!present) {
+          rowActions.push({ device: d.device, kind: 'add-agent', agent: id, spec, detail: `install ${spec}` });
         }
       }
       // config.
       if (d.sync.length > 0) {
         rowActions.push({ device: d.device, kind: 'sync-config', detail: `sync config (${d.sync.join(', ')})` });
       }
-      // login.
+      // login — per agent id, not per spec: `claude@all` names one id many times,
+      // but login propagates once per agent (its credential is version-shared).
       if (d.login === 'sync') {
-        for (const spec of d.agents) {
-          const id = agentIdOf(spec);
+        for (const id of [...new Set(d.agents.map(agentIdOf))]) {
           if (canPushLogin(id, probe.platform, ctx.sourceAuth)) {
             rowActions.push({ device: d.device, kind: 'push-login', agent: id, detail: `propagate ${id} login` });
           } else if (
@@ -150,8 +226,15 @@ function remoteEnv(platform: string | undefined): Record<string, string> | undef
   return platform === 'windows' ? undefined : { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' };
 }
 
-/** Probe one device: reachability + agents-cli version + installed agent ids. */
-export function probeDevice(device: DeviceProfile): DeviceProbe {
+export interface ProbeOptions {
+  /** Also fetch per-agent installed versions (one extra `agents view --json`
+   * round-trip). Enable only when the plan has a version-pinned spec. */
+  withVersions?: boolean;
+}
+
+/** Probe one device: reachability + agents-cli version + installed agent ids
+ * (and, when `withVersions`, the installed version strings per agent). */
+export function probeDevice(device: DeviceProfile, opts?: ProbeOptions): DeviceProbe {
   let target: string;
   try {
     target = sshTargetFor(device);
@@ -174,12 +257,19 @@ export function probeDevice(device: DeviceProfile): DeviceProbe {
       /* agents-cli present but doctor output unparsable — treat as no agents */
     }
   }
+  let installedVersions: Record<string, string[]> | undefined;
+  if (opts?.withVersions) {
+    const viewCmd = buildRemoteAgentsInvocation(['view', '--json'], undefined, hint, remoteEnv(device.platform));
+    const vres = sshExec(target, viewCmd, { timeoutMs: 30000, multiplex: true });
+    if (vres.code === 0) installedVersions = parseInstalledVersions(vres.stdout);
+  }
   return {
     device: device.name,
     reachable: true,
     platform: device.platform,
     cliVersion: ready.version ?? undefined,
     installedAgents: installed,
+    installedVersions,
   };
 }
 

--- a/apps/cli/src/lib/fleet/types.ts
+++ b/apps/cli/src/lib/fleet/types.ts
@@ -91,6 +91,14 @@ export interface DeviceProbe {
   cliVersion?: string;
   /** Agent ids currently installed on the device. */
   installedAgents: string[];
+  /**
+   * Installed version strings per agent id (e.g. `{ claude: ['2.1.170', '2.1.207'] }`),
+   * parsed from `agents view --json` on the device. Only populated when the plan
+   * involves a version-pinned spec (`claude@2.1.170`, or a `claude@all` expansion)
+   * — a bare `claude`/`claude@latest` roster never pays for the extra probe. When
+   * undefined, version-pinned specs fall back to id-level presence.
+   */
+  installedVersions?: Record<string, string[]>;
   /** Reason string when `reachable` is false or the probe partially failed. */
   note?: string;
 }
@@ -112,6 +120,9 @@ export interface FleetAction {
   kind: FleetActionKind;
   /** Agent id for agent/login actions; undefined for cli/config actions. */
   agent?: string;
+  /** Full agent spec for `add-agent` (e.g. `claude@2.1.170`) so the plan can show
+   * the exact version being installed; equals the id for a bare/latest spec. */
+  spec?: string;
   /** Human, one-line description of the action. */
   detail: string;
 }


### PR DESCRIPTION
## What

Adds `agents apply --agent <specs...>` so you can replicate **this machine's exact set of installed versions** onto another device — the piece fleet sync was missing.

The `fleet:` roster is agent-granular (`agents: [claude@latest]`), and `capture` rewrites everything to `@latest`, so a fresh box only ever got **one** latest claude. That loses a deliberate multi-version setup — several claude versions, one per Max account, to spread rate-limit quota. `--agent claude@all` closes that gap.

## How

- **`--agent <specs...>`** overrides the roster for the targeted device(s) — install exactly these specs instead of the manifest's. Pairs with `--device` to seed one box; without it, applies to every targeted device. Overrides the run only, never rewrites `agents.yaml`.
- **`claude@all`** expands **source-side** via `listInstalledVersions` to one pinned spec per version installed here (`claude@2.1.170 … @2.1.207`).
- **Version-aware diff.** A pinned spec (`claude@2.1.207`) diffs per version: it installs when that exact version is absent, even if another claude is present. Bare/`@latest` keeps the existing agent-granular behavior. Pinned specs trigger a per-device `agents view --json` probe → `DeviceProbe.installedVersions`; when unavailable it falls back to id-level presence (no crash).
- **Login stays once per agent** — a harness's credential is version-shared, so `claude@all` (one id, many specs) propagates login a single time, not four.

Harness parity: the path is agent-agnostic (`listInstalledVersions(id)` + spec diffing), so it works for every managed agent, not just claude.

## Verified end-to-end (live `yosemite-s0`)

`claude@all` expanded to the 4 versions on this box; the real SSH probe read s0's set; the diff planned **only the missing version**; the real run installed it.

```
Roster override (--agent): claude@2.1.170, claude@2.1.181, claude@2.1.186, claude@2.1.207
Fleet profile · 1 device(s) · 1 agent(s) (claude)
  device        agents-cli  agents              config    login
  yosemite-s0   upgrade     + claude@2.1.181    ok        ok 4/4
  yosemite-s0   ok    ✓ upgrade-cli  ✓ add-agent
Fleet reconciled.
```

s0 installed versions — **before**: `2.1.207, 2.1.187, 2.1.186, 2.1.170` → **after**: `2.1.207, 2.1.187, 2.1.186, 2.1.181, 2.1.170` (only `2.1.181`, the one it lacked, was added; the three it already had were left alone).

## Tests

`apps/cli/src/lib/fleet/apply.test.ts` — `pinnedVersion`, `rosterNeedsVersions`, `expandAllSpecs` (incl. the empty-set throw), `parseInstalledVersions`, and version-aware `diffFleet` (install-only-missing, install-all-when-none-match, idempotent, no-version-info fallback, login-once-per-id). 91 passed across the fleet + apply suite; `tsc --noEmit` clean.

## Docs + changelog

`apps/cli/docs/fleet.md` (new "Replicating this machine's version set" section + Flags/reconcile updates) and `apps/cli/CHANGELOG.md` under 1.20.74.

Session transcript (public repo — not attached): `yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/038d753a-7048-4e3c-b18f-066a2c02e2fb.jsonl`
