### PR TITLE
chore(release): 1.21.3

### DIFF
--- a/apps/cli/.changelog/1.21.3.md
+++ b/apps/cli/.changelog/1.21.3.md
@@ -1,3 +1,10 @@
+- **`agents projects import --from-factory` stops printing raw git errors.** Reading each
+  checkout's real remote is done per registry row, and a checkout with no `origin` makes git
+  write `error: No such remote 'origin'` straight to the terminal — its own stderr, which the
+  surrounding try/catch never sees. Importing 12 rows printed two of them between the progress
+  lines. The probe now discards git's stderr; an absent remote is an expected answer, not
+  something to report. Source: `apps/cli/src/commands/projects.ts`.
+
 - **Sessions now track browser/computer tool use and skill/plugin/slash-command
   usage, queryable with `agents sessions --skill <name>` / `--plugin <name>`.**
   `browser.navigate`, `browser.screenshot`, and a new `computer.action` event

--- a/apps/cli/.changelog/next/projects-quiet-origin-probe.md
+++ b/apps/cli/.changelog/next/projects-quiet-origin-probe.md
@@ -1,6 +1,0 @@
-- **`agents projects import --from-factory` stops printing raw git errors.** Reading each
-  checkout's real remote is done per registry row, and a checkout with no `origin` makes git
-  write `error: No such remote 'origin'` straight to the terminal — its own stderr, which the
-  surrounding try/catch never sees. Importing 12 rows printed two of them between the progress
-  lines. The probe now discards git's stderr; an absent remote is an expected answer, not
-  something to report. Source: `apps/cli/src/commands/projects.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 1.21.3
+
+- **`agents projects import --from-factory` stops printing raw git errors.** Reading each
+  checkout's real remote is done per registry row, and a checkout with no `origin` makes git
+  write `error: No such remote 'origin'` straight to the terminal — its own stderr, which the
+  surrounding try/catch never sees. Importing 12 rows printed two of them between the progress
+  lines. The probe now discards git's stderr; an absent remote is an expected answer, not
+  something to report. Source: `apps/cli/src/commands/projects.ts`.
+
+- **Sessions now track browser/computer tool use and skill/plugin/slash-command
+  usage, queryable with `agents sessions --skill <name>` / `--plugin <name>`.**
+  `browser.navigate`, `browser.screenshot`, and a new `computer.action` event
+  fire on every `agents browser`/`agents computer` action, carrying session
+  identity for free. The sessions index persists `usedBrowser`/`usedComputer`
+  (from a scoped events-log read, not a transcript re-scan) and a new
+  `session_resource_usage` table records every skill and slash-command
+  invocation with its owning plugin, source repo, and git commit — resolved
+  against `resolveResource()`/`discoverPlugins()` at scan time. The sessions
+  picker preview surfaces both as `browser`/`computer` and `Skills:` tags.
+  Source: `apps/cli/src/lib/browser/service.ts`, `apps/cli/src/commands/computer-actions.ts`,
+  `apps/cli/src/lib/session/db.ts`, `apps/cli/src/lib/session/highlights.ts`,
+  `apps/cli/src/lib/session/discover.ts`, `apps/cli/src/commands/sessions.ts`.
+- **`ResolvedResource` and `DiscoveredPlugin` carry provenance: `repoRoot` and a
+  lazily-resolved `snapshotSha`.** Every resource/plugin resolution can now
+  answer "which DotAgents repo, which commit" without an extra lookup; the git
+  shell-out is memoized per repo root and only runs when a caller actually
+  reads `snapshotSha`. Source: `apps/cli/src/lib/resources.ts`,
+  `apps/cli/src/lib/plugins.ts`, `apps/cli/src/lib/git.ts`.
+- **`SessionEvent.slashCommand` captures a typed or model-invoked slash command**
+  (both the `<command-name>` wrapper and the `SlashCommand` tool call), and
+  `agents sessions`'s perf sample for `command.end` now carries the session id
+  and agent instead of being anonymous. Source: `apps/cli/src/lib/session/prompt.ts`,
+  `apps/cli/src/lib/session/parse.ts`, `apps/cli/src/index.ts`.
+
 ## 1.21.2
 
 - **`agents trends` — resource and session analytics dashboard.** Baked recipes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phnx-labs/agents-cli",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "One CLI for all your AI coding agents - versions, config, cloud dispatch, sessions, and teams (now with first-class Grok Build CLI support)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## 1.21.3

- **`agents projects import --from-factory` stops printing raw git errors.** Reading each
  checkout's real remote is done per registry row, and a checkout with no `origin` makes git
  write `error: No such remote 'origin'` straight to the terminal — its own stderr, which the
  surrounding try/catch never sees. Importing 12 rows printed two of them between the progress
  lines. The probe now discards git's stderr; an absent remote is an expected answer, not
  something to report. Source: `apps/cli/src/commands/projects.ts`.

- **Sessions now track browser/computer tool use and skill/plugin/slash-command
  usage, queryable with `agents sessions --skill <name>` / `--plugin <name>`.**
  `browser.navigate`, `browser.screenshot`, and a new `computer.action` event
  fire on every `agents browser`/`agents computer` action, carrying session
  identity for free. The sessions index persists `usedBrowser`/`usedComputer`
  (from a scoped events-log read, not a transcript re-scan) and a new
  `session_resource_usage` table records every skill and slash-command
  invocation with its owning plugin, source repo, and git commit — resolved
  against `resolveResource()`/`discoverPlugins()` at scan time. The sessions
  picker preview surfaces both as `browser`/`computer` and `Skills:` tags.
  Source: `apps/cli/src/lib/browser/service.ts`, `apps/cli/src/commands/computer-actions.ts`,
  `apps/cli/src/lib/session/db.ts`, `apps/cli/src/lib/session/highlights.ts`,
  `apps/cli/src/lib/session/discover.ts`, `apps/cli/src/commands/sessions.ts`.
- **`ResolvedResource` and `DiscoveredPlugin` carry provenance: `repoRoot` and a
  lazily-resolved `snapshotSha`.** Every resource/plugin resolution can now
  answer "which DotAgents repo, which commit" without an extra lookup; the git
  shell-out is memoized per repo root and only runs when a caller actually
  reads `snapshotSha`. Source: `apps/cli/src/lib/resources.ts`,
  `apps/cli/src/lib/plugins.ts`, `apps/cli/src/lib/git.ts`.
- **`SessionEvent.slashCommand` captures a typed or model-invoked slash command**
  (both the `<command-name>` wrapper and the `SlashCommand` tool call), and
  `agents sessions`'s perf sample for `command.end` now carries the session id
  and agent instead of being anonymous. Source: `apps/cli/src/lib/session/prompt.ts`,
  `apps/cli/src/lib/session/parse.ts`, `apps/cli/src/index.ts`.