### PR TITLE
fix(routines): a routine runs on exactly one device, not once per device listed

### DIFF
--- a/apps/cli/.changelog/next/routines-single-device.md
+++ b/apps/cli/.changelog/next/routines-single-device.md
@@ -1,0 +1,17 @@
+- **A routine now runs on exactly one device, instead of once per device listed.** `devices:`
+  was an allowlist where *every* listed device fired independently, so a routine pinned to two
+  boxes ran twice on every schedule — two full agent sessions doing identical work and burning
+  double the agent quota. On one live fleet seven routines were in that state: `security-sweep`
+  ran at 15:30:02 on one box and 15:30:03 on the other, both completing. Ownership is now a pure
+  function of the config (the first device in normalized sort order), so every daemon reaches the
+  same answer with no lease, no cross-device coordination, and no split brain when the fleet
+  partitions. Omitting `devices` still means fleet-wide, which is what `watchdog` and
+  `check-updates` want.
+- **`agents routines add --devices a,b` and `devices --set a,b` are now rejected.** A routine
+  belongs to one machine; the error names the fix. Routines already on disk with a multi-device
+  pin keep running — on their owner only — rather than being dropped.
+- **`agents doctor` lists any routine still carrying a multi-device pin**, with the devices it
+  names, the one that now fires, and the command to make it explicit. Also in `doctor --json` as
+  `ambiguousDevicePins`. The remediation deliberately offers the candidates rather than
+  prescribing the owner: the lowest-sorted name can be a registry alias that matches no live
+  machine, and cementing that would keep the routine dead.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -111,7 +111,7 @@ timeout: 10m
 runOnce: false                # true for one-shot jobs (--at)
 endAt: "2026-12-31T23:59:00Z" # optional: auto-disable on/after this time
 hostStrategy: local           # local | host | fleet | cloud (see Host placement strategy)
-devices:                      # optional: allowlist — each listed device fires independently
+devices:                      # optional: the ONE device that owns this routine
   - yosemite-s0               # omit entirely (or --clear) for unrestricted
   - mac-mini
 # source:                     # set by `agents routines enable-project` / sync
@@ -420,7 +420,8 @@ prompt: "Drain the local work queue"
 ```
 
 Each listed machine fires the job **independently** on its own schedule — both
-`yosemite-s0` and `mac-mini` run their own copy, with their own run history.
+Only the owner runs it — one copy, one run history. Listing several devices is a
+misconfiguration and is refused at creation.
 A single-entry list is equivalent to an exclusive pin: `devices: [yosemite-s0]`
 restricts the job to one machine.
 
@@ -428,7 +429,7 @@ Or set the allowlist at creation with `--devices`:
 
 ```bash
 agents routines add drain --schedule "0 3 * * *" --agent claude \
-  --devices yosemite-s0,mac-mini --prompt "Drain the local work queue"
+  --devices yosemite-s0 --prompt "Drain the local work queue"
 ```
 
 `--devices` is validated against the registered fleet (`agents devices sync`).
@@ -513,7 +514,7 @@ The picker starts with the current allowlist pre-checked. Confirm to overwrite.
 For scripting:
 
 ```bash
-agents routines devices drain --set yosemite-s0,mac-mini  # replace allowlist
+agents routines devices drain --set yosemite-s0            # set the owning device
 agents routines devices drain --clear                      # remove allowlist (unrestricted)
 ```
 
@@ -532,7 +533,7 @@ agents routines run drain --host yosemite-s0
 
 # Create a job pre-assigned to two hosts, then confirm it looks right on one
 agents routines add drain --schedule "0 3 * * *" --agent claude \
-  --devices yosemite-s0,mac-mini --prompt "Drain queue" --host yosemite-s0
+  --devices yosemite-s0 --prompt "Drain queue" --host yosemite-s0
 ```
 
 When you try to run a job on a host outside its allowlist, the CLI prints:
@@ -943,7 +944,7 @@ runs are finalized by the monitor sweep and do not emit one.
 agents routines list                  # List all jobs with next run + status
 agents routines list --host yosemite-s0  # List another device's routines
 agents routines add <name> --schedule "0 9 * * *" --agent claude --prompt "..."  # Inline
-agents routines add <name> --devices yosemite-s0,mac-mini --schedule "0 3 * * *" \
+agents routines add <name> --devices yosemite-s0 --schedule "0 3 * * *" \
   --agent claude --prompt "..."       # Add with device allowlist
 agents routines add <path.yml>        # Add from YAML file
 agents routines add <name> --at "14:30" --agent claude --prompt "..."            # One-shot
@@ -954,7 +955,7 @@ agents routines resume <name>         # Re-enable a paused job
 
 # Device allowlist management
 agents routines devices <name>                         # Interactive multi-select picker
