### PR TITLE
feat(webhooks): handler layer with state filters, prompt vars, audit events, and run.env

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -58,6 +58,21 @@
 
 ## 1.20.85
 
+- **Webhook handler layer for one-off agent/workflow/command/routine triggers.**
+  Routines still fire from signed webhooks, but a new `~/.agents/webhooks/*.yml`
+  layer can also run one-off actions: `run.agent`, `run.workflow`, `run.command`,
+  or delegate to an existing `routine`. Handlers support the same source/event/
+  action/label/repo/branch filters as routine triggers, plus Linear
+  `stateTo`/`stateFrom` state-change filters. Prompts and commands can use
+  `{{issue.identifier}}`, `{{updatedFrom.state.name}}`, etc. The receiver emits
+  `webhook.received`, `webhook.authorized`, `webhook.rejected`, `webhook.matched`,
+  `webhook.fired`, `webhook.handler.start`, and `webhook.handler.end` events.
+  Source: `apps/cli/src/lib/triggers/handlers.ts`,
+  `apps/cli/src/lib/triggers/webhook.ts`, `apps/cli/src/lib/routines.ts`,
+  `apps/cli/src/commands/routines.ts`, `apps/cli/docs/03-routines.md`.
+
+- **`agents routines add` gains `--state-to` and `--state-from` filters for Linear triggers`.**
+
 - **`agents feed post` can now be mirrored to the systems you actually watch.**
   A post was durable but local: an operator away from every terminal never saw
   it, and the tracker that owns the work heard nothing. Declare sinks under

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.20.86
 
+- **Webhook handlers can now inject environment variables via `run.env`.**
+  One-off handler runs are sandboxed with an overlay `HOME`, which hides tools
+  like the `linear` CLI that resolve credentials from the real user home. A
+  handler can now declare `run.env.HOME: /home/muqsit` (or any other variable)
+  and it is applied on top of the sandbox env. Source:
+  `apps/cli/src/lib/triggers/handlers.ts`, `apps/cli/src/lib/routines.ts`,
+  `apps/cli/src/lib/runner.ts`.
+
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped
   `{title, status}`, where finished is `done`) rather than Claude's `TodoWrite`

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## 1.20.86
 
-- **Webhook handlers can now inject environment variables via `run.env`.**
+- **Webhook handlers can now inject environment variables via `run.env` and
+  place execution on another host via `host`.**
   One-off handler runs are sandboxed with an overlay `HOME`, which hides tools
   like the `linear` CLI that resolve credentials from the real user home. A
   handler can now declare `run.env.HOME: /home/muqsit` (or any other variable)
-  and it is applied on top of the sandbox env. Source:
+  and it is applied on top of the sandbox env. `host` accepts a specific device
+  name (`yosemite-s0`), `fleet` for any online worker, or `fleet/<platform>`
+  / `<platform>/fleet` (e.g. `fleet/linux`) for any online worker on that OS.
+  Agent version selection is automatic; handlers use the same strategy as
+  `agents run` to pick a healthy installed version. Source:
   `apps/cli/src/lib/triggers/handlers.ts`, `apps/cli/src/lib/routines.ts`,
-  `apps/cli/src/lib/runner.ts`.
+  `apps/cli/src/lib/runner.ts`, `apps/cli/src/lib/routines-placement.ts`.
 
 - **`agents sessions` now shows a Kimi session's todo list and its file-touching
   tool calls.** Kimi writes its checklist with `TodoList` (items shaped

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -228,6 +228,99 @@ agents funnel status yosemite-s0
 Funnel public ports are limited to `443`, `8443`, and `10000`; `agents funnel up`
 validates that before running the remote Tailscale CLI.
 
+### Webhook handlers
+
+In addition to routine triggers, you can define one-off **webhook handlers** in
+`~/.agents/webhooks/*.yml`. A handler matches incoming webhooks the same way a
+routine trigger does, but instead of scheduling a recurring job it runs an
+agent, workflow, shell command, or an existing routine once.
+
+```yaml
+# ~/.agents/webhooks/linear-status-planner.yml
+name: linear-status-planner
+source: linear
+event: Issue
+action: update
+stateTo: Plan
+devices:
+  - mac-mini
+run:
+  agent: claude
+  prompt: |
+    Issue {{issue.identifier}} moved from {{updatedFrom.state.name}} to {{issue.state.name}}.
+    Create a concise implementation plan and post it as a Linear comment.
+```
+
+#### Handler YAML format
+
+| Field | Description |
+| --- | --- |
+| `name` | Unique handler name. |
+| `enabled` | Set to `false` to disable without deleting the file. |
+| `devices` | Same fleet allowlist as routines — only matching devices run the handler. |
+| `source` | `github` or `linear`. |
+| `event` | Source event name (e.g. `Issue`, `pull_request`). |
+| `action` | Webhook action (e.g. `update`, `opened`, `labeled`). |
+| `run` | One-of `agent`, `workflow`, or `command`, plus an optional `prompt`. |
+| `routine` | Name of a routine to delegate to instead of `run`. |
+
+#### Filters
+
+Handlers support the same filters as routine triggers:
+
+- `source`, `event`, `action` — always available.
+- Linear: `teamKey`, `label`, `stateTo`, `stateFrom`.
+- GitHub: `repo`, `branch`, `label`.
+
+`stateTo` matches the current Linear state name (`payload.data.state.name`);
+`stateFrom` matches the previous state (`payload.updatedFrom.state.name`).
+
+#### Actions
+
+- `run.agent` — run the agent headlessly with the substituted prompt.
+- `run.workflow` — run `agents run <workflow>` with the prompt.
+- `run.command` — run a shell command directly (the command string is also
+  variable-substituted).
+- `routine` — load the named routine, substitute its prompt, and run it
+  detached. The handler's `devices` pin overrides the routine's for this fire.
+
+#### Prompt variables
+
+Use `{{dotted.path}}` placeholders in `run.prompt` (and in the delegated
+routine's prompt). For Linear webhooks the context is:
+
+```ts
+{
+  source: 'linear',
+  event: 'Issue',
+  action: 'update',
+  issue: payload.data,
+  updatedFrom: payload.updatedFrom,
+}
+```
+
+Examples: `{{issue.identifier}}`, `{{issue.state.name}}`,
+`{{updatedFrom.state.name}}`, `{{issue.title}}`, `{{issue.description}}`.
+
+For GitHub webhooks the context includes `repository`, `pull_request`, and
+`issue`.
+
+#### mac-mini ingress with funnel
+
+Handlers are fired by the same `agents webhook serve` receiver as routine
+triggers. On a headless Mac (e.g. `mac-mini`), expose it publicly with
+Tailscale Funnel:
+
+```bash
+# On mac-mini
+agents webhook serve --secrets-bundle webhooks --port 8787 &
+agents funnel up mac-mini --local-port 8787 --port 443
+```
+
+Then point Linear/GitHub at `https://mac-mini.<tailnet>.ts.net/hooks/<source>`.
+The handler's `devices: [mac-mini]` pin ensures only that machine dispatches the
+one-off agent run.
+
 ### Device Allowlist
 
 `~/.agents/routines/` rides the user repo, so every routine syncs to every machine —

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -261,7 +261,7 @@ run:
 | `source` | `github` or `linear`. |
 | `event` | Source event name (e.g. `Issue`, `pull_request`). |
 | `action` | Webhook action (e.g. `update`, `opened`, `labeled`). |
-| `run` | One-of `agent`, `workflow`, or `command`, plus an optional `prompt`. |
+| `run` | One-of `agent`, `workflow`, or `command`, plus optional `prompt` and `env`. |
 | `routine` | Name of a routine to delegate to instead of `run`. |
 
 #### Filters
@@ -283,6 +283,11 @@ Handlers support the same filters as routine triggers:
   variable-substituted).
 - `routine` — load the named routine, substitute its prompt, and run it
   detached. The handler's `devices` pin overrides the routine's for this fire.
+
+`run.env` is an optional map of environment variables injected into the spawned
+process. Use it to point tools at the real user home without breaking sandbox
+isolation, for example `HOME: /home/muqsit` so a child `linear` CLI finds
+`~/.linear-cli/config.json`.
 
 #### Prompt variables
 

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -243,7 +243,8 @@ event: Issue
 action: update
 stateTo: Plan
 devices:
-  - mac-mini
+  - yosemite-s0
+host: fleet/linux
 run:
   agent: claude
   prompt: |
@@ -257,7 +258,8 @@ run:
 | --- | --- |
 | `name` | Unique handler name. |
 | `enabled` | Set to `false` to disable without deleting the file. |
-| `devices` | Same fleet allowlist as routines — only matching devices run the handler. |
+| `devices` | Same fleet allowlist as routines — only matching devices receive and fire the handler. |
+| `host` | Where the handler body executes. A specific device name, `fleet` (any online worker), or `fleet/<platform>` / `<platform>/fleet` (e.g. `fleet/linux`, `linux/fleet`). Omitted means run on the receiving device. |
 | `source` | `github` or `linear`. |
 | `event` | Source event name (e.g. `Issue`, `pull_request`). |
 | `action` | Webhook action (e.g. `update`, `opened`, `labeled`). |
@@ -288,6 +290,17 @@ Handlers support the same filters as routine triggers:
 process. Use it to point tools at the real user home without breaking sandbox
 isolation, for example `HOME: /home/muqsit` so a child `linear` CLI finds
 `~/.linear-cli/config.json`.
+
+#### Devices vs host
+
+`devices` says which daemon may **receive and fire** the handler. `host` says
+where the handler body **executes** once fired. In the example above only
+`yosemite-s0` receives the webhook, but it then runs the agent on any online
+Linux worker (`fleet/linux`). Omit `host` to execute on the receiving device.
+
+Agent version selection is automatic: handlers use the same strategy as
+`agents run` (default `balanced`) to pick a healthy installed version of the
+requested agent. You do not need to pin a version number.
 
 #### Prompt variables
 

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -114,6 +114,8 @@ function fireConditionLabel(job: JobConfig): string {
       job.trigger.action ? `action=${job.trigger.action}` : null,
       job.trigger.teamKey ? `team=${job.trigger.teamKey}` : null,
       job.trigger.label ? `label=${job.trigger.label}` : null,
+      job.trigger.stateTo ? `stateTo=${job.trigger.stateTo}` : null,
+      job.trigger.stateFrom ? `stateFrom=${job.trigger.stateFrom}` : null,
     ].filter(Boolean).join(', ');
     return `on linear:${job.trigger.event}${filters ? ` (${filters})` : ''}`;
   }
@@ -322,6 +324,8 @@ function parseRoutineTrigger(options: Record<string, unknown>): JobTrigger | und
     if (typeof options.action === 'string') trigger.action = options.action;
     if (typeof options.teamKey === 'string') trigger.teamKey = options.teamKey;
     if (typeof options.label === 'string') trigger.label = options.label;
+    if (typeof options.stateTo === 'string') trigger.stateTo = options.stateTo;
+    if (typeof options.stateFrom === 'string') trigger.stateFrom = options.stateFrom;
     return trigger;
   }
   throw new Error('--on source must be github or linear');
@@ -679,6 +683,8 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--action <name>', 'Webhook action filter for --on triggers (GitHub: labeled/opened; Linear: update)')
     .option('--team-key <key>', 'Linear team key filter for --on linear:<event> (e.g. RUSH)')
     .option('--label <name>', 'Label filter for --on triggers (GitHub label name or Linear issue label)')
+    .option('--state-to <name>', 'Linear current-state filter for --on linear:<event> (e.g. Plan)')
+    .option('--state-from <name>', 'Linear previous-state filter for --on linear:<event> (e.g. Triage)')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
     .option('--resume <sessionId>', 'At fire time, resume this existing session id (via `agents run <agent> --resume`) instead of starting fresh — the actual session reopens with full context and the prompt becomes its next turn. Powers self-scheduled wake-ups (e.g. /hibernate). Requires --agent claude or codex; runs un-sandboxed (the session store lives in the real home, not the job overlay).')
@@ -1004,10 +1010,23 @@ export function registerRoutinesCommands(program: Command): void {
   routinesCmd
     .command('edit [name]')
     .description('Open a routine in $EDITOR. Creates a new YAML template if the routine does not exist.')
-    .action(async (name: string | undefined) => {
+    .option('--state-to <name>', 'Update the Linear current-state filter before opening the editor')
+    .option('--state-from <name>', 'Update the Linear previous-state filter before opening the editor')
+    .action(async (name: string | undefined, options: { stateTo?: string; stateFrom?: string }) => {
       if (!name) {
         name = await pickJob('Select job to edit', undefined, ['agents routines edit <name>']) ?? undefined;
         if (!name) return;
+      }
+
+      const existing = readJob(name);
+      if (existing && (options.stateTo !== undefined || options.stateFrom !== undefined)) {
+        if (!existing.trigger || existing.trigger.type !== 'linear_event') {
+          console.error(chalk.red(`'${name}' does not have a Linear trigger; --state-to/--state-from only apply to linear triggers`));
+          process.exit(1);
+        }
+        if (options.stateTo !== undefined) existing.trigger.stateTo = options.stateTo || undefined;
+        if (options.stateFrom !== undefined) existing.trigger.stateFrom = options.stateFrom || undefined;
+        writeJob(existing);
       }
 
       const jobPath = getJobPath(name);

--- a/apps/cli/src/commands/webhook.ts
+++ b/apps/cli/src/commands/webhook.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import { readAndResolveBundleEnv, isHeadlessSecretsContext } from '../lib/secrets/bundles.js';
 import { createFileDeliveryStore, startWebhookServer, type WebhookSecrets } from '../lib/triggers/webhook.js';
+import type { FiredHandler } from '../lib/triggers/handlers.js';
 import { getRuntimeStateDir } from '../lib/state.js';
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -94,10 +95,13 @@ export function registerWebhookCommand(program: Command): void {
           deliveryStore: createFileDeliveryStore(
             path.join(getRuntimeStateDir(), 'webhook', 'deliveries.json'),
           ),
-          onDelivery: (webhook, fired) => {
+          onDelivery: (webhook, fired, handlers) => {
+            const parts: string[] = [];
+            if (fired.length) parts.push(`routines ${fired.map((f) => f.jobName).join(', ')}`);
+            if (handlers.length) parts.push(`handlers ${handlers.map((h) => h.handlerName).join(', ')}`);
             console.log(
               `${new Date().toISOString()} ${webhook.source}:${webhook.event} ` +
-              `${fired.length ? `fired ${fired.map((f) => f.jobName).join(', ')}` : 'no match'}`,
+              (parts.length ? `fired ${parts.join('; ')}` : 'no match'),
             );
           },
         });

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -121,6 +121,14 @@ export type EventType =
   // Sessions
   | 'session.start'
   | 'session.end'
+  // Webhooks
+  | 'webhook.received'
+  | 'webhook.authorized'
+  | 'webhook.rejected'
+  | 'webhook.matched'
+  | 'webhook.fired'
+  | 'webhook.handler.start'
+  | 'webhook.handler.end'
   // Agent activity (emitted at hook time; see lib/activity.ts). These share the
   // one event vocabulary so operational and agent-semantic events read as a
   // single stream via lib/event-stream.ts.

--- a/apps/cli/src/lib/routines-placement.ts
+++ b/apps/cli/src/lib/routines-placement.ts
@@ -13,7 +13,7 @@
 import type { JobConfig, HostStrategy } from './routines.js';
 import { resolveHostStrategy } from './routines.js';
 import { machineId, normalizeHost } from './machine-id.js';
-import { loadDevicesSync } from './devices/registry.js';
+import { loadDevicesSync, type DevicePlatform } from './devices/registry.js';
 import { planFleetTargets } from './devices/fleet.js';
 
 export type PlacementTarget =
@@ -33,7 +33,10 @@ export type PlacementTarget =
  * the double-fire pin (`devices: [self]`) would collapse fleet placement to
  * always-local. Control / offline / no-address devices are never chosen.
  */
