### PR TITLE
feat(projects): show the next Linear milestone on the status card

### DIFF
--- a/apps/cli/.changelog/next/projects-next-milestone.md
+++ b/apps/cli/.changelog/next/projects-next-milestone.md
@@ -1,0 +1,8 @@
+- **`agents projects status` shows the next Linear milestone.** A new `next` line names
+  the project's earliest unfinished milestone with its progress and a human due date
+  (`Beta cut · 3/8 · due in 6 days`, `overdue by 3 days`, `due Aug 21`) — a percentage
+  says how far along a project is, the milestone says what it is due to hit next. The
+  milestone list comes from the project rather than from issue assignments, so a
+  milestone with nothing filed under it yet still shows; it rides along on the first
+  page of the existing issue fetch, costing no extra request. Source:
+  `apps/cli/src/lib/linear-project-counts.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -92,6 +92,7 @@ rush  ·  23 agents  ·  68% plan
   agents   claude · running · RUSH-2107 @zion  ·  codex · idle @mac-mini  ·  +21 more
   ships    4 merged (7d) · 2 open PRs · 3 worktrees · v1.20.91  # gh counts + latest release tag
   linear   12/30 done · 5 in progress           # Linear issue counts (needs linear.projectId)
+  next     Beta cut  ·  3/8  ·  due in 6 days     # the next unfinished Linear milestone
   tickets  RUSH-1201 · RUSH-1198 · …              # tickets worked or created
   proof    11 artifacts (7d) · last: plan-x.html  # artifact.created milestones by cwd
   repos    phnx-labs/rush · rush-infra
@@ -114,6 +115,25 @@ rush  ·  23 agents  ·  68% plan
   slow API (>8s) just omits the line, and `--no-remote` skips it too. `total`
   includes canceled issues; the fetch caps at 2,500 issues and a capped count
   renders as a lower bound (`2500+ done`), never as the complete total.
+- **`next`** is the project's next unfinished Linear milestone — the earliest
+  `targetDate` that is not yet complete — rendered `name · done/total · due …`.
+  A percentage says how far along a project is; the milestone says what it is due
+  to hit next, which is what a person plans around. Undated milestones sort last;
+  the line is omitted when the project declares none or all are complete.
+
+  The milestone **list comes from the project, not from its issues**
+  (`project.projectMilestones`), because a milestone commonly has nothing filed
+  under it yet — deriving the list from issue assignments hides exactly those.
+  Issues supply only the `done/total` progress, and when none are assigned the
+  fraction is omitted rather than printed as a meaningless `0/0`. The list rides
+  along on the **first** page of the existing issue fetch, so the line costs no
+  extra request and inherits the same 8s budget and best-effort degradation.
+
+  Dates read in human terms — `due today`, `due tomorrow`, `due in 6 days`,
+  `overdue by 3 days`, and `due Aug 21` once a countdown stops being useful.
+  Linear stores a calendar date with no timezone, so both sides are compared at
+  **local** midnight; parsing it as UTC would shift the answer by a day for
+  anyone west of Greenwich.
 - **`proof`** counts `artifact.created` activity milestones whose cwd is inside the
   project (`lib/project-status.ts`).
 - `--window <days>` sets the merged-PR / artifact window (default 7).

--- a/apps/cli/src/commands/projects.test.ts
+++ b/apps/cli/src/commands/projects.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { computeProjectListWidths, formatFleetSkippedNote, type ProjectListRow } from './projects.js';
+import {
+  computeProjectListWidths,
+  formatFleetSkippedNote,
+  formatMilestoneDue,
+  formatNextMilestone,
+  type ProjectListRow,
+} from './projects.js';
 
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
@@ -45,5 +51,63 @@ describe('computeProjectListWidths', () => {
   it('collapses to zero-width columns when there is nothing to show', () => {
     expect(computeProjectListWidths([])).toEqual({ name: 0, path: 0, repo: 0 });
     expect(computeProjectListWidths([{ name: 'a', path: '', repo: '' }])).toEqual({ name: 1, path: 0, repo: 0 });
+  });
+});
+
+describe('formatMilestoneDue', () => {
+  /** Local noon on 2026-08-03, so a timezone slip shows up as a whole-day error. */
+  const now = new Date(2026, 7, 3, 12, 0, 0).getTime();
+
+  it('speaks in days a person would use', () => {
+    expect(formatMilestoneDue('2026-08-03', now)).toBe('due today');
+    expect(formatMilestoneDue('2026-08-04', now)).toBe('due tomorrow');
+    expect(formatMilestoneDue('2026-08-09', now)).toBe('due in 6 days');
+    expect(formatMilestoneDue('2026-08-02', now)).toBe('overdue by a day');
+    expect(formatMilestoneDue('2026-07-27', now)).toBe('overdue by 7 days');
+  });
+
+  it('switches to a calendar date once the countdown stops being useful', () => {
+    expect(formatMilestoneDue('2026-08-21', now)).toBe('due Aug 21');
+    // A different year has to say which one.
+    expect(formatMilestoneDue('2027-01-15', now)).toBe('due Jan 15, 2027');
+  });
+
+  it('reads the date at LOCAL midnight, not UTC', () => {
+    // `new Date('2026-08-03')` is UTC midnight — west of Greenwich that is
+    // Aug 2 locally, and this would read "overdue by a day" instead of "today".
+    expect(formatMilestoneDue('2026-08-03', new Date(2026, 7, 3, 23, 59).getTime())).toBe('due today');
+    expect(formatMilestoneDue('2026-08-03', new Date(2026, 7, 3, 0, 1).getTime())).toBe('due today');
+  });
+
+  it('returns nothing for a value that is not a calendar date', () => {
+    expect(formatMilestoneDue('', now)).toBeUndefined();
+    expect(formatMilestoneDue('someday', now)).toBeUndefined();
+    expect(formatMilestoneDue('2026-08-03T00:00:00Z', now)).toBeUndefined();
+  });
+});
+
+describe('formatNextMilestone', () => {
+  const now = new Date(2026, 7, 3, 12, 0, 0).getTime();
+
+  it('reads name, progress, then when it is due', () => {
+    expect(stripAnsi(formatNextMilestone({ name: 'Beta cut', targetDate: '2026-08-09', done: 3, total: 8 }, now)))
+      .toBe('Beta cut  ·  3/8  ·  due in 6 days');
+  });
+
+  it('omits the date entirely when the milestone has none', () => {
+    expect(stripAnsi(formatNextMilestone({ name: 'Someday', done: 0, total: 4 }, now)))
+      .toBe('Someday  ·  0/4');
+  });
+
+  it('omits the fraction when nothing is filed under the milestone yet', () => {
+    // 0/0 is noise. This is the real shape of every milestone in this repo's
+    // own Linear project.
+    expect(stripAnsi(formatNextMilestone({ name: 'Factory onboarding', targetDate: '2026-09-15', done: 0, total: 0 }, now)))
+      .toBe('Factory onboarding  ·  due Sep 15');
+  });
+
+  it('does not print a raw date when the stored value is unparseable', () => {
+    expect(stripAnsi(formatNextMilestone({ name: 'Odd', targetDate: 'not-a-date', done: 1, total: 2 }, now)))
+      .toBe('Odd  ·  1/2');
   });
 });

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -51,7 +51,7 @@ import {
   type ProjectSessionRollup,
   type ProjectRemoteSignals,
 } from '../lib/project-status.js';
-import { fetchLinearProjectCounts, type LinearProjectCounts } from '../lib/linear-project-counts.js';
+import { fetchLinearProjectCounts, type LinearMilestone, type LinearProjectCounts } from '../lib/linear-project-counts.js';
 import { listLinearProjects, pickLinearProject, type LinearPick, type LinearProjectLite } from '../lib/linear-projects.js';
 import {
   buildFactoryImportCandidates,
@@ -191,6 +191,46 @@ export function computeProjectListWidths(rows: ProjectListRow[]): { name: number
   };
 }
 
+/**
+ * A milestone's target date as a person would say it — "due tomorrow",
+ * "overdue by 3 days", "due Aug 21" — never a raw `2026-08-21` or a duration in
+ * hours. Linear stores a calendar date with no timezone, so both sides are
+ * compared at LOCAL midnight; parsing `YYYY-MM-DD` with `new Date(str)` would
+ * read it as UTC and shift the answer by a day for anyone west of Greenwich.
+ */
+export function formatMilestoneDue(targetDate: string, nowMs: number): string | undefined {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(targetDate.trim());
+  if (!m) return undefined;
+  const due = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  if (Number.isNaN(due.getTime())) return undefined;
+  const now = new Date(nowMs);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const days = Math.round((due.getTime() - today.getTime()) / 86_400_000);
+  if (days === 0) return 'due today';
+  if (days === 1) return 'due tomorrow';
+  if (days === -1) return 'overdue by a day';
+  if (days < 0) return `overdue by ${-days} days`;
+  if (days <= 14) return `due in ${days} days`;
+  const sameYear = due.getFullYear() === today.getFullYear();
+  const label = due.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  });
+  return `due ${label}`;
+}
+
+/** The `next` card line: what this project is due to hit, and how far along it is. */
+export function formatNextMilestone(ms: LinearMilestone, nowMs: number): string {
+  const parts = [chalk.bold(ms.name)];
+  // A milestone with nothing filed under it yet has no progress to report —
+  // `0/0` is noise, not information.
+  if (ms.total > 0) parts.push(`${ms.done}/${ms.total}`);
+  const due = ms.targetDate ? formatMilestoneDue(ms.targetDate, nowMs) : undefined;
+  if (due) parts.push(due.startsWith('overdue') ? chalk.yellow(due) : chalk.dim(due));
+  return parts.join(chalk.dim('  ·  '));
+}
+
 function statusBar(r: ProjectSessionRollup): string {
   const parts: string[] = [];
   const push = (n: number | undefined, label: string, color: (s: string) => string) => {
@@ -214,6 +254,7 @@ function renderCard(
   remote: ProjectRemoteSignals | undefined,
   fleet?: HostWorkspaceStatus[],
   linear?: LinearProjectCounts,
+  nowMs: number = Date.now(),
 ): void {
   const agents = r?.agents ?? 0;
   const pct = r ? planPct(r.plan) : undefined;
@@ -230,6 +271,9 @@ function renderCard(
   if (ships.length) console.log(`  ${chalk.dim('ships')}    ${ships.join(' · ')}`);
   if (linear) {
     console.log(`  ${chalk.dim('linear')}   ${linear.done}/${linear.total}${linear.truncated ? '+' : ''} done · ${linear.inProgress} in progress`);
+  }
+  if (linear?.nextMilestone) {
+    console.log(`  ${chalk.dim('next')}     ${formatNextMilestone(linear.nextMilestone, nowMs)}`);
   }
   if (r && r.tickets.length) {
     console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
@@ -538,7 +582,7 @@ export function registerProjectsCommands(program: Command): void {
         return;
       }
       for (const d of defs) {
-        renderCard(d, roll.get(d.name), remote.get(d.name), opts.fleet ? fleetFor(d) : undefined, linear.get(d.name));
+        renderCard(d, roll.get(d.name), remote.get(d.name), opts.fleet ? fleetFor(d) : undefined, linear.get(d.name), nowMs);
       }
       if (fleetSkipped.length > 0) process.stdout.write(formatFleetSkippedNote(fleetSkipped));
     });

--- a/apps/cli/src/lib/linear-project-counts.test.ts
+++ b/apps/cli/src/lib/linear-project-counts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   countsFromIssuesResponse,
   fetchLinearProjectCounts,
+  nextMilestone,
   type LinearIssuesResponse,
 } from './linear-project-counts.js';
 
@@ -87,5 +88,74 @@ describe('fetchLinearProjectCounts — pagination accumulator', () => {
   it('a failed page degrades the whole enrichment to undefined (card omits the line)', async () => {
     const fetchPage = async () => undefined;
     expect(await fetchLinearProjectCounts('proj-1', fetchPage)).toBeUndefined();
+  });
+});
+
+/** An issue node as the query selects it: state plus a milestone id, if any. */
+function issue(stateType: string, msId?: string) {
+  return { state: { type: stateType }, ...(msId ? { projectMilestone: { id: msId } } : {}) };
+}
+
+const M1 = { id: 'm1', name: 'Beta cut', targetDate: '2026-08-21' };
+const M2 = { id: 'm2', name: 'GA', targetDate: '2026-09-30' };
+
+describe('nextMilestone', () => {
+  it('picks the earliest-dated milestone that still has work', () => {
+    expect(
+      nextMilestone([M2, M1], [issue('completed', 'm2'), issue('started', 'm2'), issue('completed', 'm1'), issue('unstarted', 'm1')]),
+    ).toEqual({ name: 'Beta cut', targetDate: '2026-08-21', done: 1, total: 2 });
+  });
+
+  it('surfaces a declared milestone with NO issues filed under it', () => {
+    // The real case: the milestone exists on the project, nothing is assigned
+    // to it yet. Deriving the list from issues made these invisible.
+    expect(nextMilestone([M1], [issue('started'), issue('completed')])).toEqual({
+      name: 'Beta cut',
+      targetDate: '2026-08-21',
+      done: 0,
+      total: 0,
+    });
+  });
+
+  it('skips a finished milestone — done is not "next"', () => {
+    expect(nextMilestone([M1, M2], [issue('completed', 'm1'), issue('completed', 'm1'), issue('started', 'm2')])).toEqual({
+      name: 'GA',
+      targetDate: '2026-09-30',
+      done: 0,
+      total: 1,
+    });
+  });
+
+  it('returns nothing when the project declares no milestones, or all are complete', () => {
+    expect(nextMilestone([], [issue('started', 'm1')])).toBeUndefined();
+    expect(nextMilestone([M1], [issue('completed', 'm1')])).toBeUndefined();
+  });
+
+  it('sorts undated milestones last but still surfaces one when nothing is dated', () => {
+    const undated = { id: 'm3', name: 'Someday' };
+    expect(nextMilestone([undated, M1], [])?.name).toBe('Beta cut');
+    const only = nextMilestone([undated], []);
+    expect(only).toEqual({ name: 'Someday', done: 0, total: 0 });
+    expect(only?.targetDate).toBeUndefined();
+  });
+
+  it('ignores a malformed declared milestone rather than inventing one', () => {
+    expect(nextMilestone([{ name: 'no id' }, { id: 'x', name: '' }], [])).toBeUndefined();
+  });
+});
+
+describe('countsFromIssuesResponse — milestone', () => {
+  it('carries the next milestone alongside the counts, and omits it when there is none', () => {
+    const withMs = countsFromIssuesResponse({
+      issues: { nodes: [issue('completed', 'm1'), issue('started', 'm1')] },
+      project: { projectMilestones: { nodes: [M1] } },
+    });
+    expect(withMs).toEqual({
+      done: 1,
+      total: 2,
+      inProgress: 1,
+      nextMilestone: { name: 'Beta cut', targetDate: '2026-08-21', done: 1, total: 2 },
+    });
+    expect(countsFromIssuesResponse(response(['completed', 'started']))).not.toHaveProperty('nextMilestone');
   });
 });

--- a/apps/cli/src/lib/linear-project-counts.ts
+++ b/apps/cli/src/lib/linear-project-counts.ts
@@ -7,6 +7,12 @@
  * TYPE (triage / backlog / unstarted / started / completed / canceled), never
  * hardcoded state names, same convention as `auto-dispatch-linear.ts`.
  *
+ * The same fetch also yields the **next milestone** — the earliest-dated
+ * milestone with unfinished issues — because each issue node carries its
+ * `projectMilestone`. A percentage tells you how far along a project is; the
+ * milestone tells you what it is due to hit next, which is the thing a person
+ * actually plans around. Deriving it here costs no extra request.
+ *
  * This is a best-effort card enrichment, not an explicit command: every failure
  * (no credential, offline, API error, timeout) degrades to `undefined` and the
  * card simply omits the line — never a hang, never a throw. `--no-remote`
@@ -31,6 +37,34 @@ const PAGE_SIZE = 250;
 /** Hard page cap so a pathological project can't page forever within the budget. */
 const MAX_PAGES = 10;
 
+/**
+ * The next checkpoint the project is working toward: the earliest-dated
+ * milestone that still has unfinished issues. A percentage says how far along
+ * the project is; this says what it is due to hit next.
+ */
+export interface LinearMilestone {
+  name: string;
+  /** `YYYY-MM-DD` as Linear stores it. Absent when the milestone has no date. */
+  targetDate?: string;
+  /** Issues in this milestone in a `completed`-type state. */
+  done: number;
+  /**
+   * Issues assigned to this milestone. Legitimately `0` — a milestone can be
+   * declared with a date long before any issue is filed under it (that is the
+   * state of every milestone in this repo's own Linear project), and such a
+   * milestone is still the next checkpoint. The card omits the fraction rather
+   * than printing a meaningless `0/0`.
+   */
+  total: number;
+}
+
+/** A milestone as the project declares it, independent of any issue. */
+export interface LinearMilestoneNode {
+  id?: string;
+  name?: string;
+  targetDate?: string | null;
+}
+
 /** The counts the card renders. `total` counts every issue in the project. */
 export interface LinearProjectCounts {
   /** Issues in a `completed`-type state. */
@@ -44,14 +78,29 @@ export interface LinearProjectCounts {
    * bound (rendered `2500+`), never presented as the complete count.
    */
   truncated?: boolean;
+  /**
+   * The next unfinished milestone, when the project has one. Derived from the
+   * SAME paged issue fetch as the counts — a milestone is only ever a grouping
+   * of these issues, so asking Linear again would spend a second round trip to
+   * learn what the first already said.
+   */
+  nextMilestone?: LinearMilestone;
+}
+
+/** One issue node as the query selects it. */
+export interface LinearIssueNode {
+  state?: { type?: string } | null;
+  projectMilestone?: { id?: string; name?: string; targetDate?: string | null } | null;
 }
 
 /** The GraphQL response shape this module consumes (recorded for the tests). */
 export interface LinearIssuesResponse {
   issues?: {
-    nodes?: Array<{ state?: { type?: string } | null }>;
+    nodes?: LinearIssueNode[];
     pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
   };
+  /** Only the FIRST page asks for this — the milestone list does not paginate. */
+  project?: { projectMilestones?: { nodes?: LinearMilestoneNode[] } } | null;
 }
 
 /**
@@ -68,7 +117,60 @@ export function countsFromIssuesResponse(data: LinearIssuesResponse): LinearProj
     if (type === 'completed') done++;
     else if (type === 'started') inProgress++;
   }
-  return { done, total: nodes.length, inProgress };
+  const counts: LinearProjectCounts = { done, total: nodes.length, inProgress };
+  const next = nextMilestone(data.project?.projectMilestones?.nodes ?? [], nodes);
+  if (next) counts.nextMilestone = next;
+  return counts;
+}
+
+/**
+ * Pick the milestone the project is working toward next.
+ *
+ * The **declared** list is authoritative for which milestones exist, their
+ * names, and their dates; issues only supply progress. Deriving the list from
+ * issues instead looks tempting (it costs no extra request) and is wrong: a
+ * milestone with nothing filed under it yet would be invisible, and that is the
+ * common case — every milestone in this repo's own Linear project has zero
+ * issues assigned, so an issue-derived list showed nothing at all.
+ *
+ * Next = the earliest-dated milestone that is not finished. A milestone with no
+ * issues counts as unfinished (it is upcoming work, not completed work). Undated
+ * milestones sort last, ties break by declaration order, so the answer is stable.
+ */
+export function nextMilestone(
+  declared: LinearMilestoneNode[],
+  nodes: LinearIssueNode[],
+): LinearMilestone | undefined {
+  // Progress per milestone id, from whatever issues do carry one.
+  const progress = new Map<string, { done: number; total: number }>();
+  for (const n of nodes) {
+    const id = n?.projectMilestone?.id;
+    if (!id) continue;
+    const p = progress.get(id) ?? { done: 0, total: 0 };
+    p.total++;
+    if (n.state?.type === 'completed') p.done++;
+    progress.set(id, p);
+  }
+  const candidates = declared
+    .map((d, order) => {
+      if (!d?.id || typeof d.name !== 'string' || !d.name) return undefined;
+      const p = progress.get(d.id) ?? { done: 0, total: 0 };
+      const m: LinearMilestone & { order: number } = { name: d.name, done: p.done, total: p.total, order };
+      if (d.targetDate) m.targetDate = d.targetDate;
+      return m;
+    })
+    .filter((m): m is LinearMilestone & { order: number } => m !== undefined)
+    // total 0 means "declared, nothing filed yet" — unfinished, not done.
+    .filter((m) => m.total === 0 || m.done < m.total);
+  if (candidates.length === 0) return undefined;
+  candidates.sort((a, b) => {
+    if (a.targetDate && b.targetDate) return a.targetDate < b.targetDate ? -1 : a.targetDate > b.targetDate ? 1 : a.order - b.order;
+    if (a.targetDate) return -1;
+    if (b.targetDate) return 1;
+    return a.order - b.order;
+  });
+  const { order: _order, ...m } = candidates[0];
+  return m;
 }
 
 /** $LINEAR_API_KEY → macOS Keychain → ~/.linear-cli/config.json. Null if none. */
@@ -99,12 +201,15 @@ export async function fetchLinearProjectCounts(
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
   try {
-    const all: Array<{ state?: { type?: string } | null }> = [];
+    const all: LinearIssueNode[] = [];
+    // Declared on the project, not on its issues — only page 0 asks for it.
+    let declared: LinearMilestoneNode[] = [];
     let after: string | undefined;
     let truncated = false;
     for (let page = 0; ; page++) {
       const data = await fetchPage(projectId, after, ctrl.signal);
       if (!data) return undefined;
+      if (page === 0) declared = data.project?.projectMilestones?.nodes ?? [];
       all.push(...(data.issues?.nodes ?? []));
       const pi = data.issues?.pageInfo;
       if (!pi?.hasNextPage || !pi.endCursor) break;
@@ -115,7 +220,13 @@ export async function fetchLinearProjectCounts(
       }
       after = pi.endCursor;
     }
-    return { ...countsFromIssuesResponse({ issues: { nodes: all } }), ...(truncated ? { truncated } : {}) };
+    return {
+      ...countsFromIssuesResponse({
+        issues: { nodes: all },
+        project: { projectMilestones: { nodes: declared } },
+      }),
+      ...(truncated ? { truncated } : {}),
+    };
   } catch {
     return undefined;
   } finally {
@@ -131,15 +242,25 @@ async function fetchLinearIssuesPage(
 ): Promise<LinearIssuesResponse | undefined> {
   const apiKey = resolveApiKey();
   if (!apiKey) return undefined;
+  // The declared-milestone list rides along on the FIRST page only — it does
+  // not paginate, and re-requesting it per page would spend up to MAX_PAGES
+  // copies of the same answer.
+  const issuesSelection =
+    'issues(filter:{ project:{ id:{ eq:$p } } }, first:' +
+    PAGE_SIZE +
+    ', after:$after){ nodes{ state{ type } projectMilestone{ id } } pageInfo{ hasNextPage endCursor } }';
+  const milestonesSelection = 'project(id:$pid){ projectMilestones(first:50){ nodes{ id name targetDate } } }';
+  const first = after === undefined;
   const res = await fetch(LINEAR_API, {
     method: 'POST',
     headers: { Authorization: apiKey, 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      query:
-        'query($p:ID!, $after:String){ issues(filter:{ project:{ id:{ eq:$p } } }, first:' +
-        PAGE_SIZE +
-        ', after:$after){ nodes{ state{ type } } pageInfo{ hasNextPage endCursor } } }',
-      variables: { p: projectId, after: after ?? null },
+      query: first
+        ? `query($p:ID!, $pid:String!, $after:String){ ${issuesSelection} ${milestonesSelection} }`
+        : `query($p:ID!, $after:String){ ${issuesSelection} }`,
+      variables: first
+        ? { p: projectId, pid: projectId, after: null }
+        : { p: projectId, after },
     }),
     signal,
   });


### PR DESCRIPTION
**What + type:** feature — `agents projects status` gains a `next` line: the project's next unfinished Linear milestone, with progress and a human due date.

Follow-up to #1840, requested directly: a percentage says how far along a project is; the milestone says what it is **due to hit next**, which is what a person plans around.

## The run (this repo's real Linear project)

<img width="5440" height="1208" alt="agents projects status showing the next Linear milestone line" src="https://github.com/user-attachments/assets/869fac19-60b8-4184-a227-373be6a341b8" />

```
  linear   367/448 done · 12 in progress
  next     Factory converts strategy to shipped outcomes  ·  due Sep 15
