### PR TITLE
feat(projects): goals[] — the OKR-shaped "why" on a project

### DIFF
--- a/apps/cli/.changelog/next/projects-goals.md
+++ b/apps/cli/.changelog/next/projects-goals.md
@@ -1,0 +1,9 @@
+- **`agents projects` definitions can now carry goals — the OKR-shaped "why".**
+  A project serves one or more `goals[]`, each an `objective` (the outcome) plus an
+  optional `measure` (the key result). Set them at scaffold time with
+  `agents projects add <name> --goal "objective:measure"` (repeatable), replace them
+  later with `agents projects set <name> --goal …`, or hand-edit the YAML. Goals show
+  on the `status` card (compact) and in `projects view` (in full), and survive a
+  `--from-linear` re-import like every other hand-set field. Milestones (pulled from
+  Linear) remain the dated checkpoints toward these goals. Source:
+  `apps/cli/src/lib/projects.ts`, `apps/cli/src/commands/projects.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -46,6 +46,9 @@ defaultPath: ~/src/github.com/phnx-labs/rush/apps/web   # where an agent's cwd l
 repo: phnx-labs/rush            # primary GitHub slug (PR / merge rollup)
 repos:                          # additional repos, each with an optional monorepo subpath
   - slug: phnx-labs/rush-infra
+goals:                          # the outcomes this project serves (OKR-shaped)
+  - objective: "Ship Rush 2.0"
+    measure: "all tiers migrated"
 contexts:                       # described starting points — an agent reads `purpose`
   - path: apps/web
     purpose: "user-facing Next.js app; funnel + growth surfaces"
@@ -66,6 +69,7 @@ linear:
 | `defaultPath` | Where an agent's cwd lands (a monorepo subdir). Defaults to `root`. |
 | `repo` / `repos[]` | GitHub slug(s), each with an optional `subpath`, for the PR/merge rollup. `repos[].path` (home-relative) names that repo's local checkout and opts it into workspace probing (`status --fleet`). |
 | `contexts[]` | `{path, purpose}` described starting points — indexed anchors for agents. |
+| `goals[]` | `{objective, measure}` the OKR-shaped outcomes a project serves — a project may have several. The objective is the "why"; `measure` is the optional key result. Milestones (pulled from Linear) are the dated checkpoints toward them. |
 | `integrations[]` | `{kind, url, label}` external context sources. |
 | `linear` | `{projectId, url}` — reuses the existing Linear path. |
 
@@ -213,14 +217,14 @@ rush  ·  3 agents
 | Command | Does |
 | --- | --- |
 | `agents projects list [--json]` | All projects: root, repo, live agent count. |
-| `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--context path:purpose`, `--linear`. |
+| `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--context path:purpose`, `--goal objective:measure`, `--linear`. |
 | `agents projects view <name> [--json] [--window N] [--no-remote]` (alias `show`) | Everything about one project: the whole `status` card (agents, ships, focus, schedule, tickets, proof), **every** Linear milestone, then the stored definition in full. |
 | `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
 | `agents projects status [name] [--json] [--window N] [--no-remote] [--fleet]` | The progress card (all projects, or one). `--fleet` adds per-device workspace drift over SSH. |
 | `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. |
 | `agents projects import --from-linear` | Import the workspace's Linear projects (via the `linear` CLI) as definitions. See [Importing](#importing--linear-first-factory-gated). |
 | `agents projects import --from-factory [--min-confidence low\|medium\|high] [--all]` | Absorb `~/.agents/factory/projects.json`. Imports only `high`-confidence rows by default. |
-| `agents projects set <name> [--repo\|--root\|--path\|--description]` | Change one field, preserving every other. Use this rather than `add --force`, which rebuilds the definition from flags alone. |
+| `agents projects set <name> [--repo\|--root\|--path\|--description\|--goal objective:measure]` | Change one field, preserving every other. `--goal` (repeatable) replaces the goals list. Use this rather than `add --force`, which rebuilds the definition from flags alone. |
 | `agents projects rm <name>` | Delete the definition (never touches the repo). |
 
 `agents run --project <name>` is unchanged in spelling — it just resolves richer
@@ -246,8 +250,8 @@ with nobody looking. A project with no exact local match still imports, carrying
 `projects set` or by editing the YAML.
 
 Re-importing is safe. An existing def is preserved field-for-field and only
-`linear` is overwritten, so a hand-set `description`, `contexts`, or `integrations`
-survives. A def that already carries `root`/`repo` is skipped unless `--force`,
+`linear` is overwritten, so a hand-set `description`, `goals`, `contexts`, or
+`integrations` survives. A def that already carries `root`/`repo` is skipped unless `--force`,
 so a re-import never re-points a project you have already bound by hand.
 
 **`--from-factory` is a guess, so it is gated.** Factory's registry is

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -42,6 +42,7 @@ import {
   isSafeProjectName,
   type ProjectDef,
   type ProjectContext,
+  type ProjectGoal,
 } from '../lib/projects.js';
 import {
   rollupSessionsByProject,
@@ -93,6 +94,16 @@ function parseContextFlag(raw: string): ProjectContext {
   const i = raw.indexOf(':');
   if (i === -1) return { path: raw.trim(), purpose: '' };
   return { path: raw.slice(0, i).trim(), purpose: raw.slice(i + 1).trim() };
+}
+
+/** `objective:measure` → a goal. The measure is optional; the objective may contain colons only after the first is claimed. */
+function parseGoalFlag(raw: string): ProjectGoal {
+  const i = raw.indexOf(':');
+  if (i === -1) return { objective: raw.trim() };
+  const measure = raw.slice(i + 1).trim();
+  const goal: ProjectGoal = { objective: raw.slice(0, i).trim() };
+  if (measure) goal.measure = measure;
+  return goal;
 }
 
 /**
@@ -444,6 +455,9 @@ function renderCard(
   }
   // `view` prints these in full (path + purpose, label + URL) right below, so
   // the compact one-line summaries would just say the same thing twice.
+  if (!detail && def.goals?.length) {
+    console.log(`  ${chalk.dim('goal')}     ${def.goals.map((g) => g.objective).join(' · ')}`);
+  }
   if (!detail && def.contexts?.length) {
     console.log(`  ${chalk.dim('context')}  ${def.contexts.map((c) => c.path).join(' · ')}`);
   }
@@ -538,12 +552,13 @@ export function registerProjectsCommands(program: Command): void {
     .option('--path <subdir>', 'Default cwd for agents (a monorepo subdir)')
     .option('--repo <owner/repo>', 'Primary GitHub slug (defaults to the origin remote)')
     .option('--context <path:purpose...>', 'A described starting point; repeatable')
+    .option('--goal <objective:measure...>', 'An outcome the project serves; repeatable')
     .option('--linear <url-or-id>', 'Linear project URL or id')
     .option('--force', 'Overwrite an existing definition')
     .action(
       async (
         name: string,
-        opts: { root?: string; path?: string; repo?: string; context?: string[]; linear?: string; force?: boolean },
+        opts: { root?: string; path?: string; repo?: string; context?: string[]; goal?: string[]; linear?: string; force?: boolean },
       ) => {
         if (!isSafeProjectName(name)) {
           console.error(chalk.red(`Invalid project name: "${name}" (letters, digits, ., _, - only)`));
@@ -568,6 +583,7 @@ export function registerProjectsCommands(program: Command): void {
         if (opts.path) def.defaultPath = `${root!.replace(/\/$/, '')}/${opts.path.replace(/^\//, '')}`;
         if (repo) def.repo = repo;
         if (opts.context?.length) def.contexts = opts.context.map(parseContextFlag);
+        if (opts.goal?.length) def.goals = opts.goal.map(parseGoalFlag);
         if (opts.linear) {
           def.linear = /^https?:/.test(opts.linear) ? { url: opts.linear } : { projectId: opts.linear };
         }
@@ -643,6 +659,7 @@ export function registerProjectsCommands(program: Command): void {
         const where = [rp.subpath ? `subpath ${rp.subpath}` : undefined, rp.path].filter(Boolean).join(' · ');
         console.log(`  ${chalk.dim('repo')}     ${rp.slug}${where ? chalk.dim(`  (${where})`) : ''}`);
       }
+      for (const g of def.goals ?? []) console.log(`  ${chalk.dim('goal')}     ${g.objective}${g.measure ? chalk.dim(`  · ${g.measure}`) : ''}`);
       for (const c of def.contexts ?? []) console.log(`  ${chalk.dim('context')}  ${chalk.cyan(c.path)} ${chalk.dim('—')} ${c.purpose}`);
       for (const ig of def.integrations ?? []) {
         console.log(`  ${chalk.dim(ig.kind.padEnd(8))} ${ig.url}${ig.label ? chalk.dim(`  (${ig.label})`) : ''}`);
@@ -826,14 +843,15 @@ export function registerProjectsCommands(program: Command): void {
     .option('--root <path>', 'Repo / monorepo root')
     .option('--path <subdir>', 'Default cwd for agents (a monorepo subdir)')
     .option('--description <text>', 'One-line description shown on the card')
-    .action((name: string, opts: { repo?: string; root?: string; path?: string; description?: string }) => {
+    .option('--goal <objective:measure...>', 'Replace the goals this project serves; repeatable')
+    .action((name: string, opts: { repo?: string; root?: string; path?: string; description?: string; goal?: string[] }) => {
       const def = loadProjectDef(name);
       if (!def) {
         console.error(chalk.red(`No project named "${name}". List them: agents projects list`));
         process.exit(1);
       }
       const fields = (['repo', 'root', 'path', 'description'] as const).filter((k) => opts[k] !== undefined);
-      if (fields.length === 0) {
+      if (fields.length === 0 && !opts.goal?.length) {
         console.error(chalk.red('Nothing to set. Pass a field, e.g. --repo <owner/repo>.'));
         process.exit(1);
       }
@@ -843,6 +861,7 @@ export function registerProjectsCommands(program: Command): void {
       if (opts.repo !== undefined) def.repo = opts.repo;
       if (opts.root !== undefined) def.root = opts.root;
       if (opts.description !== undefined) def.description = opts.description;
+      if (opts.goal?.length) def.goals = opts.goal.map(parseGoalFlag);
       if (opts.path !== undefined) {
         // `--path` is a subdir OF the root, so without one there is nothing to
         // hang it off. A def imported with `--from-linear` that found no local
@@ -860,6 +879,7 @@ export function registerProjectsCommands(program: Command): void {
       writeProjectDef(def);
       console.log(chalk.green(`Updated ${def.name}`));
       for (const f of fields) console.log(chalk.gray(`  ${f}  ${f === 'path' ? def.defaultPath : def[f as 'repo' | 'root' | 'description']}`));
+      if (opts.goal?.length) console.log(chalk.gray(`  goals  ${def.goals?.map((g) => g.objective).join(' · ')}`));
     });
 
   // ---- link ----

--- a/apps/cli/src/lib/projects.test.ts
+++ b/apps/cli/src/lib/projects.test.ts
@@ -78,6 +78,23 @@ describe('validateProjectDef', () => {
     });
     expect(def.repos).toEqual([{ slug: 'phnx-labs/rush-infra', path: '~/src/rush-infra' }]);
   });
+
+  it('keeps well-formed goals (measure optional) and drops entries without a string objective', () => {
+    const def = validateProjectDef({
+      name: 'rush',
+      goals: [
+        { objective: 'Ship agents-cli 2.0', measure: 'fleet on 2.x' },
+        { objective: 'Grow adoption' },
+        { measure: 'no objective' },
+        { objective: 42 },
+        'nope',
+      ],
+    });
+    expect(def.goals).toEqual([
+      { objective: 'Ship agents-cli 2.0', measure: 'fleet on 2.x' },
+      { objective: 'Grow adoption' },
+    ]);
+  });
 });
 
 describe('write/load roundtrip', () => {

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -62,6 +62,20 @@ export interface ProjectContext {
   purpose: string;
 }
 
+/**
+ * A project goal — the OKR-shaped "why". A project serves one or more goals: a
+ * qualitative `objective` ("Ship agents-cli 2.0") and an optional `measure`, the
+ * key result that says whether it's landing ("fleet on 2.x", "p95 < 200ms"). The
+ * goal is the outcome the work is chasing; milestones (dated checkpoints, pulled
+ * from Linear) and live work (agents / PRs / artifacts) are how far along it is.
+ */
+export interface ProjectGoal {
+  /** The outcome, in a line. */
+  objective: string;
+  /** Optional key result — how success is measured. */
+  measure?: string;
+}
+
 /** An external context source hung off the project (surfaced in `projects show`). */
 export interface ProjectIntegration {
   /** e.g. `gdrive`, `notion`, `figma`, `url`. */
@@ -85,6 +99,8 @@ export interface ProjectDef {
   repos?: ProjectRepo[];
   /** Described starting points inside the project. */
   contexts?: ProjectContext[];
+  /** The outcomes this project serves (OKR-shaped); a project may have several. */
+  goals?: ProjectGoal[];
   /** External context sources (Drive, docs, …). */
   integrations?: ProjectIntegration[];
   /** Linear project link — reuses the existing GraphQL path. */
@@ -176,6 +192,17 @@ export function validateProjectDef(raw: unknown, sourceName?: string): ProjectDe
       ) {
         const cc = c as Record<string, unknown>;
         return [{ path: cc.path as string, purpose: cc.purpose as string }];
+      }
+      return [];
+    });
+  }
+  if (Array.isArray(o.goals)) {
+    def.goals = o.goals.flatMap((g) => {
+      if (g && typeof g === 'object' && typeof (g as Record<string, unknown>).objective === 'string') {
+        const gg = g as Record<string, unknown>;
+        const goal: ProjectGoal = { objective: gg.objective as string };
+        if (typeof gg.measure === 'string') goal.measure = gg.measure;
+        return [goal];
       }
       return [];
     });


### PR DESCRIPTION
**feat** · `agents projects` (beta). Adds the one piece of the locked project model not already on `main`: a stored, OKR-shaped **goals** layer.

## What & why
The milestone/import/list work already landed on `main`, but a project had no place to say *what outcome it serves*. This adds `goals[]` to `ProjectDef` — each a qualitative `objective` plus an optional `measure` (the key result). A project may serve several. Milestones (pulled from Linear) stay the dated checkpoints *toward* these goals; goals are the stored "why".

Model completed: **goal → project → { milestones ⟂ cycles } → work → drift**.

## Surface
- `agents projects add <name> --goal "objective:measure"` (repeatable)
- `agents projects set <name> --goal …` (replaces the goals list, preserving every other field)
- Compact on the `status` card, in full in `projects view`
- Survives a `--from-linear` re-import like other hand-set fields

## Run result (captured)
The actual run + passing tests are in the asset **`zion:/private/tmp/claude-501/-Users-muqsit-src-github-com-muqsitnawaz-agents-cli/a7923c24-af08-4054-a7d0-0c7736224588/scratchpad/projects-goals-run.txt`** (fleet-local path; not a GitHub embed). Transcript of that run:

```
$ agents projects add demo --root /tmp/demo \
    --goal "Ship agents-cli 2.0:fleet on 2.x" --goal "Cut p95 latency:p95 < 200ms"
# written demo.yaml
goals:
  - objective: Ship agents-cli 2.0
    measure: fleet on 2.x
  - objective: Cut p95 latency
    measure: p95 < 200ms

$ agents projects view demo
  goal     Ship agents-cli 2.0  · fleet on 2.x
  goal     Cut p95 latency  · p95 < 200ms

$ agents projects set demo --goal "Grow fleet adoption"
Updated demo
  goals  Grow fleet adoption

# bun vitest run (projects suites)
 Test Files  2 passed (2)
      Tests  53 passed (53)
```

## Tests / docs
- `apps/cli/src/lib/projects.test.ts` — goals validation (measure optional, malformed entries dropped). `tsc --noEmit` clean.
- `apps/cli/docs/11-projects.md` — YAML example, fields table, `add`/`set` flags, re-import note.
- CHANGELOG fragment `.changelog/next/projects-goals.md`.

Scoped deliberately: milestones/cycles already ship (pulled from Linear); this PR is only the stored goals layer. No Linear ticket was opened for this session's work.
