### PR TITLE
fix(events): preserve provenance in activity records

### DIFF
--- a/apps/cli/.changelog/next/activity-provenance.md
+++ b/apps/cli/.changelog/next/activity-provenance.md
@@ -1,0 +1,5 @@
+- **Activity events now carry the same actor and session lineage as operational events.**
+  The TypeScript activity writer and the embedded PostToolUse hook stamp actor kind,
+  launch id, and parent session id from the shared execution provenance floor, so
+  `agents events` no longer invents an agent name as the activity record's OS user.
+  Source: `apps/cli/src/lib/event-provenance.ts`, `apps/cli/src/lib/activity.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## 1.20.94
-
-- **Activity events now carry the same actor and session lineage as operational events.**
-  The TypeScript activity writer and the embedded PostToolUse hook stamp actor kind,
-  launch id, and parent session id from the shared execution provenance floor, so
-  `agents events` no longer invents an agent name as the activity record's OS user.
-  Source: `apps/cli/src/lib/event-provenance.ts`, `apps/cli/src/lib/activity.ts`.
-
 ## 1.20.93
 
 - **`agents send` is a real delivery envelope; `notify` is just `--to owner` (RUSH-2123).** Flag-first form: `--to`, `--text`, `--channel`, `--attach`, `--url`. `--to owner` expands from `notify.owner` in agents.yaml. Positional text still works. Help names the three planes (deliver / record / control) so send is not confused with `feed post`, `activity`, or `message`/`sessions inject`. Source: `apps/cli/src/commands/send.ts`, `apps/cli/src/lib/channels/send.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.20.94
+
+- **Activity events now carry the same actor and session lineage as operational events.**
+  The TypeScript activity writer and the embedded PostToolUse hook stamp actor kind,
+  launch id, and parent session id from the shared execution provenance floor, so
+  `agents events` no longer invents an agent name as the activity record's OS user.
+  Source: `apps/cli/src/lib/event-provenance.ts`, `apps/cli/src/lib/activity.ts`.
+
 ## 1.20.93
 
 - **`agents send` is a real delivery envelope; `notify` is just `--to owner` (RUSH-2123).** Flag-first form: `--to`, `--text`, `--channel`, `--attach`, `--url`. `--to owner` expands from `notify.owner` in agents.yaml. Positional text still works. Help names the three planes (deliver / record / control) so send is not confused with `feed post`, `activity`, or `message`/`sessions inject`. Source: `apps/cli/src/commands/send.ts`, `apps/cli/src/lib/channels/send.ts`.

--- a/apps/cli/src/lib/activity.test.ts
+++ b/apps/cli/src/lib/activity.test.ts
@@ -31,6 +31,9 @@ import {
   type ActivityEvent,
   type EnrichedActivityEvent,
 } from './activity.js';
