### PR TITLE
feat(feed): broadcast a post to the systems the operator watches

### DIFF
--- a/apps/cli/.changelog/next/feed-broadcast-sinks.md
+++ b/apps/cli/.changelog/next/feed-broadcast-sinks.md
@@ -1,0 +1,14 @@
+- **`agents feed post` can now be mirrored to the systems you actually watch.**
+  A post was durable but local: an operator away from every terminal never saw
+  it, and the tracker that owns the work heard nothing. Declare sinks under
+  `feed.broadcast` in `agents.yaml` — argv templates, not built-in integrations —
+  and each post is fanned out to them. `--level important` marks a post worth
+  interrupting someone over, so a sink with `minLevel: important` never fires on
+  a routine "CI green"; a template referencing `{ticket}` is skipped when no
+  ticket is known, and the ticket is joined from the session index rather than
+  asked for as a flag. `{message}` composes the human line a messaging sink wants
+  — `<project> · <text>` plus the first attached URL — so an out-of-band ping
+  leads with the project and carries a clickable link. Delivery is best-effort
+  and reported per sink; a mirror that fails never costs you the post. Source:
+  `apps/cli/src/lib/feed-broadcast.ts`, `apps/cli/src/commands/feed.ts`,
+  `apps/cli/docs/06-observability.md`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -611,6 +611,54 @@ Identity resolution order: `--session` → `AGENT_SESSION_ID` /
 `AGENTS_SESSION_ID` / mailbox basename → `AGENT_LAUNCH_ID` match in the pid
 registry → parent-pid walk through `by-pid/<pid>.json`.
 
