### PR TITLE
feat(secrets): activity DB, usage sorting, lock state in view, description + naming guidance

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## 1.20.90
 
+- **`agents secrets` now tracks bundle activity in a local DB, sorts by usage, shows
+  lock state, and flags undescribed bundles.** A small SQLite database at
+  `~/.agents/secrets/secrets.db` records metadata-only lifecycle events per bundle —
+  `create`, `import`, `export`, `view`, and `access` (every env resolution) — with
+  per-bundle `use_count` / `last_used_at` aggregates and 90-day event pruning
+  (secret values are never stored; `AGENTS_NO_USAGE_TRACK=1` disables it).
+  `agents secrets list` gains `--sort name|used|freq` (most-recently-used or
+  most-used first), a USES column, and a `useCount` field in `--json`.
+  `agents secrets view <name>` now shows the bundle's current lock state
+  (`lock: unlocked — held by the secrets agent (expires in Nh)` vs `locked`) and an
+  `activity:` section with the recent import/export/access trail, plus `locked`,
+  `heldExpiresAt`, `useCount`, and `recentActivity` in `--json`. Bundles without a
+  description are flagged with a "No description found" pointer to
+  `agents secrets describe` in `list`, `view`, and right after `create`. The
+  `secrets` help and skill now steer bundle naming toward where the credentials
+  belong — a domain for websites (`anthropic.com`, `claude.ai`), the binary suffix
+  for desktop apps (`photoshop.app`, `slack.exe`). Source:
+  `apps/cli/src/lib/secrets/activity.ts`, `apps/cli/src/commands/secrets.ts`,
+  `apps/cli/src/lib/secrets/bundles.ts`, `skills/secrets/SKILL.md`.
+
 - **`agents sessions --active` now shows one row per agent, not one per directory.**
   A live tmux agent pane whose durable identity records were missing (the common case
   once meta/pid-registry entries age out) was dropped, then re-surfaced by the ps-scan

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -258,8 +258,8 @@ The Windows push bridge is `buildWindowsStdinImportCommand` in
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `secrets list` / `ls` | List bundles with key count, expiry warnings, timestamps | `agents secrets list` |
-| `secrets view [name]` | Show keys in a bundle (values masked by default) | `agents secrets view prod` |
+| `secrets list` / `ls` | List bundles with key count, expiry warnings, timestamps, and recorded use count. `--sort name\|used\|freq` orders by name (default), most-recently-used, or most-used (from the local activity DB). Bundles without a description are flagged | `agents secrets list --sort freq` |
+| `secrets view [name]` | Show keys in a bundle (values masked by default), plus its prompt policy, current lock state (unlocked/held vs locked), and recent create/import/export/access activity | `agents secrets view prod` |
 | `secrets view [name] --reveal` | Print keychain values in the clear (TTY only) | `agents secrets view prod --reveal` |
 | `secrets view [name] --reveal --plaintext` | Allow `--reveal` in non-interactive shells | `agents secrets view prod --reveal --plaintext` |
 | `secrets create [name]` | Create an empty bundle | `agents secrets create prod` |
@@ -378,7 +378,28 @@ allow_exec: false                   # boolean, optional (default false)
 created_at: "2026-01-15T10:00:00Z"  # ISO 8601 UTC — set once on first write
 updated_at: "2026-05-20T14:32:00Z"  # ISO 8601 UTC — refreshed on every write
 last_used: "2026-06-01T08:00:00Z"   # ISO 8601 UTC — stamped on env resolution (throttled)
+```
 
+Bundle names should say *where* the credentials belong, suffix included — a
+domain for websites (`anthropic.com`, `claude.ai`, `github.com`) and the binary
+suffix for desktop apps (`photoshop.app`, `slack.exe`), so an agent reading
+`agents secrets list` knows the target from the name alone. Always set a
+`description` (`create --description` or `agents secrets describe <name> ...`);
+bundles without one are flagged in `list` and `view`.
+
+### Activity tracking (`~/.agents/secrets/secrets.db`)
+
+Beyond the per-bundle timestamps, the CLI keeps a small local SQLite database at
+`~/.agents/secrets/secrets.db` recording metadata-only lifecycle events per
+bundle — `create`, `import`, `export`, `view`, and `access` (every env
+resolution, i.e. a real use). Access events maintain per-bundle aggregates
+(`use_count`, `last_used_at`); events are pruned after 90 days. Secret values
+are never stored. This powers `agents secrets list --sort used|freq` (and the
+USES column / `--json` `useCount`) and the `activity:` section of
+`agents secrets view`. Set `AGENTS_NO_USAGE_TRACK=1` to disable recording.
+Source: `src/lib/secrets/activity.ts`.
+
+```yaml
 vars:
   STRIPE_API_KEY: "keychain:STRIPE_API_KEY"   # keychain-backed (default for `add`)
   GITHUB_USERNAME.personal: { value: "muqsit" } # account-suffixed variant; injects as GITHUB_USERNAME when selected

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -24,6 +24,54 @@ import {
   NO_BUNDLES_HELD_LINE,
 } from './secrets.js';
 import { parseDotenv, type SecretsBundle } from '../lib/secrets/bundles.js';
+import { sortBundles } from './secrets.js';
+
+describe('sortBundles', () => {
+  const bundle = (name: string, last_used?: string): SecretsBundle => ({
+    name,
+    vars: {},
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_used,
+  });
+  const usage = (entries: Record<string, { useCount: number; lastUsedAt: string | null }>) =>
+    new Map(Object.entries(entries));
+
+  it('name is alphabetical (the default)', () => {
+    const sorted = sortBundles([bundle('b.com'), bundle('a.com')], 'name', new Map());
+    expect(sorted.map((b) => b.name)).toEqual(['a.com', 'b.com']);
+  });
+
+  it('used puts the most recently used first, never-used last (alphabetical within)', () => {
+    const sorted = sortBundles(
+      [bundle('z-no-use'), bundle('old.com', '2026-01-01T00:00:00.000Z'), bundle('recent.com', '2026-08-01T00:00:00.000Z'), bundle('a-no-use')],
+      'used',
+      new Map(),
+    );
+    expect(sorted.map((b) => b.name)).toEqual(['recent.com', 'old.com', 'a-no-use', 'z-no-use']);
+  });
+
+  it('used falls back to the activity DB last_used when the bundle stamp is absent', () => {
+    const sorted = sortBundles(
+      [bundle('stale.com'), bundle('fresh.com')],
+      'used',
+      usage({ 'fresh.com': { useCount: 1, lastUsedAt: '2026-08-01T00:00:00.000Z' } }),
+    );
+    expect(sorted.map((b) => b.name)).toEqual(['fresh.com', 'stale.com']);
+  });
+
+  it('freq puts the highest recorded use count first, unrecorded bundles as 0', () => {
+    const sorted = sortBundles(
+      [bundle('rare.com'), bundle('often.com'), bundle('never.com')],
+      'freq',
+      usage({
+        'often.com': { useCount: 42, lastUsedAt: null },
+        'rare.com': { useCount: 2, lastUsedAt: null },
+      }),
+    );
+    expect(sorted.map((b) => b.name)).toEqual(['often.com', 'rare.com', 'never.com']);
+  });
+});
+
 
 // On macOS, `secrets create --backend file` still stores bundle METADATA in the
 // Keychain, which requires the signed `Agents CLI.app` helper. GitHub macOS CI

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -94,6 +94,12 @@ import { readMeta } from '../lib/state.js';
 import { parseDuration } from '../lib/hooks/cache.js';
 import { emit, query } from '../lib/events.js';
 import { emitSecretAudit } from '../lib/secrets/audit.js';
