### PR TITLE
fix(menubar): supervise --notify one-shots so they don't pile up

### DIFF
--- a/apps/cli/.changelog/next/menubar-notify-supervise.md
+++ b/apps/cli/.changelog/next/menubar-notify-supervise.md
@@ -1,0 +1,14 @@
+- **The daemon's `MenubarHelper --notify` one-shots can no longer pile up in the
+  menu bar.** Each routine notification (start/finish/overdue/heal) spawned a
+  fresh, detached, unsupervised `MenubarHelper --notify` process; on a stalled
+  delivery — a locked screen or a WindowServer/XPC hiccup — the helper's runloop
+  spin never reached its deadline and the process hung indefinitely, so duplicate
+  "Agents" instances accumulated. The one-shot is now bounded by two independent
+  watchdogs: `runOneShot` arms a background-thread force-exit at 3s (off the main
+  queue, so a wedged main thread can't starve it — unlike the 0.6s runloop
+  deadline it backs up), and the Node spawner (`spawnDetachedQuiet`) SIGKILLs the
+  child at 4s if it never self-exits. A notifier that posts normally (the common
+  sub-second path) is untouched; only a genuinely hung one is killed. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift` (`Notifier.runOneShot`),
+  `apps/cli/src/lib/menubar/notify-desktop.ts` (`spawnDetachedQuiet`,
+  `NOTIFY_TIMEOUT_MS`).

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -179,6 +179,18 @@ folder. The Node side lives in `src/lib/menubar/notify-desktop.ts` (routing) and
 `src/lib/routine-notify.ts` (routine start/finish content + anti-spam
 threshold); see [routines.md](03-routines.md#desktop-notifications).
 
+**Bounded lifetime (no pile-up).** A one-shot posts and exits in well under a
+second, but a stalled delivery — a locked screen, a WindowServer/XPC hiccup —
+could otherwise leave a detached notifier hanging and duplicate "Agents"
+instances accumulating in the menu bar. Two independent watchdogs bound it:
+`runOneShot` arms a background-thread force-exit at 3s (it runs off the main
+queue so a wedged main thread can't starve it, unlike the 0.6s runloop deadline
+it backs up), and the Node spawner (`spawnDetachedQuiet`) SIGKILLs the child at
+4s if it never self-exits. So a notifier can never linger indefinitely. Stale
+helpers that predate `--notify` (and would ignore it and hang) are replaced by
+the upgrade self-heal (`installMenubarLaunchAgentOnUpgrade`), which reinstalls
+the current bundle on any version bump.
+
 ## Files
 
 | Path | Purpose |

--- a/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
@@ -565,6 +565,17 @@ enum Notifier {
             return args[i + 1]
         }
         guard let title = value("--title"), let body = value("--body") else { exit(2) }
+        // Hard self-terminate watchdog: guarantee this one-shot exits even if
+        // delivery stalls (a locked screen or WindowServer/XPC hiccup can block
+        // NSUserNotificationCenter.deliver on the main thread, so the runloop spin
+        // below never reaches its deadline and the process hangs — piling up in
+        // the menu bar). It runs on a BACKGROUND queue, not `.main`: a wedged main
+        // thread can't starve it, so the force-exit fires regardless of runloop
+        // state. 3s sits above the 0.6s happy-path flush and below the Node-side
+        // 4s SIGKILL (notify-desktop.ts), so the process reliably ends itself.
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 3) {
+            exit(0)
+        }
         // Establish the app object so delivery has a running NSApplication to
         // attribute the notification to; never call run() — the runloop spin below
         // drives this short-lived process.

--- a/apps/cli/src/lib/menubar/notify-desktop.test.ts
+++ b/apps/cli/src/lib/menubar/notify-desktop.test.ts
@@ -3,6 +3,7 @@ import {
   buildMenubarNotifyArgs,
   buildOsascriptNotifyArgs,
   notifyDesktop,
+  spawnDetachedQuiet,
 } from './notify-desktop.js';
 
 describe('buildMenubarNotifyArgs', () => {
@@ -86,5 +87,48 @@ describe('notifyDesktop — missing notifier must not crash the daemon', () => {
     // Let the async spawn 'error' event fire on the next libuv turn.
     await new Promise((resolve) => setTimeout(resolve, 300));
     expect(true).toBe(true);
+  });
+});
+
+describe('spawnDetachedQuiet — bounded lifetime', () => {
+  // The pile-up this fixes: a one-shot notifier that stalls (locked screen,
+  // WindowServer hiccup) must not linger forever. A real long-running child
+  // (`sleep 30`) that never self-exits must be hard-killed after the timeout.
+  // Real process, real signal — no mocking.
+  it('SIGKILLs a child that outlives the timeout', async () => {
+    const child = spawnDetachedQuiet('sleep', ['30'], 120);
+    const result = await new Promise<{ code: number | null; signal: string | null }>(
+      (resolve, reject) => {
+        const guard = setTimeout(
+          () => reject(new Error('child was not killed within the watchdog window')),
+          2000,
+        );
+        child.on('exit', (code, signal) => {
+          clearTimeout(guard);
+          resolve({ code, signal });
+        });
+        child.on('error', (err) => {
+          clearTimeout(guard);
+          reject(err);
+        });
+      },
+    );
+    expect(result.signal).toBe('SIGKILL');
+    expect(child.killed).toBe(true);
+  });
+
+  // The common path: a fast child that exits on its own is NOT signalled — the
+  // watchdog is cleared on 'exit', so `killed` stays false.
+  it('leaves a child that self-exits before the timeout untouched', async () => {
+    const child = spawnDetachedQuiet('true', [], 2000);
+    const result = await new Promise<{ code: number | null; signal: string | null }>(
+      (resolve, reject) => {
+        child.on('exit', (code, signal) => resolve({ code, signal }));
+        child.on('error', reject);
+      },
+    );
+    expect(result.signal).toBeNull();
+    expect(result.code).toBe(0);
+    expect(child.killed).toBe(false);
   });
 });

--- a/apps/cli/src/lib/menubar/notify-desktop.ts
+++ b/apps/cli/src/lib/menubar/notify-desktop.ts
@@ -17,9 +17,19 @@
  * takes the whole daemon down (the exact crash overdue.test.ts guards).
  */
 
-import { spawn } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import * as os from 'os';
 import { resolveInstalledMenubarExecutable } from './install-menubar.js';
+
+/**
+ * Hard ceiling on a one-shot notifier's lifetime. A notifier posts and exits in
+ * well under a second on the happy path; if delivery stalls (locked screen, a
+ * WindowServer/XPC hiccup) a detached GUI helper can hang indefinitely and pile
+ * up in the menu bar. This is above the Swift one-shot's own 0.6s flush + its 3s
+ * self-terminate watchdog, so Node's kill is the last-resort guarantee that runs
+ * only if the child never self-exits.
+ */
+const NOTIFY_TIMEOUT_MS = 4000;
 
 export interface DesktopNotification {
   /** Bold first line. */
@@ -54,14 +64,44 @@ export function buildOsascriptNotifyArgs(n: DesktopNotification): string[] {
   return ['-e', script];
 }
 
-/** Spawn one detached, best-effort notifier process; swallow async ENOENT. */
-function spawnDetachedQuiet(command: string, args: string[]): void {
+/**
+ * Spawn one detached, best-effort notifier process with a bounded lifetime.
+ *
+ * The child is detached + unref'd so it never blocks the daemon, but — unlike a
+ * pure fire-and-forget — it is supervised: a watchdog SIGKILLs it after
+ * `timeoutMs` so a stalled notifier can never linger (the pile-up this fixes).
+ * The common path (a sub-second post + self-exit) clears the watchdog on the
+ * child's own 'exit', so the kill only ever fires for a genuinely hung child.
+ *
+ * `timeoutMs` is injectable so the bounded-lifetime behaviour is testable against
+ * a real long-running child without a multi-second wait. Returns the child so a
+ * caller/test can observe it; callers in this module ignore it.
+ */
+export function spawnDetachedQuiet(
+  command: string,
+  args: string[],
+  timeoutMs: number = NOTIFY_TIMEOUT_MS,
+): ChildProcess {
   const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+  // Bound the lifetime: a stalled notifier is hard-killed after the timeout. The
+  // timer is unref'd so it never keeps a short-lived caller's event loop alive.
+  const watchdog = setTimeout(() => {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      /* already gone */
+    }
+  }, timeoutMs);
+  watchdog.unref();
   // A missing binary (headless box with no osascript/notify-send, or a helper
-  // that vanished) arrives as an async 'error' event. Without this listener Node
-  // re-throws it as an uncaught exception and crashes the daemon — swallow it.
-  child.on('error', () => {});
+  // that vanished) arrives as an async 'error' event — the process never started,
+  // so cancel the watchdog. Without a listener Node re-throws ENOENT as an
+  // uncaught exception and crashes the daemon; having one swallows it.
+  child.on('error', () => clearTimeout(watchdog));
+  // Fast, self-driven exit (the common path) — cancel the watchdog.
+  child.on('exit', () => clearTimeout(watchdog));
   child.unref();
+  return child;
 }
 
 /**


### PR DESCRIPTION
**Bug fix (macOS menu-bar).** Stops the daemon's `MenubarHelper --notify` one-shots from piling up as duplicate "Agents" menu-bar instances when a notification delivery stalls.

## The problem

Every routine notification (start / finish / overdue / heal) spawns a fresh, detached, **unsupervised** `MenubarHelper --notify` process (`notify-desktop.ts` → `spawnDetachedQuiet`, `{detached:true, stdio:'ignore'}` + `.unref()`). The Swift one-shot (`Notifier.runOneShot`, `PromptPanel.swift`) posts, spins `RunLoop.main.run(until: +0.6s)`, then `exit(0)`. On a stalled delivery — a locked screen, a WindowServer/XPC hiccup — `NSUserNotificationCenter.deliver` blocks the main thread, so the runloop's `until:` deadline is never checked and the process **hangs indefinitely**. Nothing tracks, times out, or reaps it. Result: lingering duplicate instances (the user reported 5).

## The fix — two independent watchdogs

1. **Swift (`runOneShot`):** arm a background-thread force-exit at 3s — `DispatchQueue.global(qos:.userInitiated).asyncAfter { exit(0) }`. It runs off the **main** queue on purpose, so a wedged main thread can't starve it (a `DispatchQueue.main` timer would be blocked by the same hang). Sits above the 0.6s happy-path flush.
2. **Node (`spawnDetachedQuiet`):** bound the child's lifetime — a `setTimeout` SIGKILLs it after `NOTIFY_TIMEOUT_MS = 4000` if it never self-exits; the timer is `unref()`'d (never holds the daemon's event loop) and is cleared on the child's `exit`/`error`. The common sub-second post is untouched; only a genuinely hung child is killed.

Ordering: normal exit at 0.6s → Swift self-exit at 3s → Node SIGKILL at 4s (last resort). A notifier can never linger.

**Stale-binary safety (verified, no change needed):** a helper predating `--notify` would ignore the flag and hang, but `installMenubarLaunchAgentOnUpgrade` already recopies + re-stamps the current bundle on any version drift (`menubarSetupStale()` → `enableMenubarService({forceReinstall:true})`), so it's replaced on the next `agents` run post-upgrade.

## Run result — `notify-desktop.test.ts` (vitest, real processes, no mocking)

Two new tests exercise the real bounded-lifetime path: a real `sleep 30` child is SIGKILLed after a 120ms injected timeout; a real `true` child that self-exits is left untouched (`killed === false`).

```
 RUN  v4.1.9  .../fix-menubar-notify-supervise/apps/cli
 Test Files  1 passed (1)
      Tests  8 passed (8)   (6 existing + 2 new bounded-lifetime)
   Duration  626ms
```

`tsc --noEmit` clean.

## Verification note

This touches macOS Swift; authored on Linux. The macOS build runs in CI (`compiled-smoke`). End-to-end menu-bar delivery (banner shows, no lingering process) needs a Mac — confirmable on zion post-merge; `killall MenubarHelper` clears the currently-lingering instances.

## Files

- `apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift` — `Notifier.runOneShot` background watchdog
- `apps/cli/src/lib/menubar/notify-desktop.ts` — `spawnDetachedQuiet` bounded lifetime + `NOTIFY_TIMEOUT_MS`
- `apps/cli/src/lib/menubar/notify-desktop.test.ts` — bounded-lifetime tests
- `apps/cli/docs/menubar.md` — Notifications section updated
- `apps/cli/.changelog/next/menubar-notify-supervise.md` — changelog fragment
