### PR TITLE
fix(factory): resume grok/kimi/droid/antigravity through restore/reopen/reload (#1747)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Factory extension are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
+## [Unreleased]
+
+- **grok / kimi / droid / antigravity tabs now restore, reopen, and reload like the prewarm agents (#1747).**
+  Resume past the picker was still gated on `supportsPrewarming` (claude/codex/gemini/cursor/opencode),
+  so a grok/kimi/droid/antigravity tab did not come back after a window reload, a reopen-last, or a
+  reload-active-terminal — even though its transcript exists and `agents run --resume` can resume it. The
+  three surfaces now gate on the same registry check the picker uses (`agentKeyFromSession`), reload falls
+  back to a generic Ctrl+C-twice exit sequence for agents without a `PREWARM_CONFIGS` entry, and the
+  `openSingleAgent` launch path now tracks + polls those harnesses too so there is a persisted session to
+  come back to.
+
 ## [0.9.309] - 2026-08-03
 
 - **Watchdog auto-rotate delegates to `agents run auto` — no more rotate loops into exhausted accounts.**

--- a/apps/factory/src/core/prewarm.test.ts
+++ b/apps/factory/src/core/prewarm.test.ts
@@ -11,6 +11,8 @@ import {
   buildResumeCommand,
   buildVersionedResumeCommand,
   supportsPrewarming,
+  exitSequenceFor,
+  DEFAULT_EXIT_SEQUENCE,
   PrewarmedSession,
 } from './prewarm';
 
@@ -340,6 +342,24 @@ describe('supportsPrewarming', () => {
 
   test('returns false for unsupported agents', () => {
     expect(supportsPrewarming('random')).toBe(false);
+  });
+});
+
+describe('exitSequenceFor', () => {
+  test('prewarm agents use their tuned exit sequence', () => {
+    // Claude needs a leading Esc; the other four use Ctrl+C twice.
+    expect(exitSequenceFor('claude')).toEqual(['\x1b', '\x03', '\x03']);
+    expect(exitSequenceFor('codex')).toEqual(['\x03', '\x03']);
+    expect(exitSequenceFor('opencode')).toEqual(['\x03', '\x03']);
+  });
+
+  test('non-prewarm harnesses fall back to Ctrl+C twice (#1747)', () => {
+    // grok/kimi/droid/antigravity have no PREWARM_CONFIGS entry but must still
+    // be reload-able; the generic exit is the default.
+    for (const agent of ['grok', 'kimi', 'droid', 'antigravity']) {
+      expect(exitSequenceFor(agent)).toEqual([...DEFAULT_EXIT_SEQUENCE]);
+    }
+    expect(DEFAULT_EXIT_SEQUENCE).toEqual(['\x03', '\x03']);
   });
 });
 

--- a/apps/factory/src/core/prewarm.ts
+++ b/apps/factory/src/core/prewarm.ts
@@ -235,6 +235,26 @@ export function supportsPrewarming(agentType: string): agentType is PrewarmAgent
   return agentType === 'claude' || agentType === 'codex' || agentType === 'gemini' || agentType === 'cursor' || agentType === 'opencode';
 }
 
+/**
+ * Ctrl+C twice — the exit sequence for any agent without a {@link PREWARM_CONFIGS}
+ * entry. Four of the five prewarm agents already use exactly this; the fifth
+ * (Claude) needs a leading Esc. A resumable non-prewarm agent (grok/kimi/droid/
+ * antigravity) is a Ctrl+C-to-quit CLI, so this is the safe default.
+ */
+export const DEFAULT_EXIT_SEQUENCE: readonly string[] = ['\x03', '\x03'];
+
+/**
+ * Keystrokes that cleanly exit a running agent before a reload/resume. Prewarm
+ * agents use their tuned sequence; every other resumable harness falls back to
+ * {@link DEFAULT_EXIT_SEQUENCE}. Keeping this beside {@link PREWARM_CONFIGS} means
+ * reload never has to know which agents are prewarm-capable.
+ */
+export function exitSequenceFor(agentType: string): readonly string[] {
+  return agentType in PREWARM_CONFIGS
+    ? PREWARM_CONFIGS[agentType as PrewarmAgentType].exitSequence
+    : DEFAULT_EXIT_SEQUENCE;
+}
+
 // === Blocking Prompt Detection ===
 
 export type BlockedReason = 'trust_prompt' | 'auth_required' | 'rate_limit' | 'unknown_prompt';

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -169,7 +169,7 @@ async function ensureAgentsCliInstalled(): Promise<void> {
     }
   }
 }
