### PR TITLE
fix(routines): anchor daemon cwd to $HOME so a deleted worktree can't crash every routine

### DIFF
--- a/apps/cli/.changelog/next/daemon-cwd-anchor.md
+++ b/apps/cli/.changelog/next/daemon-cwd-anchor.md
@@ -1,0 +1,13 @@
+- **The routines daemon now anchors its working directory to `$HOME` on startup,
+  so a deleted launch directory no longer crashes every scheduled routine.** The
+  daemon is long-lived and inherited whatever cwd it was launched from — commonly a
+  git worktree under `.agents/worktrees/`. When that directory was later removed
+  (`git worktree remove`, `rm -rf`), the daemon kept the deleted inode as its cwd
+  (a process cannot chdir out of a deleted directory on its own), and every job it
+  spawned inherited the dead cwd — `spawnJobAttempt` and command runs pass no
+  explicit `cwd`. Bun then failed `getcwd()` at startup and *every* routine died at
+  0 seconds with `ENOENT: Bun could not find a file` (or `The current working
+  directory was deleted`) before the agent ran — a fleet-wide routine outage from a
+  single removed worktree. `runDaemon` now re-anchors to the home directory once at
+  startup (`anchorDaemonCwd`), making the scheduler immune regardless of how it was
+  launched. Source: `apps/cli/src/lib/daemon.ts` (`anchorDaemonCwd`, `runDaemon`).

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -31,6 +31,7 @@ import {
   writeDaemonPid,
   removeDaemonPid,
   shouldTakeOverBroker,
+  anchorDaemonCwd,
 } from './daemon.js';
 import { ipcEndpoint } from './platform/index.js';
 
