### PR TITLE
fix(factory): Claude terminal tabs auto-label with the task topic, not the repo name

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Claude terminal tabs get a real topic label again, not the repo name.**
+  Claude 2.1.207+ auto-derives a placeholder session name `<dirname>-<n>`
+  (e.g. `agents-cli-55`, tagged `nameSource: "derived"`). The extension used it
+  verbatim as the tab label and, worse, it short-circuited the LLM topic path —
+  so every Claude tab read `CC - agents-cli-55` instead of what the agent was
+  working on, while non-Claude tabs (which skip that path) showed real topics
+  like `KM - Create Tickets`. A derived name is now treated as no name, so the
+  tab falls through to the LLM-generated topic. Genuine titles are still used.
+  The auto-label poller also refreshes the tab title itself (not just the status
+  bar) when a label resolves on the active tab, so it no longer takes a focus
+  change to appear.
 - **A dropped SSH connection no longer destroys running agents (reconnect
   resilience).** Agents run in detached tmux sessions on the shared socket, so
   they survive a network drop — but on a Remote-SSH teardown VS Code fires

--- a/apps/factory/src/core/sessionName.test.ts
+++ b/apps/factory/src/core/sessionName.test.ts
@@ -88,6 +88,25 @@ describe('readClaudeSessionName', () => {
     expect(res).toBe('Spaced title');
   });
 
