### PR TITLE
feat(actor): surface session owner in --active + actor/initiated_by DB columns [RUSH-2018]

### DIFF
--- a/apps/cli/.changelog/next/rush-2018-owner-visibility.md
+++ b/apps/cli/.changelog/next/rush-2018-owner-visibility.md
@@ -1,0 +1,11 @@
+- **`agents sessions --active` shows who launched each run (RUSH-2018).** New
+  **owner** column on the active-sessions table (and an `owner` field in
+  `--active --json`), sourced from the resolved actor stamped at spawn into the
+  per-pid registry and onto each teammate record. Displays the actor's short id
+  (an email's local-part) and stays honest — an unresolved local run shows `-`,
+  never a guessed box owner. The session index (`sessions.db`) also gains
+  write-once `actor` / `initiated_by` columns, kept out of the upsert
+  `ON CONFLICT` set so a content rescan never clobbers the original owner.
+  Source: `apps/cli/src/lib/session/pid-registry.ts`,
+  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`
+  (`ownerLabel`), `apps/cli/src/lib/session/db.ts`, `apps/cli/src/lib/exec.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -82,6 +82,21 @@ actors:
     github: bisma
 ```
 
+#### Surfacing the owner
+
+The resolved actor is stamped at spawn and read back so you can see *who* launched
+each run, not just *what* is running:
+
+- **`agents sessions --active`** shows an **owner** column — the actor's short id
+  (an email's local-part, or `-` when the run is unresolved-local). It is stamped
+  into the per-pid registry (`writePidSessionEntry`) at launch and onto each
+  teammate record, so a co-located fleet no longer collapses to one anonymous
+  account. `--active --json` carries the raw `owner` field for a consumer to join on.
+- **The session index** (`sessions.db`) carries `actor` and `initiated_by`
+  (`human`/`agent`) columns. They are **write-once at session creation** — a later
+  content rescan carries no actor and is deliberately kept out of the upsert's
+  `ON CONFLICT` update set, so the original owner is never clobbered by re-indexing.
+
 ```bash
 agents events                          # recent activity across everything
 agents events --module teams           # team lifecycle (create / add / disband)

--- a/apps/cli/src/commands/sessions.serialize.test.ts
+++ b/apps/cli/src/commands/sessions.serialize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { serializeSessionsJson, serializeActiveSessionsForJson } from './sessions.js';
+import { serializeSessionsJson, serializeActiveSessionsForJson, ownerLabel } from './sessions.js';
 import type { SessionMeta } from '../lib/session/types.js';
 import type { ActiveSession } from '../lib/session/active.js';
 
@@ -104,5 +104,38 @@ describe('serializeActiveSessionsForJson (RUSH-1981 — join keys)', () => {
     expect(row.machine).toBe('yosemite-s1');
     expect(row.ticket).toBeUndefined();
     expect(row.project).toBe('repo');
+  });
+
+  it('carries the owner field through the JSON serializer (RUSH-2018)', () => {
+    // owner rides the ...s spread, so a watcher/VS Code consumer can join on who
+    // launched each active session without a second lookup.
+    const [row] = serializeActiveSessionsForJson([active({ owner: 'ada@example.com' })]);
+    expect(row.owner).toBe('ada@example.com');
+  });
+});
+
+/**
+ * RUSH-2018: the owner column in `agents sessions --active` shortens a resolved
+ * actor id to a compact display, and stays honest — an unresolved local run
+ * shows no owner rather than inventing one.
+ */
+describe('ownerLabel (RUSH-2018 — --active owner column)', () => {
+  const s = (owner?: string): ActiveSession =>
+    ({ context: 'terminal', kind: 'agent', status: 'running', owner } as ActiveSession);
+
+  it('shows the local-part of a resolved actor email', () => {
+    expect(ownerLabel(s('muqsit@getrush.ai'))).toBe('muqsit');
+  });
+
+  it('shows a non-email login id as-is', () => {
+    expect(ownerLabel(s('ada-lovelace'))).toBe('ada-lovelace');
+  });
+
+  it('shows "-" for an unresolved actor (honest: we do not know who)', () => {
+    expect(ownerLabel(s('UNRESOLVED@yosemite-s1'))).toBe('-');
+  });
+
+  it('shows "-" when no owner was stamped (launch predates actor stamping)', () => {
+    expect(ownerLabel(s(undefined))).toBe('-');
   });
 });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -541,11 +541,12 @@ function locatorBadge(s: ActiveSession): string {
  * terminal width so the row never wraps.
  */
 function printActiveRow(s: ActiveSession, indent: string): void {
-  // shortId (8-char) · agent · host · status · badges · identity+todos+snippet
+  // shortId (8-char) · agent · host · status · owner · badges · identity+todos+snippet
   const idCol = chalk.dim(padToWidth((s.sessionId?.slice(0, 8)) ?? '-', 9));
   const kindCol = colorAgent(s.kind as any)(padToWidth(truncateToWidth(s.kind, 8), 9));
   const hostCol = chalk.gray(padToWidth(truncateToWidth(s.host ?? '-', 8), 9));
   const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), 8), 9));
