### PR TITLE
fix(cli): a usage read that fails on the credential says so

### DIFF
--- a/apps/cli/.changelog/next/usage-read-names-dead-credential.md
+++ b/apps/cli/.changelog/next/usage-read-names-dead-credential.md
@@ -1,8 +1,9 @@
-- **A usage read that fails on the credential now says so, instead of returning
-  a silent null.** Three branches in every networked usage fetch — Claude, Kimi,
-  Droid and Cursor — returned `{ snapshot: null, error: null }`: no readable
-  credential, a locally-expired one, and a rejected request. The caller could
-  not tell any of them apart from a healthy read, so it fell
+- **A usage read that fails now says so, instead of returning a silent null.**
+  Four branches in every networked usage fetch — Claude, Kimi, Droid and
+  Cursor — returned `{ snapshot: null, error: null }`: no readable credential, a
+  locally-expired one, a rejected request, and a request that threw (timeout,
+  DNS/TLS, an unparseable payload). The caller could not tell any of them apart
+  from a healthy read, so it fell
   back to whatever the stale-while-revalidate cache held and drew those bars as
   fact. Measured on `yosemite-s1`: every Claude account's stored access token had
   expired (one of them eleven days earlier), so no read could succeed, and

--- a/apps/cli/.changelog/next/usage-read-names-dead-credential.md
+++ b/apps/cli/.changelog/next/usage-read-names-dead-credential.md
@@ -1,0 +1,18 @@
+- **A usage read that fails on the credential now says so, instead of returning
+  a silent null.** Two branches in the Claude usage fetch — no readable
+  credential, and a locally-expired one — returned `{ snapshot: null, error:
+  null }`. The caller could not tell that apart from a healthy read, so it fell
+  back to whatever the stale-while-revalidate cache held and drew those bars as
+  fact. Measured on `yosemite-s1`: every Claude account's stored access token had
+  expired (one of them eleven days earlier), so no read could succeed, and
+  `agents view claude --refresh` printed a full, healthy-looking table twice
+  while writing nothing to the cache. A usage read never refreshes a token
+  (RUSH-1822), so neither state heals on its own — the account stays unreadable
+  until a real `claude` run rotates the credential.
+- **`agents view` marks bars the live read could not confirm.** A row whose
+  snapshot came from the cache after a failed live read renders the reading plus
+  `unverified`, rather than looking identical to a confirmed one. The number
+  still shows — it is the last thing we saw — but it no longer reads as current.
+- **`agents view --refresh` reports what it could not refresh.** It now lists
+  each account it failed to reach and why, instead of rendering a table that
+  looks fully refreshed regardless.

--- a/apps/cli/.changelog/next/usage-read-names-dead-credential.md
+++ b/apps/cli/.changelog/next/usage-read-names-dead-credential.md
@@ -1,14 +1,17 @@
 - **A usage read that fails on the credential now says so, instead of returning
-  a silent null.** Two branches in the Claude usage fetch — no readable
-  credential, and a locally-expired one — returned `{ snapshot: null, error:
-  null }`. The caller could not tell that apart from a healthy read, so it fell
+  a silent null.** Three branches in every networked usage fetch — Claude, Kimi,
+  Droid and Cursor — returned `{ snapshot: null, error: null }`: no readable
+  credential, a locally-expired one, and a rejected request. The caller could
+  not tell any of them apart from a healthy read, so it fell
   back to whatever the stale-while-revalidate cache held and drew those bars as
   fact. Measured on `yosemite-s1`: every Claude account's stored access token had
   expired (one of them eleven days earlier), so no read could succeed, and
   `agents view claude --refresh` printed a full, healthy-looking table twice
   while writing nothing to the cache. A usage read never refreshes a token
-  (RUSH-1822), so neither state heals on its own — the account stays unreadable
-  until a real `claude` run rotates the credential.
+  (RUSH-1822), so an expired credential does not heal on its own — the account
+  stays unreadable until that agent actually runs. A rate-limited endpoint (429)
+  now reads differently from a rejected credential (401), because re-authing
+  fixes one and not the other.
 - **`agents view` marks bars the live read could not confirm.** A row whose
   snapshot came from the cache after a failed live read renders the reading plus
   `unverified`, rather than looking identical to a confirmed one. The number

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -890,9 +890,10 @@ a stable per-account key:
   number as a fact. The cache is strictly per machine and never synced, so a box
   whose refresh is failing would otherwise route on day-old numbers indefinitely.
 - **A read that fails on the credential names the reason.** No readable
-  credential, a locally-expired one, and a rejected request are distinct errors
-  (`usageNoCredentialError` / `usageExpiredCredentialError` /
-  `usageRejectedError`, [`src/lib/usage.ts`](../src/lib/usage.ts)), not a silent
+  credential, a locally-expired one, a rejected request, and a request that threw
+  are distinct errors (`usageNoCredentialError` / `usageExpiredCredentialError` /
+  `usageRejectedError` / `usageUnreachableError`,
+  [`src/lib/usage.ts`](../src/lib/usage.ts)), not a silent
   null. All four networked providers — Claude, Kimi, Droid, Cursor — share them,
   because they share one cache fallback: a silent null in any of them presents a
   stale reading as confirmed. Because a usage read never refreshes a token,

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -890,11 +890,14 @@ a stable per-account key:
   number as a fact. The cache is strictly per machine and never synced, so a box
   whose refresh is failing would otherwise route on day-old numbers indefinitely.
 - **A read that fails on the credential names the reason.** No readable
