### PR TITLE
fix(doctor): await the overview gate's lock release before returning

### DIFF
--- a/apps/cli/.changelog/next/doctor-overview-gate-release.md
+++ b/apps/cli/.changelog/next/doctor-overview-gate-release.md
@@ -1,0 +1,7 @@
+- **`doctor --json` releases its singleflight lock before it returns.** The overview gate
+  fired the lock release without awaiting it on the path where a waiter serves the winner's
+  fresh snapshot, so the call returned with the lockfile still on disk. The next caller then
+  retried against a lock that was already logically free — the pile-up the gate exists to
+  prevent, narrowed to the window between return and unlink. The release is now awaited.
+  The existing coalescing test failed 5 times in 15 runs before this and 0 in 15 after.
+  Source: `apps/cli/src/lib/devices/doctor-overview-cache.ts`.

--- a/apps/cli/src/lib/devices/doctor-overview-cache.ts
+++ b/apps/cli/src/lib/devices/doctor-overview-cache.ts
@@ -181,7 +181,12 @@ export async function enterDoctorOverviewGate(
   //    serve it and release, instead of recomputing.
   const afterWait = serveFresh();
   if (afterWait !== null) {
-    void release();
+    // AWAIT, don't fire-and-forget: returning while the lockfile is still on
+    // disk makes the next caller retry against a lock that is logically free —
+    // the same pile-up this gate exists to prevent, just narrowed to the window
+    // between return and unlink. We are already in an async function, so the
+    // wait costs one unlink.
+    await release().catch(() => {});
     return { cached: afterWait };
   }
 


### PR DESCRIPTION
**Bugfix.** `doctor --json`'s singleflight gate returned while still holding its lockfile.
This is currently failing CI on unrelated PRs (it hit #1899).

## The bug

`enterDoctorOverviewGate` has a path where a waiter acquires the lock, finds that the winner
already wrote a fresh snapshot, and serves it instead of recomputing. It released the lock
without awaiting:

```ts
const afterWait = serveFresh();
if (afterWait !== null) {
  void release();            // fire-and-forget — returns with the lockfile still on disk
  return { cached: afterWait };
}
```

So between the return and the unlink there is a window where the next caller retries against a
lock that is already logically free. That is the pile-up this gate was added to prevent
(#1893), narrowed rather than closed.

The existing test asserts exactly this — `expect(fs.existsSync(LOCK)).toBe(false)` once both
callers are done — and it is **correct**; the implementation was racy. This is a real
concurrency defect surfacing as a flaky test, not a flaky test to loosen.

## The fix

`await release()` (already inside an `async` function, so it costs one unlink), with the
rejection swallowed so a release failure can never turn a served snapshot into a throw.

## Run result — 15 consecutive runs of the affected suite, same machine

| | pass | fail |
|---|---|---|
| `origin/main` (before) | 10 | **5** |
| this branch (after) | **15** | 0 |

```
== same 15 runs WITHOUT the fix (baseline) ==
pass=10 fail=5
== 15 consecutive runs of the previously-flaky suite ==
pass=15 fail=0
```

CI failure this unblocks — `test-shard (3)` on PR #1899:

```
FAIL src/lib/devices/doctor-overview-cache.test.ts > doctor-overview-cache: singleflight
     coalescing (the bug fix) > hands exactly one compute token to concurrent callers
AssertionError: expected true to be false // Object.is equality
```

No test changes: the existing assertion goes from flaky to deterministic. Follow-up to #1893.
