### PR TITLE
feat(menubar): project accordion + agent detail submenu

### DIFF
--- a/apps/cli/.changelog/next/menubar-active-accordion.md
+++ b/apps/cli/.changelog/next/menubar-active-accordion.md
@@ -1,8 +1,10 @@
 - **Menu bar ACTIVE: project accordion + session detail submenu.** Projects are
   collapsed by default as a status strip (`▶ agents-cli  ●8 ◐1  zion`); click
-  `▶`/`▼` to fold agents open under the project. Focusing an agent opens a side
-  submenu with linkable detail (work title URL, cwd, Linear ticket, GitHub PR,
-  duration, copy session id) from the warm `sessions --active` cache — expand
-  never re-runs the CLI. Agent rows also chip ticket/PR at a glance. Source:
+  `▶`/`▼` to fold agents open under the project (idle-row caps removed — collapse
+  is the wall protection). Focusing an agent opens a side submenu with linkable
+  detail (work title URL, cwd, Linear ticket, GitHub PR, duration, copy session
+  id) from the warm `sessions --active` cache. Accordion reopen rebuilds from
+  cache only (no teams walk / no CLI schedule). Local/remote uses the same host
+  normalize as CLI `machineId()` so local rows are not mislabeled remote. Source:
   `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`,
   `LocalState.swift`, `Models.swift`.

--- a/apps/cli/.changelog/next/menubar-active-accordion.md
+++ b/apps/cli/.changelog/next/menubar-active-accordion.md
@@ -1,9 +1,8 @@
-- **Menu bar ACTIVE is an accordion: projects collapsed by default, with session
-  detail on fold-open.** The dropdown no longer lists every Claude row under
-  each repo. Each project is one status strip (`agents-cli  ●8 ◐1  zion`); click
-  `▶` to fold it open, click a session to fold open a quick view (work title,
-  local/remote + surface, repo/cwd, Linear ticket / PR when known, duration,
-  session id) built entirely from the warm `sessions --active` cache — expand
-  does not re-run the CLI or re-index transcripts. Source:
+- **Menu bar ACTIVE: project accordion + session detail submenu.** Projects are
+  collapsed by default as a status strip (`▶ agents-cli  ●8 ◐1  zion`); click
+  `▶`/`▼` to fold agents open under the project. Focusing an agent opens a side
+  submenu with linkable detail (work title URL, cwd, Linear ticket, GitHub PR,
+  duration, copy session id) from the warm `sessions --active` cache — expand
+  never re-runs the CLI. Agent rows also chip ticket/PR at a glance. Source:
   `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`,
   `LocalState.swift`, `Models.swift`.

