### PR TITLE
fix(usage): read Claude usage via file-based setup-token, not the keychain — no Touch ID

### DIFF
--- a/apps/cli/.changelog/next/usage-setup-token-no-touchid.md
+++ b/apps/cli/.changelog/next/usage-setup-token-no-touchid.md
@@ -1,0 +1,17 @@
+- **Claude usage/probe reads can authenticate with a file-based setup-token
+  instead of the login keychain — no Touch ID.** On macOS, reading a Claude
+  account's usage went through Claude Code's ACL-bound
+  `Claude Code-credentials-<hash>` keychain item (`loadClaudeOauth` →
+  `/usr/bin/security`), popping a Touch ID sheet on every cold read — per account,
+  roughly every 8h, and again on the routines daemon's 3-minute auth-health probe
+  (`probeLocalFleetAuth`), so `ag view` and the background warm both prompted.
+  `loadClaudeOauth` now first resolves a per-account `claude setup-token` from the
+  reserved **file-based** `auth` secrets bundle (keyed by account email as
+  `CLAUDE_CODE_OAUTH_TOKEN_<slug>`); when present, the usage endpoint is
+  authenticated with that long-lived, non-rotating token and the keychain is never
+  touched — killing the prompt. This applies only to the read-only usage/probe
+  callers (`accessTokenCache`); the full-credential run/export path (which needs the
+  refresh token) is unchanged, and an account with no provisioned setup-token still
+  falls through to the keychain for now. Keyed strictly per-account (never a bare
+  shared key) so one account's token can't be misapplied to another. Source:
+  `apps/cli/src/lib/usage.ts`; design: `docs/design/credential-management.md`.

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService } from './usage.js';
-import { setKeychainToken, setKeychainBackendForTest, type KeychainBackend } from './secrets/index.js';
+import { setKeychainToken, setKeychainBackendForTest, secretsKeychainItem, type KeychainBackend } from './secrets/index.js';
+import { writeBundle, keychainRef, bundleItemStore } from './secrets/bundles.js';
+import { _resetFileStoreForTest } from './secrets/filestore.js';
 
 const LEEWAY_MS = 5 * 60 * 1000;
 const NOW = 1_800_000_000_000; // fixed epoch ms so the tests are deterministic
