### PR TITLE
feat(sessions): show a team's target + teammate on each row

### DIFF
--- a/apps/cli/.changelog/next/sessions-team-target.md
+++ b/apps/cli/.changelog/next/sessions-team-target.md
@@ -1,0 +1,7 @@
+- **`agents sessions` team rows now show the team's target and teammate, not just
+  the slug.** Each teammate row reads `<team> · <teammate> · by <orchestrator> ·
+  <live turn | mission>`, where the mission is a one-line summary of the teammate's
+  spawn prompt (`assignedTask`, shown even before it has a transcript). Several
+  teams from one orchestrator stay legible (distinct team names) and each says what
+  it is for. `--active --json` carries `assignedTask`. Source:
+  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -266,9 +266,15 @@ spawned it — the session that ran `agents teams add`, captured from
 `AGENTS_SESSION_ID` at spawn and stored as the teammate's `parentSessionId`
 (`src/lib/teams/agents.ts`). `listTeamsActive` surfaces it as `orchestratorSessionId`
 (the teammate's own transcript stays `sessionId`), and `getActiveSessions` resolves an
-`orchestratorLabel` from the orchestrator's own row when it is present in the set. The
-listing shows it as `<team> · by <orchestrator>`, so "which session spun up this team"
-is answerable at a glance; `--active --json` carries both fields for programmatic use.
+`orchestratorLabel` from the orchestrator's own row when it is present in the set.
+
+Each row also carries the team's **target** — a one-line summary of the mission the
+teammate was spawned with (`summarizeMission` over the stored `prompt`), exposed as
+`assignedTask` and shown even before the teammate has produced a transcript. The row
+reads `<team> · <teammate> · by <orchestrator> · <live turn | mission>`, so one
+orchestrator running several teams stays legible (distinct `teamName`s) and each team
+says what it is *for*, not just its slug. `--active --json` carries
+`orchestratorSessionId`, `orchestratorLabel`, and `assignedTask` for programmatic use.
 
 Two properties of the running view are worth stating, because a session missing from
 it is indistinguishable from a session that isn't running:

--- a/apps/cli/src/commands/__tests__/sessions.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions.test.ts
@@ -1050,3 +1050,32 @@ describe('buildSessionDescription — team lineage', () => {
     expect(desc).not.toContain('by ');
   });
 });
+
+describe('buildSessionDescription — team target + teammate', () => {
+  it('shows team, teammate, orchestrator, and the assigned mission', () => {
+    const desc = buildSessionDescription({
+      context: 'teams', kind: 'claude', status: 'working',
+      teamName: 'session-ship', label: 'cli-ids', orchestratorLabel: 'ship the CLI',
+      assignedTask: 'Make short + full session ids resolve everywhere',
+    } as any);
+    expect(desc).toContain('session-ship');
+    expect(desc).toContain('cli-ids');
+    expect(desc).toContain('by ship the CLI');
+    expect(desc).toContain('Make short + full session ids resolve everywhere');
+  });
+  it('prefers the live preview over the assigned mission once working', () => {
+    const desc = buildSessionDescription({
+      context: 'teams', kind: 'claude', status: 'working',
+      teamName: 't', assignedTask: 'the mission', preview: 'editing usage.ts',
+    } as any);
+    expect(desc).toContain('editing usage.ts');
+    expect(desc).not.toContain('the mission');
+  });
+  it('shows the assigned mission for a teammate with no transcript yet (pending)', () => {
+    const desc = buildSessionDescription({
+      context: 'teams', kind: 'claude', status: 'pending',
+      teamName: 't', assignedTask: 'wire up the auth flow',
+    } as any);
+    expect(desc).toContain('wire up the auth flow');
+  });
+});

