### PR TITLE
docs(projects): definitions are syncable, not synced

### DIFF
--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -18,8 +18,25 @@ noise; what matters is the **project**. This subsystem fills both gaps.
 ## The definition — `~/.agents/projects/<name>.yaml`
 
 One hand-editable YAML file per project, beside `routines/` and `monitors/` in the
-user repo, so it syncs across machines via `agents push/pull`. Paths are stored
-home-relative (`~/…`) so a definition re-roots on any machine.
+user repo. Paths are stored home-relative (`~/…`) so a definition re-roots on any
+machine.
+
+> **Commit them, or lose them.** Sitting in the user repo makes a definition
+> *syncable*, not synced. `agents projects add` writes the file; nothing commits it.
+> Until you run `agents repo push user`, `projects/` is an **untracked** directory, and
+> any reconcile that cleans the working tree deletes it — this cost one machine its four
+> definitions twice in a day. The only trace afterwards is a
+> `chore(local): save …-sync drift` commit that is unreachable from `HEAD`, so it is
+> recoverable until git collects it and not after. Recover with:
+>
+> ```bash
+> cd ~/.agents
+> git log --all --oneline --diff-filter=A -- 'projects/*'   # find the drift commit
+> git show <sha>:projects/<name>.yaml > projects/<name>.yaml
+> ```
+>
+> (`agents push` was removed; the command is `agents repo push <alias>`. Note that it
+> stages with `git add -A`, so check `git status` for unrelated drift first.)
 
 ```yaml
 name: rush                      # stable id == filename; what --project takes

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -5,8 +5,17 @@
  * directory by pure convention (`<projectRoot>/<slug>`, see `project-root.ts`).
  * This module adds editable definitions on top: one YAML file per project under
  * `~/.agents/projects/<name>.yaml`, sitting beside the existing `routines/`,
- * `monitors/`, and `teams/` dirs in the user repo (so definitions sync across
- * machines for free via `agents push/pull`). A defined project can name itself
+ * `monitors/`, and `teams/` dirs in the user repo.
+ *
+ * That location makes definitions SYNCABLE, not automatically synced: they ride
+ * the user repo only once they are committed to it, via `agents repo push user`
+ * (`agents push` was removed). Until then the directory is untracked, and a
+ * reconcile that cleans the working tree deletes it — observed twice on one
+ * machine, taking four definitions with it each time. The recovery is an
+ * orphaned `chore(local): save …-sync drift` commit, which is not a guarantee:
+ * unreachable objects are collected. Say "commit them" rather than "for free".
+ *
+ * A defined project can name itself
  * independently of its folder, bind more than one repo, pin a monorepo subpath,
  * describe context subdirectories an agent should start from, carry a Linear
  * link and external integrations, and set an explicit default path.


### PR DESCRIPTION
**docs-only.** No behavior change. Audience: anyone using `agents projects`, and the next
person to debug why their definitions vanished.

## What was wrong

`lib/projects.ts` opened by telling readers that definitions "sync across machines for free via
`agents push/pull`". Both halves are false:

- **`agents push` was removed** — `commands/push.ts` is now a hard-error redirect to
  `agents repo push <alias>`. The comment names a command that exits 2.
- **Nothing commits the files.** `agents projects add` writes
  `~/.agents/projects/<name>.yaml` and stops there, so `projects/` stays an **untracked**
  directory in the user repo — unlike its tracked siblings `routines/` (23 files) and
  `monitors/`.

## Why it matters — this destroyed real data

An untracked directory does not survive a reconcile that cleans the working tree. On one
machine that deleted all four project definitions **twice in one day**. The failure is quiet
and easy to misread: the same reconcile also resets the `projects` beta flag, so it presents as
"the feature disappeared" rather than "your data was deleted."

The apparent safety net does not hold either. The sync leaves a
`chore(local): save …-sync drift on <host>` commit that *does* contain the yaml, but it is
**unreachable from `HEAD`**:

```
$ cd ~/.agents && git merge-base --is-ancestor 26920e5 HEAD || echo ORPHANED
ORPHANED (not reachable from HEAD)

$ git status --short
 M agents.yaml
?? projects/          <- untracked; its siblings routines/ and monitors/ are tracked
```

So recovery works until git collects the objects, and not after.

## The change

States what actually happens — the location makes a definition *syncable*, not synced —
names the real command, and documents the recovery:

```bash
cd ~/.agents
git log --all --oneline --diff-filter=A -- 'projects/*'   # find the drift commit
git show <sha>:projects/<name>.yaml > projects/<name>.yaml
```

with the caveat that `agents repo push user` stages via `git add -A`, so unrelated drift in
that repo rides along.

**Not fixed here:** making `projects/` tracked automatically. That is a behavior change to the
sync and deserves its own PR — this one stops the docs from claiming the problem cannot happen.
