### PR TITLE
fix(release): publish the CI-tested tree, not a drifted merge

### DIFF
--- a/apps/cli/.changelog/next/release-publish-ci-tested-tree.md
+++ b/apps/cli/.changelog/next/release-publish-ci-tested-tree.md
@@ -1,0 +1,12 @@
+- **Releases publish the CI-tested tree, not a drifted merge.** On a busy default
+  branch, unrelated PRs merging during a release PR's CI window made the
+  squash-merge tree diverge from what CI actually tested, so `release.sh` refused
+  to publish (`merged tree != built tree`) and the release stalled — every attempt
+  merged a version bump it could never tag. The publish now tags the exact release
+  commit the full matrix went green on (the PR head), letting the intervening
+  commits ride the next release; the merge commit is still tagged when its tree
+  matches (no drift). The `wait_for_ci_green` gate is unchanged, so the published
+  tarball is always a tree the full matrix validated. The tree-comparison decision
+  is extracted into `scripts/select-publish-commit.sh` and unit-tested against a
+  real git repo. Source: `apps/cli/scripts/release.sh`,
+  `apps/cli/scripts/select-publish-commit.sh`.

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -510,8 +510,9 @@ if $MAIN_AT_TARGET && ! $PHNX_TARGET_PUBLISHED && [[ -n "$MERGED_RELEASE_SHA" ]]
   CI_TESTED_HEAD="$(git rev-parse FETCH_HEAD)"
   [[ "$CI_TESTED_HEAD" == "$MERGED_RELEASE_HEAD" ]] \
     || die "fetched PR head ${CI_TESTED_HEAD:0:9} != recorded release head ${MERGED_RELEASE_HEAD:0:9} -- refusing catch-up publish"
-  [[ "$(git rev-parse "$CI_TESTED_HEAD^{tree}")" == "$(git rev-parse "$MERGED_RELEASE_SHA^{tree}")" ]] \
-    || die "merged release PR #$MERGED_RELEASE_PR tree differs from its CI-tested head -- refusing catch-up publish"
+  if [[ "$(git rev-parse "$CI_TESTED_HEAD^{tree}")" != "$(git rev-parse "$MERGED_RELEASE_SHA^{tree}")" ]]; then
+    yellow "$DEFAULT_BRANCH drifted since release PR #$MERGED_RELEASE_PR merged (concurrent merges); will tag + publish the CI-tested head ${CI_TESTED_HEAD:0:9}, not the drifted merge."
+  fi
   [[ "$(git show "$MERGED_RELEASE_SHA:apps/cli/package.json" | jq -r .version)" == "$TARGET" ]] \
     || die "merged release PR #$MERGED_RELEASE_PR is not version $TARGET"
 
@@ -707,18 +708,25 @@ phase_ok "clean $DEFAULT_BRANCH, bump $BUMP ($PHNX_LATEST -> $TARGET), type chec
 # just make sure the tag exists on the merged commit and is pushed.
 if $PHNX_TARGET_PUBLISHED; then
   green "$PHNX_PKG@$TARGET is already on the registry."
-  TAG_TARGET="${MERGED_RELEASE_SHA:-origin/$DEFAULT_BRANCH}"
-  [[ "$(git show "$TAG_TARGET:apps/cli/package.json" | jq -r .version)" == "$TARGET" ]] \
-    || die "refusing to create v$TARGET: $TAG_TARGET does not contain package version $TARGET"
-  VERIFIED_TAG_SHA="$(git rev-parse "$TAG_TARGET^{commit}")"
   REMOTE_TAG_SHA="$(remote_tag_commit "v$TARGET")"
   if [[ -z "$REMOTE_TAG_SHA" ]]; then
