### PR TITLE
fix(routines): expire date-specific schedules and group list output

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2074-RUSH-2075.md
+++ b/apps/cli/.changelog/next/RUSH-2074-RUSH-2075.md
@@ -1,0 +1,12 @@
+- **Routines now treat date-specific cron schedules as one-shot jobs (RUSH-2074).**
+  `agents routines add --schedule "0 14 29 7 *"` now warns, persists
+  `runOnce: true`, marks the routine as one-shot in `routines list`, and
+  `agents routines cleanup` removes completed expired one-shots that still have
+  user-layer YAML. Source: `apps/cli/src/lib/routines.ts`,
+  `apps/cli/src/lib/scheduler.ts`, `apps/cli/src/commands/routines.ts`.
+
+- **`agents routines list` groups terminal output by device and placement
+  (RUSH-2075).** The default table is bucketed under this machine, fleet-wide,
+  cloud, named devices, and named hosts with offline/unknown registry hints;
+  `--flat` keeps the legacy single table and `--json` remains a flat payload.
+  Source: `apps/cli/src/commands/routines.ts`.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -44,7 +44,7 @@ What happens on enable/sync:
 3. The daemon (which only loads user + system layers) can now fire them. Reload (`SIGHUP` / `agents routines` mutations) re-syncs opted-in projects automatically.
 4. Hand-authored user routines of the same name are never overwritten.
 
-`agents routines list` shows the source repo (and `@branch` when known) in the Repo column for project-sourced routines; `--json` includes `source`, `sourceRepo`, `sourceBranch`, and `hostStrategy`.
+`agents routines list` groups terminal output by effective device/host scope so it is clear what runs on the current machine, the fleet, cloud, named devices, and named hosts. Use `agents routines list --flat` for the legacy single table, or `--json` for the flat machine-readable payload. Project-sourced routines still show the source repo (and `@branch` when known) in the Repo column; `--json` includes `source`, `sourceRepo`, `sourceBranch`, `hostStrategy`, `oneShot`, and `expired`.
 
 A project may also declare `routines: { enable: true }` in its own `agents.yaml` as a documentation signal; daemon firing still requires the explicit `enable-project` allowlist step so consent is materialised into the user layer.
 
@@ -139,7 +139,18 @@ allow:
 agents routines add reminder --at "14:30" --agent claude --prompt "Remind Muqsit to stand up"
 ```
 
-`--at` accepts `"14:30"` (today at that time) or `"2026-02-24 09:00"` (absolute). The daemon converts it to a cron expression with `runOnce: true`.
+Prefer `--at` for one-time routines. It accepts `"14:30"` (today at that time, or tomorrow if the time already passed) or `"2026-02-24 09:00"` (absolute). The daemon converts it to a cron expression with `runOnce: true` and deletes the routine after it fires.
+
+Raw cron schedules that pin minute, hour, day, and month with wildcard weekday, such as `"0 14 29 7 *"`, are also treated as one-shot at creation time. The CLI prints a warning and persists `runOnce: true`; use `--at` instead when an agent is scheduling a one-time wake-up.
+
+List output marks one-shot routines in the Schedule column. Expired one-shots that missed cleanup show `expired` instead of next year's recurrence.
+
+Remove completed, expired one-shots that still have user-layer YAML:
+
+```bash
+agents routines cleanup --dry-run
+agents routines cleanup
+```
 
 ### Webhook Triggers
 
@@ -247,6 +258,16 @@ agents routines add drain --schedule "0 3 * * *" --agent claude \
 ```
 
 `--devices` is validated against the registered fleet (`agents devices sync`).
+
+For a grouped view of everything that targets a device or placement, run:
+
+```bash
+agents routines list
+agents routines list --group-by device
+agents routines list --flat
+```
+
+The grouped view buckets routines under **This machine**, **Fleet-wide**, **Cloud**, one section per pinned device, and one section per named host. Offline or unknown registry entries are marked in the section header.
 
 Device names are compared against the local `machineId()` (normalized hostname, as
 shown by `agents devices`), so `Yosemite-S0` and `yosemite-s0.tailnet.ts.net` both

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -397,6 +397,41 @@ describe('routines add --json', () => {
   });
 });
 
