### PR TITLE
fix(release): crabbox test command quoting

### DIFF
--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -323,9 +323,10 @@ run_crabbox_tests() {
   gray "  (streaming; full log captured at $log)"
   # sandbox.sh with no --pr flag = test mode: rsync this tree to the box, run the
   # command. tee both streams so the operator watches live AND we keep the log.
-  # Monorepo root has no "test" script — CLI suite lives under apps/cli (same as
-  # .github/workflows/tests.yml working-directory and package.json "test:cli").
-  if scripts/sandbox.sh -- bash -c 'cd apps/cli && bun install && bun run test' 2>&1 | tee "$log"; then
+  # Pass ONE string (sandbox does cmd="$*" and embeds it into a remote bash -c
+  # script). Nested `bash -c '…'` loses quotes and becomes `bash -c cd …`.
+  # Crabbox syncs the monorepo root; CLI tests live under apps/cli.
+  if scripts/sandbox.sh -- 'cd apps/cli && bun install && bun run test' 2>&1 | tee "$log"; then
     rc=0
   else
     rc="${PIPESTATUS[0]}"


### PR DESCRIPTION
## Summary

Follow-up to #1597. `sandbox.sh` sets `cmd=\"\$*\"` and embeds `$cmd` into a remote `bash -c \"…\"` script. Passing `bash -c 'cd apps/cli && bun install && bun run test'` lost the quotes, so the remote ran `bash -c cd` then `bun install` at monorepo root (no test script).

**Fix:** pass a single string: `'cd apps/cli && bun install && bun run test'`.

## Test plan
- [ ] CI green
- [ ] `apps/cli/scripts/release.sh 1.20.78 --apply` crabbox phase runs vitest under apps/cli