### PR TITLE
fix(usage): honor an injected keychain backend in saveClaudeOauth too

### DIFF
--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1378,8 +1378,12 @@ export async function saveClaudeOauth(
   home: string | undefined,
   credentials: ClaudeOauthCredentials
 ): Promise<boolean> {
-  // Windows not yet supported
-  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+  // Windows not yet supported. An injected test backend is the exception, for
+  // the same reason as the loadClaudeOauth guard above: it makes the keychain
+  // path exercisable anywhere, and without it this returns before the rotated
+  // credential is written OR the no-ACL cache is evicted — so a cached reader
+  // keeps serving the pre-rotation access token.
+  if (process.platform !== 'darwin' && process.platform !== 'linux' && !isKeychainBackendOverridden()) {
     return false;
   }
 


### PR DESCRIPTION
Last of the 16 cross-platform failures that fail-closed the 1.20.75 release. #1527 fixed the other 15; this one missed that merge because the PR landed while this commit was still in flight.

## The bug

`apps/cli/src/lib/usage.ts:1382`:

```ts
// Windows not yet supported
if (process.platform !== 'darwin' && process.platform !== 'linux') {
  return false;
}
```

Identical asymmetry to the `loadClaudeOauth` guard fixed in #1527, one function down. With a test backend injected, `saveClaudeOauth` returns before it writes the rotated credential **or** evicts the no-ACL cache, so the next cached read serves the pre-rotation token:

```
FAIL src/lib/usage.test.ts > loadClaudeOauth no-ACL access-token cache
     > evicts the no-ACL cache when the source credential is rotated
AssertionError: expected 'tok-live' to be 'tok-rotated'
  ❯ src/lib/usage.test.ts:190:35
```

The inner `claudeOauthCacheActive()` gate at `usage.ts:1235` already has the right shape (`darwin || isKeychainBackendOverridden()`); this restores that symmetry in the third and last place it was missing.

## Verification

Measured on real runners via `gh workflow run ci.yml --ref <branch>` (`ci.yml` declares `workflow_dispatch`, so the full matrix can run on any branch — it does not have to wait for a `release/**` branch):

| Run | Windows failures |
|---|---|
| PR #1526, the blocked release | 14 |
| #1527 branch, before this fix | 1 — this test |
| #1527 branch, with this fix | **0 — full matrix green** |

The green run is [30700821898](https://github.com/phnx-labs/agents-cli/actions/runs/30700821898): macOS + Windows + Linux across Node 22 and 24.

Locally on top of current main: `tsc --noEmit` clean, `usage.test.ts` 14/14.