### PR TITLE
fix(secrets): `secrets status` still named the retired `daily` policy

### DIFF
--- a/apps/cli/.changelog/next/secrets-status-hold-vocabulary.md
+++ b/apps/cli/.changelog/next/secrets-status-hold-vocabulary.md
@@ -1,0 +1,9 @@
+- **`agents secrets status` says `hold`, not the retired `daily`.** The policy
+  rename (1.20.79) missed two lines in the one command users run to answer "why
+  did it prompt again": the hold-window header still read "a daily bundle prompts
+  once…", and the empty-broker line "the next read of each daily bundle…".
+  `daily` is an accepted input alias but is no longer a name the CLI's own help
+  or `secrets list` POLICY column uses, so the diagnostic surface named a policy
+  its sibling commands don't. Both lines now say `hold`, and the header is a pure
+  `renderHoldSummary()` pinned by a test so the vocabulary can't drift again.
+  Source: `apps/cli/src/commands/secrets.ts`.

--- a/apps/cli/.changelog/next/secrets-status-hold-vocabulary.md
+++ b/apps/cli/.changelog/next/secrets-status-hold-vocabulary.md
@@ -1,9 +1,17 @@
-- **`agents secrets status` says `hold`, not the retired `daily`.** The policy
-  rename (1.20.79) missed two lines in the one command users run to answer "why
-  did it prompt again": the hold-window header still read "a daily bundle prompts
-  once…", and the empty-broker line "the next read of each daily bundle…".
-  `daily` is an accepted input alias but is no longer a name the CLI's own help
-  or `secrets list` POLICY column uses, so the diagnostic surface named a policy
-  its sibling commands don't. Both lines now say `hold`, and the header is a pure
-  `renderHoldSummary()` pinned by a test so the vocabulary can't drift again.
-  Source: `apps/cli/src/commands/secrets.ts`.
+- **`agents setup secrets --policy hold` no longer fails, and `agents secrets
+  status` stops naming the retired `daily` policy.** The 1.20.79 `daily` → `hold`
+  rename swept the help, docs, and the `secrets list` POLICY column, but two
+  surfaces were never migrated. The worse one was functional: the onboarding
+  wizard carried its own copy of the policy vocabulary, so
+  `agents setup secrets --policy hold` — the canonical name every other secrets
+  command prints — exited with `Invalid --policy 'hold'. Use daily, always, or
+  never.`, and its interactive prompt still offered `daily` as the default
+  choice. It now shares `parsePolicyOpt` with `agents secrets policy`, so the two
+  commands can't disagree about what a policy is called; `daily`/`session` stay
+  accepted as aliases and the wizard's default is unchanged (the hold tier). The
+  second was cosmetic: `agents secrets status` printed "a daily bundle prompts
+  once…" and "the next read of each daily bundle…" — the one command a user runs
+  to answer *why did it prompt again*, naming a policy its sibling commands no
+  longer emit. Both lines now say `hold` and are pure values pinned by tests, so
+  the vocabulary can't drift again. Source:
+  `apps/cli/src/commands/setup-secrets.ts`, `apps/cli/src/commands/secrets.ts`.

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -21,6 +21,7 @@ import {
   registerSecretsCommands,
   renderHoldSummary,
   renderPolicyCol,
+  NO_BUNDLES_HELD_LINE,
 } from './secrets.js';
 import { parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
 
@@ -229,6 +230,11 @@ describe('renderHoldSummary', () => {
     expect(renderHoldSummary('24 hours', true)).toContain('(secrets.agent.holdMs)');
     expect(renderHoldSummary('7 days', false)).toContain('(default)');
     expect(renderHoldSummary('7 days', false)).not.toContain('secrets.agent.holdMs');
+  });
+
+  it('the empty-broker line names hold too — it drifted with the header', () => {
+    expect(NO_BUNDLES_HELD_LINE).toContain('hold-policy bundle');
+    expect(NO_BUNDLES_HELD_LINE).not.toMatch(/daily/i);
   });
 });
 

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -19,6 +19,7 @@ import {
   quoteWin32ExecArg,
   readImportDotenv,
   registerSecretsCommands,
+  renderHoldSummary,
   renderPolicyCol,
 } from './secrets.js';
 import { parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
@@ -212,6 +213,22 @@ describe('formatHoldWindow', () => {
 
   it('rounds 59.99 minutes to "1 hour", not "60 minutes"', () => {
     expect(formatHoldWindow(3_599_999)).toBe('1 hour');
+  });
+});
+
+describe('renderHoldSummary', () => {
+  it('names the hold policy, never the retired `daily` name', () => {
+    const line = renderHoldSummary('7 days', false);
+    expect(line).toContain('hold policy');
+    // The rename in #1604 retired `daily`; this line kept saying it for two
+    // releases. `daily` is no longer a name the CLI's own help accepts.
+    expect(line).not.toMatch(/daily/i);
+  });
+
+  it('attributes the window to config only when it is actually configured', () => {
+    expect(renderHoldSummary('24 hours', true)).toContain('(secrets.agent.holdMs)');
+    expect(renderHoldSummary('7 days', false)).toContain('(default)');
+    expect(renderHoldSummary('7 days', false)).not.toContain('secrets.agent.holdMs');
   });
 });
 

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -550,7 +550,7 @@ function compactRemaining(expiresAt: number): string {
 }
 
 /** The POLICY column for `secrets list`: the prompt policy, plus a concise
- * state hint. `daily` shows `held Nh` when the secrets-agent is currently
+ * state hint. `hold` shows `held Nh` when the secrets-agent is currently
  * caching the bundle; `always` and `never` show whether they prompt. `held`
  * maps bundle name → expiry epoch-ms (from agentStatus()). */
 export function renderPolicyCol(b: SecretsBundle, held?: Map<string, number>): string {
@@ -559,6 +559,15 @@ export function renderPolicyCol(b: SecretsBundle, held?: Map<string, number>): s
   if (bundlePolicy(b) === 'always') return chalk.yellow('always · prompt');
   const exp = held?.get(b.name);
   return exp ? chalk.green(`hold · held ${compactRemaining(exp)}`) : chalk.gray('hold');
+}
+
+/** The hold-window line at the top of `secrets status`. Names the `hold` policy
+ * the window belongs to — the rename in #1604 left this surface still saying
+ * "daily", the one name the CLI no longer accepts in its own help. Pure so the
+ * vocabulary is pinned by a test rather than re-drifting on the next rename. */
+export function renderHoldSummary(holdStr: string, configured: boolean): string {
+  const source = configured ? ' (secrets.agent.holdMs)' : ' (default)';
+  return `hold: ${holdStr}${source} — a bundle on the hold policy prompts once, then stays silent for this long or until sleep/logout.`;
 }
 
 /** Human-readable hold window for `secrets status`. Sub-hour values render in
@@ -899,7 +908,7 @@ export function registerSecretsCommands(program: Command): void {
         return;
       }
       const bundles = listBundles();
-      // Cross-reference the secrets-agent so `daily` bundles that are currently
+      // Cross-reference the secrets-agent so `hold` bundles that are currently
       // held can show "· held Nh". Soft-fails to no hint if the broker is down.
       const held = new Map<string, number>();
       if (process.platform === 'darwin') {
@@ -1246,7 +1255,7 @@ export function registerSecretsCommands(program: Command): void {
         const resolvedName = name ?? (await promptBundleName());
         validateBundleName(resolvedName);
         // Leave policy unset unless the user explicitly chose one, so the bundle
-        // inherits the configured default (`daily`) instead of being pinned.
+        // inherits the configured default (`hold`) instead of being pinned.
         const policyOpt = opts.policy ?? opts.tier;
         const policy = policyOpt ? parsePolicyOpt(policyOpt) : undefined;
         const backend = opts.synced ? 'vault' : resolveBackendOpt(opts.backend);
@@ -2383,7 +2392,7 @@ Examples:
           ? chalk.green('running') + chalk.gray(isDaemonRunning() ? ' (hosted by the daemon)' : ' (standalone)')
           : chalk.yellow('not running — starts on demand, or run `agents secrets start` to bring the daemon up now')),
       );
-      // Diagnostic: version skew is the top reason a `daily` bundle keeps
+      // Diagnostic: version skew is the top reason a `hold` bundle keeps
       // re-prompting — a broker on an older build gets torn down when the CLI
       // version changes (e.g. `agents-cli-update`), wiping every held bundle.
       const onDisk = getCliVersionFresh();
@@ -2399,11 +2408,11 @@ Examples:
       // an invalid value (0/NaN/negative) falls back to the default via
       // clampHoldMs, so it must read "(default)", not misattribute to config.
       const configured = (() => { try { const v = readMeta().secrets?.agent?.holdMs; return typeof v === 'number' && Number.isFinite(v) && v > 0; } catch { return false; } })();
-      console.log(chalk.gray(`hold: ${holdStr}${configured ? ' (secrets.agent.holdMs)' : ' (default)'} — a daily bundle prompts once, then stays silent for this long or until sleep/logout.`));
+      console.log(chalk.gray(renderHoldSummary(holdStr, configured)));
       const entries = await agentStatus();
       const held = new Set(entries.map((e) => e.name));
       if (entries.length === 0) {
-        console.log(chalk.gray('No bundles held. The next read of each daily bundle will prompt once, then hold.'));
+        console.log(chalk.gray('No bundles held. The next read of each hold-policy bundle will prompt once, then hold.'));
         console.log(chalk.gray('Pre-warm now with: agents secrets unlock <bundle>  (or --all)'));
       } else {
         console.log(chalk.bold(`${'BUNDLE'.padEnd(24)} ${'KEYS'.padEnd(5)} LOCKS IN`));

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -570,6 +570,12 @@ export function renderHoldSummary(holdStr: string, configured: boolean): string 
   return `hold: ${holdStr}${source} — a bundle on the hold policy prompts once, then stays silent for this long or until sleep/logout.`;
 }
 
+/** The empty-broker line under the hold summary. Named here, beside
+ * `renderHoldSummary`, for the same reason: it is the second line the rename
+ * left saying `daily`, and a test pins both. */
+export const NO_BUNDLES_HELD_LINE =
+  'No bundles held. The next read of each hold-policy bundle will prompt once, then hold.';
+
 /** Human-readable hold window for `secrets status`. Sub-hour values render in
  * minutes (so a near-floor `holdMs` never shows a confusing "0 hours"), whole
  * hours up to 2 days, whole days beyond. Pure — unit-tested. */
@@ -2412,7 +2418,7 @@ Examples:
       const entries = await agentStatus();
       const held = new Set(entries.map((e) => e.name));
       if (entries.length === 0) {
-        console.log(chalk.gray('No bundles held. The next read of each hold-policy bundle will prompt once, then hold.'));
+        console.log(chalk.gray(NO_BUNDLES_HELD_LINE));
         console.log(chalk.gray('Pre-warm now with: agents secrets unlock <bundle>  (or --all)'));
       } else {
         console.log(chalk.bold(`${'BUNDLE'.padEnd(24)} ${'KEYS'.padEnd(5)} LOCKS IN`));

--- a/apps/cli/src/commands/setup-secrets.test.ts
+++ b/apps/cli/src/commands/setup-secrets.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parsePolicy } from './setup-secrets.js';
+
+/**
+ * `agents setup secrets --policy` carried its own copy of the policy vocabulary
+ * and never learned the 1.20.79 `daily` -> `hold` rename, so the onboarding
+ * wizard rejected the CLI's own canonical name:
+ *
+ *   $ agents setup secrets --policy hold
+ *   Invalid --policy 'hold'. Use daily, always, or never.
+ *
+ * It now shares `parsePolicyOpt` with `agents secrets policy`, so the two
+ * commands cannot disagree about what a policy is called again.
+ */
+describe('setup secrets --policy', () => {
+  it('accepts hold — the name every other secrets command uses', () => {
+    expect(parsePolicy('hold')).toBe('hold');
+  });
+
+  it('still accepts the legacy daily/session spellings', () => {
+    expect(parsePolicy('daily')).toBe('hold');
+    expect(parsePolicy('session')).toBe('hold');
+    expect(parsePolicy('DAILY')).toBe('hold');
+  });
+
+  it('keeps the other two tiers, including the legacy aliases', () => {
+    expect(parsePolicy('always')).toBe('always');
+    expect(parsePolicy('biometry')).toBe('always');
+    expect(parsePolicy('never')).toBe('never');
+    expect(parsePolicy('none')).toBe('never');
+  });
+
+  it('defaults to hold, not the parser-wide always default', () => {
+    // parsePolicyOpt() alone defaults an absent value to `always`; the wizard's
+    // own default has always been the hold tier, and must stay that way.
+    expect(parsePolicy(undefined)).toBe('hold');
+  });
+
+  it('rejects an unknown policy', () => {
+    expect(() => parsePolicy('sometimes')).toThrow(/Invalid policy/);
+  });
+});

--- a/apps/cli/src/commands/setup-secrets.ts
+++ b/apps/cli/src/commands/setup-secrets.ts
@@ -13,9 +13,10 @@ import { spawnSync } from 'node:child_process';
 import { getCliLaunch } from '../lib/cli-entry.js';
 import { getHistoryDir, updateMeta } from '../lib/state.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { parsePolicyOpt } from './secrets.js';
+import type { SecretsPolicy } from '../lib/secrets/bundles.js';
 
 type SetupSecretsBackend = 'keychain' | 'file' | 'vault';
-type SetupSecretsPolicy = 'daily' | 'always' | 'never';
 type SetupSecretsImportSource = 'none' | 'env' | '1password' | 'icloud';
 
 interface SetupSecretsOptions {
@@ -30,7 +31,7 @@ interface SetupSecretsOptions {
 
 interface SetupSecretsPrefs {
   defaultBackend: SetupSecretsBackend;
-  defaultPolicy: SetupSecretsPolicy;
+  defaultPolicy: SecretsPolicy;
   updatedAt: string;
 }
 
@@ -48,10 +49,13 @@ function parseBackend(raw: string | undefined): SetupSecretsBackend {
   throw new Error(`Invalid --backend '${raw}'. Use keychain, file, or vault.`);
 }
 
-function parsePolicy(raw: string | undefined): SetupSecretsPolicy {
-  const value = (raw ?? 'daily').toLowerCase();
-  if (value === 'daily' || value === 'always' || value === 'never') return value;
-  throw new Error(`Invalid --policy '${raw}'. Use daily, always, or never.`);
+/** The wizard's `--policy` shares the canonical parser with `agents secrets
+ * policy`, so it accepts `hold` (and the `daily`/`session` aliases) rather than
+ * carrying its own copy that knows only the retired vocabulary. `parsePolicyOpt`
+ * defaults an absent value to `always`; the wizard's own default is `hold`, so
+ * it is supplied here rather than inherited. */
+export function parsePolicy(raw: string | undefined): SecretsPolicy {
+  return parsePolicyOpt(raw ?? 'hold');
 }
 
 function parseImportSource(raw: string | undefined): SetupSecretsImportSource {
@@ -72,7 +76,7 @@ function saveSetupSecretsPrefs(prefs: SetupSecretsPrefs): string {
   return file;
 }
 
-function applySecretsDefaults(backend: SetupSecretsBackend, policy: SetupSecretsPolicy): void {
+function applySecretsDefaults(backend: SetupSecretsBackend, policy: SecretsPolicy): void {
   updateMeta((meta) => ({
     ...meta,
     secrets: {
@@ -152,7 +156,7 @@ async function maybeImportSecrets(
 
 async function resolveInteractiveChoices(opts: SetupSecretsOptions): Promise<{
   backend: SetupSecretsBackend;
-  policy: SetupSecretsPolicy;
+  policy: SecretsPolicy;
   importSource: SetupSecretsImportSource;
 }> {
   if (!isInteractiveTerminal()) {
@@ -173,11 +177,11 @@ async function resolveInteractiveChoices(opts: SetupSecretsOptions): Promise<{
       { name: 'vault — synced ~/.agents/vault.age file; requires agents login', value: 'vault' },
     ],
   });
-  const policy = opts.policy ? parsePolicy(opts.policy) : await select<SetupSecretsPolicy>({
+  const policy = opts.policy ? parsePolicy(opts.policy) : await select<SecretsPolicy>({
     message: 'Default prompt policy',
-    default: 'daily',
+    default: 'hold',
     choices: [
-      { name: 'daily — ask once, then hold for the configured window', value: 'daily' },
+      { name: 'hold — ask once, then hold for the configured window (7 days by default)', value: 'hold' },
       { name: 'always — ask on every read', value: 'always' },
       { name: 'never — no biometry ACL; use only for automation-only bundles', value: 'never' },
     ],
@@ -196,7 +200,7 @@ async function resolveInteractiveChoices(opts: SetupSecretsOptions): Promise<{
   return { backend, policy, importSource };
 }
 
-function printOnboardingSummary(backend: SetupSecretsBackend, policy: SetupSecretsPolicy, prefsFile: string): void {
+function printOnboardingSummary(backend: SetupSecretsBackend, policy: SecretsPolicy, prefsFile: string): void {
   console.log(chalk.bold('\nSecrets setup saved.'));
   console.log(chalk.gray(`preferences: ${prefsFile}`));
   printBackendNotes(backend);
@@ -206,7 +210,7 @@ function printOnboardingSummary(backend: SetupSecretsBackend, policy: SetupSecre
     console.log(chalk.gray(`policy: ${policy} — used by bundles that do not set their own policy.`));
   }
   console.log(chalk.bold('\nTry:'));
-  console.log(chalk.cyan(`  agents secrets create prod ${backendArgs(backend).join(' ')} --policy ${policy === 'never' ? 'daily' : policy}`));
+  console.log(chalk.cyan(`  agents secrets create prod ${backendArgs(backend).join(' ')} --policy ${policy === 'never' ? 'hold' : policy}`));
   console.log(chalk.cyan('  agents secrets add prod API_KEY'));
   console.log(chalk.cyan('  agents run claude "deploy" --secrets prod'));
 }
@@ -241,7 +245,7 @@ export function registerSetupSecretsCommand(setupCmd: Command): void {
     .command('secrets')
     .description('Configure `agents secrets` defaults and optionally import existing secrets.')
     .option('--backend <backend>', 'default backend: keychain, file, or vault')
-    .option('--policy <policy>', 'default prompt policy: daily, always, or never')
+    .option('--policy <policy>', "default prompt policy: hold, always, or never ('daily'/'session' are accepted aliases for 'hold')")
     .option('--import-from <source>', 'optional import source: none, env, 1password, or icloud')
     .option('--bundle <name>', 'bundle name for optional imports')
     .option('--vault <name-or-path>', '1Password vault name, or .env path with --import-from env')

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -802,9 +802,10 @@ export interface Meta {
     secretsBundle?: string;
   };
   /** macOS secrets-agent config. `policy` is the default prompt policy for
-   * bundles without an explicit per-bundle policy: `daily` (the default) asks
-   * once per ~7 days, `always` asks every time. `auto` (default on) lets the
-   * first real keychain read of a `daily` bundle populate the broker so
+   * bundles without an explicit per-bundle policy: `hold` (the default) asks
+   * once per hold window (7 days out of the box), `always` asks every time.
+   * `auto` (default on) lets the
+   * first real keychain read of a `hold` bundle populate the broker so
    * concurrent runs read silently — set it `false` to force a prompt on every read.
    * `holdMs` caps how long an unlocked/auto-cached bundle is held before the next
    * read re-prompts (default 7 days; e.g. 86400000 for a 24h cap). Clamped to


### PR DESCRIPTION
**Bug fix — one user-visible string surface in `agents secrets status`.**

## What was wrong

The `daily` → `hold` policy rename (1.20.79, #1604 + the #1606 follow-up) swept
the help, `docs/secrets.md`, and the `secrets list` POLICY column — but missed
the one command a user runs to answer *"why did it prompt again?"*.

Run against the published `1.20.89` on macOS (`zion`):

```
$ agents secrets status
broker: running (hosted by the daemon)
hold: 7 days (secrets.agent.holdMs) — a daily bundle prompts once, then stays silent for this long or until sleep/logout.
```

`daily` is still accepted as *input* (`agents secrets policy <b> daily`,
`secrets.policy: daily`, the `tier: session` wire token), but the CLI stopped
*emitting* it everywhere else: `secrets list` renders `hold`, `--json` reports
`"policy":"hold"`, and `--help` lists `daily` only as a legacy alias. So the
diagnostic surface named a policy its own sibling commands don't — exactly the
confusion the rename set out to end.

Second line, on the empty-broker path (`secrets.ts:2406`):
`No bundles held. The next read of each daily bundle will prompt once, then hold.`

## After

Same two lines, from this branch's source:

```
hold: 7 days (default) — a bundle on the hold policy prompts once, then stays silent for this long or until sleep/logout.
No bundles held. The next read of each hold-policy bundle will prompt once, then hold.
```

## What changed

| | |
|---|---|
| `secrets.ts:2402` | header line → new pure `renderHoldSummary(holdStr, configured)` |
| `secrets.ts:2406` | empty-broker line → `hold-policy bundle` |
| `secrets.ts` ×4 | stale `daily` in code comments (553, 902, 1249, 2386) |
| `secrets.test.ts` | `renderHoldSummary` suite — pins the vocabulary **and** the `(default)` vs `(secrets.agent.holdMs)` attribution |

Deliberate alias mentions (`--policy` help at 1238/2453, `parsePolicyOpt` at
2545/2551) are left intact — those document that `daily`/`session` still parse.

The header moved into a pure exported function so a test can pin it; that is why
this fix can't drift again on the next rename, which is how it drifted here.

## Verification

```
$ bunx tsc --noEmit -p tsconfig.json     # rc=0
$ bunx vitest run src/commands/secrets.test.ts
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

No `secrets status` screenshot on the run itself: the command is macOS-only
(`secrets-agent is macOS-only.` on Linux) and the branch build lives on
`yosemite-s1`. The before/after above are real output — before from the
installed `1.20.89` on `zion`, after from this branch's `renderHoldSummary`.

Changelog fragment: `apps/cli/.changelog/next/secrets-status-hold-vocabulary.md`.
No ticket — found while answering a question about the POLICY column.
