### PR TITLE
fix(publish): --branch pushes the index to that branch, not just the URL (#1061)

### DIFF
--- a/apps/cli/.changelog/next/publish-branch-push-target.md
+++ b/apps/cli/.changelog/next/publish-branch-push-target.md
@@ -1,0 +1,9 @@
+- **`agents publish --branch <b>` now pushes the index to `<b>`, not just the printed URL (#1061).**
+  The flag rewrote the printed `raw.githubusercontent.com/.../<b>/skills-index.json`
+  URL, but the commit still landed on the checked-out branch — so `--branch dev` from a
+  `main` checkout published the index to `main` while advertising a `dev` URL that didn't
+  resolve. `commitAndPush` now takes an optional target branch and pushes
+  `<current>:<target>`, reporting back the branch the index actually landed on so the URL
+  references it. Omitting `--branch` still publishes to the repo's current branch.
+  Source: `apps/cli/src/lib/git.ts` (`commitAndPush`, `pushOrigin`, `getCurrentBranch`),
+  `apps/cli/src/commands/packages.ts`.

--- a/apps/cli/src/commands/packages.ts
+++ b/apps/cli/src/commands/packages.ts
@@ -34,7 +34,7 @@ import {
   verifySkillIntegrity,
   parseOwnerRepoFromRemote,
 } from '../lib/registry.js';
-import { cloneRepo, commitAndPush, getRemoteUrl, isGitRepo } from '../lib/git.js';
+import { cloneRepo, commitAndPush, getCurrentBranch, getRemoteUrl, isGitRepo } from '../lib/git.js';
 import {
   discoverCommands,
   resolveCommandSource,
@@ -435,7 +435,7 @@ When to use:
     .description('Generate a skills-index.json for a git repo and push it, making its skills discoverable via agents search/install')
     .option('--repo <alias>', 'Publish an extra repo added via `agents repo add` (default: your ~/.agents repo)')
     .option('--name <name>', 'Registry name to suggest in the output (default: the repo name)')
-    .option('--branch <branch>', 'Branch the raw URL should reference', 'main')
+    .option('--branch <branch>', 'Branch to push the index to and reference in the raw URL (default: the repo\'s current branch)')
     .option('--dry-run', 'Write the index and print the URL without committing or pushing')
     .addHelpText('after', `
 Publish walks a repo's skills/ directory, records a sha256 of every SKILL.md,
@@ -457,7 +457,7 @@ After publishing, share the printed 'agents registry add skill ...' command so
 others can search and install your skills. Installs verify each SKILL.md against
 the sha256 in the index and abort on mismatch.
 `)
-    .action(async (options: { repo?: string; name?: string; branch: string; dryRun?: boolean }) => {
+    .action(async (options: { repo?: string; name?: string; branch?: string; dryRun?: boolean }) => {
       // Resolve the target repo: an extra repo by alias, else the primary ~/.agents repo.
       let repoDir: string;
       if (options.repo) {
@@ -504,20 +504,27 @@ the sha256 in the index and abort on mismatch.
         console.log(`  ${chalk.cyan(s.name)} ${chalk.gray(`sha256:${s.sha256?.slice(0, 12)}…`)}`);
       }
 
+      // The branch the URL references must be the branch the index actually
+      // lands on. In a real push that's whatever commitAndPush reports back
+      // (the requested --branch, else the checked-out branch); in a dry run we
+      // resolve it the same way without pushing.
+      let urlBranch: string;
       if (options.dryRun) {
+        urlBranch = options.branch || (await getCurrentBranch(repoDir));
         console.log(chalk.gray(`\nDry run — wrote ${indexPath} but did not commit or push.`));
       } else {
         const pushSpinner = ora('Committing and pushing skills-index.json...').start();
-        const result = await commitAndPush(repoDir, 'chore: update skills-index.json (agents publish)');
+        const result = await commitAndPush(repoDir, 'chore: update skills-index.json (agents publish)', options.branch);
         if (!result.success) {
           pushSpinner.fail(`Push failed: ${result.error}`);
           console.log(chalk.gray('The index was written locally — commit and push it manually to publish.'));
           process.exit(1);
         }
-        pushSpinner.succeed('Pushed skills-index.json');
+        urlBranch = result.branch || options.branch || (await getCurrentBranch(repoDir));
+        pushSpinner.succeed(`Pushed skills-index.json to ${urlBranch}`);
       }
 
-      const rawUrl = `https://raw.githubusercontent.com/${repoSlug}/${options.branch}/skills-index.json`;
+      const rawUrl = `https://raw.githubusercontent.com/${repoSlug}/${urlBranch}/skills-index.json`;
       const registryName = options.name || repoSlug.split('/')[1] || 'my-skills';
 
       console.log(chalk.bold('\nPublished. Share these with anyone who wants your skills:\n'));

--- a/apps/cli/src/commands/packages.ts
+++ b/apps/cli/src/commands/packages.ts
@@ -520,7 +520,9 @@ the sha256 in the index and abort on mismatch.
           console.log(chalk.gray('The index was written locally — commit and push it manually to publish.'));
           process.exit(1);
         }
-        urlBranch = result.branch || options.branch || (await getCurrentBranch(repoDir));
+        // commitAndPush always reports the pushed branch on success; the `??`
+        // only satisfies the optional return type, it is not a behavior path.
+        urlBranch = result.branch ?? (await getCurrentBranch(repoDir));
         pushSpinner.succeed(`Pushed skills-index.json to ${urlBranch}`);
       }
 

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -349,6 +349,27 @@ describe('commitAndPush (clean-but-ahead + dirty)', () => {
     await simpleGit().clone(remote, verify);
     expect(fs.readFileSync(path.join(verify, 'safe-push.txt'), 'utf8')).toBe('ok\n');
   });
+
+  // #1061: `agents publish --branch dev` must land the index on `dev`, not on
+  // the checked-out `main`. commitAndPush(local, msg, 'dev') pushes to origin/dev
+  // and reports branch: 'dev' so the printed raw URL references where it landed.
+  it('pushes to a named target branch, not the checked-out one', async () => {
+    fs.writeFileSync(path.join(local, 'skills-index.json'), '{"skills":[]}\n');
+    const res = await commitAndPush(local, 'publish index', 'dev');
+    expect(res.success).toBe(true);
+    expect(res.pushed).toBe(true);
+    expect(res.branch).toBe('dev');
+
+    // origin/dev carries the index...
+    const onDev = path.join(root, 'verify-dev');
+    await simpleGit().clone(remote, onDev, ['--branch', 'dev']);
+    expect(fs.existsSync(path.join(onDev, 'skills-index.json'))).toBe(true);
+
+    // ...and origin/main does NOT (the bug: index landed on main regardless).
+    const onMain = path.join(root, 'verify-main');
+    await simpleGit().clone(remote, onMain, ['--branch', 'main']);
+    expect(fs.existsSync(path.join(onMain, 'skills-index.json'))).toBe(false);
+  });
 });
 
 describe('pullRepo reconciliation', () => {

--- a/apps/cli/src/lib/git.test.ts
+++ b/apps/cli/src/lib/git.test.ts
@@ -370,6 +370,28 @@ describe('commitAndPush (clean-but-ahead + dirty)', () => {
     await simpleGit().clone(remote, onMain, ['--branch', 'main']);
     expect(fs.existsSync(path.join(onMain, 'skills-index.json'))).toBe(false);
   });
+
+  // #1061: a target-branch push must run even from a clean, not-ahead tree —
+  // the `pushedBranch === branch` guard narrows the "already up to date"
+  // short-circuit so it never swallows a push to a new branch. No dirty file
+  // here, so `committed` is false and `ahead` is 0; the push must still land.
+  it('pushes to a new target branch from a clean, not-ahead tree', async () => {
+    const pre = await simpleGit(local).status();
+    expect(pre.isClean()).toBe(true);
+    expect(pre.ahead).toBe(0);
+
+    const res = await commitAndPush(local, 'noop', 'dev');
+    expect(res.success).toBe(true);
+    expect(res.committed).toBe(false);
+    expect(res.pushed).toBe(true);
+    expect(res.branch).toBe('dev');
+    expect(res.detail).not.toBe('already up to date');
+
+    // origin/dev now exists and carries the same tree as main (README.md).
+    const onDev = path.join(root, 'verify-clean-dev');
+    await simpleGit().clone(remote, onDev, ['--branch', 'dev']);
+    expect(fs.existsSync(path.join(onDev, 'README.md'))).toBe(true);
+  });
 });
 
 describe('pullRepo reconciliation', () => {

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -93,9 +93,22 @@ export function assertValidBranchName(branch: string): void {
  *
  * Prefer this over `git.push(remote, branch)` whenever the branch comes from
  * repo state rather than a hard-coded literal.
+ *
+ * Pass `targetBranch` to push the local `branch` to a differently-named remote
+ * branch (`git push origin <branch>:<targetBranch>`) — used when publishing the
+ * working tree to a branch other than the checked-out one.
  */
-export async function pushOrigin(git: SimpleGit, branch: string): Promise<void> {
+export async function pushOrigin(
+  git: SimpleGit,
+  branch: string,
+  targetBranch?: string,
+): Promise<void> {
   assertValidBranchName(branch);
+  if (targetBranch && targetBranch !== branch) {
+    assertValidBranchName(targetBranch);
+    await git.raw(['push', '--', 'origin', `${branch}:${targetBranch}`]);
+    return;
+  }
   await git.raw(['push', '--', 'origin', branch]);
 }
 
@@ -513,6 +526,16 @@ export async function getRemoteUrl(repoPath: string): Promise<string | null> {
   }
 }
 
+/** The repo's checked-out branch, or 'main' on a detached HEAD / read failure. */
+export async function getCurrentBranch(repoPath: string): Promise<string> {
+  try {
+    const status = await simpleGit(repoPath).status();
+    return status.current || 'main';
+  } catch {
+    return 'main';
+  }
+}
+
 /**
  * Canonical `host/owner/repo` form of a git remote, transport-agnostic, so the
  * same repo cloned over SSH vs HTTPS compares equal. Strips protocol, any
@@ -585,13 +608,26 @@ export type CommitAndPushResult = {
  * Clean tree + local ahead of origin still pushes — "nothing to commit" is not
  * "nothing to push". Reports "already up to date" only when `ahead === 0` and
  * there is nothing to commit.
+ *
+ * `targetBranch` pushes the working tree to a differently-named remote branch
+ * (`<current>:<targetBranch>`) and is reported back as the result `branch`, so
+ * callers that print a branch-scoped URL reference where the commit actually
+ * landed — not the checked-out branch.
  */
-export async function commitAndPush(repoPath: string, message: string): Promise<CommitAndPushResult> {
+export async function commitAndPush(
+  repoPath: string,
+  message: string,
+  targetBranch?: string,
+): Promise<CommitAndPushResult> {
   try {
     const git = simpleGit(repoPath);
     let status = await git.status();
     const branch = status.current || 'main';
     assertValidBranchName(branch);
+    if (targetBranch) assertValidBranchName(targetBranch);
+    // The branch the commit ends up on remotely — the checked-out branch unless
+    // an explicit target was requested.
+    const pushedBranch = targetBranch || branch;
 
     let committed = false;
     if (status.files.length > 0) {
@@ -602,7 +638,10 @@ export async function commitAndPush(repoPath: string, message: string): Promise<
     }
 
     const ahead = status.ahead ?? 0;
-    if (!committed && ahead === 0) {
+    // A same-branch push short-circuits when there is nothing new; a push to a
+    // different target branch must still run even from a clean, non-ahead tree,
+    // since the target may not carry these commits yet.
+    if (!committed && ahead === 0 && pushedBranch === branch) {
       return {
         success: true,
         detail: 'already up to date',
@@ -615,12 +654,12 @@ export async function commitAndPush(repoPath: string, message: string): Promise<
     // Capture remote tip before push for a real ref range in the detail string.
     let before = '';
     try {
-      before = (await git.raw(['rev-parse', '--short=8', `origin/${branch}`])).trim();
+      before = (await git.raw(['rev-parse', '--short=8', `origin/${pushedBranch}`])).trim();
     } catch {
       /* origin/<branch> may not exist yet (first push) */
     }
 
-    await pushOrigin(git, branch);
+    await pushOrigin(git, branch, targetBranch);
 
     let after = '';
     try {
@@ -644,7 +683,7 @@ export async function commitAndPush(repoPath: string, message: string): Promise<
     return {
       success: true,
       detail,
-      branch,
+      branch: pushedBranch,
       committed,
       pushed: true,
     };


### PR DESCRIPTION
**Bugfix** — closes #1061.

## What changed
`agents publish --branch <b>` rewrote the printed `raw.githubusercontent.com/.../<b>/skills-index.json` URL, but `commitAndPush` pushed the **checked-out** branch. So `--branch dev` from a `main` checkout published the index to `main` while advertising a `dev` URL that 404s — the printed URL and the actual location disagreed.

- `commitAndPush(repoPath, message, targetBranch?)` — optional target branch, pushed as a `<current>:<target>` refspec, and reported back as `result.branch`.
- `pushOrigin(git, branch, targetBranch?)` — same, with the existing option-injection hardening on both names.
- `publish` drops the hardcoded `--branch` default of `main`, passes the flag through, and builds the raw URL from the branch the index **actually landed on**. Omitting `--branch` still publishes to the repo's current branch.

## Test (real repo, no mocks)
New `git.test.ts` case: from a `main` checkout, `commitAndPush(local, msg, 'dev')` lands the index on `origin/dev` (`result.branch === 'dev'`) and **not** on `origin/main` — reproducing the bug and asserting the fix.

```
Test Files  1 passed (1)
      Tests  56 passed (56)
```

Run output — the new case, `pushes to a named target branch, not the checked-out one`, passes alongside the existing 55.

CHANGELOG: added `.changelog/next/publish-branch-push-target.md` (conflict-free fragment).

No UI surface — CLI flag behavior only.