### PR TITLE
fix(factory): keep floor cards contextual [RUSH-2031]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,13 @@
 
 ### Fixed
 
+- **Factory Floor cards keep their task context and their section counts agree.**
+  Cross-host sessions now recover the original task from `topic`, legacy `prompt`,
+  `firstUserMessage`, label, worktree, or branch before showing a clear `No topic`
+  placeholder. Background/headless runs are hidden by default and available through
+  the new **Background** feed toggle. One view-model partition now supplies both the
+  rendered Needs you / active / done cards and their displayed counts (RUSH-2031).
+
 - **`agents run <agent> --fallback …` no longer disables account rotation.**
   A `--fallback` chain skipped strategy resolution entirely ("strategy balanced
   ignored: --fallback pins versions directly"), so the bare primary always ran on

--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -71,7 +71,7 @@ Every open agent terminal is fully restorable. Session ID, icon, and custom labe
 
 ### Factory Floor
 
-The dashboard's mission control. A live grid of every agent on the floor — local IDE tabs, background teams, and cloud dispatches — beside your Linear cycle. Compose and dispatch work with the Cmd+K composer, drag issue cards onto agents, or send a ticket straight to the cloud.
+The dashboard's mission control. A live grid of interactive agents and cloud dispatches beside your Linear cycle. Background/headless runs are hidden by default; use the **Background** feed toggle when you need them. Compose and dispatch work with the Cmd+K composer, drag issue cards onto agents, or send a ticket straight to the cloud.
 
 Agent cards surface outputs such as PRs, spawned teams, created tickets, and plan
 artifacts. `.html` and `ref-*.md` plans detected in session output, worktree

--- a/apps/factory/src/core/remoteSessions.test.ts
+++ b/apps/factory/src/core/remoteSessions.test.ts
@@ -531,6 +531,18 @@ describe('normalizeActiveSession — topic', () => {
     );
     expect(cloud.topic).toBe('Read README and summarize');
     expect(cloud.label).toBe('Read README and summarize');
+    const legacy = normalizeActiveSession(
+      { kind: 'claude', status: 'running', prompt: 'Repair remote cards' } as RawActiveSession,
+      'yosemite-m0',
+      FETCHED_AT
+    );
+    expect(legacy.topic).toBe('Repair remote cards');
+    const firstMessage = normalizeActiveSession(
+      { kind: 'codex', status: 'running', firstUserMessage: 'Explain the background run' } as RawActiveSession,
+      'mac-mini',
+      FETCHED_AT
+    );
+    expect(firstMessage.topic).toBe('Explain the background run');
   });
 });
 

--- a/apps/factory/src/core/remoteSessions.ts
+++ b/apps/factory/src/core/remoteSessions.ts
@@ -299,6 +299,9 @@ export interface RawActiveSession {
   cwd?: string;
   label?: string;
   topic?: string;
+  /** Compatibility task fields emitted by older/alternate session producers. */
+  prompt?: string;
+  firstUserMessage?: string;
   sessionFile?: string;
   startedAtMs?: number;
   /** Transcript last-write epoch (ms) stamped by the CLI — the real activity signal. */
@@ -598,7 +601,7 @@ export function normalizeActiveSession(
     // hosts too. The local fan-out still re-stats as a fallback. Deliberately NOT
     // startedAtMs — start time is not activity.
     lastActivityMs: typeof raw.lastActivityMs === 'number' ? raw.lastActivityMs : 0,
-    topic: asStr(raw.topic) || asStr(raw.label),
+    topic: asStr(raw.topic) || asStr(raw.prompt) || asStr(raw.firstUserMessage) || asStr(raw.label),
     label: asStr(raw.label),
     sessionFile: asStr(raw.sessionFile),
     context: asStr(raw.context),

--- a/apps/factory/ui/settings/components/mission-control/SavedViewsBar.test.tsx
+++ b/apps/factory/ui/settings/components/mission-control/SavedViewsBar.test.tsx
@@ -33,6 +33,8 @@ describe('SavedViews feed header bar (RUSH-1526)', () => {
           abbrs: [],
           availableAbbrs: ['CC', 'CX'],
           onToggleAbbr: noop,
+          showBackground: false,
+          onToggleBackground: noop,
         }}
       />,
     )
@@ -43,6 +45,8 @@ describe('SavedViews feed header bar (RUSH-1526)', () => {
     expect(html).toContain('Project')
     expect(html).toContain('Needs you')
     expect(html).toContain('Running')
+    expect(html).toContain('Background')
+    expect(html).not.toContain('feed-header-background on')
     expect(html).toContain('feed-header-status on') // needs active
     expect(html).toContain('>CC<')
     expect(html).toContain('>CX<')
@@ -73,9 +77,12 @@ describe('SavedViews feed header bar (RUSH-1526)', () => {
           abbrs: ['CC'],
           availableAbbrs: ['CC', 'CX'],
           onToggleAbbr: noop,
+          showBackground: true,
+          onToggleBackground: noop,
         }}
       />,
     )
     expect(html).toContain('feed-header-agent on')
+    expect(html).toContain('feed-header-background on')
   })
 })

