### PR TITLE
feat(actor): per-human git credit via actor provenance (P1) [RUSH-2017]

### DIFF
--- a/apps/cli/.changelog/next/actor-provenance.md
+++ b/apps/cli/.changelog/next/actor-provenance.md
@@ -1,0 +1,20 @@
+- **Actor provenance — agent git commits are now credited to the human who
+  started the run, not the shared account.** One account across a shared fleet
+  meant every commit, from anyone who SSH'd into a box, showed up as the same
+  author. `resolveActor()` now identifies who is behind a run: over SSH it
+  `tailscale whois`es the client IP to the connecting tailnet identity (name +
+  login email); locally it stays honest with `UNRESOLVED@<host>` and claims no
+  identity. The resolved actor rides the agent's process env as `AGENTS_ACTOR` /
+  `AGENTS_ACTOR_KIND` (inherited by the whole spawn tree, so it resolves once),
+  and for a resolved human it also injects `GIT_AUTHOR_*` / `GIT_COMMITTER_*` — so
+  the agent's own `git commit` is attributed to the person. An unresolved actor
+  injects no git identity, so local runs keep their ambient git config unchanged.
+  Source: `apps/cli/src/lib/actor.ts`, wired into `buildExecEnv`
+  (`apps/cli/src/lib/exec.ts`).
+
+- **New optional `actors:` map in `agents.yaml`.** Keyed by a short slug, each
+  entry (`kind` / `name` / `email` / `github` / `login`) enriches or overrides
+  what `tailscale whois` resolves — pin a preferred git email, add a GitHub
+  handle, override the display name, or mark an entry as an agent rather than a
+  human. Entirely optional: a tailnet SSH identity already resolves without it.
+  Source: `apps/cli/src/lib/types.ts` (`ActorConfig`, `Meta.actors`).

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -36,6 +36,37 @@ So "was this agent started on the host by a remote user?" is answerable for any
 event, not just runs. The write is a synchronous single-line append (durable
 before the action proceeds); `AGENTS_DISABLE_EVENT_LOG=1` turns it off.
 
