### PR TITLE
docs(agents): root Entry points + .agents workspace; add apps/ios AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ rather than a one-off command in a PR.
 |---|---|---|
 | CLI build | [`apps/cli/scripts/build.sh`](apps/cli/scripts/build.sh) `[<version>] [--clean]` | builds into `apps/cli/dist` |
 | CLI dev install | [`apps/cli/scripts/install.sh`](apps/cli/scripts/install.sh) | side-by-side dev build at `~/.local/agents-cli-dev`, exposed via `~/.local/bin/agents`; does not touch the registry install |
-| CLI tests | [`apps/cli/scripts/sandbox.sh`](apps/cli/scripts/sandbox.sh) `test` | full vitest suite offloaded to a remote crabbox (the laptop-safe path) |
+| CLI tests | `bun run test:remote` (in `apps/cli`) | full vitest suite offloaded to a remote crabbox via [`sandbox.sh`](apps/cli/scripts/sandbox.sh) — the laptop-safe path |
 | CLI release | [`apps/cli/scripts/release.sh`](apps/cli/scripts/release.sh) `<version>` | publishes `@phnx-labs/agents-cli` to npm (legacy `@swarmify` shim built for reference, not published) |
 | Factory build / release | [`apps/factory/scripts/build.sh`](apps/factory/scripts/build.sh) `<version>` · [`release.sh`](apps/factory/scripts/release.sh) `<x.y.z> [--confirm]` | ships `swarmify.swarm-ext` to VS Code Marketplace + Open VSX (dry-run without `--confirm`) |
 | agents-dbg app release | [`scripts/release.sh`](scripts/release.sh) `<version> [--confirm]` | root — builds/signs/notarizes the debug Mac app, uploads the GitHub release, updates the Homebrew tap |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,13 @@ component-specific — this file deliberately stays shallow.
 apps/
   cli/        @phnx-labs/agents-cli — the `agents`/`ag` CLI (the published npm package)
   factory/    Factory — the VS Code extension + its React UI + Electron app (publisher: swarmify, swarm-ext)
+  ios/        Fleet Cockpit — iOS/iPadOS control-plane app (AnchorKit SwiftPM lib + Cockpit SwiftUI); steers the fleet, never a compute worker
 native/
   computer-mac/   Swift daemon behind `agents computer` (Accessibility + screen capture)
   computer-win/   C#/.NET daemon behind `agents computer` on Windows (UI Automation)
 packages/
   session-tracker/  @agents/session-tracker — SessionStart hook that WRITES live-session state
+  agi-cli/          @phnx-labs/agi-cli — DEPRECATED alias; re-exports the canonical @phnx-labs/agents-cli
   swarmify-mirror/  legacy npm-redirect stub (@companion/agents-cli → @phnx-labs/agents-cli)
 docs/         Repo-root design notes (docs/design/); the full CLI design reference is apps/cli/docs/ (start: apps/cli/docs/architecture.md)
 assets/ demo/ website/   Brand, launch demo, landing (repo-root, not shipped in any tarball)
