### PR TITLE
fix(codex): prune stale hook registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - **Codex hook sync no longer leaves startup warnings after upgrades.** See
-  `apps/cli/CHANGELOG.md`.
+  `apps/cli/.changelog/next/codex-hook-sync-warnings.md`.
 
 - **Session lifecycle status is explicit (RUSH-2066).** `agents sessions --active`
   now reports dead processes as `closed` and days-stale/dangling sessions as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **Codex hook sync no longer leaves startup warnings after upgrades.** See
+  `apps/cli/CHANGELOG.md`.
+
 - **Session lifecycle status is explicit (RUSH-2066).** `agents sessions --active`
   now reports dead processes as `closed` and days-stale/dangling sessions as
   `abandoned`, and `agents hq floor` no longer renders those rows as idle. See

--- a/apps/cli/.changelog/next/codex-hook-sync-warnings.md
+++ b/apps/cli/.changelog/next/codex-hook-sync-warnings.md
@@ -1,0 +1,7 @@
+- **Codex hook sync no longer leaves startup warnings after upgrades.** The Codex
+  hook registrar now prunes hook commands from sibling Codex version homes before
+  writing `hooks.json`, so removed versions such as `0.142.0` cannot leave dead
+  PreToolUse/Stop handlers that exit `127`. It also writes `SessionEnd` hook
+  timeouts at Codex's 3-second limit instead of emitting `timeout: 5` and making
+  Codex warn that it is clamping the value on every startup. Source:
+  `apps/cli/src/lib/hooks.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- **Codex hook sync no longer leaves startup warnings after upgrades.** The Codex
+  hook registrar now prunes hook commands from sibling Codex version homes before
+  writing `hooks.json`, so removed versions such as `0.142.0` cannot leave dead
+  PreToolUse/Stop handlers that exit `127`. It also writes `SessionEnd` hook
+  timeouts at Codex's 3-second limit instead of emitting `timeout: 5` and making
+  Codex warn that it is clamping the value on every startup. Source:
+  `apps/cli/src/lib/hooks.ts`.
+
 ## 1.20.81
 
 - **Releases publish the CI-tested tree, not a drifted merge.** On a busy default

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **Codex hook sync no longer leaves startup warnings after upgrades.** The Codex
-  hook registrar now prunes hook commands from sibling Codex version homes before
-  writing `hooks.json`, so removed versions such as `0.142.0` cannot leave dead
-  PreToolUse/Stop handlers that exit `127`. It also writes `SessionEnd` hook
-  timeouts at Codex's 3-second limit instead of emitting `timeout: 5` and making
-  Codex warn that it is clamping the value on every startup. Source:
-  `apps/cli/src/lib/hooks.ts`.
-
 ## 1.20.81
 
 - **Releases publish the CI-tested tree, not a drifted merge.** On a busy default

--- a/apps/cli/src/lib/__tests__/hooks.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks.test.ts
@@ -201,6 +201,27 @@ describe('registerHooksToSettings - Codex', () => {
     expect(content).not.toContain('codex_hooks');
   });
 
+  it('caps Codex SessionEnd hook timeout at 3 seconds', () => {
+    const versionHome = makeVersionHome();
+    makeScript('on-session-end.sh');
+
+    const manifest: Record<string, ManifestHook> = {
+      'on-session-end': {
+        script: 'on-session-end.sh',
+        events: ['SessionEnd'],
+        timeout: 5,
+      },
+    };
+
+    const result = registerHooksToSettings('codex', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+
+    const hooksJson = JSON.parse(
+      fs.readFileSync(path.join(versionHome, '.codex', 'hooks.json'), 'utf-8')
+    );
+    expect(hooksJson.hooks.SessionEnd[0].hooks[0].timeout).toBe(3);
+  });
+
   it('does not duplicate managed hook entries on repeated calls', () => {
     const versionHome = makeVersionHome();
     makeScript('on-prompt.sh');
@@ -241,6 +262,77 @@ describe('registerHooksToSettings - Codex', () => {
     // User hook and managed hook share the no-matcher group; user entry is untouched
     expect(group.hooks).toHaveLength(2);
     expect(group.hooks[0]).toEqual(userHook);
+  });
+
+  it('drops stale sibling-version hook entries from hooks.json', () => {
+    const versionHome = path.join(
+      tmpDir,
+      '.agents',
+      '.history',
+      'versions',
+      'codex',
+      '0.146.0',
+      'home'
+    );
+    const hooksPath = path.join(versionHome, '.codex', 'hooks.json');
+    fs.mkdirSync(path.dirname(hooksPath), { recursive: true });
+
+    const oldVersionHook = {
+      type: 'command',
+      command: path.join(
+        tmpDir,
+        '.agents',
+        '.history',
+        'versions',
+        'codex',
+        '0.142.0',
+        'home',
+        '.codex',
+        'hooks',
+        'git-guard.sh'
+      ),
+      timeout: 5,
+    };
+    const currentVersionHook = {
+      type: 'command',
+      command: path.join(versionHome, '.codex', 'hooks', 'git-guard.sh'),
+      timeout: 5,
+    };
+    const customHook = {
+      type: 'command',
+      command: '/usr/local/bin/my-hook.sh',
+      timeout: 10,
+    };
+    fs.writeFileSync(hooksPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [oldVersionHook, currentVersionHook, customHook],
+          },
+        ],
+      },
+    }, null, 2));
+
+    const scriptPath = makeScript('git-guard.sh');
+    const manifest: Record<string, ManifestHook> = {
+      'git-guard': {
+        script: 'git-guard.sh',
+        events: ['PreToolUse'],
+        matcher: 'Bash',
+        timeout: 5,
+      },
+    };
+
+    const result = registerHooksToSettings('codex', versionHome, manifest, agentsDir);
+    expect(result.errors).toHaveLength(0);
+
+    const hooksJson = JSON.parse(fs.readFileSync(hooksPath, 'utf-8'));
+    const commands = hooksJson.hooks.PreToolUse[0].hooks.map((h: { command: string }) => h.command);
+    expect(commands).not.toContain(oldVersionHook.command);
+    expect(commands).toContain(currentVersionHook.command);
+    expect(commands).toContain(customHook.command);
+    expect(commands.map((c: string) => resolvedCommand(c))).toContain(toPosix(scriptPath));
   });
 
   it('ignores the deprecated agents: field — capability table decides registration', () => {

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -1724,12 +1724,19 @@ function registerHooksForCodex(
     if (resolved) currentManifestPaths.add(resolved);
   }
 
+  // Identity of the version home being synced. Codex stores hooks in a shared
+  // hooks.json per CODEX_HOME, but agents-cli registers version-scoped command
+  // paths; without this, old version entries keep firing after upgrades.
+  const currentVh = versionHomeIdentity(versionHome);
+
   // Remove stale entries from all event groups
   for (const eventGroups of Object.values(hooksFile.hooks)) {
     for (const group of eventGroups) {
       if (!group.hooks) continue;
       group.hooks = group.hooks.filter(
-        (h) => !isManagedHookCommand(h.command, managedPrefixes) || currentManifestPaths.has(h.command)
+        (h) =>
+          (!isManagedHookCommand(h.command, managedPrefixes) || currentManifestPaths.has(h.command)) &&
+          !isStaleSiblingVersionCommand(h.command, currentVh)
       );
     }
   }
@@ -1781,7 +1788,8 @@ function registerHooksForCodex(
       }
 
       const existingIdx = group.hooks.findIndex((h) => h.command === commandPath);
-      const hookEntry = { type: 'command', command: commandPath, timeout };
+      const eventTimeout = event === 'SessionEnd' ? Math.min(timeout, 3) : timeout;
+      const hookEntry = { type: 'command', command: commandPath, timeout: eventTimeout };
 
       if (existingIdx >= 0) {
         group.hooks[existingIdx] = hookEntry;


### PR DESCRIPTION
bug fix: Codex hook sync stops carrying stale version hooks and timeout-clamp warnings.

## What Changed

- Prunes managed Codex hook commands that point at sibling version homes, such as `0.142.0`, before writing the active `hooks.json`.
- Caps Codex `SessionEnd` hook timeouts at 3 seconds, matching Codex's startup limit.
- Adds regressions for both behaviors in `apps/cli/src/lib/__tests__/hooks.test.ts`.
- Updates the root changelog and adds the CLI release-note fragment under `apps/cli/.changelog/next/`.

## Verification

No UI surface. This change affects generated Codex hook config and CLI startup behavior.

```text
$ bun run test src/lib/__tests__/hooks.test.ts
Test Files  1 passed (1)
Tests       95 passed (95)
```

```text
$ bun run test scripts/gen-changelog.test.ts
Test Files  1 passed (1)
Tests       5 passed (5)
```

```text
$ bun run build
$ tsc && rm -rf 'dist/lib/secrets/AgentsKeychain.app' 'dist/lib/secrets/Agents CLI.app' ...
```

```text
$ agents run codex "Reply with exactly PINGOK" --mode plan --name hook-warning-pr-proof
OpenAI Codex v0.146.0
hook: SessionStart Completed
hook: UserPromptSubmit Completed
codex
PINGOK
hook: Stop Completed
PINGOK
```

The Codex probe above did not emit the target warnings:

- `PreToolUse hook (failed) error: hook exited with code 127`
- `Stop hook (failed) error: hook exited with code 127`
- `clamping SessionEnd hook timeout to 3s`

Fleet config remediation already applied and verified:

```text
yosemite-s0  active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
yosemite-m0  active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
yosemite-m1  active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
yosemite-m3  active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
yosemite-m4  active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
yosemite-m6  active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
yosemite-s1  active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
zion         active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
mac-mini     active 0.146.0 hooks.json: staleSibling=0 sessionEndGt3=0
```
