### PR TITLE
fix(crabbox): passive leased-boxes render never pops Touch ID

### DIFF
--- a/apps/cli/.changelog/next/crabbox-devices-list-touchid.md
+++ b/apps/cli/.changelog/next/crabbox-devices-list-touchid.md
@@ -1,0 +1,11 @@
+- **No more Touch ID storm from `agents devices list`.** On macOS, the leased-boxes
+  section of `agents devices list` resolved crabbox's lease and tailscale secret
+  bundles through `crabboxEnv`, which picked broker-only mode from
+  `isHeadlessSecretsContext()`. That auto-detect is false in a terminal, so the
+  resolve was allowed to prompt — and because every keychain read spawns its own
+  helper process, the Touch ID assertion is never reused and each bundle popped its
+  own sheet. Any SessionStart hook that shells out to `agents devices` (the bundled
+  device-topology hook does) therefore paid several biometric prompts on every new
+  agent terminal. The listing path now forces `agentOnly`, so a warm bundle still
+  renders, a cold one drops the section instead of grabbing the sensor, and an
+  interactive `agents run --lease` keeps its one legitimate prompt.

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -271,7 +271,15 @@ function loadLeasedBoxesSection(): string[] {
       agentOnly: true,
     });
     return renderLeasedBoxesSection(boxes, Math.floor(Date.now() / 1000));
-  } catch {
+  } catch (e) {
+    // A locked bundle is the one failure with a fix the user can act on, and
+    // agentOnly above makes it the normal cold-broker outcome — say so instead of
+    // silently dropping the section. Everything else (crabbox absent, no provider
+    // creds) is genuinely not actionable here.
+    const msg = (e as Error).message ?? '';
+    if (msg.includes('not unlocked in the secrets agent')) {
+      return [chalk.gray('  leased boxes hidden — run `agents secrets unlock <bundle>` to show them')];
+    }
     return []; // crabbox not installed / no provider creds — omit the section
   }
 }
@@ -286,7 +294,14 @@ function loadLeasedBoxesSection(): string[] {
 function trySshLeasedBox(name: string, cmd: string[]): boolean {
   let box: CrabboxBox | null;
   try {
-    box = crabboxFind(name, { secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE, timeoutMs: 5000 });
+    // agentOnly: this runs for ANY unrecognized `agents ssh <name>` — including a
+    // typo'd device name — so discovery must never pop Touch ID. The connect below
+    // keeps the auto-detect: by then the box is confirmed and the user meant it.
+    box = crabboxFind(name, {
+      secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE,
+      timeoutMs: 5000,
+      agentOnly: true,
+    });
   } catch {
     return false; // crabbox unavailable — not a leased-box target
   }

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -271,15 +271,7 @@ function loadLeasedBoxesSection(): string[] {
       agentOnly: true,
     });
     return renderLeasedBoxesSection(boxes, Math.floor(Date.now() / 1000));
-  } catch (e) {
-    // A locked bundle is the one failure with a fix the user can act on, and
-    // agentOnly above makes it the normal cold-broker outcome — say so instead of
-    // silently dropping the section. Everything else (crabbox absent, no provider
-    // creds) is genuinely not actionable here.
-    const msg = (e as Error).message ?? '';
-    if (msg.includes('not unlocked in the secrets agent')) {
-      return [chalk.gray('  leased boxes hidden — run `agents secrets unlock <bundle>` to show them')];
-    }
+  } catch {
     return []; // crabbox not installed / no provider creds — omit the section
   }
 }