-    git tag -f "v$TARGET" "$VERIFIED_TAG_SHA" >/dev/null
+    # No tag yet: create it at the CI-tested release commit when we know it (a
+    # drift-fallback release tags the PR head, which may sit off the default
+    # branch), else at the merge commit / default branch.
+    TAG_TARGET="${CI_TESTED_HEAD:-${MERGED_RELEASE_SHA:-origin/$DEFAULT_BRANCH}}"
+    [[ "$(git show "$TAG_TARGET:apps/cli/package.json" | jq -r .version)" == "$TARGET" ]] \
+      || die "refusing to create v$TARGET: $TAG_TARGET does not contain package version $TARGET"
+    git tag -f "v$TARGET" "$(git rev-parse "$TAG_TARGET^{commit}")" >/dev/null
     git push origin "v$TARGET" && green "Pushed missing tag v$TARGET"
   else
-    [[ "$REMOTE_TAG_SHA" == "$VERIFIED_TAG_SHA" ]] \
-      || die "remote tag v$TARGET points at $REMOTE_TAG_SHA, not verified release commit $VERIFIED_TAG_SHA"
-    gray "Tag v$TARGET already points at the verified release commit."
+    # Already published + tagged: accept any tag that references version TARGET. A
+    # drift-fallback release tags the CI-tested PR head rather than the merge
+    # commit, so verify the tag's own tree carries TARGET instead of requiring it
+    # to equal the merge commit.
+    git fetch --quiet origin "refs/tags/v$TARGET:refs/tags/v$TARGET" 2>/dev/null || true
+    [[ "$(git show "v$TARGET:apps/cli/package.json" 2>/dev/null | jq -r .version 2>/dev/null || echo "")" == "$TARGET" ]] \
+      || die "remote tag v$TARGET points at $REMOTE_TAG_SHA, which is not version $TARGET"
+    gray "Tag v$TARGET already present for the published release."
   fi
   exit 0
 fi
@@ -788,8 +796,9 @@ if $MAIN_AT_TARGET && ! $PHNX_TARGET_PUBLISHED; then
   fi
   [[ "$CI_TESTED_HEAD" == "$MERGED_RELEASE_HEAD" ]] \
     || die "fetched PR head ${CI_TESTED_HEAD:0:9} != recorded release head ${MERGED_RELEASE_HEAD:0:9} -- refusing catch-up publish"
-  [[ "$(git rev-parse "$CI_TESTED_HEAD^{tree}")" == "$(git rev-parse "$MERGED_RELEASE_SHA^{tree}")" ]] \
-    || die "merged release PR #$MERGED_RELEASE_PR tree differs from its CI-tested head -- refusing catch-up publish"
+  if [[ "$(git rev-parse "$CI_TESTED_HEAD^{tree}")" != "$(git rev-parse "$MERGED_RELEASE_SHA^{tree}")" ]]; then
+    yellow "$DEFAULT_BRANCH drifted since release PR #$MERGED_RELEASE_PR merged (concurrent merges); will tag + publish the CI-tested head ${CI_TESTED_HEAD:0:9}, not the drifted merge."
+  fi
   bold "Re-validating CI from merged release PR #$MERGED_RELEASE_PR before catch-up publish..."
   wait_for_ci_green "$MERGED_RELEASE_PR"
 fi
@@ -892,46 +901,59 @@ if ! $MAIN_AT_TARGET; then
   phase_ok "PR #$PR_NUMBER: CI matrix all-green, squash-merged"
 fi
 
-# Phase 4 (both paths): verify the merged tree + create/push the tag.
-phase "Verify merged tree + tag v$TARGET" "$THIS_HOST"
+# Phase 4 (both paths): resolve the CI-tested release commit + create/push the tag.
+phase "Verify CI-tested tree + tag v$TARGET" "$THIS_HOST"
 
-# ----- Resolve the merged commit + integrity guards (before any publish) -----
+# ----- Resolve the merge commit + the CI-tested release commit -----
+# The published tarball MUST be a tree the full CI matrix went green on. Normally
+# that is the commit that landed on the default branch. But the default branch is
+# busy: if unrelated PRs merge during this release PR's CI window, the squash-merge
+# lands on a newer base and its tree diverges from what CI actually tested. In that
+# case we do NOT publish the drifted, never-tested-as-a-unit merge tree -- we tag +
+# publish the exact release commit the matrix validated (the PR head), and the
+# commits that merged during the window ride the next release.
 git fetch --quiet origin "$DEFAULT_BRANCH"
 if $HISTORICAL_CATCHUP; then
   MERGED_SHA="$MERGED_RELEASE_SHA"