-export function pickFleetDevice(_config?: Pick<JobConfig, 'devices'>): string | null {
+export function pickFleetDevice(
+  _config?: Pick<JobConfig, 'devices'>,
+  platform?: DevicePlatform,
+): string | null {
   let reg: ReturnType<typeof loadDevicesSync>;
   try {
     reg = loadDevicesSync();
@@ -41,11 +44,16 @@ export function pickFleetDevice(_config?: Pick<JobConfig, 'devices'>): string | 
     return null;
   }
   const planned = planFleetTargets(reg);
-  const candidates = planned.filter((t) => !t.skip).map((t) => t.device.name);
+  const candidates = planned
+    .filter((t) => !t.skip && (!platform || t.device.platform === platform))
+    .map((t) => t.device.name);
   if (candidates.length === 0) {
     // No registry / nothing online: fall back to self so a single-box fleet
-    // without a registry entry still runs locally.
-    return machineId();
+    // without a registry entry still runs locally. Only do this when no platform
+    // filter was requested or when we don't know our own platform (no registry
+    // means we can't verify it); otherwise an unmet platform filter should fail
+    // loud so e.g. `fleet/linux` never silently lands on a macOS box.
+    return platform ? null : machineId();
   }
   const self = machineId();
   const selfMatch = candidates.find((n) => normalizeHost(n) === self);

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -127,6 +127,21 @@ describe('validateTrigger', () => {
     expect(validateTrigger({ type: 'linear_event', event: 'Issue', action: 'update', teamKey: 'RUSH', label: 'agent' })).toEqual([]);
   });
 
+  it('accepts stateTo and stateFrom on linear_event triggers', () => {
+    expect(validateTrigger({
+      type: 'linear_event',
+      event: 'Issue',
+      action: 'update',
+      stateTo: 'Plan',
+      stateFrom: 'Triage',
+    })).toEqual([]);
+  });
+
+  it('rejects non-string stateTo/stateFrom on linear_event triggers', () => {
+    expect(validateTrigger({ type: 'linear_event', event: 'Issue', stateTo: 123 as never })).toContain('trigger.stateTo must be a string');
+    expect(validateTrigger({ type: 'linear_event', event: 'Issue', stateFrom: 123 as never })).toContain('trigger.stateFrom must be a string');
+  });
+
   it('rejects a bad type', () => {
     expect(validateTrigger({ type: 'gitlab', event: 'pull_request' })).toContain("trigger.type must be 'github_event' or 'linear_event'");
   });
@@ -661,5 +676,27 @@ describe('getLatestCompletedRun / {last_report} poison-stop', () => {
     expect(resolved).toContain('GOOD REPORT');
     expect(resolved).not.toContain('Not logged in');
     expect(resolved).not.toContain('/login');
+  });
+
+  it('substitutes {{...}} webhook context placeholders when context is passed', () => {
+    const config = {
+      name: jobName,
+      agent: 'claude',
+      schedule: '0 3 * * *',
+      prompt: 'Issue {{issue.identifier}}: {{issue.title}} (from {{updatedFrom.state.name}})',
+      mode: 'auto',
+      effort: 'auto',
+      timeout: '10m',
+      enabled: true,
+    } as JobConfig;
+
+    const resolved = resolveJobPrompt(config, {
+      source: 'linear',
+      event: 'Issue',
+      action: 'update',
+      issue: { identifier: 'RUSH-42', title: 'Fix it', state: { name: 'Plan' } },
+      updatedFrom: { state: { name: 'Triage' } },
+    });
+    expect(resolved).toBe('Issue RUSH-42: Fix it (from Triage)');
   });
 });

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -125,6 +125,10 @@ export interface LinearJobTrigger {
   teamKey?: string;
   /** Required issue label name. */
   label?: string;
+  /** Current Linear state name that must match (e.g. `Plan`). */
+  stateTo?: string;
+  /** Previous Linear state name that must match (e.g. `Triage`). */
+  stateFrom?: string;
 }
 
 export type JobTrigger = GithubJobTrigger | LinearJobTrigger;
@@ -828,6 +832,12 @@ export function validateTrigger(trigger: unknown): string[] {
   if (linear.label !== undefined && typeof linear.label !== 'string') {
     errors.push('trigger.label must be a string');
   }
+  if (linear.stateTo !== undefined && typeof linear.stateTo !== 'string') {
+    errors.push('trigger.stateTo must be a string');
+  }
+  if (linear.stateFrom !== undefined && typeof linear.stateFrom !== 'string') {
+    errors.push('trigger.stateFrom must be a string');
+  }
   return errors;
 }
 
@@ -982,8 +992,44 @@ export function shouldPurgeCompletedOneShotRoutine(
   return hasCompletedOneShotRun(config, now);
 }
 
