### PR TITLE
fix(view): align multi-agent columns and cap usage fetch pile-up

### DIFF
--- a/apps/cli/.changelog/next/view-ui-perf.md
+++ b/apps/cli/.changelog/next/view-ui-perf.md
@@ -1,0 +1,13 @@
+- **`agents view` columns stay aligned across agents, and usage no longer piles up (view-ui-perf).**
+  The multi-agent overview padded every row to the widest usage string — an
+  Antigravity account with four model quotas forced ~194-column lines that
+  wrapped so `rate-limited` and last-active drifted under the version column.
+  Overview now caps compact meters to two windows (`+N` for the rest), always
+  emits fixed account/usage/status/lastActive columns (empty cells space-padded),
+  and measures padding with `stringWidth` so chalk + block bars don't skew
+  gutters. Usage fetches go through one unified core: 5-minute fresh cache
+  (was 2), concurrency-capped live reads (`USAGE_FETCH_CONCURRENCY=3`),
+  single-flight per identity, and a background SWR queue capped at 2 so delayed
+  HTTP responses cannot stack. Spinner stays up through account+usage load.
+  Source: `apps/cli/src/commands/view.ts`, `apps/cli/src/lib/usage.ts`,
+  `apps/cli/src/lib/agents.ts`.

--- a/apps/cli/bench/view-usage-perf.ts
+++ b/apps/cli/bench/view-usage-perf.ts
@@ -1,0 +1,112 @@
+/**
+ * Before/after microbench for the `agents view` usage core.
+ *
+ * Measures:
+ *   1. Warm-cache path latency (should be near-zero network; cache hit).
+ *   2. Peak concurrent live fetches under a simulated cold multi-account load
+ *      (must never exceed USAGE_FETCH_CONCURRENCY).
+ *   3. Overview meter width with and without maxWindows=2 (alignment regressor).
+ *
+ * Run from apps/cli:
+ *   bun bench/view-usage-perf.ts
+ *   # or: npx tsx bench/view-usage-perf.ts
+ *
+ * This is a local diagnostic harness, not a CI gate. Quote the printed numbers
+ * in the PR so reviewers can see the before/after without re-running.
+ */
+import {
+  USAGE_CACHE_FRESH_MS,
+  USAGE_FETCH_CONCURRENCY,
+  formatUsageSummary,
+  pickCompactUsageWindows,
+  type UsageSnapshot,
+  type UsageWindow,
+} from '../src/lib/usage.js';
+import { stringWidth } from '../src/lib/session/width.js';
+import { mapBounded } from '../src/lib/concurrency.js';
+
+function hrMs(start: bigint): number {
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+function fakeWindows(n: number): UsageWindow[] {
+  return Array.from({ length: n }, (_, i) => ({
+    key: 'session' as const,
+    label: `m${i}`,
+    shortLabel: `M${i}`,
+    usedPercent: (i * 17) % 100,
+    resetsAt: null,
+    windowMinutes: null,
+  }));
+}
+
+function fakeSnapshot(n: number): UsageSnapshot {
+  return {
+    source: 'live',
+    sourceLabel: 'bench',
+    capturedAt: new Date(),
+    windows: fakeWindows(n),
+  };
+}
+
+async function benchConcurrencyCap(): Promise<{ peak: number; totalMs: number }> {
+  let inFlight = 0;
+  let peak = 0;
+  const items = Array.from({ length: 14 }, (_, i) => i); // typical multi-account view
+  const start = process.hrtime.bigint();
+  await mapBounded(
+    items,
+    async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      // Simulate a delayed usage HTTP call (the pile-up case).
+      await new Promise((r) => setTimeout(r, 40));
+      inFlight--;
+    },
+    { concurrency: USAGE_FETCH_CONCURRENCY },
+  );
+  return { peak, totalMs: hrMs(start) };
+}
+
+async function main(): Promise<void> {
+  console.log('=== agents view / usage core bench ===\n');
+  console.log(`USAGE_CACHE_FRESH_MS     = ${USAGE_CACHE_FRESH_MS} (${USAGE_CACHE_FRESH_MS / 60000} min)`);
+  console.log(`USAGE_FETCH_CONCURRENCY = ${USAGE_FETCH_CONCURRENCY}`);
+  console.log();
+
+  // --- Meter width: the alignment regressor ---
+  const wide = fakeSnapshot(4); // Antigravity-like
+  const uncapped = formatUsageSummary('Max', wide, 3);
+  const capped = formatUsageSummary('Max', wide, 3, { maxWindows: 2 });
+  console.log('Overview meter width (4 windows, plan=Max):');
+  console.log(`  BEFORE (no cap):  ${stringWidth(uncapped)} cols  ${JSON.stringify(uncapped.replace(/\x1b\[[0-9;]*m/g, ''))}`);
+  console.log(`  AFTER  (max=2):   ${stringWidth(capped)} cols  ${JSON.stringify(capped.replace(/\x1b\[[0-9;]*m/g, ''))}`);
+  console.log(`  pickCompact:      ${pickCompactUsageWindows(wide.windows, 2).map((w) => w.shortLabel).join(', ')}`);
+  console.log();
+
+  // --- Concurrency cap under delayed responses ---
+  const { peak, totalMs } = await benchConcurrencyCap();
+  console.log('Cold multi-account fan-out (14 identities, 40ms simulated RTT each):');
+  console.log(`  peak concurrent fetches = ${peak}  (cap ${USAGE_FETCH_CONCURRENCY})`);
+  console.log(`  wall clock              = ${totalMs.toFixed(0)} ms`);
+  console.log(`  unbounded Promise.all would peak at 14 and finish ~40ms,`);
+  console.log(`  but delayed/straggling calls would all stay open together.`);
+  console.log();
+
+  // --- Format throughput (CPU overhead of the new path) ---
+  const iters = 5000;
+  const snap = fakeSnapshot(2);
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) {
+    formatUsageSummary('Max', snap, 3, { maxWindows: 2 });
+  }
+  const formatMs = hrMs(t0);
+  console.log(`formatUsageSummary x${iters}: ${formatMs.toFixed(1)} ms  (${(formatMs / iters).toFixed(3)} ms/call)`);
+  console.log();
+  console.log('Done.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -2,12 +2,12 @@
  * Usage command -- show rate-limit / quota status for each installed agent.
  *
  * Lists every installed agent with the best available usage snapshot:
- *   - claude: live OAuth API call (cached for 2 minutes)
+ *   - claude: live OAuth API call (cached for 5 minutes)
  *   - codex:  parsed from latest session log's rate_limits event
- *   - kimi:   live Kimi Code /usages API call (cached for 2 minutes)
- *   - droid:  live Factory billing/limits API call (cached for 2 minutes)
+ *   - kimi:   live Kimi Code /usages API call (cached for 5 minutes)
+ *   - droid:  live Factory billing/limits API call (cached for 5 minutes)
  *   - grok:   parsed from the latest local usage event
- *   - cursor: live Cursor usage API call (cached for 2 minutes)
+ *   - cursor: live Cursor usage API call (cached for 5 minutes)
  *   - others: marked as "not exposed by CLI"
  */
 import type { Command } from 'commander';

--- a/apps/cli/src/commands/view.account.test.ts
+++ b/apps/cli/src/commands/view.account.test.ts
@@ -1,5 +1,72 @@
 import { describe, expect, it } from 'vitest';
-import { accountColumnLabel, pruneGroupKey } from './view.js';
+import { accountColumnLabel, joinViewColumns, pruneGroupKey } from './view.js';
+import { padToWidth, stringWidth } from '../lib/session/width.js';
+
+describe('joinViewColumns — fixed multi-agent layout', () => {
+  it('keeps the auth chip at the same column when status is empty', () => {
+    // The multi-agent misalignment bug: skipping empty status mid-row shifted
+    // lastActive/auth left. Fixed columns pad empties so gutters match.
+    const wVer = 18;
+    const wModel = 8;
+    const wEmail = 10;
+    const wUsage = 22;
+    const wStatus = 12;
+    const wActive = 10;
+
+    const row = (
+      ver: string,
+      model: string,
+      email: string,
+      usage: string,
+      status: string,
+      active: string,
+      auth: string,
+    ) =>
+      joinViewColumns([
+        padToWidth(ver, wVer),
+        padToWidth(model, wModel),
+        padToWidth(email, wEmail),
+        padToWidth(usage, wUsage),
+        padToWidth(status, wStatus),
+        padToWidth(active, wActive),
+        auth,
+      ]);
+
+    const rateLimited = row(
+      '2.1.220 (default)',
+      'default',
+      'a@x.com',
+      'Max  S: 100%',
+      'rate-limited',
+      '8h ago',
+      '○ 1m ago',
+    );
+    const healthy = row(
+      '2.1.219',
+      'default',
+      'b@y.com',
+      'Max  S: 5%',
+      '',
+      '2m ago',
+      '● 1m ago',
+    );
+
+    const authAt = (line: string): number => {
+      const m = line.match(/[●○◐]/);
+      return m?.index ?? -1;
+    };
+    expect(authAt(rateLimited)).toBeGreaterThan(0);
+    expect(authAt(healthy)).toBe(authAt(rateLimited));
+    // Both rows stay within a sane terminal width after the overview meter cap.
+    expect(stringWidth(rateLimited)).toBeLessThanOrEqual(120);
+    expect(stringWidth(healthy)).toBe(stringWidth(rateLimited));
+  });
+
+  it('drops only trailing empty columns', () => {
+    expect(joinViewColumns(['ver', 'model', '', ''])).toBe('ver  model');
+    expect(joinViewColumns(['ver', '', 'acct'])).toBe('ver    acct');
+  });
+});
 
 describe('accountColumnLabel — organization suffix', () => {
   it('appends the org NAME (identity) for a Team seat — the tier shows in the plan column', () => {

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -9,7 +9,7 @@
 import type { Command } from 'commander';
 import { addHostOption } from '../lib/hosts/option.js';
 import chalk from 'chalk';
-import { visibleWidth, termLink } from '../lib/format.js';
+import { termLink } from '../lib/format.js';
 import ora from 'ora';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -90,10 +90,34 @@ import { renderHarnessDetail } from './harness.js';
 import { loadManifest, isStale } from '../lib/staleness/index.js';
 import { confirm } from '@inquirer/prompts';
 import { formatPath, isInteractiveTerminal, isPromptCancelled } from './utils.js';
-import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
+import { terminalWidth, truncateToWidth, stringWidth, padToWidth } from '../lib/session/width.js';
 
 /** Shared account identity formatter, re-exported for the view-specific tests. */
 export const accountColumnLabel = accountDisplayLabel;
+
+/**
+ * Overview (`agents view` with no agent filter) caps compact usage windows so
+ * multi-meter agents (Antigravity's four model quotas, Droid's three buckets)
+ * cannot force every row to pad past the terminal width and wrap. Single-agent
+ * views leave the cap unset and show every blocking window.
+ */
+const OVERVIEW_MAX_USAGE_WINDOWS = 2;
+
+/** Fixed width for the last-active column ("just now", "8h ago", "2d ago"). */
+const LAST_ACTIVE_COL_WIDTH = 10;
+
+/**
+ * Join fixed view columns with a consistent two-space gutter. Empty trailing
+ * columns are dropped so a row without an auth chip does not grow a dangling
+ * gutter, but interior empties stay padded so later columns stay aligned.
+ */
+export function joinViewColumns(cols: string[]): string {
+  // Trim only pure-trailing empty strings so auth/status can be absent without
+  // shifting earlier columns for rows that do carry them.
+  let end = cols.length;
+  while (end > 0 && cols[end - 1] === '') end--;
+  return cols.slice(0, end).join('  ');
+}
 
 /**
  * Custom harnesses (the `~/.agents/profiles/*.yml` bundles), sorted by name and
@@ -337,6 +361,8 @@ async function showInstalledVersions(
   const spinner = ora({ text: spinnerText, isSilent: !process.stdout.isTTY }).start();
 
   const agentsToShow = filterAgentId ? [filterAgentId] : ALL_AGENT_IDS;
+  // Overview caps meter count; single-agent view shows every blocking window.
+  const usageWindowCap = filterAgentId ? undefined : OVERVIEW_MAX_USAGE_WINDOWS;
 
   // A globally-installed CLI is superseded only by a NORMAL managed version — that
   // is when agents-cli owns the launcher and a "global" row would just be our own
@@ -363,7 +389,6 @@ async function showInstalledVersions(
         .map(async (agentId) => [agentId, await getUnmanagedCliState(agentId)] as const)
     )
   ) as Partial<Record<AgentId, CliState>>;
-  spinner.stop();
   const showPaths = !!filterAgentId;
   const harnesses = getHarnesses(filterAgentId);
 
@@ -387,13 +412,16 @@ async function showInstalledVersions(
   }
   // Shim healing is silent — users don't need to know about internal repairs
 
-  console.log(chalk.bold('Installed Agent CLIs\n'));
-
   const selfHost = machineId();
   // Read the auth-health cache once (not per version row — see the batching note above).
   const authCache = readAuthHealthCache();
 
-  // Pre-fetch account info for all versions in parallel
+  // Pre-fetch account info for all versions in parallel. Spinner stays up through
+  // account + usage so a multi-account cold path doesn't leave a blank terminal
+  // after "Checking…" vanishes (the hang the screenshots caught).
+  spinner.text = filterAgentId
+    ? `Loading ${agentLabel(filterAgentId)} accounts...`
+    : 'Loading accounts and usage...';
   const infoFetches: Promise<{ agentId: AgentId; version: string; home: string; info: AccountInfo }>[] = [];
   const globalInfoFetches: Promise<{ agentId: AgentId; cliVersion: string | null; info: AccountInfo }>[] = [];
   for (const agentId of agentsToShow) {
@@ -437,6 +465,7 @@ async function showInstalledVersions(
   // or org scope, not a specific installed version. Version homes cache those
   // values independently, so older installs can show stale values. Reuse the
   // freshest cache entry per stable usage identity and keep lastActive per version.
+  // Goes through the unified usage core (SWR cache + concurrency cap + timeout).
   const { canonicalByUsageKey, usageByKey } = await getUsageInfoByIdentity([
     ...infoResults.map(({ agentId, home, version, info }) => ({
       agentId,
@@ -450,6 +479,9 @@ async function showInstalledVersions(
       info,
     })),
   ], { forceRefresh: viewOpts?.forceRefresh });
+
+  spinner.stop();
+  console.log(chalk.bold('Installed Agent CLIs\n'));
 
   const mergeCanonical = (info: AccountInfo): AccountInfo => {
     const key = getUsageLookupKey(info);
@@ -552,7 +584,8 @@ async function showInstalledVersions(
         }
       }
     }
-    // Second pass: compute max visible usage + status widths (now that maxPlanWidth is settled)
+    // Second pass: compute max visible usage + status widths (now that maxPlanWidth is settled).
+    // stringWidth (not String.length) so chalk + block-bar glyphs pad correctly.
     for (const agentId of versionManaged) {
       const versions = listInstalledVersions(agentId);
       for (const v of versions) {
@@ -562,10 +595,14 @@ async function showInstalledVersions(
         const usageInfo = usageKey ? usageByKey.get(usageKey) : undefined;
         const usageUnavailable = agentReportsUsage(agentId) && !!info?.signedIn && !usageInfo?.snapshot;
         const usageUnverified = !!usageInfo?.snapshot && !!usageInfo.error;
-        const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable, unverified: usageUnverified });
-        maxUsageWidth = Math.max(maxUsageWidth, visibleWidth(usageStr));
+        const usageStr = formatUsageSummary(info?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, {
+          unavailable: usageUnavailable,
+          unverified: usageUnverified,
+          maxWindows: usageWindowCap,
+        });
+        maxUsageWidth = Math.max(maxUsageWidth, stringWidth(usageStr));
         const statusStr = formatUsageStatusBadge(info?.usageStatus);
-        maxStatusWidth = Math.max(maxStatusWidth, visibleWidth(statusStr));
+        maxStatusWidth = Math.max(maxStatusWidth, stringWidth(statusStr));
       }
     }
 
@@ -610,18 +647,26 @@ async function showInstalledVersions(
         const usageKey = getUsageLookupKey(vInfo);
         const usageInfo = usageKey ? usageByKey.get(usageKey) : undefined;
 
-        // Build columns, trimming trailing whitespace when columns are empty
+        // Fixed columns for every signed-in row so status / lastActive / auth
+        // stay vertically aligned across agents — even when this row has no
+        // usage bars or no rate-limit badge. Skipping empty columns mid-table
+        // was what made the multi-agent view look unjustified next to
+        // `agents view claude`.
         const parts = [`    ${label}`];
         // Configured model — same priority as the version, right beside it.
         if (maxModelWidth > 0) {
           const model = modelByKey.get(`${agentId}:${version}`) ?? '';
-          parts.push(chalk.yellow(model.padEnd(maxModelWidth)));
+          parts.push(chalk.yellow(padToWidth(model, maxModelWidth)));
         }
         const hasEmail = !!vInfo?.email;
         const signedIn = !!vInfo?.signedIn;
         const usageUnavailable = agentReportsUsage(agentId) && signedIn && !usageInfo?.snapshot;
         const usageUnverified = !!usageInfo?.snapshot && !!usageInfo.error;
-        const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, { unavailable: usageUnavailable, unverified: usageUnverified });
+        const usageStr = formatUsageSummary(vInfo?.plan || null, usageInfo?.snapshot || null, maxPlanWidth, {
+          unavailable: usageUnavailable,
+          unverified: usageUnverified,
+          maxWindows: usageWindowCap,
+        });
         const hasUsage = usageStr.length > 0;
         // Only show lastActive for versions with an actual logged-in account.
         // Otherwise it reflects install time (misleading "just now" for fresh installs).
@@ -649,24 +694,21 @@ async function showInstalledVersions(
               : '(logged out — log in with: ' + loginHint(agentId) + ')',
           ));
         } else {
-          if (hasEmail || hasUsage || hasActive || signedIn) {
-            // Signed-in agents without a local email show their account id
-            // (Kimi's user_id) or a "signed in" placeholder (Antigravity) so they
-            // read as logged in, not blank.
-            const display = accountColumnLabel(vInfo);
-            const emailCol = display.padEnd(maxEmail);
-            parts.push(display ? chalk.cyan(emailCol) : ' '.repeat(maxEmail));
+          // Always emit account / usage / status / lastActive columns once any
+          // signed-in row exists in the table (widths are global). Empty cells
+          // are space-padded so later columns do not drift left.
+          const display = accountColumnLabel(vInfo);
+          parts.push(display ? chalk.cyan(padToWidth(display, maxEmail)) : ' '.repeat(maxEmail));
+          if (maxUsageWidth > 0) {
+            parts.push(padToWidth(usageStr, maxUsageWidth));
           }
-          if (hasUsage || hasActive) {
-            const usagePad = ' '.repeat(Math.max(0, maxUsageWidth - visibleWidth(usageStr)));
-            parts.push(usageStr + usagePad);
-          }
-          const statusStr = formatUsageStatusBadge(vInfo?.usageStatus);
           if (maxStatusWidth > 0) {
-            const statusPad = ' '.repeat(Math.max(0, maxStatusWidth - visibleWidth(statusStr)));
-            parts.push(statusStr + statusPad);
+            const statusStr = formatUsageStatusBadge(vInfo?.usageStatus);
+            parts.push(padToWidth(statusStr, maxStatusWidth));
           }
-          if (hasActive) parts.push(activeStr);
+          // Fixed-width lastActive so the auth chip (●/○/◐) lines up even when
+          // some rows have no email-derived lastActive.
+          parts.push(hasActive ? padToWidth(activeStr, LAST_ACTIVE_COL_WIDTH) : ' '.repeat(LAST_ACTIVE_COL_WIDTH));
         }
         if (runDefaultBits.length > 0) {
           parts.push(chalk.gray(`run ${runDefaultBits.join(' ')}`));
@@ -674,7 +716,7 @@ async function showInstalledVersions(
         const authChip = liveAuthChip(authCache, selfHost, agentId, version);
         if (authChip) parts.push(authChip);
 
-        console.log(parts.join('  '));
+        console.log(joinViewColumns(parts));
         if (showPaths) {
           const versionDir = getVersionDir(agentId, version);
           console.log(chalk.gray(`      ${versionDir}`));
@@ -707,17 +749,24 @@ async function showInstalledVersions(
         return `${cliState?.version || 'installed'} (global)`.length;
       })
     );
-    // Pre-pass: max badge width so rows with `lastActive` line up whether or
-    // not THIS row carries a throttle badge. Without this, the row that DOES
-    // have "out of credits" shifts every other row's `lastActive` left by
-    // ~16 chars, exactly what the version-managed block at maxStatusWidth
-    // already solves above.
+    // Pre-pass: max badge/usage/email widths so columns line up the same way
+    // the version-managed block does (stringWidth for chalk-aware padding).
     let gMaxStatusWidth = 0;
+    let gMaxUsageWidth = 0;
+    let gMaxEmail = 0;
     for (const agentId of globallyInstalled) {
       const gInfoRaw = globalInfoMap.get(agentId);
       const gInfo = gInfoRaw ? mergeCanonical(gInfoRaw) : undefined;
-      const w = visibleWidth(formatUsageStatusBadge(gInfo?.usageStatus));
-      if (w > gMaxStatusWidth) gMaxStatusWidth = w;
+      gMaxStatusWidth = Math.max(gMaxStatusWidth, stringWidth(formatUsageStatusBadge(gInfo?.usageStatus)));
+      const gUsageKey = getUsageLookupKey(gInfo);
+      const gUsage = gUsageKey ? usageByKey.get(gUsageKey) : undefined;
+      const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null, 3, {
+        unverified: !!gUsage?.snapshot && !!gUsage.error,
+        maxWindows: usageWindowCap,
+      });
+      gMaxUsageWidth = Math.max(gMaxUsageWidth, stringWidth(gUsageStr));
+      const gDisplay = accountColumnLabel(gInfo);
+      if (gDisplay) gMaxEmail = Math.max(gMaxEmail, gDisplay.length);
     }
 
     for (const agentId of globallyInstalled) {
@@ -735,20 +784,19 @@ async function showInstalledVersions(
       const gUsage = gUsageKey ? usageByKey.get(gUsageKey) : undefined;
       const gUsageStr = formatUsageSummary(gInfo?.plan || null, gUsage?.snapshot || null, 3, {
         unverified: !!gUsage?.snapshot && !!gUsage.error,
+        maxWindows: usageWindowCap,
       });
       const gActiveStr = gInfo ? formatLastActive(gInfo.lastActive) : '';
       if (gInfo?.email || gUsageStr || gActiveStr || gInfo?.signedIn) {
         const gDisplay = accountColumnLabel(gInfo);
-        parts.push(gDisplay ? chalk.cyan(gDisplay) : '');
+        parts.push(gDisplay ? chalk.cyan(padToWidth(gDisplay, gMaxEmail)) : ' '.repeat(gMaxEmail));
       }
-      if (gUsageStr || gActiveStr) parts.push(gUsageStr);
-      const gStatusStr = formatUsageStatusBadge(gInfo?.usageStatus);
+      if (gMaxUsageWidth > 0) parts.push(padToWidth(gUsageStr, gMaxUsageWidth));
       if (gMaxStatusWidth > 0) {
-        const statusPad = ' '.repeat(Math.max(0, gMaxStatusWidth - visibleWidth(gStatusStr)));
-        parts.push(gStatusStr + statusPad);
+        parts.push(padToWidth(formatUsageStatusBadge(gInfo?.usageStatus), gMaxStatusWidth));
       }
-      if (gActiveStr) parts.push(gActiveStr);
-      console.log(parts.join('  '));
+      if (gActiveStr) parts.push(padToWidth(gActiveStr, LAST_ACTIVE_COL_WIDTH));
+      console.log(joinViewColumns(parts));
       if (showPaths && cliState?.path) {
         console.log(chalk.gray(`      ${cliState.path}`));
       }

--- a/apps/cli/src/lib/__tests__/usage.test.ts
+++ b/apps/cli/src/lib/__tests__/usage.test.ts
@@ -27,7 +27,10 @@ import {
   antigravityTokenNeedsRefresh,
   normalizeAntigravityWindows,
   parseAntigravityOauthPayload,
+  pickCompactUsageWindows,
   USAGE_SOURCE_AGENT_IDS,
+  USAGE_CACHE_FRESH_MS,
+  USAGE_FETCH_CONCURRENCY,
   type DroidBillingLimitsResponse,
   type KimiUsagesResponse,
   type UsageSnapshot,
@@ -142,6 +145,65 @@ describe('usage formatting', () => {
     };
     expect(stripAnsi(formatUsageSummary('Max', snapshot, 3, { unavailable: true })))
       .not.toContain('usage unavailable');
+  });
+
+  it('caps overview meters so multi-window agents cannot blow out column width', () => {
+    // Claude-style: session + week preferred even when a later window is hotter.
+    const snapshot: UsageSnapshot = {
+      source: 'live',
+      sourceLabel: 'live',
+      capturedAt: new Date(),
+      windows: [
+        { key: 'session', label: 'S', shortLabel: 'S', usedPercent: 10, resetsAt: null, windowMinutes: null },
+        { key: 'week', label: 'W', shortLabel: 'W', usedPercent: 20, resetsAt: null, windowMinutes: null },
+        { key: 'month', label: 'M', shortLabel: 'M', usedPercent: 90, resetsAt: null, windowMinutes: null },
+        { key: 'sonnet_week', label: 'So', shortLabel: 'So', usedPercent: 50, resetsAt: null, windowMinutes: null },
+      ],
+    };
+    const picked = pickCompactUsageWindows(snapshot.windows, 2);
+    expect(picked.map((w) => w.shortLabel)).toEqual(['S', 'W']);
+
+    const summary = stripAnsi(formatUsageSummary(null, snapshot, 3, { maxWindows: 2 }));
+    expect(summary).toContain('S:');
+    expect(summary).toContain('W:');
+    expect(summary).toContain('+1'); // month only; sonnet_week already filtered
+    expect(summary).not.toContain('M:');
+    expect(summary).not.toContain('So:');
+  });
+
+  it('still fills maxWindows when every window shares key: session (Antigravity)', () => {
+    // Antigravity maps each model quota to key:'session'. Picking by key-set
+    // would keep only the first; identity-based fill keeps the hottest rest.
+    const windows: UsageWindow[] = [
+      { key: 'session', label: '2.5F', shortLabel: '2.5F', usedPercent: 10, resetsAt: null, windowMinutes: null },
+      { key: 'session', label: '2.5FL', shortLabel: '2.5FL', usedPercent: 20, resetsAt: null, windowMinutes: null },
+      { key: 'session', label: '2.5P', shortLabel: '2.5P', usedPercent: 90, resetsAt: null, windowMinutes: null },
+      { key: 'session', label: '3.1FL', shortLabel: '3.1FL', usedPercent: 5, resetsAt: null, windowMinutes: null },
+    ];
+    const picked = pickCompactUsageWindows(windows, 2);
+    expect(picked.map((w) => w.shortLabel)).toEqual(['2.5F', '2.5P']);
+    const summary = stripAnsi(formatUsageSummary(null, {
+      source: 'live', sourceLabel: 'live', capturedAt: new Date(), windows,
+    }, 3, { maxWindows: 2 }));
+    expect(summary).toContain('+2');
+  });
+
+  it('prefers highest utilization when session/week are absent', () => {
+    const windows: UsageWindow[] = [
+      { key: 'month', label: 'A', shortLabel: 'A', usedPercent: 10, resetsAt: null, windowMinutes: null },
+      { key: 'month', label: 'B', shortLabel: 'B', usedPercent: 95, resetsAt: null, windowMinutes: null },
+      { key: 'month', label: 'C', shortLabel: 'C', usedPercent: 40, resetsAt: null, windowMinutes: null },
+    ];
+    const picked = pickCompactUsageWindows(windows, 2);
+    expect(picked.map((w) => w.shortLabel)).toEqual(['B', 'C']);
+  });
+
+  it('pins the 5-minute fresh window and bounded fetch concurrency', () => {
+    // Correctness: these are the load-bearing knobs for the pile-up fix. If
+    // someone reverts the fresh window to 2 minutes or unbounded Promise.all,
+    // this fails loudly.
+    expect(USAGE_CACHE_FRESH_MS).toBe(5 * 60 * 1000);
+    expect(USAGE_FETCH_CONCURRENCY).toBe(3);
   });
 
   it('pins the complete usage source registry and derives support from it', () => {

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -397,8 +397,9 @@ describe('resolveLastActive', () => {
     const within = new Date(t0.getTime() + 60_000);
     expect(resolveLastActive('claude', home, undefined, cachePath, within)?.getTime()).toBe(5_000_000);
 
-    // Past the fresh window the walk runs again and picks up the newer file.
-    const beyond = new Date(t0.getTime() + 3 * 60_000);
+    // Past the fresh window (5 min, matching USAGE_CACHE_FRESH_MS) the walk
+    // runs again and picks up the newer file.
+    const beyond = new Date(t0.getTime() + 6 * 60_000);
     expect(resolveLastActive('claude', home, undefined, cachePath, beyond)?.getTime()).toBe(9_000_000);
   });
 

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1873,8 +1873,8 @@ export async function getAccountInfo(
 }
 
 // Fresh window for the cached session walk. Matches USAGE_CACHE_FRESH_MS in
-// usage.ts so a launch storm reuses both probes for the same period.
-const LAST_ACTIVE_CACHE_FRESH_MS = 2 * 60 * 1000;
+// usage.ts (5 minutes) so a launch storm reuses both probes for the same period.
+const LAST_ACTIVE_CACHE_FRESH_MS = 5 * 60 * 1000;
 
 const getLastActiveCachePath = () => path.join(getCacheDir(), 'last-active.json');
 

--- a/apps/cli/src/lib/rotate.ts
+++ b/apps/cli/src/lib/rotate.ts
@@ -438,7 +438,7 @@ export async function collectRunCandidates(agent: AgentId): Promise<RotateCandid
   // These candidates feed a routing decision, so cap how stale their usage may
   // be (see USAGE_DECISION_MAX_AGE_MS). Past that the fetch blocks on a live
   // read instead of serving the cache — one bounded, parallel round trip per
-  // account, and none at all inside the 2-minute fresh window that back-to-back
+  // account, and none at all inside the 5-minute fresh window that back-to-back
   // launches hit. A failed read still falls back to the cache; the pick then
   // routes around it via isUsageVerified rather than trusting the old number.
   const { usageByKey } = await getUsageInfoByIdentity(

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -34,6 +34,7 @@ import {
 } from './usage-backoff.js';
 import { getCacheDir } from './state.js';
 import type { AgentId } from './types.js';
+import { mapBounded } from './concurrency.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -345,7 +346,38 @@ export function agentReportsUsage(agentId: AgentId): boolean {
   return getUsageSource(agentId) !== undefined;
 }
 
-/** Fetch usage info for all unique accounts in parallel, keyed by usage key. */
+/**
+ * Concurrent live usage fetches for a single `agents view` / rotation pass.
+ * High enough to finish a multi-account refresh in one round-trip window; low
+ * enough that a cold cache of 10+ accounts cannot open 10+ HTTP calls at once
+ * (and cannot stack behind delayed responses until the process is pegged).
+ */
+export const USAGE_FETCH_CONCURRENCY = 3;
+
+/**
+ * Concurrent background SWR refreshes. Kept below the blocking concurrency so
+ * a display path that returns cached data immediately does not still flood the
+ * network with N silent refreshes that finish long after the command exits and
+ * pile onto the next invocation.
+ */
+const USAGE_BG_REFRESH_CONCURRENCY = 2;
+
+/**
+ * How long a cached snapshot is treated as fresh enough that we skip the network
+ * entirely. Five minutes balances "still accurate enough to glance at" against
+ * "don't re-hit every account on every `agents view` in a tight loop". Was 2
+ * minutes; that re-fired too often when delayed responses stacked.
+ */
+export const USAGE_CACHE_FRESH_MS = 5 * 60 * 1000;
+
+const USAGE_CACHE_SWR_MS = 24 * 60 * 60 * 1000; // 24 hours — beyond this, block on live fetch.
+
+/**
+ * Unified entry for every multi-account usage lookup (`agents view`, rotation,
+ * JSON export). Deduplicates by usage identity, then fans out through the
+ * shared SWR + timeout path with a hard concurrency cap so delayed calls
+ * cannot pile up.
+ */
 export async function getUsageInfoByIdentity(
   inputs: UsageIdentityInput[],
   opts?: { forceRefresh?: boolean; maxAgeMs?: number }
@@ -354,8 +386,10 @@ export async function getUsageInfoByIdentity(
   usageByKey: Map<string, UsageInfo>;
 }> {
   const { canonicalByUsageKey, usageFetchInputs } = buildCanonicalUsageContext(inputs);
-  const usageResults = await Promise.all(
-    [...usageFetchInputs.entries()].map(async ([key, input]) => ({
+  const entries = [...usageFetchInputs.entries()];
+  const usageResults = await mapBounded(
+    entries,
+    async ([key, input]) => ({
       key,
       usage: await getUsageInfoForIdentity({
         agentId: input.agentId,
@@ -363,7 +397,8 @@ export async function getUsageInfoByIdentity(
         cliVersion: input.cliVersion,
         info: canonicalByUsageKey.get(key)!,
       }, opts),
-    }))
+    }),
+    { concurrency: USAGE_FETCH_CONCURRENCY },
   );
 
   return {
@@ -371,9 +406,6 @@ export async function getUsageInfoByIdentity(
     usageByKey: new Map(usageResults.map(({ key, usage }) => [key, usage])),
   };
 }
-
-const USAGE_CACHE_FRESH_MS = 2 * 60 * 1000; // 2 minutes — fresh window: don't refresh.
-const USAGE_CACHE_SWR_MS = 24 * 60 * 60 * 1000; // 24 hours — beyond this, block on live fetch.
 
 /**
  * How stale a cached snapshot may be before the read stops serving it and blocks
@@ -387,20 +419,31 @@ export function swrWindowMsFor(maxAgeMs?: number): number {
   return Math.min(USAGE_CACHE_SWR_MS, Math.max(0, maxAgeMs));
 }
 
-/** In-process dedup: don't fire concurrent background refreshes for the same identity. */
-const inFlightRefreshes = new Map<string, Promise<void>>();
+/**
+ * In-process dedup for live + background usage work on the same identity.
+ * Covers both the blocking cold-cache path and SWR background refreshes so a
+ * delayed HTTP response cannot be stacked under a second request for the same
+ * key (the pile-up that made consecutive `agents view` runs peg CPU/network).
+ */
+const inFlightLiveFetches = new Map<string, Promise<UsageInfo>>();
+const inFlightBgKeys = new Set<string>();
+const bgRefreshQueue: Array<() => Promise<void>> = [];
+let bgRefreshActive = 0;
 
 /**
  * Fetch usage for a single identity using stale-while-revalidate.
  *
- * - Cache fresh (< 2 min): return cached snapshot, NO network.
- * - Cache stale but < 24h: return cached snapshot instantly, fire background refresh.
- * - Cache too stale or absent: block on live fetch, fall back to cache on error.
+ * - Cache fresh (< 5 min): return cached snapshot, NO network.
+ * - Cache stale but < 24h: return cached snapshot instantly, enqueue a
+ *   concurrency-capped background refresh.
+ * - Cache too stale or absent: block on live fetch (shared in-flight promise),
+ *   fall back to cache on error.
  *
- * This keeps `agents run` startup off the network on the hot path. The first
- * invocation after a cold install or 24h gap still blocks once to seed the
- * cache; every run after that returns instantly while the cache silently
- * refreshes in the background.
+ * This keeps `agents run` / `agents view` off the network on the hot path. The
+ * first invocation after a cold install or 24h gap still blocks once to seed
+ * the cache; every run after that returns instantly while the cache silently
+ * refreshes in the background — never more than {@link USAGE_BG_REFRESH_CONCURRENCY}
+ * at a time.
  */
 export async function getUsageInfoForIdentity(
   input: UsageIdentityInput,
@@ -448,62 +491,146 @@ export async function getUsageInfoForIdentity(
     // full 24h window and stay off the hot path.
     const swrWindowMs = swrWindowMsFor(opts?.maxAgeMs);
     if (cached && ageMs < swrWindowMs) {
-      triggerBackgroundUsageRefresh(input, usageKey);
+      enqueueBackgroundUsageRefresh(input, usageKey);
       return { snapshot: cached, error: null };
     }
   }
 
-  // Cold cache or > 24h old: block on live fetch.
-  const usage = await getUsageInfo(input.agentId, {
-    home: input.home,
-    cliVersion: input.cliVersion,
-    organizationId: input.info.organizationId,
-  });
-
-  if (usage.snapshot?.source === 'live') {
-    writeClaudeUsageCache(usageKey, usage.snapshot);
-    return usage;
-  }
-
-  // Live fetch failed — last-resort fallback to whatever cache we had.
-  if (cached) {
-    return { snapshot: cached, error: usage.error };
-  }
-  return usage;
+  // Cold cache or > 24h old (or forceRefresh): block on a shared live fetch so
+  // concurrent callers for the same identity share one in-flight HTTP call.
+  return fetchLiveUsageDeduped(input, usageKey, cached);
 }
 
 /**
- * Kick off a background refresh of the usage cache. Errors are swallowed —
- * a failed background refresh leaves the existing cache in place for the
- * next invocation. The work is deferred to a future event-loop tick via
- * `setImmediate` because some of the call chain (loadClaudeOauth →
- * getKeychainToken → execFileSync) does synchronous I/O even though the
- * functions are declared `async`. Without the defer, that sync I/O blocks
- * the SWR caller and defeats the whole point of returning the cache instantly.
+ * Single-flight live usage fetch per usage key. Concurrent callers (view +
+ * rotation, or two rows sharing an account) await the same promise rather than
+ * opening duplicate HTTP requests that then time out and pile up.
  */
-function triggerBackgroundUsageRefresh(input: UsageIdentityInput, usageKey: string): void {
-  if (inFlightRefreshes.has(usageKey)) return;
+async function fetchLiveUsageDeduped(
+  input: UsageIdentityInput,
+  usageKey: string,
+  cached: UsageSnapshot | null,
+): Promise<UsageInfo> {
+  const existing = inFlightLiveFetches.get(usageKey);
+  if (existing) return existing;
 
-  const promise = new Promise<void>((resolve) => {
-    setImmediate(async () => {
-      try {
-        const usage = await getUsageInfo(input.agentId, {
-          home: input.home,
-          cliVersion: input.cliVersion,
-          organizationId: input.info.organizationId,
-        });
-        if (usage.snapshot?.source === 'live') {
-          writeClaudeUsageCache(usageKey, usage.snapshot);
-        }
-      } catch {
-        /* background refresh failed — leave existing cache in place */
-      } finally {
-        inFlightRefreshes.delete(usageKey);
-        resolve();
-      }
+  const promise = (async (): Promise<UsageInfo> => {
+    const usage = await getUsageInfo(input.agentId, {
+      home: input.home,
+      cliVersion: input.cliVersion,
+      organizationId: input.info.organizationId,
     });
+
+    if (usage.snapshot?.source === 'live') {
+      writeClaudeUsageCache(usageKey, usage.snapshot);
+      return usage;
+    }
+
+    // Live fetch failed — last-resort fallback to whatever cache we had.
+    if (cached) {
+      return { snapshot: cached, error: usage.error };
+    }
+    return usage;
+  })();
+
+  inFlightLiveFetches.set(usageKey, promise);
+  try {
+    return await promise;
+  } finally {
+    inFlightLiveFetches.delete(usageKey);
+  }
+}
+
+/**
+ * Enqueue a background refresh of the usage cache. Errors are swallowed — a
+ * failed refresh leaves the existing cache in place. Work is deferred via
+ * `setImmediate` (keychain reads do sync I/O) and drained with a hard
+ * concurrency cap so N stale accounts do not open N HTTP calls at once.
+ */
+function enqueueBackgroundUsageRefresh(input: UsageIdentityInput, usageKey: string): void {
+  if (inFlightBgKeys.has(usageKey) || inFlightLiveFetches.has(usageKey)) return;
+  inFlightBgKeys.add(usageKey);
+
+  bgRefreshQueue.push(async () => {
+    try {
+      // Reuse the single-flight live path so a blocking caller that arrives
+      // mid-refresh shares the same HTTP call instead of racing it.
+      const cached = readClaudeUsageCache(usageKey);
+      await fetchLiveUsageDeduped(input, usageKey, cached);
+    } catch {
+      /* background refresh failed — leave existing cache in place */
+    } finally {
+      inFlightBgKeys.delete(usageKey);
+    }
   });
-  inFlightRefreshes.set(usageKey, promise);
+  pumpBackgroundUsageRefreshes();
+}
+
+function pumpBackgroundUsageRefreshes(): void {
+  while (bgRefreshActive < USAGE_BG_REFRESH_CONCURRENCY && bgRefreshQueue.length > 0) {
+    const work = bgRefreshQueue.shift()!;
+    bgRefreshActive++;
+    // setImmediate so the SWR caller returns the cached snapshot before any
+    // keychain/network work starts on this tick.
+    setImmediate(() => {
+      work().finally(() => {
+        bgRefreshActive--;
+        pumpBackgroundUsageRefreshes();
+      });
+    });
+  }
+}
+
+/**
+ * Pick which usage windows to render in a compact one-line summary.
+ *
+ * Overview rows (`agents view` all agents) must stay narrow enough that one
+ * multi-window agent (Antigravity's four model quotas, Droid's three buckets)
+ * does not force every other row to pad to ~200 columns and wrap. Prefer the
+ * canonical session + week windows when present; otherwise take the highest
+ * utilization remaining. Returns the full set when `maxWindows` is unset.
+ */
+export function pickCompactUsageWindows(
+  windows: UsageWindow[],
+  maxWindows?: number,
+): UsageWindow[] {
+  const filtered = windows.filter((window) => window.key !== 'sonnet_week');
+  if (maxWindows === undefined || maxWindows <= 0 || filtered.length <= maxWindows) {
+    return filtered;
+  }
+
+  // Pick by object identity, not by key. Antigravity normalizes every model
+  // quota as key: 'session', so a key-set filter would keep only the first and
+  // drop the rest even when maxWindows > 1.
+  const chosen: UsageWindow[] = [];
+  const take = (w: UsageWindow | undefined): void => {
+    if (!w || chosen.includes(w) || chosen.length >= maxWindows) return;
+    chosen.push(w);
+  };
+
+  take(filtered.find((w) => w.key === 'session'));
+  take(filtered.find((w) => w.key === 'week'));
+
+  const rest = filtered
+    .filter((w) => !chosen.includes(w))
+    .sort((a, b) => b.usedPercent - a.usedPercent);
+  for (const w of rest) {
+    if (chosen.length >= maxWindows) break;
+    chosen.push(w);
+  }
+  return chosen;
+}
+
+/** Options for {@link formatUsageSummary}. */
+export interface FormatUsageSummaryOpts {
+  unavailable?: boolean;
+  unverified?: boolean;
+  /**
+   * Cap how many usage windows render on one line. Overview (`agents view`
+   * with no agent filter) passes 2 so multi-window agents cannot blow out
+   * column width; single-agent and detail views leave this unset.
+   */
+  maxWindows?: number;
 }
 
 /** Format a one-line usage summary with compact bars for inline display. */
@@ -511,7 +638,7 @@ export function formatUsageSummary(
   plan: string | null,
   snapshot: UsageSnapshot | null,
   planWidth = 3,
-  opts?: { unavailable?: boolean; unverified?: boolean }
+  opts?: FormatUsageSummaryOpts
 ): string {
   const parts: string[] = [];
 
@@ -520,23 +647,32 @@ export function formatUsageSummary(
   }
 
   if (snapshot) {
-    // Compact rows show every BLOCKING window — the same set
+    // Compact rows show BLOCKING windows — the same set
     // deriveUsageStatusFromSnapshot uses for the rate-limited badge — so an
     // account throttled by its month window (Droid meters on 5h/week/month)
     // shows the bar that explains why. Claude's Sonnet week is a per-model
     // sub-limit, not a blocking window; it renders only in the full
     // per-version usage section. Each window reads "S: ███░░ 58% (3d)" — the
     // gauge, the exact percentage, and a compact hint of when it resets.
-    const windows = snapshot.windows
-      .filter((window) => window.key !== 'sonnet_week')
-      .map((window) => {
-        const bar = renderCompactUsageBar(window.usedPercent);
-        const pct = colorUsage(`${Math.round(window.usedPercent)}%`, window.usedPercent);
-        const reset = window.resetsAt ? chalk.dim(` (${formatResetHint(window.resetsAt)})`) : '';
-        return `${chalk.gray(`${window.shortLabel}:`)} ${bar} ${pct}${reset}`;
-      });
-    if (windows.length > 0) {
-      parts.push(windows.join('  '));
+    //
+    // Overview caps the window count (see pickCompactUsageWindows) so one
+    // multi-meter agent cannot force the whole table to wrap.
+    const selected = pickCompactUsageWindows(snapshot.windows, opts?.maxWindows);
+    const hidden = Math.max(
+      0,
+      snapshot.windows.filter((w) => w.key !== 'sonnet_week').length - selected.length,
+    );
+    const windowParts = selected.map((window) => {
+      const bar = renderCompactUsageBar(window.usedPercent);
+      const pct = colorUsage(`${Math.round(window.usedPercent)}%`, window.usedPercent);
+      const reset = window.resetsAt ? chalk.dim(` (${formatResetHint(window.resetsAt)})`) : '';
+      return `${chalk.gray(`${window.shortLabel}:`)} ${bar} ${pct}${reset}`;
+    });
+    if (hidden > 0) {
+      windowParts.push(chalk.dim(`+${hidden}`));
+    }
+    if (windowParts.length > 0) {
+      parts.push(windowParts.join('  '));
     }
     // The bars came from the cache and the live read that should have confirmed
     // them failed, so they are the last thing we saw — not the current state.
@@ -1358,9 +1494,9 @@ function parseClaudeOauthPayload(raw: string): ClaudeOauthCredentials | null {
 // The source item `Claude Code-credentials-<hash>` is ACL-bound to Claude Code's
 // own process, so every read agents-cli makes (via `/usr/bin/security`) pops
 // Touch ID. The Factory watchdog polls `agents view --json` every 60s per agent,
-// and each poll that crosses the 2-minute usage cache fires a background refresh
+// and each poll that crosses the 5-minute usage cache fires a background refresh
 // -> loadClaudeOauth -> keychain read -> a biometric prompt. With many agents and
-// accounts that is a prompt every couple of minutes, per account.
+// accounts that is a prompt every few minutes, per account.
 //
 // Fix: after one real (prompting) read, cache the ACCESS token in a device-local
 // NO-ACL keychain item — the same `set-no-acl` mechanism secrets/session-store.ts


### PR DESCRIPTION
## Summary

**UI + perf fix for `agents view`.** The multi-agent overview looked misaligned next to `agents view claude`, and cold runs could pile up delayed usage HTTP calls.

### UI (alignment)
- Overview caps compact usage meters to **2 windows** (`+N` for the rest) so one multi-meter agent (Antigravity's four model quotas, Droid's three buckets) cannot force every row to ~200 columns and wrap
- Always emit fixed account / usage / status / lastActive columns (empty cells space-padded) so `rate-limited` and auth chips stay vertically aligned
- Padding measured with `stringWidth` / `padToWidth` (not naive `String.length`) so chalk + block-bar glyphs do not skew gutters
- Spinner stays up through account + usage load (no blank terminal after "Checking…")

### Usage core (correctness + performance)
- Unified multi-account path: `getUsageInfoByIdentity` → SWR cache → single-flight live fetch
- Fresh cache window: **5 minutes** (was 2) — matches last-active cache
- Live fan-out concurrency: **3** (`USAGE_FETCH_CONCURRENCY`)
- Background SWR queue concurrency: **2** (no post-exit network flood)
- Per-identity single-flight so concurrent callers share one HTTP call

## Before / after (zion, real accounts)

| metric | before | after |
| --- | --- | --- |
| max version-row width | **197** cols | **172** cols (every row same width) |
| Antigravity meters | 4 full windows | `2.5F` + `2.5FL` + `+2` |
| Droid meters | S + W + M | S + W + `+1` |
| simulated 14-account peak concurrent fetches | 14 (unbounded) | **3** (capped) |
| 4-window meter string width | 62 cols | 36 cols |

Warm `agents view` on zion after patch: **~1.5s** wall. Microbench: `bun bench/view-usage-perf.ts`.

## Test plan
- [x] 168 targeted unit tests green (`usage.test.ts`, `view.account.test.ts`, `agents.test.ts`, `usage.test.ts`)
- [x] Built CLI: overview rows equal width; Antigravity shows `+2`; Droid shows `+1`
- [x] Zion before/after width measurement on live multi-account install
- [ ] CI green on this PR
- [ ] Smoke `agents view` and `agents view claude` after merge

## Run result (no UI screenshot — TTY table)

```
BEFORE max line width: 197  median: 195
AFTER  max line width: 172  median: 172   (every signed-in row identical width)

Antigravity after:
  1.0.6  Gemini 3.1 Pro (High)  signed in  2.5F: …  2.5FL: …  +2  ◐ …

Droid after:
  0.184.0  muqsit@getrush.ai  S: …  W: …  +1  unverified  2d ago  ○ …
```

Refactor / layout + cache policy — no new user-facing flag.