### PR TITLE
ci: serialize Windows Node 24 Vitest release leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,13 @@ jobs:
         run: bun run build
 
       - name: Test
-        run: bun run test
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ] && [ "${{ matrix.node-version }}" = "24" ]; then
+            node ./node_modules/vitest/vitest.mjs run --maxWorkers=1 --no-file-parallelism
+          else
+            bun run test
+          fi
 
   # No CI publish job — publishing happens locally on macOS via
   # `scripts/release.sh <version> --apply`.


### PR DESCRIPTION
CI-only: serialize the Windows Node 24 Vitest release leg so release PRs stop failing after the suite has already passed.

## What Changed

- Keeps the existing `bun run test` path for Linux, macOS, Windows Node 22, and all non-Windows Node 24 legs.
- Runs Windows Node 24 with Vitest directly using `--maxWorkers=1 --no-file-parallelism` in `.github/workflows/ci.yml`.
- Scope is release CI only; no package runtime behavior changes.

## Why

Release PR #1642 failed twice in `build (windows-latest, 24)` after the suite completed:

```text
Test Files 577 passed | 22 skipped (600)
Tests 7358 passed | 317 skipped (7675)
Errors 1 error
Error: [vitest-pool]: Worker forks emitted error.
Caused by: Error: Worker exited unexpectedly
```

## Validation

```text
python3 yaml parse .github/workflows/ci.yml -> yaml ok
bun run build -> passed
node ./node_modules/vitest/vitest.mjs run --maxWorkers=1 --no-file-parallelism src/lib/__tests__/hooks.test.ts -> 1 passed, 95 passed
```

No visible surface: CI-only release workflow change.
