### PR TITLE
fix(state): stop agents.yaml comment-churn that wedged agents sync

### DIFF
--- a/apps/cli/.changelog/next/agents-yaml-comment-churn.md
+++ b/apps/cli/.changelog/next/agents-yaml-comment-churn.md
@@ -1,0 +1,9 @@
+- **`agents.yaml` no longer churns on every meta write.** `writeMetaUnlocked` wrote
+  the central config with `yaml.stringify`, which strips all comments — so the
+  freshly-serialized bytes never matched the comment-annotated file on disk,
+  `writeIfChanged` rewrote it on every meta write, and the perpetually-dirty tree
+  wedged `agents sync` ("Blocked by local changes") across the fleet. It now
+  serializes via a `yaml.Document` round-trip (`serializeCentral`) that edits only
+  the keys that actually changed, so comments, key ordering, and untouched
+  top-level blocks (e.g. `hosts:`) are byte-stable — and a write that changes no
+  central field leaves `agents.yaml` untouched. Source: `apps/cli/src/lib/state.ts`.

--- a/apps/cli/src/lib/__tests__/state.test.ts
+++ b/apps/cli/src/lib/__tests__/state.test.ts
@@ -444,6 +444,59 @@ describe('agents.yaml device-local split (routing + read overlay)', () => {
     expect(meta.hosts).toBeDefined();
   });
 
