### PR TITLE
docs: agent onboarding cheat sheet + docs drift guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,28 +63,45 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: node ./node_modules/vitest/vitest.mjs run --shard=${{ matrix.shard }}/3
 
-  # Aggregate gate: the ONLY required-check context here. Runs after typecheck and
-  # every shard regardless of their outcome (`if: always()`) and fails unless ALL
-  # succeeded -- so a type error or any shard failure still blocks the merge
-  # through this single `test` check. A matrix job's `result` is `success` only
-  # when every leg passed.
+  # Verify docs stay internally consistent (no broken relative links, cheat sheet
+  # present, entry points wired). Cheap and fast; keeps the agent-facing docs from
+  # drifting silently.
+  verify-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: apps/cli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: bash scripts/verify-docs.sh
+
+  # Aggregate gate: the ONLY required-check context here. Runs after typecheck,
+  # every shard, and docs verification regardless of their outcome (`if: always()`)
+  # and fails unless ALL succeeded -- so a type error, shard failure, or docs drift
+  # still blocks the merge through this single `test` check. A matrix job's `result`
+  # is `success` only when every leg passed.
   test:
-    needs: [typecheck, test-shard]
+    needs: [typecheck, test-shard, verify-docs]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Gate on typecheck + all test shards
+      - name: Gate on typecheck + all test shards + docs
         run: |
-          echo "typecheck:  ${{ needs.typecheck.result }}"
-          echo "test-shard: ${{ needs.test-shard.result }}"
+          echo "typecheck:   ${{ needs.typecheck.result }}"
+          echo "test-shard:  ${{ needs.test-shard.result }}"
+          echo "verify-docs: ${{ needs.verify-docs.result }}"
           if [ "${{ needs.typecheck.result }}" != "success" ]; then
             echo "::error::typecheck failed"; exit 1
           fi
           if [ "${{ needs.test-shard.result }}" != "success" ]; then
             echo "::error::one or more test shards failed"; exit 1
           fi
-          echo "typecheck + all shards green"
+          if [ "${{ needs.verify-docs.result }}" != "success" ]; then
+            echo "::error::docs verification failed"; exit 1
+          fi
+          echo "typecheck + all shards + docs green"
 
   # Smoke-test the COMPILED standalone binary (`bun build --compile`), which the
   # vitest suite never exercises: on the Bun standalone, process.argv[1] /

--- a/apps/cli/.changelog/next/agent-docs-cheatsheet.md
+++ b/apps/cli/.changelog/next/agent-docs-cheatsheet.md
@@ -1,0 +1,5 @@
+- **Agent onboarding cheat sheet and docs drift guard.** Added
+  `apps/cli/docs/AGENT-CHEATSHEET.md` as a one-page on-ramp for agents, wired it
+  from `apps/cli/AGENTS.md` and `apps/cli/docs/README.md`, and added
+  `scripts/verify-docs.sh` (plus a `verify-docs` npm script and CI job) to catch
+  broken relative links and missing entry-point wiring before merge.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -4,6 +4,11 @@
 versions, config, sessions, and cloud dispatch (Claude, Codex, Cursor,
 OpenCode, OpenClaw, Grok, Droid, …).
 
+> **New agent? Read [`docs/AGENT-CHEATSHEET.md`](docs/AGENT-CHEATSHEET.md) first.**
+> It covers the dozen concepts agents repeatedly need (DotAgents repos, version
+> homes, the two "session" meanings, capability gating, the execution path) in
+> one scannable page. Come back to this file for the full architecture map.
+
 This is the **internal architecture** map. The user-facing feature tour is
 [README.md](README.md) (pin versions, run, sessions, hosts, teams, workflows,
 plugins, browser, secrets, routines, pty). This file covers the design choices,

