### PR TITLE
feat(cli): point-of-use friction events + teams instrumentation

### DIFF
--- a/apps/cli/.changelog/next/PR-1715-friction-events.md
+++ b/apps/cli/.changelog/next/PR-1715-friction-events.md
@@ -1,0 +1,8 @@
+- **Point-of-use friction events for `agents teams` failures.** The CLI's `die()`
+  chokepoints in `teams` now emit a structured `friction` event (`surface`,
+  `failureId`, `error`) before exiting, so the nightly factory-metrics routine can
+  rank recurring failures without re-parsing transcripts. A hidden
+  `agents _internal friction` recorder lets shell guard hooks (git-guard, rm-guard,
+  large-file-add-guard) self-report blocks into the same stream. Source:
+  `apps/cli/src/lib/events.ts`, `apps/cli/src/lib/format.ts`,
+  `apps/cli/src/commands/teams.ts`, `apps/cli/src/index.ts`.

--- a/apps/cli/src/commands/teams.test.ts
+++ b/apps/cli/src/commands/teams.test.ts
@@ -95,7 +95,7 @@ function run(
   args: string[],
   setup?: (home: string) => void,
   timeout = 10_000,
-): { stdout: string; stderr: string; status: number | null; error?: Error } {
+): { stdout: string; stderr: string; status: number | null; error?: Error; home: string } {
   const home = guardedHome();
   setup?.(home);
   const r = spawnSync('bun', [INDEX, ...args], {
@@ -107,9 +107,12 @@ function run(
       AGENTS_NO_UPDATE_CHECK: '1',
       AGENTS_NO_USAGE_TRACK: '1',
       AGENTS_SKIP_MIGRATION: '1',
+      // Vitest's global setup redirects the real log; point the spawned CLI at
+      // this test home's log so assertions read the right file.
+      AGENTS_EVENTS_PATH: path.join(home, '.agents', 'events.jsonl'),
     },
   });
-  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status, error: r.error };
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status, error: r.error, home };
 }
 
 describe('teams list output modes', () => {
@@ -162,5 +165,19 @@ describe('teams list output modes', () => {
       agent_count: 1,
       running: 1,
     });
+  });
+
+  it('emits a friction event when teams add --remote-cwd is rejected', () => {
+    const { status, home } = run(['teams', 'add', 't1', 'claude', 'task', '--remote-cwd', '/tmp/x']);
+
+    expect(status).toBe(1);
+    const eventsPath = path.join(home, '.agents', 'events.jsonl');
+    expect(fs.existsSync(eventsPath)).toBe(true);
+    const lines = fs.readFileSync(eventsPath, 'utf-8').trim().split('\n');
+    const friction = lines.map((l) => JSON.parse(l)).find((r) => r.event === 'friction');
+    expect(friction).toBeDefined();
+    expect(friction.surface).toBe('teams');
+    expect(friction.failureId).toBe('remote-cwd-on-add');
+    expect(friction.error).toContain('--remote-cwd');
   });
 });

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -7,7 +7,7 @@
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
-import { die, relTime, truncate, isJsonMode, padRight } from '../lib/format.js';
+import { die, dieFriction, relTime, truncate, isJsonMode, padRight } from '../lib/format.js';
 import * as fs from 'fs/promises';
 import { addHostOption } from '../lib/hosts/option.js';
 import * as path from 'path';
@@ -276,11 +276,13 @@ function parseTeammate(spec: string): {
         profileName: profile.name,
       };
     } catch (err) {
-      die(`Profile '${name}' is malformed: ${(err as Error).message}`);
+      dieFriction('teams', 'profile-malformed', `Profile '${name}' is malformed: ${(err as Error).message}`);
     }
   }
 