+/**
+ * Context passed to `resolveJobPrompt` when a job is fired by a webhook. Lets
+ * prompts use `{{issue.identifier}}`, `{{updatedFrom.state.name}}`, etc.
+ */
+export interface WebhookContext {
+  source: string;
+  event: string;
+  action?: string;
+  issue?: unknown;
+  updatedFrom?: unknown;
+  pull_request?: unknown;
+  repository?: unknown;
+}
+
+function getPath(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+/**
+ * Substitute `{{dotted.path}}` placeholders in a string using a webhook context.
+ * Missing values are replaced with an empty string.
+ */
+export function substituteWebhookPrompt(prompt: string, context: WebhookContext): string {
+  return prompt.replace(/\{\{([^{}]+)\}\}/g, (_, rawPath: string) => {
+    const value = getPath(context, rawPath.trim());
+    if (value === undefined || value === null) return '';
+    return String(value);
+  });
+}
+
 /** Expand built-in and user-defined template variables in a job's prompt string. */
-export function resolveJobPrompt(config: JobConfig): string {
+export function resolveJobPrompt(config: JobConfig, context?: WebhookContext): string {
   const now = new Date();
   const tz = config.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
   const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -1008,6 +1054,11 @@ export function resolveJobPrompt(config: JobConfig): string {
     for (const [key, value] of Object.entries(config.variables)) {
       prompt = prompt.replace(new RegExp(`\\{${key}\\}`, 'g'), value);
     }
+  }
+
+  // Webhook-driven variables ({{issue.identifier}}, {{updatedFrom.state.name}}, ...)
+  if (context) {
+    prompt = substituteWebhookPrompt(prompt, context);
   }
 
   // Last report (special handling). Only a COMPLETED run's report is injected —

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -250,6 +250,13 @@ export interface JobConfig {
    * RUSH-2020.
    */
   actor?: string;
+  /**
+   * Extra environment variables injected into the spawned process. In a
+   * sandboxed run these are applied on top of the overlay HOME, so they can
+   * point tools at the real user home (e.g. `HOME=/home/muqsit` so the `linear`
+   * CLI finds `~/.linear-cli/config.json`).
+   */
+  env?: Record<string, string>;
 }
 
 /** Metadata for a single job execution, persisted as JSON in the run directory. */

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -687,8 +687,8 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 
   const baseEnv = injectRoutineActor(
     useSandbox
-      ? buildSpawnEnv(overlayHome!)
-      : { ...process.env } as Record<string, string>,
+      ? buildSpawnEnv(overlayHome!, config.env)
+      : { ...process.env, ...(config.env || {}) } as Record<string, string>,
     config,
   );
 
@@ -1242,8 +1242,8 @@ export async function executeJobDetached(config: JobConfig, hooks?: RoutineHooks
 
   const baseEnv = injectRoutineActor(
     useSandbox
-      ? buildSpawnEnv(overlayHome!)
-      : { ...process.env } as Record<string, string>,
+      ? buildSpawnEnv(overlayHome!, config.env)
+      : { ...process.env, ...(config.env || {}) } as Record<string, string>,
     config,
   );
   const spawnEnv = dispatchesViaAgentsRun(config)

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -84,6 +84,7 @@ const SYSTEM_PLUGINS_DIR = path.join(SYSTEM_AGENTS_DIR, 'plugins');
 // Unioned under user routines by listJobs()/readJob() so a routine shipped here
 // fires for every install, while a user routine of the same name overrides it.
 const SYSTEM_ROUTINES_DIR = path.join(SYSTEM_AGENTS_DIR, 'routines');
+const SYSTEM_WEBHOOKS_DIR = path.join(SYSTEM_AGENTS_DIR, 'webhooks');
 const SYSTEM_PROMPTCUTS_FILE = path.join(SYSTEM_AGENTS_DIR, 'hooks', 'promptcuts.yaml');
 const SYSTEM_MCP_CONFIG_FILE = path.join(SYSTEM_AGENTS_DIR, 'mcp.json');
 const SYSTEM_INSTRUCTIONS_FILE = path.join(SYSTEM_AGENTS_DIR, 'instructions.md');
@@ -98,6 +99,7 @@ const CACHE_DIR = path.join(USER_AGENTS_DIR, '.cache');
 
 // Top-level user dirs (config/definitions only — runtime moves into .history/.cache).
 const ROUTINES_DIR = path.join(USER_AGENTS_DIR, 'routines');
+const WEBHOOKS_DIR = path.join(USER_AGENTS_DIR, 'webhooks');
 // Monitor definitions (event-triggered watchers). Sibling of ROUTINES_DIR: a
 // monitor is a routine whose trigger is a watched source instead of a clock.
 const MONITORS_DIR = path.join(USER_AGENTS_DIR, 'monitors');
@@ -354,7 +356,14 @@ export function getCacheDir(): string { return CACHE_DIR; }
 export function getPackagesDir(): string { return PACKAGES_DIR; }
 
 /** Path to routine YAML definitions (~/.agents/routines/). */
-export function getRoutinesDir(): string { return ROUTINES_DIR; }
+export function getRoutinesDir(): string { return process.env.AGENTS_ROUTINES_DIR ?? ROUTINES_DIR; }
+
+/**
+ * Path to webhook handler YAML definitions (~/.agents/webhooks/). Handlers are
+ * one-off triggers for agents/workflows/commands/routines, layered the same way
+ * as routines (project > user > system).
+ */
+export function getWebhooksDir(): string { return process.env.AGENTS_WEBHOOKS_DIR ?? WEBHOOKS_DIR; }
 
 /**
  * Path to built-in routine definitions shipped in the system repo
@@ -363,7 +372,13 @@ export function getRoutinesDir(): string { return ROUTINES_DIR; }
  * user routine of the same name overrides it (a user copy with `enabled: false`
  * disables the built-in). The daemon fires these; the directory need not exist.
  */
-export function getSystemRoutinesDir(): string { return SYSTEM_ROUTINES_DIR; }
+export function getSystemRoutinesDir(): string { return process.env.AGENTS_SYSTEM_ROUTINES_DIR ?? SYSTEM_ROUTINES_DIR; }
+
+/**
+ * Path to built-in webhook handler definitions shipped in the system repo
+ * (`~/.agents/.system/webhooks/`). Layered under user handlers by `listHandlers()`.
+ */
+export function getSystemWebhooksDir(): string { return process.env.AGENTS_SYSTEM_WEBHOOKS_DIR ?? SYSTEM_WEBHOOKS_DIR; }
 
 /**
  * Path to a project-scoped routines directory (`<project>/.agents/routines/`),
@@ -381,6 +396,17 @@ export function getProjectRoutinesDir(cwd: string = process.cwd()): string | nul
   const projectAgentsDir = getProjectAgentsDir(cwd);
   if (!projectAgentsDir) return null;
   return path.join(projectAgentsDir, 'routines');
+}
+
+/**
+ * Path to a project-scoped webhook handlers directory
+ * (`<project>/.agents/webhooks/`), or null when no project `.agents/` is found
+ * by walking up from cwd.
+ */
+export function getProjectWebhooksDir(cwd: string = process.cwd()): string | null {
+  const projectAgentsDir = getProjectAgentsDir(cwd);
+  if (!projectAgentsDir) return null;
+  return path.join(projectAgentsDir, 'webhooks');
 }
 
 /** Path to routine execution logs (~/.agents/.history/runs/). */
@@ -598,6 +624,7 @@ export function ensureAgentsDir(): void {
   if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, opts);
   if (!fs.existsSync(PACKAGES_DIR)) fs.mkdirSync(PACKAGES_DIR, opts);
   if (!fs.existsSync(ROUTINES_DIR)) fs.mkdirSync(ROUTINES_DIR, opts);
+  if (!fs.existsSync(WEBHOOKS_DIR)) fs.mkdirSync(WEBHOOKS_DIR, opts);
   if (!fs.existsSync(RUNS_DIR)) fs.mkdirSync(RUNS_DIR, opts);
   if (!fs.existsSync(VERSIONS_DIR)) fs.mkdirSync(VERSIONS_DIR, opts);
   if (!fs.existsSync(SHIMS_DIR)) fs.mkdirSync(SHIMS_DIR, opts);
@@ -607,6 +634,7 @@ export function ensureAgentsDir(): void {
   if (!fs.existsSync(SYSTEM_RULES_DIR)) fs.mkdirSync(SYSTEM_RULES_DIR, opts);
   if (!fs.existsSync(SYSTEM_PERMISSIONS_DIR)) fs.mkdirSync(SYSTEM_PERMISSIONS_DIR, opts);
   if (!fs.existsSync(SYSTEM_SUBAGENTS_DIR)) fs.mkdirSync(SYSTEM_SUBAGENTS_DIR, opts);
+  if (!fs.existsSync(SYSTEM_WEBHOOKS_DIR)) fs.mkdirSync(SYSTEM_WEBHOOKS_DIR, opts);
   try { fs.chmodSync(SYSTEM_AGENTS_DIR, 0o700); } catch {}
 }
 

--- a/apps/cli/src/lib/triggers/handlers.test.ts
+++ b/apps/cli/src/lib/triggers/handlers.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import type { JobConfig, RunMeta } from '../routines.js';
+import { substituteWebhookPrompt } from '../routines.js';
+import type { IncomingWebhook } from './webhook.js';
+
+describe('handler config layer', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let eventsFile: string;
+  let handlerMod: typeof import('./handlers.js');
+
+  async function loadModule() {
+    // Re-import after setting HOME so state.ts resolves the temp dirs.
+    handlerMod = await import('./handlers.js');
+  }
+
+  beforeEach(async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-handlers-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    process.env.AGENTS_WEBHOOKS_DIR = path.join(tmpHome, '.agents', 'webhooks');
+    process.env.AGENTS_SYSTEM_WEBHOOKS_DIR = path.join(tmpHome, '.agents', '.system', 'webhooks');
+    process.env.AGENTS_ROUTINES_DIR = path.join(tmpHome, '.agents', 'routines');
+    process.env.AGENTS_SYSTEM_ROUTINES_DIR = path.join(tmpHome, '.agents', '.system', 'routines');
+    eventsFile = path.join(tmpHome, 'events.jsonl');
+    process.env.AGENTS_EVENTS_PATH = eventsFile;
+    const events = await import('../events.js');
+    events._resetForTest(eventsFile);
+    handlerMod = await import('./handlers.js');
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    delete process.env.AGENTS_WEBHOOKS_DIR;
+    delete process.env.AGENTS_SYSTEM_WEBHOOKS_DIR;
+    delete process.env.AGENTS_ROUTINES_DIR;
+    delete process.env.AGENTS_SYSTEM_ROUTINES_DIR;
+    delete process.env.AGENTS_EVENTS_PATH;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function writeHandler(scope: 'user' | 'system' | 'project', name: string, content: Record<string, unknown>, projectRoot?: string) {
+    let dir: string;
+    if (scope === 'project') {
+      if (!projectRoot) throw new Error('projectRoot required');
+      dir = path.join(projectRoot, '.agents', 'webhooks');
+    } else if (scope === 'system') {
+      dir = process.env.AGENTS_SYSTEM_WEBHOOKS_DIR!;
+    } else {
+      dir = process.env.AGENTS_WEBHOOKS_DIR!;
+    }
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${name}.yml`), yaml.stringify(content), 'utf-8');
+  }
+
+  function writeRoutine(name: string, content: Record<string, unknown>) {
+    const dir = process.env.AGENTS_ROUTINES_DIR!;
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${name}.yml`), yaml.stringify(content), 'utf-8');
+  }
+
+  function linearWebhook(overrides: Record<string, unknown> = {}): IncomingWebhook {
+    return {
+      source: 'linear',
+      event: 'Issue',
+      payload: {
+        type: 'Issue',
+        action: 'update',
+        webhookTimestamp: Date.now(),
+        data: {
+          identifier: 'RUSH-1459',
+          title: 'Plan the thing',
+          description: 'Details here',
+          state: { name: 'Plan' },
+          labels: [{ name: 'agent' }],
+        },
+        updatedFrom: {
+          state: { name: 'Triage' },
+        },
+        ...overrides,
+      },
+    };
+  }
+
+  describe('listHandlers', () => {
+    it('layers project > user > system with same-name shadowing', () => {
+      writeHandler('system', 'shared', { source: 'linear', run: { agent: 'claude', prompt: 'system' } });
+      writeHandler('user', 'shared', { source: 'linear', run: { agent: 'claude', prompt: 'user' } });
+      const projectRoot = path.join(tmpHome, 'project');
+      writeHandler('project', 'shared', { source: 'linear', run: { agent: 'claude', prompt: 'project' } }, projectRoot);
+
+      const handlers = handlerMod.listHandlers(projectRoot);
+      const shared = handlers.find((h) => h.name === 'shared');
+      expect(shared).toBeDefined();
+      expect(shared!.run!.prompt).toBe('project');
+    });
+
+    it('unions handlers of different names across layers', () => {
+      writeHandler('user', 'user-only', { source: 'linear', run: { agent: 'claude' } });
+      writeHandler('system', 'system-only', { source: 'github', run: { workflow: 'ci' } });
+
+      const names = handlerMod.listHandlers().map((h) => h.name).sort();
+      expect(names).toEqual(['system-only', 'user-only']);
+    });
+
+    it('defaults enabled to true when omitted', () => {
+      writeHandler('user', 'always-on', { source: 'linear', run: { agent: 'claude' } });
+      const handler = handlerMod.listHandlers().find((h) => h.name === 'always-on');
+      expect(handler!.enabled).toBe(true);
+    });
+
+    it('omits disabled handlers from matches', () => {
+      writeHandler('user', 'off', { source: 'linear', enabled: false, run: { agent: 'claude' } });
+      const handler = handlerMod.listHandlers().find((h) => h.name === 'off');
+      expect(handler).toBeDefined();
+      expect(handlerMod.handlerMatchesWebhook(handler!, linearWebhook())).toBe(false);
+    });
+  });
+
+  describe('handlerMatchesWebhook', () => {
+    it('matches by source, event, and action', () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'issue-update',
+        source: 'linear',
+        event: 'Issue',
+        action: 'update',
+        run: { agent: 'claude' },
+      };
+      expect(handlerMod.handlerMatchesWebhook(handler, linearWebhook())).toBe(true);
+      expect(handlerMod.handlerMatchesWebhook(handler, { ...linearWebhook(), event: 'Comment' })).toBe(false);
+      expect(handlerMod.handlerMatchesWebhook(handler, { ...linearWebhook(), payload: { ...linearWebhook().payload, action: 'create' } })).toBe(false);
+    });
+
+    it('matches Linear stateTo and stateFrom filters', () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'plan-handler',
+        source: 'linear',
+        event: 'Issue',
+        action: 'update',
+        stateTo: 'Plan',
+        stateFrom: 'Triage',
+        run: { agent: 'claude' },
+      };
+      expect(handlerMod.handlerMatchesWebhook(handler, linearWebhook())).toBe(true);
+
+      const wrongTo = linearWebhook();
+      (wrongTo.payload.data as Record<string, unknown>).state = { name: 'Done' };
+      expect(handlerMod.handlerMatchesWebhook(handler, wrongTo)).toBe(false);
+
+      const wrongFrom = linearWebhook();
+      wrongFrom.payload.updatedFrom = { state: { name: 'Backlog' } };
+      expect(handlerMod.handlerMatchesWebhook(handler, wrongFrom)).toBe(false);
+    });
+
+    it('matches Linear teamKey and label filters', () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'rush-agent',
+        source: 'linear',
+        event: 'Issue',
+        teamKey: 'RUSH',
+        label: 'agent',
+        run: { agent: 'claude' },
+      };
+      expect(handlerMod.handlerMatchesWebhook(handler, linearWebhook())).toBe(true);
+
+      const noLabel = linearWebhook();
+      (noLabel.payload.data as Record<string, unknown>).labels = [];
+      expect(handlerMod.handlerMatchesWebhook(handler, noLabel)).toBe(false);
+    });
+
+    it('matches GitHub repo, branch, and label filters', () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'pr-handler',
+        source: 'github',
+        event: 'pull_request',
+        repo: 'phnx-labs/agents-cli',
+        branch: 'main',
+        label: 'ux-approved',
+        run: { agent: 'claude' },
+      };
+      const webhook: IncomingWebhook = {
+        source: 'github',
+        event: 'pull_request',
+        payload: {
+          action: 'labeled',
+          repository: { full_name: 'phnx-labs/agents-cli' },
+          label: { name: 'ux-approved' },
+          pull_request: {
+            base: { ref: 'main' },
+            head: { ref: 'feature' },
+            labels: [{ name: 'ux-approved' }],
+          },
+        },
+      };
+      expect(handlerMod.handlerMatchesWebhook(handler, webhook)).toBe(true);
+
+      const wrongRepo: IncomingWebhook = {
+        ...webhook,
+        payload: { ...webhook.payload, repository: { full_name: 'other/repo' } },
+      };
+      expect(handlerMod.handlerMatchesWebhook(handler, wrongRepo)).toBe(false);
+    });
+
+    it('honors the devices allowlist', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      try {
+        const local: import('./handlers.js').WebhookHandler = {
+          name: 'local',
+          source: 'linear',
+          devices: ['zion'],
+          run: { agent: 'claude' },
+        };
+        const foreign: import('./handlers.js').WebhookHandler = {
+          name: 'foreign',
+          source: 'linear',
+          devices: ['mac-mini'],
+          run: { agent: 'claude' },
+        };
+        expect(handlerMod.handlerMatchesWebhook(local, linearWebhook())).toBe(true);
+        expect(handlerMod.handlerMatchesWebhook(foreign, linearWebhook())).toBe(false);
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+  });
+
+  describe('executeHandler', () => {
+    it('runs an agent action with prompt substitution', async () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'agent-handler',
+        source: 'linear',
+        run: { agent: 'claude', prompt: 'Fix {{issue.identifier}}' },
+      };
+      const dispatched: JobConfig[] = [];
+      const meta: RunMeta = {
+        jobName: handler.name,
+        runId: 'run-1',
+        agent: 'claude',
+        pid: 1,
+        status: 'running',
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        exitCode: null,
+      };
+      const result = await handlerMod.executeHandler(handler, linearWebhook(), {
+        dispatchAgent: async (config) => {
+          dispatched.push(config);
+          return meta;
+        },
+      });
+      expect(result.runId).toBe('run-1');
+      expect(dispatched).toHaveLength(1);
+      expect(dispatched[0].agent).toBe('claude');
+      expect(dispatched[0].prompt).toBe('Fix RUSH-1459');
+    });
+
+    it('runs a workflow action', async () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'wf-handler',
+        source: 'linear',
+        run: { workflow: 'autodev', prompt: '{{issue.title}}' },
+      };
+      const dispatched: JobConfig[] = [];
+      await handlerMod.executeHandler(handler, linearWebhook(), {
+        dispatchWorkflow: async (config) => {
+          dispatched.push(config);
+          return {
+            jobName: handler.name,
+            runId: 'run-wf',
+            agent: 'claude',
+            pid: 1,
+            status: 'running',
+            startedAt: new Date().toISOString(),
+            completedAt: null,
+            exitCode: null,
+          };
+        },
+      });
+      expect(dispatched[0].workflow).toBe('autodev');
+      expect(dispatched[0].prompt).toBe('Plan the thing');
+    });
+
+    it('runs a shell command action with substitution', async () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'cmd-handler',
+        source: 'linear',
+        run: { command: 'echo {{issue.identifier}}' },
+      };
+      const result = await handlerMod.executeHandler(handler, linearWebhook(), {
+        execCommand: async (command) => {
+          expect(command).toBe('echo RUSH-1459');
+          return { exitCode: 0, output: 'RUSH-1459\n' };
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toBe('RUSH-1459\n');
+    });
+
+    it('delegates to a routine and substitutes its prompt', async () => {
+      writeRoutine('plan-routine', {
+        name: 'plan-routine',
+        schedule: '0 9 * * *',
+        agent: 'claude',
+        prompt: 'Plan {{issue.identifier}}',
+      });
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'routine-handler',
+        source: 'linear',
+        routine: 'plan-routine',
+      };
+      const dispatched: JobConfig[] = [];
+      await handlerMod.executeHandler(handler, linearWebhook(), {
+        dispatchRoutine: async (config) => {
+          dispatched.push(config);
+          return {
+            jobName: config.name,
+            runId: 'run-routine',
+            agent: 'claude',
+            pid: 1,
+            status: 'running',
+            startedAt: new Date().toISOString(),
+            completedAt: null,
+            exitCode: null,
+          };
+        },
+      });
+      expect(dispatched).toHaveLength(1);
+      expect(dispatched[0].prompt).toBe('Plan RUSH-1459');
+      expect(dispatched[0].name).toBe('plan-routine');
+    });
+
+    it('emits webhook.handler.start and webhook.handler.end events', async () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'event-handler',
+        source: 'linear',
+        run: { agent: 'claude', prompt: 'go' },
+      };
+      await handlerMod.executeHandler(handler, linearWebhook(), {
+        dispatchAgent: async () => ({
+          jobName: handler.name,
+          runId: 'run-evt',
+          agent: 'claude',
+          pid: 1,
+          status: 'running',
+          startedAt: new Date().toISOString(),
+          completedAt: null,
+          exitCode: null,
+        }),
+      });
+      const lines = fs.readFileSync(eventsFile, 'utf-8').trim().split('\n').filter(Boolean);
+      const events = lines.map((l) => JSON.parse(l).event);
+      expect(events).toContain('webhook.handler.start');
+      expect(events).toContain('webhook.handler.end');
+      const end = lines.map((l) => JSON.parse(l)).find((r) => r.event === 'webhook.handler.end');
+      expect(end.status).toBe('success');
+      expect(end.runId).toBe('run-evt');
+    });
+  });
+
+  describe('prompt variable substitution', () => {
+    it('substitutes {{dotted.path}} placeholders from a webhook context', () => {
+      const context = {
+        source: 'linear',
+        event: 'Issue',
+        action: 'update',
+        issue: { identifier: 'RUSH-1', state: { name: 'Plan' } },
+        updatedFrom: { state: { name: 'Triage' } },
+      };
+      const prompt = 'Issue {{issue.identifier}} moved from {{updatedFrom.state.name}} to {{issue.state.name}}.';
+      expect(substituteWebhookPrompt(prompt, context)).toBe('Issue RUSH-1 moved from Triage to Plan.');
+    });
+
+    it('replaces missing values with empty strings', () => {
+      const context = { source: 'linear', event: 'Issue', issue: {} };
+      expect(substituteWebhookPrompt('{{issue.missing}}', context)).toBe('');
+    });
+
+    it('does not affect single-brace variables like {day}', () => {
+      const context = { source: 'linear', event: 'Issue', issue: { identifier: 'RUSH-1' } };
+      expect(substituteWebhookPrompt('{day} {{issue.identifier}}', context)).toBe('{day} RUSH-1');
+    });
+  });
+});

