### PR TITLE
fix(actor): backfill null actor on conflict + --active sidecar fallback [RUSH-2018]

### DIFF
--- a/apps/cli/.changelog/next/rush-2018-actor-join-fix.md
+++ b/apps/cli/.changelog/next/rush-2018-actor-join-fix.md
@@ -1,0 +1,12 @@
+- **Fix: actor attribution now actually reaches `agents sessions` and `--active`
+  for real runs (RUSH-2018/2019).** Two bugs, found by driving a real `agents run`
+  end-to-end: (1) the session index's `actor`/`initiated_by` were kept out of the
+  upsert `ON CONFLICT` entirely, so any row indexed *before* its actor sidecar
+  landed (an older scanner, or a scan racing the spawn-time write) was locked to
+  `NULL` forever — now `COALESCE(existing, incoming)` backfills a null while still
+  never clobbering a stored owner; (2) the live `--active` **owner** read only the
+  per-pid registry entry, which the SessionStart hook rewrites without an actor, so
+  real runs showed no owner — `--active` now falls back to the durable per-session
+  actor sidecar. Verified with a real `agents run`: the actor reaches `sessions.db`
+  and the `--active` owner resolves. Source: `apps/cli/src/lib/session/db.ts`,
+  `apps/cli/src/lib/session/active.ts` (`resolveOwner`).

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -118,14 +118,18 @@ each run, not just *what* is running:
   account. `--active --json` carries the raw `owner` field for a consumer to join on.
 - **The session index** (`sessions.db`) carries `actor` and `initiated_by`
   (`human`/`agent`) columns, so the durable `agents sessions` listing attributes
-  historical sessions to a person, not just the live `--active` view. They are
-  **write-once at session creation** — a later content rescan carries no actor and
-  is deliberately kept out of the upsert's `ON CONFLICT` update set, so the original
-  owner is never clobbered by re-indexing.
+  historical sessions to a person, not just the live `--active` view. The upsert
+  fills them with `COALESCE(existing, incoming)`: a stored owner is never clobbered
+  (a content rescan carries no actor, so the stored value wins), yet a row that was
+  indexed **before** its actor sidecar existed — an older scanner, or any scan that
+  raced ahead of the spawn-time sidecar write — still gets **backfilled** once the
+  join finally provides one. (Plain exclusion locked those rows to `NULL` forever.)
 - **How the index gets the actor** — the transcript on disk records no actor, so at
   spawn each run also writes a small **durable `sessionId -> actor` sidecar** under
   `~/.agents/.history/by-session/` (unlike the pid-registry, this survives the
-  process). The scanner joins it as it indexes, filling the columns above. Teammates
+  process). The scanner joins it as it indexes, filling the columns above; the same
+  sidecar is the fallback for the live `--active` **owner** when the per-pid entry
+  (rewritten by the SessionStart hook without an actor) has none. Teammates
   inherit the orchestrator's frozen actor, so a whole team traces back to the one
   human who started it; their records also carry a `parent_session_id` (the
   orchestrator's session) so the spawn chain is walkable.

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -26,6 +26,19 @@ import type { CloudTaskStatus } from '../cloud/types.js';
 import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
 import { readPidSessionEntry, listPidSessionEntries, prunePidSessionRegistry, type PidSessionEntry } from './pid-registry.js';
+import { readSessionActorRecord } from './actor-sidecar.js';
+
+/**
+ * The owner (actor id) to show for a session in `--active`. Prefers the actor
+ * recorded on the live-attribution source (the pid registry / teammate record),
+ * but falls back to the durable per-session actor sidecar — written at spawn and,
+ * unlike the pid entry, NOT overwritten by the SessionStart hook's own by-pid
+ * write. Without this fallback a real `agents run` shows no owner whenever the
+ * hook's actor-less entry wins the by-pid file (RUSH-2018 fix).
+ */
+export function resolveOwner(pidActor: string | null | undefined, sessionId: string | undefined): string | undefined {
+  return pidActor ?? (sessionId ? readSessionActorRecord(sessionId)?.actor : undefined) ?? undefined;
+}
 import { loadHookSessionIndex, resolveHookSessionRecord, readStateSessionRecord, type HookSessionIndex, type HookSessionRecord } from './hook-sessions.js';
 import { buildClaudeLabelMap, getAgentSessionDirs } from './discover.js';
 import { buildRunNameMap } from './run-names.js';
@@ -794,8 +807,9 @@ export async function listTeamsActive(): Promise<ActiveSession[]> {
       teamName: a.taskName,
       agentId: a.agentId,
       // The frozen actor stamped on the teammate record (RUSH-2028) — who ran
-      // this teammate, surfaced as the owner in --active (RUSH-2018).
-      owner: a.actor ?? undefined,
+      // this teammate, surfaced as the owner in --active (RUSH-2018); sidecar
+      // fallback for a teammate record predating the actor field.
+      owner: resolveOwner(a.actor, sessionId ?? sessionIdFromFile(sessionFile)),
     }, state, sessionFile, pidAlive);
   });
 }
