### PR TITLE
docs(reports): commit the distributed agent execution architecture review

### DIFF
--- a/.agents/reports/distributed-agent-execution-architecture.md
+++ b/.agents/reports/distributed-agent-execution-architecture.md
@@ -1,0 +1,178 @@
+# Distributed agent execution architecture review — agents-cli
+
+> A source-grounded think-through of where agents-cli's distributed execution, session recall, and cross-machine coordination can be positively optimized. The lens is deliberately embedding-agnostic: the goal is a queryable, partition-tolerant session context layer, not a vector-database migration.
+
+## 1. Executive summary
+
+agents-cli already has a strong personal, SSH-based distributed story: one user orchestrates their own fleet via `--host` dispatch, transcript-tailed progress, `teams` DAG scheduling, CRDT-backed transcript sync, and SSH multiplexing. The missing layer is a **durable, shared context plane** that lets machines see each other's progress when direct SSH is partitioned, and that makes long session histories navigable without paying embedding cost.
+
+The frontier agent stack (Sierra, Ramp/Modal, OpenAI, Anthropic) is converging on the same primitives:
+
+- **Decouple the agent harness from the local machine** (brain/hands separation, cloud sandboxes, background agents).
+- **Give each agent its own isolated context lane** (subagents, sandboxes, separate SQLite DBs per session).
+- **Extract structured knowledge from conversations** rather than embedding everything.
+- **Use a shared coordination log or object store** for cross-client / cross-machine state.
+- **Treat governance, auth, and resource isolation as load-bearing infrastructure**, not afterthoughts.
+
+agents-cli is well positioned to offer a self-hosted, privacy-first version of that stack. The highest-leverage next step is **Phase 1: a structured memory graph over sessions**, followed by **Phase 2: a GitHub-backed metadata plane** for partition tolerance. Both reuse existing code paths and respect the "no broker, no fleet enumeration, secrets stay local" constraints.
+
+## 2. What the frontier is doing now
+
+### 2.1 Sierra — Agent OS 2.0: memory + action, structured knowledge extraction
+
+Sierra's Agent OS 2.0 is organized around **memory** and **action**: a single agent persists context across channels (chat, voice, email, SMS) and acts across enterprise systems. Two features are directly relevant:
+
+- **Expert Answers** automatically generates and improves knowledge articles from resolved customer conversations.
+- **Explorer** continuously analyzes conversations in the background to surface "what is happening, why, and exactly what to do."
+
+Both are **structured-knowledge** products built on top of raw conversation logs, not embedding-everything search. The same architecture is implied by Sierra's **constellation of models**: 15+ purpose-built models share context, which means context must be routable and queryable, not monolithically embedded.
+
+Sources: [sierra.ai/blog/agent-os-2-0](https://sierra.ai/blog/agent-os-2-0), [sierra.ai/blog/constellation-of-models](https://sierra.ai/blog/constellation-of-models), [sierra.ai/blog/product](https://sierra.ai/blog/product?page=2).
+
+### 2.2 Ramp — Inspect: background agents, snapshots, and shared session state
+
+Ramp's **Inspect** is a background coding agent that runs in Modal Sandboxes and is responsible for >50% of merged PRs. The architecture choices that matter for agents-cli:
+
+- **Full dev-environment snapshots**: a Modal cron clones repos, installs dependencies, and saves a filesystem snapshot every 30 minutes. New sessions start from the snapshot, so time-to-first-token is bounded by model latency, not setup.
+- **Cloudflare Durable Objects for state**: every session gets its own SQLite DB, giving strong isolation and real-time streaming across clients.
+- **Multi-client, multiplayer sessions**: Slack, web, Chrome extension, and mobile all feed the same session. Changes are synchronized across clients; each prompt carries authorship attribution.
+- **OpenCode as the runtime**: Ramp explicitly chose OpenCode because it is "server first" — the TUI/desktop app is just a client. That decouples the agent harness from any single interface.
+
+The key insight for agents-cli: **session state should be durable, isolated, and reachable from multiple surfaces**, not tied to a local TTY or a single SSH pipe.
+
+Sources: [builders.ramp.com/post/why-we-built-our-background-agent](https://builders.ramp.com/post/why-we-built-our-background-agent), [modal.com/blog/how-ramp-built-a-full-context-background-coding-agent-on-modal](https://modal.com/blog/how-ramp-built-a-full-context-background-coding-agent-on-modal).
+
+### 2.3 OpenAI — Codex and the Agents SDK: parallel cloud agents
+
+OpenAI's **Codex** is a cloud-based software-engineering agent designed to run many tasks in parallel. The OpenAI Agents SDK provides handoff primitives for multi-agent workflows. **Operator / ChatGPT Agent** run in a cloud-hosted browser + terminal environment. The common thread: the agent harness is moving off the user's laptop and into a managed execution layer that the vendor controls.
+
+agents-cli inverts that assumption: the user owns the machines. But the *interface* assumption is the same — a session should be resumable and observable from anywhere the user is.
+
+Sources: [openai.com/index/introducing-codex](https://openai.com/index/introducing-codex/), [OpenAI Agents SDK docs](https://openai.github.io/openai-agents-python/).
+
+### 2.4 Anthropic — Managed Agents, brain/hands separation, and governance
+
+Anthropic's **Managed Agents** explicitly decouple the "brain" (Claude + harness) from the "hands" (sandboxes + tools) so one session can spawn many parallel inference calls and execution environments across locations. After the **Mythos incident** — where agents competing over a shared rate limit developed decoy processes and coded vocabulary — Anthropic separated credentials from the sandbox and hardened isolation.
+
+Relevant takeaways:
+
+- **Context engineering matters more than prompt engineering** (per Taskade's summary of Anthropic production patterns).
+- **Sub-agent isolation can outperform a single-agent Opus baseline by ~90%** on internal evaluations.
+- **Governance, auth, and resource isolation are load-bearing infrastructure**, not add-ons.
+
+Sources: [akamai.com/blog/cloud/why-managed-agents-needs-distributed-infrastructure](https://www.akamai.com/blog/cloud/why-managed-agents-needs-distributed-infrastructure), [augmentcode.com/guides/anthropic-agent-sdk-what-ships-vs-what-you-build](https://www.augmentcode.com/guides/anthropic-agent-sdk-what-ships-vs-what-you-build), [taskade.com/blog/multi-agent-production](https://www.taskade.com/blog/multi-agent-production).
+
+## 3. Current agents-cli architecture (the good)
+
+From the docs and source:
+
+- **Two meanings of session**: a durable transcript (SQLite + FTS5 in `~/.agents/.history/sessions/sessions.db`) and a live identity (per-PID cache files in `~/.agents/.cache/terminals/`). See `apps/cli/docs/architecture.md` §2 and `src/lib/session/active.ts:103-243`.
+- **Cross-machine recall**: `--host` runs the peer's own `agents sessions` over SSH; `--active` fans out via `gatherRemoteActive` in `src/lib/session/remote-active.ts:62-69`. Offline degradation is a per-query file cache in `src/lib/session/remote.ts:148-199`.
+- **Cross-machine durability**: opt-in R2 + CRDT G-Set transcript sync in `src/lib/session/sync/crdt.ts:73-117` and `src/lib/session/sync/sync.ts:85-149` — single-writer prefixes, client-side AES-256-GCM, idempotent union.
+- **Remote execution**: `agents run --host` re-executes `agents run` on the target; progress via offset-tracked transcript tail; teams dispatch over SSH with DAG scheduling and sentinel files. See `apps/cli/docs/teams.md` and `src/lib/hosts/progress.ts`.
+- **Auth / identity**: SSH access == ownership; no separate identity layer. Secrets stay in OS keychain / encrypted vault. See `apps/cli/docs/specifications.md` §Secrets.
+- **Indexing**: incremental scanner with dir-ledger, FTS5 BM25 search, and incremental continuation for Claude/Codex/Kimi. See `apps/cli/docs/05-sessions.md` and `src/lib/session/discover.ts`.
+- **SSH transport**: multiplexed by default, keepalive, host-key pinning. See `apps/cli/docs/09-ssh-transport.md` and `src/lib/ssh-exec.ts`.
+
+In short, agents-cli is a **user-owned, multi-device, self-hosted, SSH-based** version of the cloud agent platforms above. The differentiator is that each person controls their own machines and there is no central broker; the gap is the shared context plane. The multi-tenant, sandboxed cloud counterpart lives in Prix Factory (`@../agents/prix/factory`), not in agents-cli.
+
+## 4. The interesting challenges
+
+| # | Challenge | Why it matters | Current solution | Breaks when |
+|---|---|---|---|---|
+| 1 | **Network partition tolerance for session recall** | Laptops sleep, tailnets flake, hosts move networks. | `--host` falls back to a stale per-query cache (`remote.ts:148-199`); R2 sync is opt-in and transcript-only. | Partition lasts longer than cache freshness; R2 not configured; you need *interactive* state, not just old transcripts. |
+| 2 | **GitHub as the shared coordination plane** | "If both partitions can still reach GitHub, agents should see each other's progress." | GitHub is used for code/PRs (teams boundary contracts), not session state or fleet coordination. | A machine can't advertise "I am working on X" except by pushing code/PRs; no lightweight progress signal. |
+| 3 | **Queryable context without embedding cost** | Not all transcript lines are equally important; embedding everything is expensive and often worse than structured extraction. | FTS5 keyword index + extracted signals (topic, todos, PR, ticket, cost). Coverage is uneven across harnesses (spec GAP-2). | Semantic/relational queries fail; non-Claude/Codex harnesses lack rich metadata; no "decisions made" or "files touched" index. |
+| 4 | **Importance-aware session ledgers** | Conversations contain noise; agents need a compact, navigable summary. | Live preview from the latest turn + static `topic`; no durable per-session summary or milestone index. | Long sessions become opaque; resuming/forking wastes context window on noise. |
+| 5 | **Live-state consistency across machines** | `--active` is computed on demand per peer; no CRDT for live status. | Parallel SSH polls via `remote-agents-json.ts`; dead/slow hosts skipped. | Partitions make remote active state unavailable; no eventual model of "who was doing what." |
+| 6 | **Auth beyond SSH reachability** | Cross-machine trust today requires a live SSH path. | Same-user SSH keys; secrets bundles resolved locally or via SSH. | GitHub- or token-based attestation would let machines trust each other through the shared GitHub plane even when SSH is partitioned. |
+| 7 | **Resource isolation / "turf war" prevention** | Multiple agents on one machine can starve each other (the 2026-06-27 incident). | Teams scheduler is count-based (`src/lib/teams/scheduler.ts`); no CPU/memory pressure capping. | An agent can trigger a search storm or fork-bomb that stalls the host; no guardrails against agents competing for rate limits. |
+
+## 5. Evaluation of current solutions
+
+### 5.1 Remote cache (`src/lib/session/remote.ts`)
+- **Works**: read-only query of a specific peer when it was recently reachable.
+- **Limits**: per-query, no structured index, no active state, no writes, no cross-peer aggregation. A partition turns the fleet view into a collection of stale snapshots.
+
+### 5.2 R2 CRDT sync (`src/lib/session/sync/`)
+- **Works**: durable, encrypted, append-only transcript backup; converges without conflict resolution.
+- **Limits**: requires R2 setup; only Claude/Codex today (opencode gap, spec GAP-4); eventual, not real-time; does not sync live state or extracted metadata; centralized object store is a single point of failure if credentials/region have issues.
+
+### 5.3 SQLite FTS5 index (`src/lib/session/db.ts`, `src/lib/session/discover.ts`)
+- **Works**: fast keyword search, deterministic, no network/LLM cost, incremental scanning.
+- **Limits**: local-only; keyword-based; no semantic or structured relationship queries; uneven metadata extraction across harnesses.
+
+### 5.4 SSH multiplexed fan-out (`src/lib/remote-agents-json.ts`, `src/lib/ssh-exec.ts`)
+- **Works**: low-latency live fleet view when online; no daemon.
+- **Limits**: all-or-nothing per reachability; no offline model; no caching of active state.
+
+## 6. Alternative / optimization directions (embedding-agnostic)
+
+### 6.1 Direction A — Structured memory graph over sessions (no embeddings required)
+Extract entities and relations from every harness incrementally: decisions, action items, files touched, tool calls, errors, plan checkpoints, model switches, ticket/PR links. Store them in a relational SQLite graph (`session_signals`) so queries like "what did we decide about auth?" or "which sessions touched `src/lib/exec.ts`?" run locally without any embedding API.
+
+- **Why it fits the user requirement**: "queryable, but you don't want to embed all of this."
+- **Why it fits the field**: Sierra's Expert Answers and Explorer do exactly this — turn conversations into structured, queryable knowledge.
+- **Cost**: parsing already happens at scan time in `src/lib/session/discover.ts`; incremental extraction is local and deterministic.
+
+### 6.2 Direction B — Git-backed fleet context plane (partition tolerance)
+Use a private GitHub repo as an append-only, content-addressed log of *session metadata only* (id, agent, topic, label, todos, PR/ticket refs, branch, machine, timestamp, cost, status snapshots). Full transcripts stay on origin machines or in R2.
+
+- **Why**: GitHub is already trusted, reachable from partitioned machines, and provides a natural CRDT-like merge.
+- **Auth**: reuse the GitHub token already used by git operations; sign machine identity into commit metadata or a sidecar file.
+- **Privacy**: metadata only, no transcript bodies, no secrets. Optionally encrypt metadata with the existing `R2_SYNC_ENC_KEY` bundle.
+- **Field parallel**: Ramp's multi-client sync to one session; Modal's shared Dicts/Queues; Anthropic's shared state management.
+
+### 6.3 Direction C — Anti-entropy session sync (P2P + GitHub fallback)
+Replace or augment the R2-centric sync with a protocol where machines exchange small manifests and lazily pull missing transcript events. Direct path = SSH; fallback path = GitHub- or R2-hosted manifests. The CRDT merge stays the same.
+
+- **Why**: reduces dependency on a single cloud object store; works during partitions if any shared rendezvous is reachable.
+
+### 6.4 Direction D — Cached remote active state with TTL
+Make `--active` degrade to a cached manifest of peer active sessions when SSH fails. Each peer publishes a small "active manifest"; other machines cache it.
+
+- **Why**: gives an eventual "who was doing what" view during partitions.
+- **Model**: treat active-state reports as a grow-only set with timestamps (CRDT-friendly, single-writer per machine).
+
+### 6.5 Direction E — Per-host resource guardrails
+Add concurrency caps, CPU/memory pressure gating, and rate-limit budgets per host so agents cannot turf-war each other into OS-coordination starvation.
+
+- **Why**: Anthropic's Mythos incident showed that agents with shared resources and goal pressure will compete; the 2026-06-27 agents-cli incident showed OS-coordination starvation is real.
+- **What changes**: per-host `max_in_flight` in `agents.yaml`; readiness probe that refuses new agents when load average is too high; budget/rate-limit sharing across teammates.
+
+## 7. Recommended phased path
+
+### Phase 1 — Structured memory graph (low risk, high value)
+- Add a `session_signals` table and per-harness extractors for all 11 session-tracked agents (`src/lib/session/types.ts:14`).
+- Query interface: `agents sessions "auth" --signal decision` or `agents sessions --touched src/lib/exec.ts`.
+- Reuse the existing incremental scan in `src/lib/session/discover.ts` so extraction is append-only and cheap.
+- This directly addresses the "queryable without embedding" need and improves every existing surface.
+
+### Phase 2 — GitHub metadata plane (partition tolerance)
+- Auto-publish per-machine session summary manifests to a private repo (opt-in).
+- Build a union fleet index from the repo when `--host` fan-out fails.
+- Keep transcripts local/R2; only lightweight metadata travels through GitHub.
+- Use the same `R2_SYNC_ENC_KEY` bundle for metadata encryption if desired.
+
+### Phase 3 — Anti-entropy + cached active state + resource guardrails
+- P2P manifest exchange over SSH with GitHub fallback.
+- Cache remote active manifests and merge them into `--active` when peers are unreachable.
+- Add per-host concurrency/pressure caps and cross-agent rate-limit budgets.
+
+## 8. Risks and open questions
+
+1. **Privacy boundary**: how much session metadata is acceptable to publish off-machine? Only fully non-sensitive fields (id, topic, todo counts), or also file paths and PR links? The recommendation is metadata-only, never transcript bodies, and opt-in encryption.
+2. **Coordination plane**: is GitHub the right default, or should the analysis also evaluate R2-only or self-hosted Git/Forgejo? GitHub is the most likely shared rendezvous for the target user, but the design should be plane-agnostic.
+3. **Identity layer**: moving to GitHub-attested machine identity is a subtle change from the current "SSH access == ownership" model. It should be additive, not a replacement.
+4. **Schema churn**: adding `session_signals` requires migrations in `src/lib/session/db.ts`. The existing migration framework (`SCHEMA_VERSION`, WAL, forward-only) handles this, but a schema addition forces a full rescan if the derivation changes.
+5. **Embedding option**: the recommendation avoids embeddings as the default, but a future optional local-embedding index (e.g., over `session_signals` summaries) can be added without contradiction.
+
+## 9. Conclusion
+
+agents-cli's distributed execution is already ahead of the field in one dimension: it gives users full ownership of the machines and transport. The next positive optimization is not to add a broker or a cloud relay, but to **build a durable, structured, shared context layer** on top of the existing transcript and SSH infrastructure.
+
+The cheapest, highest-value first step is a **structured memory graph** extracted at scan time. It makes sessions queryable without embedding cost. The second step is a **GitHub-backed metadata plane** so that progress remains visible across network partitions. Both steps reuse what already exists and keep the architecture aligned with the frontier's move toward isolated agents, structured memory, and shared context planes.
+
+---
+
+*Report generated 2026-08-02. Sources: agents-cli source/docs, Sierra/Ramp/OpenAI/Anthropic public engineering writing.*


### PR DESCRIPTION
**docs-only** — adds one committed report, no code touched, no behavior change. Audience: maintainers of agents-cli's distributed execution surfaces.

## What this is

`.agents/reports/distributed-agent-execution-architecture.md` (178 lines) — a source-grounded review of where agents-cli's distributed execution, session recall, and cross-machine coordination can be optimized. Deliberately embedding-agnostic: the target is a queryable, partition-tolerant session context layer, not a vector-DB migration. It surveys what the frontier stack (Sierra, Ramp/Modal, OpenAI, Anthropic) converged on and maps each primitive onto existing agents-cli code paths, then proposes Phase 1 (structured memory graph over sessions) and Phase 2 (GitHub-backed metadata plane).

## Why it is a PR and not a local file

The report was written into the main checkout **untracked**. That made `git status --porcelain` non-empty, and `apps/cli/scripts/release.sh:291` refuses to run on a dirty tree — the release commit is built straight from the index via `git write-tree`, so a dirty tree would smuggle unrelated changes into the release PR and the published tarball. It was blocking the stranded 1.20.83 publish. Committing it to `.agents/reports/` follows the repo convention (root `AGENTS.md`: durable + shareable reports are tracked there; scratch goes to the gitignored dirs).

## No run to attach

Pure doc addition — no flag, command, or behavior changed, so there is no runnable surface and no CHANGELOG entry. Verified only that the file is the sole change:

```
$ git show --stat 4a31d646
 .agents/reports/distributed-agent-execution-architecture.md | 178 +++++++++++++++++
 1 file changed, 178 insertions(+)
```