### PR TITLE
test(sessions): base ssh-peer temp homes on /tmp on macOS

### DIFF
--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -296,6 +296,16 @@ interface SessionResolverSshPeer {
   proofFile: string;
 }
 
+/**
+ * Temp base for the ssh-peer tests. The production ControlPath is
+ * `<home>/.agents/.cache/ssh/cm-%C`, and ssh appends a ~18-char listener
+ * suffix — under macOS CI's deep TMPDIR (/var/folders/<30 chars>/T/sr-XXXXXX)
+ * that blows past the 104-byte sun_path limit and every peer test fails at
+ * ControlMaster startup. `/tmp` resolves to /private/tmp (12 chars), keeping
+ * the full socket path under the limit. Linux paths are short already.
+ */
+const sshPeerTmpBase = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
+
 /** Start the real ssh2 peer and graft its ephemeral TCP listener onto the exact
  * default-port OpenSSH ControlPath the production parent will look up. */
 async function startSessionResolverSshPeer(
@@ -550,7 +560,7 @@ describe('agents sessions --resolve local-peer critical path', () => {
   });
 
   it('returns a partial fleet result when a real old peer rejects the safe resolver protocol', async () => {
-    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sr-'));
+    const tempHome = fs.mkdtempSync(path.join(sshPeerTmpBase, 'sr-'));
     let peer: SessionResolverSshPeer | undefined;
     try {
       writeUpdateCache(tempHome);
@@ -577,7 +587,7 @@ describe('agents sessions --resolve local-peer critical path', () => {
   });
 
   it('returns a partial fleet result when a real exit-zero peer emits malformed safe output', async () => {
-    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sr-'));
+    const tempHome = fs.mkdtempSync(path.join(sshPeerTmpBase, 'sr-'));
     let peer: SessionResolverSshPeer | undefined;
     try {
       writeUpdateCache(tempHome);


### PR DESCRIPTION
## What

The `agents sessions --resolve local-peer` tests (added in #1790/#1793, after 1.20.90) fail on every macOS CI leg, blocking release 1.20.91:

```
unix_listener: path "/var/folders/df/djsxfhc17x95674wsm_g8s980000gn/T/sr-ny9F69/.agents/.cache/ssh/cm-<sha>.<suffix>" too long for Unix domain socket
```

The production ControlPath is `<home>/.agents/.cache/ssh/cm-%C` and ssh appends a ~18-char listener suffix; under the macOS runner's deep TMPDIR the full socket path is ~146 bytes vs the 104-byte `sun_path` limit, so ControlMaster never starts. Linux legs are unaffected (short `/tmp`).

## Fix

Base the two ssh-peer tests' temp homes on `/tmp` on darwin (resolves to `/private/tmp`, 12 chars) — the socket must stay under the test's temp home because the production parent computes the same path from its `HOME`, so shortening the socket subpath isn't an option. One constant with the budget documented.

## Verification

Reproduced on a real Mac (zion, main HEAD): same ControlMaster failure. With this fix applied there: **ControlMaster error gone**, peer tests reach the real ssh flow. Remaining zion-only failures (`npm warn EBADENGINE` preflight, `--project` ambiguity from real on-disk sessions) are local-environment artifacts that don't occur in CI (CI's first run reached the peer fine on Linux legs; macOS legs failed only on the socket path + one flaky ENOTEMPTY cleanup that passed on rerun).

Test-only change; no production code touched.