### PR TITLE
feat(run): --notify, so a dispatched run reports back on its own

### DIFF
--- a/apps/cli/.changelog/next/run-notify-on-finish.md
+++ b/apps/cli/.changelog/next/run-notify-on-finish.md
@@ -1,0 +1,13 @@
+- **`agents run --notify` posts a desktop notification when a headless run
+  finishes, and menu-bar quick dispatch now uses it.** The dispatch panel used to
+  post its "finished"/"failed" notice from the MenubarHelper's own
+  process-termination callback, so a helper that restarted mid-run — an upgrade
+  replacing the bundle, a crash — took the callback with it while the run carried
+  on reparented to launchd, and the dispatch could never report back. The run
+  process owns the notice now: armed on its own `exit`, so it covers local,
+  `--host` and `--lease` dispatch alike and survives anything that happens to the
+  launcher. The helper's click actions also accept `url:<https…>` so a completion
+  notification can open the PR or ticket the run produced. Source:
+  `apps/cli/src/lib/run-notify.ts`, `apps/cli/src/commands/exec.ts`,
+  `apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift`,
+  `apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift`.

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -68,8 +68,17 @@ agent for **File Ticket** or one or more agents for **Fix**.
   issue description — screenshot paths never pass through an LLM-authored shell
   string.
 - **Fix** fans out to every selected agent with `agents run <agent> --mode auto
-  --name quick-<agent>-<timestamp>`, so the resulting sessions appear in normal
-  `agents sessions` and menu-bar surfaces instead of as opaque background work.
+  --balanced --notify --name <slug-of-your-note>`, so the resulting sessions
+  appear in normal `agents sessions` and menu-bar surfaces instead of as opaque
+  background work.
+
+`--notify` is what makes a dispatch report back. The run is launched **detached**
+and posts its own "finished"/"failed" notification when it ends (see
+[Notifications](#notifications)). Earlier the helper monitored the child and
+posted from the process-termination callback — which lived in the helper, so a
+helper that restarted mid-run (an upgrade replacing the bundle, a crash) took the
+callback with it. The run carried on, reparented to launchd, and could never
+report back. Nothing about the menu bar's lifetime affects the notice now.
 
 Set `AGENTS_QUICK_DISPATCH_ROSTER=claude,codex` in the helper environment to
 filter which agents appear in the picker, and
@@ -205,9 +214,9 @@ The helper is a launchd user service (`com.phnx-labs.agents-menubar`,
 
 ## Notifications
 
-The helper doubles as the daemon's branded desktop-notification channel
-(RUSH-2030). The daemon fires a notification by spawning the installed bundle in
-a one-shot mode:
+The helper doubles as the branded desktop-notification channel for the daemon
+(RUSH-2030) and for any `agents run --notify`. The caller fires a notification by
+spawning the installed bundle in a one-shot mode:
 
 ```bash
 MenubarHelper --notify --title T --body B [--subtitle S] [--action A]
@@ -218,11 +227,23 @@ agents-cli helper and shows its `AppIcon` (the agents-cli mark) instead of the
 generic osascript icon. The one-shot delivers via `NSUserNotificationCenter`,
 briefly spins the runloop so delivery flushes, then exits — it never starts the
 status-bar UI. The persistent menu-bar instance registers the click delegate at
