### PR TITLE
feat: surface Cursor account + usage bar in agents view

### DIFF
--- a/apps/cli/.changelog/next/cursor-usage.md
+++ b/apps/cli/.changelog/next/cursor-usage.md
@@ -1,0 +1,7 @@
+- **`agents view` now surfaces the Cursor account and its usage.** Cursor was
+  absent from the account view; it now shows the signed-in account (email/authId
+  from `~/.cursor/cli-config.json`, token from `~/.config/cursor/auth.json`) and,
+  for request-capped (free/legacy) plans, a monthly request bar (`M`) from
+  `cursor.com/api/usage`. Usage-based plans have no request cap, so they render the
+  account row without a bar. Source: `apps/cli/src/lib/usage.ts`,
+  `apps/cli/src/lib/agents.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -723,6 +723,7 @@ contains — this is a data-availability limit, not a policy choice:
 | Grok | email + tier | last-seen (`~/.grok/logs/unified.jsonl`) | email from the local auth file; weekly window (`W`) + subscription tier parsed from the newest `billing: fetched credits config` log line, since Grok's network usage endpoints 404 |
 | Droid | email | live (`api.factory.ai`) | `~/.factory/auth.v2.file` is AES-256-GCM (key on disk at `auth.v2.key`); decrypt locally, read the email from the WorkOS access-token JWT. That same token authorizes `GET /api/billing/limits` for the three rolling rate-limit windows (5-hour → `S`, weekly → `W`, monthly, detailed-view only). |
 | Kimi | `id:<user_id>` + tier | live (`api.kimi.com/coding/v1/usages`) | JWT carries no email — only an opaque `user_id`. Quota + membership tier come from the `/usages` endpoint. |
+| Cursor | email | live (`cursor.com/api/usage`) | email/authId from `~/.cursor/cli-config.json`; access token from `~/.config/cursor/auth.json`. The endpoint is authed with a `WorkosCursorSessionToken=<authId>::<token>` cookie and returns a monthly request bar (`M`) for request-capped (free/legacy) plans. Usage-based plans report no request cap, so they render the account row without a bar. |
 | Antigravity | `signed in` | — | OAuth grant with no id_token — presence only. File `~/.gemini/antigravity-cli/antigravity-oauth-token`, else macOS keychain / Linux libsecret (`service gemini` + user `antigravity`) |
 | others | `not signed in` unless a credential exists | — | `default` case: no detector |
 

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -21,6 +21,7 @@ import {
   normalizeKimiWindows,
   formatKimiPlan,
   normalizeDroidWindows,
+  normalizeCursorUsage,
   type DroidBillingLimitsResponse,
   type KimiUsagesResponse,
   type UsageSnapshot,
@@ -138,12 +139,39 @@ describe('usage formatting', () => {
   });
 
   it('agentReportsUsage flags only the agents that expose usage data', () => {
-    for (const a of ['claude', 'codex', 'kimi', 'droid', 'grok'] as const) {
+    for (const a of ['claude', 'codex', 'kimi', 'droid', 'grok', 'cursor'] as const) {
       expect(agentReportsUsage(a)).toBe(true);
     }
     for (const a of ['antigravity', 'opencode', 'gemini'] as const) {
       expect(agentReportsUsage(a)).toBe(false);
     }
+  });
+
+  it('normalizeCursorUsage builds a monthly request bar for request-capped plans', () => {
+    // Free / legacy plans carry a maxRequestUsage on the premium bucket.
+    const windows = normalizeCursorUsage({
+      'gpt-4': { numRequests: 120, maxRequestUsage: 500 },
+      startOfMonth: '2026-07-22T11:35:59.000Z',
+    });
+    expect(windows).toHaveLength(1);
+    expect(windows[0]?.key).toBe('month');
+    expect(windows[0]?.shortLabel).toBe('M');
+    expect(windows[0]?.usedPercent).toBe(24); // 120 / 500
+    // Resets one calendar month after startOfMonth.
+    expect(windows[0]?.resetsAt?.toISOString()).toBe(new Date('2026-08-22T11:35:59.000Z').toISOString());
+  });
+
+  it('normalizeCursorUsage returns no window for usage-based plans (no request cap)', () => {
+    // Real usage-based Pro shape: maxRequestUsage is null, so there is no bar to draw.
+    expect(
+      normalizeCursorUsage({
+        'gpt-4': { numRequests: 0, numRequestsTotal: 0, maxRequestUsage: null } as never,
+        startOfMonth: '2026-07-22T11:35:59.000Z',
+      })
+    ).toEqual([]);
+    // Missing premium bucket entirely -> no window, no throw.
+    expect(normalizeCursorUsage({ startOfMonth: '2026-07-22T11:35:59.000Z' })).toEqual([]);
+    expect(normalizeCursorUsage({})).toEqual([]);
   });
 
   it('parses Grok usage from the local unified.jsonl (real log shape)', async () => {

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -161,6 +161,17 @@ describe('usage formatting', () => {
     expect(windows[0]?.resetsAt?.toISOString()).toBe(new Date('2026-08-22T11:35:59.000Z').toISOString());
   });
 
+  it('normalizeCursorUsage clamps a month-end reset instead of overflowing into the next month', () => {
+    // A Jan-31 period start: +1 month must land in February, not spill into March
+    // (naive setMonth(m+1) yields Feb 31 -> Mar 3).
+    const [w] = normalizeCursorUsage({
+      'gpt-4': { numRequests: 10, maxRequestUsage: 100 },
+      startOfMonth: '2026-01-31T12:00:00.000Z',
+    });
+    expect(w?.resetsAt?.getMonth()).toBe(1); // February (1), not March (2)
+    expect(w?.resetsAt?.getDate()).toBeGreaterThanOrEqual(28);
+  });
+
   it('normalizeCursorUsage returns no window for usage-based plans (no request cap)', () => {
     // Real usage-based Pro shape: maxRequestUsage is null, so there is no bar to draw.
     expect(

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -960,6 +960,38 @@ describe('getAccountInfo — grok (nested auth.json)', () => {
   });
 });
 
+describe('getAccountInfo — cursor (cli-config authInfo + separate auth.json)', () => {
+  let prevRealHome: string | undefined;
+  beforeEach(() => { prevRealHome = process.env.AGENTS_REAL_HOME; process.env.AGENTS_REAL_HOME = makeTempDir(); });
+  afterEach(() => {
+    if (prevRealHome === undefined) delete process.env.AGENTS_REAL_HOME;
+    else process.env.AGENTS_REAL_HOME = prevRealHome;
+  });
+
+  it('reads email/authId from cli-config and treats a present access token as signed in', async () => {
+    const home = makeTempDir();
+    fs.mkdirSync(path.join(home, '.cursor'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.config', 'cursor'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.cursor', 'cli-config.json'), JSON.stringify({
+      authInfo: { email: 'muqsitnawaz@gmail.com', userId: 27457401, authId: 'google-oauth2|106748008124572295566' },
+    }));
+    fs.writeFileSync(path.join(home, '.config', 'cursor', 'auth.json'), JSON.stringify({
+      accessToken: 'eyJ.abc.def', refreshToken: 'eyJ.ghi.jkl',
+    }));
+
+    const info = await getAccountInfo('cursor', home);
+    expect(info.signedIn).toBe(true);
+    expect(info.email).toBe('muqsitnawaz@gmail.com');
+    expect(info.accountId).toBe('google-oauth2|106748008124572295566');
+    expect(info.accountKey).toBeTruthy();
+  });
+
+  it('treats cursor as signed out when cli-config is absent', async () => {
+    const info = await getAccountInfo('cursor', makeTempDir());
+    expect(info.signedIn).toBe(false);
+  });
+});
+
 describe('getAccountInfo — Claude organization identity', () => {
   // Fixture shapes below mirror real .claude.json oauthAccount payloads: a
   // personal Max plan carries an auto-generated organizationName while a Team

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1631,6 +1631,34 @@ export async function getAccountInfo(
         const email = data.active || null;
         return { ...empty, email, signedIn: !!email, lastActive };
       }
+      case 'cursor': {
+        // Cursor CLI keeps account metadata in ~/.cursor/cli-config.json
+        // (authInfo: { email, userId, authId }) and its OAuth tokens SEPARATELY
+        // in ~/.config/cursor/auth.json ({ accessToken, refreshToken }). Presence
+        // of an access token is the signed-in signal; email/ids come from
+        // cli-config. authId is the OAuth subject (e.g. "google-oauth2|<n>") — the
+        // same value the usage endpoint keys on (see getCursorUsageInfo).
+        const cfgPath = resolveAccountCredentialPath(base, '.cursor', 'cli-config.json');
+        if (!cfgPath) return { ...empty, lastActive };
+        try {
+          const cfg = JSON.parse(await fs.promises.readFile(cfgPath, 'utf-8'));
+          const authInfo = cfg?.authInfo;
+          const email = typeof authInfo?.email === 'string' ? authInfo.email : null;
+          const accountId = normalizeIdentityPart(authInfo?.authId ?? authInfo?.userId);
+          if (!email && !accountId) return { ...empty, lastActive };
+          const authPath = resolveAccountCredentialPath(base, '.config', 'cursor', 'auth.json');
+          let hasToken = false;
+          if (authPath) {
+            try {
+              const tok = JSON.parse(fs.readFileSync(authPath, 'utf-8'));
+              hasToken = typeof tok?.accessToken === 'string' && tok.accessToken.length > 0;
+            } catch { /* unreadable token file */ }
+          }
+          const accountKey = buildIdentityKey(agentId, [['user', accountId]]);
+          return { ...empty, email, accountId, accountKey, signedIn: hasToken || !!email, lastActive };
+        } catch {}
+        return { ...empty, lastActive };
+      }
       case 'grok': {
         // Grok stores auth in ~/.grok/auth.json as a map keyed by
         // "<oidc_issuer>::<client_id>" -> { email, user_id, refresh_token,

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -2024,16 +2024,21 @@ export function normalizeCursorUsage(data: CursorUsageResponse): UsageWindow[] {
   const premium = data['gpt-4'];
   if (!premium || typeof premium !== 'object') return [];
   const max = premium.maxRequestUsage;
-  if (typeof max !== 'number' || max <= 0) return [];
+  if (typeof max !== 'number' || !Number.isFinite(max) || max <= 0) return [];
   const used = typeof premium.numRequests === 'number' ? premium.numRequests : 0;
 
   const startOfMonth =
     typeof data.startOfMonth === 'string' ? parseDateValue(data.startOfMonth) : null;
-  // The request quota resets one calendar month after the period start.
+  // The request quota resets one calendar month after the period start. Guard the
+  // month-end overflow: setMonth on a day the target month lacks (Jan 31 -> Feb 31)
+  // rolls forward into the month after (Mar 3), so clamp back to the intended
+  // month's last day.
   let resetsAt: Date | null = null;
   if (startOfMonth) {
     resetsAt = new Date(startOfMonth);
+    const intendedMonth = (resetsAt.getMonth() + 1) % 12;
     resetsAt.setMonth(resetsAt.getMonth() + 1);
+    if (resetsAt.getMonth() !== intendedMonth) resetsAt.setDate(0);
   }
 
   return [

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1,5 +1,5 @@
 /**
- * Usage and rate-limit tracking for Claude, Codex, Kimi, Droid, and Grok agents.
+ * Usage and rate-limit tracking for Claude, Codex, Kimi, Droid, Grok, and Cursor agents.
  *
  * Fetches live usage data from each agent's usage API (Anthropic OAuth for
  * Claude, Kimi Code /usages, Factory billing limits for Droid) or parses
@@ -68,6 +68,8 @@ const CACHED_CLAUDE_USAGE_SOURCE_LABEL = 'last seen live account data';
 const KIMI_USAGES_URL = 'https://api.kimi.com/coding/v1/usages';
 
 const DROID_USAGE_URL = 'https://api.factory.ai/api/billing/limits';
+
+const CURSOR_USAGE_URL = 'https://cursor.com/api/usage';
 
 const COMPACT_BAR_LEN = 5;
 const USAGE_BAR_LEN = 10;
@@ -216,6 +218,8 @@ export async function getUsageInfo(agentId: AgentId, options?: UsageOptions): Pr
       return getDroidUsageInfo(options);
     case 'grok':
       return getGrokUsageInfo(options);
+    case 'cursor':
+      return getCursorUsageInfo(options);
     default:
       return { snapshot: null, error: null };
   }
@@ -263,14 +267,21 @@ export function buildCanonicalUsageContext(inputs: UsageIdentityInput[]): {
 }
 
 /**
- * Whether an agent exposes usage/limit data we can render — Claude/Kimi/Droid via
- * a live API, Codex/Grok via local session logs. Everything else has no usage
+ * Whether an agent exposes usage/limit data we can render — Claude/Kimi/Droid/Cursor
+ * via a live API, Codex/Grok via local session logs. Everything else has no usage
  * concept, so callers use this to decide whether a missing snapshot is worth
  * flagging as "usage unavailable" (a signed-in Claude account with no data)
  * versus simply not applicable (Antigravity, OpenCode).
  */
 export function agentReportsUsage(agentId: AgentId): boolean {
-  return agentId === 'claude' || agentId === 'codex' || agentId === 'kimi' || agentId === 'droid' || agentId === 'grok';
+  return (
+    agentId === 'claude' ||
+    agentId === 'codex' ||
+    agentId === 'kimi' ||
+    agentId === 'droid' ||
+    agentId === 'grok' ||
+    agentId === 'cursor'
+  );
 }
 
 /** Fetch usage info for all unique accounts in parallel, keyed by usage key. */
@@ -1983,4 +1994,122 @@ async function readLatestGrokBilling(filePath: string): Promise<GrokBillingMatch
     rl.on('close', () => resolve(latest));
     rl.on('error', () => resolve(latest));
   });
+}
+
+/** Per-model bucket in Cursor's /api/usage response. */
+interface CursorUsageModel {
+  numRequests?: number | null;
+  maxRequestUsage?: number | null;
+}
+
+/** Response shape from Cursor's dashboard usage endpoint. */
+export interface CursorUsageResponse {
+  /** The premium ("fast request") bucket the plan meters. */
+  'gpt-4'?: CursorUsageModel | null;
+  /** ISO timestamp the monthly request window resets from. */
+  startOfMonth?: string | null;
+  [model: string]: CursorUsageModel | string | null | undefined;
+}
+
+/**
+ * Normalize Cursor's /api/usage payload into the common UsageWindow shape.
+ *
+ * Only free / legacy request-capped plans carry a `maxRequestUsage` on the
+ * premium ("gpt-4") bucket — that's the fast-request cap the plan meters, and it
+ * maps cleanly to a monthly window. Usage-based plans report `maxRequestUsage:
+ * null` (no request cap — spend is metered in dollars instead), so they have no
+ * bar to draw here and return no windows rather than a misleading empty gauge.
+ */
+export function normalizeCursorUsage(data: CursorUsageResponse): UsageWindow[] {
+  const premium = data['gpt-4'];
+  if (!premium || typeof premium !== 'object') return [];
+  const max = premium.maxRequestUsage;
+  if (typeof max !== 'number' || max <= 0) return [];
+  const used = typeof premium.numRequests === 'number' ? premium.numRequests : 0;
+
+  const startOfMonth =
+    typeof data.startOfMonth === 'string' ? parseDateValue(data.startOfMonth) : null;
+  // The request quota resets one calendar month after the period start.
+  let resetsAt: Date | null = null;
+  if (startOfMonth) {
+    resetsAt = new Date(startOfMonth);
+    resetsAt.setMonth(resetsAt.getMonth() + 1);
+  }
+
+  return [
+    {
+      key: 'month',
+      label: 'Current month',
+      shortLabel: 'M',
+      usedPercent: Math.max(0, Math.min(100, (used / max) * 100)),
+      resetsAt,
+      windowMinutes: inferWindowMinutes('month'),
+    },
+  ];
+}
+
+/** Read Cursor's OAuth subject + access token from the local CLI config/auth files. */
+function readCursorCredentials(base: string): { sub: string; accessToken: string } | null {
+  try {
+    const cfgPath = path.join(base, '.cursor', 'cli-config.json');
+    const authPath = path.join(base, '.config', 'cursor', 'auth.json');
+    if (!fs.existsSync(cfgPath) || !fs.existsSync(authPath)) return null;
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    const sub = cfg?.authInfo?.authId;
+    const auth = JSON.parse(fs.readFileSync(authPath, 'utf-8'));
+    const accessToken = auth?.accessToken;
+    if (typeof sub !== 'string' || !sub) return null;
+    if (typeof accessToken !== 'string' || !accessToken) return null;
+    return { sub, accessToken };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch Cursor usage from the dashboard usage endpoint. Cursor authenticates the
+ * request with a `WorkosCursorSessionToken` cookie of the form
+ * `<oauth-subject>::<access-token>` (the same pair the web dashboard sends), not a
+ * bearer header. Free/legacy plans return a monthly request bar; usage-based plans
+ * have no request cap, so they return a live-but-window-less snapshot (the account
+ * row still renders, without a misleading empty gauge).
+ */
+async function getCursorUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
+  try {
+    const base = options?.home || os.homedir();
+    const creds = readCursorCredentials(base);
+    if (!creds) return { snapshot: null, error: null };
+
+    const exp = decodeJwtPayload(creds.accessToken)?.exp;
+    if (typeof exp === 'number' && Date.now() / 1000 >= exp) {
+      return { snapshot: null, error: null };
+    }
+
+    const url = `${CURSOR_USAGE_URL}?user=${encodeURIComponent(creds.sub)}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Cookie: `WorkosCursorSessionToken=${creds.sub}%3A%3A${creds.accessToken}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    // 401/redirect => revoked/expired session; render nothing rather than a
+    // misleading empty bar.
+    if (!response.ok) return { snapshot: null, error: null };
+
+    const data = (await response.json()) as CursorUsageResponse;
+    return {
+      snapshot: {
+        source: 'live',
+        sourceLabel: 'live account data',
+        capturedAt: new Date(),
+        windows: normalizeCursorUsage(data),
+      },
+      error: null,
+    };
+  } catch {
+    return { snapshot: null, error: null };
+  }
 }


### PR DESCRIPTION
Adds Cursor to `agents view` — the account row (was absent) plus a usage bar where Cursor exposes one.

**type:** feature (CLI — `apps/cli/src/lib/usage.ts`, `apps/cli/src/lib/agents.ts`)

## What changed
- **Account discovery:** `getAccountInfo` now has a `cursor` case — email/authId from `~/.cursor/cli-config.json`, access token from `~/.config/cursor/auth.json`. Cursor now appears in `agents view` as a signed-in account (previously it wasn't detected at all).
- **Usage bar:** `getCursorUsageInfo` fetches `cursor.com/api/usage` (authed with the `WorkosCursorSessionToken=<authId>::<token>` cookie the dashboard uses) and renders a monthly request bar (`M`) for **request-capped (free/legacy)** plans via `normalizeCursorUsage`.
- **Usage-based plans** (e.g. current Pro) report `maxRequestUsage: null` — no request cap — so they render the account row **without** a bar rather than a misleading empty/0% gauge.

## Scope note — usage-based spend bar deferred
Cursor's usage-based plans meter in dollars (spend vs a hard limit), not requests. That signal only comes from Cursor's **undocumented, origin-gated** dashboard endpoints, and I could not verify the billing-period math (every period-scoped variant returned the same/empty total). Rather than ship a spend % that could be wrong (the same fake-bar bug just fixed for Grok), this PR ships the **stable, verifiable** request-cap path + account row. The wiring here is the exact prerequisite for a spend bar if Cursor exposes a stable endpoint later.

## Verified — real `ag view cursor` + request-cap render
Screenshot (real run): `zion:/tmp/cursor-view.png` (also `yosemite-s0:~/cursor-view.png`).

```
Not Managed by Agents CLI

  Cursor
    2026.07.23 (global)  muqsitnawaz@gmail.com     <- account now surfaced (live)

# request-capped plan -> monthly bar (normalizeCursorUsage + formatUsageSummary):
  Cursor  M: █░░░░ 24% (20d)
```

## Tests
- `normalizeCursorUsage`: request-capped fixture → correct `M` bar (24%, reset +1 month); usage-based (`maxRequestUsage: null`) and missing-bucket → no window.
- `getAccountInfo('cursor')`: reads cli-config authInfo + auth.json token → signed in; absent → signed out.
- `agentReportsUsage` updated: cursor → true. Full `usage.test.ts` + `agents.test.ts` + `gen-changelog.test.ts` pass; `tsc --noEmit` clean.
