### PR TITLE
feat(cli): devices config surface — interactive.host, per-device prefs, setup onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,9 @@ agents devices list                     # fleet + headroom: load, mem, idle/busy
 agents devices list --live              # force a live probe of every device (alias of --refresh)
 agents devices list --full              # add per-device cores and free/total RAM
 agents devices list --no-stats          # instant: names/addresses only, skip the probe
+agents devices set-interactive zion     # the device agents show YOU artifacts on (★ in the list)
+agents devices configure mac-mini --max-agents 4 --scheduler off   # per-device config (syncs via devices/<name>/agents.yaml)
+agents devices note mac-mini "runs the releases — don't reboot"    # operator notes, repeat to append
 agents ssh mac-mini                     # hardened SSH: fails fast if offline,
                                         # PowerShell on Windows, password-from-Keychain,
                                         # auto-syncs your terminfo (Ghostty/kitty/…) so

--- a/apps/cli/.changelog/next/device-config.md
+++ b/apps/cli/.changelog/next/device-config.md
@@ -1,0 +1,20 @@
+- **Per-device and fleet-wide config keys now have a home: the `config:` block in
+  the two-tier agents.yaml store.** Three new subcommands under `agents devices`
+  (no new top-level noun): `agents devices set-interactive <name>` records the one
+  device agents show YOU artifacts on (browser opens, dashboards) as
+  `config.interactiveHost` in the central, synced agents.yaml — skills no longer
+  guess "the online macOS box", and the host is marked `★ interactive` in
+  `agents devices list`. `agents devices configure <name> --max-agents N
+  --scheduler on|off --hooks on|off` and `agents devices note <name> "…"` (repeat
+  to append, `--clear` to empty) write device-scope keys under `config:` in
+  `~/.agents/devices/<name>/agents.yaml` — targetable for any device from any box
+  (the devices/ tree syncs; each machine reads only its own). The default browser
+  profile joins the same registry as `browser.profile`, routed to the existing
+  device-local `defaultBrowserProfile` field (no duplicate key, resolution order
+  unchanged). Unset keys always mean today's behavior; everything is scriptable
+  with `--json`, and `devices list --json` now carries each row's `config` and an
+  `interactive` flag. agents.yaml files the CLI writes now carry a
+  `yaml-language-server` hint pointing at the new
+  `apps/cli/schema/agents-yaml.schema.json`. Source:
+  `apps/cli/src/lib/device-config.ts`, `apps/cli/src/lib/state.ts`,
+  `apps/cli/src/commands/ssh.ts`, `apps/cli/schema/agents-yaml.schema.json`.