-launch (`Notifier.wireClickHandler`), so clicking a daemon notification runs its
-`--action`: `open:<path>` opens a run report/log, `routines:list` opens the runs
-folder. The Node side lives in `src/lib/menubar/notify-desktop.ts` (routing) and
-`src/lib/routine-notify.ts` (routine start/finish content + anti-spam
-threshold); see [routines.md](03-routines.md#desktop-notifications).
+launch (`Notifier.wireClickHandler`), so clicking a notification runs its
+`--action`: `open:<path>` opens a run report/log, `url:<https…>` opens a web
+target (the PR or ticket a finished run produced — `http`/`https` only, so a
+notification argument can never become an open-anything primitive), and
+`routines:list` opens the runs folder. The Node side lives in
+`src/lib/menubar/notify-desktop.ts` (routing), `src/lib/routine-notify.ts`
+(routine start/finish content + anti-spam threshold; see
+[routines.md](03-routines.md#desktop-notifications)), and `src/lib/run-notify.ts`
+(the `agents run --notify` finish notice).
+
+**A run notifies for itself.** `agents run --notify` arms the finish notification
+on the run process's own `exit`, so it covers every dispatch path — local spawn,
+`--host`, `--lease`, the error path — and, more importantly, does not depend on
+whatever launched the run still being alive. That is the whole point: the menu
+bar's quick dispatch used to post from its own process-termination callback and
+lost it whenever the helper restarted. A run killed with SIGKILL never reaches an
+exit handler and so never notifies; that is the documented limit.
 
 **Bounded lifetime (no pile-up).** A one-shot posts and exits in well under a
 second, but a stalled delivery — a locked screen, a WindowServer/XPC hiccup —

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -392,6 +392,13 @@ enum AgentsCLI {
         }
     }
 
+    // Fire-and-forget: the run is launched detached and posts its OWN completion
+    // notification via `agents run --notify`. It used to be monitored here, with
+    // the finish notice in the process-termination callback — but that callback
+    // lives in THIS process, so a helper that restarted (an upgrade replacing the
+    // bundle, a crash) took it with it while the run carried on reparented to
+    // launchd. A dispatch could then never report back. The run process owns the
+    // notice now, so nothing that happens to the menu bar can lose it.
     static func dispatchQuickFix(note: String, screenshotPaths: [String], agents: [String],
                                  cwd: String? = nil, device: String? = nil) {
         let selected = agents.isEmpty ? ["claude"] : agents
@@ -400,12 +407,8 @@ enum AgentsCLI {
         Notifier.post(title: "Dispatching \(selected.count) agent\(selected.count == 1 ? "" : "s")…",
                       body: shortenForNotice(note))
         for agent in selected {
-            runMonitored(argv(quickFixRunArgs(agent: agent, prompt: prompt, name: name,
-                                              cwd: cwd, device: device))) { _, ok in
-                let label = LocalState.agentLabel(agent)
-                Notifier.post(title: ok ? "\(label) finished" : "\(label) failed",
-                              body: shortenForNotice(note))
-            }
+            runDetached(argv(quickFixRunArgs(agent: agent, prompt: prompt, name: name,
+                                             cwd: cwd, device: device)))
         }
     }
 
@@ -475,10 +478,11 @@ enum AgentsCLI {
     // (auto load-balance across signed-in versions with headroom, skipping any that
     // are rate-limited); an explicit --cwd scopes the agent to the chosen repo (never
     // the home dir); an explicit --device offloads onto the chosen box (nil = this
-    // Mac / affinity-auto is handled by the caller passing "auto").
+    // Mac / affinity-auto is handled by the caller passing "auto"). `--notify` makes
+    // the run itself post the completion notification, so it outlives this helper.
     static func quickFixRunArgs(agent: String, prompt: String, name: String,
                                 cwd: String? = nil, device: String? = nil) -> [String] {
-        var args = ["run", agent, prompt, "--mode", "auto", "--balanced", "--name", name]
+        var args = ["run", agent, prompt, "--mode", "auto", "--balanced", "--notify", "--name", name]
         if let cwd, !cwd.isEmpty {
             args.append("--cwd")
             args.append(cwd)

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -188,12 +188,14 @@ enum IssueSelfTest {
         check("empty note falls back to a timestamped task name", emptyName == "task-1234", detail: emptyName)
 
         let args = AgentsCLI.quickFixRunArgs(agent: "codex", prompt: "<prompt>", name: "my-task")
-        check("run is balanced + autonomous",
-              args == ["run", "codex", "<prompt>", "--mode", "auto", "--balanced", "--name", "my-task"],
+        check("run is balanced + autonomous + self-notifying",
+              args == ["run", "codex", "<prompt>", "--mode", "auto", "--balanced", "--notify", "--name", "my-task"],
               detail: args.joined(separator: " "))
+        check("dispatch carries --notify so completion survives a helper restart",
+              args.contains("--notify"))
         let scoped = AgentsCLI.quickFixRunArgs(agent: "codex", prompt: "<p>", name: "n", cwd: "/repo", device: "zion")
         check("run scopes to cwd + device when given",
-              scoped == ["run", "codex", "<p>", "--mode", "auto", "--balanced", "--name", "n", "--cwd", "/repo", "--device", "zion"],
+              scoped == ["run", "codex", "<p>", "--mode", "auto", "--balanced", "--notify", "--name", "n", "--cwd", "/repo", "--device", "zion"],
               detail: scoped.joined(separator: " "))
     }
 

--- a/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
@@ -649,12 +649,22 @@ enum Notifier {
 
     // Map the daemon action deep-link to a URL the click delegate opens:
     //   open:<path>   -> the run report/log file (opens in the default app)
+    //   url:<https…>  -> a web target (the PR or ticket a finished run produced)
     //   routines:list -> the runs-history folder (opens in Finder)
     // Any other/absent action yields no click target.
     private static func clickURL(for action: String?) -> String? {
         guard let action else { return nil }
         if action.hasPrefix("open:") {
             return URL(fileURLWithPath: String(action.dropFirst("open:".count))).absoluteString
+        }
+        if action.hasPrefix("url:") {
+            // Only web schemes: the click handler hands this straight to
+            // NSWorkspace, so a `file:`/custom scheme here would be an arbitrary
+            // open-anything primitive driven by a notification argument.
+            let raw = String(action.dropFirst("url:".count))
+            guard let url = URL(string: raw), let scheme = url.scheme?.lowercased(),
+                  scheme == "https" || scheme == "http" else { return nil }
+            return url.absoluteString
         }
         if action == "routines:list" {
             return URL(fileURLWithPath: "\(NSHomeDirectory())/.agents/.history/runs").absoluteString

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -54,6 +54,8 @@ interface ExecCommandActionOptions {
   sessionId?: string;
   /** --name <slug>: durable launch handle, resolvable via `agents sessions <name>`. */
   name?: string;
+  /** --notify: post a desktop notification when a headless run finishes. */
+  notify?: boolean;
   verbose?: boolean;
   raw?: boolean;
   /** `--no-tmux` → commander sets this false (default true) to bypass the tmux wrapper. */
@@ -544,6 +546,7 @@ export function registerRunCommand(program: Command): void {
     .option('--resume [id]', 'Resume a previous conversation. Accepts a full or partial session id (prefix-matched against the index); omit the id to pick from recent sessions interactively. Resumes under the version that started the session. claude/codex resume natively; other agents replay via a /continue first message. Pair with a prompt to continue headlessly.')
     .option('--session-id <id>', 'Force a NEW conversation to use this exact session UUID (Claude only). This CREATES a session — to resume an existing one, use --resume.')
     .option('--name <slug>', 'Name the run — seeds the session label so it shows up as `<name>` in `agents sessions` and resolves by it (and `agents hosts logs <name>` for --host runs) instead of an opaque id. An agent-generated title later refines the label; your name shows until then. Optional.')
+    .option('--notify', 'Post a desktop notification when a headless run finishes. Fired by this process on exit, so it survives whatever launched the run (the menu bar dispatching it, a terminal you closed).')
     .option('--verbose', 'Show detailed execution logs')
     .option('--raw', 'Interactive runs on macOS/Linux launch inside a shared tmux session (for %pane addressing + re-attach). Pass --raw to spawn the agent directly instead. Also disabled by AGENTS_NO_TMUX=1.')
     .option('--no-tmux', 'Spawn the agent directly instead of wrapping it in the shared tmux session. Same effect as --raw / AGENTS_NO_TMUX=1. Use this to see the agent\'s full startup output when a launch is failing.')
@@ -729,6 +732,21 @@ export function registerRunCommand(program: Command): void {
         // The token commander assigned to [prompt] came from behind `--` — it is
         // a native flag, not a prompt. Run interactively.
         prompt = undefined;
+      }
+
+      // --notify: post a desktop notification when this run finishes. Armed on
+      // process exit so it covers EVERY dispatch path below (local, --host,
+      // --lease, the error path) instead of one branch. Only for headless runs
+      // — an interactive run ends in front of the person who started it.
+      if (options.notify && prompt !== undefined) {
+        const { armRunFinishNotification } = await import('../lib/run-notify.js');
+        armRunFinishNotification({
+          agent: agentSpec,
+          name: options.name,
+          prompt,
+          cwd: options.cwd ?? process.cwd(),
+          host: options.host,
+        });
       }
 
       // A trailing @ is an explicit request to choose one installed account.

--- a/apps/cli/src/lib/hosts/remote-cmd.ts
+++ b/apps/cli/src/lib/hosts/remote-cmd.ts
@@ -139,6 +139,11 @@ export const RUN_OPTION_FORWARDING: Record<string, RunOptionForwarding> = {
   tailscale: 'local-only', // --tailscale/--no-tailscale gate the lease net mode; never forwarded
   copyCreds: 'local-only', // copies creds TO the host before dispatch — local concern only
   authCheck: 'local-only', // --no-auth-check gates the local interactive login preflight; --host runs skip that preflight entirely
+  // The notification must land on the box the PERSON is at — the one that
+  // dispatched — not on a headless worker with no desktop to post to. The local
+  // process follows the remote run to completion, so its exit handler fires at
+  // the right moment anyway.
+  notify: 'local-only',
   // Deprecated alias for --device auto; resolved on the launching box before SSH.
   smart: 'local-only',
 };

--- a/apps/cli/src/lib/run-notify.test.ts
+++ b/apps/cli/src/lib/run-notify.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { buildRunFinishNotification } from './run-notify.js';
+import { buildMenubarNotifyArgs } from './menubar/notify-desktop.js';
+
+describe('run finish notification', () => {
+  it('names the run by its --name slug and reports success', () => {
+    const n = buildRunFinishNotification(
+      {
+        agent: 'claude',
+        name: 'it-seems-like-the-to',
+        prompt: 'Fix the Kimi to-do parsing in the session preview',
+        cwd: '/Users/muqsit/src/github.com/muqsitnawaz/agents-cli',
+      },
+      0,
+    );
+    expect(n.title).toBe('it-seems-like-the-to finished');
+    expect(n.body).toBe('Fix the Kimi to-do parsing in the session preview');
+    expect(n.subtitle).toBe('agents-cli');
+  });
+
+  it('reports a non-zero exit as failed and falls back to the agent name', () => {
+    const n = buildRunFinishNotification({ agent: 'codex', prompt: 'ship it' }, 1);
+    expect(n.title).toBe('codex failed');
+    expect(n.body).toBe('ship it');
+    expect(n.subtitle).toBeUndefined();
+  });
+
+  it('names the box for an off-box dispatch', () => {
+    const n = buildRunFinishNotification(
+      { agent: 'claude', prompt: 'p', cwd: '/repos/agents-cli', host: 'yosemite-s0' },
+      0,
+    );
+    expect(n.subtitle).toBe('agents-cli · yosemite-s0');
+  });
+
+  it('collapses a multi-line prompt and caps the body', () => {
+    const n = buildRunFinishNotification(
+      { agent: 'claude', prompt: `line one\n  line two\n\n${'x'.repeat(300)}` },
+      0,
+    );
+    expect(n.body).not.toContain('\n');
+    expect(n.body.length).toBeLessThanOrEqual(120);
+    expect(n.body.endsWith('…')).toBe(true);
+  });
+
+  it('carries a clickable URL through to the helper argv', () => {
+    const n = buildRunFinishNotification(
+      { agent: 'claude', name: 'kimi-todo', prompt: 'p', url: 'https://github.com/phnx-labs/agents-cli/pull/1690' },
+      0,
+    );
+    expect(n.action).toBe('url:https://github.com/phnx-labs/agents-cli/pull/1690');
+    expect(buildMenubarNotifyArgs(n)).toEqual([
+      '--notify',
+      '--title', 'kimi-todo finished',
+      '--body', 'p',
+      '--action', 'url:https://github.com/phnx-labs/agents-cli/pull/1690',
+    ]);
+  });
+});

--- a/apps/cli/src/lib/run-notify.ts
+++ b/apps/cli/src/lib/run-notify.ts
@@ -1,0 +1,74 @@
+/**
+ * Desktop notification when a headless `agents run` finishes (`--notify`).
+ *
+ * The notifying process is the one that OWNS the run. That is the whole point:
+ * the menu bar's quick dispatch used to post its completion notice from the
+ * dispatching MenubarHelper's process-termination callback, so a helper that
+ * restarted (an upgrade, a crash) took the callback with it — the run kept
+ * going, reparented to launchd, and no notification could ever fire. Posting
+ * from the run process instead means the notice survives anything that happens
+ * to the menu bar, and `notifyDesktop` spawns a FRESH one-shot notifier, so it
+ * does not need a helper to have been running at dispatch time either.
+ *
+ * Armed once via `process.on('exit')` so it covers every way the run command
+ * terminates — local spawn, `--host` dispatch, `--lease` box, the error path —
+ * rather than being sprinkled over ~50 `process.exit` call sites where the next
+ * new exit path would silently miss it.
+ */
+import * as path from 'path';
+import { notifyDesktop, type DesktopNotification } from './menubar/notify-desktop.js';
+
+export interface RunNotifyContext {
+  /** Agent that ran, e.g. `claude`. */
+  agent: string;
+  /** `--name` slug when the caller named the run; falls back to the agent. */
+  name?: string;
+  /** The prompt, used for a one-line reminder of what the run was about. */
+  prompt?: string;
+  /** Working directory the run was scoped to; its basename names the project. */
+  cwd?: string;
+  /** Machine the run executed on, when it was dispatched off-box. */
+  host?: string;
+  /** Clickable target — a PR/ticket URL the caller already knows. */
+  url?: string;
+}
+
+/** Notification body cap: a banner truncates anyway, and a wall of text is noise. */
+const BODY_MAX = 120;
+
+function shorten(text: string, max = BODY_MAX): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+/**
+ * The finish notification for one run. Pure — the exit handler and the tests
+ * both build through here, so what ships is what is asserted.
+ */
+export function buildRunFinishNotification(
+  ctx: RunNotifyContext,
+  exitCode: number,
+): DesktopNotification {
+  const label = ctx.name?.trim() || ctx.agent;
+  const project = ctx.cwd ? path.basename(ctx.cwd) : undefined;
+  const where = [project, ctx.host].filter(Boolean).join(' · ');
+  const n: DesktopNotification = {
+    title: exitCode === 0 ? `${label} finished` : `${label} failed`,
+    body: shorten(ctx.prompt?.trim() || `${ctx.agent} run`),
+  };
+  if (where) n.subtitle = where;
+  if (ctx.url) n.action = `url:${ctx.url}`;
+  return n;
+}
+
+/**
+ * Post the finish notification when this process exits. Best-effort by
+ * construction: `notifyDesktop` swallows its own failures, and a run killed
+ * outright (SIGKILL) never reaches an exit handler — that is the documented
+ * limit, not a case to paper over.
+ */
+export function armRunFinishNotification(ctx: RunNotifyContext): void {
+  process.on('exit', (code) => {
+    notifyDesktop(buildRunFinishNotification(ctx, code));
+  });
+}


### PR DESCRIPTION
**Bug fix + one new flag — menu bar and CLI.** A menu-bar quick dispatch could
report "Dispatching 1 agent…" and then never say anything again, however the run
ended.

## Root cause, with the live evidence

`AgentsCLI.dispatchQuickFix` posted the finish notice from `runMonitored`'s
`terminationHandler` — a callback that lives **inside the MenubarHelper process**.

On zion, 2026-08-02:

| time | what happened |
|---|---|
| 01:10 | dispatch → `agents run claude … --name it-seems-like-the-to` (pid 65247) |
| 01:19 | `MenubarHelper.app/Contents/MacOS/MenubarHelper` mtime — the bundle was replaced; the dispatching helper died |
| 01:23 | run still going, **PPID 1** (reparented to launchd), PR #1690 already open, no notification possible |

```
$ agents ssh zion 'ps -eo pid,ppid,lstart,command | grep "agents run claude"'
65247     1 Sun Aug  2 01:10:00 2026 … agents run claude … --name it-seems-like-the-to
$ agents ssh zion 'ps -eo pid,lstart,command | grep MenubarHelper'
97775  Sun Aug  2 01:19:48 2026 … MenubarHelper      # started 10 min AFTER the dispatch
```

Not a one-off: `~/Library/Logs/DiagnosticReports/` holds 5 `MenubarHelper-*.ips`
crash reports from the last two days, each of which loses every in-flight
dispatch's notification the same way.

## The fix

The **run process** owns the notice. `agents run --notify` arms it on the run's
own `process.exit`, which:

- covers every dispatch path — local spawn, `--host`, `--lease`, the error path —
  instead of one branch (surface parity by construction, not by 50 call sites);
- does not depend on whatever launched the run still being alive;
- needs no helper running at dispatch time, because `notifyDesktop` spawns a
  **fresh** one-shot `MenubarHelper --notify`.

Quick dispatch passes `--notify` and launches detached (`runDetached`), dropping
the callback it can't keep. `--notify` is headless-only — an interactive run ends
in front of the person who started it.

The helper's click actions gain `url:<https…>` so a completion notification can
open the PR or ticket the run produced. `http`/`https` only — the click handler
hands the value to `NSWorkspace`, so accepting arbitrary schemes would make a
notification argument an open-anything primitive.

Known limit, documented rather than papered over: a run killed with `SIGKILL`
never reaches an exit handler and so never notifies.

## Run result — real delivered macOS notifications

CI is Linux and never compiles the Swift helper, so both halves were built and
run on zion.

**1. A real `--notify` run posts through the installed bundle.** Ran
`agents run claude "Reply with exactly NOTIFYOK." --notify --mode plan --name notify-verify`
on zion, then read the delivered records out of the notification store:

```
$ sqlite3 ~/Library/.../group.com.apple.usernoted/db2/db \
    'select hex(data) from record order by delivered_date desc limit 2' | xxd -r -p | strings
notify-verify failed
Reply with exactly NOTIFYOK and nothing else.
```

("failed" is correct — that claude version is signed out, so the run genuinely
failed. The title, body and delivery are the point.)

**2. The clickable PR link lands.** Posted through a *copy* of the installed
bundle carrying the new binary (the user's installed helper was left untouched):

```
$ sqlite3 … 'select hex(data) from record order by delivered_date desc limit 1' | xxd -r -p | strings
ACTION Open
https://github.com/phnx-labs/agents-cli/pull/1690
kimi-todo finished
```

The delivered record carries the `Open` action button and the PR URL.

**3. Swift builds and its self-test passes** (`swift build` on zion, then
`MENUBAR_ISSUE_TEST=1 ./MenubarHelper`):

```
PASS  run is balanced + autonomous + self-notifying
PASS  dispatch carries --notify so completion survives a helper restart
…
ALL PASS
```

## Tests

New `src/lib/run-notify.test.ts` (5 cases) pins the notification the user
actually sees: name/agent labelling, success vs failure, the project · host
subtitle, multi-line prompt collapsing and the body cap, and the `url:` action
surviving into the helper argv. The Swift self-test pins the dispatch argv.

`run-notify.test.ts` + `exec.test.ts`: 21 passed. `menubar/` suites: 30 passed.

## Series

Follows #1693 (feed updates visibility). Next: broadcasting `agents feed post` to
Linear and the user's message channel.
