### PR TITLE
fix(routines): spawn children from a stable cwd

### DIFF
--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -1125,7 +1125,7 @@ export function startDetached(opts: StartDetachedOptions = {}): { pid: number | 
   // and a console-close event tears it down when the launcher exits (#556).
   const child = spawn(command, args, {
     stdio: ['ignore', logFd, logFd],
-    ...backgroundSpawnOptions({ fdStdio: true }),
+    ...backgroundSpawnOptions({ cwd: os.homedir(), fdStdio: true }),
     env: opts.env ?? process.env,
   });
 

--- a/apps/cli/src/lib/platform/process.test.ts
+++ b/apps/cli/src/lib/platform/process.test.ts
@@ -43,26 +43,32 @@ describe('killTree', () => {
 });
 
 describe('backgroundSpawnOptions', () => {
+  it('always supplies an existing stable cwd', () => {
+    const options = backgroundSpawnOptions();
+    expect(path.isAbsolute(options.cwd)).toBe(true);
+    expect(fs.statSync(options.cwd).isDirectory()).toBe(true);
+  });
+
   it('uses a hidden console instead of detach on win32', () => {
     // CreateProcess ignores CREATE_NO_WINDOW under DETACHED_PROCESS, and a
     // console-less child makes every console descendant flash a visible
     // window — so on Windows the two options must never be combined.
-    expect(backgroundSpawnOptions({ platform: 'win32' })).toEqual({ detached: false, windowsHide: true });
+    expect(backgroundSpawnOptions({ platform: 'win32' })).toMatchObject({ detached: false, windowsHide: true });
   });
 
   it('detaches on win32 when stdio is fd-redirected (windowsHide cannot engage)', () => {
     // libuv skips CREATE_NO_WINDOW when any stdio fd is inherited (log-file
     // redirection), so a non-detached child would share the launcher's console
     // and die with it on console-close (#556). It must detach instead.
-    expect(backgroundSpawnOptions({ fdStdio: true, platform: 'win32' })).toEqual({
+    expect(backgroundSpawnOptions({ fdStdio: true, platform: 'win32' })).toMatchObject({
       detached: true,
       windowsHide: true,
     });
   });
 
   it('detaches into its own process group on POSIX', () => {
-    expect(backgroundSpawnOptions({ platform: 'darwin' })).toEqual({ detached: true, windowsHide: false });
-    expect(backgroundSpawnOptions({ fdStdio: true, platform: 'linux' })).toEqual({ detached: true, windowsHide: false });
+    expect(backgroundSpawnOptions({ platform: 'darwin' })).toMatchObject({ detached: true, windowsHide: false });
+    expect(backgroundSpawnOptions({ fdStdio: true, platform: 'linux' })).toMatchObject({ detached: true, windowsHide: false });
   });
 
   it('an fd-redirected background child survives its launcher console closing (#556 regression)', async () => {

--- a/apps/cli/src/lib/platform/process.ts
+++ b/apps/cli/src/lib/platform/process.ts
@@ -3,6 +3,7 @@
  */
 import { execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
+import * as os from 'os';
 import { sleepSync } from '../fs-atomic.js';
 
 /**
@@ -53,15 +54,16 @@ export function killTree(pid: number): void {
  *   sites pass their own `windowsHide` with piped stdio.
  */
 export function backgroundSpawnOptions(
-  opts: { fdStdio?: boolean; platform?: NodeJS.Platform } = {},
-): { detached: boolean; windowsHide: boolean } {
+  opts: { cwd?: string; fdStdio?: boolean; platform?: NodeJS.Platform } = {},
+): { cwd: string; detached: boolean; windowsHide: boolean } {
   const platform = opts.platform ?? process.platform;
+  const cwd = opts.cwd ?? os.homedir();
   if (platform === 'win32') {
     return opts.fdStdio
-      ? { detached: true, windowsHide: true }
-      : { detached: false, windowsHide: true };
+      ? { cwd, detached: true, windowsHide: true }
+      : { cwd, detached: false, windowsHide: true };
   }
-  return { detached: true, windowsHide: false };
+  return { cwd, detached: true, windowsHide: false };
 }
 
 /**

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
-import { archiveRoutineTranscripts, executeJob, executeJobDetached, monitorRunningJobs } from './runner.js';
+import { archiveRoutineTranscripts, executeJob, executeJobDetached, monitorRunningJobs, routineSpawnCwd } from './runner.js';
 import { getRunDir, writeRunMeta } from './routines.js';
 import type { JobConfig, RunMeta } from './routines.js';
 import { saveTask, hostsCacheDir } from './hosts/tasks.js';
@@ -25,6 +26,21 @@ function baseConfig(partial: Partial<JobConfig> = {}): JobConfig {
     ...partial,
   } as JobConfig;
 }
+
+describe('routine spawn cwd', () => {
+  it('uses the existing home directory when no repo is declared', () => {
+    const cwd = routineSpawnCwd({});
+    expect(cwd).toBe(os.homedir());
+    expect(fs.statSync(cwd).isDirectory()).toBe(true);
+  });
+
+  it('resolves owner/repo against the configured owner project root', () => {
+    expect(routineSpawnCwd(
+      { repo: 'phnx-labs/agents-cli' },
+      path.join(os.homedir(), 'src', 'github.com', 'phnx-labs'),
+    )).toBe(path.join(os.homedir(), 'src', 'github.com', 'phnx-labs', 'agents-cli'));
+  });
+});
 
 describe('runner device enforcement', () => {
   const savedId = process.env.AGENTS_SYNC_MACHINE_ID;

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -62,6 +62,7 @@ import {
 } from './rotate.js';
 import { readAuthHealth, isDeadVerdict } from './auth-health.js';
 import { machineId } from './machine-id.js';
+import { expandLocalHome, getProjectRoot } from './project-root.js';
 
 /** Result of a completed job execution, including metadata and optional report. */
 export interface RunResult {
@@ -82,6 +83,20 @@ const ROUTINE_TRANSCRIPT_SPECS: Partial<Record<AgentId, Array<{ root: string[]; 
   claude: [{ root: ['.claude', 'projects'], ext: '.jsonl' }],
   codex: [{ root: ['.codex', 'sessions'], ext: '.jsonl' }],
 };
+
+/** Stable working directory for routine children, independent of the daemon's launch cwd. */
+export function routineSpawnCwd(
+  config: Pick<JobConfig, 'repo'>,
+  configuredRoot: string | undefined = getProjectRoot(),
+): string {
+  if (!config.repo) return os.homedir();
+  const [owner, repo] = config.repo.split('/');
+  if (configuredRoot) {
+    const root = path.resolve(expandLocalHome(configuredRoot));
+    if (path.basename(root) === owner) return path.join(root, repo);
+  }
+  return path.join(os.homedir(), 'src', 'github.com', owner, repo);
+}
 
 /** Build the full CLI argv for executing a job, applying mode, model, and permission flags. */
 export function buildJobCommand(config: JobConfig, resolvedPrompt: string): string[] {
@@ -526,6 +541,7 @@ function spawnJobAttempt(
   attemptLogPath: string,
   timeoutMs: number,
   combinedLogPath?: string,
+  cwd: string = os.homedir(),
 ): Promise<SpawnAttemptResult> {
   // Isolate this attempt's output so detectRateLimit never sees prior attempts.
   fs.writeFileSync(attemptLogPath, '', { mode: 0o600 });
@@ -533,7 +549,7 @@ function spawnJobAttempt(
   return new Promise((resolve) => {
     const child = spawn(cmd[0], cmd.slice(1), {
       stdio: ['ignore', stdoutFd, stdoutFd],
-      ...backgroundSpawnOptions({ fdStdio: true }),
+      ...backgroundSpawnOptions({ cwd, fdStdio: true }),
       env,
     });
 
@@ -815,7 +831,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
     const remaining = Math.max(1_000, timeoutMs - (Number.isFinite(elapsed) ? elapsed : 0));
 
     const attemptLogPath = path.join(runDir, `stdout.attempt-${i}.log`);
-    const attempt = await spawnJobAttempt(cmd, spawnEnv, attemptLogPath, remaining, stdoutPath);
+    const attempt = await spawnJobAttempt(cmd, spawnEnv, attemptLogPath, remaining, stdoutPath, routineSpawnCwd(config));
     meta.pid = attempt.pid;
     writeRunMeta(meta);
 
@@ -1103,7 +1119,7 @@ async function executeCommandJobForeground(config: JobConfig): Promise<RunResult
   const result = await new Promise<{ exitCode: number | null; status: 'completed' | 'failed' | 'timeout'; error?: string }>((resolve) => {
     const child = spawn(cmd[0], cmd.slice(1), {
       stdio: ['ignore', stdoutFd, stdoutFd],
-      ...backgroundSpawnOptions({ fdStdio: true }),
+      ...backgroundSpawnOptions({ cwd: routineSpawnCwd(config), fdStdio: true }),
       env,
     });
 
@@ -1295,7 +1311,7 @@ export async function executeJobDetached(config: JobConfig, hooks?: RoutineHooks
 
   const child = spawn(cmd[0], cmd.slice(1), {
     stdio: ['ignore', stdoutFd, stdoutFd],
-    ...backgroundSpawnOptions({ fdStdio: true }),
+    ...backgroundSpawnOptions({ cwd: routineSpawnCwd(config), fdStdio: true }),
     env: spawnEnv,
   });
 
@@ -1392,7 +1408,7 @@ function executeCommandJobDetached(config: JobConfig, hooks?: RoutineHooks): Run
 
   const child = spawn(cmd[0], cmd.slice(1), {
     stdio: ['ignore', stdoutFd, stdoutFd],
-    ...backgroundSpawnOptions({ fdStdio: true }),
+    ...backgroundSpawnOptions({ cwd: routineSpawnCwd(config), fdStdio: true }),
     env,
   });
 


### PR DESCRIPTION
Fixes routine and daemon detached spawns inheriting a deleted daemon working directory. No UI surface.

## What changed

- `backgroundSpawnOptions` now always supplies a stable cwd, defaulting to the user's home directory.
- Routine children resolve `repo: owner/name` to the configured owner project root, otherwise `~/src/github.com/owner/name`; routines without `repo:` use the home directory.
- All four local routine spawn paths pass the resolved cwd, and daemon self-start explicitly re-execs from the home directory.

## Before: deleted cwd kills the child

The pre-fix spawn shape (detached, no explicit cwd) was launched after its parent cwd was removed:

```json
{"elapsedMs":17,"exitCode":1,"stderr":"Error: ENOENT: no such file or directory, uv_cwd ... code: 'ENOENT', syscall: 'uv_cwd'"}
```

## After: child starts from a stable cwd

The same deleted-parent-cwd reproduction using the built `backgroundSpawnOptions()` result:

```json
{"elapsedMs":24,"exitCode":0,"stdout":"/home/muqsit","stderr":""}
```

## Verification

```text
$ bun run test -- src/lib/runner.test.ts src/lib/platform/process.test.ts
Test Files  2 passed (2)
Tests  24 passed (24)

$ bun run build
$ tsc ...
exit 0
```

The full suite reached `591 passed` files / `7,735 passed` tests, with 11 environment-dependent failures caused by this sandbox's read-only `/home/muqsit` and npm cache, an occupied browser test port, and the live Codex model catalog. The changed runner/process tests and TypeScript build are green.
