### PR TITLE
RUSH-1958: exclude droid / single-use rotating refresh tokens from agents apply propagation

### DIFF
--- a/apps/cli/.changelog/1.20.81.md
+++ b/apps/cli/.changelog/1.20.81.md
@@ -1,3 +1,15 @@
+- **`agents apply` no longer propagates single-use rotating refresh tokens
+  (RUSH-1958).** Droid (WorkOS) credentials use a refresh token that rotates
+  server-side on every exchange; copying one credential file across N boxes
+  caused the first refresh on any box to invalidate every other holder, collapsing
+  the fleet to a single working login. `agents apply` now excludes droid — and any
+  future harness added to the shared `SINGLE_USE_ROTATING_REFRESH_AGENTS` set in
+  `src/lib/fleet/auth-sync.ts` — from credential propagation. The plan surfaces
+  these as `manual login needed (single-use rotating refresh token)` with the
+  device name, routing the user to log in on the target box itself. Source:
+  `src/lib/fleet/auth-sync.ts`, `src/lib/fleet/apply.ts`,
+  `src/commands/apply.ts`.
+
 - **Non-Claude remote/tmux agent sessions now surface with their real id
   (RUSH-2007).** `agents sessions --active` and the `agents sessions focus` picker
   dropped every non-Claude tmux session (codex/gemini/kimi/grok/…) that lacked a

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 1.20.81
 
+- **`agents apply` no longer propagates single-use rotating refresh tokens
+  (RUSH-1958).** Droid (WorkOS) credentials use a refresh token that rotates
+  server-side on every exchange; copying one credential file across N boxes
+  caused the first refresh on any box to invalidate every other holder, collapsing
+  the fleet to a single working login. `agents apply` now excludes droid — and any
+  future harness added to the shared `SINGLE_USE_ROTATING_REFRESH_AGENTS` set in
+  `src/lib/fleet/auth-sync.ts` — from credential propagation. The plan surfaces
+  these as `manual login needed (single-use rotating refresh token)` with the
+  device name, routing the user to log in on the target box itself. Source:
+  `src/lib/fleet/auth-sync.ts`, `src/lib/fleet/apply.ts`,
+  `src/commands/apply.ts`.
+
 - **Non-Claude remote/tmux agent sessions now surface with their real id
   (RUSH-2007).** `agents sessions --active` and the `agents sessions focus` picker
   dropped every non-Claude tmux session (codex/gemini/kimi/grok/…) that lacked a

--- a/apps/cli/docs/fleet.md
+++ b/apps/cli/docs/fleet.md
@@ -129,13 +129,21 @@ path traversal. Agents with a portable credential:
 
 > `claude`, `codex`, `gemini`, `grok`, `kimi`, `opencode`, `droid`, `antigravity`
 
-**Honest boundary — never faked.** macOS keychain-bound tokens (`claude`,
-`antigravity`) can't be read from the ACL-locked keychain on a **macOS target**,
-and a token that is keychain-bound on the **source** can't be extracted to push.
-Those cases surface as a one-time **manual login** in the plan, not a fake
-success. Agents with no portable credential (e.g. `cursor`), and a source that
-simply isn't signed into an agent, produce no login action at all — the same on
-every OS.
+**Honest boundary — never faked, never fatal.** macOS keychain-bound tokens
+(`claude`, `antigravity`) can't be read from the ACL-locked keychain on a **macOS
+target**, and a token that is keychain-bound on the **source** can't be extracted
+to push. Single-use rotating refresh tokens — droid (WorkOS) is the known
+offender — are also never propagated: copying one credential file across N boxes
+would let the first refresh on any box invalidate every other holder. Those cases
+surface as a one-time **manual login** in the plan, not a fake success. Agents
+with no portable credential (e.g. `cursor`), and a source that simply isn't signed
+into an agent, produce no login action at all — the same on every OS.
+
+The "is this credential safe to copy?" decision is centralized in
+`src/lib/fleet/auth-sync.ts` (`isCredentialSafeToPropagate` and
+`SINGLE_USE_ROTATING_REFRESH_AGENTS`). Add any newly-discovered single-use-
+rotation harness there rather than scattering per-agent conditionals through the
+propagation path.
 
 ## Flags
 

