### PR TITLE
fix(sessions): instrument agents computer describe + completeness guard (follow-up #1864)

### DIFF
--- a/apps/cli/.changelog/next/computer-describe-usage.md
+++ b/apps/cli/.changelog/next/computer-describe-usage.md
@@ -1,0 +1,9 @@
+- **`agents computer describe` now counts toward `usedComputer`.** Every other
+  verb (`click`, `type`, `key`, `screenshot`, `run`, …) fires the
+  `computer.action` event via `emitComputerAction`; `describe` never did, so a
+  session that only ran `agents computer describe` read back
+  `usedComputer=false` — a false-negative in the sessions preview. A new
+  completeness-guard test pins every registered `agents computer` verb command
+  to a matching `emitComputerAction` call so a future verb can't ship the same
+  gap silently. Source: `apps/cli/src/commands/computer-actions.ts`,
+  `apps/cli/src/commands/computer-actions.test.ts`.

--- a/apps/cli/src/commands/computer-actions.test.ts
+++ b/apps/cli/src/commands/computer-actions.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   pickTarget,
@@ -458,6 +459,41 @@ describe('emitComputerAction — computer.action event (#11)', () => {
     const rec = query({ eventTypes: ['computer.action'] })[0];
     expect(rec.textLength).toBe(secret.length);
     expect(JSON.stringify(rec)).not.toContain(secret);
+  });
+});
+
+// A review found that `describe` (and, separately, computer.ts's `screenshot`
+// and dispatch.ts's run-loop verbs) shipped with NO emitComputerAction() call
+// at all — the daemon call succeeded but usedComputer silently read back
+// false. That bug class (a new/existing verb registered here without its
+// emitComputerAction call) has now slipped through twice. This guard reads
+// this file's own source and pins every registered `.command('<name>')` under
+// registerActionCommands to a matching `emitComputerAction('<name>', ...)`
+// call, so a future verb added (or one whose emit call is deleted/typo'd)
+// fails CI instead of silently regressing usedComputer.
+describe('registerActionCommands — every verb calls emitComputerAction (#11 completeness)', () => {
+  const SOURCE = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), 'computer-actions.ts'),
+    'utf8',
+  );
+
+  function registeredCommandNames(source: string): string[] {
+    const body = source.slice(source.indexOf('export function registerActionCommands('));
+    return [...body.matchAll(/\.command\('([^']+)'\)/g)].map((m) => m[1]);
+  }
+
+  it('finds at least the known verb set (guards against the extraction regex silently matching nothing)', () => {
+    const names = registeredCommandNames(SOURCE);
+    expect(names).toEqual(
+      expect.arrayContaining(['apps', 'describe', 'click', 'right-click', 'type', 'launch']),
+    );
+    expect(names.length).toBeGreaterThanOrEqual(14);
+  });
+
+  it('every registered verb has a matching emitComputerAction(\'<verb>\', ...) call', () => {
+    const names = registeredCommandNames(SOURCE);
+    const uninstrumented = names.filter((name) => !SOURCE.includes(`emitComputerAction('${name}',`));
+    expect(uninstrumented).toEqual([]);
   });
 });
 

--- a/apps/cli/src/commands/computer-actions.ts
+++ b/apps/cli/src/commands/computer-actions.ts
@@ -518,6 +518,7 @@ export function registerActionCommands(program: Command): void {
       const params: Record<string, unknown> = { pid };
       if (opts.depth != null) params.max_depth = opts.depth;
       const res = unwrap(await client.call('describe', params));
+      emitComputerAction('describe', pid, opts, { depth: opts.depth });
       // The tree is inherently structured — always JSON, pretty unless --json.
       console.log(JSON.stringify(opts.json ? res : res.tree ?? res, null, 2));
     });


### PR DESCRIPTION
## What + type: bugfix + regression-guard (follow-up to #1864)

Supersedes #1880, which was malformed — it was pushed from the old #1864 worktree
branch, so after #1864 was squash-merged (3e5280e9) that branch still carried
#1864's pre-squash commits, and GitHub showed a bogus 40-file/1929-line
conflicting diff with no CI. This PR is the same fix, re-applied cleanly on a
fresh branch off current `origin/main` (single commit, 3 files, 46 lines).

**Bug:** `agents computer describe` never called `emitComputerAction`, unlike
all 14 other registered verbs (click/right-click/type/type-text/key/drag/
scroll/ax-action/focus/raise/wait/get-text/launch/run). A session that only
ran `agents computer describe` read back `usedComputer=false` in the sessions
preview — a false-negative. Present in the original #11 instrumentation,
confirmed still on `origin/main` after #1864 merged.

**Fix:** add the missing `emitComputerAction('describe', pid, opts, { depth: opts.depth })`
call right after the successful `client.call('describe', ...)`, matching the
existing pattern used by every other verb.

**Regression-guard (the run-proof):** `computer-actions.test.ts` gained a
completeness test that reads the source of `registerActionCommands`, extracts
every registered `.command('<name>')`, and asserts each has a matching
`emitComputerAction('<name>', ...)` call.

Verified locally — reverting just the `emitComputerAction('describe', ...)` line
and re-running the new test:

```
 FAIL  src/commands/computer-actions.test.ts > registerActionCommands — every verb calls emitComputerAction (#11 completeness) > every registered verb has a matching emitComputerAction('<verb>', ...) call
AssertionError: expected [ 'describe' ] to deeply equal []
```

With the fix restored, the full file passes:

```
 Test Files  1 passed (1)
      Tests  56 passed (56)
```

`bash scripts/build.sh --skip-tests` compiles clean (tsc, no errors), 1200
files / 9971 KB in dist/. (The suite's full `bun run test` run locally shows 19
pre-existing failures in `src/lib/session/sync/config.test.ts`, unrelated to
this diff — leftover from the R2/CRDT session-sync retirement in #1837, not
touched here, and green on real CI for other current PRs, e.g. #1829, #1878.)

Includes a `.changelog/next/` fragment per the conflict-free changelog
convention.

No visible UI surface — this is instrumentation only (an internal event
emission), so no screenshot applies.
