### PR TITLE
fix(factory): remove the Enable/Disable Tmux palette commands

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Factory extension are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [Unreleased]
+
+- **Removed the `Agents: Enable Tmux` / `Agents: Disable Tmux` palette commands.**
+  They were back-compat aliases that just flipped the `agents.terminalMode`
+  setting, and the extension no longer needs its own tmux "mode" toggle — the
+  `agents` CLI wraps interactive launches in tmux itself. The `agents.terminalMode`
+  setting stays (set it to `native` in settings.json if you want VS Code editor
+  terminals instead of tmux), and tmux-backed reconnect resilience is unchanged.
+  Removes the two commands, their command-palette menu entries, and the now-unused
+  `agents.tmuxEnabled` context key. Source: `src/vscode/extension.ts`,
+  `package.json`.
+
 ## [0.9.309] - 2026-08-03
 
 - **Watchdog auto-rotate delegates to `agents run auto` — no more rotate loops into exhausted accounts.**

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -275,14 +275,6 @@
         "title": "Agents: Enable Notifications"
       },
       {
-        "command": "agents.enableTmux",
-        "title": "Agents: Enable Tmux"
-      },
-      {
-        "command": "agents.disableTmux",
-        "title": "Agents: Disable Tmux"
-      },
-      {
         "command": "agents.newTask",
         "title": "Agents: New Task"
       },
@@ -702,16 +694,6 @@
           "command": "agents.newDroid",
           "when": "true",
           "group": "navigation@2"
-        },
-        {
-          "command": "agents.enableTmux",
-          "when": "!agents.tmuxEnabled",
-          "group": "navigation@3"
-        },
-        {
-          "command": "agents.disableTmux",
-          "when": "agents.tmuxEnabled",
-          "group": "navigation@3"
         },
         {
           "command": "agents.enableReader",

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -1731,26 +1731,6 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('agents.enableTmux', async () => {
-      // Back-compat command id: flips terminalMode back to 'auto' (tmux by
-      // default when available). The setting is the source of truth now.
-      const config = vscode.workspace.getConfiguration();
-      await config.update('agents.terminalMode', 'auto', vscode.ConfigurationTarget.Global);
-      vscode.window.showInformationMessage('Tmux mode enabled (auto). New agent terminals will run inside tmux when available.');
-      await updateContextKeys(context);
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('agents.disableTmux', async () => {
-      const config = vscode.workspace.getConfiguration();
-      await config.update('agents.terminalMode', 'native', vscode.ConfigurationTarget.Global);
-      vscode.window.showInformationMessage('Tmux mode disabled. New agent terminals will use VS Code editor terminals.');
-      await updateContextKeys(context);
-    })
-  );
-
-  context.subscriptions.push(
     vscode.commands.registerCommand('agents.enableReader', async () => {
       const current = settings.getSettings(context);
       const next: AgentSettings = {
@@ -4992,11 +4972,6 @@ async function reloadActiveTerminal(context: vscode.ExtensionContext) {
 }
 
 async function updateContextKeys(context: vscode.ExtensionContext): Promise<void> {
-  const config = vscode.workspace.getConfiguration('agents');
-  // 'native' hides the "Disable Tmux" toggle; 'auto'/'tmux' show it (tmux is active).
-  const tmuxEnabled = normalizeTerminalMode(config.get('terminalMode')) !== 'native';
-  await vscode.commands.executeCommand('setContext', 'agents.tmuxEnabled', tmuxEnabled);
-
   const readerEnabled = settings.getSettings(context).editor?.markdownViewerEnabled ?? true;
   await vscode.commands.executeCommand('setContext', 'agents.readerEnabled', readerEnabled);
 }


### PR DESCRIPTION
**fix / cleanup** — removes the redundant tmux mode toggle from the command palette. Audience: Factory maintainers.

## What changed

Deletes the `Agents: Enable Tmux` / `Agents: Disable Tmux` palette commands. Per the code, they were **back-compat aliases** that just flipped the `agents.terminalMode` setting between `auto` and `native`. The extension does not need its own tmux "mode" toggle — the `agents` CLI already wraps interactive launches in tmux itself (`shouldWrapInTmux` → `runInTmux` → `createSession`, `apps/cli/src/lib/exec.ts`).

Removed:
- the two `registerCommand` blocks (`src/vscode/extension.ts`)
- their two command definitions + command-palette menu entries (`package.json`)
- the now-unused `agents.tmuxEnabled` context key (only gated those two menu items)

## Kept — deliberately out of scope

- `agents.terminalMode` **setting** stays. Set it to `native` in settings.json to get VS Code editor terminals instead of tmux — the escape hatch survives, just not as a palette toggle.
- **tmux reconnect resilience** (SSH-drop survival, detached re-attach: `reconnect.ts`, the reload-ownership split, the close-handler kill/detach classification) is untouched. Fully removing the extension's tmux subsystem would regress that; not done here.

## Verification

- No remaining references to `enableTmux` / `disableTmux` / `agents.tmuxEnabled` in `src` or `package.json` (grep clean; the only `enableTmux` mentions left are historical comments in `core/terminalMode.ts`).
- `package.json` validates as JSON.
- `normalizeTerminalMode` / the tmux split logic (`Cmd+Shift+H/V`) still compile and are unchanged.
- Deletions only (12 insertions from the CHANGELOG entry, 43 deletions of the commands/menus/context-key).

Diff is command/menu/context-key deletions + a CHANGELOG note — no runtime UI to screenshot; the removed commands simply no longer appear in the palette.
