### PR TITLE
fix(factory): bind reloaded tab to the session actually running in the pane

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -24,6 +24,26 @@ All notable changes to the Factory extension are documented here. Format follows
 - **Native-mode agent terminal tabs now close automatically when the agent exits (RUSH-2026).** In native (non-tmux) terminal mode, the launch command is now prefixed with `exec` so the shell process replaces itself with the agent runner. When the agent exits the terminal process exits too and VS Code closes the tab automatically — no manual close needed. This mirrors the existing tmux pane-died behaviour. Shell tabs (the SH agent type) and tmux-mode terminals are unaffected. Remote `--host` launches get the same treatment: the local SSH wrapper exits with the remote session. Source: `apps/factory/src/core/agents.ts` (`wrapNativeAgentCommand`), `apps/factory/src/vscode/extension.ts` (`openSingleAgent`).
 
 - **Interactive agent launches now default to `--mode auto` instead of stalling in read-only plan mode (RUSH-2038).** Launching Codex, Claude, Gemini, Cursor, OpenCode, or Antigravity from Factory without explicitly choosing a mode now runs in `auto` (writable-but-gated), so the agent can edit files immediately. Previously the CLI default of `plan` was inherited, causing Codex to start with `--sandbox read-only` and wait indefinitely for approval. `buildAgentLaunchCommand` is now in `src/core/agents.ts` so it is unit-testable without a VS Code harness. Source: `apps/factory/src/core/agents.ts`, `apps/factory/src/vscode/extension.ts`.
