### PR TITLE
feat(actor): actor on events, routines, and browser tasks [RUSH-2020]

### DIFF
--- a/apps/cli/.changelog/next/rush-2020-surfaces.md
+++ b/apps/cli/.changelog/next/rush-2020-surfaces.md
@@ -1,0 +1,10 @@
+- **Actor provenance reaches events, routines, and browser tasks (RUSH-2020).**
+  Completes the actor layer's coverage beyond sessions: every emitted **event** now
+  records `actor` + `kind` through the audit origin (so `agents events` stats carry
+  a `byActor` breakdown); a **routine** stamps its creator's actor at creation and
+  injects it into each fired run's env, so an unattended cron traces back to the
+  person who scheduled it instead of `UNRESOLVED@<host>` — its run records gain
+  `actor` (creator) and `triggeredBy` (who kicked off that run); a **browser task**
+  records the `owner` who launched it, on the live task and in history. Source:
+  `apps/cli/src/lib/events.ts`, `apps/cli/src/lib/runner.ts`,
+  `apps/cli/src/lib/routines.ts`, `apps/cli/src/lib/browser/{types,service}.ts`.

--- a/apps/cli/.changelog/next/rush-2020-surfaces.md
+++ b/apps/cli/.changelog/next/rush-2020-surfaces.md
@@ -1,10 +1,11 @@
 - **Actor provenance reaches events, routines, and browser tasks (RUSH-2020).**
   Completes the actor layer's coverage beyond sessions: every emitted **event** now
   records `actor` + `kind` through the audit origin (so `agents events` stats carry
-  a `byActor` breakdown); a **routine** stamps its creator's actor at creation and
-  injects it into each fired run's env, so an unattended cron traces back to the
-  person who scheduled it instead of `UNRESOLVED@<host>` — its run records gain
-  `actor` (creator) and `triggeredBy` (who kicked off that run); a **browser task**
-  records the `owner` who launched it, on the live task and in history. Source:
+  a `byActor` breakdown in `agents logs stats`); a **routine** stamps its creator's
+  actor id at creation and seeds it into each fired run's env (`AGENTS_ACTOR`), so an
+  unattended cron's session and events attribute to the person who scheduled it
+  instead of `UNRESOLVED@<host>` — its run records gain `actor` (creator) and
+  `triggeredBy` (who kicked off that run); a **browser task** records the `owner` who
+  launched it, on the live task and in history. Source:
   `apps/cli/src/lib/events.ts`, `apps/cli/src/lib/runner.ts`,
   `apps/cli/src/lib/routines.ts`, `apps/cli/src/lib/browser/{types,service}.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -108,11 +108,14 @@ each run, not just *what* is running:
 - **Beyond sessions — events, routines, and browser tasks carry the actor too.**
   Every emitted **event** records `actor` + `kind` (via the audit origin), so
   `agents events` and its stats group by who did it (a `byActor` breakdown). A
-  **routine** stamps its creator's actor at creation and injects it into each fired
-  run's env, so an unattended cron traces back to the person who scheduled it (not
-  the `UNRESOLVED@<host>` a live resolve would give); its run records carry `actor`
-  (the creator) and `triggeredBy` (who kicked off that specific run). A **browser
-  task** records the `owner` who launched it, on the live task and in history.
+  **routine** stamps its creator's actor id at creation and seeds it into each fired
+  run's env (`AGENTS_ACTOR`), so an unattended cron's session and events attribute to
+  the person who scheduled it (not the `UNRESOLVED@<host>` a live resolve would give)
+  rather than the local box; its run records carry `actor` (the creator) and
+  `triggeredBy` (who kicked off that specific run). Only the actor *id* rides along —
+  the creator's git name/email are not stored, so git-author credit is out of scope
+  for scheduled runs. A **browser task** records the `owner` who launched it, on the
+  live task and in history.
 
 ```bash
 agents events                          # recent activity across everything

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -105,6 +105,14 @@ each run, not just *what* is running:
   inherit the orchestrator's frozen actor, so a whole team traces back to the one
   human who started it; their records also carry a `parent_session_id` (the
   orchestrator's session) so the spawn chain is walkable.
+- **Beyond sessions — events, routines, and browser tasks carry the actor too.**
+  Every emitted **event** records `actor` + `kind` (via the audit origin), so
+  `agents events` and its stats group by who did it (a `byActor` breakdown). A
+  **routine** stamps its creator's actor at creation and injects it into each fired
+  run's env, so an unattended cron traces back to the person who scheduled it (not
+  the `UNRESOLVED@<host>` a live resolve would give); its run records carry `actor`
+  (the creator) and `triggeredBy` (who kicked off that specific run). A **browser
+  task** records the `owner` who launched it, on the live task and in history.
 
 ```bash
 agents events                          # recent activity across everything

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -398,6 +398,13 @@ async function runStats(opts: { since?: string; json?: boolean }): Promise<void>
     }
   }
 
+  if (Object.keys(s.byActor).length) {
+    console.log(chalk.bold('\n  By actor:'));
+    for (const [k, v] of Object.entries(s.byActor).sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${k.padEnd(30)} ${v}`);
+    }
+  }
+
   console.log();
 }
 

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -45,6 +45,7 @@ import {
   uploadViaFileChooser,
 } from './upload.js';
 import { emit } from '../events.js';
