### PR TITLE
fix(usage): let a test keychain backend exercise saveClaudeOauth on Windows

### DIFF
--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1378,8 +1378,13 @@ export async function saveClaudeOauth(
   home: string | undefined,
   credentials: ClaudeOauthCredentials
 ): Promise<boolean> {
-  // Windows not yet supported
-  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+  // Windows not yet supported — except under an installed test keychain backend,
+  // which is in-memory and touches no real credential store. This mirrors
+  // claudeOauthCacheActive(): that gate turns the no-ACL cache ON whenever a test
+  // backend is installed, so on a Windows runner the cache was live while this
+  // save (and the deleteCachedClaudeOauth eviction below) returned early. A
+  // rotation then left the stale cached token served forever.
+  if (process.platform !== 'darwin' && process.platform !== 'linux' && !isKeychainBackendOverridden()) {
     return false;
   }
 


### PR DESCRIPTION
## The bug

The 1.20.75 release PR (#1526) merged with **both Windows jobs red**, so `main`
still carries the failure:

```
FAIL src/lib/usage.test.ts > loadClaudeOauth no-ACL access-token cache
     > evicts the no-ACL cache when the source credential is rotated
AssertionError: expected 'tok-live' to be 'tok-rotated'
 ❯ src/lib/usage.test.ts:190:35
```

Two platform gates disagree about when the keychain path is live.

`claudeOauthCacheActive()` turns the no-ACL cache **on** whenever a test keychain
backend is installed:

```ts
return process.platform === 'darwin' || isKeychainBackendOverridden();
```

So on a Windows runner the cache is active. But `saveClaudeOauth` returned early
on any non-darwin/linux platform:

```ts
// Windows not yet supported
if (process.platform !== 'darwin' && process.platform !== 'linux') {
  return false;
}
```

A rotation therefore never wrote a new source token and never reached its own
`deleteCachedClaudeOauth` eviction further down the same function — so the stale
cached access token was served forever, which is exactly what the test asserts
against.

## The fix

Widen the save guard the same way `loadClaudeOauth` already does a few lines
above in this file (`... || isKeychainBackendOverridden()`).

**No behavior change for any user on any platform.** The override is in-memory
and only ever installed by tests, so in production on Windows the predicate is
false and the early return still fires. This makes the existing test exercise a
live path on Windows instead of asserting against a dead one.

## Verification

`bunx tsc --noEmit` clean. `vitest run src/lib/usage.test.ts` → 14/14 pass on
macOS.

The Windows job itself only runs on `release/**` branches and `v*` tags per
`.github/workflows/ci.yml` (the full matrix is cost-gated), so this branch's
checks will not re-run it. It will be exercised on the next release branch —
that gating is why the failure reached `main` in the first place.
