### PR TITLE
feat(view): live per-model usage bars for Antigravity

### DIFF
--- a/apps/cli/.changelog/next/antigravity-usage-bars.md
+++ b/apps/cli/.changelog/next/antigravity-usage-bars.md
@@ -1,0 +1,13 @@
+- **`agents view` now shows live usage bars for Antigravity.** The `agy` account
+  row renders one bar per model quota bucket (`3.1P: ███░░ 42% (1d)` style),
+  sourced from the same Google Code Assist `:retrieveUserQuota` endpoint `agy`
+  itself talks to. Auth reuses the stored `agy` OAuth credential (macOS Keychain
+  item `gemini`/`antigravity`, Linux Secret Service, or the
+  `~/.gemini/antigravity-cli/antigravity-oauth-token` file fallback), refreshing
+  the access token in memory when expired — safe from a read path because
+  Google's refresh tokens are non-rotating, and never written back to the
+  keychain. Each per-model bucket also flows into the throttle badge, run
+  rotation eligibility, and `agents view --json` (whose usage windows now carry
+  a `label` so same-keyed per-model bars are distinguishable). Source:
+  `apps/cli/src/lib/usage.ts`, `apps/cli/src/lib/agents.ts`,
+  `apps/cli/src/commands/view.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -892,7 +892,7 @@ contains — this is a data-availability limit, not a policy choice:
 | Droid | email | live (`api.factory.ai`) | `~/.factory/auth.v2.file` is AES-256-GCM (key on disk at `auth.v2.key`); decrypt locally, read the email from the WorkOS access-token JWT. That same token authorizes `GET /api/billing/limits` for the three rolling rate-limit windows (5-hour → `S`, weekly → `W`, monthly, detailed-view only). |
 | Kimi | `id:<user_id>` + tier | live (`api.kimi.com/coding/v1/usages`) | JWT carries no email — only an opaque `user_id`. Quota + membership tier come from the `/usages` endpoint. |
 | Cursor | email | live (`cursor.com/api/usage`) | email/authId from `~/.cursor/cli-config.json`; access token from `~/.config/cursor/auth.json`. The endpoint is authed with a `WorkosCursorSessionToken=<authId>::<token>` cookie and returns a monthly request bar (`M`) for request-capped (free/legacy) plans. Usage-based plans report no request cap, so they render the account row without a bar. |
-| Antigravity | `signed in` | — | OAuth grant with no id_token — presence only. File `~/.gemini/antigravity-cli/antigravity-oauth-token`, else macOS keychain / Linux libsecret (`service gemini` + user `antigravity`) |
+| Antigravity | `signed in` | live (`cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`) | OAuth grant with no id_token — presence only. File `~/.gemini/antigravity-cli/antigravity-oauth-token`, else macOS keychain / Linux libsecret (`service gemini` + user `antigravity`). The stored Google OAuth token authorizes the Code Assist quota endpoint `agy` itself uses; it returns one bucket per model (`gemini-3.1-pro`, `gemini-2.5-flash`, …) with its own reset time, and each bucket renders as its own bar (compact model tag: `3.1P`, `2.5F`, …). |
 | others | `not signed in` unless a credential exists | — | `default` case: no detector |
 
 Two deliberate boundaries worth knowing:
@@ -908,6 +908,14 @@ Two deliberate boundaries worth knowing:
   snapshot; each agent's own CLI refreshes on its next launch (Droid's token
   lives 24h). Droid surfaces the `standard` (primary) rate-limit pool, not the
   free `core` fallback pool.
+- **Antigravity usage MAY refresh, in-memory only.** Google's OAuth refresh
+  tokens are stable and non-rotating — a refresh mints a new access token and
+  leaves the refresh token (and every other live access token) valid, so a
+  read-path refresh can't invalidate a running `agy` the way a Claude/WorkOS
+  rotation would. The refreshed access token is used for the quota call and
+  then dropped: the keychain item is never written (agy rewrites it on its own
+  launches). Without this the bars would never render — Google access tokens
+  live ~1 hour.
 
 The same fields are exposed programmatically via `agents view --json`
 (`email`, `accountId`, `plan`, `usageStatus`, `windows`).

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -1232,6 +1232,11 @@ export interface ViewJsonVersion {
   overageCredits?: { amount: number; currency: string } | null;
   windows: Array<{
     key: 'session' | 'week' | 'sonnet_week' | 'month';
+    // What the window meters — 'Current session'/'Current week' for most
+    // agents, the model id for Antigravity's per-model quota buckets (whose
+    // keys are all 'session', so the label is the only way to tell them
+    // apart). Optional for backward compatibility with older consumers.
+    label?: string;
     usedPercent: number;
     resetsAt: string | null;
   }>;
@@ -1503,6 +1508,7 @@ async function collectAgentsJson(filterAgentId?: AgentId, resourceSections?: Set
       windows: snapshot
         ? snapshot.windows.map((w) => ({
             key: w.key,
+            label: w.label,
             usedPercent: w.usedPercent,
             resetsAt: w.resetsAt ? w.resetsAt.toISOString() : null,
           }))

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -23,6 +23,10 @@ import {
   formatKimiPlan,
   normalizeDroidWindows,
   normalizeCursorUsage,
+  antigravityModelShortLabel,
+  antigravityTokenNeedsRefresh,
+  normalizeAntigravityWindows,
+  parseAntigravityOauthPayload,
   USAGE_SOURCE_AGENT_IDS,
   type DroidBillingLimitsResponse,
   type KimiUsagesResponse,
@@ -141,7 +145,7 @@ describe('usage formatting', () => {
   });
 
   it('pins the complete usage source registry and derives support from it', () => {
-    expect(USAGE_SOURCE_AGENT_IDS).toEqual(['claude', 'codex', 'kimi', 'droid', 'grok', 'cursor']);
+    expect(USAGE_SOURCE_AGENT_IDS).toEqual(['claude', 'codex', 'kimi', 'droid', 'grok', 'cursor', 'antigravity']);
     for (const agentId of ALL_AGENT_IDS) {
       expect(agentReportsUsage(agentId)).toBe(USAGE_SOURCE_AGENT_IDS.includes(agentId as never));
     }
@@ -183,6 +187,85 @@ describe('usage formatting', () => {
     // Missing premium bucket entirely -> no window, no throw.
     expect(normalizeCursorUsage({ startOfMonth: '2026-07-22T11:35:59.000Z' })).toEqual([]);
     expect(normalizeCursorUsage({})).toEqual([]);
+  });
+
+  it('parseAntigravityOauthPayload reads the raw JSON and the go-keyring-base64 wrapper', () => {
+    // Linux file-fallback shape: raw { token: {…} } JSON.
+    const raw = JSON.stringify({
+      token: { access_token: 'ya29.x', refresh_token: 'rt', expiry: '2026-08-01T21:06:25Z' },
+      auth_method: 'consumer',
+    });
+    expect(parseAntigravityOauthPayload(raw)).toEqual({
+      access_token: 'ya29.x',
+      refresh_token: 'rt',
+      expiry: '2026-08-01T21:06:25Z',
+    });
+
+    // macOS Keychain shape: go-keyring prefixes the same JSON with base64.
+    const wrapped = `go-keyring-base64:${Buffer.from(raw, 'utf-8').toString('base64')}`;
+    expect(parseAntigravityOauthPayload(wrapped)?.refresh_token).toBe('rt');
+
+    // Malformed / empty / token-less payloads => null, never a throw.
+    expect(parseAntigravityOauthPayload('not json')).toBeNull();
+    expect(parseAntigravityOauthPayload('{}')).toBeNull();
+    expect(parseAntigravityOauthPayload(JSON.stringify({ token: {} }))).toBeNull();
+  });
+
+  it('antigravityTokenNeedsRefresh gates on the RFC3339 expiry with a leeway', () => {
+    const now = Date.parse('2026-08-03T06:00:00Z');
+    expect(antigravityTokenNeedsRefresh('2026-08-03T07:00:00Z', now)).toBe(false); // 1h out
+    expect(antigravityTokenNeedsRefresh('2026-08-03T06:00:30Z', now)).toBe(true); // inside leeway
+    expect(antigravityTokenNeedsRefresh('2026-08-01T21:06:25Z', now)).toBe(true); // expired
+    // Missing/unparseable expiry reads as still-fresh (the quota call is the truth).
+    expect(antigravityTokenNeedsRefresh(null, now)).toBe(false);
+    expect(antigravityTokenNeedsRefresh('not-a-date', now)).toBe(false);
+  });
+
+  it('antigravityModelShortLabel compacts gemini model ids', () => {
+    expect(antigravityModelShortLabel('gemini-2.5-flash-lite')).toBe('2.5FL');
+    expect(antigravityModelShortLabel('gemini-2.5-pro')).toBe('2.5P');
+    expect(antigravityModelShortLabel('gemini-3.1-flash-lite')).toBe('3.1FL');
+    // Unknown ids pass through untouched rather than rendering a blank tag.
+    expect(antigravityModelShortLabel('custom-model')).toBe('customM');
+  });
+
+  it('normalizeAntigravityWindows builds one bar per model, most-used first', () => {
+    // Real :retrieveUserQuota shape (plus a duplicated model and a junk bucket).
+    const windows = normalizeAntigravityWindows([
+      { modelId: 'gemini-2.5-flash', tokenType: 'REQUESTS', remainingFraction: 1, resetTime: '2026-08-04T07:07:52Z' },
+      { modelId: 'gemini-3.1-pro', tokenType: 'REQUESTS', remainingFraction: 0.42, resetTime: '2026-08-04T07:07:52Z' },
+      { modelId: 'gemini-3.1-pro', tokenType: 'REQUESTS', remainingFraction: 0.5, resetTime: '2026-08-04T07:07:52Z' },
+      { modelId: 'gemini-2.5-pro', remainingFraction: 0 },
+      { modelId: null, remainingFraction: 0.5 }, // no model id -> dropped
+      { modelId: 'gemini-2.5-flash-lite' }, // no fraction -> dropped
+    ]);
+
+    expect(windows.map((w) => w.label)).toEqual(['gemini-2.5-pro', 'gemini-3.1-pro', 'gemini-2.5-flash']);
+    const pro = windows.find((w) => w.label === 'gemini-3.1-pro');
+    // Duplicate buckets keep the LOWEST remaining fraction.
+    expect(pro?.usedPercent).toBeCloseTo(58, 5);
+    expect(pro?.shortLabel).toBe('3.1P');
+    expect(pro?.key).toBe('session');
+    expect(pro?.resetsAt?.toISOString()).toBe('2026-08-04T07:07:52.000Z');
+    // Unknown window length stays null (never an inferred 5h session).
+    expect(pro?.windowMinutes).toBeNull();
+    // A fully drained bucket reads as 100% used.
+    expect(windows[0]?.usedPercent).toBe(100);
+  });
+
+  it('getUsageInfo(antigravity) renders nothing when no credential exists', async () => {
+    // No credential file in the temp home, keyring probe disabled -> null, no throw.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-agy-usage-'));
+    const prev = process.env.AGENTS_NO_KEYCHAIN_PROBE;
+    process.env.AGENTS_NO_KEYCHAIN_PROBE = '1';
+    try {
+      const info = await getUsageInfo('antigravity', { home });
+      expect(info).toEqual({ snapshot: null, error: null });
+    } finally {
+      if (prev === undefined) delete process.env.AGENTS_NO_KEYCHAIN_PROBE;
+      else process.env.AGENTS_NO_KEYCHAIN_PROBE = prev;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('parses Grok usage from the local unified.jsonl (real log shape)', async () => {

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -555,9 +555,12 @@ describe('getAccountInfo — token-only agents (no local email)', () => {
     // Consumer Google OAuth exposes no email/identity claim locally.
     expect(info.email).toBeNull();
     // A stable usage identity is derived from the refresh token so `agents
