### PR TITLE
fix(events): --limit 0 reads the whole stream; announce a capped read

### DIFF
--- a/apps/cli/.changelog/next/PR-events-limit-truncation.md
+++ b/apps/cli/.changelog/next/PR-events-limit-truncation.md
@@ -1,0 +1,14 @@
+- **`agents events --limit 0` now reads the whole stream, and a capped read says
+  so.** `--limit` parsed as `Math.max(1, parseInt(raw) || 50)`, so `--limit 0`
+  collapsed back to `50` (`0 || 50`) and there was no way to read past the default
+  cap at all. The cap is applied after filtering and before the caller sees
+  anything, so every aggregation over `--json` silently ranked the newest 50
+  records instead of the matching set — measured against a real 7-day corpus of
+  2,135 CLI failures in 9 classes, 8 of 9 ranks came out wrong with counts off by
+  roughly 100x, and nothing warned. `--limit 0` now means no cap (29,649 records
+  on a 30-day stream here, against 50 before), a truncated read prints
+  `Showing the newest 50 — more events matched. Pass --limit 0 for all.` (on
+  stderr under `--json`, so a `| jq` pipeline still receives clean JSON), and a
+  non-numeric or negative `--limit` exits 2 rather than quietly becoming 50.
+  Source: `apps/cli/src/commands/events.ts`, `apps/cli/tests/events-limit.test.ts`,
+  `apps/cli/docs/06-observability.md`.

--- a/apps/cli/.changelog/next/PR-events-limit-truncation.md
+++ b/apps/cli/.changelog/next/PR-events-limit-truncation.md
@@ -9,6 +9,8 @@
   on a 30-day stream here, against 50 before), a truncated read prints
   `Showing the newest 50 — more events matched. Pass --limit 0 for all.` (on
   stderr under `--json`, so a `| jq` pipeline still receives clean JSON), and a
-  non-numeric or negative `--limit` exits 2 rather than quietly becoming 50.
+  non-numeric, negative, or empty `--limit` exits 2 rather than quietly becoming
+  50 — an empty one (`--limit "$LIMIT"` with the variable unset) would otherwise
+  have read as "no cap" and returned the whole stream unannounced.
   Source: `apps/cli/src/commands/events.ts`, `apps/cli/tests/events-limit.test.ts`,
   `apps/cli/docs/06-observability.md`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -152,6 +152,7 @@ agents events --module secrets         # every secret accessed, revealed, or unl
 agents events --command "teams create" # a command path — prefix match
 agents events --event teams.disband    # a semantic event: a team torn down
 agents events --event secrets.get --since 7d --json
+agents events --event pr.opened --since 30d --limit 0 --json   # every match, uncapped
 agents events -f                       # live tail of today's log
 ```
 
@@ -159,6 +160,21 @@ agents events -f                       # live tail of today's log
 prefix (`teams` catches `teams create`); `--event` filters a typed event
 (repeatable); `--since` takes `2h`/`7d`/`4w` or an ISO date. `--json` emits the
 raw records for external consumers.
+
+**`--limit` caps the read at 50 records by default — pass `--limit 0` before you
+aggregate.** The cap keeps an interactive `agents events` readable, but it is
+applied *after* filtering and *before* you see the records, so a group-by over a
+capped `--json` read ranks the newest 50 rather than the real set. On a 30-day
+stream here that is 50 records out of 29,649. When a read is capped, the command
+says so — on stderr for `--json` (so a `| jq` pipeline still gets clean JSON), on
+stdout for the human view:
+
+```
+Showing the newest 50 — more events matched. Pass --limit 0 for all.
+```
+
+A non-numeric or negative `--limit` is rejected with exit 2 rather than silently
+falling back to 50.
 
 **Every secret access AND unlock is audited at the read, not just at the command.**
 `agents events --module secrets` surfaces two typed events:

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -173,8 +173,9 @@ stdout for the human view:
 Showing the newest 50 — more events matched. Pass --limit 0 for all.
 ```
 
