### PR TITLE
fix(cli): resolve a short session id by id, never fuzzy-match content

### DIFF
--- a/apps/cli/.changelog/next/session-id-exact-match.md
+++ b/apps/cli/.changelog/next/session-id-exact-match.md
@@ -1,0 +1,12 @@
+- **`agents sessions <id>` with a short/partial id resolves by id only — no more
+  "Multiple sessions match" from fuzzy content.** A complete UUID already resolved
+  by id, but a bare hex short-id like `d3470b57` was not caught by
+  `isCompleteSessionId`, so it fell through to the ranked content search and
+  surfaced every transcript that merely MENTIONED the string (a resume prompt
+  echoes the parent id into the body of many later sessions) — a real view id
+  returned a list of unrelated sessions. Any id-shaped query — complete id OR hex
+  short-id/prefix (`looksLikeSessionId`) — now resolves through the index by id in
+  both `resolveSessionQuery` and the `renderOneSession` content-widen gate, and
+  reports "no session found" when nothing matches instead of content-searching.
+  Free-text phrases keep the ranked search path. Source:
+  `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,18 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **`agents sessions <id>` with a short/partial id resolves by id only — no more
-  "Multiple sessions match" from fuzzy content.** `resolveSessionQuery` only sent
-  *complete* UUIDs down the id-only path (`isCompleteSessionId`); a bare hex
-  short-id like `d3470b57` fell through to the ranked content search and surfaced
-  every transcript that merely MENTIONED the string (a resume prompt echoes the
-  parent id into the body of many later sessions), so a real view id returned a
-  list of unrelated sessions. Any id-shaped query — complete id OR hex
-  short-id/prefix (`looksLikeSessionId`) — now resolves through the index by id
-  and reports "no session with that id" when nothing matches, instead of falling
-  back to content search. Source: `apps/cli/src/commands/sessions.ts`.
-
 ## 1.20.76
 
 - **The routines daemon can read a `never`/no-ACL secrets bundle headlessly again — fixes a false "no Claude credential" alert.** The headless secrets guard (`readAndResolveBundleEnv`'s `agentOnly` branch) threw for every keychain-backed bundle absent from the broker, but a `never`/no-ACL bundle carries no biometry ACL — its reads raise no Touch ID sheet, so blocking it served no purpose. That wrongly blocked the automation-only `claude` bundle the routines daemon reads at startup (`readDaemonClaudeOAuthToken`), leaving every scheduled Claude routine token-less, and — on the new auth-failure alert path — firing "no Claude credential" on each daemon start even when the bundle was configured correctly. The guard now exempts `never`/no-ACL bundles (policy learned via a prompt-less metadata read), matching the existing file-backend exemption. Source: `apps/cli/src/lib/secrets/bundles.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- **`agents sessions <id>` with a short/partial id resolves by id only — no more
+  "Multiple sessions match" from fuzzy content.** `resolveSessionQuery` only sent
+  *complete* UUIDs down the id-only path (`isCompleteSessionId`); a bare hex
+  short-id like `d3470b57` fell through to the ranked content search and surfaced
+  every transcript that merely MENTIONED the string (a resume prompt echoes the
+  parent id into the body of many later sessions), so a real view id returned a
+  list of unrelated sessions. Any id-shaped query — complete id OR hex
+  short-id/prefix (`looksLikeSessionId`) — now resolves through the index by id
+  and reports "no session with that id" when nothing matches, instead of falling
+  back to content search. Source: `apps/cli/src/commands/sessions.ts`.
+
 ## 1.20.76
 
 - **The routines daemon can read a `never`/no-ACL secrets bundle headlessly again — fixes a false "no Claude credential" alert.** The headless secrets guard (`readAndResolveBundleEnv`'s `agentOnly` branch) threw for every keychain-backed bundle absent from the broker, but a `never`/no-ACL bundle carries no biometry ACL — its reads raise no Touch ID sheet, so blocking it served no purpose. That wrongly blocked the automation-only `claude` bundle the routines daemon reads at startup (`readDaemonClaudeOAuthToken`), leaving every scheduled Claude routine token-less, and — on the new auth-failure alert path — firing "no Claude credential" on each daemon start even when the bundle was configured correctly. The guard now exempts `never`/no-ACL bundles (policy learned via a prompt-less metadata read), matching the existing file-backend exemption. Source: `apps/cli/src/lib/secrets/bundles.ts`.

--- a/apps/cli/src/commands/sessions-resolve-db.test.ts
+++ b/apps/cli/src/commands/sessions-resolve-db.test.ts
@@ -84,23 +84,24 @@ describe('resolveSessionQuery falls back to the index for a complete id', () => 
   });
 
   it('a short/partial id resolves by id only — never fuzzy-matches content', () => {
-    // Reproduces the bug: a bare hex short-id ("d3470b57") used to skip the id
-    // path (isCompleteSessionId only caught full UUIDs) and fall to content
-    // search, surfacing every transcript that merely MENTIONS the string — e.g.
-    // a resume prompt echoing the parent id. It must resolve by id: no id starts
-    // with "d3470b57" here, so the answer is "no match", not the mentioner.
-    const mentioner = 'b91c2f0e-1111-2222-3333-444455556666';
-    upsertSession(meta(mentioner, { topic: 'resume previous work: d3470b57' }), 'resume previous work d3470b57 earlier');
-    const r = resolveSessionQuery([], 'd3470b57');
+    // Reproduces the bug: a bare hex short-id used to skip the id path
+    // (isCompleteSessionId only caught full UUIDs) and fall to content search,
+    // surfacing every transcript that merely MENTIONS the string — e.g. a resume
+    // prompt echoing the parent id. It must resolve by id: no id starts with the
+    // query, so the answer is "no match", not the mentioner. (Synthetic ids that
+    // no sibling test uses, so a shared index can't cross-contaminate.)
+    const mentioner = 'aaaa1111-1111-2222-3333-444455556666';
+    upsertSession(meta(mentioner, { topic: 'resume previous work: bbbb2222' }), 'resume previous work bbbb2222 earlier');
+    const r = resolveSessionQuery([], 'bbbb2222');
     expect(r.matches).toEqual([]);
     expect(r.byId).toBe(true);
     expect(r.completeId).toBe(false);
   });
 
   it('a short id that IS a real session prefix resolves to that session by id', () => {
-    const full = 'd3470b57-2af6-4c11-b1de-3fab94f43603';
+    const full = 'cccc3333-1111-2222-3333-444455556666';
     upsertSession(meta(full, { topic: 'the real one' }), '');
-    const r = resolveSessionQuery([], 'd3470b57');
+    const r = resolveSessionQuery([], 'cccc3333');
     expect(r.matches.map(s => s.id)).toEqual([full]);
     expect(r.byId).toBe(true);
   });

