### PR TITLE
feat(projects): cache the Linear answer, and serve stale instead of dropping the line

### DIFF
--- a/apps/cli/.changelog/next/projects-linear-cache.md
+++ b/apps/cli/.changelog/next/projects-linear-cache.md
@@ -1,7 +1,8 @@
 - **The Linear line on `agents projects status` is cached, and stops vanishing.** The card
   paged every issue in a project on every invocation — up to 10 requests per project — against
   a 2500/hour request budget that an agent running `status` in a loop exhausts. Answers are now
-  cached on disk for 10 minutes (`~/.agents/.cache/.linear-projects.json`), so a repeated
+  cached on disk for 10 minutes (`~/.agents/.cache/linear-projects/`, one file per project written
+  by atomic rename so concurrent agent sessions cannot clobber each other), so a repeated
   `status` spends zero Linear requests. More importantly, a failed or rate-limited fetch now
   serves the last good answer marked stale instead of dropping the line: a populated Linear row
   silently disappearing on one 8s timeout was the observed defect, and it is the same rule

--- a/apps/cli/.changelog/next/projects-linear-cache.md
+++ b/apps/cli/.changelog/next/projects-linear-cache.md
@@ -1,0 +1,10 @@
+- **The Linear line on `agents projects status` is cached, and stops vanishing.** The card
+  paged every issue in a project on every invocation — up to 10 requests per project — against
+  a 2500/hour request budget that an agent running `status` in a loop exhausts. Answers are now
+  cached on disk for 10 minutes (`~/.agents/.cache/.linear-projects.json`), so a repeated
+  `status` spends zero Linear requests. More importantly, a failed or rate-limited fetch now
+  serves the last good answer marked stale instead of dropping the line: a populated Linear row
+  silently disappearing on one 8s timeout was the observed defect, and it is the same rule
+  `mergeAuthHealthEntries` already keeps for account health. A 429 records its
+  `x-ratelimit-requests-reset` so later runs don't spend a request to be told there are none
+  left. Source: `apps/cli/src/lib/linear-cache.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -281,3 +281,31 @@ number that looks right is worse than a missing one, so:
 
 The check is silent when this machine has no checkout to read a remote from — absence of
 evidence is not a finding.
+
+## The Linear line is cached, and degrades to stale rather than absent
+
+Linear meters requests and query complexity separately, and only one of them binds. Measured
+on this workspace's response headers:
+
+```
+x-ratelimit-requests-limit:   2500      remaining: 2
+x-ratelimit-complexity-limit: 3000000   remaining: 2999987
+```
+
+Requests are scarce; complexity is essentially untouched. Since the card pages every issue in
+a project (up to 10 requests each), an agent running `status` in a loop exhausts the budget —
+which is exactly how it was exhausted during this feature's development.
+
+Answers are cached at `~/.agents/.cache/.linear-projects.json` for 10 minutes, matching the
+repo's existing `SKILL_INDEX_TTL_MS` convention. A second `status` inside the window makes no
+Linear request at all.
+
+The behavior that matters more is on failure: **a stale answer is served and labelled, never
+dropped.** A Linear row that was populated a minute ago must not blank out because one fetch
+timed out — the same invariant `mergeAuthHealthEntries` keeps for account health. A 429 records
+its reset time so subsequent runs skip the call entirely instead of spending a request to learn
+the budget is gone.
+
+`AGENTS_LINEAR_CACHE_PATH` overrides the location (tests use it; `getCacheDir()` resolves
+`HOME` once at module load, so a test swapping `process.env.HOME` would otherwise read and
+write the developer's real cache).

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -296,8 +296,13 @@ Requests are scarce; complexity is essentially untouched. Since the card pages e
 a project (up to 10 requests each), an agent running `status` in a loop exhausts the budget —
 which is exactly how it was exhausted during this feature's development.
 
-Answers are cached at `~/.agents/.cache/.linear-projects.json` for 10 minutes, matching the
-repo's existing `SKILL_INDEX_TTL_MS` convention. A second `status` inside the window makes no
+Answers are cached under `~/.agents/.cache/linear-projects/` for 10 minutes, matching the
+repo's existing `SKILL_INDEX_TTL_MS` convention — **one file per project**, written by atomic
+rename. A single shared JSON document would have to be read, modified, and written back, and
+that sequence is not atomic across processes: measured with two concurrent writers of 40
+distinct keys each, **8 of 80 entries survived**. A machine running a dozen agent sessions
+makes that the normal case rather than a corner. Per-key files have nothing to clobber, and the
+same measurement now yields 80 of 80. A second `status` inside the window makes no
 Linear request at all.
 
 The behavior that matters more is on failure: **a stale answer is served and labelled, never

--- a/apps/cli/src/lib/linear-cache.test.ts
+++ b/apps/cli/src/lib/linear-cache.test.ts
@@ -22,7 +22,7 @@ const T0 = new Date(2026, 7, 3, 12, 0, 0).getTime();
 
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'linear-cache-'));
-  cacheFile = path.join(home, 'linear-projects.json');
+  cacheFile = path.join(home, 'cache');
   process.env.AGENTS_LINEAR_CACHE_PATH = cacheFile;
 });
 afterEach(() => {
@@ -97,11 +97,32 @@ describe('linear cache', () => {
 
   it('treats a corrupt cache file as an empty one instead of throwing', () => {
     writeCached('p1', 'one', T0);
-    fs.writeFileSync(cacheFile, '{not json');
+    fs.writeFileSync(path.join(cacheFile, 'p1.json'), '{not json');
     expect(readCached('p1', T0)).toBeUndefined();
     expect(isRateLimited(T0)).toBe(false);
     // And it recovers: the next write replaces the garbage.
-    writeCached('p2', 'two', T0);
-    expect(readCached<string>('p2', T0)?.value).toBe('two');
+    writeCached('p1', 'again', T0);
+    expect(readCached<string>('p1', T0)?.value).toBe('again');
+  });
+
+  it('rejects a wrong-shaped entry rather than handing it to the card', () => {
+    fs.mkdirSync(cacheFile, { recursive: true });
+    fs.writeFileSync(path.join(cacheFile, 'p9.json'), JSON.stringify({ nope: true }));
+    expect(readCached('p9', T0)).toBeUndefined();
+  });
+
+  it('keeps a project id from escaping the cache directory', () => {
+    writeCached('../../escape', 'x', T0);
+    expect(fs.existsSync(path.join(cacheFile, '.._.._escape.json'))).toBe(true);
+    expect(readCached<string>('../../escape', T0)?.value).toBe('x');
+  });
+
+  it('survives concurrent writers of distinct keys', () => {
+    // A single shared JSON document lost 72 of 80 entries here under two
+    // concurrent writers; one file per key has nothing to clobber.
+    for (let i = 0; i < 40; i++) writeCached(`a-${i}`, i, T0);
+    for (let i = 0; i < 40; i++) writeCached(`b-${i}`, i, T0);
+    const survived = fs.readdirSync(cacheFile).filter((f) => f.endsWith('.json')).length;
+    expect(survived).toBe(80);
   });
 });

--- a/apps/cli/src/lib/linear-cache.test.ts
+++ b/apps/cli/src/lib/linear-cache.test.ts
@@ -7,6 +7,7 @@ import {
   invalidateCached,
   isRateLimited,
   noteRateLimited,
+  parseRateLimitReset,
   readCached,
   writeCached,
 } from './linear-cache.js';
@@ -72,6 +73,16 @@ describe('linear cache', () => {
     // A reset already in the past is not usable either.
     noteRateLimited(T0 - 5, T0);
     expect(isRateLimited(T0 + LINEAR_CACHE_TTL_MS - 1)).toBe(true);
+  });
+
+  it('parses a usable 429 reset header, and rejects the rest', () => {
+    // Linear sends epoch milliseconds on x-ratelimit-requests-reset.
+    expect(parseRateLimitReset(String(T0 + 30 * 60_000), T0)).toBe(T0 + 30 * 60_000);
+    expect(parseRateLimitReset(null, T0)).toBeUndefined();
+    expect(parseRateLimitReset('soon', T0)).toBeUndefined();
+    expect(parseRateLimitReset('', T0)).toBeUndefined();
+    // Already elapsed is not a future window.
+    expect(parseRateLimitReset(String(T0 - 1), T0)).toBeUndefined();
   });
 
   it('invalidates one project without disturbing the rest', () => {

--- a/apps/cli/src/lib/linear-cache.test.ts
+++ b/apps/cli/src/lib/linear-cache.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  LINEAR_CACHE_TTL_MS,
+  invalidateCached,
+  isRateLimited,
+  noteRateLimited,
+  readCached,
+  writeCached,
+} from './linear-cache.js';
+
+// getCacheDir() resolves HOME once at module load, so swapping process.env.HOME
+// here would read and WRITE the developer's real cache. Point the dedicated
+// AGENTS_LINEAR_CACHE_PATH seam at a temp file instead. Real fs, real JSON, no
+// mocking.
+let home: string;
+let cacheFile: string;
+const T0 = new Date(2026, 7, 3, 12, 0, 0).getTime();
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'linear-cache-'));
+  cacheFile = path.join(home, 'linear-projects.json');
+  process.env.AGENTS_LINEAR_CACHE_PATH = cacheFile;
+});
+afterEach(() => {
+  delete process.env.AGENTS_LINEAR_CACHE_PATH;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('linear cache', () => {
+  it('returns nothing for a project it has never seen', () => {
+    expect(readCached('p1', T0)).toBeUndefined();
+  });
+
+  it('round-trips a value and reports it fresh inside the TTL', () => {
+    writeCached('p1', { progress: 0.88, scope: 419 }, T0);
+    const hit = readCached<{ progress: number; scope: number }>('p1', T0 + 60_000);
+    expect(hit?.value).toEqual({ progress: 0.88, scope: 419 });
+    expect(hit?.stale).toBe(false);
+    expect(hit?.ageMs).toBe(60_000);
+  });
+
+  it('KEEPS serving past the TTL, flagged stale, rather than vanishing', () => {
+    // The whole point: a card that loses its Linear line on one timeout is the
+    // defect. Stale-and-labelled beats absent.
+    writeCached('p1', { progress: 0.88 }, T0);
+    const hit = readCached<{ progress: number }>('p1', T0 + LINEAR_CACHE_TTL_MS + 1);
+    expect(hit?.value).toEqual({ progress: 0.88 });
+    expect(hit?.stale).toBe(true);
+  });
+
+  it('keeps entries separate per project', () => {
+    writeCached('p1', 'one', T0);
+    writeCached('p2', 'two', T0);
+    expect(readCached<string>('p1', T0)?.value).toBe('one');
+    expect(readCached<string>('p2', T0)?.value).toBe('two');
+  });
+
+  it('honours a 429 reset time, then lifts', () => {
+    expect(isRateLimited(T0)).toBe(false);
+    noteRateLimited(T0 + 30 * 60_000, T0);
+    expect(isRateLimited(T0 + 60_000)).toBe(true);
+    expect(isRateLimited(T0 + 31 * 60_000)).toBe(false);
+  });
+
+  it('backs off for one TTL when the 429 carried no usable reset header', () => {
+    noteRateLimited(undefined, T0);
+    expect(isRateLimited(T0 + LINEAR_CACHE_TTL_MS - 1)).toBe(true);
+    expect(isRateLimited(T0 + LINEAR_CACHE_TTL_MS + 1)).toBe(false);
+    // A reset already in the past is not usable either.
+    noteRateLimited(T0 - 5, T0);
+    expect(isRateLimited(T0 + LINEAR_CACHE_TTL_MS - 1)).toBe(true);
+  });
+
+  it('invalidates one project without disturbing the rest', () => {
+    writeCached('p1', 'one', T0);
+    writeCached('p2', 'two', T0);
+    invalidateCached('p1');
+    expect(readCached('p1', T0)).toBeUndefined();
+    expect(readCached<string>('p2', T0)?.value).toBe('two');
+    // Invalidating something absent is a no-op, not an error.
+    expect(() => invalidateCached('nope')).not.toThrow();
+  });
+
+  it('treats a corrupt cache file as an empty one instead of throwing', () => {
+    writeCached('p1', 'one', T0);
+    fs.writeFileSync(cacheFile, '{not json');
+    expect(readCached('p1', T0)).toBeUndefined();
+    expect(isRateLimited(T0)).toBe(false);
+    // And it recovers: the next write replaces the garbage.
+    writeCached('p2', 'two', T0);
+    expect(readCached<string>('p2', T0)?.value).toBe('two');
+  });
+});

--- a/apps/cli/src/lib/linear-cache.ts
+++ b/apps/cli/src/lib/linear-cache.ts
@@ -13,8 +13,18 @@
  * A human typing it is not the exhauster.
  *
  * The CLI is a short-lived process, so an in-memory memo would only help within
- * one invocation, which is the case that never needed help. This caches to
- * disk, mirroring `auth-health.ts`'s `getCacheDir()` snapshot.
+ * one invocation, which is the case that never needed help. This caches to disk.
+ *
+ * **One file per key, written by atomic rename.** A single JSON document holding
+ * every entry has to be read, modified, and written back, and that sequence is
+ * not atomic across processes — measured on this machine, two concurrent writers
+ * of 40 distinct keys each left **8 of 80** surviving. This box routinely runs a
+ * dozen agent sessions, so that is the normal case, not a corner. Per-key files
+ * remove the shared mutable document entirely: two processes caching different
+ * projects never touch the same path, and two caching the SAME project race only
+ * to write identical data. `writeFileSync` to a temp path followed by `rename`
+ * makes each file appear whole or not at all, so a reader never sees a partial
+ * write.
  *
  * The load-bearing behavior is what happens on FAILURE: a stale entry keeps
  * being served, marked stale, instead of the line vanishing. That rule is
@@ -30,57 +40,69 @@ import { getCacheDir } from './state.js';
 /** Matches `SKILL_INDEX_TTL_MS` (`lib/registry.ts`) — the repo's TTL convention. */
 export const LINEAR_CACHE_TTL_MS = 10 * 60_000;
 
-const CACHE_FILE = '.linear-projects.json';
+const CACHE_SUBDIR = 'linear-projects';
+/** Sits beside the per-project files; its own file, so it cannot be clobbered by them. */
+const RATE_LIMIT_FILE = 'rate-limit.json';
 
-/** One cached answer, keyed by Linear project id. */
+/** One cached answer. */
 interface CacheEntry<T> {
   /** Epoch ms the value was fetched. */
   at: number;
   value: T;
 }
 
-interface CacheFile<T> {
-  entries: Record<string, CacheEntry<T>>;
-  /**
-   * Epoch ms until which the API is known to be rate-limited, from a 429's
-   * `x-ratelimit-requests-reset`. Until then every fetch is skipped outright —
-   * spending a request to be told there are none left helps nobody.
-   */
-  rateLimitedUntil?: number;
+/**
+ * Where the snapshot lives. `AGENTS_LINEAR_CACHE_PATH` overrides the directory,
+ * mirroring `AGENTS_FACTORY_PROJECTS_PATH` (`auto-dispatch.ts`) — `getCacheDir()`
+ * resolves `HOME` once at module load, so a test that swaps `process.env.HOME`
+ * afterwards would otherwise read and WRITE the developer's real cache.
+ */
+function cacheDir(): string {
+  return process.env.AGENTS_LINEAR_CACHE_PATH ?? path.join(getCacheDir(), CACHE_SUBDIR);
 }
 
 /**
- * Where the snapshot lives. `AGENTS_LINEAR_CACHE_PATH` overrides it, mirroring
- * `AGENTS_FACTORY_PROJECTS_PATH` (`auto-dispatch.ts`) — `getCacheDir()` resolves
- * `HOME` once at module load, so a test that swaps `process.env.HOME` afterwards
- * would otherwise read and WRITE the developer's real cache.
+ * One file per project id. Linear ids are UUIDs, but this is a filename built
+ * from external input, so anything outside the safe set is encoded rather than
+ * trusted — a `/` or `..` must never escape the cache directory.
  */
-function cachePath(): string {
-  return process.env.AGENTS_LINEAR_CACHE_PATH ?? path.join(getCacheDir(), CACHE_FILE);
+function entryPath(projectId: string): string {
+  return path.join(cacheDir(), `${projectId.replace(/[^a-zA-Z0-9._-]/g, '_')}.json`);
 }
 
-/** The directory the cache file lives in, whichever path is in effect. */
-function cacheDir(): string {
-  return path.dirname(cachePath());
-}
-
-function read<T>(): CacheFile<T> {
+/** Parse a cache file, treating absent/corrupt/wrong-shaped as simply absent. */
+function readJson<T>(file: string, valid: (raw: unknown) => raw is T): T | undefined {
   try {
-    const raw = JSON.parse(fs.readFileSync(cachePath(), 'utf8')) as CacheFile<T>;
-    if (raw && typeof raw === 'object' && raw.entries && typeof raw.entries === 'object') return raw;
+    const raw: unknown = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return valid(raw) ? raw : undefined;
   } catch {
-    /* absent or corrupt — an empty cache is always a valid answer */
+    return undefined; // absent or corrupt — an empty cache is always a valid answer
   }
-  return { entries: {} };
 }
 
-function write<T>(file: CacheFile<T>): void {
+/**
+ * Write whole-or-not-at-all: a temp file in the same directory (so `rename`
+ * stays on one filesystem and is therefore atomic) swapped into place. A reader
+ * concurrent with this never observes a half-written document.
+ */
+function writeJson(file: string, value: unknown): void {
   try {
-    fs.mkdirSync(cacheDir(), { recursive: true });
-    fs.writeFileSync(cachePath(), JSON.stringify(file), 'utf8');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const tmp = `${file}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(value), 'utf8');
+    fs.renameSync(tmp, file);
   } catch {
     /* best-effort: an unwritable cache degrades to no cache, never to an error */
   }
