### PR TITLE
fix(teams): render list from cached metadata

### DIFF
--- a/apps/cli/.changelog/next/rush-1996-teams-list.md
+++ b/apps/cli/.changelog/next/rush-1996-teams-list.md
@@ -1,0 +1,7 @@
+- **`agents teams list` renders from cached team metadata instead of full status
+  probes (RUSH-1996).** The list and picker rows now read the team registry plus
+  teammate `meta.json` snapshots, so listing teams no longer blocks on remote log
+  pulls or unreachable hosts. Full teammate status is still loaded when a user picks
+  a team or runs `agents teams status <team>`. Source:
+  `apps/cli/src/commands/teams.ts`, `apps/cli/src/commands/teams.test.ts`,
+  `apps/cli/docs/teams.md`.

--- a/apps/cli/docs/teams.md
+++ b/apps/cli/docs/teams.md
@@ -71,6 +71,10 @@ PENDING ──deps resolved──▶ spawned ──▶ RUNNING ──exit 0─�
 
 ### `teams list` options
 
+`agents teams list` renders from the cached team registry and teammate `meta.json`
+records. It does not poll remote hosts or read teammate logs while listing; choosing
+a team or running `agents teams status <team>` performs the full status read.
+
 | Flag | Description |
 |---|---|
 | `-a, --agent <agent>` | Filter to teams containing this agent (e.g. `claude` or `claude@2.1.112`) |

--- a/apps/cli/src/commands/teams.test.ts
+++ b/apps/cli/src/commands/teams.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { buildTeamRowsFromSnapshots, type TeamListAgentSnapshot } from './teams.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
@@ -26,10 +27,80 @@ function guardedHome(): string {
   return home;
 }
 
-function run(args: string[]): { stdout: string; status: number | null } {
+function seedTeam(home: string, teamName: string, agents: TeamListAgentSnapshot[]): void {
+  const history = path.join(home, '.agents', '.history', 'teams');
+  fs.mkdirSync(path.join(history, 'agents'), { recursive: true });
+  fs.writeFileSync(
+    path.join(history, 'registry.json'),
+    JSON.stringify({ [teamName]: { created_at: '2026-08-01T12:00:00.000Z' } }, null, 2),
+  );
+  for (const agent of agents) {
+    const agentDir = path.join(history, 'agents', agent.agent_id);
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentDir, 'meta.json'),
+      JSON.stringify({
+        agent_id: agent.agent_id,
+        task_name: agent.task_name,
+        agent_type: agent.agent_type,
+        status: agent.status,
+        prompt: agent.prompt,
+        started_at: agent.started_at,
+        completed_at: agent.completed_at,
+        workspace_dir: agent.workspace_dir,
+        version: agent.version,
+        remote_session_id: agent.remote_session_id,
+        name: agent.name,
+        after: agent.after,
+        task_type: agent.task_type,
+        host_name: agent.host,
+        mode: agent.mode,
+        cloud_session_id: agent.cloud_session_id,
+        cloud_provider: agent.cloud_provider,
+        pr_url: agent.pr_url,
+        remote_pid: 424242,
+        remote_log: '$HOME/.agents/.cache/hosts/offline.log',
+        remote_exit: '$HOME/.agents/.cache/hosts/offline.exit',
+        host_target: '203.0.113.1',
+      }, null, 2),
+    );
+  }
+}
+
+function remoteSnapshot(overrides: Partial<TeamListAgentSnapshot> = {}): TeamListAgentSnapshot {
+  return {
+    agent_id: 'agent-remote-1',
+    task_name: 'remote-lag',
+    agent_type: 'codex',
+    status: 'running',
+    prompt: 'Investigate the remote failure',
+    started_at: '2026-08-01T12:01:00.000Z',
+    completed_at: null,
+    workspace_dir: '/work/remote-lag',
+    version: '0.146.0',
+    remote_session_id: 'session-remote-1',
+    name: 'remote',
+    after: [],
+    task_type: 'bugfix',
+    host: 'offline-box',
+    mode: 'edit',
+    cloud_session_id: null,
+    cloud_provider: null,
+    pr_url: null,
+    ...overrides,
+  };
+}
+
+function run(
+  args: string[],
+  setup?: (home: string) => void,
+  timeout = 10_000,
+): { stdout: string; stderr: string; status: number | null; error?: Error } {
   const home = guardedHome();
+  setup?.(home);
   const r = spawnSync('bun', [INDEX, ...args], {
     encoding: 'utf-8',
+    timeout,
     env: {
       ...process.env,
       HOME: home,
@@ -38,7 +109,7 @@ function run(args: string[]): { stdout: string; status: number | null } {
       AGENTS_SKIP_MIGRATION: '1',
     },
   });
-  return { stdout: r.stdout ?? '', status: r.status };
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status, error: r.error };
 }
 
 describe('teams list output modes', () => {
@@ -53,5 +124,43 @@ describe('teams list output modes', () => {
     const { stdout, status } = run(['teams', 'list', '--json']);
     expect(status).toBe(0);
     expect(JSON.parse(stdout)).toEqual({ teams: [] });
+  });
+
+  it('builds list rows from cached teammate metadata', () => {
+    const result = buildTeamRowsFromSnapshots(
+      { 'remote-lag': { created_at: '2026-08-01T12:00:00.000Z', description: 'remote work' } },
+      [remoteSnapshot()],
+    );
+
+    expect(result.teams).toHaveLength(1);
+    expect(result.teams[0]).toMatchObject({
+      task_name: 'remote-lag',
+      agent_count: 1,
+      running: 1,
+      workspace_dir: '/work/remote-lag',
+    });
+    expect(result.rows[0].agents[0]).toMatchObject({
+      agent_id: 'agent-remote-1',
+      agent_type: 'codex',
+      host: 'offline-box',
+      tool_count: 0,
+      files_modified: [],
+    });
+  });
+
+  it('does not probe unreachable remote teammates for JSON list output', () => {
+    const { stdout, status, error } = run(
+      ['teams', 'list', '--json'],
+      (home) => seedTeam(home, 'remote-lag', [remoteSnapshot()]),
+      2_500,
+    );
+
+    expect(error).toBeUndefined();
+    expect(status).toBe(0);
+    expect(JSON.parse(stdout).teams[0]).toMatchObject({
+      task_name: 'remote-lag',
+      agent_count: 1,
+      running: 1,
+    });
   });
 });

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -110,6 +110,28 @@ const VALID_CLOUD_PROVIDERS = ['rush', 'codex', 'factory'] as const satisfies re
 
 type Mode = (typeof VALID_MODES)[number];
 type Effort = (typeof VALID_EFFORTS)[number];
