### PR TITLE
fix(repo): pull rebases instead of refusing; failures exit non-zero

### DIFF
--- a/apps/cli/.changelog/next/repo-pull-rebase.md
+++ b/apps/cli/.changelog/next/repo-pull-rebase.md
@@ -4,15 +4,13 @@
   conflict. Since `pullRepo` itself auto-commits the machine's own
   `devices/<host>/agents.yaml` before pulling, every device eventually created that
   commit and stopped receiving updates: on one fleet, nine machines sat 9 commits
-  behind, and merged rule changes never reached any of them. It now rebases, which is
+  behind and merged rule changes never reached any of them. It now rebases, which is
   what its own documentation has always described. Per-device paths are disjoint, so
-  they replay cleanly; a genuine conflict still fails, now naming the conflict.
+  they replay cleanly. A genuine conflict aborts the rebase and rolls the checkout
+  back untouched, so a failed pull can never leave the repo detached, mid-rebase, or
+  with conflict markers in live config; a rebase already in progress is reported as
+  itself rather than as a dirty tree.
 - **`agents repo pull` / `push` exit non-zero when a repo fails.** Both printed a
   failure line and returned 0, so `agents fleet run "agents repo pull user"` reported
   `11 ok` across a fleet that pulled nothing. Any automation gating on the exit code
-  read a total no-op as success. Matches `agents sync`, which already did this.
-- **`agents cloud … --host` no longer reassigns a routine's device pin.** It set
-  `devices: [<this machine>]` unconditionally, so re-registering a webhook routine
-  from another box silently moved where it fires. The pin names where the routine's
-  author wants it to run; it is now filled only when empty, matching the three other
-  pin sites.
+  read a total no-op as success. Matches `agents sync <repo>`, which already did this.

--- a/apps/cli/.changelog/next/repo-pull-rebase.md
+++ b/apps/cli/.changelog/next/repo-pull-rebase.md
@@ -1,0 +1,18 @@
+- **`agents repo pull` reconciles a diverged repo instead of wedging on it.** It ran
+  `git merge --ff-only`, which refuses *any* divergence — conflict or not — so a
+  single local commit permanently blocked every later pull with nothing actually in
+  conflict. Since `pullRepo` itself auto-commits the machine's own
+  `devices/<host>/agents.yaml` before pulling, every device eventually created that
+  commit and stopped receiving updates: on one fleet, nine machines sat 9 commits
+  behind, and merged rule changes never reached any of them. It now rebases, which is
+  what its own documentation has always described. Per-device paths are disjoint, so
+  they replay cleanly; a genuine conflict still fails, now naming the conflict.
+- **`agents repo pull` / `push` exit non-zero when a repo fails.** Both printed a
+  failure line and returned 0, so `agents fleet run "agents repo pull user"` reported
+  `11 ok` across a fleet that pulled nothing. Any automation gating on the exit code
+  read a total no-op as success. Matches `agents sync`, which already did this.
+- **`agents cloud … --host` no longer reassigns a routine's device pin.** It set
+  `devices: [<this machine>]` unconditionally, so re-registering a webhook routine
+  from another box silently moved where it fires. The pin names where the routine's
+  author wants it to run; it is now filled only when empty, matching the three other
+  pin sites.

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -354,7 +354,14 @@ Examples:
         if (options.host) {
           routine.host = options.host as string;
           if (options.remoteCwd) routine.remoteCwd = options.remoteCwd as string;
-          routine.devices = [machineId()];
+          // Fill the firing pin only when the author left it empty — the same
+          // guard the three sibling pin sites use (routines.ts:637, :746,
+          // routines-project.ts:302). Without it, re-registering on another box
+          // silently reassigned a pin the routine's author had chosen, and the
+          // routine started firing from whichever machine ran the command last.
+          if (!routine.devices || routine.devices.length === 0) {
+            routine.devices = [machineId()];
+          }
         }
         writeJob(routine);
 

--- a/apps/cli/src/commands/cloud.ts
+++ b/apps/cli/src/commands/cloud.ts
@@ -354,14 +354,7 @@ Examples:
         if (options.host) {
           routine.host = options.host as string;
           if (options.remoteCwd) routine.remoteCwd = options.remoteCwd as string;
-          // Fill the firing pin only when the author left it empty — the same
-          // guard the three sibling pin sites use (routines.ts:637, :746,
-          // routines-project.ts:302). Without it, re-registering on another box
-          // silently reassigned a pin the routine's author had chosen, and the
-          // routine started firing from whichever machine ran the command last.
-          if (!routine.devices || routine.devices.length === 0) {
-            routine.devices = [machineId()];
-          }
+          routine.devices = [machineId()];
         }
         writeJob(routine);
 

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -979,6 +979,10 @@ export function registerRepoCommands(program: Command): void {
           anyPulled = true;
         } else {
           spinner.fail(`${formatRepoTarget(t.alias, t.dir)}: ${result.error}`);
+        // A failed repo must fail the command. Without this, `agents fleet run
+        // "agents repo pull user"` reported 11 ok across a fleet that pulled
+        // nothing — the silence that hid RUSH-2056. Matches commands/sync.ts.
+        process.exitCode = 1;
         }
       }
 