--- a/apps/factory/ui/settings/components/mission-control/SavedViewsBar.tsx
+++ b/apps/factory/ui/settings/components/mission-control/SavedViewsBar.tsx
@@ -47,6 +47,8 @@ interface SavedViewsProps {
     abbrs: AgentAbbr[]
     availableAbbrs: AgentAbbr[]
     onToggleAbbr: (a: AgentAbbr) => void
+    showBackground: boolean
+    onToggleBackground: () => void
   }
 }
 
@@ -153,6 +155,13 @@ export function SavedViews({
               </span>
             )
           })}
+          <span
+            className={`chip feed-header-background${feedFilters.showBackground ? ' on' : ''}`}
+            title={feedFilters.showBackground ? 'Hide background agents' : 'Show background agents'}
+            onClick={feedFilters.onToggleBackground}
+          >
+            Background
+          </span>
           {feedFilters.availableAbbrs.length > 0 && (
             <>
               <span className="sv-sep" aria-hidden="true" />

--- a/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
+++ b/apps/factory/ui/settings/components/mission-control/UnifiedAgentsPane.tsx
@@ -45,9 +45,11 @@ import {
   clusterByQuestion,
   sortAgents,
   groupAgents,
+  partitionFloorAgents,
   sessionTaskLine,
   ticketWorkers,
   projectRollups,
+  visibleFloorAgents,
   type FloorAgent,
   type FloorAttachment,
   type FloorTicket,
@@ -669,6 +671,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   const [hostPins, setHostPins] = useState<string[] | null>(floorPrefs0.hostPins)
   const [statusChips, setStatusChips] = useState<StatusChip[]>([])
   const [abbrChips, setAbbrChips] = useState<AgentAbbr[]>([])
+  const [showBackground, setShowBackground] = useState(false)
   const [savedViews, setSavedViews] = useState<SavedView[]>(() => loadSavedViews())
 
   const activeViewName = useMemo(() => {
@@ -1512,7 +1515,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
 
   // Center list scoped by project filter + host filter + status/agent chips + search.
   const scopedAgents = useMemo(() => {
-    let list = floorAgents
+    let list = visibleFloorAgents(floorAgents, showBackground)
     if (projFilter) list = list.filter((a) => a.project === projFilter)
     if (hostFilter) list = list.filter((a) => (a.hostLabel ?? a.host) === hostFilter)
     if (statusChips.length) list = list.filter((a) => statusChips.some((c) => (c === 'needs' ? a.needs : a.phase === c)))
@@ -1520,7 +1523,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     const q = floorSearch.trim().toLowerCase()
     if (q) list = list.filter((a) => `${a.name} ${a.branch} ${a.verb} ${a.target} ${a.project} ${a.host} ${a.hostLabel ?? ''}`.toLowerCase().includes(q))
     return list
-  }, [floorAgents, projFilter, hostFilter, statusChips, abbrChips, floorSearch])
+  }, [floorAgents, showBackground, projFilter, hostFilter, statusChips, abbrChips, floorSearch])
 
   // Empty host filter -> show that host's recent sessions instead of a blank pane.
   // Fetch once per host (lazily), then adapt through the SAME card path as live agents.
@@ -1554,7 +1557,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
     return buildRecap(recapSessions, liveIds, Date.now())
   }, [recapSessions, floorAgents])
 
-  const needsAgents = useMemo(() => scopedAgents.filter((a) => a.needs), [scopedAgents])
+  const feedPartition = useMemo(() => partitionFloorAgents(scopedAgents), [scopedAgents])
+  const needsAgents = feedPartition.needs
   const waitingAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'waiting'), [needsAgents])
   const failedAgents = useMemo(() => needsAgents.filter((a) => a.phase === 'failed'), [needsAgents])
   const questionClusters = useMemo(() => clusterByQuestion(waitingAgents), [waitingAgents])