-  credential and a locally-expired one are distinct errors
-  (`CLAUDE_NO_CREDENTIAL_ERROR` / `CLAUDE_EXPIRED_CREDENTIAL_ERROR`,
-  [`src/lib/usage.ts`](../src/lib/usage.ts)), not a silent null — because a usage
-  read never refreshes a token, neither state heals until a real `claude` run
-  rotates the credential or a long-lived setup-token is provisioned. `agents view`
+  credential, a locally-expired one, and a rejected request are distinct errors
+  (`usageNoCredentialError` / `usageExpiredCredentialError` /
+  `usageRejectedError`, [`src/lib/usage.ts`](../src/lib/usage.ts)), not a silent
+  null. All four networked providers — Claude, Kimi, Droid, Cursor — share them,
+  because they share one cache fallback: a silent null in any of them presents a
+  stale reading as confirmed. Because a usage read never refreshes a token,
+  an expired credential does not heal until that agent actually runs; a 429 reads
+  differently from a 401, since re-authing fixes one and not the other. `agents view`
   renders a cached reading that a failed live read could not confirm as the number
   plus `unverified`, and `--refresh` lists every account it could not reach rather
   than printing a table that looks fully refreshed. Measured on `yosemite-s1`,

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -889,6 +889,17 @@ a stable per-account key:
   reports `usage unverified` in the launch banner rather than presenting a stale
   number as a fact. The cache is strictly per machine and never synced, so a box
   whose refresh is failing would otherwise route on day-old numbers indefinitely.
+- **A read that fails on the credential names the reason.** No readable
+  credential and a locally-expired one are distinct errors
+  (`CLAUDE_NO_CREDENTIAL_ERROR` / `CLAUDE_EXPIRED_CREDENTIAL_ERROR`,
+  [`src/lib/usage.ts`](../src/lib/usage.ts)), not a silent null — because a usage
+  read never refreshes a token, neither state heals until a real `claude` run
+  rotates the credential or a long-lived setup-token is provisioned. `agents view`
+  renders a cached reading that a failed live read could not confirm as the number
+  plus `unverified`, and `--refresh` lists every account it could not reach rather
+  than printing a table that looks fully refreshed. Measured on `yosemite-s1`,
+  where every account's stored token had expired and two `--refresh` runs wrote
+  nothing to the cache while reporting nothing wrong.
 
 What each agent can surface is bounded by what its local credential actually
 contains — this is a data-availability limit, not a policy choice:

--- a/apps/cli/src/commands/versions.ts
+++ b/apps/cli/src/commands/versions.ts
@@ -103,7 +103,7 @@ function fixSessionFilePaths(agent: AgentId, version: string, oldVersionDir: str
   updateSessionFilePaths(oldVersionDir, trashPath);
 }
 
-function formatAccountHint(info: AccountInfo, usage: UsageSnapshot | null): string {
+function formatAccountHint(info: AccountInfo, usage: UsageSnapshot | null, unverified = false): string {
   const parts: string[] = [];
   if (info.email) {
     // Same-email accounts can live in different orgs (personal Max vs a Team
@@ -111,7 +111,7 @@ function formatAccountHint(info: AccountInfo, usage: UsageSnapshot | null): stri
     const badge = accountOrgBadge(info);
     parts.push(badge ? `${info.email} (${badge})` : info.email);
   }
-  const usageSummary = formatUsageSummary(info.plan, usage);
+  const usageSummary = formatUsageSummary(info.plan, usage, 3, { unverified });
   if (usageSummary) parts.push(usageSummary);
   if (parts.length === 0) return '';
   return chalk.gray(` [${parts.join(', ')}]`);
@@ -646,7 +646,10 @@ export function registerVersionsCommands(program: Command): void {
                     cliVersion: installedVersion,
                     info,
                   });
-                  const accountHint = formatAccountHint(info, usage.snapshot);
+                  // This hint sits in a "switch your default to this version?"
+                  // confirm — the one place a stale reading directly steers a
+                  // choice, so it must not present an unconfirmed bar as fact.
+                  const accountHint = formatAccountHint(info, usage.snapshot, !!usage.snapshot && !!usage.error);
 
                   const message = `Switch default from ${agentLabel(agentConfig.id)}@${currentDefault} to ${agentLabel(agentConfig.id)}@${installedVersion}${accountHint}?`;
 
@@ -837,7 +840,12 @@ export function registerVersionsCommands(program: Command): void {
               const accountInfo = pickerAccountMap.get(v);
               const email = accountInfo?.email || '';
               const usageKey = getUsageLookupKey(accountInfo);
-              const usageSummary = usageKey ? formatUsageSummary(null, usageByKey.get(usageKey)?.snapshot || null) : '';
+              const versionUsage = usageKey ? usageByKey.get(usageKey) : undefined;
+              const usageSummary = usageKey
+                ? formatUsageSummary(null, versionUsage?.snapshot || null, 3, {
+                    unverified: !!versionUsage?.snapshot && !!versionUsage.error,
+                  })
+                : '';
 
               if (maxEmailLen > 0) {
                 label += '  ';

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -732,7 +732,9 @@ async function showInstalledVersions(
       const parts = [`    ${verLabel}${padding}`];
       const gUsageKey = getUsageLookupKey(gInfo);
       const gUsage = gUsageKey ? usageByKey.get(gUsageKey) : undefined;
-      const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null);
+      const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null, 3, {
+        unverified: !!gUsage?.snapshot && !!gUsage.error,
+      });
       const gActiveStr = gInfo ? formatLastActive(gInfo.lastActive) : '';
       if (gInfo?.email || gUsageStr || gActiveStr || gInfo?.signedIn) {
         const gDisplay = accountColumnLabel(gInfo);

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -560,7 +560,8 @@ async function showInstalledVersions(
         const usageKey = getUsageLookupKey(info);
         const usageInfo = usageKey ? usageByKey.get(usageKey) : undefined;
         const usageUnavailable = agentReportsUsage(agentId) && !!info?.signedIn && !usageInfo?.snapshot;
-        const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable });
+        const usageUnverified = !!usageInfo?.snapshot && !!usageInfo.error;
+        const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable, unverified: usageUnverified });
         maxUsageWidth = Math.max(maxUsageWidth, visibleWidth(usageStr));
         const statusStr = formatUsageStatusBadge(info?.usageStatus);
         maxStatusWidth = Math.max(maxStatusWidth, visibleWidth(statusStr));
