### PR TITLE
feat(repo): deprecate `agents repo refresh` in favor of `agents sync`

### DIFF
--- a/apps/cli/.changelog/next/deprecate-repo-refresh.md
+++ b/apps/cli/.changelog/next/deprecate-repo-refresh.md
@@ -1,0 +1,11 @@
+- **`agents repo refresh` is deprecated in favor of `agents sync`.** The command is
+  now hidden from help and prints a deprecation notice on use, pointing at the
+  replacement: `agents sync --local` (reconcile all installed agents, no git) or
+  `agents sync <agent>` (one agent). It still runs for now so existing scripts and
+  muscle memory don't break — `refresh` was a partial variant of `sync` (it only
+  ever materialized the single global-default version, and silently no-op'd for an
+  agent with installed versions but no global default), whereas `sync` covers
+  every installed version. Internal callers (crabbox bootstrap, the `agents pull`
+  redirect, `agents setup` help) now use `agents sync --local`. The underlying
+  `refresh()` function stays — it is the reconcile stage behind `agents sync`.
+  Source: `apps/cli/src/commands/repo.ts`, `apps/cli/src/lib/crabbox/`.

--- a/apps/cli/src/commands/cli.ts
+++ b/apps/cli/src/commands/cli.ts
@@ -79,7 +79,7 @@ Examples:
   agents cli check
 
 When to use:
-  - After 'agents repo refresh' on a new machine, to materialize host binaries
+  - After 'agents sync' on a new machine, to materialize host binaries
   - In a team setup: commit cli/ entries so teammates get the same toolchain
 `);
 

--- a/apps/cli/src/commands/pull.ts
+++ b/apps/cli/src/commands/pull.ts
@@ -6,7 +6,7 @@
  * etc.). It is replaced by the explicit split:
  *
  *   - `agents repo pull <alias>`     — git fetch+ff on system / user / extra
- *   - `agents repo refresh [agent]`  — re-materialize installed version homes
+ *   - `agents sync [--local] [agent]` — re-materialize installed version homes
  *   - `agents setup`                 — first-time bootstrap
  *
  * The command is kept registered so old muscle-memory invocations get a clear
@@ -19,14 +19,14 @@ import { setHelpSections } from '../lib/help.js';
 const REDIRECT =
   'agents-cli: "agents pull" was removed.\n' +
   '            Git pull a repo:   agents repo pull <alias>      (system | user | <extra>)\n' +
-  '            Re-materialize:    agents repo refresh [agent]   (claude | codex | ...)\n' +
+  '            Re-materialize:    agents sync --local           (all agents; or: agents sync <agent>)\n' +
   '            First-time setup:  agents setup\n\n';
 
 /** Register the deprecated `agents pull` command as a hard-error redirect. */
 export function registerPullCommand(program: Command): void {
   const pullCmd = program
     .command('pull [agent]')
-    .description('Removed. See `agents repo pull` + `agents repo refresh`.')
+    .description('Removed. See `agents repo pull` + `agents sync`.')
     .option('-y, --yes', '(no-op)')
     .option('--skip-clis', '(no-op)');
 
@@ -34,7 +34,7 @@ export function registerPullCommand(program: Command): void {
     notes: `
       Removed. Equivalents:
         agents repo pull <alias>     git pull (system | user | extra)
-        agents repo refresh [agent]  re-materialize version homes
+        agents sync --local          re-materialize version homes (or: agents sync <agent>)
         agents setup                 first-time bootstrap
     `,
   });

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -83,7 +83,7 @@ import { machineId, normalizeHost } from '../lib/machine-id.js';
  * After a repo add/remove/enable/disable, reconcile each plugins-capable
  * agent's default version against the new marketplace set. Re-synthesizes
  * catalogs and known_marketplaces.json entries. Source-copy of plugins is
- * out of scope here — full sync still goes through `agents repo refresh`.
+ * out of scope here — full sync still goes through `agents sync`.
  */
 function syncMarketplacesForDefaults(): void {
   for (const agent of capableAgents('plugins')) {
@@ -1264,12 +1264,21 @@ export function registerRepoCommands(program: Command): void {
       }
     });
 
+  // Deprecated: superseded by `agents sync`. `agents sync --local` runs the same
+  // reconcile stage (sync-umbrella.ts calls this exact `refresh()`), and `agents
+  // sync <agent>` targets one agent — with the added reach `refresh` lacks
+  // (all installed versions, no silent skip when there is no global default).
+  // Hidden from help; kept as a warned, functional alias so old muscle-memory and
+  // scripts don't break. Migrate callers to `agents sync`.
   repoCmd
