### PR TITLE
fix(release): auto-discover the macOS sign host for Linux-driven releases

### DIFF
--- a/apps/cli/.changelog/next/linux-release-sign-host-discovery.md
+++ b/apps/cli/.changelog/next/linux-release-sign-host-discovery.md
@@ -1,0 +1,12 @@
+- **A Linux-driven release now auto-discovers its macOS sign host instead of
+  hardcoding `mac-mini`.** `scripts/remote-sign-mac.sh` previously defaulted
+  `SIGN_HOST` to `mac-mini`, so a release from a Linux box failed outright whenever
+  that one appliance was offline — the recurring reason a release stalled and a
+  human had to finish it by hand. With `SIGN_HOST` unset the script now reads
+  `agents devices list --json`, keeps the reachable/online macOS devices, and picks
+  the first that answers `ssh` in preference order `mac-mini` → `zion` → any other
+  online Mac. `mac-mini` stays first because it signs headlessly (no Touch ID);
+  `zion` (the interactive Mac) is the fallback. An explicit `SIGN_HOST=<host>` still
+  pins one and skips discovery, and when no reachable Mac qualifies the script fails
+  with the ordered list it tried rather than hanging on a dead host. Source:
+  `apps/cli/scripts/remote-sign-mac.sh`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -230,7 +230,7 @@ host), it invokes [`scripts/remote-sign-mac.sh`](scripts/remote-sign-mac.sh), wh
 rsyncs the build inputs (the full `src/` tree + `package.json`/`bun.lock`,
 keychain-helper.swift, entitlements, the build/sign scripts, the `menubar/` Swift
 package, and — if present — `bin/embedded.provisionprofile`)
-to `${SIGN_HOST:-mac-mini}`, runs the Mac build scripts there under the appliance's
+to an **auto-selected** sign host, runs the Mac build scripts there under its
 headless signing creds (unlock `rush-signing.keychain-db`; Apple notary creds via
 the `apple.com` secrets bundle), then pulls the signed `bin/*.app` +
 `bin/agents-macos` back and re-verifies both sha pins locally. `bun run build` copies the helpers into
