### PR TITLE
fix(menubar): notarize the helper + drop the runtime re-sign band-aid (RUSH-2134)

### DIFF
--- a/apps/cli/.changelog/next/menubar-notarize-mandatory.md
+++ b/apps/cli/.changelog/next/menubar-notarize-mandatory.md
@@ -1,0 +1,17 @@
+- **The macOS menu-bar helper is now notarized, ending the "app is damaged"
+  dialog and the per-run `no valid code signature; skipping launch` spam
+  (RUSH-2114).** The helper shipped Developer-ID signed but *not* notarized, so
+  Gatekeeper on macOS 26+ rejected it as damaged and the install path tried to
+  heal it by re-signing ad-hoc on every `agents` invocation — which can never
+  satisfy Gatekeeper, so the dialog and the noise persisted. The release now
+  notarizes + staples the helper (`menubar/scripts/build.sh`, mandatory for any
+  Developer-ID build, run under the release's `agents secrets exec apple.com`
+  context), the `prepack` gate refuses to pack an un-notarized bundle
+  (`scripts/verify-menubar-helper.sh` now requires a stapled ticket), and the
+  runtime ad-hoc re-sign band-aid is deleted — a notarized + stapled bundle
+  survives npm's tarball round-trip untouched, so the helper launches with no
+  per-machine healing. The launch guards now verify Gatekeeper acceptance (not
+  just `codesign --verify`) and fail loud pointing at an upgrade rather than
+  re-signing over it. Source: `apps/cli/menubar/scripts/build.sh`,
+  `apps/cli/scripts/verify-menubar-helper.sh`, `apps/cli/scripts/release.sh`,
+  `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/.changelog/next/menubar-notarize-mandatory.md
+++ b/apps/cli/.changelog/next/menubar-notarize-mandatory.md
@@ -1,6 +1,6 @@
 - **The macOS menu-bar helper is now notarized, ending the "app is damaged"
   dialog and the per-run `no valid code signature; skipping launch` spam
-  (RUSH-2114).** The helper shipped Developer-ID signed but *not* notarized, so
+  (RUSH-2134).** The helper shipped Developer-ID signed but *not* notarized, so
   Gatekeeper on macOS 26+ rejected it as damaged and the install path tried to
   heal it by re-signing ad-hoc on every `agents` invocation — which can never
   satisfy Gatekeeper, so the dialog and the noise persisted. The release now

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -308,7 +308,7 @@ package's npm tarball; two more helpers are dev-only and live at repo-root `nati
 | Helper | Source | Ships in tarball? | Resolver |
 |---|---|---|---|
 | Keychain broker | `src/lib/secrets/keychain-helper.swift` → `bin/Agents CLI.app` | **Yes** (signed + notarized) | `src/lib/secrets/` |
-| Menu-bar helper | [`menubar/`](menubar) (SwiftPM) → `bin/MenubarHelper.app` | **Yes** (signed, no notarization) | `src/lib/menubar/install-menubar.ts` |
+| Menu-bar helper | [`menubar/`](menubar) (SwiftPM) → `bin/MenubarHelper.app` | **Yes** (signed + notarized) | `src/lib/menubar/install-menubar.ts` |
 | Standalone CLI binary | `src/` → `bun build --compile` → `bin/agents-macos` | **Yes** (signed + notarized, arm64 Mach-O at `dist/bin/agents`) | `scripts/postinstall.js` |
 | computer-mac | [`../../native/computer-mac`](../../native/computer-mac) | No — signed + notarized GitHub **release asset**, downloaded on demand | `src/lib/computer-rpc.ts`, `src/lib/computer/download.ts` |
 | computer-win | [`../../native/computer-win`](../../native/computer-win) | No (staged at release) | `src/lib/ssh-tunnel.ts` |