+  CI_COMMIT="$CI_TESTED_HEAD"                 # the merged release PR's CI-tested head
 else
   MERGED_SHA="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+  CI_COMMIT="$RELEASE_COMMIT"                 # the release PR head this run built + CI-tested
 fi
 MERGED_VER="$(git show "$MERGED_SHA:apps/cli/package.json" | jq -r .version)"
 [[ "$MERGED_VER" == "$TARGET" ]] || die "merged $DEFAULT_BRANCH is at $MERGED_VER, not $TARGET -- refusing to tag/publish"
-# A normal release compares against the release-commit tree. A catch-up release
-# skips that commit because main already carries TARGET, so compare against the
-# exact base tree that passed preflight and was built locally. Either way, a
-# concurrent merge must abort before the tag or registry can point at artifacts
-# produced from a different source tree.
-if $HISTORICAL_CATCHUP; then
-  EXPECTED_TREE="$(git rev-parse "$MERGED_RELEASE_SHA^{tree}")"
-else
-  EXPECTED_TREE="${BRANCH_TREE:-$(git rev-parse "$BASE_SHA^{tree}")}"
+
+# CI_COMMIT is, by construction, the commit GH Actions ran the full matrix on (a
+# normal run built it via commit-tree and pushed it as the PR head; a catch-up
+# fetched it from pull/<pr>/head and re-asserted CI green). Its tree is the
+# CI-tested tree. Re-assert its version so we never tag a mismatched commit.
+[[ -n "${CI_COMMIT:-}" ]] || die "internal: no CI-tested release commit resolved -- refusing to publish"
+[[ "$(git show "$CI_COMMIT:apps/cli/package.json" | jq -r .version)" == "$TARGET" ]] \
+  || die "CI-tested release commit ${CI_COMMIT:0:9} is not version $TARGET -- refusing to publish"
+
+# Tag the merge commit when its tree still matches the CI-tested tree (clean, keeps
+# the tag on the default branch); on concurrent-merge drift, tag the CI-tested
+# release commit so the published artifact is exactly what CI validated.
+PUBLISH_SHA="$(scripts/select-publish-commit.sh "$MERGED_SHA" "$CI_COMMIT")"
+if [[ "$PUBLISH_SHA" != "$MERGED_SHA" ]]; then
+  yellow "Concurrent merge drifted $DEFAULT_BRANCH during CI; tagging the CI-tested release commit ${PUBLISH_SHA:0:9} (its tree passed the full matrix). Commits that merged during the window ride the next release."
 fi
-[[ "$(git rev-parse "$MERGED_SHA^{tree}")" == "$EXPECTED_TREE" ]] \
-  || die "merged tree != built tree -- refusing to publish (concurrent merge or stray push on $RELEASE_BRANCH)"
 
 # The published tarball is built on the home base from a fresh checkout of the
 # tag (below), so the trigger box's working tree is not the publish source and is
 # left untouched here -- restore_release_tree keeps it clean for a re-run.
 
-# ----- Tag at the merged commit (idempotent) -----
+# ----- Tag at the CI-tested release commit (idempotent) -----
 REMOTE_TAG_SHA="$(remote_tag_commit "v$TARGET")"
-[[ -z "$REMOTE_TAG_SHA" || "$REMOTE_TAG_SHA" == "$MERGED_SHA" ]] \
-  || die "remote tag v$TARGET points at $REMOTE_TAG_SHA, not verified release commit $MERGED_SHA"
+[[ -z "$REMOTE_TAG_SHA" || "$REMOTE_TAG_SHA" == "$PUBLISH_SHA" ]] \
+  || die "remote tag v$TARGET points at $REMOTE_TAG_SHA, not verified release commit $PUBLISH_SHA"
 if git rev-parse --verify --quiet "refs/tags/v$TARGET" >/dev/null; then
