### PR TITLE
feat(routines): run a missed fire late instead of losing it silently

### DIFF
--- a/apps/cli/.changelog/next/routines-auto-catchup.md
+++ b/apps/cli/.changelog/next/routines-auto-catchup.md
@@ -1,0 +1,25 @@
+- **A routine that misses its fire now runs late instead of being silently lost.** Fires
+  are in-process croner timers, and croner only ever schedules forward from "now" — so a
+  daemon that was down, asleep, or wedged when a routine came due dropped that fire
+  outright, and `loadAll()` rebuilt every timer looking only at the future. Detection
+  existed but ran **once, at daemon startup**, and only logged a warning plus a
+  notification; catching up was a manual `agents routines catchup`. Observed cost: zion's
+  daemon was down from 02:03Z to 08:23Z while the laptop slept, `weekly-fleet-retro` was
+  armed for exactly 04:00Z, never ran, and the restart logged `2 routine(s) overdue` and
+  did nothing. The daemon now re-scans every 5 minutes as well as at startup and runs each
+  missed routine via the same detached path `catchup` already used. Source:
+  `apps/cli/src/lib/catchup.ts`, `apps/cli/src/lib/daemon.ts`.
+- **New `catchup:` routine field, and `agents routines add --no-catchup`.** Defaults to
+  true — a routine you scheduled is one you expect to have run. Set `catchup: false` for a
+  routine whose worth expires with its slot (a 9am brief is useless at 3pm); the miss is
+  still recorded, it just is not re-run. `agents routines list --json` reports the
+  effective value as `catchup`.
+- **New `missed` run status.** A missed fire previously left no trace anywhere — no run
+  record, no log line in the routine's history — so `agents routines list` kept showing the
+  previous run's `completed` as though it were current, sometimes for weeks. A miss is now
+  written as a real run stamped at the moment the fire was due, so `agents routines runs
+  <name>` shows the gap, and the listing renders it distinctly from `failed` (a miss is an
+  infrastructure problem, not a task failure). That record is also what makes catch-up
+  idempotent: it advances the overdue comparison, so the same missed fire is never re-fired
+  across ticks or a daemon restart storm. Source: `apps/cli/src/lib/routines.ts` (`RunMeta`),
+  `apps/cli/src/commands/routines.ts`.

--- a/apps/cli/.changelog/next/routines-auto-catchup.md
+++ b/apps/cli/.changelog/next/routines-auto-catchup.md
@@ -25,3 +25,14 @@
   non-recursive `mkdir` — an atomic claim, so if the daemon's timer and a manual
   `agents routines catchup` overlap, only one of them runs the routine. Source: `apps/cli/src/lib/routines.ts` (`RunMeta`),
   `apps/cli/src/commands/routines.ts`.
+- **A routine is never caught up for a fire that predates it.** `detectOverdueJobs` walks back
+  a week for the most recent expected occurrence, and a routine with no runs is overdue by
+  definition — so before this, `agents routines add` on any daily or weekly schedule whose slot
+  had already passed made the routine instantly "overdue". That was cosmetic while catch-up was
+  a manual command; with the daemon now catching up automatically it would have run every newly
+  created routine once, within five minutes of creating it. Routines gain a `createdAt` stamp
+  (written once, like `actor`), and overdue detection floors the expected fire at it — falling
+  back to the routine file's mtime for routines written before the field existed. Observed on
+  the live fleet: `agents-cli-updates`, created Aug 1 and never run, was flagged overdue for a
+  Jul 27 fire. Source: `apps/cli/src/lib/overdue.ts` (`routineEffectiveStart`),
+  `apps/cli/src/lib/routines.ts` (`writeJob`).

--- a/apps/cli/.changelog/next/routines-auto-catchup.md
+++ b/apps/cli/.changelog/next/routines-auto-catchup.md
@@ -20,6 +20,8 @@
   written as a real run stamped at the moment the fire was due, so `agents routines runs
   <name>` shows the gap, and the listing renders it distinctly from `failed` (a miss is an
   infrastructure problem, not a task failure). That record is also what makes catch-up
