### PR TITLE
fix(factory): auto-close native agent terminal tab on agent exit via exec (RUSH-2026)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Native-mode agent terminal tabs now close automatically when the agent exits (RUSH-2026).** In native (non-tmux) terminal mode, the launch command is now prefixed with `exec` so the shell process replaces itself with the agent runner. When the agent exits the terminal process exits too and VS Code closes the tab automatically — no manual close needed. This mirrors the existing tmux pane-died behaviour. Shell tabs (the SH agent type) and tmux-mode terminals are unaffected. Remote `--host` launches get the same treatment: the local SSH wrapper exits with the remote session. Source: `apps/factory/src/core/agents.ts` (`wrapNativeAgentCommand`), `apps/factory/src/vscode/extension.ts` (`openSingleAgent`).
+
 - **Interactive agent launches now default to `--mode auto` instead of stalling in read-only plan mode (RUSH-2038).** Launching Codex, Claude, Gemini, Cursor, OpenCode, or Antigravity from Factory without explicitly choosing a mode now runs in `auto` (writable-but-gated), so the agent can edit files immediately. Previously the CLI default of `plan` was inherited, causing Codex to start with `--sandbox read-only` and wait indefinitely for approval. `buildAgentLaunchCommand` is now in `src/core/agents.ts` so it is unit-testable without a VS Code harness. Source: `apps/factory/src/core/agents.ts`, `apps/factory/src/vscode/extension.ts`.
 
 - **Stuck Claude tab labels self-heal, and an existing session name is reused

--- a/apps/factory/src/core/agents.test.ts
+++ b/apps/factory/src/core/agents.test.ts
@@ -8,6 +8,7 @@ import {
   STRATEGY_LAUNCH_AGENTS,
   modeFlagForAgent,
   buildAgentLaunchCommand,
+  wrapNativeAgentCommand,
   extractPlanFromSessionJson,
   planTextToSteps
 } from './agents';
@@ -346,5 +347,34 @@ describe('buildAgentLaunchCommand', () => {
   test('default model is included when provided', () => {
     const cmd = buildAgentLaunchCommand('claude', null, 'claude-haiku-4-5');
     expect(cmd).toContain('--model claude-haiku-4-5');
+  });
+});
+
+describe('wrapNativeAgentCommand (RUSH-2026)', () => {
+  // The exec prefix makes the shell replace itself with the agent runner so VS
+  // Code closes the tab automatically when the agent exits — mirroring tmux
+  // pane-died behaviour.
+
+  test('agent terminal: command is exec-prefixed', () => {
+    const cmd = buildAgentLaunchCommand('claude', null);
+    expect(wrapNativeAgentCommand(cmd, false)).toBe(`exec ${cmd}`);
+  });
+
+  test('agent terminal with --host: exec prefix is preserved', () => {
+    const cmd = buildAgentLaunchCommand('claude', null, undefined, undefined, undefined, undefined, undefined, 'yosemite-s0');
+    const wrapped = wrapNativeAgentCommand(cmd, false);
+    expect(wrapped).toMatch(/^exec agents run claude --interactive/);
+    expect(wrapped).toContain("--host 'yosemite-s0'");
+  });
+
+  test('shell terminal: command is NOT exec-prefixed', () => {
+    const shellCmd = 'zsh';
+    expect(wrapNativeAgentCommand(shellCmd, true)).toBe(shellCmd);
+    expect(wrapNativeAgentCommand(shellCmd, true)).not.toMatch(/^exec /);
+  });
+
+  test('empty command returns empty string unchanged', () => {
+    expect(wrapNativeAgentCommand('', false)).toBe('');
+    expect(wrapNativeAgentCommand('', true)).toBe('');
   });
 });

--- a/apps/factory/src/core/agents.ts
+++ b/apps/factory/src/core/agents.ts
@@ -206,6 +206,20 @@ export function buildAgentLaunchCommand(
   return command;
 }
 
