### PR TITLE
fix(test): close the sessions DB before removing the temp home

### DIFF
--- a/apps/cli/src/commands/sessions-resolve-db.test.ts
+++ b/apps/cli/src/commands/sessions-resolve-db.test.ts
@@ -23,7 +23,7 @@ const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-resolve-'));
 process.env.HOME = TEST_HOME;
 process.env.USERPROFILE = TEST_HOME;
 
-const { upsertSession } = await import('../lib/session/db.js');
+const { upsertSession, closeDB } = await import('../lib/session/db.js');
 const { resolveSessionQuery } = await import('./sessions.js');
 type SessionMeta = import('../lib/session/types.js').SessionMeta;
 
@@ -43,7 +43,13 @@ function meta(id: string, extra: Partial<SessionMeta> = {}): SessionMeta {
   };
 }
 
-afterAll(() => fs.rmSync(TEST_HOME, { recursive: true, force: true }));
+afterAll(() => {
+  // Close before removing the tree: Windows refuses to unlink an open file, so
+  // a leaked connection (plus its WAL sidecars) fails the whole suite there with
+  // EBUSY before a single assertion is reported.
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
 
 describe('resolveSessionQuery falls back to the index for a complete id', () => {
   const indexed = 'a7c1d88d-b543-48c1-993d-dd5cd8e210c9';


### PR DESCRIPTION
Unblocks the 1.20.76 release. `release.sh` fail-closed on PR #1541 with both Windows legs red.

## The failure

```
FAIL src/commands/sessions-resolve-db.test.ts [ src/commands/sessions-resolve-db.test.ts ]
Error: EBUSY: resource busy or locked, unlink
  'C:\Users\RUNNER~1\AppData\Local\Temp\agents-cli-resolve-jekGh0\.agents\.history\sessions\sessions.db'
```

The suite opens the real index under a temp HOME and then `rmSync`s the tree without closing the connection. POSIX allows unlinking an open file; Windows does not, so the whole suite fails to load — 4 tests, 0 assertions reported.

The file already sets `USERPROFILE` alongside `HOME`, so only the handle was missing.

## Third recurrence

Same pattern fixed for five other suites in #1527, and this is the second time it has fail-closed a release. The idiom that works is in `session/__tests__/db.test.ts` — `closeDB()` **then** `rmSync`.

Worth a follow-up guard: nothing stops the next new suite from reintroducing it, because it is invisible on macOS and Linux and the cross-platform matrix only runs on `release/**` branches — so it surfaces at release time, not at PR time. Filing that separately rather than widening this PR.

## Verification

`tsc --noEmit` clean; `sessions-resolve-db.test.ts` 4/4 locally. The Windows proof is the matrix on the next release branch, which is what caught it.