### PR TITLE
feat(projects): Linear import + confidence-gated Factory import + aligned list columns

### DIFF
--- a/apps/cli/.changelog/next/projects-import-linear-confidence.md
+++ b/apps/cli/.changelog/next/projects-import-linear-confidence.md
@@ -1,0 +1,10 @@
+- **`agents projects import` gains Linear as a source, and gates the Factory guess.**
+  `import --from-linear` turns the workspace's Linear projects into definitions via the
+  `linear` CLI, binding a local checkout only on an exact name match so it never
+  silently points a project at the wrong repo. `--from-factory` now imports only
+  `high`-confidence rows by default (`--min-confidence low|medium|high`, `--all` to
+  take everything), and prints why each row was skipped — the auto-detected registry
+  used to absorb every stale clone it found. Source: `apps/cli/src/lib/project-import.ts`.
+- **`agents projects list` columns line up again.** Widths are computed from the rows
+  being printed instead of a fixed 32-character path pad that every home-relative root
+  ran straight through. Source: `apps/cli/src/commands/projects.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -62,7 +62,7 @@ linear:
 
 Resolution is intentionally **not** beta-gated — only the `agents projects` command
 tree is. A definition exists solely by explicit user action (`projects add`,
-`import --from-factory`, or hand-authoring the YAML), so honoring it in `--project`
+`projects import`, or hand-authoring the YAML), so honoring it in `--project`
 resolution is additive and safe; users without any definitions see zero change.
 
 ## One name everywhere — activity, feed, sessions
@@ -162,11 +162,65 @@ rush  ·  3 agents
 | `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
 | `agents projects status [name] [--json] [--window N] [--no-remote] [--fleet]` | The progress card (all projects, or one). `--fleet` adds per-device workspace drift over SSH. |
 | `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. |
-| `agents projects import --from-factory` | Absorb `~/.agents/factory/projects.json` into YAML definitions. |
+| `agents projects import --from-linear` | Import the workspace's Linear projects (via the `linear` CLI) as definitions. See [Importing](#importing--linear-first-factory-gated). |
+| `agents projects import --from-factory [--min-confidence low\|medium\|high] [--all]` | Absorb `~/.agents/factory/projects.json`. Imports only `high`-confidence rows by default. |
 | `agents projects rm <name>` | Delete the definition (never touches the repo). |
 
 `agents run --project <name>` is unchanged in spelling — it just resolves richer
 definitions now.
+
+## Importing — Linear first, Factory gated
+
+Both sources write the **same** `ProjectDef` schema through `writeProjectDef`, and
+neither invents a field. What differs is how much each source knows.
+
+**`--from-linear` is the preferred source.** A Linear project exists because someone
+deliberately created it, so the name and the link are trustworthy. Each project
+becomes a def carrying `linear.projectId` (+ `url` when the CLI reports one), and
+the `show` backlink lights up immediately.
+
+The local checkout is bound **only on an exact normalized-name match** against the
+directories under the configured projects root (`matchLocalCheckoutExact`,
+`lib/linear-projects.ts`) — "Agents CLI" binds `agents-cli`, and nothing else. The
+containment fallback that powers `projects link`'s suggestion is deliberately not
+used on this write path: it would silently bind "Agents CLI" to `agents-cli-web`
+with nobody looking. A project with no exact local match still imports, carrying
+`name` + `linear` and nothing it cannot prove; fill the rest in with
+`projects add --force` or by editing the YAML.
+
+Re-importing is safe. An existing def is preserved field-for-field and only
+`linear` is overwritten, so a hand-set `description`, `contexts`, or `integrations`
+survives. A def that already carries `root`/`repo` is skipped unless `--force`,
+so a re-import never re-points a project you have already bound by hand.
+
+**`--from-factory` is a guess, so it is gated.** Factory's registry is
+auto-detected from checkouts on disk and stamps each row with a
+`confidence` — `high`, `medium`, `low`, or nothing at all. Importing every row is
+what buried two real projects under a dozen stale clones and someone else's repo,
+so the import takes only `high` rows by default:
+
+```
+agents projects import --from-factory                      # high only (default)
+agents projects import --from-factory --min-confidence medium
+agents projects import --from-factory --all                # every row, even unranked
+```
+
+`--all` is the only floor that takes a row stating **no** confidence — an unranked
+guess sits below `low`. An unrecognized `--min-confidence` value is an error, never
+a quiet fall back to the default. Every declined row prints its reason:
+
+```
+Imported 2 projects (3 skipped)
+  skip swarmify: confidence "medium" is below the "high" floor
+  skip inflow: confidence "low" is below the "high" floor
+  skip agents-cleaned-stale2: no confidence field is below the "high" floor
+  (widen with --min-confidence medium or --all)
+```
+
+The two sources are mutually exclusive in one invocation, and `--min-confidence` /
+`--all` are rejected on `--from-linear` (Linear rows carry no confidence) rather
+than silently ignored. Drop a bad import with `agents projects rm <name>` — it only
+unlinks the YAML, never the repo.
 
 ## Not yet (fast-follow)
 

--- a/apps/cli/src/commands/projects.test.ts
+++ b/apps/cli/src/commands/projects.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatFleetSkippedNote } from './projects.js';
+import { computeProjectListWidths, formatFleetSkippedNote, type ProjectListRow } from './projects.js';
 
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
@@ -13,5 +13,37 @@ describe('formatFleetSkippedNote', () => {
       .toBe("  · 1 device didn't answer (unreachable, older agents-cli, or timed out): gpu-box\n");
     expect(stripAnsi(formatFleetSkippedNote(['a', 'b', 'c', 'd', 'e', 'f'])))
       .toBe("  · 6 devices didn't answer (unreachable, older agents-cli, or timed out): a, b, c, d +2\n");
+  });
+});
+
+describe('computeProjectListWidths', () => {
+  /** Render a row the way `list` does, so a bleeding column shows up as a shifted gridline. */
+  const render = (r: ProjectListRow, w: { name: number; path: number; repo: number }) =>
+    `  ${r.name.padEnd(w.name)} ${r.path.padEnd(w.path)} ${r.repo.padEnd(w.repo)} 0 agents`;
+
+  it('sizes every column to the widest row instead of a fixed 32', () => {
+    const rows: ProjectListRow[] = [
+      { name: 'agents', path: '~/src/github.com/muqsitnawaz/agents', repo: 'muqsitnawaz/agents' },
+      { name: 'agents-cli', path: '~/src/github.com/muqsitnawaz/agents-cli', repo: 'muqsitnawaz/agents-cli' },
+    ];
+    const w = computeProjectListWidths(rows);
+    expect(w).toEqual({ name: 10, path: 39, repo: 22 });
+    // The repo column starts at the same offset on every row — the bug was a
+    // 32-char pad that a ~39-char home-relative path ran straight through.
+    const offsets = rows.map((r) => render(r, w).indexOf(r.repo));
+    expect(new Set(offsets).size).toBe(1);
+  });
+
+  it('caps the path column so one long root cannot widen the whole table', () => {
+    const w = computeProjectListWidths([
+      { name: 'a', path: '~/' + 'x'.repeat(120), repo: 'o/r' },
+      { name: 'b', path: '~/short', repo: 'o/r2' },
+    ]);
+    expect(w.path).toBe(48);
+  });
+
+  it('collapses to zero-width columns when there is nothing to show', () => {
+    expect(computeProjectListWidths([])).toEqual({ name: 0, path: 0, repo: 0 });
+    expect(computeProjectListWidths([{ name: 'a', path: '', repo: '' }])).toEqual({ name: 1, path: 0, repo: 0 });
   });
 });

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -12,13 +12,15 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
+import * as path from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 
 import { betaEnableHint, isBetaEnabled } from '../lib/beta.js';
 import { setHelpSections } from '../lib/help.js';
 import { getMainRepoRoot } from '../lib/git.js';
 import { parseOwnerRepoFromRemote } from '../lib/registry.js';
-import { toHomeRelative } from '../lib/project-root.js';
+import { truncate } from '../lib/format.js';
+import { expandLocalHome, getProjectRoot, toHomeRelative } from '../lib/project-root.js';
 import { machineId } from '../lib/machine-id.js';
 import { getActiveSessions } from '../lib/session/active.js';
 import { gatherRemoteActive } from '../lib/session/remote-active.js';
@@ -50,7 +52,15 @@ import {
   type ProjectRemoteSignals,
 } from '../lib/project-status.js';
 import { fetchLinearProjectCounts, type LinearProjectCounts } from '../lib/linear-project-counts.js';
-import { listLinearProjects, pickLinearProject, type LinearPick } from '../lib/linear-projects.js';
+import { listLinearProjects, pickLinearProject, type LinearPick, type LinearProjectLite } from '../lib/linear-projects.js';
+import {
+  buildFactoryImportCandidates,
+  buildLinearImportCandidates,
+  validateImportOpts,
+  type ImportOptions,
+  type ImportPlan,
+  type RawImportFlags,
+} from '../lib/project-import.js';
 
 /** Recursion guard: a peer answering a probe fan-out never re-fans-out itself. */
 export const PROJECTS_NO_FANOUT_ENV = 'AGENTS_PROJECTS_LOCAL';
@@ -89,6 +99,96 @@ function originSlug(cwd: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Read the Factory registry off disk and plan its import. Every read failure is
+ * fatal and named — an unreadable or malformed registry must not read as "0
+ * projects to import".
+ */
+function runFactoryImport(existing: Map<string, ProjectDef>, opts: ImportOptions): ImportPlan {
+  const src = factoryProjectsPath();
+  let rawText: string;
+  try {
+    rawText = fs.readFileSync(src, 'utf8');
+  } catch {
+    console.error(chalk.red(`No Factory registry at ${src}`));
+    process.exit(1);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    console.error(chalk.red(`Factory registry at ${src} is not valid JSON`));
+    process.exit(1);
+  }
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { projects?: unknown[] })?.projects)
+      ? (parsed as { projects: unknown[] }).projects
+      : [];
+  return buildFactoryImportCandidates(rows, existing, opts);
+}
+
+/**
+ * List the workspace's Linear projects and plan their import, binding each to a
+ * local checkout under the configured projects root when the names match
+ * exactly. A missing / logged-out `linear` CLI is loud (this is an explicit user
+ * command), and nothing is written before the whole plan is built.
+ */
+function runLinearImport(existing: Map<string, ProjectDef>, opts: ImportOptions): ImportPlan {
+  let list: LinearProjectLite[];
+  try {
+    list = listLinearProjects();
+  } catch (e) {
+    console.error(chalk.red(e instanceof Error ? e.message : String(e)));
+    process.exit(1);
+  }
+  // No projects root configured (or unreadable) → no local matching; every def
+  // still imports, carrying its Linear link and nothing it can't prove.
+  const rootAbs = getProjectRoot() ? expandLocalHome(getProjectRoot()!) : undefined;
+  let localDirs: string[] = [];
+  if (rootAbs) {
+    try {
+      localDirs = fs
+        .readdirSync(rootAbs, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+        .map((d) => d.name);
+    } catch {
+      localDirs = [];
+    }
+  }
+  return buildLinearImportCandidates(list, existing, {
+    localDirs,
+    resolveRoot: (dir) => (rootAbs ? toHomeRelative(path.join(rootAbs, dir)) : undefined),
+    resolveOrigin: (dir) => (rootAbs ? originSlug(path.join(rootAbs, dir)) : undefined),
+  }, opts);
+}
+
+/** One `projects list` row, pre-render. */
+export interface ProjectListRow {
+  name: string;
+  path: string;
+  repo: string;
+}
+
+/** Longest path a `list` row shows before it truncates. */
+const LIST_PATH_MAX = 48;
+
+/**
+ * Column widths for `projects list`, sized to the rows actually being printed.
+ * Fixed padding was the bug: home-relative roots run past 50 characters, so a
+ * hardcoded 32 pushed the repo column off its gridline on every long path.
+ * Paths longer than {@link LIST_PATH_MAX} truncate rather than widen the table.
+ */
+export function computeProjectListWidths(rows: ProjectListRow[]): { name: number; path: number; repo: number } {
+  const widest = (pick: (r: ProjectListRow) => string, cap: number) =>
+    Math.min(cap, rows.reduce((w, r) => Math.max(w, pick(r).length), 0));
+  return {
+    name: widest((r) => r.name, 64),
+    path: widest((r) => r.path, LIST_PATH_MAX),
+    repo: widest((r) => r.repo, 64),
+  };
 }
 
 function statusBar(r: ProjectSessionRollup): string {
@@ -166,6 +266,7 @@ export function registerProjectsCommands(program: Command): void {
 
   setHelpSections(projects, {
     examples: `
