### PR TITLE
fix(view): don't call a token-authenticated Claude install 'logged out'

### DIFF
--- a/apps/cli/.changelog/next/claude-ambient-token-badge.md
+++ b/apps/cli/.changelog/next/claude-ambient-token-badge.md
@@ -1,0 +1,11 @@
+- **`agents view` no longer reports a working Claude install as "logged out".**
+  Claude's `signedIn` is `!!email` read from a version home's `.claude.json`
+  (`lib/agents.ts`), so a version that authenticates from an ambient
+  `CLAUDE_CODE_OAUTH_TOKEN` — no account ever written to that home — rendered
+  "(logged out — log in with: claude, then /login)" while every run against it
+  succeeded. On one fleet box five of seven versions read as locked out and all
+  of them answered a live prompt. Those now render "(no per-version login —
+  using ambient CLAUDE_CODE_OAUTH_TOKEN)", which is both accurate and the more
+  useful warning: an ambient token is ONE account, so balanced rotation across
+  those versions rotates nothing. Source: `apps/cli/src/lib/signin-badge.ts`,
+  `apps/cli/src/commands/view.ts`.

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -28,7 +28,7 @@ import {
   colorAgent,
 } from '../lib/agents.js';
 import type { AccountInfo, CliState } from '../lib/agents.js';
-import { loginHint } from '../lib/signin-badge.js';
+import { ambientClaudeToken, loginHint } from '../lib/signin-badge.js';
 import type { AgentId } from '../lib/types.js';
 import { machineId } from '../lib/machine-id.js';
 import { authCacheKey, formatCheckedAge, readAuthHealthCache, type AuthHealth } from '../lib/auth-health.js';
