### PR TITLE
fix(cli): route owner notifications through the one channel seam

### DIFF
--- a/apps/cli/.changelog/next/notify-owner-consolidate.md
+++ b/apps/cli/.changelog/next/notify-owner-consolidate.md
@@ -1,9 +1,12 @@
 - **Owner notifications route through the one channel seam.** The feed urgent-block
   dispatch and the monitor `notify` action now send through the registered channel
-  provider (`resolveTransport` → `ChannelProvider.send`) instead of shelling out to
+  provider (`lookupTransport` → `ChannelProvider.send`) instead of shelling out to
   `openclaw` directly. The recipient comes from `notify.owner` in agents.yaml — the
   hardcoded owner chat id is gone, so changing `notify.owner` is honoured by every
   path. A bare `--notify` on a monitor now targets `notify.owner`; `--notify <channel>`
   overrides the owner channel. The monitor path also gains the provider's missing-binary
-  guard (a clean error instead of a raw ENOENT). Source: `apps/cli/src/lib/notify.ts`,
-  `apps/cli/src/lib/monitors/dispatch.ts`.
+  guard (a clean error instead of a raw ENOENT). A channel name that resolves to no
+  registered provider (a typo in `notify.owner.channel`, or `--notify <channel>`) fails
+  that one send with a clean error — it does not exit the monitor daemon or abort the
+  `agents feed --dispatch` loop. Source: `apps/cli/src/lib/notify.ts`,
+  `apps/cli/src/lib/monitors/dispatch.ts`, `apps/cli/src/lib/channels/resolve.ts`.

--- a/apps/cli/.changelog/next/notify-owner-consolidate.md
+++ b/apps/cli/.changelog/next/notify-owner-consolidate.md
@@ -1,0 +1,9 @@
+- **Owner notifications route through the one channel seam.** The feed urgent-block
+  dispatch and the monitor `notify` action now send through the registered channel
+  provider (`resolveTransport` → `ChannelProvider.send`) instead of shelling out to
+  `openclaw` directly. The recipient comes from `notify.owner` in agents.yaml — the
+  hardcoded owner chat id is gone, so changing `notify.owner` is honoured by every
+  path. A bare `--notify` on a monitor now targets `notify.owner`; `--notify <channel>`
+  overrides the owner channel. The monitor path also gains the provider's missing-binary
+  guard (a clean error instead of a raw ENOENT). Source: `apps/cli/src/lib/notify.ts`,
+  `apps/cli/src/lib/monitors/dispatch.ts`.

--- a/apps/cli/docs/10-monitors.md
+++ b/apps/cli/docs/10-monitors.md
@@ -126,8 +126,11 @@ agents monitors remove <name>
   `--action-timeout` with routines), dispatched through `executeJobDetached`.
 - `--routine <name>` — fire an existing routine (attach a monitor to a routine).
 - `--notify [channel]` — notify the owner through the one channel seam
-  (`resolveTransport` → provider). Recipient is `notify.owner` in agents.yaml;
+  (`lookupTransport` → provider). Recipient is `notify.owner` in agents.yaml;
   `[channel]` overrides `notify.owner.channel` (which itself defaults the transport).
+  A channel with no registered provider fails that one dispatch (`ok: false`, the
+  reason logged) and leaves the daemon evaluating every other monitor — the daemon
+  never exits on a bad channel name.
 - `--webhook-out <url>` — POST the event JSON.
 
 ### Placement (pin-to-one)

--- a/apps/cli/docs/10-monitors.md
+++ b/apps/cli/docs/10-monitors.md
@@ -125,7 +125,9 @@ agents monitors remove <name>
 - `--run <agent> --prompt '…'` — spawn an agent (shares `--mode`/`--effort`/
   `--action-timeout` with routines), dispatched through `executeJobDetached`.
 - `--routine <name>` — fire an existing routine (attach a monitor to a routine).
-- `--notify [channel]` — send via the openclaw Telegram path (default: telegram).
+- `--notify [channel]` — notify the owner through the one channel seam
+  (`resolveTransport` → provider). Recipient is `notify.owner` in agents.yaml;
+  `[channel]` overrides `notify.owner.channel` (which itself defaults the transport).
 - `--webhook-out <url>` — POST the event JSON.
 
 ### Placement (pin-to-one)

