### PR TITLE
fix(secrets): --device alias + surface silent keychain-over-ssh export failures

### DIFF
--- a/apps/cli/.changelog/next/harden-secrets-export.md
+++ b/apps/cli/.changelog/next/harden-secrets-export.md
@@ -1,0 +1,14 @@
+- **`agents secrets export`/`list`/`view` now accept `--device`/`--devices` as
+  aliases for `--host`/`--hosts`, and a keychain-backed `export --host` push is
+  verified.** `--device mac-mini` used to fail with "unknown option" on the secrets
+  commands even though the rest of the fleet vocabulary (`agents activity`,
+  `agents run --device`) accepts it; it now resolves identically to `--host`. And a
+  default keychain-backend push to a macOS host over headless SSH — the sign host a
+  Linux-driven release offloads `apple.com` provisioning to — used to land the bundle
+  metadata but no readable secret items (the remote login keychain is locked over
+  SSH), then fail every later read with the confusing `Bundle 'X' key 'Y': stored
+  item '...' not found`. The push now reads the bundle back the way a headless release
+  will and **fails loudly** when the keys didn't persist, naming the locked-login-keychain
+  cause and steering to `--remote-backend file` (headless-readable) or unlocking the
+  remote keychain. This unblocks headless Linux-driven releases. Source:
+  `apps/cli/src/commands/secrets.ts`, `apps/cli/src/lib/secrets/remote.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -297,6 +297,17 @@ for the narrow case of building + pulling back JUST the signed macOS artifacts f
 another Mac (no publish); it too is zero-config, targeting the same hardcoded
 `RELEASE_HOME_BASE` with no env knobs or fleet discovery.
 
+**Provisioning the `apple.com` bundle on a headless sign host.** A Linux-driven
+release offloads macOS signing to a sign host over SSH, which needs the `apple.com`
+secrets bundle *on that host*. Push it with the **file backend** —
+`agents secrets export apple.com --host <signer> --remote-backend file` (needs
+`AGENTS_SECRETS_PASSPHRASE` set locally) — **not** the default keychain backend: a
+macOS login keychain is locked under headless SSH, so a keychain-backed push lands
+the bundle metadata but no readable secret items (`secrets export --host` now
+read-back-verifies a keychain push and fails loudly if it didn't persist, pointing
+at this fix). `--device` is accepted as an alias for `--host` on the secrets remote
+commands. See [`docs/secrets.md`](docs/secrets.md) → *Pushing to a headless sign host*.
+
 **Why not CI?** The tarball bundles `dist/lib/secrets/Agents CLI.app` — a native
 keychain helper compiled with `swiftc`, codesigned (Developer ID), and notarized
 (`xcrun notarytool`). `prepack` ([`scripts/verify-keychain-helper.sh`](scripts/verify-keychain-helper.sh))

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -166,8 +166,10 @@ agents run claude "ship it" --secrets r2.backups@yosemite-s1   # bundle@host suf
 ```
 
 - **`--host <target>`** (single) and **`--hosts <a,b,c>`** (comma list) compose on
-  `list` / `view`; **`bundle@host`** is the reference form for `run --secrets` and
-  the target for `exec --host`.
+  `list` / `view` / `export`; **`--device` / `--devices`** are accepted as aliases
+  everywhere `--host` / `--hosts` are (fleet-vocabulary parity with `agents activity`
+  and `agents run --device`), and resolve identically. **`bundle@host`** is the
+  reference form for `run --secrets` and the target for `exec --host`.
 - **Ephemeral.** Remote values cross over ssh stdout (encrypted in transit), are
   parsed in memory, and injected into the run/command env — never written to this
   machine's keychain or disk.
@@ -177,6 +179,33 @@ agents run claude "ship it" --secrets r2.backups@yosemite-s1   # bundle@host suf
   a remote `file` bundle, an already-unlocked remote secrets-agent, or run
   `view --reveal` from an interactive terminal (it forces an SSH TTY so the prompt
   can surface). This machine's passphrase is never forwarded.
