### PR TITLE
test(session): platform-neutral fixture for recent-directories derivation (unblocks Windows release CI)

### DIFF
--- a/apps/cli/src/lib/session/state.test.ts
+++ b/apps/cli/src/lib/session/state.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
 import type { SessionEvent } from './types.js';
 import {
   inferActivity,
@@ -406,12 +407,24 @@ describe('extractTodoProgress (RUSH-1380)', () => {
     expect(droid).toMatchObject({ done: 1, total: 2, activeForm: 'Doing two' });
   });
 
+  // Fixture paths are built through `path` so the case reads the same on every
+  // platform. extractRecentDirectoriesTouched resolves with the host's path
+  // flavor (its inputs are always host-native: db.ts:852 bails before enrichment
+  // when filePath is empty, which is exactly how remote transcripts are indexed
+  // — hosts/session-index.ts sets `filePath: ''`). A hardcoded POSIX literal
+  // therefore breaks on win32, where `path.resolve('/repo')` is drive-rooted
+  // (`D:\repo`) while `path.isAbsolute('/repo/tests')` is already true, so the
+  // relative and absolute forms of the same directory stop string-matching and
+  // dedup silently splits one entry into two.
   it('derives recent directories from edit/write and shell cwd events', () => {
+    const root = path.resolve('/repo');
+    const src = path.join(root, 'src');
+    const tests = path.join(root, 'tests');
     expect(extractRecentDirectoriesTouched([
-      tool('Edit', { file_path: 'src/a.ts' }),
-      tool('exec_command', { cmd: 'bun test', workdir: '/repo/tests' }),
-      tool('Write', { file_path: '/repo/src/b.ts' }),
-    ], '/repo')).toEqual(['/repo/tests', '/repo/src']);
+      tool('Edit', { file_path: path.join('src', 'a.ts') }),  // relative → resolved against cwd, then dirname'd
+      tool('exec_command', { cmd: 'bun test', workdir: tests }),
+      tool('Write', { file_path: path.join(src, 'b.ts') }),   // absolute → same dir as the Edit, so it dedups
+    ], root)).toEqual([tests, src]);
   });
   it('tallies done/total and surfaces the in-progress activeForm', () => {
     const p = extractTodoProgress({


### PR DESCRIPTION
## The failure

`build (windows-latest, 22)` and `build (windows-latest, 24)` fail on every `release/**` branch, blocking releases. Exactly one test fails:

```
FAIL src/lib/session/state.test.ts > extractTodoProgress (RUSH-1380) > derives recent directories from edit/write and shell cwd events
AssertionError: expected [ 'D:\repo\src', '/repo/tests', …(1) ] to deeply equal [ '/repo/tests', '/repo/src' ]
```

[Failing job](https://github.com/phnx-labs/agents-cli/actions/runs/30709483774/job/91394298415)

## Root cause: the fixture, not the implementation

`extractRecentDirectoriesTouched` resolves with the host's path flavor — `apps/cli/src/lib/session/state.ts:268-269`:

```ts
const resolved = path.isAbsolute(value) ? value : path.resolve(cwd || process.cwd(), value);
const dir = file ? path.dirname(resolved) : resolved;
```

The test fed it hardcoded POSIX literals and asserted them back verbatim, so it only held on POSIX. On win32:

| input | win32 behavior | result |
|---|---|---|
| `Edit` `file_path: 'src/a.ts'`, cwd `/repo` | `path.resolve('/repo','src/a.ts')` prepends the runner's drive | `D:\repo\src` |
| `exec_command` `workdir: '/repo/tests'` | `path.isAbsolute('/repo/tests')` is **already true**, so it passes through untouched | `/repo/tests` |
| `Write` `file_path: '/repo/src/b.ts'` | same — absolute, untouched; `dirname` keeps the POSIX spelling | `/repo/src` |

The two spellings of the same directory (`D:\repo\src` and `/repo/src`) stop string-matching, so the dedup at `state.ts:270-272` splits one entry into two and the list goes 2 → 3. That is exactly the observed `[ 'D:\repo\src', '/repo/tests', …(1) ]`.

**The implementation is correct as written** — its inputs are always host-native, so a foreign-flavored path never reaches it:

- `enrichCachedSessionMeta` returns before enrichment when `filePath` is empty — `apps/cli/src/lib/session/db.ts:852`: `if (!meta.filePath) return meta;`
- and that is exactly how a remote transcript is indexed — `apps/cli/src/lib/hosts/session-index.ts:48`: `filePath: '',` (`// Remote transcript — no local file.`)

So the bug is in the fixture. No implementation change in this PR.

## The fix

Build the fixture through `path`, so the case reads identically on both flavors. The assertion is **not** weakened — it still pins every property of the derivation: `dirname`-for-files, cwd-for-shell, recency ordering, and dedup across a relative and an absolute spelling of one directory. No `skip`, no platform conditional.

## Verification

**Real suite (macOS):**

```
$ bunx vitest run src/lib/session/state.test.ts
 Test Files  1 passed (1)
      Tests  64 passed (64)

$ bunx vitest run src/lib/session/
 Test Files  74 passed (74)
      Tests  780 passed (780)

$ bunx tsc --noEmit    # clean
```

**Mutation (real implementation, real runner)** — each mutant fails exactly this test, then restored:

| mutation to `state.ts` | result |
|---|---|
| remove the dedup splice (`state.ts:270-271`) | `expected [ '/repo/src', '/repo/tests', …(1) ] to deeply equal [ '/repo/tests', '/repo/src' ]` — **1 failed \| 63 passed** |
| drop `path.dirname` for file paths (`state.ts:269`) | `expected [ '/repo/src/a.ts', …(2) ] to deeply equal [ '/repo/tests', '/repo/src' ]` — **1 failed \| 63 passed** |

**Cross-platform proof without a Windows box.** A Windows runner cannot be reproduced locally, so the function body was replayed verbatim under `path.win32` (drive-rooted cwd) and `path.posix`:

```
[posix] OLD fixture -> PASS  actual=["/repo/tests","/repo/src"]
[posix] NEW fixture -> PASS  actual=["/repo/tests","/repo/src"]
[win32] OLD fixture -> FAIL  actual=["D:\\repo\\src","/repo/tests","/repo/src"]   <- reproduces CI exactly
[win32] NEW fixture -> PASS  actual=["D:\\repo\\tests","D:\\repo\\src"]

-- mutation checks (NEW fixture must FAIL each mutant on BOTH platforms) --
[posix] CAUGHT  no dirname for file paths        [win32] CAUGHT
[posix] CAUGHT  no dedup (keeps duplicates)      [win32] CAUGHT
[posix] CAUGHT  no recency re-order              [win32] CAUGHT
[posix] CAUGHT  shell cwd events ignored         [win32] CAUGHT
[posix] CAUGHT  relative not resolved vs cwd     [win32] CAUGHT
```

The old fixture reproduces the CI failure byte-for-byte; the new one passes on both flavors and still catches all five mutants on both.

## Changelog

Exempt — test-only, no user-visible surface changes (`apps/cli/AGENTS.md` §Code review conventions: CHANGELOG applies to "a change to a flag, command, or behavior", same exemptions as docs). No fragment added under `apps/cli/.changelog/next/`.

## Known gap (not changed here)

PRs to `main` run only the cheap `test` job; the real cross-platform matrix is cost-gated to `release/**` + `v*` tags — `.github/workflows/ci.yml:13-16`:

```yaml
    branches: ['release/**']
```

So a Windows-only break lands green on `main` and only surfaces at release time. `ci.yml:58` records a prior break of the same class ("the matrix runs only on release/** + v*, so it never showed on PRs"). Changing that gating is a cost tradeoff outside this fix's scope; flagging it rather than silently altering it.