### PR TITLE
fix(routines): catch up routines that fire less often than weekly

### DIFF
--- a/apps/cli/.changelog/next/routines-catchup-correctness.md
+++ b/apps/cli/.changelog/next/routines-catchup-correctness.md
@@ -1,0 +1,23 @@
+- **A routine that fires less often than weekly can now be caught up at all.** Overdue
+  detection walked a fixed one-week window for the most recent expected fire, so any cron whose
+  gap exceeds that returned nothing and the routine was skipped entirely — never flagged
+  overdue on any device, never caught up, no `missed` record, silently. Monthly, semi-monthly,
+  quarterly and annual routines were all in that class. Measured on a real schedule
+  (`0 9 1,13,25 * *`, 12-day gaps): on **10 of every 28 days** the routine could not be
+  evaluated. The lookback now widens (week → month → quarter → year) only when the narrower
+  window finds nothing, so a dense schedule never walks more than a week of occurrences.
+- **Catch-up no longer resurrects a retired routine.** `detectOverdueJobs` never checked
+  `endAt`, and the scheduler only auto-disables lazily inside a live cron tick — so a routine
+  whose `endAt` elapsed while the daemon was down was still enabled on disk, rescheduled on
+  restart, and executed by the catch-up pass.
+- **One-shot detection matches the scheduler's.** Overdue used the raw `runOnce` flag while the
+  scheduler uses `isOneShotRoutine`, so a one-shot-*like* schedule (a fixed minute/hour/day/
+  month) that never carried the flag could be replayed by catch-up.
+- **The creation floor now covers built-in routines.** `routineEffectiveStart` resolved a
+  routine's file through a user-layer-only lookup, but `listJobs` reads the system layer too —
+  so a built-in shipped in the system repo had neither a `createdAt` stamp nor a resolvable
+  path, the floor was skipped, and it read as instantly overdue on first daemon start. Added
+  `resolveJobFilePath`, which resolves across every layer the loader reads.
+- **A `createdAt` in the future is clamped to now.** Left unclamped (clock skew, a hand-edited
+  year) it sits after every possible expected fire, so the routine could never be flagged
+  overdue until wall-clock time caught up.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -779,6 +779,15 @@ and every 5 minutes** — a startup-only pass would miss a fire lost while the
 daemon stayed up but its event loop was wedged, or one lost across an OS suspend
 the process survived.
 
+Detection looks back far enough to see the routine's own period. The window widens
+week → month → quarter → year, and only when the narrower one finds nothing, so a
+dense schedule never walks more than a week of occurrences. A fixed one-week
+lookback silently skipped anything sparser: `0 9 1,13,25 * *` has 12-day gaps, so on
+10 of every 28 days it could not be evaluated at all.
+
+A routine past its `endAt`, and a one-shot (by flag *or* by schedule shape), is never
+caught up — catch-up replays a missed fire, it does not resurrect a retired routine.
+
 Catch-up is idempotent without a ledger: the `missed` record advances the overdue
 comparison, so the same missed fire is never reconsidered — across ticks, a daemon
 restart, or a restart storm.

