### PR TITLE
feat(setup): add fleet onboarding wizard

### DIFF
--- a/apps/cli/.changelog/next/rush-2000-setup-fleet.md
+++ b/apps/cli/.changelog/next/rush-2000-setup-fleet.md
@@ -1,0 +1,7 @@
+- **`agents setup fleet` now guides Tailscale device onboarding (RUSH-2000).**
+  The setup command registers a new `fleet` capability wizard that verifies
+  Tailscale, syncs discovered devices through the existing `agents devices sync`
+  path, applies SSH auth with `agents devices set`, optionally writes the
+  managed SSH config include, tests connectivity with `agents ssh <device>
+  uname`, and can run `agents fleet update` after registration. Source:
+  `apps/cli/src/commands/setup-fleet.ts`, `apps/cli/src/commands/setup.ts`.

--- a/apps/cli/src/commands/setup-fleet.ts
+++ b/apps/cli/src/commands/setup-fleet.ts
@@ -9,8 +9,10 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { spawnSync } from 'node:child_process';
+import { getCliLaunch } from '../lib/cli-entry.js';
 import { loadDevices } from '../lib/devices/registry.js';
 import { runDeviceSync } from '../lib/devices/sync.js';
+import { tailscaleStatusJson } from '../lib/devices/tailscale.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 
 type FleetAuthMethod = 'key' | 'password';
