### PR TITLE
fix(trends): tools-per-session counts every scanned session, not just teams runs

### DIFF
--- a/apps/cli/.changelog/next/trends-tools-per-session.md
+++ b/apps/cli/.changelog/next/trends-tools-per-session.md
@@ -1,0 +1,13 @@
+- **`agents trends tools-per-session` now counts every scanned session, not just `agents teams`
+  runs.** The recipe read `sessions.tool_call_count`, a column nothing populates except the
+  teams summarizer (`apps/cli/src/lib/teams/summarizer.ts`) — the general session indexer never
+  computes it. So every session that did not come from a team was scored 0 or excluded outright
+  by `WHERE tool_call_count IS NOT NULL`, pinning the fleet-wide p50 at 0 however many tools ran
+  and leaving only `claude` in the table. It now reads `tool_scan_ledger.call_count`, the
+  per-session count the tool indexer writes for every session it scans — the same index behind
+  `agents sessions --include tools`, so the two surfaces stop disagreeing. Sessions with
+  genuinely zero tool calls still count as 0 instead of vanishing. On a real 7-day window this
+  took the sample from 400 to 570 sessions and surfaced `grok`, `rush`, `codex`, `kimi`,
+  `droid` and `antigravity`, none of which had ever appeared. Run `agents sessions backfill
+  tools` once if historical sessions were never indexed. Source:
+  `apps/cli/src/lib/analytics/recipes.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## 1.22.5
-
-- **`agents trends tools-per-session` now reports real tool-call counts instead of a
-  p50 of 0.** The recipe read `sessions.tool_call_count`, a column only the teams
-  summarizer ever writes (`apps/cli/src/lib/teams/summarizer.ts`), so every session
-  that did not come from `agents teams` was either scored 0 or excluded — pinning the
-  fleet-wide p50 at 0 no matter how many tools ran. It now reads
-  `tool_scan_ledger.call_count`, the per-session count the tool indexer writes for
-  every session it scans (the same index behind
-  `agents sessions --include tools`), so sessions with genuinely zero tool calls still
-  count as 0 and everything else carries its true count. Run
-  `agents sessions backfill tools` once if historical sessions were never indexed.
-  Source: `apps/cli/src/lib/analytics/recipes.ts`.
-
 ## 1.22.4
 
 - **Background processes no longer storm macOS Touch ID sheets (secrets-touchid-storm).**

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.22.5
+
+- **`agents trends tools-per-session` now reports real tool-call counts instead of a
+  p50 of 0.** The recipe read `sessions.tool_call_count`, a column only the teams
+  summarizer ever writes (`apps/cli/src/lib/teams/summarizer.ts`), so every session
+  that did not come from `agents teams` was either scored 0 or excluded — pinning the
+  fleet-wide p50 at 0 no matter how many tools ran. It now reads
+  `tool_scan_ledger.call_count`, the per-session count the tool indexer writes for
+  every session it scans (the same index behind
+  `agents sessions --include tools`), so sessions with genuinely zero tool calls still
+  count as 0 and everything else carries its true count. Run
+  `agents sessions backfill tools` once if historical sessions were never indexed.
+  Source: `apps/cli/src/lib/analytics/recipes.ts`.
+
 ## 1.22.4
 
 - **Background processes no longer storm macOS Touch ID sheets (secrets-touchid-storm).**

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -138,7 +138,7 @@ agents trends recipes             # list recipe ids
 
 | Store | Path | Holds |
 |---|---|---|
-| Session index | `sessions.db` | Harness/model mix, token ratios, `tool_call_count` (Claude scan rollup) |
+| Session index | `sessions.db` | Harness/model mix, token ratios, per-session tool-call counts (`tool_scan_ledger.call_count`, written by the tool indexer) |
 | Usage warehouse | `~/.agents/.history/analytics/usage.db` | Value-free `kind`/`name`/`event` rows (secret, agent, browser, …) |
 
 Secrets usage previously lived only in `~/.agents/secrets/secrets.db`; the warehouse

--- a/apps/cli/src/lib/analytics/dashboard.test.ts
+++ b/apps/cli/src/lib/analytics/dashboard.test.ts
@@ -34,6 +34,16 @@ function pin(): { usage: string; sessions: string } {
       tool_call_count INTEGER,
       file_path TEXT NOT NULL
     );
+    CREATE TABLE tool_scan_ledger (
+      session_id TEXT PRIMARY KEY,
+      file_path TEXT NOT NULL UNIQUE,
+      file_mtime_ms INTEGER NOT NULL,
+      file_size INTEGER NOT NULL,
+      extractor_version INTEGER NOT NULL,
+      indexed_at INTEGER NOT NULL,
+      call_count INTEGER NOT NULL,
+      evidence_bytes INTEGER NOT NULL
+    );
   `);
   const now = new Date().toISOString();
   const insert = db.prepare(
@@ -43,6 +53,16 @@ function pin(): { usage: string; sessions: string } {
   insert.run('s1', 's1', 'claude', now, 'claude-opus-4', 1000, 200, 60000, 'box-a', 12, '/tmp/a.jsonl');
   insert.run('s2', 's2', 'claude', now, 'claude-sonnet-4', 800, 100, 30000, 'box-a', 4, '/tmp/b.jsonl');
   insert.run('s3', 's3', 'codex', now, 'gpt-5', 500, 50, 120000, 'box-b', null, '/tmp/c.jsonl');
+  // The tool indexer's ledger — the real per-session call counts. s3 carries a
+  // NULL sessions.tool_call_count (nothing but the teams summarizer writes that
+  // column), so it is the regression case: the old recipe dropped it entirely.
+  const ledger = db.prepare(
+    `INSERT INTO tool_scan_ledger (session_id, file_path, file_mtime_ms, file_size, extractor_version, indexed_at, call_count, evidence_bytes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  ledger.run('s1', '/tmp/a.jsonl', 1, 10, 1, 1, 12, 100);
+  ledger.run('s2', '/tmp/b.jsonl', 1, 10, 1, 1, 4, 100);
+  ledger.run('s3', '/tmp/c.jsonl', 1, 10, 1, 1, 30, 100);
   db.close();
   return { usage, sessions };
 }
@@ -81,8 +101,27 @@ describe('trends recipes + dashboard', () => {
     const tools = recipeToolsPerSession(win);
     expect(tools.empty).toBe(false);
     const all = tools.rows.find((r) => r.scope === '(all)');
-    expect(all?.n).toBe(2);
-    expect(all?.avg).toBe(8);
+    // Every scanned session counts — 12, 4, 30 — not just the ones the teams
+    // summarizer happened to stamp a tool_call_count on.
+    expect(all?.n).toBe(3);
+    expect(all?.avg).toBe(15);
+    expect(all?.p50).toBe(12);
+  });
+
+  it('counts sessions the teams summarizer never stamped (sessions.tool_call_count IS NULL)', () => {
+    const tools = recipeToolsPerSession(trendsWindow(7));
+    // s3 is codex with a NULL tool_call_count but 30 indexed calls. Reading the
+    // column dropped it and pinned the fleet-wide p50 at 0; the ledger has it.
+    const codex = tools.rows.find((r) => r.scope === 'codex');
+    expect(codex?.n).toBe(1);
+    expect(codex?.avg).toBe(30);
+  });
+
+  it('is empty when the tool index has never been built', () => {
+    const db = new Database(process.env.AGENTS_SESSIONS_DB as string);
+    db.exec('DROP TABLE tool_scan_ledger');
+    db.close();
+    expect(recipeToolsPerSession(trendsWindow(7)).empty).toBe(true);
   });
 
   it('dashboard skips empty recipes and stays under the compute budget', () => {

--- a/apps/cli/src/lib/analytics/recipes.ts
+++ b/apps/cli/src/lib/analytics/recipes.ts
@@ -104,14 +104,22 @@ export function recipeToolsPerSession(win: TrendsWindow): RecipeSection {
   const title = 'Tools per session';
   if (!db) return { id, title, store: 'sessions', rows: [], empty: true };
   try {
-    const cols = db.prepare(`PRAGMA table_info(sessions)`).all() as Array<{ name: string }>;
-    if (!cols.some((c) => c.name === 'tool_call_count')) {
+    // Counts come from tool_scan_ledger — one row per session the tool indexer
+    // has scanned, carrying that session's true call_count (0 included). The
+    // sessions.tool_call_count column is NOT the source: only the teams
+    // summarizer ever writes it (lib/teams/summarizer.ts), so reading it scored
+    // every non-teams session as 0 and pinned p50 at 0 fleet-wide.
+    const tables = db.prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'tool_scan_ledger'`,
+    ).all() as Array<{ name: string }>;
+    if (tables.length === 0) {
       return { id, title, store: 'sessions', rows: [], empty: true };
     }
     const byAgent = db.prepare(
-      `SELECT agent, tool_call_count AS n
-         FROM sessions
-        WHERE timestamp >= ? AND tool_call_count IS NOT NULL`,
+      `SELECT s.agent AS agent, l.call_count AS n
+         FROM tool_scan_ledger l
+         JOIN sessions s ON s.id = l.session_id
+        WHERE s.timestamp >= ?`,
     ).all(win.sinceIso) as Array<{ agent: string; n: number }>;
     if (byAgent.length === 0) return { id, title, store: 'sessions', rows: [], empty: true };
 


### PR DESCRIPTION
**Bugfix — `agents trends tools-per-session` reported a p50 of 0 for the whole fleet and only ever listed `claude`.**

## The bug

`recipeToolsPerSession` read `sessions.tool_call_count`. Nothing populates that column except the teams summarizer (`apps/cli/src/lib/teams/summarizer.ts:418-460`) — the general session indexer never computes it. So every session that did not come from `agents teams` was scored 0, or excluded outright by `WHERE tool_call_count IS NOT NULL`.

Net effect: the one recipe whose job is "how many tools does a session use" was structurally incapable of answering, and five harnesses never appeared in the table at all.

## The fix

Read `tool_scan_ledger.call_count` — one row per session the tool indexer has scanned, carrying that session's true count. It is the same index that backs `agents sessions --include tools`, so the two surfaces stop disagreeing. Sessions with genuinely zero tool calls still count as 0 rather than vanishing.

## Run result

Against the real `sessions.db` on zion, 7-day window — full output: https://share.agents-cli.sh/muqsitnawaz/fix-trends-tools-per-session-trends-fix-run-667d3d2abbc529a1

| | before (1.22.4) | after |
|---|---|---|
| sessions counted | 400 | **570** |
| harnesses listed | claude | claude, grok, rush, codex, kimi, droid, antigravity |
| kimi p50 | absent | 43 |

```
=== BEFORE — installed 1.22.4 ===        === AFTER — this branch ===
SCOPE   N     AVG   P50   P99            SCOPE        N     AVG   P50   P99
(all)   400   22    0     387            (all)        570   40    0     449
claude  400   22    0     387            claude       494   42    0     479
                                         grok         20    1     0     17
                                         rush         19    0     0     0
                                         codex        16    2     0     9
                                         kimi         15    108   43    339
                                         droid        5     23    0     109
                                         antigravity  1     78    78    78
```

## Tests

`src/lib/analytics/dashboard.test.ts` — the fixture's codex row carries a NULL `tool_call_count` and 30 indexed calls, so the old query drops it and the new one counts it. Both new assertions **fail against the pre-fix SELECT** (verified: `expected 2 to be 3`, codex row `undefined`), pass after. 6/6 green, `tsc --noEmit` clean.

## Known adjacent issue — NOT fixed here

`(all)` p50 is still 0, and that is a **different defect**: the tool extractor writes `call_count = 0` for **232 of the 750 transcripts over 100 KB** in the ledger (all at `extractor_version` 7). A 610 KB claude transcript indexing as zero tool calls is not plausible, so the extractor is under-counting on large sessions. Out of scope for this diff — this PR only fixes the recipe reading the wrong column. Filing separately.

---

**Changelog:** queued as `.changelog/next/trends-tools-per-session.md`. My first push hand-edited the generated `CHANGELOG.md` and CI test-shard 3 caught it (`scripts/gen-changelog.test.ts` regenerates and compares) — corrected in 2e526d0ac.
