### PR TITLE
feat(feed): emit task.completed / checklist.created milestones (RUSH-2046)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2046.md
+++ b/apps/cli/.changelog/next/RUSH-2046.md
@@ -1,0 +1,9 @@
+- **Checklist completions emit a feed event (RUSH-2046).** When an agent marks a
+  task-checklist item done, the `11-activity-log.py` hook now appends a
+  `task.completed` milestone to the session activity log (and `checklist.created`
+  the first time a checklist appears), so completions show in `agents feed` and the
+  unified `agents events` stream with the item subject and running `N/M`. Detection
+  folds the transcript across harnesses — Claude `TaskUpdate`/`TodoWrite`, Grok
+  `todo_write`, Codex `update_plan` — so a completion is recognized regardless of
+  which agent produced it. Source: `apps/cli/src/lib/activity.ts` (incl. the embedded
+  hook), `apps/cli/src/lib/events.ts`, `apps/cli/src/commands/feed.ts`.

--- a/apps/cli/src/commands/feed.test.ts
+++ b/apps/cli/src/commands/feed.test.ts
@@ -15,6 +15,7 @@ import {
 } from './feed.js';
 import { groupBlocksByOutcome } from '../lib/feed-outcome.js';
 import { GLYPH } from '../lib/comms-render.js';
+import { formatActivityLine } from '../lib/activity.js';
 
 const children: ChildProcess[] = [];
 
@@ -206,5 +207,18 @@ describe('sessionHintsFromActive', () => {
       prNumber: 12,
       worktreeSlug: 'rush-9-fix',
     });
+  });
+});
+
+describe('formatActivityLine', () => {
+  it('renders checklist milestone events', () => {
+    const base = { v: 1, ts: new Date().toISOString(), sessionId: 's', mailboxId: 's', host: 'zion', runtime: 'headless' } as const;
+    const taskCompleted = formatActivityLine({ ...base, event: 'task.completed', tier: 'milestone', agent: 'claude', detail: 'Write tests 2/3 done' });
+    expect(taskCompleted).toContain('task completed');
+    expect(taskCompleted).toContain('Write tests 2/3 done');
+
+    const checklistCreated = formatActivityLine({ ...base, event: 'checklist.created', tier: 'milestone', agent: 'claude', detail: '3 tasks' });
+    expect(checklistCreated).toContain('checklist created');
+    expect(checklistCreated).toContain('3 tasks');
   });
 });

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -510,6 +510,42 @@ describe('real activity-log hook (Python)', () => {
     expect(updateEvents[1].detail).toBe('Build the spine 1/1 done');
   });
 
+  it.runIf(hasPython)('excludes deleted tasks from the N/M total on a TaskUpdate completion', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-task-deleted-'));
+    const sessionId = 'sess-task-deleted';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    const create = (id: string, subject: string) => [
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id: `tc-${id}`, name: 'TaskCreate', input: { subject } }] } }),
+      JSON.stringify({ type: 'user', toolUseResult: { task: { id, subject } }, tool_use_id: `tc-${id}` }),
+    ];
+    const update = (id: string, to: string) => [
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id: `tu-${id}-${to}`, name: 'TaskUpdate', input: { taskId: id, status: to } }] } }),
+      JSON.stringify({ type: 'user', toolUseResult: { success: true, taskId: id, statusChange: { from: 'pending', to } }, tool_use_id: `tu-${id}-${to}` }),
+    ];
+    fs.writeFileSync(
+      transcript,
+      [
+        ...create('1', 'A1'), ...create('2', 'A2'), ...create('3', 'A3'),
+        ...update('1', 'completed'),
+        ...update('3', 'deleted'),
+        ...update('2', 'completed'),
+      ].join('\n') + '\n',
+    );
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskUpdate',
+      tool_input: { taskId: '2', status: 'completed' },
+      tool_response: { success: true, taskId: '2', statusChange: { from: 'pending', to: 'completed' } },
+      tool_use_id: 'tu-2-completed',
+      transcript_path: transcript,
+    });
+    const events = readSessionActivity(sessionId, activityDirFor(home));
+    expect(events.map((e) => e.event)).toEqual(['task.completed']);
+    // 3 created, 1 deleted -> total is 2 (not 3); this completion is the 2nd of 2.
+    expect(events[0].detail).toBe('A2 2/2 done');
+  });
+
   it.runIf(hasPython)('is fail-open when transcript_path is missing', () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-todo-failopen-'));
     const sessionId = 'sess-todo-failopen';

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -273,4 +273,254 @@ describe('real activity-log hook (Python)', () => {
     });
     expect(readSessionActivity('sess-7', activityDirFor(home))).toHaveLength(0);
   });