+import { resolveActor } from '../actor.js';
 import { sshExecAsync } from '../ssh-exec.js';
 import type { TargetFilter } from './types.js';
 
@@ -423,6 +424,7 @@ export class BrowserService {
       currentTabId: undefined,
       createdAt: Date.now(),
       pid: conn.pid,
+      owner: resolveActor().id, // who launched this browser task (RUSH-2020)
     };
 
     // For Electron, get the existing window as the tab
@@ -2496,6 +2498,7 @@ export class BrowserService {
       endedAt: Date.now(),
       domains,
       tabCount: Object.keys(task.tabs).length,
+      ...(task.owner ? { owner: task.owner } : {}), // carry who launched it (RUSH-2020)
     });
 
     // Keep only last 50 entries

--- a/apps/cli/src/lib/browser/types.ts
+++ b/apps/cli/src/lib/browser/types.ts
@@ -74,6 +74,11 @@ export interface Task {
   createdAt: number;
   pid: number;
   /**
+   * Resolved actor id (`resolveActor().id`) stamped at task start — who launched
+   * this browser task. Optional: tasks persisted before RUSH-2020 carry none.
+   */
+  owner?: string;
+  /**
    * Per-tab snapshot of the last ref listing captured for that tab
    * (shortId -> {descriptors, opts}). Persisted to tasks.json so a later
    * `click`/`type <ref>` can self-heal a drifted ref — the cached `opts` let
@@ -120,6 +125,8 @@ export interface HistoricalTask {
   endedAt: number;
   domains: string[];
   tabCount: number;
+  /** Actor id who launched the task (RUSH-2020); absent for pre-RUSH-2020 history. */
+  owner?: string;
 }
 
 export type IPCAction =

--- a/apps/cli/src/lib/events.test.ts
+++ b/apps/cli/src/lib/events.test.ts
@@ -9,6 +9,7 @@ import {
   detectCaller,
   _resetForTest,
 } from './events.js';
+import { resetActorCache } from './actor.js';
 
 const tempDirs: string[] = [];
 
