### PR TITLE
fix(release): allow the next patch when main is ahead of an unpublishable version

### DIFF
--- a/apps/cli/.changelog/next/release-patch-from-main.md
+++ b/apps/cli/.changelog/next/release-patch-from-main.md
@@ -1,0 +1,11 @@
+- **`release.sh` can now cut the next patch when main is ahead of an unpublishable
+  version.** The catch-up guard refuses to publish a merged release PR whose squash pulled
+  in concurrent main commits — correctly, since the tree that would ship is not the tree CI
+  tested (the hole that let 1.20.58 publish before its Windows matrix failed). Its refusal
+  advises cutting the next patch through the normal release PR flow, but the version
+  validator measured patch+1 from the REGISTRY, so with main at 1.20.75 and npm at 1.20.74
+  both 1.20.75 (blocked) and 1.20.76 (read as a skipped version) were rejected — leaving no
+  patch-level path forward and a minor bump as the only escape. A new `patch-from-main`
+  case accepts the version one patch above `package.json` when main is ahead of the
+  registry; it grants no bypass, and the release still earns its own release PR, full
+  cross-platform matrix, merge, tag, and publish. Source: `apps/cli/scripts/release.sh`.

--- a/apps/cli/.changelog/next/release-patch-from-main.md
+++ b/apps/cli/.changelog/next/release-patch-from-main.md
@@ -8,4 +8,10 @@
   patch-level path forward and a minor bump as the only escape. A new `patch-from-main`
   case accepts the version one patch above `package.json` when main is ahead of the
   registry; it grants no bypass, and the release still earns its own release PR, full
-  cross-platform matrix, merge, tag, and publish. Source: `apps/cli/scripts/release.sh`.
+  cross-platform matrix, merge, tag, and publish. The decision moved out of `release.sh`
+  into `scripts/validate-bump.sh` so it can be tested directly — `release.sh` itself
+  cannot be run in a test, since it demands a clean main plus npm and gh auth long before
+  it reaches the bump decision, which is why this arithmetic had no coverage at all. The
+  rejection message now also lists the main-ahead options only when main really is ahead,
+  instead of advising a version the script would then refuse. Source:
+  `apps/cli/scripts/validate-bump.sh`, `apps/cli/scripts/release.sh`.

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -167,70 +167,15 @@ parse_v() { echo "$1" | tr '.' ' '; }
 read -r CMAJ CMIN CPAT <<< "$(parse_v "$PHNX_LATEST")"
 read -r TMAJ TMIN TPAT <<< "$(parse_v "$TARGET")"
 
-# Strict single-step bump from $PHNX_LATEST, OR equal to $PHNX_LATEST when the
-# shim is still behind (shim catch-up rerun after a partial publish), OR equal
-# to package.json on main when several patch commits accumulated without ever
-# being published (phnx catch-up — main is ahead of registry).
-is_valid_bump=false
-read -r SMAJ SMIN SPAT <<< "$(parse_v "$SWARMIFY_LATEST")"
+# Which kind of bump is this? The arithmetic lives in scripts/validate-bump.sh
+# so it can be tested directly (scripts/validate-bump.test.ts) — reaching it
+# here requires a clean main, npm auth and gh auth first. It prints the bump
+# kind, or the accepted versions to stderr and exits 1.
 PKG_JSON_VERSION="$(jq -r .version package.json)"
