### PR TITLE
chore(factory): cut the 0.9.305 changelog section

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.305] - 2026-08-03
+
 - **Session resume was broken everywhere, and `Agents: Resume` now batch-reopens
   crashed sessions.** Every session picker in the extension shelled out to
   `agents sessions list --all --json`; `sessions` has no `list` subcommand, so


### PR DESCRIPTION
**Release prep — docs-only, no behavior change.** Audience: maintainers.

`apps/factory/scripts/release.sh` refuses to publish without a `## [<version>]` heading for the target version:

```
$ bash scripts/release.sh 0.9.305
Error: no CHANGELOG.md entry for 0.9.305.
       Add a '## [0.9.305] - <date>' section before releasing.
```

This adds that heading, promoting the three merged-but-unreleased entries out of `[Unreleased]` and under `0.9.305`:

| Entry | From |
|---|---|
| Status bar showed a wrong version/account and no session id under Remote-SSH | earlier merge |
| `…/spawn` URI tabs now honour `agents.terminalMode` | PR #1734 |
| Session resume un-broken + `Agents: Resume` batch picker | PR #1743 |

No code touched — the diff is two lines in `apps/factory/CHANGELOG.md`. Release-prep PR, so no run result to attach.