@@ -32,15 +34,55 @@ assets/ demo/ website/   Brand, launch demo, landing (repo-root, not shipped in 
 |---|---|---|
 | [`apps/cli`](apps/cli) | The CLI — version mgmt, config sync, sessions, teams, cloud, browser, computer, secrets | [AGENTS.md](apps/cli/AGENTS.md) · [README.md](apps/cli/README.md) |
 | [`apps/factory`](apps/factory) | Factory VS Code extension — spawns agent terminals as tabs, Factory Floor dashboard, dispatch | [AGENTS.md](apps/factory/AGENTS.md) · [README.md](apps/factory/README.md) |
+| [`apps/ios`](apps/ios) | Fleet Cockpit — iOS/iPadOS control-plane app over the anchor (`agents serve --control`) | [AGENTS.md](apps/ios/AGENTS.md) · [README.md](apps/ios/README.md) |
 | [`native/computer-mac`](native/computer-mac) | macOS `agents computer` backend (Swift) | [AGENTS.md](native/computer-mac/AGENTS.md) · [README.md](native/computer-mac/README.md) |
 | [`native/computer-win`](native/computer-win) | Windows `agents computer` backend (C#/.NET) | [AGENTS.md](native/computer-win/AGENTS.md) · [README.md](native/computer-win/README.md) |
 | [`packages/session-tracker`](packages/session-tracker) | Live-session **writer** (SessionStart hook) | [AGENTS.md](packages/session-tracker/AGENTS.md) · [README.md](packages/session-tracker/README.md) |
+| [`packages/agi-cli`](packages/agi-cli) | Deprecated alias — re-exports the canonical CLI | [README.md](packages/agi-cli/README.md) |
 | [`packages/swarmify-mirror`](packages/swarmify-mirror) | Deprecated npm-redirect stub | [README.md](packages/swarmify-mirror/README.md) |
 
 **No JS workspaces.** Each package self-installs (`bun install` inside it). There is
 deliberately no root `workspaces` field — adding one changed bun's hoisting and broke
 `@inquirer/core` resolution under `--frozen-lockfile`. Don't add it back. There are no
 cross-package imports except the CLI resolving the native helpers by relative path.
+
+## Entry points — always build and release through the scripts
+
+Never hand-roll a build or a release. A bare `tsc` / `bun run build` / `npm publish` /
+`vsce publish` skips the version stamping, gates (tests + semver + CHANGELOG), and
+sign/notarize + tap/marketplace steps these scripts own — a green local compile that
+ships broken. Each component's `scripts/` dir is the contract (see
+[`.agents/skills/scripts`](.agents/skills/scripts/SKILL.md)); add a `scripts/<verb>.sh`
+rather than a one-off command in a PR.
+
+| Task | Script | Contract |
+|---|---|---|
+| CLI build | [`apps/cli/scripts/build.sh`](apps/cli/scripts/build.sh) `[<version>] [--clean]` | builds into `apps/cli/dist` |
+| CLI dev install | [`apps/cli/scripts/install.sh`](apps/cli/scripts/install.sh) | side-by-side dev build at `~/.local/agents-cli-dev`, exposed via `~/.local/bin/agents`; does not touch the registry install |
+| CLI tests | [`apps/cli/scripts/sandbox.sh`](apps/cli/scripts/sandbox.sh) `test` | full vitest suite offloaded to a remote crabbox (the laptop-safe path) |
+| CLI release | [`apps/cli/scripts/release.sh`](apps/cli/scripts/release.sh) `<version>` | publishes `@phnx-labs/agents-cli` to npm (legacy `@swarmify` shim built for reference, not published) |
+| Factory build / release | [`apps/factory/scripts/build.sh`](apps/factory/scripts/build.sh) `<version>` · [`release.sh`](apps/factory/scripts/release.sh) `<x.y.z> [--confirm]` | ships `swarmify.swarm-ext` to VS Code Marketplace + Open VSX (dry-run without `--confirm`) |
+| agents-dbg app release | [`scripts/release.sh`](scripts/release.sh) `<version> [--confirm]` | root — builds/signs/notarizes the debug Mac app, uploads the GitHub release, updates the Homebrew tap |
+| computer-mac build | [`native/computer-mac/scripts/build.sh`](native/computer-mac/scripts/build.sh) | Swift daemon |
+
+## The `.agents/` workspace
+
+The repo's own `.agents/` dir is where agent working files go — use it instead of `/tmp`
+or the repo root so the tree stays clean. What's committed vs gitignored is deliberate
+([`.gitignore`](.gitignore)):
+
+| Path | Git | For |
+|---|---|---|
+| `.agents/worktrees/<slug>/` | ignored | PR-bound worktrees, one per change (see [§Conventions](#conventions-repo-wide)) |
+| `.agents/scratch/` | ignored | throwaway working files |
+| `.agents/plans/` | ignored | internal implementation plans (not shipped) |
+| `.agents/artifacts/` | ignored | generated outputs, incl. a scratch rendered HTML plan |
+| `.agents/skills/`, `.agents/commands/` | committed | project skills + slash commands |
+| `.agents/reports/` | committed | durable reports meant to be kept/shared |
+
+Rule of thumb: **ephemeral → the gitignored dirs; durable + shareable → `.agents/reports/`.**
+A rendered HTML plan you want to keep goes in `reports/` (committed); a throwaway render
+goes in `artifacts/`. Never scatter scratch in `/tmp` or the repo root.
 
 ## Conventions (repo-wide)
 

--- a/apps/ios/AGENTS.md
+++ b/apps/ios/AGENTS.md
@@ -1,0 +1,42 @@
+# apps/ios — Fleet Cockpit
+
+iOS/iPadOS companion for the agents fleet. See the root [AGENTS.md](../../AGENTS.md) for
+repo-wide policy; this file is the app's contracts. Usage/build detail: [README.md](README.md).
+
+## Contracts
+
+- **A control plane, never a compute worker.** No agent runs on-device — iPadOS disables
+  the hypervisor and grants JIT to browsers only. Every action is a call to the anchor
+  (`agents serve --control`) over HTTPS+SSE on the tailnet; executors run on worker/cloud.
+  Do not add on-device agent execution.
+- **`AnchorKit/` is the load-bearing, verified surface** (`Sources/AnchorKit/`:
+  `AnchorClient.swift`, `SSEParser.swift`, `TokenStore.swift`, `Models.swift`). **`Cockpit/`
+  (SwiftUI) consumes only AnchorKit's public API** and is compiled only under full Xcode —
+  it is source-complete but NOT built in CI (CI is Node/bun, no XCTest). Put logic in
+  AnchorKit, not Cockpit, so it stays verifiable.
+- **Auth is a per-device bearer token in the Keychain** — `KeychainTokenStore`
+  (`TokenStore.swift:27`); tests use `InMemoryTokenStore` (`TokenStore.swift:15`). A bad
+  token gets a 401 — asserted live in `Sources/anchorprobe/main.swift:39`
+  (`token: "definitely-wrong"` → error).
+- **Keep the control server on the tailnet — never public Funnel.** The token is the only
+  gate; do not expose the anchor publicly.
+
+## Verify without Xcode
+
+`XCTest`/`swift-testing` need full Xcode, so AnchorKit ships two runnable verifiers
+instead of a test target:
+
+```bash
+cd apps/ios/AnchorKit
+swift run anchorcheck    # pure-logic assertions: SSE parse, model coding, token store (Sources/anchorcheck/main.swift)
+# live, against a real anchor:
+ANCHOR_URL=http://127.0.0.1:4477 ANCHOR_TOKEN=<token> ANCHOR_SESSION=<id> swift run anchorprobe
+```
+
+Any change to AnchorKit must keep `anchorcheck` green; a change to the client/SSE path
+should be exercised with `anchorprobe` against a live `agents serve --control`.
+
+## Pairing
+
+On the anchor: `agents devices pair-ios <name>` mints a control token (shown once) and
+marks the device control-only. Enter the anchor URL + token in the app's Settings.


### PR DESCRIPTION
## What

Refreshes the root `AGENTS.md` and fills the `apps/ios` gap, following the `agents-md` authoring conventions (invariant-first, in-repo source-of-truth pointers, scoped per package). Taking over the AGENTS.md task from a Grok session that stalled at the plan stage.

### Root `AGENTS.md` (additive — reviewer-enforced sections untouched)
- **Entry points table** — where the build/test/release scripts live, with the rule to *always* build/release through them (a bare `tsc`/`npm publish`/`vsce publish` skips version stamping, gates, sign/notarize, and tap/marketplace steps). Each row links the real script and states its contract, verified from the script headers.
- **The `.agents/` workspace** — `scratch`/`plans`/`artifacts`/`worktrees` are gitignored working dirs; `skills`/`commands`/`reports` are committed. Rule: ephemeral -> gitignored dirs; durable + shareable (e.g. a rendered HTML plan to keep) -> `.agents/reports/`. Reconciled against the actual `.gitignore`.
- **Repo map** now includes `apps/ios` and `packages/agi-cli`.

### `apps/ios/AGENTS.md` (new)
Control-plane-not-worker contract; AnchorKit is the verified surface (Cockpit consumes only its public API, Xcode-only); Keychain bearer-token auth (bad token -> 401, `Sources/anchorprobe/main.swift:39`); tailnet-only; and the `anchorcheck`/`anchorprobe` verify-without-Xcode recipe.

## Verification
- Every path/link referenced in the new sections resolves (scripts, `.agents/skills/scripts`, `apps/ios/*`, `packages/agi-cli/README`).
- Script contracts quoted from each script's header, not guessed.
- AnchorKit symbols confirmed present (`AnchorClient.swift:13`, `TokenStore.swift`, the two verifier targets).
- Edited `AGENTS.md` (canonical), not the `CLAUDE.md`/`GEMINI.md` symlinks.

Docs-only; CHANGELOG-exempt.