@@ -1570,13 +1574,14 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
   // lane; done (without an unreviewed PR — those are NEEDS YOU) is the terminal
   // lane. idle is no longer dropped from the feed.
   const runningFeed = useMemo(
-    () => sortAgents(scopedAgents.filter((a) => !a.needs && (a.phase === 'running' || a.phase === 'idle')), floorSort),
-    [scopedAgents, floorSort]
+    () => sortAgents(feedPartition.active, floorSort),
+    [feedPartition, floorSort]
   )
   const doneFeed = useMemo(
-    () => sortAgents(scopedAgents.filter((a) => !a.needs && a.phase === 'done'), floorSort),
-    [scopedAgents, floorSort]
+    () => sortAgents(feedPartition.done, floorSort),
+    [feedPartition, floorSort]
   )
+  const groupedFeed = useMemo(() => [...runningFeed, ...doneFeed], [runningFeed, doneFeed])
 
   const floorRunning = useMemo(() => floorAgents.filter((a) => a.phase === 'running').length, [floorAgents])
   const floorTok = useMemo(() => floorAgents.reduce((s, a) => s + a.tok, 0) + liveThroughput, [floorAgents, liveThroughput])
@@ -2086,6 +2091,8 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
           onToggleAbbr: (a) => setAbbrChips((cur) => (
             cur.includes(a) ? cur.filter((c) => c !== a) : [...cur, a]
           )),
+          showBackground,
+          onToggleBackground: () => setShowBackground((current) => !current),
         }}
       />
       {(needsAgents.length > 0 || pendingPlans.length > 0) && (
@@ -2149,7 +2156,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
         </>
       )}
 
-      <div className="feed-sec">{floorGroup === 'none' ? `RUNNING · ${runningFeed.length}` : `GROUPED BY ${floorGroup.toUpperCase()}${floorSubgroup !== 'none' && floorSubgroup !== floorGroup ? ` / ${floorSubgroup.toUpperCase()}` : ''} · ${runningFeed.length + doneFeed.length}`}<span className="ln" />
+      <div className="feed-sec">{floorGroup === 'none' ? `RUNNING · ${runningFeed.length}` : `GROUPED BY ${floorGroup.toUpperCase()}${floorSubgroup !== 'none' && floorSubgroup !== floorGroup ? ` / ${floorSubgroup.toUpperCase()}` : ''} · ${groupedFeed.length}`}<span className="ln" />
         <span
           className={`fresh${syncingHosts ? ' syncing' : ''}${!syncingHosts && lastRemoteSync > 0 && nowMs - lastRemoteSync > 2 * REMOTE_POLL_MS ? ' stale' : ''}`}
           title="Last cross-host sync. Click to refresh now."
@@ -2179,7 +2186,7 @@ export function UnifiedAgentsPane({ terminals, tasks, tasksLoading, unifiedTasks
               onOpenTerminal={openTerminalForAgent}
             />
           ))
