### PR TITLE
fix(sessions): keep model column within terminal width

### DIFF
--- a/apps/cli/src/commands/__tests__/sessions-columns.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-columns.test.ts
@@ -19,6 +19,7 @@ import {
   linkCwdCell,
 } from '../sessions.js';
 import type { SessionMeta } from '../../lib/session/types.js';
+import { stringWidth } from '../../lib/session/width.js';
 
 const strip = (s: string) => s.replace(/\[[0-9;]*m/g, '');
 
@@ -179,16 +180,22 @@ describe('static flat-list columns', () => {
 
   it('keeps a modeled row within an 80-column terminal', () => {
     const original = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+    const originalColumnsEnv = process.env.COLUMNS;
+    delete process.env.COLUMNS;
     Object.defineProperty(process.stdout, 'columns', { configurable: true, writable: true, value: 80 });
     try {
       const session = meta({
         timestamp: new Date().toISOString(),
         model: 'claude-sonnet-4-20250514',
+        ticketId: 'RUSH-1992',
         topic: 'A topic that must shrink without wrapping the row',
       });
-      const row = stripVTControlCharacters(flatSessionRow(session, undefined, false, pickerColumnsFor([session])));
-      expect(row.length).toBeLessThanOrEqual(80);
+      const row = stripVTControlCharacters(flatSessionRow(session, undefined, true, pickerColumnsFor([session])));
+      expect(stringWidth(row)).toBeLessThanOrEqual(80);
+      expect(row).not.toContain('sonnet-4');
     } finally {
+      if (originalColumnsEnv === undefined) delete process.env.COLUMNS;
+      else process.env.COLUMNS = originalColumnsEnv;
       if (original) Object.defineProperty(process.stdout, 'columns', original);
       else delete (process.stdout as { columns?: number }).columns;
     }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1614,8 +1614,14 @@ export function flatSessionRow(session: SessionMeta, live?: ActiveSession, showT
   const machineW = cols.showMachine ? machineColW : 0;
   const ticketW = showTicket ? TICKET_W + 1 : 0;
   const wtW = wt ? stringWidth(wt) + 1 : 0;
-  const modelW = cols.showModel ? (cols.modelWidth ?? PICKER_MODEL_MAX) : 0;
-  const topicW = Math.max(16, terminalWidth() - (10 + 9 + 8 + modelW + 16) - glyphW - statusW - machineW - ticketW - wtW - stringWidth(when) - 1);
+  const width = terminalWidth();
+  const requestedModelW = cols.showModel ? (cols.modelWidth ?? PICKER_MODEL_MAX) : 0;
+  const fixedW = (10 + 9 + 8 + 16) + glyphW + statusW + machineW + ticketW + wtW + stringWidth(when) + 1;
+  const modelSlack = width - fixedW - 16;
+  const modelW = requestedModelW <= modelSlack
+    ? requestedModelW
+    : modelSlack >= PICKER_MODEL_MIN ? modelSlack : 0;
+  const topicW = Math.max(16, width - fixedW - modelW);
 
   return (
     chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +


### PR DESCRIPTION
Fixes the RUSH-1992 80-column regression introduced by #1660.

## What changed

- Derive the flat row's effective model width from the slack remaining after the 16-cell topic floor and all enabled columns.
- Preserve the requested pool-sized model column when it fits, shrink it to its six-cell minimum when possible, and omit it when narrower terminals cannot afford that minimum.
- Exercise the reported ticketed-row case at 80 columns with `COLUMNS` explicitly cleared so `terminalWidth()` uses the controlled TTY width.

## Real run

Built the CLI, then invoked the compiled `flatSessionRow` renderer with `COLUMNS=80`, a Claude model, and `ticketId: RUSH-1992`:

```text
abcdef01  claude   1.2.3   agents-cli      A topic that mus…RUSH-1992  just now
display width: 79
model visible: false
```

CLI-only terminal fix; there is no graphical surface. The compiled output demonstrates the corrected user-visible row.

## Verification

- `bunx vitest run src/commands/__tests__/sessions-columns.test.ts` — 25 tests passed.
- `./scripts/build.sh --clean --skip-tests` — 1,122 files, 8,921 KB.

## Context

- [RUSH-1992](https://linear.app/rush/issue/RUSH-1992)
- Follow-up to #1660 and its independent Droid review.

Pure bug fix: existing sessions documentation and queued changelog already promise width-safe 80-column output, so no prose update is needed.