+/**
+ * Wrap a native-mode agent launch command with `exec` so the shell process is
+ * replaced by the agent runner. When the runner exits the terminal process exits
+ * too, which causes VS Code to close the tab automatically — mirroring the
+ * pane-died behaviour tmux mode already has.
+ *
+ * Shell tabs must NOT be exec-prefixed: the user drives them interactively and
+ * keeping the parent shell alive is the expected behaviour.
+ */
+export function wrapNativeAgentCommand(command: string, isShell: boolean): string {
+  if (!command || isShell) return command;
+  return `exec ${command}`;
+}
+
 // Agents that expose the per-strategy launch trio (Latest / Balanced / Pinned).
 // These are the version- and account-managed agents that route through
 // `agents run <agent>` so the agents-cli can apply a version pin or strategy.

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -3456,7 +3456,10 @@ export async function openSingleAgentWithQueue(
   }
 
   if (command) {
-    await sendCommandWhenReady(terminal, command);
+    // Native (non-tmux) path — always agent-terminal, never a shell tab. Apply
+    // exec so the shell replaces itself with the runner and VS Code closes the
+    // tab when the agent exits. isShell is always false here.
+    await sendCommandWhenReady(terminal, wrapNativeAgentCommand(command, false));
   }
 
   // Arm agentReady detection so the session-file fast path can fire.

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { BUILT_IN_AGENTS, getBuiltInByKey, getBuiltInDefByTitle, getBuiltInByPrefix, pickLatestVersion, STRATEGY_LAUNCH_AGENTS, modeFlagForAgent, AgentLaunchMode, RunStrategy, buildAgentLaunchCommand } from '../core/agents';
+import { BUILT_IN_AGENTS, getBuiltInByKey, getBuiltInDefByTitle, getBuiltInByPrefix, pickLatestVersion, STRATEGY_LAUNCH_AGENTS, modeFlagForAgent, AgentLaunchMode, RunStrategy, buildAgentLaunchCommand, wrapNativeAgentCommand } from '../core/agents';
 import { parseSpawnRequest, SpawnRequest } from '../core/spawn';
 import {
   AgentConfig,
@@ -2036,7 +2036,12 @@ async function openSingleAgent(
   }
 
   if (command) {
-    await sendCommandWhenReady(terminal, command);
+    // In native (non-tmux) mode, prefix the launch command with `exec` so the
+    // shell replaces itself with the agent runner. When the agent exits the
+    // terminal process exits too, which causes VS Code to close the tab
+    // automatically — mirroring the pane-died behaviour tmux mode already has.
+    // wrapNativeAgentCommand is a no-op for shell tabs.
+    await sendCommandWhenReady(terminal, wrapNativeAgentCommand(command, agentKey === 'shell'));
     readiness.armAgentReady(terminal, agentKey && sessionId
       ? { agentKey, sessionId, cwd }
       : {});


### PR DESCRIPTION
## What and why

In native (non-tmux) terminal mode, when an agent session ends the VS Code terminal tab stayed open with a shell prompt. The user had to manually close it, wasting time many times a day.

Root cause: `openSingleAgent()` sends the launch command via `terminal.sendText(command)`. The command runs as a shell subprocess; when the agent exits, the parent shell remains alive and VS Code keeps the tab open.

Fix (Option A from spec): prefix the launch command with `exec` so the shell **replaces itself** with the agent runner. When the runner exits, the terminal process exits, and VS Code closes the tab automatically.

## Implementation

- `apps/factory/src/core/agents.ts`: new `wrapNativeAgentCommand(command, isShell)` — pure function, shell tabs return command unchanged, all others get `exec ` prefix.
- `apps/factory/src/vscode/extension.ts` (`openSingleAgent`): imports and calls `wrapNativeAgentCommand` on the native-mode branch before `sendCommandWhenReady`.
- `apps/factory/src/core/agents.test.ts`: 4 new tests (agent prefix, agent+host prefix, shell no-prefix, empty passthrough).

## Acceptance criteria mapping

| Criterion | Met |
|---|---|
| Typing `/exit` closes the VS Code tab automatically in native mode | exec causes terminal process exit → VS Code closes tab |
| Same for remote `--host` launches | `exec agents run claude --interactive --host 'yosemite-s0'` → local SSH wrapper exits with remote session |
| Tmux mode unchanged | Branch is guarded by `if (!tmuxOk)` in `openSingleAgent`; tmux path not touched |
| Shell tabs not affected | `wrapNativeAgentCommand(cmd, true)` returns `cmd` unchanged |

## Test output

```
bun test v1.3.14 (0d9b296a)

 52 pass
 0 fail
 178 expect() calls
Ran 52 tests across 1 file. [34.00ms]
```

`bun run compile` (tsc + vite) clean.

## Files changed

- `apps/factory/src/core/agents.ts` — `wrapNativeAgentCommand` (+14 lines)
- `apps/factory/src/core/agents.test.ts` — 4 tests for `wrapNativeAgentCommand` (+30 lines)
- `apps/factory/src/vscode/extension.ts` — import + call in `openSingleAgent` (+7 lines, -2 lines)
- `apps/factory/CHANGELOG.md` — Unreleased entry