--- a/apps/cli/src/commands/monitors.ts
+++ b/apps/cli/src/commands/monitors.ts
@@ -83,7 +83,7 @@ function actionLabel(action: ActionConfig): string {
     case 'routine':
       return `routine ${action.routine ?? ''}`;
     case 'notify':
-      return `notify ${action.notifyChannel ?? 'telegram'}`;
+      return `notify ${action.notifyChannel ?? 'owner'}`;
     case 'webhook-out':
       return `webhook-out ${action.url ?? ''}`;
     default:
@@ -208,9 +208,11 @@ function buildAction(options: Record<string, any>): ActionConfig {
   }
   if (options.routine) chosen.push({ type: 'routine', routine: options.routine });
   if (options.notify !== undefined) {
-    // --notify may be a bare flag (true) or carry a channel string.
-    const channel = typeof options.notify === 'string' ? options.notify : 'telegram';
-    chosen.push({ type: 'notify', notifyChannel: channel });
+    // --notify may be a bare flag (notify the owner) or carry a channel that
+    // overrides notify.owner.channel. Left unset, the send resolves the owner
+    // channel + target from notify.owner in agents.yaml (one source of truth).
+    const channel = typeof options.notify === 'string' ? options.notify : undefined;
+    chosen.push({ type: 'notify', ...(channel ? { notifyChannel: channel } : {}) });
   }
   if (options.webhookOut) chosen.push({ type: 'webhook-out', url: options.webhookOut });
 
@@ -326,7 +328,7 @@ export function registerMonitorsCommands(program: Command): void {
     .option('--effort <effort>', 'Reasoning effort for --run: low | medium | high | xhigh | max | auto')
     .option('--action-timeout <t>', 'Kill the --run action if it runs longer than this (e.g. 10m)')
     .option('--routine <name>', 'Fire an existing routine on change')
-    .option('--notify [channel]', 'Send a notification (default channel: telegram)')
+    .option('--notify [channel]', 'Notify the owner (notify.owner); [channel] overrides the owner channel')
     .option('--webhook-out <url>', 'POST the event to this URL')
     // PLACEMENT / hygiene
     .option('--device <name>', 'OWNER device — the single machine that evaluates + fires (exactly-once)')
@@ -595,7 +597,7 @@ export function registerMonitorsCommands(program: Command): void {
           name,
           source: { type: 'poll', command: 'echo hello', interval: '1m' },
           condition: { mode: 'on-change' },
-          action: { type: 'notify', notifyChannel: 'telegram' },
+          action: { type: 'notify' },
         });
         fs.writeFileSync(monitorPath, template, 'utf-8');
         console.log(chalk.gray(`Created new monitor file: ${monitorPath}`));

--- a/apps/cli/src/lib/channels/providers/openclaw-telegram.ts
+++ b/apps/cli/src/lib/channels/providers/openclaw-telegram.ts
@@ -26,7 +26,7 @@ export const openclawTelegramProvider: ChannelProvider = {
       return { ok: false, channel: name, id: opts.target, error: 'openclaw CLI not found on PATH' };
     }
     try {
-      await execFileAsync('openclaw', buildOpenClawNotifyArgs(text, { channel: 'telegram', target: opts.target }));
+      await execFileAsync('openclaw', buildOpenClawNotifyArgs(text, { target: opts.target }));
       return { ok: true, channel: name, id: opts.target };
     } catch (err) {
       return { ok: false, channel: name, id: opts.target, error: (err as Error).message };

--- a/apps/cli/src/lib/channels/providers/rush.test.ts
+++ b/apps/cli/src/lib/channels/providers/rush.test.ts
@@ -3,8 +3,8 @@ import { buildRushSendArgs, rushProviders, RUSH_CHANNELS } from './rush.js';
 
 describe('buildRushSendArgs', () => {
   it('builds the rush send argv with required channel/id and --json', () => {
-    const args = buildRushSendArgs('telegram', 'hello', { target: '6078999250' });
-    expect(args).toEqual(['send', 'hello', '--channel', 'telegram', '--id', '6078999250', '--json']);
+    const args = buildRushSendArgs('telegram', 'hello', { target: 'chat-123' });
+    expect(args).toEqual(['send', 'hello', '--channel', 'telegram', '--id', 'chat-123', '--json']);
   });
 
   it('appends --thread and repeatable --attachment', () => {
@@ -28,9 +28,9 @@ describe('rushProviders', () => {
 
   it('dry-run short-circuits without shelling out', async () => {
     const tg = rushProviders.find((p) => p.name === 'telegram')!;
-    const res = await tg.send('hi', { target: '6078999250', dryRun: true });
+    const res = await tg.send('hi', { target: 'chat-123', dryRun: true });
     expect(res.ok).toBe(true);
     expect(res.channel).toBe('telegram');
-    expect(res.id).toBe('6078999250');
+    expect(res.id).toBe('chat-123');
   });
 });

--- a/apps/cli/src/lib/channels/resolve.test.ts
+++ b/apps/cli/src/lib/channels/resolve.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { registerChannelProvider, type ChannelProvider } from './registry.js';
-import { resolveTransport } from './resolve.js';
+import { lookupTransport, resolveTransport } from './resolve.js';
 import type { Meta } from '../types.js';
 
 const stub = (name: string): ChannelProvider => ({
@@ -36,5 +36,29 @@ describe('resolveTransport', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => resolveTransport('nonexistent-channel', emptyMeta)).toThrow(/process\.exit/);
     expect(exitSpy).toHaveBeenCalled();
+  });
+});
+
+describe('lookupTransport (the non-exiting seam daemons resolve through)', () => {
+  it('returns the mapped provider like resolveTransport does', () => {
+    const meta = { notify: { transports: { telegram: 'openclaw-telegram' } } } as Meta;
+    expect(lookupTransport('telegram', meta).provider?.name).toBe('openclaw-telegram');
+  });
+
+  it('returns the failure instead of exiting on an unregistered provider', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as typeof process.exit);
+    const result = lookupTransport('nonexistent-channel', emptyMeta);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(result.provider).toBeUndefined();
+    expect(result.error).toMatch(/No channel provider 'nonexistent-channel'/);
+  });
+
+  it('names the notify.transports mapping in the error when the channel was remapped', () => {
+    const meta = { notify: { transports: { telegram: 'ghost-provider' } } } as Meta;
+    const result = lookupTransport('telegram', meta);
+    expect(result.providerName).toBe('ghost-provider');
+    expect(result.error).toMatch(/mapped from channel 'telegram' via notify\.transports/);
   });
 });

--- a/apps/cli/src/lib/channels/resolve.ts
+++ b/apps/cli/src/lib/channels/resolve.ts
@@ -4,21 +4,44 @@
  *
  * Default is name-identity (`--channel slack` -> `slack` provider) — NOT a
  * fallback to a different transport. Only telegram is dual-homed (rush vs
- * openclaw-telegram); config picks. An unmapped-to-unregistered name dies loud.
+ * openclaw-telegram); config picks.
+ *
+ * Two entry points, deliberately: `lookupTransport` *returns* the failure, for
+ * long-lived callers (the monitor daemon, the feed-dispatch loop) that must
+ * survive a bad channel name; `resolveTransport` `die()`s on it, for the
+ * interactive `agents send` / `agents notify` command path where exiting with a
+ * loud message is the right answer. Never give a daemon the dying one.
  */
 import type { Meta } from '../types.js';
 import { die } from '../format.js';
 import { resolveChannelProvider, listChannelProviders, type ChannelProvider } from './registry.js';
 
-export function resolveTransport(channel: string, meta: Meta): ChannelProvider {
+export interface TransportLookup {
+  /** Provider name after applying the `notify.transports` mapping. */
+  providerName: string;
+  /** Registered provider, or undefined when `providerName` resolves to nothing. */
+  provider?: ChannelProvider;
+  /** Why resolution failed — set exactly when `provider` is undefined. */
+  error?: string;
+}
+
+/** Resolve a channel to its provider, returning the failure instead of exiting. */
+export function lookupTransport(channel: string, meta: Meta): TransportLookup {
   const providerName = meta.notify?.transports?.[channel] ?? channel;
   const provider = resolveChannelProvider(providerName);
-  if (!provider) {
-    die(
+  if (provider) return { providerName, provider };
+  return {
+    providerName,
+    error:
       `No channel provider '${providerName}'` +
-        (providerName === channel ? '' : ` (mapped from channel '${channel}' via notify.transports)`) +
-        `. Registered: ${listChannelProviders().join(', ')}.`,
-    );
-  }
+      (providerName === channel ? '' : ` (mapped from channel '${channel}' via notify.transports)`) +
+      `. Registered: ${listChannelProviders().join(', ')}.`,
+  };
+}
+
+/** Interactive-command resolution: an unregistered provider dies loud. */
+export function resolveTransport(channel: string, meta: Meta): ChannelProvider {
+  const { provider, error } = lookupTransport(channel, meta);
+  if (!provider) die(error!);
   return provider;
 }

--- a/apps/cli/src/lib/monitors/config.ts
+++ b/apps/cli/src/lib/monitors/config.ts
@@ -103,7 +103,7 @@ export interface ActionConfig {
   timeout?: string;
   /** routine: name of an existing routine to fire. */
   routine?: string;
-  /** notify: channel for the notification (default `telegram`). */
+  /** notify: override the owner channel (defaults to `notify.owner.channel`). */
   notifyChannel?: string;
   /** webhook-out: URL to POST the event to. */
   url?: string;

--- a/apps/cli/src/lib/monitors/dispatch.test.ts
+++ b/apps/cli/src/lib/monitors/dispatch.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { spawnSync } from 'child_process';
+import { pathToFileURL } from 'url';
 import { dispatchAction } from './dispatch.js';
 import type { MonitorConfig, MonitorEvent } from './config.js';
 import type { Meta } from '../types.js';
@@ -10,7 +12,7 @@ import type { Meta } from '../types.js';
  * The monitor `notify` action used to exec openclaw directly with no target, so
  * it inherited a hardcoded owner number and had no missing-binary guard (raw
  * ENOENT). It now routes through the one owner-send seam (sendToOwner →
- * resolveTransport). Real path: a fake `openclaw` on PATH records the argv.
+ * lookupTransport). Real path: a fake `openclaw` on PATH records the argv.
  */
 describe('dispatchAction notify (resolves the owner, fails loud on a missing binary)', () => {
   let tmp: string;
@@ -95,5 +97,75 @@ describe('dispatchAction notify (resolves the owner, fails loud on a missing bin
     expect(result.ok).toBe(true);
     const argv = fs.readFileSync(record, 'utf-8');
     expect(argv).toContain('--target monitor-owner');
+  });
+
+  it('an unresolvable notifyChannel returns ok:false — it does not exit the process', async () => {
+    // `agents monitors add --notify <channel>` validates nothing (commands/monitors.ts),
+    // so a typo lands in the config and reaches here. Resolving through the
+    // die()-capable resolveTransport used to process.exit() and take the whole
+    // monitor daemon down with it (engine.ts try/catch can't catch an exit).
+    const monitor = {
+      ...notifyMonitor(),
+      action: { type: 'notify', notifyChannel: 'not-a-real-channel' },
+    } as MonitorConfig;
+    const result = await dispatchAction(monitor, event, metaWithOwner('monitor-owner'));
+    expect(result.kind).toBe('notify');
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/No channel provider 'not-a-real-channel'/);
+  });
+});
+
+/**
+ * The daemon-survival guarantee, proven in a real child process — the same shape
+ * as the review's live repro. An in-process assertion can't distinguish "returned
+ * a result" from "would have exited", so this runs dispatchAction for real and
+ * requires the process to reach the line after it and exit 0.
+ */
+describe('dispatchAction notify (process survives an unresolvable channel)', () => {
+  const tsxBin = path.resolve('node_modules/.bin/tsx');
+  let fixtureDir: string;
+
+  beforeEach(() => {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'monitor-die-'));
+  });
+
+  afterEach(() => fs.rmSync(fixtureDir, { recursive: true, force: true }));
+
+  it('returns to its caller and exits 0 instead of process.exit()-ing', () => {
+    const moduleUrl = pathToFileURL(path.resolve('src/lib/monitors/dispatch.ts')).href;
+    // A file, not `tsx -e`: the inline form compiles to cjs, where the top-level
+    // await this needs is unavailable.
+    const fixture = path.join(fixtureDir, 'dispatch-bad-channel.mts');
+    fs.writeFileSync(
+      fixture,
+      `import { dispatchAction } from ${JSON.stringify(moduleUrl)};\n` +
+        `const monitor = {\n` +
+        `  name: 'ci-red',\n` +
+        `  enabled: true,\n` +
+        `  source: { type: 'command', command: 'echo x' },\n` +
+        `  condition: { mode: 'on-change' },\n` +
+        `  action: { type: 'notify', notifyChannel: 'not-a-real-channel' },\n` +
+        `} as any;\n` +
+        `const event = {\n` +
+        `  monitorName: 'ci-red',\n` +
+        `  firedAt: '2026-07-21T12:00:00.000Z',\n` +
+        `  summary: 'build failed',\n` +
+        `  payload: {},\n` +
+        `} as any;\n` +
+        `const meta = { notify: { owner: { channel: 'telegram', to: 'monitor-owner' } } } as any;\n` +
+        `console.log('BEFORE');\n` +
+        `const result = await dispatchAction(monitor, event, meta);\n` +
+        `console.log('AFTER ' + JSON.stringify(result));\n`,
+    );
+
+    const child = spawnSync(tsxBin, [fixture], { encoding: 'utf-8' });
+
+    expect(child.status, child.stderr).toBe(0);
+    expect(child.stdout).toContain('BEFORE');
+    expect(child.stdout).toContain('AFTER '); // the pre-fix build exited before this
+    const result = JSON.parse(child.stdout.slice(child.stdout.indexOf('AFTER ') + 6).trim());
+    expect(result.kind).toBe('notify');
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/No channel provider 'not-a-real-channel'/);
   });
 });