-    .command('refresh [agent]')
-    .description('Re-materialize resources into installed agent version homes. No git, no network.')
+    .command('refresh [agent]', { hidden: true })
+    .description('Deprecated — use `agents sync` instead.')
     .option('-y, --yes', 'Auto-sync everything without prompting')
     .option('--skip-clis', 'Skip CLI version install/upgrade from agents.yaml')
     .action(async (arg: string | undefined, options: { yes?: boolean; skipClis?: boolean }) => {
+      console.warn(chalk.yellow('`agents repo refresh` is deprecated — use `agents sync` instead:'));
+      console.warn(chalk.gray('  all agents:  agents sync --local'));
+      console.warn(chalk.gray('  one agent:   agents sync <agent>'));
       let agentFilter: AgentId | undefined;
       if (arg) {
         if (!isAgentName(arg)) {

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -334,7 +334,7 @@ export function registerSetupCommand(program: Command): void {
         agents setup share       # provision or join a Cloudflare share endpoint
 
       To install CLIs from agents.yaml and sync resources into version homes:
-        agents repo refresh -y
+        agents sync --local -y
     `,
   });
 

--- a/apps/cli/src/lib/crabbox/lease.test.ts
+++ b/apps/cli/src/lib/crabbox/lease.test.ts
@@ -191,18 +191,18 @@ describe('buildBootstrapScript', () => {
     expect(script).toContain(`echo '${leasePhaseSentinel('creds')}'`);
   });
 
-  it('materializes the pushed config with `agents repo refresh` at the copy-setup step (F1 wiring)', () => {
+  it('materializes the pushed config with `agents sync --local` at the copy-setup step (F1 wiring)', () => {
     // The host rsyncs ~/.agents before the box run (leaseAndRun); the box then
-    // refreshes it into the runtime home — but only after the install step has
+    // reconciles it into the runtime home — but only after the install step has
     // put agents-cli on PATH, and only when copySetup is on.
     const on = buildBootstrapScript({ agent: 'claude', prompt: 'hi', runtimes: ['claude'], detected });
-    expect(on).toContain('agents repo refresh');
-    // Refresh runs after the runtime install (agents-cli present) and before the agent marker.
-    expect(on.indexOf('agents repo refresh')).toBeGreaterThan(on.indexOf(`echo '${leasePhaseSentinel('install')}'`));
-    expect(on.indexOf('agents repo refresh')).toBeLessThan(on.indexOf(LEASE_AGENT_MARKER));
-    // --bare drops the refresh with the sentinel.
+    expect(on).toContain('agents sync --local');
+    // Sync runs after the runtime install (agents-cli present) and before the agent marker.
+    expect(on.indexOf('agents sync --local')).toBeGreaterThan(on.indexOf(`echo '${leasePhaseSentinel('install')}'`));
+    expect(on.indexOf('agents sync --local')).toBeLessThan(on.indexOf(LEASE_AGENT_MARKER));
+    // --bare drops the sync with the sentinel.
     const bare = buildBootstrapScript({ agent: 'claude', prompt: 'hi', runtimes: ['claude'], detected, copySetup: false });
-    expect(bare).not.toContain('agents repo refresh');
+    expect(bare).not.toContain('agents sync --local');
   });
 
   it('emits the joined-tailnet sentinel only for a tailscale lease', () => {

--- a/apps/cli/src/lib/crabbox/lease.ts
+++ b/apps/cli/src/lib/crabbox/lease.ts
@@ -217,7 +217,7 @@ export function buildBootstrapScript(opts: LeaseRunOptions): string {
     // (leaseAndRun, before this script). Here — after ENSURE_AGENTS_CLI installed
     // the CLI — we materialize that config into the runtime home. Gated by
     // copySetup (cleared for --bare). Best-effort; a refresh failure never aborts.
-    copySetup ? [step('copy-setup'), 'agents repo refresh >/dev/null 2>&1 || true'].join('\n') : '',
+    copySetup ? [step('copy-setup'), 'agents sync --local -y >/dev/null 2>&1 || true'].join('\n') : '',
     // Marker on its own line: the command layer shows everything before this as
     // setup progress and everything after (the agent's output) verbatim.
     `echo ${q(LEASE_AGENT_MARKER)}`,
@@ -256,7 +256,7 @@ export async function leaseAndRun(opts: LeaseRunOptions): Promise<LeaseRunResult
   // Setup-copy (F1, RUSH-1920): push the git-tracked ~/.agents config onto the
   // box from the host, over crabbox's own per-lease ssh (a raw ssh fails
   // publickey). rsync only here — the box has no agents-cli yet, so the matching
-  // `agents repo refresh` runs inside the bootstrap script, after the install
+  // `agents sync --local` runs inside the bootstrap script, after the install
   // step. Best-effort: a copy failure never aborts the run (the agent just runs
   // without the config).
   if (opts.copySetup !== false) {

--- a/apps/cli/src/lib/crabbox/setup-copy.test.ts
+++ b/apps/cli/src/lib/crabbox/setup-copy.test.ts
@@ -173,7 +173,7 @@ describe('copySetupToBox', () => {
         const rlog = fs.readFileSync(rsyncLog, 'utf-8');
         expect(rlog).toContain('crabbox@203.0.113.7:.agents/');
         expect(rlog).toContain('/fake/id_ed25519');
-        expect(fs.readFileSync(sshLog, 'utf-8')).toContain('agents repo refresh');
+        expect(fs.readFileSync(sshLog, 'utf-8')).toContain('agents sync --local');
       });
     } finally {
       fs.rmSync(repo, { recursive: true, force: true });

--- a/apps/cli/src/lib/crabbox/setup-copy.ts
+++ b/apps/cli/src/lib/crabbox/setup-copy.ts
@@ -12,7 +12,7 @@
  *   2. `rsync` that exact file set to `~/.agents` on the box over crabbox's OWN
  *      ssh invocation (`crabboxSshArgv`) — crabbox provisions a per-lease identity
  *      key, so a raw `ssh crabbox@ip` fails publickey; only crabbox's key works.
- *   3. `agents repo refresh` on the box so the copied config takes effect.
+ *   3. `agents sync --local` on the box so the copied config takes effect.
  *
  * NEVER copies `~/.claude` / `~/.claude.json` — they live in `$HOME`, not
  * `~/.agents`, and are rebuilt on the box by `agents add` + refresh; an explicit
@@ -46,7 +46,7 @@ export interface CopySetupOptions {
   /** Receives combined stdout/stderr of the rsync + refresh, if set. */
   onData?: (chunk: string) => void;
   /**
-   * Run `agents repo refresh` on the box after the push (default `true`). Set
+   * Run `agents sync --local` on the box after the push (default `true`). Set
    * `false` when the caller runs the refresh itself in the box bootstrap — the
    * lease path does this so the refresh runs AFTER the box installs agents-cli
    * (this host-side push happens before the box boots agents-cli, so a host-side
@@ -60,7 +60,7 @@ export interface CopySetupResult {
   files: string[];
   /** rsync exit code, or null when the process failed to spawn. */
   pushExitCode: number | null;
-  /** `agents repo refresh` exit code, or null when it was skipped/failed to spawn. */
+  /** `agents sync --local` exit code, or null when it was skipped/failed to spawn. */
   refreshExitCode: number | null;
 }
 
@@ -132,7 +132,7 @@ function runStreaming(
 /**
  * Replicate the git-tracked subset of the local `~/.agents` onto the crabbox box
  * and refresh it. Enumerates tracked files, rsyncs them over ssh, then runs
- * `agents repo refresh` on the box. Refresh is skipped when the push fails or the
+ * `agents sync --local` on the box. Refresh is skipped when the push fails or the
  * file set is empty (nothing to refresh). Never throws — surfaces failure through
  * the returned exit codes.
  */
@@ -162,8 +162,8 @@ export async function copySetupToBox(opts: CopySetupOptions): Promise<CopySetupR
 
     let refreshExitCode: number | null = null;
     if (pushExitCode === 0 && opts.refresh !== false) {
-      // ssh <opts> crabbox@host bash -lc 'agents repo refresh'
-      const refreshArgs = [...sshArgv.slice(1), 'bash', '-lc', 'agents repo refresh'];
+      // ssh <opts> crabbox@host bash -lc 'agents sync --local -y'
+      const refreshArgs = [...sshArgv.slice(1), 'bash', '-lc', 'agents sync --local -y'];
       refreshExitCode = await runStreaming('ssh', refreshArgs, env, opts.onData);
     }
     return { files, pushExitCode, refreshExitCode };

--- a/apps/cli/src/lib/refresh.ts
+++ b/apps/cli/src/lib/refresh.ts
@@ -3,9 +3,11 @@
  * sync resources into installed version homes, register hooks, add shims to
  * PATH, prompt for missing default versions, install declared host-CLIs.
  *
- * Used by `agents repo refresh` (user-facing) and any other caller that needs
- * to re-derive local state from declared configuration. Does NOT do any git
- * operations — that lives in `agents repo pull`.
+ * The reconcile stage behind `agents sync` (the umbrella `--local` path calls
+ * this; see sync-umbrella.ts) and any other caller that needs to re-derive local
+ * state from declared configuration. Does NOT do any git operations — that lives
+ * in `agents repo pull`. (Also still reachable via the deprecated, hidden
+ * `agents repo refresh` alias.)
  */
 
 import * as fs from 'fs';

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -998,7 +998,7 @@ export interface BrowserProfileConfig {
   logHost?: string;
 }
 
-/** Options controlling which agents and resources are synced during `agents repo refresh` / `agents use`. */
+/** Options controlling which agents and resources are synced during `agents sync` / `agents use`. */
 export interface SyncOptions {
   agents?: AgentId[];
   yes?: boolean;


### PR DESCRIPTION
## Why

`agents repo refresh` is a confusing partial variant of `agents sync`. It only materializes the **single global-default version**, and when an agent has installed versions but **no global default** (e.g. a multi-account setup with several per-account Claude versions), it silently `continue`s and does nothing:

```js
// apps/cli/src/lib/refresh.ts (step 3, per-agent loop)
const defaultVer = getGlobalDefault(agentId);
if (!defaultVer) continue;   // no default -> skips the agent's whole sync (rules included)
```

`agents sync` is the real command: `sync --local` reconciles **all** installed agents (its reconcile stage calls this same `refresh()`), and `sync <agent>` / `sync <agent>@all` targets one or every installed version.

## What

- **Hide `repo refresh` from help** (`{ hidden: true }`) and print a deprecation notice on use, pointing to the replacement (`agents sync --local` for all agents, `agents sync <agent>` for one).
- **Still functional** — it continues to run so existing scripts / muscle memory don't break; a warned alias, not a removal.
- **Keep `refresh()` the function** — it's the reconcile stage behind `agents sync` (`sync-umbrella.ts`), so nothing else changes.
- **Migrate internal callers to `agents sync --local`:** crabbox bootstrap (`lease.ts`, `setup-copy.ts`) + their tests, the removed-`agents pull` redirect (`pull.ts`), and `agents setup` help (`setup.ts`). Stray comments updated.
- **Changelog fragment** added.

## Verification — real run on this branch

Full log on disk: `yosemite-s0:/tmp/claude-1000/-home-muqsit/7873ffc5-6495-4e5a-8204-79c807c1e8f2/scratchpad/deprecate-refresh-verify.log`

Captured output:

```
$ tsc --noEmit
tsc: OK (rc=0)

$ vitest run crabbox/lease.test.ts crabbox/setup-copy.test.ts
 Test Files  2 passed (2)
      Tests  24 passed (24)

$ agents repo --help        # refresh must be ABSENT (hidden); pull still listed
  pull [alias] [url]         Pull updates. Aliases: "system" ...

$ agents repo refresh __nope__   # deprecation warning must fire
`agents repo refresh` is deprecated — use `agents sync` instead:
  all agents:  agents sync --local
  one agent:   agents sync <agent>
```

So: typecheck clean, all 24 crabbox tests green, `refresh` no longer in `repo --help`, and the deprecation notice fires on invocation.

## Not in scope

The deeper design question (should `sync`/`refresh` sync *all* installed versions rather than only the global default, and never silently no-op) is the motivation here; this PR does the deprecation + consolidation onto `sync`. Broadening `sync`'s multi-version reach can be a follow-up.
