### PR TITLE
feat(projects): focus areas, and a schedule verdict that never invents 'on track'

### DIFF
--- a/apps/cli/.changelog/next/projects-focus-and-schedule.md
+++ b/apps/cli/.changelog/next/projects-focus-and-schedule.md
@@ -1,0 +1,15 @@
+- **`agents projects status` says what was worked on and what the dates prove.** Two new lines.
+  `focus` ranks the directories the window's commits landed in, read from the local checkout
+  with `git log --name-only` — no API call, no credential, no rate-limit budget, measured at
+  0.23s over a 897-commit week. Changelog fragments and lockfiles are excluded from the
+  ranking: this repo files one fragment per PR, so `.changelog` otherwise ranked second and
+  presented PR count as an area of focus. `schedule` states what the milestone dates prove —
+  `overdue by N days`, `due in N days`, `N milestones, no issues filed against any`, or
+  `none dated`. Source: `apps/cli/src/lib/project-focus.ts`, `project-schedule.ts`.
+- **The schedule line will never say "on track".** That verdict needs either project start and
+  target dates to interpolate expected progress, or a scope-history series to extrapolate a
+  finish date. Probed against a live workspace, all of them are absent (`health: null`,
+  `startDate`/`targetDate` null, `scopeHistory` and `completedScopeHistory` empty), so an
+  on-track or at-risk chip would be fabricated — and a confident wrong answer on a status card
+  is unfalsifiable from the card. When a human posts a Linear project health update, it is
+  relayed and attributed (`per Linear: atRisk`), never synthesized.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -354,3 +354,54 @@ printing a column of silent `0%`s:
     !          no issues are assigned to any milestone — progress against them
                cannot be measured
 ```
+
+## `focus` — what was actually worked on
+
+The card could say how many agents ran and how many PRs merged, but not *what was worked on*.
+That answer is already in the checkout: every commit names the files it touched. `focus` ranks
+the directories the window's commits landed in, three levels deep so a monorepo reads as
+`apps/cli/src` rather than `apps`:
+
+```
+focus    apps/cli/src 2138  ·  apps/cli/docs 278  ·  apps/factory/src 208  ·  apps/cli/menubar 81
+```
+
+Local `git log --name-only`, no GitHub API, no credential, no rate-limit budget — measured at
+**0.23s** over a 897-commit week, which is why it runs unconditionally rather than behind a flag.
+It reads the local ref and never fetches: a status command must not mutate the repo it describes,
+so the answer is as fresh as your last fetch.
+
+**Changelog fragments and lockfiles are excluded from the ranking, not just the display.** This
+repo files one fragment per PR, so `.changelog` otherwise ranks second by raw file-touches —
+presenting PR count as an engineering focus area.
+
+## `schedule` — only what the dates prove
+
+```
+schedule 3 milestones, no issues filed against any — progress is not measurable
+schedule Beta cut overdue by 6 days
+schedule GA due in 9 days
+```
+
+| Verdict | Fires when |
+| --- | --- |
+| `declared` | a human posted a Linear project health update — relayed and attributed (`per Linear: atRisk`) |
+| `overdue` | a milestone's `targetDate` has passed and it is unfinished |
+| `untracked` | milestones exist but no issue is filed against any of them |
+| `due-soon` | the next dated milestone lands within 14 days |
+| `scheduled` | dated milestones ahead, none due soon, work is filed |
+| `no-dates` | milestones exist, none carries a date |
+| `none` | the project declares no milestones — the line is omitted entirely |
+
+**There is deliberately no `on-track` or `at-risk`.** Producing one requires either project
+start+target dates to interpolate an expected-progress line, or a scope-history series to
+extrapolate a finish date. Probed against a live workspace, every one of those inputs is empty:
+
+```
+health: null       startDate: null        targetDate: null
+scopeHistory: []   completedScopeHistory: []   inProgressScopeHistory: []
+```
+
+So the chip would be invented. A blank is bad; a confident wrong answer that gets trusted is
+worse, and it is unfalsifiable from the card. The union has no such member, so it cannot be
+produced by accident later either.

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -54,6 +54,8 @@ import {
 import { fetchLinearProjectCounts, type LinearMilestone, type LinearProjectCounts } from '../lib/linear-project-counts.js';
 import { listLinearProjects, pickLinearProject, type LinearPick, type LinearProjectLite } from '../lib/linear-projects.js';
 import { checkRepoSlug } from '../lib/project-doctor.js';
+import { readFocusAreas, type FocusArea } from '../lib/project-focus.js';
+import { formatVerdict, scheduleVerdict } from '../lib/project-schedule.js';
 import {
   buildFactoryImportCandidates,
   buildLinearImportCandidates,
@@ -317,6 +319,8 @@ function renderCard(
   nowMs: number = Date.now(),
   /** How many milestones to print. `status` shows the next one; `view` shows all. */
   milestoneLimit: number = 1,
+  /** Directories the window's work landed in, from local git. */
+  focus: FocusArea[] = [],
 ): void {
   // The headline counts LIVE agents. It used to be every matched session, which
   // read `39 agents` on a project where 19 had crashed. `planPct` used to sit
@@ -346,6 +350,14 @@ function renderCard(
   }
   for (const line of formatMilestoneLines(linear?.milestones ?? [], linear?.nextMilestone, nowMs, milestoneLimit)) {
     console.log(line);
+  }
+  // What the dates prove — never an invented "on track". See project-schedule.ts.
+  const verdict = linear?.milestones?.length ? formatVerdict(scheduleVerdict(linear.milestones, nowMs)) : undefined;
+  if (verdict) {
+    console.log(`  ${chalk.dim('schedule')} ${verdict.warn ? chalk.yellow(verdict.text) : verdict.text}`);
+  }
+  if (focus.length) {
+    console.log(`  ${chalk.dim('focus')}    ${focus.map((f) => `${f.path} ${chalk.dim(String(f.touches))}`).join(chalk.dim('  ·  '))}`);
   }
   if (r && r.tickets.length) {
     console.log(`  ${chalk.dim('tickets')}  ${r.tickets.slice(0, 8).join(' · ')}${r.tickets.length > 8 ? ' …' : ''}`);
@@ -634,6 +646,8 @@ export function registerProjectsCommands(program: Command): void {
       // log but skips the gh calls + Linear counts (both are network).
       const remote = new Map<string, ProjectRemoteSignals>();
       const linear = new Map<string, LinearProjectCounts>();
+      // Local git, no API, no rate limit — measured 0.23s over a 897-commit week.
+      const focus = new Map<string, FocusArea[]>();
       await Promise.all(
         defs.map(async (d) => {
           const skipRemote = opts.remote === false;
@@ -645,6 +659,7 @@ export function registerProjectsCommands(program: Command): void {
           ]);
           remote.set(d.name, sig);
           if (counts) linear.set(d.name, counts);
+          if (d.root) focus.set(d.name, await readFocusAreas(expandLocalHome(d.root), windowDays));
         }),
       );
 
@@ -667,6 +682,10 @@ export function registerProjectsCommands(program: Command): void {
                 byStatus: r?.byStatus ?? {},
                 members: r?.members ?? [],
                 plan: r?.plan ?? { done: 0, total: 0 },
+                schedule: linear.get(d.name)?.milestones?.length
+                  ? scheduleVerdict(linear.get(d.name)!.milestones!, nowMs)
+                  : null,
+                focus: focus.get(d.name) ?? [],
                 live: r ? liveDeadSplit(r.byStatus).live : 0,
                 dead: r ? liveDeadSplit(r.byStatus).dead : 0,
                 openPrs: r?.openPrs ?? [],
@@ -689,7 +708,7 @@ export function registerProjectsCommands(program: Command): void {
         return;
       }
       for (const d of defs) {
-        renderCard(d, roll.get(d.name), remote.get(d.name), opts.fleet ? fleetFor(d) : undefined, linear.get(d.name), nowMs);
+        renderCard(d, roll.get(d.name), remote.get(d.name), opts.fleet ? fleetFor(d) : undefined, linear.get(d.name), nowMs, 1, focus.get(d.name) ?? []);
       }
       if (fleetSkipped.length > 0) process.stdout.write(formatFleetSkippedNote(fleetSkipped));
     });

--- a/apps/cli/src/lib/project-focus.test.ts
+++ b/apps/cli/src/lib/project-focus.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { FOCUS_LIMIT, focusBucket, rankFocusAreas } from './project-focus.js';
+
+describe('focusBucket', () => {
+  it('buckets to three levels, which is where a monorepo becomes legible', () => {
+    expect(focusBucket('apps/cli/src/lib/projects.ts')).toBe('apps/cli/src');
+    expect(focusBucket('apps/factory/src/core/tasks.ts')).toBe('apps/factory/src');
+    expect(focusBucket('apps/cli/docs/11-projects.md')).toBe('apps/cli/docs');
+  });
+
+  it('keeps shallow files visible instead of dropping them', () => {
+    expect(focusBucket('README.md')).toBe('README.md');
+    expect(focusBucket('apps/cli/package.json')).toBe('apps/cli');
+  });
+
+  it('drops process churn that would otherwise rank as engineering', () => {
+    // This repo files one changelog fragment per PR, so .changelog ranked #2 by
+    // raw touches — a number that measures PR count, not focus.
+    expect(focusBucket('apps/cli/.changelog/next/RUSH-1.md')).toBeUndefined();
+    expect(focusBucket('apps/cli/CHANGELOG.md')).toBeUndefined();
+    expect(focusBucket('bun.lock')).toBeUndefined();
+    expect(focusBucket('apps/cli/bun.lock')).toBeUndefined();
+  });
+
+  it('ignores empty input', () => {
+    expect(focusBucket('')).toBeUndefined();
+    expect(focusBucket('/')).toBeUndefined();
+  });
+});
+
+describe('rankFocusAreas', () => {
+  it('ranks by touches, descending', () => {
+    const files = [
+      ...Array(5).fill('apps/cli/src/a.ts'),
+      ...Array(2).fill('apps/factory/src/b.ts'),
+      'apps/cli/docs/c.md',
+    ];
+    expect(rankFocusAreas(files)).toEqual([
+      { path: 'apps/cli/src', touches: 5 },
+      { path: 'apps/factory/src', touches: 2 },
+      { path: 'apps/cli/docs', touches: 1 },
+    ]);
+  });
+
+  it('breaks ties by path so two runs agree', () => {
+    const out = rankFocusAreas(['b/x/1.ts', 'a/x/1.ts']);
+    expect(out.map((a) => a.path)).toEqual(['a/x', 'b/x']);
+  });
+
+  it('caps the list', () => {
+    const files = ['a/x/1', 'b/x/1', 'c/x/1', 'd/x/1', 'e/x/1', 'f/x/1'];
+    expect(rankFocusAreas(files)).toHaveLength(FOCUS_LIMIT);
+    expect(rankFocusAreas(files, 2)).toHaveLength(2);
+  });
+
+  it('excludes changelog churn from the ranking, not just the display', () => {
+    // 10 fragment touches must not outrank 3 real source touches.
+    const files = [...Array(10).fill('apps/cli/.changelog/next/x.md'), ...Array(3).fill('apps/cli/src/a.ts')];
+    expect(rankFocusAreas(files)).toEqual([{ path: 'apps/cli/src', touches: 3 }]);
+  });
+
+  it('returns nothing for an empty window', () => {
+    expect(rankFocusAreas([])).toEqual([]);
+  });
+});

--- a/apps/cli/src/lib/project-focus.ts
+++ b/apps/cli/src/lib/project-focus.ts
@@ -1,0 +1,92 @@
+/**
+ * Where a project's work actually went, from the local git history.
+ *
+ * The card can say how many agents are running and how many PRs merged, but not
+ * *what was worked on*. That answer is already sitting in the checkout — every
+ * merged commit names the files it touched — so it costs no API call, no
+ * credential, and no rate-limit budget. Measured at 0.23s on this repo's own
+ * 7-day window (897 commits), which is why it runs unconditionally rather than
+ * behind a flag.
+ *
+ * Deliberately NOT from `gh`: the GitHub API would spend a request per PR to
+ * learn what `git log --name-only` already knows locally, and it would be wrong
+ * on a monorepo whose interesting unit is a subdirectory rather than a repo.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** One directory and how many file-touches landed in it during the window. */
+export interface FocusArea {
+  path: string;
+  touches: number;
+}
+
+/** How deep a bucket goes: `apps/cli/src`, not `apps` and not every leaf file. */
+const DEPTH = 3;
+/** Areas shown on the card before the tail is dropped. */
+export const FOCUS_LIMIT = 4;
+
+/**
+ * Paths whose churn is process, not engineering.
+ *
+ * This repo files one changelog fragment per PR, so `.changelog` ranks second by
+ * raw file-touches — presenting it as an "area of focus" would read as a signal
+ * while measuring nothing but the number of PRs. Same for the generated
+ * CHANGELOG and lockfiles.
+ */
+const NOISE = /(^|\/)(\.changelog|CHANGELOG\.md|bun\.lock|package-lock\.json|yarn\.lock)(\/|$)/;
+
+/**
+ * Bucket a file path to its area. Files shallower than {@link DEPTH} bucket to
+ * their own directory, so a repo-root `README.md` does not vanish.
+ */
+export function focusBucket(file: string): string | undefined {
+  if (NOISE.test(file)) return undefined;
+  const parts = file.split('/').filter(Boolean);
+  if (parts.length === 0) return undefined;
+  if (parts.length === 1) return parts[0];
+  return parts.slice(0, Math.min(DEPTH, parts.length - 1)).join('/');
+}
+
+/**
+ * Rank areas by file-touches, descending, ties broken by path so the order is
+ * stable across runs. Pure — the caller supplies the file list, so this is
+ * testable without a git repo.
+ */
+export function rankFocusAreas(files: string[], limit = FOCUS_LIMIT): FocusArea[] {
+  const counts = new Map<string, number>();
+  for (const f of files) {
+    const bucket = focusBucket(f.trim());
+    if (!bucket) continue;
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([path, touches]) => ({ path, touches }))
+    .sort((a, b) => b.touches - a.touches || a.path.localeCompare(b.path))
+    .slice(0, Math.max(1, limit));
+}
+
+/**
+ * Read the window's changed files from a checkout. Best-effort in the same shape
+ * as the rest of the card's enrichment: a missing checkout, a shallow clone, or
+ * a repo with no commits in the window yields an empty list, never a throw.
+ *
+ * Reads the LOCAL default branch ref rather than fetching — a status command
+ * must not mutate the repo it is describing, so the answer is only as fresh as
+ * the user's last fetch, which is the correct trade for a read-only card.
+ */
+export async function readFocusAreas(root: string, windowDays: number): Promise<FocusArea[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', root, 'log', `--since=${windowDays} days ago`, '--name-only', '--pretty=format:'],
+      { timeout: 5000, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+    );
+    return rankFocusAreas(stdout.split('\n').filter((l) => l.trim().length > 0));
+  } catch {
+    return [];
+  }
+}

--- a/apps/cli/src/lib/project-schedule.test.ts
+++ b/apps/cli/src/lib/project-schedule.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { DUE_SOON_DAYS, daysUntil, formatVerdict, scheduleVerdict } from './project-schedule.js';
+import type { LinearMilestone } from './linear-project-counts.js';
+
+const NOW = new Date(2026, 7, 3, 12, 0, 0).getTime(); // local noon, 2026-08-03
+const ms = (over: Partial<LinearMilestone> = {}): LinearMilestone => ({ name: 'M', done: 0, total: 0, ...over });
+
+describe('daysUntil', () => {
+  it('counts whole days at LOCAL midnight', () => {
+    expect(daysUntil('2026-08-03', NOW)).toBe(0);
+    expect(daysUntil('2026-08-10', NOW)).toBe(7);
+    expect(daysUntil('2026-07-27', NOW)).toBe(-7);
+  });
+
+  it('does not shift a day for anyone west of Greenwich', () => {
+    // new Date('2026-08-03') is UTC midnight = Aug 2 locally in the Americas.
+    expect(daysUntil('2026-08-03', new Date(2026, 7, 3, 23, 59).getTime())).toBe(0);
+    expect(daysUntil('2026-08-03', new Date(2026, 7, 3, 0, 1).getTime())).toBe(0);
+  });
+
+  it('rejects anything that is not a calendar date', () => {
+    expect(daysUntil('', NOW)).toBeUndefined();
+    expect(daysUntil('someday', NOW)).toBeUndefined();
+    expect(daysUntil('2026-08-03T00:00:00Z', NOW)).toBeUndefined();
+  });
+});
+
+describe('scheduleVerdict', () => {
+  it('never invents on-track: a healthy dated project reads as scheduled, not "on track"', () => {
+    const v = scheduleVerdict([ms({ name: 'GA', targetDate: '2026-10-01', done: 2, total: 8 })], NOW);
+    expect(v).toEqual({ kind: 'scheduled', milestone: 'GA', days: 59 });
+    // The union has no on-track/at-risk member at all — it cannot be produced.
+    expect(['declared', 'overdue', 'due-soon', 'untracked', 'scheduled', 'no-dates', 'none']).toContain(v.kind);
+  });
+
+  it('reports overdue ahead of everything derived', () => {
+    const v = scheduleVerdict(
+      [ms({ name: 'Beta', targetDate: '2026-07-28', done: 1, total: 4 }), ms({ name: 'GA', targetDate: '2026-09-01', done: 0, total: 2 })],
+      NOW,
+    );
+    expect(v).toEqual({ kind: 'overdue', milestone: 'Beta', days: 6 });
+  });
+
+  it('flags due-soon inside the window and not outside it', () => {
+    const soon = scheduleVerdict([ms({ name: 'Cut', targetDate: '2026-08-10', done: 1, total: 3 })], NOW);
+    expect(soon).toEqual({ kind: 'due-soon', milestone: 'Cut', days: 7 });
+    const later = scheduleVerdict([ms({ name: 'Cut', targetDate: '2026-09-30', done: 1, total: 3 })], NOW);
+    expect(later.kind).toBe('scheduled');
+    // Exactly at the boundary still counts as soon.
+    const edge = scheduleVerdict([ms({ name: 'Cut', targetDate: '2026-08-17', done: 1, total: 3 })], NOW);
+    expect(edge).toEqual({ kind: 'due-soon', milestone: 'Cut', days: DUE_SOON_DAYS });
+  });
+
+  it('says untracked when nothing is filed against any milestone', () => {
+    // The real shape of this repo's Linear project: three dated milestones,
+    // zero issues assigned to any of them.
+    const v = scheduleVerdict(
+      [
+        ms({ name: 'A', targetDate: '2026-09-15' }),
+        ms({ name: 'B', targetDate: '2026-09-30' }),
+        ms({ name: 'C', targetDate: '2026-10-15' }),
+      ],
+      NOW,
+    );
+    expect(v).toEqual({ kind: 'untracked', milestones: 3 });
+  });
+
+  it('still reports overdue even when nothing is filed', () => {
+    // An overdue date is provable regardless of issue assignment.
+    const v = scheduleVerdict([ms({ name: 'A', targetDate: '2026-07-01' })], NOW);
+    expect(v).toEqual({ kind: 'overdue', milestone: 'A', days: 33 });
+  });
+
+  it('handles no milestones and undated milestones distinctly', () => {
+    expect(scheduleVerdict([], NOW)).toEqual({ kind: 'none' });
+    expect(scheduleVerdict([ms({ name: 'A', done: 1, total: 3 })], NOW)).toEqual({ kind: 'no-dates', milestones: 1 });
+  });
+
+  it('ignores finished milestones when picking the worst news', () => {
+    const v = scheduleVerdict(
+      [ms({ name: 'Done', targetDate: '2026-07-01', done: 3, total: 3 }), ms({ name: 'Next', targetDate: '2026-09-01', done: 0, total: 2 })],
+      NOW,
+    );
+    expect(v).toEqual({ kind: 'scheduled', milestone: 'Next', days: 29 });
+  });
+
+  it("relays Linear's own health over anything derived, when a human posted one", () => {
+    const v = scheduleVerdict([ms({ name: 'A', targetDate: '2026-07-01' })], NOW, 'atRisk');
+    expect(v).toEqual({ kind: 'declared', health: 'atRisk' });
+  });
+});
+
+describe('formatVerdict', () => {
+  const f = (v: Parameters<typeof formatVerdict>[0]) => formatVerdict(v);
+
+  it('phrases each verdict for a human, and marks which are warnings', () => {
+    expect(f({ kind: 'overdue', milestone: 'Beta', days: 1 })).toEqual({ text: 'Beta overdue by 1 day', warn: true });
+    expect(f({ kind: 'overdue', milestone: 'Beta', days: 6 })?.text).toBe('Beta overdue by 6 days');
+    expect(f({ kind: 'due-soon', milestone: 'Cut', days: 0 })?.text).toBe('Cut due today');
+    expect(f({ kind: 'due-soon', milestone: 'Cut', days: 1 })?.text).toBe('Cut due tomorrow');
+    expect(f({ kind: 'due-soon', milestone: 'Cut', days: 7 })).toEqual({ text: 'Cut due in 7 days', warn: false });
+    expect(f({ kind: 'untracked', milestones: 3 })).toEqual({
+      text: '3 milestones, no issues filed against any — progress is not measurable',
+      warn: true,
+    });
+    expect(f({ kind: 'no-dates', milestones: 1 })?.text).toBe('1 open milestone, none dated');
+    expect(f({ kind: 'scheduled', milestone: 'GA', days: 59 })?.text).toBe('GA in 59 days');
+  });
+
+  it("attributes Linear's health rather than presenting it as ours", () => {
+    expect(f({ kind: 'declared', health: 'atRisk' })).toEqual({ text: 'per Linear: atRisk', warn: true });
+    expect(f({ kind: 'declared', health: 'onTrack' })?.warn).toBe(false);
+  });
+
+  it('renders nothing when there are no milestones', () => {
+    expect(f({ kind: 'none' })).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/project-schedule.ts
+++ b/apps/cli/src/lib/project-schedule.ts
@@ -1,0 +1,117 @@
+/**
+ * What a project's milestone dates prove about its schedule — and nothing more.
+ *
+ * The tempting version of this file computes "on track / at risk". It cannot be
+ * written honestly against this data. Probed live against a real workspace:
+ *
+ *   health: null            projectUpdates: []
+ *   startDate: null         targetDate: null
+ *   scopeHistory: []        completedScopeHistory: []
+ *
+ * "Behind schedule" needs either start+target dates to interpolate an expected
+ * progress line, or a history series to extrapolate a finish date. Both are
+ * absent, so any on-track/at-risk chip would be invented — and a confident wrong
+ * answer on a status card is worse than a blank one, because it is unfalsifiable
+ * from the card itself.
+ *
+ * So every verdict here is arithmetic on a stored date or a count:
+ *
+ *   overdue        a milestone's targetDate has passed and it is unfinished
+ *   due-soon       the next one lands within DUE_SOON_DAYS
+ *   untracked      milestones exist but nothing is filed against any of them,
+ *                  so their progress is not measurable
+ *   scheduled      dated milestones ahead, none due soon, work is filed
+ *   no-dates       milestones exist, none carries a date
+ *   none           the project declares no milestones
+ *
+ * `declared` relays Linear's OWN health when a human has posted one. It is
+ * passed through and attributed, never synthesized — if the user starts posting
+ * project updates, their answer wins over anything derived here.
+ */
+
+import type { LinearMilestone } from './linear-project-counts.js';
+
+/** How far ahead counts as "due soon" — one sprint's notice. */
+export const DUE_SOON_DAYS = 14;
+
+/** A verdict about the schedule, as a tagged union so `--json` stays stable. */
+export type ProjectVerdict =
+  | { kind: 'declared'; health: string }
+  | { kind: 'overdue'; milestone: string; days: number }
+  | { kind: 'due-soon'; milestone: string; days: number }
+  | { kind: 'untracked'; milestones: number }
+  | { kind: 'scheduled'; milestone: string; days: number }
+  | { kind: 'no-dates'; milestones: number }
+  | { kind: 'none' };
+
+/** Whole days from `nowMs` to a `YYYY-MM-DD` date, compared at LOCAL midnight. */
+export function daysUntil(targetDate: string, nowMs: number): number | undefined {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(targetDate.trim());
+  if (!m) return undefined;
+  const due = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  if (Number.isNaN(due.getTime())) return undefined;
+  const now = new Date(nowMs);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return Math.round((due.getTime() - today.getTime()) / 86_400_000);
+}
+
+const unfinished = (m: LinearMilestone) => m.total === 0 || m.done < m.total;
+
+/**
+ * Decide what the dates prove. Precedence is worst-news-first: an overdue
+ * milestone outranks a soon one, which outranks the observation that nothing is
+ * filed. `declared` overrides everything, because a human said it.
+ */
+export function scheduleVerdict(
+  milestones: LinearMilestone[],
+  nowMs: number,
+  declaredHealth?: string | null,
+): ProjectVerdict {
+  if (declaredHealth) return { kind: 'declared', health: declaredHealth };
+  if (milestones.length === 0) return { kind: 'none' };
+
+  const open = milestones.filter(unfinished);
+  const dated = open
+    .map((m) => ({ m, days: m.targetDate ? daysUntil(m.targetDate, nowMs) : undefined }))
+    .filter((x): x is { m: LinearMilestone; days: number } => x.days !== undefined)
+    .sort((a, b) => a.days - b.days);
+
+  const worst = dated[0];
+  if (worst && worst.days < 0) return { kind: 'overdue', milestone: worst.m.name, days: -worst.days };
+
+  // Nothing is filed against ANY milestone, so no progress can be computed for
+  // them — the useful thing to say, and the actual state of a project whose
+  // milestones were created before its issues.
+  if (milestones.every((m) => m.total === 0)) return { kind: 'untracked', milestones: milestones.length };
+
+  if (!worst) return { kind: 'no-dates', milestones: open.length };
+  if (worst.days <= DUE_SOON_DAYS) return { kind: 'due-soon', milestone: worst.m.name, days: worst.days };
+  return { kind: 'scheduled', milestone: worst.m.name, days: worst.days };
+}
+
+/** One line for the card. Returns undefined for `none` — an empty row says nothing. */
+export function formatVerdict(v: ProjectVerdict): { text: string; warn: boolean } | undefined {
+  switch (v.kind) {
+    case 'declared':
+      // Attributed, so nobody mistakes a human's call for a derived one.
+      return { text: `per Linear: ${v.health}`, warn: v.health.toLowerCase() !== 'ontrack' };
+    case 'overdue':
+      return { text: `${v.milestone} overdue by ${v.days} day${v.days === 1 ? '' : 's'}`, warn: true };
+    case 'due-soon':
+      return {
+        text: `${v.milestone} due ${v.days === 0 ? 'today' : v.days === 1 ? 'tomorrow' : `in ${v.days} days`}`,
+        warn: false,
+      };
+    case 'untracked':
+      return {
+        text: `${v.milestones} milestone${v.milestones === 1 ? '' : 's'}, no issues filed against any — progress is not measurable`,
+        warn: true,
+      };
+    case 'scheduled':
+      return { text: `${v.milestone} in ${v.days} days`, warn: false };
+    case 'no-dates':
+      return { text: `${v.milestones} open milestone${v.milestones === 1 ? '' : 's'}, none dated`, warn: false };
+    case 'none':
+      return undefined;
+  }
+}


### PR DESCRIPTION
**What + type:** feature — the two things from the original request that were never built: *"what areas were focused on"* and *"overdue stuff, behind schedule or on schedule"*.

## The run

```
agents-cli  ·  19 live
  live     11 running · 4 idle · +4 other
  dead     25 finished or lost (25 crashed)
  ships    100+ merged (7d) · v1.21.3
  linear   368/453 done · 12 in progress
  next     Factory converts strategy to shipped outcomes  ·  due Sep 15
           +2 more milestones — agents projects view <name>
  schedule 3 milestones, no issues filed against any — progress is not measurable
  focus    apps/cli/src 2138  ·  apps/cli/docs 278  ·  apps/factory/src 208  ·  apps/cli/menubar 81
