### PR TITLE
test(git): stop divergedPair checking out CRLF on Windows

### DIFF
--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -626,6 +626,14 @@ describe('pullRepo reconciles a diverged branch by rebasing', () => {
     await simpleGit().raw(['init', '--bare', '-b', 'main', remote]);
     await simpleGit().clone(remote, author);
     await identity(author);
+    // Commit `* -text` BEFORE anything clones this branch, exactly as the outer
+    // fixture does. identity() sets core.autocrlf=false, but on Windows the
+    // checkout inside `git clone` has already run by then — so `local` came out
+    // CRLF while the index held LF, status.isClean() saw a phantom modification
+    // of every file, and pullRepo correctly refused with "Blocked by local
+    // changes". A committed .gitattributes wins over autocrlf at checkout time,
+    // so the clone is byte-identical on every OS.
+    fs.writeFileSync(path.join(author, '.gitattributes'), '* -text\n');
     fs.writeFileSync(path.join(author, 'seed.txt'), 'seed\n');
     await simpleGit(author).add('-A');
     await simpleGit(author).commit('seed');


### PR DESCRIPTION
## What broke

The 1.20.79 release matrix failed on `build (windows-latest, 22)` **and** `(windows-latest, 24)`:

```
FAIL src/lib/git.test.ts > pullRepo reconciles a diverged branch by rebasing
     > pulls the remote the branch actually tracks, not a hardcoded origin
AssertionError: expected false to be true      ❯ git.test.ts:745:25
```

Line 745 is `expect(res.success).toBe(true)` — `pullRepo` itself returned `success: false`.

## Why — the fixture lied to correct product code

`divergedPair()` calls `identity(local)` (which sets `core.autocrlf=false`) **after** `git clone`. On Windows the checkout *inside* that clone has already run under the platform default `autocrlf=true`, so the working tree came out CRLF while the index held LF. `pullRepo` then hit:

```ts
if (!status.isClean()) {
  return { success: false, commit: '', error: `Blocked by local changes. …` };
}
```

which is **correct behaviour** — it was handed a repo that genuinely looks modified. The bug is the fixture, not `pullRepo`.

The outer fixture already solved exactly this, and says so:

> A committed `.gitattributes` wins over autocrlf at checkout time and prevents that.

`divergedPair` never got the same treatment. This commits `* -text` before anything clones the branch.

**Why only this one test tripped:** its sibling `divergedPair` tests commit in `local` before pulling, which absorbs the phantom modification and leaves a clean tree. This one only sets an upstream, so the phantom modification survives to the `isClean()` check.

## Verified, not assumed

macOS defaults to `autocrlf=false`, so a local pass proves nothing. I reproduced the Windows default with a scratch `GIT_CONFIG_GLOBAL` (`core.autocrlf=true`) — without touching this machine's real git config:

```
BEFORE (clean main, simulated Windows):  × pulls the remote the branch actually tracks   1 failed
AFTER  (this branch, simulated Windows):   58 tests — target test passes
AFTER  (normal macOS config):              58 passed
```

One unrelated test (`returns null when no source can resolve the username`) fails under that simulation — it fails identically on clean `main` and passed on the real Windows CI run, so it's an artifact of the scratch config, not of this change.

## Note

This is a pre-existing failure, not a regression from the release. It has been invisible because the real Windows suite only runs on path filters — most PRs get a 4-second no-op job — and the full matrix is cost-gated to release branches. It surfaced the moment a release actually ran it.

Test-only change; no changelog fragment.