### PR TITLE
feat(permissions): grant codex a baseline of build/test/install cache roots

### DIFF
--- a/apps/cli/.changelog/next/codex-default-writable-roots.md
+++ b/apps/cli/.changelog/next/codex-default-writable-roots.md
@@ -1,0 +1,13 @@
+- **Codex can now build, test, and install without escalating to YOLO.** Codex's
+  `workspace-write` sandbox blocks `$HOME`, so `cargo build`, `go build`, `npm/bun install`,
+  `pip install` etc. failed on their out-of-workspace cache writes (`~/.cargo`, `GOCACHE`,
+  `~/.npm`, `~/.cache`, …) — which is what pushed people to `--mode full`
+  (`--dangerously-bypass-approvals-and-sandbox`). agents-cli now writes a platform-resolved
+  baseline of **regenerable toolchain caches** into Codex's `config.toml`
+  (`[sandbox_workspace_write].writable_roots`) on permission sync — `~/.cargo`, `~/.rustup`,
+  `~/.npm`, `~/.bun`, `~/go`, `~/.deno`, `~/.gradle`, `~/.m2`, `~/.gem`, plus `~/Library/Caches`
+  + `~/Library/pnpm` on macOS or `~/.cache` + `~/.local/{share,state}` on Linux. Credential dirs
+  (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, `~/.netrc`) are deliberately excluded, so
+  `--mode auto` stays a real sandbox — far narrower than danger-full-access. Any
+  `writable_roots` you set yourself are preserved (unioned, never clobbered). Source:
+  `apps/cli/src/lib/permissions.ts` (`codexDefaultWritableRoots`, `mergeCodexSandboxWrite`).

--- a/apps/cli/docs/02-resource-sync.md
+++ b/apps/cli/docs/02-resource-sync.md
@@ -214,8 +214,15 @@ Per-agent conversion is lossy in both directions:
   dropped.
 - Codex (>= 0.138.0) writes `approval_policy` and `sandbox_mode` to
   `.codex/config.toml`, plus `sandbox_workspace_write.network_access=true` when
-  web tools are allowed. Deny rules are emitted as Starlark to a generated
-  `agents-deny.rules` file (`permissions.ts:38-56`).
+  web tools are allowed. It also writes a platform-resolved baseline of
+  `sandbox_workspace_write.writable_roots` — the regenerable toolchain caches
+  (`~/.cargo`, `~/.npm`, `~/go`, `~/.cache` / `~/Library/Caches`, …) so a
+  `workspace-write` run can build/test/install without escalating to
+  danger-full-access; credential dirs (`~/.ssh`, `~/.aws`, `~/.config`) are
+  excluded, and any roots the user set are unioned in, not clobbered
+  (`permissions.ts`: `codexDefaultWritableRoots`, `mergeCodexSandboxWrite`).
+  Deny rules are emitted as Starlark to a generated `agents-deny.rules` file
+  (`permissions.ts:38-56`).
 - Kiro 2.8.0+ maps canonical shell, filesystem, and web rules into v3
   capability rules under `.kiro/settings/permissions.yaml`. Existing user
   rules are preserved when managed rules are merged.