+  const ownerCol = chalk.cyan(padToWidth(truncateToWidth(ownerLabel(s), 8), 9));
   const fork = s.pidCount && s.pidCount > 1 ? chalk.dim(`×${s.pidCount} `) : '';
   const badges = (fork ? fork : '') + [signalBadges(s), locatorBadge(s)].filter(Boolean).join(' ');
   // Identity (label/project/ticket clickable) + checklist + live snippet.
@@ -553,10 +554,24 @@ function printActiveRow(s: ActiveSession, indent: string): void {
   // via the SSH fan-out already populated (including todos when the peer has them).
   const desc = formatActiveRowDescription(s) || '-';
   // Fill the remaining width with the preview so nothing wraps under tmux/SSH.
-  const fixed = stringWidth(indent) + 9 + 9 + 9 + 9 + (badges ? stringWidth(badges) + 1 : 0);
+  const fixed = stringWidth(indent) + 9 + 9 + 9 + 9 + 9 + (badges ? stringWidth(badges) + 1 : 0);
   const room = Math.max(12, terminalWidth() - fixed - 1);
   const descCol = chalk.white(truncateToWidth(desc, room));
-  console.log(indent + idCol + kindCol + hostCol + statusCol + (badges ? badges + ' ' : '') + descCol);
+  console.log(indent + idCol + kindCol + hostCol + statusCol + ownerCol + (badges ? badges + ' ' : '') + descCol);
+}
+
+/**
+ * Compact owner display for the `--active` owner column: the local-part of a
+ * resolved actor email/login (`muqsit@getrush.ai` -> `muqsit`), the id as-is
+ * when it has no `@`, and `-` when the actor is unresolved (`UNRESOLVED@<host>`)
+ * or absent (a launch predating actor stamping). Honest by design — an
+ * unresolved local run shows no owner rather than inventing one.
+ */
+export function ownerLabel(s: ActiveSession): string {
+  const owner = s.owner;
+  if (!owner || owner.startsWith('UNRESOLVED@')) return '-';
+  const at = owner.indexOf('@');
+  return at > 0 ? owner.slice(0, at) : owner;
 }
 
 /**

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -1066,6 +1066,8 @@ export async function execShimPassthrough(
         agent,
         sessionId: extractSessionIdArg(rawArgs),
         cwd,
+        actor: resolveActor().id,
+        initiatedBy: resolveActor().kind,
         launchId,
         terminalId: process.env.AGENT_TERMINAL_ID,
         startedAtMs: Date.now(),
@@ -1250,6 +1252,8 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
       agent: options.agent,
       sessionId: options.sessionId,
       cwd,
+      actor: resolveActor().id,
+      initiatedBy: resolveActor().kind,
       // spawnAgent injected AGENT_LAUNCH_ID into options.env before delegating
       // here; record the same id so the hook (running under the pane-leaf agent
       // pid) reconciles by launchId. This pane's pid usually IS the agent pid,
@@ -1479,6 +1483,8 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
       agent: options.agent,
       sessionId: options.sessionId,
       cwd: options.cwd || process.cwd(),
+      actor: resolveActor().id,
+      initiatedBy: resolveActor().kind,
       launchId,
       terminalId: process.env.AGENT_TERMINAL_ID,
       tmuxPane: process.env.TMUX_PANE,

--- a/apps/cli/src/lib/session/__tests__/db-actor.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db-actor.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-db-actor-'));
+process.env.HOME = TEST_HOME;
+
+const { getDB, closeDB, upsertSession, getSessionById } = await import('../db.js');
+type SessionMeta = import('../types.js').SessionMeta;
+
+const FILES = path.join(TEST_HOME, 'files');
+fs.mkdirSync(FILES, { recursive: true });
+
+function upsert(over: Partial<SessionMeta> & { id: string }): void {
+  const filePath = path.join(FILES, `${over.id}.jsonl`);
+  fs.writeFileSync(filePath, '');
+  upsertSession(
+    {
+      id: over.id,
+      shortId: over.id.slice(0, 8),
+      agent: 'claude',
+      timestamp: '2026-08-01T10:00:00.000Z',
+      filePath,
+      ...over,
+    },
+    '',
+  );
+}
+
+/**
+ * RUSH-2018: the sessions DB records who launched a session (`actor`) and the
+ * actor's kind (`initiated_by`). The contract that matters is write-once
+ * preservation: those columns are stamped at creation and a later content
+ * rescan — which carries no actor — must NOT clobber them. That is enforced by
+ * keeping both columns out of the upsert's ON CONFLICT update set.
+ */
+describe('sessions DB actor provenance (RUSH-2018)', () => {
+  beforeAll(() => {
+    getDB(); // migrate a fresh home to schema v19
+  });
+  afterAll(() => {
+    closeDB();
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('persists actor + initiatedBy on insert and maps them back through rowToMeta', () => {
+    upsert({ id: 'sess-actor-1', actor: 'ada@example.com', initiatedBy: 'human' });
+    const meta = getSessionById('sess-actor-1');
+    expect(meta?.actor).toBe('ada@example.com');
+    expect(meta?.initiatedBy).toBe('human');
+  });
+
+  it('stores the raw columns on the row', () => {
+    const db = getDB();
+    const row = db
+      .prepare(`SELECT actor, initiated_by FROM sessions WHERE id = ?`)
+      .get('sess-actor-1') as { actor: string; initiated_by: string };
+    expect(row.actor).toBe('ada@example.com');
+    expect(row.initiated_by).toBe('human');
+  });
+
+  it('preserves the original actor on a content rescan (ON CONFLICT excludes it)', () => {
+    upsert({ id: 'sess-actor-2', actor: 'grace@example.com', initiatedBy: 'human' });
+    // A rescan re-upserts the same id with NO actor (the scanner can't know it).
+    upsert({ id: 'sess-actor-2', topic: 'rescanned' });
+    const meta = getSessionById('sess-actor-2');
+    // The rescan updated content but must NOT have wiped who launched it.
+    expect(meta?.topic).toBe('rescanned');
+    expect(meta?.actor).toBe('grace@example.com');
+    expect(meta?.initiatedBy).toBe('human');
+  });
+
+  it('leaves actor/initiatedBy undefined when never stamped (pre-actor rows)', () => {
+    upsert({ id: 'sess-actor-3' });
+    const meta = getSessionById('sess-actor-3');
+    expect(meta?.actor).toBeUndefined();
+    expect(meta?.initiatedBy).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -166,7 +166,7 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('18');
+    expect(row.value).toBe('19');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -160,6 +160,14 @@ export interface ActiveSession {
    */
   provenance?: SessionProvenance;
   /**
+   * Who initiated this session — the resolved actor id stamped at spawn
+   * (`resolveActor().id`, read back from the pid registry / teammate record).
+   * A tailnet login/email for a resolved human, `UNRESOLVED@<host>` when it
+   * couldn't be determined, absent when the launch predates actor stamping.
+   * Surfaced as the owner column in `--active` (RUSH-2018).
+   */
+  owner?: string;
+  /**
    * The machine this session runs on, as a normalized device id (machineId()
    * form). Set when merging cross-machine results so the grouped `--active`
    * view can bucket by computer. Absent for a purely local query (the renderer
@@ -685,6 +693,9 @@ export async function listTeamsActive(): Promise<ActiveSession[]> {
       lastActivityMs: sessionFileTimes(sessionFile).mtimeMs,
       teamName: a.taskName,
       agentId: a.agentId,
+      // The frozen actor stamped on the teammate record (RUSH-2028) — who ran
+      // this teammate, surfaced as the owner in --active (RUSH-2018).
+      owner: a.actor ?? undefined,
     }, state, sessionFile, pidAlive);
   });
 }
@@ -715,7 +726,8 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
     // back to the stale cached id — the duplicate-card fix comes from
     // pickSessionFile no longer borrowing a sibling, not from this lookup. Kept as
     // a forward-looking hook for the cases where the pid does line up.
-    const resolvedId = readPidSessionEntry(t.pid)?.sessionId ?? t.sessionId;
+    const pidEntry = readPidSessionEntry(t.pid);
+    const resolvedId = pidEntry?.sessionId ?? t.sessionId;
     const sessionFile = findSessionFileForKind(t.kind, t.cwd ?? undefined, resolvedId);
     // Prefer label from live terminal, fall back to Claude's session label
     const label = t.label ?? (t.sessionId ? labelMap.get(t.sessionId) : undefined) ?? undefined;
@@ -741,6 +753,7 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
       startedAtMs: t.startedAtMs,
       lastActivityMs: sessionFileTimes(sessionFile).mtimeMs,
       windowId: t.windowId,
+      owner: pidEntry?.actor ?? undefined,
     }, state, sessionFile, pidAlive);
   });
 }
@@ -1179,6 +1192,7 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
       startedAtMs: hookRec?.ts ?? birthtimeMs,
       lastActivityMs: mtimeMs,
       pidCount: 1 + (foldedByRoot.get(pid) ?? 0),
+      owner: entry?.actor ?? undefined,
     }, state, sessionFile, true));
   }
   // Housekeeping: drop registry files for pids that have since died.
@@ -1335,6 +1349,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
       startedAtMs: birthtimeMs,
       lastActivityMs: mtimeMs,
       provenance,
+      owner: liveEntry?.actor ?? undefined,
     }, state, sessionFile, pidAlive));
   }
   return out;

--- a/apps/cli/src/lib/session/db.migrate-v14.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v14.test.ts
@@ -98,7 +98,7 @@ describe('schema migration v13 -> current (dir_ledger + resumable parser)', () =
   it('bumps the recorded schema version to the current version', () => {
     const db = getDB();
     const v = (db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string }).value;
-    expect(v).toBe('18');
+    expect(v).toBe('19');
   });
 
   it('preserves existing session rows through the migration', () => {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -20,7 +20,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 18;
+const SCHEMA_VERSION = 19;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -82,7 +82,9 @@ CREATE TABLE IF NOT EXISTS sessions (
   todos TEXT,
   recent_directories_touched TEXT,
   linear_project TEXT,
-  linear_project_url TEXT
+  linear_project_url TEXT,
+  actor TEXT,
+  initiated_by TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_timestamp ON sessions(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd);
@@ -176,6 +178,8 @@ export interface SessionRow {
   recent_directories_touched: string | null;
   linear_project: string | null;
   linear_project_url: string | null;
+  actor: string | null;
+  initiated_by: string | null;
 }
 
 /** File stat snapshot used to detect changes between scan runs. */
@@ -431,6 +435,17 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
       }
     });
     txn(rows);
+  }
+
+  if (fromVersion < 19) {
+    // v18 → v19: actor provenance (RUSH-2018) — who initiated the session and
+    // the actor's kind. Populated at write time from the resolved actor (the
+    // pid-registry/spawn path), not derivable from the transcript, so there is
+    // no ledger wipe here: a rescan can't backfill these, and forcing a full
+    // re-parse would be pure churn. Existing rows stay NULL until re-created.
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'actor')) db.exec(`ALTER TABLE sessions ADD COLUMN actor TEXT`);
+    if (!cols.some(c => c.name === 'initiated_by')) db.exec(`ALTER TABLE sessions ADD COLUMN initiated_by TEXT`);
   }
 }
 
