### PR TITLE
fix(sessions): interactive --active shows fleet-wide active sessions, not just local (RUSH-2055)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2055.md
+++ b/apps/cli/.changelog/next/RUSH-2055.md
@@ -1,0 +1,12 @@
+- **`agents sessions --active` (interactive) now shows active sessions from every
+  device, not just the local machine (RUSH-2055).** The interactive browser built
+  its pool fleet-wide but intersected the running filter against a LOCAL-ONLY live
+  set (`getActiveSessions()`), so every remote session — including agents launched
+  from this host onto other machines via VS Code / Codium — was silently dropped
+  and the view collapsed to local. The running filter now uses a fleet-wide live
+  index (local live sessions + each peer's `--active` set over SSH, deduped —
+  `fetchLiveIndex`), mirroring the static `--active` dump. Also: `--all` now widens
+  **every** non-status filter to "all" — every directory AND all-time (window),
+  where before it only widened directories; `--active` still composes as a status
+  filter and `-a`/`--device`/`--since` still narrow their axis. Source:
+  `apps/cli/src/commands/sessions-browser.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 1.20.77
 
+- **`agents sessions --active` (interactive) now shows active sessions from every
+  device, not just the local machine (RUSH-2055).** The interactive browser built
+  its pool fleet-wide but intersected the running filter against a LOCAL-ONLY live
+  set (`getActiveSessions()`), so every remote session — including agents launched
+  from this host onto other machines via VS Code / Codium — was silently dropped
+  and the view collapsed to local. The running filter now uses a fleet-wide live
+  index (local live sessions + each peer's `--active` set over SSH, deduped —
+  `fetchLiveIndex`), mirroring the static `--active` dump. Also: `--all` now widens
+  **every** non-status filter to "all" — every directory AND all-time (window),
+  where before it only widened directories; `--active` still composes as a status
+  filter and `-a`/`--device`/`--since` still narrow their axis. Source:
+  `apps/cli/src/commands/sessions-browser.ts`. (RUSH-2055)
+
 - **Interactive `agents run --host` now tracks the real session for every agent,
   not just Claude.** Codex, Kimi, Grok, and Gemini coin their own session id and
   reject a caller-supplied one, so an interactive host run of any of them showed a

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,19 +2,6 @@
 
 ## 1.20.77
 
-- **`agents sessions --active` (interactive) now shows active sessions from every
-  device, not just the local machine (RUSH-2055).** The interactive browser built
-  its pool fleet-wide but intersected the running filter against a LOCAL-ONLY live
-  set (`getActiveSessions()`), so every remote session — including agents launched
-  from this host onto other machines via VS Code / Codium — was silently dropped
-  and the view collapsed to local. The running filter now uses a fleet-wide live
-  index (local live sessions + each peer's `--active` set over SSH, deduped —
-  `fetchLiveIndex`), mirroring the static `--active` dump. Also: `--all` now widens
-  **every** non-status filter to "all" — every directory AND all-time (window),
-  where before it only widened directories; `--active` still composes as a status
-  filter and `-a`/`--device`/`--since` still narrow their axis. Source:
-  `apps/cli/src/commands/sessions-browser.ts`. (RUSH-2055)
-
 - **Interactive `agents run --host` now tracks the real session for every agent,
   not just Claude.** Codex, Kimi, Grok, and Gemini coin their own session id and
   reject a caller-supplied one, so an interactive host run of any of them showed a

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -128,6 +128,16 @@ describe('activeBrowserSeed — the --active call-site filter (fleet-wide)', () 
     expect(activeBrowserSeed({ since: '2h' }).window).toBe('2h');
   });
 
+  it('--all widens the window to all-time (undefined); --since still overrides', () => {
+    // `--all` means "all values for every non-status filter" — so the 30d cap
+    // drops to all-time. --active stays a status filter (running still true).
+    const f = activeBrowserSeed({ all: true });
+    expect(f.window).toBeUndefined();
+    expect(f.running).toBe(true);
+    expect(f.projectScope).toBe('all');
+    expect(activeBrowserSeed({ all: true, since: '2h' }).window).toBe('2h');
+  });
+
   it('normalizes a user@host / FQDN device seed to the canonical machine id', () => {
     expect(activeBrowserSeed({ host: ['muqsit@mac-mini.local'] }).device).toBe('mac-mini');
     expect(activeBrowserSeed({ host: ['YOSEMITE-S1'] }).device).toBe('yosemite-s1');
@@ -144,6 +154,13 @@ describe('bareBrowserSeed — the bare-listing call-site filter', () => {
   it('is not running-only and seeds the window from --since', () => {
     expect(bareBrowserSeed({}).running).toBeUndefined();
     expect(bareBrowserSeed({ since: '7d' }).window).toBe('7d');
+  });
+
+  it('defaults the window to 30d, but --all widens it to all-time (undefined)', () => {
+    expect(bareBrowserSeed({}).window).toBe('30d');
+    expect(bareBrowserSeed({ all: true }).window).toBeUndefined();
+    // an explicit --since still wins over --all's all-time default
+    expect(bareBrowserSeed({ all: true, since: '7d' }).window).toBe('7d');
   });
 });
 

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -17,6 +17,7 @@ import type { SessionMeta } from '../lib/session/types.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { discoverSessions } from '../lib/session/discover.js';
 import { gatherRemoteList } from '../lib/session/remote-list.js';
+import { gatherRemoteActive } from '../lib/session/remote-active.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { buildPreview } from './sessions-picker.js';
 import {
@@ -26,6 +27,7 @@ import {
   ticketLabel,
   mergeLocalFirst,
   indexActiveBySessionId,
+  dedupeByMachineSession,
   handlePickedSession,
   shouldIncludeLocal,
   remoteHostsToDial,
@@ -125,13 +127,16 @@ export function normalizeDeviceSeed(host: string | undefined): string | undefine
  * The initial filter for the `--active` browser: fleet-wide (matches the static
  * `renderActiveSessions`, which has no project scoping — the `p` hotkey narrows to
  * this repo), running-only, with the device seed normalized and `--since` seeding
- * the window. Pure, so the routing call site is unit-testable.
+ * the window. `--all` widens the window to all-time (device/agent are already
+ * fleet-wide here); an explicit `--since` still overrides. Pure, so the routing
+ * call site is unit-testable.
  */
 export function activeBrowserSeed(opts: {
   teams?: boolean;
   agent?: string;
   host?: string[];
   since?: string;
+  all?: boolean;
 }): Partial<BrowserFilter> {
   return {
     running: true,
@@ -139,14 +144,16 @@ export function activeBrowserSeed(opts: {
     agent: opts.agent,
     projectScope: 'all',
     device: normalizeDeviceSeed(opts.host?.[0]),
-    window: opts.since ?? '30d',
+    window: opts.since ?? (opts.all ? undefined : '30d'),
   };
 }
 
 /**
  * The initial filter for the bare interactive listing: current-repo subtree by
- * default (matches the static overview's cwd scoping), `--all` widens to every
- * directory, `--since` seeds the window.
+ * default (matches the static overview's cwd scoping). `--all` sets every
+ * non-status filter to its "all" value — every directory (project) AND all-time
+ * (window) — so one flag maxes the view; `--since` still overrides the window,
+ * and `-a`/`--device` still narrow their axes.
  */
 export function bareBrowserSeed(opts: {
   teams?: boolean;
@@ -158,7 +165,7 @@ export function bareBrowserSeed(opts: {
     teams: !!opts.teams,
     agent: opts.agent,
     projectScope: opts.all ? 'all' : 'repo',
-    window: opts.since ?? '30d',
+    window: opts.since ?? (opts.all ? undefined : '30d'),
   };
 }
 
@@ -230,6 +237,35 @@ async function fetchRawPool(
   return { key: `${since ?? 'all'}|${f.teams}`, rows };
 }
 
+/** The fleet-wide live index for the running/active filter: local live sessions
+ * PLUS (unless --local) every peer's `--active` set over SSH, deduped and keyed
+ * by session id. Mirrors `renderActiveSessions` so the interactive running filter
+ * intersects against the SAME active set the static `--active` dump reports.
+ *
+ * Without this the live set was local-only (`getActiveSessions()`), so remote
+ * sessions — present in the fleet-wide pool — never matched `live.has(r.id)` and
+ * were silently dropped, leaving the browser showing only this machine's
+ * sessions. `hosts` scopes which peers are dialed (undefined = sweep the fleet). */
+async function fetchLiveIndex(
+  self: string,
+  local: boolean,
+  hosts: string[] | undefined,
+): Promise<Map<string, ActiveSession>> {
+  const localActive = shouldIncludeLocal(hosts, self) ? await getActiveSessions() : [];
+  for (const s of localActive) if (!s.machine) s.machine = self;
+  let merged = localActive;
+  if (!local) {
+    const remoteHosts = remoteHostsToDial(hosts, self);
+    // An explicit list naming only self leaves nothing remote to dial — skip the
+    // fan-out rather than let an empty list fall through to the device sweep.
+    if (!hosts?.length || (remoteHosts && remoteHosts.length > 0)) {
+      const remote = await gatherRemoteActive(remoteHosts);
+      merged = dedupeByMachineSession([...localActive, ...remote.sessions]);
+    }
+  }
+  return indexActiveBySessionId(merged);
+}
+
 /** Apply the cheap in-memory filters (agent / device / project / running). */
 function applyFilters(
   rows: SessionMeta[],
@@ -297,8 +333,10 @@ export async function runSessionBrowser(
   // Cache the transcript fetch, keyed by (window, teams); agent/device/project/
   // running are applied in memory so their hotkeys don't re-fan-out the fleet.
   let rawCache: { key: string; rows: SessionMeta[] } | null = null;
-  // The live index is slow (a full ps/tmux scan) and only the running filter
-  // needs it — fetch it once, lazily, the first time running is toggled on.
+  // The live index is slow (a local ps/tmux scan + an SSH fan-out to every peer)
+  // and only the running filter needs it — fetch it once, lazily, the first time
+  // running is toggled on. Fleet-wide so remote active sessions match, not just
+  // this machine's.
   let liveCache: Map<string, ActiveSession> | null = null;
   // Generation guard: two quick keypresses can start overlapping loads whose
   // SSH fan-outs settle out of order. dynamicPicker's own gen ref guards which
@@ -325,11 +363,12 @@ export async function runSessionBrowser(
       if (myGen !== loadGen) return []; // superseded — don't touch shared state
       pool = fetched;
     }
-    // Only pay for the live scan when the running filter needs it.
+    // Only pay for the live scan when the running filter needs it. Fleet-wide:
+    // local live sessions + every peer's active set (see fetchLiveIndex).
     let live = liveCache;
     if (f.running && !live) {
       try {
-        live = indexActiveBySessionId(await getActiveSessions());
+        live = await fetchLiveIndex(self, local, hosts);
       } catch {
         live = new Map();
       }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1153,6 +1153,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
           agent: options.agent,
           host: options.host,
           since: options.since,
+          all: options.all,
         }),
         { local: options.local === true, hosts: options.host },
       );
@@ -2906,7 +2907,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--antigravity', 'Shorthand for --agent antigravity')
     .option('--grok', 'Shorthand for --agent grok')
     .option('--opencode', 'Shorthand for --agent opencode')
-    .option('--all', 'Include sessions from every directory (not just current project)')
+    .option('--all', 'Widen every non-status filter to "all": every directory (not just this project) and all time (no window cap). Status filters like --active still compose; -a/--device/--since still narrow their axis.')
     .option('--unmanaged', "Also show sessions from your own ~/.<agent> installs (hidden once agents-cli manages that agent)")
     .option('--teams', 'Include team-spawned sessions (hidden by default)')
     .option('--routine', 'Show only sessions archived from routine runs')


### PR DESCRIPTION
## Problem

Running `agents sessions --active` (interactively) on one host shows only that machine's sessions, even though many agent sessions are alive across the fleet — including ones launched from this host onto other machines in VS Code / Codium. Reported on zion: the TUI showed 3 sessions while `agents sessions --active --json` on the same box returned 30 across 9 machines.

## Root cause

`agents sessions --active` splits on TTY (`sessions.ts`); a TTY hits the interactive browser (`sessions-browser.ts`). The browser builds its session pool fleet-wide (local `discoverSessions` + `gatherRemoteList` SSH fan-out), but the running filter intersects that pool against a **local-only** live set:

- `applyFilters`: `if (f.running) out = out.filter((r) => live.has(r.id))`
- `live` was `indexActiveBySessionId(await getActiveSessions())`, and `getActiveSessions()` scans only the local machine.

Every remote session sat in the pool but was absent from `live`, so the running filter discarded it — the view collapsed to local. (The non-interactive `--active` path was unaffected: it already merges local + `gatherRemoteActive`.)

## Fix

- **Fleet-wide live index.** New `fetchLiveIndex()` builds the running-filter live set from local live sessions **plus** each peer's `--active` set over SSH (`gatherRemoteActive`), deduped with `dedupeByMachineSession` — mirroring `renderActiveSessions` exactly. The interactive running filter now intersects against the same fleet-wide active set the static dump reports.
- **`--all` semantics.** `--all` now widens *every* non-status filter to "all": every directory **and** all-time (window), where before it only widened directories. `--active` still composes as a status filter; `-a` / `--device` / `--since` still narrow their axis. (`activeBrowserSeed` / `bareBrowserSeed` window: `since ?? (all ? undefined : '30d')`.)

## Verification (end-to-end)

Ran the patched browser from source in a PTY on yosemite-s1, `--active` (running filter on). Before: only local `yosemite-s1` rows. After: rows across **yosemite-s1, yosemite-s0, mac-mini, zion** — including `aa30ec31` on yosemite-s0 (the exact remote running session the old view dropped). Genuinely-unreachable boxes (bismas/gpu-box/worker) are still correctly skipped.

- `tsc --noEmit`: clean.
- `bun test src/commands/sessions-browser.test.ts`: 24 pass (added `--all` window-widening cases for both seeds).

## Notes / follow-ups (not in this PR)

- Live-set join is by bare `sessionId` (session UUIDs are globally unique in practice). Machine-qualified keying is tracked by RUSH-1981 / RUSH-2050.
- Idle-vs-running status labeling for remote sessions and remote VS Code/Codium-Server host detection (`HOST_MATCHERS`) are separate items noted on RUSH-2055.

Fixes RUSH-2055.
