### PR TITLE
fix(secrets): stop background Touch ID prompt storms

### DIFF
--- a/apps/cli/.changelog/next/secrets-touchid-storm.md
+++ b/apps/cli/.changelog/next/secrets-touchid-storm.md
@@ -1,0 +1,17 @@
+- **Background processes no longer storm macOS Touch ID sheets (secrets-touchid-storm).**
+  Raw keychain item reads — a profile's provider token on `agents run <profile>`,
+  the Claude OAuth read behind `agents view`, any `getKeychainToken` caller — now
+  fail fast with an actionable error naming the item when the process is
+  non-interactive (an agent runtime, or a TTY-less background spawn like the
+  Factory extension host's `agents view` poll), instead of raising a sheet nobody
+  is watching. A cancelled or failed interactive read opens a 5-minute back-off
+  memo (`~/.agents/.cache/keychain-read-backoff/`) so a polling caller can't
+  re-prompt every few seconds; any successful read or write clears it. Reads that
+  are prompt-free by construction (bundle metadata, `never`-policy bundles, the
+  unlock session store, the OAuth token cache) attest their no-ACL write and are
+  unaffected. crabbox's tailscale key is now read at most once per process
+  instead of on every `crabboxEnv` call (list/wait/spawn/stop). Source:
+  `apps/cli/src/lib/secrets/index.ts`, `apps/cli/src/lib/secrets/headless.ts`,
+  `apps/cli/src/lib/secrets/read-backoff.ts`,
+  `apps/cli/src/lib/secrets/bundles.ts`, `apps/cli/src/lib/crabbox/cli.ts`,
+  `apps/cli/docs/specifications.md` (SEC-13, SEC-27).

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -20,6 +20,20 @@ the agent is the caller, not you. It names the requesting
 harness, bundle, reason, and unlock duration. Approved bundles are cached for seven
 days by default.
 
+**The same rule covers raw keychain item reads.** A profile's provider token, the
+Claude OAuth item behind `agents view`, and every other `getKeychainToken` caller
+go through one guard: a non-interactive process (an agent runtime, or no TTY — a
+VS Code extension host, a daemon, cron) gets an actionable error naming the item
+instead of a sheet nobody is watching. Items that are provably prompt-free stay
+silent — their callers attest the no-ACL write (bundle metadata, `never`-policy
+bundles, the unlock session store, the OAuth token cache). And when a context
+that *may* prompt has its read cancelled or fail, the item goes into a 5-minute
+read back-off (`~/.agents/.cache/keychain-read-backoff/`, regenerable) so a
+polling caller can't re-raise the sheet every few seconds; any successful read
+or write of the item clears the back-off. Source: `src/lib/secrets/index.ts`
+(`assertRawKeychainReadAllowed`), `src/lib/secrets/headless.ts`,
+`src/lib/secrets/read-backoff.ts`.
+
 **An unlock is global unless you narrow it.** `agents secrets unlock prod` grants
 every harness and a plain shell access for the whole TTL — one Touch ID covers all
 of them. `--for claude` narrows the grant to that harness alone, and other

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -831,11 +831,21 @@ access control (that is 1Password/Vault; this tool is device-local first).
 - **SEC-12 (MUST).** Value reads MUST be batched so a bundle costs at most one
   Touch ID prompt, not one per key (`commands/secrets.ts:1073-1076`;
   `lib/secrets/bundles.ts:772-776,1262-1273`).
-- **SEC-13 (MUST).** A headless/detached (no-TTY) context on macOS MUST resolve
+- **SEC-13 (MUST).** A headless/detached (no-TTY or agent-runtime) context on macOS MUST resolve
   broker-only and fail loudly, and MUST NOT pop a Touch ID sheet on the
   interactive user's screen (`isHeadlessSecretsContext`,
-  `lib/secrets/bundles.ts:1245-1260`; `commands/secrets.ts:1172-1175,1925-1929`;
-  `mcp.ts:112-114`).
+  `lib/secrets/headless.ts:37-66`, re-exported from `lib/secrets/bundles.ts`;
+  `commands/secrets.ts:1172-1175,1925-1929`;
+  `mcp.ts:112-114`). This covers raw item reads too, not just bundles:
+  `getKeychainToken`/`getKeychainTokens` consult `assertRawKeychainReadAllowed`
+  (`lib/secrets/index.ts:877-899`) BEFORE any helper process is spawned, and
+  throw an actionable error naming the item (and, for bundle-triggered reads,
+  the `agents secrets unlock <bundle>` fix). **Given** a TTY-less process or
+  any `AGENTS_RUNTIME` launch **When** it attempts a read of an ACL-protected
+  keychain item **Then** the read fails fast and no sheet is raised. Reads the
+  caller attests as no-ACL via `silentNoAcl` (bundle metadata per SEC-4,
+  `never`-policy bundles per SEC-19, the unlock session store, the usage OAuth
+  cache) are prompt-free by construction and MUST NOT be blocked by this guard.
 - **SEC-14 (MUST).** A broker `get` for a bundle it does not hold MUST return
   `{ ok:true, hit:false }` — never an error, never a prompt, never a human
   escalation — and the caller MUST fall through to the real store
@@ -881,6 +891,19 @@ access control (that is 1Password/Vault; this tool is device-local first).
   and MUST degrade cleanly (no usage shown) when the DB is unavailable
   (`commands/secrets.ts` `view` / `list` / `activity` actions). The read-model is a
   bounded 90-day history; the full audit trail is `agents events --module secrets`.
+- **SEC-27 (MUST).** A cancelled or failed interactive keychain read MUST open a
+  short-TTL negative memo (5 minutes, `KEYCHAIN_READ_BACKOFF_TTL_MS`, keyed by
+  the requested item name, under `~/.agents/.cache/keychain-read-backoff/` —
+  `lib/secrets/read-backoff.ts`) so a polling caller cannot re-raise a Touch ID
+  sheet every few seconds; a subsequent read of the same item within the window
+  MUST fail fast with the back-off error instead of prompting
+  (`assertRawKeychainReadAllowed`, `lib/secrets/index.ts:877-899`). Any
+  successful read or write (or delete) of the item MUST clear the memo. A plain
+  miss (helper exit 1, item not found) MUST NOT open the memo — no prompt was
+  raised. The memo is regenerable, best-effort state and MUST carry no secret
+  material (item name + deadline only). **Given** a user cancels a read's
+  prompt **When** a poller retries the read within 5 minutes **Then** the retry
+  throws the back-off error without spawning the helper.
 - **SEC-28 (MUST).** **Every secret access is attributable to the session that
   triggered it — no exceptions.** Every value read and every unlock recorded via
   `emitSecretAudit` (SEC-26) MUST carry the **requesting** identity intact: agent,

--- a/apps/cli/src/lib/crabbox/cli.test.ts
+++ b/apps/cli/src/lib/crabbox/cli.test.ts
@@ -1,16 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as bundles from '../secrets/bundles.js';
+import * as stateModule from '../state.js';
 import {
   isReapSafe,
   reapSafeOrphans,
   REAP_MIN_IDLE_SECS,
   pickLeaseBundleFromList,
   pickTailscaleBundleFromList,
+  crabboxEnv,
   crabboxList,
   crabboxWarmup,
   parseCrabboxSshArgv,
+  resetCrabboxSecretsMemosForTest,
   type CrabboxBox,
 } from './cli.js';
 import type { SecretsBundle } from '../secrets/bundles.js';
