### PR TITLE
fix(projects): the card was reading the wrong GitHub repository

### DIFF
--- a/apps/cli/.changelog/next/projects-repo-slug-truth.md
+++ b/apps/cli/.changelog/next/projects-repo-slug-truth.md
@@ -1,0 +1,17 @@
+- **`agents projects` stops reading the wrong GitHub repository.** Factory derives a
+  project's `owner/repo` from the checkout path's last two segments, so a repo cloned to
+  `~/src/github.com/<you>/agents-cli` whose origin is `phnx-labs/agents-cli` imported as
+  `<you>/agents-cli`. Both are real repositories, so nothing errored — the card's merged-PR
+  and release lines simply reported a stranger's repo (0 merges in 7 days instead of 100).
+  `import --from-factory` now reads the checkout's actual `origin` and only falls back to the
+  path guess when there is no remote to ask, and `status`/`show` print a warning with the fix
+  when a stored slug disagrees with the remote. Source: `apps/cli/src/lib/project-doctor.ts`.
+- **`agents projects set <name>` changes one field without destroying the rest.** Previously
+  the only ways to correct a field were `$EDITOR` on raw YAML or `add --force`, which rebuilds
+  the definition from flags alone and silently drops `linear`, `contexts`, and `description`.
+  `set` loads, patches the named field, and writes back. Flags: `--repo`, `--root`, `--path`,
+  `--description`. Source: `apps/cli/src/commands/projects.ts`.
+- **Merged-PR counts say when they are a lower bound.** The `gh` fetch caps at 100, and a busy
+  repo where all 100 land inside the window has more — the count now renders `100+` rather than
+  presenting the cap as a total, matching the existing Linear `2500+` contract. Source:
+  `apps/cli/src/lib/project-status.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -184,6 +184,7 @@ rush  ·  3 agents
 | `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. |
 | `agents projects import --from-linear` | Import the workspace's Linear projects (via the `linear` CLI) as definitions. See [Importing](#importing--linear-first-factory-gated). |
 | `agents projects import --from-factory [--min-confidence low\|medium\|high] [--all]` | Absorb `~/.agents/factory/projects.json`. Imports only `high`-confidence rows by default. |
+| `agents projects set <name> [--repo\|--root\|--path\|--description]` | Change one field, preserving every other. Use this rather than `add --force`, which rebuilds the definition from flags alone. |
 | `agents projects rm <name>` | Delete the definition (never touches the repo). |
 
 `agents run --project <name>` is unchanged in spelling — it just resolves richer
@@ -206,7 +207,7 @@ containment fallback that powers `projects link`'s suggestion is deliberately no
 used on this write path: it would silently bind "Agents CLI" to `agents-cli-web`
 with nobody looking. A project with no exact local match still imports, carrying
 `name` + `linear` and nothing it cannot prove; fill the rest in with
-`projects add --force` or by editing the YAML.
+`projects set` or by editing the YAML.
 
 Re-importing is safe. An existing def is preserved field-for-field and only
 `linear` is overwritten, so a hand-set `description`, `contexts`, or `integrations`
@@ -252,3 +253,31 @@ unlinks the YAML, never the repo.
 - **Re-point `agents factory snapshot`** per-project Linear rollup at defined projects.
 - **Per-repo release lines** — the `ships` release tag is the primary repo only.
 - **Persisted `project_id` session column** — today membership is derived from cwd.
+
+## The stored `repo` must match the checkout's remote
+
+A definition's `repo` is a plain string that nothing used to validate, so it could be
+confidently wrong. That is not hypothetical: Factory seeds the registry with a slug derived
+from the checkout path's last two segments (`repoSlugFromPath`,
+`apps/factory/src/core/projectIndex.ts`), so a repo cloned to
+`~/src/github.com/<you>/agents-cli` whose `origin` is `phnx-labs/agents-cli` was imported as
+`<you>/agents-cli`.
+
+Both slugs resolve to real repositories, so no call failed. The card simply read the merged-PR
+and release counts from a **different repo** — 0 merges in 7 days instead of 100. A wrong
+number that looks right is worse than a missing one, so:
+
+- `import --from-factory` reads the checkout's real `origin` and overrides the registry slug,
+  falling back to the path guess only when there is no remote to ask.
+- `status` and `show` print the disagreement with its fix attached whenever a def's `repo`
+  differs from the remote of its `root`:
+
+  ```
+  repos    muqsitnawaz/agents-cli
+  !        repo is muqsitnawaz/agents-cli but origin is phnx-labs/agents-cli —
+           PR and release counts are being read from the wrong repository
+           agents projects set agents-cli --repo phnx-labs/agents-cli
+  ```
+
+The check is silent when this machine has no checkout to read a remote from — absence of
+evidence is not a finding.

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -53,6 +53,7 @@ import {
 } from '../lib/project-status.js';
 import { fetchLinearProjectCounts, type LinearMilestone, type LinearProjectCounts } from '../lib/linear-project-counts.js';
 import { listLinearProjects, pickLinearProject, type LinearPick, type LinearProjectLite } from '../lib/linear-projects.js';
