### PR TITLE
test(sessions): reap lingering ssh-peer processes before cleanup

### DIFF
--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -294,6 +294,8 @@ interface SessionResolverSshPeer {
   fixture: ChildProcess;
   socket: string;
   proofFile: string;
+  /** The test's temp home — every process of this test carries it in argv. */
+  home: string;
 }
 
 /**
@@ -395,7 +397,7 @@ async function startSessionResolverSshPeer(
     '-o', 'ControlPersist=60s', target,
   ], { encoding: 'utf-8', timeout: 10_000 });
   if (master.status !== 0) throw new Error(`ssh ControlMaster failed: ${master.stderr}`);
-  return { target, fixture, socket, proofFile };
+  return { target, fixture, socket, proofFile, home: tempHome };
 }
 
 async function stopSessionResolverSshPeer(peer: SessionResolverSshPeer): Promise<void> {
@@ -404,6 +406,13 @@ async function stopSessionResolverSshPeer(peer: SessionResolverSshPeer): Promise
   });
   if (!peer.fixture.killed) peer.fixture.kill('SIGTERM');
   await new Promise<void>((resolve) => peer.fixture.once('exit', () => resolve()));
+  // The peer side lingers past fixture death: the npx'd old agents-cli that
+  // answered over ssh (still flushing its index into peer-home/.agents) and
+  // the parent's own ControlPersist master. Both keep writing into the temp
+  // home, which raced the cleanup rmdir ENOTEMPTY on CI even with rm retries.
+  // Every one of those processes carries this test's unique temp path in argv,
+  // so a path-scoped pkill reaps exactly them and nothing else.
+  spawnSync('pkill', ['-f', peer.home]);
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1800 — the old-peer ENOTEMPTY flake persisted on release 1.20.91's matrix even with `maxRetries: 8`: the peer-side npx'd old agents-cli keeps flushing its index into `peer-home/.agents` after the ssh2 fixture dies, and the parent's own ControlPersist master lingers as well. Both keep writing into the temp home past the retry window.\n\nEvery one of those processes carries the test's unique mkdtemp path in argv, so a path-scoped `pkill -f <tempHome>` in `stopSessionResolverSshPeer` reaps exactly them and nothing else. The rm retry stays as the second line of defense.\n\nVerified locally: the malformed-peer test (the rm-race path) passes with the change; the old-peer test's 30s timeout on this box reproduces on unmodified main (slow npx fetch of the pinned old version locally), unrelated to the change.