### PR TITLE
fix(cli): balanced routing refuses to decide on stale usage data

### DIFF
--- a/apps/cli/.changelog/next/rotation-refuses-stale-usage.md
+++ b/apps/cli/.changelog/next/rotation-refuses-stale-usage.md
@@ -1,0 +1,19 @@
+- **Balanced routing no longer launches into an account it only *thinks* has
+  headroom.** Account usage is cached per machine under stale-while-revalidate:
+  a snapshot up to 24h old was served instantly, and the background refresh that
+  should have corrected it lands after the pick is already made. On a box whose
+  refresh is failing that state is permanent — measured on `yosemite-s1`, every
+  Claude snapshot sat 26 hours to 2.7 days old, so balanced read
+  `muqsit@getrush.ai` as 48% used and launched into it while the account was at
+  its weekly cap; the session answered "You've hit your weekly limit" on its
+  first turn. Routing now caps how stale a snapshot may be when it is about to
+  decide (5 minutes), blocking on one bounded, parallel live read past that — and
+  no read at all inside the existing 2-minute fresh window, which back-to-back
+  launches hit. Display paths (`agents view`) keep the full 24h window and stay
+  off the network.
+- **A pick made on unconfirmed data says so.** When no account on the machine
+  could be refreshed, routing still launches — a broken refresh must not make a
+  box unusable — but the banner now reads `… (2 of 5 healthy, usage unverified —
+  no account could be refreshed)` instead of presenting a guess as a fact. An
+  account with a verified snapshot always wins over one with a stale snapshot,
+  even when the stale number looks emptier.

--- a/apps/cli/.changelog/next/rotation-refuses-stale-usage.md
+++ b/apps/cli/.changelog/next/rotation-refuses-stale-usage.md
@@ -16,4 +16,13 @@
   box unusable — but the banner now reads `… (2 of 5 healthy, usage unverified —
   no account could be refreshed)` instead of presenting a guess as a fact. An
   account with a verified snapshot always wins over one with a stale snapshot,
-  even when the stale number looks emptier.
+  even when the stale number looks emptier. This applies to `--strategy
+  available` as well as `balanced` — both route on the same cache, and
+  `available`'s headroom sort was inverted by a stale number in exactly the same
+  way. An explicit version preference is an instruction, not a ranking signal, so
+  it still wins.
+- **The mid-run failover chain is unchanged.** Declining to *pick* an account on
+  unconfirmed data and declining to *fail over to* it after the primary already
+  hit a 429 are different risks — by then the alternative is not launching at
+  all. Every eligible account stays in the failover chain; only the initial pick
+  prefers verified ones.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -878,7 +878,17 @@ a stable per-account key:
 - **Usage bars** — a separate network pass ([`src/lib/usage.ts`](../src/lib/usage.ts))
   fetches live quota and renders `S:`/`W:` bars + plan. It's **stale-while-revalidate**
   (on-disk cache under `~/.agents/.cache/`, keyed per account: 2-min fresh, 24-h
-  block) so `agents view` / `agents run` stay off the network on the hot path.
+  block) so `agents view` stays off the network on the hot path.
+- **Routing reads the same cache under a tighter rule.** Displaying a slightly old
+  bar costs nothing; *choosing an account* from one costs the whole run, so the
+  balanced router caps staleness at **5 minutes**
+  (`USAGE_DECISION_MAX_AGE_MS`, [`src/lib/rotate.ts`](../src/lib/rotate.ts)) and
+  blocks on a live read past that — one bounded, parallel round trip per account,
+  and none inside the 2-minute fresh window. When a read fails and the cache is
+  all it has, the router prefers any account whose snapshot IS verified, and
+  reports `usage unverified` in the launch banner rather than presenting a stale
+  number as a fact. The cache is strictly per machine and never synced, so a box
+  whose refresh is failing would otherwise route on day-old numbers indefinitely.
 
 What each agent can surface is bounded by what its local credential actually
 contains — this is a data-availability limit, not a policy choice:

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -149,7 +149,13 @@ function formatRotationBanner(result: RotateResult, verb: string = 'balanced'): 
   const { picked, healthy, excluded } = result;
   const label = picked.email ? `${picked.email} · ${picked.agent}@${picked.version}` : `${picked.agent}@${picked.version}`;
   const ratio = `${healthy.length} of ${healthy.length + excluded.length} healthy`;