-import { supportsPrewarming, buildVersionedResumeCommand, PREWARM_CONFIGS, PrewarmAgentType } from '../core/prewarm';
+import { supportsPrewarming, buildVersionedResumeCommand, exitSequenceFor, PrewarmAgentType } from '../core/prewarm';
 import { generateClaudeSessionId, listOpencodeSessions } from '../core/prewarm.simple';
 import { liveSessionIdForShell } from '../core/liveSession';
 import { getSessionPathBySessionId, getSessionPreviewInfo, getOpenCodeSessionPreviewInfo, getCursorSessionPreviewInfo } from './sessions.vscode';
@@ -2381,8 +2381,11 @@ async function openSingleAgent(
         : {});
     }
 
-    if (agentKey && supportsPrewarming(agentKey)) {
-      terminals.setAgentType(terminal, agentKey);
+    // Track + poll any known harness, not just the prewarm five (#1747), so
+    // grok/kimi/droid/antigravity tabs are resumable through restore/reopen/reload.
+    const resumeKey = agentKey ? agentKeyFromSession(agentKey) : null;
+    if (resumeKey) {
+      terminals.setAgentType(terminal, resumeKey);
     }
     // Stamp the host BEFORE the label poller starts: the poller reads the entry
     // to decide whether to look the session up locally or over `--host`.
@@ -2391,7 +2394,7 @@ async function openSingleAgent(
     }
     if (sessionId) {
       terminals.setSessionId(terminal, sessionId);
-      if (agentKey && supportsPrewarming(agentKey)) {
+      if (resumeKey) {
         startAutoLabelPollerForTerminal(terminal, context);
       }
     }
@@ -2431,8 +2434,10 @@ async function openSingleAgent(
   terminals.register(terminal, terminalId, agentConfig, pid, context);
   readiness.registerTerminal(terminal);
 
-  if (agentKey && supportsPrewarming(agentKey)) {
-    terminals.setAgentType(terminal, agentKey);
+  // Track + poll any known harness, not just the prewarm five (#1747).
+  const resumeKey = agentKey ? agentKeyFromSession(agentKey) : null;
+  if (resumeKey) {
+    terminals.setAgentType(terminal, resumeKey);
   }
   // Stamp the host BEFORE the label poller starts: the poller reads the entry
   // to decide whether to look the session up locally or over `--host`.
@@ -2441,7 +2446,7 @@ async function openSingleAgent(
   }
   if (sessionId) {
     terminals.setSessionId(terminal, sessionId);
-    if (agentKey && supportsPrewarming(agentKey)) {
+    if (resumeKey) {
       startAutoLabelPollerForTerminal(terminal, context);
     }
   }
@@ -3139,10 +3144,10 @@ async function copySessionId() {
  * a shell tab has no conversation to resume.
  *
  * The OTHER resume surfaces — `restoreAgentTerminals` (reload), the reopen-last
- * command, and reload-active-terminal — still gate on `supportsPrewarming`, so
- * grok/kimi/droid/antigravity do not come back through those. Widening them
- * means touching the crash-restore persistence path, which is deliberately out
- * of scope here; tracked in issue #1747.
+ * command, and reload-active-terminal — now gate on this same registry check
+ * rather than `supportsPrewarming`, so grok/kimi/droid/antigravity come back
+ * through those too (#1747); reload falls back to a generic exit sequence for
+ * agents without a PREWARM_CONFIGS entry.
  */
 function agentKeyFromSession(agent: string): SessionAgentType | null {
   if (!agent || agent === 'shell') return null;
@@ -4122,8 +4127,11 @@ export async function openSingleAgentWithQueue(
   if (targetHost) terminals.setHost(terminal, targetHost);
   readiness.registerTerminal(terminal);
 
-  // Track session ID and agent type
-  if (agentKey && supportsPrewarming(agentKey)) {
+  // Track session ID and agent type. Any known harness is tracked, not just the
+  // prewarm five (#1747) — this feeds the persistence path that restore/reopen
+  // read, so grok/kimi/droid/antigravity tabs must be tracked here too or they
+  // have nothing to come back to.
+  if (agentKey && agentKeyFromSession(agentKey)) {
     // Set agent type unconditionally so the sessionTracker fs watcher can adopt
     // a session id when the CLI writes a fresh rollout/jsonl (Codex 0.124+
     // dropped session id from the TUI banner so this is the only signal).
@@ -4242,8 +4250,10 @@ async function openAgentTerminals(context: vscode.ExtensionContext) {
       terminals.register(terminal, terminalId, agent, pid, context);
       readiness.registerTerminal(terminal);
 
-      // Track session ID
-      if (agentKey && supportsPrewarming(agentKey)) {
+      // Track session ID for any known harness, not just the prewarm five (#1747):
+      // this path also starts the label poller that hydrates the live session id,
+      // so a grok/kimi/droid/antigravity tab needs it too to be resumable.
+      if (agentKey && agentKeyFromSession(agentKey)) {
         // Set agent type unconditionally so sessionTracker fs watcher can adopt
         // a session id from the CLI's rollout file (Codex 0.124+ banner has none).
         terminals.setAgentType(terminal, agentKey);
@@ -4953,13 +4963,16 @@ async function reloadActiveTerminal(context: vscode.ExtensionContext) {
       return;
     }
 
-    if (!supportsPrewarming(agentType)) {
+    // Any known harness with a transcript can reload, not just the prewarm five —
+    // `agents run --resume` resumes grok/kimi/droid/antigravity too (#1747). Only
+    // a shell / unknown tab has nothing to reload.
+    if (!agentKeyFromSession(agentType)) {
       vscode.window.showErrorMessage('This agent type does not support session reload.');
       return;
     }
 
-    const config = PREWARM_CONFIGS[agentType];
-    const exitSequence = config.exitSequence;
+    // Prewarm agents use their tuned exit keys; the rest fall back to Ctrl+C twice.
+    const exitSequence = exitSequenceFor(agentType);
     const resumeCommand = buildVersionedResumeCommand(agentType, sessionId, entry.version, entry.host);
 
     terminal.show();
@@ -5586,8 +5599,10 @@ async function restoreAgentTerminals(context: vscode.ExtensionContext): Promise<
       }
       startAutoLabelPollerForTerminal(terminal, context);
 
-      // Actually resume the session by sending the resume command
-      if (supportsPrewarming(session.agentType)) {
+      // Actually resume the session by sending the resume command. Any known
+      // harness resumes here, not just the prewarm five (#1747) — buildVersioned-
+      // ResumeCommand routes non-prewarm agents through `agents run --resume`.
+      if (agentKeyFromSession(session.agentType)) {
         const resumeCmd = buildVersionedResumeCommand(
           session.agentType,
           session.sessionId,
@@ -5779,7 +5794,8 @@ async function reopenLastClosedSession(context: vscode.ExtensionContext): Promis
     }
     startAutoLabelPollerForTerminal(terminal, context);
 
-    if (supportsPrewarming(closed.agentType)) {
+    // Any known harness reopens, not just the prewarm five (#1747).
+    if (agentKeyFromSession(closed.agentType)) {
       const resumeCmd = buildVersionedResumeCommand(
         closed.agentType,
         closed.sessionId,

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -169,7 +169,7 @@ async function ensureAgentsCliInstalled(): Promise<void> {
     }
   }
 }
-import { supportsPrewarming, buildVersionedResumeCommand, exitSequenceFor, PrewarmAgentType } from '../core/prewarm';
+import { supportsPrewarming, buildVersionedResumeCommand, exitSequenceFor } from '../core/prewarm';
 import { generateClaudeSessionId, listOpencodeSessions } from '../core/prewarm.simple';
 import { liveSessionIdForShell } from '../core/liveSession';
 import { getSessionPathBySessionId, getSessionPreviewInfo, getOpenCodeSessionPreviewInfo, getCursorSessionPreviewInfo } from './sessions.vscode';
@@ -4073,7 +4073,7 @@ export async function openSingleAgentWithQueue(
 
   // Determine agent key and handle session ID
   const builtInDef = getBuiltInByPrefix(agentConfig.prefix);
-  const agentKey = builtInDef?.key as 'claude' | 'codex' | 'gemini' | 'opencode' | 'cursor' | undefined;
+  const agentKey = builtInDef?.key as keyof AgentSettings['builtIn'] | undefined;
   const defaultModel = agentKey ? settings.getDefaultModel(context, agentKey) : undefined;
 
   let command = agentConfig.command;
@@ -4131,11 +4131,12 @@ export async function openSingleAgentWithQueue(
   // prewarm five (#1747) — this feeds the persistence path that restore/reopen
   // read, so grok/kimi/droid/antigravity tabs must be tracked here too or they
   // have nothing to come back to.
-  if (agentKey && agentKeyFromSession(agentKey)) {
+  const resumeKey = agentKey ? agentKeyFromSession(agentKey) : null;
+  if (resumeKey) {
     // Set agent type unconditionally so the sessionTracker fs watcher can adopt
     // a session id when the CLI writes a fresh rollout/jsonl (Codex 0.124+
     // dropped session id from the TUI banner so this is the only signal).
-    terminals.setAgentType(terminal, agentKey);
+    terminals.setAgentType(terminal, resumeKey);
     if (sessionId) {
       terminals.setSessionId(terminal, sessionId);
     }
@@ -4218,7 +4219,7 @@ async function openAgentTerminals(context: vscode.ExtensionContext) {
 
       // Determine agent key and handle session ID
       const builtInDef = getBuiltInByPrefix(agent.prefix);
-      const agentKey = builtInDef?.key as 'claude' | 'codex' | 'gemini' | 'opencode' | undefined;
+      const agentKey = builtInDef?.key as keyof AgentSettings['builtIn'] | undefined;
       const defaultModel = agentKey ? settings.getDefaultModel(context, agentKey) : undefined;
 
       let command = agent.command;
@@ -4253,10 +4254,11 @@ async function openAgentTerminals(context: vscode.ExtensionContext) {
       // Track session ID for any known harness, not just the prewarm five (#1747):
       // this path also starts the label poller that hydrates the live session id,
       // so a grok/kimi/droid/antigravity tab needs it too to be resumable.
-      if (agentKey && agentKeyFromSession(agentKey)) {
+      const resumeKey = agentKey ? agentKeyFromSession(agentKey) : null;
+      if (resumeKey) {
         // Set agent type unconditionally so sessionTracker fs watcher can adopt
         // a session id from the CLI's rollout file (Codex 0.124+ banner has none).
-        terminals.setAgentType(terminal, agentKey);
+        terminals.setAgentType(terminal, resumeKey);
         if (sessionId) {
           terminals.setSessionId(terminal, sessionId);
         }


### PR DESCRIPTION
**Bugfix** — closes #1747.

## What changed
Resume past the picker was still gated on `supportsPrewarming` (claude/codex/gemini/cursor/opencode), so a **grok / kimi / droid / antigravity** tab did not come back through **restore** (window reload), **reopen-last**, or **reload-active-terminal** — even though its transcript exists and `agents run --resume` resumes it. #1743 fixed only the picker path and left these three "out of scope, tracked in #1747."

- The 3 surfaces now gate on the same registry check the picker uses — `agentKeyFromSession` — instead of `supportsPrewarming` (`extension.ts:4956/5590/5782`).
- **reload** falls back to a generic **Ctrl+C-twice** exit sequence for agents without a `PREWARM_CONFIGS` entry — new `exitSequenceFor()` in `prewarm.ts`, kept beside the configs so reload never has to know which agents are prewarm-capable.
- **The real gap:** `openSingleAgent`'s launch-time session tracking **and** the label poller were *also* prewarm-gated, so a grok/kimi/droid/antigravity tab was never tracked or persisted — the resume surfaces would have had nothing to come back to. Widened those too (using the typed `agentKeyFromSession` result so `setAgentType` stays type-safe).

**Deliberately out of scope** (separate surfaces, still prewarm-gated — noted so it reads as intentional, not missed): shell-adoption tracking (`:4480`), `clearActiveTerminal` re-register (`:4895`), and auto-rotate (`:3709`).

## Tests / verification
- `exitSequenceFor` unit-tested (prewarm agents keep their tuned sequence; grok/kimi/droid/antigravity → Ctrl+C-twice). `buildVersionedResumeCommand` routing for grok/kimi/droid was already covered.
- `prewarm.test.ts` **53 pass**; `tsc` clean.
- The full `bun test src/vscode src/core` shows 9 failures — all **pre-existing**, not from this diff: the watchdog cluster passes **6/6** and tmux-reattach **11/11** in isolation (the known cross-file `mock.module('vscode')` pollution), plus env-dependent model-alias / live-LLM tests. My diff touches none of those files.

**No-UI-run declared:** this is an extension-host gate change; the pure logic is unit-tested and the gate is a mechanical swap to the tested `agentKeyFromSession`. The full end-to-end proof (drive a live grok tab through reload/reopen/restore in an installed `.vsix`) needs a computer-equipped host and is the recommended manual QA before the Factory release.
