### PR TITLE
feat(feed): attachments + project on posts, rich progress render, feed --filter (RUSH-2013/2014/2015)

### DIFF
--- a/apps/cli/.changelog/next/rush-2013-2014-2015-feed-progress.md
+++ b/apps/cli/.changelog/next/rush-2013-2014-2015-feed-progress.md
@@ -1,0 +1,19 @@
+- **`agents feed post` carries artifacts and a project chip, and progress posts
+  render rich (RUSH-2013 / RUSH-2014).** `feed post` gains `--attach <path-or-url…>`
+  (repeatable): a local file is copied under
+  `~/.agents/.history/attachments/<session>/<update>/` so the link survives a
+  worktree delete, and a URL is kept as a link — each classified to an
+  image/audio/video/file/link kind by extension. Every post is now stamped with its
+  project (basename of cwd, worktree-aware) on the activity event itself, so the
+  chip shows without a live-session join. A `status.posted` event renders as a
+  multi-line update — `agent · session · host · project` chips, the message, an
+  attachment row with per-kind glyphs, and a `↳ ag focus/sessions` hint — wherever
+  it appears (`feed post` echo, the feed activity lane, `agents feed --filter
+  updates`, and `agents activity`).
+- **`agents feed --filter needs|updates|all` (RUSH-2015).** `needs` (default) is the
+  open-blocks inbox as before; `updates` shows only deliberate progress posts over
+  the local activity timeline (no block pipeline, no remote fan-out); `all` renders
+  the blocks then appends the updates view. `--json` under `--filter updates` emits
+  the raw `status.posted` events. Source:
+  `apps/cli/src/lib/activity.ts`, `apps/cli/src/lib/feed-post.ts`,
+  `apps/cli/src/commands/feed.ts`, `apps/cli/src/commands/activity.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -523,6 +523,17 @@ cost-of-delay rank, not chronology: idle minutes × downstream blast radius ×
 hourly burn × ask irreducibility. Suppressed stalls and FYIs get zero
 irreducibility, so a fresh cheap ask does not outrank an old critical-path block.
 
+`--filter <view>` selects what the surface shows:
+
+```bash
+agents feed                     # needs (default): open blocks — decisions agents wait on
+agents feed --filter updates    # only deliberate progress posts (see Status posts below)
+agents feed --filter all        # blocks first, then the updates view appended
+```
+
+`--filter updates` reads the local activity timeline only (no block pipeline, no
+remote fan-out); its `--json` emits the raw `status.posted` events.
+
 ### What publishes a block
 
 Blocks are written by the `feed-publish` hook (`~/.agents/hooks/10-feed-publish.py`,
@@ -565,6 +576,7 @@ registry (`lib/session/pid-registry.ts`).
 ```bash
 # Inside an agents-cli run (AGENT_SESSION_ID / AGENTS_MAILBOX_DIR already set):
 agents feed post "CHANGELOG pushed; watching CI and mac-mini E2E"
+agents feed post "cover render ready" --attach ./out/cover.png   # attach an artifact
 agents feed post "ready for review" --json
 
 # Escape hatch when not in a managed run:
@@ -576,6 +588,20 @@ Each post appends a `status.posted` **milestone** to
 `agents activity` and the feed’s recent-activity lane already read. It does
 **not** create a feed block. Domain facts (tickets, PRs) are not CLI flags;
 join them from the session index / live session enrichment at read time.
+
+- **`--attach <path-or-url…>` (repeatable).** Attach an artifact to the post. A
+  **local file** is copied under
+  `~/.agents/.history/attachments/<sessionId>/<updateId>/` so the reference survives
+  a worktree delete; a **URL** is kept as-is. Each is classified to an
+  image/audio/video/file/link kind by extension for its render glyph.
+- **Project chip.** The post is stamped with its project (basename of cwd,
+  worktree-aware) on the event itself, so the chip shows even without a live-session
+  join.
+- **Rich render.** A `status.posted` event renders multi-line — `agent · session ·
+  host · project` chips, the message, an attachment row with per-kind glyphs, and a
+  `↳ ag focus/sessions` hint — in the `feed post` echo, the feed activity lane,
+  `agents feed --filter updates`, and `agents activity`. Other milestones keep the
+  compact one-line form.
 
 Identity resolution order: `--session` → `AGENT_SESSION_ID` /
 `AGENTS_SESSION_ID` / mailbox basename → `AGENT_LAUNCH_ID` match in the pid

--- a/apps/cli/src/commands/activity.ts
+++ b/apps/cli/src/commands/activity.ts
@@ -24,6 +24,7 @@ import {
   filterActivityEvents,
   formatActivityGroupHeader,
   formatEnrichedActivityLine,
+  formatProgressUpdate,
   groupActivity,
   mergeActivityEvents,
   parseActivityPayload,
@@ -93,13 +94,29 @@ function activityHintsFromSessions(sessions: ActiveSession[]): ActivitySessionHi
   }));
 }
 
