### PR TITLE
docs(spec): multi-device clause for the single-scheduler invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,15 @@ and [`architecture.md`](apps/cli/docs/architecture.md).
   exposes a narrow endpoint the CLI drives (the `/inject` verb is the precedent) — the
   trigger stays in the CLI. Routines are covered by the same rule: `agents routines` +
   the daemon's pid-claimed scheduler (`apps/cli/src/lib/daemon.ts`) are the only cron
-  that fires them; a UI button may *request* a run, never *schedule* one. Violations are
+  that fires them; a UI button may *request* a run, never *schedule* one. **Multiple
+  devices are fine — shared queues are not.** Every device runs its own daemon, and
+  an unrestricted routine MAY fire on all of them when its input is the firing
+  device's own state (its repos, sessions, caches). But a job that consumes *shared*
+  input (a ticket tracker, a PR queue, the feed, a sync bucket) MUST have exactly
+  one executor per work item: an owner pin (`agents routines devices <name> --set
+  <one>`), an atomic claim per item (the feed's `O_EXCL` precedent), or verified
+  idempotency — otherwise two daemons pick the same task and run it twice.
+  Violations are
   the double-fire bug class — the 2026-08-03 incident (Factory's watchdog rotate loop
   racing the daemon, spawning resume-tabs every 120s into exhausted accounts) is the
   canonical example; the consolidation (PR #1914) is the canonical fix. The normative

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -1925,6 +1925,35 @@ nothing but its own view cache.
   (apps/factory `src/monitor/leader.ts` — presence fan-out only, not task
   execution), and idempotent effects so a redelivery is a no-op.
 
+#### 3.1 Multi-device — parallel daemons are fine, shared queues are not
+
+Every fleet device runs its own daemon, and that is by design: scheduling fans out
+across devices whenever the *work* is partitioned by device. The duplication hazard
+is not two daemons existing — it is two daemons consuming the **same** input.
+
+- **SING-8 (MUST).** An unrestricted routine (no `devices` allowlist) fires on every
+  device running the scheduler (`lib/routines.ts` `devices` doc) and therefore MUST
+  be per-device in scope: its input MUST be the firing device's own state (its
+  repos, sessions, caches, accounts). `git-hygiene` on each device's own checkout is
+  the canonical legal shape; the watchdog rotating its own machine's sessions is
+  another.
+- **SING-9 (MUST).** A routine or monitor that consumes **shared** input — a ticket
+  tracker, a PR queue, the feed, an R2/sync bucket, another device's sessions —
+  MUST have exactly one executor per work item, achieved one of three ways:
+  (a) **owner pin** — `devices: [<one>]`, so `routineOwnerDevice`
+  (`lib/routines.ts`) names the single daemon allowed to fire (a multi-device pin
+  is a misconfiguration that fires only on the owner with a fix hint,
+  `lib/scheduler.ts`); or (b) **atomic claim** — each item is claimed with an
+  atomic primitive before work begins (precedent: the feed's `O_EXCL` block claim,
+  `lib/feed.ts` — two concurrent claimers cannot both succeed); or
+  (c) **idempotency** — a concurrent second execution of the same item is a
+  verified no-op. `dispatch: fleet` (one online device picked per run,
+  `lib/routines.ts`) satisfies (a) for dispatch targets.
+- **SING-10 (MUST).** Where (b) or (c) is chosen, the claim or idempotency check
+  MUST be part of the implementation, not a comment — shared-queue consumers
+  without an owner pin ship with a test that two concurrent fires cannot process
+  the same item.
+
 ### 4. Given/When/Then scenarios
 
 - **GIVEN** a session hits its weekly account limit, **WHEN** the daemon watchdog
@@ -1945,6 +1974,16 @@ nothing but its own view cache.
   callback performs anything beyond read-only rendering, **THEN** code review MUST
   flag it under the root `AGENTS.md` §Code review conventions ("No second
   scheduler") and the action MUST move to the CLI before merge.
+- **GIVEN** a routine like `git-hygiene` that sweeps each device's own checkout,
+  **WHEN** it is left unrestricted, **THEN** every device's daemon fires it and
+  each fire touches only its own machine — legal fan-out under SING-8, no
+  coordination needed.
+- **GIVEN** a routine that drains a shared tracker (e.g. `drain-linear-cli`),
+  **WHEN** two devices' daemons both fire it, **THEN** SING-9 requires exactly one
+  executor per item: the routine is owner-pinned to one device (the current
+  configuration), or each ticket is claimed atomically before work, or processing
+  the same ticket twice is a verified no-op — never "both daemons pick the same
+  ticket and run it twice."
 
 ### 5. Known gaps
 


### PR DESCRIPTION
Follow-up to #1945. The original SING section covered singularity per device but said nothing about the cross-device case the user flagged: *'sometimes the user may want to schedule something over two devices... when we schedule on multiple devices in parallel, they could both end up picking the same task.'*

**Amendment (docs only):**

- **SING-8 (MUST)** — unrestricted (all-device) routines fire on every daemon and therefore MUST be per-device in scope: input is the firing device's own state (`git-hygiene`, the watchdog's own-machine sessions). Parallel daemons are legal fan-out, not duplication.
- **SING-9 (MUST)** — shared-input consumers (ticket tracker, PR queue, feed, sync bucket, another device's sessions) MUST have exactly one executor per work item: (a) owner pin (`routineOwnerDevice`, lib/routines.ts — a multi-device pin already fires only on the owner, lib/scheduler.ts), (b) atomic claim (the feed's `O_EXCL` precedent, lib/feed.ts), or (c) verified idempotency. `dispatch: fleet` satisfies (a).
- **SING-10 (MUST)** — claim/idempotency is implementation+test (two concurrent fires can't process the same item), never a comment.
- Two new Given/When/Then scenarios (legal fan-out vs. the `drain-linear-cli` shared-queue case) and the root AGENTS.md invariant bullet gains the multi-device carve-out.

Grounded in existing mechanisms: `devices` allowlist (lib/routines.ts:169-175), owner-pin (lib/routines.ts:374+), multi-pin owner-only fire (lib/scheduler.ts:43-53), `dispatch: fleet` single-pick (lib/routines.ts:221-222), feed `O_EXCL` claim (lib/feed.ts:204-207).