### PR TITLE
feat(cli): agents trends — session/resource analytics dashboard

### DIFF
--- a/apps/cli/.changelog/next/agents-trends.md
+++ b/apps/cli/.changelog/next/agents-trends.md
@@ -1,0 +1,7 @@
+- **`agents trends` — resource and session analytics dashboard.** Baked recipes
+  (harness/model mix, tools per session, token ratio, secrets/browser hot lists)
+  read `sessions.db` plus a new value-free warehouse at
+  `~/.agents/.history/analytics/usage.db`. Secrets usage migrates once from
+  `secrets.db`; agent run and browser launch/close emit into the warehouse.
+  Quota stays on `agents usage`, latency on `agents perf`.
+  Source: `apps/cli/src/commands/trends.ts`, `apps/cli/src/lib/analytics/`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -13,6 +13,7 @@ whose *consumer* and *axis* match your question, not whichever you remember firs
 |---|---|---|---|
 | **`events`** | **Raw unified event stream = the audit log.** Everything: secrets access, command invocations, version/skill/mcp/team ops, browser events, plus agent milestones. `--follow` to tail, `--audit` for ops-only. | `events.jsonl` + per-session `activity/*.jsonl`, merged by `readUnifiedEvents` | Audit, debugging, monitoring (human + machine) |
 | **`perf`** | **Latency rollups.** p50/p99 for hooks, CLI commands, and `agent.run` timings. Indexed SQLite — not a full scan of the audit log. | `~/.agents/.cache/perf/perf.db` (disposable) | Humans optimizing boot/run cost + `--json` |
+| **`trends`** | **Usage analytics.** Harness/model mix, tools per session, token ratios, hottest secrets/browser profiles — baked recipes over sessions + a durable resource warehouse. Distinct from quota (`agents usage`) and latency (`agents perf`). | `sessions.db` + `~/.agents/.history/analytics/usage.db` | Humans + `--json` |
 | **`feed`** | **Consolidated cross-agent surface.** Open blocks (decisions agents are waiting on) + `feed post` status updates — "what needs you / what are agents saying." | `.history/feed/*` + active sessions | Humans (operator inbox) + agents (progress) |
 | **`activity`** | **Human milestone timeline.** Recent plans / PRs / worktrees / sub-agents, plus Bash-driven deliverables (video renders, image upscales, metadata edits), newest-first — a friendly lens on the milestone tier of the event stream. Every Bash call also emits a structured `bash.executed` activity record carrying its tool category. | `activity/*.jsonl` | Human at the terminal |
 | **`output`** | **Productivity accounting.** Token burn vs shipped output (PRs, commits) across agents — the "was it worth it" axis. (`agents cost` is the pure $-and-duration sibling.) | `sessions.db` + git/gh | Human + `--json` |
@@ -100,6 +101,32 @@ agents perf run --json          # agent.run / perf.timing labels
 **Disable:** `AGENTS_DISABLE_PERF=1`. **Redirect (tests):** `AGENTS_PERF_DB`,
 `AGENTS_PERF_SPOOL`. Retention: samples older than 30 days are pruned
 opportunistically on open. Wipe anytime: `rm -rf ~/.agents/.cache/perf`.
+
+## Usage analytics (`agents trends`)
+
+Resource and session frequency — **not** model quota (`agents usage`) and **not**
+latency (`agents perf`). Implementation: `apps/cli/src/lib/analytics/`, CLI:
+`apps/cli/src/commands/trends.ts`.
+
+```
+agents trends                     # auto recipe board (skips empty sections)
+agents trends --days 30           # window
+agents trends harness-mix --json  # one baked recipe
+agents trends query --kind secret # raw warehouse rows
+agents trends recipes             # list recipe ids
+```
+
+| Store | Path | Holds |
+|---|---|---|
+| Session index | `sessions.db` | Harness/model mix, token ratios, `tool_call_count` (Claude scan rollup) |
+| Usage warehouse | `~/.agents/.history/analytics/usage.db` | Value-free `kind`/`name`/`event` rows (secret, agent, browser, …) |
+
+Secrets usage previously lived only in `~/.agents/secrets/secrets.db`; the warehouse
+migrates those rows once (`kind=secret`) and the secrets UI keeps reading through a
+thin adapter. New emitters: secret access paths, `agents run`, browser launch/close.
+
+**Disable:** `AGENTS_NO_USAGE_TRACK=1`. **Redirect (tests):** `AGENTS_USAGE_DB`,
+`AGENTS_SESSIONS_DB`. Retention: usage events older than 90 days are pruned on open.
 
 ## Audit Event Log (`agents events`)
 

