### PR TITLE
fix(view): show Grok default model in agents view

### DIFF
--- a/apps/cli/.changelog/next/PR-1707-grok-view-default-model.md
+++ b/apps/cli/.changelog/next/PR-1707-grok-view-default-model.md
@@ -1,0 +1,11 @@
+- **`agents view` now shows Grok's default model (e.g. `grok-4.5`).** Claude,
+  Codex, Antigravity, and Kimi already filled the model column via their
+  catalogs; Grok was missing from `locateModelSource`, so
+  `resolveConfiguredModel` returned null and the column stayed blank. Grok has
+  no `settings.json` `model` field (its config is `config.toml` +
+  `models_cache.json`); the authoritative default is `grok models` →
+  `Default model: <id>`. The catalog extractor now spawns that command against
+  the version-home binary (skipping failed-download stubs) and flags the
+  default, so `agents view`, `agents view --json` (`configuredModel`), and the
+  other identity-cluster surfaces show it. Source: `apps/cli/src/lib/models.ts`,
+  `apps/cli/src/commands/models.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## 1.20.85
 
-- **`agents view` now shows Grok's default model (e.g. `grok-4.5`).** Claude,
-  Codex, Antigravity, and Kimi already filled the model column via their
-  catalogs; Grok was missing from `locateModelSource`, so
-  `resolveConfiguredModel` returned null and the column stayed blank. Grok has
-  no `settings.json` `model` field (its config is `config.toml` +
-  `models_cache.json`); the authoritative default is `grok models` →
-  `Default model: <id>`. The catalog extractor now spawns that command against
-  the version-home binary (skipping failed-download stubs) and flags the
-  default, so `agents view`, `agents view --json` (`configuredModel`), and the
-  other identity-cluster surfaces show it. Source: `apps/cli/src/lib/models.ts`,
-  `apps/cli/src/commands/models.ts`.
-
 - **`agents feed post` can now be mirrored to the systems you actually watch.**
   A post was durable but local: an operator away from every terminal never saw
   it, and the tracker that owns the work heard nothing. Declare sinks under

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 1.20.85
 
+- **`agents view` now shows Grok's default model (e.g. `grok-4.5`).** Claude,
+  Codex, Antigravity, and Kimi already filled the model column via their
+  catalogs; Grok was missing from `locateModelSource`, so
+  `resolveConfiguredModel` returned null and the column stayed blank. Grok has
+  no `settings.json` `model` field (its config is `config.toml` +
+  `models_cache.json`); the authoritative default is `grok models` →
+  `Default model: <id>`. The catalog extractor now spawns that command against
+  the version-home binary (skipping failed-download stubs) and flags the
+  default, so `agents view`, `agents view --json` (`configuredModel`), and the
+  other identity-cluster surfaces show it. Source: `apps/cli/src/lib/models.ts`,
+  `apps/cli/src/commands/models.ts`.
+
 - **`agents feed post` can now be mirrored to the systems you actually watch.**
   A post was durable but local: an operator away from every terminal never saw
   it, and the tracker that owns the work heard nothing. Declare sinks under

--- a/apps/cli/src/commands/models.ts
+++ b/apps/cli/src/commands/models.ts
@@ -22,7 +22,7 @@ import { getModelCatalog, locateModelSource } from '../lib/models.js';
 import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
 import { wrapJoined } from './inspect.js';
 
-const MODEL_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'opencode', 'cursor', 'openclaw', 'antigravity', 'kimi'];
+const MODEL_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'opencode', 'cursor', 'openclaw', 'antigravity', 'kimi', 'grok'];
 
 /**
  * Agents that don't necessarily install under ~/.agents/versions (cursor ships

--- a/apps/cli/src/lib/__tests__/models.test.ts
+++ b/apps/cli/src/lib/__tests__/models.test.ts
@@ -6,6 +6,8 @@ import {
   getModelCatalog,
   resolveModel,
   buildReasoningFlags,
+  parseGrokModelsStdout,
+  resolveConfiguredModel,
 } from '../models.js';
 import { getVersionDir, listInstalledVersions } from '../versions.js';
 
@@ -27,7 +29,7 @@ const claudeBinaryVer = listInstalledVersions('claude').find((v) =>
 // Prefer a version whose model source actually resolves on this host — partial
 // installs (e.g. ones missing the vendored binary) would otherwise short-circuit
 // the catalog tests with null catalogs.
-const firstLocatable = (agent: 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'antigravity' | 'kimi'): string | null =>
+const firstLocatable = (agent: 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'antigravity' | 'kimi' | 'grok'): string | null =>
   listInstalledVersions(agent).find((v) => locateModelSource(agent, v) !== null) ?? null;
 
 const codexVer = firstLocatable('codex');
@@ -36,6 +38,7 @@ const opencodeVer = firstLocatable('opencode');
 const openclawVer = firstLocatable('openclaw');
 const antigravityVer = firstLocatable('antigravity');
 const kimiVer = firstLocatable('kimi');
+const grokVer = firstLocatable('grok');
 
 describe('locateModelSource', () => {
   it('finds the JS bundle for Claude versions that ship one', () => {
@@ -289,6 +292,59 @@ describe('getModelCatalog (kimi)', () => {
     }
     // At most one default may be flagged (the "Default model:" line).
     expect(catalog.models.filter((m) => m.isDefault).length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('parseGrokModelsStdout', () => {
+  it('reads Default model: and * id (default) rows', () => {
+    const stdout = [
+      'You are logged in with grok.com.',
+      '',
+      'Default model: grok-4.5',
+      '',
+      'Available models:',
+      '  * grok-4.5 (default)',
+      '  grok-code-fast-1',
+      '',
+    ].join('\n');
+    const { models } = parseGrokModelsStdout(stdout);
+    expect(models.map((m) => m.id)).toEqual(['grok-4.5', 'grok-code-fast-1']);
+    expect(models.filter((m) => m.isDefault).map((m) => m.id)).toEqual(['grok-4.5']);
+  });
+
+  it('surfaces Default model: when it is missing from the row list', () => {
+    const { models } = parseGrokModelsStdout('Default model: grok-4.5\n\nAvailable models:\n');
+    expect(models).toEqual([{ id: 'grok-4.5', isDefault: true }]);
+  });
+
+  it('ignores banner lines that are not model ids', () => {
+    const { models } = parseGrokModelsStdout('You are logged in with grok.com.\nAvailable models:\n');
+    expect(models).toEqual([]);
+  });
+});
+
+describe('getModelCatalog (grok)', () => {
+  it('locates the version-home downloads binary and marks the default model', () => {
+    if (!grokVer) return;
+    const src = locateModelSource('grok', grokVer);
+    expect(src).not.toBeNull();
+    expect(src!.kind).toBe('cli');
+    expect(src!.path).toMatch(/[/\\]\.grok[/\\]downloads[/\\]grok-/);
+
+    const catalog = getModelCatalog('grok', grokVer);
+    // `grok models` may fail when offline / not signed in; skip rather than fail.
+    if (!catalog || catalog.models.length === 0) return;
+    for (const m of catalog.models) {
+      expect(m.id).toMatch(/^grok[-_]/i);
+    }
+    const defaults = catalog.models.filter((m) => m.isDefault);
+    expect(defaults.length).toBe(1);
+
+    // agents view / resolveConfiguredModel should surface that default.
+    const configured = resolveConfiguredModel('grok', grokVer);
+    expect(configured).not.toBeNull();
+    expect(configured!.model).toBe(defaults[0].id);
+    expect(configured!.source).toBe('cli-default');
   });
 });
 

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -3,9 +3,9 @@
  *
  * Each agent ships its model list differently -- Claude and Codex embed it in
  * compiled bundles/binaries, Gemini exports it from a JS module, and OpenCode/
- * Cursor/OpenClaw expose it via CLI commands. This module provides a unified
- * `getModelCatalog()` and `resolveModel()` interface over all of them, backed
- * by a file-system cache keyed on source mtime.
+ * Cursor/OpenClaw/Antigravity/Kimi/Grok expose it via CLI commands. This
+ * module provides a unified `getModelCatalog()` and `resolveModel()` interface
+ * over all of them, backed by a file-system cache keyed on source mtime.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -13,7 +13,7 @@ import * as os from 'os';
 import { execFileSync } from 'child_process';
 import type { AgentId } from './types.js';
 import chalk from 'chalk';
-import { getVersionDir, getVersionHomePath } from './versions.js';
+import { getVersionDir, getVersionHomePath, getBinaryPath } from './versions.js';
 import { getModelsCachePath } from './state.js';
 import { agentConfigDirName } from './agents.js';
 import { resolveRunDefaults } from './run-defaults.js';
@@ -258,6 +258,33 @@ export function locateModelSource(
     return null;
   }
 
+  if (agent === 'grok') {
+    // Grok ships a native binary under the version home's `.grok/downloads/`,
+    // not node_modules/.bin. Prefer a real binary over a failed-download stub
+    // (a 99-byte placeholder sometimes left beside a prior good download).
+    const preferred = getBinaryPath('grok', version);
+    if (isUsableGrokBinary(preferred)) return { path: preferred, kind: 'cli' };
+    const downloads = path.join(getVersionHomePath('grok', version), '.grok', 'downloads');
+    try {
+      const candidates = fs
+        .readdirSync(downloads)
+        .filter((e) => e.startsWith('grok-'))
+        .map((e) => path.join(downloads, e))
+        .filter(isUsableGrokBinary)
+        .sort((a, b) => {
+          try {
+            return fs.statSync(b).size - fs.statSync(a).size;
+          } catch {
+            return 0;
+          }
+        });
+      if (candidates[0]) return { path: candidates[0], kind: 'cli' };
+    } catch {
+      /* empty downloads */
+    }
+    return null;
+  }
+
   if (agent === 'cursor') {
     // cursor-agent is installed via curl script, not agents-cli. Version argument
     // is accepted for API symmetry but ignored -- cursor lives on PATH.
@@ -267,6 +294,16 @@ export function locateModelSource(
   }
 
   return null;
+}
+
+/** Real Grok binaries are ~100MB+; failed-download stubs are tens of bytes. */
+function isUsableGrokBinary(filePath: string): boolean {
+  try {
+    const st = fs.statSync(filePath);
+    return st.isFile() && st.size > 1024 * 1024;
+  } catch {
+    return false;
+  }
 }
 
 /** Search PATH for a command and return its absolute path, or null. */
@@ -753,6 +790,95 @@ function extractAntigravityCatalog(binaryPath: string): { models: ModelInfo[]; a
 }
 
 /**
+ * Parse `grok models` stdout into a catalog. Exported for unit tests.
+ *
+ * Output shape (verified 0.2.118):
+ *   You are logged in with grok.com.
+ *
+ *   Default model: grok-4.5
+ *
+ *   Available models:
+ *     * grok-4.5 (default)
+ *
+ * The `Default model:` line is authoritative; rows may also carry a leading `*`
+ * and a `(default)` flag. Grok has no `--json` on this subcommand. Settings live
+ * in `config.toml` / `models_cache.json`, not `settings.json`, so the native
+ * settings.json reader cannot surface the default — the catalog is the source
+ * that makes `resolveConfiguredModel` return a cli-default for Grok.
+ */
+export function parseGrokModelsStdout(stdout: string): { models: ModelInfo[]; aliases: Record<string, string> } {
+  // Strip ANSI in case a spinner or color codes slip through.
+  // eslint-disable-next-line no-control-regex
+  const plain = stdout.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+
+  let defaultId: string | null = null;
+  const defaultLine = plain.match(/Default model:\s*(\S+)/i);
+  if (defaultLine) defaultId = defaultLine[1];
+
+  const models: ModelInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of plain.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    // Rows: "* grok-4.5 (default)" or "grok-4.5" or "  grok-code-fast-1"
+    const m = line.match(/^\*?\s*([A-Za-z0-9][A-Za-z0-9._-]*)(?:\s+\(([^)]*)\))?\s*$/);
+    if (!m) continue;
+    const id = m[1];
+    // Real model ids are grok-* (or match the Default model: line). Skip banner words.
+    if (!/^grok[-_]/i.test(id) && id !== defaultId) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const flags = (m[2] ?? '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+    models.push({
+      id,
+      isDefault: (defaultId != null && id === defaultId) || flags.includes('default'),
+    });
+  }
+
+  // If Default model was set but did not appear as a row, still surface it.
+  if (defaultId && !seen.has(defaultId)) {
+    models.unshift({ id: defaultId, isDefault: true });
+  }
+
+  // Normalize: exactly one default when we know the Default model: id.
+  if (defaultId) {
+    for (const model of models) model.isDefault = model.id === defaultId;
+  } else if (models.length > 0 && !models.some((model) => model.isDefault)) {
+    models[0].isDefault = true;
+  }
+
+  return { models, aliases: {} };
+}
+
+/** Extract Grok's catalog via `grok models` (see parseGrokModelsStdout). */
+function extractGrokCatalog(binaryPath: string): { models: ModelInfo[]; aliases: Record<string, string> } {
+  const env = { ...process.env };
+  // Point GROK_HOME at the version home that owns this binary so auth +
+  // models_cache come from the right install, not a host ~/.grok symlink.
+  // binary: <home>/.grok/downloads/grok-<ver>-...
+  const downloadsDir = path.dirname(binaryPath);
+  if (path.basename(downloadsDir) === 'downloads') {
+    env.GROK_HOME = path.dirname(downloadsDir);
+  }
+
+  let stdout: string;
+  try {
+    stdout = execFileSync(binaryPath, ['models'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 15_000,
+      maxBuffer: 8 * 1024 * 1024,
+      env,
+    });
+  } catch {
+    return { models: [], aliases: {} };
+  }
+
+  return parseGrokModelsStdout(stdout);
+}
+
+/**
  * Extract Kimi's catalog via `kimi provider list --json`, which emits the raw
  * providers/models config. Model ids are the `models` object keys (e.g.
  * `kimi-code/kimi-for-coding`). The default is reported on a separate plain
@@ -855,6 +981,7 @@ export function getModelCatalog(agent: AgentId, version: string): ModelCatalog |
     else if (agent === 'openclaw') ({ models, aliases } = extractOpenClawCatalog(src.path));
     else if (agent === 'antigravity') ({ models, aliases } = extractAntigravityCatalog(src.path));
     else if (agent === 'kimi') ({ models, aliases } = extractKimiCatalog(src.path));
+    else if (agent === 'grok') ({ models, aliases } = extractGrokCatalog(src.path));
   }
 
   const catalog: ModelCatalog = {


### PR DESCRIPTION
## Summary

Grok rows in `agents view` left the model column blank while Claude/Codex/Antigravity already show theirs. Grok was never wired into the model catalog.

**Root cause:** `locateModelSource` had no Grok branch, so `resolveConfiguredModel` returned null. Grok also has no `settings.json` `model` field (config is `config.toml` + `models_cache.json`); the authoritative default is `grok models` → `Default model: <id>`.

**Fix:** Extract the catalog from `grok models` against the version-home binary (skip failed-download stubs), flag the default, and include Grok in `MODEL_CAPABLE_AGENTS`.

## Prototype (how we found it)

```
$ grok models
Default model: grok-4.5
Available models:
  * grok-4.5 (default)

