### PR TITLE
feat(sessions): attribute the initiating device for ssh-launched sessions

### DIFF
--- a/apps/cli/.changelog/next/session-ssh-origin.md
+++ b/apps/cli/.changelog/next/session-ssh-origin.md
@@ -1,0 +1,12 @@
+- **`agents sessions --active` attributes the initiating device for SSH-launched
+  sessions.** A session started by ssh'ing into a box (common for tmux-hosted
+  runs) used to render as `local` with no origin, because the tmux discovery path
+  stamped a `transport:'local'` placeholder that made provenance enrichment skip
+  it. Enrichment now probes the pane process's env and upgrades the row to `ssh`
+  with the real origin, then resolves the SSH client IP against the device
+  registry into `provenance.origin` (`{ device, user? }`). Both the flat listing
+  and the interactive browser read `ssh←<device>` (e.g. `ssh←zion`); an
+  unregistered IP stays bare `ssh`. Answers "which box launched this session"
+  without scraping `ps`/`who`/`tailscale`. Source:
+  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/lib/session/provenance.ts`,
+  `apps/cli/src/commands/sessions.ts`, `apps/cli/src/commands/sessions-browser.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,19 +2,6 @@
 
 ## 1.20.75
 
-- **`agents sessions --active` attributes the initiating device for
-  SSH-launched sessions.** A session started by ssh'ing into a box (common for
-  tmux-hosted runs) used to render as `local` with no origin, because the tmux
-  discovery path stamped a `transport:'local'` placeholder that made provenance
-  enrichment skip it (`apps/cli/src/lib/session/active.ts`). Enrichment now
-  probes the pane process's env and upgrades the row to `ssh` with the real
-  origin, then resolves the SSH client IP against the device registry into
-  `provenance.origin` (`{ device, user? }`). The row reads `ssh←<device>` (e.g.
-  `ssh←zion`); an unregistered IP stays bare `ssh`. Answers "which box launched
-  this session" without scraping `ps`/`who`/`tailscale`. Source:
-  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/lib/session/provenance.ts`,
-  `apps/cli/src/commands/sessions.ts`.
-
 - **Wire native file-based slash commands for Grok (RUSH-1851).** Grok >= 0.2.111
 discovers commands from the cross-agent `~/.agents/commands/` dir (plus the
 legacy `~/.claude/commands/` symlink). `agents sync grok` now writes native

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 1.20.75
 
+- **`agents sessions --active` attributes the initiating device for
+  SSH-launched sessions.** A session started by ssh'ing into a box (common for
+  tmux-hosted runs) used to render as `local` with no origin, because the tmux
+  discovery path stamped a `transport:'local'` placeholder that made provenance
+  enrichment skip it (`apps/cli/src/lib/session/active.ts`). Enrichment now
+  probes the pane process's env and upgrades the row to `ssh` with the real
+  origin, then resolves the SSH client IP against the device registry into
+  `provenance.origin` (`{ device, user? }`). The row reads `ssh←<device>` (e.g.
+  `ssh←zion`); an unregistered IP stays bare `ssh`. Answers "which box launched
+  this session" without scraping `ps`/`who`/`tailscale`. Source:
+  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/lib/session/provenance.ts`,
+  `apps/cli/src/commands/sessions.ts`.
+
 - **Wire native file-based slash commands for Grok (RUSH-1851).** Grok >= 0.2.111
 discovers commands from the cross-agent `~/.agents/commands/` dir (plus the
 legacy `~/.claude/commands/` symlink). `agents sync grok` now writes native

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -36,6 +36,15 @@ So "was this agent started on the host by a remote user?" is answerable for any
 event, not just runs. The write is a synchronous single-line append (durable
 before the action proceeds); `AGENTS_DISABLE_EVENT_LOG=1` turns it off.
 
