### PR TITLE
fix(rules): don't treat a DotAgents-repo clone as a project layer (RUSH-2037)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2037.md
+++ b/apps/cli/.changelog/next/RUSH-2037.md
@@ -1,0 +1,12 @@
+- **A clone of your own DotAgents repo no longer hijacks project-layer rule resolution (RUSH-2037).**
+  Cloning `~/.agents` to the canonical `~/src/github.com/<you>/.agents` path (to edit
+  rules in an editor) made that checkout eligible as a *project* layer whenever you
+  worked from its parent directory. Because project outranks user, a stale clone's
+  `rules/subrules/*` then silently shadowed the live user rules by filename, and the
+  compile planted an out-of-date `AGENTS.md` in an ancestor dir that every session
+  beneath it ingested. Project-layer discovery now identifies a DotAgents repo by
+  **repo identity** (git origin), not path: a `.agents/` that is itself a git checkout
+  whose origin matches the user's or system's DotAgents repo is skipped, so the live
+  user layer wins. Legitimate project `.agents/` layers (a plain subdirectory of a
+  project, or a git repo with an unrelated origin) are unaffected.
+  Source: `apps/cli/src/lib/state.ts`.

--- a/apps/cli/src/lib/state.test.ts
+++ b/apps/cli/src/lib/state.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
 
 // state.ts resolves HOME and the device id at import time, so we point both at a
 // throwaway temp dir and re-import the module fresh for each test. This
