### PR TITLE
fix(ci): pause prix/code-reviewer trigger — it is spilling live tokens (#1767)

### DIFF
--- a/.github/rush.yml
+++ b/.github/rush.yml
@@ -1,7 +1,21 @@
 version: 1
-agents:
-  - id: prix/code-reviewer
-    on:
-      pull_request:
-        types: [opened, reopened, synchronize]
-        branches: [main]
+
+# prix/code-reviewer is PAUSED — see #1767.
+#
+# Every webhook-dispatched run was failing on startup: the Rush Cloud agent-host
+# token-rotation path captured the interactive `claude setup-token` TTY stream
+# (ANSI codes + banner) as the `Authorization` header instead of parsing the
+# `sk-ant-oat01-...` value, so Anthropic rejected the header and the run died —
+# and that same setup flow prints a fresh 1-year OAuth token in cleartext, so
+# every failed run (~1/min since 2026-08-02T04:27Z) minted and logged a live
+# credential. Pausing the trigger here stops this repo's spill until the upstream
+# capture bug is fixed and the leaked tokens are revoked.
+#
+# Meanwhile the non-author review falls back to a subagent reviewer (see AGENTS.md
+# "Conventions"). Re-enable by restoring the block below once the upstream fix lands.
+agents: []
+#  - id: prix/code-reviewer
+#    on:
+#      pull_request:
+#        types: [opened, reopened, synchronize]
+#        branches: [main]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,13 @@ goes in `artifacts/`. Never scatter scratch in `/tmp` or the repo root.
   reviewer reads this file before every review and enforces the conventions in
   [§Code review conventions](#code-review-conventions-the-reviewer-must-enforce-these) —
   that block is what it checks the diff against, not just prose for humans.
+  - **Currently PAUSED (#1767).** Since 2026-08-02 every run crashed on startup and each
+    failure minted + logged a live 1-year Anthropic token, so the trigger in
+    [`.github/rush.yml`](.github/rush.yml) is disabled until the upstream Rush Cloud
+    agent-host capture bug is fixed. **Until it is restored, the non-author review is a
+    subagent reviewer** (spawn one, have it verify the diff and post its verdict as a PR
+    comment, then merge on green) — the documented fallback, not a redundant extra pass.
+    Do not re-enable the trigger until #1767 is resolved.
 - **The default branch is untouchable.** Every change is a git worktree + PR — never
   edit or commit on `main`. Worktrees live under `.agents/worktrees/<slug>/`.
 - **VS Code publish identity is frozen.** `apps/factory` publishes as publisher


### PR DESCRIPTION
**Security mitigation (config + docs, no code run)** — interim fix for #1767.

## What & why
`prix/code-reviewer` has crashed on **every** webhook-dispatched run since 2026-08-02, and each failure is a **credential spill**: the Rush Cloud agent-host token-rotation path captures the interactive `claude setup-token` TTY stream (ANSI + banner) as the `Authorization` header instead of parsing the `sk-ant-oat01-…` value — so the run dies, **and** that same setup flow prints a fresh **1-year Anthropic OAuth token in cleartext into the run log**, roughly **once a minute**.

This PR **pauses the trigger** in `.github/rush.yml` (self-documenting comment, fully reversible) so this repo stops minting + logging a live token every minute, and notes the outage + the **subagent-review fallback** in `AGENTS.md` so agents stop re-diagnosing it.

## Scope — what this does NOT do
This is the interim "stop the bleeding" for **this repo only**. The two real fixes are outside this repo and remain open on #1767:
1. **Revoke the leaked tokens** — Anthropic console, per rotation account. Every `sk-ant-oat01-` in Rush Cloud run logs since 2026-08-02T04:27Z is compromised. **Urgent, human-only.**
2. **Fix the upstream capture** — the Rush Cloud agent-host wrapper must parse the token out of the setup output (not pipe the raw TTY into the header) and redact it from the log. Also stop minting a new long-lived token per run.

`muqsitnawaz/agents` and any other repo using `prix/code-reviewer` are still spilling — the global stop is fixing the wrapper or suspending the agent's GitHub App, not per-repo YAML.

Non-author review: subagent (prix is down, that's the point).
