### PR TITLE
chore: auto-checkpoint working changes from main (2026-08-01)

### DIFF
--- a/.grok/.agents-managed.json
+++ b/.grok/.agents-managed.json
@@ -1,0 +1,13 @@
+{
+  "v": 1,
+  "paths": [
+    "skills/cgraph",
+    "skills/docs",
+    "skills/reflect",
+    "skills/release",
+    "skills/scripts",
+    "skills/security",
+    "skills/sessions",
+    "skills/version"
+  ]
+}

--- a/.grok/skills/cgraph/SKILL.md
+++ b/.grok/skills/cgraph/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: cgraph
+description: "Use FIRST for any question about THIS codebase's structure, symbols, or relationships — where a function/class/file is defined, what calls or imports it, what breaks if you change it, how two parts connect, or to load focused source context before editing or reviewing. Routes to the cgraph MCP tools (graph_query / graph_explain / graph_impact / graph_path / graph_context), which serve ranked file:line results, node neighborhoods, transitive blast radius, and token-budgeted source bundles from a resident per-project graph daemon in ~10ms — far cheaper than grepping and reading files. Prefer over blind grep/read for code navigation, dependency tracing, and impact analysis."
+user-invocable: true
+---
+
+# cgraph
+
+cgraph keeps a live, queryable graph of the current project — symbols (functions,
+classes, types, files), their call/import/inheritance/containment edges, and
+centrality ranking — served by a resident per-project daemon through MCP tools.
+
+**Reach for these tools before grepping or reading files** when a question is
+about code structure or relationships. A graph call is one ~10ms round-trip and
+returns exactly the file:line (and often the source) you need, instead of many
+grep/read calls that burn context.
+
+## Setup (one-time — the tools don't exist until this is done)
+
+This skill routes to the `cgraph` MCP server. On a cold checkout that server is
+**not** registered — until it is, the `graph_*` tools below don't exist and you
+should navigate with grep/read. Registration is a local, per-machine step (the
+`.mcp.json` it writes is gitignored, not committed), so a fresh clone needs it.
+
+1. **Build cgraph from source** — it's a native C++ engine (CMake + vcpkg,
+   C++20; on Linux `igraph` also needs `gfortran`). Full instructions:
+   <https://github.com/taylor009/CGraph> → *Install & Setup*. This produces
+   `cgraph`, `graphd`, `cgraph-client`, and `cgraph-mcp`.
+2. **Register the MCP server** (project-scoped, absolute binary paths):
+   ```sh
+   agents mcp add cgraph -s project -a claude,codex -- \
+     /abs/path/to/cgraph-mcp --root "$(pwd)" --daemon /abs/path/to/graphd
+   agents mcp register cgraph
+   ```
+3. Restart the agent session so it picks up the server. `graph_status` should
+   then answer, and the first query triggers a one-time build (seconds).
+
+If the `graph_*` tools return "no such tool", registration hasn't happened —
+fall back to grep/read and (if you can) run the steps above.
+
+## Routing: question → tool
+
+| When the user / task needs… | Call |
+| --- | --- |
+| "Where is X? Find the symbol named …" | `graph_query` `{query}` — ranked by importance, each hit has `source_file` + `line` |
+| "What is X? Show its callers/callees/imports" | `graph_explain` `{id}` — node + neighbors (each with `direction` and a navigable brief) + a source snippet |
+| "What breaks if I change X? What depends on it?" | `graph_impact` `{id, direction:"dependents"}` — transitive blast radius, bounded by `max_depth` |
+| "What does X rely on?" | `graph_impact` `{id, direction:"dependencies"}` |
+| "How does A connect to B?" | `graph_path` `{source, target}` — shortest path, with `path_nodes` briefs |
+| "Load context on X" / before editing or reviewing X | `graph_context` `{query or id, budget}` — focal node + most-relevant neighbors with snippets, packed to a token budget |
+| "Verify the graph is current before I rely on it" | `graph_update {path:"."}` — blocking content-verified synchronization; returns `freshness.content_root`. Pin subsequent reads by passing the root as `expected_content_root`. |
+| "Is the graph current? / I just changed files" | Nothing for ordinary reads — the daemon watches the tree and folds edits in within seconds. Use `graph_update` when you need a verified content_root to pin reads. |
+
+## How to use the results
+
+- `graph_query` matches case-insensitively and can be narrowed with `kind`
+  (e.g. `"function"`, `"class"`, `"file"`), `file` (source-path substring), and
+  `limit`. On zero matches it returns `suggestions` — the closest symbol names —
+  so correct the spelling and retry instead of falling back to grep.
+- Every id-taking tool (`graph_explain` / `graph_impact` / `graph_path` /
+  `graph_context`) also accepts a bare symbol name (e.g. `"merge_fragments"`);
+  the response echoes the canonical `id` it resolved. A miss comes back with
+  `found: false` plus `suggestions`.
+- `graph_query` returns ids and `source_file`:`line`. Open the file at `line`
+  directly — no second search needed.
+- `graph_explain` takes `direction` (`"in"` = callers/importers, `"out"` =
+  callees/imports) and `limit`; neighbors are ordered most-important-first and
+  `neighbor_count`/`truncated` flag when a hub has more edges than returned.
+- `graph_context` is the highest-leverage call before an edit or review: ask for
+  a budget (e.g. `4000`) and it returns the focal symbol's source plus its
+  neighborhood's source, ranked and trimmed to fit. Read that instead of opening
+  files one by one. It reports `omitted` / `truncated` if more existed.
+- `graph_context` has two **gather** modes. The default (`gather:"fixed"`) packs
+  the whole k-hop neighborhood. When you have a task in hand, pass
+  `gather:"adaptive"` **together with a `query`** — it keeps the full 2-hop core
+  but expands the third hop only along query-relevant nodes. On the retrieval
+  eval that lifted grade-2 recall by **+0.057 for +13% candidate tokens**, versus
+  the **+96%** a full 3-hop gather costs. The relevance gate is a no-op without a
+  query, so never send `adaptive` without one. The response echoes
+  `gather:"adaptive"`, `packing:"knapsack"`, and a `reach` summary
+  (`{candidates, expanded_past_core, gated_at_core}` — `expanded_past_core: 0`
+  means nothing relevant lay past the 2-hop core, so it collapsed to it). Raise
+  or lower `gather_theta` to tighten or loosen the relevance threshold.
+- `graph_impact` with `dependents` is the safety check before changing a
+  signature or deleting a symbol: it lists everything that would be affected,
+  by depth.
+
+## Freshness-sensitive navigation
+
+When a task must rely on the graph being current with the worktree — before impact
+analysis of a symbol you just moved, or after a batch of file edits — use the
+synchronize-then-pin pattern:
+
+```
+1. update = graph_update {path: "."}
+2. root = update.freshness.content_root
+3. graph_query / graph_explain / graph_impact / graph_path / graph_context
+       {…, expected_content_root: root}
+```
+
+`graph_update` is a blocking content-verified barrier: it hashes every detected
+code file and re-extracts any whose content changed. The returned
+`freshness.content_root` uniquely identifies that source snapshot. The response
+also reports `files_hashed` and `bytes_hashed`. Passing the root as
+`expected_content_root` on a subsequent read pins the response to the same
+snapshot; the daemon returns an
+error instead of graph data if it has published a different root since then.
+
+Ordinary reads (without `expected_content_root`) do not scan the filesystem. They
+read the latest published snapshot and return its `freshness` metadata; during
+startup or for non-source seam graphs, `freshness.verified` can be `false`. The
+daemon keeps source-backed snapshots current through automatic file watching.
+Use synchronization and a pin when you need proof that the graph matches specific
+source content.
+
+## Session memory (survive /compact and /clear)
+
+The daemon and `graph.json` live **outside your context window**, so a checkpoint
+written before a `/compact` or `/clear` is still recall-able afterward. Use this
+to carry the task thread across a context reset instead of losing it.
+
+- `graph_remember {title, body, touches?, tags?}` — write one checkpoint. `body`
+  is a **distilled** markdown summary of what you did and what's next; `touches`
+  lists the code symbols (ids or bare names) the work concerns, so recall can link
+  back to them. Persist only the distilled outcome — **never** raw tool output,
+  DOM snapshots, or chain-of-thought.
+- `graph_recall {query?, limit?}` — return recent checkpoints newest-first, each
+  with its body and briefs of the code it touched. After a `/clear`, recall first
+  (~KB payload) to restore the thread, then `graph_context` on a linked symbol to
+  reload just-enough source.
+
+The discipline is **distill → checkpoint → clear → recall**. Checkpoints are
+inert to code analysis (they never shift query/impact/context rankings) and
+survive daemon restart, incremental edits, and full rescans — the sidecars under
+`cgraph-out/memory/` are the durable source of truth.
+
+## Practicalities
+
+- The `cgraph` MCP server must be registered (it auto-spawns a per-project daemon
+  keyed to the project root). The first tool call in a project triggers a
+  one-time graph build (seconds), then queries are warm (~10ms).
+- While that first build runs, results carry `"graph_state": "building"` — an
+  empty result then means "not built yet", not "no match". Retry after a few
+  seconds or poll `graph_status` until `build_state` is `"ready"`.
+- The daemon watches the project tree (`graph_status` reports `watching`): file
+  edits land in the graph automatically within a few seconds, and the graph is
+  re-persisted in the background.
+- Fall back to grep/read only when cgraph genuinely has no answer — e.g. a
+  string literal, a comment, a config value, or a file type cgraph does not
+  extract. For symbols and their relationships, prefer the graph.
+- cgraph indexes code structure deterministically. Prose/doc relationships
+  appear only if semantic enrichment fragments have been ingested; don't assume
+  documentation concepts are present unless `graph_status` shows enrichment.

--- a/.grok/skills/docs/SKILL.md
+++ b/.grok/skills/docs/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: docs
+description: "Write documentation — user-facing, technical, runbooks, onboarding, changelogs. Less is more: only document what code can't tell you."
+user-invocable: true
+---
+
+# Documentation
+
+Less is more. Agents and humans can gather context on the fly. Only document what's hard to see from code:
+
+- **Architecture** — Component relationships, data flow, system boundaries
+- **Why** — Decisions, constraints, tradeoffs (not what)
+- **Operations** — Procedures that require specific steps
+- **User interfaces** — Public APIs, CLIs, tools
+
+## Routing Table
+
+| Task | Subskill | When to Use |
+|---|---|---|
+| User-facing (CLI, API, tools) | `write-user.md` | Public interfaces, README, guides |
+| Internal technical | `write-technical.md` | Architecture docs, system design |
+| Runbooks | `write-runbook.md` | Operational procedures, troubleshooting |
+| Onboarding | `write-onboarding.md` | New contributor guide |
+| Changelogs | `write-changelog.md` | Release notes |
+
+## Core Principles
+
+**1. Don't document what code tells you.**
+If someone can read the function and understand it, don't write docs. Comments rot. Code is truth.
+
+**2. Architecture over implementation.**
+Document component boundaries, data flow, integration points. Not how functions work internally.
+
+**3. High-level, like a principal engineer.**
+Write for someone who understands systems but doesn't know THIS system. Skip basics.
+
+**4. Diagrams over prose.**
+One ASCII diagram or mermaid chart replaces paragraphs. Show structure visually.
+
+**5. Reference the code, don't duplicate it.**
+`See harness/agent/execution.go:306-500` beats copying code into docs.
+
+## Decision Tree
+
+```
+Need documentation?
+├── Public interface (CLI, API)? → write-user.md
+├── System architecture? → write-technical.md
+├── Operational procedure? → write-runbook.md
+├── New contributor setup? → write-onboarding.md
+├── Release notes? → write-changelog.md
+└── Implementation details? → DON'T DOCUMENT. Code is the doc.
+```

--- a/.grok/skills/docs/write-changelog.md
+++ b/.grok/skills/docs/write-changelog.md
@@ -1,0 +1,64 @@
+# Write Changelogs
+
+For release notes. User impact, not implementation.
+
+> **Where the note goes.** If the repo uses the fragment model (a `.changelog/`
+> directory — see the `code:changelog` skill), do **not** edit `CHANGELOG.md` by
+> hand. Drop one new file at `.changelog/next/<ticket>.md` with your note. Every
+> PR writes a different file, so the changelog can never become a merge conflict;
+> the release folds the queue and regenerates `CHANGELOG.md`. The guidance below
+> is about *what to write* — it applies either way.
+
+## Core Principle
+
+**What changed for users, not what you did.** Group by impact, not by commit.
+
+## Structure
+
+```markdown
+# v1.2.0
+
+## Breaking Changes
+
+- `foo` flag renamed to `bar` — update your scripts
+
+## New
+
+- Export to PDF: `tool export --pdf`
+- Dark mode support
+
+## Fixed
+
+- No longer crashes on large files
+- Memory leak in long sessions
+
+## Improved
+
+- 2x faster startup
+- Better error messages for auth failures
+```
+
+## Categories
+
+| Category | What Goes Here |
+|----------|----------------|
+| Breaking | Requires user action |
+| New | Features they can use |
+| Fixed | Bugs that affected them |
+| Improved | Better experience |
+| Security | Vulnerabilities patched |
+
+## Anti-Patterns
+
+- Raw commit messages
+- Internal refactors ("cleaned up code")
+- Ticket numbers without context
+- Technical details users don't need
+
+## Style
+
+- Start with verb: "Add", "Fix", "Remove", "Improve"
+- User perspective: "You can now..." not "We implemented..."
+- If migration needed, show exact steps
+
+Keep it scannable. Users skim for what affects them.

--- a/.grok/skills/docs/write-onboarding.md
+++ b/.grok/skills/docs/write-onboarding.md
@@ -1,0 +1,58 @@
+# Write Onboarding Docs
+
+For new contributors. Goal: first successful change, fast.
+
+## Core Principle
+
+**One working change, not comprehensive knowledge.** Get them productive, then they learn by doing.
+
+## Structure
+
+```markdown
+# Getting Started
+
+## Setup (10 min)
+
+\`\`\`bash
+# Clone and install
+git clone ...
+cd ...
+./scripts/install.sh
+\`\`\`
+
+## Your First Change (15 min)
+
+1. Find a `good-first-issue` or try this: [specific small task]
+2. Make the change in `src/foo/`
+3. Test: `./scripts/test.sh`
+4. Submit: `git commit && git push`
+
+## Where Things Live
+
+| Area | Path | What's There |
+|------|------|--------------|
+| Core | `src/core/` | Main logic |
+| UI | `src/ui/` | Components |
+| API | `src/api/` | Endpoints |
+
+## Getting Help
+
+- Questions: [channel/forum]
+- Stuck: [who to ask]
+```
+
+## Anti-Patterns
+
+- Dumping all architecture upfront
+- Explaining history and decisions
+- Tool lists without context
+- "Read the wiki" links
+
+## Key Elements
+
+1. **Working setup in 10 min** — Or you've lost them
+2. **One specific task** — Not "find something"
+3. **Where to look** — Mental map of the repo
+4. **Who to ask** — Real human contact
+
+Shorter is better. They'll explore when ready.

--- a/.grok/skills/docs/write-runbook.md
+++ b/.grok/skills/docs/write-runbook.md
@@ -1,0 +1,54 @@
+# Write Runbooks
+
+For operational procedures: incidents, deployments, maintenance.
+
+## Core Principle
+
+**Symptoms to actions.** Start from what you observe, end with what to do.
+
+## Structure
+
+```markdown
+# Runbook: [Problem/Procedure]
+
+## Symptoms
+
+- What you see (logs, metrics, alerts)
+- How to confirm this is the issue
+
+## Diagnosis
+
+1. Check X: `command`
+   - If Y, go to Step 2
+   - If Z, see [Other Runbook]
+
+2. Check A: `command`
+   - Expected output: ...
+
+## Resolution
+
+1. Do X: `command`
+2. Verify: `command`
+3. Confirm resolution: [metric/log to check]
+
+## Escalation
+
+- If still broken after 15 min: [who to contact]
+- If data loss suspected: [emergency procedure]
+```
+
+## Anti-Patterns
+
+- Vague steps ("check the logs")
+- No decision points
+- Missing verification steps
+- No escalation path
+
+## Key Elements
+
+1. **Exact commands** — Copy-pasteable
+2. **Expected output** — What success looks like
+3. **Decision points** — If X then Y, else Z
+4. **Time bounds** — When to escalate
+
+Keep it minimal. If it's not needed at 3am, cut it.

--- a/.grok/skills/docs/write-technical.md
+++ b/.grok/skills/docs/write-technical.md
@@ -1,0 +1,70 @@
+# Write Technical Documentation
+
+For internal architecture docs. High-level, principal engineer style.
+
+## Core Principle
+
+**Document what code can't tell you.** Component boundaries, data flow, system design. Not implementation details.
+
+## Structure
+
+```markdown
+# System Name
+
+One paragraph: what this system does, why it exists.
+
+## Architecture
+
+[ASCII or mermaid diagram showing components and flow]
+
+## Data Flow
+
+[Diagram: how data moves through the system]
+
+## Key Concepts
+
+| Concept | What It Is | Where |
+|---------|------------|-------|
+| Widget | Does X | `src/widget/` |
+
+## Integration Points
+
+- **Upstream:** What calls this
+- **Downstream:** What this calls
+
+## Critical Files
+
+| File | Role |
+|------|------|
+| `foo.go` | Entry point |
+```
+
+## Diagram Standards
+
+ASCII boxes for architecture:
+```
+┌─────────────┐     ┌─────────────┐
+│  Component  │────▶│  Component  │
+└─────────────┘     └─────────────┘
+```
+
+Mermaid for flows:
+```mermaid
+flowchart LR
+    A[Input] --> B[Process] --> C[Output]
+```
+
+## Anti-Patterns
+
+- Explaining how functions work (read the code)
+- Duplicating code in docs
+- Documenting stable internals
+- Prose where a diagram fits
+
+## Reference Style
+
+Point to code, don't copy it:
+- `See harness/agent/execution.go:306-500`
+- `Implementation in src/auth/`
+
+One diagram is worth 1000 words. Write less.

--- a/.grok/skills/docs/write-user.md
+++ b/.grok/skills/docs/write-user.md
@@ -1,0 +1,74 @@
+# Write User-Facing Documentation
+
+For public interfaces: CLIs, APIs, tools, libraries.
+
+Frame around what users want to do — not a regurgitation of `--help`.
+
+## Core principles
+
+**Questions, not commands.** Format sections as literal questions users would ask:
+- "How do I automate a site that blocks bots?"
+- "I don't want to log in every time"
+- "I have multiple accounts and want to keep them separate"
+
+**Situations, not syntax.** "I just generated a new API key in the browser — how do I save it?" beats "Use `--value-stdin` to pipe input."
+
+**Why not X?** Start with a comparison section that honestly positions against alternatives. Research the actual competition — clone their repos, read their code. Never make claims you haven't verified.
+
+**The 20% that delivers 80%.** Don't list every command. Identify the 5 things users actually want to do, then show how.
+
+**End with "What else can I do?"** Point to `--help` for the long tail. The skill doc isn't a reference manual.
+
+## Before writing
+
+1. **Who is the audience?** Developer? Agent user? End user? Frame accordingly.
+2. **What are they trying to accomplish?** List the top 5 goals as questions.
+3. **What's the competition?** Research honestly. Clone repos if needed. No false claims.
+4. **What's our actual edge?** Must be backed by code or architecture.
+
+## Anti-patterns
+
+- Listing all commands with their flags
+- "This tool does X" instead of "You want to do X? Here's how"
+- Copying `--help` output into markdown
+- Making claims about competitors without checking their code
+- Technical jargon without context
+- Explaining what instead of why
+
+## Example: Bad
+
+```markdown
+## Commands
+
+### `browser start`
+Starts a browser task.
+
+Options:
+- `--profile` - Browser profile to use
+- `--task` - Task ID (optional)
+```
+
+## Example: Good
+
+```markdown
+## "I don't want to log in every time"
+
+Log in once to a profile — the session persists. Every future task is already authenticated:
+
+\`\`\`bash
+agents browser profiles create social --browser chrome
+agents browser start setup --profile social
+# Log in manually, then stop
+
+# Next time — already logged in
+agents browser start post --profile social
+\`\`\`
+```
+
+## Honest competition
+
+When comparing to alternatives:
+1. Actually clone their repo and read their code
+2. Verify any claims about what they do or don't support
+3. If they're good at something, say so
+4. Our edges must be backed by actual implementation differences