+import { emit, query, _resetForTest as resetEventsForTest } from './events.js';
+import { resetActorCache } from './actor.js';
+import { resetEventProvenanceForTest } from './event-provenance.js';
 
 /** Minimal well-formed enriched event; override any field per test. */
 function ev(partial: Partial<EnrichedActivityEvent>): EnrichedActivityEvent {
@@ -67,6 +70,52 @@ function activityDirFor(home: string): string {
 }
 
 describe('activity log store (TS)', () => {
+  it('stamps the same actor, kind, launch, and parent provenance as emit()', () => {
+    const dir = tmpActivityDir();
+    const operationalPath = path.join(dir, 'events.jsonl');
+    Object.assign(process.env, {
+      AGENTS_ACTOR: 'ada@example.com',
+      AGENTS_ACTOR_KIND: 'human',
+      AGENTS_AGENT_NAME: 'codex',
+      AGENT_LAUNCH_ID: 'launch-shared',
+      AGENTS_PARENT_SESSION_ID: 'parent-shared',
+    });
+    resetActorCache();
+    resetEventProvenanceForTest();
+    try {
+      appendActivityEvent({
+        ts: '2026-08-03T12:00:00.000Z', event: 'file.edited', sessionId: 'activity-session',
+        mailboxId: 'activity-session', host: 'yosemite-s0', runtime: 'headless',
+      }, dir);
+      resetEventsForTest(operationalPath);
+      emit('info', { module: 'test' });
+
+      const activity = readSessionActivity('activity-session', dir)[0];
+      const operational = query({})[0];
+      expect({
+        actor: activity.actor,
+        kind: activity.kind,
+        agent: activity.agent,
+        launchId: activity.launchId,
+        parentSessionId: activity.parentSessionId,
+      }).toEqual({
+        actor: operational.actor,
+        kind: operational.kind,
+        agent: operational.agent,
+        launchId: operational.launchId,
+        parentSessionId: operational.parentSessionId,
+      });
+    } finally {
+      delete process.env.AGENTS_ACTOR;
+      delete process.env.AGENTS_ACTOR_KIND;
+      delete process.env.AGENTS_AGENT_NAME;
+      delete process.env.AGENT_LAUNCH_ID;
+      delete process.env.AGENTS_PARENT_SESSION_ID;
+      resetActorCache();
+      resetEventsForTest();
+    }
+  });
+
   it('appends and reads back events for a session, newest-first across sessions', () => {
     const dir = tmpActivityDir();
     appendActivityEvent({ ts: '2026-07-29T10:00:00.000Z', event: 'plan.created', sessionId: 's1', mailboxId: 's1', host: 'zion', runtime: 'headless', detail: 'Build the spine' }, dir);
@@ -186,6 +235,30 @@ describe('ensureActivityLogHook', () => {
 });
 
 describe('real activity-log hook (Python)', () => {
+  pythonTest('reads actor, kind, launch, and parent provenance from the child env', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-provenance-'));
+    const r = runHook(home, {
+      session_id: 'child-session',
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: '/home/muqsit/src/x/foo.ts' },
+      tool_response: {},
+    }, {
+      AGENTS_ACTOR: 'ada@example.com',
+      AGENTS_ACTOR_KIND: 'human',
+      AGENTS_AGENT_NAME: 'codex',
+      AGENT_LAUNCH_ID: 'launch-hook',
+      AGENTS_PARENT_SESSION_ID: 'parent-hook',
+    });
+    expect(r.status).toBe(0);
+    const event = readSessionActivity('child-session', activityDirFor(home))[0];
+    expect(event.actor).toBe('ada@example.com');
+    expect(event.kind).toBe('human');
+    expect(event.agent).toBe('codex');
+    expect(event.launchId).toBe('launch-hook');
+    expect(event.parentSessionId).toBe('parent-hook');
+  });
+
   pythonTest('logs plan.created from a PreToolUse ExitPlanMode', () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-activity-plan-'));
     const r = runHook(home, {

--- a/apps/cli/src/lib/activity.ts
+++ b/apps/cli/src/lib/activity.ts
@@ -25,6 +25,8 @@ import { relTime, truncate } from './format.js';
 import { getActivityDir, getUserAgentsDir } from './state.js';
 import { normalizeHost } from './machine-id.js';
 import { projectKeyFromCwd } from './project-key.js';
+import { stampProvenance } from './event-provenance.js';
+import type { ActorKind } from './actor.js';
 // Type-only import: no runtime dependency on events.ts, so no import cycle
 // (events.ts / event-stream.ts import THIS module at runtime).
 import type { EventRecord } from './events.js';
@@ -160,6 +162,10 @@ export interface ActivityEvent {
   project?: string;
   /** Agent that produced the event (claude, codex, ...). */
   agent?: string;
+  /** Resolved actor id shared with the operational event stream. */
+  actor?: string;
+  /** Resolved actor kind shared with the operational event stream. */
+  kind?: ActorKind | 'unknown';
   /** Tool that triggered the event (Bash, Task, ExitPlanMode, feed.post, ...). */
   tool?: string;
   /** One-line human summary (plan title, PR command, sub-agent role, status text). */
@@ -170,6 +176,8 @@ export interface ActivityEvent {
   pid?: number;
   /** Spawn-time join key (`AGENT_LAUNCH_ID`) when known. */
   launchId?: string;
+  /** Session that spawned this session (`AGENTS_PARENT_SESSION_ID`) when known. */
+  parentSessionId?: string;
   /** Factory terminal id when the launch inherited one. */
   terminalId?: string;
   /** `$TMUX_PANE` at launch when recorded. */
@@ -232,6 +240,7 @@ export function appendActivityEvent(
   const dir = root ?? getActivityDir();
   fs.mkdirSync(dir, { recursive: true });
   const record: ActivityEvent = {
+    ...stampProvenance(),
     v: event.v ?? 1,
     tier: event.tier ?? tierForEvent(event.event),
     ...event,
@@ -257,11 +266,14 @@ function parseLine(line: string): ActivityEvent | undefined {
       cwd: parsed.cwd,
       project: parsed.project,
       agent: parsed.agent,
+      actor: parsed.actor,
+      kind: parsed.kind,
       tool: parsed.tool,
       detail: parsed.detail,
       url: parsed.url,
       pid: typeof parsed.pid === 'number' ? parsed.pid : undefined,
       launchId: parsed.launchId,
+      parentSessionId: parsed.parentSessionId,
       terminalId: parsed.terminalId,
       tmuxPane: parsed.tmuxPane,
       category: typeof parsed.category === 'string' ? parsed.category : undefined,
@@ -413,10 +425,12 @@ export function activityEventToRecord(ev: ActivityEvent): EventRecord {
     level: 'info',
     caller: ev.tool === 'feed.post' ? 'agent' : 'hook',
     session: ev.sessionId,
-    osUser: ev.agent ?? 'agent',
+    osUser: 'unknown',
     transport: 'local',
     // payload
     agent: ev.agent,
+    actor: ev.actor ?? 'unknown',
+    kind: ev.kind ?? 'unknown',
     sessionId: ev.sessionId,
     cwd: ev.cwd,
     module: 'activity',
@@ -426,6 +440,7 @@ export function activityEventToRecord(ev: ActivityEvent): EventRecord {
     tier: ev.tier,
     ...(ev.project ? { project: ev.project } : {}),
     ...(ev.launchId ? { launchId: ev.launchId } : {}),
+    ...(ev.parentSessionId ? { parentSessionId: ev.parentSessionId } : {}),
     ...(ev.terminalId ? { terminalId: ev.terminalId } : {}),
     ...(ev.tmuxPane ? { tmuxPane: ev.tmuxPane } : {}),
     ...(ev.attachments?.length ? { attachments: ev.attachments } : {}),
@@ -1741,8 +1756,17 @@ def main():
         cwd = payload.get("cwd") or os.environ.get("AGENTS_CWD")
         if cwd:
             record["cwd"] = cwd
-        agent = os.environ.get("AGENTS_AGENT_NAME") or "claude"
+        agent = os.environ.get("AGENTS_AGENT_NAME") or "unknown"
         record["agent"] = agent
+        record["actor"] = os.environ.get("AGENTS_ACTOR") or "unknown"
+        actor_kind = os.environ.get("AGENTS_ACTOR_KIND")
+        record["kind"] = actor_kind if actor_kind in ("human", "agent") else "unknown"
+        launch_id = os.environ.get("AGENT_LAUNCH_ID")
+        if launch_id:
+            record["launchId"] = launch_id
+        parent_session_id = os.environ.get("AGENTS_PARENT_SESSION_ID")
+        if parent_session_id:
+            record["parentSessionId"] = parent_session_id
 
     try:
         os.makedirs(activity_dir, exist_ok=True)

--- a/apps/cli/src/lib/event-provenance.test.ts
+++ b/apps/cli/src/lib/event-provenance.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resetActorCache } from './actor.js';
+import { resetEventProvenanceForTest, stampProvenance } from './event-provenance.js';
+
+afterEach(() => {
+  delete process.env.AGENTS_ACTOR;
+  delete process.env.AGENTS_ACTOR_KIND;
+  resetActorCache();
+  resetEventProvenanceForTest();
+});
+
+describe('stampProvenance', () => {
+  it('combines actor identity with the execution lineage env', () => {
+    process.env.AGENTS_ACTOR = 'ada@example.com';
+    process.env.AGENTS_ACTOR_KIND = 'human';
+    resetActorCache();
+    resetEventProvenanceForTest();
+
+    const provenance = stampProvenance({
+      AGENTS_SESSION_ID: 'child-session',
+      AGENTS_AGENT_NAME: 'codex',
+      AGENT_LAUNCH_ID: 'launch-1',
+      AGENTS_PARENT_SESSION_ID: 'parent-session',
+    });
+
+    expect(provenance).toMatchObject({
+      actor: 'ada@example.com',
+      kind: 'human',
+      sessionId: 'child-session',
+      agent: 'codex',
+      launchId: 'launch-1',
+      parentSessionId: 'parent-session',
+    });
+  });
+});

--- a/apps/cli/src/lib/event-provenance.ts
+++ b/apps/cli/src/lib/event-provenance.ts
@@ -1,0 +1,68 @@
+import * as os from 'os';
+import { resolveActor, type ActorKind } from './actor.js';
+import { machineId } from './machine-id.js';
+import { parseSshConnection } from './session/provenance.js';
+
+export interface EventProvenance {
+  osUser: string;
+  transport: 'local' | 'ssh';
+  sshClientIp?: string;
+  actor: string;
+  kind: ActorKind;
+  machineId: string;
+  sessionId?: string;
+  agent?: string;
+  launchId?: string;
+  parentSessionId?: string;
+}
+
+interface AuditOrigin {
+  osUser: string;
+  transport: 'local' | 'ssh';
+  sshClientIp?: string;
+  actor: string;
+  kind: ActorKind;
+}
+
+let cachedOrigin: AuditOrigin | undefined;
+let cachedDeviceId: string | undefined;
+
+/**
+ * Stamp the shared identity floor used by both operational and activity events.
+ * Explicit event payload fields may override these defaults at the call site.
+ */
+export function stampProvenance(env: NodeJS.ProcessEnv = process.env): EventProvenance {
+  if (!cachedOrigin) {
+    let osUser = 'unknown';
+    try {
+      osUser = os.userInfo().username;
+    } catch {
+      // A uid without a passwd entry has no attributable OS user.
+    }
+    const ssh = env.SSH_CONNECTION ? parseSshConnection(env.SSH_CONNECTION) : undefined;
+    const actor = resolveActor();
+    cachedOrigin = {
+      osUser,
+      transport: ssh ? 'ssh' : 'local',
+      ...(ssh ? { sshClientIp: ssh.clientIp } : {}),
+      actor: actor.id,
+      kind: actor.kind,
+    };
+  }
+
+  const provenance: EventProvenance = {
+    ...cachedOrigin,
+    machineId: (cachedDeviceId ??= machineId()),
+  };
+  const sessionId = env.AGENT_SESSION_ID || env.AGENTS_SESSION_ID;
+  if (sessionId) provenance.sessionId = sessionId;
+  if (env.AGENTS_AGENT_NAME) provenance.agent = env.AGENTS_AGENT_NAME;
+  if (env.AGENT_LAUNCH_ID) provenance.launchId = env.AGENT_LAUNCH_ID;
+  if (env.AGENTS_PARENT_SESSION_ID) provenance.parentSessionId = env.AGENTS_PARENT_SESSION_ID;
+  return provenance;
+}
+
+export function resetEventProvenanceForTest(): void {
+  cachedOrigin = undefined;
+  cachedDeviceId = undefined;
+}

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -17,11 +17,10 @@ import * as path from 'path';
 import * as os from 'os';
 import { createHash } from 'node:crypto';
 import { gzipSync, gunzipSync } from 'node:zlib';
-import { parseSshConnection } from './session/provenance.js';
 import { ensureLockTarget, withFileLock } from './fs-atomic.js';
 import { getUserAgentsDir } from './state.js';
-import { resolveActor, type ActorKind } from './actor.js';
-import { machineId } from './machine-id.js';
+import { stampProvenance, resetEventProvenanceForTest } from './event-provenance.js';
+import type { ActorKind } from './actor.js';
 
 /** Lazy perf warehouse write — avoids a hard cycle at module load. */
 function recordPerfTiming(payload: {
@@ -290,7 +289,7 @@ export interface EventMeta {
   /** Resolved actor id — which human/agent is behind this event (RUSH-2020). */
   actor?: string;
   /** Actor kind (`human`/`agent`). */
-  kind?: ActorKind;
+  kind?: ActorKind | 'unknown';
 }
 
 export interface EventPayload {
@@ -547,73 +546,6 @@ export function detectCaller(
 
 // ─── Audit attribution ────────────────────────────────────────────────────────
 
-interface AuditOrigin {
-  osUser: string;
-  transport: 'local' | 'ssh';
-  sshClientIp?: string;
-  /** Resolved actor id (`resolveActor().id`) — which human/agent is behind this event. */
-  actor: string;
-  /** Actor kind (`resolveActor().kind`). */
-  kind: ActorKind;
-}
-
-/**
- * Who is running this process and from where. Derived once per process from the
- * OS user and $SSH_CONNECTION (via the same parser the sessions layer uses), then
- * cached — provenance can't change mid-process, so every emit() pays for it once.
- */
-let _origin: AuditOrigin | undefined;
-function auditOrigin(): AuditOrigin {
-  if (_origin) return _origin;
-  let osUser = 'unknown';
-  try {
-    osUser = os.userInfo().username;
-  } catch {
-    // Container/edge cases where the uid has no passwd entry.
-  }
-  const ssh = process.env.SSH_CONNECTION ? parseSshConnection(process.env.SSH_CONNECTION) : undefined;
-  const actor = resolveActor();
-  _origin = {
-    osUser,
-    transport: ssh ? 'ssh' : 'local',
-    ...(ssh ? { sshClientIp: ssh.clientIp } : {}),
-    actor: actor.id,
-    kind: actor.kind,
-  };
-  return _origin;
-}
-
-/**
- * Provenance the spawn env already carries but no call site passes: the full
- * (untruncated) session id, the harness `agent` name, the launch join key, and
- * the parent-session lineage edge. Stamped as DEFAULTS on every event so a
- * reader of `agents events` can answer "which agent, which session, spawned by
- * whom" without cross-referencing sessions.db — while an explicit payload value
- * (e.g. cloud.dispatch's own `agent`) still wins. Read fresh per emit: the reads
- * are trivial and this stays correct when a test mutates env between calls.
- */
-interface ProvenanceFloor {
-  sessionId?: string;
-  agent?: string;
-  launchId?: string;
-  parentSessionId?: string;
-}
-/** This machine's normalized device id, resolved once — it can't change mid-process. */
-let _machineId: string | undefined;
-function cachedMachineId(): string {
-  return (_machineId ??= machineId());
-}
-
-function resolveProvenance(env: NodeJS.ProcessEnv = process.env): ProvenanceFloor {
-  const p: ProvenanceFloor = {};
-  const sessionId = env.AGENT_SESSION_ID || env.AGENTS_SESSION_ID;
-  if (sessionId) p.sessionId = sessionId;
-  if (env.AGENTS_AGENT_NAME) p.agent = env.AGENTS_AGENT_NAME;
-  if (env.AGENT_LAUNCH_ID) p.launchId = env.AGENT_LAUNCH_ID;
-  if (env.AGENTS_PARENT_SESSION_ID) p.parentSessionId = env.AGENTS_PARENT_SESSION_ID;
-  return p;
-}
-
 // ─── Core API ─────────────────────────────────────────────────────────────────
 
 /**
@@ -638,13 +570,12 @@ export function emit(event: EventType, payload: EventPayload = {}, overrides: { 
     const safePayload = sanitizePayload(payload);
     const record: EventRecord = {
       // Provenance floor first: env-sourced defaults an explicit payload overrides.
-      ...resolveProvenance(),
+      ...stampProvenance(),
       ...safePayload,
       ts: overrides.ts ?? new Date().toISOString(),
       tz: getTimezoneOffset(),
       tzName: getTimezoneName(),
       hostname: os.hostname(),
-      machineId: cachedMachineId(),
       platform: os.platform(),
       arch: os.arch(),
       pid: process.pid,
@@ -653,7 +584,6 @@ export function emit(event: EventType, payload: EventPayload = {}, overrides: { 
       level: levelFor(event),
       caller: caller.kind,
       ...(caller.session ? { session: caller.session } : {}),
-      ...auditOrigin(),
     };
 
     const line = JSON.stringify(record) + '\n';
@@ -1250,8 +1180,7 @@ export function getLogsPath(): string {
 
 export function _resetForTest(overrideEventsPath?: string): void {
   _eventsPath = overrideEventsPath;
-  _origin = undefined;
-  _machineId = undefined;
+  resetEventProvenanceForTest();
   _chmoddedPath = undefined;
   lastRotationCheck = 0;
 }


### PR DESCRIPTION
Fixes the activity-store provenance floor so maintainers querying `agents events` get the same actor and session lineage from both merged streams.

## What changed

- Extracted one `stampProvenance()` primitive for actor, kind, machine, session, agent, launch, and parent-session identity.
- Reused it in `emit()` and the in-process activity writer.
- Extended the embedded Python PostToolUse writer to read actor, kind, launch id, and `AGENTS_PARENT_SESSION_ID` from the child environment.
- Replaced the fabricated activity `osUser` value with the explicit value `unknown` when that store has no OS-user evidence.
- Added the unreleased changelog queue entry.

## Run result

No UI surface: this is an event-recording fix. Real unified-reader output is captured at `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/activity-provenance-run.txt`.

Both records report `actor=ada@example.com`, `kind=human`, `agent=codex`, `launchId=launch-demo`, and `parentSessionId=parent-demo`. The activity record reports `osUser=unknown`; the operational record reports the real OS user.

## Verification

- `bun run test -- scripts/gen-changelog.test.ts src/lib/event-provenance.test.ts src/lib/activity.test.ts src/lib/events.test.ts src/lib/exec-lineage.test.ts` — 5 files, 135 tests passed.
- `bun run build` — TypeScript clean.
- Full `bun run test` executed in the foreground. One unrelated existing host-state failure repeated three times: `src/lib/__tests__/usage.test.ts:263` expects no Antigravity credential, but this host returns live Antigravity account data; all provenance tests passed.
