### PR TITLE
fix(factory): self-heal stuck derived tab labels + reuse an existing session name

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Stuck Claude tab labels self-heal, and an existing session name is reused
+  before summarizing.** Two follow-ups to the derived-label fix: (1) On reload,
+  a tab already reading `CC - muqsitnawaz-91` had that derived placeholder
+  re-adopted as a sticky manual label, which blocked the auto-label poller
+  forever. The label paths (poller-arm and focus) now detect a label that is
+  EXACTLY the session's own derived name and clear it so a real name/topic
+  resolves — matched against the session file, so a genuine label (e.g.
+  "Daemon Creds") or an old-CLI name is never touched. It only clears a label +
+  its store entry; the tmux session and agent are never affected. (2) The
+  auto-label path now reuses Claude's persisted `/status` title as soon as one
+  exists — even before a first user message is captured — and only summarizes
+  with the LLM when there is no existing name. New `readClaudeSessionNameInfo`
+  exposes the session's name + source for the heal check.
+
 ## [0.9.299] - 2026-08-01
 
 - **The extension no longer runs its own stall-detection/nudge injector — the

--- a/apps/factory/src/core/sessionName.test.ts
+++ b/apps/factory/src/core/sessionName.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { readClaudeSessionName, resetSessionNameCache } from './sessionName';
+import { readClaudeSessionName, readClaudeSessionNameInfo, resetSessionNameCache } from './sessionName';
 
 let tmpDir: string;
 
