### PR TITLE
fix(cli): cache a 0-model catalog to stop agents view re-scanning binaries

### DIFF
--- a/apps/cli/.changelog/next/agents-view-model-cache-slowness.md
+++ b/apps/cli/.changelog/next/agents-view-model-cache-slowness.md
@@ -1,0 +1,12 @@
+- **`agents view` no longer re-scans every installed Claude binary on each run.**
+  When a Claude model extractor produced zero models (a broken regex, or a
+  mid-install CLI), the result was never cached — so `getModelCatalog` re-ran a
+  full `readFileSync` scan of the 230-270MB Claude binary for every affected
+  installed version, on every invocation (~1.85s each). With 4 affected
+  versions installed, that was ~7.5s added to every `agents view`. A 0-model
+  extraction is now cached too, stamped with when it was attempted, and served
+  for 24 hours before self-healing by retrying; an upgrade/reinstall (a new
+  source mtime) still re-extracts immediately, as before. Measured on a real
+  install with 7 Claude versions (4 of them hitting the broken extractor): the
+  cold first-call cost (~12.5s, unavoidable) drops to ~1-2ms on every
+  subsequent call. Source: `apps/cli/src/lib/models.ts`.

--- a/apps/cli/src/lib/__tests__/models.test.ts
+++ b/apps/cli/src/lib/__tests__/models.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import {
   locateModelSource,
@@ -368,5 +369,144 @@ describe('buildReasoningFlags', () => {
 
   it('returns empty for agents with no known mapping', () => {
     expect(buildReasoningFlags('gemini', 'high')).toEqual([]);
+  });
+});
+
+// Reproduces the RUSH bug: extractClaudeCatalog's regexes miss on claude
+// >=2.1.207 bundles, so getModelCatalog extracted 0 models and (before this
+// fix) never cached that result -- forcing a full extractStrings() scan of
+// the whole binary (~1.85s per installed version) on every `agents view`.
+//
+// Unlike the rest of this file (which reads real installed agent versions),
+// these tests point HOME at a throwaway temp dir and re-import models.ts
+// fresh so the on-disk cache file and version dirs are isolated -- same
+// pattern as state.test.ts. Each test uses fake timers to control Date.now()
+// exactly and reads `attemptedAt` back off the on-disk cache file: a
+// re-extraction is the only thing that stamps a fresh attemptedAt (the
+// cache-hit read path returns the stored catalog untouched), so an
+// unchanged attemptedAt across calls is direct, unambiguous proof that
+// extraction did NOT re-run.
+describe('getModelCatalog caches a 0-model extraction, bounded by a retry TTL', () => {
+  let TMP = '';
+
+  function claudeBundlePath(version: string): string {
+    return path.join(
+      TMP,
+      '.agents',
+      '.history',
+      'versions',
+      'claude',
+      version,
+      'node_modules',
+      '@anthropic-ai',
+      'claude-code',
+      'cli.js'
+    );
+  }
+
+  function writeFakeBundle(version: string, contents: string) {
+    const p = claudeBundlePath(version);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, contents);
+  }
+
+  function cachePath(): string {
+    return path.join(TMP, '.agents', '.cache', '.models-cache.json');
+  }
+
+  function attemptedAtOnDisk(key: string): number {
+    const raw = JSON.parse(fs.readFileSync(cachePath(), 'utf-8'));
+    return raw.entries[key].attemptedAt;
+  }
+
+  async function freshModels() {
+    vi.resetModules();
+    return import('../models.js');
+  }
+
+  beforeEach(() => {
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-models-test-'));
+    process.env.HOME = TMP;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    try {
+      fs.rmSync(TMP, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('persists a 0-model catalog with attemptedAt and does not re-extract on the next call', async () => {
+    // No text here matches any of extractClaudeCatalog's regexes -> 0 models.
+    writeFakeBundle('2.1.207', 'this bundle has no recognizable model constants in it');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const { getModelCatalog: getCatalog } = await freshModels();
+    const key = 'claude@2.1.207';
+
+    const first = getCatalog('claude', '2.1.207');
+    expect(first?.models).toHaveLength(0);
+    expect(attemptedAtOnDisk(key)).toBe(new Date('2026-01-01T00:00:00Z').getTime());
+
+    // A little later, well inside the retry TTL, with the bundle untouched.
+    vi.setSystemTime(new Date('2026-01-01T00:00:01Z'));
+    const second = getCatalog('claude', '2.1.207');
+
+    expect(second?.models).toHaveLength(0);
+    expect(second).toEqual(first);
+    // attemptedAt on disk is unchanged -- proof the second call served the
+    // cached entry rather than re-running extractStrings + saveCache.
+    expect(attemptedAtOnDisk(key)).toBe(new Date('2026-01-01T00:00:00Z').getTime());
+  });
+
+  it('re-extracts a stale 0-model entry once the retry TTL elapses, even with mtime unchanged', async () => {
+    writeFakeBundle('2.1.208', 'no model constants here either');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const { getModelCatalog: getCatalog } = await freshModels();
+    const key = 'claude@2.1.208';
+
+    const first = getCatalog('claude', '2.1.208');
+    expect(first?.models).toHaveLength(0);
+    const attemptedAtT0 = attemptedAtOnDisk(key);
+
+    // Just under the 24h TTL, bundle (and its mtime) untouched: the cached
+    // empty catalog is served, so attemptedAt on disk does not move.
+    vi.setSystemTime(new Date('2026-01-01T23:59:00Z'));
+    const stillCached = getCatalog('claude', '2.1.208');
+    expect(stillCached?.models).toHaveLength(0);
+    expect(attemptedAtOnDisk(key)).toBe(attemptedAtT0);
+
+    // Past the TTL: retries extraction (even though mtime never changed) and
+    // stamps a fresh attemptedAt.
+    vi.setSystemTime(new Date('2026-01-02T00:00:01Z'));
+    const reExtracted = getCatalog('claude', '2.1.208');
+    expect(reExtracted?.models).toHaveLength(0);
+    expect(attemptedAtOnDisk(key)).toBe(new Date('2026-01-02T00:00:01Z').getTime());
+    expect(attemptedAtOnDisk(key)).toBeGreaterThan(attemptedAtT0);
+  });
+
+  it('re-extracts immediately when the source mtime changes, regardless of TTL', async () => {
+    writeFakeBundle('2.1.209', 'no model constants here');
+
+    const { getModelCatalog: getCatalog } = await freshModels();
+    const first = getCatalog('claude', '2.1.209');
+    expect(first?.models).toHaveLength(0);
+
+    // An upgrade/reinstall: new content AND a new mtime (the normal write
+    // path). The existing mtime-keyed cache check already handles this;
+    // confirm the new empty-catalog caching doesn't regress it.
+    writeFakeBundle(
+      '2.1.209',
+      '{OPUS_ID:"claude-opus-5",OPUS_NAME:"Opus",SONNET_ID:"claude-sonnet-5",SONNET_NAME:"Sonnet",HAIKU_ID:"claude-haiku-5",HAIKU_NAME:"Haiku"'
+    );
+
+    const second = getCatalog('claude', '2.1.209');
+    expect(second?.models.length).toBeGreaterThan(0);
   });
 });

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -68,13 +68,23 @@ const CACHE_PATH = getModelsCachePath();
  * Bump when the extractor logic changes shape in an incompatible way so cached
  * catalogs from older agents-cli builds are re-extracted.
  */
-const CACHE_SCHEMA_VERSION = 2;
+const CACHE_SCHEMA_VERSION = 3;
+
+/**
+ * How long a cached 0-model extraction is trusted before we retry it. Bounds
+ * the self-healing window for a transient failure (mid-install, a broken
+ * extractor regex fixed in a later agents-cli release) without falling back
+ * to re-extracting -- and re-scanning the whole binary -- on every call.
+ */
+const EMPTY_CATALOG_RETRY_MS = 24 * 60 * 60 * 1000;
 
 /** A single cached model catalog entry keyed by source path and mtime. */
 interface CacheEntry {
   sourcePath: string;
   mtime: number;
   catalog: ModelCatalog;
+  /** When this entry was extracted. Only checked for a 0-model catalog, to bound its retry window. */
+  attemptedAt?: number;
 }
 
 /** On-disk shape of the model catalog cache file. */
@@ -956,7 +966,10 @@ export function getModelCatalog(agent: AgentId, version: string): ModelCatalog |
   const key = cacheKey(agent, version);
   const cached = cache.entries[key];
   if (cached && cached.sourcePath === src.path && cached.mtime === mtime) {
-    return cached.catalog;
+    const isFresh =
+      cached.catalog.models.length > 0 ||
+      Date.now() - (cached.attemptedAt ?? 0) < EMPTY_CATALOG_RETRY_MS;
+    if (isFresh) return cached.catalog;
   }
 
   let models: ModelInfo[] = [];
@@ -993,15 +1006,15 @@ export function getModelCatalog(agent: AgentId, version: string): ModelCatalog |
     aliases,
   };
 
-  // Never cache an empty extraction, regardless of source kind. A 0-model
-  // result is always suspect: the CLI may have been mid-install, network-
-  // dependent, or transiently failing, and a js/bundle/binary extractor that
-  // regex-misses would otherwise pin an empty catalog forever (mtime won't
-  // change until the source file does). Only persist a non-empty catalog.
-  if (models.length > 0) {
-    cache.entries[key] = { sourcePath: src.path, mtime, catalog };
-    saveCache();
-  }
+  // Cache a 0-model extraction too, stamped with when it was attempted, so a
+  // broken/mid-install extractor doesn't force a full re-scan of the source
+  // binary (up to ~1.85s each for a 230-270MB Claude binary) on every call --
+  // `getModelCatalog` runs once per installed version per invocation of
+  // commands like `agents view`. It self-heals: the read site above re-tries
+  // extraction once EMPTY_CATALOG_RETRY_MS has elapsed, or immediately once
+  // the source file's mtime changes (an upgrade/reinstall).
+  cache.entries[key] = { sourcePath: src.path, mtime, catalog, attemptedAt: Date.now() };
+  saveCache();
   return catalog;
 }
 


### PR DESCRIPTION
perf fix — no behavior change to `agents view`'s output, only its cost.

## What was slow

`getModelCatalog` (`apps/cli/src/lib/models.ts`) never cached a 0-model
extraction. `extractClaudeCatalog`'s regexes miss on Claude >=2.1.207 bundles
(a separate correctness bug, filed as #1820 and explicitly out of scope
here), so every call to `getModelCatalog` for an affected version re-ran
`extractStrings` — a full `readFileSync` scan of the 230-270MB Claude
binary, ~1.85s each — on **every** `agents view` invocation.

## The fix

- `apps/cli/src/lib/models.ts:79` — new `EMPTY_CATALOG_RETRY_MS` (24h).
- `apps/cli/src/lib/models.ts:87` — `CacheEntry.attemptedAt?: number`.
- `apps/cli/src/lib/models.ts:71` — `CACHE_SCHEMA_VERSION` bumped `2 -> 3` so
  pre-fix cache files (no `attemptedAt`) are dropped, not misread.
- `apps/cli/src/lib/models.ts:968-973` (read site) — a cache hit now also
  requires `models.length > 0 || Date.now() - attemptedAt < 24h` before
  serving the cached catalog.
- `apps/cli/src/lib/models.ts:1006-1017` (write site) — **always** persists
  the catalog now, including a 0-model one, stamped with `attemptedAt`.

An upgrade/reinstall (new source mtime) still re-extracts immediately,
unchanged from before — the TTL only bounds how long a *stale-but-unchanged*
0-model result is trusted.

## Run proof — before/after timing

Measured directly against this host's real installed Claude versions (7
installed, 4 hitting the broken extractor), isolated from concurrent fleet
agents that share the real `~/.agents/.cache/.models-cache.json` via a
scratch `HOME` symlinked to the real version dirs (so the same 230-270MB
binaries are scanned, without racing other sessions' cache writes):

```
versions: 2.1.170, 2.1.181, 2.1.186, 2.1.207, 2.1.217, 2.1.218, 2.1.219
  2.1.170: 10 models   2.1.181: 10 models   2.1.186: 10 models
  2.1.207: 0 models    2.1.217: 0 models    2.1.218: 0 models   2.1.219: 0 models
```

| | before (unpatched `models.ts`) | after (this PR) |
|---|---|---|
| call 1 (cold) | 12676ms | 12483ms |
| call 2 | **7515ms** | **1ms** |
| call 3 | -- | 2ms |

Before: every call stays slow (~7.5s), because the 4 broken versions are
re-extracted every time — matches the reported root cause exactly (4 x
~1.85s ≈ 7.5s). After: the first call pays the same unavoidable extraction
cost, every subsequent call is served from cache.

Also ran `bash apps/cli/scripts/build.sh --clean --skip-tests` (full build,
`agents view claude` executed against the compiled `dist/index.js`) to
confirm the compiled output behaves the same as the TS source under test —
confirmed identical extraction results (10/10/10/0/0/0/0 models) at both
CLI and unit-test level.

## Tests

`apps/cli/src/lib/__tests__/models.test.ts` — 3 new tests (isolated temp
`HOME` + fake timers, no mocking of the extractor or cache):

- persists a 0-model catalog with `attemptedAt`; a second call inside the
  TTL does not move `attemptedAt` on disk (proof of no re-extraction — only
  a real extraction stamps a fresh `attemptedAt`).
- a stale 0-model entry re-extracts once the 24h TTL elapses, even with the
  source mtime unchanged (isolates the TTL path from the pre-existing
  mtime-invalidation path).
- an mtime change still triggers immediate re-extraction regardless of TTL
  (regression guard on the existing cache-key behavior).

```
node ./node_modules/vitest/vitest.mjs run src/lib/__tests__/models.test.ts src/lib/models.configured.test.ts
 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 34 passed (35)
```

The 1 failure (`getModelCatalog (codex) > extracts slugs and reasoning
levels`) is pre-existing and unrelated — verified by swapping `models.ts`
back to the original `HEAD` version and re-running just that test: it fails
identically (`expected 0 to be greater than 0`) against the untouched
original file. It depends on this host's actual installed Codex binary's
reasoning-level strings; no line in `extractCodexCatalog` is touched by this
PR.

## Scope

The Claude-regex correctness bug (`extractClaudeCatalog` broken for
>=2.1.207, causing the `agents view` model column to show `default`) is
**out of scope** for this PR — filed separately as #1820.

## Changelog

`apps/cli/.changelog/next/agents-view-model-cache-slowness.md`