+  it('skips Claude auto-derived placeholder names (nameSource="derived")', async () => {
+    // Claude 2.1.207+ writes `<dirname>-<n>` as a derived placeholder. It is
+    // not a topic, so readClaudeSessionName must treat it as no name — the
+    // caller then falls through to the LLM topic path.
+    writeSessionFile(66280, { sessionId: 'abc-123', name: 'agents-cli-55', nameSource: 'derived' });
+    const res = await readClaudeSessionName('abc-123', { sessionsDirs: [tmpDir] });
+    expect(res).toBeNull();
+  });
+
+  it('returns a genuine title even when nameSource is absent or non-derived', async () => {
+    writeSessionFile(11111, { sessionId: 'no-source', name: 'Fix Fleet Login' });
+    writeSessionFile(22222, { sessionId: 'user-set', name: 'Ship Release', nameSource: 'user' });
+    const a = await readClaudeSessionName('no-source', { sessionsDirs: [tmpDir] });
+    resetSessionNameCache();
+    const b = await readClaudeSessionName('user-set', { sessionsDirs: [tmpDir] });
+    expect(a).toBe('Fix Fleet Login');
+    expect(b).toBe('Ship Release');
+  });
+
   it('caches scans within the TTL window', async () => {
     writeSessionFile(44444, { sessionId: 'sid', name: 'First' });
     const t0 = 1_000_000;

--- a/apps/factory/src/core/sessionName.ts
+++ b/apps/factory/src/core/sessionName.ts
@@ -3,10 +3,18 @@ import * as path from 'path';
 import * as os from 'os';
 
 // Claude Code persists a per-session metadata file containing
-// { sessionId, name, ... } where `name` is the human-readable title shown
-// by `/status`. We use it as the terminal tab label so the tab matches the
-// agent's own title instead of a 5-word truncation of the user's first
-// message.
+// { sessionId, name, nameSource, ... } where `name` is the title shown by
+// `/status`. When the user (or Claude itself) has set a real title, we use it
+// as the terminal tab label so the tab matches the agent's own title instead
+// of a 5-word truncation of the user's first message.
+//
+// Claude 2.1.207+ ALSO auto-derives a placeholder name — `<dirname>-<n>`
+// (e.g. "agents-cli-55"), tagged `nameSource: "derived"`. That placeholder is
+// not a topic; surfacing it as the tab label tells you the repo, not what the
+// agent is working on, and it short-circuits the LLM topic path in
+// extension.ts (which produces "Fix Fleet Login"-style titles). So a derived
+// name is treated as no name at all — the caller falls through to the LLM
+// path. Only a genuine title (any nameSource other than "derived") is used.
 //
 // File locations:
 //   - ~/.claude/sessions/<pid>.json                          (vanilla install)
@@ -22,6 +30,7 @@ import * as os from 'os';
 interface ClaudeSessionFile {
   sessionId?: string;
   name?: string | null;
+  nameSource?: string | null;
 }
 
 interface ScanCache {
@@ -97,6 +106,11 @@ async function scanDir(dir: string, sink: Map<string, string>): Promise<void> {
         try {
           const raw = await fs.promises.readFile(path.join(dir, f), 'utf-8');
           const parsed = JSON.parse(raw) as ClaudeSessionFile;
+          // A `derived` name is Claude's auto-generated `<dirname>-<n>`
+          // placeholder, not a real title — skip it so the caller falls
+          // through to the LLM topic path instead of labelling the tab with
+          // the repo name.
+          if (parsed.nameSource === 'derived') return;
           if (parsed.sessionId && typeof parsed.name === 'string' && parsed.name.trim()) {
             sink.set(parsed.sessionId, parsed.name.trim());
           }

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -3690,8 +3690,22 @@ function startAutoLabelPollerForTerminal(terminal: vscode.Terminal, context: vsc
 
   terminals.startAutoLabelPoller(terminal, async () => {
     const autoLabel = await fetchAndSetAutoLabel(terminal, entry);
-    if (autoLabel && vscode.window.activeTerminal === terminal) {
-      updateStatusBarForTerminal(terminal, context.extensionPath);
+    if (!autoLabel || vscode.window.activeTerminal !== terminal) return;
+    updateStatusBarForTerminal(terminal, context.extensionPath);
+    // Refresh the tab title too, not just the status bar — otherwise a label
+    // that resolves while you're sitting on the tab never shows until the next
+    // focus change. Renaming briefly activates the terminal, so this is gated
+    // on the terminal already being active (same focus-safe guard as
+    // tryFetchLabelOnFocus).
+    const display = getDisplayPrefs(context);
+    if (display.showLabelsInTitles && display.autoLabelInTabTitles && entry.agentConfig) {
+      const newTitle = buildTerminalTitle(
+        entry.agentConfig.title,
+        autoLabel,
+        context,
+        entry.sessionId
+      );
+      await terminals.renameTerminal(terminal, newTitle);
     }
   });
 }


### PR DESCRIPTION
## Symptom

Spinning up Claude agents in Factory terminal tabs, the tabs don't auto-label with what the agent is working on. Most stay a bare `CC`; the few that label show `CC - agents-cli-55` / `CC - agents-cli-60` (the repo name + a number). Meanwhile a sibling **Kimi** tab correctly showed `KM - Create Tickets` — a real topic. Before screenshot: `yosemite-s0:/tmp/claude-1000/-home-muqsit/1d418ba5-bed1-4b57-80a7-f52c9569f9fe/scratchpad/cleanshot.png`

## Root cause

Two independent defects, both in the auto-label path.

**1 — Claude's derived session name hijacks the label (the big one).**
Claude `2.1.207+` now auto-derives a placeholder session name `<dirname>-<n>` (e.g. `agents-cli-55`) and tags it `"nameSource":"derived"` in `~/.claude/sessions/<pid>.json`. `readClaudeSessionName` (`apps/factory/src/core/sessionName.ts`) returned that verbatim, and `fetchAndSetAutoLabel` (`apps/factory/src/vscode/extension.ts`) prefers Claude's persisted name and **returns before ever calling `generateLabelWithLLM`**. So every Claude tab got the repo name and never reached the LLM topic path. Non-Claude agents skip that Claude-only short-circuit — which is precisely why the Kimi tab got a real topic while its Claude siblings didn't.

Verified against real data on zion (`nameSource`/`name` across all session files): every `2.1.207`/`2.1.220` session is `nameSource:"derived"` with a `<repo>-<n>` name; the only genuine titles (`Fix Fleet Login`, `Fix Agent Feed`) are older sessions with no `derived` tag.

Fix: a `derived` name is treated as no name — `readClaudeSessionName` skips it, so the tab falls through to the LLM-generated topic (or, if the LLM is unavailable, the existing 5-word first-message fallback). Genuine titles (any other `nameSource`, or none) are still used.

**2 — the poller updated the status bar but never the tab title.**
`startAutoLabelPollerForTerminal`'s callback set the auto-label and refreshed the status bar, but didn't rename the tab — so a label resolving while you sit on a tab only appeared on the next focus change. It now renames the tab too, gated on the terminal already being active (same focus-safe guard as `tryFetchLabelOnFocus`).

## Verification

- `bun test src/core/sessionName.test.ts` — 12 pass (2 new: derived skipped → null; genuine title kept). `tsc -p ./` clean.
- Built + installed the `.vsix` on zion (VS Codium), then ran the **installed** `out/core/sessionName.js` against the **real** session files:
  - derived `agents-cli-55` session → `null` (→ LLM/fallback topic path)
  - genuine-title session → `"Fix Agent Feed"` (unchanged)

## Notes
- CHANGELOG entry added under `[Unreleased]`.
- No behavior change for Codex/Gemini/OpenCode (already on the LLM path).