+#### Broadcasting a post outward (`feed.broadcast`)
+
+A post is durable in the activity log, but an operator away from every terminal
+never sees it and the tracker that owns the work hears nothing. Declare sinks in
+`agents.yaml` and each post is mirrored to them:
+
+```yaml
+feed:
+  broadcast:
+    ticket:
+      command: [linear, update, "{ticket}", --comment, "{text}"]
+    message:
+      command: [rush, message, send, --text, "{message}", --from-agent, "{agent}"]
+      minLevel: important
+```
+
+Sinks are **argv templates**, not built-in integrations — this CLI ships
+Apache-2.0 and must not depend on one person's tracker or messaging stack. The
+first element is spawned directly (no shell), so post text can never become shell
+syntax. Point the same mechanism at `jira`, `gh issue comment`, or a webhook
+script.
+
+Two rules decide whether a sink runs, both read off the post itself:
+
+- **Level.** `agents feed post … --level important` marks a post worth
+  interrupting someone over; a sink with `minLevel: important` only sees those, so
+  a routine "CI green" never buzzes a phone. The default level is `milestone`.
+- **Placeholders.** A template referencing `{ticket}` is skipped when no ticket is
+  known — the template declares what it needs, and a sink can never fire with a
+  hole in its argv (`linear update  --comment …` commenting on nothing).
+
+Available placeholders: `{text}` (the post verbatim), `{ticket}`, `{project}`,
+`{agent}`, `{host}`, `{session}`, `{level}`, `{links}` (attached URLs, space
+separated), and `{message}` — a composed human line, `<project> · <text>` with the
+first attached URL on a second line. Prefer `{message}` for a messaging sink: it
+leads with the project the reader cares about and carries a clickable link,
+rather than opening with an agent name that tells them nothing.
+
+The **ticket is joined from the session index**, not passed as a flag — it is a
+domain fact about the session (the rule above), and an agent that has to remember
+a `--ticket` argument is an agent that will forget it. Attach the PR or a shared
+plan with `--attach <url>` (an HTML plan published via `agents share` gives you a
+public one) and it rides along as `{links}` / `{message}`.
+
+Delivery is best-effort and reported: each sink that ran prints `→ <name>`, a
+failure prints a warning and a non-zero exit is never propagated. Losing a mirror
+must not cost the operator the post — it is already written.
+
 ### Activity lane (`agents activity`) — progress at a glance, fleet-wide
 
 `agents activity` reads the same append-only activity stream (never re-parsing

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -21,6 +21,15 @@ import { ensureFeedPublishHook, listAskStats, listBlocks, recordNotified, type O
 import { ensureActivityLogHook, readRecentActivity, formatActivityLine, formatProgressUpdate, type ActivityEvent } from '../lib/activity.js';
 import { postFeedStatus } from '../lib/feed-post.js';
 import {
+  parseFeedPostLevel,
+  planFeedBroadcast,
+  runFeedBroadcast,
+  type FeedPostLevel,
+  type SinkOutcome,
+} from '../lib/feed-broadcast.js';
+import { getSessionById } from '../lib/session/db.js';
+import { readMeta } from '../lib/state.js';
+import {
   enrichBlocksFromSessions,
   groupBlocksByOutcome,
   isUnambiguousOutcomeAnswer,
@@ -301,6 +310,7 @@ export function registerFeedCommand(program: Command): void {
     .argument('<text...>', 'What just happened — one short human line')
     .option('--session <id>', 'Session id escape hatch (default: auto from env / pid registry)')
     .option('--attach <path-or-url...>', 'Attach an artifact (local file or URL); repeatable')
+    .option('--level <level>', 'How loudly to broadcast: milestone (default) or important. Configured sinks with minLevel: important only fire on the latter.', 'milestone')
     .option('--json', 'Emit the written event as JSON')
     .addHelpText('after', `
 Examples:
@@ -309,16 +319,24 @@ Examples:
   agents feed post "cover render ready" --attach ./out/cover.png
   agents feed post "ready for review" --json
 
+  # Worth interrupting someone over — reaches sinks gated on minLevel: important:
+  agents feed post "release blocked: npm token expired" --level important
+
   # Outside a run, pass the session explicitly:
   agents feed post "manual note" --session 00998b0e-2d15-4d2f-a58b-974a886c9b47
 
 Identity (session, agent, host, runtime, pid, launchId) is stamped automatically.
-Domain facts (tickets, PRs) are not CLI flags — join them on the session at read time.
+Domain facts (tickets, PRs) are not CLI flags — the ticket is joined from the
+session index at post time, so a broadcast sink can comment on it without the
+agent having to remember it.
+
+Configure where a post is mirrored under feed.broadcast in agents.yaml — see
+docs/06-observability.md.
 `)
     .action((
       textParts: string[],
-      opts: { session?: string; attach?: string[]; json?: boolean },
-      cmd?: { opts: () => { session?: string; attach?: string[]; json?: boolean }; parent?: { opts: () => { json?: boolean } } },
+      opts: { session?: string; attach?: string[]; level?: string; json?: boolean },
+      cmd?: { opts: () => { session?: string; attach?: string[]; level?: string; json?: boolean }; parent?: { opts: () => { json?: boolean } } },
     ) => {
       // Parent `feed` also declares `--json` (for the list view). Commander
       // binds the flag on the parent, so a `feed post … --json` lands on
@@ -326,19 +344,23 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
       const flags = {
         session: opts?.session ?? cmd?.opts?.()?.session,
         attach: opts?.attach ?? cmd?.opts?.()?.attach,
+        level: opts?.level ?? cmd?.opts?.()?.level,
         json: Boolean(opts?.json ?? cmd?.opts?.()?.json ?? cmd?.parent?.opts?.()?.json),
       };
       try {
+        const level = parseFeedPostLevel(flags.level);
         const { event } = postFeedStatus({
           text: Array.isArray(textParts) ? textParts.join(' ') : String(textParts ?? ''),
           sessionId: flags.session,
           attach: flags.attach,
         });
+        const outcomes = broadcastPostedEvent(event, level);
         if (flags.json) {
-          console.log(JSON.stringify(event, null, 2));
+          console.log(JSON.stringify(outcomes.length ? { ...event, broadcast: outcomes } : event, null, 2));
           return;
         }
         console.log(formatProgressUpdate(event));
+        reportBroadcast(outcomes);
       } catch (err) {
         console.error(chalk.red((err as Error).message));
         process.exitCode = 1;
@@ -554,6 +576,41 @@ Domain facts (tickets, PRs) are not CLI flags — join them on the session at re
         else renderActivityLane();
       }
     });
+}
+
+/**
+ * Mirror a written post to the configured sinks (`feed.broadcast` in
+ * agents.yaml). The ticket is JOINED from the session index rather than asked
+ * for as a flag — it is a domain fact about the session, and an agent that has
+ * to remember a `--ticket` argument is an agent that will forget it. Returns the
+ * per-sink outcomes; an empty array means nothing is configured, which is the
+ * default and is not a failure.
+ */
+function broadcastPostedEvent(event: ActivityEvent, level: FeedPostLevel): SinkOutcome[] {
+  const config = readMeta().feed?.broadcast;
+  if (!config || Object.keys(config).length === 0) return [];
+  const ticket = getSessionById(event.sessionId)?.ticketId;
+  const planned = planFeedBroadcast(config, {
+    text: event.detail ?? '',
+    level,
+    ticket,
+    project: event.project,
+    agent: event.agent,
+    host: event.host,
+    session: event.sessionId,
+    links: (event.attachments ?? [])
+      .map((a) => a.href)
+      .filter((href) => /^https?:\/\//i.test(href)),
+  });
+  return runFeedBroadcast(planned);
+}
+
+/** One line per sink that ran. Silent when nothing is configured. */
+function reportBroadcast(outcomes: SinkOutcome[]): void {
+  for (const o of outcomes) {
+    if (o.ok) console.log(chalk.gray(`  → ${o.name}`));
+    else console.error(chalk.yellow(`  → ${o.name} failed: ${o.error}`));
+  }
 }
 
 /** Feed view selector (RUSH-2015): decisions, progress, or both. */

--- a/apps/cli/src/lib/feed-broadcast.test.ts
+++ b/apps/cli/src/lib/feed-broadcast.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  composeBroadcastMessage,
+  parseFeedPostLevel,
+  planFeedBroadcast,
+  renderSinkArgv,
+  runFeedBroadcast,
+  type FeedBroadcastConfig,
+  type FeedBroadcastContext,
+} from './feed-broadcast.js';
+
+const ctx = (over: Partial<FeedBroadcastContext> = {}): FeedBroadcastContext => ({
+  text: 'PR #1690 open, CI green, merging',
+  level: 'milestone',
+  project: 'agents-cli',
+  agent: 'claude',
+  host: 'yosemite-s1',
+  session: 'c854ae60-0bde-4049-bc8a-0b9674aeabd0',
+  ...over,
+});
+
+/** The config an operator would actually write for this stack. */
+const CONFIG: FeedBroadcastConfig = {
+  ticket: { command: ['linear', 'update', '{ticket}', '--comment', '{text}'] },
+  message: { command: ['rush', 'message', 'send', '--text', '{message}'], minLevel: 'important' },
+};
+
+describe('feed post level', () => {
+  it('defaults to milestone and accepts important', () => {
+    expect(parseFeedPostLevel(undefined)).toBe('milestone');
+    expect(parseFeedPostLevel('important')).toBe('important');
+  });
+
+  it('rejects an unknown level instead of silently downgrading it', () => {
+    expect(() => parseFeedPostLevel('urgent')).toThrow(/Unknown --level 'urgent'/);
+  });
+});
+
+describe('sink argv rendering', () => {
+  it('substitutes every placeholder the post can supply', () => {
+    const argv = renderSinkArgv(
+      ['linear', 'update', '{ticket}', '--comment', '{project}: {text}'],
+      ctx({ ticket: 'RUSH-2081' }),
+    );
+    expect(argv).toEqual([
+      'linear', 'update', 'RUSH-2081',
+      '--comment', 'agents-cli: PR #1690 open, CI green, merging',
+    ]);
+  });
+
+  it('skips a template whose placeholder this post cannot fill', () => {
+    // No ticket on the session — commenting on nothing is worse than not
+    // commenting, so the sink does not run at all.
+    expect(renderSinkArgv(['linear', 'update', '{ticket}', '--comment', '{text}'], ctx())).toBeUndefined();
+  });
+
+  it('keeps post text as one argv element, never shell syntax', () => {
+    const argv = renderSinkArgv(['echo', '{text}'], ctx({ text: 'done; rm -rf / && echo pwned' }));
+    expect(argv).toEqual(['echo', 'done; rm -rf / && echo pwned']);
+  });
+});
+
+describe('message composition', () => {
+  it('leads with the project and appends the link', () => {
+    expect(composeBroadcastMessage(ctx({ links: ['https://github.com/phnx-labs/agents-cli/pull/1690'] })))
+      .toBe('agents-cli · PR #1690 open, CI green, merging\nhttps://github.com/phnx-labs/agents-cli/pull/1690');
+  });
+
+  it('omits the link line when no URL is attached', () => {
+    expect(composeBroadcastMessage(ctx())).toBe('agents-cli · PR #1690 open, CI green, merging');
+  });
+
+  it('ignores a local file attachment as a link target', () => {
+    expect(composeBroadcastMessage(ctx({ links: [] }))).not.toContain('\n');
+  });
+});
+
+describe('broadcast planning', () => {
+  it('plans nothing when no sinks are configured', () => {
+    expect(planFeedBroadcast(undefined, ctx())).toEqual([]);
+    expect(planFeedBroadcast({}, ctx())).toEqual([]);
+  });
+
+  it('holds an important-only sink back from a routine post', () => {
+    const planned = planFeedBroadcast(CONFIG, ctx({ ticket: 'RUSH-2081' }));
+    expect(planned.map((p) => p.name)).toEqual(['ticket']);
+  });
+
+  it('reaches the messaging sink once the post is important', () => {
+    const planned = planFeedBroadcast(CONFIG, ctx({ ticket: 'RUSH-2081', level: 'important' }));
+    expect(planned.map((p) => p.name)).toEqual(['ticket', 'message']);
+    expect(planned[1].argv).toEqual([
+      'rush', 'message', 'send', '--text', 'agents-cli · PR #1690 open, CI green, merging',
+    ]);
+  });
+
+  it('ignores a malformed sink rather than crashing the post', () => {
+    const planned = planFeedBroadcast(
+      { broken: { command: [] }, ok: { command: ['true'] } } as FeedBroadcastConfig,
+      ctx(),
+    );
+    expect(planned.map((p) => p.name)).toEqual(['ok']);
+  });
+});
+
+describe('running sinks', () => {
+  it('runs a real command and reports success', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'feed-broadcast-'));
+    const out = path.join(dir, 'sink.txt');
+    const planned = planFeedBroadcast(
+      { file: { command: ['sh', '-c', `printf '%s' "$1" > ${out}`, 'sh', '{text}'] } },
+      ctx(),
+    );
+    expect(runFeedBroadcast(planned)).toEqual([{ name: 'file', ok: true }]);
+    expect(fs.readFileSync(out, 'utf8')).toBe('PR #1690 open, CI green, merging');
+  });
+
+  it('reports a failing sink without throwing — the post already stands', () => {
+    const [outcome] = runFeedBroadcast([{ name: 'nope', argv: ['sh', '-c', 'echo boom >&2; exit 3'] }]);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toBe('boom');
+  });
+
+  it('reports a sink whose program is not installed', () => {
+    const [outcome] = runFeedBroadcast([
+      { name: 'missing', argv: ['agents-cli-no-such-binary-42', 'x'] },
+    ]);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toMatch(/ENOENT|not found|spawnSync/i);
+  });
+});

