### PR TITLE
feat(secrets): per-bundle usage tracking + view/list surfacing + naming guidance

### DIFF
--- a/apps/cli/.changelog/next/secrets-usage-db.md
+++ b/apps/cli/.changelog/next/secrets-usage-db.md
@@ -1,0 +1,16 @@
+- **`agents secrets` now tracks per-bundle usage and surfaces it.** A small local
+  database at `~/.agents/secrets/secrets.db` records a value-free row every time a
+  bundle is accessed (read/queried), imported, exported, or unlocked — never a
+  secret value, only which bundle was touched, when, and by whom. `agents secrets
+  view <bundle>` now shows whether the bundle is currently **unlocked** (held by the
+  secrets-agent, so reads are prompt-free) and a **usage** summary ("accessed 42×
+  (last 2h ago) · exported 3× (last 1d ago)"), and prints a **"No description
+  found"** nudge for an undescribed bundle (also shown at `create` time).
+  `agents secrets list` gains **`--sort name|used|uses|created|updated`** and
+  **`--reverse`** to order bundles by how recently or how often they're used; the
+  `--json` payloads carry `heldExpiresAt`, `usage`, and `uses`. Naming guidance is
+  now taught in the help and skill: name a website bundle after its domain
+  (`stripe.com`, `openai.ai`), a desktop-app bundle after its binary suffix
+  (`slack.app`, `photoshop.exe`). Source:
+  `apps/cli/src/lib/secrets/usage-db.ts`, `apps/cli/src/lib/secrets/audit.ts`,
+  `apps/cli/src/commands/secrets.ts`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -252,6 +252,48 @@ Source: `src/lib/secrets/remote.ts` (transport + resolve), wired into `list` /
 The Windows push bridge is `buildWindowsStdinImportCommand` in
 `src/lib/hosts/remote-cmd.ts`.
 
+## Naming bundles
+
+Name a bundle after the thing it holds credentials for, so an agent can guess it
+without listing every bundle first:
+
+- **Website** → the domain *with its real suffix*: `stripe.com`, `openai.ai`,
+  `github.com`, `x.com`.
+- **Desktop app** → the app's *binary suffix*: `slack.app`, `photoshop.exe`,
+  `figma.app`.
+- Groupings that are neither a site nor an app keep a plain name: `prod`,
+  `staging`, `ci`.
+
+Always pass `--description` — it's what `list` / `view` show so an agent knows what
+a bundle is for without opening it. An undescribed bundle prints a `No description
+found` nudge at `create` time and in `view`; fix it with
+`agents secrets describe <name> "…"`.
+
+## Usage tracking
+
+A small local database at `~/.agents/secrets/secrets.db` records a **value-free**
+row every time a bundle is **accessed** (read/queried), **imported**, **exported**,
+or **unlocked** — never a secret value, only which bundle was touched, when, by
+which agent/host, and how many keys. It is the queryable, per-bundle counterpart to
+the append-only `~/.agents/events.jsonl` audit log: the same access chokepoint
+(`emitSecretAudit`) feeds both, but this store answers "how often / how recently was
+*this* bundle used?" without scanning the whole event stream.
+
+- `agents secrets view <bundle>` shows the recorded usage ("accessed 42× (last 2h
+  ago) · exported 3× (last 1d ago)") and — for a keychain bundle on macOS — whether
+  the bundle is currently **unlocked** (held by the secrets-agent, so reads are
+  prompt-free) or **locked** (Touch ID required on the next read).
+- `agents secrets list --sort used|uses` orders bundles by how **recently** or how
+  **frequently** they're accessed (`--sort created|updated` and `--reverse` are also
+  accepted; `name` is the default).
+- The `--json` payloads carry `heldExpiresAt`, per-bundle `usage`, and a `uses`
+  count for machine callers.
+
+Recording is best-effort — a failure (missing runtime SQLite, a locked db) is
+swallowed so telemetry can never break secret resolution — and honors
+`AGENTS_NO_USAGE_TRACK=1`. Source: `src/lib/secrets/usage-db.ts`,
+`src/lib/secrets/audit.ts`.
+
 ## Command Reference
 
 ### Bundle commands
@@ -259,10 +301,12 @@ The Windows push bridge is `buildWindowsStdinImportCommand` in
 | Command | Description | Example |
 |---------|-------------|---------|
 | `secrets list` / `ls` | List bundles with key count, expiry warnings, timestamps | `agents secrets list` |
-| `secrets view [name]` | Show keys in a bundle (values masked by default) | `agents secrets view prod` |
+| `secrets list --sort <field>` | Order by `name` (default), `used` (most recently used), `uses` (most frequently accessed), `created`, or `updated` | `agents secrets list --sort uses` |
+| `secrets list --reverse` | Reverse the `--sort` order | `agents secrets list --sort used --reverse` |
+| `secrets view [name]` | Show keys in a bundle (values masked), plus its unlock/held state and a usage summary (accessed/imported/exported/unlocked counts + recency) | `agents secrets view prod` |
 | `secrets view [name] --reveal` | Print keychain values in the clear (TTY only) | `agents secrets view prod --reveal` |
 | `secrets view [name] --reveal --plaintext` | Allow `--reveal` in non-interactive shells | `agents secrets view prod --reveal --plaintext` |
