### PR TITLE
feat(factory): remove deprecated Gemini launch commands (RUSH-2089)

### DIFF
--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents Extension
 
-VS Code extension for multi-agent coding. Spawns AI terminals (Claude, Codex, Gemini, Cursor, OpenCode) as editor tabs with keyboard shortcuts, and dispatches work to Rush Cloud.
+VS Code extension for multi-agent coding. Spawns AI terminals (Claude, Codex, Antigravity, Cursor, OpenCode) as editor tabs with keyboard shortcuts, and dispatches work to Rush Cloud.
 
 This file is a **map**, not the territory. Keep it a short paragraph per area plus pointers. Read the actual code for current details.
 

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.303] - 2026-08-02
+
+- **Remove deprecated Gemini launch commands from the Factory palette (RUSH-2089).** Gemini is no longer supported; Antigravity is its replacement. The command palette no longer shows `Agents: New Gemini`, `Agents: New Gemini (Pick Host)`, `Agents: New Gemini (Auto)`, or `Agents: Setup Gemini`. Existing Gemini session parsing and transcript watching remain in place so old sessions are still readable. Source: `apps/factory/src/vscode/extension.ts`, `apps/factory/package.json`.
+
 ## [0.9.302] - 2026-08-02
 
 - **Every built-in harness now has a fast `New <Harness> (Auto)` launch command.** Auto launch ranks a persisted warm cache by successful recent device history plus cached load, memory, and running-agent count; it excludes offline, SSH-unreachable, signed-out, and throttled devices without performing SSH on the command path. Every launch updates per-device history, a cold/no-match cache warns and launches locally, and Droid explains that account health is unavailable before opening the host picker. Auto-supported harnesses launch with balanced account rotation. Source: `apps/factory/src/core/launchHistory.ts`, `apps/factory/src/vscode/extension.ts`, `apps/factory/package.json`.

--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -1,8 +1,8 @@
 # Agents
 
-Orchestrate Claude, Codex, Gemini, and Cursor in parallel — from one IDE. Open source. Free.
+Orchestrate Claude, Codex, Antigravity, and Cursor in parallel — from one IDE. Open source. Free.
 
-Turn your editor into a command center for orchestrating Claude, Codex, Gemini, and Cursor in parallel. Each agent runs as a full-screen editor tab. Each agent can spawn sub-agents. You orchestrate — approving plans, monitoring execution, shipping faster.
+Turn your editor into a command center for orchestrating Claude, Codex, Antigravity, and Cursor in parallel. Each agent runs as a full-screen editor tab. Each agent can spawn sub-agents. You orchestrate — approving plans, monitoring execution, shipping faster.
 
 ## Why an IAE?
 
@@ -57,7 +57,7 @@ curl -fsSL https://raw.githubusercontent.com/phnx-labs/agents-cli/main/scripts/i
 
 ### Agent Terminals
 
-Spawn any agent as a full-screen editor tab. Built-in support for Claude Code, Codex, Gemini, OpenCode, and Cursor. Add custom agents through settings.
+Spawn any agent as a full-screen editor tab. Built-in support for Claude Code, Codex, Antigravity, OpenCode, and Cursor. Add custom agents through settings.
 
 ### Session Persistence
 
@@ -105,7 +105,7 @@ Generate commit messages from staged changes with `Cmd+Shift+G`. Learns from you
 ## Requirements
 
 - VS Code or Cursor
-- Agent CLIs installed (`claude`, `codex`, `gemini`, `cursor-agent`, `opencode`)
+- Agent CLIs installed (`claude`, `codex`, `antigravity`, `cursor-agent`, `opencode`)
 - OpenAI API key (optional, for commit generation and the Foreman voice orb)
 - ffmpeg (optional, for the Foreman voice orb: `brew install ffmpeg`)
 

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -2,8 +2,8 @@
   "name": "swarm-ext",
   "displayName": "Agents",
   "publisher": "swarmify",
-  "description": "Run Claude, Codex, Gemini, Cursor, and other coding agents from one IDE workspace.",
-  "version": "0.9.302",
+  "description": "Run Claude, Codex, Antigravity, Cursor, and other coding agents from one IDE workspace.",
+  "version": "0.9.303",
   "license": "MIT",
   "author": "Muqsit Nawaz <dev@muqsitnawaz.com>",
   "icon": "assets/agents.png",