+  it('preserves comments + hosts in central agents.yaml; a device-only write does not touch it (no churn)', () => {
+    const out = run(`
+      import * as fs from 'fs';
+      import { writeMeta, readMeta } from ${JSON.stringify(moduleUrl)};
+      const p = process.env.HOME + '/.agents/agents.yaml';
+      fs.writeFileSync(p, [
+        '# hand-written note: do not clobber me',
+        'defaultAgent: claude',
+        'hosts:',
+        '  box:',
+        '    source: inline',
+        '    address: 10.0.0.1  # tailnet IP',
+        ''
+      ].join('\\n'));
+      const before = fs.readFileSync(p, 'utf8');
+      // Unrelated write: a device pin (agents:) routes to the device file, not central.
+      writeMeta({ ...readMeta(), agents: { claude: '2.1.0' } });
+      const after = fs.readFileSync(p, 'utf8');
+      console.log(JSON.stringify({
+        commentSurvived: after.includes('do not clobber me'),
+        inlineCommentSurvived: after.includes('# tailnet IP'),
+        hostsSurvived: after.includes('address: 10.0.0.1'),
+        byteIdentical: before === after,
+      }));
+    `);
+    const r = JSON.parse(out);
+    expect(r.commentSurvived).toBe(true);
+    expect(r.inlineCommentSurvived).toBe(true);
+    expect(r.hostsSurvived).toBe(true);
+    // The churn fix: a write that changes no central field leaves agents.yaml byte-identical.
+    expect(r.byteIdentical).toBe(true);
+  });
+
+  it('updates a changed central field while keeping surrounding comments', () => {
+    const out = run(`
+      import * as fs from 'fs';
+      import { writeMeta, readMeta } from ${JSON.stringify(moduleUrl)};
+      const p = process.env.HOME + '/.agents/agents.yaml';
+      fs.writeFileSync(p, ['# keep this comment', 'projectRoot: /old/path', ''].join('\\n'));
+      writeMeta({ ...readMeta(), projectRoot: '/new/path' });
+      const after = fs.readFileSync(p, 'utf8');
+      console.log(JSON.stringify({
+        commentSurvived: after.includes('keep this comment'),
+        valueUpdated: after.includes('/new/path'),
+        oldGone: !after.includes('/old/path'),
+      }));
+    `);
+    const r = JSON.parse(out);
+    expect(r.commentSurvived).toBe(true);
+    expect(r.valueUpdated).toBe(true);
+    expect(r.oldGone).toBe(true);
+  });
+
   it('does not create a device file when there are no pins', () => {
     const out = run(`
       import * as fs from 'fs';

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -705,6 +705,50 @@ function writeIfChanged(filePath: string, content: string): void {
  * All callers funnel through writeMeta → here, so nothing else changes. Empty
  * `agents:` / `versions:` are not written (no empty committed files).
  */
+/**
+ * Serialize the central (synced) meta to `agents.yaml` WITHOUT destroying the
+ * hand-written comments in the committed file.
+ *
+ * `yaml.stringify(central)` drops every comment, so the freshly-written bytes
+ * never equal the comment-annotated file on disk — `writeIfChanged`'s byte
+ * compare then rewrites on EVERY meta write, leaving `agents.yaml` perpetually
+ * dirty and wedging `agents sync` ("Blocked by local changes"). Instead we parse
+ * the existing file into a `yaml.Document` (which preserves comments + ordering)
+ * and edit only the keys that actually changed — untouched keys, and all their
+ * comments, are left byte-stable. If nothing central changed we return the exact
+ * existing bytes, so a device-field-only write no longer touches `agents.yaml` at
+ * all. Falls back to plain stringify only when the file doesn't exist yet.
+ */
+function serializeCentral(central: Record<string, unknown>): string {
+  let existing: string | null = null;
+  try {
+    existing = fs.readFileSync(META_FILE, 'utf-8');
+  } catch {
+    /* first write — no file yet */
+  }
+  if (existing == null) {
+    return META_HEADER + yaml.stringify(central);
+  }
+  const doc = yaml.parseDocument(existing);
+  const current: Record<string, unknown> = (doc.toJSON() as Record<string, unknown>) ?? {};
+  let changed = false;
+  for (const [k, v] of Object.entries(central)) {
+    if (JSON.stringify(current[k]) !== JSON.stringify(v)) {
+      doc.set(k, v);
+      changed = true;
+    }
+  }
+  for (const k of Object.keys(current)) {
+    if (!(k in central)) {
+      doc.delete(k);
+      changed = true;
+    }
+  }
+  // No central field changed → keep the file byte-identical (comments intact),
+  // so writeIfChanged skips it and the churn loop never starts.
+  return changed ? String(doc) : existing;
+}
+
 function writeMetaUnlocked(meta: Meta): void {
   const { agents, isolatedAgents, versions, defaultBrowserProfile, ...central } = meta;
 
@@ -741,7 +785,7 @@ function writeMetaUnlocked(meta: Meta): void {
     writeIfChanged(vrPath, JSON.stringify(versions, null, 2) + '\n');
   }
 
-  writeIfChanged(META_FILE, META_HEADER + yaml.stringify(central));
+  writeIfChanged(META_FILE, serializeCentral(central));
   metaCache = null;
 }
 

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -720,6 +720,7 @@ function writeIfChanged(filePath: string, content: string): void {
  * all. Falls back to plain stringify only when the file doesn't exist yet.
  */
 function serializeCentral(central: Record<string, unknown>): string {
+  const isEmpty = Object.keys(central).length === 0;
   let existing: string | null = null;
   try {
     existing = fs.readFileSync(META_FILE, 'utf-8');
@@ -727,7 +728,11 @@ function serializeCentral(central: Record<string, unknown>): string {
     /* first write — no file yet */
   }
   if (existing == null) {
-    return META_HEADER + yaml.stringify(central);
+    // Empty central → header only. `yaml.stringify({})` emits `{}` (a FLOW empty
+    // map); once that lands on disk, a later parseDocument sees a flow root and
+    // doc.set() below would inherit flow, flow-ifying the whole file. Writing just
+    // the header avoids seeding that poison.
+    return isEmpty ? META_HEADER : META_HEADER + yaml.stringify(central);
   }
   const doc = yaml.parseDocument(existing);
   const current: Record<string, unknown> = (doc.toJSON() as Record<string, unknown>) ?? {};
@@ -744,9 +749,15 @@ function serializeCentral(central: Record<string, unknown>): string {
       changed = true;
     }
   }
-  // No central field changed → keep the file byte-identical (comments intact),
-  // so writeIfChanged skips it and the churn loop never starts.
-  return changed ? String(doc) : existing;
+  // No central field changed → keep the file byte-identical (comments intact), so
+  // writeIfChanged skips it and the churn loop never starts.
+  if (!changed) return existing;
+  // Everything cleared → header only (never leave a flow `{}` behind).
+  // Otherwise force BLOCK style: an existing flow root (e.g. a legacy `{}`) would
+  // otherwise make the edited nodes render flow (`disabledCommands: [ teams ]`
+  // instead of a `- teams` block list). collectionStyle pins the whole doc block
+  // while parseDocument still preserves comments + key ordering.
+  return isEmpty ? META_HEADER : doc.toString({ collectionStyle: 'block' });
 }
 
 function writeMetaUnlocked(meta: Meta): void {


### PR DESCRIPTION
## Type: bugfix — stops `agents.yaml` from churning and wedging `agents sync` fleet-wide.

## Proof — ran the round-trip, verified the result

Standalone verification of `serializeCentral` against real `yaml@2.9` (screenshot):

`yosemite-s1:/tmp/claude-1000/-home-muqsit/fe21bfab-f585-4581-b704-e10aeab20a85/scratchpad/churn-fix-proof.png` · also `zion:/tmp/churn-fix-proof.png`

- CASE1 no-change (device-only write): **byteIdentical=true**, comments + inline comments + `hosts:` all preserved → the churn loop never starts.
- CASE2 add a central field: changed key written; comments + `hosts:` survive.
- CASE3 remove a central field: deletes cleanly; unrelated comments kept.

`tsc --noEmit` clean; `state.test.ts` cases added (comment+hosts preservation, no-churn device-only write) — run in CI.

## The bug

`writeMetaUnlocked` wrote the central `agents.yaml` with `yaml.stringify(central)`, which **drops all comments**. `writeIfChanged` compares raw bytes, so the comment-stripped output never equaled the committed comment-annotated file → it **rewrote on every meta write** → perpetually-dirty tree → `agents sync` failed "Blocked by local changes" across the fleet.

This is distinct from the device-pin churn (fixed by gitignoring `devices/`); `agents.yaml` is real tracked config and can't be ignored.

## The fix

`serializeCentral` (`apps/cli/src/lib/state.ts`) serializes via a `yaml.Document` round-trip that edits only the keys whose value actually changed:
- comments, key ordering, and untouched top-level blocks (`hosts:`, etc.) stay **byte-stable**;
- a write that changes no central field returns the existing bytes unchanged (no rewrite, no churn);
- changed keys update; removed keys delete.

Falls back to plain `stringify` only when the file doesn't exist yet.

## Ship note

This is the running-binary fix, so it needs a release + fleet upgrade to actually stop the churn on machines (5 are currently wedged on it). Merge → release → upgrade fleet → then the wedged machines reconcile clean.