@@ -32,11 +34,8 @@ function parseAuth(raw: string | undefined): FleetAuthMethod {
 }
 
 function runAgentsSubcommand(args: string[], opts: { optional?: boolean } = {}): boolean {
-  const entry = process.argv[1];
-  if (!entry) throw new Error('Cannot locate the current agents entrypoint.');
-  const command = entry.endsWith('.ts') ? 'tsx' : process.execPath;
-  const commandArgs = entry.endsWith('.ts') ? [entry, ...args] : [entry, ...args];
-  const res = spawnSync(command, commandArgs, { stdio: 'inherit', env: process.env });
+  const launch = getCliLaunch(args);
+  const res = spawnSync(launch.command, launch.args, { stdio: 'inherit', env: process.env });
   if ((res.status ?? 1) === 0) return true;
   if (opts.optional) return false;
   throw new Error(`agents ${args.join(' ')} failed with exit ${res.status ?? 1}.`);
@@ -50,8 +49,12 @@ function commandExists(command: string): boolean {
 }
 
 function tailscaleStatusOk(): boolean {
-  const res = spawnSync('tailscale', ['status', '--json'], { stdio: 'ignore', windowsHide: true });
-  return (res.status ?? 1) === 0;
+  try {
+    tailscaleStatusJson();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function printTailscaleInstallInstructions(): void {

--- a/apps/cli/src/commands/setup-fleet.ts
+++ b/apps/cli/src/commands/setup-fleet.ts
@@ -1,0 +1,217 @@
+/**
+ * `agents setup fleet` — guided Tailscale device onboarding.
+ *
+ * This wizard is a front door over the existing fleet/device commands: sync
+ * Tailscale into the registry, choose auth, render SSH config, test devices, and
+ * optionally run the fleet updater without reimplementing those subcommands.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { spawnSync } from 'node:child_process';
+import { loadDevices } from '../lib/devices/registry.js';
+import { runDeviceSync } from '../lib/devices/sync.js';
+import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+
+type FleetAuthMethod = 'key' | 'password';
+
+interface SetupFleetOptions {
+  auth?: string;
+  bundle?: string;
+  bundleKey?: string;
+  yes?: boolean;
+  writeSshConfig?: boolean;
+  testConnectivity?: boolean;
+  fleetUpdate?: boolean;
+}
+
+function parseAuth(raw: string | undefined): FleetAuthMethod {
+  const value = (raw ?? 'key').toLowerCase();
+  if (value === 'key' || value === 'password') return value;
+  throw new Error(`Invalid --auth '${raw}'. Use key or password.`);
+}
+
+function runAgentsSubcommand(args: string[], opts: { optional?: boolean } = {}): boolean {
+  const entry = process.argv[1];
+  if (!entry) throw new Error('Cannot locate the current agents entrypoint.');
+  const command = entry.endsWith('.ts') ? 'tsx' : process.execPath;
+  const commandArgs = entry.endsWith('.ts') ? [entry, ...args] : [entry, ...args];
+  const res = spawnSync(command, commandArgs, { stdio: 'inherit', env: process.env });
+  if ((res.status ?? 1) === 0) return true;
+  if (opts.optional) return false;
+  throw new Error(`agents ${args.join(' ')} failed with exit ${res.status ?? 1}.`);
+}
+
+function commandExists(command: string): boolean {
+  const res = spawnSync(command, ['version'], { stdio: 'ignore', windowsHide: true });
+  if (!res.error) return true;
+  const fallback = spawnSync(command, ['--version'], { stdio: 'ignore', windowsHide: true });
+  return !fallback.error;
+}
+
+function tailscaleStatusOk(): boolean {
+  const res = spawnSync('tailscale', ['status', '--json'], { stdio: 'ignore', windowsHide: true });
+  return (res.status ?? 1) === 0;
+}
+
+function printTailscaleInstallInstructions(): void {
+  console.error(chalk.red('Tailscale is not installed or not on PATH.'));
+  const platform = process.platform;
+  console.log(chalk.bold('\nInstall Tailscale, then re-run `agents setup fleet`:'));
+  if (platform === 'darwin') {
+    console.log(chalk.cyan('  brew install --cask tailscale'));
+    console.log(chalk.gray('  or install from https://tailscale.com/download/mac'));
+  } else if (platform === 'linux') {
+    console.log(chalk.cyan('  curl -fsSL https://tailscale.com/install.sh | sh'));
+    console.log(chalk.gray('  then run: sudo tailscale up'));
+  } else if (platform === 'win32') {
+    console.log(chalk.cyan('  winget install Tailscale.Tailscale'));
+    console.log(chalk.gray('  or install from https://tailscale.com/download/windows'));
+  } else {
+    console.log(chalk.gray('  https://tailscale.com/download'));
+  }
+}
+
+async function resolveInteractiveChoices(opts: SetupFleetOptions): Promise<{
+  auth: FleetAuthMethod;
+  writeSshConfig: boolean;
+  testConnectivity: boolean;
+  fleetUpdate: boolean;
+}> {
+  if (!isInteractiveTerminal()) {
+    return {
+      auth: parseAuth(opts.auth),
+      writeSshConfig: Boolean(opts.writeSshConfig),
+      testConnectivity: Boolean(opts.testConnectivity),
+      fleetUpdate: Boolean(opts.fleetUpdate),
+    };
+  }
+
+  const { confirm, select } = await import('@inquirer/prompts');
+  const auth = opts.auth ? parseAuth(opts.auth) : await select<FleetAuthMethod>({
+    message: 'Default SSH auth for registered devices',
+    default: 'key',
+    choices: [
+      { name: 'key — use your SSH agent / on-disk public keys', value: 'key' },
+      { name: 'password — read the login password from an agents secrets bundle', value: 'password' },
+    ],
+  });
+  return {
+    auth,
+    writeSshConfig: opts.writeSshConfig ?? await confirm({
+      message: 'Write ~/.ssh/config.d/agents for plain ssh/scp/rsync?',
+      default: true,
+    }),
+    testConnectivity: opts.testConnectivity ?? await confirm({
+      message: 'Test connectivity with `agents ssh <device> uname`?',
+      default: true,
+    }),
+    fleetUpdate: opts.fleetUpdate ?? await confirm({
+      message: 'Run `agents fleet update` on online devices now?',
+      default: false,
+    }),
+  };
+}
+
+async function syncDevices(opts: SetupFleetOptions): Promise<boolean> {
+  if (isInteractiveTerminal() && !opts.yes) {
+    return runAgentsSubcommand(['devices', 'sync'], { optional: true });
+  }
+  const res = await runDeviceSync({ soft: true });
+  if (!res.ok) {
+    console.error(chalk.red(`Tailscale discovery failed: ${res.reason ?? 'unknown error'}`));
+    return false;
+  }
+  const extra = res.pending.length ? chalk.gray(` (${res.pending.length} new)`) : '';
+  console.log(chalk.green(`Synced ${res.synced} device${res.synced === 1 ? '' : 's'} from Tailscale${extra}.`));
+  return true;
+}
+
+async function applyAuth(auth: FleetAuthMethod, opts: SetupFleetOptions): Promise<string[]> {
+  const reg = await loadDevices();
+  const names = Object.keys(reg).sort();
+  if (names.length === 0) {
+    console.log(chalk.gray("No devices registered yet. Run 'agents setup fleet --yes' after joining Tailscale."));
+    return [];
+  }
+  if (auth === 'password' && !opts.bundle) {
+    throw new Error('--bundle is required with --auth password.');
+  }
+  for (const name of names) {
+    const args = ['devices', 'set', name, '--auth', auth];
+    if (opts.bundle) args.push('--bundle', opts.bundle);
+    if (opts.bundleKey) args.push('--bundle-key', opts.bundleKey);
+    runAgentsSubcommand(args);
+  }
+  return names;
+}
+
+function testConnectivity(names: string[]): void {
+  if (names.length === 0) return;
+  console.log(chalk.bold('\nTesting connectivity:'));
+  for (const name of names) {
+    const ok = runAgentsSubcommand(['ssh', name, 'uname'], { optional: true });
+    console.log(ok ? chalk.green(`  ${name}: ok`) : chalk.yellow(`  ${name}: failed`));
+  }
+}
+
+function printOnboardingSummary(names: string[], auth: FleetAuthMethod): void {
+  console.log(chalk.bold('\nFleet setup summary.'));
+  console.log(chalk.gray(`devices: ${names.length ? names.join(', ') : 'none registered'}`));
+  console.log(chalk.gray(`auth: ${auth}${auth === 'password' ? ' via secrets bundle' : ''}`));
+  console.log(chalk.bold('\nTry:'));
+  console.log(chalk.cyan('  agents devices list'));
+  console.log(chalk.cyan('  agents ssh <device> uname'));
+  console.log(chalk.cyan('  agents fleet run hostname'));
+  console.log(chalk.cyan('  agents fleet update'));
+}
+
+export async function runFleetSetupWizard(opts: SetupFleetOptions = {}): Promise<boolean> {
+  if (!commandExists('tailscale')) {
+    printTailscaleInstallInstructions();
+    return false;
+  }
+  if (!tailscaleStatusOk()) {
+    console.error(chalk.red('Tailscale is installed but not logged in or the daemon is unavailable.'));
+    console.log(chalk.gray('Run `tailscale login` (or `sudo tailscale up` on Linux), then re-run `agents setup fleet`.'));
+    return false;
+  }
+
+  const choices = await resolveInteractiveChoices(opts);
+  const synced = await syncDevices(opts);
+  if (!synced) return false;
+
+  const names = await applyAuth(choices.auth, opts);
+  if (choices.writeSshConfig) runAgentsSubcommand(['devices', 'render', '--write']);
+  if (choices.testConnectivity) testConnectivity(names);
+  if (choices.fleetUpdate) runAgentsSubcommand(['fleet', 'update']);
+
+  printOnboardingSummary(names, choices.auth);
+  return true;
+}
+
+/** Register `agents setup fleet` under the parent `setup` command. */
+export function registerSetupFleetCommand(setupCmd: Command): void {
+  setupCmd
+    .command('fleet')
+    .description('Set up `agents fleet` — discover Tailscale devices, choose auth, render SSH config, and test connectivity.')
+    .option('--auth <method>', 'device auth method: key or password', 'key')
+    .option('--bundle <name>', 'secrets bundle holding the login password when --auth password is used')
+    .option('--bundle-key <key>', "key within the secrets bundle (default 'password')")
+    .option('--yes', 'non-interactive: register every discovered, non-ignored Tailscale node')
+    .option('--write-ssh-config', 'write ~/.ssh/config.d/agents after syncing')
+    .option('--test-connectivity', 'run `agents ssh <device> uname` for each registered device')
+    .option('--fleet-update', 'run `agents fleet update` after setup')
+    .action(async (options: SetupFleetOptions) => {
+      try {
+        await runFleetSetupWizard(options);
+      } catch (err) {
+        if (isPromptCancelled(err)) {
+          console.log(chalk.yellow('\nCancelled'));
+          return;
+        }
+        console.error(chalk.red((err as Error).message));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/apps/cli/src/commands/setup.test.ts
+++ b/apps/cli/src/commands/setup.test.ts
@@ -12,13 +12,13 @@ const { registerSetupCommand } = await import('./setup.js');
 const { listInstalledBrowsers } = await import('../lib/browser/chrome.js');
 
 describe('agents setup command group', () => {
-  it('registers the browser/computer/share/mine/secrets capability subcommands', () => {
+  it('registers the browser/computer/share/fleet/mine/secrets capability subcommands', () => {
     const program = new Command();
     registerSetupCommand(program);
     const setup = program.commands.find((c) => c.name() === 'setup');
     expect(setup).toBeDefined();
     const subs = setup!.commands.map((c) => c.name()).sort();
-    expect(subs).toEqual(['browser', 'computer', 'mine', 'secrets', 'share']);
+    expect(subs).toEqual(['browser', 'computer', 'fleet', 'mine', 'secrets', 'share']);
   });
 
   it('keeps the bare `setup` command with its force / no-system-repo flags', () => {
@@ -89,6 +89,24 @@ describe('agents setup secrets', () => {
     registerSecretsCommands(importProgram);
     await importProgram.parseAsync(['secrets', 'import', 'setup-default-import', '--from', envPath], { from: 'user' });
     expect(readBundle('setup-default-import')?.backend).toBe('file');
+  });
+});
+
+describe('agents setup fleet', () => {
+  it('prints install guidance and exits cleanly when tailscale is unavailable', async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = '';
+    try {
+      const program = new Command();
+      program.exitOverride();
+      registerSetupCommand(program);
+
+      await program.parseAsync(['setup', 'fleet', '--yes'], { from: 'user' });
+      expect(process.exitCode).not.toBe(1);
+    } finally {
+      process.env.PATH = originalPath;
+      process.exitCode = undefined;
+    }
   });
 });
 

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -26,6 +26,7 @@ import { registerSetupComputerCommand, runComputerWizard } from './setup-compute
 import { registerSetupShareCommand, runShareWizard } from './setup-share.js';
 import { registerSetupMineCommand } from './setup-mine.js';
 import { registerSetupSecretsCommand } from './setup-secrets.js';
+import { registerSetupFleetCommand } from './setup-fleet.js';
 
 const HOME = os.homedir();
 
@@ -276,13 +277,14 @@ async function runSetupHub(): Promise<void> {
   if (!isInteractiveTerminal()) return;
   try {
     const { checkbox } = await import('@inquirer/prompts');
-    const picks = await checkbox<'browser' | 'computer' | 'share' | 'secrets'>({
+    const picks = await checkbox<'browser' | 'computer' | 'share' | 'secrets' | 'fleet'>({
       message: 'Set up optional capabilities now? (space to select, enter to confirm)',
       choices: [
         { name: 'browser  — drive a real Chrome/Brave/Edge for web automation', value: 'browser' },
         { name: 'computer — control native macOS apps (screenshot, click, type)', value: 'computer' },
         { name: 'share    — publish shareable links (Cloudflare R2 + Worker)', value: 'share' },
         { name: 'secrets  — choose storage defaults and import existing credentials', value: 'secrets' },
+        { name: 'fleet    — discover Tailscale devices and configure SSH access', value: 'fleet' },
       ],
     });
     for (const pick of picks) {
@@ -291,6 +293,7 @@ async function runSetupHub(): Promise<void> {
       else if (pick === 'computer') await runComputerWizard();
       else if (pick === 'share') await runShareWizard();
       else if (pick === 'secrets') await import('./setup-secrets.js').then((m) => m.runSecretsSetupWizard());
+      else if (pick === 'fleet') await import('./setup-fleet.js').then((m) => m.runFleetSetupWizard());
     }
   } catch (err) {
     if (isPromptCancelled(err)) return;
@@ -306,12 +309,13 @@ export function registerSetupCommand(program: Command): void {
     .option('-f, --force', 'Re-run setup even if ~/.agents/.system/ already exists (use with caution)')
     .option('--no-system-repo', 'Skip cloning the system repo (you must populate ~/.agents/.system/ yourself)');
 
-  // Capability subcommands: `agents setup browser|computer|share|mine|secrets`.
+  // Capability subcommands: `agents setup browser|computer|share|mine|secrets|fleet`.
   registerSetupBrowserCommand(setupCmd);
   registerSetupComputerCommand(setupCmd);
   registerSetupShareCommand(setupCmd);
   registerSetupMineCommand(setupCmd);
   registerSetupSecretsCommand(setupCmd);
+  registerSetupFleetCommand(setupCmd);
 
   setHelpSections(setupCmd, {
     examples: `
@@ -326,18 +330,20 @@ export function registerSetupCommand(program: Command): void {
       agents setup computer
       agents setup share
       agents setup secrets
+      agents setup fleet
     `,
     notes: `
       What it does:
         1. Clones the system repo into ~/.agents/.system/
         2. Imports any unmanaged agent installations it finds
-        3. On a TTY, offers to set up optional capabilities (browser/computer/share/secrets)
+        3. On a TTY, offers to set up optional capabilities (browser/computer/share/secrets/fleet)
 
       Capability setup can also be run any time on its own:
         agents setup browser    # detect a browser + create the default profile
         agents setup computer    # install the signed macOS helper + grant permissions
         agents setup share       # provision or join a Cloudflare share endpoint
         agents setup secrets     # choose secrets backend/policy defaults + import
+        agents setup fleet       # discover Tailscale devices + configure SSH access
 
       To install CLIs from agents.yaml and sync resources into version homes:
         agents sync --local -y


### PR DESCRIPTION
## What changed
Adds `agents setup fleet` for RUSH-2000: users can verify Tailscale, sync discovered devices, choose key/password SSH auth, render the managed SSH config include, optionally test connectivity, and optionally run the fleet updater.

Linear: https://linear.app/getrush/issue/RUSH-2000/add-agents-setup-fleet-wizard-for-tailscale-device-onboarding

## Verification
Real compiled command run on a temp HOME with a minimal initialized `.agents/.system` repo:
```text
$ HOME=/tmp/agents-setup-fleet-compiled.KDfjoG node dist/index.js setup fleet --yes --auth key --write-ssh-config
Synced 18 devices from Tailscale (18 new).
Updated device 'ipad165' (auth: key)
...
Updated device 'zion' (auth: key)
Wrote /tmp/agents-setup-fleet-compiled.KDfjoG/.ssh/config.d/agents

Fleet setup summary.
devices: ipad165, iphone182, mac-mini, macbook-air, mark, mark-aws-1, pinnacles, win-mini, yosemite-m0, yosemite-m1, yosemite-m2, yosemite-m3, yosemite-m4, yosemite-m5, yosemite-m6, yosemite-s0, yosemite-s1, zion
auth: key
registry count: 18
```

Tests/build:
```text
$ bun run test src/commands/setup.test.ts scripts/gen-changelog.test.ts
Test Files  2 passed (2)
Tests  9 passed (9)

$ bun run build
$ tsc ...
```

Session transcript: public repo, omitted from PR body; local path is `yosemite-s1:/home/muqsit/.agents/.history/versions/codex/0.146.0/home/.codex/sessions/2026/08/01/rollout-2026-08-01T20-59-26-019fc0a0-6bfd-7712-9234-edcd4f6eca1d.jsonl`.
