### PR TITLE
chore(factory): bump changelog header for 0.9.304 release

### DIFF
--- a/apps/cli/.changelog/next/PR-1714-device-auto-launch-prefs.md
+++ b/apps/cli/.changelog/next/PR-1714-device-auto-launch-prefs.md
@@ -1,0 +1,12 @@
+- **`agents devices enable|disable|prefer|unprefer <name>` control which machines
+  Factory auto-launches onto.** A *disabled* device is skipped by
+  `New <Agent>` and the balanced launch, but stays available through
+  `New <Agent> (Pick Host)`. A *preferred* device wins ties against otherwise
+  equivalent machines — worth about two running agents in the ranking, so a
+  preference never sends work to a box that is genuinely swamped. Every device
+  is enabled and unpreferred by default, and an unregistered name is now
+  rejected instead of writing a preference that matches nothing. Preferences
+  live in `~/.agents/.history/devices/auto-launch.json`, written by the CLI and
+  read by the extension. Source: `apps/cli/src/lib/devices/registry.ts`,
+  `apps/cli/src/commands/ssh.ts`, `apps/factory/src/core/deviceAutoLaunch.ts`,
+  `apps/factory/src/core/launchHost.ts`.

--- a/apps/cli/src/commands/ssh.test.ts
+++ b/apps/cli/src/commands/ssh.test.ts
@@ -175,3 +175,40 @@ describe('renderLeasedBoxesSection — F4 devices "Leased boxes" (RUSH-1923)', (
     expect(flat).toContain('agents lease stop <slug>');
   });
 });
+
+describe('devices auto-launch preferences', () => {
+  function autoLaunchPath(): string {
+    return path.join(testHome, '.agents', '.history', 'devices', 'auto-launch.json');
+  }
+
+  it('disable and enable persist through the CLI', () => {
+    guardedHome();
+
+    expect(run(['devices', 'disable', 'zion']).status).toBe(0);
+    const disabled = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
+    expect(disabled.devices.zion).toEqual({ enabled: false });
+
+    expect(run(['devices', 'enable', 'zion']).status).toBe(0);
+    const enabled = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
+    expect(enabled.devices.zion).toBeUndefined();
+  });
+
+  it('prefer and unprefer persist through the CLI', () => {
+    guardedHome();
+
+    expect(run(['devices', 'prefer', 'mac-mini']).status).toBe(0);
+    const preferred = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
+    expect(preferred.devices['mac-mini']).toEqual({ preferred: true });
+
+    expect(run(['devices', 'unprefer', 'mac-mini']).status).toBe(0);
+    const unpreferred = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
+    expect(unpreferred.devices['mac-mini']).toBeUndefined();
+  });
+
+  it('rejects an invalid device name', () => {
+    guardedHome();
+    const r = run(['devices', 'disable', 'bad;name']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/Invalid device name/);
+  });
+});

--- a/apps/cli/src/commands/ssh.test.ts
+++ b/apps/cli/src/commands/ssh.test.ts
@@ -12,6 +12,7 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
 const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
 
 let testHome = '';
+const ORIGINAL_DEVICES_DIR = process.env.AGENTS_DEVICES_DIR;
 
 // On macOS, seeding a bundle via `secrets create --backend file` stores its
 // metadata in the Keychain, which needs the signed `Agents CLI.app` helper.
@@ -29,10 +30,12 @@ const keychainHelperAvailable =
 afterEach(() => {
   if (testHome) fs.rmSync(testHome, { recursive: true, force: true });
   testHome = '';
+  process.env.AGENTS_DEVICES_DIR = ORIGINAL_DEVICES_DIR;
 });
 
 function guardedHome(): void {
   testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-home-'));
+  process.env.AGENTS_DEVICES_DIR = path.join(testHome, '.agents', '.history', 'devices');
   const systemDir = path.join(testHome, '.agents', '.system');
   fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
   fs.writeFileSync(
@@ -52,6 +55,7 @@ function run(args: string[], extraEnv: Record<string, string> = {}): { stdout: s
       USERPROFILE: testHome,
       AGENTS_NO_UPDATE_CHECK: '1',
       AGENTS_NO_USAGE_TRACK: '1',
+      AGENTS_DEVICES_DIR: process.env.AGENTS_DEVICES_DIR,
       ...extraEnv,
     },
   });
@@ -209,11 +213,13 @@ describe('devices auto-launch preferences', () => {
     guardedHome();
     registerDevice('zion');
 
-    expect(run(['devices', 'disable', 'zion']).status).toBe(0);
+    const disable = run(['devices', 'disable', 'zion']);
+    expect(disable.status).toBe(0);
     const disabled = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
     expect(disabled.devices.zion).toEqual({ enabled: false });
 
-    expect(run(['devices', 'enable', 'zion']).status).toBe(0);
+    const enable = run(['devices', 'enable', 'zion']);
+    expect(enable.status).toBe(0);
     const enabled = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
     expect(enabled.devices.zion).toBeUndefined();
   });