+import { checkRepoSlug } from '../lib/project-doctor.js';
 import {
   buildFactoryImportCandidates,
   buildLinearImportCandidates,
@@ -92,7 +93,7 @@ function parseContextFlag(raw: string): ProjectContext {
 }
 
 /** Best-effort `owner/repo` from a repo's origin remote. */
-function originSlug(cwd: string): string | undefined {
+export function originSlug(cwd: string): string | undefined {
   try {
     const url = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd, encoding: 'utf8' }).trim();
     return parseOwnerRepoFromRemote(url) ?? undefined;
@@ -127,7 +128,9 @@ function runFactoryImport(existing: Map<string, ProjectDef>, opts: ImportOptions
     : Array.isArray((parsed as { projects?: unknown[] })?.projects)
       ? (parsed as { projects: unknown[] }).projects
       : [];
-  return buildFactoryImportCandidates(rows, existing, opts);
+  // The checkout's real `origin` overrides the registry's path-derived slug —
+  // see buildFactoryImportCandidates for why the path guess is not trustworthy.
+  return buildFactoryImportCandidates(rows, existing, opts, (root) => originSlug(expandLocalHome(root)));
 }
 
 /**
@@ -264,7 +267,9 @@ function renderCard(
   console.log(`  ${chalk.dim('live')}     ${r ? statusBar(r) : chalk.gray('no live agents')}`);
   if (r && r.members.length) console.log(`  ${chalk.dim('agents')}   ${formatProjectMembers(r.members)}`);
   const ships: string[] = [];
-  if (remote?.mergedPrs) ships.push(chalk.green(`${remote.mergedPrs} merged (${remote.windowDays}d)`));
+  if (remote?.mergedPrs) {
+    ships.push(chalk.green(`${remote.mergedPrs}${remote.mergedPrsTruncated ? '+' : ''} merged (${remote.windowDays}d)`));
+  }
   if (r?.openPrs.length) ships.push(`${r.openPrs.length} open PR${r.openPrs.length === 1 ? '' : 's'}`);
   if (r?.worktrees) ships.push(`${r.worktrees} worktree${r.worktrees === 1 ? '' : 's'}`);
   if (remote?.latestRelease) ships.push(remote.latestRelease.tag);
@@ -293,6 +298,14 @@ function renderCard(
   }
   const repos = [def.repo, ...(def.repos ?? []).map((x) => x.slug)].filter(Boolean) as string[];
   if (repos.length) console.log(`  ${chalk.dim('repos')}    ${[...new Set(repos)].join(' · ')}`);
+  // A def whose `repo` disagrees with the checkout's origin reads PR and release
+  // counts from a DIFFERENT repository — both slugs resolve, so nothing errors
+  // and the wrong numbers look right. Say it here, with the fix attached.
+  const mismatch = def.root ? checkRepoSlug(def, originSlug(expandLocalHome(def.root))) : undefined;
+  if (mismatch) {
+    console.log(`  ${chalk.yellow('!')}        ${chalk.yellow(mismatch.message)}`);
+    console.log(`  ${' '.repeat(8)}${chalk.gray(mismatch.remediation)}`);
+  }
   if (def.contexts?.length) {
     console.log(`  ${chalk.dim('context')}  ${def.contexts.map((c) => c.path).join(' · ')}`);
   }
@@ -625,6 +638,40 @@ export function registerProjectsCommands(program: Command): void {
       if (opts.source === 'factory' && s > 0 && opts.minConfidence === 'high') {
         console.log(chalk.gray('  (widen with --min-confidence medium or --all)'));
       }
+    });
+
+  // ---- set ----
+  projects
+    .command('set <name>')
+    .description('Change one field on a project definition, preserving everything else.')
+    .option('--repo <owner/repo>', 'Primary GitHub slug')
+    .option('--root <path>', 'Repo / monorepo root')
+    .option('--path <subdir>', 'Default cwd for agents (a monorepo subdir)')
+    .option('--description <text>', 'One-line description shown on the card')
+    .action((name: string, opts: { repo?: string; root?: string; path?: string; description?: string }) => {
+      const def = loadProjectDef(name);
+      if (!def) {
+        console.error(chalk.red(`No project named "${name}". List them: agents projects list`));
+        process.exit(1);
+      }
+      const fields = (['repo', 'root', 'path', 'description'] as const).filter((k) => opts[k] !== undefined);
+      if (fields.length === 0) {
+        console.error(chalk.red('Nothing to set. Pass a field, e.g. --repo <owner/repo>.'));
+        process.exit(1);
+      }
+      // Load, mutate the named fields, write back — the `link` pattern. NEVER
+      // the `add --force` pattern, which rebuilds the def from flags alone and
+      // silently drops linear/contexts/integrations that were not re-passed.
+      if (opts.repo !== undefined) def.repo = opts.repo;
+      if (opts.root !== undefined) def.root = opts.root;
+      if (opts.description !== undefined) def.description = opts.description;
+      if (opts.path !== undefined) {
+        const base = (opts.root ?? def.root ?? '').replace(/\/$/, '');
+        def.defaultPath = `${base}/${opts.path.replace(/^\//, '')}`;
+      }
+      writeProjectDef(def);
+      console.log(chalk.green(`Updated ${def.name}`));
+      for (const f of fields) console.log(chalk.gray(`  ${f}  ${f === 'path' ? def.defaultPath : def[f as 'repo' | 'root' | 'description']}`));
     });
 
   // ---- link ----

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -666,7 +666,17 @@ export function registerProjectsCommands(program: Command): void {
       if (opts.root !== undefined) def.root = opts.root;
       if (opts.description !== undefined) def.description = opts.description;
       if (opts.path !== undefined) {
+        // `--path` is a subdir OF the root, so without one there is nothing to
+        // hang it off. A def imported with `--from-linear` that found no local
+        // checkout carries name + linear and no root — joining against '' there
+        // would silently write `/apps/cli`, an absolute path at the filesystem
+        // root, and the def would resolve somewhere that does not exist.
         const base = (opts.root ?? def.root ?? '').replace(/\/$/, '');
+        if (!base) {
+          console.error(chalk.red(`"${def.name}" has no root, so --path has nothing to resolve against.`));
+          console.error(chalk.gray(`  Set one first: agents projects set ${def.name} --root <path> --path ${opts.path}`));
+          process.exit(1);
+        }
         def.defaultPath = `${base}/${opts.path.replace(/^\//, '')}`;
       }
       writeProjectDef(def);

--- a/apps/cli/src/lib/project-doctor.test.ts
+++ b/apps/cli/src/lib/project-doctor.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { checkRepoSlug } from './project-doctor.js';
+import type { ProjectDef } from './projects.js';
+
+const def = (over: Partial<ProjectDef> = {}): ProjectDef => ({ name: 'agents-cli', root: '~/src/agents-cli', ...over });
+
+describe('checkRepoSlug', () => {
+  it('flags the disagreement that silently reads the wrong repository', () => {
+    // The real case: both slugs resolve to real repos, so nothing errors — the
+    // card just reports a stranger's merge counts.
+    const f = checkRepoSlug(def({ repo: 'muqsitnawaz/agents-cli' }), 'phnx-labs/agents-cli');
+    expect(f?.message).toContain('repo is muqsitnawaz/agents-cli but origin is phnx-labs/agents-cli');
+    expect(f?.message).toContain('wrong repository');
+    expect(f?.remediation).toBe('agents projects set agents-cli --repo phnx-labs/agents-cli');
+  });
+
+  it('says nothing when they agree', () => {
+    expect(checkRepoSlug(def({ repo: 'phnx-labs/agents-cli' }), 'phnx-labs/agents-cli')).toBeUndefined();
+  });
+
+  it('says nothing when this machine cannot read a remote', () => {
+    // No checkout here, or not a git repo. The def may be perfectly right —
+    // absence of evidence is not a finding.
+    expect(checkRepoSlug(def({ repo: 'phnx-labs/agents-cli' }), undefined)).toBeUndefined();
+    expect(checkRepoSlug(def(), undefined)).toBeUndefined();
+  });
+
+  it('offers to adopt the remote when the def has no repo at all', () => {
+    const f = checkRepoSlug(def(), 'phnx-labs/agents-cli');
+    expect(f?.message).toBe('no repo set; origin is phnx-labs/agents-cli');
+    expect(f?.remediation).toBe('agents projects set agents-cli --repo phnx-labs/agents-cli');
+  });
+});

--- a/apps/cli/src/lib/project-doctor.ts
+++ b/apps/cli/src/lib/project-doctor.ts
@@ -1,0 +1,55 @@
+/**
+ * Definition-vs-reality checks for `agents projects`.
+ *
+ * A project definition is hand-editable YAML that nothing validates against the
+ * world it describes, so it can drift into being confidently wrong. The one that
+ * bit for real: `repo:` said `<user>/agents-cli` while the checkout's `origin`
+ * was `phnx-labs/agents-cli`. Both are real repositories, so nothing errored —
+ * the card's merged-PR and release lines simply reported a stranger's repo (0
+ * merges in 7 days instead of 100). A wrong answer that looks like a right one
+ * is worse than a missing one, so the mismatch gets said out loud wherever the
+ * def is shown.
+ *
+ * Findings carry their own fix, mirroring `DoctorFinding.remediation`
+ * (`lib/devices/doctor-findings.ts`) — a warning the reader has to go work out
+ * how to act on is half a warning. Pure: the caller supplies the observed
+ * remote, so this is unit-testable with no git and no fixture repo.
+ */
+
+import type { ProjectDef } from './projects.js';
+
+/** A definition that disagrees with the machine it describes. */
+export interface ProjectFinding {
+  project: string;
+  /** One line naming the disagreement, both sides quoted. */
+  message: string;
+  /** The exact command that fixes it. */
+  remediation: string;
+}
+
+/**
+ * Compare a def's `repo` slug against the checkout's real `origin` remote.
+ *
+ * - remote unreadable (no checkout on this machine, not a git repo) → no
+ *   finding. The def may be perfectly right; this machine just can't say.
+ * - def has no `repo` → a finding only when a remote exists to adopt, so the
+ *   fix is a real one-liner rather than a nag.
+ * - they disagree → a finding. This is the case that silently lies.
+ */
+export function checkRepoSlug(def: ProjectDef, actualRemote: string | undefined): ProjectFinding | undefined {
+  if (!actualRemote) return undefined;
+  if (def.repo === actualRemote) return undefined;
+  const fix = `agents projects set ${def.name} --repo ${actualRemote}`;
+  if (!def.repo) {
+    return {
+      project: def.name,
+      message: `no repo set; origin is ${actualRemote}`,
+      remediation: fix,
+    };
+  }
+  return {
+    project: def.name,
+    message: `repo is ${def.repo} but origin is ${actualRemote} — PR and release counts are being read from the wrong repository`,
+    remediation: fix,
+  };
+}

--- a/apps/cli/src/lib/project-import.test.ts
+++ b/apps/cli/src/lib/project-import.test.ts
@@ -255,3 +255,29 @@ describe('buildLinearImportCandidates', () => {
     expect(r.skipped[0].reason).toMatch(/no usable project name/);
   });
 });