@@ -618,7 +619,8 @@ async function showInstalledVersions(
         const hasEmail = !!vInfo?.email;
         const signedIn = !!vInfo?.signedIn;
         const usageUnavailable = agentReportsUsage(agentId) && signedIn && !usageInfo?.snapshot;
-        const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable });
+        const usageUnverified = !!usageInfo?.snapshot && !!usageInfo.error;
+        const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable, unverified: usageUnverified });
         const hasUsage = usageStr.length > 0;
         // Only show lastActive for versions with an actual logged-in account.
         // Otherwise it reflects install time (misleading "just now" for fresh installs).
@@ -779,6 +781,26 @@ async function showInstalledVersions(
     console.log(chalk.gray('  No agent CLIs installed.'));
     console.log(chalk.gray('  Run: agents add claude@latest'));
     console.log();
+  }
+
+  // `--refresh` used to print a table that looked fully refreshed no matter how
+  // many accounts it had failed to reach, so a box whose every Claude credential
+  // had expired rendered identically to a healthy one — the bars beside each row
+  // came from a cache that the run had not managed to update. Name the accounts
+  // it could not confirm, and why.
+  if (viewOpts?.forceRefresh) {
+    const unrefreshed: string[] = [];
+    for (const [key, usage] of usageByKey) {
+      if (!usage.error) continue;
+      const label = canonicalByUsageKey.get(key)?.email ?? key;
+      unrefreshed.push(`    ${label.padEnd(24)} ${chalk.gray(usage.error)}`);
+    }
+    if (unrefreshed.length > 0) {
+      const noun = unrefreshed.length === 1 ? 'account' : 'accounts';
+      console.log(chalk.yellow(`  Could not refresh ${unrefreshed.length} ${noun} — bars above are the last cached reading:`));
+      for (const line of unrefreshed) console.log(line);
+      console.log();
+    }
   }
 
   // Host CLIs are host-global, not per-agent — show them once in the overview.

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -420,3 +420,34 @@ describe('every networked provider names the same three failures', () => {
     expect(usageExpiredCredentialError('Droid')).toContain('never refreshes');
   });
 });
+
+describe('a usage read that THROWS is still a failed read', () => {
+  // The re-review caught this: every provider swallowed a thrown request into
+  // `error: null`, so a timeout, a TLS failure, or a payload that will not parse
+  // handed the caller a stale snapshot to render as confirmed — the same silence
+  // as an expired token, through a different door.
+  //
+  // Driven through a real provider fetch (Kimi) with a credential file that
+  // cannot be parsed: JSON.parse throws inside the try, so the catch is the code
+  // under test and no network call is made.
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-usage-throw-'));
+    const dir = path.join(home, '.kimi-code', 'credentials');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'kimi-code.json'), '{ not json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('names the agent and carries the cause, instead of returning null', async () => {
+    const usage = await getUsageInfo('kimi', { home });
+
+    expect(usage.snapshot).toBeNull();
+    expect(usage.error).toBeTruthy();
+    expect(usage.error).toContain('Kimi');
+  });
+});

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService, swrWindowMsFor } from './usage.js';
+import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService, swrWindowMsFor, getUsageInfo, formatUsageSummary, CLAUDE_NO_CREDENTIAL_ERROR, CLAUDE_EXPIRED_CREDENTIAL_ERROR } from './usage.js';
 import { setKeychainToken, setKeychainBackendForTest, secretsKeychainItem, type KeychainBackend } from './secrets/index.js';
 import { writeBundle, keychainRef, bundleItemStore } from './secrets/bundles.js';
 import { _resetFileStoreForTest } from './secrets/filestore.js';
