### PR TITLE
feat(feed): agents can declare they are blocked, and it reaches the owner

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2110.md
+++ b/apps/cli/.changelog/next/RUSH-2110.md
@@ -1,0 +1,26 @@
+- **An agent can now say it is stuck: `agents feed post --blocked` (RUSH-2110).** The
+  feed carried benign progress but had no way to signal "I cannot proceed", so agents
+  hand-rolled it into the status text (`NEEDS MUQSIT: …`) and it reached nobody. A
+  blocked post writes `status.blocked` to the shared activity stream *and* opens an
+  answerable block in the ledger, so the ask stays open until someone resolves it
+  instead of scrolling away. It is a flag on the existing verb, not a new command —
+  one thing for an agent to learn, and one stream where most posts are benign and
+  some need a human. Blocked is a state, not a volume: it always broadcasts at
+  `important`, so passing `--level` too is a usage error rather than a silent
+  override. Pair it with `--option` for an answerable choice or `--default` for a
+  safe fallback policy may apply. Source: `apps/cli/src/commands/feed.ts`,
+  `apps/cli/src/lib/feed.ts`.
+- **Feed blocks are actually delivered.** `publishBlock` wrote every "needs you"
+  record to the ledger and stopped there — `broadcastPostedEvent` ran only for
+  `feed post`, so a block was durable and invisible at the same time. Blocks now
+  reach the configured `feed.broadcast` sinks, carrying the ask and the literal
+  `agents focus <id>` command that unblocks it, and a block that reaches nobody
+  exits non-zero instead of looking like a success. Source:
+  `apps/cli/src/lib/feed-broadcast.ts`.
+- **New `desktop` channel provider.** `agents send --channel desktop` (and
+  `notify.owner.channel: desktop`) posts a native notification through the branded
+  menu-bar helper. It is the only channel with no external dependency — no network,
+  no login, no vendor CLI — so it still reaches you at your Mac when a messaging
+  gateway is down. It reports real deliverability rather than always succeeding:
+  on Linux it probes for `notify-send` instead of trusting the platform name.
+  Source: `apps/cli/src/lib/channels/providers/desktop.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -683,6 +683,45 @@ Each post appends a `status.posted` **milestone** to
 **not** create a feed block. Domain facts (tickets, PRs) are not CLI flags;
 join them from the session index / live session enrichment at read time.
 
+#### `--blocked` — the same post, but the agent is stuck
+
+A plain post is history the moment it lands. `--blocked` says the agent
+**cannot proceed** and needs a human, so the ask has to stay open rather than
+scroll away:
+
+```bash
+agents feed post "force-push denied by git-guard on PR #1749" --blocked
+agents feed post "publish or wait for review?" --blocked --option publish --option wait
+agents feed post "delete the stale preview env?" --blocked --default "leave it"
+```
+
+It is a flag on the existing verb rather than a separate command: the feed is
+**one shared stream** where most posts are benign and some need a human, and one
+verb is one thing for an agent to learn.
+
+A blocked post writes to **both** stores:
+
+- `status.blocked` on the activity stream — *what happened*.
+- an **`OpenBlock`** in `~/.agents/.history/feed/` — *what is still open*, which
+  is what makes it answerable (`recordAnswer`, `agents message`) and clearable
+  (`recordContinued`). Without the ledger entry the ask would be indistinguishable
+  from any other update.
+
+**Blocked is a state, not a volume.** It always broadcasts at `important`, so an
+agent never picks a level as well — passing `--level` alongside `--blocked` is a
+usage error, not a silent override. The broadcast carries the ask plus the literal
+`agents focus <id>` command that unblocks it, so the message contains the one
+action the operator has to take.
+
+`--option <label>` (repeatable) records an answerable choice; `--default <answer>`
+makes the block an **approval** (a safe default policy may apply on no answer)
+instead of a **decision** (only a human can choose) — the distinction
+`feed-policy.ts` already keys off.
+
+**It fails loud.** A block that reaches no sink exits non-zero: a silently
+undelivered "needs you" is precisely the failure this exists to remove. One sink
+failing among several is only a warning, since the channels are redundant.
+
 - **`--attach <path-or-url…>` (repeatable).** Attach an artifact to the post. A
   **local file** is copied under
   `~/.agents/.history/attachments/<sessionId>/<updateId>/` so the reference survives
@@ -738,6 +777,15 @@ separated), and `{message}` — a composed human line, `<project> · <text>` wit
 first attached URL on a second line. Prefer `{message}` for a messaging sink: it
 leads with the project the reader cares about and carries a clickable link,
 rather than opening with an agent name that tells them nothing.
+
+**Blocked posts add four more:** `{focus}` (the literal `agents focus <id>` command
+that unblocks the session), `{class}` (`approval` | `decision`), `{cost}` (the
+cost-of-delay tag), and `{block}` (the block id). For a blocked post `{message}`
+already appends the `{focus}` line, so a messaging sink needs no extra template
+work to carry the one action the reader must take. Note the placeholder grammar is
+lowercase-only (`/\{([a-z]+)\}/`), which is why the id is `{block}` and not
+`{blockId}` — a camelCase token would never substitute, and a template with an
+unsubstituted token is **skipped**, not sent with a hole in it.
 
 The **ticket is joined from the session index**, not passed as a flag — it is a
 domain fact about the session (the rule above), and an agent that has to remember

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -27,16 +27,6 @@ import {
   type OpenBlock,
 } from '../lib/feed.js';
 
-/** Flags for `feed post`. Declared once — the action reads them off both the child and the parent. */
-interface PostCliOpts {
-  session?: string;
-  attach?: string[];
-  level?: string;
-  blocked?: boolean;
-  option?: string[];
-  default?: string;
-  json?: boolean;
-}
 import {
   ensureActivityLogHook,
   readRecentActivity,
@@ -53,6 +43,7 @@ import {
   planFeedBroadcast,
   runFeedBroadcast,
   blockBroadcastContext,
+  blockDeliveryFailure,
   type FeedPostLevel,
   type SinkOutcome,
 } from '../lib/feed-broadcast.js';
@@ -90,6 +81,17 @@ import {
   synthesizeControlCards,
   type FeedSessionSignal,
 } from '../lib/feed-ranking.js';
+
+/** Flags for `feed post`. Declared once — the action reads them off both the child and the parent. */
+interface PostCliOpts {
+  session?: string;
+  attach?: string[];
+  level?: string;
+  blocked?: boolean;
+  option?: string[];
+  default?: string;
+  json?: boolean;
+}
 
 export const FEED_NO_FANOUT_ENV = 'AGENTS_FEED_LOCAL';
 
@@ -430,23 +432,24 @@ docs/06-observability.md.
           outcomes = broadcastPostedEvent(event, level);
         }
 
+        // Fail loud when a block reached nobody. This is computed BEFORE the
+        // --json early return: a machine caller is exactly the one that reads the
+        // exit code, so returning 0 there while a human gets 1 would make the
+        // undelivered block invisible to the caller most likely to act on it —
+        // reintroducing, behind a flag, the silent failure this exists to remove.
+        // One sink failing among several stays a warning: the channels are
+        // redundant by design.
+        const undelivered = blockDeliveryFailure(flags.blocked, outcomes);
+        if (undelivered) process.exitCode = 1;
+
         if (flags.json) {
           console.log(JSON.stringify(outcomes.length ? { ...event, broadcast: outcomes } : event, null, 2));
+          if (undelivered) console.error(chalk.red(undelivered));
           return;
         }
         console.log(formatProgressUpdate(event));
         reportBroadcast(outcomes);
-        // Fail loud when a block reached nobody. A silent undelivered block is
-        // the exact bug this subsystem exists to remove, so it must not be a
-        // clean exit -- but one sink failing among several is only a warning,
-        // since the channels are redundant by design.
-        if (flags.blocked && outcomes.length > 0 && outcomes.every((o) => !o.ok)) {
-          console.error(chalk.red('Block recorded but NOT delivered — every feed.broadcast sink failed.'));
-          process.exitCode = 1;
-        } else if (flags.blocked && outcomes.length === 0) {
-          console.error(chalk.yellow('Block recorded but not broadcast — no feed.broadcast sink configured.'));
-          process.exitCode = 1;
-        }
+        if (undelivered) console.error(chalk.red(undelivered));
       } catch (err) {
         console.error(chalk.red((err as Error).message));
         process.exitCode = 1;

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -17,7 +17,26 @@
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
-import { ensureFeedPublishHook, listAskStats, listBlocks, recordNotified, type OpenBlock } from '../lib/feed.js';
+import {
+  ensureFeedPublishHook,
+  listAskStats,
+  listBlocks,
+  recordNotified,
+  buildDeclaredBlock,
+  publishBlock,
+  type OpenBlock,
+} from '../lib/feed.js';
+
+/** Flags for `feed post`. Declared once — the action reads them off both the child and the parent. */
+interface PostCliOpts {
+  session?: string;
+  attach?: string[];
+  level?: string;
+  blocked?: boolean;
+  option?: string[];
+  default?: string;
+  json?: boolean;
+}
 import {
   ensureActivityLogHook,
   readRecentActivity,
@@ -33,6 +52,7 @@ import {
   parseFeedPostLevel,
   planFeedBroadcast,
   runFeedBroadcast,
+  blockBroadcastContext,
   type FeedPostLevel,
   type SinkOutcome,
 } from '../lib/feed-broadcast.js';
@@ -320,6 +340,9 @@ export function registerFeedCommand(program: Command): void {
     .option('--session <id>', 'Session id escape hatch (default: auto from env / pid registry)')
     .option('--attach <path-or-url...>', 'Attach an artifact (local file or URL); repeatable')
     .option('--level <level>', 'How loudly to broadcast: milestone (default) or important. Configured sinks with minLevel: important only fire on the latter.', 'milestone')
+    .option('--blocked', 'You are STUCK and need the user. Opens an answerable block and always broadcasts at important — do not also pass --level.')
+    .option('--option <label...>', 'With --blocked: an answer the user can pick; repeatable')
+    .option('--default <answer>', 'With --blocked: a safe default policy may apply if nobody answers in time')
     .option('--json', 'Emit the written event as JSON')
     .addHelpText('after', `
 Examples:
