### PR TITLE
fix(projects): stop leaking git's 'No such remote' at the user during import

### DIFF
--- a/apps/cli/.changelog/next/projects-quiet-origin-probe.md
+++ b/apps/cli/.changelog/next/projects-quiet-origin-probe.md
@@ -1,0 +1,6 @@
+- **`agents projects import --from-factory` stops printing raw git errors.** Reading each
+  checkout's real remote is done per registry row, and a checkout with no `origin` makes git
+  write `error: No such remote 'origin'` straight to the terminal — its own stderr, which the
+  surrounding try/catch never sees. Importing 12 rows printed two of them between the progress
+  lines. The probe now discards git's stderr; an absent remote is an expected answer, not
+  something to report. Source: `apps/cli/src/commands/projects.ts`.

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -92,10 +92,24 @@ function parseContextFlag(raw: string): ProjectContext {
   return { path: raw.slice(0, i).trim(), purpose: raw.slice(i + 1).trim() };
 }
 
-/** Best-effort `owner/repo` from a repo's origin remote. */
+/**
+ * Best-effort `owner/repo` from a repo's origin remote.
+ *
+ * `stderr: 'ignore'` is load-bearing, not tidiness. A checkout with no origin
+ * makes git print `error: No such remote 'origin'` on ITS stderr, which is the
+ * terminal's — the catch below never sees it. That was invisible while this was
+ * called once from `add` inside a real repo, and became noise the moment
+ * `import --from-factory` started calling it per row: importing 12 registry
+ * rows printed two raw git errors between the progress lines. Absence of a
+ * remote is an expected answer here (`undefined`), not something to report.
+ */
 export function originSlug(cwd: string): string | undefined {
   try {
-    const url = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd, encoding: 'utf8' }).trim();
+    const url = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
     return parseOwnerRepoFromRemote(url) ?? undefined;
   } catch {
     return undefined;


### PR DESCRIPTION
**What + type:** bug fix — `agents projects import --from-factory` prints raw git errors at the user.

Found by verifying the **shipped 1.21.2 binary** rather than the worktree. This only surfaces on a real registry containing a checkout with no `origin`, which is why it survived unit tests and three review passes.

## The run, before and after

```
$ agents projects import --from-factory --all      # released 1.21.2
error: No such remote 'origin'
error: No such remote 'origin'
Imported 12 projects

$ agents projects import --from-factory --all      # this fix
Imported 12 projects
```

## Why the try/catch didn't stop it

`originSlug` shells `git remote get-url origin`. When there is no origin, **git writes that message to its own stderr, which is inherited from the terminal** — the surrounding `try/catch` only ever sees the non-zero exit, never the text, so it cannot suppress what has already been printed.

That was invisible while `originSlug` was called once from `projects add`, inside a repo the user is standing in. It became noise the moment #1858 started calling it **per registry row** to read each checkout's real remote — and a checkout without a remote is entirely normal there (one of mine is a plain directory that was never a git repo).

`stdio: ['ignore', 'pipe', 'ignore']`. An absent remote is an expected answer — `undefined` — not something to report.

## Scope

One-line behavior change plus the comment explaining why the `stderr: 'ignore'` is load-bearing rather than tidiness, so nobody removes it later. No test: reproducing it requires a checkout with no `origin` on disk, and asserting on inherited-stderr from a subprocess would test git's behavior rather than ours. The before/after above is the evidence, run against the released binary.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
