### PR TITLE
fix(sessions): resolve a complete session id by id only, never by content

### DIFF
--- a/apps/cli/.changelog/next/sessions-complete-id-lookup.md
+++ b/apps/cli/.changelog/next/sessions-complete-id-lookup.md
@@ -1,0 +1,14 @@
+- **`agents sessions <full-session-id>` no longer answers with an unrelated
+  session.** A complete id that was not in the local index fell through to the
+  FTS content search, which tokenizes the UUID and matches every transcript that
+  merely *mentions* it. The miss surfaced as up to ten unrelated sessions under
+  `Multiple sessions match "<id>"` plus the advice `Pass a longer ID to narrow it
+  down` — impossible to follow, since a full id is already the longest form. The
+  same fallthrough made `--preview` render a different session's transcript, and
+  an 8-char short id could lose to a content hit. A query that is a whole session
+  id (a 36-char UUID, optionally carrying a `session_` / `ses_` / `api-` prefix)
+  now resolves by id alone: it reports `No session with id <id> on this machine.`
+  and points at `--device <host>` for the fleet. Short-id prefixes and text
+  searches are unchanged. Source: `apps/cli/src/lib/session/discover.ts`
+  (`isCompleteSessionId`) and `apps/cli/src/commands/sessions.ts`
+  (`resolveSessionQuery`).

--- a/apps/cli/.changelog/next/sessions-complete-id-lookup.md
+++ b/apps/cli/.changelog/next/sessions-complete-id-lookup.md
@@ -4,11 +4,16 @@
   merely *mentions* it. The miss surfaced as up to ten unrelated sessions under
   `Multiple sessions match "<id>"` plus the advice `Pass a longer ID to narrow it
   down` — impossible to follow, since a full id is already the longest form. The
-  same fallthrough made `--preview` render a different session's transcript, and
-  an 8-char short id could lose to a content hit. A query that is a whole session
-  id (a 36-char UUID, optionally carrying a `session_` / `ses_` / `api-` prefix)
-  now resolves by id alone: it reports `No session with id <id> on this machine.`
-  and points at `--device <host>` for the fleet. Short-id prefixes and text
-  searches are unchanged. Source: `apps/cli/src/lib/session/discover.ts`
-  (`isCompleteSessionId`) and `apps/cli/src/commands/sessions.ts`
-  (`resolveSessionQuery`).
+  same fallthrough made `--preview` render a different session's transcript, let
+  an 8-char short id lose to a content hit, and made `agents sessions export
+  <id>` bundle every transcript that mentions the id (14 unrelated sessions
+  written into an archive meant to be handed to someone else). A query that is a
+  whole session id now resolves by id alone: it reports `No session with id <id>
+  on this machine.` and points at `--device <host>` for the fleet. Short-id
+  prefixes and text searches are unchanged. The recognized shapes are the ones
+  the index actually holds — a bare UUID, `session_` + UUID (kimi, rush), and
+  `ses_` + 26-char ULID (opencode); routine run ids and cloud execution ids stay
+  out of scope and keep today's search behavior. Source:
+  `apps/cli/src/lib/session/discover.ts` (`isCompleteSessionId`),
+  `apps/cli/src/commands/sessions.ts` (`resolveSessionQuery`), and
+  `apps/cli/src/commands/sessions-export.ts` (`selectSessions`).

--- a/apps/cli/src/commands/__tests__/sessions.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions.test.ts
@@ -1003,17 +1003,24 @@ describe('resolveSessionQuery id-vs-search resolution', () => {
     expect(r.completeId).toBe(true);
   });
 
+  // Synthetic ids, so these assert the resolver and never the developer's own
+  // session index (a complete id that MISSES the pool now also consults the DB,
+  // so a real id here would resolve from disk and make the test machine-specific).
   it('resolves a session_-prefixed complete id by id, not by content', () => {
-    const prefixed = 'session_933f4131-f3ed-495d-946b-71825e9f6a25';
+    const prefixed = 'session_00000000-0000-4000-8000-000000000001';
     const mentions = meta({ id: 'aaaa1111-2222-4333-8444-555566667777', topic: `see ${prefixed}` });
-    expect(resolveSessionQuery([mentions], prefixed).matches).toEqual([]);
+    const r = resolveSessionQuery([mentions], prefixed);
+    expect(r.completeId).toBe(true);
+    expect(r.matches.map(s => s.id)).not.toContain(mentions.id);
     const real = meta({ id: prefixed, topic: 'kimi run' });
     expect(resolveSessionQuery([mentions, real], prefixed).matches.map(s => s.id)).toEqual([prefixed]);
   });
 
   it('resolves a ses_ ULID complete id by id, not by content', () => {
-    const ses = 'ses_0485d75c1ffewpzVfoI0ni6hW1';
+    const ses = 'ses_00000000000000000000000001';
     const mentions = meta({ id: 'bbbb1111-2222-4333-8444-555566667777', topic: `see ${ses}` });
-    expect(resolveSessionQuery([mentions], ses).matches).toEqual([]);
+    const r = resolveSessionQuery([mentions], ses);
+    expect(r.completeId).toBe(true);
+    expect(r.matches.map(s => s.id)).not.toContain(mentions.id);
   });
 });

--- a/apps/cli/src/commands/__tests__/sessions.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions.test.ts
@@ -992,4 +992,28 @@ describe('resolveSessionQuery id-vs-search resolution', () => {
     expect(r.byId).toBe(false);
     expect(r.completeId).toBe(false);
   });
