### PR TITLE
feat(doctor): triaged severity health report for bare + target modes

### DIFF
--- a/apps/cli/.changelog/next/doctor-health-triage.md
+++ b/apps/cli/.changelog/next/doctor-health-triage.md
@@ -1,0 +1,35 @@
+- **`agents doctor` now reads as a triaged health report, not neutral status.**
+  The verdict was terse status text ("Verdict: 1 divergent, source ~/.agents 16
+  commits behind…") a user had to decode. It is now a severity-ranked health block
+  that leads with what is unhealthy, why it matters, and the exact fix — one row
+  per finding, tagged with a restrained terminal glyph (`✓` `✗` `⚠` and a subtle
+  info dot, colored via chalk to match the man-page voice):
+  ```
+  Claude@2.1.220
+    ✗ unhealthy — 3 issues (1 critical · 2 warnings)
+
+    ✗ critical  ask-user-question-guard — on disk but not wired into settings.json; the hook never fires
+                → agents sync claude@2.1.220 --yes
+    ⚠ warning   ~/.agents — 16 commits behind origin/main; you're running stale config
+                → agents repo pull user
+    ⚠ warning   11-activity-log — differs from source
+                → agents doctor claude@2.1.220 --fix
+
+    heal what's auto-fixable:  agents doctor claude@2.1.220 --fix
+  ```
+  A clean install collapses to one green line —
+  `✓ healthy — 34 resources reconciled · hooks wired · sources current`. Each
+  finding carries an agent-agnostic **severity**: **critical** (silent breakage —
+  an unwired hook, a missing/unparseable `settings.json`, a MISSING resource),
+  **warning** (stale/drift — a source layer behind origin, a DIVERGENT resource, a
+  stale/never-synced version), or **info** (an orphan/EXTRA resource →
+  `agents prune cleanup`). Both surfaces get the same treatment: the target report
+  `agents doctor <agent>@<version>` and the bare `agents doctor` overview, which
+  now opens with a `Health` banner aggregated across every installed version. The
+  existing per-resource detail rows are kept — the health block layers on top of
+  them as the verdict. `--json` gains a `verdict` field (target mode) and a
+  `health` field (overview), each carrying `severity`/`category`/`subject`/
+  `impact`/`fix` per issue; the existing `summary`/`kinds`/`hookWiring`/
+  `sourceBehind`/`sync`/`orphans` fields are unchanged. Source:
+  `apps/cli/src/commands/doctor.ts` (`computeVerdict`, `computeOverviewHealth`,
+  `healthBlockLines`, `renderHealthBlock`, `verdictIsAutoFixable`).

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -203,6 +203,55 @@ Three diagnostics with distinct scopes (RUSH-2027):
 - `agents doctor` — the **umbrella**: local diagnostics (CLI presence, sign-in,
   per-version sync, orphans) **and**, with `--devices`, cross-device divergence.
 
+### Triaged health block (local modes)
+
+Both the bare `agents doctor` overview and the target report
+`agents doctor <agent>[@version]` lead with a **triaged health block** — the
+verdict, ranked by severity, so the reader sees what is unhealthy, why it matters,
+and the exact fix without decoding status text. A clean install collapses to one
+green line:
+
+```
+Claude@2.1.220
+  ✓ healthy — 34 resources reconciled · hooks wired · sources current
+```
+
+Otherwise a severity-counted header is followed by one row per finding — icon ·
+severity · subject — impact, then the exact fix — and a heal footer when anything
+is `--fix`-able:
+
+```
+Claude@2.1.220
+  ✗ unhealthy — 3 issues (1 critical · 2 warnings)
+
+  ✗ critical  ask-user-question-guard — on disk but not wired into settings.json; the hook never fires
+              → agents sync claude@2.1.220 --yes
+  ⚠ warning   ~/.agents — 16 commits behind origin/main; you're running stale config
+              → agents repo pull user
+  ⚠ warning   11-activity-log — differs from source
+              → agents doctor claude@2.1.220 --fix
+
+  heal what's auto-fixable:  agents doctor claude@2.1.220 --fix
+```
+
+Every finding carries an agent-agnostic **severity** (glyphs `✓` `✗` `⚠` and a
+subtle info dot, colored via `chalk`):
+
+- **critical** (`✗`, silent breakage) — an unwired hook, a missing/unparseable
+  `settings.json`, a MISSING resource.
+- **warning** (`⚠`, stale / drift) — a source layer behind origin, a DIVERGENT
+  resource, a stale / never-synced version.
+- **info** (`·`, orphan) — an EXTRA resource → `agents prune cleanup`. Capped with
+  a `+N more orphans` rollup so the block stays scannable.
+
+The bare overview opens with a `Health` banner aggregated across every installed
+version; the target report renders the block below its per-resource detail rows
+(kept — the health block layers on top as the verdict). `--json` carries the same
+triage: a `verdict` field in target mode and a `health` field in the overview,
+each with `severity`/`category`/`subject`/`impact`/`fix` per issue. Source:
+`src/commands/doctor.ts` (`computeVerdict`, `computeOverviewHealth`,
+`healthBlockLines`).
+
 ### `agents doctor --devices`
 
 Compares every registered device's installed harness inventory against the local

--- a/apps/cli/src/commands/doctor.test.ts
+++ b/apps/cli/src/commands/doctor.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { execPolicyWarningLines, renderFleetDivergence, wrapLine, computeVerdict } from './doctor.js';
+import { execPolicyWarningLines, renderFleetDivergence, wrapLine, computeVerdict, computeOverviewHealth, verdictIsAutoFixable, healthBlockLines } from './doctor.js';
 import { stringWidth, stripAnsi } from '../lib/session/width.js';
-import type { VersionResourceReport } from '../lib/doctor-diff.js';
+import type { ResourceDiff, VersionResourceReport } from '../lib/doctor-diff.js';
+import type { SyncStatusRow, OrphanRow } from '../lib/drift.js';
+import type { FetchStatusMarker } from '../lib/auto-pull.js';
 import { compareFleetInventories, FLEET_RESOURCE_KINDS, type FleetInventory, type FleetResourceKind } from '../lib/devices/fleet-divergence.js';
 
 /** Minimal reconciled report; override the fields a case cares about. */
@@ -16,6 +18,11 @@ function baseReport(over: Partial<VersionResourceReport> = {}): VersionResourceR
     summary: { ok: 32, diff: 0, missing: 0, extra: 0 },
     ...over,
   };
