### PR TITLE
fix(cursor): sync commands as skills (RUSH-2083)

### DIFF
--- a/apps/cli/.changelog/next/rush-2083.md
+++ b/apps/cli/.changelog/next/rush-2083.md
@@ -1,0 +1,1 @@
+- **Cursor command sync now uses Agent Skills instead of the IDE-only `.cursor/commands/` directory (RUSH-2083).** The registry no longer claims native command support for cursor-agent, so the existing commands-as-skills writer emits `~/.cursor/skills/<name>/SKILL.md` and removes stale managed command files from the unused CLI path. Source: `apps/cli/src/lib/agents.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.20.86
 
-- **Cursor command sync now uses Agent Skills instead of the IDE-only `.cursor/commands/` directory (RUSH-2083).** The registry no longer claims native command support for cursor-agent, so the existing commands-as-skills writer emits `~/.cursor/skills/<name>/SKILL.md` and removes stale managed command files from the unused CLI path. Source: `apps/cli/src/lib/agents.ts`.
-
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.20.86
 
+- **Cursor command sync now uses Agent Skills instead of the IDE-only `.cursor/commands/` directory (RUSH-2083).** The registry no longer claims native command support for cursor-agent, so the existing commands-as-skills writer emits `~/.cursor/skills/<name>/SKILL.md` and removes stale managed command files from the unused CLI path. Source: `apps/cli/src/lib/agents.ts`.
+
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -206,7 +206,7 @@ Slash commands in `commands/*.md` can narrow sync with optional YAML frontmatter
 ```yaml
 ---
 description: Required one-line summary
-agents: [claude, cursor, codex]   # omit = all command-capable agents
+agents: [claude, cursor, codex]   # omit = all compatible agents; Cursor receives a skill
 since: "0.116.0"                  # minimum agent CLI version (inclusive)
 until: "0.117.0"                  # exclusive upper bound
 ---
@@ -214,4 +214,4 @@ until: "0.117.0"                  # exclusive upper bound
 
 `commandAppliesTo()` in `src/lib/commands.ts` evaluates these fields after the agent-level `commands` / commands-as-skills gate. The check runs on central sync (`~/.agents/commands/` user/system → version home) and on `agents commands install`; project `.agents/commands/` files are discovered in place and are not filtered by `agents:`.
 
-Example: `.agents/commands/version.md` targets Claude, Codex, Cursor, OpenCode, Copilot, and Grok; Antigravity is excluded until harness support is verified.
+Example: `.agents/commands/version.md` targets Claude, Codex, Cursor, OpenCode, Copilot, and Grok. Cursor receives the command as an Agent Skill because cursor-agent does not support the IDE's `.cursor/commands/` files; Antigravity is excluded until harness support is verified.

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -324,7 +324,10 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     // + warns for pre-2.4 installs); the direct `subagents add --agents cursor` path
     // writes unconditionally, same as the other since-gated agents.
     // See transformSubagentForCursor / https://cursor.com/docs/subagents.
-    capabilities: { hooks: true, mcp: true, mcpHttp: false, mcpHeaders: false, allowlist: true, skills: true, commands: true, plugins: true, subagents: { since: '2026.1.22' }, rules: { file: '.cursorrules' }, workflows: false, memory: false, modes: ['edit', 'skip'] }, // allowlist: ~/.cursor/cli-config.json
+    // Cursor's commands directory belongs to the IDE; cursor-agent does not read
+    // it. Keep commandsSubdir so sync can remove stale managed IDE-era files,
+    // while commands: false routes shared commands through Cursor Agent Skills.
+    capabilities: { hooks: true, mcp: true, mcpHttp: false, mcpHeaders: false, allowlist: true, skills: true, commands: false, plugins: true, subagents: { since: '2026.1.22' }, rules: { file: '.cursorrules' }, workflows: false, memory: false, modes: ['edit', 'skip'] }, // allowlist: ~/.cursor/cli-config.json
   },
   opencode: {
     id: 'opencode',

--- a/apps/cli/src/lib/staleness/writers/commands.ts
+++ b/apps/cli/src/lib/staleness/writers/commands.ts
@@ -6,12 +6,12 @@
  *  - command-as-skill — fires when `shouldInstallCommandAsSkill(agent, version)`
  *    is true. Used for Codex >= 0.117.0 (commands capability ends, skills
  *    capability remains) and agents with skills but no native command-file dir
- *    such as kimi. Writes `{agentDir}/skills/<name>/SKILL.md` with the
+ *    such as Cursor and Kimi. Writes `{agentDir}/skills/<name>/SKILL.md` with the
  *    `agents_command` marker; the agent picks it up as a slash-command equivalent.
  *
  *  - native command file — `{agentDir}/<commandsSubdir>/<name>.md` (or .toml
  *    when the agent's format is toml). Standard path for Claude, Codex
- *    < 0.117.0, Cursor, OpenCode, Copilot, Amp, Kiro, Roo, Antigravity.
+ *    < 0.117.0, OpenCode, Copilot, Amp, Kiro, Roo, Antigravity.
  *
  * Source resolution is `resolveCommandSource` (user → system → extras —
  * project layer intentionally excluded).

--- a/apps/cli/tests/agents.test.ts
+++ b/apps/cli/tests/agents.test.ts
@@ -22,7 +22,7 @@ describe('capableAgents("commands")', () => {
   });
 
   it('includes all other agents that support file-based commands', () => {
-    const expected = ['claude', 'codex', 'cursor', 'opencode'];
+    const expected = ['claude', 'codex', 'opencode'];
     const agents = capableAgents('commands');
     for (const agent of expected) {
       expect(agents).toContain(agent);

--- a/apps/cli/tests/cli-command-sync-spec.test.ts
+++ b/apps/cli/tests/cli-command-sync-spec.test.ts
@@ -272,4 +272,10 @@ describe('CLI command sync: sync-pipeline invariants', () => {
   it('grok uses native command files (per docs: ~/.agents/commands/)', () => {
     expect(shouldInstallCommandAsSkill('grok', '0.2.111')).toBe(false);
   });
+
+  it('cursor installs commands as skills because its commands directory is IDE-only', () => {
+    expect(supports('cursor', 'commands', '2026.07.23-e383d2b').ok).toBe(false);
+    expect(supports('cursor', 'skills', '2026.07.23-e383d2b').ok).toBe(true);
+    expect(shouldInstallCommandAsSkill('cursor', '2026.07.23-e383d2b')).toBe(true);
+  });
 });

--- a/apps/cli/tests/fixtures/cli-command-spec.json
+++ b/apps/cli/tests/fixtures/cli-command-spec.json
@@ -114,8 +114,7 @@
         "path_template": "{HOME}/.cursor/commands/{name}.md",
         "reason": "IDE-only per official Cursor staff response — does not work in cursor-agent CLI."
       }
-    ],
-    "registry_divergence": "agents-cli registry says commandsSubdir='commands' for cursor; per docs this only works in the IDE, not the CLI. CLI needs skills format."
+    ]
   },
 
   "opencode": {


### PR DESCRIPTION
Behavior fix for Cursor CLI command sync; shared commands now use Agent Skills instead of the IDE-only commands directory.

## Verification

Targeted real writer/conformance run:
```text
(pass) CLI command sync: registry-vs-docs conformance > cursor > commands capability should be off (docs say skill-dir only)
(pass) CLI command sync: skill-dir writer output > cursor > writes SKILL.md matching the doc-expected path + frontmatter
(pass) CLI command sync: sync-pipeline invariants > cursor installs commands as skills because its commands directory is IDE-only
48 pass, 16 skip, 0 fail
```

Installed artifact:
```text
$ /home/muqsit/.agents/tmp/cursor-registry-docs/install/bin/agents --version
0.0.0-dev.29cafb71-dirty
```

The supplied sandbox mounted `~/.cursor` and the worktree Git metadata read-only. The real signed-in sync attempt therefore could not create/update Cursor paths; the PR does not claim that hop as verified. `bun run test:remote` also could not start because the available `hetzner.com` secret bundle could not be decrypted on this host. CI is the full-suite gate.

Decision: stop writing `.cursor/commands/` for Cursor CLI. `commandsSubdir` remains only so full sync removes stale files previously managed there; the existing commands-as-skills path writes `.cursor/skills/<name>/SKILL.md`.

Linear: https://linear.app/getrush/issue/RUSH-2083/cursor-commands-capability-stop-claiming-ide-only-slash-commands-for