```

Earliest of the three milestones declared on the project. No fraction, because nothing is filed under it yet — see below.

## The design decision worth reviewing

The obvious implementation reads each issue's `projectMilestone` and groups. It costs **no extra request**, since the card already pages every issue. I built that first, and against real data it printed nothing:

```
$ issues(filter:{project:{id:"…agents-cli"}}, first:250){ nodes{ projectMilestone{ name } } }
issues sampled: 250
   250  (none)
```

The project declares three milestones; **zero issues are assigned to any of them.** An issue-derived list makes exactly the milestones you have invisible.

So the list comes from `project.projectMilestones` — authoritative for which milestones exist, their names and dates — and issues supply only `done/total`. A milestone with no issues counts as **unfinished** (upcoming work, not completed work) and reports `total: 0`, which the card renders **without** a fraction rather than as a meaningless `0/0`.

It still costs no extra round trip: the milestone list does not paginate, so it rides along as a second selection on the **first** page of the existing issue query only (pages 2..10 send the issues selection alone). Same 8s budget, same best-effort degradation — any failure just omits the line.

## Dates

`due today` · `due tomorrow` · `due in 6 days` · `overdue by 3 days` · `due Aug 21` once a countdown stops being useful, and `due Jan 15, 2027` across a year boundary.

Linear stores a calendar date with no timezone. Both sides are compared at **local** midnight — `new Date('2026-08-03')` is UTC midnight, which is Aug 2 locally for anyone west of Greenwich and would report a milestone due today as overdue by a day. Pinned by a test at both 00:01 and 23:59 local.

## Tests

51 pass across the touched suites. `nextMilestone` is pure and covers the declared-with-no-issues case, finished milestones being skipped, undated sorting last, and a malformed declaration being ignored rather than invented. `formatMilestoneDue` covers each phrasing band, the year boundary, the UTC-vs-local trap, and unparseable input returning nothing instead of leaking a raw `2026-08-03`.

Docs: `apps/cli/docs/11-projects.md` — the card example plus a `next` bullet explaining why the list is project-sourced. Changelog fragment at `.changelog/next/projects-next-milestone.md`.

Ticket: RUSH-2135 covered the import work in #1840; this line was requested on top of it.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
