### PR TITLE
fix(release): mktemp template broke every repeat release on macOS

### DIFF
--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -318,7 +318,12 @@ REMOTE="$(git rev-parse "origin/$DEFAULT_BRANCH")"
 # covers the cross-platform (macOS/Windows) legs (see wait_for_ci_green below).
 run_crabbox_tests() {
   local log rc
-  log="$(mktemp "${TMPDIR:-/tmp}/agents-cli-crabbox-tests.XXXXXX.log")"
+  # X placeholders MUST be the trailing characters: BSD mktemp (macOS) treats
+  # any suffix after them as part of a literal filename, so this template created
+  # a real file called "…crabbox-tests.XXXXXX.log" and every later release on the
+  # same box then died with "mkstemp failed: File exists". Matches the other
+  # mktemp templates in this script.
+  log="$(mktemp "${TMPDIR:-/tmp}/agents-cli-crabbox-tests.XXXXXX")"
   bold "Running the Linux test suite on a crabbox (dynamic Hetzner VM)..."
   gray "  (streaming; full log captured at $log)"
   # sandbox.sh with no --pr flag = test mode: rsync this tree to the box, run the


### PR DESCRIPTION
## The bug

`apps/cli/scripts/release.sh:321` put the `mktemp` placeholders in the **middle** of the template:

```sh
log="$(mktemp "${TMPDIR:-/tmp}/agents-cli-crabbox-tests.XXXXXX.log")"
```

BSD `mktemp` (macOS) only substitutes **trailing** `X`s. Anything after them makes the whole thing a literal filename — so the first release on a Mac creates a real file called `agents-cli-crabbox-tests.XXXXXX.log`, X's and all, and every release after that dies at phase `[2/6]`:

```
[1/6] Preflight + version validation complete  (on: zion)
  ✓ clean main, bump patch (1.20.78 -> 1.20.79), type check + tarball preview done
[2/6] Linux tests  (on: a crabbox)
mktemp: mkstemp failed on /var/folders/.../agents-cli-crabbox-tests.XXXXXX.log: File exists
```

The trap arms itself: release #1 succeeds and leaves the file, release #2 onward can't run until a human deletes a temp file by hand. Found while cutting 1.20.79 — the literal file was sitting there from an earlier attempt:

```
-rw-------@ 1 muqsit staff 211473 Aug  1 15:33 .../agents-cli-crabbox-tests.XXXXXX.log
```

## The fix

Drop the suffix so the X's are trailing. Every other `mktemp` template in this script already does this — `agents-cli-npmrc.XXXXXX` (:242), `agents-cli-tsc.XXXXXX` (:550), `agents-cli-shim.XXXXXX` (:598) — this one was the lone outlier.

Nothing reads the path by extension: `log` is only ever tailed on failure and removed, so losing `.log` changes nothing.

## Verified

`bash -n scripts/release.sh` clean, and the stale literal file is removed so the in-flight 1.20.79 release can proceed. No changelog fragment: release tooling, no user-visible CLI surface.