--- a/apps/cli/.changelog/next/menubar-active-accordion.md
+++ b/apps/cli/.changelog/next/menubar-active-accordion.md
@@ -1,0 +1,9 @@
+- **Menu bar ACTIVE is an accordion: projects collapsed by default, with session
+  detail on fold-open.** The dropdown no longer lists every Claude row under
+  each repo. Each project is one status strip (`agents-cli  ●8 ◐1  zion`); click
+  `▶` to fold it open, click a session to fold open a quick view (work title,
+  local/remote + surface, repo/cwd, Linear ticket / PR when known, duration,
+  session id) built entirely from the warm `sessions --active` cache — expand
+  does not re-run the CLI or re-index transcripts. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`,
+  `LocalState.swift`, `Models.swift`.

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -155,10 +155,11 @@ One rule shapes the menu: **attention floats up, context groups down.**
  ├────────────────────────────────────────────────┤
  │ New Session                                ⌘N │   submenu: one entry per agent
  ├────────────────────────────────────────────────┤
- │ ACTIVE · api  ·  1 running                    │   live work grouped by repo;
- │   ● Claude — draining Linear queue          ›  │   rich rows carry the session's
- │ ACTIVE · web  ·  1 running                    │   own title inline
- │   ● Codex — building hero section           ›  │
+ │ ACTIVE · 3 run · 1 idle · 2 projects          │   projects collapsed by default
+ │   ▶ agents-cli  ●2 ◐1  zion                   │   click ▶ to fold open (accordion)
+ │   ▼ web  ●1  zion                             │   ▼ = expanded; sessions under it
+ │     ▶ ● Codex · zion · tmux · 12m             │   click session for detail fold
+ │       local · tmux · repo web · 47m           │   host / ticket / PR / duration
  ├────────────────────────────────────────────────┤
  │ ROUTINES · 16 · next 7:00 PM · 2 paused       │   next few upcoming + failing
  │   ◔ triage-tickets  in 22m                  ›  │   inline; All routines… for
@@ -183,14 +184,17 @@ One rule shapes the menu: **attention floats up, context groups down.**
   wait. Failed / overdue routines and a stopped scheduler append here. Empty
   when nothing needs attention.
 - **New Session** — launches `agents run <agent>` in a new Terminal window.
-- **ACTIVE · \<repo\>** — live work grouped by repo. A session is *running* if
-  its transcript was written in the last 2 minutes, else *idle*. Rich rows show
-  the session's title inline; the row's submenu reveals the working dir. Idle
-  rows cap at 3 per repo; if the cap hides any, a `+ N more idle ›` row exposes
-  the hidden count and opens the rest in a submenu — the header count always
-  matches what's visible + explicit hidden. The `"other"` bucket (sessions with
-  no repo — a dumping-ground group whose rows carry no per-row signal) collapses
-  to a single `ACTIVE · other · N idle ›` row + submenu when it's idle-only.
+- **ACTIVE** — live work as an **accordion**, not a wall of agent rows. Projects
+  are **collapsed by default**; each project row is a status strip
+  (`agents-cli  ●8 ◐1  zion`). Click `▶` to fold the project **open** (`▼`) and
+  list its sessions inline. Click a session to fold open a **detail** block:
+  work title, local/remote + surface (tmux/codium), repo/cwd, Linear ticket /
+  PR when the engine already knows them, duration (started / last active), and
+  a short session id — plus Open… actions (reveal cwd, copy id, open PR/ticket).
+  All of that comes from the warm `sessions --active --local` cache; expand
+  never shells the CLI or re-indexes transcripts. A session is *running* if
+  the engine says so (else *idle*). Work titles prefer the session `topic` over
+  a bare agent name.
 - **ROUTINES** — kept glanceable: the next few upcoming plus any failed, timed-out,
   or overdue routine inline. Failed and timed-out routines include the latest
   failure reason when available; overdue routines are labeled `overdue` even when

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -156,10 +156,9 @@ One rule shapes the menu: **attention floats up, context groups down.**
  │ New Session                                ⌘N │   submenu: one entry per agent
  ├────────────────────────────────────────────────┤
  │ ACTIVE · 3 run · 1 idle · 2 projects          │   projects collapsed by default
- │   ▶ agents-cli  ●2 ◐1  zion                   │   click ▶ to fold open (accordion)
- │   ▼ web  ●1  zion                             │   ▼ = expanded; sessions under it
- │     ▶ ● Codex · zion · tmux · 12m             │   click session for detail fold
- │       local · tmux · repo web · 47m           │   host / ticket / PR / duration
+ │   ▶ agents-cli  ●2 ◐1  zion                   │   accordion: ▶ folds agents open
+ │   ▼ web  ●1  zion                             │
+ │     ● Codex · zion · 12m  ⌥ PR#42 — title   › │   › side submenu = full detail
  ├────────────────────────────────────────────────┤
  │ ROUTINES · 16 · next 7:00 PM · 2 paused       │   next few upcoming + failing
  │   ◔ triage-tickets  in 22m                  ›  │   inline; All routines… for
@@ -184,17 +183,17 @@ One rule shapes the menu: **attention floats up, context groups down.**
   wait. Failed / overdue routines and a stopped scheduler append here. Empty
   when nothing needs attention.
 - **New Session** — launches `agents run <agent>` in a new Terminal window.
-- **ACTIVE** — live work as an **accordion**, not a wall of agent rows. Projects
-  are **collapsed by default**; each project row is a status strip
-  (`agents-cli  ●8 ◐1  zion`). Click `▶` to fold the project **open** (`▼`) and
-  list its sessions inline. Click a session to fold open a **detail** block:
-  work title, local/remote + surface (tmux/codium), repo/cwd, Linear ticket /
-  PR when the engine already knows them, duration (started / last active), and
-  a short session id — plus Open… actions (reveal cwd, copy id, open PR/ticket).
-  All of that comes from the warm `sessions --active --local` cache; expand
-  never shells the CLI or re-indexes transcripts. A session is *running* if
-  the engine says so (else *idle*). Work titles prefer the session `topic` over
-  a bare agent name.
+- **ACTIVE** — **project accordion** + **session detail submenu**. Projects are
+  **collapsed by default** as a status strip (`▶ agents-cli  ●8 ◐1  zion`).
+  Click `▶`/`▼` to fold the project open **inline** and list its agents.
+  Focusing an agent row opens a **side submenu (›)** with richer detail and
+  **linkable actions**: work title (and open URL if the title contains one),
+  local/remote + surface, clickable cwd, Linear ticket, GitHub PR, duration,
+  copy session id, optional preview snippet. Chips on the agent row itself
+  (`🎫 RUSH-…`, `⌥ PR#N`) surface links at a glance. All of that comes from the
+  warm `sessions --active --local` cache; expand never shells the CLI or
+  re-indexes transcripts. Work titles prefer the session `topic` over a bare
+  agent name.
 - **ROUTINES** — kept glanceable: the next few upcoming plus any failed, timed-out,
   or overdue routine inline. Failed and timed-out routines include the latest
   failure reason when available; overdue routines are labeled `overdue` even when

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -28,6 +28,7 @@ enum IssueSelfTest {
         testLinearTicketQuickFilterAndSort()
         testLinearCache()
         testTicketDispatchContract()
+        testActiveDisplay()
         if failures == 0 {
             print("\nALL PASS")
             exit(0)
@@ -532,6 +533,46 @@ enum IssueSelfTest {
                   && scopeArgs.contains("open") && scopeArgs.contains("--cycle")
                   && scopeArgs.contains("all") && scopeArgs.contains("Agents CLI"),
               detail: scopeArgs.joined(separator: " "))
+    }
+
+    // ACTIVE accordion display helpers — title preference, age, locality, summary.
+    private static func testActiveDisplay() {
+        check("topic wins over terminal label and preview",
+              ActiveDisplay.workTitle(topic: "Fix auth", label: "tab", preview: "long dump",
+                                      terminalTitle: "term") == "Fix auth")
+        check("label wins when topic is empty",
+              ActiveDisplay.workTitle(topic: "  ", label: "My tab", preview: "x",
+                                      terminalTitle: nil) == "My tab")
+        check("preview falls back to first line only",
+              ActiveDisplay.workTitle(topic: nil, label: nil,
+                                      preview: "line one\nline two",
+                                      terminalTitle: nil) == "line one")
+        check("empty inputs yield empty work title",
+              ActiveDisplay.workTitle(topic: nil, label: nil, preview: nil,
+                                      terminalTitle: nil).isEmpty)
+
+        let now: Double = 100_000_000
+        check("age seconds", ActiveDisplay.ageLabel(fromMs: now - 15_000, nowMs: now) == "15s")
+        check("age minutes", ActiveDisplay.ageLabel(fromMs: now - 180_000, nowMs: now) == "3m")
+        check("age hours", ActiveDisplay.ageLabel(fromMs: now - 7_200_000, nowMs: now) == "2h")
+        check("missing timestamp is empty", ActiveDisplay.ageLabel(fromMs: nil).isEmpty)
+
+        check("same machine is local",
+              ActiveDisplay.locality(machine: "zion", thisMachine: "zion") == "local")
+        check("other machine is remote",
+              ActiveDisplay.locality(machine: "yosemite-m0", thisMachine: "zion")
+                  == "remote · yosemite-m0")
+
+        let summary = ActiveDisplay.projectSummary(repo: "agents-cli", running: 8, idle: 1,
+                                                   machines: ["zion", "zion"])
+        check("project summary carries counts and single host",
+              summary.contains("agents-cli") && summary.contains("●8")
+                  && summary.contains("◐1") && summary.contains("zion"),
+              detail: summary)
+        let multi = ActiveDisplay.projectSummary(repo: "x", running: 2, idle: 0,
+                                                 machines: ["a", "b"])
+        check("multi-host summary says N hosts",
+              multi.contains("2 hosts"), detail: multi)
     }
 
     // MARK: helpers

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -562,6 +562,21 @@ enum IssueSelfTest {
         check("other machine is remote",
               ActiveDisplay.locality(machine: "yosemite-m0", thisMachine: "zion")
                   == "remote · yosemite-m0")
+        check("nil machine is local (local-only listing)",
+              ActiveDisplay.locality(machine: nil, thisMachine: "zion") == "local")
+        // Parity with CLI machineId()/normalizeHost — engine tags rows as the
+        // short lowercased hostname, never the Sharing computer name.
+        check("normalizeHost strips domain and lowercases",
+              ActiveDisplay.normalizeHost("Zion.local") == "zion")
+        check("normalizeHost collapses non-alphanumerics",
+              ActiveDisplay.normalizeHost("Muqsit's MacBook Pro") == "muqsit-s-macbook-pro")
+        check("thisMachineId honors AGENTS_SYNC_MACHINE_ID",
+              ActiveDisplay.thisMachineId(env: ["AGENTS_SYNC_MACHINE_ID": "ZION.tail"],
+                                          hostname: "other.local") == "zion")
+        check("locality matches after normalize (engine zion vs Host.local)",
+              ActiveDisplay.locality(machine: "zion",
+                                     thisMachine: ActiveDisplay.normalizeHost("Zion.local"))
+                  == "local")
 
         let summary = ActiveDisplay.projectSummary(repo: "agents-cli", running: 8, idle: 1,
                                                    machines: ["zion", "zion"])

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -573,6 +573,11 @@ enum IssueSelfTest {
                                                  machines: ["a", "b"])
         check("multi-host summary says N hosts",
               multi.contains("2 hosts"), detail: multi)
+
+        check("PR number from pull URL",
+              ActiveDisplay.prNumber(from: "https://github.com/org/repo/pull/1753") == "1753")
+        check("PR number nil for non-PR URL",
+              ActiveDisplay.prNumber(from: "https://github.com/org/repo") == nil)
     }
 
     // MARK: helpers

--- a/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
@@ -103,6 +103,16 @@ enum ActiveDisplay {
         }
         return parts.joined(separator: "  ·  ")
     }
+
+    /// Pull `123` from `…/pull/123` or `…/pulls/123`; nil if not a PR URL.
+    static func prNumber(from url: String?) -> String? {
+        guard let url, !url.isEmpty else { return nil }
+        let parts = url.split(separator: "/").map(String.init)
+        guard let i = parts.firstIndex(where: { $0 == "pull" || $0 == "pulls" }),
+              i + 1 < parts.count else { return nil }
+        let n = parts[i + 1].split(separator: "#").first.map(String.init) ?? parts[i + 1]
+        return n.allSatisfy(\.isNumber) ? n : nil
+    }
 }
 
 // One attention sentinel: mtime = when the session flagged, content = the

--- a/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
@@ -80,11 +80,40 @@ enum ActiveDisplay {
         return "\(hr / 24)d"
     }
 