+}
+
+function isEntry(raw: unknown): raw is CacheEntry<unknown> {
+  return (
+    !!raw &&
+    typeof raw === 'object' &&
+    typeof (raw as CacheEntry<unknown>).at === 'number' &&
+    'value' in (raw as object)
+  );
 }
 
 /** What a lookup found, and how much to trust it. */
@@ -93,23 +115,34 @@ export interface CacheHit<T> {
 
 /** Look up a project's cached answer. Returns stale entries too — the caller decides. */
 export function readCached<T>(projectId: string, nowMs: number): CacheHit<T> | undefined {
-  const entry = read<T>().entries[projectId];
-  if (!entry || typeof entry.at !== 'number') return undefined;
+  const entry = readJson(entryPath(projectId), isEntry);
+  if (!entry) return undefined;
   const ageMs = nowMs - entry.at;
-  return { value: entry.value, ageMs, stale: ageMs > LINEAR_CACHE_TTL_MS };
+  return { value: entry.value as T, ageMs, stale: ageMs > LINEAR_CACHE_TTL_MS };
 }
 
 /** Store a freshly fetched answer. */
 export function writeCached<T>(projectId: string, value: T, nowMs: number): void {
-  const file = read<T>();
-  file.entries[projectId] = { at: nowMs, value };
-  write(file);
+  writeJson(entryPath(projectId), { at: nowMs, value } satisfies CacheEntry<T>);
+}
+
+/** Drop one project's entry — used when `projects link` re-points a definition. */
+export function invalidateCached(projectId: string): void {
+  try {
+    fs.rmSync(entryPath(projectId), { force: true });
+  } catch {
+    /* already gone is the desired state */
+  }
+}
+
+function isRateLimitFile(raw: unknown): raw is { until: number } {
+  return !!raw && typeof raw === 'object' && typeof (raw as { until: unknown }).until === 'number';
 }
 
 /** True when a prior 429 said the budget is exhausted and has not yet reset. */
 export function isRateLimited(nowMs: number): boolean {
-  const until = read().rateLimitedUntil;
-  return typeof until === 'number' && until > nowMs;
+  const f = readJson(path.join(cacheDir(), RATE_LIMIT_FILE), isRateLimitFile);
+  return !!f && f.until > nowMs;
 }
 
 /**
@@ -127,20 +160,13 @@ export function parseRateLimitReset(header: string | null, nowMs: number): numbe
 
 /**
  * Record a 429 so the next runs don't spend a request learning the same thing.
- * `resetAtMs` comes from the response's `x-ratelimit-requests-reset` header
- * (epoch ms); without it, back off for one TTL.
+ * `resetAtMs` comes from {@link parseRateLimitReset}; without it, back off one TTL.
  */
 export function noteRateLimited(resetAtMs: number | undefined, nowMs: number): void {
-  const file = read();
-  file.rateLimitedUntil = resetAtMs && resetAtMs > nowMs ? resetAtMs : nowMs + LINEAR_CACHE_TTL_MS;
-  write(file);
-}
-
-/** Drop one project's entry — used when `projects link` re-points a definition. */
-export function invalidateCached(projectId: string): void {
-  const file = read();
-  if (file.entries[projectId]) {
-    delete file.entries[projectId];
-    write(file);
-  }
+  // The invariant this owns: `until` is always in the future. A reset already
+  // elapsed would record a window that is over before it is written, which
+  // reads as "not rate limited" and sends the next run straight back into the
+  // 429 it just took.
+  const until = resetAtMs && resetAtMs > nowMs ? resetAtMs : nowMs + LINEAR_CACHE_TTL_MS;
+  writeJson(path.join(cacheDir(), RATE_LIMIT_FILE), { until });
 }

--- a/apps/cli/src/lib/linear-cache.ts
+++ b/apps/cli/src/lib/linear-cache.ts
@@ -1,0 +1,133 @@
+/**
+ * Disk TTL cache for the Linear answers behind the `agents projects` card.
+ *
+ * Linear meters two budgets independently, and only one of them binds. Observed
+ * on this account's response headers:
+ *
+ *   x-ratelimit-requests-limit:   2500      remaining: 2
+ *   x-ratelimit-complexity-limit: 3000000   remaining: 2999987
+ *
+ * Requests are scarce; complexity is 99.999% untouched. So the thing to
+ * optimize is the NUMBER of calls, not their cost — and the way to spend 2500
+ * of them is an agent (or a watch loop) running `projects status` repeatedly.
+ * A human typing it is not the exhauster.
+ *
+ * The CLI is a short-lived process, so an in-memory memo would only help within
+ * one invocation, which is the case that never needed help. This caches to
+ * disk, mirroring `auth-health.ts`'s `getCacheDir()` snapshot.
+ *
+ * The load-bearing behavior is what happens on FAILURE: a stale entry keeps
+ * being served, marked stale, instead of the line vanishing. That rule is
+ * borrowed from `mergeAuthHealthEntries` — one 8s timeout must not flip a
+ * populated chip to empty — and it is the fix for the card silently losing its
+ * Linear line mid-session when the request budget ran out.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getCacheDir } from './state.js';
+
+/** Matches `SKILL_INDEX_TTL_MS` (`lib/registry.ts`) — the repo's TTL convention. */
+export const LINEAR_CACHE_TTL_MS = 10 * 60_000;
+
+const CACHE_FILE = '.linear-projects.json';
+
+/** One cached answer, keyed by Linear project id. */
+interface CacheEntry<T> {
+  /** Epoch ms the value was fetched. */
+  at: number;
+  value: T;
+}
+
+interface CacheFile<T> {
+  entries: Record<string, CacheEntry<T>>;
+  /**
+   * Epoch ms until which the API is known to be rate-limited, from a 429's
+   * `x-ratelimit-requests-reset`. Until then every fetch is skipped outright —
+   * spending a request to be told there are none left helps nobody.
+   */
+  rateLimitedUntil?: number;
+}
+
+/**
+ * Where the snapshot lives. `AGENTS_LINEAR_CACHE_PATH` overrides it, mirroring
+ * `AGENTS_FACTORY_PROJECTS_PATH` (`auto-dispatch.ts`) — `getCacheDir()` resolves
+ * `HOME` once at module load, so a test that swaps `process.env.HOME` afterwards
+ * would otherwise read and WRITE the developer's real cache.
+ */
+function cachePath(): string {
+  return process.env.AGENTS_LINEAR_CACHE_PATH ?? path.join(getCacheDir(), CACHE_FILE);
+}
+
+/** The directory the cache file lives in, whichever path is in effect. */
+function cacheDir(): string {
+  return path.dirname(cachePath());
+}
+
+function read<T>(): CacheFile<T> {
+  try {
+    const raw = JSON.parse(fs.readFileSync(cachePath(), 'utf8')) as CacheFile<T>;
+    if (raw && typeof raw === 'object' && raw.entries && typeof raw.entries === 'object') return raw;
+  } catch {
+    /* absent or corrupt — an empty cache is always a valid answer */
+  }
+  return { entries: {} };
+}
+
+function write<T>(file: CacheFile<T>): void {
+  try {
+    fs.mkdirSync(cacheDir(), { recursive: true });
+    fs.writeFileSync(cachePath(), JSON.stringify(file), 'utf8');
+  } catch {
+    /* best-effort: an unwritable cache degrades to no cache, never to an error */
+  }
+}
+
+/** What a lookup found, and how much to trust it. */
+export interface CacheHit<T> {
+  value: T;
+  /** Age in ms. Past the TTL the value is still returned, flagged stale. */
+  ageMs: number;
+  stale: boolean;
+}
+
+/** Look up a project's cached answer. Returns stale entries too — the caller decides. */
+export function readCached<T>(projectId: string, nowMs: number): CacheHit<T> | undefined {
+  const entry = read<T>().entries[projectId];
+  if (!entry || typeof entry.at !== 'number') return undefined;
+  const ageMs = nowMs - entry.at;
+  return { value: entry.value, ageMs, stale: ageMs > LINEAR_CACHE_TTL_MS };
+}
+
+/** Store a freshly fetched answer. */
+export function writeCached<T>(projectId: string, value: T, nowMs: number): void {
+  const file = read<T>();
+  file.entries[projectId] = { at: nowMs, value };
+  write(file);
+}
+
+/** True when a prior 429 said the budget is exhausted and has not yet reset. */
+export function isRateLimited(nowMs: number): boolean {
+  const until = read().rateLimitedUntil;
+  return typeof until === 'number' && until > nowMs;
+}
+
+/**
+ * Record a 429 so the next runs don't spend a request learning the same thing.
+ * `resetAtMs` comes from the response's `x-ratelimit-requests-reset` header
+ * (epoch ms); without it, back off for one TTL.
+ */
+export function noteRateLimited(resetAtMs: number | undefined, nowMs: number): void {
+  const file = read();
+  file.rateLimitedUntil = resetAtMs && resetAtMs > nowMs ? resetAtMs : nowMs + LINEAR_CACHE_TTL_MS;
+  write(file);
+}
+
+/** Drop one project's entry — used when `projects link` re-points a definition. */
+export function invalidateCached(projectId: string): void {
+  const file = read();
+  if (file.entries[projectId]) {
+    delete file.entries[projectId];
+    write(file);
+  }
+}

--- a/apps/cli/src/lib/linear-cache.ts
+++ b/apps/cli/src/lib/linear-cache.ts
@@ -113,6 +113,19 @@ export function isRateLimited(nowMs: number): boolean {
 }
 
 /**
+ * Read a 429's `x-ratelimit-requests-reset` header into an epoch-ms instant.
+ * Linear sends epoch milliseconds; anything absent, non-numeric, or already in
+ * the past is not usable and the caller backs off a TTL instead. Pure, so the
+ * parsing is testable without a live 429.
+ */
+export function parseRateLimitReset(header: string | null, nowMs: number): number | undefined {
+  if (!header) return undefined;
+  const n = Number(header);
+  if (!Number.isFinite(n) || n <= nowMs) return undefined;
+  return n;
+}
+
+/**
  * Record a 429 so the next runs don't spend a request learning the same thing.
  * `resetAtMs` comes from the response's `x-ratelimit-requests-reset` header
  * (epoch ms); without it, back off for one TTL.

--- a/apps/cli/src/lib/linear-project-counts.test.ts
+++ b/apps/cli/src/lib/linear-project-counts.test.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   countsFromIssuesResponse,
   fetchLinearProjectCounts,
   nextMilestone,
   type LinearIssuesResponse,
 } from './linear-project-counts.js';
+
+// fetchLinearProjectCounts is cache-first, so every test needs its OWN cache or
+// one test's answer is served to the next — and to the developer's real cache
+// dir, since getCacheDir() resolves HOME at module load.
+let cacheHome: string;
+beforeEach(() => {
+  cacheHome = fs.mkdtempSync(path.join(os.tmpdir(), 'lpc-cache-'));
+  process.env.AGENTS_LINEAR_CACHE_PATH = path.join(cacheHome, 'c.json');
+});
+afterEach(() => {
+  delete process.env.AGENTS_LINEAR_CACHE_PATH;
+  fs.rmSync(cacheHome, { recursive: true, force: true });
+});
 
 /** A recorded Linear `issues` response shape (state types only, trimmed). */
 function response(types: (string | null | undefined)[]): LinearIssuesResponse {
@@ -157,5 +173,57 @@ describe('countsFromIssuesResponse — milestone', () => {
       nextMilestone: { name: 'Beta cut', targetDate: '2026-08-21', done: 1, total: 2 },
     });
     expect(countsFromIssuesResponse(response(['completed', 'started']))).not.toHaveProperty('nextMilestone');
+  });
+});
+
+describe('fetchLinearProjectCounts — request budget', () => {
+  const onePage = (): LinearIssuesResponse => ({
+    issues: { nodes: [{ state: { type: 'completed' } }, { state: { type: 'started' } }], pageInfo: { hasNextPage: false, endCursor: null } },
+    project: { projectMilestones: { nodes: [{ id: 'm1', name: 'Beta cut', targetDate: '2026-08-21' }] } },
+  });
+
+  it('spends ZERO requests on a second call inside the TTL', async () => {
+    // Requests are the scarce Linear budget (2500/hr) and this pages up to 10
+    // per project per call. A repeated `projects status` must not re-spend them.
+    let calls = 0;
+    const page = async () => { calls++; return onePage(); };
+    const t0 = new Date(2026, 7, 3, 12, 0, 0).getTime();
+    const first = await fetchLinearProjectCounts('p1', page, t0);
+    expect(calls).toBe(1);
+    const second = await fetchLinearProjectCounts('p1', page, t0 + 60_000);
+    expect(calls).toBe(1);
+    expect(second).toEqual(first);
+    expect(second?.stale).toBeUndefined();
+  });
+
+  it('refetches once the TTL lapses', async () => {
+    let calls = 0;
+    const page = async () => { calls++; return onePage(); };
+    const t0 = new Date(2026, 7, 3, 12, 0, 0).getTime();
+    await fetchLinearProjectCounts('p1', page, t0);
+    await fetchLinearProjectCounts('p1', page, t0 + 11 * 60_000);
+    expect(calls).toBe(2);
+  });
+
+  it('serves the last good answer marked stale rather than dropping the line', async () => {
+    // The defect this replaces: one failed fetch blanked a Linear row that was
+    // populated a minute earlier.
+    const t0 = new Date(2026, 7, 3, 12, 0, 0).getTime();
+    await fetchLinearProjectCounts('p1', async () => onePage(), t0);
+    const afterFailure = await fetchLinearProjectCounts('p1', async () => undefined, t0 + 11 * 60_000);
+    expect(afterFailure?.done).toBe(1);
+    expect(afterFailure?.stale).toBe(true);
+  });
+
+  it('still returns undefined when a fetch fails with nothing cached', async () => {
+    expect(await fetchLinearProjectCounts('never-seen', async () => undefined, Date.now())).toBeUndefined();
+  });
+
+  it('keeps separate answers per project', async () => {
+    const t0 = new Date(2026, 7, 3, 12, 0, 0).getTime();
+    await fetchLinearProjectCounts('p1', async () => onePage(), t0);
+    let calls = 0;
+    await fetchLinearProjectCounts('p2', async () => { calls++; return onePage(); }, t0);
+    expect(calls).toBe(1);
   });
 });

