### PR TITLE
docs(monitors): help example uses --notify (owner default), not --notify telegram

### DIFF
--- a/apps/cli/src/commands/monitors.ts
+++ b/apps/cli/src/commands/monitors.ts
@@ -272,7 +272,7 @@ export function registerMonitorsCommands(program: Command): void {
       # SSL cert issued → notify (poll an HTTPS endpoint every 8h)
       agents monitors add cert-issued \\
         --poll-http 'https://secure.ssl.com/team/.../co-ec1l5dgjofa' 8h \\
-        --match 'issued' --notify telegram --device zion
+        --match 'issued' --notify --device zion
 
       # Dry-run: evaluate the source once and show what it would emit (no action)
       agents monitors test ci-red


### PR DESCRIPTION
**docs-only** — one help-text example, no behavior change.

The `agents monitors add` help had a cert-issued example using `--notify telegram`. Owner notifications resolve `notify.owner` (iMessage on this fleet), so the example now uses bare `--notify` (owner default). The `--notify [channel]` option itself is unchanged — **Telegram stays a valid override** (`--notify telegram` still works); the example just no longer showcases it for an owner ping.

- `apps/cli/src/commands/monitors.ts:275` (the `examples` block only).
- No flag/command/behavior change → docs-exempt from CHANGELOG.
- No run: pure help-string edit.