-A non-numeric or negative `--limit` is rejected with exit 2 rather than silently
-falling back to 50.
+`--limit` accepts whole numbers only. Anything else — non-numeric, negative,
+fractional, or **empty** (the shape `--limit "$VAR"` takes when `VAR` is unset) —
+exits 2 rather than silently falling back to 50 or, worse, reading uncapped.
 
 **Every secret access AND unlock is audited at the read, not just at the command.**
 `agents events --module secrets` surfaces two typed events:

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -173,8 +173,9 @@ stdout for the human view:
 Showing the newest 50 — more events matched. Pass --limit 0 for all.
 ```
 
-A non-numeric or negative `--limit` is rejected with exit 2 rather than silently
-falling back to 50.
+A non-numeric, negative, or empty `--limit` is rejected with exit 2 rather than
+silently falling back to 50. Empty counts: `--limit "$LIMIT"` with an unset
+variable is a scripting mistake, not a request for the whole stream.
 
 **Every secret access AND unlock is audited at the read, not just at the command.**
 `agents events --module secrets` surfaces two typed events:

--- a/apps/cli/src/commands/events.ts
+++ b/apps/cli/src/commands/events.ts
@@ -27,7 +27,11 @@ import { readUnifiedEvents } from '../lib/event-stream.js';
  * A non-numeric or negative value is a usage error, not a quiet fallback.
  */
 export function resolveEventsLimit(raw: string | undefined): number | undefined {
-  const value = Number(raw ?? '50');
+  const token = raw ?? '50';
+  // Number('') and Number('   ') are both 0, which would read as "no cap" — an
+  // empty --limit (an unset "$LIMIT" in a script) must be rejected, not silently
+  // turned into the unbounded read.
+  const value = token.trim() === '' ? NaN : Number(token);
   if (!Number.isInteger(value) || value < 0) {
     throw new RangeError(`Invalid --limit ${raw} — pass a whole number, or 0 for no cap.`);
   }

--- a/apps/cli/src/commands/events.ts
+++ b/apps/cli/src/commands/events.ts
@@ -20,6 +20,30 @@ import * as fs from 'fs';
 import { getLogsPath, type EventRecord, type EventType } from '../lib/events.js';
 import { readUnifiedEvents } from '../lib/event-stream.js';
 
+/**
+ * Resolve `--limit` into a record cap. `0` means "no cap" — without it there is
+ * no way to read the whole stream, and any aggregation (group-by failure, count
+ * per module) silently ranks the newest 50 records instead of the real set.
+ * A non-numeric or negative value is a usage error, not a quiet fallback.
+ */
+export function resolveEventsLimit(raw: string | undefined): number | undefined {
+  const value = Number(raw ?? '50');
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`Invalid --limit ${raw} — pass a whole number, or 0 for no cap.`);
+  }
+  return value === 0 ? undefined : value;
+}
+
+/**
+ * Cap `fetched` (read with `limit + 1`) to `limit`, reporting whether records
+ * were dropped. The caller announces the cap so a truncated read is never
+ * mistaken for the complete set.
+ */
+export function capRecords<T>(fetched: T[], limit: number | undefined): { records: T[]; truncated: boolean } {
+  if (limit === undefined || fetched.length <= limit) return { records: fetched, truncated: false };
+  return { records: fetched.slice(0, limit), truncated: true };
+}
+
 interface EventsOptions {
   module?: string;
   command?: string;
@@ -89,7 +113,7 @@ export function registerEventsCommand(program: Command): void {
     .option('--agent <name>', 'Only events tagged with this agent')
     .option('--since <time>', 'Only events newer than this (e.g. 2h, 7d, or ISO date)')
     .option('--audit', 'Operational events only (skip agent activity)')
-    .option('--limit <n>', 'Max records to show (default 50)', '50')
+    .option('--limit <n>', 'Max records to show; 0 for no cap (default 50)', '50')
     .option('--json', 'Output raw records as JSON')
     .option('-f, --follow', "Tail today's operational log live")
     .addHelpText('after', `
@@ -99,33 +123,42 @@ Examples:
   agents events --audit                  Operational events only (secrets / teams / ...)
   agents events --event pr.opened --since 7d
   agents events --module secrets         Every secret accessed or revealed
