### PR TITLE
docs(agents): root Core concepts + drop Rush brand references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,7 @@ shared libraries and native helpers. Install, configure, run, and dispatch AI
 coding agents (Claude, Codex, Gemini, Cursor, OpenCode, OpenClaw, Grok, Droid, …)
 from one place.
 
-> Phoenix Labs OSS (Apache-2.0). **NOT part of the Rush brand** — see
-> [§Brand identity](#brand-identity) before touching assets, demos, or website.
+> Phoenix Labs OSS · Apache-2.0.
 
 **This file is the repo map + repo-wide policy.** Each component has its own
 `AGENTS.md` (agent map) and/or `README.md` (usage). Start there for anything
@@ -45,6 +44,43 @@ assets/ demo/ website/   Brand, launch demo, landing (repo-root, not shipped in 
 deliberately no root `workspaces` field — adding one changed bun's hoisting and broke
 `@inquirer/core` resolution under `--frozen-lockfile`. Don't add it back. There are no
 cross-package imports except the CLI resolving the native helpers by relative path.
+
+## Core concepts
+
+What agents-cli actually is: one engine that installs the **resources** an agent needs,
+**runs** the agent, and extends it with real-world **tools**, **sessions**, **teams**, and
+other **machines**. Deep reference: [`apps/cli/docs/00-concepts.md`](apps/cli/docs/00-concepts.md)
+and [`architecture.md`](apps/cli/docs/architecture.md).
+
+- **Resources** — the typed things an agent needs, one kind per subdirectory of a
+  DotAgents repo: `rules` (this `AGENTS.md` → `CLAUDE.md`/`GEMINI.md`/…), `commands`,
+  `skills`, `hooks`, `mcp`, `permissions`, `profiles`, `subagents`. Installed once in
+  `~/.agents/` and synced into each agent's native format. Resolution is **layered** —
+  project → user → extra repos → system; the highest layer wins a name collision, the
+  rest union (`apps/cli/src/lib/resources.ts`: `resolveResource`, `listResources`).
+- **One execution engine.** Every agent invocation goes through one path —
+  `buildExecEnv` → `execAgent` / `runWithFallback` in
+  [`apps/cli/src/lib/exec.ts`](apps/cli/src/lib/exec.ts), entered via `agents run`. Each
+  agent version runs in an isolated **version home** (`HOME` swapped before exec) so
+  configs never bleed between versions.
+- **Real-world tool surfaces.** `agents browser` (web) and `agents computer` (native
+  desktop, backed by the `native/computer-*` daemons) are the essential tools that let an
+  agent act on real UIs — the difference between talking about a task and doing it.
+- **Sessions.** Two things wear the name: a durable **transcript** (on disk, indexed in
+  `sessions.db`, read by `agents sessions`) and an ephemeral **live identity** (which pid
+  is which session right now, surfaced by `--active`). Transcripts sync across the fleet,
+  so a session is searchable and resumable **cross-device**.
+- **Teams.** `agents teams` runs several agents in parallel on one task, each isolated in
+  its own worktree — the multi-agent surface.
+- **Devices & hosts.** agents-cli runs commands on other machines over SSH, no daemon:
+  **devices** are the Tailscale fleet (`agents devices`), **hosts** are dispatch targets
+  (`agents hosts`); `-H/--host <name>` routes a command to any of them. This is the
+  cross-device fabric under sessions, teams, run, and cloud.
+- **One engine, many consumers.** `apps/cli` owns the state — the session index, the
+  pid→id registry, `sessions`/`teams`/`run`/`cloud`, and the SSH fan-out. `apps/factory`
+  is a **consumer**: the VS Code UI layer that shells out to
+  `agents sessions --active --json`, holding no data models of its own — not a separate
+  codebase. Fix a mechanism in the CLI and every consumer benefits.
 
 ## Entry points — always build and release through the scripts
 
@@ -96,7 +132,8 @@ goes in `artifacts/`. Never scatter scratch in `/tmp` or the repo root.
   it reviews every PR to `main` and posts its verdict as the **`prix-cloud`** comment. That
   is the non-author review: rely on it and merge on green, don't spawn a redundant subagent
   reviewer. Review manually only if `prix-cloud` hasn't posted after CI settles or flags
-  something to dig into. (It's a Rush Cloud app, not a `.github/workflows/` Action.) The
+  something to dig into. (It's a cloud reviewer configured in `.github/rush.yml`, not a
+  `.github/workflows/` Action.) The
   reviewer reads this file before every review and enforces the conventions in
   [§Code review conventions](#code-review-conventions-the-reviewer-must-enforce-these) —
   that block is what it checks the diff against, not just prose for humans.
@@ -171,42 +208,13 @@ are designed to be safely version-controlled. Use `agents secrets` (macOS
 Keychain-backed, metadata only, never raw credentials on disk). Committed a secret by
 accident? Rotate immediately — git history persists.
 
-## Brand identity
+## Assets & voice
 
-`agents-cli` is a Phoenix Labs OSS product (Apache-2.0). **NOT part of the Rush brand.**
-Phoenix Horizon, Inc. owns several brands; agents-cli sits in the OSS lane, Rush in the
-consumer-product lane.
-
-When working on this repo or the sibling `agent-cli-web` landing:
-
-- **No Rush styling** — no gold sheen, cream paper, falcon mark, Cormorant Garamond
-  serif, "Interface for the future" voice. The Rush plugin at `~/.agents/plugins/rush/`
-  is a tool to call, not a brand to import.
-- **No `~/Rush/Brand/` writes** for agents-cli renders, screenshots, or videos. Use
-  `~/Phoenix/agents-cli/` or this repo's `assets/` / `demo/out/`.
-- **Visual language is terminal-coded** — `#0a0a0a` bg, `#a3e635` lime accent, JetBrains
-  Mono for wordmark + code, Inter for prose. See [`assets/`](assets/), [`demo/src/`](demo/src/),
-  [`website/`](website/).
-- **Voice is direct-developer** — verb + artifact, no marketing claims. Closer to a `man`
-  page than a landing pitch.
-- **Composer + animator skills** can be USED here — but ignore their §Brand voice
-  sections (Rush-only). Override destination to `~/Phoenix/agents-cli/launches/` and use
-  this repo's color/type tokens.
-
-Note: what is separate about `apps/factory` (Factory) is its **brand + publish
-identity** — the `swarmify` publisher, `swarm-ext`, the Factory product name (frozen,
-above) — and the Phoenix "no Rush brand" rule that governs the CLI, assets, demo, and
-website. That is the *only* sense in which Factory is a "different product." It is **not
-architecturally separate**: Factory is the **VS Code UI layer of agi-cli**, not a
-distinct codebase or product line. The `agents` CLI is the engine (`agents tmux`,
-`agents sessions attach`, detached-tmux sessions); Factory is the IDE frontend that
-drives it. So a capability like SSH-drop reconnect spans both (CLI engine + Factory UI),
-Factory's own changelog lives at `apps/factory/CHANGELOG.md`, and **`agi-cli-web` is
-Factory's website too** — do not read "different product" as "agi-cli-web isn't where
-Factory features get documented."
-
-If any agent starts pulling Rush styling, paths, or voice into agents-cli work, stop
-and reread this block.
+Only if you touch `assets/`, `demo/`, or `website/`. Visual language is terminal-coded —
+`#0a0a0a` bg, `#a3e635` lime accent, JetBrains Mono for the wordmark + code, Inter for
+prose. Voice is direct-developer: verb + artifact, no marketing claims — closer to a
+`man` page than a landing pitch. (Factory keeps its own `swarmify`/Factory brand — see
+[§Conventions](#conventions-repo-wide) for the frozen publish identity.)
 
 ## Detailed design
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -9,8 +9,8 @@ This is the **internal architecture** map. The user-facing feature tour is
 plugins, browser, secrets, routines, pty). This file covers the design choices,
 module map, build, and release mechanics the README does not.
 
-> Phoenix Labs OSS (Apache-2.0). **NOT part of the Rush brand** — brand rules are
-> repo-wide, see the root [AGENTS.md](../../AGENTS.md) §Brand identity.
+> Phoenix Labs OSS · Apache-2.0. Repo-wide policy (conventions, code review, security)
+> lives in the root [AGENTS.md](../../AGENTS.md).
 
 ## Core design choices (read this first)
 


### PR DESCRIPTION
## What

Two changes to the root `AGENTS.md`, both from direct feedback.

### 1. Add a Core concepts section (new)
The root explained the repo layout but never what agents-cli *is*. Added a concept map, grounded in [`apps/cli/docs/00-concepts.md`](apps/cli/docs/00-concepts.md):
- **Resources** — the typed things an agent needs (`rules`/`commands`/`skills`/`hooks`/`mcp`/`permissions`/`profiles`/`subagents`) + layered resolution (project→user→extra→system), `src/lib/resources.ts`.
- **One execution engine** — `buildExecEnv → execAgent / runWithFallback` in `apps/cli/src/lib/exec.ts`, version homes.
- **Real-world tool surfaces** — `agents browser` / `agents computer`.
- **Sessions** — transcript (durable, `sessions.db`) vs live identity (ephemeral), cross-device.
- **Teams**, **Devices & hosts** (SSH fabric), and **one engine / many consumers** (Factory is a CLI consumer, not a separate codebase).

### 2. Drop Rush brand references + trim branding
agents-cli is public OSS; **Rush is a separate private project and shouldn't be named here.** Removed the top `NOT part of the Rush brand` callout and the whole Rush-vs-Phoenix Brand identity section. Branding is de-emphasized to a short `Assets & voice` note (only relevant when touching `assets/demo/website`); the Factory publish identity stays in Conventions.

## Verification
- Every concept symbol cited exists: `buildExecEnv`/`execAgent`/`runWithFallback` (`apps/cli/src/lib/exec.ts`), `resolveResource`/`listResources` (`apps/cli/src/lib/resources.ts`).
- No brand `Rush` references remain; the only `rush` tokens left are the real `.github/rush.yml` reviewer-config filename and a `RUSH-####` ticket id inside the pre-existing review-conventions block (left as-is; say the word to strip ticket ids too).
- Edited `AGENTS.md` (canonical), not the symlinks.

Docs-only; CHANGELOG-exempt.