### PR TITLE
fix(sessions): stabilize macOS ledger tests and concurrent opens

### DIFF
--- a/apps/cli/src/lib/session/__tests__/codex-incremental-scan-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/codex-incremental-scan-e2e.test.ts
@@ -353,7 +353,7 @@ describe('B-3 live incremental Codex scan parity', () => {
     legacyState.v = 1;
     delete legacyState.toolCalls;
     db.getDB().prepare('UPDATE scan_ledger SET parser_state = ? WHERE file_path = ?')
-      .run(JSON.stringify(legacyState), fp);
+      .run(JSON.stringify(legacyState), fs.realpathSync(fp));
 
     discover.__resetCodexScanBranchCountsForTest();
     appendRollout(id, [

--- a/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
+++ b/apps/cli/src/lib/session/__tests__/incremental-scan-e2e.test.ts
@@ -464,7 +464,7 @@ describe('B-2 live incremental scan parity', () => {
     legacyState.v = 1;
     delete legacyState.toolCalls;
     db.getDB().prepare('UPDATE scan_ledger SET parser_state = ? WHERE file_path = ?')
-      .run(JSON.stringify(legacyState), fp);
+      .run(JSON.stringify(legacyState), fs.realpathSync(fp));
 
     discover.__resetClaudeScanBranchCountsForTest();
     appendTranscript(id, [

--- a/apps/cli/src/lib/session/db.ts
+++ b/apps/cli/src/lib/session/db.ts
@@ -786,15 +786,17 @@ export function getDB(): Database.Database {
   if (dbInstance) return dbInstance;
   fs.mkdirSync(SESSIONS_DIR, { recursive: true });
   const db = new Database(DB_PATH);
-  db.pragma('journal_mode = WAL');
-  db.pragma('synchronous = NORMAL');
-  db.pragma('temp_store = MEMORY');
-  // Wait up to 30s instead of failing immediately on SQLITE_BUSY. Multiple
+  // Wait up to 30s instead of failing immediately on SQLITE_BUSY. Install the
+  // handler before journal_mode: concurrent first opens can race for its schema
+  // lock, before a later busy_timeout would have a chance to wait. Multiple
   // agents (CLIs, skills, hooks) open this DB concurrently. The first scan of
   // a new version home can take longer than 10s; concurrent callers need enough
   // headroom to wait. The ledger-recheck in upsertSessionsBatch makes
   // subsequent writers near-instant, so 30s is a rarely-reached safety net.
   db.pragma('busy_timeout = 30000');
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  db.pragma('temp_store = MEMORY');
   db.exec(SCHEMA);
 
   const readSchemaVersion = (): number | undefined => {

--- a/apps/cli/src/lib/session/tool-store.test.ts
+++ b/apps/cli/src/lib/session/tool-store.test.ts
@@ -7,7 +7,7 @@ const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-tool-store-'
 process.env.HOME = TEST_HOME;
 
 const { closeDB, getDB, querySessions, upsertSession } = await import('./db.js');
-const { persistToolCalls, purgeMissingToolCallsInDirectory } = await import('./tool-store.js');
+const { canonicalToolLedgerPath, persistToolCalls, purgeMissingToolCallsInDirectory } = await import('./tool-store.js');
 type SessionMeta = import('./types.js').SessionMeta;
 
 afterAll(() => {
@@ -68,7 +68,9 @@ describe('persistToolCalls', () => {
 
     expect(db.prepare(`SELECT tool, parse_error FROM tool_calls WHERE session_id = ?`).all(session.id))
       .toEqual([{ tool: 'index_limit', parse_error: 'Additional tool calls were not indexed for this session.' }]);
-    expect((db.prepare(`SELECT evidence_bytes FROM tool_scan_ledger WHERE file_path = ?`).get(filePath) as { evidence_bytes: number }).evidence_bytes)
+    const ledger = db.prepare(`SELECT evidence_bytes FROM tool_scan_ledger WHERE file_path = ?`)
+      .get(canonicalToolLedgerPath(filePath)) as { evidence_bytes: number };
+    expect(ledger.evidence_bytes)
       .toBeLessThanOrEqual(256);
   });
 
@@ -116,7 +118,8 @@ describe('persistToolCalls', () => {
       fileSize: parsedStamp.size,
     });
 
-    expect(db.prepare(`SELECT file_mtime_ms, file_size FROM tool_scan_ledger WHERE file_path = ?`).get(sourcePath))
+    expect(db.prepare(`SELECT file_mtime_ms, file_size FROM tool_scan_ledger WHERE file_path = ?`)
+      .get(canonicalToolLedgerPath(sourcePath)))
       .toEqual({ file_mtime_ms: parsedStamp.mtimeMs, file_size: parsedStamp.size });
     expect(fs.statSync(sourcePath).size).toBeGreaterThan(parsedStamp.size);
   });
@@ -203,10 +206,13 @@ describe('persistToolCalls', () => {
     upsertSession(session, 'symlink');
     const stat = fs.statSync(linkedPath);
     persistToolCalls(db, session, [], { fileMtimeMs: stat.mtimeMs, fileSize: stat.size });
-    expect(db.prepare(`SELECT file_path FROM tool_scan_ledger WHERE file_path = ?`).get(realPath)).toEqual({ file_path: realPath });
+    const canonicalRealPath = canonicalToolLedgerPath(realPath);
+    expect(db.prepare(`SELECT file_path FROM tool_scan_ledger WHERE file_path = ?`).get(canonicalRealPath))
+      .toEqual({ file_path: canonicalRealPath });
     fs.unlinkSync(realPath);
 
     expect(purgeMissingToolCallsInDirectory(db, linkedDir, [])).toBe(1);
-    expect(db.prepare(`SELECT count(*) AS n FROM tool_scan_ledger WHERE file_path = ?`).get(realPath)).toEqual({ n: 0 });
+    expect(db.prepare(`SELECT count(*) AS n FROM tool_scan_ledger WHERE file_path = ?`).get(canonicalRealPath))
+      .toEqual({ n: 0 });
   });
 });


### PR DESCRIPTION
## What changed

Fixes the two macOS-specific failures blocking release PR #1890:

- installs the SQLite busy handler before the WAL journal-mode pragma, so concurrent first opens wait instead of failing before the timeout is active;
- makes ledger tests address the same canonical real paths that production stores (`/private/var/...` on macOS rather than the `/var/...` alias).

## Verification

No visible surface: this is a database-open and cross-platform test fix.

Actual local run:

- Linux: 4 target test files passed, 39 tests passed, repeated 3 consecutive times;
- macOS arm64: the same 4 files and 39 tests passed 3 consecutive times, including the concurrent-open migration test;
- `bun run build` passed;
- `git diff --check` passed.

The PR CI matrix provides the release-blocking macOS Node 22/24 reproduction.