+type TeamRegistry = Record<string, { created_at: string; description?: string }>;
+
+export interface TeamListAgentSnapshot {
+  agent_id: string;
+  task_name: string;
+  agent_type: string;
+  status: string;
+  prompt: string;
+  started_at: string;
+  completed_at: string | null;
+  workspace_dir: string | null;
+  version: string | null;
+  remote_session_id: string | null;
+  name: string | null;
+  after: string[];
+  task_type: TaskType | null;
+  host: string | null;
+  mode: string | null;
+  cloud_session_id: string | null;
+  cloud_provider: string | null;
+  pr_url: string | null;
+}
 
 function statusColor(status: string): (s: string) => string {
   switch (status) {
@@ -136,6 +158,74 @@ function formatTimestamp(iso: string | null | undefined): string | null {
     hour: 'numeric',
     minute: '2-digit',
   });
+}
+
+function normalizeTeamListStatus(status: unknown): AgentStatus {
+  if (Object.values(AgentStatus).includes(status as AgentStatus)) {
+    return status as AgentStatus;
+  }
+  return AgentStatus.RUNNING;
+}
+
+function parseTimestamp(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function durationFromSnapshot(agent: TeamListAgentSnapshot): string | null {
+  const startedAt = parseTimestamp(agent.started_at);
+  if (!startedAt) return null;
+  const completedAt = parseTimestamp(agent.completed_at);
+  let seconds: number;
+  if (completedAt) {
+    seconds = (completedAt.getTime() - startedAt.getTime()) / 1000;
+  } else if (normalizeTeamListStatus(agent.status) === AgentStatus.RUNNING) {
+    seconds = (Date.now() - startedAt.getTime()) / 1000;
+  } else {
+    return null;
+  }
+  if (seconds < 60) return `${Math.max(0, Math.floor(seconds))} seconds`;
+  return `${Math.max(0, seconds / 60).toFixed(1)} minutes`;
+}
+
+function snapshotActivityTime(agent: TeamListAgentSnapshot): Date {
+  const status = normalizeTeamListStatus(agent.status);
+  if (status === AgentStatus.RUNNING) return new Date();
+  return parseTimestamp(agent.completed_at) || parseTimestamp(agent.started_at) || new Date(0);
+}
+
+function snapshotToStatusDetail(agent: TeamListAgentSnapshot): AgentStatusDetail {
+  return {
+    agent_id: agent.agent_id,
+    agent_type: agent.agent_type,
+    status: normalizeTeamListStatus(agent.status),
+    prompt: agent.prompt,
+    started_at: parseTimestamp(agent.started_at)?.toISOString() || new Date(0).toISOString(),
+    completed_at: parseTimestamp(agent.completed_at)?.toISOString() || null,
+    duration: durationFromSnapshot(agent),
+    files_created: [],
+    files_modified: [],
+    files_read: [],
+    files_deleted: [],
+    bash_commands: [],
+    recent_tool_calls: [],
+    last_messages: [],
+    tool_count: 0,
+    has_errors: false,
+    cursor: snapshotActivityTime(agent).toISOString(),
+    mode: agent.mode ?? undefined,
+    cloud_session_id: agent.cloud_session_id,
+    cloud_provider: agent.cloud_provider,
+    pr_url: agent.pr_url,
+    version: agent.version,
+    remote_session_id: agent.remote_session_id,
+    session_label: null,
+    name: agent.name,
+    after: agent.after,
+    task_type: agent.task_type,
+    host: agent.host,
+  };
 }
 
 
@@ -855,7 +945,7 @@ function classifyTeamStatus(t: TaskInfo): 'empty' | 'waiting' | 'working' | 'don
 // Merge persistent team registry with tasks derived from live agents so empty
 // teams (created but no teammates yet) still show up.
 function mergeTeams(
-  registry: Record<string, { created_at: string; description?: string }>,
+  registry: TeamRegistry,
   tasks: TaskInfo[]
 ): TaskInfo[] {
   const byName = new Map<string, TaskInfo>();
@@ -881,26 +971,141 @@ function mergeTeams(
   );
 }
 
-// Build the same enriched rows the `list` picker uses. Shared between `list`
-// (interactive default) and the picker fallback for `status` / `start`.
-async function loadTeamRows(
-  mgr: AgentManager
-): Promise<{ rows: TeamRow[]; names: string[] }> {
-  const [tasks, registry] = await Promise.all([handleTasks(mgr, 1000), loadTeams()]);
-  const merged = mergeTeams(registry, tasks.tasks);
-  const rows: TeamRow[] = await Promise.all(
-    merged.map(async (team) => {
-      let agents: AgentStatusDetail[] = [];
-      try {
-        const res = await handleStatus(mgr, team.task_name, 'all');
-        agents = res.agents;
-      } catch {
-        // Empty teams (no live agents) throw in some code paths.
+function buildTasksFromSnapshots(agents: TeamListAgentSnapshot[]): TaskInfo[] {
+  const byTeam = new Map<string, TeamListAgentSnapshot[]>();
+  for (const agent of agents) {
+    const teamAgents = byTeam.get(agent.task_name) || [];
+    teamAgents.push(agent);
+    byTeam.set(agent.task_name, teamAgents);
+  }
+
+  const tasks: TaskInfo[] = [];
+  for (const [taskName, teamAgents] of byTeam) {
+    let pending = 0;
+    let running = 0;
+    let completed = 0;
+    let failed = 0;
+    let stopped = 0;
+    let earliestStart: Date | null = null;
+    let latestActivity: Date | null = null;
+    let workspaceDir: string | null = null;
+
+    for (const agent of teamAgents) {
+      const status = normalizeTeamListStatus(agent.status);
+      if (status === AgentStatus.PENDING) pending++;
+      else if (status === AgentStatus.RUNNING) running++;
+      else if (status === AgentStatus.COMPLETED) completed++;
+      else if (status === AgentStatus.FAILED) failed++;
+      else if (status === AgentStatus.STOPPED) stopped++;
+
+      const startedAt = parseTimestamp(agent.started_at);
+      if (startedAt && (!earliestStart || startedAt < earliestStart)) {
+        earliestStart = startedAt;
       }
-      return { team, agents, description: registry[team.task_name]?.description };
-    })
-  );
-  return { rows, names: merged.map((t) => t.task_name) };
+
+      const activity = snapshotActivityTime(agent);
+      if (!latestActivity || activity > latestActivity) {
+        latestActivity = activity;
+      }
+
+      if (!workspaceDir && agent.workspace_dir) {
+        workspaceDir = agent.workspace_dir;
+      }
+    }
+
+    const fallback = new Date(0);
+    tasks.push({
+      task_name: taskName,
+      agent_count: teamAgents.length,
+      pending,
+      running,
+      completed,
+      failed,
+      stopped,
+      workspace_dir: workspaceDir,
+      created_at: (earliestStart || fallback).toISOString(),
+      modified_at: (latestActivity || earliestStart || fallback).toISOString(),
+    });
+  }
+
+  return tasks.sort((a, b) => new Date(b.modified_at).getTime() - new Date(a.modified_at).getTime());
+}
+
+export function buildTeamRowsFromSnapshots(
+  registry: TeamRegistry,
+  agents: TeamListAgentSnapshot[]
+): { rows: TeamRow[]; teams: TaskInfo[]; names: string[] } {
+  const byTeam = new Map<string, AgentStatusDetail[]>();
+  for (const agent of agents) {
+    const details = byTeam.get(agent.task_name) || [];
+    details.push(snapshotToStatusDetail(agent));
+    byTeam.set(agent.task_name, details);
+  }
+
+  const teams = mergeTeams(registry, buildTasksFromSnapshots(agents));
+  return {
+    teams,
+    rows: teams.map((team) => ({
+      team,
+      agents: byTeam.get(team.task_name) || [],
+      description: registry[team.task_name]?.description,
+    })),
+    names: teams.map((team) => team.task_name),
+  };
+}
+
+function snapshotFromMeta(meta: any): TeamListAgentSnapshot | null {
+  if (!meta || typeof meta !== 'object') return null;
+  const agentId = typeof meta.agent_id === 'string' ? meta.agent_id : '';
+  const taskName = typeof meta.task_name === 'string' ? meta.task_name : '';
+  const agentType = typeof meta.agent_type === 'string' ? meta.agent_type : '';
+  if (!agentId || !taskName || !agentType) return null;
+  return {
+    agent_id: agentId,
+    task_name: taskName,
+    agent_type: agentType,
+    status: normalizeTeamListStatus(meta.status),
+    prompt: typeof meta.prompt === 'string' ? meta.prompt : '',
+    started_at: parseTimestamp(meta.started_at)?.toISOString() || new Date(0).toISOString(),
+    completed_at: parseTimestamp(meta.completed_at)?.toISOString() || null,
+    workspace_dir: typeof meta.workspace_dir === 'string' ? meta.workspace_dir : null,
+    version: typeof meta.version === 'string' ? meta.version : null,
+    remote_session_id: typeof meta.remote_session_id === 'string' ? meta.remote_session_id : null,
+    name: typeof meta.name === 'string' ? meta.name : null,
+    after: Array.isArray(meta.after) ? meta.after.filter((name: unknown): name is string => typeof name === 'string') : [],
+    task_type: typeof meta.task_type === 'string' && (VALID_TASK_TYPES as readonly string[]).includes(meta.task_type)
+      ? meta.task_type as TaskType
+      : null,
+    host: typeof meta.host_name === 'string' ? meta.host_name : null,
+    mode: typeof meta.mode === 'string' ? meta.mode : null,
+    cloud_session_id: typeof meta.cloud_session_id === 'string' ? meta.cloud_session_id : null,
+    cloud_provider: typeof meta.cloud_provider === 'string' ? meta.cloud_provider : null,
+    pr_url: typeof meta.pr_url === 'string' ? meta.pr_url : null,
+  };
+}
+
+async function loadTeamAgentSnapshots(): Promise<TeamListAgentSnapshot[]> {
+  const agentsDir = await getAgentsDir();
+  const entries = await fs.readdir(agentsDir).catch(() => []);
+  const snapshots = await Promise.all(entries.map(async (entry) => {
+    const metaPath = path.join(agentsDir, entry, 'meta.json');
+    try {
+      const raw = await fs.readFile(metaPath, 'utf-8');
+      return snapshotFromMeta(JSON.parse(raw));
+    } catch {
+      return null;
+    }
+  }));
+  return snapshots.filter((snapshot): snapshot is TeamListAgentSnapshot => snapshot !== null);
+}
+
+// Build cached rows for the `list` picker. Shared between `list` and picker
+// fallbacks for `status` / `start`; full status stays lazy until a team is picked.
+async function loadTeamRows(
+  _mgr: AgentManager
+): Promise<{ rows: TeamRow[]; names: string[] }> {
+  const [registry, agents] = await Promise.all([loadTeams(), loadTeamAgentSnapshots()]);
+  return buildTeamRowsFromSnapshots(registry, agents);
 }
 
 // Picker fallback for `teams logs` when the teammate ref is omitted. Shows a
@@ -1081,28 +1286,26 @@ export function registerTeamsCommands(program: Command): void {
       agent?: string; status?: string; since?: string; until?: string;
       limit: string; json?: boolean;
     }) => {
-      const mgr = mkManager();
       const limit = Math.max(1, parseInt(opts.limit, 10) || 20);
-      const [tasks, registry, everyAgent] = await Promise.all([
-        handleTasks(mgr, 1000),
+      const [registry, everyAgent] = await Promise.all([
         loadTeams(),
-        mgr.listAll(),
+        loadTeamAgentSnapshots(),
       ]);
 
       // Group agents by team so we can filter on agent-type / version.
-      const byTeam = new Map<string, { agent_type: string; version: string | null }[]>();
+      const byTeam = new Map<string, TeamListAgentSnapshot[]>();
       for (const a of everyAgent) {
-        const arr = byTeam.get(a.taskName) || [];
-        arr.push({ agent_type: a.agentType, version: a.version });
-        byTeam.set(a.taskName, arr);
+        const arr = byTeam.get(a.task_name) || [];
+        arr.push(a);
+        byTeam.set(a.task_name, arr);
       }
 
-      let merged = mergeTeams(registry, tasks.tasks);
+      let rows = buildTeamRowsFromSnapshots(registry, everyAgent).rows;
 
       // --- query: substring match on team name ---
       if (query) {
         const q = query.toLowerCase();
-        merged = merged.filter((t) => t.task_name.toLowerCase().includes(q));
+        rows = rows.filter((row) => row.team.task_name.toLowerCase().includes(q));
       }
 
       // --- --agent: filter teams containing a matching teammate ---
@@ -1111,8 +1314,8 @@ export function registerTeamsCommands(program: Command): void {
         const wantVersion = VALID_AGENTS.includes(wantType as AgentType)
           ? resolveVersionAliasLoose(wantType as AgentId, rawVersion)
           : rawVersion;
-        merged = merged.filter((t) => {
-          const teammates = byTeam.get(t.task_name) || [];
+        rows = rows.filter((row) => {
+          const teammates = byTeam.get(row.team.task_name) || [];
           return teammates.some(
             (m) => m.agent_type === wantType && (!wantVersion || m.version === wantVersion)
           );
@@ -1126,29 +1329,29 @@ export function registerTeamsCommands(program: Command): void {
         if (!validStatuses.includes(want)) {
           die(`Invalid --status '${opts.status}'. Use one of: ${validStatuses.join(', ')}`);
         }
-        merged = merged.filter((t) => classifyTeamStatus(t) === want);
+        rows = rows.filter((row) => classifyTeamStatus(row.team) === want);
       }
 
       // --- --since / --until: filter by activity window ---
       if (opts.since) {
         const cutoff = parseTimeFilter(opts.since);
         if (!cutoff) die(`Could not parse --since '${opts.since}'`);
-        merged = merged.filter((t) => new Date(t.modified_at).getTime() >= cutoff);
+        rows = rows.filter((row) => new Date(row.team.modified_at).getTime() >= cutoff);
       }
       if (opts.until) {
         const cutoff = parseTimeFilter(opts.until);
         if (!cutoff) die(`Could not parse --until '${opts.until}'`);
-        merged = merged.filter((t) => new Date(t.modified_at).getTime() <= cutoff);
+        rows = rows.filter((row) => new Date(row.team.modified_at).getTime() <= cutoff);
       }
 
-      merged = merged.slice(0, limit);
+      rows = rows.slice(0, limit);
 
       if (isJsonMode(opts)) {
-        console.log(JSON.stringify({ teams: merged }, null, 2));
+        console.log(JSON.stringify({ teams: rows.map((row) => row.team) }, null, 2));
         return;
       }
 
-      if (merged.length === 0) {
+      if (rows.length === 0) {
         if (query || opts.agent || opts.status || opts.since || opts.until) {
           console.log(chalk.gray('No teams match those filters.'));
         } else {
@@ -1158,26 +1361,12 @@ export function registerTeamsCommands(program: Command): void {
         return;
       }
 
-      // Enrich teams with teammate details for the picker's preview pane.
-      const rows: TeamRow[] = await Promise.all(
-        merged.map(async (team) => {
-          let agents: AgentStatusDetail[] = [];
-          try {
-            const res = await handleStatus(mgr, team.task_name, 'all');
-            agents = res.agents;
-          } catch {
-            // Empty teams (no live agents) throw in some code paths — preview
-            // will just show "no teammates yet".
-          }
-          return { team, agents, description: registry[team.task_name]?.description };
-        })
-      );
-
       if (isInteractiveTerminal()) {
         try {
           const picked = await teamPicker(rows, query);
           if (picked) {
             // Fall through to the status subcommand's action for the picked team.
+            const mgr = mkManager();
             const result = await handleStatus(mgr, picked.team, 'all');
             await printTeamStatus(picked.team, result);
           }


### PR DESCRIPTION
Fixes RUSH-1996.

## What changed

- `agents teams list` now builds rows from the cached team registry plus teammate `meta.json` snapshots instead of constructing `AgentManager` and calling `handleStatus(..., 'all')` for every row.
- Full status loading stays lazy: selecting a team in the picker or running `agents teams status <team>` still uses the existing full status path.
- Added adjacent coverage for cached row construction and a real CLI JSON list run with a teammate assigned to an unreachable host.

## Verification

Before, with the registry-installed command in this sandbox:

```text
$ /usr/bin/time -p agents teams list
[agents teams] Falling back to temp agents dir at /tmp/agents/agents
agents-cli-bugs               empty · 3m ago
rush-clis-dbg                 empty · 11d ago
rush-backlog-7b               empty · 11d ago
linear-land                   empty · 15d ago
factory-tabs                  empty · 25d ago
rush-oauth-copilot            empty · 31d ago
rush-cli-wave2                empty · 31d ago
rush-cli-wave1                empty · 31d ago
wrapup-s1                     empty · 32d ago
phase1-latency                empty · 35d ago
delta                         empty · 35d ago
bravo                         empty · 35d ago
charlie                       empty · 35d ago
echo                          empty · 35d ago
alpha                         empty · 35d ago

15 teams.
real 60.53
user 0.66
sys 0.12
```

After, with this branch installed as a dev package and an unreachable remote teammate in `meta.json`:

```text
$ env HOME=/tmp/agents-teams-list-home-verify AGENTS_EVENTS_PATH=/tmp/agents-events-rush-1996-unreachable.jsonl AGENTS_CLI_DISABLE_AUTO_UPDATE=1 AGENTS_NO_USAGE_TRACK=1 AGENTS_SKIP_MIGRATION=1 PATH="/tmp/agents-cli-dev-prefix-1785641413/bin:$PATH" /usr/bin/time -p agents teams list
remote-lag    codex     working · 15h 34m · just now

1 team.
real 0.29
user 0.34
sys 0.07
```

Patched user-state list timing, with the sandbox audit log redirected to writable `/tmp` so startup event logging does not dominate the command:

```text
$ AGENTS_EVENTS_PATH=/tmp/agents-events-rush-1996.jsonl AGENTS_CLI_DISABLE_AUTO_UPDATE=1 AGENTS_NO_USAGE_TRACK=1 AGENTS_SKIP_MIGRATION=1 /usr/bin/time -p /tmp/agents-cli-dev-prefix-1785641413/bin/agents teams list
[agents teams] Falling back to temp agents dir at /tmp/agents/agents
...
15 teams.
real 0.30
user 0.34
sys 0.08
```

Tests run:

```text
$ TMPDIR=/tmp/bun-tmp TMP=/tmp/bun-tmp TEMP=/tmp/bun-tmp bun test src/commands/teams.test.ts scripts/gen-changelog.test.ts
9 pass
0 fail
16 expect() calls
Ran 9 tests across 2 files. [2.61s]

$ TMPDIR=/tmp/bun-tmp TMP=/tmp/bun-tmp TEMP=/tmp/bun-tmp bun run build
$ tsc && ...

$ git diff --check
# no output
```

Full suite note: `bun run test` currently fails in this sandbox with 161 unrelated failures. The leading failures are generated-changelog mismatch before adding this PR's `.changelog/next` fragment, read-only writes under `/home/muqsit/.agents` (for example `EROFS: read-only file system, open '/home/muqsit/.agents/.cache/helpers/daemon/daemon.pid'`), local tmux/runtime-state assumptions, and existing env-sensitive exec defaults. The targeted teams tests and changelog generator test pass after the fragment fix.

Linear: https://linear.app/getrush/issue/RUSH-1996/agents-teams-list-hangs-for-over-a-minute

Session transcript: yosemite-s1:/home/muqsit/.agents/.history/versions/codex/0.146.0/home/.codex/sessions/2026/08/01/rollout-2026-08-01T20-21-52-019fc07e-0832-7883-b9c4-0fe9170dcc62.jsonl
