### PR TITLE
fix(menubar): don't steal focus when an agent relaunches the helper

### DIFF
--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
@@ -26,6 +26,38 @@ enum SingleInstance {
     /// Distributed (not local) because the sender is a different process.
     static let surfaceNotification = Notification.Name("com.phnx-labs.agents-menubar.surface")
 
+    /// Who triggered a duplicate launch, resolved from the loser's env and carried
+    /// in the notification so the incumbent can decide whether to steal focus.
+    struct SurfaceTrigger: Equatable {
+        /// True when a coding agent (not the human) relaunched the helper — its env
+        /// carries the provenance `buildExecEnv` stamps on every spawn. The human
+        /// didn't ask to see the menu, so the incumbent re-homes silently instead
+        /// of popping the dropdown and stealing keyboard focus mid-task.
+        let automated: Bool
+        let agent: String?
+        let sessionId: String?
+
+        /// String-only so it survives distributed-notification delivery (plist).
+        var userInfo: [String: String] {
+            var info = ["automated": automated ? "1" : "0"]
+            if let agent { info["agent"] = agent }
+            if let sessionId { info["sessionId"] = sessionId }
+            return info
+        }
+    }
+
+    /// Classify a duplicate launch from its environment. An agent-spawned relaunch
+    /// (e.g. `agents menubar enable` run by a coding agent) carries AGENTS_AGENT_NAME
+    /// / AGENTS_SESSION_ID from `buildExecEnv`; a genuine user relaunch from an
+    /// interactive shell or Finder does not. Pure so the decision is unit-testable.
+    static func classifyTrigger(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> SurfaceTrigger {
+        let agent = environment["AGENTS_AGENT_NAME"]
+        let sessionId = environment["AGENTS_SESSION_ID"] ?? environment["AGENT_SESSION_ID"]
+        return SurfaceTrigger(automated: agent != nil || sessionId != nil, agent: agent, sessionId: sessionId)
+    }
+
     /// ~/.agents/.cache/state/menubar.lock — the same runtime state dir the CLI
     /// uses (`getRuntimeStateDir()` in src/lib/state.ts).
     static func lockPath(home: String = NSHomeDirectory()) -> String {
@@ -99,12 +131,16 @@ enum SingleInstance {
         case .acquired:
             return
         case .alreadyRunning(let pid):
+            let trigger = classifyTrigger()
             DistributedNotificationCenter.default().postNotificationName(
-                surfaceNotification, object: nil, userInfo: nil, deliverImmediately: true
+                surfaceNotification, object: nil, userInfo: trigger.userInfo, deliverImmediately: true
             )
             let who = pid > 0 ? " (pid \(pid))" : ""
+            let how = trigger.automated
+                ? " — automated relaunch (\(trigger.agent ?? trigger.sessionId ?? "agent")), re-homed without stealing focus"
+                : " — surfaced it instead of adding a second status item"
             FileHandle.standardError.write(Data(
-                "MenubarHelper: already running\(who) — surfaced it instead of adding a second status item.\n".utf8
+                "MenubarHelper: already running\(who)\(how).\n".utf8
             ))
             exit(0)
         }

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
@@ -17,6 +17,7 @@ enum SingleInstanceSelfTest {
         testLockReleasedWhenHolderDies()
         testLockPathIsRuntimeStateDir()
         testDumpProbeIsExempt()
+        testTriggerClassification()
         if failures == 0 {
             print("\nALL PASS")
             exit(0)
@@ -87,6 +88,27 @@ enum SingleInstanceSelfTest {
               "ordinary launch -> gated")
         check(!SingleInstance.isTransientProbe(["MENUBAR_DUMP": "0"]),
               "MENUBAR_DUMP=0 -> gated")
+    }
+
+    // An agent-spawned relaunch (buildExecEnv stamps AGENTS_AGENT_NAME /
+    // AGENTS_SESSION_ID) must be classified automated, so the incumbent re-homes
+    // without stealing focus; a bare user relaunch must surface.
+    private static func testTriggerClassification() {
+        let agentRun = SingleInstance.classifyTrigger(["AGENTS_AGENT_NAME": "claude"])
+        check(agentRun.automated, "AGENTS_AGENT_NAME set -> automated")
+        check(agentRun.agent == "claude", "automated trigger carries the agent name")
+
+        let sessionRun = SingleInstance.classifyTrigger(["AGENTS_SESSION_ID": "sess-123"])
+        check(sessionRun.automated, "AGENTS_SESSION_ID set -> automated")
+        check(sessionRun.sessionId == "sess-123", "automated trigger carries the session id")
+
+        let userRun = SingleInstance.classifyTrigger([:])
+        check(!userRun.automated, "no agent/session env -> user relaunch (surfaces)")
+        check(userRun.userInfo["automated"] == "0", "user trigger userInfo marks automated=0")
+
+        // The userInfo dict must be string-only so it survives distributed delivery.
+        check(agentRun.userInfo["automated"] == "1" && agentRun.userInfo["agent"] == "claude",
+              "automated userInfo is plist-safe strings")
     }
 
     private static func check(_ condition: Bool, _ label: String) {

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -135,11 +135,24 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     /// takes a suspensionBehavior, and this app is `.accessory` — never the
     /// active app — so the default behavior queues the notification instead of
     /// delivering it and the menu never opens.
-    @objc func surface() {
+    @objc func surface(_ note: Notification) {
         guard let button = statusItem.button else { return }
+        let info = note.userInfo as? [String: String] ?? [:]
+        // An agent/automation relaunched the helper (e.g. a coding agent running
+        // `agents menubar enable`). The human did not ask to see the menu, so
+        // re-home silently — popping the dropdown here steals the user's keyboard
+        // focus mid-task, the interruption this attribution was added to stop.
+        if info["automated"] == "1" {
+            let who = [info["agent"].map { "agent=\($0)" }, info["sessionId"].map { "session=\($0)" }]
+                .compactMap { $0 }.joined(separator: " ")
+            FileHandle.standardError.write(Data(
+                "MenubarHelper: automated relaunch (\(who.isEmpty ? "unknown" : who)) — re-homed silently, did not surface\n".utf8
+            ))
+            return
+        }
         // Logged: this is the one moment where a second launch changed what the
         // user sees, and the launchd plist routes stderr to menubar.log.
-        FileHandle.standardError.write(Data("MenubarHelper: surfacing menu for a duplicate launch\n".utf8))
+        FileHandle.standardError.write(Data("MenubarHelper: surfacing menu for a user relaunch\n".utf8))
         NSApp.activate(ignoringOtherApps: true)
         button.performClick(nil)
     }

--- a/apps/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/main.swift
@@ -86,7 +86,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // notification for an inactive app rather than delivering it — the menu
         // would simply never open.
         DistributedNotificationCenter.default().addObserver(
-            controller, selector: #selector(StatusItemController.surface),
+            controller, selector: #selector(StatusItemController.surface(_:)),
             name: SingleInstance.surfaceNotification, object: nil,
             suspensionBehavior: .deliverImmediately
         )


### PR DESCRIPTION
**Swift (menu-bar helper) behavior fix** — Phase 5 of the events-provenance plan. This is the fix for the actual bug that started this work: the menu-bar dropdown popping open and stealing keyboard focus mid-task.

## Root cause
The `SingleInstance` "surface the incumbent" path (`SingleInstance.swift`) fires on *any* duplicate launch of `MenubarHelper` and makes the running instance call `NSApp.activate(ignoringOtherApps:)` + `button.performClick(nil)` — popping the menu and stealing focus. It records nothing about who triggered it, so an **agent** running `agents menubar enable` repeatedly interrupted the user with no trace.

## Fix
The relaunching (loser) process now classifies the trigger from its env and carries it in the surface notification's `userInfo`:
- **Automated** (agent-spawned): env has `AGENTS_AGENT_NAME`/`AGENTS_SESSION_ID` (stamped by `buildExecEnv`) → the incumbent **re-homes silently**, logging who triggered it, and does **not** steal focus.
- **User** (interactive shell / Finder, no agent env) → surfaces as before, preserving "re-launch shows me the menu."

`classifyTrigger` is pure and unit-tested.

## Run result
`swift build`: **Build complete** (exit 0). Self-test (`MENUBAR_SINGLE_TEST=1`), real classifier logic, no mocks:
```
PASS  AGENTS_AGENT_NAME set -> automated
PASS  automated trigger carries the agent name
PASS  AGENTS_SESSION_ID set -> automated
PASS  automated trigger carries the session id
PASS  no agent/session env -> user relaunch (surfaces)
PASS  user trigger userInfo marks automated=0
PASS  automated userInfo is plist-safe strings
ALL PASS
```
The deterministic proof: for an automated trigger, `surface()` returns before `performClick`/`activate` — no focus steal. Behavioral confirmation on the *installed* helper happens when this ships to the fleet (the menu-bar helper is built + signed at release time; CI doesn't build the Swift bundle).

## Scope
Focused on the focus-steal fix + attribution. The additive "🖱 driving <app>" menu-bar chip (reads `computer-target-admissions.json`) is a follow-on within Phase 5.
