### PR TITLE
feat(menubar): list and dispatch the repo's open Linear tickets in quick dispatch (RUSH-2098)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,8 @@ The dropdown surfaces a **NEEDS YOU** queue (agents waiting on a question, a pla
 
 Press `Cmd-Shift-O` anywhere for a thin capture surface: type a one-line note, `Cmd-V` to paste, and attach one or more recent screenshots (double-click a thumbnail to preview it in full). Submit, and a headless agent picks the right project from your recent sessions, investigates, and files the Linear ticket itself -- you never leave what you were doing.
 
+The bar also lists the **open Linear tickets of the repo you picked**, urgent first. Switching the repo switches the Linear project; typing filters the list, so an existing ticket shows up before you file a duplicate; and clicking a row (or `⌘1`-`⌘5`) dispatches that ticket to the selected agents -- **Run** implements it, **Plan** posts a plan as a ticket comment.
+
 <p align="center">
   <img src="assets/menubar-quickissue.svg" alt="The Cmd-Shift-O quick-issue bar: a one-line note with attached screenshot thumbnails that a headless agent turns into a filed Linear ticket" width="100%" />
 </p>

--- a/apps/cli/.changelog/next/RUSH-2098.md
+++ b/apps/cli/.changelog/next/RUSH-2098.md
@@ -1,0 +1,25 @@
+- **The `Cmd-Shift-O` quick-dispatch bar now lists the repo's open Linear tickets,
+  and dispatches one on a click (RUSH-2098).** The panel only captured NEW work;
+  it now also shows what already exists. Switching the repo dropdown switches the
+  Linear project (the repo name is matched against `linear projects` reduced to
+  lowercase alphanumerics, so `agents-cli` finds "Agents CLI" with nothing to
+  configure; a worktree resolves to its parent repo, and a repo that matches no
+  project says so and lets you pick one, remembered per repo). Rows are ranked
+  urgent-first — Linear priority, then overdue, then in progress, then newest —
+  and typing filters them, so an existing ticket surfaces before Return files a
+  duplicate. Clicking a row (or `⌘1`–`⌘5`) dispatches that ticket to the selected
+  agents in the picked repo: **Run** claims it and implements it, **Plan** posts a
+  plan as a ticket comment. `⌘`-click opens it in Linear instead. The list renders
+  from a 90-second warm cache so the panel still appears instantly. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/LinearTickets.swift`,
+  `apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift`,
+  `apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift`.
+
+- **Fixed: a menu-bar dispatch whose child printed more than ~64 KiB hung forever
+  and never notified.** The helper read a monitored child's stdout only from the
+  process-termination handler, so a child that filled the pipe buffer blocked on
+  write, never exited, and the completion callback never fired — two `linear`
+  processes were left wedged by a single ticket fetch. Both monitored paths (the
+  ticket agent and `linear create`) now drain stdout, and feed stdin, on a
+  background queue while the child runs. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift`.

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -118,8 +118,8 @@ filing a duplicate.
 - **Click a row to dispatch it** to the selected agents in the picked repo
   (`⌘1` … `⌘5` do the same from the keyboard). **Plan** posts an implementation
   plan as a comment on the ticket and changes no code; **Run** claims the ticket
-  (`--status progress`), implements it per the repo's `AGENTS.md`, and comments
-  the result. Both are the same headless `agents run --mode auto --balanced
+  (`linear update <id> --pickup`), implements it per the repo's `AGENTS.md`, and
+  comments the result. Both are the same headless `agents run --mode auto --balanced
   --notify` dispatch as a quick Run, named after the ticket (`rush-2098`,
   `rush-2098-plan`) so it reads as that ticket in `agents sessions`.
   **`⌘`-click** opens the ticket in Linear instead, when you want to read it

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -58,19 +58,23 @@ process with its pid; end it and re-run `agents menubar enable`.
 ## Quick dispatch
 
 `Cmd-Shift-O` opens the Spotlight-style capture panel. Type a short request,
-optionally attach recent screenshots from the thumbnail strip, then pick one
-agent for **File Ticket** or one or more agents for **Fix**.
+optionally attach recent screenshots from the thumbnail strip, pick the repo to
+work in, then pick one agent for **Plan** or one or more agents for **Run**.
 
-- **File Ticket** sends the note and selected screenshots to the selected ticket
-  agent, which investigates and returns ticket fields as JSON. The helper then
-  runs `linear create` itself, appending `--image <path>` for every selected
+- **Plan** sends the note and selected screenshots to the selected ticket agent,
+  which investigates and returns ticket fields as JSON. The helper then runs
+  `linear create` itself, appending `--image <path>` for every selected
   screenshot so the image bytes are uploaded at create time and embedded in the
   issue description — screenshot paths never pass through an LLM-authored shell
   string.
-- **Fix** fans out to every selected agent with `agents run <agent> --mode auto
+- **Run** fans out to every selected agent with `agents run <agent> --mode auto
   --balanced --notify --name <slug-of-your-note>`, so the resulting sessions
   appear in normal `agents sessions` and menu-bar surfaces instead of as opaque
   background work.
