### PR TITLE
fix(sessions): surface non-Claude remote session ids from the deployed hook (RUSH-2007 Layer A)

### DIFF
--- a/apps/cli/.changelog/1.20.81.md
+++ b/apps/cli/.changelog/1.20.81.md
@@ -1,3 +1,15 @@
+- **Non-Claude remote/tmux agent sessions now surface with their real id
+  (RUSH-2007).** `agents sessions --active` and the `agents sessions focus` picker
+  dropped every non-Claude tmux session (codex/gemini/kimi/grok/…) that lacked a
+  launch-minted id, so a live `agents run --device <host> <agent>` was invisible and
+  un-refocusable after an SSH drop. `listTmuxAgentSessions` now backfills the id from
+  the **deployed** SessionStart hook's own per-pid record at
+  `~/.agents/.cache/state/sessions/<pid>.json` — the CLI previously only read the
+  un-deployed session-tracker path (`terminals/sessions/`, empty on the fleet). A
+  targeted per-pid read (never a scan of that graveyard dir), freshness-guarded by
+  the launch's known start so a reused-pid record can't cross sessions. Source:
+  `apps/cli/src/lib/session/hook-sessions.ts`, `apps/cli/src/lib/session/active.ts`.
+
 - **Releases publish the CI-tested tree, not a drifted merge.** On a busy default
   branch, unrelated PRs merging during a release PR's CI window made the
   squash-merge tree diverge from what CI actually tested, so `release.sh` refused

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 1.20.81
 
+- **Non-Claude remote/tmux agent sessions now surface with their real id
+  (RUSH-2007).** `agents sessions --active` and the `agents sessions focus` picker
+  dropped every non-Claude tmux session (codex/gemini/kimi/grok/…) that lacked a
+  launch-minted id, so a live `agents run --device <host> <agent>` was invisible and
+  un-refocusable after an SSH drop. `listTmuxAgentSessions` now backfills the id from
+  the **deployed** SessionStart hook's own per-pid record at
+  `~/.agents/.cache/state/sessions/<pid>.json` — the CLI previously only read the
+  un-deployed session-tracker path (`terminals/sessions/`, empty on the fleet). A
+  targeted per-pid read (never a scan of that graveyard dir), freshness-guarded by
+  the launch's known start so a reused-pid record can't cross sessions. Source:
+  `apps/cli/src/lib/session/hook-sessions.ts`, `apps/cli/src/lib/session/active.ts`.
+
 - **Releases publish the CI-tested tree, not a drifted merge.** On a busy default
   branch, unrelated PRs merging during a release PR's CI window made the
   squash-merge tree diverge from what CI actually tested, so `release.sh` refused

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -26,7 +26,7 @@ import type { CloudTaskStatus } from '../cloud/types.js';
 import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
 import { readPidSessionEntry, listPidSessionEntries, prunePidSessionRegistry, type PidSessionEntry } from './pid-registry.js';
-import { loadHookSessionIndex, resolveHookSessionRecord, type HookSessionIndex, type HookSessionRecord } from './hook-sessions.js';
+import { loadHookSessionIndex, resolveHookSessionRecord, readStateSessionRecord, type HookSessionIndex, type HookSessionRecord } from './hook-sessions.js';
 import { buildClaudeLabelMap, getAgentSessionDirs } from './discover.js';
 import { buildRunNameMap } from './run-names.js';
 import { latestSessionFileForCwd } from './db.js';
@@ -1405,8 +1405,23 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
     if (!pane || !sessName) continue;
     const meta = readSessionMeta(sessName);
     const liveEntry = liveByPane.get(pane);
-    const id = resolvePaneIdentity(pane, meta, liveEntry, getHookIndex);
+    let id = resolvePaneIdentity(pane, meta, liveEntry, getHookIndex);
     if (!id) continue;
