### PR TITLE
Rename menu bar helper to AGI Menu; heal ad-hoc Accessibility identity

### DIFF
--- a/apps/cli/.changelog/next/agi-menu-rename.md
+++ b/apps/cli/.changelog/next/agi-menu-rename.md
@@ -1,0 +1,10 @@
+- **The macOS menu bar app is now named AGI Menu in System Settings and
+  Accessibility prompts.** Privacy & Security previously showed the executable
+  name `MenubarHelper` because the bundle had no `CFBundleDisplayName`. The
+  bundle now ships `CFBundleName` / `CFBundleDisplayName` = `AGI Menu`, and
+  `agents menubar` status/enable/disable copy uses the same name. An install
+  that was left ad-hoc-signed by an older heal path is also replaced from the
+  Developer-ID source on the next `agents` run, so Accessibility stops
+  re-prompting for a new identity every upgrade. Source:
+  `apps/cli/menubar/scripts/build.sh`, `apps/cli/src/commands/menubar.ts`,
+  `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/menubar/scripts/build.sh
+++ b/apps/cli/menubar/scripts/build.sh
@@ -86,7 +86,9 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
     <key>CFBundleIdentifier</key>
     <string>com.phnx-labs.agents-menubar</string>
     <key>CFBundleName</key>
-    <string>Agents Menu Bar</string>
+    <string>AGI Menu</string>
+    <key>CFBundleDisplayName</key>
+    <string>AGI Menu</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -21,7 +21,7 @@ import {
 
 function notMac(): boolean {
   if (process.platform !== 'darwin') {
-    console.log(chalk.yellow('The menu bar helper is macOS only.'));
+    console.log(chalk.yellow('AGI Menu is macOS only.'));
     return true;
   }
   return false;
@@ -30,7 +30,7 @@ function notMac(): boolean {
 /** Shared status readout — `status`, bare `menubar`, and `setup --check` all end here. */
 function printStatus(s: MenubarStatus, opts: { brief?: boolean } = {}): void {
   const yn = (b: boolean) => (b ? chalk.green('yes') : chalk.gray('no'));
-  console.log(chalk.bold('Menu bar helper\n'));
+  console.log(chalk.bold('AGI Menu\n'));
   console.log(`  running            ${yn(s.running)}`);
   console.log(`  service installed  ${yn(s.serviceInstalled)}`);
   if (opts.brief) {
@@ -46,7 +46,7 @@ function printStatus(s: MenubarStatus, opts: { brief?: boolean } = {}): void {
   // Two copies of the INSTALLED bundle is the duplicate the user sees as two
   // agents marks in the menu bar. It used to read as a healthy `running: yes`.
   if (s.instances.length > 1) {
-    console.log(chalk.yellow(`\n  ${s.instances.length} copies of the installed helper are running — that is the duplicate menu-bar icon:`));
+    console.log(chalk.yellow(`\n  ${s.instances.length} copies of AGI Menu are running — that is the duplicate menu-bar icon:`));
     for (const p of s.instances) console.log(chalk.gray(`    ${p.pid}  ${p.executable}`));
     console.log(chalk.gray('  Fix it with `agents menubar setup`.'));
   }
@@ -56,19 +56,19 @@ function printStatus(s: MenubarStatus, opts: { brief?: boolean } = {}): void {
     // was — only that a rival exists — so report the conflict, not a winner.
     // The loser has no other symptom: its chords simply never fire.
     const n = s.foreignInstances.length;
-    console.log(chalk.yellow(`\n  ${n} other helper process${n === 1 ? '' : 'es'} running — ${n === 1 ? 'it' : 'they'} may hold Cmd-Shift-V/O instead of the installed one:`));
+    console.log(chalk.yellow(`\n  ${n} other AGI Menu process${n === 1 ? '' : 'es'} running — ${n === 1 ? 'it' : 'they'} may hold Cmd-Shift-V/O instead of the installed one:`));
     for (const p of s.foreignInstances) console.log(chalk.gray(`    ${p.pid}  ${p.executable}`));
     console.log(chalk.gray('  End them with `agents menubar setup`.'));
   }
   if (s.stale) {
-    console.log(chalk.yellow('\n  Installed helper is stale — runs on next `agents` startup, or `agents menubar setup` now.'));
+    console.log(chalk.yellow('\n  Installed AGI Menu is stale — runs on next `agents` startup, or `agents menubar setup` now.'));
   } else if (!s.serviceInstalled && !s.disabledByUser) {
     console.log(chalk.gray('\n  Set it up with `agents menubar setup`.'));
   }
 }
 
 function printSetupResult(r: SetupResult): void {
-  console.log(chalk.bold('Menu bar setup\n'));
+  console.log(chalk.bold('AGI Menu setup\n'));
   for (const step of r.steps) {
     const mark = step.outcome === 'failed' ? chalk.red('✗')
       : step.outcome === 'changed' ? chalk.green('+') : chalk.green('✓');
@@ -76,23 +76,23 @@ function printSetupResult(r: SetupResult): void {
   }
   console.log();
   if (r.configured) {
-    console.log(chalk.green('Menu bar configured.') + chalk.gray('  One agents mark, started at login.'));
+    console.log(chalk.green('AGI Menu configured.') + chalk.gray('  One agents mark, started at login.'));
   } else {
-    console.log(chalk.red('Menu bar not fully configured.') + chalk.gray('  See the failed step above.'));
+    console.log(chalk.red('AGI Menu not fully configured.') + chalk.gray('  See the failed step above.'));
   }
 }
 
 export function registerMenubarCommands(program: Command): void {
   const menubar = program
     .command('menubar')
-    .description('Manage the macOS menu-bar helper (running sessions, agents awaiting input, routines)');
+    .description('Manage AGI Menu (running sessions, agents awaiting input, routines)');
 
   // `setup` is the one command that gets a machine to the intended state:
   // exactly one status item, started at login. `enable` stays the narrow
   // install+start; setup adds duplicate cleanup and verifies the end state.
   const setup = menubar
     .command('setup')
-    .description('Configure the menu bar end-to-end: one instance, started at login')
+    .description('Configure AGI Menu end-to-end: one instance, started at login')
     .option('--check', 'Report the current state, change nothing')
     .option('--json', 'Emit machine-readable JSON')
     .action((options: { check?: boolean; json?: boolean }) => {
@@ -118,7 +118,7 @@ export function registerMenubarCommands(program: Command): void {
 
   setHelpSections(setup, {
     examples: `
-      # Configure the menu bar end-to-end (idempotent — safe to re-run)
+      # Configure AGI Menu end-to-end (idempotent — safe to re-run)
       agents menubar setup
 
       # Two agents marks in the menu bar? This ends the duplicate.
@@ -128,45 +128,45 @@ export function registerMenubarCommands(program: Command): void {
       agents menubar setup --check
     `,
     notes: `
-      Configures, in order: every running helper ended, the helper bundle at
-      ~/Library/Application Support/agents-cli, its code signature, the launchd
-      login item (com.phnx-labs.agents-menubar — RunAtLoad + KeepAlive), then
-      verifies exactly one helper came back up.
+      Configures, in order: every running helper ended, AGI Menu at
+      ~/Library/Application Support/agents-cli/MenubarHelper.app, its code
+      signature, the launchd login item (com.phnx-labs.agents-menubar —
+      RunAtLoad + KeepAlive), then verifies exactly one helper came back up.
 
       Every running helper is ended and launchd restarts one, so the survivor is
       always the login-managed copy. Exits nonzero if it cannot reach that state.
 
-      Setup clears a previous \`agents menubar disable\`. To turn the menu bar off
+      Setup clears a previous \`agents menubar disable\`. To turn AGI Menu off
       again, run \`agents menubar disable\`.
     `,
   });
 
   menubar
     .command('enable')
-    .description('Install and start the menu-bar helper (launches at login)')
+    .description('Install and start AGI Menu (launches at login)')
     .action(() => {
       if (notMac()) return;
       const ok = enableMenubarService({ clearOptOut: true });
       if (!ok) {
-        console.log(chalk.red('Could not enable: no menu-bar helper bundle ships with this install.'));
+        console.log(chalk.red('Could not enable: no AGI Menu bundle ships with this install.'));
         console.log(chalk.gray('  This build may predate the helper, or be a non-macOS package.'));
         return;
       }
-      console.log(chalk.green('Menu bar helper enabled.') + chalk.gray('  Look for the agents mark in your menu bar.'));
+      console.log(chalk.green('AGI Menu enabled.') + chalk.gray('  Look for the agents mark in your menu bar.'));
     });
 
   menubar
     .command('disable')
-    .description('Stop and remove the menu-bar helper (stays off across upgrades)')
+    .description('Stop and remove AGI Menu (stays off across upgrades)')
     .action(() => {
       if (notMac()) return;
       disableMenubarService();
-      console.log(chalk.green('Menu bar helper disabled.') + chalk.gray('  Re-enable any time with `agents menubar setup`.'));
+      console.log(chalk.green('AGI Menu disabled.') + chalk.gray('  Re-enable any time with `agents menubar setup`.'));
     });
 
   menubar
     .command('status')
-    .description('Show whether the menu-bar helper is installed and running')
+    .description('Show whether AGI Menu is installed and running')
     .option('--json', 'Emit machine-readable JSON')
     .action((options: { json?: boolean }) => {
       const s = getMenubarStatus();
@@ -175,7 +175,7 @@ export function registerMenubarCommands(program: Command): void {
         return;
       }
       if (s.platform !== 'darwin') {
-        console.log(chalk.yellow('The menu bar helper is macOS only.'));
+        console.log(chalk.yellow('AGI Menu is macOS only.'));
         return;
       }
       printStatus(s);
@@ -185,7 +185,7 @@ export function registerMenubarCommands(program: Command): void {
   menubar.action(() => {
     const s = getMenubarStatus();
     if (s.platform !== 'darwin') {
-      console.log(chalk.yellow('The menu bar helper is macOS only.'));
+      console.log(chalk.yellow('AGI Menu is macOS only.'));
       return;
     }
     printStatus(s, { brief: true });

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -8,6 +8,7 @@ import {
   codesignVerifies,
   gatekeeperAssesses,
   generateServicePlist,
+  hasDeveloperIdSignature,
   isMenubarStale,
   menubarPlistNeedsRepoint,
   processesToEnd,
@@ -238,6 +239,12 @@ darwinOnly('menubar launch guard requires notarization (real codesign/spctl)', (
     // ...but Gatekeeper rejects it because it is not notarized. The guard's AND
     // of the two is therefore false, so the helper is refused, not launched.
     expect(gatekeeperAssesses(app)).toBe(false);
+    fs.rmSync(path.dirname(app), { recursive: true, force: true });
+  });
+
+  it('hasDeveloperIdSignature is false for an ad-hoc bundle', () => {
+    const app = makeAdHocBundle();
+    expect(hasDeveloperIdSignature(app)).toBe(false);
     fs.rmSync(path.dirname(app), { recursive: true, force: true });
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -221,10 +221,26 @@ export function gatekeeperAssesses(appPath: string): boolean {
   return r.status === 0;
 }
 
+/** True when the bundle carries a Developer ID TeamIdentifier (not ad-hoc). */
+export function hasDeveloperIdSignature(appPath: string): boolean {
+  const r = spawnSync('codesign', ['-dv', '--verbose=4', appPath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  });
+  const out = `${r.stderr || ''}${r.stdout || ''}`;
+  const team = out.match(/TeamIdentifier=([A-Z0-9]+)/)?.[1];
+  return Boolean(team && team !== 'not set');
+}
+
 /**
  * Copy the bundled `.app` to the stable user path (idempotent unless forced).
  * Returns the installed executable path, or null if no source bundle ships
  * with this install (e.g. Linux package, or a build without the helper).
+ *
+ * Also heals an older install that was ad-hoc re-signed over a Developer ID
+ * source: that unstable identity made Accessibility re-prompt on every upgrade.
+ * When the shipped source is Developer ID and the installed copy is only
+ * ad-hoc, replace it — even without forceReinstall.
  */
 export function ensureMenubarAppInstalled(opts: { forceReinstall?: boolean } = {}): string | null {
   if (!onDarwin()) return null;
@@ -232,7 +248,11 @@ export function ensureMenubarAppInstalled(opts: { forceReinstall?: boolean } = {
   if (!src) return null;
   const dest = installedAppPath();
   if (!opts.forceReinstall && fs.existsSync(dest)) {
-    return installedExecutablePath();
+    const sourceIsDevId = hasDeveloperIdSignature(src);
+    const destIsDevId = hasDeveloperIdSignature(dest);
+    if (!(sourceIsDevId && !destIsDevId)) {
+      return installedExecutablePath();
+    }
   }
   copyAppBundle(src, dest);
   // A fresh copy is exactly when the bundle's icon can be new (first install) or
@@ -340,7 +360,7 @@ export function enableMenubarService(opts: { clearOptOut?: boolean } = { clearOp
   // rather than re-signing over it (an ad-hoc re-sign never satisfies Gatekeeper).
   if (!(codesignVerifies(installedAppPath()) && gatekeeperAssesses(installedAppPath()))) {
     process.stderr.write(
-      'agents: menu-bar helper is not notarized/valid on this machine; skipping launch. ' +
+      'agents: AGI Menu is not notarized/valid on this machine; skipping launch. ' +
       'Upgrade to a notarized build (npm i -g @phnx-labs/agents-cli), then `agents menubar setup`.\n'
     );
     return false;
@@ -480,13 +500,23 @@ export function installMenubarLaunchAgentOnUpgrade(): void {
     }
     // Re-enable (recopy helper + rewrite plist) when the version drifted OR the
     // plist's baked interpreter/entry no longer point at the install now running
-    // `agents` — the dual-install skew a version bump alone can't catch.
-    if (menubarSetupStale() || menubarSetupNeedsRepoint()) {
+    // `agents` — the dual-install skew a version bump alone can't catch — OR the
+    // installed copy is still ad-hoc while the shipped source is Developer ID
+    // (older heal path; Accessibility re-prompts until the identity is restored).
+    if (menubarSetupStale() || menubarSetupNeedsRepoint() || installedNeedsDevIdHeal()) {
       enableMenubarService({ clearOptOut: false });
     }
   } catch {
     /* never block startup on the menu bar */
   }
+}
+
+/** True when App Support still has an ad-hoc copy but the npm bundle is Developer ID. */
+function installedNeedsDevIdHeal(): boolean {
+  const src = sourceAppPath();
+  if (!src || !fs.existsSync(installedAppPath())) return false;
+  if (hasDeveloperIdSignature(installedAppPath())) return false;
+  return hasDeveloperIdSignature(src);
 }
 
 /** One step of `agents menubar setup`, and how it came out. */
@@ -546,14 +576,14 @@ export function runMenubarSetup(): SetupResult {
   };
 
   if (!onDarwin()) {
-    step('platform', 'failed', `the menu bar helper is macOS only (this is ${process.platform})`);
+    step('platform', 'failed', `AGI Menu is macOS only (this is ${process.platform})`);
     return { steps, configured: false, status: getMenubarStatus() };
   }
 
   const before = getMenubarStatus();
 
   if (!sourceAppPath()) {
-    step('bundle', 'failed', 'no menu-bar helper bundle ships with this install');
+    step('bundle', 'failed', 'no AGI Menu bundle ships with this install');
     return { steps, configured: false, status: before };
   }
 


### PR DESCRIPTION
## Summary
Rename the macOS menu-bar app's user-visible name from `MenubarHelper` / "menu bar helper" to **AGI Menu**, and replace leftover ad-hoc-signed App Support installs with the Developer-ID npm bundle so Accessibility stops re-prompting on every upgrade.

## Why this was broken
On zion, Privacy & Security showed **"MenubarHelper"** and the Accessibility Access dialog said the same — because `Info.plist` had no `CFBundleDisplayName` (macOS falls back to the executable name).

Separately, every `agents` upgrade re-prompted Accessibility because:
1. npm ships `MenubarHelper.app` **Developer ID** signed (`TeamIdentifier=2HTP252L87`)
2. Older install code ad-hoc re-signed the App Support copy when verify hiccuped
3. Ad-hoc identity changes with each binary → TCC treats it as a new app

Verified on zion:
- npm source: `Authority=Developer ID Application: Muqit Nawaz (2HTP252L87)`
- installed copy: `Signature=adhoc`, `TeamIdentifier=not set`
- path: `~/Library/Application Support/agents-cli/MenubarHelper.app`

## What changed
- `CFBundleName` + `CFBundleDisplayName` = `AGI Menu` in the bundle Info.plist
- `agents menubar` status/enable/disable/setup copy says AGI Menu
- Startup heal: if App Support is ad-hoc and the shipped source is Developer ID, recopy (no ad-hoc re-sign)

## Test plan
- [x] `bun test src/lib/menubar/install-menubar.test.ts` (26 pass; darwin codesign cases skip on Linux)
- [ ] After merge + release rebuild of the `.app`: Accessibility dialog / System Settings list show **AGI Menu**
- [ ] On a machine stuck on ad-hoc: next `agents` run replaces App Support copy with Developer ID; Accessibility grant sticks across upgrades

## Notes
- On-disk bundle remains `MenubarHelper.app` / executable `MenubarHelper` (stable path + launchd); only the display name changes.
- Full notarize-without-adhoc-resign lands in the 1.21.0 release track; this PR adds the name + the leftover ad-hoc heal on top of current `main`.

no-surface: display-name + install heal; the `.app` binary itself is rebuilt at release time on mac-mini

Made with [Cursor](https://cursor.com)