### PR TITLE
fix(menubar): self-test accepts MenubarHelper-universal

### DIFF
--- a/apps/cli/.changelog/next/menubar-universal-selftest.md
+++ b/apps/cli/.changelog/next/menubar-universal-selftest.md
@@ -1,0 +1,5 @@
+- **Menubar home-base self-test accepts `MenubarHelper-universal`.** The
+  signed-helper gate required `executablePath` to end in exactly `MenubarHelper`,
+  but lipo production builds name the binary `MenubarHelper-universal`, so every
+  1.22.2 publish on mac-mini failed after the release PR had already merged and
+  tagged. Source: `menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift`.

--- a/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/ChildProcessSelfTest.swift
@@ -118,8 +118,14 @@ enum ChildProcessSelfTest {
         let mismatched = recorded.filter { ChildProcess.executablePath($0.pid) != $0.path }
         check(mismatched.count == 1,
               "a live pid whose executable no longer matches is not reapable")
-        check(ChildProcess.executablePath(me)?.hasSuffix("MenubarHelper") == true,
-              "executablePath resolves a live pid (got \(ChildProcess.executablePath(me) ?? "nil"))")
+        // Production builds may name the binary MenubarHelper-universal (lipo
+        // of arm64+x86_64). Match the last path component's prefix, not a hard
+        // suffix of "MenubarHelper" alone — that failed every home-base publish
+        // of 1.22.2 with got …/MenubarHelper-universal.
+        let exe = ChildProcess.executablePath(me) ?? ""
+        let base = (exe as NSString).lastPathComponent
+        check(base.hasPrefix("MenubarHelper"),
+              "executablePath resolves a live pid (got \(exe.isEmpty ? "nil" : exe))")
         try? FileManager.default.removeItem(atPath: file)
     }
 


### PR DESCRIPTION
## Summary

Home-base signed helper self-test required `executablePath` to end with exactly `MenubarHelper`. Production lipo builds produce `MenubarHelper-universal`, so **every 1.22.2 publish on mac-mini failed** after PR #1924 merged and `v1.22.2` was tagged (npm never got 1.22.2).

## Fix

Match last path component with `hasPrefix("MenubarHelper")`.

## Test plan

- [x] Code review of the assertion
- [ ] `./scripts/release.sh 1.22.3 --apply` after merge (privileged phase must pass menubar self-tests)

no UI surface — gate test only.