--- a/apps/cli/src/commands/apply.ts
+++ b/apps/cli/src/commands/apply.ts
@@ -18,7 +18,7 @@ import { machineId } from '../lib/session/sync/config.js';
 import { loadDevices, isControlDevice, type DeviceProfile } from '../lib/devices/registry.js';
 import { ensureDevicesRegistered } from '../lib/devices/sync.js';
 import { readFleetFile, resolveDesired } from '../lib/fleet/manifest.js';
-import { snapshotAuth, materializeAuth, parseAuthBundle, KEYCHAIN_BOUND_ON_MAC } from '../lib/fleet/auth-sync.js';
+import { snapshotAuth, materializeAuth, parseAuthBundle, KEYCHAIN_BOUND_ON_MAC, isCredentialSafeToPropagate } from '../lib/fleet/auth-sync.js';
 import {
   agentIdOf,
   diffFleet,
@@ -135,16 +135,22 @@ function renderPlan(plan: FleetPlan): void {
   console.log();
   console.log(chalk.gray(`  ${plan.actions.length} action(s) across ${rows.filter((r) => r.probe.reachable).length} reachable device(s)`));
 
-  // Distinguish *why* a login can't be propagated: a macOS keychain-bound token
-  // vs. the source simply not being signed in to that agent (no portable file).
+  // Distinguish *why* a login can't be propagated: macOS keychain-bound,
+  // single-use rotating refresh token (never copied), or the source simply not
+  // being signed in to that agent (no portable file).
   const bound: string[] = [];
+  const rotating: string[] = [];
   const noToken: string[] = [];
   for (const r of rows) {
     for (const a of r.loginBlocked) {
       const tag = `${a}@${r.device}`;
-      if (r.probe.platform === 'macos' && KEYCHAIN_BOUND_ON_MAC.has(a)) bound.push(tag);
+      if (!isCredentialSafeToPropagate(a)) rotating.push(tag);
+      else if (r.probe.platform === 'macos' && KEYCHAIN_BOUND_ON_MAC.has(a)) bound.push(tag);
       else noToken.push(tag);
     }
+  }
+  if (rotating.length > 0) {
+    console.log(chalk.yellow(`  manual login needed (single-use rotating refresh token): ${rotating.join(', ')}`));
   }
   if (bound.length > 0) {
     console.log(chalk.yellow(`  manual login needed (macOS keychain-bound): ${bound.join(', ')}`));

--- a/apps/cli/src/lib/fleet/apply.test.ts
+++ b/apps/cli/src/lib/fleet/apply.test.ts
@@ -141,6 +141,25 @@ describe('diffFleet', () => {
     expect(plan.actions.some((a) => a.agent === 'codex' && a.kind === 'push-login')).toBe(true);
   });
 
+  it('excludes droid (single-use rotating refresh token) from propagation and surfaces per-machine login', () => {
+    const droidDesired: DeviceDesired[] = [
+      { device: 's1', agents: ['droid@latest', 'codex@latest'], sync: [], login: 'sync' },
+    ];
+    const probes = new Map<string, DeviceProbe>([
+      ['s1', { device: 's1', reachable: true, platform: 'linux', cliVersion: CLI, installedAgents: ['droid', 'codex'] }],
+    ]);
+    // Pretend the source has droid credentials available — the propagation gate
+    // must still refuse to push them.
+    const plan = diffFleet(droidDesired, probes, { targetCliVersion: CLI, sourceAuth: srcAuth(['droid', 'codex']) });
+    const droidActions = plan.actions.filter((a) => a.agent === 'droid');
+    expect(droidActions.some((a) => a.kind === 'push-login')).toBe(false);
+    expect(droidActions.some((a) => a.kind === 'needs-login')).toBe(true);
+    expect(droidActions.find((a) => a.kind === 'needs-login')?.detail).toMatch(/single-use rotating refresh token/);
+    expect(plan.devices[0].loginBlocked).toContain('droid');
+    // codex is still portable and safe → pushes.
+    expect(plan.actions.some((a) => a.agent === 'codex' && a.kind === 'push-login')).toBe(true);
+  });
+
   it('produces no actions for an unreachable device', () => {
     const probes = new Map<string, DeviceProbe>([
       ['s1', { device: 's1', reachable: false, platform: 'linux', installedAgents: [], note: 'unreachable' }],

--- a/apps/cli/src/lib/fleet/apply.ts
+++ b/apps/cli/src/lib/fleet/apply.ts
@@ -17,6 +17,8 @@ import { sshExec } from '../ssh-exec.js';
 import type { TeamsDoctorEntry } from '../teams/agents.js';
 import {
   isPropagatableAgent,
+  hasPortableAuthFiles,
+  isCredentialSafeToPropagate,
   KEYCHAIN_BOUND_ON_MAC,
   buildAuthBundle,
 } from './auth-sync.js';
@@ -182,6 +184,12 @@ export function diffFleet(desired: DeviceDesired[], probes: Map<string, DevicePr
         for (const id of [...new Set(d.agents.map(agentIdOf))]) {
           if (canPushLogin(id, probe.platform, ctx.sourceAuth)) {
             rowActions.push({ device: d.device, kind: 'push-login', agent: id, detail: `propagate ${id} login` });
+          } else if (hasPortableAuthFiles(id) && !isCredentialSafeToPropagate(id)) {
+            // Single-use rotating refresh tokens (e.g. droid/WorkOS) must never be
+            // copied across boxes — the first refresh invalidates every other copy.
+            // Surface per-machine login guidance instead of silently propagating.
+            loginBlocked.push(id);
+            rowActions.push({ device: d.device, kind: 'needs-login', agent: id, detail: `${id} login uses a single-use rotating refresh token — log in on ${d.device} itself` });
           } else if (
             isPropagatableAgent(id) &&
             (ctx.sourceAuth.bound.has(id) || (probe.platform === 'macos' && KEYCHAIN_BOUND_ON_MAC.has(id)))

--- a/apps/cli/src/lib/fleet/auth-sync.test.ts
+++ b/apps/cli/src/lib/fleet/auth-sync.test.ts
@@ -9,6 +9,9 @@ import {
   parseAuthBundle,
   FLEET_AUTH_FILES,
   isPropagatableAgent,
+  hasPortableAuthFiles,
+  isCredentialSafeToPropagate,
+  SINGLE_USE_ROTATING_REFRESH_AGENTS,
 } from './auth-sync.js';
 
 function seedFile(home: string, rel: string, content: string, mode = 0o600): void {
@@ -23,25 +26,46 @@ describe('snapshotAuth + materializeAuth round-trip', () => {
     const src = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-src-'));
     const dst = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-dst-'));
     seedFile(src, '.codex/auth.json', '{"tokens":"codex-abc"}');
-    seedFile(src, '.factory/auth.v2.file', 'droid-file');
-    seedFile(src, '.factory/auth.v2.key', 'droid-key');
 
-    const snap = snapshotAuth(['codex', 'gemini', 'droid'], { home: src, platform: 'linux' });
-    // codex(1) + droid(2); hard-deprecated Gemini is not propagatable.
-    expect(snap.files).toHaveLength(3);
+    const snap = snapshotAuth(['codex', 'gemini'], { home: src, platform: 'linux' });
+    // codex(1); hard-deprecated Gemini is not propagatable.
+    expect(snap.files).toHaveLength(1);
     expect(snap.bound).toEqual([]);
 
     const bundle = buildAuthBundle('src-box', snap.files);
     const res = materializeAuth(bundle, { home: dst });
     expect(res.errors).toEqual([]);
-    expect(res.written.sort()).toEqual(['codex', 'droid']);
+    expect(res.written.sort()).toEqual(['codex']);
 
     expect(fs.readFileSync(path.join(dst, '.codex/auth.json'), 'utf-8')).toBe('{"tokens":"codex-abc"}');
-    expect(fs.readFileSync(path.join(dst, '.factory/auth.v2.key'), 'utf-8')).toBe('droid-key');
     // credential mode preserved at 0600 (POSIX only — Windows has no 0600 bit)
     if (process.platform !== 'win32') {
       expect(fs.statSync(path.join(dst, '.codex/auth.json')).mode & 0o777).toBe(0o600);
     }
+  });
+
+  it('never captures single-use rotating refresh tokens (droid/WorkOS)', () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-src-'));
+    const dst = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-dst-'));
+    seedFile(src, '.factory/auth.v2.file', 'droid-file');
+    seedFile(src, '.factory/auth.v2.key', 'droid-key');
+
+    const snap = snapshotAuth(['droid'], { home: src, platform: 'linux' });
+    expect(snap.files).toHaveLength(0);
+    expect(snap.bound).toEqual([]);
+
+    // Even if a malicious/downstream caller built a bundle with droid files,
+    // materializeAuth would still write them (it writes whatever it receives).
+    // The safety gate is at capture time and in the propagation decision.
+    const bundle = buildAuthBundle('src-box', [
+      { agent: 'droid', rel: '.factory/auth.v2.file', contentB64: Buffer.from('droid-file').toString('base64'), mode: 0o600 },
+      { agent: 'droid', rel: '.factory/auth.v2.key', contentB64: Buffer.from('droid-key').toString('base64'), mode: 0o600 },
+    ]);
+    const res = materializeAuth(bundle, { home: dst });
+    expect(res.errors).toEqual([]);
+    expect(res.written.sort()).toEqual(['droid']);
+    expect(fs.existsSync(path.join(dst, '.factory/auth.v2.file'))).toBe(true);
+    expect(fs.existsSync(path.join(dst, '.factory/auth.v2.key'))).toBe(true);
   });
 
   it('silently skips agents that are not signed in (no file on disk)', () => {
@@ -97,11 +121,19 @@ describe('parseAuthBundle', () => {
 
 describe('FLEET_AUTH_FILES coverage', () => {
   it('maps the verified portable-auth agents and marks them propagatable', () => {
-    for (const agent of ['claude', 'codex', 'grok', 'kimi', 'opencode', 'droid', 'antigravity']) {
+    for (const agent of ['claude', 'codex', 'grok', 'kimi', 'opencode', 'antigravity']) {
       expect(FLEET_AUTH_FILES[agent]?.length).toBeGreaterThan(0);
       expect(isPropagatableAgent(agent)).toBe(true);
     }
     expect(isPropagatableAgent('gemini')).toBe(false);
     expect(isPropagatableAgent('cursor')).toBe(false);
+  });
+
+  it('keeps droid in portable files but marks it unsafe to propagate', () => {
+    expect(FLEET_AUTH_FILES['droid']?.length).toBeGreaterThan(0);
+    expect(hasPortableAuthFiles('droid')).toBe(true);
+    expect(SINGLE_USE_ROTATING_REFRESH_AGENTS.has('droid')).toBe(true);
+    expect(isCredentialSafeToPropagate('droid')).toBe(false);
+    expect(isPropagatableAgent('droid')).toBe(false);
   });
 });

--- a/apps/cli/src/lib/fleet/auth-sync.ts
+++ b/apps/cli/src/lib/fleet/auth-sync.ts
@@ -45,9 +45,33 @@ export const FLEET_AUTH_FILES: Record<string, AuthFileSpec[]> = {
 /** Agents whose macOS credentials live in the ACL-bound login keychain. */
 export const KEYCHAIN_BOUND_ON_MAC: ReadonlySet<string> = new Set(['claude', 'antigravity']);
 
+/**
+ * Agents whose OAuth credentials rely on single-use refresh tokens that rotate
+ * server-side on every exchange. Copying these credential files across machines
+ * is fatal: the first refresh on any box invalidates every other holder's token,
+ * collapsing the fleet to a single working login (droid/WorkOS collapsed 10 boxes
+ * to 1 overnight — RUSH-1958). Add any newly-discovered single-use-rotation
+ * harness here; the predicate below is the one place the propagation decision is
+ * made. See also `remote-login.ts` and `usage.ts` for the per-machine-login policy.
+ */
+export const SINGLE_USE_ROTATING_REFRESH_AGENTS: ReadonlySet<string> = new Set(['droid']);
+
+/** True when `agent`'s portable credential file(s) are safe to copy between
+ *  machines. Single-use rotating refresh tokens are never safe; keychain-bound
+ *  tokens are handled separately by the caller via {@link KEYCHAIN_BOUND_ON_MAC}. */
+export function isCredentialSafeToPropagate(agent: string): boolean {
+  return !SINGLE_USE_ROTATING_REFRESH_AGENTS.has(agent);
+}
+
+/** True when the agent stores credentials in portable files we can read. This
+ *  does NOT mean it is safe to propagate — check {@link isCredentialSafeToPropagate}. */
+export function hasPortableAuthFiles(agent: string): boolean {
+  return agent in FLEET_AUTH_FILES;
+}
+
 /** Which agents `apply` can propagate auth for at all. */
 export function isPropagatableAgent(agent: string): boolean {
-  return agent in FLEET_AUTH_FILES;
+  return hasPortableAuthFiles(agent) && isCredentialSafeToPropagate(agent);
 }
 
 /**
@@ -200,7 +224,8 @@ export function snapshotAuth(agents: string[], opts: SnapshotOptions): AuthSnaps
 
   for (const agent of agents) {
     const specs = FLEET_AUTH_FILES[agent];
-    if (!specs) continue; // not propagatable — caller surfaces separately if desired
+    if (!specs) continue; // no portable file — caller surfaces separately if desired
+    if (!isCredentialSafeToPropagate(agent)) continue; // single-use rotating refresh tokens are never copied
     if (opts.platform === 'darwin' && KEYCHAIN_BOUND_ON_MAC.has(agent)) {
       bound.push(agent);
       continue;

--- a/apps/cli/src/lib/fleet/remote-login.ts
+++ b/apps/cli/src/lib/fleet/remote-login.ts
@@ -9,6 +9,11 @@
  * each verification URL + user code, and surfacing them all in ONE local browser
  * page so the human enters codes back-to-back instead of babysitting N terminals.
  *
+ * The propagation gate lives in `auth-sync.ts`: {@link isCredentialSafeToPropagate}
+ * and {@link SINGLE_USE_ROTATING_REFRESH_AGENTS} are the single place where the
+ * "is this credential safe to copy?" decision is made, shared by `agents apply`
+ * and any other propagation path.
+ *
  * Layering — pure vs I/O, so the valuable logic is unit-testable without SSH:
  *  - `scrapeLogin` / `classifyLoginFlow` / `selectLoginTargets` /
  *    `buildRemoteLoginSshCommand` / `buildDashboardHtml` are PURE.

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -863,7 +863,9 @@ export interface DroidBillingLimitsResponse {
  * here would race a concurrently running droid session and can permanently
  * invalidate the user's login chain. Droid refreshes its own credential when
  * it runs; if the stored token is expired we skip the live fetch and let the
- * SWR cache serve the last-seen snapshot.
+ * SWR cache serve the last-seen snapshot. This same single-use-rotation property
+ * is why `agents apply` refuses to propagate droid credentials across machines
+ * (see `isCredentialSafeToPropagate` in `../fleet/auth-sync.ts`).
  */
 async function getDroidUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {


### PR DESCRIPTION
Fixes RUSH-1958.

## Problem
`agents apply` copied droid credential files across the fleet by default. Droid uses a WorkOS refresh token that is single-use and rotates server-side on every exchange; the first refresh on any box invalidated every other holder, collapsing 10 boxes to 1 overnight.

## Fix
Centralize the "is this credential safe to propagate?" decision in one place:
- `src/lib/fleet/auth-sync.ts` now exports `SINGLE_USE_ROTATING_REFRESH_AGENTS` and `isCredentialSafeToPropagate`.
- `snapshotAuth` skips capturing those credentials.
- `isPropagatableAgent` incorporates the safety predicate.
- `diffFleet` surfaces blocked single-use-rotation agents as `needs-login` with per-machine-login guidance instead of silently copying.
- `commands/apply.ts` renders a distinct `manual login needed (single-use rotating refresh token)` category in the plan matrix.

## Verification
Local unit tests pass:

```
$ cd apps/cli && bun run test -- src/lib/fleet/ src/commands/apply.test.ts

 RUN  v4.1.9 .../apps/cli

 Test Files  6 passed (6)
      Tests  94 passed (94)
```

Dry-run inspection of the apply plan shows droid credentials are no longer captured and the guidance is surfaced. Run output saved at `/tmp/verify-droid-creds.out`:

```
Captured files: [ 'codex:.codex/auth.json' ]

Plan actions:
  needs-login  droid  droid login uses a single-use rotating refresh token — log in on s1 itself
  push-login  codex  propagate codex login

loginBlocked: [ 'droid' ]
```

## Files changed
- `apps/cli/src/lib/fleet/auth-sync.ts` — shared predicate, skip unsafe capture
- `apps/cli/src/lib/fleet/apply.ts` — surface unsafe agents as needs-login
- `apps/cli/src/commands/apply.ts` — render new manual-login category
- `apps/cli/src/lib/fleet/remote-login.ts`, `apps/cli/src/lib/usage.ts` — cross-references
- `apps/cli/src/lib/fleet/auth-sync.test.ts`, `apps/cli/src/lib/fleet/apply.test.ts` — tests
- `apps/cli/CHANGELOG.md`, `apps/cli/docs/fleet.md` — docs