@@ -147,14 +147,6 @@
         }
       },
       {
-        "command": "agents.newGemini",
-        "title": "Agents: New Gemini",
-        "icon": {
-          "light": "assets/gemini.png",
-          "dark": "assets/gemini.png"
-        }
-      },
-      {
         "command": "agents.newAntigravity",
         "title": "Agents: New Antigravity",
         "icon": {
@@ -277,10 +269,6 @@
       {
         "command": "agents.setupCodex",
         "title": "Agents: Setup Codex"
-      },
-      {
-        "command": "agents.setupGemini",
-        "title": "Agents: Setup Gemini"
       },
       {
         "command": "agents.enableNotifications",
@@ -445,18 +433,6 @@
       {
         "command": "agents.newCodexAuto",
         "title": "Agents: New Codex (Auto)"
-      },
-      {
-        "command": "agents.newGeminiPickHost",
-        "title": "Agents: New Gemini (Pick Host)",
-        "icon": {
-          "light": "assets/gemini.png",
-          "dark": "assets/gemini.png"
-        }
-      },
-      {
-        "command": "agents.newGeminiAuto",
-        "title": "Agents: New Gemini (Auto)"
       },
       {
         "command": "agents.newOpenCodePickHost",
@@ -696,11 +672,6 @@
       ],
       "commandPalette": [
         {
-          "command": "agents.newGemini",
-          "when": "true",
-          "group": "navigation@2"
-        },
-        {
           "command": "agents.newAntigravity",
           "when": "true",
           "group": "navigation@2"
@@ -843,11 +814,6 @@
         "command": "agents.prompts",
         "key": "ctrl+shift+'",
         "mac": "cmd+shift+'"
-      },
-      {
-        "command": "agents.newGemini",
-        "key": "ctrl+shift+m",
-        "mac": "cmd+shift+m"
       },
       {
         "command": "agents.newCursor",

--- a/apps/factory/src/core/agents.test.ts
+++ b/apps/factory/src/core/agents.test.ts
@@ -25,6 +25,8 @@ describe('BUILT_IN_AGENTS', () => {
     expect(extensionSource).toContain('`${def.commandId}Auto`');
     for (const agent of BUILT_IN_AGENTS) {
       if (agent.key === 'shell') continue;
+      // Gemini is deprecated and no longer gets launch commands in the palette.
+      if (agent.key === 'gemini') continue;
       expect(contributed.has(`${agent.commandId}Auto`)).toBe(true);
     }
   });

--- a/apps/factory/src/core/agents.test.ts
+++ b/apps/factory/src/core/agents.test.ts
@@ -31,6 +31,17 @@ describe('BUILT_IN_AGENTS', () => {
     }
   });
 
+  test('deprecated Gemini launch and setup commands are not contributed', () => {
+    const packageJson = JSON.parse(readFileSync(resolve(import.meta.dir, '../../package.json'), 'utf8'));
+    const contributed = new Set(packageJson.contributes.commands.map((entry: { command: string }) => entry.command));
+    const extensionSource = readFileSync(resolve(import.meta.dir, '../vscode/extension.ts'), 'utf8');
+    expect(contributed.has('agents.newGemini')).toBe(false);
+    expect(contributed.has('agents.newGeminiPickHost')).toBe(false);
+    expect(contributed.has('agents.newGeminiAuto')).toBe(false);
+    expect(contributed.has('agents.setupGemini')).toBe(false);
+    expect(extensionSource).not.toContain("agents.setupGemini");
+  });
+
   test('every non-shell agent is a CLI agent and launches its CLI binary', () => {
     for (const agent of BUILT_IN_AGENTS) {
       if (agent.key === 'shell') continue;

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -1555,10 +1555,6 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('agents.setupGemini', () => swarm.setupSwarmIntegrationForAgent('gemini', context))
-  );
-
-  context.subscriptions.push(
     vscode.commands.registerCommand('agents.enableNotifications', () => notifications.enableNotifications(context))
   );
 
@@ -1723,6 +1719,11 @@ export async function activate(context: vscode.ExtensionContext) {
           if (agentConfig) openSingleAgent(context, agentConfig);
         })
       );
+      continue;
+    }
+    if (def.key === 'gemini') {
+      // Gemini is deprecated; Antigravity is the replacement. Don't register
+      // launch commands for it, but keep session parsing/watching intact.
       continue;
     }
     context.subscriptions.push(


### PR DESCRIPTION
Gemini is fully deprecated; Antigravity is its replacement.

Changes:
- Skip gemini when registering built-in launch commands in `extension.ts`.
- Remove `agents.newGemini`, `agents.newGeminiPickHost`, `agents.newGeminiAuto`, and `agents.setupGemini` from `package.json`.
- Remove the Gemini command-palette menu entry and keybinding.
- Update the extension description, `README.md`, and `AGENTS.md` to mention Antigravity instead of Gemini.
- Add regression test in `agents.test.ts` verifying deprecated Gemini launch/setup commands are not contributed.

Existing Gemini session parsing and transcript watching remain intact so old sessions are still readable.

## Verification

- TypeScript compile passed: `bun run compile:ext`
- `src/core/agents.test.ts` passes: 59 pass, 0 fail
- `package.json` scan confirms 0 Gemini launch/setup commands remaining (`agents.newGemini`, `agents.newGeminiPickHost`, `agents.newGeminiAuto`, `agents.setupGemini` all absent)
- CI green across all shards

Proof log: `/tmp/factory-remove-gemini-proof.txt`
