### PR TITLE
feat(factory): notify on Codex approval blocks (RUSH-2039)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2039.md
+++ b/apps/cli/.changelog/next/RUSH-2039.md
@@ -1,0 +1,12 @@
+- **Codex approval blocks now notify you.** A headless or terminal Codex agent
+  blocked on an approval prompt used to stall silently — the feed/notification path
+  only fired for Claude. Codex emits `PermissionRequest` (not Claude's
+  `Notification`), which the `feed-publish` hook now handles: it publishes an
+  approval-class block with a high cost-of-delay and a `deny` safe-default, so the
+  blocked agent surfaces on `agents feed` and `agents feed --dispatch` pages the
+  phone as urgent. The card clears once the approved tool runs. The feed hooks are
+  also registered for Codex, not Claude only. The Factory extension bridges the same
+  waiting state to an edge-triggered VS Code notification with a "Focus terminal"
+  action. Claude's path is unchanged. Source: `FEED_PUBLISH_HOOK_SCRIPT` /
+  `ensureFeedPublishHook` in `apps/cli/src/lib/feed.ts`,
+  `apps/factory/src/core/waitingNotifier.ts`. (RUSH-2039)

--- a/apps/cli/.changelog/next/RUSH-2039.md
+++ b/apps/cli/.changelog/next/RUSH-2039.md
@@ -4,9 +4,13 @@
   `Notification`), which the `feed-publish` hook now handles: it publishes an
   approval-class block with a high cost-of-delay and a `deny` safe-default, so the
   blocked agent surfaces on `agents feed` and `agents feed --dispatch` pages the
-  phone as urgent. The card clears once the approved tool runs. The feed hooks are
-  also registered for Codex, not Claude only. The Factory extension bridges the same
-  waiting state to an edge-triggered VS Code notification with a "Focus terminal"
-  action. Claude's path is unchanged. Source: `FEED_PUBLISH_HOOK_SCRIPT` /
-  `ensureFeedPublishHook` in `apps/cli/src/lib/feed.ts`,
-  `apps/factory/src/core/waitingNotifier.ts`. (RUSH-2039)
+  phone as urgent. A Codex approval card clears once the approved tool runs, via a
+  matcher-less `PostToolUse` clear hook registered **for Codex only** — so Claude's
+  card lifetime (its `permission_prompt`/`idle_prompt`/`elicitation_dialog`
+  notification blocks persist until `Stop`/`SessionEnd`) and per-tool overhead are
+  exactly as before. The other feed hooks are now registered for Codex too, not
+  Claude only. The Factory extension bridges the same waiting state to an
+  edge-triggered VS Code notification with a "Focus terminal" action. Claude's path
+  is unchanged. Source: `FEED_PUBLISH_HOOK_SCRIPT` / `ensureFeedPublishHook` in
+  `apps/cli/src/lib/feed.ts`, `apps/factory/src/core/waitingNotifier.ts`.
+  (RUSH-2039)

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -342,6 +342,25 @@ cost-of-delay rank, not chronology: idle minutes × downstream blast radius ×
 hourly burn × ask irreducibility. Suppressed stalls and FYIs get zero
 irreducibility, so a fresh cheap ask does not outrank an old critical-path block.
 
+### What publishes a block
+
+Blocks are written by the `feed-publish` hook (`~/.agents/hooks/10-feed-publish.py`,
+installed by `ensureFeedPublishHook`), registered for every hooks-capable agent:
+
+- **AskUserQuestion** (`PreToolUse`) — the structured multiple-choice ask.
+- **Waiting notifications** (`Notification`: `permission_prompt` / `idle_prompt` /
+  `elicitation_dialog`) — Claude's permission/idle prompts.
+- **Codex approval prompts** (`PermissionRequest`) — Codex emits `PermissionRequest`
+  (not Claude's `Notification`) when it blocks on an approval. The hook publishes an
+  **approval-class** block with `costOfDelay: high` and `safeDefault: deny`, so a
+  blocked headless/remote Codex agent surfaces on the feed and `agents feed --dispatch`
+  pages the phone as urgent (RUSH-2039). The card is cleared once the approved tool
+  runs (`PostToolUse`) or the session ends.
+
+The block is cleared on answer (`PostToolUse` for AskUserQuestion, or `UserPromptSubmit`
+in the TUI), on session lifecycle (`Stop` / `SessionEnd`), and — for approval/notification
+cards — as soon as the next tool runs.
+
 The same poll also synthesizes control cards for sessions that are burning
 abnormally without asking (`runaway`) or asking repeatedly (`needy`). Control
 cards are one row per session, with local controls:

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -354,12 +354,16 @@ installed by `ensureFeedPublishHook`), registered for every hooks-capable agent:
   (not Claude's `Notification`) when it blocks on an approval. The hook publishes an
   **approval-class** block with `costOfDelay: high` and `safeDefault: deny`, so a
   blocked headless/remote Codex agent surfaces on the feed and `agents feed --dispatch`
-  pages the phone as urgent (RUSH-2039). The card is cleared once the approved tool
-  runs (`PostToolUse`) or the session ends.
+  pages the phone as urgent (RUSH-2039). The Codex approval card is cleared once the
+  approved tool runs (`PostToolUse`) or the session ends.
 
 The block is cleared on answer (`PostToolUse` for AskUserQuestion, or `UserPromptSubmit`
-in the TUI), on session lifecycle (`Stop` / `SessionEnd`), and — for approval/notification
-cards — as soon as the next tool runs.
+in the TUI) and on session lifecycle (`Stop` / `SessionEnd`). A **Codex** approval card
+additionally clears as soon as the next tool runs — this is a matcher-less `PostToolUse`
+clear hook registered **for Codex only** (`feed-clear-permission`). Claude registers no
+matcher-less `PostToolUse` clear, so its `permission_prompt` / `idle_prompt` /
+`elicitation_dialog` notification cards persist until `Stop` / `SessionEnd` (and its only
+`PostToolUse` feed hook, `feed-clear-answered`, stays matcher-scoped to `AskUserQuestion`).
 
 The same poll also synthesizes control cards for sessions that are burning
 abnormally without asking (`runaway`) or asking repeatedly (`needy`). Control

