### PR TITLE
feat(sessions): finish enriched list metadata

### DIFF
--- a/apps/cli/.changelog/next/sessions-list-metadata.md
+++ b/apps/cli/.changelog/next/sessions-list-metadata.md
@@ -1,0 +1,8 @@
+- **Session lists expose the model and richer navigation metadata (RUSH-1981,
+  RUSH-1991, RUSH-1992, RUSH-1994).** Static flat rows add a compact model column
+  only when the result set has model data, with width sized to that set so an
+  80-column terminal does not wrap. Local CWD and ticket/PR cells are clickable
+  in supporting terminals, previews identify browser/computer use and sub-agent
+  counts, and `agents sessions --active --json` adds an always-present `prLink`
+  key. Existing session indexes migrate to schema v20 and rescan transcripts to
+  backfill model data.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## 1.20.81
 
-- **Session lists expose the model and richer navigation metadata (RUSH-1981,
-  RUSH-1991, RUSH-1992, RUSH-1994).** Static flat rows add a compact model column
-  only when the result set has model data, with width sized to that set so an
-  80-column terminal does not wrap. Local CWD and ticket/PR cells are clickable
-  in supporting terminals, previews identify browser/computer use and sub-agent
-  counts, and `agents sessions --active --json` adds an always-present `prLink`
-  key. Existing session indexes migrate to schema v20 and rescan transcripts to
-  backfill model data.
-
 - **Generic `--device all` / `--host all` fleet fan-out for every fleet-aware
   command (RUSH-1969).** The passthrough now treats `all` as a sentinel value on
   `--host`, `--device`, `--hosts`, and `--devices`. For any routable command

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.20.81
 
+- **Session lists expose the model and richer navigation metadata (RUSH-1981,
+  RUSH-1991, RUSH-1992, RUSH-1994).** Static flat rows add a compact model column
+  only when the result set has model data, with width sized to that set so an
+  80-column terminal does not wrap. Local CWD and ticket/PR cells are clickable
+  in supporting terminals, previews identify browser/computer use and sub-agent
+  counts, and `agents sessions --active --json` adds an always-present `prLink`
+  key. Existing session indexes migrate to schema v20 and rescan transcripts to
+  backfill model data.
+
 - **Generic `--device all` / `--host all` fleet fan-out for every fleet-aware
   command (RUSH-1969).** The passthrough now treats `all` as a sentinel value on
   `--host`, `--device`, `--hosts`, and `--devices`. For any routable command

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -138,6 +138,7 @@ Fields:
 | `topic` | First user prompt (truncated) | Best headline for a session |
 | `label` | The session name — one field, several sources | Priority: agent-generated title / Claude `/rename`, else the launch handle seeded by `agents run --name <slug>` (interactive, headless, `--host`, or a teams teammate), else `null` (listing falls back to `topic`). `agents sessions <ref>` resolves against it. |
 | `tokenCount` | Parsed from usage events | `null` for agents that don't log it |
+| `model` | Parsed from transcript metadata or assistant events | `null` for harnesses that don't record it; shortened in the static flat list |
 | `costUsd` | Σ tokens × per-model price, at scan time | `null` when the model is unknown/unpriced; see `agents cost` |
 | `durationMs` | `lastTs − firstTs` over timestamped events | `null` for single-event sessions |
 | `isTeamOrigin` | Set when spawned by `agents teams` | JSONL `entrypoint: 'sdk-cli'` |

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -407,11 +407,11 @@ contains `path`, `name`, `mediaType`, and `sizeBytes` so consumers such as Facto
 can render thumbnails and open the original attachment without re-reading the raw
 agent transcript.
 
