### PR TITLE
feat(sessions): make bare --host/--device listing interactive with previews

### DIFF
--- a/apps/cli/.changelog/next/sessions-host-interactive.md
+++ b/apps/cli/.changelog/next/sessions-host-interactive.md
@@ -1,0 +1,7 @@
+- **`agents sessions --host`/`--device <box>` now opens the interactive fleet
+  browser instead of a raw text dump.** A bare remote listing on a TTY folds the
+  named box into the same preview-rich, selectable picker as the local view (it
+  previously short-circuited to the legacy per-host stream — non-interactive, no
+  previews). A `--host` *query*, a render/filter flag, `--json`, or a
+  non-interactive caller keep the streamed output. Source:
+  `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -305,12 +305,21 @@ Discovery is local-only — every path is rooted at `os.homedir()`, so a machine
 sees only its own transcripts. `--host` runs the query on another machine instead:
 
 ```
+# Browse another machine's sessions in the interactive picker (previews + resume)
+agents sessions --host yosemite-s1        # or --device yosemite-s1
+
 # Search another machine's sessions live (no sync, always current)
 agents sessions "auth bug" --last 3 --host yosemite-s1
 
 # Fan the same query across several machines
 agents sessions --all "deploy script" --host box-a --host box-b
 ```
+
+A **bare** `--host`/`--device <box>` listing on a TTY folds that box into the same
+interactive fleet browser as the local view — preview-rich and selectable — rather
+than the legacy per-host raw stream. The stream is still used for a `--host` *query*
+(`agents sessions "term" --host <box>`), a render/filter flag, `--json`, or a
+non-interactive caller (piped/`--no-interactive`).
 
 It works by invoking the **remote's own** `agents sessions` against its already-built
 index over SSH and streaming stdout back — `ssh -o BatchMode=yes <host> bash -lc