+
+The repo dropdown comes from recent session working directories, never `$HOME`
+(running an agent straight in the home directory is too broad a permission
+surface), and passes `--cwd` to the dispatch. The last pick is remembered.
 
 `--notify` is what makes a dispatch report back. The run is launched **detached**
 and posts its own "finished"/"failed" notification when it ends (see
@@ -90,6 +94,40 @@ If another app steals focus while you are typing, the panel hides but keeps the
 draft note plus the selected screenshots, action, and agents for the next
 `Cmd-Shift-O` summon. Return submits and clears the draft; Escape clears it
 without dispatching.
+
+### The ticket list
+
+The panel captures new work; the rows under it are the work that already exists —
+the open Linear tickets of the repo you picked, so you can pick one up instead of
+filing a duplicate.
+
+- **Scope follows the repo.** Switching the repo dropdown switches the Linear
+  project: the repo name is matched against `linear projects` after both are
+  reduced to lowercase alphanumerics, so `agents-cli` finds **Agents CLI** with
+  nothing to configure. A repo whose name matches no project says so instead of
+  listing someone else's tickets — pick the project once from the dropdown and
+  that choice is remembered for that repo. A worktree resolves to its parent repo
+  (via git's common dir), not to the worktree's own directory name.
+- **Urgent first.** Rows are ranked by Linear priority (`P1` … `P4`, then
+  no-priority), then overdue, then already in progress, then newest — the order
+  answers "what should I pick up next", which is not the order Linear returns.
+  The top five show.
+- **Typing filters the list.** Every word you type has to appear in a row's
+  identifier or title, so an existing ticket surfaces before Return files a new
+  one.
+- **Click a row to dispatch it** to the selected agents in the picked repo
+  (`⌘1` … `⌘5` do the same from the keyboard). **Plan** posts an implementation
+  plan as a comment on the ticket and changes no code; **Run** claims the ticket
+  (`--status progress`), implements it per the repo's `AGENTS.md`, and comments
+  the result. Both are the same headless `agents run --mode auto --balanced
+  --notify` dispatch as a quick Run, named after the ticket (`rush-2098`,
+  `rush-2098-plan`) so it reads as that ticket in `agents sessions`.
+  **`⌘`-click** opens the ticket in Linear instead, when you want to read it
+  first.
+
+A `linear tasks` round trip costs seconds, so the list renders from a warm cache
+(`~/.agents/.history/menubar/linear-cache.json`) and refreshes in the background;
+entries older than 90 seconds are re-fetched on the next summon.
 
 ## The dropdown
 
@@ -188,6 +226,7 @@ The helper assembles the menu by reading these directly — no CLI, no re-index:
 | Cloud | `~/.agents/.cache/cloud/tasks.db` (SQLite) | cloud tasks, incl. `input_required` or `needs_review` → "awaiting input" |
 | Attention sentinels | `~/.agents/.cache/state/attention/<sessionId>` | terminal sessions awaiting input — mtime = wait start, content = the awaiting message (written by the Notification hook). On read, sentinels whose sessionId is not in the current live-terminals set are unlinked as orphans (defense against sessions killed hard, hookless Claude versions, or sessionId mismatches). |
 | Installed agents | `~/.agents/.history/versions/<agent>/` | the agent roster |
+| Linear tickets | `linear projects` / `linear tasks --all --project <p> --status open --cycle all` (warm cache, 90s TTL) | the quick-dispatch ticket list, scoped to the picked repo's project |
 
 Liveness is a `kill(pid, 0)` check; running-vs-idle is the transcript file's
 mtime. The teams directory accumulates history, so the periodic badge refresh
@@ -266,3 +305,5 @@ the current bundle on any version bump.
 | `~/Library/Application Support/agents-cli/.menubar-version` | installed-version stamp |
 | `~/.agents/.cache/state/menubar.disabled` | sticky opt-out marker |
 | `~/.agents/.cache/helpers/menubar/menubar.log` | helper stdout / stderr |
+| `~/.agents/.history/menubar/recent-tickets.json` | tickets filed from the quick-dispatch panel (RECENT TICKETS) |
+| `~/.agents/.history/menubar/linear-cache.json` | warm cache of Linear projects + each project's open tickets |

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -118,8 +118,8 @@ filing a duplicate.
 - **Click a row to dispatch it** to the selected agents in the picked repo
   (`⌘1` … `⌘5` do the same from the keyboard). **Plan** posts an implementation
   plan as a comment on the ticket and changes no code; **Run** claims the ticket
-  (`linear update <id> --pickup`), implements it per the repo's `AGENTS.md`, and
-  comments the result. Both are the same headless `agents run --mode auto --balanced
+  (moving it to whichever state `linear states` reports as `started`), implements
+  it per the repo's `AGENTS.md`, and comments the result. Both are the same headless `agents run --mode auto --balanced
   --notify` dispatch as a quick Run, named after the ticket (`rush-2098`,
   `rush-2098-plan`) so it reads as that ticket in `agents sessions`.
   **`⌘`-click** opens the ticket in Linear instead, when you want to read it

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -317,7 +317,7 @@ enum AgentsCLI {
             \(head)
 
             Steps:
-            1. Read the ticket, claim it — `linear update \(ticket.identifier) --status progress` \
+            1. Read the ticket, claim it — `linear update \(ticket.identifier) --pickup` \
             — and investigate the repo you were launched in.
             2. Implement the change following that repo's AGENTS.md (worktree + PR when the \
             repo requires it; never commit on the default branch).

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -224,6 +224,140 @@ enum AgentsCLI {
         "\(home)/.agents/skills/linear/scripts/linear"
     }
 
+    // MARK: Linear tickets in the quick-dispatch panel
+
+    // `linear projects --json`, so the panel can scope its ticket list to the
+    // project behind the picked repo (LinearTickets.resolveProject).
+    static func linearProjectsAsync(completion: @escaping ([LinearProject]?) -> Void) {
+        runMonitored([linearSkillBinary(), "projects", "--json"]) { text, ok in
+            guard ok, let data = text.data(using: .utf8),
+                  let projects = try? JSONDecoder().decode([LinearProject].self, from: data) else {
+                completion(nil)
+                return
+            }
+            completion(projects)
+        }
+    }
+
+    // Every OPEN ticket of one project, across cycles and the backlog — the panel
+    // ranks and trims the list itself (LinearTickets.rank), because "what should I
+    // pick up next" is not the cycle order Linear returns. `--all` drops the CLI's
+    // default per-agent filter so a ticket delegated to another agent is still
+    // offered.
+    static func linearTicketArgs(project: String) -> [String] {
+        [linearSkillBinary(), "tasks", "--all",
+         "--project", project,
+         "--status", "open",
+         "--cycle", "all",
+         "--json"]
+    }
+
+    static func linearTicketsAsync(project: String,
+                                   completion: @escaping ([LinearTicket]?) -> Void) {
+        runMonitored(linearTicketArgs(project: project)) { text, ok in
+            guard ok, let data = text.data(using: .utf8),
+                  let decoded = try? JSONDecoder().decode(LinearTasksResponse.self, from: data) else {
+                completion(nil)
+                return
+            }
+            completion(decoded.issues)
+        }
+    }
+
+    // The repo name behind a working directory — the identity the panel maps to a
+    // Linear project. A worktree under `<repo>/.agents/worktrees/<slug>` must
+    // resolve to `<repo>`, not to the slug, so ask git for the COMMON dir (shared
+    // by every worktree) rather than trusting the path's last component. A
+    // directory that is not a git repo has no repo name but is still a real place
+    // to run in, so it identifies as itself.
+    static func repoName(forDir dir: String) -> String {
+        let common = capture(["/usr/bin/git", "-C", dir, "rev-parse",
+                              "--path-format=absolute", "--git-common-dir"])
+            .flatMap { String(data: $0, encoding: .utf8) }?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let common, !common.isEmpty {
+            return ((common as NSString).deletingLastPathComponent as NSString).lastPathComponent
+        }
+        return (dir as NSString).lastPathComponent
+    }
+
+    // The brief for working a ticket that already exists. Plan asks for a plan
+    // posted back on the ticket; Run asks for the change, shipped. Both run in
+    // `auto` mode — even the plan has to read the repo and comment on the ticket,
+    // which a read-only run cannot do.
+    static func ticketWorkPrompt(ticket: LinearTicket, action: QuickDispatchAction) -> String {
+        let head = """
+        You are picking up an existing Linear ticket, dispatched from the agents \
+        menu-bar quick-dispatch panel. Do not ask questions — make your best call and act.
+
+        Ticket: \(ticket.identifier) — \(ticket.title)
+        Priority: \(LinearTickets.priorityLabel(ticket.priority))\
+        \(ticket.stateName.isEmpty ? "" : " · state: \(ticket.stateName)")\
+        \(ticket.url.map { "\nURL: \($0)" } ?? "")
+
+        Read the full ticket first: `linear tasks \(ticket.identifier)`.
+        """
+        switch action {
+        case .plan:
+            return """
+            \(head)
+
+            Steps:
+            1. Read the ticket, then investigate the repo you were launched in for real \
+            context — name the files and the concrete change the ticket needs.
+            2. Write an implementation plan: the approach, the files to touch, the tests \
+            that will prove it, and anything genuinely ambiguous.
+            3. Post the plan on the ticket as a comment: \
+            `linear update \(ticket.identifier) --comment <plan>`.
+            4. Do NOT change code and do NOT open a PR — this dispatch is the plan only. \
+            Print the plan as your final output.
+            """
+        case .run:
+            return """
+            \(head)
+
+            Steps:
+            1. Read the ticket, claim it — `linear update \(ticket.identifier) --status progress` \
+            — and investigate the repo you were launched in.
+            2. Implement the change following that repo's AGENTS.md (worktree + PR when the \
+            repo requires it; never commit on the default branch).
+            3. Verify with the focused tests or the real flow that proves the user-visible \
+            outcome, and quote the real output.
+            4. Comment the result on the ticket with the PR link \
+            (`linear update \(ticket.identifier) --comment <result>`), and print the PR URL \
+            or the local verification evidence as your final output.
+            """
+        }
+    }
+
+    // `agents run` argv for a ticket dispatch. Same shape as a quick Run — headless,
+    // balanced across signed-in versions, self-notifying, scoped to the picked repo
+    // — but named after the ticket so the session reads as `rush-2098` in
+    // `agents sessions` instead of a slug of a note nobody typed.
+    static func ticketWorkRunArgs(agent: String, prompt: String, ticket: LinearTicket,
+                                  action: QuickDispatchAction, cwd: String? = nil) -> [String] {
+        let suffix = action == .plan ? "-plan" : ""
+        return quickFixRunArgs(agent: agent, prompt: prompt,
+                               name: "\(ticket.identifier.lowercased())\(suffix)", cwd: cwd)
+    }
+
+    // Fan the selected agents out onto one existing ticket. Detached + `--notify`
+    // for the same reason as dispatchQuickFix: the run must outlive this helper.
+    static func dispatchTicketWork(ticket: LinearTicket, agents: [String],
+                                  action: QuickDispatchAction, cwd: String? = nil) {
+        let selected = agents.isEmpty ? ["claude"] : agents
+        let prompt = ticketWorkPrompt(ticket: ticket, action: action)
+        Notifier.post(title: action == .plan
+                        ? "Planning \(ticket.identifier)…"
+                        : "Dispatching \(ticket.identifier)…",
+                      body: shortenForNotice(ticket.title),
+                      url: ticket.url)
+        for agent in selected {
+            runDetached(argv(ticketWorkRunArgs(agent: agent, prompt: prompt, ticket: ticket,
+                                               action: action, cwd: cwd)))
+        }
+    }
+
     // The standing brief handed to the ticket agent. It embeds the user's note
     // and every selected screenshot path as user-provided ticket material so the
     // agent can inspect them. The menu-bar helper owns the actual `linear create`
@@ -525,6 +659,13 @@ enum AgentsCLI {
     // (on the main queue) when it exits. Unlike runDetached this keeps a strong
     // reference until termination so the completion callback can fire — used for
     // the ticket agent, which is long-running but must still report its result.
+    //
+    // The pipe is drained on a background queue WHILE the child runs, not from a
+    // termination handler. A child that outputs more than the pipe buffer holds
+    // (~64 KiB — `linear tasks --json` for one project is several hundred KiB, and
+    // headless `agents run` output can be far more) blocks forever on write if
+    // nothing reads until it exits, so the termination handler never fires and the
+    // dispatch hangs with no notification.
     private static var monitored: [Process] = []
     private static func runMonitored(_ argv: [String], onFinish: @escaping (String, Bool) -> Void) {
         let p = Process()
@@ -533,20 +674,22 @@ enum AgentsCLI {
         let out = Pipe()
         p.standardOutput = out
         p.standardError = FileHandle.nullDevice
-        p.terminationHandler = { proc in
-            let data = out.fileHandleForReading.readDataToEndOfFile()
-            let text = String(data: data, encoding: .utf8) ?? ""
-            let ok = proc.terminationStatus == 0
-            DispatchQueue.main.async {
-                monitored.removeAll { $0 === proc }
-                onFinish(text, ok)
-            }
-        }
         do {
             try p.run()
             monitored.append(p)
         } catch {
             DispatchQueue.main.async { onFinish("", false) }
+            return
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            let data = out.fileHandleForReading.readDataToEndOfFile()
+            p.waitUntilExit()
+            let text = String(data: data, encoding: .utf8) ?? ""
+            let ok = p.terminationStatus == 0
+            DispatchQueue.main.async {
+                monitored.removeAll { $0 === p }
+                onFinish(text, ok)
+            }
         }
     }
 
@@ -562,22 +705,29 @@ enum AgentsCLI {
         p.standardOutput = out
         p.standardInput = inPipe
         p.standardError = FileHandle.nullDevice
-        p.terminationHandler = { proc in
-            let data = out.fileHandleForReading.readDataToEndOfFile()
-            let text = String(data: data, encoding: .utf8) ?? ""
-            let ok = proc.terminationStatus == 0
-            DispatchQueue.main.async {
-                monitored.removeAll { $0 === proc }
-                onFinish(text, ok)
-            }
-        }
         do {
             try p.run()
             monitored.append(p)
-            inPipe.fileHandleForWriting.write(input)
-            inPipe.fileHandleForWriting.closeFile()
         } catch {
             DispatchQueue.main.async { onFinish("", false) }
+            return
+        }
+        // Feed stdin and drain stdout off the main thread, for the same reason as
+        // runMonitored: either direction can fill its pipe buffer and block, and a
+        // blocked main thread would freeze the menu bar.
+        DispatchQueue.global(qos: .userInitiated).async {
+            inPipe.fileHandleForWriting.write(input)
+            inPipe.fileHandleForWriting.closeFile()
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            let data = out.fileHandleForReading.readDataToEndOfFile()
+            p.waitUntilExit()
+            let text = String(data: data, encoding: .utf8) ?? ""
+            let ok = p.terminationStatus == 0
+            DispatchQueue.main.async {
+                monitored.removeAll { $0 === p }
+                onFinish(text, ok)
+            }
         }
     }
 

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -317,8 +317,11 @@ enum AgentsCLI {
             \(head)
 
             Steps:
-            1. Read the ticket, claim it — `linear update \(ticket.identifier) --pickup` \
-            — and investigate the repo you were launched in.
+            1. Read the ticket, claim it, and investigate the repo you were launched in. \
+            To claim it, move it to this workspace's in-progress state: `linear states` \
+            lists the states with their types — pick the one typed `started` and run \
+            `linear update \(ticket.identifier) --status <that state>`. Do not guess a \
+            state name; workspaces name them differently.
             2. Implement the change following that repo's AGENTS.md (worktree + PR when the \
             repo requires it; never commit on the default branch).
             3. Verify with the focused tests or the real flow that proves the user-visible \

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -447,11 +447,14 @@ enum IssueSelfTest {
         let runPrompt = AgentsCLI.ticketWorkPrompt(ticket: t, action: .run)
         check("the run brief names the ticket and how to read it",
               runPrompt.contains("RUSH-2098") && runPrompt.contains("linear tasks RUSH-2098"))
-        // `--pickup` is the state-name-independent way to move a ticket to In
-        // Progress; a literal state name like "Doing" is workspace-specific and
-        // `--status progress` is not a state at all (it is a `tasks` filter value).
-        check("the run brief claims the ticket and reports back",
-              runPrompt.contains("--pickup") && runPrompt.contains("--comment"))
+        // The brief must make the agent DISCOVER the in-progress state: state names
+        // are per-workspace ("Doing" here, not "In Progress"), `--pickup` hardcodes
+        // "In Progress", and `--status progress` is a `tasks` filter value, not a
+        // state — both fail on a workspace that names it anything else.
+        check("the run brief claims the ticket by discovering the started state",
+              runPrompt.contains("linear states") && runPrompt.contains("--status")
+                  && !runPrompt.contains("--pickup"))
+        check("the run brief reports back on the ticket", runPrompt.contains("--comment"))
         let planPrompt = AgentsCLI.ticketWorkPrompt(ticket: t, action: .plan)
         check("the plan brief forbids code changes and a PR",
               planPrompt.contains("Do NOT change code") && planPrompt.contains("do NOT open a PR"))

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -447,8 +447,11 @@ enum IssueSelfTest {
         let runPrompt = AgentsCLI.ticketWorkPrompt(ticket: t, action: .run)
         check("the run brief names the ticket and how to read it",
               runPrompt.contains("RUSH-2098") && runPrompt.contains("linear tasks RUSH-2098"))
+        // `--pickup` is the state-name-independent way to move a ticket to In
+        // Progress; a literal state name like "Doing" is workspace-specific and
+        // `--status progress` is not a state at all (it is a `tasks` filter value).
         check("the run brief claims the ticket and reports back",
-              runPrompt.contains("--status progress") && runPrompt.contains("--comment"))
+              runPrompt.contains("--pickup") && runPrompt.contains("--comment"))
         let planPrompt = AgentsCLI.ticketWorkPrompt(ticket: t, action: .plan)
         check("the plan brief forbids code changes and a PR",
               planPrompt.contains("Do NOT change code") && planPrompt.contains("do NOT open a PR"))

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 // Self-test for the quick-issue capture logic (Cmd-Shift-O). Follows the repo's
@@ -21,6 +22,11 @@ enum IssueSelfTest {
         testRecentTicketsMerge()
         testDraftPreservation()
         testRoutineFailureReason()
+        testLinearProjectResolution()
+        testLinearTicketRanking()
+        testLinearTicketFilter()
+        testLinearCache()
+        testTicketDispatchContract()
         if failures == 0 {
             print("\nALL PASS")
             exit(0)
@@ -314,7 +320,187 @@ enum IssueSelfTest {
               detail: routineFailureDetail(failed, max: 72) ?? "nil")
     }
 
+    // The repo picker drives the ticket scope, so `agents-cli` has to land on the
+    // "Agents CLI" project without any configured mapping — and a repo that matches
+    // nothing must resolve to nil rather than to someone else's project.
+    private static func testLinearProjectResolution() {
+        let projects = [
+            LinearProject(id: "p1", name: "Agents CLI"),
+            LinearProject(id: "p2", name: "Rush App"),
+            LinearProject(id: "p3", name: "Rush CLI"),
+        ]
+        check("repo name matches a project across case + punctuation",
+              LinearTickets.resolveProject(repoName: "agents-cli", projects: projects)?.id == "p1")
+        check("an ambiguous repo name matches nothing",
+              LinearTickets.resolveProject(repoName: "rush", projects: projects) == nil)
+        check("an explicit per-repo project wins over the derived match",
+              LinearTickets.resolveProject(repoName: "agents-cli", projects: projects,
+                                           override: "Rush CLI")?.id == "p3")
+        check("an override naming no live project falls through to the derived match",
+              LinearTickets.resolveProject(repoName: "agents-cli", projects: projects,
+                                           override: "Deleted Project")?.id == "p1")
+        check("no repo means no scope",
+              LinearTickets.resolveProject(repoName: nil, projects: projects) == nil)
+        check("no projects means no scope",
+              LinearTickets.resolveProject(repoName: "agents-cli", projects: []) == nil)
+    }
+
+    // The ranking IS the suggestion: urgent leads, "no priority" sinks below low,
+    // and within one priority overdue beats in-progress beats newest.
+    private static func testLinearTicketRanking() {
+        let now = date("2026-08-02T00:00:00Z")
+        let urgent = ticket("A-1", priority: 1, createdAt: "2026-07-01T00:00:00.000Z")
+        let none = ticket("A-2", priority: 0, createdAt: "2026-08-01T00:00:00.000Z")
+        let low = ticket("A-3", priority: 4, createdAt: "2026-08-01T00:00:00.000Z")
+        let highOld = ticket("A-4", priority: 2, createdAt: "2026-07-01T00:00:00.000Z")
+        let highNew = ticket("A-5", priority: 2, createdAt: "2026-08-01T00:00:00.000Z")
+        let highStarted = ticket("A-6", priority: 2, createdAt: "2026-06-01T00:00:00.000Z",
+                                 stateType: "started")
+        let highOverdue = ticket("A-7", priority: 2, createdAt: "2026-06-01T00:00:00.000Z",
+                                 dueDate: "2026-07-30")
+
+        let ranked = LinearTickets.rank([none, low, highNew, urgent, highOverdue, highStarted, highOld],
+                                        now: now).map(\.identifier)
+        check("urgent leads the list", ranked.first == "A-1", detail: ranked.joined(separator: ","))
+        check("no-priority sinks below low", ranked.last == "A-2", detail: ranked.joined(separator: ","))
+        check("inside one priority: overdue, then started, then newest",
+              Array(ranked.dropFirst().prefix(4)) == ["A-7", "A-6", "A-5", "A-4"],
+              detail: ranked.joined(separator: ","))
+        check("an overdue ticket is only overdue against today",
+              LinearTickets.isOverdue(highOverdue, now: now)
+                  && !LinearTickets.isOverdue(highOverdue, now: date("2026-07-01T00:00:00Z")))
+        check("priority labels read as Linear's scale",
+              LinearTickets.priorityLabel(1) == "P1" && LinearTickets.priorityLabel(0) == "--")
+    }
+
+    // Typing narrows the list so an existing ticket surfaces before Return files a
+    // duplicate.
+    private static func testLinearTicketFilter() {
+        let tickets = [
+            ticket("RUSH-2078", title: "prix/code-reviewer is down"),
+            ticket("RUSH-1968", title: "Passphrase exported in plaintext from .zshenv"),
+        ]
+        check("every term must match, in any order",
+              LinearTickets.filter(tickets, query: "plaintext passphrase").map(\.identifier)
+                  == ["RUSH-1968"])
+        check("the identifier is searchable too",
+              LinearTickets.filter(tickets, query: "rush-2078").map(\.identifier) == ["RUSH-2078"])
+        check("an unmatched term yields nothing",
+              LinearTickets.filter(tickets, query: "kubernetes").isEmpty)
+        check("an empty query keeps the whole ranked list",
+              LinearTickets.filter(tickets, query: "   ").count == 2)
+    }
+
+    // The cache is what makes the panel appear instantly; a write for one project
+    // must not disturb another, and staleness has to be honest.
+    private static func testLinearCache() {
+        let now = Date()
+        var cache = LinearTickets.Cache()
+        cache = LinearTickets.merged(cache, projects: [LinearProject(id: "p1", name: "Agents CLI")],
+                                     at: now)
+        cache = LinearTickets.merged(cache, project: "Agents CLI",
+                                     tickets: [ticket("A-1")], at: now)
+        cache = LinearTickets.merged(cache, project: "Rush App",
+                                     tickets: [ticket("B-1"), ticket("B-2")], at: now)
+        check("each project keeps its own tickets",
+              cache.scopes["Agents CLI"]?.tickets.count == 1 && cache.scopes["Rush App"]?.tickets.count == 2)
+        check("the project list survives a ticket write", cache.projects.count == 1)
+        check("a just-fetched scope is fresh",
+              LinearTickets.isFresh(cache, project: "Agents CLI", now: now))
+        check("a scope older than the TTL is stale",
+              !LinearTickets.isFresh(cache, project: "Agents CLI",
+                                     now: now.addingTimeInterval(LinearTickets.cacheTTL + 1)))
+        check("an unfetched scope is never fresh",
+              !LinearTickets.isFresh(cache, project: "Prix", now: now))
+
+        // The cache round-trips through JSON — it is read back on the next launch.
+        guard let encoded = try? JSONEncoder().encode(cache),
+              let decoded = try? JSONDecoder().decode(LinearTickets.Cache.self, from: encoded) else {
+            check("cache round-trips through JSON", false)
+            return
+        }
+        check("cache round-trips through JSON",
+              decoded.scopes["Rush App"]?.tickets == cache.scopes["Rush App"]?.tickets)
+    }
+
+    // Dispatching an existing ticket must produce a real, scoped, self-reporting
+    // run — and the Plan variant must not tell an agent to change code.
+    private static func testTicketDispatchContract() {
+        let t = ticket("RUSH-2098", title: "Surface the repo's open tickets", priority: 2)
+        let args = AgentsCLI.ticketWorkRunArgs(
+            agent: "claude",
+            prompt: AgentsCLI.ticketWorkPrompt(ticket: t, action: .run),
+            ticket: t, action: .run, cwd: "/Users/me/src/agents-cli")
+        for flag in ["--mode", "auto", "--balanced", "--notify"] {
+            check("ticket run argv carries \(flag)", args.contains(flag))
+        }
+        check("ticket run is scoped to the picked repo",
+              args.contains("--cwd") && args.contains("/Users/me/src/agents-cli"))
+        check("the session is named after the ticket",
+              args.contains("rush-2098"), detail: args.joined(separator: " "))
+        let planArgs = AgentsCLI.ticketWorkRunArgs(
+            agent: "claude", prompt: "p", ticket: t, action: .plan, cwd: nil)
+        check("a plan dispatch is named apart from the implementation run",
+              planArgs.contains("rush-2098-plan"), detail: planArgs.joined(separator: " "))
+        check("no --cwd when there is no repo to scope to", !planArgs.contains("--cwd"))
+
+        let runPrompt = AgentsCLI.ticketWorkPrompt(ticket: t, action: .run)
+        check("the run brief names the ticket and how to read it",
+              runPrompt.contains("RUSH-2098") && runPrompt.contains("linear tasks RUSH-2098"))
+        check("the run brief claims the ticket and reports back",
+              runPrompt.contains("--status progress") && runPrompt.contains("--comment"))
+        let planPrompt = AgentsCLI.ticketWorkPrompt(ticket: t, action: .plan)
+        check("the plan brief forbids code changes and a PR",
+              planPrompt.contains("Do NOT change code") && planPrompt.contains("do NOT open a PR"))
+        check("the plan brief posts the plan on the ticket",
+              planPrompt.contains("linear update RUSH-2098 --comment"))
+
+        // The click seam: a plain click on a row dispatches THAT ticket, and
+        // Cmd-click opens it in Linear instead of spending an agent run on it.
+        let row = TicketRowView(ticket: t, index: 0)
+        var dispatched: LinearTicket?
+        var opened: LinearTicket?
+        row.onDispatch = { dispatched = $0 }
+        row.onOpen = { opened = $0 }
+        row.mouseDown(with: mouseEvent(modifiers: []))
+        check("a click on a row dispatches that ticket",
+              dispatched?.identifier == t.identifier && opened == nil)
+        dispatched = nil
+        row.mouseDown(with: mouseEvent(modifiers: [.command]))
+        check("cmd-click opens the ticket instead of dispatching",
+              opened?.identifier == t.identifier && dispatched == nil)
+
+        let scopeArgs = AgentsCLI.linearTicketArgs(project: "Agents CLI")
+        check("the ticket query asks for every open ticket of the project",
+              scopeArgs.contains("--all") && scopeArgs.contains("--status")
+                  && scopeArgs.contains("open") && scopeArgs.contains("--cycle")
+                  && scopeArgs.contains("all") && scopeArgs.contains("Agents CLI"),
+              detail: scopeArgs.joined(separator: " "))
+    }
+
     // MARK: helpers
+
+    private static func ticket(_ identifier: String, title: String = "t", priority: Int = 2,
+                               createdAt: String? = "2026-07-01T00:00:00.000Z",
+                               dueDate: String? = nil,
+                               stateType: String = "unstarted") -> LinearTicket {
+        LinearTicket(identifier: identifier, title: title, priority: priority,
+                     state: LinearTicketState(name: stateType == "started" ? "Doing" : "Todo",
+                                              type: stateType),
+                     url: "https://linear.app/getrush/issue/\(identifier)",
+                     dueDate: dueDate, createdAt: createdAt)
+    }
+
+    private static func mouseEvent(modifiers: NSEvent.ModifierFlags) -> NSEvent {
+        NSEvent.mouseEvent(with: .leftMouseDown, location: .zero, modifierFlags: modifiers,
+                           timestamp: 0, windowNumber: 0, context: nil, eventNumber: 0,
+                           clickCount: 1, pressure: 1)!
+    }
+
+    private static func date(_ iso: String) -> Date {
+        let f = ISO8601DateFormatter()
+        return f.date(from: iso) ?? Date(timeIntervalSince1970: 0)
+    }
 
     private static func write(_ dir: URL, _ name: String, modified offset: TimeInterval) {
         let url = dir.appendingPathComponent(name)

--- a/apps/cli/menubar/Sources/MenubarHelper/LinearTickets.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LinearTickets.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+// The quick-dispatch panel's ticket half (Cmd-Shift-O). The panel captures NEW
+// work, and this is what it shows about work that ALREADY exists: the open Linear
+// tickets of the repo the picker is pointed at, ranked so the ones that should be
+// picked up next lead.
+//
+// Everything here is pure or file-local — no network, no AppKit — so the ordering,
+// the repo→project mapping, and the cache are exercised by the MENUBAR_ISSUE_TEST
+// self-test (IssueSelfTest.swift). The actual fetch lives in AgentsCLI, which
+// shells the `linear` skill CLI the same way the ticket-create path does.
+enum LinearTickets {
+    // How many rows the panel shows, and how long a fetched scope is reused
+    // before the next summon refreshes it in the background.
+    static let displayLimit = 5
+    static let cacheTTL: TimeInterval = 90
+
+    // MARK: Repo -> Linear project
+
+    // Collapse a repo directory name or a Linear project name to one comparable
+    // key: lowercase, alphanumerics only. `agents-cli` and "Agents CLI" both
+    // become "agentscli", which is what makes the repo picker able to drive the
+    // project scope without the user configuring a mapping.
+    static func projectKey(_ s: String) -> String {
+        s.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    // The Linear project a repo's tickets live in. `override` is a project name
+    // the user picked explicitly for this repo (remembered per repo by the panel)
+    // and always wins; otherwise the repo name must match a project name under
+    // `projectKey`. No near-match guessing: a repo whose name matches nothing
+    // resolves to nil and the panel says so, rather than silently listing some
+    // other project's tickets.
+    static func resolveProject(repoName: String?,
+                               projects: [LinearProject],
+                               override: String? = nil) -> LinearProject? {
+        if let override, !override.isEmpty,
+           let pinned = projects.first(where: { $0.name == override }) {
+            return pinned
+        }
+        guard let repoName, !repoName.isEmpty else { return nil }
+        let key = projectKey(repoName)
+        guard !key.isEmpty else { return nil }
+        return projects.first { projectKey($0.name) == key }
+    }
+
+    // MARK: Ranking — "what should I pick up next?"
+
+    // Linear's priority scale is 1=urgent … 4=low with 0 meaning "no priority",
+    // so 0 has to be pushed past 4 instead of sorting first.
+    static func priorityOrder(_ priority: Int) -> Int {
+        priority <= 0 ? 5 : priority
+    }
+
+    static func priorityLabel(_ priority: Int) -> String {
+        priority <= 0 ? "--" : "P\(priority)"
+    }
+
+    // Dates arrive as ISO-8601 UTC (`createdAt`) and plain `yyyy-MM-dd`
+    // (`dueDate`), both of which compare correctly as strings — so the ordering
+    // needs no date parsing and no locale.
+    static func today(_ now: Date = Date()) -> String {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .iso8601)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: now)
+    }
+
+    static func isOverdue(_ ticket: LinearTicket, now: Date = Date()) -> Bool {
+        guard let due = ticket.dueDate, !due.isEmpty else { return false }
+        return due < today(now)
+    }
+
+    // Urgent first, then overdue, then already in progress — ascending, so a
+    // smaller key leads. Exposed so the self-test asserts the rule itself, not
+    // just one sorted example. Recency is the tiebreak, applied in `rank` because
+    // it runs the other way (newest first).
+    static func rankKey(_ ticket: LinearTicket, now: Date = Date()) -> (Int, Int, Int) {
+        (priorityOrder(ticket.priority),
+         isOverdue(ticket, now: now) ? 0 : 1,
+         ticket.isStarted ? 0 : 1)
+    }
+
+    static func rank(_ tickets: [LinearTicket], now: Date = Date()) -> [LinearTicket] {
+        tickets.sorted { a, b in
+            let (ka, kb) = (rankKey(a, now: now), rankKey(b, now: now))
+            if ka != kb { return ka < kb }
+            // ISO-8601 UTC timestamps compare correctly as strings; a ticket with
+            // no timestamp sorts after one that has it.
+            let (ca, cb) = (a.createdAt ?? "", b.createdAt ?? "")
+            if ca != cb { return ca > cb }
+            return a.identifier < b.identifier
+        }
+    }
+
+    // MARK: Filtering — type to find an existing ticket before filing a new one
+
+    // Match the typed note against identifier + title, every whitespace-separated
+    // term having to appear somewhere (so "menubar ticket" finds a ticket titled
+    // "Menu bar: dispatch a ticket"). An empty query matches everything, which is
+    // what keeps the unfiltered list showing the top-ranked tickets.
+    static func filter(_ tickets: [LinearTicket], query: String) -> [LinearTicket] {
+        let terms = query.lowercased().split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard !terms.isEmpty else { return tickets }
+        return tickets.filter { ticket in
+            let haystack = "\(ticket.identifier) \(ticket.title)".lowercased()
+            return terms.allSatisfy { haystack.contains($0) }
+        }
+    }
+
+    // MARK: Cache
+
+    // Warm cache so a summon renders tickets immediately instead of waiting on a
+    // `linear tasks` round trip (measured 0.4-3.6s). Same durable, gitignored home
+    // as the recent-tickets ledger.
+    struct Cache: Codable {
+        var projects: [LinearProject] = []
+        var projectsFetchedAt: Double = 0
+        var scopes: [String: Scope] = [:]
+
+        struct Scope: Codable {
+            var fetchedAt: Double
+            var tickets: [LinearTicket]
+        }
+    }
+
+    private static var cacheURL: URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".agents/.history/menubar/linear-cache.json")
+    }
+
+    static func loadCache() -> Cache {
+        guard let data = try? Data(contentsOf: cacheURL),
+              let cache = try? JSONDecoder().decode(Cache.self, from: data) else { return Cache() }
+        return cache
+    }
+
+    static func saveCache(_ cache: Cache) {
+        try? FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if let out = try? JSONEncoder().encode(cache) { try? out.write(to: cacheURL) }
+    }
+
+    /// Pure cache update for one project's tickets — replaces that scope and
+    /// leaves every other scope (and the project list) untouched.
+    static func merged(_ cache: Cache, project: String, tickets: [LinearTicket],
+                       at now: Date = Date()) -> Cache {
+        var next = cache
+        next.scopes[project] = Cache.Scope(fetchedAt: now.timeIntervalSince1970, tickets: tickets)
+        return next
+    }
+
+    static func merged(_ cache: Cache, projects: [LinearProject], at now: Date = Date()) -> Cache {
+        var next = cache
+        next.projects = projects
+        next.projectsFetchedAt = now.timeIntervalSince1970
+        return next
+    }
+
+    /// True when a scope was fetched recently enough that the panel can show it
+    /// without kicking a refresh.
+    static func isFresh(_ cache: Cache, project: String, now: Date = Date(),
+                        ttl: TimeInterval = cacheTTL) -> Bool {
+        guard let scope = cache.scopes[project] else { return false }
+        return now.timeIntervalSince1970 - scope.fetchedAt <= ttl
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -25,6 +25,41 @@ struct MenuAgent {
     let label: String
 }
 
+// One entry of `linear projects --json` (the linear skill CLI). Only the fields
+// the quick-dispatch panel needs to name and scope a project are decoded.
+struct LinearProject: Codable, Equatable {
+    let id: String
+    let name: String
+}
+
+// Shape of `linear tasks --json`: a scope envelope around the issue list.
+struct LinearTasksResponse: Decodable {
+    let count: Int
+    let issues: [LinearTicket]
+}
+
+// One open Linear issue as the quick-dispatch panel shows it. `priority` is
+// Linear's own scale — 1 urgent, 2 high, 3 medium, 4 low, 0 none (0 sorts last,
+// see LinearTickets.rank). Cached to disk, so Codable both ways.
+struct LinearTicket: Codable, Equatable {
+    let identifier: String
+    let title: String
+    let priority: Int
+    let state: LinearTicketState?
+    let url: String?
+    let dueDate: String?
+    let createdAt: String?
+
+    // "started" is Linear's state type for in-progress workflow states.
+    var isStarted: Bool { state?.type == "started" }
+    var stateName: String { state?.name ?? "" }
+}
+
+struct LinearTicketState: Codable, Equatable {
+    let name: String
+    let type: String
+}
+
 struct RecentSession: Decodable {
     let id: String?
     let shortId: String?

--- a/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
@@ -24,6 +24,9 @@ private let kAccent = NSColor(red: 0xa3/255.0, green: 0xe6/255.0, blue: 0x35/255
 final class PromptPanel: NSPanel {
     var onResignKey: (() -> Void)?
     var onBecomeKey: (() -> Void)?
+    // Cmd-1 … Cmd-9 dispatch the Nth listed ticket. Returns true when the index
+    // matched a visible row, so an unhandled digit still reaches the field editor.
+    var onTicketShortcut: ((Int) -> Bool)?
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
     override func resignKey() {
@@ -42,6 +45,10 @@ final class PromptPanel: NSPanel {
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
            let key = event.charactersIgnoringModifiers?.lowercased() {
+            if let digit = Int(key), digit >= 1, digit <= 9,
+               onTicketShortcut?(digit - 1) == true {
+                return true
+            }
             let selector: Selector?
             switch key {
             case "v": selector = #selector(NSText.paste(_:))
@@ -107,6 +114,102 @@ final class ClipThumbView: NSView {
     }
 }
 
+// One open Linear ticket in the panel's list. Click dispatches it to the selected
+// agents in the picked repo; Cmd-click opens it in Linear instead (the escape hatch
+// for "I want to read it first"). A row is a real button-shaped surface — hover
+// highlight and a `⌘N` chip — because dispatching an agent on a click needs to look
+// deliberate, not incidental.
+final class TicketRowView: NSView {
+    let ticket: LinearTicket
+    var onDispatch: ((LinearTicket) -> Void)?
+    var onOpen: ((LinearTicket) -> Void)?
+    static let height: CGFloat = 22
+
+    private var hovered = false { didSet { updateChrome() } }
+
+    init(ticket: LinearTicket, index: Int) {
+        self.ticket = ticket
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 5
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: Self.height).isActive = true
+
+        let shortcut = Self.label(index < 9 ? "\u{2318}\(index + 1)" : "",
+                                  color: .tertiaryLabelColor, width: 24)
+        let priority = Self.label(LinearTickets.priorityLabel(ticket.priority),
+                                  color: Self.priorityColor(ticket.priority), width: 24)
+        let identifier = Self.label(ticket.identifier, color: kAccent, width: 80)
+        let state = Self.label(ticket.stateName, color: .tertiaryLabelColor, width: 56)
+        // A long title truncates instead of widening the panel.
+        let title = Self.label(ticket.title, color: .labelColor, width: nil)
+        title.lineBreakMode = .byTruncatingTail
+        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: [shortcut, priority, identifier, state, title])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 8
+        row.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(row)
+        NSLayoutConstraint.activate([
+            row.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            row.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            row.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
+        var tip = "\(ticket.identifier) — \(ticket.title)"
+        if let due = ticket.dueDate, !due.isEmpty { tip += "\ndue \(due)" }
+        tip += "\nclick dispatches · \u{2318}click opens in Linear"
+        toolTip = tip
+        updateChrome()
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas { removeTrackingArea(area) }
+        addTrackingArea(NSTrackingArea(rect: bounds,
+                                       options: [.mouseEnteredAndExited, .activeAlways],
+                                       owner: self, userInfo: nil))
+    }
+    override func mouseEntered(with event: NSEvent) { hovered = true }
+    override func mouseExited(with event: NSEvent) { hovered = false }
+
+    override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.command) {
+            onOpen?(ticket)
+        } else {
+            onDispatch?(ticket)
+        }
+    }
+
+    private func updateChrome() {
+        layer?.backgroundColor = hovered
+            ? kAccent.withAlphaComponent(0.14).cgColor
+            : NSColor.clear.cgColor
+    }
+
+    // Linear's scale: 1 urgent, 2 high, 3 medium, 4 low, 0 none.
+    static func priorityColor(_ priority: Int) -> NSColor {
+        switch priority {
+        case 1: return .systemRed
+        case 2: return .systemOrange
+        case 3: return .secondaryLabelColor
+        default: return .tertiaryLabelColor
+        }
+    }
+
+    private static func label(_ text: String, color: NSColor, width: CGFloat?) -> NSTextField {
+        let field = NSTextField(labelWithString: text)
+        field.font = .monospacedSystemFont(ofSize: 11.5, weight: .regular)
+        field.textColor = color
+        field.translatesAutoresizingMaskIntoConstraints = false
+        if let width { field.widthAnchor.constraint(equalToConstant: width).isActive = true }
+        return field
+    }
+}
+
 enum QuickDispatchAction: Int {
     case plan = 0
     case run = 1
@@ -143,6 +246,11 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
     // strip for manual attach, since the user can see exactly what they're picking.
     private static let recentClipWindow: TimeInterval = 10 * 60
     private static let panelWidth: CGFloat = 640
+    // Panel height is additive: the capture half is fixed, and the screenshot strip
+    // and the ticket list each add their own block when they have content.
+    private static let baseHeight: CGFloat = 156
+    private static let thumbStripHeight: CGFloat = 92
+    private static let ticketSectionChrome: CGFloat = 36   // header row + stack spacing
 
     private var panel: PromptPanel?
     private let field = NSTextField()
@@ -158,6 +266,21 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
     private let repoPicker = NSPopUpButton(frame: .zero, pullsDown: false)
     private var repoDirs: [String] = []
     private static let lastRepoKey = "menubar.quickDispatch.lastRepo"
+    // Ticket half: the picked repo's Linear project, its open tickets ranked
+    // urgent-first, and the rows currently shown (the ranked list narrowed by
+    // whatever has been typed).
+    private let projectPicker = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let ticketStatus = NSTextField(labelWithString: "")
+    private let ticketList = NSStackView()
+    private var linearCache = LinearTickets.Cache()
+    private var activeProject: LinearProject?
+    private var visibleTickets: [LinearTicket] = []
+    // Bumped on every scope change so a slow `linear tasks` answering after the
+    // user switched repo/project is dropped instead of overwriting the new list.
+    private var ticketFetchToken = 0
+    private var repoNamesByDir: [String: String] = [:]
+    private var rebuildingProjectPicker = false
+    private static let projectOverrideKeyPrefix = "menubar.quickDispatch.project."
     private var selected: [String] = []   // newest-first order preserved
     private var selectedAgents = Set<String>()
     private var roster: [MenuAgent] = []
@@ -189,10 +312,13 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         rebuildAgents(restoring: restoredDraft?.selectedAgents)
         rebuildThumbs(restoring: restoredDraft?.selectedPaths)
         rebuildRepos()
+        // Tickets render from the warm cache first (a `linear tasks` round trip
+        // costs seconds), then refresh in the background.
+        linearCache = LinearTickets.loadCache()
+        refreshTicketScope()
 
-        let hasThumbs = !thumbStrip.arrangedSubviews.isEmpty
-        thumbStrip.isHidden = !hasThumbs
-        panel.setContentSize(NSSize(width: Self.panelWidth, height: hasThumbs ? 248 : 156))
+        thumbStrip.isHidden = thumbStrip.arrangedSubviews.isEmpty
+        applyContentHeight()
 
         dismissArmed = false
         position(panel)
@@ -205,7 +331,11 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
             FileHandle.standardError.write(Data(
                 "summon: frame=\(panel.frame) visible=\(panel.isVisible) thumbs=\(thumbStrip.arrangedSubviews.count)\n".utf8))
         }
-        // Arm click-outside dismissal once the activation race has settled.
+        // Arm click-outside dismissal once the activation race has settled. The
+        // preview affordance leaves it disarmed: its whole point is to hold the
+        // panel on screen for QA and screenshots, and an unbundled dev build does
+        // not keep app activation, so an armed panel dismisses itself immediately.
+        guard ProcessInfo.processInfo.environment["MENUBAR_PROMPT_PREVIEW"] != "1" else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
             self?.dismissArmed = true
         }
@@ -351,6 +481,8 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
 
     @objc private func onRepoChanged(_ sender: NSPopUpButton) {
         updateHint()
+        // The repo IS the ticket scope: switching it switches the Linear project.
+        refreshTicketScope()
     }
 
     // MARK: Repo picker
@@ -384,6 +516,199 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         let idx = repoPicker.indexOfSelectedItem
         guard idx >= 0, idx < repoDirs.count else { return nil }
         return repoDirs[idx]
+    }
+
+    // MARK: Linear tickets
+
+    // The repo name behind the picked directory — the key that maps to a Linear
+    // project. Resolving it shells out to git for the common dir (a worktree must
+    // answer with its parent repo), so it runs off the main thread and is memoized
+    // for the life of the helper: the first summon for a directory fills its ticket
+    // list one beat late, every later summon has the name before the panel is on
+    // screen. Deliberately NOT persisted — a directory that gets renamed or
+    // repurposed would otherwise keep answering with a name that no longer exists.
+    private func currentRepoName() -> String? {
+        guard let dir = selectedRepo() else { return nil }
+        if let known = repoNamesByDir[dir] { return known }
+        resolveRepoName(dir: dir)
+        return nil
+    }
+
+    private func resolveRepoName(dir: String) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let name = AgentsCLI.repoName(forDir: dir)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.repoNamesByDir[dir] = name
+                if dir == self.selectedRepo() { self.refreshTicketScope() }
+            }
+        }
+    }
+
+    private func projectOverride(for repoName: String) -> String? {
+        UserDefaults.standard.string(forKey: Self.projectOverrideKeyPrefix + repoName)
+    }
+
+    @objc private func onProjectChanged(_ sender: NSPopUpButton) {
+        // Populating the popup selects its first item, which arrives here as an
+        // action — persisting that would pin every repo to whatever project Linear
+        // happens to list first.
+        guard !rebuildingProjectPicker else { return }
+        guard let name = sender.titleOfSelectedItem, let repoName = currentRepoName(),
+              name != activeProject?.name else { return }
+        // An explicit pick sticks to this repo, which is how a repo whose name
+        // matches no project (or matches the wrong one) gets scoped correctly.
+        UserDefaults.standard.set(name, forKey: Self.projectOverrideKeyPrefix + repoName)
+        refreshTicketScope()
+    }
+
+    // Point the ticket list at the project behind the picked repo: rebuild the
+    // project popup, render whatever is cached, and fetch when the cache is stale.
+    private func refreshTicketScope() {
+        ticketFetchToken += 1
+        let repoName = currentRepoName()
+        activeProject = LinearTickets.resolveProject(
+            repoName: repoName,
+            projects: linearCache.projects,
+            override: repoName.flatMap { projectOverride(for: $0) })
+        rebuildProjectPicker()
+
+        if linearCache.projects.isEmpty { fetchProjects() }
+
+        guard let project = activeProject else {
+            visibleTickets = []
+            if selectedRepo() == nil {
+                renderTickets(status: "pick a repo to see its tickets")
+            } else if let repoName {
+                renderTickets(status: "no Linear project matches \(repoName) — pick one")
+            } else {
+                // The repo name is still being resolved (first summon for this dir).
+                renderTickets(status: "loading…")
+            }
+            return
+        }
+        let cached = linearCache.scopes[project.name]?.tickets
+        visibleTickets = rankedAndFiltered(cached ?? [])
+        renderTickets(status: cached == nil ? "loading \(project.name)…" : nil)
+        if !LinearTickets.isFresh(linearCache, project: project.name) {
+            fetchTickets(project: project.name)
+        }
+    }
+
+    private func fetchProjects() {
+        let token = ticketFetchToken
+        AgentsCLI.linearProjectsAsync { [weak self] projects in
+            guard let self, let projects else { return }
+            self.linearCache = LinearTickets.merged(self.linearCache, projects: projects)
+            LinearTickets.saveCache(self.linearCache)
+            // A project list arriving after a scope change still helps the CURRENT
+            // scope, so re-resolve rather than dropping it on the token check.
+            if token == self.ticketFetchToken || self.activeProject == nil { self.refreshTicketScope() }
+        }
+    }
+
+    private func fetchTickets(project: String) {
+        let token = ticketFetchToken
+        AgentsCLI.linearTicketsAsync(project: project) { [weak self] tickets in
+            guard let self else { return }
+            guard let tickets else {
+                if token == self.ticketFetchToken, self.visibleTickets.isEmpty {
+                    self.renderTickets(status: "could not reach Linear")
+                }
+                return
+            }
+            self.linearCache = LinearTickets.merged(self.linearCache, project: project,
+                                                    tickets: tickets)
+            LinearTickets.saveCache(self.linearCache)
+            guard token == self.ticketFetchToken, self.activeProject?.name == project else { return }
+            self.visibleTickets = self.rankedAndFiltered(tickets)
+            self.renderTickets()
+        }
+    }
+
+    // Urgent first, then narrowed by whatever the user has typed — so typing a few
+    // words shows the tickets that already cover it before Return files a new one.
+    private func rankedAndFiltered(_ tickets: [LinearTicket]) -> [LinearTicket] {
+        let query = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let matched = LinearTickets.filter(LinearTickets.rank(tickets), query: query)
+        return Array(matched.prefix(LinearTickets.displayLimit))
+    }
+
+    private func renderTickets(status: String? = nil) {
+        for v in ticketList.arrangedSubviews {
+            ticketList.removeArrangedSubview(v)
+            v.removeFromSuperview()
+        }
+        for (index, ticket) in visibleTickets.enumerated() {
+            let row = TicketRowView(ticket: ticket, index: index)
+            row.onDispatch = { [weak self] t in self?.dispatchTicket(t) }
+            row.onOpen = { [weak self] t in self?.openTicket(t) }
+            ticketList.addArrangedSubview(row)
+            row.widthAnchor.constraint(equalTo: ticketList.widthAnchor).isActive = true
+        }
+        ticketList.isHidden = visibleTickets.isEmpty
+        ticketStatus.stringValue = status ?? ticketCountText()
+        applyContentHeight()
+        updateHint()
+    }
+
+    private func ticketCountText() -> String {
+        guard let project = activeProject else { return "" }
+        let total = linearCache.scopes[project.name]?.tickets.count ?? 0
+        if total == 0 { return "no open tickets" }
+        if visibleTickets.isEmpty { return "\(total) open · none match what you typed" }
+        return "\(total) open · urgent first · click or \u{2318}N dispatches"
+    }
+
+    private func rebuildProjectPicker() {
+        rebuildingProjectPicker = true
+        defer { rebuildingProjectPicker = false }
+        projectPicker.removeAllItems()
+        let names = linearCache.projects.map(\.name)
+        guard !names.isEmpty else {
+            projectPicker.addItem(withTitle: activeProject?.name ?? "Linear project")
+            projectPicker.isEnabled = false
+            return
+        }
+        projectPicker.isEnabled = true
+        for name in names {
+            projectPicker.addItem(withTitle: name)
+            projectPicker.lastItem?.toolTip = "Scope the ticket list to \(name)"
+        }
+        if let active = activeProject, let idx = names.firstIndex(of: active.name) {
+            projectPicker.selectItem(at: idx)
+        }
+    }
+
+    // Cmd-click a row: read the ticket in Linear instead of dispatching it. Same
+    // dismissal suppression as the screenshot preview — the browser taking focus
+    // must not throw away the typed note.
+    private func openTicket(_ ticket: LinearTicket) {
+        guard let raw = ticket.url, let url = URL(string: raw) else { return }
+        suppressDismiss = true
+        NSWorkspace.shared.open(url)
+    }
+
+    // Dispatch an EXISTING ticket: same agents, same repo, same balanced headless
+    // run as a quick Run — Plan asks for a plan comment on the ticket, Run asks for
+    // the change. The panel closes immediately, like a submit does, so a second
+    // click can't double-dispatch.
+    private func dispatchTicket(_ ticket: LinearTicket) {
+        guard !inFlight else { return }
+        inFlight = true
+        let cwd = selectedRepo()
+        if let cwd { UserDefaults.standard.set(cwd, forKey: Self.lastRepoKey) }
+        AgentsCLI.dispatchTicketWork(ticket: ticket, agents: selectedAgentList(),
+                                     action: action, cwd: cwd)
+        dismiss(preservingDraft: false)
+    }
+
+    // Dispatch the Nth listed ticket (Cmd-1 … Cmd-9). False when no such row is
+    // listed, so the keystroke falls through to the text field.
+    private func dispatchTicket(at index: Int) -> Bool {
+        guard index >= 0, index < visibleTickets.count else { return false }
+        dispatchTicket(visibleTickets[index])
+        return true
     }
 
     // MARK: Thumbnails
@@ -454,7 +779,38 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         let actionText = action == .plan
             ? "file ticket + plan with \(agents)\(repoName)"
             : "run \(agents)\(repoName) · balanced"
+        // Deliberately unchanged in length by the ticket list: this label's
+        // intrinsic width is what sizes the panel, and the rows carry their own
+        // `⌘N` chips plus a click/⌘click tooltip, so nothing needs saying here.
         hint.stringValue = "\(attach)\(pickable)    ↩ \(actionText) · esc clear"
+    }
+
+    // Typing is also a ticket search: narrow the list so an existing ticket shows
+    // up before Return files a duplicate.
+    func controlTextDidChange(_ obj: Notification) {
+        guard let project = activeProject,
+              let tickets = linearCache.scopes[project.name]?.tickets else {
+            updateHint()
+            return
+        }
+        visibleTickets = rankedAndFiltered(tickets)
+        renderTickets()
+    }
+
+    // Height is additive over the fixed capture half; the panel grows downward from
+    // a fixed top edge while it is on screen, so a list that fills in after an async
+    // fetch doesn't shift the text field out from under the cursor.
+    private func applyContentHeight() {
+        guard let panel else { return }
+        var height = Self.baseHeight + Self.ticketSectionChrome
+            + CGFloat(visibleTickets.count) * TicketRowView.height
+        if !thumbStrip.isHidden { height += Self.thumbStripHeight }
+        guard abs(panel.frame.height - height) > 0.5 else { return }
+        let top = panel.frame.maxY
+        panel.setContentSize(NSSize(width: Self.panelWidth, height: height))
+        if panel.isVisible {
+            panel.setFrameOrigin(NSPoint(x: panel.frame.minX, y: top - panel.frame.height))
+        }
     }
 
     // MARK: Build / layout
@@ -477,6 +833,7 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         }
         // Returning to the bar after a preview re-arms click-outside dismissal.
         panel.onBecomeKey = { [weak self] in self?.suppressDismiss = false }
+        panel.onTicketShortcut = { [weak self] index in self?.dispatchTicket(at: index) ?? false }
 
         let bg = NSVisualEffectView()
         bg.material = .hudWindow
@@ -525,12 +882,38 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         hint.font = .monospacedSystemFont(ofSize: 11.5, weight: .regular)
         hint.textColor = .secondaryLabelColor
 
+        projectPicker.translatesAutoresizingMaskIntoConstraints = false
+        projectPicker.controlSize = .small
+        projectPicker.font = .systemFont(ofSize: 12)
+        projectPicker.target = self
+        projectPicker.action = #selector(onProjectChanged(_:))
+
+        ticketStatus.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        ticketStatus.textColor = .tertiaryLabelColor
+        ticketStatus.lineBreakMode = .byTruncatingTail
+        ticketStatus.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        ticketList.orientation = .vertical
+        ticketList.alignment = .leading
+        ticketList.spacing = 0
+
         let controlRow = NSStackView(views: [modeControl, repoPicker])
         controlRow.orientation = .horizontal
         controlRow.alignment = .centerY
         controlRow.spacing = 12
 
-        let stack = NSStackView(views: [field, controlRow, agentStrip, thumbStrip, hint])
+        // The ticket header names the scope (project popup) and its state; the rows
+        // below it are the open tickets of that project.
+        let ticketTitle = NSTextField(labelWithString: "Tickets")
+        ticketTitle.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
+        ticketTitle.textColor = .secondaryLabelColor
+        let ticketHeader = NSStackView(views: [ticketTitle, projectPicker, ticketStatus])
+        ticketHeader.orientation = .horizontal
+        ticketHeader.alignment = .centerY
+        ticketHeader.spacing = 8
+
+        let stack = NSStackView(views: [field, controlRow, agentStrip, thumbStrip,
+                                        ticketHeader, ticketList, hint])
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 10
@@ -542,6 +925,12 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
             stack.centerYAnchor.constraint(equalTo: bg.centerYAnchor),
             field.widthAnchor.constraint(equalTo: stack.widthAnchor),
             modeControl.widthAnchor.constraint(equalToConstant: 180),
+            ticketList.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            // The panel is a fixed-width bar: cap the two popups so a long repo
+            // path or project name truncates inside them instead of stretching the
+            // window past panelWidth.
+            repoPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 220),
+            projectPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 190),
         ])
         return panel
     }


### PR DESCRIPTION
**Feature** — the `Cmd-Shift-O` quick-dispatch bar now lists the picked repo's open Linear tickets and dispatches one on a click. Ticket: [RUSH-2098](https://linear.app/getrush/issue/RUSH-2098).

The panel only ever captured **new** work. It now also shows the work that **already exists**, so an existing ticket gets picked up instead of duplicated.

## What it looks like

Screenshot of the running panel against live Linear data (repo `agents-cli` → project **Agents CLI**, 58 open, urgent first):
`zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/quickdispatch-tickets.png`
(a path, not an embed — `gh` cannot inline an image; open it on the fleet or drag it into this PR to embed)

```
Tickets  [Agents CLI ▾]   58 open · urgent first · click or ⌘N dispatches
 ⌘1  P1  RUSH-1968  Doing   AGENTS_SECRETS_PASSPHRASE exported in plaintext from ~/.zshenv on yosemite-s0 and…
 ⌘2  P1  RUSH-2078  Todo    prix/code-reviewer is down — 0 reviews across 8 PRs, blocking every merge-on-green
 ⌘3  P2  RUSH-1993  Doing   Fix agents feed count mismatch and clarify session metadata
 ⌘4  P2  RUSH-1978  Doing   Agent Factory: Foreman (Rush) + Mission Control — end-to-end
 ⌘5  P2  RUSH-574   Doing   agents-cli: custom social preview OG card (1280x640) — replace auto-generated GitH…
```

## What changed

| Behavior | How |
|---|---|
| **Scope follows the repo** | The repo name is matched against `linear projects` with both reduced to lowercase alphanumerics, so `agents-cli` → **Agents CLI** with nothing to configure. A worktree resolves to its **parent** repo (git's common dir), not the worktree's directory name. |
| **A repo that matches nothing fails loud** | It says `no Linear project matches <repo> — pick one` rather than listing another project's tickets; the pick is then remembered per repo (this is how an ambiguous name like `rush` gets scoped). |
| **Urgent first** | Priority (`P1`…`P4`, then no-priority) → overdue → in progress → newest. That is the "what do I pick up next" order, not the order Linear returns. |
| **Typing filters** | Every typed word must appear in a row's identifier or title, so a matching ticket surfaces before Return files a duplicate. |
| **Click, or `⌘1`–`⌘5`, dispatches** | Same headless `agents run --mode auto --balanced --notify --cwd <repo>` as a quick Run, named after the ticket (`rush-2098`, `rush-2098-plan`). **Run** claims it (moving it to whichever state `linear states` reports as `started`), implements it per the repo's `AGENTS.md`, comments the result; **Plan** posts a plan comment and changes no code. `⌘`-click opens it in Linear. |
| **Instant panel** | 90-second warm cache at `~/.agents/.history/menubar/linear-cache.json`; a stale scope refreshes in the background and re-renders. |

## Two bugs the real run surfaced (both fixed here)

1. **A monitored child that outgrew the pipe buffer hung forever, silently.** Its stdout was read only from the termination handler, so a child writing more than ~64 KiB blocked on write, never exited, and the completion callback never fired — the very first ticket fetch left two `linear` processes wedged and no notification ever came. Both monitored paths now drain stdout, and feed stdin, on a background queue while the child runs. This also covers the **pre-existing** ticket-agent and `linear create` paths, whose output could already exceed the buffer (`agents run` headless output easily does).
2. **The dispatch brief told agents to claim a ticket with a state that does not exist.** `--status progress` is a `linear tasks` *filter* value, not a workflow state, and `--pickup` hardcodes the name "In Progress" — this workspace's started state is `Doing`, so both fail (`State 'In Progress' not found. Available: … Doing`). Found by running the claim for real on RUSH-2098. The brief now has the agent read `linear states` and move the ticket to whichever state is typed `started`.

## Verification

**Self-test** (`MENUBAR_ISSUE_TEST=1 MenubarHelper`) — 33 new assertions on project resolution, the ranking rule, filtering, the cache round-trip, the dispatch argv/briefs, and the click seam (a synthesized `NSEvent` through `TicketRowView.mouseDown`):

```
PASS  repo name matches a project across case + punctuation
PASS  an ambiguous repo name matches nothing
PASS  an explicit per-repo project wins over the derived match
PASS  urgent leads the list
PASS  no-priority sinks below low
PASS  inside one priority: overdue, then started, then newest
PASS  every term must match, in any order
PASS  a just-fetched scope is fresh
PASS  cache round-trips through JSON
PASS  ticket run is scoped to the picked repo
PASS  the session is named after the ticket
PASS  the plan brief forbids code changes and a PR
PASS  a click on a row dispatches that ticket
PASS  cmd-click opens the ticket instead of dispatching
...
ALL PASS
```

**Live fetch** — the running panel resolved `agents-cli` → `Agents CLI` and cached its real ticket list:

```
$ python3 -c "…" < ~/.agents/.history/menubar/linear-cache.json
projects: ['Linear CLI', 'Rush CLI', 'Prix', 'Rush App', 'Agents CLI', 'zz-autodispatch-e2e (delete me)']
scope Agents CLI tickets 58
```

**Dispatch flag set** — the exact argv the panel builds runs and produces a real named session:

```
$ agents run claude "…" --mode auto --balanced --notify --name rush-2098-plan --cwd …/agents-cli
[agents] running claude@2.1.219 (session b4d1008b)
PINGOK
```

**Not verified:** a physical mouse click on a row in a live session. Clicks were attempted with a real HID event, but the panel was covered by another agent's Touch ID dialog and the box then moved to a fullscreen Space; the click→dispatch seam is instead covered by the self-test case above, driving `TicketRowView.mouseDown` with a real `NSEvent`.

## Notes

- One behavior change outside the feature: `MENUBAR_PROMPT_PREVIEW=1` no longer arms click-outside dismissal, so the QA/screenshot affordance holds the panel on screen (an unbundled dev build cannot keep app activation, so it used to dismiss itself instantly).
- The docs commit also corrects the quick-dispatch section's stale **File Ticket / Fix** labels to **Plan / Run** and documents the repo dropdown, which the Plan/Run rename had left undescribed.