--- a/apps/cli/src/lib/permissions.test.ts
+++ b/apps/cli/src/lib/permissions.test.ts
@@ -11,6 +11,8 @@ import {
   containsBroadGrants,
   convertDenyToCodexRules,
   convertToKimiFormat,
+  convertToCodexFormat,
+  codexDefaultWritableRoots,
   convertToDroidFormat,
   convertToHermesFormat,
   convertToOpenClawFormat,
@@ -338,6 +340,69 @@ describe('computer permission hints', () => {
     expect(hint).toContain('key');
     expect(COMPUTER_APP_GATED_VERBS).toContain('type-text');
     expect(COMPUTER_APP_GATED_VERBS).toContain('key');
+  });
+});
+
+describe('codex writable roots (build/test/install caches)', () => {
+  const HOME = '/home/u';
+
+  it('includes shared toolchain caches on every platform', () => {
+    for (const plat of ['darwin', 'linux'] as NodeJS.Platform[]) {
+      const roots = codexDefaultWritableRoots(HOME, plat);
+      for (const d of ['.cargo', '.rustup', '.npm', '.bun', 'go', '.deno', '.gradle', '.m2', '.gem']) {
+        expect(roots).toContain(path.join(HOME, d));
+      }
+    }
+  });
+
+  it('resolves the OS cache root per platform (Library/Caches on macOS, .cache on Linux)', () => {
+    const mac = codexDefaultWritableRoots(HOME, 'darwin');
+    expect(mac).toContain(path.join(HOME, 'Library', 'Caches'));
+    expect(mac).not.toContain(path.join(HOME, '.cache'));
+
+    const linux = codexDefaultWritableRoots(HOME, 'linux');
+    expect(linux).toContain(path.join(HOME, '.cache'));
+    expect(linux).toContain(path.join(HOME, '.local', 'share'));
+    expect(linux).not.toContain(path.join(HOME, 'Library', 'Caches'));
+  });
+
+  it('never grants credential dirs (keeps the sandbox meaningful, not YOLO)', () => {
+    for (const plat of ['darwin', 'linux'] as NodeJS.Platform[]) {
+      const roots = codexDefaultWritableRoots(HOME, plat);
+      for (const d of ['.ssh', '.aws', '.gnupg', '.config', '.netrc']) {
+        expect(roots).not.toContain(path.join(HOME, d));
+      }
+    }
+  });
+
+  it('convertToCodexFormat always emits the baseline writable_roots (even with no perms)', () => {
+    const codex = convertToCodexFormat({ name: 'empty', allow: [], deny: [] });
+    expect(codex.sandbox_workspace_write?.writable_roots).toEqual(codexDefaultWritableRoots());
+  });
+
+  it('keeps network_access alongside writable_roots when web perms are present', () => {
+    const codex = convertToCodexFormat({ name: 'net', allow: ['WebFetch(*)'], deny: [] });
+    expect(codex.sandbox_workspace_write?.network_access).toBe(true);
+    expect(codex.sandbox_workspace_write?.writable_roots).toContain(path.join(os.homedir(), '.cargo'));
+  });
+
+  it('unions the baseline with a writable_root the user configured directly (never clobbers)', () => {
+    const versionHome = makeTempHome();
+    const codexDir = path.join(versionHome, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    // Pre-existing user config with a custom writable root.
+    fs.writeFileSync(
+      path.join(codexDir, 'config.toml'),
+      TOML.stringify({ sandbox_workspace_write: { writable_roots: ['/opt/custom'] } } as any),
+      'utf-8',
+    );
+    const res = applyPermissionsToVersion('codex', { name: 'x', allow: ['WebFetch'], deny: [] }, versionHome);
+    expect(res.success).toBe(true);
+    const written = TOML.parse(fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8')) as any;
+    const roots: string[] = written.sandbox_workspace_write.writable_roots;
+    expect(roots).toContain('/opt/custom'); // user's root preserved
+    expect(roots).toContain(path.join(os.homedir(), '.cargo')); // baseline added
+    expect(new Set(roots).size).toBe(roots.length); // deduped
   });
 });
 

--- a/apps/cli/src/lib/permissions.ts
+++ b/apps/cli/src/lib/permissions.ts
@@ -1109,6 +1109,55 @@ export function convertToOpenCodeFormat(set: PermissionSet): OpenCodePermissions
  * Convert canonical permission set to Codex format.
  * Codex uses coarse-grained modes, so we infer the best fit.
  */
+/**
+ * Default extra writable roots for Codex's `workspace-write` sandbox: the
+ * regenerable package/toolchain caches that build/test/install write OUTSIDE the
+ * workspace (cargo registry, npm/bun/pnpm caches, GOPATH/GOCACHE, the OS cache
+ * root, …). Without these, a sandboxed `cargo build` / `go build` / `npm install`
+ * fails on its cache write, which is what pushes users to `--mode full` (YOLO).
+ *
+ * Credential dirs (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, `~/.netrc`) are
+ * deliberately EXCLUDED so the sandbox stays meaningful — this is far from
+ * danger-full-access. Resolved per platform + home; each box regenerates its own
+ * Codex config on sync, so the paths always match the box Codex runs on.
+ */
+export function codexDefaultWritableRoots(
+  home: string = HOME,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const shared = ['.cargo', '.rustup', '.npm', '.bun', 'go', '.deno', '.gradle', '.m2', '.gem'];
+  const roots = shared.map((d) => path.join(home, d));
+  if (platform === 'darwin') {
+    roots.push(path.join(home, 'Library', 'Caches'), path.join(home, 'Library', 'pnpm'));
+  } else {
+    // Linux/XDG: ~/.cache covers pip, uv, go-build, ms-playwright, etc.
+    roots.push(path.join(home, '.cache'), path.join(home, '.local', 'share'), path.join(home, '.local', 'state'));
+  }
+  return roots;
+}
+
+/**
+ * Merge Codex `[sandbox_workspace_write]` config, UNIONing `writable_roots` so a
+ * baseline cache root never clobbers a root the user configured directly (a
+ * plain object spread would overwrite the whole array), while merging scalar
+ * keys (`network_access`) normally. Shared by the user- and version-scoped Codex
+ * config writers so the two can't drift.
+ */
+export function mergeCodexSandboxWrite(
+  existing: Record<string, unknown> | undefined,
+  incoming: NonNullable<CodexPermissions['sandbox_workspace_write']>,
+): Record<string, unknown> {
+  const existingRoots = Array.isArray(existing?.writable_roots)
+    ? (existing!.writable_roots as string[])
+    : [];
+  const unionRoots = [...new Set([...existingRoots, ...(incoming.writable_roots ?? [])])];
+  return {
+    ...existing,
+    ...incoming,
+    ...(unionRoots.length > 0 ? { writable_roots: unionRoots } : {}),
+  };
+}
+
 export function convertToCodexFormat(set: PermissionSet, cwd?: string): CodexPermissions {
   const result: CodexPermissions = {};
 
@@ -1142,6 +1191,16 @@ export function convertToCodexFormat(set: PermissionSet, cwd?: string): CodexPer
       network_access: true,
     };
   }
+
+  // Baseline (unconditional): always grant the regenerable build/test/install
+  // caches as writable roots so `agents run codex` in workspace-write can build,
+  // test, and install without escalating to danger-full-access. Merged with
+  // network_access above when set; applyCodexPermissions unions these with any
+  // writable_roots the user configured directly.
+  result.sandbox_workspace_write = {
+    ...result.sandbox_workspace_write,
+    writable_roots: codexDefaultWritableRoots(),
+  };
 
   return result;
 }
