### PR TITLE
fix(menubar): bound, group-kill and reap CLI children so a helper crash can't melt the machine

### DIFF
--- a/apps/cli/.changelog/next/menubar-child-process-orphan-storm.md
+++ b/apps/cli/.changelog/next/menubar-child-process-orphan-storm.md
@@ -1,0 +1,24 @@
+- **The menu-bar helper can no longer leak CLI processes until the machine is unusable.**
+  Its poll shelled `agents doctor --json` through an unbounded `Process` +
+  `readDataToEndOfFile()`. Two properties composed badly: the call had no deadline
+  (`doctor --json` measures **136s on an idle box**, against a 60s poll interval), and a
+  helper that died mid-call left the child reparented to launchd (PPID 1) with nothing
+  to reap it — along with the `node -e` version probes that child had forked. Both fire
+  together, because the helper crashes under exactly the conditions that make the CLI
+  slow: `NSApplication.shared` segfaults inside `SLSNewConnection` when WindowServer is
+  too starved to hand out a connection, launchd's `KeepAlive` restarts it, and the
+  restart spawns a new doctor while the old one keeps burning a core. Observed on a real
+  machine: 38 orphaned doctors + 92 orphaned probes, ~13 of 18 cores consumed, load
+  average 490, keystrokes visibly lagging.
+  The crash itself cannot be prevented from inside the app — it is AppKit dereferencing
+  a null connection before any of our code runs — so a crash no longer costs anything
+  permanent: every child carries a deadline (30s; 180s for `doctor --json`, above its
+  real measured cost); it is spawned as its own process-group leader so a timeout kills
+  the whole subtree rather than just the CLI; and each live child is recorded on disk so
+  the *next* launch reaps whatever a crash abandoned (no exit handler runs on SIGSEGV).
+  The doctor refresh also drops from every 60s to every 15 minutes, and the launchd job
+  gains `ThrottleInterval` 30 so a startup crash-loop cannot respawn every 10s.
+  A poll that blows its deadline now shows a stale menu instead of taking the machine
+  down with it. Source: `apps/cli/menubar/Sources/MenubarHelper/ChildProcess.swift`,
+  `AgentsCLI.swift`, `StatusItemController.swift`, `main.swift`,
+  `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -503,6 +503,39 @@ healthy `running: yes`. `agents menubar setup` is the recovery path — it ends
 every live helper and re-kickstarts the service so the survivor is always
 launchd's.
 
+**Every CLI child the helper spawns is bounded, group-killable, and reapable.**
+The helper shells `agents` on a timer, and an unbounded `Process` there is not a
+slow menu — it is a machine-killer. `doctor --json` measures **136s on an idle
+box**, the poll asked for it every 60s, and a helper that dies mid-call leaves the
+child reparented to launchd with nothing to reap it (plus the `node -e` probes
+that child forked). The deaths are not preventable from inside the app:
+`NSApplication.shared` segfaults in `SLSNewConnection` when WindowServer is too
+starved to hand out a connection, and `KeepAlive` restarts into another doctor.
+Observed: 38 orphaned doctors + 92 orphaned probes, ~13 of 18 cores, load 490.
+So [`ChildProcess.swift`](menubar/Sources/MenubarHelper/ChildProcess.swift) holds
+three invariants, and a new CLI call MUST go through it rather than `Process`:
+
+- **Bounded.** Every spawn carries a deadline (30s; `ChildProcess.doctorTimeout`
+  180s for `doctor --json`, above its real measured cost — a ceiling set *below*
+  the true cost just makes every poll fail while still paying full CPU).
+- **Killed as a group.** The child is spawned as its own process-group leader
+  (`POSIX_SPAWN_SETPGROUP`) so a timeout `kill(-pgid)`s the subtree. Signalling
+  the pid alone is what left 92 probes running. Foundation's `Process` cannot set
+  a process group — that is why this is `posix_spawn` and not `Process`.
+- **Reaped by the NEXT launch.** Live children are recorded in
+  `~/.agents/.cache/state/menubar-children`; `reapOrphansFromPreviousLaunch()`
+  runs in `main.swift` **before** the first AppKit call, since the crash being
+  recovered from happens *inside* that call. Do NOT move it after, and do NOT
+  replace it with an exit handler — SIGSEGV runs none. Pid reuse is guarded by
+  re-checking the executable path (`proc_pidpath`) before killing.
+
+Poll intervals must stay well above the call's real cost:
+`StatusItemController.doctorRefreshInterval` is 15 min against a 136s command
+(it was 60s — a >100% duty cycle). `MENUBAR_CHILD_TEST=1 MenubarHelper` exercises
+all of it against real processes, including reaping a real surviving orphan.
+Separately, **`doctor --json` taking 136s on an idle machine is its own defect**
+— the helper is now safe against it, not a reason to consider it acceptable.
+
 **Standalone `agents` binary (#315).** Every release also builds `dist/bin/agents`
 (`bun build --compile`, arm64 Mach-O), signs it (Developer ID + hardened runtime +
 the JIT entitlement in `scripts/bun-jit-entitlements.plist` — bun's JavaScriptCore

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -512,8 +512,25 @@ that child forked). The deaths are not preventable from inside the app:
 `NSApplication.shared` segfaults in `SLSNewConnection` when WindowServer is too
 starved to hand out a connection, and `KeepAlive` restarts into another doctor.
 Observed: 38 orphaned doctors + 92 orphaned probes, ~13 of 18 cores, load 490.
-So [`ChildProcess.swift`](menubar/Sources/MenubarHelper/ChildProcess.swift) holds
-three invariants, and a new CLI call MUST go through it rather than `Process`:
+**The property that made this fatal is accumulation, so the rule is scoped to
+what accumulates: every TIMER-DRIVEN, repeating CLI call MUST go through
+[`ChildProcess`](menubar/Sources/MenubarHelper/ChildProcess.swift)** — that is the
+`capture()` path behind the cached refreshers (`routines`, `recentSessions`,
+`activeSessions`, `doctorOverview`, `watchdog`). A poller is the only thing that
+can stack 38 copies of itself.
+
+**User-initiated one-shots deliberately do NOT** — `runDetached`,
+`runMonitored`, and `runMonitoredWithInput` keep a bare `Process` on purpose,
+because every one of their callers is a menu click (`routines run/pause`,
+`devices register`, `open <url>`, and the ticket-agent / quick-fix dispatches).
+Two reasons, and both would be violated by "bound everything": a deadline there
+would **kill the user's headless `agents run` mid-work**, and a fire-and-forget
+`open`/dispatch is *supposed* to outlive the helper. One click cannot stack, so
+there is nothing to accumulate. Do not "fix" these by routing them through
+`ChildProcess` — if a future caller makes one of them repeating, that caller is
+the bug.
+
+`ChildProcess` holds three invariants:
 
 - **Bounded.** Every spawn carries a deadline (30s; `ChildProcess.doctorTimeout`
   180s for `doctor --json`, above its real measured cost — a ceiling set *below*

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,27 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **Menu-bar helper can no longer leak CLI processes until the machine is unusable.**
-  Its 10s poll shelled `agents doctor --json` through an unbounded `Process` +
-  `readDataToEndOfFile()`. Two properties composed badly: the call had no deadline, and
-  a helper that died mid-call left the child reparented to launchd (PPID 1) with
-  nothing to reap it — along with the `node -e` version probes that child had forked.
-  Both fire together, because the helper crashes under exactly the conditions that make
-  the CLI slow: `NSApplication.shared` segfaults inside `SLSNewConnection` when
-  WindowServer is too starved to hand out a connection, launchd's `KeepAlive` restarts
-  it, and the restart spawns a new doctor while the old one keeps running. Observed on a
-  real machine: 38 orphaned doctors + 92 orphaned probes, ~13 of 18 cores consumed, load
-  average 490, keystrokes visibly lagging. Three changes close it — every child now
-  carries a deadline (30s, 45s for `doctor --json`); it is spawned as its own
-  process-group leader so a timeout kills the whole subtree rather than just the CLI;
-  and each live child is recorded on disk so the *next* launch reaps whatever a crash
-  abandoned (no exit handler can help when the death is SIGSEGV). The launchd job also
-  gains `ThrottleInterval` 30 so a startup crash-loop cannot respawn every 10s.
-  A poll that blows its deadline now shows a stale menu instead of taking the machine
-  down with it. Source: `apps/cli/menubar/Sources/MenubarHelper/ChildProcess.swift`,
-  `AgentsCLI.swift`, `main.swift`, `apps/cli/src/lib/menubar/install-menubar.ts`.
-
 ## 1.20.93
 
 - **`agents send` is a real delivery envelope; `notify` is just `--to owner` (RUSH-2123).** Flag-first form: `--to`, `--text`, `--channel`, `--attach`, `--url`. `--to owner` expands from `notify.owner` in agents.yaml. Positional text still works. Help names the three planes (deliver / record / control) so send is not confused with `feed post`, `activity`, or `message`/`sessions inject`. Source: `apps/cli/src/commands/send.ts`, `apps/cli/src/lib/channels/send.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+- **Menu-bar helper can no longer leak CLI processes until the machine is unusable.**