--- a/apps/cli/src/lib/triggers/handlers.test.ts
+++ b/apps/cli/src/lib/triggers/handlers.test.ts
@@ -26,6 +26,7 @@ describe('handler config layer', () => {
     process.env.AGENTS_SYSTEM_WEBHOOKS_DIR = path.join(tmpHome, '.agents', '.system', 'webhooks');
     process.env.AGENTS_ROUTINES_DIR = path.join(tmpHome, '.agents', 'routines');
     process.env.AGENTS_SYSTEM_ROUTINES_DIR = path.join(tmpHome, '.agents', '.system', 'routines');
+    process.env.AGENTS_DEVICES_DIR = path.join(tmpHome, '.agents', '.history', 'devices');
     eventsFile = path.join(tmpHome, 'events.jsonl');
     process.env.AGENTS_EVENTS_PATH = eventsFile;
     const events = await import('../events.js');
@@ -40,6 +41,7 @@ describe('handler config layer', () => {
     delete process.env.AGENTS_SYSTEM_WEBHOOKS_DIR;
     delete process.env.AGENTS_ROUTINES_DIR;
     delete process.env.AGENTS_SYSTEM_ROUTINES_DIR;
+    delete process.env.AGENTS_DEVICES_DIR;
     delete process.env.AGENTS_EVENTS_PATH;
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
@@ -62,6 +64,12 @@ describe('handler config layer', () => {
     const dir = process.env.AGENTS_ROUTINES_DIR!;
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, `${name}.yml`), yaml.stringify(content), 'utf-8');
+  }
+
+  function writeDeviceRegistry(devices: Record<string, unknown>) {
+    const dir = process.env.AGENTS_DEVICES_DIR!;
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'registry.json'), JSON.stringify(devices), 'utf-8');
   }
 
   function linearWebhook(overrides: Record<string, unknown> = {}): IncomingWebhook {
@@ -231,6 +239,117 @@ describe('handler config layer', () => {
     });
   });
 