-  [[ "$(git rev-parse "refs/tags/v$TARGET^{commit}")" == "$MERGED_SHA" ]] \
-    || die "local tag v$TARGET does not point at the verified release commit $MERGED_SHA"
+  [[ "$(git rev-parse "refs/tags/v$TARGET^{commit}")" == "$PUBLISH_SHA" ]] \
+    || die "local tag v$TARGET does not point at the verified release commit $PUBLISH_SHA"
   gray "Tag v$TARGET already exists locally at the verified release commit"
 else
-  git tag "v$TARGET" "$MERGED_SHA"
-  green "Created tag v$TARGET at $(git rev-parse --short "$MERGED_SHA")"
+  git tag "v$TARGET" "$PUBLISH_SHA"
+  green "Created tag v$TARGET at $(git rev-parse --short "$PUBLISH_SHA")"
 fi
 
 # ----- Push the tag (git, on the trigger box) so the home base can resolve it -----
@@ -939,7 +961,7 @@ fi
 # resolves the exact release commit from origin. @swarmify/agents-cli legacy shim
 # is no longer published as of v1.20.0.
 git push origin "v$TARGET"
-phase_ok "merged tree verified; tag v$TARGET at ${MERGED_SHA:0:9} pushed"
+phase_ok "CI-tested tree verified; tag v$TARGET at ${PUBLISH_SHA:0:9} pushed"
 
 # Restore the working tree to clean now that the tag is durable; the privileged
 # phase below builds from a fresh checkout of the tag (locally on the home base,

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -710,10 +710,18 @@ if $PHNX_TARGET_PUBLISHED; then
   green "$PHNX_PKG@$TARGET is already on the registry."
   REMOTE_TAG_SHA="$(remote_tag_commit "v$TARGET")"
   if [[ -z "$REMOTE_TAG_SHA" ]]; then
-    # No tag yet: create it at the CI-tested release commit when we know it (a
-    # drift-fallback release tags the PR head, which may sit off the default
-    # branch), else at the merge commit / default branch.
-    TAG_TARGET="${CI_TESTED_HEAD:-${MERGED_RELEASE_SHA:-origin/$DEFAULT_BRANCH}}"
+    # Published but no tag yet: tag the exact commit that was shipped. When a
+    # merged release PR is known, apply the same drift rule as the primary flow --
+    # the CI-tested PR head over the drifted merge -- by re-fetching the PR head
+    # here (CI_TESTED_HEAD is only populated on the not-yet-published paths, so it
+    # is never set on this branch). Otherwise fall back to the default branch.
+    if [[ -n "$MERGED_RELEASE_PR" && -n "$MERGED_RELEASE_SHA" ]]; then
+      git fetch --quiet origin "pull/$MERGED_RELEASE_PR/head" \
+        || die "could not fetch the CI-tested head for merged release PR #$MERGED_RELEASE_PR"
+      TAG_TARGET="$(scripts/select-publish-commit.sh "$MERGED_RELEASE_SHA" "$(git rev-parse FETCH_HEAD)")"
+    else
+      TAG_TARGET="origin/$DEFAULT_BRANCH"
+    fi
     [[ "$(git show "$TAG_TARGET:apps/cli/package.json" | jq -r .version)" == "$TARGET" ]] \
       || die "refusing to create v$TARGET: $TAG_TARGET does not contain package version $TARGET"
     git tag -f "v$TARGET" "$(git rev-parse "$TAG_TARGET^{commit}")" >/dev/null
@@ -722,9 +730,13 @@ if $PHNX_TARGET_PUBLISHED; then
     # Already published + tagged: accept any tag that references version TARGET. A
     # drift-fallback release tags the CI-tested PR head rather than the merge
     # commit, so verify the tag's own tree carries TARGET instead of requiring it
