### PR TITLE
ci(runner): scripts for the shared crabbox-ci runner pool

### DIFF
--- a/scripts/ci-runner/README.md
+++ b/scripts/ci-runner/README.md
@@ -1,0 +1,61 @@
+# ci-runner — the shared phnx-labs CI runner pool
+
+One standing Hetzner box (`ci-runner-fsn1`, cpx62) is the CI runner pool for the
+org. It replaced the per-repo runner on yosemite-s0 and removed the need for
+per-run cloud leases for CI.
+
+## Layout
+
+- **4 ephemeral runners** (`runner@1-4.service`) serve `muqsitnawaz/agents`
+  (labels `self-hosted,linux,x64`) — the original bootstrap, untouched.
+- **2 persistent org runners** (`runner-phnx@1-2.service`) serve the phnx-labs
+  org runner group `crabbox-ci` (selected repos: agents-cli, agi-cli) with
+  labels `self-hosted,linux,x64,crabbox-ci,tailnet`. Created by
+  `provision-phnx-runners.sh`.
+- **Janitor** (`/etc/cron.d/ci-janitor` → `janitor.sh` daily): docker prune,
+  stale `_work` sweep, journald vacuum, apt autoremove.
+- **Supervisor** (launchd `com.phnx-labs.ci-supervise` on mac-mini, every 10
+  min → `supervise.sh`): box reachability, unit states, GitHub-side runner
+  status (when gh has org-admin), tailnet + win-mini probe from the box, disk,
+  and the **crabbox idle-reaper** (deletes crabbox-leased servers idle > 6h —
+  direct-provider crabbox has no coordinator, so nothing else reaps them).
+
+## Security invariants
+
+- The `crabbox-ci` label may only appear in workflows with **trusted triggers**
+  (push to main / schedule / workflow_dispatch). Never on `pull_request`:
+  agents-cli is public; a self-hosted runner reachable from fork PRs is
+  RCE-on-our-infra.
+- The org runner group `crabbox-ci` is restricted to selected repos; adding a
+  repo is an org-admin action.
+- The box's muqsitnawaz/agents runners are ephemeral (`--once` + re-register);
+  the phnx-labs org runners are persistent (no standing GitHub credential on
+  the box for the org — registration tokens are minted via `gh` and pushed over
+  SSH only when (re)registering).
+
+## Operating it
+
+```sh
+# health snapshot (from any machine with the ops key + gh)
+CI_BOX_KEY=~/.ssh/ci-runner-ops bash scripts/ci-runner/supervise.sh
+
+# box access
+ssh -i ~/.ssh/ci-runner-ops root@78.46.183.46
+
+# re-register a dead phnx runner (the supervisor does this automatically when
+# gh has org rights): see supervise.sh
+```
+
+Box rebuilds are manual: lease a fresh cpx62 in fsn1, copy
+`~/.ssh/ci-runner-ops.pub` into `/root/.ssh/authorized_keys`, install tailscale
++ join the tailnet, then run `provision-phnx-runners.sh` (phnx pool) — the
+muqsitnawaz/agents pool comes from the original infra-ci bootstrap (see the
+box's `/etc/runner.env` + `register-runner.sh`).
+
+## Files
+
+| File | Runs where | Purpose |
+|---|---|---|
+| `provision-phnx-runners.sh` | on the box (via ssh) | fresh-install + register the 2 org runners, systemd units |
+| `supervise.sh` | mac-mini (launchd, 10 min) | health checks, heal ladder, crabbox idle-reaper |
+| `janitor.sh` | on the box (cron, daily) | docker/_work/journal/apt hygiene |

--- a/scripts/ci-runner/janitor.sh
+++ b/scripts/ci-runner/janitor.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# janitor.sh — daily hygiene for ci-runner-fsn1 (runs on-box via root cron).
+# Keeps the standing CI box from accumulating state: docker cruft, stale
+# runner workdirs, logs, packages. Never touches runner registration state.
+set -uo pipefail
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+# 1. Docker: dangling images/containers/build cache older than 24h.
+if command -v docker >/dev/null; then
+  docker system prune -af --filter "until=24h" >/dev/null 2>&1 && log "docker pruned"
+fi
+
+# 2. Runner workdirs: delete job workspaces older than 7 days (runners clean
+#    per-job, but killed jobs leak). Only inside _work dirs we own.
+for d in /opt/actions-runner-*/_work /opt/actions-runner-phnx-*/_work; do
+  [ -d "$d" ] || continue
+  find "$d" -mindepth 1 -maxdepth 1 -mtime +7 -exec rm -rf {} + 2>/dev/null
+done
+log "workdirs swept"
+
+# 3. Logs: journald capped at 500M.
+journalctl --vacuum-size=500M >/dev/null 2>&1 && log "journal vacuumed"
+
+# 4. Packages: security updates + autoremove (unattended-upgrades handles the
+#    patching; this clears the residue).
+apt-get autoremove -y >/dev/null 2>&1 && log "apt autoremoved"
+
+# 5. Report disk.
+df -h / | tail -1 | awk '{print "[janitor] disk: "$3" used of "$2" ("$5")"}'

--- a/scripts/ci-runner/provision-phnx-runners.sh
+++ b/scripts/ci-runner/provision-phnx-runners.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fresh-install two persistent phnx-labs org runner instances on ci-runner-fsn1.
+# Usage: REG_TOKEN=<org registration token> bash provision-phnx-runners.sh
+set -euo pipefail
+
+: "${REG_TOKEN:?REG_TOKEN (org registration token for phnx-labs) must be set}"
+
+URL=$(curl -sf https://api.github.com/repos/actions/runner/releases/latest \
+  | python3 -c "import sys,json; r=json.load(sys.stdin); print([a['browser_download_url'] for a in r['assets'] if 'linux-x64' in a['name']][0])")
+echo "runner tarball: $URL"
+
+for i in 1 2; do
+  D="/opt/actions-runner-phnx-$i"
+  rm -rf "$D"
+  mkdir -p "$D"
+  curl -sfL "$URL" | tar -xz -C "$D"
+  chown -R runner:runner "$D"
+  (cd "$D" && sudo -u runner ./config.sh \
+    --url "https://github.com/phnx-labs" \
+    --token "$REG_TOKEN" \
+    --name "ci-runner-fsn1-phnx-$i" \
+    --labels "self-hosted,linux,x64,crabbox-ci,tailnet" \
+    --runnergroup "crabbox-ci" \
+    --work "_work" \
+    --unattended \
+    --replace)
+done
+
+cat > /etc/systemd/system/runner-phnx@.service <<'UNIT'
+[Unit]
+Description=GitHub Actions persistent runner (phnx-labs org) %i
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=runner
+Group=runner
+WorkingDirectory=/opt/actions-runner-phnx-%i
+ExecStart=/opt/actions-runner-phnx-%i/run.sh
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now runner-phnx@1 runner-phnx@2
+sleep 8
+systemctl --no-pager status runner-phnx@1 runner-phnx@2 2>&1 | grep -E '●|Active:' || true
+echo "provision-phnx-done"

--- a/scripts/ci-runner/supervise.sh
+++ b/scripts/ci-runner/supervise.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# supervise.sh — health + self-heal for the shared CI runner box (ci-runner-fsn1)
+# and the crabbox idle-reaper. Designed to run from launchd/cron on mac-mini
+# (needs: ~/.ssh/ci-runner-ops key, gh auth, and hetzner access via either an
+# unlocked `agents secrets` hetzner.com bundle or ~/.config/infra-ci/hcloud-token).
+#
+#   supervise.sh [--once]     one pass (default), prints a summary line
+#
+# Heal ladder per dead runner unit: systemctl restart over SSH -> verify on the
+# GitHub API -> re-register (phnx units: fresh org token minted via gh, pushed
+# over SSH; muqsitnawaz units self-heal via their on-box PAT). The box itself
+# being unreachable is reported, not rebuilt (full re-provision is a script).
+set -uo pipefail
+
+BOX_IP="${CI_BOX_IP:-78.46.183.46}"
+BOX_KEY="${CI_BOX_KEY:-$HOME/.ssh/ci-runner-ops}"
+LOG_DIR="$HOME/.cache/infra-ci"
+LOG="$LOG_DIR/supervise.log"
+REAP_IDLE_SECS="${REAP_IDLE_SECS:-21600}"   # 6h
+mkdir -p "$LOG_DIR"
+
+log() { echo "[$(date -u +%FT%TZ)] $*" | tee -a "$LOG"; }
+fail=0
+
+box() { ssh -i "$BOX_KEY" -o BatchMode=yes -o IdentitiesOnly=yes -o ConnectTimeout=10 "root@$BOX_IP" "$@" 2>/dev/null; }
+
+hcloud_token() {
+  if [ -n "${HCLOUD_TOKEN:-}" ]; then echo "$HCLOUD_TOKEN"; return; fi
+  if command -v agents >/dev/null && agents secrets exec hetzner.com -- bash -c 'echo -n "$HCLOUD_TOKEN"' 2>/dev/null | grep -q .; then
+    agents secrets exec hetzner.com -- bash -c 'echo -n "$HCLOUD_TOKEN"' 2>/dev/null; return
+  fi
+  cat "$HOME/.config/infra-ci/hcloud-token" 2>/dev/null
+}
+
+# --- 1. box reachable ---------------------------------------------------------
+if ! box 'true'; then
+  log "FATAL box $BOX_IP unreachable over SSH — runners down; manual re-provision may be needed"
+  exit 1
+fi
+
+# --- 2. runner units active + GitHub-side online ------------------------------
+restart_unit() { box "systemctl restart '$1'" && log "heal: restarted $1"; }
+
+for u in runner@1 runner@2 runner@3 runner@4 runner-phnx@1 runner-phnx@2; do
+  state=$(box "systemctl is-active '$u'.service" || echo unknown)
+  if [ "$state" != active ]; then
+    log "WARN $u is $state — restarting"
+    restart_unit "$u" || fail=1
+  fi
+done
+
+# GitHub-side view: an org runner stuck offline with an active unit means
+# registration drift — re-register the phnx units (their token path is ours).
+# The org endpoints need org admin; if gh can't (403), GitHub-side healing is
+# skipped and unit-state checks carry the health signal.
+GH_ORG_OK=1
+gh api orgs/phnx-labs/actions/runners --jq '.runners | length' >/dev/null 2>&1 || GH_ORG_OK=0
+[ "$GH_ORG_OK" = 0 ] && log "NOTE gh lacks org runner read (403) — GitHub-side checks/heals skipped; unit checks only"
+
+phnx_offline=""
+[ "$GH_ORG_OK" = 1 ] && phnx_offline=$(gh api orgs/phnx-labs/actions/runners \
+  --jq '.runners[] | select(.name | startswith("ci-runner-fsn1-phnx")) | select(.status != "online") | .name' 2>/dev/null)
+for name in $phnx_offline; do
+  n=${name##*-}
+  log "WARN $name offline on GitHub — re-registering runner-phnx@$n"
+  tok=$(gh api -X POST orgs/phnx-labs/actions/runners/registration-token --jq .token 2>/dev/null) || tok=""
+  if [ -n "$tok" ]; then
+    box "D=/opt/actions-runner-phnx-$n; cd \$D && rm -f .runner .credentials .credentials_rsaparams && \
+      sudo -u runner ./config.sh --url https://github.com/phnx-labs --token '$tok' \
+      --name 'ci-runner-fsn1-phnx-$n' --labels 'self-hosted,linux,x64,crabbox-ci,tailnet' \
+      --runnergroup crabbox-ci --work _work --unattended --replace >/dev/null 2>&1 && \
+      systemctl restart runner-phnx@$n" && log "heal: re-registered $name" || { log "FAIL re-register $name"; fail=1; }
+  else
+    log "FAIL could not mint org registration token (gh auth?)"; fail=1
+  fi
+done
+
+# --- 3. tailnet + win-mini reach from the box ---------------------------------
+ts_ip=$(box 'tailscale ip -4 2>/dev/null' || true)
+if [ -z "$ts_ip" ]; then
+  log "WARN box is off the tailnet (win-e2e will fail: cannot reach win-mini)"
+elif ! box 'ping -c1 -W3 win-mini >/dev/null 2>&1'; then
+  log "WARN box tailnet up ($ts_ip) but win-mini unreachable (win-e2e will fail)"
+fi
+
+# --- 4. disk ------------------------------------------------------------------
+disk=$(box "df --output=pcent / | tail -1 | tr -dc 0-9" || echo 0)
+[ "${disk:-0}" -ge 85 ] && { log "WARN disk at ${disk}% — running janitor"; box /usr/local/bin/janitor.sh >/dev/null; }
+
+# --- 5. crabbox idle-reaper ---------------------------------------------------
+tok=$(hcloud_token || true)
+if [ -n "$tok" ]; then
+  now=$(date +%s)
+  curl -sf -H "Authorization: Bearer $tok" "https://api.hetzner.cloud/v1/servers?per_page=50" \
+  | python3 -c "
+import sys, json
+now = $now
+for s in json.load(sys.stdin)['servers']:
+    labels = s.get('labels', {})
+    if labels.get('created_by') != 'crabbox':
+        continue
+    touched = int(labels.get('last_touched_at') or labels.get('created_at') or 0)
+    idle = now - touched
+    if idle > $REAP_IDLE_SECS:
+        print(f'{s[\"id\"]} {s[\"name\"]} idle={idle//3600}h')
+" | while read -r sid sname sidle; do
+    log "reap: deleting $sname ($sidle)"
+    curl -sf -X DELETE -H "Authorization: Bearer $tok" "https://api.hetzner.cloud/v1/servers/$sid" >/dev/null \
+      && log "reap: deleted $sname" || { log "FAIL reap $sname"; fail=1; }
+  done
+else
+  log "WARN no hcloud token (unlock hetzner.com or write ~/.config/infra-ci/hcloud-token) — reaper skipped"
+fi
+
+online="?"
+[ "$GH_ORG_OK" = 1 ] && online=$(gh api orgs/phnx-labs/actions/runners --jq '[.runners[] | select(.status=="online")] | length' 2>/dev/null || echo '?')
+log "summary: phnx runners online=$online disk=${disk}% tailnet=${ts_ip:-down} exit=$fail"
+exit $fail


### PR DESCRIPTION
## What

Durable, repo-checked versions of the operational scripts behind the new shared CI runner pool (`crabbox-ci` org runner group on ci-runner-fsn1) — all three are **already live-deployed**; this PR checks them in:

- `scripts/ci-runner/provision-phnx-runners.sh` — fresh-installs and registers the two phnx-labs org runners (`ci-runner-fsn1-phnx-{1,2}`, labels `self-hosted,linux,x64,crabbox-ci,tailnet`, runner group `crabbox-ci`) with systemd units.
- `scripts/ci-runner/supervise.sh` — health + self-heal + **crabbox idle-reaper**. Runs from launchd on mac-mini every 10 min: box reachability, runner unit states, GitHub-side runner status (degrades gracefully when gh lacks org-admin), tailnet + win-mini probe from the box, disk guard, and deletion of crabbox-leased Hetzner servers idle > 6h (direct-provider crabbox has no coordinator, so nothing else reaps them — this is the zombie-box fix at the source).
- `scripts/ci-runner/janitor.sh` — on-box daily cron: docker prune, stale `_work` sweep, journald vacuum, apt autoremove.
- `scripts/ci-runner/README.md` — layout, security invariants (the `crabbox-ci` label is trusted-triggers-only, never `pull_request`), operating + rebuild runbooks.

## Evidence (live runs, attached)

- Supervisor run from mac-mini (launchd `com.phnx-labs.ci-supervise`, already installed): box reachable, all 6 units active, disk 9%, reaper pass clean. Captured at `/Users/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/scratch/crabbox-ci-pool-evidence.txt` alongside the org runner list showing both phnx runners online.
- Janitor first run on the box: `docker pruned / workdirs swept / journal vacuumed / apt autoremoved — disk: 51G used of 601G (9%)` (freed 72 GB).
- `shellcheck scripts/ci-runner/*.sh` — clean (two info-level SC2016, intentional: expansion must happen in the env-injected child shell).
- Runner pool proof (the runners these scripts provisioned): https://github.com/phnx-labs/agents-cli/actions/runs/30887728051 — `Runner name: 'ci-runner-fsn1-phnx-2'`, group `crabbox-ci`.

Related: #1916 (workflow label flip onto this pool), phnx-labs/agi-cli#10 (same + mirror guard fix), #1915 (reuse-first --lease, the other half of the zombie-box fix).
