### PR TITLE
feat(watchdog): per-session presence tracking (RUSH-2007 Layer C)

### DIFF
--- a/apps/cli/.changelog/next/rush2007-layer-c-presence.md
+++ b/apps/cli/.changelog/next/rush2007-layer-c-presence.md
@@ -1,0 +1,11 @@
+- **`agents watchdog` now tracks per-session presence (RUSH-2007 Layer C).** Each
+  tick reconciles a per-session presence record — `{location, device, transport,
+  lastSeen, status}` at `~/.agents/.cache/state/watchdog/presence.json` — from the
+  tick's active scan, deriving `connected` / `disconnected` by diffing consecutive
+  ticks. A session that was tracked but is now absent (its SSH link dropped or the
+  peer went unreachable) flips to `disconnected`, and the flip is surfaced in
+  `agents watchdog --json` under `presence.transitions` — an interactive drop as a
+  `reconnect-nudge` candidate, a headless remote as `keep-alive`. Folded into the
+  existing tick (no revived daemon, no extra SSH fan-out); additive and does not
+  change the tick's nudge decisions. Source:
+  `apps/cli/src/lib/session/presence.ts`, `apps/cli/src/lib/watchdog/runner.ts`.

--- a/apps/cli/src/lib/session/presence.test.ts
+++ b/apps/cli/src/lib/session/presence.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  reconcilePresence,
+  actionFor,
+  observedFromActive,
+  loadPresence,
+  savePresence,
+  presenceFilePath,
+  PRESENCE_TTL_MS,
+  type ObservedSession,
+  type PresenceRecord,
+} from './presence.js';
+
+const obs = (o: Partial<ObservedSession> & { sessionId: string }): ObservedSession => ({
+  agent: 'codex',
+  location: 'ssh',
+  device: 'yosemite-s0',
+  transport: 'ssh',
+  interactive: true,
+  ...o,
+});
+
+const rec = (r: Partial<PresenceRecord> & { sessionId: string }): PresenceRecord => ({
+  agent: 'codex',
+  location: 'ssh',
+  device: 'yosemite-s0',
+  transport: 'ssh',
+  interactive: true,
+  lastSeenMs: 1_000,
+  status: 'connected',
+  ...r,
+});
+
+describe('reconcilePresence (RUSH-2007 Layer C state machine)', () => {
+  it('marks an observed session connected and stamps lastSeen = now', () => {
+    const { next, transitions } = reconcilePresence({}, [obs({ sessionId: 'a' })], 5_000);
+    expect(next.a.status).toBe('connected');
+    expect(next.a.lastSeenMs).toBe(5_000);
+    expect(transitions).toHaveLength(0); // first sighting is not a transition
+  });
+
+  it('flips a tracked-but-absent session to disconnected and emits the transition', () => {
+    const prev = { a: rec({ sessionId: 'a', lastSeenMs: 4_000, status: 'connected' }) };
+    const { next, transitions } = reconcilePresence(prev, [], 5_000);
+    expect(next.a.status).toBe('disconnected');
+    expect(next.a.lastSeenMs).toBe(4_000); // last-seen preserved, not bumped
+    expect(transitions).toEqual([
+      expect.objectContaining({ from: 'connected', to: 'disconnected', action: 'reconnect-nudge' }),
+    ]);
+  });
+
+  it('does NOT re-emit a transition for a session already disconnected last tick', () => {
+    const prev = { a: rec({ sessionId: 'a', lastSeenMs: 4_000, status: 'disconnected' }) };
+    const { next, transitions } = reconcilePresence(prev, [], 5_000);
+    expect(next.a.status).toBe('disconnected');
+    expect(transitions).toHaveLength(0); // only the connected->disconnected FLIP fires
+  });
+
+  it('interactive drop -> reconnect-nudge; headless remote drop -> keep-alive; local headless -> none', () => {
+    const prev = {
+      i: rec({ sessionId: 'i', interactive: true, location: 'ssh' }),
+      h: rec({ sessionId: 'h', interactive: false, location: 'ssh' }),
+      l: rec({ sessionId: 'l', interactive: false, location: 'local' }),
+    };
+    const { transitions } = reconcilePresence(prev, [], 5_000);
+    const byId = Object.fromEntries(transitions.map((t) => [t.record.sessionId, t.action]));
+    expect(byId).toEqual({ i: 'reconnect-nudge', h: 'keep-alive', l: 'none' });
+  });
+
+  it('re-observing a disconnected session flips it back to connected', () => {
+    const prev = { a: rec({ sessionId: 'a', lastSeenMs: 4_000, status: 'disconnected' }) };
+    const { next, transitions } = reconcilePresence(prev, [obs({ sessionId: 'a' })], 9_000);
+    expect(next.a.status).toBe('connected');
+    expect(next.a.lastSeenMs).toBe(9_000);
+    expect(transitions).toEqual([
+      expect.objectContaining({ from: 'disconnected', to: 'connected', action: 'none' }),
+    ]);
+  });
+
+  it('prunes a disconnected record once it is older than the TTL', () => {
+    const prev = { a: rec({ sessionId: 'a', lastSeenMs: 1_000, status: 'disconnected' }) };
+    const now = 1_000 + PRESENCE_TTL_MS + 1;
+    const { next, transitions } = reconcilePresence(prev, [], now);
+    expect(next.a).toBeUndefined(); // gone for good
+    expect(transitions).toHaveLength(0);
+  });
+
+  it('keeps a disconnected record that is still within the TTL', () => {
+    const prev = { a: rec({ sessionId: 'a', lastSeenMs: 1_000, status: 'disconnected' }) };
+    const now = 1_000 + PRESENCE_TTL_MS - 1;
+    const { next } = reconcilePresence(prev, [], now);
+    expect(next.a.status).toBe('disconnected');
+  });
+
+  it('actionFor never acts on a connected record', () => {
+    expect(actionFor(rec({ sessionId: 'a', status: 'connected', interactive: true }))).toBe('none');
+  });
+});
+
+describe('observedFromActive (ActiveSession -> ObservedSession adapter)', () => {
+  it('maps a peer session to ssh/location=device and a local one to local/self', () => {
+    const got = observedFromActive(
+      [
+        { sessionId: 'r', kind: 'codex', context: 'terminal', machine: 'yosemite-s0', provenance: { transport: 'ssh' } },
+        { sessionId: 'l', kind: 'claude', context: 'terminal' },
+      ],
+      'this-box',
+    );
+    expect(got).toEqual([
+      { sessionId: 'r', agent: 'codex', location: 'ssh', device: 'yosemite-s0', transport: 'ssh', interactive: true },
+      { sessionId: 'l', agent: 'claude', location: 'local', device: 'this-box', transport: 'local', interactive: true },
+    ]);
+  });
+
+  it('marks only terminal context interactive; headless is not', () => {
+    const got = observedFromActive(
+      [
+        { sessionId: 't', kind: 'codex', context: 'terminal' },
+        { sessionId: 'h', kind: 'codex', context: 'headless' },
+      ],
+      'box',
+    );
+    expect(got.map((o) => [o.sessionId, o.interactive])).toEqual([['t', true], ['h', false]]);
+  });
+
+  it('skips sessions with no id (unaddressable)', () => {
+    expect(observedFromActive([{ kind: 'codex', context: 'terminal' }], 'box')).toEqual([]);
+  });
+
+  it('falls back transport to location when provenance is absent', () => {
+    const [o] = observedFromActive([{ sessionId: 'x', kind: 'codex', context: 'terminal', machine: 'peer' }], 'box');
+    expect(o.transport).toBe('ssh');
+  });
+});
+
+describe('presence store (real filesystem round-trip)', () => {
+  afterEach(() => {
+    try { fs.unlinkSync(presenceFilePath()); } catch { /* absent */ }
+  });
+
+  it('round-trips a record through save/load', () => {
+    const map = { a: rec({ sessionId: 'a', status: 'disconnected', lastSeenMs: 7 }) };
+    savePresence(map);
+    expect(loadPresence()).toEqual(map);
+  });
+
+  it('degrades to an empty store when the file is corrupt', () => {
+    fs.mkdirSync(path.dirname(presenceFilePath()), { recursive: true });
+    fs.writeFileSync(presenceFilePath(), '{not json', 'utf8');
+    expect(loadPresence()).toEqual({});
+  });
+
+  it('returns an empty store when the file is absent', () => {
+    try { fs.unlinkSync(presenceFilePath()); } catch { /* absent */ }
+    expect(loadPresence()).toEqual({});
+  });
+});

