### PR TITLE
release(factory): 0.9.299 — reconnect resilience, detach/attach, agents-dbg pipeline

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.299] - 2026-08-01
+
 - **A dropped SSH connection no longer destroys running agents (reconnect
   resilience).** Agents run in detached tmux sessions on the shared socket, so
   they survive a network drop — but on a Remote-SSH teardown VS Code fires

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.295",
+  "version": "0.9.299",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",


### PR DESCRIPTION
Cut Factory **0.9.299**, promoting the whole `[Unreleased]` block to a dated release section and bumping the extension version so `scripts/release.sh` can publish it.

## Ships in 0.9.299
- **Reconnect resilience (#1502)** — a dropped SSH connection no longer destroys running agents. Detached tmux sessions survive; `cleanupTmuxTerminal` kills only on a true agent exit; on reconnect every live client-less session is re-attached via `agents tmux attach` (never restarted), with bounded-backoff retry.
- **Detach / Attach commands** — background a running agent from the editor and bring it back.
- **agents-dbg 0.1.0 Mac release pipeline** — signed + notarized Electron app, tap formula/cask, curl installer.

## Changes
- `apps/factory/CHANGELOG.md`: `[Unreleased]` → `[0.9.299] - 2026-08-01`
- `apps/factory/package.json`: 0.9.295 → 0.9.299

## Verification
- Built + installed 0.9.299 to disk on zion (code + codium); bundle carries `registerReconnect`, `scanReattachTargets`, `queryTmuxSessionState`, `[RECONNECT]`.
- Marketplace publish pending — VSCE/OVSX tokens are Touch-ID-gated and need an interactive session on zion.