### PR TITLE
fix(sessions): stop --active --local from dialing remote-host teammates over ssh

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2118.md
+++ b/apps/cli/.changelog/next/RUSH-2118.md
@@ -1,0 +1,17 @@
+- **`agents sessions --active --local` no longer dials remote-host teammates
+  over ssh (RUSH-2118).** `--local` is supposed to mean this-machine-only, but
+  the underlying `AgentManager` poll still fired a real ssh round-trip for
+  every teammate dispatched via `agents teams add --device` — even a teammate
+  that had already finished. On a box with 30 completed remote-host teammates
+  that measured out to 180 real `ssh` execve calls (6 per teammate: two ssh
+  calls in `syncRemoteMirror`, run three times per poll) and a ~4.3s
+  `--active --local` call. A `--local` query now reads a remote-host
+  teammate's last-persisted `meta.json` state instead of dialing it, and a
+  teammate that has already reached a terminal status (completed/failed/
+  stopped) is never re-dialed by ANY `--active` query, local or not — its
+  final log bytes and exit code were already captured on the poll that
+  resolved it. Source: `apps/cli/src/lib/teams/agents.ts`
+  (`syncRemoteMirror`, `readNewEvents`, `updateStatusFromProcess`,
+  `AgentManager`), `apps/cli/src/lib/session/active.ts` (`listTeamsActive`,
+  `getActiveSessions`), `apps/cli/src/commands/sessions.ts`
+  (`gatherActiveSessions`).

--- a/apps/cli/.changelog/next/RUSH-2118.md
+++ b/apps/cli/.changelog/next/RUSH-2118.md
@@ -1,17 +1,20 @@
-- **`agents sessions --active --local` no longer dials remote-host teammates
-  over ssh (RUSH-2118).** `--local` is supposed to mean this-machine-only, but
-  the underlying `AgentManager` poll still fired a real ssh round-trip for
-  every teammate dispatched via `agents teams add --device` — even a teammate
-  that had already finished. On a box with 30 completed remote-host teammates
-  that measured out to 180 real `ssh` execve calls (6 per teammate: two ssh
-  calls in `syncRemoteMirror`, run three times per poll) and a ~4.3s
+- **`agents sessions --local` no longer dials remote-host teammates over ssh,
+  in the default listing or `--active` (RUSH-2118).** `--local` is supposed to
+  mean this-machine-only, but the underlying `AgentManager` poll still fired a
+  real ssh round-trip for every teammate dispatched via
+  `agents teams add --device` — even a teammate that had already finished.
+  On a box with 30 completed remote-host teammates that measured out to 180
+  real `ssh` execve calls (6 per teammate: two ssh calls in
+  `syncRemoteMirror`, run three times per poll) and a ~4.3s
   `--active --local` call. A `--local` query now reads a remote-host
   teammate's last-persisted `meta.json` state instead of dialing it, and a
   teammate that has already reached a terminal status (completed/failed/
   stopped) is never re-dialed by ANY `--active` query, local or not — its
   final log bytes and exit code were already captured on the poll that
-  resolved it. Source: `apps/cli/src/lib/teams/agents.ts`
+  resolved it. The same gate also covers the bare default listing's
+  live-glyph enrichment (`maybeLiveIndex`), which the `--local` help text
+  already promised but didn't honor. Source: `apps/cli/src/lib/teams/agents.ts`
   (`syncRemoteMirror`, `readNewEvents`, `updateStatusFromProcess`,
   `AgentManager`), `apps/cli/src/lib/session/active.ts` (`listTeamsActive`,
   `getActiveSessions`), `apps/cli/src/commands/sessions.ts`
-  (`gatherActiveSessions`).
+  (`gatherActiveSessions`, `maybeLiveIndex`).

--- a/apps/cli/.changelog/next/RUSH-2118.md
+++ b/apps/cli/.changelog/next/RUSH-2118.md
@@ -11,10 +11,13 @@
   teammate that has already reached a terminal status (completed/failed/
   stopped) is never re-dialed by ANY `--active` query, local or not — its
   final log bytes and exit code were already captured on the poll that
-  resolved it. The same gate also covers the bare default listing's
-  live-glyph enrichment (`maybeLiveIndex`), which the `--local` help text
-  already promised but didn't honor. Source: `apps/cli/src/lib/teams/agents.ts`
+  resolved it. The same gate now covers every `--local` surface: the bare
+  default listing's live-glyph enrichment (`maybeLiveIndex`) and `--preview`
+  (`renderSessionPreview`, freely combinable with `--local`) both called the
+  local-only `getActiveSessions()` with no `localOnly` threaded through,
+  despite the `--local` help text already promising this-machine-only for
+  all of them. Source: `apps/cli/src/lib/teams/agents.ts`
   (`syncRemoteMirror`, `readNewEvents`, `updateStatusFromProcess`,
   `AgentManager`), `apps/cli/src/lib/session/active.ts` (`listTeamsActive`,
   `getActiveSessions`), `apps/cli/src/commands/sessions.ts`