@@ -295,5 +295,95 @@ describe('swrWindowMsFor — a routing decision does not get day-old data', () =
 
   it('clamps a negative age to zero — that IS an opinion: never serve the cache', () => {
     expect(swrWindowMsFor(-1)).toBe(0);
+  });
+});
+
+describe('a Claude usage read reports WHY it produced no snapshot', () => {
+  // Both of these returned `error: null` before, which is what let an account
+  // nobody could read render exactly like a healthy one: the caller fell back to
+  // the SWR cache and drew its bars as fact. On yosemite-s1 that hid five
+  // accounts whose stored token had expired — one of them eleven days earlier —
+  // behind a cache frozen for 26h, and balanced routing launched into an account
+  // that was already at its weekly cap.
+  //
+  // Neither path reaches the network: both return before the fetch, so these
+  // exercise the real code path with no live call.
+
+  /** Keychain backend holding exactly what the test seeds — nothing else. */
+  class MemBackend implements KeychainBackend {
+    store = new Map<string, string>();
+    has(item: string) { return this.store.has(item); }
+    get(item: string) {
+      const v = this.store.get(item);
+      if (v === undefined) throw new Error(`missing ${item}`);
+      return v;
+    }
+    set(item: string, value: string) { this.store.set(item, value); }
+    delete(item: string) { return this.store.delete(item); }
+    list(prefix: string) { return [...this.store.keys()].filter((k) => k.startsWith(prefix)); }
+  }
+
+  let home: string;
+  let prevBackend: KeychainBackend | null;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-usage-err-'));
+    prevBackend = setKeychainBackendForTest(new MemBackend());
+  });
+
+  afterEach(() => {
+    setKeychainBackendForTest(prevBackend);
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('names a missing credential instead of returning a silent null', async () => {
+    const usage = await getUsageInfo('claude', { home });
+
+    expect(usage.snapshot).toBeNull();
+    expect(usage.error).toBe(CLAUDE_NO_CREDENTIAL_ERROR);
+  });
+
+  it('names an expired credential — the state a usage read can never heal', async () => {
+    // A usage read never refreshes (RUSH-1822), so this account stays unreadable
+    // until a real claude run rotates the token. Saying so is the whole point.
+    setKeychainToken(
+      getClaudeKeychainService(home),
+      JSON.stringify({
+        claudeAiOauth: { accessToken: 'tok-stale', refreshToken: 'r', expiresAt: Date.now() - 60_000 },
+      })
+    );
+
+    const usage = await getUsageInfo('claude', { home });
+
+    expect(usage.snapshot).toBeNull();
+    expect(usage.error).toBe(CLAUDE_EXPIRED_CREDENTIAL_ERROR);
+  });
+});
+
+describe('formatUsageSummary marks bars the live read could not confirm', () => {
+  const snapshot = {
+    source: 'cache' as const,
+    sourceLabel: 'cached',
+    capturedAt: new Date(NOW),
+    windows: [
+      { key: 'week' as const, label: 'Current week', shortLabel: 'W', usedPercent: 48, resetsAt: null, windowMinutes: 10080 },
+    ],
+  };
+
+  it('draws the bars AND says they are unverified', () => {
+    // The incident in one assertion: a cached "48%" must never render the same
+    // as a confirmed one. The number still shows — it is the last thing we saw,
+    // and hiding it would be worse — but it no longer reads as current.
+    const out = formatUsageSummary(null, snapshot, 3, { unverified: true });
+
+    expect(out).toContain('48%');
+    expect(out).toContain('unverified');
+  });
+
+  it('stays clean when the reading was confirmed', () => {
+    const out = formatUsageSummary(null, snapshot, 3);
+
+    expect(out).toContain('48%');
+    expect(out).not.toContain('unverified');
   });
 });

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService, swrWindowMsFor, getUsageInfo, formatUsageSummary, CLAUDE_NO_CREDENTIAL_ERROR, CLAUDE_EXPIRED_CREDENTIAL_ERROR } from './usage.js';
+import { claudeAccessTokenNeedsRefresh, claudeUsageAccessTokenNoRefresh, loadClaudeOauth, saveClaudeOauth, getClaudeKeychainService, swrWindowMsFor, getUsageInfo, formatUsageSummary, usageNoCredentialError, usageExpiredCredentialError, usageRejectedError } from './usage.js';
 import { setKeychainToken, setKeychainBackendForTest, secretsKeychainItem, type KeychainBackend } from './secrets/index.js';
 import { writeBundle, keychainRef, bundleItemStore } from './secrets/bundles.js';
 import { _resetFileStoreForTest } from './secrets/filestore.js';
@@ -340,7 +340,7 @@ describe('a Claude usage read reports WHY it produced no snapshot', () => {
     const usage = await getUsageInfo('claude', { home });
 
     expect(usage.snapshot).toBeNull();
-    expect(usage.error).toBe(CLAUDE_NO_CREDENTIAL_ERROR);
+    expect(usage.error).toBe(usageNoCredentialError('Claude'));
   });
 
   it('names an expired credential — the state a usage read can never heal', async () => {
@@ -356,7 +356,7 @@ describe('a Claude usage read reports WHY it produced no snapshot', () => {
     const usage = await getUsageInfo('claude', { home });
 
     expect(usage.snapshot).toBeNull();
-    expect(usage.error).toBe(CLAUDE_EXPIRED_CREDENTIAL_ERROR);
+    expect(usage.error).toBe(usageExpiredCredentialError('Claude'));
   });
 });
 
