### PR TITLE
feat(sessions): surface team lineage (which orchestrator spun up each team)

### DIFF
--- a/apps/cli/.changelog/next/sessions-team-lineage.md
+++ b/apps/cli/.changelog/next/sessions-team-lineage.md
@@ -1,0 +1,9 @@
+- **`agents sessions` now shows which orchestrator spawned each team.** A teams
+  teammate row was keyed off its orchestrator's session id (captured from
+  `AGENTS_SESSION_ID` at spawn), which both hid the lineage and mislabeled the
+  teammate with the orchestrator's id/topic. The teammate now keys off its own
+  transcript, exposes the orchestrator as `orchestratorSessionId` (+ a resolved
+  `orchestratorLabel`) in `--active --json`, and the listing renders
+  `<team> · by <orchestrator>` so "which session spun up this team" is answerable
+  at a glance. Source: `apps/cli/src/lib/session/active.ts`,
+  `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -261,6 +261,15 @@ On a TTY it opens the interactive browser seeded to running-only; `--json`,
 `--waiting`, and `--no-interactive` print the static grouped view instead. Both read
 the same gather, so they always agree on what is live.
 
+**Team lineage.** A teams teammate row carries the id of the **orchestrator** that
+spawned it — the session that ran `agents teams add`, captured from
+`AGENTS_SESSION_ID` at spawn and stored as the teammate's `parentSessionId`
+(`src/lib/teams/agents.ts`). `listTeamsActive` surfaces it as `orchestratorSessionId`
+(the teammate's own transcript stays `sessionId`), and `getActiveSessions` resolves an
+`orchestratorLabel` from the orchestrator's own row when it is present in the set. The
+listing shows it as `<team> · by <orchestrator>`, so "which session spun up this team"
+is answerable at a glance; `--active --json` carries both fields for programmatic use.
+
 Two properties of the running view are worth stating, because a session missing from
 it is indistinguishable from a session that isn't running:
 

--- a/apps/cli/src/commands/__tests__/sessions.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions.test.ts
@@ -6,7 +6,7 @@ import * as crypto from 'crypto';
 import { spawnSync } from 'child_process';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
-import { buildResumeCommand, resumeSpawnInvocation, resolveSessionQuery } from '../sessions.js';
+import { buildResumeCommand, resumeSpawnInvocation, resolveSessionQuery, buildSessionDescription } from '../sessions.js';
 import { needsWindowsShell, composeWin32CommandLine } from '../../lib/platform/index.js';
 import type { SessionMeta } from '../../lib/session/types.js';
 
@@ -1022,5 +1022,31 @@ describe('resolveSessionQuery id-vs-search resolution', () => {
     const r = resolveSessionQuery([mentions], ses);
     expect(r.completeId).toBe(true);
     expect(r.matches.map(s => s.id)).not.toContain(mentions.id);
+  });
+});
+
+describe('buildSessionDescription — team lineage', () => {
+  it('shows "by <orchestrator label>" for a teammate with a resolved orchestrator', () => {
+    const desc = buildSessionDescription({
+      context: 'teams', kind: 'claude', status: 'working',
+      teamName: 'my-feature', orchestratorLabel: 'refactor auth', label: 'auth',
+    } as any);
+    expect(desc).toContain('my-feature');
+    expect(desc).toContain('by refactor auth');
+  });
+
+  it('falls back to the orchestrator short id when no label resolved', () => {
+    const desc = buildSessionDescription({
+      context: 'teams', kind: 'claude', status: 'working',
+      teamName: 't', orchestratorSessionId: 'abcd1234efgh',
+    } as any);
+    expect(desc).toContain('by abcd1234'); // first 8 chars
+  });
+
+  it('omits the "by" clause when there is no orchestrator link', () => {
+    const desc = buildSessionDescription({
+      context: 'teams', kind: 'claude', status: 'working', teamName: 't', label: 'x',
+    } as any);
+    expect(desc).not.toContain('by ');
   });
 });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -357,7 +357,7 @@ export function cleanPreview(text: string): string {
  * Covers every ActiveSession context: terminal (interactive), headless, teams,
  * cloud, and sub-agent rows that share the same ActiveSession.todos field.
  */
-function buildSessionDescription(s: ActiveSession): string {
+export function buildSessionDescription(s: ActiveSession): string {
   const todo = formatTodoCompact(s.todos);
   if (s.context === 'cloud') {
     const base = s.preview || `${s.cloudProvider ?? ''}${s.cloudTaskId ? ` · ${s.cloudTaskId.slice(0, 12)}` : ''}`;
@@ -365,6 +365,10 @@ function buildSessionDescription(s: ActiveSession): string {
   }
   if (s.context === 'teams') {
     const parts = [s.teamName];
+    // Lineage: which orchestrator spun up this team. Prefer the resolved label,
+    // else the short session id, so "by whom" is answerable at a glance.
+    const orch = s.orchestratorLabel || (s.orchestratorSessionId ? s.orchestratorSessionId.slice(0, 8) : '');
+    if (orch) parts.push(`by ${orch}`);
     if (todo) parts.push(todo);
     if (s.preview) parts.push(s.preview);
     else if (s.label) parts.push(s.label);

--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice } from './active.js';
+import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels } from './active.js';
 import type { HookSessionIndex } from './hook-sessions.js';
 import type { DeviceProfile, DeviceRegistry } from '../devices/registry.js';
 
@@ -258,5 +258,36 @@ describe('matchOriginDevice (resolve an ssh client IP to the initiating device)'
     // '' would falsely match a device whose address.ip is undefined if the guard
     // were missing; assert the no-ip device is never returned.
     expect(matchOriginDevice('', reg)).toBeUndefined();
+  });
+});
+
+describe('annotateOrchestratorLabels (team lineage — which session spun up a team)', () => {
+  const row = (over: Partial<import('./active.js').ActiveSession>) =>
+    ({ context: 'teams', kind: 'claude', status: 'working', ...over }) as any;
+
+  it('resolves a teammate\'s orchestrator label from the orchestrator\'s own row', () => {
+    const orchestrator = row({ sessionId: 'orch-1234', context: 'terminal', label: 'refactor auth' });
+    const teammate = row({ sessionId: 'mate-abcd', teamName: 'my-feature', orchestratorSessionId: 'orch-1234' });
+    annotateOrchestratorLabels([orchestrator, teammate]);
+    expect(teammate.orchestratorLabel).toBe('refactor auth');
+  });
+
+  it('falls back to the orchestrator topic when it has no label', () => {
+    const orchestrator = row({ sessionId: 'orch-1234', context: 'terminal', topic: 'ship the CLI' });
+    const teammate = row({ sessionId: 'mate-abcd', teamName: 't', orchestratorSessionId: 'orch-1234' });
+    annotateOrchestratorLabels([orchestrator, teammate]);
+    expect(teammate.orchestratorLabel).toBe('ship the CLI');
+  });
+
+  it('leaves orchestratorLabel unset when the orchestrator is not in the active set', () => {
+    const teammate = row({ sessionId: 'mate-abcd', teamName: 't', orchestratorSessionId: 'gone-9999' });
+    annotateOrchestratorLabels([teammate]);
+    expect(teammate.orchestratorLabel).toBeUndefined();
+  });
+
+  it('does nothing for a non-team row with no orchestrator link', () => {
+    const solo = row({ sessionId: 's1', context: 'terminal', label: 'x' });
+    annotateOrchestratorLabels([solo]);
+    expect(solo.orchestratorLabel).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -202,6 +202,17 @@ export interface ActiveSession {
    */
   machine?: string;
   teamName?: string;
+  /**
+   * For a teams teammate: the session id of the ORCHESTRATOR that spawned the
+   * team (the agent that ran `agents teams add`, captured from AGENTS_SESSION_ID
+   * at spawn). Lets the listing answer "which session spun up this team" and
+   * group teammates under their orchestrator. Distinct from `sessionId`, which is
+   * the teammate's OWN transcript.
+   */
+  orchestratorSessionId?: string;
+  /** Display label for the orchestrator (its topic/label), resolved when the
+   * orchestrator is itself present in the active set. Display-only. */
+  orchestratorLabel?: string;
   agentId?: string;
   cloudProvider?: string;
   cloudTaskId?: string;
@@ -787,16 +798,24 @@ export async function listTeamsActive(): Promise<ActiveSession[]> {
   const mgr = new AgentManager();
   const running = await mgr.listRunning();
   return running.map((a): ActiveSession => {
-    const sessionId = a.parentSessionId ?? a.remoteSessionId ?? undefined;
-    const sessionFile = findSessionFileForKind(a.agentType, a.cwd ?? undefined, sessionId ?? undefined);
+    // The teammate's OWN transcript is `remoteSessionId` (captured from its first
+    // stream event). `parentSessionId` is the ORCHESTRATOR that spawned the team
+    // (AGENTS_SESSION_ID at spawn) — a link, not this teammate's id. Keying the
+    // row off the orchestrator conflated the two (a teammate showed the
+    // orchestrator's id/topic and lineage was invisible); resolve the teammate's
+    // own session for the row and expose the orchestrator separately.
+    const ownSessionId = a.remoteSessionId ?? undefined;
+    const sessionFile = findSessionFileForKind(a.agentType, a.cwd ?? undefined, ownSessionId);
     const topic = sessionFile ? quickExtractTopic(sessionFile) : undefined;
     const pidAlive = a.pid ? isPidAlive(a.pid) : true;
     const { state, tokPerSec } = computeLiveSignals(a.agentType, sessionFile, a.cwd ?? undefined, pidAlive);
+    const resolvedId = ownSessionId ?? sessionIdFromFile(sessionFile);
     return applyState({
       context: 'teams',
       kind: a.agentType,
       pid: a.pid ?? undefined,
-      sessionId: sessionId ?? sessionIdFromFile(sessionFile),
+      sessionId: resolvedId,
+      orchestratorSessionId: a.parentSessionId ?? undefined,
       cwd: a.cwd ?? undefined,
       label: a.name ?? undefined,
       topic,
@@ -809,7 +828,7 @@ export async function listTeamsActive(): Promise<ActiveSession[]> {
       // The frozen actor stamped on the teammate record (RUSH-2028) — who ran
       // this teammate, surfaced as the owner in --active (RUSH-2018); sidecar
       // fallback for a teammate record predating the actor field.
-      owner: resolveOwner(a.actor, sessionId ?? sessionIdFromFile(sessionFile)),
+      owner: resolveOwner(a.actor, resolvedId),
     }, state, sessionFile, pidAlive);
   });
 }
@@ -1510,7 +1529,24 @@ export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<
   await enrichProvenance(merged);
   await resolveOrigins(merged);
   foldPresence(merged);
+  annotateOrchestratorLabels(merged);
   return merged;
+}
+
+/**
+ * Resolve each teams row's `orchestratorLabel` from the orchestrator's own row,
+ * when that orchestrator session is itself in the active set (it usually is — the
+ * agent that ran `agents teams add` is running). Falls back to nothing, so the
+ * renderer shows the short id. Pure over the array; exported for tests.
+ */
+export function annotateOrchestratorLabels(sessions: ActiveSession[]): void {
+  const byId = new Map<string, ActiveSession>();
+  for (const s of sessions) if (s.sessionId) byId.set(s.sessionId, s);
+  for (const s of sessions) {
+    if (!s.orchestratorSessionId) continue;
+    const orch = byId.get(s.orchestratorSessionId);
+    if (orch) s.orchestratorLabel = orch.label || orch.topic || undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
Makes `agents sessions` answer **"which session spun up this team?"** — the orchestrator was captured but hidden and mislabeled.

**type:** feature (CLI — `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`)

## Problem
A teams teammate's live row was keyed off `a.parentSessionId` — which is the **orchestrator's** session (captured from `AGENTS_SESSION_ID` when `agents teams add` runs), not the teammate's own. So a teammate showed the *orchestrator's* id/topic as its own, and the lineage ("who spawned this team") was invisible in `agents sessions`.

## Fix
- `listTeamsActive` keys the row off the teammate's **own** transcript (`remoteSessionId`) and exposes the orchestrator separately as `orchestratorSessionId`.
- `getActiveSessions` resolves an `orchestratorLabel` from the orchestrator's own row when it's in the active set.
- The listing renders `<team> · by <orchestrator>`; `--active --json` carries `orchestratorSessionId` + `orchestratorLabel` for the Factory extension / scripts.

## Verified end-to-end (real data)
Spawned a teammate from a live session; its persisted record captured the orchestrator:
```
task_name= lineage-probe
parent_session_id= 9d469225-...   <- the orchestrator (the session that ran `teams add`)
remote_session_id= 4b628dcc-...   <- the teammate's OWN transcript
```
Before this change that teammate's row would show `9d469225` (the orchestrator) as its own id; now it shows `4b628dcc` and surfaces `9d469225` as the orchestrator. Unit tests pin the resolve (`annotateOrchestratorLabels`) and the render (`buildSessionDescription` → `by <orchestrator>`).

## Tests
`active.test.ts` (+4, orchestrator resolution) and `sessions.test.ts` (+3, `by <orchestrator>` render) pass; `tsc --noEmit` clean. (One pre-existing `resolveSessionQuery` test is environment-coupled — it scans the dev's real `~/.agents` history — and is unrelated to this diff; it passes in CI's clean env.)
