### PR TITLE
refactor(git): remove dead commitOwnDeviceMeta auto-commit

### DIFF
--- a/apps/cli/.changelog/next/remove-commit-own-device-meta.md
+++ b/apps/cli/.changelog/next/remove-commit-own-device-meta.md
@@ -1,0 +1,10 @@
+- **Removed the dead `commitOwnDeviceMeta` auto-commit from the pull path.** It
+  committed this machine's `devices/<host>/agents.yaml` pin snapshot to the user
+  repo's `main` on nearly every `pullRepo`, without pushing — so `main` diverged
+  N-ahead per machine and wedged `agents sync` across the fleet. Now that
+  per-device pins are gitignored (they are local runtime state — written by
+  `writeMetaUnlocked`, read on-disk by pinned-strategy resolution and the shim),
+  the function only ever no-ops, so it and its sole `pullRepo` call are deleted
+  along with their tests. `--strategy balanced` never read pins; the only behavior
+  removed is the never-reached auto-commit. Source: `apps/cli/src/lib/git.ts`
+  (`pullRepo`), `apps/cli/src/lib/git.test.ts`.

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -20,7 +20,6 @@ import {
   canonicalGitRemote,
   commitAndPush,
   commitsBehindUpstream,
-  commitOwnDeviceMeta,
   displayHomePath,
   parseSource,
   pullRepo,
@@ -227,56 +226,6 @@ describe('displayHomePath', () => {
   });
 });
 