@@ -1037,6 +1041,10 @@ export function registerRepoCommands(program: Command): void {
           );
         } else {
           spinner.fail(`${formatRepoTarget(t.alias, t.dir)}: ${result.error}`);
+        // A failed repo must fail the command. Without this, `agents fleet run
+        // "agents repo pull user"` reported 11 ok across a fleet that pulled
+        // nothing — the silence that hid RUSH-2056. Matches commands/sync.ts.
+        process.exitCode = 1;
         }
       }
     });

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -979,10 +979,10 @@ export function registerRepoCommands(program: Command): void {
           anyPulled = true;
         } else {
           spinner.fail(`${formatRepoTarget(t.alias, t.dir)}: ${result.error}`);
-        // A failed repo must fail the command. Without this, `agents fleet run
-        // "agents repo pull user"` reported 11 ok across a fleet that pulled
-        // nothing — the silence that hid RUSH-2056. Matches commands/sync.ts.
-        process.exitCode = 1;
+          // A failed repo must fail the command. Without this, `agents fleet run
+          // "agents repo pull user"` reported 11 ok across a fleet that pulled
+          // nothing — the silence that hid RUSH-2056. Matches commands/sync.ts.
+          process.exitCode = 1;
         }
       }
 
@@ -1007,7 +1007,7 @@ export function registerRepoCommands(program: Command): void {
     .action(async (alias: string | undefined, options: { message: string }) => {
       const targets = collectRepoTargets(alias);
       if (!targets) {
-        process.exitCode = 1;
+          process.exitCode = 1;
         return;
       }
       // Drop system-repo targets — read-only by design.
@@ -1021,7 +1021,7 @@ export function registerRepoCommands(program: Command): void {
           console.log(chalk.yellow(`  ${t.alias}: not a git repo, skipping`));
           continue;
         }
-        // Defense in depth: refuse if origin happens to be the system upstream.
+          // Defense in depth: refuse if origin happens to be the system upstream.
         if (await isSystemRepoOrigin(t.dir)) {
           console.log(chalk.red(`  ${t.alias}: origin tracks the system repo — refusing to push.`));
           continue;
@@ -1041,10 +1041,10 @@ export function registerRepoCommands(program: Command): void {
           );
         } else {
           spinner.fail(`${formatRepoTarget(t.alias, t.dir)}: ${result.error}`);
-        // A failed repo must fail the command. Without this, `agents fleet run
-        // "agents repo pull user"` reported 11 ok across a fleet that pulled
-        // nothing — the silence that hid RUSH-2056. Matches commands/sync.ts.
-        process.exitCode = 1;
+          // A failed repo must fail the command. Without this, `agents fleet run
+          // "agents repo push user"` reported ok across a fleet that pushed
+          // nothing — the silence that hid RUSH-2056. Matches commands/sync.ts.
+          process.exitCode = 1;
         }
       }
     });

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -706,6 +706,47 @@ describe('pullRepo reconciles a diverged branch by rebasing', () => {
     expect(res.error).not.toMatch(/Blocked by local changes/);
   });
 
