### PR TITLE
feat(sessions): discover and render Cursor agent transcripts

### DIFF
--- a/apps/cli/.changelog/1.20.86.md
+++ b/apps/cli/.changelog/1.20.86.md
@@ -1,5 +1,3 @@
-- **`agents sessions` now discovers, indexes, and renders Cursor agent transcripts.**
-
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/.changelog/1.20.86.md
+++ b/apps/cli/.changelog/1.20.86.md
@@ -1,3 +1,5 @@
+- **`agents sessions` now discovers, indexes, and renders Cursor agent transcripts.**
+
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/.changelog/next/RUSH-2081.md
+++ b/apps/cli/.changelog/next/RUSH-2081.md
@@ -2,4 +2,6 @@
   Cursor writes its conversation to `projects/<encoded-cwd>/agent-transcripts/<uuid>/<uuid>.jsonl`
   and metadata to `chats/<workspace-hash>/<uuid>/meta.json`. Discovery starts from the transcript
   and joins metadata by UUID, so abandoned chats with no transcript never become empty rows.
+  Cursor is installed outside agents-cli's managed version homes, so users with any managed
+  agent version must pass `--unmanaged` to include Cursor rows.
   Source: `apps/cli/src/lib/session/discover.ts`, `apps/cli/src/lib/session/parse.ts`.