@@ -330,6 +353,17 @@ Examples:
 
   # Worth interrupting someone over — reaches sinks gated on minLevel: important:
   agents feed post "release blocked: npm token expired" --level important
+
+  # You are STUCK and cannot proceed. Opens an answerable block that stays in
+  # 'agents feed' until someone resolves it, and always reaches the owner —
+  # do NOT also pass --level:
+  agents feed post "force-push denied by git-guard on PR #1749" --blocked
+  agents feed post "publish to npm or wait for review?" --blocked --option publish --option wait
+  agents feed post "delete the stale preview env?" --blocked --default "leave it"
+
+  # Exhaust self-serve FIRST. A block is for what you genuinely cannot do:
+  # a credential only the user holds, a decision only they can make, an
+  # approval only they can give. Not "should I do the obvious next step?".
 
   # Outside a run, pass the session explicitly:
   agents feed post "manual note" --session 00998b0e-2d15-4d2f-a58b-974a886c9b47
@@ -344,8 +378,8 @@ docs/06-observability.md.
 `)
     .action((
       textParts: string[],
-      opts: { session?: string; attach?: string[]; level?: string; json?: boolean },
-      cmd?: { opts: () => { session?: string; attach?: string[]; level?: string; json?: boolean }; parent?: { opts: () => { json?: boolean } } },
+      opts: PostCliOpts,
+      cmd?: { opts: () => PostCliOpts; parent?: { opts: () => { json?: boolean } } },
     ) => {
       // Parent `feed` also declares `--json` (for the list view). Commander
       // binds the flag on the parent, so a `feed post … --json` lands on
@@ -354,22 +388,65 @@ docs/06-observability.md.
         session: opts?.session ?? cmd?.opts?.()?.session,
         attach: opts?.attach ?? cmd?.opts?.()?.attach,
         level: opts?.level ?? cmd?.opts?.()?.level,
+        blocked: Boolean(opts?.blocked ?? cmd?.opts?.()?.blocked),
+        option: opts?.option ?? cmd?.opts?.()?.option,
+        default: opts?.default ?? cmd?.opts?.()?.default,
         json: Boolean(opts?.json ?? cmd?.opts?.()?.json ?? cmd?.parent?.opts?.()?.json),
       };
       try {
-        const level = parseFeedPostLevel(flags.level);
+        // Blocked is a state, not a volume: it always broadcasts at `important`,
+        // so an agent has exactly one thing to say. Passing both is a usage
+        // error rather than a silent override -- an agent that thinks it chose
+        // the level should not be quietly ignored.
+        if (flags.blocked && flags.level && flags.level !== 'milestone') {
+          throw new Error('--blocked already broadcasts at important; drop --level.');
+        }
+        if (!flags.blocked && (flags.option?.length || flags.default)) {
+          throw new Error('--option/--default only apply with --blocked.');
+        }
+        const level = flags.blocked ? 'important' : parseFeedPostLevel(flags.level);
+
         const { event } = postFeedStatus({
           text: Array.isArray(textParts) ? textParts.join(' ') : String(textParts ?? ''),
           sessionId: flags.session,
           attach: flags.attach,
+          blocked: flags.blocked,
         });
-        const outcomes = broadcastPostedEvent(event, level);
+
+        // A blocked post lands in BOTH stores: the event in the shared activity
+        // stream (what happened) and an OpenBlock in the ledger (what is still
+        // open). The ledger is what makes it answerable and clearable -- without
+        // it the ask would scroll away like any other update.
+        let outcomes: SinkOutcome[];
+        if (flags.blocked) {
+          const block = buildDeclaredBlock(event, {
+            text: event.detail ?? '',
+            options: flags.option,
+            safeDefault: flags.default,
+          });
+          publishBlock(block);
+          outcomes = broadcastBlock(block, { project: event.project, agent: event.agent });
+        } else {
+          outcomes = broadcastPostedEvent(event, level);
+        }
+
         if (flags.json) {
           console.log(JSON.stringify(outcomes.length ? { ...event, broadcast: outcomes } : event, null, 2));
           return;
         }
         console.log(formatProgressUpdate(event));
         reportBroadcast(outcomes);
+        // Fail loud when a block reached nobody. A silent undelivered block is
+        // the exact bug this subsystem exists to remove, so it must not be a
+        // clean exit -- but one sink failing among several is only a warning,
+        // since the channels are redundant by design.
+        if (flags.blocked && outcomes.length > 0 && outcomes.every((o) => !o.ok)) {
+          console.error(chalk.red('Block recorded but NOT delivered — every feed.broadcast sink failed.'));
+          process.exitCode = 1;
+        } else if (flags.blocked && outcomes.length === 0) {
+          console.error(chalk.yellow('Block recorded but not broadcast — no feed.broadcast sink configured.'));
+          process.exitCode = 1;
+        }
       } catch (err) {
         console.error(chalk.red((err as Error).message));
         process.exitCode = 1;
@@ -625,6 +702,24 @@ function broadcastPostedEvent(event: ActivityEvent, level: FeedPostLevel): SinkO
       .filter((href) => /^https?:\/\//i.test(href)),
   });
   return runFeedBroadcast(planned);
+}
+
+/**
+ * Mirror a declared block to the same sinks a post reaches.
+ *
+ * Blocks previously never broadcast at all: `broadcastPostedEvent` ran only for
+ * `feed post`, while every `publishBlock` call wrote to the ledger and stopped
+ * there — so a "needs you" record was durable and invisible at the same time.
+ */
+function broadcastBlock(
+  block: OpenBlock,
+  extras: { project?: string; agent?: string },
+): SinkOutcome[] {
+  const config = readMeta().feed?.broadcast;
+  if (!config || Object.keys(config).length === 0) return [];
+  const ticket = getSessionById(block.sessionId)?.ticketId;
+  const ctx = blockBroadcastContext({ ...block, ticket: block.ticket ?? ticket }, extras);
+  return runFeedBroadcast(planFeedBroadcast(config, ctx));
 }
 
 /** One line per sink that ran. Silent when nothing is configured. */

--- a/apps/cli/src/commands/send.ts
+++ b/apps/cli/src/commands/send.ts
@@ -1,6 +1,10 @@
 /**
  * `agents send <text> --channel <name> --to <target>` — deliver a message over
- * any registered channel (mailbox, telegram, imessage, slack, discord, apps).
+ * any registered channel (mailbox, telegram, imessage, slack, discord, desktop, apps).
+ *
+ * `desktop` is the local machine's notification centre — the only channel with no
+ * external dependency, so it still reaches the operator at their Mac when a
+ * messaging gateway is down.
  *
  * `agents notify <text>` — owner-facing alias. Fills channel + target from the
  * `notify.owner` block in agents.yaml when not passed, so routines/agents ping
@@ -56,7 +60,7 @@ async function doSend(text: string, channel: string, to: string, opts: SendCliOp
 export function registerSendCommand(program: Command): void {
   program
     .command('send <text>')
-    .description('Send a message through a channel provider (mailbox, telegram, imessage, slack, discord).')
+    .description('Send a message through a channel provider (mailbox, telegram, imessage, slack, discord, desktop).')
     .requiredOption('--channel <name>', 'channel / provider name')
     .requiredOption('--to <target>', 'channel-specific recipient id')
     .option('--thread <id>', 'channel thread id / timestamp')

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -42,7 +42,17 @@ export type MilestoneEvent =
   | 'task.completed'
   | 'checklist.created'
   /** Deliberate agent-authored progress post (`agents feed post`). */
-  | 'status.posted';
+  | 'status.posted'
+  /**
+   * The same post, but the agent is STUCK (`agents feed post --blocked`).
+   *
+   * A distinct event rather than a flag on `status.posted` because it is a
+   * different kind of thing in the stream: a benign update is history the
+   * moment it lands, while a blocked post stays open until someone answers it.
+   * Readers that show "what needs a human" select on this; readers that show
+   * "what happened" get both.
+   */
+  | 'status.blocked';
 
 /** Routine activity events, collapsed to counts by readers. */
 export type ActivityKind = 'file.edited';
@@ -89,6 +99,7 @@ export const MILESTONE_EVENTS: readonly MilestoneEvent[] = [
   'task.completed',
   'checklist.created',
   'status.posted',
+  'status.blocked',
 ];
 
 const MILESTONE_SET = new Set<string>(MILESTONE_EVENTS);

--- a/apps/cli/src/lib/channels/providers/desktop.test.ts
+++ b/apps/cli/src/lib/channels/providers/desktop.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import * as os from 'os';
+import { desktopProvider, desktopNotifier, desktopDeliverable, splitDesktopMessage } from './desktop.js';
+import { spawnSync } from 'child_process';
+import { registerBuiltinProviders } from './index.js';
+import { resolveChannelProvider, listChannelProviders } from '../registry.js';
+
+describe('splitDesktopMessage', () => {
+  // A broadcast sink hands over composeBroadcastMessage's shape: "<project> · <text>"
+  // with the link on line 2. Getting this wrong buries the ask in the body where
+  // the banner truncates it.
+  it('puts the first line in the title and the link underneath', () => {
+    const { title, body } = splitDesktopMessage(
+      'agents-cli · release blocked: npm token expired\nhttps://github.com/x/y/pull/1',
+    );
+    expect(title).toBe('agents-cli · release blocked: npm token expired');
+    expect(body).toBe('https://github.com/x/y/pull/1');
+  });
+
+  it('keeps a short single-line message whole in the title', () => {
+    const { title, body } = splitDesktopMessage('force-push denied on PR #1749');
+    expect(title).toBe('force-push denied on PR #1749');
+    expect(body).toBe('');
+  });
+
+  // The real bug this guards: a long ask silently losing its tail. The remainder
+  // must still be delivered in the body, not dropped.
+  it('carries the remainder of a long single line into the body, losing nothing', () => {
+    const text =
+      'force-push denied by git-guard on PR #1749 and I need you to either grant the permission or push it yourself';
+    const { title, body } = splitDesktopMessage(text);
+    expect(title.length).toBeLessThanOrEqual(64);
+    expect(body).not.toBe('');
+    // Nothing is dropped: title + body reconstitute the original words.
+    expect(`${title} ${body}`.split(/\s+/)).toEqual(text.split(/\s+/));
+  });
+
+  it('breaks on a word boundary rather than mid-word', () => {
+    const text = `${'a'.repeat(20)} ${'b'.repeat(20)} ${'c'.repeat(40)}`;
+    const { title } = splitDesktopMessage(text);
+    expect(title.endsWith('-')).toBe(false);
+    expect(title.split(/\s+/).every((w) => text.includes(w))).toBe(true);
+  });
+});
+
+describe('desktopNotifier', () => {
+  it('reports a notifier on the platforms notifyDesktop actually wires', () => {
+    expect(desktopNotifier('darwin')).toBeTruthy();
+    expect(desktopNotifier('linux')).toBeTruthy();
+  });
+
+  // notifyDesktop is a documented no-op off darwin/linux. Claiming deliverability
+  // there is the silent-failure bug this whole subsystem exists to remove.
+  it('reports none where notifyDesktop is a no-op', () => {
+    expect(desktopNotifier('win32')).toBeUndefined();
+    expect(desktopNotifier('aix')).toBeUndefined();
+  });
+});
+
+describe('desktopProvider', () => {
+  it('registers as a channel named desktop alongside the other providers', () => {
+    registerBuiltinProviders();
+    expect(resolveChannelProvider('desktop')).toBeDefined();
+    expect(listChannelProviders()).toContain('desktop');
+  });
+
+  it('dry-run resolves without posting a notification', async () => {
+    const res = await desktopProvider.send('hi', { target: 'local', dryRun: true });
+    expect(res.ok).toBe(true);
+    expect(res.channel).toBe('desktop');
+    expect(res.id).toBe('local');
+  });
+
+  it('echoes the hostname when no target is given', async () => {
+    const res = await desktopProvider.send('hi', { target: '', dryRun: true });
+    expect(res.id).toBe(os.hostname());
+  });
+
+  // Empty text would post a blank banner the operator cannot act on, and on macOS
+  // MenubarHelper's one-shot exits 2 without a title. Fail loud instead.
+  it('refuses an empty message rather than posting a blank banner', async () => {
+    const res = await desktopProvider.send('   \n  ', { target: 'local', dryRun: true });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/empty/i);
+  });
+
+  // Runs the REAL send path (notifyDesktop is detached + best effort, so this
+  // exercises delivery without asserting on a GUI). The assertion follows the
+  // real deliverability probe, so it holds on a Mac, on a Linux desktop, and on
+  // a headless box with no notify-send.
+  it('reports honestly for the current platform', async () => {
+    const res = await desktopProvider.send('agents-cli test\nbody line', { target: 'local' });
+    const deliverable = desktopDeliverable();
+    expect(res.ok).toBe(deliverable.ok);
+    if (!deliverable.ok) expect(res.error).toBe(deliverable.reason);
+  });
+});
+
+describe('desktopDeliverable', () => {
+  // The bug this guards: reporting ok from the platform name alone. On a headless
+  // Linux box notify-send is absent and notifyDesktop swallows the ENOENT, so a
+  // platform-only answer would mark an undelivered notification as delivered --
+  // the same silent failure relocated.
+  it('probes for notify-send on linux rather than trusting the platform', () => {
+    const hasNotifySend = spawnSync('which', ['notify-send'], { stdio: 'ignore' }).status === 0;
+    const verdict = desktopDeliverable('linux');
+    expect(verdict.ok).toBe(hasNotifySend);
+    if (!verdict.ok) expect(verdict.reason).toMatch(/notify-send not on PATH/);
+  });
+
+  it('needs no probe on darwin — osascript ships with the OS', () => {
+    expect(desktopDeliverable('darwin')).toEqual({ ok: true });
+  });
+
+  it('fails loud where notifyDesktop is a no-op', () => {
+    const verdict = desktopDeliverable('win32');
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toMatch(/no desktop notifier on win32/);
+  });
+});

--- a/apps/cli/src/lib/channels/providers/desktop.test.ts
+++ b/apps/cli/src/lib/channels/providers/desktop.test.ts
@@ -64,7 +64,13 @@ describe('desktopProvider', () => {
     expect(listChannelProviders()).toContain('desktop');
   });
 
-  it('dry-run resolves without posting a notification', async () => {
+  // These two pin an ORDERING that CI caught and a dev box hides: a machine WITH
+  // notify-send passes them either way, so both bugs were invisible locally and
+  // only failed on a runner with no notifier. `--dry-run` means "resolve + build
+  // but do not send", so it must not depend on the ability to send; and an empty
+  // message is a caller error on every platform, so it must not be masked by
+  // "this box has no notifier". Both must therefore hold regardless of platform.
+  it('dry-run resolves even where nothing could actually be delivered', async () => {
     const res = await desktopProvider.send('hi', { target: 'local', dryRun: true });
     expect(res.ok).toBe(true);
     expect(res.channel).toBe('desktop');
@@ -77,11 +83,13 @@ describe('desktopProvider', () => {
   });
 
   // Empty text would post a blank banner the operator cannot act on, and on macOS
-  // MenubarHelper's one-shot exits 2 without a title. Fail loud instead.
-  it('refuses an empty message rather than posting a blank banner', async () => {
+  // MenubarHelper's one-shot exits 2 without a title. Fail loud instead — and with
+  // the CALLER's error, not the platform's, on a box with no notifier.
+  it('refuses an empty message with the caller error, not the platform error', async () => {
     const res = await desktopProvider.send('   \n  ', { target: 'local', dryRun: true });
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/empty/i);
+    expect(res.error).not.toMatch(/notify-send|no desktop notifier/);
   });
 
   // Runs the REAL send path (notifyDesktop is detached + best effort, so this

--- a/apps/cli/src/lib/channels/providers/desktop.ts
+++ b/apps/cli/src/lib/channels/providers/desktop.ts
@@ -115,11 +115,14 @@ export const desktopProvider: ChannelProvider = {
     // provider, and `agents notify` still requires notify.owner.to to be set.
     const id = opts.target || os.hostname();
 
-    const deliverable = desktopDeliverable();
-    if (!deliverable.ok) {
-      return { ok: false, channel: NAME, id, error: deliverable.reason };
-    }
-
+    // Order matters, and CI caught it: validate the CALLER first, then honour
+    // dry-run, and only then probe the platform.
+    //
+    // An empty message is a caller error on every platform, so it must not be
+    // masked by "this box has no notifier" — the specific, actionable error wins.
+    // And `--dry-run` means "resolve + build but do not send", so it must not
+    // depend on the ability to send; the sibling rush provider likewise returns
+    // ok for a dry run before its own `which rush` check (providers/rush.ts).
     const { title, body } = splitDesktopMessage(text);
     if (!title) {
       return { ok: false, channel: NAME, id, error: 'refusing to send an empty notification' };
@@ -127,6 +130,11 @@ export const desktopProvider: ChannelProvider = {
 
     if (opts.dryRun) {
       return { ok: true, channel: NAME, id };
+    }
+
+    const deliverable = desktopDeliverable();
+    if (!deliverable.ok) {
+      return { ok: false, channel: NAME, id, error: deliverable.reason };
     }
 
     notifyDesktop({ title, body });

--- a/apps/cli/src/lib/channels/providers/desktop.ts
+++ b/apps/cli/src/lib/channels/providers/desktop.ts
@@ -1,0 +1,135 @@
+/**
+ * Desktop provider — the local machine's native notification centre.
+ *
+ * The only channel with no external dependency: no network, no login, no vendor
+ * CLI. On the Mac the operator is sitting at it works when every other channel is
+ * dead, which is exactly when a blocked agent most needs to reach them.
+ *
+ * Delivery reuses `notifyDesktop` (lib/menubar/notify-desktop.ts), so a message
+ * sent here is attributed to MenubarHelper.app and carries the agents-cli mark —
+ * the same path that produces the "agents-cli / <title> / <body>" entries already
+ * in Notification Center.
+ *
+ * WHY THIS ISN'T A THIN PASSTHROUGH: `notifyDesktop` is deliberately
+ * fire-and-forget — it spawns detached and swallows every failure so a hiccup can
+ * never take the daemon down. A channel provider cannot inherit that: a sink that
+ * always reports `ok: true` would make an undelivered notification look delivered,
+ * which is the precise class of silent failure this whole subsystem exists to
+ * kill. So the provider resolves *deliverability* up front — is there a notifier
+ * on this platform at all — and fails loud when there is not. It reports what it
+ * can actually know: on a platform with no notifier, nothing will arrive.
+ */
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+import { notifyDesktop } from '../../menubar/notify-desktop.js';
+import type { ChannelProvider, SendOptions, SendResult } from '../registry.js';
+
+const NAME = 'desktop';
+
+/** Longest title before macOS truncates it in the banner. Keeps the ask readable. */
+const TITLE_MAX = 64;
+
+/**
+ * Split one message into the notification's title and body.
+ *
+ * A broadcast sink hands us `composeBroadcastMessage`'s shape — `<project> · <text>`
+ * with any link on a second line — so honouring the newline puts the human
+ * sentence in the title and the URL underneath, which is how the existing
+ * daemon notifications already read.
+ *
+ * Notification banners show roughly two lines before an ellipsis, so a long
+ * single-line message is split at the title boundary rather than truncated away:
+ * the head becomes the title and the remainder still arrives in the body.
+ */
+export function splitDesktopMessage(text: string): { title: string; body: string } {
+  const trimmed = text.trim();
+  const newline = trimmed.indexOf('\n');
+  if (newline !== -1) {
+    return {
+      title: trimmed.slice(0, newline).trim().slice(0, TITLE_MAX),
+      body: trimmed.slice(newline + 1).trim(),
+    };
+  }
+  if (trimmed.length <= TITLE_MAX) {
+    return { title: trimmed, body: '' };
+  }
+  // Break on the last word boundary inside the limit so the title doesn't end
+  // mid-word; fall back to a hard cut when there is no space to break on.
+  const head = trimmed.slice(0, TITLE_MAX);
+  const cut = head.lastIndexOf(' ');
+  const at = cut > TITLE_MAX / 2 ? cut : TITLE_MAX;
+  return { title: trimmed.slice(0, at).trim(), body: trimmed.slice(at).trim() };
+}
+
+/**
+ * Which native notifier this platform wires, or undefined when it wires none.
+ *
+ * macOS always ships `osascript`, and `notifyDesktop` prefers the branded
+ * MenubarHelper when installed and degrades to osascript otherwise — either way
+ * something delivers. Linux depends on `notify-send`, which is NOT guaranteed
+ * (a headless box typically lacks it), so the platform answer alone is not proof
+ * there — see `desktopDeliverable`. Every other platform has no wired notifier at
+ * all (`notifyDesktop` is a documented no-op), so sending there must fail loud.
+ *
+ * Pure and platform-injectable so the gate is testable without spawning.
+ */
+export function desktopNotifier(platform: NodeJS.Platform = os.platform()): string | undefined {
+  if (platform === 'darwin') return 'menubar-or-osascript';
+  if (platform === 'linux') return 'notify-send';
+  return undefined;
+}
+
+/**
+ * Whether a notification sent right now would actually arrive.
+ *
+ * On Linux the notifier is a separate binary that is frequently absent, and
+ * `notifyDesktop` spawns it detached — an ENOENT surfaces asynchronously and is
+ * swallowed. Reporting `ok` off the platform name alone would therefore mark an
+ * undelivered notification as delivered, which is the same silent failure this
+ * provider exists to remove, just relocated. So probe for the binary.
+ *
+ * macOS needs no probe: `osascript` is part of the OS, so the degrade path is
+ * always available even when MenubarHelper is not installed.
+ */
+export function desktopDeliverable(
+  platform: NodeJS.Platform = os.platform(),
+): { ok: true } | { ok: false; reason: string } {
+  const notifier = desktopNotifier(platform);
+  if (!notifier) {
+    return { ok: false, reason: `no desktop notifier on ${platform} — nothing would be delivered` };
+  }
+  if (platform === 'linux') {
+    const probe = spawnSync('which', ['notify-send'], { stdio: 'ignore' });
+    if (probe.status !== 0) {
+      return { ok: false, reason: 'notify-send not on PATH — nothing would be delivered' };
+    }
+  }
+  return { ok: true };
+}
+
+export const desktopProvider: ChannelProvider = {
+  name: NAME,
+  async send(text: string, opts: SendOptions): Promise<SendResult> {
+    // `target` is meaningless for a local notification — the recipient is whoever
+    // is at this machine — but it is echoed for --json parity with every other
+    // provider, and `agents notify` still requires notify.owner.to to be set.
+    const id = opts.target || os.hostname();
+
+    const deliverable = desktopDeliverable();
+    if (!deliverable.ok) {
+      return { ok: false, channel: NAME, id, error: deliverable.reason };
+    }
+
+    const { title, body } = splitDesktopMessage(text);
+    if (!title) {
+      return { ok: false, channel: NAME, id, error: 'refusing to send an empty notification' };
+    }
+
+    if (opts.dryRun) {
+      return { ok: true, channel: NAME, id };
+    }
+
+    notifyDesktop({ title, body });
+    return { ok: true, channel: NAME, id };
+  },
+};

--- a/apps/cli/src/lib/channels/providers/index.ts
+++ b/apps/cli/src/lib/channels/providers/index.ts
@@ -7,6 +7,7 @@ import { registerChannelProvider } from '../registry.js';
 import { mailboxProvider } from './mailbox.js';
 import { rushProviders } from './rush.js';
 import { openclawTelegramProvider } from './openclaw-telegram.js';
+import { desktopProvider } from './desktop.js';
 
 let registered = false;
 
@@ -17,4 +18,5 @@ export function registerBuiltinProviders(): void {
   registerChannelProvider(mailboxProvider);
   for (const p of rushProviders) registerChannelProvider(p);
   registerChannelProvider(openclawTelegramProvider);
+  registerChannelProvider(desktopProvider);
 }

--- a/apps/cli/src/lib/feed-blocked.test.ts
+++ b/apps/cli/src/lib/feed-blocked.test.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { buildDeclaredBlock, publishBlock, listBlocks, type DeclaringAgent } from './feed.js';
-import { blockBroadcastContext, planFeedBroadcast, renderSinkArgv } from './feed-broadcast.js';
+import { blockBroadcastContext, planFeedBroadcast, renderSinkArgv, blockDeliveryFailure } from './feed-broadcast.js';
 import { MILESTONE_EVENTS, tierForEvent } from './activity.js';
 
 const AGENT: DeclaringAgent = {
@@ -123,5 +123,38 @@ describe('blockBroadcastContext', () => {
       project: 'agents-cli',
     });
     expect(argv).toEqual(['agents-cli · CI green']);
+  });
+});
+
+describe('blockDeliveryFailure — the fail-loud contract', () => {
+  const ok = { name: 'owner', ok: true };
+  const bad = { name: 'owner', ok: false, error: 'rush CLI not found on PATH' };
+
+  // This lived inline in the command action and was therefore never covered,
+  // which is exactly how a `--json` early-return silently bypassed it: the
+  // machine caller — the one that actually reads the exit code — got 0 while a
+  // human got 1. Reviewer caught it; this pins the contract in a pure function.
+  it('reports failure when no sink is configured', () => {
+    expect(blockDeliveryFailure(true, [])).toMatch(/no feed\.broadcast sink configured/);
+  });
+
+  it('reports failure, with the reason, when every sink failed', () => {
+    const msg = blockDeliveryFailure(true, [bad, { name: 'other', ok: false, error: 'daemon down' }]);
+    expect(msg).toMatch(/every feed\.broadcast sink failed/);
+    expect(msg).toContain('rush CLI not found on PATH');
+    expect(msg).toContain('daemon down');
+  });
+
+  // Redundant channels are the whole point: a dead rush login must not mask a
+  // delivered desktop notification.
+  it('stays silent when at least one sink got through', () => {
+    expect(blockDeliveryFailure(true, [bad, ok])).toBeUndefined();
+    expect(blockDeliveryFailure(true, [ok])).toBeUndefined();
+  });
+
+  // A plain status post is fire-and-forget; an unconfigured sink is not an error.
+  it('never fails a non-blocked post', () => {
+    expect(blockDeliveryFailure(false, [])).toBeUndefined();
+    expect(blockDeliveryFailure(false, [bad])).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/feed-blocked.test.ts
+++ b/apps/cli/src/lib/feed-blocked.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `agents feed post --blocked` — the declared-block path.
+ *
+ * Real path throughout: a block is built from a real posted event, written to a
+ * real temp feed dir, read back with the real reader, and planned against a real
+ * sink config. Nothing is mocked.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { buildDeclaredBlock, publishBlock, listBlocks, type DeclaringAgent } from './feed.js';
+import { blockBroadcastContext, planFeedBroadcast, renderSinkArgv } from './feed-broadcast.js';
+import { MILESTONE_EVENTS, tierForEvent } from './activity.js';
+
+const AGENT: DeclaringAgent = {
+  sessionId: '74a4893f-63b3-49ef-bbcb-2437914f792e',
+  mailboxId: '74a4893f-63b3-49ef-bbcb-2437914f792e',
+  host: 'yosemite-s1',
+  runtime: 'headless',
+};
+
+let root: string;
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'feed-blocked-'));
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('status.blocked event kind', () => {
+  // A blocked post must rank as a milestone, not routine activity — readers
+  // collapse `activity` tier to counts, which would bury the one thing that
+  // needs a human.
+  it('is a milestone, so readers never collapse it into a count', () => {
+    expect(MILESTONE_EVENTS).toContain('status.blocked');
+    expect(tierForEvent('status.blocked')).toBe('milestone');
+  });
+});
+
+describe('buildDeclaredBlock', () => {
+  it('derives approval from a safe default and decision without one', () => {
+    const decision = buildDeclaredBlock(AGENT, { text: 'publish or wait?' });
+    expect(decision.blockClass).toBe('decision');
+    expect(decision.safeDefault).toBeUndefined();
+
+    const approval = buildDeclaredBlock(AGENT, { text: 'delete stale env?', safeDefault: 'leave it' });
+    expect(approval.blockClass).toBe('approval');
+    expect(approval.safeDefault).toBe('leave it');
+  });
+
+  // costOfDelay drives the urgency filter (isPhoneUrgent). A declared block is by
+  // definition an agent that has stopped, so it must not rank as low-cost.
+  it('marks a declared block high cost-of-delay', () => {
+    expect(buildDeclaredBlock(AGENT, { text: 'stuck' }).costOfDelay).toBe('high');
+    expect(buildDeclaredBlock(AGENT, { text: 'stuck' }).kind).toBe('declared');
+  });
+
+  it('carries answerable options through as BlockOptions', () => {
+    const b = buildDeclaredBlock(AGENT, { text: 'pick', options: ['publish', ' wait ', ''] });
+    expect(b.questions[0].options).toEqual([{ label: 'publish' }, { label: 'wait' }]);
+  });
+
+  it('refuses empty text rather than opening a block nobody can act on', () => {
+    expect(() => buildDeclaredBlock(AGENT, { text: '   ' })).toThrow(/empty/i);
+  });
+
+  it('round-trips through the real store and is readable as an open block', () => {
+    const block = buildDeclaredBlock(AGENT, { text: 'force-push denied by git-guard on PR #1749' });
+    publishBlock(block, root);
+    const read = listBlocks(root);
+    expect(read).toHaveLength(1);
+    expect(read[0].kind).toBe('declared');
+    expect(read[0].questions[0].text).toBe('force-push denied by git-guard on PR #1749');
+    expect(read[0].sessionId).toBe(AGENT.sessionId);
+  });
+});
+
+describe('blockBroadcastContext', () => {
+  const block = buildDeclaredBlock(AGENT, { text: 'npm token expired, cannot publish' });
+
+  it('always broadcasts a block at important — the state implies the volume', () => {
+    expect(blockBroadcastContext(block).level).toBe('important');
+  });
+
+  // The operator reading this on a phone should not have to go find the session.
+  it('carries the exact command that unblocks it', () => {
+    const ctx = blockBroadcastContext(block);
+    expect(ctx.focus).toBe('agents focus 74a4893f');
+  });
+
+  // A sink gated on minLevel:important must actually receive a block. Before this
+  // wiring, publishBlock never reached the broadcast layer at all.
+  it('reaches an important-gated sink, with the ask and the fix in the message', () => {
+    const planned = planFeedBroadcast(
+      { owner: { command: ['agents', 'notify', '{message}'], minLevel: 'important' } },
+      blockBroadcastContext(block, { project: 'agents-cli' }),
+    );
+    expect(planned).toHaveLength(1);
+    const message = planned[0].argv[2];
+    expect(message).toContain('agents-cli · npm token expired, cannot publish');
+    expect(message).toContain('agents focus 74a4893f');
+  });
+
+  // The placeholder regex is /\{([a-z]+)\}/g — lowercase only. A camelCase name
+  // would never substitute, and renderSinkArgv would silently skip the sink.
+  it('exposes block placeholders that the lowercase-only regex can actually match', () => {
+    const argv = renderSinkArgv(['x', '{focus}', '{class}', '{cost}', '{block}'], blockBroadcastContext(block));
+    expect(argv).toBeDefined();
+    expect(argv!.slice(1)).toEqual([
+      'agents focus 74a4893f',
+      'decision',
+      'high',
+      block.blockId,
+    ]);
+  });
+
+  // A status post has no focus command, so the sink must still render for it.
+  it('leaves a plain post unaffected — no focus line appended', () => {
+    const argv = renderSinkArgv(['{message}'], {
+      text: 'CI green',
+      level: 'milestone',
+      project: 'agents-cli',
+    });
+    expect(argv).toEqual(['agents-cli · CI green']);
+  });
+});

--- a/apps/cli/src/lib/feed-broadcast.ts
+++ b/apps/cli/src/lib/feed-broadcast.ts
@@ -67,6 +67,59 @@ export interface FeedBroadcastContext {
   session?: string;
   /** URLs attached to the post — the PR, the ticket, a shared plan. */
   links?: string[];
+  /** Block-only: the block's stable id. Absent on a status post. */
+  blockId?: string;
+  /** Block-only: `approval` (has a safe default) or `decision` (needs a human). */
+  class?: string;
+  /** Block-only: cost-of-delay tag used by the urgency filter. */
+  cost?: string;
+  /** Block-only: the literal `agents focus <id>` command that unblocks it. */
+  focus?: string;
+}
+
+/**
+ * Map an open block onto the broadcast context, so a block reaches the same sinks
+ * a post does instead of dying in the ledger.
+ *
+ * The `text` is the ask itself, front-loaded — a notification banner shows roughly
+ * two lines, and a phone message is scanned, not read. `focus` carries the literal
+ * command that unblocks it, so the message the operator receives contains the one
+ * action they have to take rather than making them go find the session.
+ *
+ * Level is always `important`: a block is by definition an agent that has stopped
+ * making progress, so there is no per-block level flag to get wrong.
+ */
+export function blockBroadcastContext(
+  block: {
+    blockId: string;
+    sessionId: string;
+    host?: string;
+    questions?: Array<{ text?: string }>;
+    blockClass?: string;
+    costOfDelay?: string;
+    ticket?: string;
+    pr?: string;
+  },
+  extras: { project?: string; agent?: string } = {},
+): FeedBroadcastContext {
+  const ask = block.questions?.[0]?.text?.trim() || 'agent is blocked';
+  const links = [block.pr].filter((l): l is string => !!l && /^https?:\/\//i.test(l));
+  return {
+    text: ask,
+    level: 'important',
+    ticket: block.ticket,
+    project: extras.project,
+    agent: extras.agent,
+    host: block.host,
+    session: block.sessionId,
+    blockId: block.blockId,
+    class: block.blockClass,
+    cost: block.costOfDelay,
+    // Short id: `agents focus` matches on a prefix, and a full uuid in a phone
+    // message is noise the operator has to skip past to reach the verb.
+    focus: `agents focus ${block.sessionId.slice(0, 8)}`,
+    ...(links.length ? { links } : {}),
+  };
 }
 
 export interface PlannedSink {
@@ -92,7 +145,12 @@ const PLACEHOLDER = /\{([a-z]+)\}/g;
 export function composeBroadcastMessage(ctx: FeedBroadcastContext): string {
   const head = ctx.project ? `${ctx.project} · ${ctx.text}` : ctx.text;
   const link = ctx.links?.find((l) => /^https?:\/\//i.test(l));
-  return link ? `${head}\n${link}` : head;
+  // A block's second line is the command that unblocks it. The operator reading
+  // this on a phone should not have to go find the session — the one action they
+  // must take travels with the ask. A status post has no such action, so it keeps
+  // the link there instead.
+  const tail = [ctx.focus, link].filter(Boolean);
+  return tail.length ? `${head}\n${tail.join('\n')}` : head;
 }
 
 /** The values a template may reference, resolved once per post. */
@@ -107,6 +165,10 @@ function templateVars(ctx: FeedBroadcastContext): Record<string, string | undefi
     level: ctx.level,
     links: ctx.links?.length ? ctx.links.join(' ') : undefined,
     message: composeBroadcastMessage(ctx),
+    block: ctx.blockId,
+    class: ctx.class,
+    cost: ctx.cost,
+    focus: ctx.focus,
   };
 }
 

--- a/apps/cli/src/lib/feed-broadcast.ts
+++ b/apps/cli/src/lib/feed-broadcast.ts
@@ -122,6 +122,32 @@ export function blockBroadcastContext(
   };
 }
 
+/**
+ * Why a declared block reached nobody, or undefined when it got through.
+ *
+ * Pure so the fail-loud contract is testable without driving the CLI — the
+ * original version lived inline in the command action and was consequently
+ * never covered, which is how a `--json` early-return quietly bypassed it.
+ *
+ * Only a TOTAL failure counts. One sink failing among several is a warning, not
+ * an error: the channels are redundant by design, and a dead `rush` login must
+ * not mask a delivered desktop notification.
+ */
+export function blockDeliveryFailure(
+  blocked: boolean,
+  outcomes: SinkOutcome[],
+): string | undefined {
+  if (!blocked) return undefined;
+  if (outcomes.length === 0) {
+    return 'Block recorded but NOT delivered — no feed.broadcast sink configured.';
+  }
+  if (outcomes.every((o) => !o.ok)) {
+    const why = outcomes.map((o) => `${o.name}: ${o.error ?? 'failed'}`).join('; ');
+    return `Block recorded but NOT delivered — every feed.broadcast sink failed (${why}).`;
+  }
+  return undefined;
+}
+
 export interface PlannedSink {
   name: string;
   argv: string[];

--- a/apps/cli/src/lib/feed-post.ts
+++ b/apps/cli/src/lib/feed-post.ts
@@ -40,6 +40,16 @@ export interface FeedPostInput {
   sessionId?: string;
   /** Generic artifacts to attach: local paths (copied for durability) or URLs. */
   attach?: string[];
+  /**
+   * The agent is STUCK, not merely reporting. Writes `status.blocked` instead of
+   * `status.posted`, and the caller pairs it with an OpenBlock so the ask stays
+   * answerable until someone resolves it.
+   *
+   * This is a state, not a volume: a blocked post is always broadcast at
+   * `important`, so an agent never has to decide the level as well. One thing to
+   * say is what makes the habit stick.
+   */
+  blocked?: boolean;
   /** Override activity root (tests). */
   activityRoot?: string;
   /**
@@ -356,7 +366,7 @@ export function postFeedStatus(input: FeedPostInput): FeedPostResult {
 
   const event: Omit<ActivityEvent, 'v' | 'tier'> = {
     ts,
-    event: 'status.posted',
+    event: input.blocked ? 'status.blocked' : 'status.posted',
     sessionId: identity.sessionId,
     mailboxId: identity.mailboxId,
     host: identity.host,

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -76,7 +76,7 @@ export interface OpenBlock {
    *   question     — an AskUserQuestion the harness surfaced
    *   notification — a permission/idle prompt the harness raised
    *   control      — a synthetic card the feed itself computed (runaway, needy)
-   *   declared     — the AGENT decided it is stuck and said so (`agents feed block`)
+   *   declared     — the AGENT decided it is stuck and said so (`feed post --blocked`)
    *
    * `declared` is the only kind that does not depend on the harness noticing
    * anything. Every other kind is inferred from a harness event, and hook events
@@ -406,7 +406,7 @@ export interface DeclareBlockInput {
 }
 
 /**
- * Build the block record for `agents feed block` — pure, so the shape is testable
+ * Build the block record for `agents feed post --blocked` — pure, so the shape is testable
  * without touching the store or the broadcast layer.
  *
  * Class is derived, not asked for: a `--default` means the user could be absent
@@ -422,7 +422,7 @@ export interface DeclareBlockInput {
 export function buildDeclaredBlock(agent: DeclaringAgent, input: DeclareBlockInput): OpenBlock {
   const text = input.text.trim().replace(/\s+/g, ' ');
   if (!text) {
-    throw new Error('Block text is empty. Usage: agents feed block "what you need from the user"');
+    throw new Error('Block text is empty. Usage: agents feed post "what you need from the user" --blocked');
   }
   const options = (input.options ?? [])
     .map((label) => label.trim())

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -71,7 +71,20 @@ export interface OpenBlock {
   runtime: string;
   ts: string;
   questions: BlockQuestion[];
-  kind?: 'question' | 'notification' | 'control';
+  /**
+   * How this block came to exist.
+   *   question     — an AskUserQuestion the harness surfaced
+   *   notification — a permission/idle prompt the harness raised
+   *   control      — a synthetic card the feed itself computed (runaway, needy)
+   *   declared     — the AGENT decided it is stuck and said so (`agents feed block`)
+   *
+   * `declared` is the only kind that does not depend on the harness noticing
+   * anything. Every other kind is inferred from a harness event, and hook events
+   * are not portable across harnesses (only Claude fires Notification, only Codex
+   * fires PermissionRequest), so a declared block is the one signal every agent
+   * can raise — it is just a shell command.
+   */
+  kind?: 'question' | 'notification' | 'control' | 'declared';
   notificationType?: string;
   ticket?: string;
   pr?: string;
@@ -370,6 +383,66 @@ export function clearBlockLifecycle(blockId: string, root?: string): void {
       // ignore missing
     }
   }
+}
+
+/** Identity of the agent declaring a block — the subset of `PostIdentity` it needs. */
+export interface DeclaringAgent {
+  sessionId: string;
+  mailboxId: string;
+  host: string;
+  runtime: string;
+}
+
+export interface DeclareBlockInput {
+  /** What the agent needs from the user, front-loaded. */
+  text: string;
+  /** Answerable choices, if the ask is a pick-one. */
+  options?: string[];
+  /** A safe default makes this an approval; without one it is a decision. */
+  safeDefault?: string;
+  /** Minutes before the default-on-no-answer policy may fire. */
+  timeoutMinutes?: number;
+  ts?: string;
+}
+
+/**
+ * Build the block record for `agents feed block` — pure, so the shape is testable
+ * without touching the store or the broadcast layer.
+ *
+ * Class is derived, not asked for: a `--default` means the user could be absent
+ * and policy could still resolve it (approval); no default means only a human can
+ * choose (decision). `feed-policy.ts` reads exactly that distinction, so deriving
+ * it here keeps one rule in one place instead of letting a caller set a class that
+ * contradicts its own safeDefault.
+ *
+ * `costOfDelay: high` because a declared block is, by definition, an agent that
+ * has already stopped making progress — that is what makes it worth interrupting
+ * someone over, and what `feed --dispatch`'s urgency filter keys off.
+ */
+export function buildDeclaredBlock(agent: DeclaringAgent, input: DeclareBlockInput): OpenBlock {
+  const text = input.text.trim().replace(/\s+/g, ' ');
+  if (!text) {
+    throw new Error('Block text is empty. Usage: agents feed block "what you need from the user"');
+  }
+  const options = (input.options ?? [])
+    .map((label) => label.trim())
+    .filter(Boolean)
+    .map((label) => ({ label }));
+
+  return {
+    blockId: blockIdForSession(agent.sessionId),
+    sessionId: agent.sessionId,
+    mailboxId: agent.mailboxId,
+    host: agent.host,
+    runtime: agent.runtime,
+    ts: input.ts ?? new Date().toISOString(),
+    kind: 'declared',
+    questions: [{ text, header: 'Needs you', ...(options.length ? { options } : {}) }],
+    blockClass: input.safeDefault ? 'approval' : 'decision',
+    costOfDelay: 'high',
+    ...(input.safeDefault ? { safeDefault: input.safeDefault } : {}),
+    ...(input.timeoutMinutes !== undefined ? { timeoutMinutes: input.timeoutMinutes } : {}),
+  };
 }
 
 /** Atomic write a block record to the feed store. Clears stale lifecycle state. */


### PR DESCRIPTION
**feature** — an agent can now say it is stuck, and that actually reaches a human.

RUSH-2110. Session `74a4893f` hit a `git-guard` force-push denial, wrote a careful explanation into the chat window, and stopped. Nobody found out for an hour.

## The problem, measured

Across the interactive boxes over 3 days: **10 of 62 sessions ended with the agent asking to be unblocked, and none reached anyone.** Agents had already improvised a channel — a live `feed post` reads *"NEEDS MUQSIT: … I cannot self-approve my own PR."* One session named the failure itself:

> "`rush message send` doesn't exist either. No Telegram or iMessage reached you this session."

Two causes in this repo:

| | |
|---|---|
| No way to signal "stuck" | The feed carried benign progress only, so agents hand-rolled it into status text. |
| Blocks never left the machine | `broadcastPostedEvent` ran only for `feed post`; the six `publishBlock` calls wrote to the ledger and stopped. A "needs you" record was durable and invisible at the same time. |

## What changed

**`agents feed post --blocked`** — a flag on the existing verb, deliberately *not* a new command. The feed is one shared stream where most posts are benign and some need a human; one verb is one thing for an agent to learn.

```
agents feed post "CI green, merging"
agents feed post "force-push denied by git-guard" --blocked
agents feed post "publish or wait?" --blocked --option publish --option wait
```

- **Blocked is a state, not a volume.** It always broadcasts at `important`, so an agent never picks a level too — passing both is a usage error, not a silent override.
- **It writes to both stores**: `status.blocked` on the activity stream (*what happened*) and an `OpenBlock` in the ledger (*what is still open*, hence answerable via `recordAnswer`, clearable via `recordContinued`). Without the ledger entry the ask would scroll away like any other update.
- **It fails loud.** A block reaching no sink exits non-zero. One sink failing among several is only a warning — the channels are redundant by design.

**`desktop` channel provider** — `agents send --channel desktop` posts through the branded menu-bar helper. The only channel with no external dependency, so it still reaches you when a gateway is down. It reports real deliverability rather than always succeeding: on Linux it probes for `notify-send` instead of trusting the platform name. `notifyDesktop` is fire-and-forget by design, and inheriting that would have made an undelivered notification look delivered — the same silent failure, relocated.

## Run result

**Delivered end-to-end** on the box where `rush` is authed — a real blocked post, a real iMessage:

```
$ agents feed post "RUSH-2110 end-to-end: force-push denied by git-guard on PR #1749 \
    — grant the permission or push it yourself" --blocked --json
{
  "event": "status.blocked",
  "detail": "RUSH-2110 end-to-end: force-push denied by git-guard on PR #1749 — grant …",
  "broadcast": [ { "name": "owner", "ok": true } ]
}
$ echo $?
0
```

**And the fail-loud path**, same command on a box with no `rush`:

```
{
  "event": "status.blocked",
  "broadcast": [
    { "name": "owner", "ok": false,
      "error": "send failed [imessage → +1805…]: rush CLI not found on PATH" }
  ]
}
$ echo $?
1
```

The sink **ran**, failed with a precise reason, and exited non-zero. Before this change that was a silent no-op — which is the entire bug.

> **Correction.** An earlier revision of this PR body showed the above with `--json` and claimed exit 1, but the action returned early inside the `--json` branch *before* the fail-loud check, so it actually exited 0. Review caught it; fixed in `ed83bf7d`, which computes the verdict before either output branch and extracts it to a pure `blockDeliveryFailure()` with four tests. Re-verified on a rebuilt CLI: `--blocked --json` → 1, `--blocked` → 1, plain post → 0.

Block lands in the ledger, readable by the existing reader:

```
$ agents feed --local --json
kind=declared | class=decision | cost=high | force-push denied by git-guard on PR #1749
```

Verified against a dev build of this exact commit (`0.0.0-dev.32f2c236`) on both Linux and macOS.

## Tests

25 new tests, all real-path per the no-mocking rule — the store round-trip, class derivation, the linux `notify-send` probe against the actual PATH, a live send through `notifyDesktop`, and the sink plan against a real `important`-gated config. **130/130 green** across the 11 feed + channels suites; `tsc --noEmit` clean.

One real bug caught while writing them: the placeholder grammar is lowercase-only (`/\{([a-z]+)\}/`), so a camelCase `{blockId}` would never substitute and `renderSinkArgv` would silently **skip** the sink. The token is `{block}`; the trap is documented.

**Pre-existing failures, not from this PR.** The full suite has 20 failures across 8 files (`exec`, `import`, `models`, `session/sync/config`, `serve/server`). None touch feed, channels, activity, or broadcast, and `src/lib/__tests__/exec.test.ts` reproduces its 2 failures on a clean `main` checkout. They block `build.sh`'s test gate, which is why the dev builds here used `--skip-tests`.

## Docs

`docs/06-observability.md` gains a `--blocked` section and the four block-only placeholders; changelog fragment at `.changelog/next/RUSH-2110.md` per the conflict-free convention.

## Not in this PR

The adoption layer (a `feed-blocks` rule, rewiring `no-permission-stop-guard.sh` to file a block from what the agent already wrote, and correcting the false *"can be forwarded to their phone"* claim at `00-agent-verify-work-complete.sh:698-722`), the escalate-hook resource-layer bug, and the menubar / Fleet Cockpit consumers. All tracked on RUSH-2110.