-  return `[agents] ${verb} picked ${label} (${ratio})`;
+  // Say it when the pick was a guess. A machine whose usage refresh is failing
+  // reports old percentages with total confidence, so a silent banner reads
+  // identical whether the router knew the account had headroom or merely hoped
+  // so — and the operator only finds out when the agent answers "you've hit
+  // your weekly limit".
+  const caveat = result.usageUnverified ? ', usage unverified — no account could be refreshed' : '';
+  return `[agents] ${verb} picked ${label} (${ratio}${caveat})`;
 }
 
 /** The host descriptor fields the `--copy-creds` security gate reads. */

--- a/apps/cli/src/lib/rotate.test.ts
+++ b/apps/cli/src/lib/rotate.test.ts
@@ -9,6 +9,7 @@ import {
   pickBalancedCandidate,
   readinessFromCandidate,
   matchAccountVersion,
+  isUsageVerified,
   type RotateCandidate,
   type RotateResult,
   type FailoverArmingContext,
@@ -370,5 +371,70 @@ describe('readinessFromCandidate (pre-flight warning for version-pinned teammate
     expect(
       readinessFromCandidate(candidate({ version: '1.0.0', signedIn: false })),
     ).toEqual({ ready: false, reason: 'signed_out', email: '1.0.0@example.com' });
+  });
+});
+
+/** A snapshot stamped with a real capture time, for the freshness gate. */
+function snapshotAt(
+  capturedAt: Date,
+  windows: Array<{ key: UsageWindowKey; usedPercent: number }>,
+): UsageSnapshot {
+  return { ...snapshot(windows), capturedAt };
+}
+
+describe('routing refuses to decide on usage it cannot verify', () => {
+  // The real incident: yosemite-s1's usage cache sat 26h–2.7d old with a
+  // failing refresh, so balanced read muqsit@getrush.ai as 48% used and
+  // launched into it. The account was actually at its weekly cap and the
+  // session answered "You've hit your weekly limit" on its first turn.
+  const NOW = Date.UTC(2026, 7, 3, 6, 57);
+  const fresh = (usedPercent: number) =>
+    snapshotAt(new Date(NOW - 60_000), [{ key: 'week', usedPercent }]);
+  const dayOld = (usedPercent: number) =>
+    snapshotAt(new Date(NOW - 26 * 3600 * 1000), [{ key: 'week', usedPercent }]);
+
+  it('never picks a day-old candidate while a verified one exists — even when the stale one looks emptier', () => {
+    const stale = candidate({ version: '2.1.181', usageSnapshot: dayOld(48) });
+    const verified = candidate({ version: '2.1.219', usageSnapshot: fresh(90) });
+
+    const result = pickBalancedCandidate([stale, verified], NOW)!;
+
+    // 48% "used" would outweigh 90% under pure capacity weighting; unverified
+    // loses to verified regardless, because the 48% is not evidence.
+    expect(result.picked.version).toBe('2.1.219');
+    expect(result.healthy.map((c) => c.version)).toEqual(['2.1.219']);
+    expect(result.excluded.map((c) => c.version)).toContain('2.1.181');
+    expect(result.usageUnverified).toBe(false);
+  });
+
+  it('still launches when NOTHING can be verified, and says the pick was unverified', () => {
+    // A box with a broken refresh must not become unlaunchable — but the
+    // operator has to learn the route was blind, not silently inherit it.
+    const a = candidate({ version: '2.1.181', usageSnapshot: dayOld(48) });
+    const b = candidate({ version: '2.1.207', usageSnapshot: dayOld(70) });
+
+    const result = pickBalancedCandidate([a, b], NOW)!;
+
+    expect(result.usageUnverified).toBe(true);
+    expect(result.healthy.length).toBe(2);
+    expect(['2.1.181', '2.1.207']).toContain(result.picked.version);
+  });
+
+  it('a verified rate-limited account is still excluded outright, not merely deprioritized', () => {
+    const limited = candidate({ version: '2.1.170', usageSnapshot: fresh(100) });
+    const ok = candidate({ version: '2.1.219', usageSnapshot: fresh(20) });
+
+    const result = pickBalancedCandidate([limited, ok], NOW)!;
+
+    expect(result.picked.version).toBe('2.1.219');
+    expect(result.excluded.map((c) => c.version)).toContain('2.1.170');
+  });
+
+  it('isUsageVerified: a snapshot with no capture time is unverified, not assumed current', () => {
+    expect(isUsageVerified(candidate({ version: '1.0.0', usageSnapshot: fresh(10) }), NOW)).toBe(true);
+    expect(isUsageVerified(candidate({ version: '1.0.0', usageSnapshot: dayOld(10) }), NOW)).toBe(false);
+    // snapshot() leaves capturedAt null — an undated number proves nothing.
+    expect(isUsageVerified(candidate({ version: '1.0.0', usageSnapshot: snapshot([{ key: 'week', usedPercent: 10 }]) }), NOW)).toBe(false);
+    expect(isUsageVerified(candidate({ version: '1.0.0' }), NOW)).toBe(false);
   });
 });