@@ -640,8 +640,21 @@ async function showInstalledVersions(
         if (runDefaults.mode) runDefaultBits.push(`mode:${runDefaults.mode}`);
 
         if (!hasEmail && !hasUsage && !signedIn) {
-          // Installed but never signed in
-          parts.push(chalk.gray('(logged out — log in with: ' + loginHint(agentId) + ')'));
+          // No per-version credential. That is NOT the same as unusable: Claude
+          // Code authenticates from `CLAUDE_CODE_OAUTH_TOKEN` when the
+          // environment carries one, and a run then succeeds against whatever
+          // account minted that token — while `signedIn` (agents.ts: `!!email`,
+          // read from this version home's `.claude.json`) stays false because no
+          // account was ever written here. Reporting that as "logged out" reads
+          // as a locked-out account and sends people hunting a login that is not
+          // missing; naming the ambient token instead points at the real state —
+          // every version on this box resolves to the SAME account, so balanced
+          // rotation across them is not actually rotating.
+          parts.push(chalk.gray(
+            ambientClaudeToken(agentId)
+              ? '(no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)'
+              : '(logged out — log in with: ' + loginHint(agentId) + ')',
+          ));
         } else {
           if (hasEmail || hasUsage || hasActive || signedIn) {
             // Signed-in agents without a local email show their account id

--- a/apps/cli/src/lib/signin-badge.test.ts
+++ b/apps/cli/src/lib/signin-badge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatSignInBadge, loginHint, shouldCheckLoginBeforeLaunch } from './signin-badge.js';
+import { ambientClaudeToken, formatSignInBadge, loginHint, shouldCheckLoginBeforeLaunch } from './signin-badge.js';
 import type { AccountInfo } from './agents.js';
 
 // Strip ANSI so assertions read against text, not color codes.
@@ -79,5 +79,23 @@ describe('shouldCheckLoginBeforeLaunch', () => {
     expect(shouldCheckLoginBeforeLaunch({ ...base, rotated: true })).toBe(false);
     // A suppressor wins even when forceInteractive is set.
     expect(shouldCheckLoginBeforeLaunch({ ...base, forceInteractive: true, rotated: true })).toBe(false);
+  });
+});
+
+describe('ambientClaudeToken', () => {
+  it('flags a claude box whose environment carries a token', () => {
+    expect(ambientClaudeToken('claude', { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' })).toBe(true);
+  });
+
+  it('is false with no token, an empty token, or whitespace', () => {
+    expect(ambientClaudeToken('claude', {})).toBe(false);
+    expect(ambientClaudeToken('claude', { CLAUDE_CODE_OAUTH_TOKEN: '' })).toBe(false);
+    expect(ambientClaudeToken('claude', { CLAUDE_CODE_OAUTH_TOKEN: '   ' })).toBe(false);
+  });
+
+  it('never claims an ambient token for another agent', () => {
+    // The var is claude-specific; codex/kimi read their own credential files, so
+    // a stray value must not relabel their badge.
+    expect(ambientClaudeToken('codex', { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' })).toBe(false);
   });
 });

--- a/apps/cli/src/lib/signin-badge.ts
+++ b/apps/cli/src/lib/signin-badge.ts
@@ -50,6 +50,29 @@ export function loginHint(agentId: AgentId): string {
  * agents (the ones the feature is for), so the resume's `forceInteractive` flag is
  * consulted directly.
  */
+/**
+ * Is a Claude run on this box going to authenticate from an ambient
+ * `CLAUDE_CODE_OAUTH_TOKEN` rather than a per-version login?
+ *
+ * `AccountInfo.signedIn` is `!!email` read from a version home's `.claude.json`
+ * (agents.ts), so a version with no account written there reports signed-out —
+ * even though Claude Code authenticates fine from the env token and the run
+ * succeeds. Rendering that as "logged out" sends people hunting a login that is
+ * not missing (a real fleet incident: every version on a box read as locked out
+ * while all of them answered a live prompt).
+ *
+ * It is also the more useful warning: an ambient token is ONE account, so every
+ * version on the box resolves to it and balanced rotation across them rotates
+ * nothing. `env` is a parameter so the branch is testable without mutating the
+ * process environment.
+ */
+export function ambientClaudeToken(
+  agentId: AgentId | string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return agentId === 'claude' && (env.CLAUDE_CODE_OAUTH_TOKEN ?? '').trim().length > 0;
+}
+
 export function shouldCheckLoginBeforeLaunch(o: {
   interactive?: boolean;
   forceInteractive?: boolean;


### PR DESCRIPTION
**Bug fix — `agents view` output only, no behavior change to auth.** A Claude
install that runs fine was being reported as logged out.

## The bug

`lib/agents.ts:1581` defines Claude's login state as:

```ts
signedIn: !!email          // email = oauthAccount.emailAddress from the version home's .claude.json
```

That is the *only* signal. It never consults `CLAUDE_CODE_OAUTH_TOKEN` — neither
an ambient one nor the per-account setup token in the `auth` bundle. So a version
that authenticates purely from a token has no account written to its home,
reports `signedIn: false`, and `view.ts:642` renders
`(logged out — log in with: claude, then /login)`.

The install is not logged out. It runs.

## Observed

On `mac-mini`, which exports `CLAUDE_CODE_OAUTH_TOKEN` from `~/.zshenv`:

```
$ agents view claude | grep -c "logged out"
5                                  # five of seven versions

$ agents run claude@2.1.220 "Reply with exactly PINGOK and nothing else." --mode plan
PINGOK                             # …one of the five

$ python3 -c 'print(json.load(open(".../2.1.220/home/.claude/.claude.json")).get("oauthAccount"))'
None                               # no account here — hence signedIn:false
$ …same for 2.1.187
muqsit@trp.so                      # …and this one shows an account + usage bars
```

The reading cost real time: it looks exactly like five locked-out accounts, and
sends you hunting a login that was never missing.

It is worth noting the mirror case is already documented at `agents.ts:1434` — a
failed OAuth refresh guts `.credentials.json` but leaves `.claude.json` intact,
so the install reports `signedIn: true`, draws usage bars, and balanced rotation
keeps picking it while every run dies at spawn. The badge is wrong in both
directions; this PR fixes the false-negative half.

## The change

A new `ambientClaudeToken(agentId, env)` predicate in `signin-badge.ts` (the
module that already owns the login-state LOOK), and `view.ts` renders the ambient
case distinctly:

```
- (logged out — log in with: claude, then /login)
+ (no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)
```

The new text is also the more useful warning. An ambient token is **one account**,
so every version on that box resolves to it and `--balanced` rotation across them
rotates nothing — invisible in the old rendering.

Deliberately narrow: only the no-credential branch changes, only for `claude`,
only when the env carries a non-empty token. No auth behavior is touched, and a
box with no ambient token renders exactly as before.

## Run result — the real command on the affected box

Built this branch, staged it on mac-mini, ran the actual command against the real
version homes:

```
2.1.220 (default)  (no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)
2.1.219            (no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)
2.1.207            (no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)
2.1.187            haiku  muqsit@trp.so          Max  S: 0% (now)  W: 0% (now)
2.1.186            (no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)
2.1.181            (no per-version login — using ambient CLAUDE_CODE_OAUTH_TOKEN)
2.1.143            opus   muqsitnawaz@gmail.com  Max  S: 0% (now)  W: 0% (now)
```

Versions holding a real per-version account (2.1.187, 2.1.143) are untouched. On
a box with no ambient token the "logged out" text is unchanged — verified by
running the same build on `yosemite-s1` both with and without the var set.

## Tests

`signin-badge.test.ts` gains three cases against the real predicate (env injected
as a parameter, no process mutation): a token present, the empty/whitespace/absent
cases, and that a non-claude agent never gets relabelled by a stray value.
14 passed.

## Not in this PR

The underlying gap — nothing injects the **per-account** setup token from the
`auth` bundle into `buildExecEnv`, so `resolveClaudeSetupToken` (`usage.ts:1361`)
serves usage reads only — is a separate change with real blast radius.
`runner.ts:490` documents a fleet-wide logout caused by a shared token being
inherited into spawns, so that one needs per-account keying and its own review.
