### PR TITLE
fix(secrets): an agent launch never raises a Touch ID sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 - **Project routines opt-in + host placement strategy (RUSH-2035).** `agents routines enable-project` / `sync` / `--placement local|host|fleet|cloud`. See `apps/cli/CHANGELOG.md`.
 
 - Secrets: name the requesting harness, bundle, reason, and duration in macOS
-  Touch ID prompts; allow agent-triggered approval and scope cached unlocks to
-  the harness type, with `secrets unlock --for <agent>`.
+  Touch ID prompts, and scope cached unlocks to the harness type, with
+  `secrets unlock --for <agent>`. Agent-triggered approval is **not** part of
+  this: an agent launch never raises a sheet, it fails fast naming
+  `agents secrets unlock <bundle>`. Only a human-typed `agents secrets` command
+  prompts.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   Touch ID prompts, and scope cached unlocks to the harness type, with
   `secrets unlock --for <agent>`. Agent-triggered approval is **not** part of
   this: an agent launch never raises a sheet, it fails fast naming
-  `agents secrets unlock <bundle>`. Only a human-typed `agents secrets` command
-  prompts.
+  `agents secrets unlock <bundle>`. Only an `agents secrets` command run in a plain
+  shell prompts; beneath an agent it inherits `AGENTS_RUNTIME` and refuses too.
 
 ### Added
 

--- a/apps/cli/.changelog/next/no-prompt-on-agent-launch.md
+++ b/apps/cli/.changelog/next/no-prompt-on-agent-launch.md
@@ -1,12 +1,12 @@
 - **An agent launch never raises a Touch ID sheet.** On macOS, starting an agent
-  terminal or firing a routine could pop several biometric prompts in a row. Two
-  causes: `interactiveUnlock` defaulted to true whenever an agent name was present,
-  which made `agentOnly: true` a no-op for every agent-initiated read (no caller
-  ever passed the flag, so the default *was* the behavior); and
-  `isHeadlessSecretsContext` recognized the `headless` and `teams` runtimes but not
-  `terminal`, which is what an interactive run sets. Because each keychain read runs
-  in its own helper process, the biometric assertion never reuses, so one launch
-  meant one sheet per bundle. Agent launches now resolve broker-only and a locked
-  bundle fails fast naming `agents secrets unlock <bundle>`; `AGENTS_SECRETS_NO_PROMPT=1`
-  is no longer needed as a workaround. An explicit `interactiveUnlock: true` caller
-  can still raise the sheet on purpose.
+  terminal or firing a routine could pop several biometric prompts in a row, because
+  each keychain read runs in its own helper process and the biometric assertion never
+  reuses across processes. Two causes: `interactiveUnlock` defaulted to true whenever
+  an agent name was present, which let an agent-initiated read fall through the
+  `agentOnly` guard; and `isHeadlessSecretsContext` recognized the `headless` and
+  `teams` runtimes but not `terminal`, which is what an interactive run sets. Agent
+  launches now resolve broker-only and a locked bundle fails fast naming
+  `agents secrets unlock <bundle>`; `AGENTS_SECRETS_NO_PROMPT=1` is no longer needed
+  as a workaround. A human-typed `agents secrets get/export/exec` still prompts —
+  those pass `interactiveUnlock: true` explicitly. This narrows the agent-triggered
+  approval added in RUSH-2032, which is unreleased.

--- a/apps/cli/.changelog/next/no-prompt-on-agent-launch.md
+++ b/apps/cli/.changelog/next/no-prompt-on-agent-launch.md
@@ -7,6 +7,7 @@
   `teams` runtimes but not `terminal`, which is what an interactive run sets. Agent
   launches now resolve broker-only and a locked bundle fails fast naming
   `agents secrets unlock <bundle>`; `AGENTS_SECRETS_NO_PROMPT=1` is no longer needed
-  as a workaround. A human-typed `agents secrets get/export/exec` still prompts —
-  those pass `interactiveUnlock: true` explicitly. This narrows the agent-triggered
-  approval added in RUSH-2032, which is unreleased.
+  as a workaround. `agents secrets get/export/exec` typed in a **plain shell** still
+  prompts — it carries no `AGENTS_RUNTIME`, so the guard does not apply. Run beneath
+  an agent it refuses, because there the agent is the caller. This narrows the
+  agent-triggered approval added in RUSH-2032, which is unreleased.