@@ -71,6 +72,24 @@ describe('events', () => {
 
       const records = query({});
       expect(records[0].level).toBe('warn');
+    });
+
+    it('stamps the resolved actor + kind on every record (RUSH-2020)', () => {
+      // Force an inherited actor via env so the resolve is deterministic offline.
+      process.env.AGENTS_ACTOR = 'ada@example.com';
+      process.env.AGENTS_ACTOR_KIND = 'human';
+      resetActorCache();
+      try {
+        setupLogsDir();
+        emit('info', { module: 'test' });
+        const rec = query({})[0];
+        expect(rec.actor).toBe('ada@example.com');
+        expect(rec.kind).toBe('human');
+      } finally {
+        delete process.env.AGENTS_ACTOR;
+        delete process.env.AGENTS_ACTOR_KIND;
+        resetActorCache();
+      }
     });
 
     it('assigns debug level to debug events', () => {
@@ -342,6 +361,23 @@ describe('events', () => {
       expect(s.byEvent['secrets.get']).toBe(1);
       expect(s.byModule.secrets).toBe(1);
       expect(s.fileCount).toBe(1);
+    });
+
+    it('groups events by actor (RUSH-2020)', () => {
+      process.env.AGENTS_ACTOR = 'grace@example.com';
+      process.env.AGENTS_ACTOR_KIND = 'human';
+      resetActorCache();
+      try {
+        setupLogsDir();
+        emit('info', { module: 'test' });
+        emit('warn', { module: 'test' });
+        const s = stats({ days: 1 });
+        expect(s.byActor['grace@example.com']).toBe(2);
+      } finally {
+        delete process.env.AGENTS_ACTOR;
+        delete process.env.AGENTS_ACTOR_KIND;
+        resetActorCache();
+      }
     });
   });
 

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -20,6 +20,7 @@ import { gzipSync, gunzipSync } from 'node:zlib';
 import { parseSshConnection } from './session/provenance.js';
 import { ensureLockTarget, withFileLock } from './fs-atomic.js';
 import { getUserAgentsDir } from './state.js';
+import { resolveActor, type ActorKind } from './actor.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -177,6 +178,10 @@ export interface EventMeta {
   osUser: string;
   transport: 'local' | 'ssh';
   sshClientIp?: string;