+- **A reloaded terminal tab no longer gets bound to the wrong session (wrong id,
+  account, and version).** On a window reload — especially a Remote-SSH
+  reconnect, where VS Code drops `terminal.creationOptions.env` — `scanExisting`
+  lost the tab's `AGENT_SESSION_ID` and its name chunk, then fell back to
+  matching the persisted store by agent prefix + "most recently created". That
+  heuristic has no tie to the pane, so a Claude tab actually running one session
+  could be shown as a sibling session that merely looked newest (observed: status
+  bar read `ffa1f432… 2.1.220 <gmail>` while `/status` in the same pane reported
+  `e2030c92… 2.1.186 <getrush>`). Reload now first asks the process actually
+  running in the pane: it walks the tab's live process tree (`findAgentInTree`),
+  gated to the tab's own agent, and reads the running agent's own
+  `--session-id`/`--resume` arg, which wins over every env/name/persisted
+  heuristic. `extractSessionIdFromArgs` also learned to recognize
+  `--resume <uuid>` (claude's native resume form) — previously only
+  `--session-id` was parsed, so a resumed pane's live id was invisible and the
+  shell-adoption path fell to a mtime-nearest session-file guess. Source:
+  `apps/factory/src/vscode/terminals.vscode.ts` (`scanExisting`),
+  `apps/factory/src/monitor/readinessDetector.ts` (`findAgentInTree`,
+  `selectAgentFromCandidates`),
+  `apps/factory/src/core/terminalReadiness.ts` (`extractSessionIdFromArgs`).
 
 - **Stuck Claude tab labels self-heal, and an existing session name is reused
   before summarizing.** Two follow-ups to the derived-label fix: (1) On reload,
@@ -122,7 +142,6 @@ All notable changes to the Factory extension are documented here. Format follows
   CLI's `presence` (`attached` / `background` / `parked`). Source:
   `apps/factory/src/vscode/extension.ts`, `apps/factory/src/core/remoteSessions.ts`,
   `apps/factory/package.json`.
-
 - **agents-dbg now has a 0.1.0 Mac release pipeline (RUSH-1015).** The standalone
   Electron app packages as `agents-dbg.app` with the `com.phnxlabs.agents-dbg`
   bundle id, hardened-runtime entitlements, Developer ID signing, and

--- a/apps/factory/src/core/terminalReadiness.ts
+++ b/apps/factory/src/core/terminalReadiness.ts
@@ -192,14 +192,24 @@ export function detectAgentKeyFromArgs(args: string): AgentLauncherKey | null {
 }
 
 /**
- * Extract a session UUID from agent CLI args. Recognizes:
- *   --session-id <uuid>
+ * Extract the LIVE session UUID from an agent CLI arg string. Recognizes:
+ *   --session-id <uuid>   (claude CREATES a fresh conversation with this id)
  *   --session-id=<uuid>
- *   --session <uuid>
+ *   --session <uuid>      (alternate flag)
+ *   --resume <uuid>       (claude's native resume — the id it CONTINUES)
+ *   --resume=<uuid>
+ *
+ * `--resume` is included deliberately: agents-cli resumes claude with
+ * `--resume <id>` (see apps/cli `buildExecCommand`), not `--session-id`, so a
+ * resumed pane's live session only shows up under `--resume`. Without it, a
+ * resumed claude yields no id from argv and callers fall back to a
+ * mtime-nearest session-file guess that can bind the wrong (sibling) session.
+ * `--session-id` and `--resume` are mutually exclusive at the CLI, so there is
+ * no ambiguity between the two.
  */
 export function extractSessionIdFromArgs(args: string): string | undefined {
   const m = args.match(
-    /--session(?:-id)?[\s=]([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i
+    /--(?:session(?:-id)?|resume)[\s=]([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i
   );
   return m?.[1];
 }

--- a/apps/factory/src/monitor/readinessDetector.test.ts
+++ b/apps/factory/src/monitor/readinessDetector.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawn, ChildProcess } from 'child_process';
-import { ReadinessDetector } from './readinessDetector';
+import { ReadinessDetector, selectAgentFromCandidates } from './readinessDetector';
 import { ReadinessFactPayload } from './protocol';
 
 const spawned: ChildProcess[] = [];
@@ -115,4 +115,51 @@ describe('ReadinessDetector', () => {
       detector.stop();
     }
   }, 10000);
+});
+
+// The gate that stops a Claude tab from adopting a nested codex session on
+// reload (Strategy 0 in scanExisting). Pure over ordered BFS candidates — no
+// process probing, no mocks.
+describe('selectAgentFromCandidates — agent-type gating', () => {
+  const claudeId = '11111111-1111-4111-8111-111111111111';
+  const codexId = '22222222-2222-4222-8222-222222222222';
+  // A Claude tab whose shell also has a nested codex descendant, shallower.
+  const mixedTree = [
+    { childPid: 100, args: `codex --session-id ${codexId}` },
+    { childPid: 200, args: `claude --session-id ${claudeId}` },
+  ];
+
+  test('wanting claude skips the shallower codex and returns the claude id', () => {
+    const m = selectAgentFromCandidates(mixedTree, 'claude');
+    expect(m).not.toBeNull();
+    expect(m!.agentKey).toBe('claude');
+    expect(m!.childPid).toBe(200);
+    expect(m!.sessionId).toBe(claudeId);
+  });
+
+  test('wanting codex returns the codex id from the same tree', () => {
+    const m = selectAgentFromCandidates(mixedTree, 'codex');
+    expect(m!.agentKey).toBe('codex');
+    expect(m!.sessionId).toBe(codexId);
+  });
+
+  test('no wanted agent keeps first-of-any-type (unchanged adoption behavior)', () => {
+    const m = selectAgentFromCandidates(mixedTree);
+    expect(m!.agentKey).toBe('codex');
+    expect(m!.sessionId).toBe(codexId);
+  });
+
+  test('returns null when the wanted agent is absent — no wrong-agent fallback', () => {
+    expect(selectAgentFromCandidates([{ childPid: 100, args: `codex --session-id ${codexId}` }], 'claude')).toBeNull();
+    expect(selectAgentFromCandidates([], 'claude')).toBeNull();
+  });
+
+  test('resumed claude (--resume) is matched under the agent gate', () => {
+    const m = selectAgentFromCandidates(
+      [{ childPid: 300, args: `claude --resume ${claudeId}` }],
+      'claude',
+    );
+    expect(m!.agentKey).toBe('claude');
+    expect(m!.sessionId).toBe(claudeId);
+  });
 });

--- a/apps/factory/src/monitor/readinessDetector.ts
+++ b/apps/factory/src/monitor/readinessDetector.ts
@@ -63,26 +63,52 @@ export interface AgentInTreeMatch {
   sessionId?: string;
 }
 
-/** Walk the descendant tree of `rootPid` for a known agent CLI. */
+/**
+ * Pick the first agent process from BFS-ordered `(childPid, args)` candidates.
+ * When `wantAgentKey` is set, descendants of a DIFFERENT agent are skipped, so a
+ * shallower wrong-agent process (e.g. a nested `codex` under a Claude tab's
+ * shell) can never shadow the agent the caller actually wants. Pure — no
+ * process probing — so the mixed-tree behavior is unit-testable without mocks.
+ */
+export function selectAgentFromCandidates(
+  candidates: Array<{ childPid: number; args: string }>,
+  wantAgentKey?: AgentLauncherKey,
+): AgentInTreeMatch | null {
+  for (const { childPid, args } of candidates) {
+    const agentKey = detectAgentKeyFromArgs(args);
+    if (agentKey && (!wantAgentKey || agentKey === wantAgentKey)) {
+      return { agentKey, childPid, sessionId: extractSessionIdFromArgs(args) };
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk the descendant tree of `rootPid` for a known agent CLI. When
+ * `wantAgentKey` is passed, only a descendant of that exact agent is returned —
+ * the walk continues past other-agent processes (shallow-first order preserved)
+ * instead of returning the first agent of any type.
+ */
 export async function findAgentInTree(
   rootPid: number,
   maxDepth: number,
+  wantAgentKey?: AgentLauncherKey,
 ): Promise<AgentInTreeMatch | null> {
+  const candidates: Array<{ childPid: number; args: string }> = [];
   let frontier = [rootPid];
   for (let depth = 0; depth < maxDepth && frontier.length > 0; depth++) {
     const childrenResults = await Promise.all(frontier.map((pid) => probeChildPids(pid)));
     const nextFrontier = childrenResults.flat().filter((n) => Number.isFinite(n));
     for (const childPid of nextFrontier) {
       try {
-        const args = await probeArgs(childPid);
-        const agentKey = detectAgentKeyFromArgs(args);
-        if (agentKey) {
-          return { agentKey, childPid, sessionId: extractSessionIdFromArgs(args) };
-        }
+        candidates.push({ childPid, args: await probeArgs(childPid) });
       } catch {
         // child may have exited; skip
       }
     }
+    // Shallow-first: return as soon as this depth yields the wanted agent.
+    const match = selectAgentFromCandidates(candidates, wantAgentKey);
+    if (match) return match;
     frontier = nextFrontier;
   }
   return null;

--- a/apps/factory/src/vscode/terminalReadiness.integration.test.ts
+++ b/apps/factory/src/vscode/terminalReadiness.integration.test.ts
@@ -143,12 +143,32 @@ describe('shell adoption — extractSessionIdFromArgs', () => {
     expect(extractSessionIdFromArgs(`gemini --session ${uuid}`)).toBe(uuid);
   });
 
+  // A resumed claude carries its live session id under `--resume`, not
+  // `--session-id` (agents-cli buildExecCommand). Recovering it here is what
+  // lets scanExisting bind a reloaded Remote-SSH pane to the session actually
+  // running in it, instead of a mtime-nearest sibling.
+  test('--resume space-separated (claude native resume)', () => {
+    expect(extractSessionIdFromArgs(`claude --resume ${uuid}`)).toBe(uuid);
+  });
+
+  test('--resume equals-separated', () => {
+    expect(extractSessionIdFromArgs(`claude --resume=${uuid}`)).toBe(uuid);
+  });
+
+  test('resume id wins for a real `agents run claude --resume` argv', () => {
+    const args = `node /path/agents run claude --resume ${uuid} --model opus`;
+    expect(extractSessionIdFromArgs(args)).toBe(uuid);
+  });
+
   test('returns undefined when no session flag present', () => {
     expect(extractSessionIdFromArgs('claude --foo bar')).toBeUndefined();
     expect(extractSessionIdFromArgs('')).toBeUndefined();
+    // `--continue` (resume most-recent, no id) carries no UUID to extract.
+    expect(extractSessionIdFromArgs('claude --continue')).toBeUndefined();
   });
 
   test('ignores non-UUID values', () => {
     expect(extractSessionIdFromArgs('claude --session-id not-a-uuid')).toBeUndefined();
+    expect(extractSessionIdFromArgs('claude --resume not-a-uuid')).toBeUndefined();
   });
 });

--- a/apps/factory/src/vscode/terminals.vscode.ts
+++ b/apps/factory/src/vscode/terminals.vscode.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs/promises';
 import { AgentConfig } from './agents.vscode';
 
 import { fetchGitInfo } from '../monitor/snapshotDetector';
+import { findAgentInTree, SHELL_ADOPTION_TREE_DEPTH } from '../monitor/readinessDetector';
 import { PanelSnapshotPayload, SnapshotWatch } from '../monitor/protocol';
 import { generateTerminalId, resolveRestoredVersion, RunningCounts } from '../core/terminals';
 import * as sessionsPersist from '../core/sessions.persist';
@@ -704,6 +705,34 @@ export async function scanExisting(
       setAgentType(terminal, agentType);
     }
     let sessionId = identOpts.sessionId;
+
+    // Strategy 0 (authoritative): ask the process ACTUALLY running in this
+    // pane. env (AGENT_SESSION_ID), the tab-name chunk, and the persisted
+    // store are all captured at spawn time and go stale the moment the live
+    // session changes (a /continue or a resume/rotate switches the running
+    // session id) — and VS Code frequently drops `creationOptions.env` across
+    // a Remote-SSH window reload, forcing the recency-based fallbacks below.
+    // Those fallbacks match only by agent prefix + "most recent", so on reload
+    // a tab can be bound to a SIBLING session (wrong id, account, and version)
+    // that merely looks newest. The live process's own `--session-id`/`--resume`
+    // arg is the only signal tied to THIS pane, so it wins over every heuristic.
+    if (pid !== undefined && agentType) {
+      try {
+        const live = await findAgentInTree(pid, SHELL_ADOPTION_TREE_DEPTH);
+        if (live?.sessionId) {
+          if (live.sessionId !== sessionId) {
+            console.log(
+              `[TERMINALS] Live-process sessionId ${live.sessionId} (pid=${pid}) ` +
+                `overrides ${sessionId ?? 'none'} from env`
+            );
+          }
+          sessionId = live.sessionId;
+        }
+      } catch {
+        // Process may have exited or the probe failed; fall through to the
+        // best-effort heuristics below.
+      }
+    }
 
     // Strategy 1: Try to recover from sessionChunk in terminal name
     if (!sessionId && info.sessionChunk && agentType) {

--- a/apps/factory/src/vscode/terminals.vscode.ts
+++ b/apps/factory/src/vscode/terminals.vscode.ts
@@ -8,6 +8,7 @@ import { AgentConfig } from './agents.vscode';
 
 import { fetchGitInfo } from '../monitor/snapshotDetector';
 import { findAgentInTree, SHELL_ADOPTION_TREE_DEPTH } from '../monitor/readinessDetector';
+import type { AgentLauncherKey } from '../core/terminalReadiness';
 import { PanelSnapshotPayload, SnapshotWatch } from '../monitor/protocol';
 import { generateTerminalId, resolveRestoredVersion, RunningCounts } from '../core/terminals';
 import * as sessionsPersist from '../core/sessions.persist';
@@ -716,16 +717,24 @@ export async function scanExisting(
     // a tab can be bound to a SIBLING session (wrong id, account, and version)
     // that merely looks newest. The live process's own `--session-id`/`--resume`
     // arg is the only signal tied to THIS pane, so it wins over every heuristic.
+    //
+    // Gate on THIS tab's agent: findAgentInTree only returns a descendant of
+    // `agentType`, so a nested/stray other-agent process (e.g. a codex spawned
+    // under a Claude tab's shell) can never bind this tab to the wrong agent's
+    // session. Only override an existing env id when the live id actually
+    // disagrees — a matching id is left untouched.
     if (pid !== undefined && agentType) {
       try {
-        const live = await findAgentInTree(pid, SHELL_ADOPTION_TREE_DEPTH);
-        if (live?.sessionId) {
-          if (live.sessionId !== sessionId) {
-            console.log(
-              `[TERMINALS] Live-process sessionId ${live.sessionId} (pid=${pid}) ` +
-                `overrides ${sessionId ?? 'none'} from env`
-            );
-          }
+        const live = await findAgentInTree(
+          pid,
+          SHELL_ADOPTION_TREE_DEPTH,
+          agentType as AgentLauncherKey
+        );
+        if (live?.sessionId && live.sessionId !== sessionId) {
+          console.log(
+            `[TERMINALS] Live-process sessionId ${live.sessionId} (pid=${pid}, ` +
+              `${live.agentKey}) overrides ${sessionId ?? 'none'} from env`
+          );
           sessionId = live.sessionId;
         }
       } catch {


### PR DESCRIPTION
## Problem

On a Remote-SSH window, the extension's status bar (its belief about a tab) and the session actually running in that terminal diverged:

- Status bar: `Claude 2.1.220 <muqsitnawaz@gmail.com> (ffa1f432-1a9e-4a81-8e93-e70aa8df1c95)`
- `/status` inside the same pane: `e2030c92-e3a0-4335-b9bf-79776600510b`, version `2.1.186`, `muqsit@getrush.ai`

Different session id **and** account **and** version — a clear misattribution.

## Root cause (traced, file:line)

`scanExisting` (`apps/factory/src/vscode/terminals.vscode.ts`) re-derives a tab's `sessionId` on every window reload. It reads `pid` (used only for labels) but never asks the process what session it is running. Its recovery chain is:

1. `env AGENT_SESSION_ID` — VS Code frequently drops `terminal.creationOptions.env` across a Remote-SSH reload (acknowledged in the code comment at `terminals.vscode.ts:624-632`).
2. tab-name session chunk — stale after a resume/rotate.
3. **Strategy 2** (`terminals.vscode.ts:669-696`): match the persisted store by **agent prefix only**, pick **most-recently-created**, assign positionally in terminal-iteration order. No pid/cwd/identity tie to the pane.

So when 1 and 2 are lost on reload, a Claude tab is bound to whichever persisted Claude session was created most recently — a sibling. Version rides along from that same persisted record (`:692-694`); account (`entry.statusAccount`) is never reconciled — producing a self-consistent but wrong label.

Separately, the shell-adoption path (`findAgentInTree` -> `extractSessionIdFromArgs`, `core/terminalReadiness.ts:200`) only parsed `--session-id`. agents-cli resumes claude with `--resume <id>` (`apps/cli/src/lib/exec.ts:807`), so a resumed pane's live id was invisible to arg-parsing and adoption fell to a mtime-nearest session-file guess (`readinessDetector.ts:125-147`).

## Fix (at the source)

- **Strategy 0 (authoritative)** in `scanExisting`: walk the tab's own live process tree (`findAgentInTree(pid, depth)`) and read the running agent's `--session-id`/`--resume` arg. It wins over env/name/persisted — the only signal tied to *this* pane. When it resolves, the recency heuristics never run, so the version-ride from a sibling record is also avoided.
- **`extractSessionIdFromArgs`** now recognizes `--resume <uuid>` / `--resume=<uuid>` (claude's native resume form), in addition to `--session-id`/`--session`. Benefits both Strategy 0 and the existing shell-adoption path.

## Verification

- `tsc -p ./ --noEmit` clean.
- `bun test` — `terminalReadiness.integration.test.ts` (+6 new `--resume` cases), `terminals.vscode.test.ts`, `sessionTracker.test.ts`, `core/terminals.test.ts`: **91 pass, 0 fail**.

The pure, no-mock core of the fix (`extractSessionIdFromArgs` recovering the live id from a real `--resume` argv) is unit-tested. The `scanExisting` wiring probes real processes (`ps`/`pgrep`), so full Remote-SSH-reload reproduction needs the live multi-session setup on zion — the mechanism is proven in code + the arg-parsing tests; a live reload-with-two-Claude-sessions is the remaining manual check.