--- a/apps/cli/src/lib/session/presence.ts
+++ b/apps/cli/src/lib/session/presence.ts
@@ -1,0 +1,210 @@
+/**
+ * RUSH-2007 Layer C — per-session presence tracking, folded into the `agents
+ * watchdog` tick (NOT a revived daemon).
+ *
+ * Each tick the watchdog observes the active sessions across the fleet
+ * (`gatherRemoteActive` + the local scan). This module persists one record per
+ * session — `{location, device, transport, lastSeen, status}` — and DERIVES
+ * `connected` / `disconnected` by diffing consecutive observations: a session
+ * present this tick is `connected`; one that was tracked but is now absent (its
+ * peer went unreachable, or the interactive client dropped) flips to
+ * `disconnected` while its record — and the transition — is surfaced so the tick
+ * can act (an interactive drop is a reconnect-nudge candidate; a headless remote
+ * is a keep-alive). The store is honest across a crash: it only reflects what the
+ * last scan actually saw, never an asserted state.
+ *
+ * Store: `~/.agents/.cache/state/watchdog/presence.json` — sibling of the tick's
+ * existing `nudges/flags/last-tick` files. Best-effort: an unreadable/corrupt
+ * file degrades to an empty store, never throws into the tick loop.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getRuntimeStateDir } from '../state.js';
+
+export type PresenceStatus = 'connected' | 'disconnected';
+export type PresenceLocation = 'local' | 'ssh';
+
+/** A session as OBSERVED by one tick's active scan — the pure reconcile input. */
+export interface ObservedSession {
+  sessionId: string;
+  agent: string;
+  /** `local` when the session runs on this box, `ssh` when it's on a peer. */
+  location: PresenceLocation;
+  /** The device/host the session runs on (this box's hostname, or the peer). */
+  device: string;
+  /** Transport the session's provenance reports (`local` | `ssh` | ...). */
+  transport: string;
+  /** True for an interactive (terminal/tmux) session — a drop is reconnect-worthy;
+   *  false for a headless remote continuation, where a drop means keep-alive. */
+  interactive: boolean;
+}
+
+export interface PresenceRecord {
+  sessionId: string;
+  agent: string;
+  location: PresenceLocation;
+  device: string;
+  transport: string;
+  interactive: boolean;
+  /** ms of the last tick this session was observed active. */
+  lastSeenMs: number;
+  status: PresenceStatus;
+}
+
+/** What the tick should do about a session that just flipped `disconnected`. */
+export type PresenceAction = 'reconnect-nudge' | 'keep-alive' | 'none';
+
+export interface PresenceTransition {
+  record: PresenceRecord;
+  from: PresenceStatus;
+  to: PresenceStatus;
+  action: PresenceAction;
+}
+
+/** A `disconnected` record older than this is pruned — the session is gone for
+ *  good, not merely between clients. Kept generous so a long reconnect window
+ *  (the reconnect loop's own bounded backoff) never drops a record mid-recovery. */
+export const PRESENCE_TTL_MS = 30 * 60_000; // 30 minutes
+
+/** `presence.json` under the watchdog state dir. `dir` is the watchdog state dir
+ *  (the tick passes its own, overridable in tests); default is the real one. */
+export function presenceFilePath(dir?: string): string {
+  return path.join(dir ?? path.join(getRuntimeStateDir(), 'watchdog'), 'presence.json');
+}
+
+export function loadPresence(dir?: string): Record<string, PresenceRecord> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(presenceFilePath(dir), 'utf8');
+  } catch {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, PresenceRecord>;
+    }
+  } catch {
+    /* corrupt — degrade to empty, never throw into the tick */
+  }
+  return {};
+}
+
+export function savePresence(map: Record<string, PresenceRecord>, dir?: string): void {
+  try {
+    const file = presenceFilePath(dir);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(map), 'utf8');
+  } catch {
+    /* best-effort; a failed write just re-derives next tick */
+  }
+}
+
+/** The subset of an `ActiveSession` the presence adapter reads (structural, so
+ *  this module doesn't import the heavy active-session graph). */
+export interface ActiveSessionLike {
+  sessionId?: string;
+  kind: string;
+  /** 'terminal' (interactive) | 'headless' | 'teams' | 'cloud' | ... */
+  context: string;
+  /** Set for a peer session by the fleet fan-out (`gatherRemoteActive`). */
+  machine?: string;
+  provenance?: { transport?: string };
+}
+
+/**
+ * Map this tick's active sessions to presence observations. A session on a peer
+ * carries `machine` (from the fleet fan-out) → `location: 'ssh'`; a local one →
+ * `'local'`. `interactive` is true only for a `terminal` context (a tmux/terminal
+ * session whose drop is reconnect-worthy) — headless/teams/cloud are not.
+ * Sessions with no id are skipped (they can't be tracked or addressed).
+ */
+export function observedFromActive(
+  sessions: ActiveSessionLike[],
+  selfHost: string = os.hostname(),
+): ObservedSession[] {
+  const out: ObservedSession[] = [];
+  for (const s of sessions) {
+    if (!s.sessionId) continue;
+    const location: PresenceLocation = s.machine ? 'ssh' : 'local';
+    out.push({
+      sessionId: s.sessionId,
+      agent: s.kind,
+      location,
+      device: s.machine ?? selfHost,
+      transport: s.provenance?.transport ?? location,
+      interactive: s.context === 'terminal',
+    });
+  }
+  return out;
+}
+
+/** The action for a session that just flipped to `disconnected`: an interactive
+ *  session wants a reconnect nudge; a headless remote wants keep-alive; a local
+ *  headless that vanished is simply gone (no action). */
+export function actionFor(record: PresenceRecord): PresenceAction {
+  if (record.status !== 'disconnected') return 'none';
+  if (record.interactive) return 'reconnect-nudge';
+  if (record.location === 'ssh') return 'keep-alive';
+  return 'none';
+}
+
+/**
+ * Pure state machine. Given the prior store, the sessions observed THIS tick, and
+ * `nowMs`, return the next store plus the set of status transitions.
+ *
+ * - observed now                 -> `connected`, lastSeen = now (record refreshed)
+ * - tracked but absent now       -> `disconnected` (lastSeen kept from prior tick)
+ * - `disconnected` older than TTL -> pruned (gone for good)
+ *
+ * `transitions` carries only sessions whose status actually changed, each with
+ * the action the tick should take — so the caller never re-nudges a session that
+ * was already disconnected last tick.
+ */
+export function reconcilePresence(
+  prev: Record<string, PresenceRecord>,
+  observed: ObservedSession[],
+  nowMs: number,
+): { next: Record<string, PresenceRecord>; transitions: PresenceTransition[] } {
+  const next: Record<string, PresenceRecord> = {};
+  const transitions: PresenceTransition[] = [];
+  const observedIds = new Set(observed.map((o) => o.sessionId));
+
+  // 1. Everything observed this tick is connected.
+  for (const o of observed) {
+    const before = prev[o.sessionId];
+    const record: PresenceRecord = {
+      sessionId: o.sessionId,
+      agent: o.agent,
+      location: o.location,
+      device: o.device,
+      transport: o.transport,
+      interactive: o.interactive,
+      lastSeenMs: nowMs,
+      status: 'connected',
+    };
+    next[o.sessionId] = record;
+    if (before && before.status === 'disconnected') {
+      transitions.push({ record, from: 'disconnected', to: 'connected', action: 'none' });
+    }
+  }
+
+  // 2. Tracked-but-absent sessions flip to disconnected (or prune past TTL).
+  for (const [id, before] of Object.entries(prev)) {
+    if (observedIds.has(id)) continue;
+    if (nowMs - before.lastSeenMs > PRESENCE_TTL_MS) continue; // prune: gone for good
+    const record: PresenceRecord = { ...before, status: 'disconnected' };
+    next[id] = record;
+    if (before.status === 'connected') {
+      transitions.push({
+        record,
+        from: 'connected',
+        to: 'disconnected',
+        action: actionFor(record),
+      });
+    }
+  }
+
+  return { next, transitions };
+}

