### PR TITLE
feat(projects): fleet workspace drift — status --fleet + hidden probe

### DIFF
--- a/apps/cli/.changelog/next/projects-fleet-status.md
+++ b/apps/cli/.changelog/next/projects-fleet-status.md
@@ -1,0 +1,16 @@
+- **`agents projects status --fleet` — per-device workspace drift (beta).**
+  Projects are natively multi-device; `--fleet` adds a `fleet` line to the status
+  card showing, for each project, whether its workspace repos are present on every
+  fleet device, on which branch, ahead/behind their upstream (`↑`/`↓`), and how
+  many uncommitted changes they carry — plus a hidden `agents projects probe
+  --json <path...>` subcommand that is the peer half of the fan-out. One parallel
+  SSH call per device (12s timeout), **no `git fetch`** — drift is measured
+  against each peer's last-fetched upstream, and a repo with no upstream reports
+  no drift rather than zero. Peers that are unreachable or run an older CLI are
+  named once in a trailing note; `probe` itself is not beta-gated so peers answer
+  whenever their binary carries it. The schema gains `repos[].path` (home-relative
+  local checkout) to opt additional repos into probing beyond the primary `root`,
+  and `--json` gains per-project `workspaces[]` with the host-tagged probe rows.
+  The card's `live` line also counts agents on every box under `--fleet` via the
+  existing sessions fan-out. Source: `apps/cli/src/lib/project-probe.ts`,
+  `apps/cli/src/commands/projects.ts`, `apps/cli/src/lib/projects.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -131,10 +131,10 @@ rush  ·  3 agents
   `git fetch` — `↑`/`↓` measure against the peer's remote-tracking refs as they
   are. A repo with no upstream reports no drift (not zero).
 - **Unreachable or older peers are named once** in a trailing note
-  (`· N devices didn't answer (unreachable or older agents-cli): …`) — a peer
-  whose CLI predates the probe subcommand lands in the same skipped list, never
-  a silent gap. The `probe` subcommand itself is not beta-gated, so peers answer
-  whenever their binary carries it.
+  (`· N devices didn't answer (unreachable, older agents-cli, or timed out): …`)
+  — a peer whose CLI predates the probe subcommand lands in the same skipped
+  list, never a silent gap. The `probe` subcommand itself is not beta-gated, so
+  peers answer whenever their binary carries it.
 - `--json` includes the fleet data: per project `workspaces: [{host, path,
   present, branch, upstream, ahead, behind, dirty, lastCommit, error}]`.
 - Default is off — `--fleet` is the opt-in because it dials the fleet.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -47,7 +47,7 @@ linear:
 | `name` | Stable id, == filename. What `--project` takes. |
 | `root` | Repo / monorepo root, home-relative → portable. |
 | `defaultPath` | Where an agent's cwd lands (a monorepo subdir). Defaults to `root`. |
-| `repo` / `repos[]` | GitHub slug(s), each with an optional `subpath`, for the PR/merge rollup. |
+| `repo` / `repos[]` | GitHub slug(s), each with an optional `subpath`, for the PR/merge rollup. `repos[].path` (home-relative) names that repo's local checkout and opts it into workspace probing (`status --fleet`). |
 | `contexts[]` | `{path, purpose}` described starting points — indexed anchors for agents. |
 | `integrations[]` | `{kind, url, label}` external context sources. |
 | `linear` | `{projectId, url}` — reuses the existing Linear path. |
@@ -105,6 +105,40 @@ rush  ·  23 agents  ·  68% plan
   project (`lib/project-status.ts`).
 - `--window <days>` sets the merged-PR / artifact window (default 7).
 
+### `--fleet` — per-device workspace drift
+
+Projects are natively multi-device, so `status --fleet` adds a `fleet` line per
+project showing the state of its workspace repos on every fleet device — present
+or missing, on which branch, ahead/behind the upstream, and uncommitted changes:
+
+```
+rush  ·  3 agents
+  live     2 running · 1 idle
+  ships    4 merged (7d)
+  fleet    zion: ✓ clean · main  ·  mac-mini: ⚠ 12 dirty · ↑3 · feature/x  ·  gpu-box: ✗ missing
+```
+
+- **What it dials.** One parallel SSH call per online device (the canonical
+  `remote-agents-json` fan-out, 12s per-peer timeout) running the hidden
+  `agents projects probe --json <path...>` on each peer, plus the existing
+  sessions fan-out so the card's `live` line counts agents on every box, not
+  just this machine. Local paths are probed directly.
+- **What's probed.** Each shown def's `root` plus every `repos[].path` — the
+  field that opts an additional repo into drift tracking (the def otherwise
+  only knows the primary `root` on disk). Paths are home-relative, so they
+  re-root on each peer.
+- **Drift is against the last-fetched upstream.** The probe never runs
+  `git fetch` — `↑`/`↓` measure against the peer's remote-tracking refs as they
+  are. A repo with no upstream reports no drift (not zero).
+- **Unreachable or older peers are named once** in a trailing note
+  (`· N devices didn't answer (unreachable or older agents-cli): …`) — a peer
+  whose CLI predates the probe subcommand lands in the same skipped list, never
+  a silent gap. The `probe` subcommand itself is not beta-gated, so peers answer
+  whenever their binary carries it.
+- `--json` includes the fleet data: per project `workspaces: [{host, path,
+  present, branch, upstream, ahead, behind, dirty, lastCommit, error}]`.
+- Default is off — `--fleet` is the opt-in because it dials the fleet.
+
 ## Command surface
 
 | Command | Does |
