### PR TITLE
feat(webhook): add run.env and host placement to webhook handlers

### DIFF
--- a/apps/cli/.changelog/next/webhook-run-env-host.md
+++ b/apps/cli/.changelog/next/webhook-run-env-host.md
@@ -1,0 +1,11 @@
+- **Webhook handlers gain `run.env` and `host` placement.** A handler can now
+  inject environment variables into the process it spawns (`run.env`), and choose
+  where that run executes (`host`). `host` takes a device name (`yosemite-s0`), or
+  `fleet` to pick any eligible online worker, or `fleet/<platform>` /
+  `<platform>/fleet` (also a bare `linux` / `macos` / `windows`) to restrict that
+  pick to one platform. A fleet expression that matches no eligible device fails
+  loudly rather than silently falling back to the local machine, so `fleet/linux`
+  can never land on a macOS box. Omitting `host` runs locally, as before.
+  Source: `apps/cli/src/lib/triggers/handlers.ts` (`resolveHandlerHost`),
+  `apps/cli/src/lib/routines-placement.ts` (`pickFleetDevice` platform filter),
+  `apps/cli/src/lib/routines.ts` (`JobConfig.env`), `apps/cli/src/lib/runner.ts`.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -301,7 +301,8 @@ run:
 | `source` | `github` or `linear`. |
 | `event` | Source event name (e.g. `Issue`, `pull_request`). |
 | `action` | Webhook action (e.g. `update`, `opened`, `labeled`). |
-| `run` | One-of `agent`, `workflow`, or `command`, plus an optional `prompt`. |
+| `run` | One-of `agent`, `workflow`, or `command`, plus an optional `prompt` and `env`. |
+| `host` | Where the action executes: a device name, `fleet`, or `fleet/<platform>`. Omitted runs locally. |
 | `routine` | Name of a routine to delegate to instead of `run`. |
 
 #### Filters
@@ -330,6 +331,39 @@ Handlers support the same filters as routine triggers:
   a command without placeholders there.
 - `routine` — load the named routine, substitute its prompt, and run it
   detached. The handler's `devices` pin overrides the routine's for this fire.
+
+#### Environment and placement
+
+`run.env` injects environment variables into the spawned process, on top of the
+sandbox overlay's own. It applies to both the foreground and detached paths.
+
+`host` chooses where the action executes. It is distinct from `devices`:
+`devices` says which daemon may *fire* the handler, `host` says where the fired
+run *executes*.
+
+| `host` | Effect |
+| --- | --- |
+| omitted | run locally |
+| `yosemite-s0` | run on that device over SSH (or locally if it names this machine) |
+| `fleet` | pick any eligible online worker device |
+| `fleet/linux`, `linux/fleet`, `linux` | pick any eligible online worker on that platform |
+
+Platforms are `linux`, `macos`, `windows`. A fleet expression that matches no
+eligible device raises `no eligible online fleet device` rather than falling back
+to this machine — otherwise `fleet/linux` could silently land on a macOS box.
+
+```yaml
+# ~/.agents/webhooks/deploy-on-merge.yml
+source: github
+event: pull_request
+action: closed
+host: fleet/linux
+run:
+  agent: claude
+  prompt: "Deploy {{pull_request.title}}"
+  env:
+    DEPLOY_TARGET: staging
+```
 
 #### Prompt variables
 

--- a/apps/cli/src/lib/routines-placement.ts
+++ b/apps/cli/src/lib/routines-placement.ts
@@ -13,7 +13,7 @@
 import type { JobConfig, HostStrategy } from './routines.js';
 import { resolveHostStrategy } from './routines.js';
 import { machineId, normalizeHost } from './machine-id.js';
-import { loadDevicesSync } from './devices/registry.js';
+import { loadDevicesSync, type DevicePlatform } from './devices/registry.js';
 import { planFleetTargets } from './devices/fleet.js';
 
 export type PlacementTarget =
@@ -33,7 +33,10 @@ export type PlacementTarget =
  * the double-fire pin (`devices: [self]`) would collapse fleet placement to
  * always-local. Control / offline / no-address devices are never chosen.
  */