+  describe('resolveHandlerHost', () => {
+    it('returns local for empty or missing host', () => {
+      expect(handlerMod.resolveHandlerHost(undefined)).toEqual({});
+      expect(handlerMod.resolveHandlerHost('')).toEqual({});
+      expect(handlerMod.resolveHandlerHost('   ')).toEqual({});
+    });
+
+    it('returns local when host names this machine', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      try {
+        expect(handlerMod.resolveHandlerHost('zion')).toEqual({});
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('resolves a specific peer host to host strategy', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      try {
+        expect(handlerMod.resolveHandlerHost('mac-mini')).toEqual({
+          host: 'mac-mini',
+          hostStrategy: 'host',
+        });
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('picks any online worker for fleet host', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      writeDeviceRegistry({
+        'mac-mini': {
+          name: 'mac-mini',
+          platform: 'macos',
+          shell: 'posix',
+          address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' },
+          auth: { method: 'key' },
+          tailscale: { online: true },
+        },
+      });
+      try {
+        expect(handlerMod.resolveHandlerHost('fleet')).toEqual({
+          host: 'mac-mini',
+          hostStrategy: 'host',
+        });
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('picks an online worker matching the platform for fleet/linux', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      writeDeviceRegistry({
+        'mac-mini': {
+          name: 'mac-mini',
+          platform: 'macos',
+          shell: 'posix',
+          address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' },
+          auth: { method: 'key' },
+          tailscale: { online: true },
+        },
+        'yosemite-s0': {
+          name: 'yosemite-s0',
+          platform: 'linux',
+          shell: 'posix',
+          address: { via: 'tailscale', dnsName: 'yosemite-s0.tail1a85a1.ts.net' },
+          auth: { method: 'key' },
+          tailscale: { online: true },
+        },
+      });
+      try {
+        expect(handlerMod.resolveHandlerHost('fleet/linux')).toEqual({
+          host: 'yosemite-s0',
+          hostStrategy: 'host',
+        });
+        expect(handlerMod.resolveHandlerHost('linux/fleet')).toEqual({
+          host: 'yosemite-s0',
+          hostStrategy: 'host',
+        });
+        expect(handlerMod.resolveHandlerHost('linux')).toEqual({
+          host: 'yosemite-s0',
+          hostStrategy: 'host',
+        });
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('throws when fleet has no eligible device', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      writeDeviceRegistry({});
+      try {
+        // No registry / nothing online still falls back to self, which is local.
+        expect(handlerMod.resolveHandlerHost('fleet')).toEqual({});
+        expect(() => handlerMod.resolveHandlerHost('fleet/linux')).toThrow(/no eligible online fleet device/);
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+  });
+
   describe('executeHandler', () => {
     it('runs an agent action with prompt substitution', async () => {
       const handler: import('./handlers.js').WebhookHandler = {
@@ -259,6 +378,40 @@ describe('handler config layer', () => {
       expect(dispatched).toHaveLength(1);
       expect(dispatched[0].agent).toBe('claude');
       expect(dispatched[0].prompt).toBe('Fix RUSH-1459');
+    });
+
+    it('passes host placement into the dispatched job config', async () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      try {
+        const handler: import('./handlers.js').WebhookHandler = {
+          name: 'remote-handler',
+          source: 'linear',
+          host: 'mac-mini',
+          run: { agent: 'claude', prompt: 'go' },
+        };
+        const dispatched: JobConfig[] = [];
+        await handlerMod.executeHandler(handler, linearWebhook(), {
+          dispatchAgent: async (config) => {
+            dispatched.push(config);
+            return {
+              jobName: handler.name,
+              runId: 'run-remote',
+              agent: 'claude',
+              pid: 1,
+              status: 'running',
+              startedAt: new Date().toISOString(),
+              completedAt: null,
+              exitCode: null,
+            };
+          },
+        });
+        expect(dispatched[0].host).toBe('mac-mini');
+        expect(dispatched[0].hostStrategy).toBe('host');
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
     });
 
     it('runs a workflow action', async () => {

--- a/apps/cli/src/lib/triggers/handlers.ts
+++ b/apps/cli/src/lib/triggers/handlers.ts
@@ -37,6 +37,8 @@ export interface WebhookHandler {
     workflow?: string;
     command?: string;
     prompt?: string;
+    /** Extra environment variables for agent/workflow/command actions. */
+    env?: Record<string, string>;
   };
   routine?: string;
 }
@@ -356,6 +358,7 @@ async function executeHandlerAction(
       prompt: substitutedPrompt,
       ...(handler.run.agent ? { agent: handler.run.agent } : { workflow: handler.run.workflow! }),
       ...(handler.devices ? { devices: handler.devices } : {}),
+      ...(handler.run.env ? { env: handler.run.env } : {}),
     };
     const dispatch = handler.run.agent
       ? (opts.dispatchAgent ?? dispatchDefault)

--- a/apps/cli/src/lib/triggers/handlers.ts
+++ b/apps/cli/src/lib/triggers/handlers.ts
@@ -1,0 +1,388 @@
+/**
+ * Webhook handler config layer.
+ *
+ * Handlers are one-off triggers stored in `~/.agents/webhooks/*.yml` (plus
+ * project/system layers). They complement routine triggers: a matching webhook
+ * can run an agent, workflow, shell command, or delegate to a routine.
+ */
+
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import { emit } from '../events.js';
+import { machineId, normalizeHost } from '../machine-id.js';
+import { safeJoin } from '../paths.js';
+import type { JobConfig, RunMeta, WebhookContext } from '../routines.js';
+import { readJob, substituteWebhookPrompt } from '../routines.js';
+import { ensureAgentsDir, getProjectWebhooksDir, getSystemWebhooksDir, getWebhooksDir } from '../state.js';
+import type { AgentId } from '../types.js';
+import type { IncomingWebhook, WebhookSource } from './webhook.js';
+
+export interface WebhookHandler {
+  name: string;
+  enabled?: boolean;
+  devices?: string[];
+  source: WebhookSource;
+  event?: string;
+  action?: string;
+  stateTo?: string;
+  stateFrom?: string;
+  teamKey?: string;
+  label?: string;
+  repo?: string;
+  branch?: string;
+  run?: {
+    agent?: AgentId;
+    workflow?: string;
+    command?: string;
+    prompt?: string;
+  };
+  routine?: string;
+}
+
+export interface FiredHandler {
+  handlerName: string;
+  runId?: string;
+  exitCode?: number;
+  output?: string;
+}
+
+const HANDLER_DEFAULTS: Partial<WebhookHandler> = {
+  enabled: true,
+};
+
+/** Read `repository.full_name` (`owner/name`) from a webhook payload, if present. */
+function payloadRepo(payload: Record<string, unknown>): string | null {
+  const repo = payload?.repository as { full_name?: unknown } | undefined;
+  const fullName = repo?.full_name;
+  return typeof fullName === 'string' && fullName.length > 0 ? fullName : null;
+}
+
+/** Strip a `refs/heads/` (or `refs/tags/`) prefix to the short branch/tag name. */
+function shortRef(ref: string): string {
+  return ref.replace(/^refs\/(heads|tags)\//, '');
+}
+
+/** Extract candidate branches a webhook payload references. */
+function payloadBranches(event: string, payload: Record<string, unknown>): string[] {
+  const branches = new Set<string>();
+  const add = (v: unknown) => {
+    if (typeof v === 'string' && v.length > 0) branches.add(shortRef(v));
+  };
+
+  switch (event) {
+    case 'push':
+      add(payload.ref);
+      break;
+    case 'pull_request': {
+      const pr = payload.pull_request as { base?: { ref?: unknown }; head?: { ref?: unknown } } | undefined;
+      add(pr?.base?.ref);
+      add(pr?.head?.ref);
+      break;
+    }
+    case 'workflow_run': {
+      const run = payload.workflow_run as { head_branch?: unknown } | undefined;
+      add(run?.head_branch);
+      break;
+    }
+    default:
+      break;
+  }
+  return [...branches];
+}
+
+function linearAction(payload: Record<string, unknown>): string | null {
+  return typeof payload.action === 'string' ? payload.action : null;
+}
+
+function linearTeamKey(payload: Record<string, unknown>): string | null {
+  const data = payload.data as Record<string, unknown> | undefined;
+  const identifier = data?.identifier;
+  if (typeof identifier === 'string') {
+    const match = /^([A-Z][A-Z0-9]*)-\d+$/.exec(identifier);
+    if (match) return match[1];
+  }
+  const team = data?.team as { key?: unknown } | undefined;
+  return typeof team?.key === 'string' ? team.key : null;
+}
+
+function linearLabels(payload: Record<string, unknown>): string[] {
+  const data = payload.data as Record<string, unknown> | undefined;
+  const labels = Array.isArray(data?.labels) ? (data?.labels as unknown[]) : [];
+  return labels
+    .map((n) => (n as { name?: unknown }).name)
+    .filter((n): n is string => typeof n === 'string' && n.length > 0);
+}
+
+function githubAction(payload: Record<string, unknown>): string | null {
+  return typeof payload.action === 'string' ? payload.action : null;
+}
+
+function githubLabels(payload: Record<string, unknown>): string[] {
+  const names = new Set<string>();
+  const add = (value: unknown) => {
+    if (typeof value === 'string' && value.length > 0) names.add(value);
+  };
+
+  const deliveryLabel = payload.label as { name?: unknown } | undefined;
+  add(deliveryLabel?.name);
+
+  const pr = payload.pull_request as { labels?: unknown } | undefined;
+  const prLabels = Array.isArray(pr?.labels) ? pr.labels : [];
+  for (const label of prLabels) {
+    add((label as { name?: unknown }).name);
+  }
+
+  const issue = payload.issue as { labels?: unknown } | undefined;
+  const issueLabels = Array.isArray(issue?.labels) ? issue.labels : [];
+  for (const label of issueLabels) {
+    add((label as { name?: unknown }).name);
+  }
+
+  return [...names];
+}
+
+function readHandlerFile(filePath: string): WebhookHandler | null {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = yaml.parse(content);
+    if (!parsed || typeof parsed !== 'object') return null;
+    return {
+      ...HANDLER_DEFAULTS,
+      ...parsed,
+      name: parsed.name || path.basename(filePath).replace(/\.ya?ml$/, ''),
+    } as WebhookHandler;
+  } catch {
+    return null;
+  }
+}
+
+function handlerRunsOnThisDevice(handler: Pick<WebhookHandler, 'devices'>): boolean {
+  if (!handler.devices || handler.devices.length === 0) return true;
+  const self = machineId();
+  return handler.devices.some((d) => normalizeHost(d) === self);
+}
+
+/**
+ * List all webhook handlers, scanning project > user > system webhook dirs.
+ * Higher layers shadow lower ones of the same name (first-seen wins).
+ */
+export function listHandlers(cwd?: string): WebhookHandler[] {
+  ensureAgentsDir();
+  const seen = new Set<string>();
+  const handlers: WebhookHandler[] = [];
+
+  const dirs: Array<{ scope: 'project' | 'user' | 'system'; path: string }> = [];
+  if (cwd) {
+    const projectDir = getProjectWebhooksDir(cwd);
+    if (projectDir) dirs.push({ scope: 'project', path: projectDir });
+  }
+  dirs.push({ scope: 'user', path: getWebhooksDir() });
+  dirs.push({ scope: 'system', path: getSystemWebhooksDir() });
+
+  for (const { path: dir } of dirs) {
+    if (!fs.existsSync(dir)) continue;
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+    for (const file of files) {
+      const handler = readHandlerFile(safeJoin(dir, file));
+      if (!handler) continue;
+      if (seen.has(handler.name)) continue;
+      seen.add(handler.name);
+      handlers.push(handler);
+    }
+  }
+  return handlers;
+}
+
+/** Pure matcher: does this handler match the incoming webhook? */
+export function handlerMatchesWebhook(handler: WebhookHandler, webhook: IncomingWebhook): boolean {
+  if (handler.enabled === false) return false;
+  if (handler.source !== webhook.source) return false;
+  if (handler.event && handler.event !== webhook.event) return false;
+  if (!handlerRunsOnThisDevice(handler)) return false;
+
+  if (handler.action) {
+    const action = webhook.source === 'github' ? githubAction(webhook.payload) : linearAction(webhook.payload);
+    if (action !== handler.action) return false;
+  }
+
+  if (webhook.source === 'linear') {
+    if (handler.teamKey && linearTeamKey(webhook.payload) !== handler.teamKey) return false;
+    if (handler.label) {
+      const expected = handler.label.toLowerCase();
+      if (!linearLabels(webhook.payload).some((name) => name.toLowerCase() === expected)) return false;
+    }
+    if (handler.stateTo) {
+      const data = webhook.payload.data as Record<string, unknown> | undefined;
+      const current = (data?.state as Record<string, unknown> | undefined)?.name;
+      if (current !== handler.stateTo) return false;
+    }
+    if (handler.stateFrom) {
+      const updatedFrom = webhook.payload.updatedFrom as Record<string, unknown> | undefined;
+      const previous = (updatedFrom?.state as Record<string, unknown> | undefined)?.name;
+      if (previous !== handler.stateFrom) return false;
+    }
+    return true;
+  }
+
+  if (handler.repo) {
+    const repo = payloadRepo(webhook.payload);
+    if (!repo || repo.toLowerCase() !== handler.repo.toLowerCase()) return false;
+  }
+  if (handler.branch) {
+    const branches = payloadBranches(webhook.event, webhook.payload);
+    if (!branches.some((b) => b === handler.branch)) return false;
+  }
+  if (handler.label) {
+    const expected = handler.label.toLowerCase();
+    if (!githubLabels(webhook.payload).some((name) => name.toLowerCase() === expected)) return false;
+  }
+  return true;
+}
+
+/**
+ * Build the variable-substitution context for a webhook. Linear events expose
+ * `issue` and `updatedFrom`; GitHub events expose `repository`, `pull_request`,
+ * and `issue`.
+ */
+export function buildWebhookContext(webhook: IncomingWebhook): WebhookContext {
+  const action = webhook.source === 'github'
+    ? githubAction(webhook.payload) ?? undefined
+    : linearAction(webhook.payload) ?? undefined;
+  if (webhook.source === 'linear') {
+    return {
+      source: webhook.source,
+      event: webhook.event,
+      action,
+      issue: webhook.payload.data,
+      updatedFrom: webhook.payload.updatedFrom,
+    };
+  }
+  return {
+    source: webhook.source,
+    event: webhook.event,
+    action,
+    repository: webhook.payload.repository,
+    pull_request: webhook.payload.pull_request,
+    issue: webhook.payload.issue,
+  };
+}
+
+export interface ExecuteHandlerOptions {
+  dispatchAgent?: (config: JobConfig) => Promise<RunMeta>;
+  dispatchWorkflow?: (config: JobConfig) => Promise<RunMeta>;
+  execCommand?: (command: string) => Promise<{ exitCode: number; output: string }>;
+  dispatchRoutine?: (config: JobConfig) => Promise<RunMeta>;
+}
+
+function defaultExecCommand(command: string): Promise<{ exitCode: number; output: string }> {
+  return new Promise((resolve) => {
+    exec(command, (error, stdout, stderr) => {
+      const output = stdout + stderr;
+      if (error) {
+        resolve({ exitCode: typeof error.code === 'number' ? error.code : 1, output });
+      } else {
+        resolve({ exitCode: 0, output });
+      }
+    });
+  });
+}
+
+function dispatchDefault(config: JobConfig): Promise<RunMeta> {
+  // Import lazily so the runner module (heavy) is only loaded when a handler
+  // actually needs to spawn. Tests inject dispatch functions, so this path is
+  // not exercised in unit tests.
+  return import('../runner.js').then((m) => m.executeJobDetached(config));
+}
+
+/**
+ * Execute a handler's action. Runs the configured agent/workflow/command or
+ * delegates to a routine, substituting `{{...}}` placeholders from the webhook
+ * context.
+ */
+export async function executeHandler(
+  handler: WebhookHandler,
+  webhook: IncomingWebhook,
+  opts: ExecuteHandlerOptions = {},
+): Promise<FiredHandler> {
+  const context = buildWebhookContext(webhook);
+  const base: FiredHandler = { handlerName: handler.name };
+
+  emit('webhook.handler.start', {
+    source: webhook.source,
+    event: webhook.event,
+    handlerName: handler.name,
+  });
+
+  try {
+    const result = await executeHandlerAction(handler, webhook, context, opts);
+    emit('webhook.handler.end', {
+      source: webhook.source,
+      event: webhook.event,
+      handlerName: handler.name,
+      status: 'success',
+      ...result,
+    });
+    return { ...base, ...result };
+  } catch (err) {
+    const error = (err as Error).message;
+    emit('webhook.handler.end', {
+      source: webhook.source,
+      event: webhook.event,
+      handlerName: handler.name,
+      status: 'error',
+      error,
+    });
+    throw err;
+  }
+}
+
+async function executeHandlerAction(
+  handler: WebhookHandler,
+  webhook: IncomingWebhook,
+  context: WebhookContext,
+  opts: ExecuteHandlerOptions,
+): Promise<Omit<FiredHandler, 'handlerName'>> {
+  const substitutedPrompt = handler.run?.prompt ? substituteWebhookPrompt(handler.run.prompt, context) : '';
+
+  if (handler.run?.agent || handler.run?.workflow) {
+    const config: JobConfig = {
+      name: handler.name,
+      mode: 'auto',
+      effort: 'auto',
+      timeout: '10m',
+      enabled: true,
+      prompt: substitutedPrompt,
+      ...(handler.run.agent ? { agent: handler.run.agent } : { workflow: handler.run.workflow! }),
+      ...(handler.devices ? { devices: handler.devices } : {}),
+    };
+    const dispatch = handler.run.agent
+      ? (opts.dispatchAgent ?? dispatchDefault)
+      : (opts.dispatchWorkflow ?? dispatchDefault);
+    const meta = await dispatch(config);
+    return { runId: meta.runId };
+  }
+
+  if (handler.run?.command) {
+    const command = substituteWebhookPrompt(handler.run.command, context);
+    const exec = opts.execCommand ?? defaultExecCommand;
+    const { exitCode, output } = await exec(command);
+    return { exitCode, output };
+  }
+
+  if (handler.routine) {
+    const routine = readJob(handler.routine);
+    if (!routine) throw new Error(`routine '${handler.routine}' not found`);
+    const config: JobConfig = {
+      ...routine,
+      prompt: substituteWebhookPrompt(routine.prompt, context),
+      ...(handler.devices ? { devices: handler.devices } : {}),
+    };
+    const dispatch = opts.dispatchRoutine ?? dispatchDefault;
+    const meta = await dispatch(config);
+    return { runId: meta.runId };
+  }
+
+  throw new Error(`handler '${handler.name}' has no run or routine action`);
+}

--- a/apps/cli/src/lib/triggers/handlers.ts
+++ b/apps/cli/src/lib/triggers/handlers.ts
@@ -13,8 +13,10 @@ import * as yaml from 'yaml';
 import { emit } from '../events.js';
 import { machineId, normalizeHost } from '../machine-id.js';
 import { safeJoin } from '../paths.js';
+import type { DevicePlatform } from '../devices/registry.js';
 import type { JobConfig, RunMeta, WebhookContext } from '../routines.js';
 import { readJob, substituteWebhookPrompt } from '../routines.js';
+import { pickFleetDevice } from '../routines-placement.js';
 import { ensureAgentsDir, getProjectWebhooksDir, getSystemWebhooksDir, getWebhooksDir } from '../state.js';
 import type { AgentId } from '../types.js';
 import type { IncomingWebhook, WebhookSource } from './webhook.js';
@@ -23,6 +25,13 @@ export interface WebhookHandler {
   name: string;
   enabled?: boolean;
   devices?: string[];
+  /**
+   * Where the handler body executes. A specific device name runs there over SSH.
+   * `fleet` picks any online worker; `fleet/<platform>` or `<platform>/fleet`
+   * picks any online worker on that platform (`linux`, `macos`, `windows`).
+   * Omitted means run on the device that received the webhook.
+   */
+  host?: string;
   source: WebhookSource;
   event?: string;
   action?: string;
@@ -164,6 +173,53 @@ function handlerRunsOnThisDevice(handler: Pick<WebhookHandler, 'devices'>): bool
   if (!handler.devices || handler.devices.length === 0) return true;
   const self = machineId();
   return handler.devices.some((d) => normalizeHost(d) === self);
+}
+
+const HOST_PLATFORMS: readonly string[] = ['linux', 'macos', 'windows'];
+
+function parseHostPlatform(raw: string): { base: string; platform?: DevicePlatform } {
+  const parts = raw
+    .split('/')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  const platformIdx = parts.findIndex((p) => HOST_PLATFORMS.includes(p));
+  if (platformIdx === -1) return { base: parts.join('/') };
+  const platform = parts[platformIdx] as DevicePlatform;
+  const rest = parts.filter((_, i) => i !== platformIdx).join('/');
+  return { base: rest, platform };
+}
+
+export interface HandlerHostResolution {
+  /** Resolved execution host, or undefined to run locally. */
+  host?: string;
+  /** Strategy that should be set on the JobConfig. */
+  hostStrategy?: 'host' | 'fleet';
+}
+
+/**
+ * Resolve a handler `host` expression to a concrete host or local execution.
+ *
+ * - Specific device name (e.g. `yosemite-s0`) → run there over SSH, or locally
+ *   if it names this machine.
+ * - `fleet` → pick any online worker device.
+ * - `fleet/<platform>` or `<platform>/fleet` (e.g. `fleet/linux`, `linux/fleet`)
+ *   → pick any online worker on that platform. `linux` alone is accepted as a
+ *   shorthand for `fleet/linux`.
+ */
+export function resolveHandlerHost(host: string | undefined): HandlerHostResolution {
+  if (!host || host.trim() === '') return {};
+  const { base, platform } = parseHostPlatform(host);
+  const isFleet = base === '' || base === 'fleet';
+  if (isFleet) {
+    const picked = pickFleetDevice(undefined, platform);
+    if (!picked) {
+      throw new Error(`handler host '${host}': no eligible online fleet device`);
+    }
+    if (normalizeHost(picked) === machineId()) return {};
+    return { host: picked, hostStrategy: 'host' };
+  }
+  if (normalizeHost(base) === machineId()) return {};
+  return { host: base, hostStrategy: 'host' };
 }
 
 /**
@@ -347,6 +403,11 @@ async function executeHandlerAction(
   opts: ExecuteHandlerOptions,
 ): Promise<Omit<FiredHandler, 'handlerName'>> {
   const substitutedPrompt = handler.run?.prompt ? substituteWebhookPrompt(handler.run.prompt, context) : '';
+  const hostResolution = resolveHandlerHost(handler.host);
+  const hostFields = {
+    ...(hostResolution.host ? { host: hostResolution.host } : {}),
+    ...(hostResolution.hostStrategy ? { hostStrategy: hostResolution.hostStrategy } : {}),
+  };
 
   if (handler.run?.agent || handler.run?.workflow) {
     const config: JobConfig = {
@@ -359,6 +420,7 @@ async function executeHandlerAction(
       ...(handler.run.agent ? { agent: handler.run.agent } : { workflow: handler.run.workflow! }),
       ...(handler.devices ? { devices: handler.devices } : {}),
       ...(handler.run.env ? { env: handler.run.env } : {}),
+      ...hostFields,
     };
     const dispatch = handler.run.agent
       ? (opts.dispatchAgent ?? dispatchDefault)
@@ -381,6 +443,7 @@ async function executeHandlerAction(
       ...routine,
       prompt: substituteWebhookPrompt(routine.prompt, context),
       ...(handler.devices ? { devices: handler.devices } : {}),
+      ...hostFields,
     };
     const dispatch = opts.dispatchRoutine ?? dispatchDefault;
     const meta = await dispatch(config);

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -4,7 +4,8 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
-import type { JobConfig, RunMeta } from '../routines.js';
+import * as yaml from 'yaml';
+import type { JobConfig, RunMeta, WebhookContext } from '../routines.js';
 import {
   matchJobsToWebhook,
   jobMatchesWebhook,
@@ -80,9 +81,13 @@ function linearIssueWebhook(labels: string[] = ['agent']): IncomingWebhook {
       webhookTimestamp: Date.now(),
       data: {
         identifier: 'RUSH-1459',
+        state: { name: 'Plan' },
         // Real Linear webhook shape: `data.labels` is a flat array of label
         // objects, NOT the `{ nodes: [...] }` GraphQL connection.
         labels: labels.map((name) => ({ id: `lbl-${name}`, name })),
+      },
+      updatedFrom: {
+        state: { name: 'Triage' },
       },
     },
   };
@@ -168,6 +173,22 @@ describe('matchJobsToWebhook', () => {
     });
     expect(jobMatchesWebhook(linear, linearIssueWebhook(['agent']))).toBe(true);
     expect(jobMatchesWebhook(linear, linearIssueWebhook(['triage']))).toBe(false);
+  });
+
+  it('matches Linear stateTo and stateFrom filters', () => {
+    const linear = job({
+      name: 'linear-state',
+      trigger: { type: 'linear_event', event: 'Issue', action: 'update', stateTo: 'Plan', stateFrom: 'Triage' },
+    });
+    expect(jobMatchesWebhook(linear, linearIssueWebhook(['agent']))).toBe(true);
+
+    const wrongTo = linearIssueWebhook(['agent']);
+    (wrongTo.payload.data as Record<string, unknown>).state = { name: 'Done' };
+    expect(jobMatchesWebhook(linear, wrongTo)).toBe(false);
+
+    const wrongFrom = linearIssueWebhook(['agent']);
+    wrongFrom.payload.updatedFrom = { state: { name: 'Backlog' } };
+    expect(jobMatchesWebhook(linear, wrongFrom)).toBe(false);
   });
 
   it('reads labels from the flat webhook array, not a {nodes} connection', () => {
@@ -258,6 +279,41 @@ describe('fireWebhookJobs', () => {
 
     expect(dispatched).toEqual(['pr-job']);
     expect(fired).toEqual([{ jobName: 'pr-job', runId: 'run-pr-job' }]);
+  });
+
+  it('substitutes {{...}} placeholders when a webhook context is provided', async () => {
+    const linearJob = job({
+      name: 'linear-plan',
+      trigger: { type: 'linear_event', event: 'Issue', action: 'update' },
+      prompt: 'Issue {{issue.identifier}} moved to {{issue.state.name}}.',
+    });
+    const dispatched: JobConfig[] = [];
+    const dispatch = async (config: JobConfig): Promise<RunMeta> => {
+      dispatched.push(config);
+      return {
+        jobName: config.name,
+        runId: 'run-1',
+        agent: config.agent,
+        pid: 1,
+        status: 'running',
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        exitCode: null,
+      };
+    };
+    const webhook = linearIssueWebhook(['agent']);
+    await fireWebhookJobs(webhook, {
+      jobs: [linearJob],
+      dispatch,
+      context: {
+        source: 'linear',
+        event: 'Issue',
+        action: 'update',
+        issue: webhook.payload.data,
+        updatedFrom: webhook.payload.updatedFrom,
+      },
+    });
+    expect(dispatched[0].prompt).toBe('Issue RUSH-1459 moved to Plan.');
   });
 });
 
@@ -601,6 +657,73 @@ describe('startWebhookServer', () => {
       expect(status).toBe(413);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('fires matching handlers alongside routines', async () => {
+    const secret = 'linear-secret';
+    const webhookDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webhook-handlers-'));
+    process.env.AGENTS_WEBHOOKS_DIR = webhookDir;
+    try {
+      fs.mkdirSync(path.join(webhookDir), { recursive: true });
+      fs.writeFileSync(
+        path.join(webhookDir, 'linear-agent.yml'),
+        yaml.stringify({
+          name: 'linear-agent',
+          source: 'linear',
+          event: 'Issue',
+          action: 'update',
+          run: { command: 'echo {{issue.identifier}}' },
+        }),
+        'utf-8',
+      );
+
+      const server = startWebhookServer({
+        secrets: { linear: secret },
+        fire: { jobs: [], dispatch: async (): Promise<RunMeta> => { throw new Error('should not dispatch routine'); } },
+      });
+      await new Promise<void>((resolve) => server.once('listening', resolve));
+      const address = server.address();
+      if (!address || typeof address !== 'object') throw new Error('server did not bind');
+      try {
+        const payload = Buffer.from(JSON.stringify(linearIssueWebhook(['agent']).payload));
+        const sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+        const body = await new Promise<{ status: number; parsed: Record<string, unknown> }>((resolve, reject) => {
+          const req = http.request({
+            host: '127.0.0.1',
+            port: address.port,
+            path: '/hooks/linear',
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              'content-length': String(payload.length),
+              'linear-signature': sig,
+              'linear-delivery': 'delivery-handler-1',
+            },
+          }, (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (c) => chunks.push(c as Buffer));
+            res.on('end', () => resolve({
+              status: res.statusCode ?? 0,
+              parsed: JSON.parse(Buffer.concat(chunks).toString('utf-8')),
+            }));
+          });
+          req.on('error', reject);
+          req.end(payload);
+        });
+
+        expect(body.status).toBe(200);
+        const handlers = body.parsed.handlers as Array<{ handlerName: string; exitCode?: number; output?: string }>;
+        expect(handlers).toHaveLength(1);
+        expect(handlers[0].handlerName).toBe('linear-agent');
+        expect(handlers[0].exitCode).toBe(0);
+        expect(handlers[0].output).toContain('RUSH-1459');
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    } finally {
+      delete process.env.AGENTS_WEBHOOKS_DIR;
+      fs.rmSync(webhookDir, { recursive: true, force: true });
     }
   });
 });

--- a/apps/cli/src/lib/triggers/webhook.ts
+++ b/apps/cli/src/lib/triggers/webhook.ts
@@ -22,9 +22,18 @@ import type {
   JobConfig,
   LinearJobTrigger,
   RunMeta,
+  WebhookContext,
 } from '../routines.js';
-import { jobRunsOnThisDevice, listJobs } from '../routines.js';
+import { jobRunsOnThisDevice, listJobs, substituteWebhookPrompt } from '../routines.js';
 import { executeJobDetached } from '../runner.js';
+import { emit } from '../events.js';
+import {
+  listHandlers,
+  handlerMatchesWebhook,
+  executeHandler,
+  buildWebhookContext,
+  type FiredHandler,
+} from './handlers.js';
 
 export type WebhookSource = 'github' | 'linear';
 
@@ -88,11 +97,11 @@ export function webhookBranches(event: string, payload: Record<string, unknown>)
   return [...branches];
 }
 
-function linearAction(payload: Record<string, unknown>): string | null {
+export function linearAction(payload: Record<string, unknown>): string | null {
   return typeof payload.action === 'string' ? payload.action : null;
 }
 
-function linearTeamKey(payload: Record<string, unknown>): string | null {
+export function linearTeamKey(payload: Record<string, unknown>): string | null {
   const data = payload.data as Record<string, unknown> | undefined;
   const identifier = data?.identifier;
   if (typeof identifier === 'string') {
@@ -103,7 +112,7 @@ function linearTeamKey(payload: Record<string, unknown>): string | null {
   return typeof team?.key === 'string' ? team.key : null;
 }
 
-function linearLabels(payload: Record<string, unknown>): string[] {
+export function linearLabels(payload: Record<string, unknown>): string[] {
   // Linear webhook bodies flatten list relations: an Issue event carries
   // `data.labels` as a flat array of label objects (`[{ id, name, color }]`),
   // NOT the `{ nodes: [...] }` connection shape returned by the GraphQL API.
@@ -115,11 +124,11 @@ function linearLabels(payload: Record<string, unknown>): string[] {
     .filter((n): n is string => typeof n === 'string' && n.length > 0);
 }
 
-function githubAction(payload: Record<string, unknown>): string | null {
+export function githubAction(payload: Record<string, unknown>): string | null {
   return typeof payload.action === 'string' ? payload.action : null;
 }
 
-function githubLabels(payload: Record<string, unknown>): string[] {
+export function githubLabels(payload: Record<string, unknown>): string[] {
   const names = new Set<string>();
   const add = (value: unknown) => {
     if (typeof value === 'string' && value.length > 0) names.add(value);
@@ -175,6 +184,16 @@ function linearTriggerMatches(trigger: LinearJobTrigger, webhook: IncomingWebhoo
     const expected = trigger.label.toLowerCase();
     if (!linearLabels(webhook.payload).some((name) => name.toLowerCase() === expected)) return false;
   }
+  if (trigger.stateTo) {
+    const data = webhook.payload.data as Record<string, unknown> | undefined;
+    const current = (data?.state as Record<string, unknown> | undefined)?.name;
+    if (current !== trigger.stateTo) return false;
+  }
+  if (trigger.stateFrom) {
+    const updatedFrom = webhook.payload.updatedFrom as Record<string, unknown> | undefined;
+    const previous = (updatedFrom?.state as Record<string, unknown> | undefined)?.name;
+    if (previous !== trigger.stateFrom) return false;
+  }
   return true;
 }
 
@@ -210,6 +229,8 @@ export interface FireWebhookOptions {
   skipJobNames?: ReadonlySet<string>;
   /** Called immediately after a single matched job dispatch succeeds. */
   onJobFired?: (job: JobConfig, fired: FiredJob) => void;
+  /** Optional webhook context used to expand `{{...}}` placeholders in prompts. */
+  context?: WebhookContext;
 }
 
 /** Result of firing one matched job. */
@@ -246,8 +267,12 @@ export async function fireWebhookJobs(
   const failures: { jobName: string; error: Error }[] = [];
   for (const job of matched) {
     if (skipJobNames.has(job.name)) continue;
+    emit('webhook.matched', { source: webhook.source, event: webhook.event, jobName: job.name });
     try {
-      const meta = await dispatch(job);
+      const jobToDispatch = options.context
+        ? { ...job, prompt: substituteWebhookPrompt(job.prompt, options.context) }
+        : job;
+      const meta = await dispatch(jobToDispatch);
       const firedJob = { jobName: job.name, runId: meta.runId };
       fired.push(firedJob);
       options.onJobFired?.(job, firedJob);
@@ -490,7 +515,7 @@ export interface WebhookServerOptions {
   /** Override the fire options (mainly for tests). */
   fire?: FireWebhookOptions;
   /** Called after each delivery is handled (mainly for tests/observability). */
-  onDelivery?: (webhook: IncomingWebhook, fired: FiredJob[]) => void;
+  onDelivery?: (webhook: IncomingWebhook, fired: FiredJob[], handlers: FiredHandler[]) => void;
   deliveryStore?: DeliveryStore;
   rateLimiter?: RateLimiter;
   rateLimitPerMinute?: number;
@@ -533,6 +558,7 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
 
       const secret = options.secrets[source];
       if (!secret) {
+        emit('webhook.rejected', { source, reason: 'missing webhook secret' });
         res.writeHead(503, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ ok: false, error: `missing ${source} webhook secret` }));
         return;
@@ -545,12 +571,14 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
       // shed this load on its own.
       const ip = req.socket.remoteAddress ?? 'unknown';
       if (!ipRateLimiter.take(ip)) {
+        emit('webhook.rejected', { source, reason: 'ip rate limit exceeded' });
         res.writeHead(429, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ ok: false, error: 'rate limit exceeded' }));
         return;
       }
       const declaredLength = Number.parseInt(header(req.headers, 'content-length') ?? '', 10);
       if (Number.isFinite(declaredLength) && declaredLength > maxBodyBytes) {
+        emit('webhook.rejected', { source, reason: 'payload too large' });
         res.writeHead(413, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ ok: false, error: `payload exceeds ${maxBodyBytes} bytes` }));
         return;
@@ -562,12 +590,16 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
           ? verifyGithubSignature(req.headers, rawBody, secret)
           : verifyLinearSignature(req.headers, rawBody, secret);
         if (!valid) {
+          emit('webhook.rejected', { source, reason: 'invalid signature' });
           res.writeHead(401, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ ok: false, error: 'invalid signature' }));
           return;
         }
 
         const id = deliveryId(source, req.headers, rawBody);
+        const event = source === 'github' ? (header(req.headers, 'x-github-event') ?? '') : '';
+        emit('webhook.received', { source, event, deliveryId: id });
+
         if (deliveryStore.seen(id)) {
           res.writeHead(200, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ ok: true, duplicate: true, fired: [] }));
@@ -575,13 +607,16 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
         }
 
         const payload = rawBody.length > 0 ? JSON.parse(rawBody.toString('utf-8')) as Record<string, unknown> : {};
+        const webhookEvent = source === 'github' ? event : String(payload.type ?? '');
         if (source === 'linear' && !verifyLinearTimestamp(payload)) {
+          emit('webhook.rejected', { source, event: webhookEvent, deliveryId: id, reason: 'stale linear webhook timestamp' });
           res.writeHead(401, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ ok: false, error: 'stale linear webhook timestamp' }));
           return;
         }
 
         if (!rateLimiter.take(source)) {
+          emit('webhook.rejected', { source, event: webhookEvent, deliveryId: id, reason: 'rate limit exceeded' });
           res.writeHead(429, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ ok: false, error: 'rate limit exceeded' }));
           return;
@@ -589,22 +624,52 @@ export function startWebhookServer(options: WebhookServerOptions): http.Server {
 
         const webhook: IncomingWebhook = {
           source,
-          event: source === 'github' ? (header(req.headers, 'x-github-event') ?? '') : String(payload.type ?? ''),
+          event: webhookEvent,
           payload,
         };
+        emit('webhook.authorized', { source, event: webhookEvent, deliveryId: id });
+        const context = buildWebhookContext(webhook);
+
         const fireOptions = options.fire ?? {};
-        const fired = await fireWebhookJobs(webhook, {
+        const firedJobs = await fireWebhookJobs(webhook, {
           ...fireOptions,
+          context,
           skipJobNames: deliveryStore.completedJobs(id),
           onJobFired: (job, firedJob) => {
+            emit('webhook.fired', { source, event: webhookEvent, deliveryId: id, jobName: job.name, runId: firedJob.runId });
             deliveryStore.markJob(id, job.name);
             fireOptions.onJobFired?.(job, firedJob);
           },
         });
+
+        const handlers = listHandlers();
+        const matchedHandlers = handlers.filter((handler) => handlerMatchesWebhook(handler, webhook));
+        const firedHandlers: FiredHandler[] = [];
+        const handlerErrors: { handlerName: string; error: string }[] = [];
+        await Promise.allSettled(
+          matchedHandlers.map(async (handler) => {
+            if (deliveryStore.completedJobs(id).has(handler.name)) return;
+            emit('webhook.matched', { source, event: webhookEvent, deliveryId: id, handlerName: handler.name });
+            try {
+              const result = await executeHandler(handler, webhook);
+              deliveryStore.markJob(id, handler.name);
+              firedHandlers.push(result);
+            } catch (err) {
+              handlerErrors.push({ handlerName: handler.name, error: (err as Error).message });
+            }
+          }),
+        );
+
         deliveryStore.mark(id);
-        options.onDelivery?.(webhook, fired);
+        options.onDelivery?.(webhook, firedJobs, firedHandlers);
         res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, fired: fired.map((f) => f.jobName), runs: fired }));
+        res.end(JSON.stringify({
+          ok: true,
+          fired: firedJobs.map((f) => f.jobName),
+          runs: firedJobs,
+          handlers: firedHandlers,
+          ...(handlerErrors.length > 0 ? { handlerErrors } : {}),
+        }));
       } catch (err) {
         res.writeHead(400, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ ok: false, error: (err as Error).message }));


### PR DESCRIPTION
## Summary

Adds a one-off webhook handler layer that complements routine triggers. Handlers live in `~/.agents/webhooks/*.yml`, match incoming signed GitHub/Linear webhooks, and dispatch an agent/workflow/command or delegate to a routine once.

Also wires `run.env` through handler and routine runs so a sandboxed process can see tools that need the real user home (e.g. the `linear` CLI reading `~/.linear-cli/config.json`).

## What's new

- `apps/cli/src/lib/triggers/handlers.ts` — handler loading, matching, and execution.
- `apps/cli/src/lib/triggers/webhook.ts` — integrates handlers into the webhook receiver and emits `webhook.*` audit events.
- `apps/cli/src/lib/routines.ts` — Linear triggers gain `stateTo`/`stateFrom` and `{{...}}` prompt substitution.
- `apps/cli/src/commands/routines.ts` — `--state-to`/`--state-from` CLI flags.
- `apps/cli/src/lib/events.ts` — `webhook.*` event types.
- `apps/cli/src/lib/runner.ts` — applies `config.env` on top of the sandbox env.
- Tests, docs (`apps/cli/docs/03-routines.md`), and CHANGELOG entry.

## Verification

- Unit tests: `handlers.test.ts` (17), `webhook.test.ts` (27), `routines.test.ts` (68) all pass.
- Simulated signed Linear webhook delivered to `https://yosemite-s0.tail1a85a1.ts.net/hooks/linear`:
  - HMAC verified, handler `linear-status-planner` matched, Claude dispatched.
  - Agent rendered the prompt, posted a plan comment on **RUSH-2103**, and moved the issue to **Plan**.

## Live webhook gap

Creating a real Linear webhook requires an API token with the `admin` scope; the existing token errors with `FORBIDDEN: Invalid scope: admin required`. Once a webhook is created in Linear pointing to the funnel URL with the signing secret stored in the `webhooks` bundle, moving any issue Todo → Plan will fire the handler for real.

Webhook setup:
- URL: `https://yosemite-s0.tail1a85a1.ts.net/hooks/linear`
- Secret: stored in `webhooks` bundle as `LINEAR_WEBHOOK_SECRET` on `yosemite-s0`
- Receiver: `agents webhook serve --secrets-bundle webhooks --port 8787` on `yosemite-s0`
- Ingress: Tailscale Funnel on `yosemite-s0`
