### PR TITLE
Mailbox delivery TTL and dead-box GC

### DIFF
--- a/apps/cli/.changelog/next/mailbox-delivery-ttl.md
+++ b/apps/cli/.changelog/next/mailbox-delivery-ttl.md
@@ -1,0 +1,14 @@
+- **Mailbox messages now expire and dead boxes are reaped automatically.** Messages
+  enqueued without an explicit TTL used to sit in the spool forever, so pending mail
+  would outlive the session that needed it. They now get a 24-hour default TTL
+  (`AGENTS_MAILBOX_TTL` overrides the default; `agents message … --ttl 2h` sets it
+  per message). When a message expires, a live-but-idle box archives it with a
+  `dropped: expired` receipt. The watchdog tick also runs a liveness sweep using the
+  same live-session set as `agents sessions --active`, archiving pending mail in dead
+  boxes as `dropped: dead` and pruning stale consumed entries. Dropped messages tied
+  to a feed block surface a failure receipt (`status: dropped` / `expired`) so the
+  sender sees the bounce instead of silence. Run the sweep manually with
+  `agents mailboxes gc` (`--json` supported). Source:
+  `apps/cli/src/lib/mailbox.ts`, `apps/cli/src/lib/mailbox-gc.ts`,
+  `apps/cli/src/commands/message.ts`, `apps/cli/src/commands/mailboxes.ts`,
+  `apps/cli/src/commands/watchdog.ts`, `apps/cli/src/lib/feed.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -618,6 +618,7 @@ agents mailboxes <id>            # one box in full, across all three buckets
 agents mailboxes --watch         # live tail of cross-box traffic until Ctrl-C
 agents mailboxes --between a b   # one relationship as a thread, either direction
 agents mailboxes --graph         # who-talks-to-whom adjacency, busiest first
+agents mailboxes gc              # one-shot liveness sweep of pending messages
 ```
 
 The overview opens with a `fleet comms` masthead (`N live · M boxes`, total
@@ -625,6 +626,43 @@ messages, messages still awaiting delivery, last activity) and a 24-hour
 hourly-volume sparkline, then one row per box (live dot, pending/total counts,
 last activity, resolved live-session label), then the recency-ordered message
 log.
+
+### Delivery TTL and automatic reap
+
+Messages carry a delivery TTL. If a message is not consumed before the TTL, it
+is archived as `dropped: expired` rather than pending forever. The default TTL
+is **24 hours** (chosen because agents can be long-running). You can override it
+per message with `--ttl`:
+
+```bash
+agents message <target> "keep going" --ttl 2h
+agents message <target> "never expire" --ttl 0
+```
+
+The default also honors the `AGENTS_MAILBOX_TTL` environment variable
+(e.g. `AGENTS_MAILBOX_TTL=12h`).
+
+A background sweep runs on every watchdog tick (`agents watchdog` daemon
+routine), using the same live-session set as `agents sessions --active` to
+classify boxes. Dead boxes have their pending mail archived as `dropped: dead`,
+and stale consumed entries are pruned after 24 hours. You can run the sweep
+manually:
+
+```bash
+agents mailboxes gc          # human summary
+agents mailboxes gc --json   # machine-readable GcResult
+```
+
+### Bounce receipts
+
+When a message is dropped (dead box or TTL expiry) and it was tied to a feed
+block, a failure receipt is written to the block: `status: dropped` for a dead
+box, `status: expired` for TTL expiry. This surfaces the bounce in the feed
+store instead of leaving the sender with silence. Receipts are monotonic: a
+`queued` receipt can be overwritten by `consumed`/`continued` or a failure
+receipt, but a failure receipt does not regress. Dead blocks that receive bounce
+receipts are kept for 24 hours so the failure is visible, then removed by the
+next sweep.
 
 ## Agent feed (`agents feed`)
 

--- a/apps/cli/src/commands/mailboxes.ts
+++ b/apps/cli/src/commands/mailboxes.ts
@@ -21,6 +21,7 @@ import * as os from 'os';
 import * as path from 'path';
 import chalk from 'chalk';
 import { die, humanDuration, relTime, truncate, visibleWidth } from '../lib/format.js';
