### PR TITLE
feat: parse grok usage limits from local logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Added
 
+- **`ag view grok` now shows usage limits.** It parses the latest billing period config and subscription tier from Grok's local `unified.jsonl` log, avoiding the need for an inaccessible network endpoint.
+
 - **`agents sessions migrate` (alias `detach`) relocates a RUNNING session onto another
   machine, then stops the source here (RUSH-1977).** Move the live agent — not just its
   transcript — off the interactive laptop and onto a fleet worker, a registered device, or

--- a/apps/cli/.changelog/next/grok-usage.md
+++ b/apps/cli/.changelog/next/grok-usage.md
@@ -1,0 +1,4 @@
+- **`agents view` now shows Grok usage limits.** Grok's network usage endpoints
+  404, so usage is parsed from the local `~/.grok/logs/unified.jsonl` log instead —
+  the latest billing-period config and subscription tier render as a `W` window,
+  matching the other agents' live-usage display. Source: `apps/cli/src/lib/usage.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.20.80
 
-- **`ag view grok` now shows usage limits.** Parses local `unified.jsonl` to display Grok billing configuration and subscription tiers since network APIs are inaccessible.
-
 - **`agents activity` goes fleet-wide, grouped, and session-enriched.** The activity
   lane was a flat, local-only, newest-first list; it now shows progress-so-far across
   the whole fleet — who did what, where, on which project, for which ticket. New flags:

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.20.80
 
+- **`ag view grok` now shows usage limits.** Parses local `unified.jsonl` to display Grok billing configuration and subscription tiers since network APIs are inaccessible.
+
 - **`agents activity` goes fleet-wide, grouped, and session-enriched.** The activity
   lane was a flat, local-only, newest-first list; it now shows progress-so-far across
   the whole fleet — who did what, where, on which project, for which ticket. New flags:

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -719,7 +719,8 @@ contains — this is a data-availability limit, not a policy choice:
 |---|---|---|---|
 | Claude | email + plan | live (`api.anthropic.com`) | email/plan/quota from the local OAuth credential + usage API |
 | Codex | email + plan | last-seen (session logs) | email/plan from the auth JWT; quota parsed from the newest session's rate-limit event |
