### PR TITLE
fix(factory): repair pick-session review blockers

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the Factory extension are documented here. Format follows
   box that actually holds the transcript, in the same repo. Source:
   `apps/factory/src/core/sessionBrowser.ts`, `apps/factory/src/vscode/extension.ts`
   (`pickSessionToFork`, `forkPickedSession`, `openSingleAgentWithQueue`'s new
-  `remoteCwd`), `apps/factory/package.json`.
+  `remoteCwd`, emitted as the CLI's exact `--remote-cwd`), `apps/factory/package.json`.
 
 ## [0.9.305] - 2026-08-03
 

--- a/apps/factory/src/core/agents.test.ts
+++ b/apps/factory/src/core/agents.test.ts
@@ -372,19 +372,20 @@ describe('buildAgentLaunchCommand', () => {
     expect(cmd).toContain("--host 'mac-mini'");
   });
 
-  test('remote host launch forwards the workspace cwd for CLI portability rewriting', () => {
+  test('remote host launch uses the exact remote cwd verbatim', () => {
     const cmd = buildAgentLaunchCommand(
       'codex', null, undefined, undefined, undefined, undefined, undefined, 'mac-mini', false, '/Users/muqsit/src/agents-cli',
     );
     expect(cmd).toContain("--host 'mac-mini'");
-    expect(cmd).toContain("--cwd '/Users/muqsit/src/agents-cli'");
+    expect(cmd).toContain("--remote-cwd '/Users/muqsit/src/agents-cli'");
+    expect(cmd).not.toContain(" --cwd ");
   });
 
   test('local launch does not emit an explicit cwd', () => {
     const cmd = buildAgentLaunchCommand(
       'codex', null, undefined, undefined, undefined, undefined, undefined, undefined, false, '/Users/muqsit/src/agents-cli',
     );
-    expect(cmd).not.toContain('--cwd');
+    expect(cmd).not.toContain('--remote-cwd');
   });
 
   test('default model is included when provided', () => {

--- a/apps/factory/src/core/agents.ts
+++ b/apps/factory/src/core/agents.ts
@@ -171,7 +171,7 @@ export function buildAgentLaunchCommand(
   mode?: AgentLaunchMode,
   host?: string,
   local = false,
-  cwd?: string,
+  remoteCwd?: string,
 ): string {
   const agentSpec = pinnedVersion ? `${agentKey}@${pinnedVersion}` : agentKey;
   let command = `agents run ${agentSpec} --interactive`;
@@ -180,7 +180,7 @@ export function buildAgentLaunchCommand(
   // grok/kimi/droid (which launch as raw binaries locally) get host parity.
   if (host) {
     command += ` --host ${shquote(host)}`;
-    if (cwd) command += ` --cwd ${shquote(cwd)}`;
+    if (remoteCwd) command += ` --remote-cwd ${shquote(remoteCwd)}`;
   }
   // Unpinned, no explicit host: affinity-pick device via --device auto.
   // Explicit Pick Host / @version pin skip this.

--- a/apps/factory/src/core/sessionBrowser.test.ts
+++ b/apps/factory/src/core/sessionBrowser.test.ts
@@ -162,7 +162,7 @@ describe('picked row -> launch command', () => {
       request.strategy, undefined, request.host, request.local, picked.cwd,
     );
     expect(command).toContain("--host 'yosemite-s1'");
-    expect(command).toContain("--cwd '/home/muqsit/src/github.com/muqsitnawaz/agents-cli'");
+    expect(command).toContain("--remote-cwd '/home/muqsit/src/github.com/muqsitnawaz/agents-cli'");
     expect(request.prompt).toBe('/continue sess-remote');
   });
 
@@ -181,7 +181,7 @@ describe('picked row -> launch command', () => {
       request.strategy, undefined, request.host, request.local, undefined,
     );
     expect(command).not.toContain('--host');
-    expect(command).not.toContain('--cwd');
+    expect(command).not.toContain('--remote-cwd');
   });
 });
 

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -112,7 +112,7 @@ import {
   type BrowsableSession,
   type SessionBrowserSessionRow,
 } from '../core/sessionBrowser';
-import { createForkPickSessionCommand, loadBrowsableSessions, runPickedSessionFork, runSessionBrowserPicker } from './sessionBrowser.vscode';
+import { loadBrowsableSessions, registerForkPickSessionCommand, runPickedSessionFork, runSessionBrowserPicker } from './sessionBrowser.vscode';
 import type { RemoteSession, RawActiveSession } from '../core/remoteSessions';
 import {
   buildResumeCandidates,
@@ -1653,7 +1653,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('agents.forkPickSession', createForkPickSessionCommand(() => forkPickedSession(context)))
+    registerForkPickSessionCommand(vscode.commands.registerCommand, () => forkPickedSession(context))
   );
 
   context.subscriptions.push(

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -108,11 +108,11 @@ import { buildForkSessionRequest } from '../core/forkSession';
 import {
   buildSessionBrowserRows,
   cleanSessionTopic,
-  forkHostForSession,
   formatSessionWhen,
   type BrowsableSession,
   type SessionBrowserSessionRow,
 } from '../core/sessionBrowser';
+import { LatestSessionBrowserRequest, loadBrowsableSessions, runPickedSessionFork } from './sessionBrowser.vscode';
 import type { RemoteSession, RawActiveSession } from '../core/remoteSessions';
 import {
   buildResumeCandidates,
@@ -4789,16 +4789,20 @@ const SESSION_BROWSER_LIMIT = 60;
  * SSH). With `device`, the CLI fans the same listing out to that box over SSH and
  * answers with the identical row shape — which is why one parser serves both.
  */
-async function listBrowsableSessions(device?: string): Promise<BrowsableSession[]> {
+async function listBrowsableSessions(
+  device?: string,
+  currentSessionId?: string | null,
+  currentSessionDevice?: string,
+): Promise<BrowsableSession[]> {
   const { runAgents } = await import('../core/agentsBin');
-  const scope = device ? ` --host ${shquote(device)}` : '';
-  const { stdout } = await runAgents(
-    `sessions --all -n ${SESSION_BROWSER_LIMIT} --json${scope}`,
-    { maxBuffer: 16 * 1024 * 1024, timeout: device ? 45_000 : 20_000 },
-  );
-  const parsed = JSON.parse(stdout);
-  if (!Array.isArray(parsed)) return [];
-  return parsed.filter((s): s is BrowsableSession => !!s && typeof s === 'object' && typeof s.id === 'string');
+  return loadBrowsableSessions(runAgents, {
+    device,
+    localMachine: LOCAL_MACHINE_ID,
+    limit: SESSION_BROWSER_LIMIT,
+    currentSessionId,
+    currentSessionDevice,
+    quote: shquote,
+  });
 }
 
 interface SessionBrowserItem extends vscode.QuickPickItem {
@@ -4849,7 +4853,10 @@ async function pickBrowseDevice(current: string | undefined): Promise<{ device?:
  * so the flow stays "open → filter → pick" instead of a wizard. Returns the row
  * the user chose, or null when they dismissed it.
  */
-async function pickSessionToFork(currentSessionId: string | null): Promise<SessionBrowserSessionRow | null> {
+async function pickSessionToFork(
+  currentSessionId: string | null,
+  currentSessionDevice?: string,
+): Promise<SessionBrowserSessionRow | null> {
   const quickPick = vscode.window.createQuickPick<SessionBrowserItem>();
   const switchDevice: vscode.QuickInputButton = {
     iconPath: new vscode.ThemeIcon('server-environment'),
@@ -4865,13 +4872,17 @@ async function pickSessionToFork(currentSessionId: string | null): Promise<Sessi
   quickPick.buttons = [switchDevice, reload];
 
   let device: string | undefined;
+  const requests = new LatestSessionBrowserRequest();
 
   const load = async (): Promise<void> => {
+    const request = requests.begin();
+    const loadingDevice = device;
     quickPick.title = `Agents: Fork (Pick Session) · ${device ?? LOCAL_MACHINE_ID}`;
     quickPick.busy = true;
     quickPick.items = [];
     try {
-      const sessions = await listBrowsableSessions(device);
+      const sessions = await listBrowsableSessions(loadingDevice, currentSessionId, currentSessionDevice);
+      if (!request.current()) return;
       const rows = buildSessionBrowserRows(sessions, {
         localMachine: LOCAL_MACHINE_ID,
         currentSessionId,
@@ -4881,12 +4892,13 @@ async function pickSessionToFork(currentSessionId: string | null): Promise<Sessi
         ? toBrowserItems(rows)
         : [{ label: `No sessions found on ${device ?? LOCAL_MACHINE_ID}`, alwaysShow: true }];
     } catch (err: any) {
+      if (!request.current()) return;
       // A device that is off, unreachable, or missing the CLI fails here — say so
       // in the list itself rather than closing the picker out from under the user.
       const msg = (err?.stderr || err?.message || String(err)).trim().split('\n')[0];
       quickPick.items = [{ label: `$(error) Could not list sessions: ${msg.slice(0, 120)}`, alwaysShow: true }];
     } finally {
-      quickPick.busy = false;
+      if (request.current()) quickPick.busy = false;
     }
   };
 
@@ -4935,50 +4947,34 @@ async function forkPickedSession(context: vscode.ExtensionContext): Promise<void
   const activeTerminal = vscode.window.activeTerminal;
   const entry = activeTerminal ? terminals.getByTerminal(activeTerminal) : null;
 
-  const row = await pickSessionToFork(entry?.sessionId ?? null);
+  const row = await pickSessionToFork(entry?.sessionId ?? null, entry?.host);
   if (!row) return;
 
-  const request = buildForkSessionRequest({
-    sessionId: row.session.id,
-    agentKey: row.session.agent,
-    host: forkHostForSession(row.session, LOCAL_MACHINE_ID),
+  const launched = await runPickedSessionFork({
+    row,
+    localMachine: LOCAL_MACHINE_ID,
+    showError: message => { void vscode.window.showErrorMessage(message); },
+    launch: async request => {
+      const builtIn = BUILT_IN_AGENTS.find(a => a.key === request.agentKey);
+      if (!builtIn) {
+        vscode.window.showErrorMessage(`Cannot fork a ${row.session.agent} session — no built-in agent config for it.`);
+        return false;
+      }
+      const agentConfig = createAgentConfig(
+        context.extensionPath,
+        builtIn.title,
+        builtIn.command,
+        builtIn.icon,
+        builtIn.prefix,
+      );
+      await openSingleAgentWithQueue(context, agentConfig, [request.prompt], request);
+      return true;
+    },
   });
-  if (!request.ok) {
-    vscode.window.showErrorMessage(
-      request.reason === 'no_session'
-        ? `Session ${row.session.shortId} has no id to fork.`
-        : `Session ${row.session.shortId} has no agent harness to fork with.`,
-    );
-    return;
-  }
-
-  const builtIn = BUILT_IN_AGENTS.find(a => a.key === request.agentKey);
-  if (!builtIn) {
-    vscode.window.showErrorMessage(`Cannot fork a ${row.session.agent} session — no built-in agent config for it.`);
-    return;
-  }
-  const agentConfig = createAgentConfig(
-    context.extensionPath,
-    builtIn.title,
-    builtIn.command,
-    builtIn.icon,
-    builtIn.prefix,
-  );
-
-  // The fork belongs in the SESSION's directory, not whatever this window has
-  // open — the browser spans every project on the machine. Locally that pins the
-  // terminal; on a device it becomes the remote `--cwd`, since the path exists
-  // over there (that is where the transcript came from).
-  await openSingleAgentWithQueue(context, agentConfig, [request.prompt], {
-    strategy: request.strategy,
-    host: request.host,
-    local: request.local,
-    cwd: request.local ? row.session.cwd : undefined,
-    remoteCwd: request.local ? undefined : row.session.cwd,
-  });
+  if (!launched) return;
 
   vscode.window.setStatusBarMessage(
-    `Forking ${row.session.shortId}${request.host ? ` on ${request.host}` : ''}`,
+    `Forking ${row.session.shortId}${row.remote ? ` on ${row.machine}` : ''}`,
     3000,
   );
 }

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -112,7 +112,7 @@ import {
   type BrowsableSession,
   type SessionBrowserSessionRow,
 } from '../core/sessionBrowser';
-import { LatestSessionBrowserRequest, loadBrowsableSessions, runPickedSessionFork } from './sessionBrowser.vscode';
+import { createForkPickSessionCommand, loadBrowsableSessions, runPickedSessionFork, runSessionBrowserPicker } from './sessionBrowser.vscode';
 import type { RemoteSession, RawActiveSession } from '../core/remoteSessions';
 import {
   buildResumeCandidates,
@@ -1653,7 +1653,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('agents.forkPickSession', () => forkPickedSession(context))
+    vscode.commands.registerCommand('agents.forkPickSession', createForkPickSessionCommand(() => forkPickedSession(context)))
   );
 
   context.subscriptions.push(
@@ -4871,71 +4871,24 @@ async function pickSessionToFork(
   quickPick.matchOnDetail = true;
   quickPick.buttons = [switchDevice, reload];
 
-  let device: string | undefined;
-  const requests = new LatestSessionBrowserRequest();
-
-  const load = async (): Promise<void> => {
-    const request = requests.begin();
-    const loadingDevice = device;
-    quickPick.title = `Agents: Fork (Pick Session) · ${device ?? LOCAL_MACHINE_ID}`;
-    quickPick.busy = true;
-    quickPick.items = [];
-    try {
-      const sessions = await listBrowsableSessions(loadingDevice, currentSessionId, currentSessionDevice);
-      if (!request.current()) return;
+  try {
+    return await runSessionBrowserPicker({
+      quickPick,
+      switchButton: switchDevice,
+      reloadButton: reload,
+      localMachine: LOCAL_MACHINE_ID,
+      loadItems: async device => {
+        const sessions = await listBrowsableSessions(device, currentSessionId, currentSessionDevice);
       const rows = buildSessionBrowserRows(sessions, {
         localMachine: LOCAL_MACHINE_ID,
         currentSessionId,
         limitPerMachine: SESSION_BROWSER_LIMIT,
       });
-      quickPick.items = rows.length > 0
-        ? toBrowserItems(rows)
-        : [{ label: `No sessions found on ${device ?? LOCAL_MACHINE_ID}`, alwaysShow: true }];
-    } catch (err: any) {
-      if (!request.current()) return;
-      // A device that is off, unreachable, or missing the CLI fails here — say so
-      // in the list itself rather than closing the picker out from under the user.
-      const msg = (err?.stderr || err?.message || String(err)).trim().split('\n')[0];
-      quickPick.items = [{ label: `$(error) Could not list sessions: ${msg.slice(0, 120)}`, alwaysShow: true }];
-    } finally {
-      if (request.current()) quickPick.busy = false;
-    }
-  };
-
-  try {
-    return await new Promise<SessionBrowserSessionRow | null>((resolve) => {
-      // Set while the device sub-picker is up: VS Code hides this QuickPick when
-      // another opens, and that hide must not read as "the user cancelled".
-      let switching = false;
-
-      quickPick.onDidTriggerButton(async (button) => {
-        if (button === reload) {
-          void load();
-          return;
-        }
-        switching = true;
-        quickPick.hide();
-        const chosen = await pickBrowseDevice(device);
-        switching = false;
-        quickPick.show();
-        if (chosen.cancelled) return; // back to the list, same device
-        device = chosen.device;
-        void load();
-      });
-
-      quickPick.onDidAccept(() => {
-        const picked = quickPick.selectedItems[0];
-        if (!picked?.row) return; // an empty-state / error line is not selectable
-        resolve(picked.row);
-        quickPick.hide();
-      });
-
-      quickPick.onDidHide(() => {
-        if (!switching) resolve(null);
-      });
-
-      quickPick.show();
-      void load();
+        return toBrowserItems(rows);
+      },
+      chooseDevice: pickBrowseDevice,
+      emptyItem: device => ({ label: `No sessions found on ${device ?? LOCAL_MACHINE_ID}`, alwaysShow: true }),
+      errorItem: message => ({ label: `$(error) Could not list sessions: ${message.slice(0, 120)}`, alwaysShow: true }),
     });
   } finally {
     quickPick.dispose();

--- a/apps/factory/src/vscode/forkCommands.test.ts
+++ b/apps/factory/src/vscode/forkCommands.test.ts
@@ -22,8 +22,7 @@ describe('fork command contributions', () => {
     expect(extensionSource).toContain("registerCommand('agents.forkCurrentSession'");
   });
 
-  test('Agents: Fork (Pick Session) is both contributed and registered', () => {
+  test('Agents: Fork (Pick Session) is contributed under its stable command id', () => {
     expect(contributed('agents.forkPickSession')?.title).toBe('Agents: Fork (Pick Session)');
-    expect(extensionSource).toContain("registerCommand('agents.forkPickSession'");
   });
 });

--- a/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
@@ -3,9 +3,9 @@ import { buildAgentLaunchCommand } from '../core/agents';
 import { buildSessionBrowserRows, type SessionBrowserSessionRow } from '../core/sessionBrowser';
 import {
   LatestSessionBrowserRequest,
-  createForkPickSessionCommand,
   loadBrowsableSessions,
   runPickedSessionFork,
+  registerForkPickSessionCommand,
   runSessionBrowserPicker,
   type SessionBrowserQuickPick,
   type SessionBrowserRunner,
@@ -84,7 +84,7 @@ describe('session browser extension-host seam', () => {
         : { stdout: JSON.stringify([{
             sessionId: 'current-outside-limit', kind: 'claude', startedAtMs: Date.parse('2026-01-01T00:00:00Z'),
             cwd: '/repo', project: 'agents-cli', machine: 'zion',
-          }]), stderr: '' };
+          }]), stderr: 'gpu-box: unreachable or no agents CLI — skipped\n' };
     };
 
     const sessions = await loadBrowsableSessions(run, {
@@ -100,6 +100,16 @@ describe('session browser extension-host seam', () => {
     expect(sessions.at(-1)?.timestamp).toBe('2026-01-01T00:00:00.000Z');
   });
 
+  test('pins active metadata without a start timestamp instead of throwing', async () => {
+    const run: SessionBrowserRunner = async (args) => args.startsWith('sessions --all')
+      ? { stdout: '[]', stderr: '' }
+      : { stdout: JSON.stringify([{ sessionId: 'current-no-time', kind: 'codex', cwd: '/repo' }]), stderr: '' };
+    const sessions = await loadBrowsableSessions(run, {
+      localMachine: 'zion', limit: 60, currentSessionId: 'current-no-time', quote,
+    });
+    expect(sessions[0]?.timestamp).toBe('1970-01-01T00:00:00.000Z');
+  });
+
   test('registered command -> QuickPick load/switch/reload/accept -> fork -> queued launch uses the real seams', async () => {
     const commands: string[] = [];
     const run: SessionBrowserRunner = async (args) => {
@@ -113,7 +123,13 @@ describe('session browser extension-host seam', () => {
     type Item = { label: string; row?: SessionBrowserSessionRow };
     const quickPick = new FakeQuickPick<Item, 'switch' | 'reload'>();
     let queued = '';
-    const registered = createForkPickSessionCommand(async () => {
+    let registeredId = '';
+    let registered!: () => Promise<void>;
+    registerForkPickSessionCommand((id, callback) => {
+      registeredId = id;
+      registered = callback;
+      return {};
+    }, async () => {
       const picked = await runSessionBrowserPicker({
         quickPick,
         switchButton: 'switch',
@@ -143,6 +159,7 @@ describe('session browser extension-host seam', () => {
         },
       });
     });
+    expect(registeredId).toBe('agents.forkPickSession');
     const commandRun = registered();
     await Bun.sleep(0);
     quickPick.triggerButton('switch');

--- a/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
@@ -21,13 +21,15 @@ class FakeQuickPick<Item, Button> implements SessionBrowserQuickPick<Item, Butto
   private buttonListener?: (button: Button) => void;
   private acceptListener?: () => void;
   private hideListener?: () => void;
+  private hidden = false;
   show(): void {}
-  hide(): void { this.hideListener?.(); }
+  hide(): void { this.hidden = true; this.hideListener?.(); }
   onDidTriggerButton(listener: (button: Button) => void): unknown { this.buttonListener = listener; return {}; }
   onDidAccept(listener: () => void): unknown { this.acceptListener = listener; return {}; }
   onDidHide(listener: () => void): unknown { this.hideListener = listener; return {}; }
   triggerButton(button: Button): void { this.buttonListener?.(button); }
   accept(): void { this.acceptListener?.(); }
+  get isHidden(): boolean { return this.hidden; }
 }
 
 describe('session browser extension-host seam', () => {
@@ -82,8 +84,10 @@ describe('session browser extension-host seam', () => {
       return args.startsWith('sessions --all')
         ? { stdout: JSON.stringify(recent), stderr: '' }
         : { stdout: JSON.stringify([{
-            sessionId: 'current-outside-limit', kind: 'claude', startedAtMs: Date.parse('2026-01-01T00:00:00Z'),
-            cwd: '/repo', project: 'agents-cli', machine: 'zion',
+            context: 'headless', kind: 'claude', host: 'tmux', pid: 4312,
+            sessionId: 'current-outside-limit', cwd: '/repo', topic: 'Repair picker',
+            project: 'agents-cli', machine: 'zion', status: 'working',
+            startedAtMs: Date.parse('2026-01-01T00:00:00Z'),
           }]), stderr: 'gpu-box: unreachable or no agents CLI — skipped\n' };
     };
 
@@ -98,6 +102,39 @@ describe('session browser extension-host seam', () => {
     expect(sessions.at(-1)?.id).toBe('current-outside-limit');
     expect(sessions.at(-1)?.agent).toBe('claude');
     expect(sessions.at(-1)?.timestamp).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  test('an explicitly selected device surfaces active-metadata stderr', async () => {
+    const recent = Array.from({ length: 60 }, (_, index) => ({
+      id: `recent-${index}`, shortId: `recent-${index}`, agent: 'claude', timestamp: '2026-08-03T00:00:00Z',
+    }));
+    const run: SessionBrowserRunner = async args => args.startsWith('sessions --all')
+      ? { stdout: JSON.stringify(recent), stderr: '' }
+      : { stdout: '[]', stderr: 'remote agents CLI unavailable\n' };
+    expect(loadBrowsableSessions(run, {
+      device: 'mac-mini', localMachine: 'zion', limit: 60,
+      currentSessionId: 'missing', currentSessionDevice: 'mac-mini', quote,
+    })).rejects.toThrow('remote agents CLI unavailable');
+  });
+
+  test('hiding invalidates an in-flight load before it can mutate the picker', async () => {
+    type Item = { label: string; row?: SessionBrowserSessionRow };
+    const quickPick = new FakeQuickPick<Item, 'switch' | 'reload'>();
+    let resolveLoad!: (items: Item[]) => void;
+    const picker = runSessionBrowserPicker({
+      quickPick,
+      switchButton: 'switch', reloadButton: 'reload', localMachine: 'zion',
+      loadItems: () => new Promise(resolve => { resolveLoad = resolve; }),
+      chooseDevice: async () => ({ cancelled: true }),
+      emptyItem: () => ({ label: 'empty' }),
+      errorItem: message => ({ label: message }),
+    });
+    quickPick.hide();
+    resolveLoad([{ label: 'stale result' }]);
+    expect(await picker).toBeNull();
+    await Bun.sleep(0);
+    expect(quickPick.items).toEqual([]);
+    expect(quickPick.busy).toBe(true);
   });
 
   test('pins active metadata without a start timestamp instead of throwing', async () => {

--- a/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { buildAgentLaunchCommand } from '../core/agents';
+import { buildSessionBrowserRows, type SessionBrowserSessionRow } from '../core/sessionBrowser';
+import { LatestSessionBrowserRequest, loadBrowsableSessions, runPickedSessionFork, type SessionBrowserRunner } from './sessionBrowser.vscode';
+
+const quote = (value: string) => `'${value}'`;
+
+describe('session browser extension-host seam', () => {
+  test('only the latest overlapping picker load may publish items or clear busy', async () => {
+    const requests = new LatestSessionBrowserRequest();
+    const published: string[] = [];
+    let busy = true;
+    let resolveFirst!: () => void;
+    const firstWait = new Promise<void>(resolve => { resolveFirst = resolve; });
+
+    const load = async (name: string, wait: Promise<void>) => {
+      const request = requests.begin();
+      await wait;
+      if (!request.current()) return;
+      published.push(name);
+      busy = false;
+    };
+
+    const first = load('local stale result', firstWait);
+    const second = load('remote latest result', Promise.resolve());
+    await second;
+    resolveFirst();
+    await first;
+
+    expect(published).toEqual(['remote latest result']);
+    expect(busy).toBe(false);
+  });
+
+  test('preserves an unreachable-device CLI boundary error instead of returning an empty list', async () => {
+    const run: SessionBrowserRunner = async () => ({ stdout: '', stderr: 'ssh: connect to host offline: No route to host\n' });
+    expect(loadBrowsableSessions(run, {
+      device: 'offline', localMachine: 'zion', limit: 60, quote,
+    })).rejects.toThrow('ssh: connect to host offline: No route to host');
+  });
+
+  test('keeps the ordinary 60-row query and fetches the invoked session when truncation omitted it', async () => {
+    const calls: string[] = [];
+    const recent = Array.from({ length: 60 }, (_, index) => ({
+      id: `recent-${index}`, shortId: `recent-${index}`, agent: 'claude', timestamp: '2026-08-03T00:00:00Z',
+    }));
+    const run: SessionBrowserRunner = async (args) => {
+      calls.push(args);
+      return args.startsWith('sessions --all')
+        ? { stdout: JSON.stringify(recent), stderr: '' }
+        : { stdout: JSON.stringify({ session: {
+            id: 'current-outside-limit', shortId: 'current-', agent: 'claude', timestamp: '2026-01-01T00:00:00Z',
+          } }), stderr: '' };
+    };
+
+    const sessions = await loadBrowsableSessions(run, {
+      localMachine: 'zion', limit: 60, currentSessionId: 'current-outside-limit', quote,
+    });
+    expect(calls).toEqual([
+      'sessions --all -n 60 --json',
+      "sessions 'current-outside-limit' --json",
+    ]);
+    expect(sessions).toHaveLength(61);
+    expect(sessions.at(-1)?.id).toBe('current-outside-limit');
+  });
+
+  test('list -> device switch/reload -> selection -> fork -> queued remote launch uses the real seams', async () => {
+    const commands: string[] = [];
+    const run: SessionBrowserRunner = async (args) => {
+      commands.push(args);
+      const remote = args.includes("--host 'yosemite-s0'");
+      return { stdout: JSON.stringify(remote ? [{
+        id: 'remote-session', shortId: 'remote-s', agent: 'claude', machine: 'yosemite-s0',
+        cwd: '/srv/exact repo', timestamp: '2026-08-03T00:00:00Z', topic: 'Fix picker',
+      }] : []), stderr: '' };
+    };
+    const requests = new LatestSessionBrowserRequest();
+    const stale = requests.begin();
+    await loadBrowsableSessions(run, { localMachine: 'zion', limit: 60, quote });
+    const switched = requests.begin();
+    const loaded = await loadBrowsableSessions(run, {
+      device: 'yosemite-s0', localMachine: 'zion', limit: 60, quote,
+    });
+    expect(stale.current()).toBe(false);
+    expect(switched.current()).toBe(true);
+
+    const [picked] = buildSessionBrowserRows(loaded, { localMachine: 'zion' })
+      .filter((row): row is SessionBrowserSessionRow => row.kind === 'session');
+    let queued = '';
+    const launched = await runPickedSessionFork({
+      row: picked,
+      localMachine: 'zion',
+      showError: message => { throw new Error(message); },
+      launch: async request => {
+        queued = `${buildAgentLaunchCommand(
+          request.agentKey, 'new-session', undefined, undefined, undefined,
+          request.strategy, undefined, request.host, request.local, request.remoteCwd,
+        )} && queue ${request.prompt}`;
+        return true;
+      },
+    });
+    expect(launched).toBe(true);
+    expect(commands).toEqual([
+      'sessions --all -n 60 --json',
+      "sessions --all -n 60 --json --host 'yosemite-s0'",
+    ]);
+    expect(queued).toContain("--host 'yosemite-s0' --remote-cwd '/srv/exact repo'");
+    expect(queued).toContain('queue /continue remote-session');
+  });
+});

--- a/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
@@ -58,6 +58,39 @@ describe('session browser extension-host seam', () => {
     expect(busy).toBe(false);
   });
 
+  test('hiding the picker invalidates an in-flight load before disposal', () => {
+    const requests = new LatestSessionBrowserRequest();
+    const request = requests.begin();
+    requests.invalidate();
+    expect(request.current()).toBe(false);
+  });
+
+  test('cancelling a device switch reloads after invalidating an in-flight request', async () => {
+    const quickPick = new FakeQuickPick<{ label: string }, 'switch' | 'reload'>();
+    let resolveInitial!: (items: { label: string }[]) => void;
+    const initial = new Promise<{ label: string }[]>(resolve => { resolveInitial = resolve; });
+    let loads = 0;
+    const picker = runSessionBrowserPicker({
+      quickPick,
+      switchButton: 'switch',
+      reloadButton: 'reload',
+      localMachine: 'zion',
+      loadItems: async () => ++loads === 1 ? initial : [{ label: 'reloaded local session' }],
+      chooseDevice: async () => ({ cancelled: true }),
+      emptyItem: () => ({ label: 'empty' }),
+      errorItem: message => ({ label: message }),
+    });
+    await Bun.sleep(0);
+    quickPick.triggerButton('switch');
+    await Bun.sleep(0);
+    resolveInitial([{ label: 'stale local session' }]);
+    await Bun.sleep(0);
+    expect(quickPick.busy).toBe(false);
+    expect(quickPick.items).toEqual([{ label: 'reloaded local session' }]);
+    quickPick.hide();
+    expect(await picker).toBeNull();
+  });
+
   test('preserves an explicitly selected unreachable-device CLI boundary error instead of returning an empty list', async () => {
     const run: SessionBrowserRunner = async () => ({ stdout: '', stderr: 'ssh: connect to host offline: No route to host\n' });
     expect(loadBrowsableSessions(run, {

--- a/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
@@ -1,9 +1,34 @@
 import { describe, expect, test } from 'bun:test';
 import { buildAgentLaunchCommand } from '../core/agents';
 import { buildSessionBrowserRows, type SessionBrowserSessionRow } from '../core/sessionBrowser';
-import { LatestSessionBrowserRequest, loadBrowsableSessions, runPickedSessionFork, type SessionBrowserRunner } from './sessionBrowser.vscode';
+import {
+  LatestSessionBrowserRequest,
+  createForkPickSessionCommand,
+  loadBrowsableSessions,
+  runPickedSessionFork,
+  runSessionBrowserPicker,
+  type SessionBrowserQuickPick,
+  type SessionBrowserRunner,
+} from './sessionBrowser.vscode';
 
 const quote = (value: string) => `'${value}'`;
+
+class FakeQuickPick<Item, Button> implements SessionBrowserQuickPick<Item, Button> {
+  title = '';
+  busy = false;
+  items: readonly Item[] = [];
+  selectedItems: readonly Item[] = [];
+  private buttonListener?: (button: Button) => void;
+  private acceptListener?: () => void;
+  private hideListener?: () => void;
+  show(): void {}
+  hide(): void { this.hideListener?.(); }
+  onDidTriggerButton(listener: (button: Button) => void): unknown { this.buttonListener = listener; return {}; }
+  onDidAccept(listener: () => void): unknown { this.acceptListener = listener; return {}; }
+  onDidHide(listener: () => void): unknown { this.hideListener = listener; return {}; }
+  triggerButton(button: Button): void { this.buttonListener?.(button); }
+  accept(): void { this.acceptListener?.(); }
+}
 
 describe('session browser extension-host seam', () => {
   test('only the latest overlapping picker load may publish items or clear busy', async () => {
@@ -31,11 +56,20 @@ describe('session browser extension-host seam', () => {
     expect(busy).toBe(false);
   });
 
-  test('preserves an unreachable-device CLI boundary error instead of returning an empty list', async () => {
+  test('preserves an explicitly selected unreachable-device CLI boundary error instead of returning an empty list', async () => {
     const run: SessionBrowserRunner = async () => ({ stdout: '', stderr: 'ssh: connect to host offline: No route to host\n' });
     expect(loadBrowsableSessions(run, {
       device: 'offline', localMachine: 'zion', limit: 60, quote,
     })).rejects.toThrow('ssh: connect to host offline: No route to host');
+  });
+
+  test('keeps valid local fleet rows when unrelated devices emit best-effort skip notices', async () => {
+    const run: SessionBrowserRunner = async () => ({
+      stdout: JSON.stringify([{ id: 'local', shortId: 'local', agent: 'claude', timestamp: '2026-08-03T00:00:00Z' }]),
+      stderr: 'gpu-box: unreachable or no agents CLI — skipped\n',
+    });
+    const sessions = await loadBrowsableSessions(run, { localMachine: 'zion', limit: 60, quote });
+    expect(sessions.map(session => session.id)).toEqual(['local']);
   });
 
   test('keeps the ordinary 60-row query and fetches the invoked session when truncation omitted it', async () => {
@@ -47,9 +81,9 @@ describe('session browser extension-host seam', () => {
       calls.push(args);
       return args.startsWith('sessions --all')
         ? { stdout: JSON.stringify(recent), stderr: '' }
-        : { stdout: JSON.stringify({ session: {
+        : { stdout: JSON.stringify([{
             id: 'current-outside-limit', shortId: 'current-', agent: 'claude', timestamp: '2026-01-01T00:00:00Z',
-          } }), stderr: '' };
+          }]), stderr: '' };
     };
 
     const sessions = await loadBrowsableSessions(run, {
@@ -57,13 +91,13 @@ describe('session browser extension-host seam', () => {
     });
     expect(calls).toEqual([
       'sessions --all -n 60 --json',
-      "sessions 'current-outside-limit' --json",
+      'sessions --active --json',
     ]);
     expect(sessions).toHaveLength(61);
     expect(sessions.at(-1)?.id).toBe('current-outside-limit');
   });
 
-  test('list -> device switch/reload -> selection -> fork -> queued remote launch uses the real seams', async () => {
+  test('registered command -> QuickPick load/switch/reload/accept -> fork -> queued launch uses the real seams', async () => {
     const commands: string[] = [];
     const run: SessionBrowserRunner = async (args) => {
       commands.push(args);
@@ -73,34 +107,52 @@ describe('session browser extension-host seam', () => {
         cwd: '/srv/exact repo', timestamp: '2026-08-03T00:00:00Z', topic: 'Fix picker',
       }] : []), stderr: '' };
     };
-    const requests = new LatestSessionBrowserRequest();
-    const stale = requests.begin();
-    await loadBrowsableSessions(run, { localMachine: 'zion', limit: 60, quote });
-    const switched = requests.begin();
-    const loaded = await loadBrowsableSessions(run, {
-      device: 'yosemite-s0', localMachine: 'zion', limit: 60, quote,
-    });
-    expect(stale.current()).toBe(false);
-    expect(switched.current()).toBe(true);
-
-    const [picked] = buildSessionBrowserRows(loaded, { localMachine: 'zion' })
-      .filter((row): row is SessionBrowserSessionRow => row.kind === 'session');
+    type Item = { label: string; row?: SessionBrowserSessionRow };
+    const quickPick = new FakeQuickPick<Item, 'switch' | 'reload'>();
     let queued = '';
-    const launched = await runPickedSessionFork({
-      row: picked,
-      localMachine: 'zion',
-      showError: message => { throw new Error(message); },
-      launch: async request => {
-        queued = `${buildAgentLaunchCommand(
-          request.agentKey, 'new-session', undefined, undefined, undefined,
-          request.strategy, undefined, request.host, request.local, request.remoteCwd,
-        )} && queue ${request.prompt}`;
-        return true;
-      },
+    const registered = createForkPickSessionCommand(async () => {
+      const picked = await runSessionBrowserPicker({
+        quickPick,
+        switchButton: 'switch',
+        reloadButton: 'reload',
+        localMachine: 'zion',
+        chooseDevice: async () => ({ device: 'yosemite-s0', cancelled: false }),
+        loadItems: async device => {
+          const sessions = await loadBrowsableSessions(run, { device, localMachine: 'zion', limit: 60, quote });
+          return buildSessionBrowserRows(sessions, { localMachine: 'zion' })
+            .filter((row): row is SessionBrowserSessionRow => row.kind === 'session')
+            .map(row => ({ label: row.label, row }));
+        },
+        emptyItem: () => ({ label: 'empty' }),
+        errorItem: message => ({ label: message }),
+      });
+      if (!picked) throw new Error('expected a picked session');
+      await runPickedSessionFork({
+        row: picked,
+        localMachine: 'zion',
+        showError: message => { throw new Error(message); },
+        launch: async request => {
+          queued = `${buildAgentLaunchCommand(
+            request.agentKey, 'new-session', undefined, undefined, undefined,
+            request.strategy, undefined, request.host, request.local, request.remoteCwd,
+          )} && queue ${request.prompt}`;
+          return true;
+        },
+      });
     });
-    expect(launched).toBe(true);
+    const commandRun = registered();
+    await Bun.sleep(0);
+    quickPick.triggerButton('switch');
+    await Bun.sleep(0);
+    quickPick.triggerButton('reload');
+    await Bun.sleep(0);
+    quickPick.selectedItems = [quickPick.items[0]];
+    quickPick.accept();
+    await commandRun;
+
     expect(commands).toEqual([
       'sessions --all -n 60 --json',
+      "sessions --all -n 60 --json --host 'yosemite-s0'",
       "sessions --all -n 60 --json --host 'yosemite-s0'",
     ]);
     expect(queued).toContain("--host 'yosemite-s0' --remote-cwd '/srv/exact repo'");

--- a/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.test.ts
@@ -82,7 +82,8 @@ describe('session browser extension-host seam', () => {
       return args.startsWith('sessions --all')
         ? { stdout: JSON.stringify(recent), stderr: '' }
         : { stdout: JSON.stringify([{
-            id: 'current-outside-limit', shortId: 'current-', agent: 'claude', timestamp: '2026-01-01T00:00:00Z',
+            sessionId: 'current-outside-limit', kind: 'claude', startedAtMs: Date.parse('2026-01-01T00:00:00Z'),
+            cwd: '/repo', project: 'agents-cli', machine: 'zion',
           }]), stderr: '' };
     };
 
@@ -95,6 +96,8 @@ describe('session browser extension-host seam', () => {
     ]);
     expect(sessions).toHaveLength(61);
     expect(sessions.at(-1)?.id).toBe('current-outside-limit');
+    expect(sessions.at(-1)?.agent).toBe('claude');
+    expect(sessions.at(-1)?.timestamp).toBe('2026-01-01T00:00:00.000Z');
   });
 
   test('registered command -> QuickPick load/switch/reload/accept -> fork -> queued launch uses the real seams', async () => {

--- a/apps/factory/src/vscode/sessionBrowser.vscode.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.ts
@@ -151,7 +151,10 @@ export async function runSessionBrowserPicker<Item extends { row?: SessionBrowse
       const chosen = await opts.chooseDevice(device);
       switching = false;
       opts.quickPick.show();
-      if (chosen.cancelled) return;
+      if (chosen.cancelled) {
+        void load();
+        return;
+      }
       device = chosen.device;
       void load();
     });

--- a/apps/factory/src/vscode/sessionBrowser.vscode.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.ts
@@ -1,0 +1,103 @@
+import type { BrowsableSession } from '../core/sessionBrowser';
+import type { RunStrategy } from '../core/agents';
+import { buildForkSessionRequest } from '../core/forkSession';
+import { forkHostForSession, type SessionBrowserSessionRow } from '../core/sessionBrowser';
+
+export interface SessionBrowserRunResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type SessionBrowserRunner = (
+  args: string,
+  options: { maxBuffer: number; timeout: number },
+) => Promise<SessionBrowserRunResult>;
+
+function parseSessionList(stdout: string): BrowsableSession[] {
+  const parsed = JSON.parse(stdout);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((session): session is BrowsableSession =>
+    !!session && typeof session === 'object' && typeof session.id === 'string');
+}
+
+export async function loadBrowsableSessions(
+  run: SessionBrowserRunner,
+  opts: {
+    device?: string;
+    localMachine: string;
+    limit: number;
+    currentSessionId?: string | null;
+    currentSessionDevice?: string;
+    quote: (value: string) => string;
+  },
+): Promise<BrowsableSession[]> {
+  const scope = opts.device ? ` --host ${opts.quote(opts.device)}` : '';
+  const timeout = opts.device ? 45_000 : 20_000;
+  const listed = await run(`sessions --all -n ${opts.limit} --json${scope}`, {
+    maxBuffer: 16 * 1024 * 1024,
+    timeout,
+  });
+  if (listed.stderr.trim()) throw new Error(listed.stderr.trim());
+  const sessions = parseSessionList(listed.stdout);
+
+  const browsingCurrentDevice = (opts.device ?? opts.localMachine) ===
+    (opts.currentSessionDevice ?? opts.localMachine);
+  if (!opts.currentSessionId || !browsingCurrentDevice ||
+      sessions.some(session => session.id === opts.currentSessionId || session.shortId === opts.currentSessionId)) {
+    return sessions;
+  }
+
+  const exact = await run(`sessions ${opts.quote(opts.currentSessionId)} --json${scope}`, {
+    maxBuffer: 16 * 1024 * 1024,
+    timeout,
+  });
+  if (exact.stderr.trim()) throw new Error(exact.stderr.trim());
+  const detail = JSON.parse(exact.stdout);
+  const current = detail?.session ?? detail;
+  if (current && typeof current === 'object' && typeof current.id === 'string') {
+    sessions.push(current as BrowsableSession);
+  }
+  return sessions;
+}
+
+export class LatestSessionBrowserRequest {
+  private generation = 0;
+
+  begin(): { current: () => boolean } {
+    const requestGeneration = ++this.generation;
+    return { current: () => requestGeneration === this.generation };
+  }
+}
+
+export async function runPickedSessionFork(opts: {
+  row: SessionBrowserSessionRow;
+  localMachine: string;
+  launch: (request: {
+    agentKey: string;
+    prompt: string;
+    strategy?: RunStrategy;
+    host?: string;
+    local: boolean;
+    cwd?: string;
+    remoteCwd?: string;
+  }) => Promise<boolean>;
+  showError: (message: string) => void;
+}): Promise<boolean> {
+  const request = buildForkSessionRequest({
+    sessionId: opts.row.session.id,
+    agentKey: opts.row.session.agent,
+    host: forkHostForSession(opts.row.session, opts.localMachine),
+  });
+  if (!request.ok) {
+    opts.showError(request.reason === 'no_session'
+      ? `Session ${opts.row.session.shortId} has no id to fork.`
+      : `Session ${opts.row.session.shortId} has no agent harness to fork with.`);
+    return false;
+  }
+
+  return opts.launch({
+    ...request,
+    cwd: request.local ? opts.row.session.cwd : undefined,
+    remoteCwd: request.local ? undefined : opts.row.session.cwd,
+  });
+}

--- a/apps/factory/src/vscode/sessionBrowser.vscode.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.ts
@@ -47,6 +47,7 @@ export async function loadBrowsableSessions(
       sessions.some(session => session.id === opts.currentSessionId || session.shortId === opts.currentSessionId)) {
     return sessions;
   }
+  const currentSessionId = opts.currentSessionId;
 
   const exact = await run(`sessions --active --json${scope}`, {
     maxBuffer: 16 * 1024 * 1024,
@@ -57,7 +58,7 @@ export async function loadBrowsableSessions(
     exact.stdout,
     opts.device ?? opts.localMachine,
     Date.now(),
-  ).filter(session => session.sessionId === opts.currentSessionId || session.sessionId.startsWith(opts.currentSessionId));
+  ).filter(session => session.sessionId === currentSessionId || session.sessionId.startsWith(currentSessionId));
   if (current) {
     sessions.push({
       id: current.sessionId,

--- a/apps/factory/src/vscode/sessionBrowser.vscode.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.ts
@@ -54,10 +54,19 @@ export async function loadBrowsableSessions(
   if (exact.stderr.trim()) throw new Error(exact.stderr.trim());
   const active = JSON.parse(exact.stdout);
   const current = Array.isArray(active)
-    ? active.find(session => session?.id === opts.currentSessionId || session?.shortId === opts.currentSessionId)
+    ? active.find(session => session?.sessionId === opts.currentSessionId || session?.sessionId?.startsWith(opts.currentSessionId))
     : undefined;
-  if (current && typeof current === 'object' && typeof current.id === 'string') {
-    sessions.push(current as BrowsableSession);
+  if (current && typeof current === 'object' && typeof current.sessionId === 'string') {
+    sessions.push({
+      id: current.sessionId,
+      shortId: current.sessionId.slice(0, 8),
+      agent: current.kind,
+      timestamp: new Date(current.startedAtMs).toISOString(),
+      project: current.project,
+      cwd: current.cwd,
+      topic: current.topic,
+      machine: current.machine,
+    });
   }
   return sessions;
 }

--- a/apps/factory/src/vscode/sessionBrowser.vscode.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.ts
@@ -37,7 +37,7 @@ export async function loadBrowsableSessions(
     maxBuffer: 16 * 1024 * 1024,
     timeout,
   });
-  if (listed.stderr.trim()) throw new Error(listed.stderr.trim());
+  if (opts.device && listed.stderr.trim()) throw new Error(listed.stderr.trim());
   const sessions = parseSessionList(listed.stdout);
 
   const browsingCurrentDevice = (opts.device ?? opts.localMachine) ===
@@ -47,13 +47,15 @@ export async function loadBrowsableSessions(
     return sessions;
   }
 
-  const exact = await run(`sessions ${opts.quote(opts.currentSessionId)} --json${scope}`, {
+  const exact = await run(`sessions --active --json${scope}`, {
     maxBuffer: 16 * 1024 * 1024,
     timeout,
   });
   if (exact.stderr.trim()) throw new Error(exact.stderr.trim());
-  const detail = JSON.parse(exact.stdout);
-  const current = detail?.session ?? detail;
+  const active = JSON.parse(exact.stdout);
+  const current = Array.isArray(active)
+    ? active.find(session => session?.id === opts.currentSessionId || session?.shortId === opts.currentSessionId)
+    : undefined;
   if (current && typeof current === 'object' && typeof current.id === 'string') {
     sessions.push(current as BrowsableSession);
   }
@@ -67,6 +69,85 @@ export class LatestSessionBrowserRequest {
     const requestGeneration = ++this.generation;
     return { current: () => requestGeneration === this.generation };
   }
+}
+
+export interface SessionBrowserQuickPick<Item, Button> {
+  title: string | undefined;
+  busy: boolean;
+  items: readonly Item[];
+  selectedItems: readonly Item[];
+  show(): void;
+  hide(): void;
+  onDidTriggerButton(listener: (button: Button) => void): unknown;
+  onDidAccept(listener: () => void): unknown;
+  onDidHide(listener: () => void): unknown;
+}
+
+export function createForkPickSessionCommand(run: () => Promise<void>): () => Promise<void> {
+  return run;
+}
+
+export async function runSessionBrowserPicker<Item extends { row?: SessionBrowserSessionRow }, Button>(opts: {
+  quickPick: SessionBrowserQuickPick<Item, Button>;
+  switchButton: Button;
+  reloadButton: Button;
+  localMachine: string;
+  loadItems: (device?: string) => Promise<Item[]>;
+  chooseDevice: (current?: string) => Promise<{ device?: string; cancelled: boolean }>;
+  emptyItem: (device?: string) => Item;
+  errorItem: (message: string) => Item;
+}): Promise<SessionBrowserSessionRow | null> {
+  let device: string | undefined;
+  let switching = false;
+  const requests = new LatestSessionBrowserRequest();
+
+  const load = async (): Promise<void> => {
+    const request = requests.begin();
+    const loadingDevice = device;
+    opts.quickPick.title = `Agents: Fork (Pick Session) · ${loadingDevice ?? opts.localMachine}`;
+    opts.quickPick.busy = true;
+    opts.quickPick.items = [];
+    try {
+      const items = await opts.loadItems(loadingDevice);
+      if (!request.current()) return;
+      opts.quickPick.items = items.length > 0 ? items : [opts.emptyItem(loadingDevice)];
+    } catch (error: any) {
+      if (!request.current()) return;
+      const message = (error?.stderr || error?.message || String(error)).trim().split('\n')[0];
+      opts.quickPick.items = [opts.errorItem(message)];
+    } finally {
+      if (request.current()) opts.quickPick.busy = false;
+    }
+  };
+
+  return new Promise(resolve => {
+    opts.quickPick.onDidTriggerButton(async button => {
+      if (button === opts.reloadButton) {
+        void load();
+        return;
+      }
+      if (button !== opts.switchButton) return;
+      switching = true;
+      opts.quickPick.hide();
+      const chosen = await opts.chooseDevice(device);
+      switching = false;
+      opts.quickPick.show();
+      if (chosen.cancelled) return;
+      device = chosen.device;
+      void load();
+    });
+    opts.quickPick.onDidAccept(() => {
+      const picked = opts.quickPick.selectedItems[0];
+      if (!picked?.row) return;
+      resolve(picked.row);
+      opts.quickPick.hide();
+    });
+    opts.quickPick.onDidHide(() => {
+      if (!switching) resolve(null);
+    });
+    opts.quickPick.show();
+    void load();
+  });
 }
 
 export async function runPickedSessionFork(opts: {

--- a/apps/factory/src/vscode/sessionBrowser.vscode.ts
+++ b/apps/factory/src/vscode/sessionBrowser.vscode.ts
@@ -2,6 +2,7 @@ import type { BrowsableSession } from '../core/sessionBrowser';
 import type { RunStrategy } from '../core/agents';
 import { buildForkSessionRequest } from '../core/forkSession';
 import { forkHostForSession, type SessionBrowserSessionRow } from '../core/sessionBrowser';
+import { normalizeActiveSessions } from '../core/remoteSessions';
 
 export interface SessionBrowserRunResult {
   stdout: string;
@@ -51,21 +52,22 @@ export async function loadBrowsableSessions(
     maxBuffer: 16 * 1024 * 1024,
     timeout,
   });
-  if (exact.stderr.trim()) throw new Error(exact.stderr.trim());
-  const active = JSON.parse(exact.stdout);
-  const current = Array.isArray(active)
-    ? active.find(session => session?.sessionId === opts.currentSessionId || session?.sessionId?.startsWith(opts.currentSessionId))
-    : undefined;
-  if (current && typeof current === 'object' && typeof current.sessionId === 'string') {
+  if (opts.device && exact.stderr.trim()) throw new Error(exact.stderr.trim());
+  const [current] = normalizeActiveSessions(
+    exact.stdout,
+    opts.device ?? opts.localMachine,
+    Date.now(),
+  ).filter(session => session.sessionId === opts.currentSessionId || session.sessionId.startsWith(opts.currentSessionId));
+  if (current) {
     sessions.push({
       id: current.sessionId,
       shortId: current.sessionId.slice(0, 8),
-      agent: current.kind,
-      timestamp: new Date(current.startedAtMs).toISOString(),
+      agent: current.agentType,
+      timestamp: new Date(current.startedAtMs ?? current.lastActivityMs ?? 0).toISOString(),
       project: current.project,
       cwd: current.cwd,
       topic: current.topic,
-      machine: current.machine,
+      machine: current.host,
     });
   }
   return sessions;
@@ -77,6 +79,10 @@ export class LatestSessionBrowserRequest {
   begin(): { current: () => boolean } {
     const requestGeneration = ++this.generation;
     return { current: () => requestGeneration === this.generation };
+  }
+
+  invalidate(): void {
+    this.generation++;
   }
 }
 
@@ -92,8 +98,11 @@ export interface SessionBrowserQuickPick<Item, Button> {
   onDidHide(listener: () => void): unknown;
 }
 
-export function createForkPickSessionCommand(run: () => Promise<void>): () => Promise<void> {
-  return run;
+export function registerForkPickSessionCommand<Disposable>(
+  register: (command: string, callback: () => Promise<void>) => Disposable,
+  run: () => Promise<void>,
+): Disposable {
+  return register('agents.forkPickSession', run);
 }
 
 export async function runSessionBrowserPicker<Item extends { row?: SessionBrowserSessionRow }, Button>(opts: {
@@ -152,6 +161,7 @@ export async function runSessionBrowserPicker<Item extends { row?: SessionBrowse
       opts.quickPick.hide();
     });
     opts.quickPick.onDidHide(() => {
+      requests.invalidate();
       if (!switching) resolve(null);
     });
     opts.quickPick.show();


### PR DESCRIPTION
Fixes the five blocking review findings on #1749's Factory session picker. Stacked on `factory-fork-pick-session`; this does not target `main`.

## What changed

- Guards picker loads by request generation, so only the latest startup, device-switch, or reload request can update title/items/busy state.
- Preserves stderr as the picker error for an explicitly selected device, while retaining valid local best-effort fleet rows alongside unrelated-host skip notices.
- Emits exact remote session directories through `agents run --remote-cwd`.
- Keeps the ordinary 60-session listing, then joins the invoked session from metadata-only `sessions --active --json` when truncation omitted it.
- Adds an extension-host seam test that invokes the registered command and drives QuickPick load, device switch, reload, accept, fork request, and queued remote launch without a mocking library.

## Tracking

- Repairs #1749
- Related follow-up: #1757

## Verification

```text
bun test src/core/agents.test.ts src/core/sessionBrowser.test.ts src/vscode/sessionBrowser.vscode.test.ts src/vscode/forkCommands.test.ts
83 pass
0 fail
257 expect() calls
```

```text
bun run compile
✓ 1812 modules transformed.
✓ built in 1.42s
✓ 2171 modules transformed.
✓ built in 2.06s
```

```text
git diff --check
(no output)
```

The full Factory suite has one order-dependent fake-VSCode failure in the existing `tmux.test.ts`; the same file passes alone: `11 pass, 0 fail`.

## Run artifact

Logic-only CLI/extension-host surface; there is no rendered UI screenshot. The terminal recording includes the picker-flow test and exact queued command assertion:

`yosemite-s0:/tmp/pr-1749-factory-picker-terminal-run.txt`

Public repository: session transcript intentionally omitted.
