### PR TITLE
feat(sessions): smart launch — device/harness affinity + balanced accounts

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2049.md
+++ b/apps/cli/.changelog/next/RUSH-2049.md
@@ -12,3 +12,4 @@
 - **Agents extension New Agent launches with `--smart`.** Unpinned interactive
   launches (no Pick Host / version pin) append `--smart` so the CLI affinity-picks
   the host. Source: `apps/factory/src/vscode/extension.ts` `buildAgentLaunchCommand`.
+

--- a/apps/cli/.changelog/next/RUSH-2049.md
+++ b/apps/cli/.changelog/next/RUSH-2049.md
@@ -1,0 +1,14 @@
+- **Smart launch: device/harness affinity + balanced accounts (`--smart`) (RUSH-2049).**
+  Sessions index now persists `machine` (schema v18) so affinity can `GROUP BY machine`.
+  New `queryAffinityRollup` returns launch counts by device, harness, or joint.
+  `resolveSmartLaunch` samples hosts/harnesses with weight ∝ launches^α (most-used
+  highest probability; online hosts with no history still explore at weight 1).
+  Account pick stays the existing balanced strategy (live session/week rate-limit
+  windows). CLI: `agents run claude --smart …` picks host from affinity;
+  `agents run auto --smart …` also picks among claude/codex/kimi. Explicit `--host`
+  / `@version` pins still win. Source: `apps/cli/src/lib/session/db.ts`,
+  `origin-machine.ts`, `smart-launch.ts`, `commands/exec.ts`.
+
+- **Agents extension New Agent launches with `--smart`.** Unpinned interactive
+  launches (no Pick Host / version pin) append `--smart` so the CLI affinity-picks
+  the host. Source: `apps/factory/src/vscode/extension.ts` `buildAgentLaunchCommand`.

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -739,8 +739,24 @@ export function registerRunCommand(program: Command): void {
         process.exit(1);
       }
 
+      // Account-picker conflict check runs BEFORE --smart mutates options.balanced,
+      // so an implicit smart→balanced preference never surfaces as a fake
+      // "cannot be combined with --balanced" when the user only typed trailing @.
+      if (accountPickerRequested) {
+        const conflicts = runAccountPickerConflicts(options);
+        if (conflicts.length > 0) {
+          console.error(chalk.red(
+            `Account selection with ${agentSpec} cannot be combined with ${conflicts.join(', ')}. ` +
+            'Pick the account locally, or use an explicit agent@version target.',
+          ));
+          process.exit(1);
+        }
+      }
+
       // --smart: affinity-pick host (and optional harness when agent is "auto").