+
+describe('buildFactoryImportCandidates — the remote wins over the path guess', () => {
+  const row = { name: 'agents-cli', path: '/tmp/src/github.com/muqsitnawaz/agents-cli', repoSlug: 'muqsitnawaz/agents-cli', confidence: 'high' };
+
+  it('overrides the registry slug with the checkout real origin', () => {
+    // Factory derives repoSlug from the path's last two segments, so a checkout
+    // under ~/src/github.com/<you>/ reads as <you>/repo even when origin is an
+    // org. Both are real repos, so the wrong one silently reports a stranger's
+    // merge counts rather than failing.
+    const r = buildFactoryImportCandidates([row], new Map(), { minConfidence: 'high', force: false },
+      () => 'phnx-labs/agents-cli');
+    expect(r.defs[0].repo).toBe('phnx-labs/agents-cli');
+  });
+
+  it('falls back to the registry slug when there is no remote to ask', () => {
+    const r = buildFactoryImportCandidates([row], new Map(), { minConfidence: 'high', force: false },
+      () => undefined);
+    expect(r.defs[0].repo).toBe('muqsitnawaz/agents-cli');
+  });
+
+  it('leaves repo unset when neither the remote nor the registry offers one', () => {
+    const bare = { name: 'x', path: '/tmp/x', confidence: 'high' };
+    const r = buildFactoryImportCandidates([bare], new Map(), { minConfidence: 'high', force: false }, () => undefined);
+    expect(r.defs[0]).toEqual({ name: 'x', root: '/tmp/x' });
+  });
+});

