### PR TITLE
feat(factory): add read-only snapshot command

### DIFF
--- a/apps/cli/src/commands/factory.ts
+++ b/apps/cli/src/commands/factory.ts
@@ -13,6 +13,7 @@ import { homedir } from 'os';
 import { betaEnableHint, isBetaEnabled } from '../lib/beta.js';
 import { insertTask } from '../lib/cloud/store.js';
 import { emit } from '../lib/events.js';
+import { buildFactorySnapshot, type FactorySnapshot } from '../lib/factory/snapshot.js';
 
 
 function requireFactoryUrl(): string {
@@ -70,14 +71,29 @@ export function registerFactoryCommands(program: Command): void {
 Examples:
   agents factory submit PROJ-123
   agents factory submit https://linear.app/example/issue/PROJ-123
+  agents factory snapshot --json
 `);
 
-  factory.hook('preAction', () => {
-    if (enabled) return;
+  factory.hook('preAction', (_thisCommand, actionCommand) => {
+    // Foreman must be able to read its tick input before any beta-gated action.
+    if (enabled || actionCommand.name() === 'snapshot') return;
     console.error(chalk.red('agents factory is in beta.'));
     console.error(chalk.gray(betaEnableHint('factory')));
     process.exit(1);
   });
+
+  factory
+    .command('snapshot')
+    .description('Read the complete Software Factory state without dispatching or changing it.')
+    .option('--json', 'Output the stable machine-readable snapshot')
+    .action(async (opts: { json?: boolean }) => {
+      const snapshot = await buildFactorySnapshot();
+      if (opts.json) {
+        console.log(JSON.stringify(snapshot, null, 2));
+        return;
+      }
+      renderSnapshot(snapshot);
+    });
 
   factory
     .command('submit <linear-ref>')
@@ -114,4 +130,14 @@ Examples:
       console.log(`  execution    ${result.cloud_execution_id}`);
       console.log(`  tail output  agents cloud logs ${result.cloud_execution_id}`);
     });
+}
+
+function renderSnapshot(snapshot: FactorySnapshot): void {
+  console.log(chalk.bold(`Factory snapshot ${snapshot.generatedAt}`));
+  console.log(`  sessions     ${snapshot.sessions.length}`);
+  console.log(`  open PRs     ${snapshot.prs.length}`);
+  console.log(`  devices      ${snapshot.devices.length}`);
+  for (const [project, queue] of Object.entries(snapshot.queues)) {
+    console.log(`  ${project.padEnd(12)} todo ${queue.todo} · in progress ${queue.inProgress} · blocked ${queue.blocked}`);
+  }
 }

--- a/apps/cli/src/lib/factory/snapshot.test.ts
+++ b/apps/cli/src/lib/factory/snapshot.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildFactorySnapshot,
+  FACTORY_PROJECTS,
+  parseDevices,
+  parsePullRequests,
+  queueCounts,
+  readFactoryConfig,
+} from './snapshot.js';
+
+const dirs: string[] = [];
+function home(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'factory-snapshot-'));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('factory snapshot', () => {
+  it('uses documented defaults without creating factory.yml', () => {
+    const dir = home();
+    expect(readFactoryConfig(dir)).toMatchObject({ source: 'default', ceiling: 4, max_dispatch_per_tick: 2 });
+    expect(fs.existsSync(path.join(dir, '.agents', 'factory.yml'))).toBe(false);
+  });
+
+  it('reads the documented factory.yml shape', () => {
+    const dir = home();
+    fs.mkdirSync(path.join(dir, '.agents'));
+    fs.writeFileSync(path.join(dir, '.agents', 'factory.yml'), [
+      'ceiling: 8',
+      'max_dispatch_per_tick: 3',
+      'per_project:',
+      '  Agents CLI: { weight: 2, cap: 4 }',
+      'idle_boxes: [worker-1]',
+      'digest: { times: ["09:00"], tz: UTC }',
+    ].join('\n'));
+    expect(readFactoryConfig(dir)).toEqual({
+      source: 'file', ceiling: 8, max_dispatch_per_tick: 3,
+      per_project: { 'Agents CLI': { weight: 2, cap: 4 } },
+      idle_boxes: ['worker-1'], digest: { times: ['09:00'], tz: 'UTC' },
+    });
+  });
+
+  it('normalizes queue, pull-request, and device read models', () => {
+    expect(queueCounts(
+      { count: 2 },
+      { issues: [
+        { state: { name: 'Doing', type: 'started' } },
+        { state: { name: 'Blocked', type: 'started' } },
+      ] },
+    )).toEqual({ todo: 2, inProgress: 1, blocked: 1 });
+    expect(parsePullRequests('phnx-labs/agents-cli', [{
+      number: 7, reviewDecision: 'APPROVED', mergeable: 'MERGEABLE',
+      statusCheckRollup: [{ conclusion: 'SUCCESS' }],
+    }])).toEqual([{ repo: 'phnx-labs/agents-cli', number: 7, ci: 'passing', review: 'approved', mergeable: 'mergeable' }]);
+    expect(parseDevices([{ name: 'box', loadPercent: 12 }])).toEqual([{ name: 'box', load: 12, idle: true }]);
+  });
+
+  it('returns every stable section without writing to the home directory', async () => {
+    const dir = home();
+    const calls: string[] = [];
+    const before = fs.readdirSync(dir);
+    const snapshot = await buildFactorySnapshot({
+      home: dir,
+      now: () => new Date('2026-08-02T12:00:00.000Z'),
+      activeSessions: async () => [],
+      readAuth: () => ({ 'box:claude:1.0.0': { verdict: 'live', checkedAt: 1 } }),
+      readDeviceStats: () => ({ box: { host: 'box', reachable: true, loadPercent: 10, fetchedAt: 1 } }),
+      run: async (file, args) => {
+        calls.push([file, ...args].join(' '));
+        if (file === 'gh') return '[]';
+        if (file === 'agents') return '[{"name":"box"}]';
+        return args.includes('todo') ? '{"count":1,"issues":[]}' : '{"count":0,"issues":[]}';
+      },
+    });
+    expect(Object.keys(snapshot)).toEqual(['generatedAt', 'sessions', 'queues', 'prs', 'devices', 'recentRuns', 'auth', 'config']);
+    expect(Object.keys(snapshot.queues)).toEqual(FACTORY_PROJECTS.map((project) => project.name));
+    expect(snapshot.auth).toEqual({ claude: 'live' });
+    expect(snapshot.devices).toEqual([{ name: 'box', load: 10, idle: true }]);
+    expect(calls).toContain('agents devices list --json');
+    expect(fs.readdirSync(dir)).toEqual(before);
+  });
+});

--- a/apps/cli/src/lib/factory/snapshot.ts
+++ b/apps/cli/src/lib/factory/snapshot.ts
@@ -1,0 +1,235 @@
+/**
+ * Read-only Software Factory state aggregation.
+ *
+ * ~/.agents/factory.yml example:
+ *
+ * ceiling: 4
+ * max_dispatch_per_tick: 2
+ * per_project:
+ *   Agents CLI: { weight: 2, cap: 2 }
+ * idle_boxes: [yosemite-m1, yosemite-m2]
+ * digest: { times: ["09:00", "17:00"], tz: America/Los_Angeles }
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile as execFileCallback } from 'child_process';
+import { promisify } from 'util';
+import * as yaml from 'yaml';
+import { getActiveSessions, type ActiveSession } from '../session/active.js';
+import { serializeActiveSessionsForJson } from '../../commands/sessions.js';
+import { readAuthHealthCache, type AuthVerdict } from '../auth-health.js';
+import { readStatsCache } from '../devices/stats-cache.js';
+
+const execFile = promisify(execFileCallback);
+
+export const FACTORY_PROJECTS = [
+  { name: 'Prix', repo: 'phnx-labs/prix' },
+  { name: 'Rush App', repo: 'phnx-labs/rush' },
+  { name: 'Rush CLI', repo: 'phnx-labs/rush-cli' },
+  { name: 'Agents CLI', repo: 'phnx-labs/agents-cli' },
+  { name: 'Linear CLI', repo: 'phnx-labs/linear-cli' },
+] as const;
+
+export interface FactoryConfig {
+  source: 'default' | 'file';
+  ceiling: number;
+  max_dispatch_per_tick: number;
+  per_project: Record<string, { weight: number; cap: number }>;
+  idle_boxes: string[];
+  digest: { times: string[]; tz: string };
+}
+
+export interface FactorySnapshot {
+  generatedAt: string;
+  sessions: ReturnType<typeof serializeActiveSessionsForJson>;
+  queues: Record<string, { todo: number; inProgress: number; blocked: number }>;
+  prs: Array<{ repo: string; number: number; ci: string; review: string; mergeable: string }>;
+  devices: Array<{ name: string; load: number | null; idle: boolean }>;
+  recentRuns: Array<{ routine: string; status: string; durationMs: number | null }>;
+  auth: { claude: AuthVerdict | null };
+  config: FactoryConfig;
+}
+
+export interface SnapshotDependencies {
+  home: string;
+  now: () => Date;
+  activeSessions: () => Promise<ActiveSession[]>;
+  run: (file: string, args: string[]) => Promise<string>;
+  readAuth: () => ReturnType<typeof readAuthHealthCache>;
+  readDeviceStats: () => ReturnType<typeof readStatsCache>;
+}
+
+const defaults = (): FactoryConfig => ({
+  source: 'default',
+  ceiling: 4,
+  max_dispatch_per_tick: 2,
+  per_project: {},
+  idle_boxes: [],
+  digest: { times: [], tz: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC' },
+});
+
+export function readFactoryConfig(home: string): FactoryConfig {
+  const file = path.join(home, '.agents', 'factory.yml');
+  if (!fs.existsSync(file)) return defaults();
+  const raw = yaml.parse(fs.readFileSync(file, 'utf8')) as Partial<Omit<FactoryConfig, 'source'>> | null;
+  if (!raw || typeof raw !== 'object') throw new Error(`${file} must contain a YAML mapping`);
+  const base = defaults();
+  return {
+    source: 'file',
+    ceiling: integer(raw.ceiling ?? base.ceiling, 'ceiling'),
+    max_dispatch_per_tick: integer(raw.max_dispatch_per_tick ?? base.max_dispatch_per_tick, 'max_dispatch_per_tick'),
+    per_project: parseProjectConfig(raw.per_project),
+    idle_boxes: stringArray(raw.idle_boxes, 'idle_boxes'),
+    digest: raw.digest ? {
+      times: stringArray(raw.digest.times, 'digest.times'),
+      tz: typeof raw.digest.tz === 'string' ? raw.digest.tz : base.digest.tz,
+    } : base.digest,
+  };
+}
+
+function integer(value: unknown, name: string): number {
+  if (!Number.isInteger(value) || (value as number) < 0) throw new Error(`factory.yml ${name} must be a non-negative integer`);
+  return value as number;
+}
+
+function stringArray(value: unknown, name: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) throw new Error(`factory.yml ${name} must be a string array`);
+  return value;
+}
+
+function parseProjectConfig(value: unknown): FactoryConfig['per_project'] {
+  if (value === undefined) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('factory.yml per_project must be a mapping');
+  return Object.fromEntries(Object.entries(value).map(([name, item]) => {
+    const record = item as Record<string, unknown>;
+    return [name, { weight: integer(record?.weight, `per_project.${name}.weight`), cap: integer(record?.cap, `per_project.${name}.cap`) }];
+  }));
+}
+
+function json(text: string): unknown {
+  return JSON.parse(text);
+}
+
+function issueCount(payload: unknown): number {
+  if (Array.isArray(payload)) return payload.length;
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    if (typeof record.count === 'number') return record.count;
+    if (Array.isArray(record.issues)) return record.issues.length;
+  }
+  return 0;
+}
+
+export function queueCounts(todoPayload: unknown, openPayload: unknown): FactorySnapshot['queues'][string] {
+  const issues = openPayload && typeof openPayload === 'object' && Array.isArray((openPayload as Record<string, unknown>).issues)
+    ? (openPayload as { issues: Array<Record<string, unknown>> }).issues : [];
+  const blocked = issues.filter((issue) => {
+    const state = issue.state && typeof issue.state === 'object' ? issue.state as Record<string, unknown> : {};
+    const labels = issue.labels && typeof issue.labels === 'object' && Array.isArray((issue.labels as Record<string, unknown>).nodes)
+      ? (issue.labels as { nodes: Array<Record<string, unknown>> }).nodes : [];
+    return String(state.name ?? '').toLowerCase().includes('block') || labels.some((label) => String(label.name ?? '').toLowerCase() === 'blocked');
+  }).length;
+  const inProgress = issues.filter((issue) => {
+    const state = issue.state && typeof issue.state === 'object' ? issue.state as Record<string, unknown> : {};
+    return String(state.type ?? '').toLowerCase() === 'started' && !String(state.name ?? '').toLowerCase().includes('block');
+  }).length;
+  return { todo: issueCount(todoPayload), inProgress, blocked };
+}
+
+export function parsePullRequests(repo: string, payload: unknown): FactorySnapshot['prs'] {
+  if (!Array.isArray(payload)) return [];
+  return payload.map((raw) => {
+    const pr = raw as Record<string, unknown>;
+    const checks = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup as Array<Record<string, unknown>> : [];
+    const states = checks.map((check) => String(check.conclusion ?? check.state ?? check.status ?? '').toUpperCase());
+    const ci = states.some((s) => ['FAILURE', 'ERROR', 'CANCELLED', 'TIMED_OUT'].includes(s)) ? 'failing'
+      : states.some((s) => ['', 'PENDING', 'QUEUED', 'IN_PROGRESS'].includes(s)) ? 'pending'
+        : states.length > 0 ? 'passing' : 'none';
+    return {
+      repo,
+      number: Number(pr.number),
+      ci,
+      review: String(pr.reviewDecision ?? 'none').toLowerCase(),
+      mergeable: String(pr.mergeable ?? 'unknown').toLowerCase(),
+    };
+  });
+}
+
+export function parseDevices(payload: unknown, cached: ReturnType<typeof readStatsCache> = {}): FactorySnapshot['devices'] {
+  const rows = Array.isArray(payload) ? payload : [];
+  return rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    const name = String(row.name ?? row.host ?? '');
+    const stats = row.stats && typeof row.stats === 'object' ? row.stats as Record<string, unknown> : cached[name] as unknown as Record<string, unknown> ?? row;
+    const candidate = stats.loadPercent ?? stats.load ?? stats.loadPct;
+    const load = typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : null;
+    return { name, load, idle: row.idle === true || (load !== null && load < 20) };
+  }).filter((row) => row.name.length > 0);
+}
+
+export function readRecentRuns(home: string, limit = 3): FactorySnapshot['recentRuns'] {
+  const root = path.join(home, '.agents', '.history', 'runs');
+  if (!fs.existsSync(root)) return [];
+  const found: Array<FactorySnapshot['recentRuns'][number] & { mtime: number }> = [];
+  for (const routine of fs.readdirSync(root)) {
+    const routineDir = path.join(root, routine);
+    if (!fs.statSync(routineDir).isDirectory()) continue;
+    const routineRuns: typeof found = [];
+    for (const run of fs.readdirSync(routineDir)) {
+      const file = path.join(routineDir, run, 'meta.json');
+      if (!fs.existsSync(file)) continue;
+      try {
+        const meta = JSON.parse(fs.readFileSync(file, 'utf8')) as Record<string, unknown>;
+        const started = Date.parse(String(meta.startedAt ?? meta.createdAt ?? ''));
+        const ended = Date.parse(String(meta.finishedAt ?? meta.completedAt ?? meta.updatedAt ?? ''));
+        const duration = typeof meta.durationMs === 'number' ? meta.durationMs : Number.isFinite(started) && Number.isFinite(ended) ? ended - started : null;
+        routineRuns.push({ routine, status: String(meta.status ?? 'unknown'), durationMs: duration, mtime: fs.statSync(file).mtimeMs });
+      } catch { /* A concurrently-written or malformed run is not a completed outcome. */ }
+    }
+    found.push(...routineRuns.sort((a, b) => b.mtime - a.mtime).slice(0, limit));
+  }
+  return found.sort((a, b) => b.mtime - a.mtime).map(({ mtime: _, ...run }) => run);
+}
+
+function latestClaudeVerdict(entries: ReturnType<typeof readAuthHealthCache>): AuthVerdict | null {
+  return Object.entries(entries)
+    .filter(([key]) => key.split(':').includes('claude'))
+    .map(([, value]) => value)
+    .sort((a, b) => b.checkedAt - a.checkedAt)[0]?.verdict ?? null;
+}
+
+export async function buildFactorySnapshot(overrides: Partial<SnapshotDependencies> = {}): Promise<FactorySnapshot> {
+  const deps: SnapshotDependencies = {
+    home: os.homedir(),
+    now: () => new Date(),
+    activeSessions: () => getActiveSessions(),
+    run: async (file, args) => (await execFile(file, args, { maxBuffer: 10 * 1024 * 1024 })).stdout,
+    readAuth: readAuthHealthCache,
+    readDeviceStats: readStatsCache,
+    ...overrides,
+  };
+  const linear = path.join(deps.home, '.agents', 'skills', 'linear', 'scripts', 'linear');
+  const safeRun = async (file: string, args: string[]): Promise<unknown> => {
+    try { return json(await deps.run(file, args)); } catch { return null; }
+  };
+
+  const sessionsPromise = deps.activeSessions().then(serializeActiveSessionsForJson);
+  const queuePromise = Promise.all(FACTORY_PROJECTS.map(async ({ name }) => {
+    const query = (status: string) => safeRun(linear, ['tasks', '--project', name, '--label', 'pilot', '--status', status, '--cycle', 'all', '--all', '--json']);
+    const [todo, open] = await Promise.all([query('todo'), query('open')]);
+    return [name, queueCounts(todo, open)] as const;
+  })).then(Object.fromEntries);
+  const prsPromise = Promise.all(FACTORY_PROJECTS.map(async ({ repo }) => parsePullRequests(repo, await safeRun('gh', ['pr', 'list', '--repo', repo, '--state', 'open', '--json', 'number,title,statusCheckRollup,reviewDecision,mergeable'])))).then((rows) => rows.flat());
+  // `devices list --json` is the registry's read-only JSON surface. Load comes
+  // from the daemon-warmed cache so snapshot never probes or writes reachability.
+  const devicesPromise = safeRun('agents', ['devices', 'list', '--json']).then((payload) => parseDevices(payload, deps.readDeviceStats()));
+
+  const [sessions, queues, prs, devices] = await Promise.all([sessionsPromise, queuePromise, prsPromise, devicesPromise]);
+  return {
+    generatedAt: deps.now().toISOString(), sessions, queues, prs, devices,
+    recentRuns: readRecentRuns(deps.home), auth: { claude: latestClaudeVerdict(deps.readAuth()) },
+    config: readFactoryConfig(deps.home),
+  };
+}


### PR DESCRIPTION
Adds the read-only JSON model the Foreman consumes each tick.

## What changed

- Adds `agents factory snapshot --json` with the stable sessions, Linear queues, PRs, devices, recent runs, Claude auth, and factory config sections.
- Reads live sessions through `getActiveSessions()` and `serializeActiveSessionsForJson()`.
- Reads the fleet registry and daemon-warmed load cache without probing devices or writing reachability.
- Documents and validates `~/.agents/factory.yml`; absent config reports `source: "default"`, `ceiling: 4`, and `max_dispatch_per_tick: 2`.
- Keeps `snapshot` callable as the Foreman read path when mutating Factory verbs remain beta-gated.

## Installed-artifact run

No UI surface: this is a JSON CLI read model. I installed the branch into an isolated global prefix, then ran `agents factory snapshot --json | jq`. Session details, device names, and routine names are redacted because this is a public repository.

```json
{
  "generatedAt": "2026-08-02T10:42:07.362Z",
  "sections": ["auth", "config", "devices", "generatedAt", "prs", "queues", "recentRuns", "sessions"],
  "sessionCount": 1,
  "queues": {
    "Prix": { "todo": 0, "inProgress": 0, "blocked": 0 },
    "Rush App": { "todo": 0, "inProgress": 0, "blocked": 0 },
    "Rush CLI": { "todo": 0, "inProgress": 0, "blocked": 0 },
    "Agents CLI": { "todo": 0, "inProgress": 1, "blocked": 0 },
    "Linear CLI": { "todo": 0, "inProgress": 0, "blocked": 0 }
  },
  "samplePr": { "repo": "phnx-labs/agents-cli", "number": 1709, "ci": "pending", "review": "", "mergeable": "mergeable" },
  "deviceCount": 28,
  "sampleReachableDevice": { "name": "[redacted]", "load": 10.9, "idle": true },
  "recentRuns": "[redacted; real statuses included completed and running]",
  "auth": { "claude": "live" },
  "config": {
    "source": "default",
    "ceiling": 4,
    "max_dispatch_per_tick": 2,
    "per_project": {},
    "idle_boxes": [],
    "digest": { "times": [], "tz": "America/Los_Angeles" }
  }
}
```

The before/after checks were empty for:

```text
diff ~/.agents git status: no output
diff ~/.agents/.history/sessions/by-pid SHA-256: no output
diff .fleet-stats.json and .auth-health.json SHA-256: no output
```

## Verification

```text
$ bun run test src/lib/factory/snapshot.test.ts
Test Files  1 passed (1)
Tests  4 passed (4)

$ bun run build
$ tsc ...
exit 0
```

The broader checkout suite was also attempted; unrelated environment-dependent tests fail because `claude@2.1.219` is absent on this worker and unrelated permission tests cannot write their fixtures. The snapshot test file and TypeScript build are green.
