### PR TITLE
feat(activity): read the whole fleet, grouped by project, without the warning wall

### DIFF
--- a/apps/cli/.changelog/next/activity-fleet-by-project.md
+++ b/apps/cli/.changelog/next/activity-fleet-by-project.md
@@ -1,0 +1,42 @@
+- **`agents activity` now shows the whole fleet, grouped by project.** The
+  question the command answers is "what are my agents doing", and agents run on
+  every box — but it read only the local logs unless you remembered
+  `--devices-all`, and printed one flat newest-first stream. Both defaults are
+  inverted: every run fans `activity --json` out to each reachable device and
+  merges the peers' streams host-tagged, then buckets them by project, one level,
+  no sub-grouping. `--local` scopes back to this machine, `-H/--host` to named
+  boxes, and `--flat` (or `--group-by none`) restores the single stream;
+  `--devices-all`/`--hosts-all` remain accepted so existing scripts keep working.
+  A peer answering the fan-out still carries the recursion guard, so it never
+  re-fans the fleet.
+
+- **Each project header names the machines its work ran on.** A bucket reads
+  `▸ agents-cli  12 events · 4 milestones · zion, yosemite-s0` — up to three
+  machines by name plus a `+N` tail, so a project touched by a dozen boxes stays
+  one scannable line; individual rows keep their own `[host]` tag. Peers that
+  never answered are reported once at the end (`· 2 devices unreachable: …`)
+  rather than a line each above the timeline, so a missing machine is visible but
+  not noisy.
+
+- **A project is now the repository, not whatever directory the agent sat in.**
+  A cwd resolves to the git repository containing it, so `<repo>/apps/cli` files
+  under `<repo>` instead of `cli`, and a worktree under
+  `<repo>/.agents/worktrees/<slug>` folds back into the repo it branched from.
+  A directory in no repo groups as itself, and a dotfiles repo at `$HOME` is not
+  treated as a project. The `agents sessions` overview and `agents feed post` now
+  share this one resolver (`lib/project-key.ts`), so a project reads identically
+  everywhere instead of each view folding cwds its own way.
+
+- **`--limit` is spent on milestones, not on collapsed churn.** The default view
+  rolls routine `file.edited` work up to a count, so a plain slice let one busy
+  machine's 40 file edits hide every other device's PRs behind a single
+  `file edited ×40` line. The cap now bounds the milestones shown, with the
+  routine events inside that window riding along for the counts. `--all` still
+  shows routine work inline and caps every event.
+
+- **The activity header no longer carries other subsystems' hook warnings.**
+  Registering the activity-log hooks surfaced every unresolved entry in the hook
+  manifest — a missing `inject-session-id` script, someone else's half-installed
+  plugin — printing five wrapped yellow lines above the timeline on every run.
+  Those are `agents doctor`'s job; only a failure that would leave the activity
+  log unwritten is reported here.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -752,28 +752,55 @@ must not cost the operator the post — it is already written.
 ### Activity lane (`agents activity`) — progress at a glance, fleet-wide
 
 `agents activity` reads the same append-only activity stream (never re-parsing
-transcripts) and, by opt-in, across the whole fleet:
+transcripts), across the whole fleet, bucketed by project:
 
 ```bash
-agents activity                                    # this machine, newest first (default)
-agents activity --devices-all --group-by project   # per project: what each agent did, where, for which ticket
-agents activity --host yosemite-s1                 # one box over SSH (--device is an alias)
-agents activity --devices-all --filter RUSH-2100   # one ticket, fleet-wide
-agents activity --milestones                       # only plans / PRs / worktrees / sub-agents
+agents activity                    # the whole fleet, by project (default)
+agents activity --local            # just this machine
+agents activity --flat             # one newest-first stream
+agents activity --host yosemite-s1 # one box over SSH (--device is an alias)
+agents activity --filter RUSH-2100 # one ticket, fleet-wide
+agents activity --group-by device  # by machine instead of project
+agents activity --milestones       # only plans / PRs / worktrees / sub-agents
 ```
 
-- **Fleet fan-out.** `--devices-all` (alias `--hosts-all`) runs the same
-  `activity --json` on every reachable device and merges each peer's stream
-  host-tagged (feed-style, via `gatherRemoteAgentsJson`); `-H/--host` / `--device`
-  scope to specific boxes; `--local` forces local-only. Local-only is the default.
-- **Grouping + filter.** `--group-by project|device|agent` buckets the stream;
-  `--filter <text>` narrows by project / device / agent / event / ticket. The flat
-  newest-first list stays the default.
+- **Fleet fan-out is the default.** Agents run on every box, so every invocation
+  runs the same `activity --json` on each reachable device and merges the peers'
+  streams host-tagged (feed-style, via `gatherRemoteAgentsJson`). `--local` scopes
+  to this machine, `-H/--host` / `--device` to named boxes; `--devices-all` /
+  `--hosts-all` remain accepted no-ops. A peer answering the fan-out carries the
+  `AGENTS_ACTIVITY_LOCAL` guard so it never re-fans out. Peers that don't answer
+  are named once in a trailing `· N devices unreachable: …` line — never dropped
+  silently, never a line each above the timeline.
+- **Grouping is by project by default.** `--group-by project|device|agent|none`
+  picks the dimension; `--flat` (or `--group-by none`) restores the single
+  newest-first stream. There is no sub-grouping: one level, and each project
+  header names the machines its work ran on
+  (`▸ agents-cli  12 events · 4 milestones · zion, yosemite-s0`, capped at three
+  names plus a `+N` tail). `--filter <text>` narrows by project / device / agent /
+  event / ticket.
+- **Projects are repositories.** A cwd resolves to the git repository containing
+  it (`resolveProjectKey`, `lib/project-key.ts`), so `<repo>/apps/cli` files under
+  `<repo>` and a worktree under `<repo>/.agents/worktrees/<slug>` folds back into
+  the repo it branched from. A directory in no repo groups as itself, and a
+  dotfiles repo at `$HOME` is deliberately not treated as a project. This is the
+  same fold the `agents sessions` overview groups by, so a project reads
+  identically in both. Each machine resolves its own paths — a peer stamps the
+  project before its events cross the wire.
+- **`--limit` caps milestones, not churn.** The default view collapses routine
+  `file.edited` work to a count, so `-n` bounds the milestones shown and the
+  routine events inside that window ride along for the counts
+  (`capActivityEvents`). Without this, one box editing 40 files hid every other
+  device's PRs behind a single `file edited ×40` line. `--all` shows routine work
+  inline and makes `-n` a plain event cap.
 - **Enrichment (the join, not transcript parsing).** Each item is joined to live
-  sessions for the **project** (repo/worktree slug from cwd), the **execution host**
-  (`provenance.host` — the box it actually runs on), and the **Linear ticket**
-  (`ActiveSession.ticket`). `--json` is a mergeable per-host payload carrying these
-  enriched fields.
+  sessions for the **project**, the **execution host** (`provenance.host` — the box
+  it actually runs on), and the **Linear ticket** (`ActiveSession.ticket`).
+  `--json` is a mergeable per-host payload carrying these enriched fields.
+- **Only failures of its own hooks are reported.** Registering the activity-log
+  hooks surfaces unrelated manifest problems (a missing `inject-session-id`
+  script, a half-installed plugin); those belong to `agents doctor` and are not
+  printed above the timeline.
 
 ### Live tail (`--watch`, `-f`) — the money shot
 

--- a/apps/cli/src/commands/activity.test.ts
+++ b/apps/cli/src/commands/activity.test.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import {
   formatUnreachableNote,
   isActivityHookError,
+  isManifestHookError,
   registerActivityCommand,
   resolveActivityGrouping,
   resolveActivityScope,
@@ -127,5 +128,21 @@ describe('isActivityHookError', () => {
     // The five wrapped lines this command used to print above every timeline.
     expect(isActivityHookError('inject-session-id: script not found in user or system hooks dir')).toBe(false);
     expect(isActivityHookError('register-session-pid: script not found in user or system hooks dir')).toBe(false);
+  });
+});
+
+describe('isManifestHookError', () => {
+  const manifestNames = ['activity-log-intent', 'activity-log-result', 'inject-session-id'];
+
+  it('keeps an agent-level abort that names no hook — it leaves the log unwritten', () => {
+    // A corrupt settings.json aborts registration for the whole agent; filtering
+    // it out would silently stop activity logging for that version.
+    expect(isManifestHookError('Failed to parse settings.json', manifestNames)).toBe(false);
+    expect(isManifestHookError('Failed to write agents-cli-hooks.ts: EACCES', manifestNames)).toBe(false);
+  });
+
+  it('attributes per-hook failures to their hook', () => {
+    expect(isManifestHookError('inject-session-id: script not found', manifestNames)).toBe(true);
+    expect(isManifestHookError('activity-log-intent: script not found', manifestNames)).toBe(true);
   });
 });

