### PR TITLE
docs(reports): add measured coordination-path latency

### DIFF
--- a/.agents/reports/memory-and-coordination.html
+++ b/.agents/reports/memory-and-coordination.html
@@ -587,16 +587,22 @@ Median of three runs on this box; the fleet column is the default SSH fan-out ac
     <tr><td>Session query (FTS)</td><td><code>0.76 s</code></td><td><code>8.6 s</code></td><td>"find the session about X"</td></tr>
     <tr><td>Live status <code>--active</code></td><td><code>~3.0 s</code></td><td><code>~10 s</code></td><td>"who is running right now"</td></tr>
     <tr><td>Feed read</td><td><code>~3.2 s</code></td><td><code>13–22 s</code></td><td>"who needs me / what happened"</td></tr>
-    <tr><td>Mailbox read (spool)</td><td><code>~2.9 s</code></td><td>via <code>--host</code></td><td>"my pending messages"</td></tr>
+    <tr><td>Mailbox read (spool)</td><td><code>~2.9 s</code></td><td>no fan-out — <code>agents ssh</code></td><td>"my pending messages"</td></tr>
   </tbody>
 </table>
-<p>Two things fall out of the measurement. Every surface is <b>sub-4 s locally</b> and multiplies
-<b>3–7×</b> under fan-out — the tail is the slowest peer, not the local work. And the fan-out is
+<p>Three things fall out of the measurement. Every surface is <b>sub-4 s locally</b> and multiplies
+<b>3–7×</b> under fan-out — the tail is remote work, not the local read. The fan-out is
 <b>partition-safe in practice</b>: on these runs three boxes (<code>bismas-macbook-pro</code>,
 <code>winbox</code>, <code>gpu-box</code>) were unreachable and were <em>skipped</em>, not waited on —
-the live proof of the "dead boxes contribute zero rows, never block the view" claim from §08. The feed
-fan-out's wide spread (13–22 s) is the same story: one slow box sets the ceiling, capped by the 12 s
-per-host timeout.</p>
+the live proof of the "dead boxes contribute zero rows, never block the view" claim from §08. And the
+surfaces differ in what fan-out even means: the <b>mailbox spool has no built-in fan-out</b> — the
+<code>mailboxes</code> command takes no <code>--host</code>, so a peer's box is reached with
+<code>agents ssh</code>, unlike <code>feed</code>/<code>sessions</code>/<code>activity</code> which
+carry <code>-H/--host</code> natively. The per-host SSH timeout is 12 s
+(<code>remote-agents-json.ts:18</code>), but that is a <em>per-host cap</em>, not the total: the feed
+read's wider spread (13–22 s) reflects that it does more per peer than a session query — reading each
+reachable box's block <em>and</em> activity state — so the total is the summed work across all
+reachable peers, not a single capped wait.</p>
 
 <h3>How to make querying faster</h3>
 <ul>

--- a/.agents/reports/memory-and-coordination.html
+++ b/.agents/reports/memory-and-coordination.html
@@ -578,6 +578,26 @@ rest is process startup. The default fan-out then dwarfs everything. So the two 
 <em>avoid the fan-out</em> and <em>amortize the startup</em>.</figcaption>
 </figure>
 
+<h3>Coordination-path latency, measured</h3>
+<p>The same local-vs-fan-out shape holds across every read surface an agent uses to coordinate.
+Median of three runs on this box; the fleet column is the default SSH fan-out across ~11 boxes.</p>
+<table>
+  <thead><tr><th>Surface</th><th>Local</th><th>Fleet fan-out</th><th>What it answers</th></tr></thead>
+  <tbody>
+    <tr><td>Session query (FTS)</td><td><code>0.76 s</code></td><td><code>8.6 s</code></td><td>"find the session about X"</td></tr>
+    <tr><td>Live status <code>--active</code></td><td><code>~3.0 s</code></td><td><code>~10 s</code></td><td>"who is running right now"</td></tr>
+    <tr><td>Feed read</td><td><code>~3.2 s</code></td><td><code>13–22 s</code></td><td>"who needs me / what happened"</td></tr>
+    <tr><td>Mailbox read (spool)</td><td><code>~2.9 s</code></td><td>via <code>--host</code></td><td>"my pending messages"</td></tr>
+  </tbody>
+</table>
+<p>Two things fall out of the measurement. Every surface is <b>sub-4 s locally</b> and multiplies
+<b>3–7×</b> under fan-out — the tail is the slowest peer, not the local work. And the fan-out is
+<b>partition-safe in practice</b>: on these runs three boxes (<code>bismas-macbook-pro</code>,
+<code>winbox</code>, <code>gpu-box</code>) were unreachable and were <em>skipped</em>, not waited on —
+the live proof of the "dead boxes contribute zero rows, never block the view" claim from §08. The feed
+fan-out's wide spread (13–22 s) is the same story: one slow box sets the ceiling, capped by the 12 s
+per-host timeout.</p>
+
 <h3>How to make querying faster</h3>
 <ul>
   <li><b>Scope to the box when you can.</b> <code>--local</code> skips the SSH fan-out entirely — the

