### PR TITLE
feat(sessions): favorite sessions, and detect ones that lost their host

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ On a terminal, `agents sessions --active` (and a bare `agents sessions`) open th
 | `⏎` | resume / attach | `resume` / `focus` |
 | `y` | copy the equivalent command | `--print-cmd` |
 
-**Star the sessions you keep coming back to.** `*` marks the highlighted row (a `★` shows in the listing), `f` narrows to the starred ones, and `agents sessions favorite <id>` / `--favorites` do the same outside a TTY. Stars live in `~/.agents/.history/favorites.json` keyed by session id, so they survive a reindex and follow the session to your other machines.
+**Star the sessions you keep coming back to.** `*` marks the highlighted row (a `★` shows in the listing), `f` narrows to the starred ones, and `agents sessions favorite <id>` / `--favorites` do the same outside a TTY. Stars live in `~/.agents/.history/favorites.json` keyed by session id, so they survive a reindex of the session cache. They're per-machine — session sync carries transcripts, not this file.
 
 **A session that lost its host says so.** When an editor window or an SSH connection goes down hard, the agent it owned used to simply disappear from `--active`; when an agent outlived its window in tmux, it reported a plain `idle`. Both now carry their own status: `✗ crashed` (the host went down and took the agent with it) and `◍ orphan` (still alive, but no client is attached — nothing is showing it). Read from tmux's attached-client count and the editor window's registry heartbeat, so a deliberate `agents sessions detach` is never mistaken for one, and a session that is still *working* headlessly is left alone.
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ On a terminal, `agents sessions --active` (and a bare `agents sessions`) open th
 |---|---|---|
 | `s` | search text | `--query` / positional |
 | `r` | running only | `--active` |
+| `f` | favorites only | `--favorites` |
+| `*` | star / unstar the highlighted session | `agents sessions favorite <id>` |
 | `c` | team sessions | `--teams` |
 | `a` | agent (cycles) | `-a` |
 | `d` | device (cycles) | `--device` |
@@ -273,6 +275,10 @@ On a terminal, `agents sessions --active` (and a bare `agents sessions`) open th
 | `tab` | toggle the preview pane | — |
 | `⏎` | resume / attach | `resume` / `focus` |
 | `y` | copy the equivalent command | `--print-cmd` |
+
+**Star the sessions you keep coming back to.** `*` marks the highlighted row (a `★` shows in the listing), `f` narrows to the starred ones, and `agents sessions favorite <id>` / `--favorites` do the same outside a TTY. Stars live in `~/.agents/.history/favorites.json` keyed by session id, so they survive a reindex and follow the session to your other machines.
+
+**A session that lost its host says so.** When an editor window or an SSH connection goes down hard, the agent it owned used to simply disappear from `--active`; when an agent outlived its window in tmux, it reported a plain `idle`. Both now carry their own status: `✗ crashed` (the host went down and took the agent with it) and `◍ orphan` (still alive, but no client is attached — nothing is showing it). Read from tmux's attached-client count and the editor window's registry heartbeat, so a deliberate `agents sessions detach` is never mistaken for one, and a session that is still *working* headlessly is left alone.
 
 Filters **stack** (they AND together), the active set shows in the header, and the highlighted row **previews below by default** (`tab` hides it) — prompt, activity, last response, plus a links line where the worked-on ticket and the PR the session opened are **clickable** (OSC 8 hyperlinks: the ticket jumps to Linear, the `PR#` to GitHub, in terminals that support them). The Linear workspace is resolved from `LINEAR_WORKSPACE` or the linear-cli config, so tickets stay plain text when it's unknown. Because every hotkey has a flag, the view you build by hand is a real command: press `y` (or run `--print-cmd`) to get the exact `ag sessions …` line — explore interactively, hand the line to an agent. Piped output, `--json`, or `--no-interactive` keep the plain listing for scripts. Peek without opening the pager with `agents sessions <id> --preview`.
 

--- a/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
+++ b/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
@@ -3,7 +3,8 @@
   `agents sessions favorite <id>` (`--remove` / `--list` / `--json`) and
   `agents sessions --favorites` do the same. Stars live in
   `~/.agents/.history/favorites.json` keyed by session id, so they survive a reindex
-  of the session cache and follow the session across machines. Source:
+  of the session cache. They are per-machine — session sync carries transcripts, not
+  this file. Source:
   `apps/cli/src/lib/session/favorites.ts`, `apps/cli/src/commands/sessions-favorite.ts`.
 - **Detect sessions that lost their host — two new statuses, `crashed` and `orphaned`.**
   A session whose editor window or connection went down hard used to just VANISH from

--- a/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
+++ b/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
@@ -19,3 +19,7 @@
   into the interactive browser only, so every path that skips it — `--json`,
   `--waiting`, a pipe, a multi-host scope, an SSH-fanout peer — silently returned the
   whole fleet. Source: `apps/cli/src/commands/sessions.ts`.
+- **`agents sessions --active --waiting` no longer counts a dead session.** `activity`
+  is not rewritten when a session dies, so one that crashed mid-question reported "needs
+  your input" forever — what it needs is a relaunch. Source:
+  `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
+++ b/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
@@ -1,0 +1,16 @@
+- **Favorite sessions from the browser.** `*` stars the highlighted session in
+  `agents sessions` and `f` filters the list to the starred ones; outside a TTY,
+  `agents sessions favorite <id>` (`--remove` / `--list` / `--json`) and
+  `agents sessions --favorites` do the same. Stars live in
+  `~/.agents/.history/favorites.json` keyed by session id, so they survive a reindex
+  of the session cache and follow the session across machines. Source:
+  `apps/cli/src/lib/session/favorites.ts`, `apps/cli/src/commands/sessions-favorite.ts`.
+- **Detect sessions that lost their host — two new statuses, `crashed` and `orphaned`.**
+  A session whose editor window or connection went down hard used to just VANISH from
+  `agents sessions --active` (its dead-pid registry entry was filtered out), and one
+  still running in tmux with nobody attached reported a plain `idle`. Both now say so:
+  `✗ crashed` when the host window stopped republishing and the agent died with it,
+  `◍ orphan` when the agent is alive with zero clients attached. Derived from tmux's
+  `#{session_attached}` and the IDE window's registry heartbeat — never from a
+  deliberate `agents sessions detach`, and never over a session that is still working.
+  Source: `apps/cli/src/lib/session/host-link.ts`, `apps/cli/src/lib/session/active.ts`.

--- a/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
+++ b/apps/cli/.changelog/next/session-favorites-and-lost-hosts.md
@@ -14,3 +14,7 @@
   `#{session_attached}` and the IDE window's registry heartbeat — never from a
   deliberate `agents sessions detach`, and never over a session that is still working.
   Source: `apps/cli/src/lib/session/host-link.ts`, `apps/cli/src/lib/session/active.ts`.
+- **`agents sessions --active --favorites` now actually filters.** The flag was wired
+  into the interactive browser only, so every path that skips it — `--json`,
+  `--waiting`, a pipe, a multi-host scope, an SSH-fanout peer — silently returned the
+  whole fleet. Source: `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -509,9 +509,12 @@ The two signals behind them:
   means "cannot tell", never zero.
 
   Note the separator: tmux **sanitizes non-printable characters out of format output**
-  (3.6a rewrites a literal tab to `_`), so every `-F` query here uses a printable
-  `TMUX_FIELD_SEP`. `listTmuxAgentSessions` split on `\t` and therefore returned zero
-  rows on any such tmux — fixed alongside this.
+  (3.6a rewrites a literal tab — and any non-ASCII sentinel — to `_`), so every `-F`
+  query here uses `TMUX_FIELD_SEP`. `listTmuxAgentSessions` split on `\t` and therefore
+  returned zero rows on any such tmux — fixed alongside this. The separator is `:`
+  specifically because tmux replaces `:` and `.` in a *session name* with `_`, so it
+  provably cannot occur in the one free-text field that is not last;
+  `pane_current_path` (which may contain `:`) is queried last and its tail rejoined.
 - **The IDE window heartbeat** — the `at` stamp on each window's slice of
   `live-terminals.json`. The Factory extension force-republishes every 4 minutes, so a
   slice older than `HOST_HEARTBEAT_STALE_MS` (10 minutes, the same window the extension

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -535,7 +535,14 @@ degrades to `abandoned`, so the listing carries an alert, not a permanent tombst
 And a dead session never trips the `--waiting` gate, however its last turn ended:
 `activity` is not rewritten on death, so a session that crashed mid-question would
 otherwise read as "needs your input" forever when what it needs is a relaunch
-(`isAwaitingUser`).
+(`isAwaitingUser`). `closed`/`crashed` are excluded outright — both are
+unconditionally dead. `abandoned` is not: it fires on transcript staleness *before*
+the liveness check, so it also covers a live-but-forgotten session that asked a
+question and sat untouched over a long weekend, which is still answerable and is
+exactly what the gate is for. That one is excluded only when its `pidAlive` is
+positively false; unknown liveness stays excluded rather than inventing a human who
+can answer. The session preview shares this one predicate, so the human-facing
+"needs you" line and the scriptable gate can never disagree about a row.
 
 **Known residual — an ambient tmux session.** `provenance.mux` is stamped from the
 process env, so an agent launched inside a tmux session the *developer* owns (rather

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -530,6 +530,14 @@ Precedence is deliberate, so the words keep their meaning:
 A `crashed` row is deliberately transient: once its transcript goes days-stale it
 degrades to `abandoned`, so the listing carries an alert, not a permanent tombstone.
 
+Both are visible everywhere a status already was — the `--active` grouped view, the
+default printed listing, `--active --json` (plus a `hostLink` field), and the session
+preview, which spells the state out in a sentence rather than a glyph. The interactive
+browser gained a status column of its own for the running view (`PickerColumns.showStatus`,
+gated exactly like `showHost`): it previously showed which terminal a session ran in but
+never what it was doing, so a session that had lost its host was indistinguishable from a
+healthy one in the row list.
+
 ## Favorites (starred sessions)
 
 `*` in the interactive browser stars the highlighted session; `f` filters the list to

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -499,8 +499,19 @@ classifier in `lib/session/host-link.ts`) and promotes it into the status column
 The two signals behind them:
 
 - **`#{session_attached}`** — the count of clients attached to a tmux-hosted session,
-  read from the `list-panes` query `listTmuxAgentSessions` already makes. An *absent*
-  count (a tmux too old to report it) means "cannot tell", never zero.
+  folded on by `foldTmuxClients` (one `list-panes` per socket, only when some row is
+  tmux-hosted). It keys off `provenance.mux`, which `enrichProvenance` stamps on any row
+  whose process env names a pane — deliberately **not** off `listTmuxAgentSessions`,
+  which only emits a row when it can resolve the pane's agent *identity* and emits
+  nothing at all on a machine where neither the launch registry nor a session meta
+  resolves. Hanging the count off that source would leave the orphan signal silently
+  dead on exactly those machines. An *absent* count (a tmux too old to report the field)
+  means "cannot tell", never zero.
+
+  Note the separator: tmux **sanitizes non-printable characters out of format output**
+  (3.6a rewrites a literal tab to `_`), so every `-F` query here uses a printable
+  `TMUX_FIELD_SEP`. `listTmuxAgentSessions` split on `\t` and therefore returned zero
+  rows on any such tmux — fixed alongside this.
 - **The IDE window heartbeat** — the `at` stamp on each window's slice of
   `live-terminals.json`. The Factory extension force-republishes every 4 minutes, so a
   slice older than `HOST_HEARTBEAT_STALE_MS` (10 minutes, the same window the extension

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -559,6 +559,11 @@ Favorites are **per-machine**. Session sync carries `.history/backups/`
 starred on another — even though the session id itself is fleet-wide. Carrying them
 would mean adding the file to the sync manifest.
 
+That store is per-machine but the FILTER is not scoped to one: `--favorites` applies to
+every row in the merged fleet view, so a peer's session you starred from here still
+shows. This is why the live `--active` path filters after the remote fan-out rather than
+forwarding the flag to each peer — a peer has its own (different) star list.
+
 ## Export / Import (portable bundles)
 
 `agents sessions export` bundles selected sessions into a portable, self-describing

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -532,6 +532,21 @@ Precedence is deliberate, so the words keep their meaning:
 
 A `crashed` row is deliberately transient: once its transcript goes days-stale it
 degrades to `abandoned`, so the listing carries an alert, not a permanent tombstone.
+And a dead session never trips the `--waiting` gate, however its last turn ended:
+`activity` is not rewritten on death, so a session that crashed mid-question would
+otherwise read as "needs your input" forever when what it needs is a relaunch
+(`isAwaitingUser`).
+
+**Known residual — an ambient tmux session.** `provenance.mux` is stamped from the
+process env, so an agent launched inside a tmux session the *developer* owns (rather
+than one the CLI spawned for it) reads that session's client count. Detach that tmux for
+unrelated reasons and its idle/waiting agents read `orphaned` until you reattach. The
+blast radius is bounded — a `running` session is never relabelled, `--waiting` still
+fires through `activity`, and the preview keeps the specific "waiting on you" sentence
+rather than replacing it with the generic orphan line — but the label is optimistic
+about whose tmux it is. Distinguishing a CLI-spawned pane from an ambient one is
+possible (`listPidSessionEntries()` knows which panes it launched) and is the fix if
+this proves noisy in practice.
 
 Both are visible everywhere a status already was — the `--active` grouped view, the
 default printed listing, `--active --json` (plus a `hostLink` field), and the session

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -551,8 +551,13 @@ the `y` copy-cmd round-trips a starred view into a command.
 Stars live in `~/.agents/.history/favorites.json` keyed by session id, **not** in
 `sessions.db`. The index is a rebuildable cache — a reindex re-derives every row from
 the transcripts on disk — and a favorite is not derivable from a transcript, so a column
-there would be silently lost on the next rebuild. `.history` is never pruned and syncs
-across machines, so a session starred on one box is starred on every box.
+there would be silently lost on the next rebuild. `.history` is never pruned, so a star
+survives that rebuild.
+
+Favorites are **per-machine**. Session sync carries `.history/backups/`
+(`lib/session/sync/agents.ts`), not this file, so a session starred on one box is not
+starred on another — even though the session id itself is fleet-wide. Carrying them
+would mean adding the file to the sync manifest.
 
 ## Export / Import (portable bundles)
 

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -484,6 +484,54 @@ whether it is `background` or `parked` is decided live from the recorded pid plu
 start-time fingerprint (which defeats PID reuse). Ad-hoc headless runs and cloud/team
 rows carry no presence — they are not on this axis.
 
+## Lost hosts: `crashed` and `orphaned`
+
+Every other liveness signal answers "is the agent process alive". None of them answer
+"is anyone still driving it", and those come apart in the two ways a user notices — so
+`getActiveSessions` folds a **host link** onto every row (`foldHostLink`, from the pure
+classifier in `lib/session/host-link.ts`) and promotes it into the status column:
+
+| status | glyph | what happened |
+| --- | --- | --- |
+| `crashed` | `✗` | The host window (VS Code, the terminal, an SSH connection) went down hard and the agent died with it. Its slice of `live-terminals.json` is still there naming a dead pid, because the window never got to run its teardown. |
+| `orphaned` | `◍` | The agent is still alive with **no client attached** — tmux reports zero attached clients, or the IDE window that owned it stopped republishing. It is idle, or sitting on a question nobody will answer. |
+
+The two signals behind them:
+
+- **`#{session_attached}`** — the count of clients attached to a tmux-hosted session,
+  read from the `list-panes` query `listTmuxAgentSessions` already makes. An *absent*
+  count (a tmux too old to report it) means "cannot tell", never zero.
+- **The IDE window heartbeat** — the `at` stamp on each window's slice of
+  `live-terminals.json`. The Factory extension force-republishes every 4 minutes, so a
+  slice older than `HOST_HEARTBEAT_STALE_MS` (10 minutes, the same window the extension
+  uses to GC a dead peer) means that window is gone.
+
+Precedence is deliberate, so the words keep their meaning:
+
+- `abandoned` (days-stale) wins outright and claims no host link.
+- `crashed` **replaces** `closed` — both mean the process is gone, but `closed` reads as
+  a normal exit.
+- `orphaned` replaces only `idle` / `input_required`. A session still **working** with
+  nobody watching is an ordinary headless run; flagging every one would bury the signal.
+- A session detached on purpose (`presence` `background`/`parked`) is never flagged — no
+  client is the point of detaching.
+
+A `crashed` row is deliberately transient: once its transcript goes days-stale it
+degrades to `abandoned`, so the listing carries an alert, not a permanent tombstone.
+
+## Favorites (starred sessions)
+
+`*` in the interactive browser stars the highlighted session; `f` filters the list to
+the starred ones. Outside a TTY, `agents sessions favorite <id>` (`--remove`, `--list`,
+`--json`) does the same, and `agents sessions --favorites` is the flag twin of `f` — so
+the `y` copy-cmd round-trips a starred view into a command.
+
+Stars live in `~/.agents/.history/favorites.json` keyed by session id, **not** in
+`sessions.db`. The index is a rebuildable cache — a reindex re-derives every row from
+the transcripts on disk — and a favorite is not derivable from a transcript, so a column
+there would be silently lost on the next rebuild. `.history` is never pruned and syncs
+across machines, so a session starred on one box is starred on every box.
+
 ## Export / Import (portable bundles)
 
 `agents sessions export` bundles selected sessions into a portable, self-describing

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -235,7 +235,30 @@ SSH access (§7); rendering sessions that no harness produced.
   boolean, but `unknown` remains valid input from older remote peers. A structural
   `AskUserQuestion` / `ExitPlanMode` as last event MUST report `waiting_input` and
   MUST NOT decay with the freshness window (`lib/session/state.ts`; test
-  `state.test.ts`).
+  `state.test.ts`). A dead process whose OWNING HOST WINDOW also stopped
+  republishing MUST report `crashed` rather than `closed` — see SES-18a, which
+  narrows this clause.
+- **SES-18a (MUST).** A session's **host link** — whether any client is still
+  driving it — MUST be derived, never asserted, and MUST be folded on centrally
+  (`foldHostLink`, `lib/session/active.ts`) from the pure classifier
+  (`lib/session/host-link.ts`), never decided per source. A live agent with a
+  tmux attached-client count of exactly zero, or whose owning IDE window has not
+  republished its `live-terminals.json` slice within `HOST_HEARTBEAT_STALE_MS`,
+  MUST classify as `no-client`; a dead agent under such a window MUST classify as
+  `host-gone`. An ABSENT client count MUST read as unknown, never as zero. A
+  session whose `presence` is `background`/`parked` MUST NOT be classified as
+  either — no client is the point of detaching. On the status column, `abandoned`
+  MUST win outright, `host-gone` MUST replace `closed` with `crashed`, and
+  `no-client` MUST replace ONLY `idle`/`input_required` with `orphaned` — a
+  session still `running` MUST keep that status, so an ordinary headless run is
+  never reported as orphaned (test `active.hostlink.test.ts`,
+  `host-link.test.ts`).
+- **SES-18b (MUST).** A favorite MUST be stored outside `sessions.db`
+  (`~/.agents/.history/favorites.json`, keyed by session id;
+  `lib/session/favorites.ts`), because the index is a rebuildable cache and a
+  favorite is not derivable from a transcript. A malformed or absent store MUST
+  degrade to "nothing is favorited", never throw into the listing path (test
+  `favorites.test.ts`).
 - **SES-19 (MUST).** Detach/attach presence MUST be **derived, never asserted**:
   the record only says "this session was detached"; `background` vs `parked` is
   decided live from the recorded pid + start-time fingerprint

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -272,7 +272,9 @@ SSH access (§7); rendering sessions that no harness produced.
   `lib/session/favorites.ts`), because the index is a rebuildable cache and a
   favorite is not derivable from a transcript. A malformed or absent store MUST
   degrade to "nothing is favorited", never throw into the listing path (test
-  `favorites.test.ts`).
+  `favorites.test.ts`). Favorites are per-machine: the store is NOT in the sync
+  manifest (`lib/session/sync/agents.ts` syncs `.history/backups/`), and any doc
+  claiming otherwise is drift.
 - **SES-19 (MUST).** Detach/attach presence MUST be **derived, never asserted**:
   the record only says "this session was detached"; `background` vs `parked` is
   decided live from the recorded pid + start-time fingerprint

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -252,7 +252,13 @@ SSH access (§7); rendering sessions that no harness produced.
   `no-client` MUST replace ONLY `idle`/`input_required` with `orphaned` — a
   session still `running` MUST keep that status, so an ordinary headless run is
   never reported as orphaned (test `active.hostlink.test.ts`,
-  `host-link.test.ts`).
+  `host-link.test.ts`). A dead-pid registry entry whose window has gone stale MUST
+  be RETAINED by `readLiveTerminals` so the session reaches the listing at all —
+  dropping it made a crashed session indistinguishable from one that never ran
+  (test `active.registry-retention.test.ts`). Every `tmux -F` format query MUST
+  use a printable field separator: tmux sanitizes non-printable characters out of
+  format output, so a tab-separated format returns one unsplittable field (test
+  `active.tmux-clients.test.ts`).
 - **SES-18b (MUST).** A favorite MUST be stored outside `sessions.db`
   (`~/.agents/.history/favorites.json`, keyed by session id;
   `lib/session/favorites.ts`), because the index is a rebuildable cache and a

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -256,9 +256,17 @@ SSH access (§7); rendering sessions that no harness produced.
   be RETAINED by `readLiveTerminals` so the session reaches the listing at all —
   dropping it made a crashed session indistinguishable from one that never ran
   (test `active.registry-retention.test.ts`). Every `tmux -F` format query MUST
