### PR TITLE
fix(sessions): resolve a full-UUID query to the exact session across the fleet (RUSH-2024)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2024.md
+++ b/apps/cli/.changelog/next/RUSH-2024.md
@@ -1,0 +1,19 @@
+- **`agents sessions <uuid>` now resolves a remote session exactly, across the
+  fleet.** A full session id absent from the local disk used to fall back to an
+  FTS content search — and because a UUID appears verbatim in other sessions'
+  transcripts (a watchdog `/continue <uuid>` reference), that surfaced a list of
+  unrelated "matches" instead of the one session, which actually lived on another
+  machine. A UUID is now treated as an identifier: on a local miss the CLI fans
+  the id lookup out to the online fleet (the existing `gatherRemoteList` SSH
+  sweep), and when exactly one machine holds it, renders that session's summary
+  from the owning peer via `runOnPeer` (instead of `Session transcript not
+  available`). Same id on more than one box surfaces a machine-labeled conflict to
+  disambiguate with `--device <host>`; a UUID found nowhere prints a clear "no
+  session on this machine" message. There is **no** fuzzy/content fallback for a
+  UUID anywhere — the peer's `--json` answer id-resolves too, so a content
+  mentioner can never masquerade as the session. `--local` still restricts the
+  lookup to the local machine, and a peer already answering a parent's sweep
+  (`AGENTS_SESSIONS_LOCAL=1`) never re-fans-out. Source:
+  `resolveSessionAcrossFleet` / `fleetHitsById` / `shouldFanOutForId` in
+  `apps/cli/src/commands/sessions.ts` (wired into `renderOneSession`), and the
+  id-only `--json` resolution at the sessions listing seam. (RUSH-2024)

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -298,6 +298,33 @@ cases a live pull can't reach: a machine that is **offline / asleep / decommissi
   on-demand `--host` reads and explicit export/import; reach for sync only when you want
   a passive always-on mirror (further below).
 
+### Resolving a full session id across the fleet
+
+`--host` names *which* box to look on. When you already have a full session id but
+**not** the box, `agents sessions <uuid>` finds it for you: a UUID is treated as an
+identifier, so on a local miss the CLI fans the **id lookup** out to the online fleet
+(the same `gatherRemoteList` SSH sweep the listing uses) and renders the session's
+summary from the machine that holds it — delegated to that peer via `runOnPeer`, since
+its transcript and agent binary live there.
+
+```
+# You have the id from a log or a teammate; you don't know the machine
+agents sessions d3470b57-2af6-4c11-b1de-3fab94f43603
+# → renders the summary from whichever online box owns it (e.g. yosemite-s0)
+```
+
+- **Exact id only — never a content search.** A UUID appears verbatim in *other*
+  sessions' transcripts (a watchdog `/continue <uuid>` reference echoes the parent id
+  into later sessions), so a fuzzy match would surface unrelated sessions as "matches."
+  There is no FTS/content fallback for an id-shaped query: it is found by id or reported
+  not found, locally and on every peer.
+- **Same id on more than one machine** surfaces a labeled conflict so you can pick one
+  with `--device <host>`.
+- **`--local`** restricts the lookup to this machine — no cross-machine sweep — for
+  scripts that want deterministic local behavior.
+- A peer already answering a parent's sweep (`AGENTS_SESSIONS_LOCAL=1`) never re-fans-out,
+  so a fleet resolve can't recurse.
+
 ## Forking (branch a conversation)
 
 `agents fork <session>` branches an existing conversation into a NEW, independent