@@ -105,5 +106,68 @@ describe('reading state never writes a tracked agents.yaml (RUSH-1925)', () => {
     const after = fs.readFileSync(centralPath(), 'utf-8');
     expect(after).toContain('defaultAgent: claude');
     expect(after).not.toContain('hermes-agent.nousresearch.com');
+  });
+});
+
+describe('getProjectAgentsDir does not treat a DotAgents-repo clone as a project layer (RUSH-2037)', () => {
+  // Cloning your own ~/.agents repo to the canonical ~/src/github.com/<you>/.agents
+  // path makes it a git checkout of the very repo whose rules already load as the
+  // user layer. It must not ALSO be picked up as a project layer (project outranks
+  // user), or a stale clone silently shadows the live rules and plants a compiled
+  // AGENTS.md in an ancestor dir. Discovery is by repo identity (git origin), not path.
+  function initGitRepo(dir: string, originUrl: string) {
+    fs.mkdirSync(dir, { recursive: true });
+    execFileSync('git', ['-C', dir, 'init', '-q'], { stdio: 'ignore' });
+    execFileSync('git', ['-C', dir, 'remote', 'add', 'origin', originUrl], { stdio: 'ignore' });
+  }
+
+  beforeEach(() => {
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-projectdir-test-'));
+    process.env.HOME = TMP;
+  });
+  afterEach(() => {
+    try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('returns a legitimate project .agents/ (a plain subdir, not its own git repo)', async () => {
+    const { getProjectAgentsDir } = await freshState();
+    const proj = path.join(TMP, 'proj');
+    const projAgents = path.join(proj, '.agents');
+    fs.mkdirSync(path.join(projAgents, 'rules', 'subrules'), { recursive: true });
+
+    expect(getProjectAgentsDir(proj)).toBe(projAgents);
+  });
+
+  it('rejects a checkout of the SYSTEM DotAgents repo at .agents/', async () => {
+    const { getProjectAgentsDir } = await freshState();
+    const wrap = path.join(TMP, 'src', 'github.com', 'phnx-labs');
+    fs.mkdirSync(wrap, { recursive: true });
+    fs.writeFileSync(path.join(wrap, 'agents.yaml'), 'agents: {}\n'); // walk boundary
+    initGitRepo(path.join(wrap, '.agents'), 'git@github.com:phnx-labs/.agents-system.git');
+
+    expect(getProjectAgentsDir(wrap)).toBeNull();
+  });
+
+  it('rejects a checkout of the USER DotAgents repo at .agents/ (origin matches ~/.agents)', async () => {
+    // The live user repo (~/.agents) is a git checkout with a known origin...
+    initGitRepo(path.join(TMP, '.agents'), 'git@github.com:acme/.agents.git');
+    const { getProjectAgentsDir } = await freshState();
+    // ...and a *clone* of it sits at the canonical ~/src path.
+    const wrap = path.join(TMP, 'src', 'github.com', 'acme');
+    fs.mkdirSync(wrap, { recursive: true });
+    fs.writeFileSync(path.join(wrap, 'agents.yaml'), 'agents: {}\n'); // walk boundary
+    initGitRepo(path.join(wrap, '.agents'), 'https://github.com/acme/.agents.git'); // same slug, different URL form
+
+    expect(getProjectAgentsDir(wrap)).toBeNull();
+  });
+
+  it('still returns an UNRELATED git repo checked out at .agents/ (no over-rejection)', async () => {
+    const { getProjectAgentsDir } = await freshState();
+    const proj = path.join(TMP, 'other-project');
+    const projAgents = path.join(proj, '.agents');
+    initGitRepo(projAgents, 'git@github.com:example/unrelated-project.git');
+    fs.mkdirSync(path.join(projAgents, 'rules'), { recursive: true });
+
+    expect(getProjectAgentsDir(proj)).toBe(projAgents);
   });
 });

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -27,8 +27,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
+import { execFileSync } from 'child_process';
 import { ensureLockTarget, atomicWriteFileSync, withFileLock } from './fs-atomic.js';
 import type { Meta, RegistryType } from './types.js';
+import { DEFAULT_SYSTEM_REPO, systemRepoSlug } from './types.js';
 import { machineId } from './machine-id.js';
 
 const HOME = process.env.HOME ?? os.homedir();
@@ -213,6 +215,59 @@ export function getOptionalUserAgentsDir(): string | null {
   return USER_AGENTS_DIR;
 }
 
+/**
+ * Origin `owner/repo` slug (lowercased, `.git` stripped) of a git checkout, or
+ * null when `dir` isn't a git repo / has no origin. Extracts the slug from any
+ * remote URL form: `git@host:owner/repo.git`, `https://host/owner/repo.git`,
+ * `ssh://git@host/owner/repo`. Sync (mirrors readGitConfigUser in git.ts) so it
+ * can be used from the synchronous getProjectAgentsDir walk.
+ */
+function gitOriginSlug(dir: string): string | null {
+  let url: string;
+  try {
+    url = execFileSync('git', ['-C', dir, 'config', '--get', 'remote.origin.url'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim();
+  } catch {
+    return null;
+  }
+  if (!url) return null;
+  const m = url.replace(/\.git$/i, '').match(/[:/]([^/:]+\/[^/]+)$/);
+  return m ? m[1].toLowerCase() : null;
+}
+
+/** Slugs of the user + system DotAgents repos — a checkout of any of these is not a project layer. */
+function canonicalDotAgentsRepoSlugs(): Set<string> {
+  const slugs = new Set<string>([systemRepoSlug(DEFAULT_SYSTEM_REPO).toLowerCase()]);
+  for (const dir of [USER_AGENTS_DIR, SYSTEM_AGENTS_DIR]) {
+    const slug = gitOriginSlug(dir);
+    if (slug) slugs.add(slug);
+  }
+  return slugs;
+}
+
+/**
+ * True when `agentsPath` is itself a git checkout of the user's or system's
+ * DotAgents repo — i.e. a *clone* of the very repo whose rules already load as
+ * the user/system layer (e.g. `git clone …/.agents.git ~/src/github.com/<you>/.agents`).
+ * Such a clone must NOT also be treated as a *project* layer: because project
+ * outranks user, a stale clone would silently shadow the live user rules by
+ * filename and plant a compiled AGENTS.md in an ancestor dir (RUSH-2037).
+ *
+ * A legitimate project layer is a plain subdirectory of a project and is never
+ * itself a git-repo root, so the cheap `.git` gate skips the (git-spawning)
+ * origin comparison for the common case — only a `.agents/` that is its own
+ * checkout pays it, and even then it's kept unless its origin matches the
+ * user/system DotAgents repo (an unrelated repo checked out at `.agents/`,
+ * or a project's own versioned `.agents/`, stays a valid project layer).
+ */
+function isUserOrSystemRepoCheckout(agentsPath: string): boolean {
+  if (!fs.existsSync(path.join(agentsPath, '.git'))) return false;
+  const origin = gitOriginSlug(agentsPath);
+  if (!origin) return false;
+  return canonicalDotAgentsRepoSlugs().has(origin);
+}
+
 /** Walk up from startPath to find a project-scoped .agents/ directory (skipping both roots). */
 export function getProjectAgentsDir(startPath: string = process.cwd()): string | null {
   let dir = path.resolve(startPath);
@@ -220,7 +275,8 @@ export function getProjectAgentsDir(startPath: string = process.cwd()): string |
   while (true) {
     const agentsPath = path.join(dir, '.agents');
     if (fs.existsSync(agentsPath) && fs.statSync(agentsPath).isDirectory()) {
-      if (!isSamePath(agentsPath, SYSTEM_AGENTS_DIR) && !isSamePath(agentsPath, USER_AGENTS_DIR)) {
+      if (!isSamePath(agentsPath, SYSTEM_AGENTS_DIR) && !isSamePath(agentsPath, USER_AGENTS_DIR)
+          && !isUserOrSystemRepoCheckout(agentsPath)) {
         return agentsPath;
       }
     }


### PR DESCRIPTION
**bug-fix** — `apps/cli`. A clone of the user's own DotAgents repo was eligible to become a **project** rules layer (by path, not identity), silently shadowing the live user rules and planting a stale compiled `AGENTS.md` in an ancestor dir.

## The issue

`getProjectAgentsDir` walks up from cwd and returns the first `.agents/` directory, excluding the user/system roots **by path equality only** (`apps/cli/src/lib/state.ts:223`, pre-fix):

```ts
if (!isSamePath(agentsPath, SYSTEM_AGENTS_DIR) && !isSamePath(agentsPath, USER_AGENTS_DIR)) {
  return agentsPath;
}
```

A *clone* of the user repo — `git clone git@github.com:<you>/.agents.git ~/src/github.com/<you>/.agents` — is a **different path**, so it passes and is returned as the project layer whenever cwd is its parent (`~/src/github.com/<you>/`) or a non-git subdir. Because project outranks user in resolution (`apps/cli/src/lib/rules/compose.ts:240-251`, `discoverRulesLayers` adds the project layer when `<projectAgentsDir>/rules/` exists), a **stale** clone's `rules/subrules/*` shadow the live user rules by filename, and every project-scoped path (`getInstructionsPath` in `apps/cli/src/lib/rules/rules.ts:101`, mcp, skills, hooks — ~30 callers) derives from the same walk, so the compile also plants an out-of-date `AGENTS.md` in that ancestor dir that every session beneath it ingests.

`getProjectAgentsDir` is the single chokepoint for project-layer discovery, so both defects share one root cause.

## The fix

Identify a DotAgents repo by **repo identity (git origin), not path** (the ticket's primary suggested direction). `apps/cli/src/lib/state.ts` now skips a candidate `.agents/` that is *itself a git checkout* whose `origin` slug matches the user's or system's DotAgents repo:

```ts
if (!isSamePath(agentsPath, SYSTEM_AGENTS_DIR) && !isSamePath(agentsPath, USER_AGENTS_DIR)
    && !isUserOrSystemRepoCheckout(agentsPath)) {
  return agentsPath;
}
```

`isUserOrSystemRepoCheckout` is gated behind a cheap `fs.existsSync('<candidate>/.git')` — a legitimate project layer is a plain subdirectory of a project and is **never its own git-repo root**, so the common path pays no git spawn. Only a `.agents/` that is its own checkout pays the origin comparison, and even then it is kept unless its origin matches the user/system DotAgents repo. The canonical slug set = the constant system slug (`phnx-labs/.agents-system`) plus the live `origin` of `~/.agents` and `~/.agents/.system` when those are git repos.

## Regression analysis

- **Single source of truth.** All ~30 consumers of project-layer discovery (rules compile, mcp, skills, hooks, subagents, workflows, permissions, versions, doctor, staleness) route through `getProjectAgentsDir`. Fixing it once fixes both defects and touches no consumer.
- **No over-rejection.** The exclusion fires only for a `.agents/` that (a) is its own git-repo root **and** (b) has an origin matching the user/system DotAgents repo. A legit project `.agents/` (a subdir, no own `.git`) and a git repo checked out at `.agents/` with an **unrelated** origin both stay valid project layers. A project `.agents/` that carries its own `agents.yaml` (the `project-resources` fixture does) is unaffected — the discriminator is git identity, not the presence of `agents.yaml`.
- **Walk continuation.** After rejecting a clone, the walk continues upward exactly as before, falling back to the user layer.
- **Cost.** The added work in the hot path is one `fs.existsSync` when a candidate `.agents/` is found; the git reads only run for the pathological clone case.
- **Tests:** 385 tests across state + every `getProjectAgentsDir` consumer (resolve-resource, project-resources pipeline, rules/compose, versions, staleness, doctor) pass unchanged.

## Testing

Real git checkouts, no mocking (repo rule). New tests in `apps/cli/src/lib/state.test.ts`.

**Unit — before-fail / after-pass** (the two rejection tests fail without the guard, prove they catch the bug):

```
# WITHOUT the fix (guard reverted):
 ❯ src/lib/state.test.ts (8 tests | 2 failed)
     × rejects a checkout of the SYSTEM DotAgents repo at .agents/
     × rejects a checkout of the USER DotAgents repo at .agents/ (origin matches ~/.agents)

# WITH the fix:
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**End-to-end — the exact ticket scenario** (live user repo + a stale clone at `~/src/github.com/<you>/.agents`, cwd = the clone's parent), run against the real compiled `getProjectAgentsDir` + `discoverRulesLayers` + `composeRules`:

```
# WITHOUT the fix (current main behavior):
getProjectAgentsDir = .../src/github.com/muqsitnawaz/.agents
rule layers        = project, user, system
effective rule     = "STALE clone telegram rule"      <-- the bug

# WITH the fix:
getProjectAgentsDir = null
rule layers        = user, system
effective rule     = "CURRENT telegram rule"          <-- live user rule wins
```

**Regression sweep:**

```
node ./node_modules/typescript/bin/tsc --noEmit    # rc=0
vitest run src/lib/state.test.ts src/lib/__tests__/resolve-resource.test.ts \
  src/lib/project-launch.test.ts tests/project-resources-pipeline.test.ts \
  src/lib/project-resources.test.ts src/lib/resources/*.test.ts \
  src/lib/rules src/lib/staleness src/lib/__tests__/versions.test.ts \
  src/lib/__tests__/hooks-layering.test.ts
# => 385 passed
```

Docs: the layered-resolution docs (`apps/cli/docs/00-concepts.md`) describe the happy-path project layer, which is unchanged — this restores the intended behavior for a pathological clone. CHANGELOG fragment added at `apps/cli/.changelog/next/RUSH-2037.md`.

Closes RUSH-2037.
