### PR TITLE
fix(projects): a narrowed root still covers its own checkout

### DIFF
--- a/apps/cli/.changelog/next/projects-monorepo-membership.md
+++ b/apps/cli/.changelog/next/projects-monorepo-membership.md
@@ -3,6 +3,8 @@
   whose `root` is the monorepo and whose `defaultPath` is a subdir collapsed onto the same
   path as its umbrella — the longest-match tiebreak had nothing to separate them, and work in
   `rush/apps/cli` counted toward whichever definition happened to be listed first. A
-  `defaultPath` nested under `root` is now the membership claim (the root says where the
-  checkout is; `defaultPath` says which work is this project's), and each bound repo's
-  checkout and subpath anchor too. Source: `apps/cli/src/lib/projects.ts`.
+  `defaultPath` nested under `root` now takes precedence over that `root` (the root says where
+  the checkout is; `defaultPath` says which work is this project's), and each bound repo's
+  checkout and subpath anchor too. A narrowed `root` still covers the rest of its checkout as
+  a fallback, so a lone project defined with `--path` keeps attributing work across its own
+  repo instead of only inside the subdir. Source: `apps/cli/src/lib/projects.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -413,8 +413,11 @@ claims, longest match winning so a nested project beats its parent. What a proje
 is the part that needed fixing:
 
 - `root` says where the **checkout** is.
-- `defaultPath`, when nested under `root`, says which **work** is this project's — and it
-  then becomes the membership claim *instead of* `root`.
+- `defaultPath`, when nested under `root`, says which **work** is this project's, and takes
+  precedence over `root`.
+- a narrowed `root` still claims the rest of its checkout, but only as a fallback: any other
+  project claiming that path outright wins. So the umbrella takes `apps/web` when one exists,
+  while a lone project keeps attributing work across its own repo.
 - each `repos[].path`, and `repos[].path` + `subpath`, anchor as well.
 
 Without this, two definitions sharing one monorepo checkout — an umbrella `rush` at
@@ -425,3 +428,7 @@ changed with definition order.
 
 A subproject scoped to `apps/cli` deliberately does **not** own `apps/web`; that work falls to
 the umbrella. Set the scope with `agents projects add <name> --root <monorepo> --path <subdir>`.
+
+When the subproject is the *only* definition on that checkout there is no umbrella to fall to,
+so its `root` still covers `apps/web` and the repo root. `--path` chooses where an agent
+starts, and it must not silently shrink which work counts as the project's.

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -282,4 +282,27 @@ describe('projectNameForCwd — monorepo subprojects', () => {
   it('matches nothing outside every anchor', () => {
     expect(projectNameForCwd(path.join(HOME_, 'src', 'elsewhere'), defs)).toBeUndefined();
   });
+
+  it('a lone narrowed project still owns the rest of its own checkout', () => {
+    // The subdir claim must not shrink a project that has no umbrella beside it:
+    // `--path` picks where an agent starts, not which work counts. Narrowing to
+    // the subdir alone silently orphaned every session in the repo root and in
+    // sibling subdirs.
+    const solo: ProjectDef[] = [{ name: 'foo', root: '~/src/foo', defaultPath: '~/src/foo/apps/web' }];
+    const repo = path.join(HOME_, 'src', 'foo');
+    expect(projectNameForCwd(path.join(repo, 'apps', 'web'), solo)).toBe('foo');
+    expect(projectNameForCwd(repo, solo)).toBe('foo');
+    expect(projectNameForCwd(path.join(repo, 'apps', 'api'), solo)).toBe('foo');
+    // Still bounded by the root.
+    expect(projectNameForCwd(path.join(HOME_, 'src', 'bar'), solo)).toBeUndefined();
+  });
+
+  it('the umbrella outranks a subproject root even when listed second', () => {
+    // The fallback must lose to any outright claim, in either definition order.
+    const reversed = [...defs].reverse();
+    expect(projectNameForCwd(path.join(mono, 'apps', 'web'), defs)).toBe('rush');
+    expect(projectNameForCwd(path.join(mono, 'apps', 'web'), reversed)).toBe('rush');
+    expect(projectNameForCwd(mono, defs)).toBe('rush');
+    expect(projectNameForCwd(mono, reversed)).toBe('rush');
+  });
 });

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -300,6 +300,13 @@ interface ProjectRootAbs {
    * subpath — so the most specific claim can win over a broader one.
    */
   abs: string;
+  /**
+   * A fallback claim, used only when no ordinary claim matches. The root of a
+   * project that narrowed itself with `defaultPath` is weak: it should lose the
+   * shared monorepo root to an umbrella project, yet still cover its own repo
+   * when no other project claims it.
+   */
+  weak?: boolean;
 }
 
 function projectRootsAbs(defs: ProjectDef[]): ProjectRootAbs[] {
@@ -320,12 +327,15 @@ function projectRootsAbs(defs: ProjectDef[]): ProjectRootAbs[] {
     // `rush/apps/cli` counted toward whichever definition was listed first.
     const rootAbs = def.root ? path.resolve(expandLocalHome(def.root)) : undefined;
     const defaultAbs = def.defaultPath ? path.resolve(expandLocalHome(def.defaultPath)) : undefined;
-    const narrowed = rootAbs && defaultAbs && defaultAbs !== rootAbs && isUnder(defaultAbs, rootAbs);
-    if (narrowed) out.push({ name: def.name, abs: defaultAbs! });
-    else {
-      if (rootAbs) out.push({ name: def.name, abs: rootAbs });
-      if (defaultAbs && defaultAbs !== rootAbs) out.push({ name: def.name, abs: defaultAbs });
-    }
+    const narrowed = !!(rootAbs && defaultAbs && defaultAbs !== rootAbs && isUnder(defaultAbs, rootAbs));
+    // A narrowed project's root is a WEAK claim: it still covers the rest of the
+    // checkout when nobody else wants it, but yields to any project that claims
+    // a path outright. Dropping it entirely regressed the single-project case —
+    // `add foo --root ~/src/foo --path apps/web` stopped attributing work
+    // anywhere else in its own repo, and `--path` means where agents START, not
+    // which work counts.
+    if (rootAbs) out.push({ name: def.name, abs: rootAbs, weak: narrowed });
+    if (defaultAbs && defaultAbs !== rootAbs) out.push({ name: def.name, abs: defaultAbs });
     for (const r of def.repos ?? []) {
       push(def.name, r.path);
       // A repo pinned to a monorepo subpath anchors at that subpath too.
@@ -360,13 +370,21 @@ export function projectNameForCwd(cwd: string | undefined, defs: ProjectDef[]): 
   const abs = path.resolve(expandLocalHome(cwd));
   let best: string | undefined;
   let bestLen = -1;
-  for (const { name, abs: root } of projectRootsAbs(defs)) {
-    if (isUnder(abs, root) && root.length > bestLen) {
+  let weakBest: string | undefined;
+  let weakLen = -1;
+  for (const { name, abs: root, weak } of projectRootsAbs(defs)) {
+    if (!isUnder(abs, root)) continue;
+    if (weak) {
+      if (root.length > weakLen) {
+        weakBest = name;
+        weakLen = root.length;
+      }
+    } else if (root.length > bestLen) {
       best = name;
       bestLen = root.length;
     }
   }
-  return best;
+  return best ?? weakBest;
 }
 
 /**


### PR DESCRIPTION
**Bugfix, follow-up to #1898.** Restores whole-checkout attribution for a project that
declares `--path` but has no umbrella beside it.

## What #1898 got wrong

#1898 fixed a real bug: an umbrella and a subproject sharing one monorepo checkout both
anchored at the same path, so `projectNameForCwd` picked whichever definition was listed
first. The fix anchored a narrowed project **only** on its `defaultPath`.

That silently shrank the single-project case. For `agents projects add foo --root ~/src/foo
--path apps/web` — one project, no umbrella — work outside `apps/web` stopped matching
anything:

```
  apps/web (the declared path)     -> foo
  repo root                        -> undefined   <-- regression, was "foo"
  apps/api (sibling subdir)        -> undefined   <-- regression, was "foo"
```

`--path` chooses where an agent's cwd lands. It must not decide which work counts as the
project's.

## The fix

A narrowed `root` becomes a **fallback** claim rather than being dropped: it loses any path
another project claims outright, and still covers the checkout when nobody else wants it.

## Run result — both cases, on this branch

```
-- solo project (regression case) --
  apps/web (the declared path)     -> foo
  repo root                        -> foo
  apps/api (sibling subdir)        -> foo
-- monorepo umbrella + subproject --
  rush/apps/cli                    -> rush-cli
  rush/apps/web                    -> rush
  rush root                        -> rush
-- order independence --
  rush/apps/cli (defs reversed)    -> rush-cli
```

Against the four real definitions in `~/.agents/projects/`, attribution is unchanged:

```
~/src/github.com/muqsitnawaz/agents-cli              -> agents-cli
~/src/github.com/muqsitnawaz/agents-cli/apps/cli     -> agents-cli
~/src/github.com/muqsitnawaz/agents-cli/apps/factory -> agents-cli
~/src/github.com/muqsitnawaz/linear-cli              -> linear-cli
~/src/elsewhere                                      -> undefined
```

`bunx vitest run` over the five project suites: **94 passed** (92 before; the two new cases
pin the regression and the umbrella-outranks-fallback ordering).

## Why this wasn't caught in #1898

The reviewer checked the change against `docs/11-projects.md` — which #1898 wrote in the same
diff, so the doc confirmed the change rather than testing it. The regression surfaced only by
running the resolver against a solo definition. Docs and CHANGELOG are corrected here.

Files: `apps/cli/src/lib/projects.ts`, `projects.test.ts`, `docs/11-projects.md`,
`.changelog/next/projects-monorepo-membership.md`.
