### PR TITLE
fix(hosts): preserve explicit session IDs (RUSH-2033)

### DIFF
--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -27,7 +27,6 @@ import { sshResolve, type SshGResult } from '../lib/hosts/ssh-config.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { randomUUID } from 'crypto';
 import { spawnSync } from 'child_process';
 
 interface ExecCommandActionOptions {
@@ -1111,7 +1110,7 @@ export function registerRunCommand(program: Command): void {
           process.exit(1);
         }
         const hostName = hostGiven[0];
-        const { resolveHostRunTarget, dispatchPromptToHost, HostResolutionError } = await import('../lib/hosts/run-target.js');
+        const { resolveHostRunTarget, resolveHostSessionId, dispatchPromptToHost, HostResolutionError } = await import('../lib/hosts/run-target.js');
         const { runInteractiveOnHost } = await import('../lib/hosts/dispatch.js');
         const { registerInteractiveHostSession } = await import('../lib/hosts/session-index.js');
         const { RUN_OPTION_REJECT_MESSAGES } = await import('../lib/hosts/remote-cmd.js');
@@ -1282,10 +1281,10 @@ export function registerRunCommand(program: Command): void {
               process.exit(1);
             }
             // Mirror the local path (lib/exec.ts): only Claude accepts a forced
-            // `--session-id`. Generating it here lets us register the run in the
-            // local index and makes it resumable by id. On resume the remote
-            // session keeps its existing id — don't mint a new one.
-            const hostSessionId = runAgent === 'claude' && !resumeId ? randomUUID() : undefined;
+            // `--session-id`. Adopt the caller's id when present; otherwise mint
+            // one here. Registering that same id keeps the local index aligned
+            // with the remote agent. On resume, don't mint a new one.
+            const hostSessionId = resolveHostSessionId(runAgent, resumeId, options.sessionId);
             if (hostSessionId) {
               registerInteractiveHostSession({
                 cwd: process.cwd(),
@@ -1377,6 +1376,7 @@ export function registerRunCommand(program: Command): void {
             remoteCwd: hostCwd,
             name: options.name,
             resume: resumeId,
+            sessionId: options.sessionId,
             follow: options.follow !== false,
             passthroughArgs,
             copyCreds: hostCopyCreds,

--- a/apps/cli/src/lib/hosts/run-target.test.ts
+++ b/apps/cli/src/lib/hosts/run-target.test.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-run-target-test-'));
 process.env.HOME = TEST_HOME;
 
-const { resolveHostRunTarget, HostResolutionError } = await import('./run-target.js');
+const { resolveHostRunTarget, resolveHostSessionId, HostResolutionError } = await import('./run-target.js');
 const { DeviceOffloadUnsupportedError } = await import('./registry.js');
 const { sshTargetFor } = await import('./types.js');
 const { upsertDevice } = await import('../devices/registry.js');
@@ -121,5 +121,22 @@ describe('resolveHostRunTarget — password-auth device', () => {
     const err = await resolveHostRunTarget('win-mini').catch((e) => e as Error);
     expect(err).toBeInstanceOf(DeviceOffloadUnsupportedError);
     expect(err.name).toBe('DeviceOffloadUnsupportedError');
+  });
+});
+
+describe('resolveHostSessionId', () => {
+  const explicitId = '11111111-2222-4333-8444-555555555555';
+
+  it('adopts an explicit id for a fresh Claude host run', () => {
+    expect(resolveHostSessionId('claude', undefined, explicitId)).toBe(explicitId);
+  });
+
+  it('mints an id when a fresh Claude host run has no explicit id', () => {
+    expect(resolveHostSessionId('claude')).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('does not force an id for resume or an agent that creates its own id', () => {
+    expect(resolveHostSessionId('claude', explicitId, 'ignored')).toBeUndefined();
+    expect(resolveHostSessionId('codex', undefined, explicitId)).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/hosts/run-target.ts
+++ b/apps/cli/src/lib/hosts/run-target.ts
@@ -68,6 +68,8 @@ export interface HostPromptRun {
   name?: string;
   /** Resume an existing session on the host by concrete id. */
   resume?: string;
+  /** Explicit id for a new Claude session. */
+  sessionId?: string;
   /** Working directory on the host, already made remote-portable by the caller. */
   remoteCwd?: string;
   /** Stream progress and block until completion (default true). */
@@ -98,6 +100,11 @@ export interface HostPromptRun {
   copyCreds?: HostCredentials;
 }
 
+/** Resolve the id the remote host will adopt for a fresh Claude session. */
+export function resolveHostSessionId(agent: string, resume?: string, sessionId?: string): string | undefined {
+  return agent === 'claude' && !resume ? sessionId ?? randomUUID() : undefined;
+}
+
 /**
  * Dispatch a headless prompt run onto a resolved host, then relate the run's
  * session id back to this launcher for EVERY agent — not just Claude.
@@ -114,7 +121,7 @@ export interface HostPromptRun {
  * while the run continues).
  */
 export async function dispatchPromptToHost(host: Host, opts: HostPromptRun): Promise<DispatchResult> {
-  const forcedSessionId = opts.agent === 'claude' && !opts.resume ? randomUUID() : undefined;
+  const forcedSessionId = resolveHostSessionId(opts.agent, opts.resume, opts.sessionId);
   // Ask the remote to print its resolved id whenever we did NOT force one (every
   // non-Claude agent, and Claude-on-resume where the id is already known). No-op
   // when the run isn't followed — nothing tails the log to catch the marker.


### PR DESCRIPTION
## Summary
- adopt an explicit `--session-id` for interactive Claude host runs instead of replacing it
- thread the same explicit ID through `dispatchPromptToHost` for headless runs
- centralize fresh-host ID selection so registration and remote dispatch use the same adopted ID

## Verification artifact
```text
Test Files  3 passed (3)
Tests       49 passed | 1 skipped (50)
TypeScript build passed
```

A real interactive dispatch was attempted against `yosemite-m0`, `yosemite-m2`, and `test-cockpit`; the two workers failed the preflight SSH reachability check and the cockpit correctly rejected executor work, so no remote Claude process was started.

Linear: [RUSH-2033](https://linear.app/getrush/issue/RUSH-2033/interactive-host-agent-runs-ignore-explicit-session-id-causing)