--- a/apps/cli/.changelog/next/no-prompt-on-agent-launch.md
+++ b/apps/cli/.changelog/next/no-prompt-on-agent-launch.md
@@ -1,0 +1,12 @@
+- **An agent launch never raises a Touch ID sheet.** On macOS, starting an agent
+  terminal or firing a routine could pop several biometric prompts in a row. Two
+  causes: `interactiveUnlock` defaulted to true whenever an agent name was present,
+  which made `agentOnly: true` a no-op for every agent-initiated read (no caller
+  ever passed the flag, so the default *was* the behavior); and
+  `isHeadlessSecretsContext` recognized the `headless` and `teams` runtimes but not
+  `terminal`, which is what an interactive run sets. Because each keychain read runs
+  in its own helper process, the biometric assertion never reuses, so one launch
+  meant one sheet per bundle. Agent launches now resolve broker-only and a locked
+  bundle fails fast naming `agents secrets unlock <bundle>`; `AGENTS_SECRETS_NO_PROMPT=1`
+  is no longer needed as a workaround. An explicit `interactiveUnlock: true` caller
+  can still raise the sheet on purpose.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -9,7 +9,9 @@ authenticate, and because each keychain read runs in its own helper process the
 biometric assertion never reuses, so one launch used to mean one sheet per bundle.
 
 The sheet is raised only by a deliberate human request: `agents secrets unlock`,
-or an `agents secrets get/export/exec` you typed yourself. It names the requesting
+or an `agents secrets get/export/exec` you run **in a plain shell**. Beneath an
+agent those same commands inherit `AGENTS_RUNTIME` and resolve broker-only — there
+the agent is the caller, not you. It names the requesting
 harness, bundle, reason, and unlock duration. Approved bundles are cached for seven
 days by default and are reused only by the same harness type.
 

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -2,10 +2,16 @@
 
 ## Agent-scoped unlocks
 
-On macOS, a secrets request can raise Touch ID directly, including from a
-background agent. The sheet names the requesting harness, bundle, reason, and
-unlock duration. Approved bundles are cached for seven days by default and are
-reused only by the same harness type.
+On macOS, **an agent launch never raises a Touch ID sheet.** A terminal, a
+routine, a teammate, or the daemon that needs a locked bundle fails fast and names
+`agents secrets unlock <bundle>` — opening an agent is not a request to
+authenticate, and because each keychain read runs in its own helper process the
+biometric assertion never reuses, so one launch used to mean one sheet per bundle.
+
+The sheet is raised only by a deliberate human request: `agents secrets unlock`,
+or an `agents secrets get/export/exec` you typed yourself. It names the requesting
+harness, bundle, reason, and unlock duration. Approved bundles are cached for seven
+days by default and are reused only by the same harness type.
 
 Use `agents secrets unlock prod --for claude` to pre-authorize a bundle for
 Claude. Codex, Kimi, and other harnesses require their own approval. `--ttl`

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -2183,8 +2183,10 @@ export function registerRunCommand(program: Command): void {
               agent,
               keys: secretsKeysSubset,
               allowExpired: options.allowExpired,
-              // The harness identity scopes any cached grant and allows this
-              // requesting agent to wait for interactive approval.
+              // The harness identity scopes any cached grant. It no longer lets the
+              // requesting agent wait for interactive approval — an agent launch
+              // resolves broker-only and fails fast naming
+              // `agents secrets unlock <bundle>` (bundles.ts:interactiveUnlock).
               agentOnly: isHeadlessSecretsContext(),
             });
             const entries = describeBundle(bundle);

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -1171,9 +1171,10 @@ export function registerSecretsCommands(program: Command): void {
           process.exit(1);
         }
         // `secrets get` is the scriptable automation primitive ($(agents secrets
-        // get bundle KEY)); when embedded in a headless routine/CI script it must
-        // not pop an unwatched Touch ID prompt. Interactive use still prompts.
-        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
+        // get bundle KEY)); when embedded in a headless routine/CI script — or run
+        // beneath any agent, which inherits AGENTS_RUNTIME — it must not pop an
+        // unwatched Touch ID prompt. Typed in a plain shell it still prompts.
+        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
         if (!(key in env)) {
           console.error(chalk.red(`Key '${key}' not in bundle '${item}'.`));
           process.exit(1);
@@ -1791,7 +1792,7 @@ Examples:
               'Set it for this command, then supply the same value when importing.'
             );
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           exportBundleToFile(env, opts.toFile, passphrase);
           console.log(chalk.green(`Exported ${Object.keys(env).length} key(s) to ${opts.toFile}`));
           return;
@@ -1820,7 +1821,7 @@ Examples:
               );
             }
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           const dotenv = bundleEnvToDotenv(env);
           const keyCount = Object.keys(env).length;
           // Drive the remote's own `agents secrets import --from -` so the values
