### PR TITLE
fix(routines): Last Status is per-device, not whatever this box last ran

### DIFF
--- a/apps/cli/.changelog/next/routines-status-per-device.md
+++ b/apps/cli/.changelog/next/routines-status-per-device.md
@@ -1,0 +1,16 @@
+- **`agents routines list` no longer reports another device's routine as failed.** Run
+  records are written into the runs dir of whichever machine fired the routine and carry
+  no device attribution, but the listing resolved Last Status from any local record and
+  rendered it even on rows for routines pinned elsewhere. A routine re-pinned to another
+  device therefore kept reporting the old machine's leftover records forever — on zion,
+  `security-sweep`, `review-open-prs` and `hetzner-lease-gc` all read `failed` from late
+  July while `yosemite-s0`/`s1`, the devices that actually fire them, had completed them
+  that morning. The macOS menu bar reads this JSON, so it painted a column of red `exit 1`
+  rows for routines that were green. Last Status is now scoped to the device that owns the
+  run: a routine this device does not fire shows `-`, and `--json` returns `null` for
+  `lastStatus`, `exitCode`, `failureReason`, `lastRunStartedAt` and `lastRunCompletedAt`
+  (`runsHere: false` already says why). A routine pinned to several devices renders one row
+  per device but carries a status only on its **This machine** row. Read a peer's status
+  with `agents routines list --device <name>`; the local history is untouched and still
+  readable via `agents routines runs <name>`. Source: `apps/cli/src/commands/routines.ts`
+  (`localLatestRun`, `groupRoutineJobsByDevice`), `apps/cli/docs/03-routines.md`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **`agents routines list` no longer reports another device's routine as failed.**
-  Run records are written into the runs dir of whichever machine fired the
-  routine and carry no device attribution, but the listing reported any local
-  record as the routine's status — so a routine re-pinned to another device kept
-  showing the old machine's leftover July failures, in the table and in the menu
-  bar (which reads `list --json`). Last Status is now per-device: a routine this
-  device does not fire shows `-`, and `--json` returns `null` for `lastStatus`,
-  `exitCode`, `failureReason`, `lastRunStartedAt`, and `lastRunCompletedAt`
-  (`runsHere: false` already says why). A routine pinned to several devices
-  carries a status only on its **This machine** row. Read a peer's status with
-  `agents routines list --device <name>`.
-
 ## 1.20.89
 
 - **Webhook handler layer for one-off agent/workflow/command/routine triggers.**

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- **`agents routines list` no longer reports another device's routine as failed.**
+  Run records are written into the runs dir of whichever machine fired the
+  routine and carry no device attribution, but the listing reported any local
+  record as the routine's status — so a routine re-pinned to another device kept
+  showing the old machine's leftover July failures, in the table and in the menu
+  bar (which reads `list --json`). Last Status is now per-device: a routine this
+  device does not fire shows `-`, and `--json` returns `null` for `lastStatus`,
+  `exitCode`, `failureReason`, `lastRunStartedAt`, and `lastRunCompletedAt`
+  (`runsHere: false` already says why). A routine pinned to several devices
+  carries a status only on its **This machine** row. Read a peer's status with
+  `agents routines list --device <name>`.
+
 ## 1.20.89
 
 - **Webhook handler layer for one-off agent/workflow/command/routine triggers.**

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -463,6 +463,28 @@ On a device not in the allowlist the job is fully inert:
 jobs display the word `all`; restricted lists are grayed when the local machine
 is not in the list. `--json` includes a `devices` array and `runsHere` boolean.
 