--- a/apps/cli/src/lib/feed.test.ts
+++ b/apps/cli/src/lib/feed.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as yaml from 'yaml';
 import { spawnSync } from 'child_process';
 import {
   FEED_PUBLISH_HOOK_SCRIPT,
@@ -19,6 +20,8 @@ import {
   listAskStats,
   type OpenBlock,
 } from './feed.js';
+import { classifyBlock, filterBlocksForFeed } from './ask-classifier.js';
+import { isPhoneUrgent, DEFAULT_POLICY } from './feed-policy.js';
 import { loadOperators } from './operator.js';
 
 const hasPython = spawnSync('python3', ['--version']).status === 0;
@@ -414,9 +417,25 @@ describe('feed store', () => {
     expect(updated).toContain('# keep this comment');
     expect(updated).toContain('feed-publish:');
     expect(updated).toContain('feed-publish-notification:');
+    expect(updated).toContain('feed-publish-permission:');
     expect(updated).toContain('feed-clear-answered:');
+    expect(updated).toContain('feed-clear-permission:');
     expect(updated).toContain('feed-clear-lifecycle:');
     expect(fs.readFileSync(path.join(userDir, 'hooks', '10-feed-publish.py'), 'utf-8')).toBe(FEED_PUBLISH_HOOK_SCRIPT);
+  });
+
+  it('installs feed hooks for codex as well as claude (RUSH-2039)', () => {
+    const userDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-codex-install-'));
+    expect(ensureFeedPublishHook(userDir)).toEqual({ installed: true });
+    const yamlText = fs.readFileSync(path.join(userDir, 'agents.yaml'), 'utf-8');
+    // The Codex-only approval hook subscribes to PermissionRequest.
+    expect(yamlText).toContain('feed-publish-permission:');
+    expect(yamlText).toContain('PermissionRequest');
+    // Every feed hook now lists codex so its harness parity is documented.
+    const doc = yaml.parse(yamlText) as { hooks: Record<string, { agents?: string[] }> };
+    for (const name of ['feed-publish', 'feed-publish-notification', 'feed-publish-permission', 'feed-clear-answered', 'feed-clear-permission', 'feed-clear-lifecycle']) {
+      expect(doc.hooks[name].agents).toContain('codex');
+    }
   });
 
   it('recordAnswer claims the first answer and rejects later ones', () => {
@@ -597,5 +616,130 @@ describe('feed store', () => {
     expect(republish.status).toBe(0);
     expect(isBlockAnswered(blockId, feedDir)).toBe(false);
     expect(listBlocks(feedDir)).toMatchObject([{ questions: [{ text: 'Second?' }] }]);
+  });
+
+  // --- RUSH-2039: Codex approval prompts publish urgent feed blocks ---------
+
+  it.runIf(hasPython)('real hook publishes a Codex PermissionRequest as an urgent approval block', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-codex-perm-'));
+    const feedDir = path.join(home, '.agents', '.history', 'feed');
+    const result = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'codex-sess-1',
+        hook_event_name: 'PermissionRequest',
+        permission_mode: 'default',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf build' },
+      }),
+      env: { ...process.env, HOME: home, AGENTS_RUNTIME: 'headless' },
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+    const blocks = listBlocks(feedDir);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'notification',
+      notificationType: 'permission_prompt',
+      blockClass: 'approval',
+      costOfDelay: 'high',
+      safeDefault: 'deny',
+    });
+    // The block names the tool and its command so the operator can judge it.
+    expect(blocks[0].questions[0].text).toContain('Bash');
+    expect(blocks[0].questions[0].text).toContain('rm -rf build');
+    expect(blocks[0].questions[0].header).toBe('Approval needed');
+  });
+
+  it.runIf(hasPython)('real hook clears a Codex approval block once the approved tool runs', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-codex-clear-'));
+    const feedDir = path.join(home, '.agents', '.history', 'feed');
+    const publish = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'codex-sess-2',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(publish.status).toBe(0);
+    expect(listBlocks(feedDir)).toHaveLength(1);
+
+    // Codex runs the approved tool -> matcher-less PostToolUse clears the card.
+    const clear = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'codex-sess-2',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(clear.status).toBe(0);
+    expect(listBlocks(feedDir)).toEqual([]);
+  });
+
+  it.runIf(hasPython)('matcher-less PostToolUse does not wipe an open AskUserQuestion mid-turn', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-question-guard-'));
+    const feedDir = path.join(home, '.agents', '.history', 'feed');
+    const publish = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'sess-q-guard',
+        hook_event_name: 'PreToolUse',
+        tool_input: { questions: [{ question: 'Which approach?' }] },
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(publish.status).toBe(0);
+    expect(listBlocks(feedDir)).toHaveLength(1);
+
+    // An unrelated tool completing must NOT clear the open question.
+    const unrelated = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'sess-q-guard',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(unrelated.status).toBe(0);
+    expect(listBlocks(feedDir)).toMatchObject([{ kind: 'question', questions: [{ text: 'Which approach?' }] }]);
+
+    // The AskUserQuestion PostToolUse still clears it.
+    const answer = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'sess-q-guard',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'AskUserQuestion',
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(answer.status).toBe(0);
+    expect(listBlocks(feedDir)).toEqual([]);
+  });
+
+  it('feed --dispatch classifies a Codex approval block as urgent and surfaces it', () => {
+    // Mirror the block the hook publishes for a Codex PermissionRequest.
+    const block = makeBlock('codex-dispatch', 'Codex needs approval to run Bash: rm -rf build', {
+      runtime: 'headless',
+      kind: 'notification',
+      notificationType: 'permission_prompt',
+      blockClass: 'approval',
+      costOfDelay: 'high',
+      safeDefault: 'deny',
+      questions: [{ text: 'Codex needs approval to run Bash: rm -rf build', header: 'Approval needed' }],
+    });
+
+    // Not suppressed as a stall, and classified as an approval.
+    const filtered = filterBlocksForFeed([block]);
+    expect(filtered.surfaced).toHaveLength(1);
+    expect(classifyBlock(block).class).toBe('approval');
+
+    // Urgent under the default policy (costOfDelay high >= threshold medium).
+    expect(isPhoneUrgent(block, DEFAULT_POLICY)).toBe(true);
   });
 });