--- a/apps/cli/src/lib/linear-project-counts.ts
+++ b/apps/cli/src/lib/linear-project-counts.ts
@@ -29,7 +29,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { resolveLinearApiKey } from './auto-dispatch-linear.js';
-import { isRateLimited, readCached, writeCached } from './linear-cache.js';
+import { isRateLimited, noteRateLimited, parseRateLimitReset, readCached, writeCached } from './linear-cache.js';
 
 const LINEAR_API = 'https://api.linear.app/graphql';
 /** Overall budget across all pages — the card must never hang on Linear. */
@@ -286,6 +286,14 @@ async function fetchLinearIssuesPage(
     }),
     signal,
   });
+  if (res.status === 429) {
+    // Record when the budget refills so later runs skip the call entirely
+    // rather than spending one of the zero remaining requests to be told so.
+    // The header is epoch milliseconds; absent or unparseable, back off a TTL.
+    const now = Date.now();
+    noteRateLimited(parseRateLimitReset(res.headers.get('x-ratelimit-requests-reset'), now), now);
+    return undefined;
+  }
   if (!res.ok) return undefined;
   const json = (await res.json()) as { data?: LinearIssuesResponse; errors?: unknown[] };
   if (json.errors?.length || !json.data) return undefined;

--- a/apps/cli/src/lib/linear-project-counts.ts
+++ b/apps/cli/src/lib/linear-project-counts.ts
@@ -29,6 +29,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { resolveLinearApiKey } from './auto-dispatch-linear.js';
+import { isRateLimited, readCached, writeCached } from './linear-cache.js';
 
 const LINEAR_API = 'https://api.linear.app/graphql';
 /** Overall budget across all pages — the card must never hang on Linear. */