--- a/apps/cli/src/lib/rotate.test.ts
+++ b/apps/cli/src/lib/rotate.test.ts
@@ -7,6 +7,7 @@ import {
   shouldArmRotationFailover,
   DEFAULT_ROTATION_FAILOVER_LIMIT,
   pickBalancedCandidate,
+  pickAvailableCandidate,
   readinessFromCandidate,
   matchAccountVersion,
   isUsageVerified,
@@ -402,9 +403,12 @@ describe('routing refuses to decide on usage it cannot verify', () => {
     // 48% "used" would outweigh 90% under pure capacity weighting; unverified
     // loses to verified regardless, because the 48% is not evidence.
     expect(result.picked.version).toBe('2.1.219');
-    expect(result.healthy.map((c) => c.version)).toEqual(['2.1.219']);
-    expect(result.excluded.map((c) => c.version)).toContain('2.1.181');
     expect(result.usageUnverified).toBe(false);
+    // ...but the stale account stays in `healthy`, because that array also feeds
+    // rotationFailoverChain. Refusing to PICK it is not the same call as refusing
+    // to fail over to it once the primary has already hit a 429.
+    expect(result.healthy.map((c) => c.version).sort()).toEqual(['2.1.181', '2.1.219']);
+    expect(result.excluded.map((c) => c.version)).not.toContain('2.1.181');
   });
 
   it('still launches when NOTHING can be verified, and says the pick was unverified', () => {
@@ -436,5 +440,46 @@ describe('routing refuses to decide on usage it cannot verify', () => {
     // snapshot() leaves capturedAt null — an undated number proves nothing.
     expect(isUsageVerified(candidate({ version: '1.0.0', usageSnapshot: snapshot([{ key: 'week', usedPercent: 10 }]) }), NOW)).toBe(false);
     expect(isUsageVerified(candidate({ version: '1.0.0' }), NOW)).toBe(false);
+  });
+});
+
+describe('--strategy available applies the same freshness rule as balanced', () => {
+  // The reviewer's catch: collectRunCandidates caps staleness for EVERY caller,
+  // so `available` paid the new live-fetch cost while keeping the exact bug —
+  // it sorts by apparent headroom and takes the front, so an unconfirmed "48%
+  // used" outranked an accurate "90% used" just as it did under balanced.
+  const NOW = Date.UTC(2026, 7, 3, 6, 57);
+  const fresh = (usedPercent: number) =>
+    snapshotAt(new Date(NOW - 60_000), [{ key: 'week', usedPercent }]);
+  const dayOld = (usedPercent: number) =>
+    snapshotAt(new Date(NOW - 26 * 3600 * 1000), [{ key: 'week', usedPercent }]);
+
+  it('does not route to the emptier-looking stale account over a verified one', () => {
+    const stale = candidate({ version: '2.1.181', usageSnapshot: dayOld(48) });
+    const verified = candidate({ version: '2.1.219', usageSnapshot: fresh(90) });
+
+    const result = pickAvailableCandidate([stale, verified], null, NOW)!;
+
+    expect(result.picked.version).toBe('2.1.219');
+    expect(result.usageUnverified).toBe(false);
+  });
+
+  it('flags the pick when nothing could be verified, and still launches', () => {
+    const a = candidate({ version: '2.1.181', usageSnapshot: dayOld(48) });
+    const b = candidate({ version: '2.1.207', usageSnapshot: dayOld(70) });
+
+    const result = pickAvailableCandidate([a, b], null, NOW)!;
+
+    expect(result.usageUnverified).toBe(true);
+    expect(result.picked.version).toBe('2.1.181'); // still the headroom sort
+  });
+
+  it('an explicit version preference is an instruction and still wins', () => {
+    const stale = candidate({ version: '2.1.181', usageSnapshot: dayOld(48) });
+    const verified = candidate({ version: '2.1.219', usageSnapshot: fresh(90) });
+
+    const result = pickAvailableCandidate([stale, verified], '2.1.181', NOW)!;
+
+    expect(result.picked.version).toBe('2.1.181');
   });
 });

--- a/apps/cli/src/lib/rotate.ts
+++ b/apps/cli/src/lib/rotate.ts
@@ -304,27 +304,42 @@ export function pickBalancedCandidate(
 
   if (healthy.length === 0) return null;
 
-  // An eligible account whose usage we could not confirm is a guess, not a
-  // green light: the snapshot says "48% used" with equal confidence whether it
-  // was read a minute or three days ago, and a box whose refresh is failing
-  // stays wrong indefinitely. So route to a VERIFIED account whenever one
-  // exists, and fall back to the unverified pool only when nothing on this
-  // machine could be confirmed — a launch that still happens, but says so.
-  const verified = healthy.filter((c) => isUsageVerified(c, nowMs));
-  const pool = verified.length > 0 ? verified : healthy;
-  const usageUnverified = verified.length === 0;
-  for (const c of healthy) {
-    if (!pool.includes(c)) excluded.push(c);
-  }
-
-  const sorted = dedupeAndSortCandidates(pool);
+  const sorted = dedupeAndSortCandidates(healthy);
   const deduped = new Set(sorted);
-  for (const c of pool) {
+  for (const c of healthy) {
     if (!deduped.has(c)) excluded.push(c);
   }
 
-  const picked = weightedRandomByCapacity(sorted);
+  const { picked, usageUnverified } = preferVerified(sorted, nowMs, weightedRandomByCapacity);
   return { picked, healthy: sorted, excluded, usageUnverified };
+}
+
+/**
+ * Choose from the VERIFIED candidates when any exist, else from the whole pool.
+ *
+ * An eligible account whose usage we could not confirm is a guess, not a green
+ * light: the snapshot reads "48% used" with equal confidence whether it was
+ * captured a minute or three days ago, and a box whose refresh is failing stays
+ * wrong indefinitely. Confirmed headroom therefore beats apparent headroom, even
+ * when the unconfirmed number looks better.
+ *
+ * `healthy` deliberately keeps every eligible candidate rather than just the
+ * verified ones. Declining to *pick* an account on stale data and declining to
+ * *fail over to* it after the primary has already hit a 429 are different risks:
+ * by then the alternative is not launching at all, so the failover chain
+ * (rotationFailoverChain, which reads `healthy`) keeps its full safety net —
+ * exactly on the machines this guard is protecting.
+ */
+function preferVerified(
+  pool: RotateCandidate[],
+  nowMs: number,
+  choose: (from: RotateCandidate[]) => RotateCandidate,
+): { picked: RotateCandidate; usageUnverified: boolean } {
+  const verified = pool.filter((c) => isUsageVerified(c, nowMs));
+  return {
+    picked: choose(verified.length > 0 ? verified : pool),
+    usageUnverified: verified.length === 0,
+  };
 }
 
 /**
@@ -358,6 +373,7 @@ function weightedRandomByCapacity(sorted: RotateCandidate[]): RotateCandidate {
 export function pickAvailableCandidate(
   candidates: RotateCandidate[],
   preferredVersion?: string | null,
+  nowMs: number = Date.now(),
 ): RotateResult | null {
   const healthy: RotateCandidate[] = [];
   const excluded: RotateCandidate[] = [];
@@ -377,10 +393,17 @@ export function pickAvailableCandidate(
     if (!deduped.has(c)) excluded.push(c);
   }
 
+  // `available` sorts by apparent headroom and takes the front of the list, so an
+  // unconfirmed "48% used" outranks an accurate "90% used" — the same inversion
+  // that put a launch on an exhausted account under `balanced`. It routes on the
+  // same cache, so it gets the same rule: confirmed headroom first.
+  const { picked: bestVerified, usageUnverified } = preferVerified(sorted, nowMs, (from) => from[0]);
+  // An explicit version preference is an instruction, not a ranking signal, so it
+  // still wins — but only while that version is actually eligible.
   const preferred = preferredVersion
     ? sorted.find((candidate) => candidate.version === preferredVersion)
     : undefined;
-  return { picked: preferred ?? sorted[0], healthy: sorted, excluded };
+  return { picked: preferred ?? bestVerified, healthy: sorted, excluded, usageUnverified };
 }
 
 export async function collectRunCandidates(agent: AgentId): Promise<RotateCandidate[]> {

--- a/apps/cli/src/lib/rotate.ts
+++ b/apps/cli/src/lib/rotate.ts
@@ -55,6 +55,12 @@ export interface RotateResult {
   healthy: RotateCandidate[];
   /** Candidates excluded (not signed in, or out of credits). */
   excluded: RotateCandidate[];
+  /**
+   * True when NO candidate on this machine had usage data fresh enough to decide
+   * on, so the pick was made from unverified snapshots. Callers surface it —
+   * routing blind is a fact the operator needs, not an internal detail.
+   */
+  usageUnverified?: boolean;
 }
 
 export const RUN_STRATEGIES: RunStrategy[] = ['pinned', 'available', 'balanced'];
@@ -112,6 +118,28 @@ function isRotationEligible(candidate: RotateCandidate): boolean {
 
 function isAvailableEligible(candidate: RotateCandidate): boolean {
   return isRotationEligible(candidate);
+}
+
+/**
+ * How old a usage snapshot may be and still settle a routing DECISION.
+ *
+ * Deliberately far tighter than the 24h stale-while-revalidate window the
+ * display paths use (`USAGE_CACHE_SWR_MS`): `agents view` rendering a slightly
+ * old bar costs nothing, but the router choosing an account from one costs the
+ * whole run. Measured case — `yosemite-s1` held snapshots 26h to 2.7 days old
+ * with a failing refresh, so balanced read `muqsit@getrush.ai` as 48% used and
+ * launched into it while the account was actually at its weekly cap.
+ */
+export const USAGE_DECISION_MAX_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * Whether this candidate's usage number is recent enough to route on. A missing
+ * snapshot is unverified by definition — there is no number to trust.
+ */
+export function isUsageVerified(candidate: RotateCandidate, nowMs: number = Date.now()): boolean {
+  const capturedAt = candidate.usageSnapshot?.capturedAt;
+  if (!capturedAt) return false;
+  return nowMs - capturedAt.getTime() <= USAGE_DECISION_MAX_AGE_MS;
 }
 
 function hasUsageAvailable(candidate: RotateCandidate): boolean {
@@ -260,7 +288,10 @@ function dedupeAndSortCandidates(candidates: RotateCandidate[]): RotateCandidate
  * Returns null if no candidate is eligible — callers fall back to the pinned
  * version so behavior stays predictable.
  */
-export function pickBalancedCandidate(candidates: RotateCandidate[]): RotateResult | null {
+export function pickBalancedCandidate(
+  candidates: RotateCandidate[],
+  nowMs: number = Date.now(),
+): RotateResult | null {
   const healthy: RotateCandidate[] = [];
   const excluded: RotateCandidate[] = [];
   for (const c of candidates) {
@@ -273,14 +304,27 @@ export function pickBalancedCandidate(candidates: RotateCandidate[]): RotateResu
 
   if (healthy.length === 0) return null;
 
-  const sorted = dedupeAndSortCandidates(healthy);
-  const deduped = new Set(sorted);
+  // An eligible account whose usage we could not confirm is a guess, not a
+  // green light: the snapshot says "48% used" with equal confidence whether it
+  // was read a minute or three days ago, and a box whose refresh is failing
+  // stays wrong indefinitely. So route to a VERIFIED account whenever one
+  // exists, and fall back to the unverified pool only when nothing on this
+  // machine could be confirmed — a launch that still happens, but says so.
+  const verified = healthy.filter((c) => isUsageVerified(c, nowMs));
+  const pool = verified.length > 0 ? verified : healthy;
+  const usageUnverified = verified.length === 0;
   for (const c of healthy) {
+    if (!pool.includes(c)) excluded.push(c);
+  }
+
+  const sorted = dedupeAndSortCandidates(pool);
+  const deduped = new Set(sorted);
+  for (const c of pool) {
     if (!deduped.has(c)) excluded.push(c);
   }
 
   const picked = weightedRandomByCapacity(sorted);
-  return { picked, healthy: sorted, excluded };
+  return { picked, healthy: sorted, excluded, usageUnverified };
 }
 
 /**
@@ -368,13 +412,20 @@ export async function collectRunCandidates(agent: AgentId): Promise<RotateCandid
     })
   );
 
+  // These candidates feed a routing decision, so cap how stale their usage may
+  // be (see USAGE_DECISION_MAX_AGE_MS). Past that the fetch blocks on a live
+  // read instead of serving the cache — one bounded, parallel round trip per
+  // account, and none at all inside the 2-minute fresh window that back-to-back
+  // launches hit. A failed read still falls back to the cache; the pick then
+  // routes around it via isUsageVerified rather than trusting the old number.
   const { usageByKey } = await getUsageInfoByIdentity(
     rows.map(({ home, info, version }) => ({
       agentId: agent,
       home,
       cliVersion: version,
       info,
-    }))
+    })),
+    { maxAgeMs: USAGE_DECISION_MAX_AGE_MS }
   );
 
   return rows.map(({ home: _home, info, ...candidate }) => {

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService } from './usage.js';
+import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService, swrWindowMsFor } from './usage.js';
 import { setKeychainToken, setKeychainBackendForTest, secretsKeychainItem, type KeychainBackend } from './secrets/index.js';
 import { writeBundle, keychainRef, bundleItemStore } from './secrets/bundles.js';
 import { _resetFileStoreForTest } from './secrets/filestore.js';
@@ -264,5 +264,33 @@ describe('loadClaudeOauth — file-based `auth` setup-token (Touch-ID-free usage
     // With no keychain item and no .credentials.json, that resolves to null.
     const oauth = await loadClaudeOauth(home);
     expect(oauth).toBeNull();
+  });
+});
+
+describe('swrWindowMsFor — a routing decision does not get day-old data', () => {
+  const DAY = 24 * 60 * 60 * 1000;
+
+  it('defaults to the full stale-while-revalidate window for display callers', () => {
+    // `agents view` rendering a slightly old bar costs nothing, so it stays off
+    // the network exactly as before.
+    expect(swrWindowMsFor(undefined)).toBe(DAY);
+  });
+
+  it('shortens the window for a caller that is about to route on the number', () => {
+    // The measured failure: a 26h-old snapshot read as "48% used" while the
+    // account was at its weekly cap. Five minutes is inside the window; a day
+    // is not, so the read blocks on a live fetch instead of serving the cache.
+    expect(swrWindowMsFor(5 * 60 * 1000)).toBe(5 * 60 * 1000);
+    expect(swrWindowMsFor(5 * 60 * 1000)).toBeLessThan(26 * 60 * 60 * 1000);
+  });
+
+  it('never lets a caller opt into MORE staleness than the cache policy allows', () => {
+    expect(swrWindowMsFor(7 * DAY)).toBe(DAY);
+  });
+
+  it('treats a nonsensical age as no opinion rather than zero', () => {
+    expect(swrWindowMsFor(Number.NaN)).toBe(DAY);
+    expect(swrWindowMsFor(Number.POSITIVE_INFINITY)).toBe(DAY);
+    expect(swrWindowMsFor(-1)).toBe(0);
   });
 });

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -288,9 +288,12 @@ describe('swrWindowMsFor — a routing decision does not get day-old data', () =
     expect(swrWindowMsFor(7 * DAY)).toBe(DAY);
   });
 
-  it('treats a nonsensical age as no opinion rather than zero', () => {
+  it('treats an unusable age as no opinion — the caller simply did not ask', () => {
     expect(swrWindowMsFor(Number.NaN)).toBe(DAY);
     expect(swrWindowMsFor(Number.POSITIVE_INFINITY)).toBe(DAY);
+  });
+
+  it('clamps a negative age to zero — that IS an opinion: never serve the cache', () => {
     expect(swrWindowMsFor(-1)).toBe(0);
   });
 });

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -287,7 +287,7 @@ export function agentReportsUsage(agentId: AgentId): boolean {
 /** Fetch usage info for all unique accounts in parallel, keyed by usage key. */
 export async function getUsageInfoByIdentity(
   inputs: UsageIdentityInput[],
-  opts?: { forceRefresh?: boolean }
+  opts?: { forceRefresh?: boolean; maxAgeMs?: number }
 ): Promise<{
   canonicalByUsageKey: Map<string, AccountInfo>;
   usageByKey: Map<string, UsageInfo>;
@@ -314,6 +314,18 @@ export async function getUsageInfoByIdentity(
 const USAGE_CACHE_FRESH_MS = 2 * 60 * 1000; // 2 minutes — fresh window: don't refresh.
 const USAGE_CACHE_SWR_MS = 24 * 60 * 60 * 1000; // 24 hours — beyond this, block on live fetch.
 
+/**
+ * How stale a cached snapshot may be before the read stops serving it and blocks
+ * on the network. Defaults to the full 24h stale-while-revalidate window; a
+ * caller that is about to ROUTE on the number passes a shorter `maxAgeMs` and
+ * gets a live read instead of a day-old one. Never widens past 24h — a caller
+ * cannot opt into more staleness than the cache policy allows.
+ */
+export function swrWindowMsFor(maxAgeMs?: number): number {
+  if (maxAgeMs === undefined || !Number.isFinite(maxAgeMs)) return USAGE_CACHE_SWR_MS;
+  return Math.min(USAGE_CACHE_SWR_MS, Math.max(0, maxAgeMs));
+}
+
 /** In-process dedup: don't fire concurrent background refreshes for the same identity. */
 const inFlightRefreshes = new Map<string, Promise<void>>();
 
@@ -331,7 +343,7 @@ const inFlightRefreshes = new Map<string, Promise<void>>();
  */
 export async function getUsageInfoForIdentity(
   input: UsageIdentityInput,
-  opts?: { forceRefresh?: boolean }
+  opts?: { forceRefresh?: boolean; maxAgeMs?: number }
 ): Promise<UsageInfo> {
   const usageKey = getUsageLookupKey(input.info);
   const forceRefresh = opts?.forceRefresh === true;
@@ -366,7 +378,15 @@ export async function getUsageInfoForIdentity(
 
     // Stale-while-revalidate: cache exists and isn't ancient, return it now and
     // refresh in the background so the next invocation has fresh data.
-    if (cached && ageMs < USAGE_CACHE_SWR_MS) {
+    //
+    // `maxAgeMs` shortens that window for callers that are about to make a
+    // DECISION on the number rather than display it. Serving a day-old snapshot
+    // to the account router is how a launch lands on an already-exhausted
+    // account: the box picks from its own cache, the background refresh lands
+    // after the choice is made, and nothing reconciles. Display callers keep the
+    // full 24h window and stay off the hot path.
+    const swrWindowMs = swrWindowMsFor(opts?.maxAgeMs);
+    if (cached && ageMs < swrWindowMs) {
       triggerBackgroundUsageRefresh(input, usageKey);
       return { snapshot: cached, error: null };
     }


### PR DESCRIPTION
**Bug fix** — balanced routing launched into an account that was already at its weekly cap. No new command surface; one behavior change in the account router plus the freshness plumbing it needs.

## What was wrong

Account usage is cached **per machine** under stale-while-revalidate: a snapshot up to 24h old is served instantly and a background refresh fires. That is right for `agents view`. It is wrong for the router, because the refresh lands *after* the pick is already made — and on a box whose refresh is failing, the state is permanent.

Measured on `yosemite-s1`, every Claude org snapshot in `~/.agents/.cache/claude-usage.json`:

```
claude:org=378f01db…  capturedAt 2026-08-02T04:30Z   (~26h old)
claude:org=44f67f0c…  capturedAt 2026-08-02T04:30Z   (~26h old)
claude:org=75512e67…  capturedAt 2026-08-02T04:30Z   (~26h old)
claude:org=922c2be0…  capturedAt 2026-08-02T04:30Z   (~26h old)
claude:org=d4ad9072…  capturedAt 2026-07-31T15:00Z   (~2.7 days old)
```

`agents view claude --refresh` on that box did **not** update them — every credential renders `◐` (unverified), so the live read fails and `getUsageInfoForIdentity` falls back to the cache and writes nothing.

The result: balanced read `muqsit@getrush.ai` as **48% weekly used** and launched into it. `zion`, with working credentials for that account, read it as **100%, rate-limited**. The launched session (`c1e8bdc8` on `yosemite-s1`, `claude 2.1.181`) answered `You've hit your weekly limit · resets Aug 4, 7am` on both of its turns, having done no work.

The number was never the problem. **The confidence was** — `hasUsageAvailable` reads "48% used" identically whether it was captured a minute or three days ago, and nothing downstream could tell the difference.

## What changed

- **A routing decision caps staleness at 5 minutes** (`USAGE_DECISION_MAX_AGE_MS`). `collectRunCandidates` passes `maxAgeMs` into the usage read; past that the read blocks on a live fetch instead of serving the cache. Cost is one bounded, parallel round trip per account — and **none at all** inside the existing 2-minute fresh window, which back-to-back launches hit. Display paths keep the full 24h window and stay off the network exactly as before.
- **Verified beats stale.** `pickBalancedCandidate` routes to an account whose snapshot is fresh whenever one exists, even when a stale candidate's number looks emptier — a 48% that cannot be confirmed is not evidence.
- **A blind route says so.** When *nothing* on the machine could be refreshed the launch still happens (a broken refresh must not make a box unusable), but the banner reads `… (2 of 5 healthy, usage unverified — no account could be refreshed)` instead of presenting a guess as a fact.
- `swrWindowMsFor` never lets a caller opt into *more* staleness than the cache policy allows.

## Test run

```
src/lib/rotate.test.ts   src/lib/usage.test.ts   src/commands/exec.test.ts
Test Files  3 passed (3)
     Tests  68 passed (68)
tsc --noEmit             clean
```

The new tests reproduce the incident rather than the happy path:

- a 26h-old candidate at 48% loses to a verified candidate at 90% — *the exact inversion that caused this*, since pure capacity weighting would have preferred the stale one;
- when every candidate is stale the pick still happens and is flagged `usageUnverified`;
- a **verified** rate-limited account is still excluded outright, not merely deprioritized;
- an undated snapshot (`capturedAt: null`) counts as unverified, not as current.

Existing rotate tests build snapshots with `capturedAt: null`, so they now flow through the unverified pool — behaviour is unchanged for them (pool falls back to the full healthy set), which is why all 31 still pass.

## Not covered here

`--strategy balanced` is still resolved **on the remote box** for `agents run --host` (`hosts/remote-cmd.ts:98` forwards it as an opaque string). This PR makes that remote decision honest — it will refresh or admit it couldn't — but the decision still happens on the machine with the weaker credentials. Pinning the pick locally when the target has the same version installed is the follow-up; it is a separate behavior change and does not belong in a fix this size.
