### PR TITLE
fix(hosts): short-circuit all self identities in --host + fleet fan-out (RUSH-2114)

### DIFF
--- a/apps/cli/.changelog/next/rush-2114-self-host-shortcircuit.md
+++ b/apps/cli/.changelog/next/rush-2114-self-host-shortcircuit.md
@@ -5,8 +5,9 @@
   the local box over its own name; on a loaded machine that self-SSH'd `doctor
   --json` orphaned on timeout and piled up until the host was crushed. A new
   `isSelfHost()` matches every identity the box answers to (short id, loopback,
-  tailscale dnsName + its short form) and gates the generic `--host` passthrough
-  (`maybeRunOnHost`), `remoteFleetTargets`, and `runFleet` so a self-reference
-  runs locally instead of self-SSHing. Source:
+  tailscale dnsName + its short form) and gates all four self-checks — the
+  generic `--host` passthrough (`maybeRunOnHost`), the `--devices`-all fan-out
+  (`runFleetPassthrough`), `remoteFleetTargets`, and `runFleet` — so a
+  self-reference runs locally instead of self-SSHing. Source:
   `apps/cli/src/lib/devices/self-host.ts`, `apps/cli/src/lib/hosts/passthrough.ts`,
   `apps/cli/src/lib/devices/fleet.ts`.

--- a/apps/cli/.changelog/next/rush-2114-self-host-shortcircuit.md
+++ b/apps/cli/.changelog/next/rush-2114-self-host-shortcircuit.md
@@ -1,0 +1,12 @@
+- **`--host <self>` and the fleet-health fan-out now short-circuit ALL of the
+  local machine's names, not just its short hostname (RUSH-2114).** A `--host`
+  target or fleet probe that referenced this box by its **tailscale dnsName**
+  (`zion.tail1a85a1.ts.net`) slipped past a `=== machineId()` check and SSH'd to
+  the local box over its own name; on a loaded machine that self-SSH'd `doctor
+  --json` orphaned on timeout and piled up until the host was crushed. A new
+  `isSelfHost()` matches every identity the box answers to (short id, loopback,
+  tailscale dnsName + its short form) and gates the generic `--host` passthrough
+  (`maybeRunOnHost`), `remoteFleetTargets`, and `runFleet` so a self-reference
+  runs locally instead of self-SSHing. Source:
+  `apps/cli/src/lib/devices/self-host.ts`, `apps/cli/src/lib/hosts/passthrough.ts`,
+  `apps/cli/src/lib/devices/fleet.ts`.

--- a/apps/cli/src/lib/devices/fleet.ts
+++ b/apps/cli/src/lib/devices/fleet.ts
@@ -10,6 +10,7 @@
 
 import { spawnSync } from 'child_process';
 import { isControlDevice, type DeviceProfile, type DeviceRegistry } from './registry.js';
+import { isSelfHost } from './self-host.js';
 import { buildSshInvocation, sshTargetFor, writeAskpassShim } from './connect.js';
 import type { DeviceStats } from './health.js';
 
@@ -86,7 +87,11 @@ export function planFleetTargets(reg: DeviceRegistry): FleetTarget[] {
  * surface — so their `skip` reason still flows through as an `unreachable` row.
  */
 export function remoteFleetTargets(planned: FleetTarget[], self: string): FleetTarget[] {
-  return planned.filter((t) => t.device.name !== self && t.skip !== 'control');
+  // Exclude self by name AND by full identity (tailscale dnsName, loopback): a
+  // device referenced by its dnsName slipped past the bare name check and got a
+  // remote version+doctor dial back to THIS box, which orphaned on timeout and
+  // piled up (RUSH-2114). `isSelfHost` matches every alias the box answers to.
+  return planned.filter((t) => t.device.name !== self && !isSelfHost(t.device.name) && t.skip !== 'control');
 }
 
 /**
@@ -254,7 +259,7 @@ export function runFleet(
       continue;
     }
     try {
-      const isSelf = opts.self !== undefined && t.device.name === opts.self;
+      const isSelf = (opts.self !== undefined && t.device.name === opts.self) || isSelfHost(t.device.name);
       const res = isSelf ? localRunner(cmd) : runner(t.device, cmd);
       const ok = res.code === 0;
       const detail = (res.stderr || res.stdout).trim().slice(0, 200);

--- a/apps/cli/src/lib/devices/self-host.test.ts
+++ b/apps/cli/src/lib/devices/self-host.test.ts
@@ -1,0 +1,66 @@
+/**
+ * isSelfHost — the self-identity check that gates `--host` dispatch and the
+ * fleet fan-out (RUSH-2114). The old check compared only machineId() (short
+ * hostname), so a target referenced by its tailscale dnsName self-SSH'd to the
+ * local box and orphaned. These tests pin the fix through the REAL device
+ * registry IO (no mocking): the box is matched by every alias it answers to, and
+ * — the safety-critical half — a genuine PEER is never matched (else `--host
+ * <peer>` would wrongly run locally).
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Redirect the device registry to a test-private temp + pin this machine's id.
+// getDevicesDir()/machineId() read AGENTS_DEVICES_DIR / AGENTS_SYNC_MACHINE_ID at
+// call time, immune to the module-cache race a plain HOME override loses.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-selfhost-test-'));
+process.env.AGENTS_DEVICES_DIR = path.join(TEST_HOME, 'devices');
+process.env.AGENTS_SYNC_MACHINE_ID = 'testbox';
+
+const SELF_DNS = 'testbox.tail1a85a1.ts.net';
+const PEER_DNS = 'yosemite-s0.tail1a85a1.ts.net';
+fs.mkdirSync(path.join(TEST_HOME, 'devices'), { recursive: true });
+fs.writeFileSync(
+  path.join(TEST_HOME, 'devices', 'registry.json'),
+  JSON.stringify({
+    testbox: { name: 'testbox', address: { via: 'tailscale', dnsName: SELF_DNS } },
+    'yosemite-s0': { name: 'yosemite-s0', address: { via: 'tailscale', dnsName: PEER_DNS } },
+  }),
+);
+
+const { isSelfHost, resetSelfHostCache } = await import('./self-host.js');
+resetSelfHostCache();
+
+describe('isSelfHost (RUSH-2114)', () => {
+  it('matches the short machine id', () => {
+    expect(isSelfHost('testbox')).toBe(true);
+  });
+
+  it('matches the tailscale dnsName — the alias that used to self-SSH', () => {
+    expect(isSelfHost(SELF_DNS)).toBe(true);
+  });
+
+  it('is case-insensitive and trailing-dot tolerant', () => {
+    expect(isSelfHost('TESTBOX.Tail1A85A1.TS.NET.')).toBe(true);
+  });
+
+  it('matches loopback names', () => {
+    expect(isSelfHost('localhost')).toBe(true);
+    expect(isSelfHost('127.0.0.1')).toBe(true);
+    expect(isSelfHost('::1')).toBe(true);
+  });
+
+  it('does NOT match a genuine peer by short name OR dnsName (would break --host to real remotes)', () => {
+    expect(isSelfHost('yosemite-s0')).toBe(false);
+    expect(isSelfHost(PEER_DNS)).toBe(false);
+  });
+
+  it('rejects empty / nullish input', () => {
+    expect(isSelfHost('')).toBe(false);
+    expect(isSelfHost('   ')).toBe(false);
+    expect(isSelfHost(undefined)).toBe(false);
+    expect(isSelfHost(null)).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/devices/self-host.ts
+++ b/apps/cli/src/lib/devices/self-host.ts
@@ -1,0 +1,64 @@
+/**
+ * "Is this hostname the local machine?" — matched against every identity the box
+ * answers to, not just its short id.
+ *
+ * The self-checks that gate `--host` dispatch and the fleet-health fan-out used to
+ * compare only against {@link machineId} (the lowercased short hostname, e.g.
+ * `zion`). A caller that referenced the box by its **tailscale MagicDNS name**
+ * (`zion.tail1a85a1.ts.net`) — which is exactly what `fleetDialTarget` and the
+ * Factory floor's `--host` probes use — slipped past the check and SSH'd to the
+ * LOCAL box over its own tailscale name. On a loaded machine that self-SSH'd
+ * `doctor --json` orphaned on timeout and piled up until the host was crushed
+ * (RUSH-2114). Matching the full identity set closes that gap at the source.
+ */
+import { machineId } from '../machine-id.js';
+import { loadDevicesSync } from './registry.js';
+
+const LOOPBACK = ['localhost', '127.0.0.1', '::1'];
+
+/** Lowercase + strip a trailing dot (FQDNs are equivalent with or without it). */
+function normalize(name: string): string {
+  return name.trim().toLowerCase().replace(/\.$/, '');
+}
+
+let cached: Set<string> | null = null;
+
+/**
+ * Every name that resolves to THIS machine: the short id, loopback, and the self
+ * device's tailscale dnsName plus its short form. Computed once per process — the
+ * self identity does not change under a running CLI — and reads the registry
+ * best-effort (an unreadable registry still leaves the short id + loopback).
+ */
+function selfAliases(): Set<string> {
+  if (cached) return cached;
+  const aliases = new Set<string>([machineId(), ...LOOPBACK]);
+  try {
+    const dns = loadDevicesSync()[machineId()]?.address?.dnsName;
+    if (dns) {
+      const d = normalize(dns);
+      aliases.add(d);
+      aliases.add(d.split('.')[0]); // the short form of the FQDN
+    }
+  } catch {
+    /* registry unreadable — the short id + loopback aliases still hold */
+  }
+  cached = aliases;
+  return cached;
+}
+
+/**
+ * True when `name` refers to the local machine. Case-insensitive and
+ * trailing-dot-tolerant. Use this everywhere a `--host`/fleet target is compared
+ * against "self" so a tailscale-name reference short-circuits to a local run
+ * instead of self-SSHing.
+ */
+export function isSelfHost(name: string | undefined | null): boolean {
+  if (!name) return false;
+  const n = normalize(name);
+  return n.length > 0 && selfAliases().has(n);
+}
+
+/** Test hook: drop the memoized alias set so a fresh registry/env is re-read. */
+export function resetSelfHostCache(): void {
+  cached = null;
+}

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -31,6 +31,7 @@ import {
 import { resolveRemoteOsSync } from './remote-os.js';
 import { machineId } from '../session/sync/config.js';
 import { loadDevices, type DeviceProfile, type DeviceRegistry } from '../devices/registry.js';
+import { isSelfHost } from '../devices/self-host.js';
 import {
   fanOutDevices,
   planFleetTargets,
@@ -511,11 +512,12 @@ export async function maybeRunOnHost(
   if (!hostName) return false;
 
   // Running against your own machine is just a local run — skip the SSH round-trip.
-  // `machineId()` is the same self-identifier the device registry and session
-  // sync use (lowercased short hostname); compare case-insensitively.
-  // Strip the routing flags from process.argv so the local command never sees
-  // an unregistered `--host`/`--device` and dies with "unknown option".
-  if (hostName.toLowerCase() === machineId()) {
+  // Match EVERY identity the box answers to (short id, loopback, tailscale
+  // dnsName), not just machineId() — a `--host <self-dnsName>` used to slip past a
+  // short-hostname-only check and self-SSH (RUSH-2114). Strip the routing flags
+  // from process.argv so the local command never sees an unregistered
+  // `--host`/`--device` and dies with "unknown option".
+  if (isSelfHost(hostName)) {
     const stripped = stripRoutingFlags(allArgs, STRIP_SPECS);
     process.argv = [process.argv[0], process.argv[1], ...stripped];
     return false;

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -386,7 +386,7 @@ export async function runFleetPassthrough(
     targets,
     async (target) => {
       const cmd = ['agents', ...forwarded];
-      const isSelf = target.device.name.toLowerCase() === self.toLowerCase();
+      const isSelf = target.device.name.toLowerCase() === self.toLowerCase() || isSelfHost(target.device.name);
       const res = isSelf ? localRunner(cmd) : runner(target.device, cmd);
       if (res.code !== 0) {
         const detail = (res.stderr || res.stdout || 'unreachable').trim().slice(0, 200);


### PR DESCRIPTION
**fix** — `--host <self>` and the fleet-health fan-out now short-circuit **every** name the local box answers to, not just its short hostname. RUSH-2114.

## The bug

A `--host` target or fleet probe that referenced this machine by its **tailscale dnsName** (`zion.tail1a85a1.ts.net`) slipped past a `hostName === machineId()` / `device.name === self` check — which only knows the short id `zion` — and SSH'd to the **local box over its own name**. On a loaded machine that self-SSH'd `agents doctor --json` orphaned on the client timeout and piled up (all PPID 1, 30–45% CPU each) until the host was crushed. Observed live on zion: load 483, 36+ orphaned `doctor --json`.

## The fix

New `isSelfHost(name)` (`src/lib/devices/self-host.ts`) matches the target against **every alias the box answers to** — short id (`machineId()`), loopback, and the self device's tailscale `dnsName` + its short form — case-insensitive, trailing-dot-tolerant, memoized, registry read best-effort. Wired into the two self-checks that compared only `machineId()`:

| Site | Before | After |
|---|---|---|
| `maybeRunOnHost` (`passthrough.ts:518`) | `hostName === machineId()` | `isSelfHost(hostName)` |
| `remoteFleetTargets` (`fleet.ts`) | `device.name !== self` | `… && !isSelfHost(device.name)` |
| `runFleet` (`fleet.ts`) | `device.name === opts.self` | `… || isSelfHost(device.name)` |

## Verification (ran it)

```
$ npx tsc --noEmit         → rc=0 (clean)
$ vitest run self-host.test → Test Files 1 passed (1) · Tests 6 passed (6)
```

The test uses the **real device registry IO** (no mocking — writes a temp registry via `AGENTS_DEVICES_DIR`) and pins both halves: the self box matches by short id / dnsName / dnsName-short-form / loopback (case + trailing-dot), **and** a genuine peer (`yosemite-s0`, its dnsName) does **not** match — so `--host <real-remote>` can never wrongly run locally. It also caught a real bug pre-merge: I first read `.tailscale.dnsName`, but the dnsName lives on `.address.dnsName` — tsc + the test flagged it.

## Scope (stated for parity)

Covers the generic `--host` passthrough + the fleet-health fan-out — the sites that compared only `machineId()`. The **`sessions --active --host` peer fan-out** (`session/remote-list.ts` `resolvePeerTarget`/`gatherRemoteList`) is a separate path with its own peer-resolution semantics (it's the resume-on-peer flow); giving it the same `isSelfHost` gate is a **follow-up**, called out here so it isn't silently skipped. The dominant orphan source (the menu-bar helper) was fixed separately in #1841.
