### PR TITLE
feat(sessions): unify session-id tracking via AGENT_LAUNCH_ID for all agents (RUSH-2034)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2034-interactive-host-session-id.md
+++ b/apps/cli/.changelog/next/RUSH-2034-interactive-host-session-id.md
@@ -1,0 +1,15 @@
+- **Interactive `agents run --host` now tracks the real session for every agent,
+  not just Claude.** Codex, Kimi, Grok, and Gemini coin their own session id and
+  reject a caller-supplied one, so an interactive host run of any of them showed a
+  stale/absent id locally — `agents sessions` couldn't surface it and a dropped
+  link couldn't auto-reconnect it (RUSH-2033 fixed only the Claude `--session-id`
+  path). The launcher now forwards one correlation key it controls
+  (`AGENT_LAUNCH_ID`); the remote `agents run` adopts that key
+  (`resolveLaunchId`), so its SessionStart hook records the agent's real session id
+  under it. After the stream the launcher does one ssh read of the remote hook
+  record, resolves the real id by launch id (`resolveRemoteSessionId` /
+  `pickRemoteSessionId`), registers it in the local session index, and reconnects
+  against it on a dropped link. Claude still forces its own id up front and is
+  unchanged. Source: `apps/cli/src/lib/hosts/remote-session-id.ts`,
+  `resolveLaunchId` in `apps/cli/src/lib/exec.ts`, and the interactive `--host`
+  branch in `apps/cli/src/commands/exec.ts`. (RUSH-2034)

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -154,6 +154,28 @@ the **session-discoverable** set is `SESSION_AGENTS`
 ([`src/lib/session/types.ts`](../src/lib/session/types.ts)): `claude`, `codex`,
 `gemini`, `antigravity`, `opencode`, `openclaw`, `rush`, `hermes`, `grok`, `kimi`,
 `droid`. `cursor` and `copilot` are runnable but not session-discoverable.
