### PR TITLE
fix(release): seed the gitignored provisioning profile into the home-base worktree

### DIFF
--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -384,6 +384,18 @@ git -C "\$REPO_ROOT" worktree add --quiet --detach "\$WT" "v$1" \\
   || { echo "could not create home-base publish worktree at \$WT" >&2; exit 1; }
 [ -z "\$(git -C "\$WT" status --short | grep '^ D')" ] \\
   || { echo "home-base publish worktree \$WT is incomplete -- refusing to build" >&2; exit 1; }
+# The signed keychain + menu-bar helpers need bin/embedded.provisionprofile — an
+# Apple provisioning profile that is gitignored (never committed, /apps/cli/bin/
+# is ignored wholesale), so the tag worktree has no bin/ at all. Seed it from the
+# home base's own checkout (REPO_ROOT has it) before the helper build reads it;
+# without this the home-base phase dies "Missing .../bin/embedded.provisionprofile"
+# on every release, regardless of which box triggered it.
+mkdir -p "\$WT/apps/cli/bin"
+if [ -f "\$REPO_ROOT/apps/cli/bin/embedded.provisionprofile" ]; then
+  cp "\$REPO_ROOT/apps/cli/bin/embedded.provisionprofile" "\$WT/apps/cli/bin/embedded.provisionprofile"
+else
+  echo "warning: \$REPO_ROOT/apps/cli/bin/embedded.provisionprofile absent on the home base; the signed helper build will fail" >&2
+fi
 cd "\$WT/apps/cli"
 scripts/release.sh $1 --home-base-phase
 SNIPPET


### PR DESCRIPTION
**fix / release-tooling** — no CLI behavior change (internal build script).

## Problem
The home-base publish phase (`run_home_base_phase`) builds the signed keychain + menu-bar helpers via `build-keychain-helper.sh`, which reads `bin/embedded.provisionprofile`. But `/apps/cli/bin/` is gitignored wholesale (`.gitignore:10`), so the **detached tag worktree** the phase builds in (`home_base_wt_snippet`) has no `bin/` at all → the build dies:
```
Missing .../homebase-publish-v1.20.83-XXXX/apps/cli/bin/embedded.provisionprofile. Generate at developer.apple.com and check it in.
error: signed helper build failed on mac-mini
```
This blocks **every** release (the menu-bar/keychain signing is bundled into the npm tarball, and npm publish is gated behind it) — it only ever worked when a prior build left a stale `bin/` lying around. Triggering from a non-Mac box (the whole 'runnable from any fleet box' promise) always fails here.

## Fix
`home_base_wt_snippet` now `mkdir -p`s the worktree's `bin/` and copies `embedded.provisionprofile` from the home base's own checkout (`$REPO_ROOT`, which has it) before running the phase.

## Verification
I hit this releasing **1.20.83** from Linux (yosemite-s1); applying this exact `cp` by hand let the home-base phase complete — **1.20.83 published to npm** (signed + notarized, ComputerHelper asset uploaded). This PR bakes that one missing line into the script so the next release (1.20.84) goes clean.

No CHANGELOG (internal release tooling, no published-CLI behavior change).