### PR TITLE
feat(funnel): add disable runbook

### DIFF
--- a/apps/cli/.changelog/next/rush-1461-funnel-docs.md
+++ b/apps/cli/.changelog/next/rush-1461-funnel-docs.md
@@ -1,0 +1,7 @@
+- **`agents funnel down` disables a public Funnel port from the same wrapper used
+  to enable ingress.** Webhook ingress now has a complete local receiver runbook:
+  keep GitHub/Linear signing keys in `agents secrets`, bind the receiver to
+  `127.0.0.1`, expose it with `agents funnel up`, rotate one source secret at a
+  time, and turn the public port off with `agents funnel down` before stopping or
+  moving the receiver. Source: `apps/cli/src/commands/funnel.ts`,
+  `apps/cli/src/lib/funnel.ts`, `apps/cli/docs/03-routines.md`.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -216,7 +216,9 @@ agents webhook serve --secrets-bundle webhooks --port 8787
 The bundle may contain `GITHUB_WEBHOOK_SECRET`, `LINEAR_WEBHOOK_SECRET`, or both.
 The receiver accepts `POST /hooks/github` and `POST /hooks/linear`, rejects
 unsigned deliveries, dedupes repeated delivery IDs, rate-limits each source, and
-binds `127.0.0.1` by default.
+binds `127.0.0.1` by default. Keep webhook signing keys in `agents secrets`; do
+not put keys in webhook URLs, path segments, query strings, routine YAML, or
+Funnel commands.
 
 Expose the receiver publicly from a Linux/macOS Tailscale node with Funnel:
 
@@ -227,6 +229,44 @@ agents funnel status yosemite-s0
 
 Funnel public ports are limited to `443`, `8443`, and `10000`; `agents funnel up`
 validates that before running the remote Tailscale CLI.
+
+Operational runbook:
+
+1. Create or update the secret bundle on the ingress host:
+
+   ```bash
+   agents secrets create webhooks
+   agents secrets add webhooks GITHUB_WEBHOOK_SECRET
+   agents secrets add webhooks LINEAR_WEBHOOK_SECRET
+   ```
+
+   If a key already exists, replace the matching `add` command with
+   `agents secrets rotate webhooks <KEY>`.
+
+2. Start the receiver on the ingress host and leave it bound to localhost:
+
+   ```bash
+   agents webhook serve --secrets-bundle webhooks --host 127.0.0.1 --port 8787
+   ```
+
+3. Enable Funnel only after the receiver is listening:
+
+   ```bash
+   agents funnel up yosemite-s0 --local-port 8787 --port 443
+   agents funnel status yosemite-s0
+   ```
+
+4. Rotate a signing key source by source. Set the new source secret in the
+   `webhooks` bundle, update the provider webhook configuration to sign with the
+   new value, restart `agents webhook serve`, then send one signed test delivery
+   before deleting the old provider secret.
+
+5. Disable public ingress before stopping or moving the receiver:
+
+   ```bash
+   agents funnel down yosemite-s0 --port 443
+   agents funnel status yosemite-s0
+   ```
 
 ### Device Allowlist
 

--- a/apps/cli/src/commands/funnel.ts
+++ b/apps/cli/src/commands/funnel.ts
@@ -3,7 +3,7 @@
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
-import { buildFunnelStatusCommand, buildFunnelUpCommand, parseFunnelPort } from '../lib/funnel.js';
+import { buildFunnelDownCommand, buildFunnelStatusCommand, buildFunnelUpCommand, parseFunnelPort } from '../lib/funnel.js';
 import { resolveHost } from '../lib/hosts/registry.js';
 import { resolveRemoteOsSync } from '../lib/hosts/remote-os.js';
 import { sshTargetFor } from '../lib/hosts/types.js';