-    /// local vs remote for display. `thisMachine` is the local hostname short form.
+    /// Match CLI `normalizeHost` / `machineId()` so engine-tagged rows (`zion`)
+    /// compare equal to this box. First DNS label, lowercased, non [a-z0-9_-] → `-`.
+    static func normalizeHost(_ raw: String) -> String {
+        let first = raw.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
+            .first.map(String.init) ?? raw
+        let lowered = first.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let mapped = lowered.map { ch -> Character in
+            if ch.isLetter || ch.isNumber || ch == "-" || ch == "_" { return ch }
+            return "-"
+        }
+        let out = String(mapped)
+        return out.isEmpty ? "unknown" : out
+    }
+
+    /// This machine's id — same sources as CLI `machineId()` (env override, else hostname).
+    static func thisMachineId(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        hostname: String = ProcessInfo.processInfo.hostName
+    ) -> String {
+        if let override = env["AGENTS_SYNC_MACHINE_ID"], !override.isEmpty {
+            return normalizeHost(override)
+        }
+        return normalizeHost(hostname)
+    }
+
+    /// local vs remote for display. `thisMachine` must already be normalizeHost'd
+    /// (same form as engine `machine` tags). Nil machine on a local-only listing
+    /// is treated as local — the engine usually stamps machineId, but cold paths
+    /// (terminals.json) may omit it.
     static func locality(machine: String?, thisMachine: String) -> String {
-        guard let machine, !machine.isEmpty else { return "local?" }
-        if machine == thisMachine || machine == "localhost" { return "local" }
-        return "remote · \(machine)"
+        guard let machine, !machine.isEmpty else { return "local" }
+        let m = normalizeHost(machine)
+        if m == thisMachine || m == "localhost" || m == "unknown" { return "local" }
+        return "remote · \(m)"
     }
 
     /// Collapsed project row: `agents-cli  ●8 ◐1  zion`.

--- a/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/LocalState.swift
@@ -22,13 +22,87 @@ enum SessionStatus: String {
 
 struct Session {
     let agent: String
-    let repo: String      // grouping key: working-dir name (falls back to the label)
+    let repo: String      // grouping key: git repo / working-dir name
     let cwd: String?
     let status: SessionStatus
     let context: String   // terminal | teams | cloud
-    let title: String     // what it's doing: terminal label / teams task / cloud prompt
+    let title: String     // what it's doing: topic / terminal label / preview
     let question: String  // what it's waiting on — attention-sentinel content ("" when empty)
     let attentionSinceMs: Double?  // sentinel mtime — when it started waiting
+    /// Process host (zion, yosemite-m0). Nil when unknown.
+    let machine: String?
+    /// Surface on the host (tmux, codium, …).
+    let surface: String?
+    let sessionId: String?
+    let ticketId: String?
+    let prLink: String?
+    let startedAtMs: Double?
+    let lastActivityMs: Double?
+    let preview: String?
+    let owner: String?
+
+    /// Prefer topic/label/preview for "what" — never leave a bare agent name alone
+    /// when the engine already carried a better signal.
+    var workTitle: String {
+        let candidates = [title, preview ?? "", question]
+        for c in candidates {
+            let t = c.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !t.isEmpty { return t }
+        }
+        return ""
+    }
+}
+
+// Pure formatting helpers for the ACTIVE accordion (unit-tested).
+enum ActiveDisplay {
+    /// Prefer engine topic, then terminal label, then a short preview line.
+    static func workTitle(topic: String?, label: String?, preview: String?,
+                          terminalTitle: String?) -> String {
+        for raw in [topic, label, terminalTitle, preview] {
+            guard let s = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty
+            else { continue }
+            // Previews can be multi-paragraph agent dumps — first line only.
+            let first = s.split(whereSeparator: \.isNewline).first.map(String.init) ?? s
+            return first
+        }
+        return ""
+    }
+
+    /// Human duration from an epoch-ms timestamp to now (e.g. "3m", "2h", "1d").
+    static func ageLabel(fromMs: Double?, nowMs: Double = Date().timeIntervalSince1970 * 1000) -> String {
+        guard let fromMs, fromMs > 0, nowMs >= fromMs else { return "" }
+        let sec = Int((nowMs - fromMs) / 1000)
+        if sec < 60 { return "\(max(sec, 0))s" }
+        let min = sec / 60
+        if min < 60 { return "\(min)m" }
+        let hr = min / 60
+        if hr < 48 { return "\(hr)h" }
+        return "\(hr / 24)d"
+    }
+
+    /// local vs remote for display. `thisMachine` is the local hostname short form.
+    static func locality(machine: String?, thisMachine: String) -> String {
+        guard let machine, !machine.isEmpty else { return "local?" }
+        if machine == thisMachine || machine == "localhost" { return "local" }
+        return "remote · \(machine)"
+    }
+
+    /// Collapsed project row: `agents-cli  ●8 ◐1  zion`.
+    static func projectSummary(repo: String, running: Int, idle: Int,
+                               machines: [String]) -> String {
+        var parts: [String] = [repo]
+        var counts: [String] = []
+        if running > 0 { counts.append("●\(running)") }
+        if idle > 0 { counts.append("◐\(idle)") }
+        if !counts.isEmpty { parts.append(counts.joined(separator: " ")) }
+        let hosts = Array(Set(machines.filter { !$0.isEmpty })).sorted()
+        if hosts.count == 1 {
+            parts.append(hosts[0])
+        } else if hosts.count > 1 {
+            parts.append("\(hosts.count) hosts")
+        }
+        return parts.joined(separator: "  ·  ")
+    }
 }
 
 // One attention sentinel: mtime = when the session flagged, content = the
@@ -178,16 +252,26 @@ enum LocalState {
         for a in active {
             let sid = a.sessionId ?? ""
             let mark = sid.isEmpty ? nil : attention[sid]
-            let repo = a.cwd.map { ($0 as NSString).lastPathComponent } ?? ""
+            // Prefer real git repo name over worktree slug / bare last path component.
+            let repo = Self.repoName(from: a.cwd)
+                ?? a.cwd.map { ($0 as NSString).lastPathComponent }
+                ?? ""
             let status: SessionStatus = mark != nil ? .attention
                 : a.status == "running" ? .running
                 : a.status == "input_required" ? .attention
                 : a.status == "queued" ? .queued : .idle
-            out.append(Session(agent: a.kind, repo: repo, cwd: a.cwd, status: status,
+            let work = ActiveDisplay.workTitle(topic: a.topic, label: a.label,
+                                               preview: a.preview,
+                                               terminalTitle: sid.isEmpty ? nil : titles[sid])
+            out.append(Session(agent: a.kind ?? "agent", repo: repo, cwd: a.cwd, status: status,
                                context: a.context ?? "terminal",
-                               title: sid.isEmpty ? "" : (titles[sid] ?? ""),
+                               title: work,
                                question: mark?.text ?? "",
-                               attentionSinceMs: status == .attention ? mark?.sinceMs : nil))
+                               attentionSinceMs: status == .attention ? mark?.sinceMs : nil,
+                               machine: a.machine, surface: a.host, sessionId: a.sessionId,
+                               ticketId: a.ticketId, prLink: a.prLink,
+                               startedAtMs: a.startedAtMs, lastActivityMs: a.lastActivityMs,
+                               preview: a.preview, owner: a.owner))
         }
         return out
     }
@@ -278,7 +362,11 @@ enum LocalState {
                 out.append(Session(agent: kind, repo: repo, cwd: cwd, status: status,
                                    context: "terminal", title: label,
                                    question: mark?.text ?? "",
-                                   attentionSinceMs: status == .attention ? mark?.sinceMs : nil))
+                                   attentionSinceMs: status == .attention ? mark?.sinceMs : nil,
+                                   machine: nil, surface: nil, sessionId: sid.isEmpty ? nil : sid,
+                                   ticketId: nil, prLink: nil,
+                                   startedAtMs: nil, lastActivityMs: nil,
+                                   preview: nil, owner: nil))
             }
         }
         return out
