### PR TITLE
docs: spec the single-scheduler invariant — no double-scheduling between UI and daemon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,23 @@ and [`architecture.md`](apps/cli/docs/architecture.md).
   is a **consumer**: the VS Code UI layer that shells out to
   `agents sessions --active --json`, holding no data models of its own — not a separate
   codebase. Fix a mechanism in the CLI and every consumer benefits.
+- **One scheduler, one executor — fleet-affecting features never run twice.** Anything
+  that can *act* on this machine or another fleet device — launch/resume/kill a session,
+  fire a routine or monitor, inject into a terminal, rotate an account — has exactly ONE
+  scheduler and ONE executor: the agents-cli daemon (`agents __daemon-run`) or a CLI
+  command it drives. UI surfaces (Factory, the menubar, the iOS app) are **thin
+  wrappers**: they render state and offer controls that call the CLI; they MUST NOT own
+  a timer, watcher, or loop that detects a condition and acts on it. Detection and
+  decision live in the CLI, which holds the first-party state (sessions.db, usage
+  snapshots, the device registry). Where an action needs a UI-owned surface, the UI
+  exposes a narrow endpoint the CLI drives (the `/inject` verb is the precedent) — the
+  trigger stays in the CLI. Routines are covered by the same rule: `agents routines` +
+  the daemon's pid-claimed scheduler (`apps/cli/src/lib/daemon.ts`) are the only cron
+  that fires them; a UI button may *request* a run, never *schedule* one. Violations are
+  the double-fire bug class — the 2026-08-03 incident (Factory's watchdog rotate loop
+  racing the daemon, spawning resume-tabs every 120s into exhausted accounts) is the
+  canonical example; the consolidation (PR #1914) is the canonical fix. The normative
+  contract is [§Scheduling & execution singularity](apps/cli/docs/specifications.md#scheduling--execution-singularity).
 
 ## CLI surface conventions
 
@@ -244,6 +261,14 @@ the exception.
   new or changed command that flattens a verb colliding with an owned noun, leans on flag
   soup where an object-in-path reads clearer, or ships a non-trivial tool on commander's
   default help instead of a workflow-first `setHelpSections` block.
+- **No second scheduler.** A PR that adds a timer, watcher, or polling loop in
+  `apps/factory` (or any UI surface) that *acts* — spawns, resumes, kills, injects,
+  dispatches, rotates, fires a routine — rather than polling read-only state for
+  rendering is a double-fire bug in waiting. Flag it with `file:line`. The action
+  belongs in the CLI daemon or a CLI command; the UI may only render the state and wire
+  controls to CLI calls. (Canonical incident: the Factory watchdog rotate loop,
+  2026-08-03; canonical fix: PR #1914. See
+  [§Scheduling & execution singularity](apps/cli/docs/specifications.md#scheduling--execution-singularity).)
 - **No dead or commented-out code.** Removed logic is deleted, not commented out "for
   later." git history is the archive.
 - **Tests exercise the real path.** New behavior ships with a test that hits the actual

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -51,6 +51,7 @@ guarantee, the reference for the mechanism.
 - [Sessions](#sessions) — `agents sessions`: discovery, parsing, preview, metadata, lifecycle, export/import
 - [Secrets](#secrets) — `agents secrets`: storage & materialization boundaries, sharing, no-noise
 - [Agent execution](#agent-execution) — `agents run`: the one execution engine, env, isolation, fallback, dispatch
+- [Scheduling & execution singularity](#scheduling--execution-singularity) — one scheduler, one executor for anything fleet-affecting; UIs are thin wrappers
 - [Watchdog](#watchdog) — `agents watchdog`: detect idle agents, decide nudge/skip, deliver to the exact split
 
 ---
@@ -1854,6 +1855,106 @@ overwrites `<versionHome>/.claude/CLAUDE.md` before the agent spawns — the
 harness never launches against the stale `default`-preset file. A THIRD run
 with no further preset or subrule change instead skip-fasts (EXEC-45): the
 file's mtime is left untouched.
+
+---
+
+## Scheduling & execution singularity
+
+The normative contract for **who may schedule and execute work** across the repo:
+the CLI daemon and the commands it drives — never a UI surface. Requirement keywords
+**MUST / MUST NOT / SHOULD / MAY** are per RFC 2119; scenarios are Given/When/Then.
+
+### 1. Purpose & scope
+
+A fleet-affecting feature that runs on a timer or watcher in two places fires twice:
+two resume-tabs for one exhausted session, two executions of one cron job, two
+injected nudges racing the same agent. This section makes that class of bug
+unrepresentable. In scope: every capability that can **act** — launch, resume, kill,
+or rotate a session; fire a routine or monitor; inject into a terminal; dispatch to
+a host or the cloud. Out of scope: read-only polling that renders state for a human
+(panels refreshing, presence heartbeats), which MAY live anywhere provided it writes
+nothing but its own view cache.
+
+### 2. Terminology
+
+- **Fleet-affecting action** — any operation that mutates state on this machine or
+  another fleet device: spawning or killing processes/sessions, injecting keystrokes,
+  writing shared state (sessions.db, the device registry, agents.yaml), firing a
+  scheduled job, SSH dispatch.
+- **Scheduler** — whatever decides *when* to act: a cron routine, a daemon tick, a
+  `setInterval`, a file watcher, an event subscriber acting autonomously.
+- **Executor** — whatever performs the action once decided.
+- **Thin wrapper** — a UI surface whose only relationships to a fleet-affecting
+  capability are (a) rendering its state, and (b) invoking the CLI command that
+  controls it (`apps/factory/AGENTS.md`, the root `AGENTS.md` §Core concepts).
+
+### 3. Requirements
+
+- **SING-1 (MUST).** Every fleet-affecting capability MUST have exactly one scheduler
+  and one executor: the agents-cli daemon (`agents __daemon-run`,
+  `apps/cli/src/lib/daemon.ts`) or a CLI command the daemon or the user drives.
+  Status: **Current** for routines (`lib/scheduler.ts`), the watchdog
+  (`lib/watchdog/routine.ts`, WD-1), and rotate (`lib/watchdog/rotate.ts`).
+- **SING-2 (MUST NOT).** A UI surface (apps/factory, the menubar app, the iOS app)
+  MUST NOT own a timer, watcher, or loop that detects a condition and performs a
+  fleet-affecting action. Detection and decision MUST live in the CLI, which holds
+  the first-party state (sessions.db, usage snapshots, the device registry).
+  Canonical violation: the Factory watchdog rotate loop (2026-08-03) racing the
+  daemon's view of account health; canonical fix: PR #1914, which deleted it.
+- **SING-3 (MUST).** Where an action needs a UI-owned surface (typing into an editor
+  tab, opening a tab), the UI MUST expose a narrow endpoint the CLI drives — the
+  trigger MUST stay in the CLI. Precedent: the extension's `/inject` URI verb over
+  `live-terminals.json`, driven by `apps/cli/src/lib/terminal/inject.ts`; the
+  terminal engine's vscodium launch backend.
+- **SING-4 (MUST).** A control in any UI that turns a fleet-affecting capability on
+  or off MUST flip the CLI's own state (`agents watchdog enable|disable|rotate`,
+  `agents routines`), so every surface observes one truth. A UI-local toggle that
+  gates only the UI's view of an action MUST NOT exist.
+- **SING-5 (MUST).** Routines MUST fire only from the daemon's pid-claimed
+  `JobScheduler` (`lib/daemon.ts` — the pid-file claim exists precisely so a second
+  scheduler cannot double-fire). A UI MAY request an immediate run
+  (`agents routines run <name>` or equivalent) but MUST NOT hold its own cron,
+  countdown, or "run every N" for a routine.
+- **SING-6 (MUST).** A new fleet-affecting feature MUST be implemented in
+  `apps/cli` (daemon routine and/or command) first; the UI PR adds rendering and
+  control wiring only. If the feature seemingly requires UI-side execution, SING-3
+  applies — the UI grows an endpoint, the CLI keeps the trigger.
+- **SING-7 (SHOULD).** Multi-instance safety SHOULD be structural, not by
+  convention: pid-claimed singletons for daemon loops (the daemon's claim), leader
+  election with lease handoff for any remaining UI-side coordination protocol
+  (apps/factory `src/monitor/leader.ts` — presence fan-out only, not task
+  execution), and idempotent effects so a redelivery is a no-op.
+
+### 4. Given/When/Then scenarios
+
+- **GIVEN** a session hits its weekly account limit, **WHEN** the daemon watchdog
+  tick detects it, **THEN** the daemon alone decides and executes the rotate (or the
+  skip) — no UI surface fires a second rotate for the same session.
+- **GIVEN** two daemon processes are alive on one machine, **WHEN** a routine's cron
+  occurrence arrives, **THEN** the pid-file claim ensures exactly one scheduler
+  executes it; the second daemon never runs its own `JobScheduler`
+  (`lib/daemon.ts`).
+- **GIVEN** a user disables a fleet-affecting capability from the Factory palette,
+  **WHEN** the command completes, **THEN** the CLI's config is the state that
+  changed (`agents watchdog rotate off`), and the daemon, the menubar, and every
+  other surface observe the same off state.
+- **GIVEN** a limited session lives in a Factory editor tab, **WHEN** the daemon
+  rotates it, **THEN** the daemon drives the extension's `/inject` endpoint to act
+  in that tab — the extension performs no detection or decision of its own.
+- **GIVEN** a contributor adds a `setInterval` in apps/factory, **WHEN** the
+  callback performs anything beyond read-only rendering, **THEN** code review MUST
+  flag it under the root `AGENTS.md` §Code review conventions ("No second
+  scheduler") and the action MUST move to the CLI before merge.
+
+### 5. Known gaps
+
+- **SING-GAP-1.** The Factory monitor leader/follower protocol
+  (apps/factory `src/monitor/`) still coordinates presence fan-out inside the
+  extension with its own election. It performs no fleet-affecting action today
+  (post-#1914 it broadcasts read-side snapshots only), so it satisfies SING-2, but
+  it is a second coordination fabric where the daemon's presence tracking
+  (`lib/session/presence.ts`) would be the singular home. Informative; a future
+  consolidation SHOULD retire it in the daemon's favor.
 
 ---
 

--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -63,6 +63,29 @@ Adding a harness that is a real `agents run` agent needs no launch-code change; 
 inherits the contract. Tests pin it in `src/core/agents.test.ts`
 (`describe('launch contract — every runner is balanced')`).
 
+## Thin wrapper — no second scheduler (normative — the reviewer enforces this)
+
+**Factory is a consumer, never a scheduler.** Anything that can *act* on this
+machine or a fleet device — spawn, resume, kill, inject, dispatch, rotate, fire a
+routine — is scheduled and executed by the agents-cli daemon or a CLI command, per
+the root `AGENTS.md` invariant and the normative contract in
+[`apps/cli/docs/specifications.md` §Scheduling & execution singularity](../cli/docs/specifications.md#scheduling--execution-singularity).
+
+Rules for this package:
+
+- **No `setInterval` / watcher / loop that acts.** Polling for rendering (panel
+  refresh, presence heartbeat, read-side caches) is fine; a timer whose callback
+  spawns, injects, kills, or fires is a double-fire bug in waiting and does not
+  merge. The deleted watchdog rotate loop (2026-08-03 incident, PR #1914) is the
+  canonical violation.
+- **Controls call the CLI.** A Factory control that changes a fleet-affecting
+  capability flips CLI state (`agents watchdog enable|disable|rotate`,
+  `agents routines …`) via execFile argv — never a UI-local setting that gates only
+  the UI's view of the action.
+- **Actions on UI-owned surfaces go through endpoints the CLI drives.** The
+  `/inject` URI verb over `live-terminals.json` is the precedent: the extension
+  exposes the rail; the daemon decides when to use it.
+
 ## Testing the Factory Floor UI
 
 The Factory Floor feed + Dispatch panel are a React webview (`ui/settings`, top component `UnifiedAgentsPane.tsx`). To SEE and verify UI changes, do NOT install the packaged `.vsix` and drive VS Code via accessibility automation (`osascript` / `agents computer`) to open the dashboard — that steals your focus and is slow. Use the committed preview harness, which renders the real components with representative data in a plain browser page you can screenshot:


### PR DESCRIPTION
## Why

The 2026-08-03 incident (Factory's watchdog rotate loop racing the daemon, spawning resume-tabs every 120s into exhausted accounts) happened because a fleet-affecting feature ran in two places: the UI and the daemon. #1914 consolidated the watchdog; this PR writes the rule down so the next feature can't reintroduce the class — user request, verbatim: *'things that have access to a full fleet or could affect the full fleet should not be double scheduled... if a feature is included in the factory UI, the factory UI is always supposed to be a thin wrapper.'*

## What (docs only)

- **`apps/cli/docs/specifications.md`** — new normative section **Scheduling & execution singularity** (SING-1..7, RFC-2119, file:line citations, five Given/When/Then scenarios, one honest `-GAP-` for the remaining Factory monitor election fabric). Covers routines explicitly: only the daemon's pid-claimed `JobScheduler` fires them; a UI may *request* a run, never *hold* a schedule.
- **Root `AGENTS.md`** — the invariant as a Core-concepts bullet + a blocking rule in §Code review conventions: **'No second scheduler'** — a UI timer/watcher that *acts* (spawn/resume/kill/inject/dispatch/rotate/fire) rather than polls read-only state is flagged with `file:line`. This is the enforcement mechanism — the prix reviewer reads this section every PR.
- **`apps/factory/AGENTS.md`** — 'Thin wrapper — no second scheduler' normative section beside the Launch contract: no acting timers, controls flip CLI state, UI-owned surfaces are endpoints the CLI drives.

Current-state verification behind the spec: post-#1914 the only remaining Factory intervals are read-only pollers/presence (extension.ts:5637,5782 publish/report; panel refresh), routines fire only from the daemon's pid-claimed scheduler (daemon.ts:267 exists precisely against double-fire), and the daemon is the single executor for watchdog/routines/monitors.