### PR TITLE
fix(daemon): warn when launched from an ephemeral root (/tmp, worktree)

### DIFF
--- a/apps/cli/.changelog/next/daemon-ephemeral-root-guard.md
+++ b/apps/cli/.changelog/next/daemon-ephemeral-root-guard.md
@@ -1,0 +1,18 @@
+- **The daemon warns when it was launched from an ephemeral root.** A daemon
+  started from a temp dir (`/tmp`, `/var/folders`, `/dev/shm`) or a git worktree
+  resolves its own job modules by dynamic `import()` rooted at the launch entry
+  (`getAgentsBinPath` → `process.argv[1]`). When that directory is later removed
+  — a `/tmp` cleanup, a review/verify checkout teardown, `git worktree remove` —
+  the long-lived daemon keeps ENOENT-ing on every routine's imports
+  (`auto-dispatch.ts`, `routines-placement.ts`, `devices/fleet.ts`), silently
+  wedging until restart. `anchorDaemonCwd` already rescues the cwd, but nothing
+  can re-root a deleted module tree. `runDaemon` now calls
+  `warnEphemeralDaemonRoot` at startup, so the risk is logged the moment the
+  daemon comes up — including a direct `agents __daemon-run` that never passes
+  through the launch-time `validateDaemonBinary` check. That launch-time check is
+  also broadened from git-worktree-only to any ephemeral root via the shared
+  `describeEphemeralDaemonRoot` predicate. The fix for a wedged daemon is
+  unchanged: run it from the globally installed binary
+  (`npm i -g @phnx-labs/agents-cli`) so its entry roots at a stable version home.
+  Source: `apps/cli/src/lib/daemon.ts`
+  (`describeEphemeralDaemonRoot`, `warnEphemeralDaemonRoot`, `validateDaemonBinary`).

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -888,7 +888,7 @@ The scheduler **auto-starts on the first `agents routines add`**, so in most cas
 
 `agents routines status` reports the scheduler as `running`, `wedged`, or `stopped`. A live PID whose heartbeat is more than three monitor ticks old is `wedged`; the status output includes the restart command. Both `routines list` and `routines status` also finalize orphaned `running` records before rendering. Run metadata records process birth time to reject recycled PIDs, and any run still active after 24 hours is finalized as a timeout.
 
-The status output includes the resolved daemon binary. Startup rejects bun virtual-filesystem paths and warns when the binary lives inside `.agents/worktrees/`, because deleting that worktree would strand the service.
+The status output includes the resolved daemon binary. Startup rejects bun virtual-filesystem paths and warns when the binary lives under an ephemeral root — a git worktree, or a temporary directory (`/tmp`, `/var/folders`, `/dev/shm`) — because deleting that directory would strand the service. The daemon resolves its own job modules from the launch path, so a direct `agents __daemon-run` from such a build wedges every routine with `ENOENT` once the directory is removed; the warning fires both at spawn time (`validateDaemonBinary`) and at the daemon's own startup (`warnEphemeralDaemonRoot`), so a directly-launched daemon still surfaces the risk. Run it from the globally installed binary to root it at a stable version home.
 
 ## Key Functions
 

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -32,6 +32,8 @@ import {
   removeDaemonPid,
   shouldTakeOverBroker,
   anchorDaemonCwd,
+  describeEphemeralDaemonRoot,
+  validateDaemonBinary,
 } from './daemon.js';
 import { ipcEndpoint } from './platform/index.js';
 