-Every row also carries flat top-level `ticketId` and `project` keys — always
-present, `null` when unknown — so a watcher can join active sessions on ticket and
-project without reaching into the nested `ticket` object. `project` is the
-basename of the session's cwd, the same derivation the historical `--json`
-listing uses, so the active and recent views join identically.
+Every row also carries flat top-level `ticketId`, `project`, and `prLink` keys —
+always present, `null` when unknown — so a watcher can join active sessions on
+ticket and project or open the linked pull request without reaching into nested
+objects. `project` is the basename of the session's cwd, the same derivation the
+historical `--json` listing uses, so the active and recent views join identically.
 
 Some sessions appear in multiple sources:
 

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -311,8 +311,8 @@ The command surface (bare `sessions [query]`, `tail`, `sync`, `resume`, `focus`,
   with `sessions --all --json --limit 500` (`commands/sessions-browser.ts:219`),
   so the array shape is load-bearing across the fleet.
 - **IF-2 (MUST).** `sessions --active --json` MUST emit `ActiveSession[]` with
-  `ticketId`/`project` always present as keys (test
-  `sessions.serialize.test.ts:76-108`); `tail --json` MUST pass raw JSONL through
+  `ticketId`/`project`/`prLink` always present as keys (test
+  `sessions.serialize.test.ts:76-115`); `tail --json` MUST pass raw JSONL through
   one event per line (`commands/sessions-tail.ts:229-232`); `sync --json`,
   `inject --json`, `migrations --json` emit their documented shapes.
 - **IF-3 (MUST).** The export **bundle format** is NDJSON, `kind`

--- a/apps/cli/src/commands/__tests__/sessions-columns.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-columns.test.ts
@@ -7,7 +7,17 @@
 
 import { describe, it, expect } from 'vitest';
 import chalk from 'chalk';
-import { ticketLabel, machineLabeler, formatPickerLabel, formatPickerTip } from '../sessions.js';
+import { stripVTControlCharacters } from 'node:util';
+import {
+  ticketLabel,
+  machineLabeler,
+  formatPickerLabel,
+  formatPickerTip,
+  pickerColumnsFor,
+  flatSessionRow,
+  linkTicketCell,
+  linkCwdCell,
+} from '../sessions.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
 const strip = (s: string) => s.replace(/\[[0-9;]*m/g, '');
@@ -146,6 +156,52 @@ describe('formatPickerLabel', () => {
   it('omits the host column entirely when it is off', () => {
     const row = strip(formatPickerLabel(meta(), '', { showHost: false }, undefined, 'ghostty'));
     expect(row).not.toContain('ghostty');
+  });
+});
+
+describe('static flat-list columns', () => {
+  it('shows a pool-sized model column only when the pool has model metadata', () => {
+    const withModel = [
+      meta({ model: 'claude-sonnet-4-20250514' }),
+      meta({ id: 'other', shortId: 'other', model: undefined }),
+    ];
+    const cols = pickerColumnsFor(withModel);
+    expect(cols.showModel).toBe(true);
+    expect(cols.modelWidth).toBe(9);
+    expect(stripVTControlCharacters(flatSessionRow(withModel[0], undefined, false, cols))).toContain('sonnet-4');
+
+    const withoutModel = [meta({ topic: 'Show codex versions in the session list' })];
+    const noModelCols = pickerColumnsFor(withoutModel);
+    expect(noModelCols.showModel).toBe(false);
+    expect(stripVTControlCharacters(flatSessionRow(withoutModel[0], undefined, false, noModelCols)))
+      .toContain('Show codex versions in the session list');
+  });
+
+  it('keeps a modeled row within an 80-column terminal', () => {
+    const original = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, writable: true, value: 80 });
+    try {
+      const session = meta({
+        timestamp: new Date().toISOString(),
+        model: 'claude-sonnet-4-20250514',
+        topic: 'A topic that must shrink without wrapping the row',
+      });
+      const row = stripVTControlCharacters(flatSessionRow(session, undefined, false, pickerColumnsFor([session])));
+      expect(row.length).toBeLessThanOrEqual(80);
+    } finally {
+      if (original) Object.defineProperty(process.stdout, 'columns', original);
+      else delete (process.stdout as { columns?: number }).columns;
+    }
+  });
+
+  it('links local ticket and cwd labels while remote cwd stays plain', () => {
+    const ticket = linkTicketCell(meta({ ticketId: 'RUSH-1991' }), 'RUSH-1991');
+    const cwd = linkCwdCell(meta({ cwd: '/repo/agents-cli' }), 'agents-cli');
+    expect(stripVTControlCharacters(ticket)).toBe('RUSH-1991');
+    expect(stripVTControlCharacters(cwd)).toBe('agents-cli');
+    if (ticket.includes('\x1b]8;;')) expect(ticket).toContain('/issue/RUSH-1991');
+    if (cwd.includes('\x1b]8;;')) expect(cwd).toContain('file:///repo/agents-cli');
+    expect(linkCwdCell(meta({ cwd: '/remote/repo', _remote: true }), 'remote')).toBe('remote');
   });
 });
 

--- a/apps/cli/src/commands/sessions-picker.test.ts
+++ b/apps/cli/src/commands/sessions-picker.test.ts
@@ -8,6 +8,9 @@
  * SessionMeta.todos even when no transcript is on disk.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { stripVTControlCharacters } from 'node:util';
 import { buildPreview, formatTodoCompact, githubRepoUrlFromCwd, relativizeDir } from './sessions-picker.js';
 import { _resetLinearWorkspaceCache } from '../lib/session/linear.js';