+  Its 10s poll shelled `agents doctor --json` through an unbounded `Process` +
+  `readDataToEndOfFile()`. Two properties composed badly: the call had no deadline, and
+  a helper that died mid-call left the child reparented to launchd (PPID 1) with
+  nothing to reap it — along with the `node -e` version probes that child had forked.
+  Both fire together, because the helper crashes under exactly the conditions that make
+  the CLI slow: `NSApplication.shared` segfaults inside `SLSNewConnection` when
+  WindowServer is too starved to hand out a connection, launchd's `KeepAlive` restarts
+  it, and the restart spawns a new doctor while the old one keeps running. Observed on a
+  real machine: 38 orphaned doctors + 92 orphaned probes, ~13 of 18 cores consumed, load
+  average 490, keystrokes visibly lagging. Three changes close it — every child now
+  carries a deadline (30s, 45s for `doctor --json`); it is spawned as its own
+  process-group leader so a timeout kills the whole subtree rather than just the CLI;
+  and each live child is recorded on disk so the *next* launch reaps whatever a crash
+  abandoned (no exit handler can help when the death is SIGSEGV). The launchd job also
+  gains `ThrottleInterval` 30 so a startup crash-loop cannot respawn every 10s.
+  A poll that blows its deadline now shows a stale menu instead of taking the machine
+  down with it. Source: `apps/cli/menubar/Sources/MenubarHelper/ChildProcess.swift`,
+  `AgentsCLI.swift`, `main.swift`, `apps/cli/src/lib/menubar/install-menubar.ts`.
+
 ## 1.20.93
 
 - **`agents send` is a real delivery envelope; `notify` is just `--to owner` (RUSH-2123).** Flag-first form: `--to`, `--text`, `--channel`, `--attach`, `--url`. `--to owner` expands from `notify.owner` in agents.yaml. Positional text still works. Help names the three planes (deliver / record / control) so send is not confused with `feed post`, `activity`, or `message`/`sessions inject`. Source: `apps/cli/src/commands/send.ts`, `apps/cli/src/lib/channels/send.ts`.

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -86,8 +86,12 @@ enum AgentsCLI {
         return (try? JSONDecoder().decode([ActiveSession].self, from: data)) ?? []
     }
 
+    // The heaviest call the helper makes: `doctor --json` probes every installed
+    // version of every harness with its own subprocess. Seconds on a healthy box,
+    // so it gets the longest deadline — but it does get one. An unbounded doctor
+    // is what consumed 13 of 18 cores on a real machine.
     static func doctorOverview() -> DoctorOverview? {
-        guard let data = capture(argv(["doctor", "--json"])) else { return nil }
+        guard let data = capture(argv(["doctor", "--json"]), timeout: ChildProcess.doctorTimeout) else { return nil }
         return try? JSONDecoder().decode(DoctorOverview.self, from: data)
     }
 
@@ -661,21 +665,16 @@ enum AgentsCLI {
     }
 
     // MARK: Process helpers
