### PR TITLE
feat(exec): stamp AGENTS_PARENT_SESSION_ID for sub-agent event lineage

### DIFF
--- a/apps/cli/src/lib/exec-lineage.test.ts
+++ b/apps/cli/src/lib/exec-lineage.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { buildExecEnv } from './exec.js';
+
+// A sub-agent's events can only carry a walkable "spawned by" edge if
+// buildExecEnv stamps the SPAWNER's session as AGENTS_PARENT_SESSION_ID on the
+// child's env — which the event floor (events.ts::resolveProvenance) then reads
+// onto every event the child emits. options.sessionId is the CHILD's id, so the
+// parent must come from the live env of the spawning process. This exercises the
+// real env build + cross-process delivery, not a mock.
+describe('AGENTS_PARENT_SESSION_ID lineage', () => {
+  const savedParent = process.env.AGENTS_SESSION_ID;
+  const savedAgentParent = process.env.AGENT_SESSION_ID;
+  afterEach(() => {
+    if (savedParent === undefined) delete process.env.AGENTS_SESSION_ID;
+    else process.env.AGENTS_SESSION_ID = savedParent;
+    if (savedAgentParent === undefined) delete process.env.AGENT_SESSION_ID;
+    else process.env.AGENT_SESSION_ID = savedAgentParent;
+  });
+
+  const PARENT = '11111111-1111-4111-8111-111111111111';
+  const CHILD = '22222222-2222-4222-8222-222222222222';
+
+  it('stamps the spawner session as the child parent, and delivers it to the child', () => {
+    process.env.AGENTS_SESSION_ID = PARENT;
+    delete process.env.AGENT_SESSION_ID;
+    const env = buildExecEnv({ agent: 'codex', cwd: process.cwd(), mode: 'auto', effort: 'auto', sessionId: CHILD });
+    // The child's own session is CHILD; its recorded parent is the spawner PARENT.
+    expect(env.AGENTS_SESSION_ID).toBe(CHILD);
+    expect(env.AGENTS_PARENT_SESSION_ID).toBe(PARENT);
+    const r = spawnSync(
+      process.execPath,
+      ['-e', 'process.stdout.write(process.env.AGENTS_PARENT_SESSION_ID || "MISSING")'],
+      { env, encoding: 'utf8' },
+    );
+    expect(r.stdout).toBe(PARENT);
+  });
+
+  it('does not name a same-session resume as its own parent', () => {
+    process.env.AGENTS_SESSION_ID = CHILD;
+    delete process.env.AGENT_SESSION_ID;
+    const env = buildExecEnv({ agent: 'codex', cwd: process.cwd(), mode: 'auto', effort: 'auto', sessionId: CHILD });
+    expect(env.AGENTS_PARENT_SESSION_ID).toBeUndefined();
+  });
+
+  it('sets no parent when the spawner has no session', () => {
+    delete process.env.AGENTS_SESSION_ID;
+    delete process.env.AGENT_SESSION_ID;
+    const env = buildExecEnv({ agent: 'codex', cwd: process.cwd(), mode: 'auto', effort: 'auto', sessionId: CHILD });
+    expect(env.AGENTS_PARENT_SESSION_ID).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -499,6 +499,16 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
     result.AGENT_SESSION_ID = options.sessionId;
     result.AGENTS_SESSION_ID = options.sessionId;
   }
+  // Lineage edge: the child's parent is THIS process's session (the spawner), so a
+  // sub-agent's events carry a walkable edge back to who spawned it. The event floor
+  // (events.ts::resolveProvenance) reads AGENTS_PARENT_SESSION_ID and stamps it on
+  // every event the child emits. `options.sessionId` is the CHILD's id, so read the
+  // spawner from the live env; guard a same-session resume from naming itself parent.
+  // Local-spawn scope here; forwarding it across the `--host` SSH hop is Phase 4.
+  const spawnerSessionId = process.env.AGENTS_SESSION_ID || process.env.AGENT_SESSION_ID;
+  if (spawnerSessionId && spawnerSessionId !== options.sessionId) {
+    result.AGENTS_PARENT_SESSION_ID = spawnerSessionId;
+  }
   result.AGENTS_RUNTIME = resolveInteractive(options) ? 'terminal' : 'headless';
   // So activity / feed posts stamp the right harness without re-detecting.
   if (options.agent) {


### PR DESCRIPTION
**lib change (no UI)** — Phase 2 (lineage keystone) of the events-provenance plan; builds on the Phase 1 floor (#1796).

## What
`buildExecEnv` now stamps `AGENTS_PARENT_SESSION_ID` = the spawner's live session id onto every child it builds. Phase 1's `resolveProvenance()` already reads that var, so **every event a sub-agent emits now carries a walkable `parentSessionId` edge** back to whoever spawned it — the missing half of "who spawned this."

- `options.sessionId` is the **child's** id, so the parent is read from the spawning process's env (`AGENTS_SESSION_ID`/`AGENT_SESSION_ID`).
- Guards a same-session **resume** from naming itself parent; sets nothing when the spawner has no session.

## Why
Before this, `parentSessionId` (added to the event schema in Phase 1) was never populated — the lineage lived only in the teams DB and `sessions.db`, never on the event stream. This makes `agents events` able to reconstruct the spawn chain.

## Scope / surface parity
- **Covered:** every spawn that routes through `buildExecEnv` (the one execution engine).
- **Deferred to Phase 4** (cross-host origin + join key, stated here per the surface-parity rule): forwarding the lineage across the `--host` SSH hop. Teams already persist `parent_session_id` in their own `AgentProcess` DB record (`teams/agents.ts`), independent of this env.
- **Remaining Phase 2 pieces** (follow-on PRs): emitting the declared-but-dead `agent.run/spawn.*` lifecycle events, and attributing a sub-agent's *own* activity (the `activity.ts` sub-agent gate that currently drops it).

## Run result
`tsc --noEmit`: clean. Real-path tests (`exec-lineage.test.ts`, spawns a real child and reads the env it received — no mocks):
```
Tests  3 passed (3)
  ✓ stamps the spawner session as the child parent, and delivers it to the child
  ✓ does not name a same-session resume as its own parent
  ✓ sets no parent when the spawner has no session
```
