### PR TITLE
fix(sessions): surface Kimi todo lists and file paths in the session preview

### DIFF
--- a/apps/cli/.changelog/next/PR-1690-kimi-session-preview.md
+++ b/apps/cli/.changelog/next/PR-1690-kimi-session-preview.md
@@ -1,0 +1,13 @@
+- **`agents sessions` now shows a Kimi session's todo list and its file-touching
+  tool calls.** Kimi writes its checklist with `TodoList` (items shaped
+  `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`
+  (`{content, status: "completed"}`), so the checklist registry matched nothing
+  and every Kimi session rendered with no todos — in the picker preview, the
+  session detail, and the `--active` fan-out that carries progress off remote
+  devices. Kimi also names the file argument `path` where Claude names it
+  `file_path`, so `Read`/`Write`/`Edit` calls summarized as a bare `Read ` with
+  no file. Both spellings are now handled, and the snapshot-checklist tool names
+  live in one exported registry (`SNAPSHOT_TODO_TOOLS`) that the picker and the
+  state engine share instead of each hardcoding its own pair. Source:
+  `apps/cli/src/lib/session/parse.ts`, `apps/cli/src/lib/session/state.ts`,
+  `apps/cli/src/commands/sessions-picker.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,21 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **`agents sessions` now shows a Kimi session's todo list and its file-touching
-  tool calls.** Kimi writes its checklist with `TodoList` (items shaped
-  `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`
-  (`{content, status: "completed"}`), so the checklist registry matched nothing
-  and every Kimi session rendered with no todos — in the picker preview, the
-  session detail, and the `--active` fan-out that carries progress off remote
-  devices. Kimi also names the file argument `path` where Claude names it
-  `file_path`, so `Read`/`Write`/`Edit` calls summarized as a bare `Read ` with
-  no file. Both spellings are now handled, and the snapshot-checklist tool names
-  live in one exported registry (`SNAPSHOT_TODO_TOOLS`) that the picker and the
-  state engine share instead of each hardcoding its own pair. Source:
-  `apps/cli/src/lib/session/parse.ts`, `apps/cli/src/lib/session/state.ts`,
-  `apps/cli/src/commands/sessions-picker.ts`.
-
 ## 1.20.83
 
 - **Routines now treat date-specific cron schedules as one-shot jobs (RUSH-2074).**

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+- **`agents sessions` now shows a Kimi session's todo list and its file-touching
+  tool calls.** Kimi writes its checklist with `TodoList` (items shaped
+  `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`
+  (`{content, status: "completed"}`), so the checklist registry matched nothing
+  and every Kimi session rendered with no todos — in the picker preview, the
+  session detail, and the `--active` fan-out that carries progress off remote
+  devices. Kimi also names the file argument `path` where Claude names it
+  `file_path`, so `Read`/`Write`/`Edit` calls summarized as a bare `Read ` with
+  no file. Both spellings are now handled, and the snapshot-checklist tool names
+  live in one exported registry (`SNAPSHOT_TODO_TOOLS`) that the picker and the
+  state engine share instead of each hardcoding its own pair. Source:
+  `apps/cli/src/lib/session/parse.ts`, `apps/cli/src/lib/session/state.ts`,
+  `apps/cli/src/commands/sessions-picker.ts`.
+
 ## 1.20.83
 
 - **Routines now treat date-specific cron schedules as one-shot jobs (RUSH-2074).**

--- a/apps/cli/src/commands/sessions-picker.ts
+++ b/apps/cli/src/commands/sessions-picker.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 import chalk from 'chalk';
 import { truncate, humanDuration } from '../lib/format.js';
 import type { SessionEvent, SessionMeta, TodoProgress } from '../lib/session/types.js';
-import { parseSession, sanitizeForTerminal } from '../lib/session/parse.js';
+import { parseSession, sanitizeForTerminal, SNAPSHOT_TODO_TOOLS } from '../lib/session/parse.js';
 import { cleanSessionPrompt, extractSessionTopic } from '../lib/session/prompt.js';
 import { linkPath, linkUrl, relativeToCwd, shortenModel } from '../lib/session/render.js';
 import { linearIssueUrl } from '../lib/session/linear.js';
@@ -341,9 +341,10 @@ function formatCompactPreview(events: ReturnType<typeof parseSession>, session: 
       if (!planFile && p && /\/plans\/[^/]+\.md$/.test(p)) {
         planFile = p;
       }
-      // Claude TodoWrite (`todos`) and Codex update_plan (`plan`) — same source as
-      // extractTodoProgress in the state engine. Prefer the most recent write.
-      if (tool === 'TodoWrite' || tool === 'update_plan') {
+      // Every harness's checklist-snapshot tool (Claude TodoWrite, Kimi TodoList,
+      // Codex update_plan, …) — the same registry the state engine folds through
+      // extractTodoProgress. Prefer the most recent write.
+      if (SNAPSHOT_TODO_TOOLS.has(tool)) {
         const progress = extractTodoProgress(event.args);
         if (progress) latestTodos = progress;
       }

--- a/apps/cli/src/lib/session/__tests__/parse-kimi.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-kimi.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, test } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { parseKimi, detectAgent, parseSession } from '../parse.js';
+import { parseKimi, detectAgent, parseSession, summarizeToolUse } from '../parse.js';
 import { readKimiMeta } from '../discover.js';
 import { extractTodoProgressFromEvents } from '../state.js';
 
@@ -406,6 +406,112 @@ describe('parseKimi', () => {
 
     const events = parseKimi(path.join(sessionDir, 'state.json'));
     expect(events).toEqual([]);
+  });
+});
+
+/**
+ * Kimi's checklist tool is `TodoList`, not Claude's `TodoWrite`, and its items
+ * are `{title, status}` where finished is `"done"` — not `{content, status:
+ * "completed"}`. Both spellings were unhandled, so a Kimi session with a live
+ * checklist showed no todos in `agents sessions` at all. The wire records below
+ * are verbatim shapes from a real ~/.kimi-code wire.jsonl.
+ */
+describe('kimi TodoList checklist', () => {
+  function todoListCall(todos: Array<{ title: string; status: string }>) {
+    return JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'tool_ckYuWLIhOfHpi6AbrlHEKCCE',
+        toolCallId: 'tool_ckYuWLIhOfHpi6AbrlHEKCCE',
+        name: 'TodoList',
+        args: { todos },
+        description: 'Updating todo list',
+      },
+      time: 1783981312658,
+    });
+  }
+
+  test('folds TodoList into checklist progress, mapping title/done to content/completed', () => {
+    const statePath = makeKimiSession(todoListCall([
+      { title: 'Create isolated git worktree off origin/main', status: 'done' },
+      { title: 'Redesign POLICY column labels in secrets list', status: 'done' },
+      { title: 'Run tests and verify real output', status: 'in_progress' },
+      { title: 'Roll out to fleet devices', status: 'pending' },
+    ]));
+
+    const progress = extractTodoProgressFromEvents(parseKimi(statePath));
+    expect(progress).toBeDefined();
+    expect(progress!.total).toBe(4);
+    expect(progress!.done).toBe(2);
+    expect(progress!.activeForm).toBe('Run tests and verify real output');
+    expect(progress!.items.map(i => i.status)).toEqual([
+      'completed', 'completed', 'in_progress', 'pending',
+    ]);
+    expect(progress!.items[0].content).toBe('Create isolated git worktree off origin/main');
+  });
+
+  test('the last TodoList write wins — it is a full-list snapshot', () => {
+    const statePath = makeKimiSession([
+      todoListCall([
+        { title: 'Ship the fix', status: 'pending' },
+        { title: 'Open the PR', status: 'pending' },
+      ]),
+      todoListCall([
+        { title: 'Ship the fix', status: 'done' },
+        { title: 'Open the PR', status: 'in_progress' },
+      ]),
+    ].join('\n'));
+
+    const progress = extractTodoProgressFromEvents(parseKimi(statePath));
+    expect(progress!.done).toBe(1);
+    expect(progress!.total).toBe(2);
+    expect(progress!.activeForm).toBe('Open the PR');
+  });
+
+  test('summarizes a TodoList call as plan progress, not a bare tool name', () => {
+    expect(summarizeToolUse('TodoList', {
+      todos: [
+        { title: 'Ship the fix', status: 'done' },
+        { title: 'Open the PR', status: 'in_progress' },
+      ],
+    })).toBe('Plan 1/2: Open the PR');
+  });
+});
+
+/**
+ * Kimi names the file argument `path` where Claude names it `file_path`, so
+ * Read/Write/Edit summaries rendered as a bare "Read " with no file at all.
+ */
+describe('kimi tool-call summaries carry the file path', () => {
+  test('Read/Write/Edit read the `path` arg', () => {
+    expect(summarizeToolUse('Read', { path: '/tmp/secrets.ts' })).toBe('Read /tmp/secrets.ts');
+    expect(summarizeToolUse('Write', { path: '/tmp/new.ts' })).toBe('Write /tmp/new.ts');
+    expect(summarizeToolUse('Edit', { path: '/tmp/secrets.ts', old_string: 'a', new_string: 'b' }))
+      .toBe('Edit /tmp/secrets.ts');
+  });
+
+  test('Claude `file_path` still wins where both spellings are present', () => {
+    expect(summarizeToolUse('Read', { file_path: '/tmp/claude.ts', path: '/tmp/kimi.ts' }))
+      .toBe('Read /tmp/claude.ts');
+  });
+
+  test('a parsed Kimi Read event summarizes with its path', () => {
+    const statePath = makeKimiSession(JSON.stringify({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'tool_read1',
+        toolCallId: 'tool_read1',
+        name: 'Read',
+        args: { path: '/tmp/agents-cli/secrets.ts' },
+      },
+      time: 1783981312658,
+    }));
+
+    const events = parseKimi(statePath);
+    expect(events).toHaveLength(1);
+    expect(summarizeToolUse(events[0].tool!, events[0].args)).toBe('Read /tmp/agents-cli/secrets.ts');
   });
 });
 

--- a/apps/cli/src/lib/session/parse.ts
+++ b/apps/cli/src/lib/session/parse.ts
@@ -204,6 +204,21 @@ export function detectAgent(filePath: string): SessionAgentId | null {
 }
 
 /**
+ * Checklist-snapshot tool names across harnesses — each sends the WHOLE list on
+ * every write, so the last call is the current checklist. Claude `TodoWrite`,
+ * Kimi `TodoList`, Droid/OpenCode `todo_write`, Codex `update_plan`.
+ */
+export const SNAPSHOT_TODO_TOOLS = new Set(['TodoWrite', 'TodoList', 'todo_write', 'update_plan']);
+
+/**
+ * Whether a harness's checklist status means "finished". Claude/Codex write
+ * `completed`; Kimi writes `done`.
+ */
+export function isCompletedTodoStatus(status: unknown): boolean {
+  return status === 'completed' || status === 'done';
+}
+
+/**
  * Summarize a tool_use into a one-liner string.
  */
 export function summarizeToolUse(tool: string, args?: Record<string, any>): string {
@@ -212,12 +227,13 @@ export function summarizeToolUse(tool: string, args?: Record<string, any>): stri
   switch (tool) {
     case 'Bash':
       return `Bash: ${truncate(String(args.command || '').replace(/\n/g, ' ').trim(), 120)}`;
+    // `path` is the Kimi spelling of Claude's `file_path` for the same tools.
     case 'Read':
-      return `Read ${shortenPath(args.file_path || '')}`;
+      return `Read ${shortenPath(args.file_path || args.path || '')}`;
     case 'Write':
-      return `Write ${shortenPath(args.file_path || '')}`;
+      return `Write ${shortenPath(args.file_path || args.path || '')}`;
     case 'Edit':
-      return `Edit ${shortenPath(args.file_path || '')}`;
+      return `Edit ${shortenPath(args.file_path || args.path || '')}`;
     case 'Glob':
       return `Glob ${args.pattern || ''}`;
     case 'Grep':
@@ -232,13 +248,16 @@ export function summarizeToolUse(tool: string, args?: Record<string, any>): stri
       const steps = Array.isArray(args.plan) ? args.plan.length : 0;
       return `Plan: ${steps} step${steps === 1 ? '' : 's'}`;
     }
-    // Claude's live checklist: show progress + the current step, not a bare "TodoWrite".
-    case 'TodoWrite': {
+    // Live checklist: show progress + the current step, not a bare "TodoWrite".
+    // Claude writes `TodoWrite`, Kimi writes `TodoList`; both carry the whole list
+    // under `todos`, with Kimi spelling the item text `title` and "done" `done`.
+    case 'TodoWrite':
+    case 'TodoList': {
       const todos = Array.isArray(args.todos) ? args.todos : [];
       if (todos.length === 0) return 'Plan: 0 steps';
-      const done = todos.filter((t: any) => t?.status === 'completed').length;
+      const done = todos.filter((t: any) => isCompletedTodoStatus(t?.status)).length;
       const active = todos.find((t: any) => t?.status === 'in_progress');
-      const step = active?.activeForm || active?.content;
+      const step = active?.activeForm || active?.content || active?.title;
       return step
         ? `Plan ${done}/${todos.length}: ${truncate(String(step), 80)}`
         : `Plan: ${done}/${todos.length} done`;

--- a/apps/cli/src/lib/session/state.ts
+++ b/apps/cli/src/lib/session/state.ts
@@ -17,7 +17,7 @@
 
 import * as path from 'path';
 import type { SessionAttachment, SessionEvent, TodoItem, TodoProgress } from './types.js';
-import { summarizeToolUse } from './parse.js';
+import { isCompletedTodoStatus, SNAPSHOT_TODO_TOOLS, summarizeToolUse } from './parse.js';
 
 // TodoItem / TodoProgress moved to ./types.ts so SessionMeta can carry `todos`
 // without a state↔types import cycle; re-exported here for existing importers.
@@ -162,16 +162,16 @@ const PROSE_QUESTION_FRESH_MS = 30 * 60_000;
 const PLAN_TOOL = 'ExitPlanMode';
 const ASK_TOOL = 'AskUserQuestion';
 
-const SNAPSHOT_TODO_TOOLS = new Set(['TodoWrite', 'todo_write', 'update_plan']);
 const TASK_CREATE_TOOL = 'TaskCreate';
 const TASK_UPDATE_TOOL = 'TaskUpdate';
 
 /**
- * Derive live plan progress from a checklist tool call's args. Accepts both
- * Claude's `TodoWrite` (`todos: [{content,status,activeForm}]`) and Codex's
- * `update_plan` (`plan: [{step,status}]`) shapes, so the CLI is the single source
- * of checklist state for every agent. Returns undefined when there is no usable
- * list, so a session with no plan carries no `todos` field.
+ * Derive live plan progress from a checklist tool call's args. Accepts Claude's
+ * `TodoWrite` (`todos: [{content,status,activeForm}]`), Kimi's `TodoList`
+ * (`todos: [{title,status}]`, where finished is `done` rather than `completed`)
+ * and Codex's `update_plan` (`plan: [{step,status}]`) shapes, so the CLI is the
+ * single source of checklist state for every agent. Returns undefined when there
+ * is no usable list, so a session with no plan carries no `todos` field.
  */
 export function extractTodoProgress(args?: Record<string, any>): TodoProgress | undefined {
   const input = args?.input && typeof args.input === 'object' ? args.input : args;
@@ -191,10 +191,15 @@ export function extractTodoProgress(args?: Record<string, any>): TodoProgress | 
           ? t.text
           : typeof t?.step === 'string' && t.step
             ? t.step
-            : activeForm ?? '';
+            : typeof t?.title === 'string' && t.title
+              ? t.title
+              : activeForm ?? '';
     if (!content) continue;
-    const status: TodoItem['status'] =
-      t?.status === 'completed' || t?.status === 'in_progress' ? t.status : 'pending';
+    const status: TodoItem['status'] = isCompletedTodoStatus(t?.status)
+      ? 'completed'
+      : t?.status === 'in_progress'
+        ? 'in_progress'
+        : 'pending';
     const description = typeof t?.description === 'string' && t.description ? t.description : undefined;
     items.push({ content, status, ...(description ? { description } : {}), ...(activeForm ? { activeForm } : {}) });
   }


### PR DESCRIPTION
**bugfix** — `agents sessions` never showed a Kimi session's todo list, and its `Read`/`Write`/`Edit` calls rendered with no file path.

## What was wrong

Two spelling mismatches between Kimi's wire format and the Claude-shaped assumptions in the session reader:

| | Claude | Kimi | Effect |
|---|---|---|---|
| checklist tool | `TodoWrite` | `TodoList` | tool name matched no registry entry |
| checklist item | `{content, status: "completed"}` | `{title, status: "done"}` | item text and done-count both read as empty |
| file argument | `file_path` | `path` | `Read`/`Write`/`Edit` summarized as a bare `Read ` |

So a Kimi session with a live checklist in its TUI showed **no todos anywhere** — picker preview, session detail, and the `--active` fan-out that carries progress off remote devices — while its file-touching tool calls lost their filenames.

## The fix

- `SNAPSHOT_TODO_TOOLS` is now one exported registry in `session/parse.ts` (`TodoWrite` · `TodoList` · `todo_write` · `update_plan`); `sessions-picker.ts` and `session/state.ts` both read it instead of each hardcoding its own `TodoWrite || update_plan` pair.
- `extractTodoProgress` accepts `title` as item text and `isCompletedTodoStatus` maps both `completed` and `done`.
- `summarizeToolUse` reads `args.path` as the fallback for `Read`/`Write`/`Edit`, and renders `TodoList` as plan progress like `TodoWrite`.

## Ran it

Against a real transcript on disk — `~/.kimi-code/sessions/wd_agents-cli_48ae77fb85d7/session_4930001f…/state.json`, 159 tool calls, 9 `TodoList` writes.

**Picker preview panel — the surface in the bug report:**

![preview before and after](https://github.com/user-attachments/assets/ee4e8525-3273-4f31-a8a1-355b4e1c6b8b)

**Tool-call summaries:**

![tool summaries before and after](https://github.com/user-attachments/assets/501abdbb-40f7-4733-8ff6-4fd7cc2c4bd8)

`agents sessions 4930001f` now also renders a `Plan` block that was absent before:

```
Plan
  · Create isolated git worktree off origin/main
  · Redesign POLICY column labels in secrets list
  · Update CHANGELOG.md for user-visible change
  ...
```

## Tests

`apps/cli/src/lib/session/__tests__/parse-kimi.test.ts` — fixtures are verbatim wire records from that real session. Both new suites fail on pre-fix code (no checklist at all; a bare `Read ` with no file).

```
Test Files  81 passed (81)
     Tests  884 passed (884)     # apps/cli/src/lib/session + sessions-picker
```
`tsc --noEmit` clean.

Session transcript (confidential, not inlined): `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.220/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/f7fe487e-c706-4f85-a05f-151f453ce0cb.jsonl`