@@ -385,5 +385,38 @@ describe('formatUsageSummary marks bars the live read could not confirm', () => 
 
     expect(out).toContain('48%');
     expect(out).not.toContain('unverified');
+  });
+});
+
+describe('every networked provider names the same three failures', () => {
+  // The review that caught this: wiring only Claude would leave `agents view
+  // --refresh` reporting Claude accounts while silently presenting stale Kimi,
+  // Droid, and Cursor readings as confirmed — all four share one cache fallback
+  // in getUsageInfoForIdentity, so a silent null in any of them reproduces the
+  // exact bug this change exists to close.
+  const NETWORKED = ['Claude', 'Kimi', 'Droid', 'Cursor'];
+
+  it('says which agent could not be read, so a fleet row is actionable', () => {
+    for (const agent of NETWORKED) {
+      expect(usageNoCredentialError(agent)).toContain(agent);
+      expect(usageExpiredCredentialError(agent)).toContain(agent);
+      expect(usageRejectedError(agent, 401)).toContain(agent);
+    }
+  });
+
+  it('distinguishes a rejected read from a throttled one', () => {
+    // 429 is the machine being rate-limited on the usage endpoint, not a dead
+    // credential — re-authing would not fix it, so the two must not read alike.
+    expect(usageRejectedError('Claude', 429)).toContain('429');
+    expect(usageRejectedError('Claude', 429)).toContain('rate-limiting');
+    expect(usageRejectedError('Claude', 401)).toContain('401');
+    expect(usageRejectedError('Claude', 401)).not.toContain('rate-limiting');
+  });
+
+  it('says an expired credential will not heal on its own', () => {
+    // The yosemite-s1 state: a usage read never refreshes, so the account stays
+    // unreadable until the agent itself runs. The message has to say so, or the
+    // obvious next action (re-auth) is not obvious.
+    expect(usageExpiredCredentialError('Droid')).toContain('never refreshes');
   });
 });

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -37,22 +37,36 @@ const CLAUDE_OAUTH_BETA_HEADER = 'oauth-2025-04-20';
 const CLAUDE_REFRESH_LEEWAY_MS = 5 * 60 * 1000;
 
 /**
- * Why a Claude usage read produced no snapshot, when the cause is the credential
- * rather than the network. Both cases used to return `error: null`, which made an
- * account nobody can read indistinguishable from a healthy one: the caller fell
- * back to whatever was in the SWR cache and rendered its bars as fact. On
- * `yosemite-s1` that hid five accounts whose stored access token had expired —
- * one of them eleven days earlier — behind a cache frozen for 26h, and balanced
- * routing launched into an account that was actually at its weekly cap.
+ * Why a usage read produced no snapshot, when the cause is the credential or the
+ * server rather than the payload. Every provider used to return `error: null`
+ * for all three, which made an account nobody can read indistinguishable from a
+ * healthy one: the caller fell back to whatever was in the SWR cache and
+ * rendered its bars as fact. On `yosemite-s1` that hid five Claude accounts
+ * whose stored access token had expired — one of them eleven days earlier —
+ * behind a cache frozen for 26h, and balanced routing launched into an account
+ * that was actually at its weekly cap.
  *
- * A usage read never refreshes a token (RUSH-1822), so neither state can heal on
- * its own: the account stays unreadable until a real `claude` run rotates the
- * credential, or a long-lived setup-token is provisioned for it.
+ * No usage read ever refreshes a token (RUSH-1822 for Claude; the same rule for
+ * Kimi/Droid/Cursor, whose own CLIs rotate on their next launch), so an expired
+ * credential cannot heal on its own — the account stays unreadable until that
+ * agent actually runs, or a long-lived token is provisioned for it.
+ *
+ * Shared across all four networked providers on purpose: the failure shape is
+ * identical, and wiring only Claude would leave `agents view --refresh`
+ * reporting Claude accounts while silently presenting stale Kimi, Droid, and
+ * Cursor readings as confirmed.
  */