+  // A branch may track a remote that is not named 'origin'. Hardcoding origin
+  // for the pull while comparing against `tracking` made pullRepo report SUCCESS
+  // having moved nothing — the exact "reported ok, pulled nothing" failure this
+  // change exists to remove, just narrower.
+  // A branch may track a remote that is not named 'origin'. Hardcoding origin
+  // for the pull while comparing against `tracking` made pullRepo report SUCCESS
+  // having moved nothing — the exact "reported ok, pulled nothing" failure this
+  // change exists to remove, just narrower. origin must be STALE here, or
+  // pulling it would incidentally fetch the same content and hide the bug.
+  it('pulls the remote the branch actually tracks, not a hardcoded origin', async () => {
+    const { local } = await divergedPair();
+
+    // A SECOND bare repo, seeded from local, that will receive the new commit.
+    // origin keeps pointing at the first one and never moves again.
+    const root = path.dirname(local);
+    const upstreamBare = path.join(root, 'upstream.git');
+    await simpleGit().raw(['init', '--bare', '-b', 'main', upstreamBare]);
+    await simpleGit(local).raw(['remote', 'add', 'upstream', upstreamBare]);
+    await simpleGit(local).raw(['push', 'upstream', 'main']);
+
+    const mover = path.join(root, 'mover');
+    await simpleGit().clone(upstreamBare, mover);
+    await simpleGit(mover).addConfig('user.email', 'test@example.com');
+    await simpleGit(mover).addConfig('user.name', 'Test');
+    await simpleGit(mover).addConfig('commit.gpgsign', 'false');
+    fs.writeFileSync(path.join(mover, 'from-upstream.txt'), 'x\n');
+    await simpleGit(mover).add('-A');
+    await simpleGit(mover).commit('upstream moved');
+    await simpleGit(mover).push('origin', 'main');
+
+    await simpleGit(local).raw(['fetch', 'upstream']);
+    await simpleGit(local).raw(['branch', '--set-upstream-to=upstream/main', 'main']);
+
+    const res = await pullRepo(local);
+
+    expect(res.success).toBe(true);
+    // The real assertion: content actually arrived. Reporting success without
+    // moving anything is the bug. Pulling 'origin' here is a no-op.
+    expect(fs.existsSync(path.join(local, 'from-upstream.txt'))).toBe(true);
+  });
+
   // A git WORKTREE has `.git` as a FILE (`gitdir: <path>`), so a hardcoded
   // <dir>/.git/rebase-merge probe can never fire there. pullRepo runs on real
   // clones today, but the probe must not silently depend on that.

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -401,7 +401,7 @@ describe('commitAndPush (clean-but-ahead + dirty)', () => {
   });
 });
 
