### PR TITLE
fix(exec): grant ~/.agents as a codex writable root in workspace-write

### DIFF
--- a/apps/cli/.changelog/next/codex-sandbox-agents-writable-root.md
+++ b/apps/cli/.changelog/next/codex-sandbox-agents-writable-root.md
@@ -1,0 +1,15 @@
+- **`agents run codex` can now reach the fleet from inside its sandbox.** Codex's
+  `workspace-write` sandbox blocks `$HOME` (verified against the live CLI and OpenAI's
+  sandbox docs), but the model routinely shells out to `agents ...`, whose runtime state
+  lives under `~/.agents` — the SSH askpass shim (`~/.agents/.cache/devices/askpass.sh`),
+  the device/stats cache, secrets, session writes, config tunings. Those inner writes hit
+  `EROFS` (`agents ssh` died before connecting, so a remote `agents run codex` could not
+  SSH or self-tune), and the fix was previously left to the caller (teams pass
+  `--add-dir ~/.agents` explicitly; a plain `agents run` never did). `buildExecCommand`
+  now grants `~/.agents` as an extra writable root whenever Codex runs `workspace-write`
+  (`--mode edit`/`auto`) — via `--add-dir` on fresh runs (deduped against user
+  `--add-dir`s) and via `-c sandbox_workspace_write.writable_roots` on resume forms (which
+  reject `--add-dir`). This is the officially-recommended way to widen scope "without
+  removing the sandbox entirely" — far narrower than `--mode skip` (danger-full-access).
+  `plan` (read-only) and `skip` (sandbox already dropped) are unaffected. Source:
+  `apps/cli/src/lib/exec.ts` (`buildExecCommand`, `codexWritableRootsConfig`).

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -1055,6 +1055,16 @@ schema (`--json` passes through each agent's native stream format).
   `capabilities.modes[0]`, or (headless-only, e.g. kimi/grok) to `auto` with
   a stderr warning when the agent's plan mode is known to stall headless;
   `skip` on an unsupported agent throws naming the agent's real modes.
+- **EXEC-22a (MUST).** When the resolved mode puts Codex in its `workspace-write`
+  sandbox (`resolvedMode === 'edit'`), `buildExecCommand` MUST grant the user's
+  `~/.agents` dir as an extra writable root. Codex's sandbox blocks `$HOME`, but
+  the CLI tooling Codex shells out to (the SSH askpass shim at
+  `~/.agents/.cache/devices/askpass.sh`, secrets, session state, config tunings)
+  writes there — without it those inner writes fail with `EROFS`. Fresh runs pass
+  it via `--add-dir` (deduped against user `--add-dir`s); resume forms, which
+  reject `--add-dir`, pass it via `-c sandbox_workspace_write.writable_roots`
+  (`lib/exec.ts`, `codexWritableRootsConfig`). `plan` (read-only) and `skip`
+  (sandbox dropped) MUST NOT add it.
 - **EXEC-23 (MUST).** A prompt-less run inferred as interactive at a
   non-TTY MUST be refused before spawn rather than hang on dead stdin
   (`inferredInteractiveWithoutTty`, `lib/exec.ts:270-276`; enforced

--- a/apps/cli/src/lib/__tests__/exec.test.ts
+++ b/apps/cli/src/lib/__tests__/exec.test.ts
@@ -791,6 +791,16 @@ describe('buildExecCommand', () => {
       expect(cmd[ci - 1]).toBe('-c');
     });
 
+    it('codex interactive TUI resume grants ~/.agents via -c writable_roots (rejects --add-dir)', () => {
+      const cmd = buildExecCommand(opts({
+        agent: 'codex', mode: 'edit', resume: true, sessionId: 'abc-2', interactive: true, prompt: undefined,
+      }));
+      expect(cmd).not.toContain('--add-dir');
+      const ci = cmd.indexOf(codexWritableRootsConfig(AGENTS_DIR));
+      expect(ci).toBeGreaterThan(0);
+      expect(cmd[ci - 1]).toBe('-c');
+    });
+
     it('codexWritableRootsConfig emits a TOML array of the quoted dir', () => {
       expect(codexWritableRootsConfig('/home/u/.agents'))
         .toBe('sandbox_workspace_write.writable_roots=["/home/u/.agents"]');

--- a/apps/cli/src/lib/__tests__/exec.test.ts
+++ b/apps/cli/src/lib/__tests__/exec.test.ts
@@ -12,6 +12,7 @@ import {
   resolveHeadlessMode,
   defaultModeFor,
   headlessPlanStallCommand,
+  codexWritableRootsConfig,
   type ExecOptions,
 } from '../exec.js';
 import type { AgentId, Mode } from '../types.js';
@@ -740,6 +741,59 @@ describe('buildExecCommand', () => {
     it('gemini ignores addDirs', () => {
       const cmd = buildExecCommand(opts({ agent: 'gemini', addDirs: ['/a'] }));
       expect(cmd).not.toContain('--add-dir');
+    });
+  });
+
+  // --- Codex sandbox: implicit ~/.agents writable root ---
+  //
+  // Codex's workspace-write sandbox blocks $HOME, so `agents ...` the model
+  // shells out to can't write ~/.agents (askpass shim, secrets, sessions),
+  // which broke remote `agents run codex`. A fresh edit run gets ~/.agents via
+  // --add-dir; resume forms (which reject --add-dir) get it via -c writable_roots.
+  describe('codex ~/.agents writable root', () => {
+    const AGENTS_DIR = path.join(HOME, '.agents');
+
+    it('fresh codex edit run implicitly grants ~/.agents as a writable root', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'edit' }));
+      const dirs = cmd.reduce<string[]>((acc, v, i) => (v === '--add-dir' ? [...acc, cmd[i + 1]] : acc), []);
+      expect(dirs).toContain(AGENTS_DIR);
+    });
+
+    it('dedupes ~/.agents when the user also passes it explicitly', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'edit', addDirs: [AGENTS_DIR, '/x'] }));
+      const dirs = cmd.reduce<string[]>((acc, v, i) => (v === '--add-dir' ? [...acc, cmd[i + 1]] : acc), []);
+      expect(dirs.filter((d) => d === AGENTS_DIR)).toHaveLength(1);
+      expect(dirs).toContain('/x');
+    });
+
+    it('does NOT add ~/.agents for codex read-only (plan) — no writes happen there', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'plan' }));
+      expect(cmd).not.toContain(AGENTS_DIR);
+    });
+
+    it('does NOT add --add-dir for codex skip (sandbox already dropped)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'codex', mode: 'skip' }));
+      expect(cmd).not.toContain('--add-dir');
+    });
+
+    it('does NOT grant the implicit root to claude (codex-sandbox-specific)', () => {
+      const cmd = buildExecCommand(opts({ agent: 'claude', mode: 'edit' }));
+      expect(cmd).not.toContain(AGENTS_DIR);
+    });
+
+    it('codex headless resume grants ~/.agents via -c writable_roots (rejects --add-dir)', () => {
+      const cmd = buildExecCommand(opts({
+        agent: 'codex', mode: 'edit', resume: true, sessionId: 'abc-1', prompt: 'go',
+      }));
+      expect(cmd).not.toContain('--add-dir');
+      const ci = cmd.indexOf(codexWritableRootsConfig(AGENTS_DIR));
+      expect(ci).toBeGreaterThan(0);
+      expect(cmd[ci - 1]).toBe('-c');
+    });
+
+    it('codexWritableRootsConfig emits a TOML array of the quoted dir', () => {
+      expect(codexWritableRootsConfig('/home/u/.agents'))
+        .toBe('sandbox_workspace_write.writable_roots=["/home/u/.agents"]');
     });
   });
 

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -17,7 +17,7 @@ import { resolveModel, buildReasoningFlags } from './models.js';
 import { emitStart, maybeRotate, createTimer, redactPrompt, redactArgs } from './events.js';
 import { sanitizeProcessEnv } from './secrets/bundles.js';
 import { resolveActor, actorEnv } from './actor.js';