-| `secrets create [name]` | Create an empty bundle | `agents secrets create prod` |
+| `secrets create [name]` | Create an empty bundle — name a website by domain (`stripe.com`), a desktop app by its binary suffix (`slack.app`, `photoshop.exe`) | `agents secrets create stripe.com` |
 | `secrets create [name] --description <text>` | Create with a description | `agents secrets create prod --description "Live API keys"` |
 | `secrets create [name] --allow-exec` | Enable exec: refs in this bundle | `agents secrets create tools --allow-exec` |
 | `secrets create [name] --backend <keychain\|file>` | Storage backend; `file` is passphrase-encrypted and headless-readable (see [File-backed bundles](#file-backed-bundles-headless--remote)) | `agents secrets create rush.releases --backend file` |

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -739,16 +739,26 @@ access control (that is 1Password/Vault; this tool is device-local first).
 - **SEC-16 (MUST).** The following non-actionable operations — and no others
   without a change to this spec — MUST be silent no-ops rather than errors: `lock`/`unlock` on a non-macOS host
   (exit 0, no value output), a best-effort session-store write that fails
-  (resolution still succeeds), and a throttled `last_used` stamp
+  (resolution still succeeds), a throttled `last_used` stamp, and a best-effort
+  usage-metadata write to `~/.agents/secrets/secrets.db` that fails or is
+  suppressed by `AGENTS_NO_USAGE_TRACK`
   (`commands/secrets.ts:2219,2282`; `lib/secrets/session-store.ts:24-25`;
-  `lib/secrets/bundles.ts:938-945`). A silent no-op MUST NOT be used to swallow an
-  actionable failure (a real resolution error, a missing bundle, a decrypt
-  failure) — those MUST surface.
+  `lib/secrets/bundles.ts:938-945`; `lib/secrets/usage-db.ts`). A silent no-op MUST
+  NOT be used to swallow an actionable failure (a real resolution error, a missing
+  bundle, a decrypt failure) — those MUST surface.
 - **SEC-17 (SHOULD).** `agents doctor` SHOULD warn (name + line only, never the
   value) when a credential-shaped var is exported from a shell rc file, and point
   the user at `agents secrets` (`lib/secrets/rc-hygiene.ts:16-17` for the scan;
   the `rc-secret-export` finding in `lib/devices/doctor-findings.ts` for the
   warning the user sees).
+- **SEC-26 (MUST).** Per-bundle usage metadata (access / import / export / unlock
+  counts + recency), stored in `~/.agents/secrets/secrets.db`, MUST be
+  **value-free** — bundle name, event kind, key count, resolving agent/host, and a
+  status only, never a secret value — same contract as the `emitSecretAudit` log it
+  is fed alongside (`lib/secrets/usage-db.ts`; `lib/secrets/audit.ts`). The reads it
+  drives — the `secrets view` usage summary + held state, and `secrets list --sort
+  used|uses` — MUST NOT expose a value and MUST degrade cleanly (no usage shown)
+  when the DB is unavailable (`commands/secrets.ts` `view` / `list` actions).
 
 #### 3.4 Authorization model
 

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -21,9 +21,14 @@ import {
   registerSecretsCommands,
   renderHoldSummary,
   renderPolicyCol,
+  sortSecretsBundles,
+  formatUsageLine,
+  renderViewStatusLine,
+  SECRETS_SORT_FIELDS,
   NO_BUNDLES_HELD_LINE,
 } from './secrets.js';
 import { parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
+import type { BundleUsageSummary } from '../lib/secrets/usage-db.js';
 
 // On macOS, `secrets create --backend file` still stores bundle METADATA in the
 // Keychain, which requires the signed `Agents CLI.app` helper. GitHub macOS CI
@@ -653,4 +658,201 @@ describe('exportBundleToFile / importBundleFromFile file round-trip', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+});
+
+// Build a minimal usage summary for the sort/format helpers, with per-event
+// counts and last timestamps supplied inline.
+function usage(
+  bundle: string,
+  events: Partial<Record<'access' | 'unlock' | 'import' | 'export', { count: number; last: string | null }>>,
+): BundleUsageSummary {
+  const base = {
+    access: { count: 0, last: null as string | null },
+    unlock: { count: 0, last: null as string | null },
+    import: { count: 0, last: null as string | null },
+    export: { count: 0, last: null as string | null },
+  };
+  const merged = { ...base, ...events } as BundleUsageSummary['events'];
+  const lasts = Object.values(merged).map((e) => e.last).filter(Boolean) as string[];
+  const total = Object.values(merged).reduce((n, e) => n + e.count, 0);
+  return {
+    bundle,
+    total,
+    events: merged,
+    lastUsedAt: lasts.length ? lasts.sort().at(-1)! : null,
+    firstUsedAt: lasts.length ? lasts.sort()[0] : null,
+  };
+}
+
+const bundleFor = (name: string, extra: Partial<SecretsBundle> = {}): SecretsBundle =>
+  ({ name, vars: {}, ...extra } as SecretsBundle);
+
+describe('sortSecretsBundles', () => {
+  const a = bundleFor('a.com', { created_at: '2026-01-01T00:00:00Z', updated_at: '2026-02-01T00:00:00Z', last_used: '2026-03-01T00:00:00Z' });
+  const b = bundleFor('b.app', { created_at: '2026-01-03T00:00:00Z', updated_at: '2026-01-04T00:00:00Z', last_used: '2026-05-01T00:00:00Z' });
+  const c = bundleFor('c.dev', { created_at: '2026-01-02T00:00:00Z', updated_at: '2026-03-15T00:00:00Z' }); // never used
+  const bundles = [a, b, c];
+
+  it("defaults to alphabetical by name", () => {
+    const out = sortSecretsBundles(bundles, 'name', false, new Map());
+    expect(out.map((x) => x.name)).toEqual(['a.com', 'b.app', 'c.dev']);
+  });
+
+  it("'used' orders most-recently-used first, never-used last", () => {
+    const out = sortSecretsBundles(bundles, 'used', false, new Map());
+    expect(out.map((x) => x.name)).toEqual(['b.app', 'a.com', 'c.dev']);
+  });
+
+  it("'used' folds in the usage DB's lastUsedAt when the bundle stamp is older/absent", () => {
+    // c.dev has no last_used stamp, but the DB recorded an access newer than
+    // everyone else's — it should now sort first.
+    const map = new Map([['c.dev', usage('c.dev', { access: { count: 1, last: '2026-06-01T00:00:00Z' } })]]);
+    const out = sortSecretsBundles(bundles, 'used', false, map);
+    expect(out[0].name).toBe('c.dev');
+  });
+
+  it("'uses' orders by recorded access frequency, most first", () => {
+    const map = new Map([
+      ['a.com', usage('a.com', { access: { count: 2, last: '2026-03-01T00:00:00Z' } })],
+      ['b.app', usage('b.app', { access: { count: 9, last: '2026-05-01T00:00:00Z' } })],
+    ]);
+    const out = sortSecretsBundles(bundles, 'uses', false, map);
+    expect(out.map((x) => x.name)).toEqual(['b.app', 'a.com', 'c.dev']);
+  });
+
+  it("'created' / 'updated' order newest first", () => {
+    expect(sortSecretsBundles(bundles, 'created', false, new Map()).map((x) => x.name)).toEqual(['b.app', 'c.dev', 'a.com']);
+    expect(sortSecretsBundles(bundles, 'updated', false, new Map()).map((x) => x.name)).toEqual(['c.dev', 'a.com', 'b.app']);
+  });
+
+  it('--reverse flips the order', () => {
+    const out = sortSecretsBundles(bundles, 'name', true, new Map());
+    expect(out.map((x) => x.name)).toEqual(['c.dev', 'b.app', 'a.com']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...bundles];
+    sortSecretsBundles(input, 'used', false, new Map());
+    expect(input.map((x) => x.name)).toEqual(['a.com', 'b.app', 'c.dev']);
+  });
+
+  it('exposes exactly the documented sort fields', () => {
+    expect([...SECRETS_SORT_FIELDS]).toEqual(['name', 'used', 'uses', 'created', 'updated']);
+  });
+});
+
+describe('formatUsageLine', () => {
+  it('returns empty string when there is no recorded usage', () => {
+    expect(formatUsageLine(undefined)).toBe('');
+    expect(formatUsageLine(usage('x', {}))).toBe('');
+  });
+
+  it('lists each non-zero event with its count, in access/unlock/import/export order', () => {
+    const line = formatUsageLine(usage('stripe.com', {
+      export: { count: 2, last: '2026-05-01T00:00:00Z' },
+      access: { count: 5, last: '2026-05-02T00:00:00Z' },
+    }));
+    // access is listed before export regardless of insertion order.
+    expect(line.indexOf('accessed')).toBeLessThan(line.indexOf('exported'));
+    expect(line).toContain('accessed 5×');
+    expect(line).toContain('exported 2×');
+    // zero-count kinds are omitted.
+    expect(line).not.toContain('imported');
+    expect(line).not.toContain('unlocked');
+  });
+});
+
+describe('renderViewStatusLine', () => {
+  it('is empty for non-keychain backends (no broker to hold)', () => {
+    expect(renderViewStatusLine(bundleFor('f', { backend: 'file' }), Date.now() + 60_000)).toBe('');
+    expect(renderViewStatusLine(bundleFor('v', { backend: 'vault' }), Date.now() + 60_000)).toBe('');
+  });
+
+  it("is empty for a 'never'-policy bundle (always readable, no hold state)", () => {
+    expect(renderViewStatusLine(bundleFor('n', { policy: 'never' }), Date.now() + 60_000)).toBe('');
+  });
+});
+
+// End-to-end proof that a real read is recorded in ~/.agents/secrets/secrets.db
+// and surfaced by `view` / `list`. Unlike the discovery suite above, this one
+// leaves usage tracking ON and points AGENTS_SECRETS_DB at a temp file.
+describe('secrets usage tracking (secrets.db) end-to-end', () => {
+  function runTracked(home: string, dbPath: string, args: string[]): ReturnType<typeof spawnSync> {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      AGENTS_SECRETS_PASSPHRASE: 'usage-e2e-test',
+      AGENTS_SECRETS_DB: dbPath,
+    };
+    // tests/setup.ts sets AGENTS_NO_USAGE_TRACK=1 for the parent process; this
+    // suite deliberately wants recording ON, so drop it from the child env.
+    delete env.AGENTS_NO_USAGE_TRACK;
+    return spawnSync('node', ['--import', 'tsx', 'src/index.ts', 'secrets', ...args], {
+      cwd: path.resolve(__dirname, '../..'),
+      encoding: 'utf-8',
+      env,
+    });
+  }
+
+  // Each assertion spawns a fresh `tsx` CLI (re-transforms on every run), so this
+  // multi-step end-to-end flow needs a generous timeout past the 30s default.
+  it.skipIf(!keychainHelperAvailable)('records an access on `get` and surfaces it in view/list', ({ skip }) => {
+    if (!keychainHelperAvailable) { skip(); return; }
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-secrets-e2e-'));
+    const dbPath = path.join(home, 'secrets.db');
+    try {
+      fs.mkdirSync(path.join(home, '.agents/.system'), { recursive: true });
+      spawnSync('git', ['init', '--quiet'], { cwd: path.join(home, '.agents/.system'), encoding: 'utf-8' });
+      expect(runTracked(home, dbPath, ['create', 'stripe.com', '--backend', 'file', '--description', 'live keys']).status).toBe(0);
+      expect(runTracked(home, dbPath, ['add', 'stripe.com', 'API_TOKEN', '--value', 'sk-live-xyz']).status).toBe(0);
+
+      // A real read through the canonical path → one recorded `access`.
+      const got = runTracked(home, dbPath, ['get', 'stripe.com', 'API_TOKEN']);
+      expect(got.status, got.stderr).toBe(0);
+      expect(got.stdout.trim()).toBe('sk-live-xyz');
+      expect(fs.existsSync(dbPath)).toBe(true);
+
+      const view = runTracked(home, dbPath, ['view', 'stripe.com', '--json']);
+      expect(view.status, view.stderr).toBe(0);
+      const obj = JSON.parse(view.stdout);
+      expect(obj.usage).toBeTruthy();
+      expect(obj.usage.events.access.count).toBeGreaterThanOrEqual(1);
+      // file backend has no broker to hold → not unlocked.
+      expect(obj.heldExpiresAt).toBeNull();
+
+      const list = runTracked(home, dbPath, ['list', '--json']);
+      expect(list.status, list.stderr).toBe(0);
+      const gh = JSON.parse(list.stdout).find((b: { name: string }) => b.name === 'stripe.com');
+      expect(gh.uses).toBeGreaterThanOrEqual(1);
+
+      // The sort flag is accepted and doesn't error.
+      expect(runTracked(home, dbPath, ['list', '--sort', 'uses', '--reverse']).status).toBe(0);
+      // An invalid sort field is rejected.
+      const bad = runTracked(home, dbPath, ['list', '--sort', 'bogus']);
+      expect(bad.status).toBe(1);
+      expect(bad.stderr).toMatch(/Invalid --sort/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it.skipIf(!keychainHelperAvailable)('nudges when a bundle has no description', ({ skip }) => {
+    if (!keychainHelperAvailable) { skip(); return; }
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-secrets-nodesc-'));
+    const dbPath = path.join(home, 'secrets.db');
+    try {
+      fs.mkdirSync(path.join(home, '.agents/.system'), { recursive: true });
+      spawnSync('git', ['init', '--quiet'], { cwd: path.join(home, '.agents/.system'), encoding: 'utf-8' });
+      const created = runTracked(home, dbPath, ['create', 'undescribed', '--backend', 'file']);
+      expect(created.status, created.stderr).toBe(0);
+      expect(created.stdout).toMatch(/No description found/);
+
+      const view = runTracked(home, dbPath, ['view', 'undescribed']);
+      expect(view.status, view.stderr).toBe(0);
+      expect(view.stdout).toMatch(/No description found/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  }, 60_000);
 });

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -94,6 +94,8 @@ import { readMeta } from '../lib/state.js';
 import { parseDuration } from '../lib/hooks/cache.js';
 import { emit, query } from '../lib/events.js';
 import { emitSecretAudit } from '../lib/secrets/audit.js';
+import { recordSecretUsage, getBundleUsage, getAllBundleUsage, SECRET_USAGE_EVENTS } from '../lib/secrets/usage-db.js';
+import type { BundleUsageSummary, SecretUsageEvent } from '../lib/secrets/usage-db.js';
 import { frequentlyPromptedBundles } from '../lib/secrets/unlock-hints.js';
 import { registerCommandGroups, setHelpSections } from '../lib/help.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
@@ -767,6 +769,92 @@ function countExpiringSoon(meta: Record<string, VarMeta> | undefined): number {
   return n;
 }
 
+/** Human labels for the usage events, in the order `view` prints them. */
+const USAGE_EVENT_LABELS: Record<SecretUsageEvent, string> = {
+  access: 'accessed',
+  unlock: 'unlocked',
+  import: 'imported',
+  export: 'exported',
+};
+
+/**
+ * Compact one-line usage summary for `secrets view` — each recorded event with
+ * its count and how long ago it last happened ("accessed 42x (last 2h ago) ·
+ * exported 3x (last 1d ago)"). Empty string when nothing has been recorded yet.
+ * Pure — unit-tested.
+ */
+export function formatUsageLine(summary: BundleUsageSummary | undefined): string {
+  if (!summary || summary.total === 0) return '';
+  const parts: string[] = [];
+  for (const ev of SECRET_USAGE_EVENTS) {
+    const stat = summary.events[ev];
+    if (stat.count === 0) continue;
+    const age = stat.last ? relativeAge(stat.last) : null;
+    parts.push(`${USAGE_EVENT_LABELS[ev]} ${stat.count}×${age ? ` (last ${age})` : ''}`);
+  }
+  return parts.join(' · ');
+}
+
+/**
+ * The held-state line for `secrets view`. Mirrors `renderPolicyCol` (which
+ * drives the `list` POLICY column) but as a full status line: whether the
+ * secrets-agent currently holds this bundle (so reads are prompt-free) and for
+ * how long, or that Touch ID is required on the next read. Only meaningful for
+ * keychain bundles on macOS — file/vault backends have no broker to hold, and a
+ * `never`-policy bundle is always readable, so both return an empty line and the
+ * caller skips it. `heldExpiresAt` is the max expiry across every held scope.
+ */
+export function renderViewStatusLine(b: SecretsBundle, heldExpiresAt: number | null): string {
+  if (process.platform !== 'darwin') return '';
+  if ((b.backend ?? 'keychain') !== 'keychain') return '';
+  if (bundlePolicy(b) === 'never') return '';
+  if (heldExpiresAt && heldExpiresAt > Date.now()) {
+    return chalk.green(`status:     unlocked (held ${compactRemaining(heldExpiresAt)}; reads are prompt-free until it locks)`);
+  }
+  return chalk.gray('status:     locked (Touch ID required on the next read; `agents secrets unlock` holds it)');
+}
+
+/** Fields `secrets list --sort` accepts. */
+export type SecretsSortField = 'name' | 'used' | 'uses' | 'created' | 'updated';
+export const SECRETS_SORT_FIELDS: readonly SecretsSortField[] = ['name', 'used', 'uses', 'created', 'updated'];
+
+/**
+ * Order bundles for `secrets list`. `name` is alphabetical (ascending); every
+ * other field is "most first" — most recently used / most frequently used /
+ * newest — with never-used or timestamp-less bundles sorting last. `uses`
+ * counts recorded accesses (reads); `used` is the most recent activity across
+ * both the throttled `last_used` stamp and any recorded event. Ties break on
+ * name so the order is deterministic. `--reverse` flips the whole result. Pure —
+ * unit-tested.
+ */
+export function sortSecretsBundles(
+  bundles: SecretsBundle[],
+  field: SecretsSortField,
+  reverse: boolean,
+  usage: Map<string, BundleUsageSummary>,
+): SecretsBundle[] {
+  const finite = (n: number): number => (Number.isFinite(n) ? n : -Infinity);
+  const ts = (iso?: string | null): number => finite(iso ? Date.parse(iso) : NaN);
+  const lastUsed = (b: SecretsBundle): number =>
+    Math.max(ts(b.last_used), ts(usage.get(b.name)?.lastUsedAt));
+  const uses = (b: SecretsBundle): number => usage.get(b.name)?.events.access.count ?? 0;
+  const byName = (a: SecretsBundle, b: SecretsBundle): number => a.name.localeCompare(b.name);
+  let primary: (a: SecretsBundle, b: SecretsBundle) => number;
+  switch (field) {
+    case 'used': primary = (a, b) => lastUsed(b) - lastUsed(a); break;
+    case 'uses': primary = (a, b) => uses(b) - uses(a); break;
+    case 'created': primary = (a, b) => ts(b.created_at) - ts(a.created_at); break;
+    case 'updated': primary = (a, b) => ts(b.updated_at) - ts(a.updated_at); break;
+    case 'name':
+    default: primary = byName; break;
+  }
+  const sorted = [...bundles].sort((a, b) => {
+    const c = primary(a, b);
+    return c !== 0 ? c : byName(a, b);
+  });
+  return reverse ? sorted.reverse() : sorted;
+}
+
 /**
  * Resolve an existing import target bundle (inheriting its backend) or create a
  * new one with the requested backend. Refuses to silently downgrade a
@@ -828,8 +916,12 @@ export function registerSecretsCommands(program: Command): void {
 
   setHelpSections(cmd, {
     examples: `
-      # Create a bundle
+      # Create a bundle (always give it a --description)
       agents secrets create prod --description "Production keys for the api stack"
+
+      # Name a website bundle after its domain, a desktop-app bundle after the app
+      agents secrets create stripe.com --description "Stripe live + test API keys"
+      agents secrets create slack.app  --description "Slack desktop app tokens"
 
       # Add a keychain-backed secret (prompts for the value)
       agents secrets add prod STRIPE_API_KEY
@@ -840,8 +932,12 @@ export function registerSecretsCommands(program: Command): void {
       # Inject the bundle into an agent run
       agents run claude "deploy the worker" --secrets prod
 
-      # See what's in the bundle (values masked); shows its prompt policy
+      # See what's in the bundle (values masked); shows its policy, held state, and usage
       agents secrets view prod
+
+      # Order the list by how recently / how often each bundle is used
+      agents secrets list --sort used
+      agents secrets list --sort uses
 
       # Stop a noisy automation bundle from prompting every run: ask once a week
       agents secrets policy prod hold
@@ -859,6 +955,15 @@ export function registerSecretsCommands(program: Command): void {
       Bundles are containers; secrets are the variables inside them. Keychain values
       never touch disk in plaintext. Every item is device-local and gated by Touch ID
       or device passcode; cross-machine sync is handled by 'agents secrets push/pull'.
+
+      Naming: name a bundle after the thing it holds credentials for, so an agent
+      can guess it without listing. For a website, use its domain WITH the real
+      suffix — 'stripe.com', 'openai.ai', 'github.com'. For a desktop app, use the
+      app's binary suffix — 'slack.app' (macOS) or 'photoshop.exe' (Windows). Always
+      pass '--description' so 'list' / 'view' explain the bundle without opening it;
+      an undescribed bundle prints a "No description found" nudge. 'view' also shows
+      whether the bundle is currently unlocked (held by the agent) and how often /
+      how recently it has been accessed, imported, and exported.
 
       Touch ID noise: macOS pops a prompt per bundle per process. Each bundle has
       a prompt policy, shown in the POLICY column of 'agents secrets list':
@@ -906,14 +1011,28 @@ export function registerSecretsCommands(program: Command): void {
     .option('--hosts <list>', 'Comma-separated hosts to list in one shot, e.g. yosemite-s0,yosemite-s1')
     .option('--device <target>', 'Alias for --host')
     .option('--devices <list>', 'Alias for --hosts')
+    .option('--sort <field>', 'Order bundles by: name (default), used (most recently used), uses (most frequently accessed), created, updated')
+    .option('--reverse', 'Reverse the --sort order')
     .option('--json', 'Emit machine-readable JSON (bundle metadata only — never secret values) instead of the table')
-    .action(async (opts: { host?: string; hosts?: string; device?: string; devices?: string; json?: boolean }) => {
+    .action(async (opts: { host?: string; hosts?: string; device?: string; devices?: string; sort?: string; reverse?: boolean; json?: boolean }) => {
+      if (opts.sort && !(SECRETS_SORT_FIELDS as readonly string[]).includes(opts.sort)) {
+        console.error(chalk.red(`Invalid --sort ${JSON.stringify(opts.sort)}. Expected one of: ${SECRETS_SORT_FIELDS.join(', ')}.`));
+        process.exit(1);
+      }
+      const sortField = (opts.sort as SecretsSortField | undefined) ?? 'name';
       const targets = parseHostsOption(opts);
       if (targets.length > 0) {
-        await browseRemote(targets, opts.json ? ['list', '--json'] : ['list'], false);
+        const remoteArgs = opts.json ? ['list', '--json'] : ['list'];
+        if (opts.sort) remoteArgs.push('--sort', opts.sort);
+        if (opts.reverse) remoteArgs.push('--reverse');
+        await browseRemote(targets, remoteArgs, false);
         return;
       }
-      const bundles = listBundles();
+      // Usage counts back the used/uses sort and the --json `uses` field. Skip
+      // the DB open for a plain unsorted human `list` so it stays snappy.
+      const needUsage = Boolean(opts.json) || sortField === 'used' || sortField === 'uses';
+      const usage = needUsage ? getAllBundleUsage() : new Map<string, BundleUsageSummary>();
+      const bundles = sortSecretsBundles(listBundles(), sortField, Boolean(opts.reverse), usage);
       // Cross-reference the secrets-agent so `hold` bundles that are currently
       // held can show "· held Nh". Soft-fails to no hint if the broker is down.
       const held = new Map<string, number>();
@@ -940,6 +1059,7 @@ export function registerSecretsCommands(program: Command): void {
           updatedAt: b.updated_at ?? null,
           lastUsed: b.last_used ?? null,
           heldExpiresAt: held.get(b.name) ?? null,
+          uses: usage.get(b.name)?.events.access.count ?? 0,
         }));
         process.stdout.write(JSON.stringify(payload) + '\n');
         return;
@@ -1004,6 +1124,25 @@ export function registerSecretsCommands(program: Command): void {
           process.exit(1);
         }
         const entries = describeBundle(bundle);
+        // Value-free usage metadata (access/import/export/unlock counts +
+        // recency) for both the human and --json views.
+        const usage = getBundleUsage(bundle.name);
+        // Is the secrets-agent currently holding this bundle? A held bundle
+        // reads prompt-free. macOS keychain only; take the max expiry across
+        // every scope it's held under. Soft-fails to "not held" if the broker
+        // is down.
+        let heldExpiresAt: number | null = null;
+        if (process.platform === 'darwin' && (bundle.backend ?? 'keychain') === 'keychain') {
+          try {
+            for (const e of await agentStatus()) {
+              if (e.name === bundle.name && (heldExpiresAt === null || e.expiresAt > heldExpiresAt)) {
+                heldExpiresAt = e.expiresAt;
+              }
+            }
+          } catch {
+            /* broker not running — render as not held */
+          }
+        }
         if (opts.json) {
           // Machine-readable discovery for agents. Values are null unless --reveal
           // (which still routes through the same non-TTY/plaintext gate + audit
@@ -1066,6 +1205,8 @@ export function registerSecretsCommands(program: Command): void {
               createdAt: bundle.created_at ?? null,
               updatedAt: bundle.updated_at ?? null,
               lastUsed: bundle.last_used ?? null,
+              heldExpiresAt,
+              usage: usage ?? null,
               revealed: reveal,
               keys,
             }) + '\n',
@@ -1073,7 +1214,13 @@ export function registerSecretsCommands(program: Command): void {
           return;
         }
         console.log(chalk.bold(bundle.name));
-        if (bundle.description) console.log(chalk.gray(safePrint(bundle.description)));
+        if (bundle.description) {
+          console.log(chalk.gray(safePrint(bundle.description)));
+        } else {
+          // A described bundle is self-documenting for the next agent/human.
+          // Nudge — don't block — toward adding one.
+          console.log(chalk.yellow(`No description found. Add one: agents secrets describe ${bundle.name} "what this bundle is for"`));
+        }
         if (bundle.allow_exec) console.log(chalk.yellow('allow_exec: true'));
         if (bundle.backend === 'file') console.log(chalk.gray('backend: file (passphrase-encrypted; reads need AGENTS_SECRETS_PASSPHRASE, no Touch ID)'));
         if (bundle.backend === 'vault') console.log(chalk.gray('storage: synced (age-encrypted ~/.agents/vault.age; needs agents login)'));
@@ -1086,9 +1233,13 @@ export function registerSecretsCommands(program: Command): void {
               : chalk.gray('policy: always (asks for Touch ID every time — never auto-held)'),
           );
         }
+        const statusLine = renderViewStatusLine(bundle, heldExpiresAt);
+        if (statusLine) console.log(statusLine);
         if (bundle.created_at) console.log(chalk.gray(`created_at: ${bundle.created_at} (${humanAge(bundle.created_at)})`));
         if (bundle.updated_at) console.log(chalk.gray(`updated_at: ${bundle.updated_at} (${humanAge(bundle.updated_at)})`));
         if (bundle.last_used) console.log(chalk.gray(`last_used:  ${bundle.last_used} (${humanAge(bundle.last_used)})`));
+        const usageLine = formatUsageLine(usage);
+        if (usageLine) console.log(chalk.gray(`usage:      ${usageLine}`));
         console.log();
         if (entries.length === 0) {
           console.log(chalk.gray('(no keys)'));
@@ -1247,8 +1398,8 @@ export function registerSecretsCommands(program: Command): void {
 
   cmd
     .command('create [name]')
-    .description('Create an empty bundle')
-    .option('--description <text>', 'Free-form description')
+    .description('Create an empty bundle. Name it after what it holds — a website by domain (stripe.com, openai.ai), a desktop app by its binary suffix (slack.app, photoshop.exe) — and pass --description.')
+    .option('--description <text>', 'Free-form description (recommended — an undescribed bundle prints a "No description found" nudge)')
     .option('--allow-exec', 'Allow exec: refs in this bundle (off by default)')
     .option('--policy <policy>', "prompt policy: hold (default, ask once per hold window — secrets.agent.holdMs, 7d by default), always (ask every time), or never (silent, NO biometry ACL — needs --i-understand). 'daily'/'session' are accepted aliases for 'hold'.")
     .addOption(new Option('--tier <policy>', 'deprecated alias for --policy').hideHelp())
@@ -1296,6 +1447,11 @@ export function registerSecretsCommands(program: Command): void {
           backend === 'vault' ? 'synced' : null,
         ].filter(Boolean);
         console.log(chalk.green(`Bundle '${resolvedName}' created (${tags.join(', ')}).`));
+        if (!bundle.description) {
+          // A described bundle is self-documenting for the next agent that reads
+          // `list` / `view`. Nudge toward one at create time — never blocking.
+          console.log(chalk.yellow(`No description found. Add one: agents secrets describe ${resolvedName} "what this bundle is for"`));
+        }
         if (bundlePolicy(bundle) === 'never') {
           console.log(chalk.red('Stored without biometry protection — reads are silent. Automation-only; rotate anything sensitive out of it.'));
         }
@@ -1718,6 +1874,7 @@ Examples:
           const resolvedBundleName = bundleName ?? (await pickBundleName('import into'));
           const bundle = resolveImportBundle(resolvedBundleName, opts.backend, opts.synced);
           const { added, skipped } = applyEnvToBundle(bundle, env, opts);
+          recordSecretUsage({ bundle: bundle.name, event: 'import', source: 'file', keyCount: added });
           console.log(chalk.green(`Imported ${added} key(s) from file${skipped ? `, skipped ${skipped} (already set, pass --force)` : ''}.`));
           return;
         }
@@ -1732,6 +1889,7 @@ Examples:
           const env = await remoteResolveEnv(target, resolvedBundleName, { osLookupName: opts.host });
           const bundle = resolveImportBundle(resolvedBundleName, opts.backend, opts.synced);
           const { added, skipped } = applyEnvToBundle(bundle, env, opts);
+          recordSecretUsage({ bundle: bundle.name, event: 'import', source: 'ssh', host: opts.host, keyCount: added });
           console.log(chalk.green(`Imported ${added} key(s) from ${opts.host}${skipped ? `, skipped ${skipped} (already set, pass --force)` : ''}.`));
           return;
         }
@@ -1770,6 +1928,7 @@ Examples:
           const env: Record<string, string> = {};
           for (const { envKey, value } of secrets) env[envKey] = value;
           const { added, skipped } = applyEnvToBundle(bundle, env, opts);
+          recordSecretUsage({ bundle: bundle.name, event: 'import', source: '1password', keyCount: added });
           if (opSkipped.length) {
             console.log(chalk.yellow(`Skipped ${opSkipped.length} item(s) with no importable fields.`));
           }
@@ -1778,6 +1937,7 @@ Examples:
           const raw = readImportDotenv(source.path);
           const pairs = parseDotenv(raw);
           const { added, skipped } = applyEnvToBundle(bundle, pairs, opts);
+          recordSecretUsage({ bundle: bundle.name, event: 'import', source: 'env-file', keyCount: added });
           console.log(chalk.green(`Imported ${added} key(s)${skipped ? `, skipped ${skipped} (already set, pass --force)` : ''}.`));
         }
       } catch (err) {
@@ -1828,6 +1988,7 @@ Examples:
           }
           const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           exportBundleToFile(env, opts.toFile, passphrase);
+          recordSecretUsage({ bundle: resolvedBundleName, event: 'export', source: 'file', keyCount: Object.keys(env).length });
           console.log(chalk.green(`Exported ${Object.keys(env).length} key(s) to ${opts.toFile}`));
           return;
         }