@@ -726,5 +728,54 @@ describe('anchorDaemonCwd', () => {
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+describe('describeEphemeralDaemonRoot', () => {
+  // A daemon launched from an ephemeral path wedges on every dynamic import once
+  // that path is removed — the /tmp/rv-head incident. This predicate is what
+  // both the launch-time check (validateDaemonBinary) and the runtime startup
+  // self-check (warnEphemeralDaemonRoot) share, so it must classify precisely.
+  it('flags a git worktree entry', () => {
+    expect(describeEphemeralDaemonRoot('/home/u/.agents/worktrees/rv/apps/cli/src/index.ts')).toBe('a git worktree');
+  });
+
+  it('flags /tmp and /private/tmp entries (the /tmp/rv-head case)', () => {
+    expect(describeEphemeralDaemonRoot('/tmp/rv-head/apps/cli/src/index.ts')).toBe('a temporary directory');
+    expect(describeEphemeralDaemonRoot('/private/tmp/rv-head/apps/cli/src/index.ts')).toBe('a temporary directory');
+  });
+
+  it('flags macOS /var/folders and linux /dev/shm entries', () => {
+    expect(describeEphemeralDaemonRoot('/var/folders/xy/abc/T/build/index.js')).toBe('a temporary directory');
+    expect(describeEphemeralDaemonRoot('/private/var/folders/xy/abc/T/build/index.js')).toBe('a temporary directory');
+    expect(describeEphemeralDaemonRoot('/dev/shm/build/index.js')).toBe('a temporary directory');
+  });
+
+  it('returns null for stable install roots and normal checkouts', () => {
+    // Version home (the real install location), a global npm prefix, and an
+    // ordinary source checkout under $HOME must NOT be flagged — else every
+    // dev run and every install would emit a spurious wedge warning.
+    expect(describeEphemeralDaemonRoot('/home/u/.agents/.history/versions/agents/1.20.88/node_modules/@phnx-labs/agents-cli/dist/index.js')).toBeNull();
+    expect(describeEphemeralDaemonRoot('/opt/homebrew/lib/node_modules/@phnx-labs/agents-cli/dist/index.js')).toBeNull();
+    expect(describeEphemeralDaemonRoot('/home/u/src/github.com/x/agents-cli/apps/cli/src/index.ts')).toBeNull();
+    // A directory merely named "tmp" under $HOME is not a temp root (anchored match).
+    expect(describeEphemeralDaemonRoot('/home/u/tmp/agents-cli/dist/index.js')).toBeNull();
+  });
+});
+
+describe('validateDaemonBinary (ephemeral-root warning)', () => {
+  it('warns when the daemon binary is under /tmp', () => {
+    const { warnings } = validateDaemonBinary('/tmp/rv-head/apps/cli/src/index.ts');
+    expect(warnings.some((w) => w.includes('a temporary directory'))).toBe(true);
+  });
+
+  it('warns when the daemon binary is inside a git worktree', () => {
+    const { warnings } = validateDaemonBinary('/home/u/.agents/worktrees/rv/apps/cli/src/index.ts');
+    expect(warnings.some((w) => w.includes('a git worktree'))).toBe(true);
+  });
+
+  it('does not emit a wedge warning for a version-home install', () => {
+    const { warnings } = validateDaemonBinary('/home/u/.agents/.history/versions/agents/1.20.88/dist/index.js');
+    expect(warnings.some((w) => /worktree|temporary directory/.test(w))).toBe(false);
   });
 });

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -33,6 +33,7 @@ import {
   shouldTakeOverBroker,
   anchorDaemonCwd,
   describeEphemeralDaemonRoot,
+  warnEphemeralDaemonRoot,
   validateDaemonBinary,
 } from './daemon.js';
 import { ipcEndpoint } from './platform/index.js';
@@ -760,6 +761,42 @@ describe('describeEphemeralDaemonRoot', () => {
     expect(describeEphemeralDaemonRoot('/home/u/src/github.com/x/agents-cli/apps/cli/src/index.ts')).toBeNull();
     // A directory merely named "tmp" under $HOME is not a temp root (anchored match).
     expect(describeEphemeralDaemonRoot('/home/u/tmp/agents-cli/dist/index.js')).toBeNull();
+  });
+});
+
+describe('warnEphemeralDaemonRoot', () => {
+  // The runtime startup self-check: it must warn (return the message) for an
+  // ephemeral launch root, stay silent (null) for a stable one, and never throw
+  // — including when the bin resolver itself throws (getAgentsBinPath can, when a
+  // shim's main entry is missing). resolveBin is injected so all three branches
+  // hit the real code path without mocking the module.
+  it('warns for an ephemeral launch root (the /tmp/rv-head case)', () => {
+    const msg = warnEphemeralDaemonRoot(() => '/tmp/rv-head/apps/cli/src/index.ts');
+    expect(msg).not.toBeNull();
+    expect(msg).toContain('a temporary directory');
+    expect(msg).toContain('/tmp/rv-head/apps/cli/src/index.ts');
+  });
+
+  it('stays silent for a stable version-home launch root', () => {
+    expect(
+      warnEphemeralDaemonRoot(() => '/home/u/.agents/.history/versions/agents/1.20.88/dist/index.js'),
+    ).toBeNull();
+  });
+
+  it('is non-fatal when the bin resolver throws', () => {
+    let result: string | null = 'sentinel';
+    expect(() => {
+      result = warnEphemeralDaemonRoot(() => {
+        throw new Error('no main CLI entry');
+      });
+    }).not.toThrow();
+    expect(result).toBeNull();
+  });
+
+  it('does not throw when resolving the real launch binary', () => {
+    // Default resolver (getAgentsBinPath against the live argv[1]) must run
+    // through the try without throwing — this is what runDaemon calls at startup.
+    expect(() => warnEphemeralDaemonRoot()).not.toThrow();
   });
 });
 

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -328,21 +328,26 @@ export function anchorDaemonCwd(): string | null {
  * wedge risk stays invisible until jobs start ENOENT-ing on their dynamic
  * imports. Best-effort and non-fatal; the cwd is already handled by
  * anchorDaemonCwd, but a deleted module root can only be flagged, not repaired.
+ *
+ * `resolveBin` is injectable (defaults to getAgentsBinPath) so the wiring — the
+ * predicate call, the WARN, and the non-fatal guard around a throwing resolver —
+ * is testable. Returns the warning message it logged, or null when the launch
+ * root is stable (or could not be resolved).
  */
-export function warnEphemeralDaemonRoot(): void {
+export function warnEphemeralDaemonRoot(resolveBin: () => string = getAgentsBinPath): string | null {
   try {
-    const bin = getAgentsBinPath();
+    const bin = resolveBin();
     const ephemeralRoot = describeEphemeralDaemonRoot(bin);
-    if (ephemeralRoot) {
-      log(
-        'WARN',
-        `Daemon launched from ${ephemeralRoot} (${bin}); if that directory is removed, ` +
-        `every routine will fail with ENOENT on its module imports. Run the daemon from the ` +
-        `globally installed binary instead (npm i -g @phnx-labs/agents-cli), then restart it.`,
-      );
-    }
+    if (!ephemeralRoot) return null;
+    const message =
+      `Daemon launched from ${ephemeralRoot} (${bin}); if that directory is removed, ` +
+      `every routine will fail with ENOENT on its module imports. Run the daemon from the ` +
+      `globally installed binary instead (npm i -g @phnx-labs/agents-cli), then restart it.`;
+    log('WARN', message);
+    return message;
   } catch (err) {
     log('WARN', `Could not check daemon launch root: ${(err as Error).message}`);
+    return null;
   }
 }
 

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -318,6 +318,34 @@ export function anchorDaemonCwd(): string | null {
   }
 }
 
+/**
+ * Surface, at the daemon's OWN startup, that it was launched from an ephemeral
+ * root that will wedge it if the directory is removed. This is the runtime
+ * companion to the launch-time check in validateDaemonBinary (which only runs
+ * when the daemon is *spawned* via getDaemonLaunch): a direct
+ * `agents __daemon-run` from a temp or worktree build — e.g. a review/verify
+ * checkout under /tmp — never passes through that path, so without this the
+ * wedge risk stays invisible until jobs start ENOENT-ing on their dynamic
+ * imports. Best-effort and non-fatal; the cwd is already handled by
+ * anchorDaemonCwd, but a deleted module root can only be flagged, not repaired.
+ */
+export function warnEphemeralDaemonRoot(): void {
+  try {
+    const bin = getAgentsBinPath();
+    const ephemeralRoot = describeEphemeralDaemonRoot(bin);
+    if (ephemeralRoot) {
+      log(
+        'WARN',
+        `Daemon launched from ${ephemeralRoot} (${bin}); if that directory is removed, ` +
+        `every routine will fail with ENOENT on its module imports. Run the daemon from the ` +
+        `globally installed binary instead (npm i -g @phnx-labs/agents-cli), then restart it.`,
+      );
+    }
+  } catch (err) {
+    log('WARN', `Could not check daemon launch root: ${(err as Error).message}`);
+  }
+}
+
 export async function runDaemon(): Promise<void> {
   // Single-instance guard: a direct `agents __daemon-run` (manual, or a
   // service-manager restart racing a live predecessor) must not clobber a
@@ -332,6 +360,7 @@ export async function runDaemon(): Promise<void> {
   log('INFO', `Daemon started (PID: ${process.pid})`);
 
   anchorDaemonCwd();
+  warnEphemeralDaemonRoot();
 
   // The daemon holds NO Claude credential of its own. Routine runs authenticate
   // exactly like an interactive `agents run`: through the per-account
@@ -1100,6 +1129,25 @@ export function getAgentsInvocation(
   return getCliLaunch(subArgs, agentsBin);
 }
 
+/**
+ * A daemon binary living under an ephemeral path — a git worktree, or a temp
+ * directory (`/tmp`, `/var/folders`, `/dev/shm`) — is a latent wedge. The daemon
+ * is long-lived but resolves its own job modules by dynamic `import()` rooted at
+ * this entry (getAgentsBinPath → process.argv[1]). If that directory is later
+ * removed (`git worktree remove`, a `/tmp` cleanup, a review/verify checkout
+ * teardown) the running daemon keeps ENOENT-ing on every job it loads —
+ * `anchorDaemonCwd` rescues the cwd, but nothing can re-root a deleted module
+ * tree. Returns a human phrase naming the ephemeral kind, or null for a stable
+ * install path (version home, a global npm prefix, a normal source checkout).
+ */
+export function describeEphemeralDaemonRoot(binPath: string): string | null {
+  if (/[/\\]\.agents[/\\]worktrees[/\\]/.test(binPath)) return 'a git worktree';
+  if (/^(?:\/private)?\/tmp[/\\]|^(?:\/private)?\/var\/folders[/\\]|^\/dev\/shm[/\\]/.test(binPath)) {
+    return 'a temporary directory';
+  }
+  return null;
+}
+
 export function validateDaemonBinary(binPath: string): { warnings: string[] } {
   const warnings: string[] = [];
   if (BUN_VIRTUAL_ROOT.test(binPath)) {
@@ -1108,10 +1156,11 @@ export function validateDaemonBinary(binPath: string): { warnings: string[] } {
       `Install agents globally (npm i -g @phnx-labs/agents-cli) and restart.`,
     );
   }
-  if (/[/\\]\.agents[/\\]worktrees[/\\]/.test(binPath)) {
+  const ephemeralRoot = describeEphemeralDaemonRoot(binPath);
+  if (ephemeralRoot) {
     warnings.push(
-      `Warning: daemon binary is inside a git worktree (${binPath}). ` +
-      `A worktree deletion will wedge the daemon. Use the globally installed binary instead.`,
+      `Warning: daemon binary is inside ${ephemeralRoot} (${binPath}). ` +
+      `Deleting it will wedge the daemon. Use the globally installed binary instead.`,
     );
   }
   if (!fs.existsSync(binPath) && !/\.(c|m)?js$/.test(binPath)) {


### PR DESCRIPTION
**fix — daemon robustness (no user-facing UI; a startup WARN + broadened launch-time check).**

## Why
Investigating a wedged routines daemon on a fleet box (`yosemite-s0`): it was launched as `bun /tmp/rv-head/apps/cli/src/index.ts __daemon-run`, and after `/tmp/rv-head` was deleted out from under it, every routine failed with `ENOENT reading ".../lib/routines-placement.ts"` (also `auto-dispatch.ts`, `devices/fleet.ts`) on a 2-minute loop. The daemon resolves its own job modules by dynamic `import()` rooted at the launch entry (`getAgentsBinPath` → `process.argv[1]`), so a deleted launch dir wedges it. `anchorDaemonCwd` already rescues the **cwd** axis, but nothing surfaced the **module-root** axis — and a direct `__daemon-run` never passes through the launch-time `validateDaemonBinary` check, so the risk was invisible until jobs started failing.

## What changed
- **`describeEphemeralDaemonRoot(binPath)`** — one shared predicate classifying an ephemeral launch root: a git worktree, or a temp dir (`/tmp`, `/private/tmp`, `/var/folders`, `/dev/shm`). Anchored matching, so a normal checkout / version-home / global npm prefix / a dir merely named `tmp` under `$HOME` is **not** flagged.
- **`warnEphemeralDaemonRoot()`** called in `runDaemon()` at startup — logs the wedge risk the moment the daemon comes up, including the direct-`__daemon-run` case the launch-time check misses. Best-effort, non-fatal (companion to `anchorDaemonCwd`).
- **`validateDaemonBinary`** now routes its warning through the shared predicate, broadening it from worktree-only to any ephemeral root.

No new flag/command/config → no README/AGENTS change. CHANGELOG fragment added at `apps/cli/.changelog/next/daemon-ephemeral-root-guard.md`.

## Run result

Behavior demonstrated against the exact `/tmp/rv-head` path from the incident:
```
kind: "a temporary directory" <- /tmp/rv-head/apps/cli/src/index.ts
kind: "a git worktree"        <- /home/u/.agents/worktrees/rv/apps/cli/src/index.ts
kind: null                    <- /home/u/.agents/.history/versions/agents/1.20.88/dist/index.js

WARN emitted for the /tmp/rv-head daemon:
  Warning: daemon binary is inside a temporary directory (/tmp/rv-head/apps/cli/src/index.ts).
  Deleting it will wedge the daemon. Use the globally installed binary instead.
```

New tests (`daemon.test.ts`), run locally with the real node binary:
```
✓ describeEphemeralDaemonRoot (4)  — worktree, /tmp + /private/tmp, /var/folders + /dev/shm, null for stable roots
✓ validateDaemonBinary (ephemeral-root warning) (3)
```
Typecheck: `tsc --noEmit` → 0 errors.

> Note: the 2 pre-existing `anchorDaemonCwd` tests fail on a **macOS-local** run (they rely on Linux `getcwd()`-on-deleted-dir ENOENT semantics) — they fail identically on unmodified `origin/main`, and the suite's authoritative run is the Linux crabbox in CI. Not affected by this change.
