### PR TITLE
release(factory): 0.9.299 — reconnect, detach/attach, watchdog, agents-dbg pipeline

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.299] - 2026-08-01
+
 - **The extension no longer runs its own stall-detection/nudge injector — the
   agents-cli daemon watchdog is the sole injector.** The extension's autonomous
   watchdog tick used to `fs.stat` each agent session file, call a Claude Haiku

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.295",
+  "version": "0.9.299",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",


### PR DESCRIPTION
Replaces #1535 (which conflicted after main advanced). Same release, rebased onto latest main so it also sweeps in the watchdog stall-detection-removal bullet.

## Ships in 0.9.299
- Reconnect resilience (#1502) — dropped SSH no longer kills running agents; detached tmux sessions re-attach on reconnect.
- Detach / Attach commands.
- Extension no longer runs its own stall-detection/nudge injector (daemon watchdog is sole injector).
- agents-dbg 0.1.0 Mac release pipeline.

## Changes
- `apps/factory/CHANGELOG.md`: `[Unreleased]` → `[0.9.299] - 2026-08-01`
- `apps/factory/package.json`: → 0.9.299

Publish to Marketplace/Open VSX runs from zion (Touch-ID-gated tokens).