-describe('pullRepo fast-forward only', () => {
+describe('pullRepo reconciliation', () => {
   let root: string;
   let remote: string;
   let local: string;
@@ -661,7 +661,7 @@ describe('pullRepo reconciles a diverged branch by rebasing', () => {
     expect(log.latest?.message).toContain('snapshot boxA agent pins');
   });
 
-  it('fails with a conflict message when the same file genuinely conflicts', async () => {
+  it('rolls the tree back when a conflict aborts the rebase, leaving the repo usable', async () => {
     const { local, author } = await divergedPair();
 
     fs.writeFileSync(path.join(local, 'seed.txt'), 'local version\n');
@@ -673,8 +673,35 @@ describe('pullRepo reconciles a diverged branch by rebasing', () => {
     await simpleGit(author).commit('upstream edit');
     await simpleGit(author).push('origin', 'main');
 
+    const before = await simpleGit(local).revparse(['HEAD']);
+    const res = await pullRepo(local);
+    const after = await simpleGit(local).revparse(['HEAD']);
+
+    expect(res.success).toBe(false);
+
+    // The invariant --ff-only used to give for free, and the reason this suite
+    // exists: a failed pull must leave the checkout exactly as it found it.
+    // Without `rebase --abort` the repo is left detached, mid-rebase, with
+    // conflict markers written into live config files.
+    expect(after).toBe(before);
+    expect(fs.existsSync(path.join(local, '.git', 'rebase-merge'))).toBe(false);
+    expect(fs.existsSync(path.join(local, '.git', 'rebase-apply'))).toBe(false);
+    expect(fs.readFileSync(path.join(local, 'seed.txt'), 'utf-8')).not.toContain('<<<<<<<');
+    const status = await simpleGit(local).status();
+    expect(status.current).toBe('main'); // not detached HEAD
+    expect(status.conflicted).toEqual([]);
+  });
+
+  it('reports an in-progress rebase as itself, not as a dirty tree', async () => {
+    const { local, author } = await divergedPair();
+
+    // Wedge the repo the way a pre-abort conflict used to.
+    fs.mkdirSync(path.join(local, '.git', 'rebase-merge'), { recursive: true });
+
     const res = await pullRepo(local);
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/conflict/i);
+    expect(res.error).toMatch(/rebase is still in progress/i);
+    expect(res.error).not.toMatch(/Blocked by local changes/);
+    void author;
   });
 });

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -693,15 +693,34 @@ describe('pullRepo reconciles a diverged branch by rebasing', () => {
   });
 
   it('reports an in-progress rebase as itself, not as a dirty tree', async () => {
-    const { local, author } = await divergedPair();
+    const { local } = await divergedPair();
 
-    // Wedge the repo the way a pre-abort conflict used to.
-    fs.mkdirSync(path.join(local, '.git', 'rebase-merge'), { recursive: true });
+    // Wedge the repo the way a pre-abort conflict used to. Resolve the state
+    // dir through git rather than assuming <dir>/.git is a directory.
+    const gp = (await simpleGit(local).raw(['rev-parse', '--git-path', 'rebase-merge'])).trim();
+    fs.mkdirSync(path.isAbsolute(gp) ? gp : path.join(local, gp), { recursive: true });
 
     const res = await pullRepo(local);
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/rebase is still in progress/i);
     expect(res.error).not.toMatch(/Blocked by local changes/);
-    void author;
+  });
+
+  // A git WORKTREE has `.git` as a FILE (`gitdir: <path>`), so a hardcoded
+  // <dir>/.git/rebase-merge probe can never fire there. pullRepo runs on real
+  // clones today, but the probe must not silently depend on that.
+  it('detects an in-progress rebase in a worktree, where .git is a file', async () => {
+    const { local } = await divergedPair();
+    const wt = path.join(path.dirname(local), 'wt');
+    await simpleGit(local).raw(['worktree', 'add', '--detach', wt]);
+
+    expect(fs.statSync(path.join(wt, '.git')).isFile()).toBe(true);
+
+    const gp = (await simpleGit(wt).raw(['rev-parse', '--git-path', 'rebase-merge'])).trim();
+    fs.mkdirSync(path.isAbsolute(gp) ? gp : path.join(wt, gp), { recursive: true });
+
+    const res = await pullRepo(wt);
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/rebase is still in progress/i);
   });
 });

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -468,20 +468,26 @@ describe('pullRepo fast-forward only', () => {
     expect(after).toBe(before);
   });
 
-  it('refuses to fast-forward when local commits diverge from origin', async () => {
-    // Upstream and local each add a different file → diverged histories.
+  // REVERSED deliberately (RUSH-2056). This asserted that divergence alone
+  // refuses the pull. That is what broke fleet distribution: --ff-only rejects
+  // ANY divergence, conflict or not, so one commitOwnDeviceMeta commit wedged
+  // every device permanently with nothing actually in conflict. pullRepo now
+  // rebases, which is what its own doc has always claimed it does.
+  it('rebases a diverged branch instead of refusing when nothing conflicts', async () => {
+    // Upstream and local each add a DIFFERENT file → diverged, no conflict.
     await commitFile(author, 'up.txt', 'from-author\n', 'author commit');
     await simpleGit(author).push('origin', 'main');
     await commitFile(local, 'down.txt', 'from-local\n', 'local commit');
 
-    const before = await simpleGit(local).revparse(['HEAD']);
     const res = await pullRepo(local);
-    const after = await simpleGit(local).revparse(['HEAD']);
 
-    expect(res.success).toBe(false);
-    expect(res.error).toContain('Blocked by local commits');
-    expect(after).toBe(before);
-    expect(fs.existsSync(path.join(local, 'up.txt'))).toBe(false);
+    expect(res.success).toBe(true);
+    // Upstream content arrived...
+    expect(fs.existsSync(path.join(local, 'up.txt'))).toBe(true);
+    // ...and the local commit was replayed on top, not discarded.
+    expect(fs.existsSync(path.join(local, 'down.txt'))).toBe(true);
+    const log = await simpleGit(local).log({ maxCount: 1 });
+    expect(log.latest?.message).toContain('local commit');
   });
 });
 
@@ -588,5 +594,87 @@ describe('resolveGitHubUsername', () => {
 
   it('returns null when no source can resolve the username', () => {
     expect(resolveGitHubUsernameSync()).toBeNull();
+  });
+});
+
+describe('pullRepo reconciles a diverged branch by rebasing', () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+    tmpDirs.length = 0;
+  });
+
+  async function identity(dir: string): Promise<void> {
+    const g = simpleGit(dir);
+    await g.addConfig('user.email', 'test@example.com');
+    await g.addConfig('user.name', 'Test');
+    await g.addConfig('commit.gpgsign', 'false');
+    await g.addConfig('core.autocrlf', 'false');
+  }
+
+  // Builds: bare remote + an `author` clone that pushes upstream, and a `local`
+  // clone that has its own unpushed commit. That is exactly the fleet shape —
+  // commitOwnDeviceMeta makes a local commit, upstream moves on, and the two
+  // diverge with NOTHING in conflict (different files).
+  async function divergedPair(): Promise<{ local: string; author: string }> {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pullrebase-'));
+    tmpDirs.push(root);
+    const remote = path.join(root, 'remote.git');
+    const author = path.join(root, 'author');
+    const local = path.join(root, 'local');
+    await simpleGit().raw(['init', '--bare', '-b', 'main', remote]);
+    await simpleGit().clone(remote, author);
+    await identity(author);
+    fs.writeFileSync(path.join(author, 'seed.txt'), 'seed\n');
+    await simpleGit(author).add('-A');
+    await simpleGit(author).commit('seed');
+    await simpleGit(author).push('origin', 'main');
+    await simpleGit().clone(remote, local);
+    await identity(local);
+    return { local, author };
+  }
+
+  it('replays a local-only commit on top of upstream instead of refusing', async () => {
+    const { local, author } = await divergedPair();
+
+    // local: its own commit, never pushed (the devices/<host> pin case)
+    fs.mkdirSync(path.join(local, 'devices', 'boxA'), { recursive: true });
+    fs.writeFileSync(path.join(local, 'devices', 'boxA', 'agents.yaml'), 'agents:\n  claude: 1.0.0\n');
+    await simpleGit(local).add('-A');
+    await simpleGit(local).commit('chore(devices): snapshot boxA agent pins');
+
+    // upstream: an unrelated commit, so the branches diverge
+    fs.writeFileSync(path.join(author, 'rule.md'), '# a rule\n');
+    await simpleGit(author).add('-A');
+    await simpleGit(author).commit('add a rule');
+    await simpleGit(author).push('origin', 'main');
+
+    const res = await pullRepo(local);
+
+    // --ff-only fails here: divergence alone is enough, no conflict needed.
+    expect(res.success).toBe(true);
+    // upstream content arrived...
+    expect(fs.existsSync(path.join(local, 'rule.md'))).toBe(true);
+    // ...and the local commit survived, replayed on top.
+    expect(fs.existsSync(path.join(local, 'devices', 'boxA', 'agents.yaml'))).toBe(true);
+    const log = await simpleGit(local).log({ maxCount: 1 });
+    expect(log.latest?.message).toContain('snapshot boxA agent pins');
+  });
+
+  it('fails with a conflict message when the same file genuinely conflicts', async () => {
+    const { local, author } = await divergedPair();
+
+    fs.writeFileSync(path.join(local, 'seed.txt'), 'local version\n');
+    await simpleGit(local).add('-A');
+    await simpleGit(local).commit('local edit');
+
+    fs.writeFileSync(path.join(author, 'seed.txt'), 'upstream version\n');
+    await simpleGit(author).add('-A');
+    await simpleGit(author).commit('upstream edit');
+    await simpleGit(author).push('origin', 'main');
+
+    const res = await pullRepo(local);
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/conflict/i);
   });
 });

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -1013,13 +1013,16 @@ export async function pullRepo(
     }
 
     const branch = status.current || 'main';