--- a/.grok/skills/reflect/SKILL.md
+++ b/.grok/skills/reflect/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: reflect
+description: >-
+  Recall all feedback, corrections, and constraints from the current
+  conversation before rewriting or iterating. Triggers on: reflect,
+  step back, reconsider, recall feedback, what did I say, incorporate
+  all feedback, or when iterative drafts keep missing the mark.
+argument-hint: "[optional: specific topic to reflect on]"
+user-invocable: true
+---
+
+# Reflect
+
+You are mid-conversation. The user has given you feedback — corrections, preferences, pushback, confirmations. Before your next attempt, you must surface all of it.
+
+## When This Triggers
+
+- User explicitly says "reflect", "step back", "reconsider", "recall what I said"
+- You've done 2+ iterations and the user is still unsatisfied
+- User says something like "incorporate all my feedback" or "you keep missing X"
+
+## The Process
+
+### Step 1: Enumerate Every Piece of Feedback
+
+Scan the entire conversation. Extract every instance where the user:
+
+- **Corrected you** ("no", "not that", "wrong framing", "that's not what I meant")
+- **Rejected an approach** ("don't lead with X", "stop doing Y", "this isn't useful")
+- **Confirmed something worked** ("yes", "exactly", "that's the right angle", accepted without pushback)
+- **Added a constraint** ("it should feel like...", "the audience is...", "don't mention...")
+- **Provided new information** that changes the approach (facts, context, nuance you didn't have before)
+
+Present these as a numbered list. Quote the user's words where possible — don't paraphrase into something softer.
+
+Format:
+
+```
+FEEDBACK INVENTORY:
+
+1. [REJECTED] "the first hook isn't really useful — it sounds like scrolls dropping"
+   → Thesis statements don't hook. Lead with something concrete/surprising.
+
+2. [CORRECTED] "an agent run by cron can do push notifications to ask for permissions"
+   → "Autonomous = unreachable" is wrong. The real issue is latency tolerance, not absence.
+
+3. [CONFIRMED] The per-binary network policy detail — user flagged this as the most interesting finding early on.
+   → This should be the anchor, not supporting detail.
+
+4. [CONSTRAINT] Don't sell Rush. No product pitch.
+   → Can reference contextually but not promote.
+
+5. ...
+```
+
+### Step 2: Identify the Pattern
+
+After listing, ask: what's the *thread* connecting these corrections? Usually the user is pushing toward one thing you keep missing. Name it explicitly.
+
+Example: "The thread: I keep leading with framing and structure instead of a single concrete thing that's genuinely surprising."
+
+### Step 3: State the Revised Approach
+
+Before writing anything new, state in 1-2 sentences what you'll do differently this time, grounded in the feedback inventory.
+
+### Step 4: Execute
+
+Now write the next draft/response with all constraints active simultaneously. Not just the latest correction — all of them.
+
+## Why This Works
+
+Creative iteration fails when the agent treats each correction as a local patch. Feedback is cumulative — correction #5 doesn't replace corrections #1-4. But without explicit recall, agents drift: they fix the latest issue and regress on earlier ones.
+
+This skill forces global constraint satisfaction before each attempt.
+
+## Anti-Patterns
+
+- **Summarizing feedback vaguely** ("you wanted it to be better") — quote specific words
+- **Only recalling corrections, not confirmations** — what worked is as important as what didn't
+- **Treating this as a delay tactic** — the inventory should take 30 seconds, not become a philosophical exercise
+- **Skipping Step 2** — the pattern identification is where the real insight lives

--- a/.grok/skills/release/SKILL.md
+++ b/.grok/skills/release/SKILL.md
@@ -1,0 +1,581 @@
+---
+name: release
+description: >-
+  Publish packages to registries (npm, CDN, etc.). Discovers repo structure,
+  scaffolds build/release scripts if missing, runs tests, updates changelog,
+  publishes, and tags. Supports monorepos and semver with prereleases.
+  Triggers on: release, publish, ship, npm publish, cut a release.
+user-invocable: true
+version: 1.0.0
+author: muqsit
+---
+
+# Release
+
+Publish packages to their registries. Works with single packages and monorepos.
+
+## Arguments
+
+`$ARGUMENTS` may contain:
+- A version number: `1.2.3`, `1.2.3-alpha.1`, `patch`, `minor`, `major`
+- A package path for monorepos: `rush/app`, `harness-ui`
+- Flags: `--skip-tests`, `--skip-build`, `--force`
+
+If no version is given, analyze what's needed and suggest one.
+
+---
+
+## Phase 1: Discovery
+
+Before doing anything, check for project-specific release instructions.
+
+### 1.1 Check for project-level overrides
+
+```bash
+# Project-level release skill takes precedence
+ls .agents/skills/release/ 2>/dev/null
+
+# Check for release instructions in project docs
+grep -l -i "release\|publish\|deploy" README.md CLAUDE.md AGENTS.md .agents/*.md 2>/dev/null | head -5
+```
+
+If `.agents/skills/release/` exists in the project, defer to it completely. Read those instructions and follow them instead of this skill.
+
+### 1.2 Detect repo structure
+
+```bash
+# Is this a monorepo?
+if [[ -f "package.json" ]]; then
+  # Check for workspaces
+  jq -e '.workspaces' package.json 2>/dev/null && echo "MONOREPO: npm/bun workspaces"
+fi
+
+[[ -f "pnpm-workspace.yaml" ]] && echo "MONOREPO: pnpm workspaces"
+[[ -f "lerna.json" ]] && echo "MONOREPO: lerna"
+
+# Find all package.json files
+fd -t f package.json --max-depth 3 | head -20
+```
+
+### 1.3 Identify publishable packages
+
+```bash
+# List packages that are NOT private
+fd -t f package.json --max-depth 3 -x sh -c '
+  name=$(jq -r ".name // empty" "{}")
+  private=$(jq -r ".private // false" "{}")
+  if [[ -n "$name" && "$private" != "true" ]]; then
+    echo "{}: $name"
+  fi
+'
+```
+
+### 1.4 Find release scripts
+
+```bash
+# Standard locations
+ls scripts/release.sh scripts/build.sh release.sh 2>/dev/null
+
+# Monorepo subdirs
+fd -t f release.sh --max-depth 4
+
+# Check for npm scripts
+jq -r '.scripts | keys[]' package.json 2>/dev/null | grep -E 'release|publish|deploy'
+```
+
+### 1.5 Monorepo: Ask which package
+
+If multiple publishable packages are found and `$ARGUMENTS` doesn't specify one, use `AskUserQuestion` to ask which package to release. List all discovered packages with their current versions.
+
+---
+
+## Phase 2: Infrastructure Check
+
+### 2.1 Check for existing scripts
+
+If `scripts/release.sh` exists, read it to understand:
+- Does it have dry-run mode? (look for `--apply`, `--confirm`, `--dry-run`)
+- Does it run tests? (look for `npm test`, `bun test`, `build.sh`)
+- What registry does it publish to? (npm, CDN URL, etc.)
+
+### 2.2 Scaffold if missing
+
+If no release script exists, offer to create the standard structure:
+
+**scripts/build.sh:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKIP_TESTS=false
+for arg in "$@"; do
+  case $arg in
+    --skip-tests) SKIP_TESTS=true ;;
+  esac
+done
+
+echo "==> Type checking..."
+if [[ -f "tsconfig.json" ]]; then
+  npx tsc --noEmit || { echo "Type check failed"; exit 1; }
+fi
+
+echo "==> Linting..."
+npm run lint 2>/dev/null || bun run lint 2>/dev/null || true
+
+if [[ "$SKIP_TESTS" == "true" ]]; then
+  echo ""
+  echo "=============================================="
+  echo "  WARNING: Skipping tests is discouraged."
+  echo "  Fix failing tests instead of bypassing them."
+  echo "=============================================="
+  echo ""
+else
+  echo "==> Running tests..."
+  npm test || bun test || { echo "Tests failed"; exit 1; }
+fi
+
+echo "==> Building..."
+npm run build || bun run build || { echo "Build failed"; exit 1; }
+
+echo "==> Build complete"
+```
+
+**scripts/release.sh:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+APPLY=false
+SKIP_BUILD=false
+SKIP_TESTS=false
+
+for arg in "$@"; do
+  case $arg in
+    --apply|--confirm) APPLY=true ;;
+    --skip-build) SKIP_BUILD=true ;;
+    --skip-tests) SKIP_TESTS=true ;;
+  esac
+done
+
+die() { echo "ERROR: $1" >&2; exit 1; }
+
+[[ -z "$VERSION" ]] && die "Usage: scripts/release.sh <version> [--apply]"
+
+# Validate semver (with optional prerelease)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  die "Invalid version format: $VERSION (expected semver like 1.2.3 or 1.2.3-alpha.1)"
+fi
+
+# Pre-flight checks
+echo "==> Pre-flight checks"
+[[ -n "$(git status --porcelain)" ]] && die "Working tree not clean. Commit or stash changes first."
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" != "main" && "$BRANCH" != "master" && ! "$BRANCH" =~ ^release/ ]] && \
+  echo "WARNING: Not on main branch (on $BRANCH)"
+
+# Package info
+PKG_NAME=$(jq -r '.name' package.json)
+[[ -z "$PKG_NAME" || "$PKG_NAME" == "null" ]] && die "No package name in package.json"
+
+# Check current published version
+echo "==> Checking registry for $PKG_NAME"
+CURRENT=$(npm view "$PKG_NAME" version 2>/dev/null || echo "0.0.0")
+echo "   Current published: $CURRENT"
+echo "   Target version:    $VERSION"
+
+# Build
+if [[ "$SKIP_BUILD" == "true" ]]; then
+  echo ""
+  echo "WARNING: Skipping build. Ensure artifacts are fresh."
+  echo ""
+else
+  echo "==> Running build"
+  BUILD_ARGS=""
+  [[ "$SKIP_TESTS" == "true" ]] && BUILD_ARGS="--skip-tests"
+  ./scripts/build.sh $BUILD_ARGS || die "Build failed"
+fi
+
+# Show what will be published
+echo ""
+echo "==> Package contents (dry-run):"
+npm pack --dry-run 2>&1 | head -50
+
+if [[ "$APPLY" != "true" ]]; then
+  echo ""
+  echo "================================================"
+  echo "  DRY-RUN COMPLETE"
+  echo "  "
+  echo "  To actually publish, run:"
+  echo "    scripts/release.sh $VERSION --apply"
+  echo "================================================"
+  exit 0
+fi
+
+# Update version in package.json
+echo "==> Updating version to $VERSION"
+npm version "$VERSION" --no-git-tag-version
+
+# Get npm token from agents secrets
+echo "==> Authenticating with npm"
+NPM_TOKEN=$(agents secrets export npmjs.com --plaintext 2>/dev/null | grep NPM_TOKEN | cut -d= -f2-)
+if [[ -z "$NPM_TOKEN" ]]; then
+  die "No NPM_TOKEN found. Create it with: agents secrets create npmjs.com && agents secrets add npmjs.com NPM_TOKEN"
+fi
+
+# Write temporary .npmrc
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc.release
+trap 'rm -f .npmrc.release' EXIT
+
+# Publish
+echo "==> Publishing to npm"
+npm publish --access public --userconfig .npmrc.release || die "Publish failed"
+
+# Verify publish
+echo "==> Verifying publish"
+sleep 2
+PUBLISHED=$(npm view "$PKG_NAME@$VERSION" version 2>/dev/null || echo "")
+if [[ "$PUBLISHED" != "$VERSION" ]]; then
+  echo "WARNING: Could not verify $PKG_NAME@$VERSION on registry yet (may take a moment)"
+fi
+
+# Git operations AFTER successful publish
+echo "==> Creating git tag"
+git add package.json package-lock.json 2>/dev/null || git add package.json
+git commit -m "chore(release): $VERSION"
+git tag "v$VERSION"
+git push origin "$BRANCH"
+git push origin "v$VERSION"
+
+echo ""
+echo "================================================"
+echo "  RELEASED $PKG_NAME@$VERSION"
+echo "  "
+echo "  npm: https://www.npmjs.com/package/$PKG_NAME"
+echo "  tag: v$VERSION"
+echo "================================================"
+```
+
+### 2.3 Package hygiene
+
+Check that the package doesn't publish unnecessary files:
+
+```bash
+# Check what would be published
+npm pack --dry-run 2>&1
+
+# Check for files field or .npmignore
+jq '.files' package.json
+cat .npmignore 2>/dev/null
+```
+
+If neither exists and `src/`, `tests/`, or large directories would be published, suggest creating `.npmignore`:
+
+```
+src/
+tests/
+*.test.ts
+*.spec.ts
+testdata/
+.github/
+.vscode/
+*.log
+.env*
+```
+
+---
+
+## Phase 3: Version Analysis
+
+### 3.1 Get current published version
+
+```bash
+PKG_NAME=$(jq -r '.name' package.json)
+
+# npm registry
+npm view "$PKG_NAME" version 2>/dev/null || echo "Not yet published"
+
+# All published versions
+npm view "$PKG_NAME" versions --json 2>/dev/null | jq -r '.[-5:][]'
+```
+
+### 3.2 Determine next version
+
+If `$ARGUMENTS` contains `patch`, `minor`, or `major`:
+- Calculate the next version from current published
+- For prereleases: `1.2.3-alpha.1` → `1.2.3-alpha.2`
+
+Semver rules:
+- **Stable releases** (`1.2.3`): enforce single-step bumps only
+  - `1.2.3` → `1.2.4` (patch) OK
+  - `1.2.3` → `1.3.0` (minor) OK
+  - `1.2.3` → `1.5.0` NOT OK (skips 1.4.0)
+- **Prereleases** (`1.2.3-alpha.1`): allow free jumps within prerelease
+  - `1.2.3-alpha.1` → `1.2.3-alpha.5` OK
+  - `1.2.3-alpha.1` → `1.2.3-beta.1` OK
+  - `1.2.3-rc.1` → `1.2.3` OK (promotion to stable)
+
+### 3.3 Version validation
+
+```bash
+# Parse versions
+CURRENT="1.2.3"
+TARGET="1.2.4"
+
+# Extract components
+IFS='.-' read -r CMAJ CMIN CPAT CPRE <<< "$CURRENT"
+IFS='.-' read -r TMAJ TMIN TPAT TPRE <<< "$TARGET"
+
+# Validate (simplified)
+if [[ -z "$TPRE" ]]; then
+  # Stable release - must be single step
+  # ... validation logic
+fi
+```
+
+---
+
+## Phase 4: Pre-flight Checks
+
+### 4.1 Run tests (mandatory)
+
+Even if the release script runs tests, run them first to fail fast:
+
+```bash
+npm test || bun test
+```
+
+If tests fail, this is a **blocking** issue. Do not proceed.
+
+If `--skip-tests` was passed:
+```
+============================================
+  WARNING: You are skipping tests.
+
+  Skipping tests is strongly discouraged.
+  It's better to fix failing tests than to
+  ship broken code.
+
+  Proceeding anyway because --skip-tests was set.
+============================================
+```
+
+### 4.2 Check git state
+
+```bash
+# Must be clean
+git status --porcelain
+
+# Should be on main (warn if not)
+git rev-parse --abbrev-ref HEAD
+```
+
+### 4.3 Check secrets
+
+```bash
+# List available secrets bundles
+agents secrets list
+
+# Check for npm token specifically
+agents secrets export npmjs.com --plaintext 2>/dev/null | grep -q NPM_TOKEN && echo "npm auth: OK"
+```
+
+If required secrets are missing, this is **blocking**. Guide the user:
+```
+Missing npm authentication. Set it up with:
+  agents secrets create npmjs.com
+  agents secrets add npmjs.com NPM_TOKEN
+```
+
+### 4.4 Issue categorization
+
+**Blocking (must fix before release):**
+- Test failures
+- Uncommitted changes in git
+- Missing required secrets
+- Version already published (unless `--force`)
+- Invalid semver format
+
+**Non-blocking (warn and continue):**
+- Not on main branch
+- Using `--skip-tests` or `--skip-build`
+- No CHANGELOG.md (will create one)
+- No dry-run mode in release script
+
+---
+
+## Phase 5: Changelog
+
+> **Fragment model (preferred).** If the repo has a `.changelog/` directory (the
+> `code:changelog` skill / towncrier-style fragments), the changelog is a
+> GENERATED artifact: per-PR notes live in `.changelog/next/<ticket>.md`, and the
+> release script folds them into `.changelog/<version>.md` and regenerates
+> `CHANGELOG.md`. **Skip 5.3–5.4** — the release script owns the changelog; just
+> confirm the queue is non-empty (`ls .changelog/next/*.md`) so the release can
+> document itself. Sections 5.1–5.4 below are the legacy single-file path for
+> repos without `.changelog/`.
+
+### 5.1 Get commits since last release
+
+```bash
+# Find last release tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [[ -n "$LAST_TAG" ]]; then
+  echo "Commits since $LAST_TAG:"
+  git log "$LAST_TAG"..HEAD --oneline --no-merges
+else
+  echo "No previous tags. Showing recent commits:"
+  git log -20 --oneline --no-merges
+fi
+```
+
+### 5.2 Parse conventional commits
+
+Group commits by type:
+
+```bash
+git log "$LAST_TAG"..HEAD --oneline --no-merges | while read -r line; do
+  if [[ "$line" =~ ^[a-f0-9]+\ feat ]]; then
+    echo "ADDED: $line"
+  elif [[ "$line" =~ ^[a-f0-9]+\ fix ]]; then
+    echo "FIXED: $line"
+  elif [[ "$line" =~ ^[a-f0-9]+\ (refactor|perf|chore) ]]; then
+    echo "CHANGED: $line"
+  fi
+done
+```
+
+### 5.3 Generate changelog entry
+
+Format:
+```markdown
+## [1.2.3] - 2026-05-09
+
+### Added
+- feat(auth): OAuth refresh token support (#123)
+
+### Fixed  
+- fix(sync): orphan sweep for stale resources (#124)
+
+### Changed
+- refactor(runner): simplify job execution
+```
+
+### 5.4 Update or create CHANGELOG.md
+
+If CHANGELOG.md exists, prepend the new section after the header.
+If it doesn't exist, create it:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.2.3] - 2026-05-09
+
+### Added
+...
+```
+
+---
+
+## Phase 6: Execute Release
+
+### 6.1 Dry-run first
+
+If the release script supports dry-run:
+```bash
+./scripts/release.sh "$VERSION"
+```
+
+Show the output and summarize what will happen.
+
+### 6.2 Confirm with user
+
+Before actual release, use `AskUserQuestion`:
+- Show version change: `1.2.2 → 1.2.3`
+- Show registry target
+- Show changelog entry preview
+- Show files that will be published
+
+Options: "Release now", "Edit changelog first", "Cancel"
+
+### 6.3 Execute
+
+```bash
+./scripts/release.sh "$VERSION" --apply
+```
+
+### 6.4 Verify
+
+After the script completes:
+```bash
+# Verify on npm
+npm view "$PKG_NAME@$VERSION" version
+
+# Verify tag exists
+git tag -l "v$VERSION"
+```
+
+### 6.5 Report success
+
+```
+Released @phnx-labs/agents-cli@1.2.3
+
+- npm: https://www.npmjs.com/package/@phnx-labs/agents-cli
+- tag: v1.2.3
+- changelog: Updated CHANGELOG.md
+```
+
+---
+
+## Escape Hatches
+
+These flags exist but their use is discouraged:
+
+| Flag | Effect | When shown |
+|------|--------|-----------|
+| `--skip-tests` | Skip test suite | Prints warning about fixing tests being better |
+| `--skip-build` | Skip build step | Warns about stale artifacts |
+| `--force` | Skip version validation | Warns about registry conflicts |
+
+Always show warnings when these are used. Never silently skip.
+
+---
+
+## Error Handling
+
+### Tests fail
+```
+Tests failed. Fix the failing tests before releasing.
+
+Failing tests:
+  - src/lib/runner.test.ts: timeout handling
+  - src/lib/events.test.ts: rotation logic
+
+Run `npm test` to see full output.
+```
+
+### Version already published
+```
+Version 1.2.3 is already published on npm.
+
+Options:
+1. Bump to 1.2.4: scripts/release.sh 1.2.4 --apply
+2. Use prerelease: scripts/release.sh 1.2.4-beta.1 --apply
+3. Force republish (dangerous): scripts/release.sh 1.2.3 --force --apply
+```
+
+### Missing secrets
+```
+npm authentication not configured.
+
+Set up npm token:
+  1. Go to https://www.npmjs.com/settings/tokens
+  2. Create an "Automation" token with publish access
+  3. Save it:
+     agents secrets create npmjs.com
+     agents secrets add npmjs.com NPM_TOKEN
+```

--- a/.grok/skills/scripts/SKILL.md
+++ b/.grok/skills/scripts/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: scripts
+description: "Scripts directory contract — canonical build/test/install/release.sh patterns for deployable projects. Triggers on: scripts/, release.sh, build.sh, deploy, publish."
+user-invocable: false
+---
+
+# Scripts Directory Contract
+
+Every deployable project keeps a `scripts/` directory with a small set of canonical scripts. Use them. Don't reinvent.
+
+## Canonical scripts
+
+- `scripts/build.sh` — compile/bundle and **run the test suite**. Green build means tests passed.
+- `scripts/test.sh` — full test suite, runnable on its own.
+- `scripts/install.sh` — install dependencies, set up local config.
+- `scripts/release.sh` — ship the artifact (npm publish, docker push, deploy, etc.). **Use `release` as the canonical name** — covers all forms of shipping.
+
+## release.sh contract
+
+- **Defaults to dry-run.** Without `--confirm`, the script prints exactly what it would do and exits 0. Nothing mutates.
+- **`--confirm` is required to actually release.** No other flag substitutes.
+- **`--skip-build` and `--skip-tests`** are escape hatches for re-runs after a verified-elsewhere build, or hotfixes. Default: run both.
+- **Refuses on test failure** unless `--skip-tests` was explicitly passed. If you find yourself adding `|| true` to silence a check, stop.
+- **Pre-flight checks run before slow checks.** Version-collision (`npm view <pkg> versions --json` against `package.json`) before `bun test`. Missing-secrets check before `git push`. Cheap failures fast.
+- **Source of truth is the system the script targets, not git.** npm publish status comes from the registry, not commit subjects. Deploy status comes from the deploy registry.
+- **Idempotent.** If `release.sh` is interrupted between version-bump and the actual publish, re-running converges — no double-bump, no double-tag.
+
+## What "done" means for a release
+
+A release isn't done until the package version shows up on the registry (or the deploy URL serves the new build). Code merged is not released.
+
+## Anti-patterns
+
+- `release.sh` that publishes without running tests by default.
+- Detecting "what's already published" by `git log` subject lines instead of the registry.
+- Running expensive checks (test suites, builds) before cheap checks (version collision, missing secrets).
+- A `deploy.sh` with no dry-run mode that hits production on every invocation.

--- a/.grok/skills/security/SKILL.md
+++ b/.grok/skills/security/SKILL.md
@@ -1,0 +1,189 @@
+---
+description: "Security audit of a codebase via parallel agents — one per vulnerability class. Reads code fast with Explore agents, cross-checks against current advisories via web search, filters false positives hard. Triggers on 'security scan', 'security audit', 'vulnerability scan', 'check for leaked secrets', 'scan for injection', or scheduled security checks."
+argument-hint: "[scope — days, paths, or freeform e.g. 'last 7 days', 'prix/api routes', 'pre-launch sweep']"
+allowed-tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+user-invocable: true
+---
+
+# Security
+
+A security audit pattern: analyze what changed, classify by vulnerability type, dispatch one parallel agent per class, verify every finding yourself, **filter false positives hard**, report only confirmed issues.
+
+You are the orchestrator. Each vulnerability class becomes one Explore subagent that reads code fast and cross-checks against current advisories via web search. Never trust an agent's "CRITICAL" finding without reading the cited file yourself.
+
+## How it works
+
+```
+You (orchestrator)
+ |-- 1. Discover scope: what changed, what to audit
+ |-- 2. Classify the change surface by risk
+ |-- 3. Dispatch one Explore agent per vulnerability class (in parallel)
+ |-- 4. Each agent: read code, grep patterns, web-search current advisories
+ |-- 5. Collect findings
+ |-- 6. VERIFY every CRITICAL/HIGH yourself — read the cited file:line
+ |-- 7. FILTER false positives aggressively
+ |-- 8. Report only verified findings
+```
+
+## Step 1 — Scope the scan
+
+If args give a time window, use git:
+
+```bash
+git log --oneline --since="<N> days ago" --no-merges --name-only | head -200
+```
+
+If args give a path or "pre-launch", spend 60s reading top-level `README.md`, `AGENTS.md` / `CLAUDE.md`, and the entry-point file to learn: network listener? web UI? CLI? filesystem/keychain/external API access? Multi-tenant or single-user? OSS or hosted? The attack surface determines which classes matter.
+
+State your scope back to the user in 3-4 lines before dispatching anything. They'll redirect if it's wrong.
+
+## Step 2 — Classify the change surface
+
+Look at the touched files and project conventions (the repo's `AGENTS.md` / `CLAUDE.md` are authoritative for what's high-risk). Group files into vulnerability-relevant zones — common buckets:
+
+- HTTP/API routes, controllers, middleware
+- Auth, sessions, billing, IAM
+- DB queries, ORM raw SQL, analytics query builders
+- HTML rendering, share/preview pages, embeddable surfaces
+- Shell execution, child_process, subprocess, exec.Command
+- Native/IPC boundaries (Electron main↔renderer, browser extension content scripts)
+- Infra (Terraform, CF/CDN config, Dockerfile, K8s manifests)
+- Dependencies (`package.json`, `go.mod`, lockfiles, `requirements.txt`)
+- Config & docs that may have leaked secrets (`*.env*`, `CLAUDE.md`, `docs/`, deploy scripts)
+
+If no commit list is provided, treat the whole repo's most-trafficked code paths as the surface.
+
+## Step 3 — Dispatch parallel Explore agents
+
+One agent per vulnerability class. **Spawn them all in a single message** (parallel Agent tool calls). Use `subagent_type: "Explore"` for fast, read-only code scanning. Set `model: "sonnet"` (cost-effective for pattern matching) unless the class needs deeper reasoning (then `opus`).
+
+### Vulnerability classes — pick the ones the surface warrants
+
+| Class | When to run | Typical patterns to grep |
+|---|---|---|
+| **SECRETS** | Always | `sk_live`, `phc_`, `AKID`, `xoxb-`, `ghp_`, `BEGIN PRIVATE KEY`, `.env*` tracked in git, secrets in `CLAUDE.md`/docs, deleted-but-in-history credentials |
+| **INJECTION** | DB/query code changed | String interpolation in queries, template literals near `.query()`/`.rpc()`/`SELECT`, user input reaching ORM raw escape hatches, NoSQL operator injection (`$where`, `$ne`) |
+| **AUTH** | Routes, middleware, auth changed | Endpoints without auth middleware, role checks (`isAdmin`, `isDev`) that can be skipped, broken IDOR (object access by user-controlled ID without ownership check), OAuth flow logic, JWT verification |
+| **XSS** | HTML rendering / user output changed | User input in HTML templates, `innerHTML`/`dangerouslySetInnerHTML`, missing CSP, script injection via display names or artifact content, missing `X-Frame-Options` |
+| **SHELL** | Shell-exec or child_process touched | `exec.Command("sh","-c", ...)`, `child_process.exec` with concat, `osascript -e` with input, path traversal via user-controlled paths |
+| **IPC / ELECTRON** | Electron main process or preload changed | `nodeIntegration: true`, custom protocol handlers, `webContents.executeJavaScript` with user input, `contextIsolation: false` |
+| **INFRA** | CF/Terraform/Dockerfile/K8s changed | Open redirects, SSRF in worker fetches, exposed origins (host without WAF), missing security headers, K8s `privileged: true`, overly broad RBAC |
+| **DEPS** | Lockfiles changed | Run `npm audit --json` / `go list -json -deps -m all`, web-search "CVE \<package\> \<version\> 2026" for any package not in the boring set |
+
+### Subagent prompt template
+
+```
+## Security Scan: <CLASS>
+
+Scope: <files / dirs to scan, from the changed-files list>
+Class: <CLASS>
+
+What to check:
+<2–4 lines of specifics for this class>
+
+Patterns to grep:
+<concrete patterns>
+
+Cross-check current advisories:
+- WebSearch: "<library or pattern> CVE 2026" or "<framework> security advisory 2026"
+- WebFetch: GitHub Security Advisory pages for the libraries in scope.
+
+Report format (one bullet per finding):
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
+- Location: file:line
+- Code: the actual snippet (quote it)
+- Attack vector: how an attacker reaches this
+- Confidence: high / medium / low (medium or low MUST list disconfirming evidence)
+- Fix: one line
+
+If you find nothing, say so. A clean scan is a valid result.
+Return file:line quotes for every claim. Do NOT paraphrase. If you can't quote it, don't claim it.
+```
+
+## Step 4 — Verify every CRITICAL/HIGH yourself
+
+Trust no agent verdict above MEDIUM. For each CRITICAL or HIGH:
+
+1. Read the cited file at the cited line.
+2. Confirm the code matches what the agent quoted.
+3. Trace whether user input actually reaches the vulnerable point — is there validation, escaping, middleware, parameterization in between?
+4. Check for mitigations the agent missed (framework defaults, ORM parameterization, middleware that runs before the route).
+5. Classify: `VERIFIED` / `FALSE POSITIVE` / `NEEDS RUNTIME TEST`.
+
+## Step 5 — Filter false positives HARD
+
+**False positives in security scans are the rule, not the exception.** Agents will flag patterns that look bad in isolation but aren't real vulnerabilities. The most common categories — discard these on sight unless you have evidence otherwise:
+
+### "Leaked API key" that's actually a public key
+
+| Pattern flagged | Why it's not a leak |
+|---|---|
+| `phc_xxxx` in client code | PostHog **public ingest** keys are designed to ship to browsers. Real risk is the `phx_` personal API key. |
+| `pk_live_*` / `pk_test_*` Stripe key | Stripe publishable keys are public by design. Only `sk_live_*` / `sk_test_*` are sensitive. |
+| `eyJhbGciOi...` in client | Supabase / Firebase **anon** JWTs are public by design. RLS enforces auth. The service-role key is the secret one. |
+| `AIza...` Google API key | Often a public Maps/YouTube key restricted by HTTP referrer. Check the restriction, not the format. |
+| GitHub App `client_id` | Public by design. The `client_secret` is the secret. |
+
+Confirm by reading the code: is the value embedded in shipped client bundles? Then it's by design. The check is on **intent**, not regex match.
+
+### Other common false-positive patterns
+
+- **"Missing auth on endpoint"** → check for middleware applied at the router/app level, not the handler. `app.use(authMiddleware)` covers everything below.
+- **"SQL injection in `db.query(\`...\${x}...\`)`"** → check if `x` came from validated input upstream, or if the driver is parameterizing automatically.
+- **"XSS via innerHTML"** → check if the source is hardcoded/server-controlled, not user-controlled.
+- **"Hardcoded password"** → check if it's a test fixture, a documented default, or production. Test/dev defaults aren't a vulnerability; they're an architectural choice that may or may not be appropriate.
+- **`exec.Command("sh", "-c", ...)`** → check if all interpolated values are server-controlled constants or strictly validated. Shell exec with no user-reachable input is fine.
+- **"Dependency CVE"** → check if the vulnerable code path is actually called by your code (not just present in the dependency tree). `npm audit` reports a lot of noise on transitive dev-only deps.
+
+When in doubt, **read the upstream advisory** (Web-search the CVE) and check if your usage matches the vulnerable path. Most reported CVEs only fire under narrow configurations.
+
+## Step 6 — Report
+
+Present only verified findings. Group by severity. For each, include:
+
+- Class
+- Location (`file:line`)
+- The actual code (quoted)
+- Attack vector
+- Recommended fix
+
+End the report with a **False Positives Filtered** section listing what agents flagged but you disproved — this builds trust and prevents the same flags resurfacing next scan. Also a **Clean Areas** section listing what passed (so the user knows what's been audited).
+
+## Output
+
+```markdown
+## Security Scan — <YYYY-MM-DD>
+
+### Scope
+- <window or paths>
+- <commit count if time-windowed>
+
+### Agents dispatched
+- <CLASS> (model)
+- ...
+
+### CRITICAL
+- ...
+
+### HIGH
+- ...
+
+### MEDIUM
+- ...
+
+### False positives filtered
+- <flag> — <why it's not real>
+
+### Clean
+- <area scanned, no findings>
+```
+
+Save reports under `<repo>/security/<YYYY-MM-DD>-<slug>.md` if the repo wants archived scans, otherwise return the report to the user.
+
+## Hard rules
+
+- **No "CRITICAL" without a file:line quote.** If the agent didn't quote code, demote to "needs verification" and verify yourself.
+- **No fix proposals you can't justify from the code.** "Add input validation" is a non-fix if you can't say which input on which line.
+- **Public keys are not leaked keys.** Read the surrounding code to determine intent before flagging.
+- **CVEs are not vulnerabilities until you confirm your usage matches the vulnerable path.** Look at the advisory's "Affected versions / Affected functions" section.
+- **Cost is irrelevant; correctness is everything.** If unsure about a finding, spawn another Explore agent to dig deeper. A missed bug is far more expensive than a re-scan.

--- a/.grok/skills/sessions/SKILL.md
+++ b/.grok/skills/sessions/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: sessions
+description: "Search, browse, and read agent conversation transcripts across Codex, Codex, Gemini, and OpenCode. Use this skill to find previous sessions, recover context, or inspect what agents have done."
+argument-hint: "[search query or session ID]"
+allowed-tools: Bash(agents sessions*)
+user-invocable: true
+---
+
+# Sessions Skill
+
+Search and browse agent conversation transcripts. This skill teaches you how to use the `agents sessions` CLI effectively.
+
+## Basic Usage
+
+```bash
+# Interactive picker: browse and search recent sessions
+agents sessions
+
+# List sessions from current project
+agents sessions | head -20
+
+# Search sessions by text
+agents sessions "add auth middleware"
+
+# Filter by project across all directories
+agents sessions --project agents-cli --all
+```
+
+## Filters
+
+| Filter | Example | Description |
+|--------|---------|-------------|
+| `--agent` | `--agent Codex` | Filter by agent type |
+| `--all` | `--all` | Include sessions from every directory |
+| `--project` | `--project myapp` | Filter by project name |
+| `--since` | `--since 2h` | Only sessions newer than this |
+| `--until` | `--until 2026-01-01` | Only sessions older than this |
+| `--limit` | `--limit 10` | Maximum sessions to return |
+| `--active` | `--active` | Only currently running sessions |
+| `--teams` | `--teams` | Include team-spawned sessions |
+
+## Reading Sessions
+
+```bash
+# Render session as markdown
+agents sessions --markdown <session-id>
+
+# Output as JSON
+agents sessions --json <session-id>
+
+# Include only specific roles
+agents sessions --markdown --include user,assistant <session-id>
+
+# Show only first/last N turns
+agents sessions --markdown --last 10 <session-id>
+```
+
+## Artifacts
+
+```bash
+# List all files written or edited during a session
+agents sessions --artifacts <session-id>
+
+# Read a specific artifact
+agents sessions --artifact <filename> <session-id>
+```
+
+## Live Tailing
+
+```bash
+# Live-tail a session file (Codex and Codex only)
+agents sessions tail <session-id>
+# Press Ctrl+C to stop
+```
+
+## Tips
+
+- Use `--active` to find sessions running right now across terminals, teams, cloud, and headless agents
+- Use `--teams` to see what team-spawned agents are doing
+- Use `--since 1h` for recent activity
+- Combine filters: `agents sessions --project myapp --since 1d --agent Codex`

--- a/.grok/skills/version/SKILL.md
+++ b/.grok/skills/version/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: "version"
+description: "Show agents-cli and pinned agent CLI versions for this workspace"
+agents_command: "version"
+---
+
+# /version
+
+This skill contains the behavior from the legacy `/version` slash command.
+When invoked with `$version`, treat the text after the skill name as the original command arguments.
+
+Report which agent CLIs are installed and which versions this project pins.
+
+Run:
+
+```bash
+agents --version
+agents view
+```
+
+If `agents view --json` is available in this build, prefer it for structured output.
+
+Summarize from the command output only:
+
+- agents-cli version
+- Each managed agent's pinned or default version
+- Whether each agent CLI binary is on PATH
+
+Do not guess versions. If a command fails, say which one failed and show stderr.

--- a/.kimi-code/.agents-managed.json
+++ b/.kimi-code/.agents-managed.json
@@ -1,0 +1,12 @@
+{
+  "v": 1,
+  "paths": [
+    "skills/cgraph",
+    "skills/docs",
+    "skills/reflect",
+    "skills/release",
+    "skills/scripts",
+    "skills/security",
+    "skills/sessions"
+  ]
+}

--- a/.kimi-code/skills/cgraph/SKILL.md
+++ b/.kimi-code/skills/cgraph/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: cgraph
+description: "Use FIRST for any question about THIS codebase's structure, symbols, or relationships — where a function/class/file is defined, what calls or imports it, what breaks if you change it, how two parts connect, or to load focused source context before editing or reviewing. Routes to the cgraph MCP tools (graph_query / graph_explain / graph_impact / graph_path / graph_context), which serve ranked file:line results, node neighborhoods, transitive blast radius, and token-budgeted source bundles from a resident per-project graph daemon in ~10ms — far cheaper than grepping and reading files. Prefer over blind grep/read for code navigation, dependency tracing, and impact analysis."
+user-invocable: true
+---
+
+# cgraph
+
+cgraph keeps a live, queryable graph of the current project — symbols (functions,
+classes, types, files), their call/import/inheritance/containment edges, and
+centrality ranking — served by a resident per-project daemon through MCP tools.
+
+**Reach for these tools before grepping or reading files** when a question is
+about code structure or relationships. A graph call is one ~10ms round-trip and
+returns exactly the file:line (and often the source) you need, instead of many
+grep/read calls that burn context.
+
+## Setup (one-time — the tools don't exist until this is done)
+
+This skill routes to the `cgraph` MCP server. On a cold checkout that server is
+**not** registered — until it is, the `graph_*` tools below don't exist and you
+should navigate with grep/read. Registration is a local, per-machine step (the
+`.mcp.json` it writes is gitignored, not committed), so a fresh clone needs it.
+
+1. **Build cgraph from source** — it's a native C++ engine (CMake + vcpkg,
+   C++20; on Linux `igraph` also needs `gfortran`). Full instructions:
+   <https://github.com/taylor009/CGraph> → *Install & Setup*. This produces
+   `cgraph`, `graphd`, `cgraph-client`, and `cgraph-mcp`.
+2. **Register the MCP server** (project-scoped, absolute binary paths):
+   ```sh
+   agents mcp add cgraph -s project -a claude,codex -- \
+     /abs/path/to/cgraph-mcp --root "$(pwd)" --daemon /abs/path/to/graphd
+   agents mcp register cgraph
+   ```
+3. Restart the agent session so it picks up the server. `graph_status` should
+   then answer, and the first query triggers a one-time build (seconds).
+
+If the `graph_*` tools return "no such tool", registration hasn't happened —
+fall back to grep/read and (if you can) run the steps above.
+
+## Routing: question → tool
+
+| When the user / task needs… | Call |
+| --- | --- |
+| "Where is X? Find the symbol named …" | `graph_query` `{query}` — ranked by importance, each hit has `source_file` + `line` |
+| "What is X? Show its callers/callees/imports" | `graph_explain` `{id}` — node + neighbors (each with `direction` and a navigable brief) + a source snippet |
+| "What breaks if I change X? What depends on it?" | `graph_impact` `{id, direction:"dependents"}` — transitive blast radius, bounded by `max_depth` |
+| "What does X rely on?" | `graph_impact` `{id, direction:"dependencies"}` |
+| "How does A connect to B?" | `graph_path` `{source, target}` — shortest path, with `path_nodes` briefs |
+| "Load context on X" / before editing or reviewing X | `graph_context` `{query or id, budget}` — focal node + most-relevant neighbors with snippets, packed to a token budget |
+| "Verify the graph is current before I rely on it" | `graph_update {path:"."}` — blocking content-verified synchronization; returns `freshness.content_root`. Pin subsequent reads by passing the root as `expected_content_root`. |
+| "Is the graph current? / I just changed files" | Nothing for ordinary reads — the daemon watches the tree and folds edits in within seconds. Use `graph_update` when you need a verified content_root to pin reads. |
+
+## How to use the results
+
+- `graph_query` matches case-insensitively and can be narrowed with `kind`
+  (e.g. `"function"`, `"class"`, `"file"`), `file` (source-path substring), and
+  `limit`. On zero matches it returns `suggestions` — the closest symbol names —
+  so correct the spelling and retry instead of falling back to grep.
+- Every id-taking tool (`graph_explain` / `graph_impact` / `graph_path` /
+  `graph_context`) also accepts a bare symbol name (e.g. `"merge_fragments"`);
+  the response echoes the canonical `id` it resolved. A miss comes back with
+  `found: false` plus `suggestions`.
+- `graph_query` returns ids and `source_file`:`line`. Open the file at `line`
+  directly — no second search needed.
+- `graph_explain` takes `direction` (`"in"` = callers/importers, `"out"` =
+  callees/imports) and `limit`; neighbors are ordered most-important-first and
+  `neighbor_count`/`truncated` flag when a hub has more edges than returned.
+- `graph_context` is the highest-leverage call before an edit or review: ask for
+  a budget (e.g. `4000`) and it returns the focal symbol's source plus its
+  neighborhood's source, ranked and trimmed to fit. Read that instead of opening
+  files one by one. It reports `omitted` / `truncated` if more existed.
+- `graph_context` has two **gather** modes. The default (`gather:"fixed"`) packs
+  the whole k-hop neighborhood. When you have a task in hand, pass
+  `gather:"adaptive"` **together with a `query`** — it keeps the full 2-hop core
+  but expands the third hop only along query-relevant nodes. On the retrieval
+  eval that lifted grade-2 recall by **+0.057 for +13% candidate tokens**, versus
+  the **+96%** a full 3-hop gather costs. The relevance gate is a no-op without a
+  query, so never send `adaptive` without one. The response echoes
+  `gather:"adaptive"`, `packing:"knapsack"`, and a `reach` summary
+  (`{candidates, expanded_past_core, gated_at_core}` — `expanded_past_core: 0`
+  means nothing relevant lay past the 2-hop core, so it collapsed to it). Raise
+  or lower `gather_theta` to tighten or loosen the relevance threshold.
+- `graph_impact` with `dependents` is the safety check before changing a
+  signature or deleting a symbol: it lists everything that would be affected,
+  by depth.
+
+## Freshness-sensitive navigation
+
+When a task must rely on the graph being current with the worktree — before impact
+analysis of a symbol you just moved, or after a batch of file edits — use the
+synchronize-then-pin pattern:
+
+```
+1. update = graph_update {path: "."}
+2. root = update.freshness.content_root
+3. graph_query / graph_explain / graph_impact / graph_path / graph_context
+       {…, expected_content_root: root}
+```
+
+`graph_update` is a blocking content-verified barrier: it hashes every detected
+code file and re-extracts any whose content changed. The returned
+`freshness.content_root` uniquely identifies that source snapshot. The response
+also reports `files_hashed` and `bytes_hashed`. Passing the root as
+`expected_content_root` on a subsequent read pins the response to the same
+snapshot; the daemon returns an
+error instead of graph data if it has published a different root since then.
+
+Ordinary reads (without `expected_content_root`) do not scan the filesystem. They
+read the latest published snapshot and return its `freshness` metadata; during
+startup or for non-source seam graphs, `freshness.verified` can be `false`. The
+daemon keeps source-backed snapshots current through automatic file watching.
+Use synchronization and a pin when you need proof that the graph matches specific
+source content.
+
+## Session memory (survive /compact and /clear)
+
+The daemon and `graph.json` live **outside your context window**, so a checkpoint
+written before a `/compact` or `/clear` is still recall-able afterward. Use this
+to carry the task thread across a context reset instead of losing it.
+
+- `graph_remember {title, body, touches?, tags?}` — write one checkpoint. `body`
+  is a **distilled** markdown summary of what you did and what's next; `touches`
+  lists the code symbols (ids or bare names) the work concerns, so recall can link
+  back to them. Persist only the distilled outcome — **never** raw tool output,
+  DOM snapshots, or chain-of-thought.
+- `graph_recall {query?, limit?}` — return recent checkpoints newest-first, each
+  with its body and briefs of the code it touched. After a `/clear`, recall first
+  (~KB payload) to restore the thread, then `graph_context` on a linked symbol to
+  reload just-enough source.
+
+The discipline is **distill → checkpoint → clear → recall**. Checkpoints are
+inert to code analysis (they never shift query/impact/context rankings) and
+survive daemon restart, incremental edits, and full rescans — the sidecars under
+`cgraph-out/memory/` are the durable source of truth.
+
+## Practicalities
+
+- The `cgraph` MCP server must be registered (it auto-spawns a per-project daemon
+  keyed to the project root). The first tool call in a project triggers a
+  one-time graph build (seconds), then queries are warm (~10ms).
+- While that first build runs, results carry `"graph_state": "building"` — an
+  empty result then means "not built yet", not "no match". Retry after a few
+  seconds or poll `graph_status` until `build_state` is `"ready"`.
+- The daemon watches the project tree (`graph_status` reports `watching`): file
+  edits land in the graph automatically within a few seconds, and the graph is
+  re-persisted in the background.
+- Fall back to grep/read only when cgraph genuinely has no answer — e.g. a
+  string literal, a comment, a config value, or a file type cgraph does not
+  extract. For symbols and their relationships, prefer the graph.
+- cgraph indexes code structure deterministically. Prose/doc relationships
+  appear only if semantic enrichment fragments have been ingested; don't assume
+  documentation concepts are present unless `graph_status` shows enrichment.

--- a/.kimi-code/skills/docs/SKILL.md
+++ b/.kimi-code/skills/docs/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: docs
+description: "Write documentation — user-facing, technical, runbooks, onboarding, changelogs. Less is more: only document what code can't tell you."
+user-invocable: true
+---
+
+# Documentation
+
+Less is more. Agents and humans can gather context on the fly. Only document what's hard to see from code:
+
+- **Architecture** — Component relationships, data flow, system boundaries
+- **Why** — Decisions, constraints, tradeoffs (not what)
+- **Operations** — Procedures that require specific steps
+- **User interfaces** — Public APIs, CLIs, tools
+
+## Routing Table
+
+| Task | Subskill | When to Use |
+|---|---|---|
+| User-facing (CLI, API, tools) | `write-user.md` | Public interfaces, README, guides |
+| Internal technical | `write-technical.md` | Architecture docs, system design |
+| Runbooks | `write-runbook.md` | Operational procedures, troubleshooting |
+| Onboarding | `write-onboarding.md` | New contributor guide |
+| Changelogs | `write-changelog.md` | Release notes |
+
+## Core Principles
+
+**1. Don't document what code tells you.**
+If someone can read the function and understand it, don't write docs. Comments rot. Code is truth.
+
+**2. Architecture over implementation.**
+Document component boundaries, data flow, integration points. Not how functions work internally.
+
+**3. High-level, like a principal engineer.**
+Write for someone who understands systems but doesn't know THIS system. Skip basics.
+
+**4. Diagrams over prose.**
+One ASCII diagram or mermaid chart replaces paragraphs. Show structure visually.
+
+**5. Reference the code, don't duplicate it.**
+`See harness/agent/execution.go:306-500` beats copying code into docs.
+
+## Decision Tree
+
+```
+Need documentation?
+├── Public interface (CLI, API)? → write-user.md
+├── System architecture? → write-technical.md
+├── Operational procedure? → write-runbook.md
+├── New contributor setup? → write-onboarding.md
+├── Release notes? → write-changelog.md
+└── Implementation details? → DON'T DOCUMENT. Code is the doc.
+```

--- a/.kimi-code/skills/docs/write-changelog.md
+++ b/.kimi-code/skills/docs/write-changelog.md
@@ -1,0 +1,64 @@
+# Write Changelogs
+
+For release notes. User impact, not implementation.
+
+> **Where the note goes.** If the repo uses the fragment model (a `.changelog/`
+> directory — see the `code:changelog` skill), do **not** edit `CHANGELOG.md` by
+> hand. Drop one new file at `.changelog/next/<ticket>.md` with your note. Every
+> PR writes a different file, so the changelog can never become a merge conflict;
+> the release folds the queue and regenerates `CHANGELOG.md`. The guidance below
+> is about *what to write* — it applies either way.
+
+## Core Principle
+
+**What changed for users, not what you did.** Group by impact, not by commit.
+
+## Structure
+
+```markdown
+# v1.2.0
+
+## Breaking Changes
+
+- `foo` flag renamed to `bar` — update your scripts
+
+## New
+
+- Export to PDF: `tool export --pdf`
+- Dark mode support
+
+## Fixed
+
+- No longer crashes on large files
+- Memory leak in long sessions
+
+## Improved
+
+- 2x faster startup
+- Better error messages for auth failures
+```
+
+## Categories
+
+| Category | What Goes Here |
+|----------|----------------|
+| Breaking | Requires user action |
+| New | Features they can use |
+| Fixed | Bugs that affected them |
+| Improved | Better experience |
+| Security | Vulnerabilities patched |
+
+## Anti-Patterns
+
+- Raw commit messages
+- Internal refactors ("cleaned up code")
+- Ticket numbers without context
+- Technical details users don't need
+
+## Style
+
+- Start with verb: "Add", "Fix", "Remove", "Improve"
+- User perspective: "You can now..." not "We implemented..."
+- If migration needed, show exact steps
+
+Keep it scannable. Users skim for what affects them.

--- a/.kimi-code/skills/docs/write-onboarding.md
+++ b/.kimi-code/skills/docs/write-onboarding.md
@@ -1,0 +1,58 @@
+# Write Onboarding Docs
+
+For new contributors. Goal: first successful change, fast.
+
+## Core Principle
+
+**One working change, not comprehensive knowledge.** Get them productive, then they learn by doing.
+
+## Structure
+
+```markdown
+# Getting Started
+
+## Setup (10 min)
+
+\`\`\`bash
+# Clone and install
+git clone ...
+cd ...
+./scripts/install.sh
+\`\`\`
+
+## Your First Change (15 min)
+
+1. Find a `good-first-issue` or try this: [specific small task]
+2. Make the change in `src/foo/`
+3. Test: `./scripts/test.sh`
+4. Submit: `git commit && git push`
+
+## Where Things Live
+
+| Area | Path | What's There |
+|------|------|--------------|
+| Core | `src/core/` | Main logic |
+| UI | `src/ui/` | Components |
+| API | `src/api/` | Endpoints |
+
+## Getting Help
+
+- Questions: [channel/forum]
+- Stuck: [who to ask]
+```
+
+## Anti-Patterns
+
+- Dumping all architecture upfront
+- Explaining history and decisions
+- Tool lists without context
+- "Read the wiki" links
+
+## Key Elements
+
+1. **Working setup in 10 min** — Or you've lost them
+2. **One specific task** — Not "find something"
+3. **Where to look** — Mental map of the repo
+4. **Who to ask** — Real human contact
+
+Shorter is better. They'll explore when ready.

--- a/.kimi-code/skills/docs/write-runbook.md
+++ b/.kimi-code/skills/docs/write-runbook.md
@@ -1,0 +1,54 @@
+# Write Runbooks
+
+For operational procedures: incidents, deployments, maintenance.
+
+## Core Principle
+
+**Symptoms to actions.** Start from what you observe, end with what to do.
+
+## Structure
+
+```markdown
+# Runbook: [Problem/Procedure]
+
+## Symptoms
+
+- What you see (logs, metrics, alerts)
+- How to confirm this is the issue
+
+## Diagnosis
+
+1. Check X: `command`
+   - If Y, go to Step 2
+   - If Z, see [Other Runbook]
+
+2. Check A: `command`
+   - Expected output: ...
+
+## Resolution
+
+1. Do X: `command`
+2. Verify: `command`
+3. Confirm resolution: [metric/log to check]
+
+## Escalation
+
+- If still broken after 15 min: [who to contact]
+- If data loss suspected: [emergency procedure]
+```
+
+## Anti-Patterns
+
+- Vague steps ("check the logs")
+- No decision points
+- Missing verification steps
+- No escalation path
+
+## Key Elements
+
+1. **Exact commands** — Copy-pasteable
+2. **Expected output** — What success looks like
+3. **Decision points** — If X then Y, else Z
+4. **Time bounds** — When to escalate
+
+Keep it minimal. If it's not needed at 3am, cut it.

--- a/.kimi-code/skills/docs/write-technical.md
+++ b/.kimi-code/skills/docs/write-technical.md
@@ -1,0 +1,70 @@
+# Write Technical Documentation
+
+For internal architecture docs. High-level, principal engineer style.
+
+## Core Principle
+
+**Document what code can't tell you.** Component boundaries, data flow, system design. Not implementation details.
+
+## Structure
+
+```markdown
+# System Name
+
+One paragraph: what this system does, why it exists.
+
+## Architecture
+
+[ASCII or mermaid diagram showing components and flow]
+
+## Data Flow
+
+[Diagram: how data moves through the system]
+
+## Key Concepts
+
+| Concept | What It Is | Where |
+|---------|------------|-------|
+| Widget | Does X | `src/widget/` |
+
+## Integration Points
+
+- **Upstream:** What calls this
+- **Downstream:** What this calls
+
+## Critical Files
+
+| File | Role |
+|------|------|
+| `foo.go` | Entry point |
+```
+
+## Diagram Standards
+
+ASCII boxes for architecture:
+```
+┌─────────────┐     ┌─────────────┐
+│  Component  │────▶│  Component  │
+└─────────────┘     └─────────────┘
+```
+
+Mermaid for flows:
+```mermaid
+flowchart LR
+    A[Input] --> B[Process] --> C[Output]
+```
+
+## Anti-Patterns
+
+- Explaining how functions work (read the code)
+- Duplicating code in docs
+- Documenting stable internals
+- Prose where a diagram fits
+
+## Reference Style
+
+Point to code, don't copy it:
+- `See harness/agent/execution.go:306-500`
+- `Implementation in src/auth/`
+
+One diagram is worth 1000 words. Write less.

--- a/.kimi-code/skills/docs/write-user.md
+++ b/.kimi-code/skills/docs/write-user.md
@@ -1,0 +1,74 @@
+# Write User-Facing Documentation
+
+For public interfaces: CLIs, APIs, tools, libraries.
+
+Frame around what users want to do — not a regurgitation of `--help`.
+
+## Core principles
+
+**Questions, not commands.** Format sections as literal questions users would ask:
+- "How do I automate a site that blocks bots?"
+- "I don't want to log in every time"
+- "I have multiple accounts and want to keep them separate"
+
+**Situations, not syntax.** "I just generated a new API key in the browser — how do I save it?" beats "Use `--value-stdin` to pipe input."
+
+**Why not X?** Start with a comparison section that honestly positions against alternatives. Research the actual competition — clone their repos, read their code. Never make claims you haven't verified.
+
+**The 20% that delivers 80%.** Don't list every command. Identify the 5 things users actually want to do, then show how.
+
+**End with "What else can I do?"** Point to `--help` for the long tail. The skill doc isn't a reference manual.
+
+## Before writing
+
+1. **Who is the audience?** Developer? Agent user? End user? Frame accordingly.
+2. **What are they trying to accomplish?** List the top 5 goals as questions.
+3. **What's the competition?** Research honestly. Clone repos if needed. No false claims.
+4. **What's our actual edge?** Must be backed by code or architecture.
+
+## Anti-patterns
+
+- Listing all commands with their flags
+- "This tool does X" instead of "You want to do X? Here's how"
+- Copying `--help` output into markdown
+- Making claims about competitors without checking their code
+- Technical jargon without context
+- Explaining what instead of why
+
+## Example: Bad
+
+```markdown
+## Commands
+
+### `browser start`
+Starts a browser task.
+
+Options:
+- `--profile` - Browser profile to use
+- `--task` - Task ID (optional)
+```
+
+## Example: Good
+
+```markdown
+## "I don't want to log in every time"
+
+Log in once to a profile — the session persists. Every future task is already authenticated:
+
+\`\`\`bash
+agents browser profiles create social --browser chrome
+agents browser start setup --profile social
+# Log in manually, then stop
+
+# Next time — already logged in
+agents browser start post --profile social
+\`\`\`
+```
+
+## Honest competition
+
+When comparing to alternatives:
+1. Actually clone their repo and read their code
+2. Verify any claims about what they do or don't support
+3. If they're good at something, say so
+4. Our edges must be backed by actual implementation differences

--- a/.kimi-code/skills/reflect/SKILL.md
+++ b/.kimi-code/skills/reflect/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: reflect
+description: >-
+  Recall all feedback, corrections, and constraints from the current
+  conversation before rewriting or iterating. Triggers on: reflect,
+  step back, reconsider, recall feedback, what did I say, incorporate
+  all feedback, or when iterative drafts keep missing the mark.
+argument-hint: "[optional: specific topic to reflect on]"
+user-invocable: true
+---
+
+# Reflect
+
+You are mid-conversation. The user has given you feedback — corrections, preferences, pushback, confirmations. Before your next attempt, you must surface all of it.
+
+## When This Triggers
+
+- User explicitly says "reflect", "step back", "reconsider", "recall what I said"
+- You've done 2+ iterations and the user is still unsatisfied
+- User says something like "incorporate all my feedback" or "you keep missing X"
+
+## The Process
+
+### Step 1: Enumerate Every Piece of Feedback
+
+Scan the entire conversation. Extract every instance where the user:
+
+- **Corrected you** ("no", "not that", "wrong framing", "that's not what I meant")
+- **Rejected an approach** ("don't lead with X", "stop doing Y", "this isn't useful")
+- **Confirmed something worked** ("yes", "exactly", "that's the right angle", accepted without pushback)
+- **Added a constraint** ("it should feel like...", "the audience is...", "don't mention...")
+- **Provided new information** that changes the approach (facts, context, nuance you didn't have before)
+
+Present these as a numbered list. Quote the user's words where possible — don't paraphrase into something softer.
+
+Format:
+
+```
+FEEDBACK INVENTORY:
+
+1. [REJECTED] "the first hook isn't really useful — it sounds like scrolls dropping"
+   → Thesis statements don't hook. Lead with something concrete/surprising.
+
+2. [CORRECTED] "an agent run by cron can do push notifications to ask for permissions"
+   → "Autonomous = unreachable" is wrong. The real issue is latency tolerance, not absence.
+
+3. [CONFIRMED] The per-binary network policy detail — user flagged this as the most interesting finding early on.
+   → This should be the anchor, not supporting detail.
+
+4. [CONSTRAINT] Don't sell Rush. No product pitch.
+   → Can reference contextually but not promote.
+
+5. ...
+```
+
+### Step 2: Identify the Pattern
+
+After listing, ask: what's the *thread* connecting these corrections? Usually the user is pushing toward one thing you keep missing. Name it explicitly.
+
+Example: "The thread: I keep leading with framing and structure instead of a single concrete thing that's genuinely surprising."
+
+### Step 3: State the Revised Approach
+
+Before writing anything new, state in 1-2 sentences what you'll do differently this time, grounded in the feedback inventory.
+
+### Step 4: Execute
+
+Now write the next draft/response with all constraints active simultaneously. Not just the latest correction — all of them.
+
+## Why This Works
+
+Creative iteration fails when the agent treats each correction as a local patch. Feedback is cumulative — correction #5 doesn't replace corrections #1-4. But without explicit recall, agents drift: they fix the latest issue and regress on earlier ones.
+
+This skill forces global constraint satisfaction before each attempt.
+
+## Anti-Patterns
+
+- **Summarizing feedback vaguely** ("you wanted it to be better") — quote specific words
+- **Only recalling corrections, not confirmations** — what worked is as important as what didn't
+- **Treating this as a delay tactic** — the inventory should take 30 seconds, not become a philosophical exercise
+- **Skipping Step 2** — the pattern identification is where the real insight lives

--- a/.kimi-code/skills/release/SKILL.md
+++ b/.kimi-code/skills/release/SKILL.md
@@ -1,0 +1,581 @@
+---
+name: release
+description: >-
+  Publish packages to registries (npm, CDN, etc.). Discovers repo structure,
+  scaffolds build/release scripts if missing, runs tests, updates changelog,
+  publishes, and tags. Supports monorepos and semver with prereleases.
+  Triggers on: release, publish, ship, npm publish, cut a release.
+user-invocable: true
+version: 1.0.0
+author: muqsit
+---
+
+# Release
+
+Publish packages to their registries. Works with single packages and monorepos.
+
+## Arguments
+
+`$ARGUMENTS` may contain:
+- A version number: `1.2.3`, `1.2.3-alpha.1`, `patch`, `minor`, `major`
+- A package path for monorepos: `rush/app`, `harness-ui`
+- Flags: `--skip-tests`, `--skip-build`, `--force`
+
+If no version is given, analyze what's needed and suggest one.
+
+---
+
+## Phase 1: Discovery
+
+Before doing anything, check for project-specific release instructions.
+
+### 1.1 Check for project-level overrides
+
+```bash
+# Project-level release skill takes precedence
+ls .agents/skills/release/ 2>/dev/null
+
+# Check for release instructions in project docs
+grep -l -i "release\|publish\|deploy" README.md CLAUDE.md AGENTS.md .agents/*.md 2>/dev/null | head -5
+```
+
+If `.agents/skills/release/` exists in the project, defer to it completely. Read those instructions and follow them instead of this skill.
+
+### 1.2 Detect repo structure
+
+```bash
+# Is this a monorepo?
+if [[ -f "package.json" ]]; then
+  # Check for workspaces
+  jq -e '.workspaces' package.json 2>/dev/null && echo "MONOREPO: npm/bun workspaces"
+fi
+
+[[ -f "pnpm-workspace.yaml" ]] && echo "MONOREPO: pnpm workspaces"
+[[ -f "lerna.json" ]] && echo "MONOREPO: lerna"
+
+# Find all package.json files
+fd -t f package.json --max-depth 3 | head -20
+```
+
+### 1.3 Identify publishable packages
+
+```bash
+# List packages that are NOT private
+fd -t f package.json --max-depth 3 -x sh -c '
+  name=$(jq -r ".name // empty" "{}")
+  private=$(jq -r ".private // false" "{}")
+  if [[ -n "$name" && "$private" != "true" ]]; then
+    echo "{}: $name"
+  fi
+'
+```
+
+### 1.4 Find release scripts
+
+```bash
+# Standard locations
+ls scripts/release.sh scripts/build.sh release.sh 2>/dev/null
+
+# Monorepo subdirs
+fd -t f release.sh --max-depth 4
+
+# Check for npm scripts
+jq -r '.scripts | keys[]' package.json 2>/dev/null | grep -E 'release|publish|deploy'
+```
+
+### 1.5 Monorepo: Ask which package
+
+If multiple publishable packages are found and `$ARGUMENTS` doesn't specify one, use `AskUserQuestion` to ask which package to release. List all discovered packages with their current versions.
+
+---
+
+## Phase 2: Infrastructure Check
+
+### 2.1 Check for existing scripts
+
+If `scripts/release.sh` exists, read it to understand:
+- Does it have dry-run mode? (look for `--apply`, `--confirm`, `--dry-run`)
+- Does it run tests? (look for `npm test`, `bun test`, `build.sh`)
+- What registry does it publish to? (npm, CDN URL, etc.)
+
+### 2.2 Scaffold if missing
+
+If no release script exists, offer to create the standard structure:
+
+**scripts/build.sh:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKIP_TESTS=false
+for arg in "$@"; do
+  case $arg in
+    --skip-tests) SKIP_TESTS=true ;;
+  esac
+done
+
+echo "==> Type checking..."
+if [[ -f "tsconfig.json" ]]; then
+  npx tsc --noEmit || { echo "Type check failed"; exit 1; }
+fi
+
+echo "==> Linting..."
+npm run lint 2>/dev/null || bun run lint 2>/dev/null || true
+
+if [[ "$SKIP_TESTS" == "true" ]]; then
+  echo ""
+  echo "=============================================="
+  echo "  WARNING: Skipping tests is discouraged."
+  echo "  Fix failing tests instead of bypassing them."
+  echo "=============================================="
+  echo ""
+else
+  echo "==> Running tests..."
+  npm test || bun test || { echo "Tests failed"; exit 1; }
+fi
+
+echo "==> Building..."
+npm run build || bun run build || { echo "Build failed"; exit 1; }
+
+echo "==> Build complete"
+```
+
+**scripts/release.sh:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+APPLY=false
+SKIP_BUILD=false
+SKIP_TESTS=false
+
+for arg in "$@"; do
+  case $arg in
+    --apply|--confirm) APPLY=true ;;
+    --skip-build) SKIP_BUILD=true ;;
+    --skip-tests) SKIP_TESTS=true ;;
+  esac
+done
+
+die() { echo "ERROR: $1" >&2; exit 1; }
+
+[[ -z "$VERSION" ]] && die "Usage: scripts/release.sh <version> [--apply]"
+
+# Validate semver (with optional prerelease)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  die "Invalid version format: $VERSION (expected semver like 1.2.3 or 1.2.3-alpha.1)"
+fi
+
+# Pre-flight checks
+echo "==> Pre-flight checks"
+[[ -n "$(git status --porcelain)" ]] && die "Working tree not clean. Commit or stash changes first."
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" != "main" && "$BRANCH" != "master" && ! "$BRANCH" =~ ^release/ ]] && \
+  echo "WARNING: Not on main branch (on $BRANCH)"
+
+# Package info
+PKG_NAME=$(jq -r '.name' package.json)
+[[ -z "$PKG_NAME" || "$PKG_NAME" == "null" ]] && die "No package name in package.json"
+
+# Check current published version
+echo "==> Checking registry for $PKG_NAME"
+CURRENT=$(npm view "$PKG_NAME" version 2>/dev/null || echo "0.0.0")
+echo "   Current published: $CURRENT"
+echo "   Target version:    $VERSION"
+
+# Build
+if [[ "$SKIP_BUILD" == "true" ]]; then
+  echo ""
+  echo "WARNING: Skipping build. Ensure artifacts are fresh."
+  echo ""
+else
+  echo "==> Running build"
+  BUILD_ARGS=""
+  [[ "$SKIP_TESTS" == "true" ]] && BUILD_ARGS="--skip-tests"
+  ./scripts/build.sh $BUILD_ARGS || die "Build failed"
+fi
+
+# Show what will be published
+echo ""
+echo "==> Package contents (dry-run):"
+npm pack --dry-run 2>&1 | head -50
+
+if [[ "$APPLY" != "true" ]]; then
+  echo ""
+  echo "================================================"
+  echo "  DRY-RUN COMPLETE"
+  echo "  "
+  echo "  To actually publish, run:"
+  echo "    scripts/release.sh $VERSION --apply"
+  echo "================================================"
+  exit 0
+fi
+
+# Update version in package.json
+echo "==> Updating version to $VERSION"
+npm version "$VERSION" --no-git-tag-version
+
+# Get npm token from agents secrets
+echo "==> Authenticating with npm"
+NPM_TOKEN=$(agents secrets export npmjs.com --plaintext 2>/dev/null | grep NPM_TOKEN | cut -d= -f2-)
+if [[ -z "$NPM_TOKEN" ]]; then
+  die "No NPM_TOKEN found. Create it with: agents secrets create npmjs.com && agents secrets add npmjs.com NPM_TOKEN"
+fi
+
+# Write temporary .npmrc
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc.release
+trap 'rm -f .npmrc.release' EXIT
+
+# Publish
+echo "==> Publishing to npm"
+npm publish --access public --userconfig .npmrc.release || die "Publish failed"
+
+# Verify publish
+echo "==> Verifying publish"
+sleep 2
+PUBLISHED=$(npm view "$PKG_NAME@$VERSION" version 2>/dev/null || echo "")
+if [[ "$PUBLISHED" != "$VERSION" ]]; then
+  echo "WARNING: Could not verify $PKG_NAME@$VERSION on registry yet (may take a moment)"
+fi
+
+# Git operations AFTER successful publish
+echo "==> Creating git tag"
+git add package.json package-lock.json 2>/dev/null || git add package.json
+git commit -m "chore(release): $VERSION"
+git tag "v$VERSION"
+git push origin "$BRANCH"
+git push origin "v$VERSION"
+
+echo ""
+echo "================================================"
+echo "  RELEASED $PKG_NAME@$VERSION"
+echo "  "
+echo "  npm: https://www.npmjs.com/package/$PKG_NAME"
+echo "  tag: v$VERSION"
+echo "================================================"
+```
+
+### 2.3 Package hygiene
+
+Check that the package doesn't publish unnecessary files:
+
+```bash
+# Check what would be published
+npm pack --dry-run 2>&1
+
+# Check for files field or .npmignore
+jq '.files' package.json
+cat .npmignore 2>/dev/null
+```
+
+If neither exists and `src/`, `tests/`, or large directories would be published, suggest creating `.npmignore`:
+
+```
+src/
+tests/
+*.test.ts
+*.spec.ts
+testdata/
+.github/
+.vscode/
+*.log
+.env*
+```
+
+---
+
+## Phase 3: Version Analysis
+
+### 3.1 Get current published version
+
+```bash
+PKG_NAME=$(jq -r '.name' package.json)
+
+# npm registry
+npm view "$PKG_NAME" version 2>/dev/null || echo "Not yet published"
+
+# All published versions
+npm view "$PKG_NAME" versions --json 2>/dev/null | jq -r '.[-5:][]'
+```
+
+### 3.2 Determine next version
+
+If `$ARGUMENTS` contains `patch`, `minor`, or `major`:
+- Calculate the next version from current published
+- For prereleases: `1.2.3-alpha.1` → `1.2.3-alpha.2`
+
+Semver rules:
+- **Stable releases** (`1.2.3`): enforce single-step bumps only
+  - `1.2.3` → `1.2.4` (patch) OK
+  - `1.2.3` → `1.3.0` (minor) OK
+  - `1.2.3` → `1.5.0` NOT OK (skips 1.4.0)
+- **Prereleases** (`1.2.3-alpha.1`): allow free jumps within prerelease
+  - `1.2.3-alpha.1` → `1.2.3-alpha.5` OK
+  - `1.2.3-alpha.1` → `1.2.3-beta.1` OK
+  - `1.2.3-rc.1` → `1.2.3` OK (promotion to stable)
+
+### 3.3 Version validation
+
+```bash
+# Parse versions
+CURRENT="1.2.3"
+TARGET="1.2.4"
+
+# Extract components
+IFS='.-' read -r CMAJ CMIN CPAT CPRE <<< "$CURRENT"
+IFS='.-' read -r TMAJ TMIN TPAT TPRE <<< "$TARGET"
+
+# Validate (simplified)
+if [[ -z "$TPRE" ]]; then
+  # Stable release - must be single step
+  # ... validation logic
+fi
+```
+
+---
+
+## Phase 4: Pre-flight Checks
+
+### 4.1 Run tests (mandatory)
+
+Even if the release script runs tests, run them first to fail fast:
+
+```bash
+npm test || bun test
+```
+
+If tests fail, this is a **blocking** issue. Do not proceed.
+
+If `--skip-tests` was passed:
+```
+============================================
+  WARNING: You are skipping tests.
+
+  Skipping tests is strongly discouraged.
+  It's better to fix failing tests than to
+  ship broken code.
+
+  Proceeding anyway because --skip-tests was set.
+============================================
+```
+
+### 4.2 Check git state
+
+```bash
+# Must be clean
+git status --porcelain
+
+# Should be on main (warn if not)
+git rev-parse --abbrev-ref HEAD
+```
+
+### 4.3 Check secrets
+
+```bash
+# List available secrets bundles
+agents secrets list
+
+# Check for npm token specifically
+agents secrets export npmjs.com --plaintext 2>/dev/null | grep -q NPM_TOKEN && echo "npm auth: OK"
+```
+
+If required secrets are missing, this is **blocking**. Guide the user:
+```
+Missing npm authentication. Set it up with:
+  agents secrets create npmjs.com
+  agents secrets add npmjs.com NPM_TOKEN
+```
+
+### 4.4 Issue categorization
+
+**Blocking (must fix before release):**
+- Test failures
+- Uncommitted changes in git
+- Missing required secrets
+- Version already published (unless `--force`)
+- Invalid semver format
+
+**Non-blocking (warn and continue):**
+- Not on main branch
+- Using `--skip-tests` or `--skip-build`
+- No CHANGELOG.md (will create one)
+- No dry-run mode in release script
+
+---
+
+## Phase 5: Changelog
+
+> **Fragment model (preferred).** If the repo has a `.changelog/` directory (the
+> `code:changelog` skill / towncrier-style fragments), the changelog is a
+> GENERATED artifact: per-PR notes live in `.changelog/next/<ticket>.md`, and the
+> release script folds them into `.changelog/<version>.md` and regenerates
+> `CHANGELOG.md`. **Skip 5.3–5.4** — the release script owns the changelog; just
+> confirm the queue is non-empty (`ls .changelog/next/*.md`) so the release can
+> document itself. Sections 5.1–5.4 below are the legacy single-file path for
+> repos without `.changelog/`.
+
+### 5.1 Get commits since last release
+
+```bash
+# Find last release tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [[ -n "$LAST_TAG" ]]; then
+  echo "Commits since $LAST_TAG:"
+  git log "$LAST_TAG"..HEAD --oneline --no-merges
+else
+  echo "No previous tags. Showing recent commits:"
+  git log -20 --oneline --no-merges
+fi
+```
+
+### 5.2 Parse conventional commits
+
+Group commits by type:
+
+```bash
+git log "$LAST_TAG"..HEAD --oneline --no-merges | while read -r line; do
+  if [[ "$line" =~ ^[a-f0-9]+\ feat ]]; then
+    echo "ADDED: $line"
+  elif [[ "$line" =~ ^[a-f0-9]+\ fix ]]; then
+    echo "FIXED: $line"
+  elif [[ "$line" =~ ^[a-f0-9]+\ (refactor|perf|chore) ]]; then
+    echo "CHANGED: $line"
+  fi
+done
+```
+
+### 5.3 Generate changelog entry
+
+Format:
+```markdown
+## [1.2.3] - 2026-05-09
+
+### Added
+- feat(auth): OAuth refresh token support (#123)
+
+### Fixed  
+- fix(sync): orphan sweep for stale resources (#124)
+
+### Changed
+- refactor(runner): simplify job execution
+```
+
+### 5.4 Update or create CHANGELOG.md
+
+If CHANGELOG.md exists, prepend the new section after the header.
+If it doesn't exist, create it:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.2.3] - 2026-05-09
+
+### Added
+...
+```
+
+---
+
+## Phase 6: Execute Release
+
+### 6.1 Dry-run first
+
+If the release script supports dry-run:
+```bash
+./scripts/release.sh "$VERSION"
+```
+
+Show the output and summarize what will happen.
+
+### 6.2 Confirm with user
+
+Before actual release, use `AskUserQuestion`:
+- Show version change: `1.2.2 → 1.2.3`
+- Show registry target
+- Show changelog entry preview
+- Show files that will be published
+
+Options: "Release now", "Edit changelog first", "Cancel"
+
+### 6.3 Execute
+
+```bash
+./scripts/release.sh "$VERSION" --apply
+```
+
+### 6.4 Verify
+
+After the script completes:
+```bash
+# Verify on npm
+npm view "$PKG_NAME@$VERSION" version
+
+# Verify tag exists
+git tag -l "v$VERSION"
+```
+
+### 6.5 Report success
+
+```
+Released @phnx-labs/agents-cli@1.2.3
+
+- npm: https://www.npmjs.com/package/@phnx-labs/agents-cli
+- tag: v1.2.3
+- changelog: Updated CHANGELOG.md
+```
+
+---
+
+## Escape Hatches
+
+These flags exist but their use is discouraged:
+
+| Flag | Effect | When shown |
+|------|--------|-----------|
+| `--skip-tests` | Skip test suite | Prints warning about fixing tests being better |
+| `--skip-build` | Skip build step | Warns about stale artifacts |
+| `--force` | Skip version validation | Warns about registry conflicts |
+
+Always show warnings when these are used. Never silently skip.
+
+---
+
+## Error Handling
+
+### Tests fail
+```
+Tests failed. Fix the failing tests before releasing.
+
+Failing tests:
+  - src/lib/runner.test.ts: timeout handling
+  - src/lib/events.test.ts: rotation logic
+
+Run `npm test` to see full output.
+```
+
+### Version already published
+```
+Version 1.2.3 is already published on npm.
+
+Options:
+1. Bump to 1.2.4: scripts/release.sh 1.2.4 --apply
+2. Use prerelease: scripts/release.sh 1.2.4-beta.1 --apply
+3. Force republish (dangerous): scripts/release.sh 1.2.3 --force --apply
+```
+
+### Missing secrets
+```
+npm authentication not configured.
+
+Set up npm token:
+  1. Go to https://www.npmjs.com/settings/tokens
+  2. Create an "Automation" token with publish access
+  3. Save it:
+     agents secrets create npmjs.com
+     agents secrets add npmjs.com NPM_TOKEN
+```

--- a/.kimi-code/skills/scripts/SKILL.md
+++ b/.kimi-code/skills/scripts/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: scripts
+description: "Scripts directory contract — canonical build/test/install/release.sh patterns for deployable projects. Triggers on: scripts/, release.sh, build.sh, deploy, publish."
+user-invocable: false
+---
+
+# Scripts Directory Contract
+
+Every deployable project keeps a `scripts/` directory with a small set of canonical scripts. Use them. Don't reinvent.
+
+## Canonical scripts
+
+- `scripts/build.sh` — compile/bundle and **run the test suite**. Green build means tests passed.
+- `scripts/test.sh` — full test suite, runnable on its own.
+- `scripts/install.sh` — install dependencies, set up local config.
+- `scripts/release.sh` — ship the artifact (npm publish, docker push, deploy, etc.). **Use `release` as the canonical name** — covers all forms of shipping.
+
+## release.sh contract
+
+- **Defaults to dry-run.** Without `--confirm`, the script prints exactly what it would do and exits 0. Nothing mutates.
+- **`--confirm` is required to actually release.** No other flag substitutes.
+- **`--skip-build` and `--skip-tests`** are escape hatches for re-runs after a verified-elsewhere build, or hotfixes. Default: run both.
+- **Refuses on test failure** unless `--skip-tests` was explicitly passed. If you find yourself adding `|| true` to silence a check, stop.
+- **Pre-flight checks run before slow checks.** Version-collision (`npm view <pkg> versions --json` against `package.json`) before `bun test`. Missing-secrets check before `git push`. Cheap failures fast.
+- **Source of truth is the system the script targets, not git.** npm publish status comes from the registry, not commit subjects. Deploy status comes from the deploy registry.
+- **Idempotent.** If `release.sh` is interrupted between version-bump and the actual publish, re-running converges — no double-bump, no double-tag.
+
+## What "done" means for a release
+
+A release isn't done until the package version shows up on the registry (or the deploy URL serves the new build). Code merged is not released.
+
+## Anti-patterns
+
+- `release.sh` that publishes without running tests by default.
+- Detecting "what's already published" by `git log` subject lines instead of the registry.
+- Running expensive checks (test suites, builds) before cheap checks (version collision, missing secrets).
+- A `deploy.sh` with no dry-run mode that hits production on every invocation.

--- a/.kimi-code/skills/security/SKILL.md
+++ b/.kimi-code/skills/security/SKILL.md
@@ -1,0 +1,189 @@
+---
+description: "Security audit of a codebase via parallel agents — one per vulnerability class. Reads code fast with Explore agents, cross-checks against current advisories via web search, filters false positives hard. Triggers on 'security scan', 'security audit', 'vulnerability scan', 'check for leaked secrets', 'scan for injection', or scheduled security checks."
+argument-hint: "[scope — days, paths, or freeform e.g. 'last 7 days', 'prix/api routes', 'pre-launch sweep']"
+allowed-tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+user-invocable: true
+---
+
+# Security
+
+A security audit pattern: analyze what changed, classify by vulnerability type, dispatch one parallel agent per class, verify every finding yourself, **filter false positives hard**, report only confirmed issues.
+
+You are the orchestrator. Each vulnerability class becomes one Explore subagent that reads code fast and cross-checks against current advisories via web search. Never trust an agent's "CRITICAL" finding without reading the cited file yourself.
+
+## How it works
+
+```
+You (orchestrator)
+ |-- 1. Discover scope: what changed, what to audit
+ |-- 2. Classify the change surface by risk
+ |-- 3. Dispatch one Explore agent per vulnerability class (in parallel)
+ |-- 4. Each agent: read code, grep patterns, web-search current advisories
+ |-- 5. Collect findings
+ |-- 6. VERIFY every CRITICAL/HIGH yourself — read the cited file:line
+ |-- 7. FILTER false positives aggressively
+ |-- 8. Report only verified findings
+```
+
+## Step 1 — Scope the scan
+
+If args give a time window, use git:
+
+```bash
+git log --oneline --since="<N> days ago" --no-merges --name-only | head -200
+```
+
+If args give a path or "pre-launch", spend 60s reading top-level `README.md`, `AGENTS.md` / `CLAUDE.md`, and the entry-point file to learn: network listener? web UI? CLI? filesystem/keychain/external API access? Multi-tenant or single-user? OSS or hosted? The attack surface determines which classes matter.
+
+State your scope back to the user in 3-4 lines before dispatching anything. They'll redirect if it's wrong.
+
+## Step 2 — Classify the change surface
+
+Look at the touched files and project conventions (the repo's `AGENTS.md` / `CLAUDE.md` are authoritative for what's high-risk). Group files into vulnerability-relevant zones — common buckets:
+
+- HTTP/API routes, controllers, middleware
+- Auth, sessions, billing, IAM
+- DB queries, ORM raw SQL, analytics query builders
+- HTML rendering, share/preview pages, embeddable surfaces
+- Shell execution, child_process, subprocess, exec.Command
+- Native/IPC boundaries (Electron main↔renderer, browser extension content scripts)
+- Infra (Terraform, CF/CDN config, Dockerfile, K8s manifests)
+- Dependencies (`package.json`, `go.mod`, lockfiles, `requirements.txt`)
+- Config & docs that may have leaked secrets (`*.env*`, `CLAUDE.md`, `docs/`, deploy scripts)
+
+If no commit list is provided, treat the whole repo's most-trafficked code paths as the surface.
+
+## Step 3 — Dispatch parallel Explore agents
+
+One agent per vulnerability class. **Spawn them all in a single message** (parallel Agent tool calls). Use `subagent_type: "Explore"` for fast, read-only code scanning. Set `model: "sonnet"` (cost-effective for pattern matching) unless the class needs deeper reasoning (then `opus`).
+
+### Vulnerability classes — pick the ones the surface warrants
+
+| Class | When to run | Typical patterns to grep |
+|---|---|---|
+| **SECRETS** | Always | `sk_live`, `phc_`, `AKID`, `xoxb-`, `ghp_`, `BEGIN PRIVATE KEY`, `.env*` tracked in git, secrets in `CLAUDE.md`/docs, deleted-but-in-history credentials |
+| **INJECTION** | DB/query code changed | String interpolation in queries, template literals near `.query()`/`.rpc()`/`SELECT`, user input reaching ORM raw escape hatches, NoSQL operator injection (`$where`, `$ne`) |
+| **AUTH** | Routes, middleware, auth changed | Endpoints without auth middleware, role checks (`isAdmin`, `isDev`) that can be skipped, broken IDOR (object access by user-controlled ID without ownership check), OAuth flow logic, JWT verification |
+| **XSS** | HTML rendering / user output changed | User input in HTML templates, `innerHTML`/`dangerouslySetInnerHTML`, missing CSP, script injection via display names or artifact content, missing `X-Frame-Options` |
+| **SHELL** | Shell-exec or child_process touched | `exec.Command("sh","-c", ...)`, `child_process.exec` with concat, `osascript -e` with input, path traversal via user-controlled paths |
+| **IPC / ELECTRON** | Electron main process or preload changed | `nodeIntegration: true`, custom protocol handlers, `webContents.executeJavaScript` with user input, `contextIsolation: false` |
+| **INFRA** | CF/Terraform/Dockerfile/K8s changed | Open redirects, SSRF in worker fetches, exposed origins (host without WAF), missing security headers, K8s `privileged: true`, overly broad RBAC |
+| **DEPS** | Lockfiles changed | Run `npm audit --json` / `go list -json -deps -m all`, web-search "CVE \<package\> \<version\> 2026" for any package not in the boring set |
+
+### Subagent prompt template
+
+```
+## Security Scan: <CLASS>
+
+Scope: <files / dirs to scan, from the changed-files list>
+Class: <CLASS>
+
+What to check:
+<2–4 lines of specifics for this class>
+
+Patterns to grep:
+<concrete patterns>
+
+Cross-check current advisories:
+- WebSearch: "<library or pattern> CVE 2026" or "<framework> security advisory 2026"
+- WebFetch: GitHub Security Advisory pages for the libraries in scope.
+
+Report format (one bullet per finding):
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
+- Location: file:line
+- Code: the actual snippet (quote it)
+- Attack vector: how an attacker reaches this
+- Confidence: high / medium / low (medium or low MUST list disconfirming evidence)
+- Fix: one line
+
+If you find nothing, say so. A clean scan is a valid result.
+Return file:line quotes for every claim. Do NOT paraphrase. If you can't quote it, don't claim it.
+```
+
+## Step 4 — Verify every CRITICAL/HIGH yourself
+
+Trust no agent verdict above MEDIUM. For each CRITICAL or HIGH:
+
+1. Read the cited file at the cited line.
+2. Confirm the code matches what the agent quoted.
+3. Trace whether user input actually reaches the vulnerable point — is there validation, escaping, middleware, parameterization in between?
+4. Check for mitigations the agent missed (framework defaults, ORM parameterization, middleware that runs before the route).
+5. Classify: `VERIFIED` / `FALSE POSITIVE` / `NEEDS RUNTIME TEST`.
+
+## Step 5 — Filter false positives HARD
+
+**False positives in security scans are the rule, not the exception.** Agents will flag patterns that look bad in isolation but aren't real vulnerabilities. The most common categories — discard these on sight unless you have evidence otherwise:
+
+### "Leaked API key" that's actually a public key
+
+| Pattern flagged | Why it's not a leak |
+|---|---|
+| `phc_xxxx` in client code | PostHog **public ingest** keys are designed to ship to browsers. Real risk is the `phx_` personal API key. |
+| `pk_live_*` / `pk_test_*` Stripe key | Stripe publishable keys are public by design. Only `sk_live_*` / `sk_test_*` are sensitive. |
+| `eyJhbGciOi...` in client | Supabase / Firebase **anon** JWTs are public by design. RLS enforces auth. The service-role key is the secret one. |
+| `AIza...` Google API key | Often a public Maps/YouTube key restricted by HTTP referrer. Check the restriction, not the format. |
+| GitHub App `client_id` | Public by design. The `client_secret` is the secret. |
+
+Confirm by reading the code: is the value embedded in shipped client bundles? Then it's by design. The check is on **intent**, not regex match.
+
+### Other common false-positive patterns
+
+- **"Missing auth on endpoint"** → check for middleware applied at the router/app level, not the handler. `app.use(authMiddleware)` covers everything below.
+- **"SQL injection in `db.query(\`...\${x}...\`)`"** → check if `x` came from validated input upstream, or if the driver is parameterizing automatically.
+- **"XSS via innerHTML"** → check if the source is hardcoded/server-controlled, not user-controlled.
+- **"Hardcoded password"** → check if it's a test fixture, a documented default, or production. Test/dev defaults aren't a vulnerability; they're an architectural choice that may or may not be appropriate.
+- **`exec.Command("sh", "-c", ...)`** → check if all interpolated values are server-controlled constants or strictly validated. Shell exec with no user-reachable input is fine.
+- **"Dependency CVE"** → check if the vulnerable code path is actually called by your code (not just present in the dependency tree). `npm audit` reports a lot of noise on transitive dev-only deps.
+
+When in doubt, **read the upstream advisory** (Web-search the CVE) and check if your usage matches the vulnerable path. Most reported CVEs only fire under narrow configurations.
+
+## Step 6 — Report
+
+Present only verified findings. Group by severity. For each, include:
+
+- Class
+- Location (`file:line`)
+- The actual code (quoted)
+- Attack vector
+- Recommended fix
+
+End the report with a **False Positives Filtered** section listing what agents flagged but you disproved — this builds trust and prevents the same flags resurfacing next scan. Also a **Clean Areas** section listing what passed (so the user knows what's been audited).
+
+## Output
+
+```markdown
+## Security Scan — <YYYY-MM-DD>
+
+### Scope
+- <window or paths>
+- <commit count if time-windowed>
+
+### Agents dispatched
+- <CLASS> (model)
+- ...
+
+### CRITICAL
+- ...
+
+### HIGH
+- ...
+
+### MEDIUM
+- ...
+
+### False positives filtered
+- <flag> — <why it's not real>
+
+### Clean
+- <area scanned, no findings>
+```
+
+Save reports under `<repo>/security/<YYYY-MM-DD>-<slug>.md` if the repo wants archived scans, otherwise return the report to the user.
+
+## Hard rules
+
+- **No "CRITICAL" without a file:line quote.** If the agent didn't quote code, demote to "needs verification" and verify yourself.
+- **No fix proposals you can't justify from the code.** "Add input validation" is a non-fix if you can't say which input on which line.
+- **Public keys are not leaked keys.** Read the surrounding code to determine intent before flagging.
+- **CVEs are not vulnerabilities until you confirm your usage matches the vulnerable path.** Look at the advisory's "Affected versions / Affected functions" section.
+- **Cost is irrelevant; correctness is everything.** If unsure about a finding, spawn another Explore agent to dig deeper. A missed bug is far more expensive than a re-scan.

--- a/.kimi-code/skills/sessions/SKILL.md
+++ b/.kimi-code/skills/sessions/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: sessions
+description: "Search, browse, and read agent conversation transcripts across Codex, Codex, Gemini, and OpenCode. Use this skill to find previous sessions, recover context, or inspect what agents have done."
+argument-hint: "[search query or session ID]"
+allowed-tools: Bash(agents sessions*)
+user-invocable: true
+---
+
+# Sessions Skill
+
+Search and browse agent conversation transcripts. This skill teaches you how to use the `agents sessions` CLI effectively.
+
+## Basic Usage
+
+```bash
+# Interactive picker: browse and search recent sessions
+agents sessions
+
+# List sessions from current project
+agents sessions | head -20
+
+# Search sessions by text
+agents sessions "add auth middleware"
+
+# Filter by project across all directories
+agents sessions --project agents-cli --all
+```
+
+## Filters
+
+| Filter | Example | Description |
+|--------|---------|-------------|
+| `--agent` | `--agent Codex` | Filter by agent type |
+| `--all` | `--all` | Include sessions from every directory |
+| `--project` | `--project myapp` | Filter by project name |
+| `--since` | `--since 2h` | Only sessions newer than this |
+| `--until` | `--until 2026-01-01` | Only sessions older than this |
+| `--limit` | `--limit 10` | Maximum sessions to return |
+| `--active` | `--active` | Only currently running sessions |
+| `--teams` | `--teams` | Include team-spawned sessions |
+
+## Reading Sessions
+
+```bash
+# Render session as markdown
+agents sessions --markdown <session-id>
+
+# Output as JSON
+agents sessions --json <session-id>
+
+# Include only specific roles
+agents sessions --markdown --include user,assistant <session-id>
+
+# Show only first/last N turns
+agents sessions --markdown --last 10 <session-id>
+```
+
+## Artifacts
+
+```bash
+# List all files written or edited during a session
+agents sessions --artifacts <session-id>
+
+# Read a specific artifact
+agents sessions --artifact <filename> <session-id>
+```
+
+## Live Tailing
+
+```bash
+# Live-tail a session file (Codex and Codex only)
+agents sessions tail <session-id>
+# Press Ctrl+C to stop
+```
+
+## Tips
+
+- Use `--active` to find sessions running right now across terminals, teams, cloud, and headless agents
+- Use `--teams` to see what team-spawned agents are doing
+- Use `--since 1h` for recent activity
+- Combine filters: `agents sessions --project myapp --since 1d --agent Codex`

--- a/.opencode/.agents-managed.json
+++ b/.opencode/.agents-managed.json
@@ -1,0 +1,13 @@
+{
+  "v": 1,
+  "paths": [
+    "commands/version.md",
+    "skills/cgraph",
+    "skills/docs",
+    "skills/reflect",
+    "skills/release",
+    "skills/scripts",
+    "skills/security",
+    "skills/sessions"
+  ]
+}

--- a/.opencode/commands/version.md
+++ b/.opencode/commands/version.md
@@ -1,0 +1,30 @@
+---
+description: Show agents-cli and pinned agent CLI versions for this workspace
+agents:
+  - claude
+  - codex
+  - gemini
+  - cursor
+  - opencode
+  - copilot
+  - grok
+---
+
+Report which agent CLIs are installed and which versions this project pins.
+
+Run:
+
+```bash
+agents --version
+agents view
+```
+
+If `agents view --json` is available in this build, prefer it for structured output.
+
+Summarize from the command output only:
+
+- agents-cli version
+- Each managed agent's pinned or default version
+- Whether each agent CLI binary is on PATH
+
+Do not guess versions. If a command fails, say which one failed and show stderr.

--- a/.opencode/skills/cgraph/SKILL.md
+++ b/.opencode/skills/cgraph/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: cgraph
+description: "Use FIRST for any question about THIS codebase's structure, symbols, or relationships — where a function/class/file is defined, what calls or imports it, what breaks if you change it, how two parts connect, or to load focused source context before editing or reviewing. Routes to the cgraph MCP tools (graph_query / graph_explain / graph_impact / graph_path / graph_context), which serve ranked file:line results, node neighborhoods, transitive blast radius, and token-budgeted source bundles from a resident per-project graph daemon in ~10ms — far cheaper than grepping and reading files. Prefer over blind grep/read for code navigation, dependency tracing, and impact analysis."
+user-invocable: true
+---
+
+# cgraph
+
+cgraph keeps a live, queryable graph of the current project — symbols (functions,
+classes, types, files), their call/import/inheritance/containment edges, and
+centrality ranking — served by a resident per-project daemon through MCP tools.
+
+**Reach for these tools before grepping or reading files** when a question is
+about code structure or relationships. A graph call is one ~10ms round-trip and
+returns exactly the file:line (and often the source) you need, instead of many
+grep/read calls that burn context.
+
+## Setup (one-time — the tools don't exist until this is done)
+
+This skill routes to the `cgraph` MCP server. On a cold checkout that server is
+**not** registered — until it is, the `graph_*` tools below don't exist and you
+should navigate with grep/read. Registration is a local, per-machine step (the
+`.mcp.json` it writes is gitignored, not committed), so a fresh clone needs it.
+
+1. **Build cgraph from source** — it's a native C++ engine (CMake + vcpkg,
+   C++20; on Linux `igraph` also needs `gfortran`). Full instructions:
+   <https://github.com/taylor009/CGraph> → *Install & Setup*. This produces
+   `cgraph`, `graphd`, `cgraph-client`, and `cgraph-mcp`.
+2. **Register the MCP server** (project-scoped, absolute binary paths):
+   ```sh
+   agents mcp add cgraph -s project -a claude,codex -- \
+     /abs/path/to/cgraph-mcp --root "$(pwd)" --daemon /abs/path/to/graphd
+   agents mcp register cgraph
+   ```
+3. Restart the agent session so it picks up the server. `graph_status` should
+   then answer, and the first query triggers a one-time build (seconds).
+
+If the `graph_*` tools return "no such tool", registration hasn't happened —
+fall back to grep/read and (if you can) run the steps above.
+
+## Routing: question → tool
+
+| When the user / task needs… | Call |
+| --- | --- |
+| "Where is X? Find the symbol named …" | `graph_query` `{query}` — ranked by importance, each hit has `source_file` + `line` |
+| "What is X? Show its callers/callees/imports" | `graph_explain` `{id}` — node + neighbors (each with `direction` and a navigable brief) + a source snippet |
+| "What breaks if I change X? What depends on it?" | `graph_impact` `{id, direction:"dependents"}` — transitive blast radius, bounded by `max_depth` |
+| "What does X rely on?" | `graph_impact` `{id, direction:"dependencies"}` |
+| "How does A connect to B?" | `graph_path` `{source, target}` — shortest path, with `path_nodes` briefs |
+| "Load context on X" / before editing or reviewing X | `graph_context` `{query or id, budget}` — focal node + most-relevant neighbors with snippets, packed to a token budget |
+| "Verify the graph is current before I rely on it" | `graph_update {path:"."}` — blocking content-verified synchronization; returns `freshness.content_root`. Pin subsequent reads by passing the root as `expected_content_root`. |
+| "Is the graph current? / I just changed files" | Nothing for ordinary reads — the daemon watches the tree and folds edits in within seconds. Use `graph_update` when you need a verified content_root to pin reads. |
+
+## How to use the results
+
+- `graph_query` matches case-insensitively and can be narrowed with `kind`
+  (e.g. `"function"`, `"class"`, `"file"`), `file` (source-path substring), and
+  `limit`. On zero matches it returns `suggestions` — the closest symbol names —
+  so correct the spelling and retry instead of falling back to grep.
+- Every id-taking tool (`graph_explain` / `graph_impact` / `graph_path` /
+  `graph_context`) also accepts a bare symbol name (e.g. `"merge_fragments"`);
+  the response echoes the canonical `id` it resolved. A miss comes back with
+  `found: false` plus `suggestions`.
+- `graph_query` returns ids and `source_file`:`line`. Open the file at `line`
+  directly — no second search needed.
+- `graph_explain` takes `direction` (`"in"` = callers/importers, `"out"` =
+  callees/imports) and `limit`; neighbors are ordered most-important-first and
+  `neighbor_count`/`truncated` flag when a hub has more edges than returned.
+- `graph_context` is the highest-leverage call before an edit or review: ask for
+  a budget (e.g. `4000`) and it returns the focal symbol's source plus its
+  neighborhood's source, ranked and trimmed to fit. Read that instead of opening
+  files one by one. It reports `omitted` / `truncated` if more existed.
+- `graph_context` has two **gather** modes. The default (`gather:"fixed"`) packs
+  the whole k-hop neighborhood. When you have a task in hand, pass
+  `gather:"adaptive"` **together with a `query`** — it keeps the full 2-hop core
+  but expands the third hop only along query-relevant nodes. On the retrieval
+  eval that lifted grade-2 recall by **+0.057 for +13% candidate tokens**, versus
+  the **+96%** a full 3-hop gather costs. The relevance gate is a no-op without a
+  query, so never send `adaptive` without one. The response echoes
+  `gather:"adaptive"`, `packing:"knapsack"`, and a `reach` summary
+  (`{candidates, expanded_past_core, gated_at_core}` — `expanded_past_core: 0`
+  means nothing relevant lay past the 2-hop core, so it collapsed to it). Raise
+  or lower `gather_theta` to tighten or loosen the relevance threshold.
+- `graph_impact` with `dependents` is the safety check before changing a
+  signature or deleting a symbol: it lists everything that would be affected,
+  by depth.
+
+## Freshness-sensitive navigation
+
+When a task must rely on the graph being current with the worktree — before impact
+analysis of a symbol you just moved, or after a batch of file edits — use the
+synchronize-then-pin pattern:
+
+```
+1. update = graph_update {path: "."}
+2. root = update.freshness.content_root
+3. graph_query / graph_explain / graph_impact / graph_path / graph_context
+       {…, expected_content_root: root}
+```
+
+`graph_update` is a blocking content-verified barrier: it hashes every detected
+code file and re-extracts any whose content changed. The returned
+`freshness.content_root` uniquely identifies that source snapshot. The response
+also reports `files_hashed` and `bytes_hashed`. Passing the root as
+`expected_content_root` on a subsequent read pins the response to the same
+snapshot; the daemon returns an
+error instead of graph data if it has published a different root since then.
+
+Ordinary reads (without `expected_content_root`) do not scan the filesystem. They
+read the latest published snapshot and return its `freshness` metadata; during
+startup or for non-source seam graphs, `freshness.verified` can be `false`. The
+daemon keeps source-backed snapshots current through automatic file watching.
+Use synchronization and a pin when you need proof that the graph matches specific
+source content.
+
+## Session memory (survive /compact and /clear)
+
+The daemon and `graph.json` live **outside your context window**, so a checkpoint
+written before a `/compact` or `/clear` is still recall-able afterward. Use this
+to carry the task thread across a context reset instead of losing it.
+
+- `graph_remember {title, body, touches?, tags?}` — write one checkpoint. `body`
+  is a **distilled** markdown summary of what you did and what's next; `touches`
+  lists the code symbols (ids or bare names) the work concerns, so recall can link
+  back to them. Persist only the distilled outcome — **never** raw tool output,
+  DOM snapshots, or chain-of-thought.
+- `graph_recall {query?, limit?}` — return recent checkpoints newest-first, each
+  with its body and briefs of the code it touched. After a `/clear`, recall first
+  (~KB payload) to restore the thread, then `graph_context` on a linked symbol to
+  reload just-enough source.
+
+The discipline is **distill → checkpoint → clear → recall**. Checkpoints are
+inert to code analysis (they never shift query/impact/context rankings) and
+survive daemon restart, incremental edits, and full rescans — the sidecars under
+`cgraph-out/memory/` are the durable source of truth.
+
+## Practicalities
+
+- The `cgraph` MCP server must be registered (it auto-spawns a per-project daemon
+  keyed to the project root). The first tool call in a project triggers a
+  one-time graph build (seconds), then queries are warm (~10ms).
+- While that first build runs, results carry `"graph_state": "building"` — an
+  empty result then means "not built yet", not "no match". Retry after a few
+  seconds or poll `graph_status` until `build_state` is `"ready"`.
+- The daemon watches the project tree (`graph_status` reports `watching`): file
+  edits land in the graph automatically within a few seconds, and the graph is
+  re-persisted in the background.
+- Fall back to grep/read only when cgraph genuinely has no answer — e.g. a
+  string literal, a comment, a config value, or a file type cgraph does not
+  extract. For symbols and their relationships, prefer the graph.
+- cgraph indexes code structure deterministically. Prose/doc relationships
+  appear only if semantic enrichment fragments have been ingested; don't assume
+  documentation concepts are present unless `graph_status` shows enrichment.

--- a/.opencode/skills/docs/SKILL.md
+++ b/.opencode/skills/docs/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: docs
+description: "Write documentation — user-facing, technical, runbooks, onboarding, changelogs. Less is more: only document what code can't tell you."
+user-invocable: true
+---
+
+# Documentation
+
+Less is more. Agents and humans can gather context on the fly. Only document what's hard to see from code:
+
+- **Architecture** — Component relationships, data flow, system boundaries
+- **Why** — Decisions, constraints, tradeoffs (not what)
+- **Operations** — Procedures that require specific steps
+- **User interfaces** — Public APIs, CLIs, tools
+
+## Routing Table
+
+| Task | Subskill | When to Use |
+|---|---|---|
+| User-facing (CLI, API, tools) | `write-user.md` | Public interfaces, README, guides |
+| Internal technical | `write-technical.md` | Architecture docs, system design |
+| Runbooks | `write-runbook.md` | Operational procedures, troubleshooting |
+| Onboarding | `write-onboarding.md` | New contributor guide |
+| Changelogs | `write-changelog.md` | Release notes |
+
+## Core Principles
+
+**1. Don't document what code tells you.**
+If someone can read the function and understand it, don't write docs. Comments rot. Code is truth.
+
+**2. Architecture over implementation.**
+Document component boundaries, data flow, integration points. Not how functions work internally.
+
+**3. High-level, like a principal engineer.**
+Write for someone who understands systems but doesn't know THIS system. Skip basics.
+
+**4. Diagrams over prose.**
+One ASCII diagram or mermaid chart replaces paragraphs. Show structure visually.
+
+**5. Reference the code, don't duplicate it.**
+`See harness/agent/execution.go:306-500` beats copying code into docs.
+
+## Decision Tree
+
+```
+Need documentation?
+├── Public interface (CLI, API)? → write-user.md
+├── System architecture? → write-technical.md
+├── Operational procedure? → write-runbook.md
+├── New contributor setup? → write-onboarding.md
+├── Release notes? → write-changelog.md
+└── Implementation details? → DON'T DOCUMENT. Code is the doc.
+```

--- a/.opencode/skills/docs/write-changelog.md
+++ b/.opencode/skills/docs/write-changelog.md
@@ -1,0 +1,64 @@
+# Write Changelogs
+
+For release notes. User impact, not implementation.
+
+> **Where the note goes.** If the repo uses the fragment model (a `.changelog/`
+> directory — see the `code:changelog` skill), do **not** edit `CHANGELOG.md` by
+> hand. Drop one new file at `.changelog/next/<ticket>.md` with your note. Every
+> PR writes a different file, so the changelog can never become a merge conflict;
+> the release folds the queue and regenerates `CHANGELOG.md`. The guidance below
+> is about *what to write* — it applies either way.
+
+## Core Principle
+
+**What changed for users, not what you did.** Group by impact, not by commit.
+
+## Structure
+
+```markdown
+# v1.2.0
+
+## Breaking Changes
+
+- `foo` flag renamed to `bar` — update your scripts
+
+## New
+
+- Export to PDF: `tool export --pdf`
+- Dark mode support
+
+## Fixed
+
+- No longer crashes on large files
+- Memory leak in long sessions
+
+## Improved
+
+- 2x faster startup
+- Better error messages for auth failures
+```
+
+## Categories
+
+| Category | What Goes Here |
+|----------|----------------|
+| Breaking | Requires user action |
+| New | Features they can use |
+| Fixed | Bugs that affected them |
+| Improved | Better experience |
+| Security | Vulnerabilities patched |
+
+## Anti-Patterns
+
+- Raw commit messages
+- Internal refactors ("cleaned up code")
+- Ticket numbers without context
+- Technical details users don't need
+
+## Style
+
+- Start with verb: "Add", "Fix", "Remove", "Improve"
+- User perspective: "You can now..." not "We implemented..."
+- If migration needed, show exact steps
+
+Keep it scannable. Users skim for what affects them.

--- a/.opencode/skills/docs/write-onboarding.md
+++ b/.opencode/skills/docs/write-onboarding.md
@@ -1,0 +1,58 @@
+# Write Onboarding Docs
+
+For new contributors. Goal: first successful change, fast.
+
+## Core Principle
+
+**One working change, not comprehensive knowledge.** Get them productive, then they learn by doing.
+
+## Structure
+
+```markdown
+# Getting Started
+
+## Setup (10 min)
+
+\`\`\`bash
+# Clone and install
+git clone ...
+cd ...
+./scripts/install.sh
+\`\`\`
+
+## Your First Change (15 min)
+
+1. Find a `good-first-issue` or try this: [specific small task]
+2. Make the change in `src/foo/`
+3. Test: `./scripts/test.sh`
+4. Submit: `git commit && git push`
+
+## Where Things Live
+
+| Area | Path | What's There |
+|------|------|--------------|
+| Core | `src/core/` | Main logic |
+| UI | `src/ui/` | Components |
+| API | `src/api/` | Endpoints |
+
+## Getting Help
+
+- Questions: [channel/forum]
+- Stuck: [who to ask]
+```
+
+## Anti-Patterns
+
+- Dumping all architecture upfront
+- Explaining history and decisions
+- Tool lists without context
+- "Read the wiki" links
+
+## Key Elements
+
+1. **Working setup in 10 min** — Or you've lost them
+2. **One specific task** — Not "find something"
+3. **Where to look** — Mental map of the repo
+4. **Who to ask** — Real human contact
+
+Shorter is better. They'll explore when ready.

--- a/.opencode/skills/docs/write-runbook.md
+++ b/.opencode/skills/docs/write-runbook.md
@@ -1,0 +1,54 @@
+# Write Runbooks
+
+For operational procedures: incidents, deployments, maintenance.
+
+## Core Principle
+
+**Symptoms to actions.** Start from what you observe, end with what to do.
+
+## Structure
+
+```markdown
+# Runbook: [Problem/Procedure]
+
+## Symptoms
+
+- What you see (logs, metrics, alerts)
+- How to confirm this is the issue
+
+## Diagnosis
+
+1. Check X: `command`
+   - If Y, go to Step 2
+   - If Z, see [Other Runbook]
+
+2. Check A: `command`
+   - Expected output: ...
+
+## Resolution
+
+1. Do X: `command`
+2. Verify: `command`
+3. Confirm resolution: [metric/log to check]
+
+## Escalation
+
+- If still broken after 15 min: [who to contact]
+- If data loss suspected: [emergency procedure]
+```
+
+## Anti-Patterns
+
+- Vague steps ("check the logs")
+- No decision points
+- Missing verification steps
+- No escalation path
+
+## Key Elements
+
+1. **Exact commands** — Copy-pasteable
+2. **Expected output** — What success looks like
+3. **Decision points** — If X then Y, else Z
+4. **Time bounds** — When to escalate
+
+Keep it minimal. If it's not needed at 3am, cut it.

--- a/.opencode/skills/docs/write-technical.md
+++ b/.opencode/skills/docs/write-technical.md
@@ -1,0 +1,70 @@
+# Write Technical Documentation
+
+For internal architecture docs. High-level, principal engineer style.
+
+## Core Principle
+
+**Document what code can't tell you.** Component boundaries, data flow, system design. Not implementation details.
+
+## Structure
+
+```markdown
+# System Name
+
+One paragraph: what this system does, why it exists.
+
+## Architecture
+
+[ASCII or mermaid diagram showing components and flow]
+
+## Data Flow
+
+[Diagram: how data moves through the system]
+
+## Key Concepts
+
+| Concept | What It Is | Where |
+|---------|------------|-------|
+| Widget | Does X | `src/widget/` |
+
+## Integration Points
+
+- **Upstream:** What calls this
+- **Downstream:** What this calls
+
+## Critical Files
+
+| File | Role |
+|------|------|
+| `foo.go` | Entry point |
+```
+
+## Diagram Standards
+
+ASCII boxes for architecture:
+```
+┌─────────────┐     ┌─────────────┐
+│  Component  │────▶│  Component  │
+└─────────────┘     └─────────────┘
+```
+
+Mermaid for flows:
+```mermaid
+flowchart LR
+    A[Input] --> B[Process] --> C[Output]
+```
+
+## Anti-Patterns
+
+- Explaining how functions work (read the code)
+- Duplicating code in docs
+- Documenting stable internals
+- Prose where a diagram fits
+
+## Reference Style
+
+Point to code, don't copy it:
+- `See harness/agent/execution.go:306-500`
+- `Implementation in src/auth/`
+
+One diagram is worth 1000 words. Write less.

--- a/.opencode/skills/docs/write-user.md
+++ b/.opencode/skills/docs/write-user.md
@@ -1,0 +1,74 @@
+# Write User-Facing Documentation
+
+For public interfaces: CLIs, APIs, tools, libraries.
+
+Frame around what users want to do — not a regurgitation of `--help`.
+
+## Core principles
+
+**Questions, not commands.** Format sections as literal questions users would ask:
+- "How do I automate a site that blocks bots?"
+- "I don't want to log in every time"
+- "I have multiple accounts and want to keep them separate"
+
+**Situations, not syntax.** "I just generated a new API key in the browser — how do I save it?" beats "Use `--value-stdin` to pipe input."
+
+**Why not X?** Start with a comparison section that honestly positions against alternatives. Research the actual competition — clone their repos, read their code. Never make claims you haven't verified.
+
+**The 20% that delivers 80%.** Don't list every command. Identify the 5 things users actually want to do, then show how.
+
+**End with "What else can I do?"** Point to `--help` for the long tail. The skill doc isn't a reference manual.
+
+## Before writing
+
+1. **Who is the audience?** Developer? Agent user? End user? Frame accordingly.
+2. **What are they trying to accomplish?** List the top 5 goals as questions.
+3. **What's the competition?** Research honestly. Clone repos if needed. No false claims.
+4. **What's our actual edge?** Must be backed by code or architecture.
+
+## Anti-patterns
+
+- Listing all commands with their flags
+- "This tool does X" instead of "You want to do X? Here's how"
+- Copying `--help` output into markdown
+- Making claims about competitors without checking their code
+- Technical jargon without context
+- Explaining what instead of why
+
+## Example: Bad
+
+```markdown
+## Commands
+
+### `browser start`
+Starts a browser task.
+
+Options:
+- `--profile` - Browser profile to use
+- `--task` - Task ID (optional)
+```
+
+## Example: Good
+
+```markdown
+## "I don't want to log in every time"
+
+Log in once to a profile — the session persists. Every future task is already authenticated:
+
+\`\`\`bash
+agents browser profiles create social --browser chrome
+agents browser start setup --profile social
+# Log in manually, then stop
+
+# Next time — already logged in
+agents browser start post --profile social
+\`\`\`
+```
+
+## Honest competition
+
+When comparing to alternatives:
+1. Actually clone their repo and read their code
+2. Verify any claims about what they do or don't support
+3. If they're good at something, say so
+4. Our edges must be backed by actual implementation differences

--- a/.opencode/skills/reflect/SKILL.md
+++ b/.opencode/skills/reflect/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: reflect
+description: >-
+  Recall all feedback, corrections, and constraints from the current
+  conversation before rewriting or iterating. Triggers on: reflect,
+  step back, reconsider, recall feedback, what did I say, incorporate
+  all feedback, or when iterative drafts keep missing the mark.
+argument-hint: "[optional: specific topic to reflect on]"
+user-invocable: true
+---
+
+# Reflect
+
+You are mid-conversation. The user has given you feedback — corrections, preferences, pushback, confirmations. Before your next attempt, you must surface all of it.
+
+## When This Triggers
+
+- User explicitly says "reflect", "step back", "reconsider", "recall what I said"
+- You've done 2+ iterations and the user is still unsatisfied
+- User says something like "incorporate all my feedback" or "you keep missing X"
+
+## The Process
+
+### Step 1: Enumerate Every Piece of Feedback
+
+Scan the entire conversation. Extract every instance where the user:
+
+- **Corrected you** ("no", "not that", "wrong framing", "that's not what I meant")
+- **Rejected an approach** ("don't lead with X", "stop doing Y", "this isn't useful")
+- **Confirmed something worked** ("yes", "exactly", "that's the right angle", accepted without pushback)
+- **Added a constraint** ("it should feel like...", "the audience is...", "don't mention...")
+- **Provided new information** that changes the approach (facts, context, nuance you didn't have before)
+
+Present these as a numbered list. Quote the user's words where possible — don't paraphrase into something softer.
+
+Format:
+
+```
+FEEDBACK INVENTORY:
+
+1. [REJECTED] "the first hook isn't really useful — it sounds like scrolls dropping"
+   → Thesis statements don't hook. Lead with something concrete/surprising.
+
+2. [CORRECTED] "an agent run by cron can do push notifications to ask for permissions"
+   → "Autonomous = unreachable" is wrong. The real issue is latency tolerance, not absence.
+
+3. [CONFIRMED] The per-binary network policy detail — user flagged this as the most interesting finding early on.
+   → This should be the anchor, not supporting detail.
+
+4. [CONSTRAINT] Don't sell Rush. No product pitch.
+   → Can reference contextually but not promote.
+
+5. ...
+```
+
+### Step 2: Identify the Pattern
+
+After listing, ask: what's the *thread* connecting these corrections? Usually the user is pushing toward one thing you keep missing. Name it explicitly.
+
+Example: "The thread: I keep leading with framing and structure instead of a single concrete thing that's genuinely surprising."
+
+### Step 3: State the Revised Approach
+
+Before writing anything new, state in 1-2 sentences what you'll do differently this time, grounded in the feedback inventory.
+
+### Step 4: Execute
+
+Now write the next draft/response with all constraints active simultaneously. Not just the latest correction — all of them.
+
+## Why This Works
+
+Creative iteration fails when the agent treats each correction as a local patch. Feedback is cumulative — correction #5 doesn't replace corrections #1-4. But without explicit recall, agents drift: they fix the latest issue and regress on earlier ones.
+
+This skill forces global constraint satisfaction before each attempt.
+
+## Anti-Patterns
+
+- **Summarizing feedback vaguely** ("you wanted it to be better") — quote specific words
+- **Only recalling corrections, not confirmations** — what worked is as important as what didn't
+- **Treating this as a delay tactic** — the inventory should take 30 seconds, not become a philosophical exercise
+- **Skipping Step 2** — the pattern identification is where the real insight lives

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,0 +1,581 @@
+---
+name: release
+description: >-
+  Publish packages to registries (npm, CDN, etc.). Discovers repo structure,
+  scaffolds build/release scripts if missing, runs tests, updates changelog,
+  publishes, and tags. Supports monorepos and semver with prereleases.
+  Triggers on: release, publish, ship, npm publish, cut a release.
+user-invocable: true
+version: 1.0.0
+author: muqsit
+---
+
+# Release
+
+Publish packages to their registries. Works with single packages and monorepos.
+
+## Arguments
+
+`$ARGUMENTS` may contain:
+- A version number: `1.2.3`, `1.2.3-alpha.1`, `patch`, `minor`, `major`
+- A package path for monorepos: `rush/app`, `harness-ui`
+- Flags: `--skip-tests`, `--skip-build`, `--force`
+
+If no version is given, analyze what's needed and suggest one.
+
+---
+
+## Phase 1: Discovery
+
+Before doing anything, check for project-specific release instructions.
+
+### 1.1 Check for project-level overrides
+
+```bash
+# Project-level release skill takes precedence
+ls .agents/skills/release/ 2>/dev/null
+
+# Check for release instructions in project docs
+grep -l -i "release\|publish\|deploy" README.md CLAUDE.md AGENTS.md .agents/*.md 2>/dev/null | head -5
+```
+
+If `.agents/skills/release/` exists in the project, defer to it completely. Read those instructions and follow them instead of this skill.
+
+### 1.2 Detect repo structure
+
+```bash
+# Is this a monorepo?
+if [[ -f "package.json" ]]; then
+  # Check for workspaces
+  jq -e '.workspaces' package.json 2>/dev/null && echo "MONOREPO: npm/bun workspaces"
+fi
+
+[[ -f "pnpm-workspace.yaml" ]] && echo "MONOREPO: pnpm workspaces"
+[[ -f "lerna.json" ]] && echo "MONOREPO: lerna"
+
+# Find all package.json files
+fd -t f package.json --max-depth 3 | head -20
+```
+
+### 1.3 Identify publishable packages
+
+```bash
+# List packages that are NOT private
+fd -t f package.json --max-depth 3 -x sh -c '
+  name=$(jq -r ".name // empty" "{}")
+  private=$(jq -r ".private // false" "{}")
+  if [[ -n "$name" && "$private" != "true" ]]; then
+    echo "{}: $name"
+  fi
+'
+```
+
+### 1.4 Find release scripts
+
+```bash
+# Standard locations
+ls scripts/release.sh scripts/build.sh release.sh 2>/dev/null
+
+# Monorepo subdirs
+fd -t f release.sh --max-depth 4
+
+# Check for npm scripts
+jq -r '.scripts | keys[]' package.json 2>/dev/null | grep -E 'release|publish|deploy'
+```
+
+### 1.5 Monorepo: Ask which package
+
+If multiple publishable packages are found and `$ARGUMENTS` doesn't specify one, use `AskUserQuestion` to ask which package to release. List all discovered packages with their current versions.
+
+---
+
+## Phase 2: Infrastructure Check
+
+### 2.1 Check for existing scripts
+
+If `scripts/release.sh` exists, read it to understand:
+- Does it have dry-run mode? (look for `--apply`, `--confirm`, `--dry-run`)
+- Does it run tests? (look for `npm test`, `bun test`, `build.sh`)
+- What registry does it publish to? (npm, CDN URL, etc.)
+
+### 2.2 Scaffold if missing
+
+If no release script exists, offer to create the standard structure:
+
+**scripts/build.sh:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKIP_TESTS=false
+for arg in "$@"; do
+  case $arg in
+    --skip-tests) SKIP_TESTS=true ;;
+  esac
+done
+
+echo "==> Type checking..."
+if [[ -f "tsconfig.json" ]]; then
+  npx tsc --noEmit || { echo "Type check failed"; exit 1; }
+fi
+
+echo "==> Linting..."
+npm run lint 2>/dev/null || bun run lint 2>/dev/null || true
+
+if [[ "$SKIP_TESTS" == "true" ]]; then
+  echo ""
+  echo "=============================================="
+  echo "  WARNING: Skipping tests is discouraged."
+  echo "  Fix failing tests instead of bypassing them."
+  echo "=============================================="
+  echo ""
+else
+  echo "==> Running tests..."
+  npm test || bun test || { echo "Tests failed"; exit 1; }
+fi
+
+echo "==> Building..."
+npm run build || bun run build || { echo "Build failed"; exit 1; }
+
+echo "==> Build complete"
+```
+
+**scripts/release.sh:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+APPLY=false
+SKIP_BUILD=false
+SKIP_TESTS=false
+
+for arg in "$@"; do
+  case $arg in
+    --apply|--confirm) APPLY=true ;;
+    --skip-build) SKIP_BUILD=true ;;
+    --skip-tests) SKIP_TESTS=true ;;
+  esac
+done
+
+die() { echo "ERROR: $1" >&2; exit 1; }
+
+[[ -z "$VERSION" ]] && die "Usage: scripts/release.sh <version> [--apply]"
+
+# Validate semver (with optional prerelease)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  die "Invalid version format: $VERSION (expected semver like 1.2.3 or 1.2.3-alpha.1)"
+fi
+
+# Pre-flight checks
+echo "==> Pre-flight checks"
+[[ -n "$(git status --porcelain)" ]] && die "Working tree not clean. Commit or stash changes first."
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" != "main" && "$BRANCH" != "master" && ! "$BRANCH" =~ ^release/ ]] && \
+  echo "WARNING: Not on main branch (on $BRANCH)"
+
+# Package info
+PKG_NAME=$(jq -r '.name' package.json)
+[[ -z "$PKG_NAME" || "$PKG_NAME" == "null" ]] && die "No package name in package.json"
+
+# Check current published version
+echo "==> Checking registry for $PKG_NAME"
+CURRENT=$(npm view "$PKG_NAME" version 2>/dev/null || echo "0.0.0")
+echo "   Current published: $CURRENT"
+echo "   Target version:    $VERSION"
+
+# Build
+if [[ "$SKIP_BUILD" == "true" ]]; then
+  echo ""
+  echo "WARNING: Skipping build. Ensure artifacts are fresh."
+  echo ""
+else
+  echo "==> Running build"
+  BUILD_ARGS=""
+  [[ "$SKIP_TESTS" == "true" ]] && BUILD_ARGS="--skip-tests"
+  ./scripts/build.sh $BUILD_ARGS || die "Build failed"
+fi
+
+# Show what will be published
+echo ""
+echo "==> Package contents (dry-run):"
+npm pack --dry-run 2>&1 | head -50
+
+if [[ "$APPLY" != "true" ]]; then
+  echo ""
+  echo "================================================"
+  echo "  DRY-RUN COMPLETE"
+  echo "  "
+  echo "  To actually publish, run:"
+  echo "    scripts/release.sh $VERSION --apply"
+  echo "================================================"
+  exit 0
+fi
+
+# Update version in package.json
+echo "==> Updating version to $VERSION"
+npm version "$VERSION" --no-git-tag-version
+
+# Get npm token from agents secrets
+echo "==> Authenticating with npm"
+NPM_TOKEN=$(agents secrets export npmjs.com --plaintext 2>/dev/null | grep NPM_TOKEN | cut -d= -f2-)
+if [[ -z "$NPM_TOKEN" ]]; then
+  die "No NPM_TOKEN found. Create it with: agents secrets create npmjs.com && agents secrets add npmjs.com NPM_TOKEN"
+fi
+
+# Write temporary .npmrc
+echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc.release
+trap 'rm -f .npmrc.release' EXIT
+
+# Publish
+echo "==> Publishing to npm"
+npm publish --access public --userconfig .npmrc.release || die "Publish failed"
+
+# Verify publish
+echo "==> Verifying publish"
+sleep 2
+PUBLISHED=$(npm view "$PKG_NAME@$VERSION" version 2>/dev/null || echo "")
+if [[ "$PUBLISHED" != "$VERSION" ]]; then
+  echo "WARNING: Could not verify $PKG_NAME@$VERSION on registry yet (may take a moment)"
+fi
+
+# Git operations AFTER successful publish
+echo "==> Creating git tag"
+git add package.json package-lock.json 2>/dev/null || git add package.json
+git commit -m "chore(release): $VERSION"
+git tag "v$VERSION"
+git push origin "$BRANCH"
+git push origin "v$VERSION"
+
+echo ""
+echo "================================================"
+echo "  RELEASED $PKG_NAME@$VERSION"
+echo "  "
+echo "  npm: https://www.npmjs.com/package/$PKG_NAME"
+echo "  tag: v$VERSION"
+echo "================================================"
+```
+
+### 2.3 Package hygiene
+
+Check that the package doesn't publish unnecessary files:
+
+```bash
+# Check what would be published
+npm pack --dry-run 2>&1
+
+# Check for files field or .npmignore
+jq '.files' package.json
+cat .npmignore 2>/dev/null
+```
+
+If neither exists and `src/`, `tests/`, or large directories would be published, suggest creating `.npmignore`:
+
+```
+src/
+tests/
+*.test.ts
+*.spec.ts
+testdata/
+.github/
+.vscode/
+*.log
+.env*
+```
+
+---
+
+## Phase 3: Version Analysis
+
+### 3.1 Get current published version
+
+```bash
+PKG_NAME=$(jq -r '.name' package.json)
+
+# npm registry
+npm view "$PKG_NAME" version 2>/dev/null || echo "Not yet published"
+
+# All published versions
+npm view "$PKG_NAME" versions --json 2>/dev/null | jq -r '.[-5:][]'
+```
+
+### 3.2 Determine next version
+
+If `$ARGUMENTS` contains `patch`, `minor`, or `major`:
+- Calculate the next version from current published
+- For prereleases: `1.2.3-alpha.1` → `1.2.3-alpha.2`
+
+Semver rules:
+- **Stable releases** (`1.2.3`): enforce single-step bumps only
+  - `1.2.3` → `1.2.4` (patch) OK
+  - `1.2.3` → `1.3.0` (minor) OK
+  - `1.2.3` → `1.5.0` NOT OK (skips 1.4.0)
+- **Prereleases** (`1.2.3-alpha.1`): allow free jumps within prerelease
+  - `1.2.3-alpha.1` → `1.2.3-alpha.5` OK
+  - `1.2.3-alpha.1` → `1.2.3-beta.1` OK
+  - `1.2.3-rc.1` → `1.2.3` OK (promotion to stable)
+
+### 3.3 Version validation
+
+```bash
+# Parse versions
+CURRENT="1.2.3"
+TARGET="1.2.4"
+
+# Extract components
+IFS='.-' read -r CMAJ CMIN CPAT CPRE <<< "$CURRENT"
+IFS='.-' read -r TMAJ TMIN TPAT TPRE <<< "$TARGET"
+
+# Validate (simplified)
+if [[ -z "$TPRE" ]]; then
+  # Stable release - must be single step
+  # ... validation logic
+fi
+```
+
+---
+
+## Phase 4: Pre-flight Checks
+
+### 4.1 Run tests (mandatory)
+
+Even if the release script runs tests, run them first to fail fast:
+
+```bash
+npm test || bun test
+```
+
+If tests fail, this is a **blocking** issue. Do not proceed.
+
+If `--skip-tests` was passed:
+```
+============================================
+  WARNING: You are skipping tests.
+
+  Skipping tests is strongly discouraged.
+  It's better to fix failing tests than to
+  ship broken code.
+
+  Proceeding anyway because --skip-tests was set.
+============================================
+```
+
+### 4.2 Check git state
+
+```bash
+# Must be clean
+git status --porcelain
+
+# Should be on main (warn if not)
+git rev-parse --abbrev-ref HEAD
+```
+
+### 4.3 Check secrets
+
+```bash
+# List available secrets bundles
+agents secrets list
+
+# Check for npm token specifically
+agents secrets export npmjs.com --plaintext 2>/dev/null | grep -q NPM_TOKEN && echo "npm auth: OK"
+```
+
+If required secrets are missing, this is **blocking**. Guide the user:
+```
+Missing npm authentication. Set it up with:
+  agents secrets create npmjs.com
+  agents secrets add npmjs.com NPM_TOKEN
+```
+
+### 4.4 Issue categorization
+
+**Blocking (must fix before release):**
+- Test failures
+- Uncommitted changes in git
+- Missing required secrets
+- Version already published (unless `--force`)
+- Invalid semver format
+
+**Non-blocking (warn and continue):**
+- Not on main branch
+- Using `--skip-tests` or `--skip-build`
+- No CHANGELOG.md (will create one)
+- No dry-run mode in release script
+
+---
+
+## Phase 5: Changelog
+
+> **Fragment model (preferred).** If the repo has a `.changelog/` directory (the
+> `code:changelog` skill / towncrier-style fragments), the changelog is a
+> GENERATED artifact: per-PR notes live in `.changelog/next/<ticket>.md`, and the
+> release script folds them into `.changelog/<version>.md` and regenerates
+> `CHANGELOG.md`. **Skip 5.3–5.4** — the release script owns the changelog; just
+> confirm the queue is non-empty (`ls .changelog/next/*.md`) so the release can
+> document itself. Sections 5.1–5.4 below are the legacy single-file path for
+> repos without `.changelog/`.
+
+### 5.1 Get commits since last release
+
+```bash
+# Find last release tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [[ -n "$LAST_TAG" ]]; then
+  echo "Commits since $LAST_TAG:"
+  git log "$LAST_TAG"..HEAD --oneline --no-merges
+else
+  echo "No previous tags. Showing recent commits:"
+  git log -20 --oneline --no-merges
+fi
+```
+
+### 5.2 Parse conventional commits
+
+Group commits by type:
+
+```bash
+git log "$LAST_TAG"..HEAD --oneline --no-merges | while read -r line; do
+  if [[ "$line" =~ ^[a-f0-9]+\ feat ]]; then
+    echo "ADDED: $line"
+  elif [[ "$line" =~ ^[a-f0-9]+\ fix ]]; then
+    echo "FIXED: $line"
+  elif [[ "$line" =~ ^[a-f0-9]+\ (refactor|perf|chore) ]]; then
+    echo "CHANGED: $line"
+  fi
+done
+```
+
+### 5.3 Generate changelog entry
+
+Format:
+```markdown
+## [1.2.3] - 2026-05-09
+
+### Added
+- feat(auth): OAuth refresh token support (#123)
+
+### Fixed  
+- fix(sync): orphan sweep for stale resources (#124)
+
+### Changed
+- refactor(runner): simplify job execution
+```
+
+### 5.4 Update or create CHANGELOG.md
+
+If CHANGELOG.md exists, prepend the new section after the header.
+If it doesn't exist, create it:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.2.3] - 2026-05-09
+
+### Added
+...
+```
+
+---
+
+## Phase 6: Execute Release
+
+### 6.1 Dry-run first
+
+If the release script supports dry-run:
+```bash
+./scripts/release.sh "$VERSION"
+```
+
+Show the output and summarize what will happen.
+
+### 6.2 Confirm with user
+
+Before actual release, use `AskUserQuestion`:
+- Show version change: `1.2.2 → 1.2.3`
+- Show registry target
+- Show changelog entry preview
+- Show files that will be published
+
+Options: "Release now", "Edit changelog first", "Cancel"
+
+### 6.3 Execute
+
+```bash
+./scripts/release.sh "$VERSION" --apply
+```
+
+### 6.4 Verify
+
+After the script completes:
+```bash
+# Verify on npm
+npm view "$PKG_NAME@$VERSION" version
+
+# Verify tag exists
+git tag -l "v$VERSION"
+```
+
+### 6.5 Report success
+
+```
+Released @phnx-labs/agents-cli@1.2.3
+
+- npm: https://www.npmjs.com/package/@phnx-labs/agents-cli
+- tag: v1.2.3
+- changelog: Updated CHANGELOG.md
+```
+
+---
+
+## Escape Hatches
+
+These flags exist but their use is discouraged:
+
+| Flag | Effect | When shown |
+|------|--------|-----------|
+| `--skip-tests` | Skip test suite | Prints warning about fixing tests being better |
+| `--skip-build` | Skip build step | Warns about stale artifacts |
+| `--force` | Skip version validation | Warns about registry conflicts |
+
+Always show warnings when these are used. Never silently skip.
+
+---
+
+## Error Handling
+
+### Tests fail
+```
+Tests failed. Fix the failing tests before releasing.
+
+Failing tests:
+  - src/lib/runner.test.ts: timeout handling
+  - src/lib/events.test.ts: rotation logic
+
+Run `npm test` to see full output.
+```
+
+### Version already published
+```
+Version 1.2.3 is already published on npm.
+
+Options:
+1. Bump to 1.2.4: scripts/release.sh 1.2.4 --apply
+2. Use prerelease: scripts/release.sh 1.2.4-beta.1 --apply
+3. Force republish (dangerous): scripts/release.sh 1.2.3 --force --apply
+```
+
+### Missing secrets
+```
+npm authentication not configured.
+
+Set up npm token:
+  1. Go to https://www.npmjs.com/settings/tokens
+  2. Create an "Automation" token with publish access
+  3. Save it:
+     agents secrets create npmjs.com
+     agents secrets add npmjs.com NPM_TOKEN
+```

--- a/.opencode/skills/scripts/SKILL.md
+++ b/.opencode/skills/scripts/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: scripts
+description: "Scripts directory contract — canonical build/test/install/release.sh patterns for deployable projects. Triggers on: scripts/, release.sh, build.sh, deploy, publish."
+user-invocable: false
+---
+
+# Scripts Directory Contract
+
+Every deployable project keeps a `scripts/` directory with a small set of canonical scripts. Use them. Don't reinvent.
+
+## Canonical scripts
+
+- `scripts/build.sh` — compile/bundle and **run the test suite**. Green build means tests passed.
+- `scripts/test.sh` — full test suite, runnable on its own.
+- `scripts/install.sh` — install dependencies, set up local config.
+- `scripts/release.sh` — ship the artifact (npm publish, docker push, deploy, etc.). **Use `release` as the canonical name** — covers all forms of shipping.
+
+## release.sh contract
+
+- **Defaults to dry-run.** Without `--confirm`, the script prints exactly what it would do and exits 0. Nothing mutates.
+- **`--confirm` is required to actually release.** No other flag substitutes.
+- **`--skip-build` and `--skip-tests`** are escape hatches for re-runs after a verified-elsewhere build, or hotfixes. Default: run both.
+- **Refuses on test failure** unless `--skip-tests` was explicitly passed. If you find yourself adding `|| true` to silence a check, stop.
+- **Pre-flight checks run before slow checks.** Version-collision (`npm view <pkg> versions --json` against `package.json`) before `bun test`. Missing-secrets check before `git push`. Cheap failures fast.
+- **Source of truth is the system the script targets, not git.** npm publish status comes from the registry, not commit subjects. Deploy status comes from the deploy registry.
+- **Idempotent.** If `release.sh` is interrupted between version-bump and the actual publish, re-running converges — no double-bump, no double-tag.
+
+## What "done" means for a release
+
+A release isn't done until the package version shows up on the registry (or the deploy URL serves the new build). Code merged is not released.
+
+## Anti-patterns
+
+- `release.sh` that publishes without running tests by default.
+- Detecting "what's already published" by `git log` subject lines instead of the registry.
+- Running expensive checks (test suites, builds) before cheap checks (version collision, missing secrets).
+- A `deploy.sh` with no dry-run mode that hits production on every invocation.

--- a/.opencode/skills/security/SKILL.md
+++ b/.opencode/skills/security/SKILL.md
@@ -1,0 +1,189 @@
+---
+description: "Security audit of a codebase via parallel agents — one per vulnerability class. Reads code fast with Explore agents, cross-checks against current advisories via web search, filters false positives hard. Triggers on 'security scan', 'security audit', 'vulnerability scan', 'check for leaked secrets', 'scan for injection', or scheduled security checks."
+argument-hint: "[scope — days, paths, or freeform e.g. 'last 7 days', 'prix/api routes', 'pre-launch sweep']"
+allowed-tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+user-invocable: true
+---
+
+# Security
+
+A security audit pattern: analyze what changed, classify by vulnerability type, dispatch one parallel agent per class, verify every finding yourself, **filter false positives hard**, report only confirmed issues.
+
+You are the orchestrator. Each vulnerability class becomes one Explore subagent that reads code fast and cross-checks against current advisories via web search. Never trust an agent's "CRITICAL" finding without reading the cited file yourself.
+
+## How it works
+
+```
+You (orchestrator)
+ |-- 1. Discover scope: what changed, what to audit
+ |-- 2. Classify the change surface by risk
+ |-- 3. Dispatch one Explore agent per vulnerability class (in parallel)
+ |-- 4. Each agent: read code, grep patterns, web-search current advisories
+ |-- 5. Collect findings
+ |-- 6. VERIFY every CRITICAL/HIGH yourself — read the cited file:line
+ |-- 7. FILTER false positives aggressively
+ |-- 8. Report only verified findings
+```
+
+## Step 1 — Scope the scan
+
+If args give a time window, use git:
+
+```bash
+git log --oneline --since="<N> days ago" --no-merges --name-only | head -200
+```
+
+If args give a path or "pre-launch", spend 60s reading top-level `README.md`, `AGENTS.md` / `CLAUDE.md`, and the entry-point file to learn: network listener? web UI? CLI? filesystem/keychain/external API access? Multi-tenant or single-user? OSS or hosted? The attack surface determines which classes matter.
+
+State your scope back to the user in 3-4 lines before dispatching anything. They'll redirect if it's wrong.
+
+## Step 2 — Classify the change surface
+
+Look at the touched files and project conventions (the repo's `AGENTS.md` / `CLAUDE.md` are authoritative for what's high-risk). Group files into vulnerability-relevant zones — common buckets:
+
+- HTTP/API routes, controllers, middleware
+- Auth, sessions, billing, IAM
+- DB queries, ORM raw SQL, analytics query builders
+- HTML rendering, share/preview pages, embeddable surfaces
+- Shell execution, child_process, subprocess, exec.Command
+- Native/IPC boundaries (Electron main↔renderer, browser extension content scripts)
+- Infra (Terraform, CF/CDN config, Dockerfile, K8s manifests)
+- Dependencies (`package.json`, `go.mod`, lockfiles, `requirements.txt`)
+- Config & docs that may have leaked secrets (`*.env*`, `CLAUDE.md`, `docs/`, deploy scripts)
+
+If no commit list is provided, treat the whole repo's most-trafficked code paths as the surface.
+
+## Step 3 — Dispatch parallel Explore agents
+
+One agent per vulnerability class. **Spawn them all in a single message** (parallel Agent tool calls). Use `subagent_type: "Explore"` for fast, read-only code scanning. Set `model: "sonnet"` (cost-effective for pattern matching) unless the class needs deeper reasoning (then `opus`).
+
+### Vulnerability classes — pick the ones the surface warrants
+
+| Class | When to run | Typical patterns to grep |
+|---|---|---|
+| **SECRETS** | Always | `sk_live`, `phc_`, `AKID`, `xoxb-`, `ghp_`, `BEGIN PRIVATE KEY`, `.env*` tracked in git, secrets in `CLAUDE.md`/docs, deleted-but-in-history credentials |
+| **INJECTION** | DB/query code changed | String interpolation in queries, template literals near `.query()`/`.rpc()`/`SELECT`, user input reaching ORM raw escape hatches, NoSQL operator injection (`$where`, `$ne`) |
+| **AUTH** | Routes, middleware, auth changed | Endpoints without auth middleware, role checks (`isAdmin`, `isDev`) that can be skipped, broken IDOR (object access by user-controlled ID without ownership check), OAuth flow logic, JWT verification |
+| **XSS** | HTML rendering / user output changed | User input in HTML templates, `innerHTML`/`dangerouslySetInnerHTML`, missing CSP, script injection via display names or artifact content, missing `X-Frame-Options` |
+| **SHELL** | Shell-exec or child_process touched | `exec.Command("sh","-c", ...)`, `child_process.exec` with concat, `osascript -e` with input, path traversal via user-controlled paths |
+| **IPC / ELECTRON** | Electron main process or preload changed | `nodeIntegration: true`, custom protocol handlers, `webContents.executeJavaScript` with user input, `contextIsolation: false` |
+| **INFRA** | CF/Terraform/Dockerfile/K8s changed | Open redirects, SSRF in worker fetches, exposed origins (host without WAF), missing security headers, K8s `privileged: true`, overly broad RBAC |
+| **DEPS** | Lockfiles changed | Run `npm audit --json` / `go list -json -deps -m all`, web-search "CVE \<package\> \<version\> 2026" for any package not in the boring set |
+
+### Subagent prompt template
+
+```
+## Security Scan: <CLASS>
+
+Scope: <files / dirs to scan, from the changed-files list>
+Class: <CLASS>
+
+What to check:
+<2–4 lines of specifics for this class>
+
+Patterns to grep:
+<concrete patterns>
+
+Cross-check current advisories:
+- WebSearch: "<library or pattern> CVE 2026" or "<framework> security advisory 2026"
+- WebFetch: GitHub Security Advisory pages for the libraries in scope.
+
+Report format (one bullet per finding):
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
+- Location: file:line
+- Code: the actual snippet (quote it)
+- Attack vector: how an attacker reaches this
+- Confidence: high / medium / low (medium or low MUST list disconfirming evidence)
+- Fix: one line
+
+If you find nothing, say so. A clean scan is a valid result.
+Return file:line quotes for every claim. Do NOT paraphrase. If you can't quote it, don't claim it.
+```
+
+## Step 4 — Verify every CRITICAL/HIGH yourself
+
+Trust no agent verdict above MEDIUM. For each CRITICAL or HIGH:
+
+1. Read the cited file at the cited line.
+2. Confirm the code matches what the agent quoted.
+3. Trace whether user input actually reaches the vulnerable point — is there validation, escaping, middleware, parameterization in between?
+4. Check for mitigations the agent missed (framework defaults, ORM parameterization, middleware that runs before the route).
+5. Classify: `VERIFIED` / `FALSE POSITIVE` / `NEEDS RUNTIME TEST`.
+
+## Step 5 — Filter false positives HARD
+
+**False positives in security scans are the rule, not the exception.** Agents will flag patterns that look bad in isolation but aren't real vulnerabilities. The most common categories — discard these on sight unless you have evidence otherwise:
+
+### "Leaked API key" that's actually a public key
+
+| Pattern flagged | Why it's not a leak |
+|---|---|
+| `phc_xxxx` in client code | PostHog **public ingest** keys are designed to ship to browsers. Real risk is the `phx_` personal API key. |
+| `pk_live_*` / `pk_test_*` Stripe key | Stripe publishable keys are public by design. Only `sk_live_*` / `sk_test_*` are sensitive. |
+| `eyJhbGciOi...` in client | Supabase / Firebase **anon** JWTs are public by design. RLS enforces auth. The service-role key is the secret one. |
+| `AIza...` Google API key | Often a public Maps/YouTube key restricted by HTTP referrer. Check the restriction, not the format. |
+| GitHub App `client_id` | Public by design. The `client_secret` is the secret. |
+
+Confirm by reading the code: is the value embedded in shipped client bundles? Then it's by design. The check is on **intent**, not regex match.
+
+### Other common false-positive patterns
+
+- **"Missing auth on endpoint"** → check for middleware applied at the router/app level, not the handler. `app.use(authMiddleware)` covers everything below.
+- **"SQL injection in `db.query(\`...\${x}...\`)`"** → check if `x` came from validated input upstream, or if the driver is parameterizing automatically.
+- **"XSS via innerHTML"** → check if the source is hardcoded/server-controlled, not user-controlled.
+- **"Hardcoded password"** → check if it's a test fixture, a documented default, or production. Test/dev defaults aren't a vulnerability; they're an architectural choice that may or may not be appropriate.
+- **`exec.Command("sh", "-c", ...)`** → check if all interpolated values are server-controlled constants or strictly validated. Shell exec with no user-reachable input is fine.
+- **"Dependency CVE"** → check if the vulnerable code path is actually called by your code (not just present in the dependency tree). `npm audit` reports a lot of noise on transitive dev-only deps.
+
+When in doubt, **read the upstream advisory** (Web-search the CVE) and check if your usage matches the vulnerable path. Most reported CVEs only fire under narrow configurations.
+
+## Step 6 — Report
+
+Present only verified findings. Group by severity. For each, include:
+
+- Class
+- Location (`file:line`)
+- The actual code (quoted)
+- Attack vector
+- Recommended fix
+
+End the report with a **False Positives Filtered** section listing what agents flagged but you disproved — this builds trust and prevents the same flags resurfacing next scan. Also a **Clean Areas** section listing what passed (so the user knows what's been audited).
+
+## Output
+
+```markdown
+## Security Scan — <YYYY-MM-DD>
+
+### Scope
+- <window or paths>
+- <commit count if time-windowed>
+
+### Agents dispatched
+- <CLASS> (model)
+- ...
+
+### CRITICAL
+- ...
+
+### HIGH
+- ...
+
+### MEDIUM
+- ...
+
+### False positives filtered
+- <flag> — <why it's not real>
+
+### Clean
+- <area scanned, no findings>
+```
+
+Save reports under `<repo>/security/<YYYY-MM-DD>-<slug>.md` if the repo wants archived scans, otherwise return the report to the user.
+
+## Hard rules
+
+- **No "CRITICAL" without a file:line quote.** If the agent didn't quote code, demote to "needs verification" and verify yourself.
+- **No fix proposals you can't justify from the code.** "Add input validation" is a non-fix if you can't say which input on which line.
+- **Public keys are not leaked keys.** Read the surrounding code to determine intent before flagging.
+- **CVEs are not vulnerabilities until you confirm your usage matches the vulnerable path.** Look at the advisory's "Affected versions / Affected functions" section.
+- **Cost is irrelevant; correctness is everything.** If unsure about a finding, spawn another Explore agent to dig deeper. A missed bug is far more expensive than a re-scan.

--- a/.opencode/skills/sessions/SKILL.md
+++ b/.opencode/skills/sessions/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: sessions
+description: "Search, browse, and read agent conversation transcripts across Codex, Codex, Gemini, and OpenCode. Use this skill to find previous sessions, recover context, or inspect what agents have done."
+argument-hint: "[search query or session ID]"
+allowed-tools: Bash(agents sessions*)
+user-invocable: true
+---
+
+# Sessions Skill
+
+Search and browse agent conversation transcripts. This skill teaches you how to use the `agents sessions` CLI effectively.
+
+## Basic Usage
+
+```bash
+# Interactive picker: browse and search recent sessions
+agents sessions
+
+# List sessions from current project
+agents sessions | head -20
+
+# Search sessions by text
+agents sessions "add auth middleware"
+
+# Filter by project across all directories
+agents sessions --project agents-cli --all
+```
+
+## Filters
+
+| Filter | Example | Description |
+|--------|---------|-------------|
+| `--agent` | `--agent Codex` | Filter by agent type |
+| `--all` | `--all` | Include sessions from every directory |
+| `--project` | `--project myapp` | Filter by project name |
+| `--since` | `--since 2h` | Only sessions newer than this |
+| `--until` | `--until 2026-01-01` | Only sessions older than this |
+| `--limit` | `--limit 10` | Maximum sessions to return |
+| `--active` | `--active` | Only currently running sessions |
+| `--teams` | `--teams` | Include team-spawned sessions |
+
+## Reading Sessions
+
+```bash
+# Render session as markdown
+agents sessions --markdown <session-id>
+
+# Output as JSON
+agents sessions --json <session-id>
+
+# Include only specific roles
+agents sessions --markdown --include user,assistant <session-id>
+
+# Show only first/last N turns
+agents sessions --markdown --last 10 <session-id>
+```
+
+## Artifacts
+
+```bash
+# List all files written or edited during a session
+agents sessions --artifacts <session-id>
+
+# Read a specific artifact
+agents sessions --artifact <filename> <session-id>
+```
+
+## Live Tailing
+
+```bash
+# Live-tail a session file (Codex and Codex only)
+agents sessions tail <session-id>
+# Press Ctrl+C to stop
+```
+
+## Tips
+
+- Use `--active` to find sessions running right now across terminals, teams, cloud, and headless agents
+- Use `--teams` to see what team-spawned agents are doing
+- Use `--since 1h` for recent activity
+- Combine filters: `agents sessions --project myapp --since 1d --agent Codex`

--- a/apps/cli/.remote-sign-build.sh
+++ b/apps/cli/.remote-sign-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /Users/muqsit/src/github.com/muqsitnawaz/agents-cli/apps/cli
+# Unlock the signing keychain headless, then inject the Apple notary creds.
+security unlock-keychain -p "$(cat "$HOME/Library/Application Support/rush/signing.kcpass")" rush-signing.keychain-db
+export AGENTS_SECRETS_PASSPHRASE="$(cat "$HOME/Library/Application Support/rush/secrets.pass")"
+agents secrets exec apple.com -- bash -c '
+  set -euo pipefail
+  echo "== menu-bar helper: swift build + codesign =="
+  menubar/scripts/build.sh release
+  # rm -rf first so a re-run does not nest the new .app INSIDE a stale
+  # bin/MenubarHelper.app (cp -R into an existing dir), which corrupts the
+  # signature ("unsealed contents present in the bundle root").
+  rm -rf bin/MenubarHelper.app
+  cp -R menubar/dist/MenubarHelper.app bin/MenubarHelper.app
+  codesign --verify --deep --strict "bin/MenubarHelper.app"
+  echo "== keychain helper: swiftc + codesign + notarize =="
+  scripts/build-keychain-helper.sh
+  echo "== pin sha256 of the notarized keychain binary =="
+  shasum -a 256 "bin/Agents CLI.app/Contents/MacOS/Agents CLI" > "scripts/Agents CLI.app.sha256"
+  cat "scripts/Agents CLI.app.sha256"
+  echo "== standalone agents binary: bun build + codesign + notarize =="
+  bun install --frozen-lockfile
+  scripts/sign-cli-binary.sh
+'

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.74",
+  "version": "1.20.75",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/cli/src/commands/attach.ts
+++ b/apps/cli/src/commands/attach.ts
@@ -1,0 +1,52 @@
+/**
+ * `agents attach <id>` — bring a backgrounded (or parked) agent session back to
+ * the foreground: stop its headless continuation, then resume it interactively
+ * in this terminal. The resume is version-pinned native resume (claude/codex) or
+ * a `/continue` replay (others) — the same session, full history, the exact
+ * inverse of `agents detach`.
+ */
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { discoverSessions } from '../lib/session/discover.js';
+import { resumeSessionInPlace } from './sessions.js';
+import { readDetachRecord, clearDetachRecord, isHeadlessAlive } from '../lib/session/detached.js';
+
+export function registerAttachCommand(program: Command): void {
+  program
+    .command('attach')
+    .argument('<id>', 'Short or full id of the backgrounded/parked session to resume interactively')
+    .description('Bring a backgrounded agent to the foreground — resume it interactively here')
+    .action(async (id: string) => {
+      await attachAction(id);
+    });
+}
+
+export async function attachAction(id: string): Promise<void> {
+  const q = id.toLowerCase();
+  // Rich meta carries the pinned version + origin cwd the resume needs.
+  const metas = await discoverSessions({ all: true, since: '90d', limit: 2000 });
+  const meta = metas.find((m) => m.id === id) ?? metas.find((m) => m.id.toLowerCase().startsWith(q));
+  if (!meta) {
+    console.error(chalk.red(`No session matching "${id}".`));
+    console.error(chalk.gray('  See your sessions: agents sessions'));
+    process.exitCode = 1;
+    return;
+  }
+
+  // If it's backgrounded, stop the headless continuation first so two processes
+  // don't resume the same transcript at once.
+  const rec = readDetachRecord(meta.id);
+  if (rec) {
+    if (isHeadlessAlive(rec)) {
+      try {
+        process.kill(rec.headlessPid, 'SIGTERM');
+      } catch {
+        /* already gone */
+      }
+    }
+    clearDetachRecord(meta.id);
+  }
+
+  console.log(chalk.gray(`Attaching ${meta.agent} ${meta.id.slice(0, 8)} — resuming interactively…`));
+  await resumeSessionInPlace(meta);
+}

--- a/apps/cli/src/commands/detach-core.ts
+++ b/apps/cli/src/commands/detach-core.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure core of `agents detach` — the nudge, the resumed-run argv, and the id
+ * resolver. Kept import-light (only a type import) so it is unit-tested without
+ * loading the live-session discovery graph.
+ */
+import type { ActiveSession } from '../lib/session/active.js';
+
+/**
+ * The prompt the backgrounded run resumes with. Its whole job is to stop a
+ * now-unwatched agent from stalling on a confirmation nobody will answer: it
+ * tells the agent it is headless and to drive to done, or to stop and state a
+ * blocker (which surfaces as a waiting session the user can `attach`).
+ */
+export const BACKGROUND_NUDGE =
+  "You've been sent to the background — nobody is watching this session now. " +
+  'Continue the current task and drive it to completion end-to-end. ' +
+  "Don't ask for confirmation; make the reasonable call and keep going. " +
+  'If you genuinely cannot proceed safely, stop and state the blocker plainly in one message.';
+
+/**
+ * Build the argv for the headless continuation `detach` spawns. Agent-agnostic
+ * and version-pinned by construction — it goes through the same `agents run
+ * --resume` path `attach` reverses.
+ */
+export function buildBackgroundArgv(agent: string, sessionId: string, cwd?: string): string[] {
+  const argv = ['run', agent, BACKGROUND_NUDGE, '--resume', sessionId, '--headless'];
+  if (cwd) argv.push('--cwd', cwd);
+  return argv;
+}
+
+/** What to do with a resolved session, given which machine we're on. */
+export type DetachTarget =
+  | { kind: 'local'; sessionId: string }
+  | { kind: 'remote'; machine: string; sessionId: string }
+  | { kind: 'refuse'; reason: string };
+
+/**
+ * Decide how to detach a resolved session. Cloud and team sessions are refused
+ * (they have their own lifecycles); a session on another machine is delegated to
+ * that host over SSH — never stopped/resumed locally, since its pid and tmux
+ * socket only mean something where it actually runs. Pure, so every branch is
+ * unit-tested without a live pool. Mirrors `focus`/`jumpTo`'s remote branch.
+ */
+export function resolveDetachTarget(s: ActiveSession, self: string): DetachTarget {
+  if (s.context === 'cloud') {
+    return { kind: 'refuse', reason: 'Cloud sessions run remotely and cannot be detached from here.' };
+  }
+  if (s.context === 'teams') {
+    return {
+      kind: 'refuse',
+      reason: 'That session is managed by its team — stop it with `agents teams`, not `detach`.',
+    };
+  }
+  const sessionId = s.sessionId ?? '';
+  if (!sessionId) {
+    return { kind: 'refuse', reason: 'That session has no id to resume, so it cannot be detached.' };
+  }
+  if (s.machine && s.machine !== self) {
+    return { kind: 'remote', machine: s.machine, sessionId };
+  }
+  return { kind: 'local', sessionId };
+}
+
+/**
+ * Resolve `<id>` to exactly one live session by prefix. Mirrors `focus`'s match
+ * so the two verbs accept the same ids.
+ */
+export function resolveOne(
+  activeById: Map<string, ActiveSession>,
+  id: string,
+): ActiveSession | { error: string } {
+  const q = id.toLowerCase();
+  const matches = [...activeById.values()].filter((s) => (s.sessionId ?? '').toLowerCase().startsWith(q));
+  if (matches.length === 0) return { error: `No live session matching "${id}".` };
+  if (matches.length > 1) {
+    return { error: `"${id}" is ambiguous (${matches.length} live matches). Use more of the id.` };
+  }
+  return matches[0];
+}

--- a/apps/cli/src/commands/detach.ts
+++ b/apps/cli/src/commands/detach.ts
@@ -1,0 +1,176 @@
+/**
+ * `agents detach <id>` — send a live agent session to the background: stop its
+ * interactive process and continue it headless, unattended, so it drives its
+ * task to completion without holding a terminal. Bring it back with
+ * `agents attach`.
+ *
+ * Agent-agnostic and version-pinned by construction: it re-invokes
+ * `agents run <agent> "<nudge>" --resume <id> --headless`, which resolves the
+ * session's originating version and uses the agent's native resume (claude/codex)
+ * or a `/continue` replay (others) — the same path `attach` reverses.
+ */
+import { spawn } from 'node:child_process';
+import { openSync, closeSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { gatherLiveTargets } from './go.js';
+import type { ActiveSession } from '../lib/session/active.js';
+import { killSession } from '../lib/tmux/index.js';
+import { getDefaultSocketPath } from '../lib/tmux/paths.js';
+import { getAgentsInvocation } from '../lib/daemon.js';
+import { captureProcessStartTime } from '../lib/pty-server.js';
+import { writeDetachRecord } from '../lib/session/detached.js';
+import { getLogsDir } from '../lib/state.js';
+import { runOnPeer } from '../lib/session/remote-list.js';
+import { buildBackgroundArgv, resolveDetachTarget, resolveOne } from './detach-core.js';
+
+export function registerDetachCommand(program: Command): void {
+  program
+    .command('detach')
+    .argument('<id>', 'Short or full id of the live session to background')
+    .option('--local', 'Only this machine (skip the cross-host sweep)')
+    .description('Send a live agent to the background — stop its terminal, keep it working headless')
+    .action(async (id: string, opts: { local?: boolean }) => {
+      await detachAction(id, opts);
+    });
+}
+
+/**
+ * Stop the interactive process so it can't fight the headless resume over the
+ * same transcript. tmux-hosted sessions are killed by session (closes the pane
+ * and ends the agent); a plain process is SIGTERM'd by pid. Either way we then
+ * wait for the process to actually exit before returning, so the headless
+ * continuation never starts writing the transcript while the old process is
+ * still flushing it.
+ */
+async function stopInteractive(s: ActiveSession): Promise<void> {
+  if (s.tmuxTarget) {
+    const name = s.tmuxTarget.split(':')[0];
+    await killSession(name, getDefaultSocketPath());
+  } else if (s.pid && s.pid > 0) {
+    try {
+      process.kill(s.pid, 'SIGTERM');
+    } catch {
+      return; /* already gone — nothing to wait on */
+    }
+  }
+  if (s.pid && s.pid > 0) await waitForExit(s.pid);
+}
+
+/**
+ * Poll until `pid` is gone (SIGTERM already sent), escalating to SIGKILL past the
+ * deadline so a stuck process can't wedge the detach. Bounded so `detach` never
+ * hangs waiting on a process that ignores signals.
+ */
+async function waitForExit(pid: number, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return; /* gone */
+    }
+    if (Date.now() >= deadline) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        /* raced to exit */
+      }
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
+/**
+ * Where a backgrounded continuation's stdout/stderr lands, by convention, so a
+ * crash after detach is debuggable — there is no terminal watching it, and
+ * presence only tells you the pid is gone, not whether the run finished or died.
+ */
+function backgroundLogPath(sessionId: string): string {
+  return path.join(getLogsDir(), `detach-${sessionId.slice(0, 8)}.log`);
+}
+
+/**
+ * Spawn the headless continuation detached, resolving to its pid for tracking.
+ * Its output is redirected to `logFile` rather than discarded, so a fast-failing
+ * background run leaves a trail.
+ */
+function spawnHeadless(command: string, args: string[], logFile: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    mkdirSync(path.dirname(logFile), { recursive: true });
+    const fd = openSync(logFile, 'a');
+    const child = spawn(command, args, { detached: true, stdio: ['ignore', fd, fd], env: process.env });
+    child.once('spawn', () => {
+      const pid = child.pid ?? 0;
+      child.unref();
+      try { closeSync(fd); } catch { /* fd handed to the child */ }
+      resolve(pid);
+    });
+    child.once('error', (err) => {
+      try { closeSync(fd); } catch { /* never opened for the child */ }
+      reject(err instanceof Error ? err : new Error(String(err)));
+    });
+  });
+}
+
+export async function detachAction(id: string, opts: { local?: boolean } = {}): Promise<void> {
+  const { self, activeById } = await gatherLiveTargets(!!opts.local, { includeCloud: true });
+  const resolved = resolveOne(activeById, id);
+  if ('error' in resolved) {
+    console.error(chalk.red(resolved.error));
+    process.exitCode = 1;
+    return;
+  }
+  const s = resolved;
+  const target = resolveDetachTarget(s, self);
+
+  // Cloud, team, and id-less sessions can't be backgrounded from here.
+  if (target.kind === 'refuse') {
+    console.error(chalk.red(target.reason));
+    process.exitCode = 1;
+    return;
+  }
+
+  const short = target.sessionId.slice(0, 8);
+
+  // A session on another host: its pid and tmux socket only mean something where
+  // it runs, so detach it *there* over SSH — never kill/resume locally. Mirrors
+  // focus/jumpTo's remote branch.
+  if (target.kind === 'remote') {
+    console.log(chalk.gray(`${short} lives on ${target.machine} — detaching it there over SSH…`));
+    const rc = await runOnPeer(['detach', target.sessionId, '--local'], target.machine);
+    if (rc === 'no-target') {
+      console.error(chalk.red(`Can't reach ${target.machine} to detach ${short}.`));
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  // Local: stop the interactive process, then continue it headless, detached —
+  // version-pinned via the existing `agents run --resume` path.
+  const sessionId = target.sessionId;
+  const agent = s.kind;
+  await stopInteractive(s);
+
+  const logFile = backgroundLogPath(sessionId);
+  const inv = getAgentsInvocation(buildBackgroundArgv(agent, sessionId, s.cwd));
+  const pid = await spawnHeadless(inv.command, inv.args, logFile);
+
+  // Record it so `attach` and `agents ls --active` know it's backgrounded.
+  writeDetachRecord({
+    sessionId,
+    agent,
+    cwd: s.cwd,
+    headlessPid: pid,
+    headlessStartTime: captureProcessStartTime(pid),
+    detachedAtMs: Date.now(),
+  });
+
+  console.log(
+    chalk.green(`◒ Backgrounded ${agent} ${short}`) +
+      chalk.gray(` — running headless (pid ${pid}). Bring it back: agents attach ${short}`),
+  );
+  console.log(chalk.gray(`  logs: ${logFile}`));
+}

--- a/apps/cli/src/commands/go.ts
+++ b/apps/cli/src/commands/go.ts
@@ -22,6 +22,7 @@ import { promisify } from 'util';
 import { getActiveSessions, findSessionFileForKind, type ActiveSession } from '../lib/session/active.js';
 import { gatherRemoteActive } from '../lib/session/remote-active.js';
 import { discoverSessions } from '../lib/session/discover.js';
+import { deriveShortId } from '../lib/session/short-id.js';
 import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
 import { dedupeByMachineSession, mergeLocalFirst, pickSessionInteractive } from './sessions.js';
 import { focusAction } from './focus.js';
@@ -45,8 +46,16 @@ export function registerGoCommand(program: Command): void {
     });
 }
 
-/** Live jump targets (local + remote), keyed by session id. Cloud excluded (no pid). */
-export async function gatherLiveTargets(local: boolean): Promise<{ self: string; activeById: Map<string, ActiveSession> }> {
+/**
+ * Live jump targets (local + remote), keyed by session id. Cloud is excluded by
+ * default (it has no local pid to attach), but `detach` opts in with
+ * `includeCloud` so it can resolve a cloud id and refuse it with a clear message
+ * instead of a bare "no live session".
+ */
+export async function gatherLiveTargets(
+  local: boolean,
+  opts: { includeCloud?: boolean } = {},
+): Promise<{ self: string; activeById: Map<string, ActiveSession> }> {
   const self = machineId();
   const localActive = await getActiveSessions();
   for (const s of localActive) if (!s.machine) s.machine = self;
@@ -58,7 +67,11 @@ export async function gatherLiveTargets(local: boolean): Promise<{ self: string;
     } catch { /* remote sweep is best-effort */ }
   }
   const activeById = new Map<string, ActiveSession>();
-  for (const s of active) if (s.context !== 'cloud' && s.sessionId) activeById.set(s.sessionId, s);
+  for (const s of active) {
+    if (!s.sessionId) continue;
+    if (s.context === 'cloud' && !opts.includeCloud) continue;
+    activeById.set(s.sessionId, s);
+  }
   return { self, activeById };
 }
 
@@ -104,7 +117,7 @@ function synthMeta(s: ActiveSession, self: string): SessionMeta {
   const filePath = remote ? '' : (findSessionFileForKind(s.kind, s.cwd, s.sessionId) ?? '');
   return {
     id: s.sessionId!,
-    shortId: s.sessionId!.slice(0, 8),
+    shortId: deriveShortId(s.sessionId!),
     agent: s.kind as SessionAgentId,
     timestamp: new Date(s.startedAtMs ?? Date.now()).toISOString(),
     filePath,

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -937,6 +937,7 @@ export function registerRepoCommands(program: Command): void {
         console.log(chalk.gray('No repos to pull.'));
         return;
       }
+      let anyPulled = false;
       for (const t of targets) {
         if (!fs.existsSync(t.dir) || !isGitRepo(t.dir)) {
           // A plain (never-cloned) user repo — setup makes ~/.agents a bare dir and
@@ -975,8 +976,22 @@ export function registerRepoCommands(program: Command): void {
         const result = await pullRepo(t.dir);
         if (result.success) {
           spinner.succeed(`${formatRepoTarget(t.alias, t.dir, result.branch)}: ${result.commit}`);
+          anyPulled = true;
         } else {
           spinner.fail(`${formatRepoTarget(t.alias, t.dir)}: ${result.error}`);
+        }
+      }
+
+      // RUSH-1980: a pull rewrites the routine YAML on disk, but the daemon's
+      // scheduler froze its JobConfigs (device pins included) at load. Without a
+      // reload it keeps firing the pre-pull pins — a routine re-pinned to another
+      // host still fires here, double-firing across the fleet. SIGHUP the daemon
+      // so scheduler.reloadAll() re-reads the synced YAML and device pins refresh.
+      // No-op when the daemon isn't running (or on Windows, which has no SIGHUP).
+      if (anyPulled) {
+        const { isDaemonRunning, signalDaemonReload } = await import('../lib/daemon.js');
+        if (isDaemonRunning() && signalDaemonReload()) {
+          console.log(chalk.gray('Reloaded the routines daemon (device pins refreshed).'));
         }
       }
     });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -402,6 +402,25 @@ export function ticketLabel(s: Pick<SessionMeta, 'ticketId' | 'prNumber'>): stri
 }
 
 /**
+ * The row shape `agents sessions --active --json` emits. RUSH-1981: a watcher
+ * joins active sessions on ticketId + project, but the raw ActiveSession nests
+ * the ticket (`ticket.id`) and carries no `project` at all — so a naive join
+ * silently drops every row. Emit both as flat, always-present top-level keys
+ * (null when unknown) alongside the raw fields, so every active row is joinable.
+ * `project` uses the same derivation SessionMeta does — basename(cwd) (see
+ * discover.ts) — so the active view and the history view join identically.
+ */
+export function serializeActiveSessionsForJson(
+  sessions: ActiveSession[],
+): Array<ActiveSession & { ticketId: string | null; project: string | null }> {
+  return sessions.map((s) => ({
+    ...s,
+    ticketId: s.ticket?.id ?? null,
+    project: s.cwd ? path.basename(s.cwd) : null,
+  }));
+}
+
+/**
  * Compact, colour-coded badges for the durable/awaiting signals. Text-only (no
  * emoji, per repo convention): `plan` / `ask` / `perm` for why it's waiting,
  * `PR#N`, `wt:slug`, `TICKET-123`.
@@ -879,7 +898,7 @@ async function renderActiveSessions(
   const sessions = waitingOnly ? merged.filter(s => s.status === 'input_required') : merged;
 
   if (asJson) {
-    process.stdout.write(JSON.stringify(sessions, null, 2) + '\n');
+    process.stdout.write(JSON.stringify(serializeActiveSessionsForJson(sessions), null, 2) + '\n');
     if (waitingOnly && sessions.length > 0) process.exitCode = 1;
     return;
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -176,6 +176,8 @@ import {
   loadAlias,
   loadMine,
   loadPty,
+  loadDetach,
+  loadAttach,
   loadTmux,
   loadWatchdog,
   loadBrowser,
@@ -968,6 +970,8 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadAlias);
   await reg(loadMine);
   await reg(loadPty);
+  await reg(loadDetach);
+  await reg(loadAttach);
   await reg(loadTmux);
   await reg(loadWatchdog);
   await reg(loadBrowser);

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1503,6 +1503,45 @@ export function isClaudeCredentialFileBlank(
   }
 }
 
+/**
+ * Whether a Claude version home holds its OWN on-disk credential — a non-blank
+ * `.claude/.credentials.json` (the store Claude Code writes on login off macOS)
+ * or a `.claude/.oauth_token` file (the keychain-less shim fallback, shims.ts).
+ *
+ * RUSH-1979: the routines daemon injects one ambient `CLAUDE_CODE_OAUTH_TOKEN`
+ * (RUSH-1759) so a token-less default account still authenticates. But Claude —
+ * and the Linux shim's own `-z CLAUDE_CODE_OAUTH_TOKEN` guard — both prefer that
+ * env var over a pinned account's config dir, so when balanced rotation pins a
+ * specific account's `CLAUDE_CONFIG_DIR` the ambient token shadows it: the pool
+ * is inert and every fire 401s on the one stale token. A routine spawn drops the
+ * ambient token when the pinned account has its own credential (this returns
+ * true) so the account authenticates itself; when it does not (the RUSH-1759
+ * default), the injected token is kept.
+ *
+ * Off-darwin only, mirroring {@link isClaudeCredentialFileBlank}: on macOS the
+ * login Keychain is the canonical store and probing it raises an auth sheet, and
+ * there the daemon injects no token to shadow (broker-only, usually absent), so
+ * returning false changes nothing. Sync, no Keychain, no network.
+ */
+export function claudeHomeHasOwnCredential(
+  base: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (platform === 'darwin') return false;
+  if (fs.existsSync(path.join(base, '.claude', '.oauth_token'))) return true;
+  try {
+    const raw = fs.readFileSync(path.join(base, '.claude', '.credentials.json'), 'utf-8');
+    const oauth = (JSON.parse(raw) as {
+      claudeAiOauth?: { accessToken?: unknown; refreshToken?: unknown };
+    }).claudeAiOauth;
+    if (!oauth) return false;
+    const nonEmpty = (v: unknown): v is string => typeof v === 'string' && v.trim().length > 0;
+    return nonEmpty(oauth.accessToken) || nonEmpty(oauth.refreshToken);
+  } catch {
+    return false;
+  }
+}
+
 export async function getAccountInfo(
   agentId: AgentId,
   home?: string

--- a/apps/cli/src/lib/cloud/session-index.ts
+++ b/apps/cli/src/lib/cloud/session-index.ts
@@ -20,6 +20,7 @@
 import { upsertSession } from '../session/db.js';
 import type { SessionAgentId } from '../session/types.js';
 import { SESSION_AGENTS } from '../session/types.js';
+import { deriveShortId } from '../session/short-id.js';
 import type { CloudTask } from './types.js';
 
 /** The execution-id charset the session index will accept as a row id. */
@@ -45,7 +46,7 @@ export function registerCloudSession(task: CloudTask, ctx: CloudSessionContext =
     upsertSession(
       {
         id: task.id,
-        shortId: task.id.slice(0, 8),
+        shortId: deriveShortId(task.id),
         agent: task.agent as SessionAgentId,
         timestamp: task.createdAt,
         lastActivity: task.updatedAt,

--- a/apps/cli/src/lib/hosts/session-index.ts
+++ b/apps/cli/src/lib/hosts/session-index.ts
@@ -19,6 +19,7 @@ import type { SessionMeta, SessionAgentId } from '../session/types.js';
 import { SESSION_AGENTS } from '../session/types.js';
 import { localLogPath, updateTask, type HostTask } from './tasks.js';
 import { parseSessionIdMarker } from './session-marker.js';
+import { deriveShortId } from '../session/short-id.js';
 
 export interface HostSessionContext {
   /** Local directory the `agents run --host` was invoked from. */
@@ -39,7 +40,7 @@ export function hostSessionMeta(task: HostTask, ctx: HostSessionContext): Sessio
 
   return {
     id,
-    shortId: id.slice(0, 8),
+    shortId: deriveShortId(id),
     agent: task.agent as SessionAgentId,
     timestamp: task.createdAt,
     cwd: ctx.cwd,
@@ -119,7 +120,7 @@ export function registerInteractiveHostSession(ctx: InteractiveHostSessionContex
     upsertSession(
       {
         id: ctx.sessionId,
-        shortId: ctx.sessionId.slice(0, 8),
+        shortId: deriveShortId(ctx.sessionId),
         agent: ctx.agent as SessionAgentId,
         timestamp: ctx.createdAt ?? new Date().toISOString(),
         cwd: ctx.cwd,

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -50,7 +50,8 @@ import { loadTask as loadHostTask } from './hosts/tasks.js';
 import { reconcileTask as reconcileHostTask } from './hosts/reconcile.js';
 import { backgroundSpawnOptions } from './platform/process.js';
 import { walkForFiles } from './fs-walk.js';
-import { getBinaryPath, isVersionInstalled, resolveVersion } from './versions.js';
+import { getBinaryPath, getVersionHomePath, isVersionInstalled, resolveVersion } from './versions.js';
+import { claudeHomeHasOwnCredential } from './agents.js';
 import {
   getConfiguredRunStrategy,
   resolveRunVersion,
@@ -483,6 +484,21 @@ export function buildRoutineSpawnEnv(
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(execEnv)) {
     if (v !== undefined) out[k] = v;
+  }
+  // RUSH-1979: the daemon injects one ambient CLAUDE_CODE_OAUTH_TOKEN (RUSH-1759)
+  // so a token-less default account still authenticates. When balanced rotation
+  // pins THIS spawn to a specific account's CLAUDE_CONFIG_DIR that holds its own
+  // credential, that ambient token would shadow the account (Claude and the Linux
+  // shim both prefer the env var) — making the pool inert and 401ing on the one
+  // stale token. Drop it here so the pinned account authenticates itself; keep it
+  // when the account has no on-disk credential (the RUSH-1759 default).
+  if (
+    agent === 'claude' &&
+    version &&
+    out.CLAUDE_CONFIG_DIR &&
+    claudeHomeHasOwnCredential(getVersionHomePath('claude', version))
+  ) {
+    delete out.CLAUDE_CODE_OAUTH_TOKEN;
   }
   if (timezone) out.TZ = timezone;
   return out;

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -36,6 +36,7 @@ import { computeTokPerSec } from './throughput.js';
 import { inferSessionState, type SessionState, type SessionActivity, type AwaitingReason, type StructuredQuestion, type TodoProgress, type DetectedPr, type DetectedWorktree, type DetectedTicket } from './state.js';
 import type { SessionAttachment } from './types.js';
 import { detectProvenance, type SessionProvenance } from './provenance.js';
+import { presenceFromStore, type Presence } from './detached.js';
 import { mapBounded } from '../concurrency.js';
 
 const execFileAsync = promisify(execFile);
@@ -138,6 +139,16 @@ export interface ActiveSession {
    */
   lastActivityMs?: number;
   status: ActiveStatus;
+  /**
+   * Foreground/background presence for the detach/attach model:
+   *   `attached`   — live interactive TUI you're watching;
+   *   `background` — detached: running headless, unattended (via `agents detach`);
+   *   `parked`     — the headless continuation has exited; the transcript is durable.
+   * Absent for ad-hoc headless runs and cloud/team rows, which aren't on the
+   * foreground/background axis. Folded on at the end of {@link getActiveSessions}
+   * from the detach store — never asserted by a source.
+   */
+  presence?: Presence;
   /** How many live PIDs resolve to this same session (subagents/forks). 1 unless collapsed. */
   pidCount?: number;
   /**
@@ -1258,7 +1269,23 @@ export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<
 
   const merged = dedupeBySession([...tmuxAgents, ...teams, ...terminals, ...cloud, ...unattributed]);
   await enrichProvenance(merged);
+  foldPresence(merged);
   return merged;
+}
+
+/**
+ * Fold detach/attach presence onto each row from the detach store. A stored
+ * record wins (`background`/`parked`); otherwise a live terminal session is
+ * `attached`. Ad-hoc headless runs and cloud/team rows stay unmarked — they are
+ * not on the foreground/background axis.
+ */
+function foldPresence(rows: ActiveSession[]): void {
+  for (const s of rows) {
+    if (!s.sessionId) continue;
+    const stored = presenceFromStore(s.sessionId);
+    if (stored) s.presence = stored;
+    else if (s.context === 'terminal') s.presence = 'attached';
+  }
 }
 
 /**

--- a/apps/cli/src/lib/session/cloud.ts
+++ b/apps/cli/src/lib/session/cloud.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
 import type { SessionAgentId, SessionMeta } from './types.js';
+import { deriveShortId } from './short-id.js';
 import { getCacheDir } from '../state.js';
 
 const PROXY_BASE = process.env.RUSH_PROXY_BASE ?? 'https://api.prix.dev';
@@ -124,7 +125,7 @@ export async function discoverCloudSessions(options?: {
 
     out.push({
       id,
-      shortId: id.slice(0, 8),
+      shortId: deriveShortId(id),
       agent,
       timestamp,
       project,

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -577,6 +577,78 @@ export function getScanStampsForPaths(filePaths: string[]): Map<string, ScanStam
 }
 
 /**
+ * A file's persisted resumable-parse continuation, read back from scan_ledger.
+ * `parserState` is the serialized {@link ClaudeParserState} JSON blob (offset +
+ * accumulator snapshot); `contentText` is the accumulated user doc. Both are
+ * written by the Claude scan (B-2) and consumed on the next scan to decide
+ * full-vs-incremental and to hydrate the resume.
+ */
+export interface ParserStateRow {
+  parserState: string | null;
+  contentText: string | null;
+  fileMtimeMs: number;
+  fileSize: number;
+  scannedAt: number;
+}
+
+/**
+ * Bulk-load the resumable-parse continuation (parser_state + content_text) plus
+ * the stamp for a set of file paths in a single chunked query. Mirrors
+ * {@link getScanStampsForPaths}: keys by canonical path and fans results back to
+ * every original alias so callers can `.get(filePath)` with the path they passed.
+ * The Claude incremental scan uses this to fetch each changed file's prior
+ * continuation without an N+1 of {@link getScanStampByPath}.
+ */
+export function getParserStatesForPaths(filePaths: string[]): Map<string, ParserStateRow> {
+  const result = new Map<string, ParserStateRow>();
+  if (filePaths.length === 0) return result;
+  const db = getDB();
+
+  const canonicalToOriginals = new Map<string, string[]>();
+  for (const fp of filePaths) {
+    const canonical = canonicalLedgerKey(fp);
+    const aliases = canonicalToOriginals.get(canonical);
+    if (aliases) aliases.push(fp);
+    else canonicalToOriginals.set(canonical, [fp]);
+  }
+
+  const canonicalKeys = [...canonicalToOriginals.keys()];
+  const CHUNK = 500;
+  for (let i = 0; i < canonicalKeys.length; i += CHUNK) {
+    const chunk = canonicalKeys.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = db
+      .prepare(`
+        SELECT file_path, file_mtime_ms, file_size, scanned_at, parser_state, content_text
+        FROM scan_ledger
+        WHERE file_path IN (${placeholders})
+      `)
+      .all(...chunk) as Array<{
+        file_path: string;
+        file_mtime_ms: number;
+        file_size: number;
+        scanned_at: number;
+        parser_state: string | null;
+        content_text: string | null;
+      }>;
+
+    for (const row of rows) {
+      const state: ParserStateRow = {
+        parserState: row.parser_state,
+        contentText: row.content_text,
+        fileMtimeMs: row.file_mtime_ms,
+        fileSize: row.file_size,
+        scannedAt: row.scanned_at,
+      };
+      for (const original of canonicalToOriginals.get(row.file_path) || []) {
+        result.set(original, state);
+      }
+    }
+  }
+  return result;
+}
+
+/**
  * Record scan stamps for files we've looked at. Covers both files that produced
  * a session and files we looked at but chose not to index (e.g. malformed).
  */
@@ -830,19 +902,26 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
 
 /** Batch-upsert sessions with their FTS5 content and scan stamps in a single transaction. */
 export function upsertSessionsBatch(
-  entries: Array<{ meta: SessionMeta; content: string; scan?: ScanStamp }>,
+  entries: Array<{ meta: SessionMeta; content: string; scan?: ScanStamp; parserState?: string; contentText?: string }>,
 ): void {
   if (entries.length === 0) return;
   const db = getDB();
   const { upsert, delText, insText, readLabel } = stmts(db);
   const now = Date.now();
+  // Persist the Claude resumable-parse continuation (parser_state + content_text)
+  // alongside the stamp. On a full/incremental Claude parse the caller passes the
+  // serialized newState + accumulated user doc so the NEXT scan can resume from
+  // the persisted offset (B-2). Other scanners pass neither, leaving both columns
+  // NULL exactly as before — their ledger rows are unaffected.
   const ledger = db.prepare(`
-    INSERT INTO scan_ledger (file_path, file_mtime_ms, file_size, scanned_at)
-    VALUES (?, ?, ?, ?)
+    INSERT INTO scan_ledger (file_path, file_mtime_ms, file_size, scanned_at, parser_state, content_text)
+    VALUES (?, ?, ?, ?, ?, ?)
     ON CONFLICT(file_path) DO UPDATE SET
       file_mtime_ms = excluded.file_mtime_ms,
       file_size = excluded.file_size,
-      scanned_at = excluded.scanned_at
+      scanned_at = excluded.scanned_at,
+      parser_state = excluded.parser_state,
+      content_text = excluded.content_text
   `);
 
   // Build a lookup from canonical file path → entry, used inside the write
@@ -877,7 +956,7 @@ export function upsertSessionsBatch(
       }
     }
 
-    for (const { meta, content, scan } of items) {
+    for (const { meta, content, scan, parserState, contentText } of items) {
       if (alreadyIndexed.has(meta.id)) continue;
       // Per-row guard: one malformed session (e.g. a required field that resolves to
       // NULL) must not abort the whole batch and take down the entire `agents sessions`
@@ -930,7 +1009,14 @@ export function upsertSessionsBatch(
         content ?? '',
       );
       if (scan && meta.filePath) {
-        ledger.run(canonicalLedgerKey(meta.filePath), scan.fileMtimeMs, scan.fileSize, now);
+        ledger.run(
+          canonicalLedgerKey(meta.filePath),
+          scan.fileMtimeMs,
+          scan.fileSize,
+          now,
+          parserState ?? null,
+          contentText ?? null,
+        );
       }
       } catch (err) {
         if (process.stderr.isTTY) {

--- a/apps/cli/src/lib/session/detached.ts
+++ b/apps/cli/src/lib/session/detached.ts
@@ -1,0 +1,109 @@
+/**
+ * Detached-session store — the record `agents detach` writes and both
+ * `agents attach` and the active-session scan read to know an agent is
+ * "backgrounded": running headless with no terminal, continuing its task
+ * unattended.
+ *
+ * One file per detached session under `~/.agents/.system/detached/<id>.json`.
+ * Presence is DERIVED, never asserted: a record only means "this session was
+ * detached to a headless continuation"; whether it is still `background`
+ * (that continuation is alive) or `parked` (it has exited) is decided live from
+ * the recorded pid + its start-time fingerprint. That keeps the store honest
+ * even across a crash that never ran `attach`.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { getSystemAgentsDir } from '../state.js';
+import { captureProcessStartTime } from '../pty-server.js';
+
+/** A session's foreground/background presence. */
+export type Presence = 'attached' | 'background' | 'parked';
+
+export interface DetachRecord {
+  sessionId: string;
+  agent: string;
+  cwd?: string;
+  /** pid of the detached headless continuation `agents detach` spawned. */
+  headlessPid: number;
+  /**
+   * Start-time fingerprint of {@link headlessPid} at spawn, so a liveness check
+   * survives PID reuse: the pid is only "our" continuation if it still occupies
+   * the process we launched. Null when the platform capture failed.
+   */
+  headlessStartTime: string | null;
+  detachedAtMs: number;
+}
+
+function detachedDir(): string {
+  return path.join(getSystemAgentsDir(), 'detached');
+}
+
+function recordPath(sessionId: string): string {
+  return path.join(detachedDir(), `${sessionId}.json`);
+}
+
+export function writeDetachRecord(rec: DetachRecord): void {
+  fs.mkdirSync(detachedDir(), { recursive: true });
+  fs.writeFileSync(recordPath(rec.sessionId), JSON.stringify(rec, null, 2));
+}
+
+export function readDetachRecord(sessionId: string): DetachRecord | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(recordPath(sessionId), 'utf8')) as DetachRecord;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearDetachRecord(sessionId: string): void {
+  try {
+    fs.rmSync(recordPath(sessionId));
+  } catch {
+    /* already gone */
+  }
+}
+
+export function listDetachRecords(): DetachRecord[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(detachedDir());
+  } catch {
+    return [];
+  }
+  const out: DetachRecord[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const rec = readDetachRecord(name.slice(0, -'.json'.length));
+    if (rec) out.push(rec);
+  }
+  return out;
+}
+
+/** True while the recorded headless continuation is still the live process we spawned. */
+export function isHeadlessAlive(rec: DetachRecord): boolean {
+  if (!rec.headlessPid || rec.headlessPid <= 0) return false;
+  try {
+    process.kill(rec.headlessPid, 0);
+  } catch {
+    return false;
+  }
+  // Defeat PID reuse: if the pid now belongs to a different process, it is not ours.
+  if (rec.headlessStartTime !== null) {
+    const now = captureProcessStartTime(rec.headlessPid);
+    if (now !== null && now !== rec.headlessStartTime) return false;
+  }
+  return true;
+}
+
+/**
+ * Presence for a session id from the detach store alone:
+ *   - no record            -> undefined (caller decides: `attached` for a live
+ *                             interactive row, nothing for cloud/team rows)
+ *   - record + pid alive    -> `background` (headless continuation running)
+ *   - record + pid exited   -> `parked` (the run finished; transcript is durable)
+ */
+export function presenceFromStore(sessionId: string): Presence | undefined {
+  const rec = readDetachRecord(sessionId);
+  if (!rec) return undefined;
+  return isHeadlessAlive(rec) ? 'background' : 'parked';
+}

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -25,6 +25,7 @@ import { AGENTS, agentConfigDirName, getCliVersion } from '../agents.js';
 import { walkForFilesWithStat } from '../fs-walk.js';
 import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
+import { deriveShortId } from './short-id.js';
 import { extractSessionTopic } from './prompt.js';
 import { parseAntigravity } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand, detectSpawnedTeam, isTicketCreateTool, extractCreatedTicket } from './state.js';
@@ -35,6 +36,7 @@ import {
   getDB,
   getScanStampByPath,
   getScanStampsForPaths,
+  getParserStatesForPaths,
   getDirLedgerForPaths,
   recordDirScans,
   recordScans,
@@ -201,6 +203,15 @@ interface ScanEntry {
   meta: SessionMeta;
   content: string;
   scan: ScanStamp;
+  /**
+   * Serialized {@link ClaudeParserState} continuation to persist in
+   * scan_ledger.parser_state (Claude only). Carries the offset + accumulator so
+   * the NEXT scan of this file resumes from where this parse stopped. Absent for
+   * non-Claude scanners, which leave the column NULL.
+   */
+  parserState?: string;
+  /** Accumulated user doc to persist in scan_ledger.content_text for the next hydrate (Claude only). */
+  contentText?: string;
 }
 
 /**
@@ -856,7 +867,13 @@ async function readRoutineArchiveMeta(
 
   if (agent === 'claude') {
     const sessionId = path.basename(filePath).replace(/\.jsonl$/, '');
-    const result = await readClaudeMeta(filePath, sessionId);
+    // Routine archives are finalized, immutable transcripts — no live append, so
+    // no continuation to resume. A FULL parse (undefined prior) is correct here;
+    // the returned continuation is unused by this archive path.
+    const stat = safeStatSync(filePath);
+    if (!stat) return null;
+    const scanStamp: ScanStamp = { fileMtimeMs: Math.floor(stat.mtimeMs), fileSize: stat.size };
+    const result = await readClaudeMeta(filePath, sessionId, scanStamp, undefined);
     return result ? { ...result, meta: decorateRoutineSession(result.meta, info) } : null;
   }
 
@@ -1050,6 +1067,13 @@ async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Pr
   if (changed.length > 0) {
     onProgress?.({ agent: 'claude', parsed: 0, total: changed.length });
 
+    // Bulk-fetch each changed file's prior resumable continuation. A file with a
+    // usable prior state + growth goes incremental (re-parse only the appended
+    // bytes); everything else does a FULL from-offset-0 parse. The decision + the
+    // parse both live in scanClaudeSessionResumable so full and incremental share
+    // one reducer and produce identical rows.
+    const priorStates = getParserStatesForPaths(changed.map(c => c.filePath));
+
     const entries: ScanEntry[] = [];
     const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
     let parsed = 0;
@@ -1057,9 +1081,16 @@ async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Pr
       try {
         const sessionId = path.basename(filePath).replace('.jsonl', '');
         const label = labelMap.get(sessionId) ?? undefined;
-        const result = await readClaudeMeta(filePath, sessionId, account, label);
+        const priorRow = priorStates.get(filePath);
+        const result = await readClaudeMeta(filePath, sessionId, scan, priorRow, account, label);
         if (result) {
-          entries.push({ meta: result.meta, content: result.content, scan });
+          entries.push({
+            meta: result.meta,
+            content: result.content,
+            scan,
+            parserState: result.parserState,
+            contentText: result.contentText,
+          });
         } else {
           touched.push({ filePath, scan });
         }
@@ -1079,14 +1110,31 @@ async function scanClaudeIncremental(onProgress?: (p: ScanProgress) => void): Pr
   if (labelMap.size > 0) syncLabels(labelMap);
 }
 
-/** Stream-parse a single Claude JSONL file to extract session metadata. */
+/**
+ * Stream-parse a single Claude JSONL file to extract session metadata, resuming
+ * from the persisted continuation when the file merely grew (see
+ * {@link scanClaudeSessionResumable}). Returns the row's meta + FTS content plus
+ * the serialized continuation (parser_state + content_text) to persist for the
+ * next scan.
+ */
 async function readClaudeMeta(
   filePath: string,
   sessionId: string,
+  scanStamp: ScanStamp,
+  priorRow: { parserState: string | null; fileMtimeMs: number } | undefined,
   account?: string,
   label?: string,
-): Promise<{ meta: SessionMeta; content: string } | null> {
-  const scan = await scanClaudeSession(filePath);
+): Promise<{ meta: SessionMeta; content: string; parserState: string; contentText?: string } | null> {
+  const prior = parsePriorClaudeState(priorRow);
+  const { scan, newState, mode } = await scanClaudeSessionResumable(
+    filePath,
+    prior,
+    scanStamp.fileMtimeMs,
+    scanStamp.fileSize,
+    priorRow?.fileMtimeMs,
+  );
+  if (mode === 'incremental') claudeIncrementalScanCount++;
+  else claudeFullScanCount++;
   const isTeamOrigin = scan.entrypoint === 'sdk-cli';
 
   let meta: SessionMeta;
@@ -1094,7 +1142,7 @@ async function readClaudeMeta(
     const cwd = normalizeCwd(scan.cwd || '');
     meta = {
       id: sessionId,
-      shortId: sessionId.slice(0, 8),
+      shortId: deriveShortId(sessionId),
       agent: 'claude',
       timestamp: scan.timestamp,
       lastActivity: scan.lastActivity,
@@ -1124,7 +1172,7 @@ async function readClaudeMeta(
     const stat = safeStatSync(filePath);
     meta = {
       id: sessionId,
-      shortId: sessionId.slice(0, 8),
+      shortId: deriveShortId(sessionId),
       agent: 'claude',
       timestamp: stat ? stat.mtime.toISOString() : new Date().toISOString(),
       lastActivity: scan.lastActivity,
@@ -1148,7 +1196,15 @@ async function readClaudeMeta(
     };
   }
 
-  return { meta, content: scan.contentText || '' };
+  return {
+    meta,
+    content: scan.contentText || '',
+    // Persist the continuation so the next scan of this file can resume from the
+    // offset instead of a full reparse. content_text is the same accumulated user
+    // doc, cached so the resume can hydrate userTexts without re-reading the file.
+    parserState: JSON.stringify(newState),
+    contentText: newState.contentText,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1272,19 +1328,33 @@ async function scanCodexIncremental(onProgress?: (p: ScanProgress) => void): Pro
 
   onProgress?.({ agent: 'codex', parsed: 0, total: changed.length });
 
+  // Bulk-fetch each changed rollout's prior resumable continuation. A file with
+  // a usable prior state + growth goes incremental (re-parse only the appended
+  // bytes); everything else does a FULL from-offset-0 parse. The decision + the
+  // parse both live in scanCodexSessionResumable so full and incremental share
+  // one reducer and produce identical rows.
+  const priorStates = getParserStatesForPaths(changed.map(c => c.filePath));
+
   const entries: ScanEntry[] = [];
   const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
   const seen = new Set<string>();
   let parsed = 0;
   for (const { filePath, scan } of changed) {
     try {
-      const result = await readCodexMeta(filePath, getCodexAccount, currentVersion);
+      const priorRow = priorStates.get(filePath);
+      const result = await readCodexMeta(filePath, getCodexAccount, currentVersion, scan, priorRow);
       if (result && !seen.has(result.meta.id)) {
         seen.add(result.meta.id);
         // Prefer the Codex-generated title over the first-prompt fallback.
         const title = titles.get(result.meta.id);
         if (title) result.meta.topic = title;
-        entries.push({ meta: result.meta, content: result.content, scan });
+        entries.push({
+          meta: result.meta,
+          content: result.content,
+          scan,
+          parserState: result.parserState,
+          contentText: result.contentText,
+        });
       } else {
         touched.push({ filePath, scan });
       }
@@ -1380,15 +1450,42 @@ export async function readCodexMeta(
   filePath: string,
   resolveAccount?: () => string | undefined,
   currentVersion?: string,
-): Promise<{ meta: SessionMeta; content: string } | null> {
-  const scan = await scanCodexSession(filePath);
+  scanStamp?: ScanStamp,
+  priorRow?: { parserState: string | null; fileMtimeMs: number },
+): Promise<{ meta: SessionMeta; content: string; parserState?: string; contentText?: string } | null> {
+  // Resume from the persisted continuation when the file merely grew; otherwise
+  // full-parse from byte 0. Both branches share one reducer, so an append yields
+  // a row identical to a from-scratch reparse. When no stamp is supplied (a
+  // caller outside the live scan path), fall back to a plain full parse with no
+  // continuation to persist.
+  let scan: CodexSessionScan;
+  let newState: CodexParserState | undefined;
+  let newOffset = 0;
+  if (scanStamp) {
+    const prior = parsePriorCodexState(priorRow);
+    const result = await scanCodexSessionResumable(
+      filePath,
+      prior,
+      scanStamp.fileMtimeMs,
+      scanStamp.fileSize,
+      priorRow?.fileMtimeMs,
+    );
+    if (result.mode === 'incremental') codexIncrementalScanCount++;
+    else codexFullScanCount++;
+    scan = result.scan;
+    newState = result.newState;
+    newOffset = result.newOffset;
+  } else {
+    scan = await scanCodexSession(filePath);
+  }
+
   const sessionId = scan.sessionId || '';
   if (!sessionId) return null;
 
   const cwd = normalizeCwd(scan.cwd || '');
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'codex',
     // Codex `session_meta` only carries the start time; use file mtime when
     // it's newer so long-running sessions register as recently active.
@@ -1413,7 +1510,15 @@ export async function readCodexMeta(
     createdTickets: scan.createdTickets,
     spawnedTeam: scan.spawnedTeam,
   };
-  return { meta, content: scan.contentText || '' };
+  return {
+    meta,
+    content: scan.contentText || '',
+    // Persist the continuation so the next scan of this rollout resumes from the
+    // offset instead of a full reparse; content_text caches the accumulated user
+    // doc for the resume's hydrate. Absent when no stamp was supplied.
+    parserState: newState ? JSON.stringify(newState) : undefined,
+    contentText: newState?.contentText,
+  };
 }
 
 /**
@@ -1613,7 +1718,7 @@ function readGeminiMeta(
 
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'gemini',
     timestamp: startTime || (stat ? stat.mtime.toISOString() : new Date().toISOString()),
     lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
@@ -1767,7 +1872,7 @@ function readAntigravityMeta(
   const stat = safeStatSync(filePath);
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'antigravity',
     timestamp: stat ? stat.mtime.toISOString() : new Date().toISOString(),
     project: normalizedCwd ? path.basename(normalizedCwd) : undefined,
@@ -1914,7 +2019,7 @@ async function scanOpenCodeIncremental(): Promise<void> {
 
       const meta: SessionMeta = {
         id,
-        shortId: id.replace(/^ses_/, '').slice(0, 8),
+        shortId: deriveShortId(id, /^ses_/),
         agent: 'opencode',
         timestamp,
         lastActivity,
@@ -1985,7 +2090,7 @@ async function scanOpenClawIncremental(): Promise<void> {
       entries.push({
         meta: {
           id: `openclaw-${agentId}`,
-          shortId: agentId.slice(0, 8),
+          shortId: deriveShortId(agentId),
           agent: 'openclaw',
           timestamp: new Date().toISOString(),
           project: name,
@@ -2023,7 +2128,7 @@ async function scanOpenClawIncremental(): Promise<void> {
       entries.push({
         meta: {
           id: `openclaw-cron-${jobId}`,
-          shortId: jobId.slice(0, 8),
+          shortId: deriveShortId(jobId),
           agent: 'openclaw',
           timestamp: new Date().toISOString(),
           project: `${jobName} (${agentId || 'unknown'})`,
@@ -2120,7 +2225,7 @@ async function readRushMeta(
   const timestamp = scan.timestamp
     || (stat ? stat.mtime.toISOString() : new Date().toISOString());
 
-  const shortId = sessionId.replace(/^session_/, '').slice(0, 8);
+  const shortId = deriveShortId(sessionId, /^session_/);
 
   const meta: SessionMeta = {
     id: sessionId,
@@ -2286,7 +2391,7 @@ function readHermesMeta(filePath: string): { meta: SessionMeta; content: string 
       ? session.session_start
       : stat ? stat.mtime.toISOString() : new Date().toISOString();
 
-  const shortId = sessionId.replace(/^api-/, '').slice(0, 8);
+  const shortId = deriveShortId(sessionId, /^api-/);
   const model = typeof session.model === 'string' ? session.model : undefined;
   const platform = typeof session.platform === 'string' ? session.platform : undefined;
 
@@ -2411,7 +2516,7 @@ async function readDroidMeta(
   const cwd = normalizeCwd(scan.cwd || '');
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'droid',
     timestamp: scan.timestamp || (stat ? stat.mtime.toISOString() : new Date().toISOString()),
     lastActivity: scan.lastActivity,
@@ -3067,31 +3172,332 @@ export async function scanClaudeSessionIncremental(
   };
 }
 
+/** Serialized zero-value continuation: a fresh accumulator at offset 0, used to drive a FULL parse from the start through the same resumable path. */
+function freshClaudeParserState(): ClaudeParserState {
+  return serializeClaudeParserState(initClaudeParseState(), 0);
+}
+
+/**
+ * Decide full-vs-incremental for one Claude file and parse it uniformly, always
+ * returning a finalized scan plus the continuation to persist. Both branches run
+ * through the SAME reducer (via {@link scanClaudeSessionIncremental}), so the row
+ * an append produces is identical to a from-scratch full reparse by construction
+ * (the B-1 parity harness proves this at the function level).
+ *
+ * INCREMENTAL when a prior continuation exists AND the file grew past the
+ * persisted offset AND its mtime did not go backwards — an in-place append.
+ * FULL (from byte 0, fresh state) otherwise: cold start (no prior), truncation /
+ * rewrite (size shrank to at or below the offset), or a clock rewind / restore
+ * (mtime older than the last parse). A FULL parse still produces a continuation,
+ * so the file's very next append can go incremental.
+ *
+ * `mode` is returned so the caller (and tests) can confirm which branch ran.
+ */
+async function scanClaudeSessionResumable(
+  filePath: string,
+  prior: ClaudeParserState | null,
+  currentFileMtimeMs: number,
+  currentFileSize: number,
+  priorFileMtimeMs?: number,
+): Promise<{ scan: ClaudeSessionScan; newState: ClaudeParserState; newOffset: number; mode: 'full' | 'incremental' }> {
+  // File size + mtime cannot distinguish an APPEND from an in-place rewrite or a
+  // restore that dropped DIFFERENT, larger content at the same path: both grow
+  // the file and move mtime forward. Resuming from the stored offset across that
+  // boundary would fold the new file's bytes into an accumulator hydrated from
+  // the OLD session, so the persisted row silently diverges from a full reparse.
+  // So the metadata gate below only makes a file ELIGIBLE; before trusting the
+  // offset we re-read the transcript's first user/assistant timestamp and require
+  // it to still match the prior continuation's. An append keeps that identity
+  // byte-for-byte; a rewrite/restore of a different session changes it. A
+  // mismatch — or an identity we cannot derive — falls back to a FULL parse,
+  // which is always correct. (A shrink is already handled: currentFileSize is not
+  // > prior.offset, so it takes the FULL branch.)
+  let canIncrement = false;
+  if (
+    prior !== null &&
+    currentFileSize > prior.offset &&
+    (priorFileMtimeMs === undefined || currentFileMtimeMs >= priorFileMtimeMs) &&
+    prior.timestamp !== undefined
+  ) {
+    canIncrement = (await claudeSessionIdentityAt(filePath)) === prior.timestamp;
+  }
+
+  if (canIncrement && prior !== null) {
+    const result = await scanClaudeSessionIncremental(filePath, prior.offset, prior);
+    return { ...result, mode: 'incremental' };
+  }
+
+  const result = await scanClaudeSessionIncremental(filePath, 0, freshClaudeParserState());
+  return { ...result, mode: 'full' };
+}
+
+/**
+ * Cheaply derive a Claude transcript's session identity — the first
+ * user/assistant event `timestamp` — by streaming only the START of the file
+ * (at most `maxBytes`) and stopping at the first such event. Used by
+ * {@link scanClaudeSessionResumable} to confirm a grown file is still the SAME
+ * session before resuming from a stored parse offset. Returns undefined when no
+ * user/assistant event appears within the budget, which forces a FULL parse.
+ */
+async function claudeSessionIdentityAt(filePath: string, maxBytes = 1_048_576): Promise<string | undefined> {
+  const state = initClaudeParseState();
+  const stream = fs.createReadStream(filePath, { start: 0, end: maxBytes - 1, encoding: 'utf-8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      applyClaudeLine(state, parsed);
+      if (state.timestamp !== undefined) break;
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+  return state.timestamp;
+}
+
+/**
+ * Parse the prior continuation blob for a changed file into a usable
+ * {@link ClaudeParserState}, or null when there is none / it is unusable. A blob
+ * from a different serialization version is treated as absent so the file falls
+ * back to a clean FULL parse rather than resuming against a stale shape.
+ */
+function parsePriorClaudeState(row: { parserState: string | null } | undefined): ClaudeParserState | null {
+  if (!row?.parserState) return null;
+  try {
+    const parsed = JSON.parse(row.parserState) as ClaudeParserState;
+    if (parsed?.v !== 1 || typeof parsed.offset !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Test seam: how many times the incremental (append-resume) branch was taken since the last reset. */
+let claudeIncrementalScanCount = 0;
+/** Test seam: how many times a full (from-offset-0) Claude parse ran since the last reset. */
+let claudeFullScanCount = 0;
+
+/** Test seam: read the (incremental, full) Claude parse counters. */
+export function __claudeScanBranchCountsForTest(): { incremental: number; full: number } {
+  return { incremental: claudeIncrementalScanCount, full: claudeFullScanCount };
+}
+
+/** Test seam: reset the Claude parse-branch counters to observe a scan from a clean slate. */
+export function __resetClaudeScanBranchCountsForTest(): void {
+  claudeIncrementalScanCount = 0;
+  claudeFullScanCount = 0;
+}
+
+/**
+ * Live (in-memory) accumulator for a Codex parse — the mutable state
+ * {@link scanCodexSession} used to hold in local `let`s, extracted so the same
+ * fold ({@link applyCodexLine}) runs for both a full parse and an incremental
+ * resume. Mirrors {@link ClaudeParseState}.
+ */
+export interface CodexParseState {
+  // First-wins session_meta fields.
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  model?: string;
+  topic?: string;
+  // Additive across every counted message (user + assistant).
+  messageCount: number;
+  // LAST-WINS cumulative token snapshots: Codex's token_count events carry a
+  // running total, so the final one wins (not a sum).
+  tokenCount?: number;
+  lastTotalTokenUsage?: any;
+  // Duration bounds across every timestamped event.
+  firstTsMs?: number;
+  lastTsMs?: number;
+  userTexts: string[];
+  // Straddle state: a `gh pr create` function_call marks intent; the pull URL
+  // arrives in a later function_call_output.
+  sawPrCreate: boolean;
+  prUrl?: string;
+  prNumber?: number;
+  // Ticket creation straddles a create_issue function_call and its output ref.
+  createdTickets: Set<string>;
+  pendingTicketTools: Set<string>;
+  spawnedTeam?: string;
+}
+
+/** Zero-value accumulator for a fresh (from-byte-0) Codex parse. */
+export function initCodexParseState(): CodexParseState {
+  return {
+    sessionId: undefined,
+    timestamp: undefined,
+    cwd: undefined,
+    gitBranch: undefined,
+    version: undefined,
+    model: undefined,
+    topic: undefined,
+    messageCount: 0,
+    tokenCount: undefined,
+    lastTotalTokenUsage: undefined,
+    firstTsMs: undefined,
+    lastTsMs: undefined,
+    userTexts: [],
+    sawPrCreate: false,
+    prUrl: undefined,
+    prNumber: undefined,
+    createdTickets: new Set<string>(),
+    pendingTicketTools: new Set<string>(),
+    spawnedTeam: undefined,
+  };
+}
+
+/**
+ * Fold one parsed Codex line into the accumulator — the exact loop body
+ * {@link scanCodexSession} used to run inline, extracted verbatim and mutating
+ * `state.*` in place. `parsed` is the already-`JSON.parse`d line (the
+ * malformed-line skip happens in the caller, as before).
+ */
+export function applyCodexLine(state: CodexParseState, parsed: any): void {
+  // PR signal, structurally: a Codex `function_call` whose command is
+  // `gh pr create`, then the pull URL from a `function_call_output`.
+  if (parsed.type === 'response_item') {
+    const p = parsed.payload || {};
+    if (p.type === 'function_call') {
+      let cmd = '';
+      try {
+        const args = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : (p.arguments || {});
+        cmd = String(args.command || args.cmd || '');
+      } catch { /* non-JSON args */ }
+      if (!state.prUrl && !state.sawPrCreate && isPrCreateCommand(cmd)) state.sawPrCreate = true;
+      if (!state.spawnedTeam) {
+        const team = detectSpawnedTeam(cmd);
+        if (team) state.spawnedTeam = team;
+      }
+      if (typeof p.call_id === 'string' && isTicketCreateTool(p.name, cmd)) {
+        state.pendingTicketTools.add(p.call_id);
+      }
+    }
+    if (p.type === 'function_call_output') {
+      if (!state.prUrl && state.sawPrCreate) {
+        const pr = extractPrUrl(String(p.output || ''));
+        if (pr) { state.prUrl = pr.url; state.prNumber = pr.number; }
+      }
+      if (typeof p.call_id === 'string' && state.pendingTicketTools.has(p.call_id)) {
+        state.pendingTicketTools.delete(p.call_id);
+        const t = extractCreatedTicket(String(p.output || ''));
+        if (t) state.createdTickets.add(t);
+      }
+    }
+  }
+
+  // Track duration across every timestamped event.
+  if (typeof parsed.timestamp === 'string') {
+    const ms = new Date(parsed.timestamp).getTime();
+    if (!Number.isNaN(ms)) {
+      if (state.firstTsMs === undefined || ms < state.firstTsMs) state.firstTsMs = ms;
+      if (state.lastTsMs === undefined || ms > state.lastTsMs) state.lastTsMs = ms;
+    }
+  }
+
+  if (parsed.type === 'session_meta') {
+    const payload = parsed.payload || {};
+    state.sessionId = payload.id || state.sessionId;
+    state.timestamp = payload.timestamp || parsed.timestamp || state.timestamp;
+    state.cwd = payload.cwd || state.cwd;
+    state.gitBranch = payload.git?.branch || state.gitBranch;
+    state.version = payload.cli_version || payload.version || state.version;
+    state.model = payload.model || state.model;
+    return;
+  }
+
+  if (parsed.type === 'response_item' && parsed.payload?.type === 'message') {
+    const role = parsed.payload.role === 'user' || parsed.payload.role === 'developer'
+      ? 'user'
+      : 'assistant';
+    const text = extractCodexMessageText(parsed.payload.content, role);
+    if (!text) return;
+    state.messageCount++;
+    if (role === 'user') {
+      state.userTexts.push(text);
+      if (!state.topic) state.topic = extractSessionTopic(text);
+    }
+    return;
+  }
+
+  if (parsed.type === 'event_msg' && parsed.payload?.type === 'token_count') {
+    const totalUsage = parsed.payload.info?.total_token_usage;
+    const total = getCodexTokenCount(totalUsage);
+    if (total !== null) state.tokenCount = total;
+    // token_count is cumulative — keep the latest snapshot and price it once
+    // after the stream, so we don't double-count across intermediate events.
+    if (totalUsage && typeof totalUsage === 'object') state.lastTotalTokenUsage = totalUsage;
+    // Codex also stamps the model on the rate_limits/token_count payload on
+    // some versions; prefer session_meta but fall back to it.
+    if (!state.model && typeof parsed.payload.info?.model === 'string') state.model = parsed.payload.info.model;
+  }
+}
+
+/**
+ * Build the {@link CodexSessionScan} return object from an accumulator — the
+ * exact return-building {@link scanCodexSession} used to run inline.
+ */
+export function finalizeCodexScan(state: CodexParseState): CodexSessionScan {
+  // Price the final cumulative token snapshot once, against the session model.
+  let costUsd: number | undefined;
+  if (state.model && state.lastTotalTokenUsage) {
+    const c = costOfUsage({
+      model: state.model,
+      inputTokens: state.lastTotalTokenUsage.input_tokens,
+      outputTokens: (state.lastTotalTokenUsage.output_tokens ?? 0) + (state.lastTotalTokenUsage.reasoning_output_tokens ?? 0),
+      cacheReadTokens: state.lastTotalTokenUsage.cached_input_tokens,
+    });
+    if (c > 0) costUsd = c;
+  }
+
+  const durationMs =
+    state.firstTsMs !== undefined && state.lastTsMs !== undefined && state.lastTsMs > state.firstTsMs
+      ? state.lastTsMs - state.firstTsMs
+      : undefined;
+
+  const worktree = detectWorktree(state.cwd, state.gitBranch);
+  const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
+
+  return {
+    sessionId: state.sessionId,
+    timestamp: state.timestamp,
+    cwd: state.cwd,
+    gitBranch: state.gitBranch,
+    version: state.version,
+    topic: state.topic,
+    messageCount: state.messageCount,
+    tokenCount: state.tokenCount,
+    outputTokens: state.lastTotalTokenUsage
+      ? (state.lastTotalTokenUsage.output_tokens ?? 0) + (state.lastTotalTokenUsage.reasoning_output_tokens ?? 0)
+      : undefined,
+    costUsd,
+    durationMs,
+    lastActivity: state.lastTsMs !== undefined ? new Date(state.lastTsMs).toISOString() : undefined,
+    contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,
+    prUrl: state.prUrl,
+    prNumber: state.prNumber,
+    worktreeSlug: worktree?.slug,
+    ticketId: ticket?.id,
+    createdTickets: state.createdTickets.size > 0 ? [...state.createdTickets] : undefined,
+    spawnedTeam: state.spawnedTeam,
+  };
+}
+
 /** Stream a Codex JSONL file and extract scan-level metadata (session ID, cwd, topic, tokens). */
 async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
   const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
-  let sessionId: string | undefined;
-  let timestamp: string | undefined;
-  let cwd: string | undefined;
-  let gitBranch: string | undefined;
-  let version: string | undefined;
-  let topic: string | undefined;
-  let messageCount = 0;
-  let tokenCount: number | undefined;
-  let model: string | undefined;
-  let lastTotalTokenUsage: any;
-  let firstTsMs: number | undefined;
-  let lastTsMs: number | undefined;
-  const userTexts: string[] = [];
-  let sawPrCreate = false;
-  let prUrl: string | undefined;
-  let prNumber: number | undefined;
-  // Produced artifacts (mirror of the Claude scan): created tracker refs + spawned team.
-  const createdTickets = new Set<string>();
-  const pendingTicketTools = new Set<string>();
-  let spawnedTeam: string | undefined;
+  const state = initCodexParseState();
 
   try {
     for await (const line of rl) {
@@ -3104,132 +3510,296 @@ async function scanCodexSession(filePath: string): Promise<CodexSessionScan> {
         continue;
       }
 
-      // PR signal, structurally: a Codex `function_call` whose command is
-      // `gh pr create`, then the pull URL from a `function_call_output`.
-      if (parsed.type === 'response_item') {
-        const p = parsed.payload || {};
-        if (p.type === 'function_call') {
-          let cmd = '';
-          try {
-            const args = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : (p.arguments || {});
-            cmd = String(args.command || args.cmd || '');
-          } catch { /* non-JSON args */ }
-          if (!prUrl && !sawPrCreate && isPrCreateCommand(cmd)) sawPrCreate = true;
-          if (!spawnedTeam) {
-            const team = detectSpawnedTeam(cmd);
-            if (team) spawnedTeam = team;
-          }
-          if (typeof p.call_id === 'string' && isTicketCreateTool(p.name, cmd)) {
-            pendingTicketTools.add(p.call_id);
-          }
-        }
-        if (p.type === 'function_call_output') {
-          if (!prUrl && sawPrCreate) {
-            const pr = extractPrUrl(String(p.output || ''));
-            if (pr) { prUrl = pr.url; prNumber = pr.number; }
-          }
-          if (typeof p.call_id === 'string' && pendingTicketTools.has(p.call_id)) {
-            pendingTicketTools.delete(p.call_id);
-            const t = extractCreatedTicket(String(p.output || ''));
-            if (t) createdTickets.add(t);
-          }
-        }
-      }
-
-      // Track duration across every timestamped event.
-      if (typeof parsed.timestamp === 'string') {
-        const ms = new Date(parsed.timestamp).getTime();
-        if (!Number.isNaN(ms)) {
-          if (firstTsMs === undefined || ms < firstTsMs) firstTsMs = ms;
-          if (lastTsMs === undefined || ms > lastTsMs) lastTsMs = ms;
-        }
-      }
-
-      if (parsed.type === 'session_meta') {
-        const payload = parsed.payload || {};
-        sessionId = payload.id || sessionId;
-        timestamp = payload.timestamp || parsed.timestamp || timestamp;
-        cwd = payload.cwd || cwd;
-        gitBranch = payload.git?.branch || gitBranch;
-        version = payload.cli_version || payload.version || version;
-        model = payload.model || model;
-        continue;
-      }
-
-      if (parsed.type === 'response_item' && parsed.payload?.type === 'message') {
-        const role = parsed.payload.role === 'user' || parsed.payload.role === 'developer'
-          ? 'user'
-          : 'assistant';
-        const text = extractCodexMessageText(parsed.payload.content, role);
-        if (!text) continue;
-        messageCount++;
-        if (role === 'user') {
-          userTexts.push(text);
-          if (!topic) topic = extractSessionTopic(text);
-        }
-        continue;
-      }
-
-      if (parsed.type === 'event_msg' && parsed.payload?.type === 'token_count') {
-        const totalUsage = parsed.payload.info?.total_token_usage;
-        const total = getCodexTokenCount(totalUsage);
-        if (total !== null) tokenCount = total;
-        // token_count is cumulative — keep the latest snapshot and price it once
-        // after the stream, so we don't double-count across intermediate events.
-        if (totalUsage && typeof totalUsage === 'object') lastTotalTokenUsage = totalUsage;
-        // Codex also stamps the model on the rate_limits/token_count payload on
-        // some versions; prefer session_meta but fall back to it.
-        if (!model && typeof parsed.payload.info?.model === 'string') model = parsed.payload.info.model;
-      }
+      applyCodexLine(state, parsed);
     }
   } finally {
     rl.close();
     stream.destroy();
   }
 
-  // Price the final cumulative token snapshot once, against the session model.
-  let costUsd: number | undefined;
-  if (model && lastTotalTokenUsage) {
-    const c = costOfUsage({
-      model,
-      inputTokens: lastTotalTokenUsage.input_tokens,
-      outputTokens: (lastTotalTokenUsage.output_tokens ?? 0) + (lastTotalTokenUsage.reasoning_output_tokens ?? 0),
-      cacheReadTokens: lastTotalTokenUsage.cached_input_tokens,
-    });
-    if (c > 0) costUsd = c;
+  return finalizeCodexScan(state);
+}
+
+/**
+ * SERIALIZED continuation blob persisted in `scan_ledger.parser_state` for a
+ * Codex rollout. Carries everything {@link hydrateCodexParseState} needs to
+ * resume a parse from `offset` such that resuming + applying the appended lines
+ * is byte-for-byte identical to a full parse of the whole file.
+ *
+ * Unlike Claude, Codex has NO per-message dedup set, so `messageCount` is a
+ * plain additive base with no recent-id window to persist. The `lastTotalTokenUsage`
+ * object is round-tripped whole so the last-wins cost/output-token pricing at
+ * finalize is identical after a resume.
+ */
+export interface CodexParserState {
+  v: 1;
+  offset: number;
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  model?: string;
+  topic?: string;
+  messageCount: number;
+  tokenCount?: number;
+  lastTotalTokenUsage?: any;
+  firstTsMs?: number;
+  lastTsMs?: number;
+  sawPrCreate: boolean;
+  prUrl?: string;
+  prNumber?: number;
+  pendingTicketTools: string[];
+  createdTickets: string[];
+  spawnedTeam?: string;
+  ticketId?: string;
+  contentText?: string;
+}
+
+/**
+ * Snapshot a live {@link CodexParseState} into its serializable form at `offset`
+ * bytes consumed. Round-trips through {@link hydrateCodexParseState} so
+ * incremental replay equals a full parse.
+ */
+export function serializeCodexParserState(state: CodexParseState, offset: number): CodexParserState {
+  const ticket = detectTicket(state.userTexts.join('\n') || undefined, state.gitBranch);
+  return {
+    v: 1,
+    offset,
+    sessionId: state.sessionId,
+    timestamp: state.timestamp,
+    cwd: state.cwd,
+    gitBranch: state.gitBranch,
+    version: state.version,
+    model: state.model,
+    topic: state.topic,
+    messageCount: state.messageCount,
+    tokenCount: state.tokenCount,
+    lastTotalTokenUsage: state.lastTotalTokenUsage,
+    firstTsMs: state.firstTsMs,
+    lastTsMs: state.lastTsMs,
+    sawPrCreate: state.sawPrCreate,
+    prUrl: state.prUrl,
+    prNumber: state.prNumber,
+    pendingTicketTools: [...state.pendingTicketTools],
+    createdTickets: [...state.createdTickets],
+    spawnedTeam: state.spawnedTeam,
+    // ticketId is derived at finalize time; persist it (and content_text) so a
+    // consumer can rebuild the row + FTS doc on append without re-reading the
+    // whole file. worktreeSlug is re-derived from cwd/gitBranch, so it need not
+    // be persisted.
+    ticketId: ticket?.id,
+    contentText: state.userTexts.length > 0 ? state.userTexts.join('\n') : undefined,
+  };
+}
+
+/**
+ * Rebuild a live {@link CodexParseState} from a persisted continuation so that
+ * applying the appended lines yields the same accumulator a full parse would.
+ *
+ * `userTexts` is rehydrated as a single joined blob from `contentText`: only
+ * `userTexts.join('\n')` (detectTicket + contentText) and `userTexts.length > 0`
+ * are ever read downstream, and both are preserved by a one-element array
+ * holding the joined content. Topic is first-wins and already persisted, so a
+ * collapsed userTexts never changes it.
+ */
+export function hydrateCodexParseState(prior: CodexParserState): CodexParseState {
+  return {
+    sessionId: prior.sessionId,
+    timestamp: prior.timestamp,
+    cwd: prior.cwd,
+    gitBranch: prior.gitBranch,
+    version: prior.version,
+    model: prior.model,
+    topic: prior.topic,
+    messageCount: prior.messageCount,
+    tokenCount: prior.tokenCount,
+    lastTotalTokenUsage: prior.lastTotalTokenUsage,
+    firstTsMs: prior.firstTsMs,
+    lastTsMs: prior.lastTsMs,
+    userTexts: prior.contentText !== undefined && prior.contentText.length > 0 ? [prior.contentText] : [],
+    sawPrCreate: prior.sawPrCreate,
+    prUrl: prior.prUrl,
+    prNumber: prior.prNumber,
+    createdTickets: new Set<string>(prior.createdTickets),
+    pendingTicketTools: new Set<string>(prior.pendingTicketTools),
+    spawnedTeam: prior.spawnedTeam,
+  };
+}
+
+/**
+ * Resume a Codex parse from `fromOffset` bytes into the file, folding only the
+ * newly-appended lines into `prior`. Returns the finalized scan, the next
+ * serialized continuation, and the byte offset to resume from next time.
+ *
+ * Same trailing-line discipline as {@link scanClaudeSessionIncremental}: apply
+ * ONLY the run of newline-terminated lines (slice at the last `'\n'`), and set
+ * `newOffset = fromOffset + consumedBytes`. Any tail after the last `'\n'` —
+ * syntactically broken OR a complete-but-not-yet-terminated record — is DEFERRED
+ * to the next pass once its `'\n'` lands. Codex `messageCount` is additive with
+ * NO dedup, so re-reading a still-unterminated complete line would double-count
+ * it; deferring prevents that (the bug class prix-cloud caught for Claude).
+ */
+export async function scanCodexSessionIncremental(
+  filePath: string,
+  fromOffset: number,
+  prior: CodexParserState,
+): Promise<{ scan: CodexSessionScan; newState: CodexParserState; newOffset: number }> {
+  const state = hydrateCodexParseState(prior);
+
+  const chunks: Buffer[] = [];
+  const stream = fs.createReadStream(filePath, { start: fromOffset });
+  try {
+    for await (const chunk of stream) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : chunk as Buffer);
+    }
+  } finally {
+    stream.destroy();
+  }
+  const appended = Buffer.concat(chunks);
+
+  // Bytes up to AND INCLUDING the last '\n' are the committed, complete-line run.
+  const lastNl = appended.lastIndexOf(0x0a);
+  const consumedBytes = lastNl === -1 ? 0 : lastNl + 1;
+
+  if (consumedBytes > 0) {
+    for (const line of appended.subarray(0, consumedBytes).toString('utf-8').split('\n')) {
+      if (!line.trim()) continue;
+
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      applyCodexLine(state, parsed);
+    }
   }
 
-  const durationMs =
-    firstTsMs !== undefined && lastTsMs !== undefined && lastTsMs > firstTsMs
-      ? lastTsMs - firstTsMs
-      : undefined;
-
-  const worktree = detectWorktree(cwd, gitBranch);
-  const ticket = detectTicket(userTexts.join('\n') || undefined, gitBranch);
-
+  const newOffset = fromOffset + consumedBytes;
   return {
-    sessionId,
-    timestamp,
-    cwd,
-    gitBranch,
-    version,
-    topic,
-    messageCount,
-    tokenCount,
-    outputTokens: lastTotalTokenUsage
-      ? (lastTotalTokenUsage.output_tokens ?? 0) + (lastTotalTokenUsage.reasoning_output_tokens ?? 0)
-      : undefined,
-    costUsd,
-    durationMs,
-    lastActivity: lastTsMs !== undefined ? new Date(lastTsMs).toISOString() : undefined,
-    contentText: userTexts.length > 0 ? userTexts.join('\n') : undefined,
-    prUrl,
-    prNumber,
-    worktreeSlug: worktree?.slug,
-    ticketId: ticket?.id,
-    createdTickets: createdTickets.size > 0 ? [...createdTickets] : undefined,
-    spawnedTeam,
+    scan: finalizeCodexScan(state),
+    newState: serializeCodexParserState(state, newOffset),
+    newOffset,
   };
+}
+
+/** Serialized zero-value continuation: a fresh accumulator at offset 0, used to drive a FULL parse from the start through the same resumable path. */
+function freshCodexParserState(): CodexParserState {
+  return serializeCodexParserState(initCodexParseState(), 0);
+}
+
+/**
+ * Cheaply derive a Codex rollout's session identity — the `session_meta` id — by
+ * streaming only the START of the file (at most `maxBytes`) and stopping once the
+ * id is known. Mirrors {@link claudeSessionIdentityAt}: used by
+ * {@link scanCodexSessionResumable} to confirm a grown file is still the SAME
+ * session before resuming from a stored parse offset. Codex writes `session_meta`
+ * (carrying the durable session UUID) on the first line of every rollout, so the
+ * id is reached almost immediately. Returns undefined when no id appears within
+ * the budget, which forces a FULL parse.
+ */
+async function codexSessionIdentityAt(filePath: string, maxBytes = 1_048_576): Promise<string | undefined> {
+  const state = initCodexParseState();
+  const stream = fs.createReadStream(filePath, { start: 0, end: maxBytes - 1, encoding: 'utf-8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      applyCodexLine(state, parsed);
+      if (state.sessionId !== undefined) break;
+    }
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+  return state.sessionId;
+}
+
+/**
+ * Decide full-vs-incremental for one Codex rollout and parse it uniformly,
+ * always returning a finalized scan plus the continuation to persist. Both
+ * branches run through the SAME reducer (via {@link scanCodexSessionIncremental}),
+ * so an append produces a row identical to a from-scratch full reparse by
+ * construction. INCREMENTAL when a prior continuation exists AND the file grew
+ * past the persisted offset AND its mtime did not go backwards; FULL (from byte
+ * 0, fresh state) otherwise (cold start, truncation/rewrite, clock rewind).
+ */
+async function scanCodexSessionResumable(
+  filePath: string,
+  prior: CodexParserState | null,
+  currentFileMtimeMs: number,
+  currentFileSize: number,
+  priorFileMtimeMs?: number,
+): Promise<{ scan: CodexSessionScan; newState: CodexParserState; newOffset: number; mode: 'full' | 'incremental' }> {
+  // File size + mtime cannot distinguish an APPEND from an in-place rewrite or a
+  // restore that dropped a DIFFERENT, larger rollout at the same path: both grow
+  // the file and move mtime forward. Resuming from the stored offset across that
+  // boundary would fold the new session's bytes into an accumulator hydrated from
+  // the OLD session, so the persisted row silently diverges from a full reparse.
+  // So the metadata gate below only makes a file ELIGIBLE; before trusting the
+  // offset we re-read the rollout's `session_meta` id and require it to still
+  // match the prior continuation's. An append keeps that id; a rewrite/restore of
+  // a different session changes it. A mismatch — or an id we cannot derive —
+  // falls back to a FULL parse, which is always correct. (A shrink is already
+  // handled: currentFileSize is not > prior.offset, so it takes the FULL branch.)
+  let canIncrement = false;
+  if (
+    prior !== null &&
+    currentFileSize > prior.offset &&
+    (priorFileMtimeMs === undefined || currentFileMtimeMs >= priorFileMtimeMs) &&
+    prior.sessionId !== undefined
+  ) {
+    canIncrement = (await codexSessionIdentityAt(filePath)) === prior.sessionId;
+  }
+
+  if (canIncrement && prior !== null) {
+    const result = await scanCodexSessionIncremental(filePath, prior.offset, prior);
+    return { ...result, mode: 'incremental' };
+  }
+
+  const result = await scanCodexSessionIncremental(filePath, 0, freshCodexParserState());
+  return { ...result, mode: 'full' };
+}
+
+/**
+ * Parse the prior continuation blob for a changed Codex file into a usable
+ * {@link CodexParserState}, or null when there is none / it is unusable. A blob
+ * from a different serialization version is treated as absent so the file falls
+ * back to a clean FULL parse rather than resuming against a stale shape.
+ */
+function parsePriorCodexState(row: { parserState: string | null } | undefined): CodexParserState | null {
+  if (!row?.parserState) return null;
+  try {
+    const parsed = JSON.parse(row.parserState) as CodexParserState;
+    if (parsed?.v !== 1 || typeof parsed.offset !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Test seam: how many times the incremental (append-resume) branch was taken since the last reset. */
+let codexIncrementalScanCount = 0;
+/** Test seam: how many times a full (from-offset-0) Codex parse ran since the last reset. */
+let codexFullScanCount = 0;
+
+/** Test seam: read the (incremental, full) Codex parse counters. */
+export function __codexScanBranchCountsForTest(): { incremental: number; full: number } {
+  return { incremental: codexIncrementalScanCount, full: codexFullScanCount };
+}
+
+/** Test seam: reset the Codex parse-branch counters to observe a scan from a clean slate. */
+export function __resetCodexScanBranchCountsForTest(): void {
+  codexIncrementalScanCount = 0;
+  codexFullScanCount = 0;
 }
 
 /** Resolve the working directory for an OpenClaw agent from its workspace config. */
@@ -3508,16 +4078,21 @@ async function scanKimiIncremental(onProgress?: (p: ScanProgress) => void): Prom
 
   onProgress?.({ agent: 'kimi', parsed: 0, total: changed.length });
 
+  // Bulk-fetch each changed session's prior wire-parse continuation (offset +
+  // counter bases). A session whose wire.jsonl grew resumes from the offset;
+  // everything else (cold start, truncation) full-parses from byte 0.
+  const priorStates = getParserStatesForPaths(changed.map(c => c.filePath));
+
   const scanEntries: ScanEntry[] = [];
   const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
   const seen = new Set<string>();
   let parsed = 0;
   for (const { filePath, scan } of changed) {
     try {
-      const result = readKimiMeta(filePath);
+      const result = readKimiMeta(filePath, priorStates.get(filePath));
       if (result && !seen.has(result.meta.id)) {
         seen.add(result.meta.id);
-        scanEntries.push({ meta: result.meta, content: result.content, scan });
+        scanEntries.push({ meta: result.meta, content: result.content, scan, parserState: result.parserState });
       } else {
         touched.push({ filePath, scan });
       }
@@ -3533,7 +4108,10 @@ async function scanKimiIncremental(onProgress?: (p: ScanProgress) => void): Prom
 }
 
 /** Parse a single Kimi session state.json file to extract session metadata. */
-export function readKimiMeta(filePath: string): { meta: SessionMeta; content: string } | null {
+export function readKimiMeta(
+  filePath: string,
+  priorRow?: { parserState: string | null },
+): { meta: SessionMeta; content: string; parserState?: string } | null {
   let state: any;
   try {
     state = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
@@ -3560,7 +4138,7 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
   const timestamp = updatedAt || createdAt
     || (stat ? stat.mtime.toISOString() : new Date().toISOString());
 
-  const shortId = sessionId.replace(/^session_/, '').slice(0, 8);
+  const shortId = deriveShortId(sessionId, /^session_/);
 
   // Try to infer project from session directory path
   // ~/.kimi-code/sessions/<workdir_hash>/session_<uuid>/
@@ -3573,8 +4151,11 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
     }
   }
 
-  // Parse wire.jsonl to extract message count and token usage
-  const { messageCount, tokenCount, outputTokens } = parseKimiWireMetrics(sessionDir);
+  // Parse wire.jsonl incrementally: resume from the persisted offset + counter
+  // bases when the wire grew, else full-parse from byte 0. The continuation is
+  // persisted on this session's state.json ledger row.
+  const prior = parsePriorKimiState(priorRow);
+  const { messageCount, tokenCount, outputTokens, newState } = parseKimiWireMetricsIncremental(sessionDir, prior);
 
   const meta: SessionMeta = {
     id: sessionId,
@@ -3589,46 +4170,131 @@ export function readKimiMeta(filePath: string): { meta: SessionMeta; content: st
     outputTokens: outputTokens > 0 ? outputTokens : undefined,
   };
 
-  return { meta, content: lastPrompt || '' };
+  return { meta, content: lastPrompt || '', parserState: JSON.stringify(newState) };
 }
 
-/** Parse Kimi's wire.jsonl to extract message count and token usage.
- * TODO: optimize to stream (like scanClaudeSession) to avoid loading large files into memory.
- * For now, synchronous readFileSync matches the pattern of reading state.json and is acceptable
- * since session dirs are usually fresh in FS cache during incremental scans. */
-function parseKimiWireMetrics(sessionDir: string): { messageCount: number; tokenCount: number; outputTokens: number } {
-  const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
-  let messageCount = 0;
-  let tokenCount = 0;
-  let outputTokens = 0;
+/**
+ * Kimi wire metrics are pure additive counters (messageCount, tokenCount,
+ * outputTokens) with NO straddle/dedup state, so the continuation is just those
+ * three bases plus the byte `offset` already consumed from wire.jsonl. Resuming
+ * from `offset` + adding the appended tail's deltas equals a full parse.
+ */
+export interface KimiParserState {
+  v: 1;
+  offset: number;
+  messageCount: number;
+  tokenCount: number;
+  outputTokens: number;
+}
 
-  if (!fs.existsSync(wirePath)) {
-    return { messageCount: 0, tokenCount: 0, outputTokens: 0 };
+/** Fold one parsed Kimi wire event into the additive counters, in place. */
+function applyKimiWireEvent(
+  acc: { messageCount: number; tokenCount: number; outputTokens: number },
+  event: any,
+): void {
+  if (event.type === 'context.append_message') {
+    acc.messageCount++;
+  } else if (event.type === 'usage.record' && event.usage) {
+    // Kimi usage structure: inputOther + output + inputCacheRead + inputCacheCreation
+    const u = event.usage;
+    acc.tokenCount += (u.inputOther || 0) + (u.output || 0) + (u.inputCacheRead || 0) + (u.inputCacheCreation || 0);
+    acc.outputTokens += (u.output || 0);
+  }
+}
+
+/**
+ * Incrementally parse Kimi's wire.jsonl for message-count and token counters,
+ * resuming from a persisted continuation instead of re-reading from byte 0 every
+ * scan. Returns the finalized counters and the next {@link KimiParserState} to
+ * persist (offset + the three counter bases).
+ *
+ * Same trailing-line discipline as {@link scanClaudeSessionIncremental}: read
+ * only the appended byte range from `prior.offset`, apply ONLY the run of
+ * newline-terminated lines (slice at the last `'\n'`), and advance the offset to
+ * `prior.offset + consumedBytes`. A complete-but-not-yet-terminated last record
+ * is DEFERRED to the next pass; because these counters are additive with no
+ * dedup, re-reading such a line would double-count it. FULL parse from byte 0
+ * (fresh counters) when there is no prior OR the file shrank below the stored
+ * offset (truncation/rewrite).
+ */
+export function parseKimiWireMetricsIncremental(
+  sessionDir: string,
+  prior: KimiParserState | null,
+): { messageCount: number; tokenCount: number; outputTokens: number; newState: KimiParserState } {
+  const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+
+  const stat = safeStatSync(wirePath);
+  if (!stat) {
+    // No wire.jsonl (yet): zero counters, offset 0 so a later append is a clean
+    // full parse.
+    return { messageCount: 0, tokenCount: 0, outputTokens: 0, newState: { v: 1, offset: 0, messageCount: 0, tokenCount: 0, outputTokens: 0 } };
   }
 
+  // INCREMENTAL only when a usable prior exists AND the file grew past its
+  // offset; otherwise FULL from byte 0 with fresh counters (cold start OR the
+  // file shrank to/below the offset — a truncation/rewrite).
+  //
+  // No session-identity re-check is needed here (unlike Claude's
+  // claudeSessionIdentityAt / Codex's codexSessionIdentityAt, which guard against
+  // an in-place rewrite dropping a DIFFERENT session at the same path). A Kimi
+  // wire.jsonl is uniquely keyed by its session dir — `.../session_<uuid>/agents/
+  // main/wire.jsonl` (see readKimiMeta: sessionId is `session_<uuid>` and must
+  // start with `session_`) — and Kimi only ever APPENDS to that per-session log.
+  // The path therefore cannot host a different session's transcript, so a
+  // size-grew wire.jsonl is always the same session's append. (A truncation/
+  // rewrite — the only way its bytes could diverge — already shrinks it to/below
+  // the offset and takes the FULL branch above.)
+  const canIncrement = prior !== null && stat.size > prior.offset;
+  const fromOffset = canIncrement ? prior!.offset : 0;
+  const acc = canIncrement
+    ? { messageCount: prior!.messageCount, tokenCount: prior!.tokenCount, outputTokens: prior!.outputTokens }
+    : { messageCount: 0, tokenCount: 0, outputTokens: 0 };
+
+  let consumedBytes = 0;
   try {
-    const lines = fs.readFileSync(wirePath, 'utf-8').split('\n');
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        const event = JSON.parse(line);
-        if (event.type === 'context.append_message') {
-          messageCount++;
-        } else if (event.type === 'usage.record' && event.usage) {
-          // Kimi usage structure: inputOther + output + inputCacheRead + inputCacheCreation
-          const u = event.usage;
-          tokenCount += (u.inputOther || 0) + (u.output || 0) + (u.inputCacheRead || 0) + (u.inputCacheCreation || 0);
-          outputTokens += (u.output || 0);
+    const buf = fs.readFileSync(wirePath);
+    const appended = buf.subarray(fromOffset);
+    // Bytes up to AND INCLUDING the last '\n' are the committed, complete-line run.
+    const lastNl = appended.lastIndexOf(0x0a);
+    consumedBytes = lastNl === -1 ? 0 : lastNl + 1;
+    if (consumedBytes > 0) {
+      for (const line of appended.subarray(0, consumedBytes).toString('utf-8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          applyKimiWireEvent(acc, JSON.parse(line));
+        } catch {
+          // Malformed line, skip
         }
-      } catch {
-        // Malformed line, skip
       }
     }
   } catch {
-    // If wire.jsonl can't be read, return 0s (graceful degradation)
+    // If wire.jsonl can't be read, keep the accumulated counters (0s on a cold
+    // parse) — graceful degradation, matching the pre-incremental behavior.
   }
 
-  return { messageCount, tokenCount, outputTokens };
+  return {
+    messageCount: acc.messageCount,
+    tokenCount: acc.tokenCount,
+    outputTokens: acc.outputTokens,
+    newState: { v: 1, offset: fromOffset + consumedBytes, messageCount: acc.messageCount, tokenCount: acc.tokenCount, outputTokens: acc.outputTokens },
+  };
+}
+
+/**
+ * Parse the prior continuation blob for a changed Kimi session into a usable
+ * {@link KimiParserState}, or null when there is none / it is unusable. A blob
+ * from a different serialization version is treated as absent so the wire parse
+ * falls back to a clean FULL parse rather than resuming against a stale shape.
+ */
+function parsePriorKimiState(row: { parserState: string | null } | undefined): KimiParserState | null {
+  if (!row?.parserState) return null;
+  try {
+    const parsed = JSON.parse(row.parserState) as KimiParserState;
+    if (parsed?.v !== 1 || typeof parsed.offset !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -3750,7 +4416,7 @@ export function readGrokMeta(
 
   const meta: SessionMeta = {
     id: sessionId,
-    shortId: sessionId.slice(0, 8),
+    shortId: deriveShortId(sessionId),
     agent: 'grok',
     timestamp,
     lastActivity,

--- a/apps/cli/src/lib/session/fork.ts
+++ b/apps/cli/src/lib/session/fork.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import type { SessionMeta } from './types.js';
 import { upsertSession } from './db.js';
 import { recordRunName } from './run-names.js';
+import { deriveShortId } from './short-id.js';
 
 /** Agents that `fork` can branch today (see the module doc for why). */
 export const FORKABLE_AGENTS = ['claude'] as const;
@@ -85,7 +86,7 @@ export function forkSession(source: SessionMeta, opts: { name?: string; now?: st
   }
 
   const newId = randomUUID();
-  const shortId = newId.slice(0, 8);
+  const shortId = deriveShortId(newId);
   const dir = path.dirname(source.filePath);
   const filePath = path.join(dir, `${newId}.jsonl`);
 

--- a/apps/cli/src/lib/session/short-id.ts
+++ b/apps/cli/src/lib/session/short-id.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical derivation of a session's 8-char `shortId`.
+ *
+ * Every session parser used to inline `id.slice(0, 8)` — some with a
+ * `.replace(prefix, '')` strip first (`session_`, `api-`, `ses_`). That strip is
+ * the bug: an id that is *only* its prefix (a bare `session_` directory, an id of
+ * exactly `api-`) strips to `''`, and `''.slice(0, 8)` is still `''`. An empty
+ * shortId then passes the `short_id TEXT NOT NULL` constraint (empty string is not
+ * NULL) yet matches nothing in the `short_id LIKE ?` picker lookups — a silently
+ * corrupt index row.
+ *
+ * This helper is the single source of truth: it strips the optional prefix, takes
+ * the first 8 chars, and — the whole point — guarantees a NON-EMPTY result by
+ * falling back to the unstripped id when the strip empties it, so a row always
+ * stays addressable by its shortId.
+ */
+export function deriveShortId(id: string, stripPrefix?: RegExp): string {
+  const stripped = stripPrefix ? id.replace(stripPrefix, '') : id;
+  return stripped.slice(0, 8) || id.slice(0, 8) || id;
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -82,6 +82,8 @@ export const loadBudget: ModuleLoader = async () => (await import('../../command
 export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
 export const loadMine: ModuleLoader = async () => (await import('../../commands/mine.js')).registerMineCommand;
 export const loadPty: ModuleLoader = async () => (await import('../../commands/pty.js')).registerPtyCommands;
+export const loadDetach: ModuleLoader = async () => (await import('../../commands/detach.js')).registerDetachCommand;
+export const loadAttach: ModuleLoader = async () => (await import('../../commands/attach.js')).registerAttachCommand;
 export const loadTmux: ModuleLoader = async () => (await import('../../commands/tmux.js')).registerTmuxCommands;
 export const loadWatchdog: ModuleLoader = async () => (await import('../../commands/watchdog.js')).registerWatchdogCommand;
 export const loadBrowser: ModuleLoader = async () => (await import('../../commands/browser.js')).registerBrowserCommand;
@@ -199,6 +201,8 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   alias: [loadAlias],
   mine: [loadMine],
   pty: [loadPty],
+  detach: [loadDetach],
+  attach: [loadAttach],
   tmux: [loadTmux],
   watchdog: [loadWatchdog],
   browser: [loadBrowser],


### PR DESCRIPTION
Auto-relocated by the daily git-hygiene routine: these were uncommitted working changes sitting on main in the local checkout, moved here so main stays clean. Review and either continue the work on this branch or close.

Files:
- .grok/, .kimi-code/, .opencode/ managed skill dirs (regenerated agent skill/command files)
- apps/cli/.remote-sign-build.sh (new)
- apps/cli/package.json
- apps/cli/src/commands/{attach,detach,detach-core,go,repo,sessions}.ts
- apps/cli/src/index.ts
- apps/cli/src/lib/agents.ts, runner.ts
- apps/cli/src/lib/cloud/session-index.ts, apps/cli/src/lib/hosts/session-index.ts
- apps/cli/src/lib/session/{active,cloud,db,detached,discover,fork,short-id}.ts
- apps/cli/src/lib/startup/command-registry.ts

New session attach/detach commands + short-id/detached session helpers, session-index refactors, plus regenerated managed skill dirs. 62 files changed, 6136 insertions, 200 deletions.