@@ -241,6 +241,17 @@ Developer ID identity in `rush-signing.keychain-db`, the `kcpass` + `secrets.pas
 files under `~/Library/Application Support/rush/`, the `apple.com` secrets bundle,
 and `bin/embedded.provisionprofile` (for the notarized keychain helper). Override
 the checkout with `SIGN_HOST_REPO` (`$HOME` resolves on the remote side).
+
+**Sign-host selection (no hardcoded Mac).** With `SIGN_HOST` unset,
+`remote-sign-mac.sh` discovers one at runtime: it reads `agents devices list
+--json`, keeps the reachable/online macOS boxes, and picks the first that answers
+`ssh` in preference order **`mac-mini` → `zion` → any other online Mac** — so a
+Linux-driven release still proceeds when the usual appliance is offline, without an
+agent hardcoding a host (or triggering a Touch ID prompt on a box nobody is sitting
+at). `SIGN_HOST=<host>` pins one explicitly and skips discovery; if no reachable Mac
+has the signing keychain, the script fails with the list it tried. `mac-mini` is
+preferred because it signs headlessly; `zion` (the interactive Mac) is the
+fallback.
 
 **Why not CI?** The tarball bundles `dist/lib/secrets/Agents CLI.app` — a native
 keychain helper compiled with `swiftc`, codesigned (Developer ID), and notarized

--- a/apps/cli/scripts/remote-sign-mac.sh
+++ b/apps/cli/scripts/remote-sign-mac.sh
@@ -11,14 +11,17 @@
 #   - bin/MenubarHelper.app — the menu-bar status item (swift build → codesign,
 #                            NO notarization). See menubar/scripts/build.sh.
 #
-# This script rsyncs the exact build INPUTS from THIS worktree to a dedicated
-# sign host ("mac-mini"), runs the two Mac build scripts there under the
-# appliance's headless signing creds, then pulls the signed bundles back into
-# THIS worktree's apps/cli/bin/ so `bun run build` (now presence-gated, not
-# uname-gated) can package them and `npm publish` can run anywhere.
+# This script rsyncs the exact build INPUTS from THIS worktree to an
+# auto-selected macOS sign host (see SIGN_HOST below), runs the two Mac build
+# scripts there under the appliance's headless signing creds, then pulls the
+# signed bundles back into THIS worktree's apps/cli/bin/ so `bun run build` (now
+# presence-gated, not uname-gated) can package them and `npm publish` can run
+# anywhere.
 #
 # Env knobs:
-#   SIGN_HOST        sign host (default: mac-mini) — must be ssh/scp reachable.
+#   SIGN_HOST        sign host, must be ssh/scp reachable. When unset it is
+#                    auto-discovered from `agents devices list` in preference
+#                    order mac-mini -> zion -> any other online macOS device.
 #   SIGN_HOST_REPO   agents-cli checkout on the sign host. $HOME is resolved on
 #                    the REMOTE side (default: $HOME/src/github.com/muqsitnawaz/agents-cli).
 #

--- a/apps/cli/scripts/remote-sign-mac.sh
+++ b/apps/cli/scripts/remote-sign-mac.sh
@@ -31,8 +31,12 @@
 # Usage: scripts/remote-sign-mac.sh
 set -euo pipefail
 
-SIGN_HOST="${SIGN_HOST:-mac-mini}"
+# SIGN_HOST is resolved just below: an explicit env override wins, otherwise it
+# is auto-discovered from the fleet so a Linux release never hard-depends on one
+# hardcoded Mac. Preference order when unset: mac-mini (headless sign appliance),
+# then zion (the interactive Mac), then any other reachable macOS device.
 SIGN_HOST_REPO="${SIGN_HOST_REPO:-\$HOME/src/github.com/muqsitnawaz/agents-cli}"
+PREFERRED_SIGN_HOSTS=(mac-mini zion)
 
 # apps/cli in THIS worktree (script lives in apps/cli/scripts/).
 LOCAL_CLI="$(cd "$(dirname "$0")/.." && pwd)"
@@ -44,7 +48,44 @@ die()  { printf '\033[31m[remote-sign] error:\033[0m %s\n' "$*" >&2; exit 1; }
 command -v ssh   >/dev/null || die "ssh not found"
 command -v rsync >/dev/null || die "rsync not found"
 
-log "sign host:        $SIGN_HOST"
+# Live reachability probe — a direct ssh, not the registry's cached flag.
+reachable() { ssh -o BatchMode=yes -o ConnectTimeout=8 "$1" true >/dev/null 2>&1; }
+
+# Resolve the sign host. An explicit SIGN_HOST always wins. Otherwise ask the
+# fleet registry (agents devices list --json) for macOS boxes that look online,
+# order them mac-mini -> zion -> the rest, and pick the first that answers ssh
+# right now. Falls back to the static preference list when the registry or jq is
+# unavailable, so the script still works off-fleet.
+select_sign_host() {
+  if [[ -n "${SIGN_HOST:-}" ]]; then printf '%s' "$SIGN_HOST"; return 0; fi
+  local candidates=() macos=() p m c seen name
+  if command -v agents >/dev/null && command -v jq >/dev/null; then
+    mapfile -t macos < <(agents devices list --json 2>/dev/null \
+      | jq -r '.[] | select(.platform=="macos")
+                   | select((.reachability.reachable==true) or (.tailscale.online==true))
+                   | .name' 2>/dev/null)
+    for p in "${PREFERRED_SIGN_HOSTS[@]}"; do
+      for m in "${macos[@]}"; do [[ "$m" == "$p" ]] && candidates+=("$m"); done
+    done
+    for m in "${macos[@]}"; do
+      seen=0; for c in "${candidates[@]}"; do [[ "$c" == "$m" ]] && seen=1; done
+      [[ $seen -eq 0 ]] && candidates+=("$m")
+    done
+  fi
+  [[ ${#candidates[@]} -gt 0 ]] || candidates=("${PREFERRED_SIGN_HOSTS[@]}")
+  for name in "${candidates[@]}"; do
+    if reachable "$name"; then printf '%s' "$name"; return 0; fi
+  done
+  return 1
+}
+
+[[ -n "${SIGN_HOST:-}" ]] && SIGN_HOST_SRC="from SIGN_HOST" || SIGN_HOST_SRC="auto-selected"
+if ! SIGN_HOST="$(select_sign_host)"; then
+  die "no reachable macOS sign host found (tried, in order: ${PREFERRED_SIGN_HOSTS[*]} plus any online macOS device in 'agents devices list'). Bring one online, or set SIGN_HOST=<host> to a Mac that holds the Developer ID signing keychain."
+fi
+export SIGN_HOST
+
+log "sign host:        $SIGN_HOST ($SIGN_HOST_SRC)"
 log "local apps/cli:   $LOCAL_CLI"
 
 # Resolve the remote build workspace. SIGN_HOST_REPO carries a literal '$HOME'


### PR DESCRIPTION
## Problem
A release cut from a Linux fleet box offloads the Mac-only signing to a remote host, but `remote-sign-mac.sh` **hardcoded `SIGN_HOST=mac-mini`**. If that one appliance was offline the release failed outright — a recurring reason a Linux-driven release stalled and a human had to finish it by hand. Picking "any Mac" instead is unsafe: an arbitrary Mac (e.g. a laptop on its login keychain) would prompt for Touch ID that nobody is present to approve.

## Change
With `SIGN_HOST` unset, `remote-sign-mac.sh` now discovers a sign host at runtime:
- reads `agents devices list --json`, keeps **reachable/online macOS** devices,
- picks the first that answers `ssh` in preference order **`mac-mini` → `zion` → any other online Mac**.

`mac-mini` stays first because it signs **headlessly** (dedicated `rush-signing.keychain-db` unlocked via stored kcpass — no Touch ID). `zion` (the interactive Mac) is the fallback. `SIGN_HOST=<host>` still pins one and skips discovery; when no reachable Mac qualifies the script fails with the ordered list it tried instead of hanging on a dead host. Falls back to the static preference list if the registry/`jq` is unavailable, so it still works off-fleet.

No new command, no CLI surface change, npm publish still happens on the Linux orchestrator (already works). Only `remote-sign-mac.sh` + docs + a changelog fragment.

## Verification (from yosemite-s0, Linux)
```
$ bash -n remote-sign-mac.sh            → syntax clean
$ select_sign_host                       → mac-mini      (preferred + reachable)
$ SIGN_HOST=zion select_sign_host        → zion          (explicit override honored)
reachable macOS devices seen: bismas-macbook-pro, mac-mini, zion
live ssh probe: mac-mini reachable, zion reachable
empty-array / no-jq fallback verified safe under `set -euo pipefail` (bash 5.2)
```

## Scope / deferred (noted, not in this PR)
- **Computer-helper GitHub asset on Linux** — `release.sh:751` still gates that best-effort asset behind `uname == Darwin`; publishing it from the discovered sign host is a follow-up so a Linux release is fully complete.
- **Two `release.sh` files** (root = agents-dbg app; `apps/cli` = npm package) remain a discoverability trap; addressing that was descoped per review.

Session transcript (private, not for public paste): `yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit/facede46-5178-416c-88b7-37819b807d33.jsonl`