--- a/apps/cli/src/lib/feed.test.ts
+++ b/apps/cli/src/lib/feed.test.ts
@@ -431,11 +431,73 @@ describe('feed store', () => {
     // The Codex-only approval hook subscribes to PermissionRequest.
     expect(yamlText).toContain('feed-publish-permission:');
     expect(yamlText).toContain('PermissionRequest');
-    // Every feed hook now lists codex so its harness parity is documented.
+    // Every feed hook lists codex so its harness parity is documented.
     const doc = yaml.parse(yamlText) as { hooks: Record<string, { agents?: string[] }> };
     for (const name of ['feed-publish', 'feed-publish-notification', 'feed-publish-permission', 'feed-clear-answered', 'feed-clear-permission', 'feed-clear-lifecycle']) {
       expect(doc.hooks[name].agents).toContain('codex');
     }
+  });
+
+  it('scopes the matcher-less PostToolUse clear to codex only, leaving Claude unchanged (RUSH-2039)', () => {
+    const userDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-clear-scope-'));
+    expect(ensureFeedPublishHook(userDir)).toEqual({ installed: true });
+    const doc = yaml.parse(fs.readFileSync(path.join(userDir, 'agents.yaml'), 'utf-8')) as {
+      hooks: Record<string, { agents?: string[]; events?: string[]; matcher?: string }>;
+    };
+    // feed-clear-permission fires on EVERY PostToolUse (it has no matcher), so
+    // registering it for Claude would add per-tool overhead AND delete Claude's
+    // notification-kind blocks the moment any later tool runs. Codex-only keeps
+    // Claude's card lifetime (persist to Stop/SessionEnd) exactly as before.
+    expect(doc.hooks['feed-clear-permission'].agents).toEqual(['codex']);
+    expect(doc.hooks['feed-clear-permission'].agents).not.toContain('claude');
+    expect(doc.hooks['feed-clear-permission'].matcher).toBeUndefined();
+    // The ONLY PostToolUse feed hook Claude still registers is the answered
+    // clear, and it is matcher-scoped to AskUserQuestion -- so an unrelated
+    // Claude tool completion never touches a notification-kind block.
+    expect(doc.hooks['feed-clear-answered'].agents).toContain('claude');
+    expect(doc.hooks['feed-clear-answered'].events).toEqual(['PostToolUse']);
+    expect(doc.hooks['feed-clear-answered'].matcher).toBe('AskUserQuestion');
+    expect(doc.hooks['feed-clear-permission'].events).toEqual(['PostToolUse']);
+  });
+
+  it.runIf(hasPython)('a plain PostToolUse clears a notification block at the script level -- which is why Claude must NOT register the matcher-less clear', () => {
+    // The script is agent-blind: it clears on hook_event_name alone. So if a
+    // matcher-less PostToolUse (any tool completion) were delivered for Claude,
+    // it WOULD delete Claude's notification-kind card -- that is the exact
+    // regression. This test pins that causal fact at the script level; the
+    // manifest test above pins the fix (Claude does not register the hook, so
+    // its plain tool completions never reach the script and the card persists
+    // to Stop/SessionEnd as it did before RUSH-2039).
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-notif-clear-'));
+    const feedDir = path.join(home, '.agents', '.history', 'feed');
+    const publish = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'notif-clear-sess',
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt',
+        title: 'Permission needed',
+        message: 'Claude needs permission to use Bash',
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(publish.status).toBe(0);
+    expect(listBlocks(feedDir)).toMatchObject([{ kind: 'notification', notificationType: 'permission_prompt' }]);
+
+    // A plain (non-AskUserQuestion) PostToolUse -- what feed-clear-permission
+    // delivered for EVERY Claude tool before the fix -- clears the card. The
+    // question-guard at feed.ts:546-553 preserves only kind == 'question'.
+    const plainPostToolUse = spawnSync('python3', ['-c', FEED_PUBLISH_HOOK_SCRIPT], {
+      input: JSON.stringify({
+        session_id: 'notif-clear-sess',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+      }),
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    expect(plainPostToolUse.status).toBe(0);
+    expect(listBlocks(feedDir)).toEqual([]);
   });
 
   it('recordAnswer claims the first answer and rejects later ones', () => {

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -884,10 +884,16 @@ export function ensureFeedPublishHook(userAgentsDir: string = getUserAgentsDir()
         timeout: 5,
       },
       // Matcher-less PostToolUse clear: after Codex runs an approved tool, the
-      // approval card is stale, so clear it. Kind-aware in the script so it
-      // never wipes an open AskUserQuestion mid-turn (see CLEAR_EVENTS handler).
+      // approval card is stale, so clear it. Codex-only on purpose -- Claude
+      // never fires PermissionRequest, so it has no approval card to clear here,
+      // and a matcher-less PostToolUse for Claude would (1) re-run the script on
+      // every tool completion and (2) wipe Claude's notification-kind blocks
+      // (permission_prompt/idle_prompt/elicitation_dialog) the moment any later
+      // tool runs, instead of letting them persist to Stop/SessionEnd like they
+      // did before RUSH-2039. Registering it for codex alone keeps Claude's
+      // card lifetime exactly as it was.
       'feed-clear-permission': {
-        agents: ['claude', 'codex'],
+        agents: ['codex'],
         events: ['PostToolUse'],
         script: '10-feed-publish.py',
         timeout: 5,

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -484,6 +484,10 @@ CLEAR_EVENTS = {
     "Stop",
     "SessionEnd",
 }
+# Codex emits a PermissionRequest event (not Claude's Notification) when it
+# blocks on an approval prompt. Claude never fires PermissionRequest, so the
+# same script handles both: PermissionRequest maps to an approval-class block
+# with a high cost-of-delay so 'agents feed --dispatch' pages it as urgent.
 
 
 def read_json(path):
@@ -534,6 +538,19 @@ def main():
     hook_event = payload.get("hook_event_name", "PreToolUse")
 
     if hook_event in CLEAR_EVENTS:
+        # A matcher-less PostToolUse clear (registered for Codex so an approved
+        # tool clears its approval card) must NOT wipe an open AskUserQuestion
+        # while an unrelated tool runs mid-question -- those are cleared only by
+        # the AskUserQuestion-matched PostToolUse. So on PostToolUse, keep a
+        # 'question' block; approval/notification blocks clear once the tool runs.
+        if hook_event == "PostToolUse":
+            try:
+                with open(target) as existing_file:
+                    existing = json.load(existing_file)
+                if existing.get("kind") == "question" and payload.get("tool_name") != "AskUserQuestion":
+                    return
+            except Exception:
+                pass
         try:
             os.unlink(target)
         except FileNotFoundError:
@@ -578,6 +595,7 @@ def main():
         return
 
     notification_type = None
+    codex_approval = False
     if hook_event == "Notification":
         notification_type = payload.get("notification_type", "")
         if notification_type not in WAITING_NOTIFICATION_TYPES:
@@ -602,6 +620,34 @@ def main():
             "multiSelect": False,
         }]
         kind = "notification"
+    elif hook_event == "PermissionRequest":
+        # Codex approval prompt. The payload mirrors PreToolUse (tool_name,
+        # tool_input) but carries no questions -- Codex is asking to run a tool,
+        # not asking the operator a multiple-choice question. Publish it as a
+        # notification-kind approval block naming the tool so the feed and the
+        # phone notifier can surface it, and so the Factory extension can bridge
+        # it to a VS Code notification.
+        tool_name = payload.get("tool_name") or "a tool"
+        tool_input = payload.get("tool_input", {})
+        command = ""
+        if isinstance(tool_input, dict):
+            command = (
+                tool_input.get("command")
+                or tool_input.get("cmd")
+                or tool_input.get("path")
+                or ""
+            )
+            if isinstance(command, list):
+                command = " ".join(str(c) for c in command)
+        detail = f": {command}" if command else ""
+        normalized_questions = [{
+            "text": f"Codex needs approval to run {tool_name}{detail}",
+            "header": "Approval needed",
+            "multiSelect": False,
+        }]
+        kind = "notification"
+        notification_type = "permission_prompt"
+        codex_approval = True
     else:
         tool_input = payload.get("tool_input", {})
         questions = tool_input.get("questions", [])
@@ -671,9 +717,21 @@ def main():
     if notification_type:
         block["notificationType"] = notification_type
 
+    # A Codex PermissionRequest is a real approval gate: mark it approval-class
+    # with a high cost-of-delay so 'agents feed --dispatch' classifies it urgent
+    # (isPhoneUrgent gates on costOfDelay >= phoneNotifyThreshold, default
+    # 'medium') and pages the phone. A plain 'deny' is the safe default.
+    if codex_approval:
+        block["blockClass"] = "approval"
+        block["costOfDelay"] = "high"
+        block["safeDefault"] = "deny"
+
     # Optional multi-operator control metadata passed by the agent in the
-    # AskUserQuestion tool_input. Defaults keep the existing behavior.
-    controls = payload.get("tool_input", {}) if hook_event != "Notification" else {}
+    # AskUserQuestion tool_input. Defaults keep the existing behavior. A Codex
+    # PermissionRequest carries tool ARGS in tool_input (command/path), not
+    # operator controls, so it is excluded here -- its class/cost is stamped
+    # above from codex_approval.
+    controls = payload.get("tool_input", {}) if hook_event not in ("Notification", "PermissionRequest") else {}
     block_class = controls.get("blockClass") if isinstance(controls, dict) else None
     if block_class in ("approval", "decision"):
         block["blockClass"] = block_class
@@ -743,6 +801,16 @@ export const FEED_NOTIFICATION_HOOK_MANIFEST = {
   timeout: 5,
 };
 
+// Codex fires PermissionRequest (not Claude's Notification) when it blocks on an
+// approval prompt. The same script handles it, publishing a high-cost approval
+// block so the feed dispatch pages the phone. PermissionRequest has no matcher.
+export const FEED_PERMISSION_HOOK_MANIFEST = {
+  name: 'feed-publish-permission',
+  events: ['PermissionRequest'],
+  script: '10-feed-publish.py',
+  timeout: 5,
+};
+
 export const FEED_ANSWERED_HOOK_MANIFEST = {
   name: 'feed-clear-answered',
   events: ['PostToolUse'],
@@ -787,28 +855,45 @@ export function ensureFeedPublishHook(userAgentsDir: string = getUserAgentsDir()
     }
     const desiredHooks: Record<string, Record<string, unknown>> = {
       'feed-publish': {
-        agents: ['claude'],
+        agents: ['claude', 'codex'],
         events: ['PreToolUse'],
         matcher: 'AskUserQuestion',
         script: '10-feed-publish.py',
         timeout: 5,
       },
       'feed-publish-notification': {
-        agents: ['claude'],
+        agents: ['claude', 'codex'],
         events: ['Notification'],
         matcher: 'permission_prompt|idle_prompt|elicitation_dialog',
         script: '10-feed-publish.py',
         timeout: 5,
       },
+      // Codex-specific approval gate: Codex emits PermissionRequest (Claude does
+      // not), so this hook is where a blocked Codex agent surfaces to the feed.
+      'feed-publish-permission': {
+        agents: ['claude', 'codex'],
+        events: ['PermissionRequest'],
+        script: '10-feed-publish.py',
+        timeout: 5,
+      },
       'feed-clear-answered': {
-        agents: ['claude'],
+        agents: ['claude', 'codex'],
         events: ['PostToolUse'],
         matcher: 'AskUserQuestion',
         script: '10-feed-publish.py',
         timeout: 5,
       },
+      // Matcher-less PostToolUse clear: after Codex runs an approved tool, the
+      // approval card is stale, so clear it. Kind-aware in the script so it
+      // never wipes an open AskUserQuestion mid-turn (see CLEAR_EVENTS handler).
+      'feed-clear-permission': {
+        agents: ['claude', 'codex'],
+        events: ['PostToolUse'],
+        script: '10-feed-publish.py',
+        timeout: 5,
+      },
       'feed-clear-lifecycle': {
-        agents: ['claude'],
+        agents: ['claude', 'codex'],
         events: ['Stop', 'UserPromptSubmit', 'SessionEnd'],
         script: '10-feed-publish.py',
         timeout: 5,

--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -53,6 +53,7 @@ bash scripts/install.sh <version>   # Package .vsix and install to Cursor + Code
 | Settings shape + defaults | `src/core/settings.ts` (AgentSettings interface) |
 | Agent metadata (titles, prefixes, icons) | `src/core/agents.ts` (`BUILT_IN_AGENTS`, presentation overlay) + `src/core/agents.cli.ts` (CLI registry snapshot — id set, launch binaries) |
 | Live session state (activity, waiting, tok/s) | the CLI payload: `agents sessions --active --json` via `src/vscode/remoteSessions.vscode.ts` (`fetchLocalSessions`), normalized in `src/core/remoteSessions.ts`. Per-line panel feed parsing only: `src/core/session.activity.ts` |
+| Approval-waiting notifications (RUSH-2039) | Edge-triggered VS Code `showInformationMessage` + "Focus terminal" when a session (Codex included, via the CLI's `PermissionRequest` feed hook) enters `waitingForInput`. Pure edge logic: `src/core/waitingNotifier.ts` (`detectNewlyWaiting`); VS Code surface: `src/vscode/waitingNotifier.vscode.ts` (`notifyNewlyWaiting`), driven from `pushFloorUpdate` in `src/vscode/settings.vscode.ts`. Reveal by session: `terminals.getBySessionId`. |
 | Prewarming pool | `src/core/prewarm.ts`, `src/vscode/prewarm.vscode.ts` |
 | Autogit | `src/core/git.ts`, `src/vscode/git.vscode.ts` |
 | Unified task aggregation (markdown / Linear / GitHub) | `src/core/tasks.ts`, `src/vscode/tasks.vscode.ts` |

--- a/apps/factory/src/core/waitingNotifier.test.ts
+++ b/apps/factory/src/core/waitingNotifier.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  detectNewlyWaiting,
+  formatWaitingMessage,
+  type WaitingSessionInput,
+} from './waitingNotifier';
+
+function s(sessionId: string, waiting: boolean, extra?: Partial<WaitingSessionInput>): WaitingSessionInput {
+  return { sessionId, agentType: 'codex', waitingForInput: waiting, ...extra };
+}
+
+describe('detectNewlyWaiting (RUSH-2039)', () => {
+  test('fires on the rising edge — a session entering the waiting state', () => {
+    const { newlyWaiting, nextWaiting } = detectNewlyWaiting(new Set(), [s('codex-1', true)]);
+    expect(newlyWaiting.map((n) => n.sessionId)).toEqual(['codex-1']);
+    expect(nextWaiting.has('codex-1')).toBe(true);
+  });
+
+  test('does not re-fire while a session stays waiting', () => {
+    const first = detectNewlyWaiting(new Set(), [s('codex-1', true)]);
+    const second = detectNewlyWaiting(first.nextWaiting, [s('codex-1', true)]);
+    expect(second.newlyWaiting).toEqual([]);
+    expect(second.nextWaiting.has('codex-1')).toBe(true);
+  });
+
+  test('re-fires after a session leaves and re-enters the waiting state', () => {
+    const enter = detectNewlyWaiting(new Set(), [s('codex-1', true)]);
+    const leave = detectNewlyWaiting(enter.nextWaiting, [s('codex-1', false)]);
+    expect(leave.newlyWaiting).toEqual([]);
+    expect(leave.nextWaiting.has('codex-1')).toBe(false);
+    const reenter = detectNewlyWaiting(leave.nextWaiting, [s('codex-1', true)]);
+    expect(reenter.newlyWaiting.map((n) => n.sessionId)).toEqual(['codex-1']);
+  });
+
+  test('a Claude session waiting fires too (no regression, harness parity)', () => {
+    const { newlyWaiting } = detectNewlyWaiting(new Set(), [
+      s('claude-1', true, { agentType: 'claude' }),
+      s('codex-1', true),
+    ]);
+    expect(newlyWaiting.map((n) => n.sessionId).sort()).toEqual(['claude-1', 'codex-1']);
+  });
+
+  test('ignores non-waiting and session-less rows', () => {
+    const { newlyWaiting } = detectNewlyWaiting(new Set(), [
+      s('idle', false),
+      { sessionId: null, agentType: 'codex', waitingForInput: true },
+    ]);
+    expect(newlyWaiting).toEqual([]);
+  });
+
+  test('label falls back to "<agentType> session" when unlabeled', () => {
+    const { newlyWaiting } = detectNewlyWaiting(new Set(), [s('codex-1', true, { label: '   ' })]);
+    expect(newlyWaiting[0].label).toBe('codex session');
+    const labeled = detectNewlyWaiting(new Set(), [s('codex-1', true, { label: 'refactor-auth' })]);
+    expect(labeled.newlyWaiting[0].label).toBe('refactor-auth');
+  });
+
+  test('formatWaitingMessage names the session and asks for approval', () => {
+    expect(formatWaitingMessage({ sessionId: 'codex-1', agentType: 'codex', label: 'refactor-auth' }))
+      .toBe('refactor-auth is waiting for your approval.');
+  });
+});

--- a/apps/factory/src/core/waitingNotifier.ts
+++ b/apps/factory/src/core/waitingNotifier.ts
@@ -1,0 +1,66 @@
+/**
+ * Waiting/approval notification transition logic (RUSH-2039).
+ *
+ * The Factory Floor already knows when a session is blocked waiting for input
+ * (`TerminalDetail.waitingForInput`, fed by the CLI's own state engine — for
+ * Codex this is now driven by the PermissionRequest feed hook). But knowing it
+ * and telling the user are two different things: before this, a blocked Codex
+ * agent stalled silently. This module turns the per-poll waiting state into
+ * edge-triggered notifications: fire once when a session ENTERS the waiting
+ * state, never again until it leaves and re-enters.
+ *
+ * Pure on purpose (no VS Code deps) so the edge detection is unit-testable; the
+ * VS Code surface (showInformationMessage + "Focus terminal") lives in
+ * waitingNotifier.vscode.ts.
+ */
+
+/** The minimal per-session shape the transition logic needs. */
+export interface WaitingSessionInput {
+  sessionId: string | null;
+  agentType: string;
+  label?: string | null;
+  waitingForInput?: boolean;
+}
+
+/** A session that just transitioned into the waiting state this poll. */
+export interface NewlyWaiting {
+  sessionId: string;
+  agentType: string;
+  label: string;
+}
+
+/**
+ * Given the set of session ids that were waiting last poll and the current
+ * floor sessions, compute:
+ *   - `newlyWaiting`: sessions that entered the waiting state this poll (edge)
+ *   - `nextWaiting`: the set to carry into the next poll
+ *
+ * A session only appears in `newlyWaiting` on the rising edge — the poll where
+ * it flips false→true. It is dropped from the carried set once it stops
+ * waiting, so a later re-entry fires again.
+ */
+export function detectNewlyWaiting(
+  previousWaiting: ReadonlySet<string>,
+  current: readonly WaitingSessionInput[],
+): { newlyWaiting: NewlyWaiting[]; nextWaiting: Set<string> } {
+  const nextWaiting = new Set<string>();
+  const newlyWaiting: NewlyWaiting[] = [];
+
+  for (const s of current) {
+    if (!s.sessionId || s.waitingForInput !== true) continue;
+    nextWaiting.add(s.sessionId);
+    if (previousWaiting.has(s.sessionId)) continue; // already notified this cycle
+    newlyWaiting.push({
+      sessionId: s.sessionId,
+      agentType: s.agentType,
+      label: (s.label && s.label.trim()) || `${s.agentType} session`,
+    });
+  }
+
+  return { newlyWaiting, nextWaiting };
+}
+
+/** Human notification text for a session blocked on approval/input. */
+export function formatWaitingMessage(s: NewlyWaiting): string {
+  return `${s.label} is waiting for your approval.`;
+}

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -13,6 +13,7 @@ import { readPromptsFromPath, writePromptsToPath, DEFAULT_PROMPTS } from '../cor
 import { openExternalUrl, isAllowedWebviewCommand } from './webviewSecurity';
 import * as terminals from './terminals.vscode';
 import * as swarm from './swarm.vscode';
+import { notifyNewlyWaiting } from './waitingNotifier.vscode';
 import { fetchAllTasks, detectAvailableSources } from './tasks.vscode';
 import { getBuiltInByTitle, configFromDef } from './agents.vscode';
 import { openSingleAgentWithQueue, runHeadlessAgent, focusSessionInTerminal } from './extension';
@@ -1155,6 +1156,9 @@ async function pushFloorUpdate(workspacePath?: string): Promise<void> {
   ]);
   if (!settingsPanel || !floorSubscribed) return;
   lastFloorTasks = floorTasks;
+  // RUSH-2039: page the user when a session (Codex included) enters the
+  // approval-waiting state. Edge-triggered so it fires once per wait.
+  notifyNewlyWaiting(floorTerminals);
   settingsPanel.webview.postMessage({ type: 'allTerminalsData', terminals: floorTerminals });
   settingsPanel.webview.postMessage({ type: 'tasksData', tasks: floorTasks });
   // Re-reconcile so newly-spawned terminals get watched too.

--- a/apps/factory/src/vscode/terminals.vscode.ts
+++ b/apps/factory/src/vscode/terminals.vscode.ts
@@ -225,6 +225,21 @@ export function getById(id: string): EditorTerminal | undefined {
   return editorTerminals.get(id);
 }
 
+/**
+ * The live editor-terminal entry for a CLI session id, if one is tracked in
+ * this window. Used to reveal the terminal from an approval-waiting
+ * notification (RUSH-2039). Skips entries whose process has exited.
+ */
+export function getBySessionId(sessionId: string): EditorTerminal | undefined {
+  if (!sessionId) return undefined;
+  for (const entry of editorTerminals.values()) {
+    if (entry.sessionId === sessionId && entry.terminal.exitStatus === undefined) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
 export function getAllTerminals(): EditorTerminal[] {
   return Array.from(editorTerminals.values());
 }

--- a/apps/factory/src/vscode/waitingNotifier.vscode.ts
+++ b/apps/factory/src/vscode/waitingNotifier.vscode.ts
@@ -1,0 +1,53 @@
+/**
+ * VS Code surface for waiting/approval notifications (RUSH-2039).
+ *
+ * Bridges the Floor's `waitingForInput` signal (which now fires for Codex
+ * approval prompts via the PermissionRequest feed hook) to a native VS Code
+ * notification with a "Focus terminal" action. Edge-triggered via
+ * detectNewlyWaiting so a session pages once per wait, not every 10s poll.
+ */
+import * as vscode from 'vscode';
+import * as terminals from './terminals.vscode';
+import {
+  detectNewlyWaiting,
+  formatWaitingMessage,
+  type WaitingSessionInput,
+} from '../core/waitingNotifier';
+
+// Session ids that were waiting at the previous poll — the edge-detection state.
+let waitingSessions = new Set<string>();
+
+const FOCUS_ACTION = 'Focus terminal';
+
+/**
+ * Called once per floor poll with the current terminal details. Fires a
+ * notification for each session that just entered the waiting state.
+ */
+export function notifyNewlyWaiting(current: readonly terminals.TerminalDetail[]): void {
+  const inputs: WaitingSessionInput[] = current.map((t) => ({
+    sessionId: t.sessionId,
+    agentType: t.agentType,
+    label: t.label ?? t.autoLabel ?? null,
+    waitingForInput: t.waitingForInput,
+  }));
+
+  const { newlyWaiting, nextWaiting } = detectNewlyWaiting(waitingSessions, inputs);
+  waitingSessions = nextWaiting;
+
+  for (const s of newlyWaiting) {
+    const message = formatWaitingMessage(s);
+    // Non-blocking: the reveal fires from the button, the poll loop never waits.
+    void vscode.window.showInformationMessage(message, FOCUS_ACTION).then((choice) => {
+      if (choice !== FOCUS_ACTION) return;
+      const entry = terminals.getBySessionId(s.sessionId);
+      if (entry) {
+        entry.terminal.show(true);
+      }
+    });
+  }
+}
+
+/** Reset the edge-detection state (deactivation / tests). */
+export function resetWaitingNotifierState(): void {
+  waitingSessions = new Set<string>();
+}


### PR DESCRIPTION
## What

A headless or terminal **Codex** agent blocked on an approval prompt used to stall silently — the feed / phone-notification path only fired for **Claude**. This wires the same existing feed → block → dispatch → notify path for Codex, and bridges the Floor's waiting state to a VS Code notification.

## Why

Codex emits a `PermissionRequest` hook event when it blocks on an approval; Claude emits a `Notification`. The `feed-publish` hook only subscribed to `Notification` and was registered as `agents: ['claude']`, so Codex's approval prompt never produced a feed block — and the Floor saw `waitingForInput` but never told the user. Four concrete gaps (feed hooks Claude-only; Codex's `PermissionRequest` unhandled; Floor `waitingForInput` never notified; approval blocks not classified urgent).

## The fix (reuses existing infra — no parallel notification system)

**CLI (`apps/cli`)**
- `FEED_PUBLISH_HOOK_SCRIPT` (`src/lib/feed.ts`) now handles `hook_event_name == "PermissionRequest"`: builds a notification-kind block naming the tool + command, stamped `blockClass: approval`, `costOfDelay: high`, `safeDefault: deny`. That makes `isPhoneUrgent` fire (default threshold `medium`) so `agents feed --dispatch` pages via the existing `notifyUrgentBlock`, and `applyPolicyToBlock` has a safe default.
- Matcher-less `PostToolUse` clear (`feed-clear-permission`) so an approved Codex tool clears its own card. Registered **for Codex only** (`agents: ['codex']`) — a matcher-less `PostToolUse` fires on *every* tool completion, and the script is agent-blind, so registering it for Claude would (1) re-run the hook on every Claude tool and (2) delete Claude's `permission_prompt` / `idle_prompt` / `elicitation_dialog` notification cards the moment any later tool ran. Claude never emits `PermissionRequest` and has no approval card to clear here, so codex-only keeps Claude's card lifetime (persist to `Stop` / `SessionEnd`) and per-tool overhead exactly as before. The script stays kind-aware so an open `AskUserQuestion` is never wiped mid-turn.
- `ensureFeedPublishHook` registers the publish/lifecycle feed hooks for `codex` (not just `claude`) and adds the `feed-publish-permission` (`PermissionRequest`) hook.

**Factory (`apps/factory`)**
- `src/core/waitingNotifier.ts` — pure edge detection (`detectNewlyWaiting`): fires once on the false→true `waitingForInput` transition, re-fires only after leave+re-enter.
- `src/vscode/waitingNotifier.vscode.ts` — `showInformationMessage` + "Focus terminal" (reveals via new `terminals.getBySessionId`), driven from `pushFloorUpdate`.

**Claude path is unchanged.** The only new `PostToolUse` feed hook (`feed-clear-permission`) is registered for Codex only, so Claude registers no matcher-less `PostToolUse` clear — its notification-card lifetime and per-tool overhead are identical to before this change. Claude's sole `PostToolUse` feed hook remains `feed-clear-answered`, matcher-scoped to `AskUserQuestion`. Pinned by tests (below).

## Acceptance mapping

- *Codex blocked on approval → user gets a notification naming the session, offering to focus it* → feed block (phone via `--dispatch`) + VS Code notification with "Focus terminal".
- *Claude path continues to work* → existing feed tests green; new Codex handling is a separate `elif` branch, and the matcher-less clear is Codex-scoped.

## Tests

`apps/cli` — `node ./node_modules/vitest/vitest.mjs run src/lib/feed.test.ts`
```
 Test Files  1 passed (1)
      Tests  37 passed (37)
```
Cases include: Codex `PermissionRequest` → urgent approval block; **a Codex approval block clears once the approved tool runs**; matcher-less `PostToolUse` does NOT wipe an open `AskUserQuestion`; `feed --dispatch` classifies the Codex block urgent; install writes codex + the permission hook. New in this revision: **`feed-clear-permission` is scoped to `['codex']` only, leaving Claude unchanged** (manifest-level pin — Claude registers no matcher-less clear; `feed-clear-answered` stays matcher-scoped to `AskUserQuestion`), and a script-level test showing a plain (non-`AskUserQuestion`) `PostToolUse` *would* clear a notification card — which is exactly why Claude must not register it.

`apps/factory` — `bun test src/core/waitingNotifier.test.ts`
```
 7 pass
 0 fail
Ran 7 tests across 1 file.
```

## Docs + changelog

- `apps/cli/docs/06-observability.md` — "What publishes a block" section (Codex `PermissionRequest`), and the clear-lifecycle paragraph now states the matcher-less clear is Codex-only and Claude's cards persist to `Stop` / `SessionEnd`.
- `apps/factory/AGENTS.md` — area row for the approval-waiting notification.
- Changelog fragment: `apps/cli/.changelog/next/RUSH-2039.md` — states the Codex-only clear and that Claude's path is unchanged (CHANGELOG.md is generated, not hand-edited).