--- a/apps/cli/src/lib/monitors/dispatch.test.ts
+++ b/apps/cli/src/lib/monitors/dispatch.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { dispatchAction } from './dispatch.js';
+import type { MonitorConfig, MonitorEvent } from './config.js';
+import type { Meta } from '../types.js';
+
+/**
+ * The monitor `notify` action used to exec openclaw directly with no target, so
+ * it inherited a hardcoded owner number and had no missing-binary guard (raw
+ * ENOENT). It now routes through the one owner-send seam (sendToOwner →
+ * resolveTransport). Real path: a fake `openclaw` on PATH records the argv.
+ */
+describe('dispatchAction notify (resolves the owner, fails loud on a missing binary)', () => {
+  let tmp: string;
+  let record: string;
+  const savedPath = process.env.PATH;
+  const savedRecord = process.env.OPENCLAW_RECORD;
+
+  function metaWithOwner(to: string): Meta {
+    return {
+      notify: { owner: { channel: 'telegram', to }, transports: { telegram: 'openclaw-telegram' } },
+    } as Meta;
+  }
+
+  function notifyMonitor(): MonitorConfig {
+    return {
+      name: 'ci-red',
+      enabled: true,
+      source: { type: 'command', command: 'echo x' },
+      condition: { mode: 'on-change' },
+      action: { type: 'notify' },
+    } as MonitorConfig;
+  }
+
+  const event: MonitorEvent = {
+    monitorName: 'ci-red',
+    firedAt: '2026-07-21T12:00:00.000Z',
+    summary: 'build failed',
+    payload: {},
+  };
+
+  function installFakeOpenclaw(): void {
+    const bin = path.join(tmp, 'openclaw');
+    fs.writeFileSync(bin, `#!/bin/sh\nprintf '%s\\n' "$*" >> "$OPENCLAW_RECORD"\nexit 0\n`);
+    fs.chmodSync(bin, 0o755);
+    process.env.PATH = `${tmp}${path.delimiter}/usr/bin${path.delimiter}/bin`;
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'monitor-notify-'));
+    record = path.join(tmp, 'argv.log');
+    process.env.OPENCLAW_RECORD = record;
+  });
+
+  afterEach(() => {
+    if (savedPath === undefined) delete process.env.PATH;
+    else process.env.PATH = savedPath;
+    if (savedRecord === undefined) delete process.env.OPENCLAW_RECORD;
+    else process.env.OPENCLAW_RECORD = savedRecord;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('sends the fired event to notify.owner.to, not a hardcoded number', async () => {
+    installFakeOpenclaw();
+    const result = await dispatchAction(notifyMonitor(), event, metaWithOwner('monitor-owner'));
+    expect(result).toEqual({ kind: 'notify', ok: true });
+    const argv = fs.readFileSync(record, 'utf-8');
+    expect(argv).toContain('--target monitor-owner');
+    expect(argv).toContain('--message build failed');
+  });
+
+  it('follows a change to notify.owner.to', async () => {
+    installFakeOpenclaw();
+    await dispatchAction(notifyMonitor(), event, metaWithOwner('owner-a'));
+    await dispatchAction(notifyMonitor(), event, metaWithOwner('owner-b'));
+    const argv = fs.readFileSync(record, 'utf-8');
+    expect(argv).toContain('--target owner-a');
+    expect(argv).toContain('--target owner-b');
+  });
+
+  it('fails loud with a clean error (not ENOENT) when openclaw is missing', async () => {
+    process.env.PATH = `${tmp}${path.delimiter}/usr/bin${path.delimiter}/bin`; // no openclaw on PATH
+    const result = await dispatchAction(notifyMonitor(), event, metaWithOwner('monitor-owner'));
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('openclaw CLI not found on PATH');
+    expect(result.error).not.toMatch(/ENOENT/);
+  });
+
+  it('an explicit notifyChannel overrides the owner channel but keeps the owner target', async () => {
+    installFakeOpenclaw();
+    const monitor = { ...notifyMonitor(), action: { type: 'notify', notifyChannel: 'telegram' } } as MonitorConfig;
+    const result = await dispatchAction(monitor, event, metaWithOwner('monitor-owner'));
+    expect(result.ok).toBe(true);
+    const argv = fs.readFileSync(record, 'utf-8');
+    expect(argv).toContain('--target monitor-owner');
+  });
+});