-import { getShimsDir, getHistoryDir } from './state.js';
+import { getShimsDir, getHistoryDir, getUserAgentsDir } from './state.js';
 import { resolveCodexHome } from './codex-home.js';
 import { readCodexConfiguredModel } from './shims.js';
 import { writePidSessionEntry, extractSessionIdArg } from './session/pid-registry.js';
@@ -715,6 +715,16 @@ export function nativeResume(agent: AgentId): boolean {
   return AGENT_COMMANDS[agent]?.resume !== undefined;
 }
 
+/**
+ * Build the `-c` value that adds `dir` to codex's workspace-write writable
+ * roots. Codex parses the value as TOML, so it's a single-element TOML array of
+ * one quoted string. Used on codex resume forms, which reject `--add-dir` and
+ * only accept `-c` config overrides.
+ */
+export function codexWritableRootsConfig(dir: string): string {
+  return `sandbox_workspace_write.writable_roots=[${JSON.stringify(dir)}]`;
+}
+
 /** Assemble the full CLI argument array for an agent invocation. */
 export function buildExecCommand(options: ExecOptions): string[] {
   const template = AGENT_COMMANDS[options.agent];
@@ -803,6 +813,18 @@ export function buildExecCommand(options: ExecOptions): string[] {
       `Internal error: ${options.agent} declares '${resolvedMode}' in capabilities.modes but has no entry in AGENT_COMMANDS.modeFlags.${resolvedMode}.`,
     );
   }
