### PR TITLE
feat(hosts): auto-reconnect an interactive --device run when the SSH link drops

### DIFF
--- a/apps/cli/.changelog/next/rush-2007-device-auto-reconnect.md
+++ b/apps/cli/.changelog/next/rush-2007-device-auto-reconnect.md
@@ -1,0 +1,14 @@
+- **`agents run --device`/`--host` now auto-reconnects when the network drops.** A
+  remote interactive agent runs in a detached tmux session on the peer, so an SSH
+  blink kills only the local client — the agent keeps running. Previously the local
+  side exited with ssh's connection-layer code (255) and you had to notice, find the
+  session id, and `agents sessions focus` by hand. Now, when a tmux-hosted run with a
+  known session id drops (exit 255), the client re-attaches the live remote pane
+  automatically over SSH — reusing the peer's own `agents sessions focus <id> --local
+  --attach-only` (a live join, not a resumed copy) — with bounded exponential backoff
+  (2s→30s, up to 6 attempts, and the budget refills after a genuinely live
+  reconnection). A clean detach (Ctrl-b d, exit 0) or a real agent exit (any non-255
+  code) is left alone; `--raw`/no-tmux runs, which don't survive a drop, are not
+  retried. This covers Claude and resumed runs today; capturing a resumable id for
+  other agents on the `--device` path is tracked in RUSH-2007. Source:
+  `apps/cli/src/lib/hosts/reconnect.ts`, `apps/cli/src/commands/exec.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,21 +2,6 @@
 
 ## 1.20.74
 
-- **`agents run --device`/`--host` now auto-reconnects when the network drops.** A
-  remote interactive agent runs in a detached tmux session on the peer, so an SSH
-  blink kills only the local client — the agent keeps running. Previously the local
-  side exited with ssh's connection-layer code (255) and you had to notice, find the
-  session id, and `agents sessions focus` by hand. Now, when a tmux-hosted run with a
-  known session id drops (exit 255), the client re-attaches the live remote pane
-  automatically over SSH — reusing the peer's own `agents sessions focus <id> --local
-  --attach-only` (a live join, not a resumed copy) — with bounded exponential backoff
-  (2s→30s, up to 6 attempts, and the budget refills after a genuinely live
-  reconnection). A clean detach (Ctrl-b d, exit 0) or a real agent exit (any non-255
-  code) is left alone; `--raw`/no-tmux runs, which don't survive a drop, are not
-  retried. This covers Claude and resumed runs today; capturing a resumable id for
-  other agents on the `--device` path is tracked in RUSH-2007. Source:
-  `apps/cli/src/lib/hosts/reconnect.ts`, `apps/cli/src/commands/exec.ts`.
-
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 1.20.74
 
+- **`agents run --device`/`--host` now auto-reconnects when the network drops.** A
+  remote interactive agent runs in a detached tmux session on the peer, so an SSH
+  blink kills only the local client — the agent keeps running. Previously the local
+  side exited with ssh's connection-layer code (255) and you had to notice, find the
+  session id, and `agents sessions focus` by hand. Now, when a tmux-hosted run with a
+  known session id drops (exit 255), the client re-attaches the live remote pane
+  automatically over SSH — reusing the peer's own `agents sessions focus <id> --local
+  --attach-only` (a live join, not a resumed copy) — with bounded exponential backoff
+  (2s→30s, up to 6 attempts, and the budget refills after a genuinely live
+  reconnection). A clean detach (Ctrl-b d, exit 0) or a real agent exit (any non-255
+  code) is left alone; `--raw`/no-tmux runs, which don't survive a drop, are not
+  retried. This covers Claude and resumed runs today; capturing a resumable id for
+  other agents on the `--device` path is tracked in RUSH-2007. Source:
+  `apps/cli/src/lib/hosts/reconnect.ts`, `apps/cli/src/commands/exec.ts`.
+
 - **Project resource manifests are now portable across Windows and POSIX.** The
   managed-resource manifest `.agents-managed.json` recorded its paths with the
   host's native separator, so a sync run on Windows wrote entries like

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -215,7 +215,8 @@ agents run <agent> ["<task>"] --host <host>
   └─ no prompt?                interactive TTY-forwarded path
         ssh -tt <node> 'agents run <agent>'   (only when local stdin is a TTY)
         remote agents-cli launches its normal interactive UI (tmux on the host)
-        local CLI exits when the SSH session ends
+        network drop (ssh exit 255) → auto-reattach the live remote pane;
+        clean detach / agent exit → local CLI exits with that code
 ```
 
 > Shipped surface: dispatch is `agents run <agent> ["<task>"] --host <name>`.
@@ -226,6 +227,18 @@ agents run <agent> ["<task>"] --host <host>
 > tmux wrapper.
 > Host runs are tracked in a **local** task store, not `agents cloud` (a separate
 > subsystem for Rush/Codex/Factory backends).
+>
+> **Surviving a network drop.** Because the remote agent runs in a *detached* tmux
+> session on the host, an SSH blink kills only the local client — the agent keeps
+> working. When an interactive host run with a known session id (Claude, or a
+> `--resume`d run) drops (ssh reports its connection-layer code, 255), the local CLI
+> **re-attaches the live remote pane automatically** — it drives the host's own
+> `agents sessions focus <id> --local --attach-only` over SSH (a live join, not a
+> resumed copy), with bounded exponential backoff (2s→30s, up to 6 attempts; the
+> budget refills after a genuinely live reconnection). A clean detach (`Ctrl-b d`,
+> exit 0) or a real agent exit (any non-255 code) is left alone, and `--raw`/no-tmux
+> runs are not retried (they don't survive a drop). If every attempt fails the CLI
+> prints the manual `agents sessions focus <id>` to reconnect once the link is back.
 >
 > Pass `--name <slug>` at dispatch to give the run a durable handle instead of an
 > opaque id: `agents hosts ps` shows it under a **NAME** column, and

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1295,6 +1295,8 @@ export function registerRunCommand(program: Command): void {
                 name: options.name,
               });
             }
