### PR TITLE
fix(isolated): inspect and view --json misreported isolation state

### DIFF
--- a/apps/cli/.changelog/next/isolated-diagnostics.md
+++ b/apps/cli/.changelog/next/isolated-diagnostics.md
@@ -1,0 +1,11 @@
+- **`agents inspect` and `view --json` now report isolation honestly.** Found by diffing
+  every command's output between an isolated-only and a normal install. `inspect` printed
+  the bare-shim path unconditionally, so an isolated copy — which deliberately has no
+  shim, that being the guarantee — was shown sitting on the user's PATH; it now reports
+  `(none — isolated installs stay off PATH)` and `shim: null` in JSON. `inspect` also
+  showed only `default: false` for an isolated copy, hiding that it *was* the selected
+  one; it now carries `isolated` and `isolatedDefault`, and the header reads
+  `[isolated default]`. `view --json` had no isolation signal at all, so tooling could not
+  distinguish a sandboxed copy from one that owns the launcher and real config — its
+  version entries gain `isolated` and `isIsolatedDefault`. Source:
+  `apps/cli/src/commands/inspect.ts`, `apps/cli/src/commands/view.ts`.

--- a/apps/cli/src/commands/__tests__/inspect.test.ts
+++ b/apps/cli/src/commands/__tests__/inspect.test.ts
@@ -34,6 +34,13 @@ function makeFixture(): string {
   // Suppress the update-check network call.
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8')) as { version: string };
   mkdir(path.join(home, '.agents', '.cache'));
+  // A normal (non-isolated) install owns the bare shim. The fixture omitted it, so
+  // it described a state that cannot occur — and `inspect` now reports the shim only
+  // when it is really there, since printing a phantom path told isolated users their
+  // copy sat on PATH when it did not.
+  mkdir(path.join(home, '.agents', '.cache', 'shims'));
+  writeFile(path.join(home, '.agents', '.cache', 'shims', 'claude'), '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(path.join(home, '.agents', '.cache', 'shims', 'claude'), 0o755);
   writeFile(
     path.join(home, '.agents', '.cache', '.update-check'),
     JSON.stringify({ lastCheck: Date.now(), latestVersion: pkg.version })

--- a/apps/cli/src/commands/inspect.ts
+++ b/apps/cli/src/commands/inspect.ts
@@ -33,7 +33,10 @@ import {
   getProjectAgentsDir,
   getEnabledExtraRepos,
 } from '../lib/state.js';
-import { getVersionHomePath } from '../lib/versions.js';
+import { getVersionHomePath,
+  isVersionIsolated,
+  getIsolatedDefault,
+} from '../lib/versions.js';
 import { getShimsDir, getVersionedAliasPath } from '../lib/shims.js';
 import {
   getAgentResources,
@@ -640,8 +643,19 @@ async function renderSummary(agent: AgentId, version: string, versionHome: strin
   const configSymlink = path.join(os.homedir(), `.${agent}`);
   const configTarget = readSymlinkSafe(configSymlink);
 
-  const shimPath = path.join(getShimsDir(), AGENTS[agent].cliCommand);
+  // Report the bare shim only when it is actually there. An isolated install
+  // deliberately has none — that is the promise — so printing the path
+  // unconditionally told the user this copy sits on their PATH when it does not.
+  // Same failure mode as `agents view` claiming an isolated copy was `(global)`.
+  const shimPathIfPresent = fs.existsSync(path.join(getShimsDir(), AGENTS[agent].cliCommand))
+    ? path.join(getShimsDir(), AGENTS[agent].cliCommand)
+    : null;
   const aliasPath = getVersionedAliasPath(agent, version);
+  const isolated = isVersionIsolated(agent, version);
+  // `default` means the GLOBAL default, which an isolated copy can never be. Report
+  // the isolated pointer separately rather than leaving it invisible: it is what a
+  // bare `agents run <agent>` resolves to, so "default: false" alone is misleading.
+  const isIsolatedDefault = isolated && getIsolatedDefault(agent) === version;
 
   const capabilities = collectCapabilities(agent, version);
 
@@ -658,9 +672,11 @@ async function renderSummary(agent: AgentId, version: string, versionHome: strin
       agent,
       version,
       default: isDefault,
+      isolated,
+      isolatedDefault: isIsolatedDefault,
       home: versionHome,
       configSymlink: configTarget ? { from: configSymlink, to: configTarget } : null,
-      shim: shimPath,
+      shim: shimPathIfPresent,
       alias: aliasPath,
       strategy,
       installedShim: cliState?.installed === true ? cliState.path : null,
@@ -675,13 +691,13 @@ async function renderSummary(agent: AgentId, version: string, versionHome: strin
   // Plain text — model sits right beside the version, same priority (no label).
   const configuredModel = resolveConfiguredModel(agent, version)?.model;
   const modelPart = configuredModel ? '  ' + chalk.yellow(configuredModel) : '';
-  const head = `${chalk.bold(agent)} ${chalk.gray('@')} ${chalk.cyan(version)}${modelPart}${isDefault ? '  ' + chalk.green('[default]') : ''}`;
+  const head = `${chalk.bold(agent)} ${chalk.gray('@')} ${chalk.cyan(version)}${modelPart}${isDefault ? '  ' + chalk.green('[default]') : ''}${isolated ? '  ' + chalk.gray(isIsolatedDefault ? '[isolated default]' : '[isolated]') : ''}`;
   console.log('\n' + head + '\n');
 
   const rows: Array<[string, string]> = [
     ['install', versionHome],
     ['config', configTarget ? `${configSymlink}  ${chalk.gray('→')}  ${configTarget}` : chalk.gray('(no symlink)')],
-    ['shim', shimPath],
+    ['shim', shimPathIfPresent ?? chalk.gray(isolated ? '(none — isolated installs stay off PATH)' : '(none)')],
     ['alias', aliasPath],
     ['strategy', strategy],
   ];

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -1199,6 +1199,18 @@ async function showAgentResources(
 export interface ViewJsonVersion {
   version: string;
   isDefault: boolean;
+  /**
+   * Installed with `--isolated`. The human view has shown this since the isolated
+   * tag landed, but JSON carried no signal at all, so tooling could not tell a
+   * sandboxed copy from one that owns the user's launcher and real config.
+   */
+  isolated: boolean;
+  /**
+   * The isolated copy a bare `agents run <agent>` resolves to. Separate from
+   * `isDefault`, which is the GLOBAL default an isolated version can never be —
+   * reporting only `isDefault: false` hid the fact that this one is selected.
+   */
+  isIsolatedDefault: boolean;
   signedIn: boolean;
   email: string | null;
   // Opaque account identifier when the credential exposes one but no email
@@ -1478,6 +1490,8 @@ async function collectAgentsJson(filterAgentId?: AgentId, resourceSections?: Set
     const entry: ViewJsonVersion = {
       version,
       isDefault: version === globalDefault,
+      isolated: isVersionIsolated(agentId, version),
+      isIsolatedDefault: getIsolatedDefault(agentId) === version,
       signedIn: info.signedIn,
       email: info.email,
       accountId: info.accountId,

--- a/apps/cli/src/lib/isolated-diagnostics.integration.test.ts
+++ b/apps/cli/src/lib/isolated-diagnostics.integration.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Diagnostics that misreport isolation state are the recurring failure here: an
+// isolated copy shown as `(global)` (fixed once already), a resume that claimed to
+// run and didn't, and — found by diffing every command's output between an
+// isolated-only and a normal install — `inspect` printing a bare shim path that
+// does not exist, and `view --json` carrying no isolation signal at all.
+//
+// A wrong diagnostic is worse than a missing one when the whole feature is a
+// promise about what was left alone: it is the only thing the user can check.
+describe.skipIf(process.platform === 'win32')('isolated installs report themselves honestly', () => {
+  let home: string;
+  const V = '9.9.4';
+
+  const shimsDir = () => path.join(home, '.agents', '.cache', 'shims');
+
+  function plant({ isolated }: { isolated: boolean }) {
+    const vdir = path.join(home, '.agents', '.history', 'versions', 'codex', V);
+    fs.mkdirSync(path.join(vdir, 'node_modules', '.bin'), { recursive: true });
+    fs.mkdirSync(path.join(vdir, 'home', '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(vdir, 'package.json'), '{}');
+    fs.writeFileSync(path.join(vdir, 'node_modules', '.bin', 'codex'), '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(path.join(vdir, 'node_modules', '.bin', 'codex'), 0o755);
+    fs.mkdirSync(shimsDir(), { recursive: true });
+    const alias = path.join(shimsDir(), `codex@${V}`);
+    fs.writeFileSync(alias, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(alias, 0o755);
+    if (isolated) {
+      fs.writeFileSync(path.join(vdir, '.isolated'), 'x\n');
+    } else {
+      // A normal install owns the bare shim; an isolated one never creates it.
+      const shim = path.join(shimsDir(), 'codex');
+      fs.writeFileSync(shim, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(shim, 0o755);
+    }
+  }
+
+  function run(...args: string[]): string {
+    try {
+      return execFileSync('bun', [path.resolve(process.cwd(), 'src/index.ts'), ...args], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env, HOME: home, AGENTS_REAL_HOME: home, SHELL: '/bin/bash',
+          AGENTS_NO_NUDGE: '1', FORCE_COLOR: '0',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString('utf-8');
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer };
+      return `${err.stdout ?? ''}${err.stderr ?? ''}`;
+    }
+  }
+  const json = (...args: string[]) => JSON.parse(run(...args).slice(run(...args).indexOf('{')));
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'iso-diag-'));
+    const systemDir = path.join(home, '.agents', '.system');
+    fs.mkdirSync(systemDir, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: systemDir, stdio: 'ignore' });
+  });
+  afterEach(() => { fs.rmSync(home, { recursive: true, force: true }); });
+
+  it('inspect never reports a bare shim an isolated install does not have', () => {
+    plant({ isolated: true });
+    const d = json('inspect', 'codex', '--json');
+    expect(d.shim).toBeNull();
+    expect(d.isolated).toBe(true);
+    // The human view says so in words rather than printing a phantom path.
+    expect(run('inspect', 'codex')).toContain('isolated installs stay off PATH');
+  }, 120_000);
+
+  it('inspect still reports the shim a NORMAL install really has', () => {
+    plant({ isolated: false });
+    const d = json('inspect', 'codex', '--json');
+    expect(d.shim).toBe(path.join(shimsDir(), 'codex'));
+    expect(fs.existsSync(d.shim)).toBe(true);
+    expect(d.isolated).toBe(false);
+  }, 120_000);
+
+  it('inspect surfaces the isolated default, which `default` alone cannot', () => {
+    plant({ isolated: true });
+    expect(run('use', `codex@${V}`)).toContain('ISOLATED');
+    const d = json('inspect', 'codex', '--json');
+    // Not the global default — an isolated copy never is — but it IS the selected one.
+    expect(d.default).toBe(false);
+    expect(d.isolatedDefault).toBe(true);
+    expect(run('inspect', 'codex')).toContain('[isolated default]');
+  }, 120_000);
+
+  it('view --json carries an isolation signal for machine consumers', () => {
+    plant({ isolated: true });
+    run('use', `codex@${V}`);
+    const entry = json('view', 'codex', '--json').versions[0];
+    expect(entry.isolated).toBe(true);
+    expect(entry.isIsolatedDefault).toBe(true);
+    expect(entry.isDefault).toBe(false);
+  }, 120_000);
+
+  it('view --json marks a normal install as not isolated', () => {
+    plant({ isolated: false });
+    const entry = json('view', 'codex', '--json').versions[0];
+    expect(entry.isolated).toBe(false);
+    expect(entry.isIsolatedDefault).toBe(false);
+  }, 120_000);
+});


### PR DESCRIPTION
Follow-up to #1459. Found by **diffing every command's output** between two sandboxes — one isolated-only, one a normal install — rather than by reading code. Fifteen commands, two differed: `view` (by design, it carries the isolated tag) and `inspect`.

## 1. `inspect` printed a bare shim that doesn't exist

```
shim   ~/.agents/.cache/shims/codex        ← the file is not there
```

An isolated install has **no** bare shim — that is the guarantee. So `inspect` told the user their sandboxed copy sat on their PATH. Verified: `exists=False` for isolated, `exists=True` for normal, same path printed either way.

Now reported only when present:

```
shim   (none — isolated installs stay off PATH)     # human
"shim": null                                        # json
```

## 2. `inspect` hid the isolated default

It showed `default: false` and nothing more. `default` means the **global** default, which an isolated version can never be — but the isolated pointer is what a bare `agents run <agent>` resolves to, so `false` alone reads as "nothing is selected."

Now carries `isolated` and `isolatedDefault`, and the header reads `[isolated default]`.

## 3. `view --json` had no isolation signal at all

The human view has shown `(isolated)` / `(isolated default)` since those landed, but JSON consumers couldn't distinguish a sandboxed copy from one that owns the launcher and the real config. Version entries gain `isolated` and `isIsolatedDefault`.

## Why this class keeps mattering

All three are the same failure as the original report — a diagnostic that lies about isolation. That's worse than a missing diagnostic here: when the whole feature is a promise about what was left alone, the diagnostic is the only thing a user can check.

## Before / after

```
                        isolated              normal
inspect shim            phantom path    →     (none — off PATH)      | real path
inspect default         false           →     isolatedDefault: true  | default: true
view --json isolated    (absent)        →     true                   | false
```

## Note on the fixture

The existing `inspect.test.ts` fixture never created the bare shim while asserting on its path — it described a state that cannot occur for a `default: true` install. I fixed the fixture to create it rather than loosening the assertion, since the assertion is the correct one for a normal install.

## Sweep coverage

Twelve other commands were **byte-identical** between the two modes after path normalisation: `doctor`, `usage`, `rules`, `commands`, `skills`, `mcp`, `permissions`, `subagents`, `sessions`, `check`, `resources`, `defaults`, `list`. No further gaps in this sweep.

## Tests

`isolated-diagnostics.integration.test.ts` (5) — inspect never reports a shim an isolated install lacks; still reports the one a normal install really has; surfaces the isolated default that `default` alone cannot; `view --json` carries the signal for isolated and correctly reports `false` for normal.

Full suite: **6785 pass**. The 4 failures are the pre-existing codex `exec`/`models` tests that read real local state and pass with a clean `HOME` — present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)