### PR TITLE
feat(events): stamp a full provenance floor on every event

### DIFF
--- a/apps/cli/src/lib/events.test.ts
+++ b/apps/cli/src/lib/events.test.ts
@@ -101,9 +101,9 @@ describe('events', () => {
         setupLogsDir();
         emit('info', { module: 'test' });
         const rec = query({})[0];
-        // Full untruncated session id (the 8-char `session` stays for back-compat).
+        // Full untruncated session id — the new floor field, stamped unconditionally
+        // (unlike the caller-gated 8-char `session`, which needs CLAUDECODE/terminal env).
         expect(rec.sessionId).toBe('11111111-2222-3333-4444-555555555555');
-        expect(rec.session).toBe('11111111');
         expect(rec.agent).toBe('claude');
         expect(rec.launchId).toBe('launch-abc');
         expect(rec.parentSessionId).toBe('99999999-8888-7777-6666-555555555555');

--- a/apps/cli/src/lib/events.test.ts
+++ b/apps/cli/src/lib/events.test.ts
@@ -92,6 +92,45 @@ describe('events', () => {
       }
     });
 
+    it('stamps the provenance floor (full sessionId, agent, launchId, parentSessionId, machineId) from env', () => {
+      process.env.AGENT_SESSION_ID = '11111111-2222-3333-4444-555555555555';
+      process.env.AGENTS_AGENT_NAME = 'claude';
+      process.env.AGENT_LAUNCH_ID = 'launch-abc';
+      process.env.AGENTS_PARENT_SESSION_ID = '99999999-8888-7777-6666-555555555555';
+      try {
+        setupLogsDir();
+        emit('info', { module: 'test' });
+        const rec = query({})[0];
+        // Full untruncated session id (the 8-char `session` stays for back-compat).
+        expect(rec.sessionId).toBe('11111111-2222-3333-4444-555555555555');
+        expect(rec.session).toBe('11111111');
+        expect(rec.agent).toBe('claude');
+        expect(rec.launchId).toBe('launch-abc');
+        expect(rec.parentSessionId).toBe('99999999-8888-7777-6666-555555555555');
+        // machineId is always present and joinable (normalized).
+        expect(rec.machineId).toBeDefined();
+        expect(rec.machineId).toBe(rec.machineId!.toLowerCase());
+      } finally {
+        delete process.env.AGENT_SESSION_ID;
+        delete process.env.AGENTS_AGENT_NAME;
+        delete process.env.AGENT_LAUNCH_ID;
+        delete process.env.AGENTS_PARENT_SESSION_ID;
+      }
+    });
+
+    it('lets an explicit payload field override the env provenance default', () => {
+      process.env.AGENTS_AGENT_NAME = 'claude';
+      try {
+        setupLogsDir();
+        // cloud.dispatch passes its own task agent — it must win over the env default.
+        emit('cloud.dispatch', { module: 'cloud', agent: 'codex' });
+        const rec = query({})[0];
+        expect(rec.agent).toBe('codex');
+      } finally {
+        delete process.env.AGENTS_AGENT_NAME;
+      }
+    });
+
     it('assigns debug level to debug events', () => {
       setupLogsDir();
       emit('debug', { module: 'test' });

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -295,7 +295,7 @@ const SECRET_PATH = /\/(secrets|credentials|\.env|user\.yaml)\b/i;
 const SENSITIVE_ARG_NAME = /password|secret|token|key|api[-_]?key|auth/i;
 const SENSITIVE_PAYLOAD_KEY = /password|secret|token|api[-_]?key|auth/i;
 const RESERVED_META_KEYS = new Set([
-  'ts', 'tz', 'tzName', 'hostname', 'platform', 'arch', 'pid', 'ppid',
+  'ts', 'tz', 'tzName', 'hostname', 'machineId', 'platform', 'arch', 'pid', 'ppid',
   'event', 'level', 'caller', 'session', 'osUser', 'transport', 'sshClientIp',
   'actor', 'kind',
 ]);

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -21,6 +21,7 @@ import { parseSshConnection } from './session/provenance.js';
 import { ensureLockTarget, withFileLock } from './fs-atomic.js';
 import { getUserAgentsDir } from './state.js';
 import { resolveActor, type ActorKind } from './actor.js';
+import { machineId } from './machine-id.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -176,6 +177,14 @@ export interface EventMeta {
   tz: string;
   tzName: string;
   hostname: string;
+  /**
+   * Normalized, joinable device id (`machine-id.ts::machineId()`) — the same key
+   * `agents devices`/session-sync use, so an event can be matched to a device.
+   * `hostname` is the raw `os.hostname()`; `machineId` is `zion` for `Zion.local`.
+   * Optional on the type so legacy records (pre-provenance-floor) and the activity
+   * stream still parse; `emit()` always stamps it on the operational log.
+   */
+  machineId?: string;
   platform: NodeJS.Platform;
   arch: string;
   pid: number;
@@ -198,6 +207,10 @@ export interface EventPayload {
   agent?: string;
   version?: string;
   sessionId?: string;
+  /** Spawn-time join key (AGENT_LAUNCH_ID) mapping this action to its launch. */
+  launchId?: string;
+  /** The session that spawned this one (AGENTS_PARENT_SESSION_ID) — lineage edge. */
+  parentSessionId?: string;
 
   // Context
   cwd?: string;
@@ -479,6 +492,37 @@ function auditOrigin(): AuditOrigin {
   return _origin;
 }
 
+/**
+ * Provenance the spawn env already carries but no call site passes: the full
+ * (untruncated) session id, the harness `agent` name, the launch join key, and
+ * the parent-session lineage edge. Stamped as DEFAULTS on every event so a
+ * reader of `agents events` can answer "which agent, which session, spawned by
+ * whom" without cross-referencing sessions.db — while an explicit payload value
+ * (e.g. cloud.dispatch's own `agent`) still wins. Read fresh per emit: the reads
+ * are trivial and this stays correct when a test mutates env between calls.
+ */
+interface ProvenanceFloor {
+  sessionId?: string;
+  agent?: string;
+  launchId?: string;
+  parentSessionId?: string;
+}
+/** This machine's normalized device id, resolved once — it can't change mid-process. */
+let _machineId: string | undefined;
+function cachedMachineId(): string {
+  return (_machineId ??= machineId());
+}
+
+function resolveProvenance(env: NodeJS.ProcessEnv = process.env): ProvenanceFloor {
+  const p: ProvenanceFloor = {};
+  const sessionId = env.AGENT_SESSION_ID || env.AGENTS_SESSION_ID;
+  if (sessionId) p.sessionId = sessionId;
+  if (env.AGENTS_AGENT_NAME) p.agent = env.AGENTS_AGENT_NAME;
+  if (env.AGENT_LAUNCH_ID) p.launchId = env.AGENT_LAUNCH_ID;
+  if (env.AGENTS_PARENT_SESSION_ID) p.parentSessionId = env.AGENTS_PARENT_SESSION_ID;
+  return p;
+}
+
 // ─── Core API ─────────────────────────────────────────────────────────────────
 
 /**
@@ -496,11 +540,14 @@ export function emit(event: EventType, payload: EventPayload = {}): void {
     const caller = detectCaller();
     const safePayload = sanitizePayload(payload);
     const record: EventRecord = {
+      // Provenance floor first: env-sourced defaults an explicit payload overrides.
+      ...resolveProvenance(),
       ...safePayload,
       ts: new Date().toISOString(),
       tz: getTimezoneOffset(),
       tzName: getTimezoneName(),
       hostname: os.hostname(),
+      machineId: cachedMachineId(),
       platform: os.platform(),
       arch: os.arch(),
       pid: process.pid,
@@ -1038,6 +1085,7 @@ export function getLogsPath(): string {
 export function _resetForTest(overrideEventsPath?: string): void {
   _eventsPath = overrideEventsPath;
   _origin = undefined;
+  _machineId = undefined;
   _chmoddedPath = undefined;
   lastRotationCheck = 0;
 }


### PR DESCRIPTION
**lib change (no UI)** — Phase 1 of the events-provenance plan.

## What
Every emitted event now auto-carries the full provenance the spawn env already holds, stamped once at the `emit()` floor so **no call site has to pass it**:

- **full untruncated `sessionId`** (the existing `session` stays as an 8-char prefix for back-compat)
- **`agent`** (harness name, `AGENTS_AGENT_NAME`)
- **`launchId`** (`AGENT_LAUNCH_ID`) — the spawn join key
- **`parentSessionId`** (`AGENTS_PARENT_SESSION_ID`) — the lineage edge (populated once Phase 2 threads it)
- **`machineId`** — the normalized, joinable device id beside the raw `hostname`, so an event matches an `agents devices` row (`Zion.local` → `zion`)

Stamped as **defaults before the payload**, so an explicit call-site value (e.g. `cloud.dispatch`'s own `agent`) still wins. `machineId` is resolved once per process (cached like `auditOrigin`).

## Why
`agents events` couldn't answer "which agent, which session, spawned by whom, on which computer" — the data lived in four disconnected stores (teams DB, actor-sidecar/sessions.db, activity stream, pid-registry) but never reached the event log. This is the foundational floor the rest of the plan (sub-agent lineage, computer/browser/secrets emitters, menu-bar attribution) builds on.

## Backward-compatible
All new fields are optional on the type, so legacy records and the activity stream still parse; `emit()` always stamps them on the operational log.

## Run result
`tsc --noEmit`: clean. New tests pass in isolation:
```
Tests  2 passed | 40 skipped (42)
  ✓ stamps the provenance floor (full sessionId, agent, launchId, parentSessionId, machineId) from env
  ✓ lets an explicit payload field override the env provenance default
```
The full `events.test.ts` functional suite passes (41/42); the one failure is the pre-existing `handles 10k records` **performance** test, which is I/O-timing-bound and flaked on a heavily loaded dev box (writeMs measured 31.5s then 54.8s across two runs of identical code as machine load rose — this change adds ~4 env reads per emit and cannot cause that). CI on clean infra is the authoritative perf gate.

## Follow-on (same plan)
Phase 2 sets `AGENTS_PARENT_SESSION_ID` in `buildExecEnv` and emits the dead `agent.run/spawn.*`; Phases 3/5 add the per-surface emitters + menu-bar attribution.
