### PR TITLE
feat(projects): agents projects — named multi-repo projects + cross-fleet progress rollup

### DIFF
--- a/apps/cli/.changelog/next/projects-progress-rollup.md
+++ b/apps/cli/.changelog/next/projects-progress-rollup.md
@@ -1,0 +1,15 @@
+- **`agents projects` — named multi-repo projects with a cross-fleet progress rollup (beta).**
+  Define a project once in `~/.agents/projects/<name>.yaml` (name, home-relative
+  root/defaultPath, multiple repos with monorepo subpaths, described `contexts[]`
+  starting points, external `integrations[]`, Linear link) and `agents run --project
+  <name>` resolves the definition before the old `<root>/<slug>` convention — undefined
+  slugs behave exactly as before. The headline is `agents projects status`: instead of a
+  per-agent activity line, it renders one card per project — live agents by state, plan
+  completion, open **and** recently-merged PRs, tickets in flight, and the artifacts
+  agents produced — by rolling up signals already on disk (matched to a project by session
+  cwd, so it works cross-machine with no new sync). `--window <days>` and `--no-remote`
+  tune the PR/artifact lookup. Also `list` / `add` (infers root + origin slug) / `show` /
+  `edit` / `import --from-factory` (absorbs the Factory `projects.json` registry) / `rm`.
+  Enable with `agents beta enable projects`. Source: `apps/cli/src/lib/projects.ts`,
+  `apps/cli/src/lib/project-status.ts`, `apps/cli/src/commands/projects.ts`,
+  `apps/cli/src/lib/project-root.ts`.

--- a/apps/cli/.changelog/next/projects-progress-rollup.md
+++ b/apps/cli/.changelog/next/projects-progress-rollup.md
@@ -1,4 +1,4 @@
-- **`agents projects` — named multi-repo projects with a cross-fleet progress rollup (beta).**
+- **`agents projects` — named multi-repo projects with a project progress rollup (beta).**
   Define a project once in `~/.agents/projects/<name>.yaml` (name, home-relative
   root/defaultPath, multiple repos with monorepo subpaths, described `contexts[]`
   starting points, external `integrations[]`, Linear link) and `agents run --project
@@ -6,8 +6,9 @@
   slugs behave exactly as before. The headline is `agents projects status`: instead of a
   per-agent activity line, it renders one card per project — live agents by state, plan
   completion, open **and** recently-merged PRs, tickets in flight, and the artifacts
-  agents produced — by rolling up signals already on disk (matched to a project by session
-  cwd, so it works cross-machine with no new sync). `--window <days>` and `--no-remote`
+  agents produced — by rolling up signals already on disk (live agents matched to a project
+  by this machine's session cwd; the merged-PR count is repo-global via `gh`). `--window
+  <days>` and `--no-remote`
   tune the PR/artifact lookup. Also `list` / `add` (infers root + origin slug) / `show` /
   `edit` / `import --from-factory` (absorbs the Factory `projects.json` registry) / `rm`.
   Enable with `agents beta enable projects`. Source: `apps/cli/src/lib/projects.ts`,

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -283,6 +283,7 @@ src/
     hooks.ts           # hooks.yaml parser + per-agent registrar
     hooks/match.ts     # `matches:` predicate evaluator
     monitors/          # `agents monitors` — event-triggered watchers (source→condition→action); native state-diff store; MonitorEngine runs in the daemon beside the cron scheduler. See docs/10-monitors.md
+    projects.ts        # `agents projects` — named multi-repo project defs (~/.agents/projects/*.yaml) layered above the --project convention (resolveProjectRef in project-root.ts); project-status.ts rolls live sessions + merged PRs + artifacts into the progress card. Beta-gated. See docs/11-projects.md
     migrate.ts         # One-shot idempotent migrations
     session/           # `agents sessions` READER — discovery/parse/render of agent transcripts; also `migrate-targets.ts` (the `sessions migrate` target scorer)
     terminal/          # Terminal launch engine — tab/split in iTerm/Ghostty/tmux, local or --host

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -1,0 +1,102 @@
+# Projects (Named Multi-Repo Projects + Progress Rollup)
+
+A **project** names a body of work, binds it to one or more repos, and rolls the
+fleet's live activity up into one progress card. It is a **definition layer over the
+existing `--project` convention**, not a replacement — an undefined slug resolves
+exactly as before.
+
+> Beta. Enable with `agents beta enable projects` (the command tree is hidden until then).
+
+## Why
+
+`agents run --project <slug>` already resolves a bare name to `<projectRoot>/<slug>`
+by pure convention (`lib/project-root.ts`). That cannot name a project independently
+of its folder, bind multiple repos, pin a monorepo subpath, or answer *"what is
+happening on project X right now"*. At 50–100 agents the per-agent activity line is
+noise; what matters is the **project**. This subsystem fills both gaps.
+
+## The definition — `~/.agents/projects/<name>.yaml`
+
+One hand-editable YAML file per project, beside `routines/` and `monitors/` in the
+user repo, so it syncs across machines via `agents push/pull`. Paths are stored
+home-relative (`~/…`) so a definition re-roots on any machine.
+
+```yaml
+name: rush                      # stable id == filename; what --project takes
+description: "Rush app"
+root: ~/src/github.com/phnx-labs/rush
+defaultPath: ~/src/github.com/phnx-labs/rush/apps/web   # where an agent's cwd lands
+repo: phnx-labs/rush            # primary GitHub slug (PR / merge rollup)
+repos:                          # additional repos, each with an optional monorepo subpath
+  - slug: phnx-labs/rush-infra
+contexts:                       # described starting points — an agent reads `purpose`
+  - path: apps/web    purpose: "user-facing Next.js app; funnel + growth surfaces"
+  - path: packages/api purpose: "FastAPI backend; Supabase models live here"
+integrations:                   # external context, surfaced in `projects show`
+  - kind: gdrive  url: https://drive.google.com/…  label: "design docs"
+linear:
+  projectId: a1b2c3d4-…
+```
+
+| Field | Purpose |
+| --- | --- |
+| `name` | Stable id, == filename. What `--project` takes. |
+| `root` | Repo / monorepo root, home-relative → portable. |
+| `defaultPath` | Where an agent's cwd lands (a monorepo subdir). Defaults to `root`. |
+| `repo` / `repos[]` | GitHub slug(s), each with an optional `subpath`, for the PR/merge rollup. |
+| `contexts[]` | `{path, purpose}` described starting points — indexed anchors for agents. |
+| `integrations[]` | `{kind, url, label}` external context sources. |
+| `linear` | `{projectId, url}` — reuses the existing Linear path. |
+
+## Resolution — definition first, convention fallback
+
+`resolveProjectRef` (`lib/project-root.ts`) looks up a named definition before the
+`<root>/<slug>` convention. A defined project resolves to its `defaultPath` (or
+`root`); a `@worktree` suffix lands under the repo root's `.agents/worktrees/`. An
+**undefined** slug falls through to the unchanged convention. Home-relative paths mean
+`--project rush --host <box>` re-roots on the remote's home automatically.
+
+## The progress card — `agents projects status`
+
+The headline. It matches every live session to a project **by cwd** (longest root
+wins; no persisted column, so it works cross-machine because transcript cwd already
+syncs) and rolls up the signals already on disk:
+
+```
+rush  ·  23 agents  ·  68% plan
+  live     14 running · 6 idle · 3 need-input     # active sessions by lifecycle state
+  ships    4 merged (7d) · 2 open PRs · 3 worktrees  # gh merged-PR count + open PRs held
+  tickets  RUSH-1201 · RUSH-1198 · …              # tickets worked or created
+  proof    11 artifacts (7d) · last: plan-x.html  # artifact.created milestones by cwd
+  repos    phnx-labs/rush · rush-infra
+  context  apps/web · packages/api
+```
+
+- **`live`, `plan`, open PRs, `tickets`, `worktrees`** come straight from the active
+  session list (`rollupSessionsByProject`) — no network.
+- **`ships` merged-count** is a best-effort `gh pr list` on the primary repo
+  (`--no-remote` skips it; a missing `gh`/auth degrades to 0).
+- **`proof`** counts `artifact.created` activity milestones whose cwd is inside the
+  project (`lib/project-status.ts`).
+- `--window <days>` sets the merged-PR / artifact window (default 7).
+
+## Command surface
+
+| Command | Does |
+| --- | --- |
+| `agents projects list [--json]` | All projects: root, repo, live agent count. |
+| `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--context path:purpose`, `--linear`. |
+| `agents projects show <name> [--json]` | Full definition + resolved paths + contexts + links. |
+| `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
+| `agents projects status [name] [--json] [--window N] [--no-remote]` | The progress card (all projects, or one). |
+| `agents projects import --from-factory` | Absorb `~/.agents/factory/projects.json` into YAML definitions. |
+| `agents projects rm <name>` | Delete the definition (never touches the repo). |
+
+`agents run --project <name>` is unchanged in spelling — it just resolves richer
+definitions now.
+
+## Not yet (fast-follow)
+
+Re-pointing `agents factory snapshot`'s per-project Linear rollup at defined projects,
+richer Linear ticket-state counts on the card, and a persisted `project_id` session
+column (today membership is derived from cwd) are deferred follow-ups.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -30,8 +30,10 @@ repo: phnx-labs/rush            # primary GitHub slug (PR / merge rollup)
 repos:                          # additional repos, each with an optional monorepo subpath
   - slug: phnx-labs/rush-infra
 contexts:                       # described starting points — an agent reads `purpose`
-  - path: apps/web    purpose: "user-facing Next.js app; funnel + growth surfaces"
-  - path: packages/api purpose: "FastAPI backend; Supabase models live here"
+  - path: apps/web
+    purpose: "user-facing Next.js app; funnel + growth surfaces"
+  - path: packages/api
+    purpose: "FastAPI backend; Supabase models live here"
 integrations:                   # external context, surfaced in `projects show`
   - kind: gdrive  url: https://drive.google.com/…  label: "design docs"
 linear:
@@ -59,8 +61,11 @@ linear:
 ## The progress card — `agents projects status`
 
 The headline. It matches every live session to a project **by cwd** (longest root
-wins; no persisted column, so it works cross-machine because transcript cwd already
-syncs) and rolls up the signals already on disk:
+wins) and rolls up the signals already on disk. The live-agent rollup is over this
+machine's active sessions (the same set `agents sessions --active` shows, matched by
+local-home cwd); the **merged-PR count is repo-global** (via `gh`). A fleet-wide live
+rollup — SSH fan-out plus home-relative cwd matching so a session recorded on a
+different-home machine still matches — is a deferred follow-up (see below):
 
 ```
 rush  ·  23 agents  ·  68% plan
@@ -97,6 +102,10 @@ definitions now.
 
 ## Not yet (fast-follow)
 
-Re-pointing `agents factory snapshot`'s per-project Linear rollup at defined projects,
-richer Linear ticket-state counts on the card, and a persisted `project_id` session
-column (today membership is derived from cwd) are deferred follow-ups.
+- **Fleet-wide live rollup.** Today the live-agent count is this machine's active
+  sessions; a fan-out across `agents devices` plus home-relative cwd matching (so a
+  session from a different-home machine still maps to the project) would make it truly
+  cross-fleet.
+- **Re-point `agents factory snapshot`** per-project Linear rollup at defined projects.
+- **Richer Linear ticket-state counts** on the card.
+- **Persisted `project_id` session column** — today membership is derived from cwd.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -35,7 +35,9 @@ contexts:                       # described starting points — an agent reads `
   - path: packages/api
     purpose: "FastAPI backend; Supabase models live here"
 integrations:                   # external context, surfaced in `projects show`