+    // RUSH-2007 Layer A: a non-Claude tmux session whose id resolved via neither the
+    // launch registry (no id minted at spawn) nor the session-tracker index (not
+    // deployed on the fleet — its dir is empty) — backfill it from the DEPLOYED
+    // hook's own per-pid record at state/sessions/<pid>.json. Targeted single-file
+    // reads on the pane leaf pid, then the registry launch pid; freshness-guarded by
+    // the launch's known start so a reused-pid graveyard file can't cross sessions.
+    // Without this the session surfaces id-less (keyed on the bare pane) and is
+    // invisible to `agents sessions focus` — the remaining RUSH-2007 discovery gap.
+    if (!id.sessionId) {
+      const panePid = parseInt(pidRaw, 10) || undefined;
+      const backfilled =
+        (panePid ? readStateSessionRecord(panePid, liveEntry?.startedAtMs)?.session_id : undefined)
+        ?? (liveEntry ? readStateSessionRecord(liveEntry.pid, liveEntry.startedAtMs)?.session_id : undefined);
+      if (backfilled) id = { ...id, sessionId: backfilled };
+    }
     // Dedupe by resolved session id; an as-yet-unresolved id (a hookless/lagging
     // split) keys on the unique pane so it still surfaces as its own row.
     const dedupKey = id.sessionId ?? pane;

--- a/apps/cli/src/lib/session/hook-sessions.test.ts
+++ b/apps/cli/src/lib/session/hook-sessions.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import { getTerminalsDir } from '../state.js';
-import { loadHookSessionIndex, resolveHookSessionId, resolveHookSessionRecord } from './hook-sessions.js';
+import { getTerminalsDir, getRuntimeStateDir } from '../state.js';
+import { loadHookSessionIndex, resolveHookSessionId, resolveHookSessionRecord, readStateSessionRecord } from './hook-sessions.js';
 
 // Fake pids far above any real process, so the test never reads or clobbers a
 // live hook state file.
