### PR TITLE
fix(factory): coalesce per-host fleet probes to stop duplicate agents subprocess pile-up

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Fleet health probes no longer stack duplicate `agents` subprocesses (fixes
+  CPU thrash on a loaded box).** `countRunningAgents` — the per-host running-agent
+  count behind the Dispatch panel's device health and the launch-health refresh —
+  spawned a fresh `agents sessions --active --json --host <box>` subprocess per
+  fleet device on every call, with no cache and no in-flight dedup (unlike its
+  sibling `fetchDeviceStats`). Several uncoordinated callers each fanned out over
+  the whole fleet, and on a loaded box where an `agents` cold-start alone exceeds
+  8s the batches piled up into dozens of concurrent duplicate processes. Both
+  probes now share one `cachedInFlight` guard: concurrent calls for a host
+  coalesce into a single in-flight run, and repeats within 6s serve the cache.
+  Source: `src/core/cachedInFlight.ts`, `src/vscode/deviceHealth.vscode.ts`.
+
 ## [0.9.310] - 2026-08-04
 
 - **Every New-agent launch is balanced — `agents run <agent> --interactive

--- a/apps/factory/src/core/cachedInFlight.test.ts
+++ b/apps/factory/src/core/cachedInFlight.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'bun:test';
+import { createTimedCache, cachedInFlight } from './cachedInFlight';
+
+describe('cachedInFlight', () => {
+  test('coalesces concurrent calls for the same key into ONE invocation', async () => {
+    const store = createTimedCache<number>();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 5));
+      return 42;
+    };
+    // Five callers fire at the same instant (the full-fleet fan-out from
+    // several uncoordinated timers) — they must share one in-flight run.
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => cachedInFlight(store, 'host-a', 6000, fn, 1000)),
+    );
+    expect(calls).toBe(1);
+    expect(results).toEqual([42, 42, 42, 42, 42]);
+  });
+
+  test('serves the cache within the TTL instead of re-invoking', async () => {
+    const store = createTimedCache<number>();
+    let calls = 0;
+    const fn = async () => (++calls, calls);
+    expect(await cachedInFlight(store, 'h', 6000, fn, 1000)).toBe(1);
+    // A later caller still inside the TTL window gets the cached value.
+    expect(await cachedInFlight(store, 'h', 6000, fn, 1000 + 5999)).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  test('re-invokes once the TTL has elapsed', async () => {
+    const store = createTimedCache<number>();
+    let calls = 0;
+    const fn = async () => (++calls, calls);
+    expect(await cachedInFlight(store, 'h', 6000, fn, 1000)).toBe(1);
+    expect(await cachedInFlight(store, 'h', 6000, fn, 1000 + 6001)).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  test('keys are independent — one host in flight does not block another', async () => {
+    const store = createTimedCache<string>();
+    const seen: string[] = [];
+    const make = (id: string) => async () => {
+      seen.push(id);
+      return id;
+    };
+    const [a, b] = await Promise.all([
+      cachedInFlight(store, 'a', 6000, make('a'), 1000),
+      cachedInFlight(store, 'b', 6000, make('b'), 1000),
+    ]);
+    expect(a).toBe('a');
+    expect(b).toBe('b');
+    expect(seen.sort()).toEqual(['a', 'b']);
+  });
+});

--- a/apps/factory/src/core/cachedInFlight.ts
+++ b/apps/factory/src/core/cachedInFlight.ts
@@ -1,0 +1,45 @@
+// Coalesce concurrent + repeated async fetches keyed by a string. Two callers
+// asking for the same key at the same time share ONE in-flight promise; a call
+// within `ttlMs` of the last resolved value gets the cache instead of re-running.
+//
+// This is the guard that stops several uncoordinated drivers (the launch-health
+// timer, the Dispatch panel's deviceHealth probe, each agent launch) from EACH
+// spawning a full-fleet fan-out of `agents` subprocesses for the same host —
+// the pile-up that thrashed dozens of duplicate `agents sessions --active
+// --host <box>` processes on a loaded box. `fetchDeviceStats` had this guard
+// inline; `countRunningAgents` did not, so it was the one probe that stacked.
+
+export interface TimedCache<T> {
+  cache: Map<string, { value: T; at: number }>;
+  inFlight: Map<string, Promise<T>>;
+}
+
+export function createTimedCache<T>(): TimedCache<T> {
+  return { cache: new Map(), inFlight: new Map() };
+}
+
+export async function cachedInFlight<T>(
+  store: TimedCache<T>,
+  key: string,
+  ttlMs: number,
+  fn: () => Promise<T>,
+  now: number = Date.now(),
+): Promise<T> {
+  const cached = store.cache.get(key);
+  if (cached && now - cached.at < ttlMs) return cached.value;
+  const existing = store.inFlight.get(key);
+  if (existing) return existing;
+  const promise = (async () => {
+    const value = await fn();
+    // Cache at the call-entry time so the TTL window measures from when the
+    // caller asked, matching the prior inline behavior in fetchDeviceStats.
+    store.cache.set(key, { value, at: now });
+    return value;
+  })();
+  store.inFlight.set(key, promise);
+  try {
+    return await promise;
+  } finally {
+    store.inFlight.delete(key);
+  }
+}