--- a/apps/cli/src/lib/watchdog/runner.presence.test.ts
+++ b/apps/cli/src/lib/watchdog/runner.presence.test.ts
@@ -1,0 +1,83 @@
+/**
+ * RUSH-2007 Layer C — composed integration: runWatchdogTick reconciles + persists
+ * per-session presence across ticks, using the tick's own session view (no mocks;
+ * a real tmp state dir). Tick 1 sees a session -> connected; tick 2 no longer sees
+ * it -> disconnected + the connect->disconnect transition with its action.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { ActiveSession } from '../session/active.js';
+import type { SessionProvenance } from '../session/provenance.js';
+import { runWatchdogTick, type WatchdogTickOptions } from './runner.js';
+
+let stateDir: string;
+beforeEach(() => { stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-presence-')); });
+afterEach(() => { fs.rmSync(stateDir, { recursive: true, force: true }); });
+
+const NOW = 1_700_000_000_000;
+
+/** An interactive tmux session on a peer (machine set => location ssh). */
+function peerTerminal(sessionId: string): ActiveSession {
+  const provenance: SessionProvenance = {
+    host: 'yosemite-s0',
+    transport: 'ssh',
+    mux: { kind: 'tmux', pane: '%1', socket: '/tmp/s' },
+    reply: { rail: 'tmux', target: '%1', socket: '/tmp/s' },
+  };
+  return {
+    context: 'terminal',
+    kind: 'codex',
+    host: 'ssh',
+    sessionId,
+    machine: 'yosemite-s0',
+    status: 'idle',
+    startedAtMs: NOW,
+    provenance,
+  } as ActiveSession;
+}
+
+function tick(sessions: ActiveSession[], nowMs: number): Promise<ReturnType<typeof runWatchdogTick> extends Promise<infer R> ? R : never> {
+  const opts: WatchdogTickOptions = {
+    sessions,
+    nowMs,
+    stateDir,
+    injectDryRun: true,
+    logPath: path.join(stateDir, 'watchdog.log'),
+    openBlockFor: () => null,
+    // recent activity => not stalled, so the nudge path stays quiet and the test
+    // isolates presence reconciliation.
+    lastActivityFor: () => nowMs,
+  };
+  return runWatchdogTick(opts);
+}
+
+describe('runWatchdogTick — Layer C presence reconciliation (composed)', () => {
+  it('tracks connect on the first tick, then disconnect + transition when the session vanishes', async () => {
+    // Tick 1: the codex session is present -> connected, no transition (first sighting).
+    const t1 = await tick([peerTerminal('codex-1')], NOW);
+    expect(t1.presence.connected).toBe(1);
+    expect(t1.presence.disconnected).toBe(0);
+    expect(t1.presence.transitions).toHaveLength(0);
+    // and it was persisted for the next tick
+    expect(fs.existsSync(path.join(stateDir, 'presence.json'))).toBe(true);
+
+    // Tick 2: the session is gone (SSH dropped / peer unreachable) -> disconnected.
+    const t2 = await tick([], NOW + 10_000);
+    expect(t2.presence.connected).toBe(0);
+    expect(t2.presence.disconnected).toBe(1);
+    expect(t2.presence.transitions).toEqual([
+      expect.objectContaining({
+        from: 'connected',
+        to: 'disconnected',
+        action: 'reconnect-nudge', // interactive session -> reconnect nudge candidate
+        record: expect.objectContaining({ sessionId: 'codex-1', device: 'yosemite-s0', location: 'ssh' }),
+      }),
+    ]);
+
+    // Tick 3: still gone, but no NEW transition (already disconnected last tick).
+    const t3 = await tick([], NOW + 20_000);
+    expect(t3.presence.transitions).toHaveLength(0);
+  });
+});