+`agents sessions --active` carries the same SSH origin on each live session's
+`provenance` (including tmux-hosted panes, whose launch env is read from the pane
+process) and resolves the client IP against the device registry into
+`provenance.origin` (`{ device, user? }`). The row then reads `ssh←<device>`
+(e.g. `ssh←zion`) instead of a bare `ssh`, so "which box launched this session"
+is answerable without scraping `ps`/`who`/`tailscale`. An IP that matches no
+registered device stays bare `ssh` — the raw `provenance.ssh.clientIp` is still
+present.
+
 ### Actor provenance — which *human* is behind a run
 
 `osUser` answers "which OS account", but on a shared fleet that is one account for

--- a/apps/cli/src/commands/__tests__/sessions-columns.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-columns.test.ts
@@ -87,6 +87,22 @@ describe('formatPickerLabel', () => {
     const off = strip(formatPickerLabel(meta({ machine: 'yosemite-s0' }), '', { showMachine: false }));
     expect(off).not.toContain('s0');
   });
+
+  it('tags the row with ssh←<device> when the live session was launched over ssh', () => {
+    const row = strip(formatPickerLabel(meta(), '', {}, { device: 'zion' }));
+    expect(row).toContain('ssh←zion');
+  });
+
+  it('shows a bare ssh tag when the origin IP did not match a registered device', () => {
+    const row = strip(formatPickerLabel(meta(), '', {}, {}));
+    expect(row).toContain('ssh');
+    expect(row).not.toContain('ssh←');
+  });
+
+  it('adds no ssh tag for a local (non-ssh) session', () => {
+    const row = strip(formatPickerLabel(meta(), '', {}));
+    expect(row).not.toContain('ssh');
+  });
 });
 
 describe('formatPickerLabel width fits the gutter (no wrap)', () => {

--- a/apps/cli/src/commands/__tests__/sessions-columns.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-columns.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import chalk from 'chalk';
 import { ticketLabel, machineLabeler, formatPickerLabel, formatPickerTip } from '../sessions.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
@@ -91,6 +92,23 @@ describe('formatPickerLabel', () => {
   it('tags the row with ssh←<device> when the live session was launched over ssh', () => {
     const row = strip(formatPickerLabel(meta(), '', {}, { device: 'zion' }));
     expect(row).toContain('ssh←zion');
+  });
+
+  it('renders the ssh←<device> tag in red, not folded into the whitened topic', () => {
+    // Regression: the tag used to be concatenated into the topic string, which
+    // renderTopicCell strips of ANSI and re-wraps in white — silently dropping
+    // the red. Force colour on so the assertion is deterministic across CI/TTY.
+    const prev = chalk.level;
+    chalk.level = Math.max(prev, 1) as 0 | 1 | 2 | 3;
+    try {
+      const raw = formatPickerLabel(meta(), '', {}, { device: 'zion' });
+      // chalk.red opens with \x1b[31m; it must sit immediately on the tag text,
+      // not be replaced by the topic cell's white (\x1b[37m).
+      expect(raw).toContain('\x1b[31mssh←zion');
+      expect(strip(raw)).toContain('ssh←zion');
+    } finally {
+      chalk.level = prev;
+    }
   });
 
   it('shows a bare ssh tag when the origin IP did not match a registered device', () => {

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -22,6 +22,7 @@ import { buildPreview } from './sessions-picker.js';
 import {
   formatPickerLabel,
   pickerColumnsFor,
+  type SshOriginTag,
   ticketLabel,
   mergeLocalFirst,
   indexActiveBySessionId,
@@ -247,6 +248,16 @@ function applyFilters(
   return out;
 }
 
+/** Derive the SSH-launch origin tag for a picker row from the live index. Set
+ * only when the live session's provenance is ssh transport; `device` is the
+ * resolved origin device (absent → the row shows a bare `ssh`). Rows without a
+ * live entry (the running filter off) get no tag — provenance is live-only. */
+function sshOriginTagFor(live: Map<string, ActiveSession> | null, id: string): SshOriginTag | undefined {
+  const p = live?.get(id)?.provenance;
+  if (p?.transport !== 'ssh') return undefined;
+  return p.origin?.device ? { device: p.origin.device } : {};
+}
+
 function headerFor(f: BrowserFilter): string {
   const bits = [
     `device:${f.device ?? 'all'}`,
@@ -340,7 +351,7 @@ export async function runSessionBrowser(
     initialFilter,
     load,
     keyFor: (s) => s.id,
-    labelFor: (s, q) => formatPickerLabel(s, q, cols),
+    labelFor: (s, q) => formatPickerLabel(s, q, cols, sshOriginTagFor(liveCache, s.id)),
     matches: sessionMatchesQuery,
     buildPreview,
     headerFor,

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1795,6 +1795,13 @@ function renderTopicCell(
 }
 
 /** Column-visibility flags for the picker row, computed once over the whole pool. */
+/** The SSH-launch origin for a picker row, resolved from the live session's
+ * provenance (transport 'ssh'). `device` is set when the client IP matched a
+ * registered device; absent for an unresolved IP (renders a bare `ssh`). */
+export interface SshOriginTag {
+  device?: string;
+}
+
 export interface PickerColumns {
   /** Render the machine column (only when the pool spans more than one machine). */
   showMachine?: boolean;
@@ -1865,11 +1872,19 @@ export function pickerColumnsFor(sessions: SessionMeta[]): PickerColumns {
   };
 }
 
-export function formatPickerLabel(s: SessionMeta, query: string, cols: PickerColumns = {}): string {
+export function formatPickerLabel(
+  s: SessionMeta,
+  query: string,
+  cols: PickerColumns = {},
+  ssh?: SshOriginTag,
+): string {
   const agentColor = colorAgent(s.agent);
   const when = formatRelativeTime(s.lastActivity ?? s.timestamp);
   const project = s.project || '-';
-  const tag = originTag(s) || teamTag(s);
+  // SSH-launch origin (live rows only): mirrors the flat listing's `ssh←<device>`
+  // token — prepended as a topic tag so the width-budgeted columns stay aligned.
+  const sshTag = ssh ? chalk.red(ssh.device ? `ssh←${ssh.device} ` : 'ssh ') : '';
+  const tag = `${sshTag}${originTag(s) || teamTag(s)}`;
   const label = (s as any).label;
   const topic = tag ? `${tag}${s.topic ?? ''}` : s.topic;
   const versionStr = s.version || '-';

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1882,9 +1882,14 @@ export function formatPickerLabel(
   const when = formatRelativeTime(s.lastActivity ?? s.timestamp);
   const project = s.project || '-';
   // SSH-launch origin (live rows only): mirrors the flat listing's `ssh←<device>`
-  // token — prepended as a topic tag so the width-budgeted columns stay aligned.
-  const sshTag = ssh ? chalk.red(ssh.device ? `ssh←${ssh.device} ` : 'ssh ') : '';
-  const tag = `${sshTag}${originTag(s) || teamTag(s)}`;
+  // badge. Rendered as its OWN red segment before the topic cell — folding it into
+  // the topic string loses the colour, because renderTopicCell strips ANSI and
+  // re-whitens every slice. Its width is reserved from the topic budget below
+  // (exactly like `wt`), so the fixed-width columns stay aligned.
+  const sshPlain = ssh ? (ssh.device ? `ssh←${ssh.device} ` : 'ssh ') : '';
+  const sshSeg = sshPlain ? chalk.red(sshPlain) : '';
+  const sshW = sshPlain ? stringWidth(sshPlain) : 0;
+  const tag = originTag(s) || teamTag(s);
   const label = (s as any).label;
   const topic = tag ? `${tag}${s.topic ?? ''}` : s.topic;
   const versionStr = s.version || '-';
@@ -1909,7 +1914,7 @@ export function formatPickerLabel(
   const wtW = wt ? stringWidth(wt) + 1 : 0;
   const topicW = Math.max(
     16,
-    terminalWidth() - gutter - (10 + 9 + 8 + 16) - machineColW - ticketW - wtW - stringWidth(when) - 1,
+    terminalWidth() - gutter - (10 + 9 + 8 + 16) - machineColW - ticketW - wtW - sshW - stringWidth(when) - 1,
   );
 
   return (
@@ -1918,6 +1923,7 @@ export function formatPickerLabel(
     chalk.yellow(padRight(truncate(versionStr, 7), 8)) +
     machineCell +
     chalk.cyan(padRight(truncate(project, 14), 16)) +
+    sshSeg +
     renderTopicCell(label, topic, query, topicW, topicW) +
     ticketCell +
     (wt ? wt + ' ' : '') +

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -449,7 +449,9 @@ function signalBadges(s: Pick<ActiveSession, 'awaitingReason' | 'pr' | 'worktree
 function locatorBadge(s: ActiveSession): string {
   const p = s.provenance;
   const parts: string[] = [];
-  if (p?.transport === 'ssh') parts.push(chalk.red('ssh'));
+  // An ssh-launched session shows where it was launched FROM when the client IP
+  // resolves to a registered device (`ssh←zion`); bare `ssh` when it doesn't.
+  if (p?.transport === 'ssh') parts.push(chalk.red(p.origin ? `ssh←${p.origin.device}` : 'ssh'));
   if (p?.mux?.kind === 'tmux' && (s.tmuxTarget || p.mux.pane)) {
     parts.push(chalk.green(s.tmuxTarget ?? p.mux.pane!));
     // For a tmux-hosted session, say which app+tab is looking at it right now

--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, activeStatusFromCloudStatus, resolveFallbackStatus, resolvePaneIdentity } from './active.js';
+import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, activeStatusFromCloudStatus, resolveFallbackStatus, resolvePaneIdentity, matchOriginDevice } from './active.js';
 import type { HookSessionIndex } from './hook-sessions.js';
+import type { DeviceProfile, DeviceRegistry } from '../devices/registry.js';
 
 describe('resolvePaneIdentity (per-pane attribution for the authoritative tmux source)', () => {
   const emptyHook = (): HookSessionIndex => ({ byLaunchId: new Map(), byTerminalId: new Map(), byPid: new Map() });
@@ -171,5 +172,43 @@ describe('resolveCwds', () => {
     };
     const cwds = await resolveCwds(pids, probe);
     expect(cwds).toEqual(['cwd-5', 'cwd-4', 'cwd-3', 'cwd-2', 'cwd-1']);
+  });
+});
+
+describe('matchOriginDevice (resolve an ssh client IP to the initiating device)', () => {
+  const device = (name: string, over: Partial<DeviceProfile> = {}): DeviceProfile => ({
+    name,
+    platform: 'macos',
+    shell: 'posix',
+    address: { via: 'tailscale', ip: '100.0.0.1', dnsName: `${name}.tailnet.ts.net` },
+    auth: { method: 'key' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  });
+
+  const reg: DeviceRegistry = {
+    zion: device('zion', { user: 'muqsit', address: { via: 'tailscale', ip: '100.126.152.114', dnsName: 'zion.tailnet.ts.net' } }),
+    'yosemite-s0': device('yosemite-s0', { address: { via: 'tailscale', ip: '100.125.135.113' } }),
+    // A manually-added device with no resolvable IP must never match.
+    'no-ip': device('no-ip', { address: { via: 'manual' } }),
+  };
+
+  it('resolves a client IP to its device + ssh login user', () => {
+    expect(matchOriginDevice('100.126.152.114', reg)).toEqual({ device: 'zion', user: 'muqsit' });
+  });
+
+  it('omits user when the device has none', () => {
+    expect(matchOriginDevice('100.125.135.113', reg)).toEqual({ device: 'yosemite-s0' });
+  });
+
+  it('returns undefined for an IP that matches no device', () => {
+    expect(matchOriginDevice('10.0.0.99', reg)).toBeUndefined();
+  });
+
+  it('skips a device that has no IP address', () => {
+    // '' would falsely match a device whose address.ip is undefined if the guard
+    // were missing; assert the no-ip device is never returned.
+    expect(matchOriginDevice('', reg)).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -36,6 +36,7 @@ import { computeTokPerSec } from './throughput.js';
 import { inferSessionState, type SessionState, type SessionActivity, type AwaitingReason, type StructuredQuestion, type TodoProgress, type DetectedPr, type DetectedWorktree, type DetectedTicket } from './state.js';
 import type { SessionAttachment } from './types.js';
 import { detectProvenance, type SessionProvenance } from './provenance.js';
+import { loadDevices, type DeviceRegistry } from '../devices/registry.js';
 import { presenceFromStore, type Presence } from './detached.js';
 import { mapBounded } from '../concurrency.js';
 
@@ -1271,8 +1272,11 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
     const pidAlive = pid ? isPidAlive(pid, liveEntry?.startedAtMs) : true;
     const { state, tokPerSec } = computeLiveSignals(id.agent, sessionFile, cwd, pidAlive);
     const { birthtimeMs, mtimeMs } = sessionFileTimes(sessionFile);
-    // Provenance is known exactly here (the pane IS a tmux pane) — set it so
-    // enrichProvenance skips it and the locator/reply rails resolve off the pane.
+    // The mux/reply rails are known exactly here (the pane IS a tmux pane), so we
+    // stamp them off the pane. `transport:'local'` is only a placeholder: the pane
+    // can't reveal how the shell above it was reached. enrichProvenance later reads
+    // the pane process's env and upgrades this to 'ssh' (with the real origin) when
+    // SSH_CONNECTION is present, while preserving this mux/reply.
     const provenance: SessionProvenance = {
       host: os.hostname(),
       transport: 'local',
@@ -1323,6 +1327,7 @@ export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<
 
   const merged = dedupeBySession([...tmuxAgents, ...teams, ...terminals, ...cloud, ...unattributed]);
   await enrichProvenance(merged);
+  await resolveOrigins(merged);
   foldPresence(merged);
   return merged;
 }
@@ -1348,14 +1353,72 @@ function foldPresence(rows: ActiveSession[]): void {
  * each session once, not once per fork pid. Probes run in parallel — each is a
  * single /proc read (Linux) or `ps` call (macOS); failures leave `provenance`
  * undefined rather than blocking the listing.
+ *
+ * A row that already carries provenance (the tmux path, which knows its exact
+ * mux/reply from the pane) is not skipped — it is probe-and-MERGED. The tmux
+ * path can only stamp a `transport:'local'` placeholder because the pane alone
+ * doesn't reveal how the shell above it was reached; the process env does. So we
+ * still read the env and fill in the real SSH origin/term, while preserving the
+ * authoritative mux/reply the pane already gave us. Skipping this (the old
+ * behavior) is exactly why ssh-launched tmux sessions rendered as local.
  */
 async function enrichProvenance(sessions: ActiveSession[]): Promise<void> {
   await Promise.all(
     sessions.map(async (s) => {
-      if (s.provenance || !s.pid) return;
-      s.provenance = await detectProvenance(s.pid);
+      if (!s.pid) return;
+      const probed = await detectProvenance(s.pid);
+      if (!probed) return;
+      if (!s.provenance) {
+        s.provenance = probed;
+        return;
+      }
+      // Row already carries exact mux/reply (the tmux path). Fill only what a
+      // pre-set provenance can't know from the pane alone: the real launch origin.
+      if (probed.transport === 'ssh' && !s.provenance.ssh) {
+        s.provenance.transport = 'ssh';
+        s.provenance.ssh = probed.ssh;
+      }
+      if (probed.term && !s.provenance.term) s.provenance.term = probed.term;
     }),
   );
+}
+
+/**
+ * Match an SSH client IP to a registered device (pure — testable with a plain
+ * registry object). Returns the device name + ssh login user when the IP is a
+ * known device address.
+ */
+export function matchOriginDevice(
+  clientIp: string,
+  reg: DeviceRegistry,
+): { device: string; user?: string } | undefined {
+  for (const d of Object.values(reg)) {
+    if (d.address?.ip && d.address.ip === clientIp) {
+      return { device: d.name, ...(d.user ? { user: d.user } : {}) };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the initiating device for every ssh-transport session by matching its
+ * `ssh.clientIp` against the device registry. Read-only and best-effort: a
+ * registry that can't be loaded, or an IP that matches no device, leaves
+ * `origin` undefined (the raw client IP is still on `ssh`). Mutates in place.
+ */
+async function resolveOrigins(sessions: ActiveSession[]): Promise<void> {
+  const needing = sessions.filter((s) => s.provenance?.ssh && !s.provenance.origin);
+  if (needing.length === 0) return;
+  let reg: DeviceRegistry;
+  try {
+    reg = await loadDevices();
+  } catch {
+    return;
+  }
+  for (const s of needing) {
+    const match = matchOriginDevice(s.provenance!.ssh!.clientIp, reg);
+    if (match) s.provenance!.origin = match;
+  }
 }
 
 /**

--- a/apps/cli/src/lib/session/provenance.ts
+++ b/apps/cli/src/lib/session/provenance.ts
@@ -76,6 +76,10 @@ export interface SessionProvenance {
   mux?: MuxLocation;
   /** Whether an existing rail can type back into this session (see module doc). */
   reply: ReplyRail;
+  /** The initiating device, resolved at query time from ssh.clientIp against the
+   * device registry (ssh transport only). Answers "who launched this and from
+   * where" without scraping ps/who/tailscale. */
+  origin?: { device: string; user?: string };
 }
 
 /** Env vars that carry provenance. Kept small so the macOS `ps` scan stays cheap. */


### PR DESCRIPTION
## Problem

`agents sessions --active` could not tell you **which box launched an SSH session**. A session started by ssh'ing into a machine — the common case for tmux-hosted runs — rendered as `local` with no origin. You had to scrape `ps`/`who`/`tailscale` by hand to answer "who started this and from where."

## Root cause

The tmux discovery path stamps provenance directly off the pane and hardcodes `transport: 'local'` (`apps/cli/src/lib/session/active.ts:1276-1281`) — the pane alone can't reveal how the shell above it was reached. `enrichProvenance` then **skipped** any row that already had provenance (old `if (s.provenance || !s.pid) return`), so the env-based detector that reads `SSH_CONNECTION` (→ the real origin) and `TERM_PROGRAM` never ran for tmux sessions. Net: ssh-launched tmux sessions were mislabeled local, and nothing ever resolved the client IP to a device.

## What changed

- **`enrichProvenance` is now probe-and-merge, not skip.** It reads the pane process's env and upgrades a pre-set `local` row to `ssh` with the real origin/term, while preserving the authoritative `mux`/`reply` the pane already gave it.
- **New `matchOriginDevice(clientIp, reg)` + `resolveOrigins`** map `ssh.clientIp` against the device registry into `provenance.origin` = `{ device, user? }` (pure matcher, unit-tested).
- **Render**: an ssh row reads `ssh←<device>` (e.g. `ssh←zion`) when the IP resolves; bare `ssh` when it doesn't. Raw `provenance.ssh.clientIp` is still present either way.

## Live verification (on yosemite-s0)

Built the CLI and ran it against real sessions:

```
$ agents sessions --active --local        # human view
  10 rows: ssh←zion      3 rows: ssh

$ agents sessions --active --local --json  # 13 ssh rows
  clientIp=100.126.152.114 → origin={device: zion, user: muqsit}   (10 rows)
  clientIp=100.93.177.123  → origin=None                            (3 rows)
```

The 3 unresolved rows are `100.93.177.123` = `yosemite-s1`, which is **not** in the local device registry with that IP — so bare `ssh` is the honest fallback, not a matcher miss.

Tests: `active.test.ts` + `provenance.test.ts` — 41 passed (4 new `matchOriginDevice` cases: match→{device,user}, user-omitted, unmatched-ip→undefined, address-less device→undefined). `tsc --noEmit`: 0 errors.

## Follow-up (out of scope here)

- **Persist provenance + mode/interactive at spawn** (`exec.ts` / `hook.sh` / pid-registry). Today all provenance is recomputed per query and absent from the historical `sessions.db` (which stores only `{session_id, cwd, pid, ts}` per live record). Persisting it makes host/origin/mode answerable for *past* sessions too.
- **Expose `attached` (viewingIn) + `interactive` as first-class `--active --json` fields** — today attach-state is renderer-only and interactive is inferred from `context`.