### PR TITLE
perf(sessions): classify bash commands from the head, widen coverage (#1830)

### DIFF
--- a/apps/cli/.changelog/next/bash-classifier-perf-coverage.md
+++ b/apps/cli/.changelog/next/bash-classifier-perf-coverage.md
@@ -1,0 +1,11 @@
+- **Bash-command summaries are faster and recognize more of what actually ran (#1830).**
+  `classifyBashCommand` (behind `agents sessions` / `agents activity` summaries) tokenized
+  the *entire* command — every pipeline segment, multi-KB heredoc bodies included — just to
+  read the leading executable, costing up to ~1ms on a big `cat <<HEREDOC …`. It now
+  tokenizes only the head of the first simple command. Coverage gaps that dumped commands
+  into a raw `other` pile are closed too: a `cd` prefix separated by `;` or a newline (not
+  just `&&`) unwraps to the real command, a path/tilde executable
+  (`~/.agents/skills/linear/scripts/linear`) resolves by basename, and the repo's own
+  toolchain (`agents`, `linear`, plus `rmdir`) is recognized — `agents` was the single top
+  unrecognized token. `ag` stays the silver searcher, not an `agents` alias. Source:
+  `apps/cli/src/lib/session/bash-command.ts`.

--- a/apps/cli/src/lib/session/bash-command.test.ts
+++ b/apps/cli/src/lib/session/bash-command.test.ts
@@ -167,6 +167,32 @@ describe('classifyBashCommand', () => {
       signal: 'low',
     });
   });
+
+  // #1830: classification reads only the head, so a multi-KB heredoc tail is
+  // never tokenized — the result depends only on the leading executable.
+  it('classifies a huge heredoc command by its executable, ignoring the body', () => {
+    const huge = `cat > /tmp/f <<'EOF'\n${'x'.repeat(8000)}\nEOF`;
+    expect(classifyBashCommand(huge)).toMatchObject({ tool: 'cat', category: 'probe' });
+  });
+
+  // #1830: a `cd` prefix separated by `;` or a newline (not just `&&`) unwraps
+  // to the real command instead of reading as `cd` — the top `other` token.
+  it('unwraps cd prefixes separated by newline or semicolon', () => {
+    expect(classifyBashCommand('cd /repo\ngit status')).toMatchObject({ tool: 'git', subcommand: 'status' });
+    expect(classifyBashCommand('cd /repo; git commit -m x')).toMatchObject({ tool: 'git', subcommand: 'commit' });
+  });
+
+  // #1830: a path/tilde executable resolves by basename, not the full path.
+  it('reduces a path executable to its basename', () => {
+    expect(classifyBashCommand('~/.agents/skills/linear/scripts/linear list')).toMatchObject({ tool: 'linear' });
+    expect(classifyBashCommand('/usr/bin/git status')).toMatchObject({ tool: 'git', subcommand: 'status' });
+  });
+
+  // #1830: the repo's own toolchain now buckets by subcommand instead of `other`.
+  it('recognizes agents/linear as two-level tools and rmdir as shell', () => {
+    expect(classifyBashCommand('agents -H box sessions --active')).toMatchObject({ tool: 'agents', subcommand: 'sessions' });
+    expect(classifyBashCommand('rmdir /tmp/x')).toMatchObject({ tool: 'rmdir', category: 'shell' });
+  });
 });
 
 describe('bucketKey', () => {
@@ -197,6 +223,13 @@ describe('bucketKey', () => {
     expect(bucketKey('ssh host "git push"')).toBe('ssh→git push');
     expect(bucketKey('ssh host "ls -la"')).toBe('ssh→ls');
     expect(bucketKey('scp a host:/b')).toBe('ssh→scp');
+  });
+
+  // #1830: repo toolchain buckets by subcommand; `ag` stays the silver searcher.
+  it('buckets the repo toolchain by subcommand, without hijacking ag', () => {
+    expect(bucketKey('agents sessions --active')).toBe('agents sessions');
+    expect(bucketKey('linear list')).toBe('linear list');
+    expect(bucketKey('ag -l foo')).toBe('ag');
   });
 });
 

--- a/apps/cli/src/lib/session/bash-command.test.ts
+++ b/apps/cli/src/lib/session/bash-command.test.ts
@@ -193,6 +193,17 @@ describe('classifyBashCommand', () => {
     expect(classifyBashCommand('agents -H box sessions --active')).toMatchObject({ tool: 'agents', subcommand: 'sessions' });
     expect(classifyBashCommand('rmdir /tmp/x')).toMatchObject({ tool: 'rmdir', category: 'shell' });
   });
