### PR TITLE
feat(hosts): generic --device all / --host all fleet fan-out (RUSH-1969)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,9 @@ agents run claude --host gpu-box                         # no prompt → interac
 agents run claude --host gpu-box --copy-creds "fix auth" # copy local runtime creds + Claude token, shred after
 agents run claude --device auto "…"                      # affinity-pick host from 14d usage (harness stays claude)
 agents run claude --host auto "…"                        # same — auto is a host value, not a harness name
+agents view kimi --device all                            # fan out across every registered device (grouped-by-OS roster)
+agents output --device all                               # per-device burn vs shipped output across the fleet
+agents view --device all --json                          # machine-readable fleet inventory
 agents hosts ps                         # list dispatched runs + terminal status
 agents hosts stop <id>                  # terminate a hung/detached run (alias: kill)
 agents logs --host gpu-box              # pick a dispatched run — concise summary by default

--- a/apps/cli/.changelog/1.20.81.md
+++ b/apps/cli/.changelog/1.20.81.md
@@ -1,3 +1,14 @@
+- **Generic `--device all` / `--host all` fleet fan-out for every fleet-aware
+  command (RUSH-1969).** The passthrough now treats `all` as a sentinel value on
+  `--host`, `--device`, `--hosts`, and `--devices`. For any routable command
+  (`view`, `output`, `sync`, `doctor`, `list`, …) it runs `agents <cmd> --json`
+  on every registered device concurrently, then renders an OS-grouped roster
+  (`●` installed, `○` offline/skipped, `▸ … ← this machine`). Offline and
+  no-address devices render as rows instead of hanging the whole run. Add
+  `--json` to get a device-keyed object. Commands that already own `--all-hosts`
+  (`output`) keep their existing behavior. Source:
+  `apps/cli/src/lib/hosts/passthrough.ts`, `apps/cli/src/lib/hosts/option.ts`.
+
 - **`agents apply` no longer propagates single-use rotating refresh tokens
   (RUSH-1958).** Droid (WorkOS) credentials use a refresh token that rotates
   server-side on every exchange; copying one credential file across N boxes

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 1.20.81
 
+- **Generic `--device all` / `--host all` fleet fan-out for every fleet-aware
+  command (RUSH-1969).** The passthrough now treats `all` as a sentinel value on
+  `--host`, `--device`, `--hosts`, and `--devices`. For any routable command
+  (`view`, `output`, `sync`, `doctor`, `list`, …) it runs `agents <cmd> --json`
+  on every registered device concurrently, then renders an OS-grouped roster
+  (`●` installed, `○` offline/skipped, `▸ … ← this machine`). Offline and
+  no-address devices render as rows instead of hanging the whole run. Add
+  `--json` to get a device-keyed object. Commands that already own `--all-hosts`
+  (`output`) keep their existing behavior. Source:
+  `apps/cli/src/lib/hosts/passthrough.ts`, `apps/cli/src/lib/hosts/option.ts`.
+
 - **`agents apply` no longer propagates single-use rotating refresh tokens
   (RUSH-1958).** Droid (WorkOS) credentials use a refresh token that rotates
   server-side on every exchange; copying one credential file across N boxes

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -33,6 +33,21 @@ affinity (weighted by launch counts on `sessions.db` `machine`; most-used online
 device has highest probability). Harness stays the agent you typed — never
 auto-picked. Affinity failure degrades to local rather than aborting the run.
 
+Pass `all` as the `--host` / `--device` value to fan any fleet-aware command out
+across every registered device. The passthrough runs `agents <cmd> --json` on each
+box concurrently, then renders a grouped-by-OS roster with one row per device
+(`○ offline` rows for unreachable devices, `●` rows for successful ones). Add
+`--json` to get the raw device-keyed object instead.
+
+```
+agents view kimi --device all          # every box's kimi version + account
+agents output --device all             # per-device burn vs shipped output
+agents view --device all --json        # machine-readable fleet inventory
+```
+
+`--devices all` and `--hosts all` are synonyms. Commands that already register
+`--all-hosts` (e.g. `agents output --all-hosts`) keep their existing behavior.
+
 It sits next to the vendor clouds (`agents cloud run --provider rush|codex|…`),
 not replacing them: those dispatch to *someone else's* cloud; `hosts` dispatches
 to *your* boxes (owned, or leased on demand via crabbox — see Host sources).