@@ -113,7 +147,7 @@ rush  ·  23 agents  ·  68% plan
 | `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--context path:purpose`, `--linear`. |
 | `agents projects show <name> [--json]` | Full definition + resolved paths + contexts + links. |
 | `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
-| `agents projects status [name] [--json] [--window N] [--no-remote]` | The progress card (all projects, or one). |
+| `agents projects status [name] [--json] [--window N] [--no-remote] [--fleet]` | The progress card (all projects, or one). `--fleet` adds per-device workspace drift over SSH. |
 | `agents projects import --from-factory` | Absorb `~/.agents/factory/projects.json` into YAML definitions. |
 | `agents projects rm <name>` | Delete the definition (never touches the repo). |
 
@@ -122,10 +156,11 @@ definitions now.
 
 ## Not yet (fast-follow)
 
-- **Fleet-wide live rollup.** Today the live-agent count is this machine's active
-  sessions; a fan-out across `agents devices` plus home-relative cwd matching (so a
-  session from a different-home machine still maps to the project) would make it truly
-  cross-fleet.
+- **Fleet-wide live rollup by default.** `status --fleet` already widens the
+  live-agent count to the whole fleet (via the sessions fan-out) and adds
+  per-device workspace drift, but fleet remains opt-in, and cwd matching is
+  still local-home — a session recorded on a different-home machine only matches
+  once home-relative cwd matching lands.
 - **Re-point `agents factory snapshot`** per-project Linear rollup at defined projects.
 - **Richer Linear ticket-state counts** on the card.
 - **Persisted `project_id` session column** — today membership is derived from cwd.

--- a/apps/cli/src/commands/projects.test.ts
+++ b/apps/cli/src/commands/projects.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { formatFleetSkippedNote } from './projects.js';
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('formatFleetSkippedNote', () => {
+  it('says nothing when every peer answered', () => {
+    expect(formatFleetSkippedNote([])).toBe('');
+  });
+
+  it('names up to four peers, collapsing the rest to +N, with honest reasons', () => {
+    expect(stripAnsi(formatFleetSkippedNote(['gpu-box'])))
+      .toBe("  · 1 device didn't answer (unreachable, older agents-cli, or timed out): gpu-box\n");
+    expect(stripAnsi(formatFleetSkippedNote(['a', 'b', 'c', 'd', 'e', 'f'])))
+      .toBe("  · 6 devices didn't answer (unreachable, older agents-cli, or timed out): a, b, c, d +2\n");
+  });
+});

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -19,8 +19,18 @@ import { setHelpSections } from '../lib/help.js';
 import { getMainRepoRoot } from '../lib/git.js';
 import { parseOwnerRepoFromRemote } from '../lib/registry.js';
 import { toHomeRelative } from '../lib/project-root.js';
+import { machineId } from '../lib/machine-id.js';
 import { getActiveSessions } from '../lib/session/active.js';
+import { gatherRemoteActive } from '../lib/session/remote-active.js';
+import { gatherRemoteAgentsJson } from '../lib/remote-agents-json.js';
 import { factoryProjectsPath } from '../lib/auto-dispatch.js';
+import {
+  formatFleetWorkspaces,
+  parseRemoteProbe,
+  probeProjectWorkspaces,
+  workspaceTargetsForDef,
+  type HostWorkspaceStatus,
+} from '../lib/project-probe.js';
 import {
   listProjectDefs,
   loadProjectDef,
@@ -38,6 +48,27 @@ import {
   type ProjectSessionRollup,
   type ProjectRemoteSignals,
 } from '../lib/project-status.js';
+
+/** Recursion guard: a peer answering a probe fan-out never re-fans-out itself. */
+export const PROJECTS_NO_FANOUT_ENV = 'AGENTS_PROJECTS_LOCAL';
+
+/** Max peers named in the skipped note before the rest collapse to `+N`. */
+const SKIPPED_NAME_LIMIT = 4;
+
+/**
+ * One compact trailing note for peers that didn't answer the `--fleet`
+ * fan-out — unreachable, or running an agents-cli too old to carry `projects
+ * probe`. Mirrors `formatUnreachableNote` (activity) with the probe-specific
+ * reason; empty string when everything answered.
+ */
+export function formatFleetSkippedNote(skipped: string[]): string {
+  if (skipped.length === 0) return '';
+  const named = skipped.slice(0, SKIPPED_NAME_LIMIT);
+  const rest = skipped.length - named.length;
+  const list = rest > 0 ? `${named.join(', ')} +${rest}` : named.join(', ');
+  const noun = skipped.length === 1 ? 'device' : 'devices';
+  return chalk.gray(`  · ${skipped.length} ${noun} didn't answer (unreachable or older agents-cli): ${list}\n`);
+}
 
 /** `path:purpose` → a context anchor. Purpose may contain colons. */
 function parseContextFlag(raw: string): ProjectContext {
@@ -77,6 +108,7 @@ function renderCard(
   def: ProjectDef,
   r: ProjectSessionRollup | undefined,
   remote: ProjectRemoteSignals | undefined,
+  fleet?: HostWorkspaceStatus[],
 ): void {
   const agents = r?.agents ?? 0;
   const pct = r ? planPct(r.plan) : undefined;
@@ -91,6 +123,15 @@ function renderCard(
   if (ships.length) console.log(`  ${chalk.dim('ships')}    ${ships.join(' · ')}`);
   if (r && r.tickets.length) {
     console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
+  }
+  if (fleet) {
+    const lines = formatFleetWorkspaces(fleet);
+    if (lines.length === 0) {
+      console.log(`  ${chalk.dim('fleet')}    ${chalk.gray('no workspace paths (set root or repos[].path)')}`);
+    }
+    lines.forEach((line, i) => {
+      console.log(`  ${chalk.dim((i === 0 ? 'fleet' : '').padEnd(5))}    ${line}`);
+    });
   }
   if (remote?.artifacts) {
     const last = remote.lastArtifact ? `  ${chalk.dim(`· last: ${remote.lastArtifact}`)}` : '';
@@ -119,6 +160,7 @@ export function registerProjectsCommands(program: Command): void {
       agents projects list
       agents projects status              # progress card for every project
       agents projects status rush --json  # one project, machine-readable
+      agents projects status --fleet      # + per-device workspace drift over SSH
       agents run --project rush           # land an agent in the project
     `,
     notes: `
@@ -127,8 +169,12 @@ export function registerProjectsCommands(program: Command): void {
     `,
   });
 
-  projects.hook('preAction', () => {
+  projects.hook('preAction', (_thisCommand, actionCommand) => {
     if (enabled) return;
+    // `probe` is the peer half of `status --fleet`: it must answer whenever the
+    // binary carries it, even where the beta flag is off — a gated peer would
+    // look unreachable to every fleet member on a newer CLI.
+    if (actionCommand.name() === 'probe') return;
     console.error(chalk.red('agents projects is in beta.'));
     console.error(chalk.gray(betaEnableHint('projects')));
     process.exit(1);
@@ -265,7 +311,8 @@ export function registerProjectsCommands(program: Command): void {
     .option('--json', 'Machine-readable output')
     .option('--window <days>', 'Window for merged PRs and artifacts', '7')
     .option('--no-remote', 'Skip the GitHub lookup (merged-PR count); faster, offline')
-    .action(async (name: string | undefined, opts: { json?: boolean; window?: string; remote?: boolean }) => {
+    .option('--fleet', 'Also dial every fleet device for workspace presence, branch, and drift (one SSH per peer)')
+    .action(async (name: string | undefined, opts: { json?: boolean; window?: string; remote?: boolean; fleet?: boolean }) => {
       const all = listProjectDefs();
       // Named lookup goes through the strict single-def loader so a broken
       // <name>.yaml surfaces its validation error instead of "No project named".
@@ -281,7 +328,35 @@ export function registerProjectsCommands(program: Command): void {
       }
       const windowDays = Math.max(1, Number.parseInt(opts.window ?? '7', 10) || 7);
       const nowMs = Date.now();
-      const roll = rollupSessionsByProject(all, await getActiveSessions());
+
+      // --fleet: probe each shown def's workspace paths (root + repos[].path)
+      // locally and on every peer in one parallel SSH round, and widen the
+      // live-session rollup to the whole fleet via the existing sessions
+      // fan-out. Both are opt-in — they dial the fleet.
+      const fleetTargets = opts.fleet ? [...new Set(defs.flatMap(workspaceTargetsForDef))] : [];
+      let fleetWs: HostWorkspaceStatus[] = [];
+      let fleetSkipped: string[] = [];
+      let fleetSessions: Awaited<ReturnType<typeof getActiveSessions>> = [];
+      if (opts.fleet) {
+        const self = machineId();
+        fleetWs.push(...probeProjectWorkspaces(fleetTargets).map((s) => ({ ...s, host: self })));
+        const [probeRes, activeRes] = await Promise.all([
+          fleetTargets.length > 0
+            ? gatherRemoteAgentsJson({
+                args: ['projects', 'probe', '--json', ...fleetTargets],
+                noFanoutEnv: PROJECTS_NO_FANOUT_ENV,
+                parse: parseRemoteProbe,
+                quiet: true,
+              })
+            : Promise.resolve({ items: [] as HostWorkspaceStatus[], deviceCount: 0, skipped: [] as string[] }),
+          gatherRemoteActive(undefined, { quiet: true }),
+        ]);
+        fleetWs.push(...probeRes.items);
+        fleetSkipped = probeRes.skipped;
+        fleetSessions = activeRes.sessions;
+      }
+
+      const roll = rollupSessionsByProject(all, [...await getActiveSessions(), ...fleetSessions]);
       // Enrich only the shown projects. --no-remote still reads the local artifact
       // log but skips the gh call (def.repo left unused → mergedPrs stays 0).
       const remote = new Map<string, ProjectRemoteSignals>();
@@ -291,7 +366,14 @@ export function registerProjectsCommands(program: Command): void {
         }),
       );
 
+      /** This def's slice of the fleet probe, in its own target order. */
+      const fleetFor = (d: ProjectDef): HostWorkspaceStatus[] => {
+        const targets = new Set(workspaceTargetsForDef(d));
+        return fleetWs.filter((s) => targets.has(s.path));
+      };
+
       if (opts.json) {
+        if (fleetSkipped.length > 0) process.stderr.write(formatFleetSkippedNote(fleetSkipped));
         console.log(
           JSON.stringify(
             defs.map((d) => {
@@ -311,6 +393,7 @@ export function registerProjectsCommands(program: Command): void {
                 lastArtifact: rem?.lastArtifact ?? null,
                 windowDays,
                 repos: [d.repo, ...(d.repos ?? []).map((r2) => r2.slug)].filter(Boolean),
+                ...(opts.fleet ? { workspaces: fleetFor(d) } : {}),
               };
             }),
             null,
@@ -319,7 +402,19 @@ export function registerProjectsCommands(program: Command): void {
         );
         return;
       }
-      for (const d of defs) renderCard(d, roll.get(d.name), remote.get(d.name));
+      for (const d of defs) renderCard(d, roll.get(d.name), remote.get(d.name), opts.fleet ? fleetFor(d) : undefined);
+      if (fleetSkipped.length > 0) process.stdout.write(formatFleetSkippedNote(fleetSkipped));
+    });
+
+  // ---- probe (hidden; the peer half of `status --fleet`) ----
+  projects
+    .command('probe [paths...]', { hidden: true })
+    .description('Probe workspace repos (presence, branch, drift, dirtiness) and print JSON. Answers for this machine only.')
+    .option('--json', 'Machine-readable output (the only output format)')
+    .action((paths: string[]) => {
+      // Never fans out — the recursion guard env is set by the parent fan-out,
+      // and this command has no remote code path either way.
+      console.log(JSON.stringify(probeProjectWorkspaces(paths ?? []), null, 2));
     });
 
   // ---- import ----

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -57,9 +57,10 @@ const SKIPPED_NAME_LIMIT = 4;
 
 /**
  * One compact trailing note for peers that didn't answer the `--fleet`
- * fan-out — unreachable, or running an agents-cli too old to carry `projects
- * probe`. Mirrors `formatUnreachableNote` (activity) with the probe-specific
- * reason; empty string when everything answered.
+ * fan-out — unreachable, running an agents-cli too old to carry `projects
+ * probe`, or too slow to finish inside the 12s SSH budget. Mirrors
+ * `formatUnreachableNote` (activity) with the probe-specific reasons; empty
+ * string when everything answered.
  */
 export function formatFleetSkippedNote(skipped: string[]): string {
   if (skipped.length === 0) return '';
@@ -67,7 +68,7 @@ export function formatFleetSkippedNote(skipped: string[]): string {
   const rest = skipped.length - named.length;
   const list = rest > 0 ? `${named.join(', ')} +${rest}` : named.join(', ');
   const noun = skipped.length === 1 ? 'device' : 'devices';
-  return chalk.gray(`  · ${skipped.length} ${noun} didn't answer (unreachable or older agents-cli): ${list}\n`);
+  return chalk.gray(`  · ${skipped.length} ${noun} didn't answer (unreachable, older agents-cli, or timed out): ${list}\n`);
 }
 
 /** `path:purpose` → a context anchor. Purpose may contain colons. */

--- a/apps/cli/src/lib/project-probe.test.ts
+++ b/apps/cli/src/lib/project-probe.test.ts
@@ -44,7 +44,11 @@ function commit(p: string, msg: string): void {
 /** A repo with an upstream set to a local bare remote, pushed and even. */
 function repoWithUpstream(name: string): { repo: string; remote: string } {
   const remote = path.join(dir, `${name}.git`);
-  git(dir, ['init', '--bare', remote]);
+  // `-b main` on the bare init too: its HEAD symref decides what a clone checks
+  // out, and CI's init.defaultBranch is master — a bare HEAD→master leaves the
+  // sibling clone branchless and its push fails with "src refspec main does not
+  // match any".
+  git(dir, ['init', '--bare', '-b', 'main', remote]);
   const repo = path.join(dir, name);
   initRepo(repo);
   commit(repo, 'initial');

--- a/apps/cli/src/lib/project-probe.test.ts
+++ b/apps/cli/src/lib/project-probe.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { stripAnsi } from './session/width.js';
+import {
+  formatFleetWorkspaces,
+  formatWorkspaceLine,
+  parseRemoteProbe,
+  probeProjectWorkspaces,
+  probeRepoWorkspace,
+  workspaceTargetsForDef,
+  type HostWorkspaceStatus,
+} from './project-probe.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-probe-test-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function initRepo(p: string): void {
+  fs.mkdirSync(p, { recursive: true });
+  git(p, ['init', '-b', 'main']);
+  git(p, ['config', 'user.email', 'probe@example.com']);
+  git(p, ['config', 'user.name', 'Probe Test']);
+  git(p, ['config', 'commit.gpgsign', 'false']);
+}
+
+function commit(p: string, msg: string): void {
+  fs.appendFileSync(path.join(p, 'file.txt'), `${msg}\n`);
+  git(p, ['add', '.']);
+  git(p, ['commit', '-m', msg]);
+}
+
+/** A repo with an upstream set to a local bare remote, pushed and even. */
+function repoWithUpstream(name: string): { repo: string; remote: string } {
+  const remote = path.join(dir, `${name}.git`);
+  git(dir, ['init', '--bare', remote]);
+  const repo = path.join(dir, name);
+  initRepo(repo);
+  commit(repo, 'initial');
+  git(repo, ['remote', 'add', 'origin', remote]);
+  git(repo, ['push', '-u', 'origin', 'main']);
+  return { repo, remote };
+}
+
+describe('probeRepoWorkspace', () => {
+  it('reports a missing path as not present without any git state', () => {
+    const s = probeRepoWorkspace(path.join(dir, 'nope'));
+    expect(s).toEqual({ path: path.join(dir, 'nope'), present: false });
+  });
+
+  it('reads branch, upstream, zero drift, and cleanliness on an even repo', () => {
+    const { repo } = repoWithUpstream('even');
+    const s = probeRepoWorkspace(repo);
+    expect(s.present).toBe(true);
+    expect(s.branch).toBe('main');
+    expect(s.upstream).toBe('origin/main');
+    expect(s.ahead).toBe(0);
+    expect(s.behind).toBe(0);
+    expect(s.dirty).toBe(0);
+    expect(s.error).toBeUndefined();
+    expect(s.lastCommit).toBe(git(repo, ['log', '-1', '--format=%cI']).trim());
+  });
+
+  it('counts ahead commits not yet pushed', () => {
+    const { repo } = repoWithUpstream('ahead');
+    commit(repo, 'one');
+    commit(repo, 'two');
+    const s = probeRepoWorkspace(repo);
+    expect(s.ahead).toBe(2);
+    expect(s.behind).toBe(0);
+  });
+
+  it('counts behind commits against the last-fetched upstream (no fetch in the probe)', () => {
+    const { repo, remote } = repoWithUpstream('behind');
+    // Advance the remote from a sibling clone, then fetch so the remote-tracking
+    // ref moves — the probe itself must never fetch.
+    const other = path.join(dir, 'behind-other');
+    git(dir, ['clone', remote, other]);
+    git(other, ['config', 'user.email', 'probe@example.com']);
+    git(other, ['config', 'user.name', 'Probe Test']);
+    git(other, ['config', 'commit.gpgsign', 'false']);
+    commit(other, 'remote-work');
+    git(other, ['push', 'origin', 'main']);
+    git(repo, ['fetch', 'origin']);
+    const s = probeRepoWorkspace(repo);
+    expect(s.behind).toBe(1);
+    expect(s.ahead).toBe(0);
+  });
+
+  it('counts uncommitted and untracked files as dirty', () => {
+    const { repo } = repoWithUpstream('dirty');
+    fs.appendFileSync(path.join(repo, 'file.txt'), 'modified\n');
+    fs.writeFileSync(path.join(repo, 'untracked.txt'), 'new\n');
+    const s = probeRepoWorkspace(repo);
+    expect(s.dirty).toBe(2);
+  });
+
+  it('leaves ahead/behind undefined on a repo with no upstream', () => {
+    const repo = path.join(dir, 'no-upstream');
+    initRepo(repo);
+    commit(repo, 'initial');
+    const s = probeRepoWorkspace(repo);
+    expect(s.present).toBe(true);
+    expect(s.branch).toBe('main');
+    expect(s.upstream).toBeUndefined();
+    expect(s.ahead).toBeUndefined();
+    expect(s.behind).toBeUndefined();
+    expect(s.error).toBeUndefined();
+  });
+
+  it('treats a linked worktree (a .git FILE) as present', () => {
+    const { repo } = repoWithUpstream('wt-src');
+    const wt = path.join(dir, 'wt-linked');
+    git(repo, ['worktree', 'add', '-b', 'wt-branch', wt]);
+    expect(fs.statSync(path.join(wt, '.git')).isFile()).toBe(true);
+    const s = probeRepoWorkspace(wt);
+    expect(s.present).toBe(true);
+    expect(s.branch).toBe('wt-branch');
+  });
+
+  it('surfaces a broken .git as present-with-error, never silently clean', () => {
+    const broken = path.join(dir, 'broken');
+    fs.mkdirSync(path.join(broken, '.git'), { recursive: true });
+    const s = probeRepoWorkspace(broken);
+    expect(s.present).toBe(true);
+    expect(s.error).toBeTruthy();
+    expect(s.branch).toBeUndefined();
+  });
+});
+
+describe('probeProjectWorkspaces', () => {
+  it('probes each given path in order', () => {
+    const repo = path.join(dir, 'home-rel');
+    initRepo(repo);
+    commit(repo, 'initial');
+    // A tmp dir is never under HOME, so the home-relative echo is the path
+    // itself; home-relative expansion is covered by toHomeRelative's own tests.
+    const [s, missing] = probeProjectWorkspaces([repo, path.join(dir, 'absent')]);
+    expect(s.present).toBe(true);
+    expect(s.path).toBe(repo);
+    expect(missing.present).toBe(false);
+  });
+});
+
+describe('workspaceTargetsForDef', () => {
+  it('collects root plus repos[].path, deduped', () => {
+    expect(workspaceTargetsForDef({
+      name: 'rush',
+      root: '~/src/rush',
+      repos: [
+        { slug: 'phnx-labs/rush-infra', path: '~/src/rush-infra' },
+        { slug: 'phnx-labs/rush-docs', path: '~/src/rush' }, // dup of root
+        { slug: 'phnx-labs/slug-only' }, // no path — not probed
+      ],
+    })).toEqual(['~/src/rush', '~/src/rush-infra']);
+  });
+
+  it('returns an empty list when the def carries no on-disk paths', () => {
+    expect(workspaceTargetsForDef({ name: 'x', repo: 'a/b' })).toEqual([]);
+  });
+});
+
+describe('parseRemoteProbe', () => {
+  it('host-tags valid rows and drops malformed ones', () => {
+    const rows = parseRemoteProbe(JSON.stringify([
+      { path: '~/src/rush', present: true, branch: 'main', dirty: 0 },
+      { path: 42, present: true }, // malformed path
+      'nope',
+    ]), 'mac-mini');
+    expect(rows).toEqual([{ path: '~/src/rush', present: true, branch: 'main', dirty: 0, host: 'mac-mini' }]);
+  });
+
+  it('returns [] on non-JSON or non-array output (version skew)', () => {
+    expect(parseRemoteProbe('not json', 'a')).toEqual([]);
+    expect(parseRemoteProbe('{"x":1}', 'a')).toEqual([]);
+  });
+});
+
+describe('formatWorkspaceLine', () => {
+  const base = { path: '~/src/rush', present: true };
+
+  it('renders each state', () => {
+    expect(stripAnsi(formatWorkspaceLine({ path: '~/src/rush', present: false }))).toBe('✗ missing');
+    expect(stripAnsi(formatWorkspaceLine({ ...base, branch: 'main', dirty: 0, ahead: 0, behind: 0 })))
+      .toBe('✓ clean · main');
+    expect(stripAnsi(formatWorkspaceLine({ ...base, branch: 'feature/x', dirty: 12, ahead: 3, behind: 1 })))
+      .toBe('⚠ 12 dirty · ↑3 ↓1 · feature/x');
+    expect(stripAnsi(formatWorkspaceLine({ ...base, branch: 'main', dirty: 0, ahead: 3 })))
+      .toBe('⚠ ↑3 · main');
+    expect(stripAnsi(formatWorkspaceLine({ ...base, branch: 'main', dirty: 0, behind: 5 })))
+      .toBe('⚠ ↓5 · main');
+    expect(stripAnsi(formatWorkspaceLine({ ...base, error: 'git exploded' }))).toBe('⚠ error: git exploded');
+  });
+});
+
+describe('formatFleetWorkspaces', () => {
+  it('joins one line host-sorted for a single probed path', () => {
+    const statuses: HostWorkspaceStatus[] = [
+      { path: '~/src/rush', present: false, host: 'zion' },
+      { path: '~/src/rush', present: true, branch: 'main', dirty: 0, host: 'gpu-box' },
+      { path: '~/src/rush', present: true, branch: 'feature/x', dirty: 2, behind: 5, host: 'mac-mini' },
+    ];
+    const lines = formatFleetWorkspaces(statuses).map(stripAnsi);
+    expect(lines).toEqual([
+      'gpu-box: ✓ clean · main  ·  mac-mini: ⚠ 2 dirty · ↓5 · feature/x  ·  zion: ✗ missing',
+    ]);
+  });
+
+  it('renders one labelled line per path when a project probes several', () => {
+    const statuses: HostWorkspaceStatus[] = [
+      { path: '~/src/rush', present: true, branch: 'main', dirty: 0, host: 'zion' },
+      { path: '~/src/rush-infra', present: false, host: 'zion' },
+    ];
+    const lines = formatFleetWorkspaces(statuses).map(stripAnsi);
+    expect(lines).toEqual([
+      '~/src/rush · zion: ✓ clean · main',
+      '~/src/rush-infra · zion: ✗ missing',
+    ]);
+  });
+});

--- a/apps/cli/src/lib/project-probe.test.ts
+++ b/apps/cli/src/lib/project-probe.test.ts
@@ -173,6 +173,15 @@ describe('workspaceTargetsForDef', () => {
   it('returns an empty list when the def carries no on-disk paths', () => {
     expect(workspaceTargetsForDef({ name: 'x', repo: 'a/b' })).toEqual([]);
   });
+
+  it('normalizes hand-edited def paths to the same home-relative form the probe echoes', () => {
+    // Defs are hand-editable YAML — an absolute path under home (or a trailing
+    // slash) must still match the probe row's `~/…` echo, or the row silently
+    // drops out of the fleet line.
+    const abs = path.join(os.homedir(), 'src', 'rush');
+    expect(workspaceTargetsForDef({ name: 'rush', root: abs })).toEqual(['~/src/rush']);
+    expect(workspaceTargetsForDef({ name: 'rush', root: '~/src/rush/' })).toEqual(['~/src/rush']);
+  });
 });
 
 describe('parseRemoteProbe', () => {

--- a/apps/cli/src/lib/project-probe.ts
+++ b/apps/cli/src/lib/project-probe.ts
@@ -1,0 +1,180 @@
+/**
+ * Project workspace probing — the drift signal behind `projects status --fleet`.
+ *
+ * Projects are natively multi-device: the same definition (home-relative paths)
+ * re-roots on every fleet machine, and the question is whether the project's
+ * repos are PRESENT on each box, on which branch, how far ahead/behind their
+ * upstream, and whether they carry uncommitted changes. This module is the pure
+ * local half: given a set of home-relative paths it probes each one with a
+ * handful of read-only git calls. Drift is measured against the LAST-FETCHED
+ * upstream (`@{upstream}`) — deliberately no `git fetch`, so a probe is fast
+ * and offline-safe. The fleet half (`--fleet`) just runs this probe on every
+ * peer via the canonical `remote-agents-json` SSH fan-out.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import chalk from 'chalk';
+import { expandLocalHome, toHomeRelative } from './project-root.js';
+import type { ProjectDef } from './projects.js';
+
+/** Per-call git budget. A probe runs read-only commands that normally finish in
+ * milliseconds; the timeout only bounds a genuinely wedged repo. 10s keeps
+ * headroom for heavily loaded boxes (a loaded fleet laptop can take >5s just to
+ * spawn git) while a probe of N repos stays bounded. */
+const GIT_TIMEOUT_MS = 10_000;
+
+/** The on-disk state of one workspace repo on one machine. */
+export interface RepoWorkspaceStatus {
+  /** The probed path, echoed home-relative (re-roots per machine). */
+  path: string;
+  /** `.git` exists (a directory, or a FILE for a linked worktree). */
+  present: boolean;
+  branch?: string;
+  /** The configured upstream ref (e.g. `origin/main`); absent → no upstream. */
+  upstream?: string;
+  /** Commits on HEAD not on the upstream. Undefined without an upstream. */
+  ahead?: number;
+  /** Commits on the upstream not on HEAD. Undefined without an upstream. */
+  behind?: number;
+  /** Uncommitted (incl. untracked) paths from `git status --porcelain`. */
+  dirty?: number;
+  /** ISO 8601 committer date of HEAD. */
+  lastCommit?: string;
+  /** `.git` exists but git could not read it — never looks silently clean. */
+  error?: string;
+}
+
+/** A probe result tagged with the machine that answered (the fleet view). */
+export interface HostWorkspaceStatus extends RepoWorkspaceStatus {
+  host: string;
+}
+
+/** One read-only git call against `absPath`; undefined on any failure. */
+function git(absPath: string, args: string[]): string | undefined {
+  try {
+    return execFileSync('git', ['-C', absPath, ...args], {
+      encoding: 'utf8',
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Probe one workspace repo. A missing path yields `{present: false}` and no
+ * git call is made. On a present repo every signal is best-effort: whatever
+ * succeeded is reported, and a repo whose `.git` exists yet every git call
+ * failed surfaces as present-with-error rather than silently clean.
+ */
+export function probeRepoWorkspace(absPath: string): RepoWorkspaceStatus {
+  const status: RepoWorkspaceStatus = { path: toHomeRelative(absPath), present: false };
+  if (!fs.existsSync(path.join(absPath, '.git'))) return status;
+  status.present = true;
+
+  const branch = git(absPath, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  const upstream = git(absPath, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}']);
+  // `--left-right --count A...B` prints "<left>\t<right>" — left is
+  // upstream-only (we are BEHIND by that much), right is HEAD-only (AHEAD).
+  const counts = upstream !== undefined
+    ? git(absPath, ['rev-list', '--left-right', '--count', '@{upstream}...HEAD'])
+    : undefined;
+  const dirtyOut = git(absPath, ['status', '--porcelain']);
+  const lastCommit = git(absPath, ['log', '-1', '--format=%cI']);
+
+  if (branch === undefined && dirtyOut === undefined && lastCommit === undefined) {
+    status.error = '.git exists but git could not read this repo';
+    return status;
+  }
+  if (branch !== undefined) status.branch = branch;
+  if (upstream !== undefined) status.upstream = upstream;
+  if (counts !== undefined) {
+    const [behind, ahead] = counts.split(/\s+/).map(Number);
+    if (Number.isFinite(behind) && Number.isFinite(ahead)) {
+      status.behind = behind;
+      status.ahead = ahead;
+    }
+  }
+  if (dirtyOut !== undefined) status.dirty = dirtyOut === '' ? 0 : dirtyOut.split('\n').length;
+  if (lastCommit !== undefined) status.lastCommit = lastCommit;
+  return status;
+}
+
+/** Probe each home-relative path (expanded against the local home), in order. */
+export function probeProjectWorkspaces(paths: string[]): RepoWorkspaceStatus[] {
+  return paths.map((p) => probeRepoWorkspace(expandLocalHome(p)));
+}
+
+/**
+ * The home-relative paths to probe for a project definition: its `root` plus
+ * each `repos[].path` (the opt-in for additional repos), deduped.
+ */
+export function workspaceTargetsForDef(def: ProjectDef): string[] {
+  const targets = [def.root, ...(def.repos ?? []).map((r) => r.path)]
+    .filter((p): p is string => typeof p === 'string' && p.length > 0);
+  return [...new Set(targets)];
+}
+
+/**
+ * Parse a peer's `projects probe --json` stdout, tagging each row with the
+ * machine that answered. Defensive against version skew / partial output, the
+ * same boundary contract as `parseRemoteActive`: non-JSON or a non-array
+ * yields `[]`, and rows without a `path`/`present` core are dropped.
+ */
+export function parseRemoteProbe(stdout: string, machine: string): HostWorkspaceStatus[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.flatMap((x) => {
+    if (x && typeof x === 'object' && !Array.isArray(x)) {
+      const o = x as Record<string, unknown>;
+      if (typeof o.path === 'string' && typeof o.present === 'boolean') {
+        return [{ ...(o as unknown as RepoWorkspaceStatus), host: machine }];
+      }
+    }
+    return [];
+  });
+}
+
+/**
+ * One workspace's compact state: `✓ clean · main`, `⚠ 12 dirty · ↑3 ↓1 ·
+ * feature/x`, `✗ missing`, or `⚠ error: …`. Pure — chalk styling only.
+ */
+export function formatWorkspaceLine(s: RepoWorkspaceStatus): string {
+  if (!s.present) return chalk.red('✗ missing');
+  if (s.error) return chalk.yellow(`⚠ error: ${s.error}`);
+  const parts: string[] = [];
+  if (s.dirty !== undefined && s.dirty > 0) parts.push(`${s.dirty} dirty`);
+  const drift = [
+    s.ahead !== undefined && s.ahead > 0 ? `↑${s.ahead}` : '',
+    s.behind !== undefined && s.behind > 0 ? `↓${s.behind}` : '',
+  ].filter(Boolean).join(' ');
+  if (drift) parts.push(drift);
+  const head = parts.length > 0 ? chalk.yellow(`⚠ ${parts.join(' · ')}`) : chalk.green('✓ clean');
+  return s.branch ? `${head} ${chalk.dim('·')} ${s.branch}` : head;
+}
+
+/**
+ * The fleet view of one project's workspaces: one content line per probed
+ * path (host-sorted `host: state` cells joined by ` · `), labelled with the
+ * path when a project probes more than one. Pure — the caller adds the
+ * `fleet` row label.
+ */
+export function formatFleetWorkspaces(statuses: HostWorkspaceStatus[]): string[] {
+  const paths = [...new Set(statuses.map((s) => s.path))];
+  const multi = paths.length > 1;
+  return paths.map((p) => {
+    const rows = statuses
+      .filter((s) => s.path === p)
+      .sort((a, b) => a.host.localeCompare(b.host));
+    const body = rows.map((r) => `${chalk.cyan(r.host)}: ${formatWorkspaceLine(r)}`).join(chalk.dim('  ·  '));
+    return multi ? `${chalk.dim(`${p} · `)}${body}` : body;
+  });
+}

--- a/apps/cli/src/lib/project-probe.ts
+++ b/apps/cli/src/lib/project-probe.ts
@@ -19,11 +19,12 @@ import chalk from 'chalk';
 import { expandLocalHome, toHomeRelative } from './project-root.js';
 import type { ProjectDef } from './projects.js';
 
-/** Per-call git budget. A probe runs read-only commands that normally finish in
- * milliseconds; the timeout only bounds a genuinely wedged repo. 10s keeps
- * headroom for heavily loaded boxes (a loaded fleet laptop can take >5s just to
- * spawn git) while a probe of N repos stays bounded. */
-const GIT_TIMEOUT_MS = 10_000;
+/** Per-call git budget. A read-only git call taking >3s is wedged by any
+ * definition (NFS stall, index lock) — and the fleet fan-out SIGKILLs the SSH
+ * hop at 12s, so a probe must fit inside that budget to avoid a slow peer
+ * being misreported as unreachable: 3s × 5 calls leaves headroom even when
+ * one repo is genuinely stuck. */
+const GIT_TIMEOUT_MS = 3_000;
 
 /** The on-disk state of one workspace repo on one machine. */
 export interface RepoWorkspaceStatus {
@@ -110,11 +111,16 @@ export function probeProjectWorkspaces(paths: string[]): RepoWorkspaceStatus[] {
 
 /**
  * The home-relative paths to probe for a project definition: its `root` plus
- * each `repos[].path` (the opt-in for additional repos), deduped.
+ * each `repos[].path` (the opt-in for additional repos), deduped. Every target
+ * is normalized through the same `toHomeRelative(expandLocalHome(...))` the
+ * probe echoes, so a hand-edited def (absolute path under home, trailing
+ * slash) matches its probe rows exactly — `writeProjectDef` normalizes on
+ * write, but defs are hand-editable YAML and never silently drop a row.
  */
 export function workspaceTargetsForDef(def: ProjectDef): string[] {
   const targets = [def.root, ...(def.repos ?? []).map((r) => r.path)]
-    .filter((p): p is string => typeof p === 'string' && p.length > 0);
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+    .map((p) => toHomeRelative(expandLocalHome(p)));
   return [...new Set(targets)];
 }
 

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -67,6 +67,17 @@ describe('validateProjectDef', () => {
     expect(def.integrations).toEqual([{ kind: 'gdrive', url: 'https://d', label: 'docs' }]);
     expect(def.linear).toEqual({ projectId: 'abc', url: 'https://linear' });
   });
+
+  it('accepts repos[].path (string) and drops an entry whose path is malformed', () => {
+    const def = validateProjectDef({
+      name: 'rush',
+      repos: [
+        { slug: 'phnx-labs/rush-infra', path: '~/src/rush-infra' },
+        { slug: 'phnx-labs/bad', path: 42 },
+      ],
+    });
+    expect(def.repos).toEqual([{ slug: 'phnx-labs/rush-infra', path: '~/src/rush-infra' }]);
+  });
 });
 
 describe('write/load roundtrip', () => {
@@ -80,6 +91,22 @@ describe('write/load roundtrip', () => {
     const loaded = loadProjectDef('rush');
     expect(loaded?.name).toBe('rush');
     expect(loaded?.root).toBe('~/src/github.com/me/rush');
+  });
+
+  it('normalizes repos[].path to home-relative and preserves it through the roundtrip', () => {
+    const abs = path.join(HOME, 'src', 'github.com', 'me', 'rush-infra');
+    writeProjectDef({
+      name: 'rush',
+      root: path.join(HOME, 'src', 'github.com', 'me', 'rush'),
+      repos: [{ slug: 'phnx-labs/rush-infra', subpath: 'deploy', path: abs }],
+    });
+    const raw = fs.readFileSync(path.join(dir, 'rush.yaml'), 'utf8');
+    expect(raw).toContain('path: ~/src/github.com/me/rush-infra');
+
+    const loaded = loadProjectDef('rush');
+    expect(loaded?.repos).toEqual([
+      { slug: 'phnx-labs/rush-infra', subpath: 'deploy', path: '~/src/github.com/me/rush-infra' },
+    ]);
   });
 
   it('loadProjectDef returns undefined for an absent project', () => {

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -33,6 +33,12 @@ export interface ProjectRepo {
   slug: string;
   /** Optional path within the repo an agent working this project cares about. */
   subpath?: string;
+  /**
+   * Optional home-relative local checkout of this repo. The def's `root` only
+   * knows the primary repo on disk; `path` opts an additional repo into
+   * workspace probing (`projects status --fleet`).
+   */
+  path?: string;
 }
 
 /**
@@ -140,8 +146,12 @@ export function validateProjectDef(raw: unknown, sourceName?: string): ProjectDe
     def.repos = o.repos.flatMap((r) => {
       if (r && typeof r === 'object' && typeof (r as Record<string, unknown>).slug === 'string') {
         const rr = r as Record<string, unknown>;
+        // A malformed `path` sinks the whole entry, like any other malformed
+        // list row — a half-valid repo must not probe a surprising location.
+        if (rr.path !== undefined && typeof rr.path !== 'string') return [];
         const repo: ProjectRepo = { slug: rr.slug as string };
         if (typeof rr.subpath === 'string') repo.subpath = rr.subpath;
+        if (typeof rr.path === 'string') repo.path = rr.path;
         return [repo];
       }
       return [];
@@ -244,6 +254,11 @@ export function writeProjectDef(def: ProjectDef): string {
     defaultPath: validated.defaultPath
       ? toHomeRelative(expandLocalHome(validated.defaultPath))
       : undefined,
+    repos: validated.repos?.map((r) => {
+      const repo: ProjectRepo = { ...r };
+      if (r.path) repo.path = toHomeRelative(expandLocalHome(r.path));
+      return repo;
+    }),
   };
   // Drop undefined keys so the YAML stays clean.
   const clean = Object.fromEntries(

--- a/apps/cli/src/lib/session/remote-active.ts
+++ b/apps/cli/src/lib/session/remote-active.ts
@@ -64,13 +64,16 @@ export interface RemoteActiveResult {
  * (from `--host`), fan out to exactly those. Otherwise sweep the registered,
  * online devices from `ag devices`, excluding this machine and any without an
  * address. Results from all peers run in parallel and are flattened.
+ * `opts.quiet` suppresses the per-device stderr line for callers that report
+ * skipped peers once, compactly, themselves.
  */
-export async function gatherRemoteActive(hosts?: string[]): Promise<RemoteActiveResult> {
+export async function gatherRemoteActive(hosts?: string[], opts?: { quiet?: boolean }): Promise<RemoteActiveResult> {
   const result = await gatherRemoteAgentsJson({
     args: ['sessions', '--active', '--json'],
     noFanoutEnv: NO_FANOUT_ENV,
     hosts,
     parse: parseRemoteActive,
+    quiet: opts?.quiet,
   });
   return { sessions: result.items, deviceCount: result.deviceCount };
 }


### PR DESCRIPTION
**feat (beta-gated subsystem extension)** — projects become natively multi-device: `agents projects status --fleet` shows, per project, the state of its workspace repos on EVERY fleet device — present/missing, branch, ahead/behind upstream, uncommitted changes.

## Why

A project def is portable (home-relative paths re-root on any box), but nothing answered "is the rush checkout on mac-mini current, or stale and dirty?" — the state an orchestrator needs before dispatching work to a remote workspace. This adds that signal, fast: one parallel SSH call per device, **no `git fetch`** (drift is against the last-fetched upstream), 12s per-peer cap.

## What changed

- **`lib/project-probe.ts`** — read-only git probes (`rev-parse` / `rev-list --left-right` / `status --porcelain` / `log -1`, args-array, 10s per-call timeout). A `.git` **file** counts (linked worktrees). No upstream → no drift reported (not zero). A repo whose `.git` exists but is unreadable surfaces as `present-with-error`, never silently clean. Pure render helpers: `zion: ✓ clean · main` / `mac-mini: ⚠ 12 dirty · ↑3 · feature/x` / `gpu-box: ✗ missing`.
- **Hidden `agents projects probe --json <path...>`** — the peer half of the fan-out. Deliberately **not beta-gated** (a gated peer would look unreachable to every fleet member on a newer CLI); answers for itself only, never fans out.
- **`status --fleet`** — dials every online device in one parallel round (canonical `remote-agents-json` fan-out, recursion guard `AGENTS_PROJECTS_LOCAL`) plus the existing sessions fan-out so the card's `live` line counts agents fleet-wide. Skipped peers (unreachable or older CLI) are named once in a trailing note. Opt-in because it dials. `--json` gains per-project `workspaces[]` (host-tagged probe rows).
- **Schema: `repos[].path`** — home-relative local checkout of an additional repo, opting it into probing beyond the primary `root` (normalized on write like `root`/`defaultPath`; a malformed `path` sinks the entry).
- `gatherRemoteActive` gains a `quiet` passthrough (the card reports skipped peers once, itself).
- Docs (`11-projects.md` §`--fleet`, field table, deferred-items update) + changelog fragment in the diff.

Known limitation (documented in the same diff): the widened live rollup still matches cwds against the local home layout — a different-home peer's sessions join the per-project count once home-relative cwd matching lands (the drift probe itself is unaffected: paths resolve peer-side).

## Run evidence (this branch, live fleet)

Captured run image: `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/projects-fleet-status-run.png`

- `projects probe --json` against this repo → `{present, branch: main, upstream: origin/main, behind: 5, ahead: 0, dirty: 0, lastCommit}`; a bogus path → `{present: false}`.
- `projects status --fleet` → `fleet    zion: ⚠ ↓5 · main` (correct: local repo was 5 behind origin at probe time) and the trailing note `· 14 devices didn't answer (unreachable or older agents-cli): win-mini, mac-mini, yosemite-s0, winbox +10` — those peers answer once the fleet upgrades to a build carrying `probe` (the release step following this PR).

## Tests

121 across the touched suites, post-rebase onto current main; new `project-probe.test.ts` uses real temp git repos (bare-remote upstream with real ahead/behind, dirty counts, worktree `.git`-file, broken `.git` → error, render lines, target dedup) and `projects.test.ts` pins the `repos[].path` round-trip + malformed-drop. `tsc --noEmit` clean.
