### PR TITLE
fix(sessions): resolve short ids by id only in `sessions export`

### DIFF
--- a/apps/cli/.changelog/next/session-id-export-resolve.md
+++ b/apps/cli/.changelog/next/session-id-export-resolve.md
@@ -1,0 +1,11 @@
+- **`agents sessions export <id>` now resolves a short id the same way `sessions
+  <id>` does — by id only, never fuzzy content.** The id-only fix landed for the
+  `sessions` view but `sessions export` still gated its index lookup on
+  `isCompleteSessionId`, so a bare hex short-id like `d3470b57` absent from the
+  discovered pool skipped the index and fell through to the text query — bundling
+  every transcript that merely MENTIONED the id into the export. The one canonical
+  id-shaped test, `looksLikeSessionId`, now lives beside `isCompleteSessionId` in
+  `lib/session/discover.ts` and is shared: `sessions export` resolves any id-shaped
+  selector through the index (exact -> prefix -> `findSessionsById`) and reports
+  "No session with id …" on a miss instead of shipping the mentioner. Source:
+  `apps/cli/src/lib/session/discover.ts`, `apps/cli/src/commands/sessions-export.ts`.

--- a/apps/cli/src/commands/sessions-export-resolve.test.ts
+++ b/apps/cli/src/commands/sessions-export-resolve.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `selectSessions` (behind `agents sessions export <id>`) must resolve an
+ * id-shaped selector by id ONLY — never fall back to fuzzy content search.
+ *
+ * The flagged bug: the id/content gate keyed on `isCompleteSessionId`, so a bare
+ * hex SHORT id ("eeee5555") skipped the index lookup and — worse — fell through
+ * to the text query, bundling every transcript that merely MENTIONS the string
+ * (a resume prompt echoes the parent id into many later session bodies). Gating
+ * on `looksLikeSessionId` treats a short id as an id: exact -> prefix -> index,
+ * and a miss reports "no session with that id" instead of shipping the mentioner.
+ *
+ * Real DB under a temp HOME, no mocks. Synthetic ids (dddd/eeee/ffff) that no
+ * sibling test's fixtures use, so a shared index can't cross-contaminate.
+ */
+import { describe, it, expect, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate the sessions DB under a temp HOME before db.js/state.js capture the
+// path at import time.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-export-resolve-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { upsertSession, closeDB } = await import('../lib/session/db.js');
+const { selectSessions } = await import('./sessions-export.js');
+type SessionMeta = import('../lib/session/types.js').SessionMeta;
+
+// findSessionsById (and the content search) drop rows whose transcript is gone,
+// so the fixture writes a real file rather than a dangling path.
+function meta(id: string, extra: Partial<SessionMeta> = {}): SessionMeta {
+  const filePath = path.join(TEST_HOME, `${id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  return {
+    id,
+    shortId: id.slice(0, 8),
+    agent: 'claude',
+    timestamp: new Date().toISOString(),
+    filePath,
+    ...extra,
+  };
+}
+
+afterAll(() => {
+  closeDB();
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('selectSessions resolves an id-shaped selector by id only', () => {
+  it('a short id present only in another session\'s CONTENT is NOT selected', () => {
+    // The reproduction: the mentioner is in the pool AND indexed with content
+    // that mentions the query. A content fallback would surface it; id-only must
+    // report a miss and select nothing.
+    const mentioner = 'dddd4444-1111-2222-3333-444455556666';
+    const mentionerMeta = meta(mentioner, { topic: 'resume previous work eeee5555' });
+    upsertSession(mentionerMeta, 'resume previous work eeee5555 earlier in the thread');
+
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const selected = selectSessions([mentionerMeta], ['eeee5555']);
+    errSpy.mockRestore();
+
+    // Never the mentioner: a short id must not fuzzy-match content.
+    expect(selected).toEqual([]);
+  });
+
+  it('a short id that IS a real session prefix resolves to that session via the index', () => {
+    const full = 'ffff6666-1111-2222-3333-444455556666';
+    upsertSession(meta(full, { topic: 'the real one' }), '');
+    // Empty pool: the id is absent from the discovered pool but present in the
+    // index, exactly the pool-minority case selectSessions widens through.
+    const selected = selectSessions([], ['ffff6666']);
+    expect(selected.map(s => s.id)).toEqual([full]);
+  });
+
+  it('a complete id absent from the pool still resolves through the index', () => {
+    const indexed = 'dddd4444-9999-8888-7777-666655554444';
+    upsertSession(meta(indexed, { topic: 'indexed but not discovered' }), '');
+    expect(selectSessions([], [indexed]).map(s => s.id)).toEqual([indexed]);
+  });
+
+  it('a genuine search phrase keeps the ranked content path', () => {
+    const hit = 'ffff6666-aaaa-bbbb-cccc-ddddeeeeffff';
+    const hitMeta = meta(hit, { topic: 'refactor the auth middleware' });
+    upsertSession(hitMeta, 'refactor the auth middleware for clarity');
+    // A non-id selector must still content-match (this is NOT an id-shaped query).
+    const selected = selectSessions([hitMeta], ['auth middleware']);
+    expect(selected.map(s => s.id)).toContain(hit);
+  });
+});

--- a/apps/cli/src/commands/sessions-export.ts
+++ b/apps/cli/src/commands/sessions-export.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import type { SessionMeta } from '../lib/session/types.js';
-import { discoverSessions, resolveSessionById, isCompleteSessionId } from '../lib/session/discover.js';
+import { discoverSessions, resolveSessionById, looksLikeSessionId } from '../lib/session/discover.js';
 import { findSessionsById } from '../lib/session/db.js';
 import { filterSessionsByQuery, parseAgentFilter } from './sessions.js';
 import { listLocalTranscripts, SYNC_AGENTS, type LocalTranscript } from '../lib/session/sync/agents.js';
@@ -248,8 +248,8 @@ function resolveAgentShorthand(g: GlobalSelection): string | undefined {
   return undefined;
 }
 
-/** ids > query > everything-in-scope. */
-function selectSessions(metas: SessionMeta[], selectors: string[]): SessionMeta[] {
+/** ids > query > everything-in-scope. Exported for the id-resolution test. */
+export function selectSessions(metas: SessionMeta[], selectors: string[]): SessionMeta[] {
   if (selectors.length === 0) return metas;
 
   const byId: SessionMeta[] = [];
@@ -257,9 +257,11 @@ function selectSessions(metas: SessionMeta[], selectors: string[]): SessionMeta[
   for (const sel of selectors) {
     const trimmed = sel.trim();
     // Same reason as resolveSessionQuery: the discovered pool is a minority of
-    // the index, so a complete id absent from it may still be indexed here.
+    // the index, so an id-shaped selector absent from it may still be indexed
+    // here. Gate on looksLikeSessionId, not isCompleteSessionId, so a SHORT id
+    // ("d3470b57") also resolves through the index instead of falling to content.
     const hits = resolveSessionById(metas, trimmed);
-    const resolved = hits.length > 0 || !isCompleteSessionId(trimmed) ? hits : findSessionsById(trimmed);
+    const resolved = hits.length > 0 || !looksLikeSessionId(trimmed) ? hits : findSessionsById(trimmed);
     if (resolved.length > 0) byId.push(...resolved);
     else unmatched.push(trimmed);
   }
@@ -267,11 +269,12 @@ function selectSessions(metas: SessionMeta[], selectors: string[]): SessionMeta[
     const seen = new Set<string>();
     return byId.filter(s => (seen.has(s.id) ? false : (seen.add(s.id), true)));
   }
-  // A selector that is a COMPLETE session id and still missed cannot be widened:
-  // the id is unique, so the text query below could only bundle sessions that
-  // merely mention it. Bundling those would ship unrelated transcripts to
-  // whoever receives the export, so select nothing and let the caller report it.
-  const missingIds = unmatched.filter(isCompleteSessionId);
+  // A selector that is an id (complete OR a short hex id/prefix) and still missed
+  // cannot be widened: the id is unique, so the text query below could only bundle
+  // sessions that merely mention it. Bundling those would ship unrelated
+  // transcripts to whoever receives the export, so select nothing and let the
+  // caller report it — a short id like "d3470b57" must never content-search.
+  const missingIds = unmatched.filter(looksLikeSessionId);
   if (missingIds.length > 0) {
     process.stderr.write(chalk.red(`No session with id ${missingIds.join(', ')} on this machine.\n`));
     return [];

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -30,7 +30,7 @@ import { gatherRemoteList, runOnPeer } from '../lib/session/remote-list.js';
 import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/session/width.js';
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { inferSessionState } from '../lib/session/state.js';
-import { discoverSessions, countSessionsInScope, resolveSessionById, isCompleteSessionId, searchContentIndex, parseTimeFilter, getSessionRoots, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
+import { discoverSessions, countSessionsInScope, resolveSessionById, isCompleteSessionId, looksLikeSessionId, searchContentIndex, parseTimeFilter, getSessionRoots, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
 import { findSessionsById } from '../lib/session/db.js';
 import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
@@ -1423,16 +1423,6 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     console.error(chalk.red(`Failed to discover sessions: ${err.message}`));
     process.exit(1);
   }
-}
-
-/** Whether a query should route to the single-session render rather than the
- * listing. The hex-ish test catches a bare id prefix; `isCompleteSessionId`
- * additionally catches the prefixed whole ids (`session_…`, `ses_…`) that the
- * hex test rejects — without it those never reach the id-only resolution and
- * still content-search. */
-function looksLikeSessionId(query: string): boolean {
-  const trimmed = query.trim();
-  return /^[0-9a-f-]{6,}$/i.test(trimmed) || isCompleteSessionId(trimmed);
 }
 
 function teamTag(session: SessionMeta): string {

--- a/apps/cli/src/lib/session/__tests__/discover.test.ts
+++ b/apps/cli/src/lib/session/__tests__/discover.test.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import Database from '../../sqlite.js';
 import { buildFtsQuery, getDB } from '../db.js';
-import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile, discoverSessions, resolveSessionById, isCompleteSessionId, readGrokMeta } from '../discover.js';
+import { scanClaudeSession, parseCodexThreadNameIndex, shouldDeferRecentAppend, machineForSessionFile, discoverSessions, resolveSessionById, isCompleteSessionId, looksLikeSessionId, readGrokMeta } from '../discover.js';
 import { machineId } from '../sync/config.js';
 import { getHistoryDir } from '../../state.js';
 
@@ -410,5 +410,31 @@ describe('isCompleteSessionId', () => {
   it('rejects a UUID with trailing text, so a phrase quoting an id stays a search', () => {
     expect(isCompleteSessionId('resume d3470b57-2af6-4c11-b1de-3fab94f43603')).toBe(false);
     expect(isCompleteSessionId('d3470b57-2af6-4c11-b1de-3fab94f43603.jsonl')).toBe(false);
+  });
+});
+
+describe('looksLikeSessionId', () => {
+  it('accepts a bare hex short-id/prefix that isCompleteSessionId rejects', () => {
+    // The whole point of the wider test: a short id must route to id-only
+    // resolution, not content search.
+    expect(looksLikeSessionId('d3470b57')).toBe(true);
+    expect(looksLikeSessionId('d3470b57-2af6')).toBe(true);
+    expect(isCompleteSessionId('d3470b57')).toBe(false);
+  });
+
+  it('accepts every complete id shape (delegates to isCompleteSessionId)', () => {
+    expect(looksLikeSessionId('d3470b57-2af6-4c11-b1de-3fab94f43603')).toBe(true);
+    expect(looksLikeSessionId('session_933f4131-f3ed-495d-946b-71825e9f6a25')).toBe(true);
+    expect(looksLikeSessionId('ses_0485d75c1ffewpzVfoI0ni6hW1')).toBe(true);
+  });
+
+  it('trims surrounding whitespace before testing', () => {
+    expect(looksLikeSessionId('  d3470b57  ')).toBe(true);
+  });
+
+  it('rejects a search phrase and a too-short fragment', () => {
+    expect(looksLikeSessionId('add auth middleware')).toBe(false);
+    expect(looksLikeSessionId('d347')).toBe(false); // < 6 hex chars
+    expect(looksLikeSessionId('')).toBe(false);
   });
 });

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -563,6 +563,24 @@ export function isCompleteSessionId(query: string): boolean {
 }
 
 /**
+ * Whether a query should be treated as a session id rather than a search phrase
+ * — the one canonical id-shaped test, shared by every session-id resolver.
+ *
+ * True for a complete id (`isCompleteSessionId`) AND for a bare hex short-id or
+ * prefix (`d3470b57`), which the complete-id check rejects. Any id-shaped query
+ * resolves by id ONLY (exact -> prefix -> `findSessionsById` index) and must
+ * never fall back to fuzzy content search: a short id like `d3470b57` otherwise
+ * surfaces every transcript that merely MENTIONS the string (a resume prompt
+ * echoes the parent id into the body of many later sessions). The hex test
+ * catches the bare short-id/prefix; `isCompleteSessionId` additionally catches
+ * the prefixed whole ids (`session_…`, `ses_…`) that the hex test rejects.
+ */
+export function looksLikeSessionId(query: string): boolean {
+  const trimmed = query.trim();
+  return /^[0-9a-f-]{6,}$/i.test(trimmed) || isCompleteSessionId(trimmed);
+}
+
+/**
  * Resolve a session by full or short ID. Accepts a pre-loaded session list
  * (fast path from discoverSessions) and falls back to a DB lookup for the
  * "I only know the id" case.


### PR DESCRIPTION
## Problem

The id-only resolution fix ([#1557](https://github.com/phnx-labs/agents-cli/pull/1557)) made `agents sessions <id>` resolve a short/partial id (`d3470b57`) by id alone instead of falling to fuzzy content search. But the sibling resolver in `sessions export` still gated its index lookup on `isCompleteSessionId`, so a bare hex **short** id absent from the discovered pool skipped the index and fell through to the ranked text query — **bundling every transcript that merely MENTIONS the id into the export** (a resume prompt echoes the parent id into many later session bodies).

## Fix

1. **One canonical id-shaped test.** Moved `looksLikeSessionId` out of `commands/sessions.ts` into `lib/session/discover.ts`, right next to `isCompleteSessionId`, and exported it. `sessions.ts` now imports it (no duplicate).
2. **`sessions export`** (`selectSessions`) gates both the index-widen and the "no session with that id" report on `looksLikeSessionId`, so a short id resolves by id (exact → prefix → `findSessionsById` index) and **never content-searches**.
3. **Audited every session-id resolver:**
   - `fork.ts`, `exec.ts` resume → already id-only via `findSessionsById`. No change.
   - `logs.ts`, `sessions-tail.ts` → already id-only via `resolveSessionById` over an `all:true` pool, no content fallback. No change.
   - `sessions-import.ts` → takes a bundle path, not an id. No change.
   - `teams.ts` → out of scope (different id space), untouched.

## Verification

End-to-end against a temp HOME with a real claude transcript whose **content** mentions the short id `deadc0de` (its own id starts with `aaaabbbb`):

```
$ agents sessions export deadc0de --stdout
No session with id deadc0de on this machine.
No sessions matched the selection.        # mentioner NOT exported ✓

$ agents sessions export aaaabbbb --stdout  # its own short id
...exports aaaabbbb-1111-... ✓             # id resolution still works
```

- `bunx tsc` clean.
- New real-path test `sessions-export-resolve.test.ts` (temp HOME + `upsertSession`, synthetic ids `dddd/eeee/ffff` so a shared index can't collide) proves a short id present only in another session's content is not selected; fails on the pre-fix gate.
- `looksLikeSessionId` unit tests added to `discover.test.ts`.
- Changelog fragment: `apps/cli/.changelog/next/session-id-export-resolve.md`.

Note: `commands/__tests__/sessions.test.ts` has a pre-existing, environment-dependent case (`resolveSessionQuery id-vs-search` block, unchanged here) that does not isolate `$HOME` and asserts the real UUID `d3470b57-…` is absent from the index. That UUID is a real local session on this dev box, so it fails locally but passes on clean CI. Not introduced by this change.

Session transcript: yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit-src-github-com-phnx-labs-agents-cli--agents-worktrees-cli-ids/540cbd97-658f-4d02-ba97-a9ba744ed2e3.jsonl