+      agents projects import --from-linear  # the projects you actually track
       agents projects add rush --repo phnx-labs/rush --path apps/web
       agents projects list
       agents projects status              # progress card for every project
@@ -177,6 +278,11 @@ export function registerProjectsCommands(program: Command): void {
     notes: `
       Definitions are hand-editable YAML in ~/.agents/projects/ and sync across
       machines with 'agents push/pull'. Enable with: agents beta enable projects.
+
+      'import --from-factory' reads Factory's auto-detected registry, which
+      guesses from checkouts on disk — it imports only 'high' confidence rows by
+      default. Widen with --min-confidence medium or --all, and drop a bad guess
+      with 'agents projects rm <name>'.
     `,
   });
 
@@ -214,11 +320,17 @@ export function registerProjectsCommands(program: Command): void {
         return;
       }
       const roll = rollupSessionsByProject(defs, await getActiveSessions());
-      for (const d of defs) {
+      const rows: ProjectListRow[] = defs.map((d) => ({
+        name: d.name,
+        path: truncate(d.root ?? d.defaultPath ?? '', LIST_PATH_MAX),
+        repo: d.repo ?? d.repos?.[0]?.slug ?? '',
+      }));
+      const w = computeProjectListWidths(rows);
+      for (const [i, d] of defs.entries()) {
         const agents = roll.get(d.name)?.agents ?? 0;
-        const repo = d.repo ?? d.repos?.[0]?.slug ?? '';
+        const row = rows[i];
         console.log(
-          `  ${chalk.bold(d.name.padEnd(16))} ${chalk.dim((d.root ?? d.defaultPath ?? '').padEnd(32))} ${chalk.cyan(repo.padEnd(24))} ${agents} agents`,
+          `  ${chalk.bold(row.name.padEnd(w.name))} ${chalk.dim(row.path.padEnd(w.path))} ${chalk.cyan(row.repo.padEnd(w.repo))} ${agents} agents`,
         );
       }
     });
