### PR TITLE
feat(menubar): single-row ticket filter/sort + scrollable list

### DIFF
--- a/apps/cli/.changelog/next/menubar-ticket-filter-sort.md
+++ b/apps/cli/.changelog/next/menubar-ticket-filter-sort.md
@@ -1,0 +1,10 @@
+- **Quick-dispatch ticket list: one-row filter + sort, and a scrollable list.**
+  The ticket controls sit on a single row of popups next to the Linear project
+  (project · filter · sort) — not a chip matrix or two-column block. Quick filter
+  options: All open, Todo, Doing, Backlog, P1 only, P2 only, Overdue. Quick sort
+  options: Urgent first, Newest, Oldest, Due date, Priority (flat list, no
+  status grouping). Filter and sort picks are remembered across summons. Ticket
+  rows scroll inside a fixed viewport so more than five matches stay reachable
+  without growing the panel. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/LinearTickets.swift`,
+  `apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift`.

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -98,32 +98,44 @@ without dispatching.
 ### The ticket list
 
 The panel captures new work; the rows under it are the work that already exists —
-the open Linear tickets of the repo you picked, so you can pick one up instead of
-filing a duplicate.
+the open Linear tickets of the project scoped to the repo you picked, so you can
+pick one up instead of filing a duplicate.
 
-- **Scope follows the repo.** Switching the repo dropdown switches the Linear
-  project: the repo name is matched against `linear projects` after both are
-  reduced to lowercase alphanumerics, so `agents-cli` finds **Agents CLI** with
-  nothing to configure. A repo whose name matches no project says so instead of
-  listing someone else's tickets — pick the project once from the dropdown and
-  that choice is remembered for that repo. A worktree resolves to its parent repo
+Controls sit on **one compact row** of popups (same language as the repo picker —
+not a chip grid or two-column block):
+
+```
+Tickets  [Agents CLI ▾]  [All open ▾]  [Urgent first ▾]  12/58 · urgent first · ⌘N
+ ⌘1  P1  RUSH-1968  Doing  …
+ ⌘2  …                                    ← scroll when there are more rows
+```
+
+- **Project is 1:1 with Linear.** The project popup is the ticket scope. Switching
+  the repo dropdown auto-selects the matching Linear project (the repo name is
+  matched against `linear projects` after both are reduced to lowercase
+  alphanumerics, so `agents-cli` finds **Agents CLI** with nothing to configure).
+  A repo whose name matches no project says so — pick the project once and that
+  choice is remembered for that repo. A worktree resolves to its parent repo
   (via git's common dir), not to the worktree's own directory name.
-- **Urgent first.** Rows are ranked by Linear priority (`P1` … `P4`, then
-  no-priority), then overdue, then already in progress, then newest — the order
-  answers "what should I pick up next", which is not the order Linear returns.
-  The top five show.
-- **Typing filters the list.** Every word you type has to appear in a row's
-  identifier or title, so an existing ticket surfaces before Return files a new
-  one.
+- **Quick filter (dropdown).** One popup, not chips: All open · Todo · Doing ·
+  Backlog · P1 only · P2 only · Overdue. The last pick is remembered.
+- **Quick sort (dropdown).** Flat list only — no status group headers. Options:
+  Urgent first (default: Linear priority, then overdue, then in progress, then
+  newest) · Newest · Oldest · Due date · Priority. The last pick is remembered.
+- **Scrollable rows.** The list viewport shows about five rows; more matches
+  scroll inside the bar so the capture field stays put. Up to 40 rows are kept
+  after filter+sort.
+- **Typing also filters.** Every word you type has to appear in a row's
+  identifier or title (AND with the filter), so an existing ticket surfaces
+  before Return files a new one.
 - **Click a row to dispatch it** to the selected agents in the picked repo
-  (`⌘1` … `⌘5` do the same from the keyboard). **Plan** posts an implementation
-  plan as a comment on the ticket and changes no code; **Run** claims the ticket
+  (`⌘1` … `⌘9` for the first nine listed). **Plan** posts an implementation plan
+  as a comment on the ticket and changes no code; **Run** claims the ticket
   (moving it to whichever state `linear states` reports as `started`), implements
-  it per the repo's `AGENTS.md`, and comments the result. Both are the same headless `agents run --mode auto --balanced
-  --notify` dispatch as a quick Run, named after the ticket (`rush-2098`,
-  `rush-2098-plan`) so it reads as that ticket in `agents sessions`.
-  **`⌘`-click** opens the ticket in Linear instead, when you want to read it
-  first.
+  it per the repo's `AGENTS.md`, and comments the result. Both are the same
+  headless `agents run --mode auto --balanced --notify` dispatch as a quick Run,
+  named after the ticket (`rush-2098`, `rush-2098-plan`) so it reads as that
+  ticket in `agents sessions`. **`⌘`-click** opens the ticket in Linear instead.
 
 A `linear tasks` round trip costs seconds, so the list renders from a warm cache
 (`~/.agents/.history/menubar/linear-cache.json`) and refreshes in the background;

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -25,6 +25,7 @@ enum IssueSelfTest {
         testLinearProjectResolution()
         testLinearTicketRanking()
         testLinearTicketFilter()
+        testLinearTicketQuickFilterAndSort()
         testLinearCache()
         testTicketDispatchContract()
         if failures == 0 {
@@ -391,6 +392,55 @@ enum IssueSelfTest {
               LinearTickets.filter(tickets, query: "   ").count == 2)
     }
 
+    // Quick filter + sort are single dropdowns (not chip blocks). list() is the
+    // one path the panel uses: filter → text search → sort → cap. Flat list only.
+    private static func testLinearTicketQuickFilterAndSort() {
+        let now = date("2026-08-02T00:00:00Z")
+        let todoP1 = ticket("T-1", title: "todo urgent", priority: 1,
+                            createdAt: "2026-07-01T00:00:00.000Z", stateType: "unstarted")
+        let doingP2 = ticket("T-2", title: "doing mid", priority: 2,
+                             createdAt: "2026-08-01T00:00:00.000Z", stateType: "started")
+        let backlog = ticket("T-3", title: "backlog item", priority: 3,
+                             createdAt: "2026-06-01T00:00:00.000Z",
+                             stateType: "unstarted", stateName: "Backlog")
+        let overdue = ticket("T-4", title: "overdue low", priority: 4,
+                             createdAt: "2026-05-01T00:00:00.000Z",
+                             dueDate: "2026-07-01", stateType: "unstarted")
+        let pool = [todoP1, doingP2, backlog, overdue]
+
+        check("filter Doing keeps only started",
+              LinearTickets.list(pool, filter: .doing, sort: .urgentFirst, now: now)
+                  .map(\.identifier) == ["T-2"])
+        check("filter P1 keeps only priority 1",
+              LinearTickets.list(pool, filter: .p1, sort: .urgentFirst, now: now)
+                  .map(\.identifier) == ["T-1"])
+        check("filter Overdue keeps past due dates",
+              LinearTickets.list(pool, filter: .overdue, sort: .urgentFirst, now: now)
+                  .map(\.identifier) == ["T-4"])
+        check("filter Backlog matches state name",
+              LinearTickets.list(pool, filter: .backlog, sort: .urgentFirst, now: now)
+                  .map(\.identifier) == ["T-3"])
+        check("sort Newest leads with latest createdAt",
+              LinearTickets.list(pool, filter: .all, sort: .newest, now: now)
+                  .map(\.identifier).first == "T-2")
+        check("sort Oldest leads with earliest createdAt",
+              LinearTickets.list(pool, filter: .all, sort: .oldest, now: now)
+                  .map(\.identifier).first == "T-4")
+        check("sort Due puts dated tickets first",
+              LinearTickets.list(pool, filter: .all, sort: .due, now: now)
+                  .map(\.identifier).first == "T-4")
+        check("text query ANDs with the filter",
+              LinearTickets.list(pool, filter: .all, sort: .newest, query: "urgent", now: now)
+                  .map(\.identifier) == ["T-1"])
+        check("list cap truncates a long result",
+              LinearTickets.list(Array(repeating: todoP1, count: 60),
+                                 filter: .all, sort: .newest, now: now,
+                                 cap: 10).count == 10)
+        check("QuickFilter titles are human, not raw keys",
+              LinearTickets.QuickFilter.p1.title == "P1 only"
+                  && LinearTickets.QuickSort.urgentFirst.title == "Urgent first")
+    }
+
     // The cache is what makes the panel appear instantly; a write for one project
     // must not disturb another, and staleness has to be honest.
     private static func testLinearCache() {
@@ -489,12 +539,14 @@ enum IssueSelfTest {
     private static func ticket(_ identifier: String, title: String = "t", priority: Int = 2,
                                createdAt: String? = "2026-07-01T00:00:00.000Z",
                                dueDate: String? = nil,
-                               stateType: String = "unstarted") -> LinearTicket {
-        LinearTicket(identifier: identifier, title: title, priority: priority,
-                     state: LinearTicketState(name: stateType == "started" ? "Doing" : "Todo",
-                                              type: stateType),
-                     url: "https://linear.app/getrush/issue/\(identifier)",
-                     dueDate: dueDate, createdAt: createdAt)
+                               stateType: String = "unstarted",
+                               stateName: String? = nil) -> LinearTicket {
+        let name = stateName
+            ?? (stateType == "started" ? "Doing" : "Todo")
+        return LinearTicket(identifier: identifier, title: title, priority: priority,
+                            state: LinearTicketState(name: name, type: stateType),
+                            url: "https://linear.app/getrush/issue/\(identifier)",
+                            dueDate: dueDate, createdAt: createdAt)
     }
 
     private static func mouseEvent(modifiers: NSEvent.ModifierFlags) -> NSEvent {

--- a/apps/cli/menubar/Sources/MenubarHelper/LinearTickets.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LinearTickets.swift
@@ -10,10 +10,137 @@ import Foundation
 // self-test (IssueSelfTest.swift). The actual fetch lives in AgentsCLI, which
 // shells the `linear` skill CLI the same way the ticket-create path does.
 enum LinearTickets {
-    // How many rows the panel shows, and how long a fetched scope is reused
-    // before the next summon refreshes it in the background.
-    static let displayLimit = 5
+    // How many rows fit in the ticket scroll viewport before the user scrolls.
+    // The list itself can be longer (see `viewportLimit` vs full filtered set).
+    static let viewportRows = 5
+    // Hard cap on rows kept after filter+sort so a huge project never materializes
+    // hundreds of AppKit views; scrolling still covers a useful slice.
+    static let listCap = 40
     static let cacheTTL: TimeInterval = 90
+    // Back-compat name used by older call sites / docs.
+    static let displayLimit = viewportRows
+
+    // MARK: Quick filter (one dropdown) — status / priority / overdue
+
+    // A single popup, not a chip matrix: each option is one predicate over the
+    // open tickets already loaded for the project. Labels are not in the model
+    // yet, so this stays status + priority + overdue.
+    enum QuickFilter: String, CaseIterable {
+        case all
+        case todo
+        case doing
+        case backlog
+        case p1
+        case p2
+        case overdue
+
+        var title: String {
+            switch self {
+            case .all: return "All open"
+            case .todo: return "Todo"
+            case .doing: return "Doing"
+            case .backlog: return "Backlog"
+            case .p1: return "P1 only"
+            case .p2: return "P2 only"
+            case .overdue: return "Overdue"
+            }
+        }
+
+        func matches(_ ticket: LinearTicket, now: Date = Date()) -> Bool {
+            switch self {
+            case .all:
+                return true
+            case .todo:
+                // Linear "unstarted" with a Todo-like name, or plain unstarted.
+                let t = ticket.state?.type ?? ""
+                let n = ticket.stateName.lowercased()
+                return t == "unstarted" && !n.contains("backlog")
+            case .doing:
+                return ticket.isStarted
+            case .backlog:
+                return ticket.stateName.lowercased().contains("backlog")
+                    || (ticket.state?.type == "backlog")
+            case .p1:
+                return ticket.priority == 1
+            case .p2:
+                return ticket.priority == 2
+            case .overdue:
+                return isOverdue(ticket, now: now)
+            }
+        }
+    }
+
+    // MARK: Quick sort (one dropdown) — flat list, no grouping
+
+    enum QuickSort: String, CaseIterable {
+        case urgentFirst
+        case newest
+        case oldest
+        case due
+        case priority
+
+        var title: String {
+            switch self {
+            case .urgentFirst: return "Urgent first"
+            case .newest: return "Newest"
+            case .oldest: return "Oldest"
+            case .due: return "Due date"
+            case .priority: return "Priority"
+            }
+        }
+    }
+
+    /// Apply the quick filter, then the chosen sort. No status-group headers —
+    /// one flat list. `query` is the capture field's text search (AND).
+    static func list(_ tickets: [LinearTicket],
+                     filter: QuickFilter = .all,
+                     sort: QuickSort = .urgentFirst,
+                     query: String = "",
+                     now: Date = Date(),
+                     cap: Int = listCap) -> [LinearTicket] {
+        let filtered = tickets.filter { filter.matches($0, now: now) }
+        let searched = Self.filter(filtered, query: query)
+        let ordered = applySort(searched, sort: sort, now: now)
+        return Array(ordered.prefix(cap))
+    }
+
+    static func applySort(_ tickets: [LinearTicket],
+                          sort: QuickSort,
+                          now: Date = Date()) -> [LinearTicket] {
+        switch sort {
+        case .urgentFirst:
+            return rank(tickets, now: now)
+        case .newest:
+            return tickets.sorted { a, b in
+                let (ca, cb) = (a.createdAt ?? "", b.createdAt ?? "")
+                if ca != cb { return ca > cb }
+                return a.identifier < b.identifier
+            }
+        case .oldest:
+            return tickets.sorted { a, b in
+                let (ca, cb) = (a.createdAt ?? "", b.createdAt ?? "")
+                if ca != cb { return ca < cb }
+                return a.identifier < b.identifier
+            }
+        case .due:
+            // Soonest due first; undated sink to the end; overdue still compare by date.
+            return tickets.sorted { a, b in
+                let (da, db) = (a.dueDate ?? "", b.dueDate ?? "")
+                switch (da.isEmpty, db.isEmpty) {
+                case (false, false) where da != db: return da < db
+                case (false, true): return true
+                case (true, false): return false
+                default: return a.identifier < b.identifier
+                }
+            }
+        case .priority:
+            return tickets.sorted { a, b in
+                let (pa, pb) = (priorityOrder(a.priority), priorityOrder(b.priority))
+                if pa != pb { return pa < pb }
+                return a.identifier < b.identifier
+            }
+        }
+    }
 
     // MARK: Repo -> Linear project
 

--- a/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/PromptPanel.swift
@@ -245,12 +245,16 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
     // A screenshot older than this isn't pre-selected — but it still shows in the
     // strip for manual attach, since the user can see exactly what they're picking.
     private static let recentClipWindow: TimeInterval = 10 * 60
-    private static let panelWidth: CGFloat = 640
+    private static let panelWidth: CGFloat = 680
     // Panel height is additive: the capture half is fixed, and the screenshot strip
     // and the ticket list each add their own block when they have content.
     private static let baseHeight: CGFloat = 156
     private static let thumbStripHeight: CGFloat = 92
-    private static let ticketSectionChrome: CGFloat = 36   // header row + stack spacing
+    private static let ticketSectionChrome: CGFloat = 36   // one control row + spacing
+    // Fixed viewport for the ticket list — rows scroll inside; panel height does not
+    // grow with every ticket (keeps the capture field pinned).
+    private static let ticketViewportHeight: CGFloat =
+        CGFloat(LinearTickets.viewportRows) * TicketRowView.height
 
     private var panel: PromptPanel?
     private let field = NSTextField()
@@ -266,21 +270,28 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
     private let repoPicker = NSPopUpButton(frame: .zero, pullsDown: false)
     private var repoDirs: [String] = []
     private static let lastRepoKey = "menubar.quickDispatch.lastRepo"
-    // Ticket half: the picked repo's Linear project, its open tickets ranked
-    // urgent-first, and the rows currently shown (the ranked list narrowed by
-    // whatever has been typed).
+    // Ticket half: one compact row of popups (project · filter · sort) — no chip
+    // matrices or two-column blocks — then a scrollable flat list.
     private let projectPicker = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let filterPicker = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let sortPicker = NSPopUpButton(frame: .zero, pullsDown: false)
     private let ticketStatus = NSTextField(labelWithString: "")
     private let ticketList = NSStackView()
+    private let ticketScroll = NSScrollView()
     private var linearCache = LinearTickets.Cache()
     private var activeProject: LinearProject?
     private var visibleTickets: [LinearTicket] = []
+    private var ticketFilter: LinearTickets.QuickFilter = .all
+    private var ticketSort: LinearTickets.QuickSort = .urgentFirst
     // Bumped on every scope change so a slow `linear tasks` answering after the
     // user switched repo/project is dropped instead of overwriting the new list.
     private var ticketFetchToken = 0
     private var repoNamesByDir: [String: String] = [:]
     private var rebuildingProjectPicker = false
+    private var rebuildingFilterPickers = false
     private static let projectOverrideKeyPrefix = "menubar.quickDispatch.project."
+    private static let lastFilterKey = "menubar.quickDispatch.ticketFilter"
+    private static let lastSortKey = "menubar.quickDispatch.ticketSort"
     private var selected: [String] = []   // newest-first order preserved
     private var selectedAgents = Set<String>()
     private var roster: [MenuAgent] = []
@@ -315,6 +326,7 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         // Tickets render from the warm cache first (a `linear tasks` round trip
         // costs seconds), then refresh in the background.
         linearCache = LinearTickets.loadCache()
+        restoreTicketControls()
         refreshTicketScope()
 
         thumbStrip.isHidden = thumbStrip.arrangedSubviews.isEmpty
@@ -562,6 +574,70 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         refreshTicketScope()
     }
 
+    @objc private func onFilterChanged(_ sender: NSPopUpButton) {
+        guard !rebuildingFilterPickers else { return }
+        let idx = sender.indexOfSelectedItem
+        let all = LinearTickets.QuickFilter.allCases
+        guard idx >= 0, idx < all.count else { return }
+        ticketFilter = all[idx]
+        UserDefaults.standard.set(ticketFilter.rawValue, forKey: Self.lastFilterKey)
+        reapplyTicketList()
+    }
+
+    @objc private func onSortChanged(_ sender: NSPopUpButton) {
+        guard !rebuildingFilterPickers else { return }
+        let idx = sender.indexOfSelectedItem
+        let all = LinearTickets.QuickSort.allCases
+        guard idx >= 0, idx < all.count else { return }
+        ticketSort = all[idx]
+        UserDefaults.standard.set(ticketSort.rawValue, forKey: Self.lastSortKey)
+        reapplyTicketList()
+    }
+
+    private func restoreTicketControls() {
+        if let raw = UserDefaults.standard.string(forKey: Self.lastFilterKey),
+           let f = LinearTickets.QuickFilter(rawValue: raw) {
+            ticketFilter = f
+        }
+        if let raw = UserDefaults.standard.string(forKey: Self.lastSortKey),
+           let s = LinearTickets.QuickSort(rawValue: raw) {
+            ticketSort = s
+        }
+        rebuildFilterAndSortPickers()
+    }
+
+    private func rebuildFilterAndSortPickers() {
+        rebuildingFilterPickers = true
+        defer { rebuildingFilterPickers = false }
+
+        filterPicker.removeAllItems()
+        for f in LinearTickets.QuickFilter.allCases {
+            filterPicker.addItem(withTitle: f.title)
+        }
+        if let idx = LinearTickets.QuickFilter.allCases.firstIndex(of: ticketFilter) {
+            filterPicker.selectItem(at: idx)
+        }
+
+        sortPicker.removeAllItems()
+        for s in LinearTickets.QuickSort.allCases {
+            sortPicker.addItem(withTitle: s.title)
+        }
+        if let idx = LinearTickets.QuickSort.allCases.firstIndex(of: ticketSort) {
+            sortPicker.selectItem(at: idx)
+        }
+    }
+
+    /// Re-run filter+sort on the cached tickets for the active project (no fetch).
+    private func reapplyTicketList() {
+        guard let project = activeProject,
+              let tickets = linearCache.scopes[project.name]?.tickets else {
+            updateHint()
+            return
+        }
+        visibleTickets = rankedAndFiltered(tickets)
+        renderTickets()
+    }
+
     // Point the ticket list at the project behind the picked repo: rebuild the
     // project popup, render whatever is cached, and fetch when the cache is stale.
     private func refreshTicketScope() {
@@ -626,12 +702,14 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         }
     }
 
-    // Urgent first, then narrowed by whatever the user has typed — so typing a few
-    // words shows the tickets that already cover it before Return files a new one.
+    // Quick filter + sort, then the typed note as a text search — so an existing
+    // ticket surfaces before Return files a duplicate. Flat list only (no groups).
     private func rankedAndFiltered(_ tickets: [LinearTicket]) -> [LinearTicket] {
         let query = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        let matched = LinearTickets.filter(LinearTickets.rank(tickets), query: query)
-        return Array(matched.prefix(LinearTickets.displayLimit))
+        return LinearTickets.list(tickets,
+                                  filter: ticketFilter,
+                                  sort: ticketSort,
+                                  query: query)
     }
 
     private func renderTickets(status: String? = nil) {
@@ -646,8 +724,14 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
             ticketList.addArrangedSubview(row)
             row.widthAnchor.constraint(equalTo: ticketList.widthAnchor).isActive = true
         }
-        ticketList.isHidden = visibleTickets.isEmpty
+        let empty = visibleTickets.isEmpty
+        ticketScroll.isHidden = empty
         ticketStatus.stringValue = status ?? ticketCountText()
+        // Document height grows with rows; the scroll viewport stays fixed so the
+        // user can scroll through the full filtered set.
+        let width = max(ticketScroll.contentSize.width, Self.panelWidth - 44)
+        let contentH = max(CGFloat(visibleTickets.count) * TicketRowView.height, 1)
+        ticketList.frame = NSRect(x: 0, y: 0, width: width, height: contentH)
         applyContentHeight()
         updateHint()
     }
@@ -656,8 +740,15 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         guard let project = activeProject else { return "" }
         let total = linearCache.scopes[project.name]?.tickets.count ?? 0
         if total == 0 { return "no open tickets" }
-        if visibleTickets.isEmpty { return "\(total) open · none match what you typed" }
-        return "\(total) open · urgent first · click or \u{2318}N dispatches"
+        if visibleTickets.isEmpty {
+            return "\(total) open · none match filter"
+        }
+        let shown = visibleTickets.count
+        let sortBit = ticketSort == .urgentFirst ? "urgent first" : ticketSort.title.lowercased()
+        if shown < total || ticketFilter != .all {
+            return "\(shown)/\(total) · \(sortBit) · \u{2318}N"
+        }
+        return "\(total) open · \(sortBit) · click or \u{2318}N"
     }
 
     private func rebuildProjectPicker() {
@@ -797,13 +888,16 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         renderTickets()
     }
 
-    // Height is additive over the fixed capture half; the panel grows downward from
-    // a fixed top edge while it is on screen, so a list that fills in after an async
-    // fetch doesn't shift the text field out from under the cursor.
+    // Height is additive over the fixed capture half; the ticket viewport is a
+    // fixed-height scroll area so many open tickets do not push the panel taller.
+    // Grows downward from a fixed top edge so an async fill does not shift the
+    // text field out from under the cursor.
     private func applyContentHeight() {
         guard let panel else { return }
         var height = Self.baseHeight + Self.ticketSectionChrome
-            + CGFloat(visibleTickets.count) * TicketRowView.height
+        if !ticketScroll.isHidden {
+            height += Self.ticketViewportHeight
+        }
         if !thumbStrip.isHidden { height += Self.thumbStripHeight }
         guard abs(panel.frame.height - height) > 0.5 else { return }
         let top = panel.frame.maxY
@@ -888,6 +982,19 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         projectPicker.target = self
         projectPicker.action = #selector(onProjectChanged(_:))
 
+        // Same control size as the project popup — one compact row of dropdowns,
+        // not a two-column chip matrix.
+        for picker in [filterPicker, sortPicker] {
+            picker.translatesAutoresizingMaskIntoConstraints = false
+            picker.controlSize = .small
+            picker.font = .systemFont(ofSize: 12)
+        }
+        filterPicker.target = self
+        filterPicker.action = #selector(onFilterChanged(_:))
+        sortPicker.target = self
+        sortPicker.action = #selector(onSortChanged(_:))
+        rebuildFilterAndSortPickers()
+
         ticketStatus.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
         ticketStatus.textColor = .tertiaryLabelColor
         ticketStatus.lineBreakMode = .byTruncatingTail
@@ -896,24 +1003,43 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         ticketList.orientation = .vertical
         ticketList.alignment = .leading
         ticketList.spacing = 0
+        ticketList.translatesAutoresizingMaskIntoConstraints = false
+
+        // Scrollable ticket body: fixed viewport, document grows with rows.
+        // Document view uses flipped coordinate + explicit width so rows stay
+        // full-width as the user scrolls (stack-as-document without a flip view
+        // pins from the bottom and clips the first rows).
+        ticketScroll.drawsBackground = false
+        ticketScroll.hasVerticalScroller = true
+        ticketScroll.hasHorizontalScroller = false
+        ticketScroll.autohidesScrollers = true
+        ticketScroll.borderType = .noBorder
+        ticketScroll.scrollerStyle = .overlay
+        ticketScroll.translatesAutoresizingMaskIntoConstraints = false
+        let clip = FlippedClipView()
+        clip.drawsBackground = false
+        ticketScroll.contentView = clip
+        ticketScroll.documentView = ticketList
+        clip.postsBoundsChangedNotifications = true
 
         let controlRow = NSStackView(views: [modeControl, repoPicker])
         controlRow.orientation = .horizontal
         controlRow.alignment = .centerY
         controlRow.spacing = 12
 
-        // The ticket header names the scope (project popup) and its state; the rows
-        // below it are the open tickets of that project.
+        // One row: project (1:1 Linear scope) · quick filter · quick sort · count.
+        // No block cards — same popup language as the repo picker above.
         let ticketTitle = NSTextField(labelWithString: "Tickets")
         ticketTitle.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
         ticketTitle.textColor = .secondaryLabelColor
-        let ticketHeader = NSStackView(views: [ticketTitle, projectPicker, ticketStatus])
+        let ticketHeader = NSStackView(views: [ticketTitle, projectPicker, filterPicker,
+                                               sortPicker, ticketStatus])
         ticketHeader.orientation = .horizontal
         ticketHeader.alignment = .centerY
         ticketHeader.spacing = 8
 
         let stack = NSStackView(views: [field, controlRow, agentStrip, thumbStrip,
-                                        ticketHeader, ticketList, hint])
+                                        ticketHeader, ticketScroll, hint])
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 10
@@ -925,12 +1051,14 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
             stack.centerYAnchor.constraint(equalTo: bg.centerYAnchor),
             field.widthAnchor.constraint(equalTo: stack.widthAnchor),
             modeControl.widthAnchor.constraint(equalToConstant: 180),
-            ticketList.widthAnchor.constraint(equalTo: stack.widthAnchor),
-            // The panel is a fixed-width bar: cap the two popups so a long repo
-            // path or project name truncates inside them instead of stretching the
-            // window past panelWidth.
-            repoPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 220),
-            projectPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 190),
+            ticketScroll.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            ticketScroll.heightAnchor.constraint(equalToConstant: Self.ticketViewportHeight),
+            // The panel is a fixed-width bar: cap the popups so long names truncate
+            // inside them instead of stretching the window past panelWidth.
+            repoPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 200),
+            projectPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 160),
+            filterPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 110),
+            sortPicker.widthAnchor.constraint(lessThanOrEqualToConstant: 120),
         ])
         return panel
     }
@@ -944,6 +1072,12 @@ final class PromptPanelController: NSObject, NSTextFieldDelegate {
         let y = vf.minY + (vf.height - size.height) / 2 + vf.height * 0.20
         panel.setFrameOrigin(NSPoint(x: x, y: y))
     }
+}
+
+// Top-left origin for the ticket list document view so row 0 is at the top of
+// the scroll view (AppKit's default NSClipView is bottom-left).
+private final class FlippedClipView: NSClipView {
+    override var isFlipped: Bool { true }
 }
 
 // Local notifications for the ticket flow. NSUserNotification is deprecated but


### PR DESCRIPTION
**Feature** — quick-dispatch ticket controls are one compact popup row (project · filter · sort), with a scrollable ticket list.

## What changed

| Control | Behavior |
|---|---|
| **Project** | Still 1:1 with Linear; driven by repo match + remembered override |
| **Filter** | Dropdown: All open · Todo · Doing · Backlog · P1 only · P2 only · Overdue (remembered) |
| **Sort** | Dropdown: Urgent first · Newest · Oldest · Due date · Priority — flat list, no group headers (remembered) |
| **Rows** | Fixed ~5-row viewport; scroll for more (cap 40 after filter+sort) |

No chip matrix / two-column blocks — same popup language as the repo picker.

## Verification

Self-test (`MENUBAR_ISSUE_TEST=1 MenubarHelper` on zion against this tree): ALL PASS including new filter/sort cases.

Build: `swift build` clean on zion.

Mock (layout intent): https://share.agents-cli.sh/muqsitnawaz/menubar-dispatch-v4-row

no-surface — menubar helper UI; run evidence is the self-test (macOS-only binary).