--- a/apps/cli/src/commands/sessions-resolve-fleet.test.ts
+++ b/apps/cli/src/commands/sessions-resolve-fleet.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `agents sessions <uuid>` must resolve a session that lives ONLY on a remote
+ * machine — the RUSH-2024 bug, where a UUID absent from the local disk fell back
+ * to an FTS content search and surfaced unrelated sessions that merely MENTION
+ * the id (a watchdog `/continue <uuid>` reference echoes the parent id into many
+ * later transcripts).
+ *
+ * These exercise the two seams that own the remote path — `fleetHitsById` (pure
+ * grouping) and `resolveSessionAcrossFleet` (the orchestration) — with the
+ * SSH/peer boundary (`gatherRemoteList`/`runOnPeer`) FAKED via injected deps, so
+ * no tailnet, no network, no real ssh. The fakes stand in for what a peer would
+ * actually return over SSH.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fleetHitsById, resolveSessionAcrossFleet, shouldFanOutForId, type FleetResolveDeps } from './sessions.js';
+type SessionMeta = import('../lib/session/types.js').SessionMeta;
+
+const UUID = 'd3470b57-2af6-4c11-b1de-3fab94f43603';
+
+function row(id: string, machine: string, extra: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    id,
+    shortId: id.slice(0, 8),
+    agent: 'claude',
+    timestamp: new Date().toISOString(),
+    filePath: `/home/user/.claude/${id}.jsonl`,
+    machine,
+    _remote: true,
+    ...extra,
+  };
+}
+
+/** A deps double that records what the sweep forwarded and what peer was asked
+ * to render, so a test can assert BOTH the routing and that no render happened. */
+function fakeDeps(opts: {
+  remoteRows: SessionMeta[];
+  peerResult?: 'ok' | 'no-target';
+  onGather?: (args: string[], hosts?: string[]) => void;
+}): FleetResolveDeps & { rendered: Array<{ args: string[]; machine: string }> } {
+  const rendered: Array<{ args: string[]; machine: string }> = [];
+  return {
+    rendered,
+    gatherRemoteList: async (args: string[], hosts?: string[]) => {
+      opts.onGather?.(args, hosts);
+      return { sessions: opts.remoteRows, deviceCount: 1 };
+    },
+    runOnPeer: async (args: string[], machine: string) => {
+      rendered.push({ args, machine });
+      return opts.peerResult ?? 'ok';
+    },
+  };
+}
+
+describe('shouldFanOutForId — the --local / recursion / id-shape gate', () => {
+  const origEnv = process.env.AGENTS_SESSIONS_LOCAL;
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.AGENTS_SESSIONS_LOCAL;
+    else process.env.AGENTS_SESSIONS_LOCAL = origEnv;
+  });
+
+  it('fans out for a bare UUID with no --local and not a peer', () => {
+    delete process.env.AGENTS_SESSIONS_LOCAL;
+    expect(shouldFanOutForId(UUID, undefined)).toBe(true);
+    expect(shouldFanOutForId(UUID, false)).toBe(true);
+  });
+
+  it('--local restricts the lookup to the local machine (no fan-out)', () => {
+    delete process.env.AGENTS_SESSIONS_LOCAL;
+    expect(shouldFanOutForId(UUID, true)).toBe(false);
+  });
+
+  it('a peer answering a parent sweep (AGENTS_SESSIONS_LOCAL=1) never recurses', () => {
+    process.env.AGENTS_SESSIONS_LOCAL = '1';
+    expect(shouldFanOutForId(UUID, false)).toBe(false);
+  });
+
+  it('a non-id search phrase never fans out even without --local', () => {
+    delete process.env.AGENTS_SESSIONS_LOCAL;
+    expect(shouldFanOutForId('fix the login bug', undefined)).toBe(false);
+  });
+});
+
+describe('fleetHitsById — exact id only, one hit per machine', () => {
+  it('keeps only rows whose id EXACTLY equals the query (drops content mentioners)', () => {
+    const rows = [
+      row(UUID, 'yosemite-s0', { topic: 'the real session' }),
+      // A different session that merely echoes the UUID in its body — the exact
+      // shape of the RUSH-2024 false match. It must NOT be treated as a hit.
+      row('ffd7ed24-0840-4c11-b1de-3fab94f43603', 'zion', { topic: `watchdog /continue ${UUID}` }),
+    ];
+    const hits = fleetHitsById(rows, UUID);
+    expect(hits.map(h => h.machine)).toEqual(['yosemite-s0']);
+    expect(hits[0].session.id).toBe(UUID);
+  });
+
+  it('collapses a machine that returned the id twice (live + synced mirror) to one hit', () => {
+    const rows = [row(UUID, 'yosemite-s0', { topic: 'live' }), row(UUID, 'yosemite-s0', { topic: 'mirror' })];
+    const hits = fleetHitsById(rows, UUID);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].machine).toBe('yosemite-s0');
+  });
+
+  it('surfaces DISTINCT machines when the same id is on more than one box', () => {
+    const rows = [row(UUID, 'yosemite-s0'), row(UUID, 'mac-mini')];
+    const hits = fleetHitsById(rows, UUID);
+    expect(hits.map(h => h.machine).sort()).toEqual(['mac-mini', 'yosemite-s0']);
+  });
+
+  it('drops an untagged row (no machine to route a render back to)', () => {
+    const rows = [{ ...row(UUID, ''), machine: undefined } as SessionMeta];
+    expect(fleetHitsById(rows, UUID)).toEqual([]);
+  });
+
+  it('is case-insensitive on the id', () => {
+    const hits = fleetHitsById([row(UUID, 'yosemite-s0')], UUID.toUpperCase());
+    expect(hits.map(h => h.machine)).toEqual(['yosemite-s0']);
+  });
+});
+
+describe('resolveSessionAcrossFleet — remote UUID resolution', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => true); });
+  afterEach(() => { errSpy.mockRestore(); vi.restoreAllMocks(); });
+
+  it('a UUID on exactly ONE remote machine renders from that peer', async () => {
+    const deps = fakeDeps({ remoteRows: [row(UUID, 'yosemite-s0')] });
+    const outcome = await resolveSessionAcrossFleet(UUID, 'summary', undefined, deps);
+    expect(outcome).toBe('rendered');
+    // Rendering was delegated to the owning peer, locally-pinned so it doesn't recurse.
+    expect(deps.rendered).toHaveLength(1);
+    expect(deps.rendered[0].machine).toBe('yosemite-s0');
+    expect(deps.rendered[0].args).toContain('--local');
+    expect(deps.rendered[0].args).toContain(UUID);
+    // summary is the peer's default — no mode flag appended.
+    expect(deps.rendered[0].args).not.toContain('--markdown');
+    expect(deps.rendered[0].args).not.toContain('--json');
+  });
+
+  it('forwards a UUID sweep as an id lookup (--json --all --local), NEVER a content search', async () => {
+    let forwarded: string[] = [];
+    const deps = fakeDeps({ remoteRows: [row(UUID, 'yosemite-s0')], onGather: (a) => { forwarded = a; } });
+    await resolveSessionAcrossFleet(UUID, 'summary', undefined, deps);
+    expect(forwarded).toEqual(['sessions', UUID, '--json', '--all', '--local']);
+  });
+
+  it('carries the render mode to the peer (markdown → --markdown)', async () => {
+    const deps = fakeDeps({ remoteRows: [row(UUID, 'yosemite-s0')] });
+    await resolveSessionAcrossFleet(UUID, 'markdown', undefined, deps);
+    expect(deps.rendered[0].args).toContain('--markdown');
+  });
+
+  it('a content-only sweep result (no exact id) is NOT rendered — reports not-found', async () => {
+    // Reproduces the bug at the remote layer: a peer that (wrongly) returned a
+    // mentioner instead of the id must not be treated as the session. fleetHitsById
+    // drops it, so the fleet resolve is not-found and no peer render fires.
+    const mentioner = row('ffd7ed24-0840-4c11-b1de-3fab94f43603', 'zion', { topic: `/continue ${UUID}` });
+    const deps = fakeDeps({ remoteRows: [mentioner] });
+    const outcome = await resolveSessionAcrossFleet(UUID, 'summary', undefined, deps);
+    expect(outcome).toBe('not-found');
+    expect(deps.rendered).toHaveLength(0);
+  });
+
+  it('the same UUID on MULTIPLE machines surfaces a labeled conflict, renders nothing', async () => {
+    const deps = fakeDeps({ remoteRows: [row(UUID, 'yosemite-s0'), row(UUID, 'mac-mini')] });
+    const outcome = await resolveSessionAcrossFleet(UUID, 'summary', undefined, deps);
+    expect(outcome).toBe('conflict');
+    expect(deps.rendered).toHaveLength(0);
+    const printed = errSpy.mock.calls.flat().join('\n');
+    expect(printed).toContain('multiple machines');
+    expect(printed).toContain('yosemite-s0');
+    expect(printed).toContain('mac-mini');
+  });
+
+  it('found-but-unreachable peer (no-target) is a definitive conflict, not a silent fall-through', async () => {
+    const deps = fakeDeps({ remoteRows: [row(UUID, 'yosemite-s0')], peerResult: 'no-target' });
+    const outcome = await resolveSessionAcrossFleet(UUID, 'summary', undefined, deps);
+    expect(outcome).toBe('conflict');
+  });
+
+  it('a UUID absent from the whole fleet reports not-found (no fallback rendering)', async () => {
+    const deps = fakeDeps({ remoteRows: [] });
+    const outcome = await resolveSessionAcrossFleet(UUID, 'summary', undefined, deps);
+    expect(outcome).toBe('not-found');
+    expect(deps.rendered).toHaveLength(0);
+  });
+
+  it('an explicit --device host set is passed straight through to the sweep', async () => {
+    let seenHosts: string[] | undefined;
+    const deps = fakeDeps({ remoteRows: [row(UUID, 'yosemite-s0')], onGather: (_a, h) => { seenHosts = h; } });
+    await resolveSessionAcrossFleet(UUID, 'summary', ['yosemite-s0'], deps);
+    expect(seenHosts).toEqual(['yosemite-s0']);
+  });
+
+  it('a sweep that throws is swallowed to not-found, never a crash', async () => {
+    const deps: FleetResolveDeps = {
+      gatherRemoteList: async () => { throw new Error('ssh exploded'); },
+      runOnPeer: async () => 'ok',
+    };
+    const outcome = await resolveSessionAcrossFleet(UUID, 'summary', undefined, deps);
+    expect(outcome).toBe('not-found');
+  });
+});

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1248,7 +1248,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   // When the user explicitly asks to render (via mode flag), resolve the
   // query globally so sessions outside the default cwd/30d window are found.
   if (wantsRender && searchQuery) {
-    await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact });
+    await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact, local: options.local, hosts: options.host });
     return;
   }
 
