### PR TITLE
feat(projects): outcomes on the card — agent×project members, releases, Linear counts + projects link --linear

### DIFF
--- a/apps/cli/.changelog/next/projects-outcomes-matrix.md
+++ b/apps/cli/.changelog/next/projects-outcomes-matrix.md
@@ -1,0 +1,16 @@
+- **`agents projects` outcomes on the card — agent×project members, releases,
+  Linear counts, and `projects link --linear` (beta).** The status card gains an
+  `agents` line under `live` naming WHICH harness is on each project
+  (`claude · running · RUSH-2107 @zion`, sorted running-first, capped at 6 with a
+  `+N more` tail; under `--fleet` remote agents carry their peer's hostname), a
+  latest-release tag on the `ships` line (primary repo only, best-effort
+  `gh release list`), and a `linear` line counting the bound Linear project's
+  issues by state type (`12/30 done · 5 in progress`) — best-effort with an 8s
+  budget, skipped by `--no-remote`, and omitted when the def has no
+  `linear.projectId`. The new `agents projects link <name> --linear [query]`
+  writes that binding: no query auto-suggests from the def name + repo slug via
+  the normalized-key matcher (ported from Factory's `linearProjects.ts`),
+  ambiguous/none prints the candidate list and exits 1. `--json` gains
+  `members[]`, `latestRelease`, and `linear`. Source:
+  `apps/cli/src/lib/project-status.ts`, `apps/cli/src/lib/linear-projects.ts`,
+  `apps/cli/src/lib/linear-project-counts.ts`, `apps/cli/src/commands/projects.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -89,18 +89,29 @@ different-home machine still matches — is a deferred follow-up (see below):
 ```
 rush  ·  23 agents  ·  68% plan
   live     14 running · 6 idle · 3 need-input     # active sessions by lifecycle state
-  ships    4 merged (7d) · 2 open PRs · 3 worktrees  # gh merged-PR count + open PRs held
+  agents   claude · running · RUSH-2107 @zion  ·  codex · idle @mac-mini  ·  +21 more
+  ships    4 merged (7d) · 2 open PRs · 3 worktrees · v1.20.91  # gh counts + latest release tag
+  linear   12/30 done · 5 in progress           # Linear issue counts (needs linear.projectId)
   tickets  RUSH-1201 · RUSH-1198 · …              # tickets worked or created
   proof    11 artifacts (7d) · last: plan-x.html  # artifact.created milestones by cwd
   repos    phnx-labs/rush · rush-infra
   context  apps/web · packages/api
 ```
 
-- **`live`, `plan`, open PRs, `tickets`, `worktrees`** come straight from the active
-  session list (`rollupSessionsByProject`) — no network.
+- **`live`, `agents`, `plan`, open PRs, `tickets`, `worktrees`** come straight from the
+  active session list (`rollupSessionsByProject`) — no network. The `agents` line
+  shows WHICH harness is on the project (one cell per session:
+  `agent · status · TICKET @host`), sorted running-first, capped at 6 with a
+  `+N more` tail. Under `--fleet` the remote sessions carry their peer's hostname.
 - **`ships` merged-count** is a best-effort `gh pr list` on the primary repo
   (`--no-remote` skips it; a missing `gh`/auth degrades to 0). It counts up to the
-  100 most recent merges within the window.
+  100 most recent merges within the window. The trailing tag is the **latest release
+  of the primary repo only** (`gh release list -L 1`; `repos[]` are not scanned),
+  absent when the repo has no releases.
+- **`linear`** counts issues by state TYPE (completed → done, started → in progress)
+  in the Linear project bound via `linear.projectId` — set it with
+  `agents projects link <name> --linear`. Best-effort: no credential, offline, or a
+  slow API (>8s) just omits the line, and `--no-remote` skips it too.
 - **`proof`** counts `artifact.created` activity milestones whose cwd is inside the
   project (`lib/project-status.ts`).
 - `--window <days>` sets the merged-PR / artifact window (default 7).
@@ -148,6 +159,7 @@ rush  ·  3 agents
 | `agents projects show <name> [--json]` | Full definition + resolved paths + contexts + links. |
 | `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
 | `agents projects status [name] [--json] [--window N] [--no-remote] [--fleet]` | The progress card (all projects, or one). `--fleet` adds per-device workspace drift over SSH. |
+| `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. |
 | `agents projects import --from-factory` | Absorb `~/.agents/factory/projects.json` into YAML definitions. |
 | `agents projects rm <name>` | Delete the definition (never touches the repo). |
 
@@ -162,5 +174,5 @@ definitions now.
   still local-home — a session recorded on a different-home machine only matches
   once home-relative cwd matching lands.
 - **Re-point `agents factory snapshot`** per-project Linear rollup at defined projects.
-- **Richer Linear ticket-state counts** on the card.
+- **Per-repo release lines** — the `ships` release tag is the primary repo only.
 - **Persisted `project_id` session column** — today membership is derived from cwd.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -111,7 +111,9 @@ rush  ·  23 agents  ·  68% plan
 - **`linear`** counts issues by state TYPE (completed → done, started → in progress)
   in the Linear project bound via `linear.projectId` — set it with
   `agents projects link <name> --linear`. Best-effort: no credential, offline, or a
-  slow API (>8s) just omits the line, and `--no-remote` skips it too.
+  slow API (>8s) just omits the line, and `--no-remote` skips it too. `total`
+  includes canceled issues; the fetch caps at 2,500 issues and a capped count
+  renders as a lower bound (`2500+ done`), never as the complete total.
 - **`proof`** counts `artifact.created` activity milestones whose cwd is inside the
   project (`lib/project-status.ts`).
 - `--window <days>` sets the merged-PR / artifact window (default 7).

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -45,9 +45,12 @@ import {
   rollupSessionsByProject,
   planPct,
   enrichProjectSignals,
+  formatProjectMembers,
   type ProjectSessionRollup,
   type ProjectRemoteSignals,
 } from '../lib/project-status.js';
+import { fetchLinearProjectCounts, type LinearProjectCounts } from '../lib/linear-project-counts.js';
+import { listLinearProjects, pickLinearProject, type LinearPick } from '../lib/linear-projects.js';
 
 /** Recursion guard: a peer answering a probe fan-out never re-fans-out itself. */
 export const PROJECTS_NO_FANOUT_ENV = 'AGENTS_PROJECTS_LOCAL';
@@ -110,6 +113,7 @@ function renderCard(
   r: ProjectSessionRollup | undefined,
   remote: ProjectRemoteSignals | undefined,
   fleet?: HostWorkspaceStatus[],
+  linear?: LinearProjectCounts,
 ): void {
   const agents = r?.agents ?? 0;
   const pct = r ? planPct(r.plan) : undefined;
@@ -117,11 +121,16 @@ function renderCard(
   console.log(`${chalk.bold(def.name)}  ${chalk.dim('·')}  ${chalk.bold(`${agents} agents`)}${planStr}`);
   if (def.description) console.log(`  ${chalk.dim(def.description)}`);
   console.log(`  ${chalk.dim('live')}     ${r ? statusBar(r) : chalk.gray('no live agents')}`);
+  if (r && r.members.length) console.log(`  ${chalk.dim('agents')}   ${formatProjectMembers(r.members)}`);
   const ships: string[] = [];
   if (remote?.mergedPrs) ships.push(chalk.green(`${remote.mergedPrs} merged (${remote.windowDays}d)`));
   if (r?.openPrs.length) ships.push(`${r.openPrs.length} open PR${r.openPrs.length === 1 ? '' : 's'}`);
   if (r?.worktrees) ships.push(`${r.worktrees} worktree${r.worktrees === 1 ? '' : 's'}`);
+  if (remote?.latestRelease) ships.push(remote.latestRelease.tag);
   if (ships.length) console.log(`  ${chalk.dim('ships')}    ${ships.join(' · ')}`);
+  if (linear) {
+    console.log(`  ${chalk.dim('linear')}   ${linear.done}/${linear.total} done · ${linear.inProgress} in progress`);
+  }
   if (r && r.tickets.length) {
     console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
   }
@@ -162,6 +171,7 @@ export function registerProjectsCommands(program: Command): void {
       agents projects status              # progress card for every project
       agents projects status rush --json  # one project, machine-readable
       agents projects status --fleet      # + per-device workspace drift over SSH
+      agents projects link rush --linear  # bind the Linear project (auto-suggest)
       agents run --project rush           # land an agent in the project
     `,
     notes: `
@@ -359,11 +369,20 @@ export function registerProjectsCommands(program: Command): void {
 
       const roll = rollupSessionsByProject(all, [...await getActiveSessions(), ...fleetSessions]);
       // Enrich only the shown projects. --no-remote still reads the local artifact
-      // log but skips the gh call (def.repo left unused → mergedPrs stays 0).
+      // log but skips the gh calls + Linear counts (both are network).
       const remote = new Map<string, ProjectRemoteSignals>();
+      const linear = new Map<string, LinearProjectCounts>();
       await Promise.all(
         defs.map(async (d) => {
-          remote.set(d.name, await enrichProjectSignals(d, windowDays, nowMs, { skipRemote: opts.remote === false }));
+          const skipRemote = opts.remote === false;
+          const [sig, counts] = await Promise.all([
+            enrichProjectSignals(d, windowDays, nowMs, { skipRemote }),
+            !skipRemote && d.linear?.projectId
+              ? fetchLinearProjectCounts(d.linear.projectId)
+              : Promise.resolve(undefined),
+          ]);
+          remote.set(d.name, sig);
+          if (counts) linear.set(d.name, counts);
         }),
       );
 
@@ -384,10 +403,13 @@ export function registerProjectsCommands(program: Command): void {
                 name: d.name,
                 agents: r?.agents ?? 0,
                 byStatus: r?.byStatus ?? {},
+                members: r?.members ?? [],
                 plan: r?.plan ?? { done: 0, total: 0 },
                 planPct: r ? planPct(r.plan) ?? null : null,
                 openPrs: r?.openPrs ?? [],
                 mergedPrs: rem?.mergedPrs ?? 0,
+                latestRelease: rem?.latestRelease ?? null,
+                linear: linear.get(d.name) ?? null,
                 tickets: r?.tickets ?? [],
                 worktrees: r?.worktrees ?? 0,
                 artifacts: rem?.artifacts ?? 0,
@@ -403,7 +425,9 @@ export function registerProjectsCommands(program: Command): void {
         );
         return;
       }
-      for (const d of defs) renderCard(d, roll.get(d.name), remote.get(d.name), opts.fleet ? fleetFor(d) : undefined);
+      for (const d of defs) {
+        renderCard(d, roll.get(d.name), remote.get(d.name), opts.fleet ? fleetFor(d) : undefined, linear.get(d.name));
+      }
       if (fleetSkipped.length > 0) process.stdout.write(formatFleetSkippedNote(fleetSkipped));
     });
 
@@ -463,6 +487,67 @@ export function registerProjectsCommands(program: Command): void {
         created++;
       }
       console.log(chalk.green(`Imported ${created} project${created === 1 ? '' : 's'}${skipped ? chalk.gray(` (${skipped} skipped)`) : ''}`));
+    });
+
+  // ---- link ----
+  projects
+    .command('link <name>')
+    .description('Attach an external tracker to a project definition (writes linear.projectId into the YAML).')
+    .option('--linear [query]', 'Bind a Linear project by exact name or id; no value auto-suggests from the def name + repo')
+    .action((name: string, opts: { linear?: string | boolean }) => {
+      const def = loadProjectDef(name);
+      if (!def) {
+        console.error(chalk.red(`No project named "${name}". List them: agents projects list`));
+        process.exit(1);
+      }
+      if (opts.linear === undefined) {
+        console.error(chalk.red('Nothing to link. Pass a tracker flag, e.g. --linear [query].'));
+        process.exit(1);
+      }
+      // Explicit user command — a missing/unauthenticated `linear` CLI is loud,
+      // unlike the best-effort card enrichment.
+      let list: ReturnType<typeof listLinearProjects>;
+      try {
+        list = listLinearProjects();
+      } catch (e) {
+        console.error(chalk.red(e instanceof Error ? e.message : String(e)));
+        process.exit(1);
+      }
+      const query = typeof opts.linear === 'string' ? opts.linear.trim() : '';
+      let pick: LinearPick;
+      if (query) {
+        pick = pickLinearProject(query, list);
+      } else {
+        // Auto-suggest from the def's own identity — the primary repo slug is
+        // the sharpest key, then the def name. Only an exact normalized match
+        // writes itself; anything weaker asks the user to disambiguate.
+        pick = { kind: 'none' };
+        for (const hint of [def.repo, def.name].filter((h): h is string => typeof h === 'string' && h.length > 0)) {
+          const d = pickLinearProject(hint, list);
+          if (d.kind === 'match') {
+            pick = d;
+            break;
+          }
+          if (pick.kind === 'none') pick = d;
+        }
+      }
+      if (pick.kind !== 'match') {
+        if (pick.kind === 'candidates') {
+          console.error(chalk.yellow(`No confident Linear match${query ? ` for "${query}"` : ` for "${def.name}"`}. Candidates:`));
+          for (const c of pick.projects) console.error(`  ${chalk.cyan(c.id)}  ${c.name}`);
+        } else {
+          console.error(chalk.yellow(`No Linear project matches${query ? ` "${query}"` : ` "${def.name}"`}. Available:`));
+          for (const c of list) console.error(`  ${chalk.cyan(c.id)}  ${c.name}`);
+        }
+        console.error(chalk.gray(`Re-run with an explicit name or id: agents projects link ${name} --linear "<name-or-id>"`));
+        process.exit(1);
+      }
+      const p = pick.project;
+      // Preserve every other field — load, set linear, write back.
+      def.linear = { projectId: p.id };
+      if (p.url) def.linear.url = p.url;
+      writeProjectDef(def);
+      console.log(chalk.green(`${def.name} → Linear project "${p.name}" (${p.id})${p.url ? ` ${p.url}` : ''}`));
     });
 
   // ---- rm ----

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -129,7 +129,7 @@ function renderCard(
   if (remote?.latestRelease) ships.push(remote.latestRelease.tag);
   if (ships.length) console.log(`  ${chalk.dim('ships')}    ${ships.join(' · ')}`);
   if (linear) {
-    console.log(`  ${chalk.dim('linear')}   ${linear.done}/${linear.total} done · ${linear.inProgress} in progress`);
+    console.log(`  ${chalk.dim('linear')}   ${linear.done}/${linear.total}${linear.truncated ? '+' : ''} done · ${linear.inProgress} in progress`);
   }
   if (r && r.tickets.length) {
     console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
@@ -543,8 +543,12 @@ export function registerProjectsCommands(program: Command): void {
         process.exit(1);
       }
       const p = pick.project;
-      // Preserve every other field — load, set linear, write back.
-      def.linear = { projectId: p.id };
+      // Preserve every other field — load, set linear, write back. Keep a
+      // previously linked url when the new CLI row carries none.
+      if (def.linear?.projectId && def.linear.projectId !== p.id) {
+        console.log(chalk.gray(`  replacing previous Linear link (${def.linear.projectId})`));
+      }
+      def.linear = { ...def.linear, projectId: p.id };
       if (p.url) def.linear.url = p.url;
       writeProjectDef(def);
       console.log(chalk.green(`${def.name} → Linear project "${p.name}" (${p.id})${p.url ? ` ${p.url}` : ''}`));

--- a/apps/cli/src/lib/linear-project-counts.test.ts
+++ b/apps/cli/src/lib/linear-project-counts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { countsFromIssuesResponse, type LinearIssuesResponse } from './linear-project-counts.js';
+
+/** A recorded Linear `issues` response shape (state types only, trimmed). */
+function response(types: (string | null | undefined)[]): LinearIssuesResponse {
+  return {
+    issues: {
+      nodes: types.map((t) => (t === undefined ? {} : { state: t === null ? null : { type: t } })),
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+  };
+}
+
+describe('countsFromIssuesResponse', () => {
+  it('groups by state type: completed → done, started → inProgress, all → total', () => {
+    const counts = countsFromIssuesResponse(
+      response([
+        'completed', 'completed', 'completed', // 3 done
+        'started', 'started', // 2 in progress
+        'unstarted', 'backlog', 'triage', 'canceled', // neither
+      ]),
+    );
+    expect(counts).toEqual({ done: 3, total: 9, inProgress: 2 });
+  });
+
+  it('an issue with no state still counts toward total', () => {
+    const counts = countsFromIssuesResponse(response([null, undefined, 'completed']));
+    expect(counts).toEqual({ done: 1, total: 3, inProgress: 0 });
+  });
+
+  it('an empty / malformed response is zeros, never a throw', () => {
+    expect(countsFromIssuesResponse({})).toEqual({ done: 0, total: 0, inProgress: 0 });
+    expect(countsFromIssuesResponse({ issues: {} })).toEqual({ done: 0, total: 0, inProgress: 0 });
+  });
+});

--- a/apps/cli/src/lib/linear-project-counts.test.ts
+++ b/apps/cli/src/lib/linear-project-counts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { countsFromIssuesResponse, type LinearIssuesResponse } from './linear-project-counts.js';
+import {
+  countsFromIssuesResponse,
+  fetchLinearProjectCounts,
+  type LinearIssuesResponse,
+} from './linear-project-counts.js';
 
 /** A recorded Linear `issues` response shape (state types only, trimmed). */
 function response(types: (string | null | undefined)[]): LinearIssuesResponse {
@@ -9,6 +13,26 @@ function response(types: (string | null | undefined)[]): LinearIssuesResponse {
       pageInfo: { hasNextPage: false, endCursor: null },
     },
   };
+}
+
+/** A paged response with an explicit cursor. */
+function page(types: string[], hasNextPage: boolean, endCursor: string | null): LinearIssuesResponse {
+  return {
+    issues: {
+      nodes: types.map((t) => ({ state: { type: t } })),
+      pageInfo: { hasNextPage, endCursor },
+    },
+  };
+}
+
+/** Scripted page fetcher: serves `pages` in order, recording the cursors it was called with. */
+function scriptedPages(pages: LinearIssuesResponse[]) {
+  const calls: Array<string | undefined> = [];
+  const fetchPage = async (_p: string, after: string | undefined) => {
+    calls.push(after);
+    return pages[calls.length - 1];
+  };
+  return { calls, fetchPage };
 }
 
 describe('countsFromIssuesResponse', () => {
@@ -31,5 +55,37 @@ describe('countsFromIssuesResponse', () => {
   it('an empty / malformed response is zeros, never a throw', () => {
     expect(countsFromIssuesResponse({})).toEqual({ done: 0, total: 0, inProgress: 0 });
     expect(countsFromIssuesResponse({ issues: {} })).toEqual({ done: 0, total: 0, inProgress: 0 });
+  });
+});
+
+describe('fetchLinearProjectCounts — pagination accumulator', () => {
+  it('concatenates pages without overlap, handing the cursor across', async () => {
+    const { calls, fetchPage } = scriptedPages([
+      page(['completed', 'started'], true, 'cur-1'),
+      page(['completed', 'backlog'], false, null),
+    ]);
+    const counts = await fetchLinearProjectCounts('proj-1', fetchPage);
+    expect(calls).toEqual([undefined, 'cur-1']);
+    expect(counts).toEqual({ done: 2, total: 4, inProgress: 1 });
+  });
+
+  it('terminates when hasNextPage is true but the cursor is null (no infinite loop)', async () => {
+    const { calls, fetchPage } = scriptedPages([page(['completed'], true, null)]);
+    const counts = await fetchLinearProjectCounts('proj-1', fetchPage);
+    expect(calls).toHaveLength(1);
+    expect(counts).toEqual({ done: 1, total: 1, inProgress: 0 });
+  });
+
+  it('hits the page cap and reports truncated instead of lying about the total', async () => {
+    const endless = page(['completed'], true, 'cur');
+    const { calls, fetchPage } = scriptedPages(Array.from({ length: 20 }, () => endless));
+    const counts = await fetchLinearProjectCounts('proj-1', fetchPage);
+    expect(calls).toHaveLength(10); // MAX_PAGES, no more
+    expect(counts).toEqual({ done: 10, total: 10, inProgress: 0, truncated: true });
+  });
+
+  it('a failed page degrades the whole enrichment to undefined (card omits the line)', async () => {
+    const fetchPage = async () => undefined;
+    expect(await fetchLinearProjectCounts('proj-1', fetchPage)).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/linear-project-counts.ts
+++ b/apps/cli/src/lib/linear-project-counts.ts
@@ -1,0 +1,120 @@
+/**
+ * Per-project Linear issue counts for the `agents projects status` card.
+ *
+ * When a project definition carries `linear.projectId` (set via
+ * `agents projects link <name> --linear`), the card shows one outcome line —
+ * `12/30 done · 5 in progress` — counted from the Linear GraphQL API by state
+ * TYPE (triage / backlog / unstarted / started / completed / canceled), never
+ * hardcoded state names, same convention as `auto-dispatch-linear.ts`.
+ *
+ * This is a best-effort card enrichment, not an explicit command: every failure
+ * (no credential, offline, API error, timeout) degrades to `undefined` and the
+ * card simply omits the line — never a hang, never a throw. `--no-remote`
+ * skips it (it's network). The API key resolves through the same chain the rest
+ * of the stack uses: $LINEAR_API_KEY → macOS Keychain (`resolveLinearApiKey`)
+ * → the linear-cli config (`~/.linear-cli/config.json` `apiKey`).
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveLinearApiKey } from './auto-dispatch-linear.js';
+
+const LINEAR_API = 'https://api.linear.app/graphql';
+/** Overall budget across all pages — the card must never hang on Linear. */
+const TIMEOUT_MS = 8_000;
+const PAGE_SIZE = 250;
+/** Hard page cap so a pathological project can't page forever within the budget. */
+const MAX_PAGES = 10;
+
+/** The counts the card renders. `total` counts every issue in the project. */
+export interface LinearProjectCounts {
+  /** Issues in a `completed`-type state. */
+  done: number;
+  /** All issues in the project (any state type, including canceled). */
+  total: number;
+  /** Issues in a `started`-type state. */
+  inProgress: number;
+}
+
+/** The GraphQL response shape this module consumes (recorded for the tests). */
+export interface LinearIssuesResponse {
+  issues?: {
+    nodes?: Array<{ state?: { type?: string } | null }>;
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+  };
+}
+
+/**
+ * Pure mapping: a Linear issues response → card counts, grouping by state
+ * type. Defensive at the boundary — a missing `issues`/`nodes` yields zeros,
+ * an issue with no state still counts toward `total`.
+ */
+export function countsFromIssuesResponse(data: LinearIssuesResponse): LinearProjectCounts {
+  const nodes = data.issues?.nodes ?? [];
+  let done = 0;
+  let inProgress = 0;
+  for (const n of nodes) {
+    const type = n?.state?.type;
+    if (type === 'completed') done++;
+    else if (type === 'started') inProgress++;
+  }
+  return { done, total: nodes.length, inProgress };
+}
+
+/** $LINEAR_API_KEY → macOS Keychain → ~/.linear-cli/config.json. Null if none. */
+function resolveApiKey(): string | null {
+  const fromChain = resolveLinearApiKey();
+  if (fromChain) return fromChain;
+  try {
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(os.homedir(), '.linear-cli', 'config.json'), 'utf8'),
+    ) as { apiKey?: string };
+    return cfg.apiKey?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch issue counts for one Linear project, paging `issues` filtered by
+ * project id. One shared AbortController bounds the WHOLE paged fetch at ~8s;
+ * any failure (no key, network, API error, abort) returns undefined so the
+ * card just omits the line.
+ */
+export async function fetchLinearProjectCounts(projectId: string): Promise<LinearProjectCounts | undefined> {
+  const apiKey = resolveApiKey();
+  if (!apiKey) return undefined;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const all: Array<{ state?: { type?: string } | null }> = [];
+    let after: string | undefined;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const res = await fetch(LINEAR_API, {
+        method: 'POST',
+        headers: { Authorization: apiKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query:
+            'query($p:ID!, $after:String){ issues(filter:{ project:{ id:{ eq:$p } } }, first:' +
+            PAGE_SIZE +
+            ', after:$after){ nodes{ state{ type } } pageInfo{ hasNextPage endCursor } } }',
+          variables: { p: projectId, after: after ?? null },
+        }),
+        signal: ctrl.signal,
+      });
+      if (!res.ok) return undefined;
+      const json = (await res.json()) as { data?: LinearIssuesResponse; errors?: unknown[] };
+      if (json.errors?.length || !json.data) return undefined;
+      all.push(...(json.data.issues?.nodes ?? []));
+      const pi = json.data.issues?.pageInfo;
+      if (!pi?.hasNextPage || !pi.endCursor) break;
+      after = pi.endCursor;
+    }
+    return countsFromIssuesResponse({ issues: { nodes: all } });
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/cli/src/lib/linear-project-counts.ts
+++ b/apps/cli/src/lib/linear-project-counts.ts
@@ -13,6 +13,10 @@
  * skips it (it's network). The API key resolves through the same chain the rest
  * of the stack uses: $LINEAR_API_KEY → macOS Keychain (`resolveLinearApiKey`)
  * → the linear-cli config (`~/.linear-cli/config.json` `apiKey`).
+ *
+ * Paging is capped (10 × 250 issues) so a pathological project can't burn the
+ * budget; a capped fetch reports `truncated: true` and the card renders the
+ * total as a lower bound (`2500+ done`), never as the complete count.
  */
 
 import * as fs from 'fs';
@@ -35,6 +39,11 @@ export interface LinearProjectCounts {
   total: number;
   /** Issues in a `started`-type state. */
   inProgress: number;
+  /**
+   * True when the page cap cut the fetch short — `total` is then a LOWER
+   * bound (rendered `2500+`), never presented as the complete count.
+   */
+  truncated?: boolean;
 }
 
 /** The GraphQL response shape this module consumes (recorded for the tests). */
@@ -80,41 +89,62 @@ function resolveApiKey(): string | null {
  * Fetch issue counts for one Linear project, paging `issues` filtered by
  * project id. One shared AbortController bounds the WHOLE paged fetch at ~8s;
  * any failure (no key, network, API error, abort) returns undefined so the
- * card just omits the line.
+ * card just omits the line. `fetchPage` is injectable for tests — the
+ * accumulator (cursor hand-off, cap) is the risky logic, not the HTTP.
  */
-export async function fetchLinearProjectCounts(projectId: string): Promise<LinearProjectCounts | undefined> {
-  const apiKey = resolveApiKey();
-  if (!apiKey) return undefined;
+export async function fetchLinearProjectCounts(
+  projectId: string,
+  fetchPage: (projectId: string, after: string | undefined, signal: AbortSignal) => Promise<LinearIssuesResponse | undefined> = fetchLinearIssuesPage,
+): Promise<LinearProjectCounts | undefined> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
   try {
     const all: Array<{ state?: { type?: string } | null }> = [];
     let after: string | undefined;
-    for (let page = 0; page < MAX_PAGES; page++) {
-      const res = await fetch(LINEAR_API, {
-        method: 'POST',
-        headers: { Authorization: apiKey, 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          query:
-            'query($p:ID!, $after:String){ issues(filter:{ project:{ id:{ eq:$p } } }, first:' +
-            PAGE_SIZE +
-            ', after:$after){ nodes{ state{ type } } pageInfo{ hasNextPage endCursor } } }',
-          variables: { p: projectId, after: after ?? null },
-        }),
-        signal: ctrl.signal,
-      });
-      if (!res.ok) return undefined;
-      const json = (await res.json()) as { data?: LinearIssuesResponse; errors?: unknown[] };
-      if (json.errors?.length || !json.data) return undefined;
-      all.push(...(json.data.issues?.nodes ?? []));
-      const pi = json.data.issues?.pageInfo;
+    let truncated = false;
+    for (let page = 0; ; page++) {
+      const data = await fetchPage(projectId, after, ctrl.signal);
+      if (!data) return undefined;
+      all.push(...(data.issues?.nodes ?? []));
+      const pi = data.issues?.pageInfo;
       if (!pi?.hasNextPage || !pi.endCursor) break;
+      if (page + 1 >= MAX_PAGES) {
+        // The cap cut the fetch short — total is a lower bound, say so.
+        truncated = true;
+        break;
+      }
       after = pi.endCursor;
     }
-    return countsFromIssuesResponse({ issues: { nodes: all } });
+    return { ...countsFromIssuesResponse({ issues: { nodes: all } }), ...(truncated ? { truncated } : {}) };
   } catch {
     return undefined;
   } finally {
     clearTimeout(timer);
   }
+}
+
+/** One real GraphQL page; undefined on any HTTP/API-level failure. */
+async function fetchLinearIssuesPage(
+  projectId: string,
+  after: string | undefined,
+  signal: AbortSignal,
+): Promise<LinearIssuesResponse | undefined> {
+  const apiKey = resolveApiKey();
+  if (!apiKey) return undefined;
+  const res = await fetch(LINEAR_API, {
+    method: 'POST',
+    headers: { Authorization: apiKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query:
+        'query($p:ID!, $after:String){ issues(filter:{ project:{ id:{ eq:$p } } }, first:' +
+        PAGE_SIZE +
+        ', after:$after){ nodes{ state{ type } } pageInfo{ hasNextPage endCursor } } }',
+      variables: { p: projectId, after: after ?? null },
+    }),
+    signal,
+  });
+  if (!res.ok) return undefined;
+  const json = (await res.json()) as { data?: LinearIssuesResponse; errors?: unknown[] };
+  if (json.errors?.length || !json.data) return undefined;
+  return json.data;
 }

--- a/apps/cli/src/lib/linear-projects.test.ts
+++ b/apps/cli/src/lib/linear-projects.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeProjectKey,
+  matchLinearProject,
+  pickLinearProject,
+  type LinearProjectLite,
+} from './linear-projects.js';
+
+// Matcher cases ported from apps/factory/src/core/linearProjects.test.ts
+// (bun:test → vitest); the two modules are kept in sync by hand.
+
+describe('normalizeProjectKey', () => {
+  it('collapses name / slug / folder to one key', () => {
+    expect(normalizeProjectKey('Agents CLI')).toBe('agentscli');
+    expect(normalizeProjectKey('phnx-labs/agents-cli')).toBe('agentscli');
+    expect(normalizeProjectKey('/Users/me/src/github.com/phnx-labs/agents-cli')).toBe('agentscli');
+    expect(normalizeProjectKey('rush_app')).toBe('rushapp');
+    expect(normalizeProjectKey('')).toBe('');
+  });
+});
+
+const PROJECTS: LinearProjectLite[] = [
+  { id: 'a', name: 'Agents CLI' },
+  { id: 'b', name: 'Rush App' },
+  { id: 'c', name: 'Prix' },
+];
+
+describe('matchLinearProject', () => {
+  it('exact normalized match wins', () => {
+    expect(matchLinearProject('phnx-labs/agents-cli', PROJECTS)?.id).toBe('a');
+    expect(matchLinearProject('rush-app', PROJECTS)?.id).toBe('b');
+  });
+
+  it('containment fallback for near names', () => {
+    // "agents-cli-web" has no exact peer; "agentscliweb" contains "agentscli" -> Agents CLI.
+    expect(matchLinearProject('agents-cli-web', PROJECTS)?.id).toBe('a');
+  });
+
+  it('no match returns undefined', () => {
+    expect(matchLinearProject('totally-unrelated', PROJECTS)).toBeUndefined();
+    expect(matchLinearProject('', PROJECTS)).toBeUndefined();
+  });
+});
+
+describe('pickLinearProject', () => {
+  it('matches an exact id', () => {
+    expect(pickLinearProject('b', PROJECTS)).toEqual({ kind: 'match', project: PROJECTS[1] });
+  });
+
+  it('matches an exact normalized name (case / separators ignored)', () => {
+    expect(pickLinearProject('agents-cli', PROJECTS)).toEqual({ kind: 'match', project: PROJECTS[0] });
+    expect(pickLinearProject('Rush App', PROJECTS)).toEqual({ kind: 'match', project: PROJECTS[1] });
+  });
+
+  it('matches a repo slug via its last segment', () => {
+    expect(pickLinearProject('phnx-labs/agents-cli', PROJECTS)).toEqual({ kind: 'match', project: PROJECTS[0] });
+  });
+
+  it('two exact-name peers are candidates, never a guess', () => {
+    const dupes = [...PROJECTS, { id: 'a2', name: 'agents cli' }];
+    const pick = pickLinearProject('Agents CLI', dupes);
+    expect(pick.kind).toBe('candidates');
+    expect((pick as { projects: LinearProjectLite[] }).projects.map((p) => p.id)).toEqual(['a', 'a2']);
+  });
+
+  it('containment-only matches come back as candidates', () => {
+    const pick = pickLinearProject('agents-cli-web', PROJECTS);
+    expect(pick).toEqual({ kind: 'candidates', projects: [PROJECTS[0]] });
+  });
+
+  it('no match is none, and an empty query is none', () => {
+    expect(pickLinearProject('totally-unrelated', PROJECTS)).toEqual({ kind: 'none' });
+    expect(pickLinearProject('   ', PROJECTS)).toEqual({ kind: 'none' });
+  });
+});

--- a/apps/cli/src/lib/linear-projects.ts
+++ b/apps/cli/src/lib/linear-projects.ts
@@ -1,0 +1,122 @@
+// Linear project matching for `agents projects link --linear`.
+//
+// A project's identity shows up three ways — a Linear project name ("Agents CLI"),
+// a GitHub repo slug ("phnx-labs/agents-cli"), and a filesystem folder
+// (".../agents-cli"). normalizeProjectKey() collapses all three to one comparison
+// key so they compare equal, and matchLinearProject() binds a repo/folder to the
+// Linear project the user most likely means.
+//
+// Ported from apps/factory/src/core/linearProjects.ts (no cross-package imports —
+// repo rule); keep the two in sync. The matcher half is PURE so it unit-tests
+// without a live `linear` binary; the `linear projects --json` shell-out lives at
+// the bottom (listLinearProjects) and fails LOUD — it's behind an explicit user
+// command, not a best-effort card enrichment.
+
+import { execFileSync } from 'child_process';
+
+/** The minimal Linear project shape the link flow needs (id + name + url). */
+export interface LinearProjectLite {
+  id: string;
+  name: string;
+  /** Project URL, when the `linear` CLI JSON carries one. Never fabricated. */
+  url?: string;
+}
+
+/**
+ * Collapse a Linear name / repo slug / folder path to one comparison key:
+ * lowercase, keep only the last path segment, strip separators.
+ *   "Agents CLI"            -> "agentscli"
+ *   "phnx-labs/agents-cli"  -> "agentscli"
+ *   "~/src/.../agents-cli"  -> "agentscli"
+ */
+export function normalizeProjectKey(s: string): string {
+  const last = s.toLowerCase().split('/').filter(Boolean).pop() ?? '';
+  return last.replace(/[-_\s.]/g, '');
+}
+
+/**
+ * Find the Linear project that best matches a repo slug or folder name.
+ * Exact normalized match first, then a containment fallback (either direction),
+ * so "agents-cli-web" still suggests "Agents CLI" when no exact peer exists.
+ */
+export function matchLinearProject(
+  slugOrName: string,
+  projects: LinearProjectLite[],
+): LinearProjectLite | undefined {
+  const key = normalizeProjectKey(slugOrName);
+  if (!key) return undefined;
+  const exact = projects.find((p) => normalizeProjectKey(p.name) === key);
+  if (exact) return exact;
+  return projects.find((p) => {
+    const pk = normalizeProjectKey(p.name);
+    return pk.length > 0 && (pk.includes(key) || key.includes(pk));
+  });
+}
+
+/** The outcome of picking one Linear project out of the workspace list. */
+export type LinearPick =
+  | { kind: 'match'; project: LinearProjectLite }
+  | { kind: 'candidates'; projects: LinearProjectLite[] }
+  | { kind: 'none' };
+
+/**
+ * Pick the Linear project a query refers to. An exact id or exact normalized
+ * name match is confident enough to write; anything weaker (several exact-name
+ * peers, or only containment matches) comes back as a candidate LIST for the
+ * user to disambiguate — the link command never guesses on a weak signal.
+ */
+export function pickLinearProject(query: string, projects: LinearProjectLite[]): LinearPick {
+  const q = query.trim();
+  if (!q) return { kind: 'none' };
+  const byId = projects.find((p) => p.id === q);
+  if (byId) return { kind: 'match', project: byId };
+  const key = normalizeProjectKey(q);
+  if (!key) return { kind: 'none' };
+  const exact = projects.filter((p) => normalizeProjectKey(p.name) === key);
+  if (exact.length === 1) return { kind: 'match', project: exact[0] };
+  if (exact.length > 1) return { kind: 'candidates', projects: exact };
+  const containment = projects.filter((p) => {
+    const pk = normalizeProjectKey(p.name);
+    return pk.length > 0 && (pk.includes(key) || key.includes(pk));
+  });
+  return containment.length > 0 ? { kind: 'candidates', projects: containment } : { kind: 'none' };
+}
+
+/**
+ * List the workspace's Linear projects via the `linear` CLI on PATH. Throws a
+ * clear error when the binary is missing, errors, or returns a shape we can't
+ * use — this backs an explicit user command, so a silent empty list would send
+ * the user down a wrong "no matches" path.
+ */
+export function listLinearProjects(): LinearProjectLite[] {
+  let out: string;
+  try {
+    out = execFileSync('linear', ['projects', '--json'], {
+      encoding: 'utf8',
+      timeout: 8000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch {
+    throw new Error(
+      'Could not list Linear projects — is the `linear` CLI installed and logged in? (`brew install linear-cli`, `linear auth login`)',
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(out);
+  } catch {
+    throw new Error('`linear projects --json` returned invalid JSON');
+  }
+  if (!Array.isArray(parsed)) throw new Error('`linear projects --json` did not return a list');
+  return parsed.flatMap((x) => {
+    if (x && typeof x === 'object' && !Array.isArray(x)) {
+      const o = x as Record<string, unknown>;
+      if (typeof o.id === 'string' && typeof o.name === 'string') {
+        const p: LinearProjectLite = { id: o.id, name: o.name };
+        if (typeof o.url === 'string') p.url = o.url;
+        return [p];
+      }
+    }
+    return [];
+  });
+}

--- a/apps/cli/src/lib/linear-projects.ts
+++ b/apps/cli/src/lib/linear-projects.ts
@@ -38,6 +38,11 @@ export function normalizeProjectKey(s: string): string {
  * Find the Linear project that best matches a repo slug or folder name.
  * Exact normalized match first, then a containment fallback (either direction),
  * so "agents-cli-web" still suggests "Agents CLI" when no exact peer exists.
+ *
+ * Kept for parity with the Factory original — the `link` command uses
+ * {@link pickLinearProject} instead: this one returns the FIRST match (silent
+ * on duplicate names), which is fine for a UI suggestion but never for a write
+ * path.
  */
 export function matchLinearProject(
   slugOrName: string,

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -153,6 +153,25 @@ describe('formatProjectMembers', () => {
   it('is empty for no members', () => {
     expect(formatProjectMembers([])).toBe('');
   });
+
+  it('collapses identical cells to one ×N cell — a same-harness fleet is one fact', () => {
+    const members: ProjectMember[] = [
+      ...Array.from({ length: 14 }, () => ({ agent: 'claude', status: 'running', host: 'zion' })),
+      { agent: 'codex', status: 'idle', host: 'mac-mini' },
+      { agent: 'claude', status: 'running', ticket: 'RUSH-2107', host: 'zion' },
+    ];
+    const line = stripAnsi(formatProjectMembers(members));
+    expect(line).toBe('claude · running @zion ×14  ·  claude · running · RUSH-2107 @zion  ·  codex · idle @mac-mini');
+  });
+
+  it('the +N tail counts members, not cells, when collapsed groups are capped', () => {
+    const members: ProjectMember[] = [
+      ...Array.from({ length: 30 }, () => ({ agent: 'claude', status: 'running' })),
+      ...Array.from({ length: MEMBERS_LINE_LIMIT }, (_, i) => ({ agent: `agent${i}`, status: 'idle' })),
+    ];
+    // 6 cells cap: [claude ×30, agent0..agent4] = 35 members shown, 1 left over.
+    expect(stripAnsi(formatProjectMembers(members)).endsWith('+1 more')).toBe(true);
+  });
 });
 
 describe('enrichProjectSignals — artifact counting from the activity log', () => {

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -2,7 +2,16 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { rollupSessionsByProject, planPct, enrichProjectSignals } from './project-status.js';
+import {
+  rollupSessionsByProject,
+  planPct,
+  enrichProjectSignals,
+  sortProjectMembers,
+  formatProjectMembers,
+  MEMBERS_LINE_LIMIT,
+  type ProjectMember,
+} from './project-status.js';
+import { stripAnsi } from './session/width.js';
 import type { ProjectDef } from './projects.js';
 import type { ActiveSession } from './session/active.js';
 
@@ -52,6 +61,28 @@ describe('rollupSessionsByProject', () => {
     expect(map.has('unrelated')).toBe(false);
   });
 
+  it('carries one member per session with agent, status, ticket, and host', () => {
+    const sessions = [
+      s({
+        cwd: path.join(HOME, 'src/rush/apps/web'),
+        kind: 'claude',
+        status: 'running',
+        ticket: { id: 'RUSH-2107' } as never,
+        machine: 'zion',
+      }),
+      s({ cwd: path.join(HOME, 'src/rush/apps/api'), kind: 'codex', status: 'idle', machine: 'mac-mini' }),
+      s({ cwd: path.join(HOME, 'src/rush'), kind: 'gemini', status: 'queued' }), // no ticket, no host
+    ];
+    const rush = rollupSessionsByProject(defs, sessions).get('rush')!;
+    expect(rush.members).toEqual([
+      { agent: 'claude', status: 'running', ticket: 'RUSH-2107', host: 'zion' },
+      { agent: 'codex', status: 'idle', host: 'mac-mini' },
+      { agent: 'gemini', status: 'queued' },
+    ]);
+    // planPct is untouched by the members extension
+    expect(planPct(rush.plan)).toBeUndefined();
+  });
+
   it('is empty when no session matches a project', () => {
     const map = rollupSessionsByProject(defs, [s({ cwd: path.join(HOME, 'elsewhere') })]);
     expect(map.size).toBe(0);
@@ -62,6 +93,65 @@ describe('planPct', () => {
   it('rounds a percentage and returns undefined for nothing tracked', () => {
     expect(planPct({ done: 5, total: 7 })).toBe(71);
     expect(planPct({ done: 0, total: 0 })).toBeUndefined();
+  });
+});
+
+describe('sortProjectMembers', () => {
+  it('orders running → idle → input_required → queued → rest, agent asc within a state', () => {
+    const members: ProjectMember[] = [
+      { agent: 'grok', status: 'unknown' },
+      { agent: 'zed', status: 'idle' },
+      { agent: 'codex', status: 'running' },
+      { agent: 'claude', status: 'running' },
+      { agent: 'gemini', status: 'input_required' },
+      { agent: 'amp', status: 'queued' },
+      { agent: 'droid', status: 'abandoned' },
+    ];
+    expect(sortProjectMembers(members).map((m) => m.agent)).toEqual([
+      'claude', // running first; agent asc within a state (claude < codex)
+      'codex',
+      'zed', // idle
+      'gemini', // input_required
+      'amp', // queued
+      'droid', // rest: status asc (abandoned < unknown)
+      'grok',
+    ]);
+  });
+
+  it('does not mutate the input', () => {
+    const members: ProjectMember[] = [
+      { agent: 'b', status: 'idle' },
+      { agent: 'a', status: 'running' },
+    ];
+    sortProjectMembers(members);
+    expect(members.map((m) => m.agent)).toEqual(['b', 'a']);
+  });
+});
+
+describe('formatProjectMembers', () => {
+  it('renders agent · status · ticket @host cells joined by a wide dot', () => {
+    const line = stripAnsi(
+      formatProjectMembers([
+        { agent: 'codex', status: 'idle', host: 'mac-mini' },
+        { agent: 'claude', status: 'running', ticket: 'RUSH-2107', host: 'zion' },
+      ]),
+    );
+    expect(line).toBe('claude · running · RUSH-2107 @zion  ·  codex · idle @mac-mini');
+  });
+
+  it('caps at MEMBERS_LINE_LIMIT with a +N more tail, sorted so the live ones show', () => {
+    const members: ProjectMember[] = Array.from({ length: MEMBERS_LINE_LIMIT + 2 }, (_, i) => ({
+      agent: `agent${i}`,
+      status: i === MEMBERS_LINE_LIMIT + 1 ? 'running' : 'idle',
+    }));
+    const line = stripAnsi(formatProjectMembers(members));
+    expect(line.startsWith(`agent${MEMBERS_LINE_LIMIT + 1} · running`)).toBe(true); // running sorts first
+    expect(line.endsWith('+2 more')).toBe(true);
+    expect(line.split('·').length).toBeGreaterThan(2);
+  });
+
+  it('is empty for no members', () => {
+    expect(formatProjectMembers([])).toBe('');
   });
 });
 

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -142,19 +142,32 @@ export function sortProjectMembers(members: ProjectMember[]): ProjectMember[] {
 export const MEMBERS_LINE_LIMIT = 6;
 
 /**
- * The `agents` line under `live`: one cell per member —
- * `claude · running · RUSH-2107 @zion` — capped at {@link MEMBERS_LINE_LIMIT}
- * with a `+N more` tail. Pure (chalk styling only); the caller adds the label.
+ * The `agents` line under `live`: one cell per DISTINCT member state —
+ * `claude · running · RUSH-2107 @zion` — with identical cells collapsed to a
+ * `×N` count (35 same-harness sessions in one state are one fact, not six
+ * truncated duplicates), capped at {@link MEMBERS_LINE_LIMIT} cells with a
+ * `+N more` tail counting members, not cells. Pure (chalk styling only); the
+ * caller adds the label.
  */
 export function formatProjectMembers(members: ProjectMember[], limit = MEMBERS_LINE_LIMIT): string {
   if (members.length === 0) return '';
-  const shown = sortProjectMembers(members).slice(0, Math.max(1, limit));
-  const cells = shown.map((m) => {
+  // Collapse identical cells — 35 same-harness sessions in the same state are
+  // one fact (`claude · running ×16`), not six truncated duplicates.
+  const counts = new Map<string, { cell: string; n: number }>();
+  for (const m of sortProjectMembers(members)) {
     const parts = [m.agent, m.status];
     if (m.ticket) parts.push(m.ticket);
-    return parts.join(' · ') + (m.host ? ` @${m.host}` : '');
-  });
-  const more = members.length - shown.length;
+    const cell = parts.join(' · ') + (m.host ? ` @${m.host}` : '');
+    const key = cell.toLowerCase();
+    const entry = counts.get(key);
+    if (entry) entry.n++;
+    else counts.set(key, { cell, n: 1 });
+  }
+  const entries = [...counts.values()];
+  const shown = entries.slice(0, Math.max(1, limit));
+  const shownMembers = shown.reduce((acc, e) => acc + e.n, 0);
+  const more = members.length - shownMembers;
+  const cells = shown.map(({ cell, n }) => (n > 1 ? `${cell} ×${n}` : cell));
   return cells.join(chalk.dim('  ·  ')) + (more > 0 ? chalk.dim(`  ·  +${more} more`) : '');
 }
 

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -14,11 +14,24 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import chalk from 'chalk';
 import type { ActiveSession, ActiveStatus } from './session/active.js';
 import { projectNameForCwd, type ProjectDef } from './projects.js';
 import { readRecentActivity } from './activity.js';
 
 const execFileAsync = promisify(execFile);
+
+/** One live agent on a project — the WHO behind the byStatus count. */
+export interface ProjectMember {
+  /** Harness name (claude / codex / …), from the session's `kind`. */
+  agent: string;
+  /** Lifecycle status (running / idle / …). */
+  status: string;
+  /** Tracker ticket the session is tied to, when any. */
+  ticket?: string;
+  /** Machine the session runs on (provenance host / fleet peer), when known. */
+  host?: string;
+}
 
 /** One project's live session rollup. */
 export interface ProjectSessionRollup {
@@ -27,6 +40,8 @@ export interface ProjectSessionRollup {
   agents: number;
   /** Count per lifecycle status. */
   byStatus: Partial<Record<ActiveStatus, number>>;
+  /** Which agents are on the project (one per matched session). */
+  members: ProjectMember[];
   /** Summed checklist progress across this project's sessions. */
   plan: { done: number; total: number };
   /** Distinct open PRs held by this project's sessions. */
@@ -38,7 +53,16 @@ export interface ProjectSessionRollup {
 }
 
 function blank(name: string): ProjectSessionRollup {
-  return { name, agents: 0, byStatus: {}, plan: { done: 0, total: 0 }, openPrs: [], tickets: [], worktrees: 0 };
+  return {
+    name,
+    agents: 0,
+    byStatus: {},
+    members: [],
+    plan: { done: 0, total: 0 },
+    openPrs: [],
+    tickets: [],
+    worktrees: 0,
+  };
 }
 
 /**
@@ -66,6 +90,10 @@ export function rollupSessionsByProject(
     }
     r.agents++;
     r.byStatus[s.status] = (r.byStatus[s.status] ?? 0) + 1;
+    const member: ProjectMember = { agent: s.kind, status: s.status };
+    if (s.ticket?.id) member.ticket = s.ticket.id;
+    if (s.machine) member.host = s.machine;
+    r.members.push(member);
     if (s.todos) {
       r.plan.done += s.todos.done;
       r.plan.total += s.todos.total;
@@ -92,7 +120,45 @@ export function planPct(plan: { done: number; total: number }): number | undefin
   return Math.round((plan.done / plan.total) * 100);
 }
 
-/** Harvested signals not on the session list: repo-global merged PRs + local artifacts, in a time window. */
+/**
+ * Display order for the members line: the states a human scans for first
+ * (running, then idle, then need-input, then queued), everything else after,
+ * status name then agent name ascending within a state.
+ */
+const MEMBER_STATUS_RANK: Record<string, number> = { running: 0, idle: 1, input_required: 2, queued: 3 };
+
+/** Sort members for the card: running first, then idle, then the rest; agent name asc within a state. */
+export function sortProjectMembers(members: ProjectMember[]): ProjectMember[] {
+  return [...members].sort((a, b) => {
+    const ra = MEMBER_STATUS_RANK[a.status] ?? 4;
+    const rb = MEMBER_STATUS_RANK[b.status] ?? 4;
+    if (ra !== rb) return ra - rb;
+    if (ra === 4 && a.status !== b.status) return a.status.localeCompare(b.status);
+    return a.agent.localeCompare(b.agent);
+  });
+}
+
+/** Cap for the members line before it collapses to `+N more`. */
+export const MEMBERS_LINE_LIMIT = 6;
+
+/**
+ * The `agents` line under `live`: one cell per member —
+ * `claude · running · RUSH-2107 @zion` — capped at {@link MEMBERS_LINE_LIMIT}
+ * with a `+N more` tail. Pure (chalk styling only); the caller adds the label.
+ */
+export function formatProjectMembers(members: ProjectMember[], limit = MEMBERS_LINE_LIMIT): string {
+  if (members.length === 0) return '';
+  const shown = sortProjectMembers(members).slice(0, Math.max(1, limit));
+  const cells = shown.map((m) => {
+    const parts = [m.agent, m.status];
+    if (m.ticket) parts.push(m.ticket);
+    return parts.join(' · ') + (m.host ? ` @${m.host}` : '');
+  });
+  const more = members.length - shown.length;
+  return cells.join(chalk.dim('  ·  ')) + (more > 0 ? chalk.dim(`  ·  +${more} more`) : '');
+}
+
+/** Harvested signals not on the session list: repo-global merged PRs + releases, local artifacts, in a time window. */
 export interface ProjectRemoteSignals {
   windowDays: number;
   /** PRs merged into the primary repo within the window (via `gh`). */
@@ -101,6 +167,8 @@ export interface ProjectRemoteSignals {
   artifacts: number;
   /** Basename of the most recent artifact, when any. */
   lastArtifact?: string;
+  /** Latest release of the PRIMARY repo (via `gh release list`), when any. */
+  latestRelease?: { tag: string; publishedAt: string };
 }
 
 /**
@@ -139,6 +207,20 @@ export async function enrichProjectSignals(
       out.mergedPrs = rows.filter((r) => r.mergedAt && Date.parse(r.mergedAt) >= sinceMs).length;
     } catch {
       /* gh missing / unauthenticated / repo not found — skip this signal */
+    }
+    // Latest release of the PRIMARY repo only (repos[] is deliberately not
+    // scanned — one release line per card). Same best-effort degradation.
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['release', 'list', '-R', def.repo, '-L', '1', '--json', 'tagName,publishedAt'],
+        { timeout: 8000, encoding: 'utf8' },
+      );
+      const rows = JSON.parse(stdout) as { tagName?: string; publishedAt?: string }[];
+      const first = rows[0];
+      if (first?.tagName) out.latestRelease = { tag: first.tagName, publishedAt: first.publishedAt ?? '' };
+    } catch {
+      /* gh missing / unauthenticated / repo has no releases — skip this signal */
     }
   }
   return out;


### PR DESCRIPTION
**feat (beta-gated subsystem extension)** — the `agents projects status` card becomes an OUTCOMES rollup, plus the agent×project cross-map and `agents projects link <name> --linear`.

## Why

At 35 agents nobody watches agents — they watch the project. The card already counted live sessions; it didn't say *which* agents are on the project, what the project *shipped*, or how its Linear project is trending. Stacked on #1818 (fleet drift), this completes the visibility layer.

## What changed

- **Agent × project cross-map** — `ProjectSessionRollup.members[]` (agent, status, ticket, host from the same ActiveSession join) rendered as an `agents` line under `live`: `claude · running ×13 · kimi · running ×3 · claude · idle · RUSH-2114 · codex · idle @mac-mini`. Identical cells collapse to `×N` (a 35-session same-harness fleet is one fact, not six truncated duplicates); capped at 6 cells, `+N more` counts members. In `--json` as `members`; under `--fleet` remote members carry their `@host`.
- **Outcomes: latest release** — `enrichProjectSignals` gains `latestRelease` via `gh release list -R <slug> -L 1` (primary repo only; same best-effort args-array + timeout pattern as the merged-PR call; `--no-remote` skips). Rendered on the `ships` line: `100 merged (7d) · v1.20.92`.
- **Outcomes: Linear counts** — new `lib/linear-project-counts.ts`: when `def.linear.projectId` is set, the card shows `363/448 done · 11 in progress`, counted from the Linear GraphQL API by state TYPE (never hardcoded state names). Pages properly (≤10×250 under one shared 8s AbortController budget — the real "Agents CLI" project has 448 issues, a single page would lie). Credential chain: `$LINEAR_API_KEY` → Keychain (`resolveLinearApiKey`) → `~/.linear-cli/config.json`. Best-effort: any failure omits the line, never a hang; `--no-remote` skips.
- **`agents projects link <name> --linear [query]`** — writes `linear.projectId` into the def. Ports the PURE matcher from `apps/factory/src/core/linearProjects.ts` into `apps/cli/src/lib/linear-projects.ts` (no cross-package import — repo rule): no value → auto-suggest from def name + repo slug (one confident exact match wins; ambiguity prints candidates + exits 1 with guidance); a query matching an exact normalized name or id links directly. Missing/unauthenticated `linear` CLI is LOUD here (explicit command), unlike the card enrichment.

Docs (`11-projects.md`: members/release/linear lines, `link` in the surface table, "Not yet" updated) + changelog fragment in the diff.

## Run evidence (this branch, live sessions + real Linear)

Captured run image: `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/projects-outcomes-matrix-run.png`

`projects link agentic --linear` auto-suggested `Agents CLI (8eb8f5b1-…)` and wrote the def (all other fields preserved, no URL fabricated — the CLI JSON carries none). The card then renders the collapsed members line, `ships 100 merged (7d) · v1.20.92`, and `linear 363/448 done · 11 in progress`. `--no-remote` omits both network lines; `--json` carries `members`, `latestRelease`, `linear`.

## Tests

80 across the touched suites: members rollup + sort + collapse + capped-tail math, the ported matcher cases, counts-from-response mapping (recorded shape, no live network), `pickLinearProject` confidence/ambiguity paths. `tsc --noEmit` clean.