-  agents events -f                       Live tail (operational)`)
+  agents events -f                       Live tail (operational)
+  agents events --event pr.opened --since 30d --limit 0 --json
+                                         Every match — use --limit 0 whenever you
+                                         aggregate, or you rank only the newest 50`)
     .action(async (options: EventsOptions) => {
       if (options.follow) {
         await followLog();
         return;
       }
 
-      const limit = Math.max(1, parseInt(options.limit ?? '50', 10) || 50);
+      let limit: number | undefined;
       let startDate: Date | undefined;
       try {
+        limit = resolveEventsLimit(options.limit);
         startDate = options.since ? parseSince(options.since) : undefined;
       } catch (err) {
         console.error(chalk.red((err as Error).message));
         process.exit(2);
       }
 
-      const records = readUnifiedEvents({
+      // Read one past the cap so we can tell a full result from a clipped one.
+      const fetched = readUnifiedEvents({
         startDate,
         eventTypes: options.event && options.event.length ? (options.event as EventType[]) : undefined,
         agent: options.agent,
         command: options.command,
         module: options.module,
-        limit,
+        limit: limit === undefined ? undefined : limit + 1,
         includeActivity: !options.audit,
       });
+      const { records, truncated } = capRecords(fetched, limit);
+      const capNote = `Showing the newest ${limit} — more events matched. Pass --limit 0 for all.`;
 
       if (options.json) {
+        // Notice goes to stderr so `--json | jq` still receives clean JSON.
+        if (truncated) console.error(chalk.yellow(capNote));
         console.log(JSON.stringify(records, null, 2));
         return;
       }
@@ -138,6 +171,7 @@ Examples:
       // query() returns newest-first; print oldest-first so a tail reads naturally.
       for (const r of records.slice().reverse()) console.log(renderRow(r));
       console.log(chalk.gray(`\n${records.length} event(s). Log: ${getLogsPath()}`));
+      if (truncated) console.log(chalk.yellow(capNote));
     });
 }
 

--- a/apps/cli/src/commands/events.ts
+++ b/apps/cli/src/commands/events.ts
@@ -27,10 +27,14 @@ import { readUnifiedEvents } from '../lib/event-stream.js';
  * A non-numeric or negative value is a usage error, not a quiet fallback.
  */
 export function resolveEventsLimit(raw: string | undefined): number | undefined {
-  const value = Number(raw ?? '50');
-  if (!Number.isInteger(value) || value < 0) {
-    throw new RangeError(`Invalid --limit ${raw} — pass a whole number, or 0 for no cap.`);
+  // Digits-only, not Number(): `Number('')` and `Number('  ')` are 0, so a script
+  // passing `--limit "$UNSET_VAR"` would silently get an uncapped read instead of
+  // the usage error. Rejects '', whitespace, '-5', '1.5', and '1e3' alike.
+  const text = (raw ?? '50').trim();
+  if (!/^\d+$/.test(text)) {
+    throw new RangeError(`Invalid --limit "${raw}" — pass a whole number, or 0 for no cap.`);
   }
+  const value = Number(text);
   return value === 0 ? undefined : value;
 }
 

--- a/apps/cli/tests/events-limit.test.ts
+++ b/apps/cli/tests/events-limit.test.ts
@@ -1,0 +1,158 @@
+/**
+ * `agents events --limit` truncation tests. Drive the REAL CLI entry (via tsx)
+ * against a temp HOME seeded with a real events.jsonl, then assert on the
+ * records it returns.
+ *
+ * The bug these cover: `--limit` defaulted to 50 and was applied silently, with
+ * `--limit 0` collapsing to 50 (`0 || 50`), so there was no way to read the
+ * whole stream. Any aggregation over `--json` therefore ranked the newest 50
+ * records and reported a confidently wrong answer — measured on a real 7-day
+ * friction corpus (2135 events, 9 classes): 8 of 9 ranks wrong, counts off by
+ * ~100x, no warning.
+ *
+ * No mocking — the same code path a real invocation takes.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGE_VERSION = (JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'),
+) as { version: string }).version;
+
+const tempHomes: string[] = [];
+
+function makeTempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-evlimit-'));
+  tempHomes.push(home);
+  const systemDir = path.join(home, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: PACKAGE_VERSION }),
+  );
+  return home;
+}
+
+/**
+ * Seed `alpha` (older, more numerous) and `beta` (newest) so the two answers
+ * disagree: over the full set alpha wins 55-45; over the newest 50 beta wins
+ * 45-5. That inversion is exactly what a silent cap produces.
+ */
+const ALPHA = 55;
+const BETA = 45;
+
+function seedEvents(home: string): void {
+  const file = path.join(home, '.agents', 'events.jsonl');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const base = Date.now() - 6 * 60 * 60 * 1000;
+  const lines: string[] = [];
+  for (let i = 0; i < ALPHA; i++) {
+    lines.push(JSON.stringify({
+      ts: new Date(base + i * 1000).toISOString(),
+      event: 'pr.opened', level: 'info', module: 'alpha', command: 'alpha run',
+    }));
+  }
+  for (let i = 0; i < BETA; i++) {
+    lines.push(JSON.stringify({
+      ts: new Date(base + (ALPHA + i) * 1000).toISOString(),
+      event: 'pr.opened', level: 'info', module: 'beta', command: 'beta run',
+    }));
+  }
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+}
+
+function runEvents(home: string, args: string[]) {
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'events', ...args], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: home, SHELL: '/bin/zsh', AGENTS_EVENTS_PATH: '' },
+    encoding: 'utf-8',
+  });
+}
+
+/** Parse `--json` stdout into records, ignoring the CLI's own audit rows. */
+function seededRecords(stdout: string): Array<Record<string, unknown>> {
+  const start = stdout.indexOf('[');
+  const parsed = JSON.parse(stdout.slice(start)) as Array<Record<string, unknown>>;
+  return parsed.filter((r) => r.module === 'alpha' || r.module === 'beta');
+}
+
+function winner(records: Array<Record<string, unknown>>): string {
+  const counts = new Map<string, number>();
+  for (const r of records) counts.set(r.module as string, (counts.get(r.module as string) ?? 0) + 1);
+  return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+}
+
+afterEach(() => {
+  for (const h of tempHomes.splice(0)) {
+    try {
+      fs.rmSync(h, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+describe('agents events --limit', () => {
+  it('reads the whole stream with --limit 0 and ranks correctly', () => {
+    const home = makeTempHome();
+    seedEvents(home);
+
+    const res = runEvents(home, ['--event', 'pr.opened', '--limit', '0', '--json']);
+    expect(res.status, res.stderr).toBe(0);
+    const records = seededRecords(res.stdout);
+
+    expect(records).toHaveLength(ALPHA + BETA);
+    // The true answer: alpha is the more frequent module.
+    expect(winner(records)).toBe('alpha');
+    // Nothing was capped, so nothing is announced.
+    expect(res.stderr).not.toContain('--limit 0 for all');
+  });
+
+  it('caps at the default 50 and says so, instead of silently truncating', () => {
+    const home = makeTempHome();
+    seedEvents(home);
+
+    const res = runEvents(home, ['--event', 'pr.opened', '--json']);
+    expect(res.status, res.stderr).toBe(0);
+    const records = seededRecords(res.stdout);
+
+    expect(records.length).toBeLessThan(ALPHA + BETA);
+    // The clipped slice yields the WRONG winner — which is why the cap must be
+    // announced rather than left for the caller to discover.
+    expect(winner(records)).toBe('beta');
+    expect(res.stderr).toContain('Showing the newest 50');
+    expect(res.stderr).toContain('--limit 0 for all');
+  });
+
+  it('keeps stdout valid JSON when the cap notice fires', () => {
+    const home = makeTempHome();
+    seedEvents(home);
+
+    const res = runEvents(home, ['--event', 'pr.opened', '--json']);
+    // The notice must not contaminate the pipe: stdout parses on its own.
+    expect(() => JSON.parse(res.stdout.slice(res.stdout.indexOf('[')))).not.toThrow();
+  });
+
+  it('rejects a non-numeric --limit instead of falling back to 50', () => {
+    const home = makeTempHome();
+    seedEvents(home);
+
+    const res = runEvents(home, ['--event', 'pr.opened', '--limit', 'abc', '--json']);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain('Invalid --limit abc');
+  });
+
+  it('rejects a negative --limit', () => {
+    const home = makeTempHome();
+    seedEvents(home);
+
+    const res = runEvents(home, ['--event', 'pr.opened', '--limit', '-5', '--json']);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain('Invalid --limit');
+  });
+});

--- a/apps/cli/tests/events-limit.test.ts
+++ b/apps/cli/tests/events-limit.test.ts
@@ -144,7 +144,7 @@ describe('agents events --limit', () => {
 
     const res = runEvents(home, ['--event', 'pr.opened', '--limit', 'abc', '--json']);
     expect(res.status).toBe(2);
-    expect(res.stderr).toContain('Invalid --limit abc');
+    expect(res.stderr).toContain('Invalid --limit "abc"');
   });
 
   it('rejects a negative --limit', () => {
@@ -155,4 +155,19 @@ describe('agents events --limit', () => {
     expect(res.status).toBe(2);
     expect(res.stderr).toContain('Invalid --limit');
   });
+
+  // `--limit "$VAR"` with VAR unset is the realistic way this arrives. Number('')
+  // is 0, so a laxer parse would hand back an uncapped read — the opposite of the
+  // documented contract, and silent.
+  it.each([['empty', ''], ['whitespace', '   '], ['fractional', '1.5'], ['exponent', '1e3']])(
+    'rejects a %s --limit rather than reading uncapped',
+    (_label, value) => {
+      const home = makeTempHome();
+      seedEvents(home);
+
+      const res = runEvents(home, ['--event', 'pr.opened', '--limit', value, '--json']);
+      expect(res.status, `--limit ${JSON.stringify(value)} was accepted`).toBe(2);
+      expect(res.stderr).toContain('Invalid --limit');
+    },
+  );
 });

--- a/apps/cli/tests/events-limit.test.ts
+++ b/apps/cli/tests/events-limit.test.ts
@@ -155,4 +155,20 @@ describe('agents events --limit', () => {
     expect(res.status).toBe(2);
     expect(res.stderr).toContain('Invalid --limit');
   });
+
+  // `Number('')` and `Number('   ')` are both 0, which the cap resolver reads as
+  // "no cap". An unset shell variable — `agents events --limit "$LIMIT"` — would
+  // therefore return the entire unbounded stream with exit 0 and no notice: the
+  // same silent-wrong-answer this ticket exists to remove, in the other direction.
+  it.each([['empty', ''], ['whitespace', '   ']])(
+    'rejects an %s --limit instead of reading the whole stream unannounced',
+    (_label, value) => {
+      const home = makeTempHome();
+      seedEvents(home);
+
+      const res = runEvents(home, ['--event', 'pr.opened', '--limit', value, '--json']);
+      expect(res.status).toBe(2);
+      expect(res.stderr).toContain('Invalid --limit');
+    },
+  );
 });


### PR DESCRIPTION
**Bug fix** — `agents events --limit` silently truncates, which corrupts every aggregation built on `--json`. Linear: [RUSH-2091](https://linear.app/prix/issue/RUSH-2091)

## The bug

`apps/cli/src/commands/events.ts:109` (before):

```ts
const limit = Math.max(1, parseInt(options.limit ?? '50', 10) || 50);
```

`--limit 0` → `0 || 50` → **50**. There was no value that lifted the default cap. The cap is applied *after* filtering and *before* the caller sees anything, and nothing announced it — so a group-by over `--json` ranks the newest 50 records and reports a confidently wrong answer.

## Real run — how wrong, measured

Built a friction corpus from 7 days of live transcripts (1,511 files): **2,135 real `die()` failures, 9 classes, 59 sessions**. Ranked it from the full set and from the newest 50:

```
rank  TRUE (full 2135)             FROM newest-50
1     remote-cwd-on-add (1847)     remote-cwd-on-add (14)
2     host-device-conflict (149)   cloud-rush-needs-repo (5)   <-- differs
3     invalid-worktree-name (33)   host-device-conflict (5)    <-- differs
4     unparsable-since (21)        invalid-worktree-name (5)   <-- differs
5     invalid-status (20)          after-requires-name (5)     <-- differs
...   8 of 9 ranks wrong, counts off by ~100x, no warning
```

Installed binary vs this branch, same 30-day stream, same flags:

```
$ agents events --since 30d --limit 0 --json          # 1.20.82 (installed)
 returns 50 records

$ node --import tsx src/index.ts events --since 30d --limit 0 --json   # this branch
 returns 29649 records
```

The cap notice now fires (stderr under `--json`, so `| jq` still gets clean JSON):

```
$ agents events --since 30d --json 2>&1 >/dev/null
Showing the newest 50 — more events matched. Pass --limit 0 for all.

$ agents events --limit abc
Invalid --limit abc — pass a whole number, or 0 for no cap.     # exit 2
```

## Changes

| | File | What |
|---|---|---|
| fix | `apps/cli/src/commands/events.ts` | `resolveEventsLimit()` — `0` means no cap, non-numeric/negative exits 2. `capRecords()` — read `limit + 1` to tell a full result from a clipped one, and announce the clip. |
| test | `apps/cli/tests/events-limit.test.ts` | 5 cases driving the real CLI against a seeded temp `HOME`. Includes the wrong-ranking reproduction. |
| docs | `apps/cli/docs/06-observability.md` | `--limit 0` in the example block + why it matters before aggregating. |
| changelog | `apps/cli/.changelog/next/PR-events-limit-truncation.md` | queue fragment. |

## Verification

```
$ npx vitest run tests/events-limit.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx tsc --noEmit          # clean
$ npx vitest run tests/events-audit.test.ts tests/events-redact.test.ts
      Tests  20 passed (20)
```

The test was checked against the pre-fix code — **4 of 5 fail** there (the 5th is a regression guard on stdout staying parseable, which passes both ways):

```
× reads the whole stream with --limit 0 and ranks correctly
  AssertionError: expected [...] to have a length of 100 but got 50
× caps at the default 50 and says so, instead of silently truncating
× rejects a non-numeric --limit instead of falling back to 50
× rejects a negative --limit
```

## Why this instead of a new command

This came out of deciding whether friction metrics need a dedicated `agents friction` aggregation command. They don't — the shell does the aggregation in 187 characters of `jq`, at the same context cost as a built-in. The only thing that made the raw query path unsafe was this silent cap, which affects **every** event type, not just friction. Adding a command to route around it would have been a band-aid over the bug.