@@ -1499,7 +1558,7 @@ function applyCodexPermissions(
     if (newPermissions.sandbox_workspace_write) {
       const existing = config.sandbox_workspace_write as Record<string, unknown> | undefined;
       config.sandbox_workspace_write = merge
-        ? { ...existing, ...newPermissions.sandbox_workspace_write }
+        ? mergeCodexSandboxWrite(existing, newPermissions.sandbox_workspace_write)
         : newPermissions.sandbox_workspace_write;
     }
 
@@ -1643,7 +1702,7 @@ export function applyPermissionsToVersion(
       if (newPermissions.sandbox_workspace_write) {
         const existing = config.sandbox_workspace_write as Record<string, unknown> | undefined;
         config.sandbox_workspace_write = merge
-          ? { ...existing, ...newPermissions.sandbox_workspace_write }
+          ? mergeCodexSandboxWrite(existing, newPermissions.sandbox_workspace_write)
           : newPermissions.sandbox_workspace_write;
       }
 

--- a/apps/cli/src/lib/permissions.ts
+++ b/apps/cli/src/lib/permissions.ts
@@ -1106,10 +1106,6 @@ export function convertToOpenCodeFormat(set: PermissionSet): OpenCodePermissions
 }
 
 /**
- * Convert canonical permission set to Codex format.
- * Codex uses coarse-grained modes, so we infer the best fit.
- */
-/**
  * Default extra writable roots for Codex's `workspace-write` sandbox: the
  * regenerable package/toolchain caches that build/test/install write OUTSIDE the
  * workspace (cargo registry, npm/bun/pnpm caches, GOPATH/GOCACHE, the OS cache
@@ -1158,6 +1154,10 @@ export function mergeCodexSandboxWrite(
   };
 }
 
+/**
+ * Convert canonical permission set to Codex format.
+ * Codex uses coarse-grained modes, so we infer the best fit.
+ */
 export function convertToCodexFormat(set: PermissionSet, cwd?: string): CodexPermissions {
   const result: CodexPermissions = {};
 
@@ -1557,6 +1557,8 @@ function applyCodexPermissions(
     }
     if (newPermissions.sandbox_workspace_write) {
       const existing = config.sandbox_workspace_write as Record<string, unknown> | undefined;
+      // merge=false is a deliberate full replace (drops any user-custom roots);
+      // production sync always passes merge=true, taking the union path.
       config.sandbox_workspace_write = merge
         ? mergeCodexSandboxWrite(existing, newPermissions.sandbox_workspace_write)
         : newPermissions.sandbox_workspace_write;
@@ -1701,6 +1703,8 @@ export function applyPermissionsToVersion(
       }
       if (newPermissions.sandbox_workspace_write) {
         const existing = config.sandbox_workspace_write as Record<string, unknown> | undefined;
+        // merge=false is a deliberate full replace (drops any user-custom roots);
+        // production sync always passes merge=true, taking the union path.
         config.sandbox_workspace_write = merge
           ? mergeCodexSandboxWrite(existing, newPermissions.sandbox_workspace_write)
           : newPermissions.sandbox_workspace_write;

--- a/apps/cli/tests/permissions.test.ts
+++ b/apps/cli/tests/permissions.test.ts
@@ -12,6 +12,7 @@ import {
   convertToCursorFormat,
   convertToCopilotFormat,
   convertToCodexFormat,
+  codexDefaultWritableRoots,
   convertToAntigravityFormat,
   convertToGrokFormat,
   claudeToCanonical,
@@ -280,14 +281,19 @@ describe('convertToCodexFormat', () => {
     expect(result.sandbox_workspace_write?.network_access).toBe(true);
   });
 
-  it('returns empty object for no permissions', () => {
+  it('grants the baseline cache writable_roots even with no permissions', () => {
+    // No perms → no approval_policy/sandbox_mode, but the build/test/install
+    // cache roots are an unconditional baseline so a workspace-write run can
+    // still build without escalating to danger-full-access.
     const set: PermissionSet = {
       name: 'test',
       allow: [],
     };
 
     const result = convertToCodexFormat(set);
-    expect(result).toEqual({});
+    expect(result.approval_policy).toBeUndefined();
+    expect(result.sandbox_mode).toBeUndefined();
+    expect(result.sandbox_workspace_write?.writable_roots).toEqual(codexDefaultWritableRoots());
   });
 });
 


### PR DESCRIPTION
**feat** — lets `agents run codex --mode auto` build/test/install without escalating to `--mode full` (YOLO). Follow-up to #1682 (`~/.agents` grant). No UI; run proof below.

## Problem

Codex's `workspace-write` sandbox blocks `$HOME`. Probed live on macOS — only the workspace cwd, `/tmp`, `$TMPDIR` are writable; **every** package/toolchain cache is denied:

| Target | Default |
|---|---|
| `~/.cargo`, `~/.rustup`, `~/.npm`, `~/.bun`, `~/go` | ❌ DENIED |
| `~/.cache` (Linux XDG), `~/Library/Caches` (macOS) | ❌ DENIED |

So `cargo build` (needs `~/.cargo/registry`), `go build` (`GOCACHE`+`GOPATH`), `npm/bun install`, `pip install` all fail on the cache write — which is what pushes people to `--mode full` (`--dangerously-bypass-approvals-and-sandbox`).

## Fix

agents-cli now writes a **platform-resolved baseline** of regenerable toolchain caches into codex's `config.toml` `[sandbox_workspace_write].writable_roots` on permission sync:

- **Both:** `~/.cargo`, `~/.rustup`, `~/.npm`, `~/.bun`, `~/go`, `~/.deno`, `~/.gradle`, `~/.m2`, `~/.gem`
- **macOS:** `~/Library/Caches`, `~/Library/pnpm` · **Linux:** `~/.cache`, `~/.local/{share,state}`

**Config-based, not per-run flags** (the design call): sits with the `sandbox_mode`/`network_access` agents-cli already writes there, applies uniformly to interactive/headless/**resume** (no `--add-dir` gymnastics), propagates to version homes via the settings-manifest `toml-merge`, and helps direct `codex` use too.

## Kept protected (this is what keeps it *not* YOLO)

`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, `~/.netrc` are **excluded** — codex still can't touch your credentials. Far narrower than danger-full-access. User-set `writable_roots` are **unioned, never clobbered** (shared `mergeCodexSandboxWrite` across both config writers — fixes a latent clobber in the version-scoped writer too).

## Verified (live, real codex 0.146.0)

```
$ codex sandbox -c sandbox_mode=workspace-write -- sh -c 'touch ~/.cargo/probe'
DENIED                                                              # BEFORE

$ codex sandbox -c sandbox_mode=workspace-write \
    -c 'sandbox_workspace_write.writable_roots=["~/.cargo","~/Library/Caches"]' -- …
CACHES_WRITABLE                                                     # AFTER (the config agents-cli emits)
```

Tests: 6 new in `permissions.test.ts` (platform resolution, credential-dir exclusion, unconditional baseline, network coexistence, user-root union via a real `applyPermissionsToVersion` write). Full permissions suite: **29 passed**.

## Note / possible follow-up

`gh` (codex opening PRs) writes `~/.config/gh/hosts.yml`, which stays blocked (credential-adjacent). Left out of the default deliberately — can add as an opt-in if wanted.

Docs: `apps/cli/docs/02-resource-sync.md` (codex config keys) + CHANGELOG fragment.