-    private static func capture(_ argv: [String]) -> Data? {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: argv[0])
-        p.arguments = Array(argv.dropFirst())
-        let out = Pipe()
-        p.standardOutput = out
-        p.standardError = FileHandle.nullDevice
-        do {
-            try p.run()
-        } catch {
-            return nil
-        }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        p.waitUntilExit()
-        return p.terminationStatus == 0 ? data : nil
+
+    // Every synchronous CLI call is bounded and group-killable. This used to be a
+    // bare `Process` + `readDataToEndOfFile()`, which waits forever and leaves the
+    // child (and the child's own subprocesses) orphaned at PPID 1 whenever the
+    // helper dies mid-call. Under launchd KeepAlive that compounds: each crash
+    // restart spawns a new call while the previous one keeps running, and the
+    // orphans accumulate until the machine is unusable. See ChildProcess.swift for
+    // the full failure mode and the three invariants that close it.
+    private static func capture(_ argv: [String], timeout: TimeInterval = ChildProcess.defaultTimeout) -> Data? {
+        ChildProcess.run(argv, timeout: timeout)
     }
 
     private static func runDetached(_ argv: [String]) {

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -666,17 +666,40 @@ enum AgentsCLI {
 
     // MARK: Process helpers
 
-    // Every synchronous CLI call is bounded and group-killable. This used to be a
-    // bare `Process` + `readDataToEndOfFile()`, which waits forever and leaves the
-    // child (and the child's own subprocesses) orphaned at PPID 1 whenever the
-    // helper dies mid-call. Under launchd KeepAlive that compounds: each crash
-    // restart spawns a new call while the previous one keeps running, and the
-    // orphans accumulate until the machine is unusable. See ChildProcess.swift for
-    // the full failure mode and the three invariants that close it.
+    // The TIMER-DRIVEN path: bounded, group-killable, reapable. Everything the
+    // cached refreshers poll goes through here, and it must, because a poller is
+    // the only caller that can stack copies of itself.
+    //
+    // This used to be a bare `Process` + `readDataToEndOfFile()`, which waits
+    // forever and leaves the child (and the child's own subprocesses) orphaned at
+    // PPID 1 whenever the helper dies mid-call. Under launchd KeepAlive that
+    // compounds: each crash restart spawns a new call while the previous one keeps
+    // running, and the orphans accumulate until the machine is unusable. See
+    // ChildProcess.swift for the full failure mode and the invariants that close
+    // it.
+    //
+    // The one-shot spawn helpers below (runDetached / runMonitored /
+    // runMonitoredWithInput) deliberately stay on bare `Process` — see the note
+    // above runDetached for why bounding them would be a bug, not a fix.
     private static func capture(_ argv: [String], timeout: TimeInterval = ChildProcess.defaultTimeout) -> Data? {
         ChildProcess.run(argv, timeout: timeout)
     }
 
+    // NOT routed through ChildProcess, and that is deliberate — do not "fix" it.
+    //
+    // ChildProcess exists to stop ACCUMULATION: a 10s timer that respawns work
+    // faster than it completes is what stacked 38 orphaned doctors. Every caller
+    // below is a user-initiated one-shot instead — a menu click (`routines
+    // run/pause`, `devices register`, `open <url>`) or a ticket-agent / quick-fix
+    // dispatch. One click cannot stack, so there is nothing to accumulate.
+    //
+    // Applying the timer-path invariants here would be actively wrong on both
+    // counts: a deadline would kill the user's headless `agents run` mid-work,
+    // and a fire-and-forget `open`/dispatch is SUPPOSED to outlive this helper —
+    // reaping it on the next launch would destroy work the user asked for.
+    //
+    // If a future caller ever makes one of these repeating, that caller is the
+    // bug; move it to `capture()` rather than bounding these.
     private static func runDetached(_ argv: [String]) {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: argv[0])

--- a/apps/cli/menubar/Sources/MenubarHelper/ChildProcess.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/ChildProcess.swift
@@ -89,23 +89,36 @@ enum ChildProcess {
         // Drain on a background thread so the deadline is enforceable. Draining
         // WHILE the child runs also keeps a child that outputs more than the
         // ~64 KiB pipe buffer from blocking on write forever.
+        //
+        // The reader OWNS readFD and closes it itself. That ownership is what
+        // lets the abandon path below be safe: closing a descriptor out from
+        // under a thread blocked in read(2) races that fd's reuse by any other
+        // thread, so the only correct way to walk away from a stuck reader is to
+        // leave the descriptor with it.
         var output = Data()
         let drained = DispatchSemaphore(value: 0)
         DispatchQueue.global(qos: .utility).async {
             output = readToEnd(readFD)
+            close(readFD)
             drained.signal()
         }
 
         var timedOut = false
         if drained.wait(timeout: .now() + timeout) == .timedOut {
             timedOut = true
-            // Kill the GROUP: the CLI plus every probe it forked. Closing their
-            // stdout is what releases the reader thread below.
+            // Kill the GROUP: the CLI plus every probe it forked. Every write end
+            // of the pipe closes as those processes die, which is what releases
+            // the reader.
             terminateGroup(pid)
-            drained.wait()
+            // Bounded, because this whole type exists to abolish unbounded waits
+            // — including its own. SIGKILL cannot be caught, so EOF must follow;
+            // if it somehow does not, abandon the reader (it owns its fd) and
+            // reap off-thread rather than hanging the caller's queue forever.
+            if drained.wait(timeout: .now() + 5) == .timedOut {
+                reapDetached(pid)
+                return nil
+            }
         }
-
-        close(readFD)
 
         // Always reap, even on timeout, so a killed child never lingers as a
         // zombie occupying a pid slot.
@@ -117,6 +130,15 @@ enum ChildProcess {
         let code = (status >> 8) & 0xFF
         guard exited, code == 0 else { return nil }
         return output
+    }
+
+    /// Reap a child we have stopped waiting on, without blocking the caller.
+    /// Skipping the reap entirely would leave a zombie holding its pid slot.
+    private static func reapDetached(_ pid: pid_t) {
+        DispatchQueue.global(qos: .utility).async {
+            var status: Int32 = 0
+            while waitpid(pid, &status, 0) == -1 && errno == EINTR {}
+        }
     }
 
     /// posix_spawn with the child as its own process-group leader.
@@ -191,7 +213,13 @@ enum ChildProcess {
     @discardableResult
     static func reapOrphansFromPreviousLaunch(file: String = Registry.path()) -> Int {
         let stale = Registry.readAll(file: file)
-        Registry.clear(file: file)
+        // Kill FIRST, clear after. Clearing first means a helper that dies part
+        // way through this sweep (entirely possible — the crash it is recovering
+        // from happens moments later, in the first AppKit call) has already
+        // erased the only record of the survivors, stranding them forever. In
+        // this order a death mid-sweep just leaves the record for the next launch
+        // to retry, and re-killing is harmless: the pid+path guard below refuses
+        // anything that is not still the process we spawned.
         var reaped = 0
         for entry in stale where entry.pid != getpid() {
             // Guard against pid reuse: the slot may now hold something else
@@ -201,6 +229,7 @@ enum ChildProcess {
             terminateGroup(entry.pid)
             reaped += 1
         }
+        Registry.clear(file: file)
         return reaped
     }
 

--- a/apps/cli/menubar/Sources/MenubarHelper/ChildProcess.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/ChildProcess.swift
@@ -1,0 +1,283 @@
+import Darwin
+import Foundation
+
+// Bounded, reapable child processes for the menu-bar helper.
+//
+// The helper shells the `agents` CLI on a 10s timer. Every one of those calls
+// used to run through a bare `Process` + `readDataToEndOfFile()`, which has two
+// properties that compose into a machine-killing runaway:
+//
+//   1. No deadline. `agents doctor --json` probes every installed version of
+//      every harness with a `node -e` subprocess each. On a busy box that goes
+//      from ~2s to over 12 MINUTES, and the call simply waits.
+//   2. No ownership after the parent dies. A helper killed mid-call leaves the
+//      child reparented to launchd (PPID 1) with nothing to reap it, and the
+//      child's own `node -e` probes leak the same way.
+//
+// Both fire together because the helper crashes under exactly the conditions
+// that make the CLI slow. `NSApplication.sharedApplication` segfaults in
+// `SLSNewConnection` when WindowServer is too starved to hand out a connection
+// (EXC_BAD_ACCESS at 0x10 — AppKit dereferencing the null connection it just
+// failed to get), launchd's `KeepAlive` restarts the helper, and the restart
+// spawns a fresh doctor while the previous one keeps burning a core forever.
+// Measured on a real machine: 38 orphaned doctors plus 92 orphaned `node -e`
+// probes, ~13 of 18 cores consumed, load average 490. The slower the box got,
+// the more it crashed, and every crash added another permanent orphan.
+//
+// So a child of this helper must satisfy three invariants:
+//
+//   * **It is bounded.** Every spawn carries a deadline; past it the child is
+//     terminated. A doctor that takes minutes is broken, and a stale menu is
+//     strictly better than an unresponsive machine.
+//   * **It dies as a group.** The child is spawned as its own process-group
+//     leader (`POSIX_SPAWN_SETPGROUP`), so `kill(-pgid)` takes its whole
+//     subtree — the CLI *and* the `node -e` probes it forked. Signalling just
+//     the pid is what let the 92 probes survive their own parent.
+//   * **It cannot outlive the helper.** No exit handler can be trusted here:
+//     the observed death is SIGSEGV, where nothing of ours runs. Instead each
+//     live child is recorded on disk and the NEXT launch reaps whatever the
+//     previous one left behind. Self-healing beats cleanup that a crash skips.
+enum ChildProcess {
+    /// Deadline for a routine CLI call. Every menu-bar refresher is a cache
+    /// warmer — missing one poll costs a stale menu for 10s, while an unbounded
+    /// one costs a core until reboot.
+    static let defaultTimeout: TimeInterval = 30
+
+    /// `doctor --json` probes every installed version of every harness, and it is
+    /// genuinely expensive: measured at **136s** on an idle machine (load ~11,
+    /// 169 KB of JSON), not the couple of seconds one might assume.
+    ///
+    /// The ceiling has to clear that real cost, or the deadline fires on every
+    /// single poll and the menu's System row reads "unavailable" forever while
+    /// still paying full CPU for a result that is always discarded — a timeout
+    /// tuned low enough to look tidy would just hide the command's true cost.
+    /// 180s clears the measurement with headroom and is still decisive about
+    /// wedged. See also `StatusItemController.doctorRefreshInterval`, which must
+    /// stay well above this number.
+    static let doctorTimeout: TimeInterval = 180
+
+    // MARK: - Spawn
+
+    /// Run `argv` to completion and return its stdout, or nil if it failed,
+    /// could not start, or blew the deadline.
+    ///
+    /// stderr goes to /dev/null: callers here parse JSON and must never get
+    /// diagnostics interleaved into the payload.
+    static func run(_ argv: [String], timeout: TimeInterval = defaultTimeout) -> Data? {
+        guard !argv.isEmpty else { return nil }
+
+        var fds: [Int32] = [-1, -1]
+        guard pipe(&fds) == 0 else { return nil }
+        let readFD = fds[0]
+        let writeFD = fds[1]
+
+        guard let pid = spawn(argv, stdout: writeFD, closeInChild: readFD) else {
+            close(readFD)
+            close(writeFD)
+            return nil
+        }
+
+        // The parent MUST drop its copy of the write end, or the read below
+        // never sees EOF even after the child exits — the classic pipe hang.
+        close(writeFD)
+
+        Registry.register(pid: pid, path: argv[0])
+        defer {
+            Registry.deregister(pid: pid)
+        }
+
+        // Drain on a background thread so the deadline is enforceable. Draining
+        // WHILE the child runs also keeps a child that outputs more than the
+        // ~64 KiB pipe buffer from blocking on write forever.
+        var output = Data()
+        let drained = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async {
+            output = readToEnd(readFD)
+            drained.signal()
+        }
+
+        var timedOut = false
+        if drained.wait(timeout: .now() + timeout) == .timedOut {
+            timedOut = true
+            // Kill the GROUP: the CLI plus every probe it forked. Closing their
+            // stdout is what releases the reader thread below.
+            terminateGroup(pid)
+            drained.wait()
+        }
+
+        close(readFD)
+
+        // Always reap, even on timeout, so a killed child never lingers as a
+        // zombie occupying a pid slot.
+        var status: Int32 = 0
+        while waitpid(pid, &status, 0) == -1 && errno == EINTR {}
+
+        if timedOut { return nil }
+        let exited = (status & 0x7F) == 0
+        let code = (status >> 8) & 0xFF
+        guard exited, code == 0 else { return nil }
+        return output
+    }
+
+    /// posix_spawn with the child as its own process-group leader.
+    ///
+    /// Foundation's `Process` exposes no way to set the child's process group,
+    /// and without that a `kill` reaches only the CLI while its `node -e` probes
+    /// survive as orphans — the exact leak this type exists to stop.
+    private static func spawn(_ argv: [String], stdout writeFD: Int32, closeInChild readFD: Int32) -> pid_t? {
+        var attr: posix_spawnattr_t?
+        posix_spawnattr_init(&attr)
+        defer { posix_spawnattr_destroy(&attr) }
+        // pgroup 0 == "use the child's own pid as the group id".
+        posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETPGROUP))
+        posix_spawnattr_setpgroup(&attr, 0)
+
+        var actions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&actions)
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        posix_spawn_file_actions_adddup2(&actions, writeFD, STDOUT_FILENO)
+        posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0)
+        posix_spawn_file_actions_addclose(&actions, readFD)
+        posix_spawn_file_actions_addclose(&actions, writeFD)
+
+        var cArgs: [UnsafeMutablePointer<CChar>?] = argv.map { strdup($0) }
+        cArgs.append(nil)
+        defer { for a in cArgs where a != nil { free(a) } }
+
+        var pid: pid_t = 0
+        let rc = posix_spawn(&pid, argv[0], &actions, &attr, &cArgs, environ)
+        return rc == 0 ? pid : nil
+    }
+
+    private static func readToEnd(_ fd: Int32) -> Data {
+        var data = Data()
+        var buf = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let n = buf.withUnsafeMutableBytes { read(fd, $0.baseAddress, $0.count) }
+            if n > 0 {
+                data.append(contentsOf: buf[0..<n])
+            } else if n == 0 {
+                break
+            } else if errno == EINTR {
+                continue
+            } else {
+                break
+            }
+        }
+        return data
+    }
+
+    /// SIGTERM the group, then SIGKILL anything that ignored it. The negative
+    /// pid is the whole process group — `kill(pid)` alone leaves the subtree.
+    private static func terminateGroup(_ pid: pid_t) {
+        kill(-pid, SIGTERM)
+        // A wedged node process under memory pressure does not always service
+        // SIGTERM promptly; escalate rather than wait on it indefinitely.
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if kill(-pid, 0) != 0 { return }
+            usleep(50_000)
+        }
+        kill(-pid, SIGKILL)
+    }
+
+    // MARK: - Cross-launch reaping
+
+    /// Kill anything a previous helper left running.
+    ///
+    /// Called at launch, before the status item exists. This is the only cleanup
+    /// that survives the failure mode that actually happens: a SIGSEGV runs no
+    /// handler of ours, so the *next* process has to do it.
+    @discardableResult
+    static func reapOrphansFromPreviousLaunch(file: String = Registry.path()) -> Int {
+        let stale = Registry.readAll(file: file)
+        Registry.clear(file: file)
+        var reaped = 0
+        for entry in stale where entry.pid != getpid() {
+            // Guard against pid reuse: the slot may now hold something else
+            // entirely. Only a live process still running the same executable
+            // is treated as ours.
+            guard kill(entry.pid, 0) == 0, executablePath(entry.pid) == entry.path else { continue }
+            terminateGroup(entry.pid)
+            reaped += 1
+        }
+        return reaped
+    }
+
+    /// Absolute path of a running pid's executable, or nil if it is gone or
+    /// unreadable. Used only as a pid-reuse guard, never to identify work.
+    static func executablePath(_ pid: pid_t) -> String? {
+        var buf = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
+        let n = proc_pidpath(pid, &buf, UInt32(buf.count))
+        guard n > 0 else { return nil }
+        return String(cString: buf)
+    }
+
+    // MARK: - Live-child registry
+
+    /// The on-disk record of children this helper currently has in flight.
+    ///
+    /// Lives beside the single-instance lock in the CLI's runtime state dir
+    /// (`getRuntimeStateDir()`, src/lib/state.ts). Line format: `<pid> <path>`.
+    enum Registry {
+        struct Entry: Equatable {
+            let pid: pid_t
+            let path: String
+        }
+
+        static func path(home: String = NSHomeDirectory()) -> String {
+            "\(home)/.agents/.cache/state/menubar-children"
+        }
+
+        /// Serializes the read-modify-write across the helper's refresher
+        /// threads. Cross-process contention is not a concern: SingleInstance
+        /// guarantees one helper owns this file.
+        private static let queue = DispatchQueue(label: "com.phnx-labs.agents-menubar.children")
+
+        static func register(pid: pid_t, path executable: String, file: String = path()) {
+            queue.sync {
+                var entries = parse(read(file))
+                entries.append(Entry(pid: pid, path: executable))
+                write(entries, to: file)
+            }
+        }
+
+        static func deregister(pid: pid_t, file: String = path()) {
+            queue.sync {
+                let entries = parse(read(file)).filter { $0.pid != pid }
+                write(entries, to: file)
+            }
+        }
+
+        static func readAll(file: String = path()) -> [Entry] {
+            queue.sync { parse(read(file)) }
+        }
+
+        static func clear(file: String = path()) {
+            queue.sync { write([], to: file) }
+        }
+
+        /// Pure — the parse half is what the self-test pins.
+        static func parse(_ text: String) -> [Entry] {
+            text.split(separator: "\n").compactMap { line in
+                let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+                guard parts.count == 2, let pid = pid_t(parts[0]), pid > 0 else { return nil }
+                return Entry(pid: pid, path: parts[1])
+            }
+        }
+
+        static func serialize(_ entries: [Entry]) -> String {
+            entries.map { "\($0.pid) \($0.path)" }.joined(separator: "\n")
+        }
+
+        private static func read(_ file: String) -> String {
+            (try? String(contentsOfFile: file, encoding: .utf8)) ?? ""
+        }
+
+        private static func write(_ entries: [Entry], to file: String) {
+            let dir = (file as NSString).deletingLastPathComponent
+            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            try? serialize(entries).write(toFile: file, atomically: true, encoding: .utf8)
+        }
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
@@ -1,0 +1,203 @@
+import Darwin
+import Foundation
+
+// Self-test for bounded, group-killable child processes. Follows the repo's
+// env-gated self-test idiom (see GuardsSelfTest.swift / SingleInstanceSelfTest.swift):
+// no XCTest target exists for the menu-bar helper.
+//
+//   MENUBAR_CHILD_TEST=1 MenubarHelper
+//
+// These spawn REAL processes — no mocking, per the repo convention. Each case is
+// one of the properties whose absence produced the runaway: an unbounded call, a
+// subtree that survived its parent's death, and a stale registry entry that must
+// not be allowed to kill an unrelated pid.
+enum ChildProcessSelfTest {
+    private static var failures = 0
+
+    static func run() -> Never {
+        print("menubar child-process self-test")
+        testCapturesStdout()
+        testNonZeroExitIsFailure()
+        testTimeoutKillsAndReportsFailure()
+        testTimeoutKillsTheWholeProcessGroup()
+        testRegistryTracksInFlightChildren()
+        testRegistryRoundTrip()
+        testReapSkipsPidWhoseExecutableChanged()
+        testReapKillsARealOrphanFromAPreviousLaunch()
+        if failures == 0 {
+            print("\nALL PASS")
+            exit(0)
+        }
+        print("\n\(failures) FAILED")
+        exit(1)
+    }
+
+    // MARK: Baseline — the behavior every caller already depended on.
+
+    private static func testCapturesStdout() {
+        let out = ChildProcess.run(["/bin/echo", "hello"], timeout: 10)
+        check(out.flatMap { String(data: $0, encoding: .utf8) } == "hello\n",
+              "stdout is captured verbatim")
+    }
+
+    private static func testNonZeroExitIsFailure() {
+        check(ChildProcess.run(["/usr/bin/false"], timeout: 10) == nil,
+              "non-zero exit -> nil (callers must not parse a failed run)")
+    }
+
+    // MARK: The bug — an unbounded call never returns.
+
+    // `agents doctor --json` went from ~2s to over 12 minutes on a loaded box and
+    // the old capture() simply waited, holding a core the whole time.
+    private static func testTimeoutKillsAndReportsFailure() {
+        let started = Date()
+        let out = ChildProcess.run(["/bin/sleep", "30"], timeout: 1)
+        let elapsed = Date().timeIntervalSince(started)
+        check(out == nil, "timed-out call -> nil")
+        check(elapsed < 10, "timed-out call returns promptly (took \(String(format: "%.1f", elapsed))s, child asked for 30s)")
+    }
+
+    // The 92 orphaned `node -e` probes: the doctor forked them, and signalling
+    // only the doctor's pid left every one of them running. The child must be its
+    // own process-group leader so kill(-pgid) takes the subtree.
+    private static func testTimeoutKillsTheWholeProcessGroup() {
+        // Parent spawns a grandchild that outlives it, then sleeps. Killing only
+        // the parent pid leaves the grandchild; killing the group takes both.
+        let marker = "\(NSTemporaryDirectory())menubar-childtest-\(getpid())-\(Int(Date().timeIntervalSince1970))"
+        let script = "/bin/sh -c 'sleep 45 && touch \(marker)' & sleep 45"
+        _ = ChildProcess.run(["/bin/sh", "-c", script], timeout: 1)
+
+        // Give the kill a beat to propagate, then assert nothing from that group
+        // is still alive: the grandchild's own `sleep 45` must be gone.
+        usleep(1_500_000)
+        let survivors = pgrepCount(matching: "sleep 45")
+        check(survivors == 0,
+              "timeout kills the whole process group (\(survivors) descendant sleep(s) survived)")
+        try? FileManager.default.removeItem(atPath: marker)
+    }
+
+    // MARK: The registry — what makes cross-launch reaping possible at all.
+
+    private static func testRegistryTracksInFlightChildren() {
+        let file = "\(NSTemporaryDirectory())menubar-children-test-\(getpid())"
+        try? FileManager.default.removeItem(atPath: file)
+        ChildProcess.Registry.register(pid: 4242, path: "/bin/echo", file: file)
+        ChildProcess.Registry.register(pid: 4243, path: "/bin/sleep", file: file)
+        check(ChildProcess.Registry.readAll(file: file).count == 2, "two in-flight children recorded")
+        ChildProcess.Registry.deregister(pid: 4242, file: file)
+        let left = ChildProcess.Registry.readAll(file: file)
+        check(left == [.init(pid: 4243, path: "/bin/sleep")],
+              "a completed child is removed, the other is untouched")
+        try? FileManager.default.removeItem(atPath: file)
+    }
+
+    // Paths can contain spaces, so the split must be bounded to the first one.
+    private static func testRegistryRoundTrip() {
+        let entries = [
+            ChildProcess.Registry.Entry(pid: 11, path: "/opt/homebrew/bin/agents"),
+            ChildProcess.Registry.Entry(pid: 12, path: "/Users/x/Application Support/a b/agents"),
+        ]
+        let parsed = ChildProcess.Registry.parse(ChildProcess.Registry.serialize(entries))
+        check(parsed == entries, "registry round-trips pids and paths containing spaces")
+        check(ChildProcess.Registry.parse("garbage\n\n0 /bin/x\n-1 /bin/y").isEmpty,
+              "malformed and non-positive pids are skipped, never thrown on")
+    }
+
+    // Pid reuse: by the next launch the recorded pid may belong to something else
+    // entirely. Reaping on pid alone would kill an innocent process, so the
+    // executable path must still match.
+    private static func testReapSkipsPidWhoseExecutableChanged() {
+        let file = "\(NSTemporaryDirectory())menubar-children-reuse-\(getpid())"
+        try? FileManager.default.removeItem(atPath: file)
+        // This very process is alive, but its executable is MenubarHelper, not
+        // /bin/sleep — so the guard must refuse to treat it as a stale child.
+        let me = getpid()
+        ChildProcess.Registry.register(pid: me, path: "/bin/sleep", file: file)
+        let recorded = ChildProcess.Registry.readAll(file: file)
+        let mismatched = recorded.filter { ChildProcess.executablePath($0.pid) != $0.path }
+        check(mismatched.count == 1,
+              "a live pid whose executable no longer matches is not reapable")
+        check(ChildProcess.executablePath(me)?.hasSuffix("MenubarHelper") == true,
+              "executablePath resolves a live pid (got \(ChildProcess.executablePath(me) ?? "nil"))")
+        try? FileManager.default.removeItem(atPath: file)
+    }
+
+    // The whole point of the on-disk registry: a helper killed by SIGSEGV or
+    // SIGKILL runs none of its own cleanup, so the NEXT launch has to do it.
+    // This is the end-to-end version — a real surviving process, killed by a real
+    // call to the real reaper, driven off a real registry file.
+    private static func testReapKillsARealOrphanFromAPreviousLaunch() {
+        let file = "\(NSTemporaryDirectory())menubar-children-reap-\(getpid())"
+        try? FileManager.default.removeItem(atPath: file)
+
+        // Stand in for the abandoned child: a process that is its own
+        // process-group leader (as ChildProcess.spawn makes every child), so the
+        // reaper's kill(-pgid) has a group to take.
+        guard let orphan = spawnDetachedGroupLeader() else {
+            check(false, "could not spawn a stand-in orphan")
+            return
+        }
+        ChildProcess.Registry.register(pid: orphan, path: "/bin/sleep", file: file)
+        check(kill(orphan, 0) == 0, "stand-in orphan (pid \(orphan)) is alive before the reap")
+
+        let reaped = ChildProcess.reapOrphansFromPreviousLaunch(file: file)
+        check(reaped == 1, "reaper reports exactly 1 group reaped (got \(reaped))")
+
+        // Poll rather than sleep a fixed amount: SIGTERM then SIGKILL is not
+        // instantaneous, but it must be bounded.
+        var alive = true
+        for _ in 0..<40 where alive {
+            usleep(100_000)
+            alive = kill(orphan, 0) == 0
+        }
+        check(!alive, "the orphan is dead after the reap")
+        check(ChildProcess.Registry.readAll(file: file).isEmpty,
+              "registry is cleared so the next launch does not re-reap a dead pid")
+        try? FileManager.default.removeItem(atPath: file)
+    }
+
+    /// `sleep 300` in its own process group, reparented away from this process.
+    /// macOS ships no `setsid(1)`, so python does the `setpgrp` + `exec`.
+    private static func spawnDetachedGroupLeader() -> pid_t? {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        p.arguments = ["-c", "import os; os.setpgrp(); os.execv('/bin/sleep', ['sleep', '300'])"]
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        guard (try? p.run()) != nil else { return nil }
+        // Wait for the exec to land so proc_pidpath reports /bin/sleep, not python.
+        let pid = p.processIdentifier
+        for _ in 0..<50 {
+            usleep(100_000)
+            if ChildProcess.executablePath(pid) == "/bin/sleep" { return pid }
+        }
+        return nil
+    }
+
+    // MARK: helpers
+
+    /// Count live processes whose command line contains `needle`, excluding this
+    /// process. Uses the real process table — the point is to observe survivors.
+    private static func pgrepCount(matching needle: String) -> Int {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/ps")
+        p.arguments = ["-Ao", "pid,command"]
+        let pipe = Pipe()
+        p.standardOutput = pipe
+        p.standardError = FileHandle.nullDevice
+        guard (try? p.run()) != nil else { return -1 }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        p.waitUntilExit()
+        let text = String(data: data, encoding: .utf8) ?? ""
+        return text.split(separator: "\n").filter { $0.contains(needle) }.count
+    }
+
+    private static func check(_ condition: Bool, _ label: String) {
+        if condition {
+            print("  PASS  \(label)")
+        } else {
+            failures += 1
+            print("  FAIL  \(label)")
+        }
+    }
+}

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -246,9 +246,24 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         }
     }
 
