### PR TITLE
fix(feed): show the progress posts agents actually wrote, fleet-wide

### DIFF
--- a/apps/cli/.changelog/next/feed-updates-visibility.md
+++ b/apps/cli/.changelog/next/feed-updates-visibility.md
@@ -1,0 +1,10 @@
+- **`agents feed --filter updates` now shows the progress posts agents actually
+  wrote, across the fleet.** The view read the most recent N activity events and
+  *then* kept `status.posted`, so routine `file.edited` churn filled the whole
+  slice — a box with six real posts rendered "0 posts" (and `--json` returned one
+  of six). `readRecentActivity` gained `events` / `tier` filters that apply before
+  the limit, so the limit counts posts; the same fix restores the milestone lane
+  under `agents feed`. The updates view also fans out over SSH like the block view
+  (`-H/--host`, `--device`, `--local` to opt out), because an agent posts on
+  whichever box ran it. Source: `apps/cli/src/lib/activity.ts`,
+  `apps/cli/src/commands/feed.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -535,8 +535,18 @@ agents feed --filter updates    # only deliberate progress posts (see Status pos
 agents feed --filter all        # blocks first, then the updates view appended
 ```
 
-`--filter updates` reads the local activity timeline only (no block pipeline, no
-remote fan-out); its `--json` emits the raw `status.posted` events.
+`--filter updates` skips the block pipeline (no stall suppression, no dispatch
+policy) but keeps the same SSH fan-out the block view uses — an agent posts on
+whichever box ran it, so the fleet's posts merge into one recency-ordered list.
+`-H/--host` (alias `--device`) scopes it to named machines; `--local` (or
+`AGENTS_FEED_LOCAL=1`) keeps it to this box. Its `--json` emits the raw
+`status.posted` events.
+
+The `limit` on this view counts **posts**, not raw events: the event filter is
+pushed into `readRecentActivity` (`events` / `tier` options) rather than applied
+to an already-sliced window. Slicing first meant a busy box's routine
+`file.edited` churn filled the whole slice and the view rendered "0 posts" while
+real posts sat in the log.
 
 ### What publishes a block
 

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -18,7 +18,16 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { ensureFeedPublishHook, listAskStats, listBlocks, recordNotified, type OpenBlock } from '../lib/feed.js';
-import { ensureActivityLogHook, readRecentActivity, formatActivityLine, formatProgressUpdate, type ActivityEvent } from '../lib/activity.js';
+import {
+  ensureActivityLogHook,
+  readRecentActivity,
+  formatActivityLine,
+  formatProgressUpdate,
+  mergeActivityEvents,
+  parseActivityPayload,
+  type ActivityEvent,
+  type EnrichedActivityEvent,
+} from '../lib/activity.js';
 import { postFeedStatus } from '../lib/feed-post.js';
 import {
   enrichBlocksFromSessions,
@@ -385,20 +394,39 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
         }
       }
 
-      // Updates view: deliberate progress posts only, over the local activity
-      // timeline (blocks are decisions, not announcements). Short-circuit the
-      // whole block pipeline — no remote fan-out, no dispatch policy.
+      // Trailing lane under the block views: `--filter all` appends the same
+      // fleet-wide updates section, anything else the compact local lane.
+      const renderTrailingActivity = async (): Promise<void> => {
+        if (filter === 'all') {
+          console.log();
+          renderUpdatesView(await gatherStatusPosts({
+            limit: UPDATES_VIEW_LIMIT, hosts: opts.host, local: opts.local, includeLocal, self,
+          }));
+          return;
+        }
+        if (includeLocal) renderActivityLane();
+      };
+
+      // Updates view: deliberate progress posts only (blocks are decisions, not
+      // announcements). Short-circuits the block pipeline — no dispatch policy —
+      // but fans out like the block view, because a post lands on whichever box
+      // ran the agent.
       if (filter === 'updates') {
         for (const warning of setupWarnings) {
           console.error(chalk.yellow(`Feed hook setup warning: ${warning}`));
         }
+        const updates = await gatherStatusPosts({
+          limit: opts.json ? UPDATES_JSON_LIMIT : UPDATES_VIEW_LIMIT,
+          hosts: opts.host,
+          local: opts.local,
+          includeLocal,
+          self,
+        });
         if (opts.json) {
-          const updates = readRecentActivity({ sinceMs: Date.now() - 7 * 24 * 60 * 60 * 1000, limit: 100 })
-            .filter((e) => e.event === 'status.posted');
           console.log(JSON.stringify(updates, null, 2));
           return;
         }
-        renderUpdatesView();
+        renderUpdatesView(updates);
         return;
       }
 