+describe('routines add one-shot-looking --schedule', () => {
+  it('warns, persists runOnce, and keeps JSON stdout parseable', async () => {
+    const home = makeHome({ registry });
+    let daemon: ReturnType<typeof startIsolatedDaemon> | undefined;
+    let pid: number | null = null;
+    try {
+      daemon = startIsolatedDaemon(home);
+      pid = await daemon.pidPromise;
+      expect(pid).not.toBeNull();
+
+      const res = run(home, [
+        'add', 'date-cron',
+        '--schedule', '0 14 31 12 *',
+        '--agent', 'claude',
+        '--prompt', 'hi',
+        '--json',
+      ]);
+      expect(res.status).toBe(0);
+      expect(JSON.parse(res.stdout.trim())).toMatchObject({
+        jobId: 'date-cron',
+        schedule: '0 14 31 12 *',
+      });
+      expect(res.stderr).toContain('treating it as one-shot');
+
+      const doc = readRoutineYaml(home, 'date-cron');
+      expect(doc).not.toBeNull();
+      expect(doc!.runOnce).toBe(true);
+    } finally {
+      if (daemon) await stopIsolatedDaemon(daemon.child);
+      if (typeof pid === 'number') expect(isProcessAlive(pid)).toBe(false);
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('routines list --json has devices+runsHere, no device', () => {
   it('includes devices array and runsHere, excludes singular device key', () => {
     const job = { ...baseJob, devices: ['yosemite-s0', 'mac-mini'] };
@@ -595,7 +630,7 @@ describe('routines list table has Devices column with bounded ellipsis', () => {
   it('table header includes Devices', () => {
     const home = makeHome({ jobs: [baseJob], registry });
     try {
-      const res = run(home, ['list']);
+      const res = run(home, ['list', '--flat']);
       expect(res.status).toBe(0);
       expect(res.stdout).toContain('Devices');
     } finally {
@@ -607,7 +642,7 @@ describe('routines list table has Devices column with bounded ellipsis', () => {
     const job = { ...baseJob, devices: ['yosemite-s0', 'yosemite-s1', 'mac-mini', 'zion'] };
     const home = makeHome({ jobs: [job], registry });
     try {
-      const res = run(home, ['list']);
+      const res = run(home, ['list', '--flat']);
       expect(res.status).toBe(0);
       const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
       const lines = stripped.split('\n').filter((l) => l.includes('test-job'));
@@ -621,7 +656,7 @@ describe('routines list table has Devices column with bounded ellipsis', () => {
   it('renders unrestricted routines with Devices set to "all"', () => {
     const home = makeHome({ jobs: [baseJob], registry });
     try {
-      const res = run(home, ['list']);
+      const res = run(home, ['list', '--flat']);
       expect(res.status).toBe(0);
       const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
       const lines = stripped.split('\n');
@@ -635,6 +670,97 @@ describe('routines list table has Devices column with bounded ellipsis', () => {
       expect(scheduleStart).toBeGreaterThan(deviceStart);
       const deviceField = line!.slice(deviceStart, scheduleStart).trim();
       expect(deviceField).toBe('all');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('marks one-shot routines in the schedule column', () => {
+    const job = { ...baseJob, schedule: '0 14 31 12 *', runOnce: true };
+    const home = makeHome({ jobs: [job], registry });
+    try {
+      const res = run(home, ['list', '--flat']);
+      expect(res.status).toBe(0);
+      expect(res.stdout.replace(/\x1b\[[0-9;]*m/g, '')).toContain('one-shot');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines list grouped by device', () => {
+  it('groups by fleet, current device, pinned devices, hosts, cloud, and offline registry state', () => {
+    const jobs = [
+      { ...baseJob, name: 'all-local' },
+      { ...baseJob, name: 'zion-local', devices: ['zion'] },
+      { ...baseJob, name: 's0-local', devices: ['yosemite-s0'] },
+      { ...baseJob, name: 'fleet-placed', hostStrategy: 'fleet', devices: ['zion'] },
+      { ...baseJob, name: 'cloud-placed', hostStrategy: 'cloud', devices: ['zion'] },
+      { ...baseJob, name: 'host-placed', hostStrategy: 'host', host: 'mac-mini', devices: ['zion'] },
+      { ...baseJob, name: 'offline-local', devices: ['offline-box'] },
+    ];
+    const groupedRegistry = {
+      ...registry,
+      'mac-mini': { ...registry['mac-mini'], tailscale: { online: false, direct: false } },
+      'offline-box': { name: 'offline-box', platform: 'linux', tailscale: { online: false, direct: false } },
+    };
+    const home = makeHome({ jobs, registry: groupedRegistry });
+    try {
+      const res = run(home, ['list', '--group-by', 'device'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      expect(res.status).toBe(0);
+      const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
+      expect(stripped).toContain('This machine (zion)');
+      expect(stripped).toContain('Fleet-wide');
+      expect(stripped).toContain('Cloud');
+      expect(stripped).toContain('Device: yosemite-s0');
+      expect(stripped).toContain('Device: offline-box (offline)');
+      expect(stripped).toContain('Host: mac-mini (offline)');
+      for (const job of jobs) expect(stripped).toContain(job.name);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the legacy flat table available with --flat', () => {
+    const home = makeHome({ jobs: [baseJob], registry });
+    try {
+      const grouped = run(home, ['list'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      const flat = run(home, ['list', '--flat'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      expect(grouped.status).toBe(0);
+      expect(flat.status).toBe(0);
+      expect(grouped.stdout.replace(/\x1b\[[0-9;]*m/g, '')).toContain('Fleet-wide');
+      expect(flat.stdout.replace(/\x1b\[[0-9;]*m/g, '')).not.toContain('Fleet-wide');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('routines cleanup', () => {
+  it('removes completed expired one-shot-looking routines', () => {
+    const year = new Date().getFullYear();
+    const job = { ...baseJob, name: 'stale-followup', schedule: '0 0 1 1 *' };
+    const home = makeHome({ jobs: [job], registry });
+    writeRunMeta(home, 'stale-followup', `${year}-01-02T00-00-00-000Z`, {
+      jobName: 'stale-followup',
+      runId: `${year}-01-02T00-00-00-000Z`,
+      agent: 'claude',
+      pid: null,
+      status: 'completed',
+      startedAt: `${year}-01-02T00:00:00.000Z`,
+      completedAt: `${year}-01-02T00:00:01.000Z`,
+      exitCode: 0,
+    });
+    try {
+      const dryRun = run(home, ['cleanup', '--dry-run']);
+      expect(dryRun.status).toBe(0);
+      expect(dryRun.stdout).toContain('stale-followup');
+      expect(readRoutineYaml(home, 'stale-followup')).not.toBeNull();
+
+      const res = run(home, ['cleanup']);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('Removed stale-followup');
+      expect(readRoutineYaml(home, 'stale-followup')).toBeNull();
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -37,6 +37,10 @@ import {
   getRunDir,
   getJobPath,
   parseAtTime,
+  hasCompletedOneShotRun,
+  isOneShotLikeSchedule,
+  isOneShotRoutine,
+  isPastOneShotRoutine,
   jobRunsOnThisDevice,
   checkJobDeviceEligibility,
   normalizeTriggerEvent,
@@ -66,7 +70,8 @@ import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
-import { loadDevices } from '../lib/devices/registry.js';
+import { loadDevices, loadDevicesSync } from '../lib/devices/registry.js';
+import type { DeviceRegistry } from '../lib/devices/registry.js';
 import { machineId, normalizeHost } from '../lib/machine-id.js';
 import { addHostOption } from '../lib/hosts/option.js';
 
@@ -113,6 +118,189 @@ function fireConditionLabel(job: JobConfig): string {
     return `on linear:${job.trigger.event}${filters ? ` (${filters})` : ''}`;
   }
   return '-';
+}
+
+function scheduleLabel(job: JobConfig): string {
+  let label = fireConditionLabel(job);
+  if (isOneShotRoutine(job)) label = `${label} (one-shot)`;
+  if (job.endAt) {
+    const end = new Date(job.endAt);
+    const endLabel = Number.isFinite(end.getTime())
+      ? end.toLocaleDateString()
+      : job.endAt;
+    label = `${label} (until ${endLabel})`;
+  }
+  return label;
+}
+
+function nextRunForDisplay(job: JobConfig, scheduler: JobScheduler): Date | null {
+  if (isPastOneShotRoutine(job)) return null;
+  return scheduler.getNextRun(job.name);
+}
+
+function nextRunLabel(job: JobConfig, scheduler: JobScheduler, now: Date): string {
+  if (isPastOneShotRoutine(job)) return 'expired';
+  return humanizeNextRun(scheduler.getNextRun(job.name) ?? null, now, job.timezone);
+}
+
+function deviceStateLabel(name: string, registry: DeviceRegistry): string | null {
+  const profile = registry[normalizeHost(name)] ?? registry[name];
+  if (!profile) return 'unknown';
+  if (profile.reachability?.reachable === false) return 'offline';
+  if (profile.reachability?.reachable === true) return 'online';
+  if (profile.tailscale?.online === false) return 'offline';
+  if (profile.tailscale?.online === true) return 'online';
+  return 'unknown';
+}
+
+function titleWithDeviceState(title: string, name: string, registry: DeviceRegistry): string {
+  const state = deviceStateLabel(name, registry);
+  return state && state !== 'online' ? `${title} (${state})` : title;
+}
+
+function placementTag(job: JobConfig): string {
+  const strategy = resolveHostStrategy(job);
+  if (strategy === 'local') return job.host ? `->${job.host}` : '';
+  if (strategy === 'host') return `->${job.host ?? '?'}`;
+  if (strategy === 'fleet') return '->fleet';
+  return '->cloud';
+}
+
+function deviceLabel(job: JobConfig, width?: number): { raw: string; display: string; dim: boolean } {
+  const full = [job.devices?.join(',') ?? '', placementTag(job)]
+    .filter(Boolean)
+    .join(' ');
+  const raw = full.length === 0 ? 'all' : full;
+  const display = width && raw.length > width
+    ? raw.slice(0, width - 1) + '…'
+    : raw;
+  return { raw, display, dim: full.length === 0 || !jobRunsOnThisDevice(job) };
+}
+
+export interface RoutineListGroup {
+  key: string;
+  title: string;
+  jobs: JobConfig[];
+}
+
+export function groupRoutineJobsByDevice(
+  jobs: JobConfig[],
+  registry: DeviceRegistry,
+  self: string = machineId(),
+): RoutineListGroup[] {
+  const groups = new Map<string, RoutineListGroup>();
+  const add = (key: string, title: string, job: JobConfig): void => {
+    const existing = groups.get(key);
+    if (existing) {
+      existing.jobs.push(job);
+      return;
+    }
+    groups.set(key, { key, title, jobs: [job] });
+  };
+
+  for (const job of jobs) {
+    const strategy = resolveHostStrategy(job);
+    if (strategy === 'cloud') {
+      add('cloud', 'Cloud', job);
+      continue;
+    }
+    if (strategy === 'fleet') {
+      add('fleet', 'Fleet-wide', job);
+      continue;
+    }
+    if (strategy === 'host') {
+      const host = job.host ?? 'unknown-host';
+      add(`host:${normalizeHost(host)}`, titleWithDeviceState(`Host: ${host}`, host, registry), job);
+      continue;
+    }
+
+    const devices = job.devices ?? [];
+    if (devices.length === 0) {
+      add('fleet', 'Fleet-wide', job);
+      continue;
+    }
+    for (const device of devices) {
+      const normalized = normalizeHost(device);
+      if (normalized === self) {
+        add('this-machine', `This machine (${self})`, job);
+      } else {
+        add(`device:${normalized}`, titleWithDeviceState(`Device: ${normalized}`, normalized, registry), job);
+      }
+    }
+  }
+
+  const order = (group: RoutineListGroup): number => {
+    if (group.key === 'this-machine') return 0;
+    if (group.key === 'fleet') return 1;
+    if (group.key === 'cloud') return 2;
+    if (group.key.startsWith('device:')) return 3;
+    if (group.key.startsWith('host:')) return 4;
+    return 5;
+  };
+  return [...groups.values()].sort((a, b) => order(a) - order(b) || a.title.localeCompare(b.title));
+}
+
+interface RenderRowsOptions {
+  jobs: JobConfig[];
+  scheduler: JobScheduler;
+  overdueSet: Set<string>;
+  link: (label: string, url: string | null) => string;
+  now: Date;
+}
+
+function renderRoutineRows({ jobs, scheduler, overdueSet, link, now }: RenderRowsOptions): void {
+  const NAME_W = 24;
+  const AGENT_W = 10;
+  const REPO_W = REPO_DISPLAY_MAX;
+  const DEVICE_W = 22;
+  const SCHED_W = 34;
+  const ENABLED_W = 10;
+  const NEXT_W = 22;
+
+  const header =
+    `  ${'Name'.padEnd(NAME_W)} ${'Agent'.padEnd(AGENT_W)} ${'Repo'.padEnd(REPO_W)} ${'Devices'.padEnd(DEVICE_W)} ${'Schedule'.padEnd(SCHED_W)} ${'Enabled'.padEnd(ENABLED_W)} ${'Next Run'.padEnd(NEXT_W)} Last Status`;
+  console.log(chalk.gray(header));
+  console.log(chalk.gray('  ' + '-'.repeat(NAME_W + AGENT_W + REPO_W + DEVICE_W + SCHED_W + ENABLED_W + NEXT_W + 20)));
+
+  for (const job of jobs) {
+    const nextStr = nextRunLabel(job, scheduler, now);
+    const schedStr = scheduleLabel(job);
+    const latestRun = getLatestRun(job.name);
+    const lastStatus = latestRun?.status || '-';
+
+    const sourceRepo = job.source?.repo ?? job.repo;
+    const sourceLabel = sourceRepo
+      ? (job.source?.branch ? `${sourceRepo}@${job.source.branch}` : sourceRepo)
+      : null;
+    const repoInfo = formatRepoLink(sourceLabel ?? job.repo);
+    const repoCell = link(repoInfo.display, repoInfo.href);
+    const repoPadding = Math.max(0, REPO_W - repoInfo.display.length);
+
+    const enabledStr = job.enabled ? chalk.green('yes') : chalk.gray('no');
+    const enabledWord = job.enabled ? 'yes' : 'no';
+    const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
+
+    const device = deviceLabel(job, DEVICE_W);
+    const deviceCell = device.dim ? chalk.gray(device.display) : device.display;
+    const devicePad = Math.max(0, DEVICE_W - device.display.length);
+
+    const statusColor =
+      lastStatus === 'completed' ? chalk.green
+      : lastStatus === 'failed' ? chalk.red
+      : lastStatus === 'timeout' ? chalk.yellow
+      : chalk.gray;
+
+    const overdueTag = overdueSet.has(job.name) ? chalk.yellow(' (overdue)') : '';
+
+    const agentLabelPadded = job.command
+      ? chalk.magenta('command'.padEnd(10))
+      : job.workflow
+        ? chalk.magenta(`wf:${job.workflow}`.padEnd(10))
+        : (job.agent || '').padEnd(10);
+    console.log(
+      `  ${chalk.cyan(job.name.padEnd(NAME_W))} ${agentLabelPadded} ${repoCell}${' '.repeat(repoPadding)} ${deviceCell}${' '.repeat(devicePad)} ${schedStr.padEnd(SCHED_W)} ${enabledStr}${' '.repeat(enabledPad)} ${chalk.gray(nextStr.padEnd(NEXT_W))} ${statusColor(lastStatus)}${overdueTag}`
+    );
+  }
 }
 
 function parseRoutineTrigger(options: Record<string, unknown>): JobTrigger | undefined {
@@ -363,7 +551,13 @@ export function registerRoutinesCommands(program: Command): void {
     .command('list')
     .description('See all scheduled jobs, when they run next, and their last execution status')
     .option('--json', 'Emit machine-readable JSON instead of the table (used by the menu bar helper)')
-    .action((options: { json?: boolean }) => {
+    .option('--group-by <field>', 'Group table output by device (default for terminal output)')
+    .option('--flat', 'Print the legacy flat table instead of grouped sections')
+    .action((options: { json?: boolean; groupBy?: string; flat?: boolean }) => {
+      if (options.groupBy && options.groupBy !== 'device') {
+        console.error(chalk.red(`Unsupported --group-by '${options.groupBy}'. Use: device`));
+        process.exit(1);
+      }
       try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
       const jobs = listAllJobs(process.cwd());
       if (jobs.length === 0) {
@@ -392,7 +586,6 @@ export function registerRoutinesCommands(program: Command): void {
       if (options.json) {
         const nowJson = new Date();
         const payload = jobs.map((job) => {
-          const nextRun = scheduler.getNextRun(job.name);
           const latestRun = getLatestRun(job.name);
           return {
             name: job.name,
@@ -410,11 +603,14 @@ export function registerRoutinesCommands(program: Command): void {
             source: job.source ?? null,
             sourceRepo: job.source?.repo ?? job.repo ?? null,
             sourceBranch: job.source?.branch ?? null,
+            runOnce: Boolean(job.runOnce),
+            oneShot: isOneShotRoutine(job),
+            expired: isPastOneShotRoutine(job, nowJson),
             runsHere: jobRunsOnThisDevice(job),
             enabled: job.enabled,
             overdue: overdueSet.has(job.name),
-            nextRun: nextRun ? nextRun.toISOString() : null,
-            nextRunHuman: humanizeNextRun(nextRun ?? null, nowJson, job.timezone),
+            nextRun: nextRunForDisplay(job, scheduler)?.toISOString() ?? null,
+            nextRunHuman: nextRunLabel(job, scheduler, nowJson),
             lastStatus: latestRun?.status ?? null,
             exitCode: latestRun?.exitCode ?? null,
             failureReason: latestRun?.errorMessage ?? null,
@@ -436,89 +632,19 @@ export function registerRoutinesCommands(program: Command): void {
         url && process.stdout.isTTY ? `\x1b]8;;${url}\x07${label}\x1b]8;;\x07` : label;
 
       const now = new Date();
-
-      const NAME_W = 24;
-      const AGENT_W = 10;
-      const REPO_W = REPO_DISPLAY_MAX;
-      const DEVICE_W = 22;
-      const SCHED_W = 22;
-      const ENABLED_W = 10;
-      const NEXT_W = 22;
-
-      const header =
-        `  ${'Name'.padEnd(NAME_W)} ${'Agent'.padEnd(AGENT_W)} ${'Repo'.padEnd(REPO_W)} ${'Devices'.padEnd(DEVICE_W)} ${'Schedule'.padEnd(SCHED_W)} ${'Enabled'.padEnd(ENABLED_W)} ${'Next Run'.padEnd(NEXT_W)} Last Status`;
-      console.log(chalk.gray(header));
-      console.log(chalk.gray('  ' + '-'.repeat(NAME_W + AGENT_W + REPO_W + DEVICE_W + SCHED_W + ENABLED_W + NEXT_W + 20)));
-
-      for (const job of jobs) {
-        const nextRun = scheduler.getNextRun(job.name);
-        const nextStr = humanizeNextRun(nextRun ?? null, now, job.timezone);
-        let schedStr = fireConditionLabel(job);
-        if (job.endAt) {
-          const end = new Date(job.endAt);
-          const endLabel = Number.isFinite(end.getTime())
-            ? end.toLocaleDateString()
-            : job.endAt;
-          schedStr = `${schedStr} (until ${endLabel})`;
+      if (options.flat) {
+        renderRoutineRows({ jobs, scheduler, overdueSet, link, now });
+      } else {
+        let registry: DeviceRegistry = {};
+        try {
+          registry = loadDevicesSync();
+        } catch (err) {
+          console.error(chalk.yellow(`Could not read device registry: ${(err as Error).message}`));
         }
-        const latestRun = getLatestRun(job.name);
-        const lastStatus = latestRun?.status || '-';
-
-        // Prefer project-source repo (with optional @branch) over bare job.repo.
-        const sourceRepo = job.source?.repo ?? job.repo;
-        const sourceLabel = sourceRepo
-          ? (job.source?.branch ? `${sourceRepo}@${job.source.branch}` : sourceRepo)
-          : null;
-        const repoInfo = formatRepoLink(sourceLabel ?? job.repo);
-        const repoCell = link(repoInfo.display, repoInfo.href);
-        // Pad based on the display string, not the raw cell (which may include escape codes).
-        const repoPadding = Math.max(0, REPO_W - repoInfo.display.length);
-
-        const enabledStr = job.enabled ? chalk.green('yes') : chalk.gray('no');
-        // chalk adds escape codes; pad the raw word and let chalk wrap it.
-        const enabledWord = job.enabled ? 'yes' : 'no';
-        const enabledPad = Math.max(0, ENABLED_W - enabledWord.length);
-
-        // Placement rides in the Devices cell: eligibility →execution strategy.
-        const strategy = resolveHostStrategy(job);
-        const placementTag = strategy === 'local'
-          ? (job.host ? `→${job.host}` : '')
-          : strategy === 'host'
-            ? `→${job.host ?? '?'}`
-            : strategy === 'fleet'
-              ? '→fleet'
-              : '→cloud';
-        const deviceFull = [job.devices?.join(',') ?? '', placementTag]
-          .filter(Boolean)
-          .join(' ');
-        const deviceWord = deviceFull.length === 0
-          ? 'all'
-          : deviceFull.length > DEVICE_W
-            ? deviceFull.slice(0, DEVICE_W - 1) + '…'
-            : deviceFull;
-        const deviceCell = deviceFull.length === 0
-          ? chalk.gray('all')
-          : jobRunsOnThisDevice(job)
-            ? deviceWord
-            : chalk.gray(deviceWord);
-        const devicePad = Math.max(0, DEVICE_W - deviceWord.length);
-
-        const statusColor =
-          lastStatus === 'completed' ? chalk.green
-          : lastStatus === 'failed' ? chalk.red
-          : lastStatus === 'timeout' ? chalk.yellow
-          : chalk.gray;
-
-        const overdueTag = overdueSet.has(job.name) ? chalk.yellow(' (overdue)') : '';
-
-        const agentLabelPadded = job.command
-          ? chalk.magenta('command'.padEnd(10))
-          : job.workflow
-            ? chalk.magenta(`wf:${job.workflow}`.padEnd(10))
-            : (job.agent || '').padEnd(10);
-        console.log(
-          `  ${chalk.cyan(job.name.padEnd(NAME_W))} ${agentLabelPadded} ${repoCell}${' '.repeat(repoPadding)} ${deviceCell}${' '.repeat(devicePad)} ${schedStr.padEnd(SCHED_W)} ${enabledStr}${' '.repeat(enabledPad)} ${chalk.gray(nextStr.padEnd(NEXT_W))} ${statusColor(lastStatus)}${overdueTag}`
-        );
+        for (const group of groupRoutineJobsByDevice(jobs, registry)) {
+          console.log(chalk.bold(`\n${group.title}`));
+          renderRoutineRows({ jobs: group.jobs, scheduler, overdueSet, link, now });
+        }
       }
 
       if (overdueSet.size > 0) {
@@ -595,6 +721,12 @@ export function registerRoutinesCommands(program: Command): void {
           }
           schedule = parsed.schedule;
           runOnce = parsed.runOnce;
+        }
+        if (!options.at && isOneShotLikeSchedule(schedule)) {
+          runOnce = true;
+          console.error(chalk.yellow(
+            `Schedule "${schedule}" pins minute, hour, day, and month; treating it as one-shot. Prefer --at for one-time routines.`,
+          ));
         }
 
         if (!schedule && !trigger) {
@@ -751,6 +883,12 @@ export function registerRoutinesCommands(program: Command): void {
           enabled: true,
           ...parsed,
         } as JobConfig;
+        if (isOneShotLikeSchedule(config.schedule)) {
+          config.runOnce = true;
+          console.error(chalk.yellow(
+            `Schedule "${config.schedule}" pins minute, hour, day, and month; treating it as one-shot. Prefer --at for one-time routines.`,
+          ));
+        }
 
         // Same duplicate-fire guard as --placement/--run-on: off-box placement
         // with no eligibility pin would fire from every daemon in the fleet.
@@ -781,6 +919,44 @@ export function registerRoutinesCommands(program: Command): void {
         console.log(chalk.green(`Job '${name}' added`));
 
         ensureSchedulerRunning();
+      }
+    });
+
+  routinesCmd
+    .command('cleanup')
+    .description('Remove expired one-shot routines that already fired and still have a user-layer YAML file.')
+    .option('--dry-run', 'Show routines that would be removed without deleting files')
+    .action((options: { dryRun?: boolean }) => {
+      const jobs = listAllJobs()
+        .filter((job) => getJobPath(job.name) !== null)
+        .filter((job) => hasCompletedOneShotRun(job));
+
+      if (jobs.length === 0) {
+        console.log(chalk.gray('No completed expired one-shot routines to clean up.'));
+        return;
+      }
+
+      if (options.dryRun) {
+        console.log(chalk.bold('Expired one-shot routines eligible for cleanup\n'));
+        for (const job of jobs) {
+          console.log(`  ${chalk.cyan(job.name)} ${chalk.gray(scheduleLabel(job))}`);
+        }
+        console.log(chalk.gray(`\nDry run. Remove with: agents routines cleanup`));
+        return;
+      }
+
+      let removed = 0;
+      for (const job of jobs) {
+        if (deleteJob(job.name)) {
+          removed++;
+          console.log(chalk.green(`Removed ${job.name}`));
+        }
+      }
+      console.log(chalk.gray(`Cleaned up ${removed} expired one-shot routine(s).`));
+      try {
+        signalDaemonReload();
+      } catch {
+        // The daemon may not be running; the next start will read the cleaned directory.
       }
     });
 

--- a/apps/cli/src/lib/__tests__/routines.one-shot.test.ts
+++ b/apps/cli/src/lib/__tests__/routines.one-shot.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as state from '../state.js';
+import {
+  hasCompletedOneShotRun,
+  isOneShotLikeSchedule,
+  isPastOneShotRoutine,
+  oneShotScheduleFireDate,
+  parseOneShotLikeSchedule,
+} from '../routines.js';
+
+let tmpDir = '';
+let runsDir = '';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'routines-one-shot-test-'));
+  runsDir = path.join(tmpDir, 'runs');
+  fs.mkdirSync(runsDir, { recursive: true });
+  vi.spyOn(state, 'getRunsDir').mockReturnValue(runsDir);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeRun(jobName: string, runId: string, startedAt: string): void {
+  const runDir = path.join(runsDir, jobName, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.writeFileSync(path.join(runDir, 'meta.json'), JSON.stringify({
+    jobName,
+    runId,
+    agent: 'claude',
+    pid: null,
+    status: 'completed',
+    startedAt,
+    completedAt: startedAt,
+    exitCode: 0,
+  }));
+}
+
+describe('date-specific one-shot cron detection', () => {
+  it('detects fixed minute/hour/day/month with wildcard weekday', () => {
+    expect(parseOneShotLikeSchedule('0 14 29 7 *')).toEqual({
+      minute: 0,
+      hour: 14,
+      day: 29,
+      month: 7,
+    });
+    expect(isOneShotLikeSchedule('0 14 29 7 *')).toBe(true);
+  });
+
+  it('rejects recurring cron shapes', () => {
+    expect(isOneShotLikeSchedule('0 14 29 7 1')).toBe(false);
+    expect(isOneShotLikeSchedule('0 14 * 7 *')).toBe(false);
+    expect(isOneShotLikeSchedule('0 14 29 * *')).toBe(false);
+    expect(isOneShotLikeSchedule('*/5 14 29 7 *')).toBe(false);
+  });
+
+  it('computes whether the single fire time has passed', () => {
+    const schedule = '0 14 29 7 *';
+    expect(isPastOneShotRoutine({ schedule }, new Date('2026-07-29T13:59:00'))).toBe(false);
+    expect(isPastOneShotRoutine({ schedule }, new Date('2026-07-29T14:00:00'))).toBe(true);
+  });
+
+  it('respects the routine timezone when computing the yearly fire date', () => {
+    const fireAt = oneShotScheduleFireDate(
+      '0 14 29 7 *',
+      new Date('2026-08-01T00:00:00.000Z'),
+      'America/Los_Angeles',
+    );
+    expect(fireAt?.toISOString()).toBe('2026-07-29T21:00:00.000Z');
+  });
+
+  it('requires a terminal run at or after the fire time before cleanup', () => {
+    const job = { name: 'followup', schedule: '0 14 29 7 *', timezone: 'America/Los_Angeles' };
+    expect(hasCompletedOneShotRun(job, new Date('2026-08-01T00:00:00.000Z'))).toBe(false);
+
+    writeRun('followup', '2026-07-29T21-00-01-000Z', '2026-07-29T21:00:01.000Z');
+    expect(hasCompletedOneShotRun(job, new Date('2026-08-01T00:00:00.000Z'))).toBe(true);
+  });
+});

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -845,6 +845,143 @@ export function isPastEndAt(config: Pick<JobConfig, 'endAt'>, now: Date = new Da
   return now.getTime() >= end;
 }
 
+export interface OneShotScheduleParts {
+  minute: number;
+  hour: number;
+  day: number;
+  month: number;
+}
+
+export function parseOneShotLikeSchedule(schedule: string | undefined | null): OneShotScheduleParts | null {
+  if (!schedule) return null;
+  const parts = schedule.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [minuteRaw, hourRaw, dayRaw, monthRaw, weekdayRaw] = parts;
+  if (weekdayRaw !== '*') return null;
+  if (![minuteRaw, hourRaw, dayRaw, monthRaw].every((p) => /^\d+$/.test(p))) return null;
+
+  const minute = parseInt(minuteRaw, 10);
+  const hour = parseInt(hourRaw, 10);
+  const day = parseInt(dayRaw, 10);
+  const month = parseInt(monthRaw, 10);
+  if (minute < 0 || minute > 59) return null;
+  if (hour < 0 || hour > 23) return null;
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+  return { minute, hour, day, month };
+}
+
+export function isOneShotLikeSchedule(schedule: string | undefined | null): boolean {
+  return parseOneShotLikeSchedule(schedule) !== null;
+}
+
+export function isOneShotRoutine(config: Pick<JobConfig, 'schedule' | 'runOnce'>): boolean {
+  return Boolean(config.runOnce || isOneShotLikeSchedule(config.schedule));
+}
+
+function zonedParts(date: Date, timezone: string): OneShotScheduleParts & { year: number } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+    hourCycle: 'h23',
+  }).formatToParts(date);
+  const get = (type: string): number => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour: get('hour'),
+    minute: get('minute'),
+  };
+}
+
+function zonedDateToUtc(year: number, parts: OneShotScheduleParts, timezone: string): Date | null {
+  const targetUtc = Date.UTC(year, parts.month - 1, parts.day, parts.hour, parts.minute, 0, 0);
+  let candidate = new Date(targetUtc);
+  for (let i = 0; i < 4; i++) {
+    const actual = zonedParts(candidate, timezone);
+    const actualUtc = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute, 0, 0);
+    const delta = actualUtc - targetUtc;
+    if (delta === 0) break;
+    candidate = new Date(candidate.getTime() - delta);
+  }
+  const verify = zonedParts(candidate, timezone);
+  if (
+    verify.year !== year ||
+    verify.month !== parts.month ||
+    verify.day !== parts.day ||
+    verify.hour !== parts.hour ||
+    verify.minute !== parts.minute
+  ) {
+    return null;
+  }
+  return candidate;
+}
+
+export function oneShotScheduleFireDate(
+  schedule: string | undefined | null,
+  now: Date = new Date(),
+  timezone?: string,
+): Date | null {
+  const parts = parseOneShotLikeSchedule(schedule);
+  if (!parts) return null;
+
+  if (timezone) {
+    try {
+      const year = zonedParts(now, timezone).year;
+      return zonedDateToUtc(year, parts, timezone);
+    } catch {
+      return null;
+    }
+  }
+
+  const fireAt = new Date(now.getFullYear(), parts.month - 1, parts.day, parts.hour, parts.minute, 0, 0);
+  if (
+    fireAt.getFullYear() !== now.getFullYear() ||
+    fireAt.getMonth() !== parts.month - 1 ||
+    fireAt.getDate() !== parts.day ||
+    fireAt.getHours() !== parts.hour ||
+    fireAt.getMinutes() !== parts.minute
+  ) {
+    return null;
+  }
+  return fireAt;
+}
+
+export function isPastOneShotRoutine(
+  config: Pick<JobConfig, 'schedule' | 'runOnce' | 'timezone'>,
+  now: Date = new Date(),
+): boolean {
+  if (!isOneShotRoutine(config)) return false;
+  const fireAt = oneShotScheduleFireDate(config.schedule, now, config.timezone);
+  return Boolean(fireAt && now.getTime() >= fireAt.getTime());
+}
+
+export function hasCompletedOneShotRun(
+  config: Pick<JobConfig, 'name' | 'schedule' | 'runOnce' | 'timezone'>,
+  now: Date = new Date(),
+): boolean {
+  if (!isPastOneShotRoutine(config, now)) return false;
+  const fireAt = oneShotScheduleFireDate(config.schedule, now, config.timezone);
+  if (!fireAt) return false;
+  const latest = getLatestRun(config.name);
+  if (!latest || latest.status === 'running') return false;
+  const startedAt = Date.parse(latest.startedAt);
+  return Number.isFinite(startedAt) && startedAt >= fireAt.getTime() - 60_000;
+}
+
+export function shouldPurgeCompletedOneShotRoutine(
+  config: Pick<JobConfig, 'name' | 'schedule' | 'runOnce' | 'timezone'>,
+  now: Date = new Date(),
+): boolean {
+  return hasCompletedOneShotRun(config, now);
+}
+
 /** Expand built-in and user-defined template variables in a job's prompt string. */
 export function resolveJobPrompt(config: JobConfig): string {
   const now = new Date();

--- a/apps/cli/src/lib/scheduler.ts
+++ b/apps/cli/src/lib/scheduler.ts
@@ -8,7 +8,16 @@
 
 import { Cron } from 'croner';
 import type { JobConfig } from './routines.js';
-import { listJobs, deleteJob, isPastEndAt, setJobEnabled, jobRunsOnThisDevice } from './routines.js';
+import {
+  listJobs,
+  deleteJob,
+  isPastEndAt,
+  isPastOneShotRoutine,
+  isOneShotRoutine,
+  setJobEnabled,
+  shouldPurgeCompletedOneShotRoutine,
+  jobRunsOnThisDevice,
+} from './routines.js';
 
 /** A job config paired with its active cron instance. */
 interface ScheduledJob {
@@ -31,9 +40,13 @@ export class JobScheduler {
       // Trigger-only jobs (no cron schedule) fire via the webhook receiver,
       // not the cron loop — skip them here. Jobs pinned to another device
       // (routines are fleet-synced) never enter this machine's cron loop.
-      if (config.enabled && config.schedule && jobRunsOnThisDevice(config)) {
-        this.schedule(config);
+      if (!config.enabled || !config.schedule || !jobRunsOnThisDevice(config)) continue;
+      if (shouldPurgeCompletedOneShotRoutine(config)) {
+        deleteJob(config.name);
+        continue;
       }
+      if (isPastOneShotRoutine(config)) continue;
+      this.schedule(config);
     }
   }
 
@@ -41,6 +54,11 @@ export class JobScheduler {
     // A schedule-less (trigger-only) job has nothing to hand to croner.
     if (!config.schedule) return;
     this.unschedule(config.name);
+    if (shouldPurgeCompletedOneShotRoutine(config)) {
+      deleteJob(config.name);
+      return;
+    }
+    if (isPastOneShotRoutine(config)) return;
 
     // catch: true — a throw from one job's callback should not kill the
     // whole cron loop. Each invocation of onTrigger is already wrapped in
@@ -71,7 +89,7 @@ export class JobScheduler {
       }
 
       // One-shot jobs: remove after first execution
-      if (config.runOnce) {
+      if (isOneShotRoutine(config)) {
         this.unschedule(config.name);
         deleteJob(config.name);
       }


### PR DESCRIPTION
Fixes RUSH-2074 and RUSH-2075 for agents CLI routines.

## What Changed

- Treat raw cron schedules shaped like `minute hour day month *` as one-shot routines at creation time, persist `runOnce: true`, and warn that `--at` is preferred for date-specific one-shots.
- Mark one-shot routines in `agents routines list`, show expired one-shots as `expired`, and add `agents routines cleanup` / `--dry-run` for completed expired one-shots.
- Make grouped terminal output the default for `agents routines list`, bucketed by effective device/host/cloud/fleet scope; `--flat` keeps the previous flat table available.
- Add routines docs and changelog fragment for the new list/add/cleanup behavior.

## Tickets

- https://linear.app/rush/issue/RUSH-2074
- https://linear.app/rush/issue/RUSH-2075

## Proof

No UI surface: this is CLI behavior. The terminal output below is from the changed CLI against the real local routines set.

Command:

```bash
NO_COLOR=1 node --import tsx src/index.ts routines list --group-by device
```

Output:

```text
Scheduled Jobs


This machine (yosemite-s1)
  Name                     Agent      Repo                     Devices                Schedule                           Enabled    Next Run               Last Status
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  drain-prix               claude     -                        yosemite-s1            15,45 * * * *                      yes        today 10:45 PM         completed
  drain-rush-app           claude     -                        yosemite-s1            0,30 * * * *                       yes        today 10:30 PM         completed
  hetzner-lease-gc         claude     -                        yosemite-s0,yosemite-… daily at 8:00 AM                   yes        tomorrow 8:00 AM       failed
  reaudit-prose-ask-rate   claude     -                        yosemite-s0,yosemite-… 0 9 28 7 * (one-shot)              yes        expired                -
  review-open-prs          claude     muqsitnawaz/agents       yosemite-s0,yosemite-… daily at 9:00 AM                   yes        tomorrow 9:00 AM       failed
  rush-blog-engine         wf:blog-engine muqsitnawaz/agents       yosemite-s0,yosemite-… 0 8 * * 1,3,5                      yes        Mon 8:00 AM            failed
  security-sweep           claude     muqsitnawaz/agents       yosemite-s0,yosemite-… daily at 8:30 AM                   yes        tomorrow 8:30 AM       failed
  slack-link-rotate        claude     -                        yosemite-s0,yosemite-… 0 9 1,13,25 *                    yes        Aug 13, 9:00 AM        failed

Fleet-wide
  Name                     Agent      Repo                     Devices                Schedule                           Enabled    Next Run               Last Status
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  branch-cleanup           claude     -                        all                    daily at 7:00 PM                   no         -                      -
  watchdog                 command    -                        all                    every 2 minutes                    yes        today 10:18 PM         running
  check-updates            command    -                        all                    Mondays at 9:00 AM                 yes        Mon 9:00 AM            - (overdue)

Device: mac-mini
  Name                     Agent      Repo                     Devices                Schedule                           Enabled    Next Run               Last Status
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  crm-pipeline-brief       claude     muqsitnawaz/agents       mac-mini               weekdays at 8:00 AM                yes        -                      -
  linkedin-reachout        claude     muqsitnawaz/agents       mac-mini               weekdays at 9:00 AM                yes        -                      -
  linkedin-scout           claude     muqsitnawaz/agents       mac-mini               weekdays at 9:00 AM                yes        -                      -

Device: worker (unknown)
  Name                     Agent      Repo                     Devices                Schedule                           Enabled    Next Run               Last Status
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  agents-cli-updates       claude     -                        yosemite-s0,worker     Mondays at 8:00 AM                 yes        -                      -

Device: yosemite-s0
  Name                     Agent      Repo                     Devices                Schedule                           Enabled    Next Run               Last Status
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  agents-cli-updates       claude     -                        yosemite-s0,worker     Mondays at 8:00 AM                 yes        -                      -
  content-scout            command    -                        yosemite-s0            daily at 3:00 AM                   yes        -                      -
  cycle-hygiene            claude     -                        yosemite-s0            daily at 8:00 AM                   yes        -                      -
  drain-agents-cli         claude     -                        yosemite-s0            0,30 * * * *                       yes        -                      -
  drain-linear-cli         claude     -                        yosemite-s0            20,50 * * * *                      yes        -                      failed
  drain-rush-cli           claude     -                        yosemite-s0            10,40 * * * *                      yes        -                      -
  hetzner-lease-gc         claude     -                        yosemite-s0,yosemite-… daily at 8:00 AM                   yes        tomorrow 8:00 AM       failed
  pilot-triage             claude     -                        yosemite-s0            daily at 8:30 AM                   yes        -                      -
  reaudit-prose-ask-rate   claude     -                        yosemite-s0,yosemite-… 0 9 28 7 * (one-shot)              yes        expired                -
  review-open-prs          claude     muqsitnawaz/agents       yosemite-s0,yosemite-… daily at 9:00 AM                   yes        tomorrow 9:00 AM       failed
  rush-blog-engine         wf:blog-engine muqsitnawaz/agents       yosemite-s0,yosemite-… 0 8 * * 1,3,5                      yes        Mon 8:00 AM            failed
  security-sweep           claude     muqsitnawaz/agents       yosemite-s0,yosemite-… daily at 8:30 AM                   yes        tomorrow 8:30 AM       failed
  slack-link-rotate        claude     -                        yosemite-s0,yosemite-… 0 9 1,13,25 *                    yes        Aug 13, 9:00 AM        failed

Device: zion
  Name                     Agent      Repo                     Devices                Schedule                           Enabled    Next Run               Last Status
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  git-hygiene              claude     muqsitnawaz/agents       zion                   daily at 9:00 AM                   yes        -                      -
  llyra-pitch-followup     claude     -                        zion                   0 14 29 7 * (one-shot)             yes        expired                -
  rush-1107-ssl-watch      claude     -                        zion                   0 8,13 * * 1-5                     yes        -                      -
  weekly-fleet-retro       command    -                        zion                   Sundays at 9:00 PM                 yes        -                      -

  1 routine(s) overdue — catch up with: agents routines catchup
```

Cleanup path, real local routines set:

```text
No completed expired one-shot routines to clean up.
```

Cleanup path, isolated real HOME with a completed expired one-shot YAML routine:

```text
Expired one-shot routines eligible for cleanup

  stale-one 0 0 1 1 * (one-shot)

Dry run. Remove with: agents routines cleanup
Removed stale-one
Cleaned up 1 expired one-shot routine(s).
cleanup file removed
```

Targeted verification:

```text
bun test scripts/gen-changelog.test.ts src/commands/routines.test.ts src/lib/__tests__/routines.one-shot.test.ts src/lib/__tests__/scheduler.endAt.test.ts
50 pass, 0 fail, 256 expect()

bun run build
passed

git diff --check
passed
```

Full-suite note:

```text
bun run test
Test Files 39 failed | 557 passed | 5 skipped (601)
Tests 167 failed | 7441 passed | 77 skipped (7685)
```

Representative environment failures included read-only writes under `/home/muqsit/.agents/.cache/helpers/...`, `/home/muqsit/.agents/.history/runs/...`, and `/home/muqsit/.npm/_cacache/tmp/...`, plus existing injected environment values changing expected test fixtures.

## Session Transcript

Omitted from this public PR. Local transcript path: `yosemite-s1:/home/muqsit/.agents/.history/versions/codex/0.146.0/home/.codex/sessions/2026/08/01/rollout-2026-08-01T22-01-49-019fc0d9-8869-7a52-a85d-b4e3159ecdd3.jsonl`.