@@ -1888,7 +1889,7 @@ Examples:
         if (opts.to1password) {
           assertOpAvailable();
           const vault = await resolveVault(opts.vault);
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           let created = 0;
           let overwritten = 0;
           let skipped = 0;
@@ -1924,14 +1925,14 @@ Examples:
           process.exit(1);
         }
         // `agents secrets export --plaintext` is what release/CI scripts eval.
-        // When it runs detached (both stdio non-TTY) or under a headless agent,
-        // resolve broker-only so it can never pop a Touch ID sheet on the
-        // interactive user's screen. An interactive `eval "$(...)"` keeps its
-        // terminal stdin, so it is not headless and still prompts.
+        // When it runs detached (both stdio non-TTY) or beneath ANY agent — which
+        // inherits AGENTS_RUNTIME — resolve broker-only so it can never pop a Touch
+        // ID sheet on the interactive user's screen. An `eval "$(...)"` typed in a
+        // plain shell carries no AGENTS_RUNTIME, so it is not headless and still prompts.
         const { env } = readAndResolveBundleEnv(resolvedBundleName, {
           caller: `export to shell`,
           keyMode: 'process',
-          agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true,
+          agentOnly: isHeadlessSecretsContext(),
         });
         if (opts.format === 'json') {
           // Machine-readable form consumed by `remoteResolveEnv` over SSH.
@@ -1990,7 +1991,7 @@ Examples:
             caller: `command ${cmd}`,
             keys: keysSubset,
             allowExpired: execOpts.allowExpired,
-            agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true,
+            agentOnly: isHeadlessSecretsContext(),
           }).env;
         }
         const { spawn } = await import('child_process');

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -1173,7 +1173,7 @@ export function registerSecretsCommands(program: Command): void {
         // `secrets get` is the scriptable automation primitive ($(agents secrets
         // get bundle KEY)); when embedded in a headless routine/CI script it must
         // not pop an unwatched Touch ID prompt. Interactive use still prompts.
-        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
         if (!(key in env)) {
           console.error(chalk.red(`Key '${key}' not in bundle '${item}'.`));
           process.exit(1);
@@ -1791,7 +1791,7 @@ Examples:
               'Set it for this command, then supply the same value when importing.'
             );
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
           exportBundleToFile(env, opts.toFile, passphrase);
           console.log(chalk.green(`Exported ${Object.keys(env).length} key(s) to ${opts.toFile}`));
           return;
@@ -1820,7 +1820,7 @@ Examples:
               );
             }
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
           const dotenv = bundleEnvToDotenv(env);
           const keyCount = Object.keys(env).length;
           // Drive the remote's own `agents secrets import --from -` so the values
@@ -1888,7 +1888,7 @@ Examples:
         if (opts.to1password) {
           assertOpAvailable();
           const vault = await resolveVault(opts.vault);
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true });
           let created = 0;
           let overwritten = 0;
           let skipped = 0;
@@ -1931,7 +1931,7 @@ Examples:
         const { env } = readAndResolveBundleEnv(resolvedBundleName, {
           caller: `export to shell`,
           keyMode: 'process',
-          agentOnly: isHeadlessSecretsContext(),
+          agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true,
         });
         if (opts.format === 'json') {
           // Machine-readable form consumed by `remoteResolveEnv` over SSH.
@@ -1990,7 +1990,7 @@ Examples:
             caller: `command ${cmd}`,
             keys: keysSubset,
             allowExpired: execOpts.allowExpired,
-            agentOnly: isHeadlessSecretsContext(),
+            agentOnly: isHeadlessSecretsContext(), interactiveUnlock: true,
           }).env;
         }
         const { spawn } = await import('child_process');

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -211,12 +211,27 @@ describe('readAndResolveBundleEnv agent-only reads', () => {
     else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
   });
 
