### PR TITLE
feat(exec): inject the per-account Claude setup token (RUSH-2099)

### DIFF
--- a/apps/cli/.changelog/next/rush-2099-per-account-token.md
+++ b/apps/cli/.changelog/next/rush-2099-per-account-token.md
@@ -1,0 +1,1 @@
+- **Claude per-account run tokens.** `agents run` now injects the Claude setup token keyed to the selected version home's own account email, so balanced Claude rotation no longer inherits one ambient shared token across accounts. Source: `src/lib/exec.ts`.

--- a/apps/cli/src/lib/claude-account-token.test.ts
+++ b/apps/cli/src/lib/claude-account-token.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { claudeAccountTokenKey, resolveClaudeSetupToken } from './claude-account-token.js';
+import { buildExecEnv } from './exec.js';
+import { bundleItemStore, keychainRef, writeBundle, type SecretsBundle } from './secrets/bundles.js';
+import { _resetFileStoreForTest } from './secrets/filestore.js';
+import { secretsKeychainItem } from './secrets/index.js';
+import { getVersionHomePath } from './versions.js';
+
+const PASS = 'claude-account-token-test-pass';
+
+let fileDir: string;
+let homes: string[] = [];
+let versionDirs: string[] = [];
+let prevNoAgent: string | undefined;
+let prevPassphrase: string | undefined;
+let prevClaudeToken: string | undefined;
+
+beforeEach(() => {
+  fileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-account-token-store-'));
+  homes = [];
+  versionDirs = [];
+  prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+  prevPassphrase = process.env.AGENTS_SECRETS_PASSPHRASE;
+  prevClaudeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  process.env.AGENTS_SECRETS_NO_AGENT = '1';
+  process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+  _resetFileStoreForTest({ fileDir, passphrase: PASS });
+});
+
+afterEach(() => {
+  _resetFileStoreForTest({});
+  if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+  else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
+  if (prevPassphrase === undefined) delete process.env.AGENTS_SECRETS_PASSPHRASE;
+  else process.env.AGENTS_SECRETS_PASSPHRASE = prevPassphrase;
+  if (prevClaudeToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  else process.env.CLAUDE_CODE_OAUTH_TOKEN = prevClaudeToken;
+  for (const home of homes) fs.rmSync(home, { recursive: true, force: true });
+  for (const dir of versionDirs) fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(fileDir, { recursive: true, force: true });
+});
+
+function makeHome(email?: string): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-account-token-home-'));
+  homes.push(home);
+  if (email !== undefined) {
+    const configDir = path.join(home, '.claude');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, '.claude.json'),
+      JSON.stringify({ oauthAccount: { emailAddress: email } }),
+    );
+  }
+  return home;
+}
+
+function writeAuthBundle(values: Record<string, string>): void {
+  const bundle: SecretsBundle = { name: 'auth', backend: 'file', vars: {} };
+  for (const [key, value] of Object.entries(values)) {
+    bundleItemStore('file').set(secretsKeychainItem('auth', key), value);
+    bundle.vars[key] = keychainRef(key);
+  }
+  writeBundle(bundle);
+}
+
+describe('resolveClaudeSetupToken', () => {
+  it('refuses a bare shared CLAUDE_CODE_OAUTH_TOKEN as a per-account source', () => {
+    const home = makeHome('alpha@example.com');
+    writeAuthBundle({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-shared-must-not-resolve' });
+
+    expect(resolveClaudeSetupToken(home)).toBeNull();
+  });
+
+  it('returns no token when the version home has no resolvable account email', () => {
+    const home = makeHome();
+    writeAuthBundle({
+      [claudeAccountTokenKey('alpha@example.com')]: 'sk-ant-oat01-alpha',
+    });
+
+    expect(resolveClaudeSetupToken(home)).toBeNull();
+  });
+
+  it('resolves different tokens for different account-bound homes', () => {
+    const alphaHome = makeHome('alpha@example.com');
+    const betaHome = makeHome('beta@example.com');
+    writeAuthBundle({
+      [claudeAccountTokenKey('alpha@example.com')]: 'sk-ant-oat01-alpha',
+      [claudeAccountTokenKey('beta@example.com')]: 'sk-ant-oat01-beta',
+    });
+
+    expect(resolveClaudeSetupToken(alphaHome)).toBe('sk-ant-oat01-alpha');
+    expect(resolveClaudeSetupToken(betaHome)).toBe('sk-ant-oat01-beta');
+  });
+
+  it('buildExecEnv injects the token keyed to the selected version home account', () => {
+    const version = `rush-2099-token-test-${process.pid}`;
+    const versionHome = getVersionHomePath('claude', version);
+    versionDirs.push(path.dirname(versionHome));
+    const configDir = path.join(versionHome, '.claude');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, '.claude.json'),
+      JSON.stringify({ oauthAccount: { emailAddress: 'alpha@example.com' } }),
+    );
+    writeAuthBundle({
+      [claudeAccountTokenKey('alpha@example.com')]: 'sk-ant-oat01-alpha',
+    });
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-shared-must-not-win';
+
+    const env = buildExecEnv({
+      agent: 'claude',
+      version,
+      mode: 'plan',
+      effort: 'auto',
+    });
+
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-alpha');
+    expect(env.CLAUDE_CONFIG_DIR).toBe(configDir);
+  });
+});

