### PR TITLE
chore(factory): cut 0.9.306 changelog section

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.306] - 2026-08-03
+
 - **`Agents: Fork Current Session` is now `Agents: Fork`, and a second command forks
   a session you pick from a browser.** The rename is title-only — same command id,
   same behavior (fork the tab you are in). The new `Agents: Fork (Pick Session)`


### PR DESCRIPTION
**Release PR — changelog only, no behavior change.**

Moves the `Agents: Fork` / `Agents: Fork (Pick Session)` entry (merged in #1749) out of `## [Unreleased]` and under `## [0.9.306] - 2026-08-03`.

`scripts/release.sh` refuses to publish without that section:

```
$ bash scripts/release.sh 0.9.306
Error: no CHANGELOG.md entry for 0.9.306.
       Add a '## [0.9.306] - <date>' section before releasing.
```

Publishing `swarmify.swarm-ext` 0.9.306 to the Marketplace + Open VSX follows once this lands.