@@ -483,10 +483,19 @@ the helper only when `src/lib/secrets/keychain-helper.swift` changes.
 **Menu-bar helper** ([`menubar/`](menubar) → `bin/MenubarHelper.app`) ships the same
 way — built into `bin/`, copied to `dist/lib/menubar/` by `build`, gated in `prepack`
 by [`scripts/verify-menubar-helper.sh`](scripts/verify-menubar-helper.sh) (presence +
-`codesign --verify`). No notarization (a status item has no Keychain ACL / TCC
-grant). Keep it a **separate bundle** from the keychain app — a menu-bar crash must
-never take down the secret broker. Stage a freshly-built `bin/MenubarHelper.app`
-before any release or the menu bar ships code-only (the 1.20.22 bug the gate prevents).
+`codesign --verify` + a **stapled notarization ticket**). It is Developer-ID signed
+**and notarized + stapled** ([`menubar/scripts/build.sh`](menubar/scripts/build.sh),
+run inside the release's `agents secrets exec apple.com` context): Gatekeeper on
+macOS 26+ rejects an un-notarized `.app` as "damaged" (crashing AppKit at launch),
+and the stapled ticket rides inside the bundle so it survives npm's tarball
+round-trip — so the installed helper launches with **no per-machine re-signing**
+(the old `install-menubar.ts` ad-hoc re-sign band-aid is gone; the launch guards now
+verify Gatekeeper acceptance and fail loud instead — RUSH-2114). Notarization is
+mandatory for any real (Developer-ID) build; an ad-hoc dev build can't be notarized
+and the prepack gate refuses to pack it. Keep it a **separate bundle** from the
+keychain app — a menu-bar crash must never take down the secret broker. Stage a
+freshly-built `bin/MenubarHelper.app` before any release or the menu bar ships
+code-only (the 1.20.22 bug the gate prevents).
 
 **Exactly one status item is an invariant, enforced in the helper.** The bundle
 can be started from more than one place — launchd's `KeepAlive` service, a

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -490,7 +490,7 @@ macOS 26+ rejects an un-notarized `.app` as "damaged" (crashing AppKit at launch
 and the stapled ticket rides inside the bundle so it survives npm's tarball
 round-trip — so the installed helper launches with **no per-machine re-signing**
 (the old `install-menubar.ts` ad-hoc re-sign band-aid is gone; the launch guards now
-verify Gatekeeper acceptance and fail loud instead — RUSH-2114). Notarization is
+verify Gatekeeper acceptance and fail loud instead — RUSH-2134). Notarization is
 mandatory for any real (Developer-ID) build; an ad-hoc dev build can't be notarized
 and the prepack gate refuses to pack it. Keep it a **separate bundle** from the
 keychain app — a menu-bar crash must never take down the secret broker. Stage a

--- a/apps/cli/menubar/scripts/build.sh
+++ b/apps/cli/menubar/scripts/build.sh
@@ -52,18 +52,19 @@ DEST="$DEST_DIR/menubar-helper-mac"
 cp "$SRC" "$DEST"
 
 # .app bundle. LSUIElement=true keeps it out of the Dock and the ⌘-Tab
-# switcher — it lives only in the menu bar. The helper DOES need a stable code
-# identity: its clip→paste feature (Clip.swift) synthesizes a ⌘-V keystroke,
-# which requires an Accessibility (TCC) grant, and macOS 26+ SIGKILLs an
-# unsigned/invalid binary at launch. Prefer a Developer ID identity — it
-# survives npm's tarball round-trip (an ad-hoc/linker signature gets stripped to
-# "not signed at all", which the install-time re-sign in install-menubar.ts then
-# heals per machine).
+# switcher — it lives only in the menu bar. The helper needs a code identity
+# macOS accepts end-to-end: its clip→paste feature (Clip.swift) synthesizes a
+# ⌘-V keystroke, which requires an Accessibility (TCC) grant, and macOS 26+
+# SIGKILLs an unsigned/invalid binary at launch while Gatekeeper rejects an
+# un-notarized one as "damaged" (which crashes AppKit during launch).
 #
-# Developer ID alone is no longer enough: Gatekeeper on macOS 26+ rejects an
-# un-notarized app as "damaged" and AppKit can crash during launch. Pass
-# MENUBAR_HELPER_NOTARIZE=1 and MENUBAR_HELPER_NOTARIZE_KEYCHAIN_PROFILE to
-# submit the .app to Apple and staple the ticket.
+# So a release build is Developer-ID signed AND notarized + stapled — the same
+# treatment the keychain helper gets (build-keychain-helper.sh). A Developer ID
+# signature and the stapled ticket both survive npm's tarball round-trip (the
+# ticket is a plain file inside the bundle), so the installed helper launches
+# with NO per-machine re-signing. Notarization is MANDATORY whenever we sign
+# with a real Developer ID (below); an ad-hoc dev build skips it and is caught
+# by prepack (verify-menubar-helper.sh), so an un-notarized helper can't ship.
 APP="$DEST_DIR/MenubarHelper.app"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS"
@@ -106,25 +107,46 @@ if [ -z "$SIGN_ID" ]; then
 fi
 if [ -z "$SIGN_ID" ]; then
     SIGN_ID="-"
-    echo "  WARNING: no Developer ID identity found — signing ad-hoc." >&2
-    echo "  npm will strip this signature; machines self-heal via install-menubar.ts" >&2
-    echo "  but the Accessibility grant re-prompts each upgrade. Sign on a host with" >&2
-    echo "  the Developer ID cert (see remote-sign-mac.sh) for a stable identity." >&2
+    echo "  WARNING: no Developer ID identity found — signing ad-hoc (DEV ONLY)." >&2
+    echo "  An ad-hoc build cannot be notarized, so prepack (verify-menubar-helper.sh)" >&2
+    echo "  refuses to pack it. Sign on a host with the Developer ID cert + the" >&2
+    echo "  apple.com secrets bundle to produce a shippable, notarized helper." >&2
 fi
 echo "  signing with: $SIGN_ID"
 codesign --force --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.agents-menubar "$APP" 2>&1 | sed 's/^/  /'
 codesign --force --options runtime --sign "$SIGN_ID" --identifier com.phnx-labs.agents-menubar "$DEST" 2>&1 | sed 's/^/  /'
 
-if [ -n "${MENUBAR_HELPER_NOTARIZE:-}" ] && [ "$SIGN_ID" != "-" ]; then
-  PROFILE="${MENUBAR_HELPER_NOTARIZE_KEYCHAIN_PROFILE:-}"
-  if [ -z "$PROFILE" ]; then
-    echo "  ERROR: MENUBAR_HELPER_NOTARIZE set but MENUBAR_HELPER_NOTARIZE_KEYCHAIN_PROFILE is empty" >&2
-    exit 1
-  fi
-  echo "  notarizing $APP with keychain profile '$PROFILE'..."
-  xcrun notarytool submit "$APP" --keychain-profile "$PROFILE" --wait 2>&1 | sed 's/^/  /'
+# Notarize + staple — MANDATORY for a RELEASE build. Gatekeeper on macOS 26+
+# rejects an un-notarized app as "damaged", so a signed-but-not-notarized helper
+# is not shippable. Creds come from the `apple.com` secrets bundle — both release
+# callers (release.sh, remote-sign-mac.sh) run this build under `agents secrets
+# exec apple.com`, the same vars the keychain helper + CLI binary notarize with,
+# so a release build fails loud here if they're missing. A debug build (local
+# Swift dev) skips notarization and never ships; an ad-hoc release (SIGN_ID="-",
+# no Developer ID) skips too and is caught by the prepack gate
+# (verify-menubar-helper.sh) so it can't ship un-notarized.
+if [ "$MODE" = "release" ] && [ "$SIGN_ID" != "-" ]; then
+  : "${APPLE_ID:?notarization requires APPLE_ID (from the apple.com secrets bundle)}"
+  : "${APPLE_APP_SPECIFIC_PASSWORD:?notarization requires APPLE_APP_SPECIFIC_PASSWORD (apple.com bundle)}"
+  : "${APPLE_TEAM_ID:?notarization requires APPLE_TEAM_ID (apple.com bundle)}"
+  NOTARIZE_ZIP="$DEST_DIR/MenubarHelper-notarize.zip"
+  NOTARY_LOG="$DEST_DIR/menubar-notary.log"
+  echo "  packaging $APP for notarization..."
+  ditto -c -k --keepParent "$APP" "$NOTARIZE_ZIP"
+  echo "  submitting for notarization (~1 min)..."
+  xcrun notarytool submit "$NOTARIZE_ZIP" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" \
+    --wait | tee "$NOTARY_LOG"
+  grep -q "status: Accepted" "$NOTARY_LOG" \
+    || { echo "  ERROR: menubar notarization did not report 'status: Accepted'" >&2; exit 1; }
+  rm -f "$NOTARIZE_ZIP"
   echo "  stapling ticket to $APP..."
   xcrun stapler staple "$APP" 2>&1 | sed 's/^/  /'
+  echo "  verifying Gatekeeper acceptance (spctl)..."
+  spctl --assess --type execute "$APP" 2>&1 | sed 's/^/  /' \
+    || { echo "  ERROR: spctl rejected the stapled helper — notarization incomplete" >&2; exit 1; }
 fi
 
 echo "built: $DEST"

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -197,6 +197,9 @@ run_home_base_phase() {
     rm -rf bin/MenubarHelper.app
     cp -R menubar/dist/MenubarHelper.app bin/MenubarHelper.app
     codesign --verify --deep --strict "bin/MenubarHelper.app"
+    # build.sh notarizes + staples (apple.com creds are in scope here); fail fast
+    # if the staged bundle is not stapled, before the prepack gate catches it.
+    xcrun stapler validate "bin/MenubarHelper.app"
     scripts/build-keychain-helper.sh
     shasum -a 256 "bin/Agents CLI.app/Contents/MacOS/Agents CLI" > "scripts/Agents CLI.app.sha256"
   ' || die "signed helper build failed on $RELEASE_HOME_BASE"

--- a/apps/cli/scripts/remote-sign-mac.sh
+++ b/apps/cli/scripts/remote-sign-mac.sh
@@ -14,8 +14,8 @@
 #   - bin/Agents CLI.app   — the keychain helper (swiftc universal → codesign
 #                            with entitlements + embedded provisioning profile →
 #                            notarize → staple). See build-keychain-helper.sh.
-#   - bin/MenubarHelper.app — the menu-bar status item (swift build → codesign,
-#                            NO notarization). See menubar/scripts/build.sh.
+#   - bin/MenubarHelper.app — the menu-bar status item (swift build → codesign →
+#                            notarize → staple). See menubar/scripts/build.sh.
 #
 # This script rsyncs the exact build INPUTS from THIS worktree to the home base,
 # runs the two Mac build scripts there under its headless signing creds, then
@@ -118,7 +118,7 @@ trap 'rm -f "$BUILD_SCRIPT"' EXIT
 . scripts/headless-sign-context.sh
 agents secrets exec apple.com -- bash -c '
   set -euo pipefail
-  echo "== menu-bar helper: swift build + codesign =="
+  echo "== menu-bar helper: swift build + codesign + notarize + staple =="
   menubar/scripts/build.sh release
   # rm -rf first so a re-run does not nest the new .app INSIDE a stale
   # bin/MenubarHelper.app (cp -R into an existing dir), which corrupts the

--- a/apps/cli/scripts/verify-menubar-helper.sh
+++ b/apps/cli/scripts/verify-menubar-helper.sh
@@ -9,10 +9,11 @@
 # then reports "no bundle ships" and the auto-enable no-ops. 1.20.22 shipped
 # exactly this way. This gate fails the pack so it can't happen again.
 #
-# Unlike the keychain helper we don't pin a sha: the status-bar app is ad-hoc
-# signed and rebuilt freely, so a pinned sha would false-positive on every
-# rebuild. Presence + a valid signature catches the real failure mode (missing
-# or corrupt bundle) without blocking routine rebuilds.
+# Unlike the keychain helper we don't pin a sha: the app is rebuilt freely, so a
+# pinned sha would false-positive on every rebuild. Presence + a valid signature
+# + a stapled notarization ticket catches the real failure modes (a missing or
+# corrupt bundle, or an un-notarized cut Gatekeeper rejects as "damaged") without
+# blocking routine rebuilds.
 #
 # prepack only runs at `npm pack` / `npm publish` time, which is macOS-only
 # (releases are cut locally on macOS — see CLAUDE.md), so requiring the bundle
@@ -40,4 +41,17 @@ if command -v codesign >/dev/null 2>&1; then
   fi
 fi
 
-echo "menubar helper present and signed: $APP"
+# Require a stapled notarization ticket. build.sh notarizes + staples every
+# Developer-ID build; the ticket is a file inside the bundle, so it survives npm.
+# Refuse to pack an un-notarized helper — Gatekeeper rejects it as "damaged" on
+# macOS 26+, and the install path has no re-sign fallback to paper over it.
+if command -v xcrun >/dev/null 2>&1; then
+  if ! xcrun stapler validate "$APP" >/dev/null 2>&1; then
+    echo "menubar helper is not notarized/stapled: $APP" >&2
+    echo "Rebuild it with Developer ID + apple.com creds so it notarizes:" >&2
+    echo "  agents secrets exec apple.com -- menubar/scripts/build.sh release" >&2
+    exit 1
+  fi
+fi
+
+echo "menubar helper present, signed, and notarized: $APP"

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import {
   classifyMenubarProcesses,
   codesignVerifies,
-  ensureValidSignature,
+  gatekeeperAssesses,
   isMenubarStale,
   menubarPlistNeedsRepoint,
   processesToEnd,
@@ -208,38 +208,35 @@ describe('restartMenubarLaunchAgent', () => {
   });
 });
 
-// Regression guard for the crash loop: npm strips the ad-hoc signature the
-// release bakes into MenubarHelper.app, leaving it "not signed at all" — which
-// macOS 26+ SIGKILLs on launch, spinning the launchd KeepAlive service forever.
-// ensureValidSignature must re-sign the copied bundle so codesign verifies.
-// Exercises the real `codesign` binary (no mocking), so it only runs on macOS.
+// Regression guard for the "damaged app" bug (RUSH-2114): the shipped helper is
+// Developer-ID signed AND notarized (menubar/scripts/build.sh + the
+// verify-menubar-helper.sh prepack gate). A signature alone is NOT enough —
+// Gatekeeper rejects an un-notarized bundle as "damaged" on macOS 26+ — so the
+// launch guards require BOTH `codesign --verify` (codesignVerifies) and
+// Gatekeeper acceptance (gatekeeperAssesses). This pins the reason both are
+// checked: an ad-hoc / un-notarized bundle passes codesign but fails Gatekeeper,
+// and must be refused, never re-signed. Real codesign/spctl (no mocking) → macOS.
 const darwinOnly = process.platform === 'darwin' ? describe : describe.skip;
-darwinOnly('ensureValidSignature (real codesign)', () => {
-  function makeUnsignedBundle(): string {
+darwinOnly('menubar launch guard requires notarization (real codesign/spctl)', () => {
+  function makeAdHocBundle(): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'menubar-sig-'));
     const app = path.join(dir, 'MenubarHelper.app');
     fs.mkdirSync(path.join(app, 'Contents', 'MacOS'), { recursive: true });
     // A real Mach-O so codesign has something to sign; /bin/echo is stable.
     fs.copyFileSync('/bin/echo', path.join(app, 'Contents', 'MacOS', 'MenubarHelper'));
-    // Strip the inherited system signature -> "not signed at all", the exact
-    // state npm's tarball round-trip leaves the shipped ad-hoc bundle in.
-    spawnSync('codesign', ['--remove-signature', app], { stdio: 'ignore' });
+    // Ad-hoc sign it: the signature is valid, but it is NOT notarized — the exact
+    // state a non-Developer-ID / un-notarized cut leaves the bundle in.
+    spawnSync('codesign', ['--force', '--sign', '-', '--identifier', 'com.phnx-labs.agents-menubar', app], { stdio: 'ignore' });
     return app;
   }
 
-  it('heals an unsigned bundle so it passes codesign --verify', () => {
-    const app = makeUnsignedBundle();
-    expect(codesignVerifies(app)).toBe(false);
-    expect(ensureValidSignature(app)).toBe(true);
+  it('an ad-hoc-signed (un-notarized) bundle passes codesign but FAILS Gatekeeper', () => {
+    const app = makeAdHocBundle();
+    // Signature is valid on its own...
     expect(codesignVerifies(app)).toBe(true);
-    fs.rmSync(path.dirname(app), { recursive: true, force: true });
-  });
-
-  it('leaves an already-valid signature untouched (idempotent)', () => {
-    const app = makeUnsignedBundle();
-    ensureValidSignature(app);
-    expect(ensureValidSignature(app)).toBe(true);
-    expect(codesignVerifies(app)).toBe(true);
+    // ...but Gatekeeper rejects it because it is not notarized. The guard's AND
+    // of the two is therefore false, so the helper is refused, not launched.
+    expect(gatekeeperAssesses(app)).toBe(false);
     fs.rmSync(path.dirname(app), { recursive: true, force: true });
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -208,7 +208,7 @@ describe('restartMenubarLaunchAgent', () => {
   });
 });
 
-// Regression guard for the "damaged app" bug (RUSH-2114): the shipped helper is
+// Regression guard for the "damaged app" bug (RUSH-2134): the shipped helper is
 // Developer-ID signed AND notarized (menubar/scripts/build.sh + the
 // verify-menubar-helper.sh prepack gate). A signature alone is NOT enough —
 // Gatekeeper rejects an un-notarized bundle as "damaged" on macOS 26+ — so the

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -195,44 +195,14 @@ export function codesignVerifies(appPath: string): boolean {
  * A Developer-ID-signed but un-notarized app is rejected by `spctl --assess`,
  * which macOS surfaces as "the app is damaged" and can crash AppKit during
  * launch. This is separate from `codesign --verify`: a signature can be valid
- * while Gatekeeper still refuses to run it.
+ * while Gatekeeper still refuses to run it. The release notarizes + staples the
+ * helper (menubar/scripts/build.sh, gated by verify-menubar-helper.sh), so a
+ * shipped bundle passes this; the launch guards use it to fail loud rather than
+ * bootstrap a helper macOS would reject.
  */
 export function gatekeeperAssesses(appPath: string): boolean {
   const r = spawnSync('spctl', ['--assess', '--type', 'exec', appPath], { stdio: ['ignore', 'ignore', 'ignore'] });
   return r.status === 0;
-}
-
-/**
- * Guarantee the installed bundle has a signature Gatekeeper will accept on THIS
- * machine.
- *
- * npm's pack/extract strips the ad-hoc/linker signature the release baked into
- * the helper, leaving `code object is not signed at all`. On macOS 26+ the
- * kernel's code-signing monitor SIGKILLs an unsigned/invalid binary at launch
- * (`SIGKILL (Code Signature Invalid)`), so under the launchd `KeepAlive` service
- * an ad-hoc release helper crash-loops forever and its unstable identity makes
- * the Accessibility grant (needed for the clip→paste keystroke in Clip.swift)
- * re-prompt every time. A fresh ad-hoc re-sign gives the on-disk bytes a
- * matching cdhash, which the kernel accepts.
- *
- * A Developer-ID-signed helper survives npm untouched — its embedded signature
- * still verifies — but if the release was not notarized, Gatekeeper rejects it.
- * In that case we strip the quarantine xattr and re-sign ad-hoc so the helper
- * can launch locally. The stable fix is to notarize the release build; this
- * fallback just prevents a crash-loop while the user is on an un-notarized cut.
- */
-export function ensureValidSignature(appPath: string): boolean {
-  if (codesignVerifies(appPath) && gatekeeperAssesses(appPath)) return true;
-  // Drop any quarantine/xattrs the tarball round-trip added (they can break
-  // both codesign and Gatekeeper), then re-sign ad-hoc under the helper's
-  // stable bundle identifier.
-  spawnSync('xattr', ['-cr', appPath], { stdio: ['ignore', 'ignore', 'ignore'] });
-  spawnSync(
-    'codesign',
-    ['--force', '--sign', '-', '--identifier', SERVICE_LABEL, appPath],
-    { stdio: ['ignore', 'ignore', 'ignore'] }
-  );
-  return codesignVerifies(appPath);
 }
 
 /**
@@ -246,13 +216,9 @@ export function ensureMenubarAppInstalled(opts: { forceReinstall?: boolean } = {
   if (!src) return null;
   const dest = installedAppPath();
   if (!opts.forceReinstall && fs.existsSync(dest)) {
-    // Self-heal an already-installed bundle whose signature npm stripped on a
-    // prior upgrade (macOS 26+ SIGKILLs it otherwise) without a forced recopy.
-    ensureValidSignature(dest);
     return installedExecutablePath();
   }
   copyAppBundle(src, dest);
-  ensureValidSignature(dest);
   // A fresh copy is exactly when the bundle's icon can be new (first install) or
   // superseded (upgrade) — register it so LaunchServices knows the bundle and can
   // resolve its AppIcon for the left-hand slot of daemon notifications.
@@ -348,13 +314,16 @@ export function enableMenubarService(opts: { clearOptOut?: boolean } = { clearOp
   const exec = ensureMenubarAppInstalled({ forceReinstall: true });
   if (!exec) return false;
 
-  // Never bootstrap a helper the kernel will kill on launch: an invalid
-  // signature under launchd KeepAlive is an infinite crash loop. If the bundle
-  // can't be made valid (re-sign already attempted in ensureMenubarAppInstalled),
-  // skip the service rather than spin the loop.
-  if (!codesignVerifies(installedAppPath())) {
+  // Never bootstrap a helper macOS will reject at launch: an invalid signature
+  // under launchd KeepAlive crash-loops forever, and an un-notarized bundle is
+  // rejected by Gatekeeper as "damaged". A shipped helper is Developer-ID signed
+  // AND notarized (release build + the verify-menubar-helper.sh prepack gate), so
+  // this passes; if it ever doesn't, skip the service and point at the upgrade
+  // rather than re-signing over it (an ad-hoc re-sign never satisfies Gatekeeper).
+  if (!(codesignVerifies(installedAppPath()) && gatekeeperAssesses(installedAppPath()))) {
     process.stderr.write(
-      'agents: menu-bar helper has no valid code signature; skipping launch to avoid a crash loop.\n'
+      'agents: menu-bar helper is not notarized/valid on this machine; skipping launch. ' +
+      'Upgrade to a notarized build (npm i -g @phnx-labs/agents-cli), then `agents menubar setup`.\n'
     );
     return false;
   }
@@ -592,12 +561,13 @@ export function runMenubarSetup(): SetupResult {
   step('bundle', before.installedVersion === getCliVersion() ? 'ok' : 'changed',
     `${installedAppPath()} (${getCliVersion()})`);
 
-  if (!codesignVerifies(installedAppPath())) {
+  if (!(codesignVerifies(installedAppPath()) && gatekeeperAssesses(installedAppPath()))) {
     step('signature', 'failed',
-      'no valid code signature — refusing to start it (launchd KeepAlive would crash-loop)');
+      'not notarized/valid on this machine — refusing to start it (Gatekeeper rejects an ' +
+      'un-notarized helper as "damaged"). Upgrade to a notarized build of agents-cli.');
     return { steps, configured: false, status: getMenubarStatus() };
   }
-  step('signature', 'ok', 'valid');
+  step('signature', 'ok', 'valid + notarized');
 
   // Clear the sticky opt-out: running `setup` is an explicit request for the
   // menu bar, so a stale `menubar disable` must not silently win.


### PR DESCRIPTION
**fix + refactor** — end the macOS menu-bar helper's "app is damaged" dialog (and the per-run `no valid code signature; skipping launch` spam) by **notarizing the helper properly** and **deleting the runtime re-sign band-aid** it was papering over the problem with. RUSH-2134.

> Scope note: this is the "damaged app" dialog, **not** RUSH-2114 (the `doctor --json` orphan-on-timeout pile-up that crushes the host). Those were conflated in the original investigation because the box was slow *and* the menu bar was broken; they're separate bugs with separate fixes. RUSH-2114 is tracked separately.

## The bug

The helper shipped Developer-ID signed but **not notarized**, so Gatekeeper on macOS 26+ rejects it as "damaged". The install path tried to heal that by re-signing the bundle ad-hoc on every `agents` invocation (`ensureValidSignature`) — but an ad-hoc signature can **never** satisfy Gatekeeper, so the dialog and the noise persisted, and every `agents` call spawned a `codesign`+`spctl` probe. It was an architecturally unwinnable band-aid.

The repo already had the right pattern for its **other two** in-tarball helpers: the keychain broker `.app` is signed **+ notarized + stapled** and sha-gated in `prepack`. The menu-bar helper was the lone exception. This makes it follow the same pattern.

## What changed

| File | Change |
|---|---|
| `menubar/scripts/build.sh` | Notarize + staple is **mandatory** for a release build (reuses the `apple.com` creds already in scope under `agents secrets exec apple.com`, same as the keychain helper / CLI binary). Debug builds skip it. |
| `scripts/verify-menubar-helper.sh` | Prepack gate now **requires a stapled ticket** (`xcrun stapler validate`) — a release literally cannot pack an un-notarized helper. |
| `scripts/release.sh` | Fail-fast `stapler validate` on the staged bundle before publish. |
| `src/lib/menubar/install-menubar.ts` | **Deleted** `ensureValidSignature` (the ad-hoc re-sign). The two launch guards now verify **both** `codesign --verify` AND Gatekeeper acceptance and fail loud pointing at an upgrade, instead of re-signing over a bundle macOS will reject. |
| `install-menubar.test.ts` | Test now pins the real invariant (real `codesign`/`spctl`): an ad-hoc / un-notarized bundle passes codesign but **fails Gatekeeper**. |
| `AGENTS.md` + `remote-sign-mac.sh` | Docs synced (signed → signed + notarized). |

Why deleting the re-sign is safe: a notarized + **stapled** bundle survives npm's tarball round-trip untouched (the ticket is a plain file inside the `.app`), so the installed helper launches with no per-machine healing.

## Verification (run locally)

```
$ npx tsc --noEmit          → rc=0
$ vitest install-menubar    → Test Files 1 passed (1) · Tests 24 passed (24)
$ bash -n + shellcheck      → clean (build.sh, verify-menubar-helper.sh, release.sh)
```

The new test runs the **real** `codesign`/`spctl` on macOS and confirms an ad-hoc bundle passes codesign (`true`) but Gatekeeper rejects it (`false`) — the exact reason both checks are needed.

The full notarization round-trip (Apple submit + staple) only runs in a real release on the home base (mac-mini, where the `apple.com` creds live); the notarytool invocation mirrors the proven keychain-helper / CLI-binary path exactly. It will be verified against the installed `1.20.94` build after release.