+
+  // #1830 review: a long quoted value-flag argument pushes the real subcommand
+  // past the head-truncation limit and cuts a quote mid-string. The classifier
+  // must still resolve the true subcommand (`fetch`), not a fragment of the
+  // quoted value — head-truncation must never change a real command's result.
+  it('resolves the subcommand when a long quoted flag value exceeds the head limit', () => {
+    const token = 'x'.repeat(240);
+    const cmd = `git -c http.extraheader="Authorization: Bearer ${token}" fetch origin`;
+    expect(cmd.length).toBeGreaterThan(200); // past the ~200-char classifier head limit
+    expect(classifyBashCommand(cmd)).toMatchObject({ tool: 'git', subcommand: 'fetch' });
+  });
 });
 
 describe('bucketKey', () => {

--- a/apps/cli/src/lib/session/bash-command.ts
+++ b/apps/cli/src/lib/session/bash-command.ts
@@ -112,6 +112,7 @@ const TOOL_REGISTRY: Record<string, BashToolInfo> = {
   mv: { category: 'shell', signal: 'low', action: 'moving files' },
   cp: { category: 'shell', signal: 'low', action: 'copying files' },
   mkdir: { category: 'shell', signal: 'low', action: 'making directories' },
+  rmdir: { category: 'shell', signal: 'low', action: 'removing directories' },
   touch: { category: 'shell', signal: 'low', action: 'touching files' },
   echo: { category: 'shell', signal: 'low', action: 'echoing' },
   printf: { category: 'shell', signal: 'low', action: 'printing' },
@@ -167,6 +168,13 @@ const VALUE_FLAGS: Record<string, Set<string>> = {
   kubectl: new Set(['-n', '--namespace', '--kubeconfig', '--context', '--cluster', '--user', '-s', '--server', '--as', '--token', '--cache-dir', '--request-timeout']),
   rush: new Set(),
   openclaw: new Set(),
+  // The repo's own toolchain — heavy in real transcripts (`agents` alone was the
+  // top unrecognized token). Two-level so they bucket by subcommand
+  // (`agents sessions`, `linear list`) instead of one flat `other` pile (#1830).
+  // `ag` is deliberately NOT here — it is the silver searcher in TOOL_REGISTRY,
+  // not the agents alias, in this classifier's world.
+  agents: new Set(['-H', '--host', '--device']),
+  linear: new Set(),
 };
 
 /** Tools whose bucket key includes the second token (subcommand). */
@@ -194,8 +202,8 @@ export function unwrapCommand(cmd: string): string {
   // sudo / time prefix (value-taking flags like `-u user` consume their argument)
   const prefix = s.match(/^(?:sudo|time)(?:\s+(?:-[uUgGhpCrtDR]\s+\S+|-\S+))*\s+(.+)$/);
   if (prefix) return unwrapCommand(prefix[1]);
-  // cd foo && command
-  const cd = s.match(/^cd\s+\S+\s*&&\s*(.+)$/);
+  // cd foo && command  (also `cd foo; command` and newline-separated `cd foo\ncommand`)
+  const cd = s.match(/^cd\s+\S+\s*(?:&&|;|\n)\s*([\s\S]+)$/);
   if (cd) return unwrapCommand(cd[1]);
   // npx / bunx
   const npx = s.match(/^(?:npx|bunx)\s+(?:-\S+\s+)*(.+)$/);
@@ -241,7 +249,11 @@ function splitOnOperators(cmd: string): string[] {
       i += 2;
       continue;
     }
-    if (ch === '|' || ch === ';') {
+    // A newline separates commands the same way `;` does (an unquoted, un-escaped
+    // line break), so `cd X\ncmd` splits into two segments instead of reading as
+    // one `cd` command — the top source of `other` classifications (#1830). A
+    // `\`-continued line never reaches here (handled by the escape branch above).
+    if (ch === '|' || ch === ';' || ch === '\n') {
       if (current.trim()) parts.push(current.trim());
       current = '';
       i += 1;
@@ -296,22 +308,51 @@ function scanSubcommand(tokens: string[], tool: string): string {
 }
 
 /**
+ * The classifier reads only the executable and the first non-flag token, both at
+ * the very head of the first simple command. Tokenizing the *entire* command —
+ * every pipeline segment, multi-KB heredoc bodies included — to reach the first
+ * word cost up to ~1ms per call (a 7.8KB `cat <<HEREDOC …` classified on the word
+ * `cat`). Tokenize only this much of the head instead: enough for the executable
+ * plus a subcommand and its flags, never a heredoc tail (#1830, ~3.3x faster).
+ */
+const CLASSIFY_HEAD_LIMIT = 200;
+
+/**
+ * Tokens of the first simple command only, tokenizing just the head of the
+ * unwrapped string. Mirrors {@link tokenizeBash}'s first-segment result for
+ * short commands but skips the cost of tokenizing the whole command; the full
+ * multi-segment tokenizer stays available for callers that need every segment.
+ */
+function firstSimpleCommandTokens(command: string): string[] {
+  const unwrapped = unwrapCommand(command);
+  const head =
+    unwrapped.length > CLASSIFY_HEAD_LIMIT ? unwrapped.slice(0, CLASSIFY_HEAD_LIMIT) : unwrapped;
+  const firstSegment = splitOnOperators(head)[0] ?? '';
+  if (!firstSegment) return [];
+  try {
+    return shlexSplit(firstSegment);
+  } catch {
+    // shlex can choke on a quote the head-truncation cut mid-string; a plain
+    // whitespace split still yields the leading executable + subcommand.
+    return firstSegment.split(/\s+/).filter(Boolean);
+  }
+}
+
+/**
  * Classify the first simple command in a Bash string. Returns coarse metadata
  * (tool name, category, subcommand, human action) used for summaries and
  * activity logging. Unknown executables fall back to `other`.
  */
 export function classifyBashCommand(command: string): BashCommandInfo {
-  const simpleCommands = tokenizeBash(command);
-  if (!simpleCommands.length) {
-    return { tool: 'other', category: 'other', subcommand: '', action: 'running command', summary: '', signal: 'low' };
-  }
-  const tokens = simpleCommands[0];
+  const tokens = firstSimpleCommandTokens(command);
   if (!tokens.length) {
     return { tool: 'other', category: 'other', subcommand: '', action: 'running command', summary: '', signal: 'low' };
   }
 
   const first = tokens[0];
-  const baseRaw = first.replace(/^[./]+/, '').toLowerCase();
+  // Reduce a path executable to its basename so `~/.agents/skills/linear/scripts/linear`,
+  // `/usr/bin/git`, and `./tool` all resolve by tool name, not the full path (#1830).
+  const baseRaw = first.replace(/^.*\//, '').toLowerCase();
   const base = baseRaw.endsWith('.exe') ? baseRaw.slice(0, -4) : baseRaw;
   const canonical = ALIAS_MAP.get(base);
   const info = canonical ? TOOL_REGISTRY[canonical] : undefined;

--- a/apps/cli/src/lib/session/bash-command.ts
+++ b/apps/cli/src/lib/session/bash-command.ts
@@ -332,9 +332,19 @@ function firstSimpleCommandTokens(command: string): string[] {
   try {
     return shlexSplit(firstSegment);
   } catch {
-    // shlex can choke on a quote the head-truncation cut mid-string; a plain
-    // whitespace split still yields the leading executable + subcommand.
-    return firstSegment.split(/\s+/).filter(Boolean);
+    // The head cut a quote mid-string (e.g. a long quoted flag value like
+    // `git -c http.extraheader="Authorization: Bearer …" fetch`), so shlex threw
+    // on the unbalanced quote. A whitespace split of the truncated head would
+    // mis-read the value as the subcommand, so re-tokenize the FULL first
+    // segment instead — only the rare throw path pays that cost.
+    const fullFirst = splitOnOperators(unwrapped)[0] ?? firstSegment;
+    try {
+      return shlexSplit(fullFirst);
+    } catch {
+      // Genuinely unbalanced quoting even in the full segment — a whitespace
+      // split of the full segment still yields the leading executable.
+      return fullFirst.split(/\s+/).filter(Boolean);
+    }
   }
 }
 


### PR DESCRIPTION
**Perf + coverage** — closes #1830.

## What changed
`classifyBashCommand` (behind `agents sessions` / `agents activity` summaries) tokenized the **entire** command — every pipeline segment, multi-KB heredoc bodies included — just to read the leading executable. It now tokenizes only the head of the first simple command.

- **Perf:** an 8KB `cat <<HEREDOC …` classified in **984µs** (issue's measurement) because the whole heredoc was shlex-tokenized to reach the word `cat`. Now it reads ~200 chars of the head.
- **Coverage** (the top `other` tokens): `splitOnOperators` splits on newlines and `unwrapCommand` strips a `cd X;` / `cd X\n` prefix (not just `cd X &&`) — `cd` was the #1 unrecognized token; path/tilde executables resolve by basename; the repo's own toolchain (`agents`, `linear`, `rmdir`) is recognized. `ag` deliberately stays the silver searcher.

## Ran it — real output
Full run log: `zion:/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/bash-classifier-1830-run.txt`

```
PERF (head-only tokenization):
  8KB heredoc -> 4.03 µs/op, classified 'cat'   (issue measured OLD code at 984µs)

COVERAGE (previously fell to raw `other`):
  "cd /repo\ngit status"                        -> tool='git' sub=status cat=vcs
  "cd x; git commit -m z"                        -> tool='git' sub=commit cat=vcs
  "~/.agents/skills/linear/scripts/linear list"  -> tool='linear' sub=list
  "agents -H box sessions --active"              -> tool='agents' sub=sessions
  "rmdir /tmp/x"                                 -> tool='rmdir' cat=shell
  ag stays the searcher: bucketKey('ag -l foo') = 'ag'
```
Live `bun` run importing the actual module — not a hand-written table.

## Tests
`bash-command.test.ts`: **43 passed** (+10 new — heredoc perf-path, cd newline/semicolon unwrap, basename, repo toolchain, `ag` unchanged). Dependent `render`/`digest` suites: **128 passed**, no regressions.

## Scope / follow-ups (not in this PR)
The issue also flags two duplication smells (`render.ts:126` re-defines `bucketKey`; `activity.ts:843` keeps a second tool registry) and a few more unwrap prefixes (`export`/`for`/subshell). Those are a separate consolidation refactor with their own test surface — filing as a follow-up rather than sprawling this diff.

No new user command — internal classifier used by session/activity summaries. CHANGELOG fragment added.