@@ -619,5 +620,62 @@ describe('shouldTakeOverBroker (RUSH-1817: daemon self-heals a dead standalone)'
 
   it('never clobbers a reachable (healthy) standalone broker', () => {
     expect(shouldTakeOverBroker(false, true)).toBe(false);
+  });
+});
+
+describe('anchorDaemonCwd', () => {
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    // The tests below chdir into temp dirs (some deleted); restore a valid cwd so
+    // later tests and vitest teardown aren't left standing in a dead directory.
+    try {
+      process.chdir(originalCwd);
+    } catch {
+      process.chdir(os.homedir());
+    }
+  });
+
+  it('recovers a deleted working directory by anchoring to home', () => {
+    // Reproduce the exact routine-outage failure: the daemon is running with its
+    // cwd inside a directory (a git worktree, in the real incident) that then gets
+    // removed out from under it. A process cannot chdir out of a deleted directory
+    // on its own, so every job it spawns inherits the dead cwd and Bun crashes with
+    // `ENOENT: Bun could not find a file` at startup. anchorDaemonCwd must recover.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-cwd-'));
+    const realTmp = fs.realpathSync(tmp);
+    process.chdir(realTmp);
+    fs.rmSync(realTmp, { recursive: true, force: true });
+
+    // Sanity: we are genuinely standing in a deleted directory now. On Linux,
+    // process.cwd() throws ENOENT here — the precondition of the outage.
+    let cwdBroken = false;
+    try {
+      process.cwd();
+    } catch {
+      cwdBroken = true;
+    }
+    expect(cwdBroken).toBe(true);
+
+    const resolved = anchorDaemonCwd();
+    expect(resolved).toBe(os.homedir());
+    // cwd() must now succeed and point at home — spawns will inherit a live dir.
+    expect(fs.realpathSync(process.cwd())).toBe(fs.realpathSync(os.homedir()));
+  });
+
+  it('anchors to home even when launched from an unrelated valid directory', () => {
+    const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-cwd-')));
+    try {
+      process.chdir(tmp);
+      const resolved = anchorDaemonCwd();
+      expect(resolved).toBe(os.homedir());
+      expect(fs.realpathSync(process.cwd())).toBe(fs.realpathSync(os.homedir()));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -290,6 +290,34 @@ export function log(level: string, message: string): void {
 }
 
 /** Main daemon loop: load jobs, schedule crons, monitor runs, and handle signals. */
+/**
+ * Anchor the daemon's working directory to a stable, always-present path.
+ *
+ * The daemon is long-lived and inherits whatever cwd it was launched from — often
+ * a git worktree (e.g. a `.agents/worktrees/<slug>/` a session happened to be in).
+ * When that directory is later removed (`git worktree remove`, `rm -rf`), the
+ * daemon keeps the deleted inode as its cwd — a process cannot chdir out of a
+ * deleted directory on its own — and every job it spawns inherits the dead cwd
+ * (`spawnJobAttempt` and command runs pass no explicit `cwd`, so the child uses
+ * the parent's). Bun then fails `getcwd()` during startup and every routine crashes
+ * at 0 seconds with `ENOENT: Bun could not find a file` before the agent even runs.
+ *
+ * Re-anchoring to the home directory once, at daemon startup, makes the daemon
+ * immune regardless of how it was launched (systemd unit, launchd, or a manual
+ * `agents __daemon-run` from any directory). Returns the resolved cwd, or null if
+ * anchoring failed (logged, non-fatal).
+ */
+export function anchorDaemonCwd(): string | null {
+  const home = os.homedir();
+  try {
+    process.chdir(home);
+    return home;
+  } catch (err) {
+    log('WARN', `Could not anchor daemon cwd to ${home}: ${(err as Error).message}`);
+    return null;
+  }
+}
+
 export async function runDaemon(): Promise<void> {
   // Single-instance guard: a direct `agents __daemon-run` (manual, or a
   // service-manager restart racing a live predecessor) must not clobber a
@@ -302,6 +330,8 @@ export async function runDaemon(): Promise<void> {
     process.exit(0);
   }
   log('INFO', `Daemon started (PID: ${process.pid})`);
+
+  anchorDaemonCwd();
 
   // The daemon holds NO Claude credential of its own. Routine runs authenticate
   // exactly like an interactive `agents run`: through the per-account


### PR DESCRIPTION
**fix / bug — no UI surface.** Fixes a fleet-wide routines outage: a single deleted git worktree crashed *every* scheduled routine.

## What was broken
On yosemite-s1 on 2026-08-01, ~8 routines failed at **0 seconds, exit 1**, with only:
```
ENOENT: Bun could not find a file, and the code that produces this error is missing a better error.
```
(and, on a newer claude build, `error: The current working directory was deleted`).

## Root cause
The routines daemon is long-lived and **inherited whatever cwd it was launched from** — in the incident, a git worktree at `…/agents/.agents/worktrees/foreman` (confirmed in a run's `meta.json`: `"cwd":"…/worktrees/foreman"`). That worktree was later removed while the daemon kept running. A process **cannot `chdir` out of a deleted directory on its own**, so the daemon held the dead inode as its cwd, and every job it spawned inherited it — `spawnJobAttempt` (`apps/cli/src/lib/runner.ts:534`) and command runs (`runner.ts:1104`) pass **no explicit `cwd`**. Bun (`claude.exe`) then fails `getcwd()` during startup → instant `ENOENT` before the agent ever runs.

The codebase already half-knew this: `validateDaemonBinary` warns *"daemon binary is inside a git worktree — a worktree deletion will wedge the daemon."* This closes the cwd-inheritance side of the same class.

## The fix
`runDaemon` now re-anchors the process cwd to `$HOME` once at startup via a new `anchorDaemonCwd()` (`apps/cli/src/lib/daemon.ts`). Doing it **in-process** makes the daemon immune regardless of how it was launched — systemd unit, launchd, or a manual `agents __daemon-run` from any directory — so no `WorkingDirectory=` unit edit is needed. This restores the historical-correct invariant (healthy runs always spawned from `cwd=/home/muqsit`).

## Run result (proof)
Test reproduces the **exact** failure — chdir into a temp dir, delete it, confirm `process.cwd()` genuinely throws `ENOENT`, then assert `anchorDaemonCwd()` recovers to `$HOME`:
```
$ node ./node_modules/vitest/vitest.mjs run src/lib/daemon.test.ts
 Test Files  1 passed (1)
      Tests  34 passed (34)      # +2 new: deleted-cwd recovery, unrelated-dir anchor

$ tsc --noEmit -p tsconfig.json   # exit 0
```

## Scope / not included
- Two of the failing routines (`security-sweep`, `review-open-prs`) also hardcode a **macOS path** `/Users/muqsit/src/…` in their prompt but run on Linux yosemite boxes — a separate bug in the *user's* routine YAMLs (`~/.agents/routines/`, not this repo), handled outside this PR.
- `wf:` workflow routines showing "process exited before final status could be inferred" is a distinct issue (the workflow orchestrator backgrounds a subagent and exits) — not addressed here.
