### PR TITLE
feat(setup): add secrets onboarding wizard

### DIFF
--- a/apps/cli/.changelog/next/rush-1999-setup-secrets.md
+++ b/apps/cli/.changelog/next/rush-1999-setup-secrets.md
@@ -2,7 +2,9 @@
   The setup command registers a new `secrets` capability wizard that chooses a
   default storage backend (`keychain`, encrypted `file`, or synced `vault`), sets
   the existing default prompt policy (`daily`/`always`, with `never` gated for
-  explicit automation use), optionally delegates imports to `agents secrets
-  import`, and writes durable setup preferences under `~/.agents/.history/setup`.
-  Source: `apps/cli/src/commands/setup-secrets.ts`,
+  explicit automation use), persists `secrets.backend` so future `agents
+  secrets create/import` commands use the selected backend when no backend flag is
+  passed, optionally delegates imports to `agents secrets import`, and writes
+  setup preferences under `~/.agents/.history/setup`. Source:
+  `apps/cli/src/commands/setup-secrets.ts`, `apps/cli/src/commands/secrets.ts`,
   `apps/cli/src/commands/setup.ts`.

--- a/apps/cli/.changelog/next/rush-1999-setup-secrets.md
+++ b/apps/cli/.changelog/next/rush-1999-setup-secrets.md
@@ -1,0 +1,8 @@
+- **`agents setup secrets` now guides first-run secrets onboarding (RUSH-1999).**
+  The setup command registers a new `secrets` capability wizard that chooses a
+  default storage backend (`keychain`, encrypted `file`, or synced `vault`), sets
+  the existing default prompt policy (`daily`/`always`, with `never` gated for
+  explicit automation use), optionally delegates imports to `agents secrets
+  import`, and writes durable setup preferences under `~/.agents/.history/setup`.
+  Source: `apps/cli/src/commands/setup-secrets.ts`,
+  `apps/cli/src/commands/setup.ts`.

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -758,7 +758,7 @@ function countExpiringSoon(meta: Record<string, VarMeta> | undefined): number {
  * guard can't drift between them.
  */
 function resolveImportBundle(name: string, backendOpt: string | undefined, synced = false): SecretsBundle {
-  const requestedBackend = synced ? 'vault' : parseBackendOpt(backendOpt);
+  const requestedBackend = synced ? 'vault' : resolveBackendOpt(backendOpt);
   if (bundleExists(name)) {
     const bundle = readBundle(name);
     if (requestedBackend !== 'keychain' && bundle.backend !== requestedBackend) {
@@ -1237,7 +1237,7 @@ export function registerSecretsCommands(program: Command): void {
     .option('--policy <policy>', "prompt policy: hold (default, ask once per hold window — secrets.agent.holdMs, 7d by default), always (ask every time), or never (silent, NO biometry ACL — needs --i-understand). 'daily'/'session' are accepted aliases for 'hold'.")
     .addOption(new Option('--tier <policy>', 'deprecated alias for --policy').hideHelp())
     .option('--i-understand', 'Confirm creating a "never"-policy bundle (no biometry ACL) without an interactive prompt')
-    .option('--backend <backend>', 'storage backend: keychain (default) or file (passphrase-encrypted)', 'keychain')
+    .option('--backend <backend>', 'storage backend: keychain or file (defaults to agents.yaml secrets.backend)')
     .option('--synced', 'Store this bundle in the age-encrypted synced secrets file for user-managed cross-machine file sync')
     .option('--force', 'Overwrite an existing bundle')
     .action(async (name: string | undefined, opts: { description?: string; allowExec?: boolean; policy?: string; tier?: string; iUnderstand?: boolean; backend?: string; synced?: boolean; force?: boolean }) => {
@@ -1248,7 +1248,7 @@ export function registerSecretsCommands(program: Command): void {
         // inherits the configured default (`daily`) instead of being pinned.
         const policyOpt = opts.policy ?? opts.tier;
         const policy = policyOpt ? parsePolicyOpt(policyOpt) : undefined;
-        const backend = opts.synced ? 'vault' : parseBackendOpt(opts.backend);
+        const backend = opts.synced ? 'vault' : resolveBackendOpt(opts.backend);
         if (bundleExists(resolvedName) && !opts.force) {
           console.error(chalk.red(`Bundle '${resolvedName}' already exists. Use --force to overwrite.`));
           process.exit(1);
@@ -1658,7 +1658,7 @@ Examples:
     .addOption(new Option('--from-1password', 'deprecated alias for --from 1password:<vault>').hideHelp())
     .addOption(new Option('--vault <name>', 'deprecated: name the vault in --from 1password:<vault>').hideHelp())
     .option('--all-plaintext', 'Store every imported value as a literal in the bundle metadata (skip keychain item creation)')
-    .option('--backend <backend>', 'When creating the bundle: keychain (default) or file (passphrase-encrypted)', 'keychain')
+    .option('--backend <backend>', 'When creating the bundle: keychain or file (defaults to agents.yaml secrets.backend)')
     .option('--synced', 'When creating the bundle, store it in the age-encrypted synced secrets file')
     .option('--force', 'Overwrite an existing key in the bundle')
     .option('--purge', 'With --from icloud: delete the iCloud copies after a successful import (iCloud propagates the deletion to your other devices)')
@@ -1727,7 +1727,7 @@ Examples:
         if (opts.from1password) {
           console.log(chalk.yellow('--from-1password is deprecated; use --from 1password:<vault>.'));
         }
-        const requestedBackend = opts.synced ? 'vault' : parseBackendOpt(opts.backend);
+        const requestedBackend = opts.synced ? 'vault' : resolveBackendOpt(opts.backend);
 
         if (source.kind === 'icloud') {
           await importFromICloud(bundleName, {
@@ -2589,11 +2589,24 @@ async function confirmNeverPolicyInteractive(bundleName: string): Promise<boolea
 }
 
 /** Validate a --backend value, exiting with a clear message on a bad one. */
-function parseBackendOpt(raw: string | undefined): SecretsBackend {
-  const v = (raw ?? 'keychain').toLowerCase();
+export function secretsDefaultBackend(): SecretsBackend {
+  const raw = readMeta().secrets?.backend;
+  if (raw === undefined) return 'keychain';
+  if (raw === 'keychain' || raw === 'file' || raw === 'vault') return raw;
+  console.error(chalk.red(`Invalid secrets.backend '${raw}'. Use 'keychain', 'file', or 'vault'.`));
+  process.exit(1);
+}
+
+function parseBackendOpt(raw: string | undefined, defaultBackend: SecretsBackend = 'keychain'): SecretsBackend {
+  const v = (raw ?? defaultBackend).toLowerCase();
+  if (!raw && v === 'vault') return 'vault';
   if (v === 'keychain' || v === 'file') return v;
   console.error(chalk.red(`Invalid --backend '${raw}'. Use 'keychain' or 'file'. For cross-machine file sync, pass --synced.`));
   process.exit(1);
+}
+
+function resolveBackendOpt(raw: string | undefined): SecretsBackend {
+  return parseBackendOpt(raw, raw === undefined ? secretsDefaultBackend() : 'keychain');
 }
 
 /** Human-readable "locks in 3 hours" / "locks in 5 minutes" from an epoch-ms expiry. */

--- a/apps/cli/src/commands/setup-secrets.ts
+++ b/apps/cli/src/commands/setup-secrets.ts
@@ -1,0 +1,266 @@
+/**
+ * `agents setup secrets` — guided defaults for `agents secrets` onboarding.
+ *
+ * The wizard writes setup preferences and delegates imports to the existing
+ * `agents secrets import` command, keeping bundle storage as the source of truth.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'node:child_process';
+import { getHistoryDir, updateMeta } from '../lib/state.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+
+type SetupSecretsBackend = 'keychain' | 'file' | 'vault';
+type SetupSecretsPolicy = 'daily' | 'always' | 'never';
+type SetupSecretsImportSource = 'none' | 'env' | '1password' | 'icloud';
+
+interface SetupSecretsOptions {
+  backend?: string;
+  policy?: string;
+  importFrom?: string;
+  bundle?: string;
+  vault?: string;
+  yes?: boolean;
+  iUnderstand?: boolean;
+  force?: boolean;
+}
+
+interface SetupSecretsPrefs {
+  defaultBackend: SetupSecretsBackend;
+  defaultPolicy: SetupSecretsPolicy;
+  updatedAt: string;
+}
+
+function defaultBackendForPlatform(platform: NodeJS.Platform = process.platform): SetupSecretsBackend {
+  return platform === 'darwin' ? 'keychain' : 'file';
+}
+
+function setupSecretsPrefsPath(): string {
+  return path.join(getHistoryDir(), 'setup', 'secrets.json');
+}
+
+function parseBackend(raw: string | undefined): SetupSecretsBackend {
+  const value = (raw ?? defaultBackendForPlatform()).toLowerCase();
+  if (value === 'keychain' || value === 'file' || value === 'vault') return value;
+  throw new Error(`Invalid --backend '${raw}'. Use keychain, file, or vault.`);
+}
+
+function parsePolicy(raw: string | undefined): SetupSecretsPolicy {
+  const value = (raw ?? 'daily').toLowerCase();
+  if (value === 'daily' || value === 'always' || value === 'never') return value;
+  throw new Error(`Invalid --policy '${raw}'. Use daily, always, or never.`);
+}
+
+function parseImportSource(raw: string | undefined): SetupSecretsImportSource {
+  const value = (raw ?? 'none').toLowerCase();
+  if (value === 'none' || value === 'env' || value === '1password' || value === 'icloud') return value;
+  throw new Error(`Invalid --import-from '${raw}'. Use none, env, 1password, or icloud.`);
+}
+
+function hasCommand(command: string): boolean {
+  const res = spawnSync(command, ['--version'], { stdio: 'ignore', windowsHide: true });
+  return !res.error;
+}
+
+function saveSetupSecretsPrefs(prefs: SetupSecretsPrefs): string {
+  const file = setupSecretsPrefsPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, JSON.stringify(prefs, null, 2) + '\n', { mode: 0o600 });
+  return file;
+}
+
+function applyPromptPolicyDefault(policy: SetupSecretsPolicy): void {
+  if (policy === 'never') return;
+  updateMeta((meta) => ({
+    ...meta,
+    secrets: {
+      ...meta.secrets,
+      policy,
+    },
+  }));
+}
+
+function backendArgs(backend: SetupSecretsBackend): string[] {
+  return backend === 'vault' ? ['--synced'] : ['--backend', backend];
+}
+
+function printBackendNotes(backend: SetupSecretsBackend): void {
+  if (backend === 'keychain') {
+    console.log(chalk.gray('backend: keychain — macOS reads may ask for Touch ID or the device password.'));
+  } else if (backend === 'file') {
+    console.log(chalk.gray('backend: file — set AGENTS_SECRETS_PASSPHRASE for headless encrypted-file reads.'));
+  } else {
+    console.log(chalk.gray('backend: vault — synced ~/.agents/vault.age storage; unlock it with agents login.'));
+  }
+}
+
+function runAgentsSubcommand(args: string[]): void {
+  const entry = process.argv[1];
+  if (!entry) throw new Error('Cannot locate the current agents entrypoint.');
+  const command = entry.endsWith('.ts') ? 'tsx' : process.execPath;
+  const commandArgs = entry.endsWith('.ts') ? [entry, ...args] : [entry, ...args];
+  const res = spawnSync(command, commandArgs, { stdio: 'inherit', env: process.env });
+  if ((res.status ?? 1) !== 0) {
+    throw new Error(`agents ${args.join(' ')} failed with exit ${res.status ?? 1}.`);
+  }
+}
+
+async function maybeImportSecrets(
+  source: SetupSecretsImportSource,
+  opts: { bundle?: string; vault?: string; backend: SetupSecretsBackend; force?: boolean },
+): Promise<void> {
+  if (source === 'none') return;
+
+  let bundle = opts.bundle;
+  if (!bundle) {
+    if (!isInteractiveTerminal()) {
+      throw new Error(`--bundle is required with --import-from ${source} in a non-interactive shell.`);
+    }
+    const { input } = await import('@inquirer/prompts');
+    bundle = await input({
+      message: 'Import into which bundle?',
+      default: 'default',
+      validate: (v) => (v.trim().length > 0 ? true : 'Enter a bundle name.'),
+    });
+  }
+
+  const args = ['secrets', 'import', bundle, ...backendArgs(opts.backend)];
+  if (opts.force) args.push('--force');
+  if (source === 'env') {
+    let envPath = opts.vault;
+    if (!envPath) {
+      if (!isInteractiveTerminal()) {
+        throw new Error('--vault must name the .env path when --import-from env is used non-interactively.');
+      }
+      const { input } = await import('@inquirer/prompts');
+      envPath = await input({
+        message: '.env file path',
+        default: '.env',
+        validate: (v) => (v.trim().length > 0 ? true : 'Enter a .env path.'),
+      });
+    }
+    args.push('--from', envPath);
+  } else if (source === '1password') {
+    const vault = opts.vault;
+    if (!vault) throw new Error('--vault <name> is required with --import-from 1password.');
+    args.push('--from', `1password:${vault}`);
+  } else {
+    args.push('--from', 'icloud');
+  }
+  runAgentsSubcommand(args);
+}
+
+async function resolveInteractiveChoices(opts: SetupSecretsOptions): Promise<{
+  backend: SetupSecretsBackend;
+  policy: SetupSecretsPolicy;
+  importSource: SetupSecretsImportSource;
+}> {
+  if (!isInteractiveTerminal()) {
+    return {
+      backend: parseBackend(opts.backend),
+      policy: parsePolicy(opts.policy),
+      importSource: parseImportSource(opts.importFrom),
+    };
+  }
+
+  const { select } = await import('@inquirer/prompts');
+  const backend = opts.backend ? parseBackend(opts.backend) : await select<SetupSecretsBackend>({
+    message: 'Default secrets backend',
+    default: defaultBackendForPlatform(),
+    choices: [
+      { name: 'keychain — local OS keychain; reads may ask for Touch ID/device password', value: 'keychain' },
+      { name: 'file — passphrase-encrypted file store for headless machines', value: 'file' },
+      { name: 'vault — synced ~/.agents/vault.age file; requires agents login', value: 'vault' },
+    ],
+  });
+  const policy = opts.policy ? parsePolicy(opts.policy) : await select<SetupSecretsPolicy>({
+    message: 'Default prompt policy',
+    default: 'daily',
+    choices: [
+      { name: 'daily — ask once, then hold for the configured window', value: 'daily' },
+      { name: 'always — ask on every read', value: 'always' },
+      { name: 'never — no biometry ACL; use only for automation-only bundles', value: 'never' },
+    ],
+  });
+  const importChoices = [
+    { name: 'skip import', value: 'none' as const },
+    { name: 'import from .env file', value: 'env' as const },
+    ...(hasCommand('op') ? [{ name: 'import from 1Password vault', value: '1password' as const }] : []),
+    { name: 'import legacy iCloud Keychain bundles', value: 'icloud' as const },
+  ];
+  const importSource = opts.importFrom ? parseImportSource(opts.importFrom) : await select<SetupSecretsImportSource>({
+    message: 'Import existing secrets now?',
+    default: 'none',
+    choices: importChoices,
+  });
+  return { backend, policy, importSource };
+}
+
+function printOnboardingSummary(backend: SetupSecretsBackend, policy: SetupSecretsPolicy, prefsFile: string): void {
+  console.log(chalk.bold('\nSecrets setup saved.'));
+  console.log(chalk.gray(`preferences: ${prefsFile}`));
+  printBackendNotes(backend);
+  if (policy === 'never') {
+    console.log(chalk.yellow('policy: never is saved as a setup preference; create automation-only bundles with --policy never --i-understand.'));
+  } else {
+    console.log(chalk.gray(`policy: ${policy} — used by bundles that do not set their own policy.`));
+  }
+  console.log(chalk.bold('\nTry:'));
+  console.log(chalk.cyan(`  agents secrets create prod ${backendArgs(backend).join(' ')} --policy ${policy === 'never' ? 'daily' : policy}`));
+  console.log(chalk.cyan('  agents secrets add prod API_KEY'));
+  console.log(chalk.cyan('  agents run claude "deploy" --secrets prod'));
+}
+
+export async function runSecretsSetupWizard(opts: SetupSecretsOptions = {}): Promise<boolean> {
+  const { backend, policy, importSource } = await resolveInteractiveChoices(opts);
+  if (policy === 'never' && !opts.iUnderstand && !isInteractiveTerminal()) {
+    throw new Error("Refusing to save policy 'never' non-interactively without --i-understand.");
+  }
+
+  applyPromptPolicyDefault(policy);
+  const prefsFile = saveSetupSecretsPrefs({
+    defaultBackend: backend,
+    defaultPolicy: policy,
+    updatedAt: new Date().toISOString(),
+  });
+
+  await maybeImportSecrets(importSource, {
+    bundle: opts.bundle,
+    vault: opts.vault,
+    backend,
+    force: opts.force,
+  });
+
+  printOnboardingSummary(backend, policy, prefsFile);
+  return true;
+}
+
+/** Register `agents setup secrets` under the parent `setup` command. */
+export function registerSetupSecretsCommand(setupCmd: Command): void {
+  setupCmd
+    .command('secrets')
+    .description('Configure `agents secrets` defaults and optionally import existing secrets.')
+    .option('--backend <backend>', 'default backend: keychain, file, or vault')
+    .option('--policy <policy>', 'default prompt policy: daily, always, or never')
+    .option('--import-from <source>', 'optional import source: none, env, 1password, or icloud', 'none')
+    .option('--bundle <name>', 'bundle name for optional imports')
+    .option('--vault <name-or-path>', '1Password vault name, or .env path with --import-from env')
+    .option('--yes', 'accept defaults for omitted choices in non-interactive use')
+    .option('--i-understand', 'allow saving the "never" policy preference without an interactive prompt')
+    .option('--force', 'pass --force through to optional imports')
+    .action(async (options: SetupSecretsOptions) => {
+      try {
+        await runSecretsSetupWizard(options);
+      } catch (err) {
+        if (isPromptCancelled(err)) {
+          console.log(chalk.yellow('\nCancelled'));
+          return;
+        }
+        console.error(chalk.red((err as Error).message));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/apps/cli/src/commands/setup-secrets.ts
+++ b/apps/cli/src/commands/setup-secrets.ts
@@ -10,6 +10,7 @@ import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
 import { spawnSync } from 'node:child_process';
+import { getCliLaunch } from '../lib/cli-entry.js';
 import { getHistoryDir, updateMeta } from '../lib/state.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
@@ -98,11 +99,8 @@ function printBackendNotes(backend: SetupSecretsBackend): void {
 }
 
 function runAgentsSubcommand(args: string[]): void {
-  const entry = process.argv[1];
-  if (!entry) throw new Error('Cannot locate the current agents entrypoint.');
-  const command = entry.endsWith('.ts') ? 'tsx' : process.execPath;
-  const commandArgs = entry.endsWith('.ts') ? [entry, ...args] : [entry, ...args];
-  const res = spawnSync(command, commandArgs, { stdio: 'inherit', env: process.env });
+  const launch = getCliLaunch(args);
+  const res = spawnSync(launch.command, launch.args, { stdio: 'inherit', env: process.env });
   if ((res.status ?? 1) !== 0) {
     throw new Error(`agents ${args.join(' ')} failed with exit ${res.status ?? 1}.`);
   }

--- a/apps/cli/src/commands/setup-secrets.ts
+++ b/apps/cli/src/commands/setup-secrets.ts
@@ -24,7 +24,6 @@ interface SetupSecretsOptions {
   importFrom?: string;
   bundle?: string;
   vault?: string;
-  yes?: boolean;
   iUnderstand?: boolean;
   force?: boolean;
 }
@@ -73,13 +72,13 @@ function saveSetupSecretsPrefs(prefs: SetupSecretsPrefs): string {
   return file;
 }
 
-function applyPromptPolicyDefault(policy: SetupSecretsPolicy): void {
-  if (policy === 'never') return;
+function applySecretsDefaults(backend: SetupSecretsBackend, policy: SetupSecretsPolicy): void {
   updateMeta((meta) => ({
     ...meta,
     secrets: {
       ...meta.secrets,
-      policy,
+      backend,
+      ...(policy === 'never' ? {} : { policy }),
     },
   }));
 }
@@ -218,7 +217,7 @@ export async function runSecretsSetupWizard(opts: SetupSecretsOptions = {}): Pro
     throw new Error("Refusing to save policy 'never' non-interactively without --i-understand.");
   }
 
-  applyPromptPolicyDefault(policy);
+  applySecretsDefaults(backend, policy);
   const prefsFile = saveSetupSecretsPrefs({
     defaultBackend: backend,
     defaultPolicy: policy,
@@ -243,10 +242,9 @@ export function registerSetupSecretsCommand(setupCmd: Command): void {
     .description('Configure `agents secrets` defaults and optionally import existing secrets.')
     .option('--backend <backend>', 'default backend: keychain, file, or vault')
     .option('--policy <policy>', 'default prompt policy: daily, always, or never')
-    .option('--import-from <source>', 'optional import source: none, env, 1password, or icloud', 'none')
+    .option('--import-from <source>', 'optional import source: none, env, 1password, or icloud')
     .option('--bundle <name>', 'bundle name for optional imports')
     .option('--vault <name-or-path>', '1Password vault name, or .env path with --import-from env')
-    .option('--yes', 'accept defaults for omitted choices in non-interactive use')
     .option('--i-understand', 'allow saving the "never" policy preference without an interactive prompt')
     .option('--force', 'pass --force through to optional imports')
     .action(async (options: SetupSecretsOptions) => {

--- a/apps/cli/src/commands/setup.test.ts
+++ b/apps/cli/src/commands/setup.test.ts
@@ -48,7 +48,47 @@ describe('agents setup secrets', () => {
     expect(prefs.defaultPolicy).toBe('always');
 
     const { readMeta } = await import('../lib/state.js');
+    expect(readMeta().secrets?.backend).toBe('file');
     expect(readMeta().secrets?.policy).toBe('always');
+  });
+
+  it('does not treat omitted --import-from as a CLI-selected import source', () => {
+    const program = new Command();
+    registerSetupCommand(program);
+
+    const setup = program.commands.find((c) => c.name() === 'setup')!;
+    const secrets = setup.commands.find((c) => c.name() === 'secrets')!;
+    secrets.parseOptions([]);
+
+    expect(secrets.opts().importFrom).toBeUndefined();
+  });
+
+  it('makes future secrets create/import use the saved backend default', async () => {
+    process.env.AGENTS_SECRETS_PASSPHRASE = 'setup-test-passphrase';
+
+    const setupProgram = new Command();
+    setupProgram.exitOverride();
+    registerSetupCommand(setupProgram);
+    await setupProgram.parseAsync(['setup', 'secrets', '--backend', 'file', '--policy', 'daily'], {
+      from: 'user',
+    });
+
+    const { registerSecretsCommands } = await import('./secrets.js');
+    const { readBundle } = await import('../lib/secrets/bundles.js');
+
+    const createProgram = new Command();
+    createProgram.exitOverride();
+    registerSecretsCommands(createProgram);
+    await createProgram.parseAsync(['secrets', 'create', 'setup-default-create'], { from: 'user' });
+    expect(readBundle('setup-default-create')?.backend).toBe('file');
+
+    const envPath = path.join(TEST_HOME, 'setup-default.env');
+    fs.writeFileSync(envPath, 'SETUP_DEFAULT=1\n');
+    const importProgram = new Command();
+    importProgram.exitOverride();
+    registerSecretsCommands(importProgram);
+    await importProgram.parseAsync(['secrets', 'import', 'setup-default-import', '--from', envPath], { from: 'user' });
+    expect(readBundle('setup-default-import')?.backend).toBe('file');
   });
 });
 

--- a/apps/cli/src/commands/setup.test.ts
+++ b/apps/cli/src/commands/setup.test.ts
@@ -12,13 +12,13 @@ const { registerSetupCommand } = await import('./setup.js');
 const { listInstalledBrowsers } = await import('../lib/browser/chrome.js');
 
 describe('agents setup command group', () => {
-  it('registers the browser/computer/share/mine capability subcommands', () => {
+  it('registers the browser/computer/share/mine/secrets capability subcommands', () => {
     const program = new Command();
     registerSetupCommand(program);
     const setup = program.commands.find((c) => c.name() === 'setup');
     expect(setup).toBeDefined();
     const subs = setup!.commands.map((c) => c.name()).sort();
-    expect(subs).toEqual(['browser', 'computer', 'mine', 'share']);
+    expect(subs).toEqual(['browser', 'computer', 'mine', 'secrets', 'share']);
   });
 
   it('keeps the bare `setup` command with its force / no-system-repo flags', () => {
@@ -28,6 +28,27 @@ describe('agents setup command group', () => {
     const flags = setup.options.map((o) => o.long).sort();
     expect(flags).toContain('--force');
     expect(flags).toContain('--no-system-repo');
+  });
+});
+
+describe('agents setup secrets', () => {
+  it('non-interactively persists backend preference and the existing secrets policy default', async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerSetupCommand(program);
+
+    await program.parseAsync(['setup', 'secrets', '--backend', 'file', '--policy', 'always'], {
+      from: 'user',
+    });
+
+    const prefs = JSON.parse(
+      fs.readFileSync(path.join(TEST_HOME, '.agents', '.history', 'setup', 'secrets.json'), 'utf-8'),
+    );
+    expect(prefs.defaultBackend).toBe('file');
+    expect(prefs.defaultPolicy).toBe('always');
+
+    const { readMeta } = await import('../lib/state.js');
+    expect(readMeta().secrets?.policy).toBe('always');
   });
 });
 

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -25,6 +25,7 @@ import { registerSetupBrowserCommand, runBrowserWizard } from './setup-browser.j
 import { registerSetupComputerCommand, runComputerWizard } from './setup-computer.js';
 import { registerSetupShareCommand, runShareWizard } from './setup-share.js';
 import { registerSetupMineCommand } from './setup-mine.js';
+import { registerSetupSecretsCommand } from './setup-secrets.js';
 
 const HOME = os.homedir();
 
@@ -275,12 +276,13 @@ async function runSetupHub(): Promise<void> {
   if (!isInteractiveTerminal()) return;
   try {
     const { checkbox } = await import('@inquirer/prompts');
-    const picks = await checkbox<'browser' | 'computer' | 'share'>({
+    const picks = await checkbox<'browser' | 'computer' | 'share' | 'secrets'>({
       message: 'Set up optional capabilities now? (space to select, enter to confirm)',
       choices: [
         { name: 'browser  — drive a real Chrome/Brave/Edge for web automation', value: 'browser' },
         { name: 'computer — control native macOS apps (screenshot, click, type)', value: 'computer' },
         { name: 'share    — publish shareable links (Cloudflare R2 + Worker)', value: 'share' },
+        { name: 'secrets  — choose storage defaults and import existing credentials', value: 'secrets' },
       ],
     });
     for (const pick of picks) {
@@ -288,6 +290,7 @@ async function runSetupHub(): Promise<void> {
       if (pick === 'browser') await runBrowserWizard();
       else if (pick === 'computer') await runComputerWizard();
       else if (pick === 'share') await runShareWizard();
+      else if (pick === 'secrets') await import('./setup-secrets.js').then((m) => m.runSecretsSetupWizard());
     }
   } catch (err) {
     if (isPromptCancelled(err)) return;
@@ -303,11 +306,12 @@ export function registerSetupCommand(program: Command): void {
     .option('-f, --force', 'Re-run setup even if ~/.agents/.system/ already exists (use with caution)')
     .option('--no-system-repo', 'Skip cloning the system repo (you must populate ~/.agents/.system/ yourself)');
 
-  // Capability subcommands: `agents setup browser|computer|share|mine`.
+  // Capability subcommands: `agents setup browser|computer|share|mine|secrets`.
   registerSetupBrowserCommand(setupCmd);
   registerSetupComputerCommand(setupCmd);
   registerSetupShareCommand(setupCmd);
   registerSetupMineCommand(setupCmd);
+  registerSetupSecretsCommand(setupCmd);
 
   setHelpSections(setupCmd, {
     examples: `
@@ -321,17 +325,19 @@ export function registerSetupCommand(program: Command): void {
       agents setup browser
       agents setup computer
       agents setup share
+      agents setup secrets
     `,
     notes: `
       What it does:
         1. Clones the system repo into ~/.agents/.system/
         2. Imports any unmanaged agent installations it finds
-        3. On a TTY, offers to set up optional capabilities (browser/computer/share)
+        3. On a TTY, offers to set up optional capabilities (browser/computer/share/secrets)
 
       Capability setup can also be run any time on its own:
         agents setup browser    # detect a browser + create the default profile
         agents setup computer    # install the signed macOS helper + grant permissions
         agents setup share       # provision or join a Cloudflare share endpoint
+        agents setup secrets     # choose secrets backend/policy defaults + import
 
       To install CLIs from agents.yaml and sync resources into version homes:
         agents sync --local -y

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -812,6 +812,9 @@ export interface Meta {
    * passing `--durable` per unlock; off means the secure split default (survive
    * upgrade/restart, re-lock on sleep). */
   secrets?: {
+    /** Default storage backend used when `agents secrets create/import` create a
+     * new bundle without `--backend` or `--synced`. */
+    backend?: 'keychain' | 'file' | 'vault';
     /** Default prompt policy. `hold` (the default) holds a bundle for
      * `agent.holdMs`; `daily`/`session` are accepted aliases kept so an existing
      * agents.yaml keeps working. See SecretsPolicy in lib/secrets/bundles.ts. */


### PR DESCRIPTION
## What changed
Adds `agents setup secrets` for RUSH-1999: users can choose a default secrets backend, set the default prompt policy, optionally import existing secrets, and see the next commands to create/use a bundle.

Linear: https://linear.app/getrush/issue/RUSH-1999/add-agents-setup-secrets-wizard-for-backendpolicyimport-onboarding

## Verification
Real compiled command run with delegated `.env` import through `getCliLaunch()`:
```text
$ HOME=/tmp/agents-setup-secrets-compiled.Hi4egY AGENTS_SECRETS_PASSPHRASE=test-pass node dist/index.js setup secrets --backend file --policy always --import-from env --bundle demo --vault /tmp/agents-setup-secrets-compiled.Hi4egY/test.env
Imported 1 key(s).

Secrets setup saved.
preferences: /tmp/agents-setup-secrets-compiled.Hi4egY/.agents/.history/setup/secrets.json
backend: file — set AGENTS_SECRETS_PASSPHRASE for headless encrypted-file reads.
policy: always — used by bundles that do not set their own policy.

prefs:
{
  "defaultBackend": "file",
  "defaultPolicy": "always",
  "updatedAt": "2026-08-02T04:31:22.317Z"
}

$ HOME=/tmp/agents-setup-secrets-compiled.Hi4egY AGENTS_SECRETS_PASSPHRASE=test-pass node dist/index.js secrets list
NAME  KEYS  POLICY           ...
demo  1     always · prompt  ... [file]
```

Tests/build:
```text
$ bun run test src/commands/setup.test.ts scripts/gen-changelog.test.ts
Test Files  2 passed (2)
Tests  9 passed (9)

$ bun run build
$ tsc ...
```

Session transcript: public repo, omitted from PR body; local path is `yosemite-s1:/home/muqsit/.agents/.history/versions/codex/0.146.0/home/.codex/sessions/2026/08/01/rollout-2026-08-01T20-59-26-019fc0a0-6bfd-7712-9234-edcd4f6eca1d.jsonl`.