@@ -838,7 +853,8 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     output_tokens, cost_usd, duration_ms,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id, plan, todos,
-    recent_directories_touched, linear_project, linear_project_url, machine
+    recent_directories_touched, linear_project, linear_project_url, machine,
+    actor, initiated_by
   ) VALUES (
     @id, @short_id, @agent, @origin, @routine_name, @routine_run_id,
     @version, @account, @timestamp, @last_activity,
@@ -846,7 +862,8 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     @output_tokens, @cost_usd, @duration_ms,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
     @pr_url, @pr_number, @worktree_slug, @ticket_id, @plan, @todos,
-    @recent_directories_touched, @linear_project, @linear_project_url, @machine
+    @recent_directories_touched, @linear_project, @linear_project_url, @machine,
+    @actor, @initiated_by
   )
   ON CONFLICT(id) DO UPDATE SET
     short_id = excluded.short_id,
@@ -897,6 +914,10 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
       ELSE COALESCE(excluded.linear_project_url, sessions.linear_project_url)
     END,
     machine = excluded.machine
+    -- actor / initiated_by are deliberately NOT in this update set (RUSH-2018):
+    -- they record who launched the session, write-once at creation. A later
+    -- content rescan carries no actor, so updating here would clobber the real
+    -- owner with NULL. Omitting them preserves the original on every rescan.
 `);
 
 function enrichCachedSessionMeta(meta: SessionMeta): SessionMeta {
@@ -1004,6 +1025,8 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     linear_project: meta.linearProject ?? null,
     linear_project_url: meta.linearProjectUrl ?? null,
     machine: resolveMachine(meta),
+    actor: meta.actor ?? null,
+    initiated_by: meta.initiatedBy ?? null,
   };
 
   const txn = db.transaction(() => {
@@ -1129,6 +1152,8 @@ export function upsertSessionsBatch(
         linear_project: meta.linearProject ?? null,
         linear_project_url: meta.linearProjectUrl ?? null,
     machine: resolveMachine(meta),
+        actor: meta.actor ?? null,
+        initiated_by: meta.initiatedBy ?? null,
       });
       delText.run(meta.id);
       insText.run(
@@ -1331,6 +1356,10 @@ function rowToMeta(row: SessionRow): SessionMeta {
     linearProject: row.linear_project ?? undefined,
     linearProjectUrl: row.linear_project_url ?? undefined,
     machine: row.machine ?? undefined,
+    actor: row.actor ?? undefined,
+    // Narrow the free-text column to the known kinds; an unexpected value maps
+    // to undefined rather than being asserted as a valid kind.
+    initiatedBy: row.initiated_by === 'human' || row.initiated_by === 'agent' ? row.initiated_by : undefined,
   };
 }
 

--- a/apps/cli/src/lib/session/pid-registry.test.ts
+++ b/apps/cli/src/lib/session/pid-registry.test.ts
@@ -18,6 +18,8 @@ describe('pid session registry', () => {
       agent: 'claude',
       sessionId: 'abc-123-uuid',
       cwd: '/home/x/repo',
+      actor: 'ada@example.com',
+      initiatedBy: 'human',
       launchId: 'launch-abc',
       terminalId: 'CL-1700000000000-1',
       tmuxPane: '%18',
@@ -32,6 +34,9 @@ describe('pid session registry', () => {
     expect(got?.launchId).toBe('launch-abc');
     expect(got?.terminalId).toBe('CL-1700000000000-1');
     expect(got?.tmuxPane).toBe('%18');
+    // The actor stamped at spawn rides back so --active can show an owner (RUSH-2018).
+    expect(got?.actor).toBe('ada@example.com');
+    expect(got?.initiatedBy).toBe('human');
   });
 
   it('returns undefined for a pid with no entry', () => {

--- a/apps/cli/src/lib/session/pid-registry.ts
+++ b/apps/cli/src/lib/session/pid-registry.ts
@@ -27,6 +27,19 @@ export interface PidSessionEntry {
   sessionId?: string;
   cwd?: string;
   /**
+   * Resolved actor id (`resolveActor().id`) stamped at spawn — who initiated this
+   * run. A tailnet login/email for a resolved human, or `UNRESOLVED@<host>` when
+   * it can't be determined. Read back by the active-sessions path to surface an
+   * `owner` per session (RUSH-2018), so a co-located fleet shows who launched what.
+   */
+  actor?: string;
+  /**
+   * The actor's kind (`resolveActor().kind`): `'human'` for a person-initiated
+   * run, `'agent'` for one an agent spawned. Pairs with {@link actor} the same way
+   * `AGENTS_ACTOR` / `AGENTS_ACTOR_KIND` do on the exec env.
+   */
+  initiatedBy?: 'human' | 'agent';
+  /**
    * The launch id minted by `ag run` and exported to the child as
    * `AGENT_LAUNCH_ID`. The agent's SessionStart hook records the SAME id in its
    * own state file (`terminals/sessions/<pid>.json`, `launch_id`), so the two

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -204,6 +204,20 @@ export interface SessionMeta {
    */
   machine?: string;
   /**
+   * Resolved actor id (`resolveActor().id`) who initiated this session — a
+   * tailnet login/email for a resolved human, or `UNRESOLVED@<host>`. Persisted
+   * write-once at session creation and preserved across content rescans (kept
+   * out of the DB upsert's ON CONFLICT set). Undefined for rows created before
+   * actor stamping. RUSH-2018.
+   */
+  actor?: string;
+  /**
+   * The actor's kind (`resolveActor().kind`): `'human'` for a person-initiated
+   * run, `'agent'` for one an agent spawned. Pairs with {@link actor}, same
+   * split as `AGENTS_ACTOR` / `AGENTS_ACTOR_KIND` on the exec env. RUSH-2018.
+   */
+  initiatedBy?: 'human' | 'agent';
+  /**
    * True only for rows pulled from another machine over the live cross-machine
    * fan-out (`remote-list.ts`) — their transcript is on that peer's disk, so
    * reading/resuming has to hop back over SSH. Distinct from `machine`, which is


### PR DESCRIPTION
**feat / user-visible** — RUSH-2018 (P2 of the actor-provenance layer). Surfaces **who launched each run**: an owner column in `agents sessions --active` and write-once `actor` / `initiated_by` columns on the session index. Builds on RUSH-2028 (which fixed actor propagation across the SSH hop).

## What changed

| Surface | Change |
|---|---|
| `pid-registry.ts` | `actor` / `initiatedBy` on `PidSessionEntry`, stamped at spawn from `resolveActor()` (the 3 `writePidSessionEntry` sites in `exec.ts`). |
| `active.ts` | `owner` on `ActiveSession`, sourced from the pid entry (terminal / headless / tmux) and the teammate record (teams). Rides `--active --json` and the cross-machine fan-out via existing spreads. |
| `sessions.ts` | Owner column in the `--active` table. `ownerLabel` shortens a resolved actor id (email local-part); an unresolved-local run shows `-`, never a guessed owner. |
| `db.ts` + `types.ts` | `actor` / `initiated_by` columns (schema v18→v19 + `ALTER`), **kept OUT of the upsert `ON CONFLICT` set** so a content rescan never clobbers who launched the session. |
| `docs/06-observability.md` | New "Surfacing the owner" subsection + changelog fragment. |

## Run result (live, this box)

An actor-stamped live session read back through the real `--active` scan:

```
$ agents sessions --active --json --local   # row for the actor-stamped pid
  row found: true  kind=claude  owner="ada@example.com"