-        : [...groupAgents([...runningFeed, ...doneFeed], floorGroup).entries()].map(([k, arr]) => {
+        : [...groupAgents(groupedFeed, floorGroup).entries()].map(([k, arr]) => {
             // When grouped by project, enrich the header: "N agents" + a Linear project
             // link pill (mockup: "agents-cli · 8 agents · RUSH · Agents CLI").
             const projectPill = (axis: FloorGroupBy | 'none', key: string) => (

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.test.ts
@@ -815,6 +815,22 @@ describe('toFloorAgentFromRemote', () => {
     const a = toFloorAgentFromRemote(r, new Set())
     expect(a.name).toBe('Claude session')
     expect(a.name).not.toContain('019e30a2')
+    expect(a.summary).toBe('No topic')
+  })
+
+  test('uses a remote worktree slug as the task anchor when topic is absent', () => {
+    const r: RemoteSessionLike = {
+      host: 'yosemite-m0', sessionId: 'remote-1', agentType: 'codex',
+      cwd: '/home/u/src/app/.agents/worktrees/rush-2031-factory-floor', project: 'app',
+      phase: 'running', activity: '', tokPerSec: 0, waitingForInput: false,
+      lastResponse: '', prUrl: null, ticket: null, branch: 'rush-2031-factory-floor',
+      worktreeSlug: 'rush-2031-factory-floor', sinceMs: 0, startedAtMs: NOW,
+      topic: '', context: 'terminal', cloudTaskId: '', cloudProvider: '', teamName: '',
+      pid: 0, transport: 'ssh', replyRail: '', replyMuxTarget: '', replyMuxSocket: '', tmuxPane: '',
+    }
+    const a = toFloorAgentFromRemote(r, new Set())
+    expect(a.prompt).toBe('rush-2031-factory-floor')
+    expect(a.summary).toBe('rush-2031-factory-floor')
   })
 })
 

--- a/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorAdapter.ts
@@ -583,9 +583,14 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
   }
   const id = `remote-${r.host}-${r.sessionId}`
   const name = humanRemoteSessionName(r)
-  // Remote (Tier-1) sessions have no enriched last-response yet — fall back to the
-  // session's task line (topic) so the card shows what it's working on, not blank.
-  const resp = r.lastResponse || r.topic || ''
+  const taskAnchor = firstNonEmptyStr(
+    r.topic,
+    r.label,
+    r.worktreeSlug ? cleanWorktreeSlug(r.worktreeSlug) : undefined,
+    r.branch,
+    cleanWorktreeSlug(r.cwd),
+  )
+  const resp = r.lastResponse || ''
   // Cloud tasks run in a provider sandbox, not on the dispatching machine — the CLI
   // attributes them to the querier ('zion') for reply routing, but they should NOT
   // fold under that local host in the feed. Give them their own "Cloud" category.
@@ -639,7 +644,7 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     resp,
     // Remote (Tier-1) has no first-user-message enrichment yet — the session's task line
     // (topic) is the closest durable anchor for the original task.
-    prompt: r.topic || undefined,
+    prompt: taskAnchor,
     // Prefer the last few assistant turns from the CLI (context feed); fall back to the
     // single last response when the CLI supplied no tail.
     messages: r.tail && r.tail.length ? r.tail : r.lastResponse ? [r.lastResponse] : [],
@@ -652,7 +657,7 @@ export function toFloorAgentFromRemote(r: RemoteSessionLike, pinned: Set<string>
     todos: remoteTodos,
     // Remote = summary only: the sweep carries the session's task line (topic) / last
     // response but no tool calls yet, so progress stays empty until Tier-2 enrichment.
-    summary: r.topic || r.lastResponse || '',
+    summary: taskAnchor || r.lastResponse || 'No topic',
     recent: [],
     recentEvents: [],
     // tmux %pane handle + where it's being viewed, surfaced on the card.

--- a/apps/factory/ui/settings/components/mission-control/floorModel.fixes.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.fixes.test.ts
@@ -5,7 +5,9 @@ import {
   toFloorTicket,
   groupTickets,
   groupAgents,
+  partitionFloorAgents,
   sessionTaskLine,
+  visibleFloorAgents,
   worktreeSlugOf,
   type FloorAgent,
 } from './floorModel'
@@ -60,7 +62,15 @@ describe('issue 2 — one task-line seam', () => {
     expect(sessionTaskLine(agent({ resp: 'R', worktreeSlug: 'W' }))).toBe('R')
     expect(sessionTaskLine(agent({ worktreeSlug: 'headless-secrets-shadow', branch: 'b' }))).toBe('headless-secrets-shadow')
     expect(sessionTaskLine(agent({ branch: 'my/branch' }))).toBe('my/branch')
-    expect(sessionTaskLine(agent({}))).toBe('')
+    expect(sessionTaskLine(agent({}))).toBe('No topic')
+  })
+
+  test('background visibility is opt-in and section counts cover every visible card', () => {
+    const foreground = agent({ id: 'fg' })
+    const background = agent({ id: 'bg', context: 'headless' })
+    expect(visibleFloorAgents([foreground, background], false)).toEqual([foreground])
+    const partition = partitionFloorAgents([foreground])
+    expect(partition.needs.length + partition.active.length + partition.done.length).toBe(1)
   })
 
   test('worktreeSlugOf extracts the slug under .agents/worktrees/', () => {

--- a/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.test.ts
@@ -23,6 +23,8 @@ import {
   projectRollups,
   resolveProject,
   sessionTaskLine,
+  partitionFloorAgents,
+  visibleFloorAgents,
   todosWithFallback,
   linearIssueLabel,
   linearIssueUrl,
@@ -896,8 +898,31 @@ describe('sessionTaskLine — prompt anchors the card ahead of the drifting last
     expect(sessionTaskLine(makeAgent({ prompt: '   ', summary: 'real work' }))).toBe('real work')
   })
 
-  test('returns empty string when the agent carries no task signal at all', () => {
-    expect(sessionTaskLine(makeAgent({ prompt: undefined, summary: '', resp: '', worktreeSlug: '', branch: '' }))).toBe('')
+  test('returns a clear placeholder when the agent carries no task signal at all', () => {
+    expect(sessionTaskLine(makeAgent({ prompt: undefined, summary: '', resp: '', worktreeSlug: '', branch: '' }))).toBe('No topic')
+  })
+})
+
+describe('floor visibility and section counts', () => {
+  test('background agents are hidden by default and available through the toggle', () => {
+    const foreground = makeAgent({ id: 'foreground', context: 'terminal' })
+    const background = makeAgent({ id: 'background', context: 'headless' })
+    expect(visibleFloorAgents([foreground, background], false).map((a) => a.id)).toEqual(['foreground'])
+    expect(visibleFloorAgents([foreground, background], true).map((a) => a.id)).toEqual(['foreground', 'background'])
+  })
+
+  test('every rendered card belongs to exactly one counted section', () => {
+    const agents = [
+      makeAgent({ id: 'needs', needs: true, phase: 'waiting' }),
+      makeAgent({ id: 'running', phase: 'running' }),
+      makeAgent({ id: 'idle', phase: 'idle' }),
+      makeAgent({ id: 'done', phase: 'done' }),
+    ]
+    const sections = partitionFloorAgents(agents)
+    expect(sections.needs.map((a) => a.id)).toEqual(['needs'])
+    expect(sections.active.map((a) => a.id)).toEqual(['running', 'idle'])
+    expect(sections.done.map((a) => a.id)).toEqual(['done'])
+    expect(sections.needs.length + sections.active.length + sections.done.length).toBe(agents.length)
   })
 })
 

--- a/apps/factory/ui/settings/components/mission-control/floorModel.ts
+++ b/apps/factory/ui/settings/components/mission-control/floorModel.ts
@@ -465,15 +465,38 @@ function firstNonEmpty(...values: Array<string | null | undefined>): string | un
  * rail so no surface re-derives it or renders blank. Fallback chain: the ORIGINAL
  * task (prompt / first user message — the durable anchor), then the CLI summary /
  * live preview, then the last response, then the worktree slug or branch (a task
- * label when there's no narrative — e.g. "headless-secrets-shadow"). Returns '' when
- * the agent carries no task signal at all; callers that need an absolute fallback add
- * `|| a.name` (the card already shows the name separately, so it omits that).
+ * label when there's no narrative — e.g. "headless-secrets-shadow"). Returns the
+ * explicit "No topic" placeholder when the agent carries no task signal at all.
  *
  * prompt is preferred first so a card anchors to what the agent was ASKED to do, not
  * whatever it last said — the last message drifts as work progresses, the task doesn't.
  */
 export function sessionTaskLine(a: FloorAgent): string {
-  return firstNonEmpty(a.prompt, a.summary, a.resp, a.worktreeSlug, a.branch) ?? ''
+  return firstNonEmpty(a.prompt, a.summary, a.resp, a.worktreeSlug, a.branch) ?? 'No topic'
+}
+
+/** Background/headless runs stay available through an explicit toggle, but do
+ * not crowd out interactive operator work on the floor by default. */
+export function visibleFloorAgents(agents: FloorAgent[], showBackground: boolean): FloorAgent[] {
+  return showBackground ? agents : agents.filter((a) => a.context !== 'headless')
+}
+
+/** Partition every visible card exactly once so rendered sections and counts
+ * consume the same collections. */
+export function partitionFloorAgents(agents: FloorAgent[]): {
+  needs: FloorAgent[]
+  active: FloorAgent[]
+  done: FloorAgent[]
+} {
+  const needs: FloorAgent[] = []
+  const active: FloorAgent[] = []
+  const done: FloorAgent[] = []
+  for (const agent of agents) {
+    if (agent.needs) needs.push(agent)
+    else if (agent.phase === 'done') done.push(agent)
+    else active.push(agent)
+  }
+  return { needs, active, done }
 }
 
 /**

--- a/apps/factory/ui/settings/preview/preview.tsx
+++ b/apps/factory/ui/settings/preview/preview.tsx
@@ -279,6 +279,8 @@ function Feed() {
   const [grp, setGrp] = useState<FloorGroupBy | 'none'>('project')
   const [subgrp, setSubgrp] = useState<FloorGroupBy | 'none'>('host')
   const [srt, setSrt] = useState<'needs' | 'recent' | 'tok' | 'name'>('needs')
+  const [showBackground, setShowBackground] = useState(false)
+  const visibleRunning = showBackground ? running : running.filter((a) => a.context !== 'headless')
   return (
     <div className="feed">
       <FloorControls
@@ -303,6 +305,19 @@ function Feed() {
         onApply={noop}
         onSave={noop}
         onDelete={noop}
+        feedFilters={{
+          group: grp,
+          onGroup: setGrp,
+          subgroup: subgrp,
+          onSubgroup: setSubgrp,
+          status: [],
+          onToggleStatus: noop,
+          abbrs: [],
+          availableAbbrs: ['CC', 'CX', 'GX'],
+          onToggleAbbr: noop,
+          showBackground,
+          onToggleBackground: () => setShowBackground((current) => !current),
+        }}
       />
 
       <div className="feed-sec attn">
@@ -315,10 +330,10 @@ function Feed() {
       <FeedItem agent={askAgent} selected={false} plain={false} {...feedHandlers} />
       <FeedItem agent={reviewAgent} selected={false} plain={false} {...feedHandlers} />
 
-      <div className="feed-sec">RUNNING · {running.length}<span className="ln" />
+      <div className="feed-sec">RUNNING · {visibleRunning.length}<span className="ln" />
         <span className="fresh"><span className="rot"><Icon name="refresh" size={11} /></span>hosts synced 4s ago</span>
       </div>
-      {running.map((a) => (
+      {visibleRunning.map((a) => (
         <FeedItem key={a.id} agent={a} selected={false} plain={false} {...feedHandlers} />
       ))}
 


### PR DESCRIPTION
## Summary
- preserve remote task context across topic, legacy prompt, first user message, label, worktree, and branch fallbacks
- hide background/headless sessions by default behind a Background feed toggle
- derive rendered floor lanes and grouped counts from one partition
- document the behavior and add adapter, view-model, header, and preview regressions

## Verification
- `bun test src/core/remoteSessions.test.ts ui/settings/components/mission-control/floorAdapter.test.ts ui/settings/components/mission-control/floorModel.test.ts ui/settings/components/mission-control/floorModel.fixes.test.ts ui/settings/components/mission-control/SavedViewsBar.test.tsx` — 250 pass, 0 fail
- `bun run compile` — TypeScript + settings/editor Vite builds pass
- full Factory suite — 1,294 pass; unrelated existing environment/live-service failures remain in VS Code shim, local session fixtures, and installed agent catalog tests
- rendered preview inspected at 2048×1200: Background toggle off, 3 foreground cards rendered, RUNNING count 3

Verification screenshot (fleet-local): `yosemite-s0:/tmp/rush-2031-after.png`

Ticket: [RUSH-2031](https://linear.app/getrush/issue/RUSH-2031/factory-floor-shows-emptycontextless-agent-cards-and-unexpected)