@@ -1324,20 +1324,35 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
     // Smart ID routing: a bare query that resolves to one session renders
     // directly. If nothing matches in the scoped window and the query looks
     // like a session ID, widen to global scope (incl. Claude /resume history).
-    if (searchQuery) {
+    //
+    // Exception: a PEER answering a parent's `--json` locate sweep
+    // (AGENTS_SESSIONS_LOCAL=1) must return the SessionMeta[] ROW for the id, not
+    // render its transcript — the sweep parses an array (parseRemoteList). So when
+    // we are that peer and --json is set, skip the single-session short-circuit and
+    // fall through to the array-emitting --json block below.
+    const answeringJsonSweep = options.json === true && process.env[NO_FANOUT_ENV] === '1';
+    if (searchQuery && !answeringJsonSweep) {
       const idMatches = resolveSessionById(sessions, searchQuery);
       if (idMatches.length === 1) {
         await renderSession(idMatches[0], mode, filterOpts, options);
         return;
       }
       if (idMatches.length === 0 && looksLikeSessionId(searchQuery)) {
-        await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact });
+        await renderOneSession(searchQuery, mode, { agent: options.agent, project: options.project, filter: filterOpts, redact: options.redact, local: options.local, hosts: options.host });
         return;
       }
     }
 
     if (options.json) {
-      const filtered = searchQuery ? filterSessionsByQuery(sessions, searchQuery) : sessions;
+      // An id-shaped query resolves by id ONLY — the same rule the render path
+      // uses (resolveSessionQuery). Without this a `--json <uuid>` (as issued by
+      // the fleet locate sweep, which runs `sessions <uuid> --json --local` on
+      // each peer) would fall to FTS content search and return every transcript
+      // that merely MENTIONS the id, defeating exact remote resolution. A genuine
+      // search phrase keeps the ranked metadata+content path.
+      const filtered = searchQuery
+        ? resolveSessionQuery(sessions, searchQuery).matches
+        : sessions;
       process.stdout.write(serializeSessionsJson(filtered));
       return;
     }