@@ -105,6 +105,29 @@ describe('readClaudeSessionName', () => {
     const b = await readClaudeSessionName('user-set', { sessionsDirs: [tmpDir] });
     expect(a).toBe('Fix Fleet Login');
     expect(b).toBe('Ship Release');
+  });
+
+  it('readClaudeSessionNameInfo exposes the derived placeholder (so a stuck tab can be recognized)', async () => {
+    writeSessionFile(66280, { sessionId: 'abc-123', name: 'agents-cli-55', nameSource: 'derived' });
+    const info = await readClaudeSessionNameInfo('abc-123', { sessionsDirs: [tmpDir] });
+    expect(info).toEqual({ name: 'agents-cli-55', nameSource: 'derived', derived: true });
+    // ...while readClaudeSessionName still hides it (falls through to LLM).
+    resetSessionNameCache();
+    expect(await readClaudeSessionName('abc-123', { sessionsDirs: [tmpDir] })).toBeNull();
+  });
+
+  it('readClaudeSessionNameInfo reports a genuine title as not-derived', async () => {
+    writeSessionFile(66281, { sessionId: 'real-1', name: 'Investigate agent misreporting', nameSource: 'user' });
+    writeSessionFile(66282, { sessionId: 'old-cli', name: 'Fix Fleet Login' }); // no nameSource (old CLI)
+    const a = await readClaudeSessionNameInfo('real-1', { sessionsDirs: [tmpDir] });
+    resetSessionNameCache();
+    const b = await readClaudeSessionNameInfo('old-cli', { sessionsDirs: [tmpDir] });
+    expect(a).toEqual({ name: 'Investigate agent misreporting', nameSource: 'user', derived: false });
+    expect(b).toEqual({ name: 'Fix Fleet Login', nameSource: null, derived: false });
+  });
+
+  it('readClaudeSessionNameInfo returns null for an unknown session', async () => {
+    expect(await readClaudeSessionNameInfo('nope', { sessionsDirs: [tmpDir] })).toBeNull();
   });
 
   it('caches scans within the TTL window', async () => {

--- a/apps/factory/src/core/sessionName.ts
+++ b/apps/factory/src/core/sessionName.ts
@@ -33,9 +33,19 @@ interface ClaudeSessionFile {
   nameSource?: string | null;
 }
 
+// The session's current name plus where it came from. `derived` is Claude's
+// auto-generated `<dirname>-<n>` placeholder (nameSource === 'derived'); any
+// other source (a real /status title, or an old CLI with no nameSource) is a
+// genuine name.
+export interface ClaudeSessionNameInfo {
+  name: string;
+  nameSource: string | null;
+  derived: boolean;
+}
+
 interface ScanCache {
   builtAt: number;
-  bySessionId: Map<string, string>; // only successful resolutions
+  bySessionId: Map<string, ClaudeSessionNameInfo>; // every named session, derived or not
 }
 
 const TTL_MS = 30_000;
@@ -46,10 +56,25 @@ export interface ReadSessionNameOptions {
   now?: number;
 }
 
+// The genuine title for a session, or null when there is none OR the only name
+// is Claude's derived placeholder. This is the label-worthy name — reuse it as
+// the tab label; a null means "fall through to the LLM topic path".
 export async function readClaudeSessionName(
   sessionId: string,
   options: ReadSessionNameOptions = {}
 ): Promise<string | null> {
+  const info = await readClaudeSessionNameInfo(sessionId, options);
+  if (!info || info.derived) return null;
+  return info.name;
+}
+
+// The session's CURRENT name and its source, INCLUDING the derived placeholder.
+// Callers use this to ask "is <label> exactly this session's derived name?" —
+// e.g. to un-stick a tab whose label is the `<dirname>-<n>` placeholder.
+export async function readClaudeSessionNameInfo(
+  sessionId: string,
+  options: ReadSessionNameOptions = {}
+): Promise<ClaudeSessionNameInfo | null> {
   if (!sessionId) return null;
 
   const now = options.now ?? Date.now();
@@ -84,14 +109,14 @@ async function discoverSessionDirs(): Promise<string[]> {
 }
 
 async function rebuildCache(dirs: string[], now: number): Promise<ScanCache> {
-  const bySessionId = new Map<string, string>();
+  const bySessionId = new Map<string, ClaudeSessionNameInfo>();
 
   await Promise.all(dirs.map((dir) => scanDir(dir, bySessionId)));
 
   return { builtAt: now, bySessionId };
 }
 
-async function scanDir(dir: string, sink: Map<string, string>): Promise<void> {
+async function scanDir(dir: string, sink: Map<string, ClaudeSessionNameInfo>): Promise<void> {
   let entries: string[];
   try {
     entries = await fs.promises.readdir(dir);
@@ -106,13 +131,17 @@ async function scanDir(dir: string, sink: Map<string, string>): Promise<void> {
         try {
           const raw = await fs.promises.readFile(path.join(dir, f), 'utf-8');
           const parsed = JSON.parse(raw) as ClaudeSessionFile;
-          // A `derived` name is Claude's auto-generated `<dirname>-<n>`
-          // placeholder, not a real title — skip it so the caller falls
-          // through to the LLM topic path instead of labelling the tab with
-          // the repo name.
-          if (parsed.nameSource === 'derived') return;
+          // Store EVERY named session — including Claude's derived `<dirname>-<n>`
+          // placeholder. readClaudeSessionName filters `derived` out (so a tab
+          // never labels with the repo name), while readClaudeSessionNameInfo
+          // exposes it so a caller can recognize and un-stick a promoted
+          // placeholder label.
           if (parsed.sessionId && typeof parsed.name === 'string' && parsed.name.trim()) {
-            sink.set(parsed.sessionId, parsed.name.trim());
+            sink.set(parsed.sessionId, {
+              name: parsed.name.trim(),
+              nameSource: parsed.nameSource ?? null,
+              derived: parsed.nameSource === 'derived',
+            });
           }
         } catch {
           // malformed or unreadable file — skip silently

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -73,7 +73,7 @@ import {
   SessionAgentType
 } from '../core/utils';
 import { generateLabelWithLLM } from '../core/labelgen';
-import { readClaudeSessionName } from '../core/sessionName';
+import { readClaudeSessionName, readClaudeSessionNameInfo } from '../core/sessionName';
 import { resolveTerminalCwd, tryReleaseWorktreeForTerminal } from '../core/worktree';
 import * as path from 'path';
 import { spawn } from 'child_process';
@@ -3645,15 +3645,16 @@ async function fetchAndSetAutoLabel(
   try {
     const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const previewInfo = await getSessionPreviewForEntry(entry, workspacePath);
-    if (!previewInfo) return undefined;
-    if (!previewInfo.firstUserMessage) return undefined;
+    const firstUserMessage = previewInfo?.firstUserMessage;
+    const ticket = firstUserMessage ? extractLinearTicketId(firstUserMessage) : null;
 
-    const ticket = extractLinearTicketId(previewInfo.firstUserMessage);
-
-    // Prefer Claude's own persisted session name (the title shown by /status)
-    // — it's already a clean human summary and avoids a redundant LLM call.
-    // Codex/Gemini/Opencode don't persist this yet, so they fall through to
-    // the LLM path.
+    // 1) Reuse an existing real label. Claude persists the /status title (set by
+    //    Claude itself or the user); readClaudeSessionName returns it unless it's
+    //    the derived `<dirname>-<n>` placeholder. This is a clean human summary,
+    //    needs no LLM call, and — unlike the summary path below — doesn't require
+    //    a captured first message, so a session that already has a name gets it
+    //    even before its first turn is recorded. Codex/Gemini/Opencode don't
+    //    persist an equivalent, so they fall through to the summary path.
     if (entry.agentType === 'claude') {
       const persistedName = await readClaudeSessionName(entry.sessionId);
       if (persistedName) {
@@ -3663,12 +3664,16 @@ async function fetchAndSetAutoLabel(
       }
     }
 
-    const sourceText = opts.useFullConversation && previewInfo.lastUserMessage
-      ? `Initial task:\n${previewInfo.firstUserMessage}\n\nLatest activity:\n${previewInfo.lastUserMessage}`
-      : previewInfo.firstUserMessage;
+    // 2) Otherwise summarize the session's activity into a short title. This
+    //    needs a first user message to summarize.
+    if (!firstUserMessage) return undefined;
+
+    const sourceText = opts.useFullConversation && previewInfo?.lastUserMessage
+      ? `Initial task:\n${firstUserMessage}\n\nLatest activity:\n${previewInfo.lastUserMessage}`
+      : firstUserMessage;
 
     const llmTitle = await generateLabelWithLLM(sourceText);
-    const fallback = extractFirstNWords(previewInfo.firstUserMessage, 5);
+    const fallback = extractFirstNWords(firstUserMessage, 5);
     const base = llmTitle ?? fallback;
     const autoLabel = ticket && base ? `${ticket} ${base}` : (ticket ?? base);
 
@@ -3681,13 +3686,42 @@ async function fetchAndSetAutoLabel(
   }
 }
 
+// Un-stick a tab whose label is EXACTLY this session's own derived placeholder
+// (Claude's `<dirname>-<n>`, e.g. "muqsitnawaz-91"). On a window reload the
+// derived name baked into the tab title gets re-adopted as a sticky manual
+// label (terminals.register), which then blocks the auto-label poller forever.
+// A genuine label never equals the session's derived name, and old CLIs have no
+// derived name — so this only ever clears the placeholder, never a real label.
+// It touches only the label + its persisted store entry; the tmux session and
+// agent process are never affected.
+async function maybeHealDerivedLabel(
+  terminal: vscode.Terminal,
+  entry: terminals.EditorTerminal,
+  context: vscode.ExtensionContext
+): Promise<void> {
+  if (!entry.label || !entry.sessionId || entry.agentType !== 'claude') return;
+  const info = await readClaudeSessionNameInfo(entry.sessionId);
+  if (info?.derived && info.name === entry.label) {
+    await terminals.setLabel(terminal, undefined, context);
+  }
+}
+
 function startAutoLabelPollerForTerminal(terminal: vscode.Terminal, context: vscode.ExtensionContext): void {
+  void armAutoLabelPoller(terminal, context);
+}
+
+async function armAutoLabelPoller(terminal: vscode.Terminal, context: vscode.ExtensionContext): Promise<void> {
   const display = getDisplayPrefs(context);
   if (!display.autoLabelInTabTitles) return;
 
   const entry = terminals.getByTerminal(terminal);
-  if (!entry || entry.label || entry.autoLabel) return;
-  if (!entry.sessionId || !entry.agentType) return;
+  if (!entry || !entry.sessionId || !entry.agentType) return;
+
+  // Heal first: if the sticky label is the derived placeholder, drop it so a
+  // real name/topic can resolve below.
+  await maybeHealDerivedLabel(terminal, entry, context);
+
+  if (entry.label || entry.autoLabel) return;
 
   terminals.startAutoLabelPoller(terminal, async () => {
     const autoLabel = await fetchAndSetAutoLabel(terminal, entry);
@@ -3777,11 +3811,14 @@ async function tryFetchLabelOnFocus(
   const entry = terminals.getByTerminal(terminal);
   if (!entry) return;
 
-  // Skip if already has a label
-  if (entry.label || entry.autoLabel) return;
-
   // Need sessionId and agentType to fetch label
   if (!entry.sessionId || !entry.agentType) return;
+
+  // Heal a stuck derived-placeholder label so focusing the tab re-resolves it.
+  await maybeHealDerivedLabel(terminal, entry, context);
+
+  // Skip if it already has a (real) label
+  if (entry.label || entry.autoLabel) return;
 
   // Fetch the label from session file
   const autoLabel = await fetchAndSetAutoLabel(terminal, entry);


### PR DESCRIPTION
Follow-up to #1530. Two auto-label robustness fixes, both requested after seeing #1530 land: existing tabs stayed stuck, and an already-good session name should be reused instead of re-summarized.

## 1 — Stuck derived labels now self-heal (no reload dance, no session risk)

After #1530, a Claude tab that already read `CC - muqsitnawaz-91` stayed stuck. Root cause (confirmed): on a window reload, `scanExisting` (`terminals.vscode.ts:660`) parses `muqsitnawaz-91` from the tab title and `register` promotes it to a **sticky, PID-persisted manual label**; the auto-label poller then bails on any `entry.label`, so it never re-resolves.

Fix: `maybeHealDerivedLabel` clears a label **only when it is EXACTLY the session's own derived placeholder** — matched against the session file via the new `readClaudeSessionNameInfo` (`{name, nameSource, derived}`). Wired into the two label-resolution entry points that run post-restore with a sessionId present: the poller-arm (`startAutoLabelPollerForTerminal` → `armAutoLabelPoller`) and focus (`tryFetchLabelOnFocus`). It clears only the label + its persisted store entry via the existing `setLabel(terminal, undefined)`; **the tmux session and agent process are never touched.**

Safety of the discriminator: a genuine manual label (e.g. `Daemon Creds`) never equals the session's derived name, and old CLIs have no derived name (`derived:false`) — so a real label is never healed. Verified against real session files: derived sessions are always `nameSource:"derived"` with a `<repo>-<n>` name; genuine titles are `user`/absent.

## 2 — Reuse an existing session name before summarizing

`fetchAndSetAutoLabel` used to bail if no first user message was captured, *before* checking Claude's persisted `/status` title. Now it returns that title as soon as one exists (e.g. "Investigate agent misreporting and system instructions" from `/status`), and only falls back to the LLM summary / first-message snippet when there is no name. Reuse first, summarize only as a fallback — no new command; the existing auto-label path just got more robust.

## Verification

- `bun test src/core/sessionName.test.ts` (15 pass, incl. 3 new: info exposes the derived flag; genuine/old-CLI reported not-derived; unknown → null) and `terminals.vscode.test.ts` (8) green. `tsc -p ./` clean.
- Building `0.9.300` on zion and installing to Codium (disk only — no window reload) for live confirmation.

## Notes
- CHANGELOG entry under `[Unreleased]`.
- No new command; no change for Codex/Gemini/OpenCode (they still take the summary path).