### PR TITLE
feat(activity): fleet-wide, grouped, session-enriched activity view

### DIFF
--- a/apps/cli/.changelog/next/activity-fleet-grouped.md
+++ b/apps/cli/.changelog/next/activity-fleet-grouped.md
@@ -1,0 +1,16 @@
+- **`agents activity` goes fleet-wide, grouped, and session-enriched.** The activity
+  lane was a flat, local-only, newest-first list; it now shows progress-so-far across
+  the whole fleet — who did what, where, on which project, for which ticket. New flags:
+  `--devices-all` (alias `--hosts-all`) fans the same `activity --json` payload out to
+  every reachable device (feed-style, via `gatherRemoteAgentsJson`) and merges each
+  peer's stream host-tagged; `-H/--host` / `--device` scope to specific boxes; `--local`
+  forces local-only (still the default). `--group-by project|device|agent` buckets the
+  stream (e.g. per project, what each agent did and for which ticket) and `--filter
+  <text>` narrows by project/device/agent/event/ticket. Each item is enriched by JOINING
+  to live sessions — the resolved project (repo/worktree slug from cwd), the execution
+  host (`provenance.host`), and the Linear ticket (`ActiveSession.ticket`) — never by
+  re-parsing transcripts. Milestone tiering (`--milestones`) and the default collapse are
+  unchanged, and `--json` stays a mergeable per-host payload (now carrying the enriched
+  fields). Source: `apps/cli/src/commands/activity.ts`, `apps/cli/src/lib/activity.ts`
+  (`enrichActivityEvents`, `mergeActivityEvents`, `parseActivityPayload`, `groupActivity`,
+  `filterActivityEvents`, `projectFromCwd`).

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -444,6 +444,32 @@ Identity resolution order: `--session` → `AGENT_SESSION_ID` /
 `AGENTS_SESSION_ID` / mailbox basename → `AGENT_LAUNCH_ID` match in the pid
 registry → parent-pid walk through `by-pid/<pid>.json`.
 