-read -r PMAJ PMIN PPAT <<< "$(parse_v "$PKG_JSON_VERSION")"
-if [[ $TMAJ -eq $CMAJ && $TMIN -eq $CMIN && $TPAT -eq $((CPAT + 1)) ]]; then
-  BUMP="patch"
-  is_valid_bump=true
-elif [[ $TMAJ -eq $CMAJ && $TMIN -eq $((CMIN + 1)) && $TPAT -eq 0 ]]; then
-  BUMP="minor"
-  is_valid_bump=true
-elif [[ $TMAJ -eq $((CMAJ + 1)) && $TMIN -eq 0 && $TPAT -eq 0 ]]; then
-  BUMP="major"
-  is_valid_bump=true
-elif [[ "$TARGET" == "$PHNX_LATEST" ]] && \
-     { [[ $TMAJ -gt $SMAJ ]] || \
-       { [[ $TMAJ -eq $SMAJ ]] && [[ $TMIN -gt $SMIN ]]; } || \
-       { [[ $TMAJ -eq $SMAJ ]] && [[ $TMIN -eq $SMIN ]] && [[ $TPAT -gt $SPAT ]]; }; }; then
-  BUMP="shim-catchup"
-  is_valid_bump=true
-elif [[ "$TARGET" == "$PKG_JSON_VERSION" ]] && \
-     { [[ $TMAJ -gt $CMAJ ]] || \
-       { [[ $TMAJ -eq $CMAJ ]] && [[ $TMIN -gt $CMIN ]]; } || \
-       { [[ $TMAJ -eq $CMAJ ]] && [[ $TMIN -eq $CMIN ]] && [[ $TPAT -gt $CPAT ]]; }; }; then
-  # Catch-up: main has accumulated unpublished patch commits (chore(release):
-  # N bumps that never reached the registry). Publish what main says.
-  BUMP="phnx-catchup"
-  is_valid_bump=true
-elif [[ $TMAJ -eq $PMAJ && $TMIN -eq $PMIN && $TPAT -eq $((PPAT + 1)) ]] && \
-     { [[ $PMAJ -gt $CMAJ ]] || \
-       { [[ $PMAJ -eq $CMAJ ]] && [[ $PMIN -gt $CMIN ]]; } || \
-       { [[ $PMAJ -eq $CMAJ ]] && [[ $PMIN -eq $CMIN ]] && [[ $PPAT -gt $CPAT ]]; }; }; then
-  # The next patch AFTER an unpublishable main. When main is ahead of the
-  # registry but its version can no longer be published — the catch-up guard
-  # below refuses a merged release PR whose squash pulled in concurrent main
-  # commits, so the tree that would ship is not the tree CI tested — the only
-  # correct move is to cut a fresh release from main and let it earn its own
-  # full-matrix run. That is what this script's own refusal message advises
-  # ("cut the next patch through the normal release PR flow"), and until now
-  # the validator rejected it: patch+1 is measured from the REGISTRY, so with
-  # main at 1.20.75 and npm at 1.20.74, 1.20.76 read as a skipped version and
-  # 1.20.75 was blocked — leaving no patch-level path forward at all.
-  #
-  # Deliberately NOT a bypass: the catch-up guard still owns the case where
-  # main's own version is publishable. This only opens the strictly-newer patch,
-  # which then runs the ordinary bump -> release PR -> full matrix -> merge ->
-  # tag -> publish flow against the exact tree being shipped.
-  BUMP="patch-from-main"
-  is_valid_bump=true
-fi
-
-if ! $is_valid_bump; then
-  red "invalid bump: $PHNX_LATEST -> $TARGET"
-  red "expected one of:"
-  red "  $((CMAJ)).$((CMIN)).$((CPAT + 1))   (patch)"
-  red "  $((CMAJ)).$((CMIN + 1)).0   (minor)"
-  red "  $((CMAJ + 1)).0.0   (major)"
-  red "  $PKG_JSON_VERSION              (phnx-catchup: package.json is ahead of registry)"
-  red "  $((PMAJ)).$((PMIN)).$((PPAT + 1))   (patch-from-main: the next patch after an unpublishable main)"
+if ! BUMP="$(scripts/validate-bump.sh "$PHNX_LATEST" "$PKG_JSON_VERSION" "$SWARMIFY_LATEST" "$TARGET")"; then
   exit 1
 fi
+read -r SMAJ SMIN SPAT <<< "$(parse_v "$SWARMIFY_LATEST")"
 
 # Target must also be strictly newer than @companion latest (rare edge case),
 # unless this is a shim-catchup where target == phnx_latest and shim is behind.

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -24,7 +24,10 @@
 #
 # Validates that <version> is a single-step bump from the current published
 # @phnx-labs latest -- patch+1, or minor+1 with patch=0, or major+1 with
-# minor=patch=0. No skips.
+# minor=patch=0. No skips. Two exceptions cover main running ahead of the
+# registry: the version main already carries (phnx-catchup), and the next patch
+# after it (patch-from-main) for when main's own version can no longer be
+# published because its merged release PR no longer matches the tree CI tested.
 
 set -euo pipefail
 