-  (`gatherActiveSessions`, `maybeLiveIndex`).
+  (`gatherActiveSessions`, `maybeLiveIndex`, `renderSessionPreview`).

--- a/apps/cli/src/commands/sessions.local-live-index.test.ts
+++ b/apps/cli/src/commands/sessions.local-live-index.test.ts
@@ -1,23 +1,30 @@
 /**
- * RUSH-2118 follow-up (prix-cloud review on PR #1827): the `--local` help
- * text promises "this machine only" for BOTH the default listing and
- * `--active` (sessions.ts `--local` option help). The `--active` path was
- * fixed to never dial a remote-host teammate under `--local`, but the
- * DEFAULT (non `--active`) listing enriches every row via `maybeLiveIndex()`,
- * which called the local-only `getActiveSessions()` with no `localOnly`
- * threaded through — so a bare `agents sessions --local` still fired an ssh
- * round-trip per remote-host teammate.
+ * RUSH-2118 follow-up (prix-cloud review on PR #1827, two rounds): the
+ * `--local` help text promises "this machine only" for BOTH the default
+ * listing and `--active` (sessions.ts `--local` option help). The `--active`
+ * path was fixed first to never dial a remote-host teammate under `--local`,
+ * but two more call sites called the local-only `getActiveSessions()` with no
+ * `localOnly` threaded through, each still firing a real ssh round-trip:
+ *
+ *   1. `maybeLiveIndex()` — enriches every row of the bare (non `--active`)
+ *      listing with a live glyph/preview.
+ *   2. `renderSessionPreview()` — backs `--preview <id>`, which is freely
+ *      combinable with `--local` (no mutual exclusion), so
+ *      `agents sessions --local --preview <id>` reached it too.
  *
  * HOME is pinned to a temp dir BEFORE importing anything that resolves
- * `~/.agents` (teams/agents.ts, sessions.ts), so AgentManager's default
- * construction (no explicit baseDir — `maybeLiveIndex` has no way to inject
- * one) reads/writes under our temp fixture instead of the real fleet. Only
- * the ssh network boundary is stubbed; AgentManager/AgentProcess run for real.
+ * `~/.agents` (teams/agents.ts, sessions.ts) or `~/.claude` (discover.ts), so
+ * AgentManager's default construction (no explicit baseDir — neither
+ * `maybeLiveIndex` nor `renderSessionPreview` has a way to inject one) and
+ * `discoverSessions()`'s filesystem scan both read/write under our temp
+ * fixture instead of the real fleet. Only the ssh network boundary is
+ * stubbed; AgentManager/AgentProcess/discoverSessions run for real.
  */
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as crypto from 'crypto';
 
 const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sessions-local-live-index-home-'));
 const originalHome = process.env.HOME;
@@ -36,7 +43,7 @@ vi.mock('../lib/ssh-exec.js', async () => {
   return { ...actual, sshExec: sshExecMock, sshExecRaw: sshExecRawMock };
 });
 
-const { maybeLiveIndex } = await import('./sessions.js');
+const { maybeLiveIndex, renderSessionPreview } = await import('./sessions.js');
 const { AgentProcess, AgentStatus } = await import('../lib/teams/agents.js');
 
 afterEach(() => {
@@ -70,6 +77,31 @@ async function makeRemoteTeammate(id: string): Promise<void> {
   await agent.saveMeta();
 }
 
+/**
+ * Minimal discoverable Claude transcript so `discoverSessions()` (which
+ * `renderSessionPreview` calls) resolves a real session for `query` to key
+ * `--preview` off. Mirrors `writeClaudeSession` in sessions.test.ts.
+ */
+function writeClaudeSession(sessionId: string, cwd: string): void {
+  fs.mkdirSync(cwd, { recursive: true });
+  const projectKey = cwd.replace(/[/.]/g, '-');
+  const sessionsDir = path.join(fakeHome, '.claude', 'projects', projectKey);
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sessionsDir, `${sessionId}.jsonl`),
+    JSON.stringify({
+      type: 'user',
+      timestamp: new Date().toISOString(),
+      cwd,
+      sessionId,
+      version: '2.1.110',
+      gitBranch: 'main',
+      message: { role: 'user', content: 'RUSH-2118 preview fixture' },
+    }) + '\n',
+    'utf-8',
+  );
+}
+
 describe('maybeLiveIndex --local (RUSH-2118 default-listing gap)', () => {
   it('a bare `agents sessions --local` (no --active) issues zero ssh for a remote-host teammate', async () => {
     await makeRemoteTeammate('remote-running-local');
@@ -97,5 +129,41 @@ describe('maybeLiveIndex --local (RUSH-2118 default-listing gap)', () => {
     // running remote teammate's log — proves --local is the actual gate, not
     // some accidental global disablement.
     expect(sshExecRawMock).toHaveBeenCalled();
+  });
+});
+
+describe('renderSessionPreview --local (RUSH-2118 --preview gap)', () => {
+  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  afterAll(() => consoleLogSpy.mockRestore());
+
+  it('`agents sessions --local --preview <id>` issues zero ssh for a remote-host teammate', async () => {
+    const sessionId = crypto.randomUUID();
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'rush2118-preview-cwd-'));
+    writeClaudeSession(sessionId, cwd);
+    await makeRemoteTeammate('remote-running-preview-local');
+
+    sshExecMock.mockReturnValue({ code: 0, stdout: '', stderr: '' });
+    sshExecRawMock.mockReturnValue({ code: 0, stdout: Buffer.alloc(0), stderr: '' });
+
+    await renderSessionPreview(sessionId, { local: true });
+
+    expect(sshExecMock).not.toHaveBeenCalled();
+    expect(sshExecRawMock).not.toHaveBeenCalled();
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('sanity: `agents sessions --preview <id>` WITHOUT --local still dials the remote-host teammate', async () => {
+    const sessionId = crypto.randomUUID();
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'rush2118-preview-cwd-'));
+    writeClaudeSession(sessionId, cwd);
+    await makeRemoteTeammate('remote-running-preview-nonlocal');
+
+    sshExecMock.mockReturnValue({ code: 0, stdout: '', stderr: '' });
+    sshExecRawMock.mockReturnValue({ code: 0, stdout: Buffer.alloc(0), stderr: '' });
+
+    await renderSessionPreview(sessionId, {});
+
+    expect(sshExecRawMock).toHaveBeenCalled();
+    fs.rmSync(cwd, { recursive: true, force: true });
   });
 });