-  idempotent: it advances the overdue comparison, so the same missed fire is never re-fired
-  across ticks or a daemon restart storm. Source: `apps/cli/src/lib/routines.ts` (`RunMeta`),
+  idempotent: it advances the overdue comparison, so the same missed fire is never
+  reconsidered across ticks or a daemon restart storm, and its directory is created with a
+  non-recursive `mkdir` — an atomic claim, so if the daemon's timer and a manual
+  `agents routines catchup` overlap, only one of them runs the routine. Source: `apps/cli/src/lib/routines.ts` (`RunMeta`),
   `apps/cli/src/commands/routines.ts`.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -733,7 +733,7 @@ failed — binary not found, EACCES, etc.) → `status='failed'` with `exitCode=
 
 `missed` is the one status the runner never writes, because no process was ever
 spawned. It records that a scheduled fire **did not happen**: the scheduler was
-down, asleep, or wedged when the routine came due. `recordMissedFire`
+down, asleep, or wedged when the routine came due. `claimMissedFire`
 (`catchup.ts`) writes it with `pid: null`, `exitCode: null`, and `startedAt` set
 to the moment the fire was **due** — not the moment it was noticed — so the gap
 lands at the right point in `agents routines runs <name>`.
@@ -758,8 +758,17 @@ daemon stayed up but its event loop was wedged, or one lost across an OS suspend
 the process survived.
 
 Catch-up is idempotent without a ledger: the `missed` record advances the overdue
-comparison, so the same missed fire is never re-fired — across ticks, a daemon
+comparison, so the same missed fire is never reconsidered — across ticks, a daemon
 restart, or a restart storm.
+
+Two callers that overlap are handled by a claim rather than a lock. Writing the
+`missed` record creates its run directory with a non-recursive `mkdir` — an
+atomic test-and-set — and only the caller that wins it runs the routine. So if
+the daemon's 5-minute pass and a manual `agents routines catchup` overlap, the
+routine still starts exactly once; the loser reports `already claimed by the
+scheduler`. This is deliberately at-most-once: a process that dies between
+claiming and spawning leaves that fire un-run, which is the right trade when the
+alternative is spawning an agent twice.
 
 Device scoping still applies: a routine pinned elsewhere is skipped, so a fleet of
 machines never all catch up the same routine.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -729,6 +729,73 @@ one-shot — a run never re-enters `running` once it leaves.
 Plus one error branch: `child.on('error')` at `runner.ts:208` (spawn itself
 failed — binary not found, EACCES, etc.) → `status='failed'` with `exitCode=null`.
 
+### `missed` — the run that never started
+
+`missed` is the one status the runner never writes, because no process was ever
+spawned. It records that a scheduled fire **did not happen**: the scheduler was
+down, asleep, or wedged when the routine came due. `recordMissedFire`
+(`catchup.ts`) writes it with `pid: null`, `exitCode: null`, and `startedAt` set
+to the moment the fire was **due** — not the moment it was noticed — so the gap
+lands at the right point in `agents routines runs <name>`.
+
+Without it a miss left no trace at all, and the listing kept showing the previous
+run's `completed` as though it were current.
+
+## Catching up a missed fire
+
+Fires are in-process croner timers, and croner only schedules forward from "now".
+A daemon that was not running when a routine came due therefore loses that fire —
+`loadAll()` (`scheduler.ts`) rebuilds every timer looking only at the future, so
+nothing replays it. This is routine on a laptop: close the lid over a 9pm
+schedule and the routine simply never ran.
+
+The daemon recovers from this itself. `detectOverdueJobs` (`overdue.ts`) compares
+each enabled routine's most recent expected fire against its most recent recorded
+run; `runCatchup` (`catchup.ts`) then records each miss and re-runs it via the
+same detached path `agents routines catchup` uses. It runs **at daemon startup
+and every 5 minutes** — a startup-only pass would miss a fire lost while the
+daemon stayed up but its event loop was wedged, or one lost across an OS suspend
+the process survived.
+
+Catch-up is idempotent without a ledger: the `missed` record advances the overdue
+comparison, so the same missed fire is never re-fired — across ticks, a daemon
+restart, or a restart storm.
+
+Device scoping still applies: a routine pinned elsewhere is skipped, so a fleet of
+machines never all catch up the same routine.
+
+### Opting out — `catchup: false`
+
+Catch-up defaults to **on**: a routine you scheduled is one you expect to have
+run, so losing a fire silently is never the helpful default.
+
+Set `catchup: false` on a routine whose value is tied to its clock — a 9am
+standup brief is worthless at 3pm:
+
+```yaml
+name: crm-pipeline-brief
+schedule: "0 8 * * 1-5"
+catchup: false
+```
+
+or at creation:
+
+```bash
+agents routines add crm-pipeline-brief --schedule "0 8 * * 1-5" --agent claude \
+  --no-catchup --prompt "Morning pipeline brief"
+```
+
+An opted-out routine still **records** the miss — you see it as `missed` in the
+listing and in `agents routines runs` — it is just not re-run.
+`agents routines list --json` reports the effective value as `catchup`.
+
+Force a pass by hand at any time:
+
+```bash
+agents routines catchup            # record + run every missed fire now
+agents routines catchup --dry-run  # record the misses, run nothing
+```
+
 ## Sandbox Data Flow
 
 What `prepareJobHome` produces on disk, given a job config.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -773,6 +773,13 @@ alternative is spawning an agent twice.
 Device scoping still applies: a routine pinned elsewhere is skipped, so a fleet of
 machines never all catch up the same routine.
 
+A routine is also never caught up for a fire that **predates it**. `writeJob` stamps
+`createdAt` once, and overdue detection floors the most recent expected occurrence at
+it (`routineEffectiveStart`, `overdue.ts`), falling back to the routine file's mtime
+for routines written before the field existed. Without that floor, adding a routine on
+any daily or weekly schedule whose slot had already passed would make it instantly
+overdue — and catch-up would run it once, immediately, minutes after you created it.
+
 ### Opting out — `catchup: false`
 
 Catch-up defaults to **on**: a routine you scheduled is one you expect to have

--- a/apps/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -13,7 +13,7 @@ struct Routine: Decodable {
     let overdue: Bool
     let nextRun: String?
     let nextRunHuman: String?
-    let lastStatus: String?            // completed | failed | timeout | running | null
+    let lastStatus: String?            // completed | failed | timeout | running | missed | null
     let exitCode: Int?
     let failureReason: String?
     let lastRunStartedAt: String?

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -359,7 +359,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         // whenever the triage strip has anything to say, not only when a session
         // is blocked.
         let attention = sessions.filter { $0.status == .attention }.count
-        let routinesFailing = routines.contains { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
+        let routinesFailing = routines.contains { routineNeedsAttention($0) }
         let schedulerStopped = daemonPid == nil && !routines.isEmpty
         let needsYou = attention + (routinesFailing ? 1 : 0) + (schedulerStopped ? 1 : 0)
         let rich = isRich(attention: needsYou)
@@ -509,7 +509,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             rows.append(("⚠", wait, "Scheduler stopped — routines won’t run", sub))
         }
 
-        let bad = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
+        let bad = routines.filter { routineNeedsAttention($0) }
         if bad.count == 1, let r = bad.first {
             let why = r.overdue ? "overdue" : (r.lastStatus ?? "failed")
             rows.append(("✕", fail, "Routine \(r.name) \(why)", allRoutinesSubmenu(bad)))
@@ -943,7 +943,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
 
         addSectionTitle(menu, "ROUTINES · \(summary)", color: .secondaryLabelColor)
-        let failing = routines.filter { $0.lastStatus == "failed" || $0.lastStatus == "timeout" || $0.overdue }
+        let failing = routines.filter { routineNeedsAttention($0) }
         let upcoming = routines
             .filter { r in r.enabled && !failing.contains(where: { $0.name == r.name }) && r.nextRun != nil }
             .sorted { ($0.nextRun ?? "") < ($1.nextRun ?? "") }
@@ -955,7 +955,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
         for r in failing {
             let why = routineFailureSummary(r, max: 48)
-            let row = statusRow("✕", fail, "\(r.name)  \(why)")
+            let row = statusRow(routineIsMiss(r) ? "⃠" : "✕", routineIsMiss(r) ? wait : fail, "\(r.name)  \(why)")
             row.submenu = routineSubmenu(r)
             menu.addItem(row)
         }
@@ -1089,7 +1089,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private func allRoutinesSubmenu(_ routines: [Routine]) -> NSMenu {
         let sub = NSMenu()
         for r in routines {
-            let mark = r.lastStatus == "failed" || r.lastStatus == "timeout" || r.overdue ? "! "
+            let mark = routineNeedsAttention(r) ? "! "
                 : (r.enabled ? "  " : "· ")
             let when = routineFailureDetail(r, max: 52) ?? (r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused")
             let item = NSMenuItem(title: "\(mark)\(r.name)  \(when)", action: nil, keyEquivalent: "")
@@ -1307,13 +1307,27 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
 }
 
+/// A routine the operator should look at: it failed, timed out, never ran when
+/// it was due (`missed`), or is overdue. One predicate rather than the same
+/// disjunction repeated at each call site, so a new status cannot be added to
+/// four of five checks.
+func routineNeedsAttention(_ r: Routine) -> Bool {
+    r.lastStatus == "failed" || r.lastStatus == "timeout" || r.lastStatus == "missed" || r.overdue
+}
+
+/// `missed` means the run never started — infrastructure, not a task failure —
+/// so it reads as a warning rather than a red error.
+func routineIsMiss(_ r: Routine) -> Bool {
+    r.lastStatus == "missed" || (r.overdue && r.lastStatus != "failed" && r.lastStatus != "timeout")
+}
+
 func routineFailureSummary(_ r: Routine, max: Int) -> String {
     if let detail = routineFailureDetail(r, max: max) { return detail }
     return r.overdue ? "overdue" : (r.lastStatus ?? "failed")
 }
 
 func routineFailureDetail(_ r: Routine, max: Int) -> String? {
-    let lastRunFailed = r.lastStatus == "failed" || r.lastStatus == "timeout"
+    let lastRunFailed = r.lastStatus == "failed" || r.lastStatus == "timeout" || r.lastStatus == "missed"
     guard lastRunFailed || r.overdue else { return nil }
     if let reason = r.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines), !reason.isEmpty {
         return trimText(reason.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression), max)

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -562,7 +562,9 @@ describe('routines list --json has devices+runsHere, no device', () => {
 
   it('can report overdue independently of a completed zero-exit latest run', () => {
     const home = makeHome({
-      jobs: [{ ...baseJob, schedule: '* * * * *' }],
+      // createdAt predates the run below, so the routine is old enough for a
+      // missed occurrence to count (overdue is floored at routine creation).
+      jobs: [{ ...baseJob, schedule: '* * * * *', createdAt: '2026-07-01T00:00:00.000Z' }],
       registry,
     });
     try {

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -1250,6 +1250,8 @@ export function registerRoutinesCommands(program: Command): void {
         } else if (o.result === 'recorded') {
           const why = options.dryRun ? 'dry run' : 'catchup: false';
           console.log(`  ${o.name} → ${chalk.yellow('recorded as missed')} (${why})`);
+        } else if (o.result === 'claimed-elsewhere') {
+          console.log(`  ${o.name} → ${chalk.gray('already claimed by the scheduler')}`);
         } else {
           console.log(`  ${o.name} → ${chalk.red('failed to start')}: ${o.error}`);
         }

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -68,6 +68,7 @@ import { safeJoin } from '../lib/paths.js';
 import { executeJob, executeJobDetached, monitorRunningJobs, ROUTINE_AGENT_IDS } from '../lib/runner.js';
 import { JobScheduler } from '../lib/scheduler.js';
 import { detectOverdueJobs } from '../lib/overdue.js';
+import { runCatchup } from '../lib/catchup.js';
 import { isInteractiveTerminal, requireInteractiveSelection } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 import { loadDevices, loadDevicesSync } from '../lib/devices/registry.js';
@@ -290,6 +291,9 @@ function renderRoutineRows({ jobs, scheduler, overdueSet, link, now }: RenderRow
       lastStatus === 'completed' ? chalk.green
       : lastStatus === 'failed' ? chalk.red
       : lastStatus === 'timeout' ? chalk.yellow
+      // A miss is an infrastructure problem, not a task failure — the routine
+      // never ran. Distinct from red so the two prompt different reactions.
+      : lastStatus === 'missed' ? chalk.magenta
       : chalk.gray;
 
     const overdueTag = overdueSet.has(job.name) ? chalk.yellow(' (overdue)') : '';
@@ -608,6 +612,7 @@ export function registerRoutinesCommands(program: Command): void {
             sourceRepo: job.source?.repo ?? job.repo ?? null,
             sourceBranch: job.source?.branch ?? null,
             runOnce: Boolean(job.runOnce),
+            catchup: job.catchup !== false,
             oneShot: isOneShotRoutine(job),
             expired: isPastOneShotRoutine(job, nowJson),
             runsHere: jobRunsOnThisDevice(job),
@@ -686,6 +691,7 @@ export function registerRoutinesCommands(program: Command): void {
     .option('--state-to <name>', 'Linear current-state filter for --on linear:<event> (e.g. Plan)')
     .option('--state-from <name>', 'Linear previous-state filter for --on linear:<event> (e.g. Triage)')
     .option('--end-at <iso>', 'Stop firing on or after this ISO 8601 timestamp (e.g., "2026-12-31T23:59:00Z"); routine auto-disables.')
+    .option('--no-catchup', 'Do not run this routine late if its fire is missed (daemon down/asleep). The miss is still recorded. For routines whose value expires with their slot, e.g. a 9am brief.')
     .option('--disabled', 'Create the routine but keep it paused (enable later with resume)')
     .option('--resume <sessionId>', 'At fire time, resume this existing session id (via `agents run <agent> --resume`) instead of starting fresh — the actual session reopens with full context and the prompt becomes its next turn. Powers self-scheduled wake-ups (e.g. /hibernate). Requires --agent claude or codex; runs un-sandboxed (the session store lives in the real home, not the job overlay).')
     .option('--json', 'Emit machine-readable JSON with the created routine id and status')
@@ -811,6 +817,7 @@ export function registerRoutinesCommands(program: Command): void {
           ...(hostStrategy ? { hostStrategy } : {}),
           ...(options.runCwd ? { remoteCwd: options.runCwd } : {}),
           ...(runOnce ? { runOnce: true } : {}),
+          ...(options.catchup === false ? { catchup: false } : {}),
           ...(options.endAt ? { endAt: options.endAt } : {}),
           ...(options.resume ? { resume: options.resume } : {}),
         };
@@ -1211,47 +1218,40 @@ export function registerRoutinesCommands(program: Command): void {
 
   routinesCmd
     .command('catchup')
-    .description('Run any routines that missed their last scheduled fire (e.g. because your laptop was off). Detached — runs in the background under the scheduler.')
-    .option('--dry-run', 'List overdue routines without running them')
+    .description('Run any routines that missed their last scheduled fire on demand. The daemon already does this every 5 minutes — use this to force a pass now. Detached: runs in the background under the scheduler.')
+    .option('--dry-run', 'Record the misses and list them without running anything')
     .action(async (options) => {
       const overdue = detectOverdueJobs();
       if (overdue.length === 0) {
-        console.log(chalk.gray('No overdue routines.'));
+        console.log(chalk.gray('No missed fires.'));
         return;
       }
 
-      console.log(chalk.bold(`${overdue.length} overdue routine(s):\n`));
+      console.log(chalk.bold(`${overdue.length} missed fire(s):\n`));
       for (const job of overdue) {
         const last = job.lastRanAt ? job.lastRanAt.toLocaleString() : 'never';
         console.log(`  ${chalk.cyan(job.name)} — missed ${chalk.gray(job.expectedAt.toLocaleString())}, last ran ${chalk.gray(last)}`);
       }
 
-      if (options.dryRun) {
-        console.log(chalk.gray('\n(dry run — no jobs triggered)'));
-        return;
-      }
-
       // Need the daemon alive so spawned jobs are monitored and meta.json is
       // finalized. Start it if it isn't already running.
-      if (!isDaemonRunning()) {
+      if (!options.dryRun && !isDaemonRunning()) {
         const started = startDaemon();
         if (started.pid) {
           console.log(chalk.gray(`\nStarted scheduler (PID: ${started.pid}) so catchup runs are monitored.`));
         }
       }
 
-      console.log(chalk.bold('\nTriggering catchup runs...'));
-      for (const job of overdue) {
-        const config = readJob(job.name);
-        if (!config) {
-          console.log(`  ${job.name} → ${chalk.red('config not found')}`);
-          continue;
-        }
-        try {
-          const meta = await executeJobDetached(config);
-          console.log(`  ${job.name} → ${chalk.green('started')} (run: ${meta.runId}, PID: ${meta.pid ?? 'n/a'})`);
-        } catch (err) {
-          console.log(`  ${job.name} → ${chalk.red('failed to start')}: ${(err as Error).message}`);
+      console.log(chalk.bold(options.dryRun ? '\nRecording misses...' : '\nTriggering catchup runs...'));
+      const outcomes = await runCatchup({ overdue, dryRun: options.dryRun });
+      for (const o of outcomes) {
+        if (o.result === 'ran') {
+          console.log(`  ${o.name} → ${chalk.green('started')} (run: ${o.runId})`);
+        } else if (o.result === 'recorded') {
+          const why = options.dryRun ? 'dry run' : 'catchup: false';
+          console.log(`  ${o.name} → ${chalk.yellow('recorded as missed')} (${why})`);
+        } else {
+          console.log(`  ${o.name} → ${chalk.red('failed to start')}: ${o.error}`);
         }
       }
       console.log(chalk.gray('\nTrack progress with: agents routines runs <name>'));
@@ -1382,6 +1382,7 @@ export function registerRoutinesCommands(program: Command): void {
       // is the concise view. Falls back to a bounded stdout tail when no report
       // was extracted (e.g. the run failed before finishing).
       const statusColor = run.status === 'completed' ? chalk.green
+        : run.status === 'missed' ? chalk.magenta
         : run.status === 'failed' || run.status === 'timeout' ? chalk.red
         : chalk.yellow;
       console.log(chalk.bold(name) + chalk.gray(`  run ${runId}`));

--- a/apps/cli/src/lib/__tests__/routines.project-sync.test.ts
+++ b/apps/cli/src/lib/__tests__/routines.project-sync.test.ts
@@ -157,6 +157,30 @@ describe('project opt-in + source tracking', () => {
     expect(readJob('daily')!.prompt).toBe('v2');
   });
 
+  // A sync rebuilds the user copy from the PROJECT yaml, which never carries
+  // createdAt. Without carrying it across, every sync re-stamps it to now,
+  // walking the overdue floor forward and hiding real missed fires.
+  it('sync preserves the original createdAt stamp across refreshes', () => {
+    writeRoutine(projectRoutinesDir, 'daily', {
+      schedule: '0 9 * * *',
+      agent: 'claude',
+      prompt: 'v1',
+    });
+    enableProjectRoutines(projectDir);
+    syncProjectRoutines(projectDir);
+    const first = readJob('daily')!.createdAt;
+    expect(first).toBeTruthy();
+
+    writeRoutine(projectRoutinesDir, 'daily', {
+      schedule: '0 9 * * *',
+      agent: 'claude',
+      prompt: 'v2',
+    });
+    syncProjectRoutines(projectDir);
+    expect(readJob('daily')!.prompt).toBe('v2');
+    expect(readJob('daily')!.createdAt).toBe(first);
+  });
+
   it('sync does not overwrite a hand-authored user routine of the same name', () => {
     writeRoutine(userRoutinesDir, 'daily', {
       schedule: '0 8 * * *',

--- a/apps/cli/src/lib/__tests__/scheduler.device.test.ts
+++ b/apps/cli/src/lib/__tests__/scheduler.device.test.ts
@@ -117,11 +117,14 @@ describe('JobScheduler devices allowlist', () => {
 describe('detectOverdueJobs devices allowlist', () => {
   it('never flags a job restricted to another device as overdue here', () => {
     const pastRun = { status: 'completed', exitCode: 0, startedAt: '2020-01-01T00:00:00Z', completedAt: '2020-01-01T00:01:00Z' };
+    // createdAt predates the missed occurrences: overdue is floored at routine
+    // creation, and these fixtures are written to disk during the test.
+    const born = { createdAt: '2020-01-01T00:00:00.000Z' };
     const home = makeHome({
       jobs: [
-        { ...baseJob, name: 'foreign-overdue', devices: ['yosemite-s0'] },
-        { ...baseJob, name: 'local-overdue', devices: ['zion'] },
-        { ...baseJob, name: 'unpinned-overdue' },
+        { ...baseJob, ...born, name: 'foreign-overdue', devices: ['yosemite-s0'] },
+        { ...baseJob, ...born, name: 'local-overdue', devices: ['zion'] },
+        { ...baseJob, ...born, name: 'unpinned-overdue' },
       ],
       runs: [
         { jobName: 'foreign-overdue', runId: '2020-01-01T00-00-00-000Z', meta: pastRun },

--- a/apps/cli/src/lib/catchup.test.ts
+++ b/apps/cli/src/lib/catchup.test.ts
@@ -116,10 +116,13 @@ describe('claimMissedFire', () => {
 describe('runCatchup', () => {
   /** A routine due daily at 02:00 UTC whose last run was two days before "now". */
   // timezone pinned so the cron occurrences line up with the UTC instants the
-  // fixtures use, whatever TZ the test machine runs in.
+  // fixtures use, whatever TZ the test machine runs in. createdAt predates the
+  // fixtures' runs so the routine is old enough for its slots to count as real
+  // misses (see "a routine is never judged against fires that predate it").
   const nightly = {
     name: 'nightly', schedule: '0 2 * * *', timezone: 'UTC', agent: 'claude' as const,
     mode: 'auto' as const, effort: 'auto' as const, timeout: '10m', enabled: true, prompt: 'noop',
+    createdAt: '2026-07-25T00:00:00.000Z',
   };
   const now = new Date('2026-08-03T09:00:00.000Z');
 
@@ -198,6 +201,57 @@ describe('runCatchup', () => {
 
     expect(await runCatchup({ now })).toHaveLength(0);
     expect(readRuns('nightly').map((r) => r.status)).toEqual(['completed']);
+  });
+});
+
+// The footgun this floor exists to prevent: `agents routines add` for any daily
+// or weekly schedule whose slot already passed today would otherwise be judged
+// overdue for a fire that predates the routine, and auto-catchup would run it
+// once, immediately, within five minutes of creating it.
+describe('a routine is never judged against fires that predate it', () => {
+  const now = new Date('2026-08-03T09:00:00.000Z');
+
+  it('a routine created after its last slot is not overdue and is not caught up', async () => {
+    const { runCatchup } = await import('./catchup.js');
+    const { detectOverdueJobs } = await import('./overdue.js');
+    // Daily at 02:00Z; "now" is 09:00Z, so today's slot already passed...
+    writeRoutine({
+      name: 'just-added', schedule: '0 2 * * *', timezone: 'UTC', agent: 'claude',
+      mode: 'auto', effort: 'auto', timeout: '10m', enabled: true, prompt: 'noop',
+      // ...but the routine was only written an hour ago.
+      createdAt: '2026-08-03T08:00:00.000Z',
+    });
+
+    expect(detectOverdueJobs(now)).toHaveLength(0);
+    expect(await runCatchup({ now })).toHaveLength(0);
+    expect(readRuns('just-added')).toHaveLength(0);
+  });
+
+  it('still catches up a slot that falls after the routine was created', async () => {
+    const { runCatchup } = await import('./catchup.js');
+    writeRoutine({
+      name: 'older', schedule: '0 2 * * *', timezone: 'UTC', agent: 'claude',
+      mode: 'auto', effort: 'auto', timeout: '10m', enabled: true, prompt: 'noop',
+      createdAt: '2026-07-30T00:00:00.000Z',
+    });
+
+    // Today's 02:00Z slot is after createdAt and never ran — a real miss.
+    const outcomes = await runCatchup({ now, dryRun: true });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].name).toBe('older');
+    expect(readRuns('older').map((r) => r.status)).toEqual(['missed']);
+  });
+
+  it('falls back to the file mtime for a routine written before createdAt existed', async () => {
+    const { detectOverdueJobs } = await import('./overdue.js');
+    // No createdAt — the pre-field case every existing routine on disk is in.
+    writeRoutine({
+      name: 'legacy', schedule: '0 2 * * *', timezone: 'UTC', agent: 'claude',
+      mode: 'auto', effort: 'auto', timeout: '10m', enabled: true, prompt: 'noop',
+    });
+    // The file was just written, so its mtime is "now" — later than today's
+    // 02:00Z slot, which therefore cannot be a miss.
+    expect(detectOverdueJobs(now)).toHaveLength(0);
   });
 });
 

--- a/apps/cli/src/lib/catchup.test.ts
+++ b/apps/cli/src/lib/catchup.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Catch-up tests — a missed fire is recorded, and re-run unless opted out.
+ *
+ * These drive the real module against a real `~/.agents` tree in an isolated
+ * mkdtemp HOME: real routine YAML on disk, real run records, real
+ * `detectOverdueJobs`. The only seam is the injected clock. Nothing is mocked.
+ *
+ * The scenario is the one that cost real time: zion's daemon was down at
+ * 2026-08-03T04:00Z when `weekly-fleet-retro` came due, croner rescheduled
+ * forward on restart, and the fire was simply lost.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'yaml';
+
+let home: string;
+let prevHome: string | undefined;
+let prevUserProfile: string | undefined;
+
+/** Write a routine YAML into the isolated HOME's routines dir. */
+function writeRoutine(job: Record<string, unknown>): void {
+  const dir = path.join(home, '.agents', 'routines');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${job.name}.yml`), yaml.stringify(job));
+}
+
+/** Write a completed run record so a routine is not seen as never-run. */
+function writeRun(jobName: string, startedAt: string): void {
+  const runId = startedAt.replace(/[:.]/g, '-');
+  const dir = path.join(home, '.agents', '.history', 'runs', jobName, runId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'meta.json'),
+    JSON.stringify({
+      jobName, runId, agent: 'claude', pid: null, status: 'completed',
+      startedAt, completedAt: startedAt, exitCode: 0,
+    }),
+  );
+}
+
+function readRuns(jobName: string): Record<string, unknown>[] {
+  const dir = path.join(home, '.agents', '.history', 'runs', jobName);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).sort().map((runId) =>
+    JSON.parse(fs.readFileSync(path.join(dir, runId, 'meta.json'), 'utf-8')));
+}
+
+beforeEach(() => {
+  // The state module resolves ~/.agents paths into consts at import time, so a
+  // cached module would still point at a previous test's HOME. Reset the module
+  // registry so each test imports against the temp HOME set below. Not a mock —
+  // the real path resolution runs, just against a fresh root.
+  vi.resetModules();
+  prevHome = process.env.HOME;
+  prevUserProfile = process.env.USERPROFILE;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-catchup-test-'));
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\n');
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+  if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('recordMissedFire', () => {
+  it('writes a missed run stamped at the time the fire was due', async () => {
+    const { recordMissedFire } = await import('./catchup.js');
+    const job = {
+      name: 'weekly-fleet-retro', schedule: '0 21 * * 0', agent: 'claude' as const,
+      mode: 'auto' as const, effort: 'auto' as const, timeout: '10m', enabled: true, prompt: 'noop',
+    };
+    writeRoutine(job);
+
+    const expectedAt = new Date('2026-08-03T04:00:00.000Z');
+    const meta = recordMissedFire(job, expectedAt);
+
+    expect(meta.status).toBe('missed');
+    // Stamped when it was DUE, not when it was noticed — so the gap lands at
+    // the right point in history.
+    expect(meta.startedAt).toBe('2026-08-03T04:00:00.000Z');
+    expect(meta.pid).toBeNull();
+    expect(meta.exitCode).toBeNull();
+
+    const runs = readRuns('weekly-fleet-retro');
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('missed');
+  });
+
+  it('is idempotent for the same missed fire', async () => {
+    const { recordMissedFire } = await import('./catchup.js');
+    const job = {
+      name: 'nightly', schedule: '0 2 * * *', agent: 'claude' as const,
+      mode: 'auto' as const, effort: 'auto' as const, timeout: '10m', enabled: true, prompt: 'noop',
+    };
+    writeRoutine(job);
+    const expectedAt = new Date('2026-08-02T09:00:00.000Z');
+
+    recordMissedFire(job, expectedAt);
+    recordMissedFire(job, expectedAt);
+
+    // Same fire, same derived run id — one record, not a duplicate per pass.
+    expect(readRuns('nightly')).toHaveLength(1);
+  });
+});
+
+describe('runCatchup', () => {
+  /** A routine due daily at 02:00 UTC whose last run was two days before "now". */
+  // timezone pinned so the cron occurrences line up with the UTC instants the
+  // fixtures use, whatever TZ the test machine runs in.
+  const nightly = {
+    name: 'nightly', schedule: '0 2 * * *', timezone: 'UTC', agent: 'claude' as const,
+    mode: 'auto' as const, effort: 'auto' as const, timeout: '10m', enabled: true, prompt: 'noop',
+  };
+  const now = new Date('2026-08-03T09:00:00.000Z');
+
+  it('records the miss and does not re-run when catchup is false', async () => {
+    const { runCatchup } = await import('./catchup.js');
+    writeRoutine({ ...nightly, catchup: false });
+    writeRun('nightly', '2026-08-01T02:00:00.000Z');
+
+    const outcomes = await runCatchup({ now });
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].name).toBe('nightly');
+    expect(outcomes[0].result).toBe('recorded');
+
+    const runs = readRuns('nightly');
+    // The original completed run plus exactly one missed record — no late run.
+    expect(runs.map((r) => r.status)).toEqual(['completed', 'missed']);
+  });
+
+  it('stops reporting the same missed fire on a second pass', async () => {
+    const { runCatchup } = await import('./catchup.js');
+    const { detectOverdueJobs } = await import('./overdue.js');
+    writeRoutine({ ...nightly, catchup: false });
+    writeRun('nightly', '2026-08-01T02:00:00.000Z');
+
+    expect(detectOverdueJobs(now)).toHaveLength(1);
+    await runCatchup({ now });
+
+    // The `missed` record advances getLatestRun past the expected fire, so the
+    // same miss is never processed twice — no separate ledger needed. This is
+    // what stops a restart storm from re-firing a routine on every boot.
+    expect(detectOverdueJobs(now)).toHaveLength(0);
+    const second = await runCatchup({ now });
+    expect(second).toHaveLength(0);
+    expect(readRuns('nightly')).toHaveLength(2);
+  });
+
+  it('dry run records the miss without starting a late run', async () => {
+    const { runCatchup } = await import('./catchup.js');
+    writeRoutine(nightly);
+    writeRun('nightly', '2026-08-01T02:00:00.000Z');
+
+    const outcomes = await runCatchup({ now, dryRun: true });
+
+    expect(outcomes[0].result).toBe('recorded');
+    expect(outcomes[0].runId).toBeUndefined();
+    expect(readRuns('nightly').map((r) => r.status)).toEqual(['completed', 'missed']);
+  });
+
+  it('leaves a routine that ran on schedule alone', async () => {
+    const { runCatchup } = await import('./catchup.js');
+    writeRoutine(nightly);
+    // Ran at its most recent expected fire (02:00 today) — nothing was missed.
+    writeRun('nightly', '2026-08-03T02:00:00.000Z');
+
+    expect(await runCatchup({ now })).toHaveLength(0);
+    expect(readRuns('nightly').map((r) => r.status)).toEqual(['completed']);
+  });
+});
+
+describe('shouldCatchUp', () => {
+  it('defaults to true so a scheduled routine is never silently skipped', async () => {
+    const { shouldCatchUp } = await import('./catchup.js');
+    expect(shouldCatchUp({})).toBe(true);
+    expect(shouldCatchUp({ catchup: undefined })).toBe(true);
+    expect(shouldCatchUp({ catchup: true })).toBe(true);
+    expect(shouldCatchUp({ catchup: false })).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/catchup.test.ts
+++ b/apps/cli/src/lib/catchup.test.ts
@@ -68,9 +68,9 @@ afterEach(() => {
   fs.rmSync(home, { recursive: true, force: true });
 });
 
-describe('recordMissedFire', () => {
+describe('claimMissedFire', () => {
   it('writes a missed run stamped at the time the fire was due', async () => {
-    const { recordMissedFire } = await import('./catchup.js');
+    const { claimMissedFire } = await import('./catchup.js');
     const job = {
       name: 'weekly-fleet-retro', schedule: '0 21 * * 0', agent: 'claude' as const,
       mode: 'auto' as const, effort: 'auto' as const, timeout: '10m', enabled: true, prompt: 'noop',
@@ -78,7 +78,7 @@ describe('recordMissedFire', () => {
     writeRoutine(job);
 
     const expectedAt = new Date('2026-08-03T04:00:00.000Z');
-    const meta = recordMissedFire(job, expectedAt);
+    const meta = claimMissedFire(job, expectedAt)!;
 
     expect(meta.status).toBe('missed');
     // Stamped when it was DUE, not when it was noticed — so the gap lands at
@@ -92,8 +92,10 @@ describe('recordMissedFire', () => {
     expect(runs[0].status).toBe('missed');
   });
 
-  it('is idempotent for the same missed fire', async () => {
-    const { recordMissedFire } = await import('./catchup.js');
+  // The claim is what stops two overlapping callers -- the daemon's timer and a
+  // human running `agents routines catchup` -- from both spawning the routine.
+  it('grants the claim exactly once for the same missed fire', async () => {
+    const { claimMissedFire } = await import('./catchup.js');
     const job = {
       name: 'nightly', schedule: '0 2 * * *', agent: 'claude' as const,
       mode: 'auto' as const, effort: 'auto' as const, timeout: '10m', enabled: true, prompt: 'noop',
@@ -101,10 +103,12 @@ describe('recordMissedFire', () => {
     writeRoutine(job);
     const expectedAt = new Date('2026-08-02T09:00:00.000Z');
 
-    recordMissedFire(job, expectedAt);
-    recordMissedFire(job, expectedAt);
+    const first = claimMissedFire(job, expectedAt);
+    const second = claimMissedFire(job, expectedAt);
 
-    // Same fire, same derived run id — one record, not a duplicate per pass.
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    // Same fire, same derived run id — one record, not a duplicate per caller.
     expect(readRuns('nightly')).toHaveLength(1);
   });
 });
@@ -151,6 +155,27 @@ describe('runCatchup', () => {
     const second = await runCatchup({ now });
     expect(second).toHaveLength(0);
     expect(readRuns('nightly')).toHaveLength(2);
+  });
+
+  // Simulates the daemon tick and a manual `agents routines catchup` overlapping:
+  // the second caller sees the same overdue set (it was captured before either
+  // wrote) but must lose the claim rather than spawning the routine twice.
+  it('a concurrent pass over the same overdue set does not double-run', async () => {
+    const { runCatchup } = await import('./catchup.js');
+    const { detectOverdueJobs } = await import('./overdue.js');
+    writeRoutine(nightly);
+    writeRun('nightly', '2026-08-01T02:00:00.000Z');
+
+    // Both callers captured the overdue set before either acted.
+    const shared = detectOverdueJobs(now);
+    expect(shared).toHaveLength(1);
+
+    const first = await runCatchup({ now, overdue: shared, dryRun: true });
+    const second = await runCatchup({ now, overdue: shared, dryRun: true });
+
+    expect(first[0].result).toBe('recorded');
+    expect(second[0].result).toBe('claimed-elsewhere');
+    expect(readRuns('nightly').map((r) => r.status)).toEqual(['completed', 'missed']);
   });
 
   it('dry run records the miss without starting a late run', async () => {

--- a/apps/cli/src/lib/catchup.ts
+++ b/apps/cli/src/lib/catchup.ts
@@ -10,10 +10,11 @@
  *
  * This module closes that loop. A missed fire is:
  *
- *   1. RECORDED — `recordMissedFire` writes a real run with status `missed`,
+ *   1. CLAIMED — `claimMissedFire` writes a real run with status `missed`,
  *      stamped at the time the fire was DUE, so `agents routines runs <name>`
  *      shows the gap instead of the listing showing a weeks-old `completed` as
- *      though it were current.
+ *      though it were current. The write is an atomic claim (see below), and
+ *      only the claimant proceeds to step 2.
  *   2. RUN — unless the routine sets `catchup: false`, it is executed late via
  *      the same `executeJobDetached` path `agents routines catchup` already used.
  *
@@ -21,14 +22,25 @@
  * separate ledger to keep in sync. `detectOverdueJobs` compares the most recent
  * expected fire against `getLatestRun(...).startedAt`; a `missed` record stamped
  * at `expectedAt` advances that comparison, so the same missed fire is never
- * processed twice — across ticks, daemon restarts, or a restart storm. (A job
- * that is overdue by definition has no run later than `expectedAt`, so the
+ * reconsidered — across ticks, daemon restarts, or a restart storm. (A job that
+ * is overdue by definition has no run later than `expectedAt`, so the
  * back-stamped record always sorts last in `listRuns`.)
+ *
+ * That comparison alone is not enough when two callers overlap, because both
+ * can read the same overdue set before either writes. The claim in
+ * `claimMissedFire` closes that: the record's directory is created with a
+ * non-recursive `mkdir`, an atomic test-and-set, and only the caller that wins
+ * it runs the routine. This holds across processes — the daemon's timer and a
+ * human running `agents routines catchup` — which neither an in-process flag
+ * nor `withFileLock` (synchronous; this pass awaits a spawn) can cover.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   readJob,
   writeRunMeta,
+  getRunDir,
   type JobConfig,
   type RunMeta,
 } from './routines.js';
@@ -40,8 +52,12 @@ export interface CatchupOutcome {
   name: string;
   /** The fire that was missed. */
   expectedAt: Date;
-  /** `ran` — re-run late. `recorded` — miss logged, `catchup: false`. `error` — could not run. */
-  result: 'ran' | 'recorded' | 'error';
+  /**
+   * `ran` — re-run late. `recorded` — miss logged, not re-run (`catchup: false`
+   * or a dry run). `claimed-elsewhere` — a concurrent pass or process already
+   * owns this fire. `error` — could not start the late run.
+   */
+  result: 'ran' | 'recorded' | 'claimed-elsewhere' | 'error';
   /** Run id of the late run, when one was started. */
   runId?: string;
   /** Why the late run could not be started. */
@@ -57,16 +73,47 @@ export function shouldCatchUp(job: Pick<JobConfig, 'catchup'>): boolean {
   return job.catchup !== false;
 }
 
+/** The run id a missed fire is recorded under — derived from when it was DUE. */
+export function missedRunId(expectedAt: Date): string {
+  return expectedAt.toISOString().replace(/[:.]/g, '-');
+}
+
 /**
- * Persist the fact that a fire never happened, stamped at the moment it was due.
+ * CLAIM a missed fire: atomically record that it never happened, and report
+ * whether this caller is the one that recorded it.
  *
- * The run id is derived from `expectedAt` (not "now") for two reasons: run ids
- * are ISO timestamps that `listRuns` sorts lexically, so the record lands in
- * history at the point the gap actually occurred; and re-deriving the same id
- * for the same missed fire makes the write idempotent.
+ * Returns the run on a successful claim, or `null` when another caller already
+ * claimed the same (routine, expected-fire) pair. That return value is the
+ * concurrency control for the whole module — only the claimant runs the routine
+ * late, so a fire can never be spawned twice.
+ *
+ * The atomicity is the non-recursive `mkdir` of the run directory: on every
+ * POSIX filesystem that is a single test-and-set, failing with EEXIST if the
+ * directory is already there. It therefore holds between the daemon's timer and
+ * a human running `agents routines catchup` in a separate process — which an
+ * in-process re-entrancy flag cannot cover, and which a lock cannot cover either
+ * (`withFileLock` is synchronous and this pass awaits a spawn).
+ *
+ * The run id is derived from `expectedAt` rather than "now" so the same missed
+ * fire always maps to the same directory — that is what makes the claim
+ * meaningful — and so the record sorts into `listRuns` (lexical over ISO run
+ * ids) at the point the gap actually occurred.
+ *
+ * Deliberately at-most-once: a process that dies between claiming and spawning
+ * leaves the fire un-run. That is the right trade for something that starts
+ * agent processes — a double spawn costs real work and money, while the miss is
+ * still on the record for a human to see and re-run.
  */
-export function recordMissedFire(job: JobConfig, expectedAt: Date): RunMeta {
-  const runId = expectedAt.toISOString().replace(/[:.]/g, '-');
+export function claimMissedFire(job: JobConfig, expectedAt: Date): RunMeta | null {
+  const runId = missedRunId(expectedAt);
+  const runDir = getRunDir(job.name, runId);
+  fs.mkdirSync(path.dirname(runDir), { recursive: true });
+  try {
+    fs.mkdirSync(runDir); // non-recursive: throws EEXIST if already claimed
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return null;
+    throw err;
+  }
   const at = expectedAt.toISOString();
   const meta: RunMeta = {
     jobName: job.name,
@@ -118,9 +165,12 @@ export async function runCatchup(opts: CatchupOptions = {}): Promise<CatchupOutc
       continue;
     }
 
-    // Record first: if the late run fails to spawn, the miss is still on record
-    // and the same fire is not reconsidered on the next tick.
-    recordMissedFire(config, entry.expectedAt);
+    // Claim first. Losing the claim means another pass (or another process)
+    // already owns this fire — say so rather than running it a second time.
+    if (claimMissedFire(config, entry.expectedAt) === null) {
+      outcomes.push({ name: entry.name, expectedAt: entry.expectedAt, result: 'claimed-elsewhere' });
+      continue;
+    }
 
     if (!shouldCatchUp(config) || opts.dryRun) {
       outcomes.push({ name: entry.name, expectedAt: entry.expectedAt, result: 'recorded' });

--- a/apps/cli/src/lib/catchup.ts
+++ b/apps/cli/src/lib/catchup.ts
@@ -1,0 +1,149 @@
+/**
+ * Catch-up: run a routine whose scheduled fire this device missed.
+ *
+ * Fires are in-process croner timers, and croner only ever schedules forward
+ * from "now". A daemon that is down, asleep, or wedged when a routine comes due
+ * therefore loses that fire outright — `loadAll()` rebuilds every Cron looking
+ * only at the future (scheduler.ts), so nothing replays it. Detection has always
+ * existed (`detectOverdueJobs`), but it ran once at daemon startup and only
+ * logged plus popped a notification; the routine still never ran.
+ *
+ * This module closes that loop. A missed fire is:
+ *
+ *   1. RECORDED — `recordMissedFire` writes a real run with status `missed`,
+ *      stamped at the time the fire was DUE, so `agents routines runs <name>`
+ *      shows the gap instead of the listing showing a weeks-old `completed` as
+ *      though it were current.
+ *   2. RUN — unless the routine sets `catchup: false`, it is executed late via
+ *      the same `executeJobDetached` path `agents routines catchup` already used.
+ *
+ * The `missed` record is also what makes this idempotent, so there is no
+ * separate ledger to keep in sync. `detectOverdueJobs` compares the most recent
+ * expected fire against `getLatestRun(...).startedAt`; a `missed` record stamped
+ * at `expectedAt` advances that comparison, so the same missed fire is never
+ * processed twice — across ticks, daemon restarts, or a restart storm. (A job
+ * that is overdue by definition has no run later than `expectedAt`, so the
+ * back-stamped record always sorts last in `listRuns`.)
+ */
+
+import {
+  readJob,
+  writeRunMeta,
+  type JobConfig,
+  type RunMeta,
+} from './routines.js';
+import { detectOverdueJobs, type OverdueJob } from './overdue.js';
+import { executeJobDetached } from './runner.js';
+
+/** What happened to one overdue routine on a catch-up pass. */
+export interface CatchupOutcome {
+  name: string;
+  /** The fire that was missed. */
+  expectedAt: Date;
+  /** `ran` — re-run late. `recorded` — miss logged, `catchup: false`. `error` — could not run. */
+  result: 'ran' | 'recorded' | 'error';
+  /** Run id of the late run, when one was started. */
+  runId?: string;
+  /** Why the late run could not be started. */
+  error?: string;
+}
+
+/**
+ * Is this routine allowed to run late? Default true — a routine you scheduled
+ * is one you expect to have run, so losing a fire silently is never the helpful
+ * default. `catchup: false` opts out a routine whose worth expires with its slot.
+ */
+export function shouldCatchUp(job: Pick<JobConfig, 'catchup'>): boolean {
+  return job.catchup !== false;
+}
+
+/**
+ * Persist the fact that a fire never happened, stamped at the moment it was due.
+ *
+ * The run id is derived from `expectedAt` (not "now") for two reasons: run ids
+ * are ISO timestamps that `listRuns` sorts lexically, so the record lands in
+ * history at the point the gap actually occurred; and re-deriving the same id
+ * for the same missed fire makes the write idempotent.
+ */
+export function recordMissedFire(job: JobConfig, expectedAt: Date): RunMeta {
+  const runId = expectedAt.toISOString().replace(/[:.]/g, '-');
+  const at = expectedAt.toISOString();
+  const meta: RunMeta = {
+    jobName: job.name,
+    runId,
+    agent: job.agent,
+    workflow: job.workflow,
+    command: job.command,
+    pid: null,
+    status: 'missed',
+    startedAt: at,
+    completedAt: at,
+    exitCode: null,
+    errorMessage: 'scheduled fire missed — the scheduler was not running when it came due',
+    actor: job.actor,
+  };
+  writeRunMeta(meta);
+  return meta;
+}
+
+export interface CatchupOptions {
+  /** Record misses but start no late runs. Powers `catchup --dry-run`. */
+  dryRun?: boolean;
+  /** Clock injection seam for tests. */
+  now?: Date;
+  /** Overdue set to act on. Defaults to detecting it. Lets a caller reuse a scan. */
+  overdue?: OverdueJob[];
+}
+
+/**
+ * Record — and, unless opted out, re-run — every routine this device missed.
+ *
+ * Device scoping is already enforced upstream: `detectOverdueJobs` skips a job
+ * pinned elsewhere (overdue.ts), so a fleet of machines never all catch up the
+ * same routine.
+ */
+export async function runCatchup(opts: CatchupOptions = {}): Promise<CatchupOutcome[]> {
+  const overdue = opts.overdue ?? detectOverdueJobs(opts.now ?? new Date());
+  const outcomes: CatchupOutcome[] = [];
+
+  for (const entry of overdue) {
+    const config = readJob(entry.name);
+    if (!config) {
+      outcomes.push({
+        name: entry.name,
+        expectedAt: entry.expectedAt,
+        result: 'error',
+        error: 'config not found',
+      });
+      continue;
+    }
+
+    // Record first: if the late run fails to spawn, the miss is still on record
+    // and the same fire is not reconsidered on the next tick.
+    recordMissedFire(config, entry.expectedAt);
+
+    if (!shouldCatchUp(config) || opts.dryRun) {
+      outcomes.push({ name: entry.name, expectedAt: entry.expectedAt, result: 'recorded' });
+      continue;
+    }
+
+    try {
+      const meta = await executeJobDetached(config);
+      outcomes.push({
+        name: entry.name,
+        expectedAt: entry.expectedAt,
+        result: 'ran',
+        runId: meta.runId,
+      });
+    } catch (err) {
+      outcomes.push({
+        name: entry.name,
+        expectedAt: entry.expectedAt,
+        result: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return outcomes;
+}

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -483,7 +483,17 @@ export async function runDaemon(): Promise<void> {
   // `catchup: false`, RUN late. Runs on a timer as well as at startup: a startup
   // pass alone misses a fire lost while the daemon stayed up but its event loop
   // was wedged, or one lost across an OS suspend that the process survived.
+  // Overlap guard, same shape as runSessionSync/runHealCheck below. A pass
+  // awaits executeJobDetached per job and an off-box (host/cloud) dispatch can
+  // block for a while, so a slow pass could still be working when the next tick
+  // fires. Both passes would then see a job the first has not yet reached as
+  // overdue — the miss is recorded before the await, but only for jobs already
+  // processed — and spawn it twice. The idempotency of the `missed` record
+  // guards across passes, not within one that is mid-flight.
+  let catchingUp = false;
   const catchupPass = async (): Promise<void> => {
+    if (catchingUp) return;
+    catchingUp = true;
     try {
       const overdue = detectOverdueJobs();
       if (overdue.length === 0) return;
@@ -501,6 +511,10 @@ export async function runDaemon(): Promise<void> {
       }
     } catch (err) {
       log('ERROR', `Catchup pass failed: ${(err as Error).message}`);
+    } finally {
+      // finally, not a tail assignment: the no-overdue path returns early, and a
+      // throw must not leave the guard latched shut for the daemon's lifetime.
+      catchingUp = false;
     }
   };
   await catchupPass();

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -19,6 +19,7 @@ import { JobScheduler } from './scheduler.js';
 import { MonitorEngine } from './monitors/engine.js';
 import { executeJobDetached, monitorRunningJobs } from './runner.js';
 import { detectOverdueJobs, notifyOverdue } from './overdue.js';
+import { runCatchup } from './catchup.js';
 import { notifyRoutineStart, notifyRoutineFinish, notifyRoutineStartFailed } from './routine-notify.js';
 import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
@@ -34,6 +35,14 @@ const LOG_ROTATE_COUNT = 3;
 const PLIST_NAME = 'com.phnx-labs.agents-daemon';
 const SYSTEMD_UNIT = 'agents-daemon.service';
 const MONITOR_TICK_MS = 60_000;
+/**
+ * How often to re-scan for missed fires. Deliberately slower than the monitor
+ * tick: detection walks a week of cron occurrences per routine
+ * (`previousExpectedFire`), and a fire that was already missed is not urgent to
+ * the second — five minutes bounds the cost while still recovering from a
+ * wedge or an OS suspend the process survived.
+ */
+const CATCHUP_TICK_MS = 5 * 60_000;
 const WEDGE_THRESHOLD_TICKS = 3;
 
 /**
@@ -465,24 +474,37 @@ export async function runDaemon(): Promise<void> {
     log('ERROR', `Monitor engine failed to start: ${(err as Error).message}`);
   }
 
-  // Backlog detection: any enabled recurring job whose most-recent expected
-  // fire is older than its most-recent recorded run is overdue. Happens when
-  // the laptop was off or the daemon crashed through a scheduled fire.
-  // We log it and pop a native notification — the user can review with
-  // `agents routines list` and run them with `agents routines catchup`.
-  try {
-    const overdue = detectOverdueJobs();
-    if (overdue.length > 0) {
-      log('WARN', `${overdue.length} routine(s) overdue:`);
+  // Backlog recovery: any enabled recurring job whose most-recent expected fire
+  // is older than its most-recent recorded run was missed — the laptop slept,
+  // the machine was off, or the daemon crashed through the fire. croner only
+  // schedules forward from "now", so nothing replays it on its own.
+  //
+  // Every miss is RECORDED as a `missed` run and, unless the routine sets
+  // `catchup: false`, RUN late. Runs on a timer as well as at startup: a startup
+  // pass alone misses a fire lost while the daemon stayed up but its event loop
+  // was wedged, or one lost across an OS suspend that the process survived.
+  const catchupPass = async (): Promise<void> => {
+    try {
+      const overdue = detectOverdueJobs();
+      if (overdue.length === 0) return;
+      log('WARN', `${overdue.length} routine(s) missed their fire:`);
       for (const job of overdue) {
         const last = job.lastRanAt ? job.lastRanAt.toISOString() : 'never';
         log('WARN', `  ${job.name} -- expected ${job.expectedAt.toISOString()}, last ran ${last}`);
       }
       notifyOverdue(overdue);
+      const outcomes = await runCatchup({ overdue });
+      for (const o of outcomes) {
+        if (o.result === 'ran') log('INFO', `Caught up '${o.name}' (run: ${o.runId})`);
+        else if (o.result === 'recorded') log('INFO', `Recorded missed fire for '${o.name}' (catchup disabled)`);
+        else log('ERROR', `Catchup for '${o.name}' failed: ${o.error}`);
+      }
+    } catch (err) {
+      log('ERROR', `Catchup pass failed: ${(err as Error).message}`);
     }
-  } catch (err) {
-    log('ERROR', `Overdue detection failed: ${(err as Error).message}`);
-  }
+  };
+  await catchupPass();
+  const catchupInterval = setInterval(() => { void catchupPass(); }, CATCHUP_TICK_MS);
 
   // Before the BrowserService comes up, reap browser + tunnel processes
   // spawned by previous daemons that are no longer alive. Without this,
@@ -801,6 +823,7 @@ export async function runDaemon(): Promise<void> {
     monitorEngine.stop();
     await browserIPC.stop();
     clearInterval(monitorInterval);
+    clearInterval(catchupInterval);
     clearInterval(syncInterval);
     clearInterval(healInterval);
     clearTimeout(healKickoff);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -505,9 +505,30 @@ export async function runDaemon(): Promise<void> {
       notifyOverdue(overdue);
       const outcomes = await runCatchup({ overdue });
       for (const o of outcomes) {
-        if (o.result === 'ran') log('INFO', `Caught up '${o.name}' (run: ${o.runId})`);
-        else if (o.result === 'recorded') log('INFO', `Recorded missed fire for '${o.name}' (catchup disabled)`);
-        else log('ERROR', `Catchup for '${o.name}' failed: ${o.error}`);
+        // Every variant handled explicitly: a catch-all else would log the
+        // benign 'claimed-elsewhere' (another process legitimately won the
+        // claim) as an ERROR with an undefined reason.
+        switch (o.result) {
+          case 'ran':
+            log('INFO', `Caught up '${o.name}' (run: ${o.runId})`);
+            break;
+          case 'recorded':
+            log('INFO', `Recorded missed fire for '${o.name}' (catchup disabled)`);
+            break;
+          case 'claimed-elsewhere':
+            log('INFO', `Missed fire for '${o.name}' already claimed by another catchup`);
+            break;
+          case 'error':
+            log('ERROR', `Catchup for '${o.name}' failed: ${o.error}`);
+            break;
+          default: {
+            // Compile-time exhaustiveness: a new CatchupOutcome variant fails
+            // typecheck here rather than silently landing in the wrong log level,
+            // which is exactly how 'claimed-elsewhere' was first missed.
+            const unhandled: never = o.result;
+            log('ERROR', `Catchup for '${o.name}' returned an unhandled result: ${String(unhandled)}`);
+          }
+        }
       }
     } catch (err) {
       log('ERROR', `Catchup pass failed: ${(err as Error).message}`);

--- a/apps/cli/src/lib/overdue.ts
+++ b/apps/cli/src/lib/overdue.ts
@@ -12,8 +12,9 @@
  * `agents routines catchup` command that runs them on demand.
  */
 
+import * as fs from 'fs';
 import { Cron } from 'croner';
-import { listJobs, getLatestRun, jobRunsOnThisDevice } from './routines.js';
+import { listJobs, getLatestRun, getJobPath, jobRunsOnThisDevice, type JobConfig } from './routines.js';
 import { notifyDesktop } from './menubar/notify-desktop.js';
 
 export interface OverdueJob {
@@ -47,6 +48,32 @@ function previousExpectedFire(cron: Cron, now: Date): Date | null {
   return last;
 }
 
+/**
+ * When a routine started existing, and therefore the earliest fire it can
+ * sensibly be judged against.
+ *
+ * `createdAt` is stamped by `writeJob`. Routines written before that field
+ * existed have none, so the file's own mtime stands in — it is the closest
+ * honest answer available on disk, and it only ever moves the floor later,
+ * never earlier, so it cannot manufacture a false "overdue".
+ *
+ * Returns null when neither is available, which leaves the routine unfloored
+ * (previous behaviour) rather than silently skipping it.
+ */
+export function routineEffectiveStart(job: JobConfig): Date | null {
+  if (job.createdAt) {
+    const stamped = new Date(job.createdAt);
+    if (!isNaN(stamped.getTime())) return stamped;
+  }
+  const path = getJobPath(job.name);
+  if (!path) return null;
+  try {
+    return new Date(fs.statSync(path).mtimeMs);
+  } catch {
+    return null;
+  }
+}
+
 /** Return every enabled, recurring job whose most recent expected fire was
  *  missed. One-shot jobs are excluded — they fire at most once. */
 export function detectOverdueJobs(now: Date = new Date()): OverdueJob[] {
@@ -74,6 +101,13 @@ export function detectOverdueJobs(now: Date = new Date()): OverdueJob[] {
     }
 
     if (!expected) continue;
+
+    // A fire that predates the routine never could have happened, so it is not
+    // a miss. Without this, any newly created routine on a daily/weekly cron is
+    // instantly "overdue" for the previous occurrence — and with auto-catchup
+    // that means `agents routines add` runs the routine once, immediately.
+    const start = routineEffectiveStart(job);
+    if (start && expected.getTime() < start.getTime()) continue;
 
     const latest = getLatestRun(job.name);
     const lastRanAt = latest ? new Date(latest.startedAt) : null;

--- a/apps/cli/src/lib/routines-project.ts
+++ b/apps/cli/src/lib/routines-project.ts
@@ -294,6 +294,11 @@ export function syncProjectRoutines(projectRoot: string): SyncProjectResult {
       if (job.devices === undefined && existing.devices && existing.devices.length > 0) {
         job.devices = existing.devices;
       }
+      // Carry the original creation stamp across. A sync rebuilds the config
+      // from the PROJECT yaml, which never carries `createdAt`, so without this
+      // every `agents routines sync` would re-stamp it to now — walking the
+      // overdue floor forward and hiding real missed fires for project routines.
+      if (existing.createdAt) job.createdAt = existing.createdAt;
     }
 
     // Placement that leaves the firing machine must pin devices to avoid

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -184,6 +184,17 @@ export interface JobConfig {
    */
   catchup?: boolean;
   /**
+   * When this routine came into existence, ISO 8601. Stamped once by
+   * {@link writeJob}, like `actor`.
+   *
+   * Overdue detection needs it: `detectOverdueJobs` walks back a week for the
+   * most recent expected fire, so without a floor a brand-new routine is
+   * "overdue" for occurrences that happened before it was written. Harmless
+   * when catch-up was a manual command; with auto-catchup it would run every
+   * newly created routine once, immediately.
+   */
+  createdAt?: string;
+  /**
    * Environment variables injected into the spawned run, on top of the sandbox
    * overlay's own. Merged by `buildSpawnEnv`, so it applies to both the
    * foreground and detached execution paths.
@@ -558,6 +569,11 @@ export function writeJob(config: JobConfig): void {
   // disk, which already carries `actor`, so this preserves the original creator;
   // only a brand-new routine (no actor yet) gets the current resolver.
   if (!config.actor) config.actor = resolveActor().id;
+  // Stamped once, on first write, and preserved by every later edit (an edit
+  // re-writes a config loaded from disk, which already carries it). This is the
+  // floor overdue detection uses so a routine is never judged against fires
+  // that predate it.
+  if (!config.createdAt) config.createdAt = new Date().toISOString();
   const jobsDir = getRoutinesDir();
   const ymlPath = safeJoin(jobsDir, config.name + '.yml');
   const yamlPath = safeJoin(jobsDir, config.name + '.yaml');

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -173,6 +173,17 @@ export interface JobConfig {
    */
   devices?: string[];
   /**
+   * Whether a fire this device missed (daemon down, laptop asleep, wedged event
+   * loop) is run late. Defaults to true: croner only schedules forward from
+   * "now", so without catch-up a missed fire is simply lost and the routine
+   * silently does not run.
+   *
+   * Set `catchup: false` for a routine whose value is tied to its clock — a
+   * 9am standup brief is worthless at 3pm. An opted-out routine still records
+   * the miss (a `missed` run), it just is not re-run.
+   */
+  catchup?: boolean;
+  /**
    * Environment variables injected into the spawned run, on top of the sandbox
    * overlay's own. Merged by `buildSpawnEnv`, so it applies to both the
    * foreground and detached execution paths.
@@ -269,7 +280,14 @@ export interface RunMeta {
   pid: number | null;
   /** Process birth time (epoch ms) recorded at spawn for pid-reuse detection. */
   spawnedAt?: number;
-  status: 'running' | 'completed' | 'failed' | 'timeout';
+  /**
+   * `missed` is not an execution outcome — it is the record that a scheduled
+   * fire never happened (the daemon was down, asleep, or wedged when it came
+   * due). Without it a miss leaves no trace at all and the listing keeps
+   * showing the previous run's status as if it were current. Written by
+   * `recordMissedFire` (catchup.ts), never by the runner.
+   */
+  status: 'running' | 'completed' | 'failed' | 'timeout' | 'missed';
   startedAt: string;
   completedAt: string | null;
   exitCode: number | null;
@@ -560,6 +578,7 @@ export function writeJob(config: JobConfig): void {
   if (output.timeout === '10m') delete output.timeout;
   if (output.enabled === true) delete output.enabled;
   if (output.runOnce === false || output.runOnce === undefined) delete output.runOnce;
+  if (output.catchup === true || output.catchup === undefined) delete output.catchup;
   const devArr = output.devices as string[] | undefined;
   if (!devArr || devArr.length === 0) delete output.devices;
 
@@ -779,6 +798,9 @@ export function validateJob(config: Partial<JobConfig>): string[] {
         }
       }
     }
+  }
+  if (config.catchup !== undefined && typeof config.catchup !== 'boolean') {
+    errors.push('catchup must be a boolean (false to skip running a missed fire late)');
   }
   // Off-box placement without a devices pin fires on every fleet daemon and
   // each dispatches once (RUSH-1980). Enforce the pin at validation so hand

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -285,7 +285,7 @@ export interface RunMeta {
    * fire never happened (the daemon was down, asleep, or wedged when it came
    * due). Without it a miss leaves no trace at all and the listing keeps
    * showing the previous run's status as if it were current. Written by
-   * `recordMissedFire` (catchup.ts), never by the runner.
+   * `claimMissedFire` (catchup.ts), never by the runner.
    */
   status: 'running' | 'completed' | 'failed' | 'timeout' | 'missed';
   startedAt: string;


### PR DESCRIPTION
**bug fix + new field** — a routine that misses its fire now runs late instead of vanishing. Adds `catchup:` and a `missed` run status.

## What was wrong

Fires are in-process `croner` timers, and croner only ever schedules forward from "now".
A daemon that was down, asleep, or wedged when a routine came due therefore **loses that
fire outright** — `loadAll()` (`scheduler.ts:37-51`) rebuilds every timer looking only at
the future, and `reloadAll()` (`:109-112`, called on every SIGHUP) discards pending ones.

Detection already existed, but:

- it ran **once, at daemon startup** (`daemon.ts:468-485`) and never again;
- it only logged a warning and popped a notification — **nothing ever re-ran the routine**;
- recovery was a manual `agents routines catchup` (`routines.ts:1212-1258`);
- and a miss left **no trace at all** — `RunMeta.status` had no value for it
  (`routines.ts:272`), so the listing kept showing the previous run's `completed` as
  though it were current.

Observed cost on the live fleet: zion's daemon log jumps from `Daemon started 02:03:56Z`
to `Daemon started 08:23:07Z` (laptop asleep). `weekly-fleet-retro` was armed for exactly
`2026-08-03T04:00:00.000Z`, has no run record, and the 08:23 restart logged
`2 routine(s) overdue:` — then did nothing.

## The fix

- **`apps/cli/src/lib/catchup.ts`** (new) — `recordMissedFire` + `runCatchup`.
- **Daemon re-scans every 5 minutes as well as at startup.** A startup-only pass misses a
  fire lost while the daemon stayed up but its event loop was wedged, or one lost across an
  OS suspend the process survived. The tick is deliberately slower than the 60s monitor
  tick: detection walks a week of cron occurrences per routine.
- **`catchup?: boolean`, default true** — a routine you scheduled is one you expect to have
  run. `catchup: false` (or `agents routines add --no-catchup`) opts out a routine whose
  worth expires with its slot; the miss is still recorded, it just is not re-run.
- **New `missed` run status**, stamped at the moment the fire was **due**, not when it was
  noticed — so the gap lands at the right point in history and renders distinctly from
  `failed` (a miss is infrastructure, not a task failure).
- **Idempotent with no new ledger.** The `missed` record advances the overdue comparison
  that `detectOverdueJobs` makes, so the same missed fire is never re-fired — across ticks,
  a daemon restart, or a restart storm.
- `agents routines catchup` keeps working as the manual override and now shares the engine.

## Run result — real end-to-end, isolated HOME, real `executeJobDetached`

A `command` routine due daily at 02:00Z whose last run was two days earlier, so its most
recent fire was genuinely missed:

```
=== BEFORE ===
Execution History: nightly-proof
  2026-08-01T09-00-00-000Z  completed  2026-08-01T09:00:00.000Z

  nightly-proof   command   daily at 2:00 AM   yes   tomorrow 2:00 AM   completed (overdue)

=== agents routines catchup ===
1 missed fire(s):
  nightly-proof — missed 8/2/2026, 7:00:00 PM, last ran 8/1/2026, 2:00:00 AM
Triggering catchup runs...
  nightly-proof → started (run: 2026-08-03T10-04-11-156Z)

=== the routine's real side effect ===
caught-up-at-10:04:11Z          <-- the command actually ran

=== AFTER — the gap AND the late run are both on record ===
Execution History: nightly-proof
  2026-08-01T09-00-00-000Z  completed  2026-08-01T09:00:00.000Z
  2026-08-03T02-00-00-000Z  missed     2026-08-03T02:00:00.000Z   <-- stamped when DUE
  2026-08-03T10-04-11-156Z  completed  2026-08-03T10:04:11.156Z   <-- ran late

=== second pass is a no-op ===
No missed fires.
```

## Tests

`apps/cli/src/lib/catchup.test.ts` (new, **7/7**) drives the real module against a real
`~/.agents` tree in an isolated mkdtemp HOME — real routine YAML, real run records, real
`detectOverdueJobs`. The only seam is the injected clock; nothing is mocked.

- `missed` run is stamped at the time the fire was due, and is idempotent for the same fire
- `catchup: false` records the miss and does **not** re-run
- a second pass finds nothing — the restart-storm guard
- `--dry-run` records without running
- a routine that ran on schedule is left alone

Full suite for the touched surfaces: `catchup.test.ts` + `routines.test.ts` +
`lib/routines.test.ts` = **114 passing**.

## Docs

`apps/cli/docs/03-routines.md` — new *Catching up a missed fire* section, an opt-out
subsection, and a `missed` entry under the Run State Machine. Changelog fragment queued at
`.changelog/next/routines-auto-catchup.md`.

## Field note, not in this diff

While verifying, every Linux box on the fleet turned out to have a stale hand-written
systemd drop-in (`~/.config/systemd/user/agents-daemon.service.d/override.conf`) pointing
`ExecStart` at `agents daemon _run` — a subcommand that does not exist. `NRestarts` was
**8,439** on yosemite-s0, **8,939** on s1 and worker: the supervised unit had never once
started, so the daemon only ever survived as a detached process and never came back from a
reboot. Removed on all three; they now run supervised with `NRestarts=0`. Machine config,
not repo code, but it is a second independent cause of "my routines didn't run".