+`isSessionTrackedAgent()` in the same file is the single predicate every session-index
+writer gates on.
+
+### Across the SSH hop: `AGENT_LAUNCH_ID` is the one correlation key
+
+`agents run --host` runs `agents run` on a remote box, so the "who names the session"
+split above still holds — Claude forwards a `--session-id` the launcher controls, every
+other agent coins its own id on the peer. The launcher recovers that remote-coined id
+through **one stable correlation key it controls end-to-end**: `AGENT_LAUNCH_ID`.
+
+- The launcher forwards a launch id (`--env AGENT_LAUNCH_ID=<id>`); the remote
+  `agents run` **adopts** it rather than minting a fresh one (`resolveLaunchId` in
+  [`src/lib/exec.ts`](../src/lib/exec.ts)), so the remote SessionStart hook records the
+  agent's real `session_id` under that exact key in `terminals/sessions/<pid>.json`.
+- **Headless** host runs read the id back from the followed log — the remote prints it
+  as a `--emit-session-id` marker ([`src/lib/hosts/session-marker.ts`](../src/lib/hosts/session-marker.ts)).
+- **Interactive** host runs have no followed log (the TTY is wired straight through
+  `sshStream`), so after the stream returns the launcher does one ssh read of the remote
+  hook dir and resolves the id by launch id — `resolveRemoteSessionId` /
+  `pickRemoteSessionId` in [`src/lib/hosts/remote-session-id.ts`](../src/lib/hosts/remote-session-id.ts).
+  It then registers the real id in the local session index and reconnects against it on a
+  dropped link — for Codex/Kimi/Grok/Gemini, not only Claude.
 
 ---
 

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -28,6 +28,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { spawnSync } from 'child_process';
+import { randomUUID } from 'crypto';
+import { isSessionTrackedAgent } from '../lib/session/types.js';
 
 interface ExecCommandActionOptions {
   mode: ExecMode;
@@ -1285,6 +1287,18 @@ export function registerRunCommand(program: Command): void {
             // one here. Registering that same id keeps the local index aligned
             // with the remote agent. On resume, don't mint a new one.
             const hostSessionId = resolveHostSessionId(runAgent, resumeId, options.sessionId);
+            // For every OTHER agent the remote coins its own id, which we can't
+            // know up front. Forward a launch id we control as AGENT_LAUNCH_ID:
+            // the remote `agents run` adopts it (exec.ts resolveLaunchId) and its
+            // SessionStart hook records the real id under that exact key, so after
+            // the stream we resolve the id by one ssh read of the remote hook
+            // record — the same launch-id join used locally (RUSH-2034). Not
+            // needed for Claude (id forced) or resume (id already known).
+            const correlationLaunchId =
+              !hostSessionId && !resumeId && isSessionTrackedAgent(runAgent) ? randomUUID() : undefined;
+            const hostEnv = correlationLaunchId
+              ? [...options.env, `AGENT_LAUNCH_ID=${correlationLaunchId}`]
+              : options.env;
             if (hostSessionId) {
               registerInteractiveHostSession({
                 cwd: process.cwd(),
@@ -1304,7 +1318,7 @@ export function registerRunCommand(program: Command): void {
               mode: options.mode,
               model: options.model,
               effort: options.effort,
-              env: options.env,
+              env: hostEnv,
               addDir: hostAddDirs,
               json: options.json,
               verbose: options.verbose,
@@ -1320,14 +1334,40 @@ export function registerRunCommand(program: Command): void {
               forceInteractive: options.interactive,
               copyCreds: hostCopyCreds,
             });
+            // Resolve a non-Claude agent's REAL remote session id now the run has
+            // booted (its hook has fired on the peer): one ssh read of the remote
+            // hook record, keyed by the launch id we forwarded. Register it so the
+            // run shows in `agents sessions` and can be reconnected/focused —
+            // closing the non-Claude gap RUSH-2033 left. Best-effort: an
+            // unreachable host or a not-yet-landed record leaves the run un-mapped
+            // rather than mis-mapped.
+            let resolvedRemoteId: string | undefined;
+            if (correlationLaunchId) {
+              const { resolveRemoteSessionId } = await import('../lib/hosts/remote-session-id.js');
+              const { sshTargetFor } = await import('../lib/hosts/types.js');
+              try {
+                resolvedRemoteId = resolveRemoteSessionId(sshTargetFor(host), correlationLaunchId);
+              } catch {
+                /* ssh read is best-effort — keep the run un-mapped, never guess */
+              }
+              if (resolvedRemoteId) {
+                registerInteractiveHostSession({
+                  cwd: process.cwd(),
+                  host: host.name,
+                  agent: runAgent,
+                  sessionId: resolvedRemoteId,
+                  name: options.name,
+                });
+              }
+            }
             // A network drop kills the local ssh client (exit 255) but the remote
             // agent survives in its detached tmux session. With a known session id
-            // (Claude, or a resumed run) and a tmux-hosted run, re-attach the live
-            // pane automatically instead of exiting — the user never has to notice
-            // the drop and `agents sessions focus` by hand. `raw` runs aren't tmux
-            // wrapped, so there is nothing to reconnect to. Non-Claude id capture is
-            // tracked in RUSH-2007.
-            const reconnectId = hostSessionId ?? resumeId;
+            // (Claude's forced id, a resumed run, or a non-Claude id we just
+            // resolved from the remote hook record) and a tmux-hosted run,
+            // re-attach the live pane automatically instead of exiting — the user
+            // never has to notice the drop and `agents sessions focus` by hand.
+            // `raw` runs aren't tmux wrapped, so there is nothing to reconnect to.
+            const reconnectId = hostSessionId ?? resolvedRemoteId ?? resumeId;
             if (reconnectId && !isRaw) {
               const { reconnectInteractiveSession, SSH_CONN_FAILURE } = await import('../lib/hosts/reconnect.js');
               if (exitCode === SSH_CONN_FAILURE) {

--- a/apps/cli/src/lib/cloud/session-index.ts
+++ b/apps/cli/src/lib/cloud/session-index.ts
@@ -19,7 +19,7 @@
 
 import { upsertSession } from '../session/db.js';
 import type { SessionAgentId } from '../session/types.js';
-import { SESSION_AGENTS } from '../session/types.js';
+import { isSessionTrackedAgent } from '../session/types.js';
 import { deriveShortId } from '../session/short-id.js';
 import type { CloudTask } from './types.js';
 
@@ -40,7 +40,7 @@ export interface CloudSessionContext {
  * failed index write must never break the dispatch/poll it rides on.
  */
 export function registerCloudSession(task: CloudTask, ctx: CloudSessionContext = {}): void {
-  if (!SESSION_AGENTS.includes(task.agent as SessionAgentId)) return;
+  if (!task.agent || !isSessionTrackedAgent(task.agent)) return;
   if (!task.id || !EXECUTION_ID_RE.test(task.id)) return;
   try {
     upsertSession(

--- a/apps/cli/src/lib/exec.test.ts
+++ b/apps/cli/src/lib/exec.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, detectRateLimit, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, type TmuxWrapContext } from './exec.js';
+import { shouldTapStdout, resolveInteractive, inferredInteractiveWithoutTty, buildExecCommand, nativeResume, resolveShimSpawn, buildExecEnv, shouldWrapInTmux, buildTmuxAgentCommand, formatPaneTail, detectRateLimit, detectAuthFailure, detectAuthFailureEvent, authFailureReason, isAuthFailureFromLog, resolveLaunchId, type TmuxWrapContext } from './exec.js';
 import type { ExecOptions } from './exec.js';
 import { mailboxDir } from './mailbox.js';
 
@@ -532,5 +532,33 @@ describe('buildTmuxAgentCommand (env-preserving pane command)', () => {
     // …but no real value leaks into the (persisted) string.
     expect(cmd).not.toContain('sk-ant-supersecret');
     expect(cmd).not.toContain('/usr/bin:/bin');
+  });
+});
+
+// resolveLaunchId is the one place that decides AGENT_LAUNCH_ID for a run. A
+// `--host` launcher forwards an id it controls so ONE correlation key spans the
+// SSH hop (RUSH-2034); every local run passes none and gets a fresh mint. The
+// adopt-vs-mint decision is what lets the launcher resolve a non-Claude agent's
+// real remote session id from the hook record afterwards.
+describe('resolveLaunchId', () => {
+  it('adopts a launcher-forwarded id verbatim (the cross-hop correlation key)', () => {
+    expect(resolveLaunchId('LID-from-host-42')).toBe('LID-from-host-42');
+  });
+
+  it('mints a fresh uuid when no id was forwarded (every local run)', () => {
+    expect(resolveLaunchId(undefined)).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('mints rather than adopt an empty/whitespace id — the key must be real', () => {
+    expect(resolveLaunchId('')).toMatch(/^[0-9a-f-]{36}$/);
+    expect(resolveLaunchId('   ')).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('trims a forwarded id so a stray newline never desyncs the join', () => {
+    expect(resolveLaunchId('  LID-x  \n')).toBe('LID-x');
+  });
+
+  it('mints a DISTINCT id each call when none is forwarded', () => {
+    expect(resolveLaunchId(undefined)).not.toBe(resolveLaunchId(undefined));
   });
 });

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -329,6 +329,26 @@ export function parseExecEnv(entries: string[]): Record<string, string> | undefi
 }
 
 /**
+ * Resolve the launch id a run exports as `AGENT_LAUNCH_ID`.
+ *
+ * The launch id is the stable correlation key the SessionStart hook records
+ * alongside the agent's real session id (terminals/sessions/<pid>.json), so it
+ * is what maps a launch to its exact session even when the hook runs under a
+ * different pid (tmux pane leaf / cmd.exe wrapper) — and, across an SSH hop, what
+ * lets a `--host` launcher resolve the remote-coined id for agents that never
+ * accept a forced `--session-id`.
+ *
+ * ADOPT a caller-supplied `AGENT_LAUNCH_ID` (a `--host` launcher forwards one via
+ * `--env` so it controls the key end-to-end); MINT a fresh one otherwise (every
+ * local run, which passes none). A malformed inbound value is ignored in favour
+ * of a fresh mint — the key must be a real correlation id, never an empty string.
+ */
+export function resolveLaunchId(envLaunchId: string | undefined): string {
+  const inbound = envLaunchId?.trim();
+  return inbound ? inbound : randomUUID();
+}
+
+/**
  * Build the process environment for an agent invocation.
  * Pins CLAUDE_CONFIG_DIR for Claude, CODEX_HOME for Codex, and COPILOT_HOME
  * for GitHub Copilot; strips the other agents' env vars so they don't leak
@@ -1372,15 +1392,19 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
   // timeout. Spend is recorded to the shared ledger in the close handler. The
   // watcher is dormant (and zero-cost) when no caps are configured.
   const cwd = options.cwd || process.cwd();
-  // Mint the launch id once. It doubles as the budget watcher's run id AND is
+  // Resolve the launch id once. It doubles as the budget watcher's run id AND is
   // exported to the child as AGENT_LAUNCH_ID, so the agent's SessionStart hook
   // records the SAME id in its own state file (terminals/sessions/<pid>.json).
   // That id is the join key that reconciles this launch's pid-registry entry
   // with the hook's authoritative session id even when the hook runs under a
   // different pid (tmux pane leaf / cmd.exe wrapper) — see pid-registry.ts and
-  // session/hook-sessions.ts. Injected into options.env so every downstream env
-  // build (the bare spawn below AND the tmux env prefix in runInTmux) carries it.
-  const launchId = randomUUID();
+  // session/hook-sessions.ts. ADOPT a launch id a `--host` launcher already
+  // forwarded (via `--env AGENT_LAUNCH_ID=…`) so ONE correlation key spans the
+  // SSH hop and the launcher can resolve this run's real session id for every
+  // agent, not just Claude (RUSH-2034); mint a fresh one for every local run.
+  // Injected into options.env so every downstream env build (the bare spawn
+  // below AND the tmux env prefix in runInTmux) carries it.
+  const launchId = resolveLaunchId(options.env?.AGENT_LAUNCH_ID);
   const runId = launchId;
   options = { ...options, env: { ...options.env, AGENT_LAUNCH_ID: launchId } };
   const watcherState = await setupBudgetWatcher(options, cwd, runId);

--- a/apps/cli/src/lib/hosts/remote-session-id.test.ts
+++ b/apps/cli/src/lib/hosts/remote-session-id.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { pickRemoteSessionId } from './remote-session-id.js';
+
+// The demux correlation for interactive non-Claude host runs: the launcher
+// forwards AGENT_LAUNCH_ID, the remote hook writes the agent's REAL session id
+// under that key, and after the stream the launcher reads the remote hook records
+// and resolves the id by launch id. These fixtures are the exact on-disk shape the
+// SessionStart hook writes (packages/session-tracker/src/hook.sh), one JSON object
+// per line — no real agent, no SSH.
+
+// A codex run recorded by the remote hook under our forwarded launch id.
+const codexRecord = JSON.stringify({
+  session_id: 'codex-sess-9f2a',
+  agent: 'codex',
+  cwd: '/home/me/proj',
+  pid: 4242,
+  ts: 1_700,
+  method: 'hook-stdin',
+  launch_id: 'LID-forwarded',
+});
+
+// An unrelated grok run in the same dir under a DIFFERENT launch id.
+const grokRecord = JSON.stringify({
+  session_id: 'grok-sess-1111',
+  agent: 'grok',
+  cwd: '/home/me/other',
+  pid: 5555,
+  ts: 1_900,
+  method: 'hook-env',
+  launch_id: 'LID-other',
+});
+
+describe('pickRemoteSessionId', () => {
+  it('resolves the real session id for the forwarded launch id', () => {
+    const dump = [grokRecord, codexRecord].join('\n');
+    expect(pickRemoteSessionId(dump, 'LID-forwarded')).toBe('codex-sess-9f2a');
+  });
+
+  it('ignores records under a different launch id (no cross-run leak)', () => {
+    // Only the grok record is present; asking for the codex launch id must miss,
+    // not return the co-located grok session.
+    expect(pickRemoteSessionId(grokRecord, 'LID-forwarded')).toBeUndefined();
+  });
+
+  it('resolves each launch id to its OWN session in a multi-run dir', () => {
+    const dump = [codexRecord, grokRecord].join('\n');
+    expect(pickRemoteSessionId(dump, 'LID-forwarded')).toBe('codex-sess-9f2a');
+    expect(pickRemoteSessionId(dump, 'LID-other')).toBe('grok-sess-1111');
+  });
+
+  it('returns undefined for an empty launch id (never a blind first-match)', () => {
+    const dump = [codexRecord].join('\n');
+    expect(pickRemoteSessionId(dump, '')).toBeUndefined();
+  });
+
+  it('returns undefined when the hook record has not landed yet', () => {
+    expect(pickRemoteSessionId('', 'LID-forwarded')).toBeUndefined();
+  });
+
+  it('keeps the NEWEST record (by ts) when a launch id collides — pid reuse / stale file', () => {
+    const stale = JSON.stringify({ session_id: 'codex-STALE', pid: 1, ts: 100, launch_id: 'LID-dup' });
+    const fresh = JSON.stringify({ session_id: 'codex-FRESH', pid: 2, ts: 2_000, launch_id: 'LID-dup' });
+    // Order-independent: the higher ts wins whichever way the records are listed.
+    expect(pickRemoteSessionId([stale, fresh].join('\n'), 'LID-dup')).toBe('codex-FRESH');
+    expect(pickRemoteSessionId([fresh, stale].join('\n'), 'LID-dup')).toBe('codex-FRESH');
+  });
+
+  it('skips a record with an empty/absent session_id (nothing to key on)', () => {
+    const empty = JSON.stringify({ session_id: '', pid: 3, ts: 3_000, launch_id: 'LID-forwarded' });
+    // The empty-id record must not shadow the real one under the same launch id.
+    expect(pickRemoteSessionId([empty, codexRecord].join('\n'), 'LID-forwarded')).toBe('codex-sess-9f2a');
+    // And on its own it resolves to undefined, not '' .
+    expect(pickRemoteSessionId(empty, 'LID-forwarded')).toBeUndefined();
+  });
+
+  it('tolerates a garbled line (partial write / raced read) without throwing', () => {
+    const dump = ['{not json', codexRecord].join('\n');
+    expect(pickRemoteSessionId(dump, 'LID-forwarded')).toBe('codex-sess-9f2a');
+  });
+
+  it('parses records run together on one line (cat without newline separators)', () => {
+    // A `}{` boundary is normalised by the SSH wrapper before this pure parser
+    // sees it; assert the parser handles the already-split shape it is handed.
+    const joined = `${grokRecord}\n${codexRecord}`;
+    expect(pickRemoteSessionId(joined, 'LID-forwarded')).toBe('codex-sess-9f2a');
+  });
+});

--- a/apps/cli/src/lib/hosts/remote-session-id.ts
+++ b/apps/cli/src/lib/hosts/remote-session-id.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolve a remote-created session id back to an interactive `--host` launcher.
+ *
+ * A headless `--host` run captures the remote-coined id from the followed log
+ * (the `--emit-session-id` marker — see session-marker.ts). An INTERACTIVE run
+ * has no followed log: the local TTY is wired straight through `sshStream`
+ * (stdio:'inherit'), so nothing can tap the stream for a marker without breaking
+ * the agent's raw-mode TUI. Instead we correlate by AGENT_LAUNCH_ID.
+ *
+ * The launcher forwards a launch id it controls (`--env AGENT_LAUNCH_ID=<id>`);
+ * the remote `agents run` adopts it (exec.ts `resolveLaunchId`), so the remote
+ * SessionStart hook records the agent's REAL session id under that exact key in
+ * `~/.agents/.cache/terminals/sessions/<pid>.json`. After the stream returns we
+ * do ONE ssh read of that dir and pick the record whose `launch_id` matches —
+ * the same launch-id join `agents sessions --active` uses locally
+ * (session/hook-sessions.ts), just across the SSH hop.
+ *
+ * This gives the interactive path a real per-agent id to register in the local
+ * session index and to reconnect against, for Codex/Kimi/Grok/Gemini — closing
+ * the gap RUSH-2033 left for every non-Claude agent (Claude still forces its own
+ * id up front and never reaches here).
+ */
+
+import { sshExec } from '../ssh-exec.js';
+
+/** The subset of the remote hook record this resolver reads. Extra fields ignored. */
+interface RemoteHookRecord {
+  session_id?: unknown;
+  launch_id?: unknown;
+  ts?: unknown;
+}
+
+/**
+ * Pick the real session id for `launchId` from the remote hook records.
+ *
+ * `recordsJson` is the newline-delimited JSON the remote read emits — one record
+ * per line (a `cat` of every `sessions/*.json`). Scan for the record whose
+ * `launch_id` matches and return its `session_id`; when several match (pid reuse,
+ * a lingering file) the NEWEST by `ts` wins, mirroring the local reader's
+ * keep-newest tie-break (session/hook-sessions.ts). Pure so the correlation is
+ * unit-testable from fixtures with no SSH. Returns undefined when no record
+ * carries the launch id (the hook hasn't landed yet, or a hookless harness).
+ */
+export function pickRemoteSessionId(recordsJson: string, launchId: string): string | undefined {
+  if (!launchId) return undefined;
+  let best: { sid: string; ts: number } | undefined;
+  for (const line of recordsJson.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let rec: RemoteHookRecord;
+    try {
+      rec = JSON.parse(trimmed) as RemoteHookRecord;
+    } catch {
+      continue; // a partial/garbled line — skip, never throw
+    }
+    if (rec.launch_id !== launchId) continue;
+    if (typeof rec.session_id !== 'string' || !rec.session_id) continue;
+    const ts = typeof rec.ts === 'number' ? rec.ts : 0;
+    // Strict `>` so the FIRST record wins a tie — matches keepNewest (hook-sessions.ts).
+    if (!best || ts > best.ts) best = { sid: rec.session_id, ts };
+  }
+  return best?.sid;
+}
+
+/**
+ * Read the remote hook-session dir over ssh and resolve the real session id the
+ * remote run recorded under `launchId`. One round-trip, best-effort: any ssh
+ * failure, a missing dir, or an absent record yields undefined — the caller then
+ * keeps the un-mapped run rather than a fabricated id.
+ *
+ * `$HOME` expands on the REMOTE login shell (never the local box). The glob is a
+ * literal path with no user input, so it is injection-safe; a `2>/dev/null` on a
+ * globless dir keeps the command quiet when the dir is empty or absent.
+ */
+export function resolveRemoteSessionId(target: string, launchId: string, timeoutMs = 6000): string | undefined {
+  if (!launchId) return undefined;
+  // `cat` every record onto its own line. `head -c` caps a runaway file; the
+  // trailing `true` keeps the pipeline's exit 0 even when the glob matches nothing.
+  const cmd = 'cat "$HOME"/.agents/.cache/terminals/sessions/*.json 2>/dev/null | head -c 1048576 || true';
+  const res = sshExec(target, cmd, { timeoutMs, multiplex: true });
+  if (res.code !== 0 && !res.stdout) return undefined;
+  // Each record is a single-line JSON object; `cat` may run them together, so
+  // normalise `}{` boundaries onto separate lines before scanning.
+  const normalised = res.stdout.replace(/\}\s*\{/g, '}\n{');
+  return pickRemoteSessionId(normalised, launchId);
+}

--- a/apps/cli/src/lib/hosts/session-index.ts
+++ b/apps/cli/src/lib/hosts/session-index.ts
@@ -16,7 +16,7 @@
 import * as fs from 'fs';
 import { upsertSession } from '../session/db.js';
 import type { SessionMeta, SessionAgentId } from '../session/types.js';
-import { SESSION_AGENTS } from '../session/types.js';
+import { isSessionTrackedAgent } from '../session/types.js';
 import { localLogPath, updateTask, type HostTask } from './tasks.js';
 import { parseSessionIdMarker } from './session-marker.js';
 import { deriveShortId } from '../session/short-id.js';
@@ -36,7 +36,7 @@ export interface HostSessionContext {
 export function hostSessionMeta(task: HostTask, ctx: HostSessionContext): SessionMeta | null {
   const id = task.sessionId;
   if (!id) return null;
-  if (!SESSION_AGENTS.includes(task.agent as SessionAgentId)) return null;
+  if (!isSessionTrackedAgent(task.agent)) return null;
 
   return {
     id,
@@ -115,7 +115,7 @@ export interface InteractiveHostSessionContext {
  * surface and resume it by id.
  */
 export function registerInteractiveHostSession(ctx: InteractiveHostSessionContext): void {
-  if (!SESSION_AGENTS.includes(ctx.agent as SessionAgentId)) return;
+  if (!isSessionTrackedAgent(ctx.agent)) return;
   try {
     upsertSession(
       {

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -13,6 +13,15 @@ export type SessionAgentId = 'claude' | 'codex' | 'gemini' | 'antigravity' | 'op
 /** All agents with session discovery support, in display order. */
 export const SESSION_AGENTS: SessionAgentId[] = ['claude', 'codex', 'gemini', 'antigravity', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid'];
 
+/**
+ * True when `agent` stores session data `agents sessions` can discover (a member
+ * of {@link SESSION_AGENTS}). The single predicate every session-index writer
+ * gates on, so "is this a trackable agent?" is decided in exactly one place.
+ */
+export function isSessionTrackedAgent(agent: string): agent is SessionAgentId {
+  return (SESSION_AGENTS as string[]).includes(agent);
+}
+
 /** A single normalized event within a session (message, tool call, thinking, etc.). */
 export interface SessionEvent {
   type: 'message' | 'tool_use' | 'tool_result' | 'thinking' | 'error' | 'init' | 'result' | 'usage' | 'attachment';


### PR DESCRIPTION
## What & why

Interactive `agents run --host` only tracked the **real** remote session for Claude. Codex/Kimi/Grok/Gemini coin their own id on the peer and reject a forced `--session-id`, so an interactive host run of any of them showed a stale/absent id locally — `agents sessions` couldn't surface it and a dropped SSH link couldn't auto-reconnect it. RUSH-2033 (PR #1547) fixed only the Claude `--session-id` path; this extends correct tracking to every non-Claude agent.

The fix unifies tracking around **one correlation key the launcher controls end-to-end, `AGENT_LAUNCH_ID`** — exactly the key the SessionStart hook (`packages/session-tracker/src/hook.sh`) already records alongside each agent's real `session_id`.

## How

- **`resolveLaunchId` (`apps/cli/src/lib/exec.ts`)** — the remote `agents run` now **adopts** a launcher-forwarded `AGENT_LAUNCH_ID` instead of always minting a fresh one, so the remote hook writes the agent's real `session_id` under that exact key in `terminals/sessions/<pid>.json`. Every local run passes none and still gets a fresh mint.
- **`apps/cli/src/lib/hosts/remote-session-id.ts` (new)** — after the interactive stream returns there is no followed log to parse a marker from (the TTY streams straight through `sshStream`, `stdio:'inherit'`), so `resolveRemoteSessionId` does one ssh read of the remote hook dir and `pickRemoteSessionId` resolves the real id by launch id (newest-by-`ts` on a collision, mirroring the local reader).
- **Interactive `--host` branch (`apps/cli/src/commands/exec.ts`)** — for every session-tracked agent that isn't Claude/resume, mint + forward the launch id via `--env`, then register the resolved real id in the local session index and use it for auto-reconnect on a dropped link.
- **`isSessionTrackedAgent` (`apps/cli/src/lib/session/types.ts`)** — single predicate the session-index writers gate on; replaces two ad-hoc `SESSION_AGENTS.includes(...)` checks (standardize at source).

## RUSH-2033 (Claude) path preserved

`resolveHostSessionId` still forces Claude's own id up front (`run-target.ts`), so `hostSessionId` is set for Claude and the new `correlationLaunchId` block is skipped entirely — Claude never reaches the new resolver. `run-target.test.ts` (the RUSH-2033 tests) still passes unchanged.

## Acceptance mapping

- *Codex/Kimi/Grok/Gemini via `--host` resolve to the REAL session id, not a stale provisional id* → launch-id adoption + remote hook-record read (`resolveLaunchId` + `resolveRemoteSessionId`), registered via `registerInteractiveHostSession`.
- *Resume/focus targets the correct remote session for non-Claude agents* → `reconnectId = hostSessionId ?? resolvedRemoteId ?? resumeId`.
- *Claude `--host` still behaves as after RUSH-2033* → Claude path untouched; `run-target.test.ts` green.

## Tests (no real agents / SSH — fixtures)

```
$ node ./node_modules/vitest/vitest.mjs run src/lib/hosts/remote-session-id.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ node ./node_modules/vitest/vitest.mjs run src/lib/exec.test.ts -t resolveLaunchId
 Test Files  1 passed (1)
      Tests  5 passed | 67 skipped (72)

$ node ./node_modules/vitest/vitest.mjs run src/lib/hosts/ src/lib/session/types
 Test Files  20 passed (20)
      Tests  244 passed | 1 skipped (245)
```

Repo-level `tsc` and `bun run build` both clean.

Two unrelated pre-existing failures on `origin/main` (not touched by this diff): `exec.test.ts` "codex interactive resume …" (byte-identical to base, drift over `--model gpt-5.5`) and `session/sync/config.test.ts` (R2 bundle-cache timing). Neither is in the session-tracking data path.

## Docs + changelog

- `apps/cli/docs/architecture.md` §4 — new "Across the SSH hop: `AGENT_LAUNCH_ID` is the one correlation key" subsection.
- `apps/cli/.changelog/next/RUSH-2034-interactive-host-session-id.md` — fragment (CHANGELOG.md is generated, not hand-edited).

Linear: RUSH-2034