### PR TITLE
feat(projects): canonical project names across activity, feed, and sessions + activity --project

### DIFF
--- a/apps/cli/.changelog/next/projects-activity-attribution.md
+++ b/apps/cli/.changelog/next/projects-activity-attribution.md
@@ -1,0 +1,13 @@
+- **Activity, feed posts, and the sessions overview now speak defined project
+  names.** One resolver (`resolveProjectNameForCwd`, `lib/projects.ts`) backs all
+  three: a cwd inside a defined project (`~/.agents/projects/<name>.yaml`) reads
+  as the project's name — a multi-repo project is a single bucket in `agents
+  activity`, not one per repo — and anything else falls back to the
+  repository-level key, so nothing changes without definitions. Each peer
+  resolves its own cwds against its synced definitions before events cross the
+  wire. Source: `apps/cli/src/lib/projects.ts`, `apps/cli/src/commands/activity.ts`.
+
+- **`agents activity --project <name>`** narrows the fleet stream to one project,
+  exact-matched on the resolved label — one project's PRs, plans, and worktrees
+  across every box without the rest of the fleet's noise. Source:
+  `apps/cli/src/lib/activity.ts` (`filterActivityByProject`).

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -853,14 +853,20 @@ agents activity --milestones       # only plans / PRs / worktrees / sub-agents
   (`▸ agents-cli  12 events · 4 milestones · zion, yosemite-s0`, capped at three
   names plus a `+N` tail). `--filter <text>` narrows by project / device / agent /
   event / ticket.
-- **Projects are repositories.** A cwd resolves to the git repository containing
-  it (`resolveProjectKey`, `lib/project-key.ts`), so `<repo>/apps/cli` files under
+- **Projects are defined projects first, repositories otherwise.** A cwd inside a
+  defined project (`~/.agents/projects/<name>.yaml`, see docs/11-projects.md)
+  reads as that project's NAME — so a multi-repo project is one bucket, not one
+  per repo. Anything else resolves to the git repository containing it
+  (`resolveProjectKey`, `lib/project-key.ts`), so `<repo>/apps/cli` files under
   `<repo>` and a worktree under `<repo>/.agents/worktrees/<slug>` folds back into
   the repo it branched from. A directory in no repo groups as itself, and a
-  dotfiles repo at `$HOME` is deliberately not treated as a project. This is the
-  same fold the `agents sessions` overview groups by, so a project reads
-  identically in both. Each machine resolves its own paths — a peer stamps the
-  project before its events cross the wire.
+  dotfiles repo at `$HOME` is deliberately not treated as a project. This one
+  resolver (`resolveProjectNameForCwd`, `lib/projects.ts`) is shared by the
+  activity timeline, `agents feed post`, and the `agents sessions` overview, so
+  a project reads identically in all three. Each machine resolves its own paths
+  — a peer stamps the project before its events cross the wire. `--project
+  <name>` narrows the stream to one project (exact match on this resolved
+  label).
 - **`--limit` caps milestones, not churn.** The default view collapses routine
   `file.edited` work to a count, so `-n` bounds the milestones shown and the
   routine events inside that window ride along for the counts

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -65,6 +65,18 @@ tree is. A definition exists solely by explicit user action (`projects add`,
 `import --from-factory`, or hand-authoring the YAML), so honoring it in `--project`
 resolution is additive and safe; users without any definitions see zero change.
 
+## One name everywhere — activity, feed, sessions
+
+Definitions also rename the fleet's activity. `resolveProjectNameForCwd`
+(`lib/projects.ts`) is the single project resolver shared by the `agents activity`
+timeline (buckets and row chips), `agents feed post` (the stamped project), and the
+`agents sessions` overview: a cwd inside a defined project's root reads as the
+project's **name** — a multi-repo project is one bucket, not one per repo — and
+anything else falls back to the repository-level key (`lib/project-key.ts`). Each
+machine resolves its own cwds against its own (synced) definitions before events
+cross the wire. `agents activity --project <name>` narrows the stream to one
+project, exact-matched on this label.
+
 ## The progress card — `agents projects status`
 
 The headline. It matches every live session to a project **by cwd** (longest root

--- a/apps/cli/src/commands/activity.ts
+++ b/apps/cli/src/commands/activity.ts
@@ -27,6 +27,7 @@ import {
   enrichActivityEvents,
   capActivityEvents,
   ensureActivityLogHook,
+  filterActivityByProject,
   filterActivityEvents,
   formatActivityGroupMeta,
   formatEnrichedActivityLine,
@@ -43,6 +44,7 @@ import {
 } from '../lib/activity.js';
 import { gatherRemoteAgentsJson } from '../lib/remote-agents-json.js';
 import { resolveProjectKey } from '../lib/project-key.js';
+import { listProjectDefs, resolveProjectNameForCwd } from '../lib/projects.js';
 import { machineId, normalizeHost } from '../lib/machine-id.js';
 import { shouldIncludeLocalFeed, remoteFeedHostsToDial } from './feed.js';
 import { getActiveSessions } from '../lib/session/active.js';
@@ -78,6 +80,7 @@ interface ActivityOpts {
   hostsAll?: boolean;
   groupBy?: string;
   flat?: boolean;
+  project?: string;
   filter?: string;
 }
 
@@ -138,17 +141,20 @@ export function isManifestHookError(error: string, manifestNames: string[]): boo
 
 /**
  * Session facts (project / ticket / execution host) keyed for the read-time
- * join. These sessions are this machine's, so their cwds get the repository-
- * aware resolution rather than the bare cwd fold.
+ * join. These sessions are this machine's, so their cwds get the canonical
+ * defined-project-first resolution rather than the bare cwd fold.
  */
-function activityHintsFromSessions(sessions: ActiveSession[]): ActivitySessionHint[] {
+function activityHintsFromSessions(
+  sessions: ActiveSession[],
+  resolveProject: (cwd?: string | null) => string | undefined = resolveProjectKey,
+): ActivitySessionHint[] {
   return sessions.map((s) => ({
     sessionId: s.sessionId,
     ticket: s.ticket?.id,
     // Where the process actually lives — the SSH-resolved provenance host, else
     // the cross-machine `machine` id. Normalized to match the event `host` form.
     executionHost: s.provenance?.host ? normalizeHost(s.provenance.host) : s.machine,
-    project: resolveProjectKey(s.cwd),
+    project: resolveProject(s.cwd),
   }));
 }
 
@@ -304,6 +310,7 @@ export function registerActivityCommand(program: Command): void {
     .option('--hosts-all', 'Alias for --devices-all')
     .option('--group-by <field>', 'Bucket the stream by project | device | agent | none (default: project)')
     .option('--flat', 'One newest-first stream instead of project buckets')
+    .option('--project <name>', 'Only items under one project; exact match on the resolved (defined-project-first) label')
     .option('--filter <text>', 'Narrow to items matching a project / device / agent / event / ticket')
     .addHelpText('after', `
 Examples:
