### PR TITLE
fix(menubar): notify + badge when the scheduler daemon dies

### DIFF
--- a/apps/cli/.changelog/next/menubar-daemon-down-notify.md
+++ b/apps/cli/.changelog/next/menubar-daemon-down-notify.md
@@ -1,0 +1,13 @@
+- **The menu bar now notices and reports when the scheduler dies — instead of
+  staying silent forever.** The only proactive "routines overdue / scheduler
+  down" signal was `notifyOverdue` (`src/lib/overdue.ts`), fired from inside
+  `runDaemon()` — so it could never fire while the daemon itself was down, the
+  exact outage it exists to report. `MenubarHelper` is a separate launchd
+  KeepAlive service that stays alive when the daemon dies, so its 10s tick now
+  polls daemon liveness independently of the dropdown ever being opened; once
+  it has been continuously unreachable for ~30s (debounced past a routine
+  restart blip), it fires one native notification ("Scheduler stopped —
+  routines won't run") through its own `NSUserNotificationCenter` delivery —
+  no daemon, no CLI spawn required — and lights the always-visible menu-bar
+  badge (`⏻`) until the scheduler comes back. Source:
+  `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`.

--- a/apps/cli/docs/03-routines.md
+++ b/apps/cli/docs/03-routines.md
@@ -936,6 +936,13 @@ installed (Linux, or a machine that disabled it), delivery degrades to
 | **Finish** | The run reaches a terminal state | Always for agent/workflow; command routines notify only on **failure** |
 | **Overdue** | Daemon startup finds a missed recurring routine | Any overdue routine (`src/lib/overdue.ts`) |
 
+All three of the above fire from **inside** `runDaemon()`, so none of them can
+ever notice that the daemon itself has died — the exact outage that means no
+routine will fire again until someone restarts it. That gap is closed by a
+separate, daemon-independent watchdog in the menu-bar helper (which runs as its
+own launchd `KeepAlive` service): see
+[menubar.md → Daemon-down watchdog](menubar.md#daemon-down-watchdog).
+
 "Notable output" is folded into the single **Finish** notification, not sent as
 a third message: on success the body is the first line of `report.md` (the
 routine's user-facing result), on failure it is the error reason. So a normal

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -220,8 +220,11 @@ One rule shapes the menu: **attention floats up, context groups down.**
   to one-liners and tucks Routines / Recent behind submenus. Auto is rich while
   something needs you, compact on a calm machine.
 
-The icon badges **red `!`** when anything needs you and **green with a count**
-when sessions are running; otherwise it is the bare mark.
+The icon badges **red `!`** when anything needs you, **red `⏻`** when the
+scheduler has been unreachable for ~30s (see
+[Daemon-down watchdog](#daemon-down-watchdog) below — independent of the
+dropdown ever opening), and **green with a count** when sessions are running;
+otherwise it is the bare mark.
 
 ## Commands
 
@@ -344,6 +347,40 @@ The helper is a launchd user service (`com.phnx-labs.agents-menubar`,
 The helper doubles as the branded desktop-notification channel for the daemon
 (RUSH-2030) and for any `agents run --notify`. The caller fires a notification by
 spawning the installed bundle in a one-shot mode:
+
+### Daemon-down watchdog
+
+The daemon's own overdue check (`notifyOverdue`, `src/lib/overdue.ts`) can only
+ever fire from **inside** `runDaemon()` — so it is structurally blind to the one
+outage that matters most: the daemon itself being down, at which point no
+routine fires and nothing says so. `MenubarHelper` closes that gap because it is
+a **separate** launchd `KeepAlive` service — it stays alive exactly when the
+daemon dies.
+
+`StatusItemController.tick()` (the same 10s timer that refreshes the badge)
+calls `checkDaemonLiveness()` on every fire, independent of whether the dropdown
+is ever opened:
+
+- Liveness is the same cheap, synchronous `AgentsCLI.daemonPid()` probe
+  `menuWillOpen` already uses (a pid-file read + `kill(pid, 0)`; no CLI spawn).
+- A debounce of `daemonDownTickThreshold` (3) consecutive dead ticks — about
+  30 seconds — must elapse before alerting, so a routine restart (a version
+  upgrade, an `agents doctor` self-heal, a crash-relaunch) never pages the user
+  for a blip.
+- Once past the threshold it fires **one** notification per outage —
+  `"Scheduler stopped — routines won't run"` — via `Notifier.post` directly
+  (this persistent process's own `NSUserNotificationCenter` delivery, the same
+  call site `AgentsCLI.swift`'s ticket-flow notices already use), not a spawned
+  `--notify` child process. It also lights the always-visible menu-bar badge
+  (`⏻`, ranked just under NEEDS-YOU attention) so the outage is glanceable
+  without opening the dropdown at all. Both the notification flag and the badge
+  clear the moment the daemon is observed alive again, so the next real outage
+  alerts fresh.
+
+The dropdown's own "Scheduler stopped" row (`addNeedsAttention`, rendered only
+while the menu is open and only when routines exist) is unchanged and
+complementary — the tick-driven watchdog is what makes the outage visible
+*before* you think to open the menu.
 
 ```bash
 MenubarHelper --notify --title T --body B [--subtitle S] [--action A] [--agent claude]

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -25,6 +25,28 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // New tailnet devices awaiting Register/Ignore (cheap sentinel-dir read).
     private var badgePending: [PendingDevice] = []
 
+    // Daemon-down watchdog. The only other proactive "routines won't run"
+    // signal is `notifyOverdue` (src/lib/overdue.ts), fired from INSIDE
+    // `runDaemon()` on startup — so it can never fire while the daemon itself
+    // is down, the exact circularity this closes. This helper is a SEPARATE
+    // launchd KeepAlive service that stays alive when the daemon dies, so it
+    // is the one thing that can notice and say so. Polled every `tick()`
+    // (independent of menu-open) via the cheap, synchronous `daemonPid()`
+    // (a pid-file read + `kill(pid, 0)` — no CLI spawn), and delivered through
+    // this process's own `Notifier`, not a spawned `--notify` child, so the
+    // alert cannot depend on anything the dead daemon would have provided.
+    private var daemonDeadTicks = 0
+    private var daemonDownNotified = false
+    /// True once `daemonDeadTicks` has crossed the threshold; drives the
+    /// always-visible badge (see `refreshBadge`), independent of whether the
+    /// dropdown is ever opened.
+    private var schedulerDown = false
+    /// Consecutive dead ticks (~10s apart) required before alerting. A daemon
+    /// restart — a version upgrade, `agents doctor` self-heal, a crash the
+    /// launchd-equivalent auto-relaunches — is down for a few seconds; this
+    /// debounce absorbs that blip instead of paging the user for a non-event.
+    private static let daemonDownTickThreshold = 3
+
     // These three reads shell the CLI or touch the sessions DB. They are kept
     // off the click path and rendered from warm caches when the menu opens.
     private var cachedRoutines: [Routine] = []
@@ -172,11 +194,48 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 self.refreshBadge()
             }
         }
+        checkDaemonLiveness()
         refreshRoutines()
         refreshRecentSessions()
         refreshActiveSessions()
         refreshDoctorOverview()
         refreshWatchdog()
+    }
+
+    /// Poll the scheduler's liveness on every tick — the one check that must
+    /// NOT depend on the menu ever being opened. `daemonPid()` is a plain
+    /// pid-file read + signal-0 probe (no subprocess), so it is safe to call
+    /// on the main thread here just like `menuWillOpen` already does.
+    ///
+    /// Fires once per outage, only after `daemonDownTickThreshold` consecutive
+    /// dead ticks — covers both a daemon that dies mid-session (an
+    /// alive→dead transition) and one that is already down when the helper
+    /// itself (re)launches (a reboot, a crash before the helper started).
+    /// Resets the moment the daemon comes back, so the next real outage
+    /// alerts again.
+    private func checkDaemonLiveness() {
+        let alive = AgentsCLI.daemonPid() != nil
+        if alive {
+            daemonDeadTicks = 0
+            daemonDownNotified = false
+            if schedulerDown {
+                schedulerDown = false
+                refreshBadge()
+            }
+            return
+        }
+        daemonDeadTicks += 1
+        if daemonDeadTicks >= Self.daemonDownTickThreshold && !schedulerDown {
+            schedulerDown = true
+            refreshBadge()
+        }
+        guard daemonDeadTicks == Self.daemonDownTickThreshold, !daemonDownNotified else { return }
+        daemonDownNotified = true
+        Notifier.post(
+            title: "Scheduler stopped — routines won't run",
+            body: "Restart it from the menu bar, or run: agents routines start",
+            url: URL(fileURLWithPath: "\(NSHomeDirectory())/.agents/.history/runs").absoluteString
+        )
     }
 
     private func loadDumpCaches() {
@@ -308,6 +367,11 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         let pending = badgePending.count
         if attention > 0 {
             button.attributedTitle = badge("⚠", wait)
+        } else if schedulerDown {
+            // A dead scheduler means every routine silently stops firing — that
+            // outranks a device-registration nudge or a running-session count,
+            // so it is glanceable without opening the dropdown at all.
+            button.attributedTitle = badge(" ⏻", fail)
         } else if pending > 0 {
             // New devices to review — a blue count (◆) distinct from run/attention.
             button.attributedTitle = badge(" ◆\(pending)", info)


### PR DESCRIPTION
fix: menu-bar helper notifies + badges when the scheduler daemon dies

## What + why

The only proactive "routines overdue / scheduler down" signal in this codebase
is `notifyOverdue` (`apps/cli/src/lib/overdue.ts`), and it is called **only**
from inside `runDaemon()` (`apps/cli/src/lib/daemon.ts`). That means it can
never fire while the daemon is down — the exact self-defeating loop flagged in
the design: the one thing that would tell you the scheduler died is itself
disabled by the scheduler dying.

`MenubarHelper` is a **separate** launchd `KeepAlive` service that stays alive
when the daemon dies, and it already reads daemon liveness
(`AgentsCLI.daemonPid()`) — but only on menu-open
(`StatusItemController.swift`, `menuWillOpen`), not on its 10s `tick()`. So a
user who never opens the dropdown gets no signal at all.

## What changed

`apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`:

- `tick()` (the existing 10s `Timer`) now also calls a new
  `checkDaemonLiveness()` every fire, independent of the menu ever opening.
- Liveness uses the same cheap, synchronous `AgentsCLI.daemonPid()` probe
  (pid-file read + `kill(pid, 0)`, no subprocess) `menuWillOpen` already calls.
- Debounced: only after **3 consecutive dead ticks (~30s)** does it alert —
  absorbs a routine daemon restart (version upgrade, `agents doctor`
  self-heal) without paging the user for a blip. Fires once per outage; resets
  the moment the daemon is observed alive again.
- Delivery is `Notifier.post(...)` called **directly on this persistent
  process** — the same call site `AgentsCLI.swift`'s ticket-flow notices
  already use (`NSUserNotificationCenter`) — not a spawned `MenubarHelper
  --notify` child. This is intentionally *not* a `scheduler.ts`
  routine/`JobConfig`: that only runs inside the live daemon, which is the
  exact circularity being closed.
- Also lights the always-visible menu-bar badge (`⏻`, red) — ranked just
  under the NEEDS-YOU attention glyph — so the outage is glanceable without
  opening the dropdown at all.

Docs: `docs/menubar.md` gains a "Daemon-down watchdog" section + updates the
badge legend; `docs/03-routines.md`'s Desktop notifications table cross-links
it so the daemon-side Start/Finish/Overdue notices don't read as the whole
story. Changelog fragment added at
`.changelog/next/menubar-daemon-down-notify.md`.

## Verification

**I could not build or run this on this Linux box** — no `swift`/`swiftc`
toolchain is available, and `apps/cli/menubar/scripts/build.sh` requires
macOS (`sips`, `iconutil`, `codesign`). I also checked and **this repo's CI has
no job that compiles the Swift menubar target at all**
(`grep -rn "swift\|MenubarHelper" .github/workflows/` only matches a comment in
`ci.yml` about the *keychain* helper, not `MenubarHelper`) — so this diff will
not even get a green/red compile signal from CI, unlike the framing that CI's
menubar build would catch a mistake.

What I did instead, to compensate for zero compiler feedback:
- Read the current source fully (post-#1841/#1842/#1854 refactors) before
  editing — confirmed the exact current names (`tick()`, `daemonPid()`,
  `refreshBadge()`, `Notifier.post`) rather than assuming pre-refactor names.
- Confirmed `Notifier.post` is already called directly from the persistent
  process elsewhere (`AgentsCLI.swift`, `Hotkey.swift`, `Clip.swift`) — this
  is an existing, proven pattern, not a new code path.
- Manually verified brace/paren balance across the whole file and re-read
  every new line in context.

**This needs a Mac build + manual run before merge** — `swift build` inside
`apps/cli/menubar/`, then either kill the real daemon (`agents routines stop`
/ `kill $(cat ~/.agents/.cache/helpers/daemon/daemon.pid)`) and watch for the
notification + `⏻` badge after ~30s, or run with a stubbed `daemonPid()` for a
faster loop. Handing this off named below since I cannot do it myself.

## Test plan
- [ ] `swift build` succeeds inside `apps/cli/menubar/` on macOS
- [ ] Kill the daemon while the helper is running; confirm the `⏻` badge
      appears after ~30s and exactly one notification fires
- [ ] Restart the daemon; confirm the badge clears and the notified flag resets
      (a second kill fires a second notification)
- [ ] A daemon restart shorter than ~30s (e.g. `agents doctor` self-heal)
      produces no notification