--- a/apps/cli/src/lib/hosts/option.ts
+++ b/apps/cli/src/lib/hosts/option.ts
@@ -17,9 +17,9 @@ export function addHostOption(cmd: Command): Command {
   return cmd
     .option(
       '-H, --host <name>',
-      'Run this command on another machine over SSH instead of locally — a device, a registered host, or user@host. See `agents devices` / `agents hosts`.',
+      'Run this command on another machine over SSH instead of locally — a device, a registered host, user@host, or `all` to fan out across every registered device. See `agents devices` / `agents hosts`.',
     )
-    .option('--device <name>', 'Alias of --host: run this command on a registered device (from `agents devices`).')
+    .option('--device <name>', 'Alias of --host: run this command on a registered device (from `agents devices`), or `all` to run it across the whole fleet.')
     .option('--remote-cwd <dir>', "Working directory on the host for --host runs. Resolves on the REMOTE host — pass a '$HOME'-relative path (single-quoted so your local shell doesn't expand it) or a valid remote absolute path; a local ~ expands here and won't exist there (/Users/you vs /home/you). No effect on 'teams add'.")
     .option('--no-tty', 'Force non-interactive output for --host runs even from a terminal.')
     .option('--any', 'With --host <cap> (a capability tag), pick any matching host instead of erroring when several match.');

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -1,6 +1,25 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { flagValue, maybeRunOnHost } from './passthrough.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { flagValue, maybeRunOnHost, runFleetPassthrough } from './passthrough.js';
 import { machineId } from '../session/sync/config.js';
+import type { DeviceProfile, DeviceRegistry } from '../devices/registry.js';
+
+function fakeDevice(name: string, platform: DeviceProfile['platform'], overrides?: Partial<DeviceProfile>): DeviceProfile {
+  return {
+    name,
+    platform,
+    shell: platform === 'windows' ? 'powershell' : 'posix',
+    address: { via: 'tailscale', dnsName: `${name}.tail.ts.net` },
+    auth: { method: 'key' },
+    tailscale: { online: true, direct: true },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function fakeRegistry(devices: DeviceProfile[]): DeviceRegistry {
+  return Object.fromEntries(devices.map((d) => [d.name, d]));
+}
 
 describe('flagValue', () => {
   it('reads the space-separated long form', () => {
@@ -157,5 +176,223 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
   it('bails on --hosts for routines too (generic fleet flag, not placement)', async () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
     expect(await maybeRunOnHost('routines', ['routines', 'list', '--host', '--evil', '--hosts'])).toBe(false);
+  });
+
+  it('rejects --device all on a non-routable command with a clear error', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    const result = await maybeRunOnHost('setup', ['setup', '--device', 'all']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe('maybeRunOnHost — fleet `all` sentinel (injected runners)', () => {
+  const originalArgv = process.argv.slice();
+  const logs: string[] = [];
+  const originalLog = console.log;
+
+  afterEach(() => {
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+    process.argv = originalArgv.slice();
+    process.exitCode = 0;
+    logs.length = 0;
+    console.log = originalLog;
+  });
+
+  function captureLogs() {
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+  }
+
+  function makeRunner(responses: Record<string, { code: number | null; stdout: string; stderr: string }>) {
+    return (device: DeviceProfile, cmd: string[]) => {
+      const key = cmd.slice(0, 2).join(' '); // e.g. "agents view"
+      const hit = responses[`${device.name}:${key}`] ?? responses[device.name] ?? { code: 0, stdout: '[]', stderr: '' };
+      return hit;
+    };
+  }
+
+  function makeLocalRunner(response: { code: number | null; stdout: string; stderr: string } = { code: 0, stdout: '[]', stderr: '' }) {
+    return () => response;
+  }
+
+  it('fans out view across every device with --device all', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    captureLogs();
+    const registry = fakeRegistry([
+      fakeDevice('zion', 'macos'),
+      fakeDevice('mac-mini', 'macos'),
+      fakeDevice('yosemite-s0', 'linux'),
+    ]);
+    const runner = makeRunner({
+      'mac-mini:agents view': { code: 0, stdout: JSON.stringify([{ agent: 'kimi', versions: [{ version: '0.4.2', isDefault: true, signedIn: true, email: 'trp.so' }] }]), stderr: '' },
+      'yosemite-s0:agents view': { code: 0, stdout: JSON.stringify([{ agent: 'kimi', versions: [{ version: '0.4.1', isDefault: true, signedIn: true, email: 'trp.so' }] }]), stderr: '' },
+    });
+    const localRunner = makeLocalRunner({
+      code: 0,
+      stdout: JSON.stringify([{ agent: 'kimi', versions: [{ version: '0.4.3', isDefault: true, signedIn: true, email: 'trp.so' }] }]),
+      stderr: '',
+    });
+
+    const result = await maybeRunOnHost('view', ['view', 'kimi', '--device', 'all'], {
+      self: 'zion',
+      loadDevices: async () => registry,
+      runner,
+      localRunner,
+    });
+
+    expect(result).toBe(true);
+    const output = logs.join('\n');
+    expect(output).toContain('view kimi');
+    expect(output).toContain('macOS');
+    expect(output).toContain('Linux');
+    expect(output).toContain('zion');
+    expect(output).toContain('mac-mini');
+    expect(output).toContain('yosemite-s0');
+    expect(output).toContain('← this machine');
+  });
+
+  it('fans out with --host all and --devices all too', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    captureLogs();
+    const registry = fakeRegistry([fakeDevice('mac-mini', 'macos')]);
+    const runner = makeRunner({ 'mac-mini:agents view': { code: 0, stdout: '[]', stderr: '' } });
+
+    for (const flag of ['--host all', '--devices all', '--hosts all']) {
+      logs.length = 0;
+      const [f, v] = flag.split(' ');
+      const result = await maybeRunOnHost('view', ['view', f, v], {
+        self: 'zion',
+        loadDevices: async () => registry,
+        runner,
+        localRunner: makeLocalRunner(),
+      });
+      expect(result).toBe(true);
+      expect(logs.join('\n')).toContain('mac-mini');
+    }
+  });
+
+  it('renders offline / no-address devices as skipped rows, never a hang', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    captureLogs();
+    const registry = fakeRegistry([
+      fakeDevice('zion', 'macos', { tailscale: { online: true, direct: true } }),
+      fakeDevice('pinnacles', 'macos', { tailscale: { online: false, direct: false } }),
+      fakeDevice('headless', 'linux', { address: { via: 'manual' } }), // no dns/ip → no-address
+    ]);
+
+    const result = await maybeRunOnHost('view', ['view', 'kimi', '--device', 'all'], {
+      self: 'zion',
+      loadDevices: async () => registry,
+      runner: makeRunner({}),
+      localRunner: makeLocalRunner({ code: 0, stdout: '[]', stderr: '' }),
+    });
+
+    expect(result).toBe(true);
+    const output = logs.join('\n');
+    expect(output).toContain('pinnacles');
+    expect(output).toContain('headless');
+    expect(output).toMatch(/offline|no address/);
+  });
+
+  it('emits a device-keyed JSON object under --json', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    captureLogs();
+    const registry = fakeRegistry([fakeDevice('zion', 'macos'), fakeDevice('mac-mini', 'macos')]);
+    // Remote `agents view <agent> --json` returns a single object, not an array.
+    const remotePayload = { agent: 'kimi', versions: [{ version: '0.4.2', isDefault: true, signedIn: false, email: null }], profiles: [] };
+    const runner = makeRunner({ 'mac-mini:agents view': { code: 0, stdout: JSON.stringify(remotePayload), stderr: '' } });
+
+    const result = await maybeRunOnHost('view', ['view', 'kimi', '--device', 'all', '--json'], {
+      self: 'zion',
+      loadDevices: async () => registry,
+      runner,
+      localRunner: makeLocalRunner({ code: 0, stdout: '[]', stderr: '' }),
+    });
+
+    expect(result).toBe(true);
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed['mac-mini']).toEqual(remotePayload);
+    expect(parsed.zion).toEqual([]);
+  });
+
+  it('still bails on non-all --devices for non-routines commands', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    expect(await maybeRunOnHost('view', ['view', '--devices', 'mac1,mac2'])).toBe(false);
+  });
+
+  it('fans out --devices all on routines too', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+    captureLogs();
+    const registry = fakeRegistry([fakeDevice('mac-mini', 'macos')]);
+    const runner = makeRunner({ 'mac-mini:agents routines': { code: 0, stdout: '[]', stderr: '' } });
+
+    const result = await maybeRunOnHost('routines', ['routines', 'list', '--devices', 'all'], {
+      self: 'zion',
+      loadDevices: async () => registry,
+      runner,
+      localRunner: makeLocalRunner({ code: 0, stdout: '[]', stderr: '' }),
+    });
+
+    expect(result).toBe(true);
+    expect(logs.join('\n')).toContain('mac-mini');
+  });
+
+  it('rejects a conflicting --host with --device all', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    const result = await maybeRunOnHost('view', ['view', '--device', 'all', '--host', 'other']);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe('runFleetPassthrough — direct unit tests', () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+
+  afterEach(() => {
+    logs.length = 0;
+    console.log = originalLog;
+    process.exitCode = 0;
+    delete process.env.AGENTS_SYNC_MACHINE_ID;
+  });
+
+  it('uses the output summarizer for output command', async () => {
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+    const registry = fakeRegistry([fakeDevice('mac-mini', 'macos')]);
+    const runner = (_device: DeviceProfile, cmd: string[]) => {
+      if (cmd[1] === 'output') {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            machine: 'mac-mini',
+            pricingVersion: '2026-01',
+            since: '7d',
+            burn: { costUsd: 12.5, outputTokens: 3400, tokenCount: 12000, sessionCount: 5, durationMs: 360000 },
+            output: { commits: 3, commitShas: [], prsOpened: 0, prsMerged: 0, reposScanned: 2, ghAvailable: true, authors: [], logins: [] },
+            breakdown: { by: 'agent', rows: [] },
+            uncostedAgents: [],
+          }),
+          stderr: '',
+        };
+      }
+      return { code: 1, stdout: '', stderr: 'unexpected' };
+    };
+
+    await runFleetPassthrough(
+      'output',
+      ['output', '--device', 'all'],
+      {},
+      {
+        self: 'zion',
+        loadDevices: async () => registry,
+        runner,
+        localRunner: () => ({ code: 0, stdout: '{}', stderr: '' }),
+      },
+    );
+
+    const output = logs.join('\n');
+    expect(output).toContain('mac-mini');
+    expect(output).toContain('$12.50 burned');
+    expect(output).toContain('3.4K output tokens');
   });
 });

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -30,6 +30,16 @@ import {
 } from './remote-cmd.js';
 import { resolveRemoteOsSync } from './remote-os.js';
 import { machineId } from '../session/sync/config.js';