-describe('commitOwnDeviceMeta (unwedge the pull from per-machine pin drift)', () => {
-  const tmpDirs: string[] = [];
-  afterEach(() => {
-    for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
-    tmpDirs.length = 0;
-  });
-
-  async function initRepo(): Promise<string> {
-    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'own-meta-'));
-    tmpDirs.push(repo);
-    const g = simpleGit(repo);
-    await g.init(['-b', 'main']);
-    await g.addConfig('user.email', 'test@example.com');
-    await g.addConfig('user.name', 'Test');
-    await g.addConfig('commit.gpgsign', 'false');
-    fs.mkdirSync(path.join(repo, 'devices', 'zion'), { recursive: true });
-    fs.writeFileSync(path.join(repo, 'devices', 'zion', 'agents.yaml'), 'agents:\n  claude: 1.0.0\n');
-    await g.add('-A');
-    await g.commit('init');
-    return repo;
-  }
-
-  it('commits ONLY the dirty device-meta, leaving a real user edit uncommitted (still blocks the pull)', async () => {
-    const repo = await initRepo();
-    const meta = path.join(repo, 'devices', 'zion', 'agents.yaml');
-    fs.writeFileSync(meta, 'agents:\n  claude: 2.0.0\n'); // pin drift
-    fs.writeFileSync(path.join(repo, 'hooks.yaml'), 'a real user edit\n'); // genuine work
-
-    const committed = await commitOwnDeviceMeta(repo, meta);
-    expect(committed).toBe('devices/zion/agents.yaml');
-
-    const st = await simpleGit(repo).status();
-    // device-meta is now clean (committed); the user edit is still dirty.
-    expect(st.files.map((f) => f.path)).toContain('hooks.yaml');
-    expect(st.files.map((f) => f.path)).not.toContain('devices/zion/agents.yaml');
-  });
-
-  it('is a no-op when the device-meta is clean', async () => {
-    const repo = await initRepo();
-    const meta = path.join(repo, 'devices', 'zion', 'agents.yaml');
-    expect(await commitOwnDeviceMeta(repo, meta)).toBeNull();
-  });
-
-  it('is a no-op when the device-meta lives outside the repo (system/extra repos)', async () => {
-    const repo = await initRepo();
-    const outside = path.join(os.tmpdir(), 'somewhere-else', 'devices', 'x', 'agents.yaml');
-    expect(await commitOwnDeviceMeta(repo, outside)).toBeNull();
-  });
-});
-
 describe('pullRepo dirty-tree hint', () => {
   const tmpDirs: string[] = [];
 
@@ -471,8 +420,8 @@ describe('pullRepo reconciliation', () => {
 
   // REVERSED deliberately (RUSH-2056). This asserted that divergence alone
   // refuses the pull. That is what broke fleet distribution: --ff-only rejects
-  // ANY divergence, conflict or not, so one commitOwnDeviceMeta commit wedged
-  // every device permanently with nothing actually in conflict. pullRepo now
+  // ANY divergence, conflict or not, so a single local commit wedged the pull
+  // permanently with nothing actually in conflict. pullRepo now
   // rebases, which is what its own doc has always claimed it does.
   it('rebases a diverged branch instead of refusing when nothing conflicts', async () => {
     // Upstream and local each add a DIFFERENT file → diverged, no conflict.
@@ -614,9 +563,9 @@ describe('pullRepo reconciles a diverged branch by rebasing', () => {
   }
 
   // Builds: bare remote + an `author` clone that pushes upstream, and a `local`
-  // clone that has its own unpushed commit. That is exactly the fleet shape —
-  // commitOwnDeviceMeta makes a local commit, upstream moves on, and the two
-  // diverge with NOTHING in conflict (different files).
+  // clone that has its own unpushed commit. That is exactly the fleet shape — a
+  // local commit lands, upstream moves on, and the two diverge with NOTHING in
+  // conflict (different files).
   async function divergedPair(): Promise<{ local: string; author: string }> {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pullrebase-'));
     tmpDirs.push(root);

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { IS_WINDOWS, isWindowsAbsolutePath } from './platform/index.js';
-import { getPackageLocalPath, getDeviceMetaPath } from './state.js';
+import { getPackageLocalPath } from './state.js';
 import { DEFAULT_SYSTEM_REPO, systemRepoSlug } from './types.js';
 
 /**
@@ -921,43 +921,6 @@ export function displayHomePath(dir: string): string {
  * branch reconciles instead of failing with "Need to specify how to reconcile
  * divergent branches".
  */
-/**
- * Auto-commit the machine's OWN generated per-device meta file
- * (`devices/<machineId>/agents.yaml`) if it's the dirty state blocking a pull.
- *
- * That file is committed + synced (so every machine can introspect every other
- * machine's pins), but each box rewrites its own copy whenever a pin changes —
- * leaving the tree perpetually dirty and wedging `agents repo pull` (which
- * refuses a dirty tree). This durably commits just that one path (explicit
- * pathspec) so the pull can proceed; genuine user edits to OTHER files are left
- * untouched and still (correctly) block the pull. No-op when the meta path isn't
- * inside `dir` (system/extra repos) or isn't dirty. Returns the committed rel
- * path, or null. `metaAbs` is injectable for tests; defaults to the live path.
- */
-export async function commitOwnDeviceMeta(
-  dir: string,
-  metaAbs: string = getDeviceMetaPath(),
-): Promise<string | null> {
-  const resolvedDir = path.resolve(dir);
-  const resolvedMeta = path.resolve(metaAbs);
-  if (resolvedMeta !== resolvedDir && !resolvedMeta.startsWith(resolvedDir + path.sep)) {
-    return null; // meta lives outside this repo — not ours to commit here
-  }
-  const rel = path.relative(resolvedDir, resolvedMeta).split(path.sep).join('/');
-  try {
-    const git = simpleGit(dir);
-    const status = await git.status();
-    const dirty = status.files.some((f) => f.path === rel);
-    if (!dirty) return null;
-    await git.add([rel]);
-    const machine = path.basename(path.dirname(resolvedMeta));
-    await git.commit(`chore(devices): snapshot ${machine} agent pins`, [rel]);
-    return rel;
-  } catch {
-    return null; // best-effort — never let this block the pull path
-  }
-}
-
 export async function pullRepo(
   dir: string,
 ): Promise<{ success: boolean; commit: string; error?: string; branch?: string }> {
@@ -967,7 +930,7 @@ export async function pullRepo(
     // A rebase left in progress by an earlier run must be reported as itself.
     // Without this the dirty-tree guard below claims "Blocked by local changes",
     // which is both wrong and actively harmful advice mid-rebase on a detached
-    // HEAD. Checked BEFORE commitOwnDeviceMeta so we never commit into one.
+    // HEAD.
     // Ask git where the state dirs live rather than assuming `<dir>/.git/` is a
     // directory. In a worktree `.git` is a FILE containing `gitdir: <path>`, so
     // path.join(dir, '.git', 'rebase-merge') can never exist and the check would
@@ -999,9 +962,6 @@ export async function pullRepo(
       };
     }
 
-    // Commit this machine's own device-meta first so a per-machine pin change
-    // never wedges the pull. Genuine edits elsewhere still block below.
-    await commitOwnDeviceMeta(dir);
     const status = await git.status();
 
     if (!status.isClean()) {
@@ -1066,10 +1026,8 @@ export async function pullRepo(
 
     try {
       // Rebase, not --ff-only. Fast-forward refuses ANY divergence, conflict or
-      // not, so a single local commit — including the one commitOwnDeviceMeta
-      // makes just above — permanently wedged the pull with nothing actually in
-      // conflict. Every device carries its own devices/<host>/ path, so those
-      // replay cleanly. Matches syncRepoGit (below) and this function's own doc.
+      // not, so a single local commit permanently wedged the pull with nothing
+      // actually in conflict. Matches syncRepoGit (below) and this function's doc.
       //
       // Pull the RESOLVED tracking ref, not `branch`: when the local branch has
       // no tracking config the block above falls back to origin's default head,


### PR DESCRIPTION
## Type: refactor — dead-code removal, no behavior change.

## What

Deletes `commitOwnDeviceMeta` and its single `pullRepo` call, its now-orphan `getDeviceMetaPath` import, its dedicated test suite, and the stale comments that referenced it.

## Why it was dead

`commitOwnDeviceMeta` auto-committed this machine's `devices/<host>/agents.yaml` pin snapshot to the user repo's `main` on nearly every `pullRepo` — **without pushing**. So `main` diverged N-ahead per machine and wedged `agents sync` across the fleet (the recurring "your branch and origin have diverged" deadlock).

Per-device pins are now **gitignored** — they're local runtime state, written by `writeMetaUnlocked` and read on-disk by pinned-strategy resolution + the shell shim, never needing to be committed. With `devices/` ignored, `commitOwnDeviceMeta` finds nothing dirty and only ever no-ops. Dead code, so it goes.

The actual fix that stops the churn is the config-repo change (gitignore `devices/`); this PR is the follow-up cleanup so agents-cli carries no dangling code.

## Scope / safety

- `--strategy balanced` never read device pins; the only behavior removed is the never-reached auto-commit.
- No production reference to the symbol remains (`grep` clean; the two CHANGELOG hits are historical release notes, correctly untouched).
- `tsc --noEmit` clean (including the orphaned-import removal). The removed `describe('commitOwnDeviceMeta …')` suite was self-contained; the remaining `git.test.ts` suites don't reference it.

## Proof

CI (`typecheck` + `test-shard`) is the run here — green CI on this branch is the verification for a no-behavior-change refactor.