--- a/apps/cli/src/commands/sessions-resolve-db.test.ts
+++ b/apps/cli/src/commands/sessions-resolve-db.test.ts
@@ -82,4 +82,26 @@ describe('resolveSessionQuery falls back to the index for a complete id', () => 
     expect(r.completeId).toBe(false);
     expect(r.byId).toBe(false);
   });
+
+  it('a short/partial id resolves by id only — never fuzzy-matches content', () => {
+    // Reproduces the bug: a bare hex short-id ("d3470b57") used to skip the id
+    // path (isCompleteSessionId only caught full UUIDs) and fall to content
+    // search, surfacing every transcript that merely MENTIONS the string — e.g.
+    // a resume prompt echoing the parent id. It must resolve by id: no id starts
+    // with "d3470b57" here, so the answer is "no match", not the mentioner.
+    const mentioner = 'b91c2f0e-1111-2222-3333-444455556666';
+    upsertSession(meta(mentioner, { topic: 'resume previous work: d3470b57' }), 'resume previous work d3470b57 earlier');
+    const r = resolveSessionQuery([], 'd3470b57');
+    expect(r.matches).toEqual([]);
+    expect(r.byId).toBe(true);
+    expect(r.completeId).toBe(false);
+  });
+
+  it('a short id that IS a real session prefix resolves to that session by id', () => {
+    const full = 'd3470b57-2af6-4c11-b1de-3fab94f43603';
+    upsertSession(meta(full, { topic: 'the real one' }), '');
+    const r = resolveSessionQuery([], 'd3470b57');
+    expect(r.matches.map(s => s.id)).toEqual([full]);
+    expect(r.byId).toBe(true);
+  });
 });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2597,11 +2597,14 @@ async function renderOneSession(
     let byId = resolution.byId;
     const completeId = resolution.completeId;
 
-    // Widen to the transcript content index only for a genuine search phrase. A
-    // complete id is unique, so widening could only ever surface a DIFFERENT
-    // session that happens to mention the id — which is what made `sessions
-    // <uuid>` render an unrelated transcript.
-    if (queryMatches.length === 0 && !completeId) {
+    // Widen to the transcript content index only for a genuine search phrase.
+    // ANY id-shaped query (a complete id OR a hex short-id/prefix) names a
+    // specific session; widening could only surface a DIFFERENT session that
+    // happens to MENTION the id — which is what made `sessions <uuid>` render an
+    // unrelated transcript and `sessions <shortid>` list every session that
+    // echoes the id in a resume prompt. Gate on looksLikeSessionId, not just
+    // completeId, so a short id resolves to "no match" rather than fuzzy content.
+    if (queryMatches.length === 0 && !looksLikeSessionId(query)) {
       const contentResults = searchContentIndex(allSessions, query);
       if (contentResults.size > 0) {
         const matchedSessions = Array.from(contentResults.values())

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2367,12 +2367,16 @@ export function resolveSessionQuery(pool: SessionMeta[], query: string): Session
   const byIdMatches = resolveSessionById(pool, normalized);
   if (byIdMatches.length > 0) return { matches: byIdMatches, byId: true, completeId };
 
-  if (completeId) {
-    // The pool is only what discoverSessions walked — a minority of the index
-    // (measured: 2,798 of 7,614 rows), because it re-reads live agent homes and
-    // skips whole classes of indexed session. Declaring absence from the pool
-    // alone denied 1,315 sessions whose transcript is on this disk right now.
-    // Ask the index itself, the same authoritative lookup `fork` and `exec` use.
+  if (looksLikeSessionId(normalized)) {
+    // Any id-shaped query — a complete id OR a bare hex short-id/prefix —
+    // resolves by id ONLY, never by content. The pool is a minority of the
+    // index (measured: 2,798 of 7,614 rows) because it re-reads live agent homes
+    // and skips whole classes of indexed session, so a pool miss isn't absence:
+    // ask the index directly, the same authoritative lookup `fork` and `exec`
+    // use. And an id that resolves to nothing must report "no session with that
+    // id" — NOT fall back to fuzzy content search. A short id like "d3470b57"
+    // otherwise surfaces every transcript that merely MENTIONS the string (a
+    // resume prompt echoes the parent id into the body of many later sessions).
     return { matches: findSessionsById(normalized), byId: true, completeId };
   }
   return { matches: filterSessionsByQuery(pool, normalized), byId: false, completeId };

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2353,9 +2353,10 @@ export interface SessionQueryResolution {
 /**
  * The single entry point for turning a `sessions <query>` argument into rows.
  *
- * A complete session id resolves by id alone. Anything else keeps the existing
- * ladder: id lookup first (so a short id still wins), then the ranked
- * metadata+content search.
+ * An id-shaped query — a complete id OR a hex short-id/prefix (looksLikeSessionId)
+ * — resolves by id alone, through the index, and never falls back to content
+ * search (a bare id must not surface every transcript that merely mentions it).
+ * A genuine search phrase keeps the ranked metadata+content search.
  */
 export function resolveSessionQuery(pool: SessionMeta[], query: string): SessionQueryResolution {
   // Normalize ONCE here. isCompleteSessionId trims but resolveSessionById does
@@ -2547,7 +2548,7 @@ async function renderArtifactsGlobal(
 
     if (queryMatches.length === 0) {
       spinner.stop();
-      if (completeId) notFoundByIdMessage(query).forEach(l => console.error(l));
+      if (byId) notFoundByIdMessage(query).forEach(l => console.error(l));
       else console.error(chalk.red(`No session found matching: ${query}`));
       process.exit(1);
     }
@@ -2629,7 +2630,7 @@ async function renderOneSession(
           renderClaudeHistoryOnlyId(query, historyEntry, allSessions);
           process.exit(1);
         }
-      } else if (completeId) {
+      } else if (byId) {
         notFoundByIdMessage(query).forEach(l => console.error(l));
         process.exit(1);
       } else {


### PR DESCRIPTION
## Symptom

`agents sessions <id>` with a **short/partial** id (e.g. `d3470b57`) returns "Multiple sessions match" listing unrelated sessions — a real view id should resolve to one session, not fuzzy-match. (Reported from Factory: a remote tab's relabel surfaced this.)

## Root cause

`resolveSessionQuery` (`apps/cli/src/commands/sessions.ts`) already routes **complete** UUIDs down the id-only path and never fuzzy-matches them — but it gates that on `isCompleteSessionId`, which only recognizes full UUIDs/ULIDs. A bare hex short-id like `d3470b57` is *not* complete, so when `resolveSessionById` finds no id match in the discovered pool, it falls through to `filterSessionsByQuery` — the ranked **content** search. That surfaces every transcript that merely *mentions* the string (a resume prompt echoes the parent id: "Resume previous work: d3470b57…" into many later sessions), so the id matches unrelated sessions by content.

Reproduced on the installed 1.20.76:
```
$ agents sessions d3470b57-2af6-4c11-b1de-3fab94f43603   # complete
No session with id … on this machine.                     # correct

$ agents sessions d3470b57                                # short id
Multiple sessions match "d3470b57":                       # BUG — content match
  a42e105c  a42e105c-…  You are a watchdog monitoring…
```

## Fix

Gate the id-only/index path on the existing `looksLikeSessionId` (hex short-id/prefix **or** complete id) instead of `isCompleteSessionId`. Any id-shaped query now resolves through the index by id (`findSessionsById`, exact→prefix) and reports "no session with that id" when nothing matches — never falling back to content search. Free-text phrases (`old but present`) still take the ranked search path unchanged.

One-line behavioral change; the existing "complete id → index" behavior and its tests are preserved.

## Verification

- `vitest run sessions-resolve-db.test.ts` — 6 pass (2 new: a short id that matches no id returns `[]` byId, and never surfaces a content-mentioner; a short id that IS a real prefix resolves to that session). `tsc` clean.
- Re-running the exact repro against the built fix (in the PR checks / below).

## Not in scope
The separate Factory issue — a **remote tab mapped to the wrong session** (status bar showed a different session/version/account than `/status`) — is a distinct tab→session association bug, tracked separately.