### PR TITLE
test(sessions): retry ssh-peer temp-home cleanup (ENOTEMPTY flake)

### DIFF
--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -406,6 +406,16 @@ async function stopSessionResolverSshPeer(peer: SessionResolverSshPeer): Promise
   await new Promise<void>((resolve) => peer.fixture.once('exit', () => resolve()));
 }
 
+/**
+ * rm -rf the peer test's temp home, tolerating the trailing writes the peer
+ * side (an npx'd old agents-cli answering over ssh, plus the ControlPersist
+ * master winding down) races into it after stop — a bare rmSync intermittently
+ * dies ENOTEMPTY on CI. Retries absorb exactly that window.
+ */
+function rmTempHomeWithRetries(tempHome: string): void {
+  fs.rmSync(tempHome, { recursive: true, force: true, maxRetries: 8, retryDelay: 250 });
+}
+
 describe('resolveSessionQuery indexed metadata coverage', () => {
   it('resolves complete and partial ids from the real index without using text matches', () => {
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-resolve-index-'));
@@ -582,7 +592,7 @@ describe('agents sessions --resolve local-peer critical path', () => {
       );
     } finally {
       if (peer) await stopSessionResolverSshPeer(peer);
-      fs.rmSync(tempHome, { recursive: true, force: true });
+      rmTempHomeWithRetries(tempHome);
     }
   });
 
@@ -606,7 +616,7 @@ describe('agents sessions --resolve local-peer critical path', () => {
       expect(result.stderr).toContain('No unique/no-match decision was made.');
     } finally {
       if (peer) await stopSessionResolverSshPeer(peer);
-      fs.rmSync(tempHome, { recursive: true, force: true });
+      rmTempHomeWithRetries(tempHome);
     }
   });
 


### PR DESCRIPTION
The `agents sessions --resolve local-peer` tests (added in #1790/#1793) intermittently fail CI cleanup with `ENOTEMPTY: directory not empty, rmdir '/tmp/sr-…/peer-home/.agents'` — the peer side (an npx'd old agents-cli answering over ssh, plus the ControlPersist master winding down) races trailing writes into the temp home after `stopSessionResolverSshPeer` returns. This has now flaked three times on release 1.20.91's matrix (ubuntu-22 twice, macos once), blocking the release.\n\nFix: `fs.rmSync(…, { maxRetries: 8, retryDelay: 250 })` via a small helper on the two peer tests — absorbs exactly that window. All 42 tests in the file pass locally.