--- a/apps/cli/src/commands/__tests__/sessions.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions.test.ts
@@ -958,7 +958,11 @@ describe('resolveSessionQuery id-vs-search resolution', () => {
   // another machine); the pool holds an unrelated session whose topic merely
   // quotes that id — the exact shape that made `sessions <uuid>` render the wrong
   // transcript and advise "Pass a longer ID" for an already-complete id.
-  const wanted = 'd3470b57-2af6-4c11-b1de-3fab94f43603';
+  // Synthetic id that cannot exist in any real session DB: a complete id absent
+  // from the pool now also consults the on-disk index (findSessionsById), so a
+  // REAL id here would resolve from the developer's own history and make these
+  // tests machine-specific (they'd fail wherever that session exists).
+  const wanted = '00000000-0000-4000-8000-000000000042';
   const decoy = meta({
     id: 'ffa1f432-1a9e-4a81-8e93-e70aa8df1c95',
     topic: `Resume previous work: ${wanted}`,
@@ -980,7 +984,7 @@ describe('resolveSessionQuery id-vs-search resolution', () => {
 
   it('keeps short-id prefix lookup working', () => {
     const real = meta({ id: wanted, topic: 'Improve session display' });
-    const r = resolveSessionQuery([real], 'd3470b57');
+    const r = resolveSessionQuery([real], '00000000');
     expect(r.matches.map(s => s.id)).toEqual([wanted]);
     expect(r.byId).toBe(true);
     expect(r.completeId).toBe(false);

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -364,15 +364,22 @@ export function buildSessionDescription(s: ActiveSession): string {
     return cleanPreview([todo, base].filter(Boolean).join(' · '));
   }
   if (s.context === 'teams') {
+    // A teams row identifies its TEAM, then the teammate within it, then who
+    // spun it up, then what it's working on — so several teams from one
+    // orchestrator stay distinct and each shows its target, not just its slug.
     const parts = [s.teamName];
+    // Teammate name (distinct from the team slug) — which member this row is.
+    if (s.label && s.label !== s.teamName) parts.push(s.label);
     // Lineage: which orchestrator spun up this team. Prefer the resolved label,
     // else the short session id, so "by whom" is answerable at a glance.
     const orch = s.orchestratorLabel || (s.orchestratorSessionId ? s.orchestratorSessionId.slice(0, 8) : '');
     if (orch) parts.push(`by ${orch}`);
     if (todo) parts.push(todo);
-    if (s.preview) parts.push(s.preview);
-    else if (s.label) parts.push(s.label);
-    else if (s.topic) parts.push(s.topic);
+    // Target: the live latest turn if working, else the assigned mission (the
+    // team's task/target, shown even before the teammate has a transcript), else
+    // the transcript topic.
+    const target = s.preview || s.assignedTask || s.topic;
+    if (target) parts.push(target);
     return cleanPreview(parts.filter(Boolean).join(' · '));
   }
   // Terminal, headless, or sub-agent: todos + live preview, then label, then topic.

--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels } from './active.js';
+import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels, summarizeMission } from './active.js';
 import type { HookSessionIndex } from './hook-sessions.js';
 import type { DeviceProfile, DeviceRegistry } from '../devices/registry.js';
 
@@ -289,5 +289,26 @@ describe('annotateOrchestratorLabels (team lineage — which session spun up a t
     const solo = row({ sessionId: 's1', context: 'terminal', label: 'x' });
     annotateOrchestratorLabels([solo]);
     expect(solo.orchestratorLabel).toBeUndefined();
+  });
+});
+
+describe('summarizeMission (team task/target from the spawn prompt)', () => {
+  it('takes the first line and strips a MISSION: label', () => {
+    expect(summarizeMission('MISSION: Fix the session mapping bug\n\nDetails...')).toBe('Fix the session mapping bug');
+  });
+  it('strips CONTEXT:/TASK:/GOAL: labels too', () => {
+    expect(summarizeMission('CONTEXT: improve the docs site')).toBe('improve the docs site');
+    expect(summarizeMission('TASK - ship the CLI')).toBe('ship the CLI');
+  });
+  it('truncates a long mission with an ellipsis', () => {
+    const long = 'x'.repeat(200);
+    const out = summarizeMission(long)!;
+    expect(out.length).toBe(80);
+    expect(out.endsWith('…')).toBe(true);
+  });
+  it('returns undefined for empty/whitespace prompt', () => {
+    expect(summarizeMission('')).toBeUndefined();
+    expect(summarizeMission('   \n  ')).toBeUndefined();
+    expect(summarizeMission(null)).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -213,6 +213,15 @@ export interface ActiveSession {
   /** Display label for the orchestrator (its topic/label), resolved when the
    * orchestrator is itself present in the active set. Display-only. */
   orchestratorLabel?: string;
+  /**
+   * For a teams teammate: a one-line summary of the mission it was spawned with
+   * (the `prompt` stored on the teammate record — the team's task/target), so the
+   * listing answers "what is this team working on", not just its name. Survives
+   * before the teammate has produced any transcript (a pending/staged teammate
+   * still shows its target). Distinct from `topic`, which is derived from the
+   * teammate's own transcript once it starts.
+   */
+  assignedTask?: string;
   agentId?: string;
   cloudProvider?: string;
   cloudTaskId?: string;
@@ -793,6 +802,20 @@ function quickExtractTopic(sessionFile: string): string | undefined {
   return undefined;
 }
 
+/**
+ * One-line summary of a teammate's spawn prompt — the team's task/target. Takes
+ * the first non-empty line, strips a leading `MISSION:`/`CONTEXT:`/`TASK:` label,
+ * and truncates. Exported for tests.
+ */
+export function summarizeMission(prompt: string | null | undefined): string | undefined {
+  if (!prompt) return undefined;
+  const firstLine = prompt.split('\n').map((l) => l.trim()).find(Boolean);
+  if (!firstLine) return undefined;
+  const cleaned = firstLine.replace(/^(MISSION|CONTEXT|TASK|GOAL|OBJECTIVE)\s*[:\-—]\s*/i, '').trim();
+  if (!cleaned) return undefined;
+  return cleaned.length > 80 ? `${cleaned.slice(0, 79)}…` : cleaned;
+}
+
 /** Live teams teammates. Reuses AgentManager which already polls PIDs via `kill -0`. */
 export async function listTeamsActive(): Promise<ActiveSession[]> {
   const mgr = new AgentManager();
@@ -824,6 +847,7 @@ export async function listTeamsActive(): Promise<ActiveSession[]> {
       startedAtMs: a.startedAt.getTime(),
       lastActivityMs: sessionFileTimes(sessionFile).mtimeMs,
       teamName: a.taskName,
+      assignedTask: summarizeMission(a.prompt),
       agentId: a.agentId,
       // The frozen actor stamped on the teammate record (RUSH-2028) — who ran
       // this teammate, surfaced as the owner in --active (RUSH-2018); sidecar


### PR DESCRIPTION
Follow-up to the team-lineage change: makes `agents sessions` team rows show **what each team is for** and **which teammate** a row is — answering "what if one agent spun up multiple teams?" and "what's the topic/task/target?".

**type:** feature (CLI — `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`)

## Problem
The prior change showed `<team> · by <orchestrator>` — the team's *name* but not its *purpose*. Several teams from one orchestrator were only distinguishable by slug, and there was no "what is this team working on".

## Fix
- `summarizeMission()` derives a one-line target from the teammate's spawn `prompt` (strips `MISSION:`/`CONTEXT:`/`TASK:` labels, truncates). `listTeamsActive` exposes it as `assignedTask` — present even before the teammate has a transcript (so a pending teammate still shows its target).
- `buildSessionDescription` now renders `<team> · <teammate> · by <orchestrator> · <live turn | mission>`. Multiple teams stay legible (distinct `teamName`), each says what it's for, and the teammate name is distinct from the team slug.
- `--active --json` carries `assignedTask`.

## Verified end-to-end (real data)
Ran the real `summarizeMission` + `buildSessionDescription` over a genuine stored teammate record:
```
stored prompt: "MISSION: Make short session ids and full ids resolve consistently EVERYWHERE ..."
RENDERED ROW:  session-ship · cli-ids · Make short session ids and full ids resolve consistently EVERYWHERE in the agen…
```
(team `session-ship`, teammate `cli-ids`, and its mission — exactly team · teammate · target.)

## Tests
`summarizeMission` (+4: label-strip, truncate, empty) and `buildSessionDescription` team target (+3: full row, live-preview-wins, pending-shows-mission). `active.test.ts` + `gen-changelog.test.ts` green (43); `tsc --noEmit` clean.

## Not in this PR (offered)
True visual **grouping** in the interactive browser (orchestrator → team → teammates as nested sections) is a larger `sessions-browser.ts` change; this PR keeps the flat list but makes every row self-describing. Happy to follow up with grouping if wanted.