--- a/apps/cli/src/lib/project-import.ts
+++ b/apps/cli/src/lib/project-import.ts
@@ -101,11 +101,22 @@ export function validateImportOpts(flags: RawImportFlags): ImportOptions {
  * `repoSlug`→`repo`, `linearProjectId`→`linear.projectId`), now gated on the
  * row's `confidence`. A row with no confidence field is a guess with no stated
  * strength, so it ranks below every floor and only `--all` takes it.
+ *
+ * `resolveRemote` reads the checkout's actual `origin` and OVERRIDES the row's
+ * `repoSlug`. Factory derives that slug from the checkout path's last two
+ * segments (`apps/factory/src/core/projectIndex.ts:19-26`), which is only right
+ * when the directory tree happens to mirror the GitHub org. It commonly does
+ * not: a checkout at `~/src/github.com/<you>/agents-cli` whose remote is
+ * `phnx-labs/agents-cli` imported as `<you>/agents-cli` — a real, different
+ * repo — so the card's merged-PR and release lines silently reported a
+ * stranger's repository instead of failing. The remote is the only authority on
+ * which repo a checkout is; the path is a guess about it.
  */
 export function buildFactoryImportCandidates(
   rows: unknown[],
   existing: Map<string, ProjectDef>,
   opts: Pick<ImportOptions, 'minConfidence' | 'force'>,
+  resolveRemote: (root: string) => string | undefined = () => undefined,
 ): ImportPlan {
   const floor = CONFIDENCE_RANK[opts.minConfidence];
   const defs: ProjectDef[] = [];
@@ -140,7 +151,11 @@ export function buildFactoryImportCandidates(
     seen.add(name);
     const def: ProjectDef = { name };
     if (typeof o.path === 'string') def.root = toHomeRelative(o.path);
-    if (typeof o.repoSlug === 'string') def.repo = o.repoSlug;
+    // The checkout's own remote wins over the registry's path-derived guess;
+    // the guess is the fallback for a path with no git remote to ask.
+    const fromRemote = typeof o.path === 'string' ? resolveRemote(o.path) : undefined;
+    const repo = fromRemote ?? (typeof o.repoSlug === 'string' ? o.repoSlug : undefined);
+    if (repo) def.repo = repo;
     if (typeof o.linearProjectId === 'string') def.linear = { projectId: o.linearProjectId };
     defs.push(def);
   }

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -21,6 +21,14 @@ import { readRecentActivity } from './activity.js';
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * How many recent merges `gh` is asked for. A repo busy enough that all of them
+ * land inside the window has more than this — agents-cli itself merged 100 of
+ * its 100 most recent PRs within 7 days — so the count is reported as a lower
+ * bound rather than as a total.
+ */
+const MERGED_PR_LIMIT = 100;
+
 /** One live agent on a project — the WHO behind the byStatus count. */
 export interface ProjectMember {
   /** Harness name (claude / codex / …), from the session's `kind`. */
@@ -176,6 +184,12 @@ export interface ProjectRemoteSignals {
   windowDays: number;
   /** PRs merged into the primary repo within the window (via `gh`). */
   mergedPrs: number;
+  /**
+   * True when the `gh` fetch cap cut the count short — `mergedPrs` is then a
+   * LOWER bound (rendered `100+`), never presented as the complete count. Same
+   * contract `LinearProjectCounts.truncated` keeps for the Linear line.
+   */
+  mergedPrsTruncated?: boolean;
   /** Artifacts agents produced within the window (activity.created milestones). */
   artifacts: number;
   /** Basename of the most recent artifact, when any. */
@@ -213,11 +227,16 @@ export async function enrichProjectSignals(
     try {
       const { stdout } = await execFileAsync(
         'gh',
-        ['pr', 'list', '--repo', def.repo, '--state', 'merged', '--json', 'number,mergedAt', '--limit', '100'],
+        ['pr', 'list', '--repo', def.repo, '--state', 'merged', '--json', 'number,mergedAt', '--limit', String(MERGED_PR_LIMIT)],
         { timeout: 8000, encoding: 'utf8' },
       );
       const rows = JSON.parse(stdout) as { mergedAt?: string }[];
       out.mergedPrs = rows.filter((r) => r.mergedAt && Date.parse(r.mergedAt) >= sinceMs).length;
+      // `--limit 100` caps the fetch, so a busy repo where every one of the 100
+      // most recent merges falls inside the window has MORE than 100 — this repo
+      // really does. Say so (`100+`) rather than presenting a cap as a count,
+      // the same contract `LinearProjectCounts.truncated` already keeps.
+      if (rows.length >= MERGED_PR_LIMIT && out.mergedPrs >= MERGED_PR_LIMIT) out.mergedPrsTruncated = true;
     } catch {
       /* gh missing / unauthenticated / repo not found — skip this signal */
     }

--- a/apps/cli/tests/projects-set.test.ts
+++ b/apps/cli/tests/projects-set.test.ts
@@ -1,0 +1,94 @@
+/**
+ * End-to-end `agents projects set` — the real CLI against real YAML on disk.
+ *
+ * The behavior worth pinning is what `set` does NOT do: `add --force` rebuilds a
+ * definition from flags alone and drops every field not re-passed, which is how
+ * a `linear.projectId` gets deleted by someone correcting a repo slug. `set`
+ * loads, patches one field, and writes back.
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const tsxCli = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+const entrypoint = path.join(repoRoot, 'src', 'index.ts');
+
+let home: string;
+let projectsDir: string;
+
+function runCli(args: string[]): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync('node', [tsxCli, entrypoint, ...args], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: home, USERPROFILE: home, NO_COLOR: '1', AGENTS_SKIP_MIGRATION: '1', AGENTS_PROJECTS_DIR: projectsDir },
+    });
+    return { stdout, status: 0 };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: `${err.stdout ?? ''}${err.stderr ?? ''}`, status: err.status ?? 1 };
+  }
+}
+
+const def = (name: string) => fs.readFileSync(path.join(projectsDir, `${name}.yaml`), 'utf8');
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'projects-set-home-'));
+  projectsDir = path.join(home, 'projects');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  fs.mkdirSync(path.join(home, '.agents', '.system', '.git'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.agents', 'agents.yaml'), 'agents: {}\nbeta:\n  enabled:\n    - projects\n');
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('agents projects set', () => {
+  it('changes one field and preserves every other', () => {
+    fs.writeFileSync(
+      path.join(projectsDir, 'agents-cli.yaml'),
+      'name: agents-cli\nroot: ~/src/agents-cli\nrepo: me/agents-cli\ndescription: the CLI\nlinear:\n  projectId: lin_1\n',
+    );
+    const { stdout, status } = runCli(['projects', 'set', 'agents-cli', '--repo', 'phnx-labs/agents-cli']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('Updated agents-cli');
+    const y = def('agents-cli');
+    expect(y).toContain('repo: phnx-labs/agents-cli');
+    // The fields `add --force` would have silently dropped.
+    expect(y).toContain('projectId: lin_1');
+    expect(y).toContain('description: the CLI');
+    expect(y).toContain('root: ~/src/agents-cli');
+  });
+
+  it('refuses --path when the def has no root, instead of writing an absolute path', () => {
+    // A `--from-linear` import with no local checkout carries name + linear and
+    // no root. Joining `--path` against '' wrote `/apps/cli` — a path at the
+    // filesystem root that resolves nowhere.
+    fs.writeFileSync(path.join(projectsDir, 'rootless.yaml'), 'name: rootless\nlinear:\n  projectId: abc\n');
+    const { stdout, status } = runCli(['projects', 'set', 'rootless', '--path', 'apps/cli']);
+    expect(status).toBe(1);
+    expect(stdout).toContain('has no root, so --path has nothing to resolve against');
+    expect(def('rootless')).not.toContain('defaultPath');
+  });
+
+  it('accepts --path when a root comes along in the same call', () => {
+    fs.writeFileSync(path.join(projectsDir, 'rootless.yaml'), 'name: rootless\nlinear:\n  projectId: abc\n');
+    const { status } = runCli(['projects', 'set', 'rootless', '--root', '~/src/x', '--path', 'apps/cli']);
+    expect(status).toBe(0);
+    expect(def('rootless')).toContain('defaultPath: ~/src/x/apps/cli');
+  });
+
+  it('errors on an unknown project and on no fields, writing nothing', () => {
+    expect(runCli(['projects', 'set', 'nope', '--repo', 'a/b']).stdout).toContain('No project named "nope"');
+    fs.writeFileSync(path.join(projectsDir, 'p.yaml'), 'name: p\nrepo: a/b\n');
+    const { stdout, status } = runCli(['projects', 'set', 'p']);
+    expect(status).toBe(1);
+    expect(stdout).toContain('Nothing to set');
+    expect(def('p')).toBe('name: p\nrepo: a/b\n');
+  });
+});


### PR DESCRIPTION
**What + type:** bug fix — `agents projects` was reading merged-PR and release counts from a **different GitHub repository**, silently.

## The bug, measured

Factory seeds its registry with a slug derived from the checkout path's last two segments (`apps/factory/src/core/projectIndex.ts:19-26`). A repo cloned to `~/src/github.com/<you>/agents-cli` whose `origin` is `phnx-labs/agents-cli` imported as `<you>/agents-cli`.

`<you>/agents-cli` is a **real, different repo** (`"isFork": false, "parent": null`), so nothing errored and nothing degraded. The card just answered about the wrong repository:

| slug | merged in 7d | latest release |
| --- | --- | --- |
| `muqsitnawaz/agents-cli` (what the def held) | **0** of 21 | none |
| `phnx-labs/agents-cli` (the actual origin) | **100** of 100 | `v1.21.0` |

Two of the three definitions on this machine were wrong this way. The third was right by coincidence — its checkout path happens to match its org.

## The run

<img width="5640" height="1944" alt="the warning fires, projects set fixes it, linear link preserved, ships line now reads the right repo" src="https://github.com/user-attachments/assets/84e5cd8f-1aa0-4cae-87cb-e06d4f3c77c9" />

## What changed

| Area | Before | After |
| --- | --- | --- |
| `import --from-factory` | trusted the registry's path-derived slug | reads the checkout's real `origin`; path guess only when there is no remote |
| a wrong stored slug | silent | inline warning on the card, carrying its own fix |
| fixing one field | `$EDITOR` on raw YAML, or `add --force` (rebuilds from flags, drops `linear`/`contexts`/`description`) | `agents projects set <name> --repo\|--root\|--path\|--description` — load, patch, write |
| `mergedPrs` at the 100 cap | printed `100` as if it were a total | prints `100+`, matching the existing Linear `2500+` contract |

**`set` uses the `link` pattern, not the `add` pattern.** That distinction is the whole point: the screenshot shows `linear.projectId` surviving the edit. `add --force --repo x` would have deleted it — and `docs/11-projects.md` was telling users to do exactly that, which this PR also fixes.

`checkRepoSlug` is pure and stays silent when no remote is readable — a def may be perfectly right and this machine simply unable to say. Absence of evidence is not a finding.

## Benchmarks

Measured on this repo, 3 projects, 39 sessions:

| | wall clock |
| --- | --- |
| `projects status` (gh + Linear) | **2.50s** / 2.72s |
| `projects status --no-remote` | **1.18s** |
| network portion | ~1.4s |
| `gh pr list --limit 100` | 0.54s |

Linear cost per run: **2 requests per linked project** (448 issues @ 250/page). Against the account limits observed in the response headers — `x-ratelimit-requests-limit: 2500`, `x-ratelimit-complexity-limit: 3000000` — that is ~1250 status runs/hour, while complexity sits at **13 of 3,000,000**. Requests are the only scarce resource; per-request cost is irrelevant. (I exhausted the request budget during this work — headers read `requests-remaining: 2`.) A TTL cache and a one-request project query are queued as follow-ups, not in this PR.

## Tests

`project-doctor.test.ts` (new) covers the disagreement, agreement, no-readable-remote, and adopt-the-remote cases. `project-import.test.ts` gains the remote-overrides-path-guess case and its fallback. 59 tests pass across the four touched suites.

Follow-ups already scoped: `projects view` + all milestones, an honest live/dead agent split (`orphaned` is alive per `lib/session/active.ts:110`; only `crashed` is dead), deleting `planPct`, and the Linear cache.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