-  - kind: gdrive  url: https://drive.google.com/…  label: "design docs"
+  - kind: gdrive
+    url: https://drive.google.com/…
+    label: "design docs"
 linear:
   projectId: a1b2c3d4-…
 ```
@@ -57,6 +59,11 @@ linear:
 `root`); a `@worktree` suffix lands under the repo root's `.agents/worktrees/`. An
 **undefined** slug falls through to the unchanged convention. Home-relative paths mean
 `--project rush --host <box>` re-roots on the remote's home automatically.
+
+Resolution is intentionally **not** beta-gated — only the `agents projects` command
+tree is. A definition exists solely by explicit user action (`projects add`,
+`import --from-factory`, or hand-authoring the YAML), so honoring it in `--project`
+resolution is additive and safe; users without any definitions see zero change.
 
 ## The progress card — `agents projects status`
 
@@ -80,7 +87,8 @@ rush  ·  23 agents  ·  68% plan
 - **`live`, `plan`, open PRs, `tickets`, `worktrees`** come straight from the active
   session list (`rollupSessionsByProject`) — no network.
 - **`ships` merged-count** is a best-effort `gh pr list` on the primary repo
-  (`--no-remote` skips it; a missing `gh`/auth degrades to 0).
+  (`--no-remote` skips it; a missing `gh`/auth degrades to 0). It counts up to the
+  100 most recent merges within the window.
 - **`proof`** counts `artifact.created` activity milestones whose cwd is inside the
   project (`lib/project-status.ts`).
 - `--window <days>` sets the merged-PR / artifact window (default 7).

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -1,9 +1,9 @@
 # Projects (Named Multi-Repo Projects + Progress Rollup)
 
-A **project** names a body of work, binds it to one or more repos, and rolls the
-fleet's live activity up into one progress card. It is a **definition layer over the
-existing `--project` convention**, not a replacement — an undefined slug resolves
-exactly as before.
+A **project** names a body of work, binds it to one or more repos, and rolls live
+activity up into one progress card. It is a **definition layer over the existing
+`--project` convention**, not a replacement — an undefined slug resolves exactly as
+before.
 
 > Beta. Enable with `agents beta enable projects` (the command tree is hidden until then).
 

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -51,6 +51,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Share](share.md) | Publish an HTML artifact to a public link on your own Cloudflare R2 (`agents share <file>`) — zero-egress, BYO-Cloudflare, expiry + fleet mode. |
 | [Routines](03-routines.md) | Cron-scheduled and signed-webhook-triggered agent runs with sandboxed permissions and a long-running daemon. |
 | [Monitors](10-monitors.md) | Durable event-triggered watchers: watch a source, detect a change, fire an action. A routine whose trigger is a watched source instead of a clock. |
+| [Projects](11-projects.md) | Named multi-repo projects layered over the `--project` convention, plus the cross-fleet progress rollup — one card per project instead of a per-agent activity line. Beta. |
 | [Watchdog](watchdog.md) | Detect **idle** agents across the fleet and steer them to completion — a daemon-fired routine that analyzes a stalled session's goal and nudges it with the concrete next step (idle is its job; `waiting` belongs to the feed). |
 
 ## Extensibility

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -51,7 +51,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Share](share.md) | Publish an HTML artifact to a public link on your own Cloudflare R2 (`agents share <file>`) — zero-egress, BYO-Cloudflare, expiry + fleet mode. |
 | [Routines](03-routines.md) | Cron-scheduled and signed-webhook-triggered agent runs with sandboxed permissions and a long-running daemon. |
 | [Monitors](10-monitors.md) | Durable event-triggered watchers: watch a source, detect a change, fire an action. A routine whose trigger is a watched source instead of a clock. |
-| [Projects](11-projects.md) | Named multi-repo projects layered over the `--project` convention, plus the cross-fleet progress rollup — one card per project instead of a per-agent activity line. Beta. |
+| [Projects](11-projects.md) | Named multi-repo projects layered over the `--project` convention, plus the progress rollup — one card per project instead of a per-agent activity line. Beta. |
 | [Watchdog](watchdog.md) | Detect **idle** agents across the fleet and steer them to completion — a daemon-fired routine that analyzes a stalled session's goal and nudges it with the concrete next step (idle is its job; `waiting` belongs to the feed). |
 
 ## Extensibility

--- a/apps/cli/src/commands/beta.ts
+++ b/apps/cli/src/commands/beta.ts
@@ -12,7 +12,7 @@ const BETA_DESCRIPTIONS: Record<BetaFeatureName, string> = {
   drive: 'Google Drive integration for reading and writing files',
   factory: 'Cloud-based agent dispatch via Rush Factory',
   'session-sync': 'Cross-machine session transcript sync via R2 (daemon push/pull)',
-  projects: 'Named multi-repo projects with cross-fleet progress rollup (agents projects)',
+  projects: 'Named multi-repo projects with a progress rollup (agents projects)',
 };
 
 function parseFeatures(values: string[]): BetaFeatureName[] {

--- a/apps/cli/src/commands/beta.ts
+++ b/apps/cli/src/commands/beta.ts
@@ -12,6 +12,7 @@ const BETA_DESCRIPTIONS: Record<BetaFeatureName, string> = {
   drive: 'Google Drive integration for reading and writing files',
   factory: 'Cloud-based agent dispatch via Rush Factory',
   'session-sync': 'Cross-machine session transcript sync via R2 (daemon push/pull)',
+  projects: 'Named multi-repo projects with cross-fleet progress rollup (agents projects)',
 };
 
 function parseFeatures(values: string[]): BetaFeatureName[] {

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -1,0 +1,337 @@
+/**
+ * `agents projects` — named, multi-repo projects and the cross-fleet progress
+ * rollup. Definitions live in `~/.agents/projects/<name>.yaml` (see
+ * `lib/projects.ts`); this registers the command tree over them. Beta-gated on
+ * `isBetaEnabled('projects')`, mirroring `agents factory`.
+ *
+ * The headline is `status`: instead of the vague per-agent activity line, it
+ * rolls every session up by project (matched on cwd) into one card — agents by
+ * lifecycle state, plan completion, open PRs, and tickets in flight.
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import * as fs from 'fs';
+import { execFileSync, spawnSync } from 'child_process';
+
+import { betaEnableHint, isBetaEnabled } from '../lib/beta.js';
+import { setHelpSections } from '../lib/help.js';
+import { getMainRepoRoot } from '../lib/git.js';
+import { parseOwnerRepoFromRemote } from '../lib/registry.js';
+import { toHomeRelative } from '../lib/project-root.js';
+import { getActiveSessions } from '../lib/session/active.js';
+import { factoryProjectsPath } from '../lib/auto-dispatch.js';
+import {
+  listProjectDefs,
+  loadProjectDef,
+  writeProjectDef,
+  removeProjectDef,
+  projectDefPath,
+  isSafeProjectName,
+  type ProjectDef,
+  type ProjectContext,
+} from '../lib/projects.js';
+import {
+  rollupSessionsByProject,
+  planPct,
+  type ProjectSessionRollup,
+} from '../lib/project-status.js';
+
+/** `path:purpose` → a context anchor. Purpose may contain colons. */
+function parseContextFlag(raw: string): ProjectContext {
+  const i = raw.indexOf(':');
+  if (i === -1) return { path: raw.trim(), purpose: '' };
+  return { path: raw.slice(0, i).trim(), purpose: raw.slice(i + 1).trim() };
+}
+
+/** Best-effort `owner/repo` from a repo's origin remote. */
+function originSlug(cwd: string): string | undefined {
+  try {
+    const url = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd, encoding: 'utf8' }).trim();
+    return parseOwnerRepoFromRemote(url) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function statusBar(r: ProjectSessionRollup): string {
+  const parts: string[] = [];
+  const push = (n: number | undefined, label: string, color: (s: string) => string) => {
+    if (n && n > 0) parts.push(color(`${n} ${label}`));
+  };
+  push(r.byStatus.running, 'running', chalk.green);
+  push(r.byStatus.idle, 'idle', chalk.gray);
+  push(r.byStatus.input_required, 'need-input', chalk.yellow);
+  push(r.byStatus.queued, 'queued', chalk.gray);
+  return parts.join(' · ') || chalk.gray('no live agents');
+}
+
+function renderCard(def: ProjectDef, r: ProjectSessionRollup | undefined): void {
+  const agents = r?.agents ?? 0;
+  const pct = r ? planPct(r.plan) : undefined;
+  const planStr = pct === undefined ? '' : `  ·  ${chalk.cyan(`${pct}% plan`)}`;
+  console.log(`${chalk.bold(def.name)}  ${chalk.dim('·')}  ${chalk.bold(`${agents} agents`)}${planStr}`);
+  if (def.description) console.log(`  ${chalk.dim(def.description)}`);
+  console.log(`  ${chalk.dim('live')}     ${r ? statusBar(r) : chalk.gray('no live agents')}`);
+  if (r && (r.openPrs.length || r.worktrees)) {
+    const prs = r.openPrs.length ? `${r.openPrs.length} open PR${r.openPrs.length === 1 ? '' : 's'}` : '';
+    const wt = r.worktrees ? `${r.worktrees} worktree${r.worktrees === 1 ? '' : 's'}` : '';
+    console.log(`  ${chalk.dim('ships')}    ${[prs, wt].filter(Boolean).join(' · ')}`);
+  }
+  if (r && r.tickets.length) {
+    console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
+  }
+  const repos = [def.repo, ...(def.repos ?? []).map((x) => x.slug)].filter(Boolean) as string[];
+  if (repos.length) console.log(`  ${chalk.dim('repos')}    ${[...new Set(repos)].join(' · ')}`);
+  if (def.contexts?.length) {
+    console.log(`  ${chalk.dim('context')}  ${def.contexts.map((c) => c.path).join(' · ')}`);
+  }
+  if (def.integrations?.length) {
+    console.log(`  ${chalk.dim('links')}    ${def.integrations.map((i) => i.label ?? i.kind).join(' · ')}`);
+  }
+  console.log('');
+}
+
+export function registerProjectsCommands(program: Command): void {
+  const enabled = isBetaEnabled('projects');
+  const projects = program
+    .command('projects', { hidden: !enabled })
+    .description('Named multi-repo projects with a cross-fleet progress rollup.');
+
+  setHelpSections(projects, {
+    examples: `
+      agents projects add rush --repo phnx-labs/rush --path apps/web
+      agents projects list
+      agents projects status              # progress card for every project
+      agents projects status rush --json  # one project, machine-readable
+      agents run --project rush           # land an agent in the project
+    `,
+    notes: `
+      Definitions are hand-editable YAML in ~/.agents/projects/ and sync across
+      machines with 'agents push/pull'. Enable with: agents beta enable projects.
+    `,
+  });
+
+  projects.hook('preAction', () => {
+    if (enabled) return;
+    console.error(chalk.red('agents projects is in beta.'));
+    console.error(chalk.gray(betaEnableHint('projects')));
+    process.exit(1);
+  });
+
+  // ---- list ----
+  projects
+    .command('list')
+    .description('List defined projects with their root, repo, and live agent count.')
+    .option('--json', 'Machine-readable output')
+    .action(async (opts: { json?: boolean }) => {
+      const defs = listProjectDefs();
+      if (opts.json) {
+        const roll = rollupSessionsByProject(defs, await getActiveSessions());
+        console.log(
+          JSON.stringify(
+            defs.map((d) => ({ ...d, agents: roll.get(d.name)?.agents ?? 0 })),
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+      if (!defs.length) {
+        console.log(chalk.gray('No projects defined. Add one: agents projects add <name>'));
+        return;
+      }
+      const roll = rollupSessionsByProject(defs, await getActiveSessions());
+      for (const d of defs) {
+        const agents = roll.get(d.name)?.agents ?? 0;
+        const repo = d.repo ?? d.repos?.[0]?.slug ?? '';
+        console.log(
+          `  ${chalk.bold(d.name.padEnd(16))} ${chalk.dim((d.root ?? d.defaultPath ?? '').padEnd(32))} ${chalk.cyan(repo.padEnd(24))} ${agents} agents`,
+        );
+      }
+    });
+
+  // ---- add ----
+  projects
+    .command('add <name>')
+    .description('Define a project. Infers root and repo from the current git repo when not given.')
+    .option('--root <path>', 'Repo / monorepo root (defaults to the current git repo root)')
+    .option('--path <subdir>', 'Default cwd for agents (a monorepo subdir)')
+    .option('--repo <owner/repo>', 'Primary GitHub slug (defaults to the origin remote)')
+    .option('--context <path:purpose...>', 'A described starting point; repeatable')
+    .option('--linear <url-or-id>', 'Linear project URL or id')
+    .option('--force', 'Overwrite an existing definition')
+    .action(
+      async (
+        name: string,
+        opts: { root?: string; path?: string; repo?: string; context?: string[]; linear?: string; force?: boolean },
+      ) => {
+        if (!isSafeProjectName(name)) {
+          console.error(chalk.red(`Invalid project name: "${name}" (letters, digits, ., _, - only)`));
+          process.exit(1);
+        }
+        if (loadProjectDef(name) && !opts.force) {
+          console.error(chalk.red(`Project "${name}" already exists. Use --force to overwrite, or 'agents projects edit ${name}'.`));
+          process.exit(1);
+        }
+        const cwd = process.cwd();
+        let root = opts.root;
+        if (!root) {
+          try {
+            root = toHomeRelative(await getMainRepoRoot(cwd));
+          } catch {
+            console.error(chalk.red('Not inside a git repo — pass --root <path> explicitly.'));
+            process.exit(1);
+          }
+        }
+        const repo = opts.repo ?? originSlug(cwd);
+        const def: ProjectDef = { name, root };
+        if (opts.path) def.defaultPath = `${root!.replace(/\/$/, '')}/${opts.path.replace(/^\//, '')}`;
+        if (repo) def.repo = repo;
+        if (opts.context?.length) def.contexts = opts.context.map(parseContextFlag);
+        if (opts.linear) {
+          def.linear = /^https?:/.test(opts.linear) ? { url: opts.linear } : { projectId: opts.linear };
+        }
+        const target = writeProjectDef(def);
+        console.log(chalk.green(`Defined project "${name}"`));
+        console.log(chalk.gray(`  ${target}`));
+        console.log(chalk.gray(`  root ${def.root}${def.repo ? `  ·  repo ${def.repo}` : ''}`));
+      },
+    );
+
+  // ---- show ----
+  projects
+    .command('show <name>')
+    .description('Show a project definition, resolved paths, repos, contexts, and links.')
+    .option('--json', 'Machine-readable output')
+    .action((name: string, opts: { json?: boolean }) => {
+      const def = loadProjectDef(name);
+      if (!def) {
+        console.error(chalk.red(`No project named "${name}". List them: agents projects list`));
+        process.exit(1);
+      }
+      if (opts.json) {
+        console.log(JSON.stringify(def, null, 2));
+        return;
+      }
+      console.log(chalk.bold(def.name) + (def.description ? chalk.dim(`  — ${def.description}`) : ''));
+      if (def.root) console.log(`  root         ${def.root}`);
+      if (def.defaultPath) console.log(`  defaultPath  ${def.defaultPath}`);
+      const repos = [def.repo, ...(def.repos ?? []).map((r) => (r.subpath ? `${r.slug} (${r.subpath})` : r.slug))].filter(Boolean);
+      if (repos.length) console.log(`  repos        ${repos.join(', ')}`);
+      for (const c of def.contexts ?? []) console.log(`  context      ${chalk.cyan(c.path)} — ${c.purpose}`);
+      for (const i of def.integrations ?? []) console.log(`  ${i.kind.padEnd(12)} ${i.url}${i.label ? chalk.dim(`  (${i.label})`) : ''}`);
+      if (def.linear?.url || def.linear?.projectId) console.log(`  linear       ${def.linear.url ?? def.linear.projectId}`);
+      for (const d of def.docs ?? []) console.log(`  doc          ${d}`);
+      console.log(chalk.gray(`  ${projectDefPath(name)}`));
+    });
+
+  // ---- edit ----
+  projects
+    .command('edit <name>')
+    .description('Open the project YAML in $EDITOR (it is hand-editable regardless).')
+    .action((name: string) => {
+      const target = projectDefPath(name);
+      if (!fs.existsSync(target)) {
+        console.error(chalk.red(`No project named "${name}". Create it: agents projects add ${name}`));
+        process.exit(1);
+      }
+      const editor = process.env.VISUAL || process.env.EDITOR || 'vi';
+      const res = spawnSync(editor, [target], { stdio: 'inherit' });
+      process.exit(res.status ?? 0);
+    });
+
+  // ---- status ----
+  projects
+    .command('status [name]')
+    .description('Progress rollup: agents, plan completion, open PRs, and tickets per project.')
+    .option('--json', 'Machine-readable output')
+    .action(async (name: string | undefined, opts: { json?: boolean }) => {
+      const all = listProjectDefs();
+      const defs = name ? all.filter((d) => d.name === name) : all;
+      if (name && !defs.length) {
+        console.error(chalk.red(`No project named "${name}".`));
+        process.exit(1);
+      }
+      const roll = rollupSessionsByProject(all, await getActiveSessions());
+      if (opts.json) {
+        console.log(
+          JSON.stringify(
+            defs.map((d) => ({
+              name: d.name,
+              agents: roll.get(d.name)?.agents ?? 0,
+              byStatus: roll.get(d.name)?.byStatus ?? {},
+              plan: roll.get(d.name)?.plan ?? { done: 0, total: 0 },
+              planPct: roll.get(d.name) ? planPct(roll.get(d.name)!.plan) ?? null : null,
+              openPrs: roll.get(d.name)?.openPrs ?? [],
+              tickets: roll.get(d.name)?.tickets ?? [],
+              worktrees: roll.get(d.name)?.worktrees ?? 0,
+              repos: [d.repo, ...(d.repos ?? []).map((r) => r.slug)].filter(Boolean),
+            })),
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+      if (!defs.length) {
+        console.log(chalk.gray('No projects defined. Add one: agents projects add <name>'));
+        return;
+      }
+      for (const d of defs) renderCard(d, roll.get(d.name));
+    });
+
+  // ---- import ----
+  projects
+    .command('import')
+    .description('Absorb the Factory project registry (~/.agents/factory/projects.json) into YAML definitions.')
+    .requiredOption('--from-factory', 'Import from the Factory projects.json registry')
+    .option('--force', 'Overwrite existing definitions')
+    .action((opts: { force?: boolean }) => {
+      const src = factoryProjectsPath();
+      let rows: unknown;
+      try {
+        rows = JSON.parse(fs.readFileSync(src, 'utf8'));
+      } catch {
+        console.error(chalk.red(`No Factory registry at ${src}`));
+        process.exit(1);
+      }
+      const list = Array.isArray(rows) ? rows : Array.isArray((rows as { projects?: unknown[] }).projects) ? (rows as { projects: unknown[] }).projects : [];
+      let created = 0;
+      let skipped = 0;
+      for (const raw of list) {
+        if (!raw || typeof raw !== 'object') continue;
+        const o = raw as Record<string, unknown>;
+        const name = typeof o.name === 'string' ? o.name : undefined;
+        if (!name || !isSafeProjectName(name)) {
+          skipped++;
+          continue;
+        }
+        if (loadProjectDef(name) && !opts.force) {
+          skipped++;
+          continue;
+        }
+        const def: ProjectDef = { name };
+        if (typeof o.path === 'string') def.root = toHomeRelative(o.path);
+        if (typeof o.repoSlug === 'string') def.repo = o.repoSlug;
+        if (typeof o.linearProjectId === 'string') def.linear = { projectId: o.linearProjectId };
+        writeProjectDef(def);
+        created++;
+      }
+      console.log(chalk.green(`Imported ${created} project${created === 1 ? '' : 's'}${skipped ? chalk.gray(` (${skipped} skipped)`) : ''}`));
+    });
+
+  // ---- rm ----
+  projects
+    .command('rm <name>')
+    .alias('remove')
+    .description('Delete a project definition. Never touches the repo.')
+    .action((name: string) => {
+      if (removeProjectDef(name)) {
+        console.log(chalk.green(`Removed project "${name}"`));
+      } else {
+        console.error(chalk.red(`No project named "${name}".`));
+        process.exit(1);
+      }
+    });
+}

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -34,7 +34,9 @@ import {
 import {
   rollupSessionsByProject,
   planPct,
+  enrichProjectSignals,
   type ProjectSessionRollup,
+  type ProjectRemoteSignals,
 } from '../lib/project-status.js';
 
 /** `path:purpose` → a context anchor. Purpose may contain colons. */
@@ -66,20 +68,28 @@ function statusBar(r: ProjectSessionRollup): string {
   return parts.join(' · ') || chalk.gray('no live agents');
 }
 
-function renderCard(def: ProjectDef, r: ProjectSessionRollup | undefined): void {
+function renderCard(
+  def: ProjectDef,
+  r: ProjectSessionRollup | undefined,
+  remote: ProjectRemoteSignals | undefined,
+): void {
   const agents = r?.agents ?? 0;
   const pct = r ? planPct(r.plan) : undefined;
   const planStr = pct === undefined ? '' : `  ·  ${chalk.cyan(`${pct}% plan`)}`;
   console.log(`${chalk.bold(def.name)}  ${chalk.dim('·')}  ${chalk.bold(`${agents} agents`)}${planStr}`);
   if (def.description) console.log(`  ${chalk.dim(def.description)}`);
   console.log(`  ${chalk.dim('live')}     ${r ? statusBar(r) : chalk.gray('no live agents')}`);
-  if (r && (r.openPrs.length || r.worktrees)) {
-    const prs = r.openPrs.length ? `${r.openPrs.length} open PR${r.openPrs.length === 1 ? '' : 's'}` : '';
-    const wt = r.worktrees ? `${r.worktrees} worktree${r.worktrees === 1 ? '' : 's'}` : '';
-    console.log(`  ${chalk.dim('ships')}    ${[prs, wt].filter(Boolean).join(' · ')}`);
-  }
+  const ships: string[] = [];
+  if (remote?.mergedPrs) ships.push(chalk.green(`${remote.mergedPrs} merged (${remote.windowDays}d)`));
+  if (r?.openPrs.length) ships.push(`${r.openPrs.length} open PR${r.openPrs.length === 1 ? '' : 's'}`);
+  if (r?.worktrees) ships.push(`${r.worktrees} worktree${r.worktrees === 1 ? '' : 's'}`);
+  if (ships.length) console.log(`  ${chalk.dim('ships')}    ${ships.join(' · ')}`);
   if (r && r.tickets.length) {
     console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
+  }
+  if (remote?.artifacts) {
+    const last = remote.lastArtifact ? `  ${chalk.dim(`· last: ${remote.lastArtifact}`)}` : '';
+    console.log(`  ${chalk.dim('proof')}    ${remote.artifacts} artifact${remote.artifacts === 1 ? '' : 's'} (${remote.windowDays}d)${last}`);
   }
   const repos = [def.repo, ...(def.repos ?? []).map((x) => x.slug)].filter(Boolean) as string[];
   if (repos.length) console.log(`  ${chalk.dim('repos')}    ${[...new Set(repos)].join(' · ')}`);
@@ -244,41 +254,63 @@ export function registerProjectsCommands(program: Command): void {
   // ---- status ----
   projects
     .command('status [name]')
-    .description('Progress rollup: agents, plan completion, open PRs, and tickets per project.')
+    .description('Progress rollup: agents, plan %, merged/open PRs, tickets, and artifacts per project.')
     .option('--json', 'Machine-readable output')
-    .action(async (name: string | undefined, opts: { json?: boolean }) => {
+    .option('--window <days>', 'Window for merged PRs and artifacts', '7')
+    .option('--no-remote', 'Skip the GitHub lookup (merged-PR count); faster, offline')
+    .action(async (name: string | undefined, opts: { json?: boolean; window?: string; remote?: boolean }) => {
       const all = listProjectDefs();
       const defs = name ? all.filter((d) => d.name === name) : all;
       if (name && !defs.length) {
         console.error(chalk.red(`No project named "${name}".`));
         process.exit(1);
       }
+      if (!defs.length) {
+        if (opts.json) console.log('[]');
+        else console.log(chalk.gray('No projects defined. Add one: agents projects add <name>'));
+        return;
+      }
+      const windowDays = Math.max(1, Number.parseInt(opts.window ?? '7', 10) || 7);
+      const nowMs = Date.now();
       const roll = rollupSessionsByProject(all, await getActiveSessions());
+      // Enrich only the shown projects. --no-remote still reads the local artifact
+      // log but skips the gh call (def.repo left unused → mergedPrs stays 0).
+      const remote = new Map<string, ProjectRemoteSignals>();
+      await Promise.all(
+        defs.map(async (d) => {
+          remote.set(d.name, await enrichProjectSignals(d, windowDays, nowMs, { skipRemote: opts.remote === false }));
+        }),
+      );
+
       if (opts.json) {
         console.log(
           JSON.stringify(
-            defs.map((d) => ({
-              name: d.name,
-              agents: roll.get(d.name)?.agents ?? 0,
-              byStatus: roll.get(d.name)?.byStatus ?? {},
-              plan: roll.get(d.name)?.plan ?? { done: 0, total: 0 },
-              planPct: roll.get(d.name) ? planPct(roll.get(d.name)!.plan) ?? null : null,
-              openPrs: roll.get(d.name)?.openPrs ?? [],
-              tickets: roll.get(d.name)?.tickets ?? [],
-              worktrees: roll.get(d.name)?.worktrees ?? 0,
-              repos: [d.repo, ...(d.repos ?? []).map((r) => r.slug)].filter(Boolean),
-            })),
+            defs.map((d) => {
+              const r = roll.get(d.name);
+              const rem = remote.get(d.name);
+              return {
+                name: d.name,
+                agents: r?.agents ?? 0,
+                byStatus: r?.byStatus ?? {},
+                plan: r?.plan ?? { done: 0, total: 0 },
+                planPct: r ? planPct(r.plan) ?? null : null,
+                openPrs: r?.openPrs ?? [],
+                mergedPrs: rem?.mergedPrs ?? 0,
+                tickets: r?.tickets ?? [],
+                worktrees: r?.worktrees ?? 0,
+                artifacts: rem?.artifacts ?? 0,
+                lastArtifact: rem?.lastArtifact ?? null,
+                windowDays,
+                repos: [d.repo, ...(d.repos ?? []).map((r2) => r2.slug)].filter(Boolean),
+              };
+            }),
             null,
             2,
           ),
         );
         return;
       }
-      if (!defs.length) {
-        console.log(chalk.gray('No projects defined. Add one: agents projects add <name>'));
-        return;
-      }
-      for (const d of defs) renderCard(d, roll.get(d.name));
+      for (const d of defs) renderCard(d, roll.get(d.name), remote.get(d.name));
     });
 
   // ---- import ----

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -1,5 +1,5 @@
 /**
- * `agents projects` — named, multi-repo projects and the cross-fleet progress
+ * `agents projects` — named, multi-repo projects and the progress
  * rollup. Definitions live in `~/.agents/projects/<name>.yaml` (see
  * `lib/projects.ts`); this registers the command tree over them. Beta-gated on
  * `isBetaEnabled('projects')`, mirroring `agents factory`.
@@ -106,7 +106,7 @@ export function registerProjectsCommands(program: Command): void {
   const enabled = isBetaEnabled('projects');
   const projects = program
     .command('projects', { hidden: !enabled })
-    .description('Named multi-repo projects with a cross-fleet progress rollup.');
+    .description('Named multi-repo projects with a progress rollup.');
 
   setHelpSections(projects, {
     examples: `

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -65,6 +65,11 @@ function statusBar(r: ProjectSessionRollup): string {
   push(r.byStatus.idle, 'idle', chalk.gray);
   push(r.byStatus.input_required, 'need-input', chalk.yellow);
   push(r.byStatus.queued, 'queued', chalk.gray);
+  const shown =
+    (r.byStatus.running ?? 0) + (r.byStatus.idle ?? 0) + (r.byStatus.input_required ?? 0) + (r.byStatus.queued ?? 0);
+  // Sessions in a non-live state (orphaned/crashed/unknown) count toward the
+  // headline — render the remainder so the bar never sums to less than it.
+  if (r.agents > shown) parts.push(chalk.gray(`+${r.agents - shown} other`));
   return parts.join(' · ') || chalk.gray('no live agents');
 }
 
@@ -247,7 +252,9 @@ export function registerProjectsCommands(program: Command): void {
         process.exit(1);
       }
       const editor = process.env.VISUAL || process.env.EDITOR || 'vi';
-      const res = spawnSync(editor, [target], { stdio: 'inherit' });
+      // $EDITOR commonly carries args ("code --wait") — split like monitors/routines do.
+      const parts = editor.split(/\s+/).filter(Boolean);
+      const res = spawnSync(parts[0], [...parts.slice(1), target], { stdio: 'inherit' });
       process.exit(res.status ?? 0);
     });
 
@@ -260,7 +267,9 @@ export function registerProjectsCommands(program: Command): void {
     .option('--no-remote', 'Skip the GitHub lookup (merged-PR count); faster, offline')
     .action(async (name: string | undefined, opts: { json?: boolean; window?: string; remote?: boolean }) => {
       const all = listProjectDefs();
-      const defs = name ? all.filter((d) => d.name === name) : all;
+      // Named lookup goes through the strict single-def loader so a broken
+      // <name>.yaml surfaces its validation error instead of "No project named".
+      const defs = name ? [loadProjectDef(name)].filter((d): d is ProjectDef => d !== undefined) : all;
       if (name && !defs.length) {
         console.error(chalk.red(`No project named "${name}".`));
         process.exit(1);
@@ -321,11 +330,18 @@ export function registerProjectsCommands(program: Command): void {
     .option('--force', 'Overwrite existing definitions')
     .action((opts: { force?: boolean }) => {
       const src = factoryProjectsPath();
-      let rows: unknown;
+      let rawText: string;
       try {
-        rows = JSON.parse(fs.readFileSync(src, 'utf8'));
+        rawText = fs.readFileSync(src, 'utf8');
       } catch {
         console.error(chalk.red(`No Factory registry at ${src}`));
+        process.exit(1);
+      }
+      let rows: unknown;
+      try {
+        rows = JSON.parse(rawText);
+      } catch {
+        console.error(chalk.red(`Factory registry at ${src} is not valid JSON`));
         process.exit(1);
       }
       const list = Array.isArray(rows) ? rows : Array.isArray((rows as { projects?: unknown[] }).projects) ? (rows as { projects: unknown[] }).projects : [];

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -145,6 +145,7 @@ import {
   loadPackages,
   loadRoutines,
   loadMonitors,
+  loadProjects,
   loadRun,
   loadFork,
   loadDefaults,
@@ -1011,6 +1012,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadPackages);
   await reg(loadRoutines);
   await reg(loadMonitors);
+  await reg(loadProjects);
   await reg(loadRun);
   await reg(loadFork);
   await reg(loadDefaults);

--- a/apps/cli/src/lib/beta.ts
+++ b/apps/cli/src/lib/beta.ts
@@ -13,7 +13,7 @@ import type { BetaFeatureName, Manifest, Meta } from './types.js';
 import { getAgentsDir, getOptionalUserAgentsDir, readMeta, writeMeta } from './state.js';
 import { readManifest, writeManifest } from './manifest.js';
 
-export const ALL_BETA_FEATURES = ['drive', 'factory', 'session-sync'] as const satisfies readonly BetaFeatureName[];
+export const ALL_BETA_FEATURES = ['drive', 'factory', 'session-sync', 'projects'] as const satisfies readonly BetaFeatureName[];
 
 function isBetaFeatureName(value: unknown): value is BetaFeatureName {
   return typeof value === 'string' && ALL_BETA_FEATURES.includes(value as BetaFeatureName);

--- a/apps/cli/src/lib/project-root.test.ts
+++ b/apps/cli/src/lib/project-root.test.ts
@@ -10,7 +10,9 @@ import {
   parseProjectRef,
   buildProjectPath,
   inferProjectRoot,
+  resolveProjectRef,
 } from './project-root.js';
+import { writeProjectDef } from './projects.js';
 
 const HOME = process.env.HOME ?? os.homedir();
 
@@ -83,6 +85,31 @@ describe('buildProjectPath', () => {
   it('rejects an empty slug', () => {
     expect(() => buildProjectPath('~/src', '@wt', true)).toThrow(/Invalid --project/);
   });
+});
+
+describe('resolveProjectRef — definition first', () => {
+  let projDir: string;
+  beforeAll(() => {
+    projDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proj-def-'));
+    process.env.AGENTS_PROJECTS_DIR = projDir;
+    writeProjectDef({ name: 'acme', root: '~/src/acme', defaultPath: '~/src/acme/apps/api' });
+  });
+  afterAll(() => {
+    delete process.env.AGENTS_PROJECTS_DIR;
+    fs.rmSync(projDir, { recursive: true, force: true });
+  });
+
+  it('a defined project resolves to its defaultPath (forRemote keeps ~)', async () => {
+    expect(await resolveProjectRef('acme', { forRemote: true })).toBe('~/src/acme/apps/api');
+  });
+  it('a defined project @worktree resolves under the repo root', async () => {
+    expect(await resolveProjectRef('acme@fix', { forRemote: true })).toBe(
+      '~/src/acme/.agents/worktrees/fix',
+    );
+  });
+  // The convention fallback (undefined slug → <root>/<slug>) is covered by the
+  // buildProjectPath tests above; exercising it through resolveProjectRef would
+  // couple to the machine's cached projectRoot, so it is not re-tested here.
 });
 
 describe('inferProjectRoot', () => {

--- a/apps/cli/src/lib/project-root.ts
+++ b/apps/cli/src/lib/project-root.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import { readMeta, updateMeta } from './state.js';
 import { getMainRepoRoot } from './git.js';
 import { toPosix } from './platform/index.js';
+import { loadProjectDef, resolveDefinedProjectPath } from './projects.js';
 
 const HOME = process.env.HOME ?? os.homedir();
 
@@ -134,6 +135,22 @@ export async function resolveProjectRef(
   ref: string,
   opts: { forRemote: boolean; cwd?: string },
 ): Promise<string> {
+  const { slug, worktree } = parseProjectRef(ref);
+  if (!slug) throw new Error(`Invalid --project value: "${ref}"`);
+
+  // Definition first: a named project in ~/.agents/projects/<slug>.yaml overrides
+  // the <root>/<slug> convention. Absent (or root-less) → fall through unchanged.
+  const def = loadProjectDef(slug);
+  if (def) {
+    const fromDef = resolveDefinedProjectPath(def, worktree, opts.forRemote);
+    if (fromDef) {
+      if (!opts.forRemote && !fs.existsSync(fromDef)) {
+        throw new Error(`Project path not found: ${fromDef} (defined in ${slug}.yaml)`);
+      }
+      return fromDef;
+    }
+  }
+
   const cwd = opts.cwd ?? process.cwd();
   const root = await ensureProjectRoot(cwd);
   const resolved = buildProjectPath(root, ref, opts.forRemote);

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { rollupSessionsByProject, planPct } from './project-status.js';
+import { rollupSessionsByProject, planPct, enrichProjectSignals } from './project-status.js';
 import type { ProjectDef } from './projects.js';
 import type { ActiveSession } from './session/active.js';
 
@@ -61,5 +62,58 @@ describe('planPct', () => {
   it('rounds a percentage and returns undefined for nothing tracked', () => {
     expect(planPct({ done: 5, total: 7 })).toBe(71);
     expect(planPct({ done: 0, total: 0 })).toBeUndefined();
+  });
+});
+
+describe('enrichProjectSignals — artifact counting from the activity log', () => {
+  let actDir: string;
+  const NOW = 1_754_000_000_000; // fixed epoch so window math is deterministic
+  const def: ProjectDef = { name: 'rush', root: '~/src/rush' }; // no repo → gh skipped
+
+  beforeEach(() => {
+    actDir = fs.mkdtempSync(path.join(os.tmpdir(), 'act-'));
+  });
+  afterEach(() => fs.rmSync(actDir, { recursive: true, force: true }));
+
+  const ev = (tsMs: number, cwd: string, detail: string) =>
+    JSON.stringify({
+      v: 1,
+      ts: new Date(tsMs).toISOString(),
+      event: 'artifact.created',
+      tier: 'milestone',
+      sessionId: 's1',
+      cwd,
+      detail,
+    });
+
+  it('counts only this project’s in-window artifacts, newest detail surfaced', async () => {
+    const inWin = NOW - 2 * 86_400_000; // 2 days ago
+    const newest = NOW - 3600_000; // 1h ago
+    const outWin = NOW - 30 * 86_400_000; // 30 days ago
+    const rushCwd = path.join(HOME, 'src/rush/apps/web');
+    fs.writeFileSync(
+      path.join(actDir, 's1.jsonl'),
+      [
+        ev(inWin, rushCwd, 'a.html'),
+        ev(newest, rushCwd, 'newest.html'),
+        ev(outWin, rushCwd, 'old.html'), // outside 7d window
+        ev(inWin, path.join(HOME, 'src/other'), 'other.html'), // different project
+      ].join('\n') + '\n',
+    );
+
+    const sig = await enrichProjectSignals(def, 7, NOW, { activityRoot: actDir, skipRemote: true });
+    expect(sig.artifacts).toBe(2); // a.html + newest.html; old.html and other.html excluded
+    expect(sig.lastArtifact).toBe('newest.html');
+    expect(sig.mergedPrs).toBe(0); // no repo / skipRemote
+    expect(sig.windowDays).toBe(7);
+  });
+
+  it('is zero when nothing matches, and never throws on a missing log dir', async () => {
+    const sig = await enrichProjectSignals(def, 7, NOW, {
+      activityRoot: path.join(actDir, 'nope'),
+      skipRemote: true,
+    });
+    expect(sig.artifacts).toBe(0);
+    expect(sig.lastArtifact).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import { rollupSessionsByProject, planPct } from './project-status.js';
+import type { ProjectDef } from './projects.js';
+import type { ActiveSession } from './session/active.js';
+
+const HOME = process.env.HOME ?? os.homedir();
+const defs: ProjectDef[] = [
+  { name: 'rush', root: '~/src/rush' },
+  { name: 'other', root: '~/src/other' },
+];
+
+/** Minimal ActiveSession carrying only the fields the rollup reads. */
+function s(partial: Partial<ActiveSession>): ActiveSession {
+  return { context: 'terminal', kind: 'claude', status: 'running', ...partial } as unknown as ActiveSession;
+}
+
+describe('rollupSessionsByProject', () => {
+  it('groups by cwd, counts statuses, sums plan, dedups PRs and tickets', () => {
+    const sessions = [
+      s({ cwd: path.join(HOME, 'src/rush/apps/web'), status: 'running', todos: { done: 3, total: 5 } as never }),
+      s({
+        cwd: path.join(HOME, 'src/rush/.agents/worktrees/fix'),
+        status: 'idle',
+        todos: { done: 2, total: 2 } as never,
+        pr: { url: 'https://github.com/o/r/pull/9', number: 9 } as never,
+        worktree: { path: 'x' } as never,
+      }),
+      s({
+        cwd: path.join(HOME, 'src/rush/apps/api'),
+        status: 'input_required',
+        pr: { url: 'https://github.com/o/r/pull/9', number: 9 } as never, // dup PR
+        ticket: { id: 'RUSH-1' } as never,
+        createdTickets: ['RUSH-2', 'RUSH-1'], // RUSH-1 dup
+      }),
+      s({ cwd: path.join(HOME, 'src/other'), status: 'running' }), // different project
+      s({ cwd: path.join(HOME, 'src/unrelated'), status: 'running' }), // no project
+    ];
+    const map = rollupSessionsByProject(defs, sessions);
+
+    const rush = map.get('rush')!;
+    expect(rush.agents).toBe(3);
+    expect(rush.byStatus).toEqual({ running: 1, idle: 1, input_required: 1 });
+    expect(rush.plan).toEqual({ done: 5, total: 7 });
+    expect(rush.openPrs).toEqual([{ url: 'https://github.com/o/r/pull/9', number: 9 }]); // deduped
+    expect(rush.tickets.sort()).toEqual(['RUSH-1', 'RUSH-2']); // deduped across worked+created
+    expect(rush.worktrees).toBe(1);
+
+    expect(map.get('other')!.agents).toBe(1);
+    expect(map.has('unrelated')).toBe(false);
+  });
+
+  it('is empty when no session matches a project', () => {
+    const map = rollupSessionsByProject(defs, [s({ cwd: path.join(HOME, 'elsewhere') })]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('planPct', () => {
+  it('rounds a percentage and returns undefined for nothing tracked', () => {
+    expect(planPct({ done: 5, total: 7 })).toBe(71);
+    expect(planPct({ done: 0, total: 0 })).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -92,7 +92,7 @@ export function planPct(plan: { done: number; total: number }): number | undefin
   return Math.round((plan.done / plan.total) * 100);
 }
 
-/** Cross-repo / cross-machine signals harvested for a project, in a time window. */
+/** Harvested signals not on the session list: repo-global merged PRs + local artifacts, in a time window. */
 export interface ProjectRemoteSignals {
   windowDays: number;
   /** PRs merged into the primary repo within the window (via `gh`). */

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -5,9 +5,11 @@
  * PROJECT. This aggregates the signals already carried per session (status,
  * plan progress, open PRs, tickets, worktrees) into one row per project, keyed
  * by matching each session's cwd to a defined project root (`projectNameForCwd`).
- * Pure over an `ActiveSession[]` so the aggregation is unit-testable; the richer
- * async signals (merged PRs via `gh`, Linear ticket counts, produced artifacts)
- * enrich this in `enrichProjectStatus` without changing the core shape.
+ * The session set is whatever the caller passes (today `getActiveSessions()` —
+ * this machine's live view, matched by local-home cwd; a fleet-wide fan-out is a
+ * deferred follow-up). Pure over an `ActiveSession[]` so the aggregation is
+ * unit-testable; the merged-PR signal IS repo-global (harvested via `gh`) and the
+ * artifact signal is local, both added in `enrichProjectSignals`.
  */
 
 import { execFile } from 'child_process';

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -1,0 +1,86 @@
+/**
+ * Project-level progress rollup — the headline of the projects subsystem.
+ *
+ * At 50–100 agents the per-agent activity line is noise; what matters is the
+ * PROJECT. This aggregates the signals already carried per session (status,
+ * plan progress, open PRs, tickets, worktrees) into one row per project, keyed
+ * by matching each session's cwd to a defined project root (`projectNameForCwd`).
+ * Pure over an `ActiveSession[]` so the aggregation is unit-testable; the richer
+ * async signals (merged PRs via `gh`, Linear ticket counts, produced artifacts)
+ * enrich this in `enrichProjectStatus` without changing the core shape.
+ */
+
+import type { ActiveSession, ActiveStatus } from './session/active.js';
+import { projectNameForCwd, type ProjectDef } from './projects.js';
+
+/** One project's live session rollup. */
+export interface ProjectSessionRollup {
+  name: string;
+  /** Total sessions whose cwd is inside this project. */
+  agents: number;
+  /** Count per lifecycle status. */
+  byStatus: Partial<Record<ActiveStatus, number>>;
+  /** Summed checklist progress across this project's sessions. */
+  plan: { done: number; total: number };
+  /** Distinct open PRs held by this project's sessions. */
+  openPrs: { url: string; number?: number }[];
+  /** Distinct tickets worked or created by this project's sessions. */
+  tickets: string[];
+  /** Sessions running inside a worktree. */
+  worktrees: number;
+}
+
+function blank(name: string): ProjectSessionRollup {
+  return { name, agents: 0, byStatus: {}, plan: { done: 0, total: 0 }, openPrs: [], tickets: [], worktrees: 0 };
+}
+
+/**
+ * Roll active sessions up by project. Returns a map keyed by project name,
+ * containing only projects with at least one matched session — callers merge
+ * with the full definition list to show zero-agent projects.
+ */
+export function rollupSessionsByProject(
+  defs: ProjectDef[],
+  sessions: ActiveSession[],
+): Map<string, ProjectSessionRollup> {
+  const map = new Map<string, ProjectSessionRollup>();
+  const prSeen = new Map<string, Set<string>>();
+  const ticketSeen = new Map<string, Set<string>>();
+
+  for (const s of sessions) {
+    const name = projectNameForCwd(s.cwd, defs);
+    if (!name) continue;
+    let r = map.get(name);
+    if (!r) {
+      r = blank(name);
+      map.set(name, r);
+      prSeen.set(name, new Set());
+      ticketSeen.set(name, new Set());
+    }
+    r.agents++;
+    r.byStatus[s.status] = (r.byStatus[s.status] ?? 0) + 1;
+    if (s.todos) {
+      r.plan.done += s.todos.done;
+      r.plan.total += s.todos.total;
+    }
+    if (s.pr?.url && !prSeen.get(name)!.has(s.pr.url)) {
+      prSeen.get(name)!.add(s.pr.url);
+      r.openPrs.push({ url: s.pr.url, number: s.pr.number });
+    }
+    const tset = ticketSeen.get(name)!;
+    for (const t of [s.ticket?.id, ...(s.createdTickets ?? [])]) {
+      if (t && !tset.has(t)) {
+        tset.add(t);
+        r.tickets.push(t);
+      }
+    }
+    if (s.worktree) r.worktrees++;
+  }
+  return map;
+}
+
+/** Plan completion percentage (0–100), or undefined when nothing is tracked. */
+export function planPct(plan: { done: number; total: number }): number | undefined {
+  if (plan.total <= 0) return undefined;
+  return Math.round((plan.done / plan.total) * 100);
+}

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -10,8 +10,13 @@
  * enrich this in `enrichProjectStatus` without changing the core shape.
  */
 
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import type { ActiveSession, ActiveStatus } from './session/active.js';
 import { projectNameForCwd, type ProjectDef } from './projects.js';
+import { readRecentActivity } from './activity.js';
+
+const execFileAsync = promisify(execFile);
 
 /** One project's live session rollup. */
 export interface ProjectSessionRollup {
@@ -83,4 +88,56 @@ export function rollupSessionsByProject(
 export function planPct(plan: { done: number; total: number }): number | undefined {
   if (plan.total <= 0) return undefined;
   return Math.round((plan.done / plan.total) * 100);
+}
+
+/** Cross-repo / cross-machine signals harvested for a project, in a time window. */
+export interface ProjectRemoteSignals {
+  windowDays: number;
+  /** PRs merged into the primary repo within the window (via `gh`). */
+  mergedPrs: number;
+  /** Artifacts agents produced within the window (activity.created milestones). */
+  artifacts: number;
+  /** Basename of the most recent artifact, when any. */
+  lastArtifact?: string;
+}
+
+/**
+ * Harvest the signals that don't live on the active-session list: recently
+ * merged PRs (from GitHub via `gh`) and artifacts agents produced (from the
+ * local activity-milestone log, matched to the project by cwd). Best-effort —
+ * a missing `gh`, no auth, or no repo degrades to zero rather than throwing, so
+ * `projects status` still renders. `nowMs` is injected for testability.
+ */
+export async function enrichProjectSignals(
+  def: ProjectDef,
+  windowDays: number,
+  nowMs: number,
+  opts: { activityRoot?: string; skipRemote?: boolean } = {},
+): Promise<ProjectRemoteSignals> {
+  const sinceMs = nowMs - windowDays * 86_400_000;
+  const out: ProjectRemoteSignals = { windowDays, mergedPrs: 0, artifacts: 0 };
+
+  try {
+    const evs = readRecentActivity({ events: ['artifact.created'], sinceMs, root: opts.activityRoot });
+    const mine = evs.filter((e) => projectNameForCwd(e.cwd, [def]) === def.name);
+    out.artifacts = mine.length;
+    if (mine.length && typeof mine[0].detail === 'string') out.lastArtifact = mine[0].detail;
+  } catch {
+    /* activity log unreadable — best-effort */
+  }
+
+  if (def.repo && !opts.skipRemote) {
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'list', '--repo', def.repo, '--state', 'merged', '--json', 'number,mergedAt', '--limit', '100'],
+        { timeout: 8000, encoding: 'utf8' },
+      );
+      const rows = JSON.parse(stdout) as { mergedAt?: string }[];
+      out.mergedPrs = rows.filter((r) => r.mergedAt && Date.parse(r.mergedAt) >= sinceMs).length;
+    } catch {
+      /* gh missing / unauthenticated / repo not found — skip this signal */
+    }
+  }
+  return out;
 }

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  isSafeProjectName,
+  loadProjectDef,
+  listProjectDefs,
+  writeProjectDef,
+  removeProjectDef,
+  validateProjectDef,
+  projectBasePath,
+  type ProjectDef,
+} from './projects.js';
+
+const HOME = process.env.HOME ?? os.homedir();
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'projects-test-'));
+  process.env.AGENTS_PROJECTS_DIR = dir;
+});
+afterEach(() => {
+  delete process.env.AGENTS_PROJECTS_DIR;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('isSafeProjectName', () => {
+  it('accepts slugs, rejects separators and traversal', () => {
+    expect(isSafeProjectName('rush')).toBe(true);
+    expect(isSafeProjectName('rush-web.2')).toBe(true);
+    expect(isSafeProjectName('..')).toBe(false);
+    expect(isSafeProjectName('a/b')).toBe(false);
+    expect(isSafeProjectName('.hidden')).toBe(false);
+    expect(isSafeProjectName('')).toBe(false);
+  });
+});
+
+describe('validateProjectDef', () => {
+  it('throws when name is missing or unsafe', () => {
+    expect(() => validateProjectDef({})).toThrow(/valid "name"/);
+    expect(() => validateProjectDef({ name: '../evil' })).toThrow(/valid slug/);
+    expect(() => validateProjectDef('nope')).toThrow(/mapping/);
+  });
+
+  it('keeps well-formed nested fields and drops malformed list entries', () => {
+    const def = validateProjectDef({
+      name: 'rush',
+      repos: [{ slug: 'phnx-labs/rush', subpath: 'apps/web' }, { bad: true }, 'nope'],
+      contexts: [{ path: 'apps/web', purpose: 'the app' }, { path: 'x' }],
+      integrations: [{ kind: 'gdrive', url: 'https://d', label: 'docs' }, { kind: 'x' }],
+      linear: { projectId: 'abc', url: 'https://linear' },
+    });
+    expect(def.repos).toEqual([{ slug: 'phnx-labs/rush', subpath: 'apps/web' }]);
+    expect(def.contexts).toEqual([{ path: 'apps/web', purpose: 'the app' }]);
+    expect(def.integrations).toEqual([{ kind: 'gdrive', url: 'https://d', label: 'docs' }]);
+    expect(def.linear).toEqual({ projectId: 'abc', url: 'https://linear' });
+  });
+});
+
+describe('write/load roundtrip', () => {
+  it('normalizes root/defaultPath to home-relative and reads back', () => {
+    const abs = path.join(HOME, 'src', 'github.com', 'me', 'rush');
+    writeProjectDef({ name: 'rush', root: abs, defaultPath: path.join(abs, 'apps/web') });
+    const raw = fs.readFileSync(path.join(dir, 'rush.yaml'), 'utf8');
+    expect(raw).toContain('root: ~/src/github.com/me/rush');
+    expect(raw).toContain('defaultPath: ~/src/github.com/me/rush/apps/web');
+
+    const loaded = loadProjectDef('rush');
+    expect(loaded?.name).toBe('rush');
+    expect(loaded?.root).toBe('~/src/github.com/me/rush');
+  });
+
+  it('loadProjectDef returns undefined for an absent project', () => {
+    expect(loadProjectDef('ghost')).toBeUndefined();
+  });
+
+  it('loadProjectDef throws on a bad name field and on a non-mapping (fail loud)', () => {
+    fs.writeFileSync(path.join(dir, 'badname.yaml'), 'name: 123\n', 'utf8');
+    expect(() => loadProjectDef('badname')).toThrow(/must be a valid slug/);
+    fs.writeFileSync(path.join(dir, 'seq.yaml'), '- a\n- b\n', 'utf8');
+    expect(() => loadProjectDef('seq')).toThrow(/mapping/);
+  });
+});
+
+describe('listProjectDefs', () => {
+  it('lists valid defs sorted, skipping a malformed one', () => {
+    writeProjectDef({ name: 'zeta' });
+    writeProjectDef({ name: 'alpha' });
+    fs.writeFileSync(path.join(dir, 'broken.yaml'), '- a\n- b\n', 'utf8');
+    const names = listProjectDefs().map((d) => d.name);
+    expect(names).toEqual(['alpha', 'zeta']);
+  });
+
+  it('is empty when the dir does not exist', () => {
+    process.env.AGENTS_PROJECTS_DIR = path.join(dir, 'nope');
+    expect(listProjectDefs()).toEqual([]);
+  });
+});
+
+describe('removeProjectDef', () => {
+  it('removes an existing def and reports false for a missing one', () => {
+    writeProjectDef({ name: 'gone' });
+    expect(removeProjectDef('gone')).toBe(true);
+    expect(loadProjectDef('gone')).toBeUndefined();
+    expect(removeProjectDef('gone')).toBe(false);
+  });
+});
+
+describe('projectBasePath', () => {
+  const def: ProjectDef = { name: 'rush', root: '~/src/rush', defaultPath: '~/src/rush/apps/web' };
+  it('prefers defaultPath, keeps ~ for remote, expands for local', () => {
+    expect(projectBasePath(def, true)).toBe('~/src/rush/apps/web');
+    expect(projectBasePath(def, false)).toBe(path.join(HOME, 'src/rush/apps/web'));
+  });
+  it('falls back to root, and undefined when neither set', () => {
+    expect(projectBasePath({ name: 'x', root: '~/r' }, true)).toBe('~/r');
+    expect(projectBasePath({ name: 'x' }, true)).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -45,6 +45,14 @@ describe('validateProjectDef', () => {
     expect(() => validateProjectDef('nope')).toThrow(/mapping/);
   });
 
+  it('throws when the in-file name disagrees with the filename', () => {
+    // The filename is the stable id — a def that names itself otherwise would
+    // resolve under one name and list under another.
+    expect(() => validateProjectDef({ name: 'other' }, 'rush')).toThrow(/must match the filename/);
+    expect(validateProjectDef({ name: 'rush' }, 'rush').name).toBe('rush');
+    expect(validateProjectDef({ root: '~/x' }, 'rush').name).toBe('rush'); // no name field → filename wins
+  });
+
   it('keeps well-formed nested fields and drops malformed list entries', () => {
     const def = validateProjectDef({
       name: 'rush',

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -94,6 +94,15 @@ describe('listProjectDefs', () => {
     expect(names).toEqual(['alpha', 'zeta']);
   });
 
+  it('ignores a .yml file so list and load agree on .yaml (no silent-drop)', () => {
+    writeProjectDef({ name: 'real' });
+    fs.writeFileSync(path.join(dir, 'ghost.yml'), 'name: ghost\n', 'utf8');
+    // listed set is exactly the .yaml files...
+    expect(listProjectDefs().map((d) => d.name)).toEqual(['real']);
+    // ...and loadProjectDef agrees: the .yml is not loadable, so it's not "there".
+    expect(loadProjectDef('ghost')).toBeUndefined();
+  });
+
   it('is empty when the dir does not exist', () => {
     process.env.AGENTS_PROJECTS_DIR = path.join(dir, 'nope');
     expect(listProjectDefs()).toEqual([]);

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -10,6 +10,8 @@ import {
   removeProjectDef,
   validateProjectDef,
   projectBasePath,
+  resolveDefinedProjectPath,
+  projectNameForCwd,
   type ProjectDef,
 } from './projects.js';
 
@@ -116,5 +118,45 @@ describe('projectBasePath', () => {
   it('falls back to root, and undefined when neither set', () => {
     expect(projectBasePath({ name: 'x', root: '~/r' }, true)).toBe('~/r');
     expect(projectBasePath({ name: 'x' }, true)).toBeUndefined();
+  });
+});
+
+describe('resolveDefinedProjectPath', () => {
+  const def: ProjectDef = { name: 'rush', root: '~/src/rush', defaultPath: '~/src/rush/apps/web' };
+  it('no worktree → defaultPath, ~ kept for remote', () => {
+    expect(resolveDefinedProjectPath(def, undefined, true)).toBe('~/src/rush/apps/web');
+    expect(resolveDefinedProjectPath(def, undefined, false)).toBe(path.join(HOME, 'src/rush/apps/web'));
+  });
+  it('worktree hangs off the repo ROOT, not the defaultPath subdir', () => {
+    expect(resolveDefinedProjectPath(def, 'fix', true)).toBe('~/src/rush/.agents/worktrees/fix');
+    expect(resolveDefinedProjectPath(def, 'fix', false)).toBe(
+      path.join(HOME, 'src/rush/.agents/worktrees/fix'),
+    );
+  });
+  it('undefined when the definition has no root/defaultPath', () => {
+    expect(resolveDefinedProjectPath({ name: 'bare' }, undefined, true)).toBeUndefined();
+    expect(resolveDefinedProjectPath({ name: 'bare' }, 'wt', true)).toBeUndefined();
+  });
+});
+
+describe('projectNameForCwd', () => {
+  const defs: ProjectDef[] = [
+    { name: 'rush', root: '~/src/rush' },
+    { name: 'rush-web', root: '~/src/rush/apps/web' }, // nested — must win over rush
+    { name: 'other', root: '~/src/other' },
+  ];
+  it('matches a cwd inside a project root, longest (nested) wins', () => {
+    expect(projectNameForCwd(path.join(HOME, 'src/rush/packages/api'), defs)).toBe('rush');
+    expect(projectNameForCwd(path.join(HOME, 'src/rush/apps/web/components'), defs)).toBe('rush-web');
+    expect(projectNameForCwd(path.join(HOME, 'src/rush'), defs)).toBe('rush');
+  });
+  it('matches a worktree under the project root', () => {
+    expect(projectNameForCwd(path.join(HOME, 'src/rush/.agents/worktrees/fix'), defs)).toBe('rush');
+  });
+  it('undefined for a cwd outside every project, or a sibling-prefix false match', () => {
+    expect(projectNameForCwd(path.join(HOME, 'src/unrelated'), defs)).toBeUndefined();
+    // ~/src/rush-extra must NOT match ~/src/rush (segment-aware, not string prefix)
+    expect(projectNameForCwd(path.join(HOME, 'src/rush-extra/x'), defs)).toBeUndefined();
+    expect(projectNameForCwd(undefined, defs)).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -99,8 +99,9 @@ export function projectDefPath(name: string): string {
 
 /**
  * Validate a raw parsed object into a `ProjectDef`, throwing an actionable error
- * on the first problem. Fail loud at the boundary — a malformed definition is a
- * bug to surface, never a silent partial load.
+ * on the first problem. A malformed document or identity (bad/mismatched name)
+ * throws; malformed entries inside the optional lists (`repos`/`contexts`/
+ * `integrations`) are dropped so one bad row can't sink an otherwise good def.
  */
 export function validateProjectDef(raw: unknown, sourceName?: string): ProjectDef {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -121,6 +122,11 @@ export function validateProjectDef(raw: unknown, sourceName?: string): ProjectDe
   }
   if (!name || !isSafeProjectName(name)) {
     throw new Error('Project definition is missing a valid "name"');
+  }
+  // The filename IS the stable id — a def whose `name:` disagrees with its
+  // filename would resolve under one name and list under another.
+  if (hasNameField && sourceName && name !== sourceName) {
+    throw new Error(`Project ${sourceName}: "name" (${JSON.stringify(name)}) must match the filename — the filename is the stable id`);
   }
 
   const def: ProjectDef = { name };

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -20,6 +20,7 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import * as yaml from 'yaml';
 import { getProjectsDir } from './state.js';
 import { safeJoin } from './paths.js';
@@ -266,4 +267,74 @@ export function projectBasePath(def: ProjectDef, forRemote: boolean): string | u
   const base = def.defaultPath ?? def.root;
   if (!base) return undefined;
   return forRemote ? base : expandLocalHome(base);
+}
+
+/** A project plus its repo root as an absolute local path, for cwd matching. */
+interface ProjectRootAbs {
+  name: string;
+  /** Absolute, normalized repo root (`root` preferred, else `defaultPath`). */
+  abs: string;
+}
+
+function projectRootsAbs(defs: ProjectDef[]): ProjectRootAbs[] {
+  const out: ProjectRootAbs[] = [];
+  for (const def of defs) {
+    const raw = def.root ?? def.defaultPath;
+    if (!raw) continue;
+    out.push({ name: def.name, abs: path.resolve(expandLocalHome(raw)) });
+  }
+  return out;
+}
+
+/** True when `child` is `parent` or nested under it (path-segment aware). */
+function isUnder(child: string, parent: string): boolean {
+  if (child === parent) return true;
+  const withSep = parent.endsWith(path.sep) ? parent : parent + path.sep;
+  return child.startsWith(withSep);
+}
+
+/**
+ * Which defined project a session belongs to, derived from its working
+ * directory. A session whose `cwd` sits inside a project's repo root (or a
+ * worktree under it) is a member; the LONGEST matching root wins so a nested
+ * project beats its parent. Returns undefined when no definition contains the
+ * path. This is the join key for the progress rollup — it needs no persisted
+ * column and works cross-machine because transcript `cwd` already syncs.
+ */
+export function projectNameForCwd(cwd: string | undefined, defs: ProjectDef[]): string | undefined {
+  if (!cwd) return undefined;
+  const abs = path.resolve(expandLocalHome(cwd));
+  let best: string | undefined;
+  let bestLen = -1;
+  for (const { name, abs: root } of projectRootsAbs(defs)) {
+    if (isUnder(abs, root) && root.length > bestLen) {
+      best = name;
+      bestLen = root.length;
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve a defined project's ref to a working directory, mirroring
+ * `buildProjectPath`'s `forRemote` contract (a home-relative `~/…` for the
+ * remote shell to expand, an absolute local path otherwise). A `@worktree`
+ * lands under the repo ROOT's `.agents/worktrees/`, not the `defaultPath`
+ * subdir — worktrees are per-repo, not per-focus. Returns undefined when the
+ * definition carries no `root`/`defaultPath` (caller falls back to convention).
+ */
+export function resolveDefinedProjectPath(
+  def: ProjectDef,
+  worktree: string | undefined,
+  forRemote: boolean,
+): string | undefined {
+  if (worktree) {
+    const rootRaw = def.root ?? def.defaultPath;
+    if (!rootRaw) return undefined;
+    const wt = `${rootRaw}/.agents/worktrees/${worktree}`;
+    return forRemote ? wt : path.resolve(expandLocalHome(wt));
+  }
+  const base = projectBasePath(def, forRemote);
+  if (!base) return undefined;
+  return forRemote ? base : path.resolve(base);
 }

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -1,0 +1,269 @@
+/**
+ * Named project definitions — the layer above the `--project <slug>` convention.
+ *
+ * `agents run --project <slug>` already resolves a bare name to a working
+ * directory by pure convention (`<projectRoot>/<slug>`, see `project-root.ts`).
+ * This module adds editable definitions on top: one YAML file per project under
+ * `~/.agents/projects/<name>.yaml`, sitting beside the existing `routines/`,
+ * `monitors/`, and `teams/` dirs in the user repo (so definitions sync across
+ * machines for free via `agents push/pull`). A defined project can name itself
+ * independently of its folder, bind more than one repo, pin a monorepo subpath,
+ * describe context subdirectories an agent should start from, carry a Linear
+ * link and external integrations, and set an explicit default path.
+ *
+ * Portable by construction: `root`/`defaultPath` are stored home-relative
+ * (`~/…`) via `toHomeRelative`, so the same definition re-roots on any machine
+ * whose home differs — the exact mechanism `project-root.ts` already relies on.
+ *
+ * Resolution stays additive: an undefined slug still resolves exactly as today
+ * (see `resolveProjectRef`), a defined one overrides it.
+ */
+
+import * as fs from 'fs';
+import * as yaml from 'yaml';
+import { getProjectsDir } from './state.js';
+import { safeJoin } from './paths.js';
+import { toHomeRelative, expandLocalHome } from './project-root.js';
+
+/** A git repo bound to a project, with an optional monorepo subpath. */
+export interface ProjectRepo {
+  /** GitHub slug `owner/repo`. */
+  slug: string;
+  /** Optional path within the repo an agent working this project cares about. */
+  subpath?: string;
+}
+
+/**
+ * A described context anchor: a subdirectory plus what it is. Agents starting on
+ * the project read `purpose` to know where to look — an indexed starting point,
+ * not just a path. This is the richer form of the single monorepo-focus dir.
+ */
+export interface ProjectContext {
+  /** Path relative to the project root (e.g. `apps/web`). */
+  path: string;
+  /** One line on how this subtree relates to the project. */
+  purpose: string;
+}
+
+/** An external context source hung off the project (surfaced in `projects show`). */
+export interface ProjectIntegration {
+  /** e.g. `gdrive`, `notion`, `figma`, `url`. */
+  kind: string;
+  url: string;
+  label?: string;
+}
+
+/** The parsed `~/.agents/projects/<name>.yaml`. */
+export interface ProjectDef {
+  /** Stable id; matches the filename; what `--project` takes. */
+  name: string;
+  description?: string;
+  /** Repo / monorepo root, home-relative for portability. */
+  root?: string;
+  /** Where an agent's cwd lands. Defaults to `root` when unset. */
+  defaultPath?: string;
+  /** Primary GitHub slug (`owner/repo`) — for PR / CI / status roll-up. */
+  repo?: string;
+  /** All bound repos, each with an optional monorepo subpath. */
+  repos?: ProjectRepo[];
+  /** Described starting points inside the project. */
+  contexts?: ProjectContext[];
+  /** External context sources (Drive, docs, …). */
+  integrations?: ProjectIntegration[];
+  /** Linear project link — reuses the existing GraphQL path. */
+  linear?: { projectId?: string; url?: string };
+  /** Free-form doc links surfaced in `projects show`. */
+  docs?: string[];
+  /** Preferred hosts for runs/routines (phase 2). */
+  devices?: string[];
+}
+
+/** A project name safe to use as a filename: no separators, `..`, or leading dot. */
+export function isSafeProjectName(name: string): boolean {
+  return (
+    typeof name === 'string' &&
+    name.length > 0 &&
+    name.length <= 64 &&
+    /^[a-z0-9][a-z0-9._-]*$/i.test(name) &&
+    name !== '.' &&
+    name !== '..'
+  );
+}
+
+/** Absolute path to a project's YAML definition. Throws on an unsafe name. */
+export function projectDefPath(name: string): string {
+  if (!isSafeProjectName(name)) {
+    throw new Error(`Invalid project name: "${name}" (letters, digits, ., _, - only)`);
+  }
+  return safeJoin(getProjectsDir(), `${name}.yaml`);
+}
+
+/**
+ * Validate a raw parsed object into a `ProjectDef`, throwing an actionable error
+ * on the first problem. Fail loud at the boundary — a malformed definition is a
+ * bug to surface, never a silent partial load.
+ */
+export function validateProjectDef(raw: unknown, sourceName?: string): ProjectDef {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`Project ${sourceName ?? ''} is not a YAML mapping`.trim());
+  }
+  const o = raw as Record<string, unknown>;
+  // The filename is the identity; a `name:` field is optional but, when present,
+  // must be a valid slug — a malformed one is a loud error, not a silent fallback.
+  const hasNameField = 'name' in o && o.name !== undefined && o.name !== null;
+  let name: string | undefined;
+  if (hasNameField) {
+    if (typeof o.name !== 'string' || !isSafeProjectName(o.name)) {
+      throw new Error(`Project ${sourceName ?? ''}: "name" must be a valid slug (got ${JSON.stringify(o.name)})`);
+    }
+    name = o.name;
+  } else {
+    name = sourceName;
+  }
+  if (!name || !isSafeProjectName(name)) {
+    throw new Error('Project definition is missing a valid "name"');
+  }
+
+  const def: ProjectDef = { name };
+  if (typeof o.description === 'string') def.description = o.description;
+  if (typeof o.root === 'string') def.root = o.root;
+  if (typeof o.defaultPath === 'string') def.defaultPath = o.defaultPath;
+  if (typeof o.repo === 'string') def.repo = o.repo;
+
+  if (Array.isArray(o.repos)) {
+    def.repos = o.repos.flatMap((r) => {
+      if (r && typeof r === 'object' && typeof (r as Record<string, unknown>).slug === 'string') {
+        const rr = r as Record<string, unknown>;
+        const repo: ProjectRepo = { slug: rr.slug as string };
+        if (typeof rr.subpath === 'string') repo.subpath = rr.subpath;
+        return [repo];
+      }
+      return [];
+    });
+  }
+  if (Array.isArray(o.contexts)) {
+    def.contexts = o.contexts.flatMap((c) => {
+      if (
+        c &&
+        typeof c === 'object' &&
+        typeof (c as Record<string, unknown>).path === 'string' &&
+        typeof (c as Record<string, unknown>).purpose === 'string'
+      ) {
+        const cc = c as Record<string, unknown>;
+        return [{ path: cc.path as string, purpose: cc.purpose as string }];
+      }
+      return [];
+    });
+  }
+  if (Array.isArray(o.integrations)) {
+    def.integrations = o.integrations.flatMap((i) => {
+      if (
+        i &&
+        typeof i === 'object' &&
+        typeof (i as Record<string, unknown>).kind === 'string' &&
+        typeof (i as Record<string, unknown>).url === 'string'
+      ) {
+        const ii = i as Record<string, unknown>;
+        const integ: ProjectIntegration = { kind: ii.kind as string, url: ii.url as string };
+        if (typeof ii.label === 'string') integ.label = ii.label;
+        return [integ];
+      }
+      return [];
+    });
+  }
+  if (o.linear && typeof o.linear === 'object' && !Array.isArray(o.linear)) {
+    const l = o.linear as Record<string, unknown>;
+    def.linear = {};
+    if (typeof l.projectId === 'string') def.linear.projectId = l.projectId;
+    if (typeof l.url === 'string') def.linear.url = l.url;
+  }
+  if (Array.isArray(o.docs)) def.docs = o.docs.filter((d): d is string => typeof d === 'string');
+  if (Array.isArray(o.devices)) def.devices = o.devices.filter((d): d is string => typeof d === 'string');
+
+  return def;
+}
+
+/**
+ * Load a single project definition by name. Returns undefined when the file is
+ * absent (the common "not a defined project, fall back to convention" case) but
+ * throws when a file EXISTS and is malformed — a broken definition is loud.
+ */
+export function loadProjectDef(name: string): ProjectDef | undefined {
+  if (!isSafeProjectName(name)) return undefined;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(projectDefPath(name), 'utf8');
+  } catch {
+    return undefined; // absent — not a defined project
+  }
+  return validateProjectDef(yaml.parse(raw), name);
+}
+
+/**
+ * List every defined project, sorted by name. Skips (does not throw on) a
+ * malformed file so one bad definition can't break `projects list`; the loader
+ * for a single named project stays strict.
+ */
+export function listProjectDefs(): ProjectDef[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(getProjectsDir()).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+  } catch {
+    return [];
+  }
+  const out: ProjectDef[] = [];
+  for (const f of files) {
+    const name = f.replace(/\.ya?ml$/, '');
+    try {
+      const def = loadProjectDef(name);
+      if (def) out.push(def);
+    } catch {
+      /* malformed — skip in the listing */
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Persist a project definition, normalizing `root`/`defaultPath` to home-relative
+ * so it stays portable across machines. Creates the projects dir on first write.
+ */
+export function writeProjectDef(def: ProjectDef): string {
+  const validated = validateProjectDef(def, def.name);
+  const normalized: ProjectDef = {
+    ...validated,
+    root: validated.root ? toHomeRelative(expandLocalHome(validated.root)) : undefined,
+    defaultPath: validated.defaultPath
+      ? toHomeRelative(expandLocalHome(validated.defaultPath))
+      : undefined,
+  };
+  // Drop undefined keys so the YAML stays clean.
+  const clean = Object.fromEntries(
+    Object.entries(normalized).filter(([, v]) => v !== undefined),
+  );
+  const target = projectDefPath(def.name);
+  fs.mkdirSync(getProjectsDir(), { recursive: true });
+  fs.writeFileSync(target, yaml.stringify(clean), 'utf8');
+  return target;
+}
+
+/** Delete a project definition. Returns true if a file was removed. Never touches the repo. */
+export function removeProjectDef(name: string): boolean {
+  try {
+    fs.unlinkSync(projectDefPath(name));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The cwd an agent lands in for a defined project: `defaultPath` when set, else
+ * `root`. Home-relative when `forRemote` (the remote shell expands `~`), else
+ * expanded against the local home. Returns undefined when neither is set.
+ */
+export function projectBasePath(def: ProjectDef, forRemote: boolean): string | undefined {
+  const base = def.defaultPath ?? def.root;
+  if (!base) return undefined;
+  return forRemote ? base : expandLocalHome(base);
+}

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -75,8 +75,6 @@ export interface ProjectDef {
   linear?: { projectId?: string; url?: string };
   /** Free-form doc links surfaced in `projects show`. */
   docs?: string[];
-  /** Preferred hosts for runs/routines (phase 2). */
-  devices?: string[];
 }
 
 /** A project name safe to use as a filename: no separators, `..`, or leading dot. */
@@ -179,7 +177,6 @@ export function validateProjectDef(raw: unknown, sourceName?: string): ProjectDe
     if (typeof l.url === 'string') def.linear.url = l.url;
   }
   if (Array.isArray(o.docs)) def.docs = o.docs.filter((d): d is string => typeof d === 'string');
-  if (Array.isArray(o.devices)) def.devices = o.devices.filter((d): d is string => typeof d === 'string');
 
   return def;
 }
@@ -208,13 +205,16 @@ export function loadProjectDef(name: string): ProjectDef | undefined {
 export function listProjectDefs(): ProjectDef[] {
   let files: string[];
   try {
-    files = fs.readdirSync(getProjectsDir()).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+    // Definitions are `<name>.yaml` (what projectDefPath/loadProjectDef read). We
+    // deliberately do NOT list `.yml` here — accepting it would then ENOENT in the
+    // loader and silently drop the project. One extension, one code path.
+    files = fs.readdirSync(getProjectsDir()).filter((f) => f.endsWith('.yaml'));
   } catch {
     return [];
   }
   const out: ProjectDef[] = [];
   for (const f of files) {
-    const name = f.replace(/\.ya?ml$/, '');
+    const name = f.replace(/\.yaml$/, '');
     try {
       const def = loadProjectDef(name);
       if (def) out.push(def);
@@ -298,8 +298,13 @@ function isUnder(child: string, parent: string): boolean {
  * directory. A session whose `cwd` sits inside a project's repo root (or a
  * worktree under it) is a member; the LONGEST matching root wins so a nested
  * project beats its parent. Returns undefined when no definition contains the
- * path. This is the join key for the progress rollup — it needs no persisted
- * column and works cross-machine because transcript `cwd` already syncs.
+ * path.
+ *
+ * The comparison is against the LOCAL home: roots and the cwd are both expanded
+ * with `expandLocalHome` and resolved, so this matches sessions whose cwd shares
+ * this machine's home layout. A session recorded on a different-home machine
+ * (`/Users/x/…` vs `/home/x/…`) will not match until the fleet-wide,
+ * home-relative variant lands (see the deferred item in docs/11-projects.md).
  */
 export function projectNameForCwd(cwd: string | undefined, defs: ProjectDef[]): string | undefined {
   if (!cwd) return undefined;

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -50,6 +50,7 @@ export const loadExport: ModuleLoader = async () => (await import('../../command
 export const loadPackages: ModuleLoader = async () => (await import('../../commands/packages.js')).registerPackagesCommands;
 export const loadRoutines: ModuleLoader = async () => (await import('../../commands/routines.js')).registerRoutinesCommands;
 export const loadMonitors: ModuleLoader = async () => (await import('../../commands/monitors.js')).registerMonitorsCommands;
+export const loadProjects: ModuleLoader = async () => (await import('../../commands/projects.js')).registerProjectsCommands;
 export const loadRun: ModuleLoader = async () => (await import('../../commands/exec.js')).registerRunCommand;
 export const loadFork: ModuleLoader = async () => (await import('../../commands/fork.js')).registerForkCommand;
 export const loadDefaults: ModuleLoader = async () => (await import('../../commands/defaults.js')).registerDefaultsCommands;
@@ -163,6 +164,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   install: [loadPackages],
   routines: [loadRoutines],
   monitors: [loadMonitors],
+  projects: [loadProjects],
   run: [loadRun],
   fork: [loadFork],
   defaults: [loadDefaults],

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -104,6 +104,9 @@ const WEBHOOKS_DIR = path.join(USER_AGENTS_DIR, 'webhooks');
 // monitor is a routine whose trigger is a watched source instead of a clock.
 const MONITORS_DIR = path.join(USER_AGENTS_DIR, 'monitors');
 const TEAMS_DIR = path.join(USER_AGENTS_DIR, 'teams');
+// Named project definitions (the layer above the --project convention). Sibling
+// of ROUTINES_DIR/TEAMS_DIR: hand-editable YAML, synced across machines by push/pull.
+const PROJECTS_DIR = path.join(USER_AGENTS_DIR, 'projects');
 
 // History bucket (durable).
 const SESSIONS_DIR = path.join(HISTORY_DIR, 'sessions');
@@ -357,6 +360,9 @@ export function getPackagesDir(): string { return PACKAGES_DIR; }
 
 /** Path to routine YAML definitions (~/.agents/routines/). */
 export function getRoutinesDir(): string { return process.env.AGENTS_ROUTINES_DIR ?? ROUTINES_DIR; }
+
+/** Path to named project definitions (~/.agents/projects/). */
+export function getProjectsDir(): string { return process.env.AGENTS_PROJECTS_DIR ?? PROJECTS_DIR; }
 
 /**
  * Path to webhook handler YAML definitions (~/.agents/webhooks/). Handlers are

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -71,7 +71,7 @@ export interface BudgetConfig {
 }
 
 /** Preview features that users can opt into via `agents beta`. */
-export type BetaFeatureName = 'drive' | 'factory' | 'session-sync';
+export type BetaFeatureName = 'drive' | 'factory' | 'session-sync' | 'projects';
 
 /** Subset of chalk color names used for agent-specific terminal output. */
 export type ChalkColor = 'magenta' | 'green' | 'blue' | 'cyan' | 'yellowBright' | 'redBright' | 'whiteBright' | 'blueBright' | 'greenBright' | 'magentaBright' | 'cyanBright';


### PR DESCRIPTION
**feat (new subsystem, beta-gated)** — `agents projects`: named multi-repo projects + a cross-fleet **progress rollup**.

## Why

At 50–100 agents nobody watches individual agents — they watch the **project**. Today the only project-granularity rollup, `groupTally` (`sessions.ts:904`), collapses every session to seven lifecycle counts and discards the PR/ticket/plan/artifact signals each session already carries. This adds the layer that answers *"what is happening on project X right now"*: named definitions above the existing `--project` convention, and a status card that rolls up signals already on disk.

Design (grounded in a four-way code/GitHub/Linear/filesystem audit): https://claude.ai/code/artifact/cf3d710e-8c44-4c29-a805-eb2e886241f6

## What shipped (Cut B)

- **Definitions** — `~/.agents/projects/<name>.yaml`: home-relative `root`/`defaultPath`, multiple `repos[]` with monorepo subpaths, described `contexts[]` `{path,purpose}` starting points, external `integrations[]`, `linear`. (`lib/projects.ts`)
- **Definition-first resolution** — `resolveProjectRef` consults a definition before the `<root>/<slug>` convention; undefined slugs unchanged. (`lib/project-root.ts`)
- **The progress card** — `agents projects status` matches live sessions to a project **by cwd** (no persisted column; works cross-machine because transcript cwd already syncs) and rolls up agents-by-state, plan %, open PRs, tickets, worktrees, **merged PRs** (`gh`, best-effort), and **artifacts** (`artifact.created` milestones). (`lib/project-status.ts`)
- **Command surface** — `list / add / show / edit / status / import --from-factory / rm`, beta-gated (`agents beta enable projects`). `add` infers root + origin slug; `import` absorbs the Factory `projects.json` registry so there's one registry, not a third.

## Run it — real output (not a description)

```
$ agents projects status agents-cli --window 120
agents-cli  ·  2 agents
  live     2 running
  ships    20 merged (120d)
  proof    137 artifacts (120d)  · last: layer-c-pr-body.md
  repos    muqsitnawaz/agents-cli
```

`--json` emits the same, machine-readable (agents, byStatus, plan/planPct, openPrs, mergedPrs, tickets, worktrees, artifacts, lastArtifact). `add`→`show`→`list`→`status`, the beta gate, and `--no-remote` were all exercised end-to-end in an isolated HOME; the beta flag was toggled and restored.

## Tests

43 new unit tests (`projects.test.ts`, `project-root.test.ts`, `project-status.test.ts`) — schema validation (fail-loud on bad name / non-mapping), home-relative roundtrip, definition-first + worktree resolution, cwd membership (longest-wins, segment-aware so `rush-extra` ≠ `rush`), the sessions rollup (status counts, plan sum, PR/ticket dedup), and enrichment against a **seeded activity log** (window boundary + cwd match, no mock). `tsc --noEmit` clean.

The 18 suite failures on this branch are **pre-existing and unrelated** (`exec`, `serve/server`, `sync/config`, `import`, `models`, `non-interactive` — environmental `ENOENT version-resources.json` / empty-network `expected 0 > 0`); none reference the changed files.

## Deferred (fast-follow, named in the docs)

Re-pointing `agents factory snapshot`'s per-project Linear rollup at defined projects; richer Linear ticket-state counts on the card; a persisted `project_id` session column (today membership is derived from cwd); and the screenshot-sidecar + "shipped feature + clicks" engagement signal (phase 3). The audit flagged sidecar cross-machine sync as the one genuinely risky choice, so it's out of Cut B by design.

Docs: `apps/cli/docs/11-projects.md`, AGENTS.md map entry, CHANGELOG fragment.
