### PR TITLE
fix(projects): an approaching deadline must outrank 'nothing is filed'

### DIFF
--- a/apps/cli/src/lib/project-schedule.test.ts
+++ b/apps/cli/src/lib/project-schedule.test.ts
@@ -51,6 +51,27 @@ describe('scheduleVerdict', () => {
     expect(edge).toEqual({ kind: 'due-soon', milestone: 'Cut', days: DUE_SOON_DAYS });
   });
 
+  it('does NOT let untracked hide an approaching deadline', () => {
+    // A milestone due in 2 days with nothing filed against it reported
+    // "untracked" and buried the date. A deadline moves; "nothing is filed"
+    // will still be true tomorrow, so the date wins.
+    const v = scheduleVerdict(
+      [ms({ name: 'Beta', targetDate: '2026-08-05' }), ms({ name: 'Alpha', targetDate: '2026-08-10' })],
+      NOW,
+    );
+    expect(v).toEqual({ kind: 'due-soon', milestone: 'Beta', days: 2 });
+  });
+
+  it('a completed milestone means the project is not untracked', () => {
+    // Completed implies issues exist, so "no issues filed against any" is false.
+    const v = scheduleVerdict(
+      [ms({ name: 'Done', targetDate: '2026-07-01', done: 2, total: 2 }), ms({ name: 'Far', targetDate: '2026-12-01' })],
+      NOW,
+    );
+    expect(v.kind).not.toBe('untracked');
+    expect(v).toEqual({ kind: 'scheduled', milestone: 'Far', days: 120 });
+  });
+
   it('says untracked when nothing is filed against any milestone', () => {
     // The real shape of this repo's Linear project: three dated milestones,
     // zero issues assigned to any of them.

--- a/apps/cli/src/lib/project-schedule.ts
+++ b/apps/cli/src/lib/project-schedule.ts
@@ -58,9 +58,13 @@ export function daysUntil(targetDate: string, nowMs: number): number | undefined
 const unfinished = (m: LinearMilestone) => m.total === 0 || m.done < m.total;
 
 /**
- * Decide what the dates prove. Precedence is worst-news-first: an overdue
- * milestone outranks a soon one, which outranks the observation that nothing is
- * filed. `declared` overrides everything, because a human said it.
+ * Decide what the dates prove. Precedence is time-sensitivity first:
+ *
+ *   declared > overdue > due-soon > untracked > no-dates > scheduled
+ *
+ * An overdue milestone outranks an approaching one, and both outrank the
+ * observation that nothing is filed — a deadline moves, that observation does
+ * not. `declared` overrides everything, because a human said it.
  */
 export function scheduleVerdict(
   milestones: LinearMilestone[],
@@ -79,13 +83,20 @@ export function scheduleVerdict(
   const worst = dated[0];
   if (worst && worst.days < 0) return { kind: 'overdue', milestone: worst.m.name, days: -worst.days };
 
+  // A date bearing down is time-sensitive; "nothing is filed" is a standing
+  // condition that will still be true tomorrow. So an approaching deadline is
+  // reported even when the milestone has no issues against it — reversing these
+  // hid a milestone due in two days behind "3 milestones, no issues filed".
+  if (worst && worst.days <= DUE_SOON_DAYS) return { kind: 'due-soon', milestone: worst.m.name, days: worst.days };
+
   // Nothing is filed against ANY milestone, so no progress can be computed for
   // them — the useful thing to say, and the actual state of a project whose
-  // milestones were created before its issues.
+  // milestones were created before its issues. Checked against the full list,
+  // not just the open ones: a COMPLETED milestone necessarily has issues, so a
+  // project with one cannot honestly be called untracked.
   if (milestones.every((m) => m.total === 0)) return { kind: 'untracked', milestones: milestones.length };
 
   if (!worst) return { kind: 'no-dates', milestones: open.length };
-  if (worst.days <= DUE_SOON_DAYS) return { kind: 'due-soon', milestone: worst.m.name, days: worst.days };
   return { kind: 'scheduled', milestone: worst.m.name, days: worst.days };
 }
 


### PR DESCRIPTION
**What + type:** bug fix — a milestone due in two days is reported as "no issues filed", hiding the deadline.

This fix was written for #1887 but **lost to a race**: my push and the merge watcher landed within seconds of each other, and the merge took the pre-fix head. `origin/main` currently carries the buggy ordering, so this re-lands it.

## The defect

`project-schedule.ts` documented `overdue > due-soon > untracked` and implemented `overdue > untracked > due-soon`. Reproduced against the merged code:

```
scheduleVerdict([Beta 2026-08-05 (0/0), Alpha 2026-08-10 (0/0)], now = 2026-08-03)
  main -> { kind: "untracked", milestones: 2 }
  fix  -> { kind: "due-soon",  milestone: "Beta", days: 2 }
```

Return order in the merged `scheduleVerdict`:

```
['declared', 'none', 'overdue', 'untracked', 'no-dates', 'due-soon', 'scheduled']
                                 ^^^^^^^^^ runs first, so due-soon is unreachable
                                           whenever no issues are filed
```

**A deadline is time-sensitive; "nothing is filed" is a standing condition that will still be true tomorrow.** So the date wins, which is what the docstring always claimed.

## Latent on this workspace

The live card is unchanged — this repo's milestones are 43+ days out, so `untracked` was already the correct verdict:

```
schedule 3 milestones, no issues filed against any — progress is not measurable
```

It would have surfaced the first time a milestone came within 14 days without issues attached, which is exactly when someone needs the warning.

## Also pinned

A **completed** milestone means the project is not `untracked` — completed implies issues exist. That is why the check reads the full milestone list rather than only the open ones, which is now stated in the code and covered by a test.

16 tests in the suite.

## The second review finding, declined

`focusBucket` not normalizing `..` segments: not changing it. `git log --name-only` emits repo-relative normalized paths — `..` cannot appear. Adding normalization would be defensive code for impossible input, which this repo's conventions call a fallback band-aid. The input contract is stated in the docstring.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