@@ -78,6 +79,12 @@ export interface LinearProjectCounts {
    * bound (rendered `2500+`), never presented as the complete count.
    */
   truncated?: boolean;
+  /**
+   * True when this answer came from the cache after a failed or skipped fetch.
+   * The card labels it rather than dropping the line — a populated Linear row
+   * that silently vanishes on one timeout is the defect this replaces.
+   */
+  stale?: boolean;
   /**
    * The next unfinished milestone, when the project has one. Derived from the
    * SAME paged issue fetch as the counts — a milestone is only ever a grouping
@@ -197,7 +204,16 @@ function resolveApiKey(): string | null {
 export async function fetchLinearProjectCounts(
   projectId: string,
   fetchPage: (projectId: string, after: string | undefined, signal: AbortSignal) => Promise<LinearIssuesResponse | undefined> = fetchLinearIssuesPage,
+  nowMs: number = Date.now(),
 ): Promise<LinearProjectCounts | undefined> {
+  // Requests are the scarce budget (2500/hr; complexity is untouched), and this
+  // pages up to 10 of them per project per call. Serve a fresh snapshot without
+  // spending any.
+  const cached = readCached<LinearProjectCounts>(projectId, nowMs);
+  if (cached && !cached.stale) return cached.value;
+  // A prior 429 said there is nothing left to spend — don't spend one finding
+  // that out again. Fall through to the stale snapshot rather than no line.
+  if (isRateLimited(nowMs)) return cached ? { ...cached.value, stale: true } : undefined;
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
   try {
@@ -208,7 +224,11 @@ export async function fetchLinearProjectCounts(
     let truncated = false;
     for (let page = 0; ; page++) {
       const data = await fetchPage(projectId, after, ctrl.signal);
-      if (!data) return undefined;
+      // A failed fetch keeps the last good answer on screen, marked stale,
+      // instead of the line vanishing. One 8s timeout must not blank a chip
+      // that was populated a minute ago — the rule `mergeAuthHealthEntries`
+      // already encodes for account health.
+      if (!data) return cached ? { ...cached.value, stale: true } : undefined;
       if (page === 0) declared = data.project?.projectMilestones?.nodes ?? [];
       all.push(...(data.issues?.nodes ?? []));
       const pi = data.issues?.pageInfo;
@@ -220,15 +240,17 @@ export async function fetchLinearProjectCounts(
       }
       after = pi.endCursor;
     }
-    return {
+    const counts: LinearProjectCounts = {
       ...countsFromIssuesResponse({
         issues: { nodes: all },
         project: { projectMilestones: { nodes: declared } },
       }),
       ...(truncated ? { truncated } : {}),
     };
+    writeCached(projectId, counts, nowMs);
+    return counts;
   } catch {
-    return undefined;
+    return cached ? { ...cached.value, stale: true } : undefined;
   } finally {
     clearTimeout(timer);
   }


### PR DESCRIPTION
**What + type:** feature — the Linear line on `agents projects status` is cached, and stops silently vanishing.

Follow-up to #1858. Same subsystem, independent change.

## Why

Linear meters requests and query complexity separately, and **only one of them binds**. Measured on this workspace's response headers:

```
x-ratelimit-requests-limit:   2500      remaining: 2
x-ratelimit-complexity-limit: 3000000   remaining: 2999987
```

Requests are scarce; complexity is 99.999% untouched. The card pages every issue in a project — up to 10 requests each — so an agent running `status` in a loop exhausts the budget. That is not hypothetical: **I exhausted it while building this**, which is also how the second symptom showed up.

## The second symptom is the one worth fixing

When the budget ran out, the Linear row didn't degrade — it **disappeared**. Same shape as a populated chip blanking on one 8s timeout. So the cache's load-bearing behavior is not the hit rate, it is the failure path: **serve the last good answer, marked stale, never drop the line.** That is the invariant `mergeAuthHealthEntries` already keeps for account health.

A 429 additionally records its `x-ratelimit-requests-reset`, so later runs skip the call rather than spending a request to learn the budget is gone.

## Proof it saves requests

The rate-limit header is useless as evidence here — 13 other agent sessions on this box share the same API key, and a header-delta measurement came back incoherent (cold run "spent 0", warm run "spent 6"). So this is measured deterministically off the cache entry's own timestamp instead:

```
cache before:            none
after 1st run (fetched): 1785802349586
after 2nd run:           1785802349586
=> UNCHANGED: the 2nd run made no Linear request
```

| | wall clock |
| --- | --- |
| `projects status agents-cli`, cold cache | 2.39s |
| same, warm cache | **1.91s** / 2.01s |
| all 3 projects, warm | 1.97s |

The latency win is minor — `gh` remains the dominant network call. The request saving is the point.

## Tests

`linear-cache.test.ts` (new, 8 cases): round-trip, fresh-inside-TTL, **stale-but-served past TTL**, per-project isolation, 429 reset honored then lifted, back-off when the header is missing or already past, single-project invalidation, and a corrupt cache file treated as empty then recovered.

`linear-project-counts.test.ts` (+5): zero requests on a second call inside the TTL, refetch after it lapses, stale-served on failure, still `undefined` when a fetch fails with nothing cached, per-project separation.

**A note on `AGENTS_LINEAR_CACHE_PATH`** — it is not test sugar. `getCacheDir()` resolves `HOME` once at module load, so the existing counts tests were reading *and writing* the developer's real `~/.agents/.cache/`. Three of them started failing the instant the cache landed, because a previous run's answer was being served to the next. They now get an isolated cache; I removed the stray file the first run wrote to my real cache dir.

27 tests pass across the two suites.

Still queued, not in this PR: `projects view` + all milestones, the live/dead agent split (`orphaned` is alive per `lib/session/active.ts:110` — 20 live / 19 crashed, not 24 dead), and deleting `planPct`.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
