### PR TITLE
fix(usage): derive the usage command gate from the usage library (RUSH-2082)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ agents run codex@ "review this branch"
 
 A trailing `@` opens an account picker before either an interactive or prompt-based run. Each installed version shows its account identity, exact version, login state, plan, and every available session, weekly, or monthly limit. Logged-out, rate-limited, and out-of-credit accounts remain visible with the reason they cannot be selected; signed-in accounts whose provider does not expose quota data stay selectable and say `limits unavailable`. The choice pins only that run and does not change your default version.
 
-Account selection is available for Claude, Codex, Antigravity, Grok, Kimi, Droid, and OpenCode. It requires a terminal and cannot be combined with `--resume`, `--strategy`/`--balanced`, `--lease`, or `--host`/`--device`; profiles and workflows must use their concrete host agent instead.
+Account selection is available for Claude, Codex, Gemini, Cursor, Antigravity, Grok, Kimi, Droid, and OpenCode. It requires a terminal and cannot be combined with `--resume`, `--strategy`/`--balanced`, `--lease`, or `--host`/`--device`; profiles and workflows must use their concrete host agent instead.
 
 ### Chain agents
 

--- a/apps/cli/.changelog/next/RUSH-2082.md
+++ b/apps/cli/.changelog/next/RUSH-2082.md
@@ -1,0 +1,1 @@
+- **Fix Cursor usage and account inspection (RUSH-2082).** `agents usage` now derives support from the usage library so Cursor, Grok, and future usage sources cannot drift from the command, and `agents run cursor@` can inspect Cursor's active account. Source: `apps/cli/src/commands/usage.ts`, `apps/cli/src/lib/agents.ts`.

--- a/apps/cli/src/commands/usage.test.ts
+++ b/apps/cli/src/commands/usage.test.ts
@@ -1,17 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ALL_AGENT_IDS, AGENTS } from '../lib/agents.js';
-import { agentReportsUsage } from '../lib/usage.js';
-import { formatAgentUsage, unsupportedUsageRecord, type AgentUsageRecord } from './usage.js';
-
-describe('usage support gate', () => {
-  it('derives command support from every library usage source', () => {
-    for (const agentId of ALL_AGENT_IDS) {
-      const record = unsupportedUsageRecord(agentId, AGENTS[agentId].name);
-      expect(record === null).toBe(agentReportsUsage(agentId));
-    }
-  });
-});
+import { formatAgentUsage, type AgentUsageRecord } from './usage.js';
 
 // Locks the text-path output of the collect/format refactor: `formatAgentUsage`
 // must render each status branch exactly as the old inline `renderAgentUsage` did,

--- a/apps/cli/src/commands/usage.test.ts
+++ b/apps/cli/src/commands/usage.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatAgentUsage, type AgentUsageRecord } from './usage.js';
+import { ALL_AGENT_IDS, AGENTS } from '../lib/agents.js';
+import { agentReportsUsage } from '../lib/usage.js';
+import { formatAgentUsage, unsupportedUsageRecord, type AgentUsageRecord } from './usage.js';
+
+describe('usage support gate', () => {
+  it('derives command support from every library usage source', () => {
+    for (const agentId of ALL_AGENT_IDS) {
+      const record = unsupportedUsageRecord(agentId, AGENTS[agentId].name);
+      expect(record === null).toBe(agentReportsUsage(agentId));
+    }
+  });
+});
 
 // Locks the text-path output of the collect/format refactor: `formatAgentUsage`
 // must render each status branch exactly as the old inline `renderAgentUsage` did,

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -6,8 +6,9 @@
  *   - codex:  parsed from latest session log's rate_limits event
  *   - kimi:   live Kimi Code /usages API call (cached for 2 minutes)
  *   - droid:  live Factory billing/limits API call (cached for 2 minutes)
