### PR TITLE
fix(projects): view is a superset of status, not a thinner card

### DIFF
--- a/apps/cli/.changelog/next/projects-view-superset.md
+++ b/apps/cli/.changelog/next/projects-view-superset.md
@@ -1,0 +1,14 @@
+- **`agents projects view <name>` now shows more than `status`, not less.** The command you
+  open to learn everything about one project built its own short list — root, repos, a raw
+  Linear project id, an issue count, milestones — and never called the card renderer, so it
+  omitted the agents roster, merged PRs and release, focus areas, the schedule verdict,
+  tickets, and artifacts that `status` had shown all along. `view` and `status` now gather
+  through one function and render through one card; `view` adds every milestone (instead of
+  just the next) and the stored definition in full underneath — each repo with its subpath and
+  checkout, each context with its purpose, each integration with its URL. It also takes
+  `--window <days>` to match `status`. Source: `apps/cli/src/commands/projects.ts`.
+- **The `agents` roster on the card lists live sessions only.** It included every matched
+  session, so a card headed `23 live` went on to print `claude · crashed ×25` — the corpses the
+  `dead` row already reports, counted twice and contradicting the headline. Both now derive
+  from one `isDeadStatus` predicate, pinned by a test across every `ActiveStatus`. Source:
+  `apps/cli/src/lib/project-status.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -77,6 +77,23 @@ machine resolves its own cwds against its own (synced) definitions before events
 cross the wire. `agents activity --project <name>` narrows the stream to one
 project, exact-matched on this label.
 
+## `view` is `status` for one project, plus the definition
+
+`status` answers *"is anything off track?"* across projects. `view <name>` answers *"tell me
+everything about this one"* — so it must be a **superset**, never a different, thinner card.
+
+It was thinner. `view` built its own picture (root, repos, a raw Linear id, an issue count,
+milestones) and never called the card renderer, so opening a single project showed strictly
+less than the roll-up across all of them: no agents, no ships, no focus, no schedule verdict.
+The renderer even took a `milestoneLimit` parameter documented as "`status` shows the next one;
+`view` shows all" — the seam was designed and then not connected.
+
+Both commands now gather through one function (`enrichProjectsForRender`) and render through
+one card, so a signal added for either appears on both. `view` differs in exactly two ways:
+every milestone instead of the next one, and the stored definition printed in full underneath
+(each repo with its subpath and checkout, each context with its purpose, each integration with
+its URL, the Linear link, the docs, and the YAML path).
+
 ## The progress card — `agents projects status`
 
 The headline. It matches every live session to a project **by cwd** (longest root
@@ -180,7 +197,7 @@ rush  ·  3 agents
 | --- | --- |
 | `agents projects list [--json]` | All projects: root, repo, live agent count. |
 | `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--context path:purpose`, `--linear`. |
-| `agents projects view <name> [--json] [--no-remote]` (alias `show`) | Full definition + resolved paths + contexts + links + **every** Linear milestone with dates and progress. |
+| `agents projects view <name> [--json] [--window N] [--no-remote]` (alias `show`) | Everything about one project: the whole `status` card (agents, ships, focus, schedule, tickets, proof), **every** Linear milestone, then the stored definition in full. |
 | `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
 | `agents projects status [name] [--json] [--window N] [--no-remote] [--fleet]` | The progress card (all projects, or one). `--fleet` adds per-device workspace drift over SSH. |
 | `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. |
@@ -327,6 +344,12 @@ lost (19 crashed)` — because 19 crashed sessions is a thing to go fix, not thr
 about. `orphaned` counts as **live**: `lib/session/active.ts` defines it as "alive, but no
 client is attached" (the agent outlived its window and is still working), and the repo's own
 dead rule (`commands/sessions.ts`) is `closed` and `crashed` only.
