### PR TITLE
fix(menubar): one status item, always — plus `agents menubar setup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,9 +1002,15 @@ Other useful commands: `agents doctor` checks CLI availability and resource sync
 On macOS, `agents-cli` puts a status item in your menu bar -- a live glance at what your agents are doing, plus a Spotlight-style bar for filing work without breaking focus.
 
 ```bash
-agents menubar enable      # install + launch at login
+agents menubar setup       # configure end-to-end: one instance, started at login
 agents menubar status      # is it installed and running?
 ```
+
+There is only ever **one** agents mark: the helper takes a lock at launch, so a
+second copy surfaces the running one's menu and exits instead of adding a
+duplicate icon. `agents menubar setup` is the recovery command when a machine is
+already wrong -- it ends any duplicate, installs the bundle, wires the login
+item, and verifies exactly one helper came back up.
 
 The dropdown surfaces a **NEEDS YOU** queue (agents waiting on a question, a plan review, or a permission prompt), the running roster, and a routines summary -- the same live state as `agents sessions --active`, one click away.
 

--- a/apps/cli/.changelog/next/menubar-single-instance.md
+++ b/apps/cli/.changelog/next/menubar-single-instance.md
@@ -1,0 +1,31 @@
+- **The menu bar is a single instance, always.** Two copies of the helper could
+  run at once — launchd's `KeepAlive` service plus a LaunchServices/`open` launch
+  of the same `.app` — putting two agents marks in the menu bar, and the second
+  copy could hold `Cmd-Shift-V`/`Cmd-Shift-O` (`RegisterEventHotKey` is
+  first-come). The helper now takes an `flock` on
+  `~/.agents/.cache/state/menubar.lock` at launch and holds it for its lifetime;
+  a helper that cannot take the lock pops the **running** helper's menu open and
+  exits 0, since re-launching a menu-bar app means "show me the one I already
+  have". An `flock` rather than a pid file: the kernel releases it when the
+  holder dies, so a `SIGKILL`ed helper cannot leave a stale "already running"
+  that blocks every later launch. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift`,
+  `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`.
+
+- **`agents menubar setup` configures the menu bar end-to-end.** One idempotent
+  command for a machine that is wrong — never configured, helper down, or showing
+  a duplicate icon. It ends every running helper, installs/refreshes the bundle,
+  checks its code signature, writes the launchd login item (`RunAtLoad` +
+  `KeepAlive`), clears a previous `agents menubar disable`, and verifies exactly
+  one helper came back up — reporting each as its own step and exiting nonzero if
+  it cannot reach that state. `--check` reports without changing; `--json` emits
+  the step list. Source: `apps/cli/src/commands/menubar.ts`,
+  `apps/cli/src/lib/menubar/install-menubar.ts`.
+
+- **`agents menubar status` now shows a duplicate.** Live helper processes were
+  collapsed to a boolean `running`, so two copies of the *installed* bundle — the
+  duplicate a user actually sees — reported as healthy. `--json` now carries an
+  `instances` array (copies of the installed bundle) beside the existing
+  `foreignInstances`, and the text readout names every extra pid and points at
+  `agents menubar setup`. Source:
+  `apps/cli/src/lib/menubar/install-menubar.ts` (`classifyMenubarProcesses`).

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -436,6 +436,21 @@ grant). Keep it a **separate bundle** from the keychain app — a menu-bar crash
 never take down the secret broker. Stage a freshly-built `bin/MenubarHelper.app`
 before any release or the menu bar ships code-only (the 1.20.22 bug the gate prevents).
 