+### Actor provenance — which *human* is behind a run
+
+`osUser` answers "which OS account", but on a shared fleet that is one account for
+everyone. The **actor** layer ([`src/lib/actor.ts`](../src/lib/actor.ts)) answers
+"which *person*". `resolveActor()` runs once per process:
+
+- **Over SSH** it `tailscale whois`es the client IP to the connecting tailnet
+  identity — a real name and login email.
+- **Locally** (no `$SSH_CONNECTION`) it stays honest: `UNRESOLVED@<host>`, claiming
+  no personal identity rather than guessing the box owner.
+- **Inherited** — a child spawn trusts the `AGENTS_ACTOR*` env its parent stamped
+  instead of re-resolving, so the whole spawn tree shares one actor.
+
+The resolved actor rides the agent's process env (`AGENTS_ACTOR`,
+`AGENTS_ACTOR_KIND`, and `AGENTS_ACTOR_NAME`/`_EMAIL`/`_GITHUB` when known). For a
+resolved **human**, that env also carries `GIT_AUTHOR_*` / `GIT_COMMITTER_*`, so the
+agent's own `git commit` is credited to the person, not the shared account. An
+unresolved actor injects no git identity — local runs keep their ambient git config.
+
+The optional `actors:` map in `agents.yaml` enriches or overrides a resolved
+identity, keyed by a short slug:
+
+```yaml
+actors:
+  bisma:
+    login: bisma@example.com   # tailnet login to match (defaults to the key)
+    name: Bisma Ansari
+    email: bisma@company.com    # pin a preferred git email
+    github: bisma
+```
+
 ```bash
 agents events                          # recent activity across everything
 agents events --module teams           # team lifecycle (create / add / disband)

--- a/apps/cli/src/lib/actor.test.ts
+++ b/apps/cli/src/lib/actor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeActor, actorEnv, type ResolvedActor } from './actor.js';
+import { computeActor, actorEnv, actorFromIdentity, type ResolvedActor } from './actor.js';
 
 describe('computeActor', () => {
   it('inherits an actor an ancestor stamped into the env, without re-resolving', () => {
@@ -39,6 +39,61 @@ describe('computeActor', () => {
   it('does not shell out when SSH_CONNECTION is malformed (no client ip)', () => {
     const actor = computeActor({ SSH_CONNECTION: 'garbage' });
     expect(actor.id).toMatch(/^UNRESOLVED@/);
+  });
+});
+
+describe('actorFromIdentity (the SSH-resolved enrich/override path)', () => {
+  const whoMuqsit = { login: 'muqsitnawaz@gmail.com', displayName: 'Muqsit' };
+
+  it('credits git straight from the tailnet identity when there is no actors entry', () => {
+    expect(actorFromIdentity(whoMuqsit, 'yosemite-s1', {})).toEqual<ResolvedActor>({
+      id: 'muqsitnawaz@gmail.com',
+      kind: 'human',
+      name: 'Muqsit',
+      email: 'muqsitnawaz@gmail.com',
+      github: undefined,
+    });
+  });
+
+  it('enriches + overrides from an actors entry matched by map key', () => {
+    const actors = {
+      'muqsitnawaz@gmail.com': { name: 'Muqsit Nawaz', email: 'muqsit@company.com', github: 'muqsitnawaz' },
+    };
+    const actor = actorFromIdentity(whoMuqsit, 'h', actors);
+    expect(actor.name).toBe('Muqsit Nawaz');       // overrides DisplayName
+    expect(actor.email).toBe('muqsit@company.com'); // overrides the login email
+    expect(actor.github).toBe('muqsitnawaz');
+    expect(actor.id).toBe('muqsitnawaz@gmail.com'); // id stays the tailnet login
+  });
+
+  it('matches an entry by its explicit login field, case-insensitively', () => {
+    const actors = { bisma: { login: 'BISMA@EXAMPLE.COM', name: 'Bisma', email: 'bisma@example.com' } };
+    const actor = actorFromIdentity({ login: 'bisma@example.com' }, 'h', actors);
+    expect(actor.name).toBe('Bisma');
+    expect(actor.email).toBe('bisma@example.com');
+  });
+
+  it('matches an entry by its email field', () => {
+    const actors = { b: { email: 'bisma@example.com', github: 'bee' } };
+    const actor = actorFromIdentity({ login: 'bisma@example.com' }, 'h', actors);
+    expect(actor.github).toBe('bee');
+  });
+
+  it('honors a kind: agent override (so an agent identity gets no personal git credit)', () => {
+    const actors = { scout: { login: 'scout@bots', kind: 'agent' as const, name: 'Scout', email: 'scout@bots' } };
+    const actor = actorFromIdentity({ login: 'scout@bots' }, 'h', actors);
+    expect(actor.kind).toBe('agent');
+    expect(actorEnv(actor).GIT_AUTHOR_NAME).toBeUndefined();
+  });
+
+  it('leaves email undefined for a non-email login with no config (no git credit)', () => {
+    const actor = actorFromIdentity({ login: 'plainuser', displayName: 'Plain' }, 'h', {});
+    expect(actor.email).toBeUndefined();
+    expect(actorEnv(actor).GIT_AUTHOR_EMAIL).toBeUndefined();
+  });
+
+  it('falls back to UNRESOLVED@<host> when whois names no one', () => {
+    expect(actorFromIdentity(undefined, 'zion', {})).toEqual<ResolvedActor>({ id: 'UNRESOLVED@zion', kind: 'human' });
   });
 });
 

--- a/apps/cli/src/lib/actor.test.ts
+++ b/apps/cli/src/lib/actor.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { computeActor, actorEnv, type ResolvedActor } from './actor.js';
+
+describe('computeActor', () => {
+  it('inherits an actor an ancestor stamped into the env, without re-resolving', () => {
+    const env: NodeJS.ProcessEnv = {
+      AGENTS_ACTOR: 'bisma@example.com',
+      AGENTS_ACTOR_KIND: 'human',
+      AGENTS_ACTOR_NAME: 'Bisma',
+      AGENTS_ACTOR_EMAIL: 'bisma@example.com',
+      AGENTS_ACTOR_GITHUB: 'bisma',
+      // An SSH_CONNECTION is present but must be ignored: inheritance wins so the
+      // whole spawn tree shares one actor and we never shell out again.
+      SSH_CONNECTION: '100.64.0.9 51000 100.64.0.1 22',
+    };
+    expect(computeActor(env)).toEqual<ResolvedActor>({
+      id: 'bisma@example.com',
+      kind: 'human',
+      name: 'Bisma',
+      email: 'bisma@example.com',
+      github: 'bisma',
+    });
+  });
+
+  it('inherits kind=agent verbatim', () => {
+    const actor = computeActor({ AGENTS_ACTOR: 'scout', AGENTS_ACTOR_KIND: 'agent' });
+    expect(actor.id).toBe('scout');
+    expect(actor.kind).toBe('agent');
+  });
+
+  it('falls back to UNRESOLVED@<host> for a local (non-SSH) run', () => {
+    const actor = computeActor({});
+    expect(actor.id).toMatch(/^UNRESOLVED@/);
+    expect(actor.kind).toBe('human');
+    expect(actor.email).toBeUndefined();
+    expect(actor.name).toBeUndefined();
+  });
+
+  it('does not shell out when SSH_CONNECTION is malformed (no client ip)', () => {
+    const actor = computeActor({ SSH_CONNECTION: 'garbage' });
+    expect(actor.id).toMatch(/^UNRESOLVED@/);
+  });
+});
+
+describe('actorEnv', () => {
+  it('credits git for a resolved human with a real name + email', () => {
+    const env = actorEnv({
+      id: 'muqsitnawaz@gmail.com',
+      kind: 'human',
+      name: 'Muqsit',
+      email: 'muqsitnawaz@gmail.com',
+    });
+    expect(env.AGENTS_ACTOR).toBe('muqsitnawaz@gmail.com');
+    expect(env.AGENTS_ACTOR_KIND).toBe('human');
+    expect(env.GIT_AUTHOR_NAME).toBe('Muqsit');
+    expect(env.GIT_AUTHOR_EMAIL).toBe('muqsitnawaz@gmail.com');
+    expect(env.GIT_COMMITTER_NAME).toBe('Muqsit');
+    expect(env.GIT_COMMITTER_EMAIL).toBe('muqsitnawaz@gmail.com');
+  });
+
+  it('claims no git identity for an unresolved actor (keeps ambient git config)', () => {
+    const env = actorEnv({ id: 'UNRESOLVED@zion', kind: 'human' });
+    expect(env.AGENTS_ACTOR).toBe('UNRESOLVED@zion');
+    expect(env.AGENTS_ACTOR_KIND).toBe('human');
+    expect(env.GIT_AUTHOR_NAME).toBeUndefined();
+    expect(env.GIT_AUTHOR_EMAIL).toBeUndefined();
+    expect(env.GIT_COMMITTER_NAME).toBeUndefined();
+    expect(env.GIT_COMMITTER_EMAIL).toBeUndefined();
+  });
+
+  it('does not give a non-human actor personal git credit', () => {
+    const env = actorEnv({ id: 'scout', kind: 'agent', name: 'Scout', email: 'scout@bot' });
+    expect(env.AGENTS_ACTOR_KIND).toBe('agent');
+    expect(env.GIT_AUTHOR_NAME).toBeUndefined();
+    expect(env.GIT_AUTHOR_EMAIL).toBeUndefined();
+  });
+
+  it('round-trips through the env: actorEnv output re-inherits to the same actor', () => {
+    const actor: ResolvedActor = {
+      id: 'bisma@example.com',
+      kind: 'human',
+      name: 'Bisma',
+      email: 'bisma@example.com',
+      github: 'bisma',
+    };
+    expect(computeActor(actorEnv(actor))).toEqual(actor);
+  });
+});

--- a/apps/cli/src/lib/actor.ts
+++ b/apps/cli/src/lib/actor.ts
@@ -44,22 +44,30 @@ export interface ResolvedActor {
 }
 
 /** Result of `tailscale whois --json <ip>` we care about. */
-interface WhoisIdentity {
+export interface WhoisIdentity {
   login?: string;
   displayName?: string;
 }
 
+/** Hard cap on the whois shell-out — it runs on the spawn hot path. */
+const WHOIS_TIMEOUT_MS = 2000;
+
 /**
  * Resolve the tailnet identity behind an IP via `tailscale whois`. Returns
- * undefined when tailscale is absent, the peer is unknown, or the call fails --
- * every one of those falls back to an unresolved actor, never an error.
+ * undefined when tailscale is absent, the peer is unknown, the call fails, or it
+ * exceeds WHOIS_TIMEOUT_MS -- every one of those falls back to an unresolved
+ * actor, never an error and never a hang (a wedged tailscaled is timed out, not
+ * waited on, since this sits in buildExecEnv on every agent spawn).
  */
 function tailscaleWhois(ip: string): WhoisIdentity | undefined {
   try {
     const res = spawnSync('tailscale', ['whois', '--json', ip], {
       encoding: 'utf-8',
       windowsHide: true,
+      timeout: WHOIS_TIMEOUT_MS,
     });
+    // A timeout leaves status null (child killed by SIGTERM) -- the status guard
+    // below treats it as an unresolved actor, same as any other failure.
     if (res.status !== 0 || !res.stdout) return undefined;
     const data = JSON.parse(res.stdout) as { UserProfile?: { LoginName?: string; DisplayName?: string } };
     const up = data.UserProfile;
@@ -83,14 +91,40 @@ function readActors(): Record<string, ActorConfig> {
  * Find the actors-map entry for a resolved tailnet login. Matches on an entry's
  * explicit `login`, its map key, or its `email` (all case-insensitive).
  */
-function findActorConfig(login: string): ActorConfig | undefined {
+function findActorConfig(login: string, actors: Record<string, ActorConfig>): ActorConfig | undefined {
   const needle = login.toLowerCase();
-  const actors = readActors();
   for (const [key, cfg] of Object.entries(actors)) {
     const candidates = [cfg.login, key, cfg.email].filter((v): v is string => !!v);
     if (candidates.some((c) => c.toLowerCase() === needle)) return cfg;
   }
   return undefined;
+}
+
+/**
+ * Map a resolved tailnet identity (+ the actors map) to a ResolvedActor. Pure --
+ * the impure whois/config reads happen in computeActor -- so the enrich/override
+ * path is fully testable. No login (local, or an unnameable peer) yields the
+ * honest `UNRESOLVED@<host>`; a login without a config entry still credits git
+ * from the tailnet DisplayName + login email.
+ */
+export function actorFromIdentity(
+  who: WhoisIdentity | undefined,
+  host: string,
+  actors: Record<string, ActorConfig>,
+): ResolvedActor {
+  const login = who?.login;
+  if (!login) {
+    return { id: `UNRESOLVED@${host}`, kind: 'human' };
+  }
+  const cfg = findActorConfig(login, actors);
+  const emailFromLogin = login.includes('@') ? login : undefined;
+  return {
+    id: login,
+    kind: cfg?.kind ?? 'human',
+    name: cfg?.name ?? who?.displayName,
+    email: cfg?.email ?? emailFromLogin,
+    github: cfg?.github,
+  };
 }
 
 /** Reconstruct an actor an ancestor process already resolved into the env. */
@@ -115,25 +149,9 @@ export function computeActor(env: NodeJS.ProcessEnv = process.env): ResolvedActo
   const inherited = inheritedActor(env);
   if (inherited) return inherited;
 
-  const host = machineId();
   const ssh = env.SSH_CONNECTION ? parseSshConnection(env.SSH_CONNECTION) : undefined;
   const who = ssh?.clientIp ? tailscaleWhois(ssh.clientIp) : undefined;
-
-  const login = who?.login;
-  if (!login) {
-    // Local, or an SSH peer tailscale can't name -- honest over convenient.
-    return { id: `UNRESOLVED@${host}`, kind: 'human' };
-  }
-
-  const cfg = findActorConfig(login);
-  const emailFromLogin = login.includes('@') ? login : undefined;
-  return {
-    id: login,
-    kind: cfg?.kind ?? 'human',
-    name: cfg?.name ?? who?.displayName,
-    email: cfg?.email ?? emailFromLogin,
-    github: cfg?.github,
-  };
+  return actorFromIdentity(who, machineId(), readActors());
 }
 
 let cached: ResolvedActor | undefined;

--- a/apps/cli/src/lib/actor.ts
+++ b/apps/cli/src/lib/actor.ts
@@ -1,0 +1,178 @@
+/**
+ * Actor provenance -- who initiated a run.
+ *
+ * One shared account means every session, commit, and event otherwise shows up
+ * as the same person. `resolveActor()` answers "which human is behind this run"
+ * by looking at how the process was reached:
+ *
+ *   - Over SSH (the shared-fleet case): `tailscale whois` the SSH client IP to
+ *     the connecting tailnet identity -- a real name + login email.
+ *   - Locally (non-SSH): we can't honestly say who is at the box, so the id is
+ *     `UNRESOLVED@<host>` and no personal git identity is claimed.
+ *   - Inherited: a child spawn trusts the `AGENTS_ACTOR*` env its parent
+ *     stamped rather than re-resolving, so the whole spawn tree shares one actor.
+ *
+ * The resolved actor rides the child-process env (`actorEnv()`, merged into
+ * `buildExecEnv`). When the actor is a resolved human, that env also carries
+ * `GIT_AUTHOR_*` / `GIT_COMMITTER_*`, so the agent's own `git commit` is credited
+ * to the person instead of the shared account.
+ *
+ * The optional `actors:` map in agents.yaml enriches or overrides a resolved
+ * identity (pin a work email, add a github handle, mark an entry as an agent).
+ */
+import { spawnSync } from 'child_process';
+import { machineId } from './machine-id.js';
+import { parseSshConnection } from './session/provenance.js';
+import { readMeta } from './state.js';
+import type { ActorConfig } from './types.js';
+
+export type ActorKind = 'human' | 'agent';
+
+export interface ResolvedActor {
+  /**
+   * Stable id for the responsible entity: the tailnet login (usually an email)
+   * for a resolved human, or `UNRESOLVED@<host>` when it can't be determined.
+   */
+  id: string;
+  kind: ActorKind;
+  /** Human-readable name, for git author + display. */
+  name?: string;
+  /** Email, for git author + as a durable key. */
+  email?: string;
+  /** GitHub handle, when the actors map records one. */
+  github?: string;
+}
+
+/** Result of `tailscale whois --json <ip>` we care about. */
+interface WhoisIdentity {
+  login?: string;
+  displayName?: string;
+}
+
+/**
+ * Resolve the tailnet identity behind an IP via `tailscale whois`. Returns
+ * undefined when tailscale is absent, the peer is unknown, or the call fails --
+ * every one of those falls back to an unresolved actor, never an error.
+ */
+function tailscaleWhois(ip: string): WhoisIdentity | undefined {
+  try {
+    const res = spawnSync('tailscale', ['whois', '--json', ip], {
+      encoding: 'utf-8',
+      windowsHide: true,
+    });
+    if (res.status !== 0 || !res.stdout) return undefined;
+    const data = JSON.parse(res.stdout) as { UserProfile?: { LoginName?: string; DisplayName?: string } };
+    const up = data.UserProfile;
+    if (!up) return undefined;
+    return { login: up.LoginName, displayName: up.DisplayName };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the actors map from config, tolerant of a missing/unreadable config. */
+function readActors(): Record<string, ActorConfig> {
+  try {
+    return readMeta().actors ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Find the actors-map entry for a resolved tailnet login. Matches on an entry's
+ * explicit `login`, its map key, or its `email` (all case-insensitive).
+ */
+function findActorConfig(login: string): ActorConfig | undefined {
+  const needle = login.toLowerCase();
+  const actors = readActors();
+  for (const [key, cfg] of Object.entries(actors)) {
+    const candidates = [cfg.login, key, cfg.email].filter((v): v is string => !!v);
+    if (candidates.some((c) => c.toLowerCase() === needle)) return cfg;
+  }
+  return undefined;
+}
+
+/** Reconstruct an actor an ancestor process already resolved into the env. */
+function inheritedActor(env: NodeJS.ProcessEnv): ResolvedActor | undefined {
+  const id = env.AGENTS_ACTOR;
+  if (!id) return undefined;
+  return {
+    id,
+    kind: env.AGENTS_ACTOR_KIND === 'agent' ? 'agent' : 'human',
+    name: env.AGENTS_ACTOR_NAME || undefined,
+    email: env.AGENTS_ACTOR_EMAIL || undefined,
+    github: env.AGENTS_ACTOR_GITHUB || undefined,
+  };
+}
+
+/**
+ * Compute the actor for a given environment. Pure with respect to `env` (the
+ * only impurity is the `tailscale whois` / config read on the fresh-SSH path),
+ * so tests can drive every branch by passing an env explicitly.
+ */
+export function computeActor(env: NodeJS.ProcessEnv = process.env): ResolvedActor {
+  const inherited = inheritedActor(env);
+  if (inherited) return inherited;
+
+  const host = machineId();
+  const ssh = env.SSH_CONNECTION ? parseSshConnection(env.SSH_CONNECTION) : undefined;
+  const who = ssh?.clientIp ? tailscaleWhois(ssh.clientIp) : undefined;
+
+  const login = who?.login;
+  if (!login) {
+    // Local, or an SSH peer tailscale can't name -- honest over convenient.
+    return { id: `UNRESOLVED@${host}`, kind: 'human' };
+  }
+
+  const cfg = findActorConfig(login);
+  const emailFromLogin = login.includes('@') ? login : undefined;
+  return {
+    id: login,
+    kind: cfg?.kind ?? 'human',
+    name: cfg?.name ?? who?.displayName,
+    email: cfg?.email ?? emailFromLogin,
+    github: cfg?.github,
+  };
+}
+
+let cached: ResolvedActor | undefined;
+
+/**
+ * Resolve the actor for the current process, cached for the process lifetime
+ * (the SSH `whois` shell-out runs at most once).
+ */
+export function resolveActor(): ResolvedActor {
+  if (!cached) cached = computeActor(process.env);
+  return cached;
+}
+
+/** Clear the per-process cache. For tests, and for env changes within a run. */
+export function resetActorCache(): void {
+  cached = undefined;
+}
+
+/**
+ * The env an actor propagates to child processes. Always carries the actor id +
+ * kind (so children inherit and don't re-resolve). For a resolved human with a
+ * real name and email, it also carries `GIT_AUTHOR_*` / `GIT_COMMITTER_*` so the
+ * agent's own commits are credited to the person, not the shared account. An
+ * unresolved actor sets no git identity -- git keeps its ambient config.
+ */
+export function actorEnv(actor: ResolvedActor): Record<string, string> {
+  const env: Record<string, string> = {
+    AGENTS_ACTOR: actor.id,
+    AGENTS_ACTOR_KIND: actor.kind,
+  };
+  if (actor.name) env.AGENTS_ACTOR_NAME = actor.name;
+  if (actor.email) env.AGENTS_ACTOR_EMAIL = actor.email;
+  if (actor.github) env.AGENTS_ACTOR_GITHUB = actor.github;
+
+  if (actor.kind === 'human' && actor.name && actor.email) {
+    env.GIT_AUTHOR_NAME = actor.name;
+    env.GIT_AUTHOR_EMAIL = actor.email;
+    env.GIT_COMMITTER_NAME = actor.name;
+    env.GIT_COMMITTER_EMAIL = actor.email;
+  }
+  return env;
+}

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -445,8 +445,8 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
 
   // Actor provenance -- who initiated this run. Rides the env so the whole spawn
   // tree shares one actor, and (for a resolved human) so the agent's own git
-  // commits are credited to the person instead of the shared account. A caller
-  // that pins an actor via options.env still wins (spread last).
+  // commits are credited to the person instead of the shared account. options.env
+  // (spread last) overrides any of these keys a caller sets explicitly.
   Object.assign(result, actorEnv(resolveActor()));
 
   return {

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -16,6 +16,7 @@ import { getBinaryPath, getVersionHomePath, isVersionInstalled, resolveVersion }
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { emitStart, maybeRotate, createTimer, redactPrompt, redactArgs } from './events.js';
 import { sanitizeProcessEnv } from './secrets/bundles.js';
+import { resolveActor, actorEnv } from './actor.js';
 import { getShimsDir, getHistoryDir } from './state.js';
 import { resolveCodexHome } from './codex-home.js';
 import { readCodexConfiguredModel } from './shims.js';
@@ -441,6 +442,12 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
   if (options.name) {
     result.AGENT_SESSION_NAME = options.name;
   }
+
+  // Actor provenance -- who initiated this run. Rides the env so the whole spawn
+  // tree shares one actor, and (for a resolved human) so the agent's own git
+  // commits are credited to the person instead of the shared account. A caller
+  // that pins an actor via options.env still wins (spread last).
+  Object.assign(result, actorEnv(resolveActor()));
 
   return {
     ...result,

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -753,6 +753,27 @@ export interface BrandConfig {
   enabled: boolean;
 }
 
+/**
+ * An actor -- a responsible entity behind a run (a human today, a top-level
+ * agent later). Keyed in the `actors:` map by a short slug. Every field is
+ * optional enrichment over what `tailscale whois` already resolves: pin a
+ * preferred git email, add a github handle, or override the display name.
+ * `login` is the tailnet login-name to match against (defaults to the map key).
+ * See lib/actor.ts.
+ */
+export interface ActorConfig {
+  /** 'human' (default) or 'agent'. Only humans get personal git credit. */
+  kind?: 'human' | 'agent';
+  /** Display + git author name. Overrides the tailnet DisplayName. */
+  name?: string;
+  /** Git author email. Overrides the tailnet login email. */
+  email?: string;
+  /** GitHub handle, for PR attribution. */
+  github?: string;
+  /** Tailnet login-name this entry matches. Defaults to the map key. */
+  login?: string;
+}
+
 /** Top-level structure of ~/.agents/.system/agents.yaml -- the CLI's persistent state. */
 export interface Meta {
   agents?: Partial<Record<AgentId, string>>;
@@ -830,6 +851,12 @@ export interface Meta {
    * commands + curated resource profile. See lib/brand.ts.
    */
   brands?: Record<string, BrandConfig>;
+  /**
+   * Actors keyed by slug -- who is behind a run. Enriches or overrides the
+   * identity `tailscale whois` resolves (git email, github handle, display
+   * name, human vs agent). See lib/actor.ts.
+   */
+  actors?: Record<string, ActorConfig>;
   /**
    * Removal tombstones for SEEDED_REGISTRIES presets, keyed like `skill.hermes`.
    *


### PR DESCRIPTION
## What

Phase 1 of the actor-provenance layer (parent RUSH-2016). Resolves **who initiated a run** so an agent's git commits are credited to the human behind them instead of the one shared fleet account.

- **`apps/cli/src/lib/actor.ts` (new)** — `resolveActor()`:
  - **Over SSH** → `tailscale whois` the client IP → connecting tailnet identity (name + login email).
  - **Local** (no `$SSH_CONNECTION`) → `UNRESOLVED@<host>`; claims no identity rather than guessing.
  - **Inherited** → trusts the parent's `AGENTS_ACTOR*` env, so a spawn tree resolves once and shares one actor.
  - `actorEnv()` emits `AGENTS_ACTOR`/`AGENTS_ACTOR_KIND` (+ name/email/github), and for a resolved **human** also `GIT_AUTHOR_*`/`GIT_COMMITTER_*`.
- **`exec.ts`** — `buildExecEnv` merges `actorEnv(resolveActor())` into every agent's process env (a caller's `options.env` still wins).
- **`types.ts`** — optional `actors:` map (`ActorConfig`) on `Meta` to enrich/override a resolved identity (pin a work email, add a github handle, mark an entry as an agent). Auto-persists via `readMeta`/`writeMeta`; no schema layer to touch.
- Docs (`docs/06-observability.md`) + changelog queue entry.

## Why

One account across the shared fleet means every commit — from anyone who SSH'd into a box — is authored by the same identity. This gives per-human git credit with zero per-user sandboxing. An unresolved (local) actor injects **no** git identity, so local runs keep their ambient git config unchanged — no regression.

## Verified end-to-end

Against **real** `tailscale whois` on the tailnet, then a real commit:

```
### SSH from a real tailnet client
actor: {"id":"muqsitnawaz@gmail.com","kind":"human","name":"Muqsit","email":"muqsitnawaz@gmail.com"}
env  : {"AGENTS_ACTOR":"muqsitnawaz@gmail.com","AGENTS_ACTOR_KIND":"human",...,
        "GIT_AUTHOR_NAME":"Muqsit","GIT_AUTHOR_EMAIL":"muqsitnawaz@gmail.com","GIT_COMMITTER_*":...}