-    // view` can dedupe + cache the per-model quota bars for this login.
-    expect(info.accountKey).toBe('antigravity:sub=1//refresh');
-    expect(info.usageKey).toBe('antigravity:sub=1//refresh');
+    // view` can dedupe + cache the per-model quota bars for this login. The
+    // raw (non-JWT) refresh token is a live credential, so the key carries
+    // only its SHA-256 fingerprint — never the token itself.
+    expect(info.accountKey).toMatch(/^antigravity:sub=[0-9a-f]{16}$/);
+    expect(info.accountKey).not.toContain('1//refresh');
+    expect(info.usageKey).toBe(info.accountKey);
   });
 
   it('treats Antigravity as signed out when the token file is missing', async () => {

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -554,6 +554,10 @@ describe('getAccountInfo — token-only agents (no local email)', () => {
     expect(info.signedIn).toBe(true);
     // Consumer Google OAuth exposes no email/identity claim locally.
     expect(info.email).toBeNull();
+    // A stable usage identity is derived from the refresh token so `agents
+    // view` can dedupe + cache the per-model quota bars for this login.
+    expect(info.accountKey).toBe('antigravity:sub=1//refresh');
+    expect(info.usageKey).toBe('antigravity:sub=1//refresh');
   });
 
   it('treats Antigravity as signed out when the token file is missing', async () => {

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1773,10 +1773,20 @@ export async function getAccountInfo(
         if (tokenPath) {
           const data = JSON.parse(await fs.promises.readFile(tokenPath, 'utf-8'));
           if (typeof data?.token?.refresh_token === 'string' && data.token.refresh_token) {
-            return { ...empty, signedIn: true, lastActive };
+            // A stable account/usage key (derived from the refresh token — see
+            // readAuthAccountIdentity) lets `agents view` dedupe and cache the
+            // per-model quota bars for this login.
+            const identity = readAuthAccountIdentity('antigravity', path.dirname(tokenPath));
+            return { ...empty, signedIn: true, lastActive, accountKey: identity, usageKey: identity };
           }
         }
-        if (await antigravityKeychainSignedIn()) return { ...empty, signedIn: true, lastActive };
+        if (await antigravityKeychainSignedIn()) {
+          // Keyring-only login (the macOS case): the OS keyring holds exactly
+          // ONE antigravity credential, so a stable singleton key identifies it
+          // for usage-cache dedup without reading the secret value here.
+          const identity = buildIdentityKey('antigravity', [['sub', 'keychain']]);
+          return { ...empty, signedIn: true, lastActive, accountKey: identity, usageKey: identity };
+        }
         return { ...empty, lastActive };
       }
       case 'kimi': {

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1299,8 +1299,10 @@ export function decryptDroidAuthFile(filePath: string, keyPath: string): DroidAu
  *     -> email / org_id / sub.
  *   - kimi: credentials/kimi-code.json -> access-token JWT -> user_id / sub.
  *   - antigravity: antigravity-oauth-token -> token.refresh_token -> JWT sub
- *     when the token is a JWT, else the raw refresh-token value (opaque Google
- *     consumer tokens are stable per login).
+ *     when the token is a JWT, else a SHA-256 hash of the raw refresh-token
+ *     value (opaque Google consumer tokens are stable per login — hashed so
+ *     the identity key, which is persisted as a usage-cache key, never carries
+ *     a live credential).
  * Two directories for the SAME account compare equal; two DIFFERENT accounts
  * compare distinct. Used by carryForwardAuthFiles to refuse overwriting one
  * account's login with a credential that belongs to a DIFFERENT account
@@ -1341,7 +1343,11 @@ export function readAuthAccountIdentity(agent: AgentId, configDir: string): stri
         if (typeof refreshToken !== 'string' || !refreshToken) return null;
         const claims = decodeJwtPayload(refreshToken);
         const sub = normalizeIdentityPart(claims?.sub ?? claims?.user_id);
-        return buildIdentityKey(agent, [['sub', sub ?? refreshToken]]);
+        // An opaque (non-JWT) Google refresh token IS the credential — hash it
+        // so the identity key stays stable per login without embedding a live
+        // secret (the key is persisted as a usage-cache filename key).
+        const fallback = crypto.createHash('sha256').update(refreshToken).digest('hex').slice(0, 16);
+        return buildIdentityKey(agent, [['sub', sub ?? fallback]]);
       }
       default:
         return null;

--- a/apps/cli/src/lib/shims.auth-carry.test.ts
+++ b/apps/cli/src/lib/shims.auth-carry.test.ts
@@ -238,7 +238,15 @@ describe('readAuthFileIdentity — decodes each agent REAL format', () => {
   it('antigravity: identity from the refresh_token; null when absent', () => {
     writeAntigravityCred('a', 'REFRESH_A', 1_000_000);
     const dirA = path.join(TEST_VERSIONS_DIR, 'antigravity', 'a', 'home', '.gemini', 'antigravity-cli');
-    expect(readAuthFileIdentity('antigravity', dirA)).toBe('antigravity:sub=REFRESH_A');
+    // A non-JWT refresh token is a live credential — the identity carries its
+    // SHA-256 fingerprint, never the token itself (it lands in cache keys).
+    const idA = readAuthFileIdentity('antigravity', dirA);
+    expect(idA).toMatch(/^antigravity:sub=[0-9a-f]{16}$/);
+    expect(idA).not.toContain('REFRESH_A');
+    // Distinct refresh tokens -> distinct identities.
+    writeAntigravityCred('b', 'REFRESH_B', 1_000_000);
+    const dirB = path.join(TEST_VERSIONS_DIR, 'antigravity', 'b', 'home', '.gemini', 'antigravity-cli');
+    expect(readAuthFileIdentity('antigravity', dirB)).not.toBe(idA);
     // No refresh_token -> no identity.
     fs.writeFileSync(path.join(dirA, 'antigravity-oauth-token'), JSON.stringify({ token: {} }));
     expect(readAuthFileIdentity('antigravity', dirA)).toBeNull();

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1,11 +1,13 @@
 /**
- * Usage and rate-limit tracking for Claude, Codex, Kimi, Droid, Grok, and Cursor agents.
+ * Usage and rate-limit tracking for Claude, Codex, Kimi, Droid, Grok, Cursor,
+ * and Antigravity agents.
  *
  * Fetches live usage data from each agent's usage API (Anthropic OAuth for
- * Claude, Kimi Code /usages, Factory billing limits for Droid) or parses
- * rate-limit events from Codex session logs. Results are normalized into a
- * common UsageSnapshot shape, cached to disk, and rendered as terminal
- * progress bars for the `agents view` command.
+ * Claude, Kimi Code /usages, Factory billing limits for Droid, Google Code
+ * Assist :retrieveUserQuota for Antigravity) or parses rate-limit events from
+ * Codex session logs. Results are normalized into a common UsageSnapshot
+ * shape, cached to disk, and rendered as terminal progress bars for the
+ * `agents view` command.
  */
 import { execFile } from 'child_process';
 import { createHash } from 'crypto';
@@ -218,6 +220,7 @@ const USAGE_SOURCES = {
   droid: { fetch: getDroidUsageInfo, network: true },
   grok: { fetch: getGrokUsageInfo, network: false },
   cursor: { fetch: getCursorUsageInfo, network: true },
+  antigravity: { fetch: getAntigravityUsageInfo, network: true },
 } as const satisfies Partial<Record<AgentId, UsageSource>>;
 
 export const USAGE_SOURCE_AGENT_IDS = Object.keys(USAGE_SOURCES) as (keyof typeof USAGE_SOURCES)[];
@@ -274,11 +277,11 @@ export function buildCanonicalUsageContext(inputs: UsageIdentityInput[]): {
 }
 
 /**
- * Whether an agent exposes usage/limit data we can render — Claude/Kimi/Droid/Cursor
- * via a live API, Codex/Grok via local session logs. Everything else has no usage
- * concept, so callers use this to decide whether a missing snapshot is worth
- * flagging as "usage unavailable" (a signed-in Claude account with no data)
- * versus simply not applicable (Antigravity, OpenCode).
+ * Whether an agent exposes usage/limit data we can render — Claude/Kimi/Droid/
+ * Cursor/Antigravity via a live API, Codex/Grok via local session logs.
+ * Everything else has no usage concept, so callers use this to decide whether
+ * a missing snapshot is worth flagging as "usage unavailable" (a signed-in
+ * Claude account with no data) versus simply not applicable (OpenCode).
  */
 export function agentReportsUsage(agentId: AgentId): boolean {
   return getUsageSource(agentId) !== undefined;
@@ -341,8 +344,8 @@ export async function getUsageInfoForIdentity(
   // stay off the network on the hot path. Everything else (Codex reads local
   // session logs) takes the legacy blocking path. The on-disk cache is shared and
   // keyed by usageKey, which is namespaced per agent (`claude:org=…`,
-  // `kimi:user=…`, `droid:org=…`, `cursor:user=…`), so one cache file holds every
-  // account without collision.
+  // `kimi:user=…`, `droid:org=…`, `cursor:user=…`, `antigravity:sub=…`), so one
+  // cache file holds every account without collision.
   const usesNetworkUsage = getUsageSource(input.agentId)?.network === true;
   if (!usesNetworkUsage || !usageKey) {
     return getUsageInfo(input.agentId, {
@@ -2050,6 +2053,286 @@ async function getCursorUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
         sourceLabel: 'live account data',
         capturedAt: new Date(),
         windows: normalizeCursorUsage(data),
+      },
+      error: null,
+    };
+  } catch {
+    return { snapshot: null, error: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Antigravity (`agy`) usage — Google Code Assist per-model quota buckets
+// ---------------------------------------------------------------------------
+
+const ANTIGRAVITY_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+// Production Code Assist endpoint first; the daily track is where `agy` itself
+// points when the account is enrolled in the daily channel (its log shows
+// daily-cloudcode-pa), so fall back to it when prod rejects the call.
+const ANTIGRAVITY_QUOTA_URLS = [
+  'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota',
+  'https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota',
+];
+// The public installed-app OAuth client the released `agy` binary itself
+// ships (Google installed-app clients are non-confidential by design — the
+// same client community tooling uses). Needed because a Google token refresh
+// requires the client id/secret pair the login was minted under.
+const ANTIGRAVITY_CLIENT_ID =
+  '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
+const ANTIGRAVITY_CLIENT_SECRET = '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';
+/** Refresh leeway — treat an access token expiring within a minute as expired. */
+const ANTIGRAVITY_REFRESH_LEEWAY_MS = 60 * 1000;
+
+/** The OAuth token `agy` stores (inside `{ token: … }`) in the OS keyring or file. */
+interface AntigravityOauthToken {
+  access_token?: string | null;
+  refresh_token?: string | null;
+  /** RFC3339 expiry timestamp for the access token. */
+  expiry?: string | null;
+}
+
+/** One per-model quota bucket from the :retrieveUserQuota response. */
+export interface AntigravityQuotaBucket {
+  modelId?: string | null;
+  tokenType?: string | null;
+  remainingFraction?: number | null;
+  resetTime?: string | null;
+}
+
+/** Response shape from the Code Assist :retrieveUserQuota endpoint. */
+export interface AntigravityQuotaResponse {
+  buckets?: AntigravityQuotaBucket[] | null;
+}
+
+/**
+ * Parse a stored `agy` OAuth payload into its token. Handles both on-disk
+ * shapes: the raw `{ token: {…} }` JSON (Linux file fallback) and the
+ * `go-keyring-base64:<base64>` wrapper zalando/go-keyring writes into the
+ * macOS Keychain item (service `gemini`, account `antigravity`). Never throws
+ * (malformed input => null).
+ */
+export function parseAntigravityOauthPayload(raw: string): AntigravityOauthToken | null {
+  try {
+    let text = raw.trim();
+    if (text.startsWith('go-keyring-base64:')) {
+      text = Buffer.from(text.slice('go-keyring-base64:'.length), 'base64').toString('utf-8');
+    }
+    const token = JSON.parse(text)?.token;
+    if (!token || typeof token !== 'object') return null;
+    if (typeof token.access_token !== 'string' && typeof token.refresh_token !== 'string') {
+      return null;
+    }
+    return token as AntigravityOauthToken;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the stored access token is expired (or inside the refresh leeway).
+ * A missing/unparseable expiry is treated as still-fresh — the quota call
+ * below is the source of truth if the token is actually dead (401 => render
+ * nothing), and we never want to force a refresh without evidence.
+ */
+export function antigravityTokenNeedsRefresh(
+  expiry: string | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!expiry) return false;
+  const ms = Date.parse(expiry);
+  if (Number.isNaN(ms)) return false;
+  return nowMs + ANTIGRAVITY_REFRESH_LEEWAY_MS >= ms;
+}
+
+/**
+ * Resolve the `agy` OAuth credential file. agy is a self-updating global
+ * install (no per-version homes), but check the passed home first and then the
+ * active location under the real HOME — mirrors resolveKimiCredentialPath.
+ * Present only on Linux without a Secret Service daemon; macOS logins live in
+ * the Keychain instead.
+ */
+function resolveAntigravityCredentialPath(home?: string): string | null {
+  const rel = ['.gemini', 'antigravity-cli', 'antigravity-oauth-token'];
+  const perHome = path.join(home || os.homedir(), ...rel);
+  try { if (fs.existsSync(perHome)) return perHome; } catch { /* unreadable */ }
+  const active = path.join(process.env.AGENTS_REAL_HOME || os.homedir(), ...rel);
+  if (active !== perHome) {
+    try { if (fs.existsSync(active)) return active; } catch { /* unreadable */ }
+  }
+  return null;
+}
+
+/**
+ * Load the stored `agy` OAuth token: the file fallback first, then the OS
+ * keyring (macOS Keychain / Linux Secret Service — go-keyring's two stores;
+ * the probe command pair mirrors antigravityOsKeyringProbe in agents.ts, with
+ * `-w` on macOS to read the secret value, not just metadata). Returns null on
+ * Windows or when no readable credential exists. Honors the
+ * AGENTS_NO_KEYCHAIN_PROBE=1 test guard.
+ */
+async function loadAntigravityOauth(home?: string): Promise<AntigravityOauthToken | null> {
+  const credPath = resolveAntigravityCredentialPath(home);
+  if (credPath) {
+    try {
+      const parsed = parseAntigravityOauthPayload(fs.readFileSync(credPath, 'utf-8'));
+      if (parsed) return parsed;
+    } catch { /* unreadable file — fall through to the keyring */ }
+  }
+
+  if (process.env.AGENTS_NO_KEYCHAIN_PROBE === '1') return null;
+  const probe =
+    process.platform === 'darwin'
+      ? { cmd: 'security', args: ['find-generic-password', '-w', '-s', 'gemini', '-a', 'antigravity'] }
+      : process.platform === 'linux'
+        ? { cmd: 'secret-tool', args: ['lookup', 'service', 'gemini', 'username', 'antigravity'] }
+        : null;
+  if (!probe) return null;
+  try {
+    const { stdout } = await execFileAsync(probe.cmd, probe.args, { timeout: 5000 });
+    return parseAntigravityOauthPayload(stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Refresh an `agy` access token against Google's token endpoint. This is safe
+ * from a read path in a way Claude/WorkOS refreshes are NOT: Google's OAuth
+ * refresh tokens are stable and non-rotating — a refresh mints a new access
+ * token and leaves the refresh token (and every other live access token)
+ * valid, so refreshing here cannot invalidate a concurrently running `agy`.
+ * We still never write the refreshed token back: `agy` rewrites its own
+ * keychain item on launch, and a read-only usage fetch must not mutate the
+ * user's credential.
+ */
+async function refreshAntigravityAccessToken(refreshToken: string): Promise<string | null> {
+  try {
+    const response = await fetch(ANTIGRAVITY_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: ANTIGRAVITY_CLIENT_ID,
+        client_secret: ANTIGRAVITY_CLIENT_SECRET,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      }).toString(),
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { access_token?: string };
+    return typeof data.access_token === 'string' && data.access_token ? data.access_token : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * POST :retrieveUserQuota against the Code Assist endpoints in order, returning
+ * the first successful bucket list. null when every endpoint rejects (expired
+ * token, no quota API for the account) or the network fails.
+ */
+async function fetchAntigravityQuota(accessToken: string): Promise<AntigravityQuotaBucket[] | null> {
+  for (const url of ANTIGRAVITY_QUOTA_URLS) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: '{}',
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!response.ok) continue;
+      const data = (await response.json()) as AntigravityQuotaResponse;
+      return Array.isArray(data?.buckets) ? data.buckets : [];
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/** Compact model tag for the inline bar — 'gemini-2.5-flash-lite' => '2.5FL'. */
+export function antigravityModelShortLabel(modelId: string): string {
+  const stripped = modelId.replace(/^gemini-/i, '');
+  const parts = stripped.split('-').filter(Boolean);
+  if (parts.length === 0) return modelId;
+  const [version, ...rest] = parts;
+  return version + rest.map((part) => (part[0] ? part[0].toUpperCase() : '')).join('');
+}
+
+/**
+ * Normalize the per-model quota buckets into the common UsageWindow shape —
+ * one window per model (`gemini-3.1-pro`, `gemini-2.5-flash`, …), keyed
+ * `session` since each bucket is a short-cycle quota with its own reset time.
+ * Duplicate buckets for one model keep the LOWEST remaining fraction (the
+ * most conservative read). Sorted most-used first so the bar closest to
+ * throttling leads the row. `windowMinutes` stays null: the API reports only
+ * the reset timestamp, not the window length, and an inferred 5h session
+ * length would wrongly zero the SWR cache between resets.
+ */
+export function normalizeAntigravityWindows(buckets: AntigravityQuotaBucket[]): UsageWindow[] {
+  const byModel = new Map<string, { bucket: AntigravityQuotaBucket; remaining: number }>();
+  for (const bucket of buckets) {
+    const modelId = normalizeString(bucket?.modelId);
+    const remaining = bucket?.remainingFraction;
+    if (!modelId || typeof remaining !== 'number' || !Number.isFinite(remaining)) continue;
+    const existing = byModel.get(modelId);
+    if (!existing || remaining < existing.remaining) {
+      byModel.set(modelId, { bucket, remaining });
+    }
+  }
+
+  const windows: UsageWindow[] = [];
+  for (const [modelId, { bucket, remaining }] of byModel) {
+    const usedPercent = normalizePercent((1 - remaining) * 100);
+    if (usedPercent === null) continue;
+    windows.push({
+      key: 'session',
+      label: modelId,
+      shortLabel: antigravityModelShortLabel(modelId),
+      usedPercent,
+      resetsAt: parseDateValue(bucket.resetTime),
+      windowMinutes: null,
+    });
+  }
+  windows.sort((a, b) => b.usedPercent - a.usedPercent);
+  return windows;
+}
+
+/**
+ * Fetch Antigravity usage via Google Code Assist's :retrieveUserQuota — the
+ * quota API `agy` itself talks to (its log shows the sibling :loadCodeAssist
+ * and :fetchAvailableModels calls on the same host). Auth is the stored `agy`
+ * OAuth token (OS keyring on macOS, file fallback on Linux), refreshed
+ * in-memory when expired — safe because Google's refresh tokens are
+ * non-rotating (see refreshAntigravityAccessToken).
+ */
+async function getAntigravityUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
+  try {
+    const token = await loadAntigravityOauth(options?.home);
+    if (!token) return { snapshot: null, error: null };
+
+    let accessToken = normalizeString(token.access_token);
+    if ((!accessToken || antigravityTokenNeedsRefresh(token.expiry)) && token.refresh_token) {
+      accessToken = await refreshAntigravityAccessToken(token.refresh_token);
+    }
+    if (!accessToken) return { snapshot: null, error: null };
+
+    const buckets = await fetchAntigravityQuota(accessToken);
+    if (!buckets) return { snapshot: null, error: null };
+
+    const windows = normalizeAntigravityWindows(buckets);
+    if (windows.length === 0) return { snapshot: null, error: null };
+
+    return {
+      snapshot: {
+        source: 'live',
+        sourceLabel: 'live account data',
+        capturedAt: new Date(),
+        windows,
       },
       error: null,
     };


### PR DESCRIPTION
## What

`agents view` now shows live usage bars for Antigravity (`agy`) — one bar per model quota bucket, sourced from the same Google Code Assist `:retrieveUserQuota` endpoint `agy` itself talks to (its own log shows the sibling `:loadCodeAssist` / `:fetchAvailableModels` calls on the same host), which returns one bucket per model (`gemini-3.1-pro`, `gemini-2.5-flash`, …) with `remainingFraction` + `resetTime`.

## Run evidence

Screenshot of the real run on this branch, against the live Keychain-backed account — compact per-model bars in the `agents view` row plus the detailed per-version usage section:
`/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/antigravity-usage-evidence.png`

Full captured terminal output (ANSI, same run):
`/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/antigravity-usage-evidence.log`

## How

- **`usage.ts`** — new `getAntigravityUsageInfo` registered in `USAGE_SOURCES` (network, so it rides the SWR cache). Auth reuses the stored `agy` OAuth credential: macOS Keychain item (service `gemini`, account `antigravity`, `go-keyring-base64` payload), Linux Secret Service, or the `~/.gemini/antigravity-cli/antigravity-oauth-token` file fallback. When the access token is expired it is refreshed **in memory only** via the public installed-app OAuth client shipped in the `agy` binary — safe from a read path because Google's refresh tokens are stable and non-rotating (unlike Claude/WorkOS single-use rotation), and the refreshed token is never written back (verified: the keychain item's mdate is unchanged after fetches). Buckets normalize to one `session`-keyed window per model with a compact model tag (`3.1P`, `2.5F`), sorted most-used first.
- **`agents.ts`** — `getAccountInfo('antigravity')` now reports a stable `accountKey`/`usageKey` (refresh-token-derived for file logins; a singleton `antigravity:sub=keychain` for the one-login keyring case) so the usage dedup/cache pipeline picks the account up.
- **`view.ts`** — `--json` usage windows gain an optional `label`, since Antigravity's windows all share the `session` key and the model id is the only way to tell them apart.

The per-model windows flow into the existing machinery unchanged: compact row bars, the `rate-limited` badge (`deriveUsageStatusFromSnapshot`), run-rotation eligibility, and the detailed `agents view antigravity@<ver>` usage section.

## Tests

- 7 new cases in `usage.test.ts` (payload parsing incl. the `go-keyring-base64` wrapper, expiry gate, short labels, bucket normalization/dedupe/sort, no-credential null path) + `accountKey`/`usageKey` pins in `agents.test.ts`.
- Full suite: 8024 passed; the only 12 failures (crabbox/models/exec) reproduce identically on clean `origin/main` — environmental (locked `hetzner.com` secrets bundle), unrelated to this diff.
- Changelog fragment: `apps/cli/.changelog/next/antigravity-usage-bars.md`; docs updated in `apps/cli/docs/06-observability.md`.