-  die(
+  dieFriction(
+    'teams',
+    'unknown-teammate',
     `Unknown teammate '${spec}'. Available agents: ${VALID_AGENTS.join(', ')}.\n` +
       `  Use 'claude', 'kimi@latest', 'kimi@0.19.2' (a version from 'agents view'), or a profile name.`
   );
@@ -1327,7 +1329,7 @@ export function registerTeamsCommands(program: Command): void {
         const want = opts.status.toLowerCase();
         const validStatuses = ['working', 'done', 'failed', 'empty'];
         if (!validStatuses.includes(want)) {
-          die(`Invalid --status '${opts.status}'. Use one of: ${validStatuses.join(', ')}`);
+          dieFriction('teams', 'invalid-status-filter', `Invalid --status '${opts.status}'. Use one of: ${validStatuses.join(', ')}`);
         }
         rows = rows.filter((row) => classifyTeamStatus(row.team) === want);
       }
@@ -1335,12 +1337,12 @@ export function registerTeamsCommands(program: Command): void {
       // --- --since / --until: filter by activity window ---
       if (opts.since) {
         const cutoff = parseTimeFilter(opts.since);
-        if (!cutoff) die(`Could not parse --since '${opts.since}'`);
+        if (!cutoff) dieFriction('teams', 'invalid-since-filter', `Could not parse --since '${opts.since}'`);
         rows = rows.filter((row) => new Date(row.team.modified_at).getTime() >= cutoff);
       }
       if (opts.until) {
         const cutoff = parseTimeFilter(opts.until);
-        if (!cutoff) die(`Could not parse --until '${opts.until}'`);
+        if (!cutoff) dieFriction('teams', 'invalid-until-filter', `Could not parse --until '${opts.until}'`);
         rows = rows.filter((row) => new Date(row.team.modified_at).getTime() <= cutoff);
       }
 
@@ -1410,13 +1412,17 @@ export function registerTeamsCommands(program: Command): void {
           if (name.toLowerCase() === machineId()) continue;
           const host = await resolveHost(name);
           if (!host) {
-            die(
+            dieFriction(
+              'teams',
+              'pool-device-not-resolvable',
               `Couldn't resolve pool device "${name}". Register it with \`agents devices\`, ` +
                 `enroll it with \`agents hosts add ${name}\`, or pass user@host.`,
             );
           }
           if (remoteShellFor(host.os ?? resolveRemoteOsSync(host.name)) === 'powershell') {
-            die(
+            dieFriction(
+              'teams',
+              'pool-device-windows-unsupported',
               `Distributed teams on Windows device "${host.name}" are not supported yet — ` +
                 `the teams remote monitor is POSIX-only. Use a Linux/macOS device.`,
             );
@@ -1460,7 +1466,7 @@ export function registerTeamsCommands(program: Command): void {
           console.log(chalk.gray(`  agents teams add ${team} claude "your task here"`));
         }
       } catch (err) {
-        die((err as Error).message);
+        dieFriction('teams', 'create-failed', (err as Error).message);
       }
     });
 
@@ -1498,19 +1504,19 @@ export function registerTeamsCommands(program: Command): void {
       // silently ignoring it — see remoteCwdOnAddError. `!== undefined` so even an
       // explicit empty value (`--remote-cwd ""`) is rejected, not silently dropped.
       if (opts.remoteCwd !== undefined) {
-        die(remoteCwdOnAddError(team));
+        dieFriction('teams', 'remote-cwd-on-add', remoteCwdOnAddError(team));
       }
       if (!(VALID_MODES as readonly string[]).includes(opts.mode)) {
-        die(`Invalid mode '${opts.mode}'. Use one of: ${VALID_MODES.join(', ')}`);
+        dieFriction('teams', 'invalid-mode', `Invalid mode '${opts.mode}'. Use one of: ${VALID_MODES.join(', ')}`);
       }
       if (!(VALID_EFFORTS as readonly string[]).includes(opts.effort)) {
-        die(`Invalid effort '${opts.effort}'. Use one of: ${VALID_EFFORTS.join(', ')}`);
+        dieFriction('teams', 'invalid-effort', `Invalid effort '${opts.effort}'. Use one of: ${VALID_EFFORTS.join(', ')}`);
       }
 
       let taskType: TaskType | null = null;
       if (opts.taskType) {
         if (!(VALID_TASK_TYPES as readonly string[]).includes(opts.taskType)) {
-          die(`Invalid task-type '${opts.taskType}'. Use one of: ${VALID_TASK_TYPES.join(', ')}`);
+          dieFriction('teams', 'invalid-task-type', `Invalid task-type '${opts.taskType}'. Use one of: ${VALID_TASK_TYPES.join(', ')}`);
         }
         taskType = opts.taskType as TaskType;
       }
@@ -1518,11 +1524,11 @@ export function registerTeamsCommands(program: Command): void {
       let cloudProviderId: CloudProviderId | null = null;
       if (opts.cloud) {
         if (!(VALID_CLOUD_PROVIDERS as readonly string[]).includes(opts.cloud)) {
-          die(`Invalid cloud provider '${opts.cloud}'. Use one of: ${VALID_CLOUD_PROVIDERS.join(', ')}`);
+          dieFriction('teams', 'invalid-cloud-provider', `Invalid cloud provider '${opts.cloud}'. Use one of: ${VALID_CLOUD_PROVIDERS.join(', ')}`);
         }
         cloudProviderId = opts.cloud as CloudProviderId;
         if (cloudProviderId === 'rush' && !opts.repo) {
-          die(`--cloud rush requires --repo <owner/repo>`);
+          dieFriction('teams', 'cloud-rush-needs-repo', `--cloud rush requires --repo <owner/repo>`);
         }
       }
 
@@ -1539,7 +1545,7 @@ export function registerTeamsCommands(program: Command): void {
         const h = opts.host;
         const d = opts.device;
         if (h && d && h !== d) {
-          die('Conflicting --host/--device values — pass just one.');
+          dieFriction('teams', 'conflicting-host-device', 'Conflicting --host/--device values — pass just one.');
         }
         return h ?? d ?? null;
       })();
@@ -1554,11 +1560,13 @@ export function registerTeamsCommands(program: Command): void {
       let hostRepoPath: string | null = null;
       if (explicitDevice && explicitDevice.toLowerCase() !== machineId()) {
         if (cloudProviderId) {
-          die(`--device and --cloud are mutually exclusive (two different remote backends). Pick one.`);
+          dieFriction('teams', 'device-cloud-mutually-exclusive', `--device and --cloud are mutually exclusive (two different remote backends). Pick one.`);
         }
         const host = await resolveHost(explicitDevice);
         if (!host) {
-          die(
+          dieFriction(
+            'teams',
+            'device-not-resolvable',
             `Couldn't resolve --device "${explicitDevice}". Register it with \`agents devices\`, ` +
               `enroll it with \`agents hosts add ${explicitDevice}\`, or pass user@host.`,
           );
@@ -1567,7 +1575,9 @@ export function registerTeamsCommands(program: Command): void {
         // with tail/cat/kill, which don't exist under PowerShell. Refuse Windows
         // up front, mirroring dispatch.ts launchDetached.
         if (remoteShellFor(host.os ?? resolveRemoteOsSync(host.name)) === 'powershell') {
-          die(
+          dieFriction(
+            'teams',
+            'device-windows-unsupported',
             `Distributed teammates on Windows host "${host.name}" are not supported yet — ` +
               `the teams remote monitor is POSIX-only (offset-tails the remote log with tail/cat/kill). ` +
               `Use a Linux/macOS host, or run this teammate locally.`,
@@ -1576,7 +1586,7 @@ export function registerTeamsCommands(program: Command): void {
         try {
           hostTarget = sshTargetFor(host);
         } catch (err) {
-          die(`Can't resolve an ssh target for "${host.name}": ${(err as Error).message}`);
+          dieFriction('teams', 'ssh-target-unresolvable', `Can't resolve an ssh target for "${host.name}": ${(err as Error).message}`);
         }
         // Ensure agents-cli is present + version-matched on the host; surface
         // (not fail on) an agent-not-installed warning, like the run --host path.
@@ -1584,7 +1594,7 @@ export function registerTeamsCommands(program: Command): void {
           const { warnings } = ensureHostReady(host, { agent: parseTeammate(teammate).agent });
           for (const w of warnings) process.stderr.write(chalk.yellow(`[teams] warning: ${w}\n`));
         } catch (err) {
-          die(`Host "${host.name}" is not ready: ${(err as Error).message}`);
+          dieFriction('teams', 'host-not-ready', `Host "${host.name}" is not ready: ${(err as Error).message}`);
         }
         // Provision the repo on the host from the team's --repo (clone into
         // ~/.agents/repos/<team> or reuse an existing checkout), resolving to the
@@ -1600,7 +1610,9 @@ export function registerTeamsCommands(program: Command): void {
         try {
           hostRepoPath = ensureRemoteRepo(hostTarget!, effectiveRepo, team);
         } catch (err) {
-          die(
+          dieFriction(
+            'teams',
+            'repo-provision-failed',
             `Couldn't provision the repo on "${host.name}": ${(err as Error).message}\n` +
               `  Set how each device gets the code with: agents teams create ${team} --repo <url|path>`,
           );
@@ -1613,7 +1625,9 @@ export function registerTeamsCommands(program: Command): void {
       // Version-installed check is about the LOCAL machine — a distributed (--on)
       // teammate's agent/version lives on the host, verified by ensureHostReady.
       if (version && !hostName && !isVersionInstalled(agent, version)) {
-        die(
+        dieFriction(
+          'teams',
+          'agent-version-not-installed',
           `${AGENT_NAMES[agent]} ${version} isn't installed.\n` +
             `  Install it:  agents add ${agent}@${version}\n` +
             `  Or see what's installed (incl. @latest):  agents view ${agent}`
@@ -1643,13 +1657,13 @@ export function registerTeamsCommands(program: Command): void {
 
       if (opts.name !== undefined) {
         if (!opts.name || !/^[A-Za-z0-9_-]+$/.test(opts.name)) {
-          die(`Invalid teammate name '${opts.name}'. Use letters, numbers, '-', or '_'.`);
+          dieFriction('teams', 'invalid-teammate-name', `Invalid teammate name '${opts.name}'. Use letters, numbers, '-', or '_'.`);
         }
       }
 
       if (opts.worktree !== undefined) {
         if (!opts.worktree || !/^[A-Za-z0-9_-]+$/.test(opts.worktree)) {
-          die(`Invalid worktree name '${opts.worktree}'. Use letters, numbers, '-', or '_'.`);
+          dieFriction('teams', 'invalid-worktree-name', `Invalid worktree name '${opts.worktree}'. Use letters, numbers, '-', or '_'.`);
         }
       }
 
@@ -1657,14 +1671,14 @@ export function registerTeamsCommands(program: Command): void {
         ? opts.after.split(',').map((s) => s.trim()).filter(Boolean)
         : [];
       if (after.length > 0 && !opts.name) {
-        die("--after requires --name (dependencies reference teammates by name).");
+        dieFriction('teams', 'after-requires-name', "--after requires --name (dependencies reference teammates by name).");
       }
 
       let envOverrides: Record<string, string> | undefined;
       try {
         envOverrides = parseExecEnv(opts.env);
       } catch (err) {
-        die((err as Error).message);
+        dieFriction('teams', 'invalid-env', (err as Error).message);
       }
 
       // Team already ensured + loaded above (teamMeta) for the --repo provisioning.
@@ -1679,18 +1693,18 @@ export function registerTeamsCommands(program: Command): void {
         // remote teammate; a per-teammate worktree is created ON THE HOST at launch
         // (createRemoteWorktree in launchRemoteProcess) — we just capture its name.
         if (sharedWorktree) {
-          die(`Team '${team}' uses a shared local --use-worktree, which can't apply to a --device (remote) teammate.`);
+          dieFriction('teams', 'shared-worktree-remote-conflict', `Team '${team}' uses a shared local --use-worktree, which can't apply to a --device (remote) teammate.`);
         }
         if (worktreesEnabled) {
           if (!opts.worktree) {
-            die(`Team '${team}' has worktrees enabled. Use --worktree <name> for the remote teammate (created on ${hostName}).`);
+            dieFriction('teams', 'worktree-required-remote', `Team '${team}' has worktrees enabled. Use --worktree <name> for the remote teammate (created on ${hostName}).`);
           }
           if (!opts.name) {
-            die(`Team '${team}' has worktrees enabled. Use --name <name> to identify this teammate.`);
+            dieFriction('teams', 'name-required-remote', `Team '${team}' has worktrees enabled. Use --name <name> to identify this teammate.`);
           }
           worktreeName = opts.worktree;
         } else if (opts.worktree) {
-          die(`--worktree requires --enable-worktrees on the team. Recreate the team with: agents teams create ${team} --enable-worktrees`);
+          dieFriction('teams', 'worktree-requires-enable-worktrees', `--worktree requires --enable-worktrees on the team. Recreate the team with: agents teams create ${team} --enable-worktrees`);
         }
         // Local cwd stays null — the remote cwd is repoPath / the remote worktree.
       } else if (sharedWorktree) {
@@ -1699,34 +1713,34 @@ export function registerTeamsCommands(program: Command): void {
         try {
           const stat = await fsp.stat(sharedWorktree);
           if (!stat.isDirectory()) {
-            die(`Shared worktree path is not a directory: ${sharedWorktree}`);
+            dieFriction('teams', 'shared-worktree-not-dir', `Shared worktree path is not a directory: ${sharedWorktree}`);
           }
         } catch {
-          die(`Shared worktree path does not exist: ${sharedWorktree}`);
+          dieFriction('teams', 'shared-worktree-missing', `Shared worktree path does not exist: ${sharedWorktree}`);
         }
         worktreePath = sharedWorktree;
         if (opts.worktree) {
-          die(`Team '${team}' uses --use-worktree (shared). Don't pass --worktree on add.`);
+          dieFriction('teams', 'worktree-on-shared-team', `Team '${team}' uses --use-worktree (shared). Don't pass --worktree on add.`);
         }
       } else if (worktreesEnabled) {
         if (!opts.worktree) {
-          die(`Team '${team}' has worktrees enabled. Use --worktree <name> to specify a worktree name.`);
+          dieFriction('teams', 'worktree-required', `Team '${team}' has worktrees enabled. Use --worktree <name> to specify a worktree name.`);
         }
         if (!opts.name) {
-          die(`Team '${team}' has worktrees enabled. Use --name <name> to identify this teammate.`);
+          dieFriction('teams', 'name-required', `Team '${team}' has worktrees enabled. Use --name <name> to identify this teammate.`);
         }
         const baseCwd = opts.cwd ?? process.cwd();
         if (!(await isGitRepo(baseCwd))) {
-          die(`Worktrees require a git repository. ${baseCwd} is not inside a git repo.`);
+          dieFriction('teams', 'worktree-needs-repo', `Worktrees require a git repository. ${baseCwd} is not inside a git repo.`);
         }
         try {
           worktreeName = opts.worktree;
           worktreePath = await createWorktree(baseCwd, worktreeName);
         } catch (err) {
-          die(`Failed to create worktree '${opts.worktree}': ${(err as Error).message}`);
+          dieFriction('teams', 'worktree-create-failed', `Failed to create worktree '${opts.worktree}': ${(err as Error).message}`);
         }
       } else if (opts.worktree) {
-        die(`--worktree requires --enable-worktrees on the team. Recreate the team with: agents teams create ${team} --enable-worktrees`);
+        dieFriction('teams', 'worktree-requires-enable-worktrees', `--worktree requires --enable-worktrees on the team. Recreate the team with: agents teams create ${team} --enable-worktrees`);
       }
 
       // Distributed teammates have no LOCAL cwd — their working dir lives on the
@@ -1781,7 +1795,7 @@ export function registerTeamsCommands(program: Command): void {
           const cloudTask = await prov.dispatch(dispatchOpts);
           cloudSessionId = cloudTask.id;
         } catch (err) {
-          die(`Cloud dispatch failed: ${(err as Error).message}`);
+          dieFriction('teams', 'cloud-dispatch-failed', `Cloud dispatch failed: ${(err as Error).message}`);
         }
       }
 
@@ -1866,7 +1880,7 @@ export function registerTeamsCommands(program: Command): void {
           console.log(chalk.gray(`Check in later:  agents teams status ${team}`));
         }
       } catch (err) {
-        die(`Could not add ${fullName(agent, version)} to ${team}: ${(err as Error).message}`);
+        dieFriction('teams', 'add-failed', `Could not add ${fullName(agent, version)} to ${team}: ${(err as Error).message}`);
       }
     });
 
@@ -1922,7 +1936,7 @@ export function registerTeamsCommands(program: Command): void {
           printTeamSummary(team, toTaskStatusSummary(filtered));
         }
       } catch (err) {
-        die(`Could not check on team ${team}: ${(err as Error).message}`);
+        dieFriction('teams', 'status-failed', `Could not check on team ${team}: ${(err as Error).message}`);
       }
     });
 
@@ -2214,11 +2228,11 @@ export function registerTeamsCommands(program: Command): void {
 
       const lookup = await mgr.resolveAgentIdInTask(team, ref);
       if (lookup.kind === 'none') {
-        die(`No teammate matching '${ref}' in team ${team}`, 2);
+        dieFriction('teams', 'teammate-not-found', `No teammate matching '${ref}' in team ${team}`, 2);
       }
       if (lookup.kind === 'ambiguous') {
         const shorts = lookup.matches.map(shortId).join(', ');
-        die(`'${ref}' matches multiple teammates: ${shorts}. Use more characters or a name.`, 2);
+        dieFriction('teams', 'teammate-ambiguous', `'${ref}' matches multiple teammates: ${shorts}. Use more characters or a name.`, 2);
       }
       const agentId = lookup.agentId;
 
@@ -2226,7 +2240,7 @@ export function registerTeamsCommands(program: Command): void {
       const display = agent?.name || shortId(agentId);
 
       const stopRes = await handleStop(mgr, team, agentId);
-      if ('error' in stopRes) die(stopRes.error);
+      if ('error' in stopRes) dieFriction('teams', 'stop-failed', stopRes.error);
 
       // Clean up worktree if this teammate had one
       let worktreeKept = false;
@@ -2288,10 +2302,10 @@ export function registerTeamsCommands(program: Command): void {
     const mgr = mkManager();
 
     const lookup = await mgr.resolveAgentIdInTask(team, ref);
-    if (lookup.kind === 'none') die(`No teammate matching '${ref}' in team ${team}`, 2);
+    if (lookup.kind === 'none') dieFriction('teams', 'teammate-not-found', `No teammate matching '${ref}' in team ${team}`, 2);
     if (lookup.kind === 'ambiguous') {
       const shorts = lookup.matches.map(shortId).join(', ');
-      die(`'${ref}' matches multiple teammates: ${shorts}. Use more characters or a name.`, 2);
+      dieFriction('teams', 'teammate-ambiguous', `'${ref}' matches multiple teammates: ${shorts}. Use more characters or a name.`, 2);
     }
     const agentId = (lookup as { kind: 'ok'; agentId: string }).agentId;
 
@@ -2299,7 +2313,7 @@ export function registerTeamsCommands(program: Command): void {
     // .exit sentinel / exit-code reap) before we branch — so running-vs-stopped
     // is a fact, not a guess.
     const agent = await mgr.get(agentId);
-    if (!agent) die(`Teammate ${shortId(agentId)} vanished from team ${team}.`);
+    if (!agent) dieFriction('teams', 'teammate-vanished', `Teammate ${shortId(agentId)} vanished from team ${team}.`);
     const display = agent!.name || shortId(agentId);
     const status = agent!.status;
     const hasMessage = message != null && message.trim().length > 0;
@@ -2307,13 +2321,13 @@ export function registerTeamsCommands(program: Command): void {
     const route = decideTeamMessageRoute(status, hasMessage);
     switch (route.kind) {
       case 'not-started':
-        die(`Teammate '${display}' hasn't started yet (waiting on --after deps). Run \`agents teams start ${team}\` to launch it.`);
+        dieFriction('teams', 'teammate-not-started', `Teammate '${display}' hasn't started yet (waiting on --after deps). Run \`agents teams start ${team}\` to launch it.`);
         return;
       case 'need-message':
         if (status === AgentStatus.RUNNING) {
-          die(`Teammate '${display}' is running — pass a message to steer it.`);
+          dieFriction('teams', 'steer-needs-message', `Teammate '${display}' is running — pass a message to steer it.`);
         }
-        die(`Teammate '${display}' is ${status} — pass a message to resume it: \`agents teams resume ${team} ${display} "<message>"\`.`);
+        dieFriction('teams', 'resume-needs-message', `Teammate '${display}' is ${status} — pass a message to resume it: \`agents teams resume ${team} ${display} "<message>"\`.`);
         return;
       case 'steer': {
         // Running -> steer via mailbox; never re-launch (that forks a 2nd session).
@@ -2333,7 +2347,7 @@ export function registerTeamsCommands(program: Command): void {
         try {
           await mgr.resumeTeammate(agentId, message!);
         } catch (err) {
-          die((err as Error).message);
+          dieFriction('teams', 'resume-failed', (err as Error).message);
         }
         if (isJsonMode(opts)) {
           console.log(JSON.stringify({ team, agent_id: agentId, name: agent!.name ?? null, action: 'resume', prior_status: status }, null, 2));
@@ -2399,11 +2413,11 @@ export function registerTeamsCommands(program: Command): void {
 
       const lookup = await mgr.resolveAgentIdInTask(team, ref);
       if (lookup.kind === 'none') {
-        die(`No teammate matching '${ref}' in team ${team}`, 2);
+        dieFriction('teams', 'teammate-not-found', `No teammate matching '${ref}' in team ${team}`, 2);
       }
       if (lookup.kind === 'ambiguous') {
         const shorts = lookup.matches.map(shortId).join(', ');
-        die(`'${ref}' matches multiple teammates: ${shorts}. Use more characters or a name.`, 2);
+        dieFriction('teams', 'teammate-ambiguous', `'${ref}' matches multiple teammates: ${shorts}. Use more characters or a name.`, 2);
       }
       const agentId = lookup.agentId;
 
@@ -2412,7 +2426,7 @@ export function registerTeamsCommands(program: Command): void {
 
       // Require agent to be stopped first
       if (agent?.status === 'running' || agent?.status === 'pending') {
-        die(`Teammate '${display}' is still ${agent.status}. Run 'agents teams stop ${team} ${display}' first.`);
+        dieFriction('teams', 'remove-still-running', `Teammate '${display}' is still ${agent.status}. Run 'agents teams stop ${team} ${display}' first.`);
       }
 
       if (!opts.keepLogs) {
@@ -2454,7 +2468,7 @@ export function registerTeamsCommands(program: Command): void {
       }
 
       const stopRes = await handleStop(mgr, team);
-      if ('error' in stopRes) die(stopRes.error);
+      if ('error' in stopRes) dieFriction('teams', 'stop-failed', stopRes.error);
 
       const status = await handleStatus(mgr, team, 'all');
 
@@ -2502,7 +2516,7 @@ export function registerTeamsCommands(program: Command): void {
         return;
       }
       if (!existed && stopRes.stopped.length === 0 && status.agents.length === 0) {
-        die(`No team called '${team}'`, 2);
+        dieFriction('teams', 'team-not-found', `No team called '${team}'`, 2);
       }
       console.log(chalk.green(`Team ${chalk.cyan(team)} disbanded.`));
       if (stopRes.stopped.length) console.log(chalk.gray(`  Stopped ${stopRes.stopped.length} working teammate(s).`));
@@ -2539,11 +2553,13 @@ export function registerTeamsCommands(program: Command): void {
       } else {
         const resolved = await resolveTeammateAcrossTeams(base, teammateRef, opts.team);
         if (resolved.kind === 'none') {
-          die(`No notes on record for teammate '${teammateRef}'`, 2);
+          dieFriction('teams', 'teammate-notes-not-found', `No notes on record for teammate '${teammateRef}'`, 2);
         }
         if (resolved.kind === 'ambiguous') {
           const hints = resolved.candidates.map((c) => `${c.team}/${c.display}`).join(', ');
-          die(
+          dieFriction(
+            'teams',
+            'teammate-notes-ambiguous',
             `'${teammateRef}' matches multiple teammates: ${hints}.\n` +
               `  Narrow it with --team <team>, or pass a UUID prefix.`,
             2
@@ -2578,7 +2594,7 @@ export function registerTeamsCommands(program: Command): void {
         const lines = content.split('\n');
         process.stdout.write(lines.slice(-n).join('\n'));
       } catch {
-        die(`No notes on record for teammate '${teammateRef ?? agentId}' (looked in ${logPath})`, 2);
+        dieFriction('teams', 'teammate-notes-not-found', `No notes on record for teammate '${teammateRef ?? agentId}' (looked in ${logPath})`, 2);
       }
     });
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -205,7 +205,7 @@ import { renderWhatsNew } from './lib/whats-new.js';
 import type { AgentId } from './lib/types.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
 import { getCliLaunch } from './lib/cli-entry.js';
-import { emit, redactArgs } from './lib/events.js';
+import { emit, emitFriction, redactArgs } from './lib/events.js';
 
 // Transparent shim delegate: the generated Windows `.cmd` shims invoke
 // `agents __shim <agent>[@version] <raw args>`. Intercept here, before commander
@@ -839,6 +839,33 @@ function registerResourcesTombstoneCommand(p: Command): void {
     });
 }
 
+/**
+ * Hidden `agents _internal <sub>` namespace for machine-to-machine calls that
+ * are not user-facing. The first subcommand is `friction`, used by shell guard
+ * hooks (git-guard, rm-guard, …) to self-report a block into the event log
+ * before they exit 2 — they run before any `agents` process exists, so they
+ * cannot emit in-process.
+ */
+function registerInternalCommand(p: Command): void {
+  const internal = p.command('_internal', { hidden: true });
+  internal
+    .command('friction')
+    .option('--surface <surface>', 'Subsystem that hit the failure (e.g. guard, teams)')
+    .option('--id <failureId>', 'Stable failure slug (e.g. git.reset-hard)')
+    .option('--error <message>', 'Human-readable failure reason')
+    .option('--command <command>', 'The command that was blocked')
+    .action((opts: { surface?: string; id?: string; error?: string; command?: string }) => {
+      if (!opts.surface || !opts.id) {
+        process.exit(0); // fail-open: never break the caller
+      }
+      emitFriction(opts.surface, opts.id, {
+        ...(opts.error ? { error: opts.error } : {}),
+        ...(opts.command ? { command: opts.command } : {}),
+      });
+      process.exit(0);
+    });
+}
+
 /** Self-upgrade command (`agents upgrade [version]`). */
 function registerUpgradeCommand(p: Command): void {
   p.command('upgrade')
@@ -937,6 +964,9 @@ async function registerEagerForRequest(name: string): Promise<boolean> {
       registerResourcesTombstoneCommand(program);
       await reg(loadView);
       return true;
+    case '_internal':
+      registerInternalCommand(program);
+      return true;
     case 'upgrade':
       registerUpgradeCommand(program);
       return true;
@@ -1031,6 +1061,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadSsh);
   registerJobsCronAliasCommand(program, 'jobs');
   registerJobsCronAliasCommand(program, 'cron');
+  registerInternalCommand(program);
   registerUpgradeCommand(program);
   await reg(loadPull);
   await reg(loadPush);

--- a/apps/cli/src/lib/events.test.ts
+++ b/apps/cli/src/lib/events.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { gunzipSync, gzipSync } from 'node:zlib';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
-  emit, emitStart, emitCommand, query, rotate, stats,
+  emit, emitStart, emitCommand, emitFriction, query, rotate, stats,
   redactPrompt, redactArgs, truncate,
   detectCaller,
   _resetForTest,
@@ -120,6 +120,24 @@ describe('events', () => {
       } else {
         expect(files.length).toBe(0);
       }
+    });
+
+    it('emitFriction writes a friction event with surface and failureId', () => {
+      const logsDir = setupLogsDir();
+      emitFriction('teams', 'remote-cwd-on-add', { error: 'cannot use --remote-cwd' });
+
+      const files = fs.readdirSync(logsDir).filter(f => f === 'events.jsonl');
+      expect(files).toEqual(['events.jsonl']);
+
+      const content = fs.readFileSync(path.join(logsDir, 'events.jsonl'), 'utf-8');
+      const record = JSON.parse(content.trim().split('\n').pop()!);
+      expect(record.event).toBe('friction');
+      expect(record.surface).toBe('teams');
+      expect(record.failureId).toBe('remote-cwd-on-add');
+      expect(record.error).toBe('cannot use --remote-cwd');
+      expect(record.level).toBe('info');
+      expect(record.ts).toBeDefined();
+      expect(record.hostname).toBeDefined();
     });
   });
 

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -138,6 +138,7 @@ export type EventType =
   | 'status.posted'
   | 'file.edited'
   // Generic
+  | 'friction'
   | 'error'
   | 'warn'
   | 'info'
@@ -739,6 +740,24 @@ export function emitError(
     ...payload,
     error: error.message,
     errorStack: truncate(error.stack, 1000),
+  });
+}
+
+/**
+ * Emit a friction event — a structured, point-of-use record of a failure or
+ * block the CLI just hit. `surface` is the subsystem (teams, browser, secrets,
+ * guard, …); `failureId` is a stable slug that lets the nightly routine group
+ * the same failure across sessions (e.g. 'remote-cwd-on-add', 'not-installed').
+ */
+export function emitFriction(
+  surface: string,
+  failureId: string,
+  payload: EventPayload = {}
+): void {
+  emit('friction', {
+    ...payload,
+    surface,
+    failureId,
   });
 }
 

--- a/apps/cli/src/lib/format.test.ts
+++ b/apps/cli/src/lib/format.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   truncate,
   relTime,
@@ -9,7 +12,20 @@ import {
   isJsonMode,
   termLink,
   formatDie,
+  dieFriction,
 } from './format.js';
+import { _resetForTest } from './events.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+  tempDirs.length = 0;
+  _resetForTest();
+  vi.restoreAllMocks();
+});
 
 describe('truncate', () => {
   it('returns the string unchanged when within max', () => {
@@ -121,5 +137,30 @@ describe('formatDie (RUSH-1830 — machine-readable failures for --json callers)
   it('omits an absent hint from the json payload (no null/undefined key)', () => {
     const out = formatDie('nope', { json: true });
     expect(out.text).not.toContain('hint');
+  });
+});
+
+describe('dieFriction', () => {
+  it('emits a friction event before exiting', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-format-'));
+    tempDirs.push(dir);
+    const eventsPath = path.join(dir, 'events.jsonl');
+    _resetForTest(eventsPath);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+      throw new Error(`exit:${code}`);
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => dieFriction('teams', 'remote-cwd-on-add', 'cannot use --remote-cwd')).toThrow('exit:1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy).toHaveBeenCalled();
+
+    const content = fs.readFileSync(eventsPath, 'utf-8');
+    const record = JSON.parse(content.trim().split('\n').pop()!);
+    expect(record.event).toBe('friction');
+    expect(record.surface).toBe('teams');
+    expect(record.failureId).toBe('remote-cwd-on-add');
+    expect(record.error).toBe('cannot use --remote-cwd');
   });
 });

--- a/apps/cli/src/lib/format.ts
+++ b/apps/cli/src/lib/format.ts
@@ -9,6 +9,7 @@
  */
 import chalk from 'chalk';
 import { readSync } from 'node:fs';
+import { emitFriction } from './events.js';
 
 /** Options for {@link die} — opt into machine-readable failure output. */
 export interface DieOptions {
@@ -56,6 +57,23 @@ export function die(msg: string, code = 1, opts: DieOptions = {}): never {
   if (stream === 'stdout') console.log(text);
   else console.error(text);
   process.exit(code);
+}
+
+/**
+ * `die()` with a structured friction event attached. Use this at CLI error
+ * chokepoints so the nightly routine can classify and rank recurring failures
+ * without re-parsing transcripts. `surface` is the subsystem (teams, browser,
+ * secrets, guard, …); `failureId` is a stable slug (e.g. 'remote-cwd-on-add').
+ */
+export function dieFriction(
+  surface: string,
+  failureId: string,
+  msg: string,
+  code = 1,
+  opts: DieOptions = {},
+): never {
+  emitFriction(surface, failureId, { error: msg });
+  die(msg, code, opts);
 }
 
 /**


### PR DESCRIPTION
=== 1. teams add --remote-cwd emits a friction event ===
$ agents teams add t1 claude task --remote-cwd /tmp/x
--remote-cwd has no effect on 'teams add' — it does not set a teammate's repo or directory.
  A teammate works in the team's repo plus its own --worktree:
    • Set the repo once, on the team:  agents teams create t1 --repo <url|path>
    • Place the teammate on a machine: agents teams add t1 <agent> "<task>" --device <host> --worktree <name>
  (Remote worktrees fork from the host's freshly-fetched origin/<default> automatically.)
exit=1

=== 2. The friction event landed in the log ===
$ agents events --event friction --json | jq '.[-1]'
{
  "error": "--remote-cwd has no effect on 'teams add' — it does not set a teammate's repo or directory.\n  A teammate works in the team's repo plus its own --worktree:\n    • Set the repo once, on the team:  agents teams create t1 --repo <url|path>\n    • Place the teammate on a machine: agents teams add t1 <agent> \"<task>\" --device <host> --worktree <name>\n  (Remote worktrees fork from the host's freshly-fetched origin/<default> automatically.)",
  "surface": "teams",
  "failureId": "remote-cwd-on-add",
  "ts": "2026-08-02T10:52:31.509Z",
  "tz": "-07:00",
  "tzName": "America/Los_Angeles",
  "hostname": "yosemite-s1",
  "platform": "linux",
  "arch": "arm64",
  "pid": 1768522,
  "ppid": 1768519,
  "event": "friction",
  "level": "info",
  "caller": "script",
  "osUser": "muqsit",
  "transport": "ssh",
  "sshClientIp": "100.126.152.114",
  "actor": "UNRESOLVED@zion",
  "kind": "human"
}

=== 3. Hidden _internal friction recorder for guard hooks ===
$ agents _internal friction --surface guard --id git.reset-hard --error "git reset --hard is denied" --command "git reset --hard HEAD"
exit=0

$ agents events --event friction --json | jq '.[-1]'
{
  "error": "git reset --hard is denied",
  "command": "git reset --hard HEAD",
  "surface": "guard",
  "failureId": "git.reset-hard",
  "event": "friction",
  "level": "info",
  ...
}

=== 4. Tests pass ===
$ bun run test src/lib/events.test.ts src/lib/format.test.ts src/commands/teams.test.ts
 ✓ src/lib/format.test.ts (17 tests)
 ✓ src/lib/events.test.ts (40 tests)
 ✓ src/commands/teams.test.ts (5 tests)
Test Files  3 passed (3)
Tests  62 passed (62)
