### PR TITLE
fix(teams): base local worktrees on fetched origin/default, not HEAD

### DIFF
--- a/apps/cli/.changelog/next/teams-worktree-fresh-base.md
+++ b/apps/cli/.changelog/next/teams-worktree-fresh-base.md
@@ -1,0 +1,8 @@
+- **Local team worktrees base on freshly-fetched `origin/<default>`, not `HEAD`.**
+  `createWorktree` (and `agents worktree provision` for new branches) now
+  `git fetch origin` then `worktree add -b … origin/<default>`, matching
+  `createRemoteWorktree`. Previously local teammates forked from the
+  orchestrator's current `HEAD`, so a stale checkout made every teammate write
+  on old code and only surface the conflict at merge. Source:
+  `apps/cli/src/lib/teams/worktree.ts`, `apps/cli/src/commands/worktree.ts`,
+  `apps/cli/docs/teams.md`.

--- a/apps/cli/docs/teams.md
+++ b/apps/cli/docs/teams.md
@@ -266,8 +266,8 @@ which case the worktree is kept and reported.
 
 | Teammate | Base of the new worktree branch |
 |---|---|
-| **local** (no `--device`) | your **current local `HEAD`** — no fetch is run first (`createWorktree`). Sync the checkout (`git fetch && git merge --ff-only origin/<default>`) **before** `add`, or every teammate forks off stale code. |
-| **remote** (`--device host`) | the host's **freshly-fetched `origin/<default>`** (`createRemoteWorktree` fetches first) — no manual sync needed. |
+| **local** (no `--device`) | the **freshly-fetched `origin/<default>`** (`createWorktree` runs `git fetch origin` then bases the branch on `origin/<default>` — never local `HEAD`). |
+| **remote** (`--device host`) | the host's **freshly-fetched `origin/<default>`** (`createRemoteWorktree` fetches first) — same base policy as local. |
 
 So the pre-flight for a **local** worktree team is: fast-forward your checkout to
 the default branch first. A remote team handles this itself.

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -11,9 +11,9 @@
  *   agents worktree prune                     -> removes every clean+merged one
  *
  * Worktrees live at <repo>/.agents/worktrees/<terminal-id>, on a branch
- * named agents/<terminal-id>. The branch starts at HEAD of the parent repo.
- * This matches the agent-system rule that keeps all coding-agent worktrees
- * under the repo-local .agents/ state directory.
+ * named agents/<terminal-id>. New branches start at the freshly-fetched
+ * origin/<default> (not local HEAD), matching lib/teams/worktree.ts and the
+ * agent-system rule that keeps coding-agent worktrees under .agents/.
  */
 import type { Command } from 'commander';
 import chalk from 'chalk';
@@ -106,6 +106,27 @@ async function inspect(root: string, terminalId: string): Promise<SafetyReport> 
   return { exists, dirty, aheadOfUpstream, hasUpstream, branchMerged };
 }
 
+/** Resolve origin/HEAD → default branch name; falls back to `main`. */
+async function defaultBranch(root: string): Promise<string> {
+  try {
+    await execFileAsync('git', ['remote', 'set-head', 'origin', '--auto'], { cwd: root });
+  } catch {
+    // offline / no origin
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+      { cwd: root },
+    );
+    const base = stdout.trim().replace(/^origin\//, '');
+    if (base) return base;
+  } catch {
+    // no origin/HEAD
+  }
+  return 'main';
+}
+
 async function provision(root: string, terminalId: string): Promise<string> {
   const wt = worktreePathFor(root, terminalId);
   const branch = branchNameFor(terminalId);
@@ -125,11 +146,28 @@ async function provision(root: string, terminalId: string): Promise<string> {
     branchExists = false;
   }
 
-  const args = branchExists
-    ? ['worktree', 'add', wt, branch]
-    : ['worktree', 'add', '-b', branch, wt, 'HEAD'];
+  if (branchExists) {
+    await execFileAsync('git', ['worktree', 'add', wt, branch], { cwd: root });
+    return wt;
+  }
 
-  await execFileAsync('git', args, { cwd: root });
+  // New branch: fetch + base on origin/<default>, never local HEAD (stale trap).
+  const base = await defaultBranch(root);
+  try {
+    await execFileAsync('git', ['fetch', 'origin'], { cwd: root });
+  } catch (err: any) {
+    const detail = (err?.stderr || err?.message || String(err)).toString().trim();
+    die(
+      `git fetch origin failed in ${root}` +
+        (detail ? `: ${detail}` : '') +
+        `. Cannot provision a worktree from a stale remote-tracking ref.`,
+    );
+  }
+  await execFileAsync(
+    'git',
+    ['worktree', 'add', '-b', branch, wt, `origin/${base}`],
+    { cwd: root },
+  );
   return wt;
 }
 

