### PR TITLE
chore(factory): cut 0.9.307 changelog section

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Factory extension are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
-## [Unreleased]
+## [0.9.307] - 2026-08-03
 
 - **Floor no longer collapses distinct sessions that arrive without an id.** A remote
   session row was keyed `remote-<host>-<sessionId>`; when the CLI could not attribute a


### PR DESCRIPTION
Release-prep PR — exempt from run evidence (pure doc edit). Renames `## [Unreleased]` to `## [0.9.307] - 2026-08-03` so `apps/factory/scripts/release.sh 0.9.307` passes its changelog gate. Contents: the instant host picker (SWR cache, #1782) + the Floor remote-key fix.