-      // Explicit --host/--device wins. Account rotation stays --strategy balanced.
+      // Explicit --host/--device wins. Account rotation stays --strategy balanced
+      // unless the user is already on the trailing-@ account picker (they own
+      // account selection then — do not force balanced underneath them).
       if (options.smart) {
         const hostAlready = [options.host, options.device, options.on, options.computer].some(Boolean);
         const [agentName, rawVersionPin] = normalizedAgentSpec.split('@');
@@ -762,8 +778,9 @@ export function registerRunCommand(program: Command): void {
             if (pickHarness) {
               normalizedAgentSpec = plan.agent;
             }
-            // Prefer balanced for smart launches unless the user overrode strategy.
-            if (!options.strategy && !options.balanced) {
+            // Prefer balanced for smart launches unless the user overrode strategy
+            // or requested the interactive account picker (trailing @).
+            if (!accountPickerRequested && !options.strategy && !options.balanced) {
               options.balanced = true;
             }
             if (!options.quiet) {
@@ -772,11 +789,14 @@ export function registerRunCommand(program: Command): void {
                 .slice(0, 4)
                 .map((c) => `${c.key}:${c.launches}`)
                 .join(', ');
+              const acctNote = accountPickerRequested
+                ? 'accounts=picker'
+                : 'accounts=balanced';
               process.stderr.write(
                 chalk.gray(
                   `[agents] smart: host=${hostLabel} agent=${pickHarness ? plan.agent : agentName}` +
                     (deviceHint ? ` (device affinity ${deviceHint})` : '') +
-                    ` · accounts=balanced\n`,
+                    ` · ${acctNote}\n`,
                 ),
               );
             }
@@ -787,16 +807,6 @@ export function registerRunCommand(program: Command): void {
               );
             }
           }
-        }
-      }
-      if (accountPickerRequested) {
-        const conflicts = runAccountPickerConflicts(options);
-        if (conflicts.length > 0) {
-          console.error(chalk.red(
-            `Account selection with ${agentSpec} cannot be combined with ${conflicts.join(', ')}. ` +
-            'Pick the account locally, or use an explicit agent@version target.',
-          ));
-          process.exit(1);
         }
       }
 

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -64,6 +64,8 @@ interface ExecCommandActionOptions {
   fallback?: string;
   balanced?: boolean;
   strategy?: string;
+  /** Affinity-pick host (and harness when agent is auto); accounts stay balanced. */
+  smart?: boolean;
   acp?: boolean;
   yes?: boolean;
   loop?: boolean;
@@ -557,6 +559,10 @@ export function registerRunCommand(program: Command): void {
       'Version/account selection strategy: pinned | available | balanced. Defaults to run.<agent>.strategy, then balanced (spreads load across healthy accounts and skips any that are rate-limited). (Legacy `rotate` accepted as alias for `balanced`.)',
     )
     .option(
+      '--smart',
+      'Pick host from 14d usage affinity (most-used online device has highest probability). Accounts still use balanced. Ignored when --host/--device is set. Pass agent "auto" to also pick harness among claude/codex/kimi.',
+    )
+    .option(
       '--acp',
       'Route through the Agent Client Protocol instead of direct exec. Supported for gemini, claude (via @zed-industries/claude-code-acp adapter). Unified event stream; emits ndjson when --json.',
     )
@@ -727,10 +733,61 @@ export function registerRunCommand(program: Command): void {
       // their existing meaning in every dispatch path below.
       const accountPicker = parseRunAccountPickerRequest(agentSpec);
       const accountPickerRequested = accountPicker.requested;
-      const normalizedAgentSpec = accountPicker.normalizedAgentSpec;
+      let normalizedAgentSpec = accountPicker.normalizedAgentSpec;
       if (!accountPicker.valid) {
         console.error(chalk.red(`Invalid account picker target: ${agentSpec}. Use agents run <agent>@.`));
         process.exit(1);
+      }
+
+      // --smart: affinity-pick host (and optional harness when agent is "auto").
+      // Explicit --host/--device wins. Account rotation stays --strategy balanced.
+      if (options.smart) {
+        const hostAlready = [options.host, options.device, options.on, options.computer].some(Boolean);
+        const [agentName, rawVersionPin] = normalizedAgentSpec.split('@');
+        if (rawVersionPin) {
+          if (!options.quiet) {
+            process.stderr.write(chalk.yellow('[agents] --smart ignored for host/harness pick when @version is pinned; accounts still use strategy\n'));
+          }
+        } else if (!hostAlready || agentName === 'auto') {
+          try {
+            const { resolveSmartLaunch } = await import('../lib/smart-launch.js');
+            const pickHarness = agentName === 'auto';
+            const plan = resolveSmartLaunch({
+              agent: pickHarness ? undefined : (agentName as import('../lib/types.js').AgentId),
+              pickHarness,
+            });
+            if (!hostAlready && plan.host) {
+              options.host = plan.host;
+            }
+            if (pickHarness) {
+              normalizedAgentSpec = plan.agent;
+            }
+            // Prefer balanced for smart launches unless the user overrode strategy.
+            if (!options.strategy && !options.balanced) {
+              options.balanced = true;
+            }
+            if (!options.quiet) {
+              const hostLabel = plan.host ?? 'local';
+              const deviceHint = plan.deviceCandidates
+                .slice(0, 4)
+                .map((c) => `${c.key}:${c.launches}`)
+                .join(', ');
+              process.stderr.write(
+                chalk.gray(
+                  `[agents] smart: host=${hostLabel} agent=${pickHarness ? plan.agent : agentName}` +
+                    (deviceHint ? ` (device affinity ${deviceHint})` : '') +
+                    ` · accounts=balanced\n`,
+                ),
+              );
+            }
+          } catch (err) {
+            if (!options.quiet) {
+              process.stderr.write(
+                chalk.yellow(`[agents] --smart skipped: ${(err as Error).message}\n`),
+              );
+            }
+          }
+        }
       }
       if (accountPickerRequested) {
         const conflicts = runAccountPickerConflicts(options);

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -139,6 +139,9 @@ export const RUN_OPTION_FORWARDING: Record<string, RunOptionForwarding> = {
   tailscale: 'local-only', // --tailscale/--no-tailscale gate the lease net mode; never forwarded
   copyCreds: 'local-only', // copies creds TO the host before dispatch — local concern only
   authCheck: 'local-only', // --no-auth-check gates the local interactive login preflight; --host runs skip that preflight entirely
+  // Affinity host/harness pick runs on the launching box, then may set --host
+  // and --strategy balanced. Never forward --smart itself over SSH.
+  smart: 'local-only',
 };
 
 /** Actionable messages for value-aware rejections, keyed by attribute name. */

--- a/apps/cli/src/lib/session/__tests__/affinity.test.ts
+++ b/apps/cli/src/lib/session/__tests__/affinity.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-affinity-'));
+process.env.HOME = TEST_HOME;
+
+const { getDB, closeDB, upsertSession, queryAffinityRollup } = await import('../db.js');
+type SessionMeta = import('../types.js').SessionMeta;
+
+const FILES = path.join(TEST_HOME, 'files');
+fs.mkdirSync(FILES, { recursive: true });
+
+function seed(partial: {
+  id: string;
+  agent?: SessionMeta['agent'];
+  machine?: string;
+  timestamp: string;
+  isTeamOrigin?: boolean;
+  origin?: 'cli' | 'routine';
+  tokenCount?: number;
+}): void {
+  const filePath = path.join(FILES, `${partial.id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  upsertSession(
+    {
+      id: partial.id,
+      shortId: partial.id.slice(0, 8),
+      agent: partial.agent ?? 'claude',
+      timestamp: partial.timestamp,
+      filePath,
+      machine: partial.machine,
+      isTeamOrigin: partial.isTeamOrigin,
+      origin: partial.origin,
+      tokenCount: partial.tokenCount,
+    },
+    '',
+  );
+}
+
+describe('queryAffinityRollup + machine persistence', () => {
+  beforeAll(() => {
+    // Touch DB so schema v17 migrates on a fresh home.
+    getDB();
+    const now = Date.now();
+    const day = 24 * 60 * 60 * 1000;
+    seed({
+      id: 'a1',
+      machine: 'yosemite-s1',
+      agent: 'claude',
+      timestamp: new Date(now - 1 * day).toISOString(),
+      tokenCount: 100,
+    });
+    seed({
+      id: 'a2',
+      machine: 'yosemite-s1',
+      agent: 'claude',
+      timestamp: new Date(now - 2 * day).toISOString(),
+      tokenCount: 50,
+    });
+    seed({
+      id: 'a3',
+      machine: 'yosemite-s0',
+      agent: 'codex',
+      timestamp: new Date(now - 3 * day).toISOString(),
+      tokenCount: 200,
+    });
+    seed({
+      id: 'team1',
+      machine: 'yosemite-s1',
+      agent: 'claude',
+      timestamp: new Date(now - 1 * day).toISOString(),
+      isTeamOrigin: true,
+    });
+    seed({
+      id: 'old',
+      machine: 'ancient-box',
+      agent: 'claude',
+      timestamp: new Date(now - 40 * day).toISOString(),
+    });
+  });
+
+  afterAll(() => {
+    closeDB();
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('persists machine on upsert and groups by machine', () => {
+    const rows = queryAffinityRollup({ groupBy: 'machine', sinceMs: Date.now() - 14 * 24 * 60 * 60 * 1000 });
+    const s1 = rows.find((r) => r.key === 'yosemite-s1');
+    const s0 = rows.find((r) => r.key === 'yosemite-s0');
+    expect(s1?.launches).toBe(2); // team excluded
+    expect(s0?.launches).toBe(1);
+    expect(s1!.launches).toBeGreaterThan(s0!.launches);
+  });
+
+  it('groups by agent with allowlist', () => {
+    const rows = queryAffinityRollup({
+      groupBy: 'agent',
+      agents: ['claude', 'codex'],
+      sinceMs: Date.now() - 14 * 24 * 60 * 60 * 1000,
+    });
+    expect(rows.find((r) => r.key === 'claude')?.launches).toBe(2);
+    expect(rows.find((r) => r.key === 'codex')?.launches).toBe(1);
+  });
+
+  it('stores machine column on the row', () => {
+    const db = getDB();
+    const row = db.prepare(`SELECT machine FROM sessions WHERE id = ?`).get('a1') as { machine: string };
+    expect(row.machine).toBe('yosemite-s1');
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -166,7 +166,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('17');
+    expect(row.value).toBe('18');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {

--- a/apps/cli/src/lib/session/db.migrate-v14.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v14.test.ts
@@ -98,7 +98,7 @@ describe('schema migration v13 -> current (dir_ledger + resumable parser)', () =
   it('bumps the recorded schema version to the current version', () => {
     const db = getDB();
     const v = (db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string }).value;
-    expect(v).toBe('17');
+    expect(v).toBe('18');
   });
 
   it('preserves existing session rows through the migration', () => {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -14,12 +14,13 @@ import type { SessionAgentId, SessionMeta } from './types.js';
 import { parseSession } from './parse.js';
 import { extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
 import { getSessionsDir, getSessionsDbPath } from '../state.js';
+import { machineForSessionFile } from './origin-machine.js';
 
 const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 17;
+const SCHEMA_VERSION = 18;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -77,6 +78,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   worktree_slug TEXT,
   ticket_id TEXT,
   plan TEXT,
+  machine TEXT,
   todos TEXT,
   recent_directories_touched TEXT,
   linear_project TEXT,
@@ -87,6 +89,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd);
 CREATE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent);
 CREATE INDEX IF NOT EXISTS idx_sessions_file_path ON sessions(file_path);
 CREATE INDEX IF NOT EXISTS idx_sessions_short_id ON sessions(short_id);
+-- idx_sessions_machine_ts / idx_sessions_agent_ts are created after migration
+-- v17 guarantees the machine column exists (same pattern as last_activity).
 
 CREATE VIRTUAL TABLE IF NOT EXISTS session_text USING fts5(
   session_id UNINDEXED,
@@ -167,6 +171,7 @@ export interface SessionRow {
   worktree_slug: string | null;
   ticket_id: string | null;
   plan: string | null;
+  machine: string | null;
   todos: string | null;
   recent_directories_touched: string | null;
   linear_project: string | null;
@@ -395,13 +400,37 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     // primary key — so every corrupt row becomes addressable. No rescan needed.
     db.exec(`UPDATE sessions SET short_id = substr(id, 1, 8) WHERE short_id IS NULL OR short_id = ''`);
   }
+
   if (fromVersion < 17) {
+    // v16 → v17 (main): todos / recent dirs / linear project metadata.
     const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
     if (!cols.some(c => c.name === 'todos')) db.exec(`ALTER TABLE sessions ADD COLUMN todos TEXT`);
     if (!cols.some(c => c.name === 'recent_directories_touched')) db.exec(`ALTER TABLE sessions ADD COLUMN recent_directories_touched TEXT`);
     if (!cols.some(c => c.name === 'linear_project')) db.exec(`ALTER TABLE sessions ADD COLUMN linear_project TEXT`);
     if (!cols.some(c => c.name === 'linear_project_url')) db.exec(`ALTER TABLE sessions ADD COLUMN linear_project_url TEXT`);
     db.exec(`DELETE FROM scan_ledger; DELETE FROM dir_ledger;`);
+  }
+
+  if (fromVersion < 18) {
+    // v17 → v18: persist origin machine for smart-launch affinity GROUP BY machine.
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'machine')) {
+      db.exec(`ALTER TABLE sessions ADD COLUMN machine TEXT`);
+    }
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_sessions_machine_ts ON sessions(machine, timestamp DESC);
+      CREATE INDEX IF NOT EXISTS idx_sessions_agent_ts ON sessions(agent, timestamp DESC);
+    `);
+    const rows = db
+      .prepare(`SELECT id, agent, file_path FROM sessions WHERE machine IS NULL OR machine = ''`)
+      .all() as Array<{ id: string; agent: string; file_path: string }>;
+    const upd = db.prepare(`UPDATE sessions SET machine = ? WHERE id = ?`);
+    const txn = db.transaction((items: typeof rows) => {
+      for (const r of items) {
+        upd.run(machineForSessionFile(r.file_path, r.agent), r.id);
+      }
+    });
+    txn(rows);
   }
 }
 
@@ -438,6 +467,27 @@ export function getDB(): Database.Database {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity DESC)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_origin ON sessions(origin)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_routine_run_id ON sessions(routine_run_id)`);
+  // machine column + indexes: only after the column is guaranteed present.
+  // Fresh SCHEMA (v17) includes the column; older DBs get it from migrate v17.
+  // If a partial upgrade left schema_version ahead of the column, repair here.
+  {
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some((c) => c.name === 'machine')) {
+      db.exec(`ALTER TABLE sessions ADD COLUMN machine TEXT`);
+      const rows = db
+        .prepare(`SELECT id, agent, file_path FROM sessions WHERE machine IS NULL OR machine = ''`)
+        .all() as Array<{ id: string; agent: string; file_path: string }>;
+      const upd = db.prepare(`UPDATE sessions SET machine = ? WHERE id = ?`);
+      const txn = db.transaction((items: typeof rows) => {
+        for (const r of items) {
+          upd.run(machineForSessionFile(r.file_path, r.agent), r.id);
+        }
+      });
+      txn(rows);
+    }
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_machine_ts ON sessions(machine, timestamp DESC)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_sessions_agent_ts ON sessions(agent, timestamp DESC)`);
+  }
 
   // One-shot cleanup of the pre-SQLite JSONL indexes. Safe — nothing reads
   // them anymore. Guarded by a meta flag so we only try once.