+
+  // isCompleteSessionId trims but resolveSessionById does not, so without a
+  // single normalization point a pasted, padded id classified as complete and
+  // then missed the lookup — reporting a session that IS here as absent.
+  it('resolves a padded id instead of declaring it missing', () => {
+    const real = meta({ id: wanted, topic: 'Improve session display' });
+    const r = resolveSessionQuery([decoy, real], `  ${wanted} `);
+    expect(r.matches.map(s => s.id)).toEqual([wanted]);
+    expect(r.completeId).toBe(true);
+  });
+
+  it('resolves a session_-prefixed complete id by id, not by content', () => {
+    const prefixed = 'session_933f4131-f3ed-495d-946b-71825e9f6a25';
+    const mentions = meta({ id: 'aaaa1111-2222-4333-8444-555566667777', topic: `see ${prefixed}` });
+    expect(resolveSessionQuery([mentions], prefixed).matches).toEqual([]);
+    const real = meta({ id: prefixed, topic: 'kimi run' });
+    expect(resolveSessionQuery([mentions, real], prefixed).matches.map(s => s.id)).toEqual([prefixed]);
+  });
+
+  it('resolves a ses_ ULID complete id by id, not by content', () => {
+    const ses = 'ses_0485d75c1ffewpzVfoI0ni6hW1';
+    const mentions = meta({ id: 'bbbb1111-2222-4333-8444-555566667777', topic: `see ${ses}` });
+    expect(resolveSessionQuery([mentions], ses).matches).toEqual([]);
+  });
 });

--- a/apps/cli/src/commands/__tests__/sessions.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions.test.ts
@@ -6,7 +6,7 @@ import * as crypto from 'crypto';
 import { spawnSync } from 'child_process';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
-import { buildResumeCommand, resumeSpawnInvocation } from '../sessions.js';
+import { buildResumeCommand, resumeSpawnInvocation, resolveSessionQuery } from '../sessions.js';
 import { needsWindowsShell, composeWin32CommandLine } from '../../lib/platform/index.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
@@ -942,5 +942,54 @@ describe('buildResumeCommand version-pinned resume', () => {
       expect(inv.command).toBe(composeWin32CommandLine(cmd[0], cmd.slice(1)));
       expect(inv.command).toContain(`"${evilId}"`);
     }
+  });
+});
+
+describe('resolveSessionQuery id-vs-search resolution', () => {
+  const meta = (over: Partial<SessionMeta> & { id: string }): SessionMeta => ({
+    shortId: over.id.slice(0, 8),
+    agent: 'claude',
+    timestamp: '2026-08-01T12:00:00.000Z',
+    filePath: '/fake/path.jsonl',
+    ...over,
+  });
+
+  // The session the user actually asked for is absent from the pool (it lives on
+  // another machine); the pool holds an unrelated session whose topic merely
+  // quotes that id — the exact shape that made `sessions <uuid>` render the wrong
+  // transcript and advise "Pass a longer ID" for an already-complete id.
+  const wanted = 'd3470b57-2af6-4c11-b1de-3fab94f43603';
+  const decoy = meta({
+    id: 'ffa1f432-1a9e-4a81-8e93-e70aa8df1c95',
+    topic: `Resume previous work: ${wanted}`,
+  });
+
+  it('does not answer a complete id with a session that merely mentions it', () => {
+    const r = resolveSessionQuery([decoy], wanted);
+    expect(r.matches).toEqual([]);
+    expect(r.completeId).toBe(true);
+    expect(r.byId).toBe(true);
+  });
+
+  it('still resolves a complete id that is genuinely present', () => {
+    const real = meta({ id: wanted, topic: 'Improve session display' });
+    const r = resolveSessionQuery([decoy, real], wanted);
+    expect(r.matches.map(s => s.id)).toEqual([wanted]);
+    expect(r.byId).toBe(true);
+  });
+
+  it('keeps short-id prefix lookup working', () => {
+    const real = meta({ id: wanted, topic: 'Improve session display' });
+    const r = resolveSessionQuery([real], 'd3470b57');
+    expect(r.matches.map(s => s.id)).toEqual([wanted]);
+    expect(r.byId).toBe(true);
+    expect(r.completeId).toBe(false);
+  });
+
+  it('still falls through to text search for a real search phrase', () => {
+    const r = resolveSessionQuery([decoy], 'Resume previous');
+    expect(r.matches.map(s => s.id)).toEqual([decoy.id]);
+    expect(r.byId).toBe(false);
+    expect(r.completeId).toBe(false);
   });
 });

--- a/apps/cli/src/commands/sessions-export.ts
+++ b/apps/cli/src/commands/sessions-export.ts
@@ -23,6 +23,7 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import type { SessionMeta } from '../lib/session/types.js';
 import { discoverSessions, resolveSessionById, isCompleteSessionId } from '../lib/session/discover.js';
+import { findSessionsById } from '../lib/session/db.js';
 import { filterSessionsByQuery, parseAgentFilter } from './sessions.js';
 import { listLocalTranscripts, SYNC_AGENTS, type LocalTranscript } from '../lib/session/sync/agents.js';
 import { machineId } from '../lib/machine-id.js';