- *   - others: marked as "not exposed by CLI" (Gemini, OpenCode, Cursor, etc.
- *     don't publish per-account usage today)
+ *   - grok:   parsed from the latest local usage event
+ *   - cursor: live Cursor usage API call (cached for 2 minutes)
+ *   - others: marked as "not exposed by CLI"
  */
 import type { Command } from 'commander';
 import { addHostOption } from '../lib/hosts/option.js';
@@ -23,15 +24,7 @@ import {
 } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import { listInstalledVersions, getGlobalDefault, getVersionHomePath } from '../lib/versions.js';
-import { formatUsageSection, getUsageInfoForIdentity } from '../lib/usage.js';
-
-/**
- * Agents whose CLI surfaces usage data we can read today. Kept in sync with the
- * live/last-seen sources `getUsageInfo` dispatches on in `../lib/usage.js`
- * (claude, codex, kimi, droid) — an agent with a usage source but missing here
- * would wrongly print "does not publish usage data" for a signed-in account.
- */
-const USAGE_SUPPORTED: ReadonlySet<AgentId> = new Set<AgentId>(['claude', 'codex', 'kimi', 'droid']);
+import { agentReportsUsage, formatUsageSection, getUsageInfoForIdentity } from '../lib/usage.js';
 
 /** One agent's usage snapshot — the unit the text and --json renderers share. */
 export interface AgentUsageRecord {
@@ -41,6 +34,16 @@ export interface AgentUsageRecord {
   status: 'unsupported' | 'no-version' | 'not-signed-in' | 'ok';
   email?: string;
   usage?: Awaited<ReturnType<typeof getUsageInfoForIdentity>>;
+}
+
+/** Return the unsupported record only when the usage library has no source. */
+export function unsupportedUsageRecord(
+  agentId: AgentId,
+  label: string,
+): AgentUsageRecord | null {
+  return agentReportsUsage(agentId)
+    ? null
+    : { agent: agentId, label, status: 'unsupported' };
 }
 
 export function registerUsageCommand(program: Command): void {
@@ -96,9 +99,8 @@ async function collectAgentUsage(agentId: AgentId): Promise<AgentUsageRecord> {
   // `--json` never emits ANSI escapes in `label` (e.g. under FORCE_COLOR=1).
   const label = AGENTS[agentId].name;
 
-  if (!USAGE_SUPPORTED.has(agentId)) {
-    return { agent: agentId, label, status: 'unsupported' };
-  }
+  const unsupported = unsupportedUsageRecord(agentId, label);
+  if (unsupported) return unsupported;
 
   const versions = listInstalledVersions(agentId);
   const version = getGlobalDefault(agentId) || versions[0];

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -36,16 +36,6 @@ export interface AgentUsageRecord {
   usage?: Awaited<ReturnType<typeof getUsageInfoForIdentity>>;
 }
 
-/** Return the unsupported record only when the usage library has no source. */
-export function unsupportedUsageRecord(
-  agentId: AgentId,
-  label: string,
-): AgentUsageRecord | null {
-  return agentReportsUsage(agentId)
-    ? null
-    : { agent: agentId, label, status: 'unsupported' };
-}
-
 export function registerUsageCommand(program: Command): void {
   addHostOption(program.command('usage [agent]'))
     .description('Show rate-limit / quota usage per agent')
@@ -99,8 +89,9 @@ async function collectAgentUsage(agentId: AgentId): Promise<AgentUsageRecord> {
   // `--json` never emits ANSI escapes in `label` (e.g. under FORCE_COLOR=1).
   const label = AGENTS[agentId].name;
 
-  const unsupported = unsupportedUsageRecord(agentId, label);
-  if (unsupported) return unsupported;
+  if (!agentReportsUsage(agentId)) {
+    return { agent: agentId, label, status: 'unsupported' };
+  }
 
   const versions = listInstalledVersions(agentId);
   const version = getGlobalDefault(agentId) || versions[0];

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AccountInfo } from '../agents.js';
+import { ALL_AGENT_IDS } from '../agents.js';
 import * as state from '../state.js';
 import {
   agentReportsUsage,
@@ -22,6 +23,7 @@ import {
   formatKimiPlan,
   normalizeDroidWindows,
   normalizeCursorUsage,
+  USAGE_SOURCE_AGENT_IDS,
   type DroidBillingLimitsResponse,
   type KimiUsagesResponse,
   type UsageSnapshot,
@@ -138,12 +140,10 @@ describe('usage formatting', () => {
       .not.toContain('usage unavailable');
   });
 
-  it('agentReportsUsage flags only the agents that expose usage data', () => {
-    for (const a of ['claude', 'codex', 'kimi', 'droid', 'grok', 'cursor'] as const) {
-      expect(agentReportsUsage(a)).toBe(true);
-    }
-    for (const a of ['antigravity', 'opencode', 'gemini'] as const) {
-      expect(agentReportsUsage(a)).toBe(false);
+  it('pins the complete usage source registry and derives support from it', () => {
+    expect(USAGE_SOURCE_AGENT_IDS).toEqual(['claude', 'codex', 'kimi', 'droid', 'grok', 'cursor']);
+    for (const agentId of ALL_AGENT_IDS) {
+      expect(agentReportsUsage(agentId)).toBe(USAGE_SOURCE_AGENT_IDS.includes(agentId as never));
     }
   });
 

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -34,6 +34,7 @@ describe('account inspection support', () => {
       'claude',
       'codex',
       'gemini',
+      'cursor',
       'grok',
       'antigravity',
       'kimi',

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1097,6 +1097,7 @@ export const ACCOUNT_INSPECTION_AGENT_IDS = [
   'claude',
   'codex',
   'gemini',
+  'cursor',
   'grok',
   'antigravity',
   'kimi',

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -205,24 +205,31 @@ interface CodexRateLimitMatch {
   rateLimits: CodexRateLimits;
 }
 
-/** Fetch usage info for a given agent, dispatching to the agent-specific implementation. */
+interface UsageSource {
+  fetch: (options?: UsageOptions) => Promise<UsageInfo>;
+  network: boolean;
+}
+
+/** The single registry of agent usage sources and their transport. */
+const USAGE_SOURCES = {
+  claude: { fetch: getClaudeUsageInfo, network: true },
+  codex: { fetch: getCodexUsageInfo, network: false },
+  kimi: { fetch: getKimiUsageInfo, network: true },
+  droid: { fetch: getDroidUsageInfo, network: true },
+  grok: { fetch: getGrokUsageInfo, network: false },
+  cursor: { fetch: getCursorUsageInfo, network: true },
+} as const satisfies Partial<Record<AgentId, UsageSource>>;
+
+export const USAGE_SOURCE_AGENT_IDS = Object.keys(USAGE_SOURCES) as (keyof typeof USAGE_SOURCES)[];
+
+function getUsageSource(agentId: AgentId): UsageSource | undefined {
+  return USAGE_SOURCES[agentId as keyof typeof USAGE_SOURCES];
+}
+
+/** Fetch usage info for a given agent through the canonical source registry. */
 export async function getUsageInfo(agentId: AgentId, options?: UsageOptions): Promise<UsageInfo> {
-  switch (agentId) {
-    case 'claude':
-      return getClaudeUsageInfo(options);
-    case 'codex':
-      return getCodexUsageInfo(options);
-    case 'kimi':
-      return getKimiUsageInfo(options);
-    case 'droid':
-      return getDroidUsageInfo(options);
-    case 'grok':
-      return getGrokUsageInfo(options);
-    case 'cursor':
-      return getCursorUsageInfo(options);
-    default:
-      return { snapshot: null, error: null };
-  }
+  const source = getUsageSource(agentId);
+  return source ? source.fetch(options) : { snapshot: null, error: null };
 }
 
 /** Derive a stable lookup key from account info for usage deduplication. */
@@ -274,14 +281,7 @@ export function buildCanonicalUsageContext(inputs: UsageIdentityInput[]): {
  * versus simply not applicable (Antigravity, OpenCode).
  */
 export function agentReportsUsage(agentId: AgentId): boolean {
-  return (
-    agentId === 'claude' ||
-    agentId === 'codex' ||
-    agentId === 'kimi' ||
-    agentId === 'droid' ||
-    agentId === 'grok' ||
-    agentId === 'cursor'
-  );
+  return getUsageSource(agentId) !== undefined;
 }
 
 /** Fetch usage info for all unique accounts in parallel, keyed by usage key. */
@@ -336,15 +336,14 @@ export async function getUsageInfoForIdentity(
   const usageKey = getUsageLookupKey(input.info);
   const forceRefresh = opts?.forceRefresh === true;
 
-  // Agents whose usage comes from a live network call (Claude, Kimi, Droid) go
+  // Agents whose registered usage source makes a live network call go
   // through the stale-while-revalidate cache below so `agents run`/`agents view`
   // stay off the network on the hot path. Everything else (Codex reads local
   // session logs) takes the legacy blocking path. The on-disk cache is shared and
   // keyed by usageKey, which is namespaced per agent (`claude:org=…`,
-  // `kimi:user=…`, `droid:org=…`), so one cache file holds every account without
-  // collision.
-  const usesNetworkUsage =
-    input.agentId === 'claude' || input.agentId === 'kimi' || input.agentId === 'droid';
+  // `kimi:user=…`, `droid:org=…`, `cursor:user=…`), so one cache file holds every
+  // account without collision.
+  const usesNetworkUsage = getUsageSource(input.agentId)?.network === true;
   if (!usesNetworkUsage || !usageKey) {
     return getUsageInfo(input.agentId, {
       home: input.home,


### PR DESCRIPTION
`agents usage cursor` reports real account state instead of falsely claiming Cursor publishes no usage data, and `--account` can inspect a Cursor account — **fix**, closes [RUSH-2082](https://linear.app/getrush/issue/RUSH-2082) (parent [RUSH-2079](https://linear.app/getrush/issue/RUSH-2079)).

## What was broken

Commit `5beb6249` landed Cursor's usage fetcher and its `getAccountInfo` case, but two gates were left behind:

1. `commands/usage.ts` hardcoded `USAGE_SUPPORTED = new Set(['claude','codex','kimi','droid'])`, which had drifted from `lib/usage.ts` — **cursor and grok** both had working library-level sources. `agents usage cursor` printed "Cursor CLI does not publish usage data", which was false.
2. `ACCOUNT_INSPECTION_AGENT_IDS` omitted cursor, so `agents run cursor --account` errored with "does not expose local account state" even though `getAccountInfo('cursor')` works.

## Fixed at the source — one registry, not three lists

The first attempt at this PR just pointed the command gate at `agentReportsUsage`. Review caught that this **moved** the duplication rather than removing it: `agentReportsUsage` was itself a hand-maintained `agentId === '…' ||` chain sitting 50 lines below the real `getUsageInfo` dispatch switch. The accompanying test was a tautology — it reduced to `expect(f(id)).toBe(f(id))` and passed even with `agentReportsUsage` stubbed to always return `false`.

This version introduces a single source:

```ts
const USAGE_SOURCES = {
  claude: { fetch: getClaudeUsageInfo, network: true },
  codex:  { fetch: getCodexUsageInfo,  network: false },
  kimi:   { fetch: getKimiUsageInfo,   network: true },
  droid:  { fetch: getDroidUsageInfo,  network: true },
  grok:   { fetch: getGrokUsageInfo,   network: false },
  cursor: { fetch: getCursorUsageInfo, network: true },
} as const satisfies Partial<Record<AgentId, UsageSource>>;
```

Three previously-separate hand-maintained lists now derive from it: the `getUsageInfo` dispatch, `agentReportsUsage`, and the `usesNetworkUsage` stale-while-revalidate gate. That last one also fixes a latency regression this PR would otherwise have introduced — cursor is a live network call but was missing from the SWR gate, so every `agents usage cursor` and every `agents run cursor@` would have issued an uncached HTTP request.

`unsupportedUsageRecord` (added by the first attempt, only ever called by the tautological test) is deleted.

## The test now has power — verified by breaking it

```ts
it('pins the complete usage source registry and derives support from it', () => {
  expect(USAGE_SOURCE_AGENT_IDS).toEqual(['claude', 'codex', 'kimi', 'droid', 'grok', 'cursor']);
  for (const agentId of ALL_AGENT_IDS) {
    expect(agentReportsUsage(agentId)).toBe(USAGE_SOURCE_AGENT_IDS.includes(agentId as never));
  }
});
```

Removing `cursor` from `USAGE_SOURCES` produces:

```
 FAIL  src/lib/__tests__/usage.test.ts > pins the complete usage source registry and derives support from it
AssertionError: expected [ 'claude', 'codex', 'kimi', …(2) ] to deeply equal [ 'claude', 'codex', 'kimi', …(3) ]
-   "cursor",
```

## The run — installed dev CLI, real signed-in Cursor account

```
$ agents usage cursor
Cursor
  [REDACTED_EMAIL]
  No usage data available right now.

$ agents run cursor --account
? Select a Cursor account for this run:
❯ [REDACTED_EMAIL]  2026.07.23  logged in  plan unavailable  limits unavailable
```

Before: `Cursor CLI does not publish usage data.`

"plan unavailable / limits unavailable" is honest reporting, not a faked number — Cursor's usage-based plans return no request cap, so there is no gauge to render.

On the judgement call RUSH-2082 asked for, cursor **can** support the account picker: `getAccountInfo` reads identity from `~/.cursor/cli-config.json` and signed-in state from `~/.config/cursor/auth.json`, which is what the picker needs. Multiplicity comes from installed version homes, not from the credential file, so cursor's single-account config is the same shape as every existing member of the list.

`README.md:168` updated to match `ACCOUNT_INSPECTION_AGENT_IDS` — it had also been missing Gemini before this PR.

## Deliberately out of scope

Fleet credential propagation for cursor — `apps/cli/docs/fleet.md:132-140` still says cursor has no portable credential, and moving auth files between hosts needs explicit owner authorization.

No credential values appear in this diff, its tests, or the output above.