+#### Last Status is per-device
+
+Run records live in the runs dir of whichever machine fired the routine and carry
+no device attribution, so a record only ever describes the device you are reading
+it on. `agents routines list` therefore reports **Last Status only for routines
+this device fires**: a routine pinned elsewhere shows `-` in the table, and
+`--json` returns `null` for `lastStatus`, `exitCode`, `failureReason`,
+`lastRunStartedAt`, and `lastRunCompletedAt` (`runsHere: false` says why). The
+same routine renders one row per pinned device, and only the **This machine** row
+carries a status.
+
+Without this, a routine re-pinned from one device to another kept reporting the
+old device's leftover records — showing a peer's healthy routine as failed, both
+in the table and in the menu bar, which reads this JSON.
+
+Read a peer's status where it actually ran:
+
+```bash
+agents routines list --device yosemite-s0     # that device's own view
+agents routines runs <name> --device yosemite-s0
+```
+
 #### v12 migration
 
 Existing routines that use the legacy singular `device: X` field are automatically

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -591,6 +591,55 @@ describe('routines list --json has devices+runsHere, no device', () => {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
+
+  // A routine re-pinned to other devices leaves its old run records behind on
+  // the machine that used to fire it. Reporting those as the routine's status
+  // painted a peer's healthy routine red in `list` and in the menu bar (which
+  // reads this JSON) — the record describes this device, not the owner.
+  it('reports no status for a routine pinned away from this device', () => {
+    const home = makeHome({
+      jobs: [
+        { ...baseJob, name: 'pinned-elsewhere', devices: ['yosemite-s0'] },
+        { ...baseJob, name: 'pinned-here', devices: ['zion'] },
+      ],
+      registry,
+    });
+    try {
+      for (const name of ['pinned-elsewhere', 'pinned-here']) {
+        writeRunMeta(home, name, '2026-07-25T10-00-00-000Z', {
+          jobName: name,
+          runId: '2026-07-25T10-00-00-000Z',
+          agent: 'claude',
+          pid: null,
+          status: 'failed',
+          startedAt: '2026-07-25T10:00:00.000Z',
+          completedAt: '2026-07-25T10:00:05.000Z',
+          exitCode: 1,
+          errorMessage: 'command exited with code 1',
+        });
+      }
+
+      const res = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      expect(res.status).toBe(0);
+      const parsed = JSON.parse(res.stdout.trim());
+
+      const elsewhere = parsed.find((j: Record<string, unknown>) => j.name === 'pinned-elsewhere');
+      expect(elsewhere.runsHere).toBe(false);
+      expect(elsewhere.lastStatus).toBeNull();
+      expect(elsewhere.exitCode).toBeNull();
+      expect(elsewhere.failureReason).toBeNull();
+      expect(elsewhere.lastRunStartedAt).toBeNull();
+      expect(elsewhere.lastRunCompletedAt).toBeNull();
+
+      // The same record on a routine this device does fire is still reported.
+      const here = parsed.find((j: Record<string, unknown>) => j.name === 'pinned-here');
+      expect(here.runsHere).toBe(true);
+      expect(here.lastStatus).toBe('failed');
+      expect(here.exitCode).toBe(1);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('routines runs --json', () => {
@@ -734,6 +783,46 @@ describe('routines list grouped by device', () => {
       expect(stripped).toContain('Device: offline-box (offline)');
       expect(stripped).toContain('Host: mac-mini (offline)');
       for (const job of jobs) expect(stripped).toContain(job.name);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  // One routine pinned to two devices renders a row under each. Only the row
+  // under THIS machine may carry Last Status — the peer's row previously
+  // repeated our local record, which is how a green routine showed up red.
+  it('shows Last Status only under this machine, not under a peer device', () => {
+    const home = makeHome({
+      jobs: [{ ...baseJob, name: 'two-device-job', devices: ['zion', 'yosemite-s0'] }],
+      registry,
+    });
+    try {
+      writeRunMeta(home, 'two-device-job', '2026-07-25T10-00-00-000Z', {
+        jobName: 'two-device-job',
+        runId: '2026-07-25T10-00-00-000Z',
+        agent: 'claude',
+        pid: null,
+        status: 'failed',
+        startedAt: '2026-07-25T10:00:00.000Z',
+        completedAt: '2026-07-25T10:00:05.000Z',
+        exitCode: 1,
+      });
+
+      const res = run(home, ['list'], { AGENTS_SYNC_MACHINE_ID: 'zion' });
+      expect(res.status).toBe(0);
+      const stripped = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
+
+      const lines = stripped.split('\n');
+      const mineIdx = lines.findIndex((l) => l.includes('This machine (zion)'));
+      const peerIdx = lines.findIndex((l) => l.includes('Device: yosemite-s0'));
+      expect(mineIdx).toBeGreaterThanOrEqual(0);
+      expect(peerIdx).toBeGreaterThanOrEqual(0);
+
+      const rowAfter = (start: number): string =>
+        lines.slice(start).find((l) => l.includes('two-device-job')) ?? '';
+      expect(rowAfter(mineIdx)).toContain('failed');
+      expect(rowAfter(peerIdx)).not.toContain('failed');
+      expect(stripped).toContain('Last Status is per-device');
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -179,10 +179,32 @@ function deviceLabel(job: JobConfig, width?: number): { raw: string; display: st
   return { raw, display, dim: full.length === 0 || !jobRunsOnThisDevice(job) };
 }
 
+/**
+ * The last run THIS device can speak for.
+ *
+ * A run record is written by whichever daemon fired the routine, into that
+ * machine's own runs dir — records carry no device attribution, so a record
+ * found here only ever describes this device's history. When a routine is
+ * pinned away from this machine (`devices:` excludes it) any local record is a
+ * leftover from before the pin, and reporting it as the routine's status paints
+ * another device's healthy routine red. Report nothing instead; the local
+ * history stays readable via `agents routines runs <name>`, and the owning
+ * device's status via `agents routines list --device <name>`.
+ */
+export function localLatestRun(job: JobConfig): RunMeta | null {
+  return jobRunsOnThisDevice(job) ? getLatestRun(job.name) : null;
+}
+
 export interface RoutineListGroup {
   key: string;
   title: string;
   jobs: JobConfig[];
+  /**
+   * Whether this device's run records describe the group. False for a
+   * `Device: <peer>` group — the rows are the same routine seen from a machine
+   * that does not fire it there, so Last Status is not ours to report.
+   */
+  local: boolean;
 }
 
 export function groupRoutineJobsByDevice(
@@ -197,7 +219,9 @@ export function groupRoutineJobsByDevice(
       existing.jobs.push(job);
       return;
     }
-    groups.set(key, { key, title, jobs: [job] });
+    // `device:` is the only group that describes a machine other than this one,
+    // so it is the only one whose rows this device cannot report a status for.
+    groups.set(key, { key, title, jobs: [job], local: !key.startsWith('device:') });
   };
 
   for (const job of jobs) {
@@ -248,9 +272,15 @@ interface RenderRowsOptions {
   overdueSet: Set<string>;
   link: (label: string, url: string | null) => string;
   now: Date;
+  /**
+   * Whether this device's run records describe these rows. False for a
+   * `Device: <peer>` group, whose Last Status column stays blank rather than
+   * showing this machine's leftover records for the same routine name.
+   */
+  local?: boolean;
 }
 
-function renderRoutineRows({ jobs, scheduler, overdueSet, link, now }: RenderRowsOptions): void {
+function renderRoutineRows({ jobs, scheduler, overdueSet, link, now, local = true }: RenderRowsOptions): void {
   const NAME_W = 24;
   const AGENT_W = 10;
   const REPO_W = REPO_DISPLAY_MAX;
@@ -267,7 +297,7 @@ function renderRoutineRows({ jobs, scheduler, overdueSet, link, now }: RenderRow
   for (const job of jobs) {
     const nextStr = nextRunLabel(job, scheduler, now);
     const schedStr = scheduleLabel(job);
-    const latestRun = getLatestRun(job.name);
+    const latestRun = local ? localLatestRun(job) : null;
     const lastStatus = latestRun?.status || '-';
 
     const sourceRepo = job.source?.repo ?? job.repo;
@@ -590,7 +620,7 @@ export function registerRoutinesCommands(program: Command): void {
       if (options.json) {
         const nowJson = new Date();
         const payload = jobs.map((job) => {
-          const latestRun = getLatestRun(job.name);
+          const latestRun = localLatestRun(job);
           return {
             name: job.name,
             agent: job.agent ?? null,
@@ -645,9 +675,14 @@ export function registerRoutinesCommands(program: Command): void {
         } catch (err) {
           console.error(chalk.yellow(`Could not read device registry: ${(err as Error).message}`));
         }
-        for (const group of groupRoutineJobsByDevice(jobs, registry)) {
+        const groups = groupRoutineJobsByDevice(jobs, registry);
+        for (const group of groups) {
           console.log(chalk.bold(`\n${group.title}`));
-          renderRoutineRows({ jobs: group.jobs, scheduler, overdueSet, link, now });
+          renderRoutineRows({ jobs: group.jobs, scheduler, overdueSet, link, now, local: group.local });
+        }
+        if (groups.some((group) => !group.local)) {
+          console.log();
+          console.log(chalk.gray('  Last Status is per-device: rows under another device show "-" — read it there with: agents routines list --device <name>'));
         }
       }
 


### PR DESCRIPTION
**bug fix** — `agents routines list` reported another device's routine as failed. No new surface.

## What was wrong

`renderRoutineRows` and the `--json` payload both resolved Last Status from
`getLatestRun(job.name)` — the **local** runs dir — and rendered it even on rows for routines
pinned to another device (`apps/cli/src/commands/routines.ts:270`, `:611`). Run records carry
no device attribution, so a routine re-pinned from one box to another kept reporting the old
box's leftover records, forever.

Observed on the live fleet: zion reported `security-sweep`, `review-open-prs`,
`hetzner-lease-gc` and `slack-link-rotate` as **failed** from late-July records, while
`yosemite-s0`/`s1` — the devices that actually fire them — had **completed** them on Aug 2.
The macOS menu bar reads this JSON (`AgentsCLI.swift:70-73` → `routineFailureDetail`), so it
rendered a column of red ✕ `exit 1` rows for routines that were green.

## The fix

Status is scoped to the device that owns the run.

- `localLatestRun(job)` returns a record only when `jobRunsOnThisDevice(job)`.
- `--json` emits `null` for `lastStatus`, `exitCode`, `failureReason`, `lastRunStartedAt`,
  `lastRunCompletedAt` otherwise. `runsHere` already tells a consumer why.
- `RoutineListGroup` gains `local`, false for `device:` groups — a routine pinned to several
  devices renders one row per device but carries a status only on its **This machine** row.
- A footnote points at `agents routines list --device <name>` when any row is suppressed.

Local history is untouched and still readable via `agents routines runs <name>`.

## Run result — real fleet state on `yosemite-s0`

`--json`, before (installed 1.20.89) and after (this branch), same machine, same state:

```
### BEFORE
routine                  runsHere  lastStatus  exitCode  lastRun
crm-pipeline-brief       False     failed      1         2026-07-13T15:00:00
linkedin-scout           False     failed      1         2026-07-13T16:00:00
review-open-prs          True      completed   0         2026-08-02T16:00:00
security-sweep           True      completed   0         2026-08-02T15:30:00

### AFTER
routine                  runsHere  lastStatus  exitCode  lastRun
crm-pipeline-brief       False     None        None      None
linkedin-scout           False     None        None      None
review-open-prs          True      completed   0         2026-08-02T16:00:00
security-sweep           True      completed   0         2026-08-02T15:30:00
```

The two routines this box does not fire stop reporting a status; the two it does fire are
unchanged.

Grouped table, the `Device: mac-mini` section as rendered on `yosemite-s0`:

```
BEFORE                                          AFTER
crm-pipeline-brief   weekdays at 8:00 AM  failed    crm-pipeline-brief   weekdays at 8:00 AM  -
linkedin-scout       weekdays at 9:00 AM  failed    linkedin-scout       weekdays at 9:00 AM  -

  Last Status is per-device: rows under another device show "-" — read it
  there with: agents routines list --device <name>
```

## Tests

`apps/cli/src/commands/routines.test.ts` — **41/41 passing**. Two new tests reproduce the bug
against the real CLI subprocess with an isolated `HOME` (no mocks):

- `reports no status for a routine pinned away from this device` — writes an identical failed
  run record for a routine pinned to a peer and one pinned here; asserts the peer's is nulled
  and this device's is still reported.
- `shows Last Status only under this machine, not under a peer device` — one routine pinned to
  two devices; asserts the status appears under **This machine** and not under `Device: peer`.

## Docs

`apps/cli/docs/03-routines.md` gains a *Last Status is per-device* section; CHANGELOG entry
under Unreleased.

## Follow-ups (not in this PR)

This fixes the *false* red. It does not fix the *real* problem behind it — routines that
silently miss their fire on a sleeping Mac (`weekly-fleet-retro` was armed for
`2026-08-03T04:00:00Z` on zion, never ran, and the daemon warned `2 routine(s) overdue` at its
next start and did nothing). Auto-catchup, a `missed` run status, and the menu bar consuming
`runsHere` are queued as separate PRs.
