### PR TITLE
fix(cli): balanced rotation requires per-version credentials

### DIFF
--- a/apps/cli/.changelog/next/rotate-perversion-credential.md
+++ b/apps/cli/.changelog/next/rotate-perversion-credential.md
@@ -1,0 +1,9 @@
+- **Balanced rotation no longer picks version homes that only inherit the active login.**
+  `getAccountInfo` falls back to the active/global HOME credential so `agents view`
+  still shows who is signed in when a version home has no auth file of its own.
+  Launch paths isolate config (`GROK_HOME`, `CODEX_HOME`, …) to the per-version home,
+  so those empty homes died at spawn with "Not signed in" after balanced picked them
+  (observed: `grok@0.2.118` with no `auth.json` looking signed-in via `~/.grok` →
+  `0.2.32`). Rotation now requires a real per-version credential when we know where
+  it lives (`credentialPresence.perVersion`). Source: `src/lib/rotate.ts`
+  (`isLaunchableSignedIn`, `collectRunCandidates`).

--- a/apps/cli/src/lib/rotate.test.ts
+++ b/apps/cli/src/lib/rotate.test.ts
@@ -17,6 +17,7 @@ import {
   readinessFromCandidate,
   matchAccountVersion,
   isUsageVerified,
+  isLaunchableSignedIn,
   capacityWeight,
   PROJECTION_HORIZON_MIN,
   resolveRunVersion,
@@ -55,6 +56,39 @@ function candidate(over: Partial<RotateCandidate> & { version: string }): Rotate
 function rotation(healthy: RotateCandidate[], pickedIdx = 0): RotateResult {
   return { picked: healthy[pickedIdx], healthy, excluded: [] };
 }
+
+describe('isLaunchableSignedIn (per-version credential floor for rotation)', () => {
+  // getAccountInfo falls back to the active HOME credential so `agents view`
+  // still labels empty version homes. Rotation must NOT treat that as launchable —
+  // GROK_HOME (and peers) isolate to the version home, so spawn dies "Not signed in".
+  it('rejects a signedIn signal when the known credential is only on the active home', () => {
+    expect(
+      isLaunchableSignedIn(true, { knownLocation: true, perVersion: false }),
+    ).toBe(false);
+  });
+
+  it('accepts a signedIn signal when the credential lives in this version home', () => {
+    expect(
+      isLaunchableSignedIn(true, { knownLocation: true, perVersion: true }),
+    ).toBe(true);
+  });
+
+  it('rejects when not signed in, regardless of credential presence', () => {
+    expect(
+      isLaunchableSignedIn(false, { knownLocation: true, perVersion: true }),
+    ).toBe(false);
+    expect(
+      isLaunchableSignedIn(false, { knownLocation: true, perVersion: false }),
+    ).toBe(false);
+  });
+
+  it('trusts signedIn when we do not know where the credential lives', () => {
+    // keychain-only / unmapped agents — no file path to require
+    expect(
+      isLaunchableSignedIn(true, { knownLocation: false, perVersion: false }),
+    ).toBe(true);
+  });
+});
 
 describe('matchAccountVersion (RUSH-1957 — pin a routine to an account by identity)', () => {
   const gmail = candidate({ version: '2.1.186', email: 'muqsitnawaz@gmail.com' });

--- a/apps/cli/src/lib/rotate.ts
+++ b/apps/cli/src/lib/rotate.ts
@@ -9,7 +9,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId, RunStrategy } from './types.js';
 import type { FallbackEntry } from './exec.js';
-import { accountDisplayLabel, getAccountInfo, ALL_AGENT_IDS, type AccountInfo } from './agents.js';
+import {
+  accountDisplayLabel,
+  getAccountInfo,
+  credentialPresence,
+  ALL_AGENT_IDS,
+  type AccountInfo,
+  type CredentialPresence,
+} from './agents.js';
 import { readMeta, writeMeta, getHelpersDir } from './state.js';
 import { listInstalledVersions, getVersionHomePath, resolveVersion } from './versions.js';
 import { getProjectRunConfigs } from './run-config.js';
@@ -124,6 +131,29 @@ export function setGlobalRunStrategy(agent: AgentId, strategy: RunStrategy): voi
 
 function isRotationEligible(candidate: RotateCandidate): boolean {
   return candidate.signedIn && hasUsageAvailable(candidate);
+}
+
+/**
+ * Whether a version home can actually authenticate a launch.
+ *
+ * `getAccountInfo` falls back to the active/global HOME when a version home has
+ * no credential of its own, so `agents view` still shows who is logged in. Launch
+ * paths isolate config (GROK_HOME, CODEX_HOME, KIMI_CODE_HOME, CLAUDE_CONFIG_DIR,
+ * …) to the per-version home, so a home that only "inherits" the active login
+ * cannot spawn a signed-in agent — balanced kept picking those empty homes and
+ * the run died on "Not signed in".
+ *
+ * When we know where the credential lives (`knownLocation`), require it under
+ * THIS version home. When we don't (keychain-only / unmapped agents), trust the
+ * existing `signedIn` signal.
+ */
+export function isLaunchableSignedIn(
+  signedIn: boolean,
+  presence: Pick<CredentialPresence, 'knownLocation' | 'perVersion'>,
+): boolean {
+  if (!signedIn) return false;
+  if (!presence.knownLocation) return true;
+  return presence.perVersion;
 }
 
 function isAvailableEligible(candidate: RotateCandidate): boolean {
@@ -630,17 +660,22 @@ export async function collectRunCandidates(agent: AgentId): Promise<RotateCandid
       // one per installed version, every time `agents run` cold-starts. If
       // claude's stored token has actually expired, the spawned agent detects
       // it at its own startup and re-auths; that's the correct UX.
+      //
+      // Gate signedIn on a real per-version credential when we know where it
+      // lives — see isLaunchableSignedIn. Do not reuse the active-home fallback
+      // identity for routing, or empty version homes look healthy and die at spawn.
+      const launchable = isLaunchableSignedIn(info.signedIn, credentialPresence(agent, home));
       return {
         agent,
         version,
         home,
         info,
-        accountKey: info.accountKey,
-        accountLabel: accountDisplayLabel(info),
-        email: info.email,
-        usageStatus: info.usageStatus,
-        plan: info.plan,
-        signedIn: info.signedIn,
+        accountKey: launchable ? info.accountKey : null,
+        accountLabel: launchable ? accountDisplayLabel(info) : '',
+        email: launchable ? info.email : null,
+        usageStatus: launchable ? info.usageStatus : null,
+        plan: launchable ? info.plan : null,
+        signedIn: launchable,
         lastActive: info.lastActive,
       };
     })


### PR DESCRIPTION
## Summary

Balanced / available rotation was treating version homes that only **inherit** the active HOME login as healthy, then launching into them. Launch paths isolate config (`GROK_HOME`, `CODEX_HOME`, …) to the per-version home, so those runs died with "Not signed in".

Observed on this machine: `grok@0.2.118` has no `auth.json`, but `getAccountInfo` fell back to `~/.grok` → `0.2.32` credentials, so `agents view` and balanced both reported it signed in. Every balanced pick of `0.2.118` failed at spawn.

## Fix

- `isLaunchableSignedIn(signedIn, presence)` — when we know where the credential lives, require `credentialPresence.perVersion`
- `collectRunCandidates` uses that gate for rotation `signedIn` (and clears inherited identity when not launchable)
- Unit tests for the pure gate

View still uses the active-home fallback (intentional for display). Only **routing** is tightened.

## Test plan

- [x] `bunx vitest run src/lib/rotate.test.ts` — 57 passed
- [ ] After merge/install: with a version home missing auth, balanced must not pick it (picks a home that has its own `auth.json`)
- [ ] `agents run grok --strategy balanced "…"` succeeds when at least one version home has real auth

refactor / no UI surface — behavior change on account routing only.