+    /// How often the System row's `doctor --json` may be refreshed.
+    ///
+    /// This was 60s against a command measured at **136s** on an idle machine —
+    /// i.e. the poll asked for a refresh more than twice as often as one could
+    /// possibly complete, so the helper ran a doctor essentially continuously.
+    /// (The in-flight guard kept it to one *per process*, which is why the
+    /// unbounded child and the crash-restart loop were needed to turn this into
+    /// the 38-orphan runaway — but a ~100% duty cycle was always the floor.)
+    ///
+    /// 15 minutes is matched to what the data actually is: installed CLIs,
+    /// per-version sign-in, and resource sync drift change on the timescale of a
+    /// person running `agents sync` or logging in, not second to second. That
+    /// takes the duty cycle from ~100% of one core to ~15%.
+    private static let doctorRefreshInterval: TimeInterval = 15 * 60
+
     private func refreshDoctorOverview() {
         if doctorInFlight { return }
-        if let t = doctorFetchedAt, Date().timeIntervalSince(t) < 60 { return }
+        if let t = doctorFetchedAt, Date().timeIntervalSince(t) < Self.doctorRefreshInterval { return }
         doctorInFlight = true
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let d = AgentsCLI.doctorOverview()

--- a/apps/cli/menubar/Sources/MenubarHelper/main.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/main.swift
@@ -54,6 +54,13 @@ if ProcessInfo.processInfo.environment["MENUBAR_SINGLE_TEST"] == "1" {
     SingleInstanceSelfTest.run()
 }
 
+// Child-process self-test: spawn real processes and assert they are bounded by
+// a deadline, killed as a group, and tracked so the next launch can reap them.
+// See ChildProcess.swift.
+if ProcessInfo.processInfo.environment["MENUBAR_CHILD_TEST"] == "1" {
+    ChildProcessSelfTest.run()
+}
+
 // Everything past here installs the status item and registers the global
 // chords, so it must only run where those chords can actually be serviced.
 // Refuses an ssh-started launch or an unrecognized flag — the two ways a helper
@@ -63,6 +70,21 @@ Guards.enforceForInteractiveLaunch()
 // ...and only once. A second helper surfaces the running one's menu and exits
 // rather than installing a duplicate status item (see SingleInstance.swift).
 SingleInstance.enforceOrSurface()
+
+// Kill whatever the previous helper left running. This runs BEFORE any AppKit
+// call on purpose: the death being cleaned up after is a SIGSEGV inside
+// `NSApplication.shared` itself (SLSNewConnection returns null when WindowServer
+// is starved, AppKit dereferences it), so cleanup placed after that line would
+// be skipped by the exact crash it exists to recover from — and the CLI children
+// it abandons are what starve WindowServer in the first place. Only the winner
+// of the single-instance lock reaps, so a surfacing duplicate never kills the
+// incumbent's live children. See ChildProcess.swift.
+let reaped = ChildProcess.reapOrphansFromPreviousLaunch()
+if reaped > 0 {
+    FileHandle.standardError.write(Data(
+        "MenubarHelper: reaped \(reaped) orphaned CLI child process group(s) from a previous launch.\n".utf8
+    ))
+}
 
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -267,9 +267,23 @@ describe('generateServicePlist — launchd crash-loop throttle', () => {
     expect(plist).toContain('<key>RunAtLoad</key>');
   });
 
-  it('emits a plist that plutil accepts', () => {
+  // `plutil` is macOS-only and the CI test shards run on Linux, where spawnSync
+  // returns status null (ENOENT) rather than a non-zero exit — so gate on the
+  // tool actually being present instead of asserting against a missing binary.
+  const hasPlutil = spawnSync('plutil', ['-help'], { encoding: 'utf8' }).error === undefined;
+
+  it.skipIf(!hasPlutil)('emits a plist that plutil accepts', () => {
     const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'menubar-plist-')), 'x.plist');
     fs.writeFileSync(file, plist);
     expect(spawnSync('plutil', ['-lint', file], { encoding: 'utf8' }).status).toBe(0);
+  });
+
+  // Runs everywhere, so the structural contract is still pinned on Linux CI:
+  // a plist launchd will reject is a helper that never starts.
+  it('is well-formed XML with a single top-level dict', () => {
+    expect(plist.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(plist).toContain('<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"');
+    expect(plist.match(/<dict>/g)?.length).toBe(plist.match(/<\/dict>/g)?.length);
+    expect(plist.trimEnd().endsWith('</plist>')).toBe(true);
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -7,6 +7,7 @@ import {
   classifyMenubarProcesses,
   codesignVerifies,
   ensureValidSignature,
+  generateServicePlist,
   isMenubarStale,
   menubarPlistNeedsRepoint,
   processesToEnd,
@@ -241,5 +242,34 @@ darwinOnly('ensureValidSignature (real codesign)', () => {
     expect(ensureValidSignature(app)).toBe(true);
     expect(codesignVerifies(app)).toBe(true);
     fs.rmSync(path.dirname(app), { recursive: true, force: true });
+  });
+});
+
+// Regression guard for the ORPHAN-STORM incident. The helper can crash at
+// startup on a loaded machine — `NSApplication.shared` segfaults inside
+// `SLSNewConnection` when WindowServer is too starved to hand out a connection.
+// With `KeepAlive` and no `ThrottleInterval`, launchd relaunched on its ~10s
+// default and every attempt spawned another `agents doctor --json` before dying,
+// so a starved box got hit harder the worse it got: 38 orphaned doctors, ~13 of
+// 18 cores, load average 490. The throttle paces the respawn; ChildProcess.swift
+// bounds and reaps the children.
+describe('generateServicePlist — launchd crash-loop throttle', () => {
+  const plist = generateServicePlist('/Users/x/Library/Application Support/agents-cli/MenubarHelper.app/Contents/MacOS/MenubarHelper');
+
+  it('sets a ThrottleInterval so a startup crash-loop cannot respawn every 10s', () => {
+    expect(plist).toContain('<key>ThrottleInterval</key>');
+    const seconds = Number(/<key>ThrottleInterval<\/key>\s*<integer>(\d+)<\/integer>/.exec(plist)?.[1]);
+    expect(seconds).toBeGreaterThanOrEqual(30);
+  });
+
+  it('still keeps the helper alive and starts it at load', () => {
+    expect(plist).toContain('<key>KeepAlive</key>');
+    expect(plist).toContain('<key>RunAtLoad</key>');
+  });
+
+  it('emits a plist that plutil accepts', () => {
+    const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'menubar-plist-')), 'x.plist');
+    fs.writeFileSync(file, plist);
+    expect(spawnSync('plutil', ['-lint', file], { encoding: 'utf8' }).status).toBe(0);
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -28,6 +28,22 @@ const APP_BUNDLE_NAME = 'MenubarHelper.app';
 const INSTALL_DIR_NAME = 'agents-cli';
 const SERVICE_LABEL = 'com.phnx-labs.agents-menubar';
 
+/**
+ * Minimum seconds between launchd restarts of the helper (`ThrottleInterval`).
+ *
+ * The helper can crash at startup on a loaded machine: `NSApplication.shared`
+ * segfaults inside `SLSNewConnection` when WindowServer is too starved to hand
+ * out a connection. With `KeepAlive` and no throttle, launchd relaunches on its
+ * 10s default, and each attempt spawns a fresh `agents doctor --json` before
+ * dying — so a starved box gets hit harder the worse it gets. 30s bounds that
+ * respawn rate while staying well inside "the menu bar came back on its own".
+ *
+ * This only paces the restarts. What actually stops the pile-up is the helper
+ * bounding and group-killing its own children (menubar/Sources/MenubarHelper/
+ * ChildProcess.swift); the two are complementary, not alternatives.
+ */
+const MENUBAR_THROTTLE_SECONDS = 30;
+
 function onDarwin(): boolean {
   return process.platform === 'darwin';
 }
@@ -264,7 +280,7 @@ function xmlEscape(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function generateServicePlist(execPath: string): string {
+export function generateServicePlist(execPath: string): string {
   const home = os.homedir();
   const logPath = path.join(getHelpersDir(), 'menubar', 'menubar.log');
   fs.mkdirSync(path.dirname(logPath), { recursive: true });
@@ -302,6 +318,8 @@ function generateServicePlist(execPath: string): string {
   <true/>
   <key>KeepAlive</key>
   <true/>
+  <key>ThrottleInterval</key>
+  <integer>${MENUBAR_THROTTLE_SECONDS}</integer>
   <key>ProcessType</key>
   <string>Interactive</string>
   <key>StandardOutPath</key>


### PR DESCRIPTION
**bugfix** — the menu-bar helper could leak `agents` CLI processes until the machine was unusable. Diagnosed live on `zion` at **load average 490** (18 cores) with visible keystroke lag.

## What went wrong

The helper polls `agents doctor --json` on a timer through an unbounded `Process` + `readDataToEndOfFile()`. Two properties composed into a positive feedback loop:

| # | Property | Consequence |
|---|---|---|
| 1 | **No deadline** | `doctor --json` measures **136s on an idle box** — not the seconds the 60s poll assumed |
| 2 | **No ownership after the parent dies** | a helper killed mid-call left the child at PPID 1 with nothing to reap it, plus the `node -e` probes *that* child forked |

Both fire together, because **the helper crashes under exactly the conditions that make the CLI slow**:

```
NSApplication.shared → SLSNewConnection returns null when WindowServer is starved
                     → AppKit dereferences it → EXC_BAD_ACCESS at 0x10 (SIGSEGV, at startup)
                     → launchd KeepAlive restarts → new doctor spawned, old one still running
                     → load rises → doctor slower, WindowServer more starved → crashes more
                     ↺  one permanent orphan heavier each pass
```

Measured before the fix: **38 orphaned `doctor --json` + 92 orphaned `node -e` probes, ~13 of 18 cores**, 8 crash reports in one day.

## The approach

The crash **cannot be prevented from inside the app** — it is AppKit dereferencing a null connection before any of our code runs. So the fix is not "stop the crash", it is **make a crash stop costing something permanent**. Every link that turns a transient crash into accumulating state is cut:

- **Bounded** — every spawn carries a deadline (30s; **180s** for `doctor`, set *above* its real measured cost. A tidier-looking 45s would fail every poll forever while still paying full CPU).
- **Killed as a group** — children spawn as their own process-group leader (`POSIX_SPAWN_SETPGROUP`) so a timeout `kill(-pgid)`s the subtree. Signalling the pid alone is precisely what left the 92 probes alive. Foundation's `Process` cannot set a process group — hence `posix_spawn`.
- **Reaped by the NEXT launch** — live children are recorded on disk and swept at startup, **before the first AppKit call**, since the death being recovered from happens *inside* that call. No exit handler can help against SIGSEGV.

Plus the poll design the runaway grew out of: `doctorRefreshInterval` **60s → 15 min** against a 136s command (that was a >100% duty cycle), and the launchd job gains **`ThrottleInterval` 30** so a startup crash-loop cannot respawn every 10s.

## Run result

Full evidence log (crash signature, before/after process counts, all suites): **https://share.agents-cli.sh/muqsitnawaz/menubar-doctor-orphan-storm-menubar-orphan-storm-evidence-8640e3185fee2d7f**

`MENUBAR_CHILD_TEST=1 MenubarHelper` — 15 cases against **real processes, no mocking**:

```
  PASS  timed-out call returns promptly (took 1.1s, child asked for 30s)
  PASS  timeout kills the whole process group (0 descendant sleep(s) survived)
  PASS  a live pid whose executable no longer matches is not reapable
  PASS  stand-in orphan (pid 19512) is alive before the reap
  PASS  reaper reports exactly 1 group reaped (got 1)
  PASS  the orphan is dead after the reap
  PASS  registry is cleared so the next launch does not re-reap a dead pid
ALL PASS
```

The reap case spawns a **real** process in its own process group and kills it via the **real** reaper off a **real** registry file — not a simulation of the mechanism.

Also green: 38 TS tests (incl. a `plutil`-linted `ThrottleInterval` guard) · `tsc --noEmit` clean · `MENUBAR_GUARD_TEST` / `MENUBAR_SINGLE_TEST` / `MENUBAR_ISSUE_TEST` all `ALL PASS`.

Live on the machine after reaping the orphans and pausing the service: **load 490 → 10.4**, `doctor --json` survivors 38 → 0, `node -e` orphans 92 → 0.

## Known gap, deliberately not fixed here

**`agents doctor --json` taking 136s on an idle machine is its own defect.** This PR makes the helper *safe* against it; that is not the same as it being acceptable. Worth its own ticket — the 169 KB payload and per-version subprocess probes are the place to look. Flagging rather than folding it in, so this stays a tight fix to the machine-killer.

## Not covered

`ThrottleInterval` only reaches **newly written** plists. Existing installs pick it up on the next `agents menubar setup` / version-bump reinstall (`isMenubarStale`), which is the established path — no migration added.
