### PR TITLE
refactor(sessions): share SSH fan-out

### DIFF
--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -14,7 +14,9 @@ import {
   fleetCandidatesByQuery,
   metadataResolveForwardedArgs,
 } from './sessions.js';
-import { parseRemoteList, remoteListCommand } from '../lib/session/remote-list.js';
+import { remoteAgentsJsonCommand } from '../lib/remote-agents-json.js';
+import { NO_FANOUT_ENV } from '../lib/session/remote-active.js';
+import { parseRemoteList } from '../lib/session/remote-list.js';
 import { needsWindowsShell, composeWin32CommandLine } from '../lib/platform/index.js';
 import type { SessionMeta } from '../lib/session/types.js';
 
@@ -319,7 +321,10 @@ async function startSessionResolverSshPeer(
   const username = `srp-${crypto.randomBytes(16).toString('hex')}`;
   const target = `${username}@127.0.0.1`;
   const proofFile = path.join(tempHome, `${mode}-proof.txt`);
-  const expectedCommand = remoteListCommand(metadataResolveForwardedArgs('abcd7777', {}));
+  const expectedCommand = remoteAgentsJsonCommand(
+    metadataResolveForwardedArgs('abcd7777', {}),
+    NO_FANOUT_ENV,
+  );
   const controlPathTemplate = path.join(tempHome, '.agents', '.cache', 'ssh', 'cm-%C');
   fs.mkdirSync(path.dirname(controlPathTemplate), { recursive: true, mode: 0o700 });
   writeUpdateCache(peerHome);

--- a/apps/cli/src/lib/remote-agents-json.test.ts
+++ b/apps/cli/src/lib/remote-agents-json.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
 import { decodePowershell } from './hosts/remote-cmd.js';
-import { remoteAgentsJsonCommand } from './remote-agents-json.js';
+import { parseRemoteAgentsJsonPayload, remoteAgentsJsonCommand } from './remote-agents-json.js';
+import { parseRemoteListPayload } from './session/remote-list.js';
 
 describe('remoteAgentsJsonCommand', () => {
   it('guards a POSIX peer against recursive fan-out', () => {
@@ -15,5 +17,20 @@ describe('remoteAgentsJsonCommand', () => {
     const script = decodePowershell(encoded);
     expect(script).toContain("$env:AGENTS_FEED_LOCAL = '1'");
     expect(script).toContain("& 'agents' 'feed' '--json'");
+  });
+});
+
+describe('parseRemoteAgentsJsonPayload', () => {
+  it('preserves a strict parse failure from a zero-exit peer', () => {
+    const peer = spawnSync(process.execPath, ['--eval', "process.stdout.write('[{}]')"], { encoding: 'utf8' });
+    expect(peer.status).toBe(0);
+
+    const parsed = parseRemoteAgentsJsonPayload(
+      peer.stdout,
+      'peer',
+      (stdout, machine) => parseRemoteListPayload(stdout, machine, true),
+    );
+
+    expect(parsed).toEqual({ items: [], parseFailed: true });
   });
 });

--- a/apps/cli/src/lib/remote-agents-json.ts
+++ b/apps/cli/src/lib/remote-agents-json.ts
@@ -21,7 +21,7 @@ export interface RemoteAgentsJsonOptions<T> {
   args: string[];
   noFanoutEnv: string;
   hosts?: string[];
-  parse: (stdout: string, machine: string) => T[];
+  parse: (stdout: string, machine: string) => T[] | RemoteAgentsJsonParseResult<T>;
   /**
    * Suppress the per-device "unreachable — skipped" stderr line. The skipped
    * names still come back in {@link RemoteAgentsJsonResult.skipped}, so a caller
@@ -31,11 +31,37 @@ export interface RemoteAgentsJsonOptions<T> {
   quiet?: boolean;
 }
 
+export interface RemoteAgentsJsonParseResult<T> {
+  items: T[];
+  valid: boolean;
+}
+
 export interface RemoteAgentsJsonResult<T> {
   items: T[];
   deviceCount: number;
   /** Devices that were dialed but answered with an error / no CLI / a timeout. */
   skipped: string[];
+  /** Devices that exited successfully but returned invalid JSON for this command. */
+  parseFailed: string[];
+  /** Whether automatic target discovery failed before any peer could be dialed. */
+  discoveryFailed: boolean;
+}
+
+export function normalizeRemoteAgentsJsonParse<T>(
+  parsed: T[] | RemoteAgentsJsonParseResult<T>,
+): RemoteAgentsJsonParseResult<T> {
+  return Array.isArray(parsed) ? { items: parsed, valid: true } : parsed;
+}
+
+export function parseRemoteAgentsJsonPayload<T>(
+  stdout: string,
+  machine: string,
+  parse: RemoteAgentsJsonOptions<T>['parse'],
+): { items: T[]; parseFailed: boolean } {
+  const parsed = normalizeRemoteAgentsJsonParse(parse(stdout, machine));
+  return parsed.valid
+    ? { items: parsed.items, parseFailed: false }
+    : { items: [], parseFailed: true };
 }
 
 /** Build the command one peer runs, with a guard that prevents recursive fan-out. */
@@ -84,7 +110,7 @@ export async function gatherRemoteAgentsJson<T>(
     try {
       devices = await loadDevices();
     } catch {
-      return { items: [], deviceCount: 0, skipped: [] };
+      return { items: [], deviceCount: 0, skipped: [], parseFailed: [], discoveryFailed: true };
     }
     for (const device of Object.values(devices)) {
       // Live SSH-probe verdict first, cached tailscale snapshot only as a
@@ -111,6 +137,7 @@ export async function gatherRemoteAgentsJson<T>(
   }
 
   const skipped: string[] = [];
+  const parseFailed: string[] = [];
   const results = await Promise.all(targets.map(async (target) => {
     const command = remoteAgentsJsonCommand(options.args, options.noFanoutEnv, target.os);
     const result = await sshCapture(target.target, command);
@@ -121,8 +148,16 @@ export async function gatherRemoteAgentsJson<T>(
       }
       return [] as T[];
     }
-    return options.parse(result.stdout, target.machine);
+    const parsed = parseRemoteAgentsJsonPayload(result.stdout, target.machine, options.parse);
+    if (parsed.parseFailed) {
+      parseFailed.push(target.name);
+      if (!options.quiet) {
+        process.stderr.write(chalk.gray(`  ${target.name}: unreachable or no agents CLI — skipped\n`));
+      }
+      return [] as T[];
+    }
+    return parsed.items;
   }));
 
-  return { items: results.flat(), deviceCount: targets.length, skipped };
+  return { items: results.flat(), deviceCount: targets.length, skipped, parseFailed, discoveryFailed: false };
 }

--- a/apps/cli/src/lib/session/remote-list.test.ts
+++ b/apps/cli/src/lib/session/remote-list.test.ts
@@ -7,12 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { spawnSync } from 'child_process';
-import { parseRemoteList, remoteListCaptureResult, remoteListCommand } from './remote-list.js';
-
-function runPeer(source: string, ...args: string[]) {
-  return spawnSync(process.execPath, ['--eval', source, ...args], { encoding: 'utf8' });
-}
+import { parseRemoteList, parseRemoteListPayload } from './remote-list.js';
 
 describe('parseRemoteList', () => {
   it('tags every parsed session with the source machine', () => {
@@ -64,23 +59,20 @@ describe('parseRemoteList', () => {
   });
 });
 
-describe('remoteListCaptureResult', () => {
-  it('accepts real child output and tags the owning machine', () => {
-    const peer = runPeer("process.stdout.write(JSON.stringify([{id:'abcd7777',shortId:'abcd7777',agent:'claude',timestamp:'2026-08-03T00:00:00Z'}]))");
-
-    expect(remoteListCaptureResult(peer.status, peer.stdout, 'peer-one', 'Peer One', true)).toEqual({
-      sessions: [{
+describe('parseRemoteListPayload', () => {
+  it('accepts valid output and tags the owning machine', () => {
+    const stdout = JSON.stringify([{id:'abcd7777',shortId:'abcd7777',agent:'claude',timestamp:'2026-08-03T00:00:00Z'}]);
+    expect(parseRemoteListPayload(stdout, 'peer-one', true)).toEqual({
+      items: [{
         id: 'abcd7777', shortId: 'abcd7777', agent: 'claude',
         timestamp: '2026-08-03T00:00:00Z', machine: 'peer-one', _remote: true,
       }],
+      valid: true,
     });
   });
 
   it('marks an exit-0 structurally invalid resolver row incomplete', () => {
-    expect(remoteListCaptureResult(0, '[{}]', 'peer', 'peer', true)).toEqual({
-      sessions: [],
-      unreachable: 'peer',
-    });
+    expect(parseRemoteListPayload('[{}]', 'peer', true)).toEqual({ items: [], valid: false });
   });
 
   it('rejects unsafe fields from a versioned resolver peer', () => {
@@ -88,29 +80,10 @@ describe('remoteListCaptureResult', () => {
       id: 'abcd7777', shortId: 'abcd7777', agent: 'claude',
       timestamp: '2026-08-03T00:00:00Z', filePath: '/private/transcript.jsonl',
     }]);
-    expect(remoteListCaptureResult(0, unsafe, 'peer', 'peer', true)).toEqual({
-      sessions: [],
-      unreachable: 'peer',
-    });
+    expect(parseRemoteListPayload(unsafe, 'peer', true)).toEqual({ items: [], valid: false });
   });
 
   it('accepts an exit-0 empty array as a complete peer response', () => {
-    expect(remoteListCaptureResult(0, '[]', 'peer', 'peer')).toEqual({ sessions: [] });
-  });
-
-});
-
-describe('remoteListCommand', () => {
-  it('passes the recursion guard so the peer stays local and never re-fans-out', () => {
-    const cmd = remoteListCommand(['sessions', 'auth bug', '--json']);
-    expect(cmd).toContain('AGENTS_SESSIONS_LOCAL=1');
-    expect(cmd).toContain('agents');
-  });
-
-  it('carries the caller query + filters over to the peer', () => {
-    const cmd = remoteListCommand(['sessions', 'deploy', '--since', '2d', '--json']);
-    expect(cmd).toContain('deploy');
-    expect(cmd).toContain('--since');
-    expect(cmd).toContain('--json');
+    expect(parseRemoteListPayload('[]', 'peer')).toEqual({ items: [], valid: true });
   });
 });

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -17,37 +17,13 @@ import { spawn } from 'child_process';
 import chalk from 'chalk';
 import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from '../ssh-exec.js';
 import { sshTargetFor } from '../devices/connect.js';
-import { resolveExplicitTargets } from '../devices/resolve-target.js';
-import { loadDevices, isControlDevice, isDialableDevice, type DeviceProfile } from '../devices/registry.js';
+import { loadDevices, type DeviceProfile } from '../devices/registry.js';
 import { remoteShellFor, buildWindowsAgentsCommand } from '../hosts/remote-cmd.js';
-import { machineId, normalizeHost } from './sync/config.js';
+import { gatherRemoteAgentsJson, type RemoteAgentsJsonParseResult } from '../remote-agents-json.js';
+import { normalizeHost } from './sync/config.js';
 import { NO_FANOUT_ENV } from './remote-active.js';
 import { terminalWidth } from './width.js';
 import type { SessionMeta } from './types.js';
-
-/** Per-host SSH budget. Slightly above SSH_OPTS' ConnectTimeout=10 so a
- * reachable-but-slow remote still answers before we give up. */
-const REMOTE_TIMEOUT_MS = 12_000;
-
-/**
- * The command run on each peer: answer for itself, as JSON, without recursing.
- * `forwardedArgs` carry the caller's own query/filters (already including the
- * leading `sessions` and a `--json`) so each peer returns a comparable slice.
- * A Windows peer gets a PowerShell invocation (ssh lands in cmd.exe/PowerShell
- * there, where `bash -lc` is not a command); every other OS keeps `bash -lc`.
- */
-export function remoteListCommand(forwardedArgs: string[], os?: string): string {
-  if (remoteShellFor(os) === 'powershell') {
-    return buildWindowsAgentsCommand({
-      args: forwardedArgs,
-      env: { [NO_FANOUT_ENV]: '1' },
-    });
-  }
-  const inner = [`${NO_FANOUT_ENV}=1`, 'agents', ...forwardedArgs].map((t, i) =>
-    i === 0 ? t : shellQuote(t),
-  ).join(' ');
-  return `bash -lc ${shellQuote(inner)}`;
-}
 
 /**
  * Parse a peer's `sessions --json` stdout into `SessionMeta[]`, tagging each
@@ -84,79 +60,27 @@ function isSafeResolverRow(value: Record<string, unknown>): boolean {
 }
 
 export function parseRemoteListPayload(stdout: string, machine: string, safeResolver = false): {
-  sessions: SessionMeta[];
+  items: SessionMeta[];
   valid: boolean;
 } {
   let parsed: unknown;
   try {
     parsed = JSON.parse(stdout);
   } catch {
-    return { sessions: [], valid: false };
+    return { items: [], valid: false };
   }
-  if (!Array.isArray(parsed)) return { sessions: [], valid: false };
+  if (!Array.isArray(parsed)) return { items: [], valid: false };
   const out: SessionMeta[] = [];
   for (const x of parsed) {
-    if (!x || typeof x !== 'object' || Array.isArray(x)) return { sessions: [], valid: false };
+    if (!x || typeof x !== 'object' || Array.isArray(x)) return { items: [], valid: false };
     if (safeResolver && !isSafeResolverRow(x as Record<string, unknown>)) {
-      return { sessions: [], valid: false };
+      return { items: [], valid: false };
     }
     // `_remote` marks these as living on the peer's disk (not a local mirror),
     // so the picker routes read/resume back over SSH instead of the local FS.
     out.push({ ...(x as SessionMeta), machine, _remote: true });
   }
-  return { sessions: out, valid: true };
-}
-
-/** Convert one completed peer process into the exact aggregation result. This
- * is the production parent/peer seam and is exercised with real child output. */
-export function remoteListCaptureResult(
-  code: number | null,
-  stdout: string,
-  machine: string,
-  display: string,
-  safeResolver = false,
-): { sessions: SessionMeta[]; unreachable?: string } {
-  if (code !== 0) return { sessions: [], unreachable: display };
-  const parsed = parseRemoteListPayload(stdout, machine, safeResolver);
-  return parsed.valid ? { sessions: parsed.sessions } : { sessions: [], unreachable: display };
-}
-
-/** Run one remote `agents sessions … --json` and capture stdout. Resolves
- * `{ code: null }` on spawn error or timeout (host treated as dead). */
-function sshCapture(target: string, remoteCmd: string, timeoutMs: number): Promise<{ code: number | null; stdout: string }> {
-  assertValidSshTarget(target);
-  return new Promise((resolve) => {
-    const args = [...SSH_OPTS, ...controlOpts(), target, remoteCmd];
-    const child = spawn('ssh', args, { stdio: ['ignore', 'pipe', 'ignore'] });
-    let stdout = '';
-    let settled = false;
-    const done = (code: number | null) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve({ code, stdout });
-    };
-    const timer = setTimeout(() => { child.kill('SIGKILL'); done(null); }, timeoutMs);
-    child.stdout.on('data', (d) => { stdout += d.toString(); });
-    child.on('error', () => done(null));
-    child.on('close', (code) => done(code));
-  });
-}
-
-async function fetchByTarget(
-  target: string,
-  machine: string,
-  display: string,
-  forwardedArgs: string[],
-  os?: string
-): Promise<{ sessions: SessionMeta[]; unreachable?: string }> {
-  const { code, stdout } = await sshCapture(target, remoteListCommand(forwardedArgs, os), REMOTE_TIMEOUT_MS);
-  const safeResolver = forwardedArgs.includes('--resolve-safe-v1');
-  const result = remoteListCaptureResult(code, stdout, machine, display, safeResolver);
-  if (result.unreachable) {
-    process.stderr.write(chalk.gray(`  ${display}: unreachable or no agents CLI — skipped\n`));
-  }
-  return result;
+  return { items: out, valid: true };
 }
 
 export interface RemoteListResult {
@@ -180,46 +104,22 @@ export interface RemoteListResult {
  * already `--json`) so every peer returns the same slice this machine asked for.
  */
 export async function gatherRemoteList(forwardedArgs: string[], hosts?: string[]): Promise<RemoteListResult> {
-  const self = machineId();
-  const targets: Array<{ target: string; machine: string; name: string; os?: string }> = [];
-
-  if (hosts && hosts.length > 0) {
-    // Resolve each token through the device registry so an explicit --host/--device
-    // dials the exact same address (and machine id) as the auto-discovery sweep.
-    targets.push(...await resolveExplicitTargets(hosts));
-  } else {
-    let reg: Record<string, DeviceProfile>;
-    try {
-      reg = await loadDevices();
-    } catch {
-      return { sessions: [], deviceCount: 0, unreachable: ['device registry'] };
-    }
-    for (const d of Object.values(reg)) {
-      // Live SSH-probe verdict first, cached tailscale snapshot only as a
-      // fallback — see isDialableDevice. A manually-registered device has no
-      // tailscale peer entry, so gating on `online` alone hid its sessions.
-      if (!isDialableDevice(d)) continue;
-      if (normalizeHost(d.name) === self) continue;
-      // Control-only devices (a phone/tablet running the cockpit) drive the fleet
-      // but never run agents — never dial them, whatever their platform reads as.
-      if (isControlDevice(d)) continue;
-      // Only machines that can actually run the CLI. iOS/tablet nodes register as
-      // `unknown` platform and can never answer, so skip them rather than burn a
-      // full ConnectTimeout on each.
-      if (d.platform !== 'windows' && d.platform !== 'linux' && d.platform !== 'macos') continue;
-      try {
-        targets.push({ target: sshTargetFor(d), machine: normalizeHost(d.name), name: d.name, os: d.platform });
-      } catch {
-        // No address on the profile — nothing to dial; skip silently.
-      }
-    }
-  }
-
-  const results = await Promise.all(targets.map((t) => fetchByTarget(t.target, t.machine, t.name, forwardedArgs, t.os)));
+  const safeResolver = forwardedArgs.includes('--resolve-safe-v1');
+  const result = await gatherRemoteAgentsJson<SessionMeta>({
+    args: forwardedArgs,
+    noFanoutEnv: NO_FANOUT_ENV,
+    hosts,
+    parse: (stdout, machine): RemoteAgentsJsonParseResult<SessionMeta> =>
+      parseRemoteListPayload(stdout, machine, safeResolver),
+  });
   return {
-    sessions: results.flatMap((r) => r.sessions),
-    deviceCount: targets.length,
-    unreachable: results.map((r) => r.unreachable).filter((n): n is string => !!n),
+    sessions: result.items,
+    deviceCount: result.deviceCount,
+    unreachable: [
+      ...(result.discoveryFailed ? ['device registry'] : []),
+      ...result.skipped,
+      ...result.parseFailed,
+    ],
   };
 }
 


### PR DESCRIPTION
Refactor: route `agents sessions` browse/list fleet collection through the canonical JSON SSH fan-out.

## What changed

- Replaced `remote-list.ts` target discovery, SSH command construction, timeout, and parallel capture with `gatherRemoteAgentsJson`.
- Extended the shared parser contract to distinguish zero-exit malformed payloads from valid empty arrays.
- Preserved remote-list row validation, safe-resolver validation, unreachable peer reporting, and device-registry failure reporting.
- Removed the duplicate SSH fan-out implementation and its duplicate command tests.

## Verification

No user-visible UI surface: internal refactor with behavior-preserving regression coverage.

- `bunx vitest run src/lib/session` — all session test files passed.
- `bunx tsc --noEmit` — passed.
- `bunx vitest run src/lib/remote-agents-json.test.ts src/lib/remote-agents-json.role.test.ts src/lib/session/remote-list.test.ts` — 3 files, 15 tests passed.
- `bun run test` — all changed-area tests passed; two unrelated host-dependent assertions failed and reproduced three times: the live Antigravity credential test observed this host's real credential, and the installed Codex catalog had no extracted reasoning levels. CI should evaluate both in its clean environment.

Docs/CHANGELOG exempt: no command, flag, configuration, or user-visible behavior changes.