@@ -191,5 +196,73 @@ describe('loadClaudeOauth no-ACL access-token cache', () => {
     } finally {
       setKeychainBackendForTest(prev);
     }
+  });
+});
+
+describe('loadClaudeOauth — file-based `auth` setup-token (Touch-ID-free usage read)', () => {
+  const EMAIL = 'muqsit@trp.so';
+  const SETUP_TOKEN = 'sk-ant-oat01-setup-tok-xyz';
+  const PASS = 'usage-setup-token-pass';
+  // email -> claudeAccountTokenKey(email): upper, @->_AT_, .->_DOT_.
+  const KEY = 'CLAUDE_CODE_OAUTH_TOKEN_MUQSIT_AT_TRP_DOT_SO';
+  let restore: KeychainBackend | null = null;
+  let home: string;
+  let fileDir: string;
+  let prevNoAgent: string | undefined;
+
+  // A keychain backend that THROWS on read — proves the usage path never falls
+  // through to a keychain read once the file-based setup-token resolves.
+  function makeThrowingKeychain(): KeychainBackend {
+    return {
+      has: () => false,
+      get: (item) => { throw new Error(`keychain read of '${item}' — usage must not touch the keychain`); },
+      set: () => { /* no-op */ },
+      delete: () => false,
+      list: () => [],
+    };
+  }
+
+  beforeEach(() => {
+    restore = setKeychainBackendForTest(makeThrowingKeychain());
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'usage-home-'));
+    fileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'usage-fstore-'));
+    prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+    process.env.AGENTS_SECRETS_NO_AGENT = '1';
+    process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+    _resetFileStoreForTest({ fileDir, passphrase: PASS });
+    // Reserved FILE-BASED `auth` bundle carrying the per-account setup-token.
+    bundleItemStore('file').set(secretsKeychainItem('auth', KEY), SETUP_TOKEN);
+    writeBundle({ name: 'auth', backend: 'file', vars: { [KEY]: keychainRef(KEY) } });
+    // The account's .claude.json so the resolver maps home -> email -> KEY.
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, '.claude', '.claude.json'),
+      JSON.stringify({ oauthAccount: { emailAddress: EMAIL } }),
+    );
+  });
+
+  afterEach(() => {
+    setKeychainBackendForTest(restore);
+    _resetFileStoreForTest({});
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+    else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { fs.rmSync(fileDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it('serves the file-based setup-token to accessTokenCache callers, no keychain read', async () => {
+    const oauth = await loadClaudeOauth(home, { accessTokenCache: true });
+    expect(oauth?.accessToken).toBe(SETUP_TOKEN);
+    // Non-rotating: no expiry => reads as fresh, probe never reports expired.
+    expect(oauth?.expiresAt ?? null).toBeNull();
+  });
+
+  it('ignores the setup-token for full-credential callers (accessTokenCache off)', async () => {
+    // Run/export callers need the real keychain credential (with refresh token),
+    // never the access-token-only setup-token — so this path does NOT short out.
+    // With no keychain item and no .credentials.json, that resolves to null.
+    const oauth = await loadClaudeOauth(home);
+    expect(oauth).toBeNull();
   });
 });

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -24,6 +24,7 @@ import {
   deleteKeychainToken,
   isKeychainBackendOverridden,
 } from './secrets/index.js';
+import { bundleExists, bundleBackend, readAndResolveBundleEnv } from './secrets/bundles.js';
 import { getCacheDir } from './state.js';
 import type { AgentId } from './types.js';
 
@@ -1299,6 +1300,66 @@ function deleteCachedClaudeOauth(service: string): void {
 }
 
 /**
+ * Reserved FILE-BASED secrets bundle holding long-lived, non-rotating Claude
+ * setup-tokens. Usage/probe reads authenticate with these instead of Claude
+ * Code's ACL-bound login item, so they never pop Touch ID. Keyed strictly
+ * per-account (`CLAUDE_CODE_OAUTH_TOKEN_<slug>` from the account email) — never a
+ * bare key, so one account's token can't be misapplied to another in a
+ * multi-account fleet.
+ */
+const AUTH_BUNDLE = 'auth';
+
+/** The per-account key an email maps to inside the `auth` bundle. */
+function claudeAccountTokenKey(account: string): string {
+  const slug = account
+    .trim()
+    .toUpperCase()
+    .replace(/@/g, '_AT_')
+    .replace(/\./g, '_DOT_')
+    .replace(/[^A-Z0-9_]/g, '_');
+  return `CLAUDE_CODE_OAUTH_TOKEN_${slug}`;
+}
+
+/** Signed-in account email for a version home, from `.claude.json` (no keychain). */
+function readClaudeAccountEmail(home?: string): string | null {
+  const base = home ?? os.homedir();
+  for (const p of [path.join(base, '.claude', '.claude.json'), path.join(base, '.claude.json')]) {
+    try {
+      const email = (JSON.parse(fs.readFileSync(p, 'utf-8')) as {
+        oauthAccount?: { emailAddress?: unknown };
+      }).oauthAccount?.emailAddress;
+      if (typeof email === 'string' && email.trim().length > 0) return email.trim();
+    } catch {
+      // Missing/unreadable at this location — try the next.
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a long-lived `claude setup-token` for the account signed into `home`
+ * from the reserved FILE-BASED `auth` bundle. Returns the token or null. Reads
+ * ONLY when the bundle is file-backed (never keychain), so this path itself can
+ * never trigger a Touch ID prompt — that is the entire point: usage/probe reads
+ * authenticate with the shareable setup-token, not the ACL-bound login item.
+ */
+function resolveClaudeSetupToken(home?: string): string | null {
+  try {
+    // Require a known account (email) up front: without it we cannot key a
+    // per-account token, and we must NOT fall back to a bare shared key that
+    // would misapply one account's setup-token to another.
+    const email = readClaudeAccountEmail(home);
+    if (!email) return null;
+    if (!bundleExists(AUTH_BUNDLE) || bundleBackend(AUTH_BUNDLE) !== 'file') return null;
+    const { env } = readAndResolveBundleEnv(AUTH_BUNDLE, { caller: 'usage', agentOnly: true });
+    const v = (env[claudeAccountTokenKey(email)] ?? '').trim();
+    return v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Load a version home's Claude OAuth credential from the two stores Claude Code
  * uses, tried in order:
  *
@@ -1327,6 +1388,24 @@ export async function loadClaudeOauth(
   home?: string,
   opts?: { accessTokenCache?: boolean }
 ): Promise<ClaudeOauthCredentials | null> {
+  // Read-only usage/probe callers (accessTokenCache) authenticate with a
+  // file-based setup-token when one is provisioned: the usage endpoint accepts
+  // any sk-ant-oat01 bearer, and the token is read from the file-based `auth`
+  // bundle — never Claude Code's ACL-bound keychain item — so it never pops
+  // Touch ID. Transitional: an account with no provisioned setup-token still
+  // falls through to the keychain/file read below (that fallback is removed once
+  // the fleet is fully seeded, per docs/design/credential-management.md).
+  if (opts?.accessTokenCache === true) {
+    const setupToken = resolveClaudeSetupToken(home);
+    if (setupToken) {
+      // No expiresAt: a setup-token is long-lived and non-rotating, and a null
+      // expiry reads as "still fresh" (claudeAccessTokenNeedsRefresh) so the
+      // probe never reports it expired or tries to refresh it. The endpoint is
+      // the source of truth if it has actually been revoked.
+      return { accessToken: setupToken };
+    }
+  }
+
   // The OS keychain/keyring step is macOS/Linux-only. Windows skips straight
   // to the .credentials.json fallback — the Claude CLI has no keychain
   // integration there and stores its OAuth token in that file too. An injected


### PR DESCRIPTION
First implementation PR for the credential-management design (#1598). Directly targets the live Touch ID storm.

## Problem
On macOS, `ag view` usage bars and the routines daemon's 3-min auth-health probe both read a Claude account's token through Claude Code's ACL-bound `Claude Code-credentials-<hash>` keychain item (`loadClaudeOauth` → `/usr/bin/security`), popping a Touch ID sheet on every cold read — per account, ~every 8h, plus every daemon probe.

## Fix
`loadClaudeOauth` now first resolves a per-account `claude setup-token` from the reserved **file-based** `auth` secrets bundle (keyed `CLAUDE_CODE_OAUTH_TOKEN_<slug>` from the account email). When present, the usage endpoint — which accepts any `sk-ant-oat01` bearer identically — is authenticated with that long-lived, non-rotating token, and the keychain is never touched. One change covers **both** surfaces (`probeClaudeStatus` + `getClaudeUsageInfo` both go through `loadClaudeOauth({accessTokenCache:true})`).

- **Read-only usage/probe callers only** — the full-credential run/export path (needs the refresh token) is unchanged.
- **Strictly per-account keyed** (never a bare shared key) so one account's token can't be misapplied to another in a multi-account fleet.
- **Transitional & non-regressive** — an account with no provisioned setup-token still falls through to the current keychain read; that fallback is removed once the fleet is seeded (per the design doc).

## Test
`usage.test.ts` seeds a file-based `auth` bundle + a `.claude.json` email and asserts `loadClaudeOauth` returns the setup-token **with the keychain backend set to throw on read** (proving zero keychain access). 16/16 pass; typecheck clean.

## Next
Provision the per-account setup-tokens into the `auth` bundle on zion (self-mint `claude setup-token`) to actually activate zero-Touch-ID there — separate operational step.

Session transcript (public repo, not attached): `yosemite-s1:/home/muqsit/.agents/.history/versions/claude/2.1.207/home/.claude/projects/-home-muqsit/e049f85d-f16c-4a88-95c9-a9fe8080193b.jsonl`