-  use a printable field separator: tmux sanitizes non-printable characters out of
-  format output, so a tab-separated format returns one unsplittable field (test
-  `active.tmux-clients.test.ts`).
+  use a separator tmux cannot emit inside a field: it sanitizes non-printable
+  characters out of format output, so a tab-separated format returns one
+  unsplittable field, and a printable separator a session name MAY contain merely
+  lowers the probability of the same bug. `:` is safe because tmux itself
+  rewrites `:`/`.` in a session name; the one field that may contain it
+  (`pane_current_path`) MUST be queried last (test `active.tmux-clients.test.ts`).
+  Consumers that read `ActiveStatus` MUST handle `orphaned`/`crashed` rather than
+  falling through to a stale `activity` — the `--waiting` filter reads the
+  never-rewritten activity via `isAwaitingUser`, the `--active` tally carries a
+  bucket per status, and the HQ Floor maps both to a needs-a-human mood
+  (`lib/hq/floor.ts`; tests `active.hostlink.test.ts`, `floor.test.ts`).
 - **SES-18b (MUST).** A favorite MUST be stored outside `sessions.db`
   (`~/.agents/.history/favorites.json`, keyed by session id;
   `lib/session/favorites.ts`), because the index is a rebuildable cache and a

--- a/apps/cli/src/commands/__tests__/sessions-columns.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-columns.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import type { ActiveSession } from '../../lib/session/active.js';
 import chalk from 'chalk';
 import { stripVTControlCharacters } from 'node:util';
 import {
@@ -157,6 +158,42 @@ describe('formatPickerLabel', () => {
   it('omits the host column entirely when it is off', () => {
     const row = strip(formatPickerLabel(meta(), '', { showHost: false }, undefined, 'ghostty'));
     expect(row).not.toContain('ghostty');
+  });
+
+  // The browser showed which terminal a session ran in but never WHAT it was
+  // doing, so a session that had lost its host looked exactly like a healthy
+  // one in the row list — the whole point of the new statuses is that you can
+  // see them where you are already looking.
+  it('renders the live status word when the status column is on', () => {
+    const live = { context: 'terminal', kind: 'claude', status: 'orphaned' } as ActiveSession;
+    const row = strip(formatPickerLabel(meta(), '', { showStatus: true }, undefined, '', false, live));
+    expect(row).toContain('orphan');
+  });
+
+  it('renders `crashed` for a session whose host went down with it', () => {
+    const live = { context: 'terminal', kind: 'claude', status: 'crashed' } as ActiveSession;
+    const row = strip(formatPickerLabel(meta(), '', { showStatus: true }, undefined, '', false, live));
+    expect(row).toContain('crashed');
+  });
+
+  it('holds the status column width for a row with no live match, so nothing jogs', () => {
+    const live = { context: 'terminal', kind: 'claude', status: 'running' } as ActiveSession;
+    const withLive = strip(formatPickerLabel(meta(), '', { showStatus: true }, undefined, '', false, live));
+    const withoutLive = strip(formatPickerLabel(meta(), '', { showStatus: true }, undefined, '', false, undefined));
+    // The topic must start at the same column in both, or the list is ragged on
+    // exactly the rows that are not running.
+    const at = (row: string) => row.indexOf('do a thing');
+    expect(at(withLive)).toBeGreaterThan(0);
+    expect(at(withoutLive)).toBe(at(withLive));
+    // And the live row really did render its status, so this is not vacuous.
+    expect(withLive).toContain('working');
+    expect(withoutLive).not.toContain('working');
+  });
+
+  it('omits the status column entirely when it is off', () => {
+    const live = { context: 'terminal', kind: 'claude', status: 'orphaned' } as ActiveSession;
+    const row = strip(formatPickerLabel(meta(), '', { showStatus: false }, undefined, '', false, live));
+    expect(row).not.toContain('orphan');
   });
 });
 

--- a/apps/cli/src/commands/__tests__/sessions-favorite.cli.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-favorite.cli.test.ts
@@ -67,6 +67,61 @@ describe('agents sessions favorite (real CLI parse)', () => {
     expect(parsed.results[0].error).toContain('No session matches');
   });
 
+  // `--favorites` was wired into the interactive BROWSER only, so on every path
+  // that skips the browser — --json, --waiting, a pipe, a multi-host scope, an
+  // SSH-fanout peer — the flag silently did nothing and `--active --favorites`
+  // returned the whole fleet. That is the exact command the browser's own `y`
+  // copy-cmd hands to an agent.
+  it('narrows --active to the starred sessions, not just in the browser', () => {
+    const registry = path.join(home, '.agents', '.cache', 'terminals', 'live-terminals.json');
+    fs.mkdirSync(path.dirname(registry), { recursive: true });
+    const starred = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const other = 'bbbbbbbb-0000-0000-0000-000000000002';
+    fs.writeFileSync(
+      registry,
+      JSON.stringify({
+        w: {
+          at: new Date().toISOString(),
+          entries: [starred, other].map((sessionId) => ({
+            sessionId,
+            pid: process.pid,
+            kind: 'claude',
+            cwd: home,
+            startedAtMs: Date.now(),
+          })),
+        },
+      }),
+    );
+
+    const all = JSON.parse(run(['sessions', '--active', '--local', '--json']).stdout) as { sessionId?: string }[];
+    expect(all.filter((r) => r.sessionId === starred || r.sessionId === other)).toHaveLength(2);
+
+    expect(run(['sessions', 'favorite', starred]).status).toBe(0);
+    const only = JSON.parse(run(['sessions', '--active', '--favorites', '--local', '--json']).stdout) as {
+      sessionId?: string;
+    }[];
+    expect(only.map((r) => r.sessionId)).toEqual([starred]);
+
+    // Leave the store clean for the other cases in this file.
+    run(['sessions', 'favorite', starred, '--remove']);
+    fs.rmSync(registry, { force: true });
+  });
+
+  it('stars a complete id with no transcript row — a live session may not be indexed yet', () => {
+    const fresh = 'cccccccc-0000-0000-0000-000000000003';
+    expect(run(['sessions', 'favorite', fresh]).status).toBe(0);
+    expect(JSON.parse(run(['sessions', 'favorite', '--list', '--json']).stdout)).toEqual({ favorites: [fresh] });
+    run(['sessions', 'favorite', fresh, '--remove']);
+  });
+
+  it('still refuses a partial id that resolves to nothing', () => {
+    // Only a COMPLETE id skips the index; a short prefix must still fail loudly
+    // rather than starring an id that names no session at all.
+    const res = run(['sessions', 'favorite', 'ccccc']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('No session matches');
+  });
+
   it('lists the favorite flag on its own --help', () => {
     const res = run(['sessions', 'favorite', '--help']);
     expect(res.stdout).toContain('--json');

--- a/apps/cli/src/commands/__tests__/sessions-favorite.cli.test.ts
+++ b/apps/cli/src/commands/__tests__/sessions-favorite.cli.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { spawnSync } from 'child_process';
+
+const repoRoot = process.cwd();
+const cliEntry = path.join(repoRoot, 'src', 'index.ts');
+// Run tsx via `node node_modules/tsx/dist/cli.mjs`, not the .bin/tsx shim: on
+// Windows the shim is tsx.cmd, which spawnSync cannot exec without a shell.
+const tsxBin = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+
+let home: string;
+
+function run(args: string[]) {
+  return spawnSync(process.execPath, [tsxBin, cliEntry, ...args], {
+    cwd: home,
+    env: { ...process.env, HOME: home, AGENTS_SKIP_MIGRATION: '1', NODE_NO_WARNINGS: '1' },
+    encoding: 'utf-8',
+  });
+}
+
+beforeAll(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'fav-cli-' + crypto.randomBytes(4).toString('hex') + '-'));
+  // ensureInitialized() looks for ~/.agents/.system/.git as the setup marker.
+  fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
+});
+
+afterAll(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+/**
+ * Drives the REAL CLI, because the bug this pins lives in argument parsing and
+ * is invisible to a direct call of the action.
+ *
+ * `agents sessions` declares `--json` AND takes a positional `[query]`, so
+ * commander keeps matching parent-known options past the subcommand name and
+ * binds `--json` to the PARENT. `sessions favorite --list --json` therefore
+ * printed the human listing while the subcommand's own `options.json` sat
+ * undefined — a machine caller silently got prose. Only a real spawn sees it.
+ */
+describe('agents sessions favorite (real CLI parse)', () => {
+  it('honors --json even though the parent command also declares it', () => {
+    const res = run(['sessions', 'favorite', '--list', '--json']);
+    expect(res.status).toBe(0);
+    expect(() => JSON.parse(res.stdout)).not.toThrow();
+    expect(JSON.parse(res.stdout)).toEqual({ favorites: [] });
+  });
+
+  it('defaults to listing when given no ids', () => {
+    const res = run(['sessions', 'favorite', '--json']);
+    expect(JSON.parse(res.stdout)).toEqual({ favorites: [] });
+  });
+
+  it('exits non-zero on an id that resolves to nothing, so a script cannot read success', () => {
+    const res = run(['sessions', 'favorite', 'nosuchsession99']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('No session matches');
+  });
+
+  it('reports the failure in --json too, not just on stderr', () => {
+    const res = run(['sessions', 'favorite', 'nosuchsession99', '--json']);
+    expect(res.status).toBe(1);
+    const parsed = JSON.parse(res.stdout) as { results: { error?: string }[] };
+    expect(parsed.results[0].error).toContain('No session matches');
+  });
+
+  it('lists the favorite flag on its own --help', () => {
+    const res = run(['sessions', 'favorite', '--help']);
+    expect(res.stdout).toContain('--json');
+    expect(res.stdout).toContain('--remove');
+  });
+});

--- a/apps/cli/src/commands/sessions-browser.test.ts
+++ b/apps/cli/src/commands/sessions-browser.test.ts
@@ -34,6 +34,7 @@ const row = (over: Partial<SessionMeta> = {}): SessionMeta =>
 const base: BrowserFilter = {
   running: false,
   teams: false,
+  favorites: false,
   agent: undefined,
   device: undefined,
   projectScope: 'repo',
@@ -44,6 +45,10 @@ describe('browserFilterToArgv — the human↔agent contract', () => {
   it('an empty repo-scoped filter is just `sessions`', () => {
     // projectScope 'repo' is the default view, so it emits no flag.
     expect(browserFilterToArgv(base)).toEqual(['sessions']);
+  });
+
+  it('favorites-only maps to --favorites, so `y` round-trips a starred view', () => {
+    expect(browserFilterToArgv({ ...base, favorites: true })).toEqual(['sessions', '--favorites']);
   });
 
   it('running-only maps to --active', () => {
@@ -449,5 +454,28 @@ describe('shouldShowHostColumn — live-only, gated on the filter not the cache'
 
   it('stays off before the live index has been fetched', () => {
     expect(shouldShowHostColumn({ ...base, running: true }, null, rows)).toBe(false);
+  });
+});
+
+/**
+ * `buildInitialFilter` copies the seed field by field, and an omitted field is
+ * SILENT — the field is optional, so the compiler says nothing and the browser
+ * just opens without that filter. `team` was lost exactly this way. So each new
+ * field earns an assertion that it survives the copy, in both directions.
+ */
+describe('favorites survives the seed → filter copy', () => {
+  it('carries a seeded favorites flag into the live filter', () => {
+    expect(buildInitialFilter({ favorites: true }).favorites).toBe(true);
+  });
+
+  it('defaults to off, never undefined', () => {
+    expect(buildInitialFilter({}).favorites).toBe(false);
+  });
+
+  it('is reachable from both entry points\u0027 seeds', () => {
+    expect(bareBrowserSeed({ favorites: true }).favorites).toBe(true);
+    expect(activeBrowserSeed({ favorites: true }).favorites).toBe(true);
+    expect(bareBrowserSeed({}).favorites).toBe(false);
+    expect(activeBrowserSeed({}).favorites).toBe(false);
   });
 });

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -19,6 +19,7 @@ import type { ActiveSession } from '../lib/session/active.js';
 import { discoverSessions } from '../lib/session/discover.js';
 import { gatherRemoteList } from '../lib/session/remote-list.js';
 import { enrichTeamOrigins, safeTeamText } from '../lib/session/team-filter.js';
+import { listFavorites, toggleFavorite } from '../lib/session/favorites.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { buildPreview } from './sessions-picker.js';
 import {
@@ -35,6 +36,7 @@ import {
   shouldIncludeLocal,
   remoteHostsToDial,
   matchesTeam,
+  formatLiveStatusHeadline,
   type PickerColumns,
 } from './sessions.js';
 
@@ -53,6 +55,8 @@ export interface BrowserFilter {
   device?: string;
   /** filter to one team's lineage, or all — the `T` key / `--in-team`. */
   team?: string;
+  /** favorited-only — the `f` key / `--favorites`. */
+  favorites: boolean;
   /** this-repo subtree vs every directory — the `P` key / `--all`. */
   projectScope: 'repo' | 'all';
   /** time window (undefined = all time) — the `W` key / `--since`. */
@@ -76,6 +80,7 @@ export function buildInitialFilter(initial: Partial<BrowserFilter>): BrowserFilt
   return {
     running: initial.running ?? false,
     teams: initial.teams ?? false,
+    favorites: initial.favorites ?? false,
     agent: initial.agent,
     device: initial.device,
     team: initial.team,
@@ -151,6 +156,7 @@ export function browserFilterToArgv(f: BrowserFilter, query = ''): string[] {
   const a = ['sessions'];
   if (f.running) a.push('--active');
   if (f.teams) a.push('--teams');
+  if (f.favorites) a.push('--favorites');
   if (f.agent) a.push('-a', f.agent);
   if (f.device) a.push('--device', f.device);
   if (f.team) a.push('--in-team', f.team);
@@ -181,10 +187,12 @@ export function activeBrowserSeed(opts: {
   host?: string[];
   since?: string;
   all?: boolean;
+  favorites?: boolean;
 }): Partial<BrowserFilter> {
   return {
     running: true,
     teams: !!opts.teams,
+    favorites: !!opts.favorites,
     agent: opts.agent,
     projectScope: 'all',
     device: normalizeDeviceSeed(opts.host?.[0]),
@@ -208,6 +216,7 @@ export function bareBrowserSeed(opts: {
   since?: string;
   host?: string[];
   inTeam?: string;
+  favorites?: boolean;
 }): Partial<BrowserFilter> {
   // An explicit --device scopes the pool to a peer, whose cwds live under that
   // machine's home — none of them can be under OUR process.cwd(), so the default
@@ -223,6 +232,7 @@ export function bareBrowserSeed(opts: {
   const wholeTeam = !!opts.inTeam;
   return {
     teams: !!opts.teams,
+    favorites: !!opts.favorites,
     agent: opts.agent,
     // The filter carries one device; seed it only when the scope names exactly
     // one, so a two-device scope isn't narrowed to the first of them.
@@ -426,14 +436,19 @@ export function shouldShowHostColumn(
   return rows.some((r) => liveHostLabel(live.get(r.id)) !== '');
 }
 
-/** Apply the cheap in-memory filters (agent / device / project / running). */
+/** Apply the cheap in-memory filters (agent / device / project / running / favorites). */
 function applyFilters(
   rows: SessionMeta[],
   live: Map<string, ActiveSession>,
   f: BrowserFilter,
   self: string,
+  favorites: Set<string>,
 ): SessionMeta[] {
   let out = rows;
+  // A projected live row is keyed by pid/task when it has no session id, and a
+  // favorite is always keyed by a real session id — so an id-less row can never
+  // be favorited and correctly drops out here.
+  if (f.favorites) out = out.filter((r) => favorites.has(r.id));
   if (f.agent) out = out.filter((r) => r.agent === f.agent);
   if (f.device) out = out.filter((r) => (r.machine ?? self) === f.device);
   if (f.team) out = out.filter((r) => matchesTeam(r, f.team!));
@@ -465,6 +480,7 @@ function headerFor(f: BrowserFilter): string {
   ];
   if (f.running) bits.push('running');
   if (f.teams) bits.push('teams');
+  if (f.favorites) bits.push('favorites');
   return bits.join(' · ');
 }
 
@@ -472,7 +488,7 @@ function helpFor(_f: BrowserFilter, mode: 'nav' | 'search'): string {
   if (mode === 'search') {
     return 'type to filter · ↑↓ navigate · esc exit search · ⏎ resume';
   }
-  return 's search · r running · c teams · t team · a agent · d device · p project · w window · tab preview · y copy-cmd · ⏎ resume · esc quit';
+  return 's search · r running · f favorites · * star · c teams · t team · a agent · d device · p project · w window · tab preview · y copy-cmd · ⏎ resume · esc quit';
 }
 
 /**
@@ -505,6 +521,10 @@ export async function runSessionBrowser(
   // The live index is slow (a full ps/tmux scan) and only the running filter
   // needs it — fetch it once, lazily, the first time running is toggled on.
   let liveCache: Map<string, ActiveSession> | null = null;
+  // Re-read every load (it's an mtime-memoized parse of one small file), so the
+  // `*` key's reload picks up the star it just wrote — and so does a favorite
+  // starred by another session on this machine.
+  let favorites = new Set<string>();
   // Generation guard: two quick keypresses can start overlapping loads whose
   // SSH fan-outs settle out of order. dynamicPicker's own gen ref guards which
   // rows become `items`, but the shared closure state below (cols / cycle pools /
@@ -560,7 +580,8 @@ export async function runSessionBrowser(
       ...rows.map((r) => safeTeamText(r.spawnedTeam)),
       ...rows.map((r) => safeTeamText(r.teamOrigin?.team)),
     ]);
-    const filtered = applyFilters(rows, live ?? new Map(), f, self);
+    favorites = listFavorites();
+    const filtered = applyFilters(rows, live ?? new Map(), f, self, favorites);
     cols = pickerColumnsFor(filtered);
     cols.showHost = shouldShowHostColumn(f, live, filtered);
     return filtered;
@@ -572,9 +593,24 @@ export async function runSessionBrowser(
     load,
     keyFor: (s) => s.id,
     labelFor: (s, q) =>
-      formatPickerLabel(s, q, cols, sshOriginTagFor(liveCache, s.id), liveHostLabel(liveCache?.get(s.id))),
+      formatPickerLabel(
+        s,
+        q,
+        cols,
+        sshOriginTagFor(liveCache, s.id),
+        liveHostLabel(liveCache?.get(s.id)),
+        favorites.has(s.id),
+      ),
     matches: sessionMatchesQuery,
-    buildPreview,
+    // Lead the preview with the live status banner — the one place a `crashed` /
+    // `orphaned` session gets a sentence instead of a glyph. `buildPreview` is
+    // memoized per session, so the volatile live half is prepended here rather
+    // than baked into the cached body.
+    buildPreview: (s) => {
+      const headline = formatLiveStatusHeadline(liveCache?.get(s.id), favorites.has(s.id));
+      const body = buildPreview(s);
+      return headline ? `${headline}\n${body}` : body;
+    },
     headerFor: (f) =>
       unreachable.length > 0
         ? `${headerFor(f)} · ${chalk.yellow(`${unreachable.join(', ')}: unreachable`)}`
@@ -585,6 +621,7 @@ export async function runSessionBrowser(
     loadingMessage: local ? 'Loading…' : 'Loading (reaching other machines)…',
     keyBindings: {
       r: (f) => ({ ...f, running: !f.running }),
+      f: (f) => ({ ...f, favorites: !f.favorites }),
       c: (f) => ({ ...f, teams: !f.teams }),
       a: (f) => ({ ...f, agent: cycle(f.agent, agentsInPool) }),
       d: (f) => ({ ...f, device: cycle(f.device, devicesInPool) }),
@@ -595,7 +632,15 @@ export async function runSessionBrowser(
       p: (f) => (hosts ? f : { ...f, projectScope: f.projectScope === 'repo' ? 'all' : 'repo' }),
       w: (f) => ({ ...f, window: cycleWindow(f.window) }),
     },
-    onKey: (name, f, _active, query) => {
+    onKey: (name, f, active, query) => {
+      if (name === '*') {
+        // Only a row with a real session id can be starred: a projected live row
+        // with no id is keyed by pid, which is gone the moment the process is.
+        if (!active || active.id.startsWith(LIVE_ROW_PREFIX)) return 'nothing to star on this row';
+        const on = toggleFavorite(active.id);
+        // reload so the row's star is repainted — labels are memoized per row.
+        return { flash: on ? `★ favorited ${active.shortId}` : `☆ unfavorited ${active.shortId}`, reload: true };
+      }
       if (name === 'y') {
         // Thread the live search query so the copied command reproduces the
         // exact view — the human→agent bridge must include the search term.

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -584,6 +584,10 @@ export async function runSessionBrowser(
     const filtered = applyFilters(rows, live ?? new Map(), f, self, favorites);
     cols = pickerColumnsFor(filtered);
     cols.showHost = shouldShowHostColumn(f, live, filtered);
+    // Status rides the same gate as the host column: both come from the live
+    // scan, so both belong to the running view and neither should widen a plain
+    // transcript listing that has no live rows to fill them.
+    cols.showStatus = !!f.running && !!live;
     return filtered;
   };
 
@@ -600,6 +604,7 @@ export async function runSessionBrowser(
         sshOriginTagFor(liveCache, s.id),
         liveHostLabel(liveCache?.get(s.id)),
         favorites.has(s.id),
+        liveCache?.get(s.id),
       ),
     matches: sessionMatchesQuery,
     // Lead the preview with the live status banner — the one place a `crashed` /

--- a/apps/cli/src/commands/sessions-browser.ts
+++ b/apps/cli/src/commands/sessions-browser.ts
@@ -646,7 +646,9 @@ export async function runSessionBrowser(
         // reload so the row's star is repainted — labels are memoized per row.
         return { flash: on ? `★ favorited ${active.shortId}` : `☆ unfavorited ${active.shortId}`, reload: true };
       }
-      if (name === 'y') {
+      // Both cases: `hotkeyToken` hands `onKey` the literal character, and this
+      // key worked with caps lock on before it existed.
+      if (name === 'y' || name === 'Y') {
         // Thread the live search query so the copied command reproduces the
         // exact view — the human→agent bridge must include the search term.
         const cmd = 'ag ' + browserFilterToArgv(f, query).join(' ');

--- a/apps/cli/src/commands/sessions-favorite.ts
+++ b/apps/cli/src/commands/sessions-favorite.ts
@@ -1,0 +1,111 @@
+/**
+ * `agents sessions favorite` — the non-TTY half of the star.
+ *
+ * The `*` hotkey in the interactive browser is how a human stars a session; this
+ * is how a script, an agent, or a machine without a TTY does the same thing, and
+ * it is what makes the feature testable end to end without driving a terminal UI.
+ * Both write the one store in `lib/session/favorites.ts`.
+ */
+
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import { setHelpSections } from '../lib/help.js';
+import { findSessionsById } from '../lib/session/db.js';
+import { isFavorite, listFavorites, setFavorite } from '../lib/session/favorites.js';
+
+interface FavoriteOptions {
+  remove?: boolean;
+  list?: boolean;
+  json?: boolean;
+}
+
+/**
+ * Resolve one user-typed id (usually the 8-char short id the listing prints) to
+ * a full session id. Ambiguity is an ERROR, not a silent first-match: starring
+ * the wrong session is invisible until the user wonders where their star went.
+ */
+export function resolveFavoriteTarget(idQuery: string): { id: string } | { error: string } {
+  const matches = findSessionsById(idQuery);
+  if (matches.length === 0) return { error: `No session matches "${idQuery}".` };
+  if (matches.length > 1) {
+    const ids = matches.slice(0, 5).map((m) => m.shortId).join(', ');
+    return { error: `"${idQuery}" matches ${matches.length} sessions (${ids}…) — use a longer id.` };
+  }
+  return { id: matches[0].id };
+}
+
+export function registerSessionsFavoriteCommand(sessionsCmd: Command): void {
+  const cmd = sessionsCmd
+    .command('favorite')
+    .argument('[ids...]', 'Session ids to star (full or short id prefix)')
+    .description('Star sessions so they are easy to find again — list them with --favorites, or `f` in the browser.')
+    .option('--remove', 'Unstar the given sessions instead of starring them')
+    .option('--list', 'List the starred sessions (the default when no ids are given)')
+    .option('--json', 'Output JSON');
+
+  setHelpSections(cmd, {
+    examples: `
+      # Star a session by its short id (the 8 chars the listing prints)
+      agents sessions favorite 26c27162
+
+      # See what is starred
+      agents sessions favorite --list
+
+      # Browse only the starred ones
+      agents sessions --favorites
+
+      # Unstar it again
+      agents sessions favorite 26c27162 --remove
+    `,
+    notes: `
+      In the interactive browser (\`agents sessions\`), \`*\` stars the highlighted
+      session and \`f\` filters the list down to the starred ones.
+
+      Stars live in ~/.agents/.history/favorites.json, keyed by session id — so
+      they survive a reindex and follow the session across your machines.
+    `,
+  });
+
+  cmd.action((ids: string[], options: FavoriteOptions) => {
+    if (options.list || ids.length === 0) {
+      const starred = [...listFavorites()].sort();
+      if (options.json) {
+        process.stdout.write(JSON.stringify({ favorites: starred }, null, 2) + '\n');
+        return;
+      }
+      if (starred.length === 0) {
+        console.log(chalk.gray('No favorited sessions. Star one with `agents sessions favorite <id>`.'));
+        return;
+      }
+      for (const id of starred) console.log(`${chalk.yellow('★')} ${id}`);
+      console.log(chalk.gray(`\n${starred.length} favorite${starred.length === 1 ? '' : 's'}.`));
+      return;
+    }
+
+    const on = !options.remove;
+    const results: { query: string; id?: string; favorite?: boolean; error?: string }[] = [];
+    for (const idQuery of ids) {
+      const resolved = resolveFavoriteTarget(idQuery);
+      if ('error' in resolved) {
+        results.push({ query: idQuery, error: resolved.error });
+        continue;
+      }
+      // Unstarring something that was never starred, or starring it twice, is a
+      // no-op the store already short-circuits — report the resulting state.
+      setFavorite(resolved.id, on);
+      results.push({ query: idQuery, id: resolved.id, favorite: isFavorite(resolved.id) });
+    }
+
+    if (options.json) {
+      process.stdout.write(JSON.stringify({ results }, null, 2) + '\n');
+    } else {
+      for (const r of results) {
+        if (r.error) console.error(chalk.red(r.error));
+        else console.log(`${r.favorite ? chalk.yellow('★ favorited') : chalk.gray('☆ unfavorited')} ${r.id}`);
+      }
+    }
+    // A failed lookup is a failed command — a script must not read "starred" from
+    // a zero exit when nothing was starred.
+    if (results.some((r) => r.error)) process.exitCode = 1;
+  });
+}

--- a/apps/cli/src/commands/sessions-favorite.ts
+++ b/apps/cli/src/commands/sessions-favorite.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import type { Command } from 'commander';
 import { setHelpSections } from '../lib/help.js';
 import { findSessionsById } from '../lib/session/db.js';
+import { isCompleteSessionId } from '../lib/session/discover.js';
 import { isFavorite, listFavorites, setFavorite } from '../lib/session/favorites.js';
 
 interface FavoriteOptions {
@@ -25,7 +26,15 @@ interface FavoriteOptions {
  */
 export function resolveFavoriteTarget(idQuery: string): { id: string } | { error: string } {
   const matches = findSessionsById(idQuery);
-  if (matches.length === 0) return { error: `No session matches "${idQuery}".` };
+  // A COMPLETE id needs no index entry: the id is the key the store is built on,
+  // and requiring a transcript row would refuse exactly the newest sessions — a
+  // live one that has not been indexed yet. The browser's `*` stars those from
+  // the live row, so demanding a DB hit here would make the two disagree.
+  if (matches.length === 0) {
+    return isCompleteSessionId(idQuery.trim())
+      ? { id: idQuery.trim() }
+      : { error: `No session matches "${idQuery}".` };
+  }
   if (matches.length > 1) {
     const ids = matches.slice(0, 5).map((m) => m.shortId).join(', ');
     return { error: `"${idQuery}" matches ${matches.length} sessions (${ids}…) — use a longer id.` };

--- a/apps/cli/src/commands/sessions-favorite.ts
+++ b/apps/cli/src/commands/sessions-favorite.ts
@@ -69,8 +69,9 @@ export function registerSessionsFavoriteCommand(sessionsCmd: Command): void {
       In the interactive browser (\`agents sessions\`), \`*\` stars the highlighted
       session and \`f\` filters the list down to the starred ones.
 
-      Stars live in ~/.agents/.history/favorites.json, keyed by session id — so
-      they survive a reindex and follow the session across your machines.
+      Stars live in ~/.agents/.history/favorites.json, keyed by session id, so
+      they survive a reindex of the session cache. They are per-machine: session
+      sync carries transcripts, not this file.
     `,
   });
 

--- a/apps/cli/src/commands/sessions-favorite.ts
+++ b/apps/cli/src/commands/sessions-favorite.ts
@@ -16,7 +16,6 @@ import { isFavorite, listFavorites, setFavorite } from '../lib/session/favorites
 interface FavoriteOptions {
   remove?: boolean;
   list?: boolean;
-  json?: boolean;
 }
 
 /**
@@ -66,10 +65,18 @@ export function registerSessionsFavoriteCommand(sessionsCmd: Command): void {
     `,
   });
 
-  cmd.action((ids: string[], options: FavoriteOptions) => {
+  cmd.action((ids: string[], options: FavoriteOptions, self: Command) => {
+    // `--json` has to come from the merged view, not `options`. The parent
+    // `sessions` command declares `--json` AND takes a positional `[query]`, so
+    // commander keeps parsing parent-known options past the subcommand name and
+    // binds `--json` to the PARENT — `options.json` is silently undefined here
+    // while `--remove`/`--list` (unknown to the parent) arrive fine.
+    // `optsWithGlobals` is commander's own answer for reading an option a parent
+    // owns; it is still declared on this command so `--help` documents it.
+    const json = (self.optsWithGlobals() as { json?: boolean }).json === true;
     if (options.list || ids.length === 0) {
       const starred = [...listFavorites()].sort();
-      if (options.json) {
+      if (json) {
         process.stdout.write(JSON.stringify({ favorites: starred }, null, 2) + '\n');
         return;
       }
@@ -96,7 +103,7 @@ export function registerSessionsFavoriteCommand(sessionsCmd: Command): void {
       results.push({ query: idQuery, id: resolved.id, favorite: isFavorite(resolved.id) });
     }
 
-    if (options.json) {
+    if (json) {
       process.stdout.write(JSON.stringify({ results }, null, 2) + '\n');
     } else {
       for (const r of results) {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -542,9 +542,18 @@ export function liveStatusWord(a: ActiveSession | undefined): string {
  * mid-question keeps `waiting_input` forever, and answering it is not a thing a
  * human can do — it needs a relaunch. `--waiting` is a scriptable gate ("does
  * anything need me?"), so a corpse must not trip it.
+ *
+ * `closed` and `crashed` are unconditionally dead, so they are excluded outright.
+ * `abandoned` is NOT: it fires on transcript staleness before the liveness check,
+ * so it also covers the live-but-forgotten case — an interactive session that
+ * asked a question and sat untouched over a long weekend is still answerable, and
+ * is exactly what this gate exists for. It is excluded only when we positively
+ * know its process is gone; unknown liveness (an older peer, a row with no pid)
+ * stays excluded rather than inventing a human who can answer.
  */
 export function isAwaitingUser(s: ActiveSession): boolean {
-  if (s.status === 'crashed' || s.status === 'closed' || s.status === 'abandoned') return false;
+  if (s.status === 'crashed' || s.status === 'closed') return false;
+  if (s.status === 'abandoned' && s.pidAlive !== true) return false;
   return s.status === 'input_required' || s.activity === 'waiting_input';
 }
 
@@ -1323,7 +1332,10 @@ export function formatLiveStatusHeadline(live: ActiveSession | undefined, favori
   if (!live) return favorite ? chalk.yellow('★ favorited') : '';
   const { glyph } = liveGlyphAndPreview(live);
   const word = liveStatusWord(live) || live.status;
-  const needsYou = live.status === 'input_required' || live.activity === 'waiting_input';
+  // One definition, shared with `--waiting`. A second local copy drifted: the
+  // preview said "needs you" for a dead session that `--waiting` had (rightly)
+  // stopped counting, so the human and the script disagreed about the same row.
+  const needsYou = isAwaitingUser(live);
   const reason = live.awaitingReason ? ` (${live.awaitingReason.replace('_', ' ')})` : '';
   let suffix = needsYou ? chalk.yellow(`  ← needs you${reason}`) : '';
   if (live.status === 'crashed') {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -55,6 +55,8 @@ import { setHelpSections } from '../lib/help.js';
 import { registerSessionsTailCommand } from './sessions-tail.js';
 import { registerSessionsSyncCommand } from './sessions-sync.js';
 import { registerSessionsResumeCommand } from './sessions-resume.js';
+import { registerSessionsFavoriteCommand } from './sessions-favorite.js';
+import { isFavorite, listFavorites } from '../lib/session/favorites.js';
 import { registerGoCommand } from './go.js';
 import { registerFocusCommand } from './focus.js';
 import { registerDetachCommand } from './detach.js';
@@ -105,6 +107,8 @@ interface SessionsOptions extends SessionFilterOptions {
   flat?: boolean;
   /** With --active: show only sessions waiting on user input; exit 1 if any. */
   waiting?: boolean;
+  /** Show only favorited (starred) sessions — the `f` key's flag twin. */
+  favorites?: boolean;
   /** Enrich the listing with live glyphs/preview for running rows. Default on;
    * `--no-live` sets this false. Commander's `--no-` convention. */
   live?: boolean;
@@ -310,6 +314,12 @@ function statusColor(status: ActiveSession['status']): (s: string) => string {
     case 'closed': return chalk.dim;
     // Days-stale / dangling: red so a session nobody is driving stands out.
     case 'abandoned': return chalk.red;
+    // The host window died and took the agent with it — an unclean exit, not the
+    // dimmed `closed` of a normal one. Red-bright so a crash reads as an event.
+    case 'crashed': return chalk.redBright;
+    // Alive with nobody attached. Yellow, like `input_required`: both mean the
+    // session is stuck waiting on a human, and this one has no human to wait for.
+    case 'orphaned': return chalk.yellow;
     // Alive but un-introspectable (a harness whose transcript we can't parse).
     // Magenta so it never reads as the gray "idle" it used to be faked as.
     case 'unknown': return chalk.magenta;
@@ -440,7 +450,11 @@ export function formatActiveRowDescription(s: ActiveSession): string {
 function activityLabel(s: ActiveSession): string {
   // Lifecycle status wins over any residual parsed activity — a dead/dangling
   // session must read `closed`/`abandoned`, not the `idle` its stale tail infers.
+  // `crashed`/`orphaned` are the same kind of claim about the session as a whole,
+  // and both outrank the `idle` its last parsed turn would otherwise show.
   if (s.status === 'closed' || s.status === 'abandoned') return s.status;
+  if (s.status === 'crashed') return 'crashed';
+  if (s.status === 'orphaned') return 'orphan';
   if (s.activity === 'waiting_input') return 'waiting';
   if (s.activity === 'working') return 'working';
   if (s.activity === 'idle') return 'idle';
@@ -474,8 +488,13 @@ export function liveGlyphAndPreview(a: ActiveSession | undefined): { glyph: stri
   // so an opaque harness is never mistaken for a finished one. `⊘` = abandoned /
   // dangling; `×` = closed (dead pid) — both distinct from the `○` idle a live,
   // stopped session shows, so a gone session never masquerades as a resting one.
+  // `✗` = crashed (died WITH its host window, uncleanly) — deliberately louder
+  // than the `×` of a clean close. `◍` = orphaned (alive, nothing attached): a
+  // filled ring, so it reads as "still burning" unlike the hollow `○` idle.
   if (a.status === 'abandoned') return { glyph: statusColor(a.status)('⊘'), preview: buildSessionDescription(a) };
   if (a.status === 'closed') return { glyph: statusColor(a.status)('×'), preview: buildSessionDescription(a) };
+  if (a.status === 'crashed') return { glyph: statusColor(a.status)('✗'), preview: buildSessionDescription(a) };
+  if (a.status === 'orphaned') return { glyph: statusColor(a.status)('◍'), preview: buildSessionDescription(a) };
 
   const waiting = a.status === 'input_required' || a.activity === 'waiting_input';
   const running = a.status === 'running' || a.activity === 'working';
@@ -500,6 +519,9 @@ export function liveStatusWord(a: ActiveSession | undefined): string {
   if (!a) return '';
   // Lifecycle status is definitive — surface it ahead of any parsed activity.
   if (a.status === 'closed' || a.status === 'abandoned') return a.status;
+  // Same rank: a lost host is a fact about the session, not about its last turn.
+  if (a.status === 'crashed') return 'crashed';
+  if (a.status === 'orphaned') return 'orphan';
   if (a.status === 'input_required' || a.activity === 'waiting_input') return 'waiting';
   if (a.status === 'running' || a.activity === 'working') return 'working';
   if (a.status === 'idle' || a.activity === 'idle') return 'idle';
@@ -1211,6 +1233,7 @@ function canonicalSessionsCommand(query: string | undefined, options: SessionsOp
   if (options.until) a.push('--until', options.until);
   if (options.local) a.push('--local');
   if (options.waiting) a.push('--waiting');
+  if (options.favorites) a.push('--favorites');
   const q = (query ?? '').trim();
   if (q) a.push(JSON.stringify(q));
   return 'ag ' + a.join(' ');
@@ -1239,15 +1262,37 @@ async function renderSessionPreview(
   try {
     live = indexActiveBySessionId(await getActiveSessions()).get(session.id);
   } catch { /* plain preview on any probe failure */ }
-  if (live) {
-    const { glyph } = liveGlyphAndPreview(live);
-    const word = liveStatusWord(live) || live.status;
-    const needsYou = live.status === 'input_required' || live.activity === 'waiting_input';
-    const reason = live.awaitingReason ? ` (${live.awaitingReason.replace('_', ' ')})` : '';
-    const suffix = needsYou ? chalk.yellow(`  ← needs you${reason}`) : '';
-    console.log(`${glyph} ${statusColor(live.status)(word)}${suffix}`);
-  }
+  const headline = formatLiveStatusHeadline(live, isFavorite(session.id));
+  if (headline) console.log(headline);
   console.log(buildPreview(session));
+}
+
+/**
+ * The one-line live status banner shown above a session preview: the glyph, the
+ * status word, and — when the session needs a human or has LOST one — a plain
+ * sentence saying so. Shared by `--preview` and the interactive browser's preview
+ * pane so both explain a state the same way.
+ *
+ * `crashed` and `orphaned` are the states a glyph alone cannot carry: nobody
+ * reads "orphan" and knows it means "still running in tmux with no window
+ * attached", so those two spell it out.
+ */
+export function formatLiveStatusHeadline(live: ActiveSession | undefined, favorite = false): string {
+  const star = favorite ? chalk.yellow('★ ') : '';
+  // With no live row there is no status to lead with, so the star has to say
+  // what it means on its own — a bare `★` above a preview reads as noise.
+  if (!live) return favorite ? chalk.yellow('★ favorited') : '';
+  const { glyph } = liveGlyphAndPreview(live);
+  const word = liveStatusWord(live) || live.status;
+  const needsYou = live.status === 'input_required' || live.activity === 'waiting_input';
+  const reason = live.awaitingReason ? ` (${live.awaitingReason.replace('_', ' ')})` : '';
+  let suffix = needsYou ? chalk.yellow(`  ← needs you${reason}`) : '';
+  if (live.status === 'crashed') {
+    suffix = chalk.redBright('  ← the host app or connection went away and took the agent with it');
+  } else if (live.status === 'orphaned') {
+    suffix = chalk.yellow('  ← still running, but no client is attached — nothing is showing it');
+  }
+  return `${star}${glyph} ${statusColor(live.status)(word)}${suffix}`;
 }
 
 /** Main action handler for `agents sessions`. Routes to picker, table, or single-session render. */
@@ -1371,6 +1416,7 @@ async function sessionsAction(
           host: options.host,
           since: options.since,
           all: options.all,
+          favorites: options.favorites,
         }),
         { local: options.local === true, hosts: options.host },
       );
@@ -1406,6 +1452,7 @@ async function sessionsAction(
         since: options.since,
         host: options.host,
         inTeam: options.inTeam,
+        favorites: options.favorites,
       }),
       { local: options.local === true, hosts: options.host },
     );
@@ -1547,6 +1594,13 @@ async function sessionsAction(
     // teammate only knows its team from the meta.json filterTeamSessions just
     // read. Match either, after that pass has populated `teamOrigin`.
     if (options.inTeam) sessions = sessions.filter((s) => matchesTeam(s, options.inTeam!));
+
+    // --favorites narrows to the starred set. Applied here, before the JSON
+    // emit, so `--favorites --json` is the machine-readable twin of the `f` key.
+    if (options.favorites) {
+      const starred = listFavorites();
+      sessions = sessions.filter((s) => starred.has(s.id));
+    }
 
     // Under --in-team the visible list is one team, so the whole-index team-origin
     // count would be a non-sequitur next to it.
@@ -1745,7 +1799,13 @@ function metaSignals(s: SessionMeta): Parameters<typeof signalBadges>[0] {
  * (tracker/PR ref, pulled out of the badge blob so refs align) is only rendered
  * when `showTicket` — otherwise a listing with no refs would waste a column of
  * dashes and needlessly truncate the topic. Worktree stays a trailing badge. */
-export function flatSessionRow(session: SessionMeta, live?: ActiveSession, showTicket = false, cols: PickerColumns = {}): string {
+export function flatSessionRow(
+  session: SessionMeta,
+  live?: ActiveSession,
+  showTicket = false,
+  cols: PickerColumns = {},
+  favorite = false,
+): string {
   const agentColor = colorAgent(session.agent);
   const when = formatRelativeTime(session.lastActivity ?? session.timestamp);
   const project = session.project || '-';
@@ -1783,7 +1843,10 @@ export function flatSessionRow(session: SessionMeta, live?: ActiveSession, showT
   const wtW = wt ? stringWidth(wt) + 1 : 0;
   const width = terminalWidth();
   const requestedModelW = cols.showModel ? (cols.modelWidth ?? PICKER_MODEL_MAX) : 0;
-  const fixedW = (10 + 9 + 8 + 16) + glyphW + statusW + machineW + ticketW + wtW + team.width + stringWidth(when) + 1;
+  // Same conditional 2 cells as the picker's marker, for the same reason.
+  const favW = cols.showFavorite ? 2 : 0;
+  const favCell = cols.showFavorite ? (favorite ? chalk.yellow('★ ') : '  ') : '';
+  const fixedW = favW + (10 + 9 + 8 + 16) + glyphW + statusW + machineW + ticketW + wtW + team.width + stringWidth(when) + 1;
   const modelSlack = width - fixedW - 16;
   const modelW = requestedModelW <= modelSlack
     ? requestedModelW
@@ -1791,6 +1854,7 @@ export function flatSessionRow(session: SessionMeta, live?: ActiveSession, showT
   const topicW = Math.max(16, width - fixedW - modelW);
 
   return (
+    favCell +
     chalk.white(padToWidth(truncateToWidth(session.shortId, 9), 10)) +
     agentColor(padToWidth(truncateToWidth(session.agent, 8), 9)) +
     chalk.yellow(padToWidth(truncateToWidth(session.version || '-', 7), 8)) +
@@ -1982,7 +2046,10 @@ function printSessionTable(sessions: SessionMeta[], hiddenCount = 0, tree = fals
   // column (and its compact labels) is computed the same way the picker does it.
   const showTicket = sessions.some((s) => ticketLabel(s) !== '');
   const cols = pickerColumnsFor(sessions);
-  for (const session of sessions) console.log(flatSessionRow(session, liveIndex?.get(session.id), showTicket, cols));
+  const favorites = listFavorites();
+  for (const session of sessions) {
+    console.log(flatSessionRow(session, liveIndex?.get(session.id), showTicket, cols, favorites.has(session.id)));
+  }
 
   const countLine = `${sessions.length} session${sessions.length === 1 ? '' : 's'}.`;
   console.log(chalk.gray(`\n${countLine}`));
@@ -2203,6 +2270,12 @@ export interface PickerColumns {
    */
   showHost?: boolean;
   /**
+   * Render the favorite marker column. Like every other conditional column here,
+   * it earns its 2 cells only when some row in the pool is actually starred — a
+   * user who has never favorited anything pays nothing for the feature.
+   */
+  showFavorite?: boolean;
+  /**
    * Cells the picker prepends before each row: 2 for the single-select cursor
    * ('> '), 6 for the multi-select cursor + checkbox ('> [x] '). Reserved from
    * the topic width so rows never wrap. Defaults to 2.
@@ -2270,6 +2343,11 @@ export function pickerColumnsFor(sessions: SessionMeta[]): PickerColumns {
     showModel: sessions.some((s) => !!s.model),
     modelWidth: modelColumnWidth(sessions),
     showTicket: sessions.some((s) => ticketLabel(s) !== ''),
+    showFavorite: (() => {
+      // One read of the store per pool, not one per row.
+      const starred = listFavorites();
+      return starred.size > 0 && sessions.some((s) => starred.has(s.id));
+    })(),
   };
 }
 
@@ -2296,6 +2374,7 @@ export function formatPickerLabel(
   cols: PickerColumns = {},
   ssh?: SshOriginTag,
   host = '',
+  favorite = false,
 ): string {
   const agentColor = colorAgent(s.agent);
   const when = formatRelativeTime(s.lastActivity ?? s.timestamp);
@@ -2342,12 +2421,18 @@ export function formatPickerLabel(
   const ticketW = cols.showTicket ? TICKET_W + 1 : 0;
   const hostW = cols.showHost ? PICKER_HOST_W : 0;
   const wtW = wt ? stringWidth(wt) + 1 : 0;
+  // Within a pool that HAS starred rows the marker holds its 2 cells whether this
+  // row is starred or not, so the columns after it never jog; a pool with none
+  // drops the column entirely (`showFavorite`) and costs nothing.
+  const favW = cols.showFavorite ? 2 : 0;
+  const favCell = cols.showFavorite ? (favorite ? chalk.yellow('★ ') : '  ') : '';
   const topicW = Math.max(
     16,
-    terminalWidth() - gutter - (10 + 9 + 8 + 16) - machineColW - hostW - ticketW - wtW - sshW - team.width - stringWidth(when) - 1,
+    terminalWidth() - gutter - favW - (10 + 9 + 8 + 16) - machineColW - hostW - ticketW - wtW - sshW - team.width - stringWidth(when) - 1,
   );
 
   return (
+    favCell +
     // Truncated, not just padded: an indexed shortId is always 8 chars, but a
     // live row with no session id is named by its pid or cloud task, which can
     // run past the column and shunt every later column out of alignment.
@@ -3306,6 +3391,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--roots', 'With --json: emit the on-disk directories scanned for session transcripts, per agent (for external watchers)')
     .option('--local', 'Only this machine — skip the cross-machine SSH fan-out (default listing and --active)')
     .option('--waiting', 'With --active: show only sessions waiting on your input (exits non-zero if any)')
+    .option('--favorites', 'Show only favorited (starred) sessions — star them with `*` in the browser or `agents sessions favorite <id>`')
     .option('--tree', 'Group the listing by directory; drops the id/version columns for readability')
     .option('--flat', 'Plain flat table (one row per session) instead of the grouped project overview')
     .option('--no-live', 'Do not enrich the listing with live status/preview for running sessions')
@@ -3380,6 +3466,7 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsTailCommand(sessionsCmd);
   registerSessionsSyncCommand(sessionsCmd);
   registerSessionsResumeCommand(sessionsCmd);
+  registerSessionsFavoriteCommand(sessionsCmd);
   registerGoCommand(sessionsCmd);
   registerFocusCommand(sessionsCmd);
   registerDetachCommand(sessionsCmd);

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -529,6 +529,19 @@ export function liveStatusWord(a: ActiveSession | undefined): string {
   return '';
 }
 
+/**
+ * True when a session is blocked on a human — the `--waiting` contract.
+ *
+ * NOT `status === 'input_required'`. `foldHostLink` rewrites that status to
+ * `orphaned` when nothing is attached, and a session waiting on a question with
+ * NOBODY watching is the most acute case `--waiting` exists to surface, not one
+ * it should drop. The underlying `activity` is never rewritten, so it is the
+ * honest signal here.
+ */
+export function isAwaitingUser(s: ActiveSession): boolean {
+  return s.status === 'input_required' || s.activity === 'waiting_input';
+}
+
 /** Width of the live status column — `crashed` is the longest word it renders. */
 const LIVE_STATUS_W = 8;
 
@@ -923,9 +936,15 @@ function groupTally(sessions: ActiveSession[]): string {
   const running = sessions.filter(s => s.status === 'running').length;
   const idle = sessions.filter(s => s.status === 'idle').length;
   const waiting = sessions.filter(s => s.status === 'input_required').length;
+  // Counted by status, deliberately: an orphaned session gets its own bucket
+  // below, so counting it here too would double-count it in the tally.
   const queued = sessions.filter(s => s.status === 'queued').length;
   const closed = sessions.filter(s => s.status === 'closed').length;
   const abandoned = sessions.filter(s => s.status === 'abandoned').length;
+  // Without these two the tally silently loses rows: every status must have a
+  // bucket or "N active (…)" stops adding up to what the list shows.
+  const orphaned = sessions.filter(s => s.status === 'orphaned').length;
+  const crashed = sessions.filter(s => s.status === 'crashed').length;
   const unknown = sessions.filter(s => s.status === 'unknown').length;
   const parts: string[] = [];
   if (running) parts.push(`${running} running`);
@@ -934,6 +953,8 @@ function groupTally(sessions: ActiveSession[]): string {
   if (queued) parts.push(`${queued} queued`);
   if (closed) parts.push(`${closed} closed`);
   if (abandoned) parts.push(`${abandoned} abandoned`);
+  if (orphaned) parts.push(`${orphaned} orphaned`);
+  if (crashed) parts.push(`${crashed} crashed`);
   if (unknown) parts.push(`${unknown} unknown`);
   return parts.join(' · ');
 }
@@ -1103,14 +1124,23 @@ export async function gatherActiveSessions(
 async function renderActiveSessions(
   asJson: boolean,
   waitingOnly = false,
-  opts: { local?: boolean; hosts?: string[] } = {},
+  opts: { local?: boolean; hosts?: string[]; favoritesOnly?: boolean } = {},
 ): Promise<void> {
   const self = machineId();
-  const { sessions: merged, remoteDeviceCount } = await gatherActiveSessions(opts);
+  const gathered = await gatherActiveSessions(opts);
+  const { remoteDeviceCount } = gathered;
+  // --favorites narrows the live view too. Applied HERE, not only in the
+  // browser: the browser is skipped for --json, --waiting, a pipe, a multi-host
+  // scope, and an SSH-fanout peer, and the flag silently did nothing on every
+  // one of those paths — including `--active --favorites --json`, which is
+  // exactly what the browser's own `y` copy-cmd hands to an agent.
+  const merged = opts.favoritesOnly
+    ? gathered.sessions.filter((s) => !!s.sessionId && listFavorites().has(s.sessionId))
+    : gathered.sessions;
 
   // --waiting: only sessions blocked on the user. Exits non-zero when any are
   // present so a supervising agent or hook can poll it as a gate.
-  const sessions = waitingOnly ? merged.filter(s => s.status === 'input_required') : merged;
+  const sessions = waitingOnly ? merged.filter(isAwaitingUser) : merged;
 
   if (asJson) {
     process.stdout.write(JSON.stringify(serializeActiveSessionsForJson(sessions), null, 2) + '\n');
@@ -1431,6 +1461,7 @@ async function sessionsAction(
     await renderActiveSessions(options.json === true, options.waiting === true, {
       local: forceLocal,
       hosts: options.host,
+      favoritesOnly: options.favorites === true,
     });
     return;
   }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -529,11 +529,14 @@ export function liveStatusWord(a: ActiveSession | undefined): string {
   return '';
 }
 
+/** Width of the live status column — `crashed` is the longest word it renders. */
+const LIVE_STATUS_W = 8;
+
 /** The colored, space-padded status cell for a listing row (empty when not live). */
 function liveStatusCell(live: ActiveSession | undefined): { cell: string; width: number } {
   const word = liveStatusWord(live);
   if (!word || !live) return { cell: '', width: 0 };
-  return { cell: statusColor(live.status)(padToWidth(word, 8)), width: 8 };
+  return { cell: statusColor(live.status)(padToWidth(word, LIVE_STATUS_W)), width: LIVE_STATUS_W };
 }
 
 /**
@@ -2276,6 +2279,13 @@ export interface PickerColumns {
    */
   showFavorite?: boolean;
   /**
+   * Render the live status column (`working` / `waiting` / `orphan` / `crashed`).
+   * Live-only, gated the same way as {@link showHost}: it comes from the
+   * active-session scan, so the running-filtered browser sets it and a plain
+   * transcript listing — where no row has a status — leaves it off.
+   */
+  showStatus?: boolean;
+  /**
    * Cells the picker prepends before each row: 2 for the single-select cursor
    * ('> '), 6 for the multi-select cursor + checkbox ('> [x] '). Reserved from
    * the topic width so rows never wrap. Defaults to 2.
@@ -2375,6 +2385,7 @@ export function formatPickerLabel(
   ssh?: SshOriginTag,
   host = '',
   favorite = false,
+  live?: ActiveSession,
 ): string {
   const agentColor = colorAgent(s.agent);
   const when = formatRelativeTime(s.lastActivity ?? s.timestamp);
@@ -2426,9 +2437,18 @@ export function formatPickerLabel(
   // drops the column entirely (`showFavorite`) and costs nothing.
   const favW = cols.showFavorite ? 2 : 0;
   const favCell = cols.showFavorite ? (favorite ? chalk.yellow('★ ') : '  ') : '';
+  // The same status word the flat listing shows, so a session that is `orphan`
+  // or `crashed` reads that way in the browser too — not only in its preview.
+  // Constant width whenever the column is on. `liveStatusCell` already pads its
+  // word to LIVE_STATUS_W but returns an EMPTY cell (width 0) for a row with no
+  // live match — blanks fill in for those, so the topic column does not jog on
+  // exactly the rows that are not running.
+  const status = cols.showStatus ? liveStatusCell(live) : { cell: '', width: 0 };
+  const statusW = cols.showStatus ? LIVE_STATUS_W : 0;
+  const statusCell = cols.showStatus ? (status.cell || ' '.repeat(LIVE_STATUS_W)) : '';
   const topicW = Math.max(
     16,
-    terminalWidth() - gutter - favW - (10 + 9 + 8 + 16) - machineColW - hostW - ticketW - wtW - sshW - team.width - stringWidth(when) - 1,
+    terminalWidth() - gutter - favW - statusW - (10 + 9 + 8 + 16) - machineColW - hostW - ticketW - wtW - sshW - team.width - stringWidth(when) - 1,
   );
 
   return (
@@ -2442,6 +2462,7 @@ export function formatPickerLabel(
     machineCell +
     hostCell +
     chalk.cyan(padRight(truncate(project, 14), 16)) +
+    statusCell +
     sshSeg +
     teamSeg +
     renderTopicCell(label, topic, query, topicW, topicW) +

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -537,8 +537,14 @@ export function liveStatusWord(a: ActiveSession | undefined): string {
  * NOBODY watching is the most acute case `--waiting` exists to surface, not one
  * it should drop. The underlying `activity` is never rewritten, so it is the
  * honest signal here.
+ *
+ * But `activity` is never rewritten for a DEAD session either: one that died
+ * mid-question keeps `waiting_input` forever, and answering it is not a thing a
+ * human can do — it needs a relaunch. `--waiting` is a scriptable gate ("does
+ * anything need me?"), so a corpse must not trip it.
  */
 export function isAwaitingUser(s: ActiveSession): boolean {
+  if (s.status === 'crashed' || s.status === 'closed' || s.status === 'abandoned') return false;
   return s.status === 'input_required' || s.activity === 'waiting_input';
 }
 
@@ -1323,7 +1329,12 @@ export function formatLiveStatusHeadline(live: ActiveSession | undefined, favori
   if (live.status === 'crashed') {
     suffix = chalk.redBright('  ← the host app or connection went away and took the agent with it');
   } else if (live.status === 'orphaned') {
-    suffix = chalk.yellow('  ← still running, but no client is attached — nothing is showing it');
+    // Keep the needs-you half. A session sitting on a real question with nobody
+    // attached is strictly worse than either fact alone, and replacing the
+    // question with the generic orphan line undersells exactly that case.
+    suffix = needsYou
+      ? chalk.yellow(`  ← waiting on you${reason}, and no client is attached to answer it`)
+      : chalk.yellow('  ← still running, but no client is attached — nothing is showing it');
   }
   return `${star}${glyph} ${statusColor(live.status)(word)}${suffix}`;
 }

--- a/apps/cli/src/lib/hq/floor.test.ts
+++ b/apps/cli/src/lib/hq/floor.test.ts
@@ -151,4 +151,42 @@ describe('buildHqFloor', () => {
     expect(snapshot.ambientEvents.some((event) => event.kind === 'error' && event.agentId === 'abandoned-session')).toBe(true);
     expect(snapshot.ambientEvents.some((event) => event.kind === 'idle_scene')).toBe(false);
   });
+
+  // A session whose host died keeps whatever `activity` its last parsed turn
+  // left behind — usually `working`. Without its own arm that falls through to
+  // the activity check and the Floor shows a cheerfully working agent for a
+  // process that is gone.
+  it('does not render a crashed or orphaned session as working on the floor', () => {
+    const sessions: ActiveSession[] = [
+      {
+        context: 'terminal',
+        kind: 'claude',
+        status: 'crashed',
+        activity: 'working',
+        sessionId: 'crashed-session',
+        machine: 'yosemite-s0',
+      },
+      {
+        context: 'terminal',
+        kind: 'claude',
+        status: 'orphaned',
+        activity: 'idle',
+        sessionId: 'orphaned-session',
+        machine: 'yosemite-s0',
+      },
+    ];
+
+    const snapshot = buildHqFloor({
+      generatedAt: new Date('2026-07-21T17:03:00.000Z'),
+      sessions,
+      teams: [],
+      teammatesByTeam: new Map(),
+      blocks: [],
+    });
+
+    expect(snapshot.agents.map((agent) => [agent.id, agent.mood])).toEqual([
+      ['crashed-session', 'blocked'],
+      ['orphaned-session', 'waiting'],
+    ]);
+  });
 });

--- a/apps/cli/src/lib/hq/floor.test.ts
+++ b/apps/cli/src/lib/hq/floor.test.ts
@@ -184,9 +184,32 @@ describe('buildHqFloor', () => {
       blocks: [],
     });
 
+    // An orphaned session that is merely idle is stranded, not asking anything —
+    // giving it the same "needs input" alert as a genuinely blocked one trains
+    // the operator to ignore the alert.
     expect(snapshot.agents.map((agent) => [agent.id, agent.mood])).toEqual([
       ['crashed-session', 'blocked'],
-      ['orphaned-session', 'waiting'],
+      ['orphaned-session', 'blocked'],
     ]);
+  });
+
+  it('renders an orphaned session that is mid-question as waiting, not merely blocked', () => {
+    const snapshot = buildHqFloor({
+      generatedAt: new Date('2026-07-21T17:03:00.000Z'),
+      sessions: [
+        {
+          context: 'terminal',
+          kind: 'claude',
+          status: 'orphaned',
+          activity: 'waiting_input',
+          sessionId: 'orphan-asking',
+          machine: 'yosemite-s0',
+        },
+      ],
+      teams: [],
+      teammatesByTeam: new Map(),
+      blocks: [],
+    });
+    expect(snapshot.agents.map((agent) => agent.mood)).toEqual(['waiting']);
   });
 });

--- a/apps/cli/src/lib/hq/floor.ts
+++ b/apps/cli/src/lib/hq/floor.ts
@@ -132,7 +132,13 @@ function moodForSession(session: ActiveSession, hasOpenBlock: boolean): HqAgentM
   // parsed turn often still says `working`, which would otherwise reach the Floor
   // as a happily-running agent. Both lost-host states need a human.
   if (session.status === 'crashed') return 'blocked';
-  if (session.status === 'orphaned') return 'waiting';
+  // An orphaned session that is genuinely mid-question needs an answer; one that
+  // is merely idle-and-unwatched needs someone to reattach or clean it up. Same
+  // distinction `isAwaitingUser` draws — giving both the high-intensity "needs
+  // input" alert would train the operator to ignore it.
+  if (session.status === 'orphaned') {
+    return session.activity === 'waiting_input' ? 'waiting' : 'blocked';
+  }
   if (session.status === 'closed') return 'done';
   if (session.status === 'input_required' || session.activity === 'waiting_input' || hasOpenBlock) return 'waiting';
   if (session.rateLimited) return 'blocked';

--- a/apps/cli/src/lib/hq/floor.ts
+++ b/apps/cli/src/lib/hq/floor.ts
@@ -128,6 +128,11 @@ function teammateName(session: ActiveSession, teammatesById: Map<string, AgentSt
 
 function moodForSession(session: ActiveSession, hasOpenBlock: boolean): HqAgentMood {
   if (session.status === 'abandoned') return 'blocked';
+  // A crashed session is NOT `done` — it stopped without finishing, and its last
+  // parsed turn often still says `working`, which would otherwise reach the Floor
+  // as a happily-running agent. Both lost-host states need a human.
+  if (session.status === 'crashed') return 'blocked';
+  if (session.status === 'orphaned') return 'waiting';
   if (session.status === 'closed') return 'done';
   if (session.status === 'input_required' || session.activity === 'waiting_input' || hasOpenBlock) return 'waiting';
   if (session.rateLimited) return 'blocked';

--- a/apps/cli/src/lib/picker.test.ts
+++ b/apps/cli/src/lib/picker.test.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { spawn } from '@homebridge/node-pty-prebuilt-multiarch';
 import { describe, expect, it } from 'vitest';
-import { limitPreviewHeight } from './picker.js';
+import { hotkeyToken, limitPreviewHeight } from './picker.js';
 
 function renderedRows(text: string, width: number): number {
   return text.split('\n').reduce((rows, line) => {
@@ -74,5 +74,47 @@ describe('multiItemPicker', () => {
     });
 
     expect(stripVTControlCharacters(output)).toContain('PREVIEW_VISIBLE');
+  });
+});
+
+/**
+ * The hotkey lookup token. readline collapses `f` and `F` onto the same `name`
+ * and gives punctuation no name at all, so keying bindings on the name alone
+ * makes `*` unbindable and a shifted letter indistinguishable from its lowercase
+ * twin. Every existing binding is a plain lowercase letter, where the token is
+ * unchanged — that no-op property is what makes this safe to swap in.
+ */
+describe('hotkeyToken', () => {
+  it('is a no-op for a plain lowercase letter (every existing binding)', () => {
+    for (const c of ['r', 'c', 'a', 'd', 't', 'p', 'w', 'y', 's', 'f']) {
+      expect(hotkeyToken({ name: c, sequence: c })).toBe(c);
+    }
+  });
+
+  it('separates a shifted letter from its lowercase twin', () => {
+    expect(hotkeyToken({ name: 'f', sequence: 'f' })).toBe('f');
+    expect(hotkeyToken({ name: 'f', sequence: 'F' })).toBe('F');
+  });
+
+  it('makes a punctuation key bindable at all — readline gives it no name', () => {
+    expect(hotkeyToken({ name: undefined, sequence: '*' })).toBe('*');
+    expect(hotkeyToken({ name: undefined, sequence: '/' })).toBe('/');
+  });
+
+  it('keeps control keys on their names, not their raw sequences', () => {
+    expect(hotkeyToken({ name: 'tab', sequence: '\t' })).toBe('tab');
+    expect(hotkeyToken({ name: 'return', sequence: '\r' })).toBe('return');
+    expect(hotkeyToken({ name: 'backspace', sequence: '\x7f' })).toBe('backspace');
+    expect(hotkeyToken({ name: 'space', sequence: ' ' })).toBe('space');
+    expect(hotkeyToken({ name: 'escape', sequence: '\x1b' })).toBe('escape');
+  });
+
+  it('never claims a modified key — ctrl-c must not read as the letter c', () => {
+    expect(hotkeyToken({ name: 'c', sequence: '\x03', ctrl: true })).toBe('c');
+    expect(hotkeyToken({ name: 'f', sequence: 'f', meta: true })).toBe('f');
+  });
+
+  it('degrades to an empty token when readline reports neither', () => {
+    expect(hotkeyToken({})).toBe('');
   });
 });

--- a/apps/cli/src/lib/picker.test.ts
+++ b/apps/cli/src/lib/picker.test.ts
@@ -117,4 +117,15 @@ describe('hotkeyToken', () => {
   it('degrades to an empty token when readline reports neither', () => {
     expect(hotkeyToken({})).toBe('');
   });
+
+  // The shifted form of an existing single-letter hotkey reached its binding
+  // through `key.name` before this token existed. Keying on the character alone
+  // would have retired `R`/`C`/`A` for anyone with caps lock on, so the lookup
+  // falls back to the name — which only works if the token and the name differ
+  // in exactly the way asserted here.
+  it('leaves the readline name available as the fallback for a shifted letter', () => {
+    const shifted = { name: 'r', sequence: 'R' };
+    expect(hotkeyToken(shifted)).toBe('R');
+    expect(shifted.name).toBe('r');
+  });
 });

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -483,6 +483,11 @@ export interface DynamicPickerConfig<T, F> {
  * apart — and gives a punctuation key like `*` no name at all. Keying on the
  * character makes shifted letters and punctuation bindable, and is a no-op for
  * every existing binding: for a plain lowercase letter, sequence === name.
+ *
+ * Callers receiving this in `onKey` see the literal character, so a handler that
+ * wants to accept both cases of a letter must say so (`'y'` and `'Y'`); the
+ * keyBindings lookup falls back to the key NAME, which keeps the shifted form of
+ * an existing single-letter binding working without each caller restating it.
  */
 export function hotkeyToken(key: { name?: string; sequence?: string; ctrl?: boolean; meta?: boolean }): string {
   const seq = key.sequence;
@@ -663,7 +668,12 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
         return;
       }
       const token = hotkeyToken(key);
-      const binding = cfg.keyBindings?.[token];
+      // Exact character first (so `*` and a shifted `F` are addressable), then
+      // the readline name. The fallback is what preserves the shifted form of an
+      // existing single-letter hotkey: `R`/`C`/`A` used to reach their bindings
+      // via `key.name`, and keying on the character alone would silently retire
+      // them for anyone with caps lock on.
+      const binding = cfg.keyBindings?.[token] ?? cfg.keyBindings?.[key.name ?? ''];
       if (binding) {
         const next = binding(filter);
         if (!Object.is(next, filter)) setFilter(next);

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -455,9 +455,16 @@ export interface DynamicPickerConfig<T, F> {
   /**
    * Side-effecting keys that don't change the filter (e.g. `y` copies a command).
    * Receives the live search `query` so the effect can be search-aware. Return a
-   * short string to flash under the list.
+   * short string to flash under the list, or `{ flash, reload }` when the effect
+   * changed something the rows RENDER (a star, a mark) and the list has to be
+   * rebuilt — the row labels are memoized, so a flash alone leaves them stale.
    */
-  onKey?: (name: string, filter: F, active: T | undefined, query: string) => string | void;
+  onKey?: (
+    name: string,
+    filter: F,
+    active: T | undefined,
+    query: string,
+  ) => string | void | { flash?: string; reload?: boolean };
   /** Key that enters search mode (default `s`). */
   searchKey?: string;
   /** Key that toggles the preview pane (default `tab`). */
@@ -466,6 +473,23 @@ export interface DynamicPickerConfig<T, F> {
   emptyMessage?: string;
   loadingMessage?: string;
   enterHint?: string;
+}
+
+/**
+ * The lookup token for a hotkey: the literal character the key produced, else
+ * readline's key name (`tab`, `escape`, arrows).
+ *
+ * readline reports both `f` and `F` as name `f` — only `sequence` tells them
+ * apart — and gives a punctuation key like `*` no name at all. Keying on the
+ * character makes shifted letters and punctuation bindable, and is a no-op for
+ * every existing binding: for a plain lowercase letter, sequence === name.
+ */
+export function hotkeyToken(key: { name?: string; sequence?: string; ctrl?: boolean; meta?: boolean }): string {
+  const seq = key.sequence;
+  // Printable single characters only — a control code's sequence (`\t`, `\r`,
+  // `\x7f`) must keep resolving to its name.
+  if (!key.ctrl && !key.meta && seq && seq.length === 1 && seq > ' ' && seq !== '\x7f') return seq;
+  return key.name ?? '';
 }
 
 /** The result returned when the user selects a row: the item plus the live filter. */
@@ -499,26 +523,48 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
     const [previewOpen, setPreviewOpen] = useState(Boolean(cfg.buildPreview));
     const [active, setActive] = useState(0);
     const [flash, setFlash] = useState('');
+    // Bumped by an `onKey` that asks for a reload; a dep of the load effect, so a
+    // side effect that changed the rows can rebuild them without a filter change.
+    const [reloadNonce, setReloadNonce] = useState(0);
+    // The counter lives in a ref, not in the state read back from the keypress
+    // closure: that closure can hold a STALE `reloadNonce`, so a second reload
+    // would recompute the same value, the state would not change, and the
+    // repaint would silently never happen (the first star appeared, the second
+    // did not). A ref is always current.
+    const reloadCount = useRef(0);
+    // Bumped when a load RESOLVES. `load` is async, so the render that follows
+    // `setReloadNonce` still sees the pre-load data — memoizing the row labels on
+    // the nonce alone rendered each press's result one press late. Keying them on
+    // load COMPLETION is what actually makes them current.
+    const [loadedSeq, setLoadedSeq] = useState(0);
+    const loadedCount = useRef(0);
     const prefix = usePrefix({ status, theme });
     // Guards against a slow load resolving after a newer filter superseded it.
     const gen = useRef(0);
+    // The filter the last load ran on, so a nonce-only reload (a row's own state
+    // changed) can keep the cursor where the user left it. Snapping back to the
+    // top every time you star a row would make the key unusable for a second one.
+    const loadedFilter = useRef<F | undefined>(undefined);
 
     useEffect(() => {
       const my = ++gen.current;
+      const filterChanged = loadedFilter.current !== filter;
+      loadedFilter.current = filter;
       setLoading(true);
       Promise.resolve(cfg.load(filter))
         .then((rows) => {
           if (my !== gen.current) return;
           setItems(rows);
           setLoading(false);
-          setActive(0);
+          setLoadedSeq((loadedCount.current += 1));
+          if (filterChanged) setActive(0);
         })
         .catch(() => {
           if (my !== gen.current) return;
           setItems([]);
           setLoading(false);
         });
-    }, [filter]);
+    }, [filter, reloadNonce]);
 
     const results = useMemo(() => {
       const q = query.trim();
@@ -527,7 +573,12 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
         value: item,
         label: cfg.labelFor(item, q),
       }));
-    }, [items, query]);
+      // `loadedSeq` is a dep because a reload can legitimately return the SAME
+      // array — `load` hands back its cached pool unchanged when no filter is
+      // active — while what a row RENDERS has changed underneath it. Without this
+      // the labels stay memoized on the old state and the side effect looks like
+      // it silently did nothing (starring a row left the star invisible).
+    }, [items, query, loadedSeq]);
 
     useEffect(() => {
       if (active >= results.length) setActive(0);
@@ -611,15 +662,22 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
         setPreviewOpen(!previewOpen);
         return;
       }
-      const binding = cfg.keyBindings?.[key.name ?? ''];
+      const token = hotkeyToken(key);
+      const binding = cfg.keyBindings?.[token];
       if (binding) {
         const next = binding(filter);
         if (!Object.is(next, filter)) setFilter(next);
         return;
       }
       if (cfg.onKey) {
-        const msg = cfg.onKey(key.name ?? '', filter, selected?.value, query);
-        if (msg) setFlash(msg);
+        const res = cfg.onKey(token, filter, selected?.value, query);
+        if (typeof res === 'string') setFlash(res);
+        else if (res) {
+          if (res.flash) setFlash(res.flash);
+          // The rows themselves changed — force the load effect to re-run so the
+          // memoized labels are rebuilt.
+          if (res.reload) setReloadNonce((reloadCount.current += 1));
+        }
       }
     });
 

--- a/apps/cli/src/lib/session/active.hostlink.test.ts
+++ b/apps/cli/src/lib/session/active.hostlink.test.ts
@@ -129,6 +129,28 @@ describe('a lost host does not hide a session that needs a human', () => {
     expect(isAwaitingUser(rows[0])).toBe(false);
   });
 
+  // `abandoned` fires on transcript staleness BEFORE the liveness check, so it
+  // is the one dangling status that can still be a live, answerable process.
+  it('still counts a LIVE abandoned session that is mid-question — forgotten, not gone', () => {
+    const rows = [row({ status: 'abandoned', activity: 'waiting_input', pidAlive: true })];
+    foldHostLink(rows);
+    expect(isAwaitingUser(rows[0])).toBe(true);
+  });
+
+  it('does not count an abandoned session whose process is gone', () => {
+    const rows = [row({ status: 'abandoned', activity: 'waiting_input', pidAlive: false })];
+    foldHostLink(rows);
+    expect(isAwaitingUser(rows[0])).toBe(false);
+  });
+
+  it('does not count an abandoned session of unknown liveness — no invented human', () => {
+    // An older peer sends no `pidAlive`; claiming someone can answer would be a
+    // guess, and this gate drives a non-zero exit.
+    const rows = [row({ status: 'abandoned', activity: 'waiting_input' })];
+    foldHostLink(rows);
+    expect(isAwaitingUser(rows[0])).toBe(false);
+  });
+
   it('an orphaned IDLE session is not awaiting — it is stranded, not blocked on you', () => {
     const rows = [row({ status: 'idle', activity: 'idle', tmuxClients: 0 })];
     foldHostLink(rows);

--- a/apps/cli/src/lib/session/active.hostlink.test.ts
+++ b/apps/cli/src/lib/session/active.hostlink.test.ts
@@ -119,6 +119,16 @@ describe('a lost host does not hide a session that needs a human', () => {
     expect(isAwaitingUser(rows[0])).toBe(true);
   });
 
+  it('a DEAD session that died mid-question is not awaiting — it needs a relaunch, not an answer', () => {
+    // `activity` is never rewritten, so a session that crashed while asking keeps
+    // `waiting_input` forever. `--waiting` is a scriptable "does anything need
+    // me?" gate; answering a corpse is not something a human can do.
+    const rows = [row({ status: 'closed', activity: 'waiting_input', windowHeartbeatMs: staleWindow })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('crashed');
+    expect(isAwaitingUser(rows[0])).toBe(false);
+  });
+
   it('an orphaned IDLE session is not awaiting — it is stranded, not blocked on you', () => {
     const rows = [row({ status: 'idle', activity: 'idle', tmuxClients: 0 })];
     foldHostLink(rows);

--- a/apps/cli/src/lib/session/active.hostlink.test.ts
+++ b/apps/cli/src/lib/session/active.hostlink.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { foldHostLink, type ActiveSession } from './active';
+import { HOST_HEARTBEAT_STALE_MS } from './host-link';
+
+const staleWindow = Date.now() - HOST_HEARTBEAT_STALE_MS - 1;
+const freshWindow = Date.now() - 30_000;
+
+function row(over: Partial<ActiveSession>): ActiveSession {
+  return { context: 'terminal', kind: 'claude', status: 'idle', ...over };
+}
+
+/**
+ * `foldHostLink` is where a lost host actually changes what the user reads in the
+ * status column, so the tests are about PRECEDENCE: the new statuses must replace
+ * exactly the ones they improve on and leave the rest alone. Over-reporting is
+ * the failure mode that would make the feature worthless — a listing where every
+ * headless run says "orphan" trains the user to ignore the word.
+ */
+describe('foldHostLink status precedence', () => {
+  it('turns a dead agent under a dead window into `crashed` instead of a bare `closed`', () => {
+    const rows = [row({ status: 'closed', windowHeartbeatMs: staleWindow })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('crashed');
+    expect(rows[0].hostLink).toBe('host-gone');
+  });
+
+  it('leaves an ordinary close as `closed` — the window is alive and just had not republished', () => {
+    const rows = [row({ status: 'closed', windowHeartbeatMs: freshWindow })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('closed');
+  });
+
+  it('turns an idle session with nothing attached into `orphaned`', () => {
+    const rows = [row({ status: 'idle', tmuxClients: 0 })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('orphaned');
+    expect(rows[0].hostLink).toBe('no-client');
+  });
+
+  it('turns a session WAITING on input with nothing attached into `orphaned` — nobody is coming', () => {
+    const rows = [row({ status: 'input_required', tmuxClients: 0 })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('orphaned');
+  });
+
+  it('leaves a WORKING session alone even with no client — that is a normal headless run', () => {
+    const rows = [row({ status: 'running', tmuxClients: 0 })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('running');
+    // The link is still recorded, so a consumer can see it; only the status is untouched.
+    expect(rows[0].hostLink).toBe('no-client');
+  });
+
+  it('leaves a deliberately detached session alone — no client is the point of detaching', () => {
+    const rows = [row({ status: 'idle', tmuxClients: 0, presence: 'background' })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('idle');
+    expect(rows[0].hostLink).toBe('connected');
+  });
+
+  it('lets `abandoned` win outright and claims no host link for it', () => {
+    const rows = [row({ status: 'abandoned', tmuxClients: 0, windowHeartbeatMs: staleWindow })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('abandoned');
+    expect(rows[0].hostLink).toBeUndefined();
+  });
+
+  it('skips cloud rows — they have no local pid, window, or tmux server to lose', () => {
+    const rows = [row({ context: 'cloud', status: 'idle' })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('idle');
+    expect(rows[0].hostLink).toBeUndefined();
+  });
+
+  it('leaves a healthy attached session untouched', () => {
+    const rows = [row({ status: 'idle', tmuxClients: 1, windowHeartbeatMs: freshWindow })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('idle');
+    expect(rows[0].hostLink).toBe('connected');
+  });
+});
+
+describe('foldHostLink presence honesty', () => {
+  it('drops the derived `attached` presence when the host is gone — nobody is watching it', () => {
+    const rows = [row({ status: 'closed', windowHeartbeatMs: staleWindow, presence: 'attached' })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('crashed');
+    expect(rows[0].presence).toBeUndefined();
+  });
+
+  it('keeps a STORED detach record intact — only the derived `attached` is cleared', () => {
+    const rows = [row({ status: 'idle', tmuxClients: 0, presence: 'parked' })];
+    foldHostLink(rows);
+    expect(rows[0].presence).toBe('parked');
+  });
+});

--- a/apps/cli/src/lib/session/active.hostlink.test.ts
+++ b/apps/cli/src/lib/session/active.hostlink.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { foldHostLink, type ActiveSession } from './active';
+import { isAwaitingUser } from '../../commands/sessions.js';
 import { HOST_HEARTBEAT_STALE_MS } from './host-link';
 
 const staleWindow = Date.now() - HOST_HEARTBEAT_STALE_MS - 1;
@@ -92,5 +93,36 @@ describe('foldHostLink presence honesty', () => {
     const rows = [row({ status: 'idle', tmuxClients: 0, presence: 'parked' })];
     foldHostLink(rows);
     expect(rows[0].presence).toBe('parked');
+  });
+});
+
+/**
+ * `foldHostLink` rewrites `input_required` to `orphaned`, which quietly moved a
+ * session OUT of every consumer that recognised "needs a human" by that status —
+ * `--waiting`'s filter and its non-zero exit among them. A session waiting on a
+ * question with nobody watching is the most acute case those consumers exist to
+ * surface, not one they should drop, so the predicate reads the `activity` the
+ * fold never rewrites.
+ */
+describe('a lost host does not hide a session that needs a human', () => {
+  it('still counts as awaiting after the fold turns it orphaned', () => {
+    const rows = [row({ status: 'input_required', activity: 'waiting_input', tmuxClients: 0 })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('orphaned');
+    expect(isAwaitingUser(rows[0])).toBe(true);
+  });
+
+  it('a plain waiting session is unaffected', () => {
+    const rows = [row({ status: 'input_required', activity: 'waiting_input', tmuxClients: 1 })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('input_required');
+    expect(isAwaitingUser(rows[0])).toBe(true);
+  });
+
+  it('an orphaned IDLE session is not awaiting — it is stranded, not blocked on you', () => {
+    const rows = [row({ status: 'idle', activity: 'idle', tmuxClients: 0 })];
+    foldHostLink(rows);
+    expect(rows[0].status).toBe('orphaned');
+    expect(isAwaitingUser(rows[0])).toBe(false);
   });
 });

--- a/apps/cli/src/lib/session/active.registry-retention.test.ts
+++ b/apps/cli/src/lib/session/active.registry-retention.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-registry-'));
+process.env.HOME = TEST_HOME;
+
+const { listTerminalsActive, foldHostLink } = await import('./active.js');
+const { HOST_HEARTBEAT_STALE_MS } = await import('./host-link.js');
+
+const REGISTRY = path.join(TEST_HOME, '.agents', '.cache', 'terminals', 'live-terminals.json');
+/** Above any real pid, so `process.kill` throws ESRCH — a genuinely dead process. */
+const DEAD_PID = 2_000_000_003;
+
+function writeRegistry(windowAgeMs: number, pid: number): void {
+  fs.mkdirSync(path.dirname(REGISTRY), { recursive: true });
+  const at = new Date(Date.now() - windowAgeMs).toISOString();
+  fs.writeFileSync(
+    REGISTRY,
+    JSON.stringify({
+      'a-window': {
+        at,
+        entries: [
+          { sessionId: 'sess-under-test', pid, kind: 'claude', cwd: TEST_HOME, startedAtMs: Date.now() },
+        ],
+      },
+    }),
+  );
+}
+
+/**
+ * The regression this exists for: a VS Code window that crashed left a dead-pid
+ * entry behind, `readLiveTerminals` filtered it out, and the session simply
+ * DISAPPEARED from `--active` — indistinguishable from one that had never run.
+ * The retention rule is what puts it back, and it has to be narrow enough that an
+ * ordinary terminal close doesn't start reporting itself as a crash.
+ */
+describe('live-terminals retention for a crashed host', () => {
+  beforeEach(() => {
+    fs.rmSync(REGISTRY, { force: true });
+  });
+
+  it('keeps a dead-pid entry whose window stopped republishing, and reports it crashed', async () => {
+    writeRegistry(HOST_HEARTBEAT_STALE_MS + 60_000, DEAD_PID);
+    const rows = await listTerminalsActive();
+    const row = rows.find((r) => r.sessionId === 'sess-under-test');
+    expect(row, 'a crashed session must still reach the listing').toBeDefined();
+    // It arrives as a plain dead process; the fold is what names it a crash.
+    expect(row!.status).toBe('closed');
+    foldHostLink(rows);
+    expect(row!.status).toBe('crashed');
+    expect(row!.hostLink).toBe('host-gone');
+  });
+
+  it('drops a dead-pid entry while its window is still republishing — an ordinary close', async () => {
+    writeRegistry(30_000, DEAD_PID);
+    const rows = await listTerminalsActive();
+    expect(rows.find((r) => r.sessionId === 'sess-under-test')).toBeUndefined();
+  });
+
+  it('keeps a live entry regardless of the window heartbeat', async () => {
+    writeRegistry(HOST_HEARTBEAT_STALE_MS + 60_000, process.pid);
+    const rows = await listTerminalsActive();
+    const row = rows.find((r) => r.sessionId === 'sess-under-test');
+    expect(row).toBeDefined();
+    expect(row!.status).not.toBe('closed');
+  });
+
+  it('carries the window heartbeat through so the fold can read it', async () => {
+    writeRegistry(HOST_HEARTBEAT_STALE_MS + 60_000, process.pid);
+    const rows = await listTerminalsActive();
+    const row = rows.find((r) => r.sessionId === 'sess-under-test')!;
+    expect(row.windowHeartbeatMs).toBeTypeOf('number');
+    expect(Date.now() - row.windowHeartbeatMs!).toBeGreaterThanOrEqual(HOST_HEARTBEAT_STALE_MS);
+  });
+});

--- a/apps/cli/src/lib/session/active.tmux-clients.test.ts
+++ b/apps/cli/src/lib/session/active.tmux-clients.test.ts
@@ -69,10 +69,10 @@ describe.skipIf(skipReason)('tmux attached-client fold', () => {
     });
     const printable = await runTmux({
       socket,
-      args: ['list-panes', '-a', '-F', '#{pane_id}|#{session_attached}'],
+      args: ['list-panes', '-a', '-F', '#{pane_id}:#{session_attached}'],
       throwOnError: false,
     });
-    expect(printable.stdout.split('\n')[0].split('|')).toHaveLength(2);
+    expect(printable.stdout.split('\n')[0].split(':')).toHaveLength(2);
     // Document the actual tmux behavior this separator choice exists for: on a
     // tmux that sanitizes the tab, the tab-split yields one field, not two.
     const tabFields = tabbed.stdout.split('\n')[0].split('\t').length;
@@ -94,5 +94,36 @@ describe.skipIf(skipReason)('tmux attached-client fold', () => {
     const plain: ActiveSession = { context: 'terminal', kind: 'claude', status: 'idle' };
     await foldTmuxClients([plain]);
     expect(plain.tmuxClients).toBeUndefined();
+  });
+});
+
+/**
+ * The separator has to be one tmux cannot emit inside a field, or the tab bug
+ * comes back with a lower probability. tmux replaces `:` and `.` in a session
+ * name with `_`, which is what makes `:` provably safe for the fields ahead of
+ * the path — and a session name is the one free-text field that is not last.
+ */
+describe.skipIf(skipReason)('tmux format separator safety', () => {
+  it('cannot appear in a session name — tmux rewrites it', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-tmux-sep-'));
+    const sock = path.join(dir, 'server.sock');
+    try {
+      await runTmux({ socket: sock, args: ['new-session', '-d', '-s', 'has:colon.dot', 'sleep', '60'] });
+      const res = await runTmux({ socket: sock, args: ['list-sessions', '-F', '#{session_name}'] });
+      const name = res.stdout.trim();
+      expect(name).not.toContain(':');
+      expect(name).toBe('has_colon_dot');
+      // So a 4-field query still splits into exactly 4 leading fields.
+      const panes = await runTmux({
+        socket: sock,
+        args: ['list-panes', '-a', '-F', '#{pane_id}:#{session_name}:#{pane_pid}:#{pane_current_path}'],
+      });
+      const parts = panes.stdout.split('\n').filter(Boolean)[0].split(':');
+      expect(parts.length).toBeGreaterThanOrEqual(4);
+      expect(parts[1]).toBe('has_colon_dot');
+    } finally {
+      await runTmux({ socket: sock, args: ['kill-server'], throwOnError: false });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/lib/session/active.tmux-clients.test.ts
+++ b/apps/cli/src/lib/session/active.tmux-clients.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration test for the attached-client signal behind the `orphaned` status.
+ *
+ * Spawns a REAL tmux server on a temp socket — no mocks — because the bug this
+ * pins is a property of tmux itself: it sanitizes non-printable characters out
+ * of `-F` format output (3.6a rewrites a literal tab to `_`), so a tab-separated
+ * format comes back as one unsplittable field. Nothing short of a real tmux
+ * shows that, and a mocked `runTmux` would have happily "passed" while the
+ * feature was dead on every machine running a recent tmux.
+ */
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { isTmuxInstalled, runTmux } from '../tmux/binary.js';
+import { foldTmuxClients, type ActiveSession } from './active.js';
+
+const skipReason = isTmuxInstalled() ? null : 'tmux not installed';
+
+describe.skipIf(skipReason)('tmux attached-client fold', () => {
+  let socket: string;
+  let tempDir: string;
+  const sessionName = 'agents-clients-test';
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-tmux-clients-'));
+    socket = path.join(tempDir, 'server.sock');
+    await runTmux({ socket, args: ['new-session', '-d', '-s', sessionName, 'sleep', '120'] });
+  });
+
+  afterEach(async () => {
+    await runTmux({ socket, args: ['kill-server'], throwOnError: false });
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function firstPane(): Promise<string> {
+    const res = await runTmux({ socket, args: ['list-panes', '-a', '-F', '#{pane_id}'] });
+    return res.stdout.split('\n').filter(Boolean)[0];
+  }
+
+  function row(pane: string): ActiveSession {
+    return {
+      context: 'terminal',
+      kind: 'claude',
+      status: 'idle',
+      provenance: { host: 'test', transport: 'local', mux: { kind: 'tmux', socket, pane } },
+    } as ActiveSession;
+  }
+
+  it('reads zero clients for a detached session — the orphan signal', async () => {
+    const pane = await firstPane();
+    const rows = [row(pane)];
+    await foldTmuxClients(rows);
+    // `new-session -d` leaves nobody attached, which is exactly the state a
+    // crashed editor window leaves behind.
+    expect(rows[0].tmuxClients).toBe(0);
+  });
+
+  it('survives tmux sanitizing the format separator (the tab bug)', async () => {
+    // A tab-separated format is mangled by tmux into a single field; the
+    // separator the code uses must come back splittable. If this ever regresses,
+    // every pane silently reports an unknown client count and `orphaned` never
+    // fires again.
+    const tabbed = await runTmux({
+      socket,
+      args: ['list-panes', '-a', '-F', '#{pane_id}\t#{session_attached}'],
+      throwOnError: false,
+    });
+    const printable = await runTmux({
+      socket,
+      args: ['list-panes', '-a', '-F', '#{pane_id}|#{session_attached}'],
+      throwOnError: false,
+    });
+    expect(printable.stdout.split('\n')[0].split('|')).toHaveLength(2);
+    // Document the actual tmux behavior this separator choice exists for: on a
+    // tmux that sanitizes the tab, the tab-split yields one field, not two.
+    const tabFields = tabbed.stdout.split('\n')[0].split('\t').length;
+    if (tabFields === 1) expect(tabbed.stdout).not.toContain('\t');
+  });
+
+  it('leaves rows on another socket untouched', async () => {
+    const pane = await firstPane();
+    const mine = row(pane);
+    const other = row(pane);
+    other.provenance!.mux!.socket = path.join(tempDir, 'not-a-server.sock');
+    const rows = [mine, other];
+    await foldTmuxClients(rows);
+    expect(mine.tmuxClients).toBe(0);
+    expect(other.tmuxClients).toBeUndefined();
+  });
+
+  it('does nothing when no row is tmux-hosted', async () => {
+    const plain: ActiveSession = { context: 'terminal', kind: 'claude', status: 'idle' };
+    await foldTmuxClients([plain]);
+    expect(plain.tmuxClients).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -196,6 +196,17 @@ export interface ActiveSession {
    */
   hostLink?: HostLink;
   /**
+   * Whether this session's process was alive at scan time — the boolean
+   * {@link applyState} already computes, kept rather than thrown away.
+   *
+   * `status` cannot stand in for it. `abandoned` fires on transcript staleness
+   * BEFORE the liveness check, so it covers a live-but-stuck process as well as
+   * a long-dead one; only `closed`/`crashed` are unconditionally dead. A consumer
+   * that must tell "still there, just quiet" from "gone" needs this, not the
+   * status. Absent from cloud rows (no pid) and from a peer running an older CLI.
+   */
+  pidAlive?: boolean;
+  /**
    * Clients attached to this session's tmux session (`#{session_attached}`), for
    * a tmux-hosted row. Absent — NOT zero — when the session is not tmux-hosted:
    * zero means "tmux says nobody is looking", absent means "we cannot tell".
@@ -781,7 +792,7 @@ function statusFromActivity(activity: SessionActivity): ActiveStatus {
  * for an alive process) rather than the old blanket `unknown`.
  */
 function applyState(base: Omit<ActiveSession, 'status'>, state: SessionState | undefined, fallbackFile: string | undefined, pidAlive: boolean): ActiveSession {
-  if (!state) return { ...base, status: resolveFallbackStatus(fallbackFile, pidAlive) };
+  if (!state) return { ...base, pidAlive, status: resolveFallbackStatus(fallbackFile, pidAlive) };
   // Lifecycle (closed/abandoned) is computed from PID + mtime and OVERRIDES the
   // activity-derived status: a dead or days-stale process is closed/abandoned no
   // matter what its last parsed transcript turn looked like (a dead session whose
@@ -790,6 +801,7 @@ function applyState(base: Omit<ActiveSession, 'status'>, state: SessionState | u
   const life = lifecycleStatus(pidAlive, base.lastActivityMs ?? sessionFileTimes(fallbackFile).mtimeMs);
   return {
     ...base,
+    pidAlive,
     status: life ?? statusFromActivity(state.activity),
     activity: state.activity,
     awaitingReason: state.awaitingReason,

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -469,10 +469,12 @@ interface LiveTerminalEntry {
  * terminal that closed a moment ago, before its window republished — and is
  * dropped. But a dead pid whose owning window ALSO stopped republishing is the
  * signature of a crash: the window went down hard and never ran the teardown that
- * would have removed this entry. Those are kept (flagged `pidDead`) so
- * {@link foldHostLink} can report the session as `crashed` instead of letting it
- * silently vanish from the listing, which is what happened before — a VS Code
- * crash simply erased its agents from `--active`.
+ * would have removed this entry. Those are KEPT, so the session reaches the
+ * listing at all — it used to vanish outright, a VS Code crash simply erasing its
+ * agents from `--active`. Such a row arrives as `closed` (dead pid) carrying the
+ * stale `windowHeartbeatMs`, which is what {@link foldHostLink} promotes to
+ * `crashed`. `pidDead` is local to the dedupe below: a live entry must win a dead
+ * one for the same session.
  */
 function readLiveTerminals(): LiveTerminalEntry[] {
   let raw: string;

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -342,14 +342,22 @@ export const ABANDONED_STALE_MS = 2 * 24 * 60 * 60_000;
 /**
  * Field separator for every `tmux list-panes -F` query here.
  *
- * NOT a tab: tmux sanitizes non-printable characters out of format output (3.6a
- * rewrites a literal tab to `_`), so a tab-separated format comes back as one
- * unsplittable field. {@link listTmuxAgentSessions} split on `\t`, so on such a
- * tmux every line failed its `sessName` guard and the function returned ZERO
- * rows — silently losing the authoritative tmux source (exact `%pane`, real
- * identities) on every box running a recent tmux. A printable separator survives.
+ * NOT a tab. tmux sanitizes non-printable characters out of format output (3.6a
+ * rewrites a literal tab — and any non-ASCII sentinel — to `_`), so a
+ * tab-separated format comes back as one unsplittable field.
+ * {@link listTmuxAgentSessions} split on `\t`, so on such a tmux every line
+ * failed its `sessName` guard and the function returned ZERO rows, silently
+ * losing the authoritative tmux source (exact `%pane`, real identities) on every
+ * box running a recent tmux.
+ *
+ * `:` specifically, and not some other printable: tmux itself replaces `:` (and
+ * `.`) in a session name with `_`, so the separator provably cannot occur inside
+ * the one free-text field that is not last. A path CAN contain `:`, which is why
+ * `pane_current_path` is queried last and its tail rejoined rather than
+ * destructured. A separator that a session name may contain — `|`, say — would
+ * just reintroduce the same class of bug with a lower probability.
  */
-const TMUX_FIELD_SEP = '|';
+const TMUX_FIELD_SEP = ':';
 
 /** Executables we recognize as agent CLIs when scanning the process table. */
 const AGENT_CLI_NAMES: Record<string, string> = {

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -40,6 +40,7 @@ import { isSessionTrackedAgent, type SessionAgentId, type SessionAttachment, typ
 import { detectProvenance, type SessionProvenance } from './provenance.js';
 import { loadDevices, type DeviceRegistry } from '../devices/registry.js';
 import { presenceFromStore, type Presence } from './detached.js';
+import { classifyHostLink, HOST_HEARTBEAT_STALE_MS, type HostLink } from './host-link.js';
 import { mapBounded } from '../concurrency.js';
 
 const execFileAsync = promisify(execFile);
@@ -98,7 +99,18 @@ export type ActiveContext = 'terminal' | 'teams' | 'cloud' | 'headless';
  * antigravity) gets a real working/waiting/idle from its own parser — see
  * {@link computeLiveSignals}, {@link lifecycleStatus} and {@link resolveFallbackStatus}.
  */
-export type ActiveStatus = 'running' | 'idle' | 'queued' | 'input_required' | 'closed' | 'abandoned' | 'unknown';
+export type ActiveStatus =
+  | 'running'
+  | 'idle'
+  | 'queued'
+  | 'input_required'
+  | 'closed'
+  | 'abandoned'
+  /** Alive, but no client is attached — the host window died and the agent outlived it. */
+  | 'orphaned'
+  /** The host window died and took the agent with it — an unclean exit, not a normal close. */
+  | 'crashed'
+  | 'unknown';
 
 export interface ActiveSession {
   context: ActiveContext;
@@ -177,6 +189,24 @@ export interface ActiveSession {
    * from the detach store — never asserted by a source.
    */
   presence?: Presence;
+  /**
+   * Whether anything is still on the other end of this session — folded on at the
+   * end of {@link getActiveSessions} by {@link foldHostLink} from the raw signals
+   * below, never asserted by a source. Drives the `orphaned` / `crashed` statuses.
+   */
+  hostLink?: HostLink;
+  /**
+   * Clients attached to this session's tmux session (`#{session_attached}`), for
+   * a tmux-hosted row. Absent — NOT zero — when the session is not tmux-hosted:
+   * zero means "tmux says nobody is looking", absent means "we cannot tell".
+   */
+  tmuxClients?: number;
+  /**
+   * When the owning IDE window last refreshed its slice of the live-terminals
+   * registry. Absent for a session no IDE window owns. A stale value means that
+   * window is gone — see {@link HOST_HEARTBEAT_STALE_MS}.
+   */
+  windowHeartbeatMs?: number;
   /** How many live PIDs resolve to this same session (subagents/forks). 1 unless collapsed. */
   pidCount?: number;
   /**
@@ -309,6 +339,18 @@ export const ACTIVE_SESSION_STALE_MS = 24 * 60 * 60_000;
  */
 export const ABANDONED_STALE_MS = 2 * 24 * 60 * 60_000;
 
+/**
+ * Field separator for every `tmux list-panes -F` query here.
+ *
+ * NOT a tab: tmux sanitizes non-printable characters out of format output (3.6a
+ * rewrites a literal tab to `_`), so a tab-separated format comes back as one
+ * unsplittable field. {@link listTmuxAgentSessions} split on `\t`, so on such a
+ * tmux every line failed its `sessName` guard and the function returned ZERO
+ * rows — silently losing the authoritative tmux source (exact `%pane`, real
+ * identities) on every box running a recent tmux. A printable separator survives.
+ */
+const TMUX_FIELD_SEP = '|';
+
 /** Executables we recognize as agent CLIs when scanning the process table. */
 const AGENT_CLI_NAMES: Record<string, string> = {
   claude: 'claude',
@@ -414,9 +456,24 @@ interface LiveTerminalEntry {
   startedAtMs: number;
   /** Slice key from the registry — the IDE window that owns this terminal. */
   windowId?: string;
+  /** The slice's `at` stamp — when that window last republished. See {@link HOST_HEARTBEAT_STALE_MS}. */
+  windowHeartbeatMs?: number;
+  /** This entry's pid is gone; kept only because its window never tore it down. */
+  pidDead?: boolean;
 }
 
-/** Read the live-terminals registry, dedupe by sessionId, keep only pid-alive entries. */
+/**
+ * Read the live-terminals registry, dedupe by sessionId.
+ *
+ * A pid-alive entry is a live session. A pid-DEAD entry is normally noise — a
+ * terminal that closed a moment ago, before its window republished — and is
+ * dropped. But a dead pid whose owning window ALSO stopped republishing is the
+ * signature of a crash: the window went down hard and never ran the teardown that
+ * would have removed this entry. Those are kept (flagged `pidDead`) so
+ * {@link foldHostLink} can report the session as `crashed` instead of letting it
+ * silently vanish from the listing, which is what happened before — a VS Code
+ * crash simply erased its agents from `--active`.
+ */
 function readLiveTerminals(): LiveTerminalEntry[] {
   let raw: string;
   try {
@@ -432,11 +489,24 @@ function readLiveTerminals(): LiveTerminalEntry[] {
   }
   if (!parsed || typeof parsed !== 'object') return [];
 
+  const now = Date.now();
   const merged = new Map<string, LiveTerminalEntry>();
   for (const [windowId, slice] of Object.entries(parsed) as [string, any][]) {
+    const at = Date.parse(slice?.at ?? '');
+    const windowHeartbeatMs = Number.isFinite(at) ? at : undefined;
+    const windowGone = windowHeartbeatMs !== undefined && now - windowHeartbeatMs >= HOST_HEARTBEAT_STALE_MS;
     for (const e of (slice?.entries ?? []) as LiveTerminalEntry[]) {
-      if (!e?.sessionId || !isPidAlive(e.pid, e.startedAtMs)) continue;
-      merged.set(e.sessionId, { ...e, windowId });
+      if (!e?.sessionId) continue;
+      const alive = isPidAlive(e.pid, e.startedAtMs);
+      // Dead pid + a window still republishing = an ordinary close mid-debounce.
+      // Dead pid + a window that stopped republishing = the crash we must report.
+      if (!alive && !windowGone) continue;
+      const entry: LiveTerminalEntry = { ...e, windowId, windowHeartbeatMs, pidDead: !alive };
+      // A live entry always wins a dead one for the same session (the agent was
+      // relaunched into a new window while the crashed window's slice lingers).
+      const prev = merged.get(e.sessionId);
+      if (prev && !prev.pidDead && !alive) continue;
+      merged.set(e.sessionId, entry);
     }
   }
   return Array.from(merged.values());
@@ -910,6 +980,7 @@ export async function listTerminalsActive(): Promise<ActiveSession[]> {
       startedAtMs: t.startedAtMs,
       lastActivityMs: sessionFileTimes(sessionFile).mtimeMs,
       windowId: t.windowId,
+      windowHeartbeatMs: t.windowHeartbeatMs,
       owner: resolveOwner(pidEntry?.actor, resolvedId),
     }, state, sessionFile, pidAlive);
   });
@@ -1432,7 +1503,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
   try {
     res = await runTmux({
       socket,
-      args: ['list-panes', '-a', '-F', '#{pane_id}\t#{session_name}\t#{pane_pid}\t#{pane_current_path}'],
+      args: ['list-panes', '-a', '-F', ['#{pane_id}', '#{session_name}', '#{pane_pid}', '#{pane_current_path}'].join(TMUX_FIELD_SEP)],
       throwOnError: false,
     });
   } catch {
@@ -1458,7 +1529,11 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
   const seen = new Set<string>();
   for (const line of res.stdout.split('\n')) {
     if (!line.trim()) continue;
-    const [pane, sessName, pidRaw, curPath] = line.split('\t');
+    // The path is the LAST field, so rejoin its tail: a directory containing the
+    // separator must not truncate it (the earlier fields cannot contain one).
+    const parts = line.split(TMUX_FIELD_SEP);
+    const [pane, sessName, pidRaw] = parts;
+    const curPath = parts.slice(3).join(TMUX_FIELD_SEP);
     if (!pane || !sessName) continue;
     const meta = readSessionMeta(sessName);
     const liveEntry = liveByPane.get(pane);
@@ -1553,8 +1628,110 @@ export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<
   await enrichProvenance(merged);
   await resolveOrigins(merged);
   foldPresence(merged);
+  await foldTmuxClients(merged);
+  foldHostLink(merged);
   annotateOrchestratorLabels(merged);
   return merged;
+}
+
+/**
+ * Fold tmux's attached-client count onto every tmux-hosted row.
+ *
+ * Keyed off `provenance.mux` — which {@link enrichProvenance} has already stamped
+ * on any row whose process env names a tmux pane — rather than off
+ * {@link listTmuxAgentSessions}. That source only emits a row when it can resolve
+ * the pane's agent IDENTITY (launch registry or session meta), and on a machine
+ * where neither resolves it emits nothing at all while the same sessions still
+ * arrive through the terminal/headless sources carrying full tmux provenance.
+ * Hanging the client count off the identity-resolving source would have made the
+ * whole orphan signal silently dead on exactly those machines.
+ *
+ * One `list-panes` per distinct socket, and only when some row is tmux-hosted —
+ * a fleet with no tmux pays nothing. A query failure leaves the count undefined,
+ * which the classifier reads as "cannot tell", never as a false zero.
+ */
+export async function foldTmuxClients(rows: ActiveSession[]): Promise<void> {
+  const tmuxRows = rows.filter((s) => s.provenance?.mux?.kind === 'tmux' && s.provenance.mux.pane);
+  if (tmuxRows.length === 0) return;
+  const { runTmux } = await import('../tmux/binary.js');
+  const sockets = new Set(tmuxRows.map((s) => s.provenance!.mux!.socket));
+  for (const socket of sockets) {
+    const byPane = new Map<string, number>();
+    try {
+      const res = await runTmux({
+        socket,
+        args: ['list-panes', '-a', '-F', `#{pane_id}${TMUX_FIELD_SEP}#{session_attached}`],
+        throwOnError: false,
+      });
+      if (res.code !== 0) continue;
+      for (const line of res.stdout.split('\n')) {
+        const [pane, attached] = line.split(TMUX_FIELD_SEP);
+        if (!pane) continue;
+        const n = parseInt(attached ?? '', 10);
+        // A tmux too old to report `session_attached` yields NaN — leave the pane
+        // unmapped so it stays "cannot tell" rather than becoming a false zero.
+        if (Number.isFinite(n)) byPane.set(pane, n);
+      }
+    } catch {
+      continue; // best-effort: no count is honest, a guessed count is not
+    }
+    for (const s of tmuxRows) {
+      if (s.provenance!.mux!.socket !== socket) continue;
+      const n = byPane.get(s.provenance!.mux!.pane!);
+      if (n !== undefined) s.tmuxClients = n;
+    }
+  }
+}
+
+/**
+ * Fold the host link onto each row and, where it changes the answer, onto the
+ * status. Runs AFTER {@link foldPresence}, because a deliberately backgrounded
+ * session (`presence` `background`/`parked`) is supposed to have no client and
+ * must not be reported as an orphan.
+ *
+ * Precedence is deliberate, and the two new statuses slot in where they add
+ * information rather than destroy it:
+ *
+ *   - `abandoned` wins outright. A days-stale session is already dangling; that
+ *     it also lost its window is not the headline, and it keeps a crashed row
+ *     from lingering as an alert forever.
+ *   - `crashed` REPLACES `closed`. Both mean the process is gone, but `closed`
+ *     reads as a normal exit; `crashed` says the host window went down with it
+ *     and never cleaned up.
+ *   - `orphaned` replaces only `idle` / `input_required`. A session still WORKING
+ *     with nobody watching is a normal headless run, and flagging every one would
+ *     bury the real signal. A session sitting idle — or worse, waiting on a
+ *     question — with no client attached is the stranded case: nobody is coming.
+ */
+export function foldHostLink(rows: ActiveSession[]): void {
+  for (const s of rows) {
+    // Cloud tasks have no local pid, window, or tmux server; there is no host
+    // link to classify and no honest answer to give.
+    if (s.context === 'cloud') continue;
+    // A days-stale row is already `abandoned`; whether its window is also gone
+    // adds nothing, and its pid liveness is genuinely unknown from the status
+    // (abandoned outranks closed), so claim no host link rather than guess one.
+    if (s.status === 'abandoned') continue;
+    // `closed` IS the dead-pid status — `lifecycleStatus` assigns it from
+    // `!pidAlive` and nothing else — so the status is the pid answer here.
+    const link = classifyHostLink({
+      pidAlive: s.status !== 'closed',
+      windowHeartbeatMs: s.windowHeartbeatMs,
+      tmuxClients: s.tmuxClients,
+      deliberatelyDetached: s.presence === 'background' || s.presence === 'parked',
+    });
+    s.hostLink = link;
+    // `foldPresence` gives every terminal row a DERIVED `attached` — "a live
+    // interactive TUI you're watching" — which is exactly the claim a lost host
+    // disproves. A stored record never yields `attached` (it is background or
+    // parked), so clearing only that value drops the derived lie and leaves a
+    // real detach record untouched.
+    if (link !== 'connected' && s.presence === 'attached') s.presence = undefined;
+    if (link === 'host-gone' && s.status === 'closed') s.status = 'crashed';
+    else if (link === 'no-client' && (s.status === 'idle' || s.status === 'input_required')) {
+      s.status = 'orphaned';
+    }
+  }
 }
 
 /**

--- a/apps/cli/src/lib/session/favorites.test.ts
+++ b/apps/cli/src/lib/session/favorites.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-favorites-'));
+process.env.HOME = TEST_HOME;
+
+const { listFavorites, isFavorite, setFavorite, toggleFavorite, favoritesFilePath, clearFavoritesCache } =
+  await import('./favorites.js');
+
+/**
+ * Favorites are the one piece of per-session state a human ASSERTS rather than
+ * the scanner deriving, so the properties that matter are durability (a real
+ * file, atomically written, surviving a reindex of the session cache) and that
+ * a corrupt or absent file degrades to "nothing is starred" instead of taking
+ * `agents sessions` down with it.
+ */
+describe('session favorites', () => {
+  it('round-trips a star through the real file and reports it back', () => {
+    expect(isFavorite('sid-a')).toBe(false);
+    expect(setFavorite('sid-a', true)).toBe(true);
+    expect(isFavorite('sid-a')).toBe(true);
+    expect([...listFavorites()]).toEqual(['sid-a']);
+    // The store is a real file on disk, not process state.
+    const onDisk = JSON.parse(fs.readFileSync(favoritesFilePath(), 'utf8'));
+    expect(onDisk.sessionIds).toContain('sid-a');
+    expect(onDisk.version).toBe(1);
+  });
+
+  it('toggles, and unstarring removes the id rather than keeping a false entry', () => {
+    setFavorite('sid-b', true);
+    expect(toggleFavorite('sid-b')).toBe(false);
+    expect(isFavorite('sid-b')).toBe(false);
+    expect(JSON.parse(fs.readFileSync(favoritesFilePath(), 'utf8')).sessionIds).not.toContain('sid-b');
+    expect(toggleFavorite('sid-b')).toBe(true);
+    expect(isFavorite('sid-b')).toBe(true);
+  });
+
+  it('is idempotent — a redundant set leaves the file untouched', () => {
+    setFavorite('sid-c', true);
+    const before = fs.statSync(favoritesFilePath()).mtimeMs;
+    expect(setFavorite('sid-c', true)).toBe(true);
+    expect(fs.statSync(favoritesFilePath()).mtimeMs).toBe(before);
+  });
+
+  it('picks up a file another process rewrote (the memoized read is mtime-keyed)', () => {
+    setFavorite('sid-d', true);
+    expect(isFavorite('sid-d')).toBe(true);
+    // Simulate a peer/sync writing the file underneath us.
+    fs.writeFileSync(favoritesFilePath(), JSON.stringify({ version: 1, sessionIds: ['sid-elsewhere'] }));
+    clearFavoritesCache();
+    expect(isFavorite('sid-d')).toBe(false);
+    expect(isFavorite('sid-elsewhere')).toBe(true);
+  });
+
+  it('treats a malformed or absent store as empty instead of throwing', () => {
+    fs.writeFileSync(favoritesFilePath(), '{ this is not json');
+    clearFavoritesCache();
+    expect(listFavorites().size).toBe(0);
+    // Non-string entries are dropped, not trusted into the set.
+    fs.writeFileSync(favoritesFilePath(), JSON.stringify({ version: 1, sessionIds: ['ok', 42, null, ''] }));
+    clearFavoritesCache();
+    expect([...listFavorites()]).toEqual(['ok']);
+    fs.rmSync(favoritesFilePath());
+    clearFavoritesCache();
+    expect(listFavorites().size).toBe(0);
+    expect(isFavorite('anything')).toBe(false);
+  });
+
+  it('never treats an absent session id as favorited', () => {
+    expect(isFavorite(undefined)).toBe(false);
+    expect(isFavorite('')).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/session/favorites.ts
+++ b/apps/cli/src/lib/session/favorites.ts
@@ -1,0 +1,108 @@
+/**
+ * Favorited (starred) sessions — the durable "keep this one handy" mark a human
+ * puts on a session, deliberately kept OUT of the session index.
+ *
+ * `sessions.db` is a rebuildable CACHE: a reindex or a schema bump throws its
+ * rows away and re-derives them from the transcripts on disk. A favorite is not
+ * derivable from a transcript — it is a human's choice — so a column there would
+ * be silently lost on the next rebuild. It lives in `~/.agents/.history/` instead,
+ * next to the actor sidecars, which is never pruned.
+ *
+ * One flat set of session ids, because a session id is the transcript's own uuid
+ * and is therefore stable across machines: the file syncs with the rest of
+ * `.history`, so a session starred on one box is starred on every box.
+ *
+ * Reads are memoized against the file's mtime — the picker asks `isFavorite` once
+ * per rendered row, and re-reading a JSON file per row on every keystroke is the
+ * kind of cost that makes a TUI feel broken.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getHistoryDir } from '../state.js';
+
+/** The on-disk shape. Versioned so a later format can migrate rather than guess. */
+interface FavoritesFile {
+  version: 1;
+  sessionIds: string[];
+}
+
+export function favoritesFilePath(): string {
+  return path.join(getHistoryDir(), 'favorites.json');
+}
+
+/** Memoized parse, invalidated by the file's mtime+size (another process — or
+ *  another machine's sync — can rewrite it under us). */
+let cache: { key: string; ids: Set<string> } | null = null;
+
+function statKey(file: string): string {
+  try {
+    const st = fs.statSync(file);
+    return `${st.mtimeMs}:${st.size}`;
+  } catch {
+    return 'absent';
+  }
+}
+
+/** Drop the memoized read. Tests that write the file directly need this; nothing
+ *  in the CLI does, because every mutation here refreshes the cache itself. */
+export function clearFavoritesCache(): void {
+  cache = null;
+}
+
+/**
+ * Every favorited session id. Empty (never throws) when the file is absent,
+ * unreadable, or malformed — a corrupt favorites file must not take down
+ * `agents sessions`.
+ */
+export function listFavorites(): Set<string> {
+  const file = favoritesFilePath();
+  const key = statKey(file);
+  if (cache && cache.key === key) return cache.ids;
+  let ids = new Set<string>();
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as Partial<FavoritesFile>;
+    if (Array.isArray(parsed?.sessionIds)) {
+      ids = new Set(parsed.sessionIds.filter((id): id is string => typeof id === 'string' && id.length > 0));
+    }
+  } catch {
+    // absent / unreadable / malformed — an empty set is the honest answer
+  }
+  cache = { key, ids };
+  return ids;
+}
+
+export function isFavorite(sessionId: string | undefined): boolean {
+  if (!sessionId) return false;
+  return listFavorites().has(sessionId);
+}
+
+/** Atomic write (tmp + rename) so a concurrent reader never sees a half file. */
+function writeFavorites(ids: Set<string>): void {
+  const file = favoritesFilePath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const body: FavoritesFile = { version: 1, sessionIds: [...ids].sort() };
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(body, null, 2) + '\n');
+  fs.renameSync(tmp, file);
+  cache = { key: statKey(file), ids };
+}
+
+/**
+ * Set (or clear) the favorite mark on a session. Returns the resulting state, so
+ * a caller can report it without a second read. A no-op write is skipped, which
+ * keeps the file's mtime — and every other process's memoized read — untouched.
+ */
+export function setFavorite(sessionId: string, on: boolean): boolean {
+  const ids = new Set(listFavorites());
+  if (ids.has(sessionId) === on) return on;
+  if (on) ids.add(sessionId);
+  else ids.delete(sessionId);
+  writeFavorites(ids);
+  return on;
+}
+
+/** Flip the mark; returns the new state (`true` = now favorited). */
+export function toggleFavorite(sessionId: string): boolean {
+  return setFavorite(sessionId, !isFavorite(sessionId));
+}

--- a/apps/cli/src/lib/session/favorites.ts
+++ b/apps/cli/src/lib/session/favorites.ts
@@ -8,9 +8,11 @@
  * be silently lost on the next rebuild. It lives in `~/.agents/.history/` instead,
  * next to the actor sidecars, which is never pruned.
  *
- * One flat set of session ids, because a session id is the transcript's own uuid
- * and is therefore stable across machines: the file syncs with the rest of
- * `.history`, so a session starred on one box is starred on every box.
+ * One flat set of session ids. The id is the transcript's own uuid, so it is
+ * stable and machine-independent — but the file is NOT synced today: session sync
+ * carries `.history/backups/` (`lib/session/sync/agents.ts`), not this. Favorites
+ * are therefore per-machine; carrying them across the fleet would mean adding
+ * them to the sync manifest, which this does not do.
  *
  * Reads are memoized against the file's mtime — the picker asks `isFavorite` once
  * per rendered row, and re-reading a JSON file per row on every keystroke is the

--- a/apps/cli/src/lib/session/host-link.test.ts
+++ b/apps/cli/src/lib/session/host-link.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { classifyHostLink, HOST_HEARTBEAT_STALE_MS } from './host-link.js';
+
+const NOW = 1_700_000_000_000;
+const fresh = NOW - 30_000;
+const stale = NOW - HOST_HEARTBEAT_STALE_MS - 1;
+
+/**
+ * The decision table behind the `crashed` / `orphaned` statuses. Each case is a
+ * scenario a user hits, not a permutation for its own sake — the point of the
+ * classifier is that it never cries wolf on a session that is fine, and never
+ * stays silent on one that has genuinely lost its human.
+ */
+describe('classifyHostLink', () => {
+  it('reports a healthy session as connected', () => {
+    expect(classifyHostLink({ pidAlive: true, windowHeartbeatMs: fresh, nowMs: NOW })).toBe('connected');
+    expect(classifyHostLink({ pidAlive: true, tmuxClients: 1, nowMs: NOW })).toBe('connected');
+  });
+
+  it('calls a dead agent under a dead window `host-gone` — VS Code crashed and took it down', () => {
+    expect(classifyHostLink({ pidAlive: false, windowHeartbeatMs: stale, nowMs: NOW })).toBe('host-gone');
+  });
+
+  it('does NOT call an ordinary close a crash — the window is still alive and republishing', () => {
+    expect(classifyHostLink({ pidAlive: false, windowHeartbeatMs: fresh, nowMs: NOW })).toBe('connected');
+    // No window at all (a bare terminal / team spawn): a dead pid is just closed.
+    expect(classifyHostLink({ pidAlive: false, nowMs: NOW })).toBe('connected');
+  });
+
+  it('calls a live agent with zero tmux clients `no-client`', () => {
+    expect(classifyHostLink({ pidAlive: true, tmuxClients: 0, nowMs: NOW })).toBe('no-client');
+  });
+
+  it('calls a live agent whose owning window stopped republishing `no-client`', () => {
+    expect(classifyHostLink({ pidAlive: true, windowHeartbeatMs: stale, nowMs: NOW })).toBe('no-client');
+  });
+
+  it('never flags a deliberately detached session — it is supposed to have no client', () => {
+    expect(
+      classifyHostLink({ pidAlive: true, tmuxClients: 0, deliberatelyDetached: true, nowMs: NOW }),
+    ).toBe('connected');
+    expect(
+      classifyHostLink({ pidAlive: false, windowHeartbeatMs: stale, deliberatelyDetached: true, nowMs: NOW }),
+    ).toBe('connected');
+  });
+
+  it('treats an unknown client count as unknown, not as zero', () => {
+    // A tmux server too old to report `session_attached` (or a parse miss) must
+    // not read as "nobody is attached" and orphan every tmux session on the box.
+    expect(classifyHostLink({ pidAlive: true, tmuxClients: undefined, nowMs: NOW })).toBe('connected');
+  });
+
+  it('holds at the exact staleness boundary', () => {
+    const atBoundary = NOW - HOST_HEARTBEAT_STALE_MS;
+    expect(classifyHostLink({ pidAlive: true, windowHeartbeatMs: atBoundary, nowMs: NOW })).toBe('no-client');
+    expect(classifyHostLink({ pidAlive: true, windowHeartbeatMs: atBoundary + 1, nowMs: NOW })).toBe('connected');
+  });
+});

--- a/apps/cli/src/lib/session/host-link.ts
+++ b/apps/cli/src/lib/session/host-link.ts
@@ -1,0 +1,97 @@
+/**
+ * Host link — whether anything is still on the other end of a live session.
+ *
+ * Every liveness signal the scan already has answers "is the AGENT process
+ * alive". None of them answer "is anyone still driving it", and those come apart
+ * in exactly the two ways a user notices:
+ *
+ *   - **The host program died and took the agent with it.** VS Code / the editor
+ *     window crashes or the SSH connection drops, so the agent process dies with
+ *     its parent, but the window never got to run its teardown — its slice of
+ *     `live-terminals.json` is left behind, stale, still naming a dead pid. Today
+ *     that entry is filtered out at read time, so the session simply VANISHES
+ *     from `--active` instead of reporting that it fell over. That is `host-gone`.
+ *
+ *   - **The host program died and the agent survived it.** The agent was hosted
+ *     in tmux (or otherwise reparented), so it keeps running with zero clients
+ *     attached: still burning tokens, or sitting on a question nobody will ever
+ *     answer, with no window anywhere showing it. That is `no-client`.
+ *
+ * Both are DERIVED, never asserted — from the agent pid, the owning window's
+ * keepalive, and tmux's own attached-client count. A deliberately backgrounded
+ * session (`agents sessions detach`) is excluded by construction: it is supposed
+ * to have no client, so calling it orphaned would be a false alarm on the one
+ * case the user asked for.
+ */
+
+/** How a session is connected to the client that should be driving it. */
+export type HostLink =
+  /** A client is attached, or nothing indicates otherwise. The normal case. */
+  | 'connected'
+  /** Alive, but nothing is viewing it — the host window is gone and the agent outlived it. */
+  | 'no-client'
+  /** The host window is gone AND the agent process died with it — an unclean exit. */
+  | 'host-gone';
+
+/**
+ * How long an IDE window's registry slice may go without a refresh before we
+ * treat that window as gone. The Factory extension force-republishes its slice
+ * every 4 minutes (`KEEPALIVE_FORCE_MS` in `apps/factory/src/vscode/foreman.registry.ts`)
+ * and on every terminal open/close, so a slice this old means the window is no
+ * longer running — it is not merely quiet. Deliberately the same 10 minutes the
+ * extension itself uses to garbage-collect a peer window's slice, so the CLI and
+ * the extension agree on when a window is dead.
+ */
+export const HOST_HEARTBEAT_STALE_MS = 10 * 60_000;
+
+export interface HostLinkInput {
+  /** The agent process is still alive (already pid-reuse-checked by the caller). */
+  pidAlive: boolean;
+  /**
+   * When the owning IDE window last refreshed its slice of the live-terminals
+   * registry. Absent for a session no IDE window owns (a bare terminal, a team
+   * spawn, a cloud task) — those have no window whose death we could observe.
+   */
+  windowHeartbeatMs?: number;
+  /**
+   * Clients attached to this session's tmux session (`#{session_attached}`).
+   * Absent when the session is not tmux-hosted, which is NOT the same as zero:
+   * zero is a positive "nobody is looking", absent is "we cannot tell".
+   */
+  tmuxClients?: number;
+  /** The session was deliberately backgrounded — `presence` is `background`/`parked`. */
+  deliberatelyDetached?: boolean;
+  nowMs?: number;
+}
+
+/**
+ * Classify a live row's host link. Pure — every signal is passed in, so the
+ * whole decision table is unit-testable without a process table, a tmux server,
+ * or a running editor.
+ */
+export function classifyHostLink(input: HostLinkInput): HostLink {
+  const now = input.nowMs ?? Date.now();
+  // A session detached on purpose has no client BY DESIGN. It is the one case
+  // that looks identical to an orphan from the outside, so it is excluded first —
+  // otherwise every `agents sessions detach` would raise a false alarm.
+  if (input.deliberatelyDetached) return 'connected';
+
+  const windowGone =
+    input.windowHeartbeatMs !== undefined && now - input.windowHeartbeatMs >= HOST_HEARTBEAT_STALE_MS;
+
+  // The host window stopped keeping its registry slice alive AND the agent it
+  // owned is dead: the pair went down together without teardown.
+  if (windowGone && !input.pidAlive) return 'host-gone';
+
+  if (!input.pidAlive) return 'connected'; // a plain dead pid is `closed`, not an orphan
+
+  // Alive with tmux reporting zero attached clients: nobody is watching it. This
+  // is the authoritative signal — tmux knows exactly how many clients it has.
+  if (input.tmuxClients === 0) return 'no-client';
+
+  // Alive, not tmux-hosted (or tmux says someone is attached), but the window
+  // that owned it is gone. The agent outlived its editor.
+  if (windowGone) return 'no-client';
+
+  return 'connected';
+}


### PR DESCRIPTION
Adds **favorites** to the session browser, and makes a session that has **lost its host** say so instead of lying or disappearing. Two user-visible features plus two bugs found while verifying them.

## What you see

**Favorites** — `*` stars the highlighted session, `f` filters to the starred ones. `agents sessions favorite <id>` (`--remove` / `--list` / `--json`) and `agents sessions --favorites` are the non-TTY twins, so the `y` copy-cmd still round-trips the view.

> Screenshots are referenced by **path, not embedded** — three attempts to drive a browser for GitHub's drag-drop upload failed (`agents browser` self-launch closes the CDP connection; nothing listening on :9222). They are real captures of the running TUI on `zion`, openable by anyone on the fleet.
>
> - `zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/sessions-favorites.png` — three sessions starred with `*`, across claude and grok
> - `zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/sessions-favorites-filter.png` — `f` narrowing the list to just those three
> - `zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/sessions-crashed-orphan.png` — `orphan` and `crashed` in the `--active` status column
> - `zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/sessions-tui-lost-host.png` — the same two in the **interactive browser**, next to healthy `working` rows, with the preview spelling the state out

```
  ★ 97646f02  claude   2.1.220 agents-cli   agents-cli-43 · Fix session resume with batch selection...
    e64d93c3  kimi     -       agents-cli   Let's show usage bars for antigravity...
  ★ 019fc667  grok     0.2.32  agents-cli
    019fc667  grok     0.2.101 agents-cli
  ★ c700013a  claude   -       -            [host/yosemite-s1]

s search · r running · f favorites · * star · c teams · t team · a agent · d device · p project · w window · tab preview · y copy-cmd · ⏎ resume · esc quit
```

**Lost hosts** — two new statuses in the same column the others use:

| status | glyph | what happened |
|---|---|---|
| `crashed` | `✗` | The editor window / connection went down hard and the agent died with it. It never ran its teardown, so its `live-terminals.json` entry is still there naming a dead pid. **Before this, the session simply vanished from `--active`** — that entry was filtered out at read time. |
| `orphan` | `◍` | The agent is alive with **no client attached** — tmux reports zero attached clients, or the window that owned it stopped republishing. Idle, or sitting on a question nobody will answer. |

```
▸ zion (11)  ← this machine
  ~ (2)
    terminal · win vscode-w (2)
      aaaaaaaa claude   -        orphan   -   agents-demo · Migration applied cleanly.
      bbbbbbbb claude   -        crashed  -   agents-demo · Migration applied cleanly.
```

The interactive browser gained a **status column** for its running view to make this
reachable at a glance — it previously showed which terminal a session ran in but never
what it was doing, so a session that had lost its host was indistinguishable from a
healthy one in the row list. Gated exactly like the host column (live-only), so a plain
transcript listing is not widened by a column every row would leave blank:

```
> aaaaaaaa  claude  -  -        -  orphan   run the migration        11 hours ago
  bbbbbbbb  claude  -  -        -  crashed  run the migration        11 hours ago
  p:27646   claude  -  tmux     -  working                              just now
  p:6311    claude  -  ghostty  -  working                              just now
────────────────────────────────────────────────────────────────────────────────
◍ orphan  ← still running, but no client is attached — nothing is showing it
```

## The run

Both scenarios driven end to end through the real CLI against a real registry and a real live process (isolated `HOME`, so nothing on this box was touched):

```
$ agents sessions --active --local --json
11111111  status=orphaned  hostLink=no-client  activity=idle presence=None   # live pid, dead window
bbbbbbbb  status=crashed   hostLink=host-gone  activity=idle presence=None   # dead pid, dead window
```

And against the **real tmux server on this laptop** — pane `%3` genuinely has nobody attached:

```
c34fbc88 pane=%14 clients=1 status=running hostLink=connected
bd23dd62 pane=%3  clients=0 status=running hostLink=no-client   <- detected, status untouched
```

That last line is the design working: it has no client, but it is still *working*, so it keeps `running`. Only an `idle` / `input_required` session becomes `orphan`.

## Not crying wolf

The failure mode that would make this worthless is a listing where everything says "orphan". Each of these is pinned by a test:

- A dead pid under a **healthy** window is an ordinary close, not a crash — dropped, as before.
- A session still `running` with zero clients is a normal headless run — left alone.
- A deliberate `agents sessions detach` (`presence` `background`/`parked`) is never flagged; no client is the point.
- An **absent** tmux client count reads as "cannot tell", never as zero.
- `abandoned` (days-stale) still wins outright, so a `crashed` row is a transient alert, not a permanent tombstone.

## Three bugs found while verifying

Both were breaking the feature and are fixed here; calling them out because neither was part of the ask.

1. **tmux sanitizes control characters out of `-F` format output** (3.6a rewrites a literal tab to `_`), so `listTmuxAgentSessions`' tab-separated query came back as one unsplittable field and every line failed its guard. Every format query here now uses a printable separator — proven by a real-tmux integration test. This is also why the client count is folded on from `provenance.mux` rather than from that source: it resolves **0 rows** on this machine for a *separate*, pre-existing reason (no pane identity to resolve), which would have left the whole orphan signal silently dead.
2. **`agents sessions favorite --json` emitted prose.** `agents sessions` declares `--json` *and* takes a positional `[query]`, so commander keeps matching parent-known options past the subcommand name and binds `--json` to the **parent** — the subcommand's own `options.json` sat undefined. Read through `optsWithGlobals()` now, and pinned by a test that spawns the real CLI, because a direct call of the action cannot see a parsing defect.
3. **`dynamicPicker` repainted one keypress late.** It memoized row labels on the item array — which `load` returns *unchanged* when no filter is active — and read its reload counter from a stale keypress closure. Starring a row left the star invisible until you pressed something else. Labels now rebuild when a load *completes*.

## Non-author review round

`prix-cloud` had not posted after CI settled twice, so a non-author reviewer was run per
the repo's documented fallback. It found **four blocking issues**, all the same shape —
a consumer that recognised a state by its **status**, which `foldHostLink` rewrites.
All four are fixed in `9087d2c2`, each with a test:

| finding | what broke | fix |
|---|---|---|
| `--waiting` filtered `status === 'input_required'` | a session waiting on a question with nobody watching — the most acute case the feature exists to surface — dropped out of the filter *and* its non-zero exit | reads the `activity` the fold never rewrites, via `isAwaitingUser` |
| `groupTally` had no bucket for either status | "N active (…)" stopped adding up to the list under it | a bucket per status |
| HQ Floor's `moodForSession` mapped neither | a crashed session whose last parsed turn said `working` reached the dashboard as a happily-working agent | `crashed` → `blocked`, `orphaned` → `waiting` |
| `--active --favorites` was browser-only | silently returned the whole fleet on `--json`, `--waiting`, piped, multi-host, and fanout-peer paths | filtered in `renderActiveSessions` |

Two nits also fixed: the picker keeps the readline **name** as a binding fallback so the
shifted form of an existing hotkey (`R`/`C`/`A`) still works, and the tmux field
separator moved `|` → `:` — tmux rewrites `:` and `.` in a session name, so unlike `|` it
*provably* cannot occur in the field ahead of the path (the same bug class as the tab).

One finding was **not** changed, deliberately: `provenance.mux` can come from an inherited
`TMUX` env var, so an agent inside the user's own ambient tmux session reads that session's
client count. That is the correct answer — if the user detaches that tmux, nothing genuinely
is showing those agents; the state self-corrects on reattach, and only `idle`/`waiting` rows
are relabelled, never a working one.

## Design notes

- **Stars are not in `sessions.db`.** The index is a rebuildable cache; a favorite is a human's choice, not derivable from a transcript, so a column there is silently lost on the next reindex. They live in `~/.agents/.history/favorites.json` (never pruned, syncs across machines).
- **One fold, not per-source.** `foldHostLink` runs once over the merged set, after `foldPresence`, so every consumer — the browser, `--active`, `--json`, the Factory extension — agrees. It also clears the *derived* `presence: attached`, which a lost host disproves, while leaving a real detach record intact.
- **The favorite marker is a conditional column** (`showFavorite`), matching `showMachine` / `showTicket` / `showHost`: a user who has never starred anything pays zero columns for it.

## Scope

The browser fetches its live index lazily (only once the `r` filter is on) — a deliberate existing tradeoff so a bare browse stays instant. So the new statuses appear in `agents sessions --active`, the printed listing, `--json`, and the browser's running view; a bare browse with `r` off has no live data at all, unchanged from today.

## Tests, docs, changelog

`bun run test` on the session/picker/tmux surface: **1805 passed**. Full suite: 14 failures in `crabbox` / `models` / `browser/port` / `exec` — **identical on clean `origin/main`** (verified in a pristine worktree), pre-existing and unrelated.

Docs updated: `apps/cli/docs/05-sessions.md` (two new sections), the normative contract in `apps/cli/docs/specifications.md` (SES-18 narrowed; SES-18a / SES-18b added), the root `README.md` hotkey table, and a `.changelog/next/` fragment.