+  // Codex's workspace-write sandbox blocks $HOME (verified against the live CLI
+  // and OpenAI's sandbox docs: writable roots extend scope "without removing the
+  // sandbox entirely"). But the model routinely shells out to `agents ...`, whose
+  // runtime state lives under ~/.agents — the SSH askpass shim
+  // (~/.agents/.cache/devices/askpass.sh), the device/stats cache, secrets,
+  // session writes, config tunings. Without ~/.agents as a writable root those
+  // inner writes fail with EROFS (e.g. `agents ssh` dies before connecting),
+  // which is why a remote `agents run codex` couldn't reach the fleet. Grant it
+  // implicitly whenever codex runs workspace-write — far narrower than --mode skip
+  // (danger-full-access). Fresh runs take --add-dir (below); resume forms reject
+  // --add-dir, so they take the same root via -c writable_roots here.
+  const codexWorkspaceWrite = options.agent === 'codex' && resolvedMode === 'edit';
   if (resumeSpec && 'subcommand' in resumeSpec) {
     if (resolvedMode === 'skip') {
       // skip = yolo on resume too; both `codex resume` (TUI) and
@@ -811,6 +833,7 @@ export function buildExecCommand(options: ExecOptions): string[] {
     } else if (interactive) {
       // `codex resume` (TUI) accepts the same -s/--sandbox flags as a fresh run.
       cmd.push(...modeFlags);
+      if (codexWorkspaceWrite) cmd.push('-c', codexWritableRootsConfig(getUserAgentsDir()));
     } else {
       // `codex exec resume` rejects `--sandbox <mode>` (verified against
       // `codex exec resume --help` on 0.142.5), but takes -c config overrides —
@@ -819,6 +842,7 @@ export function buildExecCommand(options: ExecOptions): string[] {
       cmd.push('-c', `sandbox_mode=${resolvedMode === 'plan' ? 'read-only' : 'workspace-write'}`);
       if (resolvedMode !== 'plan') {
         cmd.push('-c', 'sandbox_workspace_write.network_access=true');
+        cmd.push('-c', codexWritableRootsConfig(getUserAgentsDir()));
       }
     }
   } else if (options.agent === 'kimi' && !interactive) {
@@ -924,11 +948,19 @@ export function buildExecCommand(options: ExecOptions): string[] {
   // claude-only, silently dropped for codex and masked by edit mode carrying
   // the approval/sandbox bypass. Codex's resume forms reject --add-dir, so
   // skip it there (claude's flag-based resume accepts it).
+  //
+  // On top of any user-supplied dirs, a fresh codex workspace-write run
+  // implicitly gets ~/.agents (deduped) so the CLI's own tooling — askpass,
+  // secrets, sessions, tunings — can write from inside the sandbox. Resume forms
+  // get the same root via -c writable_roots above (see codexWorkspaceWrite).
+  const codexImplicitDirs =
+    codexWorkspaceWrite && !options.resume ? [getUserAgentsDir()] : [];
+  const addDirs = [...new Set([...(options.addDirs ?? []), ...codexImplicitDirs])];
   if (
-    options.addDirs &&
+    addDirs.length > 0 &&
     (options.agent === 'claude' || (options.agent === 'codex' && !options.resume))
   ) {
-    for (const dir of options.addDirs) {
+    for (const dir of addDirs) {
       cmd.push('--add-dir', dir);
     }
   }


### PR DESCRIPTION
**fix / behavior change to `agents run codex`** — lets Codex reach the fleet and self-tune from inside its own sandbox. No UI surface (CLI); the run proof is below.

## The problem

Running Codex remotely (`agents run codex --mode auto --device <box>`) couldn't do basic fleet ops — `agents ssh` died *before connecting*:

```
agents ssh failed ... needed to write /home/muqsit/.agents/.cache/devices/askpass.sh
and got EROFS: read-only file system
```

Root cause, traced end to end:
- `--mode auto`/`edit` runs Codex under `--sandbox workspace-write` (`exec.ts:537`), which blocks `$HOME` (confirmed against the live CLI and [OpenAI's sandbox docs](https://developers.openai.com/codex/concepts/sandboxing)).
- Everything Codex shells out to — the SSH **askpass shim** at `~/.agents/.cache/devices/askpass.sh` (`devices/connect.ts:178-181`), the device/stats cache, secrets, session writes, config tunings — lives under `~/.agents`. In the sandbox that's read-only → `EROFS`.
- The `--add-dir` mechanism to widen the sandbox already exists and *is* forwarded to Codex (`exec.ts:927`), but only for explicit `--add-dir`/teams. A plain `agents run codex` never granted `~/.agents`, so the CLI's own tooling couldn't run.

## The fix

`buildExecCommand` now grants `~/.agents` as an extra writable root whenever Codex runs `workspace-write` (`resolvedMode === 'edit'`):
- **Fresh runs** → `--add-dir <~/.agents>` (deduped against user `--add-dir`s).
- **Resume forms** (reject `--add-dir`, verified) → `-c sandbox_workspace_write.writable_roots=[…]`.

This is the [officially-recommended](https://developers.openai.com/codex/config-reference) way to widen scope *"without removing the sandbox entirely"* — far narrower than `--mode skip` (danger-full-access). `plan` (read-only) and `skip` (sandbox already dropped) are untouched.

## Verification (real run, not a description)

Default `workspace-write` **denies** the askpass path; with the writable root it **succeeds** — a real `codex exec` (0.146.0 on zion) with the exact flags this fix emits:

```
$ codex sandbox -c sandbox_mode=workspace-write -- sh -c 'touch ~/.agents/.cache/devices/probe'
touch: /Users/muqsit/.agents/.cache/devices/probe: Operation not permitted   # BEFORE

$ codex exec --sandbox workspace-write --add-dir ~/.agents \
    'touch ~/.agents/.cache/devices/__codex_e2e && echo E2E_DONE'
E2E_DONE
PROOF: ~/.agents WRITE SUCCEEDED via --add-dir                                # AFTER
```

Tests: 7 new cases in `exec.test.ts` (fresh grant, dedupe, plan/skip exclusion, claude exclusion, resume `-c writable_roots`, helper). `197 passed` — the only 2 failures are pre-existing on `main` (unrelated `--model gpt-5.5` injection from the box's `~/.codex/config.toml`).

## Security note

This widens Codex's writable roots to include `~/.agents` (config, secrets metadata, sessions) in `workspace-write` — matching what `agents teams` already relies on, and strictly narrower than the `--mode skip` workaround it replaces. Scoped to `edit` only.

## Docs

- Normative spec: new **EXEC-22a** in `apps/cli/docs/specifications.md`.
- CHANGELOG fragment: `.changelog/next/codex-sandbox-agents-writable-root.md`.
