### PR TITLE
fix(sessions): improve batch resume defaults

### DIFF
--- a/apps/cli/.changelog/next/rush-2023.md
+++ b/apps/cli/.changelog/next/rush-2023.md
@@ -1,0 +1,7 @@
+- **`agents sessions resume` shows session previews immediately and opens one tab
+  per session by default (RUSH-2023).** The multi-select picker now starts its
+  preview pane open whenever the caller supplies preview content; `tab` still
+  toggles it. Batch resume now uses full-width tabs across terminal backends,
+  with side-by-side two-per-tab packing available explicitly via `--splits`.
+  Source: `apps/cli/src/lib/picker.ts`,
+  `apps/cli/src/commands/sessions-resume.ts`.

--- a/apps/cli/docs/terminal-engine.md
+++ b/apps/cli/docs/terminal-engine.md
@@ -131,7 +131,7 @@ await openSurfaces(items, {
 |---|---|
 | `--iterm` / `--ghostty` / `--tmux` / `--vscodium` | Force a backend (else auto-detect / prompt). |
 | `--host <alias>` | Resume on a remote host over SSH (defaults to `tmux`). |
-| `--tabs` | One tab per session (default packs two-per-tab). |
+| `--splits` | Pack two sessions side by side per tab (default is one tab per session). |
 
 Non-resumable agents (where `buildResumeCommand` returns null) are skipped with a
 note, never silently dropped. With no GUI backend and no tmux, resume falls back
@@ -167,9 +167,8 @@ codium --open-url 'vscodium://swarmify.swarm-ext/spawn?p=<base64url(JSON)>'
 - **No `zsh -ilc` wrap** — the command runs in an editor terminal that is already
   an interactive login shell (see [above](#interactive-login-shell)).
 
-**Layout:** VSCodium defaults to **one editor tab per session** (matching swarm-ext's
-native agent-terminal UX — full-width tabs, not split panes); the two-per-tab split
-packing is for the terminal-app backends. `--tabs` forces tabs on any backend.
+**Layout:** Every backend defaults to **one full-width tab per session**. `--splits`
+opts into two-per-tab split packing for side-by-side sessions.
 
 Auto-detection is intentionally *not* wired for this backend: a VS Code integrated
 terminal reports `TERM_PROGRAM=vscode` for all three products, so the engine can't

--- a/apps/cli/src/commands/sessions-resume.test.ts
+++ b/apps/cli/src/commands/sessions-resume.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { resolveResumePacking } from './sessions-resume.js';
+
+describe('resolveResumePacking', () => {
+  it('opens every resumed session in its own tab by default', () => {
+    expect(resolveResumePacking({})).toBe('tabs');
+  });
+
+  it('packs session pairs into split panes only when requested', () => {
+    expect(resolveResumePacking({ splits: true })).toBe('two-per-tab');
+  });
+});

--- a/apps/cli/src/commands/sessions-resume.ts
+++ b/apps/cli/src/commands/sessions-resume.ts
@@ -4,9 +4,9 @@
  *
  * Unlike the single-select picker behind bare `agents sessions` (which resumes
  * one session in place), this opens a checkbox picker, then asks where the
- * chosen sessions should resume. By default they pack two-per-tab (session 1 in
- * a new tab, session 2 split beside it, session 3 a new tab, …) in the terminal
- * you're in — iTerm / Ghostty / tmux, locally or on a remote host via --host.
+ * chosen sessions should resume. By default each session opens in its own tab in
+ * the terminal you're in — iTerm / Ghostty / tmux, locally or on a remote host
+ * via --host. `--splits` opts into packing two sessions side by side per tab.
  */
 import * as fs from 'fs';
 import chalk from 'chalk';
@@ -52,7 +52,7 @@ interface ResumeOptions {
   ghostty?: boolean;
   tmux?: boolean;
   vscodium?: boolean;
-  tabs?: boolean;
+  splits?: boolean;
 }
 
 export function registerSessionsResumeCommand(sessionsCmd: Command): void {
@@ -70,26 +70,25 @@ export function registerSessionsResumeCommand(sessionsCmd: Command): void {
     .option('--ghostty', 'Force the Ghostty backend')
     .option('--tmux', 'Force the tmux backend')
     .option('--vscodium', 'Force the VSCodium agent-terminal backend (swarm-ext)')
-    .option('--tabs', 'One tab per session (default: pack two panes per tab)');
+    .option('--splits', 'Pack two sessions side by side per tab (default: one tab per session)');
 
   setHelpSections(cmd, {
     examples: `
-      # Pick several sessions; they pack two-per-tab in your current terminal
+      # Pick several sessions; each opens in its own tab
       agents sessions resume
 
       # Pre-filter the pool before selecting (space in the filter → use [query])
       agents sessions resume "auth middleware"
 
-      # Force a backend / one tab each / a remote host
+      # Force a backend / side-by-side splits / a remote host
       agents sessions resume --ghostty
       agents sessions resume --vscodium
-      agents sessions resume --tabs
+      agents sessions resume --splits
       agents sessions resume --host zion --tmux
     `,
     notes: `
       - space toggles a session, enter confirms; tab toggles the preview pane.
-      - Layout: two-per-tab by default (session 1 → new tab, session 2 → split beside it, …). --tabs disables splitting.
-      - VSCodium defaults to one editor tab per session (matches swarm-ext's native agent-terminal UX); the others default to two-per-tab.
+      - Layout: one tab per session by default. --splits packs session pairs side by side in each tab.
       - Backend: auto-detected from the terminal you're in (iTerm / Ghostty / tmux); override with --iterm/--ghostty/--tmux/--vscodium.
       - --vscodium opens each session as an agent terminal tab in VSCodium via the swarm-ext extension (works with --host too).
       - --host <alias> resumes on a remote machine over the same SSH transport as 'sessions --host' (defaults to tmux).
@@ -193,11 +192,9 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
     return;
   }
 
-  // 5b. Fan out through the engine. Split-packing (two-per-tab) suits the
-  // terminal apps; the VSCodium backend defaults to one editor tab per session,
-  // matching swarm-ext's native agent-terminal UX. --tabs forces tabs anywhere.
-  const packing: Packing =
-    options.tabs || backend === 'vscodium-agent' ? 'tabs' : 'two-per-tab';
+  // 5b. Fan out through the engine. Full-width tabs are the default for batch
+  // recovery; callers can explicitly opt into pairs of side-by-side panes.
+  const packing = resolveResumePacking(options);
   const where = options.host ? `${backend} on ${options.host}` : backend;
   console.log(chalk.gray(`Opening ${items.length} session${items.length === 1 ? '' : 's'} in ${where} (${packing})…`));
 
@@ -218,6 +215,10 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
     }
   });
   console.log(chalk.gray(`\nOpened ${opened}/${items.length} in ${where}.`));
+}
+
+export function resolveResumePacking(options: Pick<ResumeOptions, 'splits'>): Packing {
+  return options.splits ? 'two-per-tab' : 'tabs';
 }
 
 /**

--- a/apps/cli/src/lib/picker.test.ts
+++ b/apps/cli/src/lib/picker.test.ts
@@ -1,4 +1,7 @@
 import { stripVTControlCharacters } from 'node:util';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawn } from '@homebridge/node-pty-prebuilt-multiarch';
 import { describe, expect, it } from 'vitest';
 import { limitPreviewHeight } from './picker.js';
 
@@ -31,5 +34,45 @@ describe('limitPreviewHeight', () => {
 
     expect(renderedRows(clipped, 20)).toBeLessThanOrEqual(3);
     expect(stripVTControlCharacters(clipped)).toContain('truncated');
+  });
+});
+
+describe('multiItemPicker', () => {
+  it('renders a supplied preview in its initial terminal frame', async () => {
+    const pickerUrl = pathToFileURL(path.resolve('src/lib/picker.ts')).href;
+    const program = `
+      import { multiItemPicker } from ${JSON.stringify(pickerUrl)};
+      await multiItemPicker({
+        message: 'Pick:',
+        items: [{ id: 'session-1' }],
+        filter: () => [{ id: 'session-1' }],
+        labelFor: () => 'Session one',
+        keyFor: (item) => item.id,
+        buildPreview: () => 'PREVIEW_VISIBLE',
+      });
+    `;
+    const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', program], {
+      cols: 120,
+      rows: 40,
+      cwd: process.cwd(),
+      env: { ...process.env, TERM: 'xterm-256color' },
+    });
+
+    const output = await new Promise<string>((resolve, reject) => {
+      let captured = '';
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error(`picker preview did not render:\n${stripVTControlCharacters(captured)}`));
+      }, 10_000);
+      child.onData((data) => {
+        captured += data;
+        if (!captured.includes('PREVIEW_VISIBLE')) return;
+        clearTimeout(timeout);
+        child.kill();
+        resolve(captured);
+      });
+    });
+
+    expect(stripVTControlCharacters(output)).toContain('PREVIEW_VISIBLE');
   });
 });

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -302,7 +302,7 @@ export function multiItemPicker<T>(config: MultiPickerConfig<T>): Promise<T[] | 
     const theme = makeTheme({});
     const [status, setStatus] = useState<'idle' | 'done'>('idle');
     const [searchTerm, setSearchTerm] = useState(cfg.initialSearch ?? '');
-    const [previewOpen, setPreviewOpen] = useState(false);
+    const [previewOpen, setPreviewOpen] = useState(Boolean(cfg.buildPreview));
     const [selectedKeys, setSelectedKeys] = useState<ReadonlySet<string>>(new Set());
     const [active, setActive] = useState(0);
     const prefix = usePrefix({ status, theme });


### PR DESCRIPTION
Fixes RUSH-2023 by changing the two batch-recovery defaults in `agents sessions resume`.

## What changed

- The multi-select picker starts its preview pane open whenever `buildPreview` is supplied; Tab still toggles it.
- Batch resume opens one full-width tab per session by default.
- `--splits` explicitly opts into two side-by-side sessions per tab.
- Terminal-engine docs and the unreleased changelog queue describe the new behavior.

## Real CLI run

CLI-only surface; the built command was run inside a real PTY against a real Codex transcript fixture. The preview was visible in the initial frame without pressing Tab:

```text
? Select sessions to resume: (type to filter · space to toggle · enter to resume)
> [ ] codex-fi  codex    0.128.0 proj  fix the flaky test in the parser  Jul 5
────────────────────────────────────────────────────────────────────────────────
Codex v0.128.0 · codex-fi
/tmp/proj · proj · started 27d 17h ago · lasted 1s
1 msg · codex-fixture-0001
  Prompt: fix the flaky test in the parser
0 selected · ↑↓ navigate · space toggle · tab preview · ⏎ resume · esc cancel
```

Confirming the highlighted session with the tmux backend printed the new default packing before the isolated no-server transport failed safely:

```text
Opening 1 session in tmux (tabs)…
  failed codex-fi — tmux exited with code 1

Opened 0/1 in tmux.
```

## Verification

- `bun run test -- scripts/gen-changelog.test.ts src/lib/picker.test.ts src/commands/sessions-resume.test.ts` — 3 files passed, 11 tests passed.
- `bun run build` — passed.
- Full local suite: 7,422 passed, 77 skipped; 151 unrelated sandbox failures wrote to read-only `~/.agents` paths. The preferred remote runner could not dispatch because `HCLOUD_TOKEN is empty after secret resolution`.

## Context

- Linear: https://linear.app/getrush/issue/RUSH-2023/sessions-resume-show-the-preview-by-default-and-stop-defaulting-multi
- Session transcript: omitted because this is a public repository.