$ agents view grok --json   # before
"configuredModel": null
```

## Verified run (after)

```
Installed Agent CLIs

  Grok (balanced) (no default)
    0.2.91  grok-4.5  zeffmuks@gmail.com      X Premium+  W: █░░░░ 2% (5d)                  1m ago  ◐ 2m ago
      /home/muqsit/.agents/.history/versions/grok/0.2.91
    0.2.82  grok-4.5  muqsitnawaz@icloud.com  X Premium+  W: █████ 100% (8h)  rate-limited  58m ago  ◐ 2m ago
      /home/muqsit/.agents/.history/versions/grok/0.2.82
```

`agents view grok --json` configuredModel:

```json
[
  {
    "version": "0.2.91",
    "configuredModel": {
      "model": "grok-4.5",
      "source": "cli-default"
    }
  },
  {
    "version": "0.2.82",
    "configuredModel": {
      "model": "grok-4.5",
      "source": "cli-default"
    }
  }
]
```

**No UI surface** — CLI-only change; run output above is the proof.

## Test plan

- [x] Unit: `parseGrokModelsStdout` (default line, missing row, banner noise)
- [x] Live: `getModelCatalog(grok)` + `resolveConfiguredModel` → `cli-default` / `grok-4.5`
- [x] E2E: `bun run src/index.ts view grok` shows `grok-4.5` beside each version