--- a/apps/cli/src/lib/monitors/dispatch.ts
+++ b/apps/cli/src/lib/monitors/dispatch.ts
@@ -5,8 +5,9 @@
  * action goes through the *same* detached spawn cron and webhook fires use
  * (executeJobDetached, lib/runner.ts) — a monitor never duplicates spawn logic,
  * it synthesizes a JobConfig and hands it to the one dispatch seam. `notify`
- * routes the owner through the one channel seam (sendToOwner → resolveTransport,
- * lib/notify.ts) — recipient from notify.owner, no hardcoded chat id;
+ * routes the owner through the one channel seam (sendToOwner → lookupTransport,
+ * lib/notify.ts) — recipient from notify.owner, no hardcoded chat id, and an
+ * unresolvable channel comes back as `ok: false` instead of exiting the daemon;
  * `webhook-out` POSTs the event.
  */
 

--- a/apps/cli/src/lib/monitors/dispatch.ts
+++ b/apps/cli/src/lib/monitors/dispatch.ts
@@ -5,18 +5,16 @@
  * action goes through the *same* detached spawn cron and webhook fires use
  * (executeJobDetached, lib/runner.ts) — a monitor never duplicates spawn logic,
  * it synthesizes a JobConfig and hands it to the one dispatch seam. `notify`