+  /** Resolved actor id — which human/agent is behind this event (RUSH-2020). */
+  actor?: string;
+  /** Actor kind (`human`/`agent`). */
+  kind?: ActorKind;
 }
 
 export interface EventPayload {
@@ -270,6 +275,7 @@ const SENSITIVE_PAYLOAD_KEY = /password|secret|token|api[-_]?key|auth/i;
 const RESERVED_META_KEYS = new Set([
   'ts', 'tz', 'tzName', 'hostname', 'platform', 'arch', 'pid', 'ppid',
   'event', 'level', 'caller', 'session', 'osUser', 'transport', 'sshClientIp',
+  'actor', 'kind',
 ]);
 
 function promptMarker(value: string): string {
@@ -432,6 +438,10 @@ interface AuditOrigin {
   osUser: string;
   transport: 'local' | 'ssh';
   sshClientIp?: string;
+  /** Resolved actor id (`resolveActor().id`) — which human/agent is behind this event. */
+  actor: string;
+  /** Actor kind (`resolveActor().kind`). */
+  kind: ActorKind;
 }
 
 /**
@@ -449,10 +459,13 @@ function auditOrigin(): AuditOrigin {
     // Container/edge cases where the uid has no passwd entry.
   }
   const ssh = process.env.SSH_CONNECTION ? parseSshConnection(process.env.SSH_CONNECTION) : undefined;
+  const actor = resolveActor();
   _origin = {
     osUser,
     transport: ssh ? 'ssh' : 'local',
     ...(ssh ? { sshClientIp: ssh.clientIp } : {}),
+    actor: actor.id,
+    kind: actor.kind,
   };
   return _origin;
 }
@@ -932,6 +945,8 @@ export interface EventStats {
   byEvent: Record<string, number>;
   byModule: Record<string, number>;
   byUser: Record<string, number>;
+  /** Event counts grouped by resolved actor id (the human/agent behind them). */
+  byActor: Record<string, number>;
   fileCount: number;
   totalBytes: number;
 }
@@ -947,6 +962,7 @@ export function stats(options: { days?: number } = {}): EventStats {
   const byEvent: Record<string, number> = {};
   const byModule: Record<string, number> = {};
   const byUser: Record<string, number> = {};
+  const byActor: Record<string, number> = {};
 
   for (const r of records) {
     const lvl = r.level ?? levelFor(r.event as EventType);
@@ -955,6 +971,7 @@ export function stats(options: { days?: number } = {}): EventStats {
     if (r.module) byModule[r.module] = (byModule[r.module] ?? 0) + 1;
     const user = `${r.osUser ?? '?'}@${r.hostname}`;
     byUser[user] = (byUser[user] ?? 0) + 1;
+    if (r.actor) byActor[r.actor] = (byActor[r.actor] ?? 0) + 1;
   }
 
   let fileCount = 0;
@@ -979,6 +996,7 @@ export function stats(options: { days?: number } = {}): EventStats {
     byEvent,
     byModule,
     byUser,
+    byActor,
     fileCount,
     totalBytes,
   };

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -262,6 +262,30 @@ describe('writeJob atomic persistence', () => {
       deleteJob(name);
     }
   });
+
+  it('stamps the creator actor at creation and preserves it across an edit (RUSH-2020)', () => {
+    ensureAgentsDir();
+    const name = '__test-actor-stamp-routine__';
+    const name2 = '__test-actor-pinned-routine__';
+    try {
+      writeJob({ name, schedule: '0 3 * * *', agent: 'claude', prompt: 'p' } as JobConfig);
+      const created = readJob(name);
+      // A fresh routine gets the current resolver stamped (non-empty id).
+      expect(created?.actor).toBeTruthy();
+      // An edit re-writes the loaded config (which already carries actor) — the
+      // original creator is preserved, not overwritten with the editor.
+      writeJob({ ...created!, prompt: 'edited' } as JobConfig);
+      const after = readJob(name);
+      expect(after?.prompt).toBe('edited');
+      expect(after?.actor).toBe(created?.actor);
+      // An explicit actor on a new config is kept as-is.
+      writeJob({ name: name2, schedule: '0 3 * * *', agent: 'claude', prompt: 'p', actor: 'pinned@example.com' } as JobConfig);
+      expect(readJob(name2)?.actor).toBe('pinned@example.com');
+    } finally {
+      deleteJob(name);
+      deleteJob(name2);
+    }
+  });
 });
 
 describe('normalizeTriggerEvent', () => {

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -18,6 +18,7 @@ import type { AgentId } from './types.js';
 import { ALL_AGENT_IDS } from './agents.js';
 import type { LoopConfig } from './loop.js';
 import { machineId, normalizeHost } from './machine-id.js';
+import { resolveActor } from './actor.js';
 
 /** Tool/site/directory allow-list for sandboxed job execution. */
 export interface JobAllowConfig {
@@ -237,6 +238,14 @@ export interface JobConfig {
   resume?: string;
   /** When set, executeJob runs this job through the loop driver instead of once. */
   loop?: LoopConfig;
+  /**
+   * Actor id of whoever CREATED this routine (`resolveActor().id`, stamped by
+   * `writeJob` at creation and preserved across edits). Propagated into each
+   * fired run's env and RunMeta so an unattended cron traces back to the person
+   * who scheduled it, not the `UNRESOLVED@<host>` a live resolve would give.
+   * RUSH-2020.
+   */
+  actor?: string;
 }
 
 /** Metadata for a single job execution, persisted as JSON in the run directory. */
@@ -267,6 +276,18 @@ export interface RunMeta {
   cloudTaskId?: string;
   /** Cloud provider id when the run was cloud-dispatched. */
   cloudProvider?: string;
+  /**
+   * Actor id of the routine's CREATOR (stamped at creation, carried from the job
+   * config). Answers "whose scheduled run is this" for an unattended cron fire,
+   * where resolving the actor live would only yield `UNRESOLVED@<host>`. RUSH-2020.
+   */
+  actor?: string;
+  /**
+   * Actor id that TRIGGERED this particular run (`resolveActor().id` at fire
+   * time): a person for a manual `agents routines run`, `UNRESOLVED@<host>` for
+   * an unattended scheduled fire. Distinct from {@link actor} (the creator).
+   */
+  triggeredBy?: string;
 }
 
 /**
@@ -505,6 +526,10 @@ function readJobFile(filePath: string): JobConfig | null {
  */
 export function writeJob(config: JobConfig): void {
   ensureAgentsDir();
+  // Stamp the creator once (RUSH-2020). An edit re-writes a config loaded from
+  // disk, which already carries `actor`, so this preserves the original creator;
+  // only a brand-new routine (no actor yet) gets the current resolver.
+  if (!config.actor) config.actor = resolveActor().id;
   const jobsDir = getRoutinesDir();
   const ymlPath = safeJoin(jobsDir, config.name + '.yml');
   const yamlPath = safeJoin(jobsDir, config.name + '.yaml');

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -45,6 +45,7 @@ import {
   type ExecEffort,
   type FallbackEntry,
 } from './exec.js';
+import { resolveActor } from './actor.js';
 import type { LoopDeps } from './loop.js';
 import { loadTask as loadHostTask } from './hosts/tasks.js';
 import { reconcileTask as reconcileHostTask } from './hosts/reconcile.js';
@@ -607,6 +608,29 @@ function spawnJobAttempt(
  * Single-shot path: pre-flight version/account selection + mid-run rate-limit
  * failover across healthy same-agent accounts (RUSH-1016).
  */
+/**
+ * Actor provenance for a routine run (RUSH-2020): `actor` is the routine's
+ * CREATOR (carried from the job config), `triggeredBy` is whoever kicked off THIS
+ * run (`resolveActor().id` — a person for a manual run, `UNRESOLVED@<host>` for an
+ * unattended scheduled fire). Spread into every RunMeta so a fired cron traces
+ * back to the person who scheduled it.
+ */
+function runProvenance(config: JobConfig): { actor?: string; triggeredBy: string } {
+  return { ...(config.actor ? { actor: config.actor } : {}), triggeredBy: resolveActor().id };
+}
+
+/**
+ * Inject the routine creator's actor into a run's base env so the fired agent
+ * INHERITS it (the `AGENTS_ACTOR` path in actor.ts) instead of re-resolving to
+ * `UNRESOLVED@<host>` on an unattended fire — so its session, events, and commits
+ * all attribute to the person who scheduled the routine (RUSH-2020). Mutates and
+ * returns the same env object for call-site brevity.
+ */
+function injectRoutineActor(env: Record<string, string>, config: JobConfig): Record<string, string> {
+  if (config.actor && !env.AGENTS_ACTOR) env.AGENTS_ACTOR = config.actor;
+  return env;
+}
+
 export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<RunResult> {
   const eligibility = checkJobDeviceEligibility(config);
   if (eligibility) {
@@ -661,9 +685,12 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
   const runDir = getRunDir(config.name, runId);
   fs.mkdirSync(runDir, { recursive: true });
 
-  const baseEnv = useSandbox
-    ? buildSpawnEnv(overlayHome!)
-    : { ...process.env } as Record<string, string>;
+  const baseEnv = injectRoutineActor(
+    useSandbox
+      ? buildSpawnEnv(overlayHome!)
+      : { ...process.env } as Record<string, string>,
+    config,
+  );
 
   // Workflows run via `agents run <workflow>` which delegates to claude under the hood.
   // Use 'claude' as the effective agent for report extraction and metadata when workflow is set.
@@ -673,6 +700,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
   const meta: RunMeta = {
     jobName: config.name,
     runId,
+    ...runProvenance(config),
     agent: effectiveAgent,
     ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
@@ -927,6 +955,7 @@ async function executeJobOnCloud(config: JobConfig, opts: { detached: boolean })
   const meta: RunMeta = {
     jobName: config.name,
     runId,
+    ...runProvenance(config),
     agent: config.agent,
     pid: null,
     spawnedAt: Date.now(),
@@ -999,6 +1028,7 @@ async function executeJobOnHost(config: JobConfig, opts: { detached: boolean }):
   const meta: RunMeta = {
     jobName: config.name,
     runId,
+    ...runProvenance(config),
     agent: config.agent,
     pid: null, // no local process — the run lives on the host
     spawnedAt: Date.now(),
@@ -1053,6 +1083,7 @@ async function executeCommandJobForeground(config: JobConfig): Promise<RunResult
   const meta: RunMeta = {
     jobName: config.name,
     runId,
+    ...runProvenance(config),
     command: config.command,
     pid: null,
     spawnedAt: Date.now(),
@@ -1209,9 +1240,12 @@ export async function executeJobDetached(config: JobConfig, hooks?: RoutineHooks
   const stdoutPath = path.join(runDir, 'stdout.log');
   const stdoutFd = fs.openSync(stdoutPath, 'w', 0o600);
 
-  const baseEnv = useSandbox
-    ? buildSpawnEnv(overlayHome!)
-    : { ...process.env } as Record<string, string>;
+  const baseEnv = injectRoutineActor(
+    useSandbox
+      ? buildSpawnEnv(overlayHome!)
+      : { ...process.env } as Record<string, string>,
+    config,
+  );
   const spawnEnv = dispatchesViaAgentsRun(config)
     ? (() => {
         const e = { ...baseEnv };
@@ -1226,6 +1260,7 @@ export async function executeJobDetached(config: JobConfig, hooks?: RoutineHooks
   const meta: RunMeta = {
     jobName: config.name,
     runId,
+    ...runProvenance(config),
     agent: effectiveAgent,
     ...(config.workflow ? { workflow: config.workflow } : {}),
     pid: null,
@@ -1345,6 +1380,7 @@ function executeCommandJobDetached(config: JobConfig, hooks?: RoutineHooks): Run
   const meta: RunMeta = {
     jobName: config.name,
     runId,
+    ...runProvenance(config),
     command: config.command,
     pid: null,
     spawnedAt: Date.now(),


### PR DESCRIPTION
**feat / user-visible** — RUSH-2020 (P4, final phase of the actor-provenance layer). Extends actor attribution beyond sessions to **events, routines, and browser tasks**. Depends on P1 (RUSH-2028).

## What changed

| Surface | Change |
|---|---|
| `events.ts` | `actor` + `kind` on the audit origin, added to the persisted-key allowlist and `EventRecord`. Every event inherits them via the single `...auditOrigin()` spread (incl. `session.start`). `stats()` gains a **`byActor`** breakdown. |
| `routines.ts` | `JobConfig.actor` stamped at creation in `writeJob` (preserved across edits — an edit re-writes the loaded config). `RunMeta` gains `actor` (creator) + `triggeredBy` (who fired this run). |
| `runner.ts` | `runProvenance(config)` spread into every `RunMeta`; `injectRoutineActor()` seeds `AGENTS_ACTOR` into both routine `baseEnv` sites, so a fired agent **inherits** the creator instead of re-resolving to `UNRESOLVED@<host>` on an unattended cron. |
| `browser/{types,service}.ts` | `owner` on `Task` + `HistoricalTask`, stamped at task start and carried into history. |
| `docs/06-observability.md` + changelog | Updated. |

## The key nuance

A cron fires **unattended** — resolving the actor live would yield `UNRESOLVED@<host>`. So the actor is the routine's **creator** (stamped at creation, carried in the config), injected into the fired run's env so its session/events/commits all attribute to the person who scheduled it. `triggeredBy` separately records who kicked off a given run (a person for a manual run).

## Run result (live)

Event emitted through compiled code with an inherited actor, read back via the real CLI:

```
$ agents events --json --module rush2020-e2e
  event -> actor="emma@example.com" kind="human"
```

## Tests

`events.test.ts`: an emitted event carries `actor` + `kind`; `stats` groups `byActor`. `routines.test.ts`: `writeJob` stamps the creator, preserves it across an edit, and keeps an explicit actor. All green; 403 passing across the events/routines/scheduler/watchdog/browser suites, only the pre-existing environmental `sync/config` failures remain (identical on `origin/main`).

## Scope note

The **browser `owner`** is a field stamp at the save sites — no unit test, because driving the browser task path needs a real Chrome (the repo's no-mocking rule). It's verified by typecheck + the type wiring; the field surfaces in `browser` history JSON. Stated here per the no-silent-scope convention.

Ticket: https://linear.app/getrush/issue/RUSH-2020