+import {
+  recordSecretActivity,
+  listBundleUsage,
+  getBundleUsage,
+  getRecentBundleEvents,
+} from '../lib/secrets/activity.js';
 import { frequentlyPromptedBundles } from '../lib/secrets/unlock-hints.js';
 import { registerCommandGroups, setHelpSections } from '../lib/help.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
@@ -594,8 +600,35 @@ export function formatHoldWindow(ms: number): string {
 /** Below this width the fixed date columns no longer fit; `list` uses cards. */
 const SECRETS_WIDE = 96;
 
+/** Sort keys accepted by `agents secrets list --sort`. */
+export type SecretsListSort = 'name' | 'used' | 'freq';
+
+/**
+ * Sort bundles for `secrets list`. `name` is the default alphabetical order
+ * (what listBundles already returns). `used` puts the most recently used first
+ * (never-used last, alphabetical within ties); `freq` puts the highest
+ * recorded use count first (unrecorded bundles count as 0). Pure — unit-tested.
+ */
+export function sortBundles(
+  bundles: SecretsBundle[],
+  sort: SecretsListSort,
+  usage: Map<string, { useCount: number; lastUsedAt: string | null }>,
+): SecretsBundle[] {
+  if (sort === 'name') return [...bundles].sort((a, b) => a.name.localeCompare(b.name));
+  const usedMs = (b: SecretsBundle): number => {
+    const iso = b.last_used ?? usage.get(b.name)?.lastUsedAt ?? null;
+    const t = iso ? Date.parse(iso) : NaN;
+    return Number.isFinite(t) ? t : -1;
+  };
+  if (sort === 'used') {
+    return [...bundles].sort((a, b) => usedMs(b) - usedMs(a) || a.name.localeCompare(b.name));
+  }
+  const freq = (b: SecretsBundle): number => usage.get(b.name)?.useCount ?? 0;
+  return [...bundles].sort((a, b) => freq(b) - freq(a) || a.name.localeCompare(b.name));
+}
+
 /** Format a single bundle as a table row for the `secrets list` output. */
-function renderBundleRow(b: SecretsBundle, held?: Map<string, number>, cols = terminalWidth()): string {
+function renderBundleRow(b: SecretsBundle, held?: Map<string, number>, cols = terminalWidth(), useCount = 0): string {
   const entries = describeBundle(b);
   const keys = entries.length;
   const expiringCount = countExpiringSoon(b.meta);
@@ -618,7 +651,8 @@ function renderBundleRow(b: SecretsBundle, held?: Map<string, number>, cols = te
     `${padVisible(expiring, 9)} ` +
     `${padVisible(created, 9)} ` +
     `${padVisible(updated, 9)} ` +
-    `${padVisible(used, 7)}`;
+    `${padVisible(used, 7)} ` +
+    `${String(useCount).padEnd(5)}`;
   // Mark non-keychain bundles so `list` distinguishes storage at a glance.
   const tag = b.backend === 'file'
     ? chalk.magenta('[file] ')
@@ -626,17 +660,21 @@ function renderBundleRow(b: SecretsBundle, held?: Map<string, number>, cols = te
       ? chalk.blue('[synced] ')
       : '';
   // Cap the free-form description to whatever space is left on the line so a long
-  // description can't push the row to 200+ chars and wrap into a smear.
+  // description can't push the row to 200+ chars and wrap into a smear. A bundle
+  // without a description gets a loud marker instead — context is what makes a
+  // bundle usable by an agent that didn't create it.
   const budget = cols - stringWidth(head) - 1 - stringWidth(tag);
   const desc = b.description && budget > 3
     ? chalk.gray(truncateToWidth(safePrint(b.description), budget))
-    : '';
+    : !b.description
+      ? chalk.yellow('no description')
+      : '';
   const trailer = `${tag}${desc}`.trimEnd();
   return trailer ? `${head} ${trailer}` : head.trimEnd();
 }
 
 /** Narrow-terminal card: name + compact meta on one line, description below. */
-function renderBundleCard(b: SecretsBundle, held: Map<string, number> | undefined, cols: number): string {
+function renderBundleCard(b: SecretsBundle, held: Map<string, number> | undefined, cols: number, useCount = 0): string {
   const keys = describeBundle(b).length;
   const used = b.last_used ? relativeAge(b.last_used) : (b.created_at ? 'never' : '?');
   const tag = b.backend === 'file'
@@ -644,9 +682,12 @@ function renderBundleCard(b: SecretsBundle, held: Map<string, number> | undefine
     : b.backend === 'vault'
       ? chalk.blue(' [synced]')
       : '';
-  const meta = chalk.gray(`${keys} key${keys === 1 ? '' : 's'} · `) + renderPolicyCol(b, held) + chalk.gray(` · used ${used}`);
+  const uses = useCount > 0 ? chalk.gray(` · ${useCount} use${useCount === 1 ? '' : 's'}`) : '';
+  const meta = chalk.gray(`${keys} key${keys === 1 ? '' : 's'} · `) + renderPolicyCol(b, held) + chalk.gray(` · used ${used}`) + uses;
   const line1 = `${chalk.cyan(b.name)}  ${meta}${tag}`;
-  if (!b.description) return line1;
+  if (!b.description) {
+    return `${line1}\n    ${chalk.yellow(`No description found — add one: agents secrets describe ${b.name} "what these keys are for"`)}`;
+  }
   return `${line1}\n    ${chalk.gray(truncateToWidth(safePrint(b.description), cols - 4))}`;
 }
 
@@ -828,37 +869,47 @@ export function registerSecretsCommands(program: Command): void {
 
   setHelpSections(cmd, {
     examples: `
-      # Create a bundle
-      agents secrets create prod --description "Production keys for the api stack"
+      # Create a bundle, named after where the credentials belong
+      agents secrets create anthropic.com --description "Anthropic/Claude credentials"
 
       # Add a keychain-backed secret (prompts for the value)
-      agents secrets add prod STRIPE_API_KEY
+      agents secrets add anthropic.com ANTHROPIC_API_KEY
 
       # Add a non-sensitive literal
-      agents secrets add prod LOG_LEVEL --value info
+      agents secrets add anthropic.com LOG_LEVEL --value info
 
       # Inject the bundle into an agent run
-      agents run claude "deploy the worker" --secrets prod
+      agents run claude "deploy the worker" --secrets anthropic.com
 
-      # See what's in the bundle (values masked); shows its prompt policy
-      agents secrets view prod
+      # See what's in the bundle (values masked); shows lock state + activity
+      agents secrets view anthropic.com
+
+      # List bundles by how often / how recently they're used
+      agents secrets list --sort freq
 
       # Stop a noisy automation bundle from prompting every run: ask once a week
-      agents secrets policy prod hold
+      agents secrets policy anthropic.com hold
 
       # Eval the bundle into your current shell
-      eval "$(agents secrets export prod --plaintext)"
+      eval "$(agents secrets export anthropic.com --plaintext)"
 
       # Push the bundle to remote machine(s) over SSH (lands as a native bundle there)
-      agents secrets export prod --host yosemite-s0 --host yosemite-s1 --force
+      agents secrets export anthropic.com --host yosemite-s0 --host yosemite-s1 --force
 
       # Run a one-off command with secrets injected
-      agents secrets exec prod -- ./deploy.sh
+      agents secrets exec anthropic.com -- ./deploy.sh
     `,
     notes: `
       Bundles are containers; secrets are the variables inside them. Keychain values
       never touch disk in plaintext. Every item is device-local and gated by Touch ID
       or device passcode; cross-machine sync is handled by 'agents secrets push/pull'.
+
+      Naming: prefer a name that says WHERE the credentials belong, suffix included —
+      a domain for websites ('anthropic.com', 'claude.ai', 'github.com') and the
+      binary suffix for desktop apps ('photoshop.app', 'slack.exe'). An agent
+      reading 'agents secrets list' should know the target from the name alone.
+      Always add a description ('create --description' or 'agents secrets describe
+      <name> ...'); bundles without one are flagged in list/view.
 
       Touch ID noise: macOS pops a prompt per bundle per process. Each bundle has
       a prompt policy, shown in the POLICY column of 'agents secrets list':
@@ -902,18 +953,21 @@ export function registerSecretsCommands(program: Command): void {
     .command('list')
     .alias('ls')
     .description('List configured secrets bundles (use --host/--hosts to list bundles on other machines over SSH)')
+    .addOption(new Option('--sort <key>', 'Sort order: name (default), used (most recently used first), or freq (most used first — from the local activity DB)').choices(['name', 'used', 'freq']))
     .option('--host <target>', 'List bundles on a remote host over SSH (enrolled `agents hosts` name, ssh-config alias, or user@host)')
     .option('--hosts <list>', 'Comma-separated hosts to list in one shot, e.g. yosemite-s0,yosemite-s1')
     .option('--device <target>', 'Alias for --host')
     .option('--devices <list>', 'Alias for --hosts')
     .option('--json', 'Emit machine-readable JSON (bundle metadata only — never secret values) instead of the table')
-    .action(async (opts: { host?: string; hosts?: string; device?: string; devices?: string; json?: boolean }) => {
+    .action(async (opts: { sort?: SecretsListSort; host?: string; hosts?: string; device?: string; devices?: string; json?: boolean }) => {
       const targets = parseHostsOption(opts);
       if (targets.length > 0) {
-        await browseRemote(targets, opts.json ? ['list', '--json'] : ['list'], false);
+        const remoteArgs = ['list', ...(opts.sort ? ['--sort', opts.sort] : [])];
+        await browseRemote(targets, opts.json ? [...remoteArgs, '--json'] : remoteArgs, false);
         return;
       }
-      const bundles = listBundles();
+      const usage = listBundleUsage();
+      const bundles = sortBundles(listBundles(), opts.sort ?? 'name', usage);
       // Cross-reference the secrets-agent so `hold` bundles that are currently
       // held can show "· held Nh". Soft-fails to no hint if the broker is down.
       const held = new Map<string, number>();
@@ -939,6 +993,7 @@ export function registerSecretsCommands(program: Command): void {
           createdAt: b.created_at ?? null,
           updatedAt: b.updated_at ?? null,
           lastUsed: b.last_used ?? null,
+          useCount: usage.get(b.name)?.useCount ?? 0,
           heldExpiresAt: held.get(b.name) ?? null,
         }));
         process.stdout.write(JSON.stringify(payload) + '\n');
@@ -952,15 +1007,24 @@ export function registerSecretsCommands(program: Command): void {
       const cols = terminalWidth();
       if (cols >= SECRETS_WIDE) {
         console.log(chalk.bold(
-          `${'NAME'.padEnd(20)} ${'KEYS'.padEnd(5)} ${'POLICY'.padEnd(18)} ${'EXPIRING'.padEnd(9)} ${'CREATED'.padEnd(9)} ${'UPDATED'.padEnd(9)} ${'USED'.padEnd(7)} DESCRIPTION`,
+          `${'NAME'.padEnd(20)} ${'KEYS'.padEnd(5)} ${'POLICY'.padEnd(18)} ${'EXPIRING'.padEnd(9)} ${'CREATED'.padEnd(9)} ${'UPDATED'.padEnd(9)} ${'USED'.padEnd(7)} ${'USES'.padEnd(5)} DESCRIPTION`,
         ));
         for (const b of bundles) {
-          console.log(renderBundleRow(b, held, cols));
+          console.log(renderBundleRow(b, held, cols, usage.get(b.name)?.useCount ?? 0));
         }
       } else {
         for (const b of bundles) {
-          console.log(renderBundleCard(b, held, cols));
+          console.log(renderBundleCard(b, held, cols, usage.get(b.name)?.useCount ?? 0));
         }
+      }
+      // Undescribed bundles are context-free to any agent that didn't create
+      // them — say so once, with the fix, instead of leaving blank cells.
+      const undescribed = bundles.filter((b) => !b.description);
+      if (undescribed.length > 0) {
+        console.log(chalk.yellow(
+          `⚠ ${undescribed.length} bundle${undescribed.length === 1 ? '' : 's'} missing a description (${undescribed.slice(0, 3).map((b) => b.name).join(', ')}${undescribed.length > 3 ? ', …' : ''}). ` +
+          `Add one: agents secrets describe <name> "what these keys are for"`,
+        ));
       }
     });
 
@@ -1004,6 +1068,18 @@ export function registerSecretsCommands(program: Command): void {
           process.exit(1);
         }
         const entries = describeBundle(bundle);
+        recordSecretActivity({ bundle: bundle.name, kind: 'view', source: 'view' });
+        // Lock state is whole-bundle (the broker holds resolved envs, never
+        // single keys) — surface it so `view` answers "is this unlocked right
+        // now?" instead of leaving the user to cross-reference `secrets status`.
+        let heldExpiresAt: number | null = null;
+        if (process.platform === 'darwin') {
+          try {
+            heldExpiresAt = (await agentStatus()).find((e) => e.name === bundle.name)?.expiresAt ?? null;
+          } catch {
+            /* broker not running — nothing is held */
+          }
+        }
         if (opts.json) {
           // Machine-readable discovery for agents. Values are null unless --reveal
           // (which still routes through the same non-TTY/plaintext gate + audit
@@ -1066,6 +1142,10 @@ export function registerSecretsCommands(program: Command): void {
               createdAt: bundle.created_at ?? null,
               updatedAt: bundle.updated_at ?? null,
               lastUsed: bundle.last_used ?? null,
+              locked: heldExpiresAt === null,
+              heldExpiresAt,
+              useCount: getBundleUsage(bundle.name)?.useCount ?? 0,
+              recentActivity: getRecentBundleEvents(bundle.name, 5),
               revealed: reveal,
               keys,
             }) + '\n',
@@ -1073,7 +1153,11 @@ export function registerSecretsCommands(program: Command): void {
           return;
         }
         console.log(chalk.bold(bundle.name));
-        if (bundle.description) console.log(chalk.gray(safePrint(bundle.description)));
+        if (bundle.description) {
+          console.log(chalk.gray(safePrint(bundle.description)));
+        } else {
+          console.log(chalk.yellow(`No description found — add one: agents secrets describe ${bundle.name} "what these keys are for"`));
+        }
         if (bundle.allow_exec) console.log(chalk.yellow('allow_exec: true'));
         if (bundle.backend === 'file') console.log(chalk.gray('backend: file (passphrase-encrypted; reads need AGENTS_SECRETS_PASSPHRASE, no Touch ID)'));
         if (bundle.backend === 'vault') console.log(chalk.gray('storage: synced (age-encrypted ~/.agents/vault.age; needs agents login)'));
@@ -1085,10 +1169,26 @@ export function registerSecretsCommands(program: Command): void {
               ? chalk.gray('policy: hold (ask once, then held for the hold window — 7d by default — until sleep / logout; screen-lock does not drop it)')
               : chalk.gray('policy: always (asks for Touch ID every time — never auto-held)'),
           );
+          console.log(
+            heldExpiresAt
+              ? chalk.green(`lock: unlocked — held by the secrets agent (expires in ${compactRemaining(heldExpiresAt)})`)
+              : chalk.gray('lock: locked — the next read will prompt per policy'),
+          );
         }
         if (bundle.created_at) console.log(chalk.gray(`created_at: ${bundle.created_at} (${humanAge(bundle.created_at)})`));
         if (bundle.updated_at) console.log(chalk.gray(`updated_at: ${bundle.updated_at} (${humanAge(bundle.updated_at)})`));
         if (bundle.last_used) console.log(chalk.gray(`last_used:  ${bundle.last_used} (${humanAge(bundle.last_used)})`));
+        // Usage history from the local activity DB (~/.agents/secrets/secrets.db)
+        // — the import/export/access trail an operator needs to answer "when did
+        // this credential last move?".
+        const usageStats = getBundleUsage(bundle.name);
+        const recentEvents = getRecentBundleEvents(bundle.name, 5);
+        if ((usageStats?.useCount ?? 0) > 0 || recentEvents.length > 0) {
+          console.log(chalk.gray(`activity:   ${usageStats?.useCount ?? 0} use${(usageStats?.useCount ?? 0) === 1 ? '' : 's'} recorded`));
+          for (const ev of recentEvents) {
+            console.log(chalk.gray(`  ${humanAge(ev.ts)}  ${ev.kind}${ev.detail ? `  ${ev.detail}` : ''}`));
+          }
+        }
         console.log();
         if (entries.length === 0) {
           console.log(chalk.gray('(no keys)'));
@@ -1256,6 +1356,16 @@ export function registerSecretsCommands(program: Command): void {
     .option('--backend <backend>', 'storage backend: keychain or file (defaults to agents.yaml secrets.backend)')
     .option('--synced', 'Store this bundle in the age-encrypted synced secrets file for user-managed cross-machine file sync')
     .option('--force', 'Overwrite an existing bundle')
+    .addHelpText('after', `
+Naming: prefer a name that says WHERE the credentials belong, suffix included —
+a domain for websites, the binary suffix for desktop apps:
+  agents secrets create anthropic.com --description "Anthropic/Claude credentials"
+  agents secrets create github.com    --description "GitHub PAT + username"
+  agents secrets create photoshop.app --description "Adobe Photoshop license key"
+  agents secrets create slack.exe     --description "Slack desktop token (Windows)"
+Always pass --description (or run 'agents secrets describe <name> ...' after);
+bundles without one are flagged in 'agents secrets list' and 'view'.
+`)
     .action(async (name: string | undefined, opts: { description?: string; allowExec?: boolean; policy?: string; tier?: string; iUnderstand?: boolean; backend?: string; synced?: boolean; force?: boolean }) => {
       try {
         const resolvedName = name ?? (await promptBundleName());
@@ -1285,6 +1395,7 @@ export function registerSecretsCommands(program: Command): void {
           vars: {},
         };
         writeBundle(bundle);
+        recordSecretActivity({ bundle: resolvedName, kind: 'create', source: 'create' });
         const policyTag = bundlePolicy(bundle) === 'hold'
           ? 'policy: hold'
           : bundlePolicy(bundle) === 'always'
@@ -1296,6 +1407,9 @@ export function registerSecretsCommands(program: Command): void {
           backend === 'vault' ? 'synced' : null,
         ].filter(Boolean);
         console.log(chalk.green(`Bundle '${resolvedName}' created (${tags.join(', ')}).`));
+        if (!opts.description) {
+          console.log(chalk.yellow(`No description found — add one: agents secrets describe ${resolvedName} "what these keys are for"`));
+        }
         if (bundlePolicy(bundle) === 'never') {
           console.log(chalk.red('Stored without biometry protection — reads are silent. Automation-only; rotate anything sensitive out of it.'));
         }
@@ -1718,6 +1832,7 @@ Examples:
           const resolvedBundleName = bundleName ?? (await pickBundleName('import into'));
           const bundle = resolveImportBundle(resolvedBundleName, opts.backend, opts.synced);
           const { added, skipped } = applyEnvToBundle(bundle, env, opts);
+          recordSecretActivity({ bundle: resolvedBundleName, kind: 'import', detail: `--from-file ${opts.fromFile}`, source: 'import' });
           console.log(chalk.green(`Imported ${added} key(s) from file${skipped ? `, skipped ${skipped} (already set, pass --force)` : ''}.`));
           return;
         }
@@ -1732,6 +1847,7 @@ Examples:
           const env = await remoteResolveEnv(target, resolvedBundleName, { osLookupName: opts.host });
           const bundle = resolveImportBundle(resolvedBundleName, opts.backend, opts.synced);
           const { added, skipped } = applyEnvToBundle(bundle, env, opts);
+          recordSecretActivity({ bundle: resolvedBundleName, kind: 'import', detail: `--from-ssh ${opts.host}`, source: 'import' });
           console.log(chalk.green(`Imported ${added} key(s) from ${opts.host}${skipped ? `, skipped ${skipped} (already set, pass --force)` : ''}.`));
           return;
         }
@@ -1773,11 +1889,13 @@ Examples:
           if (opSkipped.length) {
             console.log(chalk.yellow(`Skipped ${opSkipped.length} item(s) with no importable fields.`));
           }
+          recordSecretActivity({ bundle: resolvedBundleName, kind: 'import', detail: `--from 1password:${vault}`, source: 'import' });
           console.log(chalk.green(`Imported ${added} key(s) from 1Password vault '${vault}'${skipped ? `, skipped ${skipped} (already set, pass --force)` : ''}.`));
         } else {
           const raw = readImportDotenv(source.path);
           const pairs = parseDotenv(raw);
           const { added, skipped } = applyEnvToBundle(bundle, pairs, opts);
+          recordSecretActivity({ bundle: resolvedBundleName, kind: 'import', detail: `--from ${source.path}`, source: 'import' });
           console.log(chalk.green(`Imported ${added} key(s)${skipped ? `, skipped ${skipped} (already set, pass --force)` : ''}.`));
         }
       } catch (err) {
@@ -1828,6 +1946,7 @@ Examples:
           }
           const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
           exportBundleToFile(env, opts.toFile, passphrase);
+          recordSecretActivity({ bundle: resolvedBundleName, kind: 'export', detail: `--to-file ${opts.toFile}`, source: 'export' });
           console.log(chalk.green(`Exported ${Object.keys(env).length} key(s) to ${opts.toFile}`));
           return;
         }
@@ -1939,6 +2058,7 @@ Examples:
             console.log(chalk.green(`${host} -> '${resolvedBundleName}': ${remoteMsg || `${keyCount} key(s) exported`}`));
           }
           if (failures > 0) process.exit(1);
+          recordSecretActivity({ bundle: resolvedBundleName, kind: 'export', detail: `--host ${hosts.join(',')}`, source: 'export' });
           return;
         }
 
@@ -1968,6 +2088,7 @@ Examples:
           if (created) parts.push(`${created} created`);
           if (overwritten) parts.push(`${overwritten} overwritten`);
           if (skipped) parts.push(`${skipped} skipped (already exist, pass --force)`);
+          recordSecretActivity({ bundle: resolvedBundleName, kind: 'export', detail: `--to-1password ${vault}`, source: 'export' });
           console.log(chalk.green(`Exported to 1Password vault '${vault}': ${parts.join(', ')}.`));
           return;
         }
@@ -1990,6 +2111,7 @@ Examples:
           keyMode: 'process',
           agentOnly: isHeadlessSecretsContext(),
         });
+        recordSecretActivity({ bundle: resolvedBundleName, kind: 'export', detail: `--plaintext${opts.format === 'json' ? ' --format json' : ''}`, source: 'export' });
         if (opts.format === 'json') {
           // Machine-readable form consumed by `remoteResolveEnv` over SSH.
           // Single object of injected env KEY -> value; values verbatim.

--- a/apps/cli/src/lib/secrets/activity.test.ts
+++ b/apps/cli/src/lib/secrets/activity.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the secrets activity DB (~/.agents/secrets/secrets.db).
+ *
+ * Both layers on the real path, mirroring audit.test.ts:
+ *  1. `recordSecretActivity` writes metadata-only events to a real SQLite DB in
+ *     a temp dir, maintains the use_count / last_used_at aggregates (access
+ *     events only), and honors the AGENTS_NO_USAGE_TRACK kill-switch.
+ *  2. The real read chokepoint (`readAndResolveBundleEnv`, file backend with
+ *     real AES-GCM crypto) records an `access` event — the event that powers
+ *     `agents secrets list --sort freq` and the view activity section.
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Database from '../sqlite.js';
+import {
+  recordSecretActivity,
+  getBundleUsage,
+  listBundleUsage,
+  getRecentBundleEvents,
+  secretsActivityDbPath,
+  _resetSecretsActivityForTest,
+} from './activity.js';
+import {
+  bundleItemStore,
+  keychainRef,
+  readAndResolveBundleEnv,
+  writeBundle,
+  type SecretsBundle,
+} from './bundles.js';
+import { _resetFileStoreForTest } from './filestore.js';
+import { secretsKeychainItem, setKeychainBackendForTest, type KeychainBackend } from './index.js';
+
+const tmpDirs: string[] = [];
+function tempDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-secret-activity-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+/** Point the activity DB at a temp path and re-open it fresh. */
+function setupDb(): string {
+  const dbPath = path.join(tempDir(), 'secrets.db');
+  _resetSecretsActivityForTest(dbPath);
+  return dbPath;
+}
+
+let prevNoUsage: string | undefined;
+beforeEach(() => {
+  // tests/setup.ts sets the kill-switch globally; these tests exercise the
+  // tracking itself, so lift it (restored in afterEach).
+  prevNoUsage = process.env.AGENTS_NO_USAGE_TRACK;
+  delete process.env.AGENTS_NO_USAGE_TRACK;
+});
+
+afterEach(() => {
+  if (prevNoUsage === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+  else process.env.AGENTS_NO_USAGE_TRACK = prevNoUsage;
+  _resetSecretsActivityForTest();
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+  tmpDirs.length = 0;
+});
+
+describe('recordSecretActivity', () => {
+  it('records metadata-only events and bumps use_count on access only', () => {
+    setupDb();
+    recordSecretActivity({ bundle: 'anthropic.com', kind: 'create', source: 'create' });
+    recordSecretActivity({ bundle: 'anthropic.com', kind: 'import', detail: '--from .env', source: 'import' });
+    recordSecretActivity({ bundle: 'anthropic.com', kind: 'access' });
+    recordSecretActivity({ bundle: 'anthropic.com', kind: 'access' });
+    recordSecretActivity({ bundle: 'anthropic.com', kind: 'view', source: 'view' });
+
+    const usage = getBundleUsage('anthropic.com');
+    expect(usage).not.toBeNull();
+    expect(usage!.useCount).toBe(2); // access events only — views don't inflate freq
+    expect(usage!.lastUsedAt).not.toBeNull();
+
+    const events = getRecentBundleEvents('anthropic.com', 10);
+    expect(events.map((e) => e.kind)).toEqual(['view', 'access', 'access', 'import', 'create']);
+    // Metadata only — no event may carry a secret value.
+    for (const e of events) {
+      expect(e).not.toHaveProperty('value');
+      expect(JSON.stringify(e)).not.toContain('sk-');
+    }
+  });
+
+  it('getRecentBundleEvents is newest-first and honors the limit', () => {
+    setupDb();
+    for (let i = 0; i < 8; i++) {
+      recordSecretActivity({ bundle: 'b', kind: 'view', detail: `view #${i}` });
+    }
+    const events = getRecentBundleEvents('b', 5);
+    expect(events).toHaveLength(5);
+    expect(events[0].detail).toBe('view #7');
+    expect(events[4].detail).toBe('view #3');
+  });
+
+  it('listBundleUsage returns aggregates for every recorded bundle', () => {
+    setupDb();
+    recordSecretActivity({ bundle: 'a.com', kind: 'access' });
+    recordSecretActivity({ bundle: 'a.com', kind: 'access' });
+    recordSecretActivity({ bundle: 'b.app', kind: 'access' });
+    recordSecretActivity({ bundle: 'c.ai', kind: 'create' }); // no access — no row
+
+    const usage = listBundleUsage();
+    expect(usage.get('a.com')?.useCount).toBe(2);
+    expect(usage.get('b.app')?.useCount).toBe(1);
+    expect(usage.has('c.ai')).toBe(false);
+  });
+
+  it('honors the AGENTS_NO_USAGE_TRACK kill-switch', () => {
+    setupDb();
+    process.env.AGENTS_NO_USAGE_TRACK = '1';
+    recordSecretActivity({ bundle: 'prod', kind: 'access' });
+    expect(getBundleUsage('prod')).toBeNull();
+    expect(getRecentBundleEvents('prod')).toEqual([]);
+  });
+
+  it('prunes events older than the retention window on open', () => {
+    const dbPath = setupDb();
+    recordSecretActivity({ bundle: 'prod', kind: 'view', detail: 'recent' });
+    _resetSecretsActivityForTest();
+    // Backdate one event beyond the 90d retention window directly in SQLite,
+    // then re-open — the open path prunes it.
+    const db = new Database(dbPath);
+    db.prepare(`UPDATE events SET ts = ? WHERE detail = 'recent'`).run(
+      new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString(),
+    );
+    db.close();
+    _resetSecretsActivityForTest(dbPath);
+    recordSecretActivity({ bundle: 'prod', kind: 'view', detail: 'fresh' });
+    const events = getRecentBundleEvents('prod', 10);
+    expect(events.map((e) => e.detail)).toEqual(['fresh']);
+  });
+
+  it('uses AGENTS_SECRETS_DB_PATH when set', () => {
+    const dbPath = path.join(tempDir(), 'custom.db');
+    process.env.AGENTS_SECRETS_DB_PATH = dbPath;
+    try {
+      _resetSecretsActivityForTest();
+      expect(secretsActivityDbPath()).toBe(dbPath);
+    } finally {
+      delete process.env.AGENTS_SECRETS_DB_PATH;
+    }
+  });
+});
+
+describe('secret access activity — real read path (file backend)', () => {
+  let restore: KeychainBackend | null = null;
+  const PASS = 'activity-test-passphrase';
+
+  beforeEach(() => {
+    setupDb();
+    const store = new Map<string, { value: string }>();
+    const backend: KeychainBackend = {
+      has: (i) => store.has(i),
+      get: (i) => { const v = store.get(i); if (!v) throw new Error(`missing ${i}`); return v.value; },
+      set: (i, v) => { store.set(i, { value: v }); },
+      delete: (i) => store.delete(i),
+      list: (p) => [...store.keys()].filter((k) => k.startsWith(p)),
+    };
+    restore = setKeychainBackendForTest(backend);
+    process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+    _resetFileStoreForTest({ fileDir: tempDir(), passphrase: PASS });
+  });
+
+  afterEach(() => {
+    setKeychainBackendForTest(restore);
+    delete process.env.AGENTS_SECRETS_PASSPHRASE;
+    _resetFileStoreForTest();
+  });
+
+  it('readAndResolveBundleEnv records an access event and bumps use_count', () => {
+    const bundle: SecretsBundle = { name: 'rel', backend: 'file', vars: {} };
+    bundleItemStore('file').set(secretsKeychainItem('rel', 'TOKEN'), 'sealed-value');
+    bundle.vars['TOKEN'] = keychainRef('TOKEN');
+    writeBundle(bundle);
+
+    const { env } = readAndResolveBundleEnv('rel', { caller: 'command deploy', agent: 'claude' });
+    expect(env.TOKEN).toBe('sealed-value'); // real decrypt happened
+
+    const usage = getBundleUsage('rel');
+    expect(usage?.useCount).toBe(1);
+    const events = getRecentBundleEvents('rel', 5);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('access');
+    // The decrypted value never enters the activity record.
+    expect(JSON.stringify(events)).not.toContain('sealed-value');
+  });
+});

--- a/apps/cli/src/lib/secrets/activity.ts
+++ b/apps/cli/src/lib/secrets/activity.ts
@@ -1,0 +1,207 @@
+/**
+ * Local secrets activity database at ~/.agents/secrets/secrets.db.
+ *
+ * Tracks the lifecycle events that matter for a credential — when a bundle was
+ * created, imported, exported, viewed, and (most importantly) accessed for
+ * injection into a run — plus per-bundle aggregates (use count, last use) that
+ * power `agents secrets list --sort used|freq` and the activity section of
+ * `agents secrets view`. The events.jsonl audit log (lib/secrets/audit.ts)
+ * records security-relevant READS for the audit surface; this DB records
+ * metadata-only usage history for operators, mirroring how sessions.db indexes
+ * session metadata. Secret values are never stored here — bundle names, event
+ * kinds, and human-readable details only.
+ *
+ * Like stampLastUsed, every write is best-effort: activity tracking must never
+ * break secret resolution, so all record paths swallow errors, and
+ * AGENTS_NO_USAGE_TRACK=1 disables recording entirely (used by tests).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from '../sqlite.js';
+import { getUserSecretsDir } from '../state.js';
+
+/** Current schema version; bump when migrations are added. */
+export const SECRETS_ACTIVITY_SCHEMA_VERSION = 1;
+
+/** The lifecycle events recorded per bundle. */
+export type SecretActivityKind = 'create' | 'import' | 'export' | 'view' | 'access';
+
+/** A single recorded activity event. */
+export interface SecretActivityEvent {
+  id: number;
+  ts: string;
+  bundle: string;
+  kind: SecretActivityKind;
+  detail: string | null;
+  agent: string | null;
+  source: string | null;
+}
+
+/** Per-bundle usage aggregates driving `--sort freq` and the view summary. */
+export interface BundleUsageStats {
+  bundle: string;
+  useCount: number;
+  lastUsedAt: string | null;
+}
+
+/** Events older than this are pruned on first open so the log stays bounded. */
+const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  bundle TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  detail TEXT,
+  agent TEXT,
+  source TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_events_bundle_ts ON events(bundle, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts DESC);
+
+CREATE TABLE IF NOT EXISTS bundle_stats (
+  bundle TEXT PRIMARY KEY,
+  use_count INTEGER NOT NULL DEFAULT 0,
+  last_used_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+`;
+
+let dbInstance: Database.Database | null = null;
+let dbPathOverride: string | null = null;
+
+/** Path to the activity DB. Honors AGENTS_SECRETS_DB_PATH (tests, sandboxes). */
+export function secretsActivityDbPath(): string {
+  if (process.env.AGENTS_SECRETS_DB_PATH) return process.env.AGENTS_SECRETS_DB_PATH;
+  if (dbPathOverride) return dbPathOverride;
+  return path.join(getUserSecretsDir(), 'secrets.db');
+}
+
+/** Open (or return the cached) activity database, creating the schema as needed. */
+function getDB(): Database.Database {
+  if (dbInstance) return dbInstance;
+  const dbPath = secretsActivityDbPath();
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  db.pragma('temp_store = MEMORY');
+  // Multiple agent processes record activity concurrently; wait rather than fail.
+  db.pragma('busy_timeout = 30000');
+  db.exec(SCHEMA);
+  db.prepare(`INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', ?)`).run(
+    String(SECRETS_ACTIVITY_SCHEMA_VERSION),
+  );
+  // Bounded retention: events are a usage history, not a compliance log (that is
+  // events.jsonl). Runs once per process, cheap on a 90-day window.
+  db.prepare(`DELETE FROM events WHERE ts < ?`).run(
+    new Date(Date.now() - EVENT_RETENTION_MS).toISOString(),
+  );
+  dbInstance = db;
+  return db;
+}
+
+/** Parameters for recordSecretActivity. */
+export interface RecordActivityParams {
+  bundle: string;
+  kind: SecretActivityKind;
+  /** Human-readable context, e.g. "--from .env" or the caller label. Never a value. */
+  detail?: string;
+  /** Harness name when the activity was performed on behalf of an agent. */
+  agent?: string;
+  /** Where the activity happened, e.g. "exec", "run --secrets", "reveal". */
+  source?: string;
+}
+
+/**
+ * Record one activity event. `access` events also bump the bundle's use_count
+ * and last_used_at aggregates (those drive `--sort freq`); the other kinds are
+ * history-only. Never throws — telemetry must not break the calling flow.
+ */
+export function recordSecretActivity(p: RecordActivityParams): void {
+  if (process.env.AGENTS_NO_USAGE_TRACK) return;
+  try {
+    const ts = new Date().toISOString();
+    const db = getDB();
+    db.prepare(
+      `INSERT INTO events(ts, bundle, kind, detail, agent, source) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(ts, p.bundle, p.kind, p.detail ?? null, p.agent ?? null, p.source ?? null);
+    if (p.kind === 'access') {
+      db.prepare(
+        `INSERT INTO bundle_stats(bundle, use_count, last_used_at) VALUES (?, 1, ?)
+         ON CONFLICT(bundle) DO UPDATE SET use_count = use_count + 1, last_used_at = excluded.last_used_at`,
+      ).run(p.bundle, ts);
+    }
+  } catch {
+    // Swallow — activity tracking is never allowed to break secret flows.
+  }
+}
+
+/** Usage aggregates for one bundle, or null when nothing has been recorded. */
+export function getBundleUsage(name: string): BundleUsageStats | null {
+  try {
+    const row = getDB()
+      .prepare(`SELECT bundle, use_count, last_used_at FROM bundle_stats WHERE bundle = ?`)
+      .get(name) as { bundle: string; use_count: number; last_used_at: string | null } | undefined;
+    if (!row) return null;
+    return { bundle: row.bundle, useCount: row.use_count, lastUsedAt: row.last_used_at };
+  } catch {
+    return null;
+  }
+}
+
+/** Usage aggregates for every recorded bundle, keyed by bundle name. */
+export function listBundleUsage(): Map<string, BundleUsageStats> {
+  const out = new Map<string, BundleUsageStats>();
+  try {
+    const rows = getDB()
+      .prepare(`SELECT bundle, use_count, last_used_at FROM bundle_stats`)
+      .all() as Array<{ bundle: string; use_count: number; last_used_at: string | null }>;
+    for (const row of rows) {
+      out.set(row.bundle, { bundle: row.bundle, useCount: row.use_count, lastUsedAt: row.last_used_at });
+    }
+  } catch {
+    // An unreadable DB must not break `secrets list` — sort hints just go empty.
+  }
+  return out;
+}
+
+/** Most recent events for a bundle, newest first. */
+export function getRecentBundleEvents(name: string, limit = 5): SecretActivityEvent[] {
+  try {
+    const rows = getDB()
+      .prepare(
+        `SELECT id, ts, bundle, kind, detail, agent, source FROM events
+         WHERE bundle = ? ORDER BY ts DESC, id DESC LIMIT ?`,
+      )
+      .all(name, limit) as Array<{
+      id: number;
+      ts: string;
+      bundle: string;
+      kind: SecretActivityKind;
+      detail: string | null;
+      agent: string | null;
+      source: string | null;
+    }>;
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+/** Test hook: close the singleton and (optionally) point it at a temp DB. */
+export function _resetSecretsActivityForTest(dbPath?: string): void {
+  try {
+    dbInstance?.close();
+  } catch {
+    /* already closed */
+  }
+  dbInstance = null;
+  dbPathOverride = dbPath ?? null;
+}

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -55,6 +55,7 @@ import {
 } from './vault.js';
 import { emit } from '../events.js';
 import { emitSecretAudit } from './audit.js';
+import { recordSecretActivity } from './activity.js';
 import { readMeta, getHelpersDir } from '../state.js';
 import { assertNameActiveInResourceProfile, filterNamesForActiveResourceProfile } from '../resource-profiles.js';
 import { agentGetSync, agentAutoLoadSync, agentGetMetaSync, agentAutoLoadMetaSync, agentEvictSync, secretsAgentAutoEnabled, secretsHoldMs } from './agent.js';
@@ -913,6 +914,9 @@ export function describeBundle(bundle: SecretsBundle): BundleEntryInfo[] {
 // Set AGENTS_NO_USAGE_TRACK=1 to disable the stamp entirely (used by tests).
 function stampLastUsed(bundle: SecretsBundle): void {
   if (process.env.AGENTS_NO_USAGE_TRACK) return;
+  // Every resolution is an access event — recorded in the activity DB even when
+  // the keychain timestamp below is throttled, so use_count stays exact.
+  recordSecretActivity({ bundle: bundle.name, kind: 'access' });
   const nowMs = Date.now();
   if (bundle.last_used) {
     const prev = Date.parse(bundle.last_used);

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -49,14 +49,16 @@ Vault providers (1Password, AWS Secrets Manager, HashiCorp Vault) are planned fo
 Create a bundle, add your keys, then pass the bundle when running agents:
 
 ```bash
-agents secrets create prod
-agents secrets add prod STRIPE_API_KEY      # prompts for value
-agents secrets add prod DATABASE_URL
+agents secrets create stripe.com --description "Stripe live keys for the billing stack"
+agents secrets add stripe.com STRIPE_API_KEY      # prompts for value
+agents secrets add stripe.com DATABASE_URL
 
-agents run claude "deploy the api" --secrets prod
+agents run claude "deploy the api" --secrets stripe.com
 ```
 
 The secrets inject as environment variables at runtime.
+
+**Naming:** prefer a name that says *where* the credentials belong, suffix included — a domain for websites (`stripe.com`, `claude.ai`, `github.com`), the binary suffix for desktop apps (`photoshop.app`, `slack.exe`). An agent reading `agents secrets list` should know the target from the name alone. Always set a description (`create --description` or `agents secrets describe <name> ...`) — bundles without one are flagged in `list` and `view`.
 
 ## "I just generated a new API key in the browser — how do I save it?"
 
@@ -94,7 +96,7 @@ The `list` command shows secrets expiring in the next 30 days. Expired secrets s
 
 ## "I have multiple accounts on one website"
 
-For browser logins, name the bundle after the domain — `x.com`, `linkedin.com`, `reddit.com` — and group keys by account handle. One bundle per site, any number of accounts inside. Every account carries a `--note` saying when to use it:
+For browser logins, name the bundle after the domain — `x.com`, `linkedin.com`, `reddit.com` — and group keys by account handle. One bundle per site, any number of accounts inside. (Same convention for desktop apps, with the binary suffix: `photoshop.app`, `slack.exe`.) Every account carries a `--note` saying when to use it:
 
 ```bash
 agents secrets create x.com --description "X/Twitter accounts. Read key notes to pick the right one."
@@ -180,4 +182,4 @@ A `biometry`-tier bundle (the default) is never auto-held — keep high-value bu
 
 ## "What else can I do?"
 
-Run `agents secrets --help` — there's more: viewing/revealing values, rotating secrets with preserved metadata, exporting to shell, organizing by environment or service.
+Run `agents secrets --help` — there's more: viewing/revealing values (the view shows the bundle's lock state and its recent create/import/export/access activity, tracked in `~/.agents/secrets/secrets.db`), sorting `list` by `--sort used|freq`, rotating secrets with preserved metadata, exporting to shell, organizing by environment or service.


### PR DESCRIPTION
## What

Four user-requested upgrades to `agents secrets`:

1. **Activity tracking in a local DB.** A small SQLite database at `~/.agents/secrets/secrets.db` (same pattern as `sessions.db`: WAL, meta-table versioning, busy_timeout via `lib/sqlite.ts`) records metadata-only lifecycle events per bundle — `create`, `import`, `export`, `view`, and `access` (every env resolution, wired through `stampLastUsed` so counts stay exact even when the keychain timestamp is throttled). Access events maintain per-bundle `use_count` / `last_used_at` aggregates; events prune after 90 days. Secret values are never stored; `AGENTS_NO_USAGE_TRACK=1` disables recording, and every write is best-effort so tracking can never break resolution.

2. **Sorting + usage surfaces in `secrets list`.** New `--sort name|used|freq` flag (forwarded to `--host` remotes), a USES column in the wide table, `· N uses` in narrow cards, and `useCount` in `--json`.

3. **Lock state + activity in `secrets view`.** The view now answers "is this unlocked right now?" — `lock: unlocked — held by the secrets agent (expires in Nh)` vs `lock: locked` (bundle-level; unlock is whole-bundle) — and shows an `activity:` section with the recent create/import/export/access trail. `--json` gains `locked`, `heldExpiresAt`, `useCount`, `recentActivity`.

4. **Description warnings + naming guidance.** A bundle without a description is flagged — `No description found — add one: agents secrets describe <name> "what these keys are for"` — in `list` (row marker + summary footer), `view`, and right after `create` without `--description`. The root help, `create --help`, and `skills/secrets/SKILL.md` now steer naming toward where the credentials belong: domain suffixes for websites (`anthropic.com`, `claude.ai`), binary suffixes for desktop apps (`photoshop.app`, `slack.exe`).

## Verification

- New `lib/secrets/activity.test.ts` (7 tests, real SQLite in temp dirs + the real `readAndResolveBundleEnv` decrypt path proving an `access` event lands with no value leakage) and `sortBundles` unit tests in `commands/secrets.test.ts`: **61 passed**.
- Neighboring suites (`bundles.test.ts`, `audit.test.ts`, `bundles.unreadable.test.ts`): **52 passed**.
- Real flow (temp HOME, file backend): `create` without description prints the warning; `export --plaintext` records access+export; `list` shows USES + no-description markers + footer hint; `list --sort freq/used` orders correctly; `view` shows the lock line and the event trail; `--json` payloads carry the new fields. Test bundles and the temp DB were cleaned up afterwards.

Docs: `apps/cli/docs/secrets.md` (command table + new Activity tracking section), `apps/cli/CHANGELOG.md` under 1.20.90, `skills/secrets/SKILL.md`.