### PR TITLE
test: skip Unix-only tests on Windows

### DIFF
--- a/apps/cli/src/lib/__tests__/sandbox.test.ts
+++ b/apps/cli/src/lib/__tests__/sandbox.test.ts
@@ -79,7 +79,9 @@ describe('generateCodexConfig', () => {
 });
 
 describe('generateCursorConfig', () => {
-  it('links the same-host Cursor auth file into the overlay', () => {
+  // Symlinks require elevated privileges on Windows; the underlying function
+  // uses a symlink, so the same-host behavior cannot be exercised in CI there.
+  it.skipIf(process.platform === 'win32')('links the same-host Cursor auth file into the overlay', () => {
     const overlayHome = createOverlayHome();
     const realConfigHome = createOverlayHome();
     const cursorDir = path.join(realConfigHome, 'cursor');

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -147,7 +147,7 @@ describe('generateLaunchdPlist', () => {
   });
 });
 
-describe('generateSystemdUnit', () => {
+describe.skipIf(process.platform === 'win32')('generateSystemdUnit', () => {
   it('never embeds a token Environment line, only PATH', () => {
     expect(generateSystemdUnit()).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
   });

--- a/apps/cli/src/lib/feed-broadcast.test.ts
+++ b/apps/cli/src/lib/feed-broadcast.test.ts
@@ -107,7 +107,7 @@ describe('broadcast planning', () => {
 });
 
 describe('running sinks', () => {
-  it('runs a real command and reports success', () => {
+  it.skipIf(process.platform === 'win32')('runs a real command and reports success', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'feed-broadcast-'));
     const out = path.join(dir, 'sink.txt');
     const planned = planFeedBroadcast(
@@ -118,7 +118,7 @@ describe('running sinks', () => {
     expect(fs.readFileSync(out, 'utf8')).toBe('PR #1690 open, CI green, merging');
   });
 
-  it('reports a failing sink without throwing — the post already stands', () => {
+  it.skipIf(process.platform === 'win32')('reports a failing sink without throwing — the post already stands', () => {
     const [outcome] = runFeedBroadcast([{ name: 'nope', argv: ['sh', '-c', 'echo boom >&2; exit 3'] }]);
     expect(outcome.ok).toBe(false);
     expect(outcome.error).toBe('boom');

--- a/apps/cli/src/lib/triggers/handlers.test.ts
+++ b/apps/cli/src/lib/triggers/handlers.test.ts
@@ -344,7 +344,7 @@ describe('handler config layer', () => {
       expect(dispatched[0].env).toEqual({ DEPLOY_TARGET: 'staging' });
     });
 
-    it('runs a shell command action with substitution', async () => {
+    it.skipIf(process.platform === 'win32')('runs a shell command action with substitution', async () => {
       const handler: import('./handlers.js').WebhookHandler = {
         name: 'cmd-handler',
         source: 'linear',
@@ -361,7 +361,7 @@ describe('handler config layer', () => {
       expect(result.output).toBe('RUSH-1459\n');
     });
 
-    it('neutralizes shell metacharacters coming from the webhook payload', async () => {
+    it.skipIf(process.platform === 'win32')('neutralizes shell metacharacters coming from the webhook payload', async () => {
       // `title` is free text an outside contributor controls on a public tracker.
       const hostile = "x'; touch /tmp/pwned; echo '";
       const handler: import('./handlers.js').WebhookHandler = {

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -660,7 +660,7 @@ describe('startWebhookServer', () => {
     }
   });
 
-  it('fires matching handlers alongside routines', async () => {
+  it.skipIf(process.platform === 'win32')('fires matching handlers alongside routines', async () => {
     const secret = 'linear-secret';
     const webhookDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webhook-handlers-'));
     process.env.AGENTS_WEBHOOKS_DIR = webhookDir;


### PR DESCRIPTION
## Summary

Skip Unix-only tests on Windows so CI can pass for cross-platform PRs.

## Context

PR #1751's `test-windows` job is failing, but the failures are pre-existing on main — they come from tests that assume a POSIX environment. This PR unblocks #1751 and any other branch that needs a green Windows run.

## Changes

- `apps/cli/src/lib/__tests__/sandbox.test.ts` — skip Cursor auth symlink test on Windows (symlinks require elevation).
- `apps/cli/src/lib/daemon.test.ts` — skip `generateSystemdUnit` describe on Windows (systemd is not a Windows service manager).
- `apps/cli/src/lib/feed-broadcast.test.ts` — skip `sh -c` sink tests on Windows.
- `apps/cli/src/lib/triggers/handlers.test.ts` — skip shell-command-with-substitution tests on Windows (the implementation already throws there intentionally).
- `apps/cli/src/lib/triggers/webhook.test.ts` — skip the end-to-end command-handler webhook test on Windows.

All skipped tests use the existing `it.skipIf(process.platform === 'win32')` / `describe.skipIf(process.platform === 'win32')` convention already present in the codebase.

## Verification

Ran the affected test files locally (Linux) — 121 tests passed:

```bash
cd apps/cli
bun run test src/lib/__tests__/sandbox.test.ts \
  src/lib/feed-broadcast.test.ts \
  src/lib/triggers/handlers.test.ts \
  src/lib/triggers/webhook.test.ts \
  src/lib/daemon.test.ts
```

## Type

Test-only change.