@@ -520,10 +548,7 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
 
       if (blocks.length === 0) {
         console.log(chalk.gray(digest ? 'No open blocks after stall suppression.' : 'No open blocks.'));
-        if (includeLocal) {
-          if (filter === 'all') { console.log(); renderUpdatesView(); }
-          else renderActivityLane();
-        }
+        await renderTrailingActivity();
         return;
       }
 
@@ -549,10 +574,7 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
         return br - ar;
       });
       for (const g of groups) renderOutcomeGroup(g, self);
-      if (includeLocal) {
-        if (filter === 'all') { console.log(); renderUpdatesView(); }
-        else renderActivityLane();
-      }
+      await renderTrailingActivity();
     });
 }
 
@@ -580,16 +602,67 @@ function renderActivityEntry(ev: ActivityEvent): void {
   }
 }
 
+/** How far back the updates view looks for deliberate progress posts. */
+const UPDATES_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+/** Posts kept per machine in the rendered view / the `--json` payload. */
+const UPDATES_VIEW_LIMIT = 30;
+const UPDATES_JSON_LIMIT = 100;
+
+/**
+ * The most recent `limit` deliberate progress posts on THIS machine, newest
+ * first. The event filter is pushed into the reader so `limit` counts posts —
+ * slicing first and filtering after returned an empty view on a busy box, where
+ * routine `file.edited` hook events fill the whole slice.
+ */
+function readStatusPosts(limit: number): ActivityEvent[] {
+  return readRecentActivity({
+    sinceMs: Date.now() - UPDATES_WINDOW_MS,
+    limit,
+    events: ['status.posted'],
+  });
+}
+
+/**
+ * Progress posts across the fleet, newest first. An agent posts on whichever
+ * box it runs on, so a local-only read shows the operator a fraction of what
+ * the fleet reported. Peers are dialed with the same SSH fan-out the block view
+ * uses; `--local` (or the no-fanout env guard on a peer) keeps it to this box.
+ */
+async function gatherStatusPosts(opts: {
+  limit: number;
+  hosts?: string[];
+  local?: boolean;
+  includeLocal: boolean;
+  self: string;
+}): Promise<EnrichedActivityEvent[]> {
+  const local: EnrichedActivityEvent[] = opts.includeLocal ? readStatusPosts(opts.limit) : [];
+  const forceLocal = opts.local === true || process.env[FEED_NO_FANOUT_ENV] === '1';
+  if (forceLocal) return local;
+  const remoteHosts = opts.hosts?.length ? remoteFeedHostsToDial(opts.hosts, opts.self) : undefined;
+  if (opts.hosts?.length && (!remoteHosts || remoteHosts.length === 0)) return local;
+  const remote = await gatherRemoteAgentsJson({
+    args: ['feed', '--filter', 'updates', '--json'],
+    noFanoutEnv: FEED_NO_FANOUT_ENV,
+    hosts: remoteHosts,
+    parse: parseActivityPayload,
+  });
+  return mergeActivityEvents(local, remote.items).slice(0, opts.limit);
+}
+
 /**
  * Render the **Updates** view: deliberate progress posts only (`status.posted`),
  * recency-ordered, with rich identity chips. Pure `file.edited` / git-hook noise
  * is excluded so operators see announcements, not tool churn.
  */