+**Exactly one status item is an invariant, enforced in the helper.** The bundle
+can be started from more than one place — launchd's `KeepAlive` service, a
+LaunchServices/`open` launch, a second `agents menubar enable` — so the helper
+takes an `flock` on `~/.agents/.cache/state/menubar.lock` at launch
+([`SingleInstance.swift`](menubar/Sources/MenubarHelper/SingleInstance.swift)) and
+holds the descriptor for its lifetime; a loser surfaces the incumbent's menu and
+exits 0. Do NOT re-derive liveness from a pid file or a `ps` scan — the kernel
+releases an `flock` however the holder dies, which a pid cannot express, and a
+process list cannot say which copy launchd will keep alive. On the CLI side,
+`classifyMenubarProcesses` returns live copies of the installed bundle as a LIST
+(`own`), never a boolean: collapsing them is what let a duplicate icon read as a
+healthy `running: yes`. `agents menubar setup` is the recovery path — it ends
+every live helper and re-kickstarts the service so the survivor is always
+launchd's.
+
 **Standalone `agents` binary (#315).** Every release also builds `dist/bin/agents`
 (`bun build --compile`, arm64 Mach-O), signs it (Developer ID + hardened runtime +
 the JIT entitlement in `scripts/bun-jit-entitlements.plist` — bun's JavaScriptCore

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 1.20.89
+
+- **The menu bar is a single instance, always.** Two copies of the helper could
+  run at once — launchd's `KeepAlive` service plus a LaunchServices/`open` launch
+  of the same `.app` — putting two agents marks in the menu bar, and the second
+  copy could hold `Cmd-Shift-V`/`Cmd-Shift-O` (`RegisterEventHotKey` is
+  first-come). The helper now takes an `flock` on
+  `~/.agents/.cache/state/menubar.lock` at launch and holds it for its lifetime;
+  a helper that cannot take the lock pops the **running** helper's menu open and
+  exits 0, since re-launching a menu-bar app means "show me the one I already
+  have". An `flock` rather than a pid file: the kernel releases it when the
+  holder dies, so a `SIGKILL`ed helper cannot leave a stale "already running"
+  that blocks every later launch. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift`,
+  `StatusItemController.surface()`.
+
+- **`agents menubar setup` configures the menu bar end-to-end.** One idempotent
+  command for a machine that is wrong — never configured, helper down, or showing
+  a duplicate icon. It ends every running helper, installs/refreshes the bundle,
+  checks its code signature, writes the launchd login item (`RunAtLoad` +
+  `KeepAlive`), clears a previous `agents menubar disable`, and verifies exactly
+  one helper came back up — reporting each as its own step and exiting nonzero if
+  it cannot reach that state. `--check` reports without changing; `--json` emits
+  the step list. Source: `apps/cli/src/commands/menubar.ts`,
+  `apps/cli/src/lib/menubar/install-menubar.ts`.
+
+- **`agents menubar status` now shows a duplicate.** Live helper processes were
+  collapsed to a boolean `running`, so two copies of the *installed* bundle — the
+  duplicate a user actually sees — reported as healthy. `--json` now carries an
+  `instances` array (copies of the installed bundle) beside the existing
+  `foreignInstances`, and the text readout names every extra pid and points at
+  `agents menubar setup`. Source:
+  `apps/cli/src/lib/menubar/install-menubar.ts` (`classifyMenubarProcesses`).
+
 ## 1.20.88
 
 - **`agents doctor` redesigned into a prioritized, fleet-aware, per-version

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,39 +1,5 @@
 # Changelog
 
-## 1.20.89
-
-- **The menu bar is a single instance, always.** Two copies of the helper could
-  run at once — launchd's `KeepAlive` service plus a LaunchServices/`open` launch
-  of the same `.app` — putting two agents marks in the menu bar, and the second
-  copy could hold `Cmd-Shift-V`/`Cmd-Shift-O` (`RegisterEventHotKey` is
-  first-come). The helper now takes an `flock` on
-  `~/.agents/.cache/state/menubar.lock` at launch and holds it for its lifetime;
-  a helper that cannot take the lock pops the **running** helper's menu open and
-  exits 0, since re-launching a menu-bar app means "show me the one I already
-  have". An `flock` rather than a pid file: the kernel releases it when the
-  holder dies, so a `SIGKILL`ed helper cannot leave a stale "already running"
-  that blocks every later launch. Source:
-  `apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift`,
-  `StatusItemController.surface()`.
-
-- **`agents menubar setup` configures the menu bar end-to-end.** One idempotent
-  command for a machine that is wrong — never configured, helper down, or showing
-  a duplicate icon. It ends every running helper, installs/refreshes the bundle,
-  checks its code signature, writes the launchd login item (`RunAtLoad` +
-  `KeepAlive`), clears a previous `agents menubar disable`, and verifies exactly
-  one helper came back up — reporting each as its own step and exiting nonzero if
-  it cannot reach that state. `--check` reports without changing; `--json` emits
-  the step list. Source: `apps/cli/src/commands/menubar.ts`,
-  `apps/cli/src/lib/menubar/install-menubar.ts`.
-
-- **`agents menubar status` now shows a duplicate.** Live helper processes were
-  collapsed to a boolean `running`, so two copies of the *installed* bundle — the
-  duplicate a user actually sees — reported as healthy. `--json` now carries an
-  `instances` array (copies of the installed bundle) beside the existing
-  `foreignInstances`, and the text readout names every extra pid and points at
-  `agents menubar setup`. Source:
-  `apps/cli/src/lib/menubar/install-menubar.ts` (`classifyMenubarProcesses`).
-
 ## 1.20.88
 
 - **`agents doctor` redesigned into a prioritized, fleet-aware, per-version

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -71,7 +71,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Browser](browser.md) | Drive Chrome / Brave / Edge / Electron via CDP. Profiles, screenshots, click/type/evaluate, remote endpoints. |
 | [PTY](pty.md) | Persistent pseudo-terminals for REPLs and TUIs — start, exec, screen-snapshot, signal. |
 | [Computer](computer.md) | macOS Accessibility automation — screenshot the active app, click by label. |
-| [Menu bar](menubar.md) | macOS status item — live sessions, agents awaiting input, routines, + new session. Auto-enabled; `agents menubar enable/disable/status`. |
+| [Menu bar](menubar.md) | macOS status item — live sessions, agents awaiting input, routines, + new session. Auto-enabled, always exactly one instance; `agents menubar setup/enable/disable/status`. |
 | [Terminal engine](terminal-engine.md) | Open a command as a tab or split pane in iTerm / Ghostty / tmux, local or over `--host`. Powers `sessions resume`. |
 
 ---

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -162,19 +162,75 @@ when sessions are running; otherwise it is the bare mark.
 
 ```
 agents menubar            # status (also: agents menubar status)
+agents menubar setup      # configure end-to-end: one instance, started at login
 agents menubar enable     # install + start the launchd login service
 agents menubar disable    # stop + remove it (sticky opt-out)
 agents menubar status     # installed / running, versions, staleness; --json
 ```
 
+`setup` is the command to reach for when the menu bar is wrong — a duplicate
+icon, a helper that did not come up, a machine that was never configured. It is
+idempotent, and each concern is a reported step, so a partial failure names
+itself instead of hiding behind "enabled":
+
+```
+$ agents menubar setup
+Menu bar setup
+
+  + duplicates      ended 2 running helpers (93048, 97417) — launchd restarts exactly one
+  ✓ bundle          /Users/me/Library/Application Support/agents-cli/MenubarHelper.app (1.20.89)
+  ✓ signature       valid
+  ✓ login item      com.phnx-labs.agents-menubar — starts at login, restarts if it dies
+  ✓ single instance pid 98566
+
+Menu bar configured.  One agents mark, started at login.
+```
+
+It ends **every** live helper and lets launchd restart one, so the survivor is
+always the login-managed copy — picking a survivor out of a process list cannot
+guarantee that, and keeping the un-managed copy would re-create the duplicate at
+the next login. It also clears a previous `agents menubar disable`, and exits
+nonzero if it cannot reach the one-instance end state. `--check` reports the
+current state without changing anything; `--json` emits the step list.
+
 `status` reports the installed bundle version vs. the current CLI version and
-whether the install is stale (see [Lifecycle](#lifecycle)). `running` tracks the
-**installed bundle** specifically, identified by its resolved executable; any
-other live `MenubarHelper` process is listed separately with its pid
-(`foreignInstances` in `--json`). `RegisterEventHotKey` is first-come, so a
-second copy may be the one holding the global chords — which of the two won is
-not answerable from a process list, so status reports the conflict rather than a
-winner. See [Do not hand-launch the helper](#do-not-hand-launch-the-helper).
+whether the install is stale (see [Lifecycle](#lifecycle)). Live helper processes
+are split two ways in `--json`: `instances` are copies of the **installed
+bundle**, identified by resolved executable, and `foreignInstances` is every
+other `MenubarHelper` process. **More than one entry in `instances` is the
+duplicate menu-bar icon** — see [One instance, always](#one-instance-always).
+`RegisterEventHotKey` is first-come, so a second copy may be the one holding the
+global chords — which of the two won is not answerable from a process list, so
+status reports the conflict rather than a winner. See
+[Do not hand-launch the helper](#do-not-hand-launch-the-helper).
+
+## One instance, always
+
+The helper refuses to be the second status item. At launch it takes an
+`flock(2)` on `~/.agents/.cache/state/menubar.lock` and holds the descriptor for
+its whole life; a helper that cannot take the lock posts a distributed
+notification that pops the **running** helper's menu open, then exits 0:
+
+```
+$ "…/MenubarHelper.app/Contents/MacOS/MenubarHelper"
+MenubarHelper: already running (pid 6815) — surfaced it instead of adding a second status item.
+```
+
+Re-launching a menu-bar app means "show me the one I already have", so
+surfacing the incumbent is the answer, and exiting 0 keeps launchd's `KeepAlive`
+from reading the surrender as a crash.
+
+An `flock` rather than a pid file: a helper `SIGKILL`ed by the code-signing
+monitor leaves its pid behind, and every later launch would then read a stale
+"already running" and never start. The kernel releases an `flock` when the holder
+dies however it dies, so the state cannot go stale.
+
+Two copies of the installed bundle used to be reachable through ordinary paths —
+launchd's `KeepAlive` service plus a LaunchServices/`open` launch of the same
+`.app` (a Finder open, a re-open after a crash, a second `agents menubar
+enable`). Both ran the same executable, so status collapsed them to a healthy
+`running: yes` while the user looked at two agents marks. Both halves are fixed:
+the helper can no longer become the second, and `status` now lists every copy.
 
 ## Data sources
 
@@ -210,7 +266,12 @@ The helper is a launchd user service (`com.phnx-labs.agents-menubar`,
 - **Opt-out is sticky.** `agents menubar disable` writes
   `~/.agents/.cache/state/menubar.disabled`; the auto-enable honors it, so a
   disabled menu bar never silently returns on the next upgrade. Re-enable with
-  `agents menubar enable`.
+  `agents menubar setup` (or `agents menubar enable`), either of which clears the
+  sentinel.
+- **Recovery is one command.** When any of the above has gone wrong on a
+  machine — never configured, helper down, duplicate icon —
+  `agents menubar setup` re-establishes the whole intended state and says which
+  parts it had to change.
 
 ## Notifications
 

--- a/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Guards.swift
@@ -60,6 +60,7 @@ enum Guards {
 
             every other mode is env-gated:
               MENUBAR_BENCH=1  MENUBAR_CLIP_TEST=1  MENUBAR_ISSUE_TEST=1  MENUBAR_GUARD_TEST=1
+              MENUBAR_SINGLE_TEST=1
             """)
         }
 

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
@@ -76,11 +76,25 @@ enum SingleInstance {
         return Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
     }
 
+    /// `MENUBAR_DUMP=1` installs a status item, prints the menu, and exits
+    /// without running the app loop or registering the global chords — a
+    /// transient probe, not a second menu bar. It is the ONE mode that reaches
+    /// the interactive path (every other env-gated mode exits before Guards), so
+    /// without this exemption a diagnostic dump would surrender and print
+    /// nothing whenever the real helper is running: a silent no-op exactly where
+    /// someone is trying to diagnose.
+    static func isTransientProbe(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        environment["MENUBAR_DUMP"] == "1"
+    }
+
     /// Launch-time gate for the interactive mode. Returns only when this process
     /// is the single owner; otherwise asks the incumbent to show itself and
     /// exits 0 (a duplicate launch is a user asking to see the menu, not an
     /// error, so launchd's KeepAlive must not treat it as a crash).
     static func enforceOrSurface(path: String = lockPath()) {
+        if isTransientProbe() { return }
         switch acquire(path: path) {
         case .acquired:
             return

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+// Exactly one status item, ever.
+//
+// Nothing stopped a second helper from installing its own NSStatusItem, so the
+// menu bar showed the agents mark twice: launchd's KeepAlive copy plus anything
+// that started the bundle again (a Finder/`open` launch, a LaunchServices
+// re-open after a crash, a second `agents menubar enable` racing the first).
+// Both ran the SAME installed executable, so the process classifier saw no
+// "foreign" copy and status reported a healthy single instance while the user
+// looked at two icons — and the duplicate silently owned Cmd-Shift-V/O, since
+// RegisterEventHotKey is first-come.
+//
+// The lock is an flock(2) on a file the incumbent holds open for its whole life.
+// A pid file alone can't do this: a helper SIGKILLed by the code-signing monitor
+// leaves its pid behind and every later launch reads a stale "already running".
+// An flock is released by the kernel when the holder dies, however it dies, so
+// the state can never go stale.
+//
+// The loser does not just exit — it surfaces the incumbent (posts a distributed
+// notification that pops the running helper's menu open), which is what a user
+// who re-launched a menu-bar app actually wanted: show me the one that is
+// already there.
+enum SingleInstance {
+    /// Distributed notification that asks a running helper to open its menu.
+    /// Distributed (not local) because the sender is a different process.
+    static let surfaceNotification = Notification.Name("com.phnx-labs.agents-menubar.surface")
+
+    /// ~/.agents/.cache/state/menubar.lock — the same runtime state dir the CLI
+    /// uses (`getRuntimeStateDir()` in src/lib/state.ts).
+    static func lockPath(home: String = NSHomeDirectory()) -> String {
+        "\(home)/.agents/.cache/state/menubar.lock"
+    }
+
+    /// Held for the process lifetime. Never closed: closing the descriptor drops
+    /// the flock, which would let a second helper in while this one still owns a
+    /// status item.
+    private static var lockDescriptor: Int32 = -1
+
+    /// Outcome of the launch-time contention check, split out so the decision is
+    /// testable without actually taking a lock.
+    enum Outcome: Equatable {
+        /// This process owns the status item.
+        case acquired
+        /// Another helper already owns it; surface that one and exit.
+        case alreadyRunning(pid: Int32)
+    }
+
+    /// Try to take the lock. Returns `.acquired` with the descriptor left open,
+    /// or `.alreadyRunning` carrying the incumbent's pid (0 when the pid file is
+    /// unreadable — the lock, not the pid, is what proves liveness).
+    static func acquire(path: String = lockPath()) -> Outcome {
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+
+        let fd = open(path, O_RDWR | O_CREAT, 0o644)
+        if fd < 0 {
+            // Can't create the lock file (read-only home, exotic sandbox). Fail
+            // OPEN: a helper that cannot lock is better than no menu bar at all.
+            return .acquired
+        }
+        if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            let incumbent = readPid(path: path)
+            close(fd)
+            return .alreadyRunning(pid: incumbent)
+        }
+        lockDescriptor = fd
+        ftruncate(fd, 0)
+        let pid = "\(ProcessInfo.processInfo.processIdentifier)\n"
+        _ = pid.withCString { write(fd, $0, strlen($0)) }
+        return .acquired
+    }
+
+    private static func readPid(path: String) -> Int32 {
+        guard let text = try? String(contentsOfFile: path, encoding: .utf8) else { return 0 }
+        return Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+    }
+
+    /// Launch-time gate for the interactive mode. Returns only when this process
+    /// is the single owner; otherwise asks the incumbent to show itself and
+    /// exits 0 (a duplicate launch is a user asking to see the menu, not an
+    /// error, so launchd's KeepAlive must not treat it as a crash).
+    static func enforceOrSurface(path: String = lockPath()) {
+        switch acquire(path: path) {
+        case .acquired:
+            return
+        case .alreadyRunning(let pid):
+            DistributedNotificationCenter.default().postNotificationName(
+                surfaceNotification, object: nil, userInfo: nil, deliverImmediately: true
+            )
+            let who = pid > 0 ? " (pid \(pid))" : ""
+            FileHandle.standardError.write(Data(
+                "MenubarHelper: already running\(who) — surfaced it instead of adding a second status item.\n".utf8
+            ))
+            exit(0)
+        }
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
@@ -16,6 +16,7 @@ enum SingleInstanceSelfTest {
         testSecondAcquireSurrenders()
         testLockReleasedWhenHolderDies()
         testLockPathIsRuntimeStateDir()
+        testDumpProbeIsExempt()
         if failures == 0 {
             print("\nALL PASS")
             exit(0)
@@ -74,6 +75,18 @@ enum SingleInstanceSelfTest {
     private static func testLockPathIsRuntimeStateDir() {
         check(SingleInstance.lockPath(home: "/Users/x") == "/Users/x/.agents/.cache/state/menubar.lock",
               "lock path -> ~/.agents/.cache/state/menubar.lock")
+    }
+
+    // MENUBAR_DUMP is the one mode that reaches the interactive path, and it
+    // exits without an app loop or chords. Gating it would turn a diagnostic
+    // dump into a silent surrender whenever the real helper is running.
+    private static func testDumpProbeIsExempt() {
+        check(SingleInstance.isTransientProbe(["MENUBAR_DUMP": "1"]),
+              "MENUBAR_DUMP=1 -> exempt from the singleton gate")
+        check(!SingleInstance.isTransientProbe([:]),
+              "ordinary launch -> gated")
+        check(!SingleInstance.isTransientProbe(["MENUBAR_DUMP": "0"]),
+              "MENUBAR_DUMP=0 -> gated")
     }
 
     private static func check(_ condition: Bool, _ label: String) {

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+// Self-test for the single-instance lock. Follows the repo's env-gated
+// self-test idiom (GuardsSelfTest.swift / IssueSelfTest.swift): no XCTest
+// target exists for the menu-bar helper. Takes REAL flocks on a real temp file
+// — the contention this guards against is a kernel behavior, so a fake would
+// prove nothing.
+//
+//   MENUBAR_SINGLE_TEST=1 MenubarHelper
+enum SingleInstanceSelfTest {
+    private static var failures = 0
+
+    static func run() -> Never {
+        print("menubar single-instance self-test")
+        testFirstAcquireWins()
+        testSecondAcquireSurrenders()
+        testLockReleasedWhenHolderDies()
+        testLockPathIsRuntimeStateDir()
+        if failures == 0 {
+            print("\nALL PASS")
+            exit(0)
+        }
+        print("\n\(failures) FAILED")
+        exit(1)
+    }
+
+    private static func tempLock(_ label: String) -> String {
+        let dir = NSTemporaryDirectory() + "menubar-single-test-\(label)-\(getpid())"
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir + "/menubar.lock"
+    }
+
+    // The launchd-started helper is the first in: it must own the status item.
+    private static func testFirstAcquireWins() {
+        let path = tempLock("first")
+        check(SingleInstance.acquire(path: path) == .acquired, "first acquire -> acquired")
+        let pid = (try? String(contentsOfFile: path, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        check(pid == "\(getpid())", "lock file records the holder pid (got \(pid ?? "nil"))")
+    }
+
+    // The duplicate launch — the bug: it used to install a second status item,
+    // so the mark appeared twice in the menu bar.
+    private static func testSecondAcquireSurrenders() {
+        let path = tempLock("second")
+        let fd = open(path, O_RDWR | O_CREAT, 0o644)
+        defer { close(fd) }
+        check(flock(fd, LOCK_EX | LOCK_NB) == 0, "incumbent holds the lock")
+        let holder = "4242\n"
+        _ = holder.withCString { write(fd, $0, strlen($0)) }
+
+        let outcome = SingleInstance.acquire(path: path)
+        check(outcome == .alreadyRunning(pid: 4242),
+              "second acquire -> alreadyRunning(4242) (got \(outcome))")
+    }
+
+    // Why an flock and not a pid file: a helper SIGKILLed by the code-signing
+    // monitor leaves its pid behind. The kernel drops the flock regardless, so
+    // the next launch must get in rather than read a stale "already running".
+    private static func testLockReleasedWhenHolderDies() {
+        let path = tempLock("stale")
+        let fd = open(path, O_RDWR | O_CREAT, 0o644)
+        _ = flock(fd, LOCK_EX | LOCK_NB)
+        let dead = "999999\n"
+        _ = dead.withCString { write(fd, $0, strlen($0)) }
+        close(fd)   // stands in for the holder dying: descriptor gone, pid still on disk
+
+        check(SingleInstance.acquire(path: path) == .acquired,
+              "stale pid file, no live holder -> acquired")
+    }
+
+    // Must match getRuntimeStateDir() in src/lib/state.ts — the CLI's
+    // `agents menubar setup` reports on the same file.
+    private static func testLockPathIsRuntimeStateDir() {
+        check(SingleInstance.lockPath(home: "/Users/x") == "/Users/x/.agents/.cache/state/menubar.lock",
+              "lock path -> ~/.agents/.cache/state/menubar.lock")
+    }
+
+    private static func check(_ condition: Bool, _ label: String) {
+        if condition {
+            print("  PASS  \(label)")
+        } else {
+            failures += 1
+            print("  FAIL  \(label)")
+        }
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -116,8 +116,17 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     /// Open this helper's menu. Called when a duplicate launch surrenders
     /// (SingleInstance) — re-launching a menu-bar app means "show me the one
     /// that is already running", so the incumbent answers by dropping its menu.
-    func surface() {
+    ///
+    /// @objc + NSObject because the observer must be registered with the
+    /// selector-based DistributedNotificationCenter API: only that overload
+    /// takes a suspensionBehavior, and this app is `.accessory` — never the
+    /// active app — so the default behavior queues the notification instead of
+    /// delivering it and the menu never opens.
+    @objc func surface() {
         guard let button = statusItem.button else { return }
+        // Logged: this is the one moment where a second launch changed what the
+        // user sees, and the launchd plist routes stderr to menubar.log.
+        FileHandle.standardError.write(Data("MenubarHelper: surfacing menu for a duplicate launch\n".utf8))
         NSApp.activate(ignoringOtherApps: true)
         button.performClick(nil)
     }

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -113,6 +113,15 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
+    /// Open this helper's menu. Called when a duplicate launch surrenders
+    /// (SingleInstance) — re-launching a menu-bar app means "show me the one
+    /// that is already running", so the incumbent answers by dropping its menu.
+    func surface() {
+        guard let button = statusItem.button else { return }
+        NSApp.activate(ignoringOtherApps: true)
+        button.performClick(nil)
+    }
+
     private func tick() {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let s = LocalState.sessions(includeTeams: false)

--- a/apps/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/main.swift
@@ -79,9 +79,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // A duplicate launch surrenders (SingleInstance) and posts this instead
         // of adding a second status item — so answering it by opening the menu
         // is what makes "launch it again" show the helper the user already has.
+        //
+        // .deliverImmediately is load-bearing, and only the selector-based
+        // overload accepts it: this app is `.accessory` and so never the active
+        // app, and the default suspension behavior queues a distributed
+        // notification for an inactive app rather than delivering it — the menu
+        // would simply never open.
         DistributedNotificationCenter.default().addObserver(
-            forName: SingleInstance.surfaceNotification, object: nil, queue: .main
-        ) { [weak controller] _ in controller?.surface() }
+            controller, selector: #selector(StatusItemController.surface),
+            name: SingleInstance.surfaceNotification, object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
         // Own notification click-through (RUSH-2030): the daemon posts branded
         // notifications via one-shot `--notify` processes, but this persistent
         // instance is the NSUserNotificationCenter delegate that opens their

--- a/apps/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/main.swift
@@ -48,11 +48,21 @@ if ProcessInfo.processInfo.environment["MENUBAR_GUARD_TEST"] == "1" {
     GuardsSelfTest.run()
 }
 
+// Single-instance self-test: take real flocks and assert the contention
+// outcomes that keep exactly one status item alive. See SingleInstance.swift.
+if ProcessInfo.processInfo.environment["MENUBAR_SINGLE_TEST"] == "1" {
+    SingleInstanceSelfTest.run()
+}
+
 // Everything past here installs the status item and registers the global
 // chords, so it must only run where those chords can actually be serviced.
 // Refuses an ssh-started launch or an unrecognized flag — the two ways a helper
 // that can never hold the Accessibility grant has ended up owning Cmd-Shift-V.
 Guards.enforceForInteractiveLaunch()
+
+// ...and only once. A second helper surfaces the running one's menu and exits
+// rather than installing a duplicate status item (see SingleInstance.swift).
+SingleInstance.enforceOrSurface()
 
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
@@ -66,6 +76,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let promptController = PromptPanelController()
     func applicationDidFinishLaunching(_ notification: Notification) {
         controller.install()
+        // A duplicate launch surrenders (SingleInstance) and posts this instead
+        // of adding a second status item — so answering it by opening the menu
+        // is what makes "launch it again" show the helper the user already has.
+        DistributedNotificationCenter.default().addObserver(
+            forName: SingleInstance.surfaceNotification, object: nil, queue: .main
+        ) { [weak controller] _ in controller?.surface() }
         // Own notification click-through (RUSH-2030): the daemon posts branded
         // notifications via one-shot `--notify` processes, but this persistent
         // instance is the NSUserNotificationCenter delegate that opens their

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -9,10 +9,14 @@
 
 import type { Command } from 'commander';
 import chalk from 'chalk';
+import { setHelpSections } from '../lib/help.js';
 import {
   enableMenubarService,
   disableMenubarService,
   getMenubarStatus,
+  runMenubarSetup,
+  type MenubarStatus,
+  type SetupResult,
 } from '../lib/menubar/install-menubar.js';
 
 function notMac(): boolean {
@@ -23,10 +27,119 @@ function notMac(): boolean {
   return false;
 }
 
+/** Shared status readout — `status`, bare `menubar`, and `setup --check` all end here. */
+function printStatus(s: MenubarStatus, opts: { brief?: boolean } = {}): void {
+  const yn = (b: boolean) => (b ? chalk.green('yes') : chalk.gray('no'));
+  console.log(chalk.bold('Menu bar helper\n'));
+  console.log(`  running            ${yn(s.running)}`);
+  console.log(`  service installed  ${yn(s.serviceInstalled)}`);
+  if (opts.brief) {
+    console.log(chalk.gray('\n  setup | enable | disable | status'));
+    return;
+  }
+  console.log(`  app installed      ${s.installedApp ? chalk.gray(s.installedApp) : chalk.gray('no')}`);
+  console.log(`  installed version  ${s.installedVersion ? chalk.gray(s.installedVersion) : chalk.gray('unknown')}`);
+  console.log(`  current version    ${chalk.gray(s.currentVersion)}`);
+  console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
+  console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
+
+  // Two copies of the INSTALLED bundle is the duplicate the user sees as two
+  // agents marks in the menu bar. It used to read as a healthy `running: yes`.
+  if (s.instances.length > 1) {
+    console.log(chalk.yellow(`\n  ${s.instances.length} copies of the installed helper are running — that is the duplicate menu-bar icon:`));
+    for (const p of s.instances) console.log(chalk.gray(`    ${p.pid}  ${p.executable}`));
+    console.log(chalk.gray('  Fix it with `agents menubar setup`.'));
+  }
+  if (s.foreignInstances.length > 0) {
+    // RegisterEventHotKey is first-come, so the helper that registered the
+    // chord first owns Cmd-Shift-V/O. A process list cannot say which that
+    // was — only that a rival exists — so report the conflict, not a winner.
+    // The loser has no other symptom: its chords simply never fire.
+    const n = s.foreignInstances.length;
+    console.log(chalk.yellow(`\n  ${n} other helper process${n === 1 ? '' : 'es'} running — ${n === 1 ? 'it' : 'they'} may hold Cmd-Shift-V/O instead of the installed one:`));
+    for (const p of s.foreignInstances) console.log(chalk.gray(`    ${p.pid}  ${p.executable}`));
+    console.log(chalk.gray('  End them with `agents menubar setup`.'));
+  }
+  if (s.stale) {
+    console.log(chalk.yellow('\n  Installed helper is stale — runs on next `agents` startup, or `agents menubar setup` now.'));
+  } else if (!s.serviceInstalled && !s.disabledByUser) {
+    console.log(chalk.gray('\n  Set it up with `agents menubar setup`.'));
+  }
+}
+
+function printSetupResult(r: SetupResult): void {
+  console.log(chalk.bold('Menu bar setup\n'));
+  for (const step of r.steps) {
+    const mark = step.outcome === 'failed' ? chalk.red('✗')
+      : step.outcome === 'changed' ? chalk.green('+') : chalk.green('✓');
+    console.log(`  ${mark} ${step.name.padEnd(15)} ${chalk.gray(step.detail)}`);
+  }
+  console.log();
+  if (r.configured) {
+    console.log(chalk.green('Menu bar configured.') + chalk.gray('  One agents mark, started at login.'));
+  } else {
+    console.log(chalk.red('Menu bar not fully configured.') + chalk.gray('  See the failed step above.'));
+  }
+}
+
 export function registerMenubarCommands(program: Command): void {
   const menubar = program
     .command('menubar')
     .description('Manage the macOS menu-bar helper (running sessions, agents awaiting input, routines)');
+
+  // `setup` is the one command that gets a machine to the intended state:
+  // exactly one status item, started at login. `enable` stays the narrow
+  // install+start; setup adds duplicate cleanup and verifies the end state.
+  const setup = menubar
+    .command('setup')
+    .description('Configure the menu bar end-to-end: one instance, started at login')
+    .option('--check', 'Report the current state, change nothing')
+    .option('--json', 'Emit machine-readable JSON')
+    .action((options: { check?: boolean; json?: boolean }) => {
+      if (options.check) {
+        const s = getMenubarStatus();
+        if (options.json) {
+          process.stdout.write(JSON.stringify(s) + '\n');
+          return;
+        }
+        if (notMac()) return;
+        printStatus(s);
+        return;
+      }
+      if (!options.json && notMac()) return;
+      const r = runMenubarSetup();
+      if (options.json) {
+        process.stdout.write(JSON.stringify(r) + '\n');
+      } else {
+        printSetupResult(r);
+      }
+      if (!r.configured) process.exitCode = 1;
+    });
+
+  setHelpSections(setup, {
+    examples: `
+      # Configure the menu bar end-to-end (idempotent — safe to re-run)
+      agents menubar setup
+
+      # Two agents marks in the menu bar? This ends the duplicate.
+      agents menubar setup
+
+      # See the current state without changing anything
+      agents menubar setup --check
+    `,
+    notes: `
+      Configures, in order: every running helper ended, the helper bundle at
+      ~/Library/Application Support/agents-cli, its code signature, the launchd
+      login item (com.phnx-labs.agents-menubar — RunAtLoad + KeepAlive), then
+      verifies exactly one helper came back up.
+
+      Every running helper is ended and launchd restarts one, so the survivor is
+      always the login-managed copy. Exits nonzero if it cannot reach that state.
+
+      Setup clears a previous \`agents menubar disable\`. To turn the menu bar off
+      again, run \`agents menubar disable\`.
+    `,
+  });
 
   menubar
     .command('enable')