@@ -788,7 +838,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     output_tokens, cost_usd, duration_ms,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id, plan, todos,
-    recent_directories_touched, linear_project, linear_project_url
+    recent_directories_touched, linear_project, linear_project_url, machine
   ) VALUES (
     @id, @short_id, @agent, @origin, @routine_name, @routine_run_id,
     @version, @account, @timestamp, @last_activity,
@@ -796,7 +846,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     @output_tokens, @cost_usd, @duration_ms,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
     @pr_url, @pr_number, @worktree_slug, @ticket_id, @plan, @todos,
-    @recent_directories_touched, @linear_project, @linear_project_url
+    @recent_directories_touched, @linear_project, @linear_project_url, @machine
   )
   ON CONFLICT(id) DO UPDATE SET
     short_id = excluded.short_id,
@@ -845,7 +895,8 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     linear_project_url = CASE
       WHEN excluded.ticket_id IS NOT sessions.ticket_id THEN excluded.linear_project_url
       ELSE COALESCE(excluded.linear_project_url, sessions.linear_project_url)
-    END
+    END,
+    machine = excluded.machine
 `);
 
 function enrichCachedSessionMeta(meta: SessionMeta): SessionMeta {
@@ -903,6 +954,12 @@ function storedFtsLabel(readLabel: Database.Statement<unknown[]>, id: string): s
   return row?.label ?? '';
 }
 
+/** Resolve origin machine for a row: prefer caller-stamped meta, else path. */
+function resolveMachine(meta: SessionMeta): string {
+  if (meta.machine && meta.machine.trim()) return meta.machine.trim();
+  return machineForSessionFile(meta.filePath, meta.agent);
+}
+
 /**
  * Upsert a session row and replace its FTS5 content in a single transaction.
  * `content` is the tokenizable user-prompt text; pass '' to leave the row unsearchable.
@@ -946,6 +1003,7 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     recent_directories_touched: meta.recentDirectoriesTouched ? JSON.stringify(meta.recentDirectoriesTouched) : null,
     linear_project: meta.linearProject ?? null,
     linear_project_url: meta.linearProjectUrl ?? null,
+    machine: resolveMachine(meta),
   };
 
   const txn = db.transaction(() => {
@@ -1070,6 +1128,7 @@ export function upsertSessionsBatch(
         recent_directories_touched: meta.recentDirectoriesTouched ? JSON.stringify(meta.recentDirectoriesTouched) : null,
         linear_project: meta.linearProject ?? null,
         linear_project_url: meta.linearProjectUrl ?? null,
+    machine: resolveMachine(meta),
       });
       delText.run(meta.id);
       insText.run(
@@ -1271,6 +1330,7 @@ function rowToMeta(row: SessionRow): SessionMeta {
     recentDirectoriesTouched: parseJsonColumn(row.recent_directories_touched),
     linearProject: row.linear_project ?? undefined,
     linearProjectUrl: row.linear_project_url ?? undefined,
+    machine: row.machine ?? undefined,
   };
 }
 
@@ -1467,6 +1527,97 @@ export interface UsageRollupRow {
 
 /** What to group a usage rollup by. */
 export type UsageRollupGroup = 'agent' | 'project' | 'day';
+
+/**
+ * Smart-launch affinity priors: group sessions by origin machine, harness, or
+ * joint (machine + agent). Ordered by launch count desc.
+ *
+ * SQL shape (device example):
+ *   SELECT machine, COUNT(*) launches, SUM(duration_ms), SUM(token_count)
+ *   FROM sessions
+ *   WHERE timestamp >= ? AND origin = 'cli' AND is_team_origin = 0
+ *   GROUP BY machine ORDER BY launches DESC
+ *
+ * Account rotation is NOT done here — that stays on live rate-limit windows
+ * via `--strategy balanced` / rotate.ts.
+ */
+export type AffinityGroup = 'machine' | 'agent' | 'machine_agent';
+
+export interface AffinityRow {
+  /** Group key: machine name, agent id, or "machine\\tagent". */
+  key: string;
+  machine?: string;
+  agent?: string;
+  launches: number;
+  durationMs: number;
+  tokenCount: number;
+  costUsd: number;
+}
+
+export function queryAffinityRollup(options: {
+  groupBy: AffinityGroup;
+  /** ISO cutoff or ms; defaults to 14 days ago when omitted. */
+  sinceMs?: number;
+  /** Restrict to these harnesses (e.g. claude/codex/kimi). */
+  agents?: SessionAgentId[];
+  /** Default true: only origin=cli rows. */
+  onlyCli?: boolean;
+  /** Default true: drop team-spawned sessions. */
+  excludeTeamOrigin?: boolean;
+  project?: string;
+}): AffinityRow[] {
+  const db = getDB();
+  const where: string[] = [];
+  const params: unknown[] = [];
+
+  const sinceMs = options.sinceMs ?? (Date.now() - 14 * 24 * 60 * 60 * 1000);
+  // ISO timestamps sort lexicographically; compare as string prefix of datetime.
+  where.push(`timestamp >= ?`);
+  params.push(new Date(sinceMs).toISOString());
+
+  if (options.onlyCli !== false) {
+    where.push(`IFNULL(origin, 'cli') = 'cli'`);
+  }
+  if (options.excludeTeamOrigin !== false) {
+    where.push(`IFNULL(is_team_origin, 0) = 0`);
+  }
+  if (options.agents && options.agents.length > 0) {
+    where.push(`agent IN (${options.agents.map(() => '?').join(',')})`);
+    params.push(...options.agents);
+  }
+  if (options.project) {
+    where.push(`LOWER(IFNULL(project, '')) LIKE ?`);
+    params.push(`%${options.project.toLowerCase()}%`);
+  }
+
+  let keyExpr: string;
+  let selectExtra: string;
+  if (options.groupBy === 'machine') {
+    keyExpr = `IFNULL(NULLIF(machine, ''), '(unknown)')`;
+    selectExtra = `${keyExpr} AS key, ${keyExpr} AS machine, NULL AS agent`;
+  } else if (options.groupBy === 'agent') {
+    keyExpr = `agent`;
+    selectExtra = `agent AS key, NULL AS machine, agent AS agent`;
+  } else {
+    keyExpr = `IFNULL(NULLIF(machine, ''), '(unknown)') || char(9) || agent`;
+    selectExtra = `${keyExpr} AS key, IFNULL(NULLIF(machine, ''), '(unknown)') AS machine, agent AS agent`;
+  }
+
+  const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const sql = `
+    SELECT
+      ${selectExtra},
+      COUNT(*) AS launches,
+      IFNULL(SUM(duration_ms), 0) AS durationMs,
+      IFNULL(SUM(token_count), 0) AS tokenCount,
+      IFNULL(SUM(cost_usd), 0) AS costUsd
+    FROM sessions
+    ${clause}
+    GROUP BY key
+    ORDER BY launches DESC, key ASC
+  `;
+  return db.prepare(sql).all(...params) as AffinityRow[];
+}
 
 /**
  * Aggregate cost / duration / tokens across sessions, grouped by agent,

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -31,6 +31,8 @@ import { parseAntigravity } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand, detectSpawnedTeam, isTicketCreateTool, extractCreatedTicket, extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
 import { costOfUsage } from '../pricing/index.js';
 import { machineId } from './sync/config.js';
+import { machineForSessionFile } from './origin-machine.js';
+export { machineForSessionFile } from './origin-machine.js';
 import { mapBounded } from '../concurrency.js';
 import {
   getDB,
@@ -383,7 +385,6 @@ function dispatchAgentScan(
   }
 }
 
-let _localMachineId: string | undefined;
 
 /**
  * The machine a discovered session originated on. Cross-machine sync mirrors a
@@ -433,14 +434,6 @@ export function isManagedSessionFile(filePath: string): boolean {
 }
 
 
-export function machineForSessionFile(filePath: string, agent: string): string {
-  const base = path.join(getHistoryDir(), 'backups', agent) + path.sep;
-  if (filePath.startsWith(base)) {
-    const seg = filePath.slice(base.length).split(path.sep)[0];
-    if (seg) return seg;
-  }
-  return (_localMachineId ??= machineId());
-}
 
 /**
  * Count sessions in scope without running an incremental scan. Assumes the DB

--- a/apps/cli/src/lib/session/origin-machine.ts
+++ b/apps/cli/src/lib/session/origin-machine.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve which machine a session transcript originated on.
+ *
+ * Cross-machine sync mirrors a remote transcript to
+ * `backups/<agent>/<machine>/<subdir>/…`. Every other transcript is a live-home
+ * file on this box, so the origin is the local machine id.
+ *
+ * Kept in a leaf module (no session/db imports) so both discovery and the
+ * sessions DB upsert path can stamp `machine` without circular deps.
+ */
+
+import * as path from 'path';
+import { getHistoryDir } from '../state.js';
+import { machineId } from '../machine-id.js';
+
+let _localMachineId: string | undefined;
+
+/** Local machine id, cached for the process lifetime. */
+export function localMachineId(): string {
+  return (_localMachineId ??= machineId());
+}
+
+/**
+ * The machine a discovered session originated on.
+ * When the path sits under the agent's backups root, the first segment below it
+ * is the origin machine id; otherwise it's the local machine.
+ */
+export function machineForSessionFile(filePath: string, agent: string): string {
+  if (!filePath) return localMachineId();
+  const base = path.join(getHistoryDir(), 'backups', agent) + path.sep;
+  if (filePath.startsWith(base)) {
+    const seg = filePath.slice(base.length).split(path.sep)[0];
+    if (seg) return seg;
+  }
+  return localMachineId();
+}

--- a/apps/cli/src/lib/smart-launch.test.ts
+++ b/apps/cli/src/lib/smart-launch.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  affinityWeights,
+  sampleWeighted,
+  resolveSmartLaunch,
+  type WeightedCandidate,
+} from './smart-launch.js';
+import type { AffinityRow } from './session/db.js';
+
+function row(key: string, launches: number): AffinityRow {
+  return { key, launches, durationMs: 0, tokenCount: 0, costUsd: 0 };
+}
+
+describe('affinityWeights', () => {
+  it('gives higher weight to more launches', () => {
+    const w = affinityWeights([row('s1', 10), row('m0', 1)], 1.0);
+    expect(w.find((c) => c.key === 's1')!.weight).toBeGreaterThan(
+      w.find((c) => c.key === 'm0')!.weight,
+    );
+  });
+
+  it('drops unknown / zero-launch keys', () => {
+    const w = affinityWeights([row('(unknown)', 5), row('s1', 0), row('s1', 3)]);
+    // filter is per-row; s1 with 0 dropped, (unknown) dropped
+    expect(w.every((c) => c.key !== '(unknown)')).toBe(true);
+    expect(w.every((c) => c.launches > 0)).toBe(true);
+  });
+});
+
+describe('sampleWeighted', () => {
+  it('returns null for empty candidates', () => {
+    expect(sampleWeighted([])).toBeNull();
+  });
+
+  it('always picks the only candidate', () => {
+    expect(sampleWeighted([{ key: 'only', launches: 1, weight: 1 }])).toBe('only');
+  });
+
+  it('prefers the heavier weight with a deterministic rng', () => {
+    // total = 90 + 10 = 100; rng 0.5 → roll 50 → first candidate (weight 90)
+    const cands: WeightedCandidate[] = [
+      { key: 's1', launches: 90, weight: 90 },
+      { key: 'm0', launches: 10, weight: 10 },
+    ];
+    expect(sampleWeighted(cands, () => 0.5)).toBe('s1');
+    // rng near 1 → second candidate
+    expect(sampleWeighted(cands, () => 0.95)).toBe('m0');
+  });
+});
+
+describe('resolveSmartLaunch', () => {
+  it('samples most-used online host and keeps agent fixed', () => {
+    const plan = resolveSmartLaunch({
+      agent: 'claude',
+      localMachine: 'yosemite-s0',
+      eligibleHosts: ['yosemite-s0', 'yosemite-s1', 'yosemite-m0'],
+      deviceAffinity: [
+        row('yosemite-s1', 50),
+        row('yosemite-s0', 5),
+        row('yosemite-m0', 1),
+      ],
+      // total ≈ 5^α + 50^α + 1; mid roll lands in the heavy s1 bucket
+      rng: () => 0.5,
+    });
+    expect(plan.agent).toBe('claude');
+    expect(plan.accountStrategy).toBe('balanced');
+    expect(plan.host).toBe('yosemite-s1'); // not local
+  });
+
+  it('returns host null when local machine is picked', () => {
+    const plan = resolveSmartLaunch({
+      agent: 'codex',
+      localMachine: 'yosemite-s0',
+      eligibleHosts: ['yosemite-s0'],
+      deviceAffinity: [row('yosemite-s0', 10)],
+      rng: () => 0.5,
+    });
+    expect(plan.host).toBeNull();
+    expect(plan.agent).toBe('codex');
+  });
+
+  it('excludes offline hosts from affinity', () => {
+    const plan = resolveSmartLaunch({
+      agent: 'claude',
+      localMachine: 'yosemite-s0',
+      eligibleHosts: ['yosemite-s0'], // s1 not online
+      deviceAffinity: [row('yosemite-s1', 100), row('yosemite-s0', 2)],
+      rng: () => 0.5,
+    });
+    expect(plan.host).toBeNull(); // only local eligible
+    expect(plan.pickedDeviceKey).toBe('yosemite-s0');
+  });
+
+  it('picks harness from allowlist when pickHarness is true', () => {
+    const plan = resolveSmartLaunch({
+      pickHarness: true,
+      allowAgents: ['claude', 'codex', 'kimi'],
+      localMachine: 'zion',
+      eligibleHosts: ['zion'],
+      deviceAffinity: [row('zion', 3)],
+      harnessAffinity: [row('codex', 40), row('claude', 10), row('kimi', 1)],
+      rng: () => 0.01,
+    });
+    expect(plan.agent).toBe('codex');
+    expect(plan.accountStrategy).toBe('balanced');
+  });
+});

--- a/apps/cli/src/lib/smart-launch.ts
+++ b/apps/cli/src/lib/smart-launch.ts
@@ -1,0 +1,207 @@
+/**
+ * Smart launch: pick device + harness from usage affinity, then leave account
+ * selection to `--strategy balanced` (live rate-limit windows in rotate.ts).
+ *
+ * Probability model (per axis):
+ *   P(x) ∝ launches(x)^α   among eligible candidates
+ * Most-used gets the highest probability; never a hard lock (sample, not argmax).
+ */
+
+import type { AgentId } from './types.js';
+import { queryAffinityRollup, type AffinityRow } from './session/db.js';
+import { localMachineId } from './session/origin-machine.js';
+import { loadDevicesSync } from './devices/registry.js';
+import { normalizeHost } from './machine-id.js';
+
+/** Default harness allowlist for auto-pick. */
+export const DEFAULT_SMART_HARNESSES: AgentId[] = ['claude', 'codex', 'kimi'];
+
+/** Peakiness of usage weights; >1 amplifies the most-used option. */
+export const DEFAULT_AFFINITY_ALPHA = 1.3;
+
+export interface WeightedCandidate {
+  key: string;
+  launches: number;
+  weight: number;
+}
+
+/**
+ * Convert affinity rows into positive weights: launches^α (floor 1 for any
+ * row with launches > 0 so a single-use host still participates).
+ */
+export function affinityWeights(
+  rows: AffinityRow[],
+  alpha: number = DEFAULT_AFFINITY_ALPHA,
+): WeightedCandidate[] {
+  return rows
+    .filter((r) => r.launches > 0 && r.key && r.key !== '(unknown)')
+    .map((r) => ({
+      key: r.key,
+      launches: r.launches,
+      weight: Math.max(1, Math.pow(r.launches, alpha)),
+    }));
+}
+
+/**
+ * Weighted random sample. Returns null when candidates is empty.
+ * Pure — inject `rng` for tests.
+ */
+export function sampleWeighted(
+  candidates: WeightedCandidate[],
+  rng: () => number = Math.random,
+): string | null {
+  if (candidates.length === 0) return null;
+  const total = candidates.reduce((s, c) => s + c.weight, 0);
+  if (total <= 0) return candidates[0].key;
+  let roll = rng() * total;
+  for (const c of candidates) {
+    roll -= c.weight;
+    if (roll <= 0) return c.key;
+  }
+  return candidates[candidates.length - 1].key;
+}
+
+/** Online device names from the local registry (+ always include local). */
+export function listOnlineDeviceNames(localName: string = localMachineId()): string[] {
+  const names = new Set<string>([normalizeHost(localName)]);
+  try {
+    const reg = loadDevicesSync();
+    for (const [name, d] of Object.entries(reg)) {
+      if (!d || typeof d !== 'object') continue;
+      const online = d.tailscale?.online;
+      // No tailscale snapshot → treat as candidate (registry-only box).
+      if (online === false) continue;
+      names.add(normalizeHost(name));
+    }
+  } catch {
+    /* registry missing — local only */
+  }
+  return [...names];
+}
+
+export interface SmartLaunchOptions {
+  /** Fixed harness (skip harness sample). */
+  agent?: AgentId;
+  /** When true and agent unset, sample harness from allowlist. */
+  pickHarness?: boolean;
+  allowAgents?: AgentId[];
+  sinceDays?: number;
+  alpha?: number;
+  /**
+   * Eligible hosts (normalized). Defaults to online devices + local.
+   * Empty after filter → fall back to local.
+   */
+  eligibleHosts?: string[];
+  localMachine?: string;
+  /** Injected affinity (tests). When omitted, reads sessions.db. */
+  deviceAffinity?: AffinityRow[];
+  harnessAffinity?: AffinityRow[];
+  rng?: () => number;
+  project?: string;
+}
+
+export interface SmartLaunchPlan {
+  /** null means run locally (do not pass --host). */
+  host: string | null;
+  agent: AgentId;
+  /** Account strategy the caller must use. Always balanced for smart launch. */
+  accountStrategy: 'balanced';
+  deviceCandidates: WeightedCandidate[];
+  harnessCandidates: WeightedCandidate[];
+  pickedDeviceKey: string | null;
+  pickedHarnessKey: string | null;
+}
+
+/**
+ * Resolve host + harness for an unpinned launch. Does NOT pick accounts —
+ * caller runs `agents run <agent> --host <host> --strategy balanced`.
+ */
+export function resolveSmartLaunch(opts: SmartLaunchOptions = {}): SmartLaunchPlan {
+  const local = normalizeHost(opts.localMachine ?? localMachineId());
+  const alpha = opts.alpha ?? DEFAULT_AFFINITY_ALPHA;
+  const rng = opts.rng ?? Math.random;
+  const sinceDays = opts.sinceDays ?? 14;
+  const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+  const allow = opts.allowAgents ?? DEFAULT_SMART_HARNESSES;
+
+  const eligible = new Set(
+    (opts.eligibleHosts ?? listOnlineDeviceNames(local)).map(normalizeHost),
+  );
+  if (eligible.size === 0) eligible.add(local);
+
+  const deviceRows =
+    opts.deviceAffinity ??
+    queryAffinityRollup({
+      groupBy: 'machine',
+      sinceMs,
+      excludeTeamOrigin: true,
+      onlyCli: true,
+      project: opts.project,
+    });
+
+  // Restrict affinity to online hosts. Hosts with history get launches^α;
+  // online hosts with no history still participate at weight 1 (exploration).
+  const launchesByHost = new Map<string, number>();
+  for (const r of deviceRows) {
+    const k = normalizeHost(r.key);
+    if (!eligible.has(k) || k === '(unknown)') continue;
+    launchesByHost.set(k, (launchesByHost.get(k) ?? 0) + r.launches);
+  }
+  let deviceWeights: WeightedCandidate[] = [...eligible].map((key) => {
+    const launches = launchesByHost.get(key) ?? 0;
+    return {
+      key,
+      launches,
+      weight: launches > 0 ? Math.max(1, Math.pow(launches, alpha)) : 1,
+    };
+  });
+  if (deviceWeights.length === 0) {
+    deviceWeights = [{ key: local, launches: 1, weight: 1 }];
+  }
+
+  const pickedDeviceKey = sampleWeighted(deviceWeights, rng);
+  const hostNorm = pickedDeviceKey ? normalizeHost(pickedDeviceKey) : local;
+  const host = hostNorm === local ? null : hostNorm;
+
+  let agent: AgentId;
+  let harnessWeights: WeightedCandidate[] = [];
+  let pickedHarnessKey: string | null = null;
+
+  if (opts.agent) {
+    agent = opts.agent;
+    pickedHarnessKey = opts.agent;
+  } else if (opts.pickHarness) {
+    const harnessRows =
+      opts.harnessAffinity ??
+      queryAffinityRollup({
+        groupBy: 'agent',
+        sinceMs,
+        agents: allow as import('./session/types.js').SessionAgentId[],
+        excludeTeamOrigin: true,
+        onlyCli: true,
+        project: opts.project,
+      });
+    harnessWeights = affinityWeights(
+      harnessRows.filter((r) => allow.includes(r.key as AgentId)),
+      alpha,
+    );
+    if (harnessWeights.length === 0) {
+      harnessWeights = allow.map((key) => ({ key, launches: 1, weight: 1 }));
+    }
+    pickedHarnessKey = sampleWeighted(harnessWeights, rng) ?? allow[0];
+    agent = (pickedHarnessKey as AgentId) ?? allow[0];
+  } else {
+    agent = allow[0] ?? 'claude';
+    pickedHarnessKey = agent;
+  }
+
+  return {
+    host,
+    agent,
+    accountStrategy: 'balanced',
+    deviceCandidates: deviceWeights,
+    harnessCandidates: harnessWeights,
+    pickedDeviceKey,
+    pickedHarnessKey,
+  };
+}

--- a/apps/factory/src/core/agents.ts
+++ b/apps/factory/src/core/agents.ts
@@ -179,6 +179,12 @@ export function buildAgentLaunchCommand(
   if (host) {
     command += ` --host ${shquote(host)}`;
   }
+  // Unpinned, no explicit host: CLI affinity-picks host via --smart (most-used
+  // online device has highest probability). Explicit Pick Host / @version pin
+  // skip this. Accounts stay on balanced unless strategy is set.
+  if (!host && !pinnedVersion) {
+    command += ' --smart';
+  }
   if (sessionId && agentKey === 'claude') {
     command += ` --session-id ${sessionId}`;
   }


### PR DESCRIPTION
## Summary

Implements smart launch routing (RUSH-2049–2052):

1. **Device** — pick host from 14d usage affinity (most-used online device has highest probability; weighted sample)
2. **Harness** — optional (`agents run auto --smart`) among claude/codex/kimi
3. **Account** — existing `--strategy balanced` (live session/week rate-limit windows in `rotate.ts`)

### Changes
- Schema **v18**: persist `machine` on `sessions` (+ backfill, indexes)
- `queryAffinityRollup({ groupBy: machine|agent|machine_agent })`
- `resolveSmartLaunch` + unit tests
- CLI: `agents run claude --smart …` / `agents run auto --smart …`
- Leaf helper `origin-machine.ts` (no circular imports)

### Explicitly unchanged
- Pin / `@version` / `--host` still win over smart
- Account rotation is **not** historical token counts

## Linear
- RUSH-2049 (epic)
- RUSH-2050 machine column
- RUSH-2051 affinity rollups
- RUSH-2052 resolveSmartLaunch + CLI
- RUSH-2053 extension New Agent — follow-up (CLI ready to call)

## Test plan
- [x] `bun run test` affinity + smart-launch + discover (45 tests)
- [x] Live DB migrated: all rows have `machine`; affinity query returns hosts
- [ ] CI green
- [ ] Optional: `agents run claude --smart -p 'ok'` smoke on a fleet box

### Evidence
```
✓ affinity.test.ts (3)
✓ smart-launch.test.ts (9)
✓ discover.test.ts (33)
schema_version 18 · machine filled on 4407/4407 rows
```