--- a/apps/cli/src/lib/claude-account-token.ts
+++ b/apps/cli/src/lib/claude-account-token.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { bundleBackend, bundleExists, readAndResolveBundleEnv } from './secrets/bundles.js';
+
+/**
+ * Reserved FILE-BASED secrets bundle holding long-lived, non-rotating Claude
+ * setup-tokens. Usage/probe reads authenticate with these instead of Claude
+ * Code's ACL-bound login item, so they never pop Touch ID. Keyed strictly
+ * per-account (`CLAUDE_CODE_OAUTH_TOKEN_<slug>` from the account email) — never a
+ * bare key, so one account's token can't be misapplied to another in a
+ * multi-account fleet.
+ */
+const AUTH_BUNDLE = 'auth';
+
+/** The per-account key an email maps to inside the `auth` bundle. */
+export function claudeAccountTokenKey(account: string): string {
+  const slug = account
+    .trim()
+    .toUpperCase()
+    .replace(/@/g, '_AT_')
+    .replace(/\./g, '_DOT_')
+    .replace(/[^A-Z0-9_]/g, '_');
+  return `CLAUDE_CODE_OAUTH_TOKEN_${slug}`;
+}
+
+/** Signed-in account email for a version home, from `.claude.json` (no keychain). */
+export function readClaudeAccountEmail(home?: string): string | null {
+  const base = home ?? os.homedir();
+  for (const p of [path.join(base, '.claude', '.claude.json'), path.join(base, '.claude.json')]) {
+    try {
+      const email = (JSON.parse(fs.readFileSync(p, 'utf-8')) as {
+        oauthAccount?: { emailAddress?: unknown };
+      }).oauthAccount?.emailAddress;
+      if (typeof email === 'string' && email.trim().length > 0) return email.trim();
+    } catch {
+      // Missing/unreadable at this location — try the next.
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a long-lived `claude setup-token` for the account signed into `home`
+ * from the reserved FILE-BASED `auth` bundle. Returns the token or null. Reads
+ * ONLY when the bundle is file-backed (never keychain), so this path itself can
+ * never trigger a Touch ID prompt — that is the entire point: usage/probe reads
+ * authenticate with the shareable setup-token, not the ACL-bound login item.
+ */
+export function resolveClaudeSetupToken(home?: string): string | null {
+  try {
+    // Require a known account (email) up front: without it we cannot key a
+    // per-account token, and we must NOT fall back to a bare shared key that
+    // would misapply one account's setup-token to another.
+    const email = readClaudeAccountEmail(home);
+    if (!email) return null;
+    if (!bundleExists(AUTH_BUNDLE) || bundleBackend(AUTH_BUNDLE) !== 'file') return null;
+    const { env } = readAndResolveBundleEnv(AUTH_BUNDLE, { caller: 'usage', agentOnly: true });
+    const v = (env[claudeAccountTokenKey(email)] ?? '').trim();
+    return v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -29,6 +29,7 @@ import { mailboxDir, isValidMailboxId } from './mailbox.js';
 import { composeWin32CommandLine } from './platform/index.js';
 import { isTmuxInstalled } from './tmux/binary.js';
 import { shellQuote } from './ssh-exec.js';
+import { resolveClaudeSetupToken } from './claude-account-token.js';
 
 /**
  * Agent execution modes. Canonical name `skip` (dangerously skip permissions);
@@ -371,7 +372,15 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
       ? resolvedVersion
       : (resolvedVersion && isVersionInstalled('claude', resolvedVersion) ? resolvedVersion : null);
     if (version) {
-      result.CLAUDE_CONFIG_DIR = path.join(getVersionHomePath('claude', version), '.claude');
+      const versionHome = getVersionHomePath('claude', version);
+      result.CLAUDE_CONFIG_DIR = path.join(versionHome, '.claude');
+      const setupToken = resolveClaudeSetupToken(versionHome);
+      if (setupToken) {
+        // A token keyed to this version home's own account replaces any ambient
+        // shared value inherited from the launcher. options.env still wins below
+        // for explicit caller overrides.
+        result.CLAUDE_CODE_OAUTH_TOKEN = setupToken;
+      }
       // A managed pin lives in a per-version dir; Claude Code's own background
       // auto-updater would rewrite that pinned binary in place (and has left it
       // half-swapped and broken). Disable it so a pin stays a pin. Honor an

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -24,7 +24,7 @@ import {
   deleteKeychainToken,
   isKeychainBackendOverridden,
 } from './secrets/index.js';
-import { bundleExists, bundleBackend, readAndResolveBundleEnv } from './secrets/bundles.js';
+import { resolveClaudeSetupToken } from './claude-account-token.js';
 import { getCacheDir } from './state.js';
 import type { AgentId } from './types.js';
 
@@ -1311,66 +1311,6 @@ function deleteCachedClaudeOauth(service: string): void {
     deleteKeychainToken(claudeOauthCacheItem(service));
   } catch {
     /* best-effort — cache is an optimization */
-  }
-}
-
-/**
- * Reserved FILE-BASED secrets bundle holding long-lived, non-rotating Claude
- * setup-tokens. Usage/probe reads authenticate with these instead of Claude
- * Code's ACL-bound login item, so they never pop Touch ID. Keyed strictly
- * per-account (`CLAUDE_CODE_OAUTH_TOKEN_<slug>` from the account email) — never a
- * bare key, so one account's token can't be misapplied to another in a
- * multi-account fleet.
- */
-const AUTH_BUNDLE = 'auth';
-
-/** The per-account key an email maps to inside the `auth` bundle. */
-function claudeAccountTokenKey(account: string): string {
-  const slug = account
-    .trim()
-    .toUpperCase()
-    .replace(/@/g, '_AT_')
-    .replace(/\./g, '_DOT_')
-    .replace(/[^A-Z0-9_]/g, '_');
-  return `CLAUDE_CODE_OAUTH_TOKEN_${slug}`;
-}
-
-/** Signed-in account email for a version home, from `.claude.json` (no keychain). */
-function readClaudeAccountEmail(home?: string): string | null {
-  const base = home ?? os.homedir();
-  for (const p of [path.join(base, '.claude', '.claude.json'), path.join(base, '.claude.json')]) {
-    try {
-      const email = (JSON.parse(fs.readFileSync(p, 'utf-8')) as {
-        oauthAccount?: { emailAddress?: unknown };
-      }).oauthAccount?.emailAddress;
-      if (typeof email === 'string' && email.trim().length > 0) return email.trim();
-    } catch {
-      // Missing/unreadable at this location — try the next.
-    }
-  }
-  return null;
-}
-
-/**
- * Resolve a long-lived `claude setup-token` for the account signed into `home`
- * from the reserved FILE-BASED `auth` bundle. Returns the token or null. Reads
- * ONLY when the bundle is file-backed (never keychain), so this path itself can
- * never trigger a Touch ID prompt — that is the entire point: usage/probe reads
- * authenticate with the shareable setup-token, not the ACL-bound login item.
- */
-function resolveClaudeSetupToken(home?: string): string | null {
-  try {
-    // Require a known account (email) up front: without it we cannot key a
-    // per-account token, and we must NOT fall back to a bare shared key that
-    // would misapply one account's setup-token to another.
-    const email = readClaudeAccountEmail(home);
-    if (!email) return null;
-    if (!bundleExists(AUTH_BUNDLE) || bundleBackend(AUTH_BUNDLE) !== 'file') return null;
-    const { env } = readAndResolveBundleEnv(AUTH_BUNDLE, { caller: 'usage', agentOnly: true });
-    const v = (env[claudeAccountTokenKey(email)] ?? '').trim();
-    return v.length > 0 ? v : null;
-  } catch {
-    return null;
   }
 }
 


### PR DESCRIPTION
## What Changed

`agents run` now resolves the Claude setup token from the selected version home's own account email and injects it into the Claude child environment.

- Moved the shared account-token resolver into `apps/cli/src/lib/claude-account-token.ts`; the account key is derived at `apps/cli/src/lib/claude-account-token.ts:18`, the version-home account email is read at `apps/cli/src/lib/claude-account-token.ts:29`, and setup-token resolution refuses to proceed without that email at `apps/cli/src/lib/claude-account-token.ts:51`.
- `buildExecEnv` now passes the Claude version home into that resolver and injects only the returned account-keyed token at `apps/cli/src/lib/exec.ts:375`.
- The precedence comment is at `apps/cli/src/lib/exec.ts:379`: an account-keyed token replaces an inherited ambient shared token; explicit `options.env` still wins.
- `usage.ts` imports the same resolver at `apps/cli/src/lib/usage.ts:27` and still calls it for access-token-cache usage reads at `apps/cli/src/lib/usage.ts:1354`.
- Coverage is in `apps/cli/src/lib/claude-account-token.test.ts:71`, `apps/cli/src/lib/claude-account-token.test.ts:78`, `apps/cli/src/lib/claude-account-token.test.ts:87`, and `apps/cli/src/lib/claude-account-token.test.ts:99`.
- Changelog fragment: `apps/cli/.changelog/next/rush-2099-per-account-token.md:1`.

## Verification

### `./node_modules/.bin/vitest run src/lib/claude-account-token.test.ts`

```text

 RUN  v4.1.9 /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-2099-per-account-token/apps/cli


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  04:40:50
   Duration  1.44s (transform 710ms, setup 27ms, import 925ms, tests 380ms, environment 0ms)

```

### `./node_modules/.bin/vitest run src/lib/exec.test.ts src/lib/usage.test.ts`

This exact command sees this session's ambient `AGENT_SESSION_ID` / `AGENTS_MAILBOX_DIR`, `DISABLE_AUTOUPDATER`, and user Codex model config. Real output:

```text

 RUN  v4.1.9 /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-2099-per-account-token/apps/cli

 ❯ src/lib/exec.test.ts (72 tests | 3 failed) 919ms
     × sets nothing when there is no session id (nothing to key a box on) 141ms
     × leaves codex untouched — no DISABLE_AUTOUPDATER injected 1ms
     × codex interactive resume drops `exec` and carries the TUI sandbox flags 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/lib/exec.test.ts > buildExecEnv — AGENTS_MAILBOX_DIR wiring (mailbox loop-closer) > sets nothing when there is no session id (nothing to key a box on)
AssertionError: expected '/home/muqsit/.agents/.history/mailbox…' to be undefined

- Expected:
undefined

+ Received:
"/home/muqsit/.agents/.history/mailbox/7ae45af4-2136-454d-ab0e-480e0dda04d5"

 ❯ src/lib/exec.test.ts:147:36
    145|   it('sets nothing when there is no session id (nothing to key a box o…
    146|     const env = buildExecEnv(execOpts({ agent: 'claude' }));
    147|     expect(env.AGENTS_MAILBOX_DIR).toBeUndefined();
       |                                    ^
    148|     expect(env.AGENT_SESSION_ID).toBeUndefined();
    149|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  src/lib/exec.test.ts > buildExecEnv — Claude Code auto-updater suppression for pinned managed installs > leaves codex untouched — no DISABLE_AUTOUPDATER injected
AssertionError: expected '1' to be undefined

- Expected:
undefined

+ Received:
"1"

 ❯ src/lib/exec.test.ts:207:37
    205|   it('leaves codex untouched — no DISABLE_AUTOUPDATER injected', () =>…
    206|     const env = buildExecEnv(execOpts({ agent: 'codex', version: '0.20…
    207|     expect(env.DISABLE_AUTOUPDATER).toBeUndefined();
       |                                     ^
    208|   });
    209| });

⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/lib/exec.test.ts > buildExecCommand — native resume wiring > codex interactive resume drops `exec` and carries the TUI sandbox flags
AssertionError: expected [ Array(7) ] to deeply equal [ Array(5) ]

- Expected
+ Received

@@ -2,6 +2,8 @@
    "codex",
    "resume",
    "--sandbox",
    "read-only",
    "xyz-9",
+   "--model",
+   "gpt-5.5",
  ]

 ❯ src/lib/exec.test.ts:312:17
    310|   it('codex interactive resume drops `exec` and carries the TUI sandbo…
    311|     const cmd = buildExecCommand(execOpts({ agent: 'codex', mode: 'pla…
    312|     expect(cmd).toEqual(['codex', 'resume', '--sandbox', 'read-only', …
       |                 ^
    313|   });
    314|

⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed | 1 passed (2)
      Tests  3 failed | 85 passed (88)
   Start at  04:41:08
   Duration  1.89s (transform 1.19s, setup 25ms, import 1.67s, tests 1.08s, environment 0ms)

```

Isolated rerun with temp `HOME` and the ambient session/autoupdater variables cleared:

```text
TEST_HOME=/tmp/agents-cli-home-f6DQUx

 RUN  v4.1.9 /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-2099-per-account-token/apps/cli


 Test Files  2 passed (2)
      Tests  88 passed (88)
   Start at  04:41:15
   Duration  1.08s (transform 1.16s, setup 25ms, import 1.72s, tests 197ms, environment 0ms)

```

### `npx tsc --noEmit -p tsconfig.json`

```text

```

No stdout/stderr; exit 0.
