### PR TITLE
feat(actor): durable sessionId->actor sidecar + teams lineage [RUSH-2019]

### DIFF
--- a/apps/cli/.changelog/next/rush-2019-lineage.md
+++ b/apps/cli/.changelog/next/rush-2019-lineage.md
@@ -1,0 +1,11 @@
+- **`agents sessions` attributes historical sessions to a person, and teams carry
+  spawn lineage (RUSH-2019).** Each run now writes a durable `sessionId -> actor`
+  sidecar at spawn (`~/.agents/.history/by-session/`, unlike the pruned pid
+  registry), and the session scanner joins it while indexing — so the write-once
+  `actor` / `initiated_by` columns added in RUSH-2018 populate automatically and the
+  durable `agents sessions` listing (not just `--active`) shows who launched each
+  session. Teammate spawns inherit the orchestrator's frozen actor and now record a
+  `parent_session_id` (the orchestrator's own `AGENTS_SESSION_ID`), so a team traces
+  back to the one human who started it and the spawn chain is walkable. Source:
+  `apps/cli/src/lib/session/actor-sidecar.ts`, `apps/cli/src/lib/exec.ts`,
+  `apps/cli/src/lib/session/db.ts`, `apps/cli/src/lib/teams/agents.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -93,9 +93,18 @@ each run, not just *what* is running:
   teammate record, so a co-located fleet no longer collapses to one anonymous
   account. `--active --json` carries the raw `owner` field for a consumer to join on.
 - **The session index** (`sessions.db`) carries `actor` and `initiated_by`
-  (`human`/`agent`) columns. They are **write-once at session creation** — a later
-  content rescan carries no actor and is deliberately kept out of the upsert's
-  `ON CONFLICT` update set, so the original owner is never clobbered by re-indexing.
+  (`human`/`agent`) columns, so the durable `agents sessions` listing attributes
+  historical sessions to a person, not just the live `--active` view. They are
+  **write-once at session creation** — a later content rescan carries no actor and
+  is deliberately kept out of the upsert's `ON CONFLICT` update set, so the original
+  owner is never clobbered by re-indexing.
+- **How the index gets the actor** — the transcript on disk records no actor, so at
+  spawn each run also writes a small **durable `sessionId -> actor` sidecar** under
+  `~/.agents/.history/by-session/` (unlike the pid-registry, this survives the
+  process). The scanner joins it as it indexes, filling the columns above. Teammates
+  inherit the orchestrator's frozen actor, so a whole team traces back to the one
+  human who started it; their records also carry a `parent_session_id` (the
+  orchestrator's session) so the spawn chain is walkable.
 
 ```bash
 agents events                          # recent activity across everything

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -21,6 +21,7 @@ import { getShimsDir, getHistoryDir } from './state.js';
 import { resolveCodexHome } from './codex-home.js';
 import { readCodexConfiguredModel } from './shims.js';
 import { writePidSessionEntry, extractSessionIdArg } from './session/pid-registry.js';
+import { writeSessionActorRecord } from './session/actor-sidecar.js';
 import { loadHookSessionIndex, resolveHookSessionId } from './session/hook-sessions.js';
 import { sessionIdMarkerLine } from './hosts/session-marker.js';
 import { recordRunName } from './session/run-names.js';
@@ -1061,10 +1062,11 @@ export async function execShimPassthrough(
     // wrapper, not the agent binary — the active scan resolves that by
     // walking the candidate's ancestors (readAncestorSessionEntry).
     if (child.pid) {
+      const passthroughSessionId = extractSessionIdArg(rawArgs);
       writePidSessionEntry({
         pid: child.pid,
         agent,
-        sessionId: extractSessionIdArg(rawArgs),
+        sessionId: passthroughSessionId,
         cwd,
         actor: resolveActor().id,
         initiatedBy: resolveActor().kind,
@@ -1072,6 +1074,16 @@ export async function execShimPassthrough(
         terminalId: process.env.AGENT_TERMINAL_ID,
         startedAtMs: Date.now(),
       });
+      // Durable sessionId -> actor record (RUSH-2019) so the scanner can attribute
+      // this session to a person after the pid dies. Best-effort; no-ops without id.
+      if (passthroughSessionId) {
+        writeSessionActorRecord({
+          sessionId: passthroughSessionId,
+          actor: resolveActor().id,
+          initiatedBy: resolveActor().kind,
+          startedAtMs: Date.now(),
+        });
+      }
     }
     child.on('exit', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
     child.on('error', (err) => {
@@ -1263,6 +1275,14 @@ async function runInTmux(options: ExecOptions, executable: string, args: string[
       tmuxPane: pane,
       startedAtMs: Date.now(),
     });
+    if (options.sessionId) {
+      writeSessionActorRecord({
+        sessionId: options.sessionId,
+        actor: resolveActor().id,
+        initiatedBy: resolveActor().kind,
+        startedAtMs: Date.now(),
+      });
+    }
   }
 
   // Recap a dead pane's tail into THIS shell's stderr. The pane-died hook
@@ -1490,6 +1510,14 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
       tmuxPane: process.env.TMUX_PANE,
       startedAtMs: Date.now(),
     });
+    if (options.sessionId) {
+      writeSessionActorRecord({
+        sessionId: options.sessionId,
+        actor: resolveActor().id,
+        initiatedBy: resolveActor().kind,
+        startedAtMs: Date.now(),
+      });
+    }
 
     // Mark startup time (time from function call to process spawn)
     timer.mark('startup');

--- a/apps/cli/src/lib/session/actor-sidecar.test.ts
+++ b/apps/cli/src/lib/session/actor-sidecar.test.ts
@@ -7,7 +7,7 @@ const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-sidecar-'));
 process.env.HOME = TEST_HOME;
 
 const { writeSessionActorRecord, readSessionActorRecord, loadSessionActorIndex } = await import('./actor-sidecar.js');
-const { getDB, closeDB, upsertSession, getSessionById } = await import('./db.js');
+const { getDB, closeDB, upsertSession, upsertSessionsBatch, getSessionById } = await import('./db.js');
 type SessionMeta = import('./types.js').SessionMeta;
 
 const FILES = path.join(TEST_HOME, 'files');
@@ -37,6 +37,15 @@ describe('session actor sidecar (RUSH-2019)', () => {
     const idx = loadSessionActorIndex();
     expect(idx.get('sid-a')?.actor).toBe('a@x.io');
     expect(idx.get('sid-b')?.initiatedBy).toBe('agent');
+  });
+
+  it('refuses a session id with path separators (no write outside by-session/)', () => {
+    // A caller-supplied `--session-id '../../evil'` must not escape the dir via
+    // path.join; the write is dropped and the read finds nothing.
+    writeSessionActorRecord({ sessionId: '../../evil', actor: 'mallory@x.io', initiatedBy: 'human', startedAtMs: 1 });
+    expect(readSessionActorRecord('../../evil')).toBeUndefined();
+    const escaped = path.join(TEST_HOME, '.agents', '.history', 'evil.json');
+    expect(fs.existsSync(escaped)).toBe(false);
   });
 });
 
@@ -81,5 +90,28 @@ describe('upsertSession joins the actor sidecar (RUSH-2019)', () => {
     const meta = { ...scanMeta('joined-3'), actor: 'explicit@example.com', initiatedBy: 'human' as const };
     upsertSession(meta, '');
     expect(getSessionById('joined-3')?.actor).toBe('explicit@example.com');
+  });
+
+  it('the batch scanner path joins the sidecar too (the real discover.ts flow)', () => {
+    // upsertSessionsBatch is what every harness scanner in discover.ts calls.
+    writeSessionActorRecord({ sessionId: 'batch-1', actor: 'linus@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    upsertSessionsBatch([
+      { meta: scanMeta('batch-1'), content: '' }, // has a sidecar -> filled
+      { meta: scanMeta('batch-2'), content: '' }, // no sidecar -> stays null
+    ]);
+    expect(getSessionById('batch-1')?.actor).toBe('linus@example.com');
+    expect(getSessionById('batch-2')?.actor).toBeUndefined();
+  });
+
+  it('a rescan through the batch path does not clobber a stored owner', () => {
+    writeSessionActorRecord({ sessionId: 'batch-3', actor: 'grace@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    upsertSessionsBatch([{ meta: scanMeta('batch-3'), content: '' }]);
+    // Rescan: same id, new content, sidecar removed — the stored owner must persist
+    // (ON CONFLICT excludes actor/initiated_by).
+    fs.rmSync(path.join(TEST_HOME, '.agents', '.history', 'by-session', 'batch-3.json'), { force: true });
+    upsertSessionsBatch([{ meta: { ...scanMeta('batch-3'), topic: 'rescanned' }, content: '' }]);
+    const meta = getSessionById('batch-3');
+    expect(meta?.topic).toBe('rescanned');
+    expect(meta?.actor).toBe('grace@example.com');
   });
 });

--- a/apps/cli/src/lib/session/actor-sidecar.test.ts
+++ b/apps/cli/src/lib/session/actor-sidecar.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-sidecar-'));
+process.env.HOME = TEST_HOME;
+
+const { writeSessionActorRecord, readSessionActorRecord, loadSessionActorIndex } = await import('./actor-sidecar.js');
+const { getDB, closeDB, upsertSession, getSessionById } = await import('./db.js');
+type SessionMeta = import('./types.js').SessionMeta;
+
+const FILES = path.join(TEST_HOME, 'files');
+fs.mkdirSync(FILES, { recursive: true });
+
+/**
+ * RUSH-2019 (P3): the durable sessionId -> actor sidecar makes the session
+ * scanner able to attribute a transcript to a person after the launching process
+ * is gone. Two things must hold: the record round-trips on disk, and the DB
+ * upsert JOINS it to fill the write-once actor column when the scanned meta
+ * carries none.
+ */
+describe('session actor sidecar (RUSH-2019)', () => {
+  it('round-trips a written record and skips one with no session id', () => {
+    writeSessionActorRecord({ sessionId: 'sid-1', actor: 'ada@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    const got = readSessionActorRecord('sid-1');
+    expect(got?.actor).toBe('ada@example.com');
+    expect(got?.initiatedBy).toBe('human');
+    // No id -> no file written, and a read of an absent id is undefined.
+    writeSessionActorRecord({ sessionId: '', actor: 'x', initiatedBy: 'human', startedAtMs: 1 });
+    expect(readSessionActorRecord('missing')).toBeUndefined();
+  });
+
+  it('loadSessionActorIndex surfaces every record keyed by session id', () => {
+    writeSessionActorRecord({ sessionId: 'sid-a', actor: 'a@x.io', initiatedBy: 'human', startedAtMs: 1 });
+    writeSessionActorRecord({ sessionId: 'sid-b', actor: 'b@x.io', initiatedBy: 'agent', startedAtMs: 2 });
+    const idx = loadSessionActorIndex();
+    expect(idx.get('sid-a')?.actor).toBe('a@x.io');
+    expect(idx.get('sid-b')?.initiatedBy).toBe('agent');
+  });
+});
+
+/**
+ * The DB join is the whole point: a scan builds a SessionMeta with NO actor (the
+ * transcript can't carry one), upsertSession reads the sidecar and fills the
+ * column — so `agents sessions` attributes historical sessions to a person.
+ */
+describe('upsertSession joins the actor sidecar (RUSH-2019)', () => {
+  beforeAll(() => {
+    fs.mkdirSync(FILES, { recursive: true });
+    getDB(); // migrate a fresh home
+  });
+  afterAll(() => {
+    closeDB();
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  function scanMeta(id: string): SessionMeta {
+    const filePath = path.join(FILES, `${id}.jsonl`);
+    fs.writeFileSync(filePath, '');
+    // No actor field — exactly what the transcript scanner produces.
+    return { id, shortId: id.slice(0, 8), agent: 'claude', timestamp: '2026-08-01T10:00:00.000Z', filePath };
+  }
+
+  it('fills actor/initiatedBy from the sidecar when the scanned meta has none', () => {
+    writeSessionActorRecord({ sessionId: 'joined-1', actor: 'grace@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    upsertSession(scanMeta('joined-1'), '');
+    const meta = getSessionById('joined-1');
+    expect(meta?.actor).toBe('grace@example.com');
+    expect(meta?.initiatedBy).toBe('human');
+  });
+
+  it('leaves actor null when no sidecar record exists (honest unattributed row)', () => {
+    upsertSession(scanMeta('joined-2'), '');
+    const meta = getSessionById('joined-2');
+    expect(meta?.actor).toBeUndefined();
+  });
+
+  it('an explicit meta.actor wins over the sidecar (caller-provided identity)', () => {
+    writeSessionActorRecord({ sessionId: 'joined-3', actor: 'sidecar@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    const meta = { ...scanMeta('joined-3'), actor: 'explicit@example.com', initiatedBy: 'human' as const };
+    upsertSession(meta, '');
+    expect(getSessionById('joined-3')?.actor).toBe('explicit@example.com');
+  });
+});

--- a/apps/cli/src/lib/session/actor-sidecar.ts
+++ b/apps/cli/src/lib/session/actor-sidecar.ts
@@ -1,0 +1,98 @@
+/**
+ * Durable sessionId -> actor sidecar (RUSH-2019, P3 lineage).
+ *
+ * The actor behind a run is resolved at spawn (`resolveActor()`), but the session
+ * transcript on disk carries no record of it — so the scanner that indexes those
+ * transcripts into `sessions.db` (`discover.ts` -> `upsertSessionsBatch`) has
+ * nothing to attribute a session to a person with. The pid-registry answers this
+ * for LIVE processes (`--active` owner, RUSH-2018), but it lives under `.cache`
+ * and is pruned when the pid dies, so it can't back a DURABLE, historical listing.
+ *
+ * This module writes one small, durable record per launched session — keyed by
+ * session id, under `~/.agents/.history` (never pruned) — that the scanner joins
+ * on to fill the write-once `actor` / `initiated_by` columns. Best-effort
+ * throughout: a failed write or a corrupt file degrades to an unattributed row,
+ * never throws into the launch or the scan path.
+ */
+import fs from 'fs';
+import path from 'path';
+import { getHistoryDir } from '../state.js';
+
+export interface SessionActorRecord {
+  sessionId: string;
+  /** Resolved actor id (`resolveActor().id`) — the responsible human/agent. */
+  actor: string;
+  /** Actor kind (`resolveActor().kind`). */
+  initiatedBy: 'human' | 'agent';
+  startedAtMs: number;
+}
+
+function sidecarDir(): string {
+  return path.join(getHistoryDir(), 'by-session');
+}
+
+function recordPath(sessionId: string): string {
+  return path.join(sidecarDir(), `${sessionId}.json`);
+}
+
+/**
+ * Record the actor a session was launched under. Never throws — the sidecar is
+ * an attribution optimization; a session with no record simply scans unattributed.
+ * No-ops without a concrete session id (nothing to key on).
+ */
+export function writeSessionActorRecord(record: SessionActorRecord): void {
+  if (!record.sessionId) return;
+  try {
+    fs.mkdirSync(sidecarDir(), { recursive: true });
+    fs.writeFileSync(recordPath(record.sessionId), JSON.stringify(record), 'utf8');
+  } catch {
+    /* degrade to an unattributed row */
+  }
+}
+
+/** Read one session's actor record. Returns undefined if absent/corrupt. */
+export function readSessionActorRecord(sessionId: string): SessionActorRecord | undefined {
+  if (!sessionId) return undefined;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(recordPath(sessionId), 'utf8');
+  } catch {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && typeof parsed.sessionId === 'string' && typeof parsed.actor === 'string') {
+      return parsed as SessionActorRecord;
+    }
+  } catch {
+    /* unparseable */
+  }
+  return undefined;
+}
+
+/**
+ * Load every session actor record into a `sessionId -> record` map, for the scan
+ * path to join a whole batch of sessions in one directory read instead of a
+ * stat-per-row. Best-effort: unreadable/corrupt files are skipped, a missing dir
+ * yields an empty map.
+ */
+export function loadSessionActorIndex(): Map<string, SessionActorRecord> {
+  const out = new Map<string, SessionActorRecord>();
+  let files: string[];
+  try {
+    files = fs.readdirSync(sidecarDir()).filter(f => f.endsWith('.json'));
+  } catch {
+    return out;
+  }
+  for (const f of files) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(path.join(sidecarDir(), f), 'utf8'));
+      if (parsed && typeof parsed === 'object' && typeof parsed.sessionId === 'string' && typeof parsed.actor === 'string') {
+        out.set(parsed.sessionId, parsed as SessionActorRecord);
+      }
+    } catch {
+      /* raced with a writer, or corrupt — skip */
+    }
+  }
+  return out;
+}

--- a/apps/cli/src/lib/session/actor-sidecar.ts
+++ b/apps/cli/src/lib/session/actor-sidecar.ts
@@ -31,6 +31,17 @@ function sidecarDir(): string {
   return path.join(getHistoryDir(), 'by-session');
 }
 
+/**
+ * A session id safe to use as a filename: no path separators or `..`, so a
+ * caller-supplied `--session-id` can never escape `by-session/` via
+ * `path.join`. Session ids are uuids in practice; anything else is rejected
+ * rather than sanitized, so a bad id degrades to no record, never a write
+ * outside the directory.
+ */
+function isSafeSessionId(sessionId: string): boolean {
+  return sessionId.length > 0 && !/[/\\]/.test(sessionId) && sessionId !== '.' && sessionId !== '..';
+}
+
 function recordPath(sessionId: string): string {
   return path.join(sidecarDir(), `${sessionId}.json`);
 }
@@ -41,7 +52,7 @@ function recordPath(sessionId: string): string {
  * No-ops without a concrete session id (nothing to key on).
  */
 export function writeSessionActorRecord(record: SessionActorRecord): void {
-  if (!record.sessionId) return;
+  if (!isSafeSessionId(record.sessionId)) return;
   try {
     fs.mkdirSync(sidecarDir(), { recursive: true });
     fs.writeFileSync(recordPath(record.sessionId), JSON.stringify(record), 'utf8');
@@ -52,7 +63,7 @@ export function writeSessionActorRecord(record: SessionActorRecord): void {
 
 /** Read one session's actor record. Returns undefined if absent/corrupt. */
 export function readSessionActorRecord(sessionId: string): SessionActorRecord | undefined {
-  if (!sessionId) return undefined;
+  if (!isSafeSessionId(sessionId)) return undefined;
   let raw: string;
   try {
     raw = fs.readFileSync(recordPath(sessionId), 'utf8');

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -15,6 +15,7 @@ import { parseSession } from './parse.js';
 import { extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
 import { getSessionsDir, getSessionsDbPath } from '../state.js';
 import { machineForSessionFile } from './origin-machine.js';
+import { loadSessionActorIndex, readSessionActorRecord } from './actor-sidecar.js';
 
 const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
@@ -987,6 +988,11 @@ function resolveMachine(meta: SessionMeta): string {
  */
 export function upsertSession(meta: SessionMeta, content: string, scan?: ScanStamp): void {
   meta = enrichCachedSessionMeta(meta);
+  // Join the durable sessionId -> actor sidecar (RUSH-2019) when the caller
+  // didn't already carry an actor, so a scanned transcript still attributes to a
+  // person. ON CONFLICT excludes actor/initiated_by, so this only ever fills a
+  // fresh row — a rescan never overwrites the stored owner.
+  const actorRec = meta.actor ? undefined : readSessionActorRecord(meta.id);
   const db = getDB();
   const { upsert, delText, insText, readLabel } = stmts(db);
   const row: SessionRow = {
@@ -1025,8 +1031,8 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     linear_project: meta.linearProject ?? null,
     linear_project_url: meta.linearProjectUrl ?? null,
     machine: resolveMachine(meta),
-    actor: meta.actor ?? null,
-    initiated_by: meta.initiatedBy ?? null,
+    actor: meta.actor ?? actorRec?.actor ?? null,
+    initiated_by: meta.initiatedBy ?? actorRec?.initiatedBy ?? null,
   };
 
   const txn = db.transaction(() => {
@@ -1053,6 +1059,11 @@ export function upsertSessionsBatch(
   const db = getDB();
   const { upsert, delText, insText, readLabel } = stmts(db);
   const now = Date.now();
+  // One directory read for the whole batch: join the durable sessionId -> actor
+  // sidecar (RUSH-2019) so scanned transcripts attribute to a person. Only used
+  // for entries whose meta carries no actor; ON CONFLICT excludes the column, so
+  // this fills fresh rows without ever clobbering a stored owner on rescan.
+  const actorIndex = loadSessionActorIndex();
   // Persist the Claude resumable-parse continuation (parser_state + content_text)
   // alongside the stamp. On a full/incremental Claude parse the caller passes the
   // serialized newState + accumulated user doc so the NEXT scan can resume from
@@ -1152,8 +1163,8 @@ export function upsertSessionsBatch(
         linear_project: meta.linearProject ?? null,
         linear_project_url: meta.linearProjectUrl ?? null,
     machine: resolveMachine(meta),
-        actor: meta.actor ?? null,
-        initiated_by: meta.initiatedBy ?? null,
+        actor: meta.actor ?? actorIndex.get(meta.id)?.actor ?? null,
+        initiated_by: meta.initiatedBy ?? actorIndex.get(meta.id)?.initiatedBy ?? null,
       });
       delText.run(meta.id);
       insText.run(

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -1522,6 +1522,15 @@ export class AgentManager {
     await this.initialize();
     const resolvedMode = resolveMode(mode, this.defaultMode);
 
+    // Lineage (RUSH-2019): when the caller didn't name a parent, inherit the
+    // orchestrator's own session id from its env (exec.ts stamps AGENTS_SESSION_ID
+    // onto every agent process). A team spawned from inside a running agent then
+    // records which session created it, so the spawn chain traces back to a parent
+    // session; a team started outside any agent simply carries none.
+    if (!parentSessionId) {
+      parentSessionId = process.env.AGENTS_SESSION_ID ?? null;
+    }
+
     // Enforce: teammate names are unique within a team.
     const siblings = await this.listByTask(taskName);
     if (name && siblings.some((a) => a.name === name)) {


### PR DESCRIPTION
**feat / user-visible** — RUSH-2019 (P3 of the actor-provenance layer). Makes the durable `agents sessions` listing attribute historical sessions to a person (not just the live `--active` view from RUSH-2018), and gives teams walkable spawn lineage. Depends on P2 (#1621, merged).

## The gap this closes

RUSH-2018 added write-once `actor`/`initiated_by` columns to `sessions.db`, but the transcript on disk carries no actor — so a scanned/historical session had nothing to fill them with (only live `--active` had the pid-registry). This wires the durable source.

## What changed

| Surface | Change |
|---|---|
| `actor-sidecar.ts` (new) | Durable `sessionId -> actor` record under `~/.agents/.history/by-session/` — survives the process (the pid registry lives under `.cache` and is pruned). Best-effort read/write/index. |
| `exec.ts` | Write the sidecar at the 3 spawn sites (where `sessionId` + actor are known), beside the existing pid-registry stamp. |
| `db.ts` | The scanner **joins** the sidecar at the upsert chokepoint (single + batch, one dir read per batch), filling `actor`/`initiated_by` when the scanned meta has none. `ON CONFLICT` still excludes them, so a rescan never clobbers a stored owner. |
| `teams/agents.ts` | Default `parentSessionId` to the orchestrator's `AGENTS_SESSION_ID`, so a team spawned inside a running agent records which session created it. Teammates already inherit the frozen actor (RUSH-2028). |
| `docs/06-observability.md` + changelog | Updated. |

## Run result (live, compiled code)

Sidecar written at "spawn", then a scan-shaped `upsertSession` with **no** actor on the meta:

```
DB row after scan-join:            actor="bisma@example.com" initiatedBy="human"   # rowToMeta / getSessionById
durable `sessions --json` emits:   actor="bisma@example.com" initiatedBy="human"   # serializeSessionsJson
```

The join fills the write-once column from the sidecar; a row with no sidecar stays honestly unattributed; an explicit `meta.actor` wins over the sidecar.

## Tests

`actor-sidecar.test.ts` (new): record round-trip + index; the DB join through **real SQLite** (scan meta with no actor + sidecar → actor filled; no sidecar → null; explicit `meta.actor` wins). All green; the only local full-run failures are the pre-existing environmental `sync/config` (R2/keychain) ones, identical on `origin/main`.

## Scope note

`created_by` (named in the ticket) is intentionally omitted — RUSH-2028 already added `actor` (= `resolveActor().id`) to the teammate record, so `created_by` would duplicate it; `parent_session_id` carries the lineage the ticket wanted. Stated here per the no-silent-scope-drop convention.

Ticket: https://linear.app/getrush/issue/RUSH-2019