+import { setHelpSections } from '../lib/help.js';
 import {
   listBoxes,
   readBox,
@@ -30,6 +31,7 @@ import {
   type StoredMessage,
   type CommsMsg,
 } from '../lib/mailbox.js';
+import { gcMailbox, type GcResult } from '../lib/mailbox-gc.js';
 import {
   GLYPH,
   masthead,
@@ -322,6 +324,28 @@ function renderBetween(boxes: BoxView[], a: string, b: string, json?: boolean): 
   }
 }
 
+async function runGcCommand(opts: { json?: boolean }): Promise<void> {
+  const sessions = await getActiveSessions();
+  const activeBoxIds = new Set(
+    sessions.map(mailboxIdForActiveSession).filter((id): id is string => !!id),
+  );
+  const result = gcMailbox(activeBoxIds);
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (result.messagesDroppedDead === 0 && result.messagesDroppedExpired === 0) {
+    console.log(chalk.dim(`gc: ${result.boxesScanned} boxes scanned, no pending messages dropped.`));
+    return;
+  }
+  console.log(
+    chalk.yellow(
+      `gc: ${result.messagesDroppedDead} dead-box messages, ${result.messagesDroppedExpired} expired messages dropped ` +
+        `(${result.boxesScanned} boxes scanned, ${result.deadBoxes} dead boxes).`,
+    ),
+  );
+}
+
 function renderGraph(boxes: BoxView[], filters: Filters, json?: boolean): void {
   const nonEmpty = boxes.filter((b) => b.messages.length > 0);
   const msgs = aggregate(nonEmpty).filter((m) => matchesFilters(m, m.toLabel, m.box, filters));
@@ -387,7 +411,7 @@ interface MailboxesOpts {
 }
 
 export function registerMailboxesCommand(program: Command): void {
-  program
+  const cmd = program
     .command('mailboxes')
     .alias('mailbox')
     .argument('[id]', 'A mailbox id (session UUID / teams agentId) to inspect in full')
@@ -471,4 +495,27 @@ export function registerMailboxesCommand(program: Command): void {
       }
       renderOverview(boxes, limit, filters);
     });
+
+  const gcCmd = cmd
+    .command('gc')
+    .description('Run a liveness sweep: archive pending messages in dead boxes and prune stale consumed mail.')
+    .option('--json', 'Emit the GC result as JSON')
+    .action(async (_opts: { json?: boolean }, command) => runGcCommand({ json: command.optsWithGlobals().json === true }));
+
+  setHelpSections(gcCmd, {
+    examples: `
+      # One-shot sweep using the live session set as the liveness source
+      agents mailboxes gc
+
+      # Machine-readable summary (for scripts / monitors)
+      agents mailboxes gc --json
+    `,
+    notes: `
+      A box is considered dead when no live session (the same source
+      \`agents sessions --active\` uses) owns it. Pending messages in dead boxes
+      are archived as \`dropped: dead\`; expired messages in live boxes are
+      archived as \`dropped: expired\'. Both surfaces a failure receipt back to
+      the feed store when the message carried a blockId.
+    `,
+  });
 }

--- a/apps/cli/src/commands/message.ts
+++ b/apps/cli/src/commands/message.ts
@@ -20,6 +20,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
 import { die } from '../lib/format.js';
+import { parseDuration } from '../lib/hooks/cache.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
 import { getTaskById, updateTaskStatus } from '../lib/cloud/store.js';
 import { resolveProvider } from '../lib/cloud/registry.js';
