### PR TITLE
feat(projects): add 'projects view', show every milestone, stop counting dead agents

### DIFF
--- a/apps/cli/.changelog/next/projects-view-and-live-count.md
+++ b/apps/cli/.changelog/next/projects-view-and-live-count.md
@@ -1,0 +1,20 @@
+- **`agents projects view <name>`** replaces `show` (kept as an alias) and now renders the
+  project's full plan: every declared Linear milestone with its date and progress, issue
+  counts, and a warning when no issues are assigned to any milestone — a milestone nothing is
+  filed against cannot report progress, and a row of silent `0%`s hid that. Sixteen other
+  command groups already use `view <name>`; `projects` was the only one that did not. Source:
+  `apps/cli/src/commands/projects.ts`.
+- **The status headline counts live agents, not corpses.** It read `39 agents` on a project
+  where 19 had crashed. It now reads `19 live`, with a separate `dead` row breaking down what
+  finished or was lost — 19 crashed sessions is a thing to go fix, not throughput. `orphaned`
+  counts as **live**: `session/active.ts` defines it as "alive, but no client is attached", and
+  the repo's own dead rule is `closed` + `crashed` only. Source:
+  `apps/cli/src/lib/project-status.ts`.
+- **`planPct` is gone from the card and from `--json`.** It summed each matched session's most
+  recent checklist snapshot, so one agent opening a fresh 40-item plan rendered the whole
+  project `0% plan`, and a project where nobody had written a checklist showed no figure at
+  all. A cross-session sum of ad-hoc checklists does not measure project progress. `live` and
+  `dead` counts replace it in `--json`.
+- **The next milestone comes from Linear's own `status: "next"`** when Linear sets it, falling
+  back to earliest-dated-unfinished only when nothing is flagged — Linear's answer is the one
+  shown in its UI, ours is a guess.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -87,12 +87,14 @@ rollup — SSH fan-out plus home-relative cwd matching so a session recorded on 
 different-home machine still matches — is a deferred follow-up (see below):
 
 ```
-rush  ·  23 agents  ·  68% plan
-  live     14 running · 6 idle · 3 need-input     # active sessions by lifecycle state
+rush  ·  23 live
+  live     14 running · 6 idle · 3 need-input     # LIVE sessions by lifecycle state
+  dead     4 finished or lost (3 crashed, 1 closed)
   agents   claude · running · RUSH-2107 @zion  ·  codex · idle @mac-mini  ·  +21 more
   ships    4 merged (7d) · 2 open PRs · 3 worktrees · v1.20.91  # gh counts + latest release tag
   linear   12/30 done · 5 in progress           # Linear issue counts (needs linear.projectId)
   next     Beta cut  ·  3/8  ·  due in 6 days     # the next unfinished Linear milestone
+           +2 more milestones — agents projects view <name>
   tickets  RUSH-1201 · RUSH-1198 · …              # tickets worked or created
   proof    11 artifacts (7d) · last: plan-x.html  # artifact.created milestones by cwd
   repos    phnx-labs/rush · rush-infra
@@ -178,7 +180,7 @@ rush  ·  3 agents
 | --- | --- |
 | `agents projects list [--json]` | All projects: root, repo, live agent count. |
 | `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--context path:purpose`, `--linear`. |
-| `agents projects show <name> [--json]` | Full definition + resolved paths + contexts + links. |
+| `agents projects view <name> [--json] [--no-remote]` (alias `show`) | Full definition + resolved paths + contexts + links + **every** Linear milestone with dates and progress. |
 | `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
 | `agents projects status [name] [--json] [--window N] [--no-remote] [--fleet]` | The progress card (all projects, or one). `--fleet` adds per-device workspace drift over SSH. |
 | `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. |
@@ -314,3 +316,41 @@ the budget is gone.
 `AGENTS_LINEAR_CACHE_PATH` overrides the location (tests use it; `getCacheDir()` resolves
 `HOME` once at module load, so a test swapping `process.env.HOME` would otherwise read and
 write the developer's real cache).
+
+## The headline counts live agents, and `planPct` is gone
+
+Two numbers used to sit on the headline and neither meant what it looked like.
+
+**The agent count included dead sessions.** A real project read `39 agents` while 19 of those
+had crashed. It now reads `19 live`, and the wreckage gets its own row — `dead  19 finished or
+lost (19 crashed)` — because 19 crashed sessions is a thing to go fix, not throughput to brag
+about. `orphaned` counts as **live**: `lib/session/active.ts` defines it as "alive, but no
+client is attached" (the agent outlived its window and is still working), and the repo's own
+dead rule (`commands/sessions.ts`) is `closed` and `crashed` only.
+
+**`planPct` measured whichever agent last wrote a todo list.** It summed each matched session's
+most recent checklist snapshot, so:
+
+- no session had ever called `TodoWrite` → `total = 0` → the figure silently disappeared;
+- one agent opened a fresh 40-item plan → `0/40` → the whole project read **`0% plan`** while
+  everyone else worked.
+
+It also counted crashed sessions' frozen final checklists forever, and summed unrelated
+denominators as though they were one plan. No repair makes a cross-session sum of ad-hoc
+checklists mean project progress, so it is removed from the card and from `--json`, replaced
+there by `live` and `dead`.
+
+## Milestones: all of them, and Linear's own "next"
+
+`status` shows the next checkpoint plus a pointer; `view <name>` shows every declared
+milestone with its date and progress. When Linear itself flags one (`status: "next"`) that is
+the one used — it is the answer showing in Linear's UI, whereas earliest-dated-unfinished is
+only our guess, used when nothing is flagged.
+
+A milestone with no issues assigned reports no progress, and `view` says so once rather than
+printing a column of silent `0%`s:
+
+```
+    !          no issues are assigned to any milestone — progress against them
+               cannot be measured
+```

--- a/apps/cli/src/commands/projects.test.ts
+++ b/apps/cli/src/commands/projects.test.ts
@@ -3,6 +3,7 @@ import {
   computeProjectListWidths,
   formatFleetSkippedNote,
   formatMilestoneDue,
+  formatMilestoneLines,
   formatNextMilestone,
   type ProjectListRow,
 } from './projects.js';
@@ -109,5 +110,46 @@ describe('formatNextMilestone', () => {
   it('does not print a raw date when the stored value is unparseable', () => {
     expect(stripAnsi(formatNextMilestone({ name: 'Odd', targetDate: 'not-a-date', done: 1, total: 2 }, now)))
       .toBe('Odd  ·  1/2');
+  });
+});
+
+describe('formatMilestoneLines', () => {
+  const now = new Date(2026, 7, 3, 12, 0, 0).getTime();
+  const ms = [
+    { name: 'Factory converts strategy', targetDate: '2026-09-15', done: 0, total: 0 },
+    { name: 'Factory reliability', targetDate: '2026-09-30', done: 0, total: 0 },
+    { name: 'Factory onboarding', targetDate: '2026-10-15', done: 0, total: 0 },
+  ];
+
+  it('shows one line plus a pointer on the compact card', () => {
+    const out = formatMilestoneLines(ms, ms[0], now, 1).map(stripAnsi);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toContain('next');
+    expect(out[0]).toContain('Factory converts strategy');
+    expect(out[1]).toContain('+2 more milestones');
+    expect(out[1]).toContain('agents projects view');
+  });
+
+  it('shows every milestone when the limit allows, with no pointer', () => {
+    const out = formatMilestoneLines(ms, ms[0], now, 99).map(stripAnsi);
+    expect(out).toHaveLength(3);
+    expect(out.join('\n')).toContain('Factory onboarding');
+    expect(out.join('\n')).not.toContain('more milestone');
+  });
+
+  it('labels the first row `plan` when it is not the flagged next one', () => {
+    const out = formatMilestoneLines(ms, ms[1], now, 1).map(stripAnsi);
+    expect(out[0].trimStart().startsWith('plan')).toBe(true);
+  });
+
+  it('renders nothing when the project declares no milestones', () => {
+    expect(formatMilestoneLines([], undefined, now, 1)).toEqual([]);
+  });
+
+  it('still renders a next carried alone by an older cached answer', () => {
+    // A cache entry written before `milestones` existed has only `nextMilestone`.
+    const out = formatMilestoneLines([], ms[0], now, 1).map(stripAnsi);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain('Factory converts strategy');
   });
 });

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -45,7 +45,7 @@ import {
 } from '../lib/projects.js';
 import {
   rollupSessionsByProject,
-  planPct,
+  liveDeadSplit,
   enrichProjectSignals,
   formatProjectMembers,
   type ProjectSessionRollup,
@@ -223,6 +223,38 @@ export function formatMilestoneDue(targetDate: string, nowMs: number): string | 
   return `due ${label}`;
 }
 
+/**
+ * The milestone block. `status` prints one line — the next checkpoint — because
+ * a roll-up across projects has to stay scannable. `view` prints every declared
+ * milestone, because "how many are there and when are they due" is the shape of
+ * the plan and the reason to open one project.
+ *
+ * Pure (chalk only) so the layout is testable without a Linear account.
+ */
+export function formatMilestoneLines(
+  milestones: LinearMilestone[],
+  next: LinearMilestone | undefined,
+  nowMs: number,
+  limit: number,
+): string[] {
+  if (milestones.length === 0) {
+    // `next` without a list only happens on a cached answer written before the
+    // list existed; render what we have rather than dropping the row.
+    return next ? [`  ${chalk.dim('next')}     ${formatNextMilestone(next, nowMs)}`] : [];
+  }
+  const shown = milestones.slice(0, Math.max(1, limit));
+  const out = shown.map((m, i) => {
+    const isNext = next && m.name === next.name;
+    const label = i === 0 ? (isNext ? 'next' : 'plan') : '';
+    return `  ${chalk.dim(label.padEnd(4))}     ${formatNextMilestone(m, nowMs)}`;
+  });
+  const rest = milestones.length - shown.length;
+  if (rest > 0) {
+    out.push(`  ${' '.repeat(4)}     ${chalk.dim(`+${rest} more milestone${rest === 1 ? '' : 's'} — agents projects view <name>`)}`);
+  }
+  return out;
+}
+
 /** The `next` card line: what this project is due to hit, and how far along it is. */
 export function formatNextMilestone(ms: LinearMilestone, nowMs: number): string {
   const parts = [chalk.bold(ms.name)];
@@ -245,9 +277,12 @@ function statusBar(r: ProjectSessionRollup): string {
   push(r.byStatus.queued, 'queued', chalk.gray);
   const shown =
     (r.byStatus.running ?? 0) + (r.byStatus.idle ?? 0) + (r.byStatus.input_required ?? 0) + (r.byStatus.queued ?? 0);
-  // Sessions in a non-live state (orphaned/crashed/unknown) count toward the
-  // headline — render the remainder so the bar never sums to less than it.
-  if (r.agents > shown) parts.push(chalk.gray(`+${r.agents - shown} other`));
+  // The remainder is the LIVE sessions in a state without its own chip
+  // (orphaned, unknown). Dead ones are on their own row now, so counting them
+  // here made the line disagree with the headline — `19 live` beside
+  // `+24 other`, which invites the reader to trust neither.
+  const live = liveDeadSplit(r.byStatus).live;
+  if (live > shown) parts.push(chalk.gray(`+${live - shown} other`));
   return parts.join(' · ') || chalk.gray('no live agents');
 }
 
@@ -258,13 +293,23 @@ function renderCard(
   fleet?: HostWorkspaceStatus[],
   linear?: LinearProjectCounts,
   nowMs: number = Date.now(),
+  /** How many milestones to print. `status` shows the next one; `view` shows all. */
+  milestoneLimit: number = 1,
 ): void {
-  const agents = r?.agents ?? 0;
-  const pct = r ? planPct(r.plan) : undefined;
-  const planStr = pct === undefined ? '' : `  ·  ${chalk.cyan(`${pct}% plan`)}`;
-  console.log(`${chalk.bold(def.name)}  ${chalk.dim('·')}  ${chalk.bold(`${agents} agents`)}${planStr}`);
+  // The headline counts LIVE agents. It used to be every matched session, which
+  // read `39 agents` on a project where 19 had crashed. `planPct` used to sit
+  // here too and is gone: it summed each session's latest checklist snapshot,
+  // so one agent opening a fresh 40-item plan rendered the whole project `0%`.
+  const split = r ? liveDeadSplit(r.byStatus) : { live: 0, dead: 0, deadByStatus: [] };
+  console.log(`${chalk.bold(def.name)}  ${chalk.dim('·')}  ${chalk.bold(`${split.live} live`)}`);
   if (def.description) console.log(`  ${chalk.dim(def.description)}`);
   console.log(`  ${chalk.dim('live')}     ${r ? statusBar(r) : chalk.gray('no live agents')}`);
+  if (split.dead > 0) {
+    // Wreckage is worth a number of its own — 19 crashed sessions is a thing to
+    // go fix, not a throughput signal to fold into the headline.
+    const detail = split.deadByStatus.map((d) => `${d.n} ${d.status}`).join(', ');
+    console.log(`  ${chalk.dim('dead')}     ${chalk.yellow(`${split.dead} finished or lost`)} ${chalk.dim(`(${detail})`)}`);
+  }
   if (r && r.members.length) console.log(`  ${chalk.dim('agents')}   ${formatProjectMembers(r.members)}`);
   const ships: string[] = [];
   if (remote?.mergedPrs) {
@@ -277,8 +322,8 @@ function renderCard(
   if (linear) {
     console.log(`  ${chalk.dim('linear')}   ${linear.done}/${linear.total}${linear.truncated ? '+' : ''} done · ${linear.inProgress} in progress`);
   }
-  if (linear?.nextMilestone) {
-    console.log(`  ${chalk.dim('next')}     ${formatNextMilestone(linear.nextMilestone, nowMs)}`);
+  for (const line of formatMilestoneLines(linear?.milestones ?? [], linear?.nextMilestone, nowMs, milestoneLimit)) {
+    console.log(line);
   }
   if (r && r.tickets.length) {
     console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
@@ -442,17 +487,25 @@ export function registerProjectsCommands(program: Command): void {
 
   // ---- show ----
   projects
-    .command('show <name>')
-    .description('Show a project definition, resolved paths, repos, contexts, and links.')
+    .command('view <name>')
+    .alias('show')
+    .description('Show a project definition, resolved paths, repos, contexts, links, and milestones.')
     .option('--json', 'Machine-readable output')
-    .action((name: string, opts: { json?: boolean }) => {
+    .option('--no-remote', 'Skip the Linear lookup; definition only')
+    .action(async (name: string, opts: { json?: boolean; remote?: boolean }) => {
       const def = loadProjectDef(name);
       if (!def) {
         console.error(chalk.red(`No project named "${name}". List them: agents projects list`));
         process.exit(1);
       }
+      // Every milestone the project declares, not just the next one — the whole
+      // point of opening ONE project is to see the shape of its plan.
+      const counts =
+        opts.remote !== false && def.linear?.projectId
+          ? await fetchLinearProjectCounts(def.linear.projectId)
+          : undefined;
       if (opts.json) {
-        console.log(JSON.stringify(def, null, 2));
+        console.log(JSON.stringify({ ...def, linear: { ...def.linear, ...(counts ?? {}) } }, null, 2));
         return;
       }
       console.log(chalk.bold(def.name) + (def.description ? chalk.dim(`  — ${def.description}`) : ''));
@@ -464,6 +517,24 @@ export function registerProjectsCommands(program: Command): void {
       for (const i of def.integrations ?? []) console.log(`  ${i.kind.padEnd(12)} ${i.url}${i.label ? chalk.dim(`  (${i.label})`) : ''}`);
       if (def.linear?.url || def.linear?.projectId) console.log(`  linear       ${def.linear.url ?? def.linear.projectId}`);
       for (const d of def.docs ?? []) console.log(`  doc          ${d}`);
+      if (counts) {
+        const staleNote = counts.stale ? chalk.dim('  (cached)') : '';
+        console.log(`  issues       ${counts.done}/${counts.total}${counts.truncated ? '+' : ''} done · ${counts.inProgress} in progress${staleNote}`);
+      }
+      const ms = counts?.milestones ?? [];
+      if (ms.length) {
+        console.log(`  ${chalk.bold('milestones')}`);
+        for (const m of ms) {
+          const mark = m.name === counts?.nextMilestone?.name ? chalk.cyan('next') : '';
+          console.log(`    ${mark.padEnd(6)}     ${formatNextMilestone(m, Date.now())}`);
+        }
+        // A milestone nothing is filed against cannot report progress. Say that
+        // once, plainly, rather than printing a row of silent 0%s.
+        const unfiled = ms.filter((m) => m.total === 0).length;
+        if (unfiled === ms.length) {
+          console.log(`    ${chalk.yellow('!')}          ${chalk.yellow(`no issues are assigned to any milestone — progress against them cannot be measured`)}`);
+        }
+      }
       console.log(chalk.gray(`  ${projectDefPath(name)}`));
     });
 
@@ -574,7 +645,8 @@ export function registerProjectsCommands(program: Command): void {
                 byStatus: r?.byStatus ?? {},
                 members: r?.members ?? [],
                 plan: r?.plan ?? { done: 0, total: 0 },
-                planPct: r ? planPct(r.plan) ?? null : null,
+                live: r ? liveDeadSplit(r.byStatus).live : 0,
+                dead: r ? liveDeadSplit(r.byStatus).dead : 0,
                 openPrs: r?.openPrs ?? [],
                 mergedPrs: rem?.mergedPrs ?? 0,
                 latestRelease: rem?.latestRelease ?? null,

--- a/apps/cli/src/lib/linear-project-counts.test.ts
+++ b/apps/cli/src/lib/linear-project-counts.test.ts
@@ -6,6 +6,7 @@ import {
   countsFromIssuesResponse,
   fetchLinearProjectCounts,
   nextMilestone,
+  orderedMilestones,
   type LinearIssuesResponse,
 } from './linear-project-counts.js';
 
@@ -170,6 +171,7 @@ describe('countsFromIssuesResponse — milestone', () => {
       done: 1,
       total: 2,
       inProgress: 1,
+      milestones: [{ name: 'Beta cut', targetDate: '2026-08-21', done: 1, total: 2 }],
       nextMilestone: { name: 'Beta cut', targetDate: '2026-08-21', done: 1, total: 2 },
     });
     expect(countsFromIssuesResponse(response(['completed', 'started']))).not.toHaveProperty('nextMilestone');
@@ -225,5 +227,52 @@ describe('fetchLinearProjectCounts — request budget', () => {
     let calls = 0;
     await fetchLinearProjectCounts('p2', async () => { calls++; return onePage(); }, t0);
     expect(calls).toBe(1);
+  });
+});
+
+describe('orderedMilestones', () => {
+  const A = { id: 'a', name: 'Beta cut', targetDate: '2026-09-30' };
+  const B = { id: 'b', name: 'GA', targetDate: '2026-09-15' };
+  const C = { id: 'c', name: 'Done thing', targetDate: '2026-08-01' };
+
+  it('returns every declared milestone, unfinished first by date', () => {
+    // C is complete, so it sorts last despite the earliest date — a reader is
+    // scanning for what is still ahead.
+    const out = orderedMilestones([A, B, C], [issue('completed', 'c')]);
+    expect(out.map((m) => m.name)).toEqual(['GA', 'Beta cut', 'Done thing']);
+  });
+
+  it('shows all three of a project whose milestones carry no issues at all', () => {
+    // The real shape of this repo's Linear project.
+    const out = orderedMilestones([A, B], []);
+    expect(out).toEqual([
+      { name: 'GA', targetDate: '2026-09-15', done: 0, total: 0 },
+      { name: 'Beta cut', targetDate: '2026-09-30', done: 0, total: 0 },
+    ]);
+  });
+
+  it("marks Linear's own next flag", () => {
+    const out = orderedMilestones([{ ...A, status: 'next' }, B], []);
+    expect(out.find((m) => m.name === 'Beta cut')?.isNext).toBe(true);
+    expect(out.find((m) => m.name === 'GA')?.isNext).toBeUndefined();
+  });
+});
+
+describe('nextMilestone — Linear wins over our date guess', () => {
+  const early = { id: 'e', name: 'Earlier', targetDate: '2026-09-01' };
+  const flagged = { id: 'f', name: 'Flagged', targetDate: '2026-12-01', status: 'next' };
+
+  it("prefers Linear's own next marker over the earliest date", () => {
+    // Linear's answer is what the user sees in Linear's UI; ours is a guess.
+    expect(nextMilestone([early, flagged], [])?.name).toBe('Flagged');
+  });
+
+  it('falls back to earliest-dated unfinished when nothing is flagged', () => {
+    expect(nextMilestone([early, { ...flagged, status: 'unstarted' }], [])?.name).toBe('Earlier');
+  });
+
+  it('never returns a finished milestone even if Linear flags it', () => {
+    const doneFlagged = { id: 'f', name: 'Flagged', targetDate: '2026-09-01', status: 'next' };
+    expect(nextMilestone([doneFlagged, early], [issue('completed', 'f')])?.name).toBe('Earlier');
   });
 });

--- a/apps/cli/src/lib/linear-project-counts.ts
+++ b/apps/cli/src/lib/linear-project-counts.ts
@@ -57,6 +57,8 @@ export interface LinearMilestone {
    * than printing a meaningless `0/0`.
    */
   total: number;
+  /** True when Linear itself flags this as the project's next milestone. */
+  isNext?: boolean;
 }
 
 /** A milestone as the project declares it, independent of any issue. */
@@ -64,6 +66,13 @@ export interface LinearMilestoneNode {
   id?: string;
   name?: string;
   targetDate?: string | null;
+  /**
+   * Linear's own marker. Observed values: `"next"` (it flags exactly one) and
+   * `"unstarted"`. Treated as an opaque string and only compared to `"next"` —
+   * the enum is not documented as closed, so switching exhaustively on it would
+   * break the day Linear adds a value.
+   */
+  status?: string | null;
 }
 
 /** The counts the card renders. `total` counts every issue in the project. */
@@ -86,10 +95,16 @@ export interface LinearProjectCounts {
    */
   stale?: boolean;
   /**
-   * The next unfinished milestone, when the project has one. Derived from the
-   * SAME paged issue fetch as the counts — a milestone is only ever a grouping
-   * of these issues, so asking Linear again would spend a second round trip to
-   * learn what the first already said.
+   * Every milestone the project declares, in the order the card shows them:
+   * unfinished first by target date, then the finished ones. A project with
+   * three checkpoints has three; showing only the next one hides the shape of
+   * the plan, which is what `projects view` exists to show.
+   */
+  milestones?: LinearMilestone[];
+  /**
+   * The one the project is working toward — `milestones[0]` when there is an
+   * unfinished one. Kept as its own field because the compact card shows only
+   * this, while `view` shows the whole list.
    */
   nextMilestone?: LinearMilestone;
 }
@@ -125,7 +140,10 @@ export function countsFromIssuesResponse(data: LinearIssuesResponse): LinearProj
     else if (type === 'started') inProgress++;
   }
   const counts: LinearProjectCounts = { done, total: nodes.length, inProgress };
-  const next = nextMilestone(data.project?.projectMilestones?.nodes ?? [], nodes);
+  const declared = data.project?.projectMilestones?.nodes ?? [];
+  const ordered = orderedMilestones(declared, nodes);
+  if (ordered.length) counts.milestones = ordered;
+  const next = nextMilestone(declared, nodes);
   if (next) counts.nextMilestone = next;
   return counts;
 }
@@ -144,10 +162,10 @@ export function countsFromIssuesResponse(data: LinearIssuesResponse): LinearProj
  * issues counts as unfinished (it is upcoming work, not completed work). Undated
  * milestones sort last, ties break by declaration order, so the answer is stable.
  */
-export function nextMilestone(
+export function orderedMilestones(
   declared: LinearMilestoneNode[],
   nodes: LinearIssueNode[],
-): LinearMilestone | undefined {
+): LinearMilestone[] {
   // Progress per milestone id, from whatever issues do carry one.
   const progress = new Map<string, { done: number; total: number }>();
   for (const n of nodes) {
@@ -158,26 +176,45 @@ export function nextMilestone(
     if (n.state?.type === 'completed') p.done++;
     progress.set(id, p);
   }
-  const candidates = declared
+  const all = declared
     .map((d, order) => {
       if (!d?.id || typeof d.name !== 'string' || !d.name) return undefined;
       const p = progress.get(d.id) ?? { done: 0, total: 0 };
       const m: LinearMilestone & { order: number } = { name: d.name, done: p.done, total: p.total, order };
       if (d.targetDate) m.targetDate = d.targetDate;
+      if (d.status === 'next') m.isNext = true;
       return m;
     })
-    .filter((m): m is LinearMilestone & { order: number } => m !== undefined)
-    // total 0 means "declared, nothing filed yet" — unfinished, not done.
-    .filter((m) => m.total === 0 || m.done < m.total);
-  if (candidates.length === 0) return undefined;
-  candidates.sort((a, b) => {
+    .filter((m): m is LinearMilestone & { order: number } => m !== undefined);
+  // total 0 means "declared, nothing filed yet" — unfinished, not done.
+  const open = (m: LinearMilestone) => m.total === 0 || m.done < m.total;
+  all.sort((a, b) => {
+    // Unfinished before finished: what is still ahead is what a reader is
+    // scanning for.
+    if (open(a) !== open(b)) return open(a) ? -1 : 1;
     if (a.targetDate && b.targetDate) return a.targetDate < b.targetDate ? -1 : a.targetDate > b.targetDate ? 1 : a.order - b.order;
     if (a.targetDate) return -1;
     if (b.targetDate) return 1;
     return a.order - b.order;
   });
-  const { order: _order, ...m } = candidates[0];
-  return m;
+  return all.map(({ order: _order, ...m }) => m);
+}
+
+/**
+ * The milestone the project is working toward next.
+ *
+ * Linear flags one itself (`status: "next"`), and that is the answer the user
+ * sees in Linear's own UI, so it wins when present. Only when nothing is
+ * flagged does this fall back to "earliest-dated unfinished", which is a
+ * reasonable guess but still a guess.
+ */
+export function nextMilestone(
+  declared: LinearMilestoneNode[],
+  nodes: LinearIssueNode[],
+): LinearMilestone | undefined {
+  const ordered = orderedMilestones(declared, nodes);
+  const open = ordered.filter((m) => m.total === 0 || m.done < m.total);
+  return open.find((m) => m.isNext) ?? open[0];
 }
 
 /** $LINEAR_API_KEY → macOS Keychain → ~/.linear-cli/config.json. Null if none. */
@@ -271,7 +308,7 @@ async function fetchLinearIssuesPage(
     'issues(filter:{ project:{ id:{ eq:$p } } }, first:' +
     PAGE_SIZE +
     ', after:$after){ nodes{ state{ type } projectMilestone{ id } } pageInfo{ hasNextPage endCursor } }';
-  const milestonesSelection = 'project(id:$pid){ projectMilestones(first:50){ nodes{ id name targetDate } } }';
+  const milestonesSelection = 'project(id:$pid){ projectMilestones(first:50){ nodes{ id name targetDate status } } }';
   const first = after === undefined;
   const res = await fetch(LINEAR_API, {
     method: 'POST',

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -106,6 +106,18 @@ describe('liveDeadSplit', () => {
     ]);
   });
 
+  it('classifies every ActiveStatus, not just the common ones', () => {
+    // abandoned fires on transcript staleness before the liveness check, so it
+    // covers the live-but-forgotten session; unknown cannot be PROVEN dead, and
+    // claiming so would overstate the wreckage row.
+    const s = liveDeadSplit({
+      running: 1, idle: 1, queued: 1, input_required: 1, orphaned: 1, abandoned: 1, unknown: 1,
+      closed: 1, crashed: 1,
+    });
+    expect(s.live).toBe(7);
+    expect(s.dead).toBe(2);
+  });
+
   it('handles an empty or all-live project', () => {
     expect(liveDeadSplit({})).toEqual({ live: 0, dead: 0, deadByStatus: [] });
     expect(liveDeadSplit({ running: 4 })).toEqual({ live: 4, dead: 0, deadByStatus: [] });

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   rollupSessionsByProject,
-  planPct,
+  liveDeadSplit,
   enrichProjectSignals,
   sortProjectMembers,
   formatProjectMembers,
@@ -79,8 +79,8 @@ describe('rollupSessionsByProject', () => {
       { agent: 'codex', status: 'idle', host: 'mac-mini' },
       { agent: 'gemini', status: 'queued' },
     ]);
-    // planPct is untouched by the members extension
-    expect(planPct(rush.plan)).toBeUndefined();
+    // the raw plan sums are untouched by the members extension
+    expect(rush.plan).toEqual({ done: 0, total: 0 });
   });
 
   it('is empty when no session matches a project', () => {
@@ -89,10 +89,30 @@ describe('rollupSessionsByProject', () => {
   });
 });
 
-describe('planPct', () => {
-  it('rounds a percentage and returns undefined for nothing tracked', () => {
-    expect(planPct({ done: 5, total: 7 })).toBe(71);
-    expect(planPct({ done: 0, total: 0 })).toBeUndefined();
+describe('liveDeadSplit', () => {
+  it('counts orphaned as LIVE — it is an agent that outlived its window', () => {
+    // session/active.ts: "Alive, but no client is attached". The repo's dead
+    // rule (commands/sessions.ts) is closed + crashed only.
+    const s = liveDeadSplit({ running: 13, idle: 2, orphaned: 5, crashed: 19 });
+    expect(s.live).toBe(20);
+    expect(s.dead).toBe(19);
+  });
+
+  it('breaks the dead down, biggest first', () => {
+    const s = liveDeadSplit({ running: 1, crashed: 19, closed: 3 });
+    expect(s.deadByStatus).toEqual([
+      { status: 'crashed', n: 19 },
+      { status: 'closed', n: 3 },
+    ]);
+  });
+
+  it('handles an empty or all-live project', () => {
+    expect(liveDeadSplit({})).toEqual({ live: 0, dead: 0, deadByStatus: [] });
+    expect(liveDeadSplit({ running: 4 })).toEqual({ live: 4, dead: 0, deadByStatus: [] });
+  });
+
+  it('ignores zero counts rather than emitting empty buckets', () => {
+    expect(liveDeadSplit({ running: 2, crashed: 0 }).deadByStatus).toEqual([]);
   });
 });
 

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -132,6 +132,25 @@ export function rollupSessionsByProject(
  */
 const DEAD_STATUSES = new Set(['closed', 'crashed']);
 
+/*
+ * Every `ActiveStatus`, and why it lands where it does:
+ *
+ *   running, idle, queued, input_required   live — obviously working or waiting
+ *   orphaned                                live — "alive, but no client is
+ *                                           attached"; the agent outlived its
+ *                                           window and is still running
+ *   abandoned                               live — it fires on transcript
+ *                                           staleness BEFORE the liveness check,
+ *                                           so it also covers the live-but-
+ *                                           forgotten session that asked a
+ *                                           question and sat over a weekend
+ *   unknown                                 live — we cannot prove it is dead,
+ *                                           and claiming so would overstate the
+ *                                           wreckage row
+ *   closed, crashed                         dead — unconditionally, per
+ *                                           commands/sessions.ts
+ */
+
 /** Live vs finished sessions on a project. */
 export interface LiveDeadSplit {
   live: number;

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -122,10 +122,47 @@ export function rollupSessionsByProject(
   return map;
 }
 
-/** Plan completion percentage (0–100), or undefined when nothing is tracked. */
-export function planPct(plan: { done: number; total: number }): number | undefined {
-  if (plan.total <= 0) return undefined;
-  return Math.round((plan.done / plan.total) * 100);
+/**
+ * Statuses that mean the session is over. Taken from the repo's own rule
+ * (`commands/sessions.ts`): "`closed` and `crashed` are unconditionally dead".
+ * `orphaned` is NOT among them — `session/active.ts` defines it as "Alive, but
+ * no client is attached", i.e. the agent outlived its window and is still
+ * working. Counting it as dead understates the project by exactly the sessions
+ * that are running unattended.
+ */
+const DEAD_STATUSES = new Set(['closed', 'crashed']);
+
+/** Live vs finished sessions on a project. */
+export interface LiveDeadSplit {
+  live: number;
+  dead: number;
+  /** Dead broken out by status, for the card's parenthetical. */
+  deadByStatus: Array<{ status: string; n: number }>;
+}
+
+/**
+ * Split a rollup's sessions into what is working and what is wreckage.
+ *
+ * The headline used to be the raw session count, which on a real project read
+ * `39 agents` when 19 of those had crashed. A count that is half corpses is not
+ * a throughput signal — but the corpses are worth their own number, because 19
+ * crashed sessions is itself a thing to go fix.
+ */
+export function liveDeadSplit(byStatus: Partial<Record<ActiveStatus, number>>): LiveDeadSplit {
+  let live = 0;
+  let dead = 0;
+  const deadByStatus: Array<{ status: string; n: number }> = [];
+  for (const [status, n] of Object.entries(byStatus)) {
+    if (!n) continue;
+    if (DEAD_STATUSES.has(status)) {
+      dead += n;
+      deadByStatus.push({ status, n });
+    } else {
+      live += n;
+    }
+  }
+  deadByStatus.sort((a, b) => b.n - a.n || a.status.localeCompare(b.status));
+  return { live, dead, deadByStatus };
 }
 
 /**


### PR DESCRIPTION
**What + type:** feature — `agents projects view` exists, shows every milestone, and the status headline stops counting crashed sessions as agents.

Third and last of the `projects` card series (after #1858, #1859). Closes the reported gaps: *"I can't really view it"*, *"I don't see any milestones for the different projects"*, and *"the status seems kind of weird"*.

## The run

<img width="5607" height="2012" alt="status headline shows 19 live with a separate dead row; view lists all three milestones and says why none show progress" src="https://github.com/user-attachments/assets/e1fb07e0-379a-4a07-ba95-cb40e63ab78c" />

## Three fixes

**`projects view <name>`** replaces `show` (kept as an alias). Sixteen other command groups already register `view <name>` — routines, monitors, workflows, secrets, skills, hooks, mcp, repo, rules, memory, subagents, permissions, harness, profiles, cli, commands. `projects` was the only one that didn't, which is why `agents projects view agents-cli` came back **unknown command**. It now renders what opening one project is for: issue counts, plus **every** declared milestone with its date, plus one honest line when nothing is filed against any of them.

**The headline counted corpses.** It read `39 agents` on a project where 19 had crashed. Now `19 live`, with the wreckage on its own row — `dead  19 finished or lost (19 crashed)` — because that is a thing to go fix, not throughput.

`orphaned` counts as **live**, which is the correction that matters: `lib/session/active.ts` defines it as *"Alive, but no client is attached"* — the agent outlived its window and is still working. The repo's own dead rule (`commands/sessions.ts`) is `closed` + `crashed` only. Counting orphans as dead would have understated the project by exactly the sessions running unattended.

**`planPct` is deleted**, from the card and from `--json`. It summed each matched session's most recent checklist snapshot, and failed four independent ways:

| | |
| --- | --- |
| no session ever called `TodoWrite` | the figure **silently vanished** |
| one agent opens a fresh 40-item plan | whole project reads **`0% plan`** |
| a session crashed three days ago | contributes its frozen final checklist forever |
| a 40-item plan and a 3-item plan | summed as though they were one plan |

Both of the first two were observed on this repo. No repair makes a cross-session sum of ad-hoc checklists mean project progress. `live` and `dead` replace it in `--json`.

## Milestones come from Linear's own marker

`nextMilestone` now prefers Linear's `status: "next"` over our earliest-dated-unfinished heuristic — Linear flags exactly one, and that is the answer showing in the UI the user is comparing against; ours is a guess, kept as the fallback when nothing is flagged. `status` is compared only to `"next"` and otherwise treated as opaque: the enum isn't documented as closed, so switching exhaustively on it would break the day Linear adds a value. A flagged-but-finished milestone is still never returned.

## Consistency catch

`statusBar`'s `+N other` was still folding the dead into its remainder, so the card read `19 live` beside `+24 other` — two numbers on adjacent lines that disagree, which invites trusting neither. It now counts only live remainder states: `19 live` = `10 running · 3 idle · 1 need-input · +5 other`.

## Tests

71 across the four touched suites. New: `liveDeadSplit` (orphaned-is-live, dead breakdown ordering, empty/all-live, zero-count buckets), `orderedMilestones` (all declared returned, unfinished-first, the zero-issue case that is this repo's real shape, Linear's next flag), `nextMilestone` (Linear's marker beats our date guess, fallback when unflagged, never returns a finished one), `formatMilestoneLines` (compact one-plus-pointer, full list, `plan` vs `next` label, empty, and an older cached answer carrying only `nextMilestone`).

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
