### PR TITLE
chore(factory): cut 0.9.308 changelog section

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Factory extension are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
-## [0.9.307] - 2026-08-03
+## [0.9.308] - 2026-08-03
 
 - **`Agents: Fork (Recap)` starts a new sibling with context from a session you pick.**
   It reuses `Agents: Fork (Pick Session)`'s device-aware browser and launches on
@@ -14,6 +14,8 @@ All notable changes to the Factory extension are documented here. Format follows
   inherits the historical session, so the user can ask a different question in a
   small new session after the recap appears.
   Source: `src/vscode/sessionBrowser.vscode.ts`, `src/vscode/extension.ts`.
+
+## [0.9.307] - 2026-08-03
 
 - **`Agents: Fork (Pick Host)` forks the session you are in onto a device you choose.**
   Same fork as `Agents: Fork` — same harness, same `--strategy balanced` account


### PR DESCRIPTION
Docs-only release bookkeeping.

## Why

Factory 0.9.307 was published concurrently from the commit before #1793. Inspection of the live Marketplace VSIX confirms it contains `Agents: Fork (Pick Session)` but not `agents.forkRecap`.

## Change

Moves the `Agents: Fork (Recap)` entry into a 0.9.308 section so the canonical release script can publish the merged #1793 artifact under the correct version.

## Verification

No runtime code changes. The live 0.9.307 package manifest reports version 0.9.307 and has no `agents.forkRecap` command contribution.