+
+  it.runIf(hasPython)('emits checklist.created on the first TodoWrite', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-todo-create-'));
+    const sessionId = 'sess-todo-create';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [{ id: '1', content: 'Explore auth', status: 'pending' }] },
+      transcript_path: transcript,
+    });
+    const events = readSessionActivity(sessionId, activityDirFor(home));
+    expect(events.map((e) => e.event)).toEqual(['checklist.created']);
+    expect(events[0].tier).toBe('milestone');
+    expect(events[0].detail).toBe('1 task');
+  });
+
+  it.runIf(hasPython)('emits task.completed when a TodoWrite item flips to completed', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-todo-done-'));
+    const sessionId = 'sess-todo-done';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcript,
+      [
+        JSON.stringify({ name: 'TodoWrite', input: { todos: [{ id: '1', content: 'Explore auth', status: 'pending' }] } }),
+        JSON.stringify({ name: 'TodoWrite', input: { todos: [{ id: '1', content: 'Explore auth', status: 'completed' }] } }),
+      ].join('\n') + '\n',
+    );
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [{ id: '1', content: 'Explore auth', status: 'completed' }] },
+      transcript_path: transcript,
+    });
+    const events = readSessionActivity(sessionId, activityDirFor(home));
+    expect(events.map((e) => e.event)).toEqual(['task.completed']);
+    expect(events[0].tier).toBe('milestone');
+    expect(events[0].detail).toBe('Explore auth 1/1 done');
+  });
+
+  it.runIf(hasPython)('emits task.completed with N/M detail for a multi-item TodoWrite', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-todo-multi-'));
+    const sessionId = 'sess-todo-multi';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { id: '1', content: 'Explore auth', status: 'completed' },
+              { id: '2', content: 'Write tests', status: 'pending' },
+              { id: '3', content: 'Open PR', status: 'pending' },
+            ],
+          },
+        }),
+        JSON.stringify({
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { id: '1', content: 'Explore auth', status: 'completed' },
+              { id: '2', content: 'Write tests', status: 'completed' },
+              { id: '3', content: 'Open PR', status: 'pending' },
+            ],
+          },
+        }),
+      ].join('\n') + '\n',
+    );
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TodoWrite',
+      tool_input: {
+        todos: [
+          { id: '1', content: 'Explore auth', status: 'completed' },
+          { id: '2', content: 'Write tests', status: 'completed' },
+          { id: '3', content: 'Open PR', status: 'pending' },
+        ],
+      },
+      transcript_path: transcript,
+    });
+    const events = readSessionActivity(sessionId, activityDirFor(home));
+    expect(events.map((e) => e.event)).toEqual(['task.completed']);
+    expect(events[0].detail).toBe('Write tests 2/3 done');
+  });
+
+  it.runIf(hasPython)('emits nothing for a TodoWrite with no new completions', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-todo-noop-'));
+    const sessionId = 'sess-todo-noop';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          name: 'TodoWrite',
+          input: { todos: [{ id: '1', content: 'Explore auth', status: 'completed' }] },
+        }),
+        JSON.stringify({
+          name: 'TodoWrite',
+          input: { todos: [{ id: '1', content: 'Explore auth', status: 'completed' }] },
+        }),
+      ].join('\n') + '\n',
+    );
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [{ id: '1', content: 'Explore auth', status: 'completed' }] },
+      transcript_path: transcript,
+    });
+    expect(readSessionActivity(sessionId, activityDirFor(home))).toHaveLength(0);
+  });
+
+  it.runIf(hasPython)('emits task.completed for codex update_plan step completion', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-plan-done-'));
+    const sessionId = 'sess-plan-done';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          name: 'update_plan',
+          arguments: JSON.stringify({ plan: [{ step: 'Read files', status: 'pending' }] }),
+        }),
+        JSON.stringify({
+          name: 'update_plan',
+          arguments: JSON.stringify({ plan: [{ step: 'Read files', status: 'completed' }] }),
+        }),
+      ].join('\n') + '\n',
+    );
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'update_plan',
+      tool_input: { plan: [{ step: 'Read files', status: 'completed' }] },
+      transcript_path: transcript,
+    });
+    const events = readSessionActivity(sessionId, activityDirFor(home));
+    expect(events.map((e) => e.event)).toEqual(['task.completed']);
+    expect(events[0].detail).toBe('Read files 1/1 done');
+  });
+
+  it.runIf(hasPython)('emits task.completed for TaskUpdate by resolving subject from transcript', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-task-update-'));
+    const sessionId = 'sess-task-update';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { id: '1', content: 'Explore auth', status: 'completed' },
+              { id: '2', content: 'Write tests', status: 'pending' },
+            ],
+          },
+        }),
+        JSON.stringify({ name: 'TaskUpdate', input: { taskId: '2', status: 'completed' } }),
+      ].join('\n') + '\n',
+    );
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskUpdate',
+      tool_input: { taskId: '2', status: 'completed' },
+      transcript_path: transcript,
+    });
+    const events = readSessionActivity(sessionId, activityDirFor(home));
+    expect(events.map((e) => e.event)).toEqual(['task.completed']);
+    expect(events[0].detail).toBe('Write tests 2/2 done');
+  });
+
+  it.runIf(hasPython)('emits checklist.created on the first TaskCreate and resolves TaskUpdate subject from TaskCreate results', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-task-create-'));
+    const sessionId = 'sess-task-create';
+    const transcript = path.join(home, `${sessionId}.jsonl`);
+    fs.writeFileSync(
+      transcript,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tc-1', name: 'TaskCreate', input: { subject: 'Build the spine', description: 'Core work' } }],
+          },
+        }),
+        JSON.stringify({
+          type: 'user',
+          toolUseResult: { task: { id: '1', subject: 'Build the spine' } },
+          tool_use_id: 'tc-1',
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tu-1', name: 'TaskUpdate', input: { taskId: '1', status: 'completed' } }],
+          },
+        }),
+        JSON.stringify({
+          type: 'user',
+          toolUseResult: { success: true, taskId: '1', statusChange: { from: 'pending', to: 'completed' } },
+          tool_use_id: 'tu-1',
+        }),
+      ].join('\n') + '\n',
+    );
+
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskCreate',
+      tool_input: { subject: 'Build the spine', description: 'Core work' },
+      tool_response: { task: { id: '1', subject: 'Build the spine' } },
+      tool_use_id: 'tc-1',
+      transcript_path: transcript,
+    });
+    const createEvents = readSessionActivity(sessionId, activityDirFor(home));
+    expect(createEvents.map((e) => e.event)).toEqual(['checklist.created']);
+    expect(createEvents[0].detail).toBe('Build the spine');
+
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskUpdate',
+      tool_input: { taskId: '1', status: 'completed' },
+      tool_response: { success: true, taskId: '1', statusChange: { from: 'pending', to: 'completed' } },
+      tool_use_id: 'tu-1',
+      transcript_path: transcript,
+    });
+    const updateEvents = readSessionActivity(sessionId, activityDirFor(home));
+    expect(updateEvents.map((e) => e.event)).toEqual(['checklist.created', 'task.completed']);
+    expect(updateEvents[1].detail).toBe('Build the spine 1/1 done');
+  });
+
+  it.runIf(hasPython)('is fail-open when transcript_path is missing', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-todo-failopen-'));
+    const sessionId = 'sess-todo-failopen';
+    runHook(home, {
+      session_id: sessionId,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TodoWrite',
+      tool_input: { todos: [{ id: '1', content: 'Explore auth', status: 'completed' }] },
+      transcript_path: path.join(home, 'nonexistent', 'transcript.jsonl'),
+    });
+    const events = readSessionActivity(sessionId, activityDirFor(home));
+    expect(events.map((e) => e.event)).toEqual(['checklist.created', 'task.completed']);
+  });
 });

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -742,6 +742,14 @@ def _claude_task_state(transcript_path, exclude_task_id=None):
             if task_id in state:
                 state[task_id]["status"] = status
 