--- a/apps/cli/src/lib/feed-broadcast.ts
+++ b/apps/cli/src/lib/feed-broadcast.ts
@@ -1,0 +1,183 @@
+/**
+ * Fan an `agents feed post` out to the systems the operator actually watches.
+ *
+ * A post is already durable — it lands in the append-only activity log and shows
+ * up in `agents feed --filter updates`. But an operator who is away from every
+ * terminal never sees it, and the tracker that owns the work (a Linear ticket,
+ * a GitHub issue) hears nothing at all. So a post can also be mirrored outward.
+ *
+ * Sinks are **argv templates from config**, never hardcoded integrations. This
+ * CLI ships Apache-2.0 and must not depend on one person's tracker or messaging
+ * stack; declaring `[linear, update, "{ticket}", --comment, "{text}"]` in
+ * `agents.yaml` keeps the coupling in the operator's config where it belongs,
+ * and lets someone else point the same mechanism at `jira`, `gh issue comment`,
+ * or a webhook script.
+ *
+ * Two rules decide whether a sink runs, both derived from the post itself:
+ *
+ *   - **Level.** `minLevel: important` keeps a sink for the posts worth
+ *     interrupting someone over, so a routine "CI green" does not buzz a phone.
+ *   - **Placeholders.** A template that references `{ticket}` is skipped when no
+ *     ticket is known. The template declares what it needs; nothing has to
+ *     restate it as a flag, and a sink can never fire with a hole in its argv.
+ *
+ * Delivery is best-effort and reported: a sink that fails prints a warning and
+ * the post still stands. Losing a mirror must never cost the operator the post.
+ */
+import { spawnSync } from 'child_process';
+
+/** How loudly a post asks to be heard. Ordered — `important` implies milestone. */
+export type FeedPostLevel = 'milestone' | 'important';
+
+const LEVEL_RANK: Record<FeedPostLevel, number> = { milestone: 0, important: 1 };
+
+/** Parse a `--level` value; anything unrecognized is a usage error, not a default. */
+export function parseFeedPostLevel(raw: string | undefined): FeedPostLevel {
+  const v = (raw ?? '').trim().toLowerCase();
+  if (!v || v === 'milestone') return 'milestone';
+  if (v === 'important') return 'important';
+  throw new Error(`Unknown --level '${raw}'. Use milestone or important.`);
+}
+
+export interface FeedSinkConfig {
+  /**
+   * argv to run, with `{placeholder}` tokens substituted. First element is the
+   * program; it is spawned directly (no shell), so quoting is not a concern and
+   * post text can never become shell syntax.
+   */
+  command: string[];
+  /** Lowest post level that reaches this sink. Defaults to `milestone` (all posts). */
+  minLevel?: FeedPostLevel;
+}
+
+/** `feed.broadcast` in agents.yaml — sink name → what to run. */
+export type FeedBroadcastConfig = Record<string, FeedSinkConfig>;
+
+/** Everything a template may interpolate. Absent values skip templates that need them. */
+export interface FeedBroadcastContext {
+  /** The post text, verbatim. */
+  text: string;
+  level: FeedPostLevel;
+  /** Tracker id for the work, e.g. `RUSH-2081`. */
+  ticket?: string;
+  /** Repo/project the post came from. */
+  project?: string;
+  agent?: string;
+  host?: string;
+  session?: string;
+  /** URLs attached to the post — the PR, the ticket, a shared plan. */
+  links?: string[];
+}
+
+export interface PlannedSink {
+  name: string;
+  argv: string[];
+}
+
+export interface SinkOutcome {
+  name: string;
+  ok: boolean;
+  /** stderr tail when the sink failed, for the warning line. */
+  error?: string;
+}
+
+const PLACEHOLDER = /\{([a-z]+)\}/g;
+
+/**
+ * A human-facing one-liner for a messaging sink: what project, what happened,
+ * and the link to go read more. Leading with the project is deliberate — a
+ * message that opens with an agent name tells the reader nothing about which of
+ * their projects just moved.
+ */
+export function composeBroadcastMessage(ctx: FeedBroadcastContext): string {
+  const head = ctx.project ? `${ctx.project} · ${ctx.text}` : ctx.text;
+  const link = ctx.links?.find((l) => /^https?:\/\//i.test(l));
+  return link ? `${head}\n${link}` : head;
+}
+
+/** The values a template may reference, resolved once per post. */
+function templateVars(ctx: FeedBroadcastContext): Record<string, string | undefined> {
+  return {
+    text: ctx.text,
+    ticket: ctx.ticket,
+    project: ctx.project,
+    agent: ctx.agent,
+    host: ctx.host,
+    session: ctx.session,
+    level: ctx.level,
+    links: ctx.links?.length ? ctx.links.join(' ') : undefined,
+    message: composeBroadcastMessage(ctx),
+  };
+}
+
+/**
+ * Substitute `{placeholder}` tokens in an argv template. Returns undefined when
+ * the template needs a value this post does not have — the sink is then skipped
+ * rather than run with an empty argument, which is how a `linear update --comment`
+ * would otherwise comment on nothing.
+ */
+export function renderSinkArgv(
+  template: string[],
+  ctx: FeedBroadcastContext,
+): string[] | undefined {
+  const vars = templateVars(ctx);
+  const argv: string[] = [];
+  for (const token of template) {
+    let missing = false;
+    const rendered = token.replace(PLACEHOLDER, (whole, key: string) => {
+      const value = vars[key];
+      if (value === undefined || value === '') {
+        missing = true;
+        return whole;
+      }
+      return value;
+    });
+    if (missing) return undefined;
+    argv.push(rendered);
+  }
+  return argv.length > 0 ? argv : undefined;
+}
+
+/**
+ * Which sinks this post reaches, in config order. Pure — the dry-run listing and
+ * the real fan-out plan through here, so what `--dry-run` shows is what runs.
+ */
+export function planFeedBroadcast(
+  config: FeedBroadcastConfig | undefined,
+  ctx: FeedBroadcastContext,
+): PlannedSink[] {
+  if (!config) return [];
+  const planned: PlannedSink[] = [];
+  for (const [name, sink] of Object.entries(config)) {
+    if (!Array.isArray(sink?.command) || sink.command.length === 0) continue;
+    const min = sink.minLevel ?? 'milestone';
+    if (LEVEL_RANK[ctx.level] < LEVEL_RANK[min]) continue;
+    const argv = renderSinkArgv(sink.command, ctx);
+    if (!argv) continue;
+    planned.push({ name, argv });
+  }
+  return planned;
+}
+
+/**
+ * Run the planned sinks. Each is a direct spawn with a bounded lifetime; a sink
+ * that fails or is not installed is reported, never thrown — the post is already
+ * written and must not be undone by a mirror that could not be reached.
+ */
+export function runFeedBroadcast(planned: PlannedSink[], timeoutMs = 20_000): SinkOutcome[] {
+  return planned.map(({ name, argv }) => {
+    const result = spawnSync(argv[0], argv.slice(1), {
+      encoding: 'utf-8',
+      timeout: timeoutMs,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (result.error) {
+      return { name, ok: false, error: result.error.message };
+    }
+    if (result.status !== 0) {
+      const tail = (result.stderr || result.stdout || '').trim().split('\n').slice(-1)[0];
+      return { name, ok: false, error: tail || `exited ${result.status}` };
+    }
+    return { name, ok: true };
+  });
+}

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CloudProviderId } from './cloud/types.js';
+import type { FeedBroadcastConfig } from './feed-broadcast.js';
 
 /** Unique identifier for a current or legacy AI coding agent. */
 export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid' | 'hermes';
@@ -827,6 +828,15 @@ export interface Meta {
   };
   /** Spend guardrails (issue #346). User-global caps; project agents.yaml overrides. */
   budget?: BudgetConfig;
+  /**
+   * `agents feed post` fan-out. `broadcast` maps a sink name to the argv template
+   * run for each post, so mirroring to a tracker or a messaging CLI is the
+   * operator's config rather than an integration compiled into this CLI. See
+   * lib/feed-broadcast.ts and docs/06-observability.md.
+   */
+  feed?: {
+    broadcast?: FeedBroadcastConfig;
+  };
   beta?: {
     enabled?: BetaFeatureName[];
   };


### PR DESCRIPTION
**New capability — CLI + config surface.** An `agents feed post` can now be
mirrored to the systems the operator actually watches: a tracker ticket, a
messaging CLI, anything with a command line.

## Why

A post is durable — it lands in the activity log and shows in
`agents feed --filter updates`. But an operator away from every terminal never
sees it, and the Linear/GitHub ticket that owns the work hears nothing at all.
Progress that only exists in a log the operator is not looking at is progress
nobody has.

## Shape

Sinks are **argv templates in `agents.yaml`**, not integrations compiled into the
CLI. This ships Apache-2.0 and must not depend on one person's tracker or
messaging stack; the same mechanism points at `jira`, `gh issue comment`, or a
webhook script.

```yaml
feed:
  broadcast:
    ticket:
      command: [linear, update, "{ticket}", --comment, "{text}"]
    message:
      command: [rush, message, send, --text, "{message}", --from-agent, "{agent}"]
      minLevel: important
```

Two rules decide whether a sink runs, both read off the post itself:

- **Level.** `--level important` marks a post worth interrupting someone over; a
  sink with `minLevel: important` sees only those, so a routine "CI green" never
  buzzes a phone. Default is `milestone`.
- **Placeholders.** A template referencing `{ticket}` is skipped when no ticket is
  known. The template declares what it needs, so a sink can never fire with a hole
  in its argv (`linear update  --comment …` commenting on nothing).

The **ticket is joined from the session index**, not passed as a flag. That keeps
the module's existing rule — "domain facts are not CLI flags" — and it is the
practical point: an agent that has to remember `--ticket` is an agent that will
forget it.

`{message}` composes the line a messaging sink wants — `<project> · <text>` plus
the first attached URL — so an out-of-band ping leads with the project the reader
cares about and carries a clickable link, instead of opening with an agent name
that tells them nothing.

Sinks are spawned directly, never through a shell, so post text can never become
shell syntax. Delivery is best-effort and reported per sink; a mirror that fails
prints a warning and the post still stands.

## Run result — the real command, real sinks

Ran the built CLI against a sandbox `agents.yaml` carrying both sinks above (with
the messaging sink swapped for a `sh -c` that writes what it received, so the
argv is inspectable).

**Routine post** — local log only. `message` is held back by `minLevel`, and
`ticket` is skipped because the session has no ticket:

```
$ agents feed post "PR #1690 open, CI green, merging" \
    --attach https://github.com/phnx-labs/agents-cli/pull/1690
  ▸ update · just now
    claude · 11111111 · yosemite-s1 · agents-cli
    "PR #1690 open, CI green, merging"
    ↗ 1690
  message file: (not written)
```

**Important post** — the messaging sink fires and is reported:

```
$ agents feed post "release blocked: npm token expired" --level important \
    --attach https://github.com/phnx-labs/agents-cli/pull/1690
  ▸ update · just now
    claude · 11111111 · yosemite-s1 · agents-cli
    "release blocked: npm token expired"
    ↗ 1690
  → message

$ cat /tmp/broadcast-message.txt
agents-cli · release blocked: npm token expired
https://github.com/phnx-labs/agents-cli/pull/1690
```

Project first, then the link — which is the whole point of `{message}`.

## Tests

`src/lib/feed-broadcast.test.ts`, 15 cases over the real code path (no mocks;
the "running sinks" group spawns actual processes): level parsing and its
rejection of an unknown value, placeholder substitution, the skip-when-unfillable
rule, post text staying one argv element rather than shell syntax, message
composition with and without a link, the level gate in both directions, a
malformed sink being ignored rather than crashing the post, a real sink writing a
real file, and a failing / not-installed sink being reported instead of thrown.

`feed-broadcast` + `feed` + `feed-post` + `run-forwarding`: 56 passed.

## Series

Third of three, after #1693 (feed updates visibility) and #1696 (`agents run
--notify`). Together: agents post progress → the post is visible fleet-wide → the
post reaches the ticket and the operator's phone.

## Not in scope

The `🤖 claude · mac-mini` header on an incoming iMessage is composed server-side
by the Rush API from `from_agent` — I byte-grepped the `rush` client binary on
zion and it carries neither the emoji nor that format string. It cannot be fixed
from this repo. What this PR does control is the message *body*: `{message}` puts
the project and the link where the reader looks first.