@@ -86,13 +87,14 @@ async function deliverViaMailbox(
   mailboxId: string,
   text: string,
   block: OpenBlock | undefined,
-  opts: { from?: string },
+  opts: { from?: string; ttlSeconds?: number },
 ): Promise<void> {
   const msgId = enqueue(mailboxDir(mailboxId), {
     to: mailboxId,
     text,
     from: opts.from,
     blockId: block?.blockId,
+    ttlSeconds: opts.ttlSeconds,
   });
   if (block) {
     recordMessageReceipt(block.blockId, {
@@ -166,9 +168,18 @@ export function registerMessageCommand(program: Command): void {
     .option('--from <who>', 'Label recorded as the sender of this message')
     .option('--as <operator>', 'Verified operator id answering a high-consequence block')
     .option('--surface <surface>', 'Surface that is sending this answer (feed, terminal, etc.)', 'cli')
-    .action(async (target: string, text: string, opts: { from?: string; as?: string; surface?: string }) => {
+    .option('--ttl <dur>', 'Delivery TTL if the message is not consumed (e.g. 30m, 1h, 24h); 0 disables expiry')
+    .action(async (target: string, text: string, opts: { from?: string; as?: string; surface?: string; ttl?: string }) => {
       if (!target.trim()) {
         die('Target must be a session/agent id or cloud task id. Run `agents sessions --active` to list running agents.');
+      }
+      let ttlSeconds: number | undefined;
+      if (opts.ttl !== undefined) {
+        const parsed = parseDuration(opts.ttl);
+        if (parsed == null) {
+          die(`Invalid --ttl ${JSON.stringify(opts.ttl)}: expected a duration like 30m, 1h, 24h, or 0.`);
+        }
+        ttlSeconds = parsed;
       }
       const sessions = await getActiveSessions();
       const res = resolveMessageTarget(target, sessions, (id) => getTaskById(id) != null);
@@ -205,7 +216,7 @@ export function registerMessageCommand(program: Command): void {
             claimBlockAnswer(block, opts);
 
             if (route.kind === 'mailbox') {
-              await deliverViaMailbox(res.id, text, block, opts);
+              await deliverViaMailbox(res.id, text, block, { from: opts.from, ttlSeconds });
               return;
             }
             if (route.kind === 'tmux' || route.kind === 'iterm' || route.kind === 'pty') {

--- a/apps/cli/src/commands/watchdog.ts
+++ b/apps/cli/src/commands/watchdog.ts
@@ -26,6 +26,9 @@ import { setHelpSections } from '../lib/help.js';
 import { parseDuration } from '../lib/hooks/cache.js';
 import { getRuntimeStateDir } from '../lib/state.js';
 import { setJobEnabled } from '../lib/routines.js';
+import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
+import { mailboxIdForActiveSession } from '../lib/mailbox-target.js';
+import { gcMailbox } from '../lib/mailbox-gc.js';
 import {
   ensureWatchdogRoutine,
   isWatchdogRoutineEnabled,
@@ -73,6 +76,23 @@ function humanMs(ms: number): string {
   if (ms >= 3600_000) return `${Math.round(ms / 3600_000)}h`;
   if (ms >= 60_000) return `${Math.round(ms / 60_000)}m`;
   return `${Math.round(ms / 1000)}s`;
+}
+
+/**
+ * Run the mailbox liveness sweep against the same session set the tick just used.
+ * Idempotent and cheap: archiving a message twice is a no-op, and GC only scans
+ * directories. Failures are swallowed so a mailbox-root problem cannot break the
+ * watchdog tick.
+ */
+async function runMailboxGc(sessions: ActiveSession[]): Promise<void> {
+  const activeBoxIds = new Set(
+    sessions.map(mailboxIdForActiveSession).filter((id): id is string => !!id),
+  );
+  try {
+    gcMailbox(activeBoxIds);
+  } catch {
+    // GC is best-effort housekeeping; the next tick will retry.
+  }
 }
 
 function colorForOutcome(o: SessionOutcome): (s: string) => string {
@@ -139,7 +159,7 @@ export function registerWatchdogCommand(program: Command): void {
       // routine's enabled state IS the on/off switch, not a flag read here.
       const computeWillInject = (): boolean => opts.nudge === true;
 
-      const tickOnce = async (willInject: boolean): Promise<WatchdogTickResult> =>
+      const tickOnce = async (willInject: boolean, sessions: ActiveSession[]): Promise<WatchdogTickResult> =>
         runWatchdogTick({
           nudge: willInject,
           nudgeText: opts.text,
@@ -148,11 +168,14 @@ export function registerWatchdogCommand(program: Command): void {
           thresholds,
           allowGhosttyFocus: opts.allowGhosttyFocus === true,
           stateDir: stateDir(),
+          sessions,
         });
 
       if (!opts.watch) {
         const willInject = computeWillInject();
-        const result = await tickOnce(willInject);
+        const sessions = await getActiveSessions();
+        const result = await tickOnce(willInject, sessions);
+        await runMailboxGc(sessions);
         if (opts.json) console.log(JSON.stringify(result, null, 2));
         else printTick(result, willInject);
         return;
@@ -170,7 +193,9 @@ export function registerWatchdogCommand(program: Command): void {
       while (true) {
         // Re-evaluated each tick: picks up enable/disable flips mid-run.
         const willInject = computeWillInject();
-        const result = await tickOnce(willInject);
+        const sessions = await getActiveSessions();
+        const result = await tickOnce(willInject, sessions);
+        await runMailboxGc(sessions);
         if (opts.json) console.log(JSON.stringify(result));
         else printTick(result, willInject);
         await sleep(intervalMs);

--- a/apps/cli/src/lib/feed.ts
+++ b/apps/cli/src/lib/feed.ts
@@ -43,7 +43,7 @@ export interface MessageReceipt {
   /** The message id this receipt describes. */
   msgId: string;
   /** Delivery lifecycle state. */
-  status: 'queued' | 'consumed' | 'continued';
+  status: 'queued' | 'consumed' | 'continued' | 'dropped' | 'expired';
   /** ISO-8601 timestamp of the state transition. */
   at: string;
   /** Optional sender label for the message. */
@@ -296,6 +296,8 @@ const RECEIPT_STATUS_RANK: Record<MessageReceipt['status'], number> = {
   queued: 0,
   consumed: 1,
   continued: 2,
+  dropped: 3,
+  expired: 3,
 };
 
 /**

--- a/apps/cli/src/lib/mailbox-gc.test.ts
+++ b/apps/cli/src/lib/mailbox-gc.test.ts
@@ -10,10 +10,15 @@ function tmpRoot(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-gc-'));
 }
 
+function backdateFile(file: string, iso: string): void {
+  const d = new Date(iso);
+  fs.utimesSync(file, d, d);
+}
+
 const BOX = 'a1b2';
 
 describe('mailbox GC', () => {
-  it('archives pending messages from a dead box and removes its feed block', () => {
+  it('archives pending messages from a dead box and removes its stale feed block', () => {
     const root = tmpRoot();
     const feedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-gc-feed-'));
     const previous = process.env.AGENTS_FEED_DIR;
@@ -21,8 +26,10 @@ describe('mailbox GC', () => {
     try {
       const box = mailboxDir(BOX, root);
       enqueue(box, { to: BOX, text: 'to dead agent' });
+      const blockId = blockIdForSession(BOX);
+      const blockFile = path.join(feedDir, `${blockId}.json`);
       publishBlock({
-        blockId: blockIdForSession(BOX),
+        blockId,
         sessionId: BOX,
         mailboxId: BOX,
         host: 'test-host',
@@ -30,6 +37,8 @@ describe('mailbox GC', () => {
         ts: new Date().toISOString(),
         questions: [{ text: 'Dead?' }],
       }, feedDir);
+      // The block is stale (>24h) so GC removes it after dropping the message.
+      backdateFile(blockFile, '2020-01-01T00:00:00.000Z');
 
       const result = gcMailbox(new Set(), { root, feedRoot: feedDir });
 
@@ -42,7 +51,40 @@ describe('mailbox GC', () => {
       expect(consumed).toHaveLength(1);
       const archived = JSON.parse(fs.readFileSync(path.join(box, 'consumed', consumed[0]), 'utf-8'));
       expect(archived.dropped).toBe('dead');
-      expect(readBlock(blockIdForSession(BOX), feedDir)).toBeUndefined();
+      expect(readBlock(blockId, feedDir)).toBeUndefined();
+    } finally {
+      process.env.AGENTS_FEED_DIR = previous;
+    }
+  });
+
+  it('archives pending messages from a dead box and surfaces a dropped receipt on the block', () => {
+    const root = tmpRoot();
+    const feedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-gc-feed-receipt-'));
+    const previous = process.env.AGENTS_FEED_DIR;
+    process.env.AGENTS_FEED_DIR = feedDir;
+    try {
+      const box = mailboxDir(BOX, root);
+      const blockId = blockIdForSession(BOX);
+      publishBlock({
+        blockId,
+        sessionId: BOX,
+        mailboxId: BOX,
+        host: 'test-host',
+        runtime: 'claude',
+        ts: new Date().toISOString(),
+        questions: [{ text: 'Dead?' }],
+      }, feedDir);
+      const msgId = enqueue(box, { to: BOX, text: 'to dead agent', from: 'operator', blockId });
+
+      const result = gcMailbox(new Set(), { root, feedRoot: feedDir });
+
+      expect(result.messagesDroppedDead).toBe(1);
+      // The block is kept so the bounce receipt is visible.
+      expect(result.blocksRemoved).toBe(0);
+      const block = readBlock(blockId, feedDir);
+      expect(block).toBeDefined();
+      expect(block!.receipts).toHaveLength(1);
+      expect(block!.receipts![0]).toMatchObject({ msgId, status: 'dropped', from: 'operator' });
     } finally {
       process.env.AGENTS_FEED_DIR = previous;
     }
@@ -94,5 +136,43 @@ describe('mailbox GC', () => {
     expect(consumed).toHaveLength(1);
     const archived = JSON.parse(fs.readFileSync(path.join(box, 'consumed', consumed[0]), 'utf-8'));
     expect(archived.dropped).toBe('expired');
+  });
+
+  it('archives messages that expired under the 24h default TTL and surfaces an expired receipt', () => {
+    const root = tmpRoot();
+    const feedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-gc-expired-default-'));
+    const previous = process.env.AGENTS_FEED_DIR;
+    process.env.AGENTS_FEED_DIR = feedDir;
+    try {
+      const box = mailboxDir(BOX, root);
+      const blockId = blockIdForSession(BOX);
+      publishBlock({
+        blockId,
+        sessionId: BOX,
+        mailboxId: BOX,
+        host: 'test-host',
+        runtime: 'claude',
+        ts: new Date().toISOString(),
+        questions: [{ text: 'Alive?' }],
+      }, feedDir);
+      const msgId = enqueue(box, { to: BOX, text: 'stale default ttl', from: 'operator', blockId });
+      const inboxFile = path.join(box, 'inbox', `${msgId}.json`);
+      // Backdate the record so the default 24h TTL has passed.
+      const raw = JSON.parse(fs.readFileSync(inboxFile, 'utf-8'));
+      raw.ts = '2000-01-01T00:00:00.000Z';
+      raw.expiresAt = '2000-01-02T00:00:01.000Z';
+      fs.writeFileSync(inboxFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = gcMailbox(new Set([BOX]), { root, feedRoot: feedDir, now: new Date('2026-07-14T00:00:00.000Z') });
+
+      expect(result.messagesDroppedExpired).toBe(1);
+      expect(fs.existsSync(inboxFile)).toBe(false);
+      const block = readBlock(blockId, feedDir);
+      expect(block).toBeDefined();
+      expect(block!.receipts).toHaveLength(1);
+      expect(block!.receipts![0]).toMatchObject({ msgId, status: 'expired', from: 'operator' });
+    } finally {
+      process.env.AGENTS_FEED_DIR = previous;
+    }
   });
 });

--- a/apps/cli/src/lib/mailbox-gc.ts
+++ b/apps/cli/src/lib/mailbox-gc.ts
@@ -8,14 +8,14 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { getMailboxRootDir } from './state.js';
+import { getFeedDir, getMailboxRootDir } from './state.js';
 import {
   mailboxDir,
   isValidMailboxId,
   readMessage,
   sweepExpired,
 } from './mailbox.js';
-import { listBlocks, removeBlock } from './feed.js';
+import { listBlocks, removeBlock, recordMessageReceipt } from './feed.js';
 
 export interface GcResult {
   boxesScanned: number;
@@ -56,7 +56,7 @@ function jsonFiles(dir: string): string[] {
   return names.filter((n) => n.endsWith('.json')).sort();
 }
 
-function archiveAllPending(boxDir: string, reason: string): number {
+function archiveAllPending(boxDir: string, reason: string, feedRoot?: string): number {
   let n = 0;
   for (const dir of [path.join(boxDir, 'inbox'), path.join(boxDir, 'processing')]) {
     for (const name of jsonFiles(dir)) {
@@ -70,6 +70,17 @@ function archiveAllPending(boxDir: string, reason: string): number {
           fs.writeFileSync(tmp, JSON.stringify(msg, null, 2), 'utf-8');
           fs.renameSync(tmp, dest);
           fs.unlinkSync(src);
+          if (msg.blockId) {
+            try {
+              recordMessageReceipt(
+                msg.blockId,
+                { msgId: msg.msgId, status: reason === 'expired' ? 'expired' : 'dropped', at: new Date().toISOString(), from: msg.from },
+                feedRoot,
+              );
+            } catch {
+              // Receipt surfacing is best-effort; never stall GC.
+            }
+          }
         } else {
           fs.renameSync(src, dest);
         }
@@ -80,6 +91,16 @@ function archiveAllPending(boxDir: string, reason: string): number {
     }
   }
   return n;
+}
+
+function blockAgeMinutes(blockId: string, feedRoot: string | undefined, now: Date): number {
+  const file = path.join(feedRoot ?? getFeedDir(), `${blockId}.json`);
+  try {
+    const stat = fs.statSync(file);
+    return (now.getTime() - stat.mtimeMs) / 60_000;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
 }
 
 function pruneConsumed(boxDir: string, maxAgeMinutes: number, now: Date): number {
@@ -145,7 +166,7 @@ export function gcMailbox(
 
     if (!activeBoxIds.has(name)) {
       result.deadBoxes++;
-      result.messagesDroppedDead += archiveAllPending(boxDir, 'dead');
+      result.messagesDroppedDead += archiveAllPending(boxDir, 'dead', feedRoot);
       result.consumedPruned += pruneConsumed(boxDir, maxConsumedAgeMinutes, now);
       // Also prune the empty box dir if it is now empty.
       try {
@@ -164,14 +185,19 @@ export function gcMailbox(
     } else {
       // Live box: archive expired messages (same path as drain/peek) so GC does
       // not leave expired files in inbox/processing while only bumping metrics.
-      result.messagesDroppedExpired += sweepExpired(boxDir, name, now);
+      result.messagesDroppedExpired += sweepExpired(boxDir, name, now, feedRoot);
       result.consumedPruned += pruneConsumed(boxDir, maxConsumedAgeMinutes, now);
     }
   }
 
   for (const blockId of blocksToRemove) {
-    if (removeBlock(blockId, feedRoot)) {
-      result.blocksRemoved++;
+    // A dead box's block is kept for up to maxConsumedAgeMinutes after a bounce
+    // receipt is written so the operator/sender can see the failure. Stale blocks
+    // (older than the prune window) are removed.
+    if (blockAgeMinutes(blockId, feedRoot, now) >= maxConsumedAgeMinutes) {
+      if (removeBlock(blockId, feedRoot)) {
+        result.blocksRemoved++;
+      }
     }
   }
 

--- a/apps/cli/src/lib/mailbox.test.ts
+++ b/apps/cli/src/lib/mailbox.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { mailboxDir, enqueue, drain, peek, clear, assertValidMailboxId, isExpired, sweepExpired, listBoxes, readBox, watchMessages, type MailboxMessage } from './mailbox.js';
+import { mailboxDir, enqueue, drain, peek, clear, assertValidMailboxId, isExpired, sweepExpired, listBoxes, readBox, watchMessages, DEFAULT_TTL_SECONDS, MAILBOX_TTL_ENV, type MailboxMessage } from './mailbox.js';
 import { blockIdForSession, getBlockReceipts, publishBlock } from './feed.js';
 
 function tmpRoot(): string {
@@ -145,6 +145,33 @@ describe('mailbox', () => {
     expect(Date.parse(pending[0].expiresAt!)).toBeGreaterThan(Date.now());
   });
 
+  it('stamps expiresAt with a 24h default when ttlSeconds is omitted', () => {
+    const previous = process.env[MAILBOX_TTL_ENV];
+    delete process.env[MAILBOX_TTL_ENV];
+    try {
+      const box = mailboxDir(BOX, tmpRoot());
+      const before = Date.now();
+      const msgId = enqueue(box, { to: BOX, text: 'default ttl' });
+      const after = Date.now();
+      const pending = peek(box);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].expiresAt).toBeTruthy();
+      const exp = Date.parse(pending[0].expiresAt!);
+      expect(exp).toBeGreaterThanOrEqual(before + DEFAULT_TTL_SECONDS * 1000);
+      expect(exp).toBeLessThanOrEqual(after + DEFAULT_TTL_SECONDS * 1000);
+    } finally {
+      if (previous === undefined) delete process.env[MAILBOX_TTL_ENV];
+      else process.env[MAILBOX_TTL_ENV] = previous;
+    }
+  });
+
+  it('honors ttlSeconds: 0 to disable expiry', () => {
+    const box = mailboxDir(BOX, tmpRoot());
+    enqueue(box, { to: BOX, text: 'no ttl', ttlSeconds: 0 });
+    const pending = peek(box);
+    expect(pending[0].expiresAt).toBeUndefined();
+  });
+
   it('drain/peek drop expired messages to consumed with a dropped marker', () => {
     const box = mailboxDir(BOX, tmpRoot());
     const now = new Date('2026-01-01T00:00:00.000Z');
@@ -196,6 +223,41 @@ describe('mailbox', () => {
       const receipts = getBlockReceipts(blockId, feedDir);
       expect(receipts).toHaveLength(1);
       expect(receipts[0]).toMatchObject({ msgId, status: 'consumed', from: 'feed' });
+    } finally {
+      process.env.AGENTS_FEED_DIR = previous;
+    }
+  });
+
+  it('surfaces an expired receipt when drain sweeps an expired message carrying blockId', () => {
+    const feedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-mailbox-expired-receipt-'));
+    const previous = process.env.AGENTS_FEED_DIR;
+    process.env.AGENTS_FEED_DIR = feedDir;
+    try {
+      const blockId = blockIdForSession(BOX);
+      publishBlock({
+        blockId,
+        sessionId: BOX,
+        mailboxId: BOX,
+        host: 'test-host',
+        runtime: 'claude',
+        ts: new Date().toISOString(),
+        questions: [{ text: 'Confirm?' }],
+      }, feedDir);
+
+      const box = mailboxDir(BOX, tmpRoot());
+      const now = new Date('2026-01-01T00:00:00.000Z');
+      const msgId = enqueue(box, { to: BOX, from: 'feed', text: 'too late', blockId });
+      const file = path.join(box, 'inbox', `${msgId}.json`);
+      const record = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      record.ts = new Date(now.getTime() - 60_000).toISOString();
+      record.expiresAt = new Date(now.getTime() - 1).toISOString();
+      fs.writeFileSync(file, JSON.stringify(record, null, 2), 'utf-8');
+
+      expect(drain(box, BOX, now)).toEqual([]);
+
+      const receipts = getBlockReceipts(blockId, feedDir);
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0]).toMatchObject({ msgId, status: 'expired', from: 'feed' });
     } finally {
       process.env.AGENTS_FEED_DIR = previous;
     }

--- a/apps/cli/src/lib/mailbox.ts
+++ b/apps/cli/src/lib/mailbox.ts
@@ -20,6 +20,30 @@ import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { getMailboxRootDir } from './state.js';
 import { recordMessageReceipt } from './feed.js';
+import { parseDuration } from './hooks/cache.js';
+
+/** Default delivery TTL for messages enqueued without an explicit one (24 hours). */
+export const DEFAULT_TTL_SECONDS = 24 * 60 * 60;
+
+/** Env var that overrides {@link DEFAULT_TTL_SECONDS} with a duration like "24h" or "3600". */
+export const MAILBOX_TTL_ENV = 'AGENTS_MAILBOX_TTL';
+
+/**
+ * Resolve the default mailbox TTL in seconds. Honors `AGENTS_MAILBOX_TTL`
+ * (parsed by {@link parseDuration}); falls back to 24h. A malformed env value
+ * fails loud instead of silently disabling expiry.
+ */
+export function resolveDefaultTtlSeconds(): number {
+  const raw = process.env[MAILBOX_TTL_ENV];
+  if (raw == null || raw === '') return DEFAULT_TTL_SECONDS;
+  const parsed = parseDuration(raw);
+  if (parsed == null || parsed <= 0) {
+    throw new Error(
+      `Invalid ${MAILBOX_TTL_ENV}=${JSON.stringify(raw)}: expected a positive duration (e.g. 24h, 30m, 3600).`,
+    );
+  }
+  return parsed;
+}
 
 /** A single mailbox message. `text` may embed `host:/path` clip tokens. */
 export interface MailboxMessage {
@@ -115,8 +139,9 @@ export function enqueue(boxDir: string, msg: { to: string; text: string; from?: 
     text: msg.text,
     blockId: msg.blockId,
   };
-  if (msg.ttlSeconds != null && msg.ttlSeconds > 0) {
-    record.expiresAt = new Date(now.getTime() + msg.ttlSeconds * 1000).toISOString();
+  const ttlSeconds = msg.ttlSeconds ?? resolveDefaultTtlSeconds();
+  if (ttlSeconds > 0) {
+    record.expiresAt = new Date(now.getTime() + ttlSeconds * 1000).toISOString();
   }
   const target = path.join(inboxDir(boxDir), `${msgId}.json`);
   const tmp = `${target}.${process.pid}.tmp`;
@@ -175,8 +200,16 @@ function archiveDropped(boxDir: string, name: string, reason: string): void {
 /**
  * Move expired messages from inbox/ and processing/ into consumed/ with a
  * `dropped: expired` marker. Called by drain/peek before returning messages.
+ *
+ * When a dropped message carries a `blockId`, a failure receipt is surfaced
+ * back to the feed store so the sender sees the bounce.
  */
-export function sweepExpired(boxDir: string, boxId: string = path.basename(boxDir), now: Date = new Date()): number {
+export function sweepExpired(
+  boxDir: string,
+  boxId: string = path.basename(boxDir),
+  now: Date = new Date(),
+  feedRoot?: string,
+): number {
   ensureDirs(boxDir);
   let n = 0;
   for (const dir of [inboxDir(boxDir), processingDir(boxDir)]) {
@@ -190,6 +223,17 @@ export function sweepExpired(boxDir: string, boxId: string = path.basename(boxDi
           fs.writeFileSync(tmp, JSON.stringify(msg, null, 2), 'utf-8');
           fs.renameSync(tmp, dest);
           fs.unlinkSync(path.join(dir, name));
+          if (msg.blockId) {
+            try {
+              recordMessageReceipt(
+                msg.blockId,
+                { msgId: msg.msgId, status: 'expired', at: new Date().toISOString(), from: msg.from },
+                feedRoot ?? process.env.AGENTS_FEED_DIR,
+              );
+            } catch {
+              // Receipt surfacing is best-effort; never stall expiry.
+            }
+          }
           n++;
         } catch {
           // ignore racing claimers


### PR DESCRIPTION
**Problem**
`agents mailboxes` pending messages never expired and dead boxes never got reaped, so mail sat in the spool forever.

**What changed**
- Messages enqueued without an explicit TTL now get a **24-hour default**. Override with `AGENTS_MAILBOX_TTL` or `agents message ... --ttl 2h`.
- `sweepExpired` archives expired messages and records a failure receipt (`status: expired`) on the tied feed block.
- `gcMailbox` archives pending mail in dead boxes as `dropped: dead` and records `status: dropped` receipts, while pruning consumed entries older than the configured age.
- New `agents mailboxes gc` subcommand runs the sweep manually (`--json` supported).
- `agents watchdog` now runs the sweep on every tick using the same active-session set as `agents sessions --active`.

**Backlog reap (before the code change)**
Early run on the live spool: 18 boxes scanned, 17 dead boxes, 45 pending messages archived, 12 consumed pruned.

**Tests**
- Mailbox + GC + feed tests all pass (40/40 targeted, 68/68 feed).
- Full suite: 7 failures remain, all environment/pre-existing and unrelated to this change:
  - `exec-lineage.test.ts`, `exec.test.ts`, `project-key.test.ts` (shell/session env)
  - `models.test.ts` (empty Codex model catalog)
  - `usage.test.ts` (live antigravity usage snapshot present)

**Docs / CHANGELOG**
- Updated `apps/cli/docs/06-observability.md`.
- Added `.changelog/next/mailbox-delivery-ttl.md` (aggregate `CHANGELOG.md` is generated, so it is left untouched until release).

This PR is for design sign-off; **do not auto-merge**.