### PR TITLE
feat(cli): forward removed check/resources to their replacements [RUSH-1234]

### DIFF
--- a/apps/cli/.changelog/next/rush-1234-deprecation-tombstones.md
+++ b/apps/cli/.changelog/next/rush-1234-deprecation-tombstones.md
@@ -1,0 +1,11 @@
+- **Removed `agents check` / `agents resources` now forward to their replacements
+  instead of erroring (RUSH-1234).** After the command consolidation, running the
+  removed names produced a bare `unknown command` (their edit-distance to `doctor`
+  was too far to even trigger a "did you mean"). They are now hidden tombstone
+  commands that print a one-line deprecation notice to stderr and re-run the
+  replacement, preserving flags and exit codes: `agents check …` runs
+  `agents doctor --check …` (so `--json` / `--quiet` / `--devices` and the CI
+  drift-gate exit code carry through), and `agents resources …` runs
+  `agents view --merged …` (with `agents inspect <target>` pointed to for
+  per-agent/per-repo detail). The notice goes to stderr so a `--json` consumer's
+  stdout stays clean. Source: `apps/cli/src/index.ts`.

--- a/apps/cli/src/index.tombstones.test.ts
+++ b/apps/cli/src/index.tombstones.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Real-CLI tests for the removed-command tombstones (RUSH-1234). `agents check`
+ * and `agents resources` were deleted when their behavior folded into
+ * `agents doctor --check` and `agents view --merged`; the hidden alias commands
+ * in index.ts must (1) print a deprecation notice to STDERR — never stdout, so a
+ * `--json` consumer's stdout stays clean — and (2) forward into the replacement,
+ * preserving flags and the drift-gate exit code. No mocks: we build a temp HOME
+ * with a real installed version + a real source command, then drive the actual
+ * CLI in a subprocess.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+
+let testHome: string;
+let projectDir: string;
+
+afterEach(() => {
+  if (testHome) fs.rmSync(testHome, { recursive: true, force: true });
+  if (projectDir) fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+/** Temp HOME with an installed claude@2.0.0 and one user-layer source command. */
+function seedHome(): void {
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-tombstone-home-'));
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-tombstone-proj-'));
+
+  const userDir = path.join(testHome, '.agents');
+  const systemDir = path.join(userDir, '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+  fs.writeFileSync(path.join(userDir, 'agents.yaml'), 'agents:\n  claude: "2.0.0"\n');
+
+  const binDir = path.join(userDir, '.history', 'versions', 'claude', '2.0.0', 'node_modules', '.bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(path.join(binDir, 'claude'), 0o755);
+
+  const commandsDir = path.join(userDir, 'commands');
+  fs.mkdirSync(commandsDir, { recursive: true });
+  fs.writeFileSync(path.join(commandsDir, 'demo.md'), '---\ndescription: demo\n---\n\n# demo\n');
+}
+
+// Note: no implicit --cwd here. `doctor` accepts --cwd (the check test passes it
+// explicitly); `view` does not, and neither did the old `resources` — view resolves
+// the resource surface from HOME + process.cwd().
+function run(...args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync('bun', [INDEX, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: testHome,
+      AGENTS_NO_AUTOPULL: '1',
+      AGENTS_DEVICES_DIR: path.join(testHome, '.agents', '.history', 'devices'),
+    },
+    encoding: 'utf-8',
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('removed-command tombstones (RUSH-1234)', () => {
+  it('`agents check` forwards to `doctor --check`: notice on stderr, JSON on stdout, exit code preserved', () => {
+    seedHome(); // installed but never-synced → doctor --check must exit non-zero
+
+    // --cwd points doctor at the empty project dir; the tombstone must forward it
+    // through to `doctor --check --json --cwd <dir>`.
+    const r = run('check', '--json', '--cwd', projectDir);
+
+    // Notice is on stderr, NOT stdout — stdout must be parseable JSON for CI.
+    expect(r.stderr).toContain('Deprecated');
+    expect(r.stderr).toContain('doctor --check');
+    expect(r.stdout).not.toContain('Deprecated');
+
+    const parsed = JSON.parse(r.stdout); // proves it reached doctor --check's JSON path
+    expect(parsed).toHaveProperty('hasDrift');
+    expect(parsed.hasDrift).toBe(true); // never-synced version → drift
+    expect(r.status).not.toBe(0); // the gate exit code survived the rename
+  });
+
+  it('`agents resources` forwards to `view --merged`: notice on stderr, merged table on stdout', () => {
+    seedHome();
+
+    const r = run('resources');
+
+    expect(r.stderr).toContain('Deprecated');
+    expect(r.stderr).toContain('view --merged');
+    expect(r.stderr).toContain('inspect'); // points at inspect for per-target detail
+    expect(r.stdout).not.toContain('Deprecated');
+    // The merged first-wins renderer prints a "… merged" header and per-kind rows.
+    expect(r.stdout.toLowerCase()).toContain('merged');
+    expect(r.status).toBe(0);
+  });
+
+  it('neither removed name appears as "unknown command"', () => {
+    seedHome();
+    for (const name of ['check', 'resources']) {
+      const r = run(name, '--help');
+      expect(r.stderr).not.toContain(`unknown command '${name}'`);
+    }
+  });
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -802,6 +802,43 @@ function registerJobsCronAliasCommand(p: Command, alias: string): void {
     });
 }
 
+/**
+ * Removed `check` command (RUSH-1234) — re-parses as `doctor --check`, forwarding
+ * any remaining flags so `check --quiet` / `check --json` / `check --devices` keep
+ * working and the drift-gate exit code survives the rename. The notice goes to
+ * stderr so `--json` stdout stays clean for CI parsers.
+ */
+function registerCheckTombstoneCommand(p: Command): void {
+  p.command('check', { hidden: true })
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async () => {
+      console.error(chalk.yellow('Deprecated: "agents check" is now "agents doctor --check". Running that for you.\n'));
+      const args = process.argv.slice(2);
+      args[0] = 'doctor';
+      args.splice(1, 0, '--check');
+      await program.parseAsync(['node', 'agents', ...args]);
+    });
+}
+
+/**
+ * Removed `resources` command (RUSH-1234) — re-parses as `view --merged` (the
+ * cross-layer, first-wins resource table now lives there; `agents inspect <target>`
+ * covers per-agent / per-repo detail). Forwards remaining flags like `--json`.
+ */
+function registerResourcesTombstoneCommand(p: Command): void {
+  p.command('resources', { hidden: true })
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async () => {
+      console.error(chalk.yellow('Deprecated: "agents resources" is now "agents view --merged" (use "agents inspect <target>" for per-agent/per-repo detail). Running that for you.\n'));
+      const args = process.argv.slice(2);
+      args[0] = 'view';
+      args.splice(1, 0, '--merged');
+      await program.parseAsync(['node', 'agents', ...args]);
+    });
+}
+
 /** Self-upgrade command (`agents upgrade [version]`). */
 function registerUpgradeCommand(p: Command): void {
   p.command('upgrade')
@@ -890,6 +927,16 @@ async function registerEagerForRequest(name: string): Promise<boolean> {
       registerJobsCronAliasCommand(program, name);
       await reg(loadRoutines);
       return true;
+    case 'check':
+      // The action re-parses as `doctor --check`, so doctor must exist too.
+      registerCheckTombstoneCommand(program);
+      await reg(loadDoctor);
+      return true;
+    case 'resources':
+      // The action re-parses as `view --merged`, so view must exist too.
+      registerResourcesTombstoneCommand(program);
+      await reg(loadView);
+      return true;
     case 'upgrade':
       registerUpgradeCommand(program);
       return true;
@@ -910,6 +957,7 @@ async function registerEagerForRequest(name: string): Promise<boolean> {
  */
 async function registerAllEagerCommands(): Promise<void> {
   await reg(loadView);
+  registerResourcesTombstoneCommand(program);
   await reg(loadShare);
   await reg(loadSend);
   await reg(loadInspect);
@@ -942,6 +990,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadTrash);
   await reg(loadRestore);
   await reg(loadDoctor);
+  registerCheckTombstoneCommand(program);
   await reg(loadApply);
   await reg(loadStatus);
   registerExecAliasCommand(program);


### PR DESCRIPTION
## What

Follow-up to the command consolidation (`da0fa793`, RUSH-1234). That change deleted `agents check` and `agents resources` but left them as bare `unknown command` errors — their edit-distance to `doctor` is too far to even trigger a "did you mean". This adds hidden **tombstone commands** that print a one-line deprecation notice and **forward** to the replacement:

- `agents check …` → `agents doctor --check …` — `--json` / `--quiet` / `--devices` and the **CI drift-gate exit code** all carry through.
- `agents resources …` → `agents view --merged …` — points at `agents inspect <target>` for per-agent/per-repo detail.

The notice goes to **stderr**, not stdout, so a `--json` consumer's stdout stays clean for parsing. Registered on both the fast request-routed path (`registerEagerForRequest`) and the slow all-eager path (`registerAllEagerCommands`), mirroring the existing `perms`/`exec`/`jobs`/`cron` aliases.

## Why

`check`/`resources` were long-standing command names; hard-failing them on rename is a poor migration. Forwarding preserves scripts and CI (the exit code survives) while nudging users to the new names.

## Captured run (real CLI, no mocks)

Full capture on disk: `/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/rush-1234-tombstones-run.txt`

```
$ agents resources
Deprecated: "agents resources" is now "agents view --merged" (use "agents inspect <target>" ...). Running that for you.   ← stderr
Resources (9 merged)                                                                                                       ← stdout
Skills (7) / Commands (2) / ...

$ agents check --json
  stderr: Deprecated: "agents check" is now "agents doctor --check". Running that for you.
  stdout: { "hasDrift": true, "neverSynced": 1, "versions": [{ "agent": "claude", "status": "never-synced", ... }] }
  exit:   rc=1  (non-zero on drift — the CI gate survives the rename)
```

Test run — `apps/cli/src/index.tombstones.test.ts` (real subprocess, no mocks):

```
✓ agents check forwards to doctor --check: notice on stderr, JSON on stdout, exit code preserved
✓ agents resources forwards to view --merged: notice on stderr, merged table on stdout
✓ neither removed name appears as "unknown command"
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The sibling `doctor.check` + `view.merged` suites stay green with the registration changes.

## Scope note

Deferred (separate follow-up): the `doctor` output polish from a Kimi review (collapse-when-healthy, `never-synced` status column, per-row fix commands, `--check` verdict shape). `doctor.ts` was just reworked +223 in RUSH-1234; that pass deserves its own taste review.