+import { loadDevices, type DeviceProfile, type DeviceRegistry } from '../devices/registry.js';
+import {
+  fanOutDevices,
+  planFleetTargets,
+  runLocalCommand,
+  runOnDevice,
+  type FleetSkipReason,
+  type FanOutDeviceResult,
+} from '../devices/fleet.js';
+import { platformGroupLabel } from '../devices/health-report.js';
 
 /** Per-command remote behaviour. Absence from this map = not host-routable here. */
 interface RemoteSpec {
@@ -128,8 +138,15 @@ const OWN_HOST_COMMANDS = new Set([
   'monitors', // `--device` names the OWNER machine (pin-to-one), not a routing target
 ]);
 
-/** `--no-tty` is stripped like the routing flags but carries no value. */
-const STRIP_SPECS: StripSpec[] = [...HOST_ROUTING_SPECS, { long: 'no-tty', takesValue: false }];
+/** `--no-tty` is stripped like the routing flags but carries no value. The plural
+ * fleet flags are stripped only when we handle the `all` sentinel ourselves;
+ * otherwise they fall through to command-level aggregators. */
+const STRIP_SPECS: StripSpec[] = [
+  ...HOST_ROUTING_SPECS,
+  { long: 'no-tty', takesValue: false },
+  { long: 'hosts', takesValue: true },
+  { long: 'devices', takesValue: true },
+];
 
 /** Pull the value of `--host`/`-H`/`--remote-cwd` (any form) out of an argv. */
 export function flagValue(args: string[], long: string, short?: string): string | undefined {
@@ -168,6 +185,238 @@ async function resolveTargetHost(name: string, any: boolean): Promise<Host> {
   return syntheticHost(name);
 }
 
+/** Injectable dependencies for {@link runFleetPassthrough} — used by tests. */
+export interface FleetPassthroughOptions {
+  /** Override the device registry loader (tests). */
+  loadDevices?: () => Promise<DeviceRegistry>;
+  /** Override the per-device runner (tests). Defaults to `runOnDevice`. */
+  runner?: typeof runOnDevice;
+  /** Override the local runner for the self device (tests). Defaults to `runLocalCommand`. */
+  localRunner?: typeof runLocalCommand;
+  /** Override this machine's id (tests). Defaults to `machineId()`. */
+  self?: string;
+}
+
+interface FleetTargetWithDevice {
+  name: string;
+  device: DeviceProfile;
+  skip?: FleetSkipReason;
+}
+
+/** Detect the `all` sentinel on any routing flag. */
+function isFleetAllSentinel(
+  hostFlag: string | undefined,
+  deviceFlag: string | undefined,
+  hostsFlag: string | undefined,
+  devicesFlag: string | undefined,
+): boolean {
+  return (
+    hostFlag?.toLowerCase() === 'all' ||
+    deviceFlag?.toLowerCase() === 'all' ||
+    hostsFlag?.toLowerCase() === 'all' ||
+    devicesFlag?.toLowerCase() === 'all'
+  );
+}
+
+/** Strip routing flags from the argv and ensure the per-device call emits JSON. */
+function buildFleetForwardedArgs(allArgs: string[]): string[] {
+  const stripped = stripRoutingFlags(allArgs, STRIP_SPECS);
+  if (!stripped.includes('--json')) stripped.push('--json');
+  return stripped;
+}
+
+/** Parse stdout as JSON; on failure return an object describing the error. */
+function safeJsonParse(stdout: string): unknown {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return { parseError: 'invalid JSON', snippet: stdout.trim().slice(0, 200) };
+  }
+}
+
+/** One-line summary of a per-device `agents view [agent] --json` payload. */
+function summarizeViewResult(forwarded: string[], json: unknown): string {
+  // After routing flags are stripped, the agent argument is the first token that
+  // is not a flag (e.g. `kimi` in `agents view kimi --json`).
+  const agentArg = forwarded.find((a, i) => i > 0 && !a.startsWith('-'));
+  // `agents view --json` returns an array; `agents view <agent> --json` returns
+  // a single object. Normalize to the per-agent shape.
+  const agent = agentArg
+    ? (Array.isArray(json) ? (json[0] as any) : (json as any))
+    : undefined;
+  if (!agentArg) {
+    const rows = Array.isArray(json) ? json : [];
+    const count = rows.reduce((n, r: any) => n + (r.versions?.length ?? 0), 0);
+    return count === 0 ? 'no agents installed' : `${count} version${count === 1 ? '' : 's'}`;
+  }
+  if (!agent || !Array.isArray(agent.versions) || agent.versions.length === 0) {
+    return 'not installed';
+  }
+  const v = agent.versions.find((x: any) => x.isDefault) ?? agent.versions[0];
+  const parts: string[] = [chalk.cyan(String(v.version))];
+  if (v.signedIn) {
+    parts.push(chalk.green('active'));
+    if (v.email) parts.push(chalk.gray(String(v.email)));
+  } else {
+    parts.push(chalk.gray('signed out'));
+  }
+  return parts.join(' · ');
+}
+
+function formatCompactUsd(usd: number): string {
+  if (usd >= 1000) return `$${(usd / 1000).toFixed(1)}k`;
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  return `$${usd.toFixed(3)}`;
+}
+
+function formatCompactTokens(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${(n / 1e3).toFixed(1)}K`;
+  return String(n);
+}
+
+/** One-line summary of a per-device `agents output --json` payload. */
+function summarizeOutputResult(json: unknown): string {
+  const p = json as any;
+  const burn = p?.burn;
+  if (!burn || typeof burn !== 'object') return 'ok';
+  const parts: string[] = [];
+  if (typeof burn.costUsd === 'number') parts.push(`${formatCompactUsd(burn.costUsd)} burned`);
+  if (typeof burn.outputTokens === 'number') parts.push(`${formatCompactTokens(burn.outputTokens)} output tokens`);
+  const commits = p?.output?.commits;
+  if (typeof commits === 'number' && commits > 0) parts.push(`${commits} commits`);
+  return parts.length ? parts.join(' · ') : 'ok';
+}
+
+/** Best-effort summary of any per-device JSON payload. */
+function summarizeResult(command: string, forwarded: string[], json: unknown): string {
+  if (command === 'view') return summarizeViewResult(forwarded, json);
+  if (command === 'output') return summarizeOutputResult(json);
+  return 'ok';
+}
+
+const GROUP_ORDER = ['macOS', 'Linux', 'Windows', 'Other'];
+
+/** Render the grouped-by-OS fleet roster from per-device results. */
+function renderFleetRoster(
+  command: string,
+  forwarded: string[],
+  results: Array<FanOutDeviceResult<unknown> & { device: DeviceProfile }>,
+  self: string,
+): void {
+  const agentArg = forwarded[1];
+  const installed = results.filter((r) => r.status === 'ok').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+
+  const title = agentArg ? `${command} ${agentArg}` : command;
+  const summaryParts: string[] = [];
+  if (installed) summaryParts.push(`${installed} installed`);
+  if (failed) summaryParts.push(`${failed} unreachable`);
+  if (skipped) summaryParts.push(`${skipped} skipped`);
+  console.log(chalk.bold(title) + chalk.gray(` · ${results.length} device${results.length === 1 ? '' : 's'}`));
+  console.log('');
+
+  const nameW = Math.max(6, ...results.map((r) => r.name.length));
+  const grouped = new Map<string, Array<FanOutDeviceResult<unknown> & { device: DeviceProfile }>>();
+  for (const r of results) {
+    const g = platformGroupLabel(r.device.platform);
+    (grouped.get(g) ?? grouped.set(g, []).get(g)!).push(r);
+  }
+
+  for (const group of GROUP_ORDER) {
+    const members = grouped.get(group);
+    if (!members || members.length === 0) continue;
+    members.sort((a, b) => {
+      const aSelf = a.name.toLowerCase() === self.toLowerCase();
+      const bSelf = b.name.toLowerCase() === self.toLowerCase();
+      return (aSelf ? -1 : bSelf ? 1 : 0) || a.name.localeCompare(b.name);
+    });
+    console.log(chalk.bold(group));
+    for (const r of members) {
+      const isSelf = r.name.toLowerCase() === self.toLowerCase();
+      const prefix = isSelf ? chalk.cyan('▸') : ' ';
+      let glyph: string;
+      let text: string;
+      if (r.status === 'skipped') {
+        glyph = chalk.gray('○');
+        text = chalk.gray(String(r.reason ?? 'skipped'));
+      } else if (r.status === 'failed') {
+        glyph = chalk.red('✕');
+        text = chalk.red(String(r.error ?? 'unreachable').split('\n')[0].slice(0, 80));
+      } else {
+        glyph = chalk.green('●');
+        text = summarizeResult(command, forwarded, r.value);
+      }
+      const selfNote = isSelf ? chalk.cyan('   ← this machine') : '';
+      console.log(` ${prefix} ${r.name.padEnd(nameW)}  ${glyph}  ${text}${selfNote}`);
+    }
+    console.log('');
+  }
+
+  if (summaryParts.length) {
+    console.log(chalk.gray(summaryParts.join(' · ')));
+  }
+}
+
+/** Run `agents <command> …` across every registered device and render the roster. */
+export async function runFleetPassthrough(
+  command: string,
+  allArgs: string[],
+  spec: RemoteSpec,
+  opts: FleetPassthroughOptions = {},
+): Promise<boolean> {
+  const self = opts.self ?? machineId();
+  const registry = await (opts.loadDevices ?? loadDevices)();
+  const planned = planFleetTargets(registry);
+  const targets: FleetTargetWithDevice[] = planned.map((t) => ({
+    name: t.device.name,
+    device: t.device,
+    skip: t.skip,
+  }));
+
+  const forwarded = buildFleetForwardedArgs(allArgs);
+  const runner = opts.runner ?? runOnDevice;
+  const localRunner = opts.localRunner ?? runLocalCommand;
+
+  const results = await fanOutDevices<unknown, FleetTargetWithDevice>(
+    targets,
+    async (target) => {
+      const cmd = ['agents', ...forwarded];
+      const isSelf = target.device.name.toLowerCase() === self.toLowerCase();
+      const res = isSelf ? localRunner(cmd) : runner(target.device, cmd);
+      if (res.code !== 0) {
+        const detail = (res.stderr || res.stdout || 'unreachable').trim().slice(0, 200);
+        throw new Error(detail || 'unreachable');
+      }
+      return safeJsonParse(res.stdout);
+    },
+    { perDeviceTimeoutMs: 120_000 },
+  );
+
+  // Map fan-out results back to typed results with device attached for rendering.
+  const typedResults: Array<FanOutDeviceResult<unknown> & { device: DeviceProfile }> = results.map((r, i) => ({
+    ...r,
+    device: targets[i].device,
+  }));
+
+  if (allArgs.includes('--json')) {
+    const out: Record<string, unknown> = {};
+    for (const r of typedResults) {
+      out[r.name] = r.status === 'ok' ? r.value : { error: r.error ?? r.reason ?? 'unknown' };
+    }
+    console.log(JSON.stringify(out, null, 2));
+  } else {
+    renderFleetRoster(command, forwarded, typedResults, self);
+  }
+
+  const anyFailed = typedResults.some((r) => r.status === 'failed');
+  process.exitCode = anyFailed ? 1 : 0;
+  return true;
+}
+
 /**
  * Route `agents <command> … --host <name>` to a remote if the command is
  * host-routable and a `--host` (or its `--device` alias) was given. Returns
@@ -180,11 +429,20 @@ async function resolveTargetHost(name: string, any: boolean): Promise<Host> {
  * @param command the resolved subcommand name (`process.argv`'s first non-flag).
  * @param allArgs `process.argv.slice(2)` — the command name followed by its args.
  */
-export async function maybeRunOnHost(command: string, allArgs: string[]): Promise<boolean> {
+export async function maybeRunOnHost(
+  command: string,
+  allArgs: string[],
+  opts?: FleetPassthroughOptions,
+): Promise<boolean> {
   const hostFlag = flagValue(allArgs, 'host', 'H');
   const deviceFlag = flagValue(allArgs, 'device');
+  const hostsFlag = flagValue(allArgs, 'hosts');
+  const devicesFlag = flagValue(allArgs, 'devices');
   const hostName = hostFlag ?? deviceFlag;
-  if (!hostName) return false;
+  const fleetAll = isFleetAllSentinel(hostFlag, deviceFlag, hostsFlag, devicesFlag);
+  // Proceed when any routing flag is present, including the plural fleet flags
+  // that may carry the `all` sentinel.
+  if (!hostName && !hostsFlag && !devicesFlag) return false;
 
   // Commands with their own richer --host semantics must reach local commander
   // BEFORE any single-target conflict gate. sessions/feed merge --host and
@@ -207,12 +465,15 @@ export async function maybeRunOnHost(command: string, allArgs: string[]): Promis
     }
   }
 
-  // `--hosts` is always a generic fleet flag — bail for every command so the
-  // local aggregator handles it. `--devices` is fan-out on most commands but
-  // a placement flag on `routines` (which devices may run the routine), so
-  // only exempt routines from the bail.
-  if (allArgs.includes('--hosts')) return false;
-  if (allArgs.includes('--devices') && command !== 'routines') return false;
+  // `--hosts` / `--devices` are command-level fleet flags unless their value is
+  // the `all` sentinel, which this module fans out generically. On `routines`,
+  // a non-all `--devices` value is placement (which devices may run the routine).
+  if (allArgs.includes('--hosts') && hostsFlag?.toLowerCase() !== 'all') return false;
+  if (allArgs.includes('--devices')) {
+    if (devicesFlag === undefined) return false; // malformed, let commander error
+    const isAll = devicesFlag.toLowerCase() === 'all';
+    if (!isAll && command !== 'routines') return false;
+  }
 
   const spec = REMOTE_PASSTHROUGH[command];
   if (!spec) {
@@ -230,13 +491,24 @@ export async function maybeRunOnHost(command: string, allArgs: string[]): Promis
     return true;
   }
 
-  // Single-target remote path only: reject a conflicting --host/--device pair
-  // rather than silently preferring one (same rule as `agents run`).
+  // Reject a conflicting --host/--device pair before either the fleet fan-out
+  // or single-target path runs. Equal values (e.g. both `all`) are allowed.
   if (hostFlag && deviceFlag && hostFlag !== deviceFlag) {
     console.error(chalk.red('Conflicting --host/--device values — pass just one.'));
     process.exitCode = 1;
     return true;
   }
+
+  // Generic fleet fan-out for the `all` sentinel — before single-host resolution
+  // so `all` is never treated as a literal hostname.
+  if (fleetAll) {
+    return runFleetPassthrough(command, allArgs, spec, opts);
+  }
+
+  // After the bailouts and fleet fan-out above, the only remaining path is a
+  // single-target --host/--device. Guard for the type checker: plural non-all
+  // flags and bare flags were already handled.
+  if (!hostName) return false;
 
   // Running against your own machine is just a local run — skip the SSH round-trip.
   // `machineId()` is the same self-identifier the device registry and session


### PR DESCRIPTION
Implements the generic `all` sentinel in the passthrough so any fleet-aware command fans out across every registered device.

### What changed
- `maybeRunOnHost` special-cases `--host all`, `--device all`, `--hosts all`, and `--devices all` before single-host resolution.
- Fans out `agents <cmd> --json` per device using `planFleetTargets` + `fanOutDevices` + `runOnDevice`/`runLocalCommand`.
- Renders a grouped-by-OS roster: `●` installed, `○` offline/skipped/control, `▸ … ← this machine`.
- Offline / no-address / control devices render as rows and never hang the run.
- Command-specific summarizers for `view` and `output`; `--json` emits a device-keyed object.
- Docs: `lib/hosts/option.ts`, `docs/hosts.md`, `README.md`, `CHANGELOG.md`.

### Proof
```
$ agents view kimi --device all
view kimi · 17 devices

macOS
   bismas-macbook-pro  ✕  ssh: Could not resolve hostname ...
   mac-mini            ●  0.19.2 · active
   zion                ●  0.19.2 · active

Linux
 ▸ yosemite-s1         ●  0.19.2 · active   ← this machine
   gpu-box             ✕  ssh: Could not resolve hostname ...
   my-iphone           ○  control
   yosemite-m0         ●  0.29.0 · active
   ...

Windows
   win-mini            ✕  ...
   winbox              ✕  ...

Other
   my-ipad             ○  control

11 installed · 4 unreachable · 2 skipped
```

`agents output --device all` and `agents view --device all --json` work too.

### Tests
`bun test src/lib/hosts/passthrough.test.ts src/lib/hosts/option.test.ts` — 33 pass.

Linear: https://linear.app/getrush/issue/RUSH-1969