### PR TITLE
fix(routines): run Cursor daemon jobs

### DIFF
--- a/apps/cli/.changelog/next/cursor-daemon-jobs.md
+++ b/apps/cli/.changelog/next/cursor-daemon-jobs.md
@@ -1,0 +1,1 @@
+- **Routines configured with `agent: cursor` now run through `cursor-agent` and write their report instead of failing as unsupported.**

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.20.86
 
-- **Routines configured with `agent: cursor` now run through `cursor-agent` and write their report instead of failing as unsupported.**
-
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.20.86
 
+- **Routines configured with `agent: cursor` now run through `cursor-agent` and write their report instead of failing as unsupported.**
+
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -74,6 +74,7 @@ const AGENT_COMMANDS: Record<string, string[]> = {
   claude: ['claude', '-p', '--verbose', '{prompt}', '--output-format', 'stream-json', '--permission-mode', 'plan'],
   codex: ['codex', 'exec', '--sandbox', 'workspace-write', '{prompt}', '--json'],
   gemini: ['gemini', '{prompt}', '--output-format', 'stream-json'],
+  cursor: ['cursor-agent', '-p', '{prompt}', '--output-format', 'stream-json'],
   kimi: ['kimi', '--prompt', '{prompt}', '--output-format', 'stream-json'],
   droid: ['droid', 'exec', '{prompt}', '-o', 'stream-json'],
 };