--- a/apps/cli/src/lib/overdue.test.ts
+++ b/apps/cli/src/lib/overdue.test.ts
@@ -1,4 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'yaml';
 import { notifyOverdue, type OverdueJob } from './overdue.js';
 
 function overdueJob(partial: Partial<OverdueJob> = {}): OverdueJob {
@@ -38,5 +42,99 @@ describe('notifyOverdue — missing desktop notifier must not crash the daemon',
   it('is a no-op for an empty job list (no spawn attempted)', () => {
     process.env.PATH = '';
     expect(() => notifyOverdue([])).not.toThrow();
+  });
+});
+
+/**
+ * detectOverdueJobs walked a fixed one-week window looking for the most recent
+ * expected fire. Any cron whose gap exceeds that returned null and was skipped
+ * entirely — never flagged overdue on any device, never caught up, no record.
+ * `slack-link-rotate` (`0 9 1,13,25 * *`, 12-day gaps) was live in that class.
+ */
+describe('detectOverdueJobs — schedules sparser than the old one-week lookback', () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    prevHome = process.env.HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-overdue-sparse-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    fs.mkdirSync(path.join(home, '.agents', 'routines'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\n');
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  const write = (job: Record<string, unknown>): void => {
+    fs.writeFileSync(
+      path.join(home, '.agents', 'routines', `${job.name}.yml`),
+      yaml.stringify(job),
+    );
+  };
+
+  const base = {
+    agent: 'claude', mode: 'auto', effort: 'auto', timeout: '10m',
+    enabled: true, prompt: 'noop', timezone: 'UTC',
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('flags a semi-monthly routine whose missed slot is older than a week', async () => {
+    const { detectOverdueJobs } = await import('./overdue.js');
+    // Fires the 1st, 13th and 25th. "Now" is the 22nd: the missed 13th is nine
+    // days back, outside the old window, and the next fire (25th) is ahead.
+    write({ ...base, name: 'semi-monthly', schedule: '0 9 1,13,25 * *' });
+    const overdue = detectOverdueJobs(new Date('2026-01-22T10:00:00.000Z'));
+    expect(overdue.map((o) => o.name)).toContain('semi-monthly');
+  });
+
+  it('flags a monthly routine', async () => {
+    const { detectOverdueJobs } = await import('./overdue.js');
+    write({ ...base, name: 'monthly', schedule: '0 9 1 * *' });
+    const overdue = detectOverdueJobs(new Date('2026-01-20T10:00:00.000Z'));
+    expect(overdue.map((o) => o.name)).toContain('monthly');
+  });
+
+  it('still leaves a routine that ran on schedule alone', async () => {
+    const { detectOverdueJobs } = await import('./overdue.js');
+    write({ ...base, name: 'ran-fine', schedule: '0 9 1,13,25 * *' });
+    const runId = '2026-01-13T09-00-00-000Z';
+    const dir = path.join(home, '.agents', '.history', 'runs', 'ran-fine', runId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'meta.json'), JSON.stringify({
+      jobName: 'ran-fine', runId, pid: null, status: 'completed',
+      startedAt: '2026-01-13T09:00:00.000Z', completedAt: '2026-01-13T09:01:00.000Z', exitCode: 0,
+    }));
+    expect(detectOverdueJobs(new Date('2026-01-22T10:00:00.000Z')).map((o) => o.name))
+      .not.toContain('ran-fine');
+  });
+
+  it('does not resurrect a routine past its endAt', async () => {
+    const { detectOverdueJobs } = await import('./overdue.js');
+    write({ ...base, name: 'retired', schedule: '0 9 * * *', endAt: '2026-01-10T00:00:00Z' });
+    expect(detectOverdueJobs(new Date('2026-01-22T10:00:00.000Z')).map((o) => o.name))
+      .not.toContain('retired');
+  });
+
+  it('does not replay a one-shot-like schedule that never carried runOnce', async () => {
+    const { detectOverdueJobs } = await import('./overdue.js');
+    // Fixed minute/hour/day/month: one-shot by shape, no runOnce flag.
+    write({ ...base, name: 'one-shot-like', schedule: '0 9 5 1 *' });
+    expect(detectOverdueJobs(new Date('2026-01-22T10:00:00.000Z')).map((o) => o.name))
+      .not.toContain('one-shot-like');
+  });
+
+  it('clamps a future createdAt so the routine is not masked forever', async () => {
+    const { routineEffectiveStart } = await import('./overdue.js');
+    const now = new Date('2026-01-22T10:00:00.000Z');
+    const start = routineEffectiveStart(
+      { name: 'skewed', createdAt: '2027-01-01T00:00:00.000Z' } as never,
+      now,
+    );
+    expect(start?.getTime()).toBe(now.getTime());
   });
 });

--- a/apps/cli/src/lib/overdue.ts
+++ b/apps/cli/src/lib/overdue.ts
@@ -14,7 +14,7 @@
 
 import * as fs from 'fs';
 import { Cron } from 'croner';
-import { listJobs, getLatestRun, getJobPath, jobRunsOnThisDevice, type JobConfig } from './routines.js';
+import { listJobs, getLatestRun, resolveJobFilePath, isPastEndAt, isOneShotRoutine, jobRunsOnThisDevice, type JobConfig } from './routines.js';
 import { notifyDesktop } from './menubar/notify-desktop.js';
 
 export interface OverdueJob {
@@ -28,24 +28,43 @@ export interface OverdueJob {
 // Tolerance between "expected fire" and "recorded run start" — accounts for
 // the small gap between the cron tick and when the runner writes meta.json.
 const GRACE_MS = 60_000;
-const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Lookback windows, narrowest first. A fixed one-week window silently blinded
+ * detection to any cron whose gap exceeds it: `0 9 1,13,25 * *` has 12-day gaps,
+ * so `nextRun(now - 7d)` jumped past `now`, the walk returned null, and the
+ * routine was never flagged overdue on any device — no missed record, no
+ * catch-up, permanently. Monthly, quarterly and annual routines were all in that
+ * class.
+ *
+ * A wider window is only tried when the narrower one found nothing, so a dense
+ * schedule (every minute, hourly, daily) never walks more than a week of
+ * occurrences. A sparse schedule has few occurrences to walk by definition.
+ */
+const LOOKBACK_WINDOWS_MS = [7 * DAY_MS, 32 * DAY_MS, 93 * DAY_MS, 400 * DAY_MS];
 
 /** Compute the most recent fire of `pattern` at or before `now`. Croner's
  *  `previousRun()` returns the cron instance's own last fire, which is null
  *  on a freshly-constructed instance — so we walk `nextRun(cursor)` forward
  *  from a week ago and keep the last fire still ≤ now. */
 function previousExpectedFire(cron: Cron, now: Date): Date | null {
-  let cursor: Date = new Date(now.getTime() - ONE_WEEK_MS);
-  let last: Date | null = null;
-  // Cap iterations: even an every-minute schedule yields ≤ 10080 steps over a
-  // week; we cap at 20k as a paranoia bound against pathological patterns.
-  for (let i = 0; i < 20000; i++) {
-    const next = cron.nextRun(cursor);
-    if (!next || next.getTime() > now.getTime()) break;
-    last = next;
-    cursor = next;
+  for (const window of LOOKBACK_WINDOWS_MS) {
+    let cursor: Date = new Date(now.getTime() - window);
+    let last: Date | null = null;
+    // Cap iterations: an every-minute schedule yields ≤ 10080 steps over a week;
+    // 20k is a paranoia bound against pathological patterns. Only a schedule
+    // that found nothing in the narrower window reaches a wider one, and such a
+    // schedule is sparse, so the cap is never the binding constraint.
+    for (let i = 0; i < 20000; i++) {
+      const next = cron.nextRun(cursor);
+      if (!next || next.getTime() > now.getTime()) break;
+      last = next;
+      cursor = next;
+    }
+    if (last) return last;
   }
-  return last;
+  return null;
 }
 
 /**
@@ -60,12 +79,17 @@ function previousExpectedFire(cron: Cron, now: Date): Date | null {
  * Returns null when neither is available, which leaves the routine unfloored
  * (previous behaviour) rather than silently skipping it.
  */
-export function routineEffectiveStart(job: JobConfig): Date | null {
+export function routineEffectiveStart(job: JobConfig, now: Date = new Date()): Date | null {
   if (job.createdAt) {
     const stamped = new Date(job.createdAt);
-    if (!isNaN(stamped.getTime())) return stamped;
+    // Clamp a future stamp (clock skew, a hand-edited year) to now. Left
+    // unclamped it sits after every possible expected fire, so the routine can
+    // never be flagged overdue until wall-clock time catches up.
+    if (!isNaN(stamped.getTime())) {
+      return stamped.getTime() > now.getTime() ? now : stamped;
+    }
   }
-  const path = getJobPath(job.name);
+  const path = resolveJobFilePath(job.name);
   if (!path) return null;
   try {
     return new Date(fs.statSync(path).mtimeMs);
@@ -80,7 +104,17 @@ export function detectOverdueJobs(now: Date = new Date()): OverdueJob[] {
   const overdue: OverdueJob[] = [];
 
   for (const job of listJobs()) {
-    if (!job.enabled || job.runOnce) continue;
+    if (!job.enabled) continue;
+    // One-shot: fires at most once, so a missed slot is not a backlog to replay.
+    // Use the same predicate the scheduler does — the raw `runOnce` flag alone
+    // missed a one-shot-LIKE schedule (a fixed minute/hour/day/month) that never
+    // carried the flag.
+    if (isOneShotRoutine(job)) continue;
+    // Past its configured end: catch-up must not resurrect a routine the author
+    // already retired. The scheduler only auto-disables lazily, inside a live
+    // cron tick, so a routine whose endAt elapsed while the daemon was down is
+    // still enabled on disk when the catch-up pass runs.
+    if (isPastEndAt(job, now)) continue;
     // Trigger-only jobs (no cron schedule) never have an expected fire time.
     if (!job.schedule) continue;
     // A job pinned to another device is that device's to run, notify, and
@@ -106,7 +140,7 @@ export function detectOverdueJobs(now: Date = new Date()): OverdueJob[] {
     // a miss. Without this, any newly created routine on a daily/weekly cron is
     // instantly "overdue" for the previous occurrence — and with auto-catchup
     // that means `agents routines add` runs the routine once, immediately.
-    const start = routineEffectiveStart(job);
+    const start = routineEffectiveStart(job, now);
     if (start && expected.getTime() < start.getTime()) continue;
 
     const latest = getLatestRun(job.name);

--- a/apps/cli/src/lib/routines.ts
+++ b/apps/cli/src/lib/routines.ts
@@ -1299,6 +1299,27 @@ export function getJobPath(name: string): string | null {
 }
 
 /**
+ * Resolve a routine's YAML across EVERY layer `listJobs`/`readJob` read — user
+ * then system — not just the user dir.
+ *
+ * `getJobPath` is user-layer only because its callers write there. Read paths
+ * that ask "when did this routine come to exist" need the system layer too:
+ * a built-in shipped in the system repo has no user-layer file and no
+ * `createdAt`, so a user-layer-only lookup returns null, the overdue floor is
+ * skipped, and the routine reads as instantly overdue on first daemon start —
+ * exactly the case the floor exists to prevent.
+ */
+export function resolveJobFilePath(name: string): string | null {
+  const userPath = getJobPath(name);
+  if (userPath) return userPath;
+  for (const ext of ['.yml', '.yaml']) {
+    const filePath = safeJoin(getSystemRoutinesDir(), name + ext);
+    if (fs.existsSync(filePath)) return filePath;
+  }
+  return null;
+}
+
+/**
  * Parse an "at" time string into a one-shot cron expression.
  * Supports formats like:
  * - "9:00" or "09:00" - today at 9:00 AM (or tomorrow if past)


### PR DESCRIPTION
**bug fix** — a routine that fires less often than weekly could never be caught up. No new surface.

## What was wrong

Overdue detection walked a **fixed one-week window** for the most recent expected fire
(`previousExpectedFire`). Any cron whose gap exceeds that window returned `null`, hit
`if (!expected) continue`, and was skipped entirely — **never flagged overdue on any device,
never caught up, no `missed` record**, silently and permanently.

Monthly, semi-monthly, quarterly and annual routines were all in that class.

Measured on a real fleet schedule — `slack-link-rotate`, `0 9 1,13,25 * *`, 12-day gaps:

```
days where the OLD lookback returned null (routine un-evaluable):
  8, 9, 10, 11, 12, 20, 21, 22, 23, 24
days where the NEW lookback returns null: none

=> 10 of every 28 days, slack-link-rotate could not be flagged overdue at all.
```

## The fix

The lookback widens **week → month → quarter → year**, and only when the narrower window
finds nothing. A dense schedule (minutely, hourly, daily) always resolves in the first
window and never walks more than a week of occurrences; a sparse schedule has few
occurrences to walk by definition. So the iteration cap is never the binding constraint.

Four smaller correctness gaps in the same path, each found by audit:

| gap | consequence |
|---|---|
| `endAt` never checked | The scheduler only auto-disables lazily inside a live cron tick, so a routine whose `endAt` elapsed while the daemon was down was still enabled on disk, rescheduled on restart, and **executed by catch-up**. |
| one-shot used raw `runOnce` | The scheduler uses `isOneShotRoutine`; a one-shot-*like* schedule (fixed minute/hour/day/month) that never carried the flag could be **replayed**. |
| creation floor couldn't see built-ins | It resolved a routine's file **user-layer only** while `listJobs` reads the system layer too — so a shipped routine had neither a `createdAt` nor a resolvable path, the floor was skipped, and it read as **instantly overdue on first daemon start**. That is the exact case the floor exists to prevent. Added `resolveJobFilePath`. |
| future `createdAt` | Sat after every possible expected fire and masked the routine **forever**; now clamped to now. |

## Tests

`apps/cli/src/lib/overdue.test.ts` — **8 passing**, driving the real module against a real
`~/.agents` tree in an isolated `HOME` (real YAML, real run records, no mocks):

- a semi-monthly routine whose missed slot is 9 days back **is** flagged
- a monthly routine is flagged
- a routine that ran on schedule is still left alone
- a routine past `endAt` is **not** resurrected
- a one-shot-like schedule with no `runOnce` is **not** replayed
- a future `createdAt` is clamped

**Verified the tests bite:** reverting the lookback to a single window fails exactly the
semi-monthly and monthly cases and nothing else.

Full local suite: **8,653 passing**. Six fail and all six reproduce identically on a clean
`origin/main` worktree — environment-dependent on this box (real credentials, installs,
model catalogs), none touching routines.

## Docs

`apps/cli/docs/03-routines.md` gains the lookback and the endAt/one-shot rules; changelog
fragment at `.changelog/next/routines-catchup-correctness.md`.
