### PR TITLE
release(factory): 0.9.301 — Harness Roster reads the CLI's run config

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
-- **The Harness Roster's run-strategy control now reads and writes the config the CLI actually uses.** `agentInventory.ts` pointed at `~/.agents-system/agents.yaml` — a directory that was folded into `~/.agents/.system/` and no longer holds `agents.yaml` (the CLI reads `run.<agent>.strategy` from `~/.agents/agents.yaml`, `apps/cli/src/lib/state.ts`). Every read returned `{}`, so the roster showed the same fallback for every agent and every toggle wrote to a file nothing reads. The fallback was also wrong: it reported `pinned`, while a bare `agents run <agent>` with no configured strategy is `balanced` (`getConfiguredRunStrategy`, `apps/cli/src/lib/rotate.ts`). On a machine with `run.codex.strategy: available` set, the roster reported `pinned` for all five managed harnesses; it now reports `balanced / available / balanced / balanced / balanced`, matching the CLI exactly. Source: `apps/factory/src/core/agentInventory.ts`.
+## [0.9.301] - 2026-08-02
+
+- **The Harness Roster's run-strategy control now reads and writes the config the CLI actually uses.** `agentInventory.ts` pointed at `~/.agents-system/agents.yaml` — a directory that was folded into `~/.agents/.system/` and no longer holds `agents.yaml` (the CLI reads `run.<agent>.strategy` from `~/.agents/agents.yaml`, `apps/cli/src/lib/state.ts`). Every read returned `{}`, so the roster showed the same fallback for every agent and every toggle wrote to a file nothing reads. The fallback was also wrong: it reported `pinned`, while a bare `agents run <agent>` with no configured strategy is `balanced` (`getConfiguredRunStrategy`, `apps/cli/src/lib/rotate.ts`). On a machine with a `run.codex.strategy: available` override set, the roster reported `pinned` for all five managed harnesses; it now reports whatever `getConfiguredRunStrategy` resolves per agent (`balanced` for an unconfigured harness, `available` for that codex override), matching the CLI exactly. Source: `apps/factory/src/core/agentInventory.ts`.
 
 ## [0.9.300] - 2026-08-02
 

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -3,7 +3,7 @@
   "displayName": "Agents",
   "publisher": "swarmify",
   "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.299",
+  "version": "0.9.301",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",


### PR DESCRIPTION
**Release PR** — no behavior change of its own. Promotes the `[Unreleased]` block to a dated `## [0.9.301]` section and bumps `apps/factory/package.json` from `0.9.299` to `0.9.301`.

The VS Code Marketplace is live on **0.9.300** (`swarmify.swarm-ext`), so `0.9.301` is the next publishable version. `package.json` had drifted behind at `0.9.299`; this realigns it with what `scripts/release.sh` will publish.

## What ships in 0.9.301

One fix, from #1641 (merged as `723757d4`):

**The Harness Roster's run-strategy control now reads and writes the config the CLI actually uses.** `agentInventory.ts` pointed at `~/.agents-system/agents.yaml` — a directory folded into `~/.agents/.system/` that no longer holds `agents.yaml`. Every read returned `{}` and the fallback was `pinned` where the CLI's is `balanced`, so the roster reported `pinned` for all five managed harnesses and its toggle wrote to a file nothing reads.

## Gates run in a clean worktree at 0.9.301

```
$ grep -qE "^## \[0\.9\.301\]" CHANGELOG.md && echo "release.sh changelog gate: PASS"
release.sh changelog gate: PASS

$ bunx tsc --noEmit -p tsconfig.json
tsc: PASS

$ bun test src/core/agentInventory.test.ts
 10 pass
 0 fail
 32 expect() calls

$ bun run compile
vite v7.3.0 building client environment for production...
✓ 2171 modules transformed.
../../out/ui/editor/index.html          0.39 kB │ gzip:   0.26 kB
../../out/ui/editor/assets/index.css   10.48 kB │ gzip:   2.52 kB
../../out/ui/editor/assets/index.js  1,094.82 kB │ gzip: 346.15 kB
✓ built in 2.16s
```

`bun run compile` is the real build (tsc + vite for both webviews) and it succeeds at the bumped version.

## After merge

`bash apps/factory/scripts/release.sh 0.9.301 --confirm` publishes to VS Code Marketplace + Open VSX. That step is not part of this PR.

## Note on the changelog wording

The 0.9.301 entry's example was reworded: it previously quoted this machine's transient config (`balanced / available / balanced / balanced / balanced`, reflecting a `run.codex.strategy: available` override that has since been removed in phnx-labs/.agents-system#140). It now states the invariant — the roster reports whatever `getConfiguredRunStrategy` resolves per agent — rather than one machine's snapshot.