@@ -70,6 +74,62 @@ describe('pickTailscaleBundleFromList', () => {
   it('returns undefined when no bundle declares one', () => {
     expect(pickTailscaleBundleFromList([bundle('misc', ['HCLOUD_TOKEN'])])).toBeUndefined();
     expect(pickTailscaleBundleFromList([])).toBeUndefined();
+  });
+});
+
+describe('crabboxEnv tailscale value memo', () => {
+  // crabboxEnv runs several times per lease (list/wait/spawn/stop). The
+  // tailscale read is a single-key subset, which canCacheResolvedEnv rejects
+  // for broker auto-cache — so without the process-lifetime value memo every
+  // call re-read the keychain (and, for a non-broker-held bundle, could
+  // re-prompt). One read per process, then the memo serves.
+  const tailscaleBundle = { name: 'tailnet', vars: { TS_AUTHKEY: 'keychain:ts' } } as SecretsBundle;
+  const ENV_KEYS = ['AGENTS_LEASE_SECRETS_BUNDLE', 'CRABBOX_TAILSCALE_AUTH_KEY'] as const;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    for (const k of ENV_KEYS) delete process.env[k];
+    resetCrabboxSecretsMemosForTest();
+    // Hermetic lease-bundle resolution: no configured lease.secretsBundle from
+    // the developer's real agents.yaml, and no auto-detectable provider token.
+    vi.spyOn(stateModule, 'readMeta').mockReturnValue({} as ReturnType<typeof stateModule.readMeta>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetCrabboxSecretsMemosForTest();
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  it('reads the tailscale keychain value at most once across repeated crabboxEnv calls', () => {
+    vi.spyOn(bundles, 'listBundles').mockReturnValue([tailscaleBundle]);
+    const readSpy = vi
+      .spyOn(bundles, 'readAndResolveBundleEnv')
+      .mockReturnValue({ bundle: tailscaleBundle, env: { TS_AUTHKEY: 'tskey-once' } });
+
+    const env1 = crabboxEnv({});
+    const env2 = crabboxEnv({});
+    const env3 = crabboxEnv({});
+
+    expect(env1.CRABBOX_TAILSCALE_AUTH_KEY).toBe('tskey-once');
+    expect(env2.CRABBOX_TAILSCALE_AUTH_KEY).toBe('tskey-once');
+    expect(env3.CRABBOX_TAILSCALE_AUTH_KEY).toBe('tskey-once');
+    expect(readSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a failed tailscale read memoizes as absent — the failure is not retried per call', () => {
+    vi.spyOn(bundles, 'listBundles').mockReturnValue([tailscaleBundle]);
+    const readSpy = vi
+      .spyOn(bundles, 'readAndResolveBundleEnv')
+      .mockImplementation(() => { throw new Error('bundle not unlocked'); });
+
+    expect(crabboxEnv({}).CRABBOX_TAILSCALE_AUTH_KEY).toBeUndefined();
+    expect(crabboxEnv({}).CRABBOX_TAILSCALE_AUTH_KEY).toBeUndefined();
+    expect(readSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/cli/src/lib/crabbox/cli.ts
+++ b/apps/cli/src/lib/crabbox/cli.ts
@@ -125,6 +125,43 @@ function resolveTailscaleBundleMemo(): { name: string; key: string } | undefined
   return tailscaleBundleMemo.value;
 }
 
+/**
+ * Process-lifetime memo for the RESOLVED tailscale key value, next to the pick
+ * memo above. `crabboxEnv` runs several times per lease (list/wait/spawn/stop),
+ * and the single-key subset read (`keys: [ts.key]`) is rejected by
+ * `canCacheResolvedEnv` for broker auto-cache — so without this memo a
+ * non-broker-held tailscale bundle re-read the keychain on EVERY call (and,
+ * pre-guard, could pop a Touch ID sheet each time). One read per process,
+ * success or failure (a failed read memoizes as undefined: the catch below
+ * already degrades to a public-network lease, retrying mid-process only
+ * repeats the same failure).
+ */
+let tailscaleValueMemo: { value: string | undefined } | undefined;
+function resolveTailscaleKeyValueMemo(ts: { name: string; key: string }): string | undefined {
+  if (!tailscaleValueMemo) {
+    let value: string | undefined;
+    try {
+      const { env } = readAndResolveBundleEnv(ts.name, {
+        caller: 'agents run --lease (crabbox tailscale)',
+        keys: [ts.key],
+        agentOnly: isHeadlessSecretsContext(),
+      });
+      value = env[ts.key];
+    } catch {
+      /* best-effort — tailscale is opt-in plumbing, never blocks a public lease */
+    }
+    tailscaleValueMemo = { value };
+  }
+  return tailscaleValueMemo.value;
+}
+
+/** Test seam: drop every crabboxEnv secrets memo so each test resolves fresh. */
+export function resetCrabboxSecretsMemosForTest(): void {
+  tailscaleBundleMemo = undefined;
+  tailscaleValueMemo = undefined;
+  leaseBundleMemo = undefined;
+}
+
 /** A resolved lease bundle: its name, plus (auto-detect only) the exact keys to inject. */
 export interface ResolvedLeaseBundle {
   name: string;
@@ -217,21 +254,14 @@ export function crabboxEnv(opts: CrabboxOptions): NodeJS.ProcessEnv {
   // declares a tailscale auth key, when the ambient env doesn't already set one.
   // Best-effort and opt-in — a missing/unreadable tailscale bundle never fails a
   // public-network lease; `crabboxWarmup({ netMode: 'tailscale' })` is what decides
-  // whether the key is actually used.
+  // whether the key is actually used. The resolved value is memoized per process
+  // (see resolveTailscaleKeyValueMemo) so repeated crabboxEnv calls read the
+  // keychain at most once.
   if (!out.CRABBOX_TAILSCALE_AUTH_KEY) {
     const ts = resolveTailscaleBundleMemo();
     if (ts) {
-      try {
-        const { env } = readAndResolveBundleEnv(ts.name, {
-          caller: 'agents run --lease (crabbox tailscale)',
-          keys: [ts.key],
-          agentOnly: isHeadlessSecretsContext(),
-        });
-        const value = env[ts.key];
-        if (value) out.CRABBOX_TAILSCALE_AUTH_KEY = value;
-      } catch {
-        /* best-effort — tailscale is opt-in plumbing, never blocks a public lease */
-      }
+      const value = resolveTailscaleKeyValueMemo(ts);
+      if (value) out.CRABBOX_TAILSCALE_AUTH_KEY = value;
     }
   }
 

--- a/apps/cli/src/lib/profiles.test.ts
+++ b/apps/cli/src/lib/profiles.test.ts
@@ -15,7 +15,7 @@ import {
   writeProfile,
   type Profile,
 } from './profiles.js';
-import { setKeychainBackendForTest, type KeychainBackend } from './secrets/index.js';
+import { setKeychainBackendForTest, setKeychainHeadlessDetectorForTest, type KeychainBackend } from './secrets/index.js';
 
 let TEST_ROOT: string;
 let USER_DIR: string;
@@ -182,6 +182,49 @@ describe('resolveProfileEnv honors authOptional', () => {
       auth: { envVar: 'ANTHROPIC_AUTH_TOKEN', keychainItem: 'agents-cli.no-such-provider-xyz.token' },
     };
     expect(() => resolveProfileEnv(p)).toThrow(/not found/i);
+  });
+});
+
+describe('resolveProfileEnv fails fast in a headless context', () => {
+  // The Touch ID storm fix: `agents run <profile>` beneath a headless/teams/
+  // terminal runtime (or any TTY-less spawn) must throw the actionable error
+  // instead of raising a sheet nobody is watching. The memory backend is
+  // removed for these tests so resolveProfileEnv reaches the REAL raw-read
+  // guard in getKeychainToken; the detector seam stands in for the darwin-only
+  // headless signal so the throw is exercisable on any CI platform.
+  it('throws the actionable headless error instead of attempting a prompting read', () => {
+    setKeychainBackendForTest(null);
+    setKeychainHeadlessDetectorForTest(() => true);
+    try {
+      const p: Profile = {
+        name: 'kimi',
+        host: { agent: 'kimi' as Profile['host']['agent'] },
+        env: {},
+        auth: { envVar: 'KIMI_API_KEY', keychainItem: 'agents-cli.kimi.token' },
+      };
+      expect(() => resolveProfileEnv(p)).toThrow(/non-interactive/);
+      expect(() => resolveProfileEnv(p)).toThrow(/agents-cli\.kimi\.token/);
+    } finally {
+      setKeychainHeadlessDetectorForTest(null);
+    }
+  });
+
+  it('an interactive context is unaffected — the required-auth missing-item error survives', () => {
+    setKeychainBackendForTest(null);
+    setKeychainHeadlessDetectorForTest(() => false);
+    try {
+      const p: Profile = {
+        name: 'corp',
+        host: { agent: 'claude' },
+        env: {},
+        auth: { envVar: 'ANTHROPIC_AUTH_TOKEN', keychainItem: 'agents-cli.no-such-provider-xyz.token' },
+      };
+      // Past the guard the read reaches the real platform path (helper absent
+      // in a source checkout / item absent on CI) — never the headless error.
+      expect(() => resolveProfileEnv(p)).toThrow(/^(?!.*non-interactive).*$/);
+    } finally {
+      setKeychainHeadlessDetectorForTest(null);
+    }
   });
 });
 

--- a/apps/cli/src/lib/secrets/__tests__/raw-read-guard.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/raw-read-guard.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  getKeychainToken,
+  getKeychainTokens,
+  setKeychainHeadlessDetectorForTest,
+} from '../index.js';
+import {
+  KEYCHAIN_READ_BACKOFF_TTL_MS,
+  clearKeychainReadBackoff,
+  isKeychainReadBackedOff,
+  noteKeychainReadFailure,
+  setKeychainReadBackoffDirForTest,
+} from '../read-backoff.js';
+
+/**
+ * The raw-read storm guard (index.ts `assertRawKeychainReadAllowed`) — the fix
+ * for background processes (the Factory extension host's `agents view` poll,
+ * daemons, cron) raising Touch ID sheets on the interactive user's screen:
+ * 167 sheets in one day, each one a TTY-less keychain read nobody could answer.
+ *
+ * These tests install NO keychain backend, so the guard sits directly on the
+ * path under test; the headless detector is stubbed via its sanctioned seam
+ * (the real detector self-gates to darwin, which would make the throw
+ * unreachable from a Linux CI run — the same parameterization argument as the
+ * injected env/platform/tty on isHeadlessSecretsContext).
+ *
+ * The guard fires BEFORE any platform branch or helper spawn, so a throw here
+ * proves no keychain process was ever launched.
+ */
+
+const HEADLESS = /non-interactive/;
+const BACKOFF = /back-off/;
+
+describe('raw keychain read storm guard', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-read-guard-'));
+    setKeychainReadBackoffDirForTest(dir);
+  });
+
+  afterEach(() => {
+    setKeychainHeadlessDetectorForTest(null);
+    setKeychainReadBackoffDirForTest(null);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('a headless single read fails fast, naming the item and the fix — never spawning the helper', () => {
+    setKeychainHeadlessDetectorForTest(() => true);
+    expect(() => getKeychainToken('agents-cli.guard-test.token')).toThrow(HEADLESS);
+    expect(() => getKeychainToken('agents-cli.guard-test.token')).toThrow(/agents-cli\.guard-test\.token/);
+    expect(() => getKeychainToken('agents-cli.guard-test.token')).toThrow(/interactive terminal/);
+  });
+
+  it('a headless BATCH read fails fast too — bundles reach the helper only through here', () => {
+    setKeychainHeadlessDetectorForTest(() => true);
+    expect(() => getKeychainTokens(['agents-cli.bundles.prod', 'agents-cli.secrets.prod.KEY'])).toThrow(HEADLESS);
+  });
+
+  it('the batch error points at agents secrets unlock when a bundle triggered the read', () => {
+    setKeychainHeadlessDetectorForTest(() => true);
+    expect(() =>
+      getKeychainTokens(['agents-cli.bundles.prod'], { bundle: 'prod' }),
+    ).toThrow(/agents secrets unlock prod/);
+  });
+
+  it('silentNoAcl attestation bypasses the guard — a no-ACL read is prompt-free even headless', () => {
+    setKeychainHeadlessDetectorForTest(() => true);
+    // Past the guard the read reaches the real platform path and fails there
+    // (no helper in a source checkout / no such item) — crucially NOT with the
+    // headless error. This is what keeps session-store / vault / usage-cache
+    // headless reads working.
+    try {
+      getKeychainToken('agents-cli.guard-test.noacl', { silentNoAcl: true });
+    } catch (err) {
+      expect((err as Error).message).not.toMatch(HEADLESS);
+      return;
+    }
+    // A value coming back is fine too (item exists on a dev machine): the
+    // assertion is only that the guard did not throw.
+  });
+
+  it('a non-headless context is NOT blocked by the guard', () => {
+    setKeychainHeadlessDetectorForTest(() => false);
+    try {
+      getKeychainToken('agents-cli.guard-test.interactive');
+    } catch (err) {
+      expect((err as Error).message).not.toMatch(HEADLESS);
+      expect((err as Error).message).not.toMatch(BACKOFF);
+    }
+  });
+
+  it('a backed-off item fails fast with the back-off error instead of re-prompting', () => {
+    setKeychainHeadlessDetectorForTest(() => false);
+    noteKeychainReadFailure('agents-cli.guard-test.cancelled');
+    expect(() => getKeychainToken('agents-cli.guard-test.cancelled')).toThrow(BACKOFF);
+    expect(() => getKeychainToken('agents-cli.guard-test.cancelled')).toThrow(/agents-cli\.guard-test\.cancelled/);
+  });
+
+  it('the headless fail-fast wins over an open back-off (the more actionable error)', () => {
+    setKeychainHeadlessDetectorForTest(() => true);
+    noteKeychainReadFailure('agents-cli.guard-test.both');
+    expect(() => getKeychainToken('agents-cli.guard-test.both')).toThrow(HEADLESS);
+  });
+
+  it('silentNoAcl bypasses an open back-off — a no-ACL read never prompted, so there is nothing to suppress', () => {
+    setKeychainHeadlessDetectorForTest(() => false);
+    noteKeychainReadFailure('agents-cli.guard-test.noacl-bo');
+    try {
+      getKeychainToken('agents-cli.guard-test.noacl-bo', { silentNoAcl: true });
+    } catch (err) {
+      expect((err as Error).message).not.toMatch(BACKOFF);
+    }
+  });
+
+  it('a backed-off batch fails fast', () => {
+    setKeychainHeadlessDetectorForTest(() => false);
+    noteKeychainReadFailure('batch:a\nb');
+    expect(() => getKeychainTokens(['a', 'b'])).toThrow(BACKOFF);
+  });
+});
+
+describe('keychain read back-off memo', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-read-backoff-'));
+    setKeychainReadBackoffDirForTest(dir);
+  });
+
+  afterEach(() => {
+    setKeychainReadBackoffDirForTest(null);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('no memo → not backed off', () => {
+    expect(isKeychainReadBackedOff('never-failed')).toBe(false);
+  });
+
+  it('a recorded failure backs the item off within the TTL', () => {
+    noteKeychainReadFailure('item-x');
+    expect(isKeychainReadBackedOff('item-x')).toBe(true);
+    // ...but not a different item.
+    expect(isKeychainReadBackedOff('item-y')).toBe(false);
+  });
+
+  it('expires after the TTL', () => {
+    const past = Date.now() - KEYCHAIN_READ_BACKOFF_TTL_MS - 1000;
+    noteKeychainReadFailure('item-old', past);
+    expect(isKeychainReadBackedOff('item-old')).toBe(false);
+  });
+
+  it('clear drops the memo (a successful read/write resets the back-off)', () => {
+    noteKeychainReadFailure('item-z');
+    clearKeychainReadBackoff('item-z');
+    expect(isKeychainReadBackedOff('item-z')).toBe(false);
+  });
+
+  it('a malformed memo file means no back-off (regenerable state, never a read blocker)', () => {
+    noteKeychainReadFailure('item-m');
+    const file = fs.readdirSync(dir)[0];
+    fs.writeFileSync(path.join(dir, file), 'not json');
+    expect(isKeychainReadBackedOff('item-m')).toBe(false);
+  });
+
+  it('the memo carries no secret material — only the item name and a deadline', () => {
+    noteKeychainReadFailure('item-plain');
+    const file = fs.readdirSync(dir)[0];
+    const stored = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8')) as Record<string, unknown>;
+    expect(Object.keys(stored).sort()).toEqual(['item', 'until']);
+  });
+});

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -41,6 +41,7 @@ import {
   type BundleValue,
   type SecretRef,
 } from './index.js';
+import { isHeadlessSecretsContext } from './headless.js';
 import { fileStore } from './filestore.js';
 import {
   getVaultSession,
@@ -393,7 +394,14 @@ export function readBundle(name: string): SecretsBundle {
   if (backend === 'vault') assertVaultBackendUsable(name);
   let json: string;
   try {
-    json = itemStore(backend).get(bundleMetaItem(name));
+    // Bundle metadata carries no biometry ACL (SEC-4), so this read is silent
+    // even in a headless context — attest that to the raw-read storm guard so
+    // a headless `readBundle` never trips the fail-fast. (A legacy
+    // pre-metadata-heal ACL'd metadata item can still prompt once; it heals on
+    // the next interactive read.)
+    json = backend === 'keychain'
+      ? getKeychainToken(bundleMetaItem(name), { silentNoAcl: true })
+      : itemStore(backend).get(bundleMetaItem(name));
   } catch (err) {
     // A file-backed bundle whose metadata is on disk but fails to decrypt is a
     // wrong-passphrase error, not a missing bundle — surface that clearly.
@@ -801,7 +809,13 @@ export function listBundles(): SecretsBundle[] {
       if (cached) {
         for (const bundle of cached) out.push(bundle);
       } else {
-        const fetched = getKeychainTokens(keychainServices);
+        // Metadata enumeration must stay silent in ANY context (SEC-11):
+        // bundle metadata items are no-ACL by contract (SEC-4), so attest that
+        // to the raw-read storm guard — a headless `listBundles` (session
+        // start, crabbox env, devices fan-out) must never fail fast on the
+        // guard nor pop a sheet. (A legacy pre-heal ACL'd metadata item can
+        // still prompt once; it heals on the next interactive scan.)
+        const fetched = getKeychainTokens(keychainServices, { silentNoAcl: true });
         const keychainBundles: SecretsBundle[] = [];
         const metaJsonByName = new Map<string, string>();
         for (const service of keychainServices) {
@@ -1170,8 +1184,14 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
   }
 
   const store = itemStore(bundle.backend ?? 'keychain');
+  // keychainStore.getBatch IS getKeychainTokens — call it directly so a
+  // `never`-policy bundle (no biometry ACL on its items) attests `silentNoAcl`
+  // and stays readable in a headless context, while an ACL'd policy hits the
+  // raw-read storm guard and fails fast there.
   const fetched = keychainItemsToFetch.length > 0
-    ? store.getBatch(keychainItemsToFetch)
+    ? (bundle.backend ?? 'keychain') === 'keychain'
+      ? getKeychainTokens(keychainItemsToFetch, { silentNoAcl: bundlePolicy(bundle) === 'never' })
+      : store.getBatch(keychainItemsToFetch)
     : new Map<string, string>();
 
   const env: Record<string, string> = {};
@@ -1212,60 +1232,12 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
 
 /**
  * True when the current process is a background / non-interactive context that
- * must NEVER raise a Keychain biometry prompt on the interactive user's screen —
- * a prompt nobody is watching. Two signals, either sufficient:
- *   - `AGENTS_RUNTIME` is `headless`, `teams`, or `terminal` — i.e. ANY agent
- *     launch, interactive included, and inherited by everything spawned beneath
- *     one (set on the child env by `agents run --headless`, scheduled routines,
- *     teammates, and interactive runs — see exec.ts:430, runner.ts,
- *     teams/agents.ts).
- *   - neither stdin nor stdout is a TTY (a detached/backgrounded task whose
- *     stdio is redirected to a log — e.g. a release script run in the
- *     background as `( ... ) >log 2>&1 </dev/null`).
- * `AGENTS_SECRETS_NO_PROMPT=1` forces headless-safe; `=0` force-allows a prompt
- * even in a non-TTY context. An `eval "$(agents secrets export X)"` typed in a
- * PLAIN shell has no AGENTS_RUNTIME, so it is not classified headless and still
- * prompts. Run beneath an agent it inherits AGENTS_RUNTIME and resolves
- * broker-only — the agent, not the human, is the caller there.
- *
- * Only **macOS keychain** reads pop an interactive Touch ID sheet — the secrets
- * broker itself is a no-op off darwin (see agent.ts), and libsecret (Linux) /
- * the Windows credential store resolve without any prompt. So off-darwin this
- * ALWAYS returns false: forcing broker-only there would break every headless
- * Linux/Windows read (CI, `agents run --headless`, routines, the Linux-driven
- * release flow) for no benefit — there is no prompt to suppress.
- *
- * A read in a macOS headless context resolves broker-only (agentOnly) and fails
- * fast with an actionable error instead of hijacking Touch ID. This generalizes
- * the per-caller broker-only pattern used across the headless secrets readers.
+ * must NEVER raise a Keychain biometry prompt on the interactive user's screen.
+ * Re-exported from ./headless.js — the detector lives there so the raw-read
+ * path in index.ts can share it without a bundles↔index import cycle. See that
+ * module for the full contract.
  */
-export function isHeadlessSecretsContext(
-  env: NodeJS.ProcessEnv = process.env,
-  platform: NodeJS.Platform = process.platform,
-  // Injected so the TTY branch below is testable: it is the branch that decides a
-  // plain human shell still prompts, which is this guard's entire safety argument,
-  // and reading process.* directly made it unreachable from a test.
-  tty: { stdin?: boolean; stdout?: boolean } = { stdin: process.stdin.isTTY, stdout: process.stdout.isTTY },
-): boolean {
-  if (platform !== 'darwin') return false; // no biometry prompt to suppress off-darwin
-  const override = env.AGENTS_SECRETS_NO_PROMPT;
-  if (override === '1') return true;
-  if (override === '0') return false;
-  // Every AGENT-LAUNCH runtime resolves broker-only, interactive included.
-  // `terminal` was missing, which made an agent terminal the one launch path
-  // still allowed to pop Touch ID: exec.ts sets AGENTS_RUNTIME='terminal' for an
-  // interactive run (exec.ts:430), that fell through to the TTY check below, and
-  // a TTY meant "a human is watching, so prompting is fine". It is not fine —
-  // opening a terminal is not a request to authenticate, and a launch that needs
-  // a locked bundle should say so and point at `agents secrets unlock`, not grab
-  // the fingerprint sensor. AGENTS_RUNTIME is INHERITED by everything spawned under
-  // an agent, so `agents secrets export` run beneath one resolves broker-only too —
-  // correctly: there the agent, not the human, is the caller. A plain shell carries
-  // no AGENTS_RUNTIME, so a person running it themselves still gets the sheet.
-  const runtime = env.AGENTS_RUNTIME;
-  if (runtime === 'headless' || runtime === 'teams' || runtime === 'terminal') return true;
-  return !tty.stdin && !tty.stdout;
-}
+export { isHeadlessSecretsContext } from './headless.js';
 
 /**
  * Read a bundle's metadata AND resolve its env in a single Touch ID prompt.
@@ -1363,10 +1335,13 @@ export function readAndResolveBundleEnv(
   // guard never fires, and they still get their prompt. No caller passes this flag;
   // it remains the seam for a future unlock path that wants the sheet on purpose.
   const interactiveUnlock = opts.interactiveUnlock ?? false;
+  // A `never`-policy bundle's items carry no biometry ACL, so once the policy
+  // check below proves that, the batch read is silent even in a headless
+  // context — attest it to the raw-read storm guard via `silentNoAcl`.
+  let verifiedNoAclBundle = false;
   if (opts.agentOnly && backend === 'keychain' && !interactiveUnlock) {
-    let noAclBundle = false;
-    try { noAclBundle = bundlePolicy(readBundle(name)) === 'never'; } catch { /* fail closed */ }
-    if (!noAclBundle) {
+    try { verifiedNoAclBundle = bundlePolicy(readBundle(name)) === 'never'; } catch { /* fail closed */ }
+    if (!verifiedNoAclBundle) {
       throw new Error(
         `Secrets bundle '${name}' is not unlocked in the secrets agent. ` +
         `Run 'agents secrets unlock ${name}' in a terminal first — an agent launch ` +
@@ -1406,6 +1381,7 @@ export function readAndResolveBundleEnv(
         duration: opts.duration || humanUnlockDuration(secretsHoldMs()),
         defaultPolicy: secretsDefaultPolicy(),
         forceDuration: Boolean(opts.duration),
+        silentNoAcl: verifiedNoAclBundle,
       })
     : store.getBatch([...new Set([metaItem, ...secretItems])]);
 

--- a/apps/cli/src/lib/secrets/headless.ts
+++ b/apps/cli/src/lib/secrets/headless.ts
@@ -1,0 +1,63 @@
+/**
+ * The headless-context detector shared by every secrets read path that could
+ * raise a macOS Touch ID sheet: bundle resolution (bundles.ts) and raw item
+ * reads (index.ts). It lives in its own module so index.ts can use it without
+ * importing bundles.ts (which already imports index.ts).
+ */
+
+/**
+ * True when the current process is a background / non-interactive context that
+ * must NEVER raise a Keychain biometry prompt on the interactive user's screen —
+ * a prompt nobody is watching. Two signals, either sufficient:
+ *   - `AGENTS_RUNTIME` is `headless`, `teams`, or `terminal` — i.e. ANY agent
+ *     launch, interactive included, and inherited by everything spawned beneath
+ *     one (set on the child env by `agents run --headless`, scheduled routines,
+ *     teammates, and interactive runs — see exec.ts:430, runner.ts,
+ *     teams/agents.ts).
+ *   - neither stdin nor stdout is a TTY (a detached/backgrounded task whose
+ *     stdio is redirected to a log — e.g. a release script run in the
+ *     background as `( ... ) >log 2>&1 </dev/null`).
+ * `AGENTS_SECRETS_NO_PROMPT=1` forces headless-safe; `=0` force-allows a prompt
+ * even in a non-TTY context. An `eval "$(agents secrets export X)"` typed in a
+ * PLAIN shell has no AGENTS_RUNTIME, so it is not classified headless and still
+ * prompts. Run beneath an agent it inherits AGENTS_RUNTIME and resolves
+ * broker-only — the agent, not the human, is the caller there.
+ *
+ * Only **macOS keychain** reads pop an interactive Touch ID sheet — the secrets
+ * broker itself is a no-op off darwin (see agent.ts), and libsecret (Linux) /
+ * the Windows credential store resolve without any prompt. So off-darwin this
+ * ALWAYS returns false: forcing broker-only there would break every headless
+ * Linux/Windows read (CI, `agents run --headless`, routines, the Linux-driven
+ * release flow) for no benefit — there is no prompt to suppress.
+ *
+ * A read in a macOS headless context resolves broker-only (agentOnly) and fails
+ * fast with an actionable error instead of hijacking Touch ID. This generalizes
+ * the per-caller broker-only pattern used across the headless secrets readers.
+ */
+export function isHeadlessSecretsContext(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  // Injected so the TTY branch below is testable: it is the branch that decides a
+  // plain human shell still prompts, which is this guard's entire safety argument,
+  // and reading process.* directly made it unreachable from a test.
+  tty: { stdin?: boolean; stdout?: boolean } = { stdin: process.stdin.isTTY, stdout: process.stdout.isTTY },
+): boolean {
+  if (platform !== 'darwin') return false; // no biometry prompt to suppress off-darwin
+  const override = env.AGENTS_SECRETS_NO_PROMPT;
+  if (override === '1') return true;
+  if (override === '0') return false;
+  // Every AGENT-LAUNCH runtime resolves broker-only, interactive included.
+  // `terminal` was missing, which made an agent terminal the one launch path
+  // still allowed to pop Touch ID: exec.ts sets AGENTS_RUNTIME='terminal' for an
+  // interactive run (exec.ts:430), that fell through to the TTY check below, and
+  // a TTY meant "a human is watching, so prompting is fine". It is not fine —
+  // opening a terminal is not a request to authenticate, and a launch that needs
+  // a locked bundle should say so and point at `agents secrets unlock`, not grab
+  // the fingerprint sensor. AGENTS_RUNTIME is INHERITED by everything spawned under
+  // an agent, so `agents secrets export` run beneath one resolves broker-only too —
+  // correctly: there the agent, not the human, is the caller. A plain shell carries
+  // no AGENTS_RUNTIME, so a person running it themselves still gets the sheet.
+  const runtime = env.AGENTS_RUNTIME;
+  if (runtime === 'headless' || runtime === 'teams' || runtime === 'terminal') return true;
+  return !tty.stdin && !tty.stdout;
+}

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -30,6 +30,13 @@ import * as os from 'os';
 import * as path from 'path';
 import { linuxBackend, usesFileFallback as linuxUsesFileFallback, importNativeSecretToolItems } from './linux.js';
 import { windowsBackend, usesFileFallback as windowsUsesFileFallback, importNativeCredManItems } from './windows.js';
+import { isHeadlessSecretsContext } from './headless.js';
+import {
+  KEYCHAIN_READ_BACKOFF_TTL_MS,
+  clearKeychainReadBackoff,
+  isKeychainReadBackedOff,
+  noteKeychainReadFailure,
+} from './read-backoff.js';
 import type { NativeImportReport } from './fallback.js';
 
 export type { NativeImportReport, NativeImportResult, NativeImportStatus } from './fallback.js';
@@ -312,10 +319,11 @@ function parseHmacKeyRecord(raw: string): HmacKeyRecord | null {
 function readHmacKeyRecord(): HmacKeyRecord | null {
   // HMAC_KEY_ITEM is exempt from the transform, so this routes to the helper
   // (or the test backend) under its literal name. The item is no-ACL, so the
-  // read is silent.
+  // read is silent — attest that to the storm guard so a headless hashed-name
+  // resolution never trips the fail-fast.
   let raw: string;
   try {
-    raw = getKeychainToken(HMAC_KEY_ITEM);
+    raw = getKeychainToken(HMAC_KEY_ITEM, { silentNoAcl: true });
   } catch {
     return null;
   }
@@ -821,6 +829,71 @@ export interface KeychainReadContext {
   duration?: string;
   defaultPolicy?: 'hold' | 'always' | 'never';
   forceDuration?: boolean;
+  /**
+   * The caller attests the item(s) carry NO biometry ACL (it wrote them with
+   * `setKeychainToken(..., { noAcl: true })`, or they are bundle metadata /
+   * `never`-policy bundle items, which are no-ACL by contract) — so the read
+   * is silent even when no one is at the screen. Skips the headless fail-fast
+   * and the back-off memo. Never pass this for an ACL-protected item: that
+   * re-opens the background Touch ID storm the guard exists to stop.
+   */
+  silentNoAcl?: boolean;
+}
+
+/**
+ * The detector the raw-read storm guard consults, overridable so tests on any
+ * platform exercise the fail-fast path — the real detector self-gates to
+ * darwin (the only platform with a Touch ID sheet to suppress), which would
+ * make the throw unreachable from a Linux CI run. Same parameterization
+ * argument as the injected env/platform/tty on isHeadlessSecretsContext.
+ */
+let rawReadHeadlessDetector: () => boolean = () => isHeadlessSecretsContext();
+
+export function setKeychainHeadlessDetectorForTest(detector: (() => boolean) | null): void {
+  rawReadHeadlessDetector = detector ?? (() => isHeadlessSecretsContext());
+}
+
+/**
+ * The raw-read storm guard, consulted by every getKeychainToken /
+ * getKeychainTokens read that could reach a prompting keychain query. Two
+ * fail-fast gates, both skipped for `silentNoAcl` (provably prompt-free)
+ * reads:
+ *
+ *  1. Headless fail-fast. A non-interactive process (AGENTS_RUNTIME set, or
+ *     no TTY — see isHeadlessSecretsContext) must NEVER raise a Touch ID sheet
+ *     on the interactive user's screen: the sheet has no one to answer it, a
+ *     polling caller re-raises it every few seconds, and a cancel just feeds
+ *     the next poll. Throw an actionable error naming the item instead.
+ *  2. Back-off. A read whose prompt recently failed or was cancelled is
+ *     suppressed for KEYCHAIN_READ_BACKOFF_TTL_MS so an interactive-context
+ *     poller (TTY but unwatched — a tmux pane, a VS Code task terminal) can't
+ *     storm sheets either. A successful read or write clears the memo.
+ *
+ * Placement note: this runs BEFORE the platform branches so the back-off memo
+ * is honored identically everywhere, and the headless gate is a no-op off
+ * darwin (the detector returns false there) — Linux/Windows reads never
+ * prompt, so there is nothing to guard.
+ */
+function assertRawKeychainReadAllowed(key: string, context: KeychainReadContext, label?: string): void {
+  if (context.silentNoAcl) return;
+  const what = label ?? `Keychain item '${key}'`;
+  if (rawReadHeadlessDetector()) {
+    const hint = context.bundle
+      ? `Run 'agents secrets unlock ${context.bundle}' in a terminal first`
+      : `Provision a prompt-free credential for headless use (a file-based setup token, or an item stored without the biometry ACL), ` +
+        `or read it once from an interactive terminal`;
+    throw new Error(
+      `${what} requires Touch ID, but this process is non-interactive — ` +
+      `a prompt would appear on screen with no one to answer it. ${hint}.`
+    );
+  }
+  if (isKeychainReadBackedOff(key)) {
+    throw new Error(
+      `${what} is in read back-off: a Touch ID prompt for it failed or was cancelled within the last ` +
+      `${Math.round(KEYCHAIN_READ_BACKOFF_TTL_MS / 60000)} minutes, and retrying is suppressed so a polling caller can't storm prompts. ` +
+      `Read it once interactively or wait out the back-off.`
+    );
+  }
 }
 
 export function keychainOperationPrompt(context: KeychainReadContext = {}): string {
@@ -840,6 +913,7 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
   const requested = item;
   item = prepareServiceName(item, { autoRekey: true });
   if (backend) return backend.get(item);
+  assertRawKeychainReadAllowed(requested, context);
   assertSupportedPlatform();
   if (isLinux()) return linuxBackend.get(item);
   if (isWindows()) return windowsBackend.get(item);
@@ -849,7 +923,10 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
     });
     if (sec.status === 0) {
       const token = sec.stdout?.toString().trim();
-      if (token) return token;
+      if (token) {
+        clearKeychainReadBackoff(requested);
+        return token;
+      }
     }
     throw new Error(`Keychain item '${requested}' not found.`);
   }
@@ -862,14 +939,20 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  // Exit 1 is a plain miss — no prompt was raised, so it opens no back-off.
   if (result.status === 1) throw new Error(`Keychain item '${requested}' not found.`);
-  if (result.status === 4) throw new Error(`Touch ID cancelled while reading '${requested}'.`);
   if (result.status !== 0) {
+    // A cancel (4) or helper failure after a prompted read: open the back-off
+    // window BEFORE throwing, so the next poll of the same item fails fast
+    // instead of re-raising the sheet.
+    if (!context.silentNoAcl) noteKeychainReadFailure(requested);
+    if (result.status === 4) throw new Error(`Touch ID cancelled while reading '${requested}'.`);
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to read keychain item '${requested}'.`);
   }
   const token = result.stdout?.toString();
   if (!token) throw new Error(`Keychain item '${requested}' exists but is empty.`);
+  clearKeychainReadBackoff(requested);
   return token;
 }
 
@@ -904,6 +987,13 @@ export function getKeychainTokens(items: string[], context: KeychainReadContext 
     }
     return result;
   }
+  // One back-off memo covers the whole batch: the batch raises at most one
+  // prompt, so a cancel/failure suppresses retrying the same batch, keyed by
+  // the requested names (never the storage hashes) for a stable identity. The
+  // guard runs before the platform branches so the headless fail-fast is
+  // exercisable on any platform (the real detector self-gates to darwin).
+  const backoffKey = `batch:${items.join('\n')}`;
+  assertRawKeychainReadAllowed(backoffKey, context, `Batch read of ${items.length} keychain item(s)`);
   assertSupportedPlatform();
   if (isLinux()) {
     for (const storage of storageItems) {
@@ -930,6 +1020,7 @@ export function getKeychainTokens(items: string[], context: KeychainReadContext 
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  if (child.status !== 0 && !context.silentNoAcl) noteKeychainReadFailure(backoffKey);
   if (child.status === 4) {
     throw new Error(`Touch ID cancelled while reading ${items.length} keychain item(s).`);
   }
@@ -937,6 +1028,7 @@ export function getKeychainTokens(items: string[], context: KeychainReadContext 
     const msg = child.stderr?.toString().trim();
     throw new Error(msg || `Failed to batch-read ${items.length} keychain items.`);
   }
+  clearKeychainReadBackoff(backoffKey);
   const out = child.stdout?.toString() ?? '';
   parseBatchRecords(out, record);
   return result;
@@ -1018,6 +1110,7 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
   // Validate the CLEARTEXT name (a hashed storage name is always clean), then
   // resolve the storage name.
   if (/[\x00=\r\n]/.test(item)) throw new Error('Secret item name contains invalid characters.');
+  const requested = item;
   item = prepareServiceName(item, { autoRekey: true });
   if (backend) { backend.set(item, value, opts); return; }
   assertSupportedPlatform();
@@ -1066,6 +1159,7 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
       const msg = sec.stderr?.toString().trim();
       throw new Error(msg || `Failed to write keychain item '${item}'.`);
     }
+    clearKeychainReadBackoff(requested);
     return;
   }
 
@@ -1090,19 +1184,27 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
     }
     throw new Error(msg || `Failed to write keychain item '${item}'.`);
   }
+  // A successful write supersedes any open back-off: the item is known-good
+  // now, so the next read must not be suppressed by a stale failure memo.
+  clearKeychainReadBackoff(requested);
 }
 
 /** Delete a keychain/keyring item. Returns true if it existed. Never prompts for biometry. */
 export function deleteKeychainToken(item: string): boolean {
+  const requested = item;
   item = prepareServiceName(item);
   if (backend) return backend.delete(item);
   assertSupportedPlatform();
   if (isLinux()) return linuxBackend.delete(item);
   if (isWindows()) return windowsBackend.delete(item);
   const bin = getKeychainHelperPath();
-  return spawnSync(bin, ['delete', item, os.userInfo().username], {
+  const deleted = spawnSync(bin, ['delete', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
   }).status === 0;
+  // A deleted item must fail its next read as plain "not found", not with a
+  // stale back-off error left over from a pre-delete cancel.
+  if (deleted) clearKeychainReadBackoff(requested);
+  return deleted;
 }
 
 /**

--- a/apps/cli/src/lib/secrets/read-backoff.ts
+++ b/apps/cli/src/lib/secrets/read-backoff.ts
@@ -1,0 +1,74 @@
+/**
+ * Negative memo for failed/cancelled macOS keychain reads (the "back-off").
+ *
+ * A cancelled Touch ID sheet is the user saying "not now" — but a polling
+ * caller (the Factory extension host's `agents view` loop, a watch script)
+ * retries the same read a few seconds later and pops the sheet again, forever.
+ * The headless guard (index.ts `assertRawKeychainReadAllowed`) covers the
+ * no-TTY case; this memo covers a context that CAN prompt but just had its
+ * prompt cancelled or fail: the next read of the same item within the TTL
+ * throws the back-off error instead of re-prompting. Any successful read (or
+ * write) of the item clears the memo.
+ *
+ * Stored as regenerable state under `~/.agents/.cache/keychain-read-backoff/`,
+ * one file per item (filename is a hash of the item name; the file carries no
+ * secret material — a name and a deadline only). All operations are
+ * best-effort: a lost memo costs at most one extra prompt, never a read.
+ */
+
+import { createHash } from 'node:crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** How long a failed/cancelled read suppresses retries of the same item. */
+export const KEYCHAIN_READ_BACKOFF_TTL_MS = 5 * 60 * 1000;
+
+let dirOverride: string | null = null;
+
+/** Test seam: point the memo at a temp dir so tests never touch the real cache. */
+export function setKeychainReadBackoffDirForTest(dir: string | null): void {
+  dirOverride = dir;
+}
+
+function backoffDir(): string {
+  return dirOverride ?? path.join(os.homedir(), '.agents', '.cache', 'keychain-read-backoff');
+}
+
+function backoffFile(key: string): string {
+  const digest = createHash('sha256').update(key).digest('hex').slice(0, 24);
+  return path.join(backoffDir(), `${digest}.json`);
+}
+
+/** True while `key` is inside the back-off window opened by a failed/cancelled read. */
+export function isKeychainReadBackedOff(key: string, now: number = Date.now()): boolean {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(backoffFile(key), 'utf8')) as { until?: unknown };
+    return typeof parsed.until === 'number' && parsed.until > now;
+  } catch {
+    return false; // absent or malformed memo → no back-off
+  }
+}
+
+/** Open (or refresh) the back-off window for `key` after a failed/cancelled read. */
+export function noteKeychainReadFailure(key: string, now: number = Date.now()): void {
+  try {
+    fs.mkdirSync(backoffDir(), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      backoffFile(key),
+      JSON.stringify({ item: key, until: now + KEYCHAIN_READ_BACKOFF_TTL_MS }),
+      { mode: 0o600 },
+    );
+  } catch {
+    /* best-effort — the cache dir is regenerable; a lost memo costs one prompt */
+  }
+}
+
+/** Clear the memo: a successful read or write of the item resets the back-off. */
+export function clearKeychainReadBackoff(key: string): void {
+  try {
+    fs.rmSync(backoffFile(key), { force: true });
+  } catch {
+    /* best-effort */
+  }
+}

--- a/apps/cli/src/lib/secrets/session-store.ts
+++ b/apps/cli/src/lib/secrets/session-store.ts
@@ -120,7 +120,8 @@ function sessionBlobItem(name: string, harness: string): string {
 /** Read the session index by its fixed name. `{bundles:{}}` when absent/unreadable. */
 export function readIndex(): SessionIndex {
   try {
-    const raw = getKeychainToken(SESSION_INDEX_ITEM);
+    // Written no-ACL (writeIndex below) — attest so a headless resolve stays silent.
+    const raw = getKeychainToken(SESSION_INDEX_ITEM, { silentNoAcl: true });
     const parsed = JSON.parse(raw) as SessionIndex;
     if (parsed && typeof parsed === 'object' && parsed.bundles) return parsed;
   } catch {
@@ -177,7 +178,8 @@ export function resolveSession(
 export function loadSession(name: string, now: number = Date.now(), harness: string = GLOBAL_HARNESS): SessionEntry | null {
   if (!shouldPersist()) return null;
   try {
-    const raw = getKeychainToken(sessionBlobItem(name, harness));
+    // Written no-ACL (saveSession) — attest so a headless resolve stays silent.
+    const raw = getKeychainToken(sessionBlobItem(name, harness), { silentNoAcl: true });
     const entry = JSON.parse(raw) as SessionEntry;
     if (!entry || typeof entry !== 'object' || !entry.bundle || !entry.env) return null;
     if (now >= entry.expiresAt) {
@@ -249,7 +251,7 @@ export function rehydrateSessions(now: number = Date.now()): Array<{ name: strin
     for (const [key, meta] of Object.entries(index.bundles)) {
       if (key.includes(':')) continue;
       try {
-        const raw = getKeychainToken(`${SESSION_ITEM_PREFIX}${key}`);
+        const raw = getKeychainToken(`${SESSION_ITEM_PREFIX}${key}`, { silentNoAcl: true });
         const legacy = JSON.parse(raw) as SessionEntry;
         setKeychainToken(sessionBlobItem(key, GLOBAL_HARNESS), JSON.stringify({ ...legacy, harness: GLOBAL_HARNESS }), { noAcl: true });
         deleteKeychainToken(`${SESSION_ITEM_PREFIX}${key}`);
@@ -282,7 +284,7 @@ export function rehydrateSessions(now: number = Date.now()): Array<{ name: strin
         continue;
       }
       try {
-        const raw = getKeychainToken(sessionBlobItem(bundleName, 'cli'));
+        const raw = getKeychainToken(sessionBlobItem(bundleName, 'cli'), { silentNoAcl: true });
         const legacy = JSON.parse(raw) as SessionEntry;
         setKeychainToken(sessionBlobItem(bundleName, GLOBAL_HARNESS), JSON.stringify({ ...legacy, harness: GLOBAL_HARNESS }), { noAcl: true });
         deleteKeychainToken(sessionBlobItem(bundleName, 'cli'));

--- a/apps/cli/src/lib/secrets/vault.ts
+++ b/apps/cli/src/lib/secrets/vault.ts
@@ -265,7 +265,9 @@ export function clearVaultKey(): void {
 export function getVaultSession(): { loggedIn: true; key: VaultKey; expiresAt: number } | { loggedIn: false; expiresAt?: number } {
   let raw: string;
   try {
-    raw = getKeychainToken(VAULT_SESSION_ITEM);
+    // Written no-ACL (cacheVaultKey) — the vault session probe runs inside bundleBackend
+    // for EVERY bundle op, headless included, so it must stay silent.
+    raw = getKeychainToken(VAULT_SESSION_ITEM, { silentNoAcl: true });
   } catch {
     return { loggedIn: false };
   }

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -1641,7 +1641,9 @@ function claudeOauthCacheActive(): boolean {
  * or the token itself has expired — in which case the stale entry is dropped. */
 function readCachedClaudeOauth(service: string): ClaudeOauthCredentials | null {
   try {
-    const entry = JSON.parse(getKeychainToken(claudeOauthCacheItem(service))) as CachedClaudeOauthEntry;
+    // The cache item is written no-ACL (writeCachedClaudeOauth) — its whole purpose is
+    // serving the token prompt-free, so attest that to the raw-read storm guard.
+    const entry = JSON.parse(getKeychainToken(claudeOauthCacheItem(service), { silentNoAcl: true })) as CachedClaudeOauthEntry;
     if (!entry || typeof entry.accessToken !== 'string' || !entry.accessToken) return null;
     const now = Date.now();
     const tokenExpired = typeof entry.expiresAt === 'number' && entry.expiresAt > 0 && now >= entry.expiresAt;


### PR DESCRIPTION
## Problem

167 macOS Touch ID sheets in one day from "Agents CLI". Root causes (verified against live logs):

1. **Raw keychain item reads had no headless guard.** `getKeychainToken`/`getKeychainTokens` spawn the signed helper with `kSecUseAuthenticationUIAllow`, so ANY process — including TTY-less background ones (the Factory extension host polling `agents view claude` every few seconds, daemons, cron) — popped a sheet on the user's screen. Bundle reads had the `isHeadlessSecretsContext` guard; raw item reads didn't. The usage path (`loadClaudeOauth`) falls through to an ACL keychain read when no file-based setup-token exists, and every cancel/ignore fed the next poll — an endless storm.
2. **Profile dispatch bypassed everything.** `resolveProfileEnv` read `agents-cli.<provider>.token` raw — every `agents run <profile>` prompted, in any context.
3. **crabbox tailscale plumbing re-read per call.** `crabboxEnv` runs several times per lease (list/wait/spawn/stop) and memoized only the bundle PICK, not the value; its single-key subset read is rejected by `canCacheResolvedEnv` for broker auto-cache, so a non-broker-held tailscale bundle re-read the keychain on every call.

## Fix

- **Headless fail-fast for raw reads** (`assertRawKeychainReadAllowed` in `secrets/index.ts`): before any helper spawn, a non-interactive process (agent runtime, or no TTY — the shared `isHeadlessSecretsContext`, moved to `secrets/headless.ts` and re-exported from `bundles.ts`) gets an actionable error naming the item and the fix (`agents secrets unlock` / interactive read / prompt-free provisioning). A plain human shell is unaffected and still prompts.
- **5-minute read back-off** (`secrets/read-backoff.ts`, under `~/.agents/.cache/keychain-read-backoff/`): a cancelled/failed interactive read suppresses retries of the same item so a poller with a TTY can't storm either; any successful read/write/delete clears it; a plain miss opens no memo.
- **Provably-silent reads attest it** via `KeychainReadContext.silentNoAcl` and stay readable headless: bundle metadata (SEC-4), `never`-policy bundles (SEC-19), the unlock session store, the vault session probe, the usage OAuth token cache, the HMAC name-hashing key. Without this the guard would have broken durable unlock sessions and the OAuth cache — the no-prompt fast paths.
- **crabbox tailscale value memo** per process next to the pick memo: one keychain read per process, not per `crabboxEnv` call; a failed read memoizes as absent.

## Run evidence

Full log: `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/touchid-storm/.agents/artifacts/touchid-storm-run-evidence.txt`

Live run against the built `dist/` (headless simulated via `AGENTS_RUNTIME=headless`) — the guard fires BEFORE any helper process exists:

```
$ AGENTS_RUNTIME=headless node -e '… getKeychainToken("agents-cli.demo.token") …'
Keychain item 'agents-cli.demo.token' requires Touch ID, but this process is non-interactive — a prompt would appear on screen with no one to answer it. Provision a prompt-free credential for headless use (…), or read it once from an interactive terminal.

$ … getKeychainTokens(['agents-cli.bundles.prod'], { bundle: 'prod' }) …
Batch read of 1 keychain item(s) requires Touch ID, but this process is non-interactive — … Run 'agents secrets unlock prod' in a terminal first.

$ … getKeychainToken('agents-cli.demo.noacl', { silentNoAcl: true }) …
Keychain item 'agents-cli.demo.noacl' not found.   ← guard bypassed; real platform error, no sheet
```

Targeted tests: `raw-read-guard.test.ts` + `crabbox/cli.test.ts` + `profiles.test.ts` — **68 passed**. Full `src/lib/secrets` + usage suites — **669 passed**. `scripts/build.sh` compiles clean. The 3 full-suite failures (`models.test.ts`, `exec.test.ts` mailbox, `sessions.test.ts` old-peer) reproduce identically on pristine `origin/main` — pre-existing, unrelated.

## Tests added

- New `secrets/__tests__/raw-read-guard.test.ts` (15 tests): headless fail-fast (single + batch), bundle-context error points at `agents secrets unlock`, `silentNoAcl` bypass, back-off consult/record/expiry/clear/malformed-memo, headless error wins over back-off.
- `profiles.test.ts`: `resolveProfileEnv` in a simulated headless context throws the actionable error instead of attempting a read (no new broker cache for profile tokens, per scope).
- `crabbox/cli.test.ts`: repeated `crabboxEnv` calls read the tailscale value at most once; failure memoizes.

## Docs

- `docs/secrets.md`: raw-read guard + back-off behavior.
- `docs/specifications.md`: SEC-13 extended to raw item reads (with Given/When/Then); new SEC-27 for the back-off memo.
- Changelog fragment: `.changelog/next/secrets-touchid-storm.md`.

## Notes for reviewers

- Behavior change worth knowing: `agents secrets get <bare-item>` in a headless context now fails fast instead of risking a prompt on a foreign ACL'd item. The Linear SessionStart hook is unaffected (it reads via its own `/usr/bin/security` call, not `getKeychainToken`).
- Branch is `fix/secrets-touchid-storm-raw-reads` because a stale, unrelated remote branch already owned `fix/secrets-touchid-storm` (no force-push).