-export const CLAUDE_NO_CREDENTIAL_ERROR =
-  'No readable Claude credential — sign in, or provision a setup-token for this account.';
-export const CLAUDE_EXPIRED_CREDENTIAL_ERROR =
-  'Claude credential expired — re-auth this account (a usage read never refreshes it).';
+export function usageNoCredentialError(agent: string): string {
+  return `No readable ${agent} credential — sign in, or provision a long-lived token for this account.`;
+}
+export function usageExpiredCredentialError(agent: string): string {
+  return `${agent} credential expired — re-auth this account (a usage read never refreshes it).`;
+}
+export function usageRejectedError(agent: string, status: number): string {
+  return status === 429
+    ? `${agent} is rate-limiting the usage endpoint for this machine (HTTP 429).`
+    : `${agent} rejected the usage read (HTTP ${status}).`;
+}
 
 /**
  * True when a Claude OAuth access token is within the refresh leeway of expiry
@@ -660,7 +674,7 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     // path and usage needs only the access token, so it kills the Touch ID storm.
     const oauth = await loadClaudeOauth(options?.home, { accessTokenCache: true });
     if (!oauth?.accessToken) {
-      return { snapshot: null, error: CLAUDE_NO_CREDENTIAL_ERROR };
+      return { snapshot: null, error: usageNoCredentialError('Claude') };
     }
 
     const requestedOrgId = normalizeString(options?.organizationId);
@@ -674,7 +688,7 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     // Read-only: never refresh a single-use token just to read usage (RUSH-1822).
     const accessToken = claudeUsageAccessTokenNoRefresh(oauth);
     if (!accessToken) {
-      return { snapshot: null, error: CLAUDE_EXPIRED_CREDENTIAL_ERROR };
+      return { snapshot: null, error: usageExpiredCredentialError('Claude') };
     }
 
     const response = await fetch(CLAUDE_USAGE_URL, {
@@ -689,7 +703,7 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     });
 
     if (!response.ok) {
-      return { snapshot: null, error: formatClaudeUsageError(response.status) };
+      return { snapshot: null, error: usageRejectedError('Claude', response.status) };
     }
 
     const data = await response.json() as ClaudeUsageResponse;
@@ -763,17 +777,17 @@ function resolveKimiCredentialPath(home?: string): string | null {
 async function getKimiUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
     const credPath = resolveKimiCredentialPath(options?.home);
-    if (!credPath) return { snapshot: null, error: null };
+    if (!credPath) return { snapshot: null, error: usageNoCredentialError('Kimi') };
 
     const cred = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
     const accessToken = cred?.access_token;
     if (typeof accessToken !== 'string' || !accessToken) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: usageNoCredentialError('Kimi') };
     }
 
     const expiresAt = typeof cred?.expires_at === 'number' ? cred.expires_at : null;
     if (expiresAt !== null && Date.now() / 1000 >= expiresAt) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: usageExpiredCredentialError('Kimi') };
     }
 
     const response = await fetch(KIMI_USAGES_URL, {
@@ -785,10 +799,10 @@ async function getKimiUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       signal: AbortSignal.timeout(5000),
     });
 
-    // 401/403/404 => expired token or no Kimi For Coding subscription; render
-    // nothing rather than a misleading empty bar.
+    // 401/403 => expired token, 404 => no Kimi For Coding subscription. Either
+    // way there are no bars to draw, and the status is what tells them apart.
     if (!response.ok) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: usageRejectedError('Kimi', response.status) };
     }
 
     const data = await response.json() as KimiUsagesResponse;
@@ -930,12 +944,12 @@ async function getDroidUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     const cred = decryptDroidAuthPayload(options?.home || os.homedir());
     const accessToken = cred?.access_token;
     if (typeof accessToken !== 'string' || !accessToken) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: usageNoCredentialError('Droid') };
     }
 
     const exp = decodeJwtPayload(accessToken)?.exp;
     if (typeof exp === 'number' && Date.now() / 1000 >= exp) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: usageExpiredCredentialError('Droid') };
     }
 
     const response = await fetch(DROID_USAGE_URL, {
@@ -947,10 +961,9 @@ async function getDroidUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       signal: AbortSignal.timeout(5000),
     });
 
-    // 401 => revoked/expired token; render nothing rather than a misleading
-    // empty bar.
+    // 401 => revoked/expired token. No bars to draw, and the status says why.
     if (!response.ok) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: usageRejectedError('Droid', response.status) };
     }
 
     const data = await response.json() as DroidBillingLimitsResponse;
@@ -1738,14 +1751,6 @@ function getClaudeUserAgent(cliVersion?: string | null): string {
   return cliVersion ? `claude-code/${cliVersion}` : 'claude-code';
 }
 
-/** Map an HTTP status code to a user-facing error message. */
-function formatClaudeUsageError(status: number): string {
-  if (status === 429) {
-    return 'Usage data unavailable right now.';
-  }
-  return 'Could not load usage data right now.';
-}
-
 /** Clamp a numeric value to 0..100, returning null for non-finite values. */
 function normalizePercent(value: number | null | undefined): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
@@ -2068,11 +2073,11 @@ async function getCursorUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
     const base = options?.home || os.homedir();
     const creds = readCursorCredentials(base);
-    if (!creds) return { snapshot: null, error: null };
+    if (!creds) return { snapshot: null, error: usageNoCredentialError('Cursor') };
 
     const exp = decodeJwtPayload(creds.accessToken)?.exp;
     if (typeof exp === 'number' && Date.now() / 1000 >= exp) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: usageExpiredCredentialError('Cursor') };
     }
 
     const url = `${CURSOR_USAGE_URL}?user=${encodeURIComponent(creds.sub)}`;
@@ -2085,9 +2090,9 @@ async function getCursorUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       signal: AbortSignal.timeout(5000),
     });
 
