### PR TITLE
feat(design-drift): nightly design-drift review skill + routine + first report

### DIFF
--- a/.agents/reports/design-drift-2026-08-03.md
+++ b/.agents/reports/design-drift-2026-08-03.md
@@ -1,0 +1,398 @@
+# Design-drift review — 2026-08-03
+
+Nightly scan for **design drift**: new primitives introduced where an existing one should have been reused/extended — overlapping surfaces that work but are messy and hard to improve. Read-only analysis; no code was changed. Each finding names the existing primitive that should have absorbed the new code and a concrete consolidation proposal. Muqsit decides per-issue whether to dispatch a fix — this routine does **not** auto-fix.
+
+- **Window:** merges since `14 days ago` on `origin/main` · **200** PRs · **1273** files changed
+- **Findings:** 11 (ranked, most consolidation value first)
+- **Engine:** reuses the `quality` skill's behavioral-signature + architecture passes
+
+| # | Severity | Finding | Existing primitive to reuse |
+|---|---|---|---|
+| 1 | HIGH | Fleet SSH fan-out is implemented twice: gatherRemoteList reimplements gatherRemoteAgentsJson | apps/cli/src/lib/remote-agents-json.ts:65 `gatherRemoteAgentsJson` — a |
+| 2 | HIGH | Three hand-rolled openclaw-Telegram senders bypass the registered ChannelProvider (and two hardcode the owner number) | apps/cli/src/lib/channels/resolve.ts:13 `resolveTransport(channel, met |
+| 3 | HIGH | The event provenance floor (#1796/#1801) never reached the activity store — ActivityEvent lacks actor/kind/parentSessionId | apps/cli/src/lib/events.ts:601 `resolveProvenance` + apps/cli/src/lib/ |
+| 4 | HIGH | PRE-MERGE CATCH (open PRs #1788 + #1789): two separate SQLite secret-usage stores at the identical path, both bypassing the emitSecretAudit chokepoint | apps/cli/src/lib/secrets/audit.ts:76 `emitSecretAudit` (canonical sinc |
+| 5 | MEDIUM | SSH fan-out + merge orchestration for the activity/feed streams is copy-pasted three times (with feature drift) | apps/cli/src/lib/remote-agents-json.ts `gatherRemoteAgentsJson` + `mer |
+| 6 | MEDIUM | Three independent 'who is running this' resolvers instead of one shared detectCaller | apps/cli/src/lib/events.ts:526 `detectCaller` + the 8-harness TERMINAL |
+| 7 | MEDIUM | agents sessions --active bypasses the canonical worktree-aware project resolver, so its project label disagrees with every other view | apps/cli/src/lib/project-key.ts:74 `resolveProjectKey` + apps/cli/src/ |
+| 8 | MEDIUM | Factory picker caches: ResumePickerCache reimplements HostPickerCache's stale-while-revalidate instead of one shared primitive | apps/factory/src/core/hostPickerCache.ts:23-50 (HostPickerCache, parse |
+| 9 | MEDIUM | runCloudSessions hand-rolls its own id match instead of the documented canonical session-query resolver | apps/cli/src/commands/sessions.ts:3068 `resolveSessionQuery` — documen |
+| 10 | MEDIUM | feed-post.ts hand-copies machine-id.ts's exported normalizeHost() regex byte-for-byte instead of importing it | apps/cli/src/lib/machine-id.ts:16-18 `normalizeHost` — its docstring l |
+| 11 | MEDIUM | Bash-command taxonomy hand-mirrored in TypeScript and Python with no test pinning them in sync | apps/cli/src/lib/session/bash-command.ts (TOOL_REGISTRY, exported, use |
+
+## Findings
+
+### 1. Fleet SSH fan-out is implemented twice: gatherRemoteList reimplements gatherRemoteAgentsJson
+
+**Severity:** HIGH · **Type:** overlapping-primitives · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `agents sessions (browse/search listing)` — `apps/cli/src/lib/session/remote-list.ts:182`
+  - `shared fan-out primitive` — `apps/cli/src/lib/remote-agents-json.ts:65`
+  - `duplicated ssh transport` — `apps/cli/src/lib/session/remote-list.ts:126`
+
+```ts
+// apps/cli/src/lib/session/remote-list.ts:182
+export async function gatherRemoteList(forwardedArgs: string[], hosts?: string[]): Promise<RemoteListResult> {
+```
+```ts
+// apps/cli/src/lib/remote-agents-json.ts:65
+export async function gatherRemoteAgentsJson<T>(
+```
+```ts
+// apps/cli/src/lib/session/remote-list.ts:126
+function sshCapture(target: string, remoteCmd: string, timeoutMs: number): Promise<{ code: number | null; stdout: string }> {
+```
+
+**Reuse instead:** apps/cli/src/lib/remote-agents-json.ts:65 `gatherRemoteAgentsJson` — already reused correctly by apps/cli/src/lib/session/remote-active.ts (gatherRemoteActive)
+
+**Why it's drift:** remote-list.ts:10-14 admits the duplication in its own docstring: "This is the browse-listing sibling of remote-active.ts ... same transport, same device set, same recursion guard." Its device-discovery loop (remote-list.ts:190-216) and its `sshCapture` (remote-list.ts:126-144, spawn('ssh', [...SSH_OPTS, ...controlOpts(), target, remoteCmd]) + timeout + SIGKILL) independently re-type what remote-agents-json.ts:41-71 already provides. remote-active.ts consumes the shared primitive; remote-list.ts forks it.
+
+**Consolidation proposal:** Make gatherRemoteList a thin wrapper over gatherRemoteAgentsJson, as gatherRemoteActive already is (args=forwardedArgs, noFanoutEnv, hosts, parse=parseRemoteListPayload). The one real divergence — remote-list's stricter 'malformed JSON on a zero-exit peer = unreachable' plus row-shape validation — is a small extension to the shared primitive (expose parse-failed peers in RemoteAgentsJsonResult), not a reason for a second fan-out implementation.
+
+### 2. Three hand-rolled openclaw-Telegram senders bypass the registered ChannelProvider (and two hardcode the owner number)
+
+**Severity:** HIGH · **Type:** non-reuse · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `registered provider (canonical)` — `apps/cli/src/lib/channels/providers/openclaw-telegram.ts:29`
+  - `agents feed --dispatch (notifyUrgentBlock)` — `apps/cli/src/lib/notify.ts:83`
+  - `monitors notify action (dispatchAction)` — `apps/cli/src/lib/monitors/dispatch.ts:89`
+
+```ts
+// apps/cli/src/lib/channels/providers/openclaw-telegram.ts:29
+await execFileAsync('openclaw', buildOpenClawNotifyArgs(text, { channel: 'telegram', target: opts.target }));
+```
+```ts
+// apps/cli/src/lib/notify.ts:83
+await execFileAsync('openclaw', buildOpenClawNotifyArgs(text, options));
+```
+```ts
+// apps/cli/src/lib/monitors/dispatch.ts:89
+await execFileAsync('openclaw', args);
+```
+
+**Reuse instead:** apps/cli/src/lib/channels/resolve.ts:13 `resolveTransport(channel, meta)` + apps/cli/src/lib/channels/registry.ts:50 `resolveChannelProvider` + the registered `openclawTelegramProvider.send()` (providers/index.ts:19) — already the single seam `agents send`/`agents notify` funnel every channel through
+
+**Why it's drift:** All three sites build identical argv via the shared buildOpenClawNotifyArgs (notify.ts:40) then independently exec `openclaw` instead of calling the registered provider. Only the provider and notify.ts preflight-check the binary; monitors/dispatch.ts has none, so a missing openclaw surfaces as a raw ENOENT there. Worse, notify.ts:46 `const target = options.target ?? '6078999250';` and monitors/dispatch.ts pass no target — both silently inherit that hardcoded number, while `agents notify` resolves it from `readMeta().notify?.owner`. A change to notify.owner in agents.yaml is invisible to two of the three send paths.
+
+**Consolidation proposal:** Make resolveTransport(channel, meta).send(text, opts) the one send primitive for every human-facing message. notifyUrgentBlock and the monitor notify action should call it with target = meta.notify?.owner?.to instead of hand-building argv. Deletes two duplicate `which openclaw` + exec blocks, gives monitors dry-run + consistent errors for free, and makes notify.owner the single source for where 'the owner' gets pinged. This is the exact feed/activity/notify/message/send smell the review exists to catch.
+
+### 3. The event provenance floor (#1796/#1801) never reached the activity store — ActivityEvent lacks actor/kind/parentSessionId
+
+**Severity:** HIGH · **Type:** non-reuse · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `activity store schema` — `apps/cli/src/lib/activity.ts:135`
+  - `activity record stamps a fabricated identity` — `apps/cli/src/lib/activity.ts:416`
+  - `operational log chokepoint (canonical)` — `apps/cli/src/lib/events.ts:601`
+
+```ts
+// apps/cli/src/lib/activity.ts:135
+export interface ActivityEvent {
+```
+```ts
+// apps/cli/src/lib/activity.ts:416
+osUser: ev.agent ?? 'agent',
+```
+```ts
+// apps/cli/src/lib/events.ts:601
+resolveProvenance()
+```
+
+**Reuse instead:** apps/cli/src/lib/events.ts:601 `resolveProvenance` + apps/cli/src/lib/events.ts:560 `auditOrigin` — the operational `emit()` stamps actor/kind/machineId/sessionId/agent/launchId/parentSessionId as defaults; the activity store never grew the same floor
+
+**Why it's drift:** activity.ts:135-158 (ActivityEvent) has no actor/kind/parentSessionId field at all. activityEventToRecord() (activity.ts:402-433) fabricates `osUser: ev.agent ?? 'agent'` and stamps neither actor, kind, nor parentSessionId. The Python PostToolUse hook — the majority writer of activity events — never sets AGENTS_PARENT_SESSION_ID either (activity.ts:1729-1744). Yet commands/events.ts:6 claims 'Each is stamped with who ran it and from where' for BOTH merged streams. The out-of-process `agents events emit` path correctly reuses emit()/appendActivityEvent — so only the activity floor is missing.
+
+**Consolidation proposal:** Add actor/kind/parentSessionId/launchId to ActivityEvent, and fill them via a shared stampProvenance() extracted from events.ts's resolveProvenance/auditOrigin — called from the TS in-process writer and re-derivable by the Python hook off the same env vars — so `agents events` shows consistent identity across both stores. exec.ts:502-507 already promises this as 'Phase 4'; it is not scoped to just the SSH hop.
+
+### 4. PRE-MERGE CATCH (open PRs #1788 + #1789): two separate SQLite secret-usage stores at the identical path, both bypassing the emitSecretAudit chokepoint
+
+**Severity:** HIGH · **Type:** overlapping-primitives · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `agents secrets (PR #1788, usage-db.ts)` — `apps/cli/src/lib/secrets/usage-db.ts:76`
+  - `agents secrets (PR #1789, activity.ts)` — `apps/cli/src/lib/secrets/activity.ts:52`
+  - `incompatible env override (PR #1788)` — `apps/cli/src/lib/state.ts:345`
+  - `incompatible env override (PR #1789)` — `apps/cli/src/lib/secrets/activity.ts:80`
+
+```ts
+// apps/cli/src/lib/secrets/usage-db.ts:76
+CREATE TABLE IF NOT EXISTS usage_events ( id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT NOT NULL, bundle TEXT NOT NULL, event TEXT NOT NULL,
+```
+```ts
+// apps/cli/src/lib/secrets/activity.ts:52
+CREATE TABLE IF NOT EXISTS events ( id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT NOT NULL, bundle TEXT NOT NULL, kind TEXT NOT NULL,
+```
+```ts
+// apps/cli/src/lib/state.ts:345
+export function getSecretsDbPath(): string { return process.env.AGENTS_SECRETS_DB ?? path.join(USER_SECRETS_DIR, 'secrets.db'); }
+```
+```ts
+// apps/cli/src/lib/secrets/activity.ts:80
+export function secretsActivityDbPath(): string { if (process.env.AGENTS_SECRETS_DB_PATH) return process.env.AGENTS_SECRETS_DB_PATH;
+```
+
+**Reuse instead:** apps/cli/src/lib/secrets/audit.ts:76 `emitSecretAudit` (canonical since #1616 — 'Every path that reads a secret VALUE or grants an unlock funnels its audit through here'). PR #1814 already does the right consolidation and says so: 'emitSecretAudit is the SOLE write path ... Supersedes #1788 and #1789.'
+
+**Why it's drift:** main (HEAD ed9aae69) is CLEAN — one chokepoint, no SQLite store in lib/secrets/. But PRs #1788 (secrets-usage-db) and #1789 (feat/secrets-activity) are both OPEN (mergedAt: null), both forked from the same base 8253f6d3, and each adds a DIFFERENT SQLite store at the SAME on-disk path ~/.agents/secrets/secrets.db with incompatible schemas (usage_events vs events+bundle_stats+meta) and incompatible env overrides (AGENTS_SECRETS_DB vs AGENTS_SECRETS_DB_PATH). Each calls its own recorder (recordSecretUsage / recordSecretActivity) directly from secrets.ts action sites, bypassing emitSecretAudit. Neither PR references the other. If either merges before #1814, main acquires exactly the overlapping-primitives problem this review exists to catch.
+
+**Consolidation proposal:** Close #1788 and #1789 as superseded; merge #1814, which folds the SQLite mirror inside emitSecretAudit via a USAGE_KIND map (one instrumentation call per site) and reuses the already-merged list-filter.ts (#1779). This is a pre-merge catch — acting now prevents the drift instead of filing a cleanup ticket after it lands.
+
+### 5. SSH fan-out + merge orchestration for the activity/feed streams is copy-pasted three times (with feature drift)
+
+**Severity:** MEDIUM · **Type:** non-reuse · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `agents feed (block fan-out)` — `apps/cli/src/commands/feed.ts:508`
+  - `agents feed --filter updates (gatherStatusPosts)` — `apps/cli/src/commands/feed.ts:696`
+  - `agents activity` — `apps/cli/src/commands/activity.ts:198`
+
+```ts
+// apps/cli/src/commands/feed.ts:508
+const forceLocal = opts.local === true || process.env[FEED_NO_FANOUT_ENV] === '1';
+```
+```ts
+// apps/cli/src/commands/feed.ts:696
+const forceLocal = opts.local === true || process.env[FEED_NO_FANOUT_ENV] === '1';
+```
+```ts
+// apps/cli/src/commands/activity.ts:198
+const forceLocal = opts.local === true || process.env[ACTIVITY_NO_FANOUT_ENV] === '1';
+```
+
+**Reuse instead:** apps/cli/src/lib/remote-agents-json.ts `gatherRemoteAgentsJson` + `mergeActivityEvents`/`mergeFeedBlocks` — the dial-and-merge mechanics are shared; only the surrounding force-local/host-resolution/wantAll orchestration is re-derived three times. Same root as finding #1.
+
+**Why it's drift:** feed.ts's block path (feed.ts:508-521) and its gatherStatusPosts sibling (feed.ts:696-706) reimplement the identical shape as activity.ts's action (activity.ts:218-233), except activity.ts additionally supports --devices-all/--hosts-all (activity.ts:200-201) that neither feed.ts copy has — a feature gap that exists only because the logic was not factored once.
+
+**Consolidation proposal:** Extract a single fanOutAndMerge<T>({ localItems, args, noFanoutEnv, hosts, wantAll, self, parse, merge }) helper in lib/remote-agents-json.ts encoding the force-local check, host resolution, and --devices-all opt-in once. Have both feed.ts sites and activity.ts call it — this retroactively gives `agents feed --filter updates` the --devices-all fan-out `agents activity` already has, closing the drift instead of hiding it.
+
+### 6. Three independent 'who is running this' resolvers instead of one shared detectCaller
+
+**Severity:** MEDIUM · **Type:** overlapping-primitives · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `events.ts (canonical, 8-harness map)` — `apps/cli/src/lib/events.ts:526`
+  - `feed-post.ts (claude/codex only)` — `apps/cli/src/lib/feed-post.ts:409`
+  - `activity.ts Python hook (defaults to 'claude')` — `apps/cli/src/lib/activity.ts:1729`
+
+```ts
+// apps/cli/src/lib/events.ts:526
+export function detectCaller(
+```
+```ts
+// apps/cli/src/lib/feed-post.ts:409
+function detectAgentKind(env: NodeJS.ProcessEnv): string {
+```
+```ts
+// apps/cli/src/lib/activity.ts:1729
+# Identity (mirrors 10-feed-publish.py).
+```
+
+**Reuse instead:** apps/cli/src/lib/events.ts:526 `detectCaller` + the 8-harness TERMINAL_CALLERS map (events.ts:514-523)
+
+**Why it's drift:** feed-post.ts:409-412 detectAgentKind recognizes only claude/codex ('if (env.CLAUDECODE === '1') return 'claude'; if (env.CODEX_CI || env.CODEX_HOME) return 'codex'; return 'agent';') versus events.ts detectCaller which resolves grok/cursor/opencode/gemini/antigravity too. The Python hook has a third, narrower resolver defaulting to 'claude' unconditionally (activity.ts:1744 `agent = os.environ.get("AGENTS_AGENT_NAME") or "claude"`). None call each other; each is a standalone guess at the same fact from the same env vars — a harness-parity gap that silently mislabels non-claude/codex agents.
+
+**Consolidation proposal:** Export detectCaller (or resolveAgentKind) from events.ts; feed-post.ts::resolvePostIdentity calls it instead of detectAgentKind. For the Python hook, default agent to the caller-detected value forwarded via AGENTS_AGENT_NAME (buildExecEnv sets it at exec.ts:514) rather than hardcoding 'claude'.
+
+### 7. agents sessions --active bypasses the canonical worktree-aware project resolver, so its project label disagrees with every other view
+
+**Severity:** MEDIUM · **Type:** non-reuse · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `agents sessions --active (row)` — `apps/cli/src/commands/sessions.ts:435`
+  - `agents sessions --active --json` — `apps/cli/src/commands/sessions.ts:628`
+
+```ts
+// apps/cli/src/commands/sessions.ts:435
+const project = s.cwd ? path.basename(s.cwd) : '';
+```
+```ts
+// apps/cli/src/commands/sessions.ts:628
+project: s.cwd ? path.basename(s.cwd) : null,
+```
+
+**Reuse instead:** apps/cli/src/lib/project-key.ts:74 `resolveProjectKey` + apps/cli/src/lib/projects.ts:338 `resolveProjectNameForCwd` — already reused by the bare `agents sessions` overview (sessions.ts:2118 overviewProjectKey) and by `agents activity` (activity.ts:396)
+
+**Why it's drift:** project-key.ts:1-16 states the resolver exists precisely so a worktree cwd folds to the repo name and a defined multi-repo project reads as one bucket everywhere — 'They must agree, or the same session shows up under agents-cli in one view and my-branch-slug in another.' sessions.ts:435 and :628 (the --active surface #1809/#1765 shipped) recompute project via raw path.basename(s.cwd) — no worktree fold, no defined-project match — so --active disagrees with activity and the bare listing for the same session.
+
+**Consolidation proposal:** Replace both path.basename(s.cwd) sites with resolveProjectNameForCwd(s.cwd, listProjectDefs()) falling back to resolveProjectKey(s.cwd), computed once per gatherActiveSessions() and threaded to render + serialize. Note: check the RUSH-1981 --active --json consumer (sessions.ts:604-610) that documents the basename shape as a deliberate join-stability choice before changing the JSON field.
+
+### 8. Factory picker caches: ResumePickerCache reimplements HostPickerCache's stale-while-revalidate instead of one shared primitive
+
+**Severity:** MEDIUM · **Type:** non-reuse · **Confidence:** medium
+
+**Overlapping surfaces:**
+  - `Agents: Resume` — `apps/factory/src/core/resumePicker.ts:55`
+  - `Agents: New <Agent> (Pick Host)` — `apps/factory/src/core/hostPickerCache.ts:48`
+  - `New <Agent> (Auto) launch-health` — `apps/factory/src/core/launchHistory.ts:92`
+  - `hot-mirror bolted onto one cache only` — `apps/factory/src/vscode/extension.ts:540`
+
+```ts
+// apps/factory/src/core/resumePicker.ts:55
+export interface ResumePickerCache {
+  candidates: ResumeCandidate[];
+  fetchedAt: number;
+}
+```
+```ts
+// apps/factory/src/core/hostPickerCache.ts:48
+export function isHostPickerStale(cache: HostPickerCache | null | undefined, now = Date.now()): boolean {
+  return !cache || now - cache.fetchedAt >= HOST_PICKER_STALE_MS;
+}
+```
+```ts
+// apps/factory/src/core/launchHistory.ts:92
+if (!cache || now - cache.refreshedAt > LAUNCH_HEALTH_MAX_AGE_MS) return null;
+```
+```ts
+// apps/factory/src/vscode/extension.ts:540
+let hostPickerHot: HostPickerCache | null = null;
+```
+
+**Reuse instead:** apps/factory/src/core/hostPickerCache.ts:23-50 (HostPickerCache, parseHostPickerCache, isHostPickerStale) — the only one of the three persisted picker caches with a named, testable staleness function
+
+**Why it's drift:** PR #1782 (commit 8253f6d3) message: 'Agents: Resume gets the same treatment (agents.resumePicker.v1, checks carried across the item swap)' — the same PR that introduced HostPickerCache hand-copied the persisted-snapshot / staleness / background-refresh pattern into ResumePickerCache rather than generalizing it. Staleness diverges: HOST_PICKER_STALE_MS=60_000 vs LAUNCH_HEALTH_MAX_AGE_MS=5*60_000 vs ResumePickerCache which defines no threshold at all (refreshes on every non-empty open, extension.ts:3283). An in-memory hot mirror exists only for HostPickerCache (extension.ts:540-552); the other two re-read+re-parse globalState on every open.
+
+**Consolidation proposal:** Extract createStaleWhileRevalidateCache<T>(key, staleMs) owning globalState read/shape-check, staleness check, in-memory hot mirror, and background-refresh-and-swap. Reimplement HostPickerCache and ResumePickerCache as instances; migrate LaunchHealthCache when its refresh is next touched. One ticket, covers all three facets.
+
+### 9. runCloudSessions hand-rolls its own id match instead of the documented canonical session-query resolver
+
+**Severity:** MEDIUM · **Type:** non-reuse · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `agents sessions --cloud <id>` — `apps/cli/src/commands/sessions.ts:2977`
+
+```ts
+// apps/cli/src/commands/sessions.ts:2977
+const matches = sessions.filter(
+    (s) => s.id === query || s.shortId === query || s.id.startsWith(query),
+  );
+```
+
+**Reuse instead:** apps/cli/src/commands/sessions.ts:3068 `resolveSessionQuery` — documented as 'The single entry point for turning a sessions <query> argument into rows'; already reused by fleetCandidatesByQuery (sessions.ts:3459) and resolveIndexedMetadataRows (sessions.ts:3482)
+
+**Why it's drift:** resolveSessionQuery gates id-shaped queries through looksLikeSessionId and keeps ranked search for phrases (sessions.ts:3063-3066). runCloudSessions applies none of that — a raw startsWith against any query string (sessions.ts:2978), so cloud sessions silently skip the id gate and ambiguity handling every other session source gets.
+
+**Consolidation proposal:** Call resolveSessionQuery(sessions, query, { indexFallback: false }) in runCloudSessions the way fleetCandidatesByQuery and resolveIndexedMetadataRows already do, so cloud sessions get the same looksLikeSessionId gate and ambiguity/hint behavior as every other source.
+
+### 10. feed-post.ts hand-copies machine-id.ts's exported normalizeHost() regex byte-for-byte instead of importing it
+
+**Severity:** MEDIUM · **Type:** non-reuse · **Confidence:** high
+
+**Overlapping surfaces:**
+  - `feed-post.ts (inline copy)` — `apps/cli/src/lib/feed-post.ts:401`
+
+```ts
+// apps/cli/src/lib/feed-post.ts:401
+function machineIdFromEnv(env: NodeJS.ProcessEnv): string {
+  const raw = env.AGENTS_SYNC_MACHINE_ID || undefined;
+  if (raw) {
+    return raw.split('.')[0].trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+  }
+  return machineId();
+}
+```
+
+**Reuse instead:** apps/cli/src/lib/machine-id.ts:16-18 `normalizeHost` — its docstring literally says 'The single source for this transform'; feed-post.ts already imports `machineId` from the same module (feed-post.ts:25)
+
+**Why it's drift:** machine-id.ts:16-18 normalizeHost body is byte-for-byte duplicated inline in feed-post.ts:401-406, in a file that already imports from ./machine-id.js — normalizeHost was one import away.
+
+**Consolidation proposal:** Import normalizeHost alongside machineId in feed-post.ts and replace machineIdFromEnv's body with `return env.AGENTS_SYNC_MACHINE_ID ? normalizeHost(env.AGENTS_SYNC_MACHINE_ID) : machineId();` — one line, zero behavior change.
+
+### 11. Bash-command taxonomy hand-mirrored in TypeScript and Python with no test pinning them in sync
+
+**Severity:** MEDIUM · **Type:** overlapping-primitives · **Confidence:** medium
+
+**Overlapping surfaces:**
+  - `activity.ts Python hook (mirror)` — `apps/cli/src/lib/activity.ts:942`
+
+```ts
+// apps/cli/src/lib/activity.ts:942
+# Canonical command taxonomy for Bash tool calls. Mirrors the TypeScript
+# registry in lib/session/bash-command.ts; keep them in sync.
+BASH_TOOL_REGISTRY = {
+```
+
+**Reuse instead:** apps/cli/src/lib/session/bash-command.ts (TOOL_REGISTRY, exported, used by session rendering / `agents sessions`)
+
+**Why it's drift:** activity.ts:942-943 documents the duplication ('Mirrors the TypeScript registry ... keep them in sync') rather than generating the Python dict from the TS registry. The two currently agree, but neither activity.test.ts nor bash-command.test.ts asserts it — nothing fails CI if a future PR adds a tool to one and forgets the other, so `agents sessions` (TS reader) and `agents activity` (Python-hook writer) would silently disagree on a command's category.
+
+**Consolidation proposal:** Either (a) generate BASH_TOOL_REGISTRY's Python literal from bash-command.ts's TOOL_REGISTRY at hook-install time (activity.ts already templates the hook as a string, so this is codegen, not a runtime import), or (b) add a test that parses both registries and fails on divergence — the same discipline activity.test.ts already applies to MILESTONE_EVENTS vs the Python hook's copy (activity.ts:120-125).
+
+## Verified distinct (not flagged)
+
+The review examined these look-alikes and confirmed they are **legitimately distinct**, not drift — recorded here so the false-positive discipline is auditable:
+
+- **`agents message` vs `agents send --channel mailbox`** — both hit the same `enqueue()` seam, but the mailbox provider's own docstring (`lib/channels/providers/mailbox.ts:4-6`) says it is "a thin wrapper over the same enqueue seam that `agents message` uses," and `agents message` additionally does block-claim / inject / resume routing `send` never does. Correct reuse of one primitive behind two deliberate surfaces.
+- **`agents feed post` broadcast sinks vs the channel-provider registry** — `lib/feed-broadcast.ts:9-14` are operator-configured argv templates ("Sinks are argv templates from config, never hardcoded integrations"), an OSS-neutrality choice, not a second typed send API.
+- **`agents activity` / `agents feed` trailing lane / `agents events --module activity`** — all read the *same* `readRecentActivity` primitive (`lib/activity.ts:321`) with shared formatters; different lenses on one store, not parallel readers.
+- **Factory host-picker PRs #1782/#1799/#1802** — legitimate iteration on ONE primitive: #1782 introduced `HostPickerCache`, #1799/#1802 extended it in place. (The drift is the *sibling* caches that hand-copied its pattern — the Factory picker-cache finding — not the picker PRs themselves.)
+- **Session-query resolver** — well-consolidated: `resolveSessionQuery` (`sessions.ts:3068`) is the single entry point and every fleet path funnels through it; `findSessionsByShortIds` (#1765) is a deliberate batched variant for N tmux panes, not drift. (The one bypass — `runCloudSessions` — is flagged separately.)
+- **Rollup formatters** (`rollupSessionsByProject`, `groupActivity`, `buildOverviewGroups`) — three genuinely different data shapes (live-session card, event timeline, history listing) for three purposes; legitimate parallel implementations.
+- **`agents events emit` (out-of-process)** — correctly reuses `emit()` / `appendActivityEvent()` rather than re-implementing the write path. The operational-log provenance floor (`resolveProvenance`) IS a real single chokepoint; only the *activity store* half missed it (the activity-store provenance finding).
+- **Secrets on `main` today** — healthy: one `emitSecretAudit` chokepoint, no parallel store. The drift (the secrets finding, blocker) lives in two still-open PRs, not on `main`.
+
+## Drafted Linear tickets
+
+> The `linear.app` secrets bundle was not reachable from the run host, so tickets are **drafted** here rather than filed. Run these once the bundle is present (`agents secrets exec linear.app -- ...`), or file them from a box that has it. Tag: `design-drift`.
+
+```bash
+linear issue create --title "design-drift: Fleet SSH fan-out is implemented twice: gatherRemoteList reimplements gatherRemoteAgentsJson" \
+  --label design-drift --description "Overlapping surfaces:\n- agents sessions (browse/search listing) (apps/cli/src/lib/session/remote-list.ts:182)\n- shared fan-out primitive (apps/cli/src/lib/remote-agents-json.ts:65)\n- duplicated ssh transport (apps/cli/src/lib/session/remote-list.ts:126)\n\nReuse instead: apps/cli/src/lib/remote-agents-json.ts:65 `gatherRemoteAgentsJson` — already reused correctly by apps/cli/src/lib/session/remote-active.ts (gatherRemoteActive)\n\nWhy it's drift: remote-list.ts:10-14 admits the duplication in its own docstring: 'This is the browse-listing sibling of remote-active.ts ... same transport, same device set, same recursion guard.' Its device-discovery loop (remote-list.ts:190-216) and its `sshCapture` (remote-list.ts:126-144, spawn('ssh', [...SSH_OPTS, ...controlOpts(), target, remoteCmd]) + timeout + SIGKILL) independently re-type what remote-agents-json.ts:41-71 already provides. remote-active.ts consumes the shared primitive; remote-list.ts forks it.\n\nProposal: Make gatherRemoteList a thin wrapper over gatherRemoteAgentsJson, as gatherRemoteActive already is (args=forwardedArgs, noFanoutEnv, hosts, parse=parseRemoteListPayload). The one real divergence — remote-list's stricter 'malformed JSON on a zero-exit peer = unreachable' plus row-shape validation — is a small extension to the shared primitive (expose parse-failed peers in RemoteAgentsJsonResult), not a reason for a second fan-out implementation."
+```
+
+```bash
+linear issue create --title "design-drift: Three hand-rolled openclaw-Telegram senders bypass the registered ChannelProvider (and two hardcode the owner number)" \
+  --label design-drift --description "Overlapping surfaces:\n- registered provider (canonical) (apps/cli/src/lib/channels/providers/openclaw-telegram.ts:29)\n- agents feed --dispatch (notifyUrgentBlock) (apps/cli/src/lib/notify.ts:83)\n- monitors notify action (dispatchAction) (apps/cli/src/lib/monitors/dispatch.ts:89)\n\nReuse instead: apps/cli/src/lib/channels/resolve.ts:13 `resolveTransport(channel, meta)` + apps/cli/src/lib/channels/registry.ts:50 `resolveChannelProvider` + the registered `openclawTelegramProvider.send()` (providers/index.ts:19) — already the single seam `agents send`/`agents notify` funnel every channel through\n\nWhy it's drift: All three sites build identical argv via the shared buildOpenClawNotifyArgs (notify.ts:40) then independently exec `openclaw` instead of calling the registered provider. Only the provider and notify.ts preflight-check the binary; monitors/dispatch.ts has none, so a missing openclaw surfaces as a raw ENOENT there. Worse, notify.ts:46 `const target = options.target ?? '6078999250';` and monitors/dispatch.ts pass no target — both silently inherit that hardcoded number, while `agents notify` resolves it from `readMeta().notify?.owner`. A change to notify.owner in agents.yaml is invisible to two of the three send paths.\n\nProposal: Make resolveTransport(channel, meta).send(text, opts) the one send primitive for every human-facing message. notifyUrgentBlock and the monitor notify action should call it with target = meta.notify?.owner?.to instead of hand-building argv. Deletes two duplicate `which openclaw` + exec blocks, gives monitors dry-run + consistent errors for free, and makes notify.owner the single source for where 'the owner' gets pinged. This is the exact feed/activity/notify/message/send smell the review exists to catch."
+```
+
+```bash
+linear issue create --title "design-drift: The event provenance floor (#1796/#1801) never reached the activity store — ActivityEvent lacks actor/kind/parentSessionId" \
+  --label design-drift --description "Overlapping surfaces:\n- activity store schema (apps/cli/src/lib/activity.ts:135)\n- activity record stamps a fabricated identity (apps/cli/src/lib/activity.ts:416)\n- operational log chokepoint (canonical) (apps/cli/src/lib/events.ts:601)\n\nReuse instead: apps/cli/src/lib/events.ts:601 `resolveProvenance` + apps/cli/src/lib/events.ts:560 `auditOrigin` — the operational `emit()` stamps actor/kind/machineId/sessionId/agent/launchId/parentSessionId as defaults; the activity store never grew the same floor\n\nWhy it's drift: activity.ts:135-158 (ActivityEvent) has no actor/kind/parentSessionId field at all. activityEventToRecord() (activity.ts:402-433) fabricates `osUser: ev.agent ?? 'agent'` and stamps neither actor, kind, nor parentSessionId. The Python PostToolUse hook — the majority writer of activity events — never sets AGENTS_PARENT_SESSION_ID either (activity.ts:1729-1744). Yet commands/events.ts:6 claims 'Each is stamped with who ran it and from where' for BOTH merged streams. The out-of-process `agents events emit` path correctly reuses emit()/appendActivityEvent — so only the activity floor is missing.\n\nProposal: Add actor/kind/parentSessionId/launchId to ActivityEvent, and fill them via a shared stampProvenance() extracted from events.ts's resolveProvenance/auditOrigin — called from the TS in-process writer and re-derivable by the Python hook off the same env vars — so `agents events` shows consistent identity across both stores. exec.ts:502-507 already promises this as 'Phase 4'; it is not scoped to just the SSH hop."
+```
+
+```bash
+linear issue create --title "design-drift: PRE-MERGE CATCH (open PRs #1788 + #1789): two separate SQLite secret-usage stores at the identical path, both bypassing the emitSecretAudit chokepoint" \
+  --label design-drift --description "Overlapping surfaces:\n- agents secrets (PR #1788, usage-db.ts) (apps/cli/src/lib/secrets/usage-db.ts:76)\n- agents secrets (PR #1789, activity.ts) (apps/cli/src/lib/secrets/activity.ts:52)\n- incompatible env override (PR #1788) (apps/cli/src/lib/state.ts:345)\n- incompatible env override (PR #1789) (apps/cli/src/lib/secrets/activity.ts:80)\n\nReuse instead: apps/cli/src/lib/secrets/audit.ts:76 `emitSecretAudit` (canonical since #1616 — 'Every path that reads a secret VALUE or grants an unlock funnels its audit through here'). PR #1814 already does the right consolidation and says so: 'emitSecretAudit is the SOLE write path ... Supersedes #1788 and #1789.'\n\nWhy it's drift: main (HEAD ed9aae69) is CLEAN — one chokepoint, no SQLite store in lib/secrets/. But PRs #1788 (secrets-usage-db) and #1789 (feat/secrets-activity) are both OPEN (mergedAt: null), both forked from the same base 8253f6d3, and each adds a DIFFERENT SQLite store at the SAME on-disk path ~/.agents/secrets/secrets.db with incompatible schemas (usage_events vs events+bundle_stats+meta) and incompatible env overrides (AGENTS_SECRETS_DB vs AGENTS_SECRETS_DB_PATH). Each calls its own recorder (recordSecretUsage / recordSecretActivity) directly from secrets.ts action sites, bypassing emitSecretAudit. Neither PR references the other. If either merges before #1814, main acquires exactly the overlapping-primitives problem this review exists to catch.\n\nProposal: Close #1788 and #1789 as superseded; merge #1814, which folds the SQLite mirror inside emitSecretAudit via a USAGE_KIND map (one instrumentation call per site) and reuses the already-merged list-filter.ts (#1779). This is a pre-merge catch — acting now prevents the drift instead of filing a cleanup ticket after it lands."
+```
+
+```bash
+linear issue create --title "design-drift: SSH fan-out + merge orchestration for the activity/feed streams is copy-pasted three times (with feature drift)" \
+  --label design-drift --description "Overlapping surfaces:\n- agents feed (block fan-out) (apps/cli/src/commands/feed.ts:508)\n- agents feed --filter updates (gatherStatusPosts) (apps/cli/src/commands/feed.ts:696)\n- agents activity (apps/cli/src/commands/activity.ts:198)\n\nReuse instead: apps/cli/src/lib/remote-agents-json.ts `gatherRemoteAgentsJson` + `mergeActivityEvents`/`mergeFeedBlocks` — the dial-and-merge mechanics are shared; only the surrounding force-local/host-resolution/wantAll orchestration is re-derived three times. Same root as finding #1.\n\nWhy it's drift: feed.ts's block path (feed.ts:508-521) and its gatherStatusPosts sibling (feed.ts:696-706) reimplement the identical shape as activity.ts's action (activity.ts:218-233), except activity.ts additionally supports --devices-all/--hosts-all (activity.ts:200-201) that neither feed.ts copy has — a feature gap that exists only because the logic was not factored once.\n\nProposal: Extract a single fanOutAndMerge<T>({ localItems, args, noFanoutEnv, hosts, wantAll, self, parse, merge }) helper in lib/remote-agents-json.ts encoding the force-local check, host resolution, and --devices-all opt-in once. Have both feed.ts sites and activity.ts call it — this retroactively gives `agents feed --filter updates` the --devices-all fan-out `agents activity` already has, closing the drift instead of hiding it."
+```
+
+```bash
+linear issue create --title "design-drift: Three independent 'who is running this' resolvers instead of one shared detectCaller" \
+  --label design-drift --description "Overlapping surfaces:\n- events.ts (canonical, 8-harness map) (apps/cli/src/lib/events.ts:526)\n- feed-post.ts (claude/codex only) (apps/cli/src/lib/feed-post.ts:409)\n- activity.ts Python hook (defaults to 'claude') (apps/cli/src/lib/activity.ts:1729)\n\nReuse instead: apps/cli/src/lib/events.ts:526 `detectCaller` + the 8-harness TERMINAL_CALLERS map (events.ts:514-523)\n\nWhy it's drift: feed-post.ts:409-412 detectAgentKind recognizes only claude/codex ('if (env.CLAUDECODE === '1') return 'claude'; if (env.CODEX_CI || env.CODEX_HOME) return 'codex'; return 'agent';') versus events.ts detectCaller which resolves grok/cursor/opencode/gemini/antigravity too. The Python hook has a third, narrower resolver defaulting to 'claude' unconditionally (activity.ts:1744 `agent = os.environ.get('AGENTS_AGENT_NAME') or 'claude'`). None call each other; each is a standalone guess at the same fact from the same env vars — a harness-parity gap that silently mislabels non-claude/codex agents.\n\nProposal: Export detectCaller (or resolveAgentKind) from events.ts; feed-post.ts::resolvePostIdentity calls it instead of detectAgentKind. For the Python hook, default agent to the caller-detected value forwarded via AGENTS_AGENT_NAME (buildExecEnv sets it at exec.ts:514) rather than hardcoding 'claude'."
+```
+
+```bash
+linear issue create --title "design-drift: agents sessions --active bypasses the canonical worktree-aware project resolver, so its project label disagrees with every other view" \
+  --label design-drift --description "Overlapping surfaces:\n- agents sessions --active (row) (apps/cli/src/commands/sessions.ts:435)\n- agents sessions --active --json (apps/cli/src/commands/sessions.ts:628)\n\nReuse instead: apps/cli/src/lib/project-key.ts:74 `resolveProjectKey` + apps/cli/src/lib/projects.ts:338 `resolveProjectNameForCwd` — already reused by the bare `agents sessions` overview (sessions.ts:2118 overviewProjectKey) and by `agents activity` (activity.ts:396)\n\nWhy it's drift: project-key.ts:1-16 states the resolver exists precisely so a worktree cwd folds to the repo name and a defined multi-repo project reads as one bucket everywhere — 'They must agree, or the same session shows up under agents-cli in one view and my-branch-slug in another.' sessions.ts:435 and :628 (the --active surface #1809/#1765 shipped) recompute project via raw path.basename(s.cwd) — no worktree fold, no defined-project match — so --active disagrees with activity and the bare listing for the same session.\n\nProposal: Replace both path.basename(s.cwd) sites with resolveProjectNameForCwd(s.cwd, listProjectDefs()) falling back to resolveProjectKey(s.cwd), computed once per gatherActiveSessions() and threaded to render + serialize. Note: check the RUSH-1981 --active --json consumer (sessions.ts:604-610) that documents the basename shape as a deliberate join-stability choice before changing the JSON field."
+```
+
+```bash
+linear issue create --title "design-drift: Factory picker caches: ResumePickerCache reimplements HostPickerCache's stale-while-revalidate instead of one shared primitive" \
+  --label design-drift --description "Overlapping surfaces:\n- Agents: Resume (apps/factory/src/core/resumePicker.ts:55)\n- Agents: New <Agent> (Pick Host) (apps/factory/src/core/hostPickerCache.ts:48)\n- New <Agent> (Auto) launch-health (apps/factory/src/core/launchHistory.ts:92)\n- hot-mirror bolted onto one cache only (apps/factory/src/vscode/extension.ts:540)\n\nReuse instead: apps/factory/src/core/hostPickerCache.ts:23-50 (HostPickerCache, parseHostPickerCache, isHostPickerStale) — the only one of the three persisted picker caches with a named, testable staleness function\n\nWhy it's drift: PR #1782 (commit 8253f6d3) message: 'Agents: Resume gets the same treatment (agents.resumePicker.v1, checks carried across the item swap)' — the same PR that introduced HostPickerCache hand-copied the persisted-snapshot / staleness / background-refresh pattern into ResumePickerCache rather than generalizing it. Staleness diverges: HOST_PICKER_STALE_MS=60_000 vs LAUNCH_HEALTH_MAX_AGE_MS=5*60_000 vs ResumePickerCache which defines no threshold at all (refreshes on every non-empty open, extension.ts:3283). An in-memory hot mirror exists only for HostPickerCache (extension.ts:540-552); the other two re-read+re-parse globalState on every open.\n\nProposal: Extract createStaleWhileRevalidateCache<T>(key, staleMs) owning globalState read/shape-check, staleness check, in-memory hot mirror, and background-refresh-and-swap. Reimplement HostPickerCache and ResumePickerCache as instances; migrate LaunchHealthCache when its refresh is next touched. One ticket, covers all three facets."
+```
+
+```bash
+linear issue create --title "design-drift: runCloudSessions hand-rolls its own id match instead of the documented canonical session-query resolver" \
+  --label design-drift --description "Overlapping surfaces:\n- agents sessions --cloud <id> (apps/cli/src/commands/sessions.ts:2977)\n\nReuse instead: apps/cli/src/commands/sessions.ts:3068 `resolveSessionQuery` — documented as 'The single entry point for turning a sessions <query> argument into rows'; already reused by fleetCandidatesByQuery (sessions.ts:3459) and resolveIndexedMetadataRows (sessions.ts:3482)\n\nWhy it's drift: resolveSessionQuery gates id-shaped queries through looksLikeSessionId and keeps ranked search for phrases (sessions.ts:3063-3066). runCloudSessions applies none of that — a raw startsWith against any query string (sessions.ts:2978), so cloud sessions silently skip the id gate and ambiguity handling every other session source gets.\n\nProposal: Call resolveSessionQuery(sessions, query, { indexFallback: false }) in runCloudSessions the way fleetCandidatesByQuery and resolveIndexedMetadataRows already do, so cloud sessions get the same looksLikeSessionId gate and ambiguity/hint behavior as every other source."
+```
+
+```bash
+linear issue create --title "design-drift: feed-post.ts hand-copies machine-id.ts's exported normalizeHost() regex byte-for-byte instead of importing it" \
+  --label design-drift --description "Overlapping surfaces:\n- feed-post.ts (inline copy) (apps/cli/src/lib/feed-post.ts:401)\n\nReuse instead: apps/cli/src/lib/machine-id.ts:16-18 `normalizeHost` — its docstring literally says 'The single source for this transform'; feed-post.ts already imports `machineId` from the same module (feed-post.ts:25)\n\nWhy it's drift: machine-id.ts:16-18 normalizeHost body is byte-for-byte duplicated inline in feed-post.ts:401-406, in a file that already imports from ./machine-id.js — normalizeHost was one import away.\n\nProposal: Import normalizeHost alongside machineId in feed-post.ts and replace machineIdFromEnv's body with `return env.AGENTS_SYNC_MACHINE_ID ? normalizeHost(env.AGENTS_SYNC_MACHINE_ID) : machineId();` — one line, zero behavior change."
+```
+
+```bash
+linear issue create --title "design-drift: Bash-command taxonomy hand-mirrored in TypeScript and Python with no test pinning them in sync" \
+  --label design-drift --description "Overlapping surfaces:\n- activity.ts Python hook (mirror) (apps/cli/src/lib/activity.ts:942)\n\nReuse instead: apps/cli/src/lib/session/bash-command.ts (TOOL_REGISTRY, exported, used by session rendering / `agents sessions`)\n\nWhy it's drift: activity.ts:942-943 documents the duplication ('Mirrors the TypeScript registry ... keep them in sync') rather than generating the Python dict from the TS registry. The two currently agree, but neither activity.test.ts nor bash-command.test.ts asserts it — nothing fails CI if a future PR adds a tool to one and forgets the other, so `agents sessions` (TS reader) and `agents activity` (Python-hook writer) would silently disagree on a command's category.\n\nProposal: Either (a) generate BASH_TOOL_REGISTRY's Python literal from bash-command.ts's TOOL_REGISTRY at hook-install time (activity.ts already templates the hook as a string, so this is codegen, not a runtime import), or (b) add a test that parses both registries and fails on divergence — the same discipline activity.test.ts already applies to MILESTONE_EVENTS vs the Python hook's copy (activity.ts:120-125)."
+```
+
+---
+
+_Produced by the `design-drift` skill — reuses the `quality` engine's behavioral-signature clustering + a cross-surface consolidation lens over the window's merged surfaces. Read-only: no code was changed. Every finding cites `file:line`; the owner decides per-ticket whether to dispatch a fix._
+

--- a/.agents/routines/design-drift.yml
+++ b/.agents/routines/design-drift.yml
@@ -1,0 +1,38 @@
+# Nightly design-drift review for agents-cli.
+#
+# Committed but INERT by default: a project routine under .agents/routines/ is
+# inspection-only until the owner explicitly opts in — it never auto-fires on a
+# clone. Enabling the recurring schedule is Muqsit's call:
+#
+#   agents routines enable-project --yes     # opt this repo's routines into firing
+#   agents routines sync                      # materialise into the user layer
+#   agents routines run design-drift          # (optional) one-shot foreground test
+#
+# Until then it does nothing. Adjust `devices:` to whichever always-on box should
+# own the nightly run before enabling.
+name: design-drift
+schedule: "0 2 * * *"        # 02:00 daily
+timezone: America/Los_Angeles
+agent: claude
+mode: edit                    # writes the report + drafts/files tickets; NEVER edits code (enforced by the prompt + skill)
+effort: high
+timeout: 45m
+devices: [mac-mini]           # single owner so the fleet doesn't all fire it; change as needed
+prompt: |
+  Run the design-drift review for this repo by invoking the `design-drift` skill
+  (.agents/skills/design-drift/SKILL.md). Pass --notify so the owner gets the
+  summary message.
+
+  This is READ-ONLY analysis of recently-merged work. You MUST NOT edit, create,
+  or delete any source file, open any PR, or dispatch any fix. The ONLY files you
+  may write are the report under .agents/reports/ and scratch under
+  .agents/artifacts/. Your deliverables are exactly three:
+    1. a ranked report at .agents/reports/design-drift-<date>.md,
+    2. Linear tickets filed (or drafted into the report if the linear.app secrets
+       bundle is unreachable) — one per consolidation, tagged design-drift,
+    3. a SHORT (1-4 line) summary message to the owner via
+       `rush message send --from-agent claude` naming the finding count, the top
+       finding, and the report path.
+  Do NOT auto-fix and do NOT auto-dispatch — the owner decides per-ticket.
+  Unattended run: never call AskUserQuestion; if a step is blocked, note it in the
+  report and continue.

--- a/.agents/skills/design-drift/SKILL.md
+++ b/.agents/skills/design-drift/SKILL.md
@@ -140,7 +140,10 @@ keep the strongest evidence.
 ## Phase 4 — Render the report
 
 ```bash
-bun "$SKILL_DIR/report.ts" "$RUN_DIR/findings.json" "$RUN_DIR/meta.json" \
+# Optional notes.md records what the review looked at and deliberately did NOT
+# flag (the false-positive discipline) — write the synthesis subagent's
+# "verified distinct" list there and pass it as the third arg.
+bun "$SKILL_DIR/report.ts" "$RUN_DIR/findings.json" "$RUN_DIR/meta.json" "$RUN_DIR/notes.md" \
   > "$(git rev-parse --show-toplevel)/.agents/reports/design-drift-$(date -u +%F).md"
 ```
 

--- a/.agents/skills/design-drift/SKILL.md
+++ b/.agents/skills/design-drift/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: design-drift
+description: "Read-only nightly review that scans recently-merged work for DESIGN DRIFT — new primitives added where an existing one should have been reused/extended, producing overlapping surfaces (the `agents feed`/`activity`/`notify`/`message`/`send` smell). Reuses the `quality` skill's engine, ranks findings with a consolidation lens, files (or drafts) Linear tickets, and messages the owner a short summary. Never fixes code. Triggers on: 'design drift', 'overlapping surfaces', 'nightly drift review', 'what merged that should have reused something', 'consolidation opportunities'."
+argument-hint: "[--since \"<date>\"] [--notify]"
+allowed-tools: Bash(git*), Bash(gh*), Bash(rg*), Bash(fd*), Bash(jq*), Bash(bun*), Bash(ls*), Bash(wc*), Bash(mkdir*), Bash(agents secrets*), Bash(rush message*), Bash(linear*), Read(*), Write(*), Agent(*)
+user-invocable: true
+---
+
+# design-drift
+
+> A read-only nightly review. Scans PRs merged since the last run for **design
+> drift** — the AI-era smell where an agent adds a NEW primitive instead of
+> reusing/extending an existing one, leaving N overlapping surfaces that work but
+> are messy and hard to improve. Ranks the findings, names the primitive that
+> should have absorbed the new code, files/drafts Linear tickets, and messages the
+> owner. **It never edits code** — it exists to flag messy code, so it must not add
+> any. Fixes are the owner's call, per-issue.
+
+The canonical smell to catch (the operator's own example): `agents feed`,
+`agents activity`, `agents notify`, `agents message`, `agents send` all exist to
+get a message to a human — overlapping surfaces one well-extended primitive could
+have covered.
+
+## Why this reuses `quality` (do not write a parallel analyzer)
+
+The repo already has a read-only code-health engine — the **`quality`** skill —
+whose `signatures.ts` clusters parallel implementations by behavioral signature and
+whose architecture pass flags "new abstraction that duplicates an existing canonical
+one." Those are exactly the drift detectors. This skill is an **orchestrator + a
+consolidation lens on top of that engine**, not a second analyzer. Writing a
+parallel analyzer here would itself be the drift this routine exists to catch.
+
+Resolve the engine dir once (installed plugin, or vendored in-repo):
+
+```bash
+QDIR="$HOME/.agents/plugins/code/skills/quality"
+[ -d "$QDIR" ] || QDIR="$(git rev-parse --show-toplevel)/.agents/plugins/code/skills/quality"
+SKILL_DIR="$(git rev-parse --show-toplevel)/.agents/skills/design-drift"
+```
+
+## Phase 1 — Scope the recent work
+
+```bash
+RUN_DIR="$(bash "$SKILL_DIR/scope.sh" ${SINCE:+--since "$SINCE"} | tail -1)"
+```
+
+`scope.sh` enumerates PRs merged to the default branch in the window (default: since
+the newest prior `.agents/reports/design-drift-*.md`, or 14 days on first run),
+collects the changed files into `$RUN_DIR/files.txt`, summarizes the touched command
+/ module surfaces into `$RUN_DIR/surfaces.txt`, and writes `$RUN_DIR/meta.json` +
+`$RUN_DIR/prs.json`. It is read-only (git/gh reads; writes only under the gitignored
+`.agents/artifacts/`).
+
+## Phase 2 — Run the reused engine passes
+
+Behavioral-signature clustering (mechanical, reused verbatim):
+
+```bash
+bun "$QDIR/signatures.ts" "$RUN_DIR" > "$RUN_DIR/findings/signatures.json"
+```
+
+Architecture / cross-surface drift pass — the `quality` architecture subagent,
+re-briefed for the consolidation lens. It sees the whole recent surface
+constellation (not just one diff), so it can spot N overlapping commands that
+per-diff analysis can't. Spawn one Sonnet subagent:
+
+```
+Agent(subagent_type: "general-purpose", model: "sonnet", prompt: <DRIFT-LENS BRIEF below>)
+```
+
+### DRIFT-LENS BRIEF (fill the `{{ }}` slots, drop verbatim)
+
+```
+You are a READ-ONLY design-drift auditor for {{ repo path }} (analyze the default
+branch; do NOT edit any file). Design drift = a NEW primitive added where an
+existing one should have been reused/extended, leaving overlapping surfaces that
+work but are messy.
+
+SURFACES TOUCHED IN THIS WINDOW (changed-file count per surface):
+{{ paste $RUN_DIR/surfaces.txt }}
+
+PRs MERGED IN THIS WINDOW:
+{{ paste `jq -r '.[] | "#\(.number) \(.title)"' $RUN_DIR/prs.json` }}
+
+MECHANICAL PARALLEL-IMPL HINTS (from the quality signatures pass — verify each, do
+not trust blindly):
+{{ paste $RUN_DIR/findings/signatures.json }}
+
+YOUR JOB — with hard file:line evidence:
+1. DUPLICATE / OVERLAPPING PRIMITIVES — N distinct command surfaces or modules
+   doing one job (several ways to emit a message to a human; several ways to read
+   one activity/event stream; two stores/caches/resolvers for one concept). Name
+   every overlapping surface with file:line and a verbatim quote.
+2. NON-REUSE / NON-EXTENSION — a new function/type/command that re-implements what
+   an existing one does (near-identical `else if (agent === ...)` arms instead of
+   the registry pattern; a second store/write-path; a parallel redactor/parser/
+   formatter) instead of extending the canonical one.
+3. CONSOLIDATION — name the SINGLE existing primitive (file:line) that should have
+   absorbed the others, and give a concrete plan (which surface becomes canonical,
+   which become thin aliases/flags, what the unified API looks like).
+
+Rank by how much messiness consolidating removes. Only flag REAL overlap — when two
+surfaces look similar but are legitimately different (e.g. message-to-a-running-agent
+vs notify-a-human), SAY SO with evidence and do not flag them. When in doubt, drop
+the finding; noise erodes adoption faster than a missed finding.
+
+Output ONE JSON array (nothing after it). Each finding:
+{"rank":1,"category":"overlapping-primitives"|"non-reuse"|"consolidation",
+ "severity":"blocker"|"should"|"nice","title":"<one line>",
+ "surfaces":[{"cmd":"agents send","file":"apps/cli/src/commands/send.ts","line":58,"quote":"<verbatim>"}],
+ "existing_primitive":"<canonical thing to reuse, file:line>",
+ "evidence":"<why these overlap, citing impl file:line>",
+ "consolidation_proposal":"<concrete plan>","confidence":"high"|"medium"|"low"}
+
+Return file:line quotes for every claim. Do NOT paraphrase. If you can't quote it,
+don't claim it. Empty array if you find no genuine drift.
+```
+
+For a wide window, fan the brief across surface clusters (messaging, fleet-rollup,
+secrets, events, caches/resolvers) — one Sonnet subagent per cluster, in parallel —
+then merge their arrays. That is how the first run was produced.
+
+Capture each subagent's JSON array to `$RUN_DIR/findings/architecture-<cluster>.json`.
+
+## Phase 3 — Aggregate + synthesize the ranked report
+
+Merge the mechanical + subagent findings with the reused aggregator, then have one
+synthesis subagent de-dupe overlapping claims, drop weak ones, and produce the final
+ranked array (one finding per consolidation, not per file):
+
+```bash
+bun "$QDIR/aggregate.ts" "$RUN_DIR/findings" > "$RUN_DIR/aggregated.json"   # reused
+```
+
+Synthesis subagent input: `aggregated.json` + every `architecture-*.json`. It emits
+the final ranked `$RUN_DIR/findings.json` in the schema `report.ts` expects (same
+finding shape as the brief). Collapse duplicates that name the same consolidation;
+keep the strongest evidence.
+
+## Phase 4 — Render the report
+
+```bash
+bun "$SKILL_DIR/report.ts" "$RUN_DIR/findings.json" "$RUN_DIR/meta.json" \
+  > "$(git rev-parse --show-toplevel)/.agents/reports/design-drift-$(date -u +%F).md"
+```
+
+`.agents/reports/` is committed — the report is durable and shareable. `report.ts`
+also emits copy-pasteable `linear issue create` blocks so a run with `linear.app`
+offline still produces filable tickets.
+
+## Phase 5 — File (or draft) Linear tickets
+
+One ticket per consolidation, tagged `design-drift` (greppable). If the bundle is
+reachable, file them; else the drafted blocks in the report are the deliverable.
+
+```bash
+if agents secrets list 2>/dev/null | grep -qi '^linear.app\|linear.app'; then
+  # file each finding's ticket via the linear CLI (see the report's drafted blocks)
+  agents secrets exec linear.app -- linear issue create --title "design-drift: <title>" \
+    --label design-drift --description "<body>"
+else
+  echo "linear.app bundle absent — tickets drafted in the report, not filed."
+fi
+```
+
+## Phase 6 — Message the owner (the "let me know" step)
+
+A SHORT (1–4 line) summary — how many findings, the top one named, the report path.
+The owner decides per-ticket whether to dispatch a fix; **do not auto-dispatch.**
+
+```bash
+rush message send --from-agent claude --text \
+  "Design-drift review: N findings across the last <window>. Top: <one-line>. Report: .agents/reports/design-drift-<date>.md + drafted tickets. Your call which to fix."
+```
+
+Only send when invoked with `--notify` (or from the routine). Skip the message on an
+ad-hoc interactive run where the user is watching.
+
+## Don'ts
+
+- **Never edit, create, or delete source code.** This routine flags messy code; it
+  must not add any. The only files it writes are the report (in `.agents/reports/`)
+  and its own scratch under `.agents/artifacts/`.
+- **Don't write a parallel analyzer.** Reuse `quality`'s `signatures.ts` +
+  `aggregate.ts` + architecture-pass shape. New analysis code here is the smell.
+- **Don't auto-fix or auto-dispatch.** Tickets + a message; the human decides.
+- **Don't flag legitimately-distinct surfaces.** message-to-agent ≠ notify-a-human.
+  Require evidence of real overlap; when in doubt, drop it.
+- **One ticket per consolidation**, not per file.

--- a/.agents/skills/design-drift/report.ts
+++ b/.agents/skills/design-drift/report.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+// design-drift · Phase 4 — render the ranked report + drafted tickets.
+//
+// Input: the synthesized, ranked design-drift findings (JSON array) produced by
+// the drift-lens subagent, plus the run's meta.json. Output: a Markdown report
+// to stdout. The skill redirects it to .agents/reports/design-drift-<date>.md.
+//
+// Read-only: renders text, never touches source. Ticket bodies are emitted as
+// copy-pasteable `linear` CLI blocks so the run works whether or not the
+// linear.app secrets bundle is reachable from the run host.
+//
+// Usage: bun report.ts <findings.json> <meta.json>
+
+import { readFileSync, existsSync } from "node:fs";
+
+interface Surface {
+  cmd?: string;
+  file: string;
+  line?: number;
+  quote?: string;
+}
+interface Finding {
+  rank?: number;
+  category: "overlapping-primitives" | "non-reuse" | "consolidation" | string;
+  severity: "blocker" | "should" | "nice" | string;
+  title: string;
+  surfaces?: Surface[];
+  existing_primitive?: string;
+  evidence?: string;
+  consolidation_proposal?: string;
+  confidence?: string;
+}
+interface Meta {
+  run_ts: string;
+  base: string;
+  window_since: string;
+  pr_count: number;
+  file_count: number;
+  repo: string;
+}
+
+const [, , findingsPath, metaPath] = process.argv;
+if (!findingsPath || !metaPath || !existsSync(findingsPath) || !existsSync(metaPath)) {
+  console.error("usage: report.ts <findings.json> <meta.json>");
+  process.exit(1);
+}
+
+const findings: Finding[] = JSON.parse(readFileSync(findingsPath, "utf8"));
+const meta: Meta = JSON.parse(readFileSync(metaPath, "utf8"));
+
+const SEV_ORDER: Record<string, number> = { blocker: 0, should: 1, nice: 2 };
+findings.sort((a, b) => {
+  if (a.rank != null && b.rank != null && a.rank !== b.rank) return a.rank - b.rank;
+  return (SEV_ORDER[a.severity] ?? 9) - (SEV_ORDER[b.severity] ?? 9);
+});
+
+const today = meta.run_ts.slice(0, 10);
+const sev = (s: string) => (s === "blocker" ? "HIGH" : s === "should" ? "MEDIUM" : "LOW");
+const surfLine = (s: Surface) =>
+  `  - \`${s.cmd ?? s.file}\` — \`${s.file}${s.line ? `:${s.line}` : ""}\``;
+
+const out: string[] = [];
+out.push(`# Design-drift review — ${today}`);
+out.push("");
+out.push(
+  `Nightly scan for **design drift**: new primitives introduced where an existing ` +
+    `one should have been reused/extended — overlapping surfaces that work but are ` +
+    `messy and hard to improve. Read-only analysis; no code was changed. Each ` +
+    `finding names the existing primitive that should have absorbed the new code ` +
+    `and a concrete consolidation proposal. Muqsit decides per-issue whether to ` +
+    `dispatch a fix — this routine does **not** auto-fix.`,
+);
+out.push("");
+out.push(
+  `- **Window:** merges since \`${meta.window_since}\` on \`origin/${meta.base}\`` +
+    ` · **${meta.pr_count}** PRs · **${meta.file_count}** files changed`,
+);
+out.push(`- **Findings:** ${findings.length} (ranked, most consolidation value first)`);
+out.push(`- **Engine:** reuses the \`quality\` skill's behavioral-signature + architecture passes`);
+out.push("");
+
+// Summary table.
+out.push("| # | Severity | Finding | Existing primitive to reuse |");
+out.push("|---|---|---|---|");
+findings.forEach((f, i) => {
+  const prim = (f.existing_primitive ?? "").split("\n")[0].slice(0, 70);
+  out.push(`| ${i + 1} | ${sev(f.severity)} | ${f.title} | ${prim} |`);
+});
+out.push("");
+
+// Detailed findings.
+out.push("## Findings");
+out.push("");
+findings.forEach((f, i) => {
+  out.push(`### ${i + 1}. ${f.title}`);
+  out.push("");
+  out.push(`**Severity:** ${sev(f.severity)} · **Type:** ${f.category}` +
+    (f.confidence ? ` · **Confidence:** ${f.confidence}` : ""));
+  out.push("");
+  if (f.surfaces?.length) {
+    out.push(`**Overlapping surfaces:**`);
+    f.surfaces.forEach((s) => out.push(surfLine(s)));
+    out.push("");
+    for (const s of f.surfaces) {
+      if (s.quote) {
+        out.push("```ts");
+        out.push(`// ${s.file}${s.line ? `:${s.line}` : ""}`);
+        out.push(s.quote.trim());
+        out.push("```");
+      }
+    }
+    out.push("");
+  }
+  if (f.existing_primitive) {
+    out.push(`**Reuse instead:** ${f.existing_primitive}`);
+    out.push("");
+  }
+  if (f.evidence) {
+    out.push(`**Why it's drift:** ${f.evidence}`);
+    out.push("");
+  }
+  if (f.consolidation_proposal) {
+    out.push(`**Consolidation proposal:** ${f.consolidation_proposal}`);
+    out.push("");
+  }
+});
+
+// Drafted tickets — copy-pasteable, so the run works with linear.app offline.
+out.push("## Drafted Linear tickets");
+out.push("");
+out.push(
+  `> The \`linear.app\` secrets bundle was not reachable from the run host, so ` +
+    `tickets are **drafted** here rather than filed. Run these once the bundle is ` +
+    `present (\`agents secrets exec linear.app -- ...\`), or file them from a box ` +
+    `that has it. Tag: \`design-drift\`.`,
+);
+out.push("");
+findings.forEach((f, i) => {
+  const title = f.title.replace(/"/g, "'");
+  const bodyParts: string[] = [];
+  if (f.surfaces?.length)
+    bodyParts.push(
+      "Overlapping surfaces:\\n" +
+        f.surfaces.map((s) => `- ${s.cmd ?? s.file} (${s.file}${s.line ? `:${s.line}` : ""})`).join("\\n"),
+    );
+  if (f.existing_primitive) bodyParts.push(`Reuse instead: ${f.existing_primitive}`);
+  if (f.evidence) bodyParts.push(`Why it's drift: ${f.evidence}`);
+  if (f.consolidation_proposal) bodyParts.push(`Proposal: ${f.consolidation_proposal}`);
+  const body = bodyParts.join("\\n\\n").replace(/"/g, "'");
+  out.push("```bash");
+  out.push(
+    `linear issue create --title "design-drift: ${title}" \\\n` +
+      `  --label design-drift --description "${body}"`,
+  );
+  out.push("```");
+  out.push("");
+});
+
+process.stdout.write(out.join("\n") + "\n");

--- a/.agents/skills/design-drift/report.ts
+++ b/.agents/skills/design-drift/report.ts
@@ -9,7 +9,9 @@
 // copy-pasteable `linear` CLI blocks so the run works whether or not the
 // linear.app secrets bundle is reachable from the run host.
 //
-// Usage: bun report.ts <findings.json> <meta.json>
+// Usage: bun report.ts <findings.json> <meta.json> [notes.md]
+//   notes.md — optional; appended under a "Verified distinct (not flagged)"
+//   heading so the report records what the review deliberately did NOT flag.
 
 import { readFileSync, existsSync } from "node:fs";
 
@@ -39,9 +41,9 @@ interface Meta {
   repo: string;
 }
 
-const [, , findingsPath, metaPath] = process.argv;
+const [, , findingsPath, metaPath, notesPath] = process.argv;
 if (!findingsPath || !metaPath || !existsSync(findingsPath) || !existsSync(metaPath)) {
-  console.error("usage: report.ts <findings.json> <meta.json>");
+  console.error("usage: report.ts <findings.json> <meta.json> [notes.md]");
   process.exit(1);
 }
 
@@ -125,6 +127,15 @@ findings.forEach((f, i) => {
   }
 });
 
+// Verified-distinct notes — what the review looked at and deliberately did NOT
+// flag. Records the false-positive discipline (message-to-agent != notify-a-human).
+if (notesPath && existsSync(notesPath)) {
+  out.push("## Verified distinct (not flagged)");
+  out.push("");
+  out.push(readFileSync(notesPath, "utf8").trim());
+  out.push("");
+}
+
 // Drafted tickets — copy-pasteable, so the run works with linear.app offline.
 out.push("## Drafted Linear tickets");
 out.push("");
@@ -155,5 +166,16 @@ findings.forEach((f, i) => {
   out.push("```");
   out.push("");
 });
+
+// Methodology footer.
+out.push("---");
+out.push("");
+out.push(
+  `_Produced by the \`design-drift\` skill — reuses the \`quality\` engine's ` +
+    `behavioral-signature clustering + a cross-surface consolidation lens over the ` +
+    `window's merged surfaces. Read-only: no code was changed. Every finding cites ` +
+    `\`file:line\`; the owner decides per-ticket whether to dispatch a fix._`,
+);
+out.push("");
 
 process.stdout.write(out.join("\n") + "\n");

--- a/.agents/skills/design-drift/scope.sh
+++ b/.agents/skills/design-drift/scope.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# design-drift · Phase 1 — scope the recently-merged work.
+#
+# Enumerates PRs merged to the default branch inside the review window, collects
+# the changed files, and lays out a RUN_DIR the quality engine can analyze.
+# READ-ONLY: only reads git/gh and writes into the gitignored .agents/artifacts/
+# scratch area. Never touches source.
+#
+# Usage: scope.sh [--since "<git-date>"]
+#   --since  explicit window start (any `git log --since` value). When omitted,
+#            the window starts at the date of the most recent prior
+#            design-drift report in .agents/reports/, or 14 days ago on first run.
+#
+# Emits (to stdout) the RUN_DIR path on the last line. Side effects, all under
+# $RUN_DIR: files.txt, surfaces.txt, prs.json, meta.json, findings/.
+set -euo pipefail
+
+REPO="$(git rev-parse --show-toplevel)"
+cd "$REPO"
+
+SINCE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) SINCE="${2:-}"; shift 2 ;;
+    *) echo "scope.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve the default branch (never hardcode main).
+git fetch origin --quiet || true
+git remote set-head origin --auto >/dev/null 2>&1 || true
+BASE="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+BASE="${BASE:-main}"
+
+REPORTS_DIR="$REPO/.agents/reports"
+
+# Window start: explicit --since wins; else the newest prior report's date; else 14d.
+if [[ -z "$SINCE" ]]; then
+  LAST_REPORT="$(ls -1 "$REPORTS_DIR"/design-drift-*.md 2>/dev/null | sort | tail -1 || true)"
+  if [[ -n "$LAST_REPORT" ]]; then
+    # Filename shape: design-drift-YYYY-MM-DD.md
+    LAST_DATE="$(basename "$LAST_REPORT" | sed -E 's/design-drift-([0-9]{4}-[0-9]{2}-[0-9]{2})\.md/\1/')"
+    SINCE="$LAST_DATE"
+  else
+    SINCE="14 days ago"
+  fi
+fi
+
+RUN_TS="$(date -u +"%Y-%m-%dT%H-%M-%S")"
+RUN_DIR="$REPO/.agents/artifacts/${RUN_TS}-design-drift"
+mkdir -p "$RUN_DIR/findings"
+
+# Merged PRs in the window (best-effort; gh may be offline on a fleet box).
+if command -v gh >/dev/null 2>&1 && \
+   gh pr list --state merged --base "$BASE" --limit 200 \
+     --json number,title,mergedAt,headRefName,author >"$RUN_DIR/prs.all.json" 2>/dev/null; then
+  # Keep only PRs merged at/after the window start.
+  SINCE_ISO="$(date -u -d "$SINCE" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")"
+  if [[ -n "$SINCE_ISO" ]]; then
+    jq --arg s "$SINCE_ISO" '[.[] | select(.mergedAt >= $s)] | sort_by(.mergedAt)' \
+      "$RUN_DIR/prs.all.json" >"$RUN_DIR/prs.json"
+  else
+    cp "$RUN_DIR/prs.all.json" "$RUN_DIR/prs.json"
+  fi
+else
+  echo "[]" >"$RUN_DIR/prs.json"
+fi
+PR_COUNT="$(jq 'length' "$RUN_DIR/prs.json")"
+
+# Changed files in the window, from the default branch history. `git log --since`
+# filters by commit (merge) date, which rebase-merge stamps at merge time.
+git log "origin/$BASE" --since="$SINCE" --name-only --pretty=tformat: -- \
+  | sed '/^$/d' | sort -u >"$RUN_DIR/files.txt" || true
+FILE_COUNT="$(wc -l <"$RUN_DIR/files.txt" | tr -d ' ')"
+
+# Surface summary: which top-level command / module surfaces the window touched,
+# with a per-surface changed-file count. This is the constellation the drift lens
+# reasons over ("N commands all touching the messaging surface").
+awk -F/ '
+  /^apps\/cli\/src\/commands\// { print "commands/" $5; next }
+  /^apps\/cli\/src\/lib\//      { print "lib/" $5; next }
+  /^apps\/factory\/src\//       { print "factory/" $4; next }
+  { print $1 "/" $2 }
+' "$RUN_DIR/files.txt" | sed 's/\.ts$//;s/\.tsx$//;s/\.test$//' \
+  | sort | uniq -c | sort -rn >"$RUN_DIR/surfaces.txt" || true
+
+cat >"$RUN_DIR/meta.json" <<JSON
+{
+  "run_ts": "$RUN_TS",
+  "base": "$BASE",
+  "window_since": "$SINCE",
+  "pr_count": $PR_COUNT,
+  "file_count": $FILE_COUNT,
+  "run_dir": "$RUN_DIR",
+  "repo": "$REPO"
+}
+JSON
+
+echo "design-drift scope: window since '$SINCE' on origin/$BASE" >&2
+echo "  merged PRs in window: $PR_COUNT" >&2
+echo "  changed files: $FILE_COUNT" >&2
+echo "  top surfaces:" >&2
+head -12 "$RUN_DIR/surfaces.txt" >&2 || true
+echo "$RUN_DIR"


### PR DESCRIPTION
**feat + docs (read-only tooling)** — a nightly **design-drift** review that scans recently-merged work for the AI-era smell where an agent adds a NEW primitive instead of reusing/extending an existing one, leaving overlapping surfaces. No product/CLI surface changes; no runtime code touched.

## What this adds

- **`.agents/skills/design-drift/`** — the reusable capability. `SKILL.md` (workflow) + `scope.sh` (window/state + surface rollup) + `report.ts` (ranked report + drafted Linear tickets). It **reuses the `quality` skill's engine** (`signatures.ts` behavioral-signature clustering + `aggregate.ts` + the architecture-pass shape) and layers a cross-surface consolidation lens — it does **not** ship a parallel analyzer (that would be the exact smell it exists to catch).
- **`.agents/routines/design-drift.yml`** — the nightly routine (cron 02:00). Committed **inert**: a project routine is inspection-only until `agents routines enable-project`, so it never auto-fires on a clone. **Enabling the recurring schedule is your call** — the code + this first run are the deliverable.
- **`.agents/reports/design-drift-2026-08-03.md`** — the first real pass.

## First run — real output (the proof)

Scoped `origin/main` for the last 14 days: **200 merged PRs · 1273 changed files**, analyzed by the reused engine + 5 parallel Sonnet passes over the hot surface clusters. **11 ranked findings**, every one with `file:line` evidence, the existing primitive it should have reused, and a concrete consolidation proposal. Report: [`.agents/reports/design-drift-2026-08-03.md`](../blob/feature/design-drift-routine/.agents/reports/design-drift-2026-08-03.md).

Top findings:

| # | Sev | Finding |
|---|---|---|
| 1 | HIGH | Fleet SSH fan-out implemented twice — `gatherRemoteList` (`remote-list.ts:182`) reimplements `gatherRemoteAgentsJson` (`remote-agents-json.ts:65`) |
| 2 | HIGH | **The flagship smell:** three hand-rolled openclaw-Telegram senders (`notify.ts:83`, `monitors/dispatch.ts:89`) bypass the registered `ChannelProvider` (`channels/resolve.ts:13`); two hardcode the owner number (`notify.ts:46`) instead of `notify.owner` |
| 3 | HIGH | The event provenance floor (#1796/#1801) never reached the activity store — `ActivityEvent` (`activity.ts:135`) lacks `actor`/`kind`/`parentSessionId` |
| 4 | HIGH | **Pre-merge catch:** open PRs #1788 + #1789 each add a separate SQLite secret-usage store at the identical path, both bypassing `emitSecretAudit` — #1814 already consolidates them |
| 5–11 | MED | fan-out orchestration copied 3× (feed/activity); 3 divergent `detectCaller` clones; `sessions --active` bypasses the project resolver; Factory picker caches; `runCloudSessions` id match; `feed-post.ts` copies `normalizeHost` byte-for-byte; TS/Python bash taxonomy with no sync test |

The report also records a **"verified distinct (not flagged)"** section (message-to-agent ≠ notify-a-human, session resolver already consolidated, secrets healthy on `main`) — the false-positive discipline is auditable.

Linear tickets: the `linear.app` secrets bundle is not reachable from the run host, so tickets are **drafted** as copy-pasteable `linear issue create` blocks in the report (tag `design-drift`), rather than filed.

## Your call

- Whether to `agents routines enable-project` the nightly schedule (and which box owns it — `devices:` currently `mac-mini`).
- Which of the 11 findings to dispatch a fix for — the review does **not** auto-fix or auto-dispatch.

No CHANGELOG entry: this adds a project skill + routine under `.agents/`, not a user-visible `agents` CLI command in the published npm package.