+### Activity lane (`agents activity`) — progress at a glance, fleet-wide
+
+`agents activity` reads the same append-only activity stream (never re-parsing
+transcripts) and, by opt-in, across the whole fleet:
+
+```bash
+agents activity                                    # this machine, newest first (default)
+agents activity --devices-all --group-by project   # per project: what each agent did, where, for which ticket
+agents activity --host yosemite-s1                 # one box over SSH (--device is an alias)
+agents activity --devices-all --filter RUSH-2100   # one ticket, fleet-wide
+agents activity --milestones                       # only plans / PRs / worktrees / sub-agents
+```
+
+- **Fleet fan-out.** `--devices-all` (alias `--hosts-all`) runs the same
+  `activity --json` on every reachable device and merges each peer's stream
+  host-tagged (feed-style, via `gatherRemoteAgentsJson`); `-H/--host` / `--device`
+  scope to specific boxes; `--local` forces local-only. Local-only is the default.
+- **Grouping + filter.** `--group-by project|device|agent` buckets the stream;
+  `--filter <text>` narrows by project / device / agent / event / ticket. The flat
+  newest-first list stays the default.
+- **Enrichment (the join, not transcript parsing).** Each item is joined to live
+  sessions for the **project** (repo/worktree slug from cwd), the **execution host**
+  (`provenance.host` — the box it actually runs on), and the **Linear ticket**
+  (`ActiveSession.ticket`). `--json` is a mergeable per-host payload carrying these
+  enriched fields.
+
 ### Live tail (`--watch`, `-f`) — the money shot
 
 ```bash

--- a/apps/cli/src/commands/activity.test.ts
+++ b/apps/cli/src/commands/activity.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { registerActivityCommand } from './activity.js';
+
+function activityCmd(): Command {
+  const program = new Command();
+  registerActivityCommand(program);
+  const cmd = program.commands.find((c) => c.name() === 'activity');
+  if (!cmd) throw new Error('activity command not registered');
+  return cmd;
+}
+
+describe('activity command option/alias wiring', () => {
+  it('registers the fleet + grouping flags and their aliases', () => {
+    const longs = activityCmd().options.map((o) => o.long);
+    for (const flag of [
+      '--local', '--host', '--device', '--devices-all', '--hosts-all',
+      '--group-by', '--filter', '--milestones', '--all', '--json', '--since', '--limit',
+    ]) {
+      expect(longs).toContain(flag);
+    }
+  });
+
+  it('parses --devices-all --group-by --filter --local without an unknown-option error', () => {
+    const cmd = activityCmd();
+    cmd.exitOverride(); // never process.exit; the async action is not reached here
+    expect(() =>
+      cmd.parseOptions(['--devices-all', '--group-by', 'project', '--filter', 'RUSH-1', '--local']),
+    ).not.toThrow();
+    const parsed = cmd.opts();
+    expect(parsed.devicesAll).toBe(true);
+    expect(parsed.groupBy).toBe('project');
+    expect(parsed.filter).toBe('RUSH-1');
+    expect(parsed.local).toBe(true);
+  });
+
+  it('accepts --hosts-all and repeatable --device', () => {
+    const cmd = activityCmd();
+    cmd.exitOverride();
+    expect(() => cmd.parseOptions(['--hosts-all'])).not.toThrow();
+    expect(cmd.opts().hostsAll).toBe(true);
+
+    const cmd2 = activityCmd();
+    cmd2.exitOverride();
+    cmd2.parseOptions(['--device', 'zion', '--device', 'mac-mini']);
+    expect(cmd2.opts().device).toEqual(['zion', 'mac-mini']);
+  });
+});

--- a/apps/cli/src/commands/activity.ts
+++ b/apps/cli/src/commands/activity.ts
@@ -7,17 +7,59 @@
  * hook time by 11-activity-log.py, so this reader never re-parses transcripts --
  * it tails the logs and collapses routine work to counts, surfacing milestones
  * individually and newest-first.
+ *
+ * Fleet-wide by opt-in: `--devices-all` (or `--host <box>`) fans the same
+ * `activity --json` payload out across the fleet the way `agents feed` does,
+ * merges every peer's stream host-tagged, and joins each item to live sessions
+ * (project / ticket / execution host) so `--group-by project` shows, per
+ * project, what each agent did, where, and for which ticket -- progress at a
+ * glance. Local-only stays the default.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import {
   collapseActivity,
+  enrichActivityEvents,
   ensureActivityLogHook,
-  formatActivityLine,
+  filterActivityEvents,
+  formatActivityGroupHeader,
+  formatEnrichedActivityLine,
+  groupActivity,
+  mergeActivityEvents,
+  parseActivityPayload,
+  projectFromCwd,
   readRecentActivity,
   styleForEvent,
   tierForEvent,
+  type ActivityGroupBy,
+  type ActivitySessionHint,
+  type EnrichedActivityEvent,
 } from '../lib/activity.js';
+import { gatherRemoteAgentsJson } from '../lib/remote-agents-json.js';
+import { machineId, normalizeHost } from '../lib/machine-id.js';
+import { shouldIncludeLocalFeed, remoteFeedHostsToDial } from './feed.js';
+import { getActiveSessions } from '../lib/session/active.js';
+import type { ActiveSession } from '../lib/session/active.js';
+
+/** Recursion guard: a peer answering a fan-out never re-fans-out itself. */
+export const ACTIVITY_NO_FANOUT_ENV = 'AGENTS_ACTIVITY_LOCAL';
+
+const GROUP_BY_VALUES: ActivityGroupBy[] = ['project', 'device', 'agent'];
+
+interface ActivityOpts {
+  json?: boolean;
+  all?: boolean;
+  milestones?: boolean;
+  limit: number;
+  since?: number;
+  local?: boolean;
+  host?: string[];
+  device?: string[];
+  devicesAll?: boolean;
+  hostsAll?: boolean;
+  groupBy?: string;
+  filter?: string;
+}
 
 /** Wire the activity-log hooks into each hooks-capable version's settings. */
 async function installActivityHooks(): Promise<string[]> {
@@ -39,53 +81,164 @@ async function installActivityHooks(): Promise<string[]> {
   return warnings;
 }
 
+/** Session facts (project / ticket / execution host) keyed for the read-time join. */
+function activityHintsFromSessions(sessions: ActiveSession[]): ActivitySessionHint[] {
+  return sessions.map((s) => ({
+    sessionId: s.sessionId,
+    ticket: s.ticket?.id,
+    // Where the process actually lives — the SSH-resolved provenance host, else
+    // the cross-machine `machine` id. Normalized to match the event `host` form.
+    executionHost: s.provenance?.host ? normalizeHost(s.provenance.host) : s.machine,
+    project: projectFromCwd(s.cwd),
+  }));
+}
+
+/** Print one flat, newest-first stream (the default view). */
+function renderFlat(events: EnrichedActivityEvent[], opts: ActivityOpts): void {
+  const { milestones, counts, subagentCount } = collapseActivity(events);
+  process.stdout.write(chalk.bold('\n  recent activity\n'));
+  const shown = opts.all ? events : milestones;
+  for (const ev of shown) {
+    process.stdout.write(`${formatEnrichedActivityLine(ev, { showHost: true, showProject: true })}\n`);
+  }
+  if (!opts.all) {
+    const parts = Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([event, n]) => `${styleForEvent(event).label} ×${n}`);
+    if (parts.length > 0) process.stdout.write(chalk.gray(`\n  · ${parts.join('  ')}\n`));
+  }
+  if (subagentCount > 0) {
+    process.stdout.write(chalk.magenta(`\n  ⑂ ${subagentCount} sub-agent${subagentCount === 1 ? '' : 's'} spawned\n`));
+  }
+  process.stdout.write('\n');
+}
+
+/** Print the bucketed view (`--group-by project|device|agent`). */
+function renderGrouped(events: EnrichedActivityEvent[], by: ActivityGroupBy, opts: ActivityOpts): void {
+  const groups = groupActivity(events, by);
+  // The grouping dimension is redundant on each line -- drop it from the tags.
+  const showHost = by !== 'device';
+  const showProject = by !== 'project';
+  process.stdout.write(chalk.bold(`\n  activity by ${by}\n`));
+  for (const group of groups) {
+    process.stdout.write(`\n  ${chalk.bold(formatActivityGroupHeader(group))}\n`);
+    const { milestones, counts, subagentCount } = collapseActivity(group.events);
+    const shown = opts.all ? group.events : milestones;
+    for (const ev of shown) {
+      process.stdout.write(`${formatEnrichedActivityLine(ev, { showHost, showProject, indent: '  ' })}\n`);
+    }
+    if (!opts.all) {
+      const parts = Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .map(([event, n]) => `${styleForEvent(event).label} ×${n}`);
+      if (parts.length > 0) process.stdout.write(chalk.gray(`    · ${parts.join('  ')}\n`));
+    }
+    if (subagentCount > 0) {
+      process.stdout.write(chalk.magenta(`    ⑂ ${subagentCount} sub-agent${subagentCount === 1 ? '' : 's'} spawned\n`));
+    }
+  }
+  process.stdout.write('\n');
+}
+
 export function registerActivityCommand(program: Command): void {
   program
     .command('activity')
     .description('Recent agent activity -- plans, PRs, worktrees, sub-agents (newest first)')
-    .option('--json', 'Emit the raw event list as JSON')
+    .option('--json', 'Emit the (enriched) event list as JSON')
     .option('--all', 'Include routine activity (file edits) inline, not collapsed')
     .option('--milestones', 'Only milestone events (plans, PRs, worktrees, sub-agents)')
     .option('-n, --limit <n>', 'Cap the number of events shown', (v) => parseInt(v, 10), 40)
     .option('--since <minutes>', 'Only events within the last N minutes', (v) => parseInt(v, 10))
-    .action(async (opts: { json?: boolean; all?: boolean; milestones?: boolean; limit: number; since?: number }) => {
-      const warnings = await installActivityHooks();
+    .option('--local', 'Only this machine -- skip the cross-machine SSH fan-out')
+    .option('-H, --host <target...>', 'Scope to remote machine(s) over SSH; repeatable')
+    .option('--device <target...>', 'Alias for --host; repeatable')
+    .option('--devices-all', 'Fan out to every reachable device on the fleet')
+    .option('--hosts-all', 'Alias for --devices-all')
+    .option('--group-by <field>', 'Bucket the stream by project | device | agent')
+    .option('--filter <text>', 'Narrow to items matching a project / device / agent / event / ticket')
+    .addHelpText('after', `
+Examples:
+  agents activity                              # this machine, newest first
+  agents activity --devices-all --group-by project   # per project across the fleet
+  agents activity --host yosemite-s1           # one box over SSH
+  agents activity --devices-all --filter RUSH-2100   # one ticket, fleet-wide
+  agents activity --milestones                 # only plans / PRs / worktrees / sub-agents
+
+Each item is enriched by JOINING to live sessions (project, execution host,
+Linear ticket) -- never by re-parsing transcripts. --devices-all runs the same
+'activity --json' on each peer and merges the streams host-tagged.
+`)
+    .action(async (opts: ActivityOpts) => {
+      if (opts.device?.length) opts.host = [...(opts.host ?? []), ...opts.device];
+      const groupBy = opts.groupBy as ActivityGroupBy | undefined;
+      if (groupBy && !GROUP_BY_VALUES.includes(groupBy)) {
+        process.stderr.write(chalk.red(`--group-by must be one of: ${GROUP_BY_VALUES.join(', ')}\n`));
+        process.exitCode = 1;
+        return;
+      }
+
+      const self = machineId();
+      const forceLocal = opts.local === true || process.env[ACTIVITY_NO_FANOUT_ENV] === '1';
+      const explicitHosts = opts.host;
+      const wantAll = Boolean(opts.devicesAll || opts.hostsAll);
+      const wantRemote = !forceLocal && (wantAll || (explicitHosts != null && explicitHosts.length > 0));
+      // Local events are included unless an explicit --host list excludes this box.
+      let includeLocal = true;
+      if (wantRemote && explicitHosts && explicitHosts.length > 0) {
+        includeLocal = shouldIncludeLocalFeed(explicitHosts, self);
+      }
+
+      const warnings = includeLocal ? await installActivityHooks() : [];
 
       const sinceMs = typeof opts.since === 'number' && opts.since > 0
         ? Date.now() - opts.since * 60_000
         : undefined;
-      let events = readRecentActivity({ sinceMs, limit: opts.limit });
-      if (opts.milestones) events = events.filter((e) => tierForEvent(e.event) === 'milestone');
+
+      let events: EnrichedActivityEvent[] = includeLocal
+        ? readRecentActivity({ sinceMs, limit: opts.limit })
+        : [];
+
+      if (wantRemote) {
+        // Explicit hosts drop self (it's the local read); --devices-all dials
+        // every online peer (hosts undefined).
+        const remoteHosts = explicitHosts?.length ? remoteFeedHostsToDial(explicitHosts, self) : undefined;
+        if (!explicitHosts?.length || (remoteHosts && remoteHosts.length > 0)) {
+          const remoteArgs = ['activity', '--json', '-n', String(opts.limit)];
+          if (typeof opts.since === 'number' && opts.since > 0) remoteArgs.push('--since', String(opts.since));
+          const remote = await gatherRemoteAgentsJson({
+            args: remoteArgs,
+            noFanoutEnv: ACTIVITY_NO_FANOUT_ENV,
+            hosts: remoteHosts,
+            parse: parseActivityPayload,
+          });
+          events = mergeActivityEvents(events, remote.items);
+        }
+      }
+
+      // Enrich by joining to live LOCAL sessions (ticket/project/execution host).
+      // Remote events arrive already enriched by their own peer, so the join only
+      // fills local ones; the pure fallbacks (cwd->project, host->device) cover
+      // everything either way. Skip the ps/lsof scan when there's nothing to show.
+      const sessions = includeLocal && events.length > 0 ? await getActiveSessions() : [];
+      let enriched = enrichActivityEvents(events, activityHintsFromSessions(sessions));
+
+      if (opts.milestones) enriched = enriched.filter((e) => tierForEvent(e.event) === 'milestone');
+      if (opts.filter) enriched = filterActivityEvents(enriched, opts.filter);
+      enriched = enriched.slice(0, opts.limit);
 
       if (opts.json) {
-        process.stdout.write(`${JSON.stringify(events, null, 2)}\n`);
+        process.stdout.write(`${JSON.stringify(enriched, null, 2)}\n`);
         return;
       }
 
       for (const w of warnings) process.stderr.write(chalk.yellow(`  ! ${w}\n`));
 
-      if (events.length === 0) {
+      if (enriched.length === 0) {
         process.stdout.write(chalk.gray('No recent agent activity. Events appear here as agents create plans, open PRs, and spawn sub-agents.\n'));
         return;
       }
 
-      const { milestones, counts, subagentCount } = collapseActivity(events);
-
-      process.stdout.write(chalk.bold('\n  recent activity\n'));
-      const shown = opts.all ? events : milestones;
-      for (const ev of shown) process.stdout.write(`${formatActivityLine(ev, { showHost: true })}\n`);
-
-      if (!opts.all) {
-        const parts = Object.entries(counts)
-          .sort((a, b) => b[1] - a[1])
-          .map(([event, n]) => `${styleForEvent(event).label} ×${n}`);
-        if (parts.length > 0) {
-          process.stdout.write(chalk.gray(`\n  · ${parts.join('  ')}\n`));
-        }
-      }
-      if (subagentCount > 0) {
-        process.stdout.write(chalk.magenta(`\n  ⑂ ${subagentCount} sub-agent${subagentCount === 1 ? '' : 's'} spawned\n`));
-      }
-      process.stdout.write('\n');
+      if (groupBy) renderGrouped(enriched, groupBy, opts);
+      else renderFlat(enriched, opts);
     });
 }

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -5,13 +5,37 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import {
   ACTIVITY_LOG_HOOK_SCRIPT,
+  activityGroupKey,
   appendActivityEvent,
   collapseActivity,
+  enrichActivityEvents,
   ensureActivityLogHook,
+  filterActivityEvents,
+  formatEnrichedActivityLine,
+  groupActivity,
+  mergeActivityEvents,
+  parseActivityPayload,
+  projectFromCwd,
   readRecentActivity,
   readSessionActivity,
   tierForEvent,
+  type EnrichedActivityEvent,
 } from './activity.js';
+
+/** Minimal well-formed enriched event; override any field per test. */
+function ev(partial: Partial<EnrichedActivityEvent>): EnrichedActivityEvent {
+  return {
+    v: 1,
+    ts: partial.ts ?? '2026-08-01T12:00:00.000Z',
+    event: partial.event ?? 'file.edited',
+    tier: partial.tier ?? 'activity',
+    sessionId: partial.sessionId ?? 'sess-1',
+    mailboxId: partial.mailboxId ?? partial.sessionId ?? 'sess-1',
+    host: partial.host ?? 'yosemite-s0',
+    runtime: partial.runtime ?? 'headless',
+    ...partial,
+  } as EnrichedActivityEvent;
+}
 
 const hasPython = spawnSync('python3', ['--version']).status === 0;
 
@@ -558,5 +582,186 @@ describe('real activity-log hook (Python)', () => {
     });
     const events = readSessionActivity(sessionId, activityDirFor(home));
     expect(events.map((e) => e.event)).toEqual(['checklist.created', 'task.completed']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fleet fan-out, enrichment, grouping (the "activity bar")
+// ---------------------------------------------------------------------------
+
+describe('projectFromCwd', () => {
+  it('resolves a worktree cwd to the repo dir name', () => {
+    expect(projectFromCwd('/home/me/src/agents-cli/.agents/worktrees/my-slug')).toBe('agents-cli');
+  });
+  it('resolves a subdir inside a worktree to the repo', () => {
+    expect(projectFromCwd('/home/me/src/agents-cli/.agents/worktrees/my-slug/apps/cli')).toBe('agents-cli');
+  });
+  it('falls back to the basename for a plain path, stripping a trailing slash', () => {
+    expect(projectFromCwd('/home/me/src/rush')).toBe('rush');
+    expect(projectFromCwd('/home/me/src/rush/')).toBe('rush');
+  });
+  it('returns undefined for an empty or missing cwd', () => {
+    expect(projectFromCwd(undefined)).toBeUndefined();
+    expect(projectFromCwd('')).toBeUndefined();
+    expect(projectFromCwd(null)).toBeUndefined();
+  });
+});
+
+describe('enrichActivityEvents', () => {
+  it('joins ticket / project / execution host from a session hint by sessionId', () => {
+    const [out] = enrichActivityEvents([ev({ sessionId: 'a', cwd: '/home/me/src/agents-cli' })], [
+      { sessionId: 'a', ticket: 'RUSH-2100', executionHost: 'yosemite-s1', project: 'agents-cli' },
+    ]);
+    expect(out.ticket).toBe('RUSH-2100');
+    expect(out.executionHost).toBe('yosemite-s1');
+    expect(out.project).toBe('agents-cli');
+  });
+
+  it('falls back to cwd-derived project and the event host when no hint matches', () => {
+    const [out] = enrichActivityEvents([ev({ sessionId: 'x', cwd: '/home/me/src/rush', host: 'mac-mini' })], [
+      { sessionId: 'other', ticket: 'RUSH-1' },
+    ]);
+    expect(out.project).toBe('rush');
+    expect(out.executionHost).toBe('mac-mini');
+    expect(out.ticket).toBeUndefined();
+  });
+
+  it('preserves pre-baked enriched fields from a remote peer (no local hint)', () => {
+    const [out] = enrichActivityEvents(
+      [ev({ sessionId: 'r', project: 'peer-repo', ticket: 'RUSH-9', executionHost: 'zion' })],
+      [],
+    );
+    expect(out).toMatchObject({ project: 'peer-repo', ticket: 'RUSH-9', executionHost: 'zion' });
+  });
+
+  it('does not treat an unknown host as an execution host', () => {
+    const [out] = enrichActivityEvents([ev({ host: 'unknown', cwd: undefined })], []);
+    expect(out.executionHost).toBeUndefined();
+  });
+});
+
+describe('parseActivityPayload', () => {
+  it('keeps the event host and drops invalid items', () => {
+    const payload = JSON.stringify([
+      { v: 1, ts: '2026-08-01T00:00:00Z', event: 'pr.opened', tier: 'milestone', sessionId: 's1', host: 'zion' },
+      { event: 'file.edited' }, // missing sessionId + ts -> dropped
+      42, // not an object -> dropped
+    ]);
+    const out = parseActivityPayload(payload, 'dialed-peer');
+    expect(out).toHaveLength(1);
+    expect(out[0].host).toBe('zion');
+  });
+  it('host-tags with the dialed peer when the item carries no host', () => {
+    const [out] = parseActivityPayload(JSON.stringify([{ ts: '2026-08-01T00:00:00Z', event: 'pushed', sessionId: 's2' }]), 'mac-mini');
+    expect(out.host).toBe('mac-mini');
+  });
+  it('returns [] for non-array or invalid JSON', () => {
+    expect(parseActivityPayload('not json', 'h')).toEqual([]);
+    expect(parseActivityPayload('{"not":"array"}', 'h')).toEqual([]);
+  });
+});
+
+describe('mergeActivityEvents', () => {
+  it('merges host-tagged streams, dedupes by identity, and sorts newest first', () => {
+    const local = ev({ sessionId: 's', ts: '2026-08-01T10:00:00.000Z', event: 'commit.created', host: 'yosemite-s0' });
+    const dup = ev({ sessionId: 's', ts: '2026-08-01T10:00:00.000Z', event: 'commit.created', host: 'yosemite-s0' });
+    const newer = ev({ sessionId: 't', ts: '2026-08-01T11:00:00.000Z', event: 'pr.opened', host: 'zion' });
+    const merged = mergeActivityEvents([local], [dup, newer]);
+    expect(merged).toHaveLength(2); // dup collapsed
+    expect(merged[0].ts).toBe('2026-08-01T11:00:00.000Z'); // newest first
+    expect(new Set(merged.map((e) => e.host))).toEqual(new Set(['yosemite-s0', 'zion']));
+  });
+  it('does not collapse the same session/ts/event across different hosts', () => {
+    const a = ev({ sessionId: 's', ts: '2026-08-01T10:00:00.000Z', event: 'pushed', host: 'zion' });
+    const b = ev({ sessionId: 's', ts: '2026-08-01T10:00:00.000Z', event: 'pushed', host: 'mac-mini' });
+    expect(mergeActivityEvents([a], [b])).toHaveLength(2);
+  });
+});
+
+describe('filterActivityEvents', () => {
+  const events = [
+    ev({ sessionId: '1', project: 'agents-cli', agent: 'claude', event: 'pr.opened', ticket: 'RUSH-2100', host: 'zion' }),
+    ev({ sessionId: '2', project: 'rush', agent: 'codex', event: 'file.edited', host: 'mac-mini', executionHost: 'mac-mini' }),
+  ];
+  it('matches on project, ticket, agent, device, and event kind (case-insensitive)', () => {
+    expect(filterActivityEvents(events, 'AGENTS-CLI').map((e) => e.sessionId)).toEqual(['1']);
+    expect(filterActivityEvents(events, 'rush-2100').map((e) => e.sessionId)).toEqual(['1']);
+    expect(filterActivityEvents(events, 'codex').map((e) => e.sessionId)).toEqual(['2']);
+    expect(filterActivityEvents(events, 'mac-mini').map((e) => e.sessionId)).toEqual(['2']);
+    expect(filterActivityEvents(events, 'pr.opened').map((e) => e.sessionId)).toEqual(['1']);
+  });
+  it('an empty filter is a no-op', () => {
+    expect(filterActivityEvents(events, '   ')).toHaveLength(2);
+  });
+});
+
+describe('activityGroupKey / groupActivity', () => {
+  it('keys by each dimension with sensible fallbacks', () => {
+    const e = ev({ project: 'agents-cli', executionHost: 'zion', agent: 'claude' });
+    expect(activityGroupKey(e, 'project')).toEqual({ key: 'agents-cli', label: 'agents-cli' });
+    expect(activityGroupKey(e, 'device')).toEqual({ key: 'zion', label: 'zion' });
+    expect(activityGroupKey(e, 'agent')).toEqual({ key: 'claude', label: 'claude' });
+    expect(activityGroupKey(ev({ agent: undefined, host: 'unknown', cwd: undefined }), 'agent'))
+      .toEqual({ key: '', label: 'unknown agent' });
+  });
+  it('buckets by project, orders by count desc, and puts the unknown bucket last', () => {
+    const groups = groupActivity([
+      ev({ sessionId: '1', project: 'agents-cli' }),
+      ev({ sessionId: '2', project: 'agents-cli' }),
+      ev({ sessionId: '3', project: 'rush' }),
+      ev({ sessionId: '4', host: 'unknown', cwd: undefined }), // unknown project
+    ], 'project');
+    expect(groups.map((g) => g.label)).toEqual(['agents-cli', 'rush', 'unknown project']);
+    expect(groups[0].events).toHaveLength(2);
+    expect(groups[2].key).toBe('');
+  });
+  it('groups by device using the resolved execution host (host fallback)', () => {
+    const groups = groupActivity([
+      ev({ sessionId: '1', executionHost: 'zion' }),
+      ev({ sessionId: '2', host: 'mac-mini' }),
+    ], 'device');
+    expect(new Set(groups.map((g) => g.label))).toEqual(new Set(['zion', 'mac-mini']));
+  });
+});
+
+describe('formatEnrichedActivityLine', () => {
+  it('appends project and ticket tags when asked', () => {
+    const line = formatEnrichedActivityLine(ev({ event: 'pr.opened', project: 'agents-cli', ticket: 'RUSH-2100' }), { showHost: true, showProject: true });
+    expect(line).toContain('agents-cli');
+    expect(line).toContain('RUSH-2100');
+  });
+  it('omits the project tag when showProject is false but keeps the ticket', () => {
+    const line = formatEnrichedActivityLine(ev({ event: 'pr.opened', project: 'agents-cli', ticket: 'RUSH-2100' }), { showProject: false });
+    expect(line).not.toContain('agents-cli');
+    expect(line).toContain('RUSH-2100');
+  });
+});
+
+describe('fleet fan-out MERGE + group (integration over per-host JSON payloads)', () => {
+  it('parses each peer payload, merges host-tagged, and groups by project', () => {
+    // Two peers each answer `activity --json` for themselves.
+    const s0 = JSON.stringify([
+      { v: 1, ts: '2026-08-01T10:00:00.000Z', event: 'pr.opened', tier: 'milestone', sessionId: 'a', host: 'yosemite-s0', runtime: 'headless', project: 'agents-cli', ticket: 'RUSH-2100' },
+    ]);
+    const zion = JSON.stringify([
+      { v: 1, ts: '2026-08-01T11:00:00.000Z', event: 'commit.created', tier: 'milestone', sessionId: 'b', host: 'zion', runtime: 'headless', project: 'rush' },
+      { v: 1, ts: '2026-08-01T09:00:00.000Z', event: 'plan.created', tier: 'milestone', sessionId: 'c', host: 'zion', runtime: 'headless', project: 'agents-cli' },
+    ]);
+    const merged = mergeActivityEvents(parseActivityPayload(s0, 'yosemite-s0'), parseActivityPayload(zion, 'zion'));
+    // Newest first across the fleet.
+    expect(merged.map((e) => e.ts)).toEqual([
+      '2026-08-01T11:00:00.000Z',
+      '2026-08-01T10:00:00.000Z',
+      '2026-08-01T09:00:00.000Z',
+    ]);
+    // Host tags survive the merge.
+    expect(new Set(merged.map((e) => e.host))).toEqual(new Set(['yosemite-s0', 'zion']));
+
+    const groups = groupActivity(merged, 'project');
+    expect(groups.map((g) => g.label)).toEqual(['agents-cli', 'rush']); // agents-cli has 2, rush 1
+    // The agents-cli bucket carries one event from each machine.
+    expect(new Set(groups[0].events.map((e) => e.host))).toEqual(new Set(['yosemite-s0', 'zion']));
+    // Grouping by device buckets by the execution host of each event.
+    expect(groupActivity(merged, 'device').map((g) => g.label).sort()).toEqual(['yosemite-s0', 'zion']);
   });
 });

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -23,6 +23,7 @@ import * as yaml from 'yaml';
 import chalk from 'chalk';
 import { relTime, truncate } from './format.js';
 import { getActivityDir, getUserAgentsDir } from './state.js';
+import { normalizeHost } from './machine-id.js';
 // Type-only import: no runtime dependency on events.ts, so no import cycle
 // (events.ts / event-stream.ts import THIS module at runtime).
 import type { EventRecord } from './events.js';
@@ -351,6 +352,212 @@ export function formatActivityLine(ev: ActivityEvent, opts: { showHost?: boolean
   const agent = ev.event === 'status.posted' && ev.agent ? chalk.gray(` · ${ev.agent}`) : '';
   const when = chalk.gray(relTime(ev.ts).padStart(7));
   return `  ${when}  ${host}${label}${detail}${agent}${url}`;
+}
+
+// ---------------------------------------------------------------------------
+// Fleet fan-out, session enrichment, grouping (the "activity bar")
+//
+// `agents activity --json` is a mergeable per-host payload, so a feed-style
+// fan-out (`gatherRemoteAgentsJson`) collects every peer's own stream and
+// merges them host-tagged. Each item is then enriched by JOINING to live
+// sessions (project / ticket / execution host) — NOT by re-parsing transcripts
+// — and can be grouped by project, device, or agent so progress reads at a
+// glance across the whole fleet.
+// ---------------------------------------------------------------------------
+
+/** An activity event with the session-derived facts joined on at read time. */
+export interface EnrichedActivityEvent extends ActivityEvent {
+  /** Resolved project/repo name (from cwd or the session join), not the raw path. */
+  project?: string;
+  /** Tracker ticket the owning session is tied to (e.g. `RUSH-1234`). */
+  ticket?: string;
+  /** Machine the event actually ran on — session `provenance.host`, else `host`. */
+  executionHost?: string;
+}
+
+/**
+ * Facts pulled off a live session to enrich its activity events. Keyed by
+ * `sessionId`; every field optional so callers pass whatever they resolved.
+ */
+export interface ActivitySessionHint {
+  sessionId?: string | null;
+  /** Tracker ticket id (from `ActiveSession.ticket`). */
+  ticket?: string | null;
+  /** Machine the session executes on (`provenance.host` / `machine`). */
+  executionHost?: string | null;
+  /** Resolved project/repo slug from the session cwd. */
+  project?: string | null;
+}
+
+/**
+ * Resolve a stable project/repo name from a working directory. A worktree cwd
+ * (`…/<repo>/.agents/worktrees/<slug>[/sub]`) resolves to the repo dir name so
+ * a worktree session groups with its own repo; any other path resolves to its
+ * basename. Pure — no filesystem access, so it works for remote events too.
+ */
+export function projectFromCwd(cwd?: string | null): string | undefined {
+  if (!cwd) return undefined;
+  const norm = cwd.replace(/\\/g, '/').replace(/\/+$/, '');
+  if (!norm) return undefined;
+  const wtIdx = norm.indexOf('/.agents/worktrees/');
+  if (wtIdx > 0) {
+    const repoPath = norm.slice(0, wtIdx);
+    const base = repoPath.slice(repoPath.lastIndexOf('/') + 1);
+    if (base) return base;
+  }
+  const base = norm.slice(norm.lastIndexOf('/') + 1);
+  return base || undefined;
+}
+
+/**
+ * Join session facts (ticket / project / execution host) onto each event by
+ * `sessionId`. A hint wins; otherwise pre-baked enriched fields (from a remote
+ * peer that already enriched its own stream) are preserved, and project/host
+ * fall back to what the event itself carries (`cwd`, `host`). Pure.
+ */
+export function enrichActivityEvents(
+  events: EnrichedActivityEvent[],
+  hints: ActivitySessionHint[],
+): EnrichedActivityEvent[] {
+  const bySession = new Map<string, ActivitySessionHint>();
+  for (const h of hints) if (h.sessionId) bySession.set(h.sessionId, h);
+  return events.map((ev) => {
+    const hint = ev.sessionId ? bySession.get(ev.sessionId) : undefined;
+    const project = hint?.project ?? ev.project ?? projectFromCwd(ev.cwd);
+    const ticket = hint?.ticket ?? ev.ticket ?? undefined;
+    const executionHost = hint?.executionHost ?? ev.executionHost
+      ?? (ev.host && ev.host !== 'unknown' ? ev.host : undefined);
+    return {
+      ...ev,
+      ...(project ? { project } : {}),
+      ...(ticket ? { ticket } : {}),
+      ...(executionHost ? { executionHost } : {}),
+    };
+  });
+}
+
+/**
+ * Validate + host-tag one peer's `activity --json` payload for the fan-out
+ * merge. Mirrors {@link parseLine}: skip anything missing `event`/`sessionId`/
+ * `ts`, drop corrupt items. The event's own `host` is the execution host and is
+ * authoritative; only fall back to the dialed peer's `machine` when it's absent.
+ * Enriched fields the peer stamped (project/ticket/executionHost) ride through.
+ */
+export function parseActivityPayload(stdout: string, machine: string): EnrichedActivityEvent[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: EnrichedActivityEvent[] = [];
+  for (const item of parsed) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const ev = item as Partial<EnrichedActivityEvent>;
+    if (!ev.event || !ev.sessionId || !ev.ts) continue;
+    const host = ev.host && ev.host !== 'unknown' ? ev.host : machine;
+    out.push({ ...(ev as EnrichedActivityEvent), host });
+  }
+  return out;
+}
+
+/**
+ * Merge local + remote event lists, keeping the first copy of a given
+ * host/session/ts/event and sorting newest first. Cross-machine activity dirs
+ * can sync in a peer's own events, so the identity key dedupes those (mirrors
+ * `mergeFeedBlocks`).
+ */
+export function mergeActivityEvents(...groups: EnrichedActivityEvent[][]): EnrichedActivityEvent[] {
+  const byKey = new Map<string, EnrichedActivityEvent>();
+  for (const ev of groups.flat()) {
+    const key = `${normalizeHost(ev.host)}\0${ev.sessionId}\0${ev.ts}\0${ev.event}`;
+    if (!byKey.has(key)) byKey.set(key, ev);
+  }
+  return [...byKey.values()].sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts));
+}
+
+export type ActivityGroupBy = 'project' | 'device' | 'agent';
+
+/** One bucket of the grouped view. */
+export interface ActivityGroup {
+  /** Grouping value; empty string for the "unknown" bucket. */
+  key: string;
+  /** Display label. */
+  label: string;
+  events: EnrichedActivityEvent[];
+}
+
+/** The (key, label) an event sorts under for a given grouping dimension. */
+export function activityGroupKey(ev: EnrichedActivityEvent, by: ActivityGroupBy): { key: string; label: string } {
+  if (by === 'project') {
+    const p = ev.project ?? projectFromCwd(ev.cwd);
+    return p ? { key: p, label: p } : { key: '', label: 'unknown project' };
+  }
+  if (by === 'device') {
+    const h = ev.executionHost ?? (ev.host && ev.host !== 'unknown' ? ev.host : undefined);
+    return h ? { key: h, label: h } : { key: '', label: 'unknown device' };
+  }
+  const a = ev.agent;
+  return a ? { key: a, label: a } : { key: '', label: 'unknown agent' };
+}
+
+/**
+ * Bucket events by project, device, or agent. Groups are ordered by event count
+ * (desc) then label; the "unknown" bucket always sorts last. Input order is
+ * preserved within a group, so newest-first survives when the input is sorted.
+ */
+export function groupActivity(events: EnrichedActivityEvent[], by: ActivityGroupBy): ActivityGroup[] {
+  const byKey = new Map<string, ActivityGroup>();
+  for (const ev of events) {
+    const { key, label } = activityGroupKey(ev, by);
+    const g = byKey.get(key);
+    if (g) g.events.push(ev);
+    else byKey.set(key, { key, label, events: [ev] });
+  }
+  return [...byKey.values()].sort((a, b) => {
+    if (!a.key && b.key) return 1;
+    if (!b.key && a.key) return -1;
+    if (b.events.length !== a.events.length) return b.events.length - a.events.length;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+/**
+ * Narrow events to those whose project, device/host, agent, event kind, or
+ * ticket contains `filter` (case-insensitive substring). An empty filter is a
+ * no-op. Pure.
+ */
+export function filterActivityEvents(events: EnrichedActivityEvent[], filter: string): EnrichedActivityEvent[] {
+  const needle = filter.trim().toLowerCase();
+  if (!needle) return events;
+  return events.filter((ev) => {
+    const fields = [ev.project, ev.executionHost, ev.host, ev.agent, ev.event, ev.ticket];
+    return fields.some((f) => typeof f === 'string' && f.toLowerCase().includes(needle));
+  });
+}
+
+/** One rendered enriched line: the base activity line + `· project · ticket` tags. */
+export function formatEnrichedActivityLine(
+  ev: EnrichedActivityEvent,
+  opts: { showHost?: boolean; showProject?: boolean; indent?: string } = {},
+): string {
+  const base = formatActivityLine(ev, { showHost: opts.showHost });
+  const tags: string[] = [];
+  if (opts.showProject && ev.project) tags.push(ev.project);
+  if (ev.ticket) tags.push(ev.ticket);
+  const suffix = tags.length > 0 ? chalk.gray(`  · ${tags.join(' · ')}`) : '';
+  return `${opts.indent ?? ''}${base}${suffix}`;
+}
+
+/** Human header for one grouped bucket: `<label> · N events · M milestones`. */
+export function formatActivityGroupHeader(group: ActivityGroup): string {
+  const { milestones } = collapseActivity(group.events);
+  const n = group.events.length;
+  const m = milestones.length;
+  const parts = [`${n} event${n === 1 ? '' : 's'}`];
+  if (m > 0) parts.push(`${m} milestone${m === 1 ? '' : 's'}`);
+  return `${group.label} · ${parts.join(' · ')}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -38,6 +38,11 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     expect(await maybeRunOnHost('feed', ['feed', '--host', 'mac', '--json'])).toBe(false);
   });
 
