### PR TITLE
feat(share): content-type static media so screenshots render inline

### DIFF
--- a/apps/cli/.changelog/next/share-content-type-media.md
+++ b/apps/cli/.changelog/next/share-content-type-media.md
@@ -1,0 +1,8 @@
+- **`agents share` serves screenshots and recordings with a real content-type.**
+  Publishing a PNG/JPEG/GIF/WebP/AVIF image, an MP4/MOV/WebM video, or a PDF now
+  sets the matching `content-type` instead of `application/octet-stream`. GitHub's
+  image proxy (camo) only renders an inline `![](url)` when the asset is served as
+  a real image/video type, so this is what lets an agent drop a screenshot or a
+  screen recording straight into a PR body via `agents share <file>`. HTML, SVG,
+  CSS, JS, JSON, and text were already typed correctly. Source:
+  `apps/cli/src/lib/share/publish.ts`.

--- a/apps/cli/docs/share.md
+++ b/apps/cli/docs/share.md
@@ -66,6 +66,13 @@ agent makes plan.html
   Chromium via the CLI's browser detector, with a managed-Chromium fallback), so there's
   no central render service and no extra cost. No headless browser available → the cover
   is skipped and the plain link still publishes. Opt out with `--no-cover`.
+- **Static media, not just HTML.** `agents share <file>` publishes any static asset —
+  a PNG/JPEG/GIF/WebP/AVIF screenshot, an MP4/MOV/WebM screen recording, a PDF — and
+  serves it with the matching `content-type` (not `application/octet-stream`). That is
+  what lets an agent embed visual PR evidence: GitHub's image proxy (camo) only renders
+  an inline `![](url)` when the asset is served as a real image/video type, so a shared
+  screenshot or recording drops straight into a PR body. Media publishes carry no OG
+  cover (that is an HTML-only step).
 - **Plan-render automation.** Hooks that render plans can run
   `agents share <plan.html> --json` after writing the HTML and read the returned
   `{ "url", "coverUrl", "expiresAt" }` object. The human output still prints the URL on

--- a/apps/cli/src/lib/share/publish.test.ts
+++ b/apps/cli/src/lib/share/publish.test.ts
@@ -169,6 +169,40 @@ describe('publishToEndpoint', () => {
     }
   });
 
+  it('serves static media with a real content-type so it renders inline (not octet-stream)', async () => {
+    // GitHub's camo image proxy only renders an inline `![](url)` when the asset is
+    // served with an image/video content-type; octet-stream is refused. Screenshots
+    // and recordings uploaded as PR evidence must therefore carry the right type.
+    const dir = mkdtempSync(join(tmpdir(), 'agents-share-media-'));
+    const cases: Array<[string, string]> = [
+      ['shot.png', 'image/png'],
+      ['before.jpg', 'image/jpeg'],
+      ['flow.gif', 'image/gif'],
+      ['ui.webp', 'image/webp'],
+      ['demo.mp4', 'video/mp4'],
+      ['capture.mov', 'video/quicktime'],
+    ];
+    for (const [name, expected] of cases) {
+      const filePath = join(dir, name);
+      writeFileSync(filePath, Buffer.from([0x00, 0x01, 0x02]));
+      let contentType = '';
+      await publishToEndpoint(
+        filePath,
+        { baseUrl: 'https://share.example', token: 'secret-token' },
+        {
+          slug: 'media',
+          githubUser: 'octocat',
+          cover: false,
+          uploader: async (_url, _body, headers) => {
+            contentType = headers['content-type'];
+            return { ok: true, status: 200 };
+          },
+        },
+      );
+      expect(contentType, name).toBe(expected);
+    }
+  });
+
   it('injects the analytics beacon when a token is provided', async () => {
     const htmlPath = join(mkdtempSync(join(tmpdir(), 'agents-share-analytics-')), 'plan.html');
     writeFileSync(htmlPath, '<!doctype html><html><head></head><body>hi</body></html>');

--- a/apps/cli/src/lib/share/publish.ts
+++ b/apps/cli/src/lib/share/publish.ts
@@ -122,6 +122,20 @@ function guessContentType(filePath: string): string {
   if (/\.js$/i.test(filePath)) return 'text/javascript; charset=utf-8';
   if (/\.json$/i.test(filePath)) return 'application/json';
   if (/\.svg$/i.test(filePath)) return 'image/svg+xml';
+  // Raster images + video: agents publish screenshots and screen recordings as PR
+  // evidence, and GitHub's image proxy (camo) only renders an inline `![](url)` when
+  // the asset is served with a real image/video content-type — octet-stream is
+  // refused. Type them so the share URL embeds instead of downloading.
+  if (/\.png$/i.test(filePath)) return 'image/png';
+  if (/\.jpe?g$/i.test(filePath)) return 'image/jpeg';
+  if (/\.gif$/i.test(filePath)) return 'image/gif';
+  if (/\.webp$/i.test(filePath)) return 'image/webp';
+  if (/\.avif$/i.test(filePath)) return 'image/avif';
+  if (/\.ico$/i.test(filePath)) return 'image/x-icon';
+  if (/\.mp4$/i.test(filePath)) return 'video/mp4';
+  if (/\.mov$/i.test(filePath)) return 'video/quicktime';
+  if (/\.webm$/i.test(filePath)) return 'video/webm';
+  if (/\.pdf$/i.test(filePath)) return 'application/pdf';
   if (/\.txt$|\.md$/i.test(filePath)) return 'text/plain; charset=utf-8';
   return 'application/octet-stream';
 }


### PR DESCRIPTION
**test-verified backend change** — no UI surface.

## What

`agents share <file>` publishes *any* static asset, but `guessContentType`
(`apps/cli/src/lib/share/publish.ts`) only typed HTML/CSS/JS/JSON/SVG/text and fell
through to `application/octet-stream` for raster images and video. GitHub's image
proxy (**camo**) only renders an inline `![](url)` when the asset is served with a
real image/video `content-type` — `octet-stream` is refused — so a shared PNG
screenshot or MP4 recording *downloaded* instead of embedding. That is exactly the
PR-evidence path agents need: drop a screenshot straight into a PR body.

## Change

- Type `png / jpg / jpeg / gif / webp / avif / ico`, `mp4 / mov / webm`, and `pdf`.
- Unit test PUTs a real file of each media kind through the actual `publishToEndpoint`
  path and asserts the served `content-type`.
- `docs/share.md` gains a "Static media, not just HTML" bullet; changelog fragment added.

## Run proof

```
$ bunx vitest run src/lib/share/publish.test.ts
 ✓ publishToEndpoint > serves static media with a real content-type so it renders inline (not octet-stream)
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Enables the agent-rules change (routing PR media through `agents share`) in
`phnx-labs/.agents-system`.