-    // 401/redirect => revoked/expired session; render nothing rather than a
-    // misleading empty bar.
-    if (!response.ok) return { snapshot: null, error: null };
+    // 401/redirect => revoked/expired session. No bars to draw, and the status
+    // says why.
+    if (!response.ok) return { snapshot: null, error: usageRejectedError('Cursor', response.status) };
 
     const data = (await response.json()) as CursorUsageResponse;
     return {

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -37,6 +37,24 @@ const CLAUDE_OAUTH_BETA_HEADER = 'oauth-2025-04-20';
 const CLAUDE_REFRESH_LEEWAY_MS = 5 * 60 * 1000;
 
 /**
+ * Why a Claude usage read produced no snapshot, when the cause is the credential
+ * rather than the network. Both cases used to return `error: null`, which made an
+ * account nobody can read indistinguishable from a healthy one: the caller fell
+ * back to whatever was in the SWR cache and rendered its bars as fact. On
+ * `yosemite-s1` that hid five accounts whose stored access token had expired —
+ * one of them eleven days earlier — behind a cache frozen for 26h, and balanced
+ * routing launched into an account that was actually at its weekly cap.
+ *
+ * A usage read never refreshes a token (RUSH-1822), so neither state can heal on
+ * its own: the account stays unreadable until a real `claude` run rotates the
+ * credential, or a long-lived setup-token is provisioned for it.
+ */
+export const CLAUDE_NO_CREDENTIAL_ERROR =
+  'No readable Claude credential — sign in, or provision a setup-token for this account.';
+export const CLAUDE_EXPIRED_CREDENTIAL_ERROR =
+  'Claude credential expired — re-auth this account (a usage read never refreshes it).';
+
+/**
  * True when a Claude OAuth access token is within the refresh leeway of expiry
  * (or already expired) — i.e. it "would need a refresh" before the next use.
  *
@@ -450,7 +468,7 @@ export function formatUsageSummary(
   plan: string | null,
   snapshot: UsageSnapshot | null,
   planWidth = 3,
-  opts?: { unavailable?: boolean }
+  opts?: { unavailable?: boolean; unverified?: boolean }
 ): string {
   const parts: string[] = [];
 
@@ -476,6 +494,12 @@ export function formatUsageSummary(
       });
     if (windows.length > 0) {
       parts.push(windows.join('  '));
+    }
+    // The bars came from the cache and the live read that should have confirmed
+    // them failed, so they are the last thing we saw — not the current state.
+    // Drawing them unmarked is what let a 26h-old "48% used" read as fact.
+    if (opts?.unverified) {
+      parts.push(chalk.yellow('unverified'));
     }
   } else if (opts?.unavailable) {
     // Signed-in account we could NOT fetch usage for (no live token in a reachable
@@ -636,19 +660,21 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
     // path and usage needs only the access token, so it kills the Touch ID storm.
     const oauth = await loadClaudeOauth(options?.home, { accessTokenCache: true });
     if (!oauth?.accessToken) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: CLAUDE_NO_CREDENTIAL_ERROR };
     }
 
     const requestedOrgId = normalizeString(options?.organizationId);
     const liveOrgId = normalizeString(oauth.organizationUuid);
     if (!isClaudeUsageOrgMatch(requestedOrgId, liveOrgId)) {
+      // Not a fault: this home is signed into a different org than the identity
+      // being read, so there is nothing to report for it.
       return { snapshot: null, error: null };
     }
 
     // Read-only: never refresh a single-use token just to read usage (RUSH-1822).
     const accessToken = claudeUsageAccessTokenNoRefresh(oauth);
     if (!accessToken) {
-      return { snapshot: null, error: null };
+      return { snapshot: null, error: CLAUDE_EXPIRED_CREDENTIAL_ERROR };
     }
 
     const response = await fetch(CLAUDE_USAGE_URL, {

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -67,6 +67,19 @@ export function usageRejectedError(agent: string, status: number): string {
     ? `${agent} is rate-limiting the usage endpoint for this machine (HTTP 429).`
     : `${agent} rejected the usage read (HTTP ${status}).`;
 }
+/**
+ * The read threw rather than answering — a timeout, DNS/TLS failure, a payload
+ * that would not parse, a credential that would not decrypt. Every provider
+ * swallowed these into `error: null`, which is the same silence as an expired
+ * token: the caller renders a stale snapshot as confirmed. The cause is carried
+ * verbatim because these are the failures a user cannot otherwise see.
+ */
+export function usageUnreachableError(agent: string, cause?: unknown): string {
+  const detail = cause instanceof Error ? cause.message : typeof cause === 'string' ? cause : '';
+  return detail
+    ? `${agent} usage read failed: ${detail}`
+    : `${agent} usage read failed.`;
+}
 
 /**
  * True when a Claude OAuth access token is within the refresh leeway of expiry
@@ -721,8 +734,11 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       },
       error: null,
     };
-  } catch {
-    return { snapshot: null, error: 'Usage data unavailable right now.' };
+  } catch (err) {
+    // A thrown request (timeout, DNS, TLS, a malformed payload) is a failed
+    // read like any other — staying silent here would hand the caller a stale
+    // snapshot to render as confirmed, which is the bug this file just closed.
+    return { snapshot: null, error: usageUnreachableError('Claude', err) };
   }
 }
 
@@ -821,8 +837,11 @@ async function getKimiUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       },
       error: null,
     };
-  } catch {
-    return { snapshot: null, error: null };
+  } catch (err) {
+    // A thrown request (timeout, DNS, TLS, a malformed payload) is a failed
+    // read like any other — staying silent here would hand the caller a stale
+    // snapshot to render as confirmed, which is the bug this file just closed.
+    return { snapshot: null, error: usageUnreachableError('Kimi', err) };
   }
 }
 
@@ -981,8 +1000,11 @@ async function getDroidUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       },
       error: null,
     };
-  } catch {
-    return { snapshot: null, error: null };
+  } catch (err) {
+    // A thrown request (timeout, DNS, TLS, a malformed payload) is a failed
+    // read like any other — staying silent here would hand the caller a stale
+    // snapshot to render as confirmed, which is the bug this file just closed.
+    return { snapshot: null, error: usageUnreachableError('Droid', err) };
   }
 }
 
@@ -2104,7 +2126,10 @@ async function getCursorUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
       },
       error: null,
     };
-  } catch {
-    return { snapshot: null, error: null };
+  } catch (err) {
+    // A thrown request (timeout, DNS, TLS, a malformed payload) is a failed
+    // read like any other — staying silent here would hand the caller a stale
+    // snapshot to render as confirmed, which is the bug this file just closed.
+    return { snapshot: null, error: usageUnreachableError('Cursor', err) };
   }
 }


### PR DESCRIPTION
**Bug fix** — a Claude usage read that fails on the *credential* returned `error: null`, so an account nobody can read rendered exactly like a healthy one. Follow-up to #1753, which guarded the symptom; this names the cause. No new command surface.

## What was wrong

Two branches in `getClaudeUsageInfo` returned `{ snapshot: null, error: null }` — no readable credential, and a locally-expired one. Neither reaches the `fetch`, so `formatClaudeUsageError` never runs and no error is produced. `getUsageInfoForIdentity` then takes its last-resort branch and returns `{ snapshot: cached, error: null }`: the caller gets a stale snapshot and no signal that the live read failed.

A usage read never refreshes a token (RUSH-1822), so neither state heals on its own. The account stays unreadable until a real `claude` run rotates the credential.

Measured on `yosemite-s1`, where every Claude account's stored access token has expired:

| version home | account | `expiresAt` | state |
|---|---|---|---|
| 2.1.181 | muqsit@getrush.ai | 2026-07-23T02:02Z | **expired 270h ago** |
| 2.1.207 | muqsit@trp.so | 2026-08-02T05:45Z | expired 27h ago |
| 2.1.170 | muqsitnawaz@icloud.com | 2026-08-02T05:45Z | expired 27h ago |

Two consecutive `agents view claude --refresh` runs on that box printed a full, healthy-looking table and wrote nothing — every `capturedAt` in `~/.agents/.cache/claude-usage.json` stayed at `2026-08-02T04:30Z` / `2026-07-31T15:00Z`. That is the cache #1753's freshness rule was refusing to trust, and this is why it could never become fresh.

## What changed

- **Both causes are named** — `CLAUDE_NO_CREDENTIAL_ERROR` and `CLAUDE_EXPIRED_CREDENTIAL_ERROR`, so the error survives `getUsageInfoForIdentity`'s cache fallback and reaches the caller.
- **`agents view` marks a reading the live read could not confirm.** The row renders the number plus `unverified` instead of looking identical to a confirmed one. The number still shows — it is the last thing we saw, and hiding it would be worse.
- **`agents view --refresh` reports what it could not refresh**, with the reason per account.
- **An org mismatch keeps `error: null`.** That home is signed into a different org than the identity being read — not a fault, nothing to report.

## Run result

`agents view claude --refresh` from this branch, against real accounts on `zion`. `muqsit@getrush.ai` is the account from #1753's incident; its credential is expired here too, so its `100%` is also a stale cached reading — which nothing said before this change:

```
  Claude (balanced)
    2.1.220 (default)  claude-fable-5  muqsitnawaz@gmail.com   Max  S: ██░░░ 38% (13m)  W: █████ 97% (4d)                             1m ago  ● 2m ago
    2.1.219            opus[1m]        dev@getrush.ai          Max  S: █░░░░ 6% (5h)  W: ██░░░ 39% (6d)                               3m ago  ● 2m ago
    2.1.207            opus[1m]        muqsit@getrush.ai       Max  S: ░░░░░ 0% (now)  W: █████ 100% (1d)  unverified   rate-limited  27m ago  ○ 2m ago
    2.1.187            default         muqsit@trp.so           Max  S: █░░░░ 16% (13m)  W: █████ 95% (8h)                             3m ago  ● 2m ago
    2.1.181            opus[1m]        muqsitnawaz@icloud.com  Max  S: ░░░░░ 0% (now)  W: █████ 100% (21h)  unverified  rate-limited  1d ago  ○ 2m ago

  Could not refresh 2 accounts — bars above are the last cached reading:
    muqsitnawaz@icloud.com   Claude credential expired — re-auth this account (a usage read never refreshes it).
    muqsit@getrush.ai        Claude credential expired — re-auth this account (a usage read never refreshes it).
```

The two flagged rows are exactly the two whose auth-health glyph is already `○`, and the three unflagged rows refreshed live.

## Test run

```
src/lib/usage.test.ts   src/lib/rotate.test.ts   src/commands/exec.test.ts   src/lib/__tests__/usage.test.ts
Test Files  4 passed
     Tests  25 + 87 passed
tsc --noEmit            clean
```

New tests hit the real path with no network — both branches return before the `fetch`:

- a temp home with no credential at all → `CLAUDE_NO_CREDENTIAL_ERROR`;
- a home seeded with a real expired token → `CLAUDE_EXPIRED_CREDENTIAL_ERROR`, the state a usage read can never heal;
- `formatUsageSummary` draws a cached `48%` *and* says `unverified`, and stays clean when the reading was confirmed — a cached 48% must never render the same as a verified one.

## Not covered here

This makes the failure visible; it does not make the accounts readable. Two separate follow-ups, both discussed in https://github.com/phnx-labs/agents-cli/pull/1753#issuecomment-5164138132:

- The `auth` bundle on `yosemite-s1` holds "setup-tokens" that are byte-identical to the version homes' short-lived login tokens (same sha256, same `expiresAt`) rather than `claude setup-token` output, so the mechanism meant to survive rotation expires with it. Re-minting them needs an interactive login per account.
- The auth-health cache on that same box reports `HTTP 429` for all five accounts as of today, where a direct request with the token `loadClaudeOauth` returns gets `401`. Unreconciled — if the probe cadence (~3 min per account) is tripping endpoint throttling, that is a different bug from expired credentials.