+/**
+ * Render one enriched event. Deliberate progress posts (`status.posted`) use the
+ * rich multi-line {@link formatProgressUpdate} (joining the ticket the event's
+ * session carries); every other milestone keeps the compact enriched line.
+ */
+function renderEnrichedEntry(
+  ev: EnrichedActivityEvent,
+  opts: { showHost?: boolean; showProject?: boolean; indent?: string } = {},
+): string {
+  if (ev.event === 'status.posted') {
+    const body = formatProgressUpdate(ev, { joined: { ticketId: ev.ticket } });
+    return opts.indent ? body.split('\n').map((l) => `${opts.indent}${l}`).join('\n') : body;
+  }
+  return formatEnrichedActivityLine(ev, opts);
+}
+
 /** Print one flat, newest-first stream (the default view). */
 function renderFlat(events: EnrichedActivityEvent[], opts: ActivityOpts): void {
   const { milestones, counts, subagentCount } = collapseActivity(events);
   process.stdout.write(chalk.bold('\n  recent activity\n'));
   const shown = opts.all ? events : milestones;
   for (const ev of shown) {
-    process.stdout.write(`${formatEnrichedActivityLine(ev, { showHost: true, showProject: true })}\n`);
+    process.stdout.write(`${renderEnrichedEntry(ev, { showHost: true, showProject: true })}\n`);
   }
   if (!opts.all) {
     const parts = Object.entries(counts)
@@ -125,7 +142,7 @@ function renderGrouped(events: EnrichedActivityEvent[], by: ActivityGroupBy, opt
     const { milestones, counts, subagentCount } = collapseActivity(group.events);
     const shown = opts.all ? group.events : milestones;
     for (const ev of shown) {
-      process.stdout.write(`${formatEnrichedActivityLine(ev, { showHost, showProject, indent: '  ' })}\n`);
+      process.stdout.write(`${renderEnrichedEntry(ev, { showHost, showProject, indent: '  ' })}\n`);
     }
     if (!opts.all) {
       const parts = Object.entries(counts)

--- a/apps/cli/src/commands/feed.test.ts
+++ b/apps/cli/src/commands/feed.test.ts
@@ -10,12 +10,25 @@ import {
   parseRemoteFeed,
   prepareLocalFeedBlocks,
   remoteFeedHostsToDial,
+  resolveFeedFilter,
   sessionHintsFromActive,
   shouldIncludeLocalFeed,
 } from './feed.js';
 import { groupBlocksByOutcome } from '../lib/feed-outcome.js';
 import { GLYPH } from '../lib/comms-render.js';
 import { formatActivityLine } from '../lib/activity.js';
+
+describe('resolveFeedFilter', () => {
+  it('defaults to needs and normalizes aliases', () => {
+    expect(resolveFeedFilter(undefined)).toBe('needs');
+    expect(resolveFeedFilter('')).toBe('needs');
+    expect(resolveFeedFilter('bogus')).toBe('needs');
+    expect(resolveFeedFilter('needs')).toBe('needs');
+    expect(resolveFeedFilter('Updates')).toBe('updates');
+    expect(resolveFeedFilter('update')).toBe('updates');
+    expect(resolveFeedFilter('ALL')).toBe('all');
+  });
+});
 
 const children: ChildProcess[] = [];
 

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -18,7 +18,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { ensureFeedPublishHook, listAskStats, listBlocks, recordNotified, type OpenBlock } from '../lib/feed.js';
-import { ensureActivityLogHook, readRecentActivity, formatActivityLine } from '../lib/activity.js';
+import { ensureActivityLogHook, readRecentActivity, formatActivityLine, formatProgressUpdate, type ActivityEvent } from '../lib/activity.js';
 import { postFeedStatus } from '../lib/feed-post.js';
 import {
   enrichBlocksFromSessions,
@@ -285,6 +285,7 @@ export function registerFeedCommand(program: Command): void {
     .command('feed')
     .description('Open blocks (needs you) + agent status posts (feed post)')
     .option('--json', 'Output as JSON (each block stamped with its outcome + ask class)')
+    .option('--filter <view>', 'What to show: needs (default) · updates · all', 'needs')
     .option('--flat', 'List one block per agent instead of grouping by outcome')
     .option('--all', 'Include stalls/FYIs that policy would suppress (default: hide them)')
     .option('--local', 'Only this machine -- skip the cross-machine SSH fan-out')
@@ -299,11 +300,13 @@ export function registerFeedCommand(program: Command): void {
     .description('Post a status update to the fleet activity stream (for agents)')
     .argument('<text...>', 'What just happened — one short human line')
     .option('--session <id>', 'Session id escape hatch (default: auto from env / pid registry)')
+    .option('--attach <path-or-url...>', 'Attach an artifact (local file or URL); repeatable')
     .option('--json', 'Emit the written event as JSON')
     .addHelpText('after', `
 Examples:
   # Inside an agents-cli run (session identity is already in the env):
   agents feed post "CHANGELOG pushed; watching CI and mac-mini E2E"
+  agents feed post "cover render ready" --attach ./out/cover.png
   agents feed post "ready for review" --json
 
   # Outside a run, pass the session explicitly:
@@ -314,26 +317,28 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
 `)
     .action((
       textParts: string[],
-      opts: { session?: string; json?: boolean },
-      cmd?: { opts: () => { session?: string; json?: boolean }; parent?: { opts: () => { json?: boolean } } },
+      opts: { session?: string; attach?: string[]; json?: boolean },
+      cmd?: { opts: () => { session?: string; attach?: string[]; json?: boolean }; parent?: { opts: () => { json?: boolean } } },
     ) => {
       // Parent `feed` also declares `--json` (for the list view). Commander
       // binds the flag on the parent, so a `feed post … --json` lands on
       // parent.opts().json — not the child. Read both.
       const flags = {
         session: opts?.session ?? cmd?.opts?.()?.session,
+        attach: opts?.attach ?? cmd?.opts?.()?.attach,
         json: Boolean(opts?.json ?? cmd?.opts?.()?.json ?? cmd?.parent?.opts?.()?.json),
       };
       try {
         const { event } = postFeedStatus({
           text: Array.isArray(textParts) ? textParts.join(' ') : String(textParts ?? ''),
           sessionId: flags.session,
+          attach: flags.attach,
         });
         if (flags.json) {
           console.log(JSON.stringify(event, null, 2));
           return;
         }
-        console.log(formatActivityLine(event, { showHost: true }).trimStart());
+        console.log(formatProgressUpdate(event));
       } catch (err) {
         console.error(chalk.red((err as Error).message));
         process.exitCode = 1;
@@ -342,6 +347,7 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
 
   feed.action(async (opts: {
       json?: boolean;
+      filter?: string;
       flat?: boolean;
       all?: boolean;
       local?: boolean;
@@ -353,6 +359,7 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
     }) => {
       if (opts.device?.length) opts.host = [...(opts.host ?? []), ...opts.device];
       const self = machineId();
+      const filter = resolveFeedFilter(opts.filter);
       const includeLocal = shouldIncludeLocalFeed(opts.host, self);
       const setupWarnings: string[] = [];
       if (includeLocal) {
@@ -376,6 +383,23 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
             }
           }
         }
+      }
+
+      // Updates view: deliberate progress posts only, over the local activity
+      // timeline (blocks are decisions, not announcements). Short-circuit the
+      // whole block pipeline — no remote fan-out, no dispatch policy.
+      if (filter === 'updates') {
+        for (const warning of setupWarnings) {
+          console.error(chalk.yellow(`Feed hook setup warning: ${warning}`));
+        }
+        if (opts.json) {
+          const updates = readRecentActivity({ sinceMs: Date.now() - 7 * 24 * 60 * 60 * 1000, limit: 100 })
+            .filter((e) => e.event === 'status.posted');
+          console.log(JSON.stringify(updates, null, 2));
+          return;
+        }
+        renderUpdatesView();
+        return;
       }
 
       // Active sessions feed both the GC sweep and outcome enrichment (ticket/PR).
@@ -496,7 +520,10 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
 
       if (blocks.length === 0) {
         console.log(chalk.gray(digest ? 'No open blocks after stall suppression.' : 'No open blocks.'));
-        if (includeLocal) renderActivityLane();
+        if (includeLocal) {
+          if (filter === 'all') { console.log(); renderUpdatesView(); }
+          else renderActivityLane();
+        }
         return;
       }
 
@@ -522,20 +549,70 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
         return br - ar;
       });
       for (const g of groups) renderOutcomeGroup(g, self);
-      if (includeLocal) renderActivityLane();
+      if (includeLocal) {
+        if (filter === 'all') { console.log(); renderUpdatesView(); }
+        else renderActivityLane();
+      }
     });
+}
+
+/** Feed view selector (RUSH-2015): decisions, progress, or both. */
+export type FeedFilter = 'needs' | 'updates' | 'all';
+
+/** Normalize a raw --filter value; unknown/empty falls back to the default. */
+export function resolveFeedFilter(raw: string | undefined): FeedFilter {
+  const v = (raw ?? '').trim().toLowerCase();
+  if (v === 'updates' || v === 'update') return 'updates';
+  if (v === 'all') return 'all';
+  return 'needs';
+}
+
+/**
+ * Render one activity event in the lane: deliberate progress posts
+ * (`status.posted`) use the rich multi-line {@link formatProgressUpdate}; hook
+ * milestones (PR, commit, …) keep the compact {@link formatActivityLine}.
+ */
+function renderActivityEntry(ev: ActivityEvent): void {
+  if (ev.event === 'status.posted') {
+    console.log(formatProgressUpdate(ev));
+  } else {
+    console.log(formatActivityLine(ev, { showHost: true }));
+  }
+}
+
+/**
+ * Render the **Updates** view: deliberate progress posts only (`status.posted`),
+ * recency-ordered, with rich identity chips. Pure `file.edited` / git-hook noise
+ * is excluded so operators see announcements, not tool churn.
+ */
+function renderUpdatesView(limit = 30): void {
+  const updates = readRecentActivity({ sinceMs: Date.now() - 7 * 24 * 60 * 60 * 1000, limit })
+    .filter((e) => e.event === 'status.posted');
+  console.log(
+    masthead({ title: 'updates', accent: 'cyan', host: machineId(), right: `${updates.length} post${updates.length === 1 ? '' : 's'}` }),
+  );
+  console.log();
+  if (updates.length === 0) {
+    console.log(chalk.gray('  No progress updates yet. Agents post them with `agents feed post "…"`.'));
+    return;
+  }
+  for (const ev of updates) {
+    console.log(formatProgressUpdate(ev));
+    console.log();
+  }
 }
 
 /**
  * Print a compact "recent activity" lane under the feed: the last few milestone
- * events (plans, PRs, worktrees, sub-agents) from the append-only activity logs.
- * Read-only tail of the logs -- no transcript re-parsing. Silent when empty.
+ * events (plans, PRs, worktrees, sub-agents, progress posts) from the append-only
+ * activity logs. Read-only tail of the logs -- no transcript re-parsing. Silent
+ * when empty.
  */
-function renderActivityLane(): void {
-  const events = readRecentActivity({ sinceMs: Date.now() - 24 * 60 * 60 * 1000, limit: 6 })
+function renderActivityLane(limit = 6): void {
+  const events = readRecentActivity({ sinceMs: Date.now() - 24 * 60 * 60 * 1000, limit })
     .filter((e) => e.tier === 'milestone');
   if (events.length === 0) return;
   console.log(chalk.bold('\n  recent activity'));
-  for (const ev of events) console.log(formatActivityLine(ev, { showHost: true }));
+  for (const ev of events) renderActivityEntry(ev);
   console.log(chalk.gray('  → agents activity  for the full stream'));
 }

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -7,18 +7,23 @@ import {
   ACTIVITY_LOG_HOOK_SCRIPT,
   activityGroupKey,
   appendActivityEvent,
+  attachmentName,
   collapseActivity,
   enrichActivityEvents,
   ensureActivityLogHook,
   filterActivityEvents,
   formatEnrichedActivityLine,
+  formatProgressUpdate,
   groupActivity,
   mergeActivityEvents,
   parseActivityPayload,
   projectFromCwd,
   readRecentActivity,
   readSessionActivity,
+  sanitizeAttachments,
+  shortSessionId,
   tierForEvent,
+  type ActivityEvent,
   type EnrichedActivityEvent,
 } from './activity.js';
 
@@ -763,5 +768,94 @@ describe('fleet fan-out MERGE + group (integration over per-host JSON payloads)'
     expect(new Set(groups[0].events.map((e) => e.host))).toEqual(new Set(['yosemite-s0', 'zion']));
     // Grouping by device buckets by the execution host of each event.
     expect(groupActivity(merged, 'device').map((g) => g.label).sort()).toEqual(['yosemite-s0', 'zion']);
+  });
+});
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('attachments schema (RUSH-2013)', () => {
+  it('sanitizeAttachments drops entries without an href and clamps meta', () => {
+    const out = sanitizeAttachments([
+      { kind: 'image', href: ' cover.png ', name: 'Cover', bytes: 42, meta: { width: 800, junk: {} } },
+      { kind: 'link' }, // no href -> dropped
+      { href: 'https://x/y' }, // kind defaults to link
+      'nope', // not an object -> dropped
+    ]);
+    expect(out).toEqual([
+      { kind: 'image', href: 'cover.png', name: 'Cover', bytes: 42, meta: { width: 800 } },
+      { kind: 'link', href: 'https://x/y' },
+    ]);
+  });
+
+  it('sanitizeAttachments returns undefined for non-arrays / empty', () => {
+    expect(sanitizeAttachments(undefined)).toBeUndefined();
+    expect(sanitizeAttachments([])).toBeUndefined();
+    expect(sanitizeAttachments('x')).toBeUndefined();
+  });
+
+  it('appended attachments + project survive a read round-trip', () => {
+    const dir = tmpActivityDir();
+    appendActivityEvent({
+      ts: '2026-07-31T10:00:00.000Z', event: 'status.posted', sessionId: 's1', mailboxId: 's1',
+      host: 'zion', runtime: 'headless', project: 'agents-cli', detail: 'shipped',
+      attachments: [{ kind: 'audio', href: '/a/draft.wav', name: 'draft.wav', bytes: 10 }],
+    }, dir);
+    const [event] = readSessionActivity('s1', dir);
+    expect(event.project).toBe('agents-cli');
+    expect(event.attachments).toEqual([{ kind: 'audio', href: '/a/draft.wav', name: 'draft.wav', bytes: 10 }]);
+  });
+});
+
+describe('formatProgressUpdate (RUSH-2014)', () => {
+  const base: ActivityEvent = {
+    v: 1, tier: 'milestone', ts: new Date().toISOString(), event: 'status.posted',
+    sessionId: '0108441e-2d15-4d2f-a58b-974a886c9b47', mailboxId: 'm', host: 'yosemite-s1',
+    runtime: 'teams', agent: 'grok', project: 'agents', detail: 'CHANGELOG pushed; watching CI',
+  };
+
+  it('shows agent, session short id, host, project chips + message', () => {
+    const out = stripAnsi(formatProgressUpdate(base));
+    expect(out).toContain('▸ update');
+    expect(out).toContain('grok · 0108441e · yosemite-s1 · agents');
+    expect(out).toContain('"CHANGELOG pushed; watching CI"');
+    expect(out).toContain('ag focus 0108441e');
+  });
+
+  it('lists attachments by name, basename fallback when name absent', () => {
+    const out = stripAnsi(formatProgressUpdate({
+      ...base,
+      attachments: [
+        { kind: 'audio', href: '/x/draft.wav', name: 'draft.wav' },
+        { kind: 'image', href: '/x/cover.png' },
+      ],
+    }));
+    expect(out).toContain('draft.wav');
+    expect(out).toContain('cover.png');
+  });
+
+  it('omits chips that are unknown', () => {
+    const out = stripAnsi(formatProgressUpdate({
+      ...base, agent: undefined, host: 'unknown', project: undefined,
+    }));
+    expect(out).not.toContain('unknown');
+    expect(out).toContain('0108441e');
+  });
+
+  it('joins ticket / label at display time when provided', () => {
+    const out = stripAnsi(formatProgressUpdate(base, { joined: { ticketId: 'RUSH-2014', label: 'render' } }));
+    expect(out).toContain('RUSH-2014');
+    expect(out).toContain('render');
+  });
+});
+
+describe('shortSessionId / attachmentName', () => {
+  it('strips known prefixes and takes 8 chars', () => {
+    expect(shortSessionId('0108441e-2d15')).toBe('0108441e');
+    expect(shortSessionId('session_abcdef01-x')).toBe('abcdef01');
+    expect(shortSessionId('ses_01HZXABCDEF')).toBe('01HZXABC');
+  });
+  it('falls back to href basename when name absent', () => {
+    expect(attachmentName({ kind: 'image', href: '/a/b/cover.png' })).toBe('cover.png');
+    expect(attachmentName({ kind: 'link', href: 'https://x/y/z', name: '  ' })).toBe('z');
   });
 });

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -51,6 +51,30 @@ export type ActivityEventKind = MilestoneEvent | ActivityKind;
 
 export type ActivityTier = 'milestone' | 'activity';
 
+/** Well-known attachment kinds; the field is an open string, not an enum. */
+export type AttachmentKind = 'link' | 'file' | 'image' | 'audio' | 'video';
+
+/**
+ * A generic artifact carried by a progress update — a rendered plan, an audio
+ * take, a preview URL. Deliberately domain-agnostic: `kind` is an open string,
+ * and `meta` is an open bag (duration, width, …) so any producer can attach
+ * anything without a schema change.
+ */
+export interface Attachment {
+  /** Coarse kind for glyph/rendering; open string, not a closed enum. */
+  kind: AttachmentKind | string;
+  /** https:// URL, an absolute path, or a history-relative path. */
+  href: string;
+  /** Display name (defaults to basename(href) at render time). */
+  name?: string;
+  /** MIME type when known (e.g. `audio/wav`). */
+  mediaType?: string;
+  /** Size in bytes for local files, when stat succeeded. */
+  bytes?: number;
+  /** Open bag for kind-specific facts (duration, width, height, …). */
+  meta?: Record<string, string | number>;
+}
+
 /** The set of milestone events, for tier classification and ordering. */
 export const MILESTONE_EVENTS: readonly MilestoneEvent[] = [
   'plan.created',
@@ -92,6 +116,13 @@ export interface ActivityEvent {
   runtime: string;
   /** Working directory at event time -- the join key to a project/git repo. */
   cwd?: string;
+  /**
+   * Project/repo name stamped by the writer (basename of cwd, worktree-aware),
+   * so a progress post carries its project even without a live-session join.
+   * Read-time enrichment ({@link enrichActivityEvents}) still fills it for
+   * hook-written events that lack it.
+   */
+  project?: string;
   /** Agent that produced the event (claude, codex, ...). */
   agent?: string;
   /** Tool that triggered the event (Bash, Task, ExitPlanMode, feed.post, ...). */
@@ -108,6 +139,40 @@ export interface ActivityEvent {
   terminalId?: string;
   /** `$TMUX_PANE` at launch when recorded. */
   tmuxPane?: string;
+  /** Generic artifacts attached to a deliberate progress post. */
+  attachments?: Attachment[];
+}
+
+/**
+ * Coerce an unknown value into a clean {@link Attachment}[] — a fail-open reader
+ * over user/agent-written JSON. Drops entries without a usable `href`, clamps
+ * `kind` to a string, and keeps only primitive `meta` values.
+ */
+export function sanitizeAttachments(value: unknown): Attachment[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: Attachment[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue;
+    const a = raw as Record<string, unknown>;
+    const href = typeof a.href === 'string' ? a.href.trim() : '';
+    if (!href) continue;
+    const att: Attachment = {
+      kind: typeof a.kind === 'string' && a.kind.trim() ? a.kind.trim() : 'link',
+      href,
+    };
+    if (typeof a.name === 'string' && a.name.trim()) att.name = a.name.trim();
+    if (typeof a.mediaType === 'string' && a.mediaType.trim()) att.mediaType = a.mediaType.trim();
+    if (typeof a.bytes === 'number' && Number.isFinite(a.bytes) && a.bytes >= 0) att.bytes = a.bytes;
+    if (a.meta && typeof a.meta === 'object' && !Array.isArray(a.meta)) {
+      const meta: Record<string, string | number> = {};
+      for (const [k, v] of Object.entries(a.meta as Record<string, unknown>)) {
+        if (typeof v === 'string' || typeof v === 'number') meta[k] = v;
+      }
+      if (Object.keys(meta).length > 0) att.meta = meta;
+    }
+    out.push(att);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 function activityPath(root: string, sessionId: string): string {
@@ -151,6 +216,7 @@ function parseLine(line: string): ActivityEvent | undefined {
       host: parsed.host ?? 'unknown',
       runtime: parsed.runtime ?? 'headless',
       cwd: parsed.cwd,
+      project: parsed.project,
       agent: parsed.agent,
       tool: parsed.tool,
       detail: parsed.detail,
@@ -159,6 +225,7 @@ function parseLine(line: string): ActivityEvent | undefined {
       launchId: parsed.launchId,
       terminalId: parsed.terminalId,
       tmuxPane: parsed.tmuxPane,
+      attachments: sanitizeAttachments(parsed.attachments),
     };
   } catch {
     return undefined; // skip corrupt / partial lines (fail-open reader)
@@ -304,9 +371,11 @@ export function activityEventToRecord(ev: ActivityEvent): EventRecord {
     detail: ev.detail,
     url: ev.url,
     tier: ev.tier,
+    ...(ev.project ? { project: ev.project } : {}),
     ...(ev.launchId ? { launchId: ev.launchId } : {}),
     ...(ev.terminalId ? { terminalId: ev.terminalId } : {}),
     ...(ev.tmuxPane ? { tmuxPane: ev.tmuxPane } : {}),
+    ...(ev.attachments?.length ? { attachments: ev.attachments } : {}),
   } as EventRecord;
 }
 
@@ -352,6 +421,94 @@ export function formatActivityLine(ev: ActivityEvent, opts: { showHost?: boolean
   const agent = ev.event === 'status.posted' && ev.agent ? chalk.gray(` · ${ev.agent}`) : '';
   const when = chalk.gray(relTime(ev.ts).padStart(7));
   return `  ${when}  ${host}${label}${detail}${agent}${url}`;
+}
+
+// ---------------------------------------------------------------------------
+// Rich progress render (RUSH-2014): `status.posted` posts are the deliberate,
+// operator-facing announcements — a single truncated line under-serves them.
+// `formatProgressUpdate` renders each as a multi-line row with full identity
+// chips (agent · session · host · project) and any attached artifacts.
+// ---------------------------------------------------------------------------
+
+/** Glyph per attachment kind, so an artifact row reads at a glance. */
+export const ATTACHMENT_GLYPH: Record<string, string> = {
+  image: '🖼',
+  audio: '♪',
+  video: '▶',
+  file: '📎',
+  link: '↗',
+};
+
+export function attachmentGlyph(kind: string): string {
+  return ATTACHMENT_GLYPH[kind] ?? '📎';
+}
+
+/** Display name for an attachment: its `name`, else the basename of its href. */
+export function attachmentName(att: Attachment): string {
+  if (att.name && att.name.trim()) return att.name.trim();
+  const href = att.href.replace(/[/\\]+$/, '');
+  const slash = Math.max(href.lastIndexOf('/'), href.lastIndexOf('\\'));
+  const base = slash >= 0 ? href.slice(slash + 1) : href;
+  return base || href;
+}
+
+/**
+ * Short session id for a chip: strip a known prefix (`session_`, `ses_`) then
+ * take the first 8 chars — enough to disambiguate, matching `ag sessions`.
+ */
+export function shortSessionId(sessionId: string): string {
+  const stripped = sessionId.replace(/^(session_|ses_)/, '');
+  return stripped.slice(0, 8) || sessionId.slice(0, 8);
+}
+
+/** Extra identity resolved at display time by joining the session index. */
+export interface ProgressJoin {
+  ticketId?: string;
+  prUrl?: string;
+  label?: string;
+}
+
+/**
+ * Render a deliberate progress update (`status.posted`) as an operator-facing,
+ * multi-line row with full identity — not a 60-char one-liner. Shape:
+ *
+ * ```
+ *   ▸ update · 3m ago
+ *     grok · 0108441e · yosemite-s1 · agents
+ *     "CHANGELOG pushed; watching CI"
+ *     ♪ draft.wav   🖼 cover.png
+ *     ↳ ag focus 0108441e · ag sessions 0108441e
+ * ```
+ *
+ * Chips (agent, short session id, host, project, optional joined ticket/label)
+ * are shown only when known. Non-progress milestones keep {@link formatActivityLine}.
+ */
+export function formatProgressUpdate(ev: ActivityEvent, opts: { joined?: ProgressJoin } = {}): string {
+  const shortId = shortSessionId(ev.sessionId);
+  const lines: string[] = [];
+
+  lines.push(`  ${chalk.white('▸ update')} ${chalk.gray(`· ${relTime(ev.ts)}`)}`);
+
+  const chips = [
+    ev.agent,
+    shortId,
+    ev.host && ev.host !== 'unknown' ? ev.host : undefined,
+    ev.project,
+    opts.joined?.ticketId,
+    opts.joined?.label,
+  ].filter((c): c is string => Boolean(c));
+  if (chips.length > 0) lines.push(`    ${chalk.gray(chips.join(' · '))}`);
+
+  if (ev.detail) lines.push(`    ${chalk.white(`"${ev.detail}"`)}`);
+
+  if (ev.attachments?.length) {
+    const parts = ev.attachments.map((a) => `${attachmentGlyph(a.kind)} ${chalk.cyan(attachmentName(a))}`);
+    lines.push(`    ${parts.join('   ')}`);
+  }
+  if (opts.joined?.prUrl) lines.push(`    ${chalk.gray(opts.joined.prUrl)}`);
+
+  lines.push(`    ${chalk.dim(`↳ ag focus ${shortId} · ag sessions ${shortId}`)}`);
+  return lines.join('\n');
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/lib/feed-post.test.ts
+++ b/apps/cli/src/lib/feed-post.test.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  buildAttachment,
+  buildAttachments,
   normalizeStatusText,
   postFeedStatus,
   resolvePostIdentity,
@@ -198,5 +200,97 @@ describe('postFeedStatus', () => {
     expect(event).not.toHaveProperty('meta');
     expect(event).not.toHaveProperty('ticket');
     expect(event).not.toHaveProperty('url');
+  });
+});
+
+describe('buildAttachment', () => {
+  const ctx = { sessionId: 's', updateId: 'u' };
+
+  it('classifies a remote URL as a link, media by extension', () => {
+    const link = buildAttachment('https://x.dev/thread/1', ctx);
+    expect(link).toEqual({ kind: 'link', href: 'https://x.dev/thread/1', name: '1' });
+    const vid = buildAttachment('https://x.dev/preview.mp4', ctx);
+    expect(vid?.kind).toBe('video');
+    expect(vid?.mediaType).toBe('video/mp4');
+  });
+
+  it('classifies + copies a local file, and stat sizes it', () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-attach-src-'));
+    const copyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-attach-store-'));
+    const wav = path.join(src, 'draft.wav');
+    fs.writeFileSync(wav, 'RIFFxxxx');
+
+    const att = buildAttachment(wav, { sessionId: 'sess-a', updateId: 'up-1', copyRoot });
+    expect(att?.kind).toBe('audio');
+    expect(att?.mediaType).toBe('audio/wav');
+    expect(att?.name).toBe('draft.wav');
+    expect(att?.bytes).toBe(8);
+    // href points at the durable copy under <copyRoot>/<sessionId>/<updateId>/
+    expect(att?.href).toBe(path.join(copyRoot, 'sess-a', 'up-1', 'draft.wav'));
+    expect(fs.existsSync(att!.href)).toBe(true);
+  });
+
+  it('drops a missing local file / blank token (fail-open)', () => {
+    expect(buildAttachment('/no/such/file.png', ctx)).toBeUndefined();
+    expect(buildAttachment('   ', ctx)).toBeUndefined();
+  });
+
+  it('buildAttachments filters out the failures', () => {
+    const list = buildAttachments(['https://a/b', '/no/such.png'], ctx);
+    expect(list).toHaveLength(1);
+    expect(list[0].href).toBe('https://a/b');
+    expect(buildAttachments(undefined, ctx)).toEqual([]);
+  });
+});
+
+describe('postFeedStatus attachments + project', () => {
+  it('writes one line with both attachments and project, round-trips', () => {
+    const dir = tmpActivityDir();
+    const store = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-attach-store-'));
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-attach-src-'));
+    const wav = path.join(src, 'take.wav');
+    fs.writeFileSync(wav, 'RIFF');
+
+    const { event } = postFeedStatus({
+      text: 'listen',
+      sessionId: 'sess-attach',
+      activityRoot: dir,
+      attachmentsRoot: store,
+      attach: [wav, 'https://x/preview.mp4'],
+      cwd: '/repo/song-factory',
+      env: { AGENTS_AGENT_NAME: 'grok', AGENTS_SYNC_MACHINE_ID: 'yosemite-s1' },
+      ts: '2026-07-31T12:00:00.000Z',
+      listEntries: () => [],
+      readEntry: () => undefined,
+      startPid: 1,
+    });
+
+    expect(event.project).toBe('song-factory');
+    expect(event.attachments).toHaveLength(2);
+    expect(event.attachments?.[0].kind).toBe('audio');
+    expect(event.attachments?.[1]).toMatchObject({ kind: 'video', href: 'https://x/preview.mp4' });
+
+    // Parse round-trip preserves attachments + project.
+    const stored = readSessionActivity('sess-attach', dir);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].project).toBe('song-factory');
+    expect(stored[0].attachments).toHaveLength(2);
+    expect(stored[0].attachments?.[0].name).toBe('take.wav');
+  });
+
+  it('omits attachments when none given', () => {
+    const dir = tmpActivityDir();
+    const { event } = postFeedStatus({
+      text: 'no attachments',
+      sessionId: 'sess-noattach',
+      activityRoot: dir,
+      cwd: '/repo/foo',
+      env: { AGENTS_AGENT_NAME: 'claude' },
+      listEntries: () => [],
+      readEntry: () => undefined,
+      startPid: 1,
+    });
+    expect(event).not.toHaveProperty('attachments');
+    expect(readSessionActivity('sess-noattach', dir)[0].attachments).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/feed-post.ts
+++ b/apps/cli/src/lib/feed-post.ts
@@ -17,8 +17,11 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import {
   appendActivityEvent,
+  projectFromCwd,
   type ActivityEvent,
+  type Attachment,
 } from './activity.js';
+import { getHistoryDir } from './state.js';
 import { machineId } from './machine-id.js';
 import { isValidMailboxId } from './mailbox.js';
 import {
@@ -35,8 +38,16 @@ export interface FeedPostInput {
   text: string;
   /** Override session id (escape hatch for scripts/tests). Prefer auto-resolve. */
   sessionId?: string;
+  /** Generic artifacts to attach: local paths (copied for durability) or URLs. */
+  attach?: string[];
   /** Override activity root (tests). */
   activityRoot?: string;
+  /**
+   * Override the attachments store root (tests). Local files are copied under
+   * `<attachmentsRoot>/<sessionId>/<updateId>/`. Defaults to
+   * `~/.agents/.history/attachments`.
+   */
+  attachmentsRoot?: string;
   /** Override env for identity resolution (tests). */
   env?: NodeJS.ProcessEnv;
   /** Override cwd stamp (defaults to process.cwd() / env). */
@@ -204,6 +215,112 @@ export function parentPidOf(pid: number): number | undefined {
   return undefined;
 }
 
+/** Extension → (kind, mediaType) for attachment classification. */
+const MEDIA_BY_EXT: Record<string, { kind: Attachment['kind']; mediaType: string }> = {
+  '.png': { kind: 'image', mediaType: 'image/png' },
+  '.jpg': { kind: 'image', mediaType: 'image/jpeg' },
+  '.jpeg': { kind: 'image', mediaType: 'image/jpeg' },
+  '.gif': { kind: 'image', mediaType: 'image/gif' },
+  '.svg': { kind: 'image', mediaType: 'image/svg+xml' },
+  '.webp': { kind: 'image', mediaType: 'image/webp' },
+  '.wav': { kind: 'audio', mediaType: 'audio/wav' },
+  '.mp3': { kind: 'audio', mediaType: 'audio/mpeg' },
+  '.m4a': { kind: 'audio', mediaType: 'audio/mp4' },
+  '.aac': { kind: 'audio', mediaType: 'audio/aac' },
+  '.ogg': { kind: 'audio', mediaType: 'audio/ogg' },
+  '.flac': { kind: 'audio', mediaType: 'audio/flac' },
+  '.mp4': { kind: 'video', mediaType: 'video/mp4' },
+  '.mov': { kind: 'video', mediaType: 'video/quicktime' },
+  '.webm': { kind: 'video', mediaType: 'video/webm' },
+  '.mkv': { kind: 'video', mediaType: 'video/x-matroska' },
+};
+
+/** True when the token is an http(s) URL (a remote attachment / link). */
+function isRemoteUrl(token: string): boolean {
+  return /^https?:\/\//i.test(token.trim());
+}
+
+function mediaForExt(ext: string): { kind: Attachment['kind']; mediaType?: string } {
+  const hit = MEDIA_BY_EXT[ext.toLowerCase()];
+  return hit ? { kind: hit.kind, mediaType: hit.mediaType } : { kind: 'file' };
+}
+
+/** A short, filesystem-safe id grouping one post's copied attachments. */
+function newUpdateId(ts: string): string {
+  const rand = Math.random().toString(36).slice(2, 8);
+  const stamp = ts.replace(/[^0-9]/g, '').slice(0, 14) || 'post';
+  return `${stamp}-${rand}`;
+}
+
+/**
+ * Turn one `--attach` token into an {@link Attachment}. Remote URLs become
+ * `link` (or a media kind when the extension is unambiguous). Local files are
+ * classified by extension and, when `copyRoot` is set, copied under
+ * `<copyRoot>/<sessionId>/<updateId>/<basename>` so the link survives a worktree
+ * delete — the stored `href` then points at the durable copy. A missing local
+ * file is dropped (fail-open) rather than throwing.
+ */
+export function buildAttachment(
+  token: string,
+  ctx: { copyRoot?: string; sessionId: string; updateId: string },
+): Attachment | undefined {
+  const value = token.trim();
+  if (!value) return undefined;
+
+  if (isRemoteUrl(value)) {
+    const ext = path.extname(new URL(value).pathname);
+    const media = mediaForExt(ext);
+    const att: Attachment = { kind: media.kind === 'file' ? 'link' : media.kind, href: value };
+    const name = path.basename(new URL(value).pathname);
+    if (name) att.name = name;
+    if (media.mediaType) att.mediaType = media.mediaType;
+    return att;
+  }
+
+  const abs = path.resolve(value);
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    return undefined; // dropped: local file does not exist
+  }
+  if (!stat.isFile()) return undefined;
+
+  const media = mediaForExt(path.extname(abs));
+  const name = path.basename(abs);
+  let href = abs;
+
+  if (ctx.copyRoot) {
+    try {
+      const destDir = path.join(ctx.copyRoot, ctx.sessionId, ctx.updateId);
+      fs.mkdirSync(destDir, { recursive: true });
+      const dest = path.join(destDir, name);
+      fs.copyFileSync(abs, dest);
+      href = dest;
+    } catch {
+      href = abs; // copy failed: fall back to the original path
+    }
+  }
+
+  const att: Attachment = { kind: media.kind, href, name, bytes: stat.size };
+  if (media.mediaType) att.mediaType = media.mediaType;
+  return att;
+}
+
+/** Classify + store every `--attach` token; empty/failed tokens are dropped. */
+export function buildAttachments(
+  tokens: string[] | undefined,
+  ctx: { copyRoot?: string; sessionId: string; updateId: string },
+): Attachment[] {
+  if (!tokens?.length) return [];
+  const out: Attachment[] = [];
+  for (const token of tokens) {
+    const att = buildAttachment(token, ctx);
+    if (att) out.push(att);
+  }
+  return out;
+}
+
 export function normalizeStatusText(text: string): string {
   const collapsed = text.replace(/\s+/g, ' ').trim();
   if (!collapsed) return '';
@@ -229,8 +346,16 @@ export function postFeedStatus(input: FeedPostInput): FeedPostResult {
     );
   }
 
+  const ts = input.ts ?? new Date().toISOString();
+  const project = projectFromCwd(identity.cwd);
+  const attachments = buildAttachments(input.attach, {
+    copyRoot: input.attachmentsRoot ?? path.join(getHistoryDir(), 'attachments'),
+    sessionId: identity.sessionId,
+    updateId: newUpdateId(ts),
+  });
+
   const event: Omit<ActivityEvent, 'v' | 'tier'> = {
-    ts: input.ts ?? new Date().toISOString(),
+    ts,
     event: 'status.posted',
     sessionId: identity.sessionId,
     mailboxId: identity.mailboxId,
@@ -240,10 +365,12 @@ export function postFeedStatus(input: FeedPostInput): FeedPostResult {
     agent: identity.agent,
     tool: 'feed.post',
     detail,
+    ...(project ? { project } : {}),
     ...(identity.pid !== undefined ? { pid: identity.pid } : {}),
     ...(identity.launchId ? { launchId: identity.launchId } : {}),
     ...(identity.terminalId ? { terminalId: identity.terminalId } : {}),
     ...(identity.tmuxPane ? { tmuxPane: identity.tmuxPane } : {}),
+    ...(attachments.length ? { attachments } : {}),
   };
 
   appendActivityEvent(event, input.activityRoot);


### PR DESCRIPTION
**feat / CLI** — `apps/cli`. Lands the remaining feed-progress work: attachments + project on status posts (RUSH-2013), a rich multi-line progress render (RUSH-2014), and `agents feed --filter needs|updates|all` (RUSH-2015). RUSH-2012 (the enriched/grouped activity view) already shipped on `main`; this builds the genuine remainder on the current structure.

## What changed

- **RUSH-2013 — artifacts + project.** New `Attachment` schema + `sanitizeAttachments` (fail-open reader) on the activity event; `project` is now stamped on the base `ActivityEvent` by the writer (worktree-aware basename of cwd) so the chip shows without a live-session join. `agents feed post` gains `--attach <path-or-url…>` (repeatable): local files are copied under `~/.agents/.history/attachments/<session>/<update>/` (survives a worktree delete), URLs are kept as links, each classified image/audio/video/file/link by extension.
- **RUSH-2014 — rich render.** `formatProgressUpdate` renders a `status.posted` event as a multi-line update: `agent · session · host · project` chips, the message, an attachment row with per-kind glyphs, and a `↳ ag focus/sessions` hint. Wired into the `feed post` echo, the feed activity lane, the updates view, and `agents activity`. Other milestones keep the compact one-line form.
- **RUSH-2015 — `agents feed --filter`.** `needs` (default) = the open-blocks inbox; `updates` = only progress posts over the local timeline (no block pipeline, no remote fan-out); `all` = blocks then the updates view. `--json` under `--filter updates` emits the raw events.

## Run result (real output)

`agents feed post "…" --attach ./cover.png --attach https://x.dev/preview.mp4`, then `agents feed --filter updates`:

```
=== feed post --attach (real writer path) ===
  ▸ update · just now
    grok · 0108441e · yosemite-s1 · song-factory
    "cover render ready; watching CI"
    🖼 cover.png   ▶ preview.mp4
    ↳ ag focus 0108441e · ag sessions 0108441e

=== agents feed --filter updates --local ===
⌁ updates · yosemite-s0                                                    1 post

  ▸ update · just now
    grok · 0108441e · yosemite-s1 · song-factory
    "cover render ready; watching CI"
    🖼 cover.png   ▶ preview.mp4
    ↳ ag focus 0108441e · ag sessions 0108441e
```

`--json` from the same post confirms the persisted payload (local file copied to the durable store):

```
project= song-factory
attachments= [{"kind":"image","href":".../.history/attachments/0108441e-.../<update>/cover.png","name":"cover.png","bytes":2,"mediaType":"image/png"}]
```

## Tests

`node vitest run` on the affected files — **131 passed** (activity, feed-post, feed, events, activity command). New coverage: `sanitizeAttachments`, `formatProgressUpdate`, `shortSessionId`/`attachmentName`, `buildAttachment`/`buildAttachments`, `postFeedStatus` attachments+project round-trip, `resolveFeedFilter`. Typecheck clean.

## Tickets

- RUSH-2013 · RUSH-2014 · RUSH-2015

Docs + changelog updated in the same delivery: `apps/cli/docs/06-observability.md`, `apps/cli/.changelog/next/rush-2013-2014-2015-feed-progress.md`.