--- a/apps/cli/src/lib/watchdog/runner.ts
+++ b/apps/cli/src/lib/watchdog/runner.ts
@@ -34,6 +34,13 @@ import * as path from 'path';
 import type { ActiveSession } from '../session/active.js';
 import { getActiveSessions } from '../session/active.js';
 import {
+  reconcilePresence,
+  loadPresence,
+  savePresence,
+  observedFromActive,
+  type PresenceTransition,
+} from '../session/presence.js';
+import {
   resolveInjectTargetForSession,
   type InjectRail,
 } from '../terminal/resolve.js';
@@ -177,6 +184,18 @@ export interface WatchdogTickResult {
     nudged: number;
     unaddressable: number;
     skipped: number;
+  };
+  /**
+   * RUSH-2007 Layer C: per-session presence reconciled from this tick's active
+   * scan. `transitions` carries only the sessions whose connect/disconnect status
+   * flipped this tick — an interactive drop is a reconnect-nudge candidate, a
+   * headless remote a keep-alive. Surfaced for the tray/status; does not alter the
+   * nudge decisions above.
+   */
+  presence: {
+    connected: number;
+    disconnected: number;
+    transitions: PresenceTransition[];
   };
 }
 
@@ -447,6 +466,22 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
   const injectFn = opts.injectFn ?? injectIntoTerminal;
 
   const sessions = opts.sessions ?? (await getActiveSessions());