@@ -226,5 +229,32 @@ describe('buildPreview — ticket + PR links line', () => {
     const preview = stripVTControlCharacters(buildPreview(mk({ topic: 'no checklist' })));
     expect(preview).not.toContain('Todos:');
     expect(preview).not.toContain('✓');
+  });
+});
+
+describe('buildPreview — usage metadata (RUSH-1994)', () => {
+  it('shows browser/computer use and the sub-agent count from a real transcript', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-preview-'));
+    try {
+      const filePath = path.join(dir, 'session.jsonl');
+      fs.writeFileSync(filePath, [
+        JSON.stringify({ type: 'user', timestamp: '2026-08-01T14:00:00.000Z', cwd: dir, sessionId: 'rich-meta-session', version: '2.1.112', message: { role: 'user', content: 'Inspect the UI' } }),
+        JSON.stringify({ type: 'assistant', timestamp: '2026-08-01T14:00:10.000Z', message: { role: 'assistant', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 1, output_tokens: 1 }, content: [{ type: 'tool_use', id: 'a1', name: 'Agent', input: { prompt: 'Explore' } }] } }),
+        JSON.stringify({ type: 'assistant', timestamp: '2026-08-01T14:00:12.000Z', message: { role: 'assistant', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 1, output_tokens: 1 }, content: [{ type: 'tool_use', id: 'b1', name: 'Bash', input: { command: 'agents browser list' } }, { type: 'tool_use', id: 'c1', name: 'Bash', input: { command: 'agents computer screenshot' } }] } }),
+      ].join('\n') + '\n');
+
+      const preview = stripVTControlCharacters(buildPreview(mk({
+        id: 'rich-meta-session',
+        shortId: 'richmeta',
+        filePath,
+        cwd: dir,
+      })));
+      expect(preview).toContain('sonnet-4');
+      expect(preview).toContain('browser');
+      expect(preview).toContain('computer');
+      expect(preview).toContain('1 sub-agent');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/commands/sessions-picker.ts
+++ b/apps/cli/src/commands/sessions-picker.ts
@@ -12,7 +12,7 @@ import { truncate, humanDuration } from '../lib/format.js';
 import type { SessionEvent, SessionMeta, TodoProgress } from '../lib/session/types.js';
 import { parseSession, sanitizeForTerminal } from '../lib/session/parse.js';
 import { cleanSessionPrompt, extractSessionTopic } from '../lib/session/prompt.js';
-import { linkPath, linkUrl, relativeToCwd } from '../lib/session/render.js';
+import { linkPath, linkUrl, relativeToCwd, shortenModel } from '../lib/session/render.js';
 import { linearIssueUrl } from '../lib/session/linear.js';
 import { extractTodoProgress, WORKTREE_RE } from '../lib/session/state.js';
 import { renderMarkdown } from '../lib/markdown.js';
@@ -165,7 +165,7 @@ function displayAgent(agent: string): string {
 const DOT = chalk.gray(' · ');
 
 function formatHeader(session: SessionMeta, events: SessionEvent[]): string {
-  const model = extractModel(events);
+  const model = extractModel(events) || session.model;
   const { startedAgo, duration } = extractTiming(events);
   const totalMessages = session.messageCount ?? countMessages(events);
   const totalTokens = session.tokenCount;
@@ -174,7 +174,7 @@ function formatHeader(session: SessionMeta, events: SessionEvent[]): string {
   const line1: string[] = [];
   line1.push(chalk.gray(`${displayAgent(session.agent)}${session.version ? ` v${session.version}` : ''}`));
   if (session.shortId) line1.push(chalk.dim(session.shortId));
-  if (model) line1.push(chalk.bold.white(model));
+  if (model) line1.push(chalk.bold.white(shortenModel(model)));
   if (session.account) line1.push(chalk.gray(session.account));
 
   // Line 2: cwd · project · branch · started X ago · lasted Y
@@ -316,6 +316,8 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
   let planFile = '';
   /** Latest checklist from the transcript (Claude TodoWrite / Codex update_plan). */
   let latestTodos: TodoProgress | undefined;
+  let subAgentCount = 0;
+  const toolTags = new Set<string>();
 
   for (const event of events) {
     if (event.type === 'message') {
@@ -329,6 +331,9 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
       }
     } else if (event.type === 'tool_use' && !event._local) {
       const tool = event.tool || '';
+      const command = event.command || '';
+      for (const tag of classifySessionTool(tool, command)) toolTags.add(tag);
+      if (isSubAgentTool(tool, command)) subAgentCount++;
       const p = event.path || event.args?.file_path || event.args?.path || '';
       if (['Read', 'read_file', 'view_file', 'cat_file', 'get_file'].includes(tool) && p) {
         filesRead.add(p);
@@ -402,6 +407,14 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
     lines.push(chalk.cyan('Changes:  ') + activity.join(chalk.gray(' · ')));
   }
 
+  const metadata = [
+    ...toolTags,
+    subAgentCount ? `${subAgentCount} sub-agent${subAgentCount === 1 ? '' : 's'}` : '',
+  ].filter(Boolean);
+  if (metadata.length) {
+    lines.push(chalk.cyan('Meta:     ') + chalk.gray(metadata.join(' · ')));
+  }
+
   // Tool mix (top 4) — what kind of work this was.
   const hist = toolHistogram(toolCounts, 4);
   if (hist.length) {
@@ -439,6 +452,22 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
   }
 
   return lines.map(l => '  ' + l).join('\n');
+}
+
+function classifySessionTool(tool: string, command: string): string[] {
+  const toolName = tool.toLowerCase();
+  const commandUses = (surface: 'browser' | 'computer') => (
+    new RegExp(`\\b(?:agents|ag)\\b[^\\n;&|]*\\b${surface}\\b`).test(command.toLowerCase())
+  );
+  const tags: string[] = [];
+  if (/browser|webfetch|websearch/.test(toolName) || commandUses('browser')) tags.push('browser');
+  if (/computer/.test(toolName) || commandUses('computer')) tags.push('computer');
+  return tags;
+}
+
+function isSubAgentTool(tool: string, command: string): boolean {
+  if (/^(Agent|Task)$/i.test(tool)) return true;
+  return /\b(?:agents|ag)\b[^\n;&|]*\b(?:run|cloud\s+run|teams\s+(?:add|start))\b/.test(command);
 }
 
 /**

--- a/apps/cli/src/commands/sessions.serialize.test.ts
+++ b/apps/cli/src/commands/sessions.serialize.test.ts
@@ -71,19 +71,24 @@ describe('serializeSessionsJson', () => {
  * RUSH-1981: `agents sessions --active --json` is what a supervising watcher
  * joins on. The raw ActiveSession nests the ticket (`ticket.id`) and carries no
  * `project`, so a naive join on ticketId+project drops every row. The serializer
- * must add both as flat, always-present top-level keys.
+ * must add those join keys plus the PR link as flat, always-present top-level keys.
  */
 describe('serializeActiveSessionsForJson (RUSH-1981 — join keys)', () => {
   function active(over: Partial<ActiveSession> = {}): ActiveSession {
     return { context: 'terminal', kind: 'agent', status: 'running', ...over } as ActiveSession;
   }
 
-  it('emits flat ticketId (from ticket.id) and project (basename of cwd)', () => {
+  it('emits flat ticketId, project, and prLink', () => {
     const [row] = serializeActiveSessionsForJson([
-      active({ cwd: '/home/u/src/github.com/acme/widget', ticket: { id: 'RUSH-1981' } as ActiveSession['ticket'] }),
+      active({
+        cwd: '/home/u/src/github.com/acme/widget',
+        ticket: { id: 'RUSH-1981' } as ActiveSession['ticket'],
+        pr: { url: 'https://github.com/acme/widget/pull/42', number: 42 },
+      }),
     ]);
     expect(row.ticketId).toBe('RUSH-1981');
     expect(row.project).toBe('widget');
+    expect(row.prLink).toBe('https://github.com/acme/widget/pull/42');
   });
 
   it('emits both keys as null (never absent) when the session has no ticket or cwd', () => {
@@ -92,8 +97,10 @@ describe('serializeActiveSessionsForJson (RUSH-1981 — join keys)', () => {
     // missing property and an explicit null are not the same to a consumer.
     expect(Object.prototype.hasOwnProperty.call(row, 'ticketId')).toBe(true);
     expect(Object.prototype.hasOwnProperty.call(row, 'project')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(row, 'prLink')).toBe(true);
     expect(row.ticketId).toBeNull();
     expect(row.project).toBeNull();
+    expect(row.prLink).toBeNull();
   });
 
   it('preserves the raw ActiveSession fields alongside the join keys', () => {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -36,7 +36,7 @@ import { filterTeamSessions } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
 import { runRemoteSessions, buildForwardedArgs, ensureWholeIndex } from '../lib/session/remote.js';
 import { formatRelativeTime } from '../lib/session/relative-time.js';
-import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, linkUrl, type FilterOptions } from '../lib/session/render.js';
+import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, linkPath, linkUrl, shortenModel, type FilterOptions } from '../lib/session/render.js';
 import { linearIssueUrl } from '../lib/session/linear.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { AGENTS, colorAgent, resolveAgentName } from '../lib/agents.js';
@@ -503,6 +503,24 @@ export function ticketLabel(s: Pick<SessionMeta, 'ticketId' | 'prNumber'>): stri
   return s.ticketId ?? (s.prNumber ? `PR#${s.prNumber}` : '');
 }
 
+function ticketUrl(s: Pick<SessionMeta, 'ticketId' | 'prNumber' | 'prUrl'>): string | undefined {
+  if (s.ticketId) return linearIssueUrl(s.ticketId);
+  return s.prNumber ? s.prUrl : undefined;
+}
+
+export function linkTicketCell(s: Pick<SessionMeta, 'ticketId' | 'prNumber' | 'prUrl'>, label: string): string {
+  const url = ticketUrl(s);
+  return url && label.trim() !== '-' ? linkUrl(url, label) : label;
+}
+
+export function linkCwdCell(s: Pick<SessionMeta, 'cwd' | '_remote'>, label: string): string {
+  return s.cwd && !s._remote ? linkPath(s.cwd, label) : label;
+}
+
+function modelLabel(model?: string): string {
+  return model ? shortenModel(model) : '-';
+}
+
 /**
  * The row shape `agents sessions --active --json` emits. RUSH-1981: a watcher
  * joins active sessions on ticketId + project, but the raw ActiveSession nests
@@ -514,11 +532,12 @@ export function ticketLabel(s: Pick<SessionMeta, 'ticketId' | 'prNumber'>): stri
  */
 export function serializeActiveSessionsForJson(
   sessions: ActiveSession[],
-): Array<ActiveSession & { ticketId: string | null; project: string | null }> {
+): Array<ActiveSession & { ticketId: string | null; project: string | null; prLink: string | null }> {
   return sessions.map((s) => ({
     ...s,
     ticketId: s.ticket?.id ?? null,
     project: s.cwd ? path.basename(s.cwd) : null,
+    prLink: s.pr?.url ?? null,
   }));
 }
 
@@ -1556,12 +1575,12 @@ function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
 }
 
 /** One flat table row:
- *   shortId · agent · version · project · [glyph] label·doing · [ticket] · [wt] · time
+ *   shortId · agent · version · model · project · [glyph] label·doing · [ticket] · [wt] · time
  * `doing` is the live preview when running, else the topic. The `ticket` column
  * (tracker/PR ref, pulled out of the badge blob so refs align) is only rendered
  * when `showTicket` — otherwise a listing with no refs would waste a column of
  * dashes and needlessly truncate the topic. Worktree stays a trailing badge. */
-function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket = false, cols: PickerColumns = {}): string {
+export function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket = false, cols: PickerColumns = {}): string {
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.lastActivity ?? session.timestamp);
   const project = session.project || '-';
@@ -1586,7 +1605,7 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
 
   const TICKET_W = 10;
   const ticketCell = showTicket
-    ? chalk.blue(padToWidth(truncateToWidth(ticketLabel(session) || '-', TICKET_W), TICKET_W + 1))
+    ? chalk.blue(linkTicketCell(session, padToWidth(truncateToWidth(ticketLabel(session) || '-', TICKET_W), TICKET_W + 1)))
     : '';
   // Live status word (working / waiting / idle) next to the glyph — the default
   // list is no longer a bare glyph. Empty (zero width) for resting rows.
@@ -1595,14 +1614,16 @@ function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket =
   const machineW = cols.showMachine ? machineColW : 0;
   const ticketW = showTicket ? TICKET_W + 1 : 0;
   const wtW = wt ? stringWidth(wt) + 1 : 0;
-  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + 16) - glyphW - statusW - machineW - ticketW - wtW - stringWidth(when) - 1);
+  const modelW = cols.showModel ? (cols.modelWidth ?? PICKER_MODEL_MAX) : 0;
+  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + modelW + 16) - glyphW - statusW - machineW - ticketW - wtW - stringWidth(when) - 1);
 
   return (
     chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +
     agentColor(padToWidth(truncateToWidth(session.agent, 8), 9)) +
     chalk.yellow(padToWidth(truncateToWidth(session.version || '-', 7), 8)) +
+    (modelW ? chalk.yellow(padToWidth(truncateToWidth(modelLabel(session.model), modelW - 1), modelW)) : '') +
     machineCell +
-    chalk.cyan(padToWidth(truncateToWidth(project, 14), 16)) +
+    chalk.cyan(linkCwdCell(session, padToWidth(truncateToWidth(project, 14), 16))) +
     (glyph ? glyph + ' ' : '') +
     statusCell +
     renderTopicCell(label, doing, '', topicW, topicW) +
@@ -1768,7 +1789,9 @@ function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = fals
       if (!first) console.log();
       first = false;
       const group = byDir.get(key)!;
-      console.log(`${chalk.cyan.bold(shortCwd(key))} ${chalk.gray(`(${group.length})`)}`);
+      const cwd = group.find((s) => s.cwd && !s._remote)?.cwd;
+      const header = cwd ? linkPath(cwd, shortCwd(key)) : shortCwd(key);
+      console.log(`${chalk.cyan.bold(header)} ${chalk.gray(`(${group.length})`)}`);
       for (const s of group) console.log(treeSessionRow(s, liveIndex?.get(s.id)));
     }
     const dirWord = keys.length === 1 ? 'directory' : 'directories';
@@ -1989,6 +2012,10 @@ export interface PickerColumns {
   /** Total width of the machine column, sized to the widest compacted hostname
    * in the pool (capped). Falls back to PICKER_MACHINE_W when absent. */
   machineWidth?: number;
+  /** Render the model column only when at least one row carries a model. */
+  showModel?: boolean;
+  /** Pool-sized model column width, including one trailing separator cell. */
+  modelWidth?: number;
   /** Render the ticket/PR column (only when at least one row carries a ref). */
   showTicket?: boolean;
   /**
@@ -2013,12 +2040,21 @@ export interface PickerColumns {
 const PICKER_MACHINE_W = 11;
 const PICKER_MACHINE_MIN = 8;
 const PICKER_MACHINE_MAX = 18;
+const PICKER_MODEL_MIN = 6;
+const PICKER_MODEL_MAX = 13;
 
 /** Column width that shows every compacted hostname in `machines` whole (one
  * trailing space for separation), bounded by MIN/MAX. */
 function machineColumnWidth(machines: string[], label: (m: string) => string): number {
   const widest = machines.reduce((w, m) => Math.max(w, stringWidth(label(m))), 0);
   return Math.min(PICKER_MACHINE_MAX, Math.max(PICKER_MACHINE_MIN, widest + 1));
+}
+
+function modelColumnWidth(sessions: SessionMeta[]): number {
+  const widest = sessions.reduce((width, session) => (
+    Math.max(width, session.model ? stringWidth(modelLabel(session.model)) : 0)
+  ), 0);
+  return Math.min(PICKER_MODEL_MAX, Math.max(PICKER_MODEL_MIN, widest + 1));
 }
 
 /**
@@ -2054,6 +2090,8 @@ export function pickerColumnsFor(sessions: SessionMeta[]): PickerColumns {
     showMachine: distinct.length > 1,
     machineLabel,
     machineWidth: machineColumnWidth(distinct, machineLabel),
+    showModel: sessions.some((s) => !!s.model),
+    modelWidth: modelColumnWidth(sessions),
     showTicket: sessions.some((s) => ticketLabel(s) !== ''),
   };
 }

--- a/apps/cli/src/lib/session/__tests__/db.migrations.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.migrations.test.ts
@@ -42,3 +42,16 @@ describe('empty-shortId repair migration (v16)', () => {
     expect(healed?.shortId).not.toBe('');
   });
 });
+
+describe('model column migration (v20)', () => {
+  it('adds the model column to a v19 index', () => {
+    const db = getDB();
+    db.exec(`ALTER TABLE sessions DROP COLUMN model`);
+    db.prepare(`INSERT OR REPLACE INTO meta(key, value) VALUES ('schema_version', '19')`).run();
+    closeDB();
+
+    const reopened = getDB();
+    const cols = (reopened.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>).map(c => c.name);
+    expect(cols).toContain('model');
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/db.test.ts
+++ b/apps/cli/src/lib/session/__tests__/db.test.ts
@@ -166,7 +166,21 @@ describe('migration v5 -> v6 adds cost/duration columns', () => {
   it('schema_version is recorded as the current version', () => {
     const db = getDB();
     const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string };
-    expect(row.value).toBe('19');
+    expect(row.value).toBe('20');
+  });
+
+  it('persists the session model when present', () => {
+    const filePath = path.join(COST_FILES_DIR, 'model-row.jsonl');
+    fs.writeFileSync(filePath, '');
+    upsertSession({
+      id: 'model-row',
+      shortId: 'model-ro',
+      agent: 'claude',
+      timestamp: '2026-08-01T14:00:00.000Z',
+      filePath,
+      model: 'claude-sonnet-4-20250514',
+    }, '');
+    expect(querySessions({ idExact: 'model-row' })[0]?.model).toBe('claude-sonnet-4-20250514');
   });
 
   it('v10 unifies name into label — the separate `name` column is dropped', () => {

--- a/apps/cli/src/lib/session/db.migrate-v14.test.ts
+++ b/apps/cli/src/lib/session/db.migrate-v14.test.ts
@@ -98,7 +98,7 @@ describe('schema migration v13 -> current (dir_ledger + resumable parser)', () =
   it('bumps the recorded schema version to the current version', () => {
     const db = getDB();
     const v = (db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string }).value;
-    expect(v).toBe('19');
+    expect(v).toBe('20');
   });
 
   it('preserves existing session rows through the migration', () => {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -21,7 +21,7 @@ const SESSIONS_DIR = getSessionsDir();
 const DB_PATH = getSessionsDbPath();
 
 /** Current schema version; bumped when migrations are added. */
-const SCHEMA_VERSION = 19;
+const SCHEMA_VERSION = 20;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   output_tokens INTEGER,
   cost_usd REAL,
   duration_ms INTEGER,
+  model TEXT,
   file_path TEXT NOT NULL,
   file_mtime_ms INTEGER,
   file_size INTEGER,
@@ -164,6 +165,7 @@ export interface SessionRow {
   output_tokens: number | null;
   cost_usd: number | null;
   duration_ms: number | null;
+  model: string | null;
   file_path: string;
   file_mtime_ms: number | null;
   file_size: number | null;
@@ -447,6 +449,13 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
     if (!cols.some(c => c.name === 'actor')) db.exec(`ALTER TABLE sessions ADD COLUMN actor TEXT`);
     if (!cols.some(c => c.name === 'initiated_by')) db.exec(`ALTER TABLE sessions ADD COLUMN initiated_by TEXT`);
+  }
+
+  if (fromVersion < 20) {
+    // v19 → v20: persist the transcript's model for the static session list.
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'model')) db.exec(`ALTER TABLE sessions ADD COLUMN model TEXT`);
+    db.exec(`DELETE FROM scan_ledger; DELETE FROM dir_ledger;`);
   }
 }
 
@@ -851,7 +860,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     id, short_id, agent, origin, routine_name, routine_run_id,
     version, account, timestamp, last_activity,
     project, cwd, git_branch, topic, label, message_count, token_count,
-    output_tokens, cost_usd, duration_ms,
+    output_tokens, cost_usd, duration_ms, model,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id, plan, todos,
     recent_directories_touched, linear_project, linear_project_url, machine,
@@ -860,7 +869,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     @id, @short_id, @agent, @origin, @routine_name, @routine_run_id,
     @version, @account, @timestamp, @last_activity,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
-    @output_tokens, @cost_usd, @duration_ms,
+    @output_tokens, @cost_usd, @duration_ms, @model,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
     @pr_url, @pr_number, @worktree_slug, @ticket_id, @plan, @todos,
     @recent_directories_touched, @linear_project, @linear_project_url, @machine,
@@ -894,6 +903,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     output_tokens = excluded.output_tokens,
     cost_usd = excluded.cost_usd,
     duration_ms = excluded.duration_ms,
+    model = excluded.model,
     file_path = excluded.file_path,
     file_mtime_ms = excluded.file_mtime_ms,
     file_size = excluded.file_size,
@@ -1016,6 +1026,7 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     output_tokens: meta.outputTokens ?? null,
     cost_usd: meta.costUsd ?? null,
     duration_ms: meta.durationMs ?? null,
+    model: meta.model ?? null,
     file_path: meta.filePath,
     file_mtime_ms: scan?.fileMtimeMs ?? null,
     file_size: scan?.fileSize ?? null,
@@ -1148,6 +1159,7 @@ export function upsertSessionsBatch(
         output_tokens: meta.outputTokens ?? null,
         cost_usd: meta.costUsd ?? null,
         duration_ms: meta.durationMs ?? null,
+        model: meta.model ?? null,
         file_path: meta.filePath,
         file_mtime_ms: scan?.fileMtimeMs ?? null,
         file_size: scan?.fileSize ?? null,
@@ -1352,6 +1364,7 @@ function rowToMeta(row: SessionRow): SessionMeta {
     outputTokens: row.output_tokens ?? undefined,
     costUsd: row.cost_usd ?? undefined,
     durationMs: row.duration_ms ?? undefined,
+    model: row.model ?? undefined,
     version: row.version ?? undefined,
     account: row.account ?? undefined,
     topic: row.topic ?? undefined,

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -145,6 +145,7 @@ interface ClaudeSessionScan {
   cwd?: string;
   gitBranch?: string;
   version?: string;
+  model?: string;
   topic?: string;
   messageCount: number;
   tokenCount?: number;
@@ -185,6 +186,7 @@ interface CodexSessionScan {
   cwd?: string;
   gitBranch?: string;
   version?: string;
+  model?: string;
   topic?: string;
   messageCount: number;
   tokenCount?: number;
@@ -1270,6 +1272,7 @@ async function readClaudeMeta(
       filePath,
       gitBranch: scan.gitBranch,
       version: scan.version,
+      model: scan.model,
       account,
       topic: scan.topic,
       label,
@@ -1299,6 +1302,7 @@ async function readClaudeMeta(
       lastActivity: scan.lastActivity,
       filePath,
       account,
+      model: scan.model,
       label,
       messageCount: scan.messageCount,
       tokenCount: scan.tokenCount,
@@ -1619,6 +1623,7 @@ export async function readCodexMeta(
     filePath,
     gitBranch: scan.gitBranch,
     version: resolveSessionVersion('codex', filePath, scan.version, currentVersion),
+    model: scan.model,
     topic: scan.topic,
     messageCount: scan.messageCount,
     tokenCount: scan.tokenCount,
@@ -1851,6 +1856,7 @@ function readGeminiMeta(
     cwd,
     filePath,
     version: resolveSessionVersion('gemini', filePath, embeddedVersion, currentVersion),
+    model: sessionModel,
     topic,
     messageCount,
     tokenCount: sawTokenCount ? tokenCount : undefined,
@@ -2528,6 +2534,7 @@ function readHermesMeta(filePath: string): { meta: SessionMeta; content: string 
     project: platform,
     filePath,
     version: model,
+    model,
     topic,
     messageCount: messageCount || (typeof session.message_count === 'number' ? session.message_count : undefined),
   };
@@ -2649,6 +2656,7 @@ async function readDroidMeta(
     cwd,
     filePath,
     version: resolveSessionVersion('droid', filePath, undefined, currentVersion),
+    model,
     topic: scan.topic,
     messageCount: scan.messageCount,
     tokenCount,
@@ -2802,6 +2810,7 @@ export interface ClaudeParseState {
   cwd?: string;
   gitBranch?: string;
   version?: string;
+  model?: string;
   topic?: string;
   // Explicit session titles: `/rename` writes a `custom-title` event; Claude
   // auto-generates an `ai-title`. Both can repeat across the file — last wins.
@@ -2845,6 +2854,7 @@ export function initClaudeParseState(): ClaudeParseState {
     cwd: undefined,
     gitBranch: undefined,
     version: undefined,
+    model: undefined,
     topic: undefined,
     customTitle: undefined,
     aiTitle: undefined,
@@ -3023,6 +3033,7 @@ export function applyClaudeLine(state: ClaudeParseState, parsed: any): void {
   // Per-assistant-message cost: each event carries its own model, so we
   // multiply that event's raw token directions by that model's price.
   const model = parsed.message?.model;
+  if (typeof model === 'string' && model) state.model = model;
   if (model && usageObj && typeof usageObj === 'object') {
     const eventCost = costOfUsage({
       model,
@@ -3059,6 +3070,7 @@ export function finalizeClaudeScan(state: ClaudeParseState): ClaudeSessionScan {
     cwd: state.cwd,
     gitBranch: state.gitBranch,
     version: state.version,
+    model: state.model,
     topic: resolvedTopic,
     entrypoint: state.entrypoint,
     messageCount: state.messageCount,
@@ -3126,6 +3138,7 @@ export interface ClaudeParserState {
   cwd?: string;
   gitBranch?: string;
   version?: string;
+  model?: string;
   entrypoint?: string;
   firstTsMs?: number;
   topic?: string;
@@ -3174,6 +3187,7 @@ export function serializeClaudeParserState(state: ClaudeParseState, offset: numb
     cwd: state.cwd,
     gitBranch: state.gitBranch,
     version: state.version,
+    model: state.model,
     entrypoint: state.entrypoint,
     firstTsMs: state.firstTsMs,
     topic: state.topic,
@@ -3235,6 +3249,7 @@ export function hydrateClaudeParseState(prior: ClaudeParserState): ClaudeParseSt
     cwd: prior.cwd,
     gitBranch: prior.gitBranch,
     version: prior.version,
+    model: prior.model,
     topic: prior.topic,
     customTitle: prior.customTitle,
     aiTitle: prior.aiTitle,
@@ -3641,6 +3656,7 @@ export function finalizeCodexScan(state: CodexParseState): CodexSessionScan {
     cwd: state.cwd,
     gitBranch: state.gitBranch,
     version: state.version,
+    model: state.model,
     topic: state.topic,
     messageCount: state.messageCount,
     tokenCount: state.tokenCount,

--- a/apps/cli/src/lib/session/render.ts
+++ b/apps/cli/src/lib/session/render.ts
@@ -255,7 +255,7 @@ export function computeSummaryStats(events: SessionEvent[]): SessionStats {
 }
 
 /** Strip the 'claude-' prefix and date suffix from a model identifier. */
-function shortenModel(model: string): string {
+export function shortenModel(model: string): string {
   return model.replace(/^claude-/, '').replace(/-\d{8}$/, '');
 }
 

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -132,6 +132,8 @@ export interface SessionMeta {
   costUsd?: number;
   /** Wall-clock duration in ms (lastTs − firstTs), persisted at scan time. */
   durationMs?: number;
+  /** Underlying LLM model observed in the transcript, when the agent records one. */
+  model?: string;
   version?: string;
   account?: string;
   topic?: string;


### PR DESCRIPTION
Completes the remaining sessions-list metadata work on current `main` (CLI behavior change).

## What changed

- RUSH-1992: persists `SessionMeta.model` through schema v20 and shows a compact model column in static flat rows.
- RUSH-1991: makes static flat ticket/CWD cells and tree CWD headers clickable while preserving plain-text degradation.
- RUSH-1994: adds browser/computer-use tags and sub-agent counts to session preview metadata.
- RUSH-1981: emits top-level `prLink` from `serializeActiveSessionsForJson`.

## Real run result

Installed the built npm artifact globally under an isolated prefix and ran it against a real Claude JSONL fixture:

```text
Claude · 11111111 · sonnet-4
/tmp/sessions-demo-project · sessions-demo-project · started 8h 13m ago · lasted 10s
1 msg · 11111111-2222-4333-8444-555555555555
RUSH-1992
  Prompt: Land RUSH-1992 model column
  Changes:  3 tools
  Meta:     browser · computer · 1 sub-agent
  Tools:    Bash 2 · Agent 1
```

The installed static flat list rendered:

```text
11111111  claude   2.1.112 sonnet-4     sessions-demo…  Land RUSH-1992 model column  RUSH-1992  8 hours ago
```

Run artifact fixture: `yosemite-s0:/tmp/sessions-demo-home/.claude/projects/-tmp-sessions-demo-project/11111111-2222-4333-8444-555555555555.jsonl` (fleet-local path, not a GitHub embed).

## Verification

- `./scripts/build.sh --clean --skip-tests` — passed (1,118 files, 8,851 KB)
- Focused Vitest run — 7 files, 122 tests passed, including 80-column flat-row and link-cell coverage
- Installed artifact — `agents --version` returned `1.20.81`; flat/tree/preview flows above ran successfully

## Tickets

- [RUSH-1992](https://linear.app/phoenix-labs/issue/RUSH-1992)
- [RUSH-1991](https://linear.app/phoenix-labs/issue/RUSH-1991)
- [RUSH-1994](https://linear.app/phoenix-labs/issue/RUSH-1994)
- [RUSH-1981](https://linear.app/phoenix-labs/issue/RUSH-1981)

## Scope notes

- RUSH-1991 is intentionally limited to the requested static flat/tree rows; preview and `--active` links were already delivered. The interactive browser row remains unchanged.
- RUSH-1992 persists model data for the five transcript scanners implemented by the seed (Claude, Codex, Gemini, Hermes, Droid). Model extraction for OpenCode, Kimi, Grok, Antigravity, and Rush requires separate parser-format work and is outside these tickets.
- Model sorting/filtering and auto-label versus user-label provenance are outside the four requested remainders.
- Existing sessions docs, the normative JSON contract, and the changelog now cover `model`, `prLink`, and the list behavior.