+}
+
+/** A single resource diff row for seeding a report's `kinds`. */
+function row(kind: ResourceDiff['kind'], name: string, status: ResourceDiff['status'], detail?: string): ResourceDiff {
+  return { kind, name, status, detail };
 }
 
 function inv(plugins: string[] = []): FleetInventory {
@@ -65,18 +72,20 @@ describe('wrapLine', () => {
   });
 });
 
-describe('computeVerdict (doctor per-version health rollup)', () => {
-  it('is healthy when nothing diverges', () => {
-    const v = computeVerdict(baseReport());
+describe('computeVerdict (doctor per-version triaged health)', () => {
+  it('is healthy when nothing diverges — with the reconciled count carried', () => {
+    const v = computeVerdict(baseReport({ summary: { ok: 34, diff: 0, missing: 0, extra: 0 } }));
     expect(v.healthy).toBe(true);
     expect(v.issues).toEqual([]);
+    expect(v.reconciled).toBe(34);
   });
 
-  it('an UNWIRED hook flips the verdict to unhealthy even when every file is ok', () => {
+  it('classifies an UNWIRED hook as CRITICAL with the sync fix — even when every file is ok', () => {
     // The yosemite-s1 bug: 32 hook files reconcile ok, but one is never wired
     // into settings.json. Files-ok must NOT read as healthy.
     const v = computeVerdict(
       baseReport({
+        version: '2.1.220',
         hookWiring: {
           supported: true,
           settingsPath: '/home/.claude/settings.json',
@@ -86,34 +95,169 @@ describe('computeVerdict (doctor per-version health rollup)', () => {
       }),
     );
     expect(v.healthy).toBe(false);
-    expect(v.issues.map((i) => i.text)).toContain('1 unwired');
+    const issue = v.issues.find((i) => i.category === 'unwired-hook');
+    expect(issue).toBeDefined();
+    expect(issue!.severity).toBe('critical');
+    expect(issue!.subject).toBe('ask-user-question-guard');
+    expect(issue!.impact).toContain('not wired into settings.json');
+    expect(issue!.fix).toBe('agents sync claude@2.1.220 --yes');
   });
 
-  it('a missing settings.json is unhealthy and names the unwired count', () => {
+  it('classifies a missing settings.json as CRITICAL and names the unwired count', () => {
     const v = computeVerdict(
       baseReport({
         hookWiring: { supported: true, settingsPath: '/home/.claude/settings.json', expected: 3, settingsMissing: true, unwired: [] },
       }),
     );
     expect(v.healthy).toBe(false);
-    expect(v.issues.some((i) => i.text.includes('settings.json missing') && i.text.includes('3'))).toBe(true);
+    const issue = v.issues.find((i) => i.category === 'settings-missing');
+    expect(issue!.severity).toBe('critical');
+    expect(issue!.impact).toContain('3 declared hooks never fire');
   });
 
-  it('a source layer behind origin flips the verdict to unhealthy (not a buried note)', () => {
+  it('classifies a source layer behind origin as WARNING with the repo-pull fix (not a --fix)', () => {
     const v = computeVerdict(
       baseReport({
         sourceBehind: [{ layer: 'user', label: '~/.agents', alias: 'user', behind: 75, branch: 'origin/main' }],
       }),
     );
     expect(v.healthy).toBe(false);
-    expect(v.issues.some((i) => i.text.includes('75 commits behind origin/main'))).toBe(true);
+    const issue = v.issues.find((i) => i.category === 'source-behind');
+    expect(issue!.severity).toBe('warning');
+    expect(issue!.subject).toBe('~/.agents');
+    expect(issue!.impact).toContain('75 commits behind origin/main');
+    expect(issue!.fix).toBe('agents repo pull user');
   });
 
-  it('still folds in classic divergences (diff / missing / extra)', () => {
-    const v = computeVerdict(baseReport({ summary: { ok: 1, diff: 2, missing: 1, extra: 3 } }));
+  it('triages a MISSING resource as critical, a DIVERGENT as warning, an EXTRA as info — by name', () => {
+    const v = computeVerdict(
+      baseReport({
+        version: '2.1.220',
+        summary: { ok: 0, diff: 1, missing: 1, extra: 1 },
+        kinds: {
+          commands: [row('commands', 'deploy', 'missing')],
+          skills: [row('skills', '11-activity-log', 'diff')],
+          hooks: [], rules: [], mcp: [], permissions: [],
+          subagents: [row('subagents', 'ghost', 'extra')],
+          plugins: [], promptcuts: [],
+        },
+      }),
+    );
     expect(v.healthy).toBe(false);
-    const texts = v.issues.map((i) => i.text);
-    expect(texts).toEqual(expect.arrayContaining(['2 divergent', '1 missing', '3 extra']));
+    const byCat = Object.fromEntries(v.issues.map((i) => [i.category, i]));
+    expect(byCat['missing'].severity).toBe('critical');
+    expect(byCat['missing'].subject).toBe('deploy');
+    expect(byCat['divergent'].severity).toBe('warning');
+    expect(byCat['divergent'].subject).toBe('11-activity-log');
+    expect(byCat['divergent'].fix).toBe('agents doctor claude@2.1.220 --fix');
+    expect(byCat['extra'].severity).toBe('info');
+    expect(byCat['extra'].subject).toBe('ghost');
+    expect(byCat['extra'].fix).toBe('agents prune cleanup');
+    // Critical is ordered before warning before info.
+    expect(v.issues.map((i) => i.severity)).toEqual(['critical', 'warning', 'info']);
+  });
+
+  it('a source-behind-only verdict is NOT auto-fixable (repo pull, not --fix)', () => {
+    const v = computeVerdict(
+      baseReport({ sourceBehind: [{ layer: 'user', label: '~/.agents', alias: 'user', behind: 3, branch: 'origin/main' }] }),
+    );
+    expect(verdictIsAutoFixable(v)).toBe(false);
+  });
+
+  it('a divergent resource IS auto-fixable', () => {
+    const v = computeVerdict(
+      baseReport({
+        summary: { ok: 0, diff: 1, missing: 0, extra: 0 },
+        kinds: { commands: [], skills: [row('skills', 'x', 'diff')], hooks: [], rules: [], mcp: [], permissions: [], subagents: [], plugins: [], promptcuts: [] },
+      }),
+    );
+    expect(verdictIsAutoFixable(v)).toBe(true);
+  });
+});
+
+describe('computeOverviewHealth (bare `agents doctor` triage across versions)', () => {
+  const syncRow = (over: Partial<SyncStatusRow> = {}): SyncStatusRow =>
+    ({ agent: 'claude', version: '2.1.220', status: 'fresh', isDefault: true, ...over });
+  const marker = (over: Partial<FetchStatusMarker> = {}): FetchStatusMarker =>
+    ({ alias: 'user', dir: '/home/.agents', behind: 16, branch: 'origin/main', fetchedAt: 0, ...over } as FetchStatusMarker);
+
+  it('is healthy when every version is fresh, wired, and sources current', () => {
+    const v = computeOverviewHealth([syncRow()], [], []);
+    expect(v.healthy).toBe(true);
+    expect(v.reconciled).toBe(1);
+  });
+
+  it('folds an unwired hook (critical), a behind source (warning), and an orphan (info)', () => {
+    const sync: SyncStatusRow[] = [
+      syncRow({ unwiredHooks: 1 }),
+      syncRow({ version: '2.1.200', status: 'stale' }),
+    ];
+    const orphans: OrphanRow[] = [{ agent: 'claude', version: '2.1.220', commands: 2, skills: 0, hooks: 0 }];
+    const v = computeOverviewHealth(sync, orphans, [marker()]);
+    expect(v.healthy).toBe(false);
+    const cats = v.issues.map((i) => i.category);
+    expect(cats).toContain('unwired-hook');
+    expect(cats).toContain('source-behind');
+    expect(cats).toContain('stale');
+    expect(cats).toContain('orphan');
+    const unwired = v.issues.find((i) => i.category === 'unwired-hook')!;
+    expect(unwired.severity).toBe('critical');
+    expect(unwired.fix).toBe('agents sync claude@2.1.220 --yes');
+    const behind = v.issues.find((i) => i.category === 'source-behind')!;
+    expect(behind.subject).toBe('~/.agents');
+    expect(behind.fix).toBe('agents repo pull user');
+    expect(v.issues.find((i) => i.category === 'orphan')!.severity).toBe('info');
+    // A stale version makes it auto-fixable via `agents doctor --fix`.
+    expect(verdictIsAutoFixable(v)).toBe(true);
+  });
+});
+
+describe('healthBlockLines (triaged health rendering)', () => {
+  it('renders a single green ✓ line when healthy', () => {
+    const v = computeVerdict(baseReport({ summary: { ok: 34, diff: 0, missing: 0, extra: 0 } }));
+    const out = healthBlockLines(v, { healthySummary: '34 resources reconciled · hooks wired · sources current' }).map(stripAnsi);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain('✓ healthy');
+    expect(out[0]).toContain('34 resources reconciled · hooks wired · sources current');
+  });
+
+  it('renders a severity-counted header, one row + fix per finding, and the heal footer', () => {
+    const v = computeVerdict(
+      baseReport({
+        version: '2.1.220',
+        summary: { ok: 30, diff: 1, missing: 0, extra: 0 },
+        hookWiring: {
+          supported: true, settingsPath: '/home/.claude/settings.json', expected: 32,
+          unwired: [{ name: 'ask-user-question-guard', event: 'PreToolUse', matcher: 'AskUserQuestion', command: '~/x.sh' }],
+        },
+        sourceBehind: [{ layer: 'user', label: '~/.agents', alias: 'user', behind: 16, branch: 'origin/main' }],
+        kinds: { commands: [], skills: [row('skills', '11-activity-log', 'diff')], hooks: [], rules: [], mcp: [], permissions: [], subagents: [], plugins: [], promptcuts: [] },
+      }),
+    );
+    const out = healthBlockLines(v, { healthySummary: 'x', healFix: 'agents doctor claude@2.1.220 --fix' }).map(stripAnsi);
+    const joined = out.join('\n');
+    expect(joined).toContain('✗ unhealthy — 3 issues (1 critical · 2 warnings)');
+    expect(joined).toContain('✗ critical  ask-user-question-guard — on disk but not wired into settings.json');
+    expect(joined).toContain('→ agents sync claude@2.1.220 --yes');
+    expect(joined).toContain('⚠ warning   ~/.agents — 16 commits behind origin/main');
+    expect(joined).toContain('→ agents repo pull user');
+    expect(joined).toContain("heal what's auto-fixable:  agents doctor claude@2.1.220 --fix");
+  });
+
+  it('caps the info tier with a "+N more orphans" rollup', () => {
+    const extras: ResourceDiff[] = [];
+    for (let i = 0; i < 9; i++) extras.push(row('skills', `orphan-${i}`, 'extra'));
+    const v = computeVerdict(
+      baseReport({
+        summary: { ok: 0, diff: 0, missing: 0, extra: 9 },
+        kinds: { commands: [], skills: extras, hooks: [], rules: [], mcp: [], permissions: [], subagents: [], plugins: [], promptcuts: [] },
+      }),
+    );
+    const out = healthBlockLines(v, { healthySummary: 'x' }).map(stripAnsi).join('\n');
+    // 9 orphans, cap 5 → 4 hidden.
+    expect(out).toContain('+4 more orphans — agents prune cleanup');
+    // The heal footer is suppressed for an orphan-only verdict (prune, not --fix).
+    expect(out).not.toContain("heal what's auto-fixable");
   });
 });
 

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -130,6 +130,19 @@ function renderOverviewText(
   signIn: Record<string, Pick<AccountInfo, 'signedIn' | 'email' | 'accountId'>>,
   repoBehindMarkers: FetchStatusMarker[],
 ): void {
+  // Triaged health banner FIRST, so a user running bare `agents doctor` sees what
+  // is unhealthy, why it matters, and the exact fix before scrolling the detail
+  // sections below. Same triage model as target mode, aggregated across versions.
+  const overviewHealth = computeOverviewHealth(syncRows, orphanRows, repoBehindMarkers);
+  console.log(chalk.bold('Health'));
+  renderHealthBlock(overviewHealth, {
+    healthySummary: syncRows.length
+      ? `${syncRows.length} version${syncRows.length === 1 ? '' : 's'} reconciled · hooks wired · sources current`
+      : 'no installed versions to check',
+    healFix: verdictIsAutoFixable(overviewHealth) ? 'agents doctor --fix' : undefined,
+  });
+  console.log();
+
   console.log(chalk.bold('Agent CLIs'));
   // Show the fleet you actually run — agents that are ready in PATH, plus any
   // you MANAGE (have installed versions) whose binary isn't resolving (a real
@@ -742,7 +755,32 @@ function readExpectedForDiff(kind: DoctorKind, row: ResourceDiff): string | null
 // Claude-style settings.json (matches checkVersionHookWiring's supported set).
 const HOOK_WIRING_FIX_AGENTS: AgentId[] = ['claude', 'droid'];
 
+export type IssueSeverity = 'critical' | 'warning' | 'info';
+
+/**
+ * One triaged health finding. `severity`/`category`/`subject`/`impact`/`fix` are
+ * the triage backbone the human report renders and `--json` carries; `text`/`color`
+ * stay the terse combined label older readers used, so the shape is additive.
+ *
+ * Severity model (agent-agnostic — applies to every agent doctor inspects):
+ *   - critical (silent breakage): an unwired hook, a missing/unparseable
+ *     settings.json, a MISSING resource.
+ *   - warning (stale / drift): a source layer behind origin, a DIVERGENT resource,
+ *     a stale / never-synced version.
+ *   - info (orphan): an EXTRA resource → `agents prune cleanup`.
+ */
 export interface VerdictIssue {
+  severity: IssueSeverity;
+  /** machine-stable class: unwired-hook | settings-missing | settings-unparseable
+   *  | missing | source-behind | divergent | extra | stale | never-synced | orphan */
+  category: string;
+  /** the hook / resource / layer / version the finding is about */
+  subject: string;
+  /** one-line plain-English consequence */
+  impact: string;
+  /** exact remediation command */
+  fix: string;
+  /** terse combined label (legacy) */
   text: string;
   color: 'yellow' | 'red' | 'magenta';
 }
@@ -750,42 +788,270 @@ export interface VerdictIssue {
 export interface DoctorVerdict {
   healthy: boolean;
   issues: VerdictIssue[];
+  /** Resources (target) / versions (overview) reconciled clean — drives the
+   *  healthy line's count. */
+  reconciled: number;
+}
+
+/** Categories `--fix` reconciles (vs. `agents repo pull` for a behind source, or
+ *  `agents prune cleanup` for an orphan). Drives the heal footer. */
+const AUTO_FIXABLE_CATEGORIES = new Set([
+  'unwired-hook', 'settings-missing', 'settings-unparseable', 'missing', 'divergent', 'stale', 'never-synced',
+]);
+
+export function verdictIsAutoFixable(v: DoctorVerdict): boolean {
+  return v.issues.some((i) => AUTO_FIXABLE_CATEGORIES.has(i.category));
 }
 
 /**
- * Fold a version report's divergences into a single verdict. Divergent files,
- * missing/extra resources, UNWIRED hooks, an absent/broken settings.json, and a
- * source layer behind origin all count against health — an UNWIRED hook or a
- * stale source is as unhealthy as a divergent file, not a footnote. Pure so the
- * health rollup is unit-testable without a version home.
+ * Fold a version report's divergences into a triaged verdict — one severity-tagged
+ * finding per unwired hook, missing/divergent/extra resource, and behind-origin
+ * source layer, each carrying its subject, plain-English impact, and exact fix. An
+ * UNWIRED hook or a stale source is as unhealthy as a divergent file, not a
+ * footnote. Pure so the health rollup is unit-testable without a version home.
  */
 export function computeVerdict(report: VersionResourceReport): DoctorVerdict {
   const issues: VerdictIssue[] = [];
-  const { diff, missing, extra } = report.summary;
-  if (diff) issues.push({ text: `${diff} divergent`, color: 'yellow' });
-  if (missing) issues.push({ text: `${missing} missing`, color: 'red' });
-  if (extra) issues.push({ text: `${extra} extra`, color: 'magenta' });
+  const idLabel = `${report.agent}@${report.version}`;
+  const fixCmd = `agents doctor ${idLabel} --fix`;
+  const syncCmd = `agents sync ${idLabel} --yes`;
 
+  // ── critical: settings.json / unwired hooks (silent breakage) ──
   const w = report.hookWiring;
   if (w?.settingsMissing) {
     const n = w.expected ?? 0;
-    issues.push({ text: `settings.json missing (${n} hook${n === 1 ? '' : 's'} unwired)`, color: 'red' });
+    issues.push({
+      severity: 'critical', category: 'settings-missing', subject: 'settings.json',
+      impact: `not found; ${n} declared hook${n === 1 ? '' : 's'} never fire`,
+      fix: syncCmd,
+      text: `settings.json missing (${n} hook${n === 1 ? '' : 's'} unwired)`, color: 'red',
+    });
   } else if (w?.settingsUnparseable) {
-    issues.push({ text: 'settings.json unparseable', color: 'red' });
-  } else if (w && w.unwired.length > 0) {
-    issues.push({ text: `${w.unwired.length} unwired`, color: 'red' });
-  }
-
-  for (const b of report.sourceBehind ?? []) {
-    if (b.behind > 0) {
+    issues.push({
+      severity: 'critical', category: 'settings-unparseable', subject: 'settings.json',
+      impact: `unparseable; hook wiring can't be verified`,
+      fix: syncCmd,
+      text: 'settings.json unparseable', color: 'red',
+    });
+  } else if (w) {
+    for (const u of w.unwired) {
       issues.push({
-        text: `source ${b.label} ${b.behind} commit${b.behind === 1 ? '' : 's'} behind ${b.branch}`,
-        color: 'red',
+        severity: 'critical', category: 'unwired-hook', subject: u.name,
+        impact: 'on disk but not wired into settings.json; the hook never fires',
+        fix: syncCmd,
+        text: `${u.name} unwired`, color: 'red',
       });
     }
   }
 
-  return { healthy: issues.length === 0, issues };
+  // ── critical: missing resources (declared in sources, absent from home) ──
+  for (const kind of DOCTOR_ALL_KINDS) {
+    for (const r of report.kinds[kind]) {
+      if (r.status !== 'missing') continue;
+      issues.push({
+        severity: 'critical', category: 'missing', subject: r.name,
+        impact: `declared in sources but absent from the version home (${kind})`,
+        fix: fixCmd,
+        text: `${r.name} missing`, color: 'red',
+      });
+    }
+  }
+
+  // ── warning: source layer behind origin (home reconciled against stale truth) ──
+  for (const b of report.sourceBehind ?? []) {
+    if (b.behind <= 0) continue;
+    issues.push({
+      severity: 'warning', category: 'source-behind', subject: b.label,
+      impact: `${b.behind} commit${b.behind === 1 ? '' : 's'} behind ${b.branch}; you're running stale config`,
+      fix: `agents repo pull ${b.alias}`,
+      text: `source ${b.label} ${b.behind} commit${b.behind === 1 ? '' : 's'} behind ${b.branch}`, color: 'yellow',
+    });
+  }
+
+  // ── warning: divergent resources (drifted from source) ──
+  for (const kind of DOCTOR_ALL_KINDS) {
+    for (const r of report.kinds[kind]) {
+      if (r.status !== 'diff') continue;
+      issues.push({
+        severity: 'warning', category: 'divergent', subject: r.name,
+        impact: r.detail ? collapseWhitespace(r.detail) : 'differs from source',
+        fix: fixCmd,
+        text: `${r.name} divergent`, color: 'yellow',
+      });
+    }
+  }
+
+  // ── info: extra / orphan resources (present in home, no source) ──
+  for (const kind of DOCTOR_ALL_KINDS) {
+    for (const r of report.kinds[kind]) {
+      if (r.status !== 'extra') continue;
+      issues.push({
+        severity: 'info', category: 'extra', subject: r.name,
+        impact: `orphan in the version home with no source (${kind})`,
+        fix: 'agents prune cleanup',
+        text: `${r.name} extra`, color: 'magenta',
+      });
+    }
+  }
+
+  return { healthy: issues.length === 0, issues, reconciled: report.summary.ok };
+}
+
+// ─── triaged health block (shared by target + overview) ────────────────────────
+
+const SEVERITY_COLOR: Record<IssueSeverity, (s: string) => string> = {
+  critical: chalk.red,
+  warning: chalk.yellow,
+  info: chalk.magenta,
+};
+// Restrained terminal glyphs — the ✓ ✗ ⚠ set plus a subtle info dot, colored via
+// chalk to match the man-page voice. No colorful emoji.
+const SEVERITY_GLYPH: Record<IssueSeverity, string> = {
+  critical: '✗',
+  warning: '⚠',
+  info: '·',
+};
+
+function severityCounts(issues: VerdictIssue[]): { critical: number; warning: number; info: number } {
+  return {
+    critical: issues.filter((i) => i.severity === 'critical').length,
+    warning: issues.filter((i) => i.severity === 'warning').length,
+    info: issues.filter((i) => i.severity === 'info').length,
+  };
+}
+
+/** The info tier (orphans; one identical `prune cleanup` fix, already enumerated
+ *  in the detail section) is capped with a rollup so the block stays scannable
+ *  when a version home carries dozens of orphans. Critical + warning are
+ *  actionable, each with a distinct subject/fix, so they are never capped. */
+const INFO_CAP = 5;
+
+/**
+ * Build the lines of a triaged health block: a single green ✓ line when healthy,
+ * otherwise a severity-counted ✗ header followed by one row per finding (icon ·
+ * severity · subject — impact, then the exact fix under it) and an optional heal
+ * footer. Pure — returns the lines so the rendered output is unit-testable. Shared
+ * by target mode and the bare overview so both read the same way.
+ */
+export function healthBlockLines(verdict: DoctorVerdict, opts: { healthySummary: string; healFix?: string }): string[] {
+  if (verdict.healthy) {
+    return [`  ${chalk.green('✓')} ${chalk.green('healthy')} ${chalk.gray('— ' + opts.healthySummary)}`];
+  }
+  const lines: string[] = [];
+  const c = severityCounts(verdict.issues);
+  const bits: string[] = [];
+  if (c.critical) bits.push(`${c.critical} critical`);
+  if (c.warning) bits.push(`${c.warning} warning${c.warning === 1 ? '' : 's'}`);
+  if (c.info) bits.push(`${c.info} info`);
+  const total = verdict.issues.length;
+  lines.push(`  ${chalk.red('✗')} ${chalk.red('unhealthy')} ${chalk.gray(`— ${total} issue${total === 1 ? '' : 's'} (${bits.join(' · ')})`)}`);
+  lines.push('');
+
+  const cont = ' '.repeat(14); // aligns the fix line under the subject column
+  const issueLines = (i: VerdictIssue): void => {
+    const glyph = SEVERITY_COLOR[i.severity](SEVERITY_GLYPH[i.severity]);
+    const word = SEVERITY_COLOR[i.severity](i.severity.padEnd(8));
+    lines.push(`  ${glyph} ${word}  ${chalk.bold(i.subject)} ${chalk.gray('— ' + i.impact)}`);
+    lines.push(chalk.gray(`${cont}→ ${i.fix}`));
+  };
+  const actionable = verdict.issues.filter((i) => i.severity !== 'info');
+  const infoIssues = verdict.issues.filter((i) => i.severity === 'info');
+  for (const i of actionable) issueLines(i);
+  for (const i of infoIssues.slice(0, INFO_CAP)) issueLines(i);
+  const hiddenInfo = infoIssues.length - Math.min(infoIssues.length, INFO_CAP);
+  if (hiddenInfo > 0) {
+    const glyph = SEVERITY_COLOR.info(SEVERITY_GLYPH.info);
+    const word = SEVERITY_COLOR.info('info'.padEnd(8));
+    lines.push(`  ${glyph} ${word}  ${chalk.gray(`+${hiddenInfo} more orphan${hiddenInfo === 1 ? '' : 's'}`)} ${chalk.gray('— agents prune cleanup')}`);
+  }
+
+  if (opts.healFix) {
+    lines.push('');
+    lines.push(`  ${chalk.gray("heal what's auto-fixable:")}  ${opts.healFix}`);
+  }
+  return lines;
+}
+
+function renderHealthBlock(verdict: DoctorVerdict, opts: { healthySummary: string; healFix?: string }): void {
+  for (const line of healthBlockLines(verdict, opts)) console.log(line);
+}
+
+/**
+ * Aggregate the bare `agents doctor` overview into the same triaged verdict target
+ * mode uses — folding per-version wiring/sync drift, behind-origin source layers,
+ * and orphan resources into severity-tagged findings. Agent-agnostic: every
+ * installed version is classified the same way. Pure, so it is unit-testable.
+ */
+export function computeOverviewHealth(
+  syncRows: SyncStatusRow[],
+  orphanRows: OrphanRow[],
+  repoBehindMarkers: FetchStatusMarker[],
+): DoctorVerdict {
+  const issues: VerdictIssue[] = [];
+  const pretty = (agent: string, version: string) => `${AGENT_NAMES[agent] || agent}@${version}`;
+
+  // critical: unwired hooks / broken settings.json per version
+  for (const row of syncRows) {
+    const n = row.unwiredHooks ?? 0;
+    if (n <= 0) continue;
+    const label = pretty(row.agent, row.version);
+    issues.push({
+      severity: 'critical', category: 'unwired-hook', subject: label,
+      impact: `${n} hook${n === 1 ? '' : 's'} present on disk but not wired into settings.json; never fire`,
+      fix: `agents sync ${row.agent}@${row.version} --yes`,
+      text: `${label} ${n} unwired`, color: 'red',
+    });
+  }
+
+  // warning: source layers behind origin
+  for (const m of repoBehindMarkers) {
+    if (m.behind <= 0) continue;
+    const label = m.alias === 'user' ? '~/.agents' : m.alias;
+    issues.push({
+      severity: 'warning', category: 'source-behind', subject: label,
+      impact: `${m.behind} commit${m.behind === 1 ? '' : 's'} behind ${m.branch}; you're running stale config`,
+      fix: `agents repo pull ${m.alias}`,
+      text: `${label} ${m.behind} behind`, color: 'yellow',
+    });
+  }
+
+  // warning: stale / never-synced versions
+  for (const row of syncRows) {
+    const label = pretty(row.agent, row.version);
+    if (row.status === 'stale') {
+      issues.push({
+        severity: 'warning', category: 'stale', subject: label,
+        impact: 'sources changed since last sync',
+        fix: `agents doctor ${row.agent}@${row.version} --fix`,
+        text: `${label} stale`, color: 'yellow',
+      });
+    } else if (row.status === 'never-synced') {
+      issues.push({
+        severity: 'warning', category: 'never-synced', subject: label,
+        impact: 'installed but never synced',
+        fix: `agents sync ${row.agent}@${row.version} --yes`,
+        text: `${label} never-synced`, color: 'yellow',
+      });
+    }
+  }
+
+  // info: orphan resources per version
+  for (const row of orphanRows) {
+    const parts: string[] = [];
+    if (row.commands) parts.push(`${row.commands} command${row.commands === 1 ? '' : 's'}`);
+    if (row.skills) parts.push(`${row.skills} skill${row.skills === 1 ? '' : 's'}`);
+    if (row.hooks) parts.push(`${row.hooks} hook${row.hooks === 1 ? '' : 's'}`);
+    const label = pretty(row.agent, row.version);
+    issues.push({
+      severity: 'info', category: 'orphan', subject: label,
+      impact: `${parts.join(', ')} in the version home with no source`,
+      fix: 'agents prune cleanup',
+      text: `${label} orphan`, color: 'magenta',
+    });
+  }
+
+  const reconciled = syncRows.filter((r) => r.status === 'fresh' && (r.unwiredHooks ?? 0) === 0).length;
+  return { healthy: issues.length === 0, issues, reconciled };
 }
 
 /**
@@ -857,29 +1123,16 @@ function renderTargetText(report: VersionResourceReport, options: { showDiff: bo
   }
 
   console.log();
-  const { ok } = report.summary;
   const verdict = computeVerdict(report);
-  if (verdict.healthy) {
-    console.log(chalk.green(`  Verdict: ${ok} resource${ok === 1 ? '' : 's'} reconciled. Version home matches resolved sources.`));
-  } else {
-    const colored = verdict.issues.map((i) => chalk[i.color](i.text));
-    console.log(`  Verdict: ${colored.join(', ')}.`);
-    // Lead with the remediation that matches the problem. A source layer behind
-    // origin is NOT healed by `--fix` (only `agents repo pull` reconciles it), so
-    // in the sourceBehind-only case the repo-pull hint must lead and the `--fix`
-    // hint is suppressed — it would mislead.
-    const behind = (report.sourceBehind ?? []).filter((b) => b.behind > 0);
-    for (const b of behind) {
-      printWrappedLine('  ', `Source ${b.label} is behind ${b.branch} — run \`agents repo pull ${b.alias}\` to reconcile against current sources.`);
-    }
-    const w = report.hookWiring;
-    const fixable =
-      report.summary.diff > 0 || report.summary.missing > 0 || report.summary.extra > 0 ||
-      (w != null && (w.unwired.length > 0 || !!w.settingsMissing || !!w.settingsUnparseable));
-    if (fixable) {
-      printWrappedLine('  ', `Run \`agents doctor ${report.agent}@${report.version} --fix\` to heal, or \`agents prune cleanup\` to drop extras.`);
-    }
-  }
+  // A source layer behind origin is healed by `agents repo pull`, not `--fix` —
+  // the per-issue fix already names the right command, so the heal footer only
+  // shows when something is genuinely `--fix`-able (never in the source-behind or
+  // orphan-only case, where it would mislead).
+  const hooksWired = report.hookWiring?.supported ? ' · hooks wired' : '';
+  renderHealthBlock(verdict, {
+    healthySummary: `${verdict.reconciled} resource${verdict.reconciled === 1 ? '' : 's'} reconciled${hooksWired} · sources current`,
+    healFix: verdictIsAutoFixable(verdict) ? `agents doctor ${report.agent}@${report.version} --fix` : undefined,
+  });
 }
 
 // ─── fix / heal mode ───────────────────────────────────────────────────────────
@@ -1160,6 +1413,10 @@ export function registerDoctorCommand(program: Command): void {
             auth: summarizeHostAuth(readAuthHealthCache(), machineId()),
             sync: syncRows,
             orphans: orphanRows,
+            // Triaged overview health — severity/category/subject/impact/fix per
+            // finding, aggregated across versions. Additive; existing consumers
+            // reading `sync`/`orphans`/`repos` are unaffected.
+            health: computeOverviewHealth(syncRows, orphanRows, repoBehindMarkers),
             // This host's harness inventory — installed resources per kind,
             // installed version ids per agent, and `.agents`/`.system` repo
             // state — so `agents doctor --devices` can compare presence across
@@ -1221,7 +1478,11 @@ export function registerDoctorCommand(program: Command): void {
       for (const r of reports) r.sourceBehind = sourceBehind;
 
       if (opts.json) {
-        console.log(JSON.stringify(reports.length === 1 ? reports[0] : reports, null, 2));
+        // Carry the triaged verdict (severity/category/subject/impact/fix per
+        // issue) alongside the report — additive, so existing consumers reading
+        // `summary`/`kinds`/`hookWiring`/`sourceBehind` are unaffected.
+        const withVerdict = reports.map((r) => ({ ...r, verdict: computeVerdict(r) }));
+        console.log(JSON.stringify(withVerdict.length === 1 ? withVerdict[0] : withVerdict, null, 2));
         return;
       }
 


### PR DESCRIPTION
## What & why

`agents doctor` (after #1554) *detects* unwired hooks + source-behind, but the
verdict still read like neutral status a user had to decode
(`Verdict: 1 divergent, source ~/.agents 16 commits behind…`). This turns the
verdict into a **triaged health report**: severity-ranked findings, each with an
icon, subject, plain-English impact, and the exact fix command — so a user running
bare `agents doctor` immediately sees what is unhealthy, why, and how to fix it.

## Severity model (agent-agnostic)

- **critical** (`✗`, silent breakage) — unwired hook, missing/unparseable `settings.json`, MISSING resource → `agents sync … --yes` / `agents doctor … --fix`
- **warning** (`⚠`, stale / drift) — source layer behind origin, DIVERGENT resource, stale/never-synced version → `agents repo pull …` / `agents doctor … --fix`
- **info** (`·`, orphan) — EXTRA resource → `agents prune cleanup` (capped with a `+N more orphans` rollup)

Applies to **both** the target report (`agents doctor <agent>@<version>`) and the
bare overview (new `Health` banner aggregated across every installed version). The
per-resource detail rows are kept — the health block layers on top as the verdict.

## Before → after (real render on this box; `~/.agents` is 16+ commits behind)

**Before** (`agents doctor claude@2.1.220`, installed 1.20.77 — terse status):
```
  Verdict: 149 ok. … source ~/.agents 16 commits behind origin/main.
  Source ~/.agents is behind origin/main — run `agents repo pull user` …
  Run `agents doctor claude@2.1.220 --fix` to heal, or `agents prune cleanup` …
```

**After** — healthy collapses to one green line:
```
Claude@2.1.220
  ✓ healthy — 34 resources reconciled · hooks wired · sources current
```

**After** — unhealthy target report (real, top of block):
```
Claude@2.1.220
  ✗ unhealthy — 41 issues (3 critical · 9 warnings · 29 info)

  ✗ critical  version — declared in sources but absent from the version home (commands)
              → agents doctor claude@2.1.220 --fix
  ✗ critical  cgraph — declared in sources but absent from the version home (skills)
              → agents doctor claude@2.1.220 --fix
  ⚠ warning   ~/.agents — 17 commits behind origin/main; you're running stale config
              → agents repo pull user
  ⚠ warning   11-activity-log — differs from source
              → agents doctor claude@2.1.220 --fix
  · info      accounts — orphan in the version home with no source (skills)
              → agents prune cleanup
  · info      +24 more orphans — agents prune cleanup

  heal what's auto-fixable:  agents doctor claude@2.1.220 --fix
```

**After** — bare `agents doctor` overview now opens with a `Health` banner:
```
Health
  ✗ unhealthy — 23 issues (12 warnings · 11 info)

  ⚠ warning   ~/.agents — 17 commits behind origin/main; you're running stale config
              → agents repo pull user
  ⚠ warning   Claude@2.1.220 — sources changed since last sync
              → agents doctor claude@2.1.220 --fix
  · info      Claude@2.1.220 — 28 skills, 18 hooks in the version home with no source
              → agents prune cleanup
  …
```

## `--json` (additive — existing consumers unaffected)

- Target mode gains a `verdict` field; overview gains a `health` field. Each carries `severity`/`category`/`subject`/`impact`/`fix` per issue.
- Verified `summary`/`kinds`/`hookWiring`/`sourceBehind` (target) and `clis`/`sync`/`orphans`/`fleet`/`repos`/`hostClis` (overview) all still present.

## Tests

`apps/cli/src/commands/doctor.test.ts` — 21 pass (was 13): severity classification
(`computeVerdict`), overview aggregation (`computeOverviewHealth`), and rendered
output (`healthBlockLines`: healthy line, unhealthy header + rows + heal footer,
info-tier rollup). New tests fail before the change (they assert fields that did
not exist) and pass after.

- `bun run` typecheck (`tsc --noEmit`): clean
- `tsc` build: clean
- `doctor.test.ts` + `check.test.ts`: 28 pass

Icons are explicitly requested (restrained terminal glyphs `✓` `✗` `⚠` `·`, colored
via the existing `chalk` usage) — allowed despite the usual no-emoji rule.

Session transcript (fleet-local): zion:/Users/muqsit/.agents/.history — available to a teammate on the fleet.