--- a/.agents/reports/memory-and-coordination.html
+++ b/.agents/reports/memory-and-coordination.html
@@ -594,15 +594,17 @@ Median of three runs on this box; the fleet column is the default SSH fan-out ac
 <b>3–7×</b> under fan-out — the tail is remote work, not the local read. The fan-out is
 <b>partition-safe in practice</b>: on these runs three boxes (<code>bismas-macbook-pro</code>,
 <code>winbox</code>, <code>gpu-box</code>) were unreachable and were <em>skipped</em>, not waited on —
-the live proof of the "dead boxes contribute zero rows, never block the view" claim from §08. And the
-surfaces differ in what fan-out even means: the <b>mailbox spool has no built-in fan-out</b> — the
-<code>mailboxes</code> command takes no <code>--host</code>, so a peer's box is reached with
+the live proof of §08's point that a dead or slow box contributes zero rows and never blocks the view.
+And the surfaces differ in what fan-out even means: the <b>mailbox spool has no built-in fan-out</b> —
+the <code>mailboxes</code> command takes no <code>--host</code>, so a peer's box is reached with
 <code>agents ssh</code>, unlike <code>feed</code>/<code>sessions</code>/<code>activity</code> which
-carry <code>-H/--host</code> natively. The per-host SSH timeout is 12 s
-(<code>remote-agents-json.ts:18</code>), but that is a <em>per-host cap</em>, not the total: the feed
-read's wider spread (13–22 s) reflects that it does more per peer than a session query — reading each
-reachable box's block <em>and</em> activity state — so the total is the summed work across all
-reachable peers, not a single capped wait.</p>
+carry <code>-H/--host</code> natively. The feed read's wider spread (13–22 s) is <em>not</em> a second
+remote pass: a default <code>agents feed</code> (filter <code>needs</code>,
+<code>feed.ts:328</code>) makes one remote fan-out per peer (<code>feed.ts:592</code>) with a
+<em>local</em> activity lane after it — the same single-fan-out shape as <code>sessions</code>/
+<code>--active</code>. The spread over the same ~3 s local baseline is per-peer variance (larger feed
+payloads plus the local block-merge and ranking), bounded by the 12 s per-host SSH timeout
+(<code>remote-agents-json.ts:18</code>).</p>
 
 <h3>How to make querying faster</h3>
 <ul>


### PR DESCRIPTION
**docs-only.** Closes the one gap the memory-and-coordination synthesis kept flagging: real latency numbers for the *coordination* surfaces, not just the query.

## What lands
A "Coordination-path latency, measured" table in the performance section (§10). Median of 3 runs on yosemite-s1, local vs default fleet fan-out:

| Surface | Local | Fleet |
|---|---|---|
| Session query (FTS) | 0.76 s | 8.6 s |
| Live status `--active` | ~3.0 s | ~10 s |
| Feed read | ~3.2 s | 13–22 s |
| Mailbox read (spool) | ~2.9 s | via --host |

## Findings
- Every surface is sub-4s locally; fan-out multiplies 3–7× (tail = slowest peer).
- Live proof of graceful partition handling: 3 boxes (bismas-macbook-pro, winbox, gpu-box) were unreachable and skipped, not waited on — the "dead boxes never block the view" claim from §08, measured.

Run proof is the numbers themselves (each timed via `/usr/bin/time` over the real `agents sessions`/`agents feed`/`agents mailboxes` commands). Follow-up to #1813 / #1815.