+
+  // RUSH-2007 Layer C — reconcile per-session presence from this tick's active
+  // scan and persist it. Additive: it derives connect/disconnect from what this
+  // tick actually saw and surfaces the flips (interactive drop => reconnect-nudge
+  // candidate, headless remote => keep-alive) for the tray/status, without
+  // touching the nudge decisions below. Uses the tick's own session view (fleet-
+  // wide when the caller passes gatherRemoteActive results), so it adds no SSH
+  // fan-out of its own.
+  const presenceResult = reconcilePresence(loadPresence(dir), observedFromActive(sessions), nowMs);
+  savePresence(presenceResult.next, dir);
+  const presence = {
+    connected: Object.values(presenceResult.next).filter((r) => r.status === 'connected').length,
+    disconnected: Object.values(presenceResult.next).filter((r) => r.status === 'disconnected').length,
+    transitions: presenceResult.transitions,
+  };
+
   const ledger = readNudgeLedger(dir);
   // Cooldown timestamps this tick decided to (re)start — merged into the ledger
   // under a lock at the end so a concurrent tick's updates are never lost.
@@ -669,7 +704,7 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
     unaddressable: outcomes.filter((o) => o.addressable === false).length,
     skipped: outcomes.filter((o) => o.decision === 'skip').length,
   };