-agents routines devices <name> --set yosemite-s0,mac-mini  # Replace allowlist
+agents routines devices <name> --set yosemite-s0           # Set the owning device
 agents routines devices <name> --clear                 # Remove allowlist (unrestricted)
 
 # Execution

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -447,8 +447,16 @@ Device names are compared against the local `machineId()` (normalized hostname, 
 shown by `agents devices`), so `Yosemite-S0` and `yosemite-s0.tailnet.ts.net` both
 match `yosemite-s0`.
 
+**A routine runs on exactly one device.** `devices:` is an allowlist, but only its
+**owner** fires — the first entry in normalized sort order. Ownership is derived from
+the config alone, so every daemon independently reaches the same answer with no lease
+and no coordination. Listing several devices is a misconfiguration: it used to fire the
+routine once per listed device (duplicate work, duplicate spend), so `add`/`devices --set`
+now reject it and `agents doctor` reports any that remain on disk.
+
 **Omitting `devices:` means unrestricted** — the job fires on every device running
-the scheduler. `--clear` restores unrestricted behavior (see below).
+the scheduler. That is the genuine fleet-wide case (`watchdog`, `check-updates`).
+`--clear` restores it (see below).
 
 On a device not in the allowlist the job is fully inert:
 

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -112,8 +112,7 @@ runOnce: false                # true for one-shot jobs (--at)
 endAt: "2026-12-31T23:59:00Z" # optional: auto-disable on/after this time
 hostStrategy: local           # local | host | fleet | cloud (see Host placement strategy)
 devices:                      # optional: the ONE device that owns this routine
-  - yosemite-s0               # omit entirely (or --clear) for unrestricted
-  - mac-mini
+  - yosemite-s0               # omit entirely (or --clear) to run on every device
 # source:                     # set by `agents routines enable-project` / sync
 #   kind: project
 #   projectPath: /path/to/repo
@@ -415,13 +414,14 @@ schedule: "0 3 * * *"
 agent: claude
 devices:
   - yosemite-s0