### local (no SSH)
actor: {"id":"UNRESOLVED@yosemite-s1","kind":"human"}
env  : {"AGENTS_ACTOR":"UNRESOLVED@yosemite-s1","AGENTS_ACTOR_KIND":"human"}   # no GIT_*

### git honors the injected env (overrides even an explicit -c user.email)
$ GIT_AUTHOR_NAME=Muqsit GIT_AUTHOR_EMAIL=muqsitnawaz@gmail.com git -c user.name=shared-account -c user.email=shared@account commit ...
author=Muqsit <muqsitnawaz@gmail.com>  committer=Muqsit <muqsitnawaz@gmail.com>
```

## Tests

- `actor.test.ts` — 8/8 pass (env inheritance, local fallback, malformed SSH, git-credit gating for human/agent/unresolved, env round-trip). No mocks.
- `tsc --noEmit` clean for the changed files.
- Full `exec.test.ts` / `__tests__/exec.test.ts` pass in a clean env; the 3 remaining `--model gpt-5.5` failures are pre-existing `buildExecCommand` test debt on `main`, untouched by this diff (which only adds an env-injection line + a config interface).

## Follow-ups (filed)

RUSH-2018 visibility (owner in `--active`), RUSH-2019 lineage (parent session id + durable sidecar), RUSH-2020 surfaces (events/routines/browser). This PR is P1 and ships independently.