@@ -81,6 +82,7 @@ const AGENT_COMMANDS: Record<string, string[]> = {
 const ROUTINE_TRANSCRIPT_SPECS: Partial<Record<AgentId, Array<{ root: string[]; ext: string }>>> = {
   claude: [{ root: ['.claude', 'projects'], ext: '.jsonl' }],
   codex: [{ root: ['.codex', 'sessions'], ext: '.jsonl' }],
+  cursor: [{ root: ['.cursor', 'projects'], ext: '.jsonl' }],
 };
 
 /** Build the full CLI argv for executing a job, applying mode, model, and permission flags. */
@@ -170,6 +172,17 @@ export function buildJobCommand(config: JobConfig, resolvedPrompt: string): stri
       cmd.push('--approval-mode', 'auto_edit');
     } else if (mode === 'skip') {
       cmd.push('--yolo');
+    }
+
+    appendModelAndReasoning(cmd, config);
+  }
+
+  if (config.agent === 'cursor') {
+    // cursor-agent has no headless read-only flag in the declared capability
+    // table: plan degrades to edit, while skip opts into force approval.
+    const cursorMode = resolveHeadlessMode('cursor', mode, false);
+    if (cursorMode === 'skip') {
+      cmd.push('-f');
     }
 
     appendModelAndReasoning(cmd, config);
@@ -1458,7 +1471,7 @@ export function extractReport(stdoutPath: string, agentType: AgentId): string | 
       try {
         const parsed = JSON.parse(line);
 
-        if (agentType === 'claude') {
+        if (agentType === 'claude' || agentType === 'cursor') {
           if (parsed.type === 'assistant' && parsed.message?.content) {
             for (const block of parsed.message.content) {
               if (block.type === 'text' && block.text) {

--- a/apps/cli/tests/runner-loop.test.ts
+++ b/apps/cli/tests/runner-loop.test.ts
@@ -112,10 +112,10 @@ describe('executeJob — loop driver (issue #400)', () => {
     const deps = makeLoopDeps(calls);
 
     // No loop field — should go to the single-shot spawn path.
-    // Use agent 'cursor' which buildJobCommand rejects immediately (unsupported),
+    // Use agent 'antigravity' which buildJobCommand rejects immediately (unsupported),
     // so executeJob throws without ever reaching a real spawn or the loop driver.
     await expect(
-      executeJob(makeConfig({ agent: 'cursor' as any }), deps),
+      executeJob(makeConfig({ agent: 'antigravity' as any }), deps),
     ).rejects.toThrow('Unsupported agent for daemon jobs');
 
     // Loop driver must not have been invoked.

--- a/apps/cli/tests/runner.test.ts
+++ b/apps/cli/tests/runner.test.ts
@@ -149,9 +149,58 @@ describe('buildJobCommand', () => {
     });
   });
 
+  describe('cursor', () => {
+    it('builds the exact edit mode command without a mode flag', () => {
+      expect(buildJobCommand(makeConfig({ agent: 'cursor', mode: 'edit' }), 'hello')).toEqual([
+        'cursor-agent',
+        '-p',
+        'hello',
+        '--output-format',
+        'stream-json',
+      ]);
+    });
+
+    it('builds the exact skip mode command with force approval', () => {
+      expect(buildJobCommand(makeConfig({ agent: 'cursor', mode: 'skip' }), 'hello')).toEqual([
+        'cursor-agent',
+        '-p',
+        'hello',
+        '--output-format',
+        'stream-json',
+        '-f',
+      ]);
+    });
+
+    it('degrades plan mode to edit without inventing a read-only flag', () => {
+      expect(buildJobCommand(makeConfig({ agent: 'cursor', mode: 'plan' }), 'hello')).toEqual([
+        'cursor-agent',
+        '-p',
+        'hello',
+        '--output-format',
+        'stream-json',
+      ]);
+    });
+
+    it('adds --model when config.model is set', () => {
+      expect(buildJobCommand(makeConfig({
+        agent: 'cursor',
+        mode: 'edit',
+        config: { model: 'sonnet-4-thinking' },
+      }), 'hello')).toEqual([
+        'cursor-agent',
+        '-p',
+        'hello',
+        '--output-format',
+        'stream-json',
+        '--model',
+        'sonnet-4-thinking',
+      ]);
+    });
+  });
+
   it('throws for unsupported agent', () => {
-    expect(() => buildJobCommand(makeConfig({ agent: 'cursor' }), 'hello')).toThrow(
-      'Unsupported agent for daemon jobs: cursor'
+    expect(() => buildJobCommand(makeConfig({ agent: 'antigravity' }), 'hello')).toThrow(
+      'Unsupported agent for daemon jobs: antigravity'
     );
   });
 });
@@ -202,6 +251,23 @@ describe('extractReport', () => {
     writeFileSync(logPath, lines.join('\n'), 'utf-8');
 
     expect(extractReport(logPath, 'gemini')).toBe('Gemini final report');
+  });
+
+  it('extracts the last assistant text from cursor stream-json', () => {
+    const lines = [
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'First' }] },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'Cursor final report' }] },
+      }),
+    ];
+    const logPath = join(TEST_DIR, 'cursor.log');
+    writeFileSync(logPath, lines.join('\n'), 'utf-8');
+
+    expect(extractReport(logPath, 'cursor')).toBe('Cursor final report');
   });
 
   it('returns null for nonexistent file', () => {


### PR DESCRIPTION
Fix: routines configured with `agent: cursor` now execute Cursor and persist the assistant report.

## What changed

- Added the existing `agents run cursor` argv shape to the daemon runner: edit has no mode flag, skip adds `-f`, and plan degrades through `resolveHeadlessMode`.
- Forwarded Cursor model configuration and parsed Cursor stream JSON into `report.md`. Cursor reasoning flags are not implemented and remain out of scope.
- Kept the Cursor `.cursor/projects` transcript archive specification for the reader landing in PR #1724. The cited end-to-end run did not produce a `sessions/` archive, so transcript archiving is not claimed as verified here.
- Repointed the two intentionally unsupported-agent tests to `antigravity`; added exact edit/skip/plan/model argv and report parsing coverage.
- Kept the other unsupported daemon agents out of scope. RUSH-2101 tracks native Cursor plan capability; RUSH-2102 tracks validating supported routine agents at add time.

## Real routine verification

Installed branch artifact: `0.0.0-dev.29cafb71-dirty`

```text
Running job 'rush-2080-cursor-e2e' (agent: cursor, mode: skip)
[agents] routine rush-2080-cursor-e2e: running cursor
✔ Job completed (exit code: 0)
  Run: 2026-08-02T12-06-02-073Z

Report:

RUSH_2080_CURSOR_ROUTINE_OK
```

Focused Vitest result: `Test Files 2 passed (2); Tests 34 passed (34)`. The required remote sandbox command was attempted, but its Hetzner secret could not be unlocked on this headless host; GitHub CI is the full-suite gate.

No UI surface. Local run evidence: `yosemite-s0:/home/muqsit/.agents/.history/runs/rush-2080-cursor-e2e/2026-08-02T12-06-02-073Z/`.

Linear: https://linear.app/getrush/issue/RUSH-2080
