### PR TITLE
fix(resources): a directory's README/AGENTS is documentation, not a resource

### DIFF
--- a/apps/cli/.changelog/next/doc-files-are-not-resources.md
+++ b/apps/cli/.changelog/next/doc-files-are-not-resources.md
@@ -12,6 +12,13 @@
   convention — a resource *directory* named `agents/` is still a real resource.
   Verified against the real installed layers: 30 commands with `README` leaking
   before, 29 with none after.
+- **`agents commands list` and the command picker no longer offer a name that
+  cannot be opened.** `listCentralCommands` and `discoverCommands`
+  (`src/lib/commands.ts`) run their own `readdirSync` scans rather than going
+  through `listResources`, so they kept offering `README` while
+  `agents commands view README` answered "not found" — a listed-but-unopenable
+  name. Both now share the one exported `isDirectoryDoc` predicate, so every
+  enumerator agrees. Verified: 27 names with `README` before, 26 with none after.
 - **`agents commands add/remove/view` no longer suggest `README` as the example
   command name.** With `README` reserved as a directory doc, the six hardcoded
   examples in the help text and non-interactive hints named a command that can never

--- a/apps/cli/.changelog/next/doc-files-are-not-resources.md
+++ b/apps/cli/.changelog/next/doc-files-are-not-resources.md
@@ -1,0 +1,18 @@
+- **A `README.md` / `AGENTS.md` sitting in a resource directory is no longer
+  installed as a resource.** `listResources` skipped only dotfiles, so every `.md`
+  beside the actual resources was materialized as one: `commands/README.md` — which
+  the system repo has shipped for months — installed a bogus `/README` slash command
+  into every agent home, and adding per-directory `AGENTS.md` docs would have added
+  `/AGENTS`, `/CLAUDE`, and `/GEMINI` alongside it. `README`, `AGENTS`, `CLAUDE`, and
+  `GEMINI` are now filtered from both `listResources` and `resolveResource` for every
+  kind **except `rules`**, where `AGENTS.md` *is* the resource (the composed ruleset
+  that syncs as each agent's memory file). The check tests `!entry.isDirectory()`
+  rather than `isFile()`, because a `Dirent` for a symlink reports
+  `isFile() === false` and `CLAUDE.md`/`GEMINI.md` are symlinks to `AGENTS.md` by
+  convention — a resource *directory* named `agents/` is still a real resource.
+  Verified against the real installed layers: 30 commands with `README` leaking
+  before, 29 with none after.
+- **`agents commands add/remove/view` no longer suggest `README` as the example
+  command name.** With `README` reserved as a directory doc, the six hardcoded
+  examples in the help text and non-interactive hints named a command that can never
+  exist. They now use `plan`, which actually ships.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,22 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **A `README.md` / `AGENTS.md` sitting in a resource directory is no longer
-  installed as a resource.** `listResources` skipped only dotfiles, so every `.md`
-  beside the actual resources was materialized as one: `commands/README.md` — which
-  the system repo has shipped for months — installed a bogus `/README` slash command
-  into every agent home, and adding the per-directory `AGENTS.md` docs would have
-  added `/AGENTS`, `/CLAUDE`, and `/GEMINI` alongside it. `README`, `AGENTS`,
-  `CLAUDE`, and `GEMINI` are now filtered from both `listResources` and
-  `resolveResource` for every kind **except `rules`**, where `AGENTS.md` *is* the
-  resource (the composed ruleset that syncs as each agent's memory file). The check
-  tests `!entry.isDirectory()` rather than `isFile()`, because a `Dirent` for a
-  symlink reports `isFile() === false` and `CLAUDE.md`/`GEMINI.md` are symlinks to
-  `AGENTS.md` by convention — a resource *directory* named `agents/` is still a real
-  resource. `apps/cli/src/lib/resources.ts` + 2 tests in `resources.test.ts`
-  (64 pass across the 5 resource-resolution suites).
-
 ## 1.20.88
 
 - **`agents doctor` redesigned into a prioritized, fleet-aware, per-version

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- **A `README.md` / `AGENTS.md` sitting in a resource directory is no longer
+  installed as a resource.** `listResources` skipped only dotfiles, so every `.md`
+  beside the actual resources was materialized as one: `commands/README.md` — which
+  the system repo has shipped for months — installed a bogus `/README` slash command
+  into every agent home, and adding the per-directory `AGENTS.md` docs would have
+  added `/AGENTS`, `/CLAUDE`, and `/GEMINI` alongside it. `README`, `AGENTS`,
+  `CLAUDE`, and `GEMINI` are now filtered from both `listResources` and
+  `resolveResource` for every kind **except `rules`**, where `AGENTS.md` *is* the
+  resource (the composed ruleset that syncs as each agent's memory file). The check
+  tests `!entry.isDirectory()` rather than `isFile()`, because a `Dirent` for a
+  symlink reports `isFile() === false` and `CLAUDE.md`/`GEMINI.md` are symlinks to
+  `AGENTS.md` by convention — a resource *directory* named `agents/` is still a real
+  resource. `apps/cli/src/lib/resources.ts` + 2 tests in `resources.test.ts`
+  (64 pass across the 5 resource-resolution suites).
+
 ## 1.20.88
 
 - **`agents doctor` redesigned into a prioritized, fleet-aware, per-version

--- a/apps/cli/src/commands/commands.ts
+++ b/apps/cli/src/commands/commands.ts
@@ -89,7 +89,7 @@ Examples:
   agents commands add
 
   # Install specific commands by name
-  agents commands add --names README,debug --agents codex@0.116.0
+  agents commands add --names plan,debug --agents codex@0.116.0
 
 When to use:
   - Project setup: 'agents commands add gh:team/commands' to sync everyone's workflow
@@ -151,7 +151,7 @@ Examples:
   agents commands add
 
   # Install specific commands to a single version
-  agents commands add --names README,debug --agents codex@0.116.0
+  agents commands add --names plan,debug --agents codex@0.116.0
 
   # Pull commands from GitHub and sync to all installed agents
   agents commands add gh:user/repo --agents claude,codex,cursor
@@ -188,7 +188,7 @@ Examples:
           } else {
             if (!isInteractiveTerminal()) {
               requireInteractiveSelection('Selecting commands from ~/.agents/commands/', [
-                'agents commands add --names README,debug --agents codex',
+                'agents commands add --names plan,debug --agents codex',
                 'agents commands add gh:user/repo --agents codex',
               ]);
             }
@@ -351,7 +351,7 @@ Examples:
     .addHelpText('after', `
 Examples:
   # Remove a command by name
-  agents commands remove README
+  agents commands remove plan
 
   # Interactive: pick commands to remove
   agents commands remove
@@ -387,7 +387,7 @@ Examples:
 
         if (!isInteractiveTerminal()) {
           requireInteractiveSelection('Selecting commands to remove', [
-            'agents commands remove README',
+            'agents commands remove plan',
           ]);
         }
 
@@ -516,7 +516,7 @@ Examples:
     .addHelpText('after', `
 Examples:
   # View a specific command
-  agents commands view README
+  agents commands view plan
 
   # Interactive picker
   agents commands view
@@ -532,7 +532,7 @@ Examples:
 
         if (!isInteractiveTerminal()) {
           requireInteractiveSelection('Selecting a command to view', [
-            'agents commands view README',
+            'agents commands view plan',
           ]);
         }
 

--- a/apps/cli/src/lib/commands.ts
+++ b/apps/cli/src/lib/commands.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import * as yaml from 'yaml';
 import { AGENTS, ensureCommandsDir, agentConfigDirName, resolveAgentName } from './agents.js';
 import { capableAgents, isCapable, supports } from './capabilities.js';
+import { isDirectoryDoc } from './resources.js';
 import { markdownToToml } from './convert.js';
 import { getCommandsDir, getUserCommandsDir, getEnabledExtraRepos, getProjectAgentsDir, getSkillsDir, getTrashCommandsDir } from './state.js';
 import { getEffectiveHome, getVersionHomePath, listInstalledVersions, resolveVersion } from './versions.js';
@@ -235,6 +236,7 @@ export function discoverCommands(repoPath: string): DiscoveredCommand[] {
     for (const file of fs.readdirSync(commandsDir)) {
       if (file.endsWith('.md')) {
         const name = file.replace('.md', '');
+        if (isDirectoryDoc('commands', name)) continue;
         const sourcePath = path.join(commandsDir, file);
         const metadata = parseCommandMetadata(sourcePath);
         const validation = validateCommandMetadata(metadata, name);
@@ -886,7 +888,11 @@ export function listCentralCommands(): string[] {
   for (const dir of [getUserCommandsDir(), getCommandsDir()]) {
     if (!fs.existsSync(dir)) continue;
     for (const f of fs.readdirSync(dir).filter((f) => f.endsWith('.md'))) {
-      seen.add(f.replace('.md', ''));
+      const name = f.replace('.md', '');
+      // A directory's README/AGENTS/CLAUDE/GEMINI documents the dir, it is not a
+      // command. Without this the picker offers a name resolveResource refuses.
+      if (isDirectoryDoc('commands', name)) continue;
+      seen.add(name);
     }
   }
   return Array.from(seen);

--- a/apps/cli/src/lib/resources.test.ts
+++ b/apps/cli/src/lib/resources.test.ts
@@ -76,4 +76,56 @@ describe('resource resolution', () => {
     expect(parsed.listed).toHaveLength(1);
     expect(parsed.listed[0]).toMatchObject({ name: 'deploy', source: 'user' });
   });
+
+  it('never treats a directory doc as a resource, so /README is not installed as a command', () => {
+    const home = makeHome();
+    const project = makeProject();
+
+    const commands = path.join(home, '.agents', 'commands');
+    fs.mkdirSync(commands, { recursive: true });
+    fs.writeFileSync(path.join(commands, 'plan.md'), 'real command');
+    fs.writeFileSync(path.join(commands, 'README.md'), '# Commands');
+    fs.writeFileSync(path.join(commands, 'AGENTS.md'), '# contract');
+    fs.symlinkSync('AGENTS.md', path.join(commands, 'CLAUDE.md'));
+    fs.symlinkSync('AGENTS.md', path.join(commands, 'GEMINI.md'));
+
+    const result = runProbe(home, project, `
+      const { resolveResource, listResources } = await import('./src/lib/resources.ts');
+      console.log(JSON.stringify({
+        listed: listResources('commands', ${JSON.stringify(project)}).map((r) => r.name).sort(),
+        readme: resolveResource('commands', 'README', ${JSON.stringify(project)}),
+        agents: resolveResource('commands', 'AGENTS', ${JSON.stringify(project)}),
+        plan: resolveResource('commands', 'plan', ${JSON.stringify(project)}),
+      }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.listed).toEqual(['plan']);
+    expect(parsed.readme).toBeNull();
+    expect(parsed.agents).toBeNull();
+    expect(parsed.plan).toMatchObject({ name: 'plan', source: 'user' });
+  });
+
+  it('still resolves rules/AGENTS.md, where the doc filename IS the resource', () => {
+    const home = makeHome();
+    const project = makeProject();
+
+    const rules = path.join(home, '.agents', 'rules');
+    fs.mkdirSync(rules, { recursive: true });
+    fs.writeFileSync(path.join(rules, 'AGENTS.md'), '# the composed ruleset');
+
+    const result = runProbe(home, project, `
+      const { resolveResource, listResources } = await import('./src/lib/resources.ts');
+      console.log(JSON.stringify({
+        listed: listResources('rules', ${JSON.stringify(project)}).map((r) => r.name),
+        resolved: resolveResource('rules', 'AGENTS', ${JSON.stringify(project)}),
+      }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.listed).toEqual(['AGENTS']);
+    expect(parsed.resolved).toMatchObject({ name: 'AGENTS', source: 'user' });
+  });
 });

--- a/apps/cli/src/lib/resources.test.ts
+++ b/apps/cli/src/lib/resources.test.ts
@@ -107,6 +107,55 @@ describe('resource resolution', () => {
     expect(parsed.plan).toMatchObject({ name: 'plan', source: 'user' });
   });
 
+  it('still resolves a resource DIRECTORY named agents/, which is not a doc', () => {
+    const home = makeHome();
+    const project = makeProject();
+
+    const skills = path.join(home, '.agents', 'skills');
+    fs.mkdirSync(path.join(skills, 'agents'), { recursive: true });
+    fs.writeFileSync(path.join(skills, 'agents', 'SKILL.md'), '---\nname: agents\n---\n');
+    fs.writeFileSync(path.join(skills, 'README.md'), '# Skills');
+
+    const result = runProbe(home, project, `
+      const { resolveResource, listResources } = await import('./src/lib/resources.ts');
+      console.log(JSON.stringify({
+        listed: listResources('skills', ${JSON.stringify(project)}).map((r) => r.name).sort(),
+        resolved: resolveResource('skills', 'agents', ${JSON.stringify(project)}),
+      }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.listed).toEqual(['agents']);
+    expect(parsed.resolved).toMatchObject({ name: 'agents', source: 'user' });
+  });
+
+  it('keeps listCentralCommands in step with resolveResource — no listed-but-unopenable name', () => {
+    const home = makeHome();
+    const project = makeProject();
+
+    const commands = path.join(home, '.agents', 'commands');
+    fs.mkdirSync(commands, { recursive: true });
+    fs.writeFileSync(path.join(commands, 'plan.md'), 'real command');
+    fs.writeFileSync(path.join(commands, 'README.md'), '# Commands');
+    fs.writeFileSync(path.join(commands, 'AGENTS.md'), '# contract');
+
+    const result = runProbe(home, project, `
+      const { listCentralCommands } = await import('./src/lib/commands.ts');
+      const { resolveResource } = await import('./src/lib/resources.ts');
+      const listed = listCentralCommands().sort();
+      console.log(JSON.stringify({
+        listed,
+        unopenable: listed.filter((n) => resolveResource('commands', n, ${JSON.stringify(project)}) === null),
+      }));
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.listed).toEqual(['plan']);
+    expect(parsed.unopenable).toEqual([]);
+  });
+
   it('still resolves rules/AGENTS.md, where the doc filename IS the resource', () => {
     const home = makeHome();
     const project = makeProject();

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -86,7 +86,14 @@ function resourceIsActive(kind: ResourceKind, name: string, source: string): boo
  */
 const DOC_BASENAMES = new Set(['readme', 'agents', 'claude', 'gemini']);
 
-function isDirectoryDoc(kind: ResourceKind, rawName: string): boolean {
+/**
+ * True when `rawName` (a filename with its extension already stripped) names a
+ * directory doc rather than a resource of `kind`. Exported so every enumerator
+ * shares one definition — `listCentralCommands` and `discoverCommands` in
+ * `commands.ts` do their own `readdirSync` scans, and without this they would
+ * list a `README` that `resolveResource` then refuses to open.
+ */
+export function isDirectoryDoc(kind: ResourceKind, rawName: string): boolean {
   if (kind === 'rules') return false;
   return DOC_BASENAMES.has(rawName.toLowerCase());
 }

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -74,6 +74,24 @@ function resourceIsActive(kind: ResourceKind, name: string, source: string): boo
 }
 
 /**
+ * Documentation filenames that live *beside* resources, describing the directory
+ * rather than being a resource in it. A DotAgents repo keeps a `README.md` (for
+ * humans) and an `AGENTS.md` (for agents) in each resource dir, with
+ * `CLAUDE.md`/`GEMINI.md` symlinked to the latter. Without this filter every one
+ * of them materializes as a resource — `commands/README.md` installs a bogus
+ * `/README` slash command into every agent home.
+ *
+ * `rules` is exempt: there `AGENTS.md` IS the resource (the composed ruleset that
+ * syncs as each agent's memory file), not documentation about the directory.
+ */
+const DOC_BASENAMES = new Set(['readme', 'agents', 'claude', 'gemini']);
+
+function isDirectoryDoc(kind: ResourceKind, rawName: string): boolean {
+  if (kind === 'rules') return false;
+  return DOC_BASENAMES.has(rawName.toLowerCase());
+}
+
+/**
  * Resolve a single resource by kind + name using project > user > system precedence.
  * For file-based resources the path ends in `.md`, `.yaml`, or `.yml` as appropriate.
  * Returns null when the resource does not exist in any scope.
@@ -107,7 +125,9 @@ export function resolveResource(
       continue;
     }
 
-    // Try with common file extensions
+    // Try with common file extensions. A directory doc (README/AGENTS/CLAUDE/
+    // GEMINI) describes the directory and is never itself a resource.
+    if (isDirectoryDoc(kind, name)) continue;
     for (const ext of ['.md', '.yaml', '.yml']) {
       const withExt = exactPath + ext;
       if (fs.existsSync(withExt)) {
@@ -153,6 +173,11 @@ export function listResources(
     for (const entry of entries) {
       if (entry.name.startsWith('.')) continue;
       const rawName = entry.name.replace(/\.(md|yaml|yml)$/, '');
+      // Not isFile(): a Dirent for a symlink reports isFile() === false, and
+      // CLAUDE.md/GEMINI.md are symlinks to AGENTS.md by convention. Anything
+      // that is not a directory is a candidate doc; a resource directory that
+      // happens to be named `agents/` is still a real resource.
+      if (!entry.isDirectory() && isDirectoryDoc(kind, rawName)) continue;
       if (seen.has(rawName)) continue;
       if (!resourceIsActive(kind, rawName, source)) continue;
       seen.add(rawName);

--- a/apps/cli/tests/non-interactive.test.ts
+++ b/apps/cli/tests/non-interactive.test.ts
@@ -233,14 +233,14 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
   it('shows a plain hint instead of opening a picker', () => {
     const home = makeTempHome();
     tempHomes.push(home);
-    writeCentralCommand(home, 'README');
+    writeCentralCommand(home, 'demo');
 
     const result = runAgents(home, ['commands', 'view']);
     const combined = `${result.stdout}\n${result.stderr}`;
 
     expect(result.status).toBe(1);
     expect(combined).toContain('Selecting a command to view requires an interactive terminal.');
-    expect(combined).toContain('agents commands view README');
+    expect(combined).toContain('agents commands view plan');
   });
 
   it('prunes a specific version while preserving home data and session rows', () => {
@@ -388,10 +388,10 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
   it('syncs central commands with --names in a non-interactive shell', () => {
     const home = makeTempHome();
     tempHomes.push(home);
-    writeCentralCommand(home, 'README');
+    writeCentralCommand(home, 'demo');
     writeFakeManagedVersion(home, 'codex', '0.1.0', 'codex');
 
-    const result = runAgents(home, ['commands', 'add', '--names', 'README', '--agents', 'codex']);
+    const result = runAgents(home, ['commands', 'add', '--names', 'demo', '--agents', 'codex']);
     const targetPath = path.join(
       home,
       '.agents',
@@ -402,7 +402,7 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
       'home',
       '.codex',
       'prompts',
-      'README.md',
+      'demo.md',
     );
 
     expect(result.status).toBe(0);
@@ -413,11 +413,11 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
   it('syncs only the requested explicit version target', () => {
     const home = makeTempHome();
     tempHomes.push(home);
-    writeCentralCommand(home, 'README');
+    writeCentralCommand(home, 'demo');
     writeFakeManagedVersion(home, 'codex', '0.1.0', 'codex');
     writeFakeManagedVersion(home, 'codex', '0.2.0', 'codex');
 
-    const result = runAgents(home, ['commands', 'add', '--names', 'README', '--agents', 'codex@0.2.0']);
+    const result = runAgents(home, ['commands', 'add', '--names', 'demo', '--agents', 'codex@0.2.0']);
     const requestedPath = path.join(
       home,
       '.agents',
@@ -428,7 +428,7 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
       'home',
       '.codex',
       'prompts',
-      'README.md',
+      'demo.md',
     );
     const untouchedPath = path.join(
       home,
@@ -440,7 +440,7 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
       'home',
       '.codex',
       'prompts',
-      'README.md',
+      'demo.md',
     );
 
     expect(result.status).toBe(0);
@@ -452,7 +452,7 @@ describe.skipIf(process.platform === 'win32')('non-interactive CLI usage', () =>
   it('uses defaults automatically for version switching in a non-interactive shell', () => {
     const home = makeTempHome();
     tempHomes.push(home);
-    writeCentralCommand(home, 'README');
+    writeCentralCommand(home, 'demo');
     writeFakeManagedVersion(home, 'codex', '0.1.0', 'codex');
 
     const result = runAgents(home, ['use', 'codex@0.1.0']);


### PR DESCRIPTION
**bug fix** — a `README.md` or `AGENTS.md` sitting in a resource directory is no longer installed as a resource.

## The bug

`listResources` (`apps/cli/src/lib/resources.ts`) skipped only dotfiles, so every `.md` beside the real resources was materialized as one. The system repo has shipped `commands/README.md` for months, which means **every agent home has a bogus `/README` slash command installed right now**:

```
$ ls ~/.claude/commands/ | grep README
README.md
```

It shows up in the model's own command list as `- README: Commands`.

This blocks adding per-directory `AGENTS.md` docs to `.agents-system` — those would install `/AGENTS`, `/CLAUDE`, and `/GEMINI` too.

## The fix

`README`, `AGENTS`, `CLAUDE`, `GEMINI` are filtered from both `listResources` and `resolveResource`, for every kind **except `rules`** — there `AGENTS.md` *is* the resource (the composed ruleset that syncs as each agent's memory file), so filtering it would break rule sync entirely.

The guard tests `!entry.isDirectory()`, not `isFile()`: a `Dirent` for a symlink reports `isFile() === false`, and `CLAUDE.md`/`GEMINI.md` are symlinks to `AGENTS.md` by repo convention. My first draft used `isFile()` and the new test caught it — the symlinks slipped straight through.

A resource *directory* named `agents/` is still a real resource.

## Ran it — real output

Same probe, unpatched `origin/main` code vs this branch, against the actual installed layers on this box:

```
BEFORE (origin/main code): commands = 30
BEFORE: doc files leaking as commands -> [ 'README' ]

AFTER  (this branch):      commands = 29
AFTER:  doc files leaking as commands -> []
sample: audit, clean, commit, continue, debug, design, done, finish
```

## Tests

Two new cases in `resources.test.ts` — one asserting a `commands/` dir holding `plan.md` + `README.md` + `AGENTS.md` + both symlinks resolves to exactly `['plan']`, one asserting `rules/AGENTS.md` still resolves. Full resource-resolution suite:

```
Test Files  5 passed (5)
     Tests  64 passed | 2 skipped (66)
```

`tsc --noEmit` clean.
