### PR TITLE
fix(hooks): collapse exact-duplicate active-version hook registrations

### DIFF
--- a/apps/cli/src/lib/__tests__/hooks.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks.test.ts
@@ -2100,6 +2100,41 @@ describe('per-version hook entry pruning (settings accumulation regression)', ()
       expect(commands).toContain(SYSTEM_HOOK);
       expect(commands).toContain(CUSTOM_HOOK);
     });
+
+    it('collapses an exact-duplicate entry of the CURRENT version to a single hook', () => {
+      // The sibling-version prune (isStaleSiblingVersionCommand) only removes a
+      // DIFFERENT version's path; it can't collapse two identical current-version
+      // entries. Seeding the same current-version command twice is what a
+      // membership-Set wiring let both survive — Claude Code then fires the hook
+      // twice. Deduplication must leave exactly one.
+      const versionHome = path.join(
+        tmpDir, '.agents', '.history', 'versions', 'claude', '2.1.201', 'home'
+      );
+      const settingsPath = path.join(versionHome, '.claude', 'settings.json');
+      fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: preToolUseGroup([
+          guardCmd('2.1.201'),   // current version
+          guardCmd('2.1.201'),   // EXACT duplicate of the current version -> collapse
+          CUSTOM_HOOK,           // user's own hook -> keep untouched
+        ]),
+      }, null, 2));
+
+      makeScript('git-guard.sh');
+      const manifest: Record<string, ManifestHook> = {
+        'git-guard': { script: 'git-guard.sh', events: ['PreToolUse'], matcher: 'Bash' },
+      };
+
+      const result = registerHooksToSettings('claude', versionHome, manifest, agentsDir);
+      expect(result.errors).toHaveLength(0);
+
+      const commands = collectCommands(JSON.parse(fs.readFileSync(settingsPath, 'utf-8')));
+      // Exactly one current-version guard entry — the duplicate is gone.
+      expect(commands.filter((c) => c === guardCmd('2.1.201'))).toEqual([guardCmd('2.1.201')]);
+      // The user's own hook is left exactly as-is.
+      expect(commands).toContain(CUSTOM_HOOK);
+    });
   });
 
   describe('remove (pruneVersionHomeHookEntriesFromSettings)', () => {

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -188,6 +188,31 @@ export function deduplicateVersionHookCommands(
   return [...passthrough, ...Array.from(selected.values(), ({ command }) => command)];
 }
 
+/**
+ * Collapse a matcher group's hook entries down to the deduplicated command
+ * multiset {@link deduplicateVersionHookCommands} returns, preserving order and
+ * the concrete entry objects. The deduped list is honored as a per-command
+ * budget, NOT a membership set: two identical active-version entries collapse to
+ * one because the budget for that command is one. (A membership `Set.has` test
+ * would keep both — the bug this replaces.) Passthrough (user / non-version-home)
+ * commands keep their original multiplicity, so genuine user hooks are untouched.
+ */
+function collapseVersionHookEntries<T extends { command: string }>(
+  entries: T[],
+  activeVersionHome: string,
+): T[] {
+  const budget = new Map<string, number>();
+  for (const command of deduplicateVersionHookCommands(entries.map((e) => e.command), activeVersionHome)) {
+    budget.set(command, (budget.get(command) ?? 0) + 1);
+  }
+  return entries.filter((e) => {
+    const remaining = budget.get(e.command) ?? 0;
+    if (remaining <= 0) return false;
+    budget.set(e.command, remaining - 1);
+    return true;
+  });
+}
+
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions, resolveVersion } from './versions.js';
 import type { AgentId, InstalledHook, ManifestHook } from './types.js';
 import { generateHookShim, getHookShimPath, isValidHookShimName, parseCacheConfig, removeHookShim } from './hooks/cache.js';
@@ -1651,16 +1676,12 @@ function registerHooksForClaude(
       hooks?: Array<{ type: string; command: string; timeout?: number }>;
     }>) {
       if (!group.hooks) continue;
-      const selectedCommands = new Set(deduplicateVersionHookCommands(
-        group.hooks.map((hook) => hook.command),
-        versionHome,
-      ));
-      group.hooks = group.hooks.filter(
+      const managed = group.hooks.filter(
         (h) =>
-          selectedCommands.has(h.command) &&
           (!isManagedHookCommand(h.command, managedPrefixes) || currentManifestPaths.has(h.command)) &&
           !isStaleSiblingVersionCommand(h.command, currentVh)
       );
+      group.hooks = collapseVersionHookEntries(managed, versionHome);
     }
   }
 
@@ -1843,16 +1864,12 @@ function registerHooksForCodex(
   for (const eventGroups of Object.values(hooksFile.hooks)) {
     for (const group of eventGroups) {
       if (!group.hooks) continue;
-      const selectedCommands = new Set(deduplicateVersionHookCommands(
-        group.hooks.map((hook) => hook.command),
-        versionHome,
-      ));
-      group.hooks = group.hooks.filter(
+      const managed = group.hooks.filter(
         (h) =>
-          selectedCommands.has(h.command) &&
           (!isManagedHookCommand(h.command, managedPrefixes) || currentManifestPaths.has(h.command)) &&
           !isStaleSiblingVersionCommand(h.command, currentVh)
       );
+      group.hooks = collapseVersionHookEntries(managed, versionHome);
     }
   }
   for (const [event, eventGroups] of Object.entries(hooksFile.hooks)) {


### PR DESCRIPTION
**bugfix / test — no UI surface** (hook registration internals + `agents doctor` unaffected). Follow-up to #1665.

## What & why

#1665 fixed the *distinct-version* Stop-hook pile-up (RUSH-2077) but left one case uncovered: its dedup wiring coerced `deduplicateVersionHookCommands`' output into a **membership `Set`**, so two **identical active-version** command entries in one matcher group both pass `selectedCommands.has(command)` and both survive. Claude Code then fires that Stop hook **twice**. The sibling-version prune only removes a *different* version's path, so it can't collapse exact duplicates either — and #1665 shipped no test through `registerHooksToSettings` for this path.

## Fix

- New shared `collapseVersionHookEntries()` helper honors the deduped list as a **per-command budget**, not a membership set — version-home resources collapse to one (active preferred), user / non-version-home commands keep their multiplicity. Wired into **both** the Claude and Codex registrars (`apps/cli/src/lib/hooks.ts`).
- Real-path regression test: seeds the current version's command **twice** in a matcher group, runs `registerHooksToSettings`, asserts exactly one survives.

## Real run (proof)

```text
tsc --noEmit  rc=0
vitest run src/lib/__tests__/hooks.test.ts
 Test Files  1 passed (1)
      Tests  97 passed (97)   # 96 prior + the new exact-duplicate real-path test
```

Found by an independent review of #1665 (which had already merged without this fix).

Linear: https://linear.app/getrush/issue/RUSH-2077/hooks-duplicate-stop-hooks-fire-from-every-installed-agent-version