--- a/apps/cli/docs/AGENT-CHEATSHEET.md
+++ b/apps/cli/docs/AGENT-CHEATSHEET.md
@@ -1,0 +1,82 @@
+# agents-cli — agent cheat sheet
+
+Read this first, then dive into [`architecture.md`](architecture.md) or the per-feature docs. This file is the on-ramp: the concepts agents repeatedly need when touching this codebase.
+
+## 1. What agents-cli actually does
+
+One engine installs the **resources** an agent needs, **runs** the agent, and extends it with tools, sessions, teams, and machines. Deep reference: [`00-concepts.md`](00-concepts.md).
+
+## 2. The three DotAgents repos (resolution order matters)
+
+Resources and `agents.yaml` resolve in this order; same-name wins, everything else unions:
+
+```
+project (.agents/)  >  user (~/.agents/)  >  extra (~/.agents-<alias>/)  >  system (~/.agents/.system/)
+```
+
+Source: [`src/lib/resources.ts`](../src/lib/resources.ts) (`resolveResource`, `listResources`).
+
+Implication: don't edit `~/.agents/.system/` directly; put overrides in `~/.agents/` or project `.agents/`.
+
+## 3. `AGENTS.md` is the canonical memory file
+
+`CLAUDE.md`, `GEMINI.md`, etc. are **symlinks**. Edit `AGENTS.md` only. The sync rewrites the per-agent file names.
+
+## 4. Capability table gates every per-agent write
+
+[`src/lib/capabilities.ts`](../src/lib/capabilities.ts) `supports(agent, cap, version?)` is the single source of truth for "can this agent+version receive this resource?". Out-of-range versions are skipped silently. Never scatter `=== 'claude'` checks; route through `supports()`.
+
+Snapshot in [`apps/cli/AGENTS.md`](../AGENTS.md) §Supported harnesses — keep it in sync when you change the registry.
+
+## 5. Version homes isolate every agent version
+
+Each installed agent version lives under `~/.agents/.history/versions/<agent>/<version>/home/`. agents-cli swaps `HOME` to that directory before exec-ing the agent. No config bleed between versions.
+
+Source: [`src/lib/versions.ts`](../src/lib/versions.ts), [`src/lib/exec.ts`](../src/lib/exec.ts).
+
+## 6. Two unrelated things are called "session"
+
+| | Transcript | Live identity |
+|---|---|---|
+| What | conversation on disk | which running **pid** is which session right now |
+| Where | agent-native files → `sessions.db` | `~/.agents/.cache/terminals/by-pid/<pid>.json` + `sessions/<pid>.json` |
+| Read by | `agents sessions` | `agents sessions --active`, Factory extension |
+| Lifetime | durable | ephemeral (pid dies → file is stale) |
+
+Details: [`architecture.md`](architecture.md) §2–4, [`05-sessions.md`](05-sessions.md).
+
+## 7. One execution path
+
+Every agent invocation goes through `buildExecEnv` → `execAgent` / `runWithFallback` in [`src/lib/exec.ts`](../src/lib/exec.ts), entered via `agents run`.
+
+## 8. Self-updating vs pinnable agents
+
+Some harnesses (droid, grok, antigravity, cursor, hermes, kiro, goose) install via `curl | sh` / `brew` and the binary self-updates in place — no pinnable semver. Use `isSelfUpdatingAgent()` ([`src/lib/agents.ts`](../src/lib/agents.ts)) as the single predicate. `isGlobalBinaryAgent()` ([`src/lib/versions.ts`](../src/lib/versions.ts)) is narrower: true only for droid.
+
+## 9. Work on a worktree, never `main`
+
+The default branch is untouchable. Create a worktree under `.agents/worktrees/<slug>/`, open a PR, merge on green. See root `AGENTS.md` §Conventions.
+
+## 10. Tests use real services — no mocking
+
+Tests hit the actual critical path. Integration tests live in `tests/`; unit tests sit next to source (`read.ts` → `read.test.ts`). The full suite runs via `bun run test:remote` in `apps/cli`.
+
+## 11. Where the major code lives
+
+| Area | Entry |
+|---|---|
+| CLI commands | `src/commands/` |
+| Resource resolution | `src/lib/resources.ts` |
+| Capability gating | `src/lib/capabilities.ts`, `src/lib/agents.ts` |
+| Agent execution | `src/lib/exec.ts` |
+| Version install/sync | `src/lib/versions.ts` |
+| Session transcript index | `src/lib/session/` |
+| Live active sessions | `src/lib/session/active.ts` |
+| Hosts / SSH dispatch | `src/lib/hosts/` |
+| Teams orchestration | `src/lib/teams/` |
+| Secrets broker | `src/lib/secrets/` |
+| Cloud providers | `src/lib/cloud/` |
+
+## 12. Keep docs in sync
+
+If you change a flag, command, config key, or behavior, update the relevant doc and `CHANGELOG.md`. If you change a core invariant here, update this cheat sheet too. Drift is checked by `scripts/verify-docs.sh`.

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -1,6 +1,14 @@
 # agents-cli docs
 
-Reference documentation for every feature `agents` ships. Read [`00-concepts.md`](00-concepts.md) first if you are new — it covers DotAgents repos, resource kinds, and the layered resolution model that everything else builds on.
+Reference documentation for every feature `agents` ships.
+
+## Agent onboarding (read in this order)
+
+| Doc | Why read it |
+|---|---|
+| **[`AGENT-CHEATSHEET.md`](AGENT-CHEATSHEET.md)** | The dozen concepts agents repeatedly need, on one page. Start here if you are an agent touching the codebase. |
+| [`00-concepts.md`](00-concepts.md) | DotAgents repos, resource kinds, and the layered resolution model that everything else builds on. |
+| [`architecture.md`](architecture.md) | How the CLI and Factory extension layer, and the two meanings of "session". |
 
 Source-grounded: every command, flag, and YAML field is sourced from `src/`. If you spot a mismatch, the code wins — please file an issue.
 