@@ -59,6 +59,21 @@ export function registerFunnelCommand(program: Command): void {
         const command = buildFunnelUpCommand(publicPort, localPort);
         await runOnHost(host, command);
         console.log(chalk.green(`Funnel enabled on ${host}: public :${publicPort} → localhost:${localPort}`));
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  funnel
+    .command('down <host>')
+    .description('Disable Tailscale Funnel exposure for a public HTTPS port.')
+    .option('--port <n>', 'Public Funnel port: 443, 8443, or 10000', '443')
+    .action(async (host: string, opts: { port?: string }) => {
+      try {
+        const publicPort = parseFunnelPort(opts.port ?? '443');
+        await runOnHost(host, buildFunnelDownCommand(publicPort));
+        console.log(chalk.green(`Funnel disabled on ${host}: public :${publicPort}`));
       } catch (err) {
         console.error(chalk.red((err as Error).message));
         process.exit(1);

--- a/apps/cli/src/lib/funnel.test.ts
+++ b/apps/cli/src/lib/funnel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildFunnelStatusCommand, buildFunnelUpCommand, parseFunnelPort } from './funnel.js';
+import { buildFunnelDownCommand, buildFunnelStatusCommand, buildFunnelUpCommand, parseFunnelPort } from './funnel.js';
 
 describe('funnel command builders', () => {
   it('accepts only Tailscale Funnel public ports', () => {
@@ -12,6 +12,7 @@ describe('funnel command builders', () => {
   it('builds status and up commands for ssh execution', () => {
     expect(buildFunnelStatusCommand()).toBe('tailscale funnel status');
     expect(buildFunnelUpCommand(443, 8787)).toBe('tailscale funnel --bg --https=443 http://localhost:8787');
+    expect(buildFunnelDownCommand(443)).toBe('tailscale funnel --https=443 off');
     expect(() => buildFunnelUpCommand(443, 70000)).toThrow(/Local port/);
   });
 });

--- a/apps/cli/src/lib/funnel.ts
+++ b/apps/cli/src/lib/funnel.ts
@@ -13,6 +13,15 @@ export function buildFunnelStatusCommand(): string {
   return 'tailscale funnel status';
 }
 
+export function buildFunnelDownCommand(publicPort: FunnelPort): string {
+  return [
+    'tailscale',
+    'funnel',
+    `--https=${publicPort}`,
+    'off',
+  ].map(shellQuote).join(' ');
+}
+
 export function buildFunnelUpCommand(publicPort: FunnelPort, localPort: number): string {
   if (!Number.isInteger(localPort) || localPort <= 0 || localPort > 65535) {
     throw new Error('Local port must be between 1 and 65535');


### PR DESCRIPTION
## What

Adds the missing Funnel disable path for RUSH-1461 docs/hardening:

- `agents funnel down <host> --port <n>` wraps `tailscale funnel --https=<port> off` through the same host resolver/SSH path as `funnel up`.
- The routines docs now include the operational runbook for creating/rotating webhook signing secrets, starting the localhost receiver, enabling Funnel, and disabling public ingress.
- The runbook explicitly keeps signing secrets out of URLs, path segments, query strings, routine YAML, and Funnel commands.
- The unreleased changelog entry is queued in `.changelog/next/` so the generated aggregate stays fresh.

## Evidence

No UI surface: CLI/docs change only.

Actual verification run from `/tmp/rush1461-pr-wt.QRTpFT/apps/cli`:

```text
$ bun install --frozen-lockfile --cache-dir /tmp/bun-cache-rush1461
$ node scripts/postinstall.js
$ bun run build
$ tsc ...
209 packages installed

$ bun test scripts/gen-changelog.test.ts src/lib/funnel.test.ts src/lib/triggers/webhook.test.ts
31 pass
0 fail
71 expect() calls
Ran 31 tests across 3 files.

$ bun run verify-docs
Docs verification passed

$ git diff --check
# no output
```

## Notes

- Existing webhook hardening already had localhost default binding plus signed-delivery per-source and pre-body per-IP rate limiting; this PR documents that runbook and adds the missing disable wrapper.
- Tailscale's current CLI docs describe disabling Funnel by appending `off` to the same `--https=<port>` command, with the target optional.