@@ -254,9 +255,13 @@ function selectSessions(metas: SessionMeta[], selectors: string[]): SessionMeta[
   const byId: SessionMeta[] = [];
   const unmatched: string[] = [];
   for (const sel of selectors) {
-    const hits = resolveSessionById(metas, sel.trim());
-    if (hits.length > 0) byId.push(...hits);
-    else unmatched.push(sel);
+    const trimmed = sel.trim();
+    // Same reason as resolveSessionQuery: the discovered pool is a minority of
+    // the index, so a complete id absent from it may still be indexed here.
+    const hits = resolveSessionById(metas, trimmed);
+    const resolved = hits.length > 0 || !isCompleteSessionId(trimmed) ? hits : findSessionsById(trimmed);
+    if (resolved.length > 0) byId.push(...resolved);
+    else unmatched.push(trimmed);
   }
   if (byId.length > 0 && unmatched.length === 0) {
     const seen = new Set<string>();

--- a/apps/cli/src/commands/sessions-export.ts
+++ b/apps/cli/src/commands/sessions-export.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import type { SessionMeta } from '../lib/session/types.js';
-import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
+import { discoverSessions, resolveSessionById, isCompleteSessionId } from '../lib/session/discover.js';
 import { filterSessionsByQuery, parseAgentFilter } from './sessions.js';
 import { listLocalTranscripts, SYNC_AGENTS, type LocalTranscript } from '../lib/session/sync/agents.js';
 import { machineId } from '../lib/machine-id.js';
@@ -254,13 +254,22 @@ function selectSessions(metas: SessionMeta[], selectors: string[]): SessionMeta[
   const byId: SessionMeta[] = [];
   const unmatched: string[] = [];
   for (const sel of selectors) {
-    const hits = resolveSessionById(metas, sel);
+    const hits = resolveSessionById(metas, sel.trim());
     if (hits.length > 0) byId.push(...hits);
     else unmatched.push(sel);
   }
   if (byId.length > 0 && unmatched.length === 0) {
     const seen = new Set<string>();
     return byId.filter(s => (seen.has(s.id) ? false : (seen.add(s.id), true)));
+  }
+  // A selector that is a COMPLETE session id and still missed cannot be widened:
+  // the id is unique, so the text query below could only bundle sessions that
+  // merely mention it. Bundling those would ship unrelated transcripts to
+  // whoever receives the export, so select nothing and let the caller report it.
+  const missingIds = unmatched.filter(isCompleteSessionId);
+  if (missingIds.length > 0) {
+    process.stderr.write(chalk.red(`No session with id ${missingIds.join(', ')} on this machine.\n`));
+    return [];
   }
   // Any selector that isn't an id → treat the whole thing as a text query.
   return filterSessionsByQuery(metas, selectors.join(' '));

--- a/apps/cli/src/commands/sessions-resolve-db.test.ts
+++ b/apps/cli/src/commands/sessions-resolve-db.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `resolveSessionQuery` must answer a complete session id from the INDEX, not
+ * only from the pool it was handed.
+ *
+ * The discovered pool is a minority of the index — it re-walks live agent homes
+ * and skips whole classes of indexed session (measured on a real index: 2,798 of
+ * 7,614 rows, leaving 1,315 sessions whose transcript is on disk invisible to
+ * it). An earlier revision declared a complete id absent whenever the pool
+ * missed, which turned those into a confident "No session with id X on this
+ * machine" plus a pointer to go look on another host.
+ *
+ * These drive the real DB (isolated under a temp HOME, no mocks) with an EMPTY
+ * pool, which is exactly the case the pool-only lookup got wrong.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate the sessions DB under a temp HOME before db.js/state.js capture the
+// path at import time.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-resolve-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { upsertSession } = await import('../lib/session/db.js');
+const { resolveSessionQuery } = await import('./sessions.js');
+type SessionMeta = import('../lib/session/types.js').SessionMeta;
+
+// querySessions (behind findSessionsById) drops rows whose transcript is gone,
+// which is what keeps "on this machine" truthful — so the fixture writes a real
+// file rather than pointing at a path that does not exist.
+function meta(id: string, extra: Partial<SessionMeta> = {}): SessionMeta {
+  const filePath = path.join(TEST_HOME, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  return {
+    id,
+    shortId: id.slice(0, 8),
+    agent: 'claude',
+    timestamp: new Date().toISOString(),
+    filePath,
+    ...extra,
+  };
+}
+
+describe('resolveSessionQuery falls back to the index for a complete id', () => {
+  const indexed = 'a7c1d88d-b543-48c1-993d-dd5cd8e210c9';
+
+  it('finds an indexed session the discovered pool never returned', () => {
+    upsertSession(meta(indexed, { topic: 'old but present' }), '');
+    const r = resolveSessionQuery([], indexed);
+    expect(r.matches.map(s => s.id)).toEqual([indexed]);
+    expect(r.completeId).toBe(true);
+    expect(r.byId).toBe(true);
+  });
+
+  it('finds a session_-prefixed id from a non-discovered agent', () => {
+    const rushId = 'session_001fa16e-9f97-453d-b0f0-5c35317bcd04';
+    upsertSession(meta(rushId, { agent: 'rush', topic: 'competitive watch' }), '');
+    expect(resolveSessionQuery([], rushId).matches.map(s => s.id)).toEqual([rushId]);
+  });
+
+  it('still reports a genuinely absent id as no match', () => {
+    const absent = '2feeb449-5c73-4f1c-9163-8459e7aafeea';
+    const r = resolveSessionQuery([], absent);
+    expect(r.matches).toEqual([]);
+    expect(r.completeId).toBe(true);
+  });
+
+  it('does not consult the index for a search phrase', () => {
+    // A phrase must keep the ranked text path; reaching for an id lookup here
+    // would resurrect the id/content confusion this whole change removes.
+    const r = resolveSessionQuery([], 'old but present');
+    expect(r.completeId).toBe(false);
+    expect(r.byId).toBe(false);
+  });
+});

--- a/apps/cli/src/commands/sessions-resolve-db.test.ts
+++ b/apps/cli/src/commands/sessions-resolve-db.test.ts
@@ -12,7 +12,7 @@
  * These drive the real DB (isolated under a temp HOME, no mocks) with an EMPTY
  * pool, which is exactly the case the pool-only lookup got wrong.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -42,6 +42,8 @@ function meta(id: string, extra: Partial<SessionMeta> = {}): SessionMeta {
     ...extra,
   };
 }
+
+afterAll(() => fs.rmSync(TEST_HOME, { recursive: true, force: true }));
 
 describe('resolveSessionQuery falls back to the index for a complete id', () => {
   const indexed = 'a7c1d88d-b543-48c1-993d-dd5cd8e210c9';

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -31,6 +31,7 @@ import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { inferSessionState } from '../lib/session/state.js';
 import { discoverSessions, countSessionsInScope, resolveSessionById, isCompleteSessionId, searchContentIndex, parseTimeFilter, getSessionRoots, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
+import { findSessionsById } from '../lib/session/db.js';
 import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
 import { runRemoteSessions, buildForwardedArgs, ensureWholeIndex } from '../lib/session/remote.js';
@@ -2341,8 +2342,15 @@ export function resolveSessionQuery(pool: SessionMeta[], query: string): Session
   const normalized = query.trim();
   const completeId = isCompleteSessionId(normalized);
   const byIdMatches = resolveSessionById(pool, normalized);
-  if (byIdMatches.length > 0 || completeId) {
-    return { matches: byIdMatches, byId: true, completeId };
+  if (byIdMatches.length > 0) return { matches: byIdMatches, byId: true, completeId };
+
+  if (completeId) {
+    // The pool is only what discoverSessions walked — a minority of the index
+    // (measured: 2,798 of 7,614 rows), because it re-reads live agent homes and
+    // skips whole classes of indexed session. Declaring absence from the pool
+    // alone denied 1,315 sessions whose transcript is on this disk right now.
+    // Ask the index itself, the same authoritative lookup `fork` and `exec` use.
+    return { matches: findSessionsById(normalized), byId: true, completeId };
   }
   return { matches: filterSessionsByQuery(pool, normalized), byId: false, completeId };
 }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -989,12 +989,10 @@ async function renderSessionPreview(
   const { matches, completeId } = resolveSessionQuery(pool, query);
   const session = matches[0];
   if (!session) {
-    // A complete id that missed is not "no match for this text" — say which.
-    console.log(
-      completeId
-        ? chalk.gray(`No session with id ${query} on this machine.`)
-        : chalk.gray(`No session matches "${query}".`),
-    );
+    // A complete id that missed is not "no match for this text" — say which, and
+    // give the same fleet pointer the render paths give.
+    if (completeId) notFoundByIdMessage(query).forEach(l => console.log(l));
+    else console.log(chalk.gray(`No session matches "${query}".`));
     return;
   }
   console.log(buildPreview(session));
@@ -1357,8 +1355,14 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   }
 }
 
+/** Whether a query should route to the single-session render rather than the
+ * listing. The hex-ish test catches a bare id prefix; `isCompleteSessionId`
+ * additionally catches the prefixed whole ids (`session_…`, `ses_…`) that the
+ * hex test rejects — without it those never reach the id-only resolution and
+ * still content-search. */
 function looksLikeSessionId(query: string): boolean {
-  return /^[0-9a-f-]{6,}$/i.test(query.trim());
+  const trimmed = query.trim();
+  return /^[0-9a-f-]{6,}$/i.test(trimmed) || isCompleteSessionId(trimmed);
 }
 
 function teamTag(session: SessionMeta): string {
@@ -2330,26 +2334,35 @@ export interface SessionQueryResolution {
  * metadata+content search.
  */
 export function resolveSessionQuery(pool: SessionMeta[], query: string): SessionQueryResolution {
-  const completeId = isCompleteSessionId(query);
-  const byIdMatches = resolveSessionById(pool, query);
+  // Normalize ONCE here. isCompleteSessionId trims but resolveSessionById does
+  // not, so a padded id ("<uuid> ", e.g. pasted from a terminal) would classify
+  // as complete and then miss the id lookup — reporting a session that IS on
+  // this machine as absent.
+  const normalized = query.trim();
+  const completeId = isCompleteSessionId(normalized);
+  const byIdMatches = resolveSessionById(pool, normalized);
   if (byIdMatches.length > 0 || completeId) {
     return { matches: byIdMatches, byId: true, completeId };
   }
-  return { matches: filterSessionsByQuery(pool, query), byId: false, completeId };
+  return { matches: filterSessionsByQuery(pool, normalized), byId: false, completeId };
 }
 
-/** Explain an ambiguous resolution: a short id can be lengthened, a search phrase cannot. */
-function ambiguityHint(byId: boolean): string {
+/** Explain an ambiguous resolution. Only a short id can be lengthened: a complete
+ * id is already maximal, and a search phrase was never an id to begin with. */
+function ambiguityHint(byId: boolean, completeId: boolean): string {
+  if (completeId) return 'That is already a complete id — these rows share it as a prefix.';
   return byId
     ? 'Pass a longer ID to narrow it down.'
     : 'That matched on text, not an id. Pass a session id, or narrow the search.';
 }
 
-/** Explain a complete-id miss, which no local rephrasing can fix. */
+/** Explain a complete-id miss, which no local rephrasing can fix. Echoes the
+ * normalized id so a pasted, padded argument doesn't produce an unrunnable hint. */
 function notFoundByIdMessage(query: string): string[] {
+  const id = query.trim();
   return [
-    chalk.red(`No session with id ${query} on this machine.`),
-    chalk.gray(`Search the fleet with: agents sessions ${query} --device <host>`),
+    chalk.red(`No session with id ${id} on this machine.`),
+    chalk.gray(`Search the fleet with: agents sessions ${id} --device <host>`),
   ];
 }
 
@@ -2509,7 +2522,7 @@ async function renderArtifactsGlobal(
       for (const m of queryMatches.slice(0, 10)) {
         console.error(chalk.cyan(`  ${m.shortId}  ${m.id}  ${(m as any).label ?? m.topic ?? ''}`));
       }
-      console.error(chalk.gray(ambiguityHint(byId)));
+      console.error(chalk.gray(ambiguityHint(byId, completeId)));
       process.exit(1);
     }
 
@@ -2547,12 +2560,13 @@ async function renderOneSession(
     const resolution = resolveSessionQuery(allSessions, query);
     let queryMatches: SessionMeta[] = resolution.matches;
     let byId = resolution.byId;
+    const completeId = resolution.completeId;
 
     // Widen to the transcript content index only for a genuine search phrase. A
     // complete id is unique, so widening could only ever surface a DIFFERENT
     // session that happens to mention the id — which is what made `sessions
     // <uuid>` render an unrelated transcript.
-    if (queryMatches.length === 0 && !resolution.completeId) {
+    if (queryMatches.length === 0 && !completeId) {
       const contentResults = searchContentIndex(allSessions, query);
       if (contentResults.size > 0) {
         const matchedSessions = Array.from(contentResults.values())
@@ -2577,7 +2591,7 @@ async function renderOneSession(
           renderClaudeHistoryOnlyId(query, historyEntry, allSessions);
           process.exit(1);
         }
-      } else if (resolution.completeId) {
+      } else if (completeId) {
         notFoundByIdMessage(query).forEach(l => console.error(l));
         process.exit(1);
       } else {
@@ -2594,7 +2608,7 @@ async function renderOneSession(
         for (const match of queryMatches.slice(0, 10)) {
           console.error(chalk.cyan(`  ${match.shortId}  ${match.id}  ${(match as any).label ?? match.topic ?? ''}`));
         }
-        console.error(chalk.gray(ambiguityHint(byId)));
+        console.error(chalk.gray(ambiguityHint(byId, completeId)));
         process.exit(1);
       } else {
         session = queryMatches[0];

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -30,7 +30,7 @@ import { gatherRemoteList, runOnPeer } from '../lib/session/remote-list.js';
 import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/session/width.js';
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { inferSessionState } from '../lib/session/state.js';
-import { discoverSessions, countSessionsInScope, resolveSessionById, searchContentIndex, parseTimeFilter, getSessionRoots, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
+import { discoverSessions, countSessionsInScope, resolveSessionById, isCompleteSessionId, searchContentIndex, parseTimeFilter, getSessionRoots, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
 import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
 import { runRemoteSessions, buildForwardedArgs, ensureWholeIndex } from '../lib/session/remote.js';
@@ -986,10 +986,15 @@ async function renderSessionPreview(
 ): Promise<void> {
   const discovered = await discoverSessions({ all: true, cwd: process.cwd(), limit: 5000 });
   const pool = applyScopeFilters(discovered, scope);
-  const matches = resolveSessionById(pool, query);
-  const session = (matches.length > 0 ? matches : filterSessionsByQuery(pool, query))[0];
+  const { matches, completeId } = resolveSessionQuery(pool, query);
+  const session = matches[0];
   if (!session) {
-    console.log(chalk.gray(`No session matches "${query}".`));
+    // A complete id that missed is not "no match for this text" — say which.
+    console.log(
+      completeId
+        ? chalk.gray(`No session with id ${query} on this machine.`)
+        : chalk.gray(`No session matches "${query}".`),
+    );
     return;
   }
   console.log(buildPreview(session));
@@ -2303,6 +2308,51 @@ function formatSearchMessage(options: SessionFilterOptions): string {
   return `Search sessions (${filters.join(', ')}):`;
 }
 
+/**
+ * How a `sessions <query>` argument was resolved against the pool.
+ *
+ * `byId` records that the rows came from an id lookup, so only then does an
+ * ambiguous result mean "your id prefix is too short". `completeId` records that
+ * the query was a whole session id: it is unique by construction, so a miss is
+ * final and must NOT widen into a text/content search.
+ */
+export interface SessionQueryResolution {
+  matches: SessionMeta[];
+  byId: boolean;
+  completeId: boolean;
+}
+
+/**
+ * The single entry point for turning a `sessions <query>` argument into rows.
+ *
+ * A complete session id resolves by id alone. Anything else keeps the existing
+ * ladder: id lookup first (so a short id still wins), then the ranked
+ * metadata+content search.
+ */
+export function resolveSessionQuery(pool: SessionMeta[], query: string): SessionQueryResolution {
+  const completeId = isCompleteSessionId(query);
+  const byIdMatches = resolveSessionById(pool, query);
+  if (byIdMatches.length > 0 || completeId) {
+    return { matches: byIdMatches, byId: true, completeId };
+  }
+  return { matches: filterSessionsByQuery(pool, query), byId: false, completeId };
+}
+
+/** Explain an ambiguous resolution: a short id can be lengthened, a search phrase cannot. */
+function ambiguityHint(byId: boolean): string {
+  return byId
+    ? 'Pass a longer ID to narrow it down.'
+    : 'That matched on text, not an id. Pass a session id, or narrow the search.';
+}
+
+/** Explain a complete-id miss, which no local rephrasing can fix. */
+function notFoundByIdMessage(query: string): string[] {
+  return [
+    chalk.red(`No session with id ${query} on this machine.`),
+    chalk.gray(`Search the fleet with: agents sessions ${query} --device <host>`),
+  ];
+}
+
 /** Filter and rank sessions by a multi-term search query across metadata and content. */
 export function filterSessionsByQuery(
   sessions: SessionMeta[],
@@ -2445,12 +2495,12 @@ async function renderArtifactsGlobal(
     tracker.stop();
 
     const allSessions = applyScopeFilters(discovered, scope);
-    const matches = resolveSessionById(allSessions, query);
-    const queryMatches = matches.length > 0 ? matches : filterSessionsByQuery(allSessions, query);
+    const { matches: queryMatches, byId, completeId } = resolveSessionQuery(allSessions, query);
 
     if (queryMatches.length === 0) {
       spinner.stop();
-      console.error(chalk.red(`No session found matching: ${query}`));
+      if (completeId) notFoundByIdMessage(query).forEach(l => console.error(l));
+      else console.error(chalk.red(`No session found matching: ${query}`));
       process.exit(1);
     }
     if (queryMatches.length > 1) {
@@ -2459,7 +2509,7 @@ async function renderArtifactsGlobal(
       for (const m of queryMatches.slice(0, 10)) {
         console.error(chalk.cyan(`  ${m.shortId}  ${m.id}  ${(m as any).label ?? m.topic ?? ''}`));
       }
-      console.error(chalk.gray('Pass a longer ID to narrow it down.'));
+      console.error(chalk.gray(ambiguityHint(byId)));
       process.exit(1);
     }
 
@@ -2494,14 +2544,20 @@ async function renderOneSession(
     const allSessions = applyScopeFilters(discovered, scope);
     let session: SessionMeta | undefined;
 
-    const matches = resolveSessionById(allSessions, query);
-    let queryMatches: SessionMeta[] = matches.length > 0 ? matches : filterSessionsByQuery(allSessions, query);
+    const resolution = resolveSessionQuery(allSessions, query);
+    let queryMatches: SessionMeta[] = resolution.matches;
+    let byId = resolution.byId;
 
-    if (queryMatches.length === 0) {
+    // Widen to the transcript content index only for a genuine search phrase. A
+    // complete id is unique, so widening could only ever surface a DIFFERENT
+    // session that happens to mention the id — which is what made `sessions
+    // <uuid>` render an unrelated transcript.
+    if (queryMatches.length === 0 && !resolution.completeId) {
       const contentResults = searchContentIndex(allSessions, query);
       if (contentResults.size > 0) {
         const matchedSessions = Array.from(contentResults.values())
           .sort((a, b) => (b._bm25Score ?? 0) - (a._bm25Score ?? 0));
+        byId = false;
         if (matchedSessions.length === 1) {
           session = matchedSessions[0];
         } else {
@@ -2521,6 +2577,9 @@ async function renderOneSession(
           renderClaudeHistoryOnlyId(query, historyEntry, allSessions);
           process.exit(1);
         }
+      } else if (resolution.completeId) {
+        notFoundByIdMessage(query).forEach(l => console.error(l));
+        process.exit(1);
       } else {
         console.error(chalk.red(`No session found matching: ${query}`));
         console.error(chalk.gray('Run "agents sessions" to browse sessions.'));
@@ -2535,7 +2594,7 @@ async function renderOneSession(
         for (const match of queryMatches.slice(0, 10)) {
           console.error(chalk.cyan(`  ${match.shortId}  ${match.id}  ${(match as any).label ?? match.topic ?? ''}`));
         }
-        console.error(chalk.gray('Pass a longer ID to narrow it down.'));
+        console.error(chalk.gray(ambiguityHint(byId)));
         process.exit(1);
       } else {
         session = queryMatches[0];

--- a/apps/cli/src/lib/session/__tests__/discover.test.ts
+++ b/apps/cli/src/lib/session/__tests__/discover.test.ts
@@ -375,10 +375,29 @@ describe('isCompleteSessionId', () => {
     expect(isCompleteSessionId('019fbd2f-971a-7fb0-a213-3709a27cd12b')).toBe(true);
   });
 
-  it('accepts the vendor-prefixed forms carried in the index', () => {
+  // The prefixed shapes are the ones the index actually holds — verified against
+  // a live 12,507-row index: session_+UUID (kimi, rush) and ses_+26-char ULID
+  // (opencode). `ses_` is NOT a UUID, so it needs its own shape, and `api-`
+  // appears zero times and is deliberately not claimed.
+  it('accepts session_ + UUID, the shape kimi and rush mint', () => {
     expect(isCompleteSessionId('session_933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(true);
-    expect(isCompleteSessionId('ses_933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(true);
-    expect(isCompleteSessionId('api-933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(true);
+  });
+
+  it('accepts ses_ + 26-char ULID, the shape opencode actually mints', () => {
+    expect(isCompleteSessionId('ses_0485d75c1ffewpzVfoI0ni6hW1')).toBe(true);
+    expect(isCompleteSessionId('ses_0e508fa24ffeZe0092umrYovhg')).toBe(true);
+  });
+
+  it('rejects ses_ + UUID — a shape no harness mints', () => {
+    expect(isCompleteSessionId('ses_933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(false);
+  });
+
+  it('rejects a truncated ULID, so a ses_ prefix stays searchable', () => {
+    expect(isCompleteSessionId('ses_0485d75c')).toBe(false);
+  });
+
+  it('accepts a padded id, matching the resolver that trims before lookup', () => {
+    expect(isCompleteSessionId('  d3470b57-2af6-4c11-b1de-3fab94f43603 ')).toBe(true);
   });
 
   it('rejects a short id, a truncated id, and a search phrase', () => {

--- a/apps/cli/src/lib/session/__tests__/discover.test.ts
+++ b/apps/cli/src/lib/session/__tests__/discover.test.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import Database from '../../sqlite.js';
 import { buildFtsQuery, getDB } from '../db.js';
-import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile, discoverSessions, resolveSessionById, readGrokMeta } from '../discover.js';
+import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile, discoverSessions, resolveSessionById, isCompleteSessionId, readGrokMeta } from '../discover.js';
 import { machineId } from '../sync/config.js';
 import { getHistoryDir } from '../../state.js';
 
@@ -362,5 +362,34 @@ describe('readGrokMeta', () => {
     const fp = path.join(dir, uuid, 'summary.json');
     fs.writeFileSync(fp, '{ not valid json');
     expect(readGrokMeta(fp)).toBeNull();
+  });
+});
+
+describe('isCompleteSessionId', () => {
+  it('accepts a bare 36-char UUID, in either case', () => {
+    expect(isCompleteSessionId('d3470b57-2af6-4c11-b1de-3fab94f43603')).toBe(true);
+    expect(isCompleteSessionId('D3470B57-2AF6-4C11-B1DE-3FAB94F43603')).toBe(true);
+  });
+
+  it('accepts a v7 UUID (the shape newer harnesses mint)', () => {
+    expect(isCompleteSessionId('019fbd2f-971a-7fb0-a213-3709a27cd12b')).toBe(true);
+  });
+
+  it('accepts the vendor-prefixed forms carried in the index', () => {
+    expect(isCompleteSessionId('session_933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(true);
+    expect(isCompleteSessionId('ses_933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(true);
+    expect(isCompleteSessionId('api-933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(true);
+  });
+
+  it('rejects a short id, a truncated id, and a search phrase', () => {
+    expect(isCompleteSessionId('d3470b57')).toBe(false);
+    expect(isCompleteSessionId('d3470b57-2af6-4c11-b1de')).toBe(false);
+    expect(isCompleteSessionId('add auth middleware')).toBe(false);
+    expect(isCompleteSessionId('')).toBe(false);
+  });
+
+  it('rejects a UUID with trailing text, so a phrase quoting an id stays a search', () => {
+    expect(isCompleteSessionId('resume d3470b57-2af6-4c11-b1de-3fab94f43603')).toBe(false);
+    expect(isCompleteSessionId('d3470b57-2af6-4c11-b1de-3fab94f43603.jsonl')).toBe(false);
   });
 });

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -454,25 +454,33 @@ function normalizeCwd(cwd?: string): string {
   return safeRealpathSync(resolved) || resolved;
 }
 
-/** The optional vendor prefixes a session id can carry, mirroring the strips in
- * {@link deriveShortId}. */
-const SESSION_ID_PREFIX = /^(session_|api-|ses_)/;
 /** Canonical 8-4-4-4-12 hex UUID (covers both v4 and the v7 ids newer harnesses mint). */
 const UUID_36 = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+/** kimi and rush mint `session_` + a UUID. */
+const SESSION_UUID_PREFIX = /^session_/;
+/** opencode mints `ses_` + a 26-char ULID — NOT a UUID, so it needs its own shape. */
+const SES_ULID = /^ses_[0-9a-z]{26}$/;
 
 /**
  * Whether a query is a session id in full, rather than an id prefix or a search
- * phrase. True for a bare 36-char UUID and for one carrying a known vendor
- * prefix (`session_…`, `api-…`, `ses_…`).
+ * phrase.
  *
  * Callers use this to decide that an id lookup is the ONLY admissible
  * interpretation: a complete id is unique, so when it misses there is nothing
  * left to widen to. Without the check, `sessions <uuid>` fell through to the
  * FTS content search, which tokenizes the UUID and matches every transcript that
  * merely mentions it — surfacing unrelated sessions as if they were id matches.
+ *
+ * The accepted shapes are the ones the index actually holds, measured over a
+ * 12,507-row index: a bare UUID (11,116 rows), `session_` + UUID (1,360 — kimi
+ * and rush), and `ses_` + ULID (15 — opencode). Deliberately NOT covered, so a
+ * miss keeps today's search behavior rather than gaining a wrong error: routine
+ * run ids (ISO timestamps, matched via `routineRunId` below) and cloud execution
+ * ids, whose charset is too permissive to distinguish from a search phrase.
  */
 export function isCompleteSessionId(query: string): boolean {
-  return UUID_36.test(query.trim().toLowerCase().replace(SESSION_ID_PREFIX, ''));
+  const q = query.trim().toLowerCase();
+  return UUID_36.test(q.replace(SESSION_UUID_PREFIX, '')) || SES_ULID.test(q);
 }
 
 /**

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -454,6 +454,27 @@ function normalizeCwd(cwd?: string): string {
   return safeRealpathSync(resolved) || resolved;
 }
 
+/** The optional vendor prefixes a session id can carry, mirroring the strips in
+ * {@link deriveShortId}. */
+const SESSION_ID_PREFIX = /^(session_|api-|ses_)/;
+/** Canonical 8-4-4-4-12 hex UUID (covers both v4 and the v7 ids newer harnesses mint). */
+const UUID_36 = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Whether a query is a session id in full, rather than an id prefix or a search
+ * phrase. True for a bare 36-char UUID and for one carrying a known vendor
+ * prefix (`session_…`, `api-…`, `ses_…`).
+ *
+ * Callers use this to decide that an id lookup is the ONLY admissible
+ * interpretation: a complete id is unique, so when it misses there is nothing
+ * left to widen to. Without the check, `sessions <uuid>` fell through to the
+ * FTS content search, which tokenizes the UUID and matches every transcript that
+ * merely mentions it — surfacing unrelated sessions as if they were id matches.
+ */
+export function isCompleteSessionId(query: string): boolean {
+  return UUID_36.test(query.trim().toLowerCase().replace(SESSION_ID_PREFIX, ''));
+}
+
 /**
  * Resolve a session by full or short ID. Accepts a pre-loaded session list
  * (fast path from discoverSessions) and falls back to a DB lookup for the


### PR DESCRIPTION
## The bug

`agents sessions <full-session-id>` answers with sessions that have nothing to do
with the id.

A complete id that is not in the local index falls through to the FTS content
search. That search tokenizes the UUID, so it matches every transcript that
merely *mentions* the id. The miss is then reported as if it were an ambiguous
id prefix:

```
$ agents sessions d3470b57-2af6-4c11-b1de-3fab94f43603
Multiple sessions match "d3470b57-2af6-4c11-b1de-3fab94f43603":
  ffd7ed24  ffd7ed24-0840-49df-86fc-6806910cd029  You are a watchdog monitoring AI coding agents...
  43364bb0  43364bb0-61fd-4b4e-9268-d4fd6998b87a  You are a watchdog monitoring AI coding agents...
  ... 8 more, none containing the queried id ...
Pass a longer ID to narrow it down.
```

There is no longer id than a full UUID, so that advice cannot be followed. The
session actually existed — on another machine.

Two further consequences of the same fallthrough:

- **`--preview` renders the wrong transcript.** `renderSessionPreview` takes
  `[0]` of the content hits, so peeking at an id you can't resolve locally shows
  you a *different* session with no indication.
- **A short id can lose to a content hit.** `agents sessions d3470b57` resolved
  to session `ffa1f432` — because that session's transcript quotes the string
  `d3470b57-…`.

## The fix

`isCompleteSessionId` (`apps/cli/src/lib/session/discover.ts`) recognizes a whole
session id: a 36-char UUID, optionally carrying the `session_` / `ses_` / `api-`
prefix the index already stores. Grounded in the real index — 12,491 of 12,507
rows are exactly those shapes.

`resolveSessionQuery` (`apps/cli/src/commands/sessions.ts`) becomes the single
resolver for all three call sites (`renderSessionPreview`,
`renderArtifactsGlobal`, `renderOneSession`). A complete id resolves by id alone
and never widens; everything else keeps the existing ladder (id lookup first, so
short ids still win, then the ranked metadata+content search).

It also returns *how* it resolved, so `Pass a longer ID to narrow it down.` is
printed only when lengthening the id could actually help. A text-derived
ambiguity now says so instead.

After:

```
$ agents sessions d3470b57-2af6-4c11-b1de-3fab94f43603
No session with id d3470b57-2af6-4c11-b1de-3fab94f43603 on this machine.
Search the fleet with: agents sessions d3470b57-2af6-4c11-b1de-3fab94f43603 --device <host>

$ agents sessions d3470b57-2af6-4c11-b1de-3fab94f43603 --device yosemite-s0
Improve session display and recovery features
claude 2.1.187  <synthetic>, opus-4-8  muqsitnawaz (HEAD)  Aug 1 04:49 · muqsitnawaz@gmail.com
19 turns · 8 tools (5 errors) · 1.6M cached / 17.9K out · 7 min
```

## Verification

Built from this branch and run against the real session index (12,507 rows), not
a fixture:

| Path | Result |
|---|---|
| full UUID, absent locally | precise not-found + `--device` hint |
| same id with `--device yosemite-s0` | renders the real session |
| short id `ffa1f432` | still resolves |
| text search `"Touch ID prompts"` | still returns 5 ranked hits |

Tests exercise the real resolver, no mocking:

- `isCompleteSessionId` — bare UUID, v7 UUID, all three prefixed forms, and the
  negatives that must stay searches (short id, truncated id, phrase, a UUID with
  trailing text).
- `resolveSessionQuery` — the decoy case (a session whose topic quotes the
  wanted id must not answer for it), a genuinely present id, short-id prefix, and
  a real search phrase.

Confirmed the tests fail without the fix: neutralizing `isCompleteSessionId`
makes the decoy test return exactly the unrelated session, reproducing the bug.

`tsc --noEmit` clean.

## Notes

No docs change: nothing in `apps/cli/docs/`, the README, or `AGENTS.md`
documents the id-vs-search resolution ladder, so there is no stale text to
correct. CHANGELOG fragment added at
`apps/cli/.changelog/next/sessions-complete-id-lookup.md`.