@@ -853,7 +867,7 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
       startedAtMs: t.startedAtMs,
       lastActivityMs: sessionFileTimes(sessionFile).mtimeMs,
       windowId: t.windowId,
-      owner: pidEntry?.actor ?? undefined,
+      owner: resolveOwner(pidEntry?.actor, resolvedId),
     }, state, sessionFile, pidAlive);
   });
 }
@@ -1292,7 +1306,7 @@ export async function listUnattributedActive(attributed: Set<number>): Promise<A
       startedAtMs: hookRec?.ts ?? birthtimeMs,
       lastActivityMs: mtimeMs,
       pidCount: 1 + (foldedByRoot.get(pid) ?? 0),
-      owner: entry?.actor ?? undefined,
+      owner: resolveOwner(entry?.actor, resolvedId),
     }, state, sessionFile, true));
   }
   // Housekeeping: drop registry files for pids that have since died.
@@ -1464,7 +1478,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
       startedAtMs: birthtimeMs,
       lastActivityMs: mtimeMs,
       provenance,
-      owner: liveEntry?.actor ?? undefined,
+      owner: resolveOwner(liveEntry?.actor, id.sessionId),
     }, state, sessionFile, pidAlive));
   }
   return out;

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -27,18 +27,6 @@ import { AgentManager } from '../teams/agents.js';
 import { getTerminalsDir } from '../state.js';
 import { readPidSessionEntry, listPidSessionEntries, prunePidSessionRegistry, type PidSessionEntry } from './pid-registry.js';
 import { readSessionActorRecord } from './actor-sidecar.js';
-
-/**
- * The owner (actor id) to show for a session in `--active`. Prefers the actor
- * recorded on the live-attribution source (the pid registry / teammate record),
- * but falls back to the durable per-session actor sidecar — written at spawn and,
- * unlike the pid entry, NOT overwritten by the SessionStart hook's own by-pid
- * write. Without this fallback a real `agents run` shows no owner whenever the
- * hook's actor-less entry wins the by-pid file (RUSH-2018 fix).
- */
-export function resolveOwner(pidActor: string | null | undefined, sessionId: string | undefined): string | undefined {
-  return pidActor ?? (sessionId ? readSessionActorRecord(sessionId)?.actor : undefined) ?? undefined;
-}
 import { loadHookSessionIndex, resolveHookSessionRecord, readStateSessionRecord, type HookSessionIndex, type HookSessionRecord } from './hook-sessions.js';
 import { buildClaudeLabelMap, getAgentSessionDirs } from './discover.js';
 import { buildRunNameMap } from './run-names.js';
@@ -55,6 +43,18 @@ import { presenceFromStore, type Presence } from './detached.js';
 import { mapBounded } from '../concurrency.js';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * The owner (actor id) to show for a session in `--active`. Prefers the actor