-export function pickFleetDevice(_config?: Pick<JobConfig, 'devices'>): string | null {
+export function pickFleetDevice(
+  _config?: Pick<JobConfig, 'devices'>,
+  platform?: DevicePlatform,
+): string | null {
   let reg: ReturnType<typeof loadDevicesSync>;
   try {
     reg = loadDevicesSync();
@@ -41,11 +44,15 @@ export function pickFleetDevice(_config?: Pick<JobConfig, 'devices'>): string | 
     return null;
   }
   const planned = planFleetTargets(reg);
-  const candidates = planned.filter((t) => !t.skip).map((t) => t.device.name);
+  const candidates = planned
+    .filter((t) => !t.skip && (!platform || t.device.platform === platform))
+    .map((t) => t.device.name);
   if (candidates.length === 0) {
     // No registry / nothing online: fall back to self so a single-box fleet
-    // without a registry entry still runs locally.
-    return machineId();
+    // without a registry entry still runs locally. Only when no platform filter
+    // was requested — an unmet filter must fail loud so e.g. `fleet/linux` never
+    // silently lands on a macOS box.
+    return platform ? null : machineId();
   }
   const self = machineId();
   const selfMatch = candidates.find((n) => normalizeHost(n) === self);

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -173,6 +173,12 @@ export interface JobConfig {
    */
   devices?: string[];
   /**
+   * Environment variables injected into the spawned run, on top of the sandbox
+   * overlay's own. Merged by `buildSpawnEnv`, so it applies to both the
+   * foreground and detached execution paths.
+   */
+  env?: Record<string, string>;
+  /**
    * Execution placement — run the job body on this machine over SSH (a
    * registered host, device, capability tag, or user@host) instead of locally.
    * Distinct from `devices`: `devices` says which daemon may FIRE the job,

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -731,7 +731,7 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
 
   const baseEnv = injectRoutineActor(
     useSandbox
-      ? buildSpawnEnv(overlayHome!)
+      ? buildSpawnEnv(overlayHome!, config.env)
       : { ...process.env } as Record<string, string>,
     config,
   );
@@ -1290,7 +1290,7 @@ export async function executeJobDetached(config: JobConfig, hooks?: RoutineHooks
 
   const baseEnv = injectRoutineActor(
     useSandbox
-      ? buildSpawnEnv(overlayHome!)
+      ? buildSpawnEnv(overlayHome!, config.env)
       : { ...process.env } as Record<string, string>,
     config,
   );

--- a/apps/cli/src/lib/triggers/handlers.test.ts
+++ b/apps/cli/src/lib/triggers/handlers.test.ts
@@ -24,6 +24,7 @@ describe('handler config layer', () => {
     process.env.HOME = tmpHome;
     process.env.AGENTS_WEBHOOKS_DIR = path.join(tmpHome, '.agents', 'webhooks');
     process.env.AGENTS_SYSTEM_WEBHOOKS_DIR = path.join(tmpHome, '.agents', '.system', 'webhooks');
+    process.env.AGENTS_DEVICES_DIR = path.join(tmpHome, '.agents', '.history', 'devices');
     process.env.AGENTS_ROUTINES_DIR = path.join(tmpHome, '.agents', 'routines');
     process.env.AGENTS_SYSTEM_ROUTINES_DIR = path.join(tmpHome, '.agents', '.system', 'routines');
     eventsFile = path.join(tmpHome, 'events.jsonl');
@@ -38,6 +39,7 @@ describe('handler config layer', () => {
     else process.env.HOME = originalHome;
     delete process.env.AGENTS_WEBHOOKS_DIR;
     delete process.env.AGENTS_SYSTEM_WEBHOOKS_DIR;
+    delete process.env.AGENTS_DEVICES_DIR;
     delete process.env.AGENTS_ROUTINES_DIR;
     delete process.env.AGENTS_SYSTEM_ROUTINES_DIR;
     delete process.env.AGENTS_EVENTS_PATH;
@@ -62,6 +64,12 @@ describe('handler config layer', () => {
     const dir = process.env.AGENTS_ROUTINES_DIR!;
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, `${name}.yml`), yaml.stringify(content), 'utf-8');
+  }
+
+  function writeDeviceRegistry(devices: Record<string, unknown>) {
+    const dir = process.env.AGENTS_DEVICES_DIR!;
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'registry.json'), JSON.stringify(devices), 'utf-8');
   }
 
   function linearWebhook(overrides: Record<string, unknown> = {}): IncomingWebhook {
@@ -287,6 +295,55 @@ describe('handler config layer', () => {
       expect(dispatched[0].prompt).toBe('Plan the thing');
     });
 
+    it('passes host placement into the dispatched job config', async () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      try {
+        const handler: import('./handlers.js').WebhookHandler = {
+          name: 'remote-handler',
+          source: 'linear',
+          host: 'mac-mini',
+          run: { agent: 'claude', prompt: 'go' },
+        };
+        const dispatched: JobConfig[] = [];
+        await handlerMod.executeHandler(handler, linearWebhook(), {
+          dispatchAgent: async (config) => {
+            dispatched.push(config);
+            return {
+              jobName: handler.name, runId: 'run-remote', agent: 'claude', pid: 1,
+              status: 'running', startedAt: new Date().toISOString(),
+              completedAt: null, exitCode: null,
+            };
+          },
+        });
+        expect(dispatched[0].host).toBe('mac-mini');
+        expect(dispatched[0].hostStrategy).toBe('host');
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('passes run.env through to the dispatched job config', async () => {
+      const handler: import('./handlers.js').WebhookHandler = {
+        name: 'env-handler',
+        source: 'linear',
+        run: { agent: 'claude', prompt: 'go', env: { DEPLOY_TARGET: 'staging' } },
+      };
+      const dispatched: JobConfig[] = [];
+      await handlerMod.executeHandler(handler, linearWebhook(), {
+        dispatchAgent: async (config) => {
+          dispatched.push(config);
+          return {
+            jobName: handler.name, runId: 'run-env', agent: 'claude', pid: 1,
+            status: 'running', startedAt: new Date().toISOString(),
+            completedAt: null, exitCode: null,
+          };
+        },
+      });
+      expect(dispatched[0].env).toEqual({ DEPLOY_TARGET: 'staging' });
+    });
+
     it('runs a shell command action with substitution', async () => {
       const handler: import('./handlers.js').WebhookHandler = {
         name: 'cmd-handler',
@@ -425,6 +482,117 @@ describe('handler config layer', () => {
     it('does not affect single-brace variables like {day}', () => {
       const context = { source: 'linear', event: 'Issue', issue: { identifier: 'RUSH-1' } };
       expect(substituteWebhookPrompt('{day} {{issue.identifier}}', context)).toBe('{day} RUSH-1');
+    });
+  });
+
+  describe('resolveHandlerHost', () => {
+    it('returns local for empty or missing host', () => {
+      expect(handlerMod.resolveHandlerHost(undefined)).toEqual({});
+      expect(handlerMod.resolveHandlerHost('')).toEqual({});
+      expect(handlerMod.resolveHandlerHost('   ')).toEqual({});
+    });
+
+    it('returns local when host names this machine', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      try {
+        expect(handlerMod.resolveHandlerHost('zion')).toEqual({});
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('resolves a specific peer host to host strategy', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      try {
+        expect(handlerMod.resolveHandlerHost('mac-mini')).toEqual({
+          host: 'mac-mini',
+          hostStrategy: 'host',
+        });
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('picks any online worker for fleet host', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      writeDeviceRegistry({
+        'mac-mini': {
+          name: 'mac-mini',
+          platform: 'macos',
+          shell: 'posix',
+          address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' },
+          auth: { method: 'key' },
+          tailscale: { online: true },
+        },
+      });
+      try {
+        expect(handlerMod.resolveHandlerHost('fleet')).toEqual({
+          host: 'mac-mini',
+          hostStrategy: 'host',
+        });
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('picks an online worker matching the platform for fleet/linux', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      writeDeviceRegistry({
+        'mac-mini': {
+          name: 'mac-mini',
+          platform: 'macos',
+          shell: 'posix',
+          address: { via: 'tailscale', dnsName: 'mac-mini.tail1a85a1.ts.net' },
+          auth: { method: 'key' },
+          tailscale: { online: true },
+        },
+        'yosemite-s0': {
+          name: 'yosemite-s0',
+          platform: 'linux',
+          shell: 'posix',
+          address: { via: 'tailscale', dnsName: 'yosemite-s0.tail1a85a1.ts.net' },
+          auth: { method: 'key' },
+          tailscale: { online: true },
+        },
+      });
+      try {
+        expect(handlerMod.resolveHandlerHost('fleet/linux')).toEqual({
+          host: 'yosemite-s0',
+          hostStrategy: 'host',
+        });
+        expect(handlerMod.resolveHandlerHost('linux/fleet')).toEqual({
+          host: 'yosemite-s0',
+          hostStrategy: 'host',
+        });
+        expect(handlerMod.resolveHandlerHost('linux')).toEqual({
+          host: 'yosemite-s0',
+          hostStrategy: 'host',
+        });
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
+    });
+
+    it('throws when fleet has no eligible device', () => {
+      const saved = process.env.AGENTS_SYNC_MACHINE_ID;
+      process.env.AGENTS_SYNC_MACHINE_ID = 'zion';
+      writeDeviceRegistry({});
+      try {
+        // No registry / nothing online still falls back to self, which is local.
+        expect(handlerMod.resolveHandlerHost('fleet')).toEqual({});
+        expect(() => handlerMod.resolveHandlerHost('fleet/linux')).toThrow(/no eligible online fleet device/);
+      } finally {
+        if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
+        else process.env.AGENTS_SYNC_MACHINE_ID = saved;
+      }
     });
   });
 });

--- a/apps/cli/src/lib/triggers/handlers.ts
+++ b/apps/cli/src/lib/triggers/handlers.ts
@@ -13,6 +13,8 @@ import * as yaml from 'yaml';
 import { emit } from '../events.js';
 import { machineId, normalizeHost } from '../machine-id.js';
 import { safeJoin } from '../paths.js';
+import { pickFleetDevice } from '../routines-placement.js';
+import type { DevicePlatform } from '../devices/registry.js';
 import type { JobConfig, RunMeta, WebhookContext } from '../routines.js';
 import {
   assertShellSubstitutionSupported,
@@ -37,11 +39,20 @@ export interface WebhookHandler {
   label?: string;
   repo?: string;
   branch?: string;
+  /**
+   * Where to run the action. A device name (`yosemite-s0`) runs there over SSH;
+   * `fleet` picks any eligible online worker; `fleet/<platform>` (or
+   * `<platform>/fleet`, or a bare `linux`/`macos`/`windows`) restricts that pick
+   * to one platform. Omitted runs locally.
+   */
+  host?: string;
   run?: {
     agent?: AgentId;
     workflow?: string;
     command?: string;
     prompt?: string;
+    /** Environment variables injected into the spawned process. */
+    env?: Record<string, string>;
   };
   routine?: string;
 }
@@ -167,6 +178,57 @@ function handlerRunsOnThisDevice(handler: Pick<WebhookHandler, 'devices'>): bool
   if (!handler.devices || handler.devices.length === 0) return true;
   const self = machineId();
   return handler.devices.some((d) => normalizeHost(d) === self);
+}
+
+const HOST_PLATFORMS: readonly string[] = ['linux', 'macos', 'windows'];
+
+function parseHostPlatform(raw: string): { base: string; platform?: DevicePlatform } {
+  const parts = raw
+    .split('/')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  const platformIdx = parts.findIndex((p) => HOST_PLATFORMS.includes(p));
+  if (platformIdx === -1) return { base: parts.join('/') };
+  const platform = parts[platformIdx] as DevicePlatform;
+  const rest = parts.filter((_, i) => i !== platformIdx).join('/');
+  return { base: rest, platform };
+}
+
+export interface HandlerHostResolution {
+  /** Resolved execution host, or undefined to run locally. */
+  host?: string;
+  /** Strategy that should be set on the JobConfig. */
+  hostStrategy?: 'host' | 'fleet';
+}
+
+/**
+ * Resolve a handler `host` expression to a concrete host or local execution.
+ *
+ * - Specific device name (e.g. `yosemite-s0`) → run there over SSH, or locally
+ *   if it names this machine.
+ * - `fleet` → pick any online worker device.
+ * - `fleet/<platform>` or `<platform>/fleet` (e.g. `fleet/linux`, `linux/fleet`)
+ *   → pick any online worker on that platform. `linux` alone is accepted as a
+ *   shorthand for `fleet/linux`.
+ *
+ * Throws when a fleet expression matches no eligible device, rather than
+ * silently falling back to this machine — `fleet/linux` must never land on a
+ * macOS box.
+ */
+export function resolveHandlerHost(host: string | undefined): HandlerHostResolution {
+  if (!host || host.trim() === '') return {};
+  const { base, platform } = parseHostPlatform(host);
+  const isFleet = base === '' || base === 'fleet';
+  if (isFleet) {
+    const picked = pickFleetDevice(undefined, platform);
+    if (!picked) {
+      throw new Error(`handler host '${host}': no eligible online fleet device`);
+    }
+    if (normalizeHost(picked) === machineId()) return {};
+    return { host: picked, hostStrategy: 'host' };
+  }
+  if (normalizeHost(base) === machineId()) return {};
+  return { host: base, hostStrategy: 'host' };
 }
 
 /**
@@ -350,6 +412,8 @@ async function executeHandlerAction(
   opts: ExecuteHandlerOptions,
 ): Promise<Omit<FiredHandler, 'handlerName'>> {
   const substitutedPrompt = handler.run?.prompt ? substituteWebhookPrompt(handler.run.prompt, context) : '';
+  // Resolved once so a fleet pick can't differ between the two dispatch paths.
+  const hostFields = resolveHandlerHost(handler.host);
 
   if (handler.run?.agent || handler.run?.workflow) {
     const config: JobConfig = {
@@ -361,6 +425,9 @@ async function executeHandlerAction(
       prompt: substitutedPrompt,
       ...(handler.run.agent ? { agent: handler.run.agent } : { workflow: handler.run.workflow! }),
       ...(handler.devices ? { devices: handler.devices } : {}),
+      ...(handler.run.env ? { env: handler.run.env } : {}),
+      ...(hostFields.host ? { host: hostFields.host } : {}),
+      ...(hostFields.hostStrategy ? { hostStrategy: hostFields.hostStrategy } : {}),
     };
     const dispatch = handler.run.agent
       ? (opts.dispatchAgent ?? dispatchDefault)
@@ -384,6 +451,8 @@ async function executeHandlerAction(
       ...routine,
       prompt: substituteWebhookPrompt(routine.prompt, context),
       ...(handler.devices ? { devices: handler.devices } : {}),
+      ...(hostFields.host ? { host: hostFields.host } : {}),
+      ...(hostFields.hostStrategy ? { hostStrategy: hostFields.hostStrategy } : {}),
     };
     const dispatch = opts.dispatchRoutine ?? dispatchDefault;
     const meta = await dispatch(config);


### PR DESCRIPTION
**feat** — the two genuinely additive capabilities from #1731, ported onto the handler layer that landed in #1737.

#1731 predates #1737 and would rewrite `handlers.ts` wholesale. Comparing the two diffs, three of the four capabilities in its title — state filters, prompt vars, audit events — are **byte-identical** to what already merged. Only these two are new, so only these two are carried over.

## `run.env`

Injects environment variables into the spawned process. `JobConfig` gains `env`, and both runner spawn paths pass it to `buildSpawnEnv`, which already accepted an `extraEnv` argument.

## `host` placement

Distinct from `devices`: `devices` says which daemon may **fire** the handler, `host` says where the fired run **executes**.

| `host` | Effect |
| --- | --- |
| omitted | run locally |
| `yosemite-s0` | run there over SSH (or locally if it names this machine) |
| `fleet` | pick any eligible online worker |
| `fleet/linux`, `linux/fleet`, `linux` | restrict that pick to one platform |

`pickFleetDevice` takes an optional platform filter and, when one is given, returns `null` instead of falling back to `machineId()` — so `fleet/linux` **fails loud** rather than silently landing on a macOS box.

```yaml
# ~/.agents/webhooks/deploy-on-merge.yml
source: github
event: pull_request
action: closed
host: fleet/linux
run:
  agent: claude
  prompt: "Deploy {{pull_request.title}}"
  env:
    DEPLOY_TARGET: staging
```

## Changelog convention

#1731 edited `apps/cli/CHANGELOG.md` directly; this uses a fragment under `.changelog/next/` per the repo's conflict-free changelog convention.

## Verification

```
$ tsc --noEmit -p apps/cli/tsconfig.json
(clean)

$ vitest run src/lib/triggers/handlers.test.ts src/lib/routines.test.ts
 Test Files  2 passed (2)
      Tests  95 passed (95)
```

Includes #1731's `resolveHandlerHost` suite (local / peer / `fleet` / `fleet/linux` / unmet-filter-throws) plus new tests asserting both `host` placement and `run.env` actually reach the dispatched `JobConfig`.

Closes out #1731 — once this lands that PR has nothing unique left.