@@ -311,13 +318,16 @@ Examples:
   agents activity --local                      # just this machine
   agents activity --flat                       # one newest-first stream
   agents activity --host yosemite-s1           # one box over SSH
+  agents activity --project rush               # one defined project, fleet-wide
   agents activity --filter RUSH-2100           # one ticket, fleet-wide
   agents activity --group-by device            # by machine instead of project
 
 Fleet-wide and project-grouped by default: the same 'activity --json' runs on
 every reachable peer and the streams merge host-tagged. Each item is enriched by
 JOINING to live sessions (project, execution host, Linear ticket) -- never by
-re-parsing transcripts. Projects fold worktrees back into their repo, and each
+re-parsing transcripts. Project labels are canonical: a cwd inside a defined
+project (~/.agents/projects/<name>.yaml) reads as that project's name, so a
+multi-repo project is one bucket; anything else folds to its repository. Each
 project header names the machines its work ran on.
 `)
     .action(async (opts: ActivityOpts) => {
@@ -377,10 +387,15 @@ project header names the machines its work ran on.
       // Remote events arrive already enriched by their own peer, so the join only
       // fills local ones; the pure fallbacks (cwd->project, host->device) cover
       // everything either way. Skip the ps/lsof scan when there's nothing to show.
+      // Project labels are canonical: a defined project's name wins over the
+      // repo-level key, so a multi-repo project buckets as one.
+      const projectDefs = listProjectDefs();
+      const resolveProject = (cwd?: string | null) => resolveProjectNameForCwd(cwd, projectDefs);
       const sessions = includeLocal && events.length > 0 ? await getActiveSessions() : [];
-      let enriched = enrichActivityEvents(events, activityHintsFromSessions(sessions), resolveProjectKey);
+      let enriched = enrichActivityEvents(events, activityHintsFromSessions(sessions, resolveProject), resolveProject);
 
       if (opts.milestones) enriched = enriched.filter((e) => tierForEvent(e.event) === 'milestone');
+      if (opts.project) enriched = filterActivityByProject(enriched, opts.project);
       if (opts.filter) enriched = filterActivityEvents(enriched, opts.filter);
       enriched = capActivityEvents(enriched, opts.limit, { all: opts.all || opts.milestones });
 

--- a/apps/cli/src/commands/activity.ts
+++ b/apps/cli/src/commands/activity.ts
@@ -44,7 +44,7 @@ import {
 } from '../lib/activity.js';
 import { gatherRemoteAgentsJson } from '../lib/remote-agents-json.js';
 import { resolveProjectKey } from '../lib/project-key.js';
-import { listProjectDefs, resolveProjectNameForCwd } from '../lib/projects.js';
+import { listProjectDefs, projectNameForCwd, resolveProjectNameForCwd } from '../lib/projects.js';
 import { machineId, normalizeHost } from '../lib/machine-id.js';
 import { shouldIncludeLocalFeed, remoteFeedHostsToDial } from './feed.js';
 import { getActiveSessions } from '../lib/session/active.js';
@@ -388,14 +388,31 @@ project header names the machines its work ran on.
       // fills local ones; the pure fallbacks (cwd->project, host->device) cover
       // everything either way. Skip the ps/lsof scan when there's nothing to show.
       // Project labels are canonical: a defined project's name wins over the
-      // repo-level key, so a multi-repo project buckets as one.
+      // repo-level key — including over a stale or def-skewed pre-baked stamp
+      // (the def match is a pure prefix compare; foreign paths just don't match),
+      // so a multi-repo project buckets as one even across version skew.
       const projectDefs = listProjectDefs();
+      const canonicalProject = (cwd?: string | null) => projectNameForCwd(cwd ?? undefined, projectDefs);
       const resolveProject = (cwd?: string | null) => resolveProjectNameForCwd(cwd, projectDefs);
       const sessions = includeLocal && events.length > 0 ? await getActiveSessions() : [];
-      let enriched = enrichActivityEvents(events, activityHintsFromSessions(sessions, resolveProject), resolveProject);
+      let enriched = enrichActivityEvents(events, activityHintsFromSessions(sessions, resolveProject), resolveProject, canonicalProject);
 
       if (opts.milestones) enriched = enriched.filter((e) => tierForEvent(e.event) === 'milestone');
-      if (opts.project) enriched = filterActivityByProject(enriched, opts.project);
+      if (opts.project) {
+        const unfiltered = enriched;
+        enriched = filterActivityByProject(enriched, opts.project);
+        // An exact-name flag that matches nothing deserves a useful answer, not
+        // a generic "no activity" that lies about the fleet.
+        if (enriched.length === 0 && unfiltered.length > 0) {
+          const seen = [...new Set(unfiltered.map((e) => e.project).filter((p): p is string => !!p))].sort();
+          const defined = projectDefs.map((d) => d.name);
+          const parts = [
+            seen.length ? `seen: ${seen.join(', ')}` : '',
+            defined.length ? `defined: ${defined.join(', ')}` : '',
+          ].filter(Boolean);
+          process.stderr.write(chalk.gray(`  · no events for project "${opts.project}" (exact match)${parts.length ? ` — ${parts.join(' · ')}` : ''}\n`));
+        }
+      }
       if (opts.filter) enriched = filterActivityEvents(enriched, opts.filter);
       enriched = capActivityEvents(enriched, opts.limit, { all: opts.all || opts.milestones });
 

--- a/apps/cli/src/commands/sessions.overview.test.ts
+++ b/apps/cli/src/commands/sessions.overview.test.ts
@@ -40,6 +40,21 @@ describe('overviewProjectKey', () => {
     expect(overviewProjectKey({ project: undefined, cwd: '/definitely/not-inside-any/repo/path-xyz' })).toBe('path-xyz');
   });
 
+  it('a defined project name wins over the repo key when defs are given', () => {
+    // Same canonical resolver as the activity timeline: a multi-repo project's
+    // sessions group under the project's name, not the repo's.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'overview-canonical-'));
+    try {
+      const repo = path.join(tmp, 'agents');
+      const sub = path.join(repo, 'apps', 'cli');
+      fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+      fs.mkdirSync(sub, { recursive: true });
+      expect(overviewProjectKey({ project: undefined, cwd: sub }, [{ name: 'agentic', root: repo }])).toBe('agentic');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('returns a sentinel for an empty cwd and no project', () => {
     expect(overviewProjectKey({ project: undefined, cwd: '' })).toBe('(no project)');
     expect(overviewProjectKey({ project: '  ', cwd: undefined })).toBe('(no project)');

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -15,6 +15,7 @@ import { Option, type Command } from 'commander';
 import chalk from 'chalk';
 import { truncate, padRight } from '../lib/format.js';
 import { resolveProjectKey } from '../lib/project-key.js';
+import { listProjectDefs, resolveProjectNameForCwd, type ProjectDef } from '../lib/projects.js';
 import ora from 'ora';
 import type { AgentId } from '../lib/types.js';
 import type { SessionAgentId, SessionMeta, ViewMode } from '../lib/session/types.js';
@@ -2073,15 +2074,16 @@ async function maybeLiveIndex(options: SessionsOptions): Promise<Map<string, Act
 }
 
 /**
- * Group key for the overview: resolve the cwd to its repo via the shared
- * {@link resolveProjectKey} — the same resolver the `agents activity` timeline
- * groups by, so a monorepo subdir (`<repo>/apps/cli`) reads as `<repo>` in both
- * views. Falls back to the indexed project name (stamped at scan time) when the
- * cwd carries nothing usable, e.g. a remote path this machine cannot see still
- * folds by basename through the same resolver.
+ * Group key for the overview: resolve the cwd through the same canonical
+ * resolver the `agents activity` timeline groups by — a defined project's name
+ * when `defs` contains the cwd (multi-repo projects read as one group), else
+ * the repo-level key, so a monorepo subdir (`<repo>/apps/cli`) reads as
+ * `<repo>` in both views. Falls back to the indexed project name (stamped at
+ * scan time) when the cwd carries nothing usable, e.g. a remote path this
+ * machine cannot see still folds by basename through the same resolver.
  */
-export function overviewProjectKey(s: Pick<SessionMeta, 'project' | 'cwd'>): string {
-  const resolved = resolveProjectKey(s.cwd);
+export function overviewProjectKey(s: Pick<SessionMeta, 'project' | 'cwd'>, defs?: ProjectDef[]): string {
+  const resolved = defs?.length ? resolveProjectNameForCwd(s.cwd, defs) : resolveProjectKey(s.cwd);
   if (resolved) return resolved;
   if (s.project && s.project.trim()) return s.project.trim();
   return '(no project)';
@@ -2104,10 +2106,11 @@ export interface OverviewGroup {
 export function buildOverviewGroups(
   pool: SessionMeta[],
   perProjectCap: number,
+  defs?: ProjectDef[],
 ): { groups: OverviewGroup[]; projectCount: number } {
   const byKey = new Map<string, SessionMeta[]>();
   for (const s of pool) {
-    const k = overviewProjectKey(s);
+    const k = overviewProjectKey(s, defs);
     (byKey.get(k) ?? byKey.set(k, []).get(k)!).push(s);
   }
   const cap = Math.max(1, perProjectCap);
@@ -2131,7 +2134,7 @@ function printSessionOverview(
   liveIndex: Map<string, ActiveSession> | undefined,
   opts: { perProjectCap: number; expand: boolean; hiddenUnmanaged?: number },
 ): void {
-  const { groups } = buildOverviewGroups(pool, opts.expand ? Infinity : opts.perProjectCap);
+  const { groups } = buildOverviewGroups(pool, opts.expand ? Infinity : opts.perProjectCap, listProjectDefs());
   const shownGroups = opts.expand ? groups : groups.slice(0, OVERVIEW_MAX_PROJECTS);
   const hiddenProjects = groups.length - shownGroups.length;
 

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -665,6 +665,31 @@ describe('enrichActivityEvents', () => {
     expect(out).toMatchObject({ project: 'peer-repo', ticket: 'RUSH-9', executionHost: 'zion' });
   });
 
+  it('upgrades a stale or def-skewed pre-baked stamp when a local def matches the cwd', () => {
+    // A peer whose defs haven't synced (or a feed post written before the def
+    // existed) stamps the repo key; the reader's canonical def match wins, so a
+    // multi-repo project stays one bucket and `--project` doesn't miss it.
+    const canonical = (cwd?: string | null) => (cwd?.startsWith('/home/me/src/rush') ? 'rush' : undefined);
+    const [out] = enrichActivityEvents(
+      [ev({ sessionId: 'r', cwd: '/home/me/src/rush/apps/web', project: 'rush-web' })],
+      [],
+      () => undefined,
+      canonical,
+    );
+    expect(out.project).toBe('rush');
+  });
+
+  it('honors the pre-baked stamp when no local def matches (foreign path)', () => {
+    const canonical = () => undefined; // different-home peer: no def matches
+    const [out] = enrichActivityEvents(
+      [ev({ sessionId: 'r', cwd: '/Users/other/src/rush', project: 'rush' })],
+      [],
+      () => undefined,
+      canonical,
+    );
+    expect(out.project).toBe('rush');
+  });
+
   it('does not treat an unknown host as an execution host', () => {
     const [out] = enrichActivityEvents([ev({ host: 'unknown', cwd: undefined })], []);
     expect(out.executionHost).toBeUndefined();

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -14,6 +14,7 @@ import {
   enrichActivityEvents,
   ensureActivityLogHook,
   filterActivityEvents,
+  filterActivityByProject,
   formatActivityGroupMeta,
   formatEnrichedActivityLine,
   formatProgressUpdate,
@@ -722,6 +723,24 @@ describe('filterActivityEvents', () => {
   });
   it('an empty filter is a no-op', () => {
     expect(filterActivityEvents(events, '   ')).toHaveLength(2);
+  });
+});
+
+describe('filterActivityByProject', () => {
+  const events = [
+    ev({ sessionId: '1', project: 'rush', event: 'pr.opened' }),
+    ev({ sessionId: '2', project: 'rush', event: 'pushed' }),
+    ev({ sessionId: '3', project: 'rush-infra', event: 'pushed' }),
+    ev({ sessionId: '4', event: 'plan.created' }), // no project label
+  ];
+  it('exact-matches the resolved project label — no substring bleed', () => {
+    // 'rush' must NOT pull in 'rush-infra'; a multi-repo project only matches
+    // because the resolver already collapsed it to one label upstream.
+    expect(filterActivityByProject(events, 'rush').map((e) => e.sessionId)).toEqual(['1', '2']);
+  });
+  it('misses nothing silently — unknown or empty names', () => {
+    expect(filterActivityByProject(events, 'nope')).toHaveLength(0);
+    expect(filterActivityByProject(events, '  ')).toHaveLength(4);
   });
 });
 

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -580,25 +580,32 @@ export function projectFromCwd(cwd?: string | null): string | undefined {
 
 /**
  * Join session facts (ticket / project / execution host) onto each event by
- * `sessionId`. A hint wins; otherwise pre-baked enriched fields (from a remote
- * peer that already enriched its own stream) are preserved, and project/host
- * fall back to what the event itself carries (`cwd`, `host`).
+ * `sessionId`. A hint wins; otherwise a CANONICAL def match (`canonicalProject`)
+ * upgrades whatever the event carries; otherwise pre-baked enriched fields (from
+ * a remote peer that already enriched its own stream) are preserved, and
+ * project/host fall back to what the event itself carries (`cwd`, `host`).
+ *
+ * The def match ranks above the pre-baked stamp because the stamp may be stale
+ * (posted before the def existed) or skewed (a peer whose defs haven't synced);
+ * the match is pure prefix compare against local defs, so a different-home
+ * peer's path simply doesn't match and its stamp is honored as before.
  *
  * `resolveProject` is how a caller reading its OWN machine's logs upgrades the
  * cwd fold to real repository detection ({@link resolveProjectKey}); it defaults
  * to the pure {@link projectFromCwd}, which is all a path from another machine
- * can be resolved with. Pure given a pure resolver.
+ * can be resolved with. Pure given pure resolvers.
  */
 export function enrichActivityEvents(
   events: EnrichedActivityEvent[],
   hints: ActivitySessionHint[],
   resolveProject: (cwd?: string | null) => string | undefined = projectFromCwd,
+  canonicalProject?: (cwd?: string | null) => string | undefined,
 ): EnrichedActivityEvent[] {
   const bySession = new Map<string, ActivitySessionHint>();
   for (const h of hints) if (h.sessionId) bySession.set(h.sessionId, h);
   return events.map((ev) => {
     const hint = ev.sessionId ? bySession.get(ev.sessionId) : undefined;
-    const project = hint?.project ?? ev.project ?? resolveProject(ev.cwd);
+    const project = hint?.project ?? canonicalProject?.(ev.cwd) ?? ev.project ?? resolveProject(ev.cwd);
     const ticket = hint?.ticket ?? ev.ticket ?? undefined;
     const executionHost = hint?.executionHost ?? ev.executionHost
       ?? (ev.host && ev.host !== 'unknown' ? ev.host : undefined);

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -750,6 +750,18 @@ export function filterActivityEvents(events: EnrichedActivityEvent[], filter: st
   });
 }
 
+/**
+ * Narrow events to one resolved project, exact match on the enriched label
+ * (unlike {@link filterActivityEvents}'s cross-field substring). This is the
+ * `--project` flag: the label is canonical (a defined project's name) once the
+ * reader's resolver has run, so a multi-repo project matches as one bucket. Pure.
+ */
+export function filterActivityByProject(events: EnrichedActivityEvent[], project: string): EnrichedActivityEvent[] {
+  const name = project.trim();
+  if (!name) return events;
+  return events.filter((ev) => ev.project === name);
+}
+
 /** One rendered enriched line: the base activity line + `· project · ticket` tags. */
 export function formatEnrichedActivityLine(
   ev: EnrichedActivityEvent,

--- a/apps/cli/src/lib/feed-post.test.ts
+++ b/apps/cli/src/lib/feed-post.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -17,6 +17,19 @@ import type { PidSessionEntry } from './session/pid-registry.js';
 function tmpActivityDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-post-'));
 }
+
+// postFeedStatus resolves project names against the defs dir — keep every test
+// hermetic (an empty dir) so a developer's real ~/.agents/projects can't flip a
+// label; the canonical-name test overrides this with its own seeded dir.
+let emptyDefsDir: string;
+beforeEach(() => {
+  emptyDefsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-feed-post-defs-'));
+  process.env.AGENTS_PROJECTS_DIR = emptyDefsDir;
+});
+afterEach(() => {
+  delete process.env.AGENTS_PROJECTS_DIR;
+  fs.rmSync(emptyDefsDir, { recursive: true, force: true });
+});
 
 describe('normalizeStatusText', () => {
   it('collapses whitespace and rejects empty', () => {

--- a/apps/cli/src/lib/feed-post.test.ts
+++ b/apps/cli/src/lib/feed-post.test.ts
@@ -278,6 +278,31 @@ describe('postFeedStatus attachments + project', () => {
     expect(stored[0].attachments?.[0].name).toBe('take.wav');
   });
 
+  it('stamps the canonical defined-project name, not the repo key', () => {
+    const dir = tmpActivityDir();
+    const defsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-proj-defs-'));
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-proj-repo-'));
+    // A multi-repo project: any repo under its root files under the ONE name.
+    fs.writeFileSync(path.join(defsDir, 'song-suite.yaml'), `name: song-suite\nroot: ${repo}\n`);
+    process.env.AGENTS_PROJECTS_DIR = defsDir;
+    try {
+      const { event } = postFeedStatus({
+        text: 'mastered',
+        sessionId: 'sess-canonical',
+        activityRoot: dir,
+        cwd: path.join(repo, 'apps', 'studio'),
+        env: { AGENTS_AGENT_NAME: 'grok', AGENTS_SYNC_MACHINE_ID: 'yosemite-s1' },
+        ts: '2026-07-31T12:00:00.000Z',
+        listEntries: () => [],
+        readEntry: () => undefined,
+        startPid: 1,
+      });
+      expect(event.project).toBe('song-suite');
+    } finally {
+      delete process.env.AGENTS_PROJECTS_DIR;
+    }
+  });
+
   it('omits attachments when none given', () => {
     const dir = tmpActivityDir();
     const { event } = postFeedStatus({

--- a/apps/cli/src/lib/feed-post.ts
+++ b/apps/cli/src/lib/feed-post.ts
@@ -20,7 +20,7 @@ import {
   type ActivityEvent,
   type Attachment,
 } from './activity.js';
-import { resolveProjectKey } from './project-key.js';
+import { resolveProjectNameForCwd, listProjectDefs } from './projects.js';
 import { getHistoryDir } from './state.js';
 import { machineId } from './machine-id.js';
 import { isValidMailboxId } from './mailbox.js';
@@ -358,9 +358,11 @@ export function postFeedStatus(input: FeedPostInput): FeedPostResult {
 
   const ts = input.ts ?? new Date().toISOString();
   // The post is written where the agent runs, so the cwd is a local path and
-  // gets full repository resolution — a post from `<repo>/apps/cli` files under
-  // `<repo>`, matching how the timeline groups everything else.
-  const project = resolveProjectKey(identity.cwd);
+  // gets full canonical resolution — a defined project's name wins (a post from
+  // any repo of a multi-repo project files under that project), else the repo
+  // key, matching how the timeline groups everything else. listProjectDefs is
+  // fail-open, so this costs one small readdir + YAML parse per post.
+  const project = resolveProjectNameForCwd(identity.cwd, listProjectDefs());
   const attachments = buildAttachments(input.attach, {
     copyRoot: input.attachmentsRoot ?? path.join(getHistoryDir(), 'attachments'),
     sessionId: identity.sessionId,

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -12,6 +12,7 @@ import {
   projectBasePath,
   resolveDefinedProjectPath,
   projectNameForCwd,
+  resolveProjectNameForCwd,
   type ProjectDef,
 } from './projects.js';
 
@@ -175,5 +176,40 @@ describe('projectNameForCwd', () => {
     // ~/src/rush-extra must NOT match ~/src/rush (segment-aware, not string prefix)
     expect(projectNameForCwd(path.join(HOME, 'src/rush-extra/x'), defs)).toBeUndefined();
     expect(projectNameForCwd(undefined, defs)).toBeUndefined();
+  });
+});
+
+describe('resolveProjectNameForCwd', () => {
+  it('prefers the defined project over the repo key', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'proj-canonical-'));
+    try {
+      fs.mkdirSync(path.join(repo, '.git'));
+      const sub = path.join(repo, 'apps', 'web');
+      fs.mkdirSync(sub, { recursive: true });
+      const defs: ProjectDef[] = [{ name: 'rush', root: repo }];
+      expect(resolveProjectNameForCwd(sub, defs)).toBe('rush'); // def name, not the repo basename
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the repository key for a cwd no definition contains — and with no defs at all', () => {
+    // Real temp repo: the fallback does the fs walk and names the repo dir.
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'proj-fallback-'));
+    try {
+      fs.mkdirSync(path.join(repo, '.git'));
+      const sub = path.join(repo, 'apps', 'cli');
+      fs.mkdirSync(sub, { recursive: true });
+      const elsewhere: ProjectDef[] = [{ name: 'rush', root: path.join(repo, 'elsewhere-def-root') }];
+      expect(resolveProjectNameForCwd(sub, elsewhere)).toBe(path.basename(repo));
+      expect(resolveProjectNameForCwd(sub, [])).toBe(path.basename(repo)); // == today's behavior
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('undefined for an empty cwd', () => {
+    expect(resolveProjectNameForCwd(undefined, [])).toBeUndefined();
+    expect(resolveProjectNameForCwd('', [])).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -25,6 +25,7 @@ import * as yaml from 'yaml';
 import { getProjectsDir } from './state.js';
 import { safeJoin } from './paths.js';
 import { toHomeRelative, expandLocalHome } from './project-root.js';
+import { resolveProjectKey } from './project-key.js';
 
 /** A git repo bound to a project, with an optional monorepo subpath. */
 export interface ProjectRepo {
@@ -324,6 +325,19 @@ export function projectNameForCwd(cwd: string | undefined, defs: ProjectDef[]): 
     }
   }
   return best;
+}
+
+/**
+ * The canonical project label for a cwd, for every surface that buckets work by
+ * project (the activity timeline, feed posts, the sessions overview): the
+ * DEFINED project whose root contains the cwd (longest root wins, so a
+ * multi-repo project reads as one bucket), else the repository-level key from
+ * {@link resolveProjectKey}. `defs` comes from {@link listProjectDefs}, which is
+ * fail-open — with no definitions this degrades to exactly today's behavior.
+ */
+export function resolveProjectNameForCwd(cwd: string | undefined | null, defs: ProjectDef[]): string | undefined {
+  if (!cwd) return undefined;
+  return projectNameForCwd(cwd, defs) ?? resolveProjectKey(cwd);
 }
 
 /**


### PR DESCRIPTION
**feat** — one project identity everywhere the fleet's work is bucketed, and a flag to watch a single project.

## Why

`agents activity` groups the fleet by project, and `agents projects` defines named multi-repo projects — but nothing connected them: the feed bucketed by *git repo*, so a project spanning `rush` + `rush-infra` showed as two unrelated groups under repo names, never the project's name. This is the seam: one resolver, every surface.

## What changed

- **`resolveProjectNameForCwd` (`lib/projects.ts`)** — the canonical label: the defined project whose root contains the cwd (longest root wins, via the existing `projectNameForCwd`), else the repo-level key (`resolveProjectKey`). With no definitions it degrades to exactly today's behavior.
- **`agents activity`** — the read-time join (`activityHintsFromSessions`) and the cwd fallback both resolve canonically. Peers run the same code against their synced defs before events cross the wire, so a multi-repo project is one bucket fleet-wide. New flag: **`--project <name>`** — exact-match on the resolved label (`filterActivityByProject`), no substring bleed (`rush` ≠ `rush-infra`).
- **`agents feed post`** — stamps the canonical project name at write time (`listProjectDefs` is fail-open; one small readdir + YAML parse per post).
- **`agents sessions` overview** — groups by the same resolver, defs threaded through `buildOverviewGroups`.

Docs (`06-observability.md`, `11-projects.md`) + changelog fragment in the diff.

## Run evidence (this branch, live activity logs, temp def `agentic` → this repo)

Captured run image: `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/projects-activity-attribution-run.png`

Top: `agents activity --local` buckets the repo's work under the **defined project name** `agentic` (was: `agents-cli`). Bottom: `--project agentic` narrows to exactly that bucket. A run with `AGENTS_PROJECTS_DIR` unset buckets under `agents-cli` — unchanged without definitions.

## Tests

178 across the touched suites pass; new tests: compose-fn precedence + hermetic fallbacks on real temp repos, the exact-match filter (no substring bleed), the canonical feed-post stamp (multi-repo → one name), the overview's def-name win. `tsc --noEmit` clean.