--- a/apps/cli/src/commands/activity.test.ts
+++ b/apps/cli/src/commands/activity.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { Command } from 'commander';
-import { registerActivityCommand } from './activity.js';
+import {
+  formatUnreachableNote,
+  isActivityHookError,
+  registerActivityCommand,
+  resolveActivityGrouping,
+  resolveActivityScope,
+} from './activity.js';
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
 function activityCmd(): Command {
   const program = new Command();
@@ -15,7 +23,7 @@ describe('activity command option/alias wiring', () => {
     const longs = activityCmd().options.map((o) => o.long);
     for (const flag of [
       '--local', '--host', '--device', '--devices-all', '--hosts-all',
-      '--group-by', '--filter', '--milestones', '--all', '--json', '--since', '--limit',
+      '--group-by', '--flat', '--filter', '--milestones', '--all', '--json', '--since', '--limit',
     ]) {
       expect(longs).toContain(flag);
     }
@@ -44,5 +52,80 @@ describe('activity command option/alias wiring', () => {
     cmd2.exitOverride();
     cmd2.parseOptions(['--device', 'zion', '--device', 'mac-mini']);
     expect(cmd2.opts().device).toEqual(['zion', 'mac-mini']);
+  });
+});
+
+describe('resolveActivityGrouping', () => {
+  it('groups by project when nothing is asked for', () => {
+    expect(resolveActivityGrouping({})).toBe('project');
+  });
+
+  it('honours an explicit dimension', () => {
+    expect(resolveActivityGrouping({ groupBy: 'device' })).toBe('device');
+    expect(resolveActivityGrouping({ groupBy: 'agent' })).toBe('agent');
+  });
+
+  it('drops back to a flat stream for --flat and --group-by none', () => {
+    expect(resolveActivityGrouping({ flat: true })).toBeUndefined();
+    expect(resolveActivityGrouping({ groupBy: 'none' })).toBeUndefined();
+    // --flat wins over a dimension: it is the explicit "no buckets" ask.
+    expect(resolveActivityGrouping({ flat: true, groupBy: 'device' })).toBeUndefined();
+  });
+
+  it('rejects an unknown dimension instead of silently defaulting', () => {
+    expect(() => resolveActivityGrouping({ groupBy: 'repo' })).toThrow(/project, device, agent, none/);
+  });
+});
+
+describe('resolveActivityScope', () => {
+  it('reads the whole fleet by default', () => {
+    expect(resolveActivityScope({}, 'zion', false)).toEqual({ includeLocal: true, wantRemote: true });
+  });
+
+  it('--local skips the fan-out', () => {
+    expect(resolveActivityScope({ local: true }, 'zion', false)).toEqual({ includeLocal: true, wantRemote: false });
+  });
+
+  it('a peer answering the fan-out never re-fans it out', () => {
+    // Without this guard, every dialed peer would dial the fleet in turn.
+    expect(resolveActivityScope({}, 'zion', true)).toEqual({ includeLocal: true, wantRemote: false });
+  });
+
+  it('an explicit --host list scopes to those peers and drops this box', () => {
+    const scope = resolveActivityScope({ host: ['mac-mini'] }, 'zion', false);
+    expect(scope.includeLocal).toBe(false);
+    expect(scope.wantRemote).toBe(true);
+    expect(scope.remoteHosts).toEqual(['mac-mini']);
+  });
+
+  it('--host <self> reads locally with no SSH hop', () => {
+    const scope = resolveActivityScope({ host: ['zion'] }, 'zion', false);
+    expect(scope.includeLocal).toBe(true);
+    expect(scope.wantRemote).toBe(false);
+  });
+});
+
+describe('formatUnreachableNote', () => {
+  it('says nothing when every peer answered', () => {
+    expect(formatUnreachableNote([])).toBe('');
+  });
+
+  it('reports offline peers once, compactly, instead of a line each', () => {
+    expect(stripAnsi(formatUnreachableNote(['winbox']))).toBe('  · 1 device unreachable: winbox\n\n');
+    expect(stripAnsi(formatUnreachableNote(['a', 'b', 'c', 'd', 'e', 'f'])))
+      .toBe('  · 6 devices unreachable: a, b, c, d +2\n\n');
+  });
+});
+
+describe('isActivityHookError', () => {
+  it('keeps a failure that would leave the activity log unwritten', () => {
+    expect(isActivityHookError('activity-log-intent: script not found')).toBe(true);
+    expect(isActivityHookError('activity-log-result: script not found')).toBe(true);
+  });
+
+  it('drops unrelated hook noise that belongs to agents doctor', () => {
+    // The five wrapped lines this command used to print above every timeline.
+    expect(isActivityHookError('inject-session-id: script not found in user or system hooks dir')).toBe(false);
+    expect(isActivityHookError('register-session-pid: script not found in user or system hooks dir')).toBe(false);
   });
 });

--- a/apps/cli/src/commands/activity.ts
+++ b/apps/cli/src/commands/activity.ts
@@ -89,7 +89,10 @@ interface ActivityOpts {
  * missing `inject-session-id` script, someone else's half-installed plugin —
  * and echoing all of them printed five wrapped lines of unrelated noise above
  * the timeline on every run. Those belong to `agents doctor`, which exists to
- * find them; here they are dropped and only an activity-hook failure surfaces.
+ * find them; here they are dropped. What still surfaces: an activity-hook
+ * failure, and any error attributable to NO manifest hook — a corrupt
+ * settings.json or an unwritable hooks file aborts registration for the whole
+ * agent, which is exactly a failure that leaves the activity log unwritten.
  */
 async function installActivityHooks(): Promise<string[]> {
   const warnings: string[] = [];
@@ -103,9 +106,12 @@ async function installActivityHooks(): Promise<string[]> {
     import('../lib/versions.js'),
   ]);
   const manifest = parseHookManifest({ warn: false });
+  const manifestNames = Object.keys(manifest);
   for (const { agent, version } of iterHooksCapableVersions({ agent: 'claude' })) {
     const result = registerHooksToSettings(agent, getVersionHomePath(agent, version), manifest);
-    const ours = result.errors.filter(isActivityHookError);
+    const ours = result.errors.filter(
+      (e) => isActivityHookError(e) || !isManifestHookError(e, manifestNames),
+    );
     if (ours.length > 0) warnings.push(`${agent}@${version}: ${ours.join('; ')}`);
   }
   return warnings;
@@ -118,6 +124,16 @@ async function installActivityHooks(): Promise<string[]> {
  */
 export function isActivityHookError(error: string): boolean {
   return Object.keys(ACTIVITY_HOOK_DEFINITIONS).some((name) => error.startsWith(`${name}:`));
+}
+
+/**
+ * Is this error attributable to a named manifest hook at all? Errors that name
+ * no hook — `Failed to parse settings.json`, `Failed to write
+ * agents-cli-hooks.ts: …` — are agent-level aborts, not per-hook noise, and
+ * must never be filtered out.
+ */
+export function isManifestHookError(error: string, manifestNames: string[]): boolean {
+  return manifestNames.some((name) => error.startsWith(`${name}:`));
 }
 
 /**
@@ -369,6 +385,8 @@ project header names the machines its work ran on.
       enriched = capActivityEvents(enriched, opts.limit, { all: opts.all || opts.milestones });
 
       if (opts.json) {
+        // stdout stays clean JSON, but an unanswered peer is never a silent drop.
+        if (unreachable.length > 0) process.stderr.write(formatUnreachableNote(unreachable));
         process.stdout.write(`${JSON.stringify(enriched, null, 2)}\n`);
         return;
       }

--- a/apps/cli/src/commands/activity.ts
+++ b/apps/cli/src/commands/activity.ts
@@ -8,27 +8,32 @@
  * it tails the logs and collapses routine work to counts, surfacing milestones
  * individually and newest-first.
  *
- * Fleet-wide by opt-in: `--devices-all` (or `--host <box>`) fans the same
- * `activity --json` payload out across the fleet the way `agents feed` does,
- * merges every peer's stream host-tagged, and joins each item to live sessions
- * (project / ticket / execution host) so `--group-by project` shows, per
- * project, what each agent did, where, and for which ticket -- progress at a
- * glance. Local-only stays the default.
+ * Fleet-wide and project-grouped BY DEFAULT: the question this command answers
+ * is "what are my agents doing", and agents run on every box, so a local-only
+ * flat stream answered a narrower question than anyone asked. Each run fans the
+ * same `activity --json` payload out across the fleet the way `agents feed`
+ * does, merges every peer's stream host-tagged, joins each item to live sessions
+ * (project / ticket / execution host), and buckets it by project -- one level,
+ * no sub-grouping, with the machines named in each project's header.
+ *
+ * `--local` scopes back to this machine, `--host <box>` to named peers, and
+ * `--flat` (or `--group-by none`) restores the single newest-first stream.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import {
+  ACTIVITY_HOOK_DEFINITIONS,
   collapseActivity,
   enrichActivityEvents,
+  capActivityEvents,
   ensureActivityLogHook,
   filterActivityEvents,
-  formatActivityGroupHeader,
+  formatActivityGroupMeta,
   formatEnrichedActivityLine,
   formatProgressUpdate,
   groupActivity,
   mergeActivityEvents,
   parseActivityPayload,
-  projectFromCwd,
   readRecentActivity,
   styleForEvent,
   tierForEvent,
@@ -37,6 +42,7 @@ import {
   type EnrichedActivityEvent,
 } from '../lib/activity.js';
 import { gatherRemoteAgentsJson } from '../lib/remote-agents-json.js';
+import { resolveProjectKey } from '../lib/project-key.js';
 import { machineId, normalizeHost } from '../lib/machine-id.js';
 import { shouldIncludeLocalFeed, remoteFeedHostsToDial } from './feed.js';
 import { getActiveSessions } from '../lib/session/active.js';
@@ -45,7 +51,19 @@ import type { ActiveSession } from '../lib/session/active.js';
 /** Recursion guard: a peer answering a fan-out never re-fans-out itself. */
 export const ACTIVITY_NO_FANOUT_ENV = 'AGENTS_ACTIVITY_LOCAL';
 
+/** `--group-by` values; `none` is the opt-out that `--flat` also selects. */
 const GROUP_BY_VALUES: ActivityGroupBy[] = ['project', 'device', 'agent'];
+const GROUP_BY_NONE = 'none';
+
+/** Grouping when neither `--group-by` nor `--flat` is given. */
+const DEFAULT_GROUP_BY: ActivityGroupBy = 'project';
+
+/**
+ * How much further back than `--limit` the LOCAL log read goes, so routine
+ * churn on this box can't crowd the fleet's milestones out of the window
+ * ({@link capActivityEvents} does the real capping).
+ */
+const LOCAL_READ_HEADROOM = 5;
 
 interface ActivityOpts {
   json?: boolean;
@@ -59,10 +77,20 @@ interface ActivityOpts {
   devicesAll?: boolean;
   hostsAll?: boolean;
   groupBy?: string;
+  flat?: boolean;
   filter?: string;
 }
 
-/** Wire the activity-log hooks into each hooks-capable version's settings. */
+/**
+ * Wire the activity-log hooks into each hooks-capable version's settings.
+ *
+ * Only a failure that leaves THIS command's log unwritten is worth a warning.
+ * `registerHooksToSettings` reports every unresolved hook in the manifest — a
+ * missing `inject-session-id` script, someone else's half-installed plugin —
+ * and echoing all of them printed five wrapped lines of unrelated noise above
+ * the timeline on every run. Those belong to `agents doctor`, which exists to
+ * find them; here they are dropped and only an activity-hook failure surfaces.
+ */
 async function installActivityHooks(): Promise<string[]> {
   const warnings: string[] = [];
   const hookInstall = ensureActivityLogHook();
@@ -77,12 +105,26 @@ async function installActivityHooks(): Promise<string[]> {
   const manifest = parseHookManifest({ warn: false });
   for (const { agent, version } of iterHooksCapableVersions({ agent: 'claude' })) {
     const result = registerHooksToSettings(agent, getVersionHomePath(agent, version), manifest);
-    if (result.errors.length > 0) warnings.push(`${agent}@${version}: ${result.errors.join('; ')}`);
+    const ours = result.errors.filter(isActivityHookError);
+    if (ours.length > 0) warnings.push(`${agent}@${version}: ${ours.join('; ')}`);
   }
   return warnings;
 }
 
-/** Session facts (project / ticket / execution host) keyed for the read-time join. */
+/**
+ * Does this hook-registration error concern one of the activity-log hooks?
+ * `registerHooksToSettings` prefixes each error with the manifest hook name
+ * (`<name>: script not found`), so the entry names are the discriminator.
+ */
+export function isActivityHookError(error: string): boolean {
+  return Object.keys(ACTIVITY_HOOK_DEFINITIONS).some((name) => error.startsWith(`${name}:`));
+}
+
+/**
+ * Session facts (project / ticket / execution host) keyed for the read-time
+ * join. These sessions are this machine's, so their cwds get the repository-
+ * aware resolution rather than the bare cwd fold.
+ */
 function activityHintsFromSessions(sessions: ActiveSession[]): ActivitySessionHint[] {
   return sessions.map((s) => ({
     sessionId: s.sessionId,
@@ -90,7 +132,7 @@ function activityHintsFromSessions(sessions: ActiveSession[]): ActivitySessionHi
     // Where the process actually lives — the SSH-resolved provenance host, else
     // the cross-machine `machine` id. Normalized to match the event `host` form.
     executionHost: s.provenance?.host ? normalizeHost(s.provenance.host) : s.machine,
-    project: projectFromCwd(s.cwd),
+    project: resolveProjectKey(s.cwd),
   }));
 }
 
@@ -130,6 +172,24 @@ function renderFlat(events: EnrichedActivityEvent[], opts: ActivityOpts): void {
   process.stdout.write('\n');
 }
 
+/** Max peers named in the unreachable note before the rest collapse to `+N`. */
+const UNREACHABLE_NAME_LIMIT = 4;
+
+/**
+ * One compact trailing note for peers that didn't answer the fan-out. Now that
+ * every run dials the fleet, an offline box is routine -- but never silent: the
+ * reader has to know the timeline is missing a machine, not that the machine
+ * was idle. Empty string when everything answered.
+ */
+export function formatUnreachableNote(skipped: string[]): string {
+  if (skipped.length === 0) return '';
+  const named = skipped.slice(0, UNREACHABLE_NAME_LIMIT);
+  const rest = skipped.length - named.length;
+  const list = rest > 0 ? `${named.join(', ')} +${rest}` : named.join(', ');
+  const noun = skipped.length === 1 ? 'device' : 'devices';
+  return chalk.gray(`  · ${skipped.length} ${noun} unreachable: ${list}\n\n`);
+}
+
 /** Print the bucketed view (`--group-by project|device|agent`). */
 function renderGrouped(events: EnrichedActivityEvent[], by: ActivityGroupBy, opts: ActivityOpts): void {
   const groups = groupActivity(events, by);
@@ -138,7 +198,11 @@ function renderGrouped(events: EnrichedActivityEvent[], by: ActivityGroupBy, opt
   const showProject = by !== 'project';
   process.stdout.write(chalk.bold(`\n  activity by ${by}\n`));
   for (const group of groups) {
-    process.stdout.write(`\n  ${chalk.bold(formatActivityGroupHeader(group))}\n`);
+    // `▸ <label>  <meta>` -- label leads in cyan so projects scan down the
+    // left edge (mirrors the `agents sessions` overview), the counts and the
+    // machines that touched this project trail behind it in gray.
+    const meta = formatActivityGroupMeta(group, { showDevices: by !== 'device' });
+    process.stdout.write(`\n  ${chalk.cyan('▸')} ${chalk.cyan.bold(group.label)}  ${chalk.gray(meta)}\n`);
     const { milestones, counts, subagentCount } = collapseActivity(group.events);
     const shown = opts.all ? group.events : milestones;
     for (const ev of shown) {
@@ -157,53 +221,102 @@ function renderGrouped(events: EnrichedActivityEvent[], by: ActivityGroupBy, opt
   process.stdout.write('\n');
 }
 
+/**
+ * Resolve `--group-by` / `--flat` into the grouping dimension, or `undefined`
+ * for a flat stream. Throws on an unknown value so the caller can exit 1 --
+ * a mistyped dimension must not silently fall back to the default.
+ */
+export function resolveActivityGrouping(opts: Pick<ActivityOpts, 'groupBy' | 'flat'>): ActivityGroupBy | undefined {
+  if (opts.flat) return undefined;
+  if (opts.groupBy === undefined) return DEFAULT_GROUP_BY;
+  if (opts.groupBy === GROUP_BY_NONE) return undefined;
+  if (!GROUP_BY_VALUES.includes(opts.groupBy as ActivityGroupBy)) {
+    throw new Error(`--group-by must be one of: ${[...GROUP_BY_VALUES, GROUP_BY_NONE].join(', ')}`);
+  }
+  return opts.groupBy as ActivityGroupBy;
+}
+
+/** Which machines an invocation reads from. Pure -- no SSH, no device registry. */
+export interface ActivityScope {
+  /** Read this box's own activity logs. */
+  includeLocal: boolean;
+  /** Dial peers over SSH. */
+  wantRemote: boolean;
+  /** Peers to dial; `undefined` means "every reachable device". */
+  remoteHosts?: string[];
+}
+
+/**
+ * Decide the read scope. Fleet-wide is the DEFAULT -- agents run on every box,
+ * so "what are my agents doing" is a fleet question -- and three things narrow
+ * it: `--local`, an explicit `--host`/`--device` list, and the recursion guard
+ * a peer answering a fan-out carries (else every peer would re-fan the fleet).
+ * `--devices-all`/`--hosts-all` are kept as explicit no-ops for scripts that
+ * already pass them.
+ */
+export function resolveActivityScope(
+  opts: Pick<ActivityOpts, 'local' | 'host'>,
+  self: string,
+  noFanoutEnv = process.env[ACTIVITY_NO_FANOUT_ENV] === '1',
+): ActivityScope {
+  if (opts.local === true || noFanoutEnv) return { includeLocal: true, wantRemote: false };
+  const explicitHosts = opts.host;
+  if (explicitHosts && explicitHosts.length > 0) {
+    const remoteHosts = remoteFeedHostsToDial(explicitHosts, self) ?? [];
+    return {
+      includeLocal: shouldIncludeLocalFeed(explicitHosts, self),
+      wantRemote: remoteHosts.length > 0,
+      remoteHosts,
+    };
+  }
+  return { includeLocal: true, wantRemote: true };
+}
+
 export function registerActivityCommand(program: Command): void {
   program
     .command('activity')
-    .description('Recent agent activity -- plans, PRs, worktrees, sub-agents (newest first)')
+    .description('Recent agent activity across the fleet -- plans, PRs, worktrees, sub-agents, by project')
     .option('--json', 'Emit the (enriched) event list as JSON')
     .option('--all', 'Include routine activity (file edits) inline, not collapsed')
     .option('--milestones', 'Only milestone events (plans, PRs, worktrees, sub-agents)')
-    .option('-n, --limit <n>', 'Cap the number of events shown', (v) => parseInt(v, 10), 40)
+    .option('-n, --limit <n>', 'Cap the milestones shown (routine work rides along as counts); with --all, caps every event', (v) => parseInt(v, 10), 40)
     .option('--since <minutes>', 'Only events within the last N minutes', (v) => parseInt(v, 10))
     .option('--local', 'Only this machine -- skip the cross-machine SSH fan-out')
     .option('-H, --host <target...>', 'Scope to remote machine(s) over SSH; repeatable')
     .option('--device <target...>', 'Alias for --host; repeatable')
-    .option('--devices-all', 'Fan out to every reachable device on the fleet')
+    .option('--devices-all', 'Fan out to every reachable device (the default; kept for scripts)')
     .option('--hosts-all', 'Alias for --devices-all')
-    .option('--group-by <field>', 'Bucket the stream by project | device | agent')
+    .option('--group-by <field>', 'Bucket the stream by project | device | agent | none (default: project)')
+    .option('--flat', 'One newest-first stream instead of project buckets')
     .option('--filter <text>', 'Narrow to items matching a project / device / agent / event / ticket')
     .addHelpText('after', `
 Examples:
-  agents activity                              # this machine, newest first
-  agents activity --devices-all --group-by project   # per project across the fleet
+  agents activity                              # the whole fleet, by project
+  agents activity --local                      # just this machine
+  agents activity --flat                       # one newest-first stream
   agents activity --host yosemite-s1           # one box over SSH
-  agents activity --devices-all --filter RUSH-2100   # one ticket, fleet-wide
-  agents activity --milestones                 # only plans / PRs / worktrees / sub-agents
+  agents activity --filter RUSH-2100           # one ticket, fleet-wide
+  agents activity --group-by device            # by machine instead of project
 
-Each item is enriched by JOINING to live sessions (project, execution host,
-Linear ticket) -- never by re-parsing transcripts. --devices-all runs the same
-'activity --json' on each peer and merges the streams host-tagged.
+Fleet-wide and project-grouped by default: the same 'activity --json' runs on
+every reachable peer and the streams merge host-tagged. Each item is enriched by
+JOINING to live sessions (project, execution host, Linear ticket) -- never by
+re-parsing transcripts. Projects fold worktrees back into their repo, and each
+project header names the machines its work ran on.
 `)
     .action(async (opts: ActivityOpts) => {
       if (opts.device?.length) opts.host = [...(opts.host ?? []), ...opts.device];
-      const groupBy = opts.groupBy as ActivityGroupBy | undefined;
-      if (groupBy && !GROUP_BY_VALUES.includes(groupBy)) {
-        process.stderr.write(chalk.red(`--group-by must be one of: ${GROUP_BY_VALUES.join(', ')}\n`));
+      let groupBy: ActivityGroupBy | undefined;
+      try {
+        groupBy = resolveActivityGrouping(opts);
+      } catch (err) {
+        process.stderr.write(chalk.red(`${(err as Error).message}\n`));
         process.exitCode = 1;
         return;
       }
 
       const self = machineId();
-      const forceLocal = opts.local === true || process.env[ACTIVITY_NO_FANOUT_ENV] === '1';
-      const explicitHosts = opts.host;
-      const wantAll = Boolean(opts.devicesAll || opts.hostsAll);
-      const wantRemote = !forceLocal && (wantAll || (explicitHosts != null && explicitHosts.length > 0));
-      // Local events are included unless an explicit --host list excludes this box.
-      let includeLocal = true;
-      if (wantRemote && explicitHosts && explicitHosts.length > 0) {
-        includeLocal = shouldIncludeLocalFeed(explicitHosts, self);
-      }
+      const { includeLocal, wantRemote, remoteHosts } = resolveActivityScope(opts, self);
 
       const warnings = includeLocal ? await installActivityHooks() : [];
 
@@ -211,25 +324,29 @@ Linear ticket) -- never by re-parsing transcripts. --devices-all runs the same
         ? Date.now() - opts.since * 60_000
         : undefined;
 
+      // Each peer contributes its own newest `-n` window, so the merged pool is
+      // already several times the cap. The local read is the one source that
+      // would otherwise be capped twice, and reading further back costs nothing
+      // (the files are tailed either way) — so it gets the headroom.
       let events: EnrichedActivityEvent[] = includeLocal
-        ? readRecentActivity({ sinceMs, limit: opts.limit })
+        ? readRecentActivity({ sinceMs, limit: opts.limit * LOCAL_READ_HEADROOM })
         : [];
 
+      // Peers that were dialed but never answered, reported once at the end
+      // rather than as a line each above the timeline.
+      let unreachable: string[] = [];
       if (wantRemote) {
-        // Explicit hosts drop self (it's the local read); --devices-all dials
-        // every online peer (hosts undefined).
-        const remoteHosts = explicitHosts?.length ? remoteFeedHostsToDial(explicitHosts, self) : undefined;
-        if (!explicitHosts?.length || (remoteHosts && remoteHosts.length > 0)) {
-          const remoteArgs = ['activity', '--json', '-n', String(opts.limit)];
-          if (typeof opts.since === 'number' && opts.since > 0) remoteArgs.push('--since', String(opts.since));
-          const remote = await gatherRemoteAgentsJson({
-            args: remoteArgs,
-            noFanoutEnv: ACTIVITY_NO_FANOUT_ENV,
-            hosts: remoteHosts,
-            parse: parseActivityPayload,
-          });
-          events = mergeActivityEvents(events, remote.items);
-        }
+        const remoteArgs = ['activity', '--json', '-n', String(opts.limit)];
+        if (typeof opts.since === 'number' && opts.since > 0) remoteArgs.push('--since', String(opts.since));
+        const remote = await gatherRemoteAgentsJson({
+          args: remoteArgs,
+          noFanoutEnv: ACTIVITY_NO_FANOUT_ENV,
+          hosts: remoteHosts?.length ? remoteHosts : undefined,
+          parse: parseActivityPayload,
+          quiet: true,
+        });
+        events = mergeActivityEvents(events, remote.items);
+        unreachable = remote.skipped;
       }
 
       // Enrich by joining to live LOCAL sessions (ticket/project/execution host).
@@ -237,11 +354,11 @@ Linear ticket) -- never by re-parsing transcripts. --devices-all runs the same
       // fills local ones; the pure fallbacks (cwd->project, host->device) cover
       // everything either way. Skip the ps/lsof scan when there's nothing to show.
       const sessions = includeLocal && events.length > 0 ? await getActiveSessions() : [];
-      let enriched = enrichActivityEvents(events, activityHintsFromSessions(sessions));
+      let enriched = enrichActivityEvents(events, activityHintsFromSessions(sessions), resolveProjectKey);
 
       if (opts.milestones) enriched = enriched.filter((e) => tierForEvent(e.event) === 'milestone');
       if (opts.filter) enriched = filterActivityEvents(enriched, opts.filter);
-      enriched = enriched.slice(0, opts.limit);
+      enriched = capActivityEvents(enriched, opts.limit, { all: opts.all || opts.milestones });
 
       if (opts.json) {
         process.stdout.write(`${JSON.stringify(enriched, null, 2)}\n`);
@@ -252,10 +369,12 @@ Linear ticket) -- never by re-parsing transcripts. --devices-all runs the same
 
       if (enriched.length === 0) {
         process.stdout.write(chalk.gray('No recent agent activity. Events appear here as agents create plans, open PRs, and spawn sub-agents.\n'));
+        process.stdout.write(formatUnreachableNote(unreachable));
         return;
       }
 
       if (groupBy) renderGrouped(enriched, groupBy, opts);
       else renderFlat(enriched, opts);
+      process.stdout.write(formatUnreachableNote(unreachable));
     });
 }

--- a/apps/cli/src/commands/activity.ts
+++ b/apps/cli/src/commands/activity.ts
@@ -314,6 +314,14 @@ project header names the machines its work ran on.
         process.exitCode = 1;
         return;
       }
+      // `parseInt` yields NaN for a non-numeric -n, and every downstream slice
+      // against NaN is empty — an unreadable flag would otherwise render as
+      // "No recent agent activity", which is a lie about the fleet.
+      if (!Number.isFinite(opts.limit) || opts.limit <= 0) {
+        process.stderr.write(chalk.red('--limit must be a positive number\n'));
+        process.exitCode = 1;
+        return;
+      }
 
       const self = machineId();
       const { includeLocal, wantRemote, remoteHosts } = resolveActivityScope(opts, self);

--- a/apps/cli/src/commands/sessions.overview.test.ts
+++ b/apps/cli/src/commands/sessions.overview.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { overviewProjectKey, buildOverviewGroups } from './sessions.js';
 import type { SessionMeta } from '../lib/session/types.js';
 
@@ -7,18 +10,34 @@ function s(id: string, project: string | undefined, timestamp: string, cwd?: str
 }
 
 describe('overviewProjectKey', () => {
-  it('prefers the indexed project name', () => {
-    expect(overviewProjectKey({ project: 'agents-cli', cwd: '/anything' })).toBe('agents-cli');
+  it('resolves a monorepo subdir to its repo, not the stale indexed basename', () => {
+    // The indexer stamps basename(cwd) at scan time; the overview must agree with
+    // the activity timeline, which groups by the repository containing the cwd.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'overview-key-'));
+    try {
+      const repo = path.join(tmp, 'agents');
+      const sub = path.join(repo, 'apps', 'cli');
+      fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+      fs.mkdirSync(sub, { recursive: true });
+      expect(overviewProjectKey({ project: 'cli', cwd: sub })).toBe('agents');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
-  it('folds a worktree path back to its repo', () => {
+  it('falls back to the indexed project name when the cwd is unusable', () => {
+    expect(overviewProjectKey({ project: 'agents-cli', cwd: '' })).toBe('agents-cli');
+    expect(overviewProjectKey({ project: 'agents-cli' })).toBe('agents-cli');
+  });
+
+  it('folds a worktree path back to its repo even when the path is not local', () => {
+    // A synced session from another machine: the fs walk finds nothing, and the
+    // pure worktree fold inside the shared resolver still applies.
     expect(overviewProjectKey({ project: undefined, cwd: '/home/me/src/swarmify/.agents/worktrees/floor-redesign' })).toBe('swarmify');
   });
 
-  it('falls back to the leaf dir for a monorepo subdir with no project', () => {
-    // A monorepo subdir with no indexed project name groups by its leaf dir — the
-    // customizable path->project mapping is a separate follow-up.
-    expect(overviewProjectKey({ project: undefined, cwd: '/home/me/src/agents/prix/api' })).toBe('api');
+  it('uses the leaf dir for a path inside no repo', () => {
+    expect(overviewProjectKey({ project: undefined, cwd: '/definitely/not-inside-any/repo/path-xyz' })).toBe('path-xyz');
   });
 
   it('returns a sentinel for an empty cwd and no project', () => {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -14,6 +14,7 @@ import { spawn, type ChildProcess } from 'child_process';
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { truncate, padRight } from '../lib/format.js';
+import { projectKeyFromCwd } from '../lib/project-key.js';
 import ora from 'ora';
 import type { AgentId } from '../lib/types.js';
 import type { SessionAgentId, SessionMeta, ViewMode } from '../lib/session/types.js';
@@ -2015,17 +2016,12 @@ async function maybeLiveIndex(options: SessionsOptions): Promise<Map<string, Act
 
 /**
  * Group key for the overview: prefer the indexed project name; else fold the cwd
- * to its repo — a worktree (`.../<repo>/.agents/worktrees/<slug>`) folds to the
- * repo, and a monorepo subdir falls back to its leaf dir basename. Pure.
+ * to its repo via the shared {@link projectKeyFromCwd} — the same fold the
+ * `agents activity` timeline groups by, so a project reads the same in both. Pure.
  */
 export function overviewProjectKey(s: Pick<SessionMeta, 'project' | 'cwd'>): string {
   if (s.project && s.project.trim()) return s.project.trim();
-  const cwd = (s.cwd ?? '').replace(/\/+$/, '');
-  if (!cwd) return '(no project)';
-  const wt = cwd.match(/\/([^/]+)\/\.agents\/worktrees\//);
-  if (wt) return wt[1];
-  const parts = cwd.split('/');
-  return parts[parts.length - 1] || cwd;
+  return projectKeyFromCwd(s.cwd) ?? '(no project)';
 }
 
 export interface OverviewGroup {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -14,7 +14,7 @@ import { spawn, type ChildProcess } from 'child_process';
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { truncate, padRight } from '../lib/format.js';
-import { projectKeyFromCwd } from '../lib/project-key.js';
+import { resolveProjectKey } from '../lib/project-key.js';
 import ora from 'ora';
 import type { AgentId } from '../lib/types.js';
 import type { SessionAgentId, SessionMeta, ViewMode } from '../lib/session/types.js';
@@ -2015,13 +2015,18 @@ async function maybeLiveIndex(options: SessionsOptions): Promise<Map<string, Act
 }
 
 /**
- * Group key for the overview: prefer the indexed project name; else fold the cwd
- * to its repo via the shared {@link projectKeyFromCwd} — the same fold the
- * `agents activity` timeline groups by, so a project reads the same in both. Pure.
+ * Group key for the overview: resolve the cwd to its repo via the shared
+ * {@link resolveProjectKey} — the same resolver the `agents activity` timeline
+ * groups by, so a monorepo subdir (`<repo>/apps/cli`) reads as `<repo>` in both
+ * views. Falls back to the indexed project name (stamped at scan time) when the
+ * cwd carries nothing usable, e.g. a remote path this machine cannot see still
+ * folds by basename through the same resolver.
  */
 export function overviewProjectKey(s: Pick<SessionMeta, 'project' | 'cwd'>): string {
+  const resolved = resolveProjectKey(s.cwd);
+  if (resolved) return resolved;
   if (s.project && s.project.trim()) return s.project.trim();
-  return projectKeyFromCwd(s.cwd) ?? '(no project)';
+  return '(no project)';
 }
 
 export interface OverviewGroup {

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -5,13 +5,16 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import {
   ACTIVITY_LOG_HOOK_SCRIPT,
+  activityGroupDevices,
   activityGroupKey,
   appendActivityEvent,
   attachmentName,
+  capActivityEvents,
   collapseActivity,
   enrichActivityEvents,
   ensureActivityLogHook,
   filterActivityEvents,
+  formatActivityGroupMeta,
   formatEnrichedActivityLine,
   formatProgressUpdate,
   groupActivity,
@@ -748,6 +751,77 @@ describe('activityGroupKey / groupActivity', () => {
       ev({ sessionId: '2', host: 'mac-mini' }),
     ], 'device');
     expect(new Set(groups.map((g) => g.label))).toEqual(new Set(['zion', 'mac-mini']));
+  });
+});
+
+describe('capActivityEvents', () => {
+  const milestone = (id: string, host = 'zion') =>
+    ev({ sessionId: id, event: 'pr.opened', tier: 'milestone', executionHost: host });
+  const routine = (id: string, host = 'zion') =>
+    ev({ sessionId: id, event: 'file.edited', tier: 'activity', executionHost: host });
+
+  it('spends the budget on milestones, not on collapsed churn', () => {
+    // The real regression: one box editing 40 files buried every other
+    // device's PRs behind a single `file edited ×40` line.
+    const stream = [...Array.from({ length: 40 }, (_, i) => routine(`edit-${i}`)), milestone('pr', 'yosemite-s0')];
+    const capped = capActivityEvents(stream, 40);
+    expect(capped.filter((e) => e.event === 'pr.opened')).toHaveLength(1);
+  });
+
+  it('stops at the milestone cap and keeps the routine events inside that window', () => {
+    const stream = [milestone('a'), routine('r1'), milestone('b'), routine('r2'), milestone('c')];
+    const capped = capActivityEvents(stream, 2);
+    expect(capped.map((e) => e.sessionId)).toEqual(['a', 'r1', 'b']);
+  });
+
+  it('--all makes it a plain cap on every event', () => {
+    const stream = [routine('r1'), routine('r2'), milestone('a')];
+    expect(capActivityEvents(stream, 2, { all: true }).map((e) => e.sessionId)).toEqual(['r1', 'r2']);
+  });
+
+  it('keeps everything when the stream holds fewer milestones than the cap', () => {
+    const stream = [routine('r1'), milestone('a'), routine('r2')];
+    expect(capActivityEvents(stream, 10)).toHaveLength(3);
+  });
+
+  it('returns nothing for a non-positive or unparsable limit', () => {
+    expect(capActivityEvents([milestone('a')], 0)).toEqual([]);
+    expect(capActivityEvents([milestone('a')], Number.NaN)).toEqual([]);
+  });
+});
+
+describe('project group headers name the machines (device labels)', () => {
+  const group = (events: EnrichedActivityEvent[]) => ({ key: 'agents-cli', label: 'agents-cli', events });
+
+  it('orders devices by event count, then alphabetically', () => {
+    expect(activityGroupDevices([
+      ev({ sessionId: '1', executionHost: 'zion' }),
+      ev({ sessionId: '2', executionHost: 'mac-mini' }),
+      ev({ sessionId: '3', executionHost: 'zion' }),
+      ev({ sessionId: '4', executionHost: 'alpha' }),
+    ])).toEqual(['zion', 'alpha', 'mac-mini']);
+  });
+
+  it('ignores events with no resolvable machine instead of inventing one', () => {
+    expect(activityGroupDevices([ev({ sessionId: '1', host: 'unknown', executionHost: undefined })])).toEqual([]);
+  });
+
+  it('appends the machines to the group meta, capped with a +N tail', () => {
+    const events = ['zion', 'mac-mini', 'yosemite-s0', 'yosemite-s1', 'win-mini']
+      .map((h, i) => ev({ sessionId: String(i), executionHost: h, event: 'pr.opened', tier: 'milestone' }));
+    const meta = formatActivityGroupMeta(group(events), { showDevices: true });
+    expect(meta).toBe('5 events · 5 milestones · mac-mini, win-mini, yosemite-s0 +2');
+  });
+
+  it('omits the machines when the grouping dimension IS the device', () => {
+    const events = [ev({ sessionId: '1', executionHost: 'zion' })];
+    expect(formatActivityGroupMeta(group(events), { showDevices: false })).toBe('1 event');
+    expect(formatActivityGroupMeta(group(events))).toBe('1 event');
+  });
+
+  it('says nothing about machines when none are known', () => {
+    const events = [ev({ sessionId: '1', host: 'unknown', executionHost: undefined })];
+    expect(formatActivityGroupMeta(group(events), { showDevices: true })).toBe('1 event');
   });
 });
 

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -784,6 +784,8 @@ describe('capActivityEvents', () => {
     expect(capActivityEvents(stream, 10)).toHaveLength(3);
   });
 
+  // The command rejects such a limit before it gets here (`--limit must be a
+  // positive number`); this pins that the primitive never invents a window.
   it('returns nothing for a non-positive or unparsable limit', () => {
     expect(capActivityEvents([milestone('a')], 0)).toEqual([]);
     expect(capActivityEvents([milestone('a')], Number.NaN)).toEqual([]);

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -24,6 +24,7 @@ import chalk from 'chalk';
 import { relTime, truncate } from './format.js';
 import { getActivityDir, getUserAgentsDir } from './state.js';
 import { normalizeHost } from './machine-id.js';
+import { projectKeyFromCwd } from './project-key.js';
 // Type-only import: no runtime dependency on events.ts, so no import cycle
 // (events.ts / event-stream.ts import THIS module at runtime).
 import type { EventRecord } from './events.js';
@@ -558,40 +559,35 @@ export interface ActivitySessionHint {
 }
 
 /**
- * Resolve a stable project/repo name from a working directory. A worktree cwd
- * (`…/<repo>/.agents/worktrees/<slug>[/sub]`) resolves to the repo dir name so
- * a worktree session groups with its own repo; any other path resolves to its
- * basename. Pure — no filesystem access, so it works for remote events too.
+ * Resolve a stable project/repo name from a working directory — the same fold
+ * the `agents sessions` overview groups by ({@link projectKeyFromCwd}), so a
+ * project reads identically in both views.
  */
 export function projectFromCwd(cwd?: string | null): string | undefined {
-  if (!cwd) return undefined;
-  const norm = cwd.replace(/\\/g, '/').replace(/\/+$/, '');
-  if (!norm) return undefined;
-  const wtIdx = norm.indexOf('/.agents/worktrees/');
-  if (wtIdx > 0) {
-    const repoPath = norm.slice(0, wtIdx);
-    const base = repoPath.slice(repoPath.lastIndexOf('/') + 1);
-    if (base) return base;
-  }
-  const base = norm.slice(norm.lastIndexOf('/') + 1);
-  return base || undefined;
+  return projectKeyFromCwd(cwd);
 }
 
 /**
  * Join session facts (ticket / project / execution host) onto each event by
  * `sessionId`. A hint wins; otherwise pre-baked enriched fields (from a remote
  * peer that already enriched its own stream) are preserved, and project/host
- * fall back to what the event itself carries (`cwd`, `host`). Pure.
+ * fall back to what the event itself carries (`cwd`, `host`).
+ *
+ * `resolveProject` is how a caller reading its OWN machine's logs upgrades the
+ * cwd fold to real repository detection ({@link resolveProjectKey}); it defaults
+ * to the pure {@link projectFromCwd}, which is all a path from another machine
+ * can be resolved with. Pure given a pure resolver.
  */
 export function enrichActivityEvents(
   events: EnrichedActivityEvent[],
   hints: ActivitySessionHint[],
+  resolveProject: (cwd?: string | null) => string | undefined = projectFromCwd,
 ): EnrichedActivityEvent[] {
   const bySession = new Map<string, ActivitySessionHint>();
   for (const h of hints) if (h.sessionId) bySession.set(h.sessionId, h);
   return events.map((ev) => {
     const hint = ev.sessionId ? bySession.get(ev.sessionId) : undefined;
-    const project = hint?.project ?? ev.project ?? projectFromCwd(ev.cwd);
+    const project = hint?.project ?? ev.project ?? resolveProject(ev.cwd);
     const ticket = hint?.ticket ?? ev.ticket ?? undefined;
     const executionHost = hint?.executionHost ?? ev.executionHost
       ?? (ev.host && ev.host !== 'unknown' ? ev.host : undefined);
@@ -643,6 +639,44 @@ export function mergeActivityEvents(...groups: EnrichedActivityEvent[][]): Enric
     if (!byKey.has(key)) byKey.set(key, ev);
   }
   return [...byKey.values()].sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts));
+}
+
+/**
+ * Apply `--limit` to the events a reader will actually SHOW.
+ *
+ * The default view collapses routine work (`file.edited`) to a count and shows
+ * milestones individually, so a plain `slice(limit)` spends the whole budget on
+ * churn: one busy machine editing 40 files hid every other device's PRs behind
+ * a single `file edited ×40` line. Milestones therefore carry the cap, and the
+ * routine events that ride along are the ones newer than the last milestone
+ * kept — so the collapsed counts describe exactly the window on screen.
+ *
+ * With `all` (routine shown inline) every event is displayed, so the cap is the
+ * plain slice again. Input must be newest-first; output preserves that order.
+ */
+export function capActivityEvents(
+  events: EnrichedActivityEvent[],
+  limit: number,
+  opts: { all?: boolean } = {},
+): EnrichedActivityEvent[] {
+  if (!Number.isFinite(limit) || limit <= 0) return [];
+  if (opts.all) return events.slice(0, limit);
+  const out: EnrichedActivityEvent[] = [];
+  let milestones = 0;
+  let lastMilestoneIdx = -1;
+  for (const ev of events) {
+    if (tierForEvent(ev.event) === 'milestone') {
+      if (milestones >= limit) {
+        // The cap is reached: the window ends at the oldest milestone kept, so
+        // trailing routine events (older than it) are outside it.
+        return out.slice(0, lastMilestoneIdx + 1);
+      }
+      milestones += 1;
+      lastMilestoneIdx = out.length;
+    }
+    out.push(ev);
+  }
+  return out;
 }
 
 export type ActivityGroupBy = 'project' | 'device' | 'agent';
@@ -718,14 +752,53 @@ export function formatEnrichedActivityLine(
   return `${opts.indent ?? ''}${base}${suffix}`;
 }
 
-/** Human header for one grouped bucket: `<label> · N events · M milestones`. */
-export function formatActivityGroupHeader(group: ActivityGroup): string {
+/** Max device names named in a group header before the rest collapse to `+N`. */
+export const GROUP_HEADER_DEVICE_LIMIT = 3;
+
+/**
+ * The distinct machines a group's events ran on, most-active first then
+ * alphabetical — so a project header can say WHERE the work happened without
+ * sub-grouping the timeline. Prefers the session-joined `executionHost` (where
+ * the process really lives) over the raw emitting `host`. Pure.
+ */
+export function activityGroupDevices(events: EnrichedActivityEvent[]): string[] {
+  const counts = new Map<string, number>();
+  for (const ev of events) {
+    const host = ev.executionHost ?? (ev.host && ev.host !== 'unknown' ? ev.host : undefined);
+    if (!host) continue;
+    counts.set(host, (counts.get(host) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => (b[1] !== a[1] ? b[1] - a[1] : a[0].localeCompare(b[0])))
+    .map(([host]) => host);
+}
+
+/**
+ * The trailing facts for one grouped bucket: `N events · M milestones`, plus
+ * the machines the work ran on when `showDevices` is set (redundant when the
+ * grouping dimension IS the device, so the caller decides). The device list is
+ * capped at {@link GROUP_HEADER_DEVICE_LIMIT} with a `+N` tail, so a project
+ * touched by a dozen boxes stays one scannable line. Separate from the label so
+ * a renderer can color the two differently without re-splitting a string.
+ */
+export function formatActivityGroupMeta(
+  group: ActivityGroup,
+  opts: { showDevices?: boolean } = {},
+): string {
   const { milestones } = collapseActivity(group.events);
   const n = group.events.length;
   const m = milestones.length;
   const parts = [`${n} event${n === 1 ? '' : 's'}`];
   if (m > 0) parts.push(`${m} milestone${m === 1 ? '' : 's'}`);
-  return `${group.label} · ${parts.join(' · ')}`;
+  if (opts.showDevices) {
+    const devices = activityGroupDevices(group.events);
+    if (devices.length > 0) {
+      const named = devices.slice(0, GROUP_HEADER_DEVICE_LIMIT);
+      const rest = devices.length - named.length;
+      parts.push(rest > 0 ? `${named.join(', ')} +${rest}` : named.join(', '));
+    }
+  }
+  return parts.join(' · ');
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/lib/feed-post.ts
+++ b/apps/cli/src/lib/feed-post.ts
@@ -17,10 +17,10 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import {
   appendActivityEvent,
-  projectFromCwd,
   type ActivityEvent,
   type Attachment,
 } from './activity.js';
+import { resolveProjectKey } from './project-key.js';
 import { getHistoryDir } from './state.js';
 import { machineId } from './machine-id.js';
 import { isValidMailboxId } from './mailbox.js';
@@ -347,7 +347,10 @@ export function postFeedStatus(input: FeedPostInput): FeedPostResult {
   }
 
   const ts = input.ts ?? new Date().toISOString();
-  const project = projectFromCwd(identity.cwd);
+  // The post is written where the agent runs, so the cwd is a local path and
+  // gets full repository resolution — a post from `<repo>/apps/cli` files under
+  // `<repo>`, matching how the timeline groups everything else.
+  const project = resolveProjectKey(identity.cwd);
   const attachments = buildAttachments(input.attach, {
     copyRoot: input.attachmentsRoot ?? path.join(getHistoryDir(), 'attachments'),
     sessionId: identity.sessionId,

--- a/apps/cli/src/lib/project-key.test.ts
+++ b/apps/cli/src/lib/project-key.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { projectKeyFromCwd, repoRootForCwd, resolveProjectKey } from './project-key.js';
+import { projectFromCwd } from './activity.js';
+import { overviewProjectKey } from '../commands/sessions.js';
+
+describe('projectKeyFromCwd', () => {
+  it('folds a worktree cwd to the repo it branched from', () => {
+    expect(projectKeyFromCwd('/Users/m/src/agents-cli/.agents/worktrees/fix-thing')).toBe('agents-cli');
+  });
+
+  it('folds a subdirectory INSIDE a worktree to the same repo', () => {
+    expect(projectKeyFromCwd('/Users/m/src/agents-cli/.agents/worktrees/fix-thing/apps/cli')).toBe('agents-cli');
+  });
+
+  it('resolves a plain repo cwd to its basename', () => {
+    expect(projectKeyFromCwd('/Users/m/src/agents-cli')).toBe('agents-cli');
+  });
+
+  it('normalizes windows separators and trailing slashes', () => {
+    expect(projectKeyFromCwd('C:\\dev\\agents-cli\\.agents\\worktrees\\slug\\')).toBe('agents-cli');
+    expect(projectKeyFromCwd('/Users/m/src/agents-cli///')).toBe('agents-cli');
+  });
+
+  it('returns undefined for nothing usable', () => {
+    expect(projectKeyFromCwd(undefined)).toBeUndefined();
+    expect(projectKeyFromCwd('')).toBeUndefined();
+    expect(projectKeyFromCwd('/')).toBeUndefined();
+    expect(projectKeyFromCwd('   ')).toBeUndefined();
+  });
+
+  it('does not fold when the worktree segment leads the path (no repo above it)', () => {
+    expect(projectKeyFromCwd('/.agents/worktrees/slug')).toBe('slug');
+  });
+
+  // The whole point of the shared module: sessions and activity must bucket the
+  // same cwd identically, or one view says `agents-cli` and the other `fix-thing`.
+  it('agrees across the sessions overview and the activity timeline', () => {
+    for (const cwd of [
+      '/Users/m/src/agents-cli/.agents/worktrees/fix-thing',
+      '/Users/m/src/agents-cli/.agents/worktrees/fix-thing/apps/cli',
+      '/Users/m/src/rush',
+    ]) {
+      expect(overviewProjectKey({ cwd })).toBe(projectKeyFromCwd(cwd));
+      expect(projectFromCwd(cwd)).toBe(projectKeyFromCwd(cwd));
+    }
+  });
+});
+
+// Real directories, real `.git` entries — no mocked filesystem.
+describe('repoRootForCwd / resolveProjectKey (a cwd on this machine)', () => {
+  let tmp: string;
+  let home: string;
+  let repo: string;
+
+  beforeAll(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-project-key-'));
+    home = path.join(tmp, 'home');
+    repo = path.join(home, 'src', 'agents-cli');
+    fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(repo, 'apps', 'cli', 'src'), { recursive: true });
+    // A linked worktree: `.git` is a FILE pointing at the primary repo's gitdir.
+    const wt = path.join(repo, '.agents', 'worktrees', 'fix-thing', 'apps');
+    fs.mkdirSync(wt, { recursive: true });
+    fs.writeFileSync(path.join(repo, '.agents', 'worktrees', 'fix-thing', '.git'),
+      `gitdir: ${path.join(repo, '.git', 'worktrees', 'fix-thing')}\n`);
+    // A plain directory that belongs to no repo at all.
+    fs.mkdirSync(path.join(home, 'src', 'github.com', 'someone'), { recursive: true });
+  });
+
+  afterAll(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('finds the repo root from a deep subdirectory', () => {
+    expect(repoRootForCwd(path.join(repo, 'apps', 'cli', 'src'), home)).toBe(repo);
+  });
+
+  it('files a monorepo subdirectory under the REPO, not the leaf dir', () => {
+    // The bug this fixes: `<repo>/apps/cli` used to group as `cli`.
+    expect(resolveProjectKey(path.join(repo, 'apps', 'cli'), home)).toBe('agents-cli');
+    expect(projectKeyFromCwd(path.join(repo, 'apps', 'cli'))).toBe('cli');
+  });
+
+  it('folds a linked worktree back into its repo', () => {
+    expect(resolveProjectKey(path.join(repo, '.agents', 'worktrees', 'fix-thing', 'apps'), home))
+      .toBe('agents-cli');
+  });
+
+  it('falls back to the directory itself when nothing above it is a repo', () => {
+    const loose = path.join(home, 'src', 'github.com', 'someone');
+    expect(repoRootForCwd(loose, home)).toBeUndefined();
+    expect(resolveProjectKey(loose, home)).toBe('someone');
+  });
+
+  it('never lets a dotfiles repo at $HOME swallow every directory under it', () => {
+    const dotfiles = path.join(home, '.git');
+    fs.mkdirSync(dotfiles, { recursive: true });
+    try {
+      const loose = path.join(home, 'src', 'github.com', 'someone');
+      expect(repoRootForCwd(loose, home)).toBeUndefined();
+      expect(resolveProjectKey(loose, home)).toBe('someone');
+      // A real repo below home is still found.
+      expect(resolveProjectKey(path.join(repo, 'apps'), home)).toBe('agents-cli');
+    } finally {
+      fs.rmSync(dotfiles, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves nothing for a path that does not exist here (another machine)', () => {
+    expect(repoRootForCwd('/definitely/not/here/agents-cli', home)).toBeUndefined();
+    // ...and still yields a usable key from the pure fold.
+    expect(resolveProjectKey('/definitely/not/here/agents-cli', home)).toBe('agents-cli');
+  });
+
+  it('resolves nothing for an empty cwd', () => {
+    expect(resolveProjectKey(undefined, home)).toBeUndefined();
+    expect(resolveProjectKey('', home)).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/project-key.ts
+++ b/apps/cli/src/lib/project-key.ts
@@ -9,8 +9,10 @@
  *
  * The rule: a worktree cwd (`…/<repo>/.agents/worktrees/<slug>[/sub]`) folds to
  * the REPO directory name, so a worktree groups with the repo it branched from;
- * any other path resolves to its own basename. Pure — no filesystem, no git, so
- * it works identically for a remote peer's events as for local ones.
+ * any other path resolves to its own basename. {@link projectKeyFromCwd} is pure
+ * — no filesystem, no git, so it works identically for a remote peer's events as
+ * for local ones; {@link resolveProjectKey} adds the filesystem repo-root walk
+ * for paths this machine can see.
  */
 
 import * as fs from 'fs';
@@ -49,13 +51,8 @@ export function projectKeyFromCwd(cwd?: string | null): string | undefined {
  * non-project directory under it into one bogus "project".
  */
 export function repoRootForCwd(dir: string, home: string = os.homedir()): string | undefined {
-  let current: string;
-  try {
-    current = path.resolve(dir);
-  } catch {
-    return undefined;
-  }
   const stop = path.resolve(home);
+  let current = path.resolve(dir);
   for (;;) {
     if (fs.existsSync(path.join(current, '.git'))) return current === stop ? undefined : current;
     const parent = path.dirname(current);

--- a/apps/cli/src/lib/project-key.ts
+++ b/apps/cli/src/lib/project-key.ts
@@ -1,0 +1,81 @@
+/**
+ * The one worktree-aware cwd -> project fold.
+ *
+ * Several surfaces bucket work "by project": the `agents sessions` overview,
+ * the `agents activity` timeline, and anything else that has a cwd and needs a
+ * stable repo-level key. They must agree, or the same session shows up under
+ * `agents-cli` in one view and `my-branch-slug` in another — so the rule lives
+ * here and every caller delegates.
+ *
+ * The rule: a worktree cwd (`…/<repo>/.agents/worktrees/<slug>[/sub]`) folds to
+ * the REPO directory name, so a worktree groups with the repo it branched from;
+ * any other path resolves to its own basename. Pure — no filesystem, no git, so
+ * it works identically for a remote peer's events as for local ones.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const WORKTREE_SEGMENT = '/.agents/worktrees/';
+
+/**
+ * Resolve a stable project key from a working directory, or `undefined` when
+ * the path carries nothing usable (empty, `/`, whitespace).
+ */
+export function projectKeyFromCwd(cwd?: string | null): string | undefined {
+  if (!cwd) return undefined;
+  const norm = cwd.replace(/\\/g, '/').replace(/\/+$/, '').trim();
+  if (!norm) return undefined;
+  const wtIdx = norm.indexOf(WORKTREE_SEGMENT);
+  if (wtIdx > 0) {
+    const repoPath = norm.slice(0, wtIdx);
+    const base = repoPath.slice(repoPath.lastIndexOf('/') + 1);
+    if (base) return base;
+  }
+  const base = norm.slice(norm.lastIndexOf('/') + 1);
+  return base || undefined;
+}
+
+/**
+ * The git working-tree root containing `dir`, by walking up for a `.git` entry
+ * — a directory in a normal checkout, a file in a linked worktree, so one
+ * `existsSync` covers both. Filesystem-only: no `git` process per lookup, which
+ * matters because a timeline can hold dozens of distinct cwds.
+ *
+ * Returns `undefined` when `dir` is not inside a repo, when it does not exist
+ * (a path from another machine), or when the only repo found IS the home
+ * directory — a dotfiles repo at `$HOME` would otherwise swallow every
+ * non-project directory under it into one bogus "project".
+ */
+export function repoRootForCwd(dir: string, home: string = os.homedir()): string | undefined {
+  let current: string;
+  try {
+    current = path.resolve(dir);
+  } catch {
+    return undefined;
+  }
+  const stop = path.resolve(home);
+  for (;;) {
+    if (fs.existsSync(path.join(current, '.git'))) return current === stop ? undefined : current;
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
+ * Resolve the project key for a cwd **on this machine**: the repository it
+ * belongs to when there is one (so a monorepo subdir like `<repo>/apps/cli`
+ * groups under `<repo>`, not `cli`), else the directory itself.
+ *
+ * Each machine resolves its own paths — a peer answering a fan-out stamps the
+ * project for its events before they cross the wire — so this is never asked
+ * about a path it cannot see. {@link projectKeyFromCwd} is the pure fold for
+ * everything else.
+ */
+export function resolveProjectKey(cwd?: string | null, home?: string): string | undefined {
+  if (!cwd) return undefined;
+  const root = repoRootForCwd(cwd, home);
+  return projectKeyFromCwd(root ?? cwd);
+}

--- a/apps/cli/src/lib/remote-agents-json.ts
+++ b/apps/cli/src/lib/remote-agents-json.ts
@@ -22,11 +22,20 @@ export interface RemoteAgentsJsonOptions<T> {
   noFanoutEnv: string;
   hosts?: string[];
   parse: (stdout: string, machine: string) => T[];
+  /**
+   * Suppress the per-device "unreachable — skipped" stderr line. The skipped
+   * names still come back in {@link RemoteAgentsJsonResult.skipped}, so a caller
+   * that fans out by DEFAULT can report them once, compactly, instead of
+   * printing a line per offline box above its output. Never a silent drop.
+   */
+  quiet?: boolean;
 }
 
 export interface RemoteAgentsJsonResult<T> {
   items: T[];
   deviceCount: number;
+  /** Devices that were dialed but answered with an error / no CLI / a timeout. */
+  skipped: string[];
 }
 
 /** Build the command one peer runs, with a guard that prevents recursive fan-out. */
@@ -75,7 +84,7 @@ export async function gatherRemoteAgentsJson<T>(
     try {
       devices = await loadDevices();
     } catch {
-      return { items: [], deviceCount: 0 };
+      return { items: [], deviceCount: 0, skipped: [] };
     }
     for (const device of Object.values(devices)) {
       if (device.tailscale?.online !== true) continue;
@@ -99,15 +108,19 @@ export async function gatherRemoteAgentsJson<T>(
     }
   }
 
+  const skipped: string[] = [];
   const results = await Promise.all(targets.map(async (target) => {
     const command = remoteAgentsJsonCommand(options.args, options.noFanoutEnv, target.os);
     const result = await sshCapture(target.target, command);
     if (result.code !== 0) {
-      process.stderr.write(chalk.gray(`  ${target.name}: unreachable or no agents CLI — skipped\n`));
+      skipped.push(target.name);
+      if (!options.quiet) {
+        process.stderr.write(chalk.gray(`  ${target.name}: unreachable or no agents CLI — skipped\n`));
+      }
       return [] as T[];
     }
     return options.parse(result.stdout, target.machine);
   }));
 
-  return { items: results.flat(), deviceCount: targets.length };
+  return { items: results.flat(), deviceCount: targets.length, skipped };
 }


### PR DESCRIPTION
**feat** — `agents activity` now defaults to the whole fleet, grouped by project, with the warning wall gone.

## What changed

| | before | after |
|---|---|---|
| Scope | this machine only, unless you remembered `--devices-all` | **every reachable device**; `--local` scopes back |
| Shape | one flat newest-first stream | **bucketed by project**, one level, no sub-grouping; `--flat` restores the stream |
| Project | basename of the cwd (`<repo>/apps/cli` → `cli`) | the **git repository** containing it (`→ agents-cli`) |
| Machines | a `[host]` tag per row | that, plus each project header naming its machines |
| Header | 5 wrapped yellow lines of unrelated hook errors | nothing — those are `agents doctor`'s job |
| Offline peers | one stderr line each, above the timeline | one trailing `· N devices unreachable: …` |
| `--limit` | plain slice, so 40 file edits hid every PR | caps **milestones**; routine work rides along as counts |

## Run evidence

Real runs, captured from this branch (paths on `zion` — not GitHub embeds; click to preview locally):

- **After** — `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/activity-after.jpg`
- **Before** (shipped 1.20.89, same machine, minutes earlier) — `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/activity-before.jpg`

The after run, verbatim:

```
  activity by project

  ▸ agents-cli  26 events · 5 milestones · zion
    26s ago  [zion] ⌦ worktree removed cd /Users/muqsit/src/github.com/muqsitnawaz/agents-cli && g…
     1m ago  [zion] ✔ PR merged gh pr merge 1749 --squash 2>&1 | tail -5
     3m ago  [zion] ↥ pushed git push 2>&1 | tail -2; sleep 8; gh pr view 1749 --json me…
    · file edited ×21

  ▸ muqsitnawaz  1 event · 1 milestone · zion
     5m ago  [zion] ⌦ worktree removed REPO=/Users/muqsit/src/github.com/muqsitnawaz/agents-cli; g…

  · 1 device unreachable: gpu-box
```

An earlier run in the same session, with a peer active, shows the merge working across boxes:

```
  ▸ muqsitnawaz  42 events · 11 milestones · zion, yosemite-s0
     3m ago  [zion]        ✔ PR merged gh pr merge 1756 --repo phnx-labs/agents-cli --rebase --del…
     8m ago  [yosemite-s0] ↥ pushed cd /home/muqsit/.agents/.system/.agents/worktrees/docs-devi…
```

Other paths driven live: `--local`, `--flat`, `--group-by device`, `--json`, and `--group-by bogus`
(exits 1 with `--group-by must be one of: project, device, agent, none`).

## How

- **`lib/project-key.ts` (new)** — the one cwd → project fold, now repository-aware: walk up for a
  `.git` entry (a dir in a checkout, a file in a linked worktree), then apply the worktree fold. A
  filesystem walk, not a `git` process per lookup. A dotfiles repo at `$HOME` is declined so it can't
  swallow every directory under it. `sessions.overviewProjectKey`, `activity.projectFromCwd`, and
  `feed post` all delegate, so a project reads identically in every view.
- **A path from another machine can't be resolved here**, so `enrichActivityEvents` takes the resolver
  as a parameter and defaults to the pure fold; each peer stamps its own projects before the events
  cross the wire.
- **`resolveActivityScope` / `resolveActivityGrouping`** — the new defaults as pure, unit-tested
  functions. The `AGENTS_ACTIVITY_LOCAL` guard a peer carries is what stops it re-fanning the fleet.
- **`capActivityEvents`** — `--limit` bounds milestones plus the routine events inside that window;
  `--all` makes it a plain event cap. The local read gets 5× headroom (tailing the files costs the
  same either way) so local churn can't crowd the fleet out.
- **`gatherRemoteAgentsJson`** returns `skipped` and takes `quiet`; only `activity` (which fans out on
  every run) opts into the compact trailing note. `feed`, `repo`, and `sessions` are untouched.

## Tests

- `project-key.test.ts` (new, 14 cases) — real temp dirs with real `.git` entries: monorepo subdir,
  linked worktree, no-repo directory, `$HOME` dotfiles repo, a path that doesn't exist here, and a
  cross-view agreement check against `overviewProjectKey` / `projectFromCwd`.
- `activity.test.ts` — `capActivityEvents` (incl. the 40-edits-hide-every-PR regression),
  `activityGroupDevices`, and the capped device list in the group meta.
- `activity.test.ts` (command) — grouping defaults, `--flat`, `--group-by none`, an unknown dimension,
  scope resolution (default / `--local` / peer guard / `--host` / `--host <self>`), the unreachable
  note, and the hook-error filter.
- 92 files / 1082 tests green across activity, project-key, sessions, feed, and session.

Docs: `apps/cli/docs/06-observability.md` §Activity lane rewritten for the new defaults.
Changelog: `apps/cli/.changelog/next/activity-fleet-by-project.md`.

## Known, out of scope

The timeline can show the same milestone two or three times, 12 ms apart, from one session — the
activity hook is registered in several version homes and fires once per registration. That's the
`duplicate-hook` finding `agents doctor` already reports; the merge dedupe (`host/session/ts/event`)
is working as designed on genuinely distinct timestamps, so this needs the hook registration fixed,
not a window-based dedupe papering over it here.