-function renderUpdatesView(limit = 30): void {
-  const updates = readRecentActivity({ sinceMs: Date.now() - 7 * 24 * 60 * 60 * 1000, limit })
-    .filter((e) => e.event === 'status.posted');
+function renderUpdatesView(updates: ActivityEvent[]): void {
+  const hosts = new Set(updates.map((e) => e.host).filter(Boolean));
   console.log(
-    masthead({ title: 'updates', accent: 'cyan', host: machineId(), right: `${updates.length} post${updates.length === 1 ? '' : 's'}` }),
+    masthead({
+      title: 'updates',
+      accent: 'cyan',
+      host: hosts.size > 1 ? `${hosts.size} machines` : (updates[0]?.host ?? machineId()),
+      right: `${updates.length} post${updates.length === 1 ? '' : 's'}`,
+    }),
   );
   console.log();
   if (updates.length === 0) {
@@ -609,8 +682,11 @@ function renderUpdatesView(limit = 30): void {
  * when empty.
  */
 function renderActivityLane(limit = 6): void {
-  const events = readRecentActivity({ sinceMs: Date.now() - 24 * 60 * 60 * 1000, limit })
-    .filter((e) => e.tier === 'milestone');
+  const events = readRecentActivity({
+    sinceMs: Date.now() - 24 * 60 * 60 * 1000,
+    limit,
+    tier: 'milestone',
+  });
   if (events.length === 0) return;
   console.log(chalk.bold('\n  recent activity'));
   for (const ev of events) renderActivityEntry(ev);

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -85,6 +85,28 @@ describe('activity log store (TS)', () => {
     expect(readRecentActivity({ root: dir, limit: 1 })).toHaveLength(1);
   });
 
+  it('applies the event filter before the limit so rare posts survive routine churn', () => {
+    const dir = tmpActivityDir();
+    // A busy box: 40 routine edits newer than the one deliberate progress post.
+    appendActivityEvent(
+      { ts: '2026-07-29T09:00:00.000Z', event: 'status.posted', sessionId: 's1', mailboxId: 's1', host: 'h', runtime: 'headless', detail: 'PR #1690 open; watching CI' },
+      dir,
+    );
+    for (let i = 0; i < 40; i += 1) {
+      appendActivityEvent(
+        { ts: `2026-07-29T10:${String(i).padStart(2, '0')}:00.000Z`, event: 'file.edited', sessionId: 's2', mailboxId: 's2', host: 'h', runtime: 'headless' },
+        dir,
+      );
+    }
+    // Slicing first and filtering after is what returned an empty updates view.
+    expect(readRecentActivity({ root: dir, limit: 30 }).filter((e) => e.event === 'status.posted')).toHaveLength(0);
+    // Pushing the filter into the reader makes `limit` count posts, not churn.
+    const posts = readRecentActivity({ root: dir, limit: 30, events: ['status.posted'] });
+    expect(posts.map((e) => e.detail)).toEqual(['PR #1690 open; watching CI']);
+    // Same defect, same fix for the milestone lane under the block view.
+    expect(readRecentActivity({ root: dir, limit: 6, tier: 'milestone' }).map((e) => e.event)).toEqual(['status.posted']);
+  });
+
   it('skips corrupt / partial lines without throwing', () => {
     const dir = tmpActivityDir();
     fs.writeFileSync(path.join(dir, 's1.jsonl'), '{not json\n{"ts":"2026-07-29T10:00:00.000Z","event":"pr.opened","sessionId":"s1"}\n\n');

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -288,6 +288,14 @@ export interface RecentActivityOptions {
   root?: string;
   /** Per-session tail budget in bytes. */
   maxBytesPerSession?: number;
+  /**
+   * Only include these event names. Applied BEFORE `limit`, so asking for a
+   * rare event (a deliberate `status.posted`) returns that many of it instead
+   * of however many survive a slice dominated by routine `file.edited` churn.
+   */
+  events?: string[];
+  /** Only include events in these tiers. Applied BEFORE `limit`, as `events` is. */
+  tier?: ActivityTier;
 }
 
 /**
@@ -297,9 +305,12 @@ export interface RecentActivityOptions {
 export function readRecentActivity(opts: RecentActivityOptions = {}): ActivityEvent[] {
   const dir = opts.root ?? getActivityDir();
   const sinceMs = opts.sinceMs ?? 0;
+  const wanted = opts.events && opts.events.length > 0 ? new Set(opts.events) : null;
   const all: ActivityEvent[] = [];
   for (const sessionId of listActivitySessions(dir)) {
     for (const ev of readSessionActivity(sessionId, dir, opts.maxBytesPerSession)) {
+      if (wanted && !wanted.has(ev.event)) continue;
+      if (opts.tier && ev.tier !== opts.tier) continue;
       const t = Date.parse(ev.ts);
       if (Number.isFinite(t) && t >= sinceMs) all.push(ev);
     }


### PR DESCRIPTION
**Bug fix — terminal CLI surface (no UI).** `agents feed --filter updates` was hiding
the progress posts agents had already written, and only ever read the local box.

## What was wrong

Two call sites read the activity timeline and filtered *after* slicing:

- `renderUpdatesView` — `readRecentActivity({ limit: 30 }).filter(e => e.event === 'status.posted')`
- the `--json` branch — same shape with `limit: 100`
- `renderActivityLane` — same defect against `tier === 'milestone'`

On a box that edits files (every box), routine `file.edited` hook events fill the
whole slice, so the filter has nothing left to keep. `yosemite-s1` has **6** real
`status.posted` events from today and the view printed **0 posts**; `--json`
returned 1 of 6. A peer on 1.20.82 returns a bare `[]`:

```
$ agents ssh yosemite-s0 'AGENTS_FEED_LOCAL=1 agents feed --filter updates --json'
[]
```

Separately, the updates view deliberately short-circuited the SSH fan-out, so
posts made on other machines never aggregated — and an agent posts on whichever
box ran it.

## What changed

- `readRecentActivity` takes `events` / `tier` filters that apply **before** `limit`,
  so the limit counts what the caller asked for. Both feed views and the milestone
  lane now go through it — the fix is at the reader, not duplicated per call site.
- `--filter updates` fans out over SSH like the block view: `-H/--host`, `--device`,
  `--local` (or `AGENTS_FEED_LOCAL=1`) to stay on one box. `--filter all` appends the
  same fleet-wide section.
- The masthead names the machine when posts come from one box, `N machines` when merged.

## Run result — same command, before and after

Installed 1.20.82:

```
$ agents feed --filter updates --local
⌁ updates · yosemite-s1                                                    0 posts

  No progress updates yet. Agents post them with `agents feed post "…"`.
```

This branch, same machine, same log:

```
$ AGENTS_FEED_LOCAL=1 node dist/index.js feed --filter updates
⌁ updates · yosemite-s1                                                    6 posts

  ▸ update · 40m ago
    claude · c854ae60 · yosemite-s1 · agents-cli
    "Factory status-bar remote fix: diagnosed (3 bugs) + built + PR #1687 opened; watching CI, will merge on green"
    ↳ ag focus c854ae60 · ag sessions c854ae60

  ▸ update · 3h ago
    claude · 34a71d3a · yosemite-s1
    "agents-cli release jam diagnosed: 4 attempts on 08-02 shipped 0 versions, cause is no mutex in release.sh + a rule telling every agent to release. Lease PR #1662 green, policy+train PR .agents#173 open."
    ↳ ag focus 34a71d3a · ag sessions 34a71d3a

  ▸ update · 3h ago
    codex · 019fc0b5 · yosemite-s1
    "agents-cli release PR #1642 now uses Vitest threads on Windows; watching the second release matrix run"
    ↳ ag focus 019fc0b5 · ag sessions 019fc0b5

  … 3 more
```

## Tests

`src/lib/activity.test.ts` gains a case that writes one `status.posted` under 40
newer `file.edited` events into a real activity dir, asserts the old
slice-then-filter shape returns 0, and that the new `events` / `tier` filters
return the post. `activity.test.ts` 56 passed, `feed.test.ts` + `feed-post.test.ts`
+ `commands/activity.test.ts` 74 passed.

Pre-existing on this Linux box and unrelated to this diff (they fail identically on
an untouched `main` checkout — no keychain, no codex binary): `exec.test.ts`,
`session/sync/config.test.ts`, `postinstall.test.ts`, `models.test.ts`.

## Follow-up in this series

Fleet aggregation returns peer data once peers carry this version — a peer still on
1.20.82 answers `[]` for the reason this PR fixes. Two more PRs follow: durable
menu-bar dispatch completion notifications, and broadcasting `feed post` to Linear
and the user's message channel.
