### PR TITLE
feat(menubar): Cmd+Shift+O → Plan/Run + repo picker (never home)

### DIFF
--- a/apps/cli/.changelog/next/menubar-plan-run.md
+++ b/apps/cli/.changelog/next/menubar-plan-run.md
@@ -1,0 +1,12 @@
+- **The Cmd+Shift+O quick-dispatch bar is now Plan / Run, and never runs an agent
+  in your home directory.** The two spotlight modes were renamed from File
+  Ticket / Fix to **Plan** (investigate → file a Linear ticket) and **Run**
+  (headless `agents run`). A new repo dropdown is populated from your recent
+  session working directories with `$HOME` dropped, and the pick is passed as
+  `--cwd` to both modes, so an agent is always scoped to a real repo instead of
+  the too-broad home dir; the last-picked repo is remembered. Run now always uses
+  `--strategy balanced` (auto load-balance across signed-in versions with
+  headroom, skipping rate-limited), and `--name` is seeded from a slug of your
+  task text instead of an opaque `quick-<timestamp>`. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift`,
+  `apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift`.

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -339,11 +339,30 @@ enum AgentsCLI {
     // paths never pass through an LLM shell string. It runs as a MONITORED async
     // process (not fully detached) so completion drives a real notification
     // without blocking the panel/UI.
-    static func dispatchTicketAgent(note: String, screenshotPaths: [String], agent: String? = nil) {
+    // Distinct recent working directories from local session history, most-recent
+    // first, with the home dir dropped — running an agent straight in $HOME is too
+    // broad a permission surface, so the panel offers real repos to scope into.
+    static func recentRepoDirs(limit: Int = 8) -> [String] {
+        let home = (NSHomeDirectory() as NSString).standardizingPath
+        var seen = Set<String>()
+        var dirs: [String] = []
+        for s in recentSessions(limit: 40) {
+            guard let cwd = s.cwd, !cwd.isEmpty else { continue }
+            let norm = (cwd as NSString).standardizingPath
+            if norm == home { continue }
+            if seen.insert(norm).inserted { dirs.append(norm) }
+            if dirs.count >= limit { break }
+        }
+        return dirs
+    }
+
+    static func dispatchTicketAgent(note: String, screenshotPaths: [String], agent: String? = nil, cwd: String? = nil) {
         let prompt = ticketAgentPrompt(note: note, screenshotPaths: screenshotPaths)
         let agent = agent ?? env["AGENTS_ISSUE_AGENT"] ?? "claude"
         Notifier.post(title: "Filing ticket…", body: shortenForNotice(note))
-        runMonitored(argv(["run", agent, prompt, "--mode", "auto"])) { output, ok in
+        var planArgs = ["run", agent, prompt, "--mode", "auto"]
+        if let cwd, !cwd.isEmpty { planArgs += ["--cwd", cwd] }
+        runMonitored(argv(planArgs)) { output, ok in
             guard ok, let draft = parseTicketDraft(output) else {
                 Notifier.post(title: "Ticket agent finished",
                               body: ok ? "Could not parse ticket draft from agent output."

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -373,14 +373,16 @@ enum AgentsCLI {
         }
     }
 
-    static func dispatchQuickFix(note: String, screenshotPaths: [String], agents: [String]) {
+    static func dispatchQuickFix(note: String, screenshotPaths: [String], agents: [String],
+                                 cwd: String? = nil, device: String? = nil) {
         let selected = agents.isEmpty ? ["claude"] : agents
         let prompt = quickFixPrompt(note: note, screenshotPaths: screenshotPaths)
+        let name = quickDispatchName(note: note)
         Notifier.post(title: "Dispatching \(selected.count) agent\(selected.count == 1 ? "" : "s")…",
                       body: shortenForNotice(note))
         for agent in selected {
-            let name = quickDispatchName(agent: agent)
-            runMonitored(argv(quickFixRunArgs(agent: agent, prompt: prompt, name: name))) { _, ok in
+            runMonitored(argv(quickFixRunArgs(agent: agent, prompt: prompt, name: name,
+                                              cwd: cwd, device: device))) { _, ok in
                 let label = LocalState.agentLabel(agent)
                 Notifier.post(title: ok ? "\(label) finished" : "\(label) failed",
                               body: shortenForNotice(note))
@@ -434,14 +436,39 @@ enum AgentsCLI {
         return t.count > 80 ? String(t.prefix(79)) + "…" : t
     }
 
-    static func quickDispatchName(agent: String, date: Date = Date()) -> String {
-        let stamp = Int(date.timeIntervalSince1970)
-        let clean = LocalState.normalizeAgent(agent).replacingOccurrences(of: "[^a-z0-9-]", with: "-", options: .regularExpression)
-        return "quick-\(clean)-\(stamp)"
+    // Seed `agents run --name` from the user's own task text — the first few words,
+    // slugified — so the run reads as THEIR task in `agents sessions` instead of an
+    // opaque `quick-<timestamp>`. The agent's generated title refines it later.
+    static func quickDispatchName(note: String, date: Date = Date()) -> String {
+        let words = note
+            .lowercased()
+            .replacingOccurrences(of: "[^a-z0-9 ]", with: " ", options: .regularExpression)
+            .split(separator: " ")
+            .prefix(5)
+        let slug = words.joined(separator: "-")
+        if slug.isEmpty {
+            return "task-\(Int(date.timeIntervalSince1970))"
+        }
+        return String(slug.prefix(48))
     }
 
-    static func quickFixRunArgs(agent: String, prompt: String, name: String) -> [String] {
-        ["run", agent, prompt, "--mode", "auto", "--name", name]
+    // Build the `agents run` argv for a headless Run. Strategy is ALWAYS balanced
+    // (auto load-balance across signed-in versions with headroom, skipping any that
+    // are rate-limited); an explicit --cwd scopes the agent to the chosen repo (never
+    // the home dir); an explicit --device offloads onto the chosen box (nil = this
+    // Mac / affinity-auto is handled by the caller passing "auto").
+    static func quickFixRunArgs(agent: String, prompt: String, name: String,
+                                cwd: String? = nil, device: String? = nil) -> [String] {
+        var args = ["run", agent, prompt, "--mode", "auto", "--balanced", "--name", name]
+        if let cwd, !cwd.isEmpty {
+            args.append("--cwd")
+            args.append(cwd)
+        }
+        if let device, !device.isEmpty, device != "local" {
+            args.append("--device")
+            args.append(device)
+        }
+        return args
     }
 
     // MARK: Process helpers

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -244,16 +244,16 @@ enum IssueSelfTest {
         //     dismisses clean so the next summon starts fresh.
         check("empty note clears the draft",
               PromptDraft.forDismissal(note: "", selectedPaths: [],
-                                       selectedAgents: [], action: .fileTicket) == nil)
+                                       selectedAgents: [], action: .plan) == nil)
         check("whitespace/newline-only note clears the draft",
               PromptDraft.forDismissal(note: "  \n\t ", selectedPaths: ["/tmp/a.png"],
-                                       selectedAgents: ["codex"], action: .fix) == nil)
+                                       selectedAgents: ["codex"], action: .run) == nil)
 
         // (b) A real note round-trips every field verbatim through save→restore.
         let saved = PromptDraft.forDismissal(note: "  cards show raw uuids  ",
                                              selectedPaths: ["/tmp/a.png", "/tmp/b.png"],
                                              selectedAgents: ["codex", "claude"],
-                                             action: .fix)
+                                             action: .run)
         check("non-empty note preserves a draft", saved != nil,
               detail: saved.map { $0.note } ?? "nil")
         check("draft preserves the raw (untrimmed) note",
@@ -264,19 +264,19 @@ enum IssueSelfTest {
         check("draft preserves selectedAgents",
               saved?.selectedAgents == ["codex", "claude"],
               detail: (saved?.selectedAgents ?? []).sorted().joined(separator: ","))
-        check("draft preserves the dispatch action", saved?.action == .fix)
+        check("draft preserves the dispatch action", saved?.action == .run)
 
         // The restore side (summon's `draft?.field ?? default`): a saved draft
         // rehydrates its fields; a nil draft — what submit and Escape leave behind
         // via clearDraft — restores to a clean slate.
         check("restore rehydrates note+action from a saved draft",
               (saved?.note ?? "") == "  cards show raw uuids  " &&
-              (saved?.action ?? .fileTicket) == .fix)
+              (saved?.action ?? .plan) == .run)
         let cleared: PromptDraft? = nil   // what submit/Escape (clearDraft) leave
         check("submit/Escape leave no draft → restore yields empty note",
               (cleared?.note ?? "") == "")
         check("submit/Escape leave no draft → restore yields default action + no selection",
-              (cleared?.action ?? .fileTicket) == .fileTicket &&
+              (cleared?.action ?? .plan) == .plan &&
               (cleared?.selectedPaths ?? []).isEmpty &&
               (cleared?.selectedAgents ?? []).isEmpty)
     }

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -182,13 +182,19 @@ enum IssueSelfTest {
         check("quick-fix prompt requires repo discovery", prompt.contains("agents sessions --all --limit 20"))
         check("quick-fix prompt requires verification", prompt.contains("Verify with the focused tests"))
 
-        let name = AgentsCLI.quickDispatchName(agent: "Codex_Cli", date: Date(timeIntervalSince1970: 1234))
-        check("quick-dispatch names are durable and normalized", name == "quick-codex-cli-1234", detail: name)
+        let name = AgentsCLI.quickDispatchName(note: "Fix the broken login button", date: Date(timeIntervalSince1970: 1234))
+        check("dispatch name is a slug of the user's task", name == "fix-the-broken-login-button", detail: name)
+        let emptyName = AgentsCLI.quickDispatchName(note: "   ", date: Date(timeIntervalSince1970: 1234))
+        check("empty note falls back to a timestamped task name", emptyName == "task-1234", detail: emptyName)
 
-        let args = AgentsCLI.quickFixRunArgs(agent: "codex", prompt: "<prompt>", name: "quick-codex-1234")
-        check("quick-fix runs in autonomous mode",
-              args == ["run", "codex", "<prompt>", "--mode", "auto", "--name", "quick-codex-1234"],
+        let args = AgentsCLI.quickFixRunArgs(agent: "codex", prompt: "<prompt>", name: "my-task")
+        check("run is balanced + autonomous",
+              args == ["run", "codex", "<prompt>", "--mode", "auto", "--balanced", "--name", "my-task"],
               detail: args.joined(separator: " "))
+        let scoped = AgentsCLI.quickFixRunArgs(agent: "codex", prompt: "<p>", name: "n", cwd: "/repo", device: "zion")
+        check("run scopes to cwd + device when given",
+              scoped == ["run", "codex", "<p>", "--mode", "auto", "--balanced", "--name", "n", "--cwd", "/repo", "--device", "zion"],
+              detail: scoped.joined(separator: " "))
     }
 
     // The picker roster is configurable but remains pinned to supported agents.

--- a/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
@@ -108,8 +108,8 @@ final class ClipThumbView: NSView {
 }
 
 enum QuickDispatchAction: Int {
-    case fileTicket = 0
-    case fix = 1
+    case plan = 0
+    case run = 1
 }
 
 struct PromptDraft {
@@ -146,18 +146,23 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
 
     private var panel: PromptPanel?
     private let field = NSTextField()
-    private let modeControl = NSSegmentedControl(labels: ["File Ticket", "Fix"],
+    private let modeControl = NSSegmentedControl(labels: ["Plan", "Run"],
                                                  trackingMode: .selectOne,
                                                  target: nil,
                                                  action: nil)
     private let agentStrip = NSStackView()
     private let hint = NSTextField(labelWithString: "")
     private let thumbStrip = NSStackView()
+    // Repo the agent runs in — sourced from recent-session cwds, never $HOME. The
+    // parallel `repoDirs` holds the full paths behind the shown basenames.
+    private let repoPicker = NSPopUpButton(frame: .zero, pullsDown: false)
+    private var repoDirs: [String] = []
+    private static let lastRepoKey = "menubar.quickDispatch.lastRepo"
     private var selected: [String] = []   // newest-first order preserved
     private var selectedAgents = Set<String>()
     private var roster: [MenuAgent] = []
     private var agentButtons: [NSButton] = []
-    private var action: QuickDispatchAction = .fileTicket
+    private var action: QuickDispatchAction = .plan
     private var inFlight = false
     private var draft: PromptDraft?
     // Click-outside dismissal is armed only AFTER the summon settles — otherwise
@@ -179,10 +184,11 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         let restoredDraft = draft
         inFlight = false
         field.stringValue = restoredDraft?.note ?? ""
-        action = restoredDraft?.action ?? .fileTicket
+        action = restoredDraft?.action ?? .plan
         modeControl.setSelected(true, forSegment: action.rawValue)
         rebuildAgents(restoring: restoredDraft?.selectedAgents)
         rebuildThumbs(restoring: restoredDraft?.selectedPaths)
+        rebuildRepos()
 
         let hasThumbs = !thumbStrip.arrangedSubviews.isEmpty
         thumbStrip.isHidden = !hasThumbs
@@ -243,11 +249,13 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         guard !note.isEmpty, !inFlight else { return }
         inFlight = true
         let agents = selectedAgentList()
+        let cwd = selectedRepo()
+        if let cwd { UserDefaults.standard.set(cwd, forKey: Self.lastRepoKey) }
         switch action {
-        case .fileTicket:
-            AgentsCLI.dispatchTicketAgent(note: note, screenshotPaths: selected, agent: agents.first)
-        case .fix:
-            AgentsCLI.dispatchQuickFix(note: note, screenshotPaths: selected, agents: agents)
+        case .plan:
+            AgentsCLI.dispatchTicketAgent(note: note, screenshotPaths: selected, agent: agents.first, cwd: cwd)
+        case .run:
+            AgentsCLI.dispatchQuickFix(note: note, screenshotPaths: selected, agents: agents, cwd: cwd)
         }
         dismiss(preservingDraft: false)
     }
@@ -263,7 +271,7 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
     // MARK: Dispatch mode / agents
 
     @objc private func onModeChanged(_ sender: NSSegmentedControl) {
-        action = QuickDispatchAction(rawValue: sender.selectedSegment) ?? .fileTicket
+        action = QuickDispatchAction(rawValue: sender.selectedSegment) ?? .plan
         normalizeSelectionForAction()
         updateAgentButtons()
         updateHint()
@@ -273,9 +281,9 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         guard sender.tag >= 0, sender.tag < roster.count else { return }
         let id = roster[sender.tag].id
         switch action {
-        case .fileTicket:
+        case .plan:
             selectedAgents = [id]
-        case .fix:
+        case .run:
             if sender.state == .on {
                 selectedAgents.insert(id)
             } else {
@@ -329,7 +337,7 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         if selectedAgents.isEmpty {
             selectedAgents = [roster.first?.id ?? "claude"]
         }
-        if action == .fileTicket, let first = selectedAgentList().first {
+        if action == .plan, let first = selectedAgentList().first {
             selectedAgents = [first]
         }
     }
@@ -339,6 +347,43 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
             let id = roster[index].id
             button.state = selectedAgents.contains(id) ? .on : .off
         }
+    }
+
+    @objc private func onRepoChanged(_ sender: NSPopUpButton) {
+        updateHint()
+    }
+
+    // MARK: Repo picker
+
+    // Populate the repo dropdown from recent-session cwds (never $HOME). The last
+    // picked repo is restored; if none is remembered, the most-recent one leads.
+    private func rebuildRepos() {
+        repoDirs = AgentsCLI.recentRepoDirs()
+        repoPicker.removeAllItems()
+        guard !repoDirs.isEmpty else {
+            repoPicker.addItem(withTitle: "This Mac (no recent repo)")
+            repoPicker.isEnabled = false
+            return
+        }
+        repoPicker.isEnabled = true
+        for dir in repoDirs {
+            repoPicker.addItem(withTitle: "\u{1F4C1} \((dir as NSString).lastPathComponent)")
+            repoPicker.lastItem?.toolTip = dir
+        }
+        if let last = UserDefaults.standard.string(forKey: Self.lastRepoKey),
+           let idx = repoDirs.firstIndex(of: last) {
+            repoPicker.selectItem(at: idx)
+        } else {
+            repoPicker.selectItem(at: 0)
+        }
+    }
+
+    // The absolute path behind the selected repo item, or nil when there is no
+    // recent repo (the agent then falls back to This Mac / cwd inheritance).
+    private func selectedRepo() -> String? {
+        let idx = repoPicker.indexOfSelectedItem
+        guard idx >= 0, idx < repoDirs.count else { return nil }
+        return repoDirs[idx]
     }
 
     // MARK: Thumbnails
@@ -405,7 +450,10 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
             : count == 1 ? "1 image attached" : "\(count) images attached"
         let pickable = thumbStrip.arrangedSubviews.isEmpty ? "" : " · click attaches · dbl-click previews"
         let agents = selectedAgentList().map(LocalState.agentLabel).joined(separator: ", ")
-        let actionText = action == .fileTicket ? "file ticket with \(agents)" : "fix with \(agents)"
+        let repoName = selectedRepo().map { " in \(($0 as NSString).lastPathComponent)" } ?? ""
+        let actionText = action == .plan
+            ? "file ticket + plan with \(agents)\(repoName)"
+            : "run \(agents)\(repoName) · balanced"
         hint.stringValue = "\(attach)\(pickable)    ↩ \(actionText) · esc clear"
     }
 
@@ -441,7 +489,7 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         bg.layer?.borderColor = kAccent.withAlphaComponent(0.35).cgColor
         panel.contentView = bg
 
-        field.placeholderString = "Describe the issue or fix…"
+        field.placeholderString = "Describe the task…"
         field.font = .systemFont(ofSize: 21, weight: .regular)
         field.textColor = .labelColor
         field.isBezeled = false
@@ -458,7 +506,7 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
 
         modeControl.target = self
         modeControl.action = #selector(onModeChanged(_:))
-        modeControl.selectedSegment = QuickDispatchAction.fileTicket.rawValue
+        modeControl.selectedSegment = QuickDispatchAction.plan.rawValue
         modeControl.segmentStyle = .rounded
         modeControl.translatesAutoresizingMaskIntoConstraints = false
 
@@ -467,10 +515,22 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         agentStrip.spacing = 10
         rebuildAgents()
 
+        repoPicker.translatesAutoresizingMaskIntoConstraints = false
+        repoPicker.controlSize = .small
+        repoPicker.font = .systemFont(ofSize: 12)
+        repoPicker.target = self
+        repoPicker.action = #selector(onRepoChanged(_:))
+        rebuildRepos()
+
         hint.font = .monospacedSystemFont(ofSize: 11.5, weight: .regular)
         hint.textColor = .secondaryLabelColor
 
-        let stack = NSStackView(views: [field, modeControl, agentStrip, thumbStrip, hint])
+        let controlRow = NSStackView(views: [modeControl, repoPicker])
+        controlRow.orientation = .horizontal
+        controlRow.alignment = .centerY
+        controlRow.spacing = 12
+
+        let stack = NSStackView(views: [field, controlRow, agentStrip, thumbStrip, hint])
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 10


### PR DESCRIPTION
**feat** — reshape the Cmd+Shift+O spotlight from File Ticket/Fix into **Plan / Run**, and stop agents running in `$HOME`.

## What changed (`apps/cli/menubar`, native Swift)
- **Modes renamed** File Ticket/Fix → **Plan** (investigate → Linear ticket) / **Run** (headless `agents run`).
- **Repo picker** — a dropdown sourced from recent-session cwds (`AgentsCLI.recentRepoDirs`, most-recent first, **`$HOME` dropped**). The pick is passed as `--cwd` to **both** Plan and Run, so an agent never executes in the too-broad home dir. **Last pick remembered** (`UserDefaults`).
- **Run is `--balanced`** — auto load-balances across signed-in versions with headroom, skipping rate-limited (was the default strategy).
- **`--name` from your task text** (a slug of what you typed), not `quick-<timestamp>`.
- Hint line reflects the resolved repo + balanced strategy.

## Verification (native Swift, macOS)
- `swift build` on zion → **Build complete**, no errors.
- Env-gated self-test (`MENUBAR_ISSUE_TEST=1`) → **ALL PASS**, exit 0, including new assertions:
  - `dispatch name is a slug of the user's task` ✓
  - `run is balanced + autonomous` ✓
  - `run scopes to cwd + device when given` ✓
- It's a native menu-bar spotlight panel (summoned by the global hotkey); a live screenshot means stealing the user's keyboard focus, so per "don't spend too much time" it's verified by compile + self-test rather than a focus-stealing capture.

## Follow-ups (noted, not in this PR)
- **Device picker** + last-pick memory — the `--device` plumbing is already in `quickFixRunArgs`; just needs the dropdown.
- **Linear project picker** for Plan (multiple projects) + memory.
- Plan-mode prompt tweak to emphasize "return a plan."

Image→Linear upload was verified working (Linear `fileUpload` → `assetUrl` → embedded), no change needed.