--- a/apps/cli/src/commands/ssh.test.ts
+++ b/apps/cli/src/commands/ssh.test.ts
@@ -181,8 +181,33 @@ describe('devices auto-launch preferences', () => {
     return path.join(testHome, '.agents', '.history', 'devices', 'auto-launch.json');
   }
 
+  // These commands refuse a device that is not registered, so the fixture has
+  // to contain one — seeding the registry the CLI reads is the cheapest way to
+  // exercise the real command path end to end.
+  function registerDevice(name: string): void {
+    const dir = path.join(testHome, '.agents', '.history', 'devices');
+    fs.mkdirSync(dir, { recursive: true });
+    const now = new Date().toISOString();
+    fs.writeFileSync(
+      path.join(dir, 'registry.json'),
+      JSON.stringify({
+        [name]: {
+          name,
+          platform: 'macos',
+          shell: 'posix',
+          user: 'someone',
+          address: { via: 'tailscale', dnsName: `${name}.example.ts.net` },
+          auth: { method: 'key' },
+          createdAt: now,
+          updatedAt: now,
+        },
+      }),
+    );
+  }
+
   it('disable and enable persist through the CLI', () => {
     guardedHome();
+    registerDevice('zion');
 
     expect(run(['devices', 'disable', 'zion']).status).toBe(0);
     const disabled = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
@@ -195,6 +220,7 @@ describe('devices auto-launch preferences', () => {
 
   it('prefer and unprefer persist through the CLI', () => {
     guardedHome();
+    registerDevice('mac-mini');
 
     expect(run(['devices', 'prefer', 'mac-mini']).status).toBe(0);
     const preferred = JSON.parse(fs.readFileSync(autoLaunchPath(), 'utf-8'));
@@ -205,10 +231,12 @@ describe('devices auto-launch preferences', () => {
     expect(unpreferred.devices['mac-mini']).toBeUndefined();
   });
 
-  it('rejects an invalid device name', () => {
+  it('refuses a device that is not registered instead of writing a dead entry', () => {
     guardedHome();
-    const r = run(['devices', 'disable', 'bad;name']);
+    registerDevice('zion');
+    const r = run(['devices', 'disable', 'zoin']);
     expect(r.status).toBe(1);
-    expect(r.stderr).toMatch(/Invalid device name/);
+    expect(r.stderr).toMatch(/Unknown device 'zoin'/);
+    expect(fs.existsSync(autoLaunchPath())).toBe(false);
   });
 });

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -889,6 +889,7 @@ Typical workflow:
     .description('Allow a registered device to be auto-picked by Factory agent launches.')
     .action(async (name: string) => {
       try {
+        await mustGetDevice(name);
         await setAutoLaunchEnabled(name, true);
         console.log(chalk.green(`Enabled '${name}'`) + chalk.gray(' for Factory auto-launch.'));
       } catch (err: any) {
@@ -902,6 +903,7 @@ Typical workflow:
     .description('Exclude a registered device from Factory auto-launch. It can still be picked manually via (Pick Host).')
     .action(async (name: string) => {
       try {
+        await mustGetDevice(name);
         await setAutoLaunchEnabled(name, false);
         console.log(chalk.green(`Disabled '${name}'`) + chalk.gray(' for Factory auto-launch.'));
       } catch (err: any) {
@@ -915,6 +917,7 @@ Typical workflow:
     .description('Boost a registered device in Factory auto-launch ranking.')
     .action(async (name: string) => {
       try {
+        await mustGetDevice(name);
         await setAutoLaunchPreferred(name, true);
         console.log(chalk.green(`Preferred '${name}'`) + chalk.gray(' for Factory auto-launch.'));
       } catch (err: any) {
@@ -928,6 +931,7 @@ Typical workflow:
     .description('Remove the auto-launch preference boost from a device.')
     .action(async (name: string) => {
       try {
+        await mustGetDevice(name);
         await setAutoLaunchPreferred(name, false);
         console.log(chalk.green(`No longer preferring '${name}'`) + chalk.gray(' for Factory auto-launch.'));
       } catch (err: any) {

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -29,6 +29,8 @@ import {
   loadIgnored,
   removeDevice,
   removeIgnored,
+  setAutoLaunchEnabled,
+  setAutoLaunchPreferred,
   upsertDevice,
   writeReachability,
   type DeviceAuthMethod,
@@ -797,6 +799,8 @@ Typical workflow:
   agents devices sync --yes      # non-interactive: register all non-ignored nodes
   agents devices list            # see what's registered
   agents devices ignore ipad165  # dismiss a node so it's never re-suggested
+  agents devices disable zion    # exclude a device from Factory auto-launch
+  agents devices prefer mac-mini # boost a device in Factory auto-launch ranking
   agents devices set win-mini --auth password --bundle muqsit
   agents devices render --write  # write ~/.ssh/config.d/agents include
   agents fleet update            # roll out latest agents-cli to every online device
@@ -878,6 +882,58 @@ Typical workflow:
         return;
       }
       console.log(chalk.green(`No longer ignoring '${name}'`) + chalk.gray(' — run `agents devices sync` to register it.'));
+    });
+
+  devicesCmd
+    .command('enable <name>')
+    .description('Allow a registered device to be auto-picked by Factory agent launches.')
+    .action(async (name: string) => {
+      try {
+        await setAutoLaunchEnabled(name, true);
+        console.log(chalk.green(`Enabled '${name}'`) + chalk.gray(' for Factory auto-launch.'));
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+
+  devicesCmd
+    .command('disable <name>')
+    .description('Exclude a registered device from Factory auto-launch. It can still be picked manually via (Pick Host).')
+    .action(async (name: string) => {
+      try {
+        await setAutoLaunchEnabled(name, false);
+        console.log(chalk.green(`Disabled '${name}'`) + chalk.gray(' for Factory auto-launch.'));
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+
+  devicesCmd
+    .command('prefer <name>')
+    .description('Boost a registered device in Factory auto-launch ranking.')
+    .action(async (name: string) => {
+      try {
+        await setAutoLaunchPreferred(name, true);
+        console.log(chalk.green(`Preferred '${name}'`) + chalk.gray(' for Factory auto-launch.'));
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+
+  devicesCmd
+    .command('unprefer <name>')
+    .description('Remove the auto-launch preference boost from a device.')
+    .action(async (name: string) => {
+      try {
+        await setAutoLaunchPreferred(name, false);
+        console.log(chalk.green(`No longer preferring '${name}'`) + chalk.gray(' for Factory auto-launch.'));
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
     });
 
   const runList = async (opts: { json?: boolean; stats?: boolean; full?: boolean; refresh?: boolean; live?: boolean } = {}) => {

--- a/apps/cli/src/lib/devices/auto-launch.test.ts
+++ b/apps/cli/src/lib/devices/auto-launch.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Persistence guarantees for device auto-launch preferences.
+ *
+ * These preferences control which registered devices Factory's auto-host
+ * selection considers and which it prefers. The real bugs to guard:
+ *   1. Preferences must survive a reload.
+ *   2. enable/disable/prefer/unprefer are idempotent and invertible.
+ *   3. Missing file defaults every device to enabled/not-preferred.
+ *   4. A malformed file throws rather than silently emptying preferences.
+ */
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-autolaunch-test-'));
+process.env.HOME = TEST_HOME;
+process.env.AGENTS_DEVICES_DIR = path.join(TEST_HOME, '.agents', '.history', 'devices');
+
+const {
+  loadAutoLaunchPreferences,
+  setAutoLaunchEnabled,
+  setAutoLaunchPreferred,
+  isAutoLaunchEnabled,
+  isAutoLaunchPreferred,
+} = await import('./registry.js');
+
+function prefsPath(): string {
+  return path.join(TEST_HOME, '.agents', '.history', 'devices', 'auto-launch.json');
+}
+
+beforeEach(async () => {
+  await fsp.rm(prefsPath(), { force: true });
+  await fsp.rm(`${prefsPath()}.lock`, { recursive: true, force: true });
+});
+
+afterAll(async () => {
+  await fsp.rm(TEST_HOME, { recursive: true, force: true });
+});
+
+describe('device auto-launch preferences', () => {
+  it('defaults every device to enabled and not preferred', async () => {
+    expect(await isAutoLaunchEnabled('zion')).toBe(true);
+    expect(await isAutoLaunchPreferred('zion')).toBe(false);
+  });
+
+  it('persists disabled state across reloads', async () => {
+    await setAutoLaunchEnabled('zion', false);
+    expect(await isAutoLaunchEnabled('zion')).toBe(false);
+    expect(await isAutoLaunchEnabled('mac-mini')).toBe(true);
+    const prefs = await loadAutoLaunchPreferences();
+    expect(prefs).toEqual({ zion: { enabled: false } });
+  });
+
+  it('persists preferred state across reloads', async () => {
+    await setAutoLaunchPreferred('mac-mini', true);
+    expect(await isAutoLaunchPreferred('mac-mini')).toBe(true);
+    expect(await isAutoLaunchPreferred('zion')).toBe(false);
+    const prefs = await loadAutoLaunchPreferences();
+    expect(prefs['mac-mini']).toEqual({ preferred: true });
+  });
+
+  it('is idempotent and inverts correctly', async () => {
+    await setAutoLaunchEnabled('zion', false);
+    await setAutoLaunchEnabled('zion', false);
+    await setAutoLaunchEnabled('zion', true);
+    const prefs = await loadAutoLaunchPreferences();
+    expect(prefs).toEqual({});
+
+    await setAutoLaunchPreferred('mac-mini', true);
+    await setAutoLaunchPreferred('mac-mini', true);
+    await setAutoLaunchPreferred('mac-mini', false);
+    expect(await loadAutoLaunchPreferences()).toEqual({});
+  });
+
+  it('throws on a corrupted file instead of silently emptying it', async () => {
+    await fsp.mkdir(path.dirname(prefsPath()), { recursive: true });
+    await fsp.writeFile(prefsPath(), '{ this is not json');
+    await expect(loadAutoLaunchPreferences()).rejects.toThrow(/corrupted/);
+  });
+});

--- a/apps/cli/src/lib/devices/registry.ts
+++ b/apps/cli/src/lib/devices/registry.ts
@@ -18,7 +18,7 @@ import * as fsSync from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 import lockfile from 'proper-lockfile';
-import { getDevicesRegistryPath, getDevicesIgnoredPath } from '../state.js';
+import { getDevicesRegistryPath, getDevicesIgnoredPath, getDevicesAutoLaunchPath } from '../state.js';
 
 /** Operating-system family of a device, used to pick the remote shell. */
 export type DevicePlatform = 'windows' | 'linux' | 'macos' | 'unknown';
@@ -415,5 +415,102 @@ export async function removeIgnored(name: string): Promise<boolean> {
     if (!set.delete(name)) return false;
     await atomicWriteJson(p, { ignored: [...set].sort(), updatedAt: new Date().toISOString() });
     return true;
+  });
+}
+
+/**
+ * Auto-launch preferences: which registered devices are eligible for Factory's
+ * auto-host selection, and which are preferred. Stored as a sibling to the
+ * registry and ignore-list under ~/.agents/.history/devices/.
+ */
+export interface AutoLaunchPreference {
+  enabled?: boolean;
+  preferred?: boolean;
+}
+
+export interface AutoLaunchPreferences {
+  devices: Record<string, AutoLaunchPreference>;
+  updatedAt: string;
+}
+
+function autoLaunchPath(): string {
+  return getDevicesAutoLaunchPath();
+}
+
+/** Load auto-launch preferences. Missing or malformed file => empty map. */
+export async function loadAutoLaunchPreferences(): Promise<Record<string, AutoLaunchPreference>> {
+  const p = autoLaunchPath();
+  let raw: string;
+  try {
+    raw = await fs.readFile(p, 'utf-8');
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return {};
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw) as AutoLaunchPreferences;
+    return parsed.devices && typeof parsed.devices === 'object' ? parsed.devices : {};
+  } catch (err: any) {
+    throw new Error(
+      `Device auto-launch preferences corrupted at ${p}: ${err?.message ?? err}. Inspect and restore from backup.`,
+    );
+  }
+}
+
+/** True if the device is enabled for auto-launch. Missing entry defaults to true. */
+export async function isAutoLaunchEnabled(name: string): Promise<boolean> {
+  assertValidDeviceName(name);
+  const prefs = await loadAutoLaunchPreferences();
+  return prefs[name]?.enabled !== false;
+}
+
+/** Set whether a device is enabled for auto-launch. Setting to the default
+ * (enabled) removes the entry to keep the file minimal. */
+export async function setAutoLaunchEnabled(name: string, enabled: boolean): Promise<void> {
+  assertValidDeviceName(name);
+  const p = autoLaunchPath();
+  await withRegistryLock(p, async () => {
+    const prefs = await loadAutoLaunchPreferences();
+    if (enabled) {
+      if (prefs[name]) {
+        const { enabled: _, ...rest } = prefs[name];
+        if (Object.keys(rest).length === 0) {
+          delete prefs[name];
+        } else {
+          prefs[name] = rest;
+        }
+      }
+    } else {
+      prefs[name] = { ...prefs[name], enabled: false };
+    }
+    await atomicWriteJson(p, { devices: prefs, updatedAt: new Date().toISOString() });
+  });
+}
+
+/** True if the device is preferred for auto-launch ranking. */
+export async function isAutoLaunchPreferred(name: string): Promise<boolean> {
+  assertValidDeviceName(name);
+  const prefs = await loadAutoLaunchPreferences();
+  return prefs[name]?.preferred === true;
+}
+
+/** Set whether a device is preferred for auto-launch. Setting to the default
+ * (not preferred) removes the flag to keep the file minimal. */
+export async function setAutoLaunchPreferred(name: string, preferred: boolean): Promise<void> {
+  assertValidDeviceName(name);
+  const p = autoLaunchPath();
+  await withRegistryLock(p, async () => {
+    const prefs = await loadAutoLaunchPreferences();
+    if (preferred) {
+      prefs[name] = { ...prefs[name], preferred: true };
+    } else if (prefs[name]) {
+      const { preferred: _, ...rest } = prefs[name];
+      if (Object.keys(rest).length === 0) {
+        delete prefs[name];
+      } else {
+        prefs[name] = rest;
+      }
+    }
+    await atomicWriteJson(p, { devices: prefs, updatedAt: new Date().toISOString() });
   });
 }

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -477,6 +477,9 @@ export function getDevicesRegistryPath(): string { return path.join(getDevicesDi
 /** Path to the device ignore-list — tailscale node names the user dismissed, so auto-discovery never re-suggests them. Per-machine, same dir as the registry. */
 export function getDevicesIgnoredPath(): string { return path.join(getDevicesDir(), 'ignored.json'); }
 
+/** Path to the device auto-launch preference file — which registered devices are eligible/preferred for Factory's auto-host selection. Per-machine, same dir as the registry. */
+export function getDevicesAutoLaunchPath(): string { return path.join(getDevicesDir(), 'auto-launch.json'); }
+
 /** Dir of "pending device" sentinels (~/.agents/.cache/state/devices-pending/) — one empty-ish file per newly-discovered, not-yet-approved tailnet node. Written by the daemon probe, read by the menu-bar helper (mirrors the attention sentinel dir). */
 export function getDevicesPendingDir(): string { return path.join(RUNTIME_STATE_DIR, 'devices-pending'); }
 

--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -46,8 +46,8 @@ bash scripts/install.sh <version>   # Package .vsix and install to Cursor + Code
 Factory's auto-host selection reads per-device enable/prefer flags managed by the CLI (`agents devices enable|disable|prefer|unprefer <name>`). The store is `~/.agents/.history/devices/auto-launch.json`.
 
 - A **disabled** device is excluded from `New <Agent>` auto picks. It remains manually pickable via `New <Agent> (Pick Host)`.
-- A **preferred** device gets a rank boost in the auto pool, so it wins ties against otherwise-equivalent machines.
-- Defaults: every registered device is enabled and not preferred.
+- A **preferred** device gets a `PREFERENCE_BONUS` (20 pts, ≈ two running agents) shaved off its `hostScore`, so it wins ties against otherwise-equivalent machines but never outranks one that is genuinely swamped. The bonus lives in `hostScore` itself, so both ranking paths — the warm-cache pick and the balanced pool pick — apply it identically.
+- Defaults: every registered device is enabled and not preferred. An unregistered name is rejected by the CLI rather than written as a dead entry.
 
 Source of truth:
 - Persistence + CLI commands: `apps/cli/src/lib/devices/registry.ts` (`loadAutoLaunchPreferences`, `setAutoLaunchEnabled`, `setAutoLaunchPreferred`) and `apps/cli/src/commands/ssh.ts`.

--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -41,6 +41,19 @@ bun test          # Full test suite, no mocks
 bash scripts/install.sh <version>   # Package .vsix and install to Cursor + Code + Codium
 ```
 
+## Device auto-launch preferences
+
+Factory's auto-host selection reads per-device enable/prefer flags managed by the CLI (`agents devices enable|disable|prefer|unprefer <name>`). The store is `~/.agents/.history/devices/auto-launch.json`.
+
+- A **disabled** device is excluded from `New <Agent>` auto picks. It remains manually pickable via `New <Agent> (Pick Host)`.
+- A **preferred** device gets a rank boost in the auto pool, so it wins ties against otherwise-equivalent machines.
+- Defaults: every registered device is enabled and not preferred.
+
+Source of truth:
+- Persistence + CLI commands: `apps/cli/src/lib/devices/registry.ts` (`loadAutoLaunchPreferences`, `setAutoLaunchEnabled`, `setAutoLaunchPreferred`) and `apps/cli/src/commands/ssh.ts`.
+- Extension consumption: `apps/factory/src/core/deviceAutoLaunch.ts`.
+- Filtering/bias applied: `apps/factory/src/core/launchHistory.ts` (`pickCachedLaunchHost`) and `apps/factory/src/vscode/extension.ts` (`resolveCachedAutoHost`, `resolveBalancedHost`).
+
 ## Releasing to the Marketplace
 
 Use `scripts/release.sh` from any fleet box. It routes itself to the machine that holds the `vs-marketplace` secrets bundle (currently `zion`) and publishes from a clean clone of the commit.
@@ -77,7 +90,7 @@ Known gotchas:
 | Area | Start here |
 |---|---|
 | Agent spawn flow + editor-tab terminals | `src/vscode/extension.ts` (`openSingleAgent`, `openSingleAgentWithQueue`) |
-| The ONE launch engine (every "New agent" command) | `launchAgent(context, {agentKey?, host?, pickHost?, local?})` in `src/vscode/extension.ts` is the single route. It resolves: **host** (explicit / device-first `pickLaunchHost` / auto `resolveBalancedHost`), **harness** (explicit, or `resolveAutoAgentKey` — usable-on-the-chosen-host via `hostHasUsableVersion`, ranked by `pickAgentByUsage`), and **version/account** (ALWAYS balanced via `--strategy balanced`; no pinned/latest/version-picker path exists). Commands are thin: `agents.newAgent` = `launchAgent({})` (auto everything), `agents.newAgentPickHost` = `{pickHost:true}` (device-first, auto harness), `agents.new<Harness>` = `{agentKey, local:true}`, `agents.new<Harness>PickHost` = `{agentKey, pickHost:true}`. Pure ranking: `src/core/launchHost.ts` (`pickBestHost`, `deviceHasUsableVersion`, `resolveBalancePool`) + `src/core/agentUsage.ts` (`pickAgentByUsage`). Health probe: `src/vscode/deviceHealth.vscode.ts` (`fetchDeviceStats`). |
+| The ONE launch engine (every "New agent" command) | `launchAgent(context, {agentKey?, host?, pickHost?, local?})` in `src/vscode/extension.ts` is the single route. It resolves: **host** (explicit / device-first `pickLaunchHost` / auto `resolveBalancedHost`), **harness** (explicit, or `resolveAutoAgentKey` — usable-on-the-chosen-host via `hostHasUsableVersion`, ranked by `pickAgentByUsage`), and **version/account** (ALWAYS balanced via `--strategy balanced`; no pinned/latest/version-picker path exists). Commands are thin: `agents.newAgent` = `launchAgent({})` (auto everything), `agents.newAgentPickHost` = `{pickHost:true}` (device-first, auto harness), `agents.new<Harness>` = `{agentKey, local:true}`, `agents.new<Harness>PickHost` = `{agentKey, pickHost:true}`. Pure ranking: `src/core/launchHost.ts` (`pickBestHost`, `deviceHasUsableVersion`, `resolveBalancePool`) + `src/core/agentUsage.ts` (`pickAgentByUsage`). Health probe: `src/vscode/deviceHealth.vscode.ts` (`fetchDeviceStats`). Auto-launch filtering/bias: `src/core/deviceAutoLaunch.ts` (loaded from CLI-managed `~/.agents/.history/devices/auto-launch.json`). |
 | Terminal registry + session IDs | `src/vscode/terminals.vscode.ts` |
 | Offloaded (`--host`) tabs — session id, title, resume | A remote tab is registered exactly like a local one: `openSingleAgent` mints the Claude session id for local AND remote (`agents run --host` adopts it via the CLI's `resolveHostSessionId`), and stamps the device on `EditorTerminal.host` (persisted in `src/core/sessions.persist.ts`, restored on reload and on Reopen Last Session). Anything that reads the session then has to follow that host: the label poller routes to `fetchRemoteSessionLabelSource` (`src/vscode/remoteSessions.vscode.ts` → `agents sessions <id> --host <device> --json`, parsed by `parseSessionLabelSource` in `src/core/remoteSessions.ts`) because the transcript is not on this machine, and resume goes through `buildVersionedResumeCommand(..., host)` (`src/core/prewarm.ts`) which emits `agents run --host … --resume` instead of a local `claude -r <id>`. |
 | Terminal readiness events (tabReady, shellReady, promptReady, agentReady) | `src/core/terminalReadiness.ts`, `src/vscode/terminalReadiness.ts` (design doc: `swarmify/docs/01-terminal-lifecycle.md`) |

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Respect per-device auto-launch preferences from the CLI (RUSH-2092).**
+  Devices disabled with `agents devices disable <name>` are excluded from
+  `New <Agent>` auto launches; devices preferred with `agents devices prefer
+  <name>` get a ranking boost. Disabled devices remain available through
+  `New <Agent> (Pick Host)`. Preferences are read from
+  `~/.agents/.history/devices/auto-launch.json`. Source:
+  `apps/factory/src/core/deviceAutoLaunch.ts`,
+  `apps/factory/src/core/launchHistory.ts`,
+  `apps/factory/src/vscode/extension.ts`.
+
 ## [0.9.303] - 2026-08-02
 
 - **Remove deprecated Gemini launch commands from the Factory palette (RUSH-2089).** Gemini is no longer supported; Antigravity is its replacement. The command palette no longer shows `Agents: New Gemini`, `Agents: New Gemini (Pick Host)`, `Agents: New Gemini (Auto)`, or `Agents: Setup Gemini`. Existing Gemini session parsing and transcript watching remain in place so old sessions are still readable. Source: `apps/factory/src/vscode/extension.ts`, `apps/factory/package.json`.

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,13 +6,17 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.304] - 2026-08-02
+
 - **Respect per-device auto-launch preferences from the CLI (RUSH-2092).**
   Devices disabled with `agents devices disable <name>` are excluded from
   `New <Agent>` auto launches; devices preferred with `agents devices prefer
-  <name>` get a ranking boost. Disabled devices remain available through
-  `New <Agent> (Pick Host)`. Preferences are read from
-  `~/.agents/.history/devices/auto-launch.json`. Source:
-  `apps/factory/src/core/deviceAutoLaunch.ts`,
+  <name>` get a ranking boost worth two running agents in the host score, so a
+  preference wins ties but never sends work to a genuinely swamped machine.
+  Disabled devices remain available through `New <Agent> (Pick Host)`.
+  Preferences are read from `~/.agents/.history/devices/auto-launch.json`.
+  Source: `apps/factory/src/core/deviceAutoLaunch.ts`,
+  `apps/factory/src/core/launchHost.ts`,
   `apps/factory/src/core/launchHistory.ts`,
   `apps/factory/src/vscode/extension.ts`.
 

--- a/apps/factory/src/core/deviceAutoLaunch.test.ts
+++ b/apps/factory/src/core/deviceAutoLaunch.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { loadAutoLaunchPreferences, isAutoLaunchEnabled, isAutoLaunchPreferred } from './deviceAutoLaunch';
+
+// The real file the CLI writes and this module reads. Tests drive the actual
+// path (no mocked fs) and restore whatever was there.
+const prefsPath = path.join(os.homedir(), '.agents', '.history', 'devices', 'auto-launch.json');
+let saved: string | null = null;
+let existedBefore = false;
+
+function write(contents: string): void {
+  if (saved === null) {
+    existedBefore = fs.existsSync(prefsPath);
+    saved = existedBefore ? fs.readFileSync(prefsPath, 'utf-8') : '';
+  }
+  fs.mkdirSync(path.dirname(prefsPath), { recursive: true });
+  fs.writeFileSync(prefsPath, contents);
+}
+
+afterEach(() => {
+  if (saved === null) return;
+  if (existedBefore) fs.writeFileSync(prefsPath, saved);
+  else fs.rmSync(prefsPath, { force: true });
+  saved = null;
+});
+
+test('reads enable/prefer flags the CLI wrote', () => {
+  write(JSON.stringify({ devices: { 'box-a': { enabled: false }, 'box-b': { preferred: true } } }));
+  const prefs = loadAutoLaunchPreferences();
+  expect(isAutoLaunchEnabled(prefs, 'box-a')).toBe(false);
+  expect(isAutoLaunchPreferred(prefs, 'box-b')).toBe(true);
+});
+
+test('an unlisted device defaults to enabled and not preferred', () => {
+  write(JSON.stringify({ devices: {} }));
+  const prefs = loadAutoLaunchPreferences();
+  expect(isAutoLaunchEnabled(prefs, 'never-seen')).toBe(true);
+  expect(isAutoLaunchPreferred(prefs, 'never-seen')).toBe(false);
+});
+
+// Counterpart to the CLI-side test that pins the opposite behavior
+// (apps/cli/src/lib/devices/auto-launch.test.ts: "throws on a corrupted file").
+// The extension must keep launching; see the module doc for why they differ.
+test('a corrupted file degrades to defaults rather than throwing', () => {
+  write('{ not json at all');
+  const prefs = loadAutoLaunchPreferences();
+  expect(prefs).toEqual({});
+  expect(isAutoLaunchEnabled(prefs, 'anything')).toBe(true);
+});

--- a/apps/factory/src/core/deviceAutoLaunch.test.ts
+++ b/apps/factory/src/core/deviceAutoLaunch.test.ts
@@ -1,52 +1,76 @@
-import { test, expect, afterEach } from 'bun:test';
+import { describe, expect, test, beforeEach, afterAll } from 'bun:test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { loadAutoLaunchPreferences, isAutoLaunchEnabled, isAutoLaunchPreferred } from './deviceAutoLaunch';
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'factory-autolaunch-test-'));
+const ORIGINAL_DEVICES_DIR = process.env.AGENTS_DEVICES_DIR;
 
-// The real file the CLI writes and this module reads. Tests drive the actual
-// path (no mocked fs) and restore whatever was there.
-const prefsPath = path.join(os.homedir(), '.agents', '.history', 'devices', 'auto-launch.json');
-let saved: string | null = null;
-let existedBefore = false;
+process.env.AGENTS_DEVICES_DIR = path.join(TEST_HOME, '.agents', '.history', 'devices');
 
-function write(contents: string): void {
-  if (saved === null) {
-    existedBefore = fs.existsSync(prefsPath);
-    saved = existedBefore ? fs.readFileSync(prefsPath, 'utf-8') : '';
-  }
-  fs.mkdirSync(path.dirname(prefsPath), { recursive: true });
-  fs.writeFileSync(prefsPath, contents);
+const {
+  loadAutoLaunchPreferences,
+  isAutoLaunchEnabled,
+  isAutoLaunchPreferred,
+} = await import('./deviceAutoLaunch');
+
+function prefsPath(): string {
+  return path.join(process.env.AGENTS_DEVICES_DIR!, 'auto-launch.json');
 }
 
-afterEach(() => {
-  if (saved === null) return;
-  if (existedBefore) fs.writeFileSync(prefsPath, saved);
-  else fs.rmSync(prefsPath, { force: true });
-  saved = null;
-});
+describe('deviceAutoLaunch', () => {
+  beforeEach(() => {
+    fs.rmSync(prefsPath(), { force: true });
+    fs.mkdirSync(path.dirname(prefsPath()), { recursive: true });
+  });
 
-test('reads enable/prefer flags the CLI wrote', () => {
-  write(JSON.stringify({ devices: { 'box-a': { enabled: false }, 'box-b': { preferred: true } } }));
-  const prefs = loadAutoLaunchPreferences();
-  expect(isAutoLaunchEnabled(prefs, 'box-a')).toBe(false);
-  expect(isAutoLaunchPreferred(prefs, 'box-b')).toBe(true);
-});
+  afterAll(() => {
+    process.env.AGENTS_DEVICES_DIR = ORIGINAL_DEVICES_DIR;
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
 
-test('an unlisted device defaults to enabled and not preferred', () => {
-  write(JSON.stringify({ devices: {} }));
-  const prefs = loadAutoLaunchPreferences();
-  expect(isAutoLaunchEnabled(prefs, 'never-seen')).toBe(true);
-  expect(isAutoLaunchPreferred(prefs, 'never-seen')).toBe(false);
-});
+  test('missing file defaults every device to enabled and not preferred', () => {
+    const prefs = loadAutoLaunchPreferences();
+    expect(prefs).toEqual({});
+    expect(isAutoLaunchEnabled(prefs, 'zion')).toBe(true);
+    expect(isAutoLaunchPreferred(prefs, 'zion')).toBe(false);
+  });
 
-// Counterpart to the CLI-side test that pins the opposite behavior
-// (apps/cli/src/lib/devices/auto-launch.test.ts: "throws on a corrupted file").
-// The extension must keep launching; see the module doc for why they differ.
-test('a corrupted file degrades to defaults rather than throwing', () => {
-  write('{ not json at all');
-  const prefs = loadAutoLaunchPreferences();
-  expect(prefs).toEqual({});
-  expect(isAutoLaunchEnabled(prefs, 'anything')).toBe(true);
+  test('reads enabled and preferred flags', () => {
+    const data = {
+      devices: {
+        'box-a': { enabled: false },
+        'box-b': { preferred: true },
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(prefsPath(), JSON.stringify(data));
+
+    const prefs = loadAutoLaunchPreferences();
+    expect(isAutoLaunchEnabled(prefs, 'box-a')).toBe(false);
+    expect(isAutoLaunchPreferred(prefs, 'box-b')).toBe(true);
+  });
+
+  test('an unlisted device defaults to enabled and not preferred', () => {
+    fs.writeFileSync(prefsPath(), JSON.stringify({ devices: {} }));
+    const prefs = loadAutoLaunchPreferences();
+    expect(isAutoLaunchEnabled(prefs, 'never-seen')).toBe(true);
+    expect(isAutoLaunchPreferred(prefs, 'never-seen')).toBe(false);
+  });
+
+  // Counterpart to the CLI-side test that pins the opposite behavior
+  // (apps/cli/src/lib/devices/auto-launch.test.ts: "throws on a corrupted file").
+  // The extension must keep launching; see the module doc for why they differ.
+  test('a corrupted file degrades to defaults rather than throwing', () => {
+    fs.writeFileSync(prefsPath(), '{ not json at all');
+    const prefs = loadAutoLaunchPreferences();
+    expect(prefs).toEqual({});
+    expect(isAutoLaunchEnabled(prefs, 'anything')).toBe(true);
+  });
+
+  test('non-object devices field returns empty map', () => {
+    fs.writeFileSync(prefsPath(), JSON.stringify({ devices: 'bad', updatedAt: new Date().toISOString() }));
+    const prefs = loadAutoLaunchPreferences();
+    expect(prefs).toEqual({});
+  });
 });

--- a/apps/factory/src/core/deviceAutoLaunch.ts
+++ b/apps/factory/src/core/deviceAutoLaunch.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface AutoLaunchPreference {
+  enabled?: boolean;
+  preferred?: boolean;
+}
+
+export interface AutoLaunchPreferences {
+  devices: Record<string, AutoLaunchPreference>;
+  updatedAt?: string;
+}
+
+function autoLaunchPath(): string {
+  return path.join(os.homedir(), '.agents', '.history', 'devices', 'auto-launch.json');
+}
+
+/**
+ * Load auto-launch preferences written by `agents devices enable/disable/prefer`.
+ * Missing or malformed file => empty map. Synchronous because callers need it
+ * during ranking without awaiting another turn.
+ */
+export function loadAutoLaunchPreferences(): Record<string, AutoLaunchPreference> {
+  try {
+    const raw = fs.readFileSync(autoLaunchPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as AutoLaunchPreferences;
+    return parsed.devices && typeof parsed.devices === 'object' ? parsed.devices : {};
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return {};
+    console.error('[deviceAutoLaunch] failed to load preferences:', err?.message ?? err);
+    return {};
+  }
+}
+
+/** True if the device is enabled for auto-launch. Defaults to true. */
+export function isAutoLaunchEnabled(
+  preferences: Record<string, AutoLaunchPreference>,
+  name: string,
+): boolean {
+  return preferences[name]?.enabled !== false;
+}
+
+/** True if the device is preferred for auto-launch ranking. */
+export function isAutoLaunchPreferred(
+  preferences: Record<string, AutoLaunchPreference>,
+  name: string,
+): boolean {
+  return preferences[name]?.preferred === true;
+}

--- a/apps/factory/src/core/deviceAutoLaunch.ts
+++ b/apps/factory/src/core/deviceAutoLaunch.ts
@@ -18,8 +18,15 @@ function autoLaunchPath(): string {
 
 /**
  * Load auto-launch preferences written by `agents devices enable/disable/prefer`.
- * Missing or malformed file => empty map. Synchronous because callers need it
- * during ranking without awaiting another turn.
+ * Synchronous because callers need it during ranking without awaiting another turn.
+ *
+ * Corruption handling deliberately differs from the CLI's reader of this same
+ * file (`apps/cli/src/lib/devices/registry.ts loadAutoLaunchPreferences`, which
+ * throws): there, the user typed a command and can act on the error. Here, the
+ * caller is a launch the user just triggered, and a bad prefs file must not stop
+ * them getting a terminal — so this degrades to "every device enabled, none
+ * preferred" (the documented default) and says so on the extension log. It is a
+ * stated fallback to a defined state, not a silent swallow.
  */
 export function loadAutoLaunchPreferences(): Record<string, AutoLaunchPreference> {
   try {

--- a/apps/factory/src/core/deviceAutoLaunch.ts
+++ b/apps/factory/src/core/deviceAutoLaunch.ts
@@ -13,7 +13,10 @@ export interface AutoLaunchPreferences {
 }
 
 function autoLaunchPath(): string {
-  return path.join(os.homedir(), '.agents', '.history', 'devices', 'auto-launch.json');
+  const dir =
+    process.env.AGENTS_DEVICES_DIR ??
+    path.join(os.homedir(), '.agents', '.history', 'devices');
+  return path.join(dir, 'auto-launch.json');
 }
 
 /**

--- a/apps/factory/src/core/launchHistory.test.ts
+++ b/apps/factory/src/core/launchHistory.test.ts
@@ -24,7 +24,7 @@ describe('pickCachedLaunchHost', () => {
       familiar: { launches: 12, successes: 12, lastLaunchAt: NOW - 60_000 },
     };
 
-    expect(pickCachedLaunchHost('codex', health, history, NOW)).toBe('familiar');
+    expect(pickCachedLaunchHost('codex', health, history, {}, NOW)).toBe('familiar');
   });
 
   test('never selects offline, SSH-unreachable, or harness-unusable devices', () => {
@@ -35,14 +35,14 @@ describe('pickCachedLaunchHost', () => {
       { name: 'ready', online: true, sshReachable: true, running: 3, usableAgents: { claude: true }, fetchedAt: NOW },
     ]);
 
-    expect(pickCachedLaunchHost('claude', health, {}, NOW)).toBe('ready');
+    expect(pickCachedLaunchHost('claude', health, {}, {}, NOW)).toBe('ready');
   });
 
   test('cold or stale cache returns null for local fallback', () => {
-    expect(pickCachedLaunchHost('gemini', undefined, {}, NOW)).toBeNull();
+    expect(pickCachedLaunchHost('gemini', undefined, {}, {}, NOW)).toBeNull();
     const stale = cache([]);
     stale.refreshedAt = NOW - LAUNCH_HEALTH_MAX_AGE_MS - 1;
-    expect(pickCachedLaunchHost('gemini', stale, {}, NOW)).toBeNull();
+    expect(pickCachedLaunchHost('gemini', stale, {}, {}, NOW)).toBeNull();
   });
 
   test('excludes devices disabled for auto-launch', () => {

--- a/apps/factory/src/core/launchHistory.test.ts
+++ b/apps/factory/src/core/launchHistory.test.ts
@@ -44,6 +44,26 @@ describe('pickCachedLaunchHost', () => {
     stale.refreshedAt = NOW - LAUNCH_HEALTH_MAX_AGE_MS - 1;
     expect(pickCachedLaunchHost('gemini', stale, {}, NOW)).toBeNull();
   });
+
+  test('excludes devices disabled for auto-launch', () => {
+    const health = cache([
+      { name: 'disabled', online: true, sshReachable: true, running: 0, loadAvg1: 1, memPercent: 20, usableAgents: { claude: true }, fetchedAt: NOW },
+      { name: 'enabled', online: true, sshReachable: true, running: 3, loadAvg1: 1, memPercent: 20, usableAgents: { claude: true }, fetchedAt: NOW },
+    ]);
+    const preferences = { disabled: { enabled: false } };
+
+    expect(pickCachedLaunchHost('claude', health, {}, preferences, NOW)).toBe('enabled');
+  });
+
+  test('boosts preferred devices in ranking', () => {
+    const health = cache([
+      { name: 'busy', online: true, sshReachable: true, running: 10, loadAvg1: 1, memPercent: 20, usableAgents: { claude: true }, fetchedAt: NOW },
+      { name: 'preferred', online: true, sshReachable: true, running: 10, loadAvg1: 1, memPercent: 20, usableAgents: { claude: true }, fetchedAt: NOW },
+    ]);
+    const preferences = { preferred: { preferred: true } };
+
+    expect(pickCachedLaunchHost('claude', health, {}, preferences, NOW)).toBe('preferred');
+  });
 });
 
 test('recordLaunch preserves per-device frequency, recency, and success', () => {

--- a/apps/factory/src/core/launchHistory.ts
+++ b/apps/factory/src/core/launchHistory.ts
@@ -1,9 +1,6 @@
 import { hostScore } from './launchHost';
 import { AutoLaunchPreference, isAutoLaunchEnabled, isAutoLaunchPreferred } from './deviceAutoLaunch';
 
-export type { AutoLaunchPreference };
-export { isAutoLaunchEnabled, isAutoLaunchPreferred };
-
 export interface LaunchHistoryEntry {
   launches: number;
   successes: number;

--- a/apps/factory/src/core/launchHistory.ts
+++ b/apps/factory/src/core/launchHistory.ts
@@ -102,17 +102,19 @@ export function pickCachedLaunchHost(
   );
   if (eligible.length === 0) return null;
 
-  const preferenceBonus = (device: CachedLaunchDevice): number => {
-    return isAutoLaunchPreferred(preferences, device.name) ? 20 : 0;
-  };
+  // The preference bonus lives inside hostScore (launchHost.ts) so the balanced
+  // pool pick applies it identically — pass the flag, don't re-implement it.
+  const rank = (device: CachedLaunchDevice): number =>
+    hostScore({ ...device, preferred: isAutoLaunchPreferred(preferences, device.name) }) -
+    historyPreference(history[normalized(device.name)], now);
 
   let best = eligible[0];
-  let bestRank = hostScore(best) - historyPreference(history[normalized(best.name)], now) - preferenceBonus(best);
+  let bestRank = rank(best);
   for (const device of eligible.slice(1)) {
-    const rank = hostScore(device) - historyPreference(history[normalized(device.name)], now) - preferenceBonus(device);
-    if (rank < bestRank) {
+    const deviceRank = rank(device);
+    if (deviceRank < bestRank) {
       best = device;
-      bestRank = rank;
+      bestRank = deviceRank;
     }
   }
   return best.name;

--- a/apps/factory/src/core/launchHistory.ts
+++ b/apps/factory/src/core/launchHistory.ts
@@ -1,4 +1,8 @@
 import { hostScore } from './launchHost';
+import { AutoLaunchPreference, isAutoLaunchEnabled, isAutoLaunchPreferred } from './deviceAutoLaunch';
+
+export type { AutoLaunchPreference };
+export { isAutoLaunchEnabled, isAutoLaunchPreferred };
 
 export interface LaunchHistoryEntry {
   launches: number;
@@ -77,25 +81,35 @@ function historyPreference(entry: LaunchHistoryEntry | undefined, now: number): 
 }
 
 /**
- * Rank a warm cache without I/O. Unreachable, offline, stale, or agent-unusable
- * devices are excluded before history and load are considered.
+ * Rank a warm cache without I/O. Unreachable, offline, stale, agent-unusable,
+ * or disabled devices are excluded before history and load are considered.
+ * Preferred devices receive a ranking bonus.
  */
 export function pickCachedLaunchHost(
   agentKey: string,
   cache: LaunchHealthCache | undefined,
   history: LaunchHistory,
+  preferences: Record<string, AutoLaunchPreference> = {},
   now = Date.now(),
 ): string | null {
   if (!cache || now - cache.refreshedAt > LAUNCH_HEALTH_MAX_AGE_MS) return null;
   const eligible = cache.devices.filter(
-    (device) => device.online && device.sshReachable && device.usableAgents[agentKey] === true,
+    (device) =>
+      device.online &&
+      device.sshReachable &&
+      device.usableAgents[agentKey] === true &&
+      isAutoLaunchEnabled(preferences, device.name),
   );
   if (eligible.length === 0) return null;
 
+  const preferenceBonus = (device: CachedLaunchDevice): number => {
+    return isAutoLaunchPreferred(preferences, device.name) ? 20 : 0;
+  };
+
   let best = eligible[0];
-  let bestRank = hostScore(best) - historyPreference(history[normalized(best.name)], now);
+  let bestRank = hostScore(best) - historyPreference(history[normalized(best.name)], now) - preferenceBonus(best);
   for (const device of eligible.slice(1)) {
-    const rank = hostScore(device) - historyPreference(history[normalized(device.name)], now);
+    const rank = hostScore(device) - historyPreference(history[normalized(device.name)], now) - preferenceBonus(device);
     if (rank < bestRank) {
       best = device;
       bestRank = rank;

--- a/apps/factory/src/core/launchHost.test.ts
+++ b/apps/factory/src/core/launchHost.test.ts
@@ -4,6 +4,7 @@ import {
   pickBestHost,
   deviceHasUsableVersion,
   hostScore,
+  PREFERENCE_BONUS,
   resolveBalancePool,
   DeviceLoad,
   VersionHealth,
@@ -196,4 +197,33 @@ test('hostScore: running agents weighted 10x, load capped at 16, mem scaled by 2
   expect(hostScore({ name: 'x', online: true, running: 0, loadAvg1: 99, memPercent: 0 })).toBe(16);
   // Unprobed hardware contributes 0.
   expect(hostScore({ name: 'x', online: true, running: 3 })).toBe(30);
+});
+
+test('hostScore: a preferred device is favored by PREFERENCE_BONUS', () => {
+  const base = { name: 'x', online: true, running: 2, loadAvg1: 3, memPercent: 40 };
+  expect(hostScore({ ...base, preferred: true })).toBeCloseTo(hostScore(base) - PREFERENCE_BONUS, 5);
+});
+
+// The regression behind the review of PR #1714: `agents devices prefer <name>`
+// only biased the warm-cache pick, because the balanced pool path ranks with
+// pickBestHost and the bonus lived outside hostScore. Both paths rank through
+// hostScore now, so a preference has to decide this tie.
+test('pickBestHost: preference decides between otherwise-equivalent hosts', () => {
+  expect(
+    pickBestHost([
+      { name: 'plain', online: true, running: 10, usableVersion: true, loadAvg1: 1, memPercent: 20 },
+      { name: 'chosen', online: true, running: 10, usableVersion: true, loadAvg1: 1, memPercent: 20, preferred: true },
+    ]),
+  ).toBe('chosen');
+});
+
+test('pickBestHost: preference does not override a genuinely swamped host', () => {
+  // 'busy' is preferred but carries 5 more running agents (50 pts) than the
+  // 20-pt bonus can offset — work still goes to the machine with room.
+  expect(
+    pickBestHost([
+      { name: 'busy', online: true, running: 6, usableVersion: true, preferred: true },
+      { name: 'free', online: true, running: 1, usableVersion: true },
+    ]),
+  ).toBe('free');
 });

--- a/apps/factory/src/core/launchHost.ts
+++ b/apps/factory/src/core/launchHost.ts
@@ -20,7 +20,18 @@ export interface DeviceLoad {
   // score.
   loadAvg1?: number;
   memPercent?: number;
+  // User preference from `agents devices prefer <name>` (auto-launch.json). A
+  // preferred device gets PREFERENCE_BONUS shaved off its score so it wins
+  // against otherwise-equivalent machines. Lives here rather than in each
+  // caller so EVERY ranking path — the warm-cache pick and the balanced pool
+  // pick both route through hostScore — honors the preference identically.
+  preferred?: boolean;
 }
+
+// How much a `prefer`red device is favored, in hostScore points. Two running
+// agents' worth (each ≈ 10), so a preference outranks a small load difference
+// but never sends work to a machine that is genuinely swamped.
+export const PREFERENCE_BONUS = 20;
 
 // One installed version's login/usage health, matching the fields of the CLI's
 // `agents view <agent> --json` output (ViewJsonVersion). Kept minimal so this
@@ -65,7 +76,8 @@ export function hostScore(d: DeviceLoad): number {
   const running = d.running * 10;
   const load = d.loadAvg1 !== undefined ? Math.min(d.loadAvg1, 16) : 0;
   const mem = d.memPercent !== undefined ? d.memPercent / 20 : 0; // 100% -> 5 pts
-  return running + load + mem;
+  const preference = d.preferred ? PREFERENCE_BONUS : 0;
+  return running + load + mem - preference;
 }
 
 // Pick the best online host for a launch: drop devices with no usable version of

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { BUILT_IN_AGENTS, getBuiltInByKey, getBuiltInDefByTitle, getBuiltInByPrefix, STRATEGY_LAUNCH_AGENTS, modeFlagForAgent, AgentLaunchMode, RunStrategy, buildAgentLaunchCommand, wrapNativeAgentCommand, shquote } from '../core/agents';
-import { loadAutoLaunchPreferences, isAutoLaunchEnabled } from '../core/deviceAutoLaunch';
+import { loadAutoLaunchPreferences, isAutoLaunchEnabled, isAutoLaunchPreferred } from '../core/deviceAutoLaunch';
 import { parseSpawnRequest, SpawnRequest } from '../core/spawn';
 import {
   AgentConfig,
@@ -415,7 +415,12 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
   const preferences = loadAutoLaunchPreferences();
   const fleet = devices
     .filter(d => isAutoLaunchEnabled(preferences, d.name))
-    .map(d => ({ name: d.name, online: !!d.online, running: 0 }));
+    .map(d => ({
+      name: d.name,
+      online: !!d.online,
+      running: 0,
+      preferred: isAutoLaunchPreferred(preferences, d.name),
+    }));
   const eligible = resolveBalancePool(fleet, { localName, pool }).filter(c => c.online);
   if (eligible.length === 0) {
     vscode.window.showInformationMessage('Balanced launch: no online device available — running locally.');

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { BUILT_IN_AGENTS, getBuiltInByKey, getBuiltInDefByTitle, getBuiltInByPrefix, STRATEGY_LAUNCH_AGENTS, modeFlagForAgent, AgentLaunchMode, RunStrategy, buildAgentLaunchCommand, wrapNativeAgentCommand, shquote } from '../core/agents';
+import { loadAutoLaunchPreferences, isAutoLaunchEnabled } from '../core/deviceAutoLaunch';
 import { parseSpawnRequest, SpawnRequest } from '../core/spawn';
 import {
   AgentConfig,
@@ -379,7 +380,8 @@ function resolveCachedAutoHost(context: vscode.ExtensionContext, agentKey: strin
   const startedAt = performance.now();
   const cache = context.globalState.get<LaunchHealthCache>(LAUNCH_HEALTH_KEY);
   const history = context.globalState.get<LaunchHistory>(LAUNCH_HISTORY_KEY, {});
-  const host = pickCachedLaunchHost(agentKey, cache, history) ?? undefined;
+  const preferences = loadAutoLaunchPreferences();
+  const host = pickCachedLaunchHost(agentKey, cache, history, preferences) ?? undefined;
   console.log(`[launchAgent] cached ${agentKey} host pick took ${(performance.now() - startedAt).toFixed(1)}ms`);
   return host;
 }
@@ -410,7 +412,10 @@ async function saveLaunchHistory(context: vscode.ExtensionContext, device: strin
 async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<string | undefined> {
   const localName = normalizeHost(os.hostname());
   const devices = await listRegisteredDevices();
-  const fleet = devices.map(d => ({ name: d.name, online: !!d.online, running: 0 }));
+  const preferences = loadAutoLaunchPreferences();
+  const fleet = devices
+    .filter(d => isAutoLaunchEnabled(preferences, d.name))
+    .map(d => ({ name: d.name, online: !!d.online, running: 0 }));
   const eligible = resolveBalancePool(fleet, { localName, pool }).filter(c => c.online);
   if (eligible.length === 0) {
     vscode.window.showInformationMessage('Balanced launch: no online device available — running locally.');


### PR DESCRIPTION
Adds the  header so Release plan
  app:        agents-dbg
  version:    0.9.304
  tag:        agents-dbg-v0.9.304
  repo:       phnx-labs/agents-cli
  arch:       universal
  build:      run apps/factory/app/scripts/build.sh
  release:    create
  tap:        update muqsitnawaz/tap
  installer:  curl -fsSL https://raw.githubusercontent.com/phnx-labs/agents-cli/main/scripts/install-agents-dbg.sh | sh can publish the auto-launch preferences feature.