@@ -74,7 +82,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 - **YAML schema** blocks document the on-disk format. Field types come from the matching TypeScript interface in `src/`.
 - **Command reference** tables list every subcommand and flag. Run `agents <cmd> --help` if anything looks stale.
 - **Recipes** are numbered, copy-pasteable shell sequences. They run end-to-end, not toy snippets.
-- **Demo clips** under `assets/videos/` are 6–15s real terminal captures. The pipeline is documented in [`../assets/videos/README.md`](../assets/videos/README.md).
+- **Demo clips** under `assets/videos/` are 6–15s real terminal captures. The pipeline is documented in [`../../../assets/videos/README.md`](../../../assets/videos/README.md).
 
 ## Contributing
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -55,6 +55,7 @@
     "start": "node dist/index.js",
     "test": "node ./node_modules/vitest/vitest.mjs run",
     "test:remote": "scripts/sandbox.sh 'bun install && bun run build && bun run test'",
+    "verify-docs": "scripts/verify-docs.sh",
     "test:watch": "node ./node_modules/vitest/vitest.mjs"
   },
   "keywords": [

--- a/apps/cli/scripts/verify-docs.sh
+++ b/apps/cli/scripts/verify-docs.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Verify that agents-cli docs stay internally consistent.
+# Run from apps/cli/.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ERRORS=0
+
+log() { printf '%s\n' "$*"; }
+fail() {
+  printf '✗ %s\n' "$*" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+# --- 1. AGENT-CHEATSHEET exists and covers the basics ---
+CHEATSHEET="docs/AGENT-CHEATSHEET.md"
+if [[ ! -f "$CHEATSHEET" ]]; then
+  fail "$CHEATSHEET is missing"
+else
+  log "✓ $CHEATSHEET exists"
+  for section in "The three DotAgents repos" "\`AGENTS.md\` is the canonical memory file" "Capability table gates" "Version homes" "Two unrelated things are called"; do
+    if grep -qF "$section" "$CHEATSHEET"; then
+      log "  ✓ covers: $section"
+    else
+      fail "$CHEATSHEET missing section: $section"
+    fi
+  done
+fi
+
+# --- 2. Entry points reference the cheat sheet ---
+if grep -qF "AGENT-CHEATSHEET.md" AGENTS.md; then
+  log "✓ AGENTS.md links to AGENT-CHEATSHEET.md"
+else
+  fail "AGENTS.md should link to AGENT-CHEATSHEET.md"
+fi
+
+if grep -qF "AGENT-CHEATSHEET.md" docs/README.md; then
+  log "✓ docs/README.md links to AGENT-CHEATSHEET.md"
+else
+  fail "docs/README.md should link to AGENT-CHEATSHEET.md"
+fi
+
+# --- 3. No broken relative markdown links in docs/*.md ---
+while IFS= read -r file; do
+  while IFS= read -r match; do
+    url="${match#*\(}"
+    url="${url%\)}"
+    url="${url%%#*}"
+    [[ -z "$url" ]] && continue
+    [[ "$url" == /* ]] && continue
+    [[ "$url" == *://* ]] && continue
+    [[ "$url" == mailto:* ]] && continue
+
+    file_dir="$(cd "$(dirname "$file")" && pwd)"
+    if (cd "$file_dir" && [[ -f "$url" || -d "$url" ]]); then
+      continue
+    fi
+    resolved="$(cd "$file_dir" && pwd)/$url"
+    fail "broken link in $file -> $url (resolved: $resolved)"
+  done < <(grep -oE '\[[^]]+\]\([^)]+\)' "$file")
+done < <(find docs -name '*.md')
+
+if [[ $ERRORS -eq 0 ]]; then
+  log "✓ Docs verification passed"
+  exit 0
+else
+  log "✗ Docs verification failed with $ERRORS error(s)"
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds an agent-facing onboarding cheat sheet and a lightweight drift guard so the docs agents land on stay current.

## Changes

- New `apps/cli/docs/AGENT-CHEATSHEET.md` — one-page reference for the dozen concepts agents repeatedly need (DotAgents repos, version homes, the two "session" meanings, capability gating, execution path, etc.).
- Wired from `apps/cli/AGENTS.md` and `apps/cli/docs/README.md` so agents see it first.
- Fixed two pre-existing broken relative links in `apps/cli/docs/README.md`.
- Added `apps/cli/scripts/verify-docs.sh` and an npm `verify-docs` script; checks that the cheat sheet exists, entry points link to it, and no relative markdown links are broken.
- Added a `verify-docs` CI job to the required `test` aggregate so broken docs links block merge.
- Added CHANGELOG entry under Unreleased.

## Verification

- `bun run verify-docs` passes.
- `bun run build` passes.
- Full `bun run test` has 14 pre-existing failures in unrelated files (exec, tmux, session sync config) that also fail on main; no source files were changed in this PR.