--- a/apps/cli/.changelog/next/RUSH-2081.md
+++ b/apps/cli/.changelog/next/RUSH-2081.md
@@ -1,0 +1,5 @@
+- **`agents sessions` now discovers, indexes, and renders Cursor agent transcripts (RUSH-2081).**
+  Cursor writes its conversation to `projects/<encoded-cwd>/agent-transcripts/<uuid>/<uuid>.jsonl`
+  and metadata to `chats/<workspace-hash>/<uuid>/meta.json`. Discovery starts from the transcript
+  and joins metadata by UUID, so abandoned chats with no transcript never become empty rows.
+  Source: `apps/cli/src/lib/session/discover.ts`, `apps/cli/src/lib/session/parse.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -367,7 +367,7 @@ bug; fix the drift. It uses RFC-2119 MUST/SHOULD language, cites the implementin
 
 - **[`docs/specifications.md` §Sessions](docs/specifications.md#sessions)** — the `agents sessions`
   contract. Load-bearing invariants: discovery MUST parse **every** harness in
-  `SESSION_AGENTS` (all 11) and a malformed line MUST be skipped, never thrown
+  `SESSION_AGENTS` (all 12) and a malformed line MUST be skipped, never thrown
   (SES-1, SES-3); every list row MUST show a **non-empty preview** — live turn →
   `label` → first-prompt `topic` → `'-'` (SES-8; `--flat` and the interactive
   picker share the one unguarded renderer, SES-GAP-1); "where a session started"

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -114,6 +114,8 @@
 
 ## 1.20.86
 
+- **`agents sessions` now discovers, indexes, and renders Cursor agent transcripts.**
+
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -114,8 +114,6 @@
 
 ## 1.20.86
 
-- **`agents sessions` now discovers, indexes, and renders Cursor agent transcripts.**
-
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -24,6 +24,7 @@ Per-agent on-disk session files (not owned by agents-cli, read-only):
 ~/.local/share/opencode/project/*/storage/session/...     # OpenCode
 ~/Library/Application Support/OpenClaw/sessions/*.json    # OpenClaw
 ~/.cursor/projects/*/agent-transcripts/*/*.jsonl          # Cursor
+~/.cursor/chats/<workspace-hash>/<uuid>/meta.json         # Cursor cwd/title/timestamps
 
 Routine archives (owned by agents-cli, durable):
 ~/.agents/.history/runs/<routine>/<run-id>/sessions/<agent>/...
@@ -68,6 +69,11 @@ create / delete / rename bumps the dir mtime and forces a full re-walk of that d
 Set `AGENTS_SESSIONS_NO_DIR_LEDGER=1` to disable the short-circuit and force the old
 full per-file walk.
 
+Cursor is installed outside agents-cli's version homes. Once any managed agent
+version exists, the default managed scope excludes Cursor transcripts; pass
+`--unmanaged` (for example, `agents sessions --agent cursor --unmanaged`) to list
+them. `--all` controls age filtering and does not replace `--unmanaged`.
+
 When a **Claude**, **Codex**, or **Kimi** transcript that already has an index row
 grows, the scan does not re-read it from the top. The `scan_ledger` stores a
 resumable continuation (`parser_state` — a byte offset plus an accumulator snapshot,
@@ -91,7 +97,7 @@ from-scratch full reparse, even when a signal straddles two scans. Both incremen
 paths apply only newline-terminated lines and defer a complete-but-unterminated
 trailing record to the next pass, so a record written before its `'\n'` is flushed
 is never double-counted. Grok is not incremental — it reads a whole `summary.json`,
-not an append-only JSONL; Gemini still full-parses each changed file.
+not an append-only JSONL; Gemini and Cursor still full-parse each changed file.
 
 ## SessionMeta (list output)
 

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -6,7 +6,7 @@
 
 Unified discovery, search, and rendering of agent conversation transcripts across
 the session-discoverable harnesses — Claude, Codex, Gemini, Antigravity, OpenCode,
-OpenClaw, Rush, Hermes, Grok, Kimi, and Droid (the `SESSION_AGENTS` set in
+OpenClaw, Rush, Hermes, Grok, Kimi, Droid, and Cursor (the `SESSION_AGENTS` set in
 `src/lib/session/types.ts`).
 
 ## Architecture
@@ -23,6 +23,7 @@ Per-agent on-disk session files (not owned by agents-cli, read-only):
 ~/.gemini/tmp/<project>/chats/session-*.json              # Gemini
 ~/.local/share/opencode/project/*/storage/session/...     # OpenCode
 ~/Library/Application Support/OpenClaw/sessions/*.json    # OpenClaw
+~/.cursor/projects/*/agent-transcripts/*/*.jsonl          # Cursor
 
 Routine archives (owned by agents-cli, durable):
 ~/.agents/.history/runs/<routine>/<run-id>/sessions/<agent>/...
@@ -127,7 +128,7 @@ Fields:
 |---|---|---|
 | `id` | Agent-native UUID | Primary key; stable across reloads |
 | `shortId` | First 8 chars of `id` | For human matching in CLI output |
-| `agent` | One of 11 formats | See the `SessionAgentId` / `SESSION_AGENTS` union |
+| `agent` | One of 12 formats | See the `SessionAgentId` / `SESSION_AGENTS` union |
 | `origin` | `cli` or `routine` | Routine rows are archived from a run directory and can be filtered with `--routine` |
 | `routineName` | Routine name | Present when `origin` is `routine` |
 | `routineRunId` | Routine run id | Present when `origin` is `routine`; `agents sessions <runId>` resolves it |

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -418,7 +418,7 @@ Each source answers a different question:
 
 | Source | Question | Coverage | Misses |
 |---|---|---|---|
-| `agents sessions --json` | What local CLI and team-spawned agents have run recently? | The `SESSION_AGENTS` harnesses on this laptop (Claude, Codex, Gemini, Antigravity, OpenCode, OpenClaw, Rush, Hermes, Grok, Kimi, Droid) | Pure-cloud runs with no local file |
+| `agents sessions --json` | What local CLI and team-spawned agents have run recently? | The `SESSION_AGENTS` harnesses on this laptop (Claude, Codex, Gemini, Antigravity, OpenCode, OpenClaw, Rush, Hermes, Grok, Kimi, Droid, Cursor) | Pure-cloud runs with no local file |
 | `agents cloud list --json` | What am I running on remote VMs right now? | Rush Cloud, Codex Cloud, Factory | Local sessions |
 | `agents teams list --json` | What multi-agent DAGs are active? | All team-coordinated runs | Standalone agents |
 

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -25,7 +25,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Self-healing installs](self-healing.md) | Detect, surface, and repair a broken agent binary (gutted install / `ENOENT`) instead of dying cryptically. |
 | [Resource sync](02-resource-sync.md) | How rules, commands, skills, hooks, etc. land in each version home. |
 | [**Specifications**](specifications.md) | **The normative contract** (MUST/SHOULD + Given/When/Then, cited to `file:line`) for the major subsystems — [Sessions](specifications.md#sessions), [Secrets](specifications.md#secrets), [Agent execution](specifications.md#agent-execution). Read the spec for the guarantee; the per-feature docs below for the how-to. |
-| [Sessions](05-sessions.md) | Unified transcript discovery across all 11 `SESSION_AGENTS` harnesses (Claude, Codex, Gemini, Antigravity, OpenCode, OpenClaw, Rush, Hermes, Grok, Kimi, Droid); resume, export/import, and migrate a live session across machines. |
+| [Sessions](05-sessions.md) | Unified transcript discovery across all 12 `SESSION_AGENTS` harnesses (Claude, Codex, Gemini, Antigravity, OpenCode, OpenClaw, Rush, Hermes, Grok, Kimi, Droid, Cursor); resume, export/import, and migrate a live session across machines. |
 | [Observability](06-observability.md) | The three `--json` sources (sessions / cloud / teams) as a fleet view, plus `agents mailboxes` fleet comms. |
 | [SSH transport](09-ssh-transport.md) | The one multiplexed engine every `--host` command rides — default connection reuse, keepalive, one-round-trip follow. |
 | [Optimizations](99-optimizations.md) | Sync manifest, SSH transport, startup profiling, hot-path notes. |

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -237,11 +237,11 @@ The rich `SessionActivity` maps to a coarse `ActiveStatus` the renderer and coun
 use: `working → running`, `waiting_input → input_required`, `idle → idle`. Rich
 state is derived for **every tracked harness**: Claude/Codex take the fast bounded
 byte-tail (`readSessionTailWithRaw`, which also yields tokens/sec), and every other
-tracked kind (grok, droid, rush, gemini, kimi, hermes, opencode, antigravity) is
+tracked kind (grok, droid, rush, gemini, kimi, hermes, opencode, antigravity, cursor) is
 parsed by its own parser and run through the same `inferSessionState`
 (`computeLiveSignals` → `parseSession`). `findSessionFileForKind` locates the
 transcript for all of them — Claude off disk by cwd, the rest via the session index
-(`latestSessionFileForCwd`). Only an **opaque/untracked** kind (cursor) or an
+(`latestSessionFileForCwd`). Only an **opaque/untracked** kind or an
 unreadable/empty transcript has no rich state, and then one canonical function,
 `resolveFallbackStatus(sessionFile, pidAlive)`, decides the status:
 

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -153,7 +153,7 @@ Two formats trip people up (both handled in [`src/lib/session/discover.ts`](../s
 the **session-discoverable** set is `SESSION_AGENTS`
 ([`src/lib/session/types.ts`](../src/lib/session/types.ts)): `claude`, `codex`,
 `gemini`, `antigravity`, `opencode`, `openclaw`, `rush`, `hermes`, `grok`, `kimi`,
-`droid`. `cursor` and `copilot` are runnable but not session-discoverable.
+`droid`, `cursor`. `copilot` is runnable but not session-discoverable.
 `isSessionTrackedAgent()` in the same file is the single predicate every session-index
 writer gates on.
 

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -113,8 +113,8 @@ SSH access (§7); rendering sessions that no harness produced.
 #### 3.1 Discovery & harness parsing
 
 - **SES-1 (MUST).** The canonical session-capable harness set is
-  `SESSION_AGENTS` — exactly these 11, in display order: `claude, codex, gemini,
-  antigravity, opencode, openclaw, rush, hermes, grok, kimi, droid`
+  `SESSION_AGENTS` — exactly these 12, in display order: `claude, codex, gemini,
+  antigravity, opencode, openclaw, rush, hermes, grok, kimi, droid, cursor`
   (`lib/session/types.ts:14`). Adding harness discovery MUST extend this set (and
   its parser + `dispatchAgentScan` arm), not special-case a caller.
 - **SES-2 (MUST).** Each harness's transcript location + on-disk format is fixed
@@ -377,7 +377,7 @@ normative — a change that widens/narrows a cell is a spec change.
 
 | Behavior | macOS | Linux | Windows |
 |---|---|---|---|
-| Discovery & parsing (all 11 harnesses) | yes | yes | yes |
+| Discovery & parsing (all 12 harnesses) | yes | yes | yes |
 | Process table source | `ps` | `ps` | `Get-CimInstance Win32_Process` (`active.ts:793-799`) |
 | PID-reuse start-time guard | yes | yes | **no** — bare existence (`active.ts:299-300`) |
 | Live-process provenance | `ps eww` | `/proc/<pid>/environ` | **none** (`provenance.ts:196-217`) |

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -124,7 +124,7 @@ SSH access (§7); rendering sessions that no harness produced.
   home, every version-home, and backup mirrors, deduped by realpath, **live root
   scanned first** (`lib/session/discover.ts:772-787,1092-1093`).
 - **SES-3 (MUST).** A malformed JSONL **line** MUST be skipped, never thrown —
-  for every harness (`lib/session/parse.ts:322-328,531-537,720-726,1004-1010,1151,1356-1362,1448-1454,1538-1544,1691-1697`).
+  for every harness (`lib/session/parse.ts:322-328,531-537,1004-1010,1151,1356-1362,1448-1454,1538-1544,1707-1713`).
 - **SES-4 (MUST).** An unrecognized path MUST fail loudly
   (`Cannot detect agent type from path`), never be silently mis-indexed
   (`lib/session/parse.ts:143-147`); an unknown agent id in the scanner is a no-op,

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -124,7 +124,7 @@ SSH access (§7); rendering sessions that no harness produced.
   home, every version-home, and backup mirrors, deduped by realpath, **live root
   scanned first** (`lib/session/discover.ts:772-787,1092-1093`).
 - **SES-3 (MUST).** A malformed JSONL **line** MUST be skipped, never thrown —
-  for every harness (`lib/session/parse.ts:292-298,501-507,1120,1327-1332,1509-1513,1654-1658`).
+  for every harness (`lib/session/parse.ts:322-328,531-537,720-726,1004-1010,1151,1356-1362,1448-1454,1538-1544,1691-1697`).
 - **SES-4 (MUST).** An unrecognized path MUST fail loudly
   (`Cannot detect agent type from path`), never be silently mis-indexed
   (`lib/session/parse.ts:143-147`); an unknown agent id in the scanner is a no-op,

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -1976,7 +1976,7 @@ export function registerRunCommand(program: Command): void {
         const { buildContinuePrompt } = await import('../lib/loop.js');
 
         // Freshen the index for this agent before any lookup (incremental, cached).
-        // AgentId is wider than SessionAgentId (cursor/amp/… keep no transcripts);
+        // AgentId is wider than SessionAgentId (amp/kiro/goose/copilot keep no transcripts);
         // those simply yield no matches and fall through to the not-found error.
         const sessionAgent = agent as import('../lib/session/types.js').SessionAgentId;
         await discoverSessions({ agent: sessionAgent, version });

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -46,7 +46,7 @@ import { listMcpServerConfigs, discoverMcpConfigsFromRepo, type McpYamlConfig } 
 import { discoverPlugins, discoverPluginsInDir, pluginResourceGroups, type PluginResourceGroup } from '../lib/plugins.js';
 import { PLUGIN_GROUP_COLORS } from './plugins.js';
 import { countSessionsInScope } from '../lib/session/discover.js';
-import type { SessionAgentId } from '../lib/session/types.js';
+import { isSessionTrackedAgent } from '../lib/session/types.js';
 import { damerauLevenshtein } from '../lib/fuzzy.js';
 import { terminalWidth, truncateToWidth, stringWidth, stripAnsi } from '../lib/session/width.js';
 
@@ -1353,12 +1353,7 @@ function safeStat(p: string): fs.Stats | null {
   try { return fs.statSync(p); } catch { return null; }
 }
 
-const SESSION_AGENTS: ReadonlySet<string> = new Set([
-  'claude', 'codex', 'gemini', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid',
-]);
-
 function safeCountSessions(agent: AgentId): number {
-  if (!SESSION_AGENTS.has(agent)) return 0;
-  try { return countSessionsInScope({ agent: agent as SessionAgentId }); } catch { return 0; }
+  if (!isSessionTrackedAgent(agent)) return 0;
+  try { return countSessionsInScope({ agent }); } catch { return 0; }
 }
-

--- a/apps/cli/src/commands/sessions-migrate.test.ts
+++ b/apps/cli/src/commands/sessions-migrate.test.ts
@@ -27,7 +27,7 @@ describe('effectiveMode — harness parity gate', () => {
   });
 
   it('downgrades resume→rehydrate for every non-resumable agent (no silent skip)', () => {
-    const nonResumable: SessionAgentId[] = ['gemini', 'antigravity', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid'];
+    const nonResumable: SessionAgentId[] = ['gemini', 'antigravity', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid', 'cursor'];
     for (const agent of nonResumable) {
       const r = effectiveMode(meta(agent), 'resume');
       expect(r).toEqual({ mode: 'rehydrate', downgraded: true });

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2656,6 +2656,7 @@ export function buildResumeCommand(session: SessionMeta): string[] | null {
     case 'grok':
     case 'kimi':
     case 'droid':
+    case 'cursor':
       // Grok (and some others) sessions are captured artifacts, not resumable the same way.
       return null;
   }

--- a/apps/cli/src/lib/session/__tests__/parse-cursor.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-cursor.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { readCursorMeta } from '../discover.js';
+import { detectAgent, parseCursor, parseSession } from '../parse.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'testdata', 'cursor-session.jsonl');
+const SESSION_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+describe('Cursor session parsing and discovery metadata', () => {
+  let root: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-cursor-'));
+    transcriptPath = path.join(
+      root, '.cursor', 'projects', 'tmp-public-project', 'agent-transcripts',
+      SESSION_ID, `${SESSION_ID}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+    fs.copyFileSync(FIXTURE, transcriptPath);
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  test('maps text and tool-use blocks and ignores turn_ended', () => {
+    const events = parseCursor(transcriptPath);
+    expect(events).toHaveLength(4);
+    expect(events[0]).toMatchObject({ agent: 'cursor', type: 'message', role: 'user' });
+    expect(events[1]).toMatchObject({
+      agent: 'cursor', type: 'message', role: 'assistant',
+      content: 'I will inspect the session documentation.',
+    });
+    expect(events[2]).toMatchObject({
+      agent: 'cursor', type: 'tool_use', tool: 'Read',
+      path: '/tmp/public-project/docs/sessions.md',
+    });
+    expect(events[3]).toMatchObject({
+      agent: 'cursor', type: 'message', role: 'assistant',
+      content: 'The sessions command discovers and renders local transcripts.',
+    });
+  });
+
+  test('joins authoritative cwd, title, and timestamps from chats meta.json', () => {
+    const metaPath = path.join(root, '.cursor', 'chats', 'workspace-hash', SESSION_ID, 'meta.json');
+    fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+    fs.writeFileSync(metaPath, JSON.stringify({
+      schemaVersion: 1,
+      createdAtMs: 1785654071336,
+      hasConversation: true,
+      title: 'Session command audit',
+      updatedAtMs: 1785668144486,
+      cwd: '/tmp/public-project',
+    }));
+
+    const result = readCursorMeta(transcriptPath, '2026.07.23-e383d2b');
+    expect(result).not.toBeNull();
+    expect(result!.meta).toMatchObject({
+      id: SESSION_ID,
+      shortId: '123e4567',
+      agent: 'cursor',
+      timestamp: '2026-08-02T07:01:11.336Z',
+      lastActivity: '2026-08-02T10:55:44.486Z',
+      cwd: '/tmp/public-project',
+      project: 'public-project',
+      label: 'Session command audit',
+      topic: 'Inspect the public CLI documentation and summarize the session commands.',
+      messageCount: 3,
+    });
+    expect(result!.content).toBe('Inspect the public CLI documentation and summarize the session commands.');
+  });
+
+  test('indexes transcript-only archives without inventing cwd or title', () => {
+    const result = readCursorMeta(transcriptPath);
+    expect(result).not.toBeNull();
+    expect(result!.meta.cwd).toBe('');
+    expect(result!.meta.project).toBeUndefined();
+    expect(result!.meta.label).toBeUndefined();
+    expect(result!.meta.messageCount).toBe(3);
+  });
+
+  test('detectAgent and parseSession route Cursor transcript paths', () => {
+    expect(detectAgent(transcriptPath)).toBe('cursor');
+    expect(parseSession(transcriptPath)).toEqual(parseCursor(transcriptPath));
+  });
+
+  test('skips malformed JSONL lines without dropping valid events', () => {
+    fs.appendFileSync(transcriptPath, '{not json}\n');
+    expect(parseCursor(transcriptPath)).toHaveLength(4);
+  });
+});

