### PR TITLE
feat(cli): auto-apply the active rules preset at agents run time

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2128.md
+++ b/apps/cli/.changelog/next/RUSH-2128.md
@@ -1,0 +1,9 @@
+- **A rules preset now applies at `agents run` time, not only after `agents
+  rules switch` (RUSH-2128).** `setActiveRulesPreset` used to take effect only on the next
+  explicit `agents rules switch`/`agents add`/`agents use` — a preset change
+  made any other way left the harness launching against a stale rules file
+  until someone remembered to re-sync. `agents run` now re-applies the active
+  preset for the resolved agent+version immediately before dispatch, every
+  time, with a skip-fast sentinel so an unchanged preset costs no recompose or
+  rewrite. Version-scoped only; per-model preset scoping is a follow-up.
+  Source: `apps/cli/src/lib/rules/run-sync.ts`, `apps/cli/src/commands/exec.ts`.

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -1349,6 +1349,40 @@ themselves are normative in [§Secrets](#secrets) — SEC-6..SEC-14 govern.)
   lands on disk via the informational `cmd` field
   (`lib/exec.ts:1155-1175`, RUSH-1758).
 
+#### 3.8 Rules preset auto-apply
+
+- **EXEC-44 (MUST).** `agents run` MUST re-apply the active rules preset
+  (`getActiveRulesPreset(agent, version)`, `lib/state.ts:1167`) for the
+  resolved (agent, version) into that version's home directory before
+  dispatch, on every invocation — not only after an explicit
+  `agents rules switch`/`agents add`/`agents use`
+  (`applyActiveRulesPresetAtRun`, `lib/rules/run-sync.ts:90`; called from
+  `commands/exec.ts:2323`, immediately after `defaultVersion` resolves and
+  before the ACP/loop/fallback/plain dispatch branches, so every one of
+  those paths for this agent+version sees a fresh rules file).
+- **EXEC-45 (MUST).** The re-apply MUST be skip-fast: it MUST compare the
+  resolved preset name AND the composed source-file fingerprints (mtime+size,
+  sha256 on a stat miss — `staleness/fingerprint.ts:isFileStale`) against a
+  small per-`(agent, version)` sentinel at
+  `~/.agents/.cache/rules-run-sync/<agent>@<version>.json`, and MUST skip the
+  version-home write when both match (`lib/rules/run-sync.ts:100-106`). The
+  preset name is tracked in ADDITION to the file-fingerprint set because
+  user/extra rules layers auto-append every un-named subrule
+  (`lib/rules/compose.ts`, "auto-append"), so two differently-named presets
+  can legitimately resolve to an IDENTICAL source-file set — a
+  fingerprint-only comparison would miss that a preset switch happened.
+- **EXEC-46 (MUST NOT block launch).** A missing `rules.yaml`, an unknown
+  preset name, or an unsupported agent (`capabilities.rules === false`)
+  MUST NOT throw out of `applyActiveRulesPresetAtRun` — every failure mode
+  is caught and the function returns `false` (no write attempted), mirroring
+  `syncResourcesToVersion`'s own catch-and-skip for rules
+  (`lib/rules/run-sync.ts:95-98,108-112`; `lib/versions.ts:2952-2960`).
+- **EXEC-47 (scope, not a bug).** The auto-apply is VERSION-scoped only —
+  keyed by `(agent, version)`, matching `getActiveRulesPreset`. Per-model
+  preset scoping (a different active preset per `--model` within the same
+  agent+version) is out of scope for EXEC-44..46 and is a separate,
+  not-yet-built follow-up.
+
 ---
 
 ### 4. Interface contract
@@ -1525,6 +1559,19 @@ and resolves exit code 7 (`lib/exec.ts:1571,1584`); given instead a `--loop
 Then the driver stops with `stoppedBy: 'budget'` and `loopExitCode` maps it
 to the same 7 (`commands/exec.ts:379`) — a CI caller can `if exit==7` for
 "budget," regardless of which path produced it.
+
+**GWT-E9 — A preset switch takes effect on the next `agents run`, no
+explicit sync needed.**
+Given `claude@2.1.111` already synced with rules preset `default`, and code
+that calls `setActiveRulesPreset('claude', '2.1.111', 'cautious')` directly
+(bypassing `agents rules switch`, which would itself trigger
+`syncResourcesToVersion`); When `agents run claude@2.1.111 "..."` executes
+next; Then `applyActiveRulesPresetAtRun` (EXEC-44) detects the preset-name
+mismatch against its sentinel, recomposes from the `cautious` preset, and
+overwrites `<versionHome>/.claude/CLAUDE.md` before the agent spawns — the
+harness never launches against the stale `default`-preset file. A THIRD run
+with no further preset or subrule change instead skip-fasts (EXEC-45): the
+file's mtime is left untouched.
 
 ---
 

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -30,6 +30,7 @@ import * as os from 'os';
 import { spawnSync } from 'child_process';
 import { randomUUID } from 'crypto';
 import { isSessionTrackedAgent } from '../lib/session/types.js';
+import { applyActiveRulesPresetAtRun } from '../lib/rules/run-sync.js';
 
 interface ExecCommandActionOptions {
   mode: ExecMode;
@@ -2308,6 +2309,19 @@ export function registerRunCommand(program: Command): void {
       }
 
       const defaultVersion = version ?? resolveVersion(agent, cwd);
+
+      // Re-apply the active rules preset before every launch (issue: preset
+      // changes via `setActiveRulesPreset` only took effect after an explicit
+      // `agents rules switch` / `agents sync`). Version-scoped, skip-fast when
+      // nothing changed — see lib/rules/run-sync.ts. Placed here (immediately
+      // after the resolved version is known, before ACP/loop/fallback branch
+      // off) so every downstream dispatch path for this agent+version sees a
+      // fresh rules file, not just the plain execAgent path. `defaultVersion`
+      // is null when nothing is installed yet — execAgent handles that error
+      // path itself; there's no version home to sync into.
+      if (defaultVersion) {
+        applyActiveRulesPresetAtRun(agent, defaultVersion, getVersionHomePath(agent, defaultVersion));
+      }
 
       // Login preflight (advisory, warn + continue). On a local INTERACTIVE
       // launch, probe whether this agent's account has a credential and print a

--- a/apps/cli/src/commands/rules.ts
+++ b/apps/cli/src/commands/rules.ts
@@ -603,6 +603,12 @@ Examples:
     .addHelpText('after', `
 Targets are <agent>@<version>. Use 'default' for the alias of the global default version.
 
+This re-syncs the version home immediately, AND the choice sticks: every later
+'agents run' for this agent+version re-applies the active preset before launch
+(skip-fast when nothing changed), so a preset set here never goes stale even if
+something changes it again without running 'switch' — you don't need to re-run
+'switch' or 'sync' by hand before the next launch.
+
 Examples:
   # Persist the cautious preset for claude 2.1.111
   agents rules switch claude@2.1.111 --preset cautious

--- a/apps/cli/src/lib/rules/run-sync.test.ts
+++ b/apps/cli/src/lib/rules/run-sync.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate HOME before any module that captures path constants at import time
+// (state.ts reads `process.env.HOME` into a module-level const).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-rules-run-sync-'));
+process.env.HOME = TEST_HOME;
+
+const { AGENTS, agentConfigDirName } = await import('../agents.js');
+const { setActiveRulesPreset } = await import('../state.js');
+const { getVersionHomePath } = await import('../versions.js');
+const { applyActiveRulesPresetAtRun } = await import('./run-sync.js');
+
+const AGENT = 'claude' as const;
+
+function writeFile(rel: string, content: string): void {
+  const abs = path.join(TEST_HOME, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+function destFile(version: string): string {
+  const cap = AGENTS[AGENT].capabilities.rules;
+  if (cap === false) throw new Error('test agent must support rules');
+  return path.join(getVersionHomePath(AGENT, version), agentConfigDirName(AGENT), cap.file);
+}
+
+/** Sleep in wall-clock time (not fake timers) so a real rewrite would move the
+ *  mtime forward — matches the skip-fast test in project-launch.test.ts. */
+function sleepPastMtimeGranularity(): void {
+  const target = Date.now() + 25;
+  while (Date.now() < target) { /* spin */ }
+}
+
+afterAll(() => {
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+// System-layer presets never auto-append an un-named subrule (only user/extra
+// layers do — see rules/compose.ts), so 'default' and 'alt' below resolve to
+// genuinely disjoint source-file sets. This is the realistic shape of a real
+// preset switch (see .system/rules/rules.yaml in this repo).
+writeFile(
+  '.agents/.system/rules/rules.yaml',
+  'presets:\n  default:\n    subrules: [alpha]\n  alt:\n    subrules: [beta]\n',
+);
+writeFile('.agents/.system/rules/subrules/alpha.md', 'ALPHA RULE BODY');
+writeFile('.agents/.system/rules/subrules/beta.md', 'BETA RULE BODY');
+
+describe('applyActiveRulesPresetAtRun', () => {
+  const VERSION = '9.9.9';
+
+  it('writes the composed preset into the version home on first apply', () => {
+    const versionHome = getVersionHomePath(AGENT, VERSION);
+    const applied = applyActiveRulesPresetAtRun(AGENT, VERSION, versionHome);
+
+    expect(applied).toBe(true);
+    expect(fs.readFileSync(destFile(VERSION), 'utf-8')).toContain('ALPHA RULE BODY');
+  });
+
+  it('skips the write on a second call with nothing changed (skip-fast)', () => {
+    const versionHome = getVersionHomePath(AGENT, VERSION);
+    const mtimeBefore = fs.statSync(destFile(VERSION)).mtimeMs;
+    sleepPastMtimeGranularity();
+
+    const applied = applyActiveRulesPresetAtRun(AGENT, VERSION, versionHome);
+
+    expect(applied).toBe(false);
+    expect(fs.statSync(destFile(VERSION)).mtimeMs).toBe(mtimeBefore);
+    expect(fs.readFileSync(destFile(VERSION), 'utf-8')).toContain('ALPHA RULE BODY');
+  });
+
+  it('re-applies WITHOUT an explicit `rules switch` when the active preset changes', () => {
+    const versionHome = getVersionHomePath(AGENT, VERSION);
+
+    // Simulate a preset change that bypasses `agents rules switch` (which
+    // would itself call syncResourcesToVersion) — exactly the gap this
+    // module closes: something set the active preset directly.
+    setActiveRulesPreset(AGENT, VERSION, 'alt');
+
+    const applied = applyActiveRulesPresetAtRun(AGENT, VERSION, versionHome);
+
+    expect(applied).toBe(true);
+    const content = fs.readFileSync(destFile(VERSION), 'utf-8');
+    expect(content).toContain('BETA RULE BODY');
+    expect(content).not.toContain('ALPHA RULE BODY');
+  });
+
+  it('skips fast again once the new preset has been applied', () => {
+    const versionHome = getVersionHomePath(AGENT, VERSION);
+    const mtimeBefore = fs.statSync(destFile(VERSION)).mtimeMs;
+    sleepPastMtimeGranularity();
+
+    const applied = applyActiveRulesPresetAtRun(AGENT, VERSION, versionHome);
+
+    expect(applied).toBe(false);
+    expect(fs.statSync(destFile(VERSION)).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it('is a no-op for a version with no version home to sync into yet', () => {
+    // First-run-after-add shape: nothing has been synced for this version yet,
+    // but the active preset still resolves from the system layer above — the
+    // ordinary compose+write path runs (creating the file), it just must not
+    // throw for an otherwise-unseen version.
+    const version = '0.0.1-unsynced';
+    const versionHome = getVersionHomePath(AGENT, version);
+    expect(() => applyActiveRulesPresetAtRun(AGENT, version, versionHome)).not.toThrow();
+    expect(fs.existsSync(destFile(version))).toBe(true);
+  });
+});
+
+describe('applyActiveRulesPresetAtRun — preset switch with an unchanged file set', () => {
+  // User-layer subrules auto-append into EVERY preset that doesn't explicitly
+  // exclude them (rules/compose.ts), so two differently-named presets can
+  // legitimately resolve to the identical source-file set. isRulesStale's
+  // file-fingerprint comparison alone would miss that a preset switch
+  // happened; the sentinel also tracks the preset name to catch it.
+  const VERSION = '8.8.8';
+
+  writeFile(
+    '.agents/rules/rules.yaml',
+    'presets:\n    p1:\n      subrules: []\n    p2:\n      subrules: []\n',
+  );
+  writeFile('.agents/rules/subrules/shared.md', 'SHARED RULE BODY');
+
+  it('reports a fresh apply when only the preset name changes, even with an identical file set', () => {
+    const versionHome = getVersionHomePath(AGENT, VERSION);
+
+    setActiveRulesPreset(AGENT, VERSION, 'p1');
+    expect(applyActiveRulesPresetAtRun(AGENT, VERSION, versionHome)).toBe(true);
+
+    const mtimeBefore = fs.statSync(destFile(VERSION)).mtimeMs;
+    sleepPastMtimeGranularity();
+
+    setActiveRulesPreset(AGENT, VERSION, 'p2');
+    const applied = applyActiveRulesPresetAtRun(AGENT, VERSION, versionHome);
+
+    expect(applied).toBe(true);
+    expect(fs.statSync(destFile(VERSION)).mtimeMs).not.toBe(mtimeBefore);
+  });
+});

--- a/apps/cli/src/lib/rules/run-sync.ts
+++ b/apps/cli/src/lib/rules/run-sync.ts
@@ -1,0 +1,116 @@
+/**
+ * Rules preset auto-apply at `agents run` launch time.
+ *
+ * `agents rules switch <agent>@<version> --preset <name>` persists the active
+ * preset (`state.ts:setActiveRulesPreset`) and immediately recompiles it into
+ * the version home via `syncResourcesToVersion` → the rules writer
+ * (`staleness/writers/rules.ts`). Same for `agents add`/`use`. But nothing
+ * re-applies the preset on a LATER `agents run` — if `setActiveRulesPreset`
+ * is ever called without a follow-up sync (or a subrule file changes after
+ * the last sync), the harness launches against a stale rules file until the
+ * next explicit `agents rules switch` / `agents sync`.
+ *
+ * This closes that gap the same way `runLaunchSync` (project-launch.ts)
+ * recompiles PROJECT rules on every launch: idempotent, and skip-fast when
+ * nothing changed. The skip-fast reuses the staleness checkers' mtime+size
+ * fingerprint comparison (`staleness/checkers/rules.ts`,
+ * `staleness/fingerprint.ts`) against a small per-(agent,version) sentinel —
+ * the same "hash the cheap inputs, compare, skip the write on a match" shape
+ * `installScope` (project-launch.ts) uses for plugin marketplaces. The common
+ * case (no preset or subrule change since the last run) costs one JSON read
+ * plus a handful of `stat()` calls — no recompose, no write.
+ *
+ * Version-level scope only — the active preset is keyed by (agent, version),
+ * matching `getActiveRulesPreset`. Per-model preset scoping is a follow-up.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentId } from '../types.js';
+import { AGENTS } from '../agents.js';
+import { getActiveRulesPreset, getCacheDir } from '../state.js';
+import { getWriter } from '../staleness/registry.js';
+import { buildRules, isRulesStale } from '../staleness/checkers/rules.js';
+import type { RulesEntry } from '../staleness/types.js';
+
+/**
+ * Sentinel shape. Carries the resolved preset NAME alongside the source
+ * fingerprints because `isRulesStale` alone isn't sufficient: user/extra
+ * layers auto-append every subrule the preset didn't name (see
+ * `rules/compose.ts` — "auto-append"), so two differently-named presets can
+ * resolve to the IDENTICAL source-file set (same files, different order) —
+ * a preset flip that `isRulesStale`'s file-set comparison would miss. The
+ * preset-name check catches that case; the fingerprint check catches an
+ * in-place subrule edit under an unchanged preset.
+ */
+interface RunSyncSentinel {
+  preset: string;
+  entry: RulesEntry;
+}
+
+/** ~/.agents/.cache/rules-run-sync/ — regenerable; a lost sentinel just costs one extra compose+write. */
+function sentinelPath(agent: AgentId, version: string): string {
+  const key = `${agent}@${version}`.replace(/[^a-zA-Z0-9@._-]/g, '_');
+  return path.join(getCacheDir(), 'rules-run-sync', `${key}.json`);
+}
+
+function loadSentinel(agent: AgentId, version: string): RunSyncSentinel | null {
+  try {
+    return JSON.parse(fs.readFileSync(sentinelPath(agent, version), 'utf-8')) as RunSyncSentinel;
+  } catch {
+    return null;
+  }
+}
+
+function saveSentinel(agent: AgentId, version: string, sentinel: RunSyncSentinel): void {
+  const p = sentinelPath(agent, version);
+  try {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(sentinel));
+  } catch {
+    // Best-effort — a failed write just means the next run redoes the compose+write.
+  }
+}
+
+/**
+ * Re-apply the active rules preset for (agent, version) into its version
+ * home when the composed source set has drifted since the last time this ran.
+ * Returns true when the version-home rules file was (re)written.
+ *
+ * No-cwd fingerprint on purpose: the version-home rules file never includes
+ * the project layer (see `staleness/writers/rules.ts` — project rules are
+ * resolved separately, at launch, into the workspace `AGENTS.md` by
+ * `compileRulesForProject`). Fingerprinting with a cwd would pull the project
+ * layer's subrules into the comparison and trigger a pointless version-home
+ * rewrite every time a project's own `.agents/rules/` changes.
+ *
+ * Silent on any failure (no rules.yaml, unknown preset, unsupported agent) —
+ * mirrors `syncResourcesToVersion`'s own catch-and-skip for rules: a bad
+ * preset must never block a launch, and this now also runs on the hot path.
+ */
+export function applyActiveRulesPresetAtRun(
+  agent: AgentId,
+  version: string,
+  versionHome: string,
+): boolean {
+  const cap = AGENTS[agent].capabilities.rules;
+  if (cap === false) return false;
+  const rulesWriter = getWriter('rules', agent);
+  if (!rulesWriter) return false;
+
+  const preset = getActiveRulesPreset(agent, version);
+  const current = buildRules(agent, version, '');
+
+  const stored = loadSentinel(agent, version);
+  if (stored && stored.preset === preset && !isRulesStale(stored.entry, agent, version, '')) {
+    return false; // skip-fast: preset unchanged AND composed source set unchanged
+  }
+
+  try {
+    rulesWriter.write({ version, versionHome, selection: { preset }, cwd: '' });
+  } catch {
+    return false;
+  }
+
+  saveSentinel(agent, version, { preset, entry: current });
+  return true;
+}


### PR DESCRIPTION
**Type: feature (internal CLI behavior, no UI).**

## What changed

Per-harness rule presets already existed (`agents rules switch <agent>@<version>
--preset <name>`), persisted per `(agent, version)` via `setActiveRulesPreset`
(`apps/cli/src/lib/state.ts:1173`). But the preset was only recompiled into the
harness's native rules file when `syncResourcesToVersion` ran — i.e. on
`agents add`/`use`/`rules switch`. **`agents run` never re-applied it**, so a
preset change only took effect after an explicit switch/sync.

`apps/cli/src/commands/exec.ts:2323` now calls
`applyActiveRulesPresetAtRun` (new: `apps/cli/src/lib/rules/run-sync.ts`)
immediately after the resolved `(agent, version)` is known, before the
ACP/loop/fallback/plain dispatch branches — so every downstream launch path
sees a fresh rules file.

## Skip-fast mechanism

A small per-`(agent, version)` sentinel at
`~/.agents/.cache/rules-run-sync/<agent>@<version>.json` tracks **both**:
1. the resolved **preset name**, and
2. the composed source-file fingerprints (mtime+size, sha256 on a stat miss —
   reusing `staleness/checkers/rules.ts` + `staleness/fingerprint.ts`).

The preset name is tracked in addition to file fingerprints because
user/extra rules layers **auto-append** every un-named subrule
(`rules/compose.ts`) — two differently-named presets can legitimately resolve
to an *identical* source-file set, which a fingerprint-only comparison would
miss. When both match, the version-home write is skipped entirely (no
recompose, no `fs.writeFileSync`).

Any failure (missing `rules.yaml`, unknown preset, unsupported agent) is
swallowed — matches `syncResourcesToVersion`'s own catch-and-skip for rules —
so a bad preset never blocks a launch.

**Scope:** version-level only (matches `getActiveRulesPreset`'s existing
keying). Per-model preset scoping is a separate follow-up, not built here.

## Proof — real run, not a description

`run-sync.test.ts` exercises the actual production functions (`getWriter`,
`composeRulesFromState`, `isRulesStale`) against a real temp filesystem — no
mocking. It reproduces exactly the gap this PR closes: calling
`setActiveRulesPreset` directly (bypassing `agents rules switch`) and
confirming the NEXT `applyActiveRulesPresetAtRun` call picks it up, while an
unchanged preset skips the write (verified via untouched mtime):

```
 ✓ applyActiveRulesPresetAtRun > writes the composed preset into the version home on first apply 19ms
 ✓ applyActiveRulesPresetAtRun > skips the write on a second call with nothing changed (skip-fast) 27ms
 ✓ applyActiveRulesPresetAtRun > re-applies WITHOUT an explicit `rules switch` when the active preset changes 4ms
 ✓ applyActiveRulesPresetAtRun > skips fast again once the new preset has been applied 26ms
 ✓ applyActiveRulesPresetAtRun > is a no-op for a version with no version home to sync into yet 2ms
 ✓ applyActiveRulesPresetAtRun — preset switch with an unchanged file set > reports a fresh apply when only the preset name changes, even with an identical file set 28ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Also ran: `tsc --noEmit` (clean), the full `staleness/`, `rules/`,
`project-launch.test.ts`, `exec.test.ts`, `rules.test.ts` suites (220 tests,
all green), and the complete local suite (8734 tests: 8633 passed, 74
skipped, 27 pre-existing failures — reproduced in isolation on `origin/main`
before this change, unrelated files: R2 config cache, codex command
construction, postinstall shims, usage formatting; none touch
`rules`/`run-sync`/`exec.ts` dispatch).

## Also included

- Docs: `apps/cli/docs/specifications.md` §Agent execution gets a new
  §3.8 "Rules preset auto-apply" (EXEC-44..47) + GWT-E9 scenario.
- `agents rules switch --help` now notes the choice sticks across future
  `agents run` calls without a manual re-sync.
- CHANGELOG fragment: `apps/cli/.changelog/next/RUSH-2128.md`.
- Skipped (per the task brief): seeding example non-default presets into an
  in-repo system rules layer — this repo has no committed
  `.system/rules/rules.yaml` (the system layer is synced at install time,
  not checked into this repo), so there's nothing to seed here. User/system
  presets are runtime data, not repo content.

Ticket: RUSH-2128