+  it('leaves activity host lists to the command-level fleet aggregator', async () => {
+    expect(await maybeRunOnHost('activity', ['activity', '--host', 'mac', '--json'])).toBe(false);
+    expect(await maybeRunOnHost('activity', ['activity', '--device', 'a', '--devices-all'])).toBe(false);
+  });
+
   it('rejects --host on a non-routable, non-OWN_HOST group with a clear error (not unknown option)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
     // setup has no remote semantics and no own-host handler — must not fall

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -116,6 +116,7 @@ const OWN_HOST_COMMANDS = new Set([
   'harnesses',
   'sessions',
   'feed',
+  'activity', // fans `--host`/`--device`/`--devices-all` out itself (feed-style)
   'computer',
   'secrets',
   'logs',


### PR DESCRIPTION
**feat — `agents activity` goes fleet-wide, grouped, and session-enriched.** The activity lane was a flat, local-only, newest-first list; it's now the "activity bar": progress-so-far across the whole fleet — who did what, where, on which project, for which ticket.

## What changed

- **Fleet fan-out** — `--devices-all` (alias `--hosts-all`) runs the same `activity --json` on every reachable device (feed-style, via `gatherRemoteAgentsJson`) and merges each peer's stream **host-tagged**; `-H/--host` / `--device` scope to specific boxes; `--local` forces local-only (still the default). `activity` is added to `OWN_HOST_COMMANDS` so it self-handles `--host` instead of being rejected by the passthrough layer.
- **Group-by + filter** — `--group-by project|device|agent` buckets the stream; `--filter <text>` narrows by project / device / agent / event / ticket. Flat newest-first stays the default.
- **Enrichment (the join, NOT transcript parsing)** — each item is joined to live sessions for the **project** (repo/worktree slug from cwd), the **execution host** (`provenance.host`), and the **Linear ticket** (`ActiveSession.ticket`). `--json` stays a mergeable per-host payload, now carrying the enriched fields.
- Milestone tiering (`--milestones`) and the default collapse are unchanged; the hook-emitted activity-log format is untouched (backward-compatible).

## Run result (real fleet fan-out)

`agents activity --devices-all --group-by device -n 6` — dialed the fleet over SSH, merged a real remote event from `zion` with local events, skipped an unreachable peer:

```
  bismas-macbook-pro: unreachable or no agents CLI — skipped

  activity by device

  yosemite-s0 · 5 events
    · file edited ×5

  zion · 1 event · 1 milestone
    38s ago  ⌥ worktree created git worktree add -b fix/git-test-windows-crlf "$(pwd)/.agen…  · agents-cli
```

`agents activity --group-by project --all` (local) — project resolved from the worktree cwd, PRs/pushes/commits surfaced with URLs:

```
  activity by project

  agents-cli · 27 events · 4 milestones
    12m ago  [yosemite-s0] ⇡ PR opened …  https://github.com/phnx-labs/agents-cli/pull/1610
    13m ago  [yosemite-s0] ↥ pushed  …
    13m ago  [yosemite-s0] ● commit  …
    …
```

`--json` carries the enriched fields (`project`, `executionHost`, `ticket`).

## Tests

Added to `apps/cli/src/lib/activity.test.ts` (pure grouping/filter/merge/project/parse + a fan-out MERGE integration over per-host JSON payloads), `apps/cli/src/commands/activity.test.ts` (option/alias wiring), `apps/cli/src/lib/hosts/passthrough.test.ts` (`activity` self-handles `--host`). No mocking of the critical path.

```
Test Files  2 passed (2)      Tests  49 passed (49)   # activity.test.ts + commands/activity.test.ts
Test Files  1 passed (1)      Tests  22 passed (22)   # passthrough.test.ts
```

`tsc --noEmit` clean.

## Docs / changelog

`apps/cli/docs/06-observability.md` gains an "Activity lane" subsection documenting the flags; `.changelog/next/activity-fleet-grouped.md` added.

No Linear ticket was assigned for this task.