+    # Drop tasks removed from the checklist (deleted/cancelled): they are gone
+    # from the user-visible list, so they must not count toward the N/M total.
+    for task_id in list(state.keys()):
+        if task_id.startswith("__"):
+            continue
+        if state[task_id].get("status") in ("deleted", "cancelled", "canceled", "removed"):
+            del state[task_id]
+
     # Drop internal bookkeeping.
     state.pop("__pending_subject", None)
     return state

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -38,6 +38,8 @@ export type MilestoneEvent =
   | 'pushed'
   | 'subagent.spawned'
   | 'artifact.created'
+  | 'task.completed'
+  | 'checklist.created'
   /** Deliberate agent-authored progress post (`agents feed post`). */
   | 'status.posted';
 
@@ -59,6 +61,8 @@ export const MILESTONE_EVENTS: readonly MilestoneEvent[] = [
   'pushed',
   'subagent.spawned',
   'artifact.created',
+  'task.completed',
+  'checklist.created',
   'status.posted',
 ];
 
@@ -325,6 +329,8 @@ export const EVENT_STYLE: Record<string, { glyph: string; color: (s: string) => 
   'pushed': { glyph: '↥', color: chalk.yellow, label: 'pushed' },
   'subagent.spawned': { glyph: '⑂', color: chalk.magenta, label: 'sub-agent spawned' },
   'artifact.created': { glyph: '▤', color: chalk.cyan, label: 'artifact' },
+  'task.completed': { glyph: '✓', color: chalk.green, label: 'task completed' },
+  'checklist.created': { glyph: '☐', color: chalk.cyan, label: 'checklist created' },
   'status.posted': { glyph: '▸', color: chalk.white, label: 'status' },
   'file.edited': { glyph: '·', color: chalk.gray, label: 'file edited' },
 };
