### PR TITLE
chore: gitignore every harness config home, not just claude/codex/gemini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,23 @@ scripts/scrub-history.sh
 .rush/
 
 # Agents (recurisve)
+# Harness config homes written by `agents` config sync. Keep this list in step
+# with the AGENTS registry in apps/cli/src/lib/agents.ts — a harness that syncs
+# a dir here but is missing below leaves the tree permanently dirty, which
+# blocks scripts/release.sh (it refuses to build a release from a dirty tree).
 **/.claude
 **/.codex
 **/.gemini
+**/.factory
+**/.grok
+**/.kimi-code
+**/.opencode
+**/.antigravity
+**/.cursor
+**/.droid
+**/.goose
+**/.kiro
+**/.openclaw
 **/.tmp
 **/.tmp-bun
 


### PR DESCRIPTION
## Why

`agents` config sync writes a config home per harness, but `.gitignore` only covered `.claude`, `.codex`, and `.gemini`. Every other supported harness leaves a permanently untracked dir in whatever repo it syncs into.

That isn't cosmetic in this repo. `scripts/release.sh` refuses to release from a dirty tree:

```
# Working tree must be clean. This is load-bearing: the release commit is built
# straight from the index via 'git write-tree' (see the apply phase), so a dirty
# tree would smuggle unrelated changes into the release PR + published tarball.
if [[ -n "$(git status --porcelain)" ]]; then
  die "working tree is dirty -- commit or stash first"
fi
```

So syncing any newer harness into this checkout **silently blocks releasing the CLI**. Hit for real while cutting a release from a checkout carrying `.factory/`, `.grok/`, `.kimi-code/`, and `.opencode/`:

```
$ git status --porcelain
?? .factory/
?? .grok/
?? .kimi-code/
?? .opencode/
```

## What

Adds the remaining harness homes from the `AGENTS` registry — `.factory`, `.grok`, `.kimi-code`, `.opencode`, `.antigravity`, `.cursor`, `.droid`, `.goose`, `.kiro`, `.openclaw` — and a comment pointing at `apps/cli/src/lib/agents.ts` so the list is maintained alongside the registry rather than drifting again.

## Safety

None of these paths are tracked, so nothing is shadowed and no file leaves the repo:

```
$ for d in .factory .grok .kimi-code .opencode .antigravity .cursor .droid .goose .kiro .openclaw; do
    echo "$d tracked_files=$(git ls-files "$d" "**/$d" | wc -l)"; done
.factory tracked_files=0
.grok tracked_files=0
.kimi-code tracked_files=0
.opencode tracked_files=0
.antigravity tracked_files=0
.cursor tracked_files=0
.droid tracked_files=0
.goose tracked_files=0
.kiro tracked_files=0
.openclaw tracked_files=0
```

After the change `git status --porcelain` is empty and `scripts/release.sh` gets past its pre-flight.

No changelog fragment: repo hygiene, no user-visible CLI surface.