### PR TITLE
feat(menubar): a blocked row takes you to the session

### DIFF
--- a/apps/cli/.changelog/next/menubar-focus-blocked.md
+++ b/apps/cli/.changelog/next/menubar-focus-blocked.md
@@ -1,0 +1,10 @@
+- **A blocked menu-bar row now takes you to the session (RUSH-2110).** A NEEDS-YOU row
+  exists because an agent is waiting on you, but its only action was "Reveal working
+  dir", which unblocks nothing — you still had to go find the session by hand. Blocked
+  rows now lead with **Focus session**, which runs `agents focus <id>`: attach the live
+  terminal, or open a new tab and resume, cross-host. Reveal stays underneath. Both
+  render paths are covered — the single inline row and each entry inside a collapsed
+  multi-waiter group. A row the engine could not identify (a cloud task, a stale
+  sentinel) simply omits the item rather than offering an action that would do nothing.
+  Source: `apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift`,
+  `AgentsCLI.swift`.

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -172,6 +172,7 @@ enum AgentsCLI {
     // `ignore` dismisses it for good. Both clear the pending sentinel CLI-side,
     // so the badge/section updates on the next 10s poll. TS owns the truth.
     static func deviceRegister(_ name: String) { runDetached(argv(["devices", "register", name])) }
+    static func deviceIgnore(_ name: String) { runDetached(argv(["devices", "ignore", name])) }
 
     /// Take the operator to a blocked session: attach its terminal, or open a new
     /// tab and resume it (`agents focus` decides, and handles a remote host).
@@ -182,7 +183,6 @@ enum AgentsCLI {
     static func focusSession(_ sessionId: String) {
         runDetached(argv(["focus", sessionId]))
     }
-    static func deviceIgnore(_ name: String) { runDetached(argv(["devices", "ignore", name])) }
 
     // Surface CLI health in a terminal — `agents doctor` is interactive output.
     static func runDoctor() {

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -172,6 +172,16 @@ enum AgentsCLI {
     // `ignore` dismisses it for good. Both clear the pending sentinel CLI-side,
     // so the badge/section updates on the next 10s poll. TS owns the truth.
     static func deviceRegister(_ name: String) { runDetached(argv(["devices", "register", name])) }
+
+    /// Take the operator to a blocked session: attach its terminal, or open a new
+    /// tab and resume it (`agents focus` decides, and handles a remote host).
+    ///
+    /// Detached on purpose. `focus` opens a Terminal/tmux surface and can block on
+    /// an attach; the menu bar must never wait on that, and there is nothing to
+    /// report back — the operator sees the session appear.
+    static func focusSession(_ sessionId: String) {
+        runDetached(argv(["focus", sessionId]))
+    }
     static func deviceIgnore(_ name: String) { runDetached(argv(["devices", "ignore", name])) }
 
     // Surface CLI health in a terminal — `agents doctor` is interactive output.

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -1116,14 +1116,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         return sub.items.isEmpty ? nil : sub
     }
 
-    private func revealSubmenu(_ cwd: String) -> NSMenu {
-        let sub = NSMenu()
-        let reveal = NSMenuItem(title: "Reveal working dir", action: #selector(onOpenPath(_:)), keyEquivalent: "")
-        reveal.target = self
-        reveal.representedObject = cwd
-        sub.addItem(reveal)
-        return sub
-    }
 
     private func routineSubmenu(_ r: Routine) -> NSMenu {
         let sub = NSMenu()

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -519,7 +519,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                     text += " — \(trim(first.question, rich ? 48 : 34))"
                 }
                 if let since = first.attentionSinceMs { text += "  ·  \(elapsedShort(since))" }
-                rows.append(("⚠", wait, text, first.cwd.map { revealSubmenu($0) }))
+                rows.append(("⚠", wait, text, blockedSubmenu(sessionId: first.sessionId, cwd: first.cwd)))
             } else {
                 // Collapsed: N waiting · oldest elapsed. Submenu lists each session.
                 var text = "\(agentLabel) · \(repo) · \(group.count) waiting"
@@ -576,7 +576,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             if !s.question.isEmpty { text += " — \(trim(s.question, 34))" }
             if let since = s.attentionSinceMs { text += "  ·  \(elapsedShort(since))" }
             let it = statusRow("⚠", wait, text)
-            if let cwd = s.cwd { it.submenu = revealSubmenu(cwd) }
+            it.submenu = blockedSubmenu(sessionId: s.sessionId, cwd: s.cwd)
             sub.addItem(it)
         }
         return sub
@@ -1091,6 +1091,31 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         return sub
     }
 
+    /// Submenu for a blocked row. "Focus session" comes FIRST and is the point:
+    /// a NEEDS-YOU row exists because an agent is waiting on the operator, so the
+    /// action that resolves it — land in that session — must be the first thing
+    /// under the cursor. Revealing the working dir does not unblock anything.
+    ///
+    /// `sessionId` is nil for a row the engine could not identify (a cloud task,
+    /// a stale sentinel); the item is simply omitted rather than shown disabled,
+    /// so the menu never offers an action that would do nothing.
+    private func blockedSubmenu(sessionId: String?, cwd: String?) -> NSMenu? {
+        let sub = NSMenu()
+        if let id = sessionId, !id.isEmpty {
+            let focus = NSMenuItem(title: "Focus session", action: #selector(onFocusSession(_:)), keyEquivalent: "")
+            focus.target = self
+            focus.representedObject = id
+            sub.addItem(focus)
+        }
+        if let dir = cwd, !dir.isEmpty {
+            let reveal = NSMenuItem(title: "Reveal working dir", action: #selector(onOpenPath(_:)), keyEquivalent: "")
+            reveal.target = self
+            reveal.representedObject = dir
+            sub.addItem(reveal)
+        }
+        return sub.items.isEmpty ? nil : sub
+    }
+
     private func revealSubmenu(_ cwd: String) -> NSMenu {
         let sub = NSMenu()
         let reveal = NSMenuItem(title: "Reveal working dir", action: #selector(onOpenPath(_:)), keyEquivalent: "")
@@ -1237,6 +1262,9 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     @objc private func onRoutineLogs(_ s: NSMenuItem) { withName(s, AgentsCLI.routineLogs) }
     @objc private func onOpenPath(_ s: NSMenuItem) {
         if let p = s.representedObject as? String { AgentsCLI.openPath(p) }
+    }
+    @objc private func onFocusSession(_ s: NSMenuItem) {
+        if let id = s.representedObject as? String { AgentsCLI.focusSession(id) }
     }
     @objc private func onOpenAgentsHome() { AgentsCLI.openPath("\(AgentsCLI.home)/.agents") }
     @objc private func onStartScheduler() { AgentsCLI.startScheduler() }


### PR DESCRIPTION
**feature** — a blocked menu-bar row now takes you to the session that's stuck.

## Why

A NEEDS-YOU row exists because an agent is waiting on the operator. Its only action was **"Reveal working dir"**, which unblocks nothing. Seeing that an agent is stuck and then having to hunt down its session by hand is most of the friction this path was meant to remove.

## What changed

Blocked rows lead with **"Focus session"**, shelling `agents focus <id>` — attach the live terminal, or open a new tab and resume, cross-host. Reveal stays underneath.

Both render paths are covered: the single inline row, and each entry inside a collapsed multi-waiter group (`groupedWaitersSubmenu`).

**No new plumbing.** `Session` already carries `sessionId` (`LocalState.swift`), and `agents focus` already resolves live sessions across hosts (`commands/focus.ts:40`). This is one bridge method plus a submenu builder.

## Edge case handled

`sessionId` is nil for a row the engine couldn't identify (a cloud task, a stale sentinel). The item is **omitted rather than shown disabled**, so the menu never offers an action that would do nothing — and the submenu collapses to `nil` when neither action applies, rather than rendering an empty flyout.

The spawn is detached on purpose: `focus` opens a Terminal/tmux surface and can block on an attach; the menu bar must never wait on that.

## Run result

Built clean on macOS from this branch:

```
$ ssh zion 'cd /tmp/mb-build && swift build -c release'
[3/5] Write Objects.LinkFileList
[4/5] Linking MenubarHelper
Build complete! (46.82s)
```

Swift 6.3.2. The one warning is pre-existing (`NSUserNotificationCenter` deprecation in `PromptPanel.swift:1143`), untouched by this change.

**Not yet visually verified in the running menu bar** — that needs the helper installed and a live blocked session to click. Stated plainly rather than claimed.

Ticket: RUSH-2110.