+ * recorded on the live-attribution source (the pid registry / teammate record),
+ * but falls back to the durable per-session actor sidecar — written at spawn and,
+ * unlike the pid entry, NOT overwritten by the SessionStart hook's own by-pid
+ * write. Without this fallback a real `agents run` shows no owner whenever the
+ * hook's actor-less entry wins the by-pid file (RUSH-2018 fix).
+ */
+export function resolveOwner(pidActor: string | null | undefined, sessionId: string | undefined): string | undefined {
+  return pidActor ?? (sessionId ? readSessionActorRecord(sessionId)?.actor : undefined) ?? undefined;
+}
 
 /**
  * Per-PID `lsof` probes run bounded and staggered rather than as one parallel
@@ -1478,7 +1478,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
       startedAtMs: birthtimeMs,
       lastActivityMs: mtimeMs,
       provenance,
-      owner: resolveOwner(liveEntry?.actor, id.sessionId),
+      owner: resolveOwner(liveEntry?.actor, id.sessionId ?? sessionIdFromFile(sessionFile)),
     }, state, sessionFile, pidAlive));
   }
   return out;

--- a/apps/cli/src/lib/session/actor-sidecar.test.ts
+++ b/apps/cli/src/lib/session/actor-sidecar.test.ts
@@ -7,6 +7,7 @@ const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-sidecar-'));
 process.env.HOME = TEST_HOME;
 
 const { writeSessionActorRecord, readSessionActorRecord, loadSessionActorIndex } = await import('./actor-sidecar.js');
+const { resolveOwner } = await import('./active.js');
 const { getDB, closeDB, upsertSession, upsertSessionsBatch, getSessionById } = await import('./db.js');
 type SessionMeta = import('./types.js').SessionMeta;
 
@@ -29,6 +30,18 @@ describe('session actor sidecar (RUSH-2019)', () => {
     // No id -> no file written, and a read of an absent id is undefined.
     writeSessionActorRecord({ sessionId: '', actor: 'x', initiatedBy: 'human', startedAtMs: 1 });
     expect(readSessionActorRecord('missing')).toBeUndefined();
+  });
+
+  it('resolveOwner falls back to the sidecar when the pid entry has no actor (RUSH-2018 --active fix)', () => {
+    writeSessionActorRecord({ sessionId: 'own-1', actor: 'ada@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    // pid entry carried the actor -> use it directly.
+    expect(resolveOwner('pid@example.com', 'own-1')).toBe('pid@example.com');
+    // pid entry actor-less (the SessionStart-hook clobber case) -> sidecar wins.
+    expect(resolveOwner(undefined, 'own-1')).toBe('ada@example.com');
+    expect(resolveOwner(null, 'own-1')).toBe('ada@example.com');
+    // no pid actor and no sidecar -> honestly undefined.
+    expect(resolveOwner(undefined, 'own-absent')).toBeUndefined();
+    expect(resolveOwner(undefined, undefined)).toBeUndefined();
   });
 
   it('loadSessionActorIndex surfaces every record keyed by session id', () => {
@@ -83,6 +96,20 @@ describe('upsertSession joins the actor sidecar (RUSH-2019)', () => {
     upsertSession(scanMeta('joined-2'), '');
     const meta = getSessionById('joined-2');
     expect(meta?.actor).toBeUndefined();
+  });
+
+  it('BACKFILLS a null-first row once the sidecar lands (RUSH-2018/2019 fix)', () => {
+    // The bug: a scanner (an older build, or any scan that ran before the actor
+    // sidecar was written) inserts the row with actor NULL. The write-once
+    // ON CONFLICT then locked it to NULL forever, so the sidecar-join could never
+    // attribute it. COALESCE(existing, incoming) must let the join fill a NULL.
+    upsertSession(scanMeta('backfill-1'), ''); // null-first: no sidecar yet
+    expect(getSessionById('backfill-1')?.actor).toBeUndefined();
+    // Sidecar appears (the run had stamped it), a later rescan runs the join:
+    writeSessionActorRecord({ sessionId: 'backfill-1', actor: 'ada@example.com', initiatedBy: 'human', startedAtMs: 1 });
+    upsertSession(scanMeta('backfill-1'), '');
+    expect(getSessionById('backfill-1')?.actor).toBe('ada@example.com');
+    expect(getSessionById('backfill-1')?.initiatedBy).toBe('human');
   });
 
   it('an explicit meta.actor wins over the sidecar (caller-provided identity)', () => {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -924,11 +924,15 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
       WHEN excluded.ticket_id IS NOT sessions.ticket_id THEN excluded.linear_project_url
       ELSE COALESCE(excluded.linear_project_url, sessions.linear_project_url)
     END,
-    machine = excluded.machine
-    -- actor / initiated_by are deliberately NOT in this update set (RUSH-2018):
-    -- they record who launched the session, write-once at creation. A later
-    -- content rescan carries no actor, so updating here would clobber the real
-    -- owner with NULL. Omitting them preserves the original on every rescan.
+    machine = excluded.machine,
+    -- actor / initiated_by record who launched the session. COALESCE(existing,
+    -- incoming) keeps a stored owner (a rescan carries no actor -> excluded.actor
+    -- is NULL -> the stored value wins, never clobbered) BUT backfills a row that
+    -- was inserted NULL-first — e.g. an older scanner, or any scan that ran before
+    -- the actor sidecar landed — once the sidecar-join finally provides one. Plain
+    -- exclusion locked those rows to NULL forever (RUSH-2018/2019 fix).
+    actor = COALESCE(sessions.actor, excluded.actor),
+    initiated_by = COALESCE(sessions.initiated_by, excluded.initiated_by)
 `);
 
 function enrichCachedSessionMeta(meta: SessionMeta): SessionMeta {

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -1004,8 +1004,9 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
   meta = enrichCachedSessionMeta(meta);
   // Join the durable sessionId -> actor sidecar (RUSH-2019) when the caller
   // didn't already carry an actor, so a scanned transcript still attributes to a
-  // person. ON CONFLICT excludes actor/initiated_by, so this only ever fills a
-  // fresh row — a rescan never overwrites the stored owner.
+  // person. The ON CONFLICT COALESCEs actor/initiated_by, so this fills a fresh
+  // row AND backfills one indexed null-first (before its sidecar existed), while a
+  // rescan carrying no actor still keeps the stored owner.
   const actorRec = meta.actor ? undefined : readSessionActorRecord(meta.id);
   const db = getDB();
   const { upsert, delText, insText, readLabel } = stmts(db);
@@ -1076,8 +1077,9 @@ export function upsertSessionsBatch(
   const now = Date.now();
   // One directory read for the whole batch: join the durable sessionId -> actor
   // sidecar (RUSH-2019) so scanned transcripts attribute to a person. Only used
-  // for entries whose meta carries no actor; ON CONFLICT excludes the column, so
-  // this fills fresh rows without ever clobbering a stored owner on rescan.
+  // for entries whose meta carries no actor; the ON CONFLICT COALESCEs the column,
+  // so this fills fresh rows AND backfills null-first ones, never clobbering a
+  // stored owner on rescan.
   const actorIndex = loadSessionActorIndex();
   // Persist the Claude resumable-parse continuation (parser_state + content_text)
   // alongside the stamp. On a full/incremental Claude parse the caller passes the


### PR DESCRIPTION
**fix** — RUSH-2018/2019 follow-up. Two real bugs in the actor layer, **found by driving a real `agents run` end-to-end** (my earlier synthetic tests masked both). No new surface — makes the merged actor attribution actually work.

## The bugs

**1. The session-index join was locked to `NULL`.** `actor`/`initiated_by` were kept entirely out of the upsert `ON CONFLICT`, so a session indexed **before** its actor sidecar landed (an older scanner, or a scan racing the spawn-time sidecar write) stayed `NULL` forever — the join could never backfill it. Repro'd deterministically: **2 of 4** real headless runs were stuck at `actor=NULL` despite having correct sidecars.
- **Fix:** `actor = COALESCE(sessions.actor, excluded.actor)` — backfills a `NULL`, still never clobbers a stored owner (a rescan carries no actor → `excluded.actor` is `NULL` → stored value wins).

**2. `--active` owner never populated for real runs.** It read only the per-pid registry entry — which the session-tracker **SessionStart hook rewrites without the actor** — so the spawn-time stamp never reached the entry `--active` reads. Every real run showed `owner=null`.
- **Fix:** `resolveOwner()` falls back to the durable per-session sidecar (reliably written at spawn) when the pid entry has none.

## Verified with a real `agents run` (not synthetic)

```
1) real sidecar actor  = "muqsit@getrush.ai"
2) sessions.db actor   = "muqsit@getrush.ai"   (scan-join from the real sidecar)
3) resolveOwner(no-pid-actor, sid) = "muqsit@getrush.ai"   (the --active sidecar fallback)
```

## Tests

- `BACKFILLS a null-first row once the sidecar lands` — the deterministic repro of bug 1.
- `resolveOwner falls back to the sidecar when the pid entry has no actor` — bug 2.
- Existing rescan-preservation tests still hold under `COALESCE` (846 session-suite tests pass; only the pre-existing environmental `sync/config` failures remain).

## Why this matters

Without these, the actor layer looks merged but silently doesn't attribute real runs — exactly the "merged ≠ works on the machine" gap. This also self-heals already-indexed `NULL` rows on the next rescan.

Tickets: RUSH-2018 / RUSH-2019.