@@ -48,7 +161,7 @@ export function registerMenubarCommands(program: Command): void {
     .action(() => {
       if (notMac()) return;
       disableMenubarService();
-      console.log(chalk.green('Menu bar helper disabled.') + chalk.gray('  Re-enable any time with `agents menubar enable`.'));
+      console.log(chalk.green('Menu bar helper disabled.') + chalk.gray('  Re-enable any time with `agents menubar setup`.'));
     });
 
   menubar
@@ -65,31 +178,7 @@ export function registerMenubarCommands(program: Command): void {
         console.log(chalk.yellow('The menu bar helper is macOS only.'));
         return;
       }
-      const yn = (b: boolean) => (b ? chalk.green('yes') : chalk.gray('no'));
-      console.log(chalk.bold('Menu bar helper\n'));
-      console.log(`  running            ${yn(s.running)}`);
-      console.log(`  service installed  ${yn(s.serviceInstalled)}`);
-      console.log(`  app installed      ${s.installedApp ? chalk.gray(s.installedApp) : chalk.gray('no')}`);
-      console.log(`  installed version  ${s.installedVersion ? chalk.gray(s.installedVersion) : chalk.gray('unknown')}`);
-      console.log(`  current version    ${chalk.gray(s.currentVersion)}`);
-      console.log(`  bundle source      ${s.source ? chalk.gray(s.source) : chalk.red('missing (cannot enable)')}`);
-      console.log(`  disabled by user   ${yn(s.disabledByUser)}`);
-      if (s.foreignInstances.length > 0) {
-        // RegisterEventHotKey is first-come, so the helper that registered the
-        // chord first owns Cmd-Shift-V/O. A process list cannot say which that
-        // was — only that a rival exists — so report the conflict, not a
-        // winner. The loser
-        // has no other symptom: its chords simply never fire.
-        const n = s.foreignInstances.length;
-        console.log(chalk.yellow(`\n  ${n} other helper process${n === 1 ? '' : 'es'} running — ${n === 1 ? 'it' : 'they'} may hold Cmd-Shift-V/O instead of the installed one:`));
-        for (const p of s.foreignInstances) console.log(chalk.gray(`    ${p.pid}  ${p.executable}`));
-        console.log(chalk.gray('  End it, then `agents menubar enable` to restart the installed helper.'));
-      }
-      if (s.stale) {
-        console.log(chalk.yellow('\n  Installed helper is stale — runs on next `agents` startup, or `agents menubar enable` now.'));
-      } else if (!s.serviceInstalled && !s.disabledByUser) {
-        console.log(chalk.gray('\n  Enable it with `agents menubar enable`.'));
-      }
+      printStatus(s);
     });
 
   // Bare `agents menubar` -> status.