-    await git.fetch('origin');
 
     // Resolve the upstream ref to fast-forward against. Prefer the local
     // branch's tracking config; otherwise ask origin for its default branch.
     let tracking = status.tracking;
     if (!tracking) {
+      // No tracking config: fetch origin so its HEAD is known, then ask which
+      // branch it points at. This path only ever concerns origin — a branch with
+      // no upstream has no other remote to consult.
       try {
+        await git.fetch('origin');
         await git.raw(['remote', 'set-head', 'origin', '--auto']);
         const sym = await git.raw(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
         tracking = sym.trim();
@@ -1028,8 +1031,20 @@ export async function pullRepo(
       }
     }
 
-    // `tracking` is a remote-tracking ref (origin/<name>); git pull wants <name>.
-    const remoteBranch = tracking.startsWith('origin/') ? tracking.slice('origin/'.length) : branch;
+    // Split the remote-tracking ref (<remote>/<branch>) into its parts and pull
+    // THOSE. Hardcoding 'origin' while comparing against `tracking` is how a
+    // branch tracking e.g. upstream/main silently 'succeeded': revparse saw a
+    // difference, the pull fetched origin/main (already current), and pullRepo
+    // returned success having moved nothing — the same "reported ok, pulled
+    // nothing" failure this change exists to remove. Branch names may contain
+    // slashes, so split on the FIRST separator only.
+    const sep = tracking.indexOf('/');
+    const remoteName = sep > 0 ? tracking.slice(0, sep) : 'origin';
+    const remoteBranch = sep > 0 ? tracking.slice(sep + 1) : branch;
+
+    // Fetch the resolved remote, not a hardcoded 'origin' — otherwise the
+    // revparse below compares against a stale ref for any other remote.
+    await git.fetch(remoteName);
 
     const localRef = await git.revparse(['HEAD']);
     const remoteRef = await git.revparse([tracking]).catch(() => null);
@@ -1058,7 +1073,7 @@ export async function pullRepo(
       // which may be named differently (local `main` vs origin `master`). Using
       // `branch` there asks origin for a ref it does not have.
       assertValidBranchName(remoteBranch);
-      await git.pull('origin', remoteBranch, { '--rebase': 'true' });
+      await git.pull(remoteName, remoteBranch, { '--rebase': 'true' });
     } catch (err) {
       // Abort so the tree is restored, matching the atomicity --ff-only gave us.
       // Without this a conflict leaves the repo detached, mid-rebase, with

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -968,9 +968,25 @@ export async function pullRepo(
     // Without this the dirty-tree guard below claims "Blocked by local changes",
     // which is both wrong and actively harmful advice mid-rebase on a detached
     // HEAD. Checked BEFORE commitOwnDeviceMeta so we never commit into one.
+    // Ask git where the state dirs live rather than assuming `<dir>/.git/` is a
+    // directory. In a worktree `.git` is a FILE containing `gitdir: <path>`, so
+    // path.join(dir, '.git', 'rebase-merge') can never exist and the check would
+    // silently never fire. `rev-parse --git-path` resolves both layouts.
+    const gitPath = async (name: string): Promise<string | null> => {
+      try {
+        const raw = (await git.raw(['rev-parse', '--git-path', name])).trim();
+        return path.isAbsolute(raw) ? raw : path.join(dir, raw);
+      } catch {
+        return null;
+      }
+    };
+    const [rebaseMerge, rebaseApply] = await Promise.all([
+      gitPath('rebase-merge'),
+      gitPath('rebase-apply'),
+    ]);
     const rebaseInProgress =
-      fs.existsSync(path.join(dir, '.git', 'rebase-merge')) ||
-      fs.existsSync(path.join(dir, '.git', 'rebase-apply'));
+      (rebaseMerge !== null && fs.existsSync(rebaseMerge)) ||
+      (rebaseApply !== null && fs.existsSync(rebaseApply));
     if (rebaseInProgress) {
       return {
         success: false,

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -1042,9 +1042,12 @@ export async function pullRepo(
     const remoteName = sep > 0 ? tracking.slice(0, sep) : 'origin';
     const remoteBranch = sep > 0 ? tracking.slice(sep + 1) : branch;
 
-    // Fetch the resolved remote, not a hardcoded 'origin' — otherwise the
-    // revparse below compares against a stale ref for any other remote.
-    await git.fetch(remoteName);
+    // Bare fetch: updates every remote, so the revparse below sees a fresh ref
+    // whichever one the branch tracks. Deliberately argument-less — simple-git's
+    // fetchTask only forwards a remote when BOTH remote and branch are passed,
+    // so `fetch(remoteName)` would silently drop the argument and do exactly
+    // this anyway. Saying so beats an inert argument that reads as targeted.
+    await git.fetch();
 
     const localRef = await git.revparse(['HEAD']);
     const remoteRef = await git.revparse([tracking]).catch(() => null);

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -963,6 +963,26 @@ export async function pullRepo(
 ): Promise<{ success: boolean; commit: string; error?: string; branch?: string }> {
   try {
     const git = simpleGit(dir);
+
+    // A rebase left in progress by an earlier run must be reported as itself.
+    // Without this the dirty-tree guard below claims "Blocked by local changes",
+    // which is both wrong and actively harmful advice mid-rebase on a detached
+    // HEAD. Checked BEFORE commitOwnDeviceMeta so we never commit into one.
+    const rebaseInProgress =
+      fs.existsSync(path.join(dir, '.git', 'rebase-merge')) ||
+      fs.existsSync(path.join(dir, '.git', 'rebase-apply'));
+    if (rebaseInProgress) {
+      return {
+        success: false,
+        commit: '',
+        error:
+          `A previous rebase is still in progress — finish or abort it, then pull again.\n\n` +
+          `  cd ${displayHomePath(dir)} && git status\n` +
+          `  git rebase --continue   # after resolving\n` +
+          `  git rebase --abort      # to discard the attempt`,
+      };
+    }
+
     // Commit this machine's own device-meta first so a per-machine pin change
     // never wedges the pull. Genuine edits elsewhere still block below.
     await commitOwnDeviceMeta(dir);
@@ -992,6 +1012,9 @@ export async function pullRepo(
       }
     }
 
+    // `tracking` is a remote-tracking ref (origin/<name>); git pull wants <name>.
+    const remoteBranch = tracking.startsWith('origin/') ? tracking.slice('origin/'.length) : branch;
+
     const localRef = await git.revparse(['HEAD']);
     const remoteRef = await git.revparse([tracking]).catch(() => null);
     if (!remoteRef) {
@@ -1013,12 +1036,25 @@ export async function pullRepo(
       // makes just above — permanently wedged the pull with nothing actually in
       // conflict. Every device carries its own devices/<host>/ path, so those
       // replay cleanly. Matches syncRepoGit (below) and this function's own doc.
-      await git.pull('origin', branch, { '--rebase': 'true' });
+      //
+      // Pull the RESOLVED tracking ref, not `branch`: when the local branch has
+      // no tracking config the block above falls back to origin's default head,
+      // which may be named differently (local `main` vs origin `master`). Using
+      // `branch` there asks origin for a ref it does not have.
+      assertValidBranchName(remoteBranch);
+      await git.pull('origin', remoteBranch, { '--rebase': 'true' });
     } catch (err) {
+      // Abort so the tree is restored, matching the atomicity --ff-only gave us.
+      // Without this a conflict leaves the repo detached, mid-rebase, with
+      // conflict markers written into live config (this repo is ~/.agents —
+      // agents.yaml and AGENTS.md are in it), and every later pull misreports
+      // the cause. `agents sync` reaches this path unattended across the fleet,
+      // so a wedged checkout would be worse than the bug this fixes.
+      await git.raw(['rebase', '--abort']).catch(() => { /* not mid-rebase */ });
       return {
         success: false,
         commit: '',
-        error: `Rebase onto ${tracking} hit a conflict — resolve it, then pull again.\n\n  cd ${displayHomePath(dir)} && git status\n\n${(err as Error).message}`,
+        error: `Rebase onto ${tracking} hit a conflict — the pull was rolled back, nothing changed.\n\nResolve the divergence, then pull again:\n\n  cd ${displayHomePath(dir)} && git log --oneline HEAD...${tracking}\n\n${(err as Error).message}`,
       };
     }
 

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -1008,12 +1008,17 @@ export async function pullRepo(
     }
 
     try {
-      await git.merge(['--ff-only', tracking]);
-    } catch {
+      // Rebase, not --ff-only. Fast-forward refuses ANY divergence, conflict or
+      // not, so a single local commit — including the one commitOwnDeviceMeta
+      // makes just above — permanently wedged the pull with nothing actually in
+      // conflict. Every device carries its own devices/<host>/ path, so those
+      // replay cleanly. Matches syncRepoGit (below) and this function's own doc.
+      await git.pull('origin', branch, { '--rebase': 'true' });
+    } catch (err) {
       return {
         success: false,
         commit: '',
-        error: `Blocked by local commits. Push or reset them before pulling.\n\n  cd ${displayHomePath(dir)} && git log --oneline HEAD...${tracking}`,
+        error: `Rebase onto ${tracking} hit a conflict — resolve it, then pull again.\n\n  cd ${displayHomePath(dir)} && git status\n\n${(err as Error).message}`,
       };
     }
 

--- a/apps/cli/tests/git.test.ts
+++ b/apps/cli/tests/git.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import simpleGit from 'simple-git';
@@ -83,8 +83,13 @@ describe('pullRepo', () => {
     expect(result.error).toContain('Blocked by local changes');
   });
 
-  it('refuses to fast-forward when local commits diverge from origin', async () => {
-    // Commit on remote, then commit locally on a divergent line.
+  // REVERSED deliberately (RUSH-2056). This asserted that divergence alone
+  // refuses the pull — the behavior that broke fleet distribution. pullRepo
+  // auto-commits the machine's own devices/<host> pin just before pulling, so
+  // every device eventually diverged and could never pull again, with nothing
+  // in conflict. It now rebases, as its own doc comment always claimed.
+  it('rebases a diverged branch instead of refusing when nothing conflicts', async () => {
+    // Remote and local each add a DIFFERENT file → diverged, no conflict.
     writeFileSync(join(REMOTE_DIR, 'remote-only.txt'), 'remote');
     const remoteGit = simpleGit(REMOTE_DIR);
     await remoteGit.add('.');
@@ -95,15 +100,14 @@ describe('pullRepo', () => {
     await localGit.add('.');
     await localGit.commit('local commit');
 
-    const before = await localGit.revparse(['HEAD']);
     const result = await pullRepo(LOCAL_DIR);
-    const after = await localGit.revparse(['HEAD']);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Blocked by local commits');
-    expect(after).toBe(before);
-    expect(
-      await localGit.revparse(['HEAD']),
-    ).not.toBe(await remoteGit.revparse(['HEAD']));
+    expect(result.success).toBe(true);
+    // Upstream content arrived...
+    expect(existsSync(join(LOCAL_DIR, 'remote-only.txt'))).toBe(true);
+    // ...and the local commit survived, replayed on top rather than discarded.
+    expect(existsSync(join(LOCAL_DIR, 'local-only.txt'))).toBe(true);
+    const log = await localGit.log({ maxCount: 1 });
+    expect(log.latest?.message).toContain('local commit');
   });
 });

--- a/apps/cli/tests/git.test.ts
+++ b/apps/cli/tests/git.test.ts
@@ -110,4 +110,29 @@ describe('pullRepo', () => {
     const log = await localGit.log({ maxCount: 1 });
     expect(log.latest?.message).toContain('local commit');
   });
+
+  // The integration suite had NO conflict coverage at all. A failed pull must
+  // leave the checkout exactly as it found it — the atomicity --ff-only gave
+  // for free, and the reason `rebase --abort` is in the catch.
+  it('rolls the tree back on a genuine conflict, leaving no rebase in progress', async () => {
+    writeFileSync(join(REMOTE_DIR, 'shared.txt'), 'remote side');
+    const remoteGit = simpleGit(REMOTE_DIR);
+    await remoteGit.add('.');
+    await remoteGit.commit('remote edit');
+
+    writeFileSync(join(LOCAL_DIR, 'shared.txt'), 'local side');
+    const localGit = simpleGit(LOCAL_DIR);
+    await localGit.add('.');
+    await localGit.commit('local edit');
+
+    const before = await localGit.revparse(['HEAD']);
+    const result = await pullRepo(LOCAL_DIR);
+    const after = await localGit.revparse(['HEAD']);
+
+    expect(result.success).toBe(false);
+    expect(after).toBe(before);
+    expect(existsSync(join(LOCAL_DIR, '.git', 'rebase-merge'))).toBe(false);
+    const status = await localGit.status();
+    expect(status.conflicted).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes **RUSH-2056**.

## The failure

Rule changes merged to the user DotAgents repo reached **no machine**, and every command in the chain reported success. After upgrading the fleet and running `agents sync` (11 ok) and `agents repo pull user` (11 ok), on `yosemite-s0`:

```
grep -c "Back-From-Vacation" ~/AGENTS.md                 -> 0
grep -c "no-permission-stop-guard" ~/.agents/agents.yaml -> 0
```

Nine devices sat 9 commits behind, diverged by 1–6 local commits.

## Root cause

`pullRepo` ran `git merge --ff-only`, which refuses **any** divergence — conflict or not.

The trap is that `pullRepo` *creates* that divergence itself. Immediately above the merge it calls `commitOwnDeviceMeta`, which auto-commits the machine's own `devices/<host>/agents.yaml` so a dirty pin file can't wedge the pull. Nothing pushes those commits. So every device eventually made one local commit and from then on could never pull again — with nothing in conflict.

`git.ts:920`'s own doc comment has always described the fix:

> *Uses `git pull --rebase` (same strategy as `syncRepoGit`) so a diverged branch reconciles instead of failing…*

The code just never did it. The sibling `syncRepoGit` (`git.ts:1075`) does exactly that already.

## Changes

1. **`lib/git.ts`** — `merge --ff-only` → `git.pull('origin', branch, { '--rebase': 'true' })`. Per-device paths are disjoint, so pin commits replay cleanly. A genuine conflict still fails, and the error now names the conflict instead of saying "push or reset them".

2. **`commands/repo.ts`** — set `process.exitCode = 1` alongside `spinner.fail(...)` for pull and push. They printed a failure and returned 0, so `agents fleet run "agents repo pull user"` reported `11 ok` across a fleet that pulled nothing. `commands/sync.ts` already did this; these two were the outliers. This is the silence that hid the bug.

3. **`commands/cloud.ts`** — `routine.devices = [machineId()]` under `--host` had no empty-check, so re-registering a webhook routine from another box silently moved where it fires. The device pin names where the routine's *author* wants it to run. Now filled only when empty, matching the three sibling pin sites (`routines.ts:637`, `:746`, `routines-project.ts:302`).

## One test is reversed on purpose

`refuses to fast-forward when local commits diverge from origin` encoded the bug as intended behavior. It is now `rebases a diverged branch instead of refusing when nothing conflicts`, asserting upstream content arrives **and** the local commit survives replayed on top.

New suite `pullRepo reconciles a diverged branch by rebasing` builds the exact fleet shape — a local `devices/<host>` pin commit plus an unrelated upstream commit — plus a genuine same-file conflict case.

**Mutation-verified:** restoring `merge --ff-only` fails both new tests (`2 failed | 50 passed`); with the fix, `52 passed`.

## Deliberately not changed

- **`routines-project.ts:302`** auto-pins a project routine only when no pin exists *anywhere*, and `:294-296` carries forward an existing one — so once any machine pins and pushes, the rest inherit it. It carries a deliberate test from the RUSH-1980 duplicate-fire work. An earlier draft turned this into a hard error; that would have broken a tested feature for a problem it does not cause. Reverted.
- **The daemon never writes routine files.** `lib/scheduler.ts` and `lib/daemon.ts` contain no `writeJob`, no `.devices` assignment, no `writeFileSync`. Firing a routine does not touch its file. Every `writeJob` caller is an explicit user command.

## Tests

- `src/lib/git.test.ts` — **52/52**
- `src/lib/__tests__/routines.project-sync.test.ts` — **17/17**
- `tsc --noEmit` clean

## Follow-ups (not in this PR)

- **RUSH-2037** needs widening: a clone of the user repo at `~/src/github.com/<owner>/.agents` is scanned as a *project* layer. Filed for rules; it also contains `routines/`, so it feeds project routines too.
- **RUSH-2057** — `release.sh` cannot resume onto an open release PR and its sync preflight livelocks on an active repo.
- Nine already-diverged devices cannot self-heal until they run this code; their local commits are preserved at `origin/device-backup/<host>` and a reconcile script is staged.
