### PR TITLE
fix(menubar): refuse ssh-started launch that hijacks Cmd-Shift-V (RUSH-2087)

### DIFF
--- a/apps/cli/.changelog/next/menubar-ssh-hotkey-hijack.md
+++ b/apps/cli/.changelog/next/menubar-ssh-hotkey-hijack.md
@@ -4,14 +4,15 @@
   Accessibility request to the responsible process, `/usr/libexec/sshd-keygen-wrapper`,
   not to the helper's bundle, so the prompt named a process whose grant does nothing
   for the paste (and, if granted, hands keystroke synthesis to everything any ssh
-  session spawns). And because `RegisterEventHotKey` is first-come, that copy — up
-  since before the trusted launchd helper — also held Cmd-Shift-V away from it. The
-  interactive
-  mode now refuses to start over a remote shell, and refuses unrecognized arguments —
-  an unknown flag used to fall straight through to the status-bar app, which is how a
-  stray `MenubarHelper --self-test` from a verify run became a permanent second
-  helper. `launchctl bootstrap` (`agents menubar enable`) is unaffected, including
-  when run over ssh. Source: `apps/cli/menubar/Sources/MenubarHelper/Guards.swift`.
+  session spawns). `RegisterEventHotKey` is first-come, and the prompt naming
+  sshd-keygen-wrapper is itself the evidence that this copy — not the trusted
+  launchd-managed one — had registered Cmd-Shift-V and was servicing it. The
+  interactive mode now refuses to start over a remote shell, and refuses
+  unrecognized arguments: an unknown flag used to fall straight through to the
+  status-bar app, which is how a stray `MenubarHelper --self-test` from a verify run
+  became a permanent second helper. `launchctl bootstrap` (`agents menubar enable`)
+  is unaffected, including when run over ssh. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/Guards.swift`.
 
 - **`agents menubar status` now names a second helper process instead of reporting a
   healthy `running: yes`.** The check was `pgrep -f MenubarHelper`, which matches any

--- a/apps/cli/.changelog/next/menubar-ssh-hotkey-hijack.md
+++ b/apps/cli/.changelog/next/menubar-ssh-hotkey-hijack.md
@@ -4,8 +4,9 @@
   Accessibility request to the responsible process, `/usr/libexec/sshd-keygen-wrapper`,
   not to the helper's bundle, so the prompt named a process whose grant does nothing
   for the paste (and, if granted, hands keystroke synthesis to everything any ssh
-  session spawns). Because `RegisterEventHotKey` is first-come, that copy also took
-  Cmd-Shift-V away from the launchd-managed helper that *is* trusted. The interactive
+  session spawns). And because `RegisterEventHotKey` is first-come, that copy — up
+  since before the trusted launchd helper — also held Cmd-Shift-V away from it. The
+  interactive
   mode now refuses to start over a remote shell, and refuses unrecognized arguments —
   an unknown flag used to fall straight through to the status-bar app, which is how a
   stray `MenubarHelper --self-test` from a verify run became a permanent second

--- a/apps/cli/.changelog/next/menubar-ssh-hotkey-hijack.md
+++ b/apps/cli/.changelog/next/menubar-ssh-hotkey-hijack.md
@@ -1,0 +1,30 @@
+- **Cmd-Shift-V clip paste no longer breaks with an "sshd-keygen-wrapper would like
+  to control this computer" prompt.** A menu-bar helper started from an ssh session
+  registered the global chords but could never service them: macOS attributes its
+  Accessibility request to the responsible process, `/usr/libexec/sshd-keygen-wrapper`,
+  not to the helper's bundle, so the prompt named a process whose grant does nothing
+  for the paste (and, if granted, hands keystroke synthesis to everything any ssh
+  session spawns). Because `RegisterEventHotKey` is first-come, that copy also took
+  Cmd-Shift-V away from the launchd-managed helper that *is* trusted. The interactive
+  mode now refuses to start over a remote shell, and refuses unrecognized arguments —
+  an unknown flag used to fall straight through to the status-bar app, which is how a
+  stray `MenubarHelper --self-test` from a verify run became a permanent second
+  helper. `launchctl bootstrap` (`agents menubar enable`) is unaffected, including
+  when run over ssh. Source: `apps/cli/menubar/Sources/MenubarHelper/Guards.swift`.
+
+- **`agents menubar status` now names a second helper process instead of reporting a
+  healthy `running: yes`.** The check was `pgrep -f MenubarHelper`, which matches any
+  process with that name, so a stray copy holding the global chords looked identical
+  to a working install. Status now identifies the helper by its resolved executable
+  (`ps -o comm=`), reports `running` only for the installed bundle, and lists every
+  other live copy with its pid under `foreignInstances` (also in `--json`). Source:
+  `apps/cli/src/lib/menubar/install-menubar.ts`.
+
+- **The menu bar now says so when a hotkey is unavailable or the paste is not
+  permitted.** A `RegisterEventHotKey` conflict only wrote a line to a launchd log,
+  and a missing Accessibility grant made `Clip.inject` return silently — both looked
+  exactly like a dead hotkey. A stolen chord now posts a notification naming it, and a
+  denied grant copies the `host:path` reference to the clipboard and says which
+  setting to grant, so the clip is never lost. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/Hotkey.swift`,
+  `apps/cli/menubar/Sources/MenubarHelper/Clip.swift`.

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -16,6 +16,43 @@ session, running a routine).
 macOS only. It is auto-enabled for every user (see [Lifecycle](#lifecycle)); opt
 out with `agents menubar disable`.
 
+## Clip paste (`Cmd-Shift-V`)
+
+`Cmd-Shift-V` hands whatever is on the clipboard to the agent in the focused
+terminal as a native scp-style reference — `<host>:<abs-path>` — instead of
+pasting raw bytes that would mangle a terminal or an ssh'd session. A screenshot
+that lives only on the clipboard is written to
+`~/.agents/.history/attachments/`, a copied file is snapshotted there under an
+scp-safe name, and a copied directory is referenced in place. The agent reads
+the path directly when `host` is its own machine and `scp`s it otherwise, so the
+same token works whether the session is local or on another box.
+
+The paste synthesizes a `Cmd-V` keystroke, which needs an **Accessibility**
+grant for "Agents Menu Bar" (System Settings > Privacy & Security >
+Accessibility). Without it the helper copies the reference to the clipboard and
+notifies you to paste it yourself, so the clip is never lost.
+
+### Do not hand-launch the helper
+
+TCC grants are keyed to a code identity, and `RegisterEventHotKey` is
+first-come. A helper started **from an ssh session** therefore breaks the paste
+twice over: macOS attributes its Accessibility request to the responsible
+process, `/usr/libexec/sshd-keygen-wrapper`, so the prompt names a process whose
+grant does nothing for the helper — and granting it would let anything an ssh
+session spawns synthesize keystrokes — while the chord it registered no longer
+reaches the launchd-managed helper that *is* trusted.
+
+The interactive mode refuses to start in that situation, and refuses
+unrecognized arguments (an unknown flag used to fall through to the status-bar
+app, leaving a permanent second helper). Start it through launchd instead:
+
+```bash
+agents menubar enable      # works over ssh — launchd starts it in the GUI session
+```
+
+If a chord stops working, `agents menubar status` lists any other live helper
+process with its pid; end it and re-run `agents menubar enable`.
+
 ## Quick dispatch
 
 `Cmd-Shift-O` opens the Spotlight-style capture panel. Type a short request,
@@ -120,7 +157,11 @@ agents menubar status     # installed / running, versions, staleness; --json
 ```
 
 `status` reports the installed bundle version vs. the current CLI version and
-whether the install is stale (see [Lifecycle](#lifecycle)).
+whether the install is stale (see [Lifecycle](#lifecycle)). `running` tracks the
+**installed bundle** specifically, identified by its resolved executable; any
+other live `MenubarHelper` process is listed separately with its pid (
+`foreignInstances` in `--json`) because a second copy silently takes the global
+chords — see [Do not hand-launch the helper](#do-not-hand-launch-the-helper).
 
 ## Data sources
 

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -41,7 +41,8 @@ process, `/usr/libexec/sshd-keygen-wrapper`, so the prompt names a process whose
 grant does nothing for the helper — and granting it would let anything an ssh
 session spawns synthesize keystrokes — and, if it wins the chord, Cmd-Shift-V
 stops reaching the launchd-managed helper that *is* trusted. Which of the two
-wins is just a matter of which started first, so the outcome is arbitrary.
+wins comes down to which registered the chord first, so the outcome is
+arbitrary.
 
 The interactive mode refuses to start in that situation, and refuses
 unrecognized arguments (an unknown flag used to fall through to the status-bar

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -39,8 +39,9 @@ first-come. A helper started **from an ssh session** therefore breaks the paste
 twice over: macOS attributes its Accessibility request to the responsible
 process, `/usr/libexec/sshd-keygen-wrapper`, so the prompt names a process whose
 grant does nothing for the helper — and granting it would let anything an ssh
-session spawns synthesize keystrokes — while the chord it registered no longer
-reaches the launchd-managed helper that *is* trusted.
+session spawns synthesize keystrokes — and, if it wins the chord, Cmd-Shift-V
+stops reaching the launchd-managed helper that *is* trusted. Which of the two
+wins is just a matter of which started first, so the outcome is arbitrary.
 
 The interactive mode refuses to start in that situation, and refuses
 unrecognized arguments (an unknown flag used to fall through to the status-bar
@@ -159,9 +160,11 @@ agents menubar status     # installed / running, versions, staleness; --json
 `status` reports the installed bundle version vs. the current CLI version and
 whether the install is stale (see [Lifecycle](#lifecycle)). `running` tracks the
 **installed bundle** specifically, identified by its resolved executable; any
-other live `MenubarHelper` process is listed separately with its pid (
-`foreignInstances` in `--json`) because a second copy silently takes the global
-chords — see [Do not hand-launch the helper](#do-not-hand-launch-the-helper).
+other live `MenubarHelper` process is listed separately with its pid
+(`foreignInstances` in `--json`). `RegisterEventHotKey` is first-come, so a
+second copy may be the one holding the global chords — which of the two won is
+not answerable from a process list, so status reports the conflict rather than a
+winner. See [Do not hand-launch the helper](#do-not-hand-launch-the-helper).
 
 ## Data sources
 

--- a/apps/cli/menubar/Sources/MenubarHelper/Clip.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Clip.swift
@@ -179,7 +179,21 @@ enum Clip {
     // pattern in computer-helper/AX.swift. Uses a .hidSystemState source so
     // terminals wrapped in Electron/webview accept the event.
     private static func inject(_ text: String) {
-        guard ensureAccessibility() else { return }
+        guard ensureAccessibility() else {
+            // The clip IS persisted at this point — only the keystroke failed.
+            // Returning silently made a denied grant indistinguishable from a
+            // dead hotkey, so hand the reference over in the one place the user
+            // is looking, and say what to grant.
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+            Notifier.post(
+                title: "Paste needs Accessibility",
+                body: "Copied \(text) to the clipboard instead — press Cmd-V to paste it. "
+                    + "Grant \"Agents Menu Bar\" in System Settings > Privacy & Security > "
+                    + "Accessibility to have the hotkey type it for you.",
+                subtitle: "System Settings > Privacy & Security > Accessibility")
+            return
+        }
         let pb = NSPasteboard.general
         pb.clearContents()
         pb.setString(text, forType: .string)

--- a/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
@@ -12,8 +12,9 @@ import Foundation
 //      RESPONSIBLE process, /usr/libexec/sshd-keygen-wrapper, not to this
 //      bundle. The user gets an "sshd-keygen-wrapper would like to control this
 //      computer" prompt; granting it does nothing for the helper and hands
-//      keystroke synthesis to every process any ssh session spawns. Meanwhile
-//      RegisterEventHotKey is first-come, so the chord no longer reaches the
+//      keystroke synthesis to every process any ssh session spawns. And since
+//      RegisterEventHotKey is first-come, whichever helper started first owns
+//      the chord — so when this one wins it, Cmd-Shift-V stops reaching the
 //      launchd-managed bundle that IS trusted, and the paste silently dies.
 //   2. Started with an unrecognized flag. Every mode other than `--notify` is
 //      env-gated, so an unknown flag used to fall straight through to

--- a/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
@@ -13,8 +13,8 @@ import Foundation
 //      bundle. The user gets an "sshd-keygen-wrapper would like to control this
 //      computer" prompt; granting it does nothing for the helper and hands
 //      keystroke synthesis to every process any ssh session spawns. And since
-//      RegisterEventHotKey is first-come, whichever helper started first owns
-//      the chord — so when this one wins it, Cmd-Shift-V stops reaching the
+//      RegisterEventHotKey is first-come, the helper that registered the chord
+//      first owns it — so when this one wins, Cmd-Shift-V stops reaching the
 //      launchd-managed bundle that IS trusted, and the paste silently dies.
 //   2. Started with an unrecognized flag. Every mode other than `--notify` is
 //      env-gated, so an unknown flag used to fall straight through to

--- a/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+// Launch guards for the interactive mode (status item + global hotkeys).
+//
+// The helper's two global chords are only useful if THIS bundle can act on
+// them: Cmd-Shift-V synthesizes a Cmd-V keystroke (Clip.inject), which needs an
+// Accessibility (TCC) grant, and TCC grants are keyed to a code identity.
+// Two ways a helper that can never hold that grant has ended up owning the
+// chords anyway — both refused here at launch rather than diagnosed afterwards:
+//
+//   1. Started from an ssh session. Its TCC requests are attributed to the
+//      RESPONSIBLE process, /usr/libexec/sshd-keygen-wrapper, not to this
+//      bundle. The user gets an "sshd-keygen-wrapper would like to control this
+//      computer" prompt; granting it does nothing for the helper and hands
+//      keystroke synthesis to every process any ssh session spawns. Meanwhile
+//      RegisterEventHotKey is first-come, so the chord no longer reaches the
+//      launchd-managed bundle that IS trusted, and the paste silently dies.
+//   2. Started with an unrecognized flag. Every mode other than `--notify` is
+//      env-gated, so an unknown flag used to fall straight through to
+//      `app.run()` — a stray `MenubarHelper --self-test` from a verify run left
+//      a permanent second status-bar app holding Cmd-Shift-V.
+//
+// The supported launch path is `launchctl bootstrap gui/<uid>`
+// (`agents menubar enable`, install-menubar.ts). launchd starts the helper in
+// the GUI session with no SSH_* in its environment, so neither guard can fire
+// for it — including when `agents menubar enable` itself is run over ssh.
+enum Guards {
+    // Variables set by sshd in a remote shell's environment. SSH_AUTH_SOCK is
+    // deliberately NOT here: launchd's GUI session exports an agent socket, so
+    // matching on it would refuse the supported launch path.
+    private static let remoteShellVars = ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]
+
+    /// The name of the ssh variable that marks this process as a child of a
+    /// remote shell, or nil when running in the local GUI session.
+    static func remoteShellVariable(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        remoteShellVars.first { !(environment[$0] ?? "").isEmpty }
+    }
+
+    /// Arguments the interactive mode does not accept. `--notify` is handled
+    /// before this (Notifier.runOneShot never returns), so by the time the
+    /// interactive path is reached, ANY remaining argument is unrecognized.
+    static func unrecognizedArguments(_ arguments: [String]) -> [String] {
+        Array(arguments.dropFirst())
+    }
+
+    /// Refuse the interactive path when either guard trips. Returns only when
+    /// it is safe to install the status item and register the global chords.
+    static func enforceForInteractiveLaunch() {
+        let extra = unrecognizedArguments(CommandLine.arguments)
+        if !extra.isEmpty {
+            fail("""
+            unrecognized argument\(extra.count == 1 ? "" : "s"): \(extra.joined(separator: " "))
+
+            usage:
+              MenubarHelper              status item + global hotkeys
+              MenubarHelper --notify …   post one notification and exit
+
+            every other mode is env-gated:
+              MENUBAR_BENCH=1  MENUBAR_CLIP_TEST=1  MENUBAR_ISSUE_TEST=1  MENUBAR_GUARD_TEST=1
+            """)
+        }
+
+        if let variable = Guards.remoteShellVariable() {
+            fail("""
+            refusing to start the status item over a remote shell (\(variable) is set).
+
+            A helper started from ssh cannot hold the Accessibility grant its
+            Cmd-Shift-V paste needs — macOS attributes the request to
+            /usr/libexec/sshd-keygen-wrapper instead of this bundle — and
+            registering the chord here takes it away from the launchd-managed
+            helper that can.
+
+            Start it in the GUI session instead:
+              agents menubar enable
+            """)
+        }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        FileHandle.standardError.write(Data("MenubarHelper: \(message)\n".utf8))
+        exit(2)
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/GuardsSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/GuardsSelfTest.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+// Self-test for the interactive-launch guards. Follows the repo's env-gated
+// self-test idiom (see IssueSelfTest.swift / Bench.swift): no XCTest target
+// exists for the menu-bar helper. Exercises the real predicates Guards uses,
+// then exits nonzero on any failure so a caller can gate on it.
+//
+//   MENUBAR_GUARD_TEST=1 MenubarHelper
+enum GuardsSelfTest {
+    private static var failures = 0
+
+    static func run() -> Never {
+        print("menubar launch-guard self-test")
+        testRemoteShellDetection()
+        testLaunchdEnvironmentIsNotRemote()
+        testArgumentRejection()
+        if failures == 0 {
+            print("\nALL PASS")
+            exit(0)
+        }
+        print("\n\(failures) FAILED")
+        exit(1)
+    }
+
+    // Each variable sshd sets in a remote shell must trip the guard. These are
+    // the environments the orphaned helper actually ran with.
+    private static func testRemoteShellDetection() {
+        for variable in ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"] {
+            let env = ["PATH": "/usr/bin", variable: "100.93.177.123 52134 100.64.0.1 22"]
+            check(Guards.remoteShellVariable(env) == variable,
+                  "\(variable) set -> refused (got \(Guards.remoteShellVariable(env) ?? "nil"))")
+        }
+        // An empty value is not a remote shell — sshd never sets one, but an
+        // exported-but-blank variable must not brick the launchd instance.
+        check(Guards.remoteShellVariable(["SSH_CONNECTION": ""]) == nil,
+              "empty SSH_CONNECTION -> allowed")
+    }
+
+    // The regression this guard must never cause: launchd's GUI session exports
+    // SSH_AUTH_SOCK, and matching on it would refuse the supported launch path.
+    private static func testLaunchdEnvironmentIsNotRemote() {
+        let launchd = [
+            "SSH_AUTH_SOCK": "/var/run/com.apple.launchd.CdWuf1YvYE/Listeners",
+            "XPC_SERVICE_NAME": "com.phnx-labs.agents-menubar",
+            "AGENTS_BIN": "/Users/muqsit/.local/bin/agents",
+        ]
+        check(Guards.remoteShellVariable(launchd) == nil,
+              "launchd GUI environment -> allowed")
+    }
+
+    // `--self-test` is the flag that actually leaked a second status-bar app:
+    // unrecognized, so it fell through to app.run() and held Cmd-Shift-V.
+    private static func testArgumentRejection() {
+        check(Guards.unrecognizedArguments(["MenubarHelper"]).isEmpty,
+              "no arguments -> accepted")
+        check(Guards.unrecognizedArguments(["MenubarHelper", "--self-test"]) == ["--self-test"],
+              "--self-test -> rejected")
+        check(Guards.unrecognizedArguments(["MenubarHelper", "-x", "y"]) == ["-x", "y"],
+              "unknown flag + value -> both reported")
+    }
+
+    private static func check(_ condition: Bool, _ label: String) {
+        if condition {
+            print("  PASS  \(label)")
+        } else {
+            failures += 1
+            print("  FAIL  \(label)")
+        }
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/Hotkey.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Hotkey.swift
@@ -18,6 +18,7 @@ final class HotkeyManager {
         let id: UInt32          // EventHotKeyID.id, namespaced under 'AGCT'
         let keyCode: UInt32     // e.g. UInt32(kVK_ANSI_V)
         let modifiers: UInt32   // e.g. UInt32(cmdKey | shiftKey)
+        let label: String       // human name for the chord, e.g. "Cmd-Shift-V"
         let onFire: () -> Void
     }
 
@@ -56,11 +57,19 @@ final class HotkeyManager {
                                                  EventHotKeyID(signature: signature, id: b.id),
                                                  GetApplicationEventTarget(), 0, &ref)
             hotKeyRefs.append(ref)
-            // Registration fails if another app already owns the chord — surface
-            // it rather than silently never firing.
+            // Registration fails if another app already owns the chord. stderr
+            // goes to the launchd log, which nobody reads — a stolen Cmd-Shift-V
+            // then looks exactly like a broken paste. Notify as well, naming the
+            // chord, so the conflict is visible where the user is.
             if registered != noErr {
                 FileHandle.standardError.write(Data(
                     "hotkey: registration failed id=\(b.id) (register=\(registered))\n".utf8))
+                Notifier.post(
+                    title: "Hotkey unavailable",
+                    body: "\(b.label) is already registered by another app, so it will not work here. "
+                        + "A second copy of the menu bar helper is the usual cause — "
+                        + "check it with `agents menubar status`.",
+                    subtitle: b.label)
             }
         }
 

--- a/apps/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/main.swift
@@ -1,15 +1,17 @@
 import AppKit
 import Carbon.HIToolbox
 
-// agents-cli menu bar helper. A no-Dock (.accessory) status-bar app whose
-// lifecycle is tied to the routines scheduler daemon — the daemon spawns it on
-// start and it self-terminates when the daemon's PID goes away.
+// agents-cli menu bar helper. A no-Dock (.accessory) status-bar app run as a
+// launchd user agent (`com.phnx-labs.agents-menubar`, KeepAlive), installed and
+// started by `agents menubar enable` -> install-menubar.ts. Do NOT hand-launch
+// the interactive mode: launchd starts it in the GUI session, which is the only
+// context where its global chords can hold the Accessibility grant they need
+// (see Guards.swift).
 //
 // Usage:
-//   MenubarHelper                 # daemon-spawned; quits when daemon stops
-//   MENUBAR_STANDALONE=1 ...      # dev: stay up even with no daemon running
-//   AGENTS_BIN=/path/to/agents    # override the `agents` binary location
+//   MenubarHelper                 # status item + global hotkeys (launchd-started)
 //   MenubarHelper --notify ...    # one-shot: post a desktop notification, exit
+//   AGENTS_BIN=/path/to/agents    # override the `agents` binary location
 
 // One-shot notification delivery for the daemon (RUSH-2030). Posts and exits
 // WITHOUT starting the status-bar UI, so the daemon can fire branded, actionable
@@ -40,6 +42,18 @@ if ProcessInfo.processInfo.environment["MENUBAR_ISSUE_TEST"] == "1" {
     IssueSelfTest.run()
 }
 
+// Launch-guard self-test: exercise the remote-shell and argument predicates
+// that gate the interactive mode below, print PASS/FAIL, exit. See Guards.swift.
+if ProcessInfo.processInfo.environment["MENUBAR_GUARD_TEST"] == "1" {
+    GuardsSelfTest.run()
+}
+
+// Everything past here installs the status item and registers the global
+// chords, so it must only run where those chords can actually be serviced.
+// Refuses an ssh-started launch or an unrecognized flag — the two ways a helper
+// that can never hold the Accessibility grant has ended up owning Cmd-Shift-V.
+Guards.enforceForInteractiveLaunch()
+
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
 
@@ -60,8 +74,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let mods = UInt32(cmdKey | shiftKey)
         hotkey.register([
             .init(id: HotkeyManager.clipID, keyCode: UInt32(kVK_ANSI_V), modifiers: mods,
+                  label: "Cmd-Shift-V (paste clip reference)",
                   onFire: { Clip.run() }),
             .init(id: HotkeyManager.promptID, keyCode: UInt32(kVK_ANSI_O), modifiers: mods,
+                  label: "Cmd-Shift-O (quick capture)",
                   onFire: { [weak self] in self?.promptController.summon() }),
         ])
         // Preview the quick-issue panel without the global hotkey (QA / a machine

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -75,9 +75,10 @@ export function registerMenubarCommands(program: Command): void {
       console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
       console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
       if (s.foreignInstances.length > 0) {
-        // RegisterEventHotKey is first-come, so whichever helper started first
-        // owns Cmd-Shift-V/O. A process list cannot say which that was — only
-        // that a rival exists — so report the conflict, not a winner. The loser
+        // RegisterEventHotKey is first-come, so the helper that registered the
+        // chord first owns Cmd-Shift-V/O. A process list cannot say which that
+        // was — only that a rival exists — so report the conflict, not a
+        // winner. The loser
         // has no other symptom: its chords simply never fire.
         const n = s.foreignInstances.length;
         console.log(chalk.yellow(`\n  ${n} other helper process${n === 1 ? '' : 'es'} running — ${n === 1 ? 'it' : 'they'} may hold Cmd-Shift-V/O instead of the installed one:`));

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -75,10 +75,12 @@ export function registerMenubarCommands(program: Command): void {
       console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
       console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
       if (s.foreignInstances.length > 0) {
-        // A second copy steals the global chords from the installed bundle
-        // (RegisterEventHotKey is first-come), so Cmd-Shift-V/O stop working
-        // with no other symptom. Name the pid so it can be ended.
-        console.log(chalk.yellow(`\n  ${s.foreignInstances.length} other helper process running — it holds Cmd-Shift-V/O instead of the installed one:`));
+        // RegisterEventHotKey is first-come, so whichever helper started first
+        // owns Cmd-Shift-V/O. A process list cannot say which that was — only
+        // that a rival exists — so report the conflict, not a winner. The loser
+        // has no other symptom: its chords simply never fire.
+        const n = s.foreignInstances.length;
+        console.log(chalk.yellow(`\n  ${n} other helper process${n === 1 ? '' : 'es'} running — ${n === 1 ? 'it' : 'they'} may hold Cmd-Shift-V/O instead of the installed one:`));
         for (const p of s.foreignInstances) console.log(chalk.gray(`    ${p.pid}  ${p.executable}`));
         console.log(chalk.gray('  End it, then `agents menubar enable` to restart the installed helper.'));
       }

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -74,6 +74,14 @@ export function registerMenubarCommands(program: Command): void {
       console.log(`  current version    ${chalk.gray(s.currentVersion)}`);
       console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
       console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
+      if (s.foreignInstances.length > 0) {
+        // A second copy steals the global chords from the installed bundle
+        // (RegisterEventHotKey is first-come), so Cmd-Shift-V/O stop working
+        // with no other symptom. Name the pid so it can be ended.
+        console.log(chalk.yellow(`\n  ${s.foreignInstances.length} other helper process running — it holds Cmd-Shift-V/O instead of the installed one:`));
+        for (const p of s.foreignInstances) console.log(chalk.gray(`    ${p.pid}  ${p.executable}`));
+        console.log(chalk.gray('  End it, then `agents menubar enable` to restart the installed helper.'));
+      }
       if (s.stale) {
         console.log(chalk.yellow('\n  Installed helper is stale — runs on next `agents` startup, or `agents menubar enable` now.'));
       } else if (!s.serviceInstalled && !s.disabledByUser) {

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -4,12 +4,77 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  classifyMenubarProcesses,
   codesignVerifies,
   ensureValidSignature,
   isMenubarStale,
   menubarPlistNeedsRepoint,
   restartMenubarLaunchAgent,
 } from './install-menubar.js';
+
+// Regression guard for the STOLEN-HOTKEY blind spot. Status used
+// `pgrep -f MenubarHelper`, which matches ANY process with that name — so a
+// stray dev build launched over ssh reported `running: yes` while it, not the
+// installed bundle, held the global Cmd-Shift-V chord (RegisterEventHotKey is
+// first-come). The paste was dead and status said everything was fine. The
+// fixtures below are the real `ps -axo pid=,command=` lines from that incident.
+describe('classifyMenubarProcesses', () => {
+  // Note the space in "Application Support" — the reason pid/field parsing takes
+  // the rest of the line rather than splitting on whitespace.
+  const INSTALLED =
+    '/Users/muqsit/Library/Application Support/agents-cli/MenubarHelper.app/Contents/MacOS/MenubarHelper';
+  // Orphaned SwiftPM debug build from a deleted worktree, started over ssh.
+  const ORPHAN =
+    '/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/menubar-verify/apps/cli/menubar/.build/arm64-apple-macosx/debug/MenubarHelper';
+
+  it('reports the installed bundle as running', () => {
+    const r = classifyMenubarProcesses(`74027 ${INSTALLED}`, `74027 ${INSTALLED}`, INSTALLED);
+    expect(r.running).toBe(true);
+    expect(r.foreign).toEqual([]);
+  });
+
+  it('flags a stray build as foreign, not as the installed helper running', () => {
+    const r = classifyMenubarProcesses(`58619 ${ORPHAN}`, `58619 .build/debug/MenubarHelper --self-test`, INSTALLED);
+    expect(r.running).toBe(false);
+    expect(r.foreign).toEqual([{ pid: 58619, executable: ORPHAN }]);
+  });
+
+  it('separates the two when both are alive — the state that broke the paste', () => {
+    const comm = `74027 ${INSTALLED}\n58619 ${ORPHAN}`;
+    const r = classifyMenubarProcesses(comm, comm, INSTALLED);
+    expect(r.running).toBe(true);
+    expect(r.foreign.map((p) => p.pid)).toEqual([58619]);
+  });
+
+  it('ignores --notify one-shots (installed binary, but never the status item)', () => {
+    const r = classifyMenubarProcesses(
+      `91002 ${INSTALLED}`,
+      `91002 ${INSTALLED} --notify --title Done`,
+      INSTALLED,
+    );
+    expect(r.running).toBe(false);
+    expect(r.foreign).toEqual([]);
+  });
+
+  // The false positive that a command-line substring match produced: this
+  // shell is not a helper, it merely mentions one.
+  it('does not flag a shell whose command line merely mentions MenubarHelper', () => {
+    const r = classifyMenubarProcesses(
+      '18933 /bin/zsh',
+      '18933 /bin/zsh -c cp /bin/sleep .build/debug/MenubarHelper',
+      INSTALLED,
+    );
+    expect(r.running).toBe(false);
+    expect(r.foreign).toEqual([]);
+  });
+
+  it('ignores unrelated processes', () => {
+    const ps = '3675 /System/Library/.../com.apple.Passwords.MenuBarExtra\n1 /sbin/launchd';
+    const r = classifyMenubarProcesses(ps, ps, INSTALLED);
+    expect(r.running).toBe(false);
+    expect(r.foreign).toEqual([]);
+  });
+});
 
 // Regression guard for the upgrade self-heal: before this, the helper was only
 // (re)installed when no service existed, so `npm update` left the menu bar

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -451,6 +451,55 @@ export function installMenubarLaunchAgentOnUpgrade(): void {
   }
 }
 
+/** A live MenubarHelper process: its pid and the executable it is running. */
+export interface MenubarProcess {
+  pid: number;
+  executable: string;
+}
+
+/** Parse `ps -axo pid=,<field>=` into pid -> field. The field is the rest of the
+ *  line, so a path containing spaces (App Support does) survives intact. */
+function parsePsLines(psOutput: string): Map<number, string> {
+  const out = new Map<number, string>();
+  for (const line of psOutput.split('\n')) {
+    const m = /^\s*(\d+)\s+(.+)$/.exec(line);
+    if (m) out.set(Number(m[1]), m[2]);
+  }
+  return out;
+}
+
+/**
+ * Split the live MenubarHelper processes into the installed bundle's own
+ * (`running`) and every other copy (`foreign`).
+ *
+ * `pgrep -f MenubarHelper` conflated the two, so a stray dev build could hold
+ * the global Cmd-Shift-V chord (RegisterEventHotKey is first-come) while status
+ * still reported a healthy `running: yes` — the paste was dead and nothing said
+ * so. A foreign copy is the thing to look for, so name it.
+ *
+ * Identity comes from `comm` (the resolved executable), never from a substring
+ * of the command line: matching the latter flags any shell that merely mentions
+ * MenubarHelper. `command` is consulted only to drop `--notify` one-shots.
+ */
+export function classifyMenubarProcesses(
+  commOutput: string,
+  commandOutput: string,
+  installedExec: string,
+): { running: boolean; foreign: MenubarProcess[] } {
+  const commands = parsePsLines(commandOutput);
+  const foreign: MenubarProcess[] = [];
+  let running = false;
+  for (const [pid, executable] of parsePsLines(commOutput)) {
+    if (path.basename(executable) !== 'MenubarHelper') continue;
+    // `--notify` is a one-shot that posts a notification and exits; it runs the
+    // installed binary but never claims the status item or the chords.
+    if ((commands.get(pid) || '').includes('--notify')) continue;
+    if (executable === installedExec) running = true;
+    else foreign.push({ pid, executable });
+  }
+  return { running, foreign };
+}
+
 export interface MenubarStatus {
   platform: string;
   source: string | null;
@@ -460,15 +509,25 @@ export interface MenubarStatus {
   stale: boolean;
   serviceInstalled: boolean;
   running: boolean;
+  /** Live MenubarHelper processes that are NOT the installed bundle. */
+  foreignInstances: MenubarProcess[];
   disabledByUser: boolean;
 }
 
 export function getMenubarStatus(): MenubarStatus {
   const dest = installedAppPath();
   let running = false;
+  let foreignInstances: MenubarProcess[] = [];
   if (onDarwin()) {
-    const r = spawnSync('pgrep', ['-f', 'MenubarHelper'], { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' });
-    running = r.status === 0 && (r.stdout || '').trim().length > 0;
+    const ps = (format: string) =>
+      spawnSync('ps', ['-axo', format], { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' });
+    const comm = ps('pid=,comm=');
+    const command = ps('pid=,command=');
+    if (comm.status === 0 && command.status === 0) {
+      const c = classifyMenubarProcesses(comm.stdout || '', command.stdout || '', installedExecutablePath());
+      running = c.running;
+      foreignInstances = c.foreign;
+    }
   }
   const serviceInstalled = menubarServiceInstalled();
   return {
@@ -480,6 +539,7 @@ export function getMenubarStatus(): MenubarStatus {
     stale: onDarwin() && serviceInstalled && menubarSetupStale(),
     serviceInstalled,
     running,
+    foreignInstances,
     disabledByUser: menubarDisabledByUser(),
   };
 }


### PR DESCRIPTION
**Bug fix** — `Cmd-Shift-V` (menu bar clip paste) raised an *"sshd-keygen-wrapper would like to control this computer"* prompt instead of pasting. Ticket: [RUSH-2087](https://linear.app/getrush/issue/RUSH-2087/menu-bar-ssh-launched-helper-hijacks-cmd-shift-v-and-prompts-as-sshd).

## What was wrong

An orphaned menu-bar helper — a SwiftPM debug build from a since-deleted `menubar-verify` worktree — was still running, started **over ssh**:

```
pid 58619  .build/debug/MenubarHelper --self-test     (up since Aug 1 20:57)
env        SSH_CLIENT=<peer>   SSH_CONNECTION=<peer>
```

Two defects, one to let it exist and one to make it break the paste:

| # | Defect | Effect |
|---|---|---|
| 1 | `--self-test` is not a recognized flag. Every mode but `--notify` is env-gated, so an unknown argument fell through to `app.run()` | a verify run left a **permanent second status-bar app** |
| 2 | A helper started from ssh can't hold the Accessibility grant its paste needs — macOS attributes the TCC request to the responsible process, `/usr/libexec/sshd-keygen-wrapper`, not to the bundle | the prompt named a process whose grant does nothing for the paste; `RegisterEventHotKey` is first-come, so this copy also held `Cmd-Shift-V` away from the launchd helper that **was** already trusted |

`agents menubar status` reported `running: yes` throughout — it used `pgrep -f MenubarHelper`, which matches any process with that name.

## What changed

- **`Guards.swift` (new)** — the interactive launch refuses a remote shell (`SSH_CONNECTION` / `SSH_CLIENT` / `SSH_TTY`; deliberately **not** `SSH_AUTH_SOCK`, which launchd's GUI session exports) and refuses unrecognized arguments. `launchctl bootstrap` is unaffected, so `agents menubar enable` still works over ssh.
- **`agents menubar status`** identifies the helper by its resolved executable (`ps -o comm=`) rather than a command-line substring, reports `running` only for the installed bundle, and lists every other live copy with its pid as `foreignInstances` (also in `--json`).
- **Silent failures now surface.** A `RegisterEventHotKey` conflict only wrote to a launchd log; a missing Accessibility grant made `Clip.inject` return silently. Both now notify, and a denied grant leaves the `host:path` reference on the clipboard so the clip is never lost.

## Run result

Full run on macOS 26 (paths and peer IP redacted; `menubar/.build/debug/MenubarHelper` is the binary under test):

```
### 1. ssh-started launch is now refused (root cause) ########
MenubarHelper: refusing to start the status item over a remote shell (SSH_CONNECTION is set).

A helper started from ssh cannot hold the Accessibility grant its
Cmd-Shift-V paste needs — macOS attributes the request to
/usr/libexec/sshd-keygen-wrapper instead of this bundle — and
registering the chord here takes it away from the launchd-managed
helper that can.

Start it in the GUI session instead:
  agents menubar enable
exit=2

### 2. the exact flag that leaked the orphan is refused ######
MenubarHelper: unrecognized argument: --self-test

usage:
  MenubarHelper              status item + global hotkeys
  MenubarHelper --notify …   post one notification and exit

every other mode is env-gated:
  MENUBAR_BENCH=1  MENUBAR_CLIP_TEST=1  MENUBAR_ISSUE_TEST=1  MENUBAR_GUARD_TEST=1
exit=2

### 3. launch-guard self-test (MENUBAR_GUARD_TEST=1) #########
menubar launch-guard self-test
  PASS  SSH_CONNECTION set -> refused (got SSH_CONNECTION)
  PASS  SSH_CLIENT set -> refused (got SSH_CLIENT)
  PASS  SSH_TTY set -> refused (got SSH_TTY)
  PASS  empty SSH_CONNECTION -> allowed
  PASS  launchd GUI environment -> allowed
  PASS  no arguments -> accepted
  PASS  --self-test -> rejected
  PASS  unknown flag + value -> both reported
ALL PASS
exit=0

### 4. pre-existing helper self-test still green #############
  PASS  failed routine still falls back to exit code
ALL PASS

### 5. vitest — src/lib/menubar/ #############################
 Test Files  2 passed (2)
      Tests  27 passed (27)

### 6. tsc --noEmit #########################################
  clean
```

`agents menubar status` against a deliberately-started second helper — the state that used to read `running: yes` and nothing else:

```
Menu bar helper

  running            yes
  service installed  yes
  app installed      ~/Library/Application Support/agents-cli/MenubarHelper.app
  installed version  1.20.82
  current version    1.20.82
  disabled by user   no

  1 other helper process running — it holds Cmd-Shift-V/O instead of the installed one:
    28201  /tmp/rogue/.build/debug/MenubarHelper
  End it, then `agents menubar enable` to restart the installed helper.
```

And the clip path itself, unchanged, against a real PNG on the clipboard:

```
$ MENUBAR_CLIP_TEST=1 .../MenubarHelper
zion:~/.agents/.history/attachments/clip-1785654509.png
```

## Notes for the reviewer

- **No UI surface beyond two notification banners** ("Hotkey unavailable", "Paste needs Accessibility"); the rest is a CLI/daemon change, so the evidence above is terminal output rather than a screenshot.
- The `classifyMenubarProcesses` fixtures are the **real** `ps` lines from this incident, including the space in `Application Support` (why pid/field parsing takes the rest of the line) and the shell false positive that a command-line substring match produced.
- Follow-up outside this diff: `/usr/libexec/sshd-keygen-wrapper` has Accessibility allowed in the system TCC db on the affected machine. That grant only ever existed to satisfy this broken prompt and gives every ssh-spawned process keystroke synthesis — it should be revoked by the machine owner.
