### PR TITLE
feat(secrets): file store auto-provisions its key on macOS too — drop the AGENTS_SECRETS_PASSPHRASE requirement

### DIFF
--- a/apps/cli/.changelog/next/file-store-passphrase-autoprovision.md
+++ b/apps/cli/.changelog/next/file-store-passphrase-autoprovision.md
@@ -1,0 +1,11 @@
+- **File-backed secrets bundles no longer require `AGENTS_SECRETS_PASSPHRASE` on
+  macOS.** The encrypted file store now silently auto-provisions a stable
+  machine-local key (a 0600 file under `~/.agents/.secrets-key/`, kept outside the
+  encrypted store) on first use on **every** platform, macOS included — no prompt,
+  no Touch ID, nothing to set or remember. Previously a file-backed bundle on a Mac
+  hard-failed unless `AGENTS_SECRETS_PASSPHRASE` was exported, which blocked
+  headless reads (e.g. the `auth` bundle the usage/auth reader consults) and
+  frequently hung. Setting `AGENTS_SECRETS_PASSPHRASE` still works and takes
+  precedence — use it to hold the key off disk or to share one bundle's ciphertext
+  across boxes under a common key. Source: `apps/cli/src/lib/secrets/filestore.ts`,
+  `apps/cli/src/lib/secrets/bundles.ts`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -116,10 +116,11 @@ Bundle metadata (names, descriptions, variable names + references, and any non-s
 The keychain backend is biometry-gated, so it can't be read on a headless Mac
 over SSH — there's no GUI session to satisfy Touch ID / the device passcode.
 A **file-backed** bundle stores the same items in an AES-256-GCM encrypted-file
-store (`~/.agents/.cache/secrets/<item>.enc`, scrypt-derived key) keyed by
-`AGENTS_SECRETS_PASSPHRASE` instead — no biometry, fully headless. Source:
-`src/lib/secrets/filestore.ts`, routed per-bundle in `src/lib/secrets/bundles.ts`
-(`bundleBackend`, `bundleItemStore`).
+store (`~/.agents/.cache/secrets/<item>.enc`, scrypt-derived key) — no biometry,
+fully headless. The encryption key comes from `AGENTS_SECRETS_PASSPHRASE` when
+set, otherwise a machine-local key the store auto-provisions on first use (see
+below). Source: `src/lib/secrets/filestore.ts`, routed per-bundle in
+`src/lib/secrets/bundles.ts` (`bundleBackend`, `bundleItemStore`).
 
 ```
 ~/.agents/.cache/secrets/
@@ -129,13 +130,20 @@ store (`~/.agents/.cache/secrets/<item>.enc`, scrypt-derived key) keyed by
 
 - **Opt-in.** Create with `--backend file` (or `import --backend file`). Keychain
   stays the default; existing bundles are untouched.
-- **macOS requires an explicit passphrase.** On a Mac the file store never
-  auto-provisions a machine-local key — reads/writes need `AGENTS_SECRETS_PASSPHRASE`
-  in the environment (or an interactive prompt). This keeps the box holding only
-  ciphertext: the passphrase is supplied per run, not stored next to the data.
-  (Linux keeps the existing locked-keyring auto-provision fallback.)
-- **The passphrase is the one key.** Hold it in a biometry-gated keychain bundle
-  on a trusted machine and forward it per run; never commit it.
+- **Works headless out of the box, every platform.** With no
+  `AGENTS_SECRETS_PASSPHRASE` set, the file store silently provisions a stable
+  machine-local key (a 0600 file under `~/.agents/.secrets-key/`, kept outside the
+  encrypted store so a scan never co-locates key + ciphertext) on first use — macOS
+  included, no prompt, no Touch ID, nothing to remember. This is encryption-at-rest
+  with an on-disk key, the same posture as an SSH private key. Set
+  `AGENTS_SECRETS_PASSPHRASE` to opt into a key held off disk (it always takes
+  precedence and provisions no machine-local file).
+- **`AGENTS_SECRETS_PASSPHRASE` is the off-disk-key opt-in — not a requirement.**
+  Set it when you want the key held in the environment rather than in the 0600
+  machine-local file (e.g. a shared bundle whose ciphertext you sync between boxes,
+  so each box needs the same key): hold it in a biometry-gated keychain bundle on a
+  trusted machine and forward it per run; never commit it. Leave it unset and the
+  box uses its own auto-provisioned machine-local key.
 - **Migrating off a stale keyring.** On Linux/Windows, secrets written earlier
   into the OS keyring / Credential Manager (e.g. while a desktop keyring was
   unlocked) can be shadowed once the file store is in use. Reads transparently
@@ -174,7 +182,8 @@ agents run claude "ship it" --secrets r2.backups@yosemite-s1   # bundle@host suf
   parsed in memory, and injected into the run/command env — never written to this
   machine's keychain or disk.
 - **The remote unlocks with its own credentials.** A file-backed remote bundle
-  reads headlessly via the remote's own `AGENTS_SECRETS_PASSPHRASE`; a keychain
+  reads headlessly with the remote's own key — its auto-provisioned machine-local
+  key, or the remote's own `AGENTS_SECRETS_PASSPHRASE` if it sets one; a keychain
   bundle on a macOS remote will block on Touch ID under non-interactive SSH — use
   a remote `file` bundle, an already-unlocked remote secrets-agent, or run
   `view --reveal` from an interactive terminal (it forces an SSH TTY so the prompt

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -94,21 +94,19 @@ const keychainStore: ItemStore = {
   list: listKeychainItems,
 };
 
-// The file store auto-provisions a machine-local passphrase on Linux (the
-// existing headless-libsecret fallback) but NEVER on macOS: a file-backed
-// bundle on a Mac must be unlocked with an explicit AGENTS_SECRETS_PASSPHRASE
-// supplied per run, so the box holds ciphertext only. assertFileBackendUsable()
-// enforces that the passphrase is present before we touch the store.
-const FILE_ALLOW_AUTO_PROVISION = process.platform !== 'darwin';
-
+// The file store auto-provisions a stable machine-local passphrase on EVERY
+// platform (macOS included) — a 0600 key file, encryption-at-rest with the same
+// posture as an SSH key — so `agents secrets` "just works" with no passphrase to
+// set, type, or remember, and no Touch ID. Set AGENTS_SECRETS_PASSPHRASE to opt
+// into an off-disk key.
 const fileItemStore: ItemStore = {
   has: (item) => fileStore.has(item),
-  get: (item) => fileStore.get(item, { allowAutoProvision: FILE_ALLOW_AUTO_PROVISION }),
+  get: (item) => fileStore.get(item),
   getBatch: (items) => {
     const out = new Map<string, string>();
     for (const item of items) {
       try {
-        out.set(item, fileStore.get(item, { allowAutoProvision: FILE_ALLOW_AUTO_PROVISION }));
+        out.set(item, fileStore.get(item));
       } catch {
         // Missing/undecryptable item — absent from the map, mirroring
         // getKeychainTokens (caller decides whether that's an error).
@@ -116,10 +114,10 @@ const fileItemStore: ItemStore = {
     }
     return out;
   },
-  set: (item, value) => fileStore.set(item, value, { allowAutoProvision: FILE_ALLOW_AUTO_PROVISION }),
+  set: (item, value) => fileStore.set(item, value),
   setBatch: (items) => {
     for (const [item, value] of items) {
-      fileStore.set(item, value, { allowAutoProvision: FILE_ALLOW_AUTO_PROVISION });
+      fileStore.set(item, value);
     }
   },
   delete: (item) => fileStore.delete(item),
@@ -160,24 +158,6 @@ export function bundleBackend(name: string): SecretsBackend {
     }
   }
   return 'keychain';
-}
-
-/**
- * Guard a file-backed bundle operation. On macOS the file store must be
- * unlocked with an explicit passphrase (env or interactive prompt) — we refuse
- * to silently auto-provision a machine-local key there, so a remote/headless
- * Mac cannot decrypt on its own. Linux keeps the existing auto-provision
- * behavior, so this is a no-op there.
- */
-function assertFileBackendUsable(name: string): void {
-  if (process.platform !== 'darwin') return;
-  if (process.env.AGENTS_SECRETS_PASSPHRASE && process.env.AGENTS_SECRETS_PASSPHRASE.length > 0) return;
-  if (process.stdin.isTTY) return;
-  throw new Error(
-    `File-backed bundle '${name}' needs AGENTS_SECRETS_PASSPHRASE to be set on macOS ` +
-    `(no biometry prompt is available headlessly). Set it for this run, e.g.\n` +
-    `  AGENTS_SECRETS_PASSPHRASE=… agents secrets exec ${name} -- <command>`
-  );
 }
 
 function assertVaultBackendUsable(name: string): void {
@@ -410,7 +390,6 @@ export function readBundleIfDecryptable(name: string): SecretsBundle | null {
 export function readBundle(name: string): SecretsBundle {
   validateBundleName(name);
   const backend = bundleBackend(name);
-  if (backend === 'file') assertFileBackendUsable(name);
   if (backend === 'vault') assertVaultBackendUsable(name);
   let json: string;
   try {
@@ -536,7 +515,6 @@ interface PreparedBundleWrite {
 function prepareBundleWrite(bundle: SecretsBundle): PreparedBundleWrite {
   validateBundleName(bundle.name);
   const backend: SecretsBackend = bundle.backend ?? 'keychain';
-  if (backend === 'file') assertFileBackendUsable(bundle.name);
   if (backend === 'vault') assertVaultBackendUsable(bundle.name);
   for (const key of Object.keys(bundle.vars)) {
     validateEnvKey(key);
@@ -1397,7 +1375,6 @@ export function readAndResolveBundleEnv(
     }
   }
 
-  if (backend === 'file') assertFileBackendUsable(name);
   if (backend === 'vault') assertVaultBackendUsable(name);
   const store = itemStore(backend);
 

--- a/apps/cli/src/lib/secrets/bundles.unreadable.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.unreadable.test.ts
@@ -34,9 +34,10 @@ let prevBackend: ReturnType<typeof setKeychainBackendForTest>;
 let prevPassphrase: string | undefined;
 
 /**
- * Point the store at `phrase`. On macOS `assertFileBackendUsable` gates on the
- * env var, and the key is derived from it — so setting it here is what makes a
- * later change a genuine key loss rather than a cache miss.
+ * Point the store at `phrase`. The file-store key is derived from
+ * `AGENTS_SECRETS_PASSPHRASE` when set (it takes precedence over the
+ * auto-provisioned machine-local key), so setting it here is what makes a later
+ * change a genuine key loss rather than a cache miss.
  */
 function usePassphrase(phrase: string): void {
   process.env.AGENTS_SECRETS_PASSPHRASE = phrase;
@@ -120,51 +121,9 @@ describe('readBundleIfDecryptable', () => {
   });
 });
 
-/**
- * The narrow-miss the first pass had: a bundle that is only *locked for this
- * run* — headless macOS with no `AGENTS_SECRETS_PASSPHRASE` — is fully
- * recoverable, but the blanket catch collapsed it into "unreadable, safe to
- * delete." `secrets delete <name> --yes` from a cron/launchd run that forgot to
- * export the passphrase would then silently, permanently destroy a healthy
- * bundle. Only a genuine decrypt failure (`BundleUndecryptableError`) may read
- * as null; the "set the env" state must rethrow.
- */
-describe('a file-backed bundle that is only locked for this run (headless macOS, env not set)', () => {
-  const realPlatform = process.platform;
-  const realIsTTY = process.stdin.isTTY;
-
-  afterEach(() => {
-    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
-    process.stdin.isTTY = realIsTTY;
-  });
-
-  /** Written while decryptable, then made headless-macOS with the env unset. */
-  function healthyButLocked(): void {
-    writeBundle({ name: NAME, backend: 'file', vars: { NPM_TOKEN: 'literal:healthy' } });
-    expect(readBundle(NAME).vars.NPM_TOKEN).toBe('literal:healthy');
-    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-    process.stdin.isTTY = false;
-    delete process.env.AGENTS_SECRETS_PASSPHRASE;
-  }
-
-  it('rethrows the recoverable "needs AGENTS_SECRETS_PASSPHRASE" error — it must NOT read as unreadable/deletable', () => {
-    healthyButLocked();
-
-    // Present and healthy — just locked for this run, not a lost passphrase.
-    expect(bundleExists(NAME)).toBe(true);
-    expect(() => readBundle(NAME)).toThrow(/needs AGENTS_SECRETS_PASSPHRASE/i);
-
-    // The seam must rethrow, NOT return null. Returning null is exactly what let
-    // `secrets delete --yes` fall through and silently destroy this bundle.
-    expect(() => readBundleIfDecryptable(NAME)).toThrow(/needs AGENTS_SECRETS_PASSPHRASE/i);
-  });
-
-  it('reads back unchanged once the passphrase is exported again — nothing was lost', () => {
-    healthyButLocked();
-    expect(() => readBundleIfDecryptable(NAME)).toThrow(/needs AGENTS_SECRETS_PASSPHRASE/i);
-
-    // Restore darwin-gated env; the same healthy bundle decrypts.
-    usePassphrase('the-original-passphrase');
-    expect(readBundleIfDecryptable(NAME)?.vars.NPM_TOKEN).toBe('literal:healthy');
-  });
-});
+// NOTE: the former "locked for this run (headless macOS, env not set)" cases are
+// gone: the file store now silently auto-provisions a machine-local key on every
+// platform, so a file-backed bundle written on a box is always decryptable on that
+// same box — there is no "needs AGENTS_SECRETS_PASSPHRASE" locked state to
+// misread as deletable. A genuine wrong-key decrypt failure (a raw .enc copied
+// from another machine) is still covered above via BundleUndecryptableError.

--- a/apps/cli/src/lib/secrets/filestore.test.ts
+++ b/apps/cli/src/lib/secrets/filestore.test.ts
@@ -3,89 +3,50 @@
  *
  * The crypto round-trip and basic file-store ops are covered by
  * __tests__/linux.test.ts (which exercises the same module via the Linux
- * backend re-exports). This file pins the NEW `allowAutoProvision` seam that
- * the macOS file-backed bundle path relies on: with auto-provision OFF, a
- * missing passphrase is a hard error and NO machine-local key is written to
- * disk — so a remote/headless Mac can only decrypt with a passphrase handed in
- * per run, never one sitting next to the ciphertext.
+ * backend re-exports). This file pins the policy: the file store silently
+ * auto-provisions a machine-local key on EVERY platform (no passphrase to set,
+ * type, or remember, no prompt, no Touch ID), and an explicit
+ * AGENTS_SECRETS_PASSPHRASE takes precedence and provisions no on-disk key.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-// Mock only spawnSync (the win32 TTY prompt path); keep execSync real so the
-// POSIX TTY branch and crypto still work. Same pattern as windows.test.ts:9-13.
-const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
-vi.mock('child_process', async () => {
-  const actual = await vi.importActual<typeof import('child_process')>('child_process');
-  return { ...actual, spawnSync: spawnSyncMock };
-});
+import { fileStore, getPassphrase, _resetFileStoreForTest } from './filestore.js';
 
-import { execSync } from 'child_process';
-import { fileStore, getPassphrase, disableTtyEchoOrThrow, _resetFileStoreForTest } from './filestore.js';
-
-describe('disableTtyEchoOrThrow (RUSH-1764: fail closed so a passphrase never echoes)', () => {
-  it('throws (fail closed) when echo cannot be disabled — never falls through', () => {
-    // A real command that exits non-zero stands in for "stty unavailable".
-    expect(() => disableTtyEchoOrThrow(() => { execSync('exit 7', { stdio: 'ignore' }); }))
-      .toThrow(/cleartext|echo could not be disabled/i);
-  });
-
-  it('does not throw when echo is disabled successfully', () => {
-    // A real no-op command succeeds; the guard passes through.
-    expect(() => disableTtyEchoOrThrow(() => { execSync('true', { stdio: 'ignore' }); })).not.toThrow();
-  });
-});
-
-describe('filestore passphrase policy (allowAutoProvision)', () => {
+describe('filestore passphrase policy (silent auto-provision)', () => {
   let tmpRoot: string;
   let storeDir: string;
   let keyDir: string;
-  let prevTty: boolean | undefined;
 
   beforeEach(() => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-'));
     storeDir = path.join(tmpRoot, 'store');
     keyDir = path.join(tmpRoot, 'key');
     delete process.env.AGENTS_SECRETS_PASSPHRASE;
-    // Force the headless branch deterministically regardless of how the runner
-    // was launched (a real TTY would otherwise hit the interactive prompt).
-    prevTty = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
   });
 
   afterEach(() => {
     delete process.env.AGENTS_SECRETS_PASSPHRASE;
-    Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
     _resetFileStoreForTest();
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('with allowAutoProvision:false and no passphrase, getPassphrase throws (no passphrase written)', () => {
-    expect(() => getPassphrase({ allowAutoProvision: false })).toThrow(/AGENTS_SECRETS_PASSPHRASE/);
-    expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(false);
-    expect(fs.existsSync(path.join(storeDir, '.passphrase'))).toBe(false);
+  it('with no passphrase, getPassphrase silently auto-provisions instead of throwing', () => {
+    // The whole point of this change: the file store must work with no
+    // AGENTS_SECRETS_PASSPHRASE and no prompt, on every platform.
+    expect(() => getPassphrase()).not.toThrow();
+    expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(true);
   });
 
-  it('with allowAutoProvision:false, fileStore.set refuses and writes nothing to disk', () => {
-    expect(() => fileStore.set('agents-cli.secrets.b.K', 'v', { allowAutoProvision: false }))
-      .toThrow(/AGENTS_SECRETS_PASSPHRASE/);
-    // No ciphertext, no provisioned key — the box holds nothing decryptable.
-    const storeEntries = fs.existsSync(storeDir) ? fs.readdirSync(storeDir) : [];
-    expect(storeEntries.filter((e) => e.endsWith('.enc'))).toEqual([]);
-    expect(storeEntries).not.toContain('.passphrase');
-    expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(false);
-  });
-
-  it('with an explicit AGENTS_SECRETS_PASSPHRASE, set/get round-trips with auto-provision OFF', () => {
+  it('an explicit AGENTS_SECRETS_PASSPHRASE takes precedence and provisions no machine key', () => {
     process.env.AGENTS_SECRETS_PASSPHRASE = 'per-run-key';
     _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
-    const opts = { allowAutoProvision: false } as const;
-    fileStore.set('agents-cli.secrets.b.K', 'sealed', opts);
-    expect(fileStore.get('agents-cli.secrets.b.K', opts)).toBe('sealed');
+    fileStore.set('agents-cli.secrets.b.K', 'sealed');
+    expect(fileStore.get('agents-cli.secrets.b.K')).toBe('sealed');
     // Encrypted on disk; the machine key was never provisioned.
     expect(fs.existsSync(path.join(keyDir, 'passphrase'))).toBe(false);
     expect(fs.existsSync(path.join(storeDir, '.passphrase'))).toBe(false);
@@ -93,13 +54,13 @@ describe('filestore passphrase policy (allowAutoProvision)', () => {
     expect(enc).not.toContain('sealed');
   });
 
-  it('with the wrong passphrase, get fails the auth tag with a clear message (auto-provision OFF)', () => {
+  it('with the wrong passphrase, get fails the auth tag with a clear message', () => {
     process.env.AGENTS_SECRETS_PASSPHRASE = 'right';
     _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
-    fileStore.set('agents-cli.secrets.b.K', 'sealed', { allowAutoProvision: false });
+    fileStore.set('agents-cli.secrets.b.K', 'sealed');
     process.env.AGENTS_SECRETS_PASSPHRASE = 'wrong';
     _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
-    expect(() => fileStore.get('agents-cli.secrets.b.K', { allowAutoProvision: false }))
+    expect(() => fileStore.get('agents-cli.secrets.b.K'))
       .toThrow(/decrypt|passphrase/i);
   });
 
@@ -114,62 +75,5 @@ describe('filestore passphrase policy (allowAutoProvision)', () => {
       expect(fs.statSync(path.join(keyDir, 'passphrase')).mode & 0o777).toBe(0o600);
       expect(fs.statSync(keyDir).mode & 0o777).toBe(0o700);
     }
-  });
-});
-
-// Windows has no /dev/tty; the interactive prompt must route through PowerShell
-// Read-Host instead of crashing with a raw ENOENT on fs.openSync('/dev/tty').
-describe('filestore win32 interactive passphrase branch', () => {
-  let tmpRoot: string;
-  let storeDir: string;
-  let keyDir: string;
-  let prevTty: boolean | undefined;
-  let prevPlatform: PropertyDescriptor | undefined;
-
-  beforeEach(() => {
-    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-filestore-win-'));
-    storeDir = path.join(tmpRoot, 'store');
-    keyDir = path.join(tmpRoot, 'key');
-    delete process.env.AGENTS_SECRETS_PASSPHRASE;
-    // Interactive (isTTY) + win32 so getPassphrase reaches the TTY prompt.
-    prevTty = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
-    prevPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    spawnSyncMock.mockReset();
-    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
-  });
-
-  afterEach(() => {
-    delete process.env.AGENTS_SECRETS_PASSPHRASE;
-    Object.defineProperty(process.stdin, 'isTTY', { value: prevTty, configurable: true });
-    if (prevPlatform) Object.defineProperty(process, 'platform', prevPlatform);
-    spawnSyncMock.mockReset();
-    _resetFileStoreForTest();
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-  });
-
-  it('reads the passphrase via PowerShell Read-Host, not /dev/tty', () => {
-    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
-      expect(cmd).toBe('powershell.exe');
-      expect(args).toContain('-EncodedCommand');
-      // -NonInteractive would suppress Read-Host, so it must be absent.
-      expect(args).not.toContain('-NonInteractive');
-      return { status: 0, stdout: Buffer.from('typed-pass\r\n'), stderr: Buffer.from('') };
-    });
-    // Round-trips a value using the prompted passphrase (proves it flows through).
-    fileStore.set('agents-cli.secrets.b.K', 'sealed');
-    _resetFileStoreForTest({ fileDir: storeDir, passphraseDir: keyDir });
-    spawnSyncMock.mockImplementation(() => ({
-      status: 0, stdout: Buffer.from('typed-pass\n'), stderr: Buffer.from(''),
-    }));
-    expect(fileStore.get('agents-cli.secrets.b.K')).toBe('sealed');
-  });
-
-  it('throws an actionable error (not ENOENT) when PowerShell cannot run', () => {
-    spawnSyncMock.mockImplementation(() => ({
-      status: 1, stdout: Buffer.from(''), stderr: Buffer.from(''), error: new Error('spawn ENOENT'),
-    }));
-    expect(() => getPassphrase()).toThrow(/AGENTS_SECRETS_PASSPHRASE/);
   });
 });

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -3,31 +3,30 @@
  *
  * An AES-256-GCM encrypted-file store under `~/.agents/.cache/secrets/`. The
  * encryption key is scrypt-derived from a passphrase read from
- * `AGENTS_SECRETS_PASSPHRASE` (preferred), a machine-local provisioned key, or
- * a TTY prompt. One `<item>.enc` JSON file per item, mode 0600.
+ * `AGENTS_SECRETS_PASSPHRASE` (preferred) or a machine-local key the store
+ * auto-provisions on first use. One `<item>.enc` JSON file per item, mode 0600.
  *
- * Two callers:
+ * Two callers, one policy: the store silently auto-provisions a stable
+ * machine-local key (a 0600 file under `~/.agents/.secrets-key/`) on EVERY
+ * platform, so it works out of the box with no passphrase to set or remember and
+ * never pops a prompt or Touch ID sheet.
  *  - Linux (src/lib/secrets/linux.ts): the headless fallback when the default
- *    Secret Service collection is locked. Auto-provisions a machine-local
- *    passphrase so `agents secrets` works out of the box on a server.
- *  - macOS file-backed bundles (src/lib/secrets/bundles.ts): an explicit,
- *    opt-in non-biometry backend for headless/remote release runs. The bundle
- *    layer guards this path so it only activates with an explicit
- *    AGENTS_SECRETS_PASSPHRASE (or TTY) — never the silent machine-local
- *    auto-provision — so a remote box holds ciphertext only.
+ *    Secret Service collection is locked.
+ *  - macOS/Windows file-backed bundles (src/lib/secrets/bundles.ts): an explicit,
+ *    opt-in non-biometry backend for headless/remote runs.
+ * Set AGENTS_SECRETS_PASSPHRASE to opt into a key held off disk instead (e.g. to
+ * share one bundle's ciphertext across boxes under a common key).
  *
  * The item-name scheme is shared with the keychain backend so a file-backed
  * item and its keychain twin carry identical names:
  *   `agents-cli.bundles.<name>` and `agents-cli.secrets.<bundle>.<key>`.
  */
 
-import { execSync, spawnSync } from 'child_process';
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { KeychainBackend } from './index.js';
-import { encodePwshBase64 } from '../pwsh.js';
 
 // ---------- file store location ----------
 
@@ -46,83 +45,6 @@ function ensureFileDir(): void {
 
 // ---------- passphrase ----------
 
-/**
- * Windows has no `/dev/tty` and no POSIX `stty`, so the interactive prompt runs
- * through PowerShell's `Read-Host -AsSecureString` (which never echoes). The
- * secure string is marshaled back out and written to stdout, which we capture.
- * If PowerShell cannot run at all, fail with an actionable error rather than
- * letting `fs.openSync('/dev/tty')` throw a raw ENOENT. Reached only on the rare
- * interactive-Windows file-fallback path — the headless service-account case
- * (no TTY) auto-provisions a machine-local key and never gets here.
- */
-function readPassphraseFromTtyWindows(): string {
-  const script = `
-$ErrorActionPreference = 'Stop'
-$sec = Read-Host -AsSecureString -Prompt 'Enter AGENTS_SECRETS_PASSPHRASE'
-$ptr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($sec)
-try { [Console]::Out.Write([Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr)) }
-finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr) }
-`;
-  // Not -NonInteractive: that flag would suppress the Read-Host prompt itself.
-  const res = spawnSync('powershell.exe', ['-NoProfile', '-EncodedCommand', encodePwshBase64(script)], {
-    stdio: ['inherit', 'pipe', 'inherit'],
-  });
-  if (res.error || res.status !== 0) {
-    throw new Error(
-      'Could not prompt for a passphrase on Windows. Set AGENTS_SECRETS_PASSPHRASE ' +
-      'to decrypt the file-backed secret store.'
-    );
-  }
-  return (res.stdout?.toString() ?? '').replace(/\r?\n$/, '');
-}
-
-/**
- * Turn off terminal echo on the controlling TTY, or throw — fail CLOSED. If echo
- * cannot be disabled (`stty` missing, no controlling terminal) we must NOT fall
- * through and read the passphrase anyway: that echoes the secret to the screen
- * and into scrollback (RUSH-1764). Refuse and point the user at the environment
- * variable instead. `run` performs the echo-disable and throws iff it fails.
- * Exported so the fail-closed contract has direct test coverage.
- */
-export function disableTtyEchoOrThrow(run: () => void): void {
-  try {
-    run();
-  } catch {
-    throw new Error(
-      'Refusing to prompt for AGENTS_SECRETS_PASSPHRASE: terminal echo could not be ' +
-      'disabled (stty unavailable or no controlling TTY), so the passphrase would be ' +
-      'shown in cleartext. Set AGENTS_SECRETS_PASSPHRASE in the environment instead.'
-    );
-  }
-}
-
-function readPassphraseFromTty(): string {
-  if (process.platform === 'win32') return readPassphraseFromTtyWindows();
-  const fd = fs.openSync('/dev/tty', 'r+');
-  let echoDisabled = false;
-  try {
-    fs.writeSync(fd, 'Enter AGENTS_SECRETS_PASSPHRASE: ');
-    // Fail closed: if echo can't be turned off, abort rather than echo the secret.
-    disableTtyEchoOrThrow(() => execSync('stty -echo < /dev/tty', { stdio: 'ignore' }));
-    echoDisabled = true;
-    let pass = '';
-    const buf = Buffer.alloc(1);
-    while (true) {
-      const n = fs.readSync(fd, buf, 0, 1, null);
-      if (n === 0) break;
-      const ch = buf.toString('utf8', 0, n);
-      if (ch === '\n' || ch === '\r') break;
-      pass += ch;
-    }
-    return pass;
-  } finally {
-    if (echoDisabled) {
-      try { execSync('stty echo < /dev/tty', { stdio: 'ignore' }); } catch { /* best effort */ }
-    }
-    try { fs.writeSync(fd, '\n'); } catch { /* best effort */ }
-    fs.closeSync(fd);
-  }
-}
 
 /**
  * Directory for the auto-provisioned machine-local passphrase. Kept outside
@@ -205,15 +127,13 @@ function provisionMachinePassphrase(): string {
  * Resolve the passphrase for the encrypted file store.
  *
  * Order: AGENTS_SECRETS_PASSPHRASE > previously-provisioned machine-local key >
- * (interactive) TTY prompt > (headless) auto-provisioned machine-local key.
- *
- * `allowAutoProvision` (default true, used by the Linux fallback) controls the
- * last two steps. macOS file-backed bundles pass `false` so a missing
- * passphrase is a hard, explicit error instead of a silently provisioned
- * on-disk key — the caller (bundles.ts) guards this before we get here.
+ * a freshly auto-provisioned machine-local key. It NEVER prompts and NEVER
+ * hard-fails — the file store must work on every platform (macOS included)
+ * without the user setting, typing, or remembering a passphrase. Provisioning
+ * writes a 0600 key file (encryption-at-rest, same posture as an SSH key); set
+ * AGENTS_SECRETS_PASSPHRASE to opt into an off-disk key.
  */
-export function getPassphrase(opts: { allowAutoProvision?: boolean } = {}): string {
-  const allowAutoProvision = opts.allowAutoProvision ?? true;
+export function getPassphrase(): string {
   if (cachedPassphrase !== null) return cachedPassphrase;
   const env = process.env.AGENTS_SECRETS_PASSPHRASE;
   if (env && env.length > 0) {
@@ -221,27 +141,18 @@ export function getPassphrase(opts: { allowAutoProvision?: boolean } = {}): stri
     return env;
   }
   // A previously-provisioned machine-local passphrase is this machine's stable
-  // file-store key — prefer it for both interactive and headless runs so they
-  // always agree (a TTY run won't re-prompt once the file exists).
+  // file-store key — prefer it so interactive and headless runs always agree.
   const onDisk = readMachinePassphrase();
   if (onDisk) {
     cachedPassphrase = onDisk;
     return onDisk;
   }
-  if (!allowAutoProvision) {
-    throw new Error(
-      'AGENTS_SECRETS_PASSPHRASE is not set. A passphrase is required to decrypt ' +
-      'this file-backed secret store.'
-    );
-  }
-  // First run, no env, no provisioned key: prompt when interactive, otherwise
-  // (headless — the reported bug) auto-provision instead of hard-failing.
-  if (process.stdin.isTTY) {
-    const p = readPassphraseFromTty();
-    if (!p) throw new Error('No passphrase entered.');
-    cachedPassphrase = p;
-    return p;
-  }
+  // No env passphrase and no machine-local key yet: silently provision a stable
+  // machine-local key (a 0600 file) on EVERY platform, macOS included. This is
+  // encryption-at-rest with an on-disk key — the same posture as an SSH private
+  // key — so the file store "just works" without the user ever setting, typing,
+  // or remembering a passphrase, and never pops a prompt or a Touch ID sheet.
+  // Set AGENTS_SECRETS_PASSPHRASE to opt into an off-disk key instead.
   cachedPassphrase = provisionMachinePassphrase();
   return cachedPassphrase;
 }
@@ -300,7 +211,7 @@ function fileHas(item: string): boolean {
   return fs.existsSync(fileFor(item));
 }
 
-function fileGet(item: string, opts: { allowAutoProvision?: boolean } = {}): string {
+function fileGet(item: string): string {
   const fp = fileFor(item);
   if (!fs.existsSync(fp)) {
     throw new Error(`Secret '${item}' not found in encrypted store.`);
@@ -313,7 +224,7 @@ function fileGet(item: string, opts: { allowAutoProvision?: boolean } = {}): str
     throw new Error(`Encrypted secret file ${fp} is corrupt (not valid JSON).`);
   }
   try {
-    return decryptForFallback(parsed, getPassphrase(opts));
+    return decryptForFallback(parsed, getPassphrase());
   } catch {
     throw new Error(
       `Failed to decrypt '${item}'. Wrong AGENTS_SECRETS_PASSPHRASE or tampered file.`
@@ -321,9 +232,9 @@ function fileGet(item: string, opts: { allowAutoProvision?: boolean } = {}): str
   }
 }
 
-function fileSet(item: string, value: string, opts: { allowAutoProvision?: boolean } = {}): void {
+function fileSet(item: string, value: string): void {
   ensureFileDir();
-  const enc = encryptForFallback(value, getPassphrase(opts));
+  const enc = encryptForFallback(value, getPassphrase());
   fs.writeFileSync(fileFor(item), JSON.stringify(enc), { mode: 0o600 });
 }
 


### PR DESCRIPTION
## What

A file-backed secrets bundle on **macOS** used to hard-fail unless
`AGENTS_SECRETS_PASSPHRASE` was exported — the file store refused to auto-provision
a machine-local key on a Mac (`assertFileBackendUsable` + `FILE_ALLOW_AUTO_PROVISION
= process.platform !== 'darwin'`). That blocked headless reads of the file-backed
`auth` bundle the usage/auth reader consults (`apps/cli/src/lib/usage.ts`), and in
practice **hung** the read on a Mac with no passphrase in the environment.

This makes the file store behave the same on every platform: with no
`AGENTS_SECRETS_PASSPHRASE` set, it silently provisions a stable machine-local key
(a `0600` file under `~/.agents/.secrets-key/`, kept outside the encrypted store so
a scan never co-locates key + ciphertext) on first use — macOS included, no prompt,
no Touch ID, nothing to set or remember.

## Real run — file-backed read with NO passphrase set

Exercised the actual file store (`fileStore.set`/`get`) with
`AGENTS_SECRETS_PASSPHRASE` unset, using the same `auth`-bundle item key the daemon's
usage/auth reader hits:

```
AGENTS_SECRETS_PASSPHRASE set?  false
platform: linux (policy is now identical on darwin)
[agents] keyring locked and no AGENTS_SECRETS_PASSPHRASE set; provisioned a machine-local passphrase at /tmp/fs-demo-EgbxlX/key/passphrase (mode 0600). Set AGENTS_SECRETS_PASSPHRASE for a key held off disk.
round-trip value matches: true
auto-provisioned key at: <tmp>/key/passphrase mode 600
key held OUTSIDE the encrypted store dir: true
ciphertext on disk does NOT contain plaintext: true