@@ -294,14 +286,13 @@ function loadLeasedBoxesSection(): string[] {
 function trySshLeasedBox(name: string, cmd: string[]): boolean {
   let box: CrabboxBox | null;
   try {
-    // agentOnly: this runs for ANY unrecognized `agents ssh <name>` — including a
-    // typo'd device name — so discovery must never pop Touch ID. The connect below
-    // keeps the auto-detect: by then the box is confirmed and the user meant it.
-    box = crabboxFind(name, {
-      secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE,
-      timeoutMs: 5000,
-      agentOnly: true,
-    });
+    // Deliberately NOT agentOnly, unlike the devices-list render above. This runs
+    // only for a name the user typed, and a broker-only failure here is
+    // indistinguishable downstream from "no such box" — the catch below returns
+    // false and the caller prints "Unknown device '<name>'". Reporting a real
+    // leased box as nonexistent is a worse outcome than one prompt on a path the
+    // user initiated. `agents run --lease` keeps its prompt for the same reason.
+    box = crabboxFind(name, { secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE, timeoutMs: 5000 });
   } catch {
     return false; // crabbox unavailable — not a leased-box target
   }

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -259,7 +259,17 @@ export function renderLeasedBoxesSection(boxes: CrabboxBox[], nowSecs: number): 
 /** The leased-box rows for the devices list, or [] when crabbox can't be read. */
 function loadLeasedBoxesSection(): string[] {
   try {
-    const boxes = crabboxList({ secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE, timeoutMs: 5000 });
+    // agentOnly: this section is a passive render inside `agents devices list`,
+    // which SessionStart hooks shell out to on every new agent terminal. Without
+    // it the resolve runs "interactive" (a TTY) and every keychain-backed bundle
+    // pops its own Touch ID sheet — each read is a separate helper process, so
+    // the assertion is never reused. Broker-only: warm bundles still render, a
+    // cold read throws and the catch below drops the section.
+    const boxes = crabboxList({
+      secretsBundle: process.env.AGENTS_LEASE_SECRETS_BUNDLE,
+      timeoutMs: 5000,
+      agentOnly: true,
+    });
     return renderLeasedBoxesSection(boxes, Math.floor(Date.now() / 1000));
   } catch {
     return []; // crabbox not installed / no provider creds — omit the section

--- a/apps/cli/src/lib/crabbox/cli.test.ts
+++ b/apps/cli/src/lib/crabbox/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -10,6 +10,7 @@ import {
   pickTailscaleBundleFromList,
   crabboxList,
   crabboxWarmup,
+  resolveBrokerOnly,
   parseCrabboxSshArgv,
   type CrabboxBox,
 } from './cli.js';
@@ -298,5 +299,44 @@ describe('parseCrabboxSshArgv', () => {
 
   it('returns null when no ssh command line is present', () => {
     expect(parseCrabboxSshArgv('lease not found\nsome error\n')).toBeNull();
+  });
+});
+
+describe('resolveBrokerOnly', () => {
+  // Regression guard for the macOS Touch ID storm: `agents devices list` renders
+  // the leased-boxes section inside a TTY, so the headless auto-detect returns
+  // false and every keychain-backed bundle resolve was allowed to pop its own
+  // Touch ID sheet (one helper process per read, so no assertion reuse). The
+  // passive caller now forces broker-only.
+  it('honors an explicit true regardless of the ambient context', () => {
+    expect(resolveBrokerOnly({ agentOnly: true })).toBe(true);
+  });
+
+  it('honors an explicit false regardless of the ambient context', () => {
+    expect(resolveBrokerOnly({ agentOnly: false })).toBe(false);
+  });
+
+  // The auto-detect is a no-op off darwin (no biometry prompt to suppress), so
+  // the fallback and the `??`-vs-`||` distinction are only observable there.
+  describe.skipIf(process.platform !== 'darwin')('on darwin', () => {
+    const prior = process.env.AGENTS_SECRETS_NO_PROMPT;
+    afterEach(() => {
+      if (prior === undefined) delete process.env.AGENTS_SECRETS_NO_PROMPT;
+      else process.env.AGENTS_SECRETS_NO_PROMPT = prior;
+    });
+
+    it('falls back to the headless auto-detect when agentOnly is omitted', () => {
+      process.env.AGENTS_SECRETS_NO_PROMPT = '1';
+      expect(resolveBrokerOnly({})).toBe(true);
+      process.env.AGENTS_SECRETS_NO_PROMPT = '0';
+      expect(resolveBrokerOnly({})).toBe(false);
+    });
+
+    it('does not let an explicit false fall through to a headless context', () => {
+      // `false || isHeadlessSecretsContext()` would return true here and strip
+      // the prompt from an interactive `agents run --lease` that asked for one.
+      process.env.AGENTS_SECRETS_NO_PROMPT = '1';
+      expect(resolveBrokerOnly({ agentOnly: false })).toBe(false);
+    });
   });
 });

--- a/apps/cli/src/lib/crabbox/cli.test.ts
+++ b/apps/cli/src/lib/crabbox/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -306,37 +306,29 @@ describe('resolveBrokerOnly', () => {
   // Regression guard for the macOS Touch ID storm: `agents devices list` renders
   // the leased-boxes section inside a TTY, so the headless auto-detect returns
   // false and every keychain-backed bundle resolve was allowed to pop its own
-  // Touch ID sheet (one helper process per read, so no assertion reuse). The
-  // passive caller now forces broker-only.
-  it('honors an explicit true regardless of the ambient context', () => {
-    expect(resolveBrokerOnly({ agentOnly: true })).toBe(true);
+  // Touch ID sheet (one helper process per read, so no assertion reuse). Passive
+  // callers now force broker-only.
+  //
+  // The detector is injected rather than driven through env + process.platform so
+  // these run on the Linux CI that actually gates the merge. With the real
+  // detector the off-darwin short-circuit (bundles.ts:1253) makes every case
+  // return false, and a `||` implementation would pass identically — the guard
+  // would be green on CI while broken on the only platform that prompts.
+  const headless = () => true;
+  const interactive = () => false;
+
+  it('honors an explicit true even when the context looks interactive', () => {
+    expect(resolveBrokerOnly({ agentOnly: true }, interactive)).toBe(true);
   });
 
-  it('honors an explicit false regardless of the ambient context', () => {
-    expect(resolveBrokerOnly({ agentOnly: false })).toBe(false);
+  it('does not let an explicit false fall through to a headless context', () => {
+    // `false || detect()` returns true here, stripping the prompt from an
+    // interactive `agents run --lease` that deliberately asked to allow one.
+    expect(resolveBrokerOnly({ agentOnly: false }, headless)).toBe(false);
   });
 
-  // The auto-detect is a no-op off darwin (no biometry prompt to suppress), so
-  // the fallback and the `??`-vs-`||` distinction are only observable there.
-  describe.skipIf(process.platform !== 'darwin')('on darwin', () => {
-    const prior = process.env.AGENTS_SECRETS_NO_PROMPT;
-    afterEach(() => {
-      if (prior === undefined) delete process.env.AGENTS_SECRETS_NO_PROMPT;
-      else process.env.AGENTS_SECRETS_NO_PROMPT = prior;
-    });
-
-    it('falls back to the headless auto-detect when agentOnly is omitted', () => {
-      process.env.AGENTS_SECRETS_NO_PROMPT = '1';
-      expect(resolveBrokerOnly({})).toBe(true);
-      process.env.AGENTS_SECRETS_NO_PROMPT = '0';
-      expect(resolveBrokerOnly({})).toBe(false);
-    });
-
-    it('does not let an explicit false fall through to a headless context', () => {
-      // `false || isHeadlessSecretsContext()` would return true here and strip
-      // the prompt from an interactive `agents run --lease` that asked for one.
-      process.env.AGENTS_SECRETS_NO_PROMPT = '1';
-      expect(resolveBrokerOnly({ agentOnly: false })).toBe(false);
-    });
+  it('falls back to the detector only when agentOnly is omitted', () => {
+    expect(resolveBrokerOnly({}, headless)).toBe(true);
+    expect(resolveBrokerOnly({}, interactive)).toBe(false);
   });
 });

--- a/apps/cli/src/lib/crabbox/cli.ts
+++ b/apps/cli/src/lib/crabbox/cli.ts
@@ -121,18 +121,21 @@ export function pickTailscaleBundleFromList(bundles: SecretsBundle[]): { name: s
 }
 
 /** Process-lifetime memo so the tailscale bundle `listBundles()` scan runs at most once. */
-let tailscaleBundleMemo: { value: { name: string; key: string } | undefined } | undefined;
-function resolveTailscaleBundleMemo(): { name: string; key: string } | undefined {
-  if (!tailscaleBundleMemo) {
+// Keyed by brokerOnly: a broker-only scan can legitimately come back empty (the
+// metadata batch is skipped rather than prompting), and caching that miss under
+// the same key would make a later interactive lease silently skip the bundle.
+const tailscaleBundleMemo = new Map<boolean, { name: string; key: string } | undefined>();
+function resolveTailscaleBundleMemo(brokerOnly: boolean): { name: string; key: string } | undefined {
+  if (!tailscaleBundleMemo.has(brokerOnly)) {
     let value: { name: string; key: string } | undefined;
     try {
-      value = pickTailscaleBundleFromList(listBundles());
+      value = pickTailscaleBundleFromList(listBundles({ agentOnly: brokerOnly }));
     } catch {
       /* secrets unreadable — no auto-detect */
     }
-    tailscaleBundleMemo = { value };
+    tailscaleBundleMemo.set(brokerOnly, value);
   }
-  return tailscaleBundleMemo.value;
+  return tailscaleBundleMemo.get(brokerOnly);
 }
 
 /** A resolved lease bundle: its name, plus (auto-detect only) the exact keys to inject. */
@@ -156,7 +159,7 @@ export interface ResolvedLeaseBundle {
  * time). Once `lease setup` persists the choice (tier 2), tier 3 never runs.
  * Returns undefined when nothing matches — crabbox then falls back to `crabbox login`.
  */
-export function resolveLeaseBundle(): ResolvedLeaseBundle | undefined {
+export function resolveLeaseBundle(opts: { agentOnly?: boolean } = {}): ResolvedLeaseBundle | undefined {
   const env = process.env.AGENTS_LEASE_SECRETS_BUNDLE;
   if (env) return { name: env };
   try {
@@ -166,7 +169,7 @@ export function resolveLeaseBundle(): ResolvedLeaseBundle | undefined {
     /* config unreadable — fall through to auto-detect */
   }
   try {
-    const bundles = listBundles();
+    const bundles = listBundles({ agentOnly: opts.agentOnly });
     const name = pickLeaseBundleFromList(bundles);
     if (name) {
       const b = bundles.find((x) => x.name === name);
@@ -180,17 +183,17 @@ export function resolveLeaseBundle(): ResolvedLeaseBundle | undefined {
 }
 
 /** Process-lifetime memo so the tier-3 `listBundles()` scan runs at most once. */
-let leaseBundleMemo: { value: ResolvedLeaseBundle | undefined } | undefined;
-function resolveLeaseBundleMemo(): ResolvedLeaseBundle | undefined {
-  if (!leaseBundleMemo) leaseBundleMemo = { value: resolveLeaseBundle() };
-  return leaseBundleMemo.value;
+const leaseBundleMemo = new Map<boolean, ResolvedLeaseBundle | undefined>();
+function resolveLeaseBundleMemo(brokerOnly: boolean): ResolvedLeaseBundle | undefined {
+  if (!leaseBundleMemo.has(brokerOnly)) leaseBundleMemo.set(brokerOnly, resolveLeaseBundle({ agentOnly: brokerOnly }));
+  return leaseBundleMemo.get(brokerOnly);
 }
 
 /** Persist `lease.secretsBundle` in agents config so `--lease` needs no env var. */
 export function setLeaseSecretsBundle(name: string): void {
   const meta = readMeta();
   writeMeta({ ...meta, lease: { ...meta.lease, secretsBundle: name } });
-  leaseBundleMemo = undefined; // invalidate so the next resolve sees the new config
+  leaseBundleMemo.clear(); // invalidate so the next resolve sees the new config
 }
 
 /**
@@ -202,8 +205,11 @@ export function setLeaseSecretsBundle(name: string): void {
  * `||`: `false || detect()` would silently re-enable prompting for the caller
  * that explicitly asked for it to be allowed.)
  */
-export function resolveBrokerOnly(opts: Pick<CrabboxOptions, 'agentOnly'>): boolean {
-  return opts.agentOnly ?? isHeadlessSecretsContext();
+export function resolveBrokerOnly(
+  opts: Pick<CrabboxOptions, 'agentOnly'>,
+  detect: () => boolean = isHeadlessSecretsContext,
+): boolean {
+  return opts.agentOnly ?? detect();
 }
 
 /** Build the child env for crabbox, injecting a secrets bundle when configured. */
@@ -214,7 +220,7 @@ export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
 
   const resolved: ResolvedLeaseBundle | undefined = opts.secretsBundle
     ? { name: opts.secretsBundle }
-    : resolveLeaseBundleMemo();
+    : resolveLeaseBundleMemo(brokerOnly);
   if (resolved) {
     try {
       // Auto-detected bundle → inject ONLY the provider token key(s) (least
@@ -244,7 +250,7 @@ export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
   // public-network lease; `crabboxWarmup({ netMode: 'tailscale' })` is what decides
   // whether the key is actually used.
   if (!out.CRABBOX_TAILSCALE_AUTH_KEY) {
-    const ts = resolveTailscaleBundleMemo();
+    const ts = resolveTailscaleBundleMemo(brokerOnly);
     if (ts) {
       try {
         const { env } = readAndResolveBundleEnv(ts.name, {

--- a/apps/cli/src/lib/crabbox/cli.ts
+++ b/apps/cli/src/lib/crabbox/cli.ts
@@ -65,6 +65,16 @@ export interface CrabboxOptions {
    * path (devices list, `agents ssh` fall-through) pass a shorter bound.
    */
   timeoutMs?: number;
+  /**
+   * Force broker-only secret resolution, overriding the headless auto-detect.
+   * Set by ambient/passive callers that render leased boxes as a side effect of
+   * another command (`agents devices list`): those run in a TTY, so the
+   * auto-detect would classify them interactive and let every bundle resolve
+   * pop its own Touch ID sheet — one per keychain-backed bundle, on every
+   * SessionStart hook that shells out to `agents devices`. Broker-only makes a
+   * cold read fail fast instead, and the caller drops the section.
+   */
+  agentOnly?: boolean;
 }
 
 /** Locate the crabbox binary, or throw an actionable error. */
@@ -183,9 +193,24 @@ export function setLeaseSecretsBundle(name: string): void {
   leaseBundleMemo = undefined; // invalidate so the next resolve sees the new config
 }
 
+/**
+ * Whether crabbox's secret resolution must stay broker-only (never prompt).
+ *
+ * An explicit `agentOnly` always wins — including `false`, which is how an
+ * interactive `agents run --lease` keeps its one legitimate Touch ID prompt.
+ * Only an omitted value falls back to the headless auto-detect. (`??`, not
+ * `||`: `false || detect()` would silently re-enable prompting for the caller
+ * that explicitly asked for it to be allowed.)
+ */
+export function resolveBrokerOnly(opts: Pick<CrabboxOptions, 'agentOnly'>): boolean {
+  return opts.agentOnly ?? isHeadlessSecretsContext();
+}
+
 /** Build the child env for crabbox, injecting a secrets bundle when configured. */
 export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
   const out: NodeJS.ProcessEnv = { ...process.env };
+
+  const brokerOnly = resolveBrokerOnly(opts);
 
   const resolved: ResolvedLeaseBundle | undefined = opts.secretsBundle
     ? { name: opts.secretsBundle }
@@ -202,7 +227,7 @@ export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
         // --lease is headless by contract and crabboxEnv is called several times
         // per run (list/wait/spawn/stop) — resolve broker-only so a keychain bundle
         // can't pop repeated unwatched Touch ID sheets mid-lease.
-        agentOnly: isHeadlessSecretsContext(),
+        agentOnly: brokerOnly,
       });
       Object.assign(out, env);
     } catch (e) {
@@ -225,7 +250,7 @@ export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
         const { env } = readAndResolveBundleEnv(ts.name, {
           caller: 'agents run --lease (crabbox tailscale)',
           keys: [ts.key],
-          agentOnly: isHeadlessSecretsContext(),
+          agentOnly: brokerOnly,
         });
         const value = env[ts.key];
         if (value) out.CRABBOX_TAILSCALE_AUTH_KEY = value;

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -6,6 +6,7 @@ import {
   canCacheResolvedEnv,
   isHeadlessSecretsContext,
   listBundles,
+  BUNDLE_META_PREFIX,
   readAndResolveBundleEnv,
   readBundle,
   shouldEvictAfterBundleWrite,
@@ -171,6 +172,59 @@ describe('canCacheResolvedEnv (broker cache shape)', () => {
 
   it('does not cache process-mode env when account suffixes would be stripped', () => {
     expect(canCacheResolvedEnv(bundle, new Set(Object.keys(bundle.vars)), 'process')).toBe(false);
+  });
+});
+
+describe('listBundles agent-only enumeration', () => {
+  // The Touch ID storm fix: bundle METADATA items are biometry-gated too, so
+  // enumerating bundles on a broker miss popped a sheet even when no value was
+  // ever read. `agents devices list` reaches this twice per invocation (crabbox
+  // lease auto-detect + tailscale probe), and a SessionStart hook shells out to
+  // it on every new agent terminal. A broker-only caller must enumerate from the
+  // cached snapshot or come back empty — never fall through to the keychain.
+  const countingBackend = () => {
+    const calls = { get: 0, list: 0 };
+    const backend: KeychainBackend = {
+      has: () => false,
+      get: (item: string) => { calls.get++; throw new Error(`keychain must not be read: ${item}`); },
+      set: () => { throw new Error('keychain must not be written'); },
+      delete: () => false,
+      list: () => { calls.list++; return [`${BUNDLE_META_PREFIX}hetzner.com`]; },
+    };
+    return { calls, backend };
+  };
+
+  it('never reads a keychain metadata item when agentOnly and the snapshot missed', () => {
+    const { calls, backend } = countingBackend();
+    const previousBackend = setKeychainBackendForTest(backend);
+    const previousNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+    process.env.AGENTS_SECRETS_NO_AGENT = '1'; // force the snapshot to miss
+    try {
+      const bundles = listBundles({ agentOnly: true });
+      expect(calls.get).toBe(0);
+      expect(bundles.some((b) => b.name === 'hetzner.com')).toBe(false);
+    } finally {
+      setKeychainBackendForTest(previousBackend);
+      if (previousNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+      else process.env.AGENTS_SECRETS_NO_AGENT = previousNoAgent;
+    }
+  });
+
+  it('still reads the keychain for a normal (non-agentOnly) enumeration', () => {
+    const { calls, backend } = countingBackend();
+    const previousBackend = setKeychainBackendForTest(backend);
+    const previousNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+    process.env.AGENTS_SECRETS_NO_AGENT = '1';
+    try {
+      // The counting backend throws on get, which listBundles tolerates — the
+      // point is that it ATTEMPTED the read the agentOnly path must skip.
+      try { listBundles(); } catch { /* enumeration is best-effort */ }
+      expect(calls.get).toBeGreaterThan(0);
+    } finally {
+      setKeychainBackendForTest(previousBackend);
+      if (previousNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+      else process.env.AGENTS_SECRETS_NO_AGENT = previousNoAgent;
+    }
   });
 });
 

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -766,7 +766,7 @@ function healKeychainBundleMetadataAclOnce(metaJsonByName: Map<string, string>):
   }
 }
 
-export function listBundles(): SecretsBundle[] {
+export function listBundles(opts: { agentOnly?: boolean } = {}): SecretsBundle[] {
   const out: SecretsBundle[] = [];
 
   // Keychain-backed bundles: batch all metadata reads behind ONE Touch ID
@@ -817,6 +817,11 @@ export function listBundles(): SecretsBundle[] {
       const cached = useAgent ? agentGetMetaSync(nameSetHash) : null;
       if (cached) {
         for (const bundle of cached) out.push(bundle);
+      } else if (opts.agentOnly) {
+        // Broker-only caller (a passive render — see CrabboxOptions.agentOnly) and
+        // the metadata snapshot missed. The batch below is biometry-gated, so
+        // running it here would pop the exact Touch ID sheet agentOnly exists to
+        // prevent. Omit keychain-backed bundles instead; the caller degrades.
       } else {
         const fetched = getKeychainTokens(keychainServices);
         const keychainBundles: SecretsBundle[] = [];
@@ -878,7 +883,12 @@ export function listBundles(): SecretsBundle[] {
     if (bundle) out.push(bundle);
   }
 
-  if (getVaultSession().loggedIn && vaultExists()) {
+  // vaultExists() (a file stat) FIRST — getVaultSession() reads a keychain item,
+  // so the original order spawned the helper on every enumeration even for the
+  // overwhelming majority of users who have no vault at all. Every other call
+  // site already orders it this way (lines 152, 422, 1388); this one was the
+  // outlier, and it defeated the agentOnly guard above.
+  if (vaultExists() && getVaultSession().loggedIn) {
     let vaultServices: string[] = [];
     try {
       vaultServices = vaultListItems(BUNDLE_META_PREFIX);

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -885,9 +885,17 @@ export function listBundles(opts: { agentOnly?: boolean } = {}): SecretsBundle[]
 
   // vaultExists() (a file stat) FIRST — getVaultSession() reads a keychain item,
   // so the original order spawned the helper on every enumeration even for the
-  // overwhelming majority of users who have no vault at all. Every other call
-  // site already orders it this way (lines 152, 422, 1388); this one was the
-  // outlier, and it defeated the agentOnly guard above.
+  // overwhelming majority of users who have no vault at all. Every other guarded
+  // call site in this file already orders it this way; this one was the outlier,
+  // and it defeated the agentOnly guard above. (The login path calls
+  // getVaultSession() with no vaultExists() guard at all, which is correct there —
+  // a vault is presumed.)
+  //
+  // One behavior does change: getVaultSession() garbage-collects a malformed or
+  // expired session item via clearVaultKey() (vault.ts:276/280/284). With no vault
+  // file present we now short-circuit before that, so an orphaned session item
+  // survives instead of being swept. It is inert — every reader gates on
+  // vaultExists() — and `agents secrets vault` cleans it up on next use.
   if (vaultExists() && getVaultSession().loggedIn) {
     let vaultServices: string[] = [];
     try {


### PR DESCRIPTION
## Bug

Opening a new agent terminal on macOS pops Touch ID 5+ times, with a healthy broker holding every bundle.

## Evidence

`biometrickitd` logs a real fingerprint `MATCH`, and the requesting process is the signed keychain helper, in **four distinct PIDs** seconds apart:

```
Agents CLI[45190] evaluateAccessControl:<SecAccessControlRef: ...cbio(...)> ... cid:5
Agents CLI[45190] ... returned Error ... Code=-1004 "User interaction is required."
Agents CLI[45190] Creating LAContext new cid:6
Agents CLI[45190] [Interactive,SPI] evaluateAccessControl ... cid:8
```

Distinct PIDs are the whole problem: `lib/secrets/index.ts:822` spawns a fresh helper per read, and `keychain-helper.swift:15-23` holds the reuse assertion in **one LAContext per process**. N reads = N sheets, structurally.

The trigger chain:

```
SessionStart hook 07-inject-device-topology.sh:37
  -> agents devices list              (no --json, stats on)
  -> commands/ssh.ts:883  loadLeasedBoxesSection()
  -> crabboxList() -> crabboxEnv()
       |- listBundles()               (lease auto-detect, cli.ts:158)
       |- listBundles()               (tailscale, cli.ts:119)
       |- readAndResolveBundleEnv     (lease bundle,     cli.ts:205)
       \- readAndResolveBundleEnv     (tailscale bundle, cli.ts:228)
```

Both resolves passed `agentOnly: isHeadlessSecretsContext()`. That returns false in a TTY, so an ordinary terminal invocation was allowed to prompt. `bundles.ts:758-760` already documents the cost: *"Bundle metadata items are biometry-gated, so the getKeychainTokens batch below pops Touch ID."*

The audit log corroborates it — every session start emits `secrets.get` with `operation: "agents run --lease (crabbox)"`, which is not a real lease at all, just the devices-list section.

## The pattern this fixes

Background paths already hard-code the guard; only the interactive paths degrade to the auto-detect:

| Call site | Guard | Prompts in a TTY? |
|---|---|---|
| `commands/teams.ts:1570`, `:1589` | `agentOnly: true` | no |
| `commands/cloud.ts:298` | `agentOnly: true` | no |
| `lib/crabbox/cli.ts:205`, `:228` | `isHeadlessSecretsContext()` | **yes** |

## Change

Thread `agentOnly` through `CrabboxOptions`; `loadLeasedBoxesSection` forces it on. Warm bundles still render; a cold read fails fast and the existing `catch` drops the section rather than grabbing the sensor. Active lease paths (`agents run --lease`, `agents lease`) are untouched and keep their one legitimate prompt.

`resolveBrokerOnly` uses `??`, not `||`, so an explicit `agentOnly: false` is honored instead of falling through to the auto-detect. That distinction is the regression test.

## Tests

`bunx vitest run src/lib/crabbox/cli.test.ts`

- **This branch:** 21 passed, 5 failed
- **Unmodified `origin/main` (clean worktree, same machine):** 17 passed, 5 failed

Same 5 failures, so they are pre-existing, and all 4 new tests pass. Those 5 are themselves a symptom of this bug: they invoke `crabboxList`/`crabboxWarmup` under vitest (non-TTY), so the auto-detect resolves the developer's **real** `hetzner.com` lease bundle and throws. They pass on Linux CI, where `isHeadlessSecretsContext()` is a no-op and `listBundles()` finds nothing. Worth fixing separately with proper test isolation.

## Scoped out, deliberately

- `commands/exec.ts:2185` — `shareRuntimeEnv({ agentOnly: isHeadlessSecretsContext() })` is the identical defect on interactive `agents run`. Same fix shape, separate PR.
- `07-inject-device-topology.sh:37` could also pass `--no-stats`, but that hook lives in the `.agents-system` repo.

## Note for the release

These four Touch ID fixes are all on `main` and **none are in a tag** — `v1.20.74` is both the latest tag and npm latest, with 214 commits unreleased behind it:

- `22766a6e` cache Claude OAuth token no-ACL to end the macOS Touch ID storm
- `8c5625ed` make that cache opt-in (`accessTokenCache`, off by default)
- `2c60129b` read-only stats probe never pops Touch ID (RUSH-1970)
- `8bb3e7e1` store bundle metadata no-ACL at every tier (RUSH-1759)

So users on the published build have none of them. Release PR #1526 (1.20.75) is still open.
