### PR TITLE
docs: --device auto host affinity (align RUSH-2049 fragment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ agents hosts check gpu-box              # reachable? which agents-cli version?
 agents run claude --host gpu-box "profile this build"   # headless: follows live by default
 agents run claude --host gpu-box                         # no prompt → interactive TTY over SSH (tmux-backed)
 agents run claude --host gpu-box --copy-creds "fix auth" # copy local runtime creds + Claude token, shred after
+agents run claude --device auto "…"                      # affinity-pick host from 14d usage (harness stays claude)
+agents run claude --host auto "…"                        # same — auto is a host value, not a harness name
 agents hosts ps                         # list dispatched runs + terminal status
 agents hosts stop <id>                  # terminate a hung/detached run (alias: kill)
 agents logs --host gpu-box              # pick a dispatched run — concise summary by default

--- a/apps/cli/.changelog/next/RUSH-2049.md
+++ b/apps/cli/.changelog/next/RUSH-2049.md
@@ -1,15 +1,10 @@
-- **Smart launch: device/harness affinity + balanced accounts (`--smart`) (RUSH-2049).**
-  Sessions index now persists `machine` (schema v18) so affinity can `GROUP BY machine`.
-  New `queryAffinityRollup` returns launch counts by device, harness, or joint.
-  `resolveSmartLaunch` samples hosts/harnesses with weight ∝ launches^α (most-used
-  highest probability; online hosts with no history still explore at weight 1).
-  Account pick stays the existing balanced strategy (live session/week rate-limit
-  windows). CLI: `agents run claude --smart …` picks host from affinity;
-  `agents run auto --smart …` also picks among claude/codex/kimi. Explicit `--host`
-  / `@version` pins still win. Source: `apps/cli/src/lib/session/db.ts`,
-  `origin-machine.ts`, `smart-launch.ts`, `commands/exec.ts`.
-
-- **Agents extension New Agent launches with `--smart`.** Unpinned interactive
-  launches (no Pick Host / version pin) append `--smart` so the CLI affinity-picks
-  the host. Source: `apps/factory/src/vscode/extension.ts` `buildAgentLaunchCommand`.
-
+- **Session affinity data + host affinity resolver (RUSH-2049).** Sessions index
+  persists `machine` (schema v18) so affinity can `GROUP BY machine`.
+  `queryAffinityRollup` returns launch counts by device (and harness/joint for
+  analytics). Host affinity sampling lives in `smart-launch.ts` as
+  `resolveDeviceAffinity` / `applyDeviceAutoToOptions` (weight ∝ launches^α;
+  online hosts with no history still explore at weight 1). Account pick stays
+  the existing balanced strategy (live session/week rate-limit windows).
+  **User-facing host pick shipped as `--device auto` / `--host auto` in
+  RUSH-2059** (not a public `--smart` flag and not harness auto-pick). Source:
+  `apps/cli/src/lib/session/db.ts`, `origin-machine.ts`, `smart-launch.ts`.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -140,7 +140,10 @@ SSH to that machine — supported on virtually every first-class group (`repos`,
 handling (`run`, `sessions`, `feed`, `computer`, `secrets`, `logs`). Groups with
 no remote semantics reject the flag with a clear message rather than commander's
 raw `unknown option`. The target may be a registered host name, a capability tag
-(`--host gpu --any`), or a raw `user@host`.
+(`--host gpu --any`), a raw `user@host`, or the special value `auto`
+(`--device auto` / `--host auto`) to affinity-pick a host from 14-day session
+usage on `sessions.db` (weighted sample among online devices). Harness is always
+the agent you type — never auto-picked. Affinity failure degrades to local.
 
 The two registries feed **one host pool** behind the `HostProvider` seam:
 `local` (agents.yaml overlay ∪ ssh-config) registers first, `devices` (the


### PR DESCRIPTION
## Summary

Docs follow-up for RUSH-2059 (merged in #1589):

- README: `--device auto` / `--host auto` examples next to `--host gpu-box`
- `docs/00-concepts.md`: special value `auto` on host flags
- `.changelog/next/RUSH-2049.md`: describe affinity *data/resolver*; point UX at RUSH-2059 so the folded changelog does not re-document the rejected `--smart` / harness-auto API

## Test plan
- [x] Diff is docs + fragment only
- [ ] CI green
- [ ] Fold into next release changelog cleanly