--- a/apps/cli/src/lib/teams/remoteWorktree.ts
+++ b/apps/cli/src/lib/teams/remoteWorktree.ts
@@ -96,10 +96,9 @@ export function remoteDefaultBranch(target: string, repoPath: string): string {
  * Create a worktree on the host for a teammate, branched off the freshly-fetched
  * default branch. Returns the absolute worktree path on the host.
  *
- * Mirrors local `createWorktree`, with two deliberate differences: it fetches
- * origin first (the orchestrator can't reach into the host's tree to do it), and
- * it bases the branch on `origin/<default>` rather than local `HEAD` so a stale
- * checkout on the host can't fork the teammate off old code.
+ * Same base policy as local `createWorktree`: fetch origin, then
+ * `worktree add -b … origin/<default>` so a stale checkout can't fork the
+ * teammate off old code.
  */
 export function createRemoteWorktree(target: string, repoPath: string, worktreeName: string): string {
   assertValidSshTarget(target);

--- a/apps/cli/src/lib/teams/worktree.test.ts
+++ b/apps/cli/src/lib/teams/worktree.test.ts
@@ -1,0 +1,113 @@
+/**
+ * createWorktree must base the new branch on freshly-fetched origin/<default>,
+ * never local HEAD — the failure mode that made every teammate inherit a stale
+ * orchestrator checkout and only discover it at merge time.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createWorktree, localDefaultBranch, removeWorktree } from './worktree.js';
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', ['-c', 'user.email=t@t.dev', '-c', 'user.name=t', ...args], {
+    cwd,
+    encoding: 'utf8',
+  }).trim();
+}
+
+describe('createWorktree base freshness', () => {
+  let tmp: string;
+  let bare: string;
+  let clone: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-wt-'));
+    bare = path.join(tmp, 'remote.git');
+    clone = path.join(tmp, 'clone');
+
+    // Bare origin + seed clone that pushes commit A as main.
+    git(tmp, ['init', '--bare', bare]);
+    const seed = path.join(tmp, 'seed');
+    git(tmp, ['clone', bare, seed]);
+    git(seed, ['checkout', '-b', 'main']);
+    fs.writeFileSync(path.join(seed, 'base.txt'), 'A\n');
+    git(seed, ['add', 'base.txt']);
+    git(seed, ['commit', '-m', 'A']);
+    git(seed, ['push', '-u', 'origin', 'main']);
+    // origin/HEAD → main
+    git(bare, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+
+    git(tmp, ['clone', bare, clone]);
+    // Make sure origin/HEAD is set on the clone.
+    try {
+      git(clone, ['remote', 'set-head', 'origin', '--auto']);
+    } catch {
+      // some git versions need the bare HEAD already set (done above)
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('localDefaultBranch resolves origin/HEAD to main', async () => {
+    expect(await localDefaultBranch(clone)).toBe('main');
+  });
+
+  it('bases the worktree on origin/main, not a diverged local HEAD', async () => {
+    const originMain = git(clone, ['rev-parse', 'origin/main']);
+
+    // Local-only commit B on main — HEAD is ahead of origin/main.
+    fs.writeFileSync(path.join(clone, 'local-only.txt'), 'B\n');
+    git(clone, ['add', 'local-only.txt']);
+    git(clone, ['commit', '-m', 'B-local-only']);
+    const localHead = git(clone, ['rev-parse', 'HEAD']);
+    expect(localHead).not.toBe(originMain);
+
+    const wt = await createWorktree(clone, 'teammate-a');
+    try {
+      const wtHead = git(wt, ['rev-parse', 'HEAD']);
+      // Must match origin/main (A), not the diverged local HEAD (B).
+      expect(wtHead).toBe(originMain);
+      expect(wtHead).not.toBe(localHead);
+      expect(fs.existsSync(path.join(wt, 'local-only.txt'))).toBe(false);
+      expect(fs.existsSync(path.join(wt, 'base.txt'))).toBe(true);
+
+      const branch = git(wt, ['rev-parse', '--abbrev-ref', 'HEAD']);
+      expect(branch).toBe('agents/teammate-a');
+    } finally {
+      await removeWorktree(clone, 'teammate-a');
+    }
+  });
+
+  it('picks up commits that landed on origin after the local clone went stale', async () => {
+    // Advance origin/main with a second seed push (simulates teammates
+    // spinning up after main moved on the remote).
+    const seed2 = path.join(tmp, 'seed2');
+    git(tmp, ['clone', bare, seed2]);
+    fs.writeFileSync(path.join(seed2, 'newer.txt'), 'fresh\n');
+    git(seed2, ['add', 'newer.txt']);
+    git(seed2, ['commit', '-m', 'C-on-origin']);
+    git(seed2, ['push', 'origin', 'main']);
+    const originAfter = git(seed2, ['rev-parse', 'HEAD']);
+
+    // clone's origin/main is still pre-C until createWorktree fetches.
+    const staleOrigin = git(clone, ['rev-parse', 'origin/main']);
+    expect(staleOrigin).not.toBe(originAfter);
+
+    const wt = await createWorktree(clone, 'teammate-b');
+    try {
+      const wtHead = git(wt, ['rev-parse', 'HEAD']);
+      expect(wtHead).toBe(originAfter);
+      expect(fs.existsSync(path.join(wt, 'newer.txt'))).toBe(true);
+    } finally {
+      await removeWorktree(clone, 'teammate-b');
+    }
+  });
+
+  it('rejects invalid worktree names', async () => {
+    await expect(createWorktree(clone, '../evil')).rejects.toThrow(/Invalid worktree name/);
+  });
+});

--- a/apps/cli/src/lib/teams/worktree.ts
+++ b/apps/cli/src/lib/teams/worktree.ts
@@ -84,7 +84,36 @@ export async function gitDiff(
 }
 
 /**
- * Create a new git worktree for a teammate.
+ * Resolve the repo's default branch name (origin/HEAD → `main`/`master`/…).
+ * Refreshes origin/HEAD first so a repo cloned before the default was set resolves.
+ * Falls back to `main` when origin/HEAD isn't set.
+ */
+export async function localDefaultBranch(gitRoot: string): Promise<string> {
+  try {
+    await execFileAsync('git', ['remote', 'set-head', 'origin', '--auto'], { cwd: gitRoot });
+  } catch {
+    // Offline / no origin — fall through to symbolic-ref or main.
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+      { cwd: gitRoot },
+    );
+    const base = stdout.trim().replace(/^origin\//, '');
+    if (base) return base;
+  } catch {
+    // no origin/HEAD
+  }
+  return 'main';
+}
+
+/**
+ * Create a new git worktree for a teammate, branched off the freshly-fetched
+ * default branch. Fetches `origin` first and bases the branch on
+ * `origin/<default>` so a stale local checkout cannot fork teammates off old
+ * code. Matches `createRemoteWorktree` — local and remote isolation share one
+ * base policy.
  *
  * @param repoDir - Directory inside the git repository
  * @param worktreeName - Name for the worktree (used in path and branch)
@@ -97,11 +126,29 @@ export async function createWorktree(repoDir: string, worktreeName: string): Pro
   const gitRoot = await getGitRoot(repoDir);
   const worktreePath = safeJoin(path.join(gitRoot, '.agents', 'worktrees'), worktreeName);
   const branchName = `agents/${worktreeName}`;
+  const base = await localDefaultBranch(gitRoot);
 
   await fs.mkdir(path.dirname(worktreePath), { recursive: true });
-  await execFileAsync('git', ['worktree', 'add', '-b', branchName, worktreePath, 'HEAD'], {
-    cwd: gitRoot,
-  });
+
+  // Fetch first so origin/<default> is current. Fail loud on network errors —
+  // silent fallback to HEAD is how swarms write on a days-stale base and only
+  // discover it at merge time.
+  try {
+    await execFileAsync('git', ['fetch', 'origin'], { cwd: gitRoot });
+  } catch (err: any) {
+    const detail = (err?.stderr || err?.message || String(err)).toString().trim();
+    throw new Error(
+      `createWorktree: git fetch origin failed in ${gitRoot}` +
+        (detail ? `: ${detail}` : '') +
+        `. Cannot base a teammate worktree on a stale remote-tracking ref.`,
+    );
+  }
+
+  await execFileAsync(
+    'git',
+    ['worktree', 'add', '-b', branchName, worktreePath, `origin/${base}`],
+    { cwd: gitRoot },
+  );
 
   return worktreePath;
 }


### PR DESCRIPTION
## Summary

Local team worktrees no longer fork from the orchestrator's `HEAD`.

**Before:** `createWorktree` ran `git worktree add -b … HEAD`, so every teammate inherited a stale local checkout. Remote teammates already fetched + based on `origin/<default>` — local was the gap.

**After:** `createWorktree` (and `agents worktree provision` for new branches) runs `git fetch origin` then bases on `origin/<default>`, matching `createRemoteWorktree`.

Also updates `apps/cli/docs/teams.md`, which previously documented the HEAD trap as expected behavior.

## Run result (no UI surface — unit tests)

```
$ bun run test -- src/lib/teams/worktree.test.ts
 ✓ src/lib/teams/worktree.test.ts (4 tests) 359ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Coverage:
- bases on `origin/main`, not a diverged local HEAD
- picks up commits that landed on origin after the clone went stale
- rejects invalid worktree names
- `localDefaultBranch` resolves origin/HEAD

## Files

- `apps/cli/src/lib/teams/worktree.ts` — fetch + origin base
- `apps/cli/src/lib/teams/worktree.test.ts` — new
- `apps/cli/src/commands/worktree.ts` — same for provision
- `apps/cli/src/lib/teams/remoteWorktree.ts` — comment alignment
- `apps/cli/docs/teams.md` — local/remote base policy table
- `apps/cli/.changelog/next/teams-worktree-fresh-base.md`

## Related

Companion system-repo PR: hardens `main-branch-guard` so agent-shell `worktree add -b origin/*` also requires a recent fetch (age gate).