-  const result: WatchdogTickResult = { atMs: nowMs, didNudge: opts.nudge === true, outcomes, counts };
+  const result: WatchdogTickResult = { atMs: nowMs, didNudge: opts.nudge === true, outcomes, counts, presence };
   writeJsonFile(path.join(dir, 'last-tick.json'), result);
 
   // Heartbeat + decision/nudge events to the canonical watchdog.log the Factory


### PR DESCRIPTION
## What

Closes the last open piece of **RUSH-2007** — **Layer C: presence tracker**. (Layer A #1633, Layer B #1524, and the #1502 Factory reattach-env fix are all merged + shipped.)

Folds per-session presence tracking into the `agents watchdog` tick — **not** a revived `agents daemon`, per the ticket.

## How

- **`apps/cli/src/lib/session/presence.ts`** — the store + a pure state machine:
  - One record per session `{sessionId, agent, location, device, transport, lastSeen, status}` at `~/.agents/.cache/state/watchdog/presence.json` (sibling of the tick's `nudges/flags/last-tick`).
  - `reconcilePresence(prev, observed, now)` derives `connected`/`disconnected` by diffing consecutive ticks: observed → `connected`; tracked-but-absent → `disconnected` (last-seen preserved); a `disconnected` record past a 30-min TTL is pruned. Only real status **flips** are emitted as `transitions`, each tagged with its action — interactive drop → `reconnect-nudge`, headless remote → `keep-alive`, local headless → `none`.
  - `observedFromActive()` maps `ActiveSession[]` → observations (peer `machine` ⇒ `location: ssh`; `terminal` context ⇒ `interactive`).
- **`apps/cli/src/lib/watchdog/runner.ts`** — one additive step in `runWatchdogTick`: reconcile presence from the tick's own session view, persist it, and surface `presence: {connected, disconnected, transitions}` in `watchdog --json`. **No extra SSH fan-out** (uses the sessions the tick already has — fleet-wide when the caller passes `gatherRemoteActive` results), and it **does not change the nudge decisions**.

## Proof — real test run (not pasted source)

Captured: `mac-mini:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/layer-c-testrun.log`

```
$ bun test presence + watchdog runner + composed integration
 32 pass
 0 fail
 109 expect() calls
Ran 32 tests across 3 files.

$ bunx tsc --noEmit (touched files)
OK: no type errors in touched files
```

- `presence.test.ts` (15) — pure state machine (connect/disconnect, no-double-transition, reconnect-vs-keep-alive-vs-none action, TTL prune, re-observe), the `observedFromActive` adapter, and a real-fs store round-trip incl. corrupt-file degradation. No mocks.
- `runner.presence.test.ts` (1) — **composed**: drives `runWatchdogTick` across three real ticks (tmp state dir), asserting connect → disconnect+`reconnect-nudge` transition → no-new-transition, and that `presence.json` is persisted between ticks.
- `runner.test.ts` (16) — the existing watchdog suite still passes with the new result field.

## Scope notes for the reviewer

- **Additive/observability first.** This lands the presence mechanism + the `presence.transitions` signal. The transitions already carry the `reconnect-nudge`/`keep-alive` **action**, but wiring those into actual injection reuses the existing opt-in nudge rail and is a deliberate follow-up (kept out to avoid new auto-injection in this PR).
- **Docs:** no existing doc documents the `watchdog --json` result shape (checked `docs/06-observability.md`, `docs/self-healing.md`), so the change is captured in the `.changelog/next/` fragment. Happy to add a doc section if you'd prefer one.
- **CHANGELOG:** `.changelog/next/rush2007-layer-c-presence.md` (conflict-free queue).

Linear: RUSH-2007 (Layer C).
