### PR TITLE
feat(hooks): accept Go-style duration strings for hook timeout (#1555)

### DIFF
--- a/apps/cli/.changelog/next/hook-timeout-duration-strings.md
+++ b/apps/cli/.changelog/next/hook-timeout-duration-strings.md
@@ -1,0 +1,8 @@
+- **Hook `timeout` in agents.yaml now accepts duration strings, not just bare seconds (#1555).**
+  A hook can be written `timeout: 5s` / `timeout: 2m` / `timeout: 1h30m` instead of only
+  `timeout: 30` — self-documenting at the call site. A bare number still means seconds, so
+  every existing manifest keeps working. `parseHookManifest` normalizes the value to a
+  seconds number once, so all harness serializers keep consuming a number; an unparseable
+  timeout is dropped with a warning rather than silently coerced. Source:
+  `apps/cli/src/lib/hooks.ts` (`normalizeHookTimeoutSeconds`, `parseHookManifest`),
+  `apps/cli/docs/hooks.md`.

--- a/apps/cli/docs/hooks.md
+++ b/apps/cli/docs/hooks.md
@@ -81,7 +81,7 @@ hooks:
     script: post-edit.sh               # filename in ~/.agents/hooks/
     events:
       - PostToolUse
-    timeout: 30                        # seconds; default 600
+    timeout: 30s                       # seconds, or a duration string (5s, 2m, 1h30m); default 600
     matcher: "Edit"                    # optional: tool name filter (PreToolUse/PostToolUse)
     matches:
       cwd_includes: /projects/myapp    # predicate: only fire in this path
@@ -105,7 +105,7 @@ hooks:
 |-------|------|----------|-------------|
 | `script` | string | yes | Filename of the shell script in `~/.agents/hooks/` (or system hooks dir) |
 | `events` | `string[]` | yes | One or more lifecycle events that trigger this hook |
-| `timeout` | number | no | Seconds before the hook is killed; default `600` |
+| `timeout` | number \| string | no | Time before the hook is killed; default `600`. A bare number is seconds; a duration string (`5s`, `2m`, `1h30m`) is also accepted and normalized to seconds |
 | `matcher` | string | no | Tool name substring filter for `PreToolUse`/`PostToolUse` events (Codex) |
 | `matches` | `HookMatches` | no | Predicate set; all predicates AND together |
 | `enabled` | boolean | no | Set `false` in user layer to disable a system-shipped hook of the same name |

--- a/apps/cli/src/lib/__tests__/hooks-layering.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks-layering.test.ts
@@ -44,7 +44,7 @@ vi.mock('../versions.js', () => ({
   listInstalledVersions: () => [],
 }));
 
-import { parseHookManifest } from '../hooks.js';
+import { normalizeHookTimeoutSeconds, parseHookManifest } from '../hooks.js';
 
 describe('parseHookManifest layering', () => {
   beforeEach(() => {
@@ -120,6 +120,38 @@ describe('parseHookManifest layering', () => {
     expect(out['shared'].timeout).toBe(10);
     expect(warn).toHaveBeenCalledWith(
       "[agents hooks] User-layer hook 'shared' shadows system-shipped hook. Set 'override: true' to silence this warning.",
+    );
+  });
+
+  // #1555: a duration-string timeout in agents.yaml normalizes to a seconds
+  // number, so every downstream serializer keeps reading a number.
+  it('normalizes a duration-string timeout to seconds', () => {
+    fs.writeFileSync(
+      path.join(USER_DIR, 'agents.yaml'),
+      'hooks:\n' +
+        '  quick:\n    script: q.sh\n    events: [Stop]\n    timeout: 5s\n' +
+        '  slow:\n    script: s.sh\n    events: [Stop]\n    timeout: 1h30m\n' +
+        '  bare:\n    script: b.sh\n    events: [Stop]\n    timeout: 45\n',
+      'utf-8'
+    );
+    const out = parseHookManifest();
+    expect(out['quick'].timeout).toBe(5);
+    expect(out['slow'].timeout).toBe(5400);
+    expect(out['bare'].timeout).toBe(45);
+  });
+
+  it('drops an unparseable timeout with a warning, leaving other fields intact', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fs.writeFileSync(
+      path.join(USER_DIR, 'agents.yaml'),
+      'hooks:\n  bad:\n    script: bad.sh\n    events: [Stop]\n    timeout: "soon"\n',
+      'utf-8'
+    );
+    const out = parseHookManifest();
+    expect(out['bad'].script).toBe('bad.sh');
+    expect(out['bad'].timeout).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Hook 'bad' has an invalid timeout"),
     );
   });
 
@@ -243,5 +275,36 @@ describe('parseHookManifest layering', () => {
     ENABLED_EXTRAS = [{ alias: 'work', dir: extraDir, url: 'gh:me/.agents-work' }];
 
     expect(parseHookManifest()).not.toHaveProperty('work-session');
+  });
+});
+
+describe('normalizeHookTimeoutSeconds', () => {
+  it('keeps a positive number as seconds (backward compatible)', () => {
+    expect(normalizeHookTimeoutSeconds(30)).toBe(30);
+    expect(normalizeHookTimeoutSeconds(600)).toBe(600);
+  });
+
+  it('parses duration strings into seconds', () => {
+    expect(normalizeHookTimeoutSeconds('5s')).toBe(5);
+    expect(normalizeHookTimeoutSeconds('2m')).toBe(120);
+    expect(normalizeHookTimeoutSeconds('90s')).toBe(90);
+    expect(normalizeHookTimeoutSeconds('1h')).toBe(3600);
+    expect(normalizeHookTimeoutSeconds('1h30m')).toBe(5400);
+    expect(normalizeHookTimeoutSeconds('1m30s')).toBe(90);
+  });
+
+  it('treats a bare integer string as seconds', () => {
+    expect(normalizeHookTimeoutSeconds('45')).toBe(45);
+  });
+
+  it('returns null for non-positive or unparseable values', () => {
+    expect(normalizeHookTimeoutSeconds(0)).toBeNull();
+    expect(normalizeHookTimeoutSeconds(-5)).toBeNull();
+    expect(normalizeHookTimeoutSeconds('0s')).toBeNull();
+    expect(normalizeHookTimeoutSeconds('soon')).toBeNull();
+    expect(normalizeHookTimeoutSeconds('5 minutes')).toBeNull();
+    expect(normalizeHookTimeoutSeconds('')).toBeNull();
+    expect(normalizeHookTimeoutSeconds(undefined)).toBeNull();
+    expect(normalizeHookTimeoutSeconds(null)).toBeNull();
   });
 });

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -1117,13 +1117,52 @@ export function listCentralHooks(): HookEntry[] {
 }
 
 /**
+ * Normalize a hook `timeout` from agents.yaml into a whole number of seconds.
+ *
+ * A bare number stays seconds (`timeout: 30` → 30) for backward compatibility.
+ * A Go-style duration string is parsed into seconds: `5s`, `2m`, `1h30m`,
+ * `90s`, `1h`. This intentionally does NOT reuse {@link parseTimeout} from
+ * routines.ts — that one returns milliseconds, has no seconds (`s`) unit, and
+ * floors at one minute, none of which fit hook timeouts (typically 5–600s).
+ *
+ * Returns the seconds value, or `null` when the input is not a positive number
+ * or a parseable duration string — the caller decides how to surface that.
+ */
+export function normalizeHookTimeoutSeconds(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? value : null;
+  }
+  if (typeof value === 'string') {
+    const s = value.trim();
+    if (s === '') return null;
+    // A bare integer string means seconds, matching the bare-number form.
+    if (/^\d+$/.test(s)) {
+      const n = Number(s);
+      return n > 0 ? n : null;
+    }
+    const m = s.match(/^(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+    if (!m || m[0] === '') return null;
+    const weeks = Number(m[1] || 0);
+    const days = Number(m[2] || 0);
+    const hours = Number(m[3] || 0);
+    const minutes = Number(m[4] || 0);
+    const seconds = Number(m[5] || 0);
+    const total = ((weeks * 7 + days) * 24 + hours) * 3600 + minutes * 60 + seconds;
+    return total > 0 ? total : null;
+  }
+  return null;
+}
+
+/**
  * Parse hook manifests. Reads system hooks from ~/.agents/.system/hooks.yaml
  * (npm-shipped defaults) and user hooks from the `hooks:` section of
  * ~/.agents/agents.yaml. Merges with user-wins-on-key-collision precedence.
  * A user entry with `enabled: false` disables the system-shipped hook of
  * the same name without forking the system file.
  *
- * Hooks marked `enabled: false` are dropped from the returned map.
+ * Hooks marked `enabled: false` are dropped from the returned map. A hook
+ * `timeout` written as a duration string (`5s`, `2m`) is normalized to a
+ * seconds number here, so every downstream serializer keeps reading a number.
  */
 export function parseHookManifest(opts: { warn?: boolean } = {}): Record<string, ManifestHook> {
   const warn = opts.warn !== false;
@@ -1186,6 +1225,28 @@ export function parseHookManifest(opts: { warn?: boolean } = {}): Record<string,
   for (const [name, def] of Object.entries(merged)) {
     if (def.enabled === false) delete merged[name];
   }
+
+  // Normalize each surviving hook's timeout to a seconds number, so the raw
+  // agents.yaml can express it as a duration string (`5s`, `2m`) while every
+  // downstream serializer keeps consuming a plain number. An unparseable value
+  // is dropped with a warning rather than silently coerced to a wrong duration.
+  for (const [name, def] of Object.entries(merged)) {
+    const raw = (def as { timeout?: unknown }).timeout;
+    if (raw === undefined) continue;
+    const seconds = normalizeHookTimeoutSeconds(raw);
+    if (seconds === null) {
+      if (warn) {
+        console.warn(
+          `[agents hooks] Hook '${name}' has an invalid timeout ${JSON.stringify(raw)}; ` +
+          `expected seconds or a duration string like '5s', '2m', '1h30m'. Ignoring it.`,
+        );
+      }
+      delete def.timeout;
+    } else {
+      def.timeout = seconds;
+    }
+  }
+
   return merged;
 }
 

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -1141,7 +1141,7 @@ export function normalizeHookTimeoutSeconds(value: unknown): number | null {
       return n > 0 ? n : null;
     }
     const m = s.match(/^(?:(\d+)w)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
-    if (!m || m[0] === '') return null;
+    if (!m) return null;
     const weeks = Number(m[1] || 0);
     const days = Number(m[2] || 0);
     const hours = Number(m[3] || 0);

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -300,6 +300,12 @@ export type HookCache = string | HookCacheConfig;
 export interface ManifestHook {
   script: string;
   events: string[];
+  /**
+   * Seconds before the hook is killed (default 600). In agents.yaml this may be
+   * written as a bare number (seconds) or a duration string (`5s`, `2m`,
+   * `1h30m`); `parseHookManifest` normalizes it to a seconds number here, so
+   * consumers always see a number.
+   */
   timeout?: number;
   matcher?: string;
   /** @deprecated Use the agent capability table; field is ignored. */


### PR DESCRIPTION
**Feature** — closes #1555.

## What changed
A hook's `timeout` in `agents.yaml` can now be a duration string — `timeout: 5s`, `2m`, `1h30m` — not just a bare number of seconds. `timeout: 5` is only unambiguous if you already know the unit; `timeout: 5s` documents itself.

- New `normalizeHookTimeoutSeconds(value)` parses a bare number (seconds, unchanged) **or** a `w/d/h/m/s` duration string into a whole-second number.
- `parseHookManifest` normalizes each hook's timeout **once**, at the yaml→`ManifestHook` boundary, so all 15 harness serializers keep consuming a plain number — no per-serializer change.
- **Backward compatible:** a bare number still means seconds; every existing manifest keeps working.
- **Fails loud:** an unparseable timeout (`"soon"`, `"5 minutes"`, `"0s"`) is dropped with a warning, never silently coerced.

**Not reusing** routines' `parseTimeout`: it returns milliseconds, has no seconds unit, and floors at one minute — none of which fit hook timeouts (typically 5–600s). Documented inline so it doesn't read as a missed reuse.

## Ran it — the parser on real inputs
Full run log: `zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/hook-timeout-1555-testrun.txt`

```
agents.yaml timeout  ->  normalized seconds
  "5s"           -> 5s
  "30"           -> 30s
  "2m"           -> 120s
  "1h30m"        -> 5400s
  "1m30s"        -> 90s
  "soon"         -> INVALID (dropped + warned)
  "5 minutes"    -> INVALID (dropped + warned)
  "0s"           -> INVALID (dropped + warned)
  30 (bare number) -> 30s
```

That output is a live `bun` run importing the actual parser from `src/lib/hooks.ts`, not a hand-written table.

## Tests (real path, no mocks)
`hooks-layering.test.ts` drives the real `parseHookManifest` merge path (`5s`→5, `1h30m`→5400, bare `45`→45; invalid dropped + warns) plus a unit table for `normalizeHookTimeoutSeconds`. Full hooks suites: **21 passed** (layering + serializers), no serializer regressions.

## Docs
`apps/cli/docs/hooks.md` — `timeout` field row + example updated to `number | string`. CHANGELOG: `.changelog/next/hook-timeout-duration-strings.md` (conflict-free fragment).

No UI surface — config parsing only.