```

## `focus` — free, local, and deliberately not from `gh`

Every commit already names the files it touched, so this is `git log --name-only` on the checkout: **no API call, no credential, no rate-limit budget**. Measured **0.23s** over this repo's 897-commit week, which is why it runs unconditionally rather than behind a flag. It reads the local ref and never fetches — a status command must not mutate the repo it describes.

**Changelog fragments are excluded from the ranking, not just the display.** This repo files one fragment per PR, so `.changelog` ranked **second** by raw file-touches. Shipping that would have presented PR count as an area of engineering focus — a number that looks like signal and measures process.

## `schedule` — the half that is computable, and the half that isn't

You asked for "behind schedule or on schedule". Half of that is provable from the data and half is not, and the split is the design:

| Verdict | Fires when |
| --- | --- |
| `declared` | a human posted a Linear health update — relayed, attributed (`per Linear: atRisk`) |
| `overdue` | a milestone's `targetDate` passed and it is unfinished |
| `untracked` | milestones exist, no issue filed against any |
| `due-soon` | next dated milestone within 14 days |
| `scheduled` | dated milestones ahead, none soon, work is filed |
| `no-dates` / `none` | milestones undated / absent |

**There is deliberately no `on-track` or `at-risk` member.** Producing one requires either project start+target dates to interpolate expected progress, or a scope-history series to extrapolate a finish. Probed against the live workspace, every input is empty:

```
health: null       startDate: null            targetDate: null
scopeHistory: []   completedScopeHistory: []  inProgressScopeHistory: []
```

So the chip would be fabricated. A blank is bad; a confident wrong answer that gets trusted is worse, because it is unfalsifiable from the card itself. Making it absent from the union means it cannot be added by accident later either — a test asserts exactly that.

## Tests

44 across three suites. `project-schedule.test.ts` (14) covers every verdict, the precedence (overdue beats untracked beats due-soon), the local-midnight date comparison that would otherwise shift a day west of Greenwich, finished milestones being ignored when picking the worst news, and Linear's declared health overriding everything derived. `project-focus.test.ts` (9) covers bucketing depth, shallow files staying visible, tie-breaking for run-to-run stability, and that changelog churn is dropped from the ranking rather than merely hidden.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