-  - mac-mini
 prompt: "Drain the local work queue"
 ```
 
-Each listed machine fires the job **independently** on its own schedule — both
-Only the owner runs it — one copy, one run history. Listing several devices is a
-misconfiguration and is refused at creation.
+Only the **owner** fires the job — one copy, one run history. Ownership is the
+first device in normalized sort order, computed from the config alone, so every
+daemon agrees without coordination. Listing several devices is a misconfiguration
+(it used to fire the routine once per device) and is refused at creation; omit
+`devices:` entirely for a routine that genuinely belongs on every machine.
 A single-entry list is equivalent to an exclusive pin: `devices: [yosemite-s0]`
 restricts the job to one machine.
 

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -44,6 +44,7 @@ import { resolveHost } from '../lib/hosts/registry.js';
 import { sshExecAsync } from '../lib/ssh-exec.js';
 import { sshTargetFor } from '../lib/hosts/types.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
+import { findAmbiguousDevicePins } from '../lib/routines.js';
 import chalk from 'chalk';
 import { checkAllClis, collectTeamsDoctorData, type TeamsDoctorEntry } from '../lib/teams/agents.js';
 import { AGENTS, ALL_AGENT_IDS, resolveAgentName, formatAgentError, getAccountInfo, type AccountInfo } from '../lib/agents.js';
@@ -1515,6 +1516,10 @@ export function registerDoctorCommand(program: Command): void {
         const inventory = await collectLocalFleetInventory(cwd);
         const localName = machineId();
         const duplicateHooks = inspectDuplicateVersionHooks(cwd);
+        // A routine belongs to one device. A multi-device pin used to fire it
+        // once per listed device — duplicate agent runs, duplicate spend — so
+        // surface any that are still on disk with the exact fix.
+        const ambiguousPins = findAmbiguousDevicePins(cwd);
 
         // Legacy account-global sign-in map, kept for `--json` back-compat
         // (ssh.ts RemoteDoctorJson / menubar read `signIn`). File-based, no home.
@@ -1586,6 +1591,9 @@ export function registerDoctorCommand(program: Command): void {
             // reading `sync`/`orphans`/`repos` are unaffected.
             health: computeOverviewHealth(syncRows, orphanRows, repoBehindMarkers, duplicateHooks),
             duplicateHooks,
+            // Routines whose `devices` names more than one machine — each used to
+            // fire once per device. `owner` is the one that fires now.
+            ambiguousDevicePins: ambiguousPins,
             // Prioritized RUSH-2069 findings (critical/warning, per-version, with
             // remediation). Additive alongside the legacy fields above.
             findings,
@@ -1629,6 +1637,25 @@ export function registerDoctorCommand(program: Command): void {
         // reviews and applies them together (opt-in, never auto-fires here).
         if (syncRows.some((r) => r.status !== 'fresh' || (r.unwiredHooks ?? 0) > 0) || repoBehindMarkers.some((m) => m.behind > 0)) {
           console.log(chalk.gray('\nRun `agents status` to review and sync what has drifted.'));
+        }
+        // A routine runs on exactly one device. Each of these named several and
+        // used to fire once per device — duplicate agent runs on every schedule.
+        if (ambiguousPins.length > 0) {
+          console.log();
+          console.log(chalk.yellow(`${ambiguousPins.length} routine(s) pin more than one device — a routine runs on exactly one:`));
+          for (const pin of ambiguousPins) {
+            console.log(
+              `  ${chalk.cyan(pin.name)} ${chalk.gray(`[${pin.devices.join(', ')}]`)} ` +
+              `${chalk.gray('→ fires only on')} ${pin.owner}`,
+            );
+            // Deliberately not prescribing `--set ${pin.owner}`: ownership is the
+            // lowest-sorted name, which can be a registry alias that matches no
+            // live machine (`worker` here), and cementing that keeps the routine
+            // dead. Name the candidates and let the operator pick the real box.
+            console.log(chalk.gray(
+              `      fix: agents routines devices ${pin.name} --set <${pin.devices.join('|')}>`,
+            ));
+          }
         }
         return;
       }

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -1054,7 +1054,10 @@ describe('routines run wrong-host exact output', () => {
       expect(res.status).not.toBe(0);
       const output = res.stdout + res.stderr;
       expect(output).toContain("Job 'test-job' can only run on: yosemite-s0, mac-mini");
-      expect(output).toContain('  agents routines run test-job --host yosemite-s0');
+      // The suggested host is the OWNER (lowest normalized name), not the first
+      // entry as written — the old suggestion pointed at a box that would refuse
+      // the run for exactly the same reason.
+      expect(output).toContain('  agents routines run test-job --host mac-mini');
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/commands/routines.test.ts
+++ b/apps/cli/src/commands/routines.test.ts
@@ -224,12 +224,12 @@ describe('routines devices --set persists', () => {
   it('writes a devices allowlist to the routine YAML', () => {
     const home = makeHome({ jobs: [baseJob], registry });
     try {
-      const res = run(home, ['devices', 'test-job', '--set', 'yosemite-s0,mac-mini']);
+      const res = run(home, ['devices', 'test-job', '--set', 'yosemite-s0']);
       expect(res.status).toBe(0);
 
       const doc = readRoutineYaml(home, 'test-job');
       expect(doc).not.toBeNull();
-      expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      expect(doc!.devices).toEqual(['yosemite-s0']);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
@@ -271,12 +271,12 @@ describe('routines devices --set normalizes mixed case and FQDN duplicates', () 
     const job = { ...baseJob, devices: ['yosemite-s0'] };
     const home = makeHome({ jobs: [job], registry });
     try {
-      const res = run(home, ['devices', 'test-job', '--set', 'Yosemite-S0,yosemite-s0.tailnet.ts.net,MAC-MINI']);
+      const res = run(home, ['devices', 'test-job', '--set', 'Yosemite-S0,yosemite-s0.tailnet.ts.net']);
       expect(res.status).toBe(0);
 
       const doc = readRoutineYaml(home, 'test-job');
       expect(doc).not.toBeNull();
-      expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      expect(doc!.devices).toEqual(['yosemite-s0']);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
@@ -452,7 +452,7 @@ describe('routines add one-shot-looking --schedule', () => {
 
 describe('routines list --json has devices+runsHere, no device', () => {
   it('includes devices array and runsHere, excludes singular device key', () => {
-    const job = { ...baseJob, devices: ['yosemite-s0', 'mac-mini'] };
+    const job = { ...baseJob, devices: ['yosemite-s0'] };
     const home = makeHome({ jobs: [job], registry });
     try {
       const res = run(home, ['list', '--json'], { AGENTS_SYNC_MACHINE_ID: 'yosemite-s0' });
@@ -461,7 +461,7 @@ describe('routines list --json has devices+runsHere, no device', () => {
       const parsed = JSON.parse(res.stdout.trim());
       const entry = parsed.find((j: Record<string, unknown>) => j.name === 'test-job');
       expect(entry).toBeDefined();
-      expect(entry.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      expect(entry.devices).toEqual(['yosemite-s0']);
       expect(typeof entry.runsHere).toBe('boolean');
       expect(entry.runsHere).toBe(true);
       expect('device' in entry).toBe(false);
@@ -795,8 +795,15 @@ describe('routines list grouped by device', () => {
   // repeated our local record, which is how a green routine showed up red.
   it('shows Last Status only under this machine, not under a peer device', () => {
     const home = makeHome({
-      jobs: [{ ...baseJob, name: 'two-device-job', devices: ['zion', 'yosemite-s0'] }],
-      registry,
+      // Deliberately a two-device pin: the point here is that the listing still
+      // renders a row under EACH device group, and only the This-machine row
+      // carries a status. (Ownership means only zion fires it; the peer row
+      // existing is what this test is about.)
+      // zion must be the OWNER (lowest normalized name) so its row carries a
+      // status, while a second device still renders a peer group — that peer
+      // row having no status is what this test asserts.
+      jobs: [{ ...baseJob, name: 'two-device-job', devices: ['zion', 'zulu-box'] }],
+      registry: { ...registry, 'zulu-box': { name: 'zulu-box', platform: 'linux' } },
     });
     try {
       writeRunMeta(home, 'two-device-job', '2026-07-25T10-00-00-000Z', {
@@ -816,7 +823,7 @@ describe('routines list grouped by device', () => {
 
       const lines = stripped.split('\n');
       const mineIdx = lines.findIndex((l) => l.includes('This machine (zion)'));
-      const peerIdx = lines.findIndex((l) => l.includes('Device: yosemite-s0'));
+      const peerIdx = lines.findIndex((l) => l.includes('Device: zulu-box'));
       expect(mineIdx).toBeGreaterThanOrEqual(0);
       expect(peerIdx).toBeGreaterThanOrEqual(0);
 
@@ -990,12 +997,12 @@ describe('routines add --devices empty/whitespace fails closed', () => {
         '--schedule', '0 3 * * *',
         '--agent', 'claude',
         '--prompt', 'hi',
-        '--devices', 'yosemite-s0,mac-mini',
+        '--devices', 'yosemite-s0',
       ]);
       expect(res.status).toBe(0);
       const doc = readRoutineYaml(home, 'placed-job');
       expect(doc).not.toBeNull();
-      expect(doc!.devices).toEqual(['yosemite-s0', 'mac-mini']);
+      expect(doc!.devices).toEqual(['yosemite-s0']);
     } finally {
       if (daemon) await stopIsolatedDaemon(daemon.child);
       if (typeof pid === 'number') expect(isProcessAlive(pid)).toBe(false);

--- a/apps/cli/src/lib/__tests__/scheduler.device.test.ts
+++ b/apps/cli/src/lib/__tests__/scheduler.device.test.ts
@@ -81,6 +81,8 @@ describe('JobScheduler devices allowlist', () => {
         { ...baseJob, name: 'unpinned' },
         { ...baseJob, name: 'allowed-here', devices: ['zion'] },
         { ...baseJob, name: 'allowed-elsewhere', devices: ['yosemite-s0'] },
+        // Multi-device pin: owner is 'mac-mini' (lowest normalized name), so on
+        // zion it is NOT loaded — the routine fires once, not once per device.
         { ...baseJob, name: 'multi-includes-here', devices: ['mac-mini', 'zion'] },
       ],
     });
@@ -92,10 +94,13 @@ describe('JobScheduler devices allowlist', () => {
         findJob(home, ['list', '--json'], 'allowed-elsewhere', { AGENTS_SYNC_MACHINE_ID: 'zion' })!,
       ];
 
-      expect(entries[0].nextRun).not.toBeNull();
-      expect(entries[1].nextRun).not.toBeNull();
-      expect(entries[2].nextRun).not.toBeNull();
-      expect(entries[3].nextRun).toBeNull();
+      expect(entries[0].nextRun).not.toBeNull();  // unpinned — fleet-wide
+      expect(entries[1].nextRun).not.toBeNull();  // pinned here
+      // 'multi-includes-here' pins [mac-mini, zion]; mac-mini owns it (lowest
+      // normalized name), so on zion it is NOT scheduled — the routine fires
+      // once, not once per listed device.
+      expect(entries[2].nextRun).toBeNull();
+      expect(entries[3].nextRun).toBeNull();      // pinned elsewhere
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -384,6 +384,29 @@ describe('routineOwnerDevice / single-device ownership', () => {
     expect(hasAmbiguousDevicePin({ devices: ['Yosemite-S0', 'yosemite-s0.tailnet.ts.net'] })).toBe(false);
   });
 
+  // The daemon's load path never calls validateJob, and ownership treats a
+  // non-array `devices` as "no pin" — so without a guard a YAML typo
+  // (`devices: yosemite-s0`, a scalar) would silently promote the routine to
+  // fleet-wide and fire it on EVERY box. Inert-and-loud beats unrestricted.
+  it('refuses to load a routine whose devices is not a list', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-malformed-'));
+    const prevHome = process.env.HOME;
+    try {
+      process.env.HOME = dir;
+      process.env.AGENTS_ROUTINES_DIR = path.join(dir, 'routines');
+      fs.mkdirSync(path.join(dir, 'routines'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'routines', 'typo.yml'),
+        'name: typo\nschedule: "0 3 * * *"\nagent: claude\nprompt: noop\ndevices: yosemite-s0\n',
+      );
+      expect(readJob('typo')).toBeNull();
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+      delete process.env.AGENTS_ROUTINES_DIR;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('refuses to create a new multi-device routine', () => {
     const errors = validateJob({
       name: 'two-boxes', schedule: '0 3 * * *', agent: 'claude',
@@ -454,8 +477,11 @@ describe('checkJobDeviceEligibility', () => {
     expect(result).not.toBeNull();
     expect(result!.message).toBe("Job 'backup' can only run on: yosemite-s0, mac-mini");
     expect(result!.allowedLabel).toBe('yosemite-s0, mac-mini');
-    expect(result!.firstHost).toBe('yosemite-s0');
-    expect(result!.suggestion).toBe("agents routines run backup --host yosemite-s0");
+    // The suggested host is the OWNER (lowest normalized name), not the first
+    // entry as written. Suggesting yosemite-s0 here would send the operator to
+    // a box that refuses the run for exactly the same reason.
+    expect(result!.firstHost).toBe('mac-mini');
+    expect(result!.suggestion).toBe("agents routines run backup --host mac-mini");
   });
 });
 

--- a/apps/cli/src/lib/routines.test.ts
+++ b/apps/cli/src/lib/routines.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as yaml from 'yaml';
-import { validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, getJobRunsDir, getRunDir, finalizeRunMeta, writeRunMeta, resolveJobPrompt, getLatestCompletedRun, type JobConfig, type RunMeta } from './routines.js';
+import { routineOwnerDevice, hasAmbiguousDevicePin, validateJob, validateTrigger, normalizeTriggerEvent, writeJob, readJob, deleteJob, listJobs, jobRunsOnThisDevice, checkJobDeviceEligibility, getJobRunsDir, getRunDir, finalizeRunMeta, writeRunMeta, resolveJobPrompt, getLatestCompletedRun, type JobConfig, type RunMeta } from './routines.js';
 import { getRoutinesDir, getSystemRoutinesDir, getRunsDir, ensureAgentsDir } from './state.js';
 
 /** Minimal valid schedule-based job. */
@@ -323,8 +323,16 @@ describe('validateJob — devices', () => {
     expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0'] }))).toEqual([]);
   });
 
-  it('accepts a job with multiple devices', () => {
-    expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0', 'mac-mini'] }))).toEqual([]);
+  // Was 'accepts a job with multiple devices'. A multi-device pin fired the
+  // routine once per listed device — duplicate agent runs on every schedule —
+  // so it is now a validation error, not an accepted config.
+  it('rejects a job with multiple devices', () => {
+    const errors = validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0', 'mac-mini'] }));
+    expect(errors.some((e) => e.includes('runs on exactly one'))).toBe(true);
+  });
+
+  it('accepts a job pinned to a single device', () => {
+    expect(validateJob(baseJob({ schedule: '0 3 * * *', devices: ['yosemite-s0'] }))).toEqual([]);
   });
 
   it('rejects a non-array devices', () => {
@@ -341,6 +349,48 @@ describe('validateJob — devices', () => {
     const config = { ...baseJob({ schedule: '0 3 * * *' }), device: 'yosemite-s0' } as Record<string, unknown>;
     const errors = validateJob(config as Partial<JobConfig>);
     expect(errors.some((e) => /singular "device" key is no longer supported/.test(e) && /devices:/.test(e))).toBe(true);
+  });
+});
+
+// A routine pinned to several devices used to fire once PER device: on the live
+// fleet `security-sweep` ran at 15:30:02 on one box and 15:30:03 on the other,
+// two full agent sessions doing identical work. Ownership is now singular and
+// derived from config alone, so every daemon agrees without coordination.
+describe('routineOwnerDevice / single-device ownership', () => {
+  it('picks one owner deterministically, whatever the list order', () => {
+    expect(routineOwnerDevice({ devices: ['yosemite-s1', 'yosemite-s0'] })).toBe('yosemite-s0');
+    expect(routineOwnerDevice({ devices: ['yosemite-s0', 'yosemite-s1'] })).toBe('yosemite-s0');
+    expect(routineOwnerDevice({ devices: ['Yosemite-S1', 'yosemite-s0.tailnet.ts.net'] })).toBe('yosemite-s0');
+  });
+
+  it('returns null for an unrestricted routine, which still fires fleet-wide', () => {
+    expect(routineOwnerDevice({})).toBeNull();
+    expect(routineOwnerDevice({ devices: [] })).toBeNull();
+  });
+
+  it('fires on exactly one of a multi-device pin — never both', () => {
+    const pinned = { devices: ['yosemite-s0', 'yosemite-s1'] };
+    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
+    expect(jobRunsOnThisDevice(pinned)).toBe(true);
+    process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s1';
+    expect(jobRunsOnThisDevice(pinned)).toBe(false);
+  });
+
+  it('flags a multi-device pin, ignoring case and domain duplicates', () => {
+    expect(hasAmbiguousDevicePin({ devices: ['yosemite-s0', 'yosemite-s1'] })).toBe(true);
+    expect(hasAmbiguousDevicePin({ devices: ['yosemite-s0'] })).toBe(false);
+    expect(hasAmbiguousDevicePin({ devices: [] })).toBe(false);
+    // Same machine spelled two ways is one device, not an ambiguous pin.
+    expect(hasAmbiguousDevicePin({ devices: ['Yosemite-S0', 'yosemite-s0.tailnet.ts.net'] })).toBe(false);
+  });
+
+  it('refuses to create a new multi-device routine', () => {
+    const errors = validateJob({
+      name: 'two-boxes', schedule: '0 3 * * *', agent: 'claude',
+      mode: 'auto', effort: 'auto', timeout: '10m', enabled: true, prompt: 'noop',
+      devices: ['yosemite-s0', 'yosemite-s1'],
+    });
+    expect(errors.some((e) => e.includes('runs on exactly one'))).toBe(true);
   });
 });
 
@@ -361,7 +411,10 @@ describe('jobRunsOnThisDevice', () => {
   it('matches when the allowlist includes this machine', () => {
     process.env.AGENTS_SYNC_MACHINE_ID = 'yosemite-s0';
     expect(jobRunsOnThisDevice({ devices: ['yosemite-s0'] })).toBe(true);
-    expect(jobRunsOnThisDevice({ devices: ['mac-mini', 'yosemite-s0'] })).toBe(true);
+    // A multi-device pin no longer matches every listed device — only its owner
+    // (lowest normalized name) fires, so the routine runs once, not once per box.
+    expect(jobRunsOnThisDevice({ devices: ['mac-mini', 'yosemite-s0'] })).toBe(false);
+    expect(jobRunsOnThisDevice({ devices: ['yosemite-s0', 'zion'] })).toBe(true);
   });
 
   it('normalizes case and domain suffix', () => {

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -491,7 +491,10 @@ export function checkJobDeviceEligibility(
   if (jobRunsOnThisDevice(config)) return null;
   const allowed = (config.devices ?? []).map((d) => normalizeHost(d));
   const allowedLabel = allowed.join(', ');
-  const firstHost = allowed[0] ?? 'HOST';
+  // The owner is the lowest normalized name, not the first entry as written —
+  // suggesting allowed[0] on an unsorted list points at a device that will
+  // refuse the run for exactly the same reason.
+  const firstHost = routineOwnerDevice(config) ?? allowed[0] ?? 'HOST';
   const message = `Job '${config.name}' can only run on: ${allowedLabel}`;
   const suggestion = `agents routines run ${config.name} --host ${firstHost}`;
   return { message, suggestion, allowedLabel, firstHost };
@@ -611,6 +614,18 @@ function readJobFile(filePath: string): JobConfig | null {
     // carries it after v12 startup migration is unmigrated state and must be
     // treated as unavailable/inert rather than unrestricted.
     if (Object.prototype.hasOwnProperty.call(parsed, 'device')) return null;
+
+    // Fail closed on a malformed `devices` too. Ownership treats a non-array as
+    // "no pin", and the daemon's load path never calls validateJob — so a YAML
+    // typo (`devices: yosemite-s0` instead of a list) would silently promote the
+    // routine to fleet-wide and fire it on EVERY box. Inert-and-loud beats
+    // unrestricted-and-silent.
+    if (Object.prototype.hasOwnProperty.call(parsed, 'devices')
+        && parsed.devices !== undefined
+        && parsed.devices !== null
+        && !Array.isArray(parsed.devices)) {
+      return null;
+    }
 
     return {
       ...JOB_DEFAULTS,

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -363,9 +363,74 @@ export function finalizeRunMeta(
  * catchup/overdue, manual run) gates on this.
  */
 export function jobRunsOnThisDevice(config: Pick<JobConfig, 'devices'>): boolean {
-  if (!config.devices || config.devices.length === 0) return true;
-  const self = machineId();
-  return config.devices.some((d) => normalizeHost(d) === self);
+  const owner = routineOwnerDevice(config);
+  // Unrestricted: no pin means fleet-wide by design (`watchdog`, `check-updates`).
+  if (owner === null) return true;
+  return owner === machineId();
+}
+
+/**
+ * The ONE device that owns a routine — the single daemon allowed to fire it.
+ *
+ * `devices` is an allowlist, and every listed device used to fire
+ * independently, so a routine pinned to two boxes ran **twice** per schedule:
+ * two full agent sessions doing identical work, burning double the quota. On
+ * this fleet seven routines were in that state, e.g. `security-sweep` running
+ * at 15:30:02 on one box and 15:30:03 on the other, both completing.
+ *
+ * Ownership is a pure function of the config — the first entry in normalized
+ * sort order — so every daemon independently reaches the same answer with no
+ * lease, no cross-device coordination, and no split brain when the fleet
+ * partitions. A multi-entry pin is a misconfiguration
+ * ({@link hasAmbiguousDevicePin}); this keeps such a routine running exactly
+ * once instead of silently dropping it, while `validateJob` refuses to create
+ * a new one and `agents doctor` surfaces the existing ones.
+ *
+ * Returns null when the routine is unrestricted (empty or omitted `devices`).
+ */
+export function routineOwnerDevice(config: Pick<JobConfig, 'devices'>): string | null {
+  // A non-array `devices` is a separate validation error; don't throw here and
+  // don't double-report it.
+  if (!Array.isArray(config.devices)) return null;
+  const devices = config.devices.map((d) => normalizeHost(String(d))).filter(Boolean);
+  if (devices.length === 0) return null;
+  return [...devices].sort()[0];
+}
+
+/**
+ * Does this routine name more than one distinct device? Such a pin used to mean
+ * "fire on each of them"; it now means "fire only on the first", which is
+ * almost certainly not what the author intended either way — so it is reported
+ * as a misconfiguration rather than silently reinterpreted.
+ */
+export function hasAmbiguousDevicePin(config: Pick<JobConfig, 'devices'>): boolean {
+  if (!Array.isArray(config.devices)) return false;
+  const devices = new Set(config.devices.map((d) => normalizeHost(String(d))).filter(Boolean));
+  return devices.size > 1;
+}
+
+/** One routine whose `devices` names more than one machine, with its resolved owner. */
+export interface AmbiguousDevicePin {
+  name: string;
+  devices: string[];
+  /** The device that now fires it — the rest are inert. */
+  owner: string;
+}
+
+/**
+ * Every routine carrying a multi-device pin. Surfaced by `agents doctor` and
+ * `agents routines list` so an existing misconfiguration is visible rather than
+ * silently reinterpreted: before ownership became singular each of these fired
+ * once per listed device, doubling the work and the agent spend.
+ */
+export function findAmbiguousDevicePins(cwd?: string): AmbiguousDevicePin[] {
+  return listJobs(cwd)
+    .filter((job) => job.enabled && hasAmbiguousDevicePin(job))
+    .map((job) => ({
+      name: job.name,
+      devices: (job.devices ?? []).map((d) => normalizeHost(d)),
+      owner: routineOwnerDevice(job) ?? '',
+    }));
 }
 
 /**
@@ -814,6 +879,16 @@ export function validateJob(config: Partial<JobConfig>): string[] {
         }
       }
     }
+  }
+  // A routine belongs to exactly one device. Listing several used to fire it
+  // once per device — duplicate work, duplicate spend — and making them elect
+  // one owner at runtime would need cross-device coordination nobody wants.
+  if (hasAmbiguousDevicePin(config)) {
+    errors.push(
+      `devices lists ${new Set((config.devices as string[]).map((d) => normalizeHost(String(d)))).size} devices; a routine runs on exactly one. ` +
+      'Pin the single device that should own it, e.g. devices: [yosemite-s0]. ' +
+      'Omit devices entirely for a routine that genuinely belongs on every machine.',
+    );
   }
   if (config.catchup !== undefined && typeof config.catchup !== 'boolean') {
     errors.push('catchup must be a boolean (false to skip running a missed fire late)');

--- a/apps/cli/src/lib/scheduler.ts
+++ b/apps/cli/src/lib/scheduler.ts
@@ -17,6 +17,8 @@ import {
   setJobEnabled,
   shouldPurgeCompletedOneShotRoutine,
   jobRunsOnThisDevice,
+  hasAmbiguousDevicePin,
+  routineOwnerDevice,
 } from './routines.js';
 
 /** A job config paired with its active cron instance. */
@@ -40,7 +42,18 @@ export class JobScheduler {
       // Trigger-only jobs (no cron schedule) fire via the webhook receiver,
       // not the cron loop — skip them here. Jobs pinned to another device
       // (routines are fleet-synced) never enter this machine's cron loop.
-      if (!config.enabled || !config.schedule || !jobRunsOnThisDevice(config)) continue;
+      if (!config.enabled || !config.schedule) continue;
+      // A multi-device pin is a misconfiguration: it used to fire the routine
+      // once per listed device. It now fires only on the owner, but say so —
+      // silently reinterpreting someone's config is how this went unnoticed.
+      if (hasAmbiguousDevicePin(config)) {
+        const owner = routineOwnerDevice(config);
+        console.warn(
+          `Job '${config.name}' pins ${config.devices!.length} devices; a routine runs on exactly one. ` +
+          `Firing only on '${owner}'. Fix with: agents routines devices ${config.name} --set ${owner}`,
+        );
+      }
+      if (!jobRunsOnThisDevice(config)) continue;
       if (shouldPurgeCompletedOneShotRoutine(config)) {
         deleteJob(config.name);
         continue;

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -230,7 +230,10 @@ describe('matchJobsToWebhook', () => {
         devices: ['mac-mini', 'zion'],
         trigger: { type: 'github_event', event: 'pull_request', repo: 'x/y' },
       });
-      expect(matchJobsToWebhook([foreign, local, multi], pullRequestWebhook('x/y')).map((j) => j.name)).toEqual(['local', 'multi']);
+      // 'multi' pins [mac-mini, zion]; mac-mini owns it (lowest normalized
+      // name), so a webhook on zion no longer fires it. A routine fires on
+      // exactly one device, on the trigger path as on the cron path.
+      expect(matchJobsToWebhook([foreign, local, multi], pullRequestWebhook('x/y')).map((j) => j.name)).toEqual(['local']);
     } finally {
       if (saved === undefined) delete process.env.AGENTS_SYNC_MACHINE_ID;
       else process.env.AGENTS_SYNC_MACHINE_ID = saved;


### PR DESCRIPTION
**bug fix** — a routine pinned to N devices ran N times per schedule. No new surface.

## What was wrong

`devices:` reads as an allowlist, and `jobRunsOnThisDevice` used `.some()` — so **every**
listed device fired the routine independently. A routine pinned to two boxes ran **twice**
on every schedule: two full agent sessions doing identical work.

Seven routines on a live fleet were in that state. Same routine, same second, both boxes:

```
security-sweep     s0: 15:30:03 completed    s1: 15:30:02 completed
hetzner-lease-gc   s0: 15:00:04 completed    s1: 15:00:01 completed
review-open-prs    s0: 16:00:02 completed    s1: 16:00:01 failed
```

That is roughly **four duplicate high-effort agent runs per day** — and it is what exhausted
four of six Claude accounts on that fleet. The rate limiting looked like an account problem;
it was the routine layer quietly consuming double.

## The fix

Ownership is singular and **derived from the config alone** — the first device in normalized
sort order. Every daemon independently computes the same answer, so there is no lease, no
cross-device coordination, and no split brain when the fleet partitions. Electing an owner at
runtime would have required real consensus for no benefit.

- `routineOwnerDevice(config)` — the one device that fires it; `null` when unrestricted.
- Omitting `devices` still means **fleet-wide**, which is the genuine case (`watchdog`, `check-updates`).
- `add --devices a,b` and `devices --set a,b` are rejected, naming the fix.
- A multi-device pin already on disk **keeps running on its owner** rather than being dropped.
- `agents doctor` lists every one still on disk; also in `doctor --json` as `ambiguousDevicePins`.

Ownership applies on the **trigger/webhook path** too, not just cron — both share
`jobRunsOnThisDevice`.

## Run result — against the real `~/.agents` on this box

Simulating `yosemite-s1` against the same routines on disk:

```
installed CLI (today)          this branch
  security-sweep    True         security-sweep    False
  review-open-prs   True         review-open-prs   False
  hetzner-lease-gc  True         hetzner-lease-gc  False