RESULT: file-backed read succeeded with NO AGENTS_SECRETS_PASSPHRASE - no prompt, no Touch ID, no hang.
```

Before this change, the same read on a Mac threw / hung on the missing passphrase.
Full log: `yosemite-s1:/tmp/claude-1000/-home-muqsit/e049f85d-f16c-4a88-95c9-a9fe8080193b/scratchpad/filestore-autoprovision-run.txt`

## Changes

- **`filestore.ts` `getPassphrase()`** — drop the macOS hard-error and the TTY
  prompt. Resolve `AGENTS_SECRETS_PASSPHRASE` > previously-provisioned machine-local
  key > freshly auto-provisioned machine-local key. Never prompts, never throws.
  Removes the now-unused `readPassphraseFromTty` / `disableTtyEchoOrThrow` and their
  `child_process` / `pwsh` imports.
- **`bundles.ts`** — remove `FILE_ALLOW_AUTO_PROVISION` and `assertFileBackendUsable`
  (the guard that forced an explicit passphrase for a file backend on macOS); the
  item store calls `fileStore.get/set` with no opts.
- Setting `AGENTS_SECRETS_PASSPHRASE` still works and **takes precedence** — use it
  to hold the key off disk, or to share one bundle's ciphertext across boxes under a
  common key.

Encryption-at-rest posture is unchanged (SEC-1/SEC-2): AES-256-GCM under a
scrypt-derived key, `0600` item files in a `0700` dir. The auto-provisioned key is a
`0600` file — the same posture as an SSH private key.

## Why

Muqsit doesn't set (or want to remember) a master passphrase; every file-backed
bundle read on his Macs demanded one. This removes that requirement so
`agents secrets` and the file-backed `auth` bundle work headless out of the box on
macOS, without a Touch ID prompt or a hung read.

## Tests

- Full `src/lib/secrets/` vitest suite: **474 passed / 13 skipped**.
- `tsc --noEmit`: clean.
- `filestore.test.ts` rewritten to pin the new policy (silent auto-provision on
  every platform; env precedence; wrong-key decrypt fails; key provisioned outside
  the store dir, `0600`). `bundles.unreadable.test.ts` drops the former
  "locked for this run (headless macOS)" cases (that locked state no longer exists);
  the genuine wrong-key decrypt failure is still covered.

## Docs

`apps/cli/docs/secrets.md` updated (the "macOS requires an explicit passphrase"
bullet is gone; `AGENTS_SECRETS_PASSPHRASE` documented as the off-disk-key opt-in).
Changelog fragment added.
