### PR TITLE
fix(release): pin CI wait to pushed commit

### DIFF
--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -896,15 +896,13 @@ if [[ "${RELEASE_REQUIRE_WINDOWS:-1}" == "1" ]]; then
 fi
 check_bucket() { jq -r --arg n "$1" 'map(select(.name==$n)) | (.[0].bucket // "missing")' <<<"$2"; }
 wait_for_ci_green() {
-  local pr="$1" ctx b results problem=0
-  # Pin the wait to the PR's CURRENT head sha and poll the check-runs API for
-  # that exact commit. `gh pr checks` right after a force-update briefly still
-  # reports the PREVIOUS commit's all-green checks — an all-pass read then
-  # breaks the wait before the new commit's checks even register, and the
-  # final assertion dies on "missing" (the 1.20.91 release hit this loop four
-  # times). Per-sha check-runs can never serve that stale state.
-  local head_sha
-  head_sha="$(gh pr view "$pr" --json headRefOid -q .headRefOid)" || die "could not read PR #$pr head sha"
+  local pr="$1" head_sha="${2:-}" ctx b results problem=0
+  # The caller passes the exact commit it pushed or fetched. GitHub's PR API can
+  # briefly return the PREVIOUS head after a force-update; resolving headRefOid
+  # here made release.sh inspect that stale commit's failed checks and abort even
+  # while the new commit's matrix was running (1.22.0). Per-sha check-runs pinned
+  # to the caller's known commit cannot serve that stale state.
+  [[ -n "$head_sha" ]] || die "missing CI-tested head sha for PR #$pr"
   bold "Waiting for CI on PR #$pr @ ${head_sha:0:9} (full matrix + test + gitleaks; up to 60m)..."
   local deadline=$(( $(date +%s) + 3600 ))
   while :; do
@@ -957,7 +955,7 @@ if $MAIN_AT_TARGET && ! $PHNX_TARGET_PUBLISHED; then
   # and abort under `set -u`. That aborted every retry of an unpublished release.
   HISTORICAL_CATCHUP=true
   bold "Re-validating CI from merged release PR #$MERGED_RELEASE_PR before catch-up publish..."
-  wait_for_ci_green "$MERGED_RELEASE_PR"
+  wait_for_ci_green "$MERGED_RELEASE_PR" "$CI_TESTED_HEAD"
 fi
 
 # ----- Tests on a crabbox (before opening the PR) -----
@@ -1048,7 +1046,7 @@ if ! $MAIN_AT_TARGET; then
     green "Opened release PR #$PR_NUMBER"
   fi
 
-  wait_for_ci_green "$PR_NUMBER"
+  wait_for_ci_green "$PR_NUMBER" "$RELEASE_COMMIT"
 
   # Squash-merge. Never --admin: branch protection must hold, and the ruleset has
   # no PR-review rule, so green test+gitleaks is a sufficient, non-bypass merge.

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -1014,13 +1014,16 @@ if ! $MAIN_AT_TARGET; then
   RELEASE_COMMIT="$(git commit-tree "$BRANCH_TREE" -p "$BASE_SHA" -m "chore(release): $TARGET")"
 
   PR_NUMBER=""
+  RELEASE_CI_HEAD=""
   if [[ -n "$EXISTING_PR" ]]; then
     PR_NUMBER="$EXISTING_PR"
     EXISTING_HEAD="$(gh pr view "$EXISTING_PR" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
     if [[ -n "$EXISTING_HEAD" && "$(git rev-parse "$EXISTING_HEAD^{tree}" 2>/dev/null || true)" == "$BRANCH_TREE" ]]; then
+      RELEASE_CI_HEAD="$EXISTING_HEAD"
       gray "Reusing open PR #$PR_NUMBER ($RELEASE_BRANCH); branch tree already matches."
     else
       git push --force-with-lease origin "$RELEASE_COMMIT:refs/heads/$RELEASE_BRANCH"
+      RELEASE_CI_HEAD="$RELEASE_COMMIT"
       gray "Updated PR #$PR_NUMBER branch to the freshly built release commit."
     fi
   else
@@ -1030,6 +1033,7 @@ if ! $MAIN_AT_TARGET; then
     # push would be rejected non-fast-forward and brick the re-run. The lease is
     # safe -- preflight fetched origin, so we only overwrite a ref we have seen.
     git push --force-with-lease origin "$RELEASE_COMMIT:refs/heads/$RELEASE_BRANCH"
+    RELEASE_CI_HEAD="$RELEASE_COMMIT"
     green "Pushed $RELEASE_BRANCH"
   fi
 
@@ -1046,7 +1050,8 @@ if ! $MAIN_AT_TARGET; then
     green "Opened release PR #$PR_NUMBER"
   fi
 
-  wait_for_ci_green "$PR_NUMBER" "$RELEASE_COMMIT"
+  [[ -n "$RELEASE_CI_HEAD" ]] || die "could not resolve CI-tested head for PR #$PR_NUMBER"
+  wait_for_ci_green "$PR_NUMBER" "$RELEASE_CI_HEAD"
 
   # Squash-merge. Never --admin: branch protection must hold, and the ruleset has
   # no PR-review rule, so green test+gitleaks is a sufficient, non-bypass merge.

--- a/apps/cli/scripts/release.test.ts
+++ b/apps/cli/scripts/release.test.ts
@@ -13,7 +13,10 @@ describe('release.sh PR-head synchronization', () => {
     expect(waitFunction).toBeDefined();
     expect(waitFunction).toContain('local pr="$1" head_sha="${2:-}"');
     expect(waitFunction).not.toContain('gh pr view');
-    expect(RELEASE_SH).toContain('wait_for_ci_green "$PR_NUMBER" "$RELEASE_COMMIT"');
+    expect(RELEASE_SH).toContain('RELEASE_CI_HEAD="$EXISTING_HEAD"');
+    expect(RELEASE_SH.match(/RELEASE_CI_HEAD="\$RELEASE_COMMIT"/g)).toHaveLength(2);
+    expect(RELEASE_SH).toContain('wait_for_ci_green "$PR_NUMBER" "$RELEASE_CI_HEAD"');
+    expect(RELEASE_SH).not.toContain('wait_for_ci_green "$PR_NUMBER" "$RELEASE_COMMIT"');
     expect(RELEASE_SH).toContain(
       'wait_for_ci_green "$MERGED_RELEASE_PR" "$CI_TESTED_HEAD"',
     );

--- a/apps/cli/scripts/release.test.ts
+++ b/apps/cli/scripts/release.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const RELEASE_SH = fs.readFileSync(path.resolve(__dirname, 'release.sh'), 'utf-8');
+
+describe('release.sh PR-head synchronization', () => {
+  it('pins CI to the exact release commit instead of GitHub\'s eventually consistent PR head', () => {
+    const waitFunction = RELEASE_SH.match(
+      /wait_for_ci_green\(\) \{(?<body>[\s\S]*?)\n\}/,
+    )?.groups?.body;
+
+    expect(waitFunction).toBeDefined();
+    expect(waitFunction).toContain('local pr="$1" head_sha="${2:-}"');
+    expect(waitFunction).not.toContain('gh pr view');
+    expect(RELEASE_SH).toContain('wait_for_ci_green "$PR_NUMBER" "$RELEASE_COMMIT"');
+    expect(RELEASE_SH).toContain(
+      'wait_for_ci_green "$MERGED_RELEASE_PR" "$CI_TESTED_HEAD"',
+    );
+  });
+});


### PR DESCRIPTION
Internal release-safety fix; no user-visible surface.

## What changed

- Pass the exact pushed or fetched commit into `wait_for_ci_green`.
- Stop resolving `headRefOid` from GitHub immediately after a force-update, when the PR API can still return the previous head.
- Add a regression contract covering both new-release and catch-up-release paths.

## Real run

- `bun vitest run scripts/release.test.ts`: 1 file passed, 1 test passed.
- `bash -n scripts/release.sh`: passed.
- `bun run build`: passed.
- Triggered during release PR #1890: the script pushed `f7b76925`, then incorrectly inspected prior head `1a499a95`; the new head CI is running normally.

## Scope

No CLI behavior, docs, or package API changes. This only fixes the canonical release pipeline.