$ agents sessions --active --local          # table (id · agent · host · status · OWNER · badges · desc)
    019fc009 codex    tmux     idle     -        ssh←zion ... muqsit · Ye…
    -        claude   -        unknown  ada      ssh←zion ... viewing in terminal
```

The stamped run shows `owner=ada@example.com` in JSON and `ada` in the table's owner column; sessions that predate the change honestly show `-`.

## Tests

New/updated (all green locally): pid-registry round-trips actor; `serializeActiveSessionsForJson` carries `owner`; `ownerLabel` rendering (email local-part / non-email / unresolved / absent); `db-actor.test.ts` persists actor + **rescan-preserves** it via the `ON CONFLICT` exclusion; schema-version tests bumped to 19.

The 15 unrelated failures in the local full run (`sync/config` R2/keychain, codex/`exec`/`models` fixtures) reproduce **identically on clean `origin/main`** — environmental (headless Linux, no keychain / codex binary), not from this diff.

## Scope note

DB `actor`/`initiated_by` columns are fully plumbed (INSERT / VALUES / `rowToMeta`) and populated when a `SessionMeta` carries an actor; the automatic durable-record population the scanner joins on is **P3 (RUSH-2019)**, per the ticket's phasing. The live `--active` owner path is complete here.

Ticket: https://linear.app/getrush/issue/RUSH-2018