+
+The `agents` roster below the headline is filtered the same way. It used to list every matched
+session, so a card headed `23 live` went on to print `claude · crashed ×25` — the corpses the
+`dead` row already accounts for, shown a second time and contradicting the number above them.
+`isDeadStatus` is the single predicate behind both, and a test pins them to agree across every
+`ActiveStatus` so they cannot drift apart.
 
 **`planPct` measured whichever agent last wrote a todo list.** It summed each matched session's
 most recent checklist snapshot, so:

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -45,6 +45,7 @@ import {
 } from '../lib/projects.js';
 import {
   rollupSessionsByProject,
+  isDeadStatus,
   liveDeadSplit,
   enrichProjectSignals,
   formatProjectMembers,
@@ -310,6 +311,56 @@ function statusBar(r: ProjectSessionRollup): string {
   return parts.join(' · ') || chalk.gray('no live agents');
 }
 
+/** Everything a project card needs beyond the stored definition. */
+interface ProjectRenderData {
+  roll: Map<string, ProjectSessionRollup>;
+  remote: Map<string, ProjectRemoteSignals>;
+  linear: Map<string, LinearProjectCounts>;
+  focus: Map<string, FocusArea[]>;
+}
+
+/**
+ * Gather the live/remote/Linear/focus signals for the projects about to be
+ * rendered. `status` and `view` share this deliberately: `view` used to build
+ * its own thinner picture, so the command you open to learn everything about
+ * ONE project showed strictly less than the roll-up across all of them — no
+ * agents, no ships, no focus, no schedule verdict. One gatherer means a signal
+ * added for either surface appears on both.
+ *
+ * Only the shown projects are enriched. `skipRemote` still reads the local
+ * artifact log and git focus, and skips just the network calls (`gh`, Linear).
+ */
+async function enrichProjectsForRender(
+  defs: ProjectDef[],
+  all: ProjectDef[],
+  opts: {
+    windowDays: number;
+    nowMs: number;
+    skipRemote: boolean;
+    extraSessions?: Awaited<ReturnType<typeof getActiveSessions>>;
+  },
+): Promise<ProjectRenderData> {
+  const roll = rollupSessionsByProject(all, [...(await getActiveSessions()), ...(opts.extraSessions ?? [])]);
+  const remote = new Map<string, ProjectRemoteSignals>();
+  const linear = new Map<string, LinearProjectCounts>();
+  // Local git, no API, no rate limit — measured 0.23s over a 897-commit week.
+  const focus = new Map<string, FocusArea[]>();
+  await Promise.all(
+    defs.map(async (d) => {
+      const [sig, counts] = await Promise.all([
+        enrichProjectSignals(d, opts.windowDays, opts.nowMs, { skipRemote: opts.skipRemote }),
+        !opts.skipRemote && d.linear?.projectId
+          ? fetchLinearProjectCounts(d.linear.projectId)
+          : Promise.resolve(undefined),
+      ]);
+      remote.set(d.name, sig);
+      if (counts) linear.set(d.name, counts);
+      if (d.root) focus.set(d.name, await readFocusAreas(expandLocalHome(d.root), opts.windowDays));
+    }),
+  );
+  return { roll, remote, linear, focus };
+}
+
 function renderCard(
   def: ProjectDef,
   r: ProjectSessionRollup | undefined,
@@ -321,6 +372,8 @@ function renderCard(
   milestoneLimit: number = 1,
   /** Directories the window's work landed in, from local git. */
   focus: FocusArea[] = [],
+  /** `view` mode: the caller prints the stored definition in full afterwards. */
+  detail: boolean = false,
 ): void {
   // The headline counts LIVE agents. It used to be every matched session, which
   // read `39 agents` on a project where 19 had crashed. `planPct` used to sit
@@ -336,7 +389,11 @@ function renderCard(
     const detail = split.deadByStatus.map((d) => `${d.n} ${d.status}`).join(', ');
     console.log(`  ${chalk.dim('dead')}     ${chalk.yellow(`${split.dead} finished or lost`)} ${chalk.dim(`(${detail})`)}`);
   }
-  if (r && r.members.length) console.log(`  ${chalk.dim('agents')}   ${formatProjectMembers(r.members)}`);
+  // Live only. The roster used to list every matched session, so a card headed
+  // `23 live` went on to show `crashed ×25` — the corpses the `dead` row above
+  // already accounts for, counted twice and contradicting the headline.
+  const liveMembers = r?.members.filter((m) => !isDeadStatus(m.status)) ?? [];
+  if (liveMembers.length) console.log(`  ${chalk.dim('agents')}   ${formatProjectMembers(liveMembers)}`);
   const ships: string[] = [];
   if (remote?.mergedPrs) {
     ships.push(chalk.green(`${remote.mergedPrs}${remote.mergedPrsTruncated ? '+' : ''} merged (${remote.windowDays}d)`));
@@ -385,13 +442,15 @@ function renderCard(
     console.log(`  ${chalk.yellow('!')}        ${chalk.yellow(mismatch.message)}`);
     console.log(`  ${' '.repeat(8)}${chalk.gray(mismatch.remediation)}`);
   }
-  if (def.contexts?.length) {
+  // `view` prints these in full (path + purpose, label + URL) right below, so
+  // the compact one-line summaries would just say the same thing twice.
+  if (!detail && def.contexts?.length) {
     console.log(`  ${chalk.dim('context')}  ${def.contexts.map((c) => c.path).join(' · ')}`);
   }
-  if (def.integrations?.length) {
+  if (!detail && def.integrations?.length) {
     console.log(`  ${chalk.dim('links')}    ${def.integrations.map((i) => i.label ?? i.kind).join(' · ')}`);
   }
-  console.log('');
+  if (!detail) console.log('');
 }
 
 export function registerProjectsCommands(program: Command): void {
@@ -523,52 +582,73 @@ export function registerProjectsCommands(program: Command): void {
   projects
     .command('view <name>')
     .alias('show')
-    .description('Show a project definition, resolved paths, repos, contexts, links, and milestones.')
+    .description('Everything about one project: the full status card, every milestone, and the stored definition.')
     .option('--json', 'Machine-readable output')
-    .option('--no-remote', 'Skip the Linear lookup; definition only')
-    .action(async (name: string, opts: { json?: boolean; remote?: boolean }) => {
+    .option('--window <days>', 'Window for merged PRs, artifacts, and focus areas', '7')
+    .option('--no-remote', 'Skip the GitHub and Linear lookups; definition only')
+    .action(async (name: string, opts: { json?: boolean; window?: string; remote?: boolean }) => {
       const def = loadProjectDef(name);
       if (!def) {
         console.error(chalk.red(`No project named "${name}". List them: agents projects list`));
         process.exit(1);
       }
-      // Every milestone the project declares, not just the next one — the whole
-      // point of opening ONE project is to see the shape of its plan.
-      const counts =
-        opts.remote !== false && def.linear?.projectId
-          ? await fetchLinearProjectCounts(def.linear.projectId)
-          : undefined;
+      // `view` is `status` for one project PLUS the stored definition and every
+      // milestone. It used to render its own short list — root, repos, a raw
+      // Linear id, issues — so opening a single project told you LESS than the
+      // roll-up did: no agents, no ships, no focus, no schedule verdict.
+      const windowDays = Math.max(1, Number.parseInt(opts.window ?? '7', 10) || 7);
+      const nowMs = Date.now();
+      const all = listProjectDefs();
+      const { roll, remote, linear, focus } = await enrichProjectsForRender([def], all, {
+        windowDays,
+        nowMs,
+        skipRemote: opts.remote === false,
+      });
+      const r = roll.get(def.name);
+      const sig = remote.get(def.name);
+      const counts = linear.get(def.name);
       if (opts.json) {
-        console.log(JSON.stringify({ ...def, linear: { ...def.linear, ...(counts ?? {}) } }, null, 2));
+        console.log(
+          JSON.stringify(
+            {
+              ...def,
+              linear: { ...def.linear, ...(counts ?? {}) },
+              schedule: counts?.milestones?.length ? scheduleVerdict(counts.milestones, nowMs) : null,
+              live: r ? liveDeadSplit(r.byStatus).live : 0,
+              dead: r ? liveDeadSplit(r.byStatus).dead : 0,
+              byStatus: r?.byStatus ?? {},
+              members: r?.members ?? [],
+              openPrs: r?.openPrs ?? [],
+              tickets: r?.tickets ?? [],
+              mergedPrs: sig?.mergedPrs ?? 0,
+              latestRelease: sig?.latestRelease ?? null,
+              artifacts: sig?.artifacts ?? 0,
+              focus: focus.get(def.name) ?? [],
+            },
+            null,
+            2,
+          ),
+        );
         return;
       }
-      console.log(chalk.bold(def.name) + (def.description ? chalk.dim(`  — ${def.description}`) : ''));
-      if (def.root) console.log(`  root         ${def.root}`);
-      if (def.defaultPath) console.log(`  defaultPath  ${def.defaultPath}`);
-      const repos = [def.repo, ...(def.repos ?? []).map((r) => (r.subpath ? `${r.slug} (${r.subpath})` : r.slug))].filter(Boolean);
-      if (repos.length) console.log(`  repos        ${repos.join(', ')}`);
-      for (const c of def.contexts ?? []) console.log(`  context      ${chalk.cyan(c.path)} — ${c.purpose}`);
-      for (const i of def.integrations ?? []) console.log(`  ${i.kind.padEnd(12)} ${i.url}${i.label ? chalk.dim(`  (${i.label})`) : ''}`);
-      if (def.linear?.url || def.linear?.projectId) console.log(`  linear       ${def.linear.url ?? def.linear.projectId}`);
-      for (const d of def.docs ?? []) console.log(`  doc          ${d}`);
-      if (counts) {
-        const staleNote = counts.stale ? chalk.dim('  (cached)') : '';
-        console.log(`  issues       ${counts.done}/${counts.total}${counts.truncated ? '+' : ''} done · ${counts.inProgress} in progress${staleNote}`);
+
+      // The same card `status` prints, with every milestone instead of the next.
+      renderCard(def, r, sig, undefined, counts, nowMs, Number.POSITIVE_INFINITY, focus.get(def.name) ?? [], true);
+
+      // Then what only `view` shows: the stored definition, in full.
+      console.log();
+      if (def.root) console.log(`  ${chalk.dim('root')}     ${def.root}`);
+      if (def.defaultPath) console.log(`  ${chalk.dim('path')}     ${def.defaultPath}`);
+      for (const rp of def.repos ?? []) {
+        const where = [rp.subpath ? `subpath ${rp.subpath}` : undefined, rp.path].filter(Boolean).join(' · ');
+        console.log(`  ${chalk.dim('repo')}     ${rp.slug}${where ? chalk.dim(`  (${where})`) : ''}`);
       }
-      const ms = counts?.milestones ?? [];
-      if (ms.length) {
-        console.log(`  ${chalk.bold('milestones')}`);
-        for (const m of ms) {
-          const mark = m.name === counts?.nextMilestone?.name ? chalk.cyan('next') : '';
-          console.log(`    ${mark.padEnd(6)}     ${formatNextMilestone(m, Date.now())}`);
-        }
-        // A milestone nothing is filed against cannot report progress. Say that
-        // once, plainly, rather than printing a row of silent 0%s.
-        const unfiled = ms.filter((m) => m.total === 0).length;
-        if (unfiled === ms.length) {
-          console.log(`    ${chalk.yellow('!')}          ${chalk.yellow(`no issues are assigned to any milestone — progress against them cannot be measured`)}`);
-        }
+      for (const c of def.contexts ?? []) console.log(`  ${chalk.dim('context')}  ${chalk.cyan(c.path)} ${chalk.dim('—')} ${c.purpose}`);
+      for (const ig of def.integrations ?? []) {
+        console.log(`  ${chalk.dim(ig.kind.padEnd(8))} ${ig.url}${ig.label ? chalk.dim(`  (${ig.label})`) : ''}`);
       }
+      if (def.linear?.url || def.linear?.projectId) console.log(`  ${chalk.dim('linear')}   ${def.linear.url ?? def.linear.projectId}`);
+      for (const d of def.docs ?? []) console.log(`  ${chalk.dim('doc')}      ${d}`);
       console.log(chalk.gray(`  ${projectDefPath(name)}`));
     });
 
@@ -641,27 +721,12 @@ export function registerProjectsCommands(program: Command): void {
         fleetSessions = activeRes.sessions;
       }
 
-      const roll = rollupSessionsByProject(all, [...await getActiveSessions(), ...fleetSessions]);
-      // Enrich only the shown projects. --no-remote still reads the local artifact
-      // log but skips the gh calls + Linear counts (both are network).
-      const remote = new Map<string, ProjectRemoteSignals>();
-      const linear = new Map<string, LinearProjectCounts>();
-      // Local git, no API, no rate limit — measured 0.23s over a 897-commit week.
-      const focus = new Map<string, FocusArea[]>();
-      await Promise.all(
-        defs.map(async (d) => {
-          const skipRemote = opts.remote === false;
-          const [sig, counts] = await Promise.all([
-            enrichProjectSignals(d, windowDays, nowMs, { skipRemote }),
-            !skipRemote && d.linear?.projectId
-              ? fetchLinearProjectCounts(d.linear.projectId)
-              : Promise.resolve(undefined),
-          ]);
-          remote.set(d.name, sig);
-          if (counts) linear.set(d.name, counts);
-          if (d.root) focus.set(d.name, await readFocusAreas(expandLocalHome(d.root), windowDays));
-        }),
-      );
+      const { roll, remote, linear, focus } = await enrichProjectsForRender(defs, all, {
+        windowDays,
+        nowMs,
+        skipRemote: opts.remote === false,
+        extraSessions: fleetSessions,
+      });
 
       /** This def's slice of the fleet probe, in its own target order. */
       const fleetFor = (d: ProjectDef): HostWorkspaceStatus[] => {

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   rollupSessionsByProject,
+  isDeadStatus,
   liveDeadSplit,
   enrichProjectSignals,
   sortProjectMembers,
@@ -125,6 +126,32 @@ describe('liveDeadSplit', () => {
 
   it('ignores zero counts rather than emitting empty buckets', () => {
     expect(liveDeadSplit({ running: 2, crashed: 0 }).deadByStatus).toEqual([]);
+  });
+});
+
+describe('isDeadStatus — keeps the agents roster consistent with the headline', () => {
+  // The card prints `N live`, a `dead` row, then the agents roster. The roster
+  // used to list every matched session, so a card headed `23 live` went on to
+  // show `crashed x25` — the same corpses the dead row reports, contradicting
+  // the headline. The roster filter and the headline split must never disagree.
+  const EVERY_STATUS = [
+    'running', 'idle', 'queued', 'input_required',
+    'orphaned', 'abandoned', 'unknown',
+    'closed', 'crashed',
+  ];
+
+  it('agrees with liveDeadSplit on every ActiveStatus', () => {
+    const keptByRoster = EVERY_STATUS.filter((s) => !isDeadStatus(s)).length;
+    const split = liveDeadSplit(Object.fromEntries(EVERY_STATUS.map((s) => [s, 1])));
+    expect(keptByRoster).toBe(split.live);
+  });
+
+  it('drops exactly the statuses the dead row already accounts for', () => {
+    expect(isDeadStatus('crashed')).toBe(true);
+    expect(isDeadStatus('closed')).toBe(true);
+    // orphaned is alive — an agent that outlived its window, still working.
+    expect(isDeadStatus('orphaned')).toBe(false);
+    expect(isDeadStatus('running')).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -132,6 +132,16 @@ export function rollupSessionsByProject(
  */
 const DEAD_STATUSES = new Set(['closed', 'crashed']);
 
+/**
+ * True when a session's status means it is over. Exported so the card can keep
+ * the `agents` roster to live sessions: the headline and the `dead` row already
+ * separate the two, and a roster that reads `crashed ×25` beside `23 live`
+ * makes the reader distrust both numbers.
+ */
+export function isDeadStatus(status: string): boolean {
+  return DEAD_STATUSES.has(status);
+}
+
 /*
  * Every `ActiveStatus`, and why it lands where it does:
  *


### PR DESCRIPTION
**Bugfix.** `agents projects view <name>` showed strictly **less** than `agents projects
status` — the opposite of what a per-project deep view should do. Reported from a real run.

## Before / after — the same command, same board

```
                                   BEFORE                          AFTER
agents-cli                         agents-cli                      agents-cli · 22 live
                                     root  ~/src/.../agents-cli       live     16 running · 1 idle · +5 other
                                     repos phnx-labs/agents-cli       dead     25 finished or lost (25 crashed)
                                     linear 8eb8f5b1-3870-45...      agents   claude · running x14 · grok ...
                                     issues 368/453 done             ships    100+ merged (7d) · v1.22.0
                                     milestones                      linear   368/453 done · 12 in progress
                                       next Factory converts...      next     Factory converts... · due Sep 15
                                            Factory reliability...            Factory reliability... · due Sep 30
                                            Factory onboarding...             Factory onboarding... · due Oct 15
                                       ! no issues assigned          schedule 3 milestones, no issues filed
                                                                     focus    apps/cli/src 2138 · docs 278 ...
                                                                     tickets  RUSH-2107 · PROJ-123
                                                                     proof    90 artifacts (7d)
                                                                     repos    phnx-labs/agents-cli
                                                                     root/linear/contexts/docs + YAML path
```

## Why it happened

`view` never called `renderCard`; it hand-rolled a short list. `renderCard` already takes a
`milestoneLimit` parameter documented as **"`status` shows the next one; `view` shows all"** —
the seam was designed and then not connected, so every signal added since (focus, schedule
verdict, live/dead split, ships, tickets, artifacts) landed on `status` only.

Fix: one gatherer (`enrichProjectsForRender`) and one renderer for both commands, so a signal
added for either appears on both. `view` differs in exactly two ways — every milestone instead
of the next, and the stored definition printed in full underneath (each repo with subpath and
checkout, each context with its purpose, each integration with its URL). It also gains
`--window <days>` to match `status`.

## Second fix in the same card: the roster listed corpses

The headline says `22 live` and the `dead` row says `25 crashed` — then the `agents` roster
printed `claude · crashed ×25` anyway, counting the wreckage twice and contradicting the number
directly above it. Both now derive from one `isDeadStatus` predicate.

## Run result

`agents projects view agents-cli` after (real board, trimmed above; full output in the diff's
doc section). `agents projects status` re-run to confirm no regression — both render.

Tests: **96 passed** across the five project suites (94 before). The two new cases pin the
roster filter against `liveDeadSplit` over **every** `ActiveStatus`, so the roster and the
headline cannot drift apart again.

Docs: `apps/cli/docs/11-projects.md` gains a "`view` is `status` for one project" section and a
corrected command table row. CHANGELOG entry added.
