### PR TITLE
feat(cli): agents perf — disposable SQLite latency warehouse

### DIFF
--- a/apps/cli/.changelog/next/perf-warehouse.md
+++ b/apps/cli/.changelog/next/perf-warehouse.md
@@ -1,0 +1,7 @@
+- **`agents perf` — disposable SQLite latency warehouse.** Indexed p50/p99
+  rollups for hooks, CLI commands, and `agent.run` timings without scanning the
+  audit JSONL. Warehouse lives at `~/.agents/.cache/perf/perf.db` (safe to wipe);
+  identity columns reuse sessions/events string shapes (`session_id`, `agent`,
+  `machine`, …) for soft cross-reference — no foreign keys. Hook shims spool
+  into the same DB; `agents hooks profile` reads it first. Source:
+  `apps/cli/src/lib/perf/db.ts`, `apps/cli/src/commands/perf.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -6,27 +6,53 @@ Using agents-cli as a programmatic observability layer for agent fleets.
 
 ## Command roles at a glance
 
-Five surfaces read the fleet's activity; each has one job. Reach for the one whose
+Six surfaces read the fleet's activity; each has one job. Reach for the one whose
 *consumer* and *axis* match your question, not whichever you remember first.
 
 | Command | Role (one line) | Source | Consumer |
 |---|---|---|---|
 | **`events`** | **Raw unified event stream = the audit log.** Everything: secrets access, command invocations, version/skill/mcp/team ops, browser events, plus agent milestones. `--follow` to tail, `--audit` for ops-only. | `events.jsonl` + per-session `activity/*.jsonl`, merged by `readUnifiedEvents` | Audit, debugging, monitoring (human + machine) |
+| **`perf`** | **Latency rollups.** p50/p99 for hooks, CLI commands, and `agent.run` timings. Indexed SQLite — not a full scan of the audit log. | `~/.agents/.cache/perf/perf.db` (disposable) | Humans optimizing boot/run cost + `--json` |
 | **`feed`** | **Consolidated cross-agent surface.** Open blocks (decisions agents are waiting on) + `feed post` status updates — "what needs you / what are agents saying." | `.history/feed/*` + active sessions | Humans (operator inbox) + agents (progress) |
 | **`activity`** | **Human milestone timeline.** Recent plans / PRs / worktrees / sub-agents, newest-first — a friendly lens on the milestone tier of the event stream. | `activity/*.jsonl` | Human at the terminal |
 | **`output`** | **Productivity accounting.** Token burn vs shipped output (PRs, commits) across agents — the "was it worth it" axis. (`agents cost` is the pure $-and-duration sibling.) | `sessions.db` + git/gh | Human + `--json` |
 | **`sessions`** | **Live agent roster + transcripts.** Which agents are running right now and their state; browse/read past conversation transcripts. A live process probe + transcript index, not an event log. | live pid/transcript probe + `sessions.db` | Human + `--json` |
 
-The two write-stores behind these: `~/.agents/events.jsonl` (operational audit) and
-per-session `~/.agents/.history/activity/<id>.jsonl` (agent milestones). They are
-distinct on disk and merged only at read time by
-`event-stream.ts::readUnifiedEvents` — so `events` is the union, while `activity`
-is the milestone tier on its own.
+The write-stores: `~/.agents/events.jsonl` (operational audit), per-session
+`~/.agents/.history/activity/<id>.jsonl` (agent milestones), and the disposable
+perf warehouse `~/.agents/.cache/perf/perf.db` (latency samples). Audit + activity
+are merged at read time by `event-stream.ts::readUnifiedEvents`. Perf is a
+separate SQLite file — **loss is acceptable** (under `.cache/`); it does **not**
+foreign-key into `sessions.db`, but uses the same string shapes for
+`session_id` / `session_short` / `agent` / `machine` / `actor` / `cwd` so you can
+soft-join later.
 
 For the inspection/health cluster, `agents doctor` is the canonical detector of
 which resources are configured, synced, or drifted; `agents doctor --check` is its
 scriptable CI gate (exit non-zero on drift). See
 [§Fleet health & cross-device divergence](#fleet-health--cross-device-divergence-agents-doctor).
+
+## Performance warehouse (`agents perf`)
+
+Latency samples for optimization — **not** the audit log. Implementation:
+`apps/cli/src/lib/perf/db.ts`, CLI: `apps/cli/src/commands/perf.ts`.
+
+```
+agents perf                     # summary: commands + hooks + runs
+agents perf hooks               # same as agents hooks profile (SQLite-first)
+agents perf commands --days 30  # slowest CLI entrypoints
+agents perf run --json          # agent.run / perf.timing labels
+```
+
+| Producer | Kind | How it lands |
+|---|---|---|
+| CLI `postAction` | `command.end` | Direct `recordSample` (skips the `perf` command itself) |
+| `createTimer` / `time` / `timeAsync` / `withTiming` | `perf.timing` | Best-effort from `events.ts` |
+| Hook cache/matches shims | `hook.fire` | NDJSON spool → drained into SQLite on open |
+
+**Disable:** `AGENTS_DISABLE_PERF=1`. **Redirect (tests):** `AGENTS_PERF_DB`,
+`AGENTS_PERF_SPOOL`. Retention: samples older than 30 days are pruned
+opportunistically on open. Wipe anytime: `rm -rf ~/.agents/.cache/perf`.
 
 ## Audit Event Log (`agents events`)
 

--- a/apps/cli/docs/hooks.md
+++ b/apps/cli/docs/hooks.md
@@ -161,21 +161,35 @@ When the registrar sees `cache:` on a hook, it writes a per-hook shim under `~/.
 4. If stale + `prefetch: background`, serves stale + spawns a detached refresh (cache=stale-prefetch).
 5. If stale + no prefetch, runs the real script + caches the output (cache=miss).
 6. Appends one JSONL line per fire to `~/.agents/.cache/logs/events-YYYY-MM-DD.jsonl`.
+7. Appends one NDJSON line to the disposable perf spool
+   (`~/.agents/.cache/perf/spool.jsonl`), drained into `perf.db` on the next
+   `agents perf` / `agents hooks profile` open.
 
 Stale shim files are garbage-collected automatically when a hook is renamed, deleted, or has its `cache:` field removed.
 
-### `agents hooks profile`
+### `agents hooks profile` / `agents perf hooks`
 
 ```
 agents hooks profile              # last 7 days, table form
 agents hooks profile --days 30
 agents hooks profile --json | jq
 agents hooks profile --warn-ms 500
+agents perf hooks                 # same rollup under the perf surface
 ```
 
-Aggregates `hook.fire` events into per-hook p50/p99/mean/max + cache hit rate. Any hook whose p99 exceeds `--warn-ms` (default 2000) and has no cache config gets flagged as a candidate for `cache:`.
+Aggregates hook timings into per-hook p50/p99/mean/max + cache hit rate. Primary
+source is the indexed warehouse `~/.agents/.cache/perf/perf.db` (safe to wipe).
+Falls back to the legacy daily JSONL when the warehouse is empty. Any hook whose
+p99 exceeds `--warn-ms` (default 2000) and has no cache hits gets flagged as a
+candidate for `cache:`.
 
-Only hooks with `cache:` are instrumented today — that's deliberate. Opting into the primitive is what surfaces the data. To make every hook show up, declare `cache: 5m` on it (or `cache: 1s` to effectively disable caching while still getting timing).
+Hooks are instrumented when a generated shim wraps them (`cache:` and/or
+`matches:`). To make every hook show up, declare `cache: 5m` on it (or
+`cache: 1s` to effectively disable caching while still getting timing), then
+resync.
+
+See also [`06-observability.md`](./06-observability.md) for the `agents perf`
+summary (`commands`, `run`, multi-section default).
 
 
 ### Supported Events

--- a/apps/cli/src/commands/hooks.ts
+++ b/apps/cli/src/commands/hooks.ts
@@ -710,23 +710,39 @@ Examples:
     .option('--warn-ms <n>', 'p99 threshold above which a hook is flagged as slow', '2000')
     .option('--json', 'Emit raw JSON rows instead of the table')
     .addHelpText('after', `
-Shows aggregated stats for every hook that emitted a hook.fire event into
-~/.agents/.cache/logs/events-YYYY-MM-DD.jsonl. Only hooks with \`cache:\` in
-their manifest are instrumented today — the generated shim writes the events.
+Shows aggregated stats for every hook that fired through a generated shim.
+Primary source: disposable SQLite warehouse ~/.agents/.cache/perf/perf.db
+(same data as \`agents perf hooks\`). Falls back to the legacy daily JSONL under
+~/.agents/.cache/logs/ when the warehouse is empty.
 
 Examples:
   agents hooks profile                # last 7 days, table form
   agents hooks profile --days 30      # roll up the full month
   agents hooks profile --json | jq    # pipe somewhere
+  agents perf hooks                   # same rollup under the perf surface
 
 A hook whose p99 exceeds --warn-ms gets flagged in the cache column. Add
 'cache: 5m' or 'cache: 5m-bg' to its hooks.yaml entry to fix it.
 `)
     .action(async (options: { days: string; warnMs: string; json?: boolean }) => {
       const { aggregateHookProfile, loadHookFireEvents, formatMs, formatCacheColumn, DEFAULT_SLOW_HOOK_WARN_MS } = await import('../lib/hooks/profile.js');
+      const { aggregateSamples } = await import('../lib/perf/db.js');
       const days = Math.max(1, parseInt(options.days, 10) || 7);
       const warnMs = Math.max(0, parseInt(options.warnMs, 10) || DEFAULT_SLOW_HOOK_WARN_MS);
-      const rows = aggregateHookProfile(loadHookFireEvents(days));
+      // Prefer the indexed warehouse; fall back to legacy JSONL for pre-warehouse shims.
+      const fromDb = aggregateSamples({ days, kinds: ['hook.fire'] }).map((r) => ({
+        hook: r.label,
+        n: r.n,
+        p50Ms: r.p50Ms,
+        p99Ms: r.p99Ms,
+        meanMs: r.meanMs,
+        maxMs: r.maxMs,
+        cacheHitPct: r.cacheHitPct ?? 0,
+        cacheStalePct: r.cacheStalePct ?? 0,
+        cacheMissPct: r.cacheMissPct ?? 0,
+        errorCount: r.errorCount ?? 0,
+      }));
+      const rows = fromDb.length > 0 ? fromDb : aggregateHookProfile(loadHookFireEvents(days));
 
       if (options.json) {
         console.log(JSON.stringify(rows, null, 2));
@@ -734,8 +750,8 @@ A hook whose p99 exceeds --warn-ms gets flagged in the cache column. Add
       }
 
       if (rows.length === 0) {
-        console.log(chalk.gray(`No hook.fire events in the last ${days} day${days === 1 ? '' : 's'}.`));
-        console.log(chalk.gray('Add \'cache: 5m\' to a hook in hooks.yaml to start collecting stats.'));
+        console.log(chalk.gray(`No hook.fire samples in the last ${days} day${days === 1 ? '' : 's'}.`));
+        console.log(chalk.gray('Add \'cache: 5m\' to a hook (or matches:) so a shim instruments it, then resync.'));
         return;
       }
 

--- a/apps/cli/src/commands/perf.ts
+++ b/apps/cli/src/commands/perf.ts
@@ -1,0 +1,273 @@
+/**
+ * `agents perf` — latency rollups over the disposable perf SQLite warehouse.
+ *
+ * Subcommands:
+ *   agents perf              multi-section summary (commands + hooks + runs)
+ *   agents perf hooks        per-hook p50/p99 + cache hit rates
+ *   agents perf commands     slowest CLI command paths (from command.end)
+ *   agents perf run          agent.run / perf.timing labels
+ *
+ * Soft-joins sessions.db via shared string keys (session_id, agent, machine) —
+ * no foreign keys. Warehouse lives at ~/.agents/.cache/perf/perf.db (safe to wipe).
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  aggregateSamples,
+  perfDbPath,
+  type PerfAggregateRow,
+} from '../lib/perf/db.js';
+import {
+  formatMs,
+  formatCacheColumn,
+  DEFAULT_SLOW_HOOK_WARN_MS,
+  loadHookFireEvents,
+  aggregateHookProfile,
+  type HookProfileRow,
+} from '../lib/hooks/profile.js';
+
+interface PerfGlobalOpts {
+  days?: string;
+  warnMs?: string;
+  json?: boolean;
+  limit?: string;
+}
+
+function parseDays(raw: string | undefined): number {
+  const n = parseInt(raw ?? '7', 10);
+  return Number.isFinite(n) && n > 0 ? n : 7;
+}
+
+function parseWarnMs(raw: string | undefined, fallback: number): number {
+  const n = parseInt(raw ?? String(fallback), 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function parseLimit(raw: string | undefined, fallback: number): number {
+  const n = parseInt(raw ?? String(fallback), 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Map warehouse rows shaped like hook.fire into the existing HookProfileRow UI. */
+function asHookRows(rows: PerfAggregateRow[]): HookProfileRow[] {
+  return rows.map((r) => ({
+    hook: r.label,
+    n: r.n,
+    p50Ms: r.p50Ms,
+    p99Ms: r.p99Ms,
+    meanMs: r.meanMs,
+    maxMs: r.maxMs,
+    cacheHitPct: r.cacheHitPct ?? 0,
+    cacheStalePct: r.cacheStalePct ?? 0,
+    cacheMissPct: r.cacheMissPct ?? 0,
+    errorCount: r.errorCount ?? 0,
+  }));
+}
+
+function printTable(
+  headers: string[],
+  widths: number[],
+  lines: string[][],
+  slowFlags: boolean[],
+): void {
+  const pad = (s: string, w: number) => (s.length >= w ? s.slice(0, w) : s + ' '.repeat(w - s.length));
+  const header = headers.map((h, i) => pad(h, widths[i])).join(' ');
+  console.log(chalk.bold(header));
+  console.log(chalk.gray('─'.repeat(header.length)));
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].map((c, j) => pad(c, widths[j])).join(' ');
+    console.log(slowFlags[i] ? chalk.yellow(line) : line);
+  }
+}
+
+function renderHookTable(rows: HookProfileRow[], warnMs: number): void {
+  if (rows.length === 0) {
+    console.log(chalk.gray('No hook timing samples yet.'));
+    console.log(chalk.gray(`Warehouse: ${perfDbPath()}`));
+    console.log(chalk.gray('Hooks write via cache/matches shims into the spool; run a session or resync hooks.'));
+    return;
+  }
+  const widths = { hook: 36, n: 5, p50: 7, p99: 7, mean: 7, max: 7, cache: 28 };
+  const pad = (s: string, w: number) => (s.length >= w ? s.slice(0, w) : s + ' '.repeat(w - s.length));
+  const header = [
+    pad('HOOK', widths.hook),
+    pad('N', widths.n),
+    pad('P50', widths.p50),
+    pad('P99', widths.p99),
+    pad('MEAN', widths.mean),
+    pad('MAX', widths.max),
+    pad('CACHE', widths.cache),
+  ].join(' ');
+  console.log(chalk.bold(header));
+  console.log(chalk.gray('─'.repeat(header.length)));
+  for (const r of rows) {
+    const slow = r.p99Ms > warnMs;
+    const cacheCol = formatCacheColumn(r);
+    const warning = slow && r.cacheHitPct + r.cacheStalePct === 0 ? '  ← add cache: 5m' : '';
+    const line = [
+      pad(r.hook, widths.hook),
+      pad(String(r.n), widths.n),
+      pad(formatMs(r.p50Ms), widths.p50),
+      pad(formatMs(r.p99Ms), widths.p99),
+      pad(formatMs(r.meanMs), widths.mean),
+      pad(formatMs(r.maxMs), widths.max),
+      pad(cacheCol, widths.cache),
+    ].join(' ') + warning;
+    console.log(slow ? chalk.yellow(line) : line);
+  }
+}
+
+function renderLabelTable(title: string, rows: PerfAggregateRow[], warnMs: number, limit: number): void {
+  const sliced = rows.slice(0, limit);
+  if (sliced.length === 0) {
+    console.log(chalk.gray(`No ${title} samples yet.`));
+    return;
+  }
+  const widths = [40, 5, 7, 7, 7, 7];
+  printTable(
+    ['LABEL', 'N', 'P50', 'P99', 'MEAN', 'MAX'],
+    widths,
+    sliced.map((r) => [
+      r.label,
+      String(r.n),
+      formatMs(r.p50Ms),
+      formatMs(r.p99Ms),
+      formatMs(r.meanMs),
+      formatMs(r.maxMs),
+    ]),
+    sliced.map((r) => r.p99Ms > warnMs),
+  );
+}
+
+/**
+ * Prefer SQLite samples; fall back to the legacy daily JSONL so existing
+ * instrumentation still surfaces until shims are resynced.
+ */
+function loadHookProfile(days: number): HookProfileRow[] {
+  const fromDb = asHookRows(aggregateSamples({ days, kinds: ['hook.fire'] }));
+  if (fromDb.length > 0) return fromDb;
+  return aggregateHookProfile(loadHookFireEvents(days));
+}
+
+function hooksAction(opts: PerfGlobalOpts): void {
+  const days = parseDays(opts.days);
+  const warnMs = parseWarnMs(opts.warnMs, DEFAULT_SLOW_HOOK_WARN_MS);
+  const rows = loadHookProfile(days);
+  if (opts.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  renderHookTable(rows, warnMs);
+}
+
+function commandsAction(opts: PerfGlobalOpts): void {
+  const days = parseDays(opts.days);
+  const warnMs = parseWarnMs(opts.warnMs, 500);
+  const limit = parseLimit(opts.limit, 40);
+  const rows = aggregateSamples({ days, kinds: ['command.end'] });
+  if (opts.json) {
+    console.log(JSON.stringify(rows.slice(0, limit), null, 2));
+    return;
+  }
+  renderLabelTable('command', rows, warnMs, limit);
+}
+
+function runAction(opts: PerfGlobalOpts): void {
+  const days = parseDays(opts.days);
+  const warnMs = parseWarnMs(opts.warnMs, 60_000);
+  const limit = parseLimit(opts.limit, 40);
+  const rows = aggregateSamples({ days, kinds: ['perf.timing'] });
+  if (opts.json) {
+    console.log(JSON.stringify(rows.slice(0, limit), null, 2));
+    return;
+  }
+  renderLabelTable('run/timing', rows, warnMs, limit);
+}
+
+function summaryAction(opts: PerfGlobalOpts): void {
+  const days = parseDays(opts.days);
+  if (opts.json) {
+    console.log(JSON.stringify({
+      days,
+      warehouse: perfDbPath(),
+      hooks: loadHookProfile(days),
+      commands: aggregateSamples({ days, kinds: ['command.end'] }).slice(0, 20),
+      run: aggregateSamples({ days, kinds: ['perf.timing'] }).slice(0, 20),
+    }, null, 2));
+    return;
+  }
+
+  console.log(chalk.bold(`agents perf — last ${days} day${days === 1 ? '' : 's'}`));
+  console.log(chalk.gray(`warehouse: ${perfDbPath()}  (disposable; soft-join sessions via session_id/agent/machine)`));
+  console.log('');
+
+  console.log(chalk.bold('Commands (slowest by p99)'));
+  renderLabelTable('command', aggregateSamples({ days, kinds: ['command.end'] }), parseWarnMs(opts.warnMs, 500), 12);
+  console.log('');
+
+  console.log(chalk.bold('Hooks'));
+  renderHookTable(loadHookProfile(days), parseWarnMs(opts.warnMs, DEFAULT_SLOW_HOOK_WARN_MS));
+  console.log('');
+
+  console.log(chalk.bold('Runs (perf.timing)'));
+  renderLabelTable('run/timing', aggregateSamples({ days, kinds: ['perf.timing'] }), parseWarnMs(opts.warnMs, 60_000), 12);
+}
+
+function attachSharedOptions(cmd: Command): Command {
+  return cmd
+    .option('--days <n>', 'Days of samples to include', '7')
+    .option('--warn-ms <n>', 'p99 above this is highlighted')
+    .option('--limit <n>', 'Max rows in the table', '40')
+    .option('--json', 'Emit JSON instead of a table');
+}
+
+/**
+ * Commander binds a flag declared on both parent and child to the *parent*.
+ * Merge so `agents perf commands --json` still sees json:true on the leaf.
+ */
+function leafOpts(cmd: Command): PerfGlobalOpts {
+  const parent = cmd.parent && typeof cmd.parent.opts === 'function'
+    ? (cmd.parent.opts() as PerfGlobalOpts)
+    : {};
+  return { ...parent, ...(cmd.opts() as PerfGlobalOpts) };
+}
+
+export function registerPerfCommand(program: Command): void {
+  const perf = program
+    .command('perf')
+    .description('Latency rollups from the disposable perf warehouse (hooks, commands, runs)')
+    .addHelpText('after', `
+The warehouse is SQLite at ~/.agents/.cache/perf/perf.db — safe to delete.
+Identity columns reuse sessions/events string shapes (session_id, agent, machine)
+for soft cross-reference; there are no foreign keys.
+
+Examples:
+  agents perf                     # summary: commands + hooks + runs
+  agents perf hooks               # per-hook p50/p99 + cache hit rate
+  agents perf commands --days 30  # slowest CLI entrypoints
+  agents perf run --json          # agent.run timings as JSON
+  agents perf hooks --warn-ms 500
+`);
+
+  // Options live on the parent so `agents perf --json` and
+  // `agents perf commands --json` both work (see leafOpts).
+  attachSharedOptions(perf).action(function summary(this: Command) {
+    summaryAction(this.opts() as PerfGlobalOpts);
+  });
+
+  perf.command('hooks').description('Per-hook timing + cache stats')
+    .action(function hooks(this: Command) {
+      hooksAction(leafOpts(this));
+    });
+
+  perf.command('commands').description('Slowest CLI command paths (command.end samples)')
+    .action(function commands(this: Command) {
+      commandsAction(leafOpts(this));
+    });
+
+  perf.command('run').description('agent.run / perf.timing label rollups')
+    .action(function run(this: Command) {
+      runAction(leafOpts(this));
+    });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -207,7 +207,6 @@ import type { AgentId } from './lib/types.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
 import { getCliLaunch } from './lib/cli-entry.js';
 import { emit, emitFriction, redactArgs } from './lib/events.js';
-import { recordSample } from './lib/perf/db.js';
 
 // Transparent shim delegate: the generated Windows `.cmd` shims invoke
 // `agents __shim <agent>[@version] <raw args>`. Intercept here, before commander
@@ -296,14 +295,16 @@ program.hook('postAction', (_thisCommand, actionCommand) => {
       command,
       ...(durationMs !== undefined ? { durationMs } : {}),
     });
-    // Disposable perf warehouse — fail-soft, no FK to sessions.
+    // Disposable perf warehouse — fail-soft spool append (no SQLite on this path).
     if (durationMs !== undefined && parts[0] !== 'perf') {
-      recordSample({
-        kind: 'command.end',
-        label: command,
-        durationMs,
-        cwd: process.cwd(),
-      });
+      void import('./lib/perf/spool.js').then(({ recordSample }) => {
+        recordSample({
+          kind: 'command.end',
+          label: command,
+          durationMs,
+          cwd: process.cwd(),
+        });
+      }).catch(() => { /* fail soft */ });
     }
   } catch {
     // Best-effort completion record; the start line is the durable audit fact.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -171,6 +171,7 @@ import {
   loadFactory,
   loadUsage,
   loadCost,
+  loadPerf,
   loadOutput,
   loadBudget,
   loadAlias,
@@ -206,6 +207,7 @@ import type { AgentId } from './lib/types.js';
 import { IS_WINDOWS } from './lib/platform/index.js';
 import { getCliLaunch } from './lib/cli-entry.js';
 import { emit, emitFriction, redactArgs } from './lib/events.js';
+import { recordSample } from './lib/perf/db.js';
 
 // Transparent shim delegate: the generated Windows `.cmd` shims invoke
 // `agents __shim <agent>[@version] <raw args>`. Intercept here, before commander
@@ -287,11 +289,22 @@ program.hook('postAction', (_thisCommand, actionCommand) => {
     const parts = auditCommandPath(actionCommand);
     if (parts.length === 0) return;
     const started = auditStarts.get(actionCommand);
+    const durationMs = started !== undefined ? Date.now() - started : undefined;
+    const command = parts.join(' ');
     emit('command.end', {
       module: parts[0],
-      command: parts.join(' '),
-      ...(started !== undefined ? { durationMs: Date.now() - started } : {}),
+      command,
+      ...(durationMs !== undefined ? { durationMs } : {}),
     });
+    // Disposable perf warehouse — fail-soft, no FK to sessions.
+    if (durationMs !== undefined && parts[0] !== 'perf') {
+      recordSample({
+        kind: 'command.end',
+        label: command,
+        durationMs,
+        cwd: process.cwd(),
+      });
+    }
   } catch {
     // Best-effort completion record; the start line is the durable audit fact.
   }
@@ -384,6 +397,7 @@ Credentials and profiles:
 Diagnostics:
   doctor [agent[@version]]        Diagnose CLI availability, sync status, and resource divergence; --check for the CI drift gate
   usage [agent]                   Show rate-limit and quota usage per agent
+  perf                            Latency rollups (hooks, commands, runs) from the disposable perf warehouse
 
 Config sync:
   drive                           Sync session history across machines via rsync
@@ -1039,6 +1053,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadFactory);
   await reg(loadUsage);
   await reg(loadCost);
+  await reg(loadPerf);
   await reg(loadOutput);
   await reg(loadBudget);
   await reg(loadAlias);

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -34,7 +34,7 @@ function recordPerfTiming(payload: {
 }): void {
   try {
     // Dynamic import keeps events.ts free of a load-time dependency on perf/db.
-    void import('./perf/db.js').then(({ recordSample }) => {
+    void import('./perf/spool.js').then(({ recordSample }) => {
       recordSample({
         kind: 'perf.timing',
         label: payload.label,

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -22,6 +22,35 @@ import { ensureLockTarget, withFileLock } from './fs-atomic.js';
 import { getUserAgentsDir } from './state.js';
 import { resolveActor, type ActorKind } from './actor.js';
 
+/** Lazy perf warehouse write — avoids a hard cycle at module load. */
+function recordPerfTiming(payload: {
+  label: string;
+  durationMs: number;
+  status?: string;
+  agent?: string;
+  version?: string;
+  sessionId?: string;
+  cwd?: string;
+}): void {
+  try {
+    // Dynamic import keeps events.ts free of a load-time dependency on perf/db.
+    void import('./perf/db.js').then(({ recordSample }) => {
+      recordSample({
+        kind: 'perf.timing',
+        label: payload.label,
+        durationMs: payload.durationMs,
+        status: payload.status,
+        agent: payload.agent,
+        agentVersion: payload.version,
+        sessionId: payload.sessionId,
+        cwd: payload.cwd,
+      });
+    }).catch(() => { /* fail soft */ });
+  } catch {
+    // fail soft
+  }
+}
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 // Resolved lazily: events.ts is imported transitively by most CLI surfaces, and
@@ -578,20 +607,40 @@ export function time<T>(label: string, fn: () => T, payload: EventPayload = {}):
   const start = Date.now();
   try {
     const result = fn();
+    const durationMs = Date.now() - start;
     emit('perf.timing', {
       ...payload,
       label,
-      durationMs: Date.now() - start,
+      durationMs,
       status: 'success',
+    });
+    recordPerfTiming({
+      label,
+      durationMs,
+      status: 'success',
+      agent: payload.agent,
+      version: payload.version,
+      sessionId: payload.sessionId,
+      cwd: payload.cwd,
     });
     return result;
   } catch (err) {
+    const durationMs = Date.now() - start;
     emit('perf.timing', {
       ...payload,
       label,
-      durationMs: Date.now() - start,
+      durationMs,
       status: 'error',
       error: err instanceof Error ? err.message : String(err),
+    });
+    recordPerfTiming({
+      label,
+      durationMs,
+      status: 'error',
+      agent: payload.agent,
+      version: payload.version,
+      sessionId: payload.sessionId,
+      cwd: payload.cwd,
     });
     throw err;
   }
@@ -612,20 +661,40 @@ export async function timeAsync<T>(
   const start = Date.now();
   try {
     const result = await fn();
+    const durationMs = Date.now() - start;
     emit('perf.timing', {
       ...payload,
       label,
-      durationMs: Date.now() - start,
+      durationMs,
       status: 'success',
+    });
+    recordPerfTiming({
+      label,
+      durationMs,
+      status: 'success',
+      agent: payload.agent,
+      version: payload.version,
+      sessionId: payload.sessionId,
+      cwd: payload.cwd,
     });
     return result;
   } catch (err) {
+    const durationMs = Date.now() - start;
     emit('perf.timing', {
       ...payload,
       label,
-      durationMs: Date.now() - start,
+      durationMs,
       status: 'error',
       error: err instanceof Error ? err.message : String(err),
+    });
+    recordPerfTiming({
+      label,
+      durationMs,
+      status: 'error',
+      agent: payload.agent,
+      version: payload.version,
+      sessionId: payload.sessionId,
+      cwd: payload.cwd,
     });
     throw err;
   }
@@ -661,12 +730,21 @@ export function createTimer(label: string, payload: EventPayload = {}): {
     },
     end(endPayload: EventPayload = {}): void {
       const durationMs = Date.now() - start;
+      const merged = { ...payload, ...endPayload };
       emit('perf.timing', {
-        ...payload,
-        ...endPayload,
+        ...merged,
         label,
         durationMs,
         phases: marks,
+      });
+      recordPerfTiming({
+        label,
+        durationMs,
+        status: typeof merged.status === 'string' ? merged.status : undefined,
+        agent: merged.agent,
+        version: merged.version,
+        sessionId: merged.sessionId,
+        cwd: merged.cwd,
       });
     },
   };
@@ -689,20 +767,40 @@ export function withTiming<Args extends unknown[], R>(
     const start = Date.now();
     try {
       const result = await fn(...args);
+      const durationMs = Date.now() - start;
       emit('perf.timing', {
         ...basePayload,
         label,
-        durationMs: Date.now() - start,
+        durationMs,
         status: 'success',
+      });
+      recordPerfTiming({
+        label,
+        durationMs,
+        status: 'success',
+        agent: basePayload.agent,
+        version: basePayload.version,
+        sessionId: basePayload.sessionId,
+        cwd: basePayload.cwd,
       });
       return result;
     } catch (err) {
+      const durationMs = Date.now() - start;
       emit('perf.timing', {
         ...basePayload,
         label,
-        durationMs: Date.now() - start,
+        durationMs,
         status: 'error',
         error: err instanceof Error ? err.message : String(err),
+      });
+      recordPerfTiming({
+        label,
+        durationMs,
+        status: 'error',
+        agent: basePayload.agent,
+        version: basePayload.version,
+        sessionId: basePayload.sessionId,
+        cwd: basePayload.cwd,
       });
       throw err;
     }

--- a/apps/cli/src/lib/hooks/cache-integration.test.ts
+++ b/apps/cli/src/lib/hooks/cache-integration.test.ts
@@ -28,6 +28,7 @@ describe('generated shim — bash execution', () => {
       shimsDir: path.join(tmpHome, 'shims'),
       cacheDir: path.join(tmpHome, 'cache'),
       logsDir: path.join(tmpHome, 'logs'),
+      perfDir: path.join(tmpHome, 'perf'),
     };
 
     // A real bash script the shim will invoke. It increments a counter file
@@ -123,6 +124,30 @@ echo "call=$count"
     expect(lines[0].cache).toBe('miss');
     expect(lines[1].cache).toBe('hit');
     expect(typeof lines[0].ms).toBe('number');
+  });
+
+  it('appends matching rows to the perf spool for the disposable warehouse', () => {
+    const shim = generateHookShim({
+      name: 'perf-spooled-hook',
+      scriptPath,
+      cache: { ttl: 300, key: 'global', prefetch: 'none' },
+      paths,
+    });
+
+    runShim(shim, '{}');
+    runShim(shim, '{}');
+
+    const spool = path.join(paths.perfDir!, 'spool.jsonl');
+    expect(fs.existsSync(spool)).toBe(true);
+    const lines = fs.readFileSync(spool, 'utf-8')
+      .split('\n').filter(Boolean).map(l => JSON.parse(l));
+    expect(lines.length).toBe(2);
+    expect(lines[0].kind).toBe('hook.fire');
+    expect(lines[0].label).toBe('perf-spooled-hook');
+    expect(lines[0].cache).toBe('miss');
+    expect(lines[1].cache).toBe('hit');
+    expect(typeof lines[0].duration_ms).toBe('number');
+    expect(typeof lines[0].ts_ms).toBe('number');
   });
 
   it('per-cwd key produces distinct cache files keyed on stdin cwd', () => {

--- a/apps/cli/src/lib/hooks/cache-matches.test.ts
+++ b/apps/cli/src/lib/hooks/cache-matches.test.ts
@@ -31,6 +31,7 @@ describe('generated shim — matches: gate', () => {
       shimsDir: path.join(tmpHome, 'shims'),
       cacheDir: path.join(tmpHome, 'cache'),
       logsDir: path.join(tmpHome, 'logs'),
+      perfDir: path.join(tmpHome, 'perf'),
     };
     counterFile = path.join(tmpHome, 'counter');
     fs.writeFileSync(counterFile, '0');

--- a/apps/cli/src/lib/hooks/cache.test.ts
+++ b/apps/cli/src/lib/hooks/cache.test.ts
@@ -80,7 +80,7 @@ describe('parseCacheConfig', () => {
 
 describe('generateHookShim', () => {
   let tmpHome: string;
-  let testPaths: { shimsDir: string; cacheDir: string; logsDir: string };
+  let testPaths: { shimsDir: string; cacheDir: string; logsDir: string; perfDir: string };
 
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-hook-cache-test-'));
@@ -88,6 +88,7 @@ describe('generateHookShim', () => {
       shimsDir: path.join(tmpHome, 'shims'),
       cacheDir: path.join(tmpHome, 'cache'),
       logsDir: path.join(tmpHome, 'logs'),
+      perfDir: path.join(tmpHome, 'perf'),
     };
   });
 

--- a/apps/cli/src/lib/hooks/cache.ts
+++ b/apps/cli/src/lib/hooks/cache.ts
@@ -19,7 +19,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { HookCache, HookCacheConfig, HookCacheKey, HookCachePrefetch, HookMatches } from '../types.js';
-import { getHookCacheDir, getHookShimsDir, getLogsDir } from '../state.js';
+import { getHookCacheDir, getHookShimsDir, getLogsDir, getPerfDir } from '../state.js';
 
 /**
  * Parse a `cache:` value from hooks.yaml into the canonical config form.
@@ -112,6 +112,8 @@ export interface HookShimPaths {
   shimsDir?: string;
   cacheDir?: string;
   logsDir?: string;
+  /** Directory for the disposable perf warehouse + spool (default ~/.agents/.cache/perf). */
+  perfDir?: string;
 }
 
 /**
@@ -134,8 +136,9 @@ export function generateHookShim(args: {
   const shimsDir = args.paths?.shimsDir ?? getHookShimsDir();
   const cacheDir = args.paths?.cacheDir ?? getHookCacheDir();
   const logsDir = args.paths?.logsDir ?? getLogsDir();
+  const perfDir = args.paths?.perfDir ?? getPerfDir();
   const shimPath = resolveContainedHookShimPath(shimsDir, args.name);
-  const content = renderShim(args.name, args.scriptPath, args.cache ?? null, args.matches, { cacheDir, logsDir });
+  const content = renderShim(args.name, args.scriptPath, args.cache ?? null, args.matches, { cacheDir, logsDir, perfDir });
   fs.mkdirSync(shimsDir, { recursive: true });
 
   let existing: string | null = null;
@@ -317,6 +320,12 @@ TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 LOG_FILE="$LOGS_DIR/events-$(date -u +%Y-%m-%d).jsonl"
 printf '{"ts":"%s","event":"hook.fire","hook":"%s","ms":%d,"cache":"%s","exit":%d}\\n' \\
   "$TS" "$HOOK_NAME" "$MS" "none" "$EXIT" >>"$LOG_FILE" 2>/dev/null || true
+# Disposable perf spool → drained into ~/.agents/.cache/perf/perf.db on next agents perf/open.
+mkdir -p "$PERF_DIR" 2>/dev/null || true
+TS_MS=$("$PY" -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0)
+HOST=$(hostname 2>/dev/null || echo unknown)
+printf '{"ts_ms":%s,"kind":"hook.fire","label":"%s","duration_ms":%d,"cache":"%s","exit_code":%d,"hostname":"%s"}\\n' \\
+  "$TS_MS" "$HOOK_NAME" "$MS" "none" "$EXIT" "$HOST" >>"$PERF_SPOOL" 2>/dev/null || true
 
 exit "$EXIT"`;
 
@@ -338,12 +347,13 @@ function renderShim(
   scriptPath: string,
   cache: HookCacheConfig | null,
   matches: HookMatches | undefined,
-  paths: { cacheDir: string; logsDir: string }
+  paths: { cacheDir: string; logsDir: string; perfDir: string }
 ): string {
   const ttl = cache ? (typeof cache.ttl === 'number' ? cache.ttl : (parseDuration(cache.ttl) ?? 0)) : 0;
   const key: HookCacheKey = cache?.key ?? 'global';
   const prefetch: HookCachePrefetch = cache?.prefetch ?? 'none';
-  const { cacheDir, logsDir } = paths;
+  const { cacheDir, logsDir, perfDir } = paths;
+  const perfSpool = path.join(perfDir, 'spool.jsonl');
 
   const hasMatches = matches != null && Object.keys(matches).length > 0;
   const matchesJson = hasMatches ? JSON.stringify(matches) : '';
@@ -367,12 +377,14 @@ HOOK_NAME=${q(name)}
 SOURCE=${q(scriptPath)}
 CACHE_DIR=${q(cacheDir)}
 LOGS_DIR=${q(logsDir)}
+PERF_DIR=${q(perfDir)}
+PERF_SPOOL=${q(perfSpool)}
 TTL=${ttl}
 PREFETCH=${q(prefetch)}
 KEY_MODE=${q(key)}
 MATCHES_JSON=${q(matchesJson)}
 
-mkdir -p "$CACHE_DIR" "$LOGS_DIR"
+mkdir -p "$CACHE_DIR" "$LOGS_DIR" "$PERF_DIR"
 
 # Resolve a real Python. On Windows, bare python3 is often a Microsoft Store
 # app-execution alias stub that prints to stderr and exits non-zero (0 bytes on
@@ -405,6 +417,11 @@ if [ -n "$MATCHES_JSON" ]; then
     _LOG_FILE="$LOGS_DIR/events-$(date -u +%Y-%m-%d).jsonl"
     printf '{"ts":"%s","event":"hook.fire","hook":"%s","ms":0,"cache":"skip","exit":0}\\n' \\
       "$_TS" "$HOOK_NAME" >>"$_LOG_FILE" 2>/dev/null || true
+    mkdir -p "$PERF_DIR" 2>/dev/null || true
+    _TS_MS=$("$PY" -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0)
+    _HOST=$(hostname 2>/dev/null || echo unknown)
+    printf '{"ts_ms":%s,"kind":"hook.fire","label":"%s","duration_ms":0,"cache":"skip","exit_code":0,"hostname":"%s"}\\n' \\
+      "$_TS_MS" "$HOOK_NAME" "$_HOST" >>"$PERF_SPOOL" 2>/dev/null || true
     exit 0
   fi
 fi
@@ -503,6 +520,11 @@ TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 LOG_FILE="$LOGS_DIR/events-$(date -u +%Y-%m-%d).jsonl"
 printf '{"ts":"%s","event":"hook.fire","hook":"%s","ms":%d,"cache":"%s","exit":%d}\\n' \\
   "$TS" "$HOOK_NAME" "$MS" "$CACHE_STATUS" "$EXIT" >>"$LOG_FILE" 2>/dev/null || true
+# Disposable perf spool → drained into perf.db (see lib/perf/db.ts). Soft keys only.
+TS_MS=$("$PY" -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0)
+HOST=$(hostname 2>/dev/null || echo unknown)
+printf '{"ts_ms":%s,"kind":"hook.fire","label":"%s","duration_ms":%d,"cache":"%s","exit_code":%d,"hostname":"%s"}\\n' \\
+  "$TS_MS" "$HOOK_NAME" "$MS" "$CACHE_STATUS" "$EXIT" "$HOST" >>"$PERF_SPOOL" 2>/dev/null || true
 
 exit "$EXIT"
 `;

--- a/apps/cli/src/lib/perf/db.test.ts
+++ b/apps/cli/src/lib/perf/db.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Real SQLite warehouse under a temp dir — no mocks.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  _resetPerfDbForTest,
+  aggregateSamples,
+  drainSpool,
+  percentile,
+  recordSample,
+  shortSessionId,
+} from './db.js';
+
+describe('perf/db', () => {
+  let tmp: string;
+  let dbPath: string;
+  let spoolPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-db-'));
+    dbPath = path.join(tmp, 'perf.db');
+    spoolPath = path.join(tmp, 'spool.jsonl');
+    process.env.AGENTS_PERF_DB = dbPath;
+    process.env.AGENTS_PERF_SPOOL = spoolPath;
+    delete process.env.AGENTS_DISABLE_PERF;
+    _resetPerfDbForTest(dbPath);
+  });
+
+  afterEach(() => {
+    _resetPerfDbForTest(null);
+    delete process.env.AGENTS_PERF_DB;
+    delete process.env.AGENTS_PERF_SPOOL;
+    delete process.env.AGENTS_DISABLE_PERF;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('shortSessionId strips session_ prefix and keeps 8 chars', () => {
+    expect(shortSessionId('session_087bf3be-64f7-4bbc')).toBe('087bf3be');
+    expect(shortSessionId('b0b06be0-c484-4db4-8031')).toBe('b0b06be0');
+    expect(shortSessionId(undefined)).toBeUndefined();
+  });
+
+  it('percentile is linear and bounds-safe', () => {
+    expect(percentile([1], 50)).toBe(1);
+    expect(percentile([1, 2, 3, 4, 5], 50)).toBe(3);
+    expect(percentile([10, 20, 30, 40, 50], 0)).toBe(10);
+    expect(percentile([10, 20, 30, 40, 50], 100)).toBe(50);
+  });
+
+  it('recordSample + aggregateSamples returns p50/p99 by kind+label', () => {
+    const base = Date.now();
+    for (const ms of [10, 20, 30, 40, 100]) {
+      recordSample({
+        tsMs: base,
+        kind: 'hook.fire',
+        label: 'inject-repo-inflight',
+        durationMs: ms,
+        sessionId: 'b0b06be0-c484-4db4-8031-1cf89563e6e1',
+        agent: 'claude',
+        machine: 'yosemite-s1',
+        cache: ms === 10 ? 'hit' : 'miss',
+      });
+    }
+    recordSample({
+      tsMs: base,
+      kind: 'command.end',
+      label: 'sessions focus',
+      durationMs: 5,
+      agent: 'claude',
+    });
+
+    const hooks = aggregateSamples({ days: 1, kinds: ['hook.fire'] });
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].label).toBe('inject-repo-inflight');
+    expect(hooks[0].n).toBe(5);
+    expect(hooks[0].p50Ms).toBe(30);
+    expect(hooks[0].maxMs).toBe(100);
+    expect(hooks[0].cacheHitPct).toBe(20);
+    expect(hooks[0].cacheMissPct).toBe(80);
+
+    const cmds = aggregateSamples({ days: 1, kinds: ['command.end'] });
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0].label).toBe('sessions focus');
+    expect(cmds[0].n).toBe(1);
+  });
+
+  it('drainSpool ingests bash-shaped NDJSON and empties the spool', () => {
+    const line = JSON.stringify({
+      ts_ms: Date.now(),
+      kind: 'hook.fire',
+      label: 'session-identity',
+      duration_ms: 18,
+      cache: 'none',
+      exit_code: 0,
+      machine: 'zion',
+      hostname: 'zion.local',
+    });
+    fs.writeFileSync(spoolPath, line + '\n');
+    const n = drainSpool();
+    expect(n).toBe(1);
+    expect(fs.readFileSync(spoolPath, 'utf-8')).toBe('');
+
+    const rows = aggregateSamples({ days: 1, kinds: ['hook.fire'] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].label).toBe('session-identity');
+    expect(rows[0].meanMs).toBe(18);
+  });
+
+  it('AGENTS_DISABLE_PERF silences writes', () => {
+    process.env.AGENTS_DISABLE_PERF = '1';
+    _resetPerfDbForTest(dbPath);
+    recordSample({ kind: 'hook.fire', label: 'x', durationMs: 1 });
+    process.env.AGENTS_DISABLE_PERF = '0';
+    _resetPerfDbForTest(dbPath);
+    // re-enable and confirm empty
+    delete process.env.AGENTS_DISABLE_PERF;
+    _resetPerfDbForTest(dbPath);
+    expect(aggregateSamples({ days: 1 })).toHaveLength(0);
+  });
+
+  it('fail-soft: empty label is ignored', () => {
+    recordSample({ kind: 'hook.fire', label: '', durationMs: 10 });
+    expect(aggregateSamples({ days: 1 })).toHaveLength(0);
+  });
+});

--- a/apps/cli/src/lib/perf/db.ts
+++ b/apps/cli/src/lib/perf/db.ts
@@ -1,0 +1,419 @@
+/**
+ * Disposable performance warehouse — SQLite under ~/.agents/.cache/perf/.
+ *
+ * Design:
+ *  - Loss is acceptable (cache dir). No FKs into sessions.db.
+ *  - Identity columns use the same *string shapes* as sessions/events
+ *    (session_id, session_short, agent, machine, actor, cwd) for soft joins.
+ *  - Producers call {@link recordSample} (fail-soft). Hook shims append NDJSON
+ *    to a spool file; the next open drains it into the table.
+ *  - Retention defaults to 30 days; wipe anytime with `rm -rf ~/.agents/.cache/perf`.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Database from '../sqlite.js';
+import { getPerfDbPath, getPerfDir, getPerfSpoolPath } from '../state.js';
+import { localMachineId } from '../session/origin-machine.js';
+
+export const PERF_SCHEMA_VERSION = 1;
+export const DEFAULT_RETENTION_DAYS = 30;
+
+export type PerfKind = 'hook.fire' | 'perf.timing' | 'command.end' | string;
+
+export interface PerfSample {
+  tsMs?: number;
+  kind: PerfKind;
+  label: string;
+  durationMs: number;
+  /** Full session id — same string as sessions.id when known. */
+  sessionId?: string;
+  /** First 8 chars of sessionId (sessions.short_id shape). */
+  sessionShort?: string;
+  agent?: string;
+  agentVersion?: string;
+  /** Fleet registry name (sessions.machine), preferred over raw hostname. */
+  machine?: string;
+  hostname?: string;
+  actor?: string;
+  cwd?: string;
+  cache?: string;
+  exitCode?: number;
+  status?: string;
+  metaJson?: string;
+}
+
+export interface PerfAggregateRow {
+  kind: string;
+  label: string;
+  n: number;
+  p50Ms: number;
+  p99Ms: number;
+  meanMs: number;
+  maxMs: number;
+  minMs: number;
+  /** Present for hook.fire rows with cache data. */
+  cacheHitPct?: number;
+  cacheStalePct?: number;
+  cacheMissPct?: number;
+  errorCount?: number;
+}
+
+export interface AggregateOptions {
+  /** Only samples with ts_ms >= now - days*86400000. Default 7. */
+  days?: number;
+  kinds?: string[];
+  label?: string;
+  machine?: string;
+  agent?: string;
+  /** Drop labels with fewer samples than this. Default 1. */
+  minN?: number;
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS samples (
+  id INTEGER PRIMARY KEY,
+  ts_ms INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  label TEXT NOT NULL,
+  duration_ms REAL NOT NULL,
+  session_id TEXT,
+  session_short TEXT,
+  agent TEXT,
+  agent_version TEXT,
+  machine TEXT,
+  hostname TEXT,
+  actor TEXT,
+  cwd TEXT,
+  cache TEXT,
+  exit_code INTEGER,
+  status TEXT,
+  meta_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_perf_ts ON samples(ts_ms);
+CREATE INDEX IF NOT EXISTS idx_perf_kind_ts ON samples(kind, ts_ms);
+CREATE INDEX IF NOT EXISTS idx_perf_label_ts ON samples(label, ts_ms);
+CREATE INDEX IF NOT EXISTS idx_perf_machine_ts ON samples(machine, ts_ms);
+CREATE INDEX IF NOT EXISTS idx_perf_session ON samples(session_id);
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;
+
+let _db: Database.Database | null = null;
+let _dbPath: string | null = null;
+let _disabled = false;
+
+/** Test seam — redirect the warehouse path (like AGENTS_EVENTS_PATH). */
+export function _resetPerfDbForTest(overridePath?: string | null): void {
+  if (_db) {
+    try { _db.close(); } catch { /* ignore */ }
+  }
+  _db = null;
+  _dbPath = overridePath === undefined ? null : overridePath;
+  _disabled = false;
+}
+
+function resolveDbPath(): string {
+  return process.env.AGENTS_PERF_DB || _dbPath || getPerfDbPath();
+}
+
+function resolveSpoolPath(): string {
+  if (process.env.AGENTS_PERF_SPOOL) return process.env.AGENTS_PERF_SPOOL;
+  if (_dbPath) return path.join(path.dirname(_dbPath), 'spool.jsonl');
+  return getPerfSpoolPath();
+}
+
+function isDisabled(): boolean {
+  if (_disabled) return true;
+  const v = process.env.AGENTS_DISABLE_PERF;
+  return v === '1' || v === 'true';
+}
+
+/** Short session id: first 8 hex-ish chars of a full id. */
+export function shortSessionId(sessionId: string | undefined | null): string | undefined {
+  if (!sessionId) return undefined;
+  const cleaned = sessionId.replace(/^session_/, '');
+  return cleaned.length >= 8 ? cleaned.slice(0, 8) : cleaned || undefined;
+}
+
+function openDb(): Database.Database | null {
+  if (isDisabled()) return null;
+  const dbPath = resolveDbPath();
+  if (_db && _dbPath === dbPath) return _db;
+  if (_db) {
+    try { _db.close(); } catch { /* ignore */ }
+    _db = null;
+  }
+  try {
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true, mode: 0o700 });
+    const db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
+    db.pragma('busy_timeout = 2000');
+    db.exec(SCHEMA);
+    const row = db.prepare(`SELECT value FROM meta WHERE key = 'schema_version'`).get() as { value: string } | undefined;
+    if (!row) {
+      db.prepare(`INSERT INTO meta(key, value) VALUES ('schema_version', ?)`).run(String(PERF_SCHEMA_VERSION));
+    }
+    _db = db;
+    _dbPath = dbPath;
+    drainSpool(db);
+    maybeRetain(db);
+    return db;
+  } catch {
+    _disabled = true;
+    return null;
+  }
+}
+
+/**
+ * Insert one timing sample. Never throws — perf must not break the critical path.
+ */
+export function recordSample(sample: PerfSample): void {
+  if (isDisabled()) return;
+  if (!sample.label || !Number.isFinite(sample.durationMs)) return;
+  try {
+    const db = openDb();
+    if (!db) return;
+    const tsMs = sample.tsMs ?? Date.now();
+    const sessionId = sample.sessionId;
+    const sessionShort = sample.sessionShort ?? shortSessionId(sessionId);
+    const machine = sample.machine ?? localMachineId();
+    const hostname = sample.hostname ?? os.hostname();
+    db.prepare(`
+      INSERT INTO samples (
+        ts_ms, kind, label, duration_ms,
+        session_id, session_short, agent, agent_version,
+        machine, hostname, actor, cwd,
+        cache, exit_code, status, meta_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      tsMs,
+      sample.kind,
+      sample.label,
+      sample.durationMs,
+      sessionId ?? null,
+      sessionShort ?? null,
+      sample.agent ?? null,
+      sample.agentVersion ?? null,
+      machine ?? null,
+      hostname ?? null,
+      sample.actor ?? null,
+      sample.cwd ?? null,
+      sample.cache ?? null,
+      sample.exitCode ?? null,
+      sample.status ?? null,
+      sample.metaJson ?? null,
+    );
+  } catch {
+    // Fail soft.
+  }
+}
+
+/** Drain the bash-shim NDJSON spool into samples. Idempotent; truncates on success. */
+export function drainSpool(db?: Database.Database): number {
+  const spool = resolveSpoolPath();
+  if (!fs.existsSync(spool)) return 0;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(spool, 'utf-8');
+  } catch {
+    return 0;
+  }
+  if (!raw.trim()) {
+    try { fs.writeFileSync(spool, ''); } catch { /* ignore */ }
+    return 0;
+  }
+  const target = db ?? openDb();
+  if (!target) return 0;
+
+  let n = 0;
+  const insert = target.prepare(`
+    INSERT INTO samples (
+      ts_ms, kind, label, duration_ms,
+      session_id, session_short, agent, agent_version,
+      machine, hostname, actor, cwd,
+      cache, exit_code, status, meta_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const txn = target.transaction((lines: string[]) => {
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let o: Record<string, unknown>;
+      try { o = JSON.parse(line); } catch { continue; }
+      const label = String(o.label ?? o.hook ?? '');
+      const durationMs = Number(o.duration_ms ?? o.durationMs ?? o.ms);
+      if (!label || !Number.isFinite(durationMs)) continue;
+      const sessionId = o.session_id != null ? String(o.session_id)
+        : o.sessionId != null ? String(o.sessionId) : null;
+      const tsMs = Number(o.ts_ms ?? o.tsMs) || (typeof o.ts === 'string' ? Date.parse(o.ts) : Date.now());
+      insert.run(
+        Number.isFinite(tsMs) ? tsMs : Date.now(),
+        String(o.kind ?? 'hook.fire'),
+        label,
+        durationMs,
+        sessionId,
+        o.session_short != null ? String(o.session_short) : shortSessionId(sessionId) ?? null,
+        o.agent != null ? String(o.agent) : null,
+        o.agent_version != null ? String(o.agent_version) : o.agentVersion != null ? String(o.agentVersion) : null,
+        o.machine != null ? String(o.machine) : localMachineId(),
+        o.hostname != null ? String(o.hostname) : os.hostname(),
+        o.actor != null ? String(o.actor) : null,
+        o.cwd != null ? String(o.cwd) : null,
+        o.cache != null ? String(o.cache) : null,
+        o.exit_code != null ? Number(o.exit_code) : o.exit != null ? Number(o.exit) : null,
+        o.status != null ? String(o.status) : null,
+        o.meta_json != null ? String(o.meta_json) : null,
+      );
+      n++;
+    }
+  });
+  try {
+    txn(raw.split('\n'));
+    fs.writeFileSync(spool, '');
+  } catch {
+    return 0;
+  }
+  return n;
+}
+
+function maybeRetain(db: Database.Database): void {
+  try {
+    const last = db.prepare(`SELECT value FROM meta WHERE key = 'last_retain_ms'`).get() as { value: string } | undefined;
+    const lastMs = last ? parseInt(last.value, 10) : 0;
+    const now = Date.now();
+    // At most once per hour.
+    if (now - lastMs < 3_600_000) return;
+    const cutoff = now - DEFAULT_RETENTION_DAYS * 86_400_000;
+    db.prepare(`DELETE FROM samples WHERE ts_ms < ?`).run(cutoff);
+    db.prepare(`INSERT OR REPLACE INTO meta(key, value) VALUES ('last_retain_ms', ?)`).run(String(now));
+  } catch {
+    // ignore
+  }
+}
+
+/** Percentile of a sorted-ascending array. p in [0,100]. */
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const frac = rank - lo;
+  return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}
+
+/**
+ * Aggregate samples by (kind, label) with p50/p99. Drains the spool first.
+ */
+export function aggregateSamples(opts: AggregateOptions = {}): PerfAggregateRow[] {
+  const db = openDb();
+  if (!db) return [];
+  drainSpool(db);
+
+  const days = opts.days ?? 7;
+  const sinceMs = Date.now() - days * 86_400_000;
+  const minN = opts.minN ?? 1;
+
+  const clauses = ['ts_ms >= ?'];
+  const params: unknown[] = [sinceMs];
+  if (opts.kinds && opts.kinds.length > 0) {
+    clauses.push(`kind IN (${opts.kinds.map(() => '?').join(',')})`);
+    params.push(...opts.kinds);
+  }
+  if (opts.label) {
+    clauses.push('label = ?');
+    params.push(opts.label);
+  }
+  if (opts.machine) {
+    clauses.push('machine = ?');
+    params.push(opts.machine);
+  }
+  if (opts.agent) {
+    clauses.push('agent = ?');
+    params.push(opts.agent);
+  }
+
+  const rows = db.prepare(
+    `SELECT kind, label, duration_ms, cache, exit_code
+     FROM samples WHERE ${clauses.join(' AND ')}`
+  ).all(...params) as Array<{
+    kind: string;
+    label: string;
+    duration_ms: number;
+    cache: string | null;
+    exit_code: number | null;
+  }>;
+
+  type Bucket = {
+    kind: string;
+    label: string;
+    durations: number[];
+    hits: number;
+    stale: number;
+    misses: number;
+    errors: number;
+  };
+  const map = new Map<string, Bucket>();
+  for (const r of rows) {
+    const key = `${r.kind}\0${r.label}`;
+    let b = map.get(key);
+    if (!b) {
+      b = { kind: r.kind, label: r.label, durations: [], hits: 0, stale: 0, misses: 0, errors: 0 };
+      map.set(key, b);
+    }
+    b.durations.push(Number(r.duration_ms));
+    if (r.cache === 'hit') b.hits++;
+    else if (r.cache === 'stale-prefetch') b.stale++;
+    else if (r.cache === 'miss' || r.cache === 'none') b.misses++;
+    if (typeof r.exit_code === 'number' && r.exit_code !== 0) b.errors++;
+  }
+
+  const out: PerfAggregateRow[] = [];
+  for (const b of map.values()) {
+    if (b.durations.length < minN) continue;
+    const sorted = b.durations.slice().sort((a, c) => a - c);
+    const n = sorted.length;
+    const sum = sorted.reduce((a, c) => a + c, 0);
+    const row: PerfAggregateRow = {
+      kind: b.kind,
+      label: b.label,
+      n,
+      p50Ms: Math.round(percentile(sorted, 50)),
+      p99Ms: Math.round(percentile(sorted, 99)),
+      meanMs: Math.round(sum / n),
+      maxMs: sorted[n - 1],
+      minMs: sorted[0],
+    };
+    if (b.hits + b.stale + b.misses > 0) {
+      row.cacheHitPct = Math.round((b.hits / n) * 100);
+      row.cacheStalePct = Math.round((b.stale / n) * 100);
+      row.cacheMissPct = Math.round((b.misses / n) * 100);
+    }
+    if (b.errors > 0) row.errorCount = b.errors;
+    out.push(row);
+  }
+  out.sort((a, b) => b.p99Ms - a.p99Ms);
+  return out;
+}
+
+/** Absolute path of the warehouse (for help / doctor). */
+export function perfDbPath(): string {
+  return resolveDbPath();
+}
+
+/** Absolute path of the spool (for shim generation). */
+export function perfSpoolPath(): string {
+  return resolveSpoolPath();
+}
+
+/** Ensure the perf dir exists and return it (for shims). */
+export function ensurePerfDir(): string {
+  const dir = process.env.AGENTS_PERF_DIR || (_dbPath ? path.dirname(_dbPath) : getPerfDir());
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return dir;
+}

--- a/apps/cli/src/lib/perf/db.ts
+++ b/apps/cli/src/lib/perf/db.ts
@@ -1,75 +1,23 @@
 /**
  * Disposable performance warehouse — SQLite under ~/.agents/.cache/perf/.
  *
- * Design:
- *  - Loss is acceptable (cache dir). No FKs into sessions.db.
- *  - Identity columns use the same *string shapes* as sessions/events
- *    (session_id, session_short, agent, machine, actor, cwd) for soft joins.
- *  - Producers call {@link recordSample} (fail-soft). Hook shims append NDJSON
- *    to a spool file; the next open drains it into the table.
- *  - Retention defaults to 30 days; wipe anytime with `rm -rf ~/.agents/.cache/perf`.
+ * Opened only by `agents perf` / `hooks profile` (read path). Writers use
+ * {@link recordSample} in `./spool.ts` (NDJSON, no SQLite).
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import Database from '../sqlite.js';
-import { getPerfDbPath, getPerfDir, getPerfSpoolPath } from '../state.js';
+import { getPerfDbPath, getPerfDir } from '../state.js';
 import { localMachineId } from '../session/origin-machine.js';
+import { resolveSpoolPath, shortSessionId, _resetPerfSpoolForTest } from './spool.js';
+import type { AggregateOptions, PerfAggregateRow } from './types.js';
+
+export type { AggregateOptions, PerfAggregateRow, PerfSample } from './types.js';
+export { recordSample, shortSessionId, resolveSpoolPath } from './spool.js';
 
 export const PERF_SCHEMA_VERSION = 1;
 export const DEFAULT_RETENTION_DAYS = 30;
-
-export type PerfKind = 'hook.fire' | 'perf.timing' | 'command.end' | string;
-
-export interface PerfSample {
-  tsMs?: number;
-  kind: PerfKind;
-  label: string;
-  durationMs: number;
-  /** Full session id — same string as sessions.id when known. */
-  sessionId?: string;
-  /** First 8 chars of sessionId (sessions.short_id shape). */
-  sessionShort?: string;
-  agent?: string;
-  agentVersion?: string;
-  /** Fleet registry name (sessions.machine), preferred over raw hostname. */
-  machine?: string;
-  hostname?: string;
-  actor?: string;
-  cwd?: string;
-  cache?: string;
-  exitCode?: number;
-  status?: string;
-  metaJson?: string;
-}
-
-export interface PerfAggregateRow {
-  kind: string;
-  label: string;
-  n: number;
-  p50Ms: number;
-  p99Ms: number;
-  meanMs: number;
-  maxMs: number;
-  minMs: number;
-  /** Present for hook.fire rows with cache data. */
-  cacheHitPct?: number;
-  cacheStalePct?: number;
-  cacheMissPct?: number;
-  errorCount?: number;
-}
-
-export interface AggregateOptions {
-  /** Only samples with ts_ms >= now - days*86400000. Default 7. */
-  days?: number;
-  kinds?: string[];
-  label?: string;
-  machine?: string;
-  agent?: string;
-  /** Drop labels with fewer samples than this. Default 1. */
-  minN?: number;
-}
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS samples (
@@ -114,29 +62,21 @@ export function _resetPerfDbForTest(overridePath?: string | null): void {
   _db = null;
   _dbPath = overridePath === undefined ? null : overridePath;
   _disabled = false;
+  if (overridePath) {
+    _resetPerfSpoolForTest(path.join(path.dirname(overridePath), 'spool.jsonl'));
+  } else if (overridePath === null) {
+    _resetPerfSpoolForTest(null);
+  }
 }
 
 function resolveDbPath(): string {
   return process.env.AGENTS_PERF_DB || _dbPath || getPerfDbPath();
 }
 
-function resolveSpoolPath(): string {
-  if (process.env.AGENTS_PERF_SPOOL) return process.env.AGENTS_PERF_SPOOL;
-  if (_dbPath) return path.join(path.dirname(_dbPath), 'spool.jsonl');
-  return getPerfSpoolPath();
-}
-
 function isDisabled(): boolean {
   if (_disabled) return true;
   const v = process.env.AGENTS_DISABLE_PERF;
   return v === '1' || v === 'true';
-}
-
-/** Short session id: first 8 hex-ish chars of a full id. */
-export function shortSessionId(sessionId: string | undefined | null): string | undefined {
-  if (!sessionId) return undefined;
-  const cleaned = sessionId.replace(/^session_/, '');
-  return cleaned.length >= 8 ? cleaned.slice(0, 8) : cleaned || undefined;
 }
 
 function openDb(): Database.Database | null {
@@ -169,51 +109,7 @@ function openDb(): Database.Database | null {
   }
 }
 
-/**
- * Insert one timing sample. Never throws — perf must not break the critical path.
- */
-export function recordSample(sample: PerfSample): void {
-  if (isDisabled()) return;
-  if (!sample.label || !Number.isFinite(sample.durationMs)) return;
-  try {
-    const db = openDb();
-    if (!db) return;
-    const tsMs = sample.tsMs ?? Date.now();
-    const sessionId = sample.sessionId;
-    const sessionShort = sample.sessionShort ?? shortSessionId(sessionId);
-    const machine = sample.machine ?? localMachineId();
-    const hostname = sample.hostname ?? os.hostname();
-    db.prepare(`
-      INSERT INTO samples (
-        ts_ms, kind, label, duration_ms,
-        session_id, session_short, agent, agent_version,
-        machine, hostname, actor, cwd,
-        cache, exit_code, status, meta_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      tsMs,
-      sample.kind,
-      sample.label,
-      sample.durationMs,
-      sessionId ?? null,
-      sessionShort ?? null,
-      sample.agent ?? null,
-      sample.agentVersion ?? null,
-      machine ?? null,
-      hostname ?? null,
-      sample.actor ?? null,
-      sample.cwd ?? null,
-      sample.cache ?? null,
-      sample.exitCode ?? null,
-      sample.status ?? null,
-      sample.metaJson ?? null,
-    );
-  } catch {
-    // Fail soft.
-  }
-}
-
-/** Drain the bash-shim NDJSON spool into samples. Idempotent; truncates on success. */
+/** Drain the NDJSON spool into samples. Idempotent; truncates on success. */
 export function drainSpool(db?: Database.Database): number {
   const spool = resolveSpoolPath();
   if (!fs.existsSync(spool)) return 0;
@@ -260,7 +156,7 @@ export function drainSpool(db?: Database.Database): number {
         o.agent != null ? String(o.agent) : null,
         o.agent_version != null ? String(o.agent_version) : o.agentVersion != null ? String(o.agentVersion) : null,
         o.machine != null ? String(o.machine) : localMachineId(),
-        o.hostname != null ? String(o.hostname) : os.hostname(),
+        o.hostname != null ? String(o.hostname) : null,
         o.actor != null ? String(o.actor) : null,
         o.cwd != null ? String(o.cwd) : null,
         o.cache != null ? String(o.cache) : null,
@@ -285,7 +181,6 @@ function maybeRetain(db: Database.Database): void {
     const last = db.prepare(`SELECT value FROM meta WHERE key = 'last_retain_ms'`).get() as { value: string } | undefined;
     const lastMs = last ? parseInt(last.value, 10) : 0;
     const now = Date.now();
-    // At most once per hour.
     if (now - lastMs < 3_600_000) return;
     const cutoff = now - DEFAULT_RETENTION_DAYS * 86_400_000;
     db.prepare(`DELETE FROM samples WHERE ts_ms < ?`).run(cutoff);
@@ -401,19 +296,17 @@ export function aggregateSamples(opts: AggregateOptions = {}): PerfAggregateRow[
   return out;
 }
 
-/** Absolute path of the warehouse (for help / doctor). */
 export function perfDbPath(): string {
   return resolveDbPath();
 }
 
-/** Absolute path of the spool (for shim generation). */
 export function perfSpoolPath(): string {
   return resolveSpoolPath();
 }
 
-/** Ensure the perf dir exists and return it (for shims). */
 export function ensurePerfDir(): string {
   const dir = process.env.AGENTS_PERF_DIR || (_dbPath ? path.dirname(_dbPath) : getPerfDir());
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   return dir;
 }
+

--- a/apps/cli/src/lib/perf/spool.ts
+++ b/apps/cli/src/lib/perf/spool.ts
@@ -1,0 +1,82 @@
+/**
+ * Hot-path perf writers — append-only NDJSON spool, no SQLite.
+ *
+ * Loaded from the CLI root `postAction` and from `events.ts` timing helpers.
+ * Must stay free of `../sqlite.js` so ordinary commands never load node:sqlite
+ * (which emits ExperimentalWarning on stderr).
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getPerfSpoolPath } from '../state.js';
+import { localMachineId } from '../session/origin-machine.js';
+import type { PerfSample } from './types.js';
+
+export type { PerfSample } from './types.js';
+
+let _spoolOverride: string | null = null;
+let _disabled = false;
+
+/** Test seam — pair with db._resetPerfDbForTest. */
+export function _resetPerfSpoolForTest(spoolPath?: string | null): void {
+  _spoolOverride = spoolPath === undefined ? null : spoolPath;
+  _disabled = false;
+}
+
+export function resolveSpoolPath(): string {
+  if (process.env.AGENTS_PERF_SPOOL) return process.env.AGENTS_PERF_SPOOL;
+  if (_spoolOverride) return _spoolOverride;
+  return getPerfSpoolPath();
+}
+
+function isDisabled(): boolean {
+  if (_disabled) return true;
+  const v = process.env.AGENTS_DISABLE_PERF;
+  return v === '1' || v === 'true';
+}
+
+/** Short session id: first 8 chars (sessions.short_id shape). */
+export function shortSessionId(sessionId: string | undefined | null): string | undefined {
+  if (!sessionId) return undefined;
+  const cleaned = sessionId.replace(/^session_/, '');
+  return cleaned.length >= 8 ? cleaned.slice(0, 8) : cleaned || undefined;
+}
+
+/**
+ * Append one sample to the spool. Never throws. Never opens SQLite.
+ */
+export function recordSample(sample: PerfSample): void {
+  if (isDisabled()) return;
+  if (!sample.label || !Number.isFinite(sample.durationMs)) return;
+  try {
+    const tsMs = sample.tsMs ?? Date.now();
+    const sessionId = sample.sessionId;
+    const sessionShort = sample.sessionShort ?? shortSessionId(sessionId);
+    const machine = sample.machine ?? localMachineId();
+    const hostname = sample.hostname ?? os.hostname();
+    const line = JSON.stringify({
+      ts_ms: tsMs,
+      kind: sample.kind,
+      label: sample.label,
+      duration_ms: sample.durationMs,
+      session_id: sessionId,
+      session_short: sessionShort,
+      agent: sample.agent,
+      agent_version: sample.agentVersion,
+      machine,
+      hostname,
+      actor: sample.actor,
+      cwd: sample.cwd,
+      cache: sample.cache,
+      exit_code: sample.exitCode,
+      status: sample.status,
+      meta_json: sample.metaJson,
+    });
+    const spool = resolveSpoolPath();
+    fs.mkdirSync(path.dirname(spool), { recursive: true, mode: 0o700 });
+    fs.appendFileSync(spool, line + '\n', { mode: 0o600 });
+  } catch {
+    // Fail soft.
+  }
+}

--- a/apps/cli/src/lib/perf/types.ts
+++ b/apps/cli/src/lib/perf/types.ts
@@ -1,0 +1,49 @@
+/** Shared perf sample shape (spool NDJSON + SQLite rows). */
+
+export type PerfKind = 'hook.fire' | 'perf.timing' | 'command.end' | string;
+
+export interface PerfSample {
+  tsMs?: number;
+  kind: PerfKind;
+  label: string;
+  durationMs: number;
+  /** Full session id — same string as sessions.id when known. */
+  sessionId?: string;
+  /** First 8 chars of sessionId (sessions.short_id shape). */
+  sessionShort?: string;
+  agent?: string;
+  agentVersion?: string;
+  /** Fleet registry name (sessions.machine), preferred over raw hostname. */
+  machine?: string;
+  hostname?: string;
+  actor?: string;
+  cwd?: string;
+  cache?: string;
+  exitCode?: number;
+  status?: string;
+  metaJson?: string;
+}
+
+export interface PerfAggregateRow {
+  kind: string;
+  label: string;
+  n: number;
+  p50Ms: number;
+  p99Ms: number;
+  meanMs: number;
+  maxMs: number;
+  minMs: number;
+  cacheHitPct?: number;
+  cacheStalePct?: number;
+  cacheMissPct?: number;
+  errorCount?: number;
+}
+
+export interface AggregateOptions {
+  days?: number;
+  kinds?: string[];
+  label?: string;
+  machine?: string;
+  agent?: string;
+  minN?: number;
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -76,6 +76,7 @@ export const loadDrive: ModuleLoader = async () => (await import('../../commands
 export const loadFactory: ModuleLoader = async () => (await import('../../commands/factory.js')).registerFactoryCommands;
 export const loadUsage: ModuleLoader = async () => (await import('../../commands/usage.js')).registerUsageCommand;
 export const loadCost: ModuleLoader = async () => (await import('../../commands/cost.js')).registerCostCommand;
+export const loadPerf: ModuleLoader = async () => (await import('../../commands/perf.js')).registerPerfCommand;
 export const loadOutput: ModuleLoader = async () => (await import('../../commands/output.js')).registerOutputCommand;
 export const loadBudget: ModuleLoader = async () => (await import('../../commands/budget.js')).registerBudgetCommand;
 export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
@@ -192,6 +193,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   factory: [loadFactory],
   usage: [loadUsage],
   cost: [loadCost],
+  perf: [loadPerf],
   output: [loadOutput],
   budget: [loadBudget],
   alias: [loadAlias],

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -134,6 +134,8 @@ const CLOUD_DIR = path.join(CACHE_DIR, 'cloud');
 const DRIVE_DIR = path.join(CACHE_DIR, 'drive');
 const TERMINALS_DIR = path.join(CACHE_DIR, 'terminals');
 const LOGS_DIR = path.join(CACHE_DIR, 'logs');
+/** Disposable performance samples (~/.agents/.cache/perf/) — safe to wipe. */
+const PERF_DIR = path.join(CACHE_DIR, 'perf');
 const RUNTIME_STATE_DIR = path.join(CACHE_DIR, 'state');
 const COMPANION_CACHE_DIR = path.join(CACHE_DIR, 'companion');
 const BROWSER_RUNTIME_DIR = path.join(CACHE_DIR, 'browser');
@@ -517,6 +519,18 @@ export function getTerminalsDir(): string { return TERMINALS_DIR; }
 
 /** Path to runtime logs (~/.agents/.cache/logs/). */
 export function getLogsDir(): string { return LOGS_DIR; }
+
+/**
+ * Path to disposable performance samples (~/.agents/.cache/perf/).
+ * Holds `perf.db` + a hook-shim spool. Loss is acceptable — wipe freely.
+ */
+export function getPerfDir(): string { return PERF_DIR; }
+
+/** Path to the perf SQLite warehouse (~/.agents/.cache/perf/perf.db). */
+export function getPerfDbPath(): string { return path.join(PERF_DIR, 'perf.db'); }
+
+/** Path to the hook-shim NDJSON spool drained into perf.db on open. */
+export function getPerfSpoolPath(): string { return path.join(PERF_DIR, 'spool.jsonl'); }
 
 /** Path to per-process runtime state (~/.agents/.cache/state/). */
 export function getRuntimeStateDir(): string { return RUNTIME_STATE_DIR; }


### PR DESCRIPTION
**New CLI surface.** Indexed latency rollups for hooks, commands, and runs — without scanning the audit JSONL.

## Why

At fleet scale, full-scan JSONL is the wrong query path for p50/p99. Perf data is disposable (optimize with it; losing it is fine), so it lives in its own SQLite under `~/.agents/.cache/perf/` with **no foreign keys** into `sessions.db`. Identity columns reuse the same string shapes (`session_id`, `session_short`, `agent`, `machine`, `actor`, `cwd`) for soft cross-reference later.

## Surface

```
agents perf                     # summary: commands + hooks + runs
agents perf hooks               # same rollup as agents hooks profile (SQLite-first)
agents perf commands --days 30
agents perf run --json
```

| Producer | Kind | Path |
|---|---|---|
| CLI `postAction` | `command.end` | direct `recordSample` |
| `createTimer` / `time*` | `perf.timing` | best-effort from `events.ts` |
| Hook cache/matches shims | `hook.fire` | NDJSON spool → drained on open |

Disable: `AGENTS_DISABLE_PERF=1`. Wipe: `rm -rf ~/.agents/.cache/perf`.

## The run

Seeded warehouse via `recordSample`, then `agents perf` (tsx against source):

```
agents perf — last 7 days
warehouse: /tmp/.../perf.db  (disposable; soft-join sessions via session_id/agent/machine)

Commands (slowest by p99)
LABEL                                    N     P50     P99     MEAN    MAX    
──────────────────────────────────────────────────────────────────────────────
teams start                              4     180ms   647ms   266ms   660ms  
sessions list                            4     60ms    216ms   89ms    220ms  

Hooks
HOOK                                 N     P50     P99     MEAN    MAX     CACHE                       
───────────────────────────────────────────────────────────────────────────────────────────────────────
inject-repo-inflight                 4     1.5s    5.4s    2.2s    5.5s    hit:50% miss:50%            

Runs (perf.timing)
LABEL                                    N     P50     P99     MEAN    MAX    
──────────────────────────────────────────────────────────────────────────────
agent.run                                4     10m     35m58s  14m48s  36m40s 
```

Tests: `vitest run src/lib/perf src/lib/hooks/cache*` → **56 pass**.

## Notes

- `agents hooks profile` now prefers the warehouse, falls back to legacy daily JSONL.
- Hook shims still write the legacy JSONL for back-compat; they also append the spool.
- Not in this PR: enabling `cache:` on the slow SessionStart hooks in `.agents-system` (separate repo).
- No UI surface — CLI tables only (declared no-UI).