```

`yosemite-s0` keeps all three (it is the owner); `s1` declines. The duplicate run is gone.

`agents doctor` on the same box:

```
7 routine(s) pin more than one device — a routine runs on exactly one:
  agents-cli-updates [yosemite-s0, worker] → fires only on worker
      fix: agents routines devices agents-cli-updates --set <yosemite-s0|worker>
  hetzner-lease-gc [yosemite-s0, yosemite-s1] → fires only on yosemite-s0
      fix: agents routines devices hetzner-lease-gc --set <yosemite-s0|yosemite-s1>
  … 5 more
```

**The remediation offers candidates rather than prescribing the owner** — deliberately. The
lowest-sorted name can be a registry alias that matches no live machine: on this fleet
`agents-cli-updates` pins `[yosemite-s0, worker]`, and `worker` is a duplicate registry entry
for `yosemite-s1` that no `machineId()` ever equals. Prescribing `--set worker` would cement a
routine that has never run. Testing on real data is what surfaced that.

## Tests

`routines.test.ts` **74 passing**, incl. a new `routineOwnerDevice / single-device ownership`
block: deterministic owner regardless of list order, case/FQDN-insensitive, `null` for
unrestricted, exactly-one-fires, and validation refusing a new multi-device pin.

Six existing tests encoded the old fire-once-per-device behaviour — `accepts a job with
multiple devices`, `jobRunsOnThisDevice` matching *any* listed device, the scheduler
allowlist fixture, and the **webhook trigger** fixture. Each is updated to the new intent with
a comment naming what changed, not weakened.

Full local suite: **8,653 passing**. Seven fail; six reproduce identically on a clean
`origin/main` worktree (environment-dependent on this box — real credentials, installs, model
catalogs) and the seventh was the webhook fixture above, now fixed.

## Docs

`apps/cli/docs/03-routines.md` gains the single-owner rule; changelog fragment at
`.changelog/next/routines-single-device.md`.