-  it('allows an agent-triggered interactive read for a daily bundle with no broker/session snapshot', () => {
+  // REVERSED deliberately. This previously asserted that an agent-triggered read
+  // may prompt: interactiveUnlock defaulted to true whenever an agent name was
+  // present, so agentOnly was a no-op for every agent-initiated read. That is the
+  // bug — opening an agent terminal is not a request to authenticate, and each
+  // keychain read is its own helper process, so one launch raised several sheets.
+  // An agent-initiated read now fails fast with an actionable message instead.
+  it('refuses an agent-triggered read of a locked daily bundle instead of prompting', () => {
     writeBundleWithItems(
       { name: 'apple.com', policy: 'daily', vars: { APPLE_TEAM_ID: 'keychain:APPLE_TEAM_ID' } },
       new Map([[secretsKeychainItem('apple.com', 'APPLE_TEAM_ID'), '2HTP252L87']]),
     );
-    expect(readAndResolveBundleEnv('apple.com', { caller: 'command deploy', agent: 'claude', agentOnly: true }).env)
+    expect(() => readAndResolveBundleEnv('apple.com', { caller: 'command deploy', agent: 'claude', agentOnly: true }))
+      .toThrow("Secrets bundle 'apple.com' is not unlocked in the secrets agent");
+  });
+
+  it('still resolves for a caller that explicitly opts into an interactive unlock', () => {
+    writeBundleWithItems(
+      { name: 'apple.com', policy: 'daily', vars: { APPLE_TEAM_ID: 'keychain:APPLE_TEAM_ID' } },
+      new Map([[secretsKeychainItem('apple.com', 'APPLE_TEAM_ID'), '2HTP252L87']]),
+    );
+    expect(readAndResolveBundleEnv('apple.com', { caller: 'secrets unlock', agent: 'claude', agentOnly: true, interactiveUnlock: true }).env)
       .toEqual({ APPLE_TEAM_ID: '2HTP252L87' });
   });
 
@@ -234,9 +249,21 @@ describe('readAndResolveBundleEnv agent-only reads', () => {
 });
 
 describe('isHeadlessSecretsContext', () => {
+  it('still allows a prompt for an explicit agents-secrets command (no AGENTS_RUNTIME)', () => {
+    // No runtime marker => not an agent launch => falls through to the TTY check.
+    expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin')).toBe(
+      !process.stdin.isTTY && !process.stdout.isTTY,
+    );
+  });
+
   it('is true for headless/teams runtime on darwin (where the Touch ID sheet exists)', () => {
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'headless' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'teams' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);
+    // An interactive agent terminal too: exec.ts sets AGENTS_RUNTIME='terminal',
+    // and opening a terminal is not a request to authenticate. Without this, the
+    // agent terminal was the ONE launch path that could still pop Touch ID —
+    // several sheets per launch, since each keychain read is its own process.
+    expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'terminal' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);
   });
 
   it('is ALWAYS false off-darwin — no biometry prompt to suppress on Linux/Windows', () => {

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -249,15 +249,6 @@ describe('readAndResolveBundleEnv agent-only reads', () => {
 });
 
 describe('isHeadlessSecretsContext', () => {
-  it('classifies a plain human shell by its TTY state, not as an agent launch', () => {
-    // No AGENTS_RUNTIME => not an agent launch => the TTY check decides. Pinned to
-    // fixed values rather than reading live TTY state, which made this tautological.
-    const noTty = { AGENTS_SECRETS_NO_PROMPT: '1' } as NodeJS.ProcessEnv;
-    expect(isHeadlessSecretsContext(noTty, 'darwin')).toBe(true);
-    const withTty = { AGENTS_SECRETS_NO_PROMPT: '0' } as NodeJS.ProcessEnv;
-    expect(isHeadlessSecretsContext(withTty, 'darwin')).toBe(false);
-  });
-
   it('is true for headless/teams runtime on darwin (where the Touch ID sheet exists)', () => {
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'headless' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'teams' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -211,10 +211,10 @@ describe('readAndResolveBundleEnv agent-only reads', () => {
     else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
   });
 
-  // REVERSED deliberately. This previously asserted that an agent-triggered read
-  // may prompt: interactiveUnlock defaulted to true whenever an agent name was
-  // present, so agentOnly was a no-op for every agent-initiated read. That is the
-  // bug — opening an agent terminal is not a request to authenticate, and each
+  // REVERSED deliberately, and this is a NARROWING of RUSH-2032 rather than a bug
+  // fix: interactiveUnlock defaulting to true whenever an agent name was present
+  // was that feature's spec (b99796f8, 4eeada68), not an oversight. It is unwanted
+  // here — opening an agent terminal is not a request to authenticate, and each
   // keychain read is its own helper process, so one launch raised several sheets.
   // An agent-initiated read now fails fast with an actionable message instead.
   it('refuses an agent-triggered read of a locked daily bundle instead of prompting', () => {
@@ -249,6 +249,24 @@ describe('readAndResolveBundleEnv agent-only reads', () => {
 });
 
 describe('isHeadlessSecretsContext', () => {
+  // The branch carrying this guard's entire safety argument: a person in a plain
+  // shell must still get their prompt. Nothing reached it before — the TTY state was
+  // read from process.* directly, so a mutant that made a plain shell NEVER prompt
+  // (which would strand every cold bundle) left the whole suite green.
+  it('a plain human shell with a TTY is NOT headless — it still prompts', () => {
+    expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin', { stdin: true, stdout: true })).toBe(false);
+  });
+
+  it('a detached process with no TTY IS headless — it must not prompt', () => {
+    expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin', { stdin: false, stdout: false })).toBe(true);
+  });
+
+  it('an agent runtime is headless even with a TTY — the agent is the caller', () => {
+    for (const runtime of ['headless', 'teams', 'terminal']) {
+      expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: runtime } as NodeJS.ProcessEnv, 'darwin', { stdin: true, stdout: true })).toBe(true);
+    }
+  });
+
   it('is true for headless/teams runtime on darwin (where the Touch ID sheet exists)', () => {
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'headless' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'teams' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -253,6 +253,27 @@ describe('isHeadlessSecretsContext', () => {
   // shell must still get their prompt. Nothing reached it before — the TTY state was
   // read from process.* directly, so a mutant that made a plain shell NEVER prompt
   // (which would strand every cold bundle) left the whole suite green.
+  // The DEFAULT binding, not just the branch. Parameterizing the TTY state split one
+  // untested expression into a tested branch plus an untested default; a miswired
+  // default would make a detached release script `( ... ) >log 2>&1 </dev/null`
+  // classify as non-headless and pop a sheet nobody is watching — the exact failure
+  // this guard exists to prevent. Calls the TWO-arg form so the default is exercised.
+  it('defaults to the live process TTY state when none is passed', () => {
+    const d = (k: 'stdin' | 'stdout') => Object.getOwnPropertyDescriptor(process[k], 'isTTY');
+    const set = (k: 'stdin' | 'stdout', v: boolean | undefined) =>
+      Object.defineProperty(process[k], 'isTTY', { value: v, configurable: true, writable: true });
+    const [pin, pout] = [d('stdin'), d('stdout')];
+    try {
+      set('stdin', undefined); set('stdout', undefined);
+      expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin')).toBe(true);
+      set('stdin', true); set('stdout', true);
+      expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin')).toBe(false);
+    } finally {
+      if (pin) Object.defineProperty(process.stdin, 'isTTY', pin);
+      if (pout) Object.defineProperty(process.stdout, 'isTTY', pout);
+    }
+  });
+
   it('a plain human shell with a TTY is NOT headless — it still prompts', () => {
     expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin', { stdin: true, stdout: true })).toBe(false);
   });

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -249,11 +249,13 @@ describe('readAndResolveBundleEnv agent-only reads', () => {
 });
 
 describe('isHeadlessSecretsContext', () => {
-  it('still allows a prompt for an explicit agents-secrets command (no AGENTS_RUNTIME)', () => {
-    // No runtime marker => not an agent launch => falls through to the TTY check.
-    expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin')).toBe(
-      !process.stdin.isTTY && !process.stdout.isTTY,
-    );
+  it('classifies a plain human shell by its TTY state, not as an agent launch', () => {
+    // No AGENTS_RUNTIME => not an agent launch => the TTY check decides. Pinned to
+    // fixed values rather than reading live TTY state, which made this tautological.
+    const noTty = { AGENTS_SECRETS_NO_PROMPT: '1' } as NodeJS.ProcessEnv;
+    expect(isHeadlessSecretsContext(noTty, 'darwin')).toBe(true);
+    const withTty = { AGENTS_SECRETS_NO_PROMPT: '0' } as NodeJS.ProcessEnv;
+    expect(isHeadlessSecretsContext(withTty, 'darwin')).toBe(false);
   });
 
   it('is true for headless/teams runtime on darwin (where the Touch ID sheet exists)', () => {

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -1260,8 +1260,17 @@ export function isHeadlessSecretsContext(
   const override = env.AGENTS_SECRETS_NO_PROMPT;
   if (override === '1') return true;
   if (override === '0') return false;
+  // Every AGENT-LAUNCH runtime resolves broker-only, interactive included.
+  // `terminal` was missing, which made an agent terminal the one launch path
+  // still allowed to pop Touch ID: exec.ts sets AGENTS_RUNTIME='terminal' for an
+  // interactive run (exec.ts:426), that fell through to the TTY check below, and
+  // a TTY meant "a human is watching, so prompting is fine". It is not fine —
+  // opening a terminal is not a request to authenticate, and a launch that needs
+  // a locked bundle should say so and point at `agents secrets unlock`, not grab
+  // the fingerprint sensor. Explicit `agents secrets` commands are unaffected:
+  // they carry no AGENTS_RUNTIME and still fall through to the TTY check.
   const runtime = env.AGENTS_RUNTIME;
-  if (runtime === 'headless' || runtime === 'teams') return true;
+  if (runtime === 'headless' || runtime === 'teams' || runtime === 'terminal') return true;
   return !process.stdin.isTTY && !process.stdout.isTTY;
 }
 
@@ -1343,8 +1352,16 @@ export function readAndResolveBundleEnv(
   // synchronously wait for approval. Never/no-ACL bundles remain prompt-free.
   // The always-on daemon has no requesting agent waiting on the result, so it
   // remains prompt-free unless the bundle is explicitly no-ACL.
-  const interactiveUnlock = opts.interactiveUnlock
-    ?? (Boolean(opts.agent || process.env.AGENTS_AGENT_NAME) && process.env.AGENTS_SECRETS_NO_PROMPT !== '1');
+  // Explicit opt-in ONLY. This used to default to true whenever an agent name was
+  // present, which made `agentOnly: true` a no-op for every agent-initiated read —
+  // the guard was dead in precisely the case it exists for. The effect: opening an
+  // agent terminal, or a routine firing, would fall through to a prompting keychain
+  // read, and because each read is its own helper process the assertion never
+  // reuses, so one launch could raise several Touch ID sheets in a row. Only
+  // `AGENTS_SECRETS_NO_PROMPT=1` suppressed it, which is a workaround, not a
+  // default. No caller passes this flag today; it stays for a genuinely
+  // user-initiated unlock path that wants to raise the sheet on purpose.
+  const interactiveUnlock = opts.interactiveUnlock ?? false;
   if (opts.agentOnly && backend === 'keychain' && !interactiveUnlock) {
     let noAclBundle = false;
     try { noAclBundle = bundlePolicy(readBundle(name)) === 'never'; } catch { /* fail closed */ }

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -1259,6 +1259,10 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
 export function isHeadlessSecretsContext(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
+  // Injected so the TTY branch below is testable: it is the branch that decides a
+  // plain human shell still prompts, which is this guard's entire safety argument,
+  // and reading process.* directly made it unreachable from a test.
+  tty: { stdin?: boolean; stdout?: boolean } = { stdin: process.stdin.isTTY, stdout: process.stdout.isTTY },
 ): boolean {
   if (platform !== 'darwin') return false; // no biometry prompt to suppress off-darwin
   const override = env.AGENTS_SECRETS_NO_PROMPT;
@@ -1271,13 +1275,13 @@ export function isHeadlessSecretsContext(
   // a TTY meant "a human is watching, so prompting is fine". It is not fine —
   // opening a terminal is not a request to authenticate, and a launch that needs
   // a locked bundle should say so and point at `agents secrets unlock`, not grab
-  // the fingerprint sensor. Note AGENTS_RUNTIME is INHERITED by everything spawned
-  // under an agent terminal, so a human typing `agents secrets export` inside one
-  // sees it too — those commands pass `interactiveUnlock: true` explicitly
-  // (commands/secrets.ts) so a deliberate human request still raises the sheet.
+  // the fingerprint sensor. AGENTS_RUNTIME is INHERITED by everything spawned under
+  // an agent, so `agents secrets export` run beneath one resolves broker-only too —
+  // correctly: there the agent, not the human, is the caller. A plain shell carries
+  // no AGENTS_RUNTIME, so a person running it themselves still gets the sheet.
   const runtime = env.AGENTS_RUNTIME;
   if (runtime === 'headless' || runtime === 'teams' || runtime === 'terminal') return true;
-  return !process.stdin.isTTY && !process.stdout.isTTY;
+  return !tty.stdin && !tty.stdout;
 }
 
 /**
@@ -1354,10 +1358,8 @@ export function readAndResolveBundleEnv(
     }
   }
 
-  // A headless harness may initiate the macOS authentication sheet itself and
-  // synchronously wait for approval. Never/no-ACL bundles remain prompt-free.
-  // The always-on daemon has no requesting agent waiting on the result, so it
-  // remains prompt-free unless the bundle is explicitly no-ACL.
+  // Never/no-ACL bundles remain prompt-free regardless. No agent launch — harness,
+  // teammate, routine, or the always-on daemon — may raise the sheet itself.
   // Explicit opt-in ONLY — a deliberate NARROWING of the agent-triggered approval
   // added in RUSH-2032 (b99796f8 removed this throw so an agent could raise the
   // sheet itself; 4eeada68 generalized the daemon rule into `!interactiveUnlock`).

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -1263,12 +1263,14 @@ export function isHeadlessSecretsContext(
   // Every AGENT-LAUNCH runtime resolves broker-only, interactive included.
   // `terminal` was missing, which made an agent terminal the one launch path
   // still allowed to pop Touch ID: exec.ts sets AGENTS_RUNTIME='terminal' for an
-  // interactive run (exec.ts:426), that fell through to the TTY check below, and
+  // interactive run (exec.ts:430), that fell through to the TTY check below, and
   // a TTY meant "a human is watching, so prompting is fine". It is not fine —
   // opening a terminal is not a request to authenticate, and a launch that needs
   // a locked bundle should say so and point at `agents secrets unlock`, not grab
-  // the fingerprint sensor. Explicit `agents secrets` commands are unaffected:
-  // they carry no AGENTS_RUNTIME and still fall through to the TTY check.
+  // the fingerprint sensor. Note AGENTS_RUNTIME is INHERITED by everything spawned
+  // under an agent terminal, so a human typing `agents secrets export` inside one
+  // sees it too — those commands pass `interactiveUnlock: true` explicitly
+  // (commands/secrets.ts) so a deliberate human request still raises the sheet.
   const runtime = env.AGENTS_RUNTIME;
   if (runtime === 'headless' || runtime === 'teams' || runtime === 'terminal') return true;
   return !process.stdin.isTTY && !process.stdout.isTTY;
@@ -1366,7 +1368,11 @@ export function readAndResolveBundleEnv(
     let noAclBundle = false;
     try { noAclBundle = bundlePolicy(readBundle(name)) === 'never'; } catch { /* fail closed */ }
     if (!noAclBundle) {
-      throw new Error(`Secrets bundle '${name}' is not unlocked in the secrets agent.`);
+      throw new Error(
+        `Secrets bundle '${name}' is not unlocked in the secrets agent. ` +
+        `Run 'agents secrets unlock ${name}' in a terminal first — an agent launch ` +
+        `never raises a Touch ID sheet on its own.`
+      );
     }
   }
 

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -1231,15 +1231,19 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
  * True when the current process is a background / non-interactive context that
  * must NEVER raise a Keychain biometry prompt on the interactive user's screen —
  * a prompt nobody is watching. Two signals, either sufficient:
- *   - `AGENTS_RUNTIME` is `headless` or `teams` (set on the child env by
- *     `agents run --headless`, scheduled routines, and teammates — see
- *     exec.ts:resolveInteractive, runner.ts, teams/agents.ts).
+ *   - `AGENTS_RUNTIME` is `headless`, `teams`, or `terminal` — i.e. ANY agent
+ *     launch, interactive included, and inherited by everything spawned beneath
+ *     one (set on the child env by `agents run --headless`, scheduled routines,
+ *     teammates, and interactive runs — see exec.ts:430, runner.ts,
+ *     teams/agents.ts).
  *   - neither stdin nor stdout is a TTY (a detached/backgrounded task whose
  *     stdio is redirected to a log — e.g. a release script run in the
  *     background as `( ... ) >log 2>&1 </dev/null`).
  * `AGENTS_SECRETS_NO_PROMPT=1` forces headless-safe; `=0` force-allows a prompt
- * even in a non-TTY context. An interactive `eval "$(agents secrets export X)"`
- * keeps its terminal stdin, so it is NOT classified headless and still prompts.
+ * even in a non-TTY context. An `eval "$(agents secrets export X)"` typed in a
+ * PLAIN shell has no AGENTS_RUNTIME, so it is not classified headless and still
+ * prompts. Run beneath an agent it inherits AGENTS_RUNTIME and resolves
+ * broker-only — the agent, not the human, is the caller there.
  *
  * Only **macOS keychain** reads pop an interactive Touch ID sheet — the secrets
  * broker itself is a no-op off darwin (see agent.ts), and libsecret (Linux) /
@@ -1354,15 +1358,16 @@ export function readAndResolveBundleEnv(
   // synchronously wait for approval. Never/no-ACL bundles remain prompt-free.
   // The always-on daemon has no requesting agent waiting on the result, so it
   // remains prompt-free unless the bundle is explicitly no-ACL.
-  // Explicit opt-in ONLY. This used to default to true whenever an agent name was
-  // present, which made `agentOnly: true` a no-op for every agent-initiated read —
-  // the guard was dead in precisely the case it exists for. The effect: opening an
-  // agent terminal, or a routine firing, would fall through to a prompting keychain
-  // read, and because each read is its own helper process the assertion never
-  // reuses, so one launch could raise several Touch ID sheets in a row. Only
-  // `AGENTS_SECRETS_NO_PROMPT=1` suppressed it, which is a workaround, not a
-  // default. No caller passes this flag today; it stays for a genuinely
-  // user-initiated unlock path that wants to raise the sheet on purpose.
+  // Explicit opt-in ONLY — a deliberate NARROWING of the agent-triggered approval
+  // added in RUSH-2032 (b99796f8 removed this throw so an agent could raise the
+  // sheet itself; 4eeada68 generalized the daemon rule into `!interactiveUnlock`).
+  // That default — true whenever an agent name was present — was the spec, not a
+  // bug. It is unwanted: each keychain read runs in its own helper process, so the
+  // biometric assertion never reuses and one agent launch meant one sheet per
+  // bundle. `agentOnly` decides alone now; a human in a plain shell carries no
+  // AGENTS_RUNTIME, so isHeadlessSecretsContext() is false, agentOnly is false, the
+  // guard never fires, and they still get their prompt. No caller passes this flag;
+  // it remains the seam for a future unlock path that wants the sheet on purpose.
   const interactiveUnlock = opts.interactiveUnlock ?? false;
   if (opts.agentOnly && backend === 'keychain' && !interactiveUnlock) {
     let noAclBundle = false;


### PR DESCRIPTION
## What this is

A **deliberate narrowing of RUSH-2032** at the user's direction — not a bugfix.

> the Touch ID helper should not be getting asked when routines run. Or when I start a new Claude Code agent terminal

RUSH-2032 (`b99796f8` → `fa0f55d6` → `4eeada68`, all unreleased) introduced **agent-triggered approval**: an agent could raise the macOS sheet itself and wait for it. The `interactiveUnlock` default — true whenever an agent name is present — is that spec, not dead code. An earlier revision of this PR described it as a dead guard; review corrected that with the commit history.

The behavior is unwanted: each keychain read runs in **its own helper process**, so the biometric assertion never reuses — one launch meant one sheet per bundle.

## The change

1. `interactiveUnlock` is explicit opt-in (`opts.interactiveUnlock ?? false`). No caller passes it, so an agent-initiated read no longer bypasses `agentOnly`.
2. `isHeadlessSecretsContext` treats `terminal` as a launch runtime alongside `headless`/`teams` — `exec.ts:430` sets it for interactive runs. Routines and teammates were already prompt-free; agent terminals were not.
3. The TTY state is now an injected parameter, so the branch that decides a plain shell still prompts is testable.

`agentOnly: isHeadlessSecretsContext()` draws the whole line by itself. An intermediate revision added `interactiveUnlock: true` at six `agents secrets` call sites to protect "human-typed" commands; review proved that **re-opened the hole** — a literal cannot tell a keystroke from an agent's `Bash` call, so a routine calling `agents secrets get` still prompted. Reverted. The premise was wrong: typing into an agent terminal is not a human invoking the command, the agent is.

## Behavior, verified under a real PTY

| Context | `isHeadlessSecretsContext` | Result |
|---|---|---|
| plain shell, TTY | `false` | prompts |
| routine (`headless`) | `true` | refuses, names `agents secrets unlock` |
| agent terminal (`terminal`) | `true` | refuses |
| teammate (`teams`) | `true` | refuses |
| `agents secrets unlock` | n/a — passes no `agentOnly` | prompts |

`AGENTS_SECRETS_NO_PROMPT=1` stops being a required workaround.

## Tests

`src/lib/secrets` → **441 passed, 0 failed**. `tsc --noEmit` clean.

The TTY branch previously had **zero** coverage — a mutant making a plain shell never prompt (which would strand every cold bundle) left all 438 tests green. Now covered, and verified by mutation: substituting `return true` yields `1 failed | 40 passed`; restored yields `41 passed`.

One test reversed on purpose: `allows an agent-triggered interactive read...` asserted the RUSH-2032 behavior. Now `refuses an agent-triggered read of a locked daily bundle instead of prompting`, with a sibling proving an explicit `interactiveUnlock: true` still resolves.

## Surfaces that now refuse when invoked from inside an agent

`agents share` (`share/config.ts:97`), `agents browser type --secret` (`browser.ts:1560`), `agents webhook serve` (`webhook.ts:29`), the `get_secret` MCP tool (`mcp.ts:114`), crabbox leases (`crabbox/cli.ts:205`), antigravity dispatch (`cloud/antigravity.ts:100`), password-auth `agents ssh` (`ssh.ts:1235`), and `agents secrets get/export/exec`. Four swallow the throw and degrade quietly (`share/config.ts:135`, `browser/chrome.ts:319`, `crabbox/cli.ts:231`, `daemon.ts:793`) — pre-existing. All recoverable with `agents secrets unlock`.

## Docs

`apps/cli/docs/secrets.md` §"Agent-scoped unlocks" and the root `CHANGELOG.md` RUSH-2032 entry both advertised agent-triggered approval; both now describe the narrowed behavior, including that "typed yourself" means **in a plain shell** — beneath an agent the same command refuses.

## Note

The commit message on `e4552199` lost two backticked code spans to shell substitution. Content is unaffected; not force-pushing to fix a message.
