### PR TITLE
feat(sessions): --all widens every non-status filter (dirs + window), incl. --active (RUSH-2055)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2055-all-semantics.md
+++ b/apps/cli/.changelog/next/RUSH-2055-all-semantics.md
@@ -1,0 +1,7 @@
+- **`agents sessions --all` now widens every non-status filter, not just the
+  directory (RUSH-2055).** `--all` used to only drop the current-project scope; it
+  now also drops the 30-day window cap, so one flag means "all values for every
+  non-status filter" — all directories AND all time. `--active` still composes as a
+  status filter, and `-a` / `--device` / `--since` still narrow their own axis (an
+  explicit `--since` overrides the all-time default). Applies to both the bare
+  listing and `--active`. Source: `apps/cli/src/commands/sessions-browser.ts`.

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -135,6 +135,14 @@ describe('activeBrowserSeed — the --active call-site filter (fleet-wide)', () 
     expect(activeBrowserSeed({ since: '2h' }).window).toBe('2h');
   });
 
+  it('--all widens the window to all-time (undefined); --since still overrides; stays running-only', () => {
+    const f = activeBrowserSeed({ all: true });
+    expect(f.window).toBeUndefined();
+    expect(f.running).toBe(true);
+    expect(f.projectScope).toBe('all');
+    expect(activeBrowserSeed({ all: true, since: '2h' }).window).toBe('2h');
+  });
+
   it('normalizes a user@host / FQDN device seed to the canonical machine id', () => {
     expect(activeBrowserSeed({ host: ['muqsit@mac-mini.local'] }).device).toBe('mac-mini');
     expect(activeBrowserSeed({ host: ['YOSEMITE-S1'] }).device).toBe('yosemite-s1');
@@ -151,6 +159,13 @@ describe('bareBrowserSeed — the bare-listing call-site filter', () => {
   it('is not running-only and seeds the window from --since', () => {
     expect(bareBrowserSeed({}).running).toBeUndefined();
     expect(bareBrowserSeed({ since: '7d' }).window).toBe('7d');
+  });
+
+  it('defaults the window to 30d, but --all widens it to all-time (undefined)', () => {
+    expect(bareBrowserSeed({}).window).toBe('30d');
+    expect(bareBrowserSeed({ all: true }).window).toBeUndefined();
+    // an explicit --since still wins over --all's all-time default
+    expect(bareBrowserSeed({ all: true, since: '7d' }).window).toBe('7d');
   });
 });
 

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -136,6 +136,7 @@ export function activeBrowserSeed(opts: {
   agent?: string;
   host?: string[];
   since?: string;
+  all?: boolean;
 }): Partial<BrowserFilter> {
   return {
     running: true,
@@ -143,14 +144,18 @@ export function activeBrowserSeed(opts: {
     agent: opts.agent,
     projectScope: 'all',
     device: normalizeDeviceSeed(opts.host?.[0]),
-    window: opts.since ?? '30d',
+    // --all widens the window to all-time (project is already 'all' here);
+    // --since still overrides.
+    window: opts.since ?? (opts.all ? undefined : '30d'),
   };
 }
 
 /**
  * The initial filter for the bare interactive listing: current-repo subtree by
- * default (matches the static overview's cwd scoping), `--all` widens to every
- * directory, `--since` seeds the window.
+ * default (matches the static overview's cwd scoping). `--all` sets every
+ * non-status filter to its "all" value — every directory (project) AND all-time
+ * (window) — so one flag maxes the view; `--since` still overrides the window and
+ * `-a`/`--device` still narrow their axis.
  */
 export function bareBrowserSeed(opts: {
   teams?: boolean;
@@ -161,8 +166,9 @@ export function bareBrowserSeed(opts: {
   return {
     teams: !!opts.teams,
     agent: opts.agent,
+    // --all maxes every non-status filter: all dirs AND all-time. --since wins.
     projectScope: opts.all ? 'all' : 'repo',
-    window: opts.since ?? '30d',
+    window: opts.since ?? (opts.all ? undefined : '30d'),
   };
 }
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1170,6 +1170,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
           agent: options.agent,
           host: options.host,
           since: options.since,
+          all: options.all,
         }),
         { local: options.local === true, hosts: options.host },
       );
@@ -2979,7 +2980,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--antigravity', 'Shorthand for --agent antigravity')
     .option('--grok', 'Shorthand for --agent grok')
     .option('--opencode', 'Shorthand for --agent opencode')
-    .option('--all', 'Include sessions from every directory (not just current project)')
+    .option('--all', 'Widen every non-status filter to "all": every directory (not just this project) and all time (no window cap). Status filters like --active still compose; -a/--device/--since still narrow their axis.')
     .option('--unmanaged', "Also show sessions from your own ~/.<agent> installs (hidden once agents-cli manages that agent)")
     .option('--teams', 'Include team-spawned sessions (hidden by default)')
     .option('--routine', 'Show only sessions archived from routine runs')


### PR DESCRIPTION
## What

Make `agents sessions --all` mean **"all values for every non-status filter"** — every directory (project) **and** all time (window) — instead of only widening the directory scope. `--active` still composes as a status filter, and `-a` / `--device` / `--since` still narrow their own axis (an explicit `--since` overrides the all-time default). Threaded through `activeBrowserSeed` too, so `--active --all` widens the window as well.

## Why

Reported: a user shouldn't have to reason about per-axis flags — `--all` should be the single "show me everything" switch. Before, `--all` only dropped the current-project scope; the 30-day window cap still hid older sessions, so `--all` didn't actually mean everything.

## Change

- `activeBrowserSeed` / `bareBrowserSeed`: `window: opts.since ?? (opts.all ? undefined : '30d')` — `--all` drops the window cap; `--since` still wins (`sessions-browser.ts`).
- `activeBrowserSeed` now accepts `all`, and the `--active` routing passes `options.all` (`sessions.ts`).
- `--all` option help updated to describe the new semantics.
- Tests: `--all` window-widening + `--since` override for both seeds (47 pass).

## Scope note

The **interactive `--active` fleet-wide fix** (remote sessions were dropped by a local-only live-set intersection) landed **separately on `main`** in `0679d6bd` / `8a58b403` (`mergeLiveIntoPool` — a superset of the approach I first took in #1587, which I'm closing as superseded). I verified that merged fix end-to-end: the interactive `--active` browser now renders sessions across multiple machines (box/zion/yosemite-s1), not just local. This PR is the remaining `--all` semantics piece not covered by that fix.

Relates to RUSH-2055.