@@ -301,7 +389,11 @@ enum LocalState {
             let repo = Self.repoName(from: cwd) ?? ""
             out.append(Session(agent: agent, repo: repo, cwd: cwd,
                                status: .running, context: "teams", title: task,
-                               question: "", attentionSinceMs: nil))
+                               question: "", attentionSinceMs: nil,
+                               machine: nil, surface: nil, sessionId: id,
+                               ticketId: nil, prLink: nil,
+                               startedAtMs: nil, lastActivityMs: nil,
+                               preview: nil, owner: nil))
         }
         return out
     }
@@ -333,7 +425,11 @@ enum LocalState {
                                status: status, context: "cloud",
                                title: String(prompt.prefix(60)),
                                question: status == .attention ? "needs review" : "",
-                               attentionSinceMs: nil))
+                               attentionSinceMs: nil,
+                               machine: nil, surface: "cloud", sessionId: nil,
+                               ticketId: nil, prLink: nil,
+                               startedAtMs: nil, lastActivityMs: nil,
+                               preview: nil, owner: nil))
         }
         return out
     }

--- a/apps/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -132,11 +132,27 @@ struct DoctorOrphan: Decodable {
 // authoritative live view (terminals, tmux, IDE, headless). Richer coverage than
 // the cheap live-terminals.json file, which only carries extension-registered
 // terminals; used to feed the ACTIVE section from a warm cache.
+//
+// Field names match the engine JSON (camelCase). Optional fields are omitted by
+// some kinds of session (cloud vs tmux); decode must not require them.
 struct ActiveSession: Decodable {
-    let kind: String
+    let kind: String?
     let sessionId: String?
     let cwd: String?
     let status: String       // running | idle | queued | …
     let context: String?
+    /// Host that owns the process (e.g. zion, yosemite-m0).
     let machine: String?
+    /// Surface on that machine: tmux, codium, terminal, …
+    let host: String?
+    /// First-prompt / assigned task — best "what is it doing" signal.
+    let topic: String?
+    /// Latest-turn snippet (can be long; UI trims).
+    let preview: String?
+    let ticketId: String?
+    let prLink: String?
+    let startedAtMs: Double?
+    let lastActivityMs: Double?
+    let owner: String?
+    let label: String?
 }

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -74,12 +74,13 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // cache with NO extra CLI calls. Session *detail* lives in a side submenu (›),
     // not a second accordion level.
     private var expandedProjects = Set<String>()
-    private lazy var thisMachine: String = {
-        Host.current().localizedName
-            ?? ProcessInfo.processInfo.hostName
-                .split(separator: ".").first.map(String.init)
-            ?? "local"
-    }()
+    /// True after a project accordion toggle until menuDidClose schedules reopen.
+    private var pendingAccordionReopen = false
+    /// True for the menuWillOpen that follows accordion reopen — skip CLI schedule
+    /// and the expensive teams scan; rebuild from warm caches only.
+    private var accordionCacheOnlyOpen = false
+    /// Same form as CLI `machineId()` so engine-tagged sessions compare as local.
+    private lazy var thisMachine: String = ActiveDisplay.thisMachineId()
 
     private var densitySetting: Density {
         get {
@@ -294,6 +295,21 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
     // MARK: - Menu
     func menuWillOpen(_ menu: NSMenu) {
+        // Accordion reopen: rebuild purely from warm caches. No teams history
+        // walk, no CLI schedule — expand must stay cheap and not re-shell
+        // `sessions --active`.
+        if accordionCacheOnlyOpen {
+            accordionCacheOnlyOpen = false
+            let sessions = LocalState.sessions(includeTeams: false)
+            let browserTasks = LocalState.browserTasks(limit: 3)
+            let pending = LocalState.pendingDevices()
+            rebuild(menu, sessions: sessions, browserTasks: browserTasks,
+                    recentSessions: cachedRecentSessions, routines: cachedRoutines,
+                    doctor: cachedDoctorOverview, daemonPid: AgentsCLI.daemonPid(),
+                    pending: pending)
+            return
+        }
+
         // Critical path is all cheap disk reads. CLI-backed sections come from
         // warm caches; opening the menu only schedules refreshes for next time.
         let sessions = LocalState.sessions(includeTeams: true)
@@ -311,6 +327,17 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         refreshActiveSessions()
         refreshDoctorOverview()
         refreshWatchdog()
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        // Accordion click dismissed the menu; reopen only AFTER close so
+        // performClick cannot race and toggle the status item shut again.
+        guard pendingAccordionReopen else { return }
+        pendingAccordionReopen = false
+        accordionCacheOnlyOpen = true
+        DispatchQueue.main.async { [weak self] in
+            self?.statusItem.button?.performClick(nil)
+        }
     }
 
     // The one rule: attention floats to the top triage strip (wait-time sorted,
@@ -812,27 +839,8 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         } else {
             expandedProjects.insert(repo)
         }
-        reopenMenu()
-    }
-
-    /// Rebuild the menu from warm caches and re-open it so project accordion
-    /// toggles feel like fold/unfold rather than dismiss. No network / re-index.
-    private func reopenMenu() {
-        guard let menu = statusItem.menu else { return }
-        let cheap = LocalState.sessions(includeTeams: false)
-        let browser = LocalState.browserTasks()
-        let pending = LocalState.pendingDevices()
-        rebuild(menu,
-                sessions: cheap,
-                browserTasks: browser,
-                recentSessions: cachedRecentSessions,
-                routines: cachedRoutines,
-                doctor: cachedDoctorOverview,
-                daemonPid: AgentsCLI.daemonPid(),
-                pending: pending)
-        DispatchQueue.main.async { [weak self] in
-            self?.statusItem.button?.performClick(nil)
-        }
+        // Defer reopen to menuDidClose so performClick cannot race the dismiss.
+        pendingAccordionReopen = true
     }
 
     @objc private func onRevealPath(_ sender: NSMenuItem) {

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -69,6 +69,18 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
+    // ACTIVE accordion state — projects and sessions collapsed by default.
+    // In-memory only (resets on helper restart); toggling rebuilds the menu from
+    // the warm active-session cache with NO extra CLI calls.
+    private var expandedProjects = Set<String>()
+    private var expandedSessions = Set<String>()
+    private lazy var thisMachine: String = {
+        Host.current().localizedName
+            ?? ProcessInfo.processInfo.hostName
+                .split(separator: ".").first.map(String.init)
+            ?? "local"
+    }()
+
     private var densitySetting: Density {
         get {
             // Env override so dump mode can probe a fixed density.
@@ -548,75 +560,68 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         menu.addItem(newItem)
     }
 
-    // Live work grouped by repo: one `ACTIVE · <repo>` header per project, the
-    // repo's sessions clustered under it. Rich rows carry the session's own
-    // title inline (the repo lives in the header, so rows don't repeat it).
+    // Live work as an ACCORDION: projects collapsed by default with a status
+    // strip (●N ◐M · host); click the disclosure (▼/▶) to fold the project open
+    // inline; click a session to fold its detail open. Expand toggles rebuild the
+    // menu from the warm cache — no CLI, no re-index.
     //
-    // Two rendering rules keep the section from walling the menu:
-    //   • The "other" bucket (sessions with no repo) collapses to a single
-    //     clickable section header + submenu when it's idle-only. That's a
-    //     dumping-ground group whose individual rows don't repay their space.
-    //   • Idle rows cap at 3 per repo, but the 4th+ never disappears silently:
-    //     an explicit "+ N more idle" row shows the count with a submenu of
-    //     the rest, so the header count always matches what's on screen.
-    private let idlePerRepoCap = 3
-
+    // (NSMenu has no first-class accordion; we simulate it by re-populating the
+    // menu and re-opening it so the click does not feel like a dead end.)
     private func addActive(_ menu: NSMenu, live: [Session], browserTasks: [BrowserTask], rich: Bool) {
+        let totalRun = live.filter { $0.status == .running }.count
+        let totalIdle = live.count - totalRun
+        let projectCount = Set(live.map { $0.repo.isEmpty ? "other" : $0.repo }).count
+        var head = "ACTIVE"
+        var bits: [String] = []
+        if totalRun > 0 { bits.append("\(totalRun) run") }
+        if totalIdle > 0 { bits.append("\(totalIdle) idle") }
+        if projectCount > 0 { bits.append("\(projectCount) project\(projectCount == 1 ? "" : "s")") }
+        if !bits.isEmpty { head += " · " + bits.joined(separator: " · ") }
+        addSectionTitle(menu, head, color: .secondaryLabelColor)
+
         let groups = Dictionary(grouping: live) { $0.repo.isEmpty ? "other" : $0.repo }
-        for (repo, group) in groups.sorted(by: { $0.key.lowercased() < $1.key.lowercased() }) {
+        // Running projects first, then name — scannable triage order.
+        let orderedKeys = groups.keys.sorted { a, b in
+            let ra = groups[a]!.filter { $0.status == .running }.count
+            let rb = groups[b]!.filter { $0.status == .running }.count
+            if ra != rb { return ra > rb }
+            return a.lowercased() < b.lowercased()
+        }
+
+        for repo in orderedKeys {
+            guard let group = groups[repo] else { continue }
             let running = group.filter { $0.status == .running }.count
             let idle = group.count - running
+            let machines = group.compactMap(\.machine)
+            let open = expandedProjects.contains(repo)
+            let arrow = open ? "▼" : "▶"
+            let summary = ActiveDisplay.projectSummary(repo: repo, running: running,
+                                                       idle: idle, machines: machines)
+            let header = NSMenuItem(title: "  \(arrow)  \(summary)",
+                                    action: #selector(onToggleProject(_:)),
+                                    keyEquivalent: "")
+            header.target = self
+            header.representedObject = repo
+            header.toolTip = open
+                ? "Collapse \(repo)"
+                : "Expand \(repo) — \(group.count) session\(group.count == 1 ? "" : "s")"
+            menu.addItem(header)
 
-            // Collapsed "other" bucket: idle-only groups render as one
-            // interactive section header. No fake ◐ session row — the header
-            // itself carries the count and opens the submenu.
-            if repo == "other" && running == 0 && idle > 0 {
-                let title = "ACTIVE · other  ·  \(idle) idle"
-                let item = statusRow("", .secondaryLabelColor, title)
-                item.submenu = collapsedIdleSubmenu(group, rich: rich)
-                menu.addItem(item)
-                continue
-            }
+            guard open else { continue }
 
-            var title = "ACTIVE · \(repo)"
-            var counts: [String] = []
-            if running > 0 { counts.append("\(running) running") }
-            if idle > 0 { counts.append("\(idle) idle") }
-            if !counts.isEmpty { title += "  ·  " + counts.joined(separator: " · ") }
-            addSectionTitle(menu, title, color: .secondaryLabelColor)
-
-            // Running rows always render; idle rows cap at idlePerRepoCap. If
-            // the cap hides any, an explicit "+ N more idle" row exposes the
-            // hidden count and opens the rest in a submenu.
-            let ordered = group.sorted { a, b in
-                (a.status == .running ? 0 : 1) < (b.status == .running ? 0 : 1)
+            let sessions = group.sorted { a, b in
+                let ra = a.status == .running ? 0 : 1
+                let rb = b.status == .running ? 0 : 1
+                if ra != rb { return ra < rb }
+                return (a.lastActivityMs ?? 0) > (b.lastActivityMs ?? 0)
             }
-            var idleShown = 0
-            var hiddenIdle: [Session] = []
-            for s in ordered {
-                if s.status != .running {
-                    if idleShown >= idlePerRepoCap {
-                        hiddenIdle.append(s)
-                        continue
-                    }
-                    idleShown += 1
-                }
-                let glyph = s.status == .running ? "●" : "◐"
-                let color = s.status == .running ? run : idleC
-                let detail = (rich && !s.title.isEmpty) ? " — \(trim(s.title, 36))" : ""
-                let row = statusRow(glyph, color, "\(LocalState.agentLabel(s.agent))\(detail)")
-                if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
-                menu.addItem(row)
-            }
-            if !hiddenIdle.isEmpty {
-                let moreLabel = "+ \(hiddenIdle.count) more idle"
-                let more = statusRow("", info, moreLabel)
-                more.submenu = collapsedIdleSubmenu(hiddenIdle, rich: rich)
-                menu.addItem(more)
+            for s in sessions {
+                addSessionAccordion(menu, session: s, rich: rich)
             }
         }
+
         if !browserTasks.isEmpty {
-            addSectionTitle(menu, "ACTIVE · Browser", color: .secondaryLabelColor)
+            addSectionTitle(menu, "  Browser", color: .secondaryLabelColor)
             for task in browserTasks {
                 let tabs = task.tabCount == 1 ? "1 tab" : "\(task.tabCount) tabs"
                 let row = statusRow("◦", idleC, "\(trim(task.name, 24)) · \(shortProfile(task.profile)) · \(tabs)")
@@ -626,17 +631,209 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
-    // Submenu for the "+N more idle" row and the collapsed "other" section
-    // header — every hidden session gets a row with agent · title.
-    private func collapsedIdleSubmenu(_ sessions: [Session], rich: Bool) -> NSMenu {
-        let sub = NSMenu()
-        for s in sessions {
-            let detail = (rich && !s.title.isEmpty) ? " — \(trim(s.title, 36))" : ""
-            let row = statusRow("◐", idleC, "\(LocalState.agentLabel(s.agent))\(detail)")
-            if let cwd = s.cwd { row.submenu = revealSubmenu(cwd) }
-            sub.addItem(row)
+    /// One session summary row (+ optional folded detail block under it).
+    private func addSessionAccordion(_ menu: NSMenu, session s: Session, rich: Bool) {
+        let key = sessionKey(s)
+        let open = expandedSessions.contains(key)
+        let arrow = open ? "▼" : "▶"
+        let glyph = s.status == .running ? "●" : (s.status == .attention ? "⚠" : "◐")
+        let color = s.status == .running ? run : (s.status == .attention ? wait : idleC)
+        let agent = LocalState.agentLabel(s.agent)
+        let host = s.machine ?? thisMachine
+        let age = ActiveDisplay.ageLabel(fromMs: s.lastActivityMs ?? s.startedAtMs)
+        let work = s.workTitle
+        var line = "\(arrow) \(glyph) \(agent) · \(host)"
+        if let surface = s.surface, !surface.isEmpty { line += " · \(surface)" }
+        if !age.isEmpty { line += " · \(age)" }
+        if rich && !work.isEmpty && !open {
+            line += " — \(trim(work, 28))"
         }
-        return sub
+
+        let row = statusRow("", color, line)
+        // statusRow builds an attributed title with empty glyph — set plain title
+        // so the disclosure arrow is visible as part of the string.
+        row.title = "    \(line)"
+        row.attributedTitle = NSAttributedString(string: "    \(line)", attributes: [
+            .foregroundColor: NSColor.labelColor,
+            .font: NSFont.menuFont(ofSize: 0),
+        ])
+        row.action = #selector(onToggleSession(_:))
+        row.target = self
+        row.representedObject = key
+        row.toolTip = open ? "Collapse session detail" : "Expand session detail"
+        menu.addItem(row)
+
+        guard open else { return }
+
+        // Detail block — all from the already-cached active payload (no CLI).
+        for line in sessionDetailLines(s) {
+            let item = disabled("       \(line)")
+            item.toolTip = line
+            menu.addItem(item)
+        }
+        // Actions stay available without another expand hop.
+        let actions = NSMenuItem(title: "       Open…", action: nil, keyEquivalent: "")
+        let sub = NSMenu()
+        if let cwd = s.cwd {
+            let reveal = NSMenuItem(title: "Reveal working dir",
+                                    action: #selector(onRevealPath(_:)), keyEquivalent: "")
+            reveal.target = self
+            reveal.representedObject = cwd
+            sub.addItem(reveal)
+        }
+        if let sid = s.sessionId, !sid.isEmpty {
+            let copy = NSMenuItem(title: "Copy session id",
+                                  action: #selector(onCopySessionId(_:)), keyEquivalent: "")
+            copy.target = self
+            copy.representedObject = sid
+            sub.addItem(copy)
+        }
+        if let url = s.prLink, !url.isEmpty {
+            let pr = NSMenuItem(title: "Open pull request",
+                                action: #selector(onOpenURL(_:)), keyEquivalent: "")
+            pr.target = self
+            pr.representedObject = url
+            sub.addItem(pr)
+        }
+        if let ticket = s.ticketId, !ticket.isEmpty {
+            let t = NSMenuItem(title: "Open \(ticket)",
+                               action: #selector(onOpenTicket(_:)), keyEquivalent: "")
+            t.target = self
+            t.representedObject = ticket
+            sub.addItem(t)
+        }
+        if !sub.items.isEmpty {
+            actions.submenu = sub
+            menu.addItem(actions)
+        }
+    }
+
+    private func sessionKey(_ s: Session) -> String {
+        if let sid = s.sessionId, !sid.isEmpty { return sid }
+        return "\(s.agent)|\(s.cwd ?? "")|\(s.title)"
+    }
+
+    /// Quick-view lines for a folded-open session. Pure formatting over cached fields.
+    private func sessionDetailLines(_ s: Session) -> [String] {
+        var lines: [String] = []
+        let work = s.workTitle
+        if !work.isEmpty { lines.append(trim(work, 64)) }
+
+        let locality = ActiveDisplay.locality(machine: s.machine, thisMachine: thisMachine)
+        var whereBits = [locality]
+        if let surface = s.surface, !surface.isEmpty { whereBits.append(surface) }
+        if let owner = s.owner, !owner.isEmpty, !owner.hasPrefix("UNRESOLVED") {
+            whereBits.append(owner)
+        }
+        lines.append(whereBits.joined(separator: " · "))
+
+        if let repo = s.repo.isEmpty ? nil : s.repo {
+            var repoLine = "repo \(repo)"
+            if let cwd = s.cwd { repoLine += " · \(shortHome(cwd))" }
+            lines.append(repoLine)
+        } else if let cwd = s.cwd {
+            lines.append(shortHome(cwd))
+        }
+
+        var links: [String] = []
+        if let t = s.ticketId, !t.isEmpty { links.append(t) }
+        if let pr = s.prLink, !pr.isEmpty {
+            // Prefer a short PR# if the URL ends with /pull/N
+            if let n = pr.split(separator: "/").last, n.allSatisfy(\.isNumber) {
+                links.append("PR#\(n)")
+            } else {
+                links.append("PR")
+            }
+        }
+        if !links.isEmpty { lines.append(links.joined(separator: " · ")) }
+
+        let started = ActiveDisplay.ageLabel(fromMs: s.startedAtMs)
+        let active = ActiveDisplay.ageLabel(fromMs: s.lastActivityMs)
+        var times: [String] = []
+        if !started.isEmpty { times.append("started \(started) ago") }
+        if !active.isEmpty { times.append("active \(active) ago") }
+        if s.status == .running { times.append("running") }
+        else if s.status == .idle { times.append("idle") }
+        else if s.status == .attention { times.append("needs you") }
+        if !times.isEmpty { lines.append(times.joined(separator: " · ")) }
+
+        if let sid = s.sessionId, !sid.isEmpty {
+            lines.append("id \(String(sid.prefix(8)))")
+        }
+        return lines
+    }
+
+    private func shortHome(_ path: String) -> String {
+        let home = NSHomeDirectory()
+        if path.hasPrefix(home) {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+
+    @objc private func onToggleProject(_ sender: NSMenuItem) {
+        guard let repo = sender.representedObject as? String else { return }
+        if expandedProjects.contains(repo) {
+            expandedProjects.remove(repo)
+        } else {
+            expandedProjects.insert(repo)
+        }
+        reopenMenu()
+    }
+
+    @objc private func onToggleSession(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String else { return }
+        if expandedSessions.contains(key) {
+            expandedSessions.remove(key)
+        } else {
+            expandedSessions.insert(key)
+        }
+        reopenMenu()
+    }
+
+    /// Rebuild the menu from warm caches and re-open it so accordion toggles
+    /// feel like fold/unfold rather than dismiss. No network, no sessions re-index.
+    private func reopenMenu() {
+        guard let menu = statusItem.menu else { return }
+        let cheap = LocalState.sessions(includeTeams: false)
+        let browser = LocalState.browserTasks()
+        let pending = LocalState.pendingDevices()
+        rebuild(menu,
+                sessions: cheap,
+                browserTasks: browser,
+                recentSessions: cachedRecentSessions,
+                routines: cachedRoutines,
+                doctor: cachedDoctorOverview,
+                daemonPid: AgentsCLI.daemonPid(),
+                pending: pending)
+        // Re-open after the click closes the menu (next runloop).
+        DispatchQueue.main.async { [weak self] in
+            self?.statusItem.button?.performClick(nil)
+        }
+    }
+
+    @objc private func onRevealPath(_ sender: NSMenuItem) {
+        guard let path = sender.representedObject as? String else { return }
+        AgentsCLI.openPath(path)
+    }
+
+    @objc private func onCopySessionId(_ sender: NSMenuItem) {
+        guard let sid = sender.representedObject as? String else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(sid, forType: .string)
+    }
+
+    @objc private func onOpenURL(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String, let url = URL(string: raw) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func onOpenTicket(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? String else { return }
+        // Linear deep link pattern used elsewhere in the stack.
+        if let url = URL(string: "https://linear.app/getrush/issue/\(id)") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     private func addRecent(_ menu: NSMenu, recentSessions: [RecentSession], rich: Bool) {

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -69,11 +69,11 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
-    // ACTIVE accordion state — projects and sessions collapsed by default.
-    // In-memory only (resets on helper restart); toggling rebuilds the menu from
-    // the warm active-session cache with NO extra CLI calls.
+    // ACTIVE project accordion — projects collapsed by default. In-memory only
+    // (resets on helper restart). Toggling rebuilds from the warm active-session
+    // cache with NO extra CLI calls. Session *detail* lives in a side submenu (›),
+    // not a second accordion level.
     private var expandedProjects = Set<String>()
-    private var expandedSessions = Set<String>()
     private lazy var thisMachine: String = {
         Host.current().localizedName
             ?? ProcessInfo.processInfo.hostName
@@ -560,13 +560,15 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         menu.addItem(newItem)
     }
 
-    // Live work as an ACCORDION: projects collapsed by default with a status
-    // strip (●N ◐M · host); click the disclosure (▼/▶) to fold the project open
-    // inline; click a session to fold its detail open. Expand toggles rebuild the
-    // menu from the warm cache — no CLI, no re-index.
+    // Live work: PROJECT accordion + SESSION side-submenu.
     //
-    // (NSMenu has no first-class accordion; we simulate it by re-populating the
-    // menu and re-opening it so the click does not feel like a dead end.)
+    //   ▶ agents-cli  ●8 ◐1  zion          ← project collapsed (default)
+    //   ▼ agents-cli  ●8 ◐1  zion          ← click folds open inline
+    //       ● Claude · zion · 3m — work… ›  ← agent row; › opens detail submenu
+    //
+    // Project expand is an accordion (▶/▼). Session detail is a native side
+    // submenu so linkable actions and multi-line context don't wall the main menu.
+    // Expand rebuilds from the warm cache only — no CLI, no re-index.
     private func addActive(_ menu: NSMenu, live: [Session], browserTasks: [BrowserTask], rich: Bool) {
         let totalRun = live.filter { $0.status == .running }.count
         let totalIdle = live.count - totalRun
@@ -616,7 +618,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 return (a.lastActivityMs ?? 0) > (b.lastActivityMs ?? 0)
             }
             for s in sessions {
-                addSessionAccordion(menu, session: s, rich: rich)
+                addSessionRow(menu, session: s, rich: rich)
             }
         }
 
@@ -631,136 +633,168 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
-    /// One session summary row (+ optional folded detail block under it).
-    private func addSessionAccordion(_ menu: NSMenu, session s: Session, rich: Bool) {
-        let key = sessionKey(s)
-        let open = expandedSessions.contains(key)
-        let arrow = open ? "▼" : "▶"
+    /// Agent summary under an expanded project. Detail lives in the › submenu
+    /// (linkable ticket/PR/cwd, locality, duration) — not a second accordion.
+    private func addSessionRow(_ menu: NSMenu, session s: Session, rich: Bool) {
         let glyph = s.status == .running ? "●" : (s.status == .attention ? "⚠" : "◐")
         let color = s.status == .running ? run : (s.status == .attention ? wait : idleC)
         let agent = LocalState.agentLabel(s.agent)
         let host = s.machine ?? thisMachine
         let age = ActiveDisplay.ageLabel(fromMs: s.lastActivityMs ?? s.startedAtMs)
         let work = s.workTitle
-        var line = "\(arrow) \(glyph) \(agent) · \(host)"
+
+        // Compact chips on the main row so you see signal without opening ›.
+        var chips: [String] = []
+        if let t = s.ticketId, !t.isEmpty { chips.append("🎫\(t)") }
+        if let pr = ActiveDisplay.prNumber(from: s.prLink) { chips.append("PR#\(pr)") }
+        else if let link = s.prLink, !link.isEmpty { chips.append("PR") }
+
+        var line = "\(glyph) \(agent) · \(host)"
         if let surface = s.surface, !surface.isEmpty { line += " · \(surface)" }
         if !age.isEmpty { line += " · \(age)" }
-        if rich && !work.isEmpty && !open {
-            line += " — \(trim(work, 28))"
-        }
+        if !chips.isEmpty { line += "  " + chips.joined(separator: " ") }
+        if rich && !work.isEmpty { line += " — \(trim(work, 32))" }
 
         let row = statusRow("", color, line)
-        // statusRow builds an attributed title with empty glyph — set plain title
-        // so the disclosure arrow is visible as part of the string.
         row.title = "    \(line)"
-        row.attributedTitle = NSAttributedString(string: "    \(line)", attributes: [
-            .foregroundColor: NSColor.labelColor,
-            .font: NSFont.menuFont(ofSize: 0),
-        ])
-        row.action = #selector(onToggleSession(_:))
-        row.target = self
-        row.representedObject = key
-        row.toolTip = open ? "Collapse session detail" : "Expand session detail"
+        row.attributedTitle = sessionRowTitle(glyph: glyph, glyphColor: color, rest: line)
+        row.submenu = sessionDetailSubmenu(s)
+        row.toolTip = work.isEmpty ? "Session detail" : work
         menu.addItem(row)
+    }
 
-        guard open else { return }
-
-        // Detail block — all from the already-cached active payload (no CLI).
-        for line in sessionDetailLines(s) {
-            let item = disabled("       \(line)")
-            item.toolTip = line
-            menu.addItem(item)
+    /// Status-colored glyph + label for the agent row.
+    private func sessionRowTitle(glyph: String, glyphColor: NSColor, rest: String) -> NSAttributedString {
+        let out = NSMutableAttributedString()
+        let font = NSFont.menuFont(ofSize: 0)
+        out.append(NSAttributedString(string: "    \(glyph) ", attributes: [
+            .foregroundColor: glyphColor, .font: font,
+        ]))
+        // rest already starts with glyph when built above — strip the leading glyph
+        // if present so we don't double it.
+        var body = rest
+        for prefix in ["● ", "◐ ", "⚠ "] {
+            if body.hasPrefix(prefix) { body = String(body.dropFirst(prefix.count)); break }
         }
-        // Actions stay available without another expand hop.
-        let actions = NSMenuItem(title: "       Open…", action: nil, keyEquivalent: "")
+        out.append(NSAttributedString(string: body, attributes: [
+            .foregroundColor: NSColor.labelColor, .font: font,
+        ]))
+        return out
+    }
+
+    /// Side submenu: graphical sections + linkable actions for one session.
+    /// All fields from the warm active payload — no CLI on open.
+    private func sessionDetailSubmenu(_ s: Session) -> NSMenu {
         let sub = NSMenu()
+        let work = s.workTitle
+
+        // ── What ──────────────────────────────────────────────────────────
+        if !work.isEmpty {
+            let head = NSMenuItem(title: "◎  \(trim(work, 72))", action: nil, keyEquivalent: "")
+            head.isEnabled = false
+            head.toolTip = work
+            sub.addItem(head)
+            // If the work title looks like a URL, make it one-click openable.
+            if let url = firstURL(in: work) {
+                let openWork = NSMenuItem(title: "   Open link in work title",
+                                          action: #selector(onOpenURL(_:)), keyEquivalent: "")
+                openWork.target = self
+                openWork.representedObject = url.absoluteString
+                sub.addItem(openWork)
+            }
+            sub.addItem(.separator())
+        }
+
+        // ── Where ─────────────────────────────────────────────────────────
+        let locality = ActiveDisplay.locality(machine: s.machine, thisMachine: thisMachine)
+        let locIcon = locality.hasPrefix("remote") ? "☁" : "💻"
+        var whereLine = "\(locIcon)  \(locality)"
+        if let surface = s.surface, !surface.isEmpty { whereLine += " · \(surface)" }
+        sub.addItem(disabled(whereLine))
+
+        if !s.repo.isEmpty {
+            sub.addItem(disabled("📁  \(s.repo)"))
+        }
         if let cwd = s.cwd {
-            let reveal = NSMenuItem(title: "Reveal working dir",
+            let reveal = NSMenuItem(title: "📂  \(shortHome(cwd))",
                                     action: #selector(onRevealPath(_:)), keyEquivalent: "")
             reveal.target = self
             reveal.representedObject = cwd
+            reveal.toolTip = "Reveal in Finder"
             sub.addItem(reveal)
         }
+
+        // ── Links (ticket / PR) — primary actions, not just labels ────────
+        let hasTicket = !(s.ticketId ?? "").isEmpty
+        let hasPR = !(s.prLink ?? "").isEmpty
+        if hasTicket || hasPR {
+            sub.addItem(.separator())
+            if let ticket = s.ticketId, !ticket.isEmpty {
+                let t = NSMenuItem(title: "🎫  \(ticket)  — open in Linear",
+                                   action: #selector(onOpenTicket(_:)), keyEquivalent: "")
+                t.target = self
+                t.representedObject = ticket
+                sub.addItem(t)
+            }
+            if let pr = s.prLink, !pr.isEmpty {
+                let label: String
+                if let n = ActiveDisplay.prNumber(from: pr) {
+                    label = "🔗  PR#\(n)  — open on GitHub"
+                } else {
+                    label = "🔗  Pull request  — open on GitHub"
+                }
+                let p = NSMenuItem(title: label, action: #selector(onOpenURL(_:)), keyEquivalent: "")
+                p.target = self
+                p.representedObject = pr
+                sub.addItem(p)
+            }
+        }
+
+        // ── Timing / status ───────────────────────────────────────────────
+        sub.addItem(.separator())
+        let started = ActiveDisplay.ageLabel(fromMs: s.startedAtMs)
+        let active = ActiveDisplay.ageLabel(fromMs: s.lastActivityMs)
+        let statusWord: String = {
+            switch s.status {
+            case .running: return "● running"
+            case .idle: return "◐ idle"
+            case .attention: return "⚠ needs you"
+            case .queued: return "queued"
+            }
+        }()
+        var timeLine = statusWord
+        if !started.isEmpty { timeLine += " · started \(started) ago" }
+        if !active.isEmpty { timeLine += " · active \(active) ago" }
+        sub.addItem(disabled("⏱  \(timeLine)"))
+
+        if let owner = s.owner, !owner.isEmpty, !owner.hasPrefix("UNRESOLVED") {
+            sub.addItem(disabled("👤  \(owner)"))
+        }
         if let sid = s.sessionId, !sid.isEmpty {
-            let copy = NSMenuItem(title: "Copy session id",
+            let copy = NSMenuItem(title: "⧉  Copy session id  (\(String(sid.prefix(8)))…)",
                                   action: #selector(onCopySessionId(_:)), keyEquivalent: "")
             copy.target = self
             copy.representedObject = sid
             sub.addItem(copy)
         }
-        if let url = s.prLink, !url.isEmpty {
-            let pr = NSMenuItem(title: "Open pull request",
-                                action: #selector(onOpenURL(_:)), keyEquivalent: "")
-            pr.target = self
-            pr.representedObject = url
-            sub.addItem(pr)
+
+        // Latest preview snippet (trimmed) — optional context, not a wall.
+        if let preview = s.preview?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !preview.isEmpty, preview != work {
+            sub.addItem(.separator())
+            let snip = disabled("💬  \(trim(preview, 80))")
+            snip.toolTip = preview
+            sub.addItem(snip)
         }
-        if let ticket = s.ticketId, !ticket.isEmpty {
-            let t = NSMenuItem(title: "Open \(ticket)",
-                               action: #selector(onOpenTicket(_:)), keyEquivalent: "")
-            t.target = self
-            t.representedObject = ticket
-            sub.addItem(t)
-        }
-        if !sub.items.isEmpty {
-            actions.submenu = sub
-            menu.addItem(actions)
-        }
+
+        return sub
     }
 
-    private func sessionKey(_ s: Session) -> String {
-        if let sid = s.sessionId, !sid.isEmpty { return sid }
-        return "\(s.agent)|\(s.cwd ?? "")|\(s.title)"
-    }
-
-    /// Quick-view lines for a folded-open session. Pure formatting over cached fields.
-    private func sessionDetailLines(_ s: Session) -> [String] {
-        var lines: [String] = []
-        let work = s.workTitle
-        if !work.isEmpty { lines.append(trim(work, 64)) }
-
-        let locality = ActiveDisplay.locality(machine: s.machine, thisMachine: thisMachine)
-        var whereBits = [locality]
-        if let surface = s.surface, !surface.isEmpty { whereBits.append(surface) }
-        if let owner = s.owner, !owner.isEmpty, !owner.hasPrefix("UNRESOLVED") {
-            whereBits.append(owner)
-        }
-        lines.append(whereBits.joined(separator: " · "))
-
-        if let repo = s.repo.isEmpty ? nil : s.repo {
-            var repoLine = "repo \(repo)"
-            if let cwd = s.cwd { repoLine += " · \(shortHome(cwd))" }
-            lines.append(repoLine)
-        } else if let cwd = s.cwd {
-            lines.append(shortHome(cwd))
-        }
-
-        var links: [String] = []
-        if let t = s.ticketId, !t.isEmpty { links.append(t) }
-        if let pr = s.prLink, !pr.isEmpty {
-            // Prefer a short PR# if the URL ends with /pull/N
-            if let n = pr.split(separator: "/").last, n.allSatisfy(\.isNumber) {
-                links.append("PR#\(n)")
-            } else {
-                links.append("PR")
-            }
-        }
-        if !links.isEmpty { lines.append(links.joined(separator: " · ")) }
-
-        let started = ActiveDisplay.ageLabel(fromMs: s.startedAtMs)
-        let active = ActiveDisplay.ageLabel(fromMs: s.lastActivityMs)
-        var times: [String] = []
-        if !started.isEmpty { times.append("started \(started) ago") }
-        if !active.isEmpty { times.append("active \(active) ago") }
-        if s.status == .running { times.append("running") }
-        else if s.status == .idle { times.append("idle") }
-        else if s.status == .attention { times.append("needs you") }
-        if !times.isEmpty { lines.append(times.joined(separator: " · ")) }
-
-        if let sid = s.sessionId, !sid.isEmpty {
-            lines.append("id \(String(sid.prefix(8)))")
-        }
-        return lines
+    private func firstURL(in text: String) -> URL? {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return detector.firstMatch(in: text, options: [], range: range)?.url
     }
 
     private func shortHome(_ path: String) -> String {
@@ -781,18 +815,8 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         reopenMenu()
     }
 
-    @objc private func onToggleSession(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String else { return }
-        if expandedSessions.contains(key) {
-            expandedSessions.remove(key)
-        } else {
-            expandedSessions.insert(key)
-        }
-        reopenMenu()
-    }
-
-    /// Rebuild the menu from warm caches and re-open it so accordion toggles
-    /// feel like fold/unfold rather than dismiss. No network, no sessions re-index.
+    /// Rebuild the menu from warm caches and re-open it so project accordion
+    /// toggles feel like fold/unfold rather than dismiss. No network / re-index.
     private func reopenMenu() {
         guard let menu = statusItem.menu else { return }
         let cheap = LocalState.sessions(includeTeams: false)
@@ -806,7 +830,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 doctor: cachedDoctorOverview,
                 daemonPid: AgentsCLI.daemonPid(),
                 pending: pending)
-        // Re-open after the click closes the menu (next runloop).
         DispatchQueue.main.async { [weak self] in
             self?.statusItem.button?.performClick(nil)
         }
@@ -830,7 +853,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
     @objc private func onOpenTicket(_ sender: NSMenuItem) {
         guard let id = sender.representedObject as? String else { return }
-        // Linear deep link pattern used elsewhere in the stack.
         if let url = URL(string: "https://linear.app/getrush/issue/\(id)") {
             NSWorkspace.shared.open(url)
         }


### PR DESCRIPTION
**Feature** — ACTIVE projects accordion-fold open; each agent’s detail is a **side submenu** with linkable context.

## Interaction model

| Level | Pattern | What you get |
|-------|---------|----------------|
| **Project** | Accordion `▶` / `▼` | Status strip; fold agent list **under** the row |
| **Agent** | Side submenu `›` | Full session quick-view + clickable links |

```
ACTIVE · 11 run · 3 idle · 4 projects
  ▶ agents-cli  ·  ●8 ◐1  ·  zion
  ▼ web  ·  ●1  ·  zion
      ● Claude · zion · tmux · 12m  PR#42 — Fix routing…  ›
```

## Agent submenu (graphical + linkable)

Built only from warm `sessions --active` fields (no extra CLI on open):

- **◎ Work title** — open URL if the title contains one  
- **💻/☁ local · remote** + surface (tmux/codium)  
- **📁 repo** · **📂 cwd** (click → Reveal in Finder)  
- **🎫 Linear ticket** / **🔗 PR#N** (one-click open)  
- **⏱** status · started/active ages  
- **⧉** copy session id  
- **💬** short preview snippet when useful  

Main agent row also **chips** `🎫RUSH-…` / `PR#N` so you see links without opening `›`.

## Performance

Project accordion toggles only rebuild the menu from the **existing warm cache**. Session `›` is pure AppKit — no shell, no re-index, no fleet fan-out.

## Verification

`MENUBAR_ISSUE_TEST=1` on zion: **ALL PASS** (ActiveDisplay + PR number helpers).  
`swift build` clean on zion.

no-surface — menubar NSMenu; self-test is the run proof.