--- a/apps/cli/src/commands/__tests__/sessions-host-filter.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-host-filter.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { shouldIncludeLocal, remoteHostsToDial } from '../sessions.js';
+import { shouldIncludeLocal, remoteHostsToDial, hasNoBrowserDisqualifyingFlags } from '../sessions.js';
 
 describe('shouldIncludeLocal', () => {
   const self = 'zion';
@@ -58,5 +58,26 @@ describe('remoteHostsToDial', () => {
   it('returns [] when the only named host is self (caller then skips the fan-out)', () => {
     expect(remoteHostsToDial(['zion'], self)).toEqual([]);
     expect(remoteHostsToDial(['zion.tail1a85a1.ts.net'], self)).toEqual([]);
+  });
+});
+
+describe('hasNoBrowserDisqualifyingFlags (bare interactive --host routing)', () => {
+  // The bug this pins: a bare `agents sessions --host/--device <box>` used to
+  // short-circuit into the legacy per-host raw stream (non-interactive, no
+  // previews) instead of the fleet browser. The browser handles an explicit
+  // host scope; the gate below is what lets `--host` reach it — but only for a
+  // bare listing the picker can represent (no query / render / filter flag).
+  it('allows a bare --host listing (no query, no flags) into the browser', () => {
+    expect(hasNoBrowserDisqualifyingFlags({ host: ['yosemite-s0'] } as any, undefined)).toBe(true);
+  });
+
+  it('keeps the raw stream for a --host search (a query the picker path owns)', () => {
+    expect(hasNoBrowserDisqualifyingFlags({ host: ['yosemite-s0'] } as any, 'auth bug')).toBe(false);
+  });
+
+  it('keeps the raw stream when a render/filter flag is set', () => {
+    for (const flags of [{ flat: true }, { tree: true }, { markdown: true }, { until: '2d' }, { project: 'x' }, { sort: 'cost' }, { artifacts: true }]) {
+      expect(hasNoBrowserDisqualifyingFlags({ host: ['yosemite-s0'], ...flags } as any, undefined)).toBe(false);
+    }
   });
 });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1126,6 +1126,40 @@ function useInteractiveBrowser(options: SessionsOptions): boolean {
   return options.interactive !== false && !options.json && isInteractiveTerminal();
 }
 
+/**
+ * A bare interactive fleet listing — no query, no render/filter flag — that the
+ * `runSessionBrowser` picker can represent. The single predicate shared by the
+ * bare-browser branch and the `--host` early-return guard so they can't drift:
+ * when this holds, an explicit `--host`/`--device` scope is folded into the
+ * browser (preview-rich, selectable) instead of the legacy per-host raw stream.
+ */
+export function isBareBrowserListing(options: SessionsOptions, query: string | undefined): boolean {
+  return useInteractiveBrowser(options) && hasNoBrowserDisqualifyingFlags(options, query);
+}
+
+/**
+ * Pure flag-gate half of {@link isBareBrowserListing} (TTY-independent, so it is
+ * unit-testable): true when no query, render, or filter flag is present that the
+ * `runSessionBrowser` picker cannot represent.
+ */
+export function hasNoBrowserDisqualifyingFlags(
+  options: SessionsOptions,
+  query: string | undefined
+): boolean {
+  return (
+    !query &&
+    !options.routine &&
+    !options.flat &&
+    !options.tree &&
+    !options.markdown &&
+    !options.until &&
+    !options.project &&
+    !options.sort &&
+    !options.artifacts &&
+    options.artifact === undefined
+  );
+}
+
 /** The canonical `ag sessions …` command for a set of flags — the twin of the
  * browser's `y` hotkey (see --print-cmd). Normalizes to the stable flag form. */
 function canonicalSessionsCommand(query: string | undefined, options: SessionsOptions): string {
@@ -1222,13 +1256,20 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
       await runRemoteSessionsJson(options.host);
       return;
     }
-    try {
-      runRemoteSessions(options.host);
-    } catch (err: any) {
-      console.error(chalk.red(err.message));
-      process.exit(1);
+    // A bare interactive `--host`/`--device <box>` listing falls through to the
+    // fleet browser below, which folds the named host(s) into the same merged,
+    // preview-rich, selectable view as the local listing (via gatherRemoteList).
+    // A query, a render/filter flag, or a non-interactive caller keeps the legacy
+    // per-host raw stream under a `── host ──` banner.
+    if (!isBareBrowserListing(options, query)) {
+      try {
+        runRemoteSessions(options.host);
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+      return;
     }
-    return;
   }
 
   // --preview <id/query>: resolve one session and print its compact preview, then
@@ -1291,19 +1332,7 @@ async function sessionsAction(query: string | undefined, options: SessionsOption
   // filter the browser can't represent), or --no-interactive keep the existing
   // printed/render paths (agents and scripts unaffected). An explicit --since seeds
   // the browser's window so the flag is honored, not swallowed.
-  if (
-    useInteractiveBrowser(options) &&
-    !query &&
-    !options.routine &&
-    !options.flat &&
-    !options.tree &&
-    !options.markdown &&
-    !options.until &&
-    !options.project &&
-    !options.sort &&
-    !options.artifacts &&
-    options.artifact === undefined
-  ) {
+  if (isBareBrowserListing(options, query)) {
     const { runSessionBrowser, bareBrowserSeed } = await import('./sessions-browser.js');
     await runSessionBrowser(
       bareBrowserSeed({


### PR DESCRIPTION
Makes a bare `agents sessions --host/--device <box>` open the **interactive fleet browser with previews**, instead of the legacy per-host raw text dump.

**type:** feature (CLI — `apps/cli/src/commands/sessions.ts`)

## Problem
`agents sessions --device <box>` (or `--host`) was non-interactive and showed no session previews — it short-circuited at `sessions.ts` into `runRemoteSessions()` (each remote's raw stdout under a `── host ──` banner). The local listing, by contrast, is a preview-rich, selectable picker.

## Fix
`runSessionBrowser` already accepts a host scope (`sessions-browser.ts` → `gatherRemoteList`), so a bare remote listing just needed to reach it. Extracted one shared predicate — `isBareBrowserListing` (+ the pure, testable `hasNoBrowserDisqualifyingFlags`) — used by BOTH the `--host` early-return guard and the bare-browser branch so they can't drift. A bare interactive `--host`/`--device` listing now folds the named box into the browser; a `--host` **query**, a render/filter flag (`--flat/--tree/--markdown/--until/--project/--sort/--artifacts`), `--json`, or a non-interactive caller keep the raw stream unchanged.

## Verified
`tsc --noEmit` clean. Routing gate unit-tested (`sessions-host-filter.test.ts`, 12 pass):
```
hasNoBrowserDisqualifyingFlags (bare interactive --host routing)
  ✓ allows a bare --host listing (no query, no flags) into the browser
  ✓ keeps the raw stream for a --host search (a query the picker path owns)
  ✓ keeps the raw stream when a render/filter flag is set
```
The interactive browser render itself is a TTY-only surface (verified manually; the unit test pins the routing decision that was the bug). No-surface-for-CI beyond the passing test run — declared.