--- a/apps/cli/.changelog/next/device-config.md
+++ b/apps/cli/.changelog/next/device-config.md
@@ -5,7 +5,7 @@
   `config.interactiveHost` in the central, synced agents.yaml — skills no longer
   guess "the online macOS box", and the host is marked `★ interactive` in
   `agents devices list`. `agents devices configure <name> --max-agents N
-  --scheduler on|off --hooks on|off` and `agents devices note <name> "…"` (repeat
+  --scheduler on|off` and `agents devices note <name> "…"` (repeat
   to append, `--clear` to empty) write device-scope keys under `config:` in
   `~/.agents/devices/<name>/agents.yaml` — targetable for any device from any box
   (the devices/ tree syncs; each machine reads only its own). The default browser
@@ -15,6 +15,25 @@
   with `--json`, and `devices list --json` now carries each row's `config` and an
   `interactive` flag. agents.yaml files the CLI writes now carry a
   `yaml-language-server` hint pointing at the new
-  `apps/cli/schema/agents-yaml.schema.json`. Source:
-  `apps/cli/src/lib/device-config.ts`, `apps/cli/src/lib/state.ts`,
-  `apps/cli/src/commands/ssh.ts`, `apps/cli/schema/agents-yaml.schema.json`.
+  `apps/cli/schema/agents-yaml.schema.json`.
+
+  The keys are live inputs, not just stored values. `--scheduler off` stops the
+  routines scheduler from starting on that device — `routines add` skips the
+  auto-start with the reason, a manual `routines start` refuses, and the daemon
+  re-evaluates the gate on every SIGHUP reload (boot it again with
+  `agents devices configure <host> --scheduler on` + any reload, no daemon
+  restart). `--max-agents` feeds host ranking: Factory auto-launch excludes a
+  device at its cap (counting device-wide running agents) and names the cap when
+  a pool is exhausted; teams placement excludes it from the least-loaded
+  auto-pick (counting the team's own roster, local teammates included) and an
+  all-capped pool fails loud instead of over-filling a machine. Setup asks
+  instead of guessing: bare `agents setup` ends with a skippable preferences
+  step (which machine you sit at → interactive host; which browser agents drive
+  here → device default), `agents setup fleet` offers the interactive host after
+  a sync, and the `agents setup browser` picker highlights the auto-detect
+  winner. Source: `apps/cli/src/lib/device-config.ts`,
+  `apps/cli/src/lib/state.ts`, `apps/cli/src/lib/daemon.ts`,
+  `apps/cli/src/lib/teams/scheduler.ts`, `apps/cli/src/commands/ssh.ts`,
+  `apps/cli/src/commands/setup-preferences.ts`,
+  `apps/factory/src/core/launchHost.ts`,
+  `apps/cli/schema/agents-yaml.schema.json`.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -130,7 +130,7 @@ same logical names.
 
 **Per-device and fleet-wide settings** live in the same two-tier agents.yaml
 store as version pins. `agents devices configure <name>` sets device-scope keys
-(`--max-agents`, `--scheduler on|off`, `--hooks on|off`) and `agents devices
+(`--max-agents`, `--scheduler on|off`) and `agents devices
 note <name> "…"` appends free-form operator notes — both land under `config:` in
 `~/.agents/devices/<name>/agents.yaml`, so they are per-machine by default and
 can be written for a peer from any box (the `devices/` tree syncs, each machine
@@ -142,6 +142,21 @@ in `agents devices list`; `list --json` carries each row's `config` and an
 `interactive` flag. The default browser profile is likewise device-local config
 (`browser.profile` → `agents browser profiles set-default`). Unset keys always
 mean today's behavior. The key registry is `src/lib/device-config.ts`.
+
+The keys are consumed, not just stored. `scheduler.enabled=false` keeps the
+routines scheduler from starting on that device — `routines add` skips the
+auto-start with the reason, `routines start` refuses, and a running daemon
+re-evaluates the gate on every SIGHUP reload, so flipping the key never needs a
+daemon restart. `agents.max-concurrent` feeds host ranking, and what counts
+toward it depends on the consumer: Factory auto-launch counts device-wide
+running agents, while teams placement counts the team's own roster on the
+device (local teammates included); a capped device is excluded from auto-pick
+with a stated reason, and an all-capped pool fails loud. Setup asks instead of
+guessing: bare `agents setup` ends with a skippable preferences step (which
+machine you sit at → `interactive.host`; which browser agents drive here →
+`browser.profile`), `agents setup fleet` offers the interactive host after a
+sync, and `agents setup browser` highlights the auto-detect winner in its
+picker.
 
 **Hosts** — machines you dispatch agent work to. `agents hosts add` enrolls a
 target either from an existing `~/.ssh/config` stanza (connection details stay in

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -128,6 +128,21 @@ password from a Keychain bundle via an askpass shim. `agents devices render --wr
 emits a `~/.ssh/config.d/agents` include so plain `ssh`/`scp`/`rsync` resolve the
 same logical names.
 
+**Per-device and fleet-wide settings** live in the same two-tier agents.yaml
+store as version pins. `agents devices configure <name>` sets device-scope keys
+(`--max-agents`, `--scheduler on|off`, `--hooks on|off`) and `agents devices
+note <name> "…"` appends free-form operator notes — both land under `config:` in
+`~/.agents/devices/<name>/agents.yaml`, so they are per-machine by default and
+can be written for a peer from any box (the `devices/` tree syncs, each machine
+reads only its own). `agents devices set-interactive <name>` sets the one
+user-scope key, `config.interactiveHost` in the *central* agents.yaml: the
+device agents show YOU artifacts on (browser opens, dashboards), so skills stop
+guessing "the online macOS box". The interactive host is marked `★ interactive`
+in `agents devices list`; `list --json` carries each row's `config` and an
+`interactive` flag. The default browser profile is likewise device-local config
+(`browser.profile` → `agents browser profiles set-default`). Unset keys always
+mean today's behavior. The key registry is `src/lib/device-config.ts`.
+
 **Hosts** — machines you dispatch agent work to. `agents hosts add` enrolls a
 target either from an existing `~/.ssh/config` stanza (connection details stay in
 ssh config; agents-cli stores only a caps/os overlay) or *inline* (with its own

--- a/apps/cli/schema/agents-yaml.schema.json
+++ b/apps/cli/schema/agents-yaml.schema.json
@@ -22,7 +22,7 @@
     },
     "config": {
       "type": "object",
-      "description": "Typed config keys (registry: apps/cli/src/lib/device-config.ts). In the central file this holds user-scope keys (interactiveHost); in a device doc it holds device-scope keys (maxAgents, schedulerEnabled, hooksEnabled, notes). Unset keys keep default behavior.",
+      "description": "Typed config keys (registry: apps/cli/src/lib/device-config.ts). In the central file this holds user-scope keys (interactiveHost); in a device doc it holds device-scope keys (maxAgents, schedulerEnabled, notes). Unset keys keep default behavior.",
       "additionalProperties": true,
       "properties": {
         "interactiveHost": {
@@ -32,15 +32,11 @@
         "maxAgents": {
           "type": "integer",
           "minimum": 1,
-          "description": "Device scope. Max agents allowed to run concurrently (agents.max-concurrent)."
+          "description": "Device scope. Cap on concurrent agents (agents.max-concurrent). Factory auto-launch counts device-wide running agents; teams placement counts the team's roster on the device."
         },
         "schedulerEnabled": {
           "type": "boolean",
           "description": "Device scope. Whether the routines scheduler may fire here (scheduler.enabled)."
-        },
-        "hooksEnabled": {
-          "type": "boolean",
-          "description": "Device scope. Whether hooks fire here (hooks.enabled)."
         },
         "notes": {
           "type": "array",

--- a/apps/cli/schema/agents-yaml.schema.json
+++ b/apps/cli/schema/agents-yaml.schema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/phnx-labs/agents-cli/main/apps/cli/schema/agents-yaml.schema.json",
+  "title": "agents-cli agents.yaml",
+  "description": "agents-cli metadata file. Two tiers share this shape: the central (synced) ~/.agents/agents.yaml and each per-device ~/.agents/devices/<host>/agents.yaml. Device-local fields (agents, isolatedAgents, defaultBrowserProfile, device-scope config) belong in the device doc; everything else is portable user config. Source of truth: apps/cli/src/lib/types.ts (Meta).",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "agents": {
+      "type": "object",
+      "description": "Per-device global version pins (agent id → version). Device doc only.",
+      "additionalProperties": { "type": "string" }
+    },
+    "isolatedAgents": {
+      "type": "object",
+      "description": "Per-device preferred isolated version per agent. Device doc only.",
+      "additionalProperties": { "type": "string" }
+    },
+    "defaultBrowserProfile": {
+      "type": "string",
+      "description": "Browser profile `agents browser start` resolves to without --profile. Device doc only (config key: browser.profile)."
+    },
+    "config": {
+      "type": "object",
+      "description": "Typed config keys (registry: apps/cli/src/lib/device-config.ts). In the central file this holds user-scope keys (interactiveHost); in a device doc it holds device-scope keys (maxAgents, schedulerEnabled, hooksEnabled, notes). Unset keys keep default behavior.",
+      "additionalProperties": true,
+      "properties": {
+        "interactiveHost": {
+          "type": "string",
+          "description": "User scope. Device that shows the user artifacts (browser opens, dashboards). Set via `agents devices set-interactive`."
+        },
+        "maxAgents": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Device scope. Max agents allowed to run concurrently (agents.max-concurrent)."
+        },
+        "schedulerEnabled": {
+          "type": "boolean",
+          "description": "Device scope. Whether the routines scheduler may fire here (scheduler.enabled)."
+        },
+        "hooksEnabled": {
+          "type": "boolean",
+          "description": "Device scope. Whether hooks fire here (hooks.enabled)."
+        },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Device scope. Free-form operator notes (`agents devices note`)."
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "description": "`agents run` defaults (mode, effort, fallback chains)."
+    },
+    "lease": {
+      "type": "object",
+      "properties": {
+        "secretsBundle": { "type": "string" }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "description": "macOS secrets-agent defaults (backend, prompt policy, hold window).",
+      "properties": {
+        "backend": { "type": "string", "enum": ["keychain", "file", "vault"] },
+        "policy": { "type": "string", "enum": ["always", "hold", "daily"] },
+        "agent": {
+          "type": "object",
+          "properties": {
+            "auto": { "type": "boolean" },
+            "holdMs": { "type": "integer" },
+            "durable": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "description": "Spend guardrails (user-global caps; project agents.yaml overrides)."
+    },
+    "feed": {
+      "type": "object",
+      "properties": {
+        "broadcast": { "type": "object" }
+      }
+    },
+    "beta": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "registries": {
+      "type": "object",
+      "description": "Resource registries by type (commands, skills, hooks, mcp, …)."
+    },
+    "profiles": {
+      "type": "object",
+      "description": "Top-level resource profiles filtering the resolved resource set."
+    },
+    "versions": {
+      "type": "object",
+      "description": "Per-version resource tracking. Machine-local — partitioned to ~/.agents/.history/version-resources.json on write."
+    },
+    "source": {
+      "type": "string",
+      "description": "Git remote source URL of the system repo."
+    },
+    "projectRoot": {
+      "type": "string",
+      "description": "Projects root for `agents run --project <slug>` (home-relative)."
+    },
+    "extraRepos": {
+      "type": "object",
+      "description": "Extra DotAgent repos merged after ~/.agents/."
+    },
+    "brands": {
+      "type": "object",
+      "description": "White-label brands keyed by name."
+    },
+    "actors": {
+      "type": "object",
+      "description": "Actors keyed by slug — who is behind a run."
+    },
+    "seededPresets": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Removal tombstones for seeded registry presets."
+    },
+    "hooks": {
+      "type": "object",
+      "description": "Hook manifest entries keyed by hook name."
+    },
+    "browser": {
+      "type": "object",
+      "description": "Browser profile definitions keyed by profile name (portable; syncs)."
+    },
+    "hosts": {
+      "type": "object",
+      "description": "Agent-host registry (`agents hosts`) keyed by host name."
+    },
+    "fleet": {
+      "type": "object",
+      "description": "Declarative fleet profile (`agents apply`). Shape: lib/fleet/types.ts FleetManifest."
+    },
+    "share": {
+      "type": "object",
+      "description": "`agents share` endpoint (Cloudflare R2 + Worker).",
+      "properties": {
+        "baseUrl": { "type": "string" },
+        "accountId": { "type": "string" },
+        "workerName": { "type": "string" },
+        "bucketName": { "type": "string" },
+        "domain": { "type": "string" },
+        "analyticsToken": { "type": "string" }
+      }
+    },
+    "notify": {
+      "type": "object",
+      "description": "Owner/channel notification config for `agents send` / `agents notify`.",
+      "properties": {
+        "owner": {
+          "type": "object",
+          "properties": {
+            "channel": { "type": "string" },
+            "to": { "type": "string" }
+          }
+        },
+        "transports": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "routines": {
+      "type": "object",
+      "description": "Routines daemon settings.",
+      "properties": {
+        "projects": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allowlist of project roots whose .agents/routines may fire."
+        }
+      }
+    }
+  }
+}

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -1660,7 +1660,11 @@ export function registerRoutinesCommands(program: Command): void {
       }
       const result = startDaemon();
       if (result.method === 'already-running') {
-        console.log(chalk.yellow(`Scheduler already running (PID: ${result.pid})`));
+        // Signal a reload even here: if the daemon booted while this device had
+        // scheduler.enabled=false, the reload re-evaluates the gate and boots
+        // the scheduler — a manual start heals a scheduler-less daemon.
+        signalDaemonReload();
+        console.log(chalk.yellow(`Scheduler already running (PID: ${result.pid}) — reloaded`));
       } else if (result.pid) {
         console.log(chalk.green(`Scheduler started (PID: ${result.pid})`));
       } else {

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -23,6 +23,7 @@ import {
   readDaemonLog,
   getDaemonStatus,
 } from '../lib/daemon.js';
+import { assertSchedulerEnabled } from '../lib/device-config.js';
 import { resolveAgentName, isAgentHardDeprecated, hardDeprecationError } from '../lib/agents.js';
 import { humanizeCron, humanizeNextRun, formatRepoLink, REPO_DISPLAY_MAX } from '../lib/routines-format.js';
 import {
@@ -368,9 +369,20 @@ function parseRoutineTrigger(options: Record<string, unknown>): JobTrigger | und
 /**
  * Start or reload the background scheduler so newly-added jobs fire on time.
  * `quiet` suppresses human status lines for JSON callers.
+ *
+ * When this device has `scheduler.enabled=false` the auto-start is skipped with
+ * the stated reason (the add itself already succeeded — the job is config and
+ * stays valid fleet-wide); the refusal message names the setting and the fix.
  */
 function ensureSchedulerRunning(opts: { quiet?: boolean; stderr?: boolean } = {}): void {
   const log = opts.stderr ? console.error : console.log;
+  try {
+    assertSchedulerEnabled();
+  } catch (err) {
+    // Loud stated skip, on stderr so --json stdout stays clean.
+    console.error(chalk.yellow((err as Error).message));
+    return;
+  }
   if (isDaemonRunning()) {
     signalDaemonReload();
     if (!opts.quiet) log(chalk.gray('Scheduler reloaded'));
@@ -1638,6 +1650,14 @@ export function registerRoutinesCommands(program: Command): void {
     .command('start')
     .description('Start the background scheduler. Usually unnecessary — it auto-starts when you add your first routine.')
     .action(() => {
+      try {
+        // A manual start on a scheduler-disabled device refuses with the same
+        // message the auto-start surfaces give.
+        assertSchedulerEnabled();
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
       const result = startDaemon();
       if (result.method === 'already-running') {
         console.log(chalk.yellow(`Scheduler already running (PID: ${result.pid})`));

--- a/apps/cli/src/commands/setup-browser.ts
+++ b/apps/cli/src/commands/setup-browser.ts
@@ -22,6 +22,7 @@ import {
 } from '../lib/browser/profiles.js';
 import { DEFAULT_VIEWPORT } from '../lib/browser/devices.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { defaultBrowserChoice } from './setup-preferences.js';
 
 const INSTALL_HINT =
   'Install one of: Google Chrome, Brave, Microsoft Edge, Chromium, or Comet, then re-run `agents setup browser`.\n' +
@@ -78,11 +79,14 @@ export async function runBrowserWizard(): Promise<boolean> {
     await deleteProfile(existing.name);
   }
 
-  // Pick which installed browser to pin (auto-select if only one).
+  // Pick which installed browser to pin (auto-select if only one). The picker
+  // highlights the same browser auto-detect would win — choosing is an
+  // override of the default, never a guess.
   let chosen = installed[0];
   if (installed.length > 1) {
     const value = await select({
       message: 'Which browser should the default profile use?',
+      default: defaultBrowserChoice(installed) ?? undefined,
       choices: installed.map((b) => ({ name: `${b.browserType}  ${chalk.dim(b.binary)}`, value: b.browserType })),
     });
     chosen = installed.find((b) => b.browserType === value) ?? installed[0];

--- a/apps/cli/src/commands/setup-fleet.ts
+++ b/apps/cli/src/commands/setup-fleet.ts
@@ -14,6 +14,7 @@ import { loadDevices } from '../lib/devices/registry.js';
 import { runDeviceSync } from '../lib/devices/sync.js';
 import { tailscaleStatusJson } from '../lib/devices/tailscale.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import { maybePickInteractiveHost } from './setup-preferences.js';
 
 type FleetAuthMethod = 'key' | 'password';
 
@@ -190,6 +191,11 @@ export async function runFleetSetupWizard(opts: SetupFleetOptions = {}): Promise
   if (choices.fleetUpdate) runAgentsSubcommand(['fleet', 'update']);
 
   printOnboardingSummary(names, choices.auth);
+
+  // With a fleet registered, the next wrong-machine trap is artifacts opening on
+  // some other box — offer to pin the interactive host (TTY-only, skippable,
+  // silent non-TTY and when already set).
+  await maybePickInteractiveHost();
   return true;
 }
 

--- a/apps/cli/src/commands/setup-preferences.test.ts
+++ b/apps/cli/src/commands/setup-preferences.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure chooser logic behind the setup preferences prompts (which machine you
+ * sit at, which browser agents drive). The prompts themselves need a TTY; the
+ * choice/default math is extracted pure so it is testable without one.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  defaultBrowserChoice,
+  defaultInteractiveHostChoice,
+  macDeviceNames,
+} from './setup-preferences.js';
+import type { DeviceProfile } from '../lib/devices/registry.js';
+
+function device(name: string, platform: DeviceProfile['platform']): DeviceProfile {
+  return {
+    name,
+    platform,
+    shell: platform === 'windows' ? 'powershell' : 'posix',
+    address: { via: 'manual' },
+    auth: { method: 'key' },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('macDeviceNames', () => {
+  it('keeps only macOS devices, sorted by name', () => {
+    const reg = {
+      zion: device('zion', 'macos'),
+      'win-mini': device('win-mini', 'windows'),
+      'mac-mini': device('mac-mini', 'macos'),
+      'yosemite-s0': device('yosemite-s0', 'linux'),
+    };
+    expect(macDeviceNames(reg)).toEqual(['mac-mini', 'zion']);
+  });
+
+  it('returns [] when no macOS device is registered', () => {
+    expect(macDeviceNames({ 'win-mini': device('win-mini', 'windows') })).toEqual([]);
+  });
+});
+
+describe('defaultInteractiveHostChoice', () => {
+  it('is null with no candidates', () => {
+    expect(defaultInteractiveHostChoice([], 'zion')).toBeNull();
+  });
+
+  it('highlights this machine when it is a candidate', () => {
+    expect(defaultInteractiveHostChoice(['mac-mini', 'zion'], 'zion')).toBe('zion');
+  });
+
+  it('falls back to the first candidate when this machine is not one', () => {
+    expect(defaultInteractiveHostChoice(['mac-mini', 'zion'], 'laptop')).toBe('mac-mini');
+  });
+});
+
+describe('defaultBrowserChoice', () => {
+  it('is null when nothing is installed', () => {
+    expect(defaultBrowserChoice([])).toBeNull();
+  });
+
+  it('highlights the first candidate — the same browser auto-detect would win (priority order)', () => {
+    // listInstalledBrowsers returns platform priority order (macOS: chrome first).
+    expect(defaultBrowserChoice([{ browserType: 'chrome' }, { browserType: 'comet' }])).toBe('chrome');
+    expect(defaultBrowserChoice([{ browserType: 'comet' }])).toBe('comet');
+  });
+});

--- a/apps/cli/src/commands/setup-preferences.ts
+++ b/apps/cli/src/commands/setup-preferences.ts
@@ -1,0 +1,144 @@
+/**
+ * Preferences onboarding — the guided path over the same device-config keys the
+ * `agents devices …` commands write (lib/device-config.ts). Two questions, each
+ * TTY-only, skippable, and absent non-interactively:
+ *
+ *   1. "Which machine do you sit at?"   → `interactive.host` (central config:)
+ *   2. "Which browser should agents drive on THIS machine?"
+ *                                       → `browser.profile` (device-local default)
+ *
+ * Shared by the bare `agents setup` flow (a short step after the capability
+ * hub) and by `agents setup fleet` (interactive host after a successful sync).
+ * Unset always keeps today's behavior — skipping is a real choice, not a
+ * partial state.
+ */
+
+import chalk from 'chalk';
+import { listInstalledBrowsers } from '../lib/browser/chrome.js';
+import {
+  DEFAULT_BROWSER_PROFILE_NAME,
+  createProfile,
+  findFreeProfilePort,
+  getConfiguredDefaultProfileName,
+  getProfile,
+  type BrowserProfile,
+} from '../lib/browser/profiles.js';
+import { DEFAULT_VIEWPORT } from '../lib/browser/devices.js';
+import { getConfigValue, setConfigValue } from '../lib/device-config.js';
+import { loadDevices, type DeviceRegistry } from '../lib/devices/registry.js';
+import { machineId } from '../lib/machine-id.js';
+import { isInteractiveTerminal } from './utils.js';
+
+const SKIP = '__skip__';
+
+/** Registered macOS device names, sorted — the interactive-host candidates. */
+export function macDeviceNames(reg: DeviceRegistry): string[] {
+  return Object.values(reg)
+    .filter((d) => d.platform === 'macos')
+    .map((d) => d.name)
+    .sort();
+}
+
+/**
+ * The interactive-host picker's highlighted default: this machine when it is a
+ * candidate (the common case — you run setup on the box you sit at), else the
+ * first candidate. null when there are no candidates.
+ */
+export function defaultInteractiveHostChoice(candidates: string[], self: string = machineId()): string | null {
+  if (candidates.length === 0) return null;
+  return candidates.includes(self) ? self : candidates[0];
+}
+
+/**
+ * The browser picker's highlighted default — the same browser auto-detect
+ * would win, since `listInstalledBrowsers` returns platform priority order
+ * (macOS: chrome first). null when nothing is installed.
+ */
+export function defaultBrowserChoice<T extends { browserType: string }>(installed: T[]): T['browserType'] | null {
+  return installed.length > 0 ? installed[0].browserType : null;
+}
+
+/**
+ * Offer to set the interactive host when none is configured and the registry
+ * has more than one macOS device. Returns true when a host was set. Silent
+ * no-op non-TTY, when already set, or with fewer than two candidates (the
+ * answer is obvious or absent).
+ */
+export async function maybePickInteractiveHost(): Promise<boolean> {
+  if (!isInteractiveTerminal()) return false;
+  if (getConfigValue('interactive.host').value !== undefined) return false;
+  const macs = macDeviceNames(await loadDevices());
+  if (macs.length < 2) return false;
+
+  const { select } = await import('@inquirer/prompts');
+  const self = machineId();
+  const picked = await select<string>({
+    message: 'Which machine do you sit at? (agents open browser windows and artifacts there)',
+    default: defaultInteractiveHostChoice(macs, self) ?? SKIP,
+    choices: [
+      ...macs.map((n) => ({ name: n === self ? `${n}  ${chalk.dim('(this machine)')}` : n, value: n })),
+      { name: `Skip ${chalk.dim('— decide later: agents devices set-interactive <name>')}`, value: SKIP },
+    ],
+  });
+  if (picked === SKIP) return false;
+  setConfigValue('interactive.host', picked);
+  console.log(chalk.green(`Interactive host: '${picked}'`) + chalk.dim(' — marked ★ interactive in `agents devices list`.'));
+  return true;
+}
+
+/**
+ * Offer to pin this machine's default browser profile to a chosen browser.
+ * Only asked when there is nothing to preserve: no configured device default
+ * AND no existing `default` profile (an existing profile is the user's earlier
+ * choice — never re-pinned behind their back). Returns true when a profile was
+ * created and set as the device default. Silent no-op non-TTY.
+ */
+export async function maybePickBrowserProfile(): Promise<boolean> {
+  if (!isInteractiveTerminal()) return false;
+  if (getConfiguredDefaultProfileName()) return false;
+  if (await getProfile(DEFAULT_BROWSER_PROFILE_NAME)) return false;
+  const installed = listInstalledBrowsers();
+  if (installed.length === 0) return false;
+
+  const { select } = await import('@inquirer/prompts');
+  const picked = await select<string>({
+    message: 'Which browser should agents drive on THIS machine?',
+    default: defaultBrowserChoice(installed) ?? SKIP,
+    choices: [
+      ...installed.map((b) => ({ name: `${b.browserType}  ${chalk.dim(b.binary)}`, value: b.browserType })),
+      { name: `Skip ${chalk.dim('— auto-detect on first use (priority order)')}`, value: SKIP },
+    ],
+  });
+  if (picked === SKIP) return false;
+
+  const chosen = installed.find((b) => b.browserType === picked) ?? installed[0];
+  const freePort = await findFreeProfilePort();
+  const profile: BrowserProfile = {
+    name: DEFAULT_BROWSER_PROFILE_NAME,
+    description: `${chosen.browserType} profile (chosen during setup)`,
+    browser: chosen.browserType,
+    binary: chosen.binary,
+    endpoints: [`cdp://127.0.0.1:${freePort}`],
+    viewport: { width: DEFAULT_VIEWPORT.width, height: DEFAULT_VIEWPORT.height },
+  };
+  await createProfile(profile);
+  // The same key `agents browser profiles set-default` writes (device-local).
+  setConfigValue('browser.profile', profile.name);
+  console.log(
+    chalk.green(`Browser: '${chosen.browserType}'`) +
+      chalk.dim(` — profile "${profile.name}" is this machine's default (agents browser profiles set-default to change).`),
+  );
+  return true;
+}
+
+/**
+ * The bare-`agents setup` preferences step: interactive host, then browser.
+ * Runs AFTER the capability hub so it never delays the bootstrap. Never
+ * throws — a cancel or a failed pick just ends the step (hub semantics).
+ */
+export async function runPreferencesStep(): Promise<void> {
+  if (!isInteractiveTerminal()) return;
+  const pickedHost = await maybePickInteractiveHost();
+  const pickedBrowser = await maybePickBrowserProfile();
+  if (pickedHost || pickedBrowser) console.log();
+}

--- a/apps/cli/src/commands/setup-preferences.ts
+++ b/apps/cli/src/commands/setup-preferences.ts
@@ -134,11 +134,16 @@ export async function maybePickBrowserProfile(): Promise<boolean> {
 /**
  * The bare-`agents setup` preferences step: interactive host, then browser.
  * Runs AFTER the capability hub so it never delays the bootstrap. Never
- * throws — a cancel or a failed pick just ends the step (hub semantics).
+ * throws — a prompt cancel or a failed pick ends the step quietly and lets
+ * setup complete (the same semantics as the capability hub).
  */
 export async function runPreferencesStep(): Promise<void> {
   if (!isInteractiveTerminal()) return;
-  const pickedHost = await maybePickInteractiveHost();
-  const pickedBrowser = await maybePickBrowserProfile();
-  if (pickedHost || pickedBrowser) console.log();
+  try {
+    const pickedHost = await maybePickInteractiveHost();
+    const pickedBrowser = await maybePickBrowserProfile();
+    if (pickedHost || pickedBrowser) console.log();
+  } catch {
+    // Cancel (ctrl-c) or a picker failure — the step is optional; end it.
+  }
 }

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -27,6 +27,7 @@ import { registerSetupShareCommand, runShareWizard } from './setup-share.js';
 import { registerSetupMineCommand } from './setup-mine.js';
 import { registerSetupSecretsCommand } from './setup-secrets.js';
 import { registerSetupFleetCommand } from './setup-fleet.js';
+import { runPreferencesStep } from './setup-preferences.js';
 
 const HOME = os.homedir();
 
@@ -231,6 +232,11 @@ export async function runSetup(program: Command, options: { force?: boolean; sup
   // stops at the system-repo bootstrap above, unchanged.
   await runSetupHub();
 
+  // Preferences step: the two questions that keep agents off the wrong machine —
+  // which box you sit at (interactive host) and which browser agents drive here.
+  // TTY-only, skippable, and writes the same keys as `agents devices …`.
+  await runPreferencesStep();
+
   console.log(chalk.bold('\nSetup complete. Try:'));
   console.log(chalk.cyan('  agents view                 ') + chalk.gray(' # see what\'s installed'));
   console.log(chalk.cyan('  agents run <agent> "hello"  ') + chalk.gray(' # run an agent'));
@@ -337,6 +343,9 @@ export function registerSetupCommand(program: Command): void {
         1. Clones the system repo into ~/.agents/.system/
         2. Imports any unmanaged agent installations it finds
         3. On a TTY, offers to set up optional capabilities (browser/computer/share/secrets/fleet)
+        4. On a TTY, asks preferences: which machine you sit at (interactive host)
+           and which browser agents drive here — both skippable, both the same
+           keys 'agents devices set-interactive' / 'browser profiles set-default' write
 
       Capability setup can also be run any time on its own:
         agents setup browser    # detect a browser + create the default profile

--- a/apps/cli/src/commands/ssh.device-config.test.ts
+++ b/apps/cli/src/commands/ssh.device-config.test.ts
@@ -93,14 +93,13 @@ describe('devices configure', () => {
     guardedHome();
     expect(run(['devices', 'add', 'mac-mini', 'muqsit@192.0.2.2']).status).toBe(0);
 
-    const set = run(['devices', 'configure', 'mac-mini', '--max-agents', '4', '--scheduler', 'off', '--hooks', 'off']);
+    const set = run(['devices', 'configure', 'mac-mini', '--max-agents', '4', '--scheduler', 'off']);
     expect(set.status, set.stderr).toBe(0);
     expect(set.stdout).toContain('agents.max-concurrent = 4');
 
     const doc = deviceDoc('mac-mini');
     expect(doc).toContain('maxAgents: 4');
     expect(doc).toContain('schedulerEnabled: false');
-    expect(doc).toContain('hooksEnabled: false');
     // Device scope never lands in central.
     expect(centralDoc()).not.toContain('maxAgents');
 
@@ -111,7 +110,6 @@ describe('devices configure', () => {
     expect(parsed.config).toMatchObject({
       'agents.max-concurrent': 4,
       'scheduler.enabled': false,
-      'hooks.enabled': false,
     });
 
     // No flags → print current config.

--- a/apps/cli/src/commands/ssh.device-config.test.ts
+++ b/apps/cli/src/commands/ssh.device-config.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// End-to-end tests for the device-config subcommands (`agents devices
+// set-interactive|configure|note`). Spawns the REAL CLI against a throwaway
+// HOME (same pattern as ssh.test.ts) — no mocking; the assertions read the
+// actual agents.yaml files the commands wrote.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
+
+let testHome = '';
+
+afterEach(() => {
+  if (testHome) fs.rmSync(testHome, { recursive: true, force: true });
+  testHome = '';
+});
+
+function guardedHome(): void {
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-devices-config-home-'));
+  const systemDir = path.join(testHome, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: 4102444800000, latestVersion: '0.0.0' }),
+  );
+}
+
+function run(args: string[], extraEnv: Record<string, string> = {}): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('bun', [INDEX, ...args], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: testHome,
+      // os.homedir() reads USERPROFILE on Windows, so HOME alone leaves the
+      // spawned CLI resolving the real profile ('agents-cli is not set up').
+      USERPROFILE: testHome,
+      AGENTS_NO_UPDATE_CHECK: '1',
+      AGENTS_NO_USAGE_TRACK: '1',
+      ...extraEnv,
+    },
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status };
+}
+
+function deviceDoc(host: string): string {
+  const p = path.join(testHome, '.agents', 'devices', host, 'agents.yaml');
+  return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '';
+}
+function centralDoc(): string {
+  const p = path.join(testHome, '.agents', 'agents.yaml');
+  return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '';
+}
+
+describe('devices set-interactive', () => {
+  it('reports unset, sets a registered device, reads back, and unsets', () => {
+    guardedHome();
+
+    const empty = run(['devices', 'set-interactive']);
+    expect(empty.status).toBe(0);
+    expect(empty.stdout).toContain('No interactive host set');
+
+    expect(run(['devices', 'add', 'zion', 'muqsit@192.0.2.1']).status).toBe(0);
+
+    const set = run(['devices', 'set-interactive', 'zion']);
+    expect(set.status, set.stderr).toBe(0);
+    expect(set.stdout).toContain("Interactive host: 'zion'");
+    // User scope → central agents.yaml under config:.
+    expect(centralDoc()).toContain('interactiveHost: zion');
+
+    const got = run(['devices', 'set-interactive', '--json']);
+    expect(got.status).toBe(0);
+    expect(JSON.parse(got.stdout).interactiveHost).toBe('zion');
+
+    const unset = run(['devices', 'set-interactive', '--unset']);
+    expect(unset.status).toBe(0);
+    expect(JSON.parse(run(['devices', 'set-interactive', '--json']).stdout).interactiveHost).toBeNull();
+  });
+
+  it('rejects a device that is not registered', () => {
+    guardedHome();
+    const r = run(['devices', 'set-interactive', 'ghost']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("Unknown device 'ghost'");
+  });
+});
+
+describe('devices configure', () => {
+  it('writes device-scope keys into the named device’s doc and prints them back', () => {
+    guardedHome();
+    expect(run(['devices', 'add', 'mac-mini', 'muqsit@192.0.2.2']).status).toBe(0);
+
+    const set = run(['devices', 'configure', 'mac-mini', '--max-agents', '4', '--scheduler', 'off', '--hooks', 'off']);
+    expect(set.status, set.stderr).toBe(0);
+    expect(set.stdout).toContain('agents.max-concurrent = 4');
+
+    const doc = deviceDoc('mac-mini');
+    expect(doc).toContain('maxAgents: 4');
+    expect(doc).toContain('schedulerEnabled: false');
+    expect(doc).toContain('hooksEnabled: false');
+    // Device scope never lands in central.
+    expect(centralDoc()).not.toContain('maxAgents');
+
+    const got = run(['devices', 'configure', 'mac-mini', '--json']);
+    expect(got.status).toBe(0);
+    const parsed = JSON.parse(got.stdout);
+    expect(parsed.device).toBe('mac-mini');
+    expect(parsed.config).toMatchObject({
+      'agents.max-concurrent': 4,
+      'scheduler.enabled': false,
+      'hooks.enabled': false,
+    });
+
+    // No flags → print current config.
+    const show = run(['devices', 'configure', 'mac-mini']);
+    expect(show.status).toBe(0);
+    expect(show.stdout).toContain("Config for 'mac-mini'");
+    expect(show.stdout).toContain('agents.max-concurrent');
+  });
+
+  it('rejects bad values loudly', () => {
+    guardedHome();
+    expect(run(['devices', 'add', 'mac-mini', 'muqsit@192.0.2.2']).status).toBe(0);
+
+    expect(run(['devices', 'configure', 'mac-mini', '--max-agents', '0']).status).toBe(1);
+    const badBool = run(['devices', 'configure', 'mac-mini', '--scheduler', 'maybe']);
+    expect(badBool.status).toBe(1);
+    expect(badBool.stderr).toContain("expects 'on' or 'off'");
+    expect(run(['devices', 'configure', 'ghost', '--max-agents', '2']).status).toBe(1);
+  });
+});
+
+describe('devices note', () => {
+  it('appends notes, lists them, and clears', () => {
+    guardedHome();
+    expect(run(['devices', 'add', 'mac-mini', 'muqsit@192.0.2.2']).status).toBe(0);
+
+    const first = run(['devices', 'note', 'mac-mini', 'runs the releases']);
+    expect(first.status, first.stderr).toBe(0);
+    const second = run(['devices', 'note', 'mac-mini', 'do not', 'reboot']);
+    expect(second.status).toBe(0);
+
+    const doc = deviceDoc('mac-mini');
+    expect(doc).toContain('- runs the releases');
+    expect(doc).toContain('- do not reboot');
+
+    const got = run(['devices', 'note', 'mac-mini', '--json']);
+    expect(JSON.parse(got.stdout).notes).toEqual(['runs the releases', 'do not reboot']);
+
+    const show = run(['devices', 'note', 'mac-mini']);
+    expect(show.stdout).toContain('runs the releases');
+    expect(show.stdout).toContain('do not reboot');
+
+    expect(run(['devices', 'note', 'mac-mini', '--clear']).status).toBe(0);
+    expect(JSON.parse(run(['devices', 'note', 'mac-mini', '--json']).stdout).notes).toEqual([]);
+  });
+});
+
+describe('devices list surfaces the config', () => {
+  it('marks the interactive host in the table and carries config in --json', () => {
+    guardedHome();
+    expect(run(['devices', 'add', 'zion', 'muqsit@192.0.2.1']).status).toBe(0);
+    expect(run(['devices', 'add', 'mac-mini', 'muqsit@192.0.2.2']).status).toBe(0);
+    expect(run(['devices', 'set-interactive', 'zion']).status).toBe(0);
+    expect(run(['devices', 'configure', 'mac-mini', '--max-agents', '4']).status).toBe(0);
+
+    const table = run(['devices', 'list', '--no-stats']);
+    expect(table.status, table.stderr).toBe(0);
+    expect(table.stdout).toContain('★ interactive');
+
+    const json = run(['devices', 'list', '--json']);
+    expect(json.status).toBe(0);
+    const rows = JSON.parse(json.stdout) as Array<{ name: string; interactive: boolean; config?: Record<string, unknown> }>;
+    const zion = rows.find((r) => r.name === 'zion');
+    const macMini = rows.find((r) => r.name === 'mac-mini');
+    expect(zion?.interactive).toBe(true);
+    expect(macMini?.interactive).toBe(false);
+    expect(macMini?.config).toMatchObject({ maxAgents: 4 });
+  });
+});

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -999,12 +999,11 @@ Typical workflow:
 
   const configureCmd = devicesCmd
     .command('configure <name>')
-    .description('Get or set per-device config: --max-agents, --scheduler, --hooks. Written to ~/.agents/devices/<name>/agents.yaml (works for any device — the devices/ tree syncs). Unset = default behavior.')
-    .option('--max-agents <n>', 'max agents allowed to run concurrently on this device')
-    .option('--scheduler <on|off>', 'allow the routines scheduler (daemon) to fire on this device')
-    .option('--hooks <on|off>', 'allow hooks to fire on this device')
+    .description('Get or set per-device config: --max-agents, --scheduler. Written to ~/.agents/devices/<name>/agents.yaml (works for any device — the devices/ tree syncs). Unset = default behavior.')
+    .option('--max-agents <n>', 'cap concurrent agents (Factory auto-launch counts device-wide; teams placement counts the team’s roster on the device)')
+    .option('--scheduler <on|off>', 'allow the routines scheduler (daemon) to fire on this device (takes effect on daemon reload/restart)')
     .option('--json', 'output machine-readable JSON')
-    .action(async (name: string, opts: { maxAgents?: string; scheduler?: string; hooks?: string; json?: boolean }) => {
+    .action(async (name: string, opts: { maxAgents?: string; scheduler?: string; json?: boolean }) => {
       try {
         await mustGetDevice(name);
         const parseOnOff = (flag: string, raw: string): boolean => {
@@ -1019,7 +1018,6 @@ Typical workflow:
           writes.push(['agents.max-concurrent', n]);
         }
         if (opts.scheduler !== undefined) writes.push(['scheduler.enabled', parseOnOff('scheduler', opts.scheduler)]);
-        if (opts.hooks !== undefined) writes.push(['hooks.enabled', parseOnOff('hooks', opts.hooks)]);
 
         if (writes.length > 0) {
           for (const [key, value] of writes) setConfigValue(key, value, { device: name });
@@ -1053,16 +1051,17 @@ Typical workflow:
     examples: `
       agents devices configure mac-mini --max-agents 4      # cap concurrent agents
       agents devices configure mac-mini --scheduler off     # no routines firing there
-      agents devices configure win-mini --hooks off         # no hooks on that box
       agents devices configure mac-mini                     # print its current config
       agents devices configure mac-mini --json              # machine-readable
     `,
     notes: `
       Run it on any machine for any device: the value lands in
       ~/.agents/devices/<name>/agents.yaml locally and reaches the device on the
-      next 'agents repo push/pull'. Unset keys keep today's behavior. For the
-      default browser profile use 'agents browser profiles set-default <name>';
-      for free-form text use 'agents devices note'.
+      next 'agents repo push/pull'. Unset keys keep today's behavior.
+      --scheduler takes effect when the daemon reloads or restarts on that
+      device ('agents routines start' / the reload a 'routines add' sends).
+      For the default browser profile use 'agents browser profiles set-default
+      <name>'; for free-form text use 'agents devices note'.
     `,
   });
 
@@ -1133,7 +1132,7 @@ Typical workflow:
     if (opts.json) {
       // Registry + local device docs, always fast — the Factory extension polls
       // this path. Each row carries its device-scope `config` (maxAgents,
-      // schedulerEnabled, hooksEnabled, notes, defaultBrowserProfile — set keys
+      // schedulerEnabled, notes, defaultBrowserProfile — set keys
       // only) and an `interactive` flag for the configured interactive host.
       process.stdout.write(
         JSON.stringify(

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -111,10 +111,13 @@ import {
   type VerdictSummary,
 } from '../lib/auth-health.js';
 import { runFleetLogin, type LoginStatus } from '../lib/fleet/remote-login.js';
+import { getConfigValue, listConfig, setConfigValue, unsetConfigValue } from '../lib/device-config.js';
+import { setHelpSections } from '../lib/help.js';
 
 /** One-line summary of a device for `list`. `isSelf` marks the machine this
- * command is running on so it stands out from the rest of the tailnet. */
-function deviceSummary(d: DeviceProfile, isSelf = false, stats?: DeviceStats): string {
+ * command is running on so it stands out from the rest of the tailnet.
+ * `isInteractive` marks the configured interactive host (`devices set-interactive`). */
+function deviceSummary(d: DeviceProfile, isSelf = false, stats?: DeviceStats, isInteractive = false): string {
   const addr = hostNameFor(d) ?? chalk.gray('no address');
   // Prefer a fresh live verdict (this run's probe, else the written-back
   // reachability) over the stale tailscale.online snapshot (RUSH-1965).
@@ -129,7 +132,8 @@ function deviceSummary(d: DeviceProfile, isSelf = false, stats?: DeviceStats): s
   const marker = isSelf ? chalk.cyan('▸ ') : '  ';
   const name = isSelf ? chalk.bold.cyan(d.name.padEnd(16)) : chalk.bold(d.name.padEnd(16));
   const here = isSelf ? chalk.cyan('  ← this machine') : '';
-  return `${marker}${name} ${String(d.platform).padEnd(8)} ${(d.user ? d.user + '@' : '') + addr}  ${online}${reach}${here}`;
+  const interactive = isInteractive ? chalk.yellow('  ★ interactive') : '';
+  return `${marker}${name} ${String(d.platform).padEnd(8)} ${(d.user ? d.user + '@' : '') + addr}  ${online}${reach}${here}${interactive}`;
 }
 
 const HEADROOM_BADGE: Record<Headroom, string> = {
@@ -162,8 +166,9 @@ function renderDeviceTable(
   self: string | undefined,
   statsMap?: Map<string, DeviceStats>,
   full = false,
+  interactiveHost?: string,
 ): string[] {
-  if (!statsMap) return names.map((n) => deviceSummary(reg[n], n === self));
+  if (!statsMap) return names.map((n) => deviceSummary(reg[n], n === self, undefined, n === interactiveHost));
 
   const lines: string[] = [];
   const head =
@@ -206,7 +211,8 @@ function renderDeviceTable(
       : '';
     const badge = HEADROOM_BADGE[headroom(stats)];
     const here = isSelf ? chalk.cyan('  ← this machine') : '';
-    lines.push(`${marker}${label}${plat} ${cores}${load}${mem}${freeTotal}  ${badge}${relay}${here}`);
+    const interactive = name === interactiveHost ? chalk.yellow('  ★ interactive') : '';
+    lines.push(`${marker}${label}${plat} ${cores}${load}${mem}${freeTotal}  ${badge}${relay}${here}${interactive}`);
   }
 
   // Fleet capacity summary — total cores + how much RAM is free right now.
@@ -797,10 +803,13 @@ function registerDevicesCommands(program: Command): void {
 Typical workflow:
   agents devices sync            # curate: pick which tailscale nodes to keep (TTY)
   agents devices sync --yes      # non-interactive: register all non-ignored nodes
-  agents devices list            # see what's registered
+  agents devices list            # see what's registered (★ = interactive host)
   agents devices ignore ipad165  # dismiss a node so it's never re-suggested
   agents devices disable zion    # exclude a device from Factory auto-launch
   agents devices prefer mac-mini # boost a device in Factory auto-launch ranking
+  agents devices set-interactive zion        # where agents show YOU artifacts
+  agents devices configure mac-mini --max-agents 4 --scheduler off
+  agents devices note mac-mini "runs the releases — don't reboot"
   agents devices set win-mini --auth password --bundle muqsit
   agents devices render --write  # write ~/.ssh/config.d/agents include
   agents fleet update            # roll out latest agents-cli to every online device
@@ -940,12 +949,202 @@ Typical workflow:
       }
     });
 
+  const setInteractiveCmd = devicesCmd
+    .command('set-interactive [name]')
+    .description('Get or set the interactive host — the one device that shows YOU artifacts (browser opens, dashboards, rendered plans). Stored fleet-wide as config.interactiveHost in central agents.yaml.')
+    .option('--unset', 'clear the interactive host')
+    .option('--json', 'output machine-readable JSON')
+    .action(async (name: string | undefined, opts: { unset?: boolean; json?: boolean }) => {
+      try {
+        if (opts.unset) {
+          unsetConfigValue('interactive.host');
+          if (opts.json) process.stdout.write(JSON.stringify({ interactiveHost: null }, null, 2) + '\n');
+          else console.log(chalk.green('Cleared the interactive host.'));
+          return;
+        }
+        if (name) {
+          await mustGetDevice(name);
+          setConfigValue('interactive.host', name);
+          if (opts.json) process.stdout.write(JSON.stringify({ interactiveHost: name }, null, 2) + '\n');
+          else console.log(chalk.green(`Interactive host: '${name}'`) + chalk.gray(' — agents show you artifacts there. Clear with --unset.'));
+          return;
+        }
+        const current = getConfigValue('interactive.host').value as string | undefined;
+        if (opts.json) {
+          process.stdout.write(JSON.stringify({ interactiveHost: current ?? null }, null, 2) + '\n');
+        } else if (current) {
+          console.log(`${chalk.bold('Interactive host:')} ${chalk.cyan(current)}`);
+        } else {
+          console.log(chalk.gray("No interactive host set. Set one with 'agents devices set-interactive <name>'."));
+        }
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+  setHelpSections(setInteractiveCmd, {
+    examples: `
+      agents devices set-interactive zion      # zion is where artifacts open for you
+      agents devices set-interactive           # print the current interactive host
+      agents devices set-interactive --unset   # back to no interactive host
+      agents devices set-interactive --json    # machine-readable (for skills)
+    `,
+    notes: `
+      The interactive host answers "which online macOS device do I show this on?"
+      so skills stop guessing. It is marked ★ interactive in 'agents devices list'.
+      The value syncs fleet-wide (central agents.yaml, config.interactiveHost);
+      per-device settings live under 'agents devices configure' instead.
+    `,
+  });
+
+  const configureCmd = devicesCmd
+    .command('configure <name>')
+    .description('Get or set per-device config: --max-agents, --scheduler, --hooks. Written to ~/.agents/devices/<name>/agents.yaml (works for any device — the devices/ tree syncs). Unset = default behavior.')
+    .option('--max-agents <n>', 'max agents allowed to run concurrently on this device')
+    .option('--scheduler <on|off>', 'allow the routines scheduler (daemon) to fire on this device')
+    .option('--hooks <on|off>', 'allow hooks to fire on this device')
+    .option('--json', 'output machine-readable JSON')
+    .action(async (name: string, opts: { maxAgents?: string; scheduler?: string; hooks?: string; json?: boolean }) => {
+      try {
+        await mustGetDevice(name);
+        const parseOnOff = (flag: string, raw: string): boolean => {
+          if (raw === 'on') return true;
+          if (raw === 'off') return false;
+          throw new Error(`--${flag} expects 'on' or 'off', got '${raw}'.`);
+        };
+        const writes: Array<[string, unknown]> = [];
+        if (opts.maxAgents !== undefined) {
+          const n = Number(opts.maxAgents);
+          if (!Number.isInteger(n)) throw new Error(`--max-agents expects an integer, got '${opts.maxAgents}'.`);
+          writes.push(['agents.max-concurrent', n]);
+        }
+        if (opts.scheduler !== undefined) writes.push(['scheduler.enabled', parseOnOff('scheduler', opts.scheduler)]);
+        if (opts.hooks !== undefined) writes.push(['hooks.enabled', parseOnOff('hooks', opts.hooks)]);
+
+        if (writes.length > 0) {
+          for (const [key, value] of writes) setConfigValue(key, value, { device: name });
+          if (!opts.json) {
+            for (const [key, value] of writes) {
+              console.log(chalk.green(`Set ${key} = ${JSON.stringify(value)}`) + chalk.gray(` on '${name}'.`));
+            }
+          }
+        }
+
+        if (opts.json || writes.length === 0) {
+          const entries = listConfig({ device: name }).filter((e) => e.spec.scope === 'device');
+          if (opts.json) {
+            const config: Record<string, unknown> = {};
+            for (const e of entries) if (e.value !== undefined) config[e.spec.name] = e.value;
+            process.stdout.write(JSON.stringify({ device: name, config }, null, 2) + '\n');
+          } else {
+            console.log(chalk.bold(`Config for '${name}'`));
+            for (const e of entries) {
+              const value = e.value === undefined ? chalk.gray('— (default)') : chalk.cyan(JSON.stringify(e.value));
+              console.log(`  ${e.spec.name.padEnd(24)} ${value}${chalk.gray(`  ${e.spec.description}`)}`);
+            }
+          }
+        }
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+  setHelpSections(configureCmd, {
+    examples: `
+      agents devices configure mac-mini --max-agents 4      # cap concurrent agents
+      agents devices configure mac-mini --scheduler off     # no routines firing there
+      agents devices configure win-mini --hooks off         # no hooks on that box
+      agents devices configure mac-mini                     # print its current config
+      agents devices configure mac-mini --json              # machine-readable
+    `,
+    notes: `
+      Run it on any machine for any device: the value lands in
+      ~/.agents/devices/<name>/agents.yaml locally and reaches the device on the
+      next 'agents repo push/pull'. Unset keys keep today's behavior. For the
+      default browser profile use 'agents browser profiles set-default <name>';
+      for free-form text use 'agents devices note'.
+    `,
+  });
+
+  const noteCmd = devicesCmd
+    .command('note <name> [text...]')
+    .description('Append a free-form note to a device (repeat to append more). No text prints the notes; --clear empties them.')
+    .option('--clear', 'remove all notes from the device')
+    .option('--json', 'output machine-readable JSON')
+    .action(async (name: string, text: string[], opts: { clear?: boolean; json?: boolean }) => {
+      try {
+        await mustGetDevice(name);
+        if (opts.clear) {
+          unsetConfigValue('notes', { device: name });
+          if (opts.json) process.stdout.write(JSON.stringify({ device: name, notes: [] }, null, 2) + '\n');
+          else console.log(chalk.green(`Cleared notes on '${name}'.`));
+          return;
+        }
+        if (text.length > 0) {
+          const existing = (getConfigValue('notes', { device: name }).value as string[] | undefined) ?? [];
+          const notes = [...existing, text.join(' ')];
+          setConfigValue('notes', notes, { device: name });
+          if (opts.json) process.stdout.write(JSON.stringify({ device: name, notes }, null, 2) + '\n');
+          else console.log(chalk.green(`Noted on '${name}':`) + ` ${text.join(' ')}`);
+          return;
+        }
+        const notes = (getConfigValue('notes', { device: name }).value as string[] | undefined) ?? [];
+        if (opts.json) {
+          process.stdout.write(JSON.stringify({ device: name, notes }, null, 2) + '\n');
+        } else if (notes.length > 0) {
+          console.log(chalk.bold(`Notes for '${name}'`));
+          for (const n of notes) console.log(`  ${chalk.gray('•')} ${n}`);
+        } else {
+          console.log(chalk.gray(`No notes on '${name}'. Add one with 'agents devices note ${name} "..."'.`));
+        }
+      } catch (err: any) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+    });
+  setHelpSections(noteCmd, {
+    examples: `
+      agents devices note mac-mini "runs the releases — don't reboot"
+      agents devices note mac-mini "4 displays attached"   # appends a second note
+      agents devices note mac-mini                         # print its notes
+      agents devices note mac-mini --clear                 # drop them all
+    `,
+    notes: `
+      Notes are operator memory for a box (why it exists, what to never do to
+      it). They sync like every other device doc; 'agents devices list --json'
+      carries them under config.notes.
+    `,
+  });
+
+  /** Device-scope config block for `list --json`, keyed by yamlKey (set keys only). */
+  const deviceConfigJson = (name: string): Record<string, unknown> | undefined => {
+    const config: Record<string, unknown> = {};
+    for (const entry of listConfig({ device: name })) {
+      if (entry.spec.scope !== 'device' || entry.value === undefined) continue;
+      config[entry.spec.yamlKey] = entry.value;
+    }
+    return Object.keys(config).length > 0 ? config : undefined;
+  };
+
   const runList = async (opts: { json?: boolean; stats?: boolean; full?: boolean; refresh?: boolean; live?: boolean } = {}) => {
     const reg = await loadDevices();
     const names = Object.keys(reg).sort();
+    const interactiveHost = getConfigValue('interactive.host').value as string | undefined;
     if (opts.json) {
-      // Registry-only, always fast — the Factory extension polls this path.
-      process.stdout.write(JSON.stringify(names.map((n) => reg[n]), null, 2) + '\n');
+      // Registry + local device docs, always fast — the Factory extension polls
+      // this path. Each row carries its device-scope `config` (maxAgents,
+      // schedulerEnabled, hooksEnabled, notes, defaultBrowserProfile — set keys
+      // only) and an `interactive` flag for the configured interactive host.
+      process.stdout.write(
+        JSON.stringify(
+          names.map((n) => {
+            const config = deviceConfigJson(n);
+            return { ...reg[n], interactive: n === interactiveHost, ...(config ? { config } : {}) };
+          }),
+          null,
+          2,
+        ) + '\n',
+      );
       return;
     }
     if (names.length === 0) {
@@ -983,7 +1182,7 @@ Typical workflow:
     }
 
     console.log(chalk.bold(`Devices (${names.length})`));
-    for (const line of renderDeviceTable(reg, names, self, statsMap, opts.full)) console.log(line);
+    for (const line of renderDeviceTable(reg, names, self, statsMap, opts.full, interactiveHost)) console.log(line);
     if (freshness?.servedFromCache && freshness.oldestFetchedAt != null) {
       console.log(chalk.gray(`  updated ${formatCheckedAge(freshness.oldestFetchedAt)} — pass --refresh (--live) for a live probe`));
     }

--- a/apps/cli/src/lib/daemon.test.ts
+++ b/apps/cli/src/lib/daemon.test.ts
@@ -31,6 +31,7 @@ import {
   writeDaemonPid,
   removeDaemonPid,
   shouldTakeOverBroker,
+  schedulerGateTransition,
   anchorDaemonCwd,
   describeEphemeralDaemonRoot,
   warnEphemeralDaemonRoot,
@@ -814,5 +815,23 @@ describe('validateDaemonBinary (ephemeral-root warning)', () => {
   it('does not emit a wedge warning for a version-home install', () => {
     const { warnings } = validateDaemonBinary('/home/u/.agents/.history/versions/agents/1.20.88/dist/index.js');
     expect(warnings.some((w) => /worktree|temporary directory/.test(w))).toBe(false);
+  });
+});
+
+describe('schedulerGateTransition (scheduler.enabled re-evaluated on SIGHUP)', () => {
+  it('boots the scheduler when the gate flipped on while the daemon ran scheduler-less', () => {
+    expect(schedulerGateTransition(false, true)).toBe('boot');
+  });
+
+  it('stops a running scheduler when the gate flipped off', () => {
+    expect(schedulerGateTransition(true, false)).toBe('stop');
+  });
+
+  it('reloads a running scheduler when the gate is unchanged', () => {
+    expect(schedulerGateTransition(true, true)).toBe('reload');
+  });
+
+  it('stays dark when the gate is off and nothing runs', () => {
+    expect(schedulerGateTransition(false, false)).toBe('none');
   });
 });

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -25,6 +25,7 @@ import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
 import { redactSecrets } from './redact.js';
 import { getAgentsBinPath, getCliLaunch, BUN_VIRTUAL_ROOT } from './cli-entry.js';
+import { isSchedulerEnabled, assertSchedulerEnabled } from './device-config.js';
 
 const PID_FILE = 'daemon.pid';
 const LOCK_FILE = 'daemon.lock';
@@ -416,7 +417,20 @@ export async function runDaemon(): Promise<void> {
     log('WARN', `Secrets broker host skipped: ${(err as Error).message}`);
   }
 
-  const scheduler = new JobScheduler(async (config) => {
+  // scheduler.enabled=false in this machine's device doc means NO routines fire
+  // here — the scheduler and its catchup recovery simply never start, while the
+  // daemon keeps its other duties (secrets broker, browser IPC, session sync).
+  // The refusal message is the same one the start surfaces
+  // (`routines add` auto-start, manual `routines start`) raise.
+  let schedulerDisabledReason: string | null = null;
+  try {
+    assertSchedulerEnabled();
+  } catch (err) {
+    schedulerDisabledReason = (err as Error).message;
+    log('WARN', schedulerDisabledReason);
+  }
+
+  const scheduler = schedulerDisabledReason ? null : new JobScheduler(async (config) => {
     const jobLabel = config.command
       ? 'command'
       : config.workflow
@@ -457,11 +471,13 @@ export async function runDaemon(): Promise<void> {
     log('WARN', `Project routines sync failed: ${(err as Error).message}`);
   }
 
-  scheduler.loadAll();
-  const scheduled = scheduler.listScheduled();
-  log('INFO', `Loaded ${scheduled.length} jobs`);
-  for (const job of scheduled) {
-    log('INFO', `  ${job.name} -> next: ${job.nextRun?.toISOString() || 'unknown'}`);
+  if (scheduler) {
+    scheduler.loadAll();
+    const scheduled = scheduler.listScheduled();
+    log('INFO', `Loaded ${scheduled.length} jobs`);
+    for (const job of scheduled) {
+      log('INFO', `  ${job.name} -> next: ${job.nextRun?.toISOString() || 'unknown'}`);
+    }
   }
 
   // Monitor engine: event-triggered watchers, beside the cron scheduler. Same
@@ -538,8 +554,10 @@ export async function runDaemon(): Promise<void> {
       catchingUp = false;
     }
   };
-  await catchupPass();
-  const catchupInterval = setInterval(() => { void catchupPass(); }, CATCHUP_TICK_MS);
+  if (scheduler) await catchupPass();
+  const catchupInterval = scheduler
+    ? setInterval(() => { void catchupPass(); }, CATCHUP_TICK_MS)
+    : undefined;
 
   // Before the BrowserService comes up, reap browser + tunnel processes
   // spawned by previous daemons that are no longer alive. Without this,
@@ -839,9 +857,11 @@ export async function runDaemon(): Promise<void> {
     } catch (err) {
       log('WARN', `Project routines sync failed: ${(err as Error).message}`);
     }
-    scheduler.reloadAll();
-    const reloaded = scheduler.listScheduled();
-    log('INFO', `Reloaded ${reloaded.length} jobs`);
+    if (scheduler) {
+      scheduler.reloadAll();
+      const reloaded = scheduler.listScheduled();
+      log('INFO', `Reloaded ${reloaded.length} jobs`);
+    }
     try {
       monitorEngine.reload();
     } catch (err) {
@@ -854,7 +874,7 @@ export async function runDaemon(): Promise<void> {
 
   const handleShutdown = async () => {
     log('INFO', 'Daemon shutting down');
-    scheduler.stopAll();
+    scheduler?.stopAll();
     monitorEngine.stop();
     await browserIPC.stop();
     clearInterval(monitorInterval);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { getDaemonDir as getDaemonDirRoot } from './state.js';
 import { isAlive, killTree, backgroundSpawnOptions, waitForExit } from './platform/index.js';
-import { listJobs as listAllJobs } from './routines.js';
+import { listJobs as listAllJobs, type JobConfig } from './routines.js';
 import { syncAllProjectRoutines } from './routines-project.js';
 import { JobScheduler } from './scheduler.js';
 import { MonitorEngine } from './monitors/engine.js';
@@ -56,6 +56,24 @@ const WEDGE_THRESHOLD_TICKS = 3;
  */
 export function shouldTakeOverBroker(isHosting: boolean, brokerReachable: boolean): boolean {
   return !isHosting && !brokerReachable;
+}
+
+/**
+ * What a gate re-evaluation must do with the routines scheduler. The daemon
+ * re-evaluates `scheduler.enabled` on every SIGHUP reload so flipping the key
+ * takes effect without a daemon restart (and `routines add`'s reload signal on
+ * a re-enabled box boots the scheduler — the reload is truthful, not a no-op).
+ *
+ *   running + enabled   → reload (the normal SIGHUP path)
+ *   running + !enabled  → stop  (gate flipped off since boot)
+ *   !running + enabled  → boot  (gate flipped on since boot)
+ *   !running + !enabled → none  (stay dark)
+ */
+export type SchedulerGateTransition = 'reload' | 'stop' | 'boot' | 'none';
+
+export function schedulerGateTransition(running: boolean, enabled: boolean): SchedulerGateTransition {
+  if (running) return enabled ? 'reload' : 'stop';
+  return enabled ? 'boot' : 'none';
 }
 
 function getDaemonDir(): string {
@@ -421,16 +439,19 @@ export async function runDaemon(): Promise<void> {
   // here — the scheduler and its catchup recovery simply never start, while the
   // daemon keeps its other duties (secrets broker, browser IPC, session sync).
   // The refusal message is the same one the start surfaces
-  // (`routines add` auto-start, manual `routines start`) raise.
-  let schedulerDisabledReason: string | null = null;
-  try {
-    assertSchedulerEnabled();
-  } catch (err) {
-    schedulerDisabledReason = (err as Error).message;
-    log('WARN', schedulerDisabledReason);
+  // (`routines add` auto-start, manual `routines start`) raise. The gate is
+  // re-evaluated on every SIGHUP reload (handleReload below) via
+  // schedulerGateTransition, so flipping the key never needs a daemon restart.
+  const schedulerEnabledAtBoot = isSchedulerEnabled();
+  if (!schedulerEnabledAtBoot) {
+    try {
+      assertSchedulerEnabled();
+    } catch (err) {
+      log('WARN', (err as Error).message);
+    }
   }
 
-  const scheduler = schedulerDisabledReason ? null : new JobScheduler(async (config) => {
+  const triggerJob = async (config: JobConfig) => {
     const jobLabel = config.command
       ? 'command'
       : config.workflow
@@ -459,7 +480,39 @@ export async function runDaemon(): Promise<void> {
       // "Routine started" and never told it failed.
       try { notifyRoutineStartFailed(config, message); } catch { /* best-effort */ }
     }
-  });
+  };
+
+  let scheduler: JobScheduler | null = null;
+  let catchupInterval: NodeJS.Timeout | undefined;
+  // Catchup overlap guard. Declared up here (not beside catchupPass) because
+  // bootScheduler() runs before catchupPass's textual position — a `let` down
+  // there would still be in its TDZ at the first call and crash the daemon.
+  let catchingUp = false;
+
+  // Boot the scheduler + catchup recovery. Called at daemon start when the gate
+  // allows, and again from handleReload when the gate flips on (function
+  // declarations hoist — catchupPass below is in scope).
+  function bootScheduler(): void {
+    scheduler = new JobScheduler(triggerJob);
+    scheduler.loadAll();
+    const scheduled = scheduler.listScheduled();
+    log('INFO', `Loaded ${scheduled.length} jobs`);
+    for (const job of scheduled) {
+      log('INFO', `  ${job.name} -> next: ${job.nextRun?.toISOString() || 'unknown'}`);
+    }
+    void catchupPass();
+    catchupInterval = setInterval(() => { void catchupPass(); }, CATCHUP_TICK_MS);
+  }
+
+  // Stop the scheduler + catchup recovery (gate flipped off on reload).
+  function stopScheduler(): void {
+    scheduler?.stopAll();
+    scheduler = null;
+    if (catchupInterval !== undefined) {
+      clearInterval(catchupInterval);
+      catchupInterval = undefined;
+    }
+  }
 
   // Materialise opted-in project routines into the user layer on every start
   // so a fresh daemon picks up project YAML without a separate sync step.
@@ -471,14 +524,7 @@ export async function runDaemon(): Promise<void> {
     log('WARN', `Project routines sync failed: ${(err as Error).message}`);
   }
 
-  if (scheduler) {
-    scheduler.loadAll();
-    const scheduled = scheduler.listScheduled();
-    log('INFO', `Loaded ${scheduled.length} jobs`);
-    for (const job of scheduled) {
-      log('INFO', `  ${job.name} -> next: ${job.nextRun?.toISOString() || 'unknown'}`);
-    }
-  }
+  if (schedulerEnabledAtBoot) bootScheduler();
 
   // Monitor engine: event-triggered watchers, beside the cron scheduler. Same
   // daemon, same dispatch seam — a monitor is a routine whose trigger is a
@@ -506,8 +552,9 @@ export async function runDaemon(): Promise<void> {
   // overdue — the miss is recorded before the await, but only for jobs already
   // processed — and spawn it twice. The idempotency of the `missed` record
   // guards across passes, not within one that is mid-flight.
-  let catchingUp = false;
-  const catchupPass = async (): Promise<void> => {
+  // Function declaration (hoisted) so bootScheduler() can schedule it. Its
+  // guard (`catchingUp`) is declared beside `scheduler` above for TDZ safety.
+  async function catchupPass(): Promise<void> {
     if (catchingUp) return;
     catchingUp = true;
     try {
@@ -553,11 +600,7 @@ export async function runDaemon(): Promise<void> {
       // throw must not leave the guard latched shut for the daemon's lifetime.
       catchingUp = false;
     }
-  };
-  if (scheduler) await catchupPass();
-  const catchupInterval = scheduler
-    ? setInterval(() => { void catchupPass(); }, CATCHUP_TICK_MS)
-    : undefined;
+  }
 
   // Before the BrowserService comes up, reap browser + tunnel processes
   // spawned by previous daemons that are no longer alive. Without this,
@@ -857,9 +900,20 @@ export async function runDaemon(): Promise<void> {
     } catch (err) {
       log('WARN', `Project routines sync failed: ${(err as Error).message}`);
     }
-    if (scheduler) {
-      scheduler.reloadAll();
-      const reloaded = scheduler.listScheduled();
+    // Re-evaluate the scheduler.enabled gate: flipping the key takes effect on
+    // this reload, no daemon restart needed. A `routines add` on a re-enabled
+    // box signals exactly this reload, which boots the scheduler — the
+    // "Scheduler reloaded" it prints is then truthful, not a dead-end.
+    const transition = schedulerGateTransition(scheduler !== null, isSchedulerEnabled());
+    if (transition === 'boot') {
+      log('INFO', 'scheduler.enabled is now on — booting the scheduler');
+      bootScheduler();
+    } else if (transition === 'stop') {
+      log('WARN', 'scheduler.enabled is now off — stopping the scheduler; no routines will fire on this device');
+      stopScheduler();
+    } else if (transition === 'reload') {
+      scheduler!.reloadAll();
+      const reloaded = scheduler!.listScheduled();
       log('INFO', `Reloaded ${reloaded.length} jobs`);
     }
     try {
@@ -874,11 +928,10 @@ export async function runDaemon(): Promise<void> {
 
   const handleShutdown = async () => {
     log('INFO', 'Daemon shutting down');
-    scheduler?.stopAll();
+    stopScheduler();
     monitorEngine.stop();
     await browserIPC.stop();
     clearInterval(monitorInterval);
-    clearInterval(catchupInterval);
     clearInterval(syncInterval);
     clearInterval(healInterval);
     clearTimeout(healKickoff);

--- a/apps/cli/src/lib/device-config.test.ts
+++ b/apps/cli/src/lib/device-config.test.ts
@@ -135,11 +135,11 @@ describe('device-scope keys', () => {
     fs.mkdirSync(path.dirname(devicePath('mac-mini')), { recursive: true });
     fs.writeFileSync(devicePath('mac-mini'), 'agents:\n  claude: 2.1.0\n');
 
-    setConfigValue('hooks.enabled', false, { device: 'mac-mini' });
+    setConfigValue('scheduler.enabled', false, { device: 'mac-mini' });
 
     const peer = fs.readFileSync(devicePath('mac-mini'), 'utf-8');
     expect(peer).toContain('claude: 2.1.0');
-    expect(peer).toContain('hooksEnabled: false');
+    expect(peer).toContain('schedulerEnabled: false');
   });
 });
 
@@ -199,7 +199,6 @@ describe('listConfig', () => {
     expect(Object.keys(byName).sort()).toEqual([
       'agents.max-concurrent',
       'browser.profile',
-      'hooks.enabled',
       'interactive.host',
       'notes',
       'scheduler.enabled',
@@ -257,5 +256,46 @@ describe('readMaxConcurrentCaps', () => {
   it('returns {} when no device has a cap', async () => {
     const { readMaxConcurrentCaps } = await freshModules();
     expect(readMaxConcurrentCaps(['testbox', 'ghost'])).toEqual({});
+  });
+});
+
+describe('device doc corruption contract', () => {
+  it('rejects valid-but-non-map YAML with the corruption error, not a later TypeError', async () => {
+    const { getConfigValue, setConfigValue } = await freshModules();
+    fs.mkdirSync(path.dirname(devicePath('mac-mini')), { recursive: true });
+    fs.writeFileSync(devicePath('mac-mini'), 'just a string\n');
+    expect(() => getConfigValue('agents.max-concurrent', { device: 'mac-mini' }))
+      .toThrow(/Device config corrupted.*expected a YAML map/);
+    expect(() => setConfigValue('agents.max-concurrent', 2, { device: 'mac-mini' }))
+      .toThrow(/Device config corrupted/);
+
+    fs.writeFileSync(devicePath('mac-mini'), '- a\n- b\n');
+    expect(() => getConfigValue('agents.max-concurrent', { device: 'mac-mini' }))
+      .toThrow(/Device config corrupted.*got a list/);
+  });
+
+  it('still parses a header-only (empty) doc as empty', async () => {
+    const { getConfigValue } = await freshModules();
+    fs.mkdirSync(path.dirname(devicePath('mac-mini')), { recursive: true });
+    fs.writeFileSync(devicePath('mac-mini'), '# agents-cli metadata\n');
+    expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBeUndefined();
+  });
+});
+
+describe('self vs peer routing is case-insensitive', () => {
+  it('targeting TESTBOX on host testbox takes the self path (no peer doc created)', async () => {
+    const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
+
+    setConfigValue('agents.max-concurrent', 3, { device: 'TESTBOX' });
+    // Written through the SELF path: the value is visible to a plain self read
+    // (readMeta + overlay of devices/testbox/agents.yaml). (No peer-path
+    // assertion — macOS fileystems are case-insensitive, so devices/TESTBOX and
+    // devices/testbox are the same file there.)
+    expect(getConfigValue('agents.max-concurrent').value).toBe(3);
+    expect(fs.readFileSync(devicePath('testbox'), 'utf-8')).toContain('maxAgents: 3');
+
+    expect(getConfigValue('agents.max-concurrent', { device: 'TestBox' }).value).toBe(3);
+    unsetConfigValue('agents.max-concurrent', { device: 'TESTBOX' });
+    expect(getConfigValue('agents.max-concurrent').value).toBeUndefined();
   });
 });

--- a/apps/cli/src/lib/device-config.test.ts
+++ b/apps/cli/src/lib/device-config.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// state.ts resolves HOME and the device id at import time, so we point both at a
+// throwaway temp dir and re-import the modules fresh for each test — the REAL
+// partition + overlay + device-doc routing against real files, no mocks
+// (mirrors state.test.ts).
+let TMP = '';
+
+async function freshModules() {
+  vi.resetModules();
+  const state = await import('./state.js');
+  const deviceConfig = await import('./device-config.js');
+  return { ...state, ...deviceConfig };
+}
+
+function centralPath() {
+  return path.join(TMP, '.agents', 'agents.yaml');
+}
+function devicePath(host = 'testbox') {
+  return path.join(TMP, '.agents', 'devices', host, 'agents.yaml');
+}
+function readCentral(): string {
+  return fs.existsSync(centralPath()) ? fs.readFileSync(centralPath(), 'utf-8') : '';
+}
+function writeCentral(yamlText: string) {
+  fs.mkdirSync(path.join(TMP, '.agents'), { recursive: true });
+  fs.writeFileSync(centralPath(), yamlText);
+}
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-device-config-test-'));
+  process.env.HOME = TMP;
+  process.env.AGENTS_SYNC_MACHINE_ID = 'testbox';
+});
+afterEach(() => {
+  delete process.env.AGENTS_SYNC_MACHINE_ID;
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('user-scope keys (interactive.host)', () => {
+  it('round-trips through central agents.yaml under config:, never the device doc', async () => {
+    const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
+
+    setConfigValue('interactive.host', 'zion');
+
+    const central = readCentral();
+    expect(central).toContain('config:');
+    expect(central).toContain('interactiveHost: zion');
+    // User scope never lands in the per-device doc.
+    expect(fs.existsSync(devicePath()) ? fs.readFileSync(devicePath(), 'utf-8') : '').not.toContain('interactiveHost');
+
+    const got = getConfigValue('interactive.host');
+    expect(got.value).toBe('zion');
+    expect(got.layer).toBe('user');
+
+    unsetConfigValue('interactive.host');
+    expect(getConfigValue('interactive.host').value).toBeUndefined();
+    expect(readCentral()).not.toContain('interactiveHost');
+  });
+
+  it('keeps hand-written comments in central agents.yaml when setting config', async () => {
+    writeCentral('# my hand-written note\nprojectRoot: ~/src\n# another comment\n');
+    const { setConfigValue } = await freshModules();
+
+    setConfigValue('interactive.host', 'zion');
+
+    const central = readCentral();
+    expect(central).toContain('# my hand-written note');
+    expect(central).toContain('# another comment');
+    expect(central).toContain('projectRoot: ~/src');
+    expect(central).toContain('interactiveHost: zion');
+  });
+});
+
+describe('device-scope keys', () => {
+  it('round-trips through devices/<host>/agents.yaml under config:, never central', async () => {
+    const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
+
+    setConfigValue('agents.max-concurrent', 4);
+    setConfigValue('scheduler.enabled', false);
+    setConfigValue('notes', ['runs the releases']);
+
+    const device = fs.readFileSync(devicePath(), 'utf-8');
+    expect(device).toContain('config:');
+    expect(device).toContain('maxAgents: 4');
+    expect(device).toContain('schedulerEnabled: false');
+    expect(device).toContain('- runs the releases');
+
+    const central = readCentral();
+    expect(central).not.toContain('maxAgents');
+    expect(central).not.toContain('schedulerEnabled');
+    expect(central).not.toContain('notes:');
+
+    expect(getConfigValue('agents.max-concurrent')).toMatchObject({ value: 4, layer: 'device' });
+    expect(getConfigValue('scheduler.enabled')).toMatchObject({ value: false, layer: 'device' });
+    expect(getConfigValue('notes')).toMatchObject({ value: ['runs the releases'], layer: 'device' });
+
+    unsetConfigValue('agents.max-concurrent');
+    expect(getConfigValue('agents.max-concurrent').value).toBeUndefined();
+    // The other device-scope keys survive an unset of a sibling key.
+    expect(getConfigValue('scheduler.enabled').value).toBe(false);
+    expect(fs.readFileSync(devicePath(), 'utf-8')).not.toContain('maxAgents');
+  });
+
+  it('targets another device by writing its doc in place (devices/ tree syncs)', async () => {
+    const { setConfigValue, getConfigValue, unsetConfigValue } = await freshModules();
+
+    setConfigValue('agents.max-concurrent', 2, { device: 'mac-mini' });
+    setConfigValue('notes', ['do not reboot'], { device: 'mac-mini' });
+
+    const peer = fs.readFileSync(devicePath('mac-mini'), 'utf-8');
+    expect(peer).toContain('maxAgents: 2');
+    expect(peer).toContain('- do not reboot');
+
+    // Self doc and central stay clean of the peer's values.
+    expect(fs.existsSync(devicePath()) ? fs.readFileSync(devicePath(), 'utf-8') : '').not.toContain('maxAgents');
+    expect(readCentral()).not.toContain('maxAgents');
+
+    expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBe(2);
+    expect(getConfigValue('agents.max-concurrent').value).toBeUndefined();
+
+    unsetConfigValue('agents.max-concurrent', { device: 'mac-mini' });
+    expect(getConfigValue('agents.max-concurrent', { device: 'mac-mini' }).value).toBeUndefined();
+    // Unsetting a key that was never set on a peer with no doc is a no-op.
+    unsetConfigValue('scheduler.enabled', { device: 'ghost' });
+    expect(fs.existsSync(devicePath('ghost'))).toBe(false);
+  });
+
+  it('preserves a peer doc’s other fields across a config write', async () => {
+    const { setConfigValue } = await freshModules();
+    // A peer doc that already pins an agent version.
+    fs.mkdirSync(path.dirname(devicePath('mac-mini')), { recursive: true });
+    fs.writeFileSync(devicePath('mac-mini'), 'agents:\n  claude: 2.1.0\n');
+
+    setConfigValue('hooks.enabled', false, { device: 'mac-mini' });
+
+    const peer = fs.readFileSync(devicePath('mac-mini'), 'utf-8');
+    expect(peer).toContain('claude: 2.1.0');
+    expect(peer).toContain('hooksEnabled: false');
+  });
+});
+
+describe('browser.profile routes to defaultBrowserProfile (no config: key)', () => {
+  it('set/get/unset land on the existing device-local field', async () => {
+    const { setConfigValue, getConfigValue, unsetConfigValue, readMeta } = await freshModules();
+
+    setConfigValue('browser.profile', 'comet-local');
+
+    const device = fs.readFileSync(devicePath(), 'utf-8');
+    expect(device).toContain('defaultBrowserProfile: comet-local');
+    expect(device).not.toContain('config:');
+    expect(readMeta().defaultBrowserProfile).toBe('comet-local');
+
+    const got = getConfigValue('browser.profile');
+    expect(got.value).toBe('comet-local');
+    expect(got.layer).toBe('device');
+
+    unsetConfigValue('browser.profile');
+    expect(readMeta().defaultBrowserProfile).toBeUndefined();
+    expect(fs.readFileSync(devicePath(), 'utf-8')).not.toContain('defaultBrowserProfile');
+  });
+});
+
+describe('validation', () => {
+  it('rejects unknown keys, naming the known set', async () => {
+    const { setConfigValue, getConfigValue } = await freshModules();
+    expect(() => setConfigValue('nope.nope', 1)).toThrow(/Unknown config key 'nope\.nope'.*interactive\.host/);
+    expect(() => getConfigValue('nope.nope')).toThrow(/Unknown config key/);
+  });
+
+  it('rejects values of the wrong type', async () => {
+    const { setConfigValue } = await freshModules();
+    expect(() => setConfigValue('agents.max-concurrent', 'four')).toThrow(/expects an integer/);
+    expect(() => setConfigValue('agents.max-concurrent', 2.5)).toThrow(/expects an integer/);
+    expect(() => setConfigValue('scheduler.enabled', 'off')).toThrow(/expects a boolean/);
+    expect(() => setConfigValue('notes', 'just a string')).toThrow(/expects a list of strings/);
+    expect(() => setConfigValue('notes', ['ok', 7])).toThrow(/expects a list of strings/);
+    expect(() => setConfigValue('interactive.host', '')).toThrow(/non-empty string/);
+  });
+
+  it('rejects out-of-domain values (maxAgents < 1, bad device name)', async () => {
+    const { setConfigValue } = await freshModules();
+    expect(() => setConfigValue('agents.max-concurrent', 0)).toThrow(/>= 1/);
+    expect(() => setConfigValue('interactive.host', 'has spaces')).toThrow(/Invalid value/);
+  });
+});
+
+describe('listConfig', () => {
+  it('reports every known key with its value and setting layer', async () => {
+    const { listConfig, setConfigValue } = await freshModules();
+    setConfigValue('interactive.host', 'zion');
+    setConfigValue('scheduler.enabled', true);
+
+    const entries = listConfig();
+    const byName = Object.fromEntries(entries.map((e) => [e.spec.name, e]));
+    expect(Object.keys(byName).sort()).toEqual([
+      'agents.max-concurrent',
+      'browser.profile',
+      'hooks.enabled',
+      'interactive.host',
+      'notes',
+      'scheduler.enabled',
+    ]);
+    expect(byName['interactive.host']).toMatchObject({ value: 'zion', layer: 'user' });
+    expect(byName['scheduler.enabled']).toMatchObject({ value: true, layer: 'device' });
+    expect(byName['notes'].value).toBeUndefined();
+    expect(byName['notes'].layer).toBeUndefined();
+  });
+});
+
+describe('scheduler gate (scheduler.enabled=false on this device)', () => {
+  it('defaults to enabled when unset (unset = today’s behavior)', async () => {
+    const { isSchedulerEnabled, assertSchedulerEnabled } = await freshModules();
+    expect(isSchedulerEnabled()).toBe(true);
+    expect(() => assertSchedulerEnabled()).not.toThrow();
+  });
+
+  it('isSchedulerEnabled reflects the stored value', async () => {
+    const { isSchedulerEnabled, setConfigValue } = await freshModules();
+    setConfigValue('scheduler.enabled', false);
+    expect(isSchedulerEnabled()).toBe(false);
+    setConfigValue('scheduler.enabled', true);
+    expect(isSchedulerEnabled()).toBe(true);
+  });
+
+  it('assertSchedulerEnabled throws naming the setting and the fix', async () => {
+    const { assertSchedulerEnabled, setConfigValue } = await freshModules();
+    setConfigValue('scheduler.enabled', false);
+    expect(() => assertSchedulerEnabled()).toThrow(/scheduler\.enabled=false/);
+    expect(() => assertSchedulerEnabled()).toThrow(
+      /agents devices configure testbox --scheduler on/,
+    );
+  });
+
+  it('a peer device’s scheduler.enabled does not gate this machine', async () => {
+    const { isSchedulerEnabled, setConfigValue } = await freshModules();
+    setConfigValue('scheduler.enabled', false, { device: 'mac-mini' });
+    expect(isSchedulerEnabled()).toBe(true);
+  });
+});
+
+describe('readMaxConcurrentCaps', () => {
+  it('reads caps from local + peer device docs, omitting uncapped devices', async () => {
+    const { readMaxConcurrentCaps, setConfigValue } = await freshModules();
+    setConfigValue('agents.max-concurrent', 4);                    // self (testbox)
+    setConfigValue('agents.max-concurrent', 2, { device: 'mac-mini' }); // peer doc
+
+    expect(readMaxConcurrentCaps(['testbox', 'mac-mini', 'zion'])).toEqual({
+      testbox: 4,
+      'mac-mini': 2,
+    });
+  });
+
+  it('returns {} when no device has a cap', async () => {
+    const { readMaxConcurrentCaps } = await freshModules();
+    expect(readMaxConcurrentCaps(['testbox', 'ghost'])).toEqual({});
+  });
+});

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -99,7 +99,9 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     yamlKey: 'maxAgents',
     scope: 'device',
     type: 'int',
-    description: 'Max agents allowed to run concurrently on this device.',
+    description:
+      'Cap on concurrent agents on this device. What counts toward it depends on the consumer: ' +
+      'Factory auto-launch counts device-wide running agents; teams placement counts the team’s own roster on the device.',
     validate: (v) => ((v as number) >= 1 ? null : 'agents.max-concurrent must be >= 1.'),
   },
   {
@@ -108,13 +110,6 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     scope: 'device',
     type: 'bool',
     description: 'Whether the routines scheduler (daemon) may fire on this device.',
-  },
-  {
-    name: 'hooks.enabled',
-    yamlKey: 'hooksEnabled',
-    scope: 'device',
-    type: 'bool',
-    description: 'Whether hooks fire on this device.',
   },
   {
     name: 'notes',
@@ -175,6 +170,8 @@ function deviceDocPath(device: string): string {
  * Read a device doc directly. Returns null when the file does not exist. A
  * malformed file is a hard error — silently returning null would let the next
  * write wipe the device's pins/default (same contract as the device registry).
+ * A valid-but-non-map document (a bare string, a list) is the same kind of
+ * corruption: reject it here instead of failing later with a TypeError.
  */
 function readDeviceDoc(device: string): Meta | null {
   const p = deviceDocPath(device);
@@ -185,11 +182,19 @@ function readDeviceDoc(device: string): Meta | null {
     if (err && err.code === 'ENOENT') return null;
     throw err;
   }
+  const corrupted = (detail: string) =>
+    new Error(`Device config corrupted at ${p}: ${detail}. Inspect and restore from backup.`);
+  let parsed: unknown;
   try {
-    return (yaml.parse(raw) as Meta) ?? {};
+    parsed = yaml.parse(raw);
   } catch (err: any) {
-    throw new Error(`Device config corrupted at ${p}: ${err?.message ?? err}. Inspect and restore from backup.`);
+    throw corrupted(err?.message ?? String(err));
   }
+  if (parsed === null || parsed === undefined) return {};
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw corrupted(`expected a YAML map, got ${Array.isArray(parsed) ? 'a list' : JSON.stringify(parsed)}`);
+  }
+  return parsed as Meta;
 }
 
 /** Write a device doc in place (atomic). Only ever holds device-local fields. */
@@ -215,10 +220,17 @@ function entryFromMeta(spec: ConfigKeySpec, meta: Meta): ConfigEntry {
   return { spec, value, layer: value !== undefined ? 'device' : undefined };
 }
 
+/** True when `device` names this machine (case-insensitive, mirroring
+ * `isLocalDevice` in teams/scheduler.ts) — `configure ZION` on host zion must
+ * take the self path (readMeta/updateMeta funnel), not the peer-doc path. */
+function isSelfDevice(device: string): boolean {
+  return device.toLowerCase() === machineId();
+}
+
 /** Get one config key's value and the layer that set it. */
 export function getConfigValue(name: string, opts?: ConfigTarget): ConfigEntry {
   const spec = configKeySpec(name);
-  if (spec.scope === 'device' && opts?.device && opts.device !== machineId()) {
+  if (spec.scope === 'device' && opts?.device && !isSelfDevice(opts.device)) {
     const doc = readDeviceDoc(opts.device) ?? {};
     return entryFromMeta(spec, { deviceConfig: doc.config, defaultBrowserProfile: doc.defaultBrowserProfile });
   }
@@ -288,7 +300,7 @@ function unsetInDeviceDoc(device: string, spec: ConfigKeySpec): void {
 export function setConfigValue(name: string, value: unknown, opts?: ConfigTarget): void {
   const spec = configKeySpec(name);
   assertValidValue(spec, value);
-  if (spec.scope === 'device' && opts?.device && opts.device !== machineId()) {
+  if (spec.scope === 'device' && opts?.device && !isSelfDevice(opts.device)) {
     setInDeviceDoc(opts.device, spec, value);
     return;
   }
@@ -298,7 +310,7 @@ export function setConfigValue(name: string, value: unknown, opts?: ConfigTarget
 /** Unset a config key — restores default behavior. No-op when already unset. */
 export function unsetConfigValue(name: string, opts?: ConfigTarget): void {
   const spec = configKeySpec(name);
-  if (spec.scope === 'device' && opts?.device && opts.device !== machineId()) {
+  if (spec.scope === 'device' && opts?.device && !isSelfDevice(opts.device)) {
     unsetInDeviceDoc(opts.device, spec);
     return;
   }

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -1,0 +1,342 @@
+/**
+ * Device/user config keys — typed read/write over the two-tier agents.yaml store.
+ *
+ * One registry (`CONFIG_KEYS`) maps each CLI dotted name to where it lives:
+ *   - user scope   → central `~/.agents/agents.yaml` under `config:` (syncs
+ *                    fleet-wide via `agents repo push/pull`)
+ *   - device scope → `~/.agents/devices/<host>/agents.yaml` under `config:`
+ *                    (per-machine; mirrors how `defaultBrowserProfile` is routed)
+ *
+ * This machine's keys go through the readMeta/updateMeta funnel (state.ts) so the
+ * partition/overlay logic stays the single writer. Another device's doc is
+ * read/written in place — the devices/ tree syncs via the DotAgents repo, so
+ * editing `devices/mac-mini/agents.yaml` locally is how `configure`/`note`
+ * target a peer (`--device`-style).
+ *
+ * `browser.profile` is NOT a `config:` key — it is the existing
+ * `Meta.defaultBrowserProfile` field; the registry entry documents the mapping
+ * and set/get route to it so there is one source of truth (no duplicate key).
+ *
+ * Unset always means today's behavior.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import { META_HEADER, getUserAgentsDir, readMeta, updateMeta } from './state.js';
+import { atomicWriteFileSync } from './fs-atomic.js';
+import { machineId } from './machine-id.js';
+import { assertValidDeviceName } from './devices/registry.js';
+import type { Meta } from './types.js';
+
+/** Which tier of the agents.yaml store a key lives in. */
+export type ConfigScope = 'user' | 'device';
+
+/** Value type of a config key — drives validation and `--json` rendering. */
+export type ConfigType = 'string' | 'int' | 'bool' | 'string-list';
+
+/** One known config key. */
+export interface ConfigKeySpec {
+  /** CLI dotted name, e.g. `interactive.host`. */
+  name: string;
+  /** camelCase key under the YAML `config:` block. */
+  yamlKey: string;
+  scope: ConfigScope;
+  type: ConfigType;
+  /** One-line description for help/list output. */
+  description: string;
+  /**
+   * When set, the value lives in this top-level Meta field instead of the
+   * `config:` block (only `browser.profile` → `defaultBrowserProfile` today).
+   */
+  field?: 'defaultBrowserProfile';
+  /** Extra validation beyond the type check; return an error string or null. */
+  validate?: (value: unknown) => string | null;
+}
+
+/** A key with its resolved value and the layer that set it. */
+export interface ConfigEntry {
+  spec: ConfigKeySpec;
+  /** The stored value, or undefined when unset (unset = default behavior). */
+  value: unknown;
+  /** Which layer set it; undefined when unset. */
+  layer?: ConfigScope;
+}
+
+/** Options scoping a read/write to a specific device's doc (default: this machine). */
+export interface ConfigTarget {
+  device?: string;
+}
+
+export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
+  {
+    name: 'interactive.host',
+    yamlKey: 'interactiveHost',
+    scope: 'user',
+    type: 'string',
+    description:
+      'Device that shows the user artifacts (browser opens, dashboards) — the "online macOS box" skills should use instead of guessing.',
+    validate: (v) => {
+      try {
+        assertValidDeviceName(v as string);
+        return null;
+      } catch (err: any) {
+        return err?.message ?? String(err);
+      }
+    },
+  },
+  {
+    name: 'browser.profile',
+    yamlKey: 'defaultBrowserProfile',
+    scope: 'device',
+    type: 'string',
+    field: 'defaultBrowserProfile',
+    description:
+      'Browser profile `agents browser start` resolves to without --profile (set via `agents browser profiles set-default`).',
+  },
+  {
+    name: 'agents.max-concurrent',
+    yamlKey: 'maxAgents',
+    scope: 'device',
+    type: 'int',
+    description: 'Max agents allowed to run concurrently on this device.',
+    validate: (v) => ((v as number) >= 1 ? null : 'agents.max-concurrent must be >= 1.'),
+  },
+  {
+    name: 'scheduler.enabled',
+    yamlKey: 'schedulerEnabled',
+    scope: 'device',
+    type: 'bool',
+    description: 'Whether the routines scheduler (daemon) may fire on this device.',
+  },
+  {
+    name: 'hooks.enabled',
+    yamlKey: 'hooksEnabled',
+    scope: 'device',
+    type: 'bool',
+    description: 'Whether hooks fire on this device.',
+  },
+  {
+    name: 'notes',
+    yamlKey: 'notes',
+    scope: 'device',
+    type: 'string-list',
+    description: 'Free-form operator notes about this device (one entry per `agents devices note`).',
+  },
+];
+
+/** Look up a key spec by CLI dotted name, or throw listing the known keys. */
+export function configKeySpec(name: string): ConfigKeySpec {
+  const spec = CONFIG_KEYS.find((k) => k.name === name);
+  if (!spec) {
+    throw new Error(
+      `Unknown config key '${name}'. Known keys: ${CONFIG_KEYS.map((k) => k.name).join(', ')}.`,
+    );
+  }
+  return spec;
+}
+
+/** Throw when `value` does not match the key's declared type or validation. */
+function assertValidValue(spec: ConfigKeySpec, value: unknown): void {
+  switch (spec.type) {
+    case 'string':
+      if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`Config key '${spec.name}' expects a non-empty string, got ${JSON.stringify(value)}.`);
+      }
+      break;
+    case 'int':
+      if (!Number.isInteger(value)) {
+        throw new Error(`Config key '${spec.name}' expects an integer, got ${JSON.stringify(value)}.`);
+      }
+      break;
+    case 'bool':
+      if (typeof value !== 'boolean') {
+        throw new Error(`Config key '${spec.name}' expects a boolean, got ${JSON.stringify(value)}.`);
+      }
+      break;
+    case 'string-list':
+      if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+        throw new Error(`Config key '${spec.name}' expects a list of strings, got ${JSON.stringify(value)}.`);
+      }
+      break;
+  }
+  const err = spec.validate?.(value);
+  if (err) throw new Error(`Invalid value for '${spec.name}': ${err}`);
+}
+
+// ─── Sibling-device doc access ────────────────────────────────────────────────
+
+/** Path to any device's doc (self or a peer) under the synced devices/ tree. */
+function deviceDocPath(device: string): string {
+  return path.join(getUserAgentsDir(), 'devices', device, 'agents.yaml');
+}
+
+/**
+ * Read a device doc directly. Returns null when the file does not exist. A
+ * malformed file is a hard error — silently returning null would let the next
+ * write wipe the device's pins/default (same contract as the device registry).
+ */
+function readDeviceDoc(device: string): Meta | null {
+  const p = deviceDocPath(device);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(p, 'utf-8');
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+  try {
+    return (yaml.parse(raw) as Meta) ?? {};
+  } catch (err: any) {
+    throw new Error(`Device config corrupted at ${p}: ${err?.message ?? err}. Inspect and restore from backup.`);
+  }
+}
+
+/** Write a device doc in place (atomic). Only ever holds device-local fields. */
+function writeDeviceDoc(device: string, doc: Meta): void {
+  const p = deviceDocPath(device);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const body = Object.keys(doc).length > 0 ? doc : { agents: {} };
+  atomicWriteFileSync(p, META_HEADER + yaml.stringify(body));
+}
+
+// ─── Reads ────────────────────────────────────────────────────────────────────
+
+function entryFromMeta(spec: ConfigKeySpec, meta: Meta): ConfigEntry {
+  if (spec.field === 'defaultBrowserProfile') {
+    const value = meta.defaultBrowserProfile;
+    return { spec, value, layer: value !== undefined ? 'device' : undefined };
+  }
+  if (spec.scope === 'user') {
+    const value = meta.config?.[spec.yamlKey];
+    return { spec, value, layer: value !== undefined ? 'user' : undefined };
+  }
+  const value = meta.deviceConfig?.[spec.yamlKey];
+  return { spec, value, layer: value !== undefined ? 'device' : undefined };
+}
+
+/** Get one config key's value and the layer that set it. */
+export function getConfigValue(name: string, opts?: ConfigTarget): ConfigEntry {
+  const spec = configKeySpec(name);
+  if (spec.scope === 'device' && opts?.device && opts.device !== machineId()) {
+    const doc = readDeviceDoc(opts.device) ?? {};
+    return entryFromMeta(spec, { deviceConfig: doc.config, defaultBrowserProfile: doc.defaultBrowserProfile });
+  }
+  return entryFromMeta(spec, readMeta());
+}
+
+/** List every known key with its value and the layer that set it. */
+export function listConfig(opts?: ConfigTarget): ConfigEntry[] {
+  return CONFIG_KEYS.map((spec) => getConfigValue(spec.name, opts));
+}
+
+// ─── Writes ───────────────────────────────────────────────────────────────────
+
+function setInMeta(spec: ConfigKeySpec, value: unknown): void {
+  updateMeta((m) => {
+    if (spec.field === 'defaultBrowserProfile') {
+      return { ...m, defaultBrowserProfile: value as string };
+    }
+    if (spec.scope === 'user') {
+      return { ...m, config: { ...m.config, [spec.yamlKey]: value } };
+    }
+    return { ...m, deviceConfig: { ...m.deviceConfig, [spec.yamlKey]: value } };
+  });
+}
+
+function unsetInMeta(spec: ConfigKeySpec): void {
+  updateMeta((m) => {
+    if (spec.field === 'defaultBrowserProfile') {
+      const { defaultBrowserProfile, ...rest } = m;
+      void defaultBrowserProfile;
+      return rest;
+    }
+    const block = spec.scope === 'user' ? m.config : m.deviceConfig;
+    if (!block || !(spec.yamlKey in block)) return m;
+    const next = { ...block };
+    delete next[spec.yamlKey];
+    const cleaned = Object.keys(next).length > 0 ? next : undefined;
+    return spec.scope === 'user' ? { ...m, config: cleaned } : { ...m, deviceConfig: cleaned };
+  });
+}
+
+function setInDeviceDoc(device: string, spec: ConfigKeySpec, value: unknown): void {
+  const doc = readDeviceDoc(device) ?? {};
+  if (spec.field === 'defaultBrowserProfile') {
+    doc.defaultBrowserProfile = value as string;
+  } else {
+    doc.config = { ...doc.config, [spec.yamlKey]: value };
+  }
+  writeDeviceDoc(device, doc);
+}
+
+function unsetInDeviceDoc(device: string, spec: ConfigKeySpec): void {
+  const doc = readDeviceDoc(device);
+  if (!doc) return; // nothing stored — unset is a no-op
+  if (spec.field === 'defaultBrowserProfile') {
+    delete doc.defaultBrowserProfile;
+  } else if (doc.config && spec.yamlKey in doc.config) {
+    delete doc.config[spec.yamlKey];
+    if (Object.keys(doc.config).length === 0) delete doc.config;
+  } else {
+    return; // key not present — no write needed
+  }
+  writeDeviceDoc(device, doc);
+}
+
+/** Set a config key (validated). Device-scope keys target this machine unless `opts.device` names a peer. */
+export function setConfigValue(name: string, value: unknown, opts?: ConfigTarget): void {
+  const spec = configKeySpec(name);
+  assertValidValue(spec, value);
+  if (spec.scope === 'device' && opts?.device && opts.device !== machineId()) {
+    setInDeviceDoc(opts.device, spec, value);
+    return;
+  }
+  setInMeta(spec, value);
+}
+
+/** Unset a config key — restores default behavior. No-op when already unset. */
+export function unsetConfigValue(name: string, opts?: ConfigTarget): void {
+  const spec = configKeySpec(name);
+  if (spec.scope === 'device' && opts?.device && opts.device !== machineId()) {
+    unsetInDeviceDoc(opts.device, spec);
+    return;
+  }
+  unsetInMeta(spec);
+}
+
+// ─── Consumers' helpers ───────────────────────────────────────────────────────
+
+/** True unless this machine's device doc disables the routines scheduler. */
+export function isSchedulerEnabled(): boolean {
+  return getConfigValue('scheduler.enabled').value !== false;
+}
+
+/**
+ * Throw when the routines scheduler is disabled on this machine, naming the
+ * setting and the fix. The single message every scheduler-start surface
+ * (auto-start on `routines add`, manual `routines start`, the daemon's own
+ * scheduler init) refuses with.
+ */
+export function assertSchedulerEnabled(): void {
+  if (isSchedulerEnabled()) return;
+  throw new Error(
+    `The routines scheduler is disabled on this device (scheduler.enabled=false in ~/.agents/devices/${machineId()}/agents.yaml). ` +
+      `Re-enable with: agents devices configure ${machineId()} --scheduler on`,
+  );
+}
+
+/**
+ * Read the `agents.max-concurrent` cap for each named device from its synced
+ * device doc (no SSH). Devices without a cap are omitted — uncapped is the
+ * default. Used as an input to host ranking (teams placement, Factory
+ * auto-launch), never as a remote probe.
+ */
+export function readMaxConcurrentCaps(devices: string[]): Record<string, number> {
+  const caps: Record<string, number> = {};
+  for (const device of devices) {
+    const value = getConfigValue('agents.max-concurrent', { device }).value;
+    if (typeof value === 'number') caps[device] = value;
+  }
+  return caps;
+}

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1563,7 +1563,7 @@ function migrateVersionResourcesToPatterns(): void {
   }
 
   if (changed) {
-    const META_HEADER = '# agents-cli metadata\n# Auto-generated - do not edit manually\n# https://github.com/phnx-labs/agents-cli\n\n';
+    const META_HEADER = '# agents-cli metadata\n# Auto-generated - do not edit manually\n# https://github.com/phnx-labs/agents-cli\n# yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agents-cli/main/apps/cli/schema/agents-yaml.schema.json\n\n';
     fs.writeFileSync(metaFile, META_HEADER + yaml.stringify(meta), 'utf-8');
     console.error('Migrated agents.yaml versions: entries to pattern format');
   }

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -165,9 +165,16 @@ const USER_WORKFLOWS_DIR = path.join(USER_AGENTS_DIR, 'workflows');
 const USER_SECRETS_DIR = path.join(USER_AGENTS_DIR, 'secrets');
 const USER_PROMPTCUTS_FILE = path.join(USER_AGENTS_DIR, 'hooks', 'promptcuts.yaml');
 
-const META_HEADER = `# agents-cli metadata
+/**
+ * Header prepended to every agents.yaml the CLI writes (central and per-device
+ * docs). Carries the yaml-language-server schema hint so editors validate the
+ * file against `schema/agents-yaml.schema.json`. Exported so
+ * `lib/device-config.ts` writes a sibling device's doc with the same header.
+ */
+export const META_HEADER = `# agents-cli metadata
 # Auto-generated - do not edit manually
 # https://github.com/phnx-labs/agents-cli
+# yaml-language-server: $schema=https://raw.githubusercontent.com/phnx-labs/agents-cli/main/apps/cli/schema/agents-yaml.schema.json
 
 `;
 
@@ -764,8 +771,9 @@ function writeIfChanged(filePath: string, content: string): void {
 /**
  * Partition the in-memory Meta across three files by sync-domain:
  *   - central  `~/.agents/agents.yaml`             — portable, everything else
+ *              (including the user-scope `config:` block)
  *   - device   `~/.agents/devices/<machine>/agents.yaml` — `agents:` pins +
- *              `defaultBrowserProfile:` (both per-device)
+ *              `defaultBrowserProfile:` + device-scope `config:` (all per-device)
  *   - history  `~/.agents/.history/version-resources.json` — `versions:` (machine-local)
  * All callers funnel through writeMeta → here, so nothing else changes. Empty
  * `agents:` / `versions:` are not written (no empty committed files).
@@ -826,7 +834,7 @@ function serializeCentral(central: Record<string, unknown>): string {
 }
 
 function writeMetaUnlocked(meta: Meta): void {
-  const { agents, isolatedAgents, versions, defaultBrowserProfile, ...central } = meta;
+  const { agents, isolatedAgents, versions, defaultBrowserProfile, deviceConfig, ...central } = meta;
 
   // Write the machine-local files FIRST, then strip central — so a crash mid-write
   // never removes pins/versions from central before they're persisted elsewhere.
@@ -838,13 +846,18 @@ function writeMetaUnlocked(meta: Meta): void {
   // it does not have.
   const hasIsolatedAgents = !!isolatedAgents && Object.keys(isolatedAgents).length > 0;
   const hasDefaultBrowser = !!defaultBrowserProfile;
-  if (hasAgents || hasIsolatedAgents || hasDefaultBrowser) {
-    // Device-local doc carries `agents:` pins and `defaultBrowserProfile:` — both
-    // are per-machine and must never land in central agents.yaml (which syncs).
+  // Device-scope config (`maxAgents`, `schedulerEnabled`, …) is per-machine, so it
+  // rides the device doc under `config:` — never the central doc that syncs.
+  const hasDeviceConfig = !!deviceConfig && Object.keys(deviceConfig).length > 0;
+  if (hasAgents || hasIsolatedAgents || hasDefaultBrowser || hasDeviceConfig) {
+    // Device-local doc carries `agents:` pins, `defaultBrowserProfile:`, and the
+    // device-scope `config:` — all per-machine and must never land in central
+    // agents.yaml (which syncs).
     const deviceDoc: Partial<Meta> = {};
     if (hasAgents) deviceDoc.agents = agents;
     if (hasIsolatedAgents) deviceDoc.isolatedAgents = isolatedAgents;
     if (hasDefaultBrowser) deviceDoc.defaultBrowserProfile = defaultBrowserProfile;
+    if (hasDeviceConfig) deviceDoc.config = deviceConfig;
     fs.mkdirSync(path.dirname(devicePath), { recursive: true });
     writeIfChanged(devicePath, META_HEADER + yaml.stringify(deviceDoc));
   } else if (fs.existsSync(devicePath)) {
@@ -872,6 +885,10 @@ function writeMetaUnlocked(meta: Meta): void {
  *     still has pins)
  *   - `defaultBrowserProfile:` from the device file (device is the sole source;
  *     the field is stripped from central on write, so nothing to merge against)
+ *   - `config:` from the device file into `deviceConfig` (device is the sole
+ *     source for device-scope config, same routing as `defaultBrowserProfile`;
+ *     the in-memory field is named `deviceConfig` so it can never collide with
+ *     the user-scope `config:` central carries)
  *   - `versions:` from the history JSON (wholesale replace; falls back to
  *     whatever central carried when the history file doesn't exist yet)
  */
@@ -883,6 +900,7 @@ function overlayMachineLocal(meta: Meta): Meta {
       if (dm?.agents) meta.agents = { ...meta.agents, ...dm.agents };
       if (dm?.isolatedAgents) meta.isolatedAgents = { ...meta.isolatedAgents, ...dm.isolatedAgents };
       if (dm?.defaultBrowserProfile) meta.defaultBrowserProfile = dm.defaultBrowserProfile;
+      if (dm?.config) meta.deviceConfig = dm.config;
     } catch { /* ignore malformed device file */ }
   }
   const vrPath = getVersionResourcesPath();

--- a/apps/cli/src/lib/teams/agents.ts
+++ b/apps/cli/src/lib/teams/agents.ts
@@ -35,7 +35,9 @@ import { resolveRemoteOsSync } from '../hosts/remote-os.js';
 import { pullRemoteLogDelta, REMOTE_MIRROR_MAX_BYTES } from '../hosts/progress.js';
 import { createRemoteWorktree, ensureRemoteRepo } from './remoteWorktree.js';
 import { getTeam } from './registry.js';
-import { resolvePlacement } from './scheduler.js';
+import { resolvePlacement, cappedDevices } from './scheduler.js';
+import { readMaxConcurrentCaps } from '../device-config.js';
+import chalk from 'chalk';
 
 let lastMemoryWarnAt = 0;
 
@@ -2082,7 +2084,16 @@ export class AgentManager {
     const teamMeta = await getTeam(taskName);
     if (!teamMeta) return;
     const roster = await this.listByTask(taskName);
-    const { device } = resolvePlacement(teamMeta, null, roster);
+    const pool = teamMeta.devices ?? [];
+    const maxConcurrent = pool.length > 1 ? readMaxConcurrentCaps(pool) : undefined;
+    if (maxConcurrent) {
+      for (const c of cappedDevices(pool, roster, maxConcurrent)) {
+        console.error(chalk.dim(
+          `[placement] '${c.device}' excluded from auto-pick — at its agents.max-concurrent cap (${c.running}/${c.cap} running)`,
+        ));
+      }
+    }
+    const { device } = resolvePlacement(teamMeta, null, roster, { maxConcurrent });
     if (device) await this.resolveScheduledPlacement(agent, device, taskName);
   }
 

--- a/apps/cli/src/lib/teams/scheduler.test.ts
+++ b/apps/cli/src/lib/teams/scheduler.test.ts
@@ -7,7 +7,7 @@
  * short-circuit never fires, keeping assertions host-independent.
  */
 import { describe, it, expect } from 'vitest';
-import { resolvePlacement, pickLeastLoaded, type RosterEntry } from './scheduler.js';
+import { resolvePlacement, pickLeastLoaded, cappedDevices, type RosterEntry } from './scheduler.js';
 
 const running = (hostName: string | null): RosterEntry => ({ hostName, status: 'running' });
 const done = (hostName: string | null): RosterEntry => ({ hostName, status: 'completed' });
@@ -62,5 +62,59 @@ describe('pickLeastLoaded', () => {
 
   it('throws on an empty pool (caller must guard)', () => {
     expect(() => pickLeastLoaded([], [])).toThrow(/empty device pool/);
+  });
+});
+
+describe('agents.max-concurrent caps (auto-pick only)', () => {
+  it('excludes a device at its cap from the least-loaded pick', () => {
+    // box-a is at its cap (2/2 running) → box-b wins despite ties-by-order.
+    const roster = [running('box-a'), running('box-a')];
+    expect(pickLeastLoaded(['box-a', 'box-b'], roster, { 'box-a': 2 })).toBe('box-b');
+  });
+
+  it('keeps a device under its cap eligible', () => {
+    const roster = [running('box-a')];
+    expect(pickLeastLoaded(['box-a', 'box-b'], roster, { 'box-a': 2 })).toBe('box-b');
+    // box-a 1/2 is NOT capped, but box-b at 0 is still less loaded — prove the
+    // cap didn't exclude box-a by making box-b busier:
+    const busier = [running('box-a'), running('box-b'), running('box-b')];
+    expect(pickLeastLoaded(['box-a', 'box-b'], busier, { 'box-a': 2 })).toBe('box-a');
+  });
+
+  it('throws naming each cap and the fix when every device is capped', () => {
+    const roster = [running('box-a'), running('box-a'), running('box-b')];
+    expect(() => pickLeastLoaded(['box-a', 'box-b'], roster, { 'box-a': 2, 'box-b': 1 }))
+      .toThrow(/agents\.max-concurrent cap: box-a \(2\/2\), box-b \(1\/1\)/);
+    expect(() => pickLeastLoaded(['box-a', 'box-b'], roster, { 'box-a': 2, 'box-b': 1 }))
+      .toThrow(/agents devices configure <name> --max-agents N/);
+  });
+
+  it('cappedDevices reports the exclusion reason with live counts', () => {
+    const roster = [running('box-a'), running('box-a'), done('box-b')];
+    // box-b's COMPLETED teammate is not load — a 1-cap box-b is not capped.
+    expect(cappedDevices(['box-a', 'box-b'], roster, { 'box-a': 2, 'box-b': 1 })).toEqual([
+      { device: 'box-a', running: 2, cap: 2 },
+    ]);
+  });
+
+  it('resolvePlacement passes caps through the least-loaded step', () => {
+    const roster = [running('box-a')];
+    expect(
+      resolvePlacement({ devices: ['box-a', 'box-b'] }, null, roster, { maxConcurrent: { 'box-a': 1 } }),
+    ).toEqual({ device: 'box-b' });
+  });
+
+  it('never second-guesses an explicit pin, even onto a capped device', () => {
+    const roster = [running('box-a')];
+    expect(
+      resolvePlacement({ devices: ['box-a', 'box-b'] }, 'box-a', roster, { maxConcurrent: { 'box-a': 1 } }),
+    ).toEqual({ device: 'box-a' });
+  });
+
+  it('never second-guesses a pool of one, even when capped', () => {
+    const roster = [running('box-a')];
+    expect(
+      resolvePlacement({ devices: ['box-a'] }, null, roster, { maxConcurrent: { 'box-a': 1 } }),
+    ).toEqual({ device: 'box-a' });
   });
 });

--- a/apps/cli/src/lib/teams/scheduler.test.ts
+++ b/apps/cli/src/lib/teams/scheduler.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { resolvePlacement, pickLeastLoaded, cappedDevices, type RosterEntry } from './scheduler.js';
+import { machineId } from '../machine-id.js';
 
 const running = (hostName: string | null): RosterEntry => ({ hostName, status: 'running' });
 const done = (hostName: string | null): RosterEntry => ({ hostName, status: 'completed' });
@@ -116,5 +117,35 @@ describe('agents.max-concurrent caps (auto-pick only)', () => {
     expect(
       resolvePlacement({ devices: ['box-a'] }, null, roster, { maxConcurrent: { 'box-a': 1 } }),
     ).toEqual({ device: 'box-a' });
+  });
+});
+
+describe('local teammates count against the local pool member', () => {
+  it('a cap on the local device engages once local teammates reach it', () => {
+    const self = machineId();
+    const roster = [running(null), running(null)];
+    expect(pickLeastLoaded([self, 'box-b'], roster, { [self]: 2 })).toBe('box-b');
+  });
+
+  it('mixed local + remote pool counts both sides', () => {
+    const self = machineId();
+    // self: 1 local running, box-b: 2 remote running → self is least-loaded.
+    const roster = [running(null), running('box-b'), running('box-b')];
+    expect(pickLeastLoaded([self, 'box-b'], roster)).toBe(self);
+    expect(cappedDevices([self, 'box-b'], roster, { [self]: 1 })).toEqual([
+      { device: self, running: 1, cap: 1 },
+    ]);
+  });
+
+  it('an empty-string hostName is local too', () => {
+    const self = machineId();
+    const roster: RosterEntry[] = [{ hostName: '', status: 'running' }];
+    expect(pickLeastLoaded([self, 'box-b'], roster, { [self]: 1 })).toBe('box-b');
+  });
+
+  it('ignores a local teammate when this machine is not in the pool', () => {
+    // Today’s behavior preserved: roster entries outside the pool never skew it.
+    const roster = [running(null), running('box-b')];
+    expect(pickLeastLoaded(['box-a', 'box-b'], roster)).toBe('box-a');
   });
 });

--- a/apps/cli/src/lib/teams/scheduler.ts
+++ b/apps/cli/src/lib/teams/scheduler.ts
@@ -11,6 +11,11 @@
  *   3. else the team pool has many devices           → least-loaded pick
  *   4. else (no pin, no pool)                         → null == run local
  *
+ * Step 3 is cap-aware: a device at its `agents.max-concurrent` cap (from the
+ * device doc, passed in via PlacementOptions) is excluded from the auto-pick,
+ * and an all-capped pool fails loud. Pins and pools of one are the user's own
+ * choice and are never second-guessed.
+ *
  * A device whose name equals the local machine id is treated as "local" — it
  * resolves to a null placement so the existing local spawn path runs unchanged,
  * letting the local machine participate in a pool as just another member.
@@ -20,6 +25,17 @@ import { machineId } from '../session/sync/config.js';
 /** Team fields the placement cascade reads (a subset of TeamMeta). */
 export interface PlacementTeam {
   devices?: string[];
+}
+
+/**
+ * Optional placement inputs beyond the team + roster. `maxConcurrent` maps a
+ * device name to its `agents.max-concurrent` cap (from the device doc — read
+ * locally via `readMaxConcurrentCaps`, never probed over SSH). Only the
+ * least-loaded AUTO-PICK (cascade step 3) honors caps: an explicit pin or a
+ * pool of one is the user's own choice and is never second-guessed.
+ */
+export interface PlacementOptions {
+  maxConcurrent?: Record<string, number>;
 }
 
 /**
@@ -37,16 +53,8 @@ function isLocalDevice(device: string): boolean {
   return device.toLowerCase() === machineId();
 }
 
-/**
- * Pick the least-loaded device from the pool — the one with the fewest RUNNING
- * teammates currently assigned to it. Ties break by pool order (first wins), so
- * an empty pool fills round-robin-ish as teammates launch. Pure: counts the
- * roster, no I/O.
- */
-export function pickLeastLoaded(devices: string[], roster: RosterEntry[]): string {
-  if (devices.length === 0) {
-    throw new Error('pickLeastLoaded called with an empty device pool');
-  }
+/** Count RUNNING teammates per pool device. Pure. */
+function loadByDevice(devices: string[], roster: RosterEntry[]): Map<string, number> {
   const load = new Map<string, number>();
   for (const d of devices) load.set(d, 0);
   for (const r of roster) {
@@ -54,10 +62,66 @@ export function pickLeastLoaded(devices: string[], roster: RosterEntry[]): strin
     if (r.status !== 'running') continue;
     if (load.has(r.hostName)) load.set(r.hostName, (load.get(r.hostName) ?? 0) + 1);
   }
-  // Iterate the pool in declared order so the first device wins ties.
-  let best = devices[0];
-  let bestLoad = load.get(best) ?? 0;
+  return load;
+}
+
+/**
+ * Pool devices excluded from auto-pick because they are at (or over) their
+ * `agents.max-concurrent` cap. Returned with the live counts so the caller can
+ * state the reason to the user instead of the device silently never winning.
+ */
+export function cappedDevices(
+  devices: string[],
+  roster: RosterEntry[],
+  maxConcurrent: Record<string, number>,
+): Array<{ device: string; running: number; cap: number }> {
+  const load = loadByDevice(devices, roster);
+  const capped: Array<{ device: string; running: number; cap: number }> = [];
   for (const d of devices) {
+    const cap = maxConcurrent[d];
+    if (cap === undefined) continue;
+    const running = load.get(d) ?? 0;
+    if (running >= cap) capped.push({ device: d, running, cap });
+  }
+  return capped;
+}
+
+/**
+ * Pick the least-loaded device from the pool — the one with the fewest RUNNING
+ * teammates currently assigned to it. Ties break by pool order (first wins), so
+ * an empty pool fills round-robin-ish as teammates launch. Pure: counts the
+ * roster, no I/O.
+ *
+ * With `maxConcurrent`, devices at their cap are excluded; if EVERY device is
+ * capped this throws naming each cap and the fix — a loud failure beats a
+ * teammate silently landing on a machine its operator capped.
+ */
+export function pickLeastLoaded(
+  devices: string[],
+  roster: RosterEntry[],
+  maxConcurrent?: Record<string, number>,
+): string {
+  if (devices.length === 0) {
+    throw new Error('pickLeastLoaded called with an empty device pool');
+  }
+  const load = loadByDevice(devices, roster);
+  const capped = new Set(
+    maxConcurrent ? cappedDevices(devices, roster, maxConcurrent).map((c) => c.device) : [],
+  );
+  const eligible = devices.filter((d) => !capped.has(d));
+  if (eligible.length === 0) {
+    const detail = devices
+      .map((d) => `${d} (${load.get(d) ?? 0}/${maxConcurrent![d]})`)
+      .join(', ');
+    throw new Error(
+      `Every device in the pool is at its agents.max-concurrent cap: ${detail}. ` +
+        `Raise a cap with 'agents devices configure <name> --max-agents N' or add a device to the pool.`,
+    );
+  }
+  // Iterate the pool in declared order so the first device wins ties.
+  let best = eligible[0];
+  let bestLoad = load.get(best) ?? 0;
+  for (const d of eligible) {
     const l = load.get(d) ?? 0;
     if (l < bestLoad) {
       best = d;
@@ -77,6 +141,7 @@ export function resolvePlacement(
   team: PlacementTeam,
   explicitDevice: string | null,
   roster: RosterEntry[],
+  opts?: PlacementOptions,
 ): { device: string | null } {
   // 1. Explicit pin wins — even without a pool.
   if (explicitDevice) {
@@ -89,7 +154,7 @@ export function resolvePlacement(
   if (pool.length === 1) {
     return { device: isLocalDevice(pool[0]) ? null : pool[0] };
   }
-  // 3. Many → least-loaded across the pool.
-  const picked = pickLeastLoaded(pool, roster);
+  // 3. Many → least-loaded across the pool (cap-aware when caps are provided).
+  const picked = pickLeastLoaded(pool, roster, opts?.maxConcurrent);
   return { device: isLocalDevice(picked) ? null : picked };
 }

--- a/apps/cli/src/lib/teams/scheduler.ts
+++ b/apps/cli/src/lib/teams/scheduler.ts
@@ -30,9 +30,12 @@ export interface PlacementTeam {
 /**
  * Optional placement inputs beyond the team + roster. `maxConcurrent` maps a
  * device name to its `agents.max-concurrent` cap (from the device doc — read
- * locally via `readMaxConcurrentCaps`, never probed over SSH). Only the
- * least-loaded AUTO-PICK (cascade step 3) honors caps: an explicit pin or a
- * pool of one is the user's own choice and is never second-guessed.
+ * locally via `readMaxConcurrentCaps`, never probed over SSH). Teams counts
+ * the team's OWN roster against the cap (device-global counting would need an
+ * SSH probe per candidate — out of the hot path; Factory auto-launch is the
+ * device-wide counter). Only the least-loaded AUTO-PICK (cascade step 3)
+ * honors caps: an explicit pin or a pool of one is the user's own choice and
+ * is never second-guessed.
  */
 export interface PlacementOptions {
   maxConcurrent?: Record<string, number>;
@@ -53,14 +56,17 @@ function isLocalDevice(device: string): boolean {
   return device.toLowerCase() === machineId();
 }
 
-/** Count RUNNING teammates per pool device. Pure. */
+/** Count RUNNING teammates per pool device. Pure. A null/empty hostName is a
+ * LOCAL teammate — it counts against the pool member that is this machine,
+ * otherwise a cap on the local device could never engage. */
 function loadByDevice(devices: string[], roster: RosterEntry[]): Map<string, number> {
   const load = new Map<string, number>();
   for (const d of devices) load.set(d, 0);
   for (const r of roster) {
-    if (!r.hostName) continue;
     if (r.status !== 'running') continue;
-    if (load.has(r.hostName)) load.set(r.hostName, (load.get(r.hostName) ?? 0) + 1);
+    const host = r.hostName ? r.hostName : devices.find((d) => isLocalDevice(d));
+    if (!host) continue; // local teammate but this machine is not in the pool
+    if (load.has(host)) load.set(host, (load.get(host) ?? 0) + 1);
   }
   return load;
 }

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -913,6 +913,23 @@ export interface Meta {
    */
   defaultBrowserProfile?: string;
   /**
+   * User-scope config block (`config:` in central agents.yaml). Holds the
+   * user-scope keys from the device-config registry (`lib/device-config.ts`) —
+   * today just `interactiveHost`. Syncs fleet-wide via `agents repo push/pull`.
+   * Device-scope keys live in {@link Meta.deviceConfig} instead.
+   */
+  config?: Record<string, unknown>;
+  /**
+   * Device-scope config block, carried in memory under a distinct field so it
+   * can never leak into the central (synced) agents.yaml: `writeMetaUnlocked`
+   * routes it to `~/.agents/devices/<machine>/agents.yaml` under the `config:`
+   * key (mirroring how `defaultBrowserProfile` is routed), and
+   * `overlayMachineLocal` reads it back. Holds the device-scope keys from the
+   * device-config registry (`maxAgents`, `schedulerEnabled`, `hooksEnabled`,
+   * `notes`). Per-machine by design — unset = today's behavior.
+   */
+  deviceConfig?: Record<string, unknown>;
+  /**
    * Agent-host registry keyed by host name (`agents hosts`). Portable user
    * config synced with `agents repo push/pull`. For `ssh-config` hosts this is
    * just an overlay (caps/os) — the connection details stay in ~/.ssh/config and

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -925,8 +925,7 @@ export interface Meta {
    * routes it to `~/.agents/devices/<machine>/agents.yaml` under the `config:`
    * key (mirroring how `defaultBrowserProfile` is routed), and
    * `overlayMachineLocal` reads it back. Holds the device-scope keys from the
-   * device-config registry (`maxAgents`, `schedulerEnabled`, `hooksEnabled`,
-   * `notes`). Per-machine by design — unset = today's behavior.
+   * device-config registry (`maxAgents`, `schedulerEnabled`, `notes`). Per-machine by design — unset = today's behavior.
    */
   deviceConfig?: Record<string, unknown>;
   /**

--- a/apps/factory/bun.lock
+++ b/apps/factory/bun.lock
@@ -1,0 +1,561 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "swarm-ext",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.3",
+        "@vscode/webview-ui-toolkit": "^1.4.0",
+        "node-pty": "^1.0.0",
+        "sql.js": "^1.13.0",
+        "ws": "^8.20.0",
+        "yaml": "^2.8.2",
+      },
+      "devDependencies": {
+        "@electron/rebuild": "^3.7.1",
+        "@types/node": "^20.x",
+        "@types/sql.js": "^1.4.9",
+        "@types/vscode": "^1.85.0",
+        "@types/ws": "^8.18.1",
+        "react-dom": "^19.2.7",
+        "typescript": "^5.3.3",
+      },
+    },
+  },
+  "packages": {
+    "@electron/node-gyp": ["@electron/node-gyp@github:electron/node-gyp#06b29aa", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^8.1.0", "graceful-fs": "^4.2.6", "make-fetch-happen": "^10.2.1", "nopt": "^6.0.0", "proc-log": "^2.0.1", "semver": "^7.3.5", "tar": "^6.2.1", "which": "^2.0.2" }, "bin": "./bin/node-gyp.js" }, "electron-node-gyp-06b29aa", "sha512-UJwi6aXMAiUaOvqPHVlMtCOLRa1QAU2SqYD9H07KHpN+I2mBoFuxP1HnUOkt86+j+/o/XyHpM7D33JFFQi/jfA=="],
+
+    "@electron/rebuild": ["@electron/rebuild@3.7.2", "", { "dependencies": { "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2", "@malept/cross-spawn-promise": "^2.0.0", "chalk": "^4.0.0", "debug": "^4.1.1", "detect-libc": "^2.0.1", "fs-extra": "^10.0.0", "got": "^11.7.0", "node-abi": "^3.45.0", "node-api-version": "^0.2.0", "ora": "^5.1.0", "read-binary-file-arch": "^1.0.6", "semver": "^7.3.5", "tar": "^6.0.5", "yargs": "^17.0.1" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg=="],
+
+    "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
+
+    "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
+
+    "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
+
+    "@microsoft/fast-element": ["@microsoft/fast-element@1.14.0", "", {}, "sha512-zXvuSOzvsu8zDTy9eby8ix8VqLop2rwKRgp++ZN2kTCsoB3+QJVoaGD2T/Cyso2ViZQFXNpiNCVKfnmxBvmWkQ=="],
+
+    "@microsoft/fast-foundation": ["@microsoft/fast-foundation@2.50.0", "", { "dependencies": { "@microsoft/fast-element": "^1.14.0", "@microsoft/fast-web-utilities": "^5.4.1", "tabbable": "^5.2.0", "tslib": "^1.13.0" } }, "sha512-8mFYG88Xea1jZf2TI9Lm/jzZ6RWR8x29r24mGuLojNYqIR2Bl8+hnswoV6laApKdCbGMPKnsAL/O68Q0sRxeVg=="],
+
+    "@microsoft/fast-react-wrapper": ["@microsoft/fast-react-wrapper@0.3.25", "", { "dependencies": { "@microsoft/fast-element": "^1.14.0", "@microsoft/fast-foundation": "^2.50.0" }, "peerDependencies": { "react": ">=16.9.0" } }, "sha512-jKzmk2xJV93RL/jEFXEZgBvXlKIY4N4kXy3qrjmBfFpqNi3VjY+oUTWyMnHRMC5EUhIFxD+Y1VD4u9uIPX3jQw=="],
+
+    "@microsoft/fast-web-utilities": ["@microsoft/fast-web-utilities@5.4.1", "", { "dependencies": { "exenv-es6": "^1.1.1" } }, "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
+    "@npmcli/fs": ["@npmcli/fs@2.1.2", "", { "dependencies": { "@gar/promisify": "^1.1.3", "semver": "^7.3.5" } }, "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ=="],
+
+    "@npmcli/move-file": ["@npmcli/move-file@2.0.1", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
+
+    "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
+
+    "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
+
+    "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
+
+    "@types/emscripten": ["@types/emscripten@1.41.5", "", {}, "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="],
+
+    "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
+
+    "@types/keyv": ["@types/keyv@3.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg=="],
+
+    "@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
+    "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
+
+    "@types/sql.js": ["@types/sql.js@1.4.11", "", { "dependencies": { "@types/emscripten": "*", "@types/node": "*" } }, "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ=="],
+
+    "@types/vscode": ["@types/vscode@1.125.0", "", {}, "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@vscode/webview-ui-toolkit": ["@vscode/webview-ui-toolkit@1.4.0", "", { "dependencies": { "@microsoft/fast-element": "^1.12.0", "@microsoft/fast-foundation": "^2.49.4", "@microsoft/fast-react-wrapper": "^0.3.22", "tslib": "^2.6.2" }, "peerDependencies": { "react": ">=16.9.0" } }, "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww=="],
+
+    "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
+
+    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cacache": ["cacache@16.1.3", "", { "dependencies": { "@npmcli/fs": "^2.1.0", "@npmcli/move-file": "^2.0.0", "chownr": "^2.0.0", "fs-minipass": "^2.1.0", "glob": "^8.0.1", "infer-owner": "^1.0.4", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "mkdirp": "^1.0.4", "p-map": "^4.0.0", "promise-inflight": "^1.0.1", "rimraf": "^3.0.2", "ssri": "^9.0.0", "tar": "^6.1.11", "unique-filename": "^2.0.0" } }, "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ=="],
+
+    "cacheable-lookup": ["cacheable-lookup@5.0.4", "", {}, "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="],
+
+    "cacheable-request": ["cacheable-request@7.0.4", "", { "dependencies": { "clone-response": "^1.0.2", "get-stream": "^5.1.0", "http-cache-semantics": "^4.0.0", "keyv": "^4.0.0", "lowercase-keys": "^2.0.0", "normalize-url": "^6.0.1", "responselike": "^2.0.0" } }, "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
+
+    "cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
+
+    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+
+    "clone-response": ["clone-response@1.0.3", "", { "dependencies": { "mimic-response": "^1.0.0" } }, "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
+
+    "defer-to-connect": ["defer-to-connect@2.0.1", "", {}, "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "exenv-es6": ["exenv-es6@1.1.1", "", {}, "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="],
+
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.1", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
+
+    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "got": ["got@11.8.6", "", { "dependencies": { "@sindresorhus/is": "^4.0.0", "@szmarczak/http-timer": "^4.0.5", "@types/cacheable-request": "^6.0.1", "@types/responselike": "^1.0.0", "cacheable-lookup": "^5.0.3", "cacheable-request": "^7.0.2", "decompress-response": "^6.0.0", "http2-wrapper": "^1.0.0-beta.5.2", "lowercase-keys": "^2.0.0", "p-cancelable": "^2.0.0", "responselike": "^2.0.0" } }, "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
+
+    "http2-wrapper": ["http2-wrapper@1.0.3", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.0.0" } }, "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "infer-owner": ["infer-owner@1.0.4", "", {}, "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
+
+    "is-lambda": ["is-lambda@1.0.1", "", {}, "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
+
+    "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
+
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "make-fetch-happen": ["make-fetch-happen@10.2.1", "", { "dependencies": { "agentkeepalive": "^4.2.1", "cacache": "^16.1.0", "http-cache-semantics": "^4.1.0", "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "is-lambda": "^1.0.1", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-fetch": "^2.0.3", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.3", "promise-retry": "^2.0.1", "socks-proxy-agent": "^7.0.0", "ssri": "^9.0.0" } }, "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "minipass-collect": ["minipass-collect@1.0.2", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA=="],
+
+    "minipass-fetch": ["minipass-fetch@2.1.2", "", { "dependencies": { "minipass": "^3.1.6", "minipass-sized": "^1.0.3", "minizlib": "^2.1.2" }, "optionalDependencies": { "encoding": "^0.1.13" } }, "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA=="],
+
+    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
+    "minipass-sized": ["minipass-sized@1.0.3", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g=="],
+
+    "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
+    "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-api-version": ["node-api-version@0.2.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q=="],
+
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
+    "nopt": ["nopt@6.0.0", "", { "dependencies": { "abbrev": "^1.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g=="],
+
+    "normalize-url": ["normalize-url@6.1.0", "", {}, "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
+
+    "p-cancelable": ["p-cancelable@2.1.1", "", {}, "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="],
+
+    "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proc-log": ["proc-log@2.0.1", "", {}, "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw=="],
+
+    "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
+
+    "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-alpn": ["resolve-alpn@1.2.1", "", {}, "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="],
+
+    "responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
+
+    "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@7.0.0", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww=="],
+
+    "sql.js": ["sql.js@1.14.1", "", {}, "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A=="],
+
+    "ssri": ["ssri@9.0.1", "", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tabbable": ["tabbable@5.3.3", "", {}, "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="],
+
+    "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unique-filename": ["unique-filename@2.0.1", "", { "dependencies": { "unique-slug": "^3.0.0" } }, "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A=="],
+
+    "unique-slug": ["unique-slug@3.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w=="],
+
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@microsoft/fast-foundation/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "cacache/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
+
+    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-collect/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-fetch/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+  }
+}

--- a/apps/factory/src/core/deviceAutoLaunch.test.ts
+++ b/apps/factory/src/core/deviceAutoLaunch.test.ts
@@ -12,6 +12,7 @@ const {
   loadAutoLaunchPreferences,
   isAutoLaunchEnabled,
   isAutoLaunchPreferred,
+  readDeviceMaxConcurrent,
 } = await import('./deviceAutoLaunch');
 
 function prefsPath(): string {
@@ -72,5 +73,51 @@ describe('deviceAutoLaunch', () => {
     fs.writeFileSync(prefsPath(), JSON.stringify({ devices: 'bad', updatedAt: new Date().toISOString() }));
     const prefs = loadAutoLaunchPreferences();
     expect(prefs).toEqual({});
+  });
+});
+
+describe('readDeviceMaxConcurrent (agents.max-concurrent from the device doc)', () => {
+  const ORIGINAL_USER_DIR = process.env.AGENTS_USER_AGENTS_DIR;
+
+  beforeEach(() => {
+    process.env.AGENTS_USER_AGENTS_DIR = path.join(TEST_HOME, '.agents');
+  });
+
+  afterAll(() => {
+    process.env.AGENTS_USER_AGENTS_DIR = ORIGINAL_USER_DIR;
+  });
+
+  function writeDeviceDoc(name: string, text: string): void {
+    const dir = path.join(process.env.AGENTS_USER_AGENTS_DIR!, 'devices', name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'agents.yaml'), text);
+  }
+
+  test('missing doc means uncapped (undefined)', () => {
+    expect(readDeviceMaxConcurrent('never-configured')).toBeUndefined();
+  });
+
+  test('reads config.maxAgents from the device doc', () => {
+    writeDeviceDoc('mac-mini', 'config:\n  maxAgents: 4\n  schedulerEnabled: false\n');
+    expect(readDeviceMaxConcurrent('mac-mini')).toBe(4);
+  });
+
+  test('a doc without maxAgents is uncapped', () => {
+    writeDeviceDoc('zion', 'config:\n  schedulerEnabled: true\n');
+    expect(readDeviceMaxConcurrent('zion')).toBeUndefined();
+  });
+
+  test('invalid cap values are ignored (uncapped), not trusted', () => {
+    writeDeviceDoc('bad-zero', 'config:\n  maxAgents: 0\n');
+    writeDeviceDoc('bad-string', 'config:\n  maxAgents: four\n');
+    writeDeviceDoc('bad-float', 'config:\n  maxAgents: 2.5\n');
+    expect(readDeviceMaxConcurrent('bad-zero')).toBeUndefined();
+    expect(readDeviceMaxConcurrent('bad-string')).toBeUndefined();
+    expect(readDeviceMaxConcurrent('bad-float')).toBeUndefined();
+  });
+
+  test('a malformed doc degrades to uncapped rather than throwing', () => {
+    writeDeviceDoc('broken', 'config:\n  maxAgents: [unclosed\n');
+    expect(readDeviceMaxConcurrent('broken')).toBeUndefined();
   });
 });

--- a/apps/factory/src/core/deviceAutoLaunch.ts
+++ b/apps/factory/src/core/deviceAutoLaunch.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as yaml from 'yaml';
 
 export interface AutoLaunchPreference {
   enabled?: boolean;
@@ -17,6 +18,15 @@ function autoLaunchPath(): string {
     process.env.AGENTS_DEVICES_DIR ??
     path.join(os.homedir(), '.agents', '.history', 'devices');
   return path.join(dir, 'auto-launch.json');
+}
+
+/**
+ * Root of the user DotAgents repo (`~/.agents`), overridable for tests. The
+ * per-device config docs (`devices/<host>/agents.yaml`) live here — a
+ * different tree from the AGENTS_DEVICES_DIR registry dir above.
+ */
+function userAgentsDir(): string {
+  return process.env.AGENTS_USER_AGENTS_DIR ?? path.join(os.homedir(), '.agents');
 }
 
 /**
@@ -57,4 +67,35 @@ export function isAutoLaunchPreferred(
   name: string,
 ): boolean {
   return preferences[name]?.preferred === true;
+}
+
+/**
+ * Read a device's `agents.max-concurrent` cap from its synced device doc
+ * (`~/.agents/devices/<name>/agents.yaml`, `config.maxAgents`) — written by
+ * `agents devices configure <name> --max-agents N`. Local file read, no SSH;
+ * the devices/ tree syncs via the DotAgents repo so the cap the operator set
+ * on any box is visible here.
+ *
+ * Returns undefined when uncapped (the default). Same corruption contract as
+ * loadAutoLaunchPreferences above: a malformed doc degrades to "uncapped" with
+ * a log line rather than blocking a launch the user just triggered.
+ */
+export function readDeviceMaxConcurrent(name: string): number | undefined {
+  const docPath = path.join(userAgentsDir(), 'devices', name, 'agents.yaml');
+  let raw: string;
+  try {
+    raw = fs.readFileSync(docPath, 'utf-8');
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return undefined;
+    console.error('[deviceAutoLaunch] failed to read device doc:', err?.message ?? err);
+    return undefined;
+  }
+  try {
+    const parsed = yaml.parse(raw) as { config?: { maxAgents?: unknown } } | null;
+    const cap = parsed?.config?.maxAgents;
+    return typeof cap === 'number' && Number.isInteger(cap) && cap >= 1 ? cap : undefined;
+  } catch (err: any) {
+    console.error('[deviceAutoLaunch] failed to parse device doc:', err?.message ?? err);
+    return undefined;
+  }
 }

--- a/apps/factory/src/core/launchHost.test.ts
+++ b/apps/factory/src/core/launchHost.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from 'bun:test';
 import {
   pickLeastBusyDevice,
   pickBestHost,
+  cappedOutDevices,
   deviceHasUsableVersion,
   hostScore,
   PREFERENCE_BONUS,
@@ -226,4 +227,44 @@ test('pickBestHost: preference does not override a genuinely swamped host', () =
       { name: 'free', online: true, running: 1, usableVersion: true },
     ]),
   ).toBe('free');
+});
+
+test('pickBestHost: a device at its agents.max-concurrent cap is excluded', () => {
+  expect(
+    pickBestHost([
+      { name: 'mac-mini', online: true, running: 2, maxConcurrent: 2 },
+      { name: 's0', online: true, running: 5 },
+    ]),
+  ).toBe('s0');
+});
+
+test('pickBestHost: uncapped devices (undefined) keep legacy behavior', () => {
+  expect(
+    pickBestHost([
+      { name: 'mac-mini', online: true, running: 2 },
+      { name: 's0', online: true, running: 5 },
+    ]),
+  ).toBe('mac-mini');
+});
+
+test('pickBestHost: under the cap stays eligible', () => {
+  expect(
+    pickBestHost([
+      { name: 'mac-mini', online: true, running: 1, maxConcurrent: 2 },
+      { name: 's0', online: true, running: 5 },
+    ]),
+  ).toBe('mac-mini');
+});
+
+test('pickBestHost: an all-capped pool returns null, and cappedOutDevices states the reason', () => {
+  const pool: DeviceLoad[] = [
+    { name: 'mac-mini', online: true, running: 4, maxConcurrent: 4 },
+    { name: 's0', online: true, running: 2, maxConcurrent: 2 },
+  ];
+  expect(pickBestHost(pool)).toBeNull();
+  expect(cappedOutDevices(pool).map((d) => d.name)).toEqual(['mac-mini', 's0']);
+  // An offline capped device is not part of the stated reason — it was never a candidate.
+  expect(
+    cappedOutDevices([...pool, { name: 'ghost', online: false, running: 9, maxConcurrent: 1 }]),
+  ).toHaveLength(2);
 });

--- a/apps/factory/src/core/launchHost.test.ts
+++ b/apps/factory/src/core/launchHost.test.ts
@@ -3,6 +3,7 @@ import {
   pickLeastBusyDevice,
   pickBestHost,
   cappedOutDevices,
+  noHostReason,
   deviceHasUsableVersion,
   hostScore,
   PREFERENCE_BONUS,
@@ -267,4 +268,29 @@ test('pickBestHost: an all-capped pool returns null, and cappedOutDevices states
   expect(
     cappedOutDevices([...pool, { name: 'ghost', online: false, running: 9, maxConcurrent: 1 }]),
   ).toHaveLength(2);
+});
+
+test('noHostReason: an all-capped pool names the caps first, even with an agentKey', () => {
+  // Regression: caps were checked AFTER the usable-version branch, so a capped
+  // pool with no signed-in version reported "go sign in" — the wrong fix.
+  const pool: DeviceLoad[] = [
+    { name: 'mac-mini', online: true, running: 4, maxConcurrent: 4, usableVersion: false },
+  ];
+  const reason = noHostReason(pool, 'claude');
+  expect(reason).toContain('agents.max-concurrent cap: mac-mini (4/4)');
+  expect(reason).toContain('agents devices configure <name> --max-agents N');
+  expect(reason).not.toContain('usable claude version');
+});
+
+test('noHostReason: no caps + agentKey → usable-version reason', () => {
+  const pool: DeviceLoad[] = [{ name: 's0', online: true, running: 0, usableVersion: false }];
+  expect(noHostReason(pool, 'claude')).toBe(
+    'no fleet device has a usable claude version (signed in and not rate-limited)',
+  );
+});
+
+test('noHostReason: nothing to say → null', () => {
+  expect(noHostReason([], 'claude')).toBeNull();
+  // No agentKey (agent-unaware caller) keeps the legacy silent fallback.
+  expect(noHostReason([{ name: 's0', online: true, running: 0 }])).toBeNull();
 });

--- a/apps/factory/src/core/launchHost.ts
+++ b/apps/factory/src/core/launchHost.ts
@@ -99,6 +99,26 @@ export function cappedOutDevices(candidates: DeviceLoad[]): DeviceLoad[] {
   return candidates.filter((c) => c.online && isCappedOut(c));
 }
 
+// Why a pick produced no host, for the fallback warning. Caps are checked
+// FIRST: an all-capped pool is an operator boundary to raise, and reporting
+// "go sign in" (the usable-version reason) when the devices were really capped
+// sends the user down the wrong fix. Returns null when there is nothing to say
+// (the pool itself was empty — the caller already said "no online device").
+export function noHostReason(loaded: DeviceLoad[], agentKey?: string): string | null {
+  const capped = cappedOutDevices(loaded);
+  if (capped.length > 0) {
+    const detail = capped.map((c) => `${c.name} (${c.running}/${c.maxConcurrent})`).join(', ');
+    return (
+      `every online device is at its agents.max-concurrent cap: ${detail} — ` +
+      `raise with: agents devices configure <name> --max-agents N`
+    );
+  }
+  if (agentKey && loaded.length > 0) {
+    return `no fleet device has a usable ${agentKey} version (signed in and not rate-limited)`;
+  }
+  return null;
+}
+
 // Pick the best online host for a launch: drop devices with no usable version of
 // the target agent (when that signal was probed) and devices at their
 // agents.max-concurrent cap, then rank the rest by the composite hostScore

--- a/apps/factory/src/core/launchHost.ts
+++ b/apps/factory/src/core/launchHost.ts
@@ -26,6 +26,11 @@ export interface DeviceLoad {
   // caller so EVERY ranking path — the warm-cache pick and the balanced pool
   // pick both route through hostScore — honors the preference identically.
   preferred?: boolean;
+  // Operator cap from `agents devices configure <name> --max-agents N` (read
+  // from the synced device doc). A device at its cap is EXCLUDED from the
+  // auto-pick entirely — it never reaches hostScore. undefined = uncapped
+  // (the default).
+  maxConcurrent?: number;
 }
 
 // How much a `prefer`red device is favored, in hostScore points. Two running
@@ -80,16 +85,31 @@ export function hostScore(d: DeviceLoad): number {
   return running + load + mem - preference;
 }
 
+// A device is capped out when it carries an agents.max-concurrent cap and its
+// running-agent count has reached it. Capped devices are excluded from
+// auto-pick (never scored) — an operator cap is a hard boundary, not a tie-break.
+export function isCappedOut(d: DeviceLoad): boolean {
+  return d.maxConcurrent !== undefined && d.running >= d.maxConcurrent;
+}
+
+// Online candidates excluded from the auto-pick by their agents.max-concurrent
+// cap, so callers can STATE the reason (a device silently never winning reads
+// as a ranking bug). Only meaningful alongside a pick call on the same pool.
+export function cappedOutDevices(candidates: DeviceLoad[]): DeviceLoad[] {
+  return candidates.filter((c) => c.online && isCappedOut(c));
+}
+
 // Pick the best online host for a launch: drop devices with no usable version of
-// the target agent (when that signal was probed), then rank the rest by the
-// composite hostScore (running agents + hardware load/memory). Ties break by
-// input order (first declared wins). Returns null when no candidate survives, so
-// the caller falls back to the local machine with a warning.
+// the target agent (when that signal was probed) and devices at their
+// agents.max-concurrent cap, then rank the rest by the composite hostScore
+// (running agents + hardware load/memory). Ties break by input order (first
+// declared wins). Returns null when no candidate survives, so the caller falls
+// back to the local machine with a warning.
 export function pickBestHost(candidates: DeviceLoad[]): string | null {
   // usableVersion === false is an explicit "no signed-in version here" — filter
   // it out. undefined (unprobed) stays eligible so agent-unaware callers keep
   // the old behavior.
-  const eligible = candidates.filter((c) => c.online && c.usableVersion !== false);
+  const eligible = candidates.filter((c) => c.online && c.usableVersion !== false && !isCappedOut(c));
   if (eligible.length === 0) return null;
   let best = eligible[0];
   let bestScore = hostScore(best);

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -14,7 +14,7 @@ import * as git from './git.vscode';
 import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot, QuickLaunchSlotKey } from '../core/settings';
 import { listRegisteredDevices, countRunningAgents, fetchDeviceStats, resolveSecret } from './deviceHealth.vscode';
 import { normalizeHost } from '../core/remoteSessions';
-import { pickBestHost, cappedOutDevices, deviceHasUsableVersion, resolveBalancePool, DeviceLoad } from '../core/launchHost';
+import { pickBestHost, cappedOutDevices, noHostReason, deviceHasUsableVersion, resolveBalancePool, DeviceLoad } from '../core/launchHost';
 import {
   LAUNCH_HEALTH_KEY,
   LAUNCH_HISTORY_KEY,
@@ -500,28 +500,14 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
     })),
   );
   const best = pickBestHost(loaded);
-  if (!best && agentKey && loaded.length > 0) {
-    // Every online device lacks a signed-in, non-throttled version of this
-    // agent — fall back to local rather than launch into a broken agent.
-    vscode.window.showWarningMessage(
-      `No fleet device has a usable ${agentKey} version (signed in and not rate-limited) — running locally.`,
-    );
-    return undefined;
+  if (best) return best;
+  // State WHY the pool produced nothing — caps first (an operator boundary to
+  // raise), then agent usability. See noHostReason.
+  const reason = noHostReason(loaded, agentKey);
+  if (reason) {
+    vscode.window.showWarningMessage(`Balanced launch: ${reason} — running locally.`);
   }
-  if (!best) {
-    // State WHY the pool produced nothing: an all-capped pool is an operator
-    // boundary to raise, not a silent fall-through to local.
-    const capped = cappedOutDevices(loaded);
-    if (capped.length > 0) {
-      const detail = capped.map(c => `${c.name} (${c.running}/${c.maxConcurrent})`).join(', ');
-      vscode.window.showWarningMessage(
-        `Balanced launch: every online device is at its agents.max-concurrent cap: ${detail} — running locally. ` +
-        `Raise with: agents devices configure <name> --max-agents N`,
-      );
-    }
-    return undefined;
-  }
-  return best;
+  return undefined;
 }
 
 // Resolve a Quick Launch slot's Run-on target to a device name (undefined =

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { BUILT_IN_AGENTS, getBuiltInByKey, getBuiltInDefByTitle, getBuiltInByPrefix, STRATEGY_LAUNCH_AGENTS, usesManagedAgentLaunch, modeFlagForAgent, AgentLaunchMode, RunStrategy, buildAgentLaunchCommand, wrapNativeAgentCommand, shquote } from '../core/agents';
-import { loadAutoLaunchPreferences, isAutoLaunchEnabled, isAutoLaunchPreferred } from '../core/deviceAutoLaunch';
+import { loadAutoLaunchPreferences, isAutoLaunchEnabled, isAutoLaunchPreferred, readDeviceMaxConcurrent } from '../core/deviceAutoLaunch';
 import { parseSpawnRequest, resolveSpawnSurface, SpawnRequest } from '../core/spawn';
 import {
   AgentConfig,
@@ -14,7 +14,7 @@ import * as git from './git.vscode';
 import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot, QuickLaunchSlotKey } from '../core/settings';
 import { listRegisteredDevices, countRunningAgents, fetchDeviceStats, resolveSecret } from './deviceHealth.vscode';
 import { normalizeHost } from '../core/remoteSessions';
-import { pickBestHost, deviceHasUsableVersion, resolveBalancePool, DeviceLoad } from '../core/launchHost';
+import { pickBestHost, cappedOutDevices, deviceHasUsableVersion, resolveBalancePool, DeviceLoad } from '../core/launchHost';
 import {
   LAUNCH_HEALTH_KEY,
   LAUNCH_HISTORY_KEY,
@@ -464,6 +464,9 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
       online: !!d.online,
       running: 0,
       preferred: isAutoLaunchPreferred(preferences, d.name),
+      // Operator cap from the synced device doc (agents devices configure
+      // <name> --max-agents N) — local read, no SSH.
+      maxConcurrent: readDeviceMaxConcurrent(d.name),
     }));
   const eligible = resolveBalancePool(fleet, { localName, pool }).filter(c => c.online);
   if (eligible.length === 0) {
@@ -505,7 +508,20 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
     );
     return undefined;
   }
-  return best ?? undefined;
+  if (!best) {
+    // State WHY the pool produced nothing: an all-capped pool is an operator
+    // boundary to raise, not a silent fall-through to local.
+    const capped = cappedOutDevices(loaded);
+    if (capped.length > 0) {
+      const detail = capped.map(c => `${c.name} (${c.running}/${c.maxConcurrent})`).join(', ');
+      vscode.window.showWarningMessage(
+        `Balanced launch: every online device is at its agents.max-concurrent cap: ${detail} — running locally. ` +
+        `Raise with: agents devices configure <name> --max-agents N`,
+      );
+    }
+    return undefined;
+  }
+  return best;
 }
 
 // Resolve a Quick Launch slot's Run-on target to a device name (undefined =


### PR DESCRIPTION
## Why

A remote agent showing a rendered plan ran `agents browser start` on the user's Mac and the CLI auto-detect spawned **Google Chrome** — on a machine whose default browser is Arc. Root causes: the device-local default-browser-profile mechanism was a hidden verb no agent knows; there was no **interactive host** primitive (skills guessed "the online macOS device" — ambiguous when two Macs are online); and per-device prefs (max agents, scheduler on/off, notes) had no home.

Design discussion converged on: keep `agents.yaml` as the single store (new `config:` block, two-tier like the existing version-pin split), **no new top-level noun** — settings live under the nouns that own them, and `agents setup` becomes the guided onboarding path. The modern affordances are schema + typed verbs + pickers, not a new file format.

## What

**Store** — `config:` block in the existing two-tier agents.yaml (`state.ts`): user scope (central, syncs fleet-wide) vs device scope (`devices/<host>/agents.yaml`, same routing as `defaultBrowserProfile`). Key registry in `lib/device-config.ts`. `browser.profile` is a documented alias of the existing `defaultBrowserProfile` field — no duplicate key, resolution order unchanged. agents.yaml now carries a `yaml-language-server` $schema hint → `apps/cli/schema/agents-yaml.schema.json`.

**New surfaces** (all scriptable, `--json`, unset = today's behavior):
- `agents devices set-interactive [name]` — the one device agents show YOU artifacts on; ★ in the devices table; `list --json` carries `interactive` + per-row `config`
- `agents devices configure <name> --max-agents N --scheduler on|off --hooks on|off` — per-device caps, writable for any peer (devices/ tree syncs)
- `agents devices note <name> "…"` — operator notes

**Setup onboarding** — bare `agents setup` gains a skippable preferences step (which machine you sit at / which browser agents drive here); `setup fleet` offers set-interactive when >1 Mac is registered; `setup browser` now **asks** which browser instead of silently taking priority-order winner (Chrome).

**Engine consumers** — team placement excludes devices at their `agents.max-concurrent` cap (loud all-capped failure; pins never second-guessed); `scheduler.enabled=false` stops the routines scheduler on that box (auto-start skips with stated reason, manual start refuses, daemon never starts its JobScheduler but keeps other duties); Factory's `pickBestHost` honors the same cap and says why when a pool is exhausted.

## Tests

Real paths, no mocks, next to source: `device-config.test.ts` (16), `ssh.device-config.test.ts` (6, subprocess CLI runs on temp HOME), `setup-preferences.test.ts` (7), `teams/scheduler.test.ts` caps (17 total), factory `launchHost`+`deviceAutoLaunch` (36). Full vitest suite in the worktree: 8344 passed; the 12 failures in 5 files reproduce identically on `origin/main` (crabbox secrets bundle env, codex model-catalog drift, SSH-timing flakes) — none from this diff. `tsc --noEmit` clean for apps/cli and apps/factory. `test:remote` could not run — Hetzner server-limit 403 on crabbox warmup (infra), so the suite ran locally.

## Follow-ups (not in this PR)

- Fleet rollout: `agents devices set-interactive zion` once released; hook + skill updates reading the primitive live in the DotAgents repos (`~/.agents/.system` hook 07 already updated locally — backward-compatible, silent on older CLIs).
- Docs: README devices section + 00-concepts; changelog fragment included.