### PR TITLE
fix(projects): the compact card must lead with the milestone it calls next

### DIFF
--- a/apps/cli/.changelog/next/projects-next-milestone-leads.md
+++ b/apps/cli/.changelog/next/projects-next-milestone-leads.md
@@ -1,0 +1,6 @@
+- **The compact `projects status` card shows the milestone it calls `next`.** Milestones are
+  listed in date order, and Linear can flag a later-dated one as next — so slicing the front
+  of the list showed an earlier milestone while burying the actual next under `+N more`, which
+  is the one thing that row exists to say. The next milestone now leads, and identity is
+  matched on name plus target date rather than name alone (two milestones can share a name,
+  which put the `next` label on the wrong row). Source: `apps/cli/src/commands/projects.ts`.

--- a/apps/cli/src/commands/projects.test.ts
+++ b/apps/cli/src/commands/projects.test.ts
@@ -137,9 +137,37 @@ describe('formatMilestoneLines', () => {
     expect(out.join('\n')).not.toContain('more milestone');
   });
 
-  it('labels the first row `plan` when it is not the flagged next one', () => {
-    const out = formatMilestoneLines(ms, ms[1], now, 1).map(stripAnsi);
+  it('labels the first row `plan` when there is no next at all', () => {
+    const out = formatMilestoneLines(ms, undefined, now, 1).map(stripAnsi);
     expect(out[0].trimStart().startsWith('plan')).toBe(true);
+  });
+
+  it('leads with the NEXT milestone even when a different one is dated earlier', () => {
+    // Linear can flag a later milestone as next. Slicing the date-ordered front
+    // would show the earlier one and bury the actual next under "+N more".
+    const out = formatMilestoneLines(ms, ms[2], now, 1).map(stripAnsi);
+    expect(out[0]).toContain('next');
+    expect(out[0]).toContain('Factory onboarding');
+    expect(out[1]).toContain('+2 more');
+  });
+
+  it('does not repeat the next milestone further down the full list', () => {
+    const out = formatMilestoneLines(ms, ms[2], now, 99).map(stripAnsi);
+    expect(out).toHaveLength(3);
+    expect(out.filter((l) => l.includes('Factory onboarding'))).toHaveLength(1);
+    expect(out[0]).toContain('Factory onboarding');
+  });
+
+  it('labels the right row when two milestones share a name', () => {
+    const dup = [
+      { name: 'Cut', targetDate: '2026-09-01', done: 0, total: 0 },
+      { name: 'Cut', targetDate: '2026-10-01', done: 0, total: 0 },
+    ];
+    // Matching on name alone put the label on the Sep row.
+    const out = formatMilestoneLines(dup, dup[1], now, 99).map(stripAnsi);
+    expect(out[0]).toContain('next');
+    expect(out[0]).toContain('Oct 1');
+    expect(out[1]).not.toContain('next');
   });
 
   it('renders nothing when the project declares no milestones', () => {

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -242,10 +242,18 @@ export function formatMilestoneLines(
     // list existed; render what we have rather than dropping the row.
     return next ? [`  ${chalk.dim('next')}     ${formatNextMilestone(next, nowMs)}`] : [];
   }
-  const shown = milestones.slice(0, Math.max(1, limit));
+  // The next milestone leads, always. Linear can flag a LATER-dated milestone
+  // as next, and `milestones` is date-ordered — so slicing the front would show
+  // an earlier one and hide the actual next behind "+N more", which is the one
+  // thing this row exists to say. Identity is name+targetDate: two milestones
+  // can share a name, and matching on name alone labelled the wrong row.
+  const key = (m: LinearMilestone) => `${m.name} ${m.targetDate ?? ''}`;
+  const lead = next ? milestones.filter((m) => key(m) === key(next)).slice(0, 1) : [];
+  const others = next ? milestones.filter((m) => key(m) !== key(next)) : milestones;
+  const ordered = [...lead, ...others];
+  const shown = ordered.slice(0, Math.max(1, limit));
   const out = shown.map((m, i) => {
-    const isNext = next && m.name === next.name;
-    const label = i === 0 ? (isNext ? 'next' : 'plan') : '';
+    const label = i === 0 && lead.length > 0 ? 'next' : i === 0 ? 'plan' : '';
     return `  ${chalk.dim(label.padEnd(4))}     ${formatNextMilestone(m, nowMs)}`;
   });
   const rest = milestones.length - shown.length;


### PR DESCRIPTION
**What + type:** bug fix — the compact `projects status` card could show a milestone that is *not* the one it labels `next`, hiding the actual next behind `+N more`.

Found by probing my own merged diff from #1862 after the reviewer for it died mid-run (API error) while analysing exactly this function. Rather than let an unreviewed merge stand, I ran the cases the review brief had asked it to check.

## The defect

`milestones` is date-ordered. `nextMilestone` prefers Linear's own `status: "next"` flag. Those two disagree whenever Linear flags a later-dated milestone — and the compact card sliced the front of the date-ordered list:

```
formatMilestoneLines([A(Sep 1), B(Oct 1)], next=B, limit 1)
  -> [plan  A  ·  due Sep 1]
     [      +1 more milestone — agents projects view <name>]
```

So the row that exists to answer *"what is this project due to hit next"* showed the wrong milestone and buried the right one. The next milestone now leads the list, so the compact card and `view` agree.

**Second, smaller:** identity moved from `name` to `name + targetDate`. Two milestones can share a name, and matching on name alone put the `next` label on the first match rather than the flagged one:

```
formatMilestoneLines([Cut(Sep 1), Cut(Oct 1)], next=Cut(Oct 1), limit 99)
  before -> [next  Cut · due Sep 1]      <- wrong row
  after  -> [next  Cut · due Oct 1]
```

## Latent here, not visible

On this workspace Linear happens to flag the earliest-dated milestone, so the live card was already correct — verified before and after, output identical:

```
next     Factory converts strategy to shipped outcomes  ·  due Sep 15
         +2 more milestones — agents projects view <name>
```

It would have surfaced the first time someone re-ordered a milestone in Linear. That is precisely the kind of bug worth fixing while the context is fresh rather than waiting for the report.

## Tests

Three new cases in `projects.test.ts`: next leads when a different milestone is dated earlier; the next milestone is not repeated further down the full list; the right row is labelled when two milestones share a name. The pre-existing `plan`-label case was rewritten to cover "no next at all", which is what it was actually testing. 21 pass in the suite.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