+            const isRaw = options.raw || options.tmux === false || options.disableTmux === true;
+            const runStartedMs = Date.now();
             const exitCode = await runInteractiveOnHost(host, {
               agent: runAgent,
               version: resumeId ? undefined : runVersion,
@@ -1316,10 +1318,32 @@ export function registerRunCommand(program: Command): void {
               name: options.name,
               resume: resumeId,
               passthroughArgs,
-              raw: options.raw || options.tmux === false || options.disableTmux === true,
+              raw: isRaw,
               forceInteractive: options.interactive,
               copyCreds: hostCopyCreds,
             });
+            // A network drop kills the local ssh client (exit 255) but the remote
+            // agent survives in its detached tmux session. With a known session id
+            // (Claude, or a resumed run) and a tmux-hosted run, re-attach the live
+            // pane automatically instead of exiting — the user never has to notice
+            // the drop and `agents sessions focus` by hand. `raw` runs aren't tmux
+            // wrapped, so there is nothing to reconnect to. Non-Claude id capture is
+            // tracked in RUSH-2007.
+            const reconnectId = hostSessionId ?? resumeId;
+            if (reconnectId && !isRaw) {
+              const { reconnectInteractiveSession, SSH_CONN_FAILURE } = await import('../lib/hosts/reconnect.js');
+              if (exitCode === SSH_CONN_FAILURE) {
+                process.exit(
+                  await reconnectInteractiveSession({
+                    host,
+                    sessionId: reconnectId,
+                    initialExit: exitCode,
+                    initialDurationMs: Date.now() - runStartedMs,
+                    copyCreds: hostCopyCreds,
+                  }),
+                );
+              }
+            }
             process.exit(exitCode);
           }
 

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1296,7 +1296,6 @@ export function registerRunCommand(program: Command): void {
               });
             }
             const isRaw = options.raw || options.tmux === false || options.disableTmux === true;
-            const runStartedMs = Date.now();
             const exitCode = await runInteractiveOnHost(host, {
               agent: runAgent,
               version: resumeId ? undefined : runVersion,
@@ -1338,7 +1337,6 @@ export function registerRunCommand(program: Command): void {
                     host,
                     sessionId: reconnectId,
                     initialExit: exitCode,
-                    initialDurationMs: Date.now() - runStartedMs,
                   }),
                 );
               }

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1339,7 +1339,6 @@ export function registerRunCommand(program: Command): void {
                     sessionId: reconnectId,
                     initialExit: exitCode,
                     initialDurationMs: Date.now() - runStartedMs,
-                    copyCreds: hostCopyCreds,
                   }),
                 );
               }

--- a/apps/cli/src/lib/hosts/reconnect.test.ts
+++ b/apps/cli/src/lib/hosts/reconnect.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the interactive-session auto-reconnect policy. The load-bearing logic
+ * is the pure state machine `reconnectStep` + `backoffMs` — exercised directly with
+ * real inputs, no mocks. `reconnectInteractiveSession` is driven through that same
+ * real state machine; only the two genuinely-external effects (the SSH re-attach and
+ * the wall-clock wait) are supplied as deterministic sequences, because SSH cannot
+ * run in CI. No production code path is stubbed.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { Host } from './types.js';
+import {
+  reconnectStep,
+  backoffMs,
+  reconnectNotice,
+  exhaustedNotice,
+  reconnectInteractiveSession,
+  initialReconnectState,
+  SSH_CONN_FAILURE,
+  MAX_ATTEMPTS,
+  LIVE_SESSION_MS,
+  type ReconnectOutcome,
+} from './reconnect.js';
+
+const HOST = { name: 'zion' } as Host;
+const SID = '94c75686-145c-465d-b3f8-a9c0d3a0387c';
+
+describe('reconnectStep — the pure retry decision', () => {
+  test('a clean detach (exit 0) stops and surfaces 0 — never reconnects', () => {
+    const d = reconnectStep(initialReconnectState(), { code: 0, durationMs: 60_000 });
+    expect(d).toEqual({ action: 'stop', code: 0 });
+  });
+
+  test('a real remote exit code (agent ended, non-255) stops and surfaces it', () => {
+    expect(reconnectStep({ attempt: 0 }, { code: 1, durationMs: 5_000 })).toEqual({ action: 'stop', code: 1 });
+    expect(reconnectStep({ attempt: 3 }, { code: 130, durationMs: 5_000 })).toEqual({ action: 'stop', code: 130 });
+  });
+
+  test('a 255 drop retries with exponential backoff and advances the attempt', () => {
+    const d = reconnectStep({ attempt: 0 }, { code: SSH_CONN_FAILURE, durationMs: 500 });
+    expect(d).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
+    const d2 = reconnectStep({ attempt: 1 }, { code: SSH_CONN_FAILURE, durationMs: 500 });
+    expect(d2).toEqual({ action: 'retry', waitMs: 4_000, state: { attempt: 2 } });
+  });
+
+  test('the retry budget is bounded: attempt === MAX_ATTEMPTS on a fast drop stops at 255', () => {
+    const d = reconnectStep({ attempt: MAX_ATTEMPTS }, { code: SSH_CONN_FAILURE, durationMs: 500 });
+    expect(d).toEqual({ action: 'stop', code: SSH_CONN_FAILURE });
+  });
+
+  test('a drop AFTER a genuinely live session refills the budget (does not burn attempts)', () => {
+    // attempt is already maxed, but the session held past the live threshold, so a
+    // fresh drop should reconnect again rather than give up.
+    const d = reconnectStep({ attempt: MAX_ATTEMPTS }, { code: SSH_CONN_FAILURE, durationMs: LIVE_SESSION_MS + 1 });
+    expect(d).toEqual({ action: 'retry', waitMs: backoffMs(0), state: { attempt: 1 } });
+  });
+});
+
+describe('backoffMs — capped exponential', () => {
+  test('doubles then caps at 30s', () => {
+    expect(backoffMs(0)).toBe(2_000);
+    expect(backoffMs(1)).toBe(4_000);
+    expect(backoffMs(2)).toBe(8_000);
+    expect(backoffMs(3)).toBe(16_000);
+    expect(backoffMs(4)).toBe(30_000); // 32s clamped
+    expect(backoffMs(10)).toBe(30_000);
+  });
+});
+
+describe('notices — human readable', () => {
+  test('reconnect notice names the host, the short id, the wait, and the attempt', () => {
+    const s = reconnectNotice(SID, 'zion', 2, 4_000);
+    expect(s).toContain('zion');
+    expect(s).toContain('94c75686');
+    expect(s).toContain('in 4 seconds');
+    expect(s).toContain(`attempt 2/${MAX_ATTEMPTS}`);
+  });
+
+  test('exhausted notice hands back the manual command', () => {
+    const s = exhaustedNotice(SID, 'zion');
+    expect(s).toContain('agents sessions focus 94c75686');
+  });
+});
+
+describe('reconnectInteractiveSession — the loop over the real state machine', () => {
+  const noWait = async () => {};
+
+  test('reattaches after a drop, then returns 0 when the user detaches cleanly', async () => {
+    const codes: ReconnectOutcome[] = [{ code: 0, durationMs: 30_000 }]; // reattach → clean detach
+    const writes: string[] = [];
+    const rc = await reconnectInteractiveSession({
+      host: HOST,
+      sessionId: SID,
+      initialExit: SSH_CONN_FAILURE,
+      initialDurationMs: 500,
+      reattach: () => codes.shift()!,
+      wait: noWait,
+      write: (s) => writes.push(s),
+    });
+    expect(rc).toBe(0);
+    expect(writes.some((w) => w.includes('attempt 1/'))).toBe(true);
+    expect(writes.some((w) => w.includes("Couldn't reconnect"))).toBe(false);
+  });
+
+  test('gives up after MAX_ATTEMPTS fast failures and returns 255 with the manual hint', async () => {
+    let calls = 0;
+    const writes: string[] = [];
+    const rc = await reconnectInteractiveSession({
+      host: HOST,
+      sessionId: SID,
+      initialExit: SSH_CONN_FAILURE,
+      initialDurationMs: 500,
+      reattach: () => {
+        calls++;
+        return { code: SSH_CONN_FAILURE, durationMs: 200 }; // always fails fast
+      },
+      wait: noWait,
+      write: (s) => writes.push(s),
+    });
+    expect(rc).toBe(SSH_CONN_FAILURE);
+    expect(calls).toBe(MAX_ATTEMPTS); // exactly the budget, no more
+    expect(writes.some((w) => w.includes('agents sessions focus 94c75686'))).toBe(true);
+  });
+
+  test('a mid-run second drop after a live reconnection keeps reconnecting', async () => {
+    // drop → reattach holds a long live session → drops again → reattach → clean exit.
+    const seq: ReconnectOutcome[] = [
+      { code: SSH_CONN_FAILURE, durationMs: LIVE_SESSION_MS + 5_000 }, // lived, then dropped
+      { code: 0, durationMs: 20_000 }, // reattached, clean detach
+    ];
+    const rc = await reconnectInteractiveSession({
+      host: HOST,
+      sessionId: SID,
+      initialExit: SSH_CONN_FAILURE,
+      initialDurationMs: 500,
+      reattach: () => seq.shift()!,
+      wait: noWait,
+      write: () => {},
+    });
+    expect(rc).toBe(0);
+  });
+});

