### PR TITLE
feat(secrets): name the triggering session in the keychain Touch ID prompt (RUSH-1971)

### DIFF
--- a/apps/cli/.changelog/next/rush-1971.md
+++ b/apps/cli/.changelog/next/rush-1971.md
@@ -1,0 +1,10 @@
+- **The keychain Touch ID prompt now names the session that triggered the read
+  (RUSH-1971).** When a bundle read pops Touch ID, the operation prompt already
+  named the requesting agent, bundle, and reason; it now also carries the
+  triggering session's 8-char short-id — e.g. *"Claude is requesting to unlock the
+  'prod' bundle (session e0a1b2c3) for 7 days …"* — so an unexpected prompt is
+  attributable when an interactive agent, headless workers, and `secrets exec`
+  deploys all run at once. The short-id is derived from the `AGENT_SESSION_ID` the
+  exec env already exports; no keychain-helper re-sign is required (the enriched
+  string flows through the existing `AGENTS_KEYCHAIN_PROMPT` env). Source:
+  `apps/cli/src/lib/secrets/index.ts`, `apps/cli/src/lib/secrets/bundles.ts`.

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -1422,6 +1422,9 @@ export function readAndResolveBundleEnv(
     ? getKeychainTokens([...new Set([metaItem, ...secretItems])], {
         agent: opts.agent || process.env.AGENTS_AGENT_NAME || 'Agents CLI',
         bundle: name,
+        // The session that triggered the read, so a Touch ID prompt is
+        // attributable when several agents run at once. Exported by exec.ts.
+        sessionId: process.env.AGENT_SESSION_ID || process.env.AGENTS_SESSION_ID,
         reason: opts.caller ? `to ${opts.caller}` : reason,
         duration: opts.duration || humanUnlockDuration(secretsHoldMs()),
         defaultPolicy: secretsDefaultPolicy(),

--- a/apps/cli/src/lib/secrets/index.test.ts
+++ b/apps/cli/src/lib/secrets/index.test.ts
@@ -41,6 +41,24 @@ describe('keychainOperationPrompt', () => {
       duration: '7 days',
     })).toBe("Claude is requesting to unlock the 'prod' bundle for 7 days to deploy the API.");
   });
+
+  it('names the session (short-id) that triggered the read (RUSH-1971)', () => {
+    expect(keychainOperationPrompt({
+      agent: 'Claude',
+      bundle: 'prod',
+      sessionId: 'e0a1b2c3-4d5e-6f70-8192-a3b4c5d6e7f8',
+      reason: 'to deploy the API',
+      duration: '7 days',
+    })).toBe(
+      "Claude is requesting to unlock the 'prod' bundle (session e0a1b2c3) for 7 days to deploy the API.",
+    );
+  });
+
+  it('omits the session clause when no sessionId is supplied', () => {
+    expect(keychainOperationPrompt({ agent: 'Claude', bundle: 'prod' })).toBe(
+      "Claude is requesting to unlock the 'prod' bundle.",
+    );
+  });
 });
 
 describe('buildAddGenericPasswordArgs (RUSH-1764: value never in argv)', () => {

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -34,6 +34,7 @@ import type { NativeImportReport } from './fallback.js';
 
 export type { NativeImportReport, NativeImportResult, NativeImportStatus } from './fallback.js';
 import { getKeychainHelperPath } from './install-helper.js';
+import { deriveShortId } from '../session/short-id.js';
 
 const SERVICE_PREFIX = 'agents-cli';
 export const SECRETS_ITEM_PREFIX = `${SERVICE_PREFIX}.secrets.`;
@@ -816,6 +817,7 @@ export function hasKeychainToken(item: string): boolean {
 export interface KeychainReadContext {
   agent?: string;
   bundle?: string;
+  sessionId?: string;
   reason?: string;
   duration?: string;
   defaultPolicy?: 'hold' | 'always' | 'never';
@@ -825,9 +827,12 @@ export interface KeychainReadContext {
 export function keychainOperationPrompt(context: KeychainReadContext = {}): string {
   const agent = context.agent || 'Agents CLI';
   const bundle = context.bundle ? ` the '${context.bundle}' bundle` : ' secrets';
+  // Which session triggered the read — the short-id disambiguates an unexpected
+  // prompt when several agents run at once (interactive + headless + exec).
+  const session = context.sessionId ? ` (session ${deriveShortId(context.sessionId)})` : '';
   const duration = context.duration ? ` for ${context.duration}` : '';
   const reason = context.reason ? ` ${context.reason}` : '';
-  return `${agent} is requesting to unlock${bundle}${duration}${reason}.`;
+  return `${agent} is requesting to unlock${bundle}${session}${duration}${reason}.`;
 }
 
 export function getKeychainToken(item: string, context: KeychainReadContext = {}): string {


### PR DESCRIPTION
**feat / small behavior change** — the keychain Touch ID prompt now names the session that triggered the read. Audience: end users of `agents secrets` on macOS.

## What changed

The bundle-read Touch ID prompt already named the requesting **agent**, **bundle**, and **reason** — but not **which session** triggered it. When an interactive agent, headless workers, and `secrets exec` deploys all run at once, an unexpected prompt was unattributable.

- Add `sessionId` to `KeychainReadContext` (`apps/cli/src/lib/secrets/index.ts`).
- `keychainOperationPrompt()` now inserts the session's 8-char short-id (`deriveShortId`) as a `(session <shortid>)` clause.
- Thread `sessionId` from the JIT bundle read path `readAndResolveBundleEnv` (`apps/cli/src/lib/secrets/bundles.ts:~1423`) off `AGENT_SESSION_ID` / `AGENTS_SESSION_ID` that the exec env already exports.

The enriched string flows to `kSecUseOperationPrompt` through the **existing** `AGENTS_KEYCHAIN_PROMPT` env var the signed helper already reads (`keychain-helper.swift:5,179`) — **no keychain-helper re-sign/notarize required.**

Example prompt tail (after the OS-supplied "Agents CLI is trying to"):
> Claude is requesting to unlock the 'prod' bundle **(session e0a1b2c3)** for 7 days to deploy the API.

## Run result — `vitest run src/lib/secrets/index.test.ts`

```
 RUN  v4.1.9 .../apps/cli

 Test Files  1 passed (1)
      Tests  37 passed (37)
   Duration  200ms
```

Three prompt cases (all green): existing agent+bundle+reason+duration string unchanged; new session short-id clause present; and the clause omitted when no `sessionId` is supplied (backwards-compatible default).

## Not in this PR (follow-up)

- **Live Touch ID visual verification is macOS-only** — this change is authored/tested on Linux; the string + env plumbing is unit-tested here, but eyeballing the actual biometric dialog on a Mac is a follow-up.
- `secrets exec --reason` (ticket item #3) and the Swift `--prompt` arg-plumbing (item #1) remain deferred — they are the release-heavy parts; this is the TS-only enrichment the ticket scoped to ship first.

Ticket: https://linear.app/getrush/issue/RUSH-1971