- * reuses the openclaw Telegram path (lib/notify.ts); `webhook-out` POSTs the event.
+ * routes the owner through the one channel seam (sendToOwner → resolveTransport,
+ * lib/notify.ts) — recipient from notify.owner, no hardcoded chat id;
+ * `webhook-out` POSTs the event.
  */
 
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { executeJobDetached } from '../runner.js';
 import { readJob, type JobConfig } from '../routines.js';
-import { buildOpenClawNotifyArgs } from '../notify.js';
-import type { AgentId } from '../types.js';
+import { sendToOwner } from '../notify.js';
+import type { AgentId, Meta } from '../types.js';
 import type { ActionConfig, MonitorConfig, MonitorEvent } from './config.js';
-
-const execFileAsync = promisify(execFile);
 
 /** Outcome of a dispatched action. */
 export interface DispatchResult {
@@ -42,6 +40,7 @@ export function injectEvent(prompt: string, event: MonitorEvent): string {
 export async function dispatchAction(
   monitor: MonitorConfig,
   event: MonitorEvent,
+  meta?: Meta,
 ): Promise<DispatchResult> {
   const action = monitor.action;
 
@@ -82,15 +81,11 @@ export async function dispatchAction(
   }
 
   if (action.type === 'notify') {
-    const args = buildOpenClawNotifyArgs(event.summary, {
-      channel: action.notifyChannel ?? 'telegram',
+    const result = await sendToOwner(event.summary, {
+      ...(meta ? { meta } : {}),
+      ...(action.notifyChannel ? { channel: action.notifyChannel } : {}),
     });
-    try {
-      await execFileAsync('openclaw', args);
-      return { kind: 'notify', ok: true };
-    } catch (err) {
-      return { kind: 'notify', ok: false, error: (err as Error).message };
-    }
+    return { kind: 'notify', ok: result.ok, ...(result.ok ? {} : { error: result.error }) };
   }
 
   // webhook-out

--- a/apps/cli/src/lib/notify.test.ts
+++ b/apps/cli/src/lib/notify.test.ts
@@ -59,7 +59,7 @@ describe('formatUrgentBlockMessage', () => {
 /**
  * Real-path tests for the consolidated owner-send seam. No mocking: a real
  * `openclaw` executable (a shell script that records its argv) is placed on PATH,
- * so the assertions run through resolveTransport → openclaw-telegram provider →
+ * so the assertions run through lookupTransport → openclaw-telegram provider →
  * exec, the actual delivery path.
  */
 describe('sendToOwner (owner resolution + provider routing)', () => {
@@ -145,6 +145,32 @@ describe('sendToOwner (owner resolution + provider routing)', () => {
     const result = await sendToOwner('ping', { meta: {} as Meta });
     expect(result.ok).toBe(false);
     expect(result.error).toContain('notify.owner');
+  });
+
+  it('returns ok:false on an unresolvable channel — never process.exit()', async () => {
+    // sendToOwner is called from the monitor daemon and the feed-dispatch loop,
+    // so it must resolve via lookupTransport, not the die()-capable
+    // resolveTransport: an exit here bypasses both callers' try/catch.
+    let exited: number | undefined;
+    const realExit = process.exit;
+    // Tripwire, not a mock of the code under test: if the seam still exits, the
+    // call would abort the run — record the attempt and let the assertion fail.
+    process.exit = ((code?: number) => {
+      exited = code ?? 0;
+      throw new Error(`process.exit(${exited})`);
+    }) as typeof process.exit;
+    try {
+      const result = await sendToOwner('ping', {
+        meta: { notify: { owner: { channel: 'typo-channel', to: 'owner-chat-4' } } } as Meta,
+      });
+      expect(exited).toBeUndefined();
+      expect(result.ok).toBe(false);
+      expect(result.channel).toBe('typo-channel');
+      expect(result.id).toBe('owner-chat-4');
+      expect(result.error).toMatch(/No channel provider 'typo-channel'/);
+    } finally {
+      process.exit = realExit;
+    }
   });
 });
 

--- a/apps/cli/src/lib/notify.test.ts
+++ b/apps/cli/src/lib/notify.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from 'vitest';
-import { buildOpenClawNotifyArgs, formatUrgentBlockMessage } from './notify.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  buildOpenClawNotifyArgs,
+  formatUrgentBlockMessage,
+  notifyUrgentBlock,
+  sendToOwner,
+} from './notify.js';
+import type { Meta } from './types.js';
+import type { OpenBlock } from './feed.js';
 
-describe('buildOpenClawNotifyArgs (RUSH-1620)', () => {
-  it('includes --target and --message (not --text)', () => {
-    const args = buildOpenClawNotifyArgs('hello');
+describe('buildOpenClawNotifyArgs', () => {
+  it('builds message-send argv with the caller-supplied target (no hardcoded number)', () => {
+    const args = buildOpenClawNotifyArgs('hello', { target: 'chat-42' });
     expect(args).toEqual([
       'message',
       'send',
@@ -12,16 +22,18 @@ describe('buildOpenClawNotifyArgs (RUSH-1620)', () => {
       '--account',
       'default',
       '--target',
-      '6078999250',
+      'chat-42',
       '--message',
       'hello',
     ]);
     expect(args).not.toContain('--text');
   });
 
-  it('allows overriding target', () => {
-    const args = buildOpenClawNotifyArgs('hi', { target: '123' });
-    expect(args[args.indexOf('--target') + 1]).toBe('123');
+  it('has no numeric-literal recipient default baked into the source', () => {
+    // The recipient is always resolved by the caller; regression guard against
+    // re-introducing a `?? '<some chat id>'` default for any target/owner.
+    const src = fs.readFileSync(new URL('./notify.ts', import.meta.url), 'utf-8');
+    expect(src).not.toMatch(/\?\?\s*['"]\d{5,}['"]/);
   });
 });
 
@@ -41,5 +53,154 @@ describe('formatUrgentBlockMessage', () => {
 
     expect(message).toBe('URGENT DECISION on zion: [Deploy] Production deploy? (cost: high, id: block-a)');
     expect(message).not.toContain(String.fromCodePoint(0x1f6a8));
+  });
+});
+
+/**
+ * Real-path tests for the consolidated owner-send seam. No mocking: a real
+ * `openclaw` executable (a shell script that records its argv) is placed on PATH,
+ * so the assertions run through resolveTransport → openclaw-telegram provider →
+ * exec, the actual delivery path.
+ */
+describe('sendToOwner (owner resolution + provider routing)', () => {
+  let tmp: string;
+  let record: string;
+  const savedPath = process.env.PATH;
+  const savedRecord = process.env.OPENCLAW_RECORD;
+
+  /** A Meta that routes telegram -> openclaw-telegram and names an owner. */
+  function metaWithOwner(to: string): Meta {
+    return {
+      notify: {
+        owner: { channel: 'telegram', to },
+        transports: { telegram: 'openclaw-telegram' },
+      },
+    } as Meta;
+  }
+
+  /** Install a fake `openclaw` on PATH that appends its argv to `record`. */
+  function installFakeOpenclaw(): void {
+    const bin = path.join(tmp, 'openclaw');
+    fs.writeFileSync(bin, `#!/bin/sh\nprintf '%s\\n' "$*" >> "$OPENCLAW_RECORD"\nexit 0\n`);
+    fs.chmodSync(bin, 0o755);
+    process.env.PATH = `${tmp}${path.delimiter}/usr/bin${path.delimiter}/bin`;
+  }
+
+  /** A PATH with `which`/`sh` available but no `openclaw` anywhere on it. */
+  function pathWithoutOpenclaw(): void {
+    process.env.PATH = `${tmp}${path.delimiter}/usr/bin${path.delimiter}/bin`;
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-'));
+    record = path.join(tmp, 'argv.log');
+    process.env.OPENCLAW_RECORD = record;
+  });
+
+  afterEach(() => {
+    if (savedPath === undefined) delete process.env.PATH;
+    else process.env.PATH = savedPath;
+    if (savedRecord === undefined) delete process.env.OPENCLAW_RECORD;
+    else process.env.OPENCLAW_RECORD = savedRecord;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('resolves the recipient from notify.owner.to and hands it to the provider', async () => {
+    installFakeOpenclaw();
+    const result = await sendToOwner('ping', { meta: metaWithOwner('owner-chat-1') });
+    expect(result.ok).toBe(true);
+    expect(result.channel).toBe('openclaw-telegram');
+    expect(result.id).toBe('owner-chat-1');
+    const argv = fs.readFileSync(record, 'utf-8');
+    expect(argv).toContain('--target owner-chat-1');
+    expect(argv).toContain('--message ping');
+  });
+
+  it('follows a change to notify.owner.to (one source of truth)', async () => {
+    installFakeOpenclaw();
+    await sendToOwner('a', { meta: metaWithOwner('first') });
+    await sendToOwner('b', { meta: metaWithOwner('second') });
+    const argv = fs.readFileSync(record, 'utf-8');
+    expect(argv).toContain('--target first');
+    expect(argv).toContain('--target second');
+  });
+
+  it('honours a dry-run without exec, echoing the resolved target', async () => {
+    installFakeOpenclaw();
+    const result = await sendToOwner('ping', { meta: metaWithOwner('owner-chat-2'), dryRun: true });
+    expect(result.ok).toBe(true);
+    expect(result.id).toBe('owner-chat-2');
+    expect(fs.existsSync(record)).toBe(false); // nothing exec'd
+  });
+
+  it('fails loud (not ENOENT) when the provider binary is missing', async () => {
+    pathWithoutOpenclaw();
+    const result = await sendToOwner('ping', { meta: metaWithOwner('owner-chat-3') });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('openclaw CLI not found on PATH');
+    expect(result.error).not.toMatch(/ENOENT/);
+  });
+
+  it('fails loud when notify.owner is unset (no hardcoded fallback)', async () => {
+    const result = await sendToOwner('ping', { meta: {} as Meta });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('notify.owner');
+  });
+});
+
+describe('notifyUrgentBlock (feed urgent-block dispatch resolves the owner)', () => {
+  let tmp: string;
+  let record: string;
+  const savedPath = process.env.PATH;
+  const savedRecord = process.env.OPENCLAW_RECORD;
+
+  function block(): OpenBlock {
+    return {
+      blockId: 'b1',
+      sessionId: 's1',
+      mailboxId: 'm1',
+      host: 'zion',
+      runtime: 'headless',
+      ts: '2026-07-21T12:00:00.000Z',
+      questions: [{ header: 'Deploy', text: 'Ship it?' }],
+    };
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-block-'));
+    record = path.join(tmp, 'argv.log');
+    process.env.OPENCLAW_RECORD = record;
+    const bin = path.join(tmp, 'openclaw');
+    fs.writeFileSync(bin, `#!/bin/sh\nprintf '%s\\n' "$*" >> "$OPENCLAW_RECORD"\nexit 0\n`);
+    fs.chmodSync(bin, 0o755);
+    process.env.PATH = `${tmp}${path.delimiter}/usr/bin${path.delimiter}/bin`;
+  });
+
+  afterEach(() => {
+    if (savedPath === undefined) delete process.env.PATH;
+    else process.env.PATH = savedPath;
+    if (savedRecord === undefined) delete process.env.OPENCLAW_RECORD;
+    else process.env.OPENCLAW_RECORD = savedRecord;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('sends the urgent block to notify.owner.to, not a hardcoded number', async () => {
+    const meta = {
+      notify: { owner: { channel: 'telegram', to: 'urgent-owner' }, transports: { telegram: 'openclaw-telegram' } },
+    } as Meta;
+    const result = await notifyUrgentBlock(block(), { meta });
+    expect(result.ok).toBe(true);
+    const argv = fs.readFileSync(record, 'utf-8');
+    expect(argv).toContain('--target urgent-owner');
+    expect(argv).toContain('URGENT');
+  });
+
+  it('skips an already-notified block without touching the provider', async () => {
+    const meta = {
+      notify: { owner: { channel: 'telegram', to: 'urgent-owner' }, transports: { telegram: 'openclaw-telegram' } },
+    } as Meta;
+    const result = await notifyUrgentBlock({ ...block(), notifiedAt: '2026-07-21T12:00:00.000Z' }, { meta });
+    expect(result.skipped).toBe(true);
+    expect(fs.existsSync(record)).toBe(false);
   });
 });

--- a/apps/cli/src/lib/notify.ts
+++ b/apps/cli/src/lib/notify.ts
@@ -3,18 +3,21 @@
  *
  * Every human-facing owner notification (feed urgent-block dispatch, monitor
  * `notify` action, `agents notify`) funnels through the single channel seam:
- * `resolveTransport(channel, meta).send(text, opts)`. The recipient comes from
- * `notify.owner` in agents.yaml — never a hardcoded chat id — so changing the
+ * `lookupTransport(channel, meta).provider.send(text, opts)`. The recipient comes
+ * from `notify.owner` in agents.yaml — never a hardcoded chat id — so changing the
  * owner is honoured by every path at once. `notify.transports` picks the actual
  * provider per host (rush telegram on zion, openclaw-telegram on mac-mini).
  * Best-effort: a delivery failure is returned to the caller, never thrown, so a
- * notification hiccup never blocks the agent.
+ * notification hiccup never blocks the agent. That is why this module resolves
+ * with `lookupTransport` and not the `die()`-capable `resolveTransport` — the
+ * monitor daemon and the feed-dispatch loop call in here, and `process.exit()`
+ * would take them down on a typo'd channel name, bypassing their try/catch.
  */
 import type { OpenBlock } from './feed.js';
 import type { Meta } from './types.js';
 import { readMeta } from './state.js';
 import { registerBuiltinProviders } from './channels/providers/index.js';
-import { resolveTransport } from './channels/resolve.js';
+import { lookupTransport } from './channels/resolve.js';
 import type { SendResult } from './channels/registry.js';
 
 export interface OwnerNotifyOptions {
@@ -90,7 +93,10 @@ export async function sendToOwner(text: string, options: OwnerNotifyOptions = {}
     };
   }
   registerBuiltinProviders();
-  const provider = resolveTransport(channel, meta);
+  const { provider, error } = lookupTransport(channel, meta);
+  if (!provider) {
+    return { ok: false, channel, id: target, error };
+  }
   return provider.send(text, { target, dryRun: options.dryRun });
 }
 

--- a/apps/cli/src/lib/notify.ts
+++ b/apps/cli/src/lib/notify.ts
@@ -1,22 +1,30 @@
 /**
- * Urgent-block phone notifier.
+ * Owner notifier — the one seam for "ping the human" messages.
  *
- * Reuses the OpenClaw Telegram gateway on the local mac-mini (Jeff/`default` bot)
- * instead of raw bot tokens. Notifies once per block (tracked by `notifiedAt`).
- * Best-effort: any openclaw failure is surfaced as a warning, not a hard error,
- * so a notification hiccup never blocks the agent.
+ * Every human-facing owner notification (feed urgent-block dispatch, monitor
+ * `notify` action, `agents notify`) funnels through the single channel seam:
+ * `resolveTransport(channel, meta).send(text, opts)`. The recipient comes from
+ * `notify.owner` in agents.yaml — never a hardcoded chat id — so changing the
+ * owner is honoured by every path at once. `notify.transports` picks the actual
+ * provider per host (rush telegram on zion, openclaw-telegram on mac-mini).
+ * Best-effort: a delivery failure is returned to the caller, never thrown, so a
+ * notification hiccup never blocks the agent.
  */
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import type { OpenBlock } from './feed.js';
+import type { Meta } from './types.js';
+import { readMeta } from './state.js';
+import { registerBuiltinProviders } from './channels/providers/index.js';
+import { resolveTransport } from './channels/resolve.js';
+import type { SendResult } from './channels/registry.js';
 
-const execFileAsync = promisify(execFile);
-
-export interface NotifyOptions {
+export interface OwnerNotifyOptions {
+  /** Config source (defaults to `readMeta()`); lets callers/tests inject it. */
+  meta?: Meta;
+  /** Override the owner channel from `notify.owner.channel`. */
   channel?: string;
-  account?: string;
-  /** OpenClaw destination (Telegram chat id). Defaults to Muqsit's chat. */
+  /** Override the owner target from `notify.owner.to`. */
   target?: string;
+  /** Resolve + build the delivery but do not actually send. */
   dryRun?: boolean;
 }
 
@@ -36,14 +44,17 @@ export function formatUrgentBlockMessage(block: OpenBlock): string {
   return `URGENT ${cls.toUpperCase()}${host}: ${header}${text} (cost: ${cost}, id: ${block.blockId})`;
 }
 
-/** Build openclaw argv for urgent notify (exported for tests). */
+/**
+ * Build openclaw argv for a Telegram send (used by the openclaw-telegram
+ * provider and its tests). `target` is required — the recipient is always
+ * resolved by the caller, never defaulted to a hardcoded number here.
+ */
 export function buildOpenClawNotifyArgs(
   text: string,
-  options: Pick<NotifyOptions, 'channel' | 'account' | 'target'> = {},
+  opts: { target: string; channel?: string; account?: string },
 ): string[] {
-  const channel = options.channel ?? 'telegram';
-  const account = options.account ?? 'default';
-  const target = options.target ?? '6078999250';
+  const channel = opts.channel ?? 'telegram';
+  const account = opts.account ?? 'default';
   return [
     'message',
     'send',
@@ -52,15 +63,40 @@ export function buildOpenClawNotifyArgs(
     '--account',
     account,
     '--target',
-    target,
+    opts.target,
     '--message',
     text,
   ];
 }
 
+/**
+ * Deliver a message to the configured owner through the one channel seam.
+ * `channel`/`target` default to `notify.owner.{channel,to}`; `notify.transports`
+ * selects the provider per host. A missing owner config or a delivery failure
+ * (e.g. openclaw not on PATH) returns a clean `SendResult` error — never a raw
+ * ENOENT — so callers surface a consistent, best-effort failure.
+ */
+export async function sendToOwner(text: string, options: OwnerNotifyOptions = {}): Promise<SendResult> {
+  const meta = options.meta ?? readMeta();
+  const owner = meta.notify?.owner;
+  const channel = options.channel ?? owner?.channel;
+  const target = options.target ?? owner?.to;
+  if (!channel || !target) {
+    return {
+      ok: false,
+      channel: channel ?? 'unknown',
+      id: target ?? '',
+      error: 'notify.owner.{channel,to} not set in agents.yaml',
+    };
+  }
+  registerBuiltinProviders();
+  const provider = resolveTransport(channel, meta);
+  return provider.send(text, { target, dryRun: options.dryRun });
+}
+
 export async function notifyUrgentBlock(
   block: OpenBlock,
-  options: NotifyOptions = {},
+  options: OwnerNotifyOptions = {},
 ): Promise<NotifyResult> {
   if (block.notifiedAt) {
     return { ok: true, skipped: true };
@@ -70,19 +106,6 @@ export async function notifyUrgentBlock(
     return { ok: true, skipped: true };
   }
 
-  // Check that openclaw is installed.
-  try {
-    await execFileAsync('which', ['openclaw']);
-  } catch {
-    return { ok: false, error: 'openclaw CLI not found on PATH' };
-  }
-
-  const text = formatUrgentBlockMessage(block);
-
-  try {
-    await execFileAsync('openclaw', buildOpenClawNotifyArgs(text, options));
-    return { ok: true };
-  } catch (err) {
-    return { ok: false, error: (err as Error).message };
-  }
+  const result = await sendToOwner(formatUrgentBlockMessage(block), options);
+  return result.ok ? { ok: true } : { ok: false, error: result.error };
 }


### PR DESCRIPTION
**fix / bug** — one send primitive for owner notifications; removes a hardcoded owner chat id that made `notify.owner` changes invisible to two send paths.

## The bug

Two paths shelled out to `openclaw` directly (via `buildOpenClawNotifyArgs`), bypassing the registered `ChannelProvider`, and both inherited a hardcoded owner number `'6078999250'`:

- `notifyUrgentBlock` — `agents feed --dispatch` urgent-block phone ping (`src/lib/notify.ts`)
- the monitor `notify` action (`src/lib/monitors/dispatch.ts`) — passed **no** target, so it inherited that same hardcoded number, and had **no** `which openclaw` guard (a missing binary surfaced as a raw `ENOENT`)

Meanwhile `agents notify` correctly resolves the owner from `notify.owner` in agents.yaml. So a change to `notify.owner` was honoured by one path and silently ignored by the other two.

## The fix

`sendToOwner(text, opts)` is now the single owner-send primitive — `resolveTransport(channel, meta).send()` with the recipient resolved from `notify.owner` (channel + target), and `notify.transports` selecting the provider per host (rush telegram on zion, openclaw-telegram on mac-mini).

- `notifyUrgentBlock` and the monitor `notify` action both call it; the two duplicate `which openclaw` + exec blocks are deleted.
- The `'6078999250'` literal is **gone** (`buildOpenClawNotifyArgs` now requires an explicit `target`; `grep 6078999250 src/` is zero).
- A bare monitor `--notify` targets `notify.owner`; `--notify <channel>` overrides the owner channel. The monitor path gains the provider's missing-binary guard (clean error, not ENOENT) and dry-run for free.
- Docs (`docs/10-monitors.md`) + CHANGELOG fragment updated.

## Test run (real path, no mocking)

New tests place a real fake `openclaw` on `PATH` that records its argv, then drive each path and assert the recipient came from `notify.owner` — and that changing `notify.owner.to` is followed, and a missing binary fails loud (clean error, not ENOENT).

```
$ vitest run src/lib/notify.test.ts src/lib/monitors/dispatch.test.ts \
             src/lib/channels/providers/rush.test.ts
 Test Files  3 passed (3)
      Tests  18 passed (18)

$ vitest run src/lib/monitors/ src/commands/monitors.test.ts \
             src/lib/channels/ src/commands/feed.test.ts src/commands/send.test.ts
 Test Files  14 passed (14)
      Tests  117 passed (117)
```

`tsc --noEmit` and `bun run build` are clean.

**Note:** the full local suite has 7 unrelated failures on this linux box (exec-lineage, exec, usage/keychain, codex model catalog, project-key repo-root) — all environment-dependent (no keychain/codex, worktree cwd) and none import notify/monitors/channels. CI runs the canonical crabbox suite.

No Linear ticket (linear.app bundle unavailable on this host); scoped from the design-drift review's HIGH finding #2.
