### PR TITLE
docs(sessions): fix resolver test citation

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -411,7 +411,7 @@ The command surface (bare `sessions [query]`, `tail`, `sync`, `resume`, `focus`,
   `metadataResolveForwardedArgs`; tests
   `commands/sessions-resolve-db.test.ts`,
   `commands/__tests__/sessions.test.ts`,
-  `lib/session/remote-list.test.ts`).
+  `lib/session/__tests__/remote-list.test.ts`).
 - **SES-IF-3 (MUST).** The export **bundle format** is NDJSON, `kind`
   `agents-session-bundle`, `version` 1; parse MUST reject a wrong kind/version;
   per-record `hash`/`size` are always over **plaintext** for byte-exact dedup;


### PR DESCRIPTION
Docs-only follow-up to #1771 and #1757.

## What changed

Correct the SES-IF-2a adjacent-test citation from `lib/session/remote-list.test.ts` to the checked-in `lib/session/__tests__/remote-list.test.ts` path.

## Verification

Docs-only path correction; no visual or runtime surface. `git diff --check` passed in the feature worktree.

Public repository: session transcript intentionally omitted.