### PR TITLE
docs(readme): surface the --active owner column [RUSH-2018]

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ agents sessions detach a1b2c3d4     # go headless in the background, keep workin
 agents sessions attach a1b2c3d4     # resume it interactively, right here
 ```
 
-Both are agent-agnostic -- they route through the same `agents run --resume` path (native resume for Claude/Codex, `/continue` replay for the rest). `agents sessions --active` marks each session's `presence` -- `attached` (you're watching it), `background` (running headless), or `parked` (its background run finished) -- so the menu bar and Factory show where every agent is. In the Factory extension, **Agents: Detach** (`Cmd/Ctrl+K B`) and **Agents: Attach** (`Cmd/Ctrl+K A`) do the same over the focused terminal.
+Both are agent-agnostic -- they route through the same `agents run --resume` path (native resume for Claude/Codex, `/continue` replay for the rest). `agents sessions --active` shows each session's **owner** (the human who launched it, resolved from the tailnet identity, or `-` for an unresolved local run) and its `presence` -- `attached` (you're watching it), `background` (running headless), or `parked` (its background run finished) -- so the menu bar and Factory show who is running what, and where. In the Factory extension, **Agents: Detach** (`Cmd/Ctrl+K B`) and **Agents: Attach** (`Cmd/Ctrl+K A`) do the same over the focused terminal.
 
 ---
 


### PR DESCRIPTION
**docs-only** — one-sentence README sync, no behavior change. Audience: end users of the `agents` CLI.

## What
The actor/owner provenance feature (RUSH-2018, merged in #1621/#1673) added an **owner** column to `agents sessions --active`. It's documented fully in `apps/cli/docs/06-observability.md` ("Surfacing the owner") and in the CHANGELOG, but the **top-level README** still described `--active` by `presence` alone — so the headline surface of the feature was invisible from the README.

This updates the one stale sentence to name the owner column alongside presence.

## Why now
Follow-up to the actor/owner work: closing the doc-sync gap the repo's own review conventions require ("Docs stay in sync with behavior" / "README for core features").

No run needed — pure doc edit.