### PR TITLE
fix(factory): local New-agent stays local under balanced launch (0.9.310)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.310] - 2026-08-04
+
+- **Every New-agent launch is balanced — `agents run <agent> --interactive
+  --strategy balanced --mode auto`, with no per-harness exception (#1908).** Local
+  **Grok, Kimi, and Droid** used to launch as raw binaries (`grok` / `kimi` /
+  `droid`) with no account rotation and no `--mode`, because three disagreeing
+  allowlists (`STRATEGY_LAUNCH_AGENTS`, `LAUNCHABLE`, `usesManagedAgentLaunch`)
+  gated whether an agent got `--strategy balanced` and whether it even routed
+  through `agents run`. Those lists are collapsed into one predicate,
+  `isAgentRunner(key)` = `key !== 'shell'`. Local New-agent launches also pass
+  `local: true` into the launch builder so they do not accidentally emit
+  `--device auto` and leave this Mac. Source: `src/core/agents.ts`,
+  `src/vscode/extension.ts`.
+
 - **grok / kimi / droid / antigravity tabs now restore, reopen, and reload like the prewarm agents (#1747).**
   Resume past the picker was still gated on `supportsPrewarming` (claude/codex/gemini/cursor/opencode),
   so a grok/kimi/droid/antigravity tab did not come back after a window reload, a reopen-last, or a
@@ -23,23 +37,6 @@ All notable changes to the Factory extension are documented here. Format follows
   Removes the two commands, their command-palette menu entries, and the now-unused
   `agents.tmuxEnabled` context key. Source: `src/vscode/extension.ts`,
   `package.json`.
-- **Every New-agent launch is balanced — `agents run <agent> --interactive
-  --strategy balanced --mode auto`, with no per-harness exception.** Local
-  **Grok, Kimi, and Droid** used to launch as raw binaries (`grok` / `kimi` /
-  `droid`) with no account rotation and no `--mode`, because three disagreeing
-  allowlists (`STRATEGY_LAUNCH_AGENTS`, `LAUNCHABLE`, `usesManagedAgentLaunch`)
-  gated whether an agent got `--strategy balanced` and whether it even routed
-  through `agents run`. Those lists are collapsed into one predicate,
-  `isAgentRunner(key)` = `key !== 'shell'`, so every runner — local, `(Auto)`,
-  and `(Pick Host)` alike — now routes through `agents run` with
-  `--strategy balanced --mode auto`. Forks are balanced by the same rule. The
-  contract is recorded in `apps/factory/AGENTS.md` (§ "Launch contract") and
-  pinned by tests in `src/core/agents.test.ts`. `--strategy balanced` is a
-  graceful CLI no-op for a runner with no accounts to rotate (droid), never an
-  error. Shell stays a plain terminal; Resume is unchanged (it reuses the
-  session's already-bound account). Source: `src/core/agents.ts`,
-  `src/vscode/extension.ts`, `src/core/forkSession.ts`.
-
 - **BREAKING (settings): the extension's watchdog loop is deleted — the CLI daemon watchdog is the only watchdog.**
   `agents watchdog enable` (the `agents __daemon-run` routine) now owns
   rotate-on-exhaustion in addition to stall nudging: it injects the harness

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -2322,6 +2322,10 @@ async function openSingleAgent(
       sessionId = generateClaudeSessionId();
       console.log(`[SESSION] Claude using on-demand session ID: ${sessionId}${targetHost ? ` (host ${targetHost})` : ''}`);
     }
+    // No remote host → this machine. Pass `local: true` so buildAgentLaunchCommand
+    // does NOT emit `--device auto` (that flag is only for the explicit Auto path
+    // which resolves a host first, or for openSingleAgentWithQueue callers that
+    // set local: false). New Grok/Kimi/… must stay local with balanced strategy.
     command = buildAgentLaunchCommand(
       agentKey,
       sessionId,
@@ -2330,7 +2334,11 @@ async function openSingleAgent(
       pinnedVersion,
       strategy,
       undefined,
-      { host: targetHost, cwd: targetHost ? cwd : undefined },
+      {
+        host: targetHost,
+        local: !targetHost,
+        cwd: targetHost ? cwd : undefined,
+      },
     );
   }
 


### PR DESCRIPTION
**fix / behavior** — complete the #1908 launch contract so local New Grok/Kimi stay on this Mac with balanced rotation. Audience: Factory maintainers + users on 0.9.309 who still see `exec grok`.

## Context

#1908 collapsed three allowlists into `isAgentRunner` so every runner routes through `agents run … --strategy balanced --mode auto`. That fix is on main but **not in the installed extension** (`swarmify.swarm-ext@0.9.309` still has the old `LAUNCHABLE` set and emits bare `exec grok`).

A residual gap remained on main: `openSingleAgent` called `buildAgentLaunchCommand` without `local: true`, so a local New-agent launch still emitted `--device auto` instead of staying on this machine.

## What changed

- `openSingleAgent` passes `local: !targetHost` into `buildAgentLaunchCommand`.
- CHANGELOG cut for **0.9.310** so we can ship the balanced-launch fix to the marketplace.

## Expected commands after install

| Action | Command |
|---|---|
| New Grok (local) | `agents run grok --interactive --strategy balanced --mode auto` |
| New Grok (Pick Host) | `agents run grok --interactive --host '…' --strategy balanced --mode auto` |
| Before (0.9.309) | `exec grok` |

## Tests

`bun test src/core/agents.test.ts src/core/forkSession.test.ts` → **71 pass, 0 fail**.

## Release

After merge: `apps/factory/scripts/release.sh 0.9.310 --confirm` then install/reload Factory.

No UI surface beyond the terminal command line (refactor of launch args). Declared: command-line / test-only verification.