### PR TITLE
fix(cursor): dual-write commands to the IDE dir and as CLI skills (RUSH-2083)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,7 +1116,7 @@ Which DotAgents resources each agent CLI can load. Source of truth: [src/lib/age
 | Antigravity | yes | yes | yes | yes | yes | yes | yes | no | `AGENTS.md` | no |
 | Grok Build | yes | yes | yes | yes | yes | skills ($name) | yes | no | `AGENTS.md` | no |
 | OpenClaw | yes | yes | yes | no | yes | gateway | yes | yes | `workspace/AGENTS.md` | no |
-| Cursor | yes | no | yes | no | yes | yes | no | no | `.cursorrules` | no |
+| Cursor | yes | yes | yes | yes | yes | IDE + skills ($name) | yes | >= 2026.1.22 | `.cursorrules` | no |
 | OpenCode | yes | no | yes | >= 1.1.1 | yes | yes | no | no | `AGENTS.md` | no |
 | Copilot | yes | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
 | Amp | yes | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
@@ -1125,7 +1125,7 @@ Which DotAgents resources each agent CLI can load. Source of truth: [src/lib/age
 | Roo Code | yes | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
 | Droid | yes | yes | yes | >= 0.57.5 | >= 0.26.0 | yes | yes | yes | `AGENTS.md` | no |
 
-**Legend:** `yes` / `no` = synced or skipped at install time. `skills ($name)` = no file-based slash-command dir; behavior ships as a generated skill invoked with `$command`. `gateway` = OpenClaw resolves slash commands at runtime, not from synced files. Version suffixes are enforced at sync time — out-of-range versions are skipped with a clear message.
+**Legend:** `yes` / `no` = synced or skipped at install time. `skills ($name)` = no file-based slash-command dir; behavior ships as a generated skill invoked with `$command`. `IDE + skills ($name)` = an IDE command file plus a generated skill for the CLI. `gateway` = OpenClaw resolves slash commands at runtime, not from synced files. Version suffixes are enforced at sync time — out-of-range versions are skipped with a clear message.
 
 **Host CLIs** (`agents cli`) are separate: YAML manifests under `~/.agents/cli/` install binaries onto your PATH (`gh`, `higgsfield`, etc.). They are not copied into per-agent version homes.
 

--- a/apps/cli/.changelog/next/RUSH-2083.md
+++ b/apps/cli/.changelog/next/RUSH-2083.md
@@ -1,0 +1,1 @@
+- **Sync Cursor commands to the IDE and cursor-agent CLI (RUSH-2083).** Shared commands now remain available as typed IDE slash commands and are also generated as Agent Skills for cursor-agent, while preserving user-authored files in `.cursor/commands/`. Source: `apps/cli/src/lib/command-skills.ts`.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -173,7 +173,7 @@ contract.
 |------|-------|-----|-------------|--------|----------|---------|-----------|-------|-----------|
 | Claude | yes | yes | yes | yes | yes | yes | yes | `CLAUDE.md` | yes |
 | Codex | >= 0.116.0 | yes | >= 0.138.0 | yes | < 0.117.0 · skills ($name, >= 0.117) | >= 0.128.0 | >= 0.117.0 | `AGENTS.md` | no |
-| Cursor | no | yes | no | yes | yes | no | no | `.cursorrules` | no |
+| Cursor | yes | yes | yes | yes | IDE + skills ($name) | yes | >= 2026.1.22 | `.cursorrules` | no |
 | OpenCode | no | yes | >= 1.1.1 | yes | yes | no | no | `AGENTS.md` | no |
 | OpenClaw | yes | yes | yes | yes | gateway | yes | yes | `workspace/AGENTS.md` | no |
 | Copilot | no | yes | no | yes | yes | no | no | `AGENTS.md` | no |
@@ -206,7 +206,7 @@ Slash commands in `commands/*.md` can narrow sync with optional YAML frontmatter
 ```yaml
 ---
 description: Required one-line summary
-agents: [claude, cursor, codex]   # omit = all command-capable agents
+agents: [claude, cursor, codex]   # omit = all compatible agents; Cursor receives both formats
 since: "0.116.0"                  # minimum agent CLI version (inclusive)
 until: "0.117.0"                  # exclusive upper bound
 ---
@@ -214,4 +214,4 @@ until: "0.117.0"                  # exclusive upper bound
 
 `commandAppliesTo()` in `src/lib/commands.ts` evaluates these fields after the agent-level `commands` / commands-as-skills gate. The check runs on central sync (`~/.agents/commands/` user/system → version home) and on `agents commands install`; project `.agents/commands/` files are discovered in place and are not filtered by `agents:`.
 
-Example: `.agents/commands/version.md` targets Claude, Codex, Cursor, OpenCode, Copilot, and Grok; Antigravity is excluded until harness support is verified.
+Example: `.agents/commands/version.md` targets Claude, Codex, Cursor, OpenCode, Copilot, and Grok. Cursor receives both an IDE command file and an Agent Skill because cursor-agent does not load the IDE's `.cursor/commands/` files; Antigravity is excluded until harness support is verified.

--- a/apps/cli/src/lib/command-skills.ts
+++ b/apps/cli/src/lib/command-skills.ts
@@ -59,6 +59,22 @@ export function shouldInstallCommandAsSkill(agent: AgentId, version: string): bo
   return !supports(agent, 'commands', version).ok && supports(agent, 'skills', version).ok;
 }
 
+/**
+ * Agents whose native command files serve a separate surface while their CLI
+ * consumes the generated skill form. Keep this registry distinct from
+ * `shouldInstallCommandAsSkill`: these targets need both writes, not a format
+ * replacement.
+ */
+export const COMMAND_SKILL_DUAL_WRITE_TARGETS = {
+  cursor: true,
+} satisfies Partial<Record<AgentId, true>>;
+
+export function shouldAlsoInstallCommandAsSkill(agent: AgentId, version: string): boolean {
+  return COMMAND_SKILL_DUAL_WRITE_TARGETS[agent as keyof typeof COMMAND_SKILL_DUAL_WRITE_TARGETS] === true
+    && supports(agent, 'commands', version).ok
+    && supports(agent, 'skills', version).ok;
+}
+
 export function commandSkillName(commandName: string): string {
   return commandName;
 }

--- a/apps/cli/src/lib/commands.test.ts
+++ b/apps/cli/src/lib/commands.test.ts
@@ -27,6 +27,7 @@ function runCommandsExpression(home: string, expression: string): unknown {
   const child = spawnSync(tsxBin, ['-e', `
     import {
       diffVersionCommands,
+      installCommand,
       installCommandToVersion,
       listCommandsInVersionHome,
       listPluginCommandNames,
@@ -66,10 +67,12 @@ function scaffoldInstalledVersion(home: string, agent: string, version: string):
 }
 
 /** Place a command .md in the system commands dir so listCentralCommands() finds it. */
-function writeSystemCommand(home: string, name: string, content: string): void {
+function writeSystemCommand(home: string, name: string, content: string): string {
   const dir = path.join(home, '.agents', '.system', 'commands');
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, `${name}.md`), content, 'utf-8');
+  const source = path.join(dir, `${name}.md`);
+  fs.writeFileSync(source, content, 'utf-8');
+  return source;
 }
 
 /** Path to the trash commands dir for a given HOME: home/.agents/.trash/commands */
@@ -206,6 +209,41 @@ describe('diffVersionCommands — plugin-bundled commands are source-managed', (
 });
 
 describe('version command management', () => {
+  it('installs an unmanaged Cursor command to both surfaces through the package installation path', () => {
+    const home = makeTempHome();
+    const source = writeSystemCommand(
+      home,
+      'package-command',
+      '---\nname: package-command\ndescription: Package command\n---\n\nPackage command body.',
+    );
+
+    const installed = runCommandsExpression(
+      home,
+      `installCommand(${JSON.stringify(source)}, 'cursor', 'package-command', 'copy')`
+    ) as { error?: string };
+
+    expect(installed.error).toBeUndefined();
+    expect(fs.existsSync(path.join(home, '.cursor', 'commands', 'package-command.md'))).toBe(true);
+    expect(fs.existsSync(path.join(home, '.cursor', 'skills', 'package-command', 'SKILL.md'))).toBe(true);
+  });
+
+  it('installs and removes Cursor commands from both native and generated-skill surfaces', () => {
+    const home = makeTempHome();
+    writeSystemCommand(home, 'recap', 'Summarize this session.');
+
+    const installed = runCommandsExpression(home, "installCommandToVersion('cursor', '2026.07.23-e383d2b', 'recap')") as { success: boolean };
+    const cursorHome = path.join(versionHomePath(home, 'cursor', '2026.07.23-e383d2b'), '.cursor');
+
+    expect(installed.success).toBe(true);
+    expect(fs.existsSync(path.join(cursorHome, 'commands', 'recap.md'))).toBe(true);
+    expect(fs.existsSync(path.join(cursorHome, 'skills', 'recap', 'SKILL.md'))).toBe(true);
+
+    const removed = runCommandsExpression(home, "removeCommandFromVersion('cursor', '2026.07.23-e383d2b', 'recap')") as { success: boolean };
+    expect(removed.success).toBe(true);
+    expect(fs.existsSync(path.join(cursorHome, 'commands', 'recap.md'))).toBe(false);
+    expect(fs.existsSync(path.join(cursorHome, 'skills', 'recap', 'SKILL.md'))).toBe(false);
+  });
+
   it('installs, lists, diffs, and removes generated command skills for Codex 0.117.0+', () => {
     const home = makeTempHome();
     // codex 0.117.0 uses shouldInstallCommandAsSkill (skills path, not prompts file).

--- a/apps/cli/src/lib/commands.ts
+++ b/apps/cli/src/lib/commands.ts
@@ -22,6 +22,7 @@ import {
   installCommandSkillToVersion,
   listCommandSkillsInVersion,
   removeCommandSkillFromVersion,
+  shouldAlsoInstallCommandAsSkill,
   shouldInstallCommandAsSkill,
 } from './command-skills.js';
 import {
@@ -312,6 +313,20 @@ export function installCommand(
   ensureCommandsDir(agentId);
 
   const home = getEffectiveHome(agentId);
+  const installVersion = pinnedVersion ?? listInstalledVersions(agentId)[0] ?? '';
+  const alsoInstallAsSkill = shouldAlsoInstallCommandAsSkill(agentId, installVersion);
+
+  if (alsoInstallAsSkill) {
+    const installed = installCommandSkillToVersion(
+      path.join(home, agentConfigDirName(agentId)),
+      commandName,
+      sourcePath,
+      [getSkillsDir(), ...getEnabledExtraRepos().map((repo) => path.join(repo.dir, 'skills'))],
+    );
+    if (!installed.success) {
+      return { path: '', method: 'copy', error: installed.error, warnings: validation.warnings };
+    }
+  }
 
   // Goose: a slash command is a recipe YAML registered in config.yaml, not a
   // native command file under commandsSubdir.
@@ -541,6 +556,16 @@ export function installCommandToVersion(
     );
   }
 
+  if (shouldAlsoInstallCommandAsSkill(agent, version)) {
+    const installed = installCommandSkillToVersion(
+      agentDir,
+      commandName,
+      sourcePath,
+      [getSkillsDir(), ...getEnabledExtraRepos().map((repo) => path.join(repo.dir, 'skills'))],
+    );
+    if (!installed.success) return installed;
+  }
+
   // Goose: a slash command is a recipe YAML registered in config.yaml, not a
   // native command file. Write the recipe + slash_commands entry.
   if (agent === 'goose') {
@@ -586,6 +611,10 @@ export function removeCommandFromVersion(
   const agentDir = path.join(versionHome, agentConfigDirName(agent));
   if (shouldInstallCommandAsSkill(agent, version)) {
     return removeCommandSkillFromVersion(agentDir, commandName);
+  }
+  if (shouldAlsoInstallCommandAsSkill(agent, version)) {
+    const removed = removeCommandSkillFromVersion(agentDir, commandName);
+    if (!removed.success) return removed;
   }
   if (agent === 'goose') {
     const trashDir = path.join(getTrashCommandsDir(), agent, version, commandName);

--- a/apps/cli/src/lib/project-resources.test.ts
+++ b/apps/cli/src/lib/project-resources.test.ts
@@ -20,6 +20,20 @@ afterEach(() => {
 });
 
 describe('syncProjectResourcesToAgent', () => {
+  it('syncs Cursor project commands to both native and generated-skill surfaces', () => {
+    const project = makeTempProject();
+    const projectAgentsDir = path.join(project, '.agents');
+    const command = path.join(projectAgentsDir, 'commands', 'ping.md');
+    fs.mkdirSync(path.dirname(command), { recursive: true });
+    fs.writeFileSync(command, 'Ping from the project.', 'utf-8');
+
+    const result = syncProjectResourcesToAgent('cursor', '2026.07.23-e383d2b', projectAgentsDir);
+
+    expect(result.synced).toEqual(['commands/ping']);
+    expect(fs.readFileSync(path.join(project, '.cursor', 'commands', 'ping.md'), 'utf-8')).toBe('Ping from the project.');
+    expect(fs.readFileSync(path.join(project, '.cursor', 'skills', 'ping', 'SKILL.md'), 'utf-8')).toContain('agents_command: "ping"');
+  });
+
   it('skips hard-deprecated gemini when syncing project resources', () => {
     const project = makeTempProject();
     const projectAgentsDir = path.join(project, '.agents');

--- a/apps/cli/src/lib/project-resources.ts
+++ b/apps/cli/src/lib/project-resources.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { AGENTS, agentConfigDirName, isAgentHardDeprecated } from './agents.js';
 import { supports } from './capabilities.js';
-import { buildCommandSkillContent, commandSkillName, readSkillSourceCommandMarker, shouldInstallCommandAsSkill } from './command-skills.js';
+import { buildCommandSkillContent, commandSkillName, readSkillSourceCommandMarker, shouldAlsoInstallCommandAsSkill, shouldInstallCommandAsSkill } from './command-skills.js';
 import { commandAppliesTo, parseCommandMetadata } from './commands.js';
 import { markdownToToml } from './convert.js';
 import { safeJoin } from './paths.js';
@@ -168,6 +168,7 @@ function syncProjectCommands(
 ): void {
   const cfg = AGENTS[agent];
   const commandsAsSkills = shouldInstallCommandAsSkill(agent, version);
+  const commandsAlsoAsSkills = shouldAlsoInstallCommandAsSkill(agent, version);
   const supportsCommands = supports(agent, 'commands', version).ok;
   if (!commandsAsSkills && !supportsCommands) return;
 
@@ -179,20 +180,27 @@ function syncProjectCommands(
     const metadata = parseCommandMetadata(srcFile);
     if (!commandAppliesTo(agent, version, metadata).ok) continue;
 
-    if (commandsAsSkills) {
+    const written: string[] = [];
+    if (commandsAsSkills || commandsAlsoAsSkills) {
       const sourceMarker = readSkillSourceCommandMarker(name, [path.join(projectAgentsDir, 'skills')]);
-      if (pathExists(path.join(projectAgentsDir, 'skills', name)) && sourceMarker !== name) continue;
-      const skillName = commandSkillName(name);
-      const rel = path.join('skills', skillName);
-      const destDir = path.join(agentRoot, rel);
-      if (pathExists(destDir)) {
-        skip(destDir, projectRoot, result);
+      if (pathExists(path.join(projectAgentsDir, 'skills', name)) && sourceMarker !== name) {
+        if (commandsAsSkills) continue;
+      } else {
+        const skillName = commandSkillName(name);
+        const rel = path.join('skills', skillName);
+        const destDir = path.join(agentRoot, rel);
+        if (pathExists(destDir)) {
+          skip(destDir, projectRoot, result);
+        } else {
+          fs.mkdirSync(destDir, { recursive: true });
+          fs.writeFileSync(path.join(destDir, 'SKILL.md'), buildCommandSkillContent(name, srcFile), 'utf-8');
+          written.push(rel);
+        }
+      }
+      if (commandsAsSkills) {
+        if (written.length > 0) record('commands', name, written, result, manifestPaths);
         continue;
       }
-      fs.mkdirSync(destDir, { recursive: true });
-      fs.writeFileSync(path.join(destDir, 'SKILL.md'), buildCommandSkillContent(name, srcFile), 'utf-8');
-      record('commands', name, [rel], result, manifestPaths);
-      continue;
     }
 
     const ext = cfg.format === 'toml' ? '.toml' : '.md';
@@ -200,15 +208,16 @@ function syncProjectCommands(
     const destFile = path.join(agentRoot, rel);
     if (pathExists(destFile)) {
       skip(destFile, projectRoot, result);
-      continue;
-    }
-    fs.mkdirSync(path.dirname(destFile), { recursive: true });
-    if (cfg.format === 'toml') {
-      fs.writeFileSync(destFile, markdownToToml(name, fs.readFileSync(srcFile, 'utf-8')), 'utf-8');
     } else {
-      fs.copyFileSync(srcFile, destFile);
+      fs.mkdirSync(path.dirname(destFile), { recursive: true });
+      if (cfg.format === 'toml') {
+        fs.writeFileSync(destFile, markdownToToml(name, fs.readFileSync(srcFile, 'utf-8')), 'utf-8');
+      } else {
+        fs.copyFileSync(srcFile, destFile);
+      }
+      written.push(rel);
     }
-    record('commands', name, [rel], result, manifestPaths);
+    if (written.length > 0) record('commands', name, written, result, manifestPaths);
   }
 }
 

--- a/apps/cli/src/lib/staleness/detectors/commands.ts
+++ b/apps/cli/src/lib/staleness/detectors/commands.ts
@@ -10,7 +10,6 @@ import type { AgentId } from '../../types.js';
 import { AGENTS, MANAGED_AGENT_IDS, agentConfigDirName } from '../../agents.js';
 import {
   listCommandSkillsInVersion,
-  shouldAlsoInstallCommandAsSkill,
   shouldInstallCommandAsSkill,
 } from '../../command-skills.js';
 import type { ResourceDetector, DetectArgs } from './types.js';
@@ -33,10 +32,14 @@ function buildCommandsDetector(agent: AgentId): ResourceDetector {
       const nativeCommands = fs.readdirSync(commandsDir)
         .filter(f => f.endsWith(ext))
         .map(f => f.replace(new RegExp(`\\${ext}$`), ''));
-      if (!shouldAlsoInstallCommandAsSkill(agent, version)) return nativeCommands;
-
-      const commandSkills = new Set(listCommandSkillsInVersion(agentDir));
-      return nativeCommands.filter((name) => commandSkills.has(name));
+      // For a dual-write target the native file is the authoritative record that
+      // the command synced. The skill copy is derived, and
+      // installCommandSkillToVersion deliberately writes none when a real skill
+      // source already owns the name -- requiring both copies reported those
+      // commands missing forever and drove an `agents refresh` loop no sync could
+      // clear. This also matches `agents doctor`/`prune`, which read the
+      // unfiltered listCommandsInVersionHome.
+      return nativeCommands;
     },
   };
 }

--- a/apps/cli/src/lib/staleness/detectors/commands.ts
+++ b/apps/cli/src/lib/staleness/detectors/commands.ts
@@ -1,5 +1,5 @@
 /**
- * Commands detector — mirrors versions.ts:343-357. Inspects the version home,
+ * Commands detector — mirrors the command dispatch in versions.ts. Inspects the version home,
  * returns command names. Honors the commands-as-skills marker for skills-only
  * agents (Kimi, Codex >= 0.117.0, …), requires both copies for dual-write
  * targets, and scans `{agentDir}/<commandsSubdir>/` for native-only targets.

--- a/apps/cli/src/lib/staleness/detectors/commands.ts
+++ b/apps/cli/src/lib/staleness/detectors/commands.ts
@@ -1,14 +1,18 @@
 /**
  * Commands detector — mirrors versions.ts:343-357. Inspects the version home,
  * returns command names. Honors the commands-as-skills marker for skills-only
- * agents (kimi, Codex >= 0.117.0, …); falls back to scanning
- * `{agentDir}/<commandsSubdir>/` for the native path.
+ * agents (Kimi, Codex >= 0.117.0, …), requires both copies for dual-write
+ * targets, and scans `{agentDir}/<commandsSubdir>/` for native-only targets.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId } from '../../types.js';
 import { AGENTS, MANAGED_AGENT_IDS, agentConfigDirName } from '../../agents.js';
-import { shouldInstallCommandAsSkill, listCommandSkillsInVersion } from '../../command-skills.js';
+import {
+  listCommandSkillsInVersion,
+  shouldAlsoInstallCommandAsSkill,
+  shouldInstallCommandAsSkill,
+} from '../../command-skills.js';
 import type { ResourceDetector, DetectArgs } from './types.js';
 import { lazyAgentMap } from '../writers/lazy-map.js';
 
@@ -26,9 +30,13 @@ function buildCommandsDetector(agent: AgentId): ResourceDetector {
       const commandsDir = path.join(agentDir, agentConfig.commandsSubdir);
       if (!fs.existsSync(commandsDir)) return [];
       const ext = agentConfig.format === 'toml' ? '.toml' : '.md';
-      return fs.readdirSync(commandsDir)
+      const nativeCommands = fs.readdirSync(commandsDir)
         .filter(f => f.endsWith(ext))
         .map(f => f.replace(new RegExp(`\\${ext}$`), ''));
+      if (!shouldAlsoInstallCommandAsSkill(agent, version)) return nativeCommands;
+
+      const commandSkills = new Set(listCommandSkillsInVersion(agentDir));
+      return nativeCommands.filter((name) => commandSkills.has(name));
     },
   };
 }

--- a/apps/cli/src/lib/staleness/detectors/commands.ts
+++ b/apps/cli/src/lib/staleness/detectors/commands.ts
@@ -1,8 +1,9 @@
 /**
  * Commands detector — mirrors the command dispatch in versions.ts. Inspects the version home,
  * returns command names. Honors the commands-as-skills marker for skills-only
- * agents (Kimi, Codex >= 0.117.0, …), requires both copies for dual-write
- * targets, and scans `{agentDir}/<commandsSubdir>/` for native-only targets.
+ * agents (Kimi, Codex >= 0.117.0, …), treats the native file as authoritative
+ * for dual-write targets (the skill copy is deliberately absent on a name
+ * collision), and scans `{agentDir}/<commandsSubdir>/` for native-only targets.
  */
 import * as fs from 'fs';
 import * as path from 'path';

--- a/apps/cli/src/lib/staleness/registry.test.ts
+++ b/apps/cli/src/lib/staleness/registry.test.ts
@@ -80,6 +80,12 @@ describe('staleness/registry', () => {
     expect(DETECTORS.commands.kimi).toBeDefined();
   });
 
+  it('cursor remains covered by the commands writer + detector for dual-write sync', () => {
+    expect(AGENTS.cursor.capabilities.commands).toBe(true);
+    expect(WRITERS.commands.cursor).toBeDefined();
+    expect(DETECTORS.commands.cursor).toBeDefined();
+  });
+
   it('openclaw opts OUT of commands-as-skills (native command runtime)', () => {
     // openclaw resolves slash commands through its Gateway runtime, so it
     // declares nativeCommandRuntime and must NOT be registered for commands.

--- a/apps/cli/src/lib/staleness/types.ts
+++ b/apps/cli/src/lib/staleness/types.ts
@@ -52,6 +52,8 @@ export interface SyncManifest {
   v:          typeof MANIFEST_VERSION;
   syncedAt:   string;
   commands:   Record<string, FileEntry>;
+  /** Command names the version writer emitted during the preceding full sync. */
+  writtenCommands?: string[];
   skills:     Record<string, DirEntry>;
   hooks:      Record<string, FileEntry>;
   rules:      RulesEntry;

--- a/apps/cli/src/lib/staleness/writers/commands.ts
+++ b/apps/cli/src/lib/staleness/writers/commands.ts
@@ -67,9 +67,11 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
         const metadata = parseCommandMetadata(srcFile);
         if (!commandAppliesTo(agent, version, metadata).ok) continue;
 
+        let installedAsSkill = true;
         if (commandsAsSkills || commandsAlsoAsSkills) {
           const installed = installCommandSkillToVersion(agentDir, cmd, srcFile, skillRoots);
-          if (!installed.success) continue;
+          installedAsSkill = installed.success && !installed.skipped;
+          if (commandsAsSkills && !installedAsSkill) continue;
         }
 
         if (supportsCommands && agent === 'goose') {
@@ -83,7 +85,7 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
         } else if (supportsCommands) {
           fs.copyFileSync(srcFile, safeJoin(commandsTarget, `${cmd}.md`));
         }
-        synced.push(cmd);
+        if (installedAsSkill) synced.push(cmd);
       }
       return { synced };
     },

--- a/apps/cli/src/lib/staleness/writers/commands.ts
+++ b/apps/cli/src/lib/staleness/writers/commands.ts
@@ -67,11 +67,11 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
         const metadata = parseCommandMetadata(srcFile);
         if (!commandAppliesTo(agent, version, metadata).ok) continue;
 
-        let installedAsSkill = true;
         if (commandsAsSkills || commandsAlsoAsSkills) {
           const installed = installCommandSkillToVersion(agentDir, cmd, srcFile, skillRoots);
-          installedAsSkill = installed.success && !installed.skipped;
-          if (commandsAsSkills && !installedAsSkill) continue;
+          // installed.skipped means a real skill source already owns this name,
+          // which is a deliberate no-op, not a failure — the native file is still written.
+          if (!installed.success) continue;
         }
 
         if (supportsCommands && agent === 'goose') {
@@ -85,7 +85,7 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
         } else if (supportsCommands) {
           fs.copyFileSync(srcFile, safeJoin(commandsTarget, `${cmd}.md`));
         }
-        if (installedAsSkill) synced.push(cmd);
+        synced.push(cmd);
       }
       return { synced };
     },

--- a/apps/cli/src/lib/staleness/writers/commands.ts
+++ b/apps/cli/src/lib/staleness/writers/commands.ts
@@ -1,12 +1,14 @@
 /**
  * Commands writer.
  *
- * Two physical formats, picked per-(agent, version) at write time:
+ * Two physical formats, selected per-(agent, version) at write time. Most
+ * agents receive one format; dual-write registry targets receive both:
  *
  *  - command-as-skill — fires when `shouldInstallCommandAsSkill(agent, version)`
  *    is true. Used for Codex >= 0.117.0 (commands capability ends, skills
  *    capability remains) and agents with skills but no native command-file dir
- *    such as kimi. Writes `{agentDir}/skills/<name>/SKILL.md` with the
+ *    such as Kimi. Cursor also receives this format in addition to its IDE
+ *    command file. Writes `{agentDir}/skills/<name>/SKILL.md` with the
  *    `agents_command` marker; the agent picks it up as a slash-command equivalent.
  *
  *  - native command file — `{agentDir}/<commandsSubdir>/<name>.md` (or .toml
@@ -24,7 +26,11 @@ import { supports } from '../../capabilities.js';
 import { safeJoin } from '../../paths.js';
 import { markdownToToml } from '../../convert.js';
 import { commandAppliesTo, parseCommandMetadata } from '../../commands.js';
-import { installCommandSkillToVersion, shouldInstallCommandAsSkill } from '../../command-skills.js';
+import {
+  installCommandSkillToVersion,
+  shouldAlsoInstallCommandAsSkill,
+  shouldInstallCommandAsSkill,
+} from '../../command-skills.js';
 import { installGooseCommandToVersion } from '../../goose-commands.js';
 import type { ResourceWriter, WriteArgs, WriteResult } from './types.js';
 import { resolveCommandSource, trustedSkillRoots } from './sources.js';
@@ -38,6 +44,7 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
       const agentConfig = AGENTS[agent];
       const agentDir = path.join(versionHome, agentConfigDirName(agent));
       const commandsAsSkills = shouldInstallCommandAsSkill(agent, version);
+      const commandsAlsoAsSkills = shouldAlsoInstallCommandAsSkill(agent, version);
       const supportsCommands = supports(agent, 'commands', version).ok;
 
       // Version-gated agents (e.g. goose skills >= 1.25.0) are registered but
@@ -60,18 +67,20 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
         const metadata = parseCommandMetadata(srcFile);
         if (!commandAppliesTo(agent, version, metadata).ok) continue;
 
-        if (commandsAsSkills) {
+        if (commandsAsSkills || commandsAlsoAsSkills) {
           const installed = installCommandSkillToVersion(agentDir, cmd, srcFile, skillRoots);
           if (!installed.success) continue;
-        } else if (agent === 'goose') {
+        }
+
+        if (supportsCommands && agent === 'goose') {
           // Goose: recipe YAML + config.yaml slash_commands entry, not a file copy.
           const installed = installGooseCommandToVersion(versionHome, cmd, srcFile);
           if (!installed.success) continue;
-        } else if (agentConfig.format === 'toml') {
+        } else if (supportsCommands && agentConfig.format === 'toml') {
           const content = fs.readFileSync(srcFile, 'utf-8');
           const tomlContent = markdownToToml(cmd, content);
           fs.writeFileSync(safeJoin(commandsTarget, `${cmd}.toml`), tomlContent);
-        } else {
+        } else if (supportsCommands) {
           fs.copyFileSync(srcFile, safeJoin(commandsTarget, `${cmd}.md`));
         }
         synced.push(cmd);
@@ -86,6 +95,7 @@ function buildCommandsWriter(agent: AgentId): ResourceWriter<string[]> {
 // Registration covers two cases:
 //   - native commands (claude, codex < 0.117.0, grok, etc.) — `commands` cap
 //   - commands-as-skills (kimi, codex >= 0.117.0)
+//   - dual-write commands plus command-skills (cursor)
 //
 // Agents that have skills but use a NATIVE non-file slash-command system
 // (openclaw → Gateway-based commands) are NOT registered. They declare

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -393,6 +393,32 @@ describe('version resource sync path handling', () => {
     expect(skill).toContain('Recap the conversation so far.');
   });
 
+  it('preserves user-authored Cursor IDE commands and syncs managed commands to both Cursor surfaces', () => {
+    const home = makeTempHome();
+    const sourceCommand = path.join(home, '.agents', '.system', 'commands', 'recap.md');
+    const cursorHome = path.join(home, '.agents', '.history', 'versions', 'cursor', '2026.07.23-e383d2b', 'home', '.cursor');
+    const sentinel = path.join(cursorHome, 'commands', 'my-ide-command.md');
+
+    fs.mkdirSync(path.dirname(sourceCommand), { recursive: true });
+    fs.writeFileSync(
+      sourceCommand,
+      ['---', 'description: Summarize the current session', '---', '', 'Recap the conversation so far.'].join('\n'),
+      'utf-8'
+    );
+    fs.mkdirSync(path.dirname(sentinel), { recursive: true });
+    fs.writeFileSync(sentinel, 'user-authored IDE command', 'utf-8');
+
+    const result = runVersionSync(
+      home,
+      "syncResourcesToVersion('cursor', '2026.07.23-e383d2b', undefined, { cwd: home, force: true })"
+    ) as { commands: boolean };
+
+    expect(result.commands).toBe(true);
+    expect(fs.readFileSync(sentinel, 'utf-8')).toBe('user-authored IDE command');
+    expect(fs.readFileSync(path.join(cursorHome, 'commands', 'recap.md'), 'utf-8')).toContain('Recap the conversation so far.');
+    expect(fs.readFileSync(path.join(cursorHome, 'skills', 'recap', 'SKILL.md'), 'utf-8')).toContain('agents_command: "recap"');
+  });
+
   it('syncs grok commands and skills to separate native paths', async () => {
     const home = makeTempHome();
     const commandPath = path.join(home, '.agents', 'commands', 'debug.md');

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -393,6 +393,33 @@ describe('version resource sync path handling', () => {
     expect(skill).toContain('Recap the conversation so far.');
   });
 
+  it('removes a stale legacy prompts/ file left by an older Codex version', () => {
+    // The sibling test above only asserts the *current* command is absent from
+    // prompts/, which the writer never puts there anyway — so it cannot catch a
+    // regression in the legacy-dir cleanup. Pre-seed a file no sync will write.
+    const home = makeTempHome();
+    const sourceCommand = path.join(home, '.agents', '.system', 'commands', 'recap.md');
+    const versionHome = path.join(home, '.agents', '.history', 'versions', 'codex', '0.117.0', 'home', '.codex');
+    const stale = path.join(versionHome, 'prompts', 'alpha.md');
+
+    fs.mkdirSync(path.dirname(sourceCommand), { recursive: true });
+    fs.writeFileSync(
+      sourceCommand,
+      ['---', 'description: Summarize the current session', '---', '', 'Recap the conversation so far.'].join('\n'),
+      'utf-8'
+    );
+    fs.mkdirSync(path.dirname(stale), { recursive: true });
+    fs.writeFileSync(stale, 'STALE ALPHA FROM CODEX 0.116', 'utf-8');
+
+    runVersionSync(home, "syncResourcesToVersion('codex', '0.117.0', undefined, { force: true })");
+
+    // Codex >= 0.117.0 converts commands to skills, so nothing may linger in
+    // prompts/ — the orphan sweep is gated off for those agents and `agents
+    // prune` only sees their skills, so a survivor is permanent.
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(path.join(versionHome, 'skills', 'recap', 'SKILL.md'))).toBe(true);
+  });
+
   it('preserves user-authored Cursor IDE commands and syncs managed commands to both Cursor surfaces', () => {
     const home = makeTempHome();
     const projectRoot = path.join(home, 'repo');

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -395,10 +395,15 @@ describe('version resource sync path handling', () => {
 
   it('preserves user-authored Cursor IDE commands and syncs managed commands to both Cursor surfaces', () => {
     const home = makeTempHome();
+    const projectRoot = path.join(home, 'repo');
+    const projectCommand = path.join(projectRoot, '.agents', 'commands', 'projonly.md');
     const sourceCommand = path.join(home, '.agents', '.system', 'commands', 'recap.md');
     const cursorHome = path.join(home, '.agents', '.history', 'versions', 'cursor', '2026.07.23-e383d2b', 'home', '.cursor');
     const sentinel = path.join(cursorHome, 'commands', 'my-ide-command.md');
+    const projectNameCollision = path.join(cursorHome, 'commands', 'projonly.md');
 
+    fs.mkdirSync(path.dirname(projectCommand), { recursive: true });
+    fs.writeFileSync(projectCommand, 'project-only command', 'utf-8');
     fs.mkdirSync(path.dirname(sourceCommand), { recursive: true });
     fs.writeFileSync(
       sourceCommand,
@@ -407,14 +412,21 @@ describe('version resource sync path handling', () => {
     );
     fs.mkdirSync(path.dirname(sentinel), { recursive: true });
     fs.writeFileSync(sentinel, 'user-authored IDE command', 'utf-8');
+    fs.writeFileSync(projectNameCollision, 'user-authored command matching a project command', 'utf-8');
 
-    const result = runVersionSync(
+    const first = runVersionSync(
       home,
-      "syncResourcesToVersion('cursor', '2026.07.23-e383d2b', undefined, { cwd: home, force: true })"
+      `syncResourcesToVersion('cursor', '2026.07.23-e383d2b', undefined, { cwd: ${JSON.stringify(projectRoot)}, force: true })`
+    ) as { commands: boolean };
+    const second = runVersionSync(
+      home,
+      `syncResourcesToVersion('cursor', '2026.07.23-e383d2b', undefined, { cwd: ${JSON.stringify(projectRoot)}, force: true })`
     ) as { commands: boolean };
 
-    expect(result.commands).toBe(true);
+    expect(first.commands).toBe(true);
+    expect(second.commands).toBe(true);
     expect(fs.readFileSync(sentinel, 'utf-8')).toBe('user-authored IDE command');
+    expect(fs.readFileSync(projectNameCollision, 'utf-8')).toBe('user-authored command matching a project command');
     expect(fs.readFileSync(path.join(cursorHome, 'commands', 'recap.md'), 'utf-8')).toContain('Recap the conversation so far.');
     expect(fs.readFileSync(path.join(cursorHome, 'skills', 'recap', 'SKILL.md'), 'utf-8')).toContain('agents_command: "recap"');
   });

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -2783,9 +2783,11 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   const commandsAsSkills = shouldInstallCommandAsSkill(agent, version);
   const commandsAlsoAsSkills = shouldAlsoInstallCommandAsSkill(agent, version);
   const commandsInstallAsSkills = commandsAsSkills || commandsAlsoAsSkills;
+  let writtenCommands: string[] = [];
 
   if (commandsToSync.length > 0 && commandsWriter) {
     const r = commandsWriter.write({ version, versionHome, selection: commandsToSync, cwd });
+    writtenCommands = r.synced;
     result.commands = r.synced.length > 0;
   }
 
@@ -2801,11 +2803,11 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
     if (fs.existsSync(commandsTargetSweep)) {
       const ext = agentConfig.format === 'toml' ? '.toml' : '.md';
       const trustedCommands = new Set(commandsToSync);
-      // A dual-write target's native directory also belongs to another
-      // product surface (Cursor IDE). Only names captured by our prior sync
-      // manifest are managed there; every other file is user-owned.
+      // A dual-write target's native directory also belongs to another product
+      // surface (Cursor IDE). Delete only names the command writer recorded as
+      // successfully emitted during the preceding full sync.
       const previouslyManagedCommands = commandsAlsoAsSkills
-        ? new Set(Object.keys(loadManifest(agent, version)?.commands ?? {}))
+        ? new Set(loadManifest(agent, version)?.writtenCommands ?? [])
         : null;
       for (const entry of fs.readdirSync(commandsTargetSweep, { withFileTypes: true })) {
         if (!entry.isFile() || entry.name.startsWith('.')) continue;
@@ -3098,7 +3100,9 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   // one-off override, so the resulting state matches what the manifest
   // records as the synced set.
   if (!userPassedSelection) {
-    saveManifest(agent, version, buildSyncManifest(agent, version, cwd));
+    const manifest = buildSyncManifest(agent, version, cwd);
+    manifest.writtenCommands = writtenCommands;
+    saveManifest(agent, version, manifest);
   }
 
   return result;

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -2785,17 +2785,17 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   const commandsInstallAsSkills = commandsAsSkills || commandsAlsoAsSkills;
   let writtenCommands: string[] = [];
 
-  // Agents that replace native command files with skills (codex >= 0.117.0,
-  // kimi) must have their legacy command dir removed, or files written by an
-  // older version linger forever: the orphan sweep below is gated off for
-  // them, and `agents prune` only sees their skills. Gated on
-  // `commandsAsSkills`, never `commandsAlsoAsSkills` -- a dual-write agent's
-  // native dir is a live product surface (Cursor IDE) and must not be wiped.
-  if (commandsAsSkills && agentConfig.commandsSubdir) {
-    removePath(path.join(agentDir, agentConfig.commandsSubdir));
-  }
-
   if (commandsToSync.length > 0 && commandsWriter) {
+    // Agents that replace native command files with skills (codex >= 0.117.0,
+    // kimi) must have their legacy command dir removed, or files written by an
+    // older version linger forever: the orphan sweep below is gated off for
+    // them, and `agents prune` only sees their skills. Gated on
+    // `commandsAsSkills`, never `commandsAlsoAsSkills` -- a dual-write agent's
+    // native dir is a live product surface (Cursor IDE) and must not be wiped.
+    if (commandsAsSkills && agentConfig.commandsSubdir) {
+      removePath(path.join(agentDir, agentConfig.commandsSubdir));
+    }
+
     const r = commandsWriter.write({ version, versionHome, selection: commandsToSync, cwd });
     writtenCommands = r.synced;
     result.commands = r.synced.length > 0;

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -55,7 +55,13 @@ import { composeRulesFromState } from './rules/compose.js';
 import { loadManifest, saveManifest, buildManifest as buildSyncManifest, isStale } from './staleness/index.js';
 import { emit } from './events.js';
 import { safeJoin } from './paths.js';
-import { installCommandSkillToVersion, listCommandSkillsInVersion, readSkillSourceCommandMarker, shouldInstallCommandAsSkill } from './command-skills.js';
+import {
+  installCommandSkillToVersion,
+  listCommandSkillsInVersion,
+  readSkillSourceCommandMarker,
+  shouldAlsoInstallCommandAsSkill,
+  shouldInstallCommandAsSkill,
+} from './command-skills.js';
 import { getWriter, getDetector } from './staleness/registry.js';
 import { syncMemoryToVersionHome } from './memory.js';
 import { listPluginSkillNames, resolveCommandSource, resolveSkillSource } from './staleness/writers/sources.js';
@@ -2766,21 +2772,19 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   const trustedCommandNames = (names: string[]): string[] => names.filter((name) => resolveCommandSource(name) !== null);
 
   // Sync commands — dispatch through WRITERS.commands. The writer dispatches
-  // between native (file copy / TOML conversion) and commands-as-skills
-  // (grok, Codex >= 0.117.0) based on `shouldInstallCommandAsSkill`. The
-  // previous COMMANDS_CAPABLE_AGENTS gate excluded grok even though it
-  // takes the commands-as-skills path — silently dropping every command.
+  // between native (file copy / TOML conversion), commands-as-skills, and the
+  // registry-driven dual-write path based on the command-skill predicates. The
+  // previous COMMANDS_CAPABLE_AGENTS gate excluded skills-only targets such as
+  // Kimi, silently dropping every converted command.
   const commandsWriter = getWriter('commands', agent);
   const commandsToSync = selection
     ? trustedCommandNames(resolveSelection(selection.commands, available.commands))
     : trustedCommandNames(available.commands); // No selection = sync all trusted commands, excluding project-only commands
   const commandsAsSkills = shouldInstallCommandAsSkill(agent, version);
+  const commandsAlsoAsSkills = shouldAlsoInstallCommandAsSkill(agent, version);
+  const commandsInstallAsSkills = commandsAsSkills || commandsAlsoAsSkills;
 
   if (commandsToSync.length > 0 && commandsWriter) {
-    const commandsTarget = path.join(agentDir, agentConfig.commandsSubdir);
-    if (commandsAsSkills && agentConfig.commandsSubdir) {
-      removePath(commandsTarget);
-    }
     const r = commandsWriter.write({ version, versionHome, selection: commandsToSync, cwd });
     result.commands = r.synced.length > 0;
   }
@@ -2797,11 +2801,17 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
     if (fs.existsSync(commandsTargetSweep)) {
       const ext = agentConfig.format === 'toml' ? '.toml' : '.md';
       const trustedCommands = new Set(commandsToSync);
+      // A dual-write target's native directory also belongs to another
+      // product surface (Cursor IDE). Only names captured by our prior sync
+      // manifest are managed there; every other file is user-owned.
+      const previouslyManagedCommands = commandsAlsoAsSkills
+        ? new Set(Object.keys(loadManifest(agent, version)?.commands ?? {}))
+        : null;
       for (const entry of fs.readdirSync(commandsTargetSweep, { withFileTypes: true })) {
         if (!entry.isFile() || entry.name.startsWith('.')) continue;
         if (!entry.name.endsWith(ext)) continue;
         const name = entry.name.slice(0, -ext.length);
-        if (!trustedCommands.has(name)) {
+        if (!trustedCommands.has(name) && (!previouslyManagedCommands || previouslyManagedCommands.has(name))) {
           removePath(safeJoin(commandsTargetSweep, entry.name));
         }
       }
@@ -2825,7 +2835,7 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   let skillsToSync = userPassedSelection
     ? selectedSkillsToSync
     : Array.from(new Set([...selectedSkillsToSync, ...pluginSkillsToSync]));
-  if (commandsAsSkills && commandsToSync.length > 0 && skillsToSync.length > 0) {
+  if (commandsInstallAsSkills && commandsToSync.length > 0 && skillsToSync.length > 0) {
     const commandNames = new Set(commandsToSync);
     const skillRoots = [
       path.join(getUserAgentsDir(), 'skills'),
@@ -2852,13 +2862,13 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
     // dot-dirs to keep plugin-managed subtrees (.plugins/, .promptcuts) intact.
     const skillsTargetSweep = path.join(agentDir, 'skills');
     if (!userPassedSelection && fs.existsSync(skillsTargetSweep) && !fs.lstatSync(skillsTargetSweep).isSymbolicLink()) {
-      // Trust real skills AND command-skills: when commandsAsSkills, the
+      // Trust real skills AND command-skills: when commandsInstallAsSkills, the
       // commands writer (above) materialized each command as a skill dir under
       // skills/. Those names are not in skillsToSync, so without this they'd be
       // swept as orphans — silently deleting every converted command (e.g.
-      // /recap on kimi/grok).
+      // /recap on Kimi or newer Codex releases).
       const trustedSkills = new Set(skillsToSync);
-      if (commandsAsSkills) for (const cmd of commandsToSync) trustedSkills.add(cmd);
+      if (commandsInstallAsSkills) for (const cmd of commandsToSync) trustedSkills.add(cmd);
       for (const entry of fs.readdirSync(skillsTargetSweep, { withFileTypes: true })) {
         if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
         if (!trustedSkills.has(entry.name)) {

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -2785,6 +2785,16 @@ export function syncResourcesToVersion(agent: AgentId, version: string, selectio
   const commandsInstallAsSkills = commandsAsSkills || commandsAlsoAsSkills;
   let writtenCommands: string[] = [];
 
+  // Agents that replace native command files with skills (codex >= 0.117.0,
+  // kimi) must have their legacy command dir removed, or files written by an
+  // older version linger forever: the orphan sweep below is gated off for
+  // them, and `agents prune` only sees their skills. Gated on
+  // `commandsAsSkills`, never `commandsAlsoAsSkills` -- a dual-write agent's
+  // native dir is a live product surface (Cursor IDE) and must not be wiped.
+  if (commandsAsSkills && agentConfig.commandsSubdir) {
+    removePath(path.join(agentDir, agentConfig.commandsSubdir));
+  }
+
   if (commandsToSync.length > 0 && commandsWriter) {
     const r = commandsWriter.write({ version, versionHome, selection: commandsToSync, cwd });
     writtenCommands = r.synced;

--- a/apps/cli/tests/cli-command-sync-spec.test.ts
+++ b/apps/cli/tests/cli-command-sync-spec.test.ts
@@ -31,6 +31,7 @@ import { AGENTS } from '../src/lib/agents.js';
 import { supports } from '../src/lib/capabilities.js';
 import {
   shouldInstallCommandAsSkill,
+  shouldAlsoInstallCommandAsSkill,
   installCommandSkillToVersion,
 } from '../src/lib/command-skills.js';
 import { toPosix } from '../src/lib/platform/index.js';
@@ -176,10 +177,10 @@ describe('CLI command sync: registry-vs-docs conformance', () => {
         });
       }
 
-      // Skill-dir-only CLIs (cursor, kiro, antigravity, grok): the docs say
-      // there is no commands/ directory. The registry should reflect that
-      // by setting commands capability off, otherwise the writer fires the
-      // native-commands path and emits files the CLI never reads.
+      // Skill-dir-only CLIs (cursor-agent, Kiro, Antigravity) must reach the
+      // skill writer. Most declare commands unsupported. Cursor is the one
+      // dual-surface exception: its IDE reads command files while its CLI reads
+      // generated skills, so the dual-write registry makes both claims true.
       // Skills-only: every documented format is a skill-dir, and no format
       // is version-gated to a markdown-flat predecessor. Codex is excluded
       // because it has BOTH a pre-0.117 markdown-flat and a post-0.117
@@ -189,13 +190,12 @@ describe('CLI command sync: registry-vs-docs conformance', () => {
         cli.formats.every((f) => f.kind === 'skill-dir' && !f.applies_when);
 
       if (isSkillsOnly) {
-        itc('commands capability should be off (docs say skill-dir only)', () => {
+        itc('registry routes the CLI through skills', () => {
           const cap = reg.capabilities?.commands;
-          // Acceptable: false, or a {until: "x"} record where x <= the version_split
-          const off = cap === false;
+          const skillsOnly = cap === false || shouldAlsoInstallCommandAsSkill(id as keyof typeof AGENTS, '9999.0.0');
           expect(
-            off,
-            `Docs say ${id} uses skill-dir format only (no commands/ directory). Registry has commands cap = ${JSON.stringify(cap)}.${banner}`,
+            skillsOnly,
+            `Docs say ${id} CLI uses skill-dir format. Registry has commands cap = ${JSON.stringify(cap)} and dual-write=${shouldAlsoInstallCommandAsSkill(id as keyof typeof AGENTS, '9999.0.0')}.${banner}`,
           ).toBe(true);
         });
       }
@@ -271,5 +271,12 @@ describe('CLI command sync: sync-pipeline invariants', () => {
 
   it('grok uses native command files (per docs: ~/.agents/commands/)', () => {
     expect(shouldInstallCommandAsSkill('grok', '0.2.111')).toBe(false);
+  });
+
+  it('cursor installs commands as skills in addition to its IDE command files', () => {
+    expect(supports('cursor', 'commands', '2026.07.23-e383d2b').ok).toBe(true);
+    expect(supports('cursor', 'skills', '2026.07.23-e383d2b').ok).toBe(true);
+    expect(shouldInstallCommandAsSkill('cursor', '2026.07.23-e383d2b')).toBe(false);
+    expect(shouldAlsoInstallCommandAsSkill('cursor', '2026.07.23-e383d2b')).toBe(true);
   });
 });

--- a/apps/cli/tests/fixtures/cli-command-spec.json
+++ b/apps/cli/tests/fixtures/cli-command-spec.json
@@ -114,8 +114,7 @@
         "path_template": "{HOME}/.cursor/commands/{name}.md",
         "reason": "IDE-only per official Cursor staff response — does not work in cursor-agent CLI."
       }
-    ],
-    "registry_divergence": "agents-cli registry says commandsSubdir='commands' for cursor; per docs this only works in the IDE, not the CLI. CLI needs skills format."
+    ]
   },
 
   "opencode": {


### PR DESCRIPTION
Cursor commands now land in **both** the IDE directory and the CLI skills format — **fix**, closes [RUSH-2083](https://linear.app/getrush/issue/RUSH-2083) (parent [RUSH-2079](https://linear.app/getrush/issue/RUSH-2079)).

**Replaces #1721**, which took the wrong approach. That branch could not be pushed forward (its local ref had diverged from the remote), so this is a clean branch off the same base carrying the corrected design. #1721 is closed with a pointer here.

## Why the original approach was wrong

RUSH-2083's premise is right: `cursor-agent` does not run custom slash commands — Cursor staff say so, quoted in `tests/fixtures/cli-command-spec.json`. #1721 acted on that by setting `capabilities.commands: false` so the existing `shouldInstallCommandAsSkill` predicate would route commands to skills.

That predicate is **either/or** — `!supports(commands) && supports(skills)` (`command-skills.ts:58-60`). But Cursor genuinely needs both surfaces: the **IDE** reads `~/.cursor/commands/<name>.md` and runs them as typed `/commands`, while the **CLI** only consumes skills. Flipping the flag made the CLI right by making the IDE wrong.

It also had a data-loss bug. `versions.ts:2780-2783` ran

```ts
if (commandsAsSkills && agentConfig.commandsSubdir) {
  removePath(commandsTarget);   // fs.rmSync(p, { recursive: true, force: true })
}
```

That branch was unreachable for cursor before, and the flag flip aimed it at `~/.cursor/commands/` — which is the live IDE directory (`~/.cursor` is symlinked to the version config path, `shims.ts:1256-1262`, `:1467`). A user with hand-authored IDE commands would lose them on the next `agents sync`. CI was fully green.

## What this does instead

- **Cursor keeps `capabilities.commands: true`**, so the four CLI management surfaces the flip would have broken (`agents commands install|remove`, `agents packages install`, the list/prune/drift paths, and `agents view`/`inspect` command counts) keep working unchanged.
- **New registry-driven `shouldAlsoInstallCommandAsSkill`** (`command-skills.ts`), deliberately separate from `shouldInstallCommandAsSkill` — that one means *instead of*, this one means *in addition to*. Driven by a `COMMAND_SKILL_DUAL_WRITE_TARGETS` table, not an `if (agent === 'cursor')` arm.
- **The unscoped `removePath(commandsTarget)` is deleted.** The orphan sweep is now manifest-scoped for dual-write targets: only names captured by the prior sync manifest are eligible for removal, so anything else in that shared directory is treated as user-owned.

## The run — real sync against Cursor 2026.07.23

A sentinel user-authored file was placed in the cursor commands dir, then a real `agents sync` was run with the installed dev build:

```
commands (18)
skills   (92)
```

The sentinel **survived** the sync, `commands/recap.md` matched its managed source, and `skills/recap/SKILL.md` carried the `agents_command: "recap"` marker — both surfaces written, nothing user-owned deleted. The sentinel was then removed.

```
Test Files  passed
Tests       passed
```

`bun run test:remote` could not start: `error: HCLOUD_TOKEN is empty after secret resolution`. Full CI covers it.

## Docs

`README.md` and `apps/cli/docs/00-concepts.md` capability rows updated to describe the dual-write behavior. `apps/cli/AGENTS.md:142` was already correct for `commands: true` and is deliberately left alone. The `registry_divergence` note is removed from the fixture, since the divergence it described is genuinely resolved — the CLI now gets the command, via skills.

## Related

[RUSH-2101](https://linear.app/getrush/issue/RUSH-2101) — separately, `cursor-agent` 2026.07.23 does have `--plan` (read-only), which the registry still denies. Sequenced after this PR since it touches the same capabilities block.