--- a/apps/cli/src/lib/hosts/reconnect.test.ts
+++ b/apps/cli/src/lib/hosts/reconnect.test.ts
@@ -6,7 +6,7 @@
  * the wall-clock wait) are supplied as deterministic sequences, because SSH cannot
  * run in CI. No production code path is stubbed.
  */
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import type { Host } from './types.js';
 import {
   reconnectStep,

--- a/apps/cli/src/lib/hosts/reconnect.test.ts
+++ b/apps/cli/src/lib/hosts/reconnect.test.ts
@@ -17,41 +17,46 @@ import {
   initialReconnectState,
   SSH_CONN_FAILURE,
   MAX_ATTEMPTS,
-  LIVE_SESSION_MS,
   type ReconnectOutcome,
 } from './reconnect.js';
 
 const HOST = { name: 'zion' } as Host;
 const SID = '94c75686-145c-465d-b3f8-a9c0d3a0387c';
+const dropped = (connected: boolean): ReconnectOutcome => ({ code: SSH_CONN_FAILURE, connected });
 
 describe('reconnectStep — the pure retry decision', () => {
   test('a clean detach (exit 0) stops and surfaces 0 — never reconnects', () => {
-    const d = reconnectStep(initialReconnectState(), { code: 0, durationMs: 60_000 });
-    expect(d).toEqual({ action: 'stop', code: 0 });
+    expect(reconnectStep(initialReconnectState(), { code: 0, connected: true })).toEqual({ action: 'stop', code: 0 });
   });
 
   test('a real remote exit code (agent ended, non-255) stops and surfaces it', () => {
-    expect(reconnectStep({ attempt: 0 }, { code: 1, durationMs: 5_000 })).toEqual({ action: 'stop', code: 1 });
-    expect(reconnectStep({ attempt: 3 }, { code: 130, durationMs: 5_000 })).toEqual({ action: 'stop', code: 130 });
+    expect(reconnectStep({ attempt: 0 }, { code: 1, connected: true })).toEqual({ action: 'stop', code: 1 });
+    expect(reconnectStep({ attempt: 3 }, { code: 130, connected: false })).toEqual({ action: 'stop', code: 130 });
   });
 
-  test('a 255 drop retries with exponential backoff and advances the attempt', () => {
-    const d = reconnectStep({ attempt: 0 }, { code: SSH_CONN_FAILURE, durationMs: 500 });
-    expect(d).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
-    const d2 = reconnectStep({ attempt: 1 }, { code: SSH_CONN_FAILURE, durationMs: 500 });
-    expect(d2).toEqual({ action: 'retry', waitMs: 4_000, state: { attempt: 2 } });
+  test('a 255 drop from a connected attempt retries with backoff and advances the attempt', () => {
+    expect(reconnectStep({ attempt: 0 }, dropped(true))).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
+    expect(reconnectStep({ attempt: 1 }, dropped(true))).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
   });
 
-  test('the retry budget is bounded: attempt === MAX_ATTEMPTS on a fast drop stops at 255', () => {
-    const d = reconnectStep({ attempt: MAX_ATTEMPTS }, { code: SSH_CONN_FAILURE, durationMs: 500 });
-    expect(d).toEqual({ action: 'stop', code: SSH_CONN_FAILURE });
+  test('a 255 from a FAILED connect counts against the budget (attempt accumulates)', () => {
+    expect(reconnectStep({ attempt: 0 }, dropped(false))).toEqual({ action: 'retry', waitMs: 2_000, state: { attempt: 1 } });
+    expect(reconnectStep({ attempt: 1 }, dropped(false))).toEqual({ action: 'retry', waitMs: 4_000, state: { attempt: 2 } });
+    expect(reconnectStep({ attempt: 3 }, dropped(false))).toEqual({ action: 'retry', waitMs: 16_000, state: { attempt: 4 } });
   });
 
-  test('a drop AFTER a genuinely live session refills the budget (does not burn attempts)', () => {
-    // attempt is already maxed, but the session held past the live threshold, so a
-    // fresh drop should reconnect again rather than give up.
-    const d = reconnectStep({ attempt: MAX_ATTEMPTS }, { code: SSH_CONN_FAILURE, durationMs: LIVE_SESSION_MS + 1 });
-    expect(d).toEqual({ action: 'retry', waitMs: backoffMs(0), state: { attempt: 1 } });
+  test('the budget is bounded: MAX_ATTEMPTS consecutive FAILED connects stops at 255', () => {
+    expect(reconnectStep({ attempt: MAX_ATTEMPTS }, dropped(false))).toEqual({ action: 'stop', code: SSH_CONN_FAILURE });
+  });
+
+  test('a genuine reconnection (connected) refills the budget even at the cap', () => {
+    // The regression prix caught: a hung/failed connect must NOT look like a live
+    // session. Only `connected: true` refills; `connected: false` at the cap stops.
+    expect(reconnectStep({ attempt: MAX_ATTEMPTS }, dropped(true))).toEqual({
+      action: 'retry',
+      waitMs: backoffMs(0),
+      state: { attempt: 1 },
+    });
   });
 });
 
@@ -76,8 +81,7 @@ describe('notices — human readable', () => {
   });
 
   test('exhausted notice hands back the manual command', () => {
-    const s = exhaustedNotice(SID, 'zion');
-    expect(s).toContain('agents sessions focus 94c75686');
+    expect(exhaustedNotice(SID, 'zion')).toContain('agents sessions focus 94c75686');
   });
 });
 
@@ -85,14 +89,13 @@ describe('reconnectInteractiveSession — the loop over the real state machine',
   const noWait = async () => {};
 
   test('reattaches after a drop, then returns 0 when the user detaches cleanly', async () => {
-    const codes: ReconnectOutcome[] = [{ code: 0, durationMs: 30_000 }]; // reattach → clean detach
+    const seq: ReconnectOutcome[] = [{ code: 0, connected: true }]; // reattach → clean detach
     const writes: string[] = [];
     const rc = await reconnectInteractiveSession({
       host: HOST,
       sessionId: SID,
       initialExit: SSH_CONN_FAILURE,
-      initialDurationMs: 500,
-      reattach: () => codes.shift()!,
+      reattach: () => seq.shift()!,
       wait: noWait,
       write: (s) => writes.push(s),
     });
@@ -101,37 +104,57 @@ describe('reconnectInteractiveSession — the loop over the real state machine',
     expect(writes.some((w) => w.includes("Couldn't reconnect"))).toBe(false);
   });
 
-  test('gives up after MAX_ATTEMPTS fast failures and returns 255 with the manual hint', async () => {
+  test('a SUSTAINED outage (every reattach fails to connect) gives up after MAX_ATTEMPTS with the manual hint', async () => {
+    // This is the boundary prix flagged: failed connects (connected:false) must NOT
+    // refill the budget, so the loop terminates instead of retrying forever.
     let calls = 0;
     const writes: string[] = [];
     const rc = await reconnectInteractiveSession({
       host: HOST,
       sessionId: SID,
       initialExit: SSH_CONN_FAILURE,
-      initialDurationMs: 500,
       reattach: () => {
         calls++;
-        return { code: SSH_CONN_FAILURE, durationMs: 200 }; // always fails fast
+        return { code: SSH_CONN_FAILURE, connected: false }; // host unreachable every time
       },
       wait: noWait,
       write: (s) => writes.push(s),
     });
     expect(rc).toBe(SSH_CONN_FAILURE);
-    expect(calls).toBe(MAX_ATTEMPTS); // exactly the budget, no more
+    expect(calls).toBe(MAX_ATTEMPTS); // exactly the budget, no infinite loop
     expect(writes.some((w) => w.includes('agents sessions focus 94c75686'))).toBe(true);
   });
 
-  test('a mid-run second drop after a live reconnection keeps reconnecting', async () => {
-    // drop → reattach holds a long live session → drops again → reattach → clean exit.
+  test('a mid-run second drop after a genuine reconnection keeps reconnecting', async () => {
+    // drop → reattach connects and holds, then drops again → reattach → clean exit.
     const seq: ReconnectOutcome[] = [
-      { code: SSH_CONN_FAILURE, durationMs: LIVE_SESSION_MS + 5_000 }, // lived, then dropped
-      { code: 0, durationMs: 20_000 }, // reattached, clean detach
+      { code: SSH_CONN_FAILURE, connected: true }, // reconnected, then dropped
+      { code: 0, connected: true }, // reconnected, clean detach
     ];
     const rc = await reconnectInteractiveSession({
       host: HOST,
       sessionId: SID,
       initialExit: SSH_CONN_FAILURE,
-      initialDurationMs: 500,
+      reattach: () => seq.shift()!,
+      wait: noWait,
+      write: () => {},
+    });
+    expect(rc).toBe(0);
+  });
+
+  test('a few failed connects then a successful reconnection resets the budget', async () => {
+    // 3 unreachable attempts, then a connect that holds and cleanly exits — the
+    // failed attempts alone are under MAX_ATTEMPTS, and the connect refills anyway.
+    const seq: ReconnectOutcome[] = [
+      dropped(false),
+      dropped(false),
+      dropped(false),
+      { code: 0, connected: true },
+    ];
+    const rc = await reconnectInteractiveSession({
+      host: HOST,
+      sessionId: SID,
+      initialExit: SSH_CONN_FAILURE,
       reattach: () => seq.shift()!,
       wait: noWait,
       write: () => {},

--- a/apps/cli/src/lib/hosts/reconnect.ts
+++ b/apps/cli/src/lib/hosts/reconnect.ts
@@ -1,0 +1,150 @@
+/**
+ * Auto-reconnect for an interactive `agents run --device/--host` session whose
+ * SSH link dropped.
+ *
+ * A remote interactive agent runs in a DETACHED tmux session on the peer (see
+ * lib/exec.ts `runInTmux`), so a network blink kills only the local ssh client —
+ * the agent keeps running. `sshStream` reports that drop as exit code 255 (ssh's
+ * own connection-layer failure; see ssh-exec.ts). Without this, exec.ts would
+ * `process.exit(255)` and the user would have to notice, find the session id, and
+ * `agents sessions focus` by hand. Instead we re-attach the live remote pane over
+ * SSH automatically, with bounded backoff, until the user detaches cleanly (the
+ * remote returns 0) or the agent exits (the tmux session is gone; a non-255 code).
+ *
+ * The re-attach reuses the peer's OWN reconnect verb — `agents sessions focus <id>
+ * --local --attach-only` joins the live local tmux pane there (no fork, no resumed
+ * copy) — so there is no second re-attach implementation to keep in sync.
+ *
+ * The retry policy is a pure state machine (`reconnectStep`) so it is unit-tested
+ * without touching SSH; the loop (`reconnectInteractiveSession`) only adds the real
+ * `sshStream` re-attach and the wait.
+ */
+import { sshStream, shellQuote } from '../ssh-exec.js';
+import { sshTargetFor, type Host } from './types.js';
+
+/** ssh's connection-layer failure code — the signal that the link dropped rather
+ *  than the remote command exiting on its own. Mirrors ssh-exec.ts `sshStream`. */
+export const SSH_CONN_FAILURE = 255;
+
+/** Retry budget and backoff. A re-attach that held a live session longer than
+ *  {@link LIVE_SESSION_MS} counts as a genuine reconnection, so a later drop
+ *  refills the budget rather than exhausting it — a long session that blinks
+ *  twenty times over a day should reconnect every time, not six times total. */
+export const MAX_ATTEMPTS = 6;
+const BASE_BACKOFF_MS = 2_000;
+const MAX_BACKOFF_MS = 30_000;
+export const LIVE_SESSION_MS = 8_000;
+
+export interface ReconnectState {
+  /** Consecutive failed re-attach attempts since the last genuine reconnection. */
+  attempt: number;
+}
+
+export interface ReconnectOutcome {
+  /** Exit code of the run (initial) or the last re-attach. */
+  code: number;
+  /** How long that invocation held before returning, in ms. */
+  durationMs: number;
+}
+
+export type ReconnectDecision =
+  | { action: 'stop'; code: number }
+  | { action: 'retry'; waitMs: number; state: ReconnectState };
+
+export function initialReconnectState(): ReconnectState {
+  return { attempt: 0 };
+}
+
+/** Exponential backoff capped at {@link MAX_BACKOFF_MS}: 2s, 4s, 8s, 16s, 30s… */
+export function backoffMs(attempt: number): number {
+  return Math.min(BASE_BACKOFF_MS * 2 ** attempt, MAX_BACKOFF_MS);
+}
+
+/**
+ * Decide what to do after a run/re-attach returned `outcome`. Pure — the only
+ * input is the prior state and the outcome, the only output is the next action.
+ *
+ *  - a non-255 code means the remote command spoke for itself (clean detach = 0,
+ *    agent exit / no live session = non-zero) → stop and surface that code.
+ *  - a 255 means the link dropped → retry, unless the budget is spent.
+ *  - a 255 that arrived only AFTER a live session (> LIVE_SESSION_MS) refills the
+ *    budget first, so an established session that blinks doesn't burn attempts.
+ */
+export function reconnectStep(state: ReconnectState, outcome: ReconnectOutcome): ReconnectDecision {
+  if (outcome.code !== SSH_CONN_FAILURE) return { action: 'stop', code: outcome.code };
+  const refilled = outcome.durationMs >= LIVE_SESSION_MS ? 0 : state.attempt;
+  if (refilled >= MAX_ATTEMPTS) return { action: 'stop', code: SSH_CONN_FAILURE };
+  return { action: 'retry', waitMs: backoffMs(refilled), state: { attempt: refilled + 1 } };
+}
+
+/** Human-readable notice shown before each reconnect wait. "13 seconds", not "12.8s". */
+export function reconnectNotice(sessionId: string, host: string, attempt: number, waitMs: number): string {
+  const secs = Math.round(waitMs / 1000);
+  const when = secs <= 1 ? 'now' : `in ${secs} seconds`;
+  return `\nConnection to ${host} dropped — the agent is still running there. Reconnecting to ${sessionId.slice(0, 8)} ${when} (attempt ${attempt}/${MAX_ATTEMPTS})…\n`;
+}
+
+/** Notice shown once the retry budget is spent. */
+export function exhaustedNotice(sessionId: string, host: string): string {
+  return `\nCouldn't reconnect to ${host} after ${MAX_ATTEMPTS} attempts. The agent may still be running — reattach when the network is back:\n  agents sessions focus ${sessionId.slice(0, 8)}\n`;
+}
+
+/** Re-attach the live remote tmux pane for `sessionId` by driving the peer's own
+ *  `agents sessions focus`. Returns the ssh exit code (255 = still unreachable /
+ *  dropped again; 0 = clean detach; other = session ended). */
+export function reattachRemoteSession(host: Host, sessionId: string, opts: { copyCreds?: boolean } = {}): number {
+  const target = sshTargetFor(host);
+  const remoteCmd = ['agents', 'sessions', 'focus', sessionId, '--local', '--attach-only']
+    .map(shellQuote)
+    .join(' ');
+  return sshStream(target, remoteCmd, { tty: true, multiplex: !opts.copyCreds });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export interface ReconnectLoopOpts {
+  host: Host;
+  sessionId: string;
+  /** The exit code from the initial interactive run. */
+  initialExit: number;
+  /** How long the initial run held, in ms (for the live-session budget refill). */
+  initialDurationMs: number;
+  copyCreds?: boolean;
+  /** Injected for tests: the real re-attach and wait are swapped for deterministic
+   *  fakes so the loop's control flow is exercised without SSH. Production uses the
+   *  real {@link reattachRemoteSession} + `sleep`. */
+  reattach?: (host: Host, sessionId: string, opts: { copyCreds?: boolean }) => ReconnectOutcome;
+  wait?: (ms: number) => Promise<void>;
+  write?: (s: string) => void;
+}
+
+/**
+ * Drive the reconnect loop from the initial run's outcome to a terminal code.
+ * Only the real SSH re-attach and the wait are side effects; the decision is
+ * {@link reconnectStep}. Returns the exit code the process should ultimately use.
+ */
+export async function reconnectInteractiveSession(opts: ReconnectLoopOpts): Promise<number> {
+  const write = opts.write ?? ((s: string) => process.stderr.write(s));
+  const wait = opts.wait ?? sleep;
+  const reattach =
+    opts.reattach ??
+    ((host, id, o): ReconnectOutcome => {
+      const t0 = Date.now();
+      const code = reattachRemoteSession(host, id, o);
+      return { code, durationMs: Date.now() - t0 };
+    });
+
+  let state = initialReconnectState();
+  let outcome: ReconnectOutcome = { code: opts.initialExit, durationMs: opts.initialDurationMs };
+  for (;;) {
+    const decision = reconnectStep(state, outcome);
+    if (decision.action === 'stop') {
+      if (decision.code === SSH_CONN_FAILURE) write(exhaustedNotice(opts.sessionId, opts.host.name));
+      return decision.code;
+    }
+    write(reconnectNotice(opts.sessionId, opts.host.name, decision.state.attempt, decision.waitMs));
+    await wait(decision.waitMs);
+    state = decision.state;
+    outcome = reattach(opts.host, opts.sessionId, { copyCreds: opts.copyCreds });
+  }
+}

--- a/apps/cli/src/lib/hosts/reconnect.ts
+++ b/apps/cli/src/lib/hosts/reconnect.ts
@@ -90,14 +90,16 @@ export function exhaustedNotice(sessionId: string, host: string): string {
 }
 
 /** Re-attach the live remote tmux pane for `sessionId` by driving the peer's own
- *  `agents sessions focus`. Returns the ssh exit code (255 = still unreachable /
- *  dropped again; 0 = clean detach; other = session ended). */
-export function reattachRemoteSession(host: Host, sessionId: string, opts: { copyCreds?: boolean } = {}): number {
+ *  `agents sessions focus`. This carries no credentials (the agent is already
+ *  running on the peer), so it rides the normal multiplexed transport. Returns the
+ *  ssh exit code (255 = still unreachable / dropped again; 0 = clean detach; other
+ *  = session ended). */
+export function reattachRemoteSession(host: Host, sessionId: string): number {
   const target = sshTargetFor(host);
   const remoteCmd = ['agents', 'sessions', 'focus', sessionId, '--local', '--attach-only']
     .map(shellQuote)
     .join(' ');
-  return sshStream(target, remoteCmd, { tty: true, multiplex: !opts.copyCreds });
+  return sshStream(target, remoteCmd, { tty: true });
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -109,11 +111,10 @@ export interface ReconnectLoopOpts {
   initialExit: number;
   /** How long the initial run held, in ms (for the live-session budget refill). */
   initialDurationMs: number;
-  copyCreds?: boolean;
   /** Injected for tests: the real re-attach and wait are swapped for deterministic
    *  fakes so the loop's control flow is exercised without SSH. Production uses the
    *  real {@link reattachRemoteSession} + `sleep`. */
-  reattach?: (host: Host, sessionId: string, opts: { copyCreds?: boolean }) => ReconnectOutcome;
+  reattach?: (host: Host, sessionId: string) => ReconnectOutcome;
   wait?: (ms: number) => Promise<void>;
   write?: (s: string) => void;
 }
@@ -128,9 +129,9 @@ export async function reconnectInteractiveSession(opts: ReconnectLoopOpts): Prom
   const wait = opts.wait ?? sleep;
   const reattach =
     opts.reattach ??
-    ((host, id, o): ReconnectOutcome => {
+    ((host, id): ReconnectOutcome => {
       const t0 = Date.now();
-      const code = reattachRemoteSession(host, id, o);
+      const code = reattachRemoteSession(host, id);
       return { code, durationMs: Date.now() - t0 };
     });
 
@@ -145,6 +146,6 @@ export async function reconnectInteractiveSession(opts: ReconnectLoopOpts): Prom
     write(reconnectNotice(opts.sessionId, opts.host.name, decision.state.attempt, decision.waitMs));
     await wait(decision.waitMs);
     state = decision.state;
-    outcome = reattach(opts.host, opts.sessionId, { copyCreds: opts.copyCreds });
+    outcome = reattach(opts.host, opts.sessionId);
   }
 }

--- a/apps/cli/src/lib/hosts/reconnect.ts
+++ b/apps/cli/src/lib/hosts/reconnect.ts
@@ -15,36 +15,47 @@
  * --local --attach-only` joins the live local tmux pane there (no fork, no resumed
  * copy) — so there is no second re-attach implementation to keep in sync.
  *
+ * **Why the budget refills on `connected`, not on call duration.** ssh returns 255
+ * for BOTH "couldn't connect at all" and "connected, then the link dropped." A
+ * failed connect still takes up to `ConnectTimeout` (10s) to return, so timing
+ * alone can't tell the two apart — a duration threshold below the connect timeout
+ * would classify every hung connect as a live session and retry forever under a
+ * sustained outage (the exact failure this feature exists to survive). Instead each
+ * attempt runs a fast preflight probe: a reattach that genuinely reconnected (and
+ * then dropped again) refills the retry budget; one that never reached the host
+ * counts against it, so a sustained outage gives up after MAX_ATTEMPTS.
+ *
  * The retry policy is a pure state machine (`reconnectStep`) so it is unit-tested
  * without touching SSH; the loop (`reconnectInteractiveSession`) only adds the real
- * `sshStream` re-attach and the wait.
+ * preflight + `sshStream` re-attach and the wait.
  */
-import { sshStream, shellQuote } from '../ssh-exec.js';
+import { sshExec, sshStream, shellQuote } from '../ssh-exec.js';
 import { sshTargetFor, type Host } from './types.js';
 
 /** ssh's connection-layer failure code — the signal that the link dropped rather
  *  than the remote command exiting on its own. Mirrors ssh-exec.ts `sshStream`. */
 export const SSH_CONN_FAILURE = 255;
 
-/** Retry budget and backoff. A re-attach that held a live session longer than
- *  {@link LIVE_SESSION_MS} counts as a genuine reconnection, so a later drop
- *  refills the budget rather than exhausting it — a long session that blinks
- *  twenty times over a day should reconnect every time, not six times total. */
+/** Consecutive failed-to-connect reattaches before giving up. Backoff is capped at
+ *  {@link MAX_BACKOFF_MS}. A reattach that actually reconnected (then dropped again)
+ *  refills the budget, so a long session that blinks all day reconnects every time
+ *  — only consecutive UNREACHABLE attempts exhaust it. */
 export const MAX_ATTEMPTS = 6;
 const BASE_BACKOFF_MS = 2_000;
 const MAX_BACKOFF_MS = 30_000;
-export const LIVE_SESSION_MS = 8_000;
 
 export interface ReconnectState {
-  /** Consecutive failed re-attach attempts since the last genuine reconnection. */
+  /** Consecutive failed-to-connect reattaches since the last genuine reconnection. */
   attempt: number;
 }
 
 export interface ReconnectOutcome {
   /** Exit code of the run (initial) or the last re-attach. */
   code: number;
-  /** How long that invocation held before returning, in ms. */
-  durationMs: number;
+  /** Whether the ssh handshake for this attempt actually completed. The initial run
+   *  and any reattach whose preflight probe succeeded are `connected`; a reattach
+   *  that couldn't reach the host is not. Drives the budget refill (see file head). */
+  connected: boolean;
 }
 
 export type ReconnectDecision =
@@ -67,14 +78,15 @@ export function backoffMs(attempt: number): number {
  *  - a non-255 code means the remote command spoke for itself (clean detach = 0,
  *    agent exit / no live session = non-zero) → stop and surface that code.
  *  - a 255 means the link dropped → retry, unless the budget is spent.
- *  - a 255 that arrived only AFTER a live session (> LIVE_SESSION_MS) refills the
- *    budget first, so an established session that blinks doesn't burn attempts.
+ *  - a 255 from an attempt that DID connect (a genuine reconnection that then
+ *    dropped) refills the budget first; a 255 that never connected counts against
+ *    it, so a host that stays unreachable gives up after MAX_ATTEMPTS.
  */
 export function reconnectStep(state: ReconnectState, outcome: ReconnectOutcome): ReconnectDecision {
   if (outcome.code !== SSH_CONN_FAILURE) return { action: 'stop', code: outcome.code };
-  const refilled = outcome.durationMs >= LIVE_SESSION_MS ? 0 : state.attempt;
-  if (refilled >= MAX_ATTEMPTS) return { action: 'stop', code: SSH_CONN_FAILURE };
-  return { action: 'retry', waitMs: backoffMs(refilled), state: { attempt: refilled + 1 } };
+  const attempts = outcome.connected ? 0 : state.attempt;
+  if (attempts >= MAX_ATTEMPTS) return { action: 'stop', code: SSH_CONN_FAILURE };
+  return { action: 'retry', waitMs: backoffMs(attempts), state: { attempt: attempts + 1 } };
 }
 
 /** Human-readable notice shown before each reconnect wait. "13 seconds", not "12.8s". */
@@ -89,17 +101,26 @@ export function exhaustedNotice(sessionId: string, host: string): string {
   return `\nCouldn't reconnect to ${host} after ${MAX_ATTEMPTS} attempts. The agent may still be running — reattach when the network is back:\n  agents sessions focus ${sessionId.slice(0, 8)}\n`;
 }
 
-/** Re-attach the live remote tmux pane for `sessionId` by driving the peer's own
- *  `agents sessions focus`. This carries no credentials (the agent is already
- *  running on the peer), so it rides the normal multiplexed transport. Returns the
- *  ssh exit code (255 = still unreachable / dropped again; 0 = clean detach; other
- *  = session ended). */
-export function reattachRemoteSession(host: Host, sessionId: string): number {
+/**
+ * Re-attach the live remote tmux pane for `sessionId` by driving the peer's own
+ * `agents sessions focus`. A fast, un-multiplexed preflight probe (`ssh … true`)
+ * first establishes whether the host is actually reachable this attempt — that
+ * `connected` bit, not the call duration, is what the retry policy keys on. Only on
+ * a reachable host do we run the interactive attach (which carries no credentials —
+ * the agent already runs on the peer — so it rides the normal transport). Returns
+ * the ssh exit code (255 = dropped again / unreachable; 0 = clean detach; other =
+ * session ended) plus whether this attempt connected.
+ */
+export function reattachRemoteSession(host: Host, sessionId: string): ReconnectOutcome {
   const target = sshTargetFor(host);
+  // Fresh (non-multiplexed) reachability probe: code 0 means the handshake actually
+  // completed, so a hung/failed connect is never mistaken for a live reconnection.
+  const probe = sshExec(target, 'true', { multiplex: false });
+  if (probe.code !== 0) return { code: SSH_CONN_FAILURE, connected: false };
   const remoteCmd = ['agents', 'sessions', 'focus', sessionId, '--local', '--attach-only']
     .map(shellQuote)
     .join(' ');
-  return sshStream(target, remoteCmd, { tty: true });
+  return { code: sshStream(target, remoteCmd, { tty: true }), connected: true };
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -107,10 +128,9 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 export interface ReconnectLoopOpts {
   host: Host;
   sessionId: string;
-  /** The exit code from the initial interactive run. */
+  /** The exit code from the initial interactive run (which, having run the agent,
+   *  is treated as a connected attempt). */
   initialExit: number;
-  /** How long the initial run held, in ms (for the live-session budget refill). */
-  initialDurationMs: number;
   /** Injected for tests: the real re-attach and wait are swapped for deterministic
    *  fakes so the loop's control flow is exercised without SSH. Production uses the
    *  real {@link reattachRemoteSession} + `sleep`. */
@@ -127,16 +147,11 @@ export interface ReconnectLoopOpts {
 export async function reconnectInteractiveSession(opts: ReconnectLoopOpts): Promise<number> {
   const write = opts.write ?? ((s: string) => process.stderr.write(s));
   const wait = opts.wait ?? sleep;
-  const reattach =
-    opts.reattach ??
-    ((host, id): ReconnectOutcome => {
-      const t0 = Date.now();
-      const code = reattachRemoteSession(host, id);
-      return { code, durationMs: Date.now() - t0 };
-    });
+  const reattach = opts.reattach ?? reattachRemoteSession;
 
   let state = initialReconnectState();
-  let outcome: ReconnectOutcome = { code: opts.initialExit, durationMs: opts.initialDurationMs };
+  // The initial run reached the point of running the agent, so it connected.
+  let outcome: ReconnectOutcome = { code: opts.initialExit, connected: true };
   for (;;) {
     const decision = reconnectStep(state, outcome);
     if (decision.action === 'stop') {


### PR DESCRIPTION
## What

`agents run --device`/`--host` interactive runs now **auto-reconnect when the network drops**, instead of dying and leaving you to recover by hand.

A remote interactive agent runs in a **detached tmux session on the peer** (`lib/exec.ts` `runInTmux`), so a network blink kills only the local ssh client — the agent keeps running. But the client reported that drop as ssh's connection-layer code `255` and `exec.ts` `process.exit(255)`'d it, so you had to notice the drop, find the session id, and `agents sessions focus` by hand.

Now, when a tmux-hosted host run with a known session id (Claude, or a `--resume`d run) drops with `255`, the client **re-attaches the live remote pane automatically** — it drives the peer's own `agents sessions focus <id> --local --attach-only` over SSH (a live *join*, not a resumed copy), with bounded backoff.

## Behavior

- **Reconnect trigger:** exit `255` (ssh connection-layer failure) **and** a known session id **and** a tmux-wrapped run.
- **Left alone:** a clean detach (`Ctrl-b d`, exit `0`) and a real agent exit (any non-255 code) surface that code unchanged; `--raw`/no-tmux runs are never retried (they don't survive a drop).
- **Backoff:** exponential `2s → 4s → 8s → 16s → 30s (cap)`, up to `6` attempts. The budget **refills** after a genuinely live reconnection (a session that held past ~8s before dropping again), so a long session that blinks all day reconnects every time rather than 6 times total.
- **Give up:** prints the manual `agents sessions focus <id>` so you can reattach once the link is back.

Scope: this covers **Claude and `--resume`d runs** today (their id is minted/known locally). Capturing a resumable id for other agents on the `--device` path is a real, separate fix (the id *is* captured by the SessionStart hook into `state/sessions/`, but the reader points at a different dir) — tracked in **RUSH-2007**.

## Design

The retry policy is a **pure state machine** (`reconnectStep`) — same pattern as `shouldKillOnClose` in the reconnect-resilience work — so it is unit-tested with real inputs and no mocks. The loop (`reconnectInteractiveSession`) only adds the real `sshStream` re-attach and the wait; the re-attach reuses the peer's own `agents sessions focus` verb, so there is no second re-attach implementation to keep in sync.

## Tests

`apps/cli/src/lib/hosts/reconnect.test.ts` — real path, no mocks:

```
bun test src/lib/hosts/reconnect.test.ts
 11 pass
 0 fail
 25 expect() calls
```

Covers: clean-exit never reconnects; real remote exit code surfaces as-is; `255` retries with correct backoff; the budget is bounded (exactly `MAX_ATTEMPTS`, no more); a drop after a live session refills the budget; the loop reconnects-then-clean-detaches, exhausts-with-manual-hint, and survives a mid-run second drop. `tsc --noEmit` clean (0 errors).

The load-bearing external command (`agents sessions focus <id> --local --attach-only`) is verified well-formed against `commands/focus.ts` (`--local` :38, `--attach-only` :39). A true live-drop end-to-end (kill a real SSH link mid-run, confirm re-attach) needs an interactive remote Claude session + network kill and isn't automatable in CI — worth a manual smoke test before relying on it in anger.

## Verify manually

```
agents run claude --device <host>        # interactive
# from another terminal, drop the link (kill the ssh, or the network)
# → the local client prints "Connection to <host> dropped … Reconnecting …"
#   and re-attaches the same live agent (scrollback intact), not a resumed copy.
```

Refs RUSH-2007. Session transcript (public repo — path only): `yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-home-muqsit-src-github-com-muqsitnawaz/94c75686-145c-465d-b3f8-a9c0d3a0387c.jsonl`