--- a/apps/cli/src/lib/session/__tests__/parse-cursor.test.ts
+++ b/apps/cli/src/lib/session/__tests__/parse-cursor.test.ts
@@ -29,7 +29,11 @@ describe('Cursor session parsing and discovery metadata', () => {
   test('maps text and tool-use blocks and ignores turn_ended', () => {
     const events = parseCursor(transcriptPath);
     expect(events).toHaveLength(4);
-    expect(events[0]).toMatchObject({ agent: 'cursor', type: 'message', role: 'user' });
+    expect(events[0]).toMatchObject({
+      agent: 'cursor', type: 'message', role: 'user',
+      content: 'Inspect the public CLI documentation and summarize the session commands.',
+      timestamp: '2026-08-02T10:51:00.000Z',
+    });
     expect(events[1]).toMatchObject({
       agent: 'cursor', type: 'message', role: 'assistant',
       content: 'I will inspect the session documentation.',
@@ -45,6 +49,9 @@ describe('Cursor session parsing and discovery metadata', () => {
   });
 
   test('joins authoritative cwd, title, and timestamps from chats meta.json', () => {
+    const unrelatedMetaPath = path.join(root, '.cursor', 'chats', 'another-workspace', 'other-session', 'meta.json');
+    fs.mkdirSync(path.dirname(unrelatedMetaPath), { recursive: true });
+    fs.writeFileSync(unrelatedMetaPath, JSON.stringify({ title: 'Different session' }));
     const metaPath = path.join(root, '.cursor', 'chats', 'workspace-hash', SESSION_ID, 'meta.json');
     fs.mkdirSync(path.dirname(metaPath), { recursive: true });
     fs.writeFileSync(metaPath, JSON.stringify({

--- a/apps/cli/src/lib/session/active.livesignals.test.ts
+++ b/apps/cli/src/lib/session/active.livesignals.test.ts
@@ -42,9 +42,9 @@ describe('computeLiveSignals wires every tracked harness into real state', () =>
 
   it('an untracked/opaque kind yields no state (falls back to the live floor upstream)', () => {
     const file = freshCopy('grok-idle/chat_history.jsonl', 'chat_history.jsonl');
-    // `cursor` has no parser — computeLiveSignals returns {} and the caller's
+    // `amp` is not session-tracked — computeLiveSignals returns {} and the caller's
     // resolveFallbackStatus reports `running` for the live process.
-    expect(computeLiveSignals('cursor', file, path.dirname(file), true)).toEqual({});
+    expect(computeLiveSignals('amp', file, path.dirname(file), true)).toEqual({});
   });
 
   it('no transcript file yields no state', () => {

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -574,7 +574,7 @@ export function lifecycleStatus(
 
 /**
  * The ONE place a fallback status is decided when no rich transcript state is
- * available — an opaque kind we cannot parse (cursor, openclaw), or a transcript
+ * available — an opaque kind we cannot parse (openclaw), or a transcript
  * whose parse/tail was empty or unreadable. Honest by construction: computed from
  * PID + mtime, never a fabricated `idle`.
  *

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -600,13 +600,13 @@ export function resolveFallbackStatus(
  * Locate the live transcript for an agent process. Claude files are keyed by cwd
  * (+ optional session uuid), so they resolve straight off disk. Every OTHER
  * tracked harness — Codex (date-partitioned), plus grok / droid / rush / gemini /
- * kimi / hermes / opencode / antigravity (per-session dirs, SQLite, single-JSON)
+ * kimi / hermes / opencode / antigravity / cursor (per-session dirs, SQLite, single-JSON)
  * — is resolved through the session index by cwd: the newest indexed transcript
  * for that cwd, bounded by ACTIVE_SESSION_STALE_MS so a live pid never borrows a
  * weeks-old transcript. This is what lets a live NON-claude/codex agent get a real
  * status instead of falling through to `unknown` (the file feeds
- * {@link computeLiveSignals}). An opaque kind we don't track (cursor) still yields
- * undefined here and degrades honestly to a live `running`.
+ * {@link computeLiveSignals}). An opaque kind we don't track still yields undefined
+ * here and degrades honestly to a live `running`.
  */
 export function findSessionFileForKind(kind: string, cwd?: string, sessionId?: string): string | undefined {
   if (!cwd) return undefined;
@@ -661,10 +661,10 @@ function parseTailEventsForKind(agent: SessionAgentId, sessionFile: string): Ses
  * Claude/Codex take the fast bounded byte-tail ({@link readSessionTailWithRaw}) —
  * the hot path, and the only two that also yield throughput (their raw lines
  * carry usage the event model drops). EVERY OTHER tracked harness (grok, droid,
- * rush, gemini, kimi, hermes, opencode, antigravity) is parsed with its own
+ * rush, gemini, kimi, hermes, opencode, antigravity, cursor) is parsed with its own
  * parser and run through the SAME {@link inferSessionState}, so a live
  * non-claude/codex agent gets a real working/waiting/idle instead of the blanket
- * `unknown` it used to fall through to. An opaque/untracked kind (cursor) or an
+ * `unknown` it used to fall through to. An opaque/untracked kind or an
  * unreadable/empty transcript yields an empty signal set, and the caller's
  * {@link resolveFallbackStatus} reports the honest live floor (`running`).
  */

--- a/apps/cli/src/lib/session/discover.test.ts
+++ b/apps/cli/src/lib/session/discover.test.ts
@@ -95,13 +95,13 @@ describe('scanAgentsBounded (mitigation 3 — no simultaneous multi-dotfile burs
 });
 
 describe('getSessionRoots (the `agents sessions --roots --json` payload, issue #741)', () => {
-  const KNOWN_AGENTS = new Set(['claude', 'codex', 'gemini', 'antigravity', 'droid', 'kimi', 'grok']);
+  const KNOWN_AGENTS = new Set(['claude', 'codex', 'gemini', 'antigravity', 'droid', 'kimi', 'grok', 'cursor']);
   // The subdir each agent's roots must end with — the discovery contract external
   // watchers depend on. A drift here (e.g. gemini → 'sessions' instead of 'tmp')
   // would silently point the extension's fs.watch at the wrong directory.
   const EXPECTED_SUBDIR: Record<string, string> = {
     claude: 'projects', codex: 'sessions', gemini: 'tmp',
-    antigravity: 'conversations', droid: 'sessions', kimi: 'sessions', grok: 'sessions',
+    antigravity: 'conversations', droid: 'sessions', kimi: 'sessions', grok: 'sessions', cursor: 'projects',
   };
 
   it('never throws and returns a well-formed SessionRoots[]', () => {

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -27,7 +27,7 @@ import { getConfigSymlinkVersion } from '../shims.js';
 import { SESSION_AGENTS } from './types.js';
 import { deriveShortId } from './short-id.js';
 import { extractSessionTopic } from './prompt.js';
-import { parseAntigravity } from './parse.js';
+import { parseAntigravity, parseCursor } from './parse.js';
 import { extractPrUrl, detectWorktree, detectTicket, isPrCreateCommand, detectSpawnedTeam, isTicketCreateTool, extractCreatedTicket, extractRecentDirectoriesTouched, extractTodoProgressFromEvents } from './state.js';
 import { costOfUsage } from '../pricing/index.js';
 import { machineId } from './sync/config.js';
@@ -383,6 +383,7 @@ function dispatchAgentScan(
     case 'kimi': return scanKimiIncremental(onProgress);
     case 'droid': return scanDroidIncremental(onProgress);
     case 'grok': return scanGrokIncremental(onProgress);
+    case 'cursor': return scanCursorIncremental(onProgress);
     default: return Promise.resolve();
   }
 }
@@ -897,6 +898,7 @@ const SESSION_ROOT_SPECS: ReadonlyArray<{ agent: SessionAgentId; subdir: string 
   { agent: 'droid', subdir: 'sessions' },
   { agent: 'kimi', subdir: 'sessions' },
   { agent: 'grok', subdir: 'sessions' },
+  { agent: 'cursor', subdir: 'projects' },
 ];
 
 function sessionRootSubdir(agent: SessionAgentId): string | null {
@@ -1000,6 +1002,11 @@ async function readRoutineArchiveMeta(
 
   if (agent === 'codex') {
     const result = await readCodexMeta(filePath);
+    return result ? { ...result, meta: decorateRoutineSession(result.meta, info) } : null;
+  }
+
+  if (agent === 'cursor') {
+    const result = await readCursorMeta(filePath);
     return result ? { ...result, meta: decorateRoutineSession(result.meta, info) } : null;
   }
 
@@ -4227,6 +4234,148 @@ function sumKnownNumbers(values: unknown[]): number | null {
 // ---------------------------------------------------------------------------
 // Time range parsing
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Cursor
+// ---------------------------------------------------------------------------
+// Cursor writes the conversation to
+// projects/<encoded-cwd>/agent-transcripts/<uuid>/<uuid>.jsonl and metadata to
+// chats/<workspace-hash>/<uuid>/meta.json. Discovery deliberately starts from
+// transcripts, then joins metadata by UUID: chat directories with no transcript
+// are empty or abandoned sessions and must not become broken zero-event rows.
+// Routine archives may contain only the transcript; those remain browsable with
+// file timestamps and without guessed cwd/title metadata.
+
+/** Incrementally re-scan changed Cursor transcript files and upsert into the DB. */
+async function scanCursorIncremental(onProgress?: (p: ScanProgress) => void): Promise<void> {
+  const currentVersion = await getCurrentAgentVersion('cursor');
+  const prestat: PreStatEntry[] = [];
+
+  for (const projectsDir of getAgentSessionDirs('cursor', 'projects')) {
+    collectCursorTranscripts(projectsDir, prestat);
+  }
+
+  const changed = filterChangedEntries(prestat);
+  if (changed.length === 0) return;
+
+  onProgress?.({ agent: 'cursor', parsed: 0, total: changed.length });
+
+  const entries: ScanEntry[] = [];
+  const touched: Array<{ filePath: string; scan: ScanStamp }> = [];
+  const seen = new Set<string>();
+  let parsed = 0;
+  for (const { filePath, scan } of changed) {
+    try {
+      const result = readCursorMeta(filePath, currentVersion);
+      if (result && !seen.has(result.meta.id)) {
+        seen.add(result.meta.id);
+        entries.push({ meta: result.meta, content: result.content, scan });
+      } else {
+        touched.push({ filePath, scan });
+      }
+    } catch {
+      touched.push({ filePath, scan });
+    }
+    parsed++;
+    onProgress?.({ agent: 'cursor', parsed, total: changed.length });
+  }
+
+  upsertSessionsBatch(entries);
+  recordScans(touched);
+}
+
+function collectCursorTranscripts(projectsDir: string, out: PreStatEntry[]): void {
+  let projectNames: string[];
+  try {
+    projectNames = fs.readdirSync(projectsDir);
+  } catch {
+    return;
+  }
+
+  for (const projectName of projectNames) {
+    const transcriptsDir = path.join(projectsDir, projectName, 'agent-transcripts');
+    for (const f of walkForFilesWithStat(transcriptsDir, '.jsonl', 100_000)) {
+      const sessionId = path.basename(path.dirname(f.path));
+      if (path.basename(f.path) !== `${sessionId}.jsonl`) continue;
+      out.push({ filePath: f.path, fileMtimeMs: f.mtimeMs, fileSize: f.size });
+    }
+  }
+}
+
+function readCursorChatMeta(filePath: string, sessionId: string): any | undefined {
+  const projectDir = path.dirname(path.dirname(path.dirname(filePath)));
+  const projectsDir = path.dirname(projectDir);
+  const chatsDir = path.join(path.dirname(projectsDir), 'chats');
+  let workspaceHashes: string[];
+  try {
+    workspaceHashes = fs.readdirSync(chatsDir);
+  } catch {
+    return undefined;
+  }
+
+  for (const workspaceHash of workspaceHashes) {
+    const metaPath = path.join(chatsDir, workspaceHash, sessionId, 'meta.json');
+    try {
+      return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+    } catch {
+      // This workspace hash does not own the session, or its metadata is unreadable.
+    }
+  }
+  return undefined;
+}
+
+function cursorUserText(text: string): string {
+  const query = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
+  return (query?.[1] || text).trim();
+}
+
+/** Parse one Cursor transcript and enrich it with the matching chat meta.json. */
+export function readCursorMeta(
+  filePath: string,
+  currentVersion?: string,
+): { meta: SessionMeta; content: string } | null {
+  const sessionId = path.basename(filePath).replace(/\.jsonl$/, '');
+  if (!sessionId || path.basename(path.dirname(filePath)) !== sessionId) return null;
+
+  const events = parseCursor(filePath);
+  if (events.length === 0) return null;
+
+  const chatMeta = readCursorChatMeta(filePath, sessionId);
+  const stat = safeStatSync(filePath);
+  const createdAtMs = typeof chatMeta?.createdAtMs === 'number' ? chatMeta.createdAtMs : undefined;
+  const updatedAtMs = typeof chatMeta?.updatedAtMs === 'number' ? chatMeta.updatedAtMs : undefined;
+  const timestamp = createdAtMs !== undefined
+    ? new Date(createdAtMs).toISOString()
+    : stat ? stat.mtime.toISOString() : new Date().toISOString();
+  const lastActivity = updatedAtMs !== undefined
+    ? new Date(updatedAtMs).toISOString()
+    : stat ? stat.mtime.toISOString() : timestamp;
+  const cwd = normalizeCwd(typeof chatMeta?.cwd === 'string' ? chatMeta.cwd : '');
+  const userTexts = events
+    .filter((event) => event.type === 'message' && event.role === 'user' && event.content)
+    .map((event) => cursorUserText(event.content!));
+  const firstUserText = userTexts[0];
+  const title = typeof chatMeta?.title === 'string' && chatMeta.title.trim()
+    ? chatMeta.title.trim()
+    : undefined;
+
+  const meta: SessionMeta = {
+    id: sessionId,
+    shortId: deriveShortId(sessionId),
+    agent: 'cursor',
+    timestamp,
+    lastActivity,
+    project: cwd ? path.basename(cwd) : undefined,
+    cwd,
+    filePath,
+    version: resolveSessionVersion('cursor', filePath, undefined, currentVersion),
+    topic: firstUserText ? extractSessionTopic(firstUserText) : undefined,
+    label: title,
+    messageCount: events.filter((event) => event.type === 'message').length,
+  };
+
+  return { meta, content: userTexts.join('\n') };
+}
 
 // ---------------------------------------------------------------------------
 // Kimi

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -1006,7 +1006,10 @@ async function readRoutineArchiveMeta(
   }
 
   if (agent === 'cursor') {
-    const result = await readCursorMeta(filePath);
+    // PR #1723 archives Cursor routine transcripts; preserve version resolution
+    // when this reader consumes those archives.
+    const currentVersion = await getCurrentAgentVersion('cursor');
+    const result = readCursorMeta(filePath, currentVersion);
     return result ? { ...result, meta: decorateRoutineSession(result.meta, info) } : null;
   }
 
@@ -4324,11 +4327,6 @@ function readCursorChatMeta(filePath: string, sessionId: string): any | undefine
   return undefined;
 }
 
-function cursorUserText(text: string): string {
-  const query = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
-  return (query?.[1] || text).trim();
-}
-
 /** Parse one Cursor transcript and enrich it with the matching chat meta.json. */
 export function readCursorMeta(
   filePath: string,
@@ -4353,7 +4351,7 @@ export function readCursorMeta(
   const cwd = normalizeCwd(typeof chatMeta?.cwd === 'string' ? chatMeta.cwd : '');
   const userTexts = events
     .filter((event) => event.type === 'message' && event.role === 'user' && event.content)
-    .map((event) => cursorUserText(event.content!));
+    .map((event) => event.content!);
   const firstUserText = userTexts[0];
   const title = typeof chatMeta?.title === 'string' && chatMeta.title.trim()
     ? chatMeta.title.trim()

--- a/apps/cli/src/lib/session/parse.ts
+++ b/apps/cli/src/lib/session/parse.ts
@@ -1671,6 +1671,16 @@ export function parseCursor(filePath: string): SessionEvent[] {
   return parseAnthropicMessageJsonl(filePath, 'cursor');
 }
 
+function parseCursorUserText(text: string): { text: string; timestamp?: string } {
+  const query = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
+  const timestampText = text.match(/<timestamp>\s*([\s\S]*?)\s*<\/timestamp>/)?.[1]?.trim();
+  const parsedTimestamp = timestampText ? Date.parse(timestampText) : Number.NaN;
+  return {
+    text: (query?.[1] ?? text).trim(),
+    timestamp: Number.isNaN(parsedTimestamp) ? undefined : new Date(parsedTimestamp).toISOString(),
+  };
+}
+
 function parseAnthropicMessageJsonl(filePath: string, agent: 'cursor' | 'droid'): SessionEvent[] {
   const content = safeReadSessionFile(filePath);
   const lines = content.split('\n').filter(l => l.trim());
@@ -1689,14 +1699,18 @@ function parseAnthropicMessageJsonl(filePath: string, agent: 'cursor' | 'droid')
     if (raw.type === 'turn_ended' || (agent === 'droid' && raw.type !== 'message')) continue;
     const message = raw.message;
     const wireRole = agent === 'cursor' ? raw.role : message?.role;
-    if (!message || !['user', 'assistant'].includes(wireRole)) continue;
+    if (!message || (agent === 'cursor' && !['user', 'assistant'].includes(wireRole))) continue;
 
     const role = wireRole === 'user' ? 'user' : 'assistant';
-    const timestamp = raw.timestamp || fallbackTimestamp;
+    let timestamp = raw.timestamp || fallbackTimestamp;
     const blocks = message.content;
 
     if (typeof blocks === 'string') {
-      const text = blocks.trim();
+      const parsed = agent === 'cursor' && role === 'user'
+        ? parseCursorUserText(blocks)
+        : { text: blocks.trim(), timestamp: undefined };
+      const text = parsed.text;
+      timestamp = parsed.timestamp || timestamp;
       if (text) events.push({ type: 'message', agent, timestamp, role, content: text });
       continue;
     }
@@ -1704,7 +1718,11 @@ function parseAnthropicMessageJsonl(filePath: string, agent: 'cursor' | 'droid')
 
     for (const block of blocks) {
       if (block.type === 'text') {
-        const text = (block.text || '').trim();
+        const parsed = agent === 'cursor' && role === 'user'
+          ? parseCursorUserText(block.text || '')
+          : { text: (block.text || '').trim(), timestamp: undefined };
+        const text = parsed.text;
+        timestamp = parsed.timestamp || timestamp;
         if (text && !(role === 'user' && text.startsWith('<system-reminder>'))) {
           events.push({ type: 'message', agent, timestamp, role, content: text });
         }

--- a/apps/cli/src/lib/session/parse.ts
+++ b/apps/cli/src/lib/session/parse.ts
@@ -160,6 +160,7 @@ export function parseSession(filePath: string, agent?: SessionAgentId): SessionE
     case 'hermes': events = parseHermes(filePath); break;
     case 'kimi': events = parseKimi(filePath); break;
     case 'droid': events = parseDroid(filePath); break;
+    case 'cursor': events = parseCursor(filePath); break;
   }
 
   // Chokepoint: every string field that originated in an untrusted session
@@ -193,6 +194,7 @@ export function detectAgent(filePath: string): SessionAgentId | null {
   if (filePath.includes('/.hermes/') || filePath.includes('\\.hermes\\')) return 'hermes';
   if (filePath.includes('/.kimi-code/') || filePath.includes('\\.kimi-code\\')) return 'kimi';
   if (filePath.includes('/.factory/') || filePath.includes('\\.factory\\')) return 'droid';
+  if (filePath.includes('/.cursor/') || filePath.includes('\\.cursor\\')) return 'cursor';
   // Cloud convention: cloud-sessions/<id>/session.<format>.jsonl
   const cloudMatch = filePath.match(/session\.(claude|codex|rush)\.jsonl(?:$|[?#])/);
   if (cloudMatch) return cloudMatch[1] as SessionAgentId;
@@ -1661,22 +1663,20 @@ export function parseKimi(filePath: string): SessionEvent[] {
 }
 
 // ---------------------------------------------------------------------------
-// Droid (Factory) parser
+// Cursor and Droid (Factory) parsers
 // ---------------------------------------------------------------------------
 
-/**
- * Parse a Droid (Factory) JSONL session file into normalized events. Droid
- * wraps each turn in a `{type:'message', message:{role, content, modelId}}`
- * envelope; the content blocks are Anthropic-shaped (text/thinking/tool_use/
- * tool_result), so block handling mirrors the Claude parser.
- */
-export function parseDroid(filePath: string): SessionEvent[] {
+/** Parse Cursor's Anthropic-shaped message JSONL transcript. */
+export function parseCursor(filePath: string): SessionEvent[] {
+  return parseAnthropicMessageJsonl(filePath, 'cursor');
+}
+
+function parseAnthropicMessageJsonl(filePath: string, agent: 'cursor' | 'droid'): SessionEvent[] {
   const content = safeReadSessionFile(filePath);
   const lines = content.split('\n').filter(l => l.trim());
   const events: SessionEvent[] = [];
-
-  // Map tool_use id -> {tool, args} for correlating with tool_result.
   const toolUseMap = new Map<string, { tool: string; args: Record<string, any> }>();
+  const fallbackTimestamp = fs.statSync(filePath).mtime.toISOString();
 
   for (const line of lines) {
     let raw: any;
@@ -1686,17 +1686,18 @@ export function parseDroid(filePath: string): SessionEvent[] {
       continue;
     }
 
-    if (raw.type !== 'message') continue;
+    if (raw.type === 'turn_ended' || (agent === 'droid' && raw.type !== 'message')) continue;
+    const message = raw.message;
+    const wireRole = agent === 'cursor' ? raw.role : message?.role;
+    if (!message || !['user', 'assistant'].includes(wireRole)) continue;
 
-    const message = raw.message || {};
-    const role = message.role === 'user' ? 'user' : 'assistant';
-    const timestamp = raw.timestamp || new Date().toISOString();
+    const role = wireRole === 'user' ? 'user' : 'assistant';
+    const timestamp = raw.timestamp || fallbackTimestamp;
     const blocks = message.content;
 
-    // Plain-string content (rare) renders as a single message.
     if (typeof blocks === 'string') {
       const text = blocks.trim();
-      if (text) events.push({ type: 'message', agent: 'droid', timestamp, role, content: text });
+      if (text) events.push({ type: 'message', agent, timestamp, role, content: text });
       continue;
     }
     if (!Array.isArray(blocks)) continue;
@@ -1704,50 +1705,40 @@ export function parseDroid(filePath: string): SessionEvent[] {
     for (const block of blocks) {
       if (block.type === 'text') {
         const text = (block.text || '').trim();
-        // Skip injected context blocks (date, skills list) on the first user turn.
         if (text && !(role === 'user' && text.startsWith('<system-reminder>'))) {
-          events.push({ type: 'message', agent: 'droid', timestamp, role, content: text });
+          events.push({ type: 'message', agent, timestamp, role, content: text });
         }
       } else if (block.type === 'thinking') {
         const thinkingText = (block.thinking || '').trim();
-        if (thinkingText) events.push({ type: 'thinking', agent: 'droid', timestamp, content: thinkingText });
+        if (thinkingText) events.push({ type: 'thinking', agent, timestamp, content: thinkingText });
       } else if (block.type === 'tool_use') {
         const toolName = block.name || 'unknown';
         const toolInput = block.input || {};
         if (block.id) toolUseMap.set(block.id, { tool: toolName, args: toolInput });
         events.push({
           type: 'tool_use',
-          agent: 'droid',
+          agent,
           timestamp,
           tool: toolName,
           args: toolInput,
           path: toolInput.file_path || toolInput.path || undefined,
-          command: (toolName === 'Bash' || toolName === 'Execute') ? toolInput.command : undefined,
+          command: (toolName === 'Bash' || toolName === 'Execute' || toolName === 'Shell') ? toolInput.command : undefined,
         });
       } else if (block.type === 'tool_result') {
         const toolId = block.tool_use_id;
         const toolInfo = toolId ? toolUseMap.get(toolId) : undefined;
         const isError = block.is_error === true;
-
-        let output = '';
-        if (typeof block.content === 'string') {
-          output = block.content;
-        } else if (Array.isArray(block.content)) {
-          output = block.content
-            .filter((c: any) => c.type === 'text')
-            .map((c: any) => c.text || '')
-            .join('\n');
-        }
+        const output = typeof block.content === 'string'
+          ? block.content
+          : Array.isArray(block.content)
+            ? block.content.filter((c: any) => c.type === 'text').map((c: any) => c.text || '').join('\n')
+            : '';
 
         if (isError) {
-          events.push({ type: 'error', agent: 'droid', timestamp, tool: toolInfo?.tool, content: output || 'Tool execution failed' });
+          events.push({ type: 'error', agent, timestamp, tool: toolInfo?.tool, content: output || 'Tool execution failed' });
         } else {
           events.push({
-            type: 'tool_result',
-            agent: 'droid',
-            timestamp,
-            tool: toolInfo?.tool,
-            success: true,
+            type: 'tool_result', agent, timestamp, tool: toolInfo?.tool, success: true,
             output: output.length > 500 ? output.slice(0, 497) + '...' : output,
           });
         }
@@ -1755,10 +1746,20 @@ export function parseDroid(filePath: string): SessionEvent[] {
       } else if (block.type === 'image') {
         const source = block.source || {};
         const sizeBytes = source.type === 'base64' ? Math.ceil(((source.data as string)?.length || 0) * 0.75) : 0;
-        events.push(normalizedAttachmentEvent('droid', timestamp, block, source, 'image/png', sizeBytes));
+        events.push(normalizedAttachmentEvent(agent, timestamp, block, source, 'image/png', sizeBytes));
       }
     }
   }
 
   return events;
+}
+
+/**
+ * Parse a Droid (Factory) JSONL session file into normalized events. Droid
+ * wraps each turn in a `{type:'message', message:{role, content, modelId}}`
+ * envelope; the content blocks are Anthropic-shaped (text/thinking/tool_use/
+ * tool_result), so block handling mirrors the Claude parser.
+ */
+export function parseDroid(filePath: string): SessionEvent[] {
+  return parseAnthropicMessageJsonl(filePath, 'droid');
 }

--- a/apps/cli/src/lib/session/parse.ts
+++ b/apps/cli/src/lib/session/parse.ts
@@ -1671,14 +1671,30 @@ export function parseCursor(filePath: string): SessionEvent[] {
   return parseAnthropicMessageJsonl(filePath, 'cursor');
 }
 
+/**
+ * Cursor stamps the first user turn as
+ * `<timestamp>Sunday, Aug 2, 2026, 3:51 AM (UTC-7)</timestamp>` followed by the
+ * real question in `<user_query>`. `Date.parse` silently DISCARDS the `(UTC-7)`
+ * parenthetical and reads the rest as local time, so the offset has to be applied
+ * by hand — otherwise the recovered instant is wrong on every machine whose zone
+ * differs from the one that wrote the transcript.
+ */
 function parseCursorUserText(text: string): { text: string; timestamp?: string } {
   const query = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
-  const timestampText = text.match(/<timestamp>\s*([\s\S]*?)\s*<\/timestamp>/)?.[1]?.trim();
-  const parsedTimestamp = timestampText ? Date.parse(timestampText) : Number.NaN;
-  return {
-    text: (query?.[1] ?? text).trim(),
-    timestamp: Number.isNaN(parsedTimestamp) ? undefined : new Date(parsedTimestamp).toISOString(),
-  };
+  const stamp = text.match(/<timestamp>\s*([\s\S]*?)\s*<\/timestamp>/)?.[1]?.trim();
+  return { text: (query?.[1] ?? text).trim(), timestamp: parseCursorTimestamp(stamp) };
+}
+
+function parseCursorTimestamp(stamp: string | undefined): string | undefined {
+  if (!stamp) return undefined;
+  const offset = stamp.match(/\(UTC([+-])(\d{1,2})(?::(\d{2}))?\)/);
+  // Without a declared offset there is no instant to recover -- guessing the
+  // local zone would be worse than falling back to the file mtime.
+  if (!offset) return undefined;
+  const wall = Date.parse(`${stamp.replace(/\s*\(UTC[^)]*\)\s*/, " ").trim()} UTC`);
+  if (Number.isNaN(wall)) return undefined;
+  const offsetMs = (Number(offset[2]) * 60 + Number(offset[3] ?? 0)) * 60_000;
+  return new Date(offset[1] === "-" ? wall + offsetMs : wall - offsetMs).toISOString();
 }
 
 function parseAnthropicMessageJsonl(filePath: string, agent: 'cursor' | 'droid'): SessionEvent[] {

--- a/apps/cli/src/lib/session/sync/agents.test.ts
+++ b/apps/cli/src/lib/session/sync/agents.test.ts
@@ -13,6 +13,7 @@ describe('SYNC_AGENTS expanded beyond claude+codex', () => {
   it('includes the four agents from RUSH-1467', () => {
     const ids = SYNC_AGENTS.map(s => s.id);
     expect(ids).toContain('droid');
+    expect(ids).toContain('cursor');
     expect(ids).toContain('grok');
     expect(ids).toContain('kimi');
     expect(ids).toContain('opencode');
@@ -49,6 +50,12 @@ describe('sessionIdFromRelKey', () => {
     expect(
       spec('droid').sessionIdFromRelKey('-home-muqsit/2bd0daa3-8336-464a-bf51-42b1ea22cd30.jsonl'),
     ).toBe('2bd0daa3-8336-464a-bf51-42b1ea22cd30');
+  });
+
+  it('cursor: parent directory name (UUID)', () => {
+    expect(
+      spec('cursor').sessionIdFromRelKey('encoded-cwd/agent-transcripts/019f5a97-33ec-7001-8aad-4c42ae1d30d9/019f5a97-33ec-7001-8aad-4c42ae1d30d9.jsonl'),
+    ).toBe('019f5a97-33ec-7001-8aad-4c42ae1d30d9');
   });
 
   it('grok: parent directory name (UUID)', () => {

--- a/apps/cli/src/lib/session/sync/agents.ts
+++ b/apps/cli/src/lib/session/sync/agents.ts
@@ -100,6 +100,12 @@ export const SYNC_AGENTS: SyncAgentSpec[] = [
     sessionIdFromRelKey: rel => path.basename(rel).replace(/\.jsonl$/, ''),
   },
   {
+    id: 'cursor',
+    subdir: 'projects',
+    // Cursor writes <encoded-cwd>/agent-transcripts/<uuid>/<uuid>.jsonl.
+    sessionIdFromRelKey: rel => path.basename(path.dirname(rel)),
+  },
+  {
     id: 'grok',
     subdir: 'sessions',
     // Grok sessions are multi-file directories under ~/.grok/sessions/<cwd>/<uuid>/.

--- a/apps/cli/src/lib/session/testdata/cursor-session.jsonl
+++ b/apps/cli/src/lib/session/testdata/cursor-session.jsonl
@@ -1,0 +1,4 @@
+{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Sunday, Aug 2, 2026, 3:51 AM (UTC-7)</timestamp>\n<user_query>\nInspect the public CLI documentation and summarize the session commands.\n</user_query>"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I will inspect the session documentation."},{"type":"tool_use","id":"tool-1","name":"Read","input":{"path":"/tmp/public-project/docs/sessions.md","limit":40}}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"The sessions command discovers and renders local transcripts."}]}}
+{"type":"turn_ended","status":"success"}

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -8,10 +8,10 @@
  */
 
 /** Agents that store session data on disk and can be discovered by `agents sessions`. */
-export type SessionAgentId = 'claude' | 'codex' | 'gemini' | 'antigravity' | 'opencode' | 'openclaw' | 'rush' | 'hermes' | 'grok' | 'kimi' | 'droid';
+export type SessionAgentId = 'claude' | 'codex' | 'gemini' | 'antigravity' | 'opencode' | 'openclaw' | 'rush' | 'hermes' | 'grok' | 'kimi' | 'droid' | 'cursor';
 
 /** All agents with session discovery support, in display order. */
-export const SESSION_AGENTS: SessionAgentId[] = ['claude', 'codex', 'gemini', 'antigravity', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid'];
+export const SESSION_AGENTS: SessionAgentId[] = ['claude', 'codex', 'gemini', 'antigravity', 'opencode', 'openclaw', 'rush', 'hermes', 'grok', 'kimi', 'droid', 'cursor'];
 
 /**
  * True when `agent` stores session data `agents sessions` can discover (a member


### PR DESCRIPTION
`agents sessions` now discovers, indexes, and renders Cursor agent transcripts — **feature**, closes [RUSH-2081](https://linear.app/getrush/issue/RUSH-2081) (parent [RUSH-2079](https://linear.app/getrush/issue/RUSH-2079)).

## The run — installed dev CLI against a real cursor-agent session

Built and installed from this branch on `yosemite-s0` (the one fleet box with a real, signed-in `cursor-agent` 2026.07.23), then ran the installed binary:

```
$ agents --version
0.0.0-dev.29cafb71-dirty

$ agents sessions --agent cursor --local --all --unmanaged
aaaec9b1  cursor   2026.0… agents-cli      Agent CLI Audit · Can you do a quick audit of…1 hour ago

1 session.

$ agents sessions aaaec9b1-e3ee-4163-9f93-a424e5ef0404 --local
Agent CLI Audit
cursor 2026.07.23  agents-cli  Aug 2 00:01 (5 hours ago)
5 turns · 21 tools
────────────────────────────────────────────────────────────

Prompt: Sunday, Aug 2, 2026, 3:51 AM (UTC-7)
  Can you do a quick audit of the agent-cli's API surface? ...

Recent Activity (last 7 of 13)
  Bash  echo '=== sessions --active head ==='; agents sessions --active 2>&1 | head -30; echo '==…
  ...
Tools  Shell 9 · Read 8 · Grep 2 · AwaitShell 1 · Glob 1
```

Before this change the same command answered `Unknown agent: cursor. Use: claude, codex, gemini, antigravity, opencode, openclaw, rush, hermes, grok, kimi, droid`.

## On-disk layout (verified empirically, not inferred)

| What | Where |
|---|---|
| Transcript | `~/.cursor/projects/<encoded-cwd>/agent-transcripts/<uuid>/<uuid>.jsonl` |
| Metadata | `~/.cursor/chats/<workspace-hash>/<uuid>/meta.json` — `{schemaVersion, createdAtMs, hasConversation, title, updatedAtMs, cwd}` |

Discovery is **transcript-first**, joining metadata by UUID. That ordering is deliberate: on the probe box 4 chat dirs existed but only 1 had a transcript — the rest were abandoned/empty sessions (`hasConversation:false`) or metadata-less `store.db` leftovers. Keying off `chats/` would have produced broken zero-event rows. `store.db` (SQLite) is deliberately not read — the JSONL plus `meta.json` carry everything needed, and a SQLite dependency here would be unjustified.

## Tests

```
✓ src/lib/session/__tests__/parse-droid.test.ts (6 tests)
✓ src/lib/session/__tests__/parse-cursor.test.ts (5 tests)
✓ src/lib/session/discover.test.ts (9 tests)
Test Files  3 passed (3)      Tests  20 passed (20)
```

Fixture `testdata/cursor-session.jsonl` is real-shaped but synthetic-content (no private paths or repo content) — this is a public repo.

## Reviewer, please look closely at

1. **`parseDroid` was refactored onto a shared `parseAnthropicMessageJsonl`.** Droid's timestamp fallback changed from `new Date().toISOString()` (wall clock at parse time) to the transcript file's mtime. That is a deliberate determinism improvement, but it is a behavior change to an agent this ticket did not target. Droid's 6 tests still pass.
2. The helper calls `fs.statSync` for that fallback after `safeReadSessionFile` already stat'd the same file (`parse.ts:132`) — a redundant syscall, not a new failure mode, but flag it if you want it threaded through instead.
3. `'Shell'` was added alongside `'Bash'`/`'Execute'` for command extraction, which also affects droid.

## Follow-up worth a ticket (not fixed here)

Cursor sessions are hidden from `agents sessions` **by default** — they only appear with `--unmanaged`, because `cursor-agent` is curl-installed to `~/.local/bin` and so has no managed version home. Most users will not pass that flag, so discovery works but is effectively invisible. That is pre-existing gating behavior, not introduced here, and fixing it is out of scope for RUSH-2081.