@@ -95,5 +95,55 @@ describe('hook session index + resolver', () => {
     writeRecord(P1, { agent: 'codex', pid: P1, launch_id: 'L-empty', ts: 1 });
     const idx = loadHookSessionIndex();
     expect(resolveHookSessionId(idx, { pid: P1, kind: 'codex', launchId: 'L-empty' })).toBeUndefined();
+  });
+});
+
+// RUSH-2007 Layer A: the DEPLOYED hook writes state/sessions/<pid>.json (a distinct
+// path from the un-deployed session-tracker's terminals/sessions/ above). This is the
+// targeted per-pid reader that surfaces non-Claude ids from the real fleet source.
+const STATE_SESSIONS_DIR = path.join(getRuntimeStateDir(), 'sessions');
+const SP = 999_200_001; // fake pid, far above any real process
+
+function writeStateRecord(pid: number, rec: Record<string, unknown>): void {
+  fs.mkdirSync(STATE_SESSIONS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(STATE_SESSIONS_DIR, `${pid}.json`), JSON.stringify(rec), 'utf8');
+}
+
+describe('readStateSessionRecord (deployed hook, state/sessions/<pid>.json)', () => {
+  afterEach(() => {
+    try { fs.unlinkSync(path.join(STATE_SESSIONS_DIR, `${SP}.json`)); } catch { /* absent */ }
+  });
+
+  it('reads the deployed hook record for a specific pid (the real fleet id source)', () => {
+    // ts is Unix SECONDS, as the hook stamps it (`date +%s`).
+    writeStateRecord(SP, { session_id: '33109c18-real', cwd: '/x', pid: SP, ts: 1785640088 });
+    expect(readStateSessionRecord(SP)?.session_id).toBe('33109c18-real');
+  });
+
+  it('returns undefined when no record exists for the pid (the common miss — no dir scan)', () => {
+    expect(readStateSessionRecord(SP)).toBeUndefined();
+  });
+
+  it('freshness guard: rejects a record whose ts predates the live process start (reused pid)', () => {
+    // Record written at ts=1000s (=1_000_000ms) by a DEAD predecessor; the live
+    // process at this reused pid started at 5_000_000ms — the stale id must not cross.
+    writeStateRecord(SP, { session_id: 'stale-predecessor', pid: SP, ts: 1000 });
+    expect(readStateSessionRecord(SP, 5_000_000)).toBeUndefined();
+  });
+
+  it('freshness guard: accepts a record written after the process start (within skew)', () => {
+    // Process started at 1_000_000ms; hook stamped ts=1000s (=1_000_000ms) just after.
+    writeStateRecord(SP, { session_id: 'fresh-current', pid: SP, ts: 1000 });
+    expect(readStateSessionRecord(SP, 1_000_000)?.session_id).toBe('fresh-current');
+  });
+
+  it('is best-effort without a start time: returns the record when startedAtMs is unknown', () => {
+    writeStateRecord(SP, { session_id: 'no-anchor', pid: SP, ts: 1 });
+    expect(readStateSessionRecord(SP)?.session_id).toBe('no-anchor');
+  });
+
+  it('ignores a record missing session_id', () => {
+    writeStateRecord(SP, { cwd: '/x', pid: SP, ts: 1785640088 });
+    expect(readStateSessionRecord(SP)).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/session/hook-sessions.ts
+++ b/apps/cli/src/lib/session/hook-sessions.ts
@@ -1,13 +1,18 @@
 /**
  * Read-only view of the SessionStart hook's live-session state files.
  *
- * The `@agents/session-tracker` hook (installed into each agent's own config)
- * writes `~/.agents/.cache/terminals/sessions/<pid>.json` AFTER an agent boots,
- * carrying the agent's OWN authoritative session id (from its SessionStart
- * payload) plus the join keys `launch_id` / `terminal_id`. It is the only writer
- * that sees agents `ag run` did NOT launch (you typing `claude` in a terminal),
- * and the only source of an exact id for non-Claude agents (whose id we can't
- * know at spawn).
+ * Two on-disk sources carry a non-Claude agent's authoritative id (whose id we
+ * can't know at spawn), both read here:
+ *   1. The `@agents/session-tracker` hook writes
+ *      `~/.agents/.cache/terminals/sessions/<pid>.json` with the id plus the join
+ *      keys `launch_id` / `terminal_id`. Rich schema, but this package is NOT
+ *      deployed on the fleet — its dir is empty there. Scanned into the index by
+ *      {@link loadHookSessionIndex}.
+ *   2. The ACTUALLY-DEPLOYED SessionStart hook writes
+ *      `~/.agents/.cache/state/sessions/<pid>.json` ({@link readStateSessionRecord})
+ *      — `{session_id,cwd,pid,ts}`, keyed purely by pid. This is the real fleet id
+ *      source for every agent; read targeted per-pid, never scanned (RUSH-2007).
+ * Both see agents `ag run` did NOT launch (you typing `claude` in a terminal).
  *
  * This module lets `sessions --active` reconcile a `ps`-discovered pid to that
  * authoritative id. It is deliberately a small hand-rolled reader — the CLI does
@@ -23,7 +28,7 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { getTerminalsDir } from '../state.js';
+import { getTerminalsDir, getRuntimeStateDir } from '../state.js';
 
 /** The subset of the hook's on-disk record this reader relies on. Extra fields are ignored. */
 export interface HookSessionRecord {
@@ -47,6 +52,51 @@ function hookSessionsDir(): string {
   // Sibling of the pid-registry's by-pid/ dir. The hook hardcodes this same path
   // (packages/session-tracker/src/hook.sh); we read it, never move it.
   return path.join(getTerminalsDir(), 'sessions');
+}
+
+/**
+ * The path the ACTUALLY-DEPLOYED SessionStart hook writes:
+ * `~/.agents/.cache/state/sessions/<pid>.json`, carrying `{session_id,cwd,pid,ts}`
+ * for EVERY agent (claude/codex/gemini/kimi/grok/antigravity). This is the fleet's
+ * real id source; the `terminals/sessions/` path above belongs to the separate
+ * `@agents/session-tracker` package, which is not deployed (its dir is empty on the
+ * fleet), so a non-Claude tmux session's id resolved ONLY through the index above
+ * never landed (RUSH-2007). These records are keyed purely by pid — no
+ * launch_id/terminal_id/agent — so they join only on pid. The dir is an unpruned
+ * graveyard (thousands of dead-pid files), so this is a TARGETED per-pid read on
+ * demand, never a full-dir scan folded into {@link loadHookSessionIndex}.
+ */
+function stateSessionRecordPath(pid: number): string {
+  return path.join(getRuntimeStateDir(), 'sessions', `${pid}.json`);
+}
+
+/**
+ * Read the deployed hook's record for one specific pid, or undefined if absent /
+ * corrupt / not fresh. `startedAtMs` (the live process's known start, when the
+ * caller has it) rejects a stale record left by a PRIOR process at a reused pid:
+ * the hook writes its record AFTER the agent boots, so a record whose `ts`
+ * predates the current process's start belongs to a dead predecessor. `ts` is
+ * Unix SECONDS (the hook stamps `date +%s`); `startedAtMs` is millis.
+ */
+export function readStateSessionRecord(
+  pid: number,
+  startedAtMs?: number,
+): HookSessionRecord | undefined {
+  if (!pid || pid < 1) return undefined;
+  let rec: HookSessionRecord | undefined;
+  try {
+    rec = parseRecord(fs.readFileSync(stateSessionRecordPath(pid), 'utf8'));
+  } catch {
+    return undefined; // absent (the common case) or unreadable
+  }
+  if (!rec) return undefined;
+  if (startedAtMs !== undefined && typeof rec.ts === 'number') {
+    // Allow a small skew: the hook fires just after exec, and ts is second-
+    // granular so it can floor to just before a sub-second process start.
+    const SKEW_MS = 5_000;
+    if (rec.ts * 1000 < startedAtMs - SKEW_MS) return undefined; // reused-pid graveyard record
+  }
+  return rec;
 }
 
 function parseRecord(raw: string): HookSessionRecord | undefined {


### PR DESCRIPTION
## What

Closes the RUSH-2007 **Layer A / discovery** gap: non-Claude remote tmux sessions (`agents run --device <host> codex|gemini|kimi|grok`) never surfaced in `agents sessions --active` or the `agents sessions focus` picker, so after an SSH drop they were live-but-invisible and un-refocusable.

Linear: RUSH-2007 — Remote session resilience.

## Root cause (verified in code + on the live fleet)

`listTmuxAgentSessions` resolved a session id only via the launch registry (Claude-only at spawn) and `loadHookSessionIndex`, which reads `~/.agents/.cache/terminals/sessions/` — the **un-deployed** `@agents/session-tracker` path (empty on every fleet box). The **deployed** SessionStart hook actually writes `~/.agents/.cache/state/sessions/<pid>.json` (`{session_id,cwd,pid,ts}`, keyed by pid).

Confirmed live on this box: **3,905** records; sample `1123254.json` = `{"session_id":"33109c18-e8f8-4e0b-b3c9-e82774336bb1","cwd":"…/agents-cli","pid":1123254,"ts":1785640088}`.

## Fix

- `hook-sessions.ts`: new `readStateSessionRecord(pid, startedAtMs?)` — a **targeted single-file** read of `state/sessions/<pid>.json` (never a scan of that unpruned graveyard dir, per the ticket's caveat), freshness-guarded: a record whose `ts` predates the live process's start is rejected as a reused-pid graveyard file.
- `active.ts`: when `resolvePaneIdentity` yields no id, backfill from the pane leaf pid then the launch pid. Strictly **additive** — it can only fill a previously-missing id, keyed on pids the enumeration already considers.
- Module docs + CHANGELOG updated.

## Proof — real test run (not pasted source)

Captured run: `mac-mini:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/rush2007-layerA-testrun.log`

```
$ bun test src/lib/session/hook-sessions.test.ts src/lib/session/active.test.ts src/lib/session/active.dedupe.test.ts
bun test v1.3.14 (0d9b296a)

 52 pass
 0 fail
 73 expect() calls
Ran 52 tests across 3 files. [557.00ms]

$ bunx tsc --noEmit -p tsconfig.json   (touched files)
OK: no type errors in active.ts / hook-sessions.ts
```

New `readStateSessionRecord` cases (real filesystem, no mocks): read / miss / freshness-reject (reused pid) / freshness-accept / best-effort-without-start-time / missing-id.

## Reviewer notes (judgment calls)

- **pid topology:** backfill tries the pane leaf pid then the launch pid. Handles the common case (agent runs as the pane process); a wrapper-shell-with-agent-child would still miss — I did not add an ancestor/child walk to keep the change tight. Flagging in case you want it here vs a follow-up.
- **freshness guard** is start-time-anchored (reused-pid safe), deliberately **not** a duration heuristic (prix flagged that pattern on #1524).

## Out of scope (tracked in RUSH-2007)

Layer C presence tracker; the #1502 Factory reattach-env fix.

## End-to-end verification (needs a TTY — not runnable from this auto-mode sandbox)

`agents run --device yosemite-s0 codex` interactively, drop the SSH link, confirm the codex session now appears in `agents sessions --active` + `focus` with its real id (today: nothing).