@@ -1935,6 +2096,7 @@ Examples:
                 continue;
               }
             }
+            recordSecretUsage({ bundle: resolvedBundleName, event: 'export', source: 'ssh', host, keyCount });
             const remoteMsg = (res.stdout || '').trim().split('\n').map((l) => l.trim()).filter(Boolean).pop();
             console.log(chalk.green(`${host} -> '${resolvedBundleName}': ${remoteMsg || `${keyCount} key(s) exported`}`));
           }
@@ -1968,6 +2130,7 @@ Examples:
           if (created) parts.push(`${created} created`);
           if (overwritten) parts.push(`${overwritten} overwritten`);
           if (skipped) parts.push(`${skipped} skipped (already exist, pass --force)`);
+          recordSecretUsage({ bundle: resolvedBundleName, event: 'export', source: '1password', keyCount: created + overwritten });
           console.log(chalk.green(`Exported to 1Password vault '${vault}': ${parts.join(', ')}.`));
           return;
         }
@@ -2003,6 +2166,11 @@ Examples:
           const output = needsQuotes ? `'${v.replace(/'/g, `'\\''`)}'` : v;
           process.stdout.write(`export ${exportKey}=${output}\n`);
         }
+        // Record the shell export (the `eval "$(...)"` path). The `--format json`
+        // branch above is the machine-to-machine remote-resolve transport (already
+        // counted as an access on this machine), so it is deliberately not counted
+        // here as an export to avoid tallying every peer pull as an export.
+        recordSecretUsage({ bundle: resolvedBundleName, event: 'export', source: 'shell', keyCount: Object.keys(env).length });
       } catch (err) {
         if (isPromptCancelled(err)) return;
         console.error(chalk.red((err as Error).message));

--- a/apps/cli/src/lib/secrets/audit.ts
+++ b/apps/cli/src/lib/secrets/audit.ts
@@ -21,6 +21,7 @@
  *                         prompt-free for the grant TTL.
  */
 import { emit } from '../events.js';
+import { recordSecretUsage } from './usage-db.js';
 
 export type SecretAuditEvent = 'secrets.get' | 'secrets.unlocked';
 
@@ -91,4 +92,20 @@ export function emitSecretAudit(p: SecretAuditParams): void {
     ...(p.ttlMs !== undefined ? { ttlMs: p.ttlMs } : {}),
     ...(p.error !== undefined ? { error: p.error } : {}),
   });
+
+  // Mirror the read/unlock into the per-bundle usage DB so `secrets view` /
+  // `list` can report access frequency and recency without scanning the whole
+  // event stream. Per-bundle only — a raw `secrets get <item>` has no bundle,
+  // so it stays in the events.jsonl audit but is not counted as bundle usage.
+  if (p.bundle) {
+    recordSecretUsage({
+      bundle: p.bundle,
+      event: p.event === 'secrets.unlocked' ? 'unlock' : 'access',
+      agent,
+      host: p.host,
+      source: p.source,
+      status: p.status,
+      keyCount: p.keyCount,
+    });
+  }
 }

--- a/apps/cli/src/lib/secrets/usage-db.test.ts
+++ b/apps/cli/src/lib/secrets/usage-db.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  recordSecretUsage,
+  getBundleUsage,
+  getAllBundleUsage,
+  closeSecretsUsageDb,
+} from './usage-db.js';
+
+// Isolate every test to its own temp secrets.db via the AGENTS_SECRETS_DB escape
+// hatch (getSecretsDbPath reads it at call time), and make sure recording is ON
+// (a prior suite may have set AGENTS_NO_USAGE_TRACK).
+let dir: string;
+let prevNoTrack: string | undefined;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-secrets-usage-'));
+  process.env.AGENTS_SECRETS_DB = path.join(dir, 'secrets.db');
+  prevNoTrack = process.env.AGENTS_NO_USAGE_TRACK;
+  delete process.env.AGENTS_NO_USAGE_TRACK;
+  closeSecretsUsageDb();
+});
+
+afterEach(() => {
+  closeSecretsUsageDb();
+  delete process.env.AGENTS_SECRETS_DB;
+  if (prevNoTrack === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+  else process.env.AGENTS_NO_USAGE_TRACK = prevNoTrack;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('recordSecretUsage + getBundleUsage', () => {
+  it('creates the db on first write and aggregates per-event counts', () => {
+    recordSecretUsage({ bundle: 'stripe.com', event: 'access', keyCount: 3 });
+    recordSecretUsage({ bundle: 'stripe.com', event: 'access', keyCount: 3 });
+    recordSecretUsage({ bundle: 'stripe.com', event: 'export', source: 'shell' });
+    recordSecretUsage({ bundle: 'stripe.com', event: 'unlock' });
+
+    expect(fs.existsSync(process.env.AGENTS_SECRETS_DB!)).toBe(true);
+
+    const u = getBundleUsage('stripe.com');
+    expect(u).toBeTruthy();
+    expect(u!.total).toBe(4);
+    expect(u!.events.access.count).toBe(2);
+    expect(u!.events.export.count).toBe(1);
+    expect(u!.events.unlock.count).toBe(1);
+    expect(u!.events.import.count).toBe(0);
+    // Every recorded event carries a timestamp; the zero-count kind has none.
+    expect(u!.events.access.last).toBeTruthy();
+    expect(u!.events.import.last).toBeNull();
+    expect(u!.lastUsedAt).toBeTruthy();
+    expect(u!.firstUsedAt).toBeTruthy();
+  });
+
+  it('returns undefined for a bundle with no recorded usage', () => {
+    recordSecretUsage({ bundle: 'other', event: 'access' });
+    expect(getBundleUsage('never-touched')).toBeUndefined();
+  });
+
+  it('ignores an empty bundle name (usage is per-bundle by definition)', () => {
+    recordSecretUsage({ bundle: '', event: 'access' });
+    expect(getAllBundleUsage().size).toBe(0);
+  });
+
+  it('honors AGENTS_NO_USAGE_TRACK by not writing anything', () => {
+    process.env.AGENTS_NO_USAGE_TRACK = '1';
+    recordSecretUsage({ bundle: 'stripe.com', event: 'access' });
+    expect(getBundleUsage('stripe.com')).toBeUndefined();
+  });
+});
+
+describe('getAllBundleUsage', () => {
+  it('summarizes every bundle that has any event, keyed by name', () => {
+    recordSecretUsage({ bundle: 'a.com', event: 'access' });
+    recordSecretUsage({ bundle: 'a.com', event: 'access' });
+    recordSecretUsage({ bundle: 'b.app', event: 'import' });
+
+    const all = getAllBundleUsage();
+    expect(all.size).toBe(2);
+    expect(all.get('a.com')!.events.access.count).toBe(2);
+    expect(all.get('b.app')!.events.import.count).toBe(1);
+    expect(all.get('b.app')!.events.access.count).toBe(0);
+  });
+
+  it('empty map when nothing has been recorded', () => {
+    expect(getAllBundleUsage().size).toBe(0);
+  });
+});
+
+describe('path isolation', () => {
+  it('reopens against a fresh AGENTS_SECRETS_DB path (no stale handle reuse)', () => {
+    recordSecretUsage({ bundle: 'first', event: 'access' });
+    expect(getBundleUsage('first')).toBeTruthy();
+
+    // Point at a brand-new db file; the module must reopen, not reuse the old
+    // handle — otherwise a test's writes would bleed into the previous file.
+    const second = path.join(dir, 'second.db');
+    process.env.AGENTS_SECRETS_DB = second;
+    expect(getBundleUsage('first')).toBeUndefined();
+    recordSecretUsage({ bundle: 'second', event: 'access' });
+    expect(fs.existsSync(second)).toBe(true);
+    expect(getBundleUsage('second')).toBeTruthy();
+  });
+});

--- a/apps/cli/src/lib/secrets/usage-db.ts
+++ b/apps/cli/src/lib/secrets/usage-db.ts
@@ -1,0 +1,237 @@
+/**
+ * SQLite-backed usage metadata for `agents secrets`.
+ *
+ * A small local database at ~/.agents/secrets/secrets.db that records one
+ * value-free row every time a bundle is READ (accessed/queried), IMPORTED,
+ * EXPORTED, or UNLOCKED — the operational events the `view` / `list` surfaces
+ * report on ("accessed 42 times, last 2h ago; last exported 3d ago"). It is the
+ * queryable, per-bundle counterpart to the append-only ~/.agents/events.jsonl
+ * audit log: the same access chokepoint (`emitSecretAudit`) feeds both, but this
+ * store answers "how often / how recently was THIS bundle used?" without scanning
+ * the whole event stream.
+ *
+ * Contract, mirroring the audit log: NEVER a secret value. Only metadata — the
+ * bundle name, the event kind, key counts, the resolving agent/host, a status.
+ *
+ * Every write is best-effort: a failure here (missing runtime SQLite, a locked
+ * db, a read-only fs) is swallowed so usage telemetry can never break secret
+ * resolution. Set AGENTS_NO_USAGE_TRACK=1 to disable recording entirely (used by
+ * tests and by callers that must stay perfectly silent).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from '../sqlite.js';
+import { getSecretsDbPath } from '../state.js';
+
+/** The four operational events a bundle accrues over its life. */
+export type SecretUsageEvent = 'access' | 'import' | 'export' | 'unlock';
+
+/** All event kinds, in the order `view` prints them. */
+export const SECRET_USAGE_EVENTS: readonly SecretUsageEvent[] = [
+  'access',
+  'unlock',
+  'import',
+  'export',
+] as const;
+
+export interface RecordUsageParams {
+  /** Bundle the event applies to (required — usage is always per-bundle). */
+  bundle: string;
+  /** What happened. */
+  event: SecretUsageEvent;
+  /** Resolving agent/harness identity, when known (`*` = a global grant). */
+  agent?: string;
+  /** Remote host the value was pulled from / pushed to, when applicable. */
+  host?: string;
+  /** Free-form origin label, e.g. 'agent', 'reveal', 'ssh', '1password'. */
+  source?: string;
+  /** Outcome; defaults to 'success'. */
+  status?: 'success' | 'error';
+  /** How many keys the event touched (names only are ever known here). */
+  keyCount?: number;
+}
+
+/** One event kind's rollup for a bundle. */
+export interface UsageStat {
+  count: number;
+  /** ISO 8601 timestamp of the most recent occurrence, or null if never. */
+  last: string | null;
+}
+
+/** Per-bundle usage summary for the `view` / `list` surfaces. */
+export interface BundleUsageSummary {
+  bundle: string;
+  /** Every recorded event, all kinds. */
+  total: number;
+  /** Rollup per event kind (every kind present, zeroed when unused). */
+  events: Record<SecretUsageEvent, UsageStat>;
+  /** Most recent event across all kinds, or null. */
+  lastUsedAt: string | null;
+  /** Earliest event across all kinds, or null. */
+  firstUsedAt: string | null;
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  bundle TEXT NOT NULL,
+  event TEXT NOT NULL,
+  agent TEXT,
+  host TEXT,
+  source TEXT,
+  status TEXT,
+  key_count INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_usage_bundle ON usage_events(bundle);
+CREATE INDEX IF NOT EXISTS idx_usage_bundle_event ON usage_events(bundle, event);
+CREATE INDEX IF NOT EXISTS idx_usage_ts ON usage_events(ts DESC);
+`;
+
+// Cached handle keyed by the resolved path, so a test that redirects
+// AGENTS_SECRETS_DB to a fresh temp file transparently reopens instead of
+// reusing a stale handle pointed at the previous path.
+let cached: { path: string; db: Database.Database } | null = null;
+
+function emptyEvents(): Record<SecretUsageEvent, UsageStat> {
+  return {
+    access: { count: 0, last: null },
+    unlock: { count: 0, last: null },
+    import: { count: 0, last: null },
+    export: { count: 0, last: null },
+  };
+}
+
+/**
+ * Open (creating if needed) the usage DB, returning null on any failure so
+ * every caller degrades to a no-op rather than throwing into secret resolution.
+ */
+function open(): Database.Database | null {
+  const dbPath = getSecretsDbPath();
+  if (cached && cached.path === dbPath) return cached.db;
+  if (cached) {
+    try { cached.db.close(); } catch { /* ignore */ }
+    cached = null;
+  }
+  try {
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const db = new Database(dbPath);
+    // WAL + a busy timeout so concurrent agent runs writing usage rows don't
+    // fail each other under load; every write is still best-effort besides.
+    db.pragma('journal_mode = WAL');
+    db.pragma('busy_timeout = 2000');
+    db.exec(SCHEMA);
+    cached = { path: dbPath, db };
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record one usage event. Best-effort and value-free — swallows every error and
+ * honors AGENTS_NO_USAGE_TRACK so telemetry never blocks or slows a read. Rows
+ * with an empty bundle name are ignored (usage is per-bundle by definition).
+ */
+export function recordSecretUsage(p: RecordUsageParams): void {
+  if (process.env.AGENTS_NO_USAGE_TRACK) return;
+  if (!p.bundle) return;
+  const db = open();
+  if (!db) return;
+  try {
+    db.prepare(
+      `INSERT INTO usage_events (ts, bundle, event, agent, host, source, status, key_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      new Date().toISOString(),
+      p.bundle,
+      p.event,
+      p.agent ?? null,
+      p.host ?? null,
+      p.source ?? null,
+      p.status ?? 'success',
+      p.keyCount ?? null,
+    );
+  } catch {
+    // Telemetry must never break secret resolution.
+  }
+}
+
+interface RollupRow { event: string; n: number; last: string | null; first: string | null }
+
+function toSummary(bundle: string, rows: RollupRow[]): BundleUsageSummary {
+  const events = emptyEvents();
+  let total = 0;
+  let lastUsedAt: string | null = null;
+  let firstUsedAt: string | null = null;
+  for (const r of rows) {
+    if (r.event in events) {
+      const stat = events[r.event as SecretUsageEvent];
+      stat.count = r.n;
+      stat.last = r.last;
+    }
+    total += r.n;
+    if (r.last && (!lastUsedAt || r.last > lastUsedAt)) lastUsedAt = r.last;
+    if (r.first && (!firstUsedAt || r.first < firstUsedAt)) firstUsedAt = r.first;
+  }
+  return { bundle, total, events, lastUsedAt, firstUsedAt };
+}
+
+/**
+ * Usage summary for one bundle, or undefined when nothing has ever been
+ * recorded (or the DB is unavailable). Never throws.
+ */
+export function getBundleUsage(bundle: string): BundleUsageSummary | undefined {
+  const db = open();
+  if (!db) return undefined;
+  try {
+    const rows = db
+      .prepare(
+        `SELECT event, COUNT(*) AS n, MAX(ts) AS last, MIN(ts) AS first
+           FROM usage_events WHERE bundle = ? GROUP BY event`,
+      )
+      .all(bundle) as RollupRow[];
+    if (rows.length === 0) return undefined;
+    return toSummary(bundle, rows);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Usage summaries for every bundle that has any recorded event, keyed by bundle
+ * name. Powers `secrets list --sort uses|used`. Empty map when the DB is
+ * unavailable or has no rows. Never throws.
+ */
+export function getAllBundleUsage(): Map<string, BundleUsageSummary> {
+  const out = new Map<string, BundleUsageSummary>();
+  const db = open();
+  if (!db) return out;
+  try {
+    const rows = db
+      .prepare(
+        `SELECT bundle, event, COUNT(*) AS n, MAX(ts) AS last, MIN(ts) AS first
+           FROM usage_events GROUP BY bundle, event`,
+      )
+      .all() as (RollupRow & { bundle: string })[];
+    const byBundle = new Map<string, RollupRow[]>();
+    for (const r of rows) {
+      const list = byBundle.get(r.bundle) ?? [];
+      list.push(r);
+      byBundle.set(r.bundle, list);
+    }
+    for (const [bundle, list] of byBundle) out.set(bundle, toSummary(bundle, list));
+    return out;
+  } catch {
+    return out;
+  }
+}
+
+/** Close the cached handle. Used by tests between temp-db swaps. */
+export function closeSecretsUsageDb(): void {
+  if (cached) {
+    try { cached.db.close(); } catch { /* ignore */ }
+    cached = null;
+  }
+}

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -336,6 +336,18 @@ export function getUserSubagentsDir(): string { return USER_SUBAGENTS_DIR; }
 export function getSystemWorkflowsDir(): string { return SYSTEM_WORKFLOWS_DIR; }
 export function getUserWorkflowsDir(): string { return USER_WORKFLOWS_DIR; }
 export function getUserSecretsDir(): string { return USER_SECRETS_DIR; }
+/**
+ * Path to the secrets usage-metadata database (~/.agents/secrets/secrets.db).
+ * Read at CALL time so a test can redirect it to a temp file via
+ * AGENTS_SECRETS_DB without racing the module-load capture of USER_SECRETS_DIR —
+ * mirrors the AGENTS_EVENTS_PATH / AGENTS_DEVICES_DIR escape hatches. Holds only
+ * value-free access telemetry (which bundle was read/imported/exported/unlocked,
+ * when, by whom), never a secret value. Separate from the append-only
+ * ~/.agents/events.jsonl audit log, which this feeds alongside.
+ */
+export function getSecretsDbPath(): string {
+  return process.env.AGENTS_SECRETS_DB ?? path.join(USER_SECRETS_DIR, 'secrets.db');
+}
 export function getUserPromptcutsPath(): string { return USER_PROMPTCUTS_FILE; }
 
 // ─── User operational path getters ────────────────────────────────────────────

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -44,6 +44,21 @@ Vault providers (1Password, AWS Secrets Manager, HashiCorp Vault) are planned fo
 
 **agents secrets**: Scoped bundles (agent only sees what you pass), OS keychain-backed (encrypted at rest), and agent-friendly (agents can read *and* write programmatically).
 
+## Naming a bundle
+
+Name a bundle after the thing it holds credentials for, so an agent can guess it without listing every bundle first:
+
+- **Website** → the domain **with its real suffix**: `stripe.com`, `openai.ai`, `github.com`, `x.com`.
+- **Desktop app** → the app's **binary suffix**: `slack.app`, `photoshop.exe`, `figma.app`.
+- Environment/service groupings that aren't a site or app keep a plain name: `prod`, `staging`, `ci`.
+
+Always pass `--description` — it's what `list` and `view` show so an agent knows what a bundle is for without opening it. An undescribed bundle prints a `No description found` nudge in `view`:
+
+```bash
+agents secrets create stripe.com --description "Stripe live + test API keys"
+agents secrets create slack.app  --description "Slack desktop app OAuth tokens"
+```
+
 ## "I need to give an agent access to my API keys"
 
 Create a bundle, add your keys, then pass the bundle when running agents:
@@ -177,6 +192,18 @@ agents secrets tier prod session            # or: secrets create prod --tier ses
 ```
 
 A `biometry`-tier bundle (the default) is never auto-held — keep high-value bundles there so every read is confirmed. While a bundle is unlocked, any process running as you can read it from the socket without a prompt; that's the trade-off, so keep TTLs short and `lock` when you step away.
+
+## "Which bundles do I actually use?"
+
+`view` and `list` report usage. `agents secrets view <bundle>` shows whether the bundle is currently unlocked (held by the agent, so reads are prompt-free) and how often / how recently it's been accessed, imported, and exported. Sort the list by activity:
+
+```bash
+agents secrets list --sort used     # most recently used first
+agents secrets list --sort uses     # most frequently accessed first
+agents secrets list --sort used --reverse
+```
+
+Usage metadata is value-free and lives in a small local database at `~/.agents/secrets/secrets.db` — never a secret value, only which bundle was touched, when, and by whom.
 
 ## "What else can I do?"
 


### PR DESCRIPTION
**feat + docs** — per-bundle usage tracking for `agents secrets`, surfaced in `view`/`list`, plus bundle-naming guidance. CLI feature (terminal output below is the run proof; no web UI).

## What changed

| Ask | Change |
|---|---|
| Track import/export/query/access events | New value-free SQLite store `~/.agents/secrets/secrets.db` (`usage-db.ts`). Every read/unlock is counted at the existing `emitSecretAudit` chokepoint; import/export record explicit events. |
| `view` doesn't show unlocked status | `view` now shows `status: unlocked (held …)` / `locked` for macOS keychain bundles. |
| Show events in the bundle view | `view` prints a `usage:` summary (`accessed 4× (last now) · exported 1× …`). |
| Sort the list by last-used / frequency | `secrets list --sort name\|used\|uses\|created\|updated` + `--reverse`. |
| Warn when a bundle has no description | `No description found` nudge at `create` time and in `view`, with the exact `describe` command. |
| Prefer domain/app suffixes | Help + `SKILL.md` + docs: websites → `stripe.com`/`openai.ai`, desktop apps → `slack.app`/`photoshop.exe`. |

Backed by a new normative requirement (**SEC-26**, value-free + degrades cleanly) and SEC-16 (best-effort silent no-op). Everything is best-effort and honors `AGENTS_NO_USAGE_TRACK`, so telemetry can never break secret resolution.

## Run proof (live, real CLI via `tsx`)

`agents secrets view` after 4 reads + 1 export of a demo bundle — the new `status`, `usage`, and no-description lines:

```
$ agents secrets view stripe.com
stripe.com
Stripe live + test API keys
backend: file (passphrase-encrypted; reads need AGENTS_SECRETS_PASSPHRASE, no Touch ID)
policy: hold (ask once, then held for the hold window — 7d by default — …)
created_at: … (now)
last_used:  … (now)
usage:      accessed 4× (last now) · exported 1× (last now)

  STRIPE_API_KEY               literal            ********

$ agents secrets view undescribed
undescribed
No description found. Add one: agents secrets describe undescribed "what this bundle is for"
backend: file (passphrase-encrypted; …)
policy: hold (…)
(no keys)
```

`list --sort uses` puts the 4-access demo bundle first; every other bundle (uses=0) falls back to name order. (Real bundle inventory omitted — bundle names/descriptions are sensitive metadata.)

## Tests

- `usage-db.test.ts` — record/aggregate/isolation/`AGENTS_NO_USAGE_TRACK` (7).
- `secrets.test.ts` — `sortSecretsBundles`, `formatUsageLine`, `renderViewStatusLine` (12), plus a live end-to-end suite (create → `get` → `view`/`list` surface real usage from `secrets.db`; no-description nudge) gated on the keychain helper (2 passed locally).
- `audit.test.ts` + `mcp.test.ts` unchanged-green (20). `tsc --noEmit` clean.

No Linear ticket was opened (autonomous quick-dispatch); scope is described here.