+
+### Pushing to a headless sign host — use `--remote-backend file`
+
+`secrets export --host` defaults to `--remote-backend keychain`. On a **macOS**
+target reached over headless SSH (e.g. the sign host a Linux-driven release offloads
+notarization to), the remote login keychain is **locked** in the non-interactive SSH
+context: the keychain *write* is accepted but the biometry-gated items are not
+readable, so the push lands the bundle **metadata** with no readable secret values,
+and the remote `import` still reports success. A later headless read then fails with
+the confusing `Bundle '<b>' key '<k>': stored item '…' not found`.
+
+The push now **verifies** a keychain-backed write by reading the bundle back the way
+a release will (headlessly, so no Touch ID) and **fails loudly** if the keys didn't
+materialize — naming the locked-login-keychain cause and steering to the fix. For a
+headless sign host, push with the headless-readable file backend instead:
+
+```bash
+export AGENTS_SECRETS_PASSPHRASE="…"                 # one biometry-gated read on the laptop
+agents secrets export apple.com --host mac-mini --remote-backend file
+```
+
+A file-backed bundle is encrypted at rest with `AGENTS_SECRETS_PASSPHRASE` (forwarded
+over ssh stdin, never argv) and reads with no biometry — the right choice whenever the
+remote can't satisfy a Touch ID prompt. Alternatively, unlock the remote login
+keychain first (an interactive login / `agents secrets unlock` on the target) and
+retry the keychain push. See [File-backed bundles](#file-backed-bundles-headless--remote)
+and [Recipe 8](#8-headless-release-on-a-remote-mac).
 
 ### Push to a Windows host
 
@@ -269,6 +298,8 @@ The Windows push bridge is `buildWindowsStdinImportCommand` in
 | `secrets export [bundle] --to-1password --vault <name>` | Push bundle to a 1Password vault | `agents secrets export prod --to-1password --vault Team` |
 | `secrets export ... --force` | Overwrite existing 1Password items | `agents secrets export prod --to-1password --vault Team --force` |
 | `secrets export [bundle] --to-file <path>` | Write the bundle as an AES-256-GCM encrypted offline file (needs `AGENTS_SECRETS_PASSPHRASE`; symmetric counterpart of `import --from-file`) | `agents secrets export prod --to-file prod.enc` |
+| `secrets export [bundle] --host <target>` | Push the bundle over SSH to a remote (repeatable; `--device` is an alias). Keychain-backed by default; the push read-back-verifies the write and fails loudly if it didn't persist | `agents secrets export apple.com --host mac-mini` |
+| `secrets export ... --remote-backend file` | Push as a headless-readable file bundle (needs `AGENTS_SECRETS_PASSPHRASE`) — required for a **headless sign host** whose login keychain is locked over SSH | `agents secrets export apple.com --host mac-mini --remote-backend file` |
 
 ### Agent commands (macOS)
 

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -17,6 +18,7 @@ import {
   parsePolicyOpt,
   quoteWin32ExecArg,
   readImportDotenv,
+  registerSecretsCommands,
   renderPolicyCol,
 } from './secrets.js';
 import { parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
@@ -62,6 +64,51 @@ describe('parseImportSource', () => {
   it('rejects missing and conflicting sources', () => {
     expect(() => parseImportSource({})).toThrow(/--from <source>/);
     expect(() => parseImportSource({ from: '.env', from1password: true })).toThrow(/mutually exclusive/);
+  });
+});
+
+describe('secrets --device alias wiring (resolves identically to --host)', () => {
+  function secretsSub(name: string): Command {
+    const program = new Command();
+    registerSecretsCommands(program);
+    const secrets = program.commands.find((c) => c.name() === 'secrets');
+    if (!secrets) throw new Error('secrets command not registered');
+    const sub = secrets.commands.find((c) => c.name() === name || c.aliases().includes(name));
+    if (!sub) throw new Error(`secrets ${name} not registered`);
+    return sub;
+  }
+
+  it('registers --device / --devices on export, list, and view', () => {
+    for (const name of ['export', 'list', 'view']) {
+      const longs = secretsSub(name).options.map((o) => o.long);
+      expect(longs).toContain('--host');
+      expect(longs).toContain('--device');
+    }
+  });
+
+  it('export accepts repeatable --device without an unknown-option error and parses the target', () => {
+    const cmd = secretsSub('export');
+    cmd.exitOverride();
+    expect(() => cmd.parseOptions(['apple.com', '--device', 'mac-mini'])).not.toThrow();
+    // Variadic --device mirrors the variadic --host it aliases.
+    expect(cmd.opts().device).toEqual(['mac-mini']);
+    const cmd2 = secretsSub('export');
+    cmd2.exitOverride();
+    cmd2.parseOptions(['apple.com', '--device', 'a', '--device', 'b']);
+    expect(cmd2.opts().device).toEqual(['a', 'b']);
+  });
+
+  it('list/view accept --device and --devices without an unknown-option error', () => {
+    for (const name of ['list', 'view']) {
+      const cmd = secretsSub(name);
+      cmd.exitOverride();
+      expect(() => cmd.parseOptions(['--device', 'mac-mini'])).not.toThrow();
+      expect(cmd.opts().device).toBe('mac-mini');
+      const cmd2 = secretsSub(name);
+      cmd2.exitOverride();
+      expect(() => cmd2.parseOptions(['--devices', 'a,b'])).not.toThrow();
+      expect(cmd2.opts().devices).toBe('a,b');
+    }
   });
 });
 

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -22,6 +22,8 @@ import {
   remoteSecretsRaw,
   remoteSecretsStream,
   resolveHostSshTarget,
+  verifyRemoteKeychainPush,
+  keychainWriteFailureMessage,
 } from '../lib/secrets/remote.js';
 import { remoteShellFor, buildWindowsStdinImportCommand } from '../lib/hosts/remote-cmd.js';
 import { resolveRemoteOsSync } from '../lib/hosts/remote-os.js';
@@ -886,8 +888,10 @@ export function registerSecretsCommands(program: Command): void {
     .description('List configured secrets bundles (use --host/--hosts to list bundles on other machines over SSH)')
     .option('--host <target>', 'List bundles on a remote host over SSH (enrolled `agents hosts` name, ssh-config alias, or user@host)')
     .option('--hosts <list>', 'Comma-separated hosts to list in one shot, e.g. yosemite-s0,yosemite-s1')
+    .option('--device <target>', 'Alias for --host')
+    .option('--devices <list>', 'Alias for --hosts')
     .option('--json', 'Emit machine-readable JSON (bundle metadata only — never secret values) instead of the table')
-    .action(async (opts: { host?: string; hosts?: string; json?: boolean }) => {
+    .action(async (opts: { host?: string; hosts?: string; device?: string; devices?: string; json?: boolean }) => {
       const targets = parseHostsOption(opts);
       if (targets.length > 0) {
         await browseRemote(targets, opts.json ? ['list', '--json'] : ['list'], false);
@@ -953,7 +957,9 @@ export function registerSecretsCommands(program: Command): void {
     .option('--json', 'Emit machine-readable JSON (values masked unless --reveal) instead of the human view')
     .option('--host <target>', 'Show a bundle on a remote host over SSH (enrolled `agents hosts` name, ssh-config alias, or user@host)')
     .option('--hosts <list>', 'Comma-separated hosts to show in one shot, e.g. yosemite-s0,yosemite-s1')
-    .action(async (name: string | undefined, opts: { reveal?: boolean; plaintext?: boolean; json?: boolean; host?: string; hosts?: string }) => {
+    .option('--device <target>', 'Alias for --host')
+    .option('--devices <list>', 'Alias for --hosts')
+    .action(async (name: string | undefined, opts: { reveal?: boolean; plaintext?: boolean; json?: boolean; host?: string; hosts?: string; device?: string; devices?: string }) => {
       try {
         const targets = parseHostsOption(opts);
         if (targets.length > 0) {
@@ -1772,6 +1778,7 @@ Examples:
     .option('--to-1password', 'Push every key in the bundle as a PASSWORD item in a 1Password vault')
     .option('--vault <name>', '1Password vault name (used with --to-1password)')
     .option('--host <target...>', 'Push the bundle over SSH to this target (host alias or user@host); repeatable for multiple machines')
+    .option('--device <target...>', 'Alias for --host; repeatable')
     .option('--remote-backend <backend>', 'Backend for the bundle on the remote (with --host): keychain (default) or file (passphrase-encrypted, headless-readable). file forwards AGENTS_SECRETS_PASSPHRASE over stdin.', 'keychain')
     .option('--force', 'Overwrite existing keys/items on the target (used with --to-1password and --host)')
     .option('--format <shell|json>', 'Output for --plaintext export: shell (default) or json (lossless, machine-readable; used by remote resolve)', 'shell')
@@ -1781,12 +1788,17 @@ Examples:
       to1password?: boolean;
       vault?: string;
       host?: string[];
+      device?: string[];
       remoteBackend?: string;
       force?: boolean;
       format?: string;
       toFile?: string;
     }) => {
       try {
+        // `--device` is an alias for `--host` (fleet vocabulary parity with
+        // `agents activity`/`run --device`); fold it into the host list up front so
+        // every downstream branch sees one resolved target list.
+        if (opts.device?.length) opts.host = [...(opts.host ?? []), ...opts.device];
         const { readAndResolveBundleEnv, bundleToEnvPrefix, isReservedEnvName } = await import('../lib/secrets/bundles.js');
         const resolvedBundleName = bundleName ?? (await pickBundleName('export'));
 
@@ -1884,6 +1896,28 @@ Examples:
               const msg = (res.stderr || res.stdout || '').trim();
               console.error(chalk.red(`${host}: remote import failed (exit ${res.code})${msg ? `: ${msg}` : ''}`));
               continue;
+            }
+            // A keychain-backed push to a macOS remote over headless SSH can land
+            // the bundle metadata but no READABLE value items: the remote login
+            // keychain is locked in the non-interactive SSH context, so Security
+            // accepts the write but the biometry-ACL'd item is unreadable, and the
+            // remote `import` still exits 0. Read the bundle back the same way a
+            // release will (drops the plaintext, keeps only key presence; the
+            // remote's headless `agentOnly` guard fails fast, so no Touch ID) and
+            // FAIL LOUDLY if the keys didn't materialize — rather than leave a
+            // metadata-only bundle that breaks later with "stored item not found".
+            // The file backend is headless-readable by construction, so skip it.
+            if (remoteBackend === 'keychain') {
+              const verdict = verifyRemoteKeychainPush(host, resolvedBundleName, Object.keys(env), { osLookupName: host });
+              if (!verdict.ok) {
+                failures++;
+                if (verdict.kind === 'locked-keychain') {
+                  console.error(chalk.red(keychainWriteFailureMessage(host, resolvedBundleName, verdict.reason)));
+                } else {
+                  console.error(chalk.red(`${host}: pushed '${resolvedBundleName}' but could not verify it on the remote: ${verdict.reason}`));
+                }
+                continue;
+              }
             }
             const remoteMsg = (res.stdout || '').trim().split('\n').map((l) => l.trim()).filter(Boolean).pop();
             console.log(chalk.green(`${host} -> '${resolvedBundleName}': ${remoteMsg || `${keyCount} key(s) exported`}`));

--- a/apps/cli/src/lib/secrets/remote.test.ts
+++ b/apps/cli/src/lib/secrets/remote.test.ts
@@ -34,6 +34,9 @@ import {
   remoteSecretsRaw,
   remoteResolveEnv,
   isDangerousRemoteEnvKey,
+  verifyRemoteKeychainPush,
+  evaluateKeychainWriteVerification,
+  keychainWriteFailureMessage,
 } from './remote.js';
 
 const ok = (stdout: string): SshExecResult => ({ code: 0, stdout, stderr: '', timedOut: false });
@@ -62,6 +65,24 @@ describe('parseHostsOption', () => {
 
   it('merges --host and --hosts, trims, drops empties, dedupes in order', () => {
     expect(parseHostsOption({ host: 'a', hosts: 'b, a ,,c' })).toEqual(['a', 'b', 'c']);
+  });
+
+  it('resolves --device identically to --host', () => {
+    expect(parseHostsOption({ device: 'mac-mini' })).toEqual(['mac-mini']);
+  });
+
+  it('resolves --devices identically to --hosts', () => {
+    expect(parseHostsOption({ devices: 'yosemite-s0,yosemite-s1' })).toEqual(['yosemite-s0', 'yosemite-s1']);
+  });
+
+  it('--host and --device dedupe to the same resolved target', () => {
+    // A user passing both the host name and its device alias must not get it twice.
+    expect(parseHostsOption({ host: 'mac-mini', device: 'mac-mini' })).toEqual(['mac-mini']);
+  });
+
+  it('composes all four flags in host,device,hosts,devices order, deduped', () => {
+    expect(parseHostsOption({ host: 'a', device: 'b', hosts: 'c,a', devices: 'd,b' }))
+      .toEqual(['a', 'b', 'c', 'd']);
   });
 });
 
@@ -271,5 +292,111 @@ describe('isDangerousRemoteEnvKey', () => {
     for (const k of ['FOO', 'ANTHROPIC_API_KEY', 'DATABASE_URL', 'GITHUB_TOKEN', 'MY_PROXYING']) {
       expect(isDangerousRemoteEnvKey(k)).toBe(false);
     }
+  });
+});
+
+describe('evaluateKeychainWriteVerification (post-push read-back verdict)', () => {
+  it('passes when the read-back returns every pushed key', () => {
+    expect(evaluateKeychainWriteVerification(['A', 'B'], { ok: true, keys: ['A', 'B', 'C'] }))
+      .toEqual({ ok: true });
+  });
+
+  it('flags locked-keychain when a pushed key is absent from the read-back', () => {
+    const v = evaluateKeychainWriteVerification(['A', 'B'], { ok: true, keys: ['A'] });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error('expected failure');
+    expect(v.kind).toBe('locked-keychain');
+    expect(v.reason).toContain('B');
+  });
+
+  it('flags locked-keychain on the remote "not unlocked in the secrets agent" read-back error', () => {
+    const v = evaluateKeychainWriteVerification(['A'], {
+      ok: false,
+      stderr: "Bundle 'apple.com' is not unlocked in the secrets agent.",
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error('expected failure');
+    expect(v.kind).toBe('locked-keychain');
+  });
+
+  it('flags locked-keychain on the "stored item ... not found" read-back error', () => {
+    const v = evaluateKeychainWriteVerification(['A'], {
+      ok: false,
+      stderr: "Bundle 'apple.com' key 'A': stored item 'agents-cli.secrets.apple.com.A' not found.",
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error('expected failure');
+    expect(v.kind).toBe('locked-keychain');
+  });
+
+  it('does NOT diagnose a locked keychain from a transient SSH/network failure', () => {
+    // A flaky connection must be re-surfaced as-is, never mislabeled "locked keychain".
+    const v = evaluateKeychainWriteVerification(['A'], {
+      ok: false,
+      stderr: 'ssh: connect to host mac-mini port 22: Connection refused',
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error('expected failure');
+    expect(v.kind).toBe('error');
+    expect(v.reason).toContain('Connection refused');
+  });
+});
+
+describe('keychainWriteFailureMessage', () => {
+  it('names the locked-login-keychain cause and steers to --remote-backend file', () => {
+    const msg = keychainWriteFailureMessage('mac-mini', 'apple.com', 'the remote could not read it back');
+    expect(msg).toContain('mac-mini');
+    expect(msg).toContain('apple.com');
+    expect(msg).toContain('login keychain is LOCKED');
+    expect(msg).toContain('--remote-backend file');
+    expect(msg).toContain('unlock the remote keychain');
+  });
+});
+
+describe('verifyRemoteKeychainPush (real read-back over the stubbed SSH boundary)', () => {
+  it('passes when the remote read-back returns the pushed keys, and never retains values', () => {
+    // The remote export returns plaintext values; verification keeps only key names.
+    sshExecMock.mockReturnValue(ok('{"APPLE_ID":"secret-value","APP_PWD":"another"}'));
+    const v = verifyRemoteKeychainPush('mac-mini', 'apple.com', ['APPLE_ID', 'APP_PWD']);
+    expect(v).toEqual({ ok: true });
+    // The verdict must not leak the plaintext values it read back.
+    expect(JSON.stringify(v)).not.toContain('secret-value');
+    // It drove the same read a headless release performs.
+    const [, remoteCmd] = sshExecMock.mock.calls[0];
+    expect(remoteCmd).toContain('agents secrets export apple.com --plaintext --format json');
+  });
+
+  it('flags locked-keychain when the remote headless read-back fails with the not-unlocked guard', () => {
+    // This is the real silent-failure: keychain write "succeeded" (exit 0 on the
+    // import) but the value items are unreadable, so the remote's own headless read
+    // (agentOnly guard) refuses — exactly what a later release hits.
+    sshExecMock.mockReturnValue({
+      code: 1,
+      stdout: '',
+      stderr: "Bundle 'apple.com' is not unlocked in the secrets agent. Run: agents secrets unlock apple.com",
+      timedOut: false,
+    });
+    const v = verifyRemoteKeychainPush('mac-mini', 'apple.com', ['APPLE_ID']);
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error('expected failure');
+    expect(v.kind).toBe('locked-keychain');
+  });
+
+  it('flags locked-keychain when a pushed key is missing from a successful read-back', () => {
+    sshExecMock.mockReturnValue(ok('{"APPLE_ID":"v"}'));
+    const v = verifyRemoteKeychainPush('mac-mini', 'apple.com', ['APPLE_ID', 'APP_PWD']);
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error('expected failure');
+    expect(v.kind).toBe('locked-keychain');
+    expect(v.reason).toContain('APP_PWD');
+  });
+
+  it('re-surfaces a transient error verbatim rather than diagnosing a locked keychain', () => {
+    sshExecMock.mockReturnValue({ code: null, stdout: '', stderr: '', timedOut: true });
+    const v = verifyRemoteKeychainPush('mac-mini', 'apple.com', ['APPLE_ID']);
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error('expected failure');
+    expect(v.kind).toBe('error');
+    expect(v.reason).toContain('timed out');
   });
 });

--- a/apps/cli/src/lib/secrets/remote.ts
+++ b/apps/cli/src/lib/secrets/remote.ts
@@ -75,10 +75,18 @@ export async function resolveHostSshTarget(nameOrAlias: string): Promise<string>
 }
 
 /**
- * Merge `--host <single>` and `--hosts <a,b,c>` into an ordered, de-duplicated
- * list. Both flags compose; either alone works. Empty when neither is set.
+ * Merge `--host <single>` / `--hosts <a,b,c>` (and their `--device` / `--devices`
+ * aliases) into an ordered, de-duplicated list. All four flags compose; any alone
+ * works. `--device`/`--devices` resolve identically to `--host`/`--hosts` so the
+ * fleet-wide `--device` vocabulary (see `agents activity`, `agents run --device`)
+ * works on the secrets remote commands too. Empty when none is set.
  */
-export function parseHostsOption(opts: { host?: string; hosts?: string }): string[] {
+export function parseHostsOption(opts: {
+  host?: string;
+  hosts?: string;
+  device?: string;
+  devices?: string;
+}): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   const push = (h: string) => {
@@ -89,7 +97,9 @@ export function parseHostsOption(opts: { host?: string; hosts?: string }): strin
     }
   };
   if (opts.host) push(opts.host);
+  if (opts.device) push(opts.device);
   if (opts.hosts) for (const h of opts.hosts.split(',')) push(h);
+  if (opts.devices) for (const h of opts.devices.split(',')) push(h);
   return out;
 }
 
@@ -231,4 +241,173 @@ export async function remoteResolveEnv(
     keyCount: Object.keys(env).length,
   });
   return env;
+}
+
+/**
+ * Outcome of a post-push read-back verification (see verifyRemoteKeychainPush).
+ *   - `ok`               — the pushed keys materialized readably on the remote.
+ *   - `locked-keychain`  — the read-back gave the SPECIFIC signal of a keychain
+ *                          that didn't persist (the remote's headless "not unlocked
+ *                          in the secrets agent" guard, or a "stored item … not
+ *                          found" on read-back, or pushed keys simply absent). Only
+ *                          this verdict earns the locked-login-keychain diagnosis +
+ *                          `--remote-backend file` steer.
+ *   - `error`            — a DIFFERENT failure (flaky SSH, timeout, unparseable
+ *                          payload). The raw error is re-surfaced verbatim, never
+ *                          mislabeled as a locked keychain.
+ */
+export type RemoteKeychainWriteVerification =
+  | { ok: true }
+  | { ok: false; kind: 'locked-keychain'; reason: string }
+  | { ok: false; kind: 'error'; reason: string };
+
+/**
+ * The remote's headless read-back raises one of these when a keychain-backed bundle
+ * has metadata but no readable value items — the exact locked-login-keychain
+ * signature. Anything else (connection refused, timeout, host key error) is a
+ * transient/unrelated failure and must NOT be mislabeled as a locked keychain.
+ */
+function isLockedKeychainReadBackError(stderr: string): boolean {
+  const s = stderr.toLowerCase();
+  return (
+    // bundles.ts agentOnly guard: "…is not unlocked in the secrets agent…"
+    s.includes('not unlocked') ||
+    s.includes('secrets agent') ||
+    // resolveBundleEnv: "Bundle '<b>' key '<k>': stored item '<item>' not found."
+    s.includes('stored item') ||
+    s.includes('not found')
+  );
+}
+
+/**
+ * Decide whether a keychain-backed push to a remote actually PERSISTED its secret
+ * value items, given the read-back of that bundle from the remote's own store.
+ *
+ * The silent-failure this guards: pushing `--remote-backend keychain` (default) to
+ * a macOS host over headless SSH lands the bundle METADATA but not readable value
+ * items — the remote login keychain is locked in the non-interactive SSH context,
+ * so Security accepts the item WRITE at the DB level but the biometry-ACL'd item is
+ * unreadable, and the remote `import` still reports success (values written first,
+ * metadata `noAcl` last — bundles.ts writeBundleWithItems). The metadata-only bundle
+ * then fails every later read with the confusing `Bundle '<b>' key '<k>': stored
+ * item '<item>' not found` (bundles.ts resolveBundleEnv). We catch it by reading
+ * the bundle back the same way a release will (`secrets export --plaintext --format
+ * json`, driven headlessly on the remote so its `agentOnly` guard FAILS FAST before
+ * any keychain read — no Touch ID prompt) and confirming every pushed key returned.
+ *
+ * Pure so both branches are unit-testable without a real locked keychain: inject the
+ * "read-back failed / key absent" condition through `readBack`.
+ */
+export function evaluateKeychainWriteVerification(
+  pushedKeys: string[],
+  readBack:
+    | { ok: true; keys: string[] }
+    | { ok: false; stderr: string },
+): RemoteKeychainWriteVerification {
+  if (!readBack.ok) {
+    const stderr = readBack.stderr.trim();
+    if (isLockedKeychainReadBackError(stderr)) {
+      // The remote's own headless read raised the not-unlocked / not-found signal —
+      // exactly the confusing error the user hits later. Surface it now, at push
+      // time, with the fix.
+      return {
+        ok: false,
+        kind: 'locked-keychain',
+        reason: `the remote could not read it back${stderr ? ` (${stderr})` : ''}`,
+      };
+    }
+    // A transient / unrelated failure (flaky SSH, timeout, bad payload). Re-surface
+    // verbatim — do NOT diagnose a locked keychain from a connection error.
+    return {
+      ok: false,
+      kind: 'error',
+      reason: stderr || 'read-back failed',
+    };
+  }
+  const present = new Set(readBack.keys);
+  const missing = pushedKeys.filter((k) => !present.has(k));
+  if (missing.length > 0) {
+    // Read-back succeeded but some pushed keys are absent — the value items didn't
+    // persist. Same locked-keychain cause and fix.
+    return {
+      ok: false,
+      kind: 'locked-keychain',
+      reason:
+        `${missing.length} of ${pushedKeys.length} key(s) did not persist on the remote ` +
+        `(missing: ${missing.slice(0, 5).join(', ')}${missing.length > 5 ? ', …' : ''})`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * The actionable error message for a failed keychain-over-SSH push verification.
+ * Names the cause (locked remote login keychain) and steers to the two real fixes:
+ * re-run with the headless-readable file backend, or unlock the remote keychain.
+ * Pure + exported so the exact guidance is asserted in tests.
+ */
+export function keychainWriteFailureMessage(
+  host: string,
+  bundle: string,
+  reason: string,
+): string {
+  return (
+    `${host}: pushed '${bundle}' but the keychain items did not persist — ${reason}. ` +
+    `A macOS login keychain is LOCKED under headless SSH, so a keychain-backed write ` +
+    `lands the bundle metadata but no readable secret items, and later reads fail with ` +
+    `"stored item '…' not found". Re-run with a headless-readable backend:\n` +
+    `    agents secrets export ${bundle} --host ${host} --remote-backend file\n` +
+    `(needs AGENTS_SECRETS_PASSPHRASE set locally), or unlock the remote keychain first ` +
+    `(e.g. an interactive login / \`agents secrets unlock\` on ${host}) and retry.`
+  );
+}
+
+/**
+ * Read a bundle back from a remote over SSH (headlessly, so it fails fast rather
+ * than prompting Touch ID) and confirm the pushed keys materialized. Drives the
+ * remote's own `secrets export <bundle> --plaintext --format json` — the same read
+ * a headless release performs — but keeps only the KEY NAMES; the plaintext values
+ * are dropped immediately and never retained or logged. Returns a verification
+ * verdict; the caller renders `keychainWriteFailureMessage` on failure.
+ */
+export function verifyRemoteKeychainPush(
+  target: string,
+  bundle: string,
+  pushedKeys: string[],
+  opts: { osLookupName?: string } = {},
+): RemoteKeychainWriteVerification {
+  const remoteCmd = buildRemoteAgentsInvocation(
+    ['secrets', 'export', bundle, '--plaintext', '--format', 'json'],
+    undefined,
+    osForTarget(target, opts.osLookupName),
+  );
+  const res: SshExecResult = sshExec(target, remoteCmd, { timeoutMs: REMOTE_TIMEOUT_MS });
+  if (res.code !== 0) {
+    const why = res.timedOut ? 'timed out' : res.code === null ? 'ssh failed' : `exit ${res.code}`;
+    const stderr = `${why}${(res.stderr || res.stdout || '').trim() ? `: ${(res.stderr || res.stdout).trim()}` : ''}`;
+    return evaluateKeychainWriteVerification(pushedKeys, { ok: false, stderr });
+  }
+  // Take the outer { … } object (tolerate login-shell banner noise), read the key
+  // names, and immediately discard the values — we only need presence here.
+  const raw = res.stdout;
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  const jsonText = start >= 0 && end >= start ? raw.slice(start, end + 1) : raw.trim();
+  let keys: string[];
+  try {
+    const parsed = JSON.parse(jsonText) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return evaluateKeychainWriteVerification(pushedKeys, {
+        ok: false,
+        stderr: 'unexpected read-back payload',
+      });
+    }
+    keys = Object.keys(parsed as Record<string, unknown>);
+  } catch {
+    return evaluateKeychainWriteVerification(pushedKeys, {
+      ok: false,
+      stderr: 'could not parse read-back JSON',
+    });
+  }
+  return evaluateKeychainWriteVerification(pushedKeys, { ok: true, keys });
 }


### PR DESCRIPTION
## Why

A Linux-driven release offloads macOS signing to a sign host over SSH (via `remote-sign-mac.sh`), which needs the `apple.com` secrets bundle provisioned on that host. Two bugs in `agents secrets export` made that provisioning fail confusingly and sent users in circles.

### Bug 1 — `--device` rejected on the secrets commands

`agents secrets export <bundle> --host <target>` accepted `--host` but **not** `--device`, while the rest of the fleet vocabulary (`agents activity`, `agents run --device`) takes `--device`. A user typing `--device mac-mini` hit:

```
error: unknown option '--device'
```

### Bug 2 — silent keychain-over-SSH write, then a confusing read failure

Pushing with the default `--remote-backend keychain` to a **macOS** host over headless SSH landed the bundle **metadata** but no readable secret items. The remote login keychain is locked in the non-interactive SSH context: macOS Security *accepts* the item write at the DB level, but the biometry-ACL'd item is unreadable, and the remote `import` still exits 0. A later headless read then failed with:

```
Bundle 'apple.com' key 'APPLE_ID': stored item 'agents-cli.secrets.apple.com.APPLE_ID' not found.
```

`--remote-backend file` (headless-readable) was the fix, but nothing pointed there at failure time.

## What changed

**A. `--device` / `--devices` alias `--host` / `--hosts`** on `secrets export`, `list`, and `view` — resolving identically. `parseHostsOption` merges all four for `list`/`view` (`remote.ts`); the `export` action folds `--device` into `--host` up front, mirroring the existing `activity.ts` pattern.

**B. Read-back verification of a keychain-backed push.** After a keychain-backed `export --host` reports success, the push reads the bundle back the way a headless release will — the remote's own `secrets export --plaintext --format json`, which **fails fast** via the `agentOnly` guard (no Touch ID prompt), keeping only key **presence** and never retaining the plaintext values. If the pushed keys didn't materialize, the push **fails loudly**:

```
mac-mini: pushed 'apple.com' but the keychain items did not persist — the remote could not read it back
(Bundle 'apple.com' is not unlocked in the secrets agent). A macOS login keychain is LOCKED under headless
SSH, so a keychain-backed write lands the bundle metadata but no readable secret items, and later reads fail
with "stored item '…' not found". Re-run with a headless-readable backend:
    agents secrets export apple.com --host mac-mini --remote-backend file
(needs AGENTS_SECRETS_PASSPHRASE set locally), or unlock the remote keychain first ... and retry.
```

Guardrails: the check is **gated to `--remote-backend keychain`** (the `file` backend is headless-readable by construction, so it's skipped — no extra round-trip); a **transient** SSH/network failure is re-surfaced verbatim, never mislabeled as a locked keychain (it keys on the specific not-unlocked / stored-item-not-found signal); a remote that has a broker/unlock session passes **silently**.

## Test evidence

Real-path tests (the SSH subprocess boundary is stubbed the same way `remote.test.ts` already stubs it; all option-parsing and verification logic runs for real). `bun test` on the two touched files + the `activity` alias regression:

```
 Test Files  3 passed (3)
      Tests  94 passed (94)
```

New coverage:
- `--device` resolves the same target as `--host` on `export` / `list` / `view` (asserts the parsed argv + the resolved host list, incl. dedupe and four-flag compose).
- `verifyRemoteKeychainPush` / `evaluateKeychainWriteVerification` flag `locked-keychain` on the not-unlocked guard, the `stored item … not found` read-back, and a missing pushed key; pass on a healthy read-back **without leaking the read-back values**; and re-surface a transient timeout verbatim as `error` (not `locked-keychain`).
- `keychainWriteFailureMessage` names the locked-login-keychain cause and both fixes (`--remote-backend file`, unlock the remote keychain).

`tsc --noEmit` clean.

## Impact

Unblocks headless Linux-driven releases: provisioning the `apple.com` bundle on a sign host now either succeeds readably or fails with the exact fix, and `--device` works everywhere the fleet already speaks it.

## Docs + changelog

`docs/secrets.md` (new *Pushing to a headless sign host* section + reference-table rows), `apps/cli/AGENTS.md` (release-section provisioning note), and a `.changelog/next/` fragment.

Session transcript (confidential — internal repo): `zion:/home/muqsit/.agents/.history/versions/claude/2.1.187/home/.claude/projects/-home-muqsit/679f41b7-e9a0-4022-9702-a881e8f2d4e3/`