@@ -2650,7 +2665,7 @@ async function renderArtifactsGlobal(
 async function renderOneSession(
   query: string,
   mode: ViewMode,
-  scope: { agent?: string; project?: string; filter: FilterOptions; redact?: boolean },
+  scope: { agent?: string; project?: string; filter: FilterOptions; redact?: boolean; local?: boolean; hosts?: string[] },
 ): Promise<void> {
   const spinner = ora().start();
   const tracker = createScanProgressTracker(FIND_VERBS, 'session', spinner);
@@ -2705,6 +2720,19 @@ async function renderOneSession(
           process.exit(1);
         }
       } else if (byId) {
+        // Not on this machine. A UUID names ONE session, so before giving up ask
+        // the fleet — the session may live only on a peer (the whole point of
+        // RUSH-2024). Skip the sweep when the caller pinned --local, or when we
+        // are ourselves a peer answering a parent's sweep (AGENTS_SESSIONS_LOCAL),
+        // so a locate never recurses. On a single remote hit we hand rendering to
+        // that peer; a multi-host hit surfaces the conflict; a miss keeps the
+        // local not-found message. No FTS fallback either way.
+        if (shouldFanOutForId(query, scope.local)) {
+          const outcome = await resolveSessionAcrossFleet(query, mode, scope.hosts);
+          if (outcome === 'rendered') return;
+          if (outcome === 'conflict') process.exit(1);
+          // 'not-found' falls through to the local message below.
+        }
         notFoundByIdMessage(query).forEach(l => console.error(l));
         process.exit(1);
       } else {
@@ -2741,6 +2769,137 @@ async function renderOneSession(
     console.error(chalk.red(`Failed to read session: ${err.message}`));
     process.exit(1);
   }
+}
+
+/**
+ * Whether a missed local id lookup should widen to a cross-machine sweep.
+ *
+ * Gate (all must hold):
+ *   - the query is id-shaped (`looksLikeSessionId`) — only an identifier resolves
+ *     across the fleet; a search phrase never does.
+ *   - not `--local` — the caller opted out of cross-machine lookup (deterministic
+ *     local behavior for scripts, RUSH-2024 acceptance: "--local still restricts").
+ *   - `AGENTS_SESSIONS_LOCAL` is unset — we are not ourselves a peer answering a
+ *     parent's sweep, so a locate can never recurse (RUSH-2024: avoid double-fan-out).
+ *
+ * Pure + exported so the gate is unit-tested without driving discovery / SSH.
+ */
+export function shouldFanOutForId(query: string, local: boolean | undefined): boolean {
+  if (local === true) return false;
+  if (process.env[NO_FANOUT_ENV] === '1') return false;
+  return looksLikeSessionId(query);
+}
+
+/** The render-mode flag a peer's `agents sessions <id>` must carry so the remote
+ * summary matches the mode the user asked for. `summary` is the peer's default,
+ * so it needs no flag; the others map 1:1 to a CLI flag. */
+function modeFlag(mode: ViewMode): string | undefined {
+  if (mode === 'markdown') return '--markdown';
+  if (mode === 'json') return '--json';
+  return undefined; // summary — the peer's default render
+}
+
+/** Injectable SSH/peer boundary so the fleet-resolve logic is unit-testable
+ * without a live tailnet. Production wires these to the real remote-list infra. */
+export interface FleetResolveDeps {
+  gatherRemoteList: typeof gatherRemoteList;
+  runOnPeer: typeof runOnPeer;
+}
+
+/** One distinct machine that reported the id, plus its winning row. */
+interface FleetHit {
+  machine: string;
+  session: SessionMeta;
+}
+
+/** Group a fleet sweep's rows to the DISTINCT machines that hold the id. Each
+ * peer answered `sessions <id> --json --local`, which (post-fix) id-resolves and
+ * so returns the matching row(s); a peer with a synced MIRROR of the same id can
+ * emit more than one row, so we keep the first per machine. Rows the peer somehow
+ * returned that do NOT match the id (defensive against version skew) are dropped
+ * so a stray content hit can never masquerade as an exact resolution. */
+export function fleetHitsById(rows: SessionMeta[], id: string): FleetHit[] {
+  const q = id.trim().toLowerCase();
+  const byMachine = new Map<string, SessionMeta>();
+  for (const s of rows) {
+    const machine = s.machine;
+    if (!machine) continue; // an untagged row can't be routed back to a peer
+    if (s.id?.toLowerCase() !== q) continue; // exact id only — never a content hit
+    if (!byMachine.has(machine)) byMachine.set(machine, s);
+  }
+  return Array.from(byMachine.entries()).map(([machine, session]) => ({ machine, session }));
+}
+
+/**
+ * Locate a full session id across the online fleet and render it from the machine
+ * that holds it. The local disk already missed; this fans `sessions <id> --json
+ * --all` out to every registered online peer (or the explicit `hosts` set),
+ * groups the rows to distinct machines, then:
+ *
+ *   - exactly one machine  → delegate rendering to that peer via `runOnPeer`
+ *     (its transcript and agent binary live there — a local `--host` hop would
+ *     re-discover locally and dead-end), returning `'rendered'`.
+ *   - more than one machine → print the conflict with machine labels so the user
+ *     can disambiguate with `--device <host>`, returning `'conflict'`.
+ *   - none                 → `'not-found'`, letting the caller print the local
+ *     "no session on this machine" message.
+ *
+ * No fuzzy/content fallback: the sweep forwards a UUID, each peer id-resolves it,
+ * and `fleetHitsById` drops anything that isn't an exact id match.
+ */
+export async function resolveSessionAcrossFleet(
+  id: string,
+  mode: ViewMode,
+  hosts?: string[],
+  deps: FleetResolveDeps = { gatherRemoteList, runOnPeer },
+): Promise<'rendered' | 'conflict' | 'not-found'> {
+  const spinner = isInteractiveTerminal() ? ora('Searching the fleet...').start() : null;
+  let hits: FleetHit[];
+  try {
+    // Force whole-index scope (--all): the peer runs in its SSH-login home dir,
+    // whose cwd would otherwise silently narrow the lookup and hide the row.
+    // --json so each peer answers a parseable array; --local so it answers for
+    // itself and never re-fans-out (belt-and-suspenders with the parent's
+    // AGENTS_SESSIONS_LOCAL, which remote-list also sets on the peer).
+    const forwarded = ['sessions', id, '--json', '--all', '--local'];
+    const { sessions } = await deps.gatherRemoteList(forwarded, hosts);
+    hits = fleetHitsById(sessions, id);
+  } catch {
+    // A fan-out failure is not an exact resolution — treat as not-found so the
+    // caller prints the honest local message rather than a half-answer.
+    hits = [];
+  } finally {
+    spinner?.stop();
+  }
+
+  if (hits.length === 0) return 'not-found';
+
+  if (hits.length > 1) {
+    console.error(chalk.red(`Session ${id} exists on multiple machines:`));
+    for (const h of hits) {
+      const s = h.session;
+      const label = (s as any).label ?? s.topic ?? '';
+      console.error(chalk.cyan(`  ${h.machine}`) + chalk.gray(`  ${s.agent}${s.version ? ` ${s.version}` : ''}  ${label}`));
+    }
+    console.error(chalk.gray(`Pick one with: agents sessions ${id} --device <host>`));
+    return 'conflict';
+  }
+
+  const { machine } = hits[0];
+  // Render the remote summary by re-running `sessions <id>` ON the peer. --local
+  // keeps that render on the peer (it owns the transcript); the mode flag matches
+  // the mode the user asked for. No TTY: a summary/markdown/json render is a
+  // one-shot capture, not an interactive resume.
+  const peerArgs = ['sessions', id, '--local'];
+  const flag = modeFlag(mode);
+  if (flag) peerArgs.push(flag);
+  const result = await deps.runOnPeer(peerArgs, machine);
+  if (result === 'no-target') {
+    console.error(chalk.red(`Session ${id} is on ${machine}, but it is not a reachable registered device.`));
+    console.error(chalk.gray('Register it with `agents devices` or run the command on that machine.'));
+    return 'conflict'; // a definitive answer (found, un-renderable) — do NOT fall to the local not-found line
+  }
+  return 'rendered';
 }
 
 /** Register the `agents sessions` command with all its options and help text. */


### PR DESCRIPTION
## What & why

`agents sessions <full-uuid>` returned **unrelated fuzzy/content matches** instead of the exact session when that session lived only on a remote machine (RUSH-2024). Root cause: a UUID absent from the local disk fell through to an FTS5 content search, and a full UUID appears **verbatim** in other sessions' transcripts (a watchdog `/continue <uuid>` reference echoes the parent id into many later sessions) — so those unrelated sessions scored as "matches."

This treats a UUID as an **identifier**, not a search term: on a local miss the CLI fans the **id lookup** out to the online fleet (the existing `gatherRemoteList` SSH sweep) and renders the session's summary **from the machine that holds it** via `runOnPeer`, instead of `Session transcript not available`. No fuzzy/content fallback for a UUID, anywhere.

## How

- **`renderOneSession`** (`apps/cli/src/commands/sessions.ts`): on a by-id local miss for an id-shaped query, calls the new `resolveSessionAcrossFleet` before the not-found exit — gated by `shouldFanOutForId` (id-shaped **and** not `--local` **and** not already a peer).
- **`resolveSessionAcrossFleet`**: forwards `sessions <id> --json --all --local` to peers via `gatherRemoteList`, groups rows with `fleetHitsById`, then: one machine → render on that peer (`runOnPeer`, `--local` so it doesn't recurse, carrying the render mode); >1 → labeled conflict (`--device <host>` hint); 0 → falls back to the local not-found message.
- **`fleetHitsById`**: keeps only rows whose id is an **exact** match (drops content mentioners and untagged rows), one hit per machine (collapses a live+mirror duplicate).
- **Peer `--json` id path**: the sessions-listing `--json` seam now id-resolves an id-shaped query via `resolveSessionQuery` instead of raw `filterSessionsByQuery`, so a peer answering the sweep returns the exact **row** (not a content list). A peer answering a `--json` sweep (`AGENTS_SESSIONS_LOCAL=1`) skips the single-session render short-circuit so it emits the `SessionMeta[]` array `parseRemoteList` expects.

## Acceptance criteria → coverage

| Criterion | Where |
|---|---|
| UUID present only on a remote machine returns its summary (not a content list) | `resolveSessionAcrossFleet` → `runOnPeer`; test *"a UUID on exactly ONE remote machine renders from that peer"* |
| Same UUID on multiple machines → machine-labeled conflict | test *"the same UUID on MULTIPLE machines surfaces a labeled conflict"* |
| UUID found nowhere → clear no-session message, no content search | `fleetHitsById` exact-only + `notFoundByIdMessage`; tests *"content-only sweep result is NOT rendered"*, *"absent from the whole fleet reports not-found"* |
| `--local` still restricts to the local machine | `shouldFanOutForId`; test *"--local restricts the lookup to the local machine"* |
| No double-fan-out under `AGENTS_SESSIONS_LOCAL=1` | `shouldFanOutForId`; test *"a peer answering a parent sweep never recurses"* |
| Covered by unit tests for resolution paths | `apps/cli/src/commands/sessions-resolve-fleet.test.ts` (18 tests) + existing `sessions-resolve-db.test.ts` |

The SSH/peer boundary (`gatherRemoteList`/`runOnPeer`) is **faked via injected deps** — no real network.

## Tests

```
$ npx vitest run \
    src/commands/__tests__/sessions.test.ts \
    src/commands/sessions-resolve-db.test.ts \
    src/commands/sessions-resolve-fleet.test.ts \
    src/commands/__tests__/sessions-host-filter.test.ts \
    src/lib/session/__tests__/discover.test.ts

 Test Files  5 passed (5)
      Tests  94 passed (94)
```

`tsc --noEmit` clean. Changelog fragment `apps/cli/.changelog/next/RUSH-2024.md`; docs updated in `apps/cli/docs/05-sessions.md` (new "Resolving a full session id across the fleet" subsection).
