### PR TITLE
fix(cli): device affinity is --device auto (not --smart / harness auto)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2059.md
+++ b/apps/cli/.changelog/next/RUSH-2059.md
@@ -1,0 +1,8 @@
+- **Device affinity is `--device auto` (not `--smart` / harness `auto`) (RUSH-2059).**
+  Host pick from 14d usage affinity is a special value on the existing host flags:
+  `agents run claude --device auto` or `--host auto`. The harness is always the
+  agent you type — never auto-selected. Deprecated hidden `--smart` maps to
+  `--device auto` for one release. Extension New Agent unpinned launches use
+  `--device auto`. Banner: `device=auto → <host> (affinity …) · accounts=balanced`.
+  Source: `apps/cli/src/commands/exec.ts`, `smart-launch.ts`,
+  `apps/factory/src/core/agents.ts`.

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -24,7 +24,14 @@ agents run claude "fix the auth bug"   --host mac-mini   # headless: prompt give
 agents run codex  "port this to rust"  --host spark-0    # headless: prompt given
 agents run droid  "triage the inbox"   --host win-mini    # headless: prompt given
 agents run claude                      --host mac-mini   # interactive: TTY forwarded
+agents run claude "…"                  --device auto     # affinity-pick host from 14d usage
+agents run claude "…"                  --host auto       # same (host is the special value auto)
 ```
+
+Pass `auto` as the `--host` / `--device` value to pick a host from 14-day session
+affinity (weighted by launch counts on `sessions.db` `machine`; most-used online
+device has highest probability). Harness stays the agent you typed — never
+auto-picked. Affinity failure degrades to local rather than aborting the run.
 
 It sits next to the vendor clouds (`agents cloud run --provider rush|codex|…`),
 not replacing them: those dispatch to *someone else's* cloud; `hosts` dispatches

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -758,63 +758,33 @@ export function registerRunCommand(program: Command): void {
 
       // --device auto / --host auto (and deprecated --smart): affinity-pick host.
       // Harness is always the agent the user typed — never auto-picked.
+      // Affinity failure degrades to local (does not kill the run).
       {
-        const { isDeviceAuto, resolveDeviceAffinity } = await import('../lib/smart-launch.js');
-        // Hidden --smart → same as --device auto when no host flag was given.
-        if (options.smart) {
-          const anyHost = [options.host, options.device, options.on, options.computer].some(
-            (v) => typeof v === 'string' && v.trim() !== '',
+        const { applyDeviceAutoToOptions } = await import('../lib/smart-launch.js');
+        const result = applyDeviceAutoToOptions(options, {
+          accountPickerRequested,
+        });
+        if (!options.quiet && result.deprecationSmart) {
+          process.stderr.write(
+            chalk.yellow('[agents] --smart is deprecated; use --device auto\n'),
           );
-          if (!anyHost) options.device = 'auto';
-          if (!options.quiet) {
-            process.stderr.write(
-              chalk.yellow('[agents] --smart is deprecated; use --device auto\n'),
-            );
-          }
         }
-        const hostSlots: Array<'host' | 'device' | 'on' | 'computer'> = [
-          'host',
-          'device',
-          'on',
-          'computer',
-        ];
-        const autoSlot = hostSlots.find((k) => isDeviceAuto(options[k]));
-        if (autoSlot) {
-          // Only one host flag should be set; if several say auto, resolve once.
-          try {
-            const plan = resolveDeviceAffinity({});
-            const concrete = plan.host; // null = local
-            for (const k of hostSlots) {
-              if (isDeviceAuto(options[k])) {
-                options[k] = concrete ?? undefined;
-              }
-            }
-            // Prefer balanced accounts on affinity launches unless overridden or
-            // the user is on the trailing-@ account picker.
-            if (!accountPickerRequested && !options.strategy && !options.balanced) {
-              options.balanced = true;
-            }
-            if (!options.quiet) {
-              const hostLabel = concrete ?? 'local';
-              const deviceHint = plan.deviceCandidates
-                .slice(0, 4)
-                .map((c) => `${c.key}:${c.launches}`)
-                .join(', ');
-              const acctNote = accountPickerRequested
-                ? 'accounts=picker'
-                : 'accounts=balanced';
-              process.stderr.write(
-                chalk.gray(
-                  `[agents] device=auto → ${hostLabel}` +
-                    (deviceHint ? ` (affinity ${deviceHint})` : '') +
-                    ` · ${acctNote}\n`,
-                ),
-              );
-            }
-          } catch (err) {
-            console.error(chalk.red(`[agents] device=auto failed: ${(err as Error).message}`));
-            process.exit(1);
-          }
+        if (!options.quiet && result.skipped) {
+          process.stderr.write(
+            chalk.yellow(
+              `[agents] device=auto skipped: ${result.skipped} (running local)\n`,
+            ),
+          );
+        }
+        if (!options.quiet && result.banner) {
+          const { hostLabel, deviceHint, acctNote } = result.banner;
+          process.stderr.write(
+            chalk.gray(
+              `[agents] device=auto → ${hostLabel}` +
+                (deviceHint ? ` (affinity ${deviceHint})` : '') +
+                ` · ${acctNote}\n`,
+            ),
+          );
         }
       }
 

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -64,7 +64,10 @@ interface ExecCommandActionOptions {
   fallback?: string;
   balanced?: boolean;
   strategy?: string;
-  /** Affinity-pick host (and harness when agent is auto); accounts stay balanced. */
+  /**
+   * @deprecated Hidden alias for `--device auto`. Resolved before host dispatch.
+   * Remove after one release.
+   */
   smart?: boolean;
   acp?: boolean;
   yes?: boolean;
@@ -559,10 +562,6 @@ export function registerRunCommand(program: Command): void {
       'Version/account selection strategy: pinned | available | balanced. Defaults to run.<agent>.strategy, then balanced (spreads load across healthy accounts and skips any that are rate-limited). (Legacy `rotate` accepted as alias for `balanced`.)',
     )
     .option(
-      '--smart',
-      'Pick host from 14d usage affinity (most-used online device has highest probability). Accounts still use balanced. Ignored when --host/--device is set. Pass agent "auto" to also pick harness among claude/codex/kimi.',
-    )
-    .option(
       '--acp',
       'Route through the Agent Client Protocol instead of direct exec. Supported for gemini, claude (via @zed-industries/claude-code-acp adapter). Unified event stream; emits ndjson when --json.',
     )
@@ -597,11 +596,11 @@ export function registerRunCommand(program: Command): void {
     )
     .option(
       '--host <name>',
-      'Offload this run onto another machine over SSH instead of running locally — a device, a registered agent host, or user@host. See `agents devices` / `agents hosts`.',
+      'Offload this run onto another machine over SSH — a device name, registered host, or user@host. Pass "auto" to pick from 14d usage affinity (most-used online device has highest probability). See `agents devices`.',
     )
     .option(
       '--device <name>',
-      'Alias of --host: offload this run onto a registered device (from `agents devices`).',
+      'Alias of --host. Pass "auto" for affinity-based device pick (same as --host auto).',
     )
     .option('--remote-cwd <dir>', "Explicit host working directory for --host runs, used VERBATIM (overrides --cwd; usually --cwd suffices — it re-roots a local-home path onto the remote home). Pass a single-quoted '$HOME/…' or a valid remote absolute path; a local ~ expands here and won't exist there (/Users/you vs /home/you).")
     .option('--no-follow', 'With --host, dispatch detached and return immediately (track via `agents hosts ps/logs`).')
@@ -630,6 +629,10 @@ export function registerRunCommand(program: Command): void {
   // `--on` and `--computer` are hidden aliases of `--host` — same behavior.
   runCmd.addOption(new Option('--on <name>', 'Alias of --host.').hideHelp());
   runCmd.addOption(new Option('--computer <name>', 'Alias of --host.').hideHelp());
+  // Deprecated one-release alias: `agents run … --smart` → treat as `--device auto`.
+  runCmd.addOption(
+    new Option('--smart', 'Deprecated: use --device auto (affinity host pick).').hideHelp(),
+  );
 
   // Internal: the `--host` dispatch forwards this so the REMOTE run prints its
   // resolved session id as a one-line stdout sentinel (hosts/session-marker.ts),
@@ -739,8 +742,8 @@ export function registerRunCommand(program: Command): void {
         process.exit(1);
       }
 
-      // Account-picker conflict check runs BEFORE --smart mutates options.balanced,
-      // so an implicit smart→balanced preference never surfaces as a fake
+      // Account-picker conflict check runs BEFORE device=auto may set balanced,
+      // so an implicit balanced preference never surfaces as a fake
       // "cannot be combined with --balanced" when the user only typed trailing @.
       if (accountPickerRequested) {
         const conflicts = runAccountPickerConflicts(options);
@@ -753,38 +756,46 @@ export function registerRunCommand(program: Command): void {
         }
       }
 
-      // --smart: affinity-pick host (and optional harness when agent is "auto").
-      // Explicit --host/--device wins. Account rotation stays --strategy balanced
-      // unless the user is already on the trailing-@ account picker (they own
-      // account selection then — do not force balanced underneath them).
-      if (options.smart) {
-        const hostAlready = [options.host, options.device, options.on, options.computer].some(Boolean);
-        const [agentName, rawVersionPin] = normalizedAgentSpec.split('@');
-        if (rawVersionPin) {
+      // --device auto / --host auto (and deprecated --smart): affinity-pick host.
+      // Harness is always the agent the user typed — never auto-picked.
+      {
+        const { isDeviceAuto, resolveDeviceAffinity } = await import('../lib/smart-launch.js');
+        // Hidden --smart → same as --device auto when no host flag was given.
+        if (options.smart) {
+          const anyHost = [options.host, options.device, options.on, options.computer].some(
+            (v) => typeof v === 'string' && v.trim() !== '',
+          );
+          if (!anyHost) options.device = 'auto';
           if (!options.quiet) {
-            process.stderr.write(chalk.yellow('[agents] --smart ignored for host/harness pick when @version is pinned; accounts still use strategy\n'));
+            process.stderr.write(
+              chalk.yellow('[agents] --smart is deprecated; use --device auto\n'),
+            );
           }
-        } else if (!hostAlready || agentName === 'auto') {
+        }
+        const hostSlots: Array<'host' | 'device' | 'on' | 'computer'> = [
+          'host',
+          'device',
+          'on',
+          'computer',
+        ];
+        const autoSlot = hostSlots.find((k) => isDeviceAuto(options[k]));
+        if (autoSlot) {
+          // Only one host flag should be set; if several say auto, resolve once.
           try {
-            const { resolveSmartLaunch } = await import('../lib/smart-launch.js');
-            const pickHarness = agentName === 'auto';
-            const plan = resolveSmartLaunch({
-              agent: pickHarness ? undefined : (agentName as import('../lib/types.js').AgentId),
-              pickHarness,
-            });
-            if (!hostAlready && plan.host) {
-              options.host = plan.host;
+            const plan = resolveDeviceAffinity({});
+            const concrete = plan.host; // null = local
+            for (const k of hostSlots) {
+              if (isDeviceAuto(options[k])) {
+                options[k] = concrete ?? undefined;
+              }
             }
-            if (pickHarness) {
-              normalizedAgentSpec = plan.agent;
-            }
-            // Prefer balanced for smart launches unless the user overrode strategy
-            // or requested the interactive account picker (trailing @).
+            // Prefer balanced accounts on affinity launches unless overridden or
+            // the user is on the trailing-@ account picker.
             if (!accountPickerRequested && !options.strategy && !options.balanced) {
               options.balanced = true;
             }
             if (!options.quiet) {
-              const hostLabel = plan.host ?? 'local';
+              const hostLabel = concrete ?? 'local';
               const deviceHint = plan.deviceCandidates
                 .slice(0, 4)
                 .map((c) => `${c.key}:${c.launches}`)
@@ -794,18 +805,15 @@ export function registerRunCommand(program: Command): void {
                 : 'accounts=balanced';
               process.stderr.write(
                 chalk.gray(
-                  `[agents] smart: host=${hostLabel} agent=${pickHarness ? plan.agent : agentName}` +
-                    (deviceHint ? ` (device affinity ${deviceHint})` : '') +
+                  `[agents] device=auto → ${hostLabel}` +
+                    (deviceHint ? ` (affinity ${deviceHint})` : '') +
                     ` · ${acctNote}\n`,
                 ),
               );
             }
           } catch (err) {
-            if (!options.quiet) {
-              process.stderr.write(
-                chalk.yellow(`[agents] --smart skipped: ${(err as Error).message}\n`),
-              );
-            }
+            console.error(chalk.red(`[agents] device=auto failed: ${(err as Error).message}`));
+            process.exit(1);
           }
         }
       }

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -139,8 +139,7 @@ export const RUN_OPTION_FORWARDING: Record<string, RunOptionForwarding> = {
   tailscale: 'local-only', // --tailscale/--no-tailscale gate the lease net mode; never forwarded
   copyCreds: 'local-only', // copies creds TO the host before dispatch — local concern only
   authCheck: 'local-only', // --no-auth-check gates the local interactive login preflight; --host runs skip that preflight entirely
-  // Affinity host/harness pick runs on the launching box, then may set --host
-  // and --strategy balanced. Never forward --smart itself over SSH.
+  // Deprecated alias for --device auto; resolved on the launching box before SSH.
   smart: 'local-only',
 };
 

--- a/apps/cli/src/lib/smart-launch.test.ts
+++ b/apps/cli/src/lib/smart-launch.test.ts
@@ -4,6 +4,7 @@ import {
   sampleWeighted,
   resolveDeviceAffinity,
   isDeviceAuto,
+  applyDeviceAutoToOptions,
   type WeightedCandidate,
 } from './smart-launch.js';
 import type { AffinityRow } from './session/db.js';
@@ -90,5 +91,112 @@ describe('resolveDeviceAffinity', () => {
     });
     expect(plan.host).toBeNull();
     expect(plan.pickedDeviceKey).toBe('yosemite-s0');
+  });
+});
+
+describe('applyDeviceAutoToOptions', () => {
+  it('rewrites --device auto to a concrete remote host and enables balanced', () => {
+    const options = { device: 'auto' as string | undefined };
+    const result = applyDeviceAutoToOptions(options, {
+      resolve: () => ({
+        host: 'yosemite-s1',
+        deviceCandidates: [
+          { key: 'yosemite-s1', launches: 50, weight: 50 },
+          { key: 'yosemite-s0', launches: 5, weight: 5 },
+        ],
+        pickedDeviceKey: 'yosemite-s1',
+      }),
+    });
+    expect(options.device).toBe('yosemite-s1');
+    expect(options.balanced).toBe(true);
+    expect(result.attempted).toBe(true);
+    expect(result.skipped).toBeUndefined();
+    expect(result.banner?.hostLabel).toBe('yosemite-s1');
+    expect(result.banner?.deviceHint).toContain('yosemite-s1:50');
+    expect(result.banner?.acctNote).toBe('accounts=balanced');
+  });
+
+  it('rewrites auto on every host slot alias once', () => {
+    const options = {
+      host: 'auto' as string | undefined,
+      device: 'auto' as string | undefined,
+    };
+    applyDeviceAutoToOptions(options, {
+      resolve: () => ({
+        host: 'mac-mini',
+        deviceCandidates: [{ key: 'mac-mini', launches: 3, weight: 3 }],
+        pickedDeviceKey: 'mac-mini',
+      }),
+    });
+    expect(options.host).toBe('mac-mini');
+    expect(options.device).toBe('mac-mini');
+  });
+
+  it('maps local pick to undefined host (no --host)', () => {
+    const options = { device: 'auto' as string | undefined };
+    const result = applyDeviceAutoToOptions(options, {
+      resolve: () => ({
+        host: null,
+        deviceCandidates: [{ key: 'yosemite-s0', launches: 10, weight: 10 }],
+        pickedDeviceKey: 'yosemite-s0',
+      }),
+    });
+    expect(options.device).toBeUndefined();
+    expect(result.banner?.hostLabel).toBe('local');
+  });
+
+  it('maps deprecated --smart to --device auto when no host given', () => {
+    const options: { smart?: boolean; device?: string } = { smart: true };
+    applyDeviceAutoToOptions(options, {
+      resolve: () => ({
+        host: 'zion',
+        deviceCandidates: [{ key: 'zion', launches: 1, weight: 1 }],
+        pickedDeviceKey: 'zion',
+      }),
+    });
+    expect(options.device).toBe('zion');
+  });
+
+  it('does not override an explicit host when --smart is also set', () => {
+    const options = { smart: true, device: 'gpu-box' as string | undefined };
+    const result = applyDeviceAutoToOptions(options, {
+      resolve: () => {
+        throw new Error('should not resolve');
+      },
+    });
+    expect(options.device).toBe('gpu-box');
+    expect(result.attempted).toBe(false);
+    expect(result.deprecationSmart).toBe(true);
+  });
+
+  it('degrades to local on resolve failure without throwing', () => {
+    const options = { device: 'auto' as string | undefined, balanced: undefined as boolean | undefined };
+    const result = applyDeviceAutoToOptions(options, {
+      resolve: () => {
+        throw new Error('db locked');
+      },
+    });
+    expect(result.skipped).toBe('db locked');
+    expect(options.device).toBeUndefined();
+    expect(options.balanced).toBeUndefined();
+    expect(result.banner).toBeUndefined();
+  });
+
+  it('preserves strategy override and account-picker note', () => {
+    const options = {
+      device: 'auto' as string | undefined,
+      strategy: 'round-robin',
+    };
+    const result = applyDeviceAutoToOptions(options, {
+      accountPickerRequested: true,
+      resolve: () => ({
+        host: null,
+        deviceCandidates: [],
+        pickedDeviceKey: 'local',
+      }),
+    });
+    expect(options.strategy).toBe('round-robin');
+    expect(options.balanced).toBeUndefined();
+    expect(result.banner?.acctNote).toBe('accounts=picker');
   });
 });

--- a/apps/cli/src/lib/smart-launch.test.ts
+++ b/apps/cli/src/lib/smart-launch.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   affinityWeights,
   sampleWeighted,
-  resolveSmartLaunch,
+  resolveDeviceAffinity,
+  isDeviceAuto,
   type WeightedCandidate,
 } from './smart-launch.js';
 import type { AffinityRow } from './session/db.js';
@@ -21,7 +22,6 @@ describe('affinityWeights', () => {
 
   it('drops unknown / zero-launch keys', () => {
     const w = affinityWeights([row('(unknown)', 5), row('s1', 0), row('s1', 3)]);
-    // filter is per-row; s1 with 0 dropped, (unknown) dropped
     expect(w.every((c) => c.key !== '(unknown)')).toBe(true);
     expect(w.every((c) => c.launches > 0)).toBe(true);
   });
@@ -37,21 +37,28 @@ describe('sampleWeighted', () => {
   });
 
   it('prefers the heavier weight with a deterministic rng', () => {
-    // total = 90 + 10 = 100; rng 0.5 → roll 50 → first candidate (weight 90)
     const cands: WeightedCandidate[] = [
       { key: 's1', launches: 90, weight: 90 },
       { key: 'm0', launches: 10, weight: 10 },
     ];
     expect(sampleWeighted(cands, () => 0.5)).toBe('s1');
-    // rng near 1 → second candidate
     expect(sampleWeighted(cands, () => 0.95)).toBe('m0');
   });
 });
 
-describe('resolveSmartLaunch', () => {
-  it('samples most-used online host and keeps agent fixed', () => {
-    const plan = resolveSmartLaunch({
-      agent: 'claude',
+describe('isDeviceAuto', () => {
+  it('matches auto case-insensitively', () => {
+    expect(isDeviceAuto('auto')).toBe(true);
+    expect(isDeviceAuto('AUTO')).toBe(true);
+    expect(isDeviceAuto(' Auto ')).toBe(true);
+    expect(isDeviceAuto('yosemite-s1')).toBe(false);
+    expect(isDeviceAuto(undefined)).toBe(false);
+  });
+});
+
+describe('resolveDeviceAffinity', () => {
+  it('samples most-used online host', () => {
+    const plan = resolveDeviceAffinity({
       localMachine: 'yosemite-s0',
       eligibleHosts: ['yosemite-s0', 'yosemite-s1', 'yosemite-m0'],
       deviceAffinity: [
@@ -59,49 +66,29 @@ describe('resolveSmartLaunch', () => {
         row('yosemite-s0', 5),
         row('yosemite-m0', 1),
       ],
-      // total ≈ 5^α + 50^α + 1; mid roll lands in the heavy s1 bucket
       rng: () => 0.5,
     });
-    expect(plan.agent).toBe('claude');
-    expect(plan.accountStrategy).toBe('balanced');
-    expect(plan.host).toBe('yosemite-s1'); // not local
+    expect(plan.host).toBe('yosemite-s1');
   });
 
   it('returns host null when local machine is picked', () => {
-    const plan = resolveSmartLaunch({
-      agent: 'codex',
+    const plan = resolveDeviceAffinity({
       localMachine: 'yosemite-s0',
       eligibleHosts: ['yosemite-s0'],
       deviceAffinity: [row('yosemite-s0', 10)],
       rng: () => 0.5,
     });
     expect(plan.host).toBeNull();
-    expect(plan.agent).toBe('codex');
   });
 
   it('excludes offline hosts from affinity', () => {
-    const plan = resolveSmartLaunch({
-      agent: 'claude',
+    const plan = resolveDeviceAffinity({
       localMachine: 'yosemite-s0',
-      eligibleHosts: ['yosemite-s0'], // s1 not online
+      eligibleHosts: ['yosemite-s0'],
       deviceAffinity: [row('yosemite-s1', 100), row('yosemite-s0', 2)],
       rng: () => 0.5,
     });
-    expect(plan.host).toBeNull(); // only local eligible
+    expect(plan.host).toBeNull();
     expect(plan.pickedDeviceKey).toBe('yosemite-s0');
-  });
-
-  it('picks harness from allowlist when pickHarness is true', () => {
-    const plan = resolveSmartLaunch({
-      pickHarness: true,
-      allowAgents: ['claude', 'codex', 'kimi'],
-      localMachine: 'zion',
-      eligibleHosts: ['zion'],
-      deviceAffinity: [row('zion', 3)],
-      harnessAffinity: [row('codex', 40), row('claude', 10), row('kimi', 1)],
-      rng: () => 0.01,
-    });
-    expect(plan.agent).toBe('codex');
-    expect(plan.accountStrategy).toBe('balanced');
   });
 });

--- a/apps/cli/src/lib/smart-launch.ts
+++ b/apps/cli/src/lib/smart-launch.ts
@@ -1,20 +1,15 @@
 /**
- * Smart launch: pick device + harness from usage affinity, then leave account
- * selection to `--strategy balanced` (live rate-limit windows in rotate.ts).
+ * Device affinity for `--device auto` / `--host auto`.
  *
- * Probability model (per axis):
- *   P(x) ∝ launches(x)^α   among eligible candidates
- * Most-used gets the highest probability; never a hard lock (sample, not argmax).
+ * Picks a host from 14d session usage (launches by machine), weighted sample
+ * among online devices. Most-used has highest probability — not a hard lock.
+ * Account selection is separate (`--strategy balanced` / rotate.ts).
  */
 
-import type { AgentId } from './types.js';
 import { queryAffinityRollup, type AffinityRow } from './session/db.js';
 import { localMachineId } from './session/origin-machine.js';
 import { loadDevicesSync } from './devices/registry.js';
 import { normalizeHost } from './machine-id.js';
-
-/** Default harness allowlist for auto-pick. */
-export const DEFAULT_SMART_HARNESSES: AgentId[] = ['claude', 'codex', 'kimi'];
 
 /** Peakiness of usage weights; >1 amplifies the most-used option. */
 export const DEFAULT_AFFINITY_ALPHA = 1.3;
@@ -79,12 +74,7 @@ export function listOnlineDeviceNames(localName: string = localMachineId()): str
   return [...names];
 }
 
-export interface SmartLaunchOptions {
-  /** Fixed harness (skip harness sample). */
-  agent?: AgentId;
-  /** When true and agent unset, sample harness from allowlist. */
-  pickHarness?: boolean;
-  allowAgents?: AgentId[];
+export interface DeviceAffinityOptions {
   sinceDays?: number;
   alpha?: number;
   /**
@@ -95,34 +85,26 @@ export interface SmartLaunchOptions {
   localMachine?: string;
   /** Injected affinity (tests). When omitted, reads sessions.db. */
   deviceAffinity?: AffinityRow[];
-  harnessAffinity?: AffinityRow[];
   rng?: () => number;
   project?: string;
 }
 
-export interface SmartLaunchPlan {
+export interface DeviceAffinityPlan {
   /** null means run locally (do not pass --host). */
   host: string | null;
-  agent: AgentId;
-  /** Account strategy the caller must use. Always balanced for smart launch. */
-  accountStrategy: 'balanced';
   deviceCandidates: WeightedCandidate[];
-  harnessCandidates: WeightedCandidate[];
   pickedDeviceKey: string | null;
-  pickedHarnessKey: string | null;
 }
 
 /**
- * Resolve host + harness for an unpinned launch. Does NOT pick accounts —
- * caller runs `agents run <agent> --host <host> --strategy balanced`.
+ * Resolve host for `--device auto`. Does NOT pick harness or accounts.
  */
-export function resolveSmartLaunch(opts: SmartLaunchOptions = {}): SmartLaunchPlan {
+export function resolveDeviceAffinity(opts: DeviceAffinityOptions = {}): DeviceAffinityPlan {
   const local = normalizeHost(opts.localMachine ?? localMachineId());
   const alpha = opts.alpha ?? DEFAULT_AFFINITY_ALPHA;
   const rng = opts.rng ?? Math.random;
   const sinceDays = opts.sinceDays ?? 14;
   const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
-  const allow = opts.allowAgents ?? DEFAULT_SMART_HARNESSES;
 
   const eligible = new Set(
     (opts.eligibleHosts ?? listOnlineDeviceNames(local)).map(normalizeHost),
@@ -139,8 +121,7 @@ export function resolveSmartLaunch(opts: SmartLaunchOptions = {}): SmartLaunchPl
       project: opts.project,
     });
 
-  // Restrict affinity to online hosts. Hosts with history get launches^α;
-  // online hosts with no history still participate at weight 1 (exploration).
+  // Hosts with history get launches^α; online hosts with no history explore at weight 1.
   const launchesByHost = new Map<string, number>();
   for (const r of deviceRows) {
     const k = normalizeHost(r.key);
@@ -163,45 +144,31 @@ export function resolveSmartLaunch(opts: SmartLaunchOptions = {}): SmartLaunchPl
   const hostNorm = pickedDeviceKey ? normalizeHost(pickedDeviceKey) : local;
   const host = hostNorm === local ? null : hostNorm;
 
-  let agent: AgentId;
-  let harnessWeights: WeightedCandidate[] = [];
-  let pickedHarnessKey: string | null = null;
-
-  if (opts.agent) {
-    agent = opts.agent;
-    pickedHarnessKey = opts.agent;
-  } else if (opts.pickHarness) {
-    const harnessRows =
-      opts.harnessAffinity ??
-      queryAffinityRollup({
-        groupBy: 'agent',
-        sinceMs,
-        agents: allow as import('./session/types.js').SessionAgentId[],
-        excludeTeamOrigin: true,
-        onlyCli: true,
-        project: opts.project,
-      });
-    harnessWeights = affinityWeights(
-      harnessRows.filter((r) => allow.includes(r.key as AgentId)),
-      alpha,
-    );
-    if (harnessWeights.length === 0) {
-      harnessWeights = allow.map((key) => ({ key, launches: 1, weight: 1 }));
-    }
-    pickedHarnessKey = sampleWeighted(harnessWeights, rng) ?? allow[0];
-    agent = (pickedHarnessKey as AgentId) ?? allow[0];
-  } else {
-    agent = allow[0] ?? 'claude';
-    pickedHarnessKey = agent;
-  }
-
   return {
     host,
-    agent,
-    accountStrategy: 'balanced',
     deviceCandidates: deviceWeights,
-    harnessCandidates: harnessWeights,
     pickedDeviceKey,
-    pickedHarnessKey,
   };
+}
+
+/** @deprecated Use resolveDeviceAffinity — kept for any transitional callers. */
+export function resolveSmartLaunch(opts: DeviceAffinityOptions & { agent?: string } = {}): DeviceAffinityPlan & {
+  agent?: string;
+  accountStrategy: 'balanced';
+  harnessCandidates: WeightedCandidate[];
+  pickedHarnessKey: string | null;
+} {
+  const plan = resolveDeviceAffinity(opts);
+  return {
+    ...plan,
+    agent: opts.agent,
+    accountStrategy: 'balanced',
+    harnessCandidates: [],
+    pickedHarnessKey: opts.agent ?? null,
+  };
+}
+
+/** True when a host flag value means affinity pick. */
+export function isDeviceAuto(value: string | undefined | null): boolean {
+  return typeof value === 'string' && value.trim().toLowerCase() === 'auto';
 }

--- a/apps/cli/src/lib/smart-launch.ts
+++ b/apps/cli/src/lib/smart-launch.ts
@@ -151,24 +151,100 @@ export function resolveDeviceAffinity(opts: DeviceAffinityOptions = {}): DeviceA
   };
 }
 
-/** @deprecated Use resolveDeviceAffinity — kept for any transitional callers. */
-export function resolveSmartLaunch(opts: DeviceAffinityOptions & { agent?: string } = {}): DeviceAffinityPlan & {
-  agent?: string;
-  accountStrategy: 'balanced';
-  harnessCandidates: WeightedCandidate[];
-  pickedHarnessKey: string | null;
-} {
-  const plan = resolveDeviceAffinity(opts);
-  return {
-    ...plan,
-    agent: opts.agent,
-    accountStrategy: 'balanced',
-    harnessCandidates: [],
-    pickedHarnessKey: opts.agent ?? null,
-  };
-}
-
 /** True when a host flag value means affinity pick. */
 export function isDeviceAuto(value: string | undefined | null): boolean {
   return typeof value === 'string' && value.trim().toLowerCase() === 'auto';
+}
+
+const HOST_SLOTS = ['host', 'device', 'on', 'computer'] as const;
+
+export type DeviceAutoHostOptions = {
+  host?: string;
+  device?: string;
+  on?: string;
+  computer?: string;
+  /** @deprecated Hidden alias for `--device auto`. */
+  smart?: boolean;
+  balanced?: boolean;
+  strategy?: string;
+};
+
+export type DeviceAutoApplyResult = {
+  /** True when affinity ran (success or degrade-to-local). */
+  attempted: boolean;
+  /** True when deprecated `--smart` was seen. */
+  deprecationSmart: boolean;
+  /** Affinity threw: host slots cleared → local; message for stderr. */
+  skipped?: string;
+  /** Present when affinity resolved without error. */
+  banner?: {
+    hostLabel: string;
+    deviceHint: string;
+    acctNote: string;
+  };
+};
+
+/**
+ * Apply `--device auto` / `--host auto` (and deprecated `--smart`) onto run options.
+ * Mutates `options` in place. On affinity failure, clears auto slots (local) and
+ * returns `skipped` — never throws; callers must not hard-exit.
+ */
+export function applyDeviceAutoToOptions(
+  options: DeviceAutoHostOptions,
+  deps: {
+    resolve?: () => DeviceAffinityPlan;
+    accountPickerRequested?: boolean;
+  } = {},
+): DeviceAutoApplyResult {
+  let deprecationSmart = false;
+
+  if (options.smart) {
+    const anyHost = HOST_SLOTS.some(
+      (k) => typeof options[k] === 'string' && options[k]!.trim() !== '',
+    );
+    if (!anyHost) options.device = 'auto';
+    deprecationSmart = true;
+  }
+
+  const hasAuto = HOST_SLOTS.some((k) => isDeviceAuto(options[k]));
+  if (!hasAuto) {
+    return { attempted: false, deprecationSmart };
+  }
+
+  try {
+    const plan = (deps.resolve ?? (() => resolveDeviceAffinity({})))();
+    const concrete = plan.host; // null = local
+    for (const k of HOST_SLOTS) {
+      if (isDeviceAuto(options[k])) {
+        options[k] = concrete ?? undefined;
+      }
+    }
+    const accountPickerRequested = deps.accountPickerRequested ?? false;
+    if (!accountPickerRequested && !options.strategy && !options.balanced) {
+      options.balanced = true;
+    }
+    const hostLabel = concrete ?? 'local';
+    const deviceHint = plan.deviceCandidates
+      .slice(0, 4)
+      .map((c) => `${c.key}:${c.launches}`)
+      .join(', ');
+    const acctNote = accountPickerRequested ? 'accounts=picker' : 'accounts=balanced';
+    return {
+      attempted: true,
+      deprecationSmart,
+      banner: { hostLabel, deviceHint, acctNote },
+    };
+  } catch (err) {
+    // Graceful degrade: clear auto slots so the run continues locally.
+    for (const k of HOST_SLOTS) {
+      if (isDeviceAuto(options[k])) {
+        options[k] = undefined;
+      }
+    }
+    return {
+      attempted: true,
+      deprecationSmart,
+      skipped: (err as Error).message,
+    };
+  }
 }

--- a/apps/factory/src/core/agents.ts
+++ b/apps/factory/src/core/agents.ts
@@ -179,11 +179,10 @@ export function buildAgentLaunchCommand(
   if (host) {
     command += ` --host ${shquote(host)}`;
   }
-  // Unpinned, no explicit host: CLI affinity-picks host via --smart (most-used
-  // online device has highest probability). Explicit Pick Host / @version pin
-  // skip this. Accounts stay on balanced unless strategy is set.
+  // Unpinned, no explicit host: affinity-pick device via --device auto.
+  // Explicit Pick Host / @version pin skip this.
   if (!host && !pinnedVersion) {
-    command += ' --smart';
+    command += ' --device auto';
   }
   if (sessionId && agentKey === 'claude') {
     command += ` --session-id ${sessionId}`;


### PR DESCRIPTION
## Summary

Replaces the ugly API from RUSH-2049:

**Before (wrong):**
```bash
agents run auto --smart "…"   # looked like harness auto-pick
agents run claude --smart "…"
```

**After:**
```bash
agents run claude --device auto "…"
agents run claude --host auto "…"   # same
```

- Harness is always the agent you type
- Host affinity is the special value `auto` on `--device` / `--host`
- Accounts still use balanced strategy
- Hidden `--smart` → `--device auto` for one release (deprecated)
- Extension New Agent uses `--device auto`

Banner:
```
[agents] device=auto → local (affinity yosemite-s0:244, …) · accounts=balanced
[agents] balanced picked … · claude@…
```

Linear: RUSH-2059

## Test plan
- [x] unit: smart-launch + run-forwarding
- [x] live: `agents run claude --device auto --mode plan -y "pong"` shows new banner
- [ ] CI green