--- a/apps/factory/src/vscode/deviceHealth.vscode.ts
+++ b/apps/factory/src/vscode/deviceHealth.vscode.ts
@@ -7,6 +7,7 @@ import { promisify } from 'util';
 import { DeviceStats, parseUptime, parseVmStat, parseLinuxMemInfo, isDeviceOnline } from '../core/deviceHealth';
 import { RepoSyncStatus, classifySync } from '../core/repoSync';
 import { resolveAgentsBin, bootstrapPath } from '../core/agentsBin';
+import { createTimedCache, cachedInFlight } from '../core/cachedInFlight';
 
 const execFileAsync = promisify(execFile);
 
@@ -75,8 +76,12 @@ export async function listRegisteredDevices(): Promise<Device[]> {
 const CACHE_TTL_MS = 6_000;
 const PROBE_TIMEOUT_MS = 4_000;
 
-const cache = new Map<string, { stats: DeviceStats; fetchedAt: number }>();
-const inFlight = new Map<string, Promise<DeviceStats>>();
+// Both fleet probes coalesce concurrent + repeated calls per host through the
+// shared cachedInFlight guard, so N uncoordinated callers (the launch-health
+// timer, the Dispatch panel, each launch) never each spawn a full-fleet fan-out
+// of `agents` subprocesses for the same host.
+const statsStore = createTimedCache<DeviceStats>();
+const agentCountStore = createTimedCache<number>();
 
 type SecretsFormat = 'json' | 'shell' | 'unknown';
 
@@ -114,20 +119,7 @@ export async function fetchDeviceStats(
   host: string,
   opts: { isLocal: boolean; identityFile?: string; user?: string },
 ): Promise<DeviceStats> {
-  const now = Date.now();
-  const cached = cache.get(host);
-  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) return cached.stats;
-  const existing = inFlight.get(host);
-  if (existing) return existing;
-  const promise = fetchDeviceStatsOnce(host, opts);
-  inFlight.set(host, promise);
-  try {
-    const stats = await promise;
-    cache.set(host, { stats, fetchedAt: stats.fetchedAt });
-    return stats;
-  } finally {
-    inFlight.delete(host);
-  }
+  return cachedInFlight(statsStore, host, CACHE_TTL_MS, () => fetchDeviceStatsOnce(host, opts));
 }
 
 async function fetchDeviceStatsOnce(
@@ -164,6 +156,10 @@ async function fetchDeviceStatsOnce(
 }
 
 export async function countRunningAgents(host: string, opts: { isLocal: boolean }): Promise<number> {
+  return cachedInFlight(agentCountStore, host, CACHE_TTL_MS, () => countRunningAgentsOnce(host, opts));
+}
+
+async function countRunningAgentsOnce(host: string, opts: { isLocal: boolean }): Promise<number> {
   try {
     const bin = await resolveAgentsBin();
     const args = ['sessions', '--active', '--json'];


### PR DESCRIPTION
**bug fix (backend / perf) — no UI surface.** Stops the Factory extension from thrashing CPU by spawning dozens of duplicate `agents` subprocesses.

## What was wrong

`countRunningAgents` (`apps/factory/src/vscode/deviceHealth.vscode.ts`) — the per-host running-agent count behind the Dispatch panel's device health and the launch-health refresh — spawned a **fresh `agents sessions --active --json --host <box>` subprocess per fleet device on every call**, with **no cache and no in-flight dedup**. Its sibling `fetchDeviceStats` already had both.

It's driven from several uncoordinated callers with no shared throttle:
- the 60s `launchHealthTimer` → `refreshLaunchHealth` (`extension.ts:402`), a whole-fleet fan-out
- the Dispatch panel's `deviceHealth` handler (`settings.vscode.ts:1945`)
- each agent launch's `resolveBalancedHost` (`extension.ts:485`)

Each per-host call is a heavyweight `agents` CLI subprocess, and on a loaded box the CLI cold-start alone exceeds 8s (its own comment at `deviceHealth.vscode.ts:50-54`). Because nothing coalesced, a new full-fleet batch spawned before the previous drained → the batches overlapped and stacked into **dozens of concurrent `agents ... --host <box>` processes**, which raised load, which slowed every subsequent cold-start — a self-reinforcing loop. Observed live on `zion` as ~16–18 concurrent duplicates plus multi-hour orphans.

## The fix

Extract the cache + in-flight coalescing (that `fetchDeviceStats` had inline) into a shared `cachedInFlight` helper and route **both** probes through it:

- concurrent calls for a host share **one** in-flight run
- a repeat within 6s serves the cache instead of re-spawning

One implementation, no duplication. `fetchDeviceStats` behavior is unchanged (same 6s TTL, cache timestamp still measured from call-entry).

## Files
- `apps/factory/src/core/cachedInFlight.ts` — new shared coalescing guard
- `apps/factory/src/core/cachedInFlight.test.ts` — tests (real counting fn, no mocking)
- `apps/factory/src/vscode/deviceHealth.vscode.ts` — route both probes through it
- `apps/factory/CHANGELOG.md`

## Run result (no visible surface — perf fix)

Typecheck — `bun run compile:ext` (`tsc -p ./`): **exit 0, clean.**

New test — `bun test src/core/cachedInFlight.test.ts`:
```
 4 pass
 0 fail
 11 expect() calls
Ran 4 tests across 1 file. [12.00ms]
```
Covers: concurrent calls coalesce to ONE invocation; cache hit within TTL; re-invoke after TTL; independent keys don't block each other.

Regression — existing `bun test src/core/deviceHealth.test.ts`: **10 pass / 0 fail.**