@@ -99,10 +188,6 @@ export function registerMenubarCommands(program: Command): void {
       console.log(chalk.yellow('The menu bar helper is macOS only.'));
       return;
     }
-    const yn = (b: boolean) => (b ? chalk.green('yes') : chalk.gray('no'));
-    console.log(chalk.bold('Menu bar helper\n'));
-    console.log(`  running            ${yn(s.running)}`);
-    console.log(`  service installed  ${yn(s.serviceInstalled)}`);
-    console.log(chalk.gray('\n  enable | disable | status'));
+    printStatus(s, { brief: true });
   });
 }

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -9,6 +9,7 @@ import {
   ensureValidSignature,
   isMenubarStale,
   menubarPlistNeedsRepoint,
+  processesToEnd,
   restartMenubarLaunchAgent,
 } from './install-menubar.js';
 
@@ -29,21 +30,32 @@ describe('classifyMenubarProcesses', () => {
 
   it('reports the installed bundle as running', () => {
     const r = classifyMenubarProcesses(`74027 ${INSTALLED}`, `74027 ${INSTALLED}`, INSTALLED);
-    expect(r.running).toBe(true);
+    expect(r.own.map((p) => p.pid)).toEqual([74027]);
     expect(r.foreign).toEqual([]);
   });
 
   it('flags a stray build as foreign, not as the installed helper running', () => {
     const r = classifyMenubarProcesses(`58619 ${ORPHAN}`, `58619 .build/debug/MenubarHelper --self-test`, INSTALLED);
-    expect(r.running).toBe(false);
+    expect(r.own).toEqual([]);
     expect(r.foreign).toEqual([{ pid: 58619, executable: ORPHAN }]);
   });
 
   it('separates the two when both are alive — the state that broke the paste', () => {
     const comm = `74027 ${INSTALLED}\n58619 ${ORPHAN}`;
     const r = classifyMenubarProcesses(comm, comm, INSTALLED);
-    expect(r.running).toBe(true);
+    expect(r.own.map((p) => p.pid)).toEqual([74027]);
     expect(r.foreign.map((p) => p.pid)).toEqual([58619]);
+  });
+
+  // The DUPLICATE-ICON blind spot: launchd's KeepAlive copy and a
+  // LaunchServices/`open` launch of the SAME .app both run the installed
+  // executable, so a boolean `running` reported this as healthy while the user
+  // looked at two agents marks in the menu bar. Both pids must be visible.
+  it('reports BOTH copies when the installed bundle is running twice', () => {
+    const comm = `43244 ${INSTALLED}\n93684 ${INSTALLED}`;
+    const r = classifyMenubarProcesses(comm, comm, INSTALLED);
+    expect(r.own.map((p) => p.pid)).toEqual([43244, 93684]);
+    expect(r.foreign).toEqual([]);
   });
 
   it('ignores --notify one-shots (installed binary, but never the status item)', () => {
@@ -52,8 +64,17 @@ describe('classifyMenubarProcesses', () => {
       `91002 ${INSTALLED} --notify --title Done`,
       INSTALLED,
     );
-    expect(r.running).toBe(false);
+    expect(r.own).toEqual([]);
     expect(r.foreign).toEqual([]);
+  });
+
+  // A --notify one-shot running alongside the real status item must not be
+  // mistaken for the duplicate — setup would then kill a healthy single helper.
+  it('does not count a --notify one-shot as a second copy', () => {
+    const comm = `43244 ${INSTALLED}\n91002 ${INSTALLED}`;
+    const command = `43244 ${INSTALLED}\n91002 ${INSTALLED} --notify --title Done`;
+    const r = classifyMenubarProcesses(comm, command, INSTALLED);
+    expect(r.own.map((p) => p.pid)).toEqual([43244]);
   });
 
   // The false positive that a command-line substring match produced: this
@@ -64,15 +85,41 @@ describe('classifyMenubarProcesses', () => {
       '18933 /bin/zsh -c cp /bin/sleep .build/debug/MenubarHelper',
       INSTALLED,
     );
-    expect(r.running).toBe(false);
+    expect(r.own).toEqual([]);
     expect(r.foreign).toEqual([]);
   });
 
   it('ignores unrelated processes', () => {
     const ps = '3675 /System/Library/.../com.apple.Passwords.MenuBarExtra\n1 /sbin/launchd';
     const r = classifyMenubarProcesses(ps, ps, INSTALLED);
-    expect(r.running).toBe(false);
+    expect(r.own).toEqual([]);
     expect(r.foreign).toEqual([]);
+  });
+});
+
+// `agents menubar setup` ends every live helper and lets launchd restart one,
+// so the survivor is always the login-managed copy. Selecting a survivor from
+// a `ps` listing instead would risk keeping the UNMANAGED copy alive — the
+// duplicate would then come straight back at next login.
+describe('processesToEnd', () => {
+  const A = { pid: 43244, executable: '/Applications/…/MenubarHelper' };
+  const B = { pid: 93684, executable: '/Applications/…/MenubarHelper' };
+  const STRAY = { pid: 58619, executable: '/tmp/.build/debug/MenubarHelper' };
+
+  it('ends both copies of a duplicated installed helper', () => {
+    expect(processesToEnd({ instances: [A, B], foreignInstances: [] })).toEqual([A, B]);
+  });
+
+  it('ends the lone running helper too, so launchd owns the restart', () => {
+    expect(processesToEnd({ instances: [A], foreignInstances: [] })).toEqual([A]);
+  });
+
+  it('ends foreign copies as well — they hold Cmd-Shift-V/O first-come', () => {
+    expect(processesToEnd({ instances: [A], foreignInstances: [STRAY] })).toEqual([A, STRAY]);
+  });
+
+  it('ends nothing when no helper is running', () => {
+    expect(processesToEnd({ instances: [], foreignInstances: [] })).toEqual([]);
   });
 });
 

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -317,21 +317,29 @@ export function enableMenubarService(opts: { clearOptOut?: boolean } = { clearOp
     return false;
   }
 
-  if (opts.clearOptOut) {
-    try { fs.rmSync(disabledSentinelPath(), { force: true }); } catch { /* already gone */ }
-  }
+  if (opts.clearOptOut) clearMenubarOptOut();
+  installAndStartService(exec);
+  return true;
+}
 
