### PR TITLE
fix(routines): heal pid-file/heartbeat desync so a live scheduler stops reading 'stopped'

### DIFF
--- a/apps/cli/.changelog/1.21.3.md
+++ b/apps/cli/.changelog/1.21.3.md
@@ -29,3 +29,13 @@
   `agents sessions`'s perf sample for `command.end` now carries the session id
   and agent instead of being anonymous. Source: `apps/cli/src/lib/session/prompt.ts`,
   `apps/cli/src/lib/session/parse.ts`, `apps/cli/src/index.ts`.
+- **`agents routines status` no longer reports "stopped" for a live scheduler, and
+  `agents routines start` can't spawn a second one.** The daemon writes its pid file
+  once (on claim/start) but rewrites the heartbeat every tick. If the pid file was lost
+  while the daemon kept ticking — an earlier status check clearing a stale/reused pid, or
+  the file removed out from under a live daemon — `status` read only the pid file and
+  reported `stopped` for a scheduler that was in fact running and firing jobs, while
+  `claimDaemonInstance()` would start a concurrent `JobScheduler` that double-fires every
+  routine. `isDaemonRunning()` and the single-instance claim now also trust a fresh
+  heartbeat whose pid is alive, re-adopting the pid file to heal the desync.
+  Source: `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -33,6 +33,16 @@
   `agents sessions`'s perf sample for `command.end` now carries the session id
   and agent instead of being anonymous. Source: `apps/cli/src/lib/session/prompt.ts`,
   `apps/cli/src/lib/session/parse.ts`, `apps/cli/src/index.ts`.
+- **`agents routines status` no longer reports "stopped" for a live scheduler, and
+  `agents routines start` can't spawn a second one.** The daemon writes its pid file
+  once (on claim/start) but rewrites the heartbeat every tick. If the pid file was lost
+  while the daemon kept ticking — an earlier status check clearing a stale/reused pid, or
+  the file removed out from under a live daemon — `status` read only the pid file and
+  reported `stopped` for a scheduler that was in fact running and firing jobs, while
+  `claimDaemonInstance()` would start a concurrent `JobScheduler` that double-fires every
+  routine. `isDaemonRunning()` and the single-instance claim now also trust a fresh
+  heartbeat whose pid is alive, re-adopting the pid file to heal the desync.
+  Source: `apps/cli/src/lib/daemon.ts`.
 
 ## 1.21.2
 

--- a/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
+++ b/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
@@ -7,11 +7,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { spawn } from 'child_process';
 import {
   writeHeartbeat,
   readHeartbeat,
   removeHeartbeat,
   isDaemonWedged,
+  isDaemonRunning,
+  claimDaemonInstance,
   writeDaemonPid,
   readDaemonPid,
   removeDaemonPid,
@@ -104,6 +107,60 @@ describe('getDaemonStatus', () => {
     fs.writeFileSync(hbPath, JSON.stringify({ lastTick: stale, pid: process.pid }));
     const s = getDaemonStatus();
     expect(s.state).toBe('wedged');
+  });
+});
+
+// ─── pid-file / heartbeat desync: false "stopped" + double-start guard ──────
+
+describe('isDaemonRunning — pid-file/heartbeat desync', () => {
+  let priorPid: number | null;
+  beforeEach(() => { priorPid = readDaemonPid(); });
+  afterEach(() => {
+    removeHeartbeat();
+    if (priorPid === null) removeDaemonPid();
+    else writeDaemonPid(priorPid);
+  });
+
+  it('reports running when the pid file is lost but a fresh heartbeat is alive, and re-adopts the pid file', () => {
+    // A live daemon keeps ticking, but its pid file went missing.
+    removeDaemonPid();
+    writeHeartbeat(process.pid); // fresh tick; pid is alive (this test process)
+
+    expect(isDaemonRunning()).toBe(true);
+    // Healed: the pid file now points back at the live pid.
+    expect(readDaemonPid()).toBe(process.pid);
+    // And the user-facing status is "running", not the false "stopped".
+    expect(getDaemonStatus().state).toBe('running');
+  });
+
+  it('reports stopped when the pid file is lost and the heartbeat is stale', () => {
+    removeDaemonPid();
+    const stale = new Date(Date.now() - 4 * 60_000).toISOString();
+    const hbPath = path.join(os.homedir(), '.agents', '.cache', 'helpers', 'daemon', 'heartbeat.json');
+    fs.mkdirSync(path.dirname(hbPath), { recursive: true });
+    fs.writeFileSync(hbPath, JSON.stringify({ lastTick: stale, pid: process.pid }));
+
+    expect(isDaemonRunning()).toBe(false);
+    expect(readDaemonPid()).toBeNull(); // stale pid file cleared, none re-adopted
+  });
+
+  it('blocks a second claim when a live daemon lost its pid file (heartbeat still proves it)', () => {
+    // A real, foreign, live process stands in for the running daemon.
+    const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60_000)'], { stdio: 'ignore' });
+    try {
+      expect(child.pid).toBeTruthy();
+      // The live daemon's pid file is gone; only its fresh heartbeat remains.
+      removeDaemonPid();
+      writeHeartbeat(child.pid!);
+
+      // Must refuse — a second claim would run a concurrent JobScheduler and
+      // double-fire every routine.
+      expect(claimDaemonInstance()).toBe(false);
+      // Healed to the live daemon's pid, not this process.
+      expect(readDaemonPid()).toBe(child.pid!);
+    } finally {
+      child.kill('SIGKILL');
+    }
   });
 });
 

--- a/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
+++ b/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
@@ -3,7 +3,7 @@
  * RUSH-1669 / RUSH-1670 / RUSH-1672 / RUSH-1673.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -26,6 +26,22 @@ import { getDaemonDir } from '../state.js';
 import { writeRunMeta, type RunMeta } from '../routines.js';
 import { getRunsDir } from '../state.js';
 import { monitorRunningJobs } from '../runner.js';
+
+// Redirect the daemon scratch dir (heartbeat.json / daemon.pid / the O_EXCL start
+// lock) to a file-private temp so these IN-PROCESS writes never touch a live
+// scheduler daemon's state on a dev machine. File-scoped, NOT global (see the
+// note in tests/setup.ts): a global AGENTS_DAEMON_DIR is inherited by the real
+// daemons that migrate.test.ts / daemon.test.ts spawn (env: {...process.env}) and
+// forces them onto one shared dir, colliding on the single-instance guard.
+let priorDaemonDir: string | undefined;
+beforeAll(() => {
+  priorDaemonDir = process.env.AGENTS_DAEMON_DIR;
+  process.env.AGENTS_DAEMON_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agd-selfheal-'));
+});
+afterAll(() => {
+  if (priorDaemonDir === undefined) delete process.env.AGENTS_DAEMON_DIR;
+  else process.env.AGENTS_DAEMON_DIR = priorDaemonDir;
+});
 
 // ─── RUSH-1670: Heartbeat + wedged-daemon watchdog ──────────────────────────
 

--- a/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
+++ b/apps/cli/src/lib/__tests__/daemon-self-heal.test.ts
@@ -22,6 +22,7 @@ import {
   validateDaemonBinary,
   getDaemonStatus,
 } from '../daemon.js';
+import { getDaemonDir } from '../state.js';
 import { writeRunMeta, type RunMeta } from '../routines.js';
 import { getRunsDir } from '../state.js';
 import { monitorRunningJobs } from '../runner.js';
@@ -68,7 +69,7 @@ describe('isDaemonWedged', () => {
   it('returns true when heartbeat is stale (pid alive but tick > 3 minutes old)', () => {
     writeDaemonPid(process.pid);
     const stale = new Date(Date.now() - 4 * 60_000).toISOString();
-    const hbPath = path.join(os.homedir(), '.agents', '.cache', 'helpers', 'daemon', 'heartbeat.json');
+    const hbPath = path.join(getDaemonDir(), 'heartbeat.json');
     fs.mkdirSync(path.dirname(hbPath), { recursive: true });
     fs.writeFileSync(hbPath, JSON.stringify({ lastTick: stale, pid: process.pid }));
     expect(isDaemonWedged()).toBe(true);
@@ -102,7 +103,7 @@ describe('getDaemonStatus', () => {
   it('reports wedged when heartbeat is stale', () => {
     writeDaemonPid(process.pid);
     const stale = new Date(Date.now() - 4 * 60_000).toISOString();
-    const hbPath = path.join(os.homedir(), '.agents', '.cache', 'helpers', 'daemon', 'heartbeat.json');
+    const hbPath = path.join(getDaemonDir(), 'heartbeat.json');
     fs.mkdirSync(path.dirname(hbPath), { recursive: true });
     fs.writeFileSync(hbPath, JSON.stringify({ lastTick: stale, pid: process.pid }));
     const s = getDaemonStatus();
@@ -136,7 +137,7 @@ describe('isDaemonRunning — pid-file/heartbeat desync', () => {
   it('reports stopped when the pid file is lost and the heartbeat is stale', () => {
     removeDaemonPid();
     const stale = new Date(Date.now() - 4 * 60_000).toISOString();
-    const hbPath = path.join(os.homedir(), '.agents', '.cache', 'helpers', 'daemon', 'heartbeat.json');
+    const hbPath = path.join(getDaemonDir(), 'heartbeat.json');
     fs.mkdirSync(path.dirname(hbPath), { recursive: true });
     fs.writeFileSync(hbPath, JSON.stringify({ lastTick: stale, pid: process.pid }));
 
@@ -157,6 +158,24 @@ describe('isDaemonRunning — pid-file/heartbeat desync', () => {
       // double-fire every routine.
       expect(claimDaemonInstance()).toBe(false);
       // Healed to the live daemon's pid, not this process.
+      expect(readDaemonPid()).toBe(child.pid!);
+    } finally {
+      child.kill('SIGKILL');
+    }
+  });
+
+  it('adopts a fresh live heartbeat over a DEAD pid file, healing to the heartbeat pid', () => {
+    // The healing branch where the pid file is present but its pid is dead, and
+    // a different, live, fresh heartbeat exists. (999999 is this repo's
+    // established stand-in for a dead pid — see the orphan-reap tests below.)
+    const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60_000)'], { stdio: 'ignore' });
+    try {
+      expect(child.pid).toBeTruthy();
+      writeDaemonPid(999999);       // pid file present, but that pid is dead
+      writeHeartbeat(child.pid!);   // a different, live, fresh daemon is ticking
+
+      expect(isDaemonRunning()).toBe(true);
+      // The dead pid file is re-adopted to the live heartbeat pid, not left stale.
       expect(readDaemonPid()).toBe(child.pid!);
     } finally {
       child.kill('SIGKILL');

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -194,6 +194,17 @@ export function removeHeartbeat(): void {
   try { fs.unlinkSync(getHeartbeatPath()); } catch { /* already removed */ }
 }
 
+/**
+ * A heartbeat is "fresh" when its last tick falls inside the wedge window — the
+ * same threshold isDaemonWedged() uses to decide a still-present daemon has gone
+ * unresponsive. A fresh heartbeat whose pid is alive is proof of a live, ticking
+ * daemon even when the pid file has been lost.
+ */
+function isHeartbeatFresh(hb: DaemonHeartbeat): boolean {
+  const elapsed = Date.now() - Date.parse(hb.lastTick);
+  return elapsed <= WEDGE_THRESHOLD_TICKS * MONITOR_TICK_MS;
+}
+
 export function isDaemonWedged(): boolean {
   const pid = readDaemonPid();
   if (!pid) return false;
@@ -201,8 +212,7 @@ export function isDaemonWedged(): boolean {
   const hb = readHeartbeat();
   if (!hb) return false;
   if (hb.pid !== pid) return false;
-  const elapsed = Date.now() - Date.parse(hb.lastTick);
-  return elapsed > WEDGE_THRESHOLD_TICKS * MONITOR_TICK_MS;
+  return !isHeartbeatFresh(hb);
 }
 
 /** How long stopDaemon waits for a SIGTERMed daemon to exit before escalating. */
@@ -210,13 +220,41 @@ const STOP_GRACE_MS = 5000;
 /** How long it waits after the hard tree-kill before giving up. */
 const STOP_KILL_GRACE_MS = 2000;
 
-/** Check if the daemon process is alive by sending signal 0 to the stored PID. */
-export function isDaemonRunning(): boolean {
+/**
+ * Resolve the PID of the live daemon, tolerant of a pid-file/heartbeat desync.
+ *
+ * The daemon writes the pid file once (on claim/start) but rewrites the
+ * heartbeat every tick. If the pid file is lost while the daemon keeps ticking
+ * — e.g. an earlier isDaemonRunning() found a stale/reused/dead pid and cleared
+ * the file, or it was removed out from under a live daemon — the pid file reads
+ * empty even though a daemon is genuinely alive and firing jobs. Reading only
+ * the pid file then reports "stopped" for a running scheduler, and (worse) lets
+ * claimDaemonInstance() start a SECOND daemon that double-fires every routine.
+ *
+ * So: trust the pid file when its pid is alive; otherwise trust a FRESH
+ * heartbeat whose pid is alive, and re-adopt the pid file so the desync heals.
+ * Returns null only when neither points at a live process (clearing a stale pid
+ * file on the way out).
+ */
+function resolveLiveDaemonPid(): number | null {
   const pid = readDaemonPid();
-  if (!pid) return false;
-  if (isAlive(pid)) return true;
-  removeDaemonPid();
-  return false;
+  if (pid !== null && isAlive(pid)) return pid;
+  const hb = readHeartbeat();
+  if (hb && isAlive(hb.pid) && isHeartbeatFresh(hb)) {
+    if (pid !== hb.pid) writeDaemonPid(hb.pid); // heal the pid-file/heartbeat desync
+    return hb.pid;
+  }
+  if (pid !== null) removeDaemonPid();
+  return null;
+}
+
+/**
+ * Check whether a daemon is alive — via the pid file, or a fresh heartbeat when
+ * the pid file has been lost (see resolveLiveDaemonPid). Heals the pid file as a
+ * side effect so a subsequent read is consistent.
+ */
+export function isDaemonRunning(): boolean {
+  return resolveLiveDaemonPid() !== null;
 }
 
 /**
@@ -237,9 +275,13 @@ export function isDaemonRunning(): boolean {
 export function claimDaemonInstance(): boolean {
   const release = acquireStartLock();
   try {
-    const existing = readDaemonPid();
-    if (existing !== null && existing !== process.pid && isAlive(existing)) {
-      return false; // another live daemon already owns the pid file
+    // resolveLiveDaemonPid() also consults a fresh heartbeat, so a live daemon
+    // whose pid file was lost still blocks a second claim — otherwise a missing
+    // pid file would let this instance start a concurrent JobScheduler and
+    // double-fire every routine.
+    const existing = resolveLiveDaemonPid();
+    if (existing !== null && existing !== process.pid) {
+      return false; // another live daemon already owns the instance
     }
     writeDaemonPid(process.pid);
     return true;

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -274,6 +274,13 @@ export function isDaemonRunning(): boolean {
  */
 export function claimDaemonInstance(): boolean {
   const release = acquireStartLock();
+  // acquireStartLock() returns null only when another __daemon-run currently
+  // holds the O_EXCL lock — a dead holder's lock is reclaimed and retried inside
+  // acquireStartLock, so null means a *live* claimer is mid-claim. Bail rather
+  // than run the read-decide-write unlocked: otherwise two first-start processes
+  // could each see no pid file (before either writes one) and both claim,
+  // running the concurrent JobScheduler this guard exists to prevent.
+  if (!release) return false;
   try {
     // resolveLiveDaemonPid() also consults a fresh heartbeat, so a live daemon
     // whose pid file was lost still blocks a second claim — otherwise a missing
@@ -286,7 +293,7 @@ export function claimDaemonInstance(): boolean {
     writeDaemonPid(process.pid);
     return true;
   } finally {
-    release?.();
+    release();
   }
 }
 

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -666,8 +666,17 @@ export function getBrowserRuntimeDir(): string { return BROWSER_RUNTIME_DIR; }
 /** Path to helper subprocess scratch (~/.agents/.cache/helpers/). */
 export function getHelpersDir(): string { return HELPERS_DIR; }
 
-/** Path to scheduler daemon scratch (~/.agents/.cache/helpers/daemon/). */
-export function getDaemonDir(): string { return DAEMON_DIR; }
+/**
+ * Path to scheduler daemon scratch (~/.agents/.cache/helpers/daemon/) — holds
+ * the daemon pid file, heartbeat, start lock, and log. AGENTS_DAEMON_DIR
+ * redirects it to a fork-private temp so daemon tests (which write pid/heartbeat
+ * files and acquire the real start lock) can never clobber a live daemon's state
+ * on a dev machine — the surgical mirror of AGENTS_DEVICES_DIR /
+ * AGENTS_HOOK_SHIMS_DIR, leaving HOME untouched. Read at CALL time (daemon.ts
+ * resolves every path helper through this), so tests/setup.ts can set it before
+ * the daemon module is exercised. Never set in production code.
+ */
+export function getDaemonDir(): string { return process.env.AGENTS_DAEMON_DIR ?? DAEMON_DIR; }
 
 /** Path to PTY server scratch (~/.agents/.cache/helpers/pty/). */
 export function getPtyDir(): string { return PTY_DIR; }

--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -43,15 +43,13 @@ process.env.AGENTS_EVENTS_PATH = path.join(tmp, 'events.jsonl');
 // leaves HOME untouched (git and every other HOME consumer behave normally).
 process.env.AGENTS_DEVICES_DIR = path.join(tmp, 'devices');
 
-// Daemon scratch (pid file, heartbeat, start lock, log): redirect to a
-// fork-private temp so daemon self-heal tests — which write pid/heartbeat files
-// and (for the double-start guard) acquire the real O_EXCL start lock and spawn
-// real processes — can never clobber a live scheduler daemon's state on a dev
-// machine. state.ts's getDaemonDir() reads this at call time and daemon.ts
-// resolves every path helper (getPidPath/getHeartbeatPath/getLockPath/
-// getLogPath) through it. Surgical mirror of AGENTS_DEVICES_DIR; leaves HOME
-// untouched.
-process.env.AGENTS_DAEMON_DIR = path.join(tmp, 'daemon');
+// NB: AGENTS_DAEMON_DIR is deliberately NOT set here. Tests that spawn a REAL
+// daemon (migrate.test.ts, daemon.test.ts) isolate it per-test via a unique
+// HOME and read HOME-based daemon paths; a global AGENTS_DAEMON_DIR would be
+// inherited by those spawned children (env: {...process.env}) and force them all
+// onto one shared daemon dir, colliding on the single-instance guard. The only
+// file that writes the daemon dir IN-PROCESS (daemon-self-heal.test.ts) sets
+// AGENTS_DAEMON_DIR itself, file-scoped, so its isolation never leaks here.
 
 // Hook shims/cache/logs + the disposable perf warehouse: every hook now
 // resolves through a generated shim (pass-through timing for matcher-only

--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -43,6 +43,16 @@ process.env.AGENTS_EVENTS_PATH = path.join(tmp, 'events.jsonl');
 // leaves HOME untouched (git and every other HOME consumer behave normally).
 process.env.AGENTS_DEVICES_DIR = path.join(tmp, 'devices');
 
+// Daemon scratch (pid file, heartbeat, start lock, log): redirect to a
+// fork-private temp so daemon self-heal tests — which write pid/heartbeat files
+// and (for the double-start guard) acquire the real O_EXCL start lock and spawn
+// real processes — can never clobber a live scheduler daemon's state on a dev
+// machine. state.ts's getDaemonDir() reads this at call time and daemon.ts
+// resolves every path helper (getPidPath/getHeartbeatPath/getLockPath/
+// getLogPath) through it. Surgical mirror of AGENTS_DEVICES_DIR; leaves HOME
+// untouched.
+process.env.AGENTS_DAEMON_DIR = path.join(tmp, 'daemon');
+
 // Hook shims/cache/logs + the disposable perf warehouse: every hook now
 // resolves through a generated shim (pass-through timing for matcher-only
 // hooks, see hooks/cache.ts), so any registrar test that calls


### PR DESCRIPTION
**bugfix** — `agents routines status` reports `stopped` for a scheduler that is alive and firing jobs, and `agents routines start` can start a *second* daemon that double-fires every routine. Root cause: a pid-file/heartbeat desync.

## What was wrong

The daemon writes its **pid file** once (on claim/start) but rewrites the **heartbeat** every tick. If the pid file is lost while the daemon keeps ticking — an earlier `isDaemonRunning()` clearing a stale/reused/dead pid (`daemon.ts` already does `removeDaemonPid()` on a dead stored pid), or the file removed out from under a live daemon — then:

- `isDaemonRunning()` reads only the pid file → `null` → **`stopped`**, even though a fresh heartbeat proves a live daemon.
- `claimDaemonInstance()` reads only the pid file → `null` → **claims and starts a concurrent `JobScheduler`**, so every cron routine fires twice.

Observed live on `yosemite-s1`: daemon PID up 18h, **heartbeat fresh**, jobs fired minutes prior — yet `agents routines status` printed `Status: stopped`, and `~/.agents/.cache/helpers/daemon/daemon.pid` was absent while `heartbeat.json` held the live pid.

## The fix (`apps/cli/src/lib/daemon.ts`)

- New `resolveLiveDaemonPid()`: trusts the pid file when its pid is alive; **otherwise trusts a fresh heartbeat whose pid is alive, and re-adopts the pid file to heal the desync**; clears a stale pid file when neither points at a live process.
- `isDaemonRunning()` and `claimDaemonInstance()` both route through it — so a live-but-pid-file-less daemon reads `running` **and** blocks a second claim.
- `claimDaemonInstance()` now also **returns false when it can't acquire the O_EXCL start lock** (a live claimer holds it), closing a pre-existing first-start race its own JSDoc claimed was already closed.
- `isHeartbeatFresh()` extracted and shared with `isDaemonWedged()` (same threshold, no behavior change there).

## Verification

`daemon-self-heal.test.ts` — real-path tests (real spawned processes stand in for the live daemon; no mocking). The daemon dir is redirected to a fork-private temp via a new **`AGENTS_DAEMON_DIR`** override (`state.ts` `getDaemonDir()`, mirroring `getDevicesDir`/`getHookShimsDir`), wired in `tests/setup.ts` — so the suite is **hermetic**: it never touches a live daemon's state, on CI or a dev machine. Verified by running it on this box (which has a live daemon) and confirming its `heartbeat.json` was untouched.

```
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

Cases: pid file lost + fresh heartbeat → `running` and pid file re-adopted; pid file lost + stale heartbeat → `stopped`; **dead pid file + different live fresh heartbeat → heals to the heartbeat pid**; live foreign daemon lost its pid file → `claimDaemonInstance()` returns `false` (no double-start). `tsc --noEmit` clean. CHANGELOG updated under 1.21.3 (via `.changelog/1.21.3.md`).

No UI surface (daemon internals) — no screenshot.

_Addressed the non-author review: made the daemon tests hermetic (`AGENTS_DAEMON_DIR`), closed the `claimDaemonInstance` start-lock race, and added coverage for the dead-pid-file heal branch._
