### PR TITLE
fix(release): crabbox tests run in apps/cli

### DIFF
--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -323,7 +323,9 @@ run_crabbox_tests() {
   gray "  (streaming; full log captured at $log)"
   # sandbox.sh with no --pr flag = test mode: rsync this tree to the box, run the
   # command. tee both streams so the operator watches live AND we keep the log.
-  if scripts/sandbox.sh -- bash -c 'bun install && bun run test' 2>&1 | tee "$log"; then
+  # Monorepo root has no "test" script — CLI suite lives under apps/cli (same as
+  # .github/workflows/tests.yml working-directory and package.json "test:cli").
+  if scripts/sandbox.sh -- bash -c 'cd apps/cli && bun install && bun run test' 2>&1 | tee "$log"; then
     rc=0
   else
     rc="${PIPESTATUS[0]}"


### PR DESCRIPTION
## Summary

`scripts/release.sh` crabbox phase ran `bun install && bun run test` at the monorepo root. Root has no `test` script, so Bun fell through to `/usr/bin/test` and failed (`a package.json script \"test\" was not found`). That halted the 1.20.78 release before opening the release PR.

Fix: run the suite the same way CI does — `cd apps/cli && bun install && bun run test`.

## Test plan
- [x] Diff is one-line command path + comment
- [ ] CI green
- [ ] Next `apps/cli/scripts/release.sh 1.20.78 --apply` gets past crabbox phase