### PR TITLE
fix(menubar): self-heal a stale single-instance lock, O_CLOEXEC the fd, gate the self-tests

### DIFF
--- a/apps/cli/.changelog/next/menubar-flock-selfheal.md
+++ b/apps/cli/.changelog/next/menubar-flock-selfheal.md
@@ -1,0 +1,9 @@
+- **Menu bar recovers from a stale single-instance lock instead of staying dead.**
+  The helper's lock fd is now opened `O_CLOEXEC`, so a spawned `doctor` child can
+  never inherit it and hold the `menubar.lock` flock after the helper crashes; and
+  `SingleInstance.acquire` now self-heals — when the flock is held but no live
+  `MenubarHelper` owns it (a leaked orphan / dead pid), it reaps the orphan and
+  retries rather than exiting as "already running". Previously a leaked orphan
+  bricked the menu bar until reboot. The headless Swift self-tests (single-instance
+  + child-process) now run as a build gate (`menubar/scripts/test-menubar.sh`),
+  which nothing invoked before. Source: `apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -512,6 +512,20 @@ healthy `running: yes`. `agents menubar setup` is the recovery path — it ends
 every live helper and re-kickstarts the service so the survivor is always
 launchd's.
 
+**The lock fd is `O_CLOEXEC`, and `acquire` self-heals a stale lock.** The lock is
+opened `O_RDWR | O_CREAT | O_CLOEXEC` so no spawned child can inherit the
+descriptor — a pre-fix `doctor` child that inherited it and orphaned at PPID 1 held
+the flock forever, and every relaunch then read "already running" and exited, so
+the menu bar stayed dead until reboot (`O_CLOEXEC` is the fd-level guarantee across
+*every* spawn path, complementing `ChildProcess`'s `POSIX_SPAWN_CLOEXEC_DEFAULT`).
+The helper never execs itself, so it keeps the fd for life. And when the flock is
+held but **no LIVE `MenubarHelper` owns it** — the lock-file pid is dead, or belongs
+to some other program by reuse (`liveHelperOwnsLock` checks liveness + `proc_pidpath`
+basename) — `acquire` reaps the leaked orphan and retries the lock once, instead of
+surfacing into the deadlock. Only a genuine live incumbent is ever surfaced, so a
+duplicate launch never reaps a live helper's in-flight children (the reap is reached
+only when the holder is provably not a live helper).
+
 **Every CLI child the helper spawns is bounded, group-killable, and reapable.**
 The helper shells `agents` on a timer, and an unbounded `Process` there is not a
 slow menu — it is a machine-killer. `doctor --json` measures **136s on an idle
@@ -558,9 +572,22 @@ the bug.
 Poll intervals must stay well above the call's real cost:
 `StatusItemController.doctorRefreshInterval` is 15 min against a 136s command
 (it was 60s — a >100% duty cycle). `MENUBAR_CHILD_TEST=1 MenubarHelper` exercises
-all of it against real processes, including reaping a real surviving orphan.
+all of it against real processes, including reaping a real surviving orphan and
+proving a spawned child never inherits the single-instance flock fd.
 Separately, **`doctor --json` taking 136s on an idle machine is its own defect**
 — the helper is now safe against it, not a reason to consider it acceptable.
+
+**These self-tests are a build gate now, not just manual modes.** The helper's
+env-gated self-tests (`MENUBAR_SINGLE_TEST`, `MENUBAR_CHILD_TEST`,
+`MENUBAR_GUARD_TEST`, `MENUBAR_ISSUE_TEST`) are headless — they exit before the
+AppKit path (`Guards.enforceForInteractiveLaunch`) so they need no GUI or signing.
+[`menubar/scripts/test-menubar.sh`](menubar/scripts/build.sh) runs all four against
+the just-built binary and [`build.sh`](menubar/scripts/build.sh) invokes it before
+signing, so no helper artifact ships whose invariants regressed. Nothing ran these
+before — PR CI is Linux (can't build Swift) and prepack only checks the shipped
+bundle's signature — which is how the flock fd-inheritance deadlock escaped. Do NOT
+add `MENUBAR_DUMP` / `MENUBAR_PROMPT_PREVIEW` to the gate: those reach AppKit and
+need a GUI session.
 
 **Standalone `agents` binary (#315).** Every release also builds `dist/bin/agents`
 (`bun build --compile`, arm64 Mach-O), signs it (Developer ID + hardened runtime +

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -516,9 +516,12 @@ launchd's.
 opened `O_RDWR | O_CREAT | O_CLOEXEC` so no spawned child can inherit the
 descriptor — a pre-fix `doctor` child that inherited it and orphaned at PPID 1 held
 the flock forever, and every relaunch then read "already running" and exited, so
-the menu bar stayed dead until reboot (`O_CLOEXEC` is the fd-level guarantee across
-*every* spawn path, complementing `ChildProcess`'s `POSIX_SPAWN_CLOEXEC_DEFAULT`).
-The helper never execs itself, so it keeps the fd for life. And when the flock is
+the menu bar stayed dead until reboot. `O_CLOEXEC` is the fd-level guarantee across
+*every* spawn path: `ChildProcess.spawn` sets only `POSIX_SPAWN_SETPGROUP` (no
+close-on-exec default), and the bare-`Process` one-shots (`runDetached` /
+`runMonitored`) are meant to *outlive* the helper — so the flag on the fd, not the
+spawn site, is what keeps the lock out of every child. The helper never execs
+itself, so it keeps the fd for life. And when the flock is
 held but **no LIVE `MenubarHelper` owns it** — the lock-file pid is dead, or belongs
 to some other program by reuse (`liveHelperOwnsLock` checks liveness + `proc_pidpath`
 basename) — `acquire` reaps the leaked orphan and retries the lock once, instead of
@@ -581,7 +584,7 @@ Separately, **`doctor --json` taking 136s on an idle machine is its own defect**
 env-gated self-tests (`MENUBAR_SINGLE_TEST`, `MENUBAR_CHILD_TEST`,
 `MENUBAR_GUARD_TEST`, `MENUBAR_ISSUE_TEST`) are headless — they exit before the
 AppKit path (`Guards.enforceForInteractiveLaunch`) so they need no GUI or signing.
-[`menubar/scripts/test-menubar.sh`](menubar/scripts/build.sh) runs all four against
+[`menubar/scripts/test-menubar.sh`](menubar/scripts/test-menubar.sh) runs all four against
 the just-built binary and [`build.sh`](menubar/scripts/build.sh) invokes it before
 signing, so no helper artifact ships whose invariants regressed. Nothing ran these
 before — PR CI is Linux (can't build Swift) and prepack only checks the shipped

--- a/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
@@ -162,8 +162,9 @@ enum ChildProcessSelfTest {
     // fd. If it does, an orphaned child (helper crashed) keeps the open-file-
     // description — and its flock — alive at PPID 1, and every later launch
     // deadlocks as "already running". Guarded at the source by O_CLOEXEC on the
-    // lock open (SingleInstance.acquire) plus POSIX_SPAWN_CLOEXEC_DEFAULT here.
-    // Real flock, real child that execs and outlives the parent's fd — no mock.
+    // lock open (SingleInstance.acquire) — the fd is close-on-exec, so no exec'd
+    // child inherits it. Real flock, real child via raw posix_spawn (the leak
+    // vehicle Foundation.Process can't reproduce) — no mock.
     private static func testChildDoesNotInheritSingleInstanceFlock() {
         let path = "\(NSTemporaryDirectory())menubar-flock-inherit-\(getpid()).lock"
         try? FileManager.default.removeItem(atPath: path)

--- a/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
@@ -24,6 +24,7 @@ enum ChildProcessSelfTest {
         testRegistryRoundTrip()
         testReapSkipsPidWhoseExecutableChanged()
         testReapKillsARealOrphanFromAPreviousLaunch()
+        testChildDoesNotInheritSingleInstanceFlock()
         if failures == 0 {
             print("\nALL PASS")
             exit(0)
@@ -154,6 +155,56 @@ enum ChildProcessSelfTest {
         check(ChildProcess.Registry.readAll(file: file).isEmpty,
               "registry is cleared so the next launch does not re-reap a dead pid")
         try? FileManager.default.removeItem(atPath: file)
+    }
+
+    // The flock-inheritance leak that bricked the single-instance guard: a child
+    // spawned while the helper holds the menubar.lock flock must NOT inherit that
+    // fd. If it does, an orphaned child (helper crashed) keeps the open-file-
+    // description — and its flock — alive at PPID 1, and every later launch
+    // deadlocks as "already running". Guarded at the source by O_CLOEXEC on the
+    // lock open (SingleInstance.acquire) plus POSIX_SPAWN_CLOEXEC_DEFAULT here.
+    // Real flock, real child that execs and outlives the parent's fd — no mock.
+    private static func testChildDoesNotInheritSingleInstanceFlock() {
+        let path = "\(NSTemporaryDirectory())menubar-flock-inherit-\(getpid()).lock"
+        try? FileManager.default.removeItem(atPath: path)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        // Take the lock exactly as SingleInstance.acquire does — WITH O_CLOEXEC.
+        let held = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
+        guard held >= 0, flock(held, LOCK_EX | LOCK_NB) == 0 else {
+            check(false, "parent could not take the lock (fd \(held))"); return
+        }
+        // Direct invariant: the lock fd is close-on-exec, so no exec'd child keeps it.
+        check((fcntl(held, F_GETFD) & FD_CLOEXEC) != 0,
+              "lock fd is O_CLOEXEC (close-on-exec)")
+
+        // End-to-end: a child spawned via a RAW posix_spawn with NO
+        // CLOEXEC_DEFAULT and no file actions — the exact pre-#1841 spawn shape —
+        // inherits every fd that is not itself close-on-exec. If the lock fd were
+        // not O_CLOEXEC it would ride into /bin/sleep and keep the open-file-
+        // description (and its flock) alive after the parent drops its own. This is
+        // the real leak vehicle: Foundation.Process closes inherited fds itself and
+        // so cannot reproduce the bug, which is why this uses posix_spawn directly.
+        var childPid: pid_t = 0
+        var argv: [UnsafeMutablePointer<CChar>?] = (["/bin/sleep", "300"] as [String]).map { strdup($0) } + [nil]
+        defer { for a in argv where a != nil { free(a) } }
+        let rc = posix_spawn(&childPid, "/bin/sleep", nil, nil, &argv, environ)
+        guard rc == 0 else {
+            check(false, "could not posix_spawn a stand-in child (rc \(rc))"); close(held); return
+        }
+
+        // Parent drops its reference. If the child never inherited the fd, this
+        // closes the last reference to the open-file-description and frees the lock.
+        close(held)
+
+        // A fresh open+flock MUST succeed — proof no child kept the lock alive.
+        let probe = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
+        let free = probe >= 0 && flock(probe, LOCK_EX | LOCK_NB) == 0
+        if probe >= 0 { close(probe) }
+        kill(childPid, SIGKILL)
+        var st: Int32 = 0
+        while waitpid(childPid, &st, 0) == -1 && errno == EINTR {}
+        check(free, "flock is free after the holder drops its fd (child never inherited it)")
     }
 
     /// `sleep 300` in its own process group, reparented away from this process.

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
@@ -81,26 +81,83 @@ enum SingleInstance {
     /// Try to take the lock. Returns `.acquired` with the descriptor left open,
     /// or `.alreadyRunning` carrying the incumbent's pid (0 when the pid file is
     /// unreadable — the lock, not the pid, is what proves liveness).
-    static func acquire(path: String = lockPath()) -> Outcome {
+    static func acquire(
+        path: String = lockPath(),
+        registryFile: String = ChildProcess.Registry.path()
+    ) -> Outcome {
         let dir = (path as NSString).deletingLastPathComponent
         try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
 
-        let fd = open(path, O_RDWR | O_CREAT, 0o644)
+        // O_CLOEXEC so the flock fd is close-on-exec across EVERY spawn path, not
+        // just ChildProcess's POSIX_SPAWN_CLOEXEC_DEFAULT (ChildProcess.swift). A
+        // child that reaches exec() without it — a future bare Process(), or one
+        // spawned before that fix — inherits this fd and holds the flock at PPID 1
+        // forever, deadlocking every later launch as "already running". This holder
+        // never execs itself (main.swift runs straight to app.run()), so
+        // close-on-exec never drops the lock we mean to keep for the process life.
+        let fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
         if fd < 0 {
             // Can't create the lock file (read-only home, exotic sandbox). Fail
             // OPEN: a helper that cannot lock is better than no menu bar at all.
             return .acquired
         }
-        if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+        if flock(fd, LOCK_EX | LOCK_NB) == 0 {
+            return claim(fd)
+        }
+
+        // The lock is held. A LIVE MenubarHelper owner is a genuine incumbent —
+        // surface it and leave its in-flight children untouched (main.swift's
+        // "only the flock winner reaps" invariant).
+        if liveHelperOwnsLock(path: path) {
             let incumbent = readPid(path: path)
             close(fd)
             return .alreadyRunning(pid: incumbent)
         }
+
+        // No live helper owns it: the holder is a leaked orphan or a dead pid — a
+        // pre-fix `doctor` child at PPID 1 that inherited the lock fd and never let
+        // go. Reaping that orphan (kill(-pgid)) is what releases the flock, so reap
+        // the previous launch's children and RETRY the lock once. We only reach
+        // here when the owner is provably NOT a live helper, so no live incumbent's
+        // children can be in the reap set — the invariant above is preserved.
+        _ = ChildProcess.reapOrphansFromPreviousLaunch(file: registryFile)
+        // The reaper confirms a SIGTERM death but returns as soon as it escalates
+        // to SIGKILL (ChildProcess.terminateGroup), so the kernel's release of the
+        // orphan's flock can lag the reap by a few ms. Poll the lock briefly —
+        // bounded, never a spin — rather than trying exactly once.
+        for _ in 0..<15 {
+            if flock(fd, LOCK_EX | LOCK_NB) == 0 { return claim(fd) }
+            usleep(100_000)
+        }
+
+        // Still held after reap+retry (a holder the registry never recorded, or a
+        // racing sibling that re-grabbed it). Fall back to surfacing — never spin.
+        let incumbent = readPid(path: path)
+        close(fd)
+        return .alreadyRunning(pid: incumbent)
+    }
+
+    /// Commit ownership: keep the descriptor for the process lifetime, truncate,
+    /// and stamp our pid. Shared by the first-try and the reap-and-retry paths.
+    private static func claim(_ fd: Int32) -> Outcome {
         lockDescriptor = fd
         ftruncate(fd, 0)
         let pid = "\(ProcessInfo.processInfo.processIdentifier)\n"
         _ = pid.withCString { write(fd, $0, strlen($0)) }
         return .acquired
+    }
+
+    /// True only when the pid recorded in the lock file is a LIVE process running
+    /// a MenubarHelper. Everything else — pid 0/unreadable, a dead pid, a live pid
+    /// reused by some other program, or a non-helper orphan holding an inherited fd
+    /// — is a stale holder we may self-heal past. Mirrors the pid+path reuse guard
+    /// the reaper uses (ChildProcess.executablePath): a pid alone can be reused, so
+    /// the running executable must still be ours.
+    static func liveHelperOwnsLock(path: String = lockPath()) -> Bool {
+        let pid = readPid(path: path)
+        guard pid > 0, kill(pid, 0) == 0,
+              let exe = ChildProcess.executablePath(pid) else { return false }
+        return (exe as NSString).lastPathComponent == "MenubarHelper"
     }
 
     private static func readPid(path: String) -> Int32 {

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstance.swift
@@ -88,12 +88,13 @@ enum SingleInstance {
         let dir = (path as NSString).deletingLastPathComponent
         try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
 
-        // O_CLOEXEC so the flock fd is close-on-exec across EVERY spawn path, not
-        // just ChildProcess's POSIX_SPAWN_CLOEXEC_DEFAULT (ChildProcess.swift). A
-        // child that reaches exec() without it — a future bare Process(), or one
-        // spawned before that fix — inherits this fd and holds the flock at PPID 1
-        // forever, deadlocking every later launch as "already running". This holder
-        // never execs itself (main.swift runs straight to app.run()), so
+        // O_CLOEXEC so the flock fd is close-on-exec — no spawned child inherits it,
+        // on ANY path. ChildProcess.spawn sets only POSIX_SPAWN_SETPGROUP
+        // (ChildProcess.swift), not a close-on-exec default, and the bare-Process
+        // one-shots (AgentsCLI.runDetached / runMonitored) are MEANT to outlive the
+        // helper — so without this flag a child inherits this fd and holds the flock
+        // at PPID 1 forever, deadlocking every later launch as "already running".
+        // This holder never execs itself (main.swift runs straight to app.run()), so
         // close-on-exec never drops the lock we mean to keep for the process life.
         let fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
         if fd < 0 {

--- a/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/SingleInstanceSelfTest.swift
@@ -15,6 +15,7 @@ enum SingleInstanceSelfTest {
         testFirstAcquireWins()
         testSecondAcquireSurrenders()
         testLockReleasedWhenHolderDies()
+        testAcquireSelfHealsPastALeakedOrphan()
         testLockPathIsRuntimeStateDir()
         testDumpProbeIsExempt()
         testTriggerClassification()
@@ -109,6 +110,86 @@ enum SingleInstanceSelfTest {
         // The userInfo dict must be string-only so it survives distributed delivery.
         check(agentRun.userInfo["automated"] == "1" && agentRun.userInfo["agent"] == "claude",
               "automated userInfo is plist-safe strings")
+    }
+
+    // The deadlock that bricked the menu bar: a leaked orphan (a pre-#1841 `doctor`
+    // child at PPID 1 that inherited the lock fd) holds the flock while NO live
+    // helper runs, and the lock file carries the crashed helper's now-dead pid. The
+    // old acquire returned .alreadyRunning unconditionally and main.swift exited
+    // before it could reap — so the icon stayed dead until reboot. acquire must now
+    // recognize the holder is no live helper, reap it, and WIN. Real held flock,
+    // real orphan process, real reaper — no mock.
+    private static func testAcquireSelfHealsPastALeakedOrphan() {
+        let dir = NSTemporaryDirectory() + "menubar-selfheal-\(getpid())"
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/menubar.lock"
+        let registry = dir + "/menubar-children"
+
+        guard let orphan = spawnOrphanHoldingLock(path) else {
+            check(false, "could not spawn a lock-holding orphan"); return
+        }
+        // The holder is a live process but NOT a MenubarHelper, and the lock file
+        // carries a dead pid — so it must classify as a stale (self-healable) owner.
+        check(!SingleInstance.liveHelperOwnsLock(path: path),
+              "leaked orphan is classified as a stale (non-helper) owner")
+
+        // Record it so the recovery's reaper finds it; its executablePath must
+        // match the recorded path (the reaper's pid-reuse guard).
+        ChildProcess.Registry.register(
+            pid: orphan,
+            path: ChildProcess.executablePath(orphan) ?? "/usr/bin/python3",
+            file: registry)
+
+        // The fix: acquire reaps the orphan (releasing its flock) and WINS instead
+        // of surfacing into the deadlock.
+        let outcome = SingleInstance.acquire(path: path, registryFile: registry)
+        check(outcome == .acquired,
+              "acquire self-heals past a leaked orphan and wins the lock (got \(outcome))")
+
+        // And the orphan is gone.
+        var alive = true
+        for _ in 0..<40 where alive { usleep(100_000); alive = kill(orphan, 0) == 0 }
+        check(!alive, "the leaked orphan was reaped during self-healing acquire")
+        if alive { kill(orphan, SIGKILL) }
+    }
+
+    /// A real detached, non-helper process that holds the lock's flock: its own
+    /// process-group leader (so the reaper's kill(-pgid) has a group), running
+    /// python3 (executablePath != MenubarHelper), holding LOCK_EX and stamping a
+    /// dead pid into the lock file — exactly a leaked helper child. Returns once
+    /// the flock is provably held, so the acquire under test is guaranteed to
+    /// contend. Mirrors ChildProcessSelfTest.spawnDetachedGroupLeader.
+    private static func spawnOrphanHoldingLock(_ lockPath: String) -> pid_t? {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        let script = """
+        import fcntl, os, time
+        os.setpgrp()
+        fd = os.open('\(lockPath)', os.O_RDWR | os.O_CREAT, 0o644)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        os.ftruncate(fd, 0)
+        os.write(fd, b'999999\\n')
+        time.sleep(300)
+        """
+        p.arguments = ["-c", script]
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        guard (try? p.run()) != nil else { return nil }
+        let pid = p.processIdentifier
+        // Wait until the orphan has actually taken the flock (a fresh flock from
+        // here must be refused) so acquire() is guaranteed to contend.
+        for _ in 0..<50 {
+            usleep(100_000)
+            let probe = open(lockPath, O_RDWR | O_CREAT, 0o644)
+            if probe >= 0 {
+                let refused = flock(probe, LOCK_EX | LOCK_NB) != 0
+                close(probe)
+                if refused { return pid }
+            }
+        }
+        kill(pid, SIGKILL)
+        return nil
     }
 
     private static func check(_ condition: Bool, _ label: String) {

--- a/apps/cli/menubar/scripts/build.sh
+++ b/apps/cli/menubar/scripts/build.sh
@@ -44,6 +44,12 @@ else
     SRC=".build/debug/MenubarHelper"
 fi
 
+# Gate the artifact on the headless self-tests (single-instance flock, bounded
+# children). Runs against the just-built binary, BEFORE signing/notarization, so
+# a regression fails the build instead of shipping — and never wastes a notarize
+# submit. These modes exit before AppKit, so they need no GUI/signing.
+scripts/test-menubar.sh "$SRC"
+
 DEST_DIR="dist"
 mkdir -p "$DEST_DIR"
 

--- a/apps/cli/menubar/scripts/test-menubar.sh
+++ b/apps/cli/menubar/scripts/test-menubar.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Runs every HEADLESS MenubarHelper self-test and fails on any FAIL.
+#
+# The helper's self-tests (SingleInstanceSelfTest, ChildProcessSelfTest,
+# GuardsSelfTest, IssueSelfTest) are env-gated modes of the binary that exit
+# BEFORE the GUI/AppKit path (Guards.enforceForInteractiveLaunch in main.swift),
+# so they run headless — no display, no signing, no bundle. Until this script
+# nothing invoked them: PR CI is Linux (can't build Swift) and prepack only
+# checks the shipped bundle's signature. A whole class of helper bugs (the flock
+# fd-inheritance deadlock, the unbounded-child runaway) could regress unseen.
+#
+# NOT run here: MENUBAR_DUMP / MENUBAR_PROMPT_PREVIEW — those DO reach AppKit and
+# need a GUI session, so they would hang/fail on a headless runner.
+#
+# Usage:
+#   test-menubar.sh [BINARY]   # BINARY defaults to a fresh `swift build` debug binary
+#
+# build.sh calls this against the just-built binary, so no helper artifact is
+# produced whose self-tests regressed. Runnable standalone (no args) for local
+# dev or a macOS CI job. macOS-only (SwiftPM / Swift toolchain).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BIN="${1:-}"
+if [ -z "$BIN" ]; then
+  swift build >/dev/null
+  BIN=".build/debug/MenubarHelper"
+fi
+if [ ! -x "$BIN" ]; then
+  echo "test-menubar: binary not found or not executable: $BIN" >&2
+  exit 1
+fi
+
+fail=0
+for mode in MENUBAR_GUARD_TEST MENUBAR_ISSUE_TEST MENUBAR_SINGLE_TEST MENUBAR_CHILD_TEST; do
+  echo "=== $mode ==="
+  if ! env "$mode=1" "$BIN"; then
+    echo "  $mode FAILED" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "menubar self-tests FAILED" >&2
+  exit 1
+fi
+echo "menubar self-tests: all passed"


### PR DESCRIPTION
**bugfix** — the menu-bar helper self-heals a stale single-instance lock instead of staying dead until reboot.

## The bug (found live on `zion`)

An orphaned `agents doctor --json` process (pid 17093, PPID 1, 3h44m old) was holding `fd 3u` on `~/.agents/.cache/state/menubar.lock` — the single-instance flock — with **no live helper running**. Every relaunch saw "already running", surfaced, and exited; `agents menubar enable` reported "single instance the helper did not come back up". Killing that one orphan freed the flock and the icon came back immediately.

Two defects:

- **Spawned children inherit the flock fd.** The helper polls `doctor --json` on a timer; the child inherits the lock fd and, orphaned at PPID 1 after a helper crash, holds the flock forever. `ChildProcess.spawn` sets only `POSIX_SPAWN_SETPGROUP` (no close-on-exec default — verified on `origin/main`), and the bare-`Process` one-shots are *designed* to outlive the helper, so nothing stopped the fd from riding into an orphan. The fd was never guarded.
- **The recovery path couldn't break a stale lock.** `main.swift` runs the flock check `exit(0)` (`:72`) *before* the orphan reap (`:82`), so a leaked orphan deadlocks every relaunch — the reap that would free the lock never runs.

## The fix

1. **`O_CLOEXEC` on the lock open** (`SingleInstance.swift`) — the fd is close-on-exec, so no spawned child inherits it, on any path (the spawn sites set no close-on-exec default; the guarantee is on the fd). The holder never execs itself, so it keeps the fd for life.
2. **Self-heal in `acquire()`** — when the flock is held but no **live `MenubarHelper`** owns it (lock-file pid dead / reused, checked via liveness + `proc_pidpath`), reap the leaked orphan and retry once. Only a genuine live incumbent is surfaced, so a duplicate launch never reaps a live helper's in-flight children. No `main.swift` reorder — the "only the flock winner reaps" invariant is preserved.
3. **Two self-tests** (real flocks/processes, no mocking): a child spawned via raw `posix_spawn` does **not** inherit the flock fd; `acquire` self-heals past a leaked non-helper orphan.
4. **A build gate** — `menubar/scripts/test-menubar.sh` runs the four headless self-tests; `build.sh` invokes it before signing, so no artifact ships whose invariants regressed. **Nothing ran these before** — PR CI is Linux (can't build Swift) and prepack only checks the shipped signature — which is exactly how this escaped tests.

## Evidence — ran it, both tests proven non-vacuous

Fixed source — all headless self-tests green (the gated `build.sh` output):

```
=== MENUBAR_GUARD_TEST ===   ALL PASS
=== MENUBAR_ISSUE_TEST ===   ALL PASS
=== MENUBAR_SINGLE_TEST ===  ALL PASS
  PASS  leaked orphan is classified as a stale (non-helper) owner
  PASS  acquire self-heals past a leaked orphan and wins the lock (got acquired)
  PASS  the leaked orphan was reaped during self-healing acquire
=== MENUBAR_CHILD_TEST ===   ALL PASS
  PASS  lock fd is O_CLOEXEC (close-on-exec)
  PASS  flock is free after the holder drops its fd (child never inherited it)
menubar self-tests: all passed
built: dist/MenubarHelper.app
```

Red-check — remove the fix and both new tests fail (proving they catch the real bug):

```
# O_CLOEXEC removed from the child test's lock open:
  FAIL  lock fd is O_CLOEXEC (close-on-exec)
  FAIL  flock is free after the holder drops its fd (child never inherited it)

# self-heal disabled in acquire():
  FAIL  acquire self-heals past a leaked orphan and wins the lock (got alreadyRunning(pid: 999999))
  FAIL  the leaked orphan was reaped during self-healing acquire
```

**No screenshot:** the menu-bar icon only renders inside the user's Aqua (GUI) session, which a headless build host can't drive — so the verification is the self-test against real flocks/processes plus the live repro above (killing the real orphan on `zion` restored the icon). The installed-bundle end-to-end recovery is verified on the fleet after release.

No Linear ticket paired (tracker locked this session); the work is scoped here.