@@ -357,15 +363,17 @@ export function formatActivityLine(ev: ActivityEvent, opts: { showHost?: boolean
  * line per event to ~/.agents/.history/activity/<sessionId>.jsonl.
  *
  * Matcher-gated to mutating/milestone tools (Bash|Task|ExitPlanMode|Write|
- * Edit|MultiEdit) so read-only tools never pay the hook cost. Fail-open: any
- * error is swallowed so a logging hiccup never blocks a tool call.
+ * Edit|MultiEdit|TodoWrite|update_plan|TaskUpdate|todo_write|TaskCreate) so
+ * read-only tools never pay the hook cost. Fail-open: any error is swallowed so
+ * a logging hiccup never blocks a tool call.
  */
 export const ACTIVITY_LOG_HOOK_SCRIPT = `#!/usr/bin/env python3
 """Append agent-activity events for \`agents feed\` / \`agents activity\`.
 
 Bound to PreToolUse (ExitPlanMode, Task) and PostToolUse (Bash, Write, Edit,
-MultiEdit). One append-only file per session; read-only tools never trigger it
-because the manifest matcher excludes them.
+MultiEdit, TodoWrite, update_plan, TaskUpdate, todo_write, TaskCreate). One
+append-only file per session; read-only tools never trigger it because the
+manifest matcher excludes them.
 
 Sub-agent gate: when the payload carries \`agent_type\`, this is a Task/Agent
 sub-agent -- skip so only the top-level agent logs its own activity.
@@ -384,7 +392,7 @@ MAX_LOG_BYTES = 5 * 1024 * 1024  # cap a pathological session's log
 MILESTONE_EVENTS = {
     "plan.created", "pr.opened", "pr.merged", "worktree.created",
     "worktree.removed", "commit.created", "pushed", "subagent.spawned",
-    "artifact.created", "status.posted",
+    "artifact.created", "task.completed", "checklist.created", "status.posted",
 }
 
 # Deliverable file types + locations -- a Write here is a recognizable artifact
@@ -394,6 +402,14 @@ ARTIFACT_EXTS = {
     ".webp", ".mp4", ".mov", ".webm", ".csv", ".xlsx", ".pptx", ".docx",
 }
 ARTIFACT_DIR_HINTS = ("/tmp/", "/downloads/", "/.agents/artifacts/")
+
+# Checklist tools across harnesses. The value is the key that holds the item list.
+CHECKLIST_TOOLS = {
+    "TodoWrite": "todos",
+    "todo_write": "todos",
+    "TaskUpdate": "tasks",
+    "update_plan": "plan",
+}
 
 
 def is_artifact(file_path):
@@ -470,10 +486,409 @@ def extract_url(tool_response):
     return m.group(0).rstrip(").,") if m else None
 
 
+def _checklist_items(tool_input, kind):
+    """Extract normalized checklist items from tool input."""
+    if not isinstance(tool_input, dict):
+        return []
+    if kind == "todos":
+        arr = tool_input.get("todos") or []
+    elif kind == "tasks":
+        arr = tool_input.get("tasks") or []
+        if not arr and "taskId" in tool_input:
+            arr = [tool_input]
+    elif kind == "plan":
+        arr = tool_input.get("plan") or []
+    else:
+        return []
+    if not isinstance(arr, list):
+        return []
+
+    items = []
+    for t in arr:
+        if not isinstance(t, dict):
+            continue
+        subject = (
+            t.get("content") or
+            t.get("text") or
+            t.get("step") or
+            t.get("title") or
+            t.get("description") or
+            t.get("activeForm") or
+            ""
+        )
+        if not isinstance(subject, str):
+            subject = str(subject)
+        subject = subject.strip()
+        item_id = t.get("id") or t.get("taskId") or subject
+        if not item_id:
+            continue
+        status = str(t.get("status", "") or "").lower()
+        items.append({"id": item_id, "subject": subject, "status": status})
+    return items
+
+
+def _read_transcript_checklists(transcript_path, current_tool, current_items):
+    """Tail-read the session transcript and return the previous checklist state.
+
+    The most recent checklist entry is assumed to be the current tool call if
+    it carries the same ids; skip that one and return the next older checklist
+    state (or None if there isn't one).
+    """
+    if not transcript_path or not os.path.exists(transcript_path):
+        return None
+    try:
+        size = os.path.getsize(transcript_path)
+        start = max(0, size - 512 * 1024)
+        with open(transcript_path, "r", encoding="utf-8", errors="ignore") as f:
+            f.seek(start)
+            if start > 0:
+                f.readline()  # drop a leading partial line
+            lines = f.readlines()
+    except Exception:
+        return None
+
+    current_ids = {str(item.get("id")) for item in current_items if item.get("id")}
+    skipped_current = False
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(record, dict):
+            continue
+
+        tool_uses = []
+        if isinstance(record.get("tool_use"), list):
+            tool_uses = record["tool_use"]
+        elif record.get("name"):
+            tool_uses = [record]
+        elif record.get("tool_name"):
+            tool_uses = [record]
+
+        for tu in reversed(tool_uses):
+            if not isinstance(tu, dict):
+                continue
+            name = tu.get("name") or tu.get("tool_name") or ""
+            if name not in CHECKLIST_TOOLS:
+                continue
+            kind = CHECKLIST_TOOLS[name]
+            args = tu.get("input") or tu.get("tool_input") or tu.get("arguments") or {}
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except Exception:
+                    continue
+            items = _checklist_items(args, kind)
+            if not items:
+                continue
+            ids = {str(item.get("id")) for item in items if item.get("id")}
+            # Skip the most recent matching checklist entry once; that is the
+            # current call already reflected in the transcript.
+            if not skipped_current and name == current_tool and ids == current_ids:
+                skipped_current = True
+                continue
+            return items
+    return None
+
+
+def _has_previous_task_create(transcript_path, current_tool_use_id=""):
+    """Return True if the transcript contains a TaskCreate before the current one."""
+    if not transcript_path or not os.path.exists(transcript_path):
+        return False
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+    except Exception:
+        return False
+
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(record, dict):
+            continue
+
+        tool_uses = []
+        msg = record.get("message", {})
+        if isinstance(msg, dict) and isinstance(msg.get("content"), list):
+            tool_uses = [
+                c for c in msg["content"]
+                if isinstance(c, dict) and c.get("type") == "tool_use"
+            ]
+        elif isinstance(record.get("tool_use"), list):
+            tool_uses = record["tool_use"]
+        elif record.get("name"):
+            tool_uses = [record]
+
+        for tu in reversed(tool_uses):
+            if not isinstance(tu, dict):
+                continue
+            if (tu.get("name") or tu.get("tool_name")) == "TaskCreate":
+                if tu.get("id") != current_tool_use_id:
+                    return True
+    return False
+
+
+def _claude_task_state(transcript_path, exclude_task_id=None):
+    """Fold Claude TaskCreate/TaskUpdate calls into a task id -> subject/status map.
+
+    TaskCreate provides the subject (and id via toolUseResult); TaskUpdate
+    provides the status. If exclude_task_id is given, the last TaskUpdate for
+    that id is skipped (it is the current call already reflected in the
+    transcript).
+    """
+    state = {}
+    if not transcript_path or not os.path.exists(transcript_path):
+        return state
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+    except Exception:
+        return state
+
+    updates = []  # (task_id, status, line_index)
+    for idx, line in enumerate(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(record, dict):
+            continue
+
+        tool_uses = []
+        msg = record.get("message", {})
+        if isinstance(msg, dict) and isinstance(msg.get("content"), list):
+            tool_uses = [
+                c for c in msg["content"]
+                if isinstance(c, dict) and c.get("type") == "tool_use"
+            ]
+        elif isinstance(record.get("tool_use"), list):
+            tool_uses = record["tool_use"]
+        elif record.get("name"):
+            tool_uses = [record]
+
+        for tu in tool_uses:
+            if not isinstance(tu, dict):
+                continue
+            name = tu.get("name") or ""
+            args = tu.get("input") or tu.get("tool_input") or {}
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except Exception:
+                    continue
+            if name == "TaskCreate":
+                subject = (
+                    args.get("subject") or
+                    args.get("description") or
+                    args.get("title") or
+                    ""
+                )
+                if subject:
+                    # Link subject to the tool_use id so the result can map it.
+                    tool_id = tu.get("id")
+                    if tool_id:
+                        state.setdefault("__pending_subject", {})[tool_id] = subject
+
+        tool_result = record.get("toolUseResult") or {}
+        if not isinstance(tool_result, dict):
+            continue
+        task = tool_result.get("task")
+        if isinstance(task, dict):
+            task_id = str(task.get("id") or task.get("taskId") or "")
+            if task_id:
+                state.setdefault(task_id, {})
+                if task.get("subject"):
+                    state[task_id]["subject"] = task["subject"]
+                if task.get("status"):
+                    state[task_id]["status"] = str(task.get("status")).lower()
+                # Link any pending subject from the matching tool_use id.
+                tool_use_id = record.get("tool_use_id") or ""
+                pending = state.get("__pending_subject", {})
+                if tool_use_id and tool_use_id in pending:
+                    state[task_id]["subject"] = pending[tool_use_id]
+        task_id = str(tool_result.get("taskId") or "")
+        status_change = tool_result.get("statusChange") or {}
+        status = status_change.get("to") or tool_result.get("status")
+        if task_id and status:
+            state.setdefault(task_id, {})
+            state[task_id]["status"] = str(status).lower()
+            updates.append((task_id, str(status).lower(), idx))
+
+    if exclude_task_id and updates:
+        for i in range(len(updates) - 1, -1, -1):
+            if updates[i][0] == exclude_task_id:
+                del updates[i]
+                break
+        # Rebuild statuses from remaining updates.
+        for task_id in list(state.keys()):
+            if task_id.startswith("__"):
+                continue
+            if "subject" not in state[task_id]:
+                del state[task_id]
+            else:
+                state[task_id].pop("status", None)
+        for task_id, status, _ in updates:
+            if task_id in state:
+                state[task_id]["status"] = status
+
+    # Drop internal bookkeeping.
+    state.pop("__pending_subject", None)
+    return state
+
+
+def _checklist_events(payload, hook_event):
+    """Return a list of (event, detail) tuples for checklist tool calls."""
+    if hook_event != "PostToolUse":
+        return []
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {}) or {}
+
+    if tool_name == "TaskCreate":
+        subject = (
+            tool_input.get("subject") or
+            tool_input.get("description") or
+            tool_input.get("title") or
+            "task"
+        )
+        # Only announce the checklist on the very first task creation.
+        current_tool_use_id = payload.get("tool_use_id", "")
+        transcript_path = payload.get("transcript_path")
+        if _has_previous_task_create(transcript_path, current_tool_use_id):
+            return []
+        return [("checklist.created", subject)]
+
+    if tool_name not in CHECKLIST_TOOLS:
+        return []
+
+    kind = CHECKLIST_TOOLS[tool_name]
+    items = _checklist_items(tool_input, kind)
+    if not items:
+        return []
+
+    # Full-list tools (TodoWrite, update_plan) send the whole checklist every
+    # time. Per-task update tools (TaskUpdate) send only the changed item, so
+    # totals and subject must be resolved from the previous full-list state.
+    list_key = {"todos": "todos", "tasks": "tasks", "plan": "plan"}.get(kind)
+    is_full_list = list_key is not None and list_key in tool_input
+
+    previous = _read_transcript_checklists(
+        payload.get("transcript_path"), tool_name, items
+    )
+
+    if not is_full_list and previous:
+        total = len(previous)
+        previous_done = {
+            str(i.get("id")) for i in previous
+            if i.get("status") == "completed" and i.get("id")
+        }
+        done_count = len(previous_done)
+        events = []
+        for item in items:
+            if item.get("status") != "completed":
+                continue
+            item_id = str(item.get("id"))
+            if item_id in previous_done:
+                continue
+            subject = item.get("subject")
+            if not subject:
+                for p in previous:
+                    if str(p.get("id")) == item_id and p.get("subject"):
+                        subject = p["subject"]
+                        break
+            if not subject:
+                subject = "task"
+            done_count += 1
+            events.append(("task.completed", f"{subject} {done_count}/{total} done"))
+        return events
+
+    # For TaskUpdate without a previous full-list state, fold the Claude
+    # TaskCreate/TaskUpdate history to resolve subject and N/M.
+    if tool_name == "TaskUpdate" and previous is None:
+        task_id = str(items[0].get("id")) if items else ""
+        task_state = _claude_task_state(
+            payload.get("transcript_path"), exclude_task_id=task_id
+        )
+        if task_state:
+            total = len(task_state)
+            previous_done = {
+                tid for tid, info in task_state.items()
+                if info.get("status") == "completed"
+            }
+            done_count = len(previous_done)
+            if task_id in task_state and items[0].get("status") == "completed" and task_id not in previous_done:
+                subject = task_state[task_id].get("subject") or "task"
+                return [("task.completed", f"{subject} {done_count + 1}/{total} done")]
+            return []
+
+    total = len(items)
+    completed = [i for i in items if i.get("status") == "completed"]
+
+    if previous is None:
+        # First checklist call in this session.
+        events = []
+        events.append(("checklist.created", f"{total} task{'s' if total != 1 else ''}"))
+        for item in completed:
+            events.append((
+                "task.completed",
+                f"{item['subject']} {len(completed)}/{total} done",
+            ))
+        return events
+
+    previous_done = {
+        str(i.get("id")) for i in previous
+        if i.get("status") == "completed" and i.get("id")
+    }
+    newly_completed = [
+        i for i in completed
+        if str(i.get("id")) not in previous_done
+    ]
+    if not newly_completed:
+        return []
+
+    done_count = len(completed)
+    events = []
+    for item in newly_completed:
+        events.append((
+            "task.completed",
+            f"{item['subject']} {done_count}/{total} done",
+        ))
+    return events
+
+
+def _make_record(event, detail, tool_name):
+    tier = "milestone" if event in MILESTONE_EVENTS else "activity"
+    record = {
+        "v": 1,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": event,
+        "tier": tier,
+    }
+    if detail:
+        record["detail"] = detail
+    record["tool"] = tool_name
+    return record
+
+
 def build_event(payload, hook_event):
     tool_name = payload.get("tool_name", "")
     tool_input = payload.get("tool_input", {}) or {}
     tool_response = payload.get("tool_response", {})
+
+    # Checklist completions first -- cheap guard above already filtered tool name.
+    checklist = _checklist_events(payload, hook_event)
+    if checklist:
+        return [_make_record(event, detail, tool_name) for event, detail in checklist], tool_name
 
     event = None
     detail = None
@@ -505,21 +920,12 @@ def build_event(payload, hook_event):
             detail = os.path.basename(fp) if fp else tool_name
 
     if not event:
-        return None, tool_name
+        return [], tool_name
 
-    tier = "milestone" if event in MILESTONE_EVENTS else "activity"
-    record = {
-        "v": 1,
-        "ts": datetime.now(timezone.utc).isoformat(),
-        "event": event,
-        "tier": tier,
-    }
-    if detail:
-        record["detail"] = detail
+    record = _make_record(event, detail, tool_name)
     if url:
         record["url"] = url
-    record["tool"] = tool_name
-    return record, tool_name
+    return [record], tool_name
 
 
 def main():
@@ -538,8 +944,8 @@ def main():
         return
 
     hook_event = payload.get("hook_event_name", "")
-    record, tool_name = build_event(payload, hook_event)
-    if not record:
+    records, tool_name = build_event(payload, hook_event)
+    if not records:
         return
 
     safe_session = re.sub(r"[^A-Za-z0-9._-]", "-", session_id) or "unknown"
@@ -554,27 +960,29 @@ def main():
     hostname = os.environ.get("AGENTS_SYNC_MACHINE_ID") or socket.gethostname()
     host = re.sub(r"[^a-z0-9_-]", "-", hostname.split(".")[0].strip().lower()) or "unknown"
 
-    record["sessionId"] = session_id
-    record["mailboxId"] = mailbox_id
-    record["host"] = host
-    record["runtime"] = os.environ.get("AGENTS_RUNTIME", "headless")
-    cwd = payload.get("cwd") or os.environ.get("AGENTS_CWD")
-    if cwd:
-        record["cwd"] = cwd
-    agent = os.environ.get("AGENTS_AGENT_NAME") or "claude"
-    record["agent"] = agent
+    for record in records:
+        record["sessionId"] = session_id
+        record["mailboxId"] = mailbox_id
+        record["host"] = host
+        record["runtime"] = os.environ.get("AGENTS_RUNTIME", "headless")
+        cwd = payload.get("cwd") or os.environ.get("AGENTS_CWD")
+        if cwd:
+            record["cwd"] = cwd
+        agent = os.environ.get("AGENTS_AGENT_NAME") or "claude"
+        record["agent"] = agent
 
     try:
         os.makedirs(activity_dir, exist_ok=True)
         # Cap growth: once over the size limit, keep only milestones.
-        if record["tier"] != "milestone":
-            try:
-                if os.path.getsize(target) > MAX_LOG_BYTES:
-                    return
-            except OSError:
-                pass
+        try:
+            over_limit = os.path.getsize(target) > MAX_LOG_BYTES
+        except OSError:
+            over_limit = False
         with open(target, "a") as f:
-            f.write(json.dumps(record) + "\\n")
+            for record in records:
+                if over_limit and record.get("tier") != "milestone":
+                    continue
+                f.write(json.dumps(record) + "\\n")
     except Exception:
         pass  # fail open
 
@@ -598,7 +1006,7 @@ export const ACTIVITY_HOOK_DEFINITIONS: Record<string, Record<string, unknown>> 
   'activity-log-result': {
     agents: ['claude'],
     events: ['PostToolUse'],
-    matcher: 'Bash|Write|Edit|MultiEdit',
+    matcher: 'Bash|Write|Edit|MultiEdit|TodoWrite|update_plan|TaskUpdate|todo_write|TaskCreate',
     script: '11-activity-log.py',
     timeout: 5,
   },

--- a/apps/cli/src/lib/event-stream.test.ts
+++ b/apps/cli/src/lib/event-stream.test.ts
@@ -98,4 +98,20 @@ describe('readUnifiedEvents', () => {
     }
     expect(readUnifiedEvents({ activityRoot, limit: 3 })).toHaveLength(3);
   });
+
+  it('carries checklist activity events into the unified stream', () => {
+    const { activityRoot } = setup();
+    appendActivityEvent(
+      { ts: new Date(Date.now() - 1000).toISOString(), event: 'task.completed', sessionId: 's-check', mailboxId: 's-check', host: 'h', runtime: 'headless', agent: 'claude', detail: 'Write tests 2/3 done' },
+      activityRoot,
+    );
+    appendActivityEvent(
+      { ts: new Date(Date.now() - 2000).toISOString(), event: 'checklist.created', sessionId: 's-check', mailboxId: 's-check', host: 'h', runtime: 'headless', agent: 'claude', detail: '3 tasks' },
+      activityRoot,
+    );
+    const events = readUnifiedEvents({ activityRoot, eventTypes: ['task.completed', 'checklist.created'] });
+    expect(events.map((e) => e.event)).toEqual(['task.completed', 'checklist.created']);
+    expect(events[0].detail).toBe('Write tests 2/3 done');
+    expect(events[0].module).toBe('activity');
+  });
 });

--- a/apps/cli/src/lib/events.test.ts
+++ b/apps/cli/src/lib/events.test.ts
@@ -390,4 +390,21 @@ describe('events', () => {
       expect(results[0].args).toEqual(['claude', '-p', 'hi']);
     });
   });
+
+  describe('activity event types', () => {
+    it('accepts checklist events in the EventType union through emit/query', () => {
+      setupLogsDir();
+      emit('task.completed', { agent: 'claude', detail: 'Write tests 2/3 done' });
+      emit('checklist.created', { agent: 'claude', detail: '3 tasks' });
+
+      const tasks = query({ eventTypes: ['task.completed'] });
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].event).toBe('task.completed');
+      expect(tasks[0].detail).toBe('Write tests 2/3 done');
+
+      const lists = query({ eventTypes: ['checklist.created'] });
+      expect(lists).toHaveLength(1);
+      expect(lists[0].event).toBe('checklist.created');
+    });
+  });
 });

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -131,6 +131,8 @@ export type EventType =
   | 'pushed'
   | 'subagent.spawned'
   | 'artifact.created'
+  | 'task.completed'
+  | 'checklist.created'
   | 'status.posted'
   | 'file.edited'
   // Generic


### PR DESCRIPTION
Emits a feed event when an agent checks off a task-checklist item, so completions show as milestones in `agents feed` and the unified `agents events` stream. Part of RUSH-2043 (task checklists as a first-class signal); pairs with the parser (#1562) and preview (#1561) PRs.

## What changed
- **`lib/activity.ts`** — the embedded `11-activity-log.py` hook now, on a PostToolUse checklist-completion, folds the session transcript to get the item subject + running `N/M` and appends a **`task.completed`** milestone (and **`checklist.created`** on first appearance). Added both kinds to `MilestoneEvent` with glyphs (`✓` / `☐`) and labels.
- **`lib/events.ts`** — the new kinds bridged into the `EventType` union so `agents events` carries them.
- Renders automatically in the feed lane (`renderActivityLane`, tier `milestone`).

## Harness parity
Completion detection folds the transcript across the harnesses that have a checklist tool: **Claude** `TaskUpdate`/`TodoWrite`, **Grok** `todo_write`, **Codex** `update_plan`. Harnesses without a checklist tool are no-ops.

## Tests
82 tests pass across the 4 changed test files (`activity.test.ts`, `events.test.ts`, `event-stream.test.ts`, `feed.test.ts`) — no mocks; they drive the real hook classification + append path.

Closes RUSH-2046.