--- a/apps/cli/src/commands/sessions.local-live-index.test.ts
+++ b/apps/cli/src/commands/sessions.local-live-index.test.ts
@@ -1,0 +1,101 @@
+/**
+ * RUSH-2118 follow-up (prix-cloud review on PR #1827): the `--local` help
+ * text promises "this machine only" for BOTH the default listing and
+ * `--active` (sessions.ts `--local` option help). The `--active` path was
+ * fixed to never dial a remote-host teammate under `--local`, but the
+ * DEFAULT (non `--active`) listing enriches every row via `maybeLiveIndex()`,
+ * which called the local-only `getActiveSessions()` with no `localOnly`
+ * threaded through — so a bare `agents sessions --local` still fired an ssh
+ * round-trip per remote-host teammate.
+ *
+ * HOME is pinned to a temp dir BEFORE importing anything that resolves
+ * `~/.agents` (teams/agents.ts, sessions.ts), so AgentManager's default
+ * construction (no explicit baseDir — `maybeLiveIndex` has no way to inject
+ * one) reads/writes under our temp fixture instead of the real fleet. Only
+ * the ssh network boundary is stubbed; AgentManager/AgentProcess run for real.
+ */
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sessions-local-live-index-home-'));
+const originalHome = process.env.HOME;
+process.env.HOME = fakeHome;
+fs.mkdirSync(path.join(fakeHome, '.agents'), { recursive: true });
+
+const { sshExecMock, sshExecRawMock } = vi.hoisted(() => ({
+  sshExecMock: vi.fn(),
+  sshExecRawMock: vi.fn(),
+}));
+
+// Keep everything else in ssh-exec.js real; only the two functions that
+// actually reach the network are stubbed.
+vi.mock('../lib/ssh-exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/ssh-exec.js')>('../lib/ssh-exec.js');
+  return { ...actual, sshExec: sshExecMock, sshExecRaw: sshExecRawMock };
+});
+
+const { maybeLiveIndex } = await import('./sessions.js');
+const { AgentProcess, AgentStatus } = await import('../lib/teams/agents.js');
+
+afterEach(() => {
+  sshExecMock.mockReset();
+  sshExecRawMock.mockReset();
+});
+
+afterAll(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(fakeHome, { recursive: true, force: true });
+});
+
+/** A remote-host teammate (dispatched via `agents teams add --device`): no
+ * local pid, lifecycle lives entirely on the host via hostName/hostTarget. */
+async function makeRemoteTeammate(id: string): Promise<void> {
+  const agent = new AgentProcess(
+    id, 'dist-team', 'claude', 'do a thing',
+    null, 'plan', null, AgentStatus.RUNNING, new Date(), null,
+  );
+  agent.hostName = 'fake-device';
+  agent.hostTarget = 'fake-device.tail1a85a1.ts.net';
+  agent.repoPath = '/home/fake/repo';
+  agent.remotePid = 4242;
+  // A real remote teammate captures this off its first stream event; without
+  // it the row has no id to key `indexActiveBySessionId` on and gets dropped
+  // — set it directly so the row survives into the live index for asserting on.
+  agent.remoteSessionId = `${id}-ffffffff-ffff-ffff-ffff-ffffffffffff`;
+  agent.remoteLog = '$HOME/.agents/.cache/hosts/aaaaaaaa.log';
+  agent.remoteExit = '$HOME/.agents/.cache/hosts/aaaaaaaa.exit';
+  agent.remoteLogOffset = 0;
+  await agent.saveMeta();
+}
+
+describe('maybeLiveIndex --local (RUSH-2118 default-listing gap)', () => {
+  it('a bare `agents sessions --local` (no --active) issues zero ssh for a remote-host teammate', async () => {
+    await makeRemoteTeammate('remote-running-local');
+
+    sshExecMock.mockReturnValue({ code: 0, stdout: '', stderr: '' });
+    sshExecRawMock.mockReturnValue({ code: 0, stdout: Buffer.alloc(0), stderr: '' });
+
+    const index = await maybeLiveIndex({ local: true } as any);
+
+    expect(sshExecMock).not.toHaveBeenCalled();
+    expect(sshExecRawMock).not.toHaveBeenCalled();
+    // The teammate still shows up — read from cached meta.json, not dropped.
+    expect(index?.size ?? 0).toBeGreaterThan(0);
+  });
+
+  it('sanity: without --local, the same remote-host teammate DOES get dialed', async () => {
+    await makeRemoteTeammate('remote-running-nonlocal');
+
+    sshExecMock.mockReturnValue({ code: 0, stdout: '', stderr: '' });
+    sshExecRawMock.mockReturnValue({ code: 0, stdout: Buffer.alloc(0), stderr: '' });
+
+    await maybeLiveIndex({} as any);
+
+    // pullRemoteLogDelta (hosts/progress.ts) is the ssh call that mirrors a
+    // running remote teammate's log — proves --local is the actual gate, not
+    // some accidental global disablement.
+    expect(sshExecRawMock).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1352,9 +1352,9 @@ function canonicalSessionsCommand(query: string | undefined, options: SessionsOp
 
 /** Resolve a session by id/query globally and print its compact preview (no pager).
  * Backs `--preview` — the fast path for the "peek before resume" hot loop. */
-async function renderSessionPreview(
+export async function renderSessionPreview(
   query: string,
-  scope: { agent?: string; project?: string },
+  scope: { agent?: string; project?: string; local?: boolean },
 ): Promise<void> {
   const discovered = await discoverSessions({ all: true, cwd: process.cwd(), limit: 5000 });
   const pool = applyScopeFilters(discovered, scope);
@@ -1369,9 +1369,11 @@ async function renderSessionPreview(
   }
   // Lead with the live status when the session is still running, so the preview
   // says working / waiting / idle up front — not just the historical transcript.
+  // `--local --preview` is freely combinable with `--local` (RUSH-2118): thread
+  // it through so this probe never dials a remote-host teammate either.
   let live: ActiveSession | undefined;
   try {
-    live = indexActiveBySessionId(await getActiveSessions()).get(session.id);
+    live = indexActiveBySessionId(await getActiveSessions({ localOnly: scope.local === true })).get(session.id);
   } catch { /* plain preview on any probe failure */ }
   const headline = formatLiveStatusHeadline(live, isFavorite(session.id));
   if (headline) console.log(headline);
@@ -1533,7 +1535,7 @@ async function sessionsAction(
       console.error(chalk.red('--preview requires a session id or query.'));
       process.exit(1);
     }
-    await renderSessionPreview(query, { agent: options.agent, project: options.project });
+    await renderSessionPreview(query, { agent: options.agent, project: options.project, local: options.local });
     return;
   }
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -1166,7 +1166,11 @@ export async function gatherActiveSessions(
   const self = machineId();
   // An explicit --host/--device list scopes the view: seed local sessions only
   // when no hosts are named, or when this machine is one of the named targets.
-  const local = shouldIncludeLocal(opts.hosts, self) ? await getActiveSessions() : [];
+  // `localOnly: opts.local` (RUSH-2118) keeps a `--local` query from dialing a
+  // remote-host teammate over ssh even for this machine's OWN local gather —
+  // "this machine only" must mean zero ssh, not just "skip the cross-machine
+  // device fan-out below".
+  const local = shouldIncludeLocal(opts.hosts, self) ? await getActiveSessions({ localOnly: opts.local }) : [];
   for (const s of local) if (!s.machine) s.machine = self;
 
   let remoteDeviceCount = 0;

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -2100,10 +2100,14 @@ function treeSessionRow(session: SessionMeta, live?: ActiveSession): string {
  * not a hot loop, so the `ps`/`lsof` cost is acceptable; `--no-live` is the
  * escape hatch. Never throws — a probe failure just yields a plain listing.
  */
-async function maybeLiveIndex(options: SessionsOptions): Promise<Map<string, ActiveSession> | undefined> {
+export async function maybeLiveIndex(options: SessionsOptions): Promise<Map<string, ActiveSession> | undefined> {
   if (options.live === false || options.json) return undefined;
   try {
-    return indexActiveBySessionId(await getActiveSessions());
+    // `--local` promises "this machine only" for the default listing too (see
+    // the `--local` help text), so it must gate the live-enrichment probe the
+    // same way `--active --local` does — never dial a remote-host teammate
+    // over ssh here either (RUSH-2118).
+    return indexActiveBySessionId(await getActiveSessions({ localOnly: options.local === true }));
   } catch {
     return undefined;
   }

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -337,6 +337,14 @@ export function activeStatusFromCloudStatus(status: CloudTaskStatus): ActiveStat
 export interface ActiveQueryOptions {
   /** Skip the `ps` scan for ad-hoc headless agents. */
   skipHeadless?: boolean;
+  /**
+   * A `--local` query: this machine only. Never dial a remote-host teammate
+   * (one dispatched via `agents teams add --device`) over ssh — report its
+   * last-persisted meta.json state instead of polling it. RUSH-2118: without
+   * this, `agents sessions --active --local` still fired one ssh round-trip
+   * per remote-host teammate (finished or not) on every call.
+   */
+  localOnly?: boolean;
 }
 
 const LIVE_TERMINALS_FILE = path.join(getTerminalsDir(), 'live-terminals.json');
@@ -985,9 +993,13 @@ export function summarizeMission(prompt: string | null | undefined): string | un
   return cleaned.length > 80 ? `${cleaned.slice(0, 79)}…` : cleaned;
 }
 
-/** Live teams teammates. Reuses AgentManager which already polls PIDs via `kill -0`. */
-export async function listTeamsActive(): Promise<ActiveSession[]> {
-  const mgr = new AgentManager();
+/**
+ * Live teams teammates. Reuses AgentManager which already polls PIDs via
+ * `kill -0`. `localOnly` (RUSH-2118) skips the ssh round-trip AgentManager
+ * would otherwise issue for every distributed (remote-host) teammate.
+ */
+export async function listTeamsActive(opts: { localOnly?: boolean } = {}): Promise<ActiveSession[]> {
+  const mgr = new AgentManager(undefined, undefined, undefined, undefined, undefined, opts.localOnly ?? false);
   const running = await mgr.listRunning();
   return running.map((a): ActiveSession => {
     // The teammate's OWN transcript is `remoteSessionId` (captured from its first
@@ -1751,7 +1763,7 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
 export async function getActiveSessions(opts: ActiveQueryOptions = {}): Promise<ActiveSession[]> {
   const [tmuxAgents, teams, terminals, cloud] = await Promise.all([
     listTmuxAgentSessions().catch(() => [] as ActiveSession[]),
-    listTeamsActive().catch(() => [] as ActiveSession[]),
+    listTeamsActive({ localOnly: opts.localOnly }).catch(() => [] as ActiveSession[]),
     listTerminalsActive().catch(() => [] as ActiveSession[]),
     Promise.resolve(listCloudActive()),
   ]);

--- a/apps/cli/src/lib/teams/agents.remote-poll.test.ts
+++ b/apps/cli/src/lib/teams/agents.remote-poll.test.ts
@@ -1,0 +1,122 @@
+/**
+ * RUSH-2118: `agents sessions --active --local` fired ~1 ssh round-trip per
+ * remote-host teammate (finished or not) on EVERY poll — `updateStatusFromProcess`
+ * → `readNewEvents` → `syncRemoteMirror` dialed the host unconditionally, and
+ * `--local` never gated it at all. On a box with 30 completed teammates that was
+ * ~60 real ssh calls (loadExistingAgents polls once at construction, listAll polls
+ * again) for a query that is supposed to be this-machine-only.
+ *
+ * These tests exercise the real AgentManager/AgentProcess lifecycle against a temp
+ * meta.json dir (no mocking of the code under test) and stub only the ssh network
+ * boundary, asserting it is NEVER called for the two cases the fix targets:
+ *   (a) a `--local` (localOnly) query, even against a still-RUNNING remote teammate
+ *   (b) a terminal-status remote teammate, --local or not
+ * A third "sanity" test proves the fix didn't over-broadly kill polling for a
+ * genuinely running remote teammate under a normal (non --local) query.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const { sshExecMock, sshExecRawMock } = vi.hoisted(() => ({
+  sshExecMock: vi.fn(),
+  sshExecRawMock: vi.fn(),
+}));
+
+// Keep everything else in ssh-exec.js real (shellQuote, assertValidSshTarget,
+// …); only the two functions that actually reach the network are stubbed.
+vi.mock('../ssh-exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../ssh-exec.js')>('../ssh-exec.js');
+  return { ...actual, sshExec: sshExecMock, sshExecRaw: sshExecRawMock };
+});
+
+import { AgentManager, AgentProcess, AgentStatus } from './agents.js';
+
+function tmpBase(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agents-remote-poll-'));
+}
+
+/** A remote-host teammate (dispatched via `agents teams add --device`): no local
+ * pid, lifecycle lives entirely on the host via hostName/hostTarget/remoteLog. */
+async function makeRemoteTeammate(base: string, id: string, status: AgentStatus): Promise<AgentProcess> {
+  const agent = new AgentProcess(
+    id, 'dist-team', 'claude', 'do a thing',
+    null, 'plan', null, status, new Date(),
+    status === AgentStatus.RUNNING ? null : new Date(), base,
+  );
+  agent.hostName = 'yosemite-s0';
+  agent.hostTarget = 'yosemite-s0.tail1a85a1.ts.net';
+  agent.repoPath = '/home/muqsit/.agents/repos/dist-team';
+  agent.remotePid = 4242;
+  agent.remoteLog = '$HOME/.agents/.cache/hosts/aaaaaaaa.log';
+  agent.remoteExit = '$HOME/.agents/.cache/hosts/aaaaaaaa.exit';
+  agent.remoteLogOffset = 0;
+  await agent.saveMeta();
+  return agent;
+}
+
+describe('remote-host teammate polling (RUSH-2118)', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+    sshExecMock.mockReset();
+    sshExecRawMock.mockReset();
+  });
+
+  it('a --local (localOnly) query issues zero ssh for a still-RUNNING remote teammate', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    await makeRemoteTeammate(base, 'remote-running', AgentStatus.RUNNING);
+
+    sshExecMock.mockReturnValue({ code: 0, stdout: '', stderr: '' });
+    sshExecRawMock.mockReturnValue({ code: 0, stdout: Buffer.alloc(0), stderr: '' });
+
+    const mgr = new AgentManager(50, base, undefined, undefined, undefined, true);
+    const all = await mgr.listAll();
+
+    expect(all).toHaveLength(1);
+    // Cached meta.json state stands as-is — never dialed, never overwritten.
+    expect(all[0].status).toBe(AgentStatus.RUNNING);
+    expect(sshExecMock).not.toHaveBeenCalled();
+    expect(sshExecRawMock).not.toHaveBeenCalled();
+  });
+
+  it('a terminal-status remote teammate is never re-polled, --local or not', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    await makeRemoteTeammate(base, 'remote-done', AgentStatus.COMPLETED);
+
+    sshExecMock.mockReturnValue({ code: 0, stdout: '', stderr: '' });
+    sshExecRawMock.mockReturnValue({ code: 0, stdout: Buffer.alloc(0), stderr: '' });
+
+    // A normal `--active` poll — NOT --local. Even here, a teammate that has
+    // already resolved terminal must not be dialed again: its `.exit` sentinel
+    // and final log bytes were already captured on the poll that resolved it.
+    const mgr = new AgentManager(50, base);
+    const all = await mgr.listAll();
+
+    expect(all).toHaveLength(1);
+    expect(all[0].status).toBe(AgentStatus.COMPLETED);
+    expect(sshExecMock).not.toHaveBeenCalled();
+    expect(sshExecRawMock).not.toHaveBeenCalled();
+  });
+
+  it('sanity: a still-RUNNING remote teammate DOES get polled when not --local', async () => {
+    const base = tmpBase();
+    dirs.push(base);
+    await makeRemoteTeammate(base, 'remote-running-2', AgentStatus.RUNNING);
+
+    sshExecMock.mockReturnValue({ code: 0, stdout: '', stderr: '' });
+    sshExecRawMock.mockReturnValue({ code: 0, stdout: Buffer.alloc(0), stderr: '' });
+
+    const mgr = new AgentManager(50, base); // no localOnly — polling must remain intact
+    await mgr.listAll();
+
+    // pullRemoteLogDelta (hosts/progress.ts) is the ssh call that mirrors a
+    // running remote teammate's new log bytes — proves the fix didn't disable
+    // polling outright, only the terminal/--local cases.
+    expect(sshExecRawMock).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -794,9 +794,19 @@ export class AgentProcess {
    * Uses a per-wave batched snapshot (remotePollSnapshot) when the supervisor's
    * one-ssh-per-host pre-pass populated it; otherwise falls back to its own
    * round-trips so a bare `teams status`/`teams logs` is still correct.
+   *
+   * Only polls a teammate that is plausibly still RUNNING (RUSH-2118). Once a
+   * remote teammate reaches a terminal status, the poll that resolved it already
+   * mirrored the final log bytes and read the `.exit` sentinel in this SAME
+   * function (delta pulled before the exit check below) — the underlying process
+   * is gone and can never write more, so there is nothing left to fetch. Without
+   * this guard every finished remote teammate still cost one ssh round-trip on
+   * EVERY `--active`/`listAll` poll forever, which is what made `agents sessions
+   * --active --local` take ~4.3s on a box with 30 completed teammates.
    */
   private async syncRemoteMirror(): Promise<void> {
     if (!this.hostName || !this.hostTarget || !this.remoteLog) return;
+    if (this.status !== AgentStatus.RUNNING) return;
 
     // Pull the new remote bytes and append them to the local mirror the parser
     // reads. One offset-tail round-trip; nothing to write when the log is quiet.
@@ -855,7 +865,14 @@ export class AgentProcess {
     this.lastReadPos = position;
   }
 
-  async readNewEvents(): Promise<void> {
+  /**
+   * @param opts.skipRemote A `--local` caller (RUSH-2118): never dial a
+   *   remote-host teammate, not even a still-RUNNING one — report its
+   *   last-persisted meta.json state as-is. A local-only query is by definition
+   *   this-machine-only, so it must not issue an ssh round-trip at all.
+   */
+  async readNewEvents(opts: { skipRemote?: boolean } = {}): Promise<void> {
+    if (this.hostName && opts.skipRemote) return;
     // Distributed teammate: mirror the host's new log bytes locally first, then
     // fall through to the identical local read+parse below.
     if (this.hostName) {
@@ -1147,7 +1164,12 @@ export class AgentProcess {
     return true;
   }
 
-  async updateStatusFromProcess(): Promise<void> {
+  /**
+   * @param opts.skipRemote A `--local` caller (RUSH-2118): a distributed
+   *   teammate is never dialed — its in-memory state (already loaded from
+   *   meta.json) stands as-is, no ssh, no re-save.
+   */
+  async updateStatusFromProcess(opts: { skipRemote?: boolean } = {}): Promise<void> {
     if (!this.pid) {
       // Distributed (remote-host) teammates have no local PID by design; their
       // lifecycle lives on the host. readNewEvents() mirrors the remote log and
@@ -1155,6 +1177,7 @@ export class AgentProcess {
       // syncRemoteMirror), so we just persist and return — never the local
       // "RUNNING without a PID is impossible" fail path below.
       if (this.hostName) {
+        if (opts.skipRemote) return;
         await this.readNewEvents();
         if (this.status !== AgentStatus.RUNNING && !this.completedAt) {
           this.completedAt = this.getLatestEventTime() || this.startedAt || new Date();
@@ -1353,6 +1376,14 @@ export class AgentManager {
   private defaultMode: Mode;
   private initPromise: Promise<void> | null = null;
   private cloudDispatcher: CloudDispatchFn | null = null;
+  /**
+   * A `--local` caller (RUSH-2118): every poll this manager issues skips the
+   * ssh round-trip for a distributed (remote-host) teammate, reporting its
+   * last-persisted meta.json state instead. Set once at construction so the
+   * INITIAL load in doInitialize()/loadExistingAgents() — which polls every
+   * teammate before listRunning()/listAll() ever run — honors it too.
+   */
+  private localOnly: boolean;
 
   private constructorAgentsDir: string | null = null;
 
@@ -1362,11 +1393,13 @@ export class AgentManager {
     defaultMode: Mode | null = null,
     filterByCwd: string | null = null,
     cleanupAgeDays: number = 7,
+    localOnly: boolean = false,
   ) {
     this.maxAgents = maxAgents;
     this.constructorAgentsDir = agentsDir;
     this.filterByCwd = filterByCwd;
     this.cleanupAgeDays = cleanupAgeDays;
+    this.localOnly = localOnly;
     const resolvedDefaultMode = defaultMode ? normalizeModeValue(defaultMode) : defaultModeFromEnv();
     if (!resolvedDefaultMode) {
       throw new Error(`Invalid default_mode '${defaultMode}'. Use plan, edit, auto, or skip.`);
@@ -1479,7 +1512,7 @@ export class AgentManager {
         }
       }
 
-      await agent.updateStatusFromProcess();
+      await agent.updateStatusFromProcess({ skipRemote: this.localOnly });
       this.agents.set(agentId, agent);
       loadedCount++;
     }
@@ -2355,8 +2388,8 @@ export class AgentManager {
     await this.initialize();
     const agents = Array.from(this.agents.values());
     for (const agent of agents) {
-      await agent.readNewEvents();
-      await agent.updateStatusFromProcess();
+      await agent.readNewEvents({ skipRemote: this.localOnly });
+      await agent.updateStatusFromProcess({ skipRemote: this.localOnly });
     }
     return agents;
   }


### PR DESCRIPTION
**fix** — `agents sessions --active --local` was silently dialing other machines over ssh.

## What was broken

`--local` is supposed to mean "this machine only." `AgentManager` (the engine
behind `agents teams`) still fired a real `ssh` round-trip per remote-host
teammate — one dispatched via `agents teams add --device` — on **every**
`--active` poll, whether or not the teammate had already finished, and
`--local` never gated it at all.

`readNewEvents()` → `syncRemoteMirror()` was the unconditional choke point:
called once from `AgentManager.loadExistingAgents()` at construction and twice
more from `listAll()` (`readNewEvents` + `updateStatusFromProcess`'s own
internal `readNewEvents`) — 3 ssh-capable passes per teammate per poll, with no
gate on status or on `--local`.

## Fix

Both in `apps/cli/src/lib/teams/agents.ts`:

1. `syncRemoteMirror()` now no-ops once a remote teammate's status is terminal
   (completed/failed/stopped) — the poll that resolved it already mirrored the
   final log bytes and read the `.exit` sentinel, so there's nothing left to
   fetch. Applies to every `--active` query, `--local` or not.
2. `readNewEvents()` / `updateStatusFromProcess()` take a `skipRemote` option,
   threaded from a new `AgentManager(..., localOnly)` constructor flag. A
   `--local` query never dials a remote-host teammate at all — not even a
   still-RUNNING one — and reports its last-persisted `meta.json` state
   instead.

`--local` is threaded end to end: `listTeamsActive`/`getActiveSessions`
(`apps/cli/src/lib/session/active.ts`) and `gatherActiveSessions`
(`apps/cli/src/commands/sessions.ts`).

## Run proof — before vs after

Real CLI entrypoint (`tsx src/index.ts sessions --active --json --local`)
against a synthetic fixture home with N remote-host teammates dispatched to an
unreachable hostname (fails DNS fast, ~0.13s/attempt) — isolated from the real
fleet, no user data touched.

| Fixture | Before (reverted fix) | After (this PR) | Zero-teammate baseline |
| --- | --- | --- | --- |
| 30 teammates (25 completed + 5 running) | 5966 ms | 4112 ms | 4015 ms |
| 100 teammates (95 completed + 5 running) | **13060 ms** | **3905 ms** | 4015 ms |

After the fix, the 100-teammate run is indistinguishable from the
zero-teammate baseline — the ~4s floor is pure Node/tsx process-startup cost in
this dev-source (non-compiled) invocation, unrelated to this change.

`strace -f -e trace=execve` on the 30-teammate fixture, counting real
`execve("/usr/bin/ssh", …)` calls for one `--active --local` poll:

```
before: 180 ssh execve calls   (6 per teammate: 2 ssh calls in syncRemoteMirror x 3 poll passes)
after:    0 ssh execve calls
```

## Tests

`apps/cli/src/lib/teams/agents.remote-poll.test.ts` (new) — real
`AgentManager`/`AgentProcess` against a temp `meta.json` dir, only the ssh
network boundary (`sshExec`/`sshExecRaw`) stubbed:

- a `--local` (`localOnly`) query issues **zero** ssh for a still-RUNNING
  remote teammate
- a terminal-status remote teammate is **never re-polled**, `--local` or not
- sanity: a still-RUNNING remote teammate **does** get polled under a normal
  (non `--local`) query — proves the fix didn't disable polling outright

Verified these fail without the fix (temporarily reverted the two guards,
re-ran, confirmed 3 ssh calls per teammate as expected, then restored).

Full suite: `npx vitest run src/lib/teams src/lib/session --exclude "**/sync/**"`
→ 107 files / 1134 tests passed. Two pre-existing, unrelated failures excluded
from that run and left untouched (`src/lib/session/sync/config.test.ts` — an
R2-config-cache cooldown test failing in isolation regardless of this diff, and
a flaky real-sshd-based test in `sessions.test.ts` that passes alone but times
out under parallel load) — neither touches teams/sessions `--active`.

## Update — closing a scope gap the `prix-cloud` review found

The first commit only threaded `localOnly` through the `--active` path
(`gatherActiveSessions`). The `--local` help text promises this-machine-only
for **both** "default listing and --active", but the bare `agents sessions
--local` (no `--active`) enriches every row via `maybeLiveIndex()`, which
called `getActiveSessions()` with no `localOnly` — so it still dialed a
remote-host teammate over ssh.

`maybeLiveIndex()` (now exported) threads `localOnly: options.local` through
to `getActiveSessions()`, closing the gap.

New test: `apps/cli/src/commands/sessions.local-live-index.test.ts` — HOME
pinned to a temp dir, only the ssh boundary stubbed, real
`AgentManager`/`AgentProcess` underneath:

- a bare `agents sessions --local` issues **zero** ssh for a remote-host
  teammate (and the row still surfaces from cached `meta.json` state — not
  silently dropped)
- sanity: the same teammate **is** dialed without `--local`

Verified it fails without the fix (temporarily reverted, confirmed 3 ssh
calls, restored). Typecheck clean; `src/lib/teams src/lib/session
src/commands/sessions.test.ts src/commands/sessions.local-live-index.test.ts`
→ 109 files / 1178 tests passed.

Fixes RUSH-2118.


## Update 2 — a second unguarded call site (independent review)

An independent review found `renderSessionPreview()` (backs `--preview <id>`)
also called `getActiveSessions()` with no `localOnly`. `--preview` and
`--local` are freely combinable (no mutual exclusion), so
`agents sessions --local --preview <id>` still dialed a remote-host teammate
over ssh — the exact round-trip this PR set out to kill.

Fix: `renderSessionPreview`'s `scope` param gains `local?: boolean`, threaded
into `getActiveSessions({ localOnly: scope.local === true })`; the `--preview`
call site forwards `options.local`. Exported `renderSessionPreview` for direct
testing.

Extended `sessions.local-live-index.test.ts` with a discoverable Claude
transcript fixture (`writeClaudeSession`) + a remote-host teammate:

- `agents sessions --local --preview <id>` issues **zero** ssh
- sanity: the same query without `--local` still dials

Verified it fails without the fix (temporarily reverted, confirmed real ssh
calls, restored). All 3 `getActiveSessions()` call sites in `sessions.ts` are
now confirmed gated: `gatherActiveSessions` (`--active`), `maybeLiveIndex`
(default listing), `renderSessionPreview` (`--preview`). Other commands that
call `getActiveSessions()` directly (`activity`, `go`, `feed`, `hq`,
`sessions-migrate`, `message`, `exec`, `sessions-inject`, `mailboxes`,
`projects`, `terminal/resolve`, `factory/snapshot`, `watchdog/runner`) don't
expose a `--local` flag, so they're out of scope for this ticket.

Typecheck clean; `src/lib/teams src/lib/session src/commands/sessions.test.ts
src/commands/sessions.local-live-index.test.ts` → 109 files / 1180 tests
passed.