@@ -445,48 +557,30 @@ export function registerProjectsCommands(program: Command): void {
   // ---- import ----
   projects
     .command('import')
-    .description('Absorb the Factory project registry (~/.agents/factory/projects.json) into YAML definitions.')
-    .requiredOption('--from-factory', 'Import from the Factory projects.json registry')
+    .description('Import project definitions from Linear (preferred) or the Factory auto-detection registry.')
+    .option('--from-linear', 'Import the workspace\'s Linear projects (via the `linear` CLI)')
+    .option('--from-factory', 'Import the Factory registry (~/.agents/factory/projects.json)')
+    .option('--min-confidence <level>', '--from-factory only: lowest detection confidence to import — low|medium|high (default: high)')
+    .option('--all', '--from-factory only: import every row regardless of confidence')
     .option('--force', 'Overwrite existing definitions')
-    .action((opts: { force?: boolean }) => {
-      const src = factoryProjectsPath();
-      let rawText: string;
+    .action((raw: RawImportFlags) => {
+      let opts: ImportOptions;
       try {
-        rawText = fs.readFileSync(src, 'utf8');
-      } catch {
-        console.error(chalk.red(`No Factory registry at ${src}`));
+        opts = validateImportOpts(raw);
+      } catch (e) {
+        console.error(chalk.red(e instanceof Error ? e.message : String(e)));
         process.exit(1);
       }
-      let rows: unknown;
-      try {
-        rows = JSON.parse(rawText);
-      } catch {
-        console.error(chalk.red(`Factory registry at ${src} is not valid JSON`));
-        process.exit(1);
+      const existing = new Map(listProjectDefs().map((d) => [d.name, d]));
+      const result = opts.source === 'linear' ? runLinearImport(existing, opts) : runFactoryImport(existing, opts);
+      for (const def of result.defs) writeProjectDef(def);
+      const n = result.defs.length;
+      const s = result.skipped.length;
+      console.log(chalk.green(`Imported ${n} project${n === 1 ? '' : 's'}${s ? chalk.gray(` (${s} skipped)`) : ''}`));
+      for (const skip of result.skipped) console.log(chalk.gray(`  skip ${skip.name}: ${skip.reason}`));
+      if (opts.source === 'factory' && s > 0 && opts.minConfidence === 'high') {
+        console.log(chalk.gray('  (widen with --min-confidence medium or --all)'));
       }
-      const list = Array.isArray(rows) ? rows : Array.isArray((rows as { projects?: unknown[] }).projects) ? (rows as { projects: unknown[] }).projects : [];
-      let created = 0;
-      let skipped = 0;
-      for (const raw of list) {
-        if (!raw || typeof raw !== 'object') continue;
-        const o = raw as Record<string, unknown>;
-        const name = typeof o.name === 'string' ? o.name : undefined;
-        if (!name || !isSafeProjectName(name)) {
-          skipped++;
-          continue;
-        }
-        if (loadProjectDef(name) && !opts.force) {
-          skipped++;
-          continue;
-        }
-        const def: ProjectDef = { name };
-        if (typeof o.path === 'string') def.root = toHomeRelative(o.path);
-        if (typeof o.repoSlug === 'string') def.repo = o.repoSlug;
-        if (typeof o.linearProjectId === 'string') def.linear = { projectId: o.linearProjectId };
-        writeProjectDef(def);
-        created++;
-      }
-      console.log(chalk.green(`Imported ${created} project${created === 1 ? '' : 's'}${skipped ? chalk.gray(` (${skipped} skipped)`) : ''}`));
     });
 
   // ---- link ----

--- a/apps/cli/src/lib/auto-dispatch.ts
+++ b/apps/cli/src/lib/auto-dispatch.ts
@@ -51,9 +51,14 @@ export interface PlannedDispatch {
   delegateName: string;
 }
 
-/** Path to the shared factory project registry (written by the factory UI). */
+/**
+ * Path to the shared factory project registry (written by the factory UI).
+ * `AGENTS_FACTORY_PROJECTS_PATH` overrides it, mirroring `AGENTS_PROJECTS_DIR`
+ * (`state.ts`) — that seam is what lets `projects import --from-factory` be
+ * tested end-to-end against a real fixture file instead of a mock.
+ */
 export function factoryProjectsPath(): string {
-  return path.join(homedir(), '.agents', 'factory', 'projects.json');
+  return process.env.AGENTS_FACTORY_PROJECTS_PATH ?? path.join(homedir(), '.agents', 'factory', 'projects.json');
 }
 
 /** Read the project registry rows this module cares about. */

--- a/apps/cli/src/lib/linear-projects.ts
+++ b/apps/cli/src/lib/linear-projects.ts
@@ -59,20 +59,33 @@ export function matchLinearProject(
 }
 
 /**
+ * Collapse a Linear **display name** or a directory basename to one comparison
+ * key. Deliberately NOT `normalizeProjectKey`: that one keeps only the segment
+ * after the last `/`, which is right for an `owner/repo` slug or a filesystem
+ * path and wrong for a display name, where `/` is ordinary punctuation. Keying
+ * "Rush / Web" the path way yields `web`, which exact-matches an unrelated
+ * `web/` checkout — the precise silent mis-binding this whole match path exists
+ * to prevent.
+ */
+function checkoutMatchKey(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/**
  * Find the local checkout directory a Linear project name refers to, on EXACT
- * normalized-key equality only — never containment. `matchLinearProject`'s
- * containment fallback is right for suggesting a link a human then confirms;
- * this backs `projects import --from-linear`, which writes `root`/`repo` with
- * nobody looking, and "Agents CLI" must not silently bind `agents-cli-web`.
+ * key equality only — never containment. `matchLinearProject`'s containment
+ * fallback is right for suggesting a link a human then confirms; this backs
+ * `projects import --from-linear`, which writes `root`/`repo` with nobody
+ * looking, and "Agents CLI" must not silently bind `agents-cli-web`.
  *
- * Returns `undefined` when nothing matches, and also when SEVERAL dirs
- * normalize to the same key (`agents-cli` and `agents_cli`) — an ambiguous
- * match is not a match.
+ * Returns `undefined` when nothing matches, and also when SEVERAL dirs key to
+ * the same value (`agents-cli` and `agents_cli`) — an ambiguous match is not a
+ * match.
  */
 export function matchLocalCheckoutExact(name: string, dirNames: string[]): string | undefined {
-  const key = normalizeProjectKey(name);
+  const key = checkoutMatchKey(name);
   if (!key) return undefined;
-  const hits = dirNames.filter((d) => normalizeProjectKey(d) === key);
+  const hits = dirNames.filter((d) => checkoutMatchKey(d) === key);
   return hits.length === 1 ? hits[0] : undefined;
 }
 

--- a/apps/cli/src/lib/linear-projects.ts
+++ b/apps/cli/src/lib/linear-projects.ts
@@ -58,6 +58,24 @@ export function matchLinearProject(
   });
 }
 
+/**
+ * Find the local checkout directory a Linear project name refers to, on EXACT
+ * normalized-key equality only — never containment. `matchLinearProject`'s
+ * containment fallback is right for suggesting a link a human then confirms;
+ * this backs `projects import --from-linear`, which writes `root`/`repo` with
+ * nobody looking, and "Agents CLI" must not silently bind `agents-cli-web`.
+ *
+ * Returns `undefined` when nothing matches, and also when SEVERAL dirs
+ * normalize to the same key (`agents-cli` and `agents_cli`) — an ambiguous
+ * match is not a match.
+ */
+export function matchLocalCheckoutExact(name: string, dirNames: string[]): string | undefined {
+  const key = normalizeProjectKey(name);
+  if (!key) return undefined;
+  const hits = dirNames.filter((d) => normalizeProjectKey(d) === key);
+  return hits.length === 1 ? hits[0] : undefined;
+}
+
 /** The outcome of picking one Linear project out of the workspace list. */
 export type LinearPick =
   | { kind: 'match'; project: LinearProjectLite }

--- a/apps/cli/src/lib/project-import.test.ts
+++ b/apps/cli/src/lib/project-import.test.ts
@@ -94,6 +94,22 @@ describe('buildFactoryImportCandidates', () => {
     expect(names(forced)).toEqual(['agents-cli', 'agents']);
   });
 
+  it('skips a duplicate name in the same registry instead of silently clobbering the first', () => {
+    // The registry keys by owner/repo but names by basename, so two orgs with
+    // the same repo name arrive as two rows called `inflow`.
+    const r = buildFactoryImportCandidates(
+      [
+        { name: 'inflow', path: '/tmp/a/inflow', repoSlug: 'grinich/inflow', confidence: 'high' },
+        { name: 'inflow', path: '/tmp/b/inflow', repoSlug: 'me/inflow', confidence: 'high' },
+      ],
+      new Map(),
+      { minConfidence: 'high', force: false },
+    );
+    expect(r.defs).toHaveLength(1);
+    expect(r.defs[0].repo).toBe('grinich/inflow');
+    expect(r.skipped).toEqual([{ name: 'inflow', reason: 'another row in this registry already claimed the name' }]);
+  });
+
   it('skips rows with an unusable name rather than writing a bad filename', () => {
     const r = buildFactoryImportCandidates(
       [{ name: '../escape', confidence: 'high' }, { confidence: 'high' }],
@@ -138,6 +154,13 @@ describe('matchLocalCheckoutExact', () => {
   it('refuses an ambiguous match', () => {
     expect(matchLocalCheckoutExact('Agents CLI', ['agents-cli', 'agents_cli'])).toBeUndefined();
   });
+
+  it('treats a slash in a display name as punctuation, not a path boundary', () => {
+    // "Rush / Web" is one name, not `rush/web`. Keying it the path way (last
+    // segment) yields `web`, which exact-matches an unrelated `web/` checkout.
+    expect(matchLocalCheckoutExact('Rush / Web', ['web', 'agents-cli'])).toBeUndefined();
+    expect(matchLocalCheckoutExact('Rush / Web', ['rush-web', 'web'])).toBe('rush-web');
+  });
 });
 
 describe('buildLinearImportCandidates', () => {
@@ -171,6 +194,19 @@ describe('buildLinearImportCandidates', () => {
   it('does NOT auto-bind on a containment-only match', () => {
     const r = buildLinearImportCandidates([{ id: 'lin_3', name: 'Agents' }], new Map(), deps, { force: false });
     expect(r.defs[0]).toEqual({ name: 'agents', linear: { projectId: 'lin_3' } });
+  });
+
+  it('does NOT bind a slashed display name to the checkout after the slash', () => {
+    // Regression: "Rush / Web" once bound `~/src/web` because the match key
+    // kept only the last path segment. The def name and the match key must be
+    // derived from the same reading of the string.
+    const r = buildLinearImportCandidates(
+      [{ id: 'lin_rw', name: 'Rush / Web' }],
+      new Map(),
+      { localDirs: ['web', 'agents-cli'], resolveRoot: (d) => `~/src/${d}`, resolveOrigin: (d) => `someone/${d}` },
+      { force: false },
+    );
+    expect(r.defs[0]).toEqual({ name: 'rush-web', linear: { projectId: 'lin_rw' } });
   });
 
   it('preserves hand-set fields on an existing def and overwrites only linear', () => {

--- a/apps/cli/src/lib/project-import.test.ts
+++ b/apps/cli/src/lib/project-import.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildFactoryImportCandidates,
+  buildLinearImportCandidates,
+  slugifyProjectName,
+  validateImportOpts,
+  type LinearImportDeps,
+} from './project-import.js';
+import { matchLocalCheckoutExact } from './linear-projects.js';
+import type { ProjectDef } from './projects.js';
+
+const HOME = process.env.HOME ?? os.homedir();
+
+/** The real registry's shape — the rows that buried the user's actual projects. */
+const FACTORY_ROWS = [
+  { name: 'agents-cli', path: path.join(HOME, 'src/agents-cli'), repoSlug: 'muqsitnawaz/agents-cli', confidence: 'high' },
+  { name: 'agents', path: path.join(HOME, 'src/agents'), repoSlug: 'muqsitnawaz/agents', confidence: 'high' },
+  { name: 'swarmify', path: path.join(HOME, 'src/swarmify'), repoSlug: 'muqsitnawaz/swarmify', confidence: 'medium' },
+  { name: 'inflow', path: path.join(HOME, 'src/inflow'), repoSlug: 'grinich/inflow', confidence: 'low' },
+  { name: 'agents-cleaned-stale2', path: path.join(HOME, 'src/agents-cleaned-stale2'), confidence: 'low' },
+  { name: 'nameless-confidence', path: path.join(HOME, 'src/x') },
+];
+
+const names = (r: { defs: ProjectDef[] }) => r.defs.map((d) => d.name);
+
+describe('validateImportOpts', () => {
+  it('requires exactly one source', () => {
+    expect(() => validateImportOpts({})).toThrow(/Pick an import source/);
+    expect(() => validateImportOpts({ fromFactory: true, fromLinear: true })).toThrow(/mutually exclusive/);
+    expect(validateImportOpts({ fromLinear: true }).source).toBe('linear');
+  });
+
+  it('defaults the factory floor to high and lowers it with --all', () => {
+    expect(validateImportOpts({ fromFactory: true }).minConfidence).toBe('high');
+    expect(validateImportOpts({ fromFactory: true, all: true }).minConfidence).toBe('any');
+    expect(validateImportOpts({ fromFactory: true, minConfidence: 'MEDIUM' }).minConfidence).toBe('medium');
+  });
+
+  it('errors loudly on an unknown confidence instead of falling back', () => {
+    expect(() => validateImportOpts({ fromFactory: true, minConfidence: 'kinda' })).toThrow(/Invalid --min-confidence/);
+  });
+
+  it('rejects confidence flags that do not apply, and contradictory ones', () => {
+    expect(() => validateImportOpts({ fromLinear: true, all: true })).toThrow(/--from-factory only/);
+    expect(() => validateImportOpts({ fromLinear: true, minConfidence: 'low' })).toThrow(/--from-factory only/);
+    expect(() => validateImportOpts({ fromFactory: true, all: true, minConfidence: 'high' })).toThrow(/mutually exclusive/);
+  });
+});
+
+describe('buildFactoryImportCandidates', () => {
+  it('imports only high-confidence rows by default', () => {
+    const r = buildFactoryImportCandidates(FACTORY_ROWS, new Map(), { minConfidence: 'high', force: false });
+    expect(names(r)).toEqual(['agents-cli', 'agents']);
+    expect(r.skipped.map((s) => s.name)).toEqual(['swarmify', 'inflow', 'agents-cleaned-stale2', 'nameless-confidence']);
+    expect(r.skipped[0].reason).toBe('confidence "medium" is below the "high" floor');
+  });
+
+  it('widens to medium, and to everything under --all', () => {
+    const med = buildFactoryImportCandidates(FACTORY_ROWS, new Map(), { minConfidence: 'medium', force: false });
+    expect(names(med)).toEqual(['agents-cli', 'agents', 'swarmify']);
+    const low = buildFactoryImportCandidates(FACTORY_ROWS, new Map(), { minConfidence: 'low', force: false });
+    expect(names(low)).toEqual(['agents-cli', 'agents', 'swarmify', 'inflow', 'agents-cleaned-stale2']);
+    const all = buildFactoryImportCandidates(FACTORY_ROWS, new Map(), { minConfidence: 'any', force: false });
+    expect(names(all)).toEqual(['agents-cli', 'agents', 'swarmify', 'inflow', 'agents-cleaned-stale2', 'nameless-confidence']);
+  });
+
+  it('treats a missing confidence field as below every stated floor — only --all takes it', () => {
+    const r = buildFactoryImportCandidates(FACTORY_ROWS, new Map(), { minConfidence: 'any', force: false });
+    expect(names(r)).toContain('nameless-confidence');
+    const low = buildFactoryImportCandidates(FACTORY_ROWS, new Map(), { minConfidence: 'low', force: false });
+    expect(names(low)).not.toContain('nameless-confidence');
+    const strict = buildFactoryImportCandidates(FACTORY_ROWS, new Map(), { minConfidence: 'medium', force: false });
+    expect(strict.skipped.find((s) => s.name === 'nameless-confidence')?.reason)
+      .toBe('no confidence field is below the "medium" floor');
+  });
+
+  it('stores the root home-relative and maps repo + linear id', () => {
+    const r = buildFactoryImportCandidates(
+      [{ name: 'rush', path: path.join(HOME, 'src/rush'), repoSlug: 'phnx-labs/rush', linearProjectId: 'lin_1', confidence: 'high' }],
+      new Map(),
+      { minConfidence: 'high', force: false },
+    );
+    expect(r.defs[0]).toEqual({ name: 'rush', root: '~/src/rush', repo: 'phnx-labs/rush', linear: { projectId: 'lin_1' } });
+  });
+
+  it('keeps an existing def unless --force', () => {
+    const existing = new Map<string, ProjectDef>([['agents-cli', { name: 'agents-cli', description: 'mine' }]]);
+    const keep = buildFactoryImportCandidates(FACTORY_ROWS, existing, { minConfidence: 'high', force: false });
+    expect(names(keep)).toEqual(['agents']);
+    expect(keep.skipped[0]).toEqual({ name: 'agents-cli', reason: 'already defined — pass --force to overwrite' });
+    const forced = buildFactoryImportCandidates(FACTORY_ROWS, existing, { minConfidence: 'high', force: true });
+    expect(names(forced)).toEqual(['agents-cli', 'agents']);
+  });
+
+  it('skips rows with an unusable name rather than writing a bad filename', () => {
+    const r = buildFactoryImportCandidates(
+      [{ name: '../escape', confidence: 'high' }, { confidence: 'high' }],
+      new Map(),
+      { minConfidence: 'high', force: false },
+    );
+    expect(r.defs).toEqual([]);
+    expect(r.skipped).toEqual([
+      { name: '../escape', reason: 'not a usable project name' },
+      { name: '(unnamed)', reason: 'not a usable project name' },
+    ]);
+  });
+});
+
+describe('slugifyProjectName', () => {
+  it('turns a Linear display name into a safe slug', () => {
+    expect(slugifyProjectName('Agents CLI')).toBe('agents-cli');
+    expect(slugifyProjectName('Rush / Web')).toBe('rush-web');
+    expect(slugifyProjectName('  Q3 — Growth!  ')).toBe('q3-growth');
+    expect(slugifyProjectName('x'.repeat(80))).toHaveLength(64);
+  });
+
+  it('returns empty when nothing usable survives', () => {
+    expect(slugifyProjectName('!!!')).toBe('');
+    expect(slugifyProjectName('')).toBe('');
+  });
+});
+
+describe('matchLocalCheckoutExact', () => {
+  const dirs = ['agents-cli', 'agents-cli-web', 'rush'];
+
+  it('binds only on an exact normalized match', () => {
+    expect(matchLocalCheckoutExact('Agents CLI', dirs)).toBe('agents-cli');
+    expect(matchLocalCheckoutExact('agents_cli', dirs)).toBe('agents-cli');
+  });
+
+  it('refuses the containment match that would bind the wrong checkout', () => {
+    expect(matchLocalCheckoutExact('Agents CLI Website', dirs)).toBeUndefined();
+    expect(matchLocalCheckoutExact('Nothing Here', dirs)).toBeUndefined();
+  });
+
+  it('refuses an ambiguous match', () => {
+    expect(matchLocalCheckoutExact('Agents CLI', ['agents-cli', 'agents_cli'])).toBeUndefined();
+  });
+});
+
+describe('buildLinearImportCandidates', () => {
+  const deps: LinearImportDeps = {
+    localDirs: ['agents-cli', 'agents-cli-web'],
+    resolveRoot: (d) => `~/src/${d}`,
+    resolveOrigin: (d) => `muqsitnawaz/${d}`,
+  };
+  const noLocal: LinearImportDeps = { localDirs: [], resolveRoot: () => undefined, resolveOrigin: () => undefined };
+
+  it('binds root and repo on an exact local match', () => {
+    const r = buildLinearImportCandidates(
+      [{ id: 'lin_1', name: 'Agents CLI', url: 'https://linear.app/x/project/agents-cli' }],
+      new Map(),
+      deps,
+      { force: false },
+    );
+    expect(r.defs[0]).toEqual({
+      name: 'agents-cli',
+      root: '~/src/agents-cli',
+      repo: 'muqsitnawaz/agents-cli',
+      linear: { projectId: 'lin_1', url: 'https://linear.app/x/project/agents-cli' },
+    });
+  });
+
+  it('writes name + linear only when no local checkout matches', () => {
+    const r = buildLinearImportCandidates([{ id: 'lin_2', name: 'Marketing Site' }], new Map(), deps, { force: false });
+    expect(r.defs[0]).toEqual({ name: 'marketing-site', linear: { projectId: 'lin_2' } });
+  });
+
+  it('does NOT auto-bind on a containment-only match', () => {
+    const r = buildLinearImportCandidates([{ id: 'lin_3', name: 'Agents' }], new Map(), deps, { force: false });
+    expect(r.defs[0]).toEqual({ name: 'agents', linear: { projectId: 'lin_3' } });
+  });
+
+  it('preserves hand-set fields on an existing def and overwrites only linear', () => {
+    const existing = new Map<string, ProjectDef>([
+      ['agents-cli', { name: 'agents-cli', description: 'the CLI', contexts: [{ path: 'apps/cli', purpose: 'the package' }], linear: { projectId: 'old' } }],
+    ]);
+    const r = buildLinearImportCandidates([{ id: 'lin_1', name: 'Agents CLI' }], existing, noLocal, { force: false });
+    expect(r.defs[0]).toEqual({
+      name: 'agents-cli',
+      description: 'the CLI',
+      contexts: [{ path: 'apps/cli', purpose: 'the package' }],
+      linear: { projectId: 'lin_1' },
+    });
+  });
+
+  it('re-imports idempotently — the same name overwrites in place', () => {
+    const first = buildLinearImportCandidates([{ id: 'lin_1', name: 'Agents CLI' }], new Map(), deps, { force: false });
+    const second = buildLinearImportCandidates([{ id: 'lin_1', name: 'Agents CLI' }], new Map(first.defs.map((d) => [d.name, d])), deps, { force: true });
+    expect(second.defs).toEqual(first.defs);
+  });
+
+  it('refuses to relink a def that already has root/repo without --force', () => {
+    const existing = new Map<string, ProjectDef>([['agents-cli', { name: 'agents-cli', root: '~/elsewhere', repo: 'me/mine' }]]);
+    const r = buildLinearImportCandidates([{ id: 'lin_1', name: 'Agents CLI' }], existing, deps, { force: false });
+    expect(r.defs).toEqual([]);
+    expect(r.skipped).toEqual([{ name: 'agents-cli', reason: 'existing def already has root/repo — pass --force to relink' }]);
+    const forced = buildLinearImportCandidates([{ id: 'lin_1', name: 'Agents CLI' }], existing, deps, { force: true });
+    expect(forced.defs[0].root).toBe('~/src/agents-cli');
+  });
+
+  it('skips a slug collision instead of silently overwriting the first', () => {
+    const r = buildLinearImportCandidates(
+      [{ id: 'a', name: 'Rush Web' }, { id: 'b', name: 'rush/web' }],
+      new Map(),
+      noLocal,
+      { force: false },
+    );
+    expect(names(r)).toEqual(['rush-web']);
+    expect(r.defs[0].linear).toEqual({ projectId: 'a' });
+    expect(r.skipped).toEqual([{ name: 'rush/web', reason: 'another Linear project already claimed the name "rush-web"' }]);
+  });
+
+  it('skips a project whose name has no safe slug', () => {
+    const r = buildLinearImportCandidates([{ id: 'a', name: '!!!' }], new Map(), noLocal, { force: false });
+    expect(r.defs).toEqual([]);
+    expect(r.skipped[0].reason).toMatch(/no usable project name/);
+  });
+});

--- a/apps/cli/src/lib/project-import.ts
+++ b/apps/cli/src/lib/project-import.ts
@@ -1,0 +1,216 @@
+/**
+ * Pure builders behind `agents projects import`.
+ *
+ * Two sources feed the one `ProjectDef` schema: **Linear** (the preferred one —
+ * a project someone deliberately created on the board) and the **Factory
+ * registry** (`~/.agents/factory/projects.json`, an auto-detection that guesses
+ * from checkouts on disk). Both funnel through `writeProjectDef`.
+ *
+ * The Factory registry stamps each row with a `confidence` — and importing every
+ * row regardless is what buried the real projects under a dozen guesses
+ * (`agents-cleaned-stale2`, a repo cloned from someone else's org, …). So the
+ * import is gated on that field, `high` by default.
+ *
+ * Everything here is a pure function of its arguments — no fs, no shell, no
+ * process env. The command layer reads the registry / shells out to `linear` and
+ * hands the rows in; that's what makes these testable against plain fixtures
+ * with no mocking. The one exception is `toHomeRelative`, a string rewrite
+ * against `$HOME`.
+ */
+
+import { toHomeRelative } from './project-root.js';
+import { isSafeProjectName, type ProjectDef } from './projects.js';
+import { matchLocalCheckoutExact, type LinearProjectLite } from './linear-projects.js';
+
+/** Factory's per-row detection confidence, weakest first. */
+export type ImportConfidence = 'low' | 'medium' | 'high';
+
+/**
+ * The floor an import runs at. `any` is what `--all` means — it takes rows that
+ * state no confidence at all, which rank below even `low`; without it "import
+ * every row regardless of confidence" would quietly drop the unranked ones.
+ */
+export type ImportFloor = ImportConfidence | 'any';
+
+const CONFIDENCE_RANK: Record<ImportFloor, number> = { any: 0, low: 1, medium: 2, high: 3 };
+
+/** Rank a raw `confidence` value; anything absent or unrecognized ranks 0 (below every floor). */
+function confidenceRank(raw: unknown): number {
+  return typeof raw === 'string' ? (CONFIDENCE_RANK[raw as ImportConfidence] ?? 0) : 0;
+}
+
+/** A row the import declined to write, with the reason to print. */
+export interface ImportSkip {
+  name: string;
+  reason: string;
+}
+
+/** What an import would write, and what it declined. */
+export interface ImportPlan {
+  defs: ProjectDef[];
+  skipped: ImportSkip[];
+}
+
+/** The validated shape of the `import` flags. */
+export interface ImportOptions {
+  source: 'factory' | 'linear';
+  /** Factory only: the lowest confidence that still imports. */
+  minConfidence: ImportFloor;
+  force: boolean;
+}
+
+/** The raw commander flags, before validation. */
+export interface RawImportFlags {
+  fromFactory?: boolean;
+  fromLinear?: boolean;
+  minConfidence?: string;
+  all?: boolean;
+  force?: boolean;
+}
+
+/**
+ * Validate the flag combination, throwing a user-facing message on the first
+ * problem. Every rejection is loud: an unrecognized `--min-confidence` is an
+ * error, never a silent fall back to the default floor.
+ */
+export function validateImportOpts(flags: RawImportFlags): ImportOptions {
+  const sources = [flags.fromFactory && 'factory', flags.fromLinear && 'linear'].filter(Boolean) as ('factory' | 'linear')[];
+  if (sources.length === 0) throw new Error('Pick an import source: --from-linear or --from-factory.');
+  if (sources.length > 1) throw new Error('--from-linear and --from-factory are mutually exclusive — pick one.');
+  const source = sources[0];
+  if (source === 'linear' && (flags.all || flags.minConfidence !== undefined)) {
+    throw new Error('--all and --min-confidence apply to --from-factory only (Linear rows carry no confidence).');
+  }
+  if (flags.all && flags.minConfidence !== undefined) {
+    throw new Error('--all and --min-confidence are mutually exclusive (--all means --min-confidence low).');
+  }
+  let minConfidence: ImportFloor = 'high';
+  if (flags.all) minConfidence = 'any';
+  else if (flags.minConfidence !== undefined) {
+    const v = flags.minConfidence.trim().toLowerCase();
+    if (v !== 'low' && v !== 'medium' && v !== 'high') {
+      throw new Error(`Invalid --min-confidence "${flags.minConfidence}" (expected low, medium, or high).`);
+    }
+    minConfidence = v;
+  }
+  return { source, minConfidence, force: flags.force === true };
+}
+
+/**
+ * Plan the Factory import: same field mapping as before (`path`→`root`,
+ * `repoSlug`→`repo`, `linearProjectId`→`linear.projectId`), now gated on the
+ * row's `confidence`. A row with no confidence field is a guess with no stated
+ * strength, so it ranks below every floor and only `--all` takes it.
+ */
+export function buildFactoryImportCandidates(
+  rows: unknown[],
+  existing: Map<string, ProjectDef>,
+  opts: Pick<ImportOptions, 'minConfidence' | 'force'>,
+): ImportPlan {
+  const floor = CONFIDENCE_RANK[opts.minConfidence];
+  const defs: ProjectDef[] = [];
+  const skipped: ImportSkip[] = [];
+  for (const raw of rows) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const o = raw as Record<string, unknown>;
+    const name = typeof o.name === 'string' ? o.name : undefined;
+    if (!name || !isSafeProjectName(name)) {
+      skipped.push({ name: name || '(unnamed)', reason: 'not a usable project name' });
+      continue;
+    }
+    const rank = confidenceRank(o.confidence);
+    if (rank < floor) {
+      const stated = typeof o.confidence === 'string' && o.confidence ? `confidence "${o.confidence}"` : 'no confidence field';
+      skipped.push({ name, reason: `${stated} is below the "${opts.minConfidence}" floor` });
+      continue;
+    }
+    if (existing.has(name) && !opts.force) {
+      skipped.push({ name, reason: 'already defined — pass --force to overwrite' });
+      continue;
+    }
+    const def: ProjectDef = { name };
+    if (typeof o.path === 'string') def.root = toHomeRelative(o.path);
+    if (typeof o.repoSlug === 'string') def.repo = o.repoSlug;
+    if (typeof o.linearProjectId === 'string') def.linear = { projectId: o.linearProjectId };
+    defs.push(def);
+  }
+  return { defs, skipped };
+}
+
+/**
+ * Turn a Linear project name into a definition slug: lowercase, every run of
+ * unusable characters collapsed to one `-`, trimmed of leading/trailing
+ * punctuation, capped at the 64 chars `isSafeProjectName` allows. Returns `''`
+ * when nothing usable survives — the caller skips those loudly.
+ */
+export function slugifyProjectName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[-._]+|[-._]+$/g, '')
+    .slice(0, 64)
+    .replace(/[-._]+$/g, '');
+  return isSafeProjectName(slug) ? slug : '';
+}
+
+/** The local-checkout lookups the Linear builder needs, injected so it stays pure. */
+export interface LinearImportDeps {
+  /** Directory names directly under the configured projects root. */
+  localDirs: string[];
+  /** Home-relative root path for one of `localDirs`. */
+  resolveRoot: (dir: string) => string | undefined;
+  /** `owner/repo` from that checkout's origin remote, when it has one. */
+  resolveOrigin: (dir: string) => string | undefined;
+}
+
+/**
+ * Plan the Linear import. Every project becomes a def carrying its `linear`
+ * link; the local checkout is bound **only on an exact normalized-name match**
+ * (`matchLocalCheckoutExact`). The containment fallback that powers the `link`
+ * suggestion is deliberately not used here — "Agents CLI" containing
+ * "agents-cli-web" is a fine hint for a human to confirm, and a silently wrong
+ * `root` on a write path.
+ *
+ * An existing def is preserved field-for-field; only `name` and `linear` are
+ * overwritten, so a hand-set `description`/`contexts`/`integrations` survives a
+ * re-import.
+ */
+export function buildLinearImportCandidates(
+  projects: LinearProjectLite[],
+  existing: Map<string, ProjectDef>,
+  deps: LinearImportDeps,
+  opts: Pick<ImportOptions, 'force'>,
+): ImportPlan {
+  const defs: ProjectDef[] = [];
+  const skipped: ImportSkip[] = [];
+  const seen = new Set<string>();
+  for (const p of projects) {
+    const name = slugifyProjectName(p.name);
+    if (!name) {
+      skipped.push({ name: p.name, reason: 'no usable project name (letters, digits, ., _, - only)' });
+      continue;
+    }
+    if (seen.has(name)) {
+      skipped.push({ name: p.name, reason: `another Linear project already claimed the name "${name}"` });
+      continue;
+    }
+    const prior = existing.get(name);
+    if (prior && (prior.root || prior.repo) && !opts.force) {
+      skipped.push({ name, reason: 'existing def already has root/repo — pass --force to relink' });
+      continue;
+    }
+    seen.add(name);
+    const def: ProjectDef = { ...prior, name, linear: { projectId: p.id } };
+    if (p.url) def.linear!.url = p.url;
+    const dir = matchLocalCheckoutExact(p.name, deps.localDirs);
+    if (dir) {
+      const root = deps.resolveRoot(dir);
+      if (root) def.root = root;
+      const repo = deps.resolveOrigin(dir);
+      if (repo) def.repo = repo;
+    }
+    defs.push(def);
+  }
+  return { defs, skipped };
+}

--- a/apps/cli/src/lib/project-import.ts
+++ b/apps/cli/src/lib/project-import.ts
@@ -110,6 +110,11 @@ export function buildFactoryImportCandidates(
   const floor = CONFIDENCE_RANK[opts.minConfidence];
   const defs: ProjectDef[] = [];
   const skipped: ImportSkip[] = [];
+  // The registry keys rows by `owner/repo` but names them by basename, so two
+  // repos with the same basename in different orgs (grinich/inflow, me/inflow)
+  // arrive as two rows called `inflow`. Without this the second silently
+  // overwrote the first on disk and the run still reported both as imported.
+  const seen = new Set<string>();
   for (const raw of rows) {
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
     const o = raw as Record<string, unknown>;
@@ -124,10 +129,15 @@ export function buildFactoryImportCandidates(
       skipped.push({ name, reason: `${stated} is below the "${opts.minConfidence}" floor` });
       continue;
     }
+    if (seen.has(name)) {
+      skipped.push({ name, reason: 'another row in this registry already claimed the name' });
+      continue;
+    }
     if (existing.has(name) && !opts.force) {
       skipped.push({ name, reason: 'already defined — pass --force to overwrite' });
       continue;
     }
+    seen.add(name);
     const def: ProjectDef = { name };
     if (typeof o.path === 'string') def.root = toHomeRelative(o.path);
     if (typeof o.repoSlug === 'string') def.repo = o.repoSlug;

--- a/apps/cli/tests/projects-import.test.ts
+++ b/apps/cli/tests/projects-import.test.ts
@@ -1,0 +1,144 @@
+/**
+ * End-to-end `agents projects import` — the real CLI, a real registry file on
+ * disk, real YAML written to a real directory. No mocks: the seams are
+ * `AGENTS_FACTORY_PROJECTS_PATH` (the source) and `AGENTS_PROJECTS_DIR` (the
+ * destination), plus a throwaway `HOME` carrying the beta opt-in.
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const tsxCli = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+const entrypoint = path.join(repoRoot, 'src', 'index.ts');
+
+let home: string;
+let projectsDir: string;
+let registry: string;
+
+/** The registry shape Factory writes, including the low-confidence guesses. */
+const REGISTRY = [
+  { id: 'me/agents-cli', name: 'agents-cli', path: '/tmp/src/agents-cli', repoSlug: 'me/agents-cli', confidence: 'high' },
+  { id: 'me/agents', name: 'agents', path: '/tmp/src/agents', repoSlug: 'me/agents', confidence: 'high' },
+  { id: 'me/swarmify', name: 'swarmify', path: '/tmp/src/swarmify', repoSlug: 'me/swarmify', confidence: 'medium' },
+  { id: 'other/inflow', name: 'inflow', path: '/tmp/src/inflow', repoSlug: 'other/inflow', confidence: 'low' },
+  // No `confidence` at all — an unranked guess, below every stated floor.
+  { id: 'me/stale', name: 'agents-cleaned-stale2', path: '/tmp/src/agents-cleaned-stale2' },
+];
+
+function runCli(args: string[]): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync('node', [tsxCli, entrypoint, ...args], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        NO_COLOR: '1',
+        AGENTS_SKIP_MIGRATION: '1',
+        AGENTS_PROJECTS_DIR: projectsDir,
+        AGENTS_FACTORY_PROJECTS_PATH: registry,
+      },
+    });
+    return { stdout, status: 0 };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: `${err.stdout ?? ''}${err.stderr ?? ''}`, status: err.status ?? 1 };
+  }
+}
+
+const defined = () =>
+  fs
+    .readdirSync(projectsDir)
+    .filter((f) => f.endsWith('.yaml'))
+    .map((f) => f.replace(/\.yaml$/, ''))
+    .sort();
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'projects-import-home-'));
+  projectsDir = path.join(home, 'projects');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+  // The beta opt-in this command tree is gated on, plus a populated config so
+  // the interactive first-run setup can never trigger.
+  fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\nbeta:\n  enabled:\n    - projects\n');
+  // ensureInitialized() gates every non-setup command on the system repo being a
+  // git checkout — seed it, or every run errors "agents-cli is not set up".
+  fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
+  registry = path.join(home, 'factory-projects.json');
+  fs.writeFileSync(registry, JSON.stringify(REGISTRY, null, 2));
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('agents projects import --from-factory', () => {
+  it('imports only high-confidence rows by default and names every skip', () => {
+    const { stdout, status } = runCli(['projects', 'import', '--from-factory']);
+    expect(status).toBe(0);
+    expect(defined()).toEqual(['agents', 'agents-cli']);
+    expect(stdout).toContain('Imported 2 projects (3 skipped)');
+    expect(stdout).toContain('skip swarmify: confidence "medium" is below the "high" floor');
+    expect(stdout).toContain('skip inflow: confidence "low" is below the "high" floor');
+    expect(stdout).toContain('skip agents-cleaned-stale2: no confidence field is below the "high" floor');
+  });
+
+  it('widens with --min-confidence medium', () => {
+    runCli(['projects', 'import', '--from-factory', '--min-confidence', 'medium']);
+    expect(defined()).toEqual(['agents', 'agents-cli', 'swarmify']);
+  });
+
+  it('takes every row under --all, including one with no confidence field', () => {
+    runCli(['projects', 'import', '--from-factory', '--all']);
+    expect(defined()).toEqual(['agents', 'agents-cleaned-stale2', 'agents-cli', 'inflow', 'swarmify']);
+  });
+
+  it('writes the mapped fields into the YAML', () => {
+    runCli(['projects', 'import', '--from-factory']);
+    const yaml = fs.readFileSync(path.join(projectsDir, 'agents-cli.yaml'), 'utf8');
+    expect(yaml).toContain('name: agents-cli');
+    expect(yaml).toContain('root: /tmp/src/agents-cli');
+    expect(yaml).toContain('repo: me/agents-cli');
+  });
+
+  it('is idempotent — a re-import skips what already exists', () => {
+    runCli(['projects', 'import', '--from-factory']);
+    const { stdout } = runCli(['projects', 'import', '--from-factory']);
+    expect(stdout).toContain('Imported 0 projects (5 skipped)');
+    expect(stdout).toContain('skip agents-cli: already defined — pass --force to overwrite');
+    expect(defined()).toEqual(['agents', 'agents-cli']);
+  });
+
+  it('rejects an unknown --min-confidence loudly, writing nothing', () => {
+    const { stdout, status } = runCli(['projects', 'import', '--from-factory', '--min-confidence', 'kinda']);
+    expect(status).toBe(1);
+    expect(stdout).toContain('Invalid --min-confidence "kinda"');
+    expect(defined()).toEqual([]);
+  });
+
+  it('requires a source, and refuses both at once', () => {
+    expect(runCli(['projects', 'import']).stdout).toContain('Pick an import source');
+    expect(runCli(['projects', 'import', '--from-factory', '--from-linear']).stdout)
+      .toContain('mutually exclusive');
+    expect(defined()).toEqual([]);
+  });
+
+  it('refuses confidence flags on the Linear source instead of ignoring them', () => {
+    const { stdout, status } = runCli(['projects', 'import', '--from-linear', '--all']);
+    expect(status).toBe(1);
+    expect(stdout).toContain('--from-factory only');
+    expect(defined()).toEqual([]);
+  });
+
+  it('fails loudly on a missing registry rather than reporting zero imports', () => {
+    fs.rmSync(registry);
+    const { stdout, status } = runCli(['projects', 'import', '--from-factory']);
+    expect(status).toBe(1);
+    expect(stdout).toContain('No Factory registry at');
+  });
+});

--- a/apps/cli/tests/projects-import.test.ts
+++ b/apps/cli/tests/projects-import.test.ts
@@ -18,6 +18,10 @@ const entrypoint = path.join(repoRoot, 'src', 'index.ts');
 let home: string;
 let projectsDir: string;
 let registry: string;
+/** Prepended to PATH so `listLinearProjects` spawns our stub `linear` binary. */
+let binDir: string;
+/** The configured projects root the Linear import scans for local checkouts. */
+let srcRoot: string;
 
 /** The registry shape Factory writes, including the low-confidence guesses. */
 const REGISTRY = [
@@ -38,6 +42,7 @@ function runCli(args: string[]): { stdout: string; status: number } {
         ...process.env,
         HOME: home,
         USERPROFILE: home,
+        PATH: `${binDir}:${process.env.PATH}`,
         NO_COLOR: '1',
         AGENTS_SKIP_MIGRATION: '1',
         AGENTS_PROJECTS_DIR: projectsDir,
@@ -58,14 +63,38 @@ const defined = () =>
     .map((f) => f.replace(/\.yaml$/, ''))
     .sort();
 
+/** A real git repo with a real origin remote, so `originSlug` reads a real remote. */
+function makeCheckout(name: string, slug: string): void {
+  const dir = path.join(srcRoot, name);
+  fs.mkdirSync(dir, { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['remote', 'add', 'origin', `git@github.com:${slug}.git`], { cwd: dir });
+}
+
+/** Install a real executable named `linear` that prints `projects` as JSON. */
+function stubLinearCli(projects: unknown[]): void {
+  const script = `#!/bin/sh\n[ "$1" = "projects" ] || exit 1\ncat <<'JSON'\n${JSON.stringify(projects, null, 2)}\nJSON\n`;
+  const p = path.join(binDir, 'linear');
+  fs.writeFileSync(p, script);
+  fs.chmodSync(p, 0o755);
+}
+
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'projects-import-home-'));
   projectsDir = path.join(home, 'projects');
+  binDir = path.join(home, 'bin');
+  srcRoot = path.join(home, 'src');
   fs.mkdirSync(projectsDir, { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(srcRoot, { recursive: true });
   fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
-  // The beta opt-in this command tree is gated on, plus a populated config so
-  // the interactive first-run setup can never trigger.
-  fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\nbeta:\n  enabled:\n    - projects\n');
+  // The beta opt-in this command tree is gated on, a projects root for the
+  // Linear import to scan, plus a populated config so the interactive first-run
+  // setup can never trigger.
+  fs.writeFileSync(
+    path.join(home, '.agents', 'agents.yaml'),
+    `agents: {}\nprojectRoot: ${srcRoot}\nbeta:\n  enabled:\n    - projects\n`,
+  );
   // ensureInitialized() gates every non-setup command on the system repo being a
   // git checkout — seed it, or every run errors "agents-cli is not set up".
   fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
@@ -140,5 +169,61 @@ describe('agents projects import --from-factory', () => {
     const { stdout, status } = runCli(['projects', 'import', '--from-factory']);
     expect(status).toBe(1);
     expect(stdout).toContain('No Factory registry at');
+  });
+});
+
+describe('agents projects import --from-linear', () => {
+  /** Read a written def back off disk (the YAML is the contract, not a return value). */
+  const def = (name: string) => fs.readFileSync(path.join(projectsDir, `${name}.yaml`), 'utf8');
+
+  it('binds an exact local checkout and leaves the rest to name + link', () => {
+    makeCheckout('agents-cli', 'muqsitnawaz/agents-cli');
+    makeCheckout('web', 'someone/web');
+    stubLinearCli([
+      { id: 'lin_1', name: 'Agents CLI', url: 'https://linear.app/w/project/agents-cli' },
+      { id: 'lin_2', name: 'Marketing Site' },
+      // A slash in a DISPLAY name is punctuation. Keying it as a path would
+      // bind the unrelated `web/` checkout above — the bug this pins.
+      { id: 'lin_3', name: 'Rush / Web' },
+    ]);
+    const { stdout, status } = runCli(['projects', 'import', '--from-linear']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('Imported 3 projects');
+    expect(defined()).toEqual(['agents-cli', 'marketing-site', 'rush-web']);
+
+    // Stored home-relative so the def re-roots on any machine (toHomeRelative).
+    expect(def('agents-cli')).toContain('root: ~/src/agents-cli');
+    expect(def('agents-cli')).toContain('repo: muqsitnawaz/agents-cli');
+    expect(def('agents-cli')).toContain('projectId: lin_1');
+    expect(def('agents-cli')).toContain('url: https://linear.app/w/project/agents-cli');
+
+    for (const unbound of ['marketing-site', 'rush-web']) {
+      expect(def(unbound)).not.toContain('root:');
+      expect(def(unbound)).not.toContain('repo:');
+    }
+    expect(def('rush-web')).toContain('projectId: lin_3');
+  });
+
+  it('preserves hand-set fields and refuses to relink a bound def without --force', () => {
+    makeCheckout('agents-cli', 'muqsitnawaz/agents-cli');
+    stubLinearCli([{ id: 'lin_1', name: 'Agents CLI' }]);
+    runCli(['projects', 'import', '--from-linear']);
+    fs.appendFileSync(path.join(projectsDir, 'agents-cli.yaml'), 'description: the CLI\n');
+
+    const { stdout } = runCli(['projects', 'import', '--from-linear']);
+    expect(stdout).toContain('skip agents-cli: existing def already has root/repo — pass --force to relink');
+    expect(def('agents-cli')).toContain('description: the CLI');
+
+    stubLinearCli([{ id: 'lin_9', name: 'Agents CLI' }]);
+    runCli(['projects', 'import', '--from-linear', '--force']);
+    expect(def('agents-cli')).toContain('projectId: lin_9');
+    expect(def('agents-cli')).toContain('description: the CLI');
+  });
+
+  it('fails loudly when the linear CLI is missing, writing nothing', () => {
+    const { stdout, status } = runCli(['projects', 'import', '--from-linear']);
+    expect(status).toBe(1);
+    expect(stdout).toContain('is the `linear` CLI installed and logged in?');
+    expect(defined()).toEqual([]);
   });
 });


### PR DESCRIPTION
**What + type:** feature — `agents projects import` gains Linear as a source and stops absorbing the Factory registry's low-confidence guesses; `projects list` columns line up again.

Reported from real use: *"it's showing a lot of unnecessary projects while I just want to focus on the agents CLI and the agents project — and it's also considering some of the work for it as projects as well."* Twelve definitions existed; two were real.

## The run (real data, real registry)

`import --from-factory` on the actual `~/.agents/factory/projects.json`, then widened with `--all` — and the `list` alignment fix in the same frame:

<img width="4140" height="2684" alt="agents projects import --from-factory, then --all, with aligned list columns" src="https://github.com/user-attachments/assets/6957f1f5-f09e-4983-9917-ec64604001ce" />

`import --from-linear` against the live `linear` CLI — exact name match bound `agents-cli`/`linear-cli` to their checkouts, the rest imported name + link only, and a re-import is idempotent:

<img width="3674" height="1944" alt="agents projects import --from-linear against the live linear CLI" src="https://github.com/user-attachments/assets/eb4baf18-d6e4-4b21-bf92-2c9aed6f01d1" />

## What changed

| Area | Before | After |
| --- | --- | --- |
| `import` source | `--from-factory` only (a `requiredOption`) | `--from-linear` **or** `--from-factory`, exactly one |
| Factory rows | every row written, `confidence` ignored | `high` only by default; `--min-confidence low\|medium\|high`, `--all` |
| Declined rows | silent `(N skipped)` | one `skip <name>: <reason>` line each |
| Linear | link only via `projects link <name>` | whole workspace importable; checkout bound on **exact** name match only |
| `list` columns | path padded to a fixed 32 | widths computed from the rows, path capped at 48 |

**The exact-match rule is the safety-relevant bit.** `matchLinearProject`'s containment fallback (`lib/linear-projects.ts`) returns the first loose match — fine for suggesting a link a human then confirms, unsafe on a write path where "Agents CLI" would silently bind `agents-cli-web`. `--from-linear` uses the new `matchLocalCheckoutExact`, which requires normalized-key equality and returns nothing when two dirs are ambiguous. A project with no exact match still imports, carrying `name` + `linear` and nothing it cannot prove.

An existing def is preserved field-for-field on re-import — only `linear` is overwritten, so a hand-set `description`/`contexts`/`integrations` survives — and a def already carrying `root`/`repo` is skipped unless `--force`.

## Tests

New pure builders sit in `lib/project-import.ts` with no fs, shell, or env, so they test against plain fixtures with no mocking: `src/lib/project-import.test.ts` (23 cases — floors, missing-confidence rows, slug collisions, containment refusal, field preservation, idempotent re-import). `tests/projects-import.test.ts` drives the **real CLI** end-to-end against a real registry file on disk via the new `AGENTS_FACTORY_PROJECTS_PATH` seam (9 cases, including the loud failures). `src/commands/projects.test.ts` pins the column widths so a bleeding gridline fails a test.

```
Test Files  5 passed (5)
     Tests  71 passed (71)
```

One of those tests caught a real bug during the build: `--all` documented "every row regardless of confidence" but an unranked row still fell below the `low` floor. Fixed at the source with a distinct `any` floor rather than by relaxing the test.

## Docs + CHANGELOG

`docs/11-projects.md` gains an *Importing — Linear first, Factory gated* section and updated command-table rows; changelog fragment at `.changelog/next/projects-import-linear-confidence.md` (`CHANGELOG.md` is generated — not hand-edited).

Plan: https://claude.ai/code/artifact/4b3f3738-df4c-40d2-9327-ce9efa92f6cf (stored-vs-computed schema reference from the design pass).

<sub>Session transcript is confidential and this repo is public — it is not attached. Local path for a teammate on the fleet: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