-    # to equal the merge commit.
-    git fetch --quiet origin "refs/tags/v$TARGET:refs/tags/v$TARGET" 2>/dev/null || true
-    [[ "$(git show "v$TARGET:apps/cli/package.json" 2>/dev/null | jq -r .version 2>/dev/null || echo "")" == "$TARGET" ]] \
+    # to equal the merge commit. Fetch --force so a stale local v$TARGET (from a
+    # prior tagging attempt) is overwritten rather than leaving the fetch rejected
+    # ("would clobber existing tag") and reading the stale ref; never swallow the
+    # fetch's exit code.
+    git fetch --quiet --force origin "refs/tags/v$TARGET:refs/tags/v$TARGET" \
+      || die "could not fetch remote tag v$TARGET to verify its version"
+    [[ "$(git show "v$TARGET:apps/cli/package.json" | jq -r .version)" == "$TARGET" ]] \
       || die "remote tag v$TARGET points at $REMOTE_TAG_SHA, which is not version $TARGET"
     gray "Tag v$TARGET already present for the published release."
   fi

--- a/apps/cli/scripts/select-publish-commit.sh
+++ b/apps/cli/scripts/select-publish-commit.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Pick the commit a release should tag + publish, given the commit that landed on
+# the default branch (the squash-merge) and the commit CI actually tested (the
+# release PR head).
+#
+# The published tarball MUST be a tree the full CI matrix went green on. Normally
+# that is the merge commit on the default branch, so we tag that (keeps the tag on
+# the branch's first-parent history). But the default branch is busy: if unrelated
+# PRs merge during a release PR's CI window, the squash-merge lands on a newer base
+# and its tree diverges from what CI tested. In that case the merge tree was never
+# validated as a unit, so we tag + publish the exact CI-tested release commit
+# instead; the commits that merged during the window ride the next release.
+#
+# The decision is a single tree comparison, extracted here so release.sh's core
+# integrity rule ("published tree == a CI-green tree") is unit-testable without
+# npm/gh/CI — the same reason validate-bump.sh exists.
+#
+# Usage: select-publish-commit.sh <merged-sha> <ci-tested-sha>
+# Echoes the chosen commit SHA. Runs in the current git repository.
+set -euo pipefail
+
+[[ $# -eq 2 ]] || { echo "usage: select-publish-commit.sh <merged-sha> <ci-tested-sha>" >&2; exit 2; }
+merged_sha="$1"
+ci_commit="$2"
+
+if [[ "$(git rev-parse "$merged_sha^{tree}")" == "$(git rev-parse "$ci_commit^{tree}")" ]]; then
+  # No drift: the merge tree still equals the CI-tested tree. Tag the merge commit.
+  printf '%s\n' "$merged_sha"
+else
+  # Concurrent-merge drift: publish the exact commit the matrix went green on.
+  printf '%s\n' "$ci_commit"
+fi

--- a/apps/cli/scripts/select-publish-commit.test.ts
+++ b/apps/cli/scripts/select-publish-commit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Which commit a release tags + publishes, exercised by running the REAL script
+ * against a REAL git repository (no mocks).
+ *
+ * This is the integrity rule that keeps a busy default branch from publishing an
+ * untested tarball: when unrelated PRs merge during a release PR's CI window, the
+ * squash-merge tree diverges from what CI tested, and release.sh must fall back to
+ * the CI-tested release commit rather than the drifted merge. release.sh itself
+ * cannot run in a test (it demands a clean main, npm + gh auth); extracting the
+ * decision into select-publish-commit.sh is what makes this path testable — the
+ * same reason validate-bump.sh exists.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const SCRIPT = path.resolve(__dirname, 'select-publish-commit.sh');
+
+let repo: string;
+
+function git(...args: string[]): string {
+  const r = spawnSync('git', args, { cwd: repo, encoding: 'utf-8' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+/** Commit a file's content on top of the current HEAD, return the new commit SHA. */
+function commit(file: string, content: string, message: string): string {
+  fs.writeFileSync(path.join(repo, file), content);
+  git('add', file);
+  git('commit', '-q', '-m', message);
+  return git('rev-parse', 'HEAD');
+}
+
+/** Run the real script; return { sha, status }. */
+function select(mergedSha: string, ciSha: string) {
+  const r = spawnSync('bash', [SCRIPT, mergedSha, ciSha], { cwd: repo, encoding: 'utf-8' });
+  return { sha: r.stdout.trim(), status: r.status, stderr: r.stderr };
+}
+
+beforeAll(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'select-publish-'));
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+});
+
+afterAll(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+describe('select-publish-commit', () => {
+  it('tags the merge commit when its tree still matches the CI-tested tree', () => {
+    // The clean, no-drift case: a distinct commit whose tree is identical to the
+    // CI-tested one. An empty commit on top shares its parent's tree but has a new
+    // SHA — exactly a fast-forward-equivalent squash-merge with no drift.
+    const ci = commit('pkg', 'v=1.20.80', 'release commit (CI-tested)');
+    git('commit', '-q', '--allow-empty', '-m', 'squash-merge, no drift');
+    const merged = git('rev-parse', 'HEAD');
+    expect(git('rev-parse', `${ci}^{tree}`)).toBe(git('rev-parse', `${merged}^{tree}`));
+    expect(ci).not.toBe(merged);
+    expect(select(merged, ci).sha).toBe(merged);
+  });
+
+  it('falls back to the CI-tested commit when the merge tree drifted', () => {
+    // Busy main: a source file changed between the CI-tested commit and the merge,
+    // so the merge tree differs. The script must publish the CI-tested commit.
+    const ci = commit('pkg', 'v=1.20.81', 'release commit (CI-tested)');
+    const merged = commit('src', 'unrelated PR merged during CI', 'squash-merge onto drifted main');
+    expect(git('rev-parse', `${ci}^{tree}`)).not.toBe(git('rev-parse', `${merged}^{tree}`));
+    expect(select(merged, ci).sha).toBe(ci);
+  });
+
+  it('is a pure function of the trees: identical sha in both slots returns that sha', () => {
+    const c = commit('pkg', 'v=1.20.82', 'lone commit');
+    expect(select(c, c).sha).toBe(c);
+  });
+
+  it('exits 2 on the wrong argument count', () => {
+    expect(spawnSync('bash', [SCRIPT, 'only-one'], { cwd: repo, encoding: 'utf-8' }).status).toBe(2);
+  });
+});


### PR DESCRIPTION
**What + type:** bugfix to release tooling (`release.sh`). No user-facing runtime surface — release-process behavior only.

## The bug (stalled 1.20.79 and 1.20.80)

`main` is a busy branch. When unrelated PRs merge during a release PR's CI window, the squash-merge lands on a newer base and its tree diverges from the tree CI tested. `release.sh` phase 4 then refused with `merged tree != built tree` and the release stalled — each attempt merged a version bump it could never tag/publish. Real evidence: PR #1614 (1.20.79) and PR #1622 (1.20.80) both merged, neither published; the 1.20.80 merge tree diverged **89 files** from its CI-tested head because #1617 + RUSH-2018 landed mid-window.

## The fix

Publish the exact commit the full matrix went green on:

- **No drift** (merge tree == CI-tested tree): tag the merge commit, as before (tag stays on the default branch).
- **Drift** (concurrent merge): tag + publish the **CI-tested release commit** (the PR head). Intervening commits ride the next release.

The `wait_for_ci_green` gate is **unchanged** — the published tarball is always a tree the full matrix validated. The fix relaxes only the "tag must equal the default-branch HEAD" coupling, not the CI-green requirement.

The tree-comparison decision is extracted into `scripts/select-publish-commit.sh` (same rationale as `validate-bump.sh`) and unit-tested against a **real git repo**. The already-published re-run tolerates a tag that references the CI-tested commit (which can sit off the default branch after a drift fallback).

## Run result — new + adjacent script tests, real git, no mocks

```
$ npx vitest run scripts/select-publish-commit.test.ts scripts/validate-bump.test.ts
 Test Files  2 passed (2)
      Tests  19 passed (19)
```

`select-publish-commit.test.ts` covers: no-drift → tags the merge; drift → falls back to the CI-tested commit; pure-tree behavior; arg-count guard.

Transcript (fleet-local, this is a public repo): yosemite-s0:/home/muqsit/.agents/.history/versions/claude/2.1.186/home/.claude/projects/-home-muqsit/21805f5f-c71f-4990-bbe4-c06966c863b0.jsonl