### PR TITLE
fix(projects): a monorepo subproject owns its subdir, not the whole checkout

### DIFF
--- a/apps/cli/.changelog/next/projects-monorepo-membership.md
+++ b/apps/cli/.changelog/next/projects-monorepo-membership.md
@@ -1,0 +1,8 @@
+- **Two projects sharing one monorepo checkout are no longer indistinguishable.** Session,
+  activity, and feed attribution anchored a project on `root ?? defaultPath`, so a subproject
+  whose `root` is the monorepo and whose `defaultPath` is a subdir collapsed onto the same
+  path as its umbrella — the longest-match tiebreak had nothing to separate them, and work in
+  `rush/apps/cli` counted toward whichever definition happened to be listed first. A
+  `defaultPath` nested under `root` is now the membership claim (the root says where the
+  checkout is; `defaultPath` says which work is this project's), and each bound repo's
+  checkout and subpath anchor too. Source: `apps/cli/src/lib/projects.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -405,3 +405,23 @@ scopeHistory: []   completedScopeHistory: []   inProgressScopeHistory: []
 So the chip would be invented. A blank is bad; a confident wrong answer that gets trusted is
 worse, and it is unfalsifiable from the card. The union has no such member, so it cannot be
 produced by accident later either.
+
+## Monorepo subprojects: which project owns a session
+
+Attribution (`projectNameForCwd`) matches a session's cwd against the paths each project
+claims, longest match winning so a nested project beats its parent. What a project *claims*
+is the part that needed fixing:
+
+- `root` says where the **checkout** is.
+- `defaultPath`, when nested under `root`, says which **work** is this project's — and it
+  then becomes the membership claim *instead of* `root`.
+- each `repos[].path`, and `repos[].path` + `subpath`, anchor as well.
+
+Without this, two definitions sharing one monorepo checkout — an umbrella `rush` at
+`~/src/rush` and a subproject `rush-cli` at `~/src/rush` with `defaultPath ~/src/rush/apps/cli`
+— both anchored at `~/src/rush`. Longest-match had nothing to separate them, so a session in
+`rush/apps/cli` was attributed to whichever definition was listed first, and the answer
+changed with definition order.
+
+A subproject scoped to `apps/cli` deliberately does **not** own `apps/web`; that work falls to
+the umbrella. Set the scope with `agents projects add <name> --root <monorepo> --path <subdir>`.

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -240,3 +240,46 @@ describe('resolveProjectNameForCwd', () => {
     expect(resolveProjectNameForCwd('', [])).toBeUndefined();
   });
 });
+
+describe('projectNameForCwd — monorepo subprojects', () => {
+  const HOME_ = process.env.HOME ?? os.homedir();
+  const mono = path.join(HOME_, 'src', 'rush');
+  // Two projects sharing ONE checkout: the umbrella and a subdir project.
+  const defs: ProjectDef[] = [
+    { name: 'rush', root: '~/src/rush' },
+    { name: 'rush-cli', root: '~/src/rush', defaultPath: '~/src/rush/apps/cli' },
+  ];
+
+  it('attributes work in the subdir to the SUBPROJECT, not the umbrella', () => {
+    // `root ?? defaultPath` gave both defs the same anchor (~/src/rush), so the
+    // longest-match tiebreak had nothing to separate them and the first listed
+    // def won regardless of where the session actually was.
+    expect(projectNameForCwd(path.join(mono, 'apps', 'cli', 'src'), defs)).toBe('rush-cli');
+    expect(projectNameForCwd(path.join(mono, 'apps', 'cli'), defs)).toBe('rush-cli');
+  });
+
+  it('still attributes work outside the subdir to the umbrella', () => {
+    expect(projectNameForCwd(path.join(mono, 'apps', 'web'), defs)).toBe('rush');
+    expect(projectNameForCwd(mono, defs)).toBe('rush');
+  });
+
+  it('does not depend on definition order', () => {
+    const reversed = [...defs].reverse();
+    expect(projectNameForCwd(path.join(mono, 'apps', 'cli', 'x'), reversed)).toBe('rush-cli');
+    expect(projectNameForCwd(path.join(mono, 'apps', 'web'), reversed)).toBe('rush');
+  });
+
+  it('anchors a bound repo checkout and its subpath too', () => {
+    const withRepos: ProjectDef[] = [
+      { name: 'umbrella', root: '~/src/rush' },
+      { name: 'infra', root: '~/src/rush', repos: [{ slug: 'o/infra', path: '~/src/rush/infra', subpath: 'deploy' }] },
+    ];
+    expect(projectNameForCwd(path.join(mono, 'infra', 'deploy', 'k8s'), withRepos)).toBe('infra');
+    expect(projectNameForCwd(path.join(mono, 'infra'), withRepos)).toBe('infra');
+    expect(projectNameForCwd(path.join(mono, 'docs'), withRepos)).toBe('umbrella');
+  });
+
+  it('matches nothing outside every anchor', () => {
+    expect(projectNameForCwd(path.join(HOME_, 'src', 'elsewhere'), defs)).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -294,16 +294,43 @@ export function projectBasePath(def: ProjectDef, forRemote: boolean): string | u
 /** A project plus its repo root as an absolute local path, for cwd matching. */
 interface ProjectRootAbs {
   name: string;
-  /** Absolute, normalized repo root (`root` preferred, else `defaultPath`). */
+  /**
+   * One absolute, normalized path this project claims. A project contributes
+   * SEVERAL — its root, its monorepo subdir, and each bound repo's checkout and
+   * subpath — so the most specific claim can win over a broader one.
+   */
   abs: string;
 }
 
 function projectRootsAbs(defs: ProjectDef[]): ProjectRootAbs[] {
   const out: ProjectRootAbs[] = [];
+  const push = (name: string, raw: string | undefined) => {
+    if (!raw) return;
+    out.push({ name, abs: path.resolve(expandLocalHome(raw)) });
+  };
   for (const def of defs) {
-    const raw = def.root ?? def.defaultPath;
-    if (!raw) continue;
-    out.push({ name: def.name, abs: path.resolve(expandLocalHome(raw)) });
+    // `root` says where the CHECKOUT is; `defaultPath` says which work is this
+    // project's. For a monorepo subproject those differ, and only the narrower
+    // one is a membership claim — a project scoped to `rush/apps/cli` does not
+    // own `rush/apps/web`.
+    //
+    // The old `root ?? defaultPath` collapsed such a subproject onto the
+    // monorepo root, the same path its umbrella anchors at, so the longest-match
+    // tiebreak below had nothing to separate them and a session in
+    // `rush/apps/cli` counted toward whichever definition was listed first.
+    const rootAbs = def.root ? path.resolve(expandLocalHome(def.root)) : undefined;
+    const defaultAbs = def.defaultPath ? path.resolve(expandLocalHome(def.defaultPath)) : undefined;
+    const narrowed = rootAbs && defaultAbs && defaultAbs !== rootAbs && isUnder(defaultAbs, rootAbs);
+    if (narrowed) out.push({ name: def.name, abs: defaultAbs! });
+    else {
+      if (rootAbs) out.push({ name: def.name, abs: rootAbs });
+      if (defaultAbs && defaultAbs !== rootAbs) out.push({ name: def.name, abs: defaultAbs });
+    }
+    for (const r of def.repos ?? []) {
+      push(def.name, r.path);
+      // A repo pinned to a monorepo subpath anchors at that subpath too.
+      if (r.path && r.subpath) push(def.name, path.join(expandLocalHome(r.path), r.subpath));
+    }
   }
   return out;
 }


### PR DESCRIPTION
**What + type:** bug fix — two projects sharing one monorepo checkout are indistinguishable, so session/activity/feed attribution picks one by definition order.

Phase 2 of the original plan calls this out as load-bearing: *"without it, monorepo subprojects don't roll up correctly."* It is the shape of Rush App / Rush CLI — one checkout, two projects at different subdirs.

## The defect

`projectRootsAbs` emitted **one** anchor per project: `root ?? defaultPath`. `projectNameForCwd` already resolves ties by longest match, but there was nothing to be long *about*:

| def | root | defaultPath | anchor (before) |
| --- | --- | --- | --- |
| `rush` | `~/src/rush` | — | `~/src/rush` |
| `rush-cli` | `~/src/rush` | `~/src/rush/apps/cli` | `~/src/rush` ← same path |

Both anchored identically, so a session in `rush/apps/cli` was attributed to whichever definition was listed first — and the answer **changed with definition order**. A test asserts that order-independence now.

## The rule, from what the two fields mean

- `root` says where the **checkout** is.
- `defaultPath`, when nested under `root`, says which **work** is this project's — so it becomes the membership claim *instead of* `root`.
- each `repos[].path`, and `path` + `subpath`, anchor too.

A subproject scoped to `apps/cli` deliberately does **not** own `apps/web`; that stays with the umbrella.

## A wrong first attempt, caught by a test

My first cut pushed `root` **and** `defaultPath` as claims. That still left the umbrella and the subproject tied on the monorepo root, so `apps/web` resolved to `rush-cli` when the definitions were reversed. The order-independence test failed and forced the sharper rule above — which is the semantically correct one, not just the one that makes the test pass.

## Blast radius

`projectNameForCwd` is the single project resolver behind the `agents activity` timeline, `agents feed post`'s stamped project, the `agents sessions` overview, and `project-status.ts`'s rollup. All five project suites pass (**92 tests**), and live attribution on this machine is unchanged — `agents-cli` still shows its 44 sessions.

<sub>Session transcript is confidential and this repo is public — not attached. Local path: `zion:/Users/muqsit/.agents/.history/versions/claude/2.1.219/home/.claude/projects/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/9b113ec5-253e-4cbe-bb7d-bc5b84f3b0fe.jsonl`</sub>