+/** Drop the sticky `agents menubar disable` sentinel. */
+function clearMenubarOptOut(): void {
+  try { fs.rmSync(disabledSentinelPath(), { force: true }); } catch { /* already gone */ }
+}
+
+/**
+ * Write the launchd plist for `exec`, restart the job, and stamp the installed
+ * version. Shared by `enableMenubarService` and `runMenubarSetup` so the two
+ * cannot drift on what "installed and started" means — the version stamp in
+ * particular is what the upgrade self-heal reads to decide staleness, and a
+ * path that skipped it would make every later `agents` invocation reinstall.
+ */
+function installAndStartService(exec: string): void {
   const plist = servicePlistPath();
   fs.mkdirSync(path.dirname(plist), { recursive: true });
   fs.writeFileSync(plist, generateServicePlist(exec));
-
-  const uid = process.getuid?.() ?? 0;
-  restartMenubarLaunchAgent(uid, plist);
-
-  // Stamp the version we just installed so the upgrade self-heal can tell when
-  // a later release ships a newer helper that needs reinstalling.
+  restartMenubarLaunchAgent(process.getuid?.() ?? 0, plist);
   try { fs.writeFileSync(installedVersionMarkerPath(), getCliVersion()); } catch { /* best effort */ }
-  return true;
 }
 
 /**
@@ -551,13 +559,9 @@ export function runMenubarSetup(): SetupResult {
 
   // Clear the sticky opt-out: running `setup` is an explicit request for the
   // menu bar, so a stale `menubar disable` must not silently win.
-  try { fs.rmSync(disabledSentinelPath(), { force: true }); } catch { /* already gone */ }
+  clearMenubarOptOut();
 
-  const plist = servicePlistPath();
-  fs.mkdirSync(path.dirname(plist), { recursive: true });
-  fs.writeFileSync(plist, generateServicePlist(exec));
-  restartMenubarLaunchAgent(process.getuid?.() ?? 0, plist);
-  try { fs.writeFileSync(installedVersionMarkerPath(), getCliVersion()); } catch { /* best effort */ }
+  installAndStartService(exec);
   step('login item', before.serviceInstalled ? 'ok' : 'changed',
     `${SERVICE_LABEL} — starts at login, restarts if it dies`);
 

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -20,6 +20,7 @@ import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { sleepSync } from '../fs-atomic.js';
 import { getRuntimeStateDir, getHelpersDir } from '../state.js';
 import { getCliVersion, resolveAgentsBin, resolveInstalledLayout } from '../version.js';
 
@@ -588,7 +589,7 @@ export function runMenubarSetup(): SetupResult {
 function waitForSingleInstance(): MenubarStatus {
   let status = getMenubarStatus();
   for (let i = 0; i < 15 && status.instances.length !== 1; i++) {
-    spawnSync('sleep', ['0.2'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    sleepSync(200);
     status = getMenubarStatus();
   }
   return status;

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -451,6 +451,149 @@ export function installMenubarLaunchAgentOnUpgrade(): void {
   }
 }
 
+/** One step of `agents menubar setup`, and how it came out. */
+export interface SetupStep {
+  /** What was configured. */
+  name: string;
+  /** `ok` — already correct or now correct; `changed` — this run fixed it;
+   *  `failed` — could not be configured (setup reports and exits nonzero). */
+  outcome: 'ok' | 'changed' | 'failed';
+  detail: string;
+}
+
+export interface SetupResult {
+  steps: SetupStep[];
+  /** Every step landed on `ok`/`changed` and exactly one helper is running. */
+  configured: boolean;
+  status: MenubarStatus;
+}
+
+/**
+ * Decide which live helper processes must be ended so exactly one status item
+ * survives. Pure so the choice is unit-testable without a live menu bar.
+ *
+ * EVERY current process is ended, including the wanted one: the caller
+ * re-kickstarts the launchd service straight after, so the survivor is the one
+ * launchd owns (RunAtLoad + KeepAlive), not whichever copy happened to win a
+ * race. Picking a survivor from a `ps` listing cannot do this — the list says
+ * nothing about which pid launchd will keep alive, so leaving one alive risks
+ * keeping the un-managed copy and re-creating the duplicate on next login.
+ */
+export function processesToEnd(status: Pick<MenubarStatus, 'instances' | 'foreignInstances'>): MenubarProcess[] {
+  return [...status.instances, ...status.foreignInstances];
+}
+
+function endProcess(pid: number): void {
+  try { process.kill(pid, 'SIGTERM'); } catch { /* already gone */ }
+}
+
+/**
+ * `agents menubar setup` — configure the menu bar end-to-end, idempotently.
+ *
+ * The one command that gets a machine to the intended state: exactly one status
+ * item, owned by a launchd service that starts it at login and restarts it if it
+ * dies. Each concern is a reported step, so a partial failure names itself
+ * instead of hiding behind "enabled".
+ *
+ *   1. bundle      — install/refresh the .app at the stable App Support path
+ *   2. signature   — a valid code identity (macOS 26+ SIGKILLs an invalid one)
+ *   3. duplicates  — end every live helper, so the only survivor is launchd's
+ *   4. login item  — write the plist (RunAtLoad + KeepAlive) and bootstrap it
+ *   5. single      — verify exactly one helper came back up
+ */
+export function runMenubarSetup(): SetupResult {
+  const steps: SetupStep[] = [];
+  const step = (name: string, outcome: SetupStep['outcome'], detail: string) => {
+    steps.push({ name, outcome, detail });
+  };
+
+  if (!onDarwin()) {
+    step('platform', 'failed', `the menu bar helper is macOS only (this is ${process.platform})`);
+    return { steps, configured: false, status: getMenubarStatus() };
+  }
+
+  const before = getMenubarStatus();
+
+  if (!sourceAppPath()) {
+    step('bundle', 'failed', 'no menu-bar helper bundle ships with this install');
+    return { steps, configured: false, status: before };
+  }
+
+  // 3 before 1: end the running copies BEFORE swapping the bundle underneath
+  // them, so no helper keeps a status item alive on a binary that no longer
+  // exists on disk.
+  const doomed = processesToEnd(before);
+  for (const p of doomed) endProcess(p.pid);
+  if (doomed.length > 1) {
+    step('duplicates', 'changed',
+      `ended ${doomed.length} running helpers (${doomed.map((p) => p.pid).join(', ')}) — launchd restarts exactly one`);
+  } else if (doomed.length === 1) {
+    step('duplicates', 'ok', 'one helper was running; restarting it under launchd');
+  } else {
+    step('duplicates', 'ok', 'no helper was running');
+  }
+
+  const exec = ensureMenubarAppInstalled({ forceReinstall: true });
+  if (!exec) {
+    step('bundle', 'failed', 'could not install the helper bundle');
+    return { steps, configured: false, status: getMenubarStatus() };
+  }
+  step('bundle', before.installedVersion === getCliVersion() ? 'ok' : 'changed',
+    `${installedAppPath()} (${getCliVersion()})`);
+
+  if (!codesignVerifies(installedAppPath())) {
+    step('signature', 'failed',
+      'no valid code signature — refusing to start it (launchd KeepAlive would crash-loop)');
+    return { steps, configured: false, status: getMenubarStatus() };
+  }
+  step('signature', 'ok', 'valid');
+
+  // Clear the sticky opt-out: running `setup` is an explicit request for the
+  // menu bar, so a stale `menubar disable` must not silently win.
+  try { fs.rmSync(disabledSentinelPath(), { force: true }); } catch { /* already gone */ }
+
+  const plist = servicePlistPath();
+  fs.mkdirSync(path.dirname(plist), { recursive: true });
+  fs.writeFileSync(plist, generateServicePlist(exec));
+  restartMenubarLaunchAgent(process.getuid?.() ?? 0, plist);
+  try { fs.writeFileSync(installedVersionMarkerPath(), getCliVersion()); } catch { /* best effort */ }
+  step('login item', before.serviceInstalled ? 'ok' : 'changed',
+    `${SERVICE_LABEL} — starts at login, restarts if it dies`);
+
+  // launchd's bootstrap+kickstart is asynchronous; give the status item a beat
+  // to claim the lock before counting instances, or `setup` reports zero on a
+  // machine that is in fact coming up correctly.
+  const after = waitForSingleInstance();
+  if (after.instances.length === 1 && after.foreignInstances.length === 0) {
+    step('single instance', 'ok', `pid ${after.instances[0].pid}`);
+  } else if (after.instances.length === 0) {
+    step('single instance', 'failed', 'the helper did not come back up — see `agents menubar status`');
+  } else {
+    const extra = [...after.instances.slice(1), ...after.foreignInstances];
+    step('single instance', 'failed',
+      `${after.instances.length + after.foreignInstances.length} helpers running (${extra.map((p) => p.pid).join(', ')} are extra)`);
+  }
+
+  return {
+    steps,
+    configured: steps.every((s) => s.outcome !== 'failed'),
+    status: after,
+  };
+}
+
+/**
+ * Poll (up to ~3s) for launchd to bring the single helper back. Returns the
+ * last status read either way — the caller decides what a miss means.
+ */
+function waitForSingleInstance(): MenubarStatus {
+  let status = getMenubarStatus();
+  for (let i = 0; i < 15 && status.instances.length !== 1; i++) {
+    spawnSync('sleep', ['0.2'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    status = getMenubarStatus();
+  }
+  return status;
+}
+
 /** A live MenubarHelper process: its pid and the executable it is running. */
 export interface MenubarProcess {
   pid: number;
@@ -470,12 +613,19 @@ function parsePsLines(psOutput: string): Map<number, string> {
 
 /**
  * Split the live MenubarHelper processes into the installed bundle's own
- * (`running`) and every other copy (`foreign`).
+ * (`own`) and every other copy (`foreign`).
  *
  * `pgrep -f MenubarHelper` conflated the two, so a stray dev build could hold
  * the global Cmd-Shift-V chord (RegisterEventHotKey is first-come) while status
  * still reported a healthy `running: yes` — the paste was dead and nothing said
  * so. A foreign copy is the thing to look for, so name it.
+ *
+ * `own` is a LIST, not a boolean: two copies of the INSTALLED bundle can run at
+ * once (launchd's KeepAlive service plus a LaunchServices/`open` launch of the
+ * same .app), which is the duplicate the user actually sees — two agents marks
+ * in the menu bar. Collapsing them to `running: true` reported that state as
+ * healthy. The helper now refuses to be the second (SingleInstance.swift), and
+ * `agents menubar setup` ends any duplicate a pre-fix helper left behind.
  *
  * Identity comes from `comm` (the resolved executable), never from a substring
  * of the command line: matching the latter flags any shell that merely mentions
@@ -485,19 +635,19 @@ export function classifyMenubarProcesses(
   commOutput: string,
   commandOutput: string,
   installedExec: string,
-): { running: boolean; foreign: MenubarProcess[] } {
+): { own: MenubarProcess[]; foreign: MenubarProcess[] } {
   const commands = parsePsLines(commandOutput);
+  const own: MenubarProcess[] = [];
   const foreign: MenubarProcess[] = [];
-  let running = false;
   for (const [pid, executable] of parsePsLines(commOutput)) {
     if (path.basename(executable) !== 'MenubarHelper') continue;
     // `--notify` is a one-shot that posts a notification and exits; it runs the
     // installed binary but never claims the status item or the chords.
     if ((commands.get(pid) || '').includes('--notify')) continue;
-    if (executable === installedExec) running = true;
+    if (executable === installedExec) own.push({ pid, executable });
     else foreign.push({ pid, executable });
   }
-  return { running, foreign };
+  return { own, foreign };
 }
 
 export interface MenubarStatus {
@@ -509,26 +659,27 @@ export interface MenubarStatus {
   stale: boolean;
   serviceInstalled: boolean;
   running: boolean;
+  /** Live processes of the INSTALLED bundle. More than one is the duplicate. */
+  instances: MenubarProcess[];
   /** Live MenubarHelper processes that are NOT the installed bundle. */
   foreignInstances: MenubarProcess[];
   disabledByUser: boolean;
 }
 
+/** Live MenubarHelper processes, split by whether they are the installed bundle. */
+function liveMenubarProcesses(): { own: MenubarProcess[]; foreign: MenubarProcess[] } {
+  if (!onDarwin()) return { own: [], foreign: [] };
+  const ps = (format: string) =>
+    spawnSync('ps', ['-axo', format], { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' });
+  const comm = ps('pid=,comm=');
+  const command = ps('pid=,command=');
+  if (comm.status !== 0 || command.status !== 0) return { own: [], foreign: [] };
+  return classifyMenubarProcesses(comm.stdout || '', command.stdout || '', installedExecutablePath());
+}
+
 export function getMenubarStatus(): MenubarStatus {
   const dest = installedAppPath();
-  let running = false;
-  let foreignInstances: MenubarProcess[] = [];
-  if (onDarwin()) {
-    const ps = (format: string) =>
-      spawnSync('ps', ['-axo', format], { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' });
-    const comm = ps('pid=,comm=');
-    const command = ps('pid=,command=');
-    if (comm.status === 0 && command.status === 0) {
-      const c = classifyMenubarProcesses(comm.stdout || '', command.stdout || '', installedExecutablePath());
-      running = c.running;
-      foreignInstances = c.foreign;
-    }
-  }
+  const { own, foreign } = liveMenubarProcesses();
   const serviceInstalled = menubarServiceInstalled();
   return {
     platform: process.platform,
@@ -538,8 +689,9 @@ export function getMenubarStatus(): MenubarStatus {
     currentVersion: getCliVersion(),
     stale: onDarwin() && serviceInstalled && menubarSetupStale(),
     serviceInstalled,
-    running,
-    foreignInstances,
+    running: own.length > 0,
+    instances: own,
+    foreignInstances: foreign,
     disabledByUser: menubarDisabledByUser(),
   };
 }


### PR DESCRIPTION
**One agents mark in the menu bar, always — plus `agents menubar setup` to fix a machine that is already wrong.** Bug fix + new command (macOS).

## The bug

Two copies of the helper could run at once: launchd's `KeepAlive` service **plus** a LaunchServices/`open` launch of the *same* `.app` (a Finder open, a re-open after a crash, a second `agents menubar enable`). Two agents marks in the menu bar — and the duplicate could hold `Cmd-Shift-V`/`Cmd-Shift-O`, since `RegisterEventHotKey` is first-come.

Both copies ran the **same** executable, so `classifyMenubarProcesses` saw no "foreign" copy and `agents menubar status` reported a healthy `running: yes` while the user looked at two icons.

| | Menu bar |
|---|---|
| **Before** | two marks — `▣ 1` and `▣ ⚠` |
| **After** | one mark — `▣ 1` |

Screenshots (paths on `zion`, not embeds): before `zion:/Users/muqsit/Screenshots/CleanShot 2026-08-02 at 17.10.44@2x.png` · after `zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/menubar-after.png`

## What changed

**1. The helper refuses to be the second status item.** At launch it takes an `flock(2)` on `~/.agents/.cache/state/menubar.lock` and holds the descriptor for its whole life. A helper that cannot take the lock posts a distributed notification that pops the **running** helper's menu open, then exits 0 — re-launching a menu-bar app means "show me the one I already have", and a nonzero exit would read as a crash to launchd's `KeepAlive`.

An `flock` rather than a pid file: a helper `SIGKILL`ed by the code-signing monitor leaves its pid behind, and every later launch would then read a stale "already running" and never start. The kernel releases an `flock` however the holder dies.

**2. `agents menubar setup`** — one idempotent command that reaches the intended state (never configured, helper down, or duplicate icon). It ends **every** live helper and lets launchd restart one, so the survivor is always the login-managed copy; picking a survivor out of a `ps` listing cannot guarantee that, and keeping the un-managed copy would re-create the duplicate at next login. Exits nonzero if it cannot reach one instance.

**3. `status` can see a duplicate.** `classifyMenubarProcesses` returns live copies of the installed bundle as a **list** (`own`) instead of collapsing them to a boolean; `--json` gains an `instances` array beside the existing `foreignInstances`.

## Ran it

`agents menubar setup` on a machine that actually had the duplicate:

```
$ agents menubar setup
Menu bar setup

  + duplicates      ended 2 running helpers (93048, 97417) — launchd restarts exactly one
  ✓ bundle          /Users/muqsit/Library/Application Support/agents-cli/MenubarHelper.app (1.20.88)
  ✓ signature       valid
  ✓ login item      com.phnx-labs.agents-menubar — starts at login, restarts if it dies
  ✓ single instance pid 98566

Menu bar configured.  One agents mark, started at login.
```

Three launches of the built bundle — the second and third surrender instead of adding an icon:

```
$ nohup "…/MenubarHelper.app/Contents/MacOS/MenubarHelper" &      # A
A pid=6815  lock=[6815]

$ "…/MenubarHelper.app/Contents/MacOS/MenubarHelper"              # B
MenubarHelper: already running (pid 6815) — surfaced it instead of adding a second status item.
B exit=0

$ "…/MenubarHelper.app/Contents/MacOS/MenubarHelper"              # C
MenubarHelper: already running (pid 6815) — surfaced it instead of adding a second status item.
C exit=0

$ pgrep -f "MenubarHelper.app" | wc -l
       1
```

Swift self-test (`MENUBAR_SINGLE_TEST=1`), taking real flocks — no mocks:

```
menubar single-instance self-test
  PASS  first acquire -> acquired
  PASS  lock file records the holder pid (got 66211)
  PASS  incumbent holds the lock
  PASS  second acquire -> alreadyRunning(4242) (got alreadyRunning(pid: 4242))
  PASS  stale pid file, no live holder -> acquired
  PASS  lock path -> ~/.agents/.cache/state/menubar.lock

ALL PASS
```

`vitest run src/lib/menubar/` — 33 passed, including the two new regression cases (two copies of the installed bundle are both reported; a `--notify` one-shot is not counted as a second copy) and `processesToEnd`.

## Docs + CHANGELOG

`apps/cli/docs/menubar.md` (new *One instance, always* section + the `setup` step list), `apps/cli/docs/README.md`, root `README.md`, `apps/cli/AGENTS.md` (the invariant, and why not a pid file / `ps` scan), CHANGELOG under 1.20.89.

## Known adjacent issue, not fixed here

This box has **several agents-cli installs**, and each one's startup self-heal (`installMenubarLaunchAgentOnUpgrade`) reinstalls *its own* `MenubarHelper.app` over App Support and re-bootstraps the service — observed mid-verification, twice, stamping a version marker that did not match the bundle it wrote. That churn is what keeps producing overlapping helper processes in the first place. The lock makes a duplicate **status item** impossible regardless of who launches it, so the user-visible bug is fixed; the install-fight itself deserves its own change.