-| Gemini, Grok | email | — | email read from the local auth file |
+| Gemini | email | — | email read from the local auth file |
+| Grok | email + tier | last-seen (`~/.grok/logs/unified.jsonl`) | email from the local auth file; weekly window (`W`) + subscription tier parsed from the newest `billing: fetched credits config` log line, since Grok's network usage endpoints 404 |
 | Droid | email | live (`api.factory.ai`) | `~/.factory/auth.v2.file` is AES-256-GCM (key on disk at `auth.v2.key`); decrypt locally, read the email from the WorkOS access-token JWT. That same token authorizes `GET /api/billing/limits` for the three rolling rate-limit windows (5-hour → `S`, weekly → `W`, monthly, detailed-view only). |
 | Kimi | `id:<user_id>` + tier | live (`api.kimi.com/coding/v1/usages`) | JWT carries no email — only an opaque `user_id`. Quota + membership tier come from the `/usages` endpoint. |
 | Antigravity | `signed in` | — | OAuth grant with no id_token — presence only. File `~/.gemini/antigravity-cli/antigravity-oauth-token`, else macOS keychain / Linux libsecret (`service gemini` + user `antigravity`) |

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -11,6 +11,7 @@ import {
   deriveUsageStatusFromSnapshot,
   formatUsageSummary,
   formatUsageStatusBadge,
+  getUsageInfo,
   getClaudeKeychainService,
   loadClaudeOauth,
   getUsageInfoForIdentity,
@@ -137,11 +138,65 @@ describe('usage formatting', () => {
   });
 
   it('agentReportsUsage flags only the agents that expose usage data', () => {
-    for (const a of ['claude', 'codex', 'kimi', 'droid'] as const) {
+    for (const a of ['claude', 'codex', 'kimi', 'droid', 'grok'] as const) {
       expect(agentReportsUsage(a)).toBe(true);
     }
-    for (const a of ['antigravity', 'grok', 'opencode', 'gemini'] as const) {
+    for (const a of ['antigravity', 'opencode', 'gemini'] as const) {
       expect(agentReportsUsage(a)).toBe(false);
+    }
+  });
+
+  it('parses Grok usage from the local unified.jsonl (real log shape)', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-grok-usage-'));
+    try {
+      const logDir = path.join(home, '.grok', 'logs');
+      fs.mkdirSync(logDir, { recursive: true });
+      // Two billing lines; the parser keeps the LAST one seen.
+      const lines = [
+        JSON.stringify({
+          ts: '2026-08-01T00:00:00.000Z',
+          msg: 'billing: fetched credits config',
+          ctx: { config: { creditUsagePercent: 10, currentPeriod: { end: '2026-08-01T18:27:00Z' } }, subscriptionTier: 'X Premium' },
+        }),
+        // Real-world shape captured from ~/.grok/logs/unified.jsonl.
+        JSON.stringify({
+          ts: '2026-08-02T04:00:49.628Z',
+          src: 'shell',
+          lvl: 'info',
+          msg: 'billing: fetched credits config',
+          ctx: {
+            config: {
+              creditUsagePercent: 100.0,
+              currentPeriod: { type: 'USAGE_PERIOD_TYPE_WEEKLY', end: '2026-08-02T18:27:00.269749+00:00' },
+              isUnifiedBillingUser: true,
+            },
+            subscriptionTier: 'X Premium+',
+          },
+        }),
+      ];
+      fs.writeFileSync(path.join(logDir, 'unified.jsonl'), `${lines.join('\n')}\n`);
+
+      const { snapshot, error } = await getUsageInfo('grok', { home });
+      expect(error).toBeNull();
+      expect(snapshot?.plan).toBe('X Premium+');
+      const week = snapshot?.windows.find((w) => w.key === 'week');
+      expect(week?.shortLabel).toBe('W');
+      // Real credit consumption is surfaced, not a hardcoded 0%.
+      expect(week?.usedPercent).toBe(100);
+      expect(week?.resetsAt?.toISOString()).toBe(new Date('2026-08-02T18:27:00.269749+00:00').toISOString());
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('returns an empty Grok snapshot when the log is absent', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-grok-nolog-'));
+    try {
+      const { snapshot, error } = await getUsageInfo('grok', { home });
+      expect(error).toBeNull();
+      expect(snapshot).toBeNull();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
     }
   });
 

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1,5 +1,5 @@
 /**
- * Usage and rate-limit tracking for Claude, Codex, Kimi, and Droid agents.
+ * Usage and rate-limit tracking for Claude, Codex, Kimi, Droid, and Grok agents.
  *
  * Fetches live usage data from each agent's usage API (Anthropic OAuth for
  * Claude, Kimi Code /usages, Factory billing limits for Droid) or parses

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -264,10 +264,10 @@ export function buildCanonicalUsageContext(inputs: UsageIdentityInput[]): {
 
 /**
  * Whether an agent exposes usage/limit data we can render — Claude/Kimi/Droid via
- * a live API, Codex via local session logs. Everything else has no usage concept,
- * so callers use this to decide whether a missing snapshot is worth flagging as
- * "usage unavailable" (a signed-in Claude account with no data) versus simply not
- * applicable (Antigravity, Grok, OpenCode).
+ * a live API, Codex/Grok via local session logs. Everything else has no usage
+ * concept, so callers use this to decide whether a missing snapshot is worth
+ * flagging as "usage unavailable" (a signed-in Claude account with no data)
+ * versus simply not applicable (Antigravity, OpenCode).
  */
 export function agentReportsUsage(agentId: AgentId): boolean {
   return agentId === 'claude' || agentId === 'codex' || agentId === 'kimi' || agentId === 'droid' || agentId === 'grok';

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -214,6 +214,8 @@ export async function getUsageInfo(agentId: AgentId, options?: UsageOptions): Pr
       return getKimiUsageInfo(options);
     case 'droid':
       return getDroidUsageInfo(options);
+    case 'grok':
+      return getGrokUsageInfo(options);
     default:
       return { snapshot: null, error: null };
   }
@@ -268,7 +270,7 @@ export function buildCanonicalUsageContext(inputs: UsageIdentityInput[]): {
  * applicable (Antigravity, Grok, OpenCode).
  */
 export function agentReportsUsage(agentId: AgentId): boolean {
-  return agentId === 'claude' || agentId === 'codex' || agentId === 'kimi' || agentId === 'droid';
+  return agentId === 'claude' || agentId === 'codex' || agentId === 'kimi' || agentId === 'droid' || agentId === 'grok';
 }
 
 /** Fetch usage info for all unique accounts in parallel, keyed by usage key. */
@@ -1903,4 +1905,80 @@ function safeStatSync(filePath: string): fs.Stats | null {
   } catch {
     return null;
   }
+}
+
+/** Parse the latest billing info from Grok's unified log. */
+async function getGrokUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
+  try {
+    const base = options?.home || os.homedir();
+    const logPath = path.join(base, '.grok', 'logs', 'unified.jsonl');
+    if (!fs.existsSync(logPath)) return { snapshot: null, error: null };
+
+    const match = await readLatestGrokBilling(logPath);
+    if (!match) return { snapshot: null, error: null };
+
+    return {
+      snapshot: {
+        source: 'last_seen',
+        sourceLabel: 'last seen in Grok logs',
+        capturedAt: match.capturedAt,
+        windows: match.windows,
+        plan: match.subscriptionTier,
+      },
+      error: null,
+    };
+  } catch {
+    return { snapshot: null, error: null };
+  }
+}
+
+interface GrokBillingMatch {
+  capturedAt: Date | null;
+  subscriptionTier?: string | null;
+  windows: UsageWindow[];
+}
+
+async function readLatestGrokBilling(filePath: string): Promise<GrokBillingMatch | null> {
+  return new Promise((resolve) => {
+    let latest: GrokBillingMatch | null = null;
+    const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed.msg === 'billing: fetched credits config' && parsed.ctx?.config) {
+          const config = parsed.ctx.config;
+          const windows: UsageWindow[] = [];
+
+          if (config.currentPeriod?.end) {
+            // Grok does not provide a hard limit percentage in this payload,
+            // but we can map the billing period end as a 'week' window reset.
+            // Using 0% to avoid rendering a full limit bar, while still displaying
+            // the window period.
+            windows.push({
+              key: 'week',
+              label: 'Current week',
+              shortLabel: 'W',
+              usedPercent: 0,
+              resetsAt: parseDateValue(config.currentPeriod.end),
+              windowMinutes: inferWindowMinutes('week'),
+            });
+          }
+
+          latest = {
+            capturedAt: parseDateValue(parsed.ts),
+            subscriptionTier: parsed.ctx.subscriptionTier || null,
+            windows,
+          };
+        }
+      } catch {
+        /* malformed session line */
+      }
+    });
+
+    rl.on('close', () => resolve(latest));
+    rl.on('error', () => resolve(latest));
+  });
 }

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1953,15 +1953,15 @@ async function readLatestGrokBilling(filePath: string): Promise<GrokBillingMatch
           const windows: UsageWindow[] = [];
 
           if (config.currentPeriod?.end) {
-            // Grok does not provide a hard limit percentage in this payload,
-            // but we can map the billing period end as a 'week' window reset.
-            // Using 0% to avoid rendering a full limit bar, while still displaying
-            // the window period.
+            // `creditUsagePercent` is Grok's weekly credit consumption (0-100);
+            // the billing period's `end` is when that window resets.
+            const rawPercent =
+              typeof config.creditUsagePercent === 'number' ? config.creditUsagePercent : 0;
             windows.push({
               key: 'week',
               label: 'Current week',
               shortLabel: 'W',
-              usedPercent: 0,
+              usedPercent: Math.max(0, Math.min(100, rawPercent)),
               resetsAt: parseDateValue(config.currentPeriod.end),
               windowMinutes: inferWindowMinutes('week'),
             });


### PR DESCRIPTION
Parses Grok usage limits from the local `~/.grok/logs/unified.jsonl` since the network usage endpoints 404.

**type:** feature (CLI — `apps/cli/src/lib/usage.ts`)

## What changed
- `agents view` now shows Grok usage: the weekly billing window (`W`) + subscription tier, parsed from the latest `billing: fetched credits config` log line.
- The window percentage is the real `creditUsagePercent` from the log. An earlier revision hardcoded `usedPercent: 0`, so the bar always rendered empty regardless of actual consumption — fixed.
- Changelog note moved to a `.changelog/next/` fragment (the aggregate `apps/cli/CHANGELOG.md` is generated, never hand-edited — the `gen-changelog` test enforces this, which was one of the two CI failures).

## Verified — real `ag view grok` against the live local log
Screenshot of the running command (rendered from the real captured output): `zion:/tmp/grok-view.png` (also `yosemite-s0:~/grok-view.png`). Real terminal output:

```
Installed Agent CLIs

  Grok (balanced) (no default)
    0.2.82  muqsitnawaz@icloud.com  X Premium+  W: █████ 100% (14h)  rate-limited  1h ago
```

The `W` bar reflects the real `creditUsagePercent: 100.0` from the log — previously it was hardcoded to 0%, so it always rendered empty.

## Tests
- Real-path parser tests (real log shape + missing-log) added to `usage.test.ts`.
- `agentReportsUsage` test updated: grok now reports usage.
- Full `usage.test.ts` (35) + `gen-changelog.test.ts` (5) pass locally; `tsc --noEmit` clean.