@@ -171,6 +174,7 @@ read -r TMAJ TMIN TPAT <<< "$(parse_v "$TARGET")"
 is_valid_bump=false
 read -r SMAJ SMIN SPAT <<< "$(parse_v "$SWARMIFY_LATEST")"
 PKG_JSON_VERSION="$(jq -r .version package.json)"
+read -r PMAJ PMIN PPAT <<< "$(parse_v "$PKG_JSON_VERSION")"
 if [[ $TMAJ -eq $CMAJ && $TMIN -eq $CMIN && $TPAT -eq $((CPAT + 1)) ]]; then
   BUMP="patch"
   is_valid_bump=true
@@ -194,6 +198,27 @@ elif [[ "$TARGET" == "$PKG_JSON_VERSION" ]] && \
   # N bumps that never reached the registry). Publish what main says.
   BUMP="phnx-catchup"
   is_valid_bump=true
+elif [[ $TMAJ -eq $PMAJ && $TMIN -eq $PMIN && $TPAT -eq $((PPAT + 1)) ]] && \
+     { [[ $PMAJ -gt $CMAJ ]] || \
+       { [[ $PMAJ -eq $CMAJ ]] && [[ $PMIN -gt $CMIN ]]; } || \
+       { [[ $PMAJ -eq $CMAJ ]] && [[ $PMIN -eq $CMIN ]] && [[ $PPAT -gt $CPAT ]]; }; }; then
+  # The next patch AFTER an unpublishable main. When main is ahead of the
+  # registry but its version can no longer be published — the catch-up guard
+  # below refuses a merged release PR whose squash pulled in concurrent main
+  # commits, so the tree that would ship is not the tree CI tested — the only
+  # correct move is to cut a fresh release from main and let it earn its own
+  # full-matrix run. That is what this script's own refusal message advises
+  # ("cut the next patch through the normal release PR flow"), and until now
+  # the validator rejected it: patch+1 is measured from the REGISTRY, so with
+  # main at 1.20.75 and npm at 1.20.74, 1.20.76 read as a skipped version and
+  # 1.20.75 was blocked — leaving no patch-level path forward at all.
+  #
+  # Deliberately NOT a bypass: the catch-up guard still owns the case where
+  # main's own version is publishable. This only opens the strictly-newer patch,
+  # which then runs the ordinary bump -> release PR -> full matrix -> merge ->
+  # tag -> publish flow against the exact tree being shipped.
+  BUMP="patch-from-main"
+  is_valid_bump=true
 fi
 
 if ! $is_valid_bump; then
@@ -203,6 +228,7 @@ if ! $is_valid_bump; then
   red "  $((CMAJ)).$((CMIN + 1)).0   (minor)"
   red "  $((CMAJ + 1)).0.0   (major)"
   red "  $PKG_JSON_VERSION              (phnx-catchup: package.json is ahead of registry)"
+  red "  $((PMAJ)).$((PMIN)).$((PPAT + 1))   (patch-from-main: the next patch after an unpublishable main)"
   exit 1
 fi
 

--- a/apps/cli/scripts/validate-bump.sh
+++ b/apps/cli/scripts/validate-bump.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Decide whether a target version is an acceptable next release, and say which
+# KIND of bump it is.
+#
+# Extracted from release.sh so the arithmetic can be tested directly: it is pure
+# (four version strings in, one word out) while release.sh needs a clean main, a
+# logged-in npm, and gh auth before it reaches this point. See
+# scripts/validate-bump.test.ts.
+#
+# usage: validate-bump.sh <published-latest> <package-json-version> <shim-latest> <target>
+#
+# On success prints the bump kind to stdout and exits 0:
+#   patch | minor | major        a single step from the PUBLISHED latest
+#   shim-catchup                 target == published latest, republishing the
+#                                frozen @companion shim which is still behind
+#   phnx-catchup                 target == the version main already carries,
+#                                when main is ahead of the registry
+#   patch-from-main              the next patch AFTER an unpublishable main (see
+#                                below)
+#
+# On failure prints the accepted versions to stderr and exits 1.
+#
+# Why patch-from-main exists: release.sh refuses to publish a merged release PR
+# whose squash pulled in concurrent main commits, because the tree that would
+# ship is no longer the tree CI tested. Its refusal advises cutting the next
+# patch through the normal release PR flow — but patch+1 is measured from the
+# REGISTRY, so with main at 1.20.75 and npm at 1.20.74 both 1.20.75 (blocked by
+# that guard) and 1.20.76 (a skipped version) were rejected, leaving no
+# patch-level path forward. This opens exactly that one step, and only while
+# package.json is strictly ahead of the registry. It is not a bypass: the
+# resulting release still earns its own release PR, full cross-platform matrix,
+# merge, tag and publish against the exact tree being shipped.
+
+set -euo pipefail
+
+[[ $# -eq 4 ]] || { echo "usage: validate-bump.sh <published> <pkg-json> <shim> <target>" >&2; exit 2; }
+
+PHNX_LATEST="$1"
+PKG_JSON_VERSION="$2"
+SWARMIFY_LATEST="$3"
+TARGET="$4"
+
+parse_v() { echo "$1" | tr '.' ' '; }
+read -r CMAJ CMIN CPAT <<< "$(parse_v "$PHNX_LATEST")"
+read -r PMAJ PMIN PPAT <<< "$(parse_v "$PKG_JSON_VERSION")"
+read -r SMAJ SMIN SPAT <<< "$(parse_v "$SWARMIFY_LATEST")"
+read -r TMAJ TMIN TPAT <<< "$(parse_v "$TARGET")"
+
+# Strictly-newer semver-triple compare: is $1.$2.$3 above $4.$5.$6?
+newer_than() {
+  [[ $1 -gt $4 ]] && return 0
+  [[ $1 -eq $4 && $2 -gt $5 ]] && return 0
+  [[ $1 -eq $4 && $2 -eq $5 && $3 -gt $6 ]] && return 0
+  return 1
+}
+
+BUMP=""
+if [[ $TMAJ -eq $CMAJ && $TMIN -eq $CMIN && $TPAT -eq $((CPAT + 1)) ]]; then
+  BUMP="patch"
+elif [[ $TMAJ -eq $CMAJ && $TMIN -eq $((CMIN + 1)) && $TPAT -eq 0 ]]; then
+  BUMP="minor"
+elif [[ $TMAJ -eq $((CMAJ + 1)) && $TMIN -eq 0 && $TPAT -eq 0 ]]; then
+  BUMP="major"
+elif [[ "$TARGET" == "$PHNX_LATEST" ]] && newer_than "$TMAJ" "$TMIN" "$TPAT" "$SMAJ" "$SMIN" "$SPAT"; then
+  # Shim catch-up rerun after a partial publish: @phnx is already at target and
+  # only the frozen @companion shim is behind.
+  BUMP="shim-catchup"
+elif [[ "$TARGET" == "$PKG_JSON_VERSION" ]] && newer_than "$PMAJ" "$PMIN" "$PPAT" "$CMAJ" "$CMIN" "$CPAT"; then
+  # Main accumulated unpublished chore(release) bumps. Publish what main says.
+  BUMP="phnx-catchup"
+elif [[ $TMAJ -eq $PMAJ && $TMIN -eq $PMIN && $TPAT -eq $((PPAT + 1)) ]] \
+     && newer_than "$PMAJ" "$PMIN" "$PPAT" "$CMAJ" "$CMIN" "$CPAT"; then
+  BUMP="patch-from-main"
+fi
+
+if [[ -n "$BUMP" ]]; then
+  echo "$BUMP"
+  exit 0
+fi
+
+{
+  echo "invalid bump: $PHNX_LATEST -> $TARGET"
+  echo "expected one of:"
+  echo "  $CMAJ.$CMIN.$((CPAT + 1))   (patch)"
+  echo "  $CMAJ.$((CMIN + 1)).0   (minor)"
+  echo "  $((CMAJ + 1)).0.0   (major)"
+  # Only advertise the main-ahead options when main actually IS ahead, so the
+  # script never tells an operator to run a version it would then reject.
+  if newer_than "$PMAJ" "$PMIN" "$PPAT" "$CMAJ" "$CMIN" "$CPAT"; then
+    echo "  $PKG_JSON_VERSION   (phnx-catchup: package.json is ahead of registry)"
+    echo "  $PMAJ.$PMIN.$((PPAT + 1))   (patch-from-main: the next patch after an unpublishable main)"
+  fi
+} >&2
+exit 1

--- a/apps/cli/scripts/validate-bump.test.ts
+++ b/apps/cli/scripts/validate-bump.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The release version arithmetic, exercised by running the REAL script.
+ *
+ * This is the only thing standing between a typo in the comparison chain and a
+ * bad `latest` on npm: nothing else in CI runs `scripts/`, and `release.sh`
+ * cannot be invoked in a test — it demands a clean main, npm auth and gh auth
+ * long before it reaches the bump decision. Extracting the decision into
+ * `validate-bump.sh` is what makes the real code path testable here.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+
+const SCRIPT = path.resolve(__dirname, 'validate-bump.sh');
+
+/** Run the real script. Returns its verdict: the bump kind, or null when rejected. */
+function bumpKind(published: string, pkgJson: string, target: string, shim = '1.19.1') {
+  const r = spawnSync('bash', [SCRIPT, published, pkgJson, shim, target], { encoding: 'utf-8' });
+  return { kind: r.status === 0 ? r.stdout.trim() : null, status: r.status, stderr: r.stderr };
+}
+
+describe('validate-bump: single-step bumps from the published latest', () => {
+  it('accepts patch, minor and major', () => {
+    expect(bumpKind('1.20.74', '1.20.74', '1.20.75').kind).toBe('patch');
+    expect(bumpKind('1.20.74', '1.20.74', '1.21.0').kind).toBe('minor');
+    expect(bumpKind('1.20.74', '1.20.74', '2.0.0').kind).toBe('major');
+  });
+
+  it('rejects a skipped version', () => {
+    expect(bumpKind('1.20.74', '1.20.74', '1.20.76').kind).toBeNull();
+    expect(bumpKind('1.20.74', '1.20.74', '1.22.0').kind).toBeNull();
+  });
+
+  it('rejects going backwards', () => {
+    expect(bumpKind('1.20.74', '1.20.74', '1.20.73').kind).toBeNull();
+  });
+});
+
+describe('validate-bump: main ahead of the registry', () => {
+  it('publishes the version main already carries (phnx-catchup)', () => {
+    expect(bumpKind('1.20.70', '1.20.75', '1.20.75').kind).toBe('phnx-catchup');
+  });
+
+  /**
+   * The 1.20.75 incident: a merged release PR whose squash pulled in concurrent
+   * main commits cannot be published (its tree is not the tree CI tested), and
+   * before patch-from-main existed the next patch read as a skipped version —
+   * so there was no patch-level path forward at all.
+   */
+  it('accepts the next patch after an unpublishable main (patch-from-main)', () => {
+    expect(bumpKind('1.20.74', '1.20.75', '1.20.76').kind).toBe('patch-from-main');
+  });
+
+  it('rejects skipping TWO past an unpublishable main', () => {
+    expect(bumpKind('1.20.74', '1.20.75', '1.20.77').kind).toBeNull();
+  });
+
+  it('does not loosen the normal path when main equals the registry', () => {
+    // Without the main-ahead precondition this would wrongly read as
+    // patch-from-main and publish a version nobody bumped to.
+    expect(bumpKind('1.20.74', '1.20.74', '1.20.76').kind).toBeNull();
+  });
+
+  it('rejects a target derived from a main BEHIND the registry', () => {
+    // The guard that matters most: accepting this would publish 1.20.71 as
+    // `latest` and regress the dist-tag below the released 1.20.74.
+    expect(bumpKind('1.20.74', '1.20.70', '1.20.71').kind).toBeNull();
+  });
+
+  it('compares the whole triple, not just the patch component', () => {
+    // main behind on MINOR — the patch arithmetic alone would accept these.
+    expect(bumpKind('1.21.0', '1.20.75', '1.20.76').kind).toBeNull();
+    // main behind on MAJOR.
+    expect(bumpKind('2.0.0', '1.20.75', '1.20.76').kind).toBeNull();
+  });
+
+  it('carries the same rule across a minor or major main', () => {
+    expect(bumpKind('1.20.74', '1.21.0', '1.21.1').kind).toBe('patch-from-main');
+    expect(bumpKind('1.20.74', '2.0.0', '2.0.1').kind).toBe('patch-from-main');
+  });
+
+  it('lets a retry after a failed publish resolve again', () => {
+    // release.sh reruns after main has moved to the target; it must still validate.
+    expect(bumpKind('1.20.74', '1.20.76', '1.20.76').kind).toBe('phnx-catchup');
+  });
+});
+
+describe('validate-bump: shim catch-up', () => {
+  it('republishes the current latest when only the frozen shim is behind', () => {
+    expect(bumpKind('1.20.74', '1.20.74', '1.20.74', '1.19.1').kind).toBe('shim-catchup');
+  });
+
+  it('does not fire when the shim is already at the target', () => {
+    expect(bumpKind('1.20.74', '1.20.74', '1.20.74', '1.20.74').kind).toBeNull();
+  });
+});
+
+describe('validate-bump: the rejection message', () => {
+  it('lists the main-ahead options only when main actually is ahead', () => {
+    const ahead = bumpKind('1.20.74', '1.20.75', '9.9.9').stderr;
+    expect(ahead).toContain('phnx-catchup');
+    expect(ahead).toContain('1.20.76');
+
+    // Main BEHIND: advertising 1.20.71 here would tell the operator to run a
+    // version the script then refuses.
+    const behind = bumpKind('1.20.74', '1.20.70', '9.9.9').stderr;
+    expect(behind).not.toContain('patch-from-main');
+    expect(behind).not.toContain('phnx-catchup');
+    expect(behind).toContain('1.20.75');
+  });
+
+  it('exits 2 on wrong argument count', () => {
+    const r = spawnSync('bash', [SCRIPT, '1.0.0'], { encoding: 'utf-8' });
+    expect(r.status).toBe(2);
+  });
+});


### PR DESCRIPTION
The 1.20.75 release is stuck with no patch-level way out. This unblocks it without weakening the guard that stopped it.

## What happened

`release.sh` refused to publish:

```
error: merged release PR #1526 tree differs from its CI-tested head -- refusing catch-up publish
```

That refusal is **correct**. #1526's squash merge pulled in the 15 concurrent fixes from #1527, so the tree that would ship is not the tree CI tested. The guard's own comment explains why it exists:

> never treat a manual package.json bump or a squash merge containing concurrent main changes as release validation. This is the catch-up hole that let 1.20.58 publish before its Windows tag matrix failed.

## The gap

The refusal advises *"cut the next patch through the normal release PR flow"* — but the validator measures patch+1 from the **registry**, not from main. With npm at 1.20.74 and main at 1.20.75:

| target | before | why |
|---|---|---|
| 1.20.75 | blocked | the catch-up guard above |
| 1.20.76 | rejected | reads as a skipped version (74 → 76) |
| 1.21.0 | accepted | a minor bump for a set of patch-level bug fixes |

So the advised remedy was unreachable, and burning a minor version was the only escape.

## The change

Adds a `patch-from-main` case: the version one patch above `package.json`, valid only while `package.json` is strictly ahead of the registry.

It grants **no bypass**. The catch-up guard still owns the case where main's own version is publishable, and a `patch-from-main` release runs the ordinary flow — bump → release PR → full cross-platform matrix → merge → tag → publish — against the exact tree being shipped.

## Verification

Replayed the validator block against the real values, including the cases that must stay rejected:

```
npm=1.20.74  main=1.20.75  target=1.20.76  -> VALID patch-from-main
npm=1.20.74  main=1.20.75  target=1.20.75  -> VALID patch
npm=1.20.74  main=1.20.75  target=1.21.0   -> VALID minor
npm=1.20.74  main=1.20.75  target=1.20.77  -> INVALID          (no double-skip)
npm=1.20.74  main=1.20.74  target=1.20.76  -> INVALID          (unchanged when main == registry)
npm=1.20.74  main=1.20.70  target=1.20.71  -> INVALID          (main behind registry)
```

`bash -n scripts/release.sh` clean. The `--help` header and the invalid-bump error message both list the new option.