--- a/apps/cli/src/commands/trends.ts
+++ b/apps/cli/src/commands/trends.ts
@@ -1,0 +1,174 @@
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { setHelpSections } from '../lib/help.js';
+import { buildTrendsDashboard, trendsWindow, runRecipe, RECIPE_IDS, type RecipeId } from '../lib/analytics/dashboard.js';
+import { listRecipes } from '../lib/analytics/recipes.js';
+import { queryUsage, usageDbPath, type UsageKind, USAGE_KINDS } from '../lib/analytics/usage-db.js';
+
+interface TrendsOpts {
+  days?: string;
+  json?: boolean;
+  limit?: string;
+}
+
+function parseDays(raw: string | undefined): number {
+  const n = parseInt(raw ?? '7', 10);
+  return Number.isFinite(n) && n > 0 ? n : 7;
+}
+
+function parseLimit(raw: string | undefined, fallback: number): number {
+  const n = parseInt(raw ?? String(fallback), 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function printSection(section: { id: string; title: string; rows: Array<Record<string, string | number | null>> }): void {
+  console.log(chalk.bold(section.title));
+  if (section.rows.length === 0) {
+    console.log(chalk.gray('  (no data)'));
+    console.log();
+    return;
+  }
+  const keys = Object.keys(section.rows[0]);
+  const widths = keys.map((k) => Math.max(k.length, ...section.rows.map((r) => String(r[k] ?? '').length), 4));
+  const pad = (s: string, w: number) => (s.length >= w ? s.slice(0, w) : s + ' '.repeat(w - s.length));
+  console.log(chalk.gray(keys.map((k, i) => pad(k.toUpperCase(), widths[i])).join('  ')));
+  for (const row of section.rows) {
+    console.log(keys.map((k, i) => pad(String(row[k] ?? ''), widths[i])).join('  '));
+  }
+  console.log();
+}
+
+function renderDashboard(days: number, asJson: boolean): void {
+  const dash = buildTrendsDashboard({ days });
+  if (asJson) {
+    console.log(JSON.stringify(dash, null, 2));
+    return;
+  }
+  console.log(chalk.bold(`agents trends — last ${dash.window.days} days`));
+  console.log(chalk.gray(`compute ${dash.durationMs}ms · usage ${usageDbPath()}`));
+  console.log();
+  if (dash.sections.length === 0) {
+    console.log(chalk.gray('No session or usage data in this window yet.'));
+    return;
+  }
+  for (const section of dash.sections) printSection(section);
+}
+
+export function registerTrendsCommand(program: Command): void {
+  const trends = program
+    .command('trends')
+    .description('Usage analytics — harness/model mix, token ratios, resource frequency')
+    .option('--days <n>', 'Days of history to include', '7')
+    .option('--json', 'Emit JSON instead of tables')
+    .option('--limit <n>', 'Max rows for query', '40')
+    .action(function summary(this: Command) {
+      const opts = this.opts() as TrendsOpts;
+      renderDashboard(parseDays(opts.days), Boolean(opts.json));
+    });
+
+  setHelpSections(trends, {
+    examples: `
+      # Auto recipe dashboard (7d)
+      agents trends
+
+      # Last 30 days
+      agents trends --days 30
+
+      # One recipe as JSON
+      agents trends harness-mix --json
+
+      # Raw usage events
+      agents trends query --kind secret --days 7
+
+      # List baked recipe ids
+      agents trends recipes
+    `,
+    notes: `
+      Session recipes read sessions.db; resource recipes read ~/.agents/.history/analytics/usage.db.
+      Empty recipes are skipped on the default dashboard.
+      Quota / rate-limits remain on \`agents usage\`; latency on \`agents perf\`.
+    `,
+  });
+
+  trends.command('recipes')
+    .description('List baked recipe ids')
+    .option('--json', 'Emit JSON')
+    .action((opts: { json?: boolean }) => {
+      const list = listRecipes();
+      if (opts.json) {
+        console.log(JSON.stringify(list, null, 2));
+        return;
+      }
+      for (const r of list) {
+        console.log(`${r.id.padEnd(22)} ${r.store.padEnd(10)} ${r.title}`);
+      }
+    });
+
+  trends.command('query')
+    .description('Raw usage-event query')
+    .option('--kind <kind>', `One of: ${USAGE_KINDS.join(', ')}`)
+    .option('--name <name>', 'Resource name filter')
+    .option('--event <event>', 'Event name filter')
+    .option('--days <n>', 'Days of history', '7')
+    .option('--limit <n>', 'Max rows', '40')
+    .option('--json', 'Emit JSON')
+    .action((opts: { kind?: string; name?: string; event?: string; days?: string; limit?: string; json?: boolean }) => {
+      const win = trendsWindow(parseDays(opts.days));
+      const kind = opts.kind && (USAGE_KINDS as readonly string[]).includes(opts.kind)
+        ? opts.kind as UsageKind
+        : undefined;
+      if (opts.kind && !kind) {
+        console.error(`Unknown kind '${opts.kind}'. Expected: ${USAGE_KINDS.join(', ')}`);
+        process.exitCode = 1;
+        return;
+      }
+      const rows = queryUsage({
+        kind,
+        name: opts.name,
+        event: opts.event,
+        sinceIso: win.sinceIso,
+        limit: parseLimit(opts.limit, 40),
+      });
+      if (opts.json) {
+        console.log(JSON.stringify({ window: win, rows }, null, 2));
+        return;
+      }
+      if (rows.length === 0) {
+        console.log(chalk.gray('No usage events.'));
+        return;
+      }
+      printSection({
+        id: 'query',
+        title: 'Usage events',
+        rows: rows.map((r) => ({
+          ts: r.ts,
+          kind: r.kind,
+          name: r.name,
+          event: r.event,
+          agent: r.agent,
+        })),
+      });
+    });
+
+  for (const id of RECIPE_IDS) {
+    trends.command(id)
+      .description(`Recipe: ${id}`)
+      .option('--days <n>', 'Days of history', '7')
+      .option('--json', 'Emit JSON')
+      .action(function recipeAction(this: Command) {
+        const parent = this.parent?.opts?.() as TrendsOpts | undefined;
+        const opts = { ...parent, ...(this.opts() as TrendsOpts) };
+        const win = trendsWindow(parseDays(opts.days));
+        const section = runRecipe(id as RecipeId, win);
+        if (opts.json) {
+          console.log(JSON.stringify({ window: win, section }, null, 2));
+          return;
+        }
+        if (section.empty) {
+          console.log(chalk.gray(`No data for recipe '${id}' in the last ${win.days} days.`));
+          return;
+        }
+        printSection(section);
+      });
+  }
+}

--- a/apps/cli/src/commands/trends.ts
+++ b/apps/cli/src/commands/trends.ts
@@ -60,7 +60,6 @@ export function registerTrendsCommand(program: Command): void {
     .description('Usage analytics — harness/model mix, token ratios, resource frequency')
     .option('--days <n>', 'Days of history to include', '7')
     .option('--json', 'Emit JSON instead of tables')
-    .option('--limit <n>', 'Max rows for query', '40')
     .action(function summary(this: Command) {
       const opts = this.opts() as TrendsOpts;
       renderDashboard(parseDays(opts.days), Boolean(opts.json));

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -172,6 +172,7 @@ import {
   loadUsage,
   loadCost,
   loadPerf,
+  loadTrends,
   loadOutput,
   loadBudget,
   loadAlias,
@@ -310,6 +311,18 @@ program.hook('postAction', (_thisCommand, actionCommand) => {
       command,
       ...(durationMs !== undefined ? { durationMs } : {}),
     });
+    if (parts[0] === 'run') {
+      const agentName = actionCommand.args?.[0] ? String(actionCommand.args[0]).split('@')[0] : 'run';
+      void import('./lib/analytics/usage-db.js').then(({ recordUsage }) => {
+        recordUsage({
+          kind: 'agent',
+          name: agentName || 'run',
+          event: 'invoke',
+          source: 'cli',
+          meta: durationMs !== undefined ? { durationMs } : undefined,
+        });
+      }).catch(() => { /* fail soft */ });
+    }
     // Disposable perf warehouse — fail-soft spool append (no SQLite on this path).
     if (durationMs !== undefined && parts[0] !== 'perf') {
       void import('./lib/perf/spool.js').then(({ recordSample }) => {
@@ -1087,6 +1100,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadUsage);
   await reg(loadCost);
   await reg(loadPerf);
+  await reg(loadTrends);
   await reg(loadOutput);
   await reg(loadBudget);
   await reg(loadAlias);

--- a/apps/cli/src/lib/analytics/dashboard.test.ts
+++ b/apps/cli/src/lib/analytics/dashboard.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Database from '../sqlite.js';
+import { closeUsageDb, recordUsage } from './usage-db.js';
+import { buildTrendsDashboard } from './dashboard.js';
+import { recipeHarnessMix, recipeToolsPerSession, trendsWindow } from './recipes.js';
+
+const tmpDirs: string[] = [];
+let prevNoTrack: string | undefined;
+let prevUsageDb: string | undefined;
+let prevSessionsDb: string | undefined;
+
+function pin(): { usage: string; sessions: string } {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-trends-dash-'));
+  tmpDirs.push(d);
+  const usage = path.join(d, 'usage.db');
+  const sessions = path.join(d, 'sessions.db');
+  process.env.AGENTS_USAGE_DB = usage;
+  process.env.AGENTS_SESSIONS_DB = sessions;
+  const db = new Database(sessions);
+  db.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      short_id TEXT NOT NULL,
+      agent TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      model TEXT,
+      token_count INTEGER,
+      output_tokens INTEGER,
+      duration_ms INTEGER,
+      machine TEXT,
+      tool_call_count INTEGER,
+      file_path TEXT NOT NULL
+    );
+  `);
+  const now = new Date().toISOString();
+  const insert = db.prepare(
+    `INSERT INTO sessions (id, short_id, agent, timestamp, model, token_count, output_tokens, duration_ms, machine, tool_call_count, file_path)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  insert.run('s1', 's1', 'claude', now, 'claude-opus-4', 1000, 200, 60000, 'box-a', 12, '/tmp/a.jsonl');
+  insert.run('s2', 's2', 'claude', now, 'claude-sonnet-4', 800, 100, 30000, 'box-a', 4, '/tmp/b.jsonl');
+  insert.run('s3', 's3', 'codex', now, 'gpt-5', 500, 50, 120000, 'box-b', null, '/tmp/c.jsonl');
+  db.close();
+  return { usage, sessions };
+}
+
+beforeEach(() => {
+  prevNoTrack = process.env.AGENTS_NO_USAGE_TRACK;
+  prevUsageDb = process.env.AGENTS_USAGE_DB;
+  prevSessionsDb = process.env.AGENTS_SESSIONS_DB;
+  delete process.env.AGENTS_NO_USAGE_TRACK;
+  closeUsageDb();
+  pin();
+});
+
+afterEach(() => {
+  closeUsageDb();
+  if (prevNoTrack === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+  else process.env.AGENTS_NO_USAGE_TRACK = prevNoTrack;
+  if (prevUsageDb === undefined) delete process.env.AGENTS_USAGE_DB;
+  else process.env.AGENTS_USAGE_DB = prevUsageDb;
+  if (prevSessionsDb === undefined) delete process.env.AGENTS_SESSIONS_DB;
+  else process.env.AGENTS_SESSIONS_DB = prevSessionsDb;
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+  tmpDirs.length = 0;
+});
+
+describe('trends recipes + dashboard', () => {
+  it('harness-mix and tools-per-session read the sessions index', () => {
+    const win = trendsWindow(7);
+    const harness = recipeHarnessMix(win);
+    expect(harness.empty).toBe(false);
+    expect(harness.rows.some((r) => r.harness === 'claude' && r.sessions === 2)).toBe(true);
+    expect(harness.rows.some((r) => r.harness === 'codex' && r.sessions === 1)).toBe(true);
+
+    const tools = recipeToolsPerSession(win);
+    expect(tools.empty).toBe(false);
+    const all = tools.rows.find((r) => r.scope === '(all)');
+    expect(all?.n).toBe(2);
+    expect(all?.avg).toBe(8);
+  });
+
+  it('dashboard skips empty recipes and stays under the compute budget', () => {
+    recordUsage({ kind: 'secret', name: 'npm', event: 'access' });
+    const samples: number[] = [];
+    for (let i = 0; i < 25; i++) {
+      const dash = buildTrendsDashboard({ days: 7 });
+      samples.push(dash.durationMs);
+      expect(dash.sections.length).toBeGreaterThan(0);
+      expect(dash.sections.every((s) => !s.empty)).toBe(true);
+    }
+    samples.sort((a, b) => a - b);
+    const p50 = samples[Math.floor(samples.length * 0.5)];
+    const p99 = samples[Math.floor(samples.length * 0.99)];
+    expect(p50).toBeLessThan(50);
+    expect(p99).toBeLessThan(150);
+  });
+});

--- a/apps/cli/src/lib/analytics/dashboard.ts
+++ b/apps/cli/src/lib/analytics/dashboard.ts
@@ -1,0 +1,45 @@
+import {
+  RECIPE_IDS,
+  runRecipe,
+  trendsWindow,
+  type RecipeId,
+  type RecipeSection,
+  type TrendsWindow,
+} from './recipes.js';
+
+export interface TrendsDashboard {
+  window: TrendsWindow;
+  durationMs: number;
+  sections: RecipeSection[];
+}
+
+const DEFAULT_ORDER: RecipeId[] = [
+  'harness-mix',
+  'model-mix',
+  'session-volume',
+  'token-ratio',
+  'tools-per-session',
+  'secrets-hot',
+  'browser-activity',
+  'resource-mix',
+];
+
+export function buildTrendsDashboard(opts: { days?: number; ids?: RecipeId[] } = {}): TrendsDashboard {
+  const t0 = Date.now();
+  const win = trendsWindow(opts.days ?? 7);
+  const ids = opts.ids ?? DEFAULT_ORDER;
+  const sections: RecipeSection[] = [];
+  for (const id of ids) {
+    if (!RECIPE_IDS.includes(id)) continue;
+    const section = runRecipe(id, win);
+    if (section.empty) continue;
+    sections.push(section);
+  }
+  return {
+    window: win,
+    durationMs: Date.now() - t0,
+    sections,
+  };
+}
+
+export { trendsWindow, runRecipe, RECIPE_IDS, type RecipeId, type RecipeSection };

--- a/apps/cli/src/lib/analytics/recipes.ts
+++ b/apps/cli/src/lib/analytics/recipes.ts
@@ -1,0 +1,332 @@
+import Database from '../sqlite.js';
+import { getSessionsDbPath } from '../state.js';
+import {
+  topNamesByKind,
+  kindMix,
+  countUsage,
+  listUsageKindsWithData,
+  type UsageKind,
+} from './usage-db.js';
+
+export interface TrendsWindow {
+  days: number;
+  sinceIso: string;
+}
+
+export interface RecipeSection {
+  id: string;
+  title: string;
+  store: 'sessions' | 'usage';
+  rows: Array<Record<string, string | number | null>>;
+  empty?: boolean;
+}
+
+export function trendsWindow(days: number): TrendsWindow {
+  const d = Number.isFinite(days) && days > 0 ? days : 7;
+  const since = new Date(Date.now() - d * 24 * 60 * 60 * 1000);
+  return { days: d, sinceIso: since.toISOString() };
+}
+
+function openSessions(): Database.Database | null {
+  try {
+    const db = new Database(getSessionsDbPath());
+    db.pragma('busy_timeout = 2000');
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const frac = rank - lo;
+  return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}
+
+export function recipeHarnessMix(win: TrendsWindow): RecipeSection {
+  const db = openSessions();
+  const id = 'harness-mix';
+  const title = 'Harness mix';
+  if (!db) return { id, title, store: 'sessions', rows: [], empty: true };
+  try {
+    const rows = db.prepare(
+      `SELECT agent AS name, COUNT(*) AS n
+         FROM sessions WHERE timestamp >= ?
+         GROUP BY agent ORDER BY n DESC`,
+    ).all(win.sinceIso) as Array<{ name: string; n: number }>;
+    return {
+      id,
+      title,
+      store: 'sessions',
+      rows: rows.map((r) => ({ harness: r.name, sessions: r.n })),
+      empty: rows.length === 0,
+    };
+  } catch {
+    return { id, title, store: 'sessions', rows: [], empty: true };
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+}
+
+export function recipeModelMix(win: TrendsWindow): RecipeSection {
+  const db = openSessions();
+  const id = 'model-mix';
+  const title = 'Model mix';
+  if (!db) return { id, title, store: 'sessions', rows: [], empty: true };
+  try {
+    const rows = db.prepare(
+      `SELECT COALESCE(NULLIF(TRIM(model), ''), '(unrecorded)') AS name, COUNT(*) AS n
+         FROM sessions WHERE timestamp >= ?
+         GROUP BY 1 ORDER BY n DESC LIMIT 25`,
+    ).all(win.sinceIso) as Array<{ name: string; n: number }>;
+    return {
+      id,
+      title,
+      store: 'sessions',
+      rows: rows.map((r) => ({ model: r.name, sessions: r.n })),
+      empty: rows.length === 0,
+    };
+  } catch {
+    return { id, title, store: 'sessions', rows: [], empty: true };
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+}
+
+export function recipeToolsPerSession(win: TrendsWindow): RecipeSection {
+  const db = openSessions();
+  const id = 'tools-per-session';
+  const title = 'Tools per session';
+  if (!db) return { id, title, store: 'sessions', rows: [], empty: true };
+  try {
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some((c) => c.name === 'tool_call_count')) {
+      return { id, title, store: 'sessions', rows: [], empty: true };
+    }
+    const byAgent = db.prepare(
+      `SELECT agent, tool_call_count AS n
+         FROM sessions
+        WHERE timestamp >= ? AND tool_call_count IS NOT NULL`,
+    ).all(win.sinceIso) as Array<{ agent: string; n: number }>;
+    if (byAgent.length === 0) return { id, title, store: 'sessions', rows: [], empty: true };
+
+    const groups = new Map<string, number[]>();
+    const all: number[] = [];
+    for (const r of byAgent) {
+      all.push(r.n);
+      const list = groups.get(r.agent) ?? [];
+      list.push(r.n);
+      groups.set(r.agent, list);
+    }
+    const roll = (label: string, vals: number[]) => {
+      const sorted = [...vals].sort((a, b) => a - b);
+      const sum = sorted.reduce((a, b) => a + b, 0);
+      return {
+        scope: label,
+        n: sorted.length,
+        avg: Math.round(sum / sorted.length),
+        p50: Math.round(percentile(sorted, 50)),
+        p99: Math.round(percentile(sorted, 99)),
+      };
+    };
+    const rows: Array<Record<string, string | number | null>> = [roll('(all)', all)];
+    for (const [agent, vals] of [...groups.entries()].sort((a, b) => b[1].length - a[1].length)) {
+      rows.push(roll(agent, vals));
+    }
+    return { id, title, store: 'sessions', rows, empty: false };
+  } catch {
+    return { id, title, store: 'sessions', rows: [], empty: true };
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+}
+
+export function recipeTokenRatio(win: TrendsWindow): RecipeSection {
+  const db = openSessions();
+  const id = 'token-ratio';
+  const title = 'Token read→write ratio';
+  if (!db) return { id, title, store: 'sessions', rows: [], empty: true };
+  try {
+    const rows = db.prepare(
+      `SELECT agent,
+              COUNT(*) AS sessions,
+              IFNULL(SUM(token_count), 0) AS tokenIn,
+              IFNULL(SUM(output_tokens), 0) AS tokenOut
+         FROM sessions
+        WHERE timestamp >= ?
+          AND (token_count IS NOT NULL OR output_tokens IS NOT NULL)
+        GROUP BY agent
+        ORDER BY sessions DESC`,
+    ).all(win.sinceIso) as Array<{ agent: string; sessions: number; tokenIn: number; tokenOut: number }>;
+    if (rows.length === 0) return { id, title, store: 'sessions', rows: [], empty: true };
+    const totalIn = rows.reduce((a, r) => a + r.tokenIn, 0);
+    const totalOut = rows.reduce((a, r) => a + r.tokenOut, 0);
+    const totalSessions = rows.reduce((a, r) => a + r.sessions, 0);
+    const fmt = (inn: number, out: number) => (out > 0 ? (inn / out).toFixed(2) : out === 0 && inn > 0 ? '∞' : '—');
+    const outRows: Array<Record<string, string | number | null>> = [{
+      scope: '(all)',
+      sessions: totalSessions,
+      token_in: totalIn,
+      token_out: totalOut,
+      ratio: fmt(totalIn, totalOut),
+      avg_in: totalSessions ? Math.round(totalIn / totalSessions) : 0,
+      avg_out: totalSessions ? Math.round(totalOut / totalSessions) : 0,
+    }];
+    for (const r of rows) {
+      outRows.push({
+        scope: r.agent,
+        sessions: r.sessions,
+        token_in: r.tokenIn,
+        token_out: r.tokenOut,
+        ratio: fmt(r.tokenIn, r.tokenOut),
+        avg_in: Math.round(r.tokenIn / r.sessions),
+        avg_out: Math.round(r.tokenOut / r.sessions),
+      });
+    }
+    return { id, title, store: 'sessions', rows: outRows, empty: false };
+  } catch {
+    return { id, title, store: 'sessions', rows: [], empty: true };
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+}
+
+export function recipeSessionVolume(win: TrendsWindow): RecipeSection {
+  const db = openSessions();
+  const id = 'session-volume';
+  const title = 'Session volume';
+  if (!db) return { id, title, store: 'sessions', rows: [], empty: true };
+  try {
+    const rows = db.prepare(
+      `SELECT COALESCE(NULLIF(TRIM(machine), ''), '(unknown)') AS machine,
+              COUNT(*) AS sessions,
+              IFNULL(SUM(duration_ms), 0) AS durationMs
+         FROM sessions WHERE timestamp >= ?
+         GROUP BY 1 ORDER BY sessions DESC`,
+    ).all(win.sinceIso) as Array<{ machine: string; sessions: number; durationMs: number }>;
+    return {
+      id,
+      title,
+      store: 'sessions',
+      rows: rows.map((r) => ({
+        machine: r.machine,
+        sessions: r.sessions,
+        duration_min: Math.round(r.durationMs / 60000),
+      })),
+      empty: rows.length === 0,
+    };
+  } catch {
+    return { id, title, store: 'sessions', rows: [], empty: true };
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+}
+
+export function recipeSecretsHot(win: TrendsWindow): RecipeSection {
+  const id = 'secrets-hot';
+  const title = 'Hottest secrets';
+  const rows = topNamesByKind('secret', win.sinceIso, 15);
+  return {
+    id,
+    title,
+    store: 'usage',
+    rows: rows.map((r) => ({ bundle: r.name, accesses: r.n, last: r.last })),
+    empty: rows.length === 0,
+  };
+}
+
+export function recipeBrowserActivity(win: TrendsWindow): RecipeSection {
+  const id = 'browser-activity';
+  const title = 'Browser activity';
+  const rows = topNamesByKind('browser', win.sinceIso, 15);
+  return {
+    id,
+    title,
+    store: 'usage',
+    rows: rows.map((r) => ({ profile: r.name, events: r.n, last: r.last })),
+    empty: rows.length === 0,
+  };
+}
+
+export function recipeResourceMix(win: TrendsWindow): RecipeSection {
+  const id = 'resource-mix';
+  const title = 'Resource usage mix';
+  const rows = kindMix(win.sinceIso);
+  return {
+    id,
+    title,
+    store: 'usage',
+    rows: rows.map((r) => ({ kind: r.kind, events: r.n })),
+    empty: rows.length < 2,
+  };
+}
+
+export type RecipeId =
+  | 'harness-mix'
+  | 'model-mix'
+  | 'tools-per-session'
+  | 'token-ratio'
+  | 'session-volume'
+  | 'secrets-hot'
+  | 'browser-activity'
+  | 'resource-mix';
+
+export const RECIPE_IDS: readonly RecipeId[] = [
+  'harness-mix',
+  'model-mix',
+  'tools-per-session',
+  'token-ratio',
+  'session-volume',
+  'secrets-hot',
+  'browser-activity',
+  'resource-mix',
+] as const;
+
+const RUNNERS: Record<RecipeId, (win: TrendsWindow) => RecipeSection> = {
+  'harness-mix': recipeHarnessMix,
+  'model-mix': recipeModelMix,
+  'tools-per-session': recipeToolsPerSession,
+  'token-ratio': recipeTokenRatio,
+  'session-volume': recipeSessionVolume,
+  'secrets-hot': recipeSecretsHot,
+  'browser-activity': recipeBrowserActivity,
+  'resource-mix': recipeResourceMix,
+};
+
+export function runRecipe(id: RecipeId, win: TrendsWindow): RecipeSection {
+  return RUNNERS[id](win);
+}
+
+export function listRecipes(): Array<{ id: RecipeId; title: string; store: 'sessions' | 'usage' }> {
+  const win = trendsWindow(7);
+  return RECIPE_IDS.map((id) => {
+    const s = RUNNERS[id](win);
+    return { id, title: s.title, store: s.store };
+  });
+}
+
+export function hasSessionsInWindow(win: TrendsWindow): boolean {
+  const db = openSessions();
+  if (!db) return false;
+  try {
+    const row = db.prepare(`SELECT 1 AS ok FROM sessions WHERE timestamp >= ? LIMIT 1`).get(win.sinceIso) as { ok: number } | undefined;
+    return Boolean(row);
+  } catch {
+    return false;
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+}
+
+export function usageKindsPresent(win: TrendsWindow): UsageKind[] {
+  return listUsageKindsWithData(win.sinceIso);
+}
+
+export function usageEventCount(kind: UsageKind, win: TrendsWindow): number {
+  return countUsage({ kind, sinceIso: win.sinceIso });
+}

--- a/apps/cli/src/lib/analytics/usage-db.test.ts
+++ b/apps/cli/src/lib/analytics/usage-db.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Database from '../sqlite.js';
+import {
+  recordUsage,
+  countUsage,
+  kindMix,
+  topNamesByKind,
+  queryUsage,
+  closeUsageDb,
+} from './usage-db.js';
+
+const tmpDirs: string[] = [];
+let prevNoTrack: string | undefined;
+let prevDbPath: string | undefined;
+let prevSecretsDb: string | undefined;
+
+function pinDb(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-analytics-usage-'));
+  tmpDirs.push(d);
+  const dbPath = path.join(d, 'usage.db');
+  process.env.AGENTS_USAGE_DB = dbPath;
+  process.env.AGENTS_SECRETS_DB = path.join(d, 'secrets-legacy.db');
+  return dbPath;
+}
+
+beforeEach(() => {
+  prevNoTrack = process.env.AGENTS_NO_USAGE_TRACK;
+  prevDbPath = process.env.AGENTS_USAGE_DB;
+  prevSecretsDb = process.env.AGENTS_SECRETS_DB;
+  delete process.env.AGENTS_NO_USAGE_TRACK;
+  closeUsageDb();
+  pinDb();
+});
+
+afterEach(() => {
+  closeUsageDb();
+  if (prevNoTrack === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
+  else process.env.AGENTS_NO_USAGE_TRACK = prevNoTrack;
+  if (prevDbPath === undefined) delete process.env.AGENTS_USAGE_DB;
+  else process.env.AGENTS_USAGE_DB = prevDbPath;
+  if (prevSecretsDb === undefined) delete process.env.AGENTS_SECRETS_DB;
+  else process.env.AGENTS_SECRETS_DB = prevSecretsDb;
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+  tmpDirs.length = 0;
+});
+
+describe('analytics usage warehouse', () => {
+  it('records and queries cross-kind events', () => {
+    recordUsage({ kind: 'secret', name: 'npm', event: 'access', agent: 'claude' });
+    recordUsage({ kind: 'browser', name: 'default', event: 'launch' });
+    recordUsage({ kind: 'agent', name: 'claude', event: 'run' });
+    recordUsage({ kind: 'browser', name: 'default', event: 'close' });
+
+    const since = new Date(Date.now() - 60_000).toISOString();
+    expect(countUsage({ sinceIso: since })).toBe(4);
+    expect(countUsage({ kind: 'browser', sinceIso: since })).toBe(2);
+    expect(topNamesByKind('browser', since).map((r) => r.name)).toEqual(['default']);
+    expect(kindMix(since).map((r) => r.kind).sort()).toEqual(['agent', 'browser', 'secret']);
+    const rows = queryUsage({ kind: 'secret', sinceIso: since });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('npm');
+    expect(rows[0].agent).toBe('claude');
+  });
+
+  it('migrates legacy secrets.db usage_events into kind=secret once', () => {
+    const secretsPath = process.env.AGENTS_SECRETS_DB!;
+    fs.mkdirSync(path.dirname(secretsPath), { recursive: true });
+    const legacy = new Database(secretsPath);
+    legacy.exec(`
+      CREATE TABLE usage_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts TEXT NOT NULL,
+        bundle TEXT NOT NULL,
+        event TEXT NOT NULL,
+        agent TEXT,
+        host TEXT,
+        source TEXT,
+        status TEXT,
+        key_count INTEGER
+      );
+    `);
+    legacy.prepare(
+      `INSERT INTO usage_events (ts, bundle, event, agent, host, source, status, key_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run('2026-07-01T00:00:00.000Z', 'legacy-bundle', 'access', 'codex', 'zion', 'cli', 'success', 2);
+    legacy.close();
+
+    const since = '2020-01-01T00:00:00.000Z';
+    expect(countUsage({ kind: 'secret', sinceIso: since, name: 'legacy-bundle' })).toBe(1);
+    closeUsageDb();
+    expect(countUsage({ kind: 'secret', sinceIso: since, name: 'legacy-bundle' })).toBe(1);
+  });
+});

--- a/apps/cli/src/lib/analytics/usage-db.ts
+++ b/apps/cli/src/lib/analytics/usage-db.ts
@@ -1,0 +1,370 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from '../sqlite.js';
+import { getUsageDbPath, getSecretsDbPath, getAnalyticsDir } from '../state.js';
+import { localMachineId } from '../session/origin-machine.js';
+
+export type UsageKind = 'secret' | 'agent' | 'skill' | 'plugin' | 'browser' | 'computer';
+
+export const USAGE_KINDS: readonly UsageKind[] = [
+  'secret',
+  'agent',
+  'skill',
+  'plugin',
+  'browser',
+  'computer',
+] as const;
+
+const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+export interface RecordUsageParams {
+  kind: UsageKind;
+  name: string;
+  event: string;
+  agent?: string;
+  sessionId?: string;
+  machine?: string;
+  actor?: string;
+  source?: string;
+  status?: 'success' | 'error' | string;
+  meta?: Record<string, unknown>;
+  ts?: string;
+}
+
+export interface UsageEventRow {
+  ts: string;
+  kind: UsageKind;
+  name: string;
+  event: string;
+  agent: string | null;
+  sessionId: string | null;
+  machine: string | null;
+  actor: string | null;
+  source: string | null;
+  status: string | null;
+  metaJson: string | null;
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  event TEXT NOT NULL,
+  agent TEXT,
+  session_id TEXT,
+  machine TEXT,
+  actor TEXT,
+  source TEXT,
+  status TEXT,
+  meta_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_analytics_usage_ts ON usage_events(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_usage_kind_ts ON usage_events(kind, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_usage_kind_name ON usage_events(kind, name);
+CREATE INDEX IF NOT EXISTS idx_analytics_usage_kind_event ON usage_events(kind, event);
+CREATE INDEX IF NOT EXISTS idx_analytics_usage_machine_ts ON usage_events(machine, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_usage_session ON usage_events(session_id);
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;
+
+let cached: { path: string; db: Database.Database } | null = null;
+
+function isDisabled(): boolean {
+  const v = process.env.AGENTS_NO_USAGE_TRACK;
+  return v === '1' || v === 'true';
+}
+
+function open(): Database.Database | null {
+  if (isDisabled()) return null;
+  const dbPath = getUsageDbPath();
+  if (cached && cached.path === dbPath) return cached.db;
+  if (cached) {
+    try { cached.db.close(); } catch { /* ignore */ }
+    cached = null;
+  }
+  try {
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true, mode: 0o700 });
+    const db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    db.pragma('busy_timeout = 2000');
+    db.exec(SCHEMA);
+    try {
+      db.prepare(`DELETE FROM usage_events WHERE ts < ?`).run(
+        new Date(Date.now() - EVENT_RETENTION_MS).toISOString(),
+      );
+    } catch { /* prune best-effort */ }
+    migrateSecretsUsageOnce(db);
+    cached = { path: dbPath, db };
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+function migrateSecretsUsageOnce(db: Database.Database): void {
+  try {
+    const done = db.prepare(`SELECT value FROM meta WHERE key = 'migrate_secrets_v1'`).get() as { value: string } | undefined;
+    if (done?.value === '1') return;
+    const secretsPath = getSecretsDbPath();
+    if (fs.existsSync(secretsPath)) {
+      const legacy = new Database(secretsPath);
+      try {
+        const rows = legacy.prepare(
+          `SELECT ts, bundle, event, agent, host, source, status, key_count FROM usage_events`,
+        ).all() as Array<{
+          ts: string;
+          bundle: string;
+          event: string;
+          agent: string | null;
+          host: string | null;
+          source: string | null;
+          status: string | null;
+          key_count: number | null;
+        }>;
+        const insert = db.prepare(
+          `INSERT INTO usage_events (ts, kind, name, event, agent, session_id, machine, actor, source, status, meta_json)
+           VALUES (?, 'secret', ?, ?, ?, NULL, ?, NULL, ?, ?, ?)`,
+        );
+        const machine = localMachineId();
+        const txn = db.transaction((items: typeof rows) => {
+          for (const r of items) {
+            if (!r.bundle) continue;
+            const meta = r.key_count != null ? JSON.stringify({ keyCount: r.key_count, host: r.host }) : (r.host ? JSON.stringify({ host: r.host }) : null);
+            insert.run(r.ts, r.bundle, r.event, r.agent, machine, r.source, r.status, meta);
+          }
+        });
+        txn(rows);
+      } finally {
+        try { legacy.close(); } catch { /* ignore */ }
+      }
+    }
+    db.prepare(`INSERT OR REPLACE INTO meta(key, value) VALUES ('migrate_secrets_v1', '1')`).run();
+  } catch {
+    /* migrate is best-effort */
+  }
+}
+
+export function recordUsage(p: RecordUsageParams): void {
+  if (isDisabled()) return;
+  if (!p.kind || !p.name || !p.event) return;
+  const db = open();
+  if (!db) return;
+  try {
+    db.prepare(
+      `INSERT INTO usage_events (ts, kind, name, event, agent, session_id, machine, actor, source, status, meta_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      p.ts ?? new Date().toISOString(),
+      p.kind,
+      p.name,
+      p.event,
+      p.agent ?? null,
+      p.sessionId ?? null,
+      p.machine ?? localMachineId(),
+      p.actor ?? null,
+      p.source ?? null,
+      p.status ?? 'success',
+      p.meta != null ? JSON.stringify(p.meta) : null,
+    );
+  } catch {
+    /* telemetry must never break callers */
+  }
+}
+
+export function usageDbPath(): string {
+  return getUsageDbPath();
+}
+
+export function analyticsDir(): string {
+  return getAnalyticsDir();
+}
+
+export function listUsageKindsWithData(sinceIso: string): UsageKind[] {
+  const db = open();
+  if (!db) return [];
+  try {
+    const rows = db.prepare(
+      `SELECT DISTINCT kind FROM usage_events WHERE ts >= ?`,
+    ).all(sinceIso) as Array<{ kind: string }>;
+    return rows.map((r) => r.kind).filter((k): k is UsageKind => (USAGE_KINDS as readonly string[]).includes(k));
+  } catch {
+    return [];
+  }
+}
+
+export function countUsage(opts: { kind?: UsageKind; sinceIso: string; name?: string; event?: string }): number {
+  const db = open();
+  if (!db) return 0;
+  try {
+    const clauses = ['ts >= ?'];
+    const args: unknown[] = [opts.sinceIso];
+    if (opts.kind) { clauses.push('kind = ?'); args.push(opts.kind); }
+    if (opts.name) { clauses.push('name = ?'); args.push(opts.name); }
+    if (opts.event) { clauses.push('event = ?'); args.push(opts.event); }
+    const row = db.prepare(`SELECT COUNT(*) AS n FROM usage_events WHERE ${clauses.join(' AND ')}`).get(...args) as { n: number };
+    return row?.n ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function queryUsage(opts: {
+  kind?: UsageKind;
+  name?: string;
+  event?: string;
+  sinceIso: string;
+  limit?: number;
+}): UsageEventRow[] {
+  const db = open();
+  if (!db) return [];
+  try {
+    const clauses = ['ts >= ?'];
+    const args: unknown[] = [opts.sinceIso];
+    if (opts.kind) { clauses.push('kind = ?'); args.push(opts.kind); }
+    if (opts.name) { clauses.push('name = ?'); args.push(opts.name); }
+    if (opts.event) { clauses.push('event = ?'); args.push(opts.event); }
+    const limit = opts.limit && opts.limit > 0 ? opts.limit : 100;
+    args.push(limit);
+    const rows = db.prepare(
+      `SELECT ts, kind, name, event, agent, session_id AS sessionId, machine, actor, source, status, meta_json AS metaJson
+         FROM usage_events WHERE ${clauses.join(' AND ')}
+         ORDER BY ts DESC, id DESC LIMIT ?`,
+    ).all(...args) as UsageEventRow[];
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+export interface NameCountRow {
+  name: string;
+  n: number;
+  last: string | null;
+}
+
+export function topNamesByKind(kind: UsageKind, sinceIso: string, limit = 20): NameCountRow[] {
+  const db = open();
+  if (!db) return [];
+  try {
+    return db.prepare(
+      `SELECT name, COUNT(*) AS n, MAX(ts) AS last
+         FROM usage_events WHERE kind = ? AND ts >= ?
+         GROUP BY name ORDER BY n DESC LIMIT ?`,
+    ).all(kind, sinceIso, limit) as NameCountRow[];
+  } catch {
+    return [];
+  }
+}
+
+export interface KindCountRow {
+  kind: string;
+  n: number;
+}
+
+export function kindMix(sinceIso: string): KindCountRow[] {
+  const db = open();
+  if (!db) return [];
+  try {
+    return db.prepare(
+      `SELECT kind, COUNT(*) AS n FROM usage_events WHERE ts >= ? GROUP BY kind ORDER BY n DESC`,
+    ).all(sinceIso) as KindCountRow[];
+  } catch {
+    return [];
+  }
+}
+
+export function getSecretBundleRollup(bundle: string): Array<{ event: string; n: number; last: string | null; first: string | null }> {
+  const db = open();
+  if (!db) return [];
+  try {
+    return db.prepare(
+      `SELECT event, COUNT(*) AS n, MAX(ts) AS last, MIN(ts) AS first
+         FROM usage_events WHERE kind = 'secret' AND name = ? GROUP BY event`,
+    ).all(bundle) as Array<{ event: string; n: number; last: string | null; first: string | null }>;
+  } catch {
+    return [];
+  }
+}
+
+export function getSecretBundleAgents(bundle: string): Array<{ agent: string; n: number }> {
+  const db = open();
+  if (!db) return [];
+  try {
+    return db.prepare(
+      `SELECT agent, COUNT(*) AS n FROM usage_events
+         WHERE kind = 'secret' AND name = ? AND agent IS NOT NULL
+         GROUP BY agent ORDER BY n DESC`,
+    ).all(bundle) as Array<{ agent: string; n: number }>;
+  } catch {
+    return [];
+  }
+}
+
+export function getAllSecretBundleRollups(): Array<{ name: string; event: string; n: number; last: string | null; first: string | null }> {
+  const db = open();
+  if (!db) return [];
+  try {
+    return db.prepare(
+      `SELECT name, event, COUNT(*) AS n, MAX(ts) AS last, MIN(ts) AS first
+         FROM usage_events WHERE kind = 'secret' GROUP BY name, event`,
+    ).all() as Array<{ name: string; event: string; n: number; last: string | null; first: string | null }>;
+  } catch {
+    return [];
+  }
+}
+
+export function getSecretHistory(bundle: string | undefined, limit = 20): Array<{
+  ts: string;
+  bundle: string;
+  event: string;
+  agent: string | null;
+  host: string | null;
+  source: string | null;
+  status: string | null;
+  keyCount: number | null;
+}> {
+  const db = open();
+  if (!db) return [];
+  try {
+    const sql = bundle
+      ? `SELECT ts, name AS bundle, event, agent, source, status, meta_json
+           FROM usage_events WHERE kind = 'secret' AND name = ? ORDER BY ts DESC, id DESC LIMIT ?`
+      : `SELECT ts, name AS bundle, event, agent, source, status, meta_json
+           FROM usage_events WHERE kind = 'secret' ORDER BY ts DESC, id DESC LIMIT ?`;
+    const rows = (bundle ? db.prepare(sql).all(bundle, limit) : db.prepare(sql).all(limit)) as Array<{
+      ts: string;
+      bundle: string;
+      event: string;
+      agent: string | null;
+      source: string | null;
+      status: string | null;
+      meta_json: string | null;
+    }>;
+    return rows.map((r) => {
+      let host: string | null = null;
+      let keyCount: number | null = null;
+      if (r.meta_json) {
+        try {
+          const m = JSON.parse(r.meta_json) as { host?: string; keyCount?: number };
+          host = m.host ?? null;
+          keyCount = typeof m.keyCount === 'number' ? m.keyCount : null;
+        } catch { /* ignore */ }
+      }
+      return { ts: r.ts, bundle: r.bundle, event: r.event, agent: r.agent, host, source: r.source, status: r.status, keyCount };
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function closeUsageDb(): void {
+  if (cached) {
+    try { cached.db.close(); } catch { /* ignore */ }
+    cached = null;
+  }
+}

--- a/apps/cli/src/lib/browser/service.ts
+++ b/apps/cli/src/lib/browser/service.ts
@@ -441,6 +441,15 @@ export class BrowserService {
     await this.saveTaskState(effectiveProfileName, conn.tasks);
 
     emit('browser.launch', { profile: effectiveProfileName, task: taskName, pid: conn.pid });
+    void import('../analytics/usage-db.js').then(({ recordUsage }) => {
+      recordUsage({
+        kind: 'browser',
+        name: effectiveProfileName,
+        event: 'launch',
+        source: 'browser',
+        meta: { task: taskName },
+      });
+    }).catch(() => { /* fail soft */ });
 
     // If URL provided, create tab directly (no about:blank)
     let tabId: string | undefined;
@@ -516,6 +525,15 @@ export class BrowserService {
         await this.saveTaskState(profileName, conn.tasks);
 
         emit('browser.close', { profile: profileName, task: taskName });
+        void import('../analytics/usage-db.js').then(({ recordUsage }) => {
+          recordUsage({
+            kind: 'browser',
+            name: profileName,
+            event: 'close',
+            source: 'browser',
+            meta: { task: taskName },
+          });
+        }).catch(() => { /* fail soft */ });
 
         if (conn.forkedFrom && conn.tasks.size === 0) {
           conn.cdp.close();

--- a/apps/cli/src/lib/secrets/audit.test.ts
+++ b/apps/cli/src/lib/secrets/audit.test.ts
@@ -139,27 +139,30 @@ describe('emitSecretAudit', () => {
  */
 describe('emitSecretAudit feeds events.jsonl AND the usage read-model from one call', () => {
   let prevNoTrack: string | undefined;
-  let prevDbPath: string | undefined;
+  let prevSecretsDb: string | undefined;
+  let prevUsageDb: string | undefined;
   let dbDir: string;
 
   beforeEach(() => {
     setupEvents();
     prevNoTrack = process.env.AGENTS_NO_USAGE_TRACK;
-    prevDbPath = process.env.AGENTS_SECRETS_DB;
-    // Recording is off by the hermetic default — opt in and pin the DB to a
-    // fork-private temp file so the usage rows land there, not the real store.
+    prevSecretsDb = process.env.AGENTS_SECRETS_DB;
+    prevUsageDb = process.env.AGENTS_USAGE_DB;
     delete process.env.AGENTS_NO_USAGE_TRACK;
     closeSecretsUsageDb();
     dbDir = tempDir();
-    process.env.AGENTS_SECRETS_DB = path.join(dbDir, 'secrets.db');
+    process.env.AGENTS_SECRETS_DB = path.join(dbDir, 'secrets-legacy.db');
+    process.env.AGENTS_USAGE_DB = path.join(dbDir, 'usage.db');
   });
 
   afterEach(() => {
     closeSecretsUsageDb();
     if (prevNoTrack === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
     else process.env.AGENTS_NO_USAGE_TRACK = prevNoTrack;
-    if (prevDbPath === undefined) delete process.env.AGENTS_SECRETS_DB;
-    else process.env.AGENTS_SECRETS_DB = prevDbPath;
+    if (prevSecretsDb === undefined) delete process.env.AGENTS_SECRETS_DB;
+    else process.env.AGENTS_SECRETS_DB = prevSecretsDb;
+    if (prevUsageDb === undefined) delete process.env.AGENTS_USAGE_DB;
+    else process.env.AGENTS_USAGE_DB = prevUsageDb;
   });
 
   it('records ONE access in the audit log AND one row in the read-model DB', () => {
@@ -217,8 +220,8 @@ describe('emitSecretAudit feeds events.jsonl AND the usage read-model from one c
   it('a raw `secrets get <item>` (no bundle) audits but records no bundle usage', () => {
     emitSecretAudit({ event: 'secrets.get', item: 'raw-item', source: 'raw-item', status: 'success' });
     expect(query({ eventTypes: ['secrets.get'] })).toHaveLength(1);
-    // No bundle ⇒ nothing in the per-bundle read-model.
-    expect(getUsageHistory(undefined, 10)).toHaveLength(0);
+    expect(getBundleUsage('raw-item')).toBeUndefined();
+    expect(getUsageHistory('raw-item', 10)).toHaveLength(0);
   });
 });
 

--- a/apps/cli/src/lib/secrets/usage-db.test.ts
+++ b/apps/cli/src/lib/secrets/usage-db.test.ts
@@ -22,6 +22,7 @@ import {
 const tmpDirs: string[] = [];
 let prevNoTrack: string | undefined;
 let prevDbPath: string | undefined;
+let prevSecretsDb: string | undefined;
 
 function pinDb(): string {
   const d = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-usage-db-'));
@@ -35,6 +36,7 @@ function pinDb(): string {
 beforeEach(() => {
   prevNoTrack = process.env.AGENTS_NO_USAGE_TRACK;
   prevDbPath = process.env.AGENTS_USAGE_DB;
+  prevSecretsDb = process.env.AGENTS_SECRETS_DB;
   delete process.env.AGENTS_NO_USAGE_TRACK;
   closeSecretsUsageDb();
   pinDb();
@@ -46,7 +48,8 @@ afterEach(() => {
   else process.env.AGENTS_NO_USAGE_TRACK = prevNoTrack;
   if (prevDbPath === undefined) delete process.env.AGENTS_USAGE_DB;
   else process.env.AGENTS_USAGE_DB = prevDbPath;
-  delete process.env.AGENTS_SECRETS_DB;
+  if (prevSecretsDb === undefined) delete process.env.AGENTS_SECRETS_DB;
+  else process.env.AGENTS_SECRETS_DB = prevSecretsDb;
   for (const d of tmpDirs) {
     try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ok */ }
   }

--- a/apps/cli/src/lib/secrets/usage-db.test.ts
+++ b/apps/cli/src/lib/secrets/usage-db.test.ts
@@ -26,15 +26,15 @@ let prevDbPath: string | undefined;
 function pinDb(): string {
   const d = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-usage-db-'));
   tmpDirs.push(d);
-  const dbPath = path.join(d, 'secrets.db');
-  process.env.AGENTS_SECRETS_DB = dbPath;
+  const dbPath = path.join(d, 'usage.db');
+  process.env.AGENTS_USAGE_DB = dbPath;
+  process.env.AGENTS_SECRETS_DB = path.join(d, 'secrets-legacy.db');
   return dbPath;
 }
 
 beforeEach(() => {
   prevNoTrack = process.env.AGENTS_NO_USAGE_TRACK;
-  prevDbPath = process.env.AGENTS_SECRETS_DB;
-  // Recording is disabled by the hermetic default; opt back in for these tests.
+  prevDbPath = process.env.AGENTS_USAGE_DB;
   delete process.env.AGENTS_NO_USAGE_TRACK;
   closeSecretsUsageDb();
   pinDb();
@@ -44,8 +44,9 @@ afterEach(() => {
   closeSecretsUsageDb();
   if (prevNoTrack === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
   else process.env.AGENTS_NO_USAGE_TRACK = prevNoTrack;
-  if (prevDbPath === undefined) delete process.env.AGENTS_SECRETS_DB;
-  else process.env.AGENTS_SECRETS_DB = prevDbPath;
+  if (prevDbPath === undefined) delete process.env.AGENTS_USAGE_DB;
+  else process.env.AGENTS_USAGE_DB = prevDbPath;
+  delete process.env.AGENTS_SECRETS_DB;
   for (const d of tmpDirs) {
     try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ok */ }
   }

--- a/apps/cli/src/lib/secrets/usage-db.ts
+++ b/apps/cli/src/lib/secrets/usage-db.ts
@@ -1,35 +1,20 @@
 /**
- * SQLite-backed usage read-model for `agents secrets`.
- *
- * A small local database at ~/.agents/secrets/secrets.db that records one
- * value-free row for every secret lifecycle/access event a bundle accrues over
- * its life — created, imported, exported, viewed, accessed (read for injection),
- * unlocked. It is the queryable, per-bundle counterpart to the append-only
- * ~/.agents/events.jsonl audit log: the SAME chokepoint (`emitSecretAudit`,
- * lib/secrets/audit.ts) feeds both, and this store answers "how often / how
- * recently / by whom was THIS bundle used?" without scanning the whole event
- * stream. It is a DERIVED index fed off the real access flow — the way
- * sessions.db indexes session metadata — never a second write path an operation
- * has to remember to call.
- *
- * Contract, mirroring the audit log: NEVER a secret value. Only metadata — the
- * bundle name, the event kind, key counts, the resolving agent/host, a status.
- *
- * Every write is best-effort: a failure here (missing runtime SQLite, a locked
- * db, a read-only fs) is swallowed so usage telemetry can never break secret
- * resolution. Set AGENTS_NO_USAGE_TRACK=1 to disable recording entirely (used by
- * tests and by callers that must stay perfectly silent).
+ * Secrets usage read-model — thin adapter over the analytics usage warehouse
+ * (`kind=secret`). Kept so `secrets view` / `list` / `activity` keep their API
+ * while the durable store lives at ~/.agents/.history/analytics/usage.db.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import Database from '../sqlite.js';
-import { getSecretsDbPath } from '../state.js';
+import {
+  recordUsage,
+  getSecretBundleRollup,
+  getSecretBundleAgents,
+  getAllSecretBundleRollups,
+  getSecretHistory,
+  closeUsageDb,
+} from '../analytics/usage-db.js';
 
-/** The lifecycle/access events a bundle accrues over its life. */
 export type SecretUsageEvent = 'access' | 'unlock' | 'import' | 'export' | 'create' | 'view';
 
-/** All event kinds, in the order `view` prints them. */
 export const SECRET_USAGE_EVENTS: readonly SecretUsageEvent[] = [
   'access',
   'unlock',
@@ -39,49 +24,30 @@ export const SECRET_USAGE_EVENTS: readonly SecretUsageEvent[] = [
   'view',
 ] as const;
 
-/** Events older than this are pruned on open so the history table stays bounded. */
-const EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
-
 export interface RecordUsageParams {
-  /** Bundle the event applies to (required — usage is always per-bundle). */
   bundle: string;
-  /** What happened. */
   event: SecretUsageEvent;
-  /** Resolving agent/harness identity, when known (`*` = a global grant). */
   agent?: string;
-  /** Remote host the value was pulled from / pushed to, when applicable. */
   host?: string;
-  /** Free-form origin label, e.g. 'agent', 'reveal', 'ssh', '1password'. */
   source?: string;
-  /** Outcome; defaults to 'success'. */
   status?: 'success' | 'error';
-  /** How many keys the event touched (names only are ever known here). */
   keyCount?: number;
 }
 
-/** One event kind's rollup for a bundle. */
 export interface UsageStat {
   count: number;
-  /** ISO 8601 timestamp of the most recent occurrence, or null if never. */
   last: string | null;
 }
 
-/** Per-bundle usage summary for the `view` / `list` surfaces. */
 export interface BundleUsageSummary {
   bundle: string;
-  /** Every recorded event, all kinds. */
   total: number;
-  /** Rollup per event kind (every kind present, zeroed when unused). */
   events: Record<SecretUsageEvent, UsageStat>;
-  /** Most recent event across all kinds, or null. */
   lastUsedAt: string | null;
-  /** Earliest event across all kinds, or null. */
   firstUsedAt: string | null;
-  /** Event count grouped by resolving agent, most-first. `*` = a global grant. */
   byAgent: Array<{ agent: string; count: number }>;
 }
 
-/** One recorded event, for the `secrets activity` timeline. */
 export interface SecretUsageHistoryEntry {
   ts: string;
   bundle: string;
@@ -92,28 +58,6 @@ export interface SecretUsageHistoryEntry {
   status: string | null;
   keyCount: number | null;
 }
-
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS usage_events (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  ts TEXT NOT NULL,
-  bundle TEXT NOT NULL,
-  event TEXT NOT NULL,
-  agent TEXT,
-  host TEXT,
-  source TEXT,
-  status TEXT,
-  key_count INTEGER
-);
-CREATE INDEX IF NOT EXISTS idx_usage_bundle ON usage_events(bundle);
-CREATE INDEX IF NOT EXISTS idx_usage_bundle_event ON usage_events(bundle, event);
-CREATE INDEX IF NOT EXISTS idx_usage_ts ON usage_events(ts DESC);
-`;
-
-// Cached handle keyed by the resolved path, so a test that redirects
-// AGENTS_SECRETS_DB to a fresh temp file transparently reopens instead of
-// reusing a stale handle pointed at the previous path.
-let cached: { path: string; db: Database.Database } | null = null;
 
 function emptyEvents(): Record<SecretUsageEvent, UsageStat> {
   return {
@@ -126,76 +70,11 @@ function emptyEvents(): Record<SecretUsageEvent, UsageStat> {
   };
 }
 
-/**
- * Open (creating if needed) the usage DB, returning null on any failure so
- * every caller degrades to a no-op rather than throwing into secret resolution.
- */
-function open(): Database.Database | null {
-  const dbPath = getSecretsDbPath();
-  if (cached && cached.path === dbPath) return cached.db;
-  if (cached) {
-    try { cached.db.close(); } catch { /* ignore */ }
-    cached = null;
-  }
-  try {
-    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-    const db = new Database(dbPath);
-    // WAL + a busy timeout so concurrent agent runs writing usage rows don't
-    // fail each other under load; every write is still best-effort besides.
-    db.pragma('journal_mode = WAL');
-    db.pragma('busy_timeout = 2000');
-    db.exec(SCHEMA);
-    // Bounded retention: this is a usage history for operators, not a compliance
-    // log (that is events.jsonl). Prune once per open on a 90-day window.
-    try {
-      db.prepare(`DELETE FROM usage_events WHERE ts < ?`).run(
-        new Date(Date.now() - EVENT_RETENTION_MS).toISOString(),
-      );
-    } catch { /* prune is best-effort */ }
-    cached = { path: dbPath, db };
-    return db;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Record one usage event. Best-effort and value-free — swallows every error and
- * honors AGENTS_NO_USAGE_TRACK so telemetry never blocks or slows a read. Rows
- * with an empty bundle name are ignored (usage is per-bundle by definition).
- *
- * This is called from ONE place only — `emitSecretAudit` (lib/secrets/audit.ts)
- * — so every recorded event has already been written to the events.jsonl audit
- * log through the same chokepoint. Do not call it from a command handler; emit
- * the audit event instead.
- */
-export function recordSecretUsage(p: RecordUsageParams): void {
-  if (process.env.AGENTS_NO_USAGE_TRACK) return;
-  if (!p.bundle) return;
-  const db = open();
-  if (!db) return;
-  try {
-    db.prepare(
-      `INSERT INTO usage_events (ts, bundle, event, agent, host, source, status, key_count)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      new Date().toISOString(),
-      p.bundle,
-      p.event,
-      p.agent ?? null,
-      p.host ?? null,
-      p.source ?? null,
-      p.status ?? 'success',
-      p.keyCount ?? null,
-    );
-  } catch {
-    // Telemetry must never break secret resolution.
-  }
-}
-
-interface RollupRow { event: string; n: number; last: string | null; first: string | null }
-
-function toSummary(bundle: string, rows: RollupRow[], byAgent: Array<{ agent: string; count: number }>): BundleUsageSummary {
+function toSummary(
+  bundle: string,
+  rows: Array<{ event: string; n: number; last: string | null; first: string | null }>,
+  byAgent: Array<{ agent: string; count: number }>,
+): BundleUsageSummary {
   const events = emptyEvents();
   let total = 0;
   let lastUsedAt: string | null = null;
@@ -213,89 +92,55 @@ function toSummary(bundle: string, rows: RollupRow[], byAgent: Array<{ agent: st
   return { bundle, total, events, lastUsedAt, firstUsedAt, byAgent };
 }
 
-/**
- * Usage summary for one bundle, or undefined when nothing has ever been
- * recorded (or the DB is unavailable). Never throws.
- */
-export function getBundleUsage(bundle: string): BundleUsageSummary | undefined {
-  const db = open();
-  if (!db) return undefined;
-  try {
-    const rows = db
-      .prepare(
-        `SELECT event, COUNT(*) AS n, MAX(ts) AS last, MIN(ts) AS first
-           FROM usage_events WHERE bundle = ? GROUP BY event`,
-      )
-      .all(bundle) as RollupRow[];
-    if (rows.length === 0) return undefined;
-    const agents = db
-      .prepare(
-        `SELECT agent, COUNT(*) AS n FROM usage_events
-           WHERE bundle = ? AND agent IS NOT NULL GROUP BY agent ORDER BY n DESC`,
-      )
-      .all(bundle) as Array<{ agent: string; n: number }>;
-    return toSummary(bundle, rows, agents.map((a) => ({ agent: a.agent, count: a.n })));
-  } catch {
-    return undefined;
-  }
+export function recordSecretUsage(p: RecordUsageParams): void {
+  if (!p.bundle) return;
+  const meta: Record<string, unknown> = {};
+  if (p.keyCount != null) meta.keyCount = p.keyCount;
+  if (p.host) meta.host = p.host;
+  recordUsage({
+    kind: 'secret',
+    name: p.bundle,
+    event: p.event,
+    agent: p.agent,
+    source: p.source,
+    status: p.status,
+    meta: Object.keys(meta).length ? meta : undefined,
+  });
 }
 
-/**
- * Usage summaries for every bundle that has any recorded event, keyed by bundle
- * name. Powers `secrets list --sort uses|used`. Empty map when the DB is
- * unavailable or has no rows. Never throws.
- */
+export function getBundleUsage(bundle: string): BundleUsageSummary | undefined {
+  const rows = getSecretBundleRollup(bundle);
+  if (rows.length === 0) return undefined;
+  const agents = getSecretBundleAgents(bundle);
+  return toSummary(bundle, rows, agents.map((a) => ({ agent: a.agent, count: a.n })));
+}
+
 export function getAllBundleUsage(): Map<string, BundleUsageSummary> {
   const out = new Map<string, BundleUsageSummary>();
-  const db = open();
-  if (!db) return out;
-  try {
-    const rows = db
-      .prepare(
-        `SELECT bundle, event, COUNT(*) AS n, MAX(ts) AS last, MIN(ts) AS first
-           FROM usage_events GROUP BY bundle, event`,
-      )
-      .all() as (RollupRow & { bundle: string })[];
-    const byBundle = new Map<string, RollupRow[]>();
-    for (const r of rows) {
-      const list = byBundle.get(r.bundle) ?? [];
-      list.push(r);
-      byBundle.set(r.bundle, list);
-    }
-    for (const [bundle, list] of byBundle) out.set(bundle, toSummary(bundle, list, []));
-    return out;
-  } catch {
-    return out;
+  const rows = getAllSecretBundleRollups();
+  const byBundle = new Map<string, Array<{ event: string; n: number; last: string | null; first: string | null }>>();
+  for (const r of rows) {
+    const list = byBundle.get(r.name) ?? [];
+    list.push(r);
+    byBundle.set(r.name, list);
   }
+  for (const [bundle, list] of byBundle) out.set(bundle, toSummary(bundle, list, []));
+  return out;
 }
 
-/**
- * Recent events for the `secrets activity` timeline — one bundle when named,
- * else across all bundles — newest first. Empty when the DB is unavailable.
- * Never throws.
- */
 export function getUsageHistory(bundle: string | undefined, limit = 20): SecretUsageHistoryEntry[] {
-  const db = open();
-  if (!db) return [];
-  try {
-    const sql = bundle
-      ? `SELECT ts, bundle, event, agent, host, source, status, key_count AS keyCount
-           FROM usage_events WHERE bundle = ? ORDER BY ts DESC, id DESC LIMIT ?`
-      : `SELECT ts, bundle, event, agent, host, source, status, key_count AS keyCount
-           FROM usage_events ORDER BY ts DESC, id DESC LIMIT ?`;
-    const rows = bundle
-      ? db.prepare(sql).all(bundle, limit)
-      : db.prepare(sql).all(limit);
-    return rows as SecretUsageHistoryEntry[];
-  } catch {
-    return [];
-  }
+  return getSecretHistory(bundle, limit).map((r) => ({
+    ts: r.ts,
+    bundle: r.bundle,
+    event: r.event as SecretUsageEvent,
+    agent: r.agent,
+    host: r.host,
+    source: r.source,
+    status: r.status,
+    keyCount: r.keyCount,
+  }));
 }
 
-/** Close the cached handle. Used by tests between temp-db swaps. */
 export function closeSecretsUsageDb(): void {
-  if (cached) {
-    try { cached.db.close(); } catch { /* ignore */ }
-    cached = null;
-  }
+  closeUsageDb();
 }

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -23,7 +23,7 @@ const DB_PATH = getSessionsDbPath();
 /** Current schema version; bumped when migrations are added. Exported so tests
  * assert against the constant instead of hardcoding a number that every bump
  * then has to chase (docs/05-sessions.md calls the constant the source of truth). */
-export const SCHEMA_VERSION = 21;
+export const SCHEMA_VERSION = 22;
 
 /**
  * Canonicalize a file path for use as a scan_ledger key. The same physical
@@ -72,6 +72,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   cost_usd REAL,
   duration_ms INTEGER,
   model TEXT,
+  tool_call_count INTEGER,
   file_path TEXT NOT NULL,
   file_mtime_ms INTEGER,
   file_size INTEGER,
@@ -169,6 +170,7 @@ export interface SessionRow {
   cost_usd: number | null;
   duration_ms: number | null;
   model: string | null;
+  tool_call_count: number | null;
   file_path: string;
   file_mtime_ms: number | null;
   file_size: number | null;
@@ -472,6 +474,12 @@ function migrateSchema(db: Database.Database, fromVersion: number): void {
     // so archived dirs would never be re-parsed and would stay NULL forever.
     const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
     if (!cols.some(c => c.name === 'spawned_team')) db.exec(`ALTER TABLE sessions ADD COLUMN spawned_team TEXT`);
+    db.exec(`DELETE FROM scan_ledger; DELETE FROM dir_ledger;`);
+  }
+
+  if (fromVersion < 22) {
+    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
+    if (!cols.some(c => c.name === 'tool_call_count')) db.exec(`ALTER TABLE sessions ADD COLUMN tool_call_count INTEGER`);
     db.exec(`DELETE FROM scan_ledger; DELETE FROM dir_ledger;`);
   }
 }
@@ -877,7 +885,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     id, short_id, agent, origin, routine_name, routine_run_id,
     version, account, timestamp, last_activity,
     project, cwd, git_branch, topic, label, message_count, token_count,
-    output_tokens, cost_usd, duration_ms, model,
+    output_tokens, cost_usd, duration_ms, model, tool_call_count,
     file_path, file_mtime_ms, file_size, scanned_at, is_team_origin,
     pr_url, pr_number, worktree_slug, ticket_id, spawned_team, plan, todos,
     recent_directories_touched, linear_project, linear_project_url, machine,
@@ -886,7 +894,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     @id, @short_id, @agent, @origin, @routine_name, @routine_run_id,
     @version, @account, @timestamp, @last_activity,
     @project, @cwd, @git_branch, @topic, @label, @message_count, @token_count,
-    @output_tokens, @cost_usd, @duration_ms, @model,
+    @output_tokens, @cost_usd, @duration_ms, @model, @tool_call_count,
     @file_path, @file_mtime_ms, @file_size, @scanned_at, @is_team_origin,
     @pr_url, @pr_number, @worktree_slug, @ticket_id, @spawned_team, @plan, @todos,
     @recent_directories_touched, @linear_project, @linear_project_url, @machine,
@@ -921,6 +929,7 @@ const upsertSessionStmt = (db: Database.Database) => db.prepare(`
     cost_usd = excluded.cost_usd,
     duration_ms = excluded.duration_ms,
     model = excluded.model,
+    tool_call_count = excluded.tool_call_count,
     file_path = excluded.file_path,
     file_mtime_ms = excluded.file_mtime_ms,
     file_size = excluded.file_size,
@@ -1050,6 +1059,7 @@ export function upsertSession(meta: SessionMeta, content: string, scan?: ScanSta
     cost_usd: meta.costUsd ?? null,
     duration_ms: meta.durationMs ?? null,
     model: meta.model ?? null,
+    tool_call_count: meta.toolCallCount ?? null,
     file_path: meta.filePath,
     file_mtime_ms: scan?.fileMtimeMs ?? null,
     file_size: scan?.fileSize ?? null,
@@ -1185,6 +1195,7 @@ export function upsertSessionsBatch(
         cost_usd: meta.costUsd ?? null,
         duration_ms: meta.durationMs ?? null,
         model: meta.model ?? null,
+        tool_call_count: meta.toolCallCount ?? null,
         file_path: meta.filePath,
         file_mtime_ms: scan?.fileMtimeMs ?? null,
         file_size: scan?.fileSize ?? null,
@@ -1391,6 +1402,7 @@ function rowToMeta(row: SessionRow): SessionMeta {
     costUsd: row.cost_usd ?? undefined,
     durationMs: row.duration_ms ?? undefined,
     model: row.model ?? undefined,
+    toolCallCount: row.tool_call_count ?? undefined,
     version: row.version ?? undefined,
     account: row.account ?? undefined,
     topic: row.topic ?? undefined,

--- a/apps/cli/src/lib/session/discover.tool-count.test.ts
+++ b/apps/cli/src/lib/session/discover.tool-count.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyClaudeLine,
+  finalizeClaudeScan,
+  initClaudeParseState,
+  serializeClaudeParserState,
+  hydrateClaudeParseState,
+} from './discover.js';
+
+describe('Claude toolCallCount scan rollup', () => {
+  it('counts tool_use blocks and survives serialize/hydrate', () => {
+    const state = initClaudeParseState();
+    applyClaudeLine(state, {
+      type: 'assistant',
+      timestamp: '2026-08-01T12:00:00.000Z',
+      message: {
+        id: 'msg_1',
+        content: [
+          { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/tmp/a' } },
+          { type: 'tool_use', id: 't2', name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    });
+    applyClaudeLine(state, {
+      type: 'assistant',
+      timestamp: '2026-08-01T12:00:01.000Z',
+      message: {
+        id: 'msg_2',
+        content: [{ type: 'tool_use', id: 't3', name: 'Edit', input: { file_path: '/tmp/a' } }],
+      },
+    });
+    expect(state.toolCallCount).toBe(3);
+    const scan = finalizeClaudeScan(state);
+    expect(scan.toolCallCount).toBe(3);
+
+    const snap = serializeClaudeParserState(state, 100);
+    expect(snap.toolCallCount).toBe(3);
+    const resumed = hydrateClaudeParseState(snap);
+    expect(resumed.toolCallCount).toBe(3);
+    applyClaudeLine(resumed, {
+      type: 'assistant',
+      timestamp: '2026-08-01T12:00:02.000Z',
+      message: {
+        id: 'msg_3',
+        content: [{ type: 'tool_use', id: 't4', name: 'Write', input: { file_path: '/tmp/b' } }],
+      },
+    });
+    expect(finalizeClaudeScan(resumed).toolCallCount).toBe(4);
+  });
+});

--- a/apps/cli/src/lib/session/discover.ts
+++ b/apps/cli/src/lib/session/discover.ts
@@ -158,6 +158,7 @@ interface ClaudeSessionScan {
   durationMs?: number;
   /** ISO time of the last timestamped event — the session's last activity. */
   lastActivity?: string;
+  toolCallCount?: number;
   /**
    * Value of the JSONL `entrypoint` field on the first event that carries it.
    * 'cli' for real interactive sessions, 'sdk-cli' for team-spawned ones.
@@ -1288,6 +1289,7 @@ async function readClaudeMeta(
       topic: scan.topic,
       label,
       messageCount: scan.messageCount,
+      toolCallCount: scan.toolCallCount,
       tokenCount: scan.tokenCount,
       outputTokens: scan.outputTokens,
       costUsd: scan.costUsd,
@@ -1316,6 +1318,7 @@ async function readClaudeMeta(
       model: scan.model,
       label,
       messageCount: scan.messageCount,
+      toolCallCount: scan.toolCallCount,
       tokenCount: scan.tokenCount,
       outputTokens: scan.outputTokens,
       costUsd: scan.costUsd,
@@ -2829,6 +2832,7 @@ export interface ClaudeParseState {
   aiTitle?: string;
   entrypoint?: string;
   messageCount: number;
+  toolCallCount: number;
   tokenCount: number;
   outputTokens: number;
   sawTokenCount: boolean;
@@ -2871,6 +2875,7 @@ export function initClaudeParseState(): ClaudeParseState {
     aiTitle: undefined,
     entrypoint: undefined,
     messageCount: 0,
+    toolCallCount: 0,
     tokenCount: 0,
     outputTokens: 0,
     sawTokenCount: false,
@@ -2930,6 +2935,7 @@ export function applyClaudeLine(state: ClaudeParseState, parsed: any): void {
   if (parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
     for (const b of parsed.message.content) {
       if (b?.type !== 'tool_use') continue;
+      state.toolCallCount++;
       if (!state.spawnedTeam && typeof b?.input?.command === 'string') {
         const team = detectSpawnedTeam(b.input.command);
         if (team) state.spawnedTeam = team;
@@ -3085,6 +3091,7 @@ export function finalizeClaudeScan(state: ClaudeParseState): ClaudeSessionScan {
     topic: resolvedTopic,
     entrypoint: state.entrypoint,
     messageCount: state.messageCount,
+    toolCallCount: state.toolCallCount,
     tokenCount: state.sawTokenCount ? state.tokenCount : undefined,
     outputTokens: state.sawTokenCount ? state.outputTokens : undefined,
     costUsd: state.sawCost ? state.costUsd : undefined,
@@ -3158,6 +3165,7 @@ export interface ClaudeParserState {
   plan?: string;
   lastTsMs?: number;
   messageCount: number;
+  toolCallCount: number;
   tokenCount: number;
   outputTokens: number;
   sawTokenCount: boolean;
@@ -3207,6 +3215,7 @@ export function serializeClaudeParserState(state: ClaudeParseState, offset: numb
     plan: state.plan,
     lastTsMs: state.lastTsMs,
     messageCount: state.messageCount,
+    toolCallCount: state.toolCallCount,
     tokenCount: state.tokenCount,
     outputTokens: state.outputTokens,
     sawTokenCount: state.sawTokenCount,
@@ -3266,6 +3275,7 @@ export function hydrateClaudeParseState(prior: ClaudeParserState): ClaudeParseSt
     aiTitle: prior.aiTitle,
     entrypoint: prior.entrypoint,
     messageCount: prior.messageCount,
+    toolCallCount: prior.toolCallCount ?? 0,
     tokenCount: prior.tokenCount,
     outputTokens: prior.outputTokens,
     sawTokenCount: prior.sawTokenCount,

--- a/apps/cli/src/lib/session/types.ts
+++ b/apps/cli/src/lib/session/types.ts
@@ -148,6 +148,7 @@ export interface SessionMeta {
   durationMs?: number;
   /** Underlying LLM model observed in the transcript, when the agent records one. */
   model?: string;
+  toolCallCount?: number;
   version?: string;
   account?: string;
   topic?: string;

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -77,6 +77,7 @@ export const loadFactory: ModuleLoader = async () => (await import('../../comman
 export const loadUsage: ModuleLoader = async () => (await import('../../commands/usage.js')).registerUsageCommand;
 export const loadCost: ModuleLoader = async () => (await import('../../commands/cost.js')).registerCostCommand;
 export const loadPerf: ModuleLoader = async () => (await import('../../commands/perf.js')).registerPerfCommand;
+export const loadTrends: ModuleLoader = async () => (await import('../../commands/trends.js')).registerTrendsCommand;
 export const loadOutput: ModuleLoader = async () => (await import('../../commands/output.js')).registerOutputCommand;
 export const loadBudget: ModuleLoader = async () => (await import('../../commands/budget.js')).registerBudgetCommand;
 export const loadAlias: ModuleLoader = async () => (await import('../../commands/alias.js')).registerAliasCommand;
@@ -193,6 +194,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   usage: [loadUsage],
   cost: [loadCost],
   perf: [loadPerf],
+  trends: [loadTrends],
   output: [loadOutput],
   budget: [loadBudget],
   alias: [loadAlias],

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -113,6 +113,7 @@ const PROJECTS_DIR = path.join(USER_AGENTS_DIR, 'projects');
 // History bucket (durable).
 const SESSIONS_DIR = path.join(HISTORY_DIR, 'sessions');
 const SESSIONS_DB_PATH = path.join(SESSIONS_DIR, 'sessions.db');
+const ANALYTICS_DIR = path.join(HISTORY_DIR, 'analytics');
 const VERSIONS_DIR = path.join(HISTORY_DIR, 'versions');
 const RUNS_DIR = path.join(HISTORY_DIR, 'runs');
 // Durable per-monitor state-diff store + fire history (last-seen value/hash,
@@ -417,6 +418,18 @@ export function getUserSecretsDir(): string { return USER_SECRETS_DIR; }
 export function getSecretsDbPath(): string {
   return process.env.AGENTS_SECRETS_DB ?? path.join(USER_SECRETS_DIR, 'secrets.db');
 }
+/**
+ * Path to the durable resource-usage warehouse (~/.agents/.history/analytics/usage.db).
+ * Value-free frequency/lifecycle events (secrets, agents, browser, …). Read at CALL
+ * time so AGENTS_USAGE_DB can redirect tests. Sync shards may also appear as
+ * usage.<machine-id>.db beside this default file.
+ */
+export function getAnalyticsDir(): string {
+  return process.env.AGENTS_ANALYTICS_DIR ?? ANALYTICS_DIR;
+}
+export function getUsageDbPath(): string {
+  return process.env.AGENTS_USAGE_DB ?? path.join(getAnalyticsDir(), 'usage.db');
+}
 export function getUserPromptcutsPath(): string { return USER_PROMPTCUTS_FILE; }
 
 // ─── User operational path getters ────────────────────────────────────────────
@@ -555,7 +568,9 @@ export function getTrashDir(): string { return TRASH_DIR; }
 export function getSessionsDir(): string { return SESSIONS_DIR; }
 
 /** Path to the session index database (~/.agents/.history/sessions/sessions.db). */
-export function getSessionsDbPath(): string { return SESSIONS_DB_PATH; }
+export function getSessionsDbPath(): string {
+  return process.env.AGENTS_SESSIONS_DB ?? SESSIONS_DB_PATH;
+}
 
 /** Path to teams config + registry (~/.agents/teams/). */
 export function getTeamsDir(): string { return TEAMS_DIR; }


### PR DESCRIPTION
## Summary
Adds `agents trends`: baked analytics recipes over `sessions.db` plus a durable value-free warehouse at `~/.agents/.history/analytics/usage.db`.

- Leaves `agents usage` (quota) and `agents perf` (latency) alone
- Migrates legacy `secrets.db` usage rows once; secrets UI adapts to the warehouse
- Emits agent-run + browser launch/close into usage.db
- Persists Claude `tool_call_count` at scan time for tools-per-session
- Docs in `06-observability.md` + changelog fragment

## Test plan
- [x] `vitest` analytics + secrets usage + tool-count tests (14 passed)
- [x] `bun run build` (tsc clean)
- [x] Smoke `node dist/index.js trends --days 7` against live sessions/usage DBs

## Run result
Terminal capture of `agents trends --days 7` (warm compute 9ms on ~1.8k sessions):

![agents trends smoke](/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/agents-trends/.agents/scratch/agents-trends-smoke.png)

Full text log: `/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/agents-trends/.agents/scratch/agents-trends-smoke.txt`

Plan: `/home/muqsit/.cursor/plans/agents trends analytics-a9ab9fb6.plan.md`
