### PR TITLE
chore(release): 1.20.84

### DIFF
--- a/apps/cli/.changelog/1.20.84.md
+++ b/apps/cli/.changelog/1.20.84.md
@@ -1,3 +1,9 @@
+- **Agent onboarding cheat sheet and docs drift guard.** Added
+  `apps/cli/docs/AGENT-CHEATSHEET.md` as a one-page on-ramp for agents, wired it
+  from `apps/cli/AGENTS.md` and `apps/cli/docs/README.md`, and added
+  `scripts/verify-docs.sh` (plus a `verify-docs` npm script and CI job) to catch
+  broken relative links and missing entry-point wiring before merge.
+
 - **Codex can now build, test, and install without escalating to YOLO.** Codex's
   `workspace-write` sandbox blocks `$HOME`, so `cargo build`, `go build`, `npm/bun install`,
   `pip install` etc. failed on their out-of-workspace cache writes (`~/.cargo`, `GOCACHE`,
@@ -11,3 +17,11 @@
   `--mode auto` stays a real sandbox — far narrower than danger-full-access. Any
   `writable_roots` you set yourself are preserved (unioned, never clobbered). Source:
   `apps/cli/src/lib/permissions.ts` (`codexDefaultWritableRoots`, `mergeCodexSandboxWrite`).
+
+- **`agents sessions` team rows now show the team's target and teammate, not just
+  the slug.** Each teammate row reads `<team> · <teammate> · by <orchestrator> ·
+  <live turn | mission>`, where the mission is a one-line summary of the teammate's
+  spawn prompt (`assignedTask`, shown even before it has a transcript). Several
+  teams from one orchestrator stay legible (distinct team names) and each says what
+  it is for. `--active --json` carries `assignedTask`. Source:
+  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/.changelog/next/agent-docs-cheatsheet.md
+++ b/apps/cli/.changelog/next/agent-docs-cheatsheet.md
@@ -1,5 +1,0 @@
-- **Agent onboarding cheat sheet and docs drift guard.** Added
-  `apps/cli/docs/AGENT-CHEATSHEET.md` as a one-page on-ramp for agents, wired it
-  from `apps/cli/AGENTS.md` and `apps/cli/docs/README.md`, and added
-  `scripts/verify-docs.sh` (plus a `verify-docs` npm script and CI job) to catch
-  broken relative links and missing entry-point wiring before merge.

--- a/apps/cli/.changelog/next/sessions-team-target.md
+++ b/apps/cli/.changelog/next/sessions-team-target.md
@@ -1,7 +1,0 @@
-- **`agents sessions` team rows now show the team's target and teammate, not just
-  the slug.** Each teammate row reads `<team> · <teammate> · by <orchestrator> ·
-  <live turn | mission>`, where the mission is a one-line summary of the teammate's
-  spawn prompt (`assignedTask`, shown even before it has a transcript). Several
-  teams from one orchestrator stay legible (distinct team names) and each says what
-  it is for. `--active --json` carries `assignedTask`. Source:
-  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.20.84
+
+- **Agent onboarding cheat sheet and docs drift guard.** Added
+  `apps/cli/docs/AGENT-CHEATSHEET.md` as a one-page on-ramp for agents, wired it
+  from `apps/cli/AGENTS.md` and `apps/cli/docs/README.md`, and added
+  `scripts/verify-docs.sh` (plus a `verify-docs` npm script and CI job) to catch
+  broken relative links and missing entry-point wiring before merge.
+
+- **Codex can now build, test, and install without escalating to YOLO.** Codex's
+  `workspace-write` sandbox blocks `$HOME`, so `cargo build`, `go build`, `npm/bun install`,
+  `pip install` etc. failed on their out-of-workspace cache writes (`~/.cargo`, `GOCACHE`,
+  `~/.npm`, `~/.cache`, …) — which is what pushed people to `--mode full`
+  (`--dangerously-bypass-approvals-and-sandbox`). agents-cli now writes a platform-resolved
+  baseline of **regenerable toolchain caches** into Codex's `config.toml`
+  (`[sandbox_workspace_write].writable_roots`) on permission sync — `~/.cargo`, `~/.rustup`,
+  `~/.npm`, `~/.bun`, `~/go`, `~/.deno`, `~/.gradle`, `~/.m2`, `~/.gem`, plus `~/Library/Caches`
+  + `~/Library/pnpm` on macOS or `~/.cache` + `~/.local/{share,state}` on Linux. Credential dirs
+  (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, `~/.netrc`) are deliberately excluded, so
+  `--mode auto` stays a real sandbox — far narrower than danger-full-access. Any
+  `writable_roots` you set yourself are preserved (unioned, never clobbered). Source:
+  `apps/cli/src/lib/permissions.ts` (`codexDefaultWritableRoots`, `mergeCodexSandboxWrite`).
+
+- **`agents sessions` team rows now show the team's target and teammate, not just
+  the slug.** Each teammate row reads `<team> · <teammate> · by <orchestrator> ·
+  <live turn | mission>`, where the mission is a one-line summary of the teammate's
+  spawn prompt (`assignedTask`, shown even before it has a transcript). Several
+  teams from one orchestrator stay legible (distinct team names) and each says what
+  it is for. `--active --json` carries `assignedTask`. Source:
+  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`.
+
 ## 1.20.83
 
 - **Routines now treat date-specific cron schedules as one-shot jobs (RUSH-2074).**

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.20.83",
+  "version": "1.20.84",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## 1.20.84

- **Agent onboarding cheat sheet and docs drift guard.** Added
  `apps/cli/docs/AGENT-CHEATSHEET.md` as a one-page on-ramp for agents, wired it
  from `apps/cli/AGENTS.md` and `apps/cli/docs/README.md`, and added
  `scripts/verify-docs.sh` (plus a `verify-docs` npm script and CI job) to catch
  broken relative links and missing entry-point wiring before merge.

- **Codex can now build, test, and install without escalating to YOLO.** Codex's
  `workspace-write` sandbox blocks `$HOME`, so `cargo build`, `go build`, `npm/bun install`,
  `pip install` etc. failed on their out-of-workspace cache writes (`~/.cargo`, `GOCACHE`,
  `~/.npm`, `~/.cache`, …) — which is what pushed people to `--mode full`
  (`--dangerously-bypass-approvals-and-sandbox`). agents-cli now writes a platform-resolved
  baseline of **regenerable toolchain caches** into Codex's `config.toml`
  (`[sandbox_workspace_write].writable_roots`) on permission sync — `~/.cargo`, `~/.rustup`,
  `~/.npm`, `~/.bun`, `~/go`, `~/.deno`, `~/.gradle`, `~/.m2`, `~/.gem`, plus `~/Library/Caches`
  + `~/Library/pnpm` on macOS or `~/.cache` + `~/.local/{share,state}` on Linux. Credential dirs
  (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, `~/.netrc`) are deliberately excluded, so
  `--mode auto` stays a real sandbox — far narrower than danger-full-access. Any
  `writable_roots` you set yourself are preserved (unioned, never clobbered). Source:
  `apps/cli/src/lib/permissions.ts` (`codexDefaultWritableRoots`, `mergeCodexSandboxWrite`).

- **`agents sessions` team rows now show the team's target and teammate, not just
  the slug.** Each teammate row reads `<team> · <teammate> · by <orchestrator> ·
  <live turn | mission>`, where the mission is a one-line summary of the teammate's
  spawn prompt (`assignedTask`, shown even before it has a transcript). Several
  teams from one orchestrator stay legible (distinct team names) and each says what
  it is for. `--active --json` carries `assignedTask`. Source:
  `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`.