### PR TITLE
fix(help): top-level listing advertised a removed command

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -436,7 +436,8 @@ Diagnostics:
   perf                            Latency rollups (hooks, commands, runs) from the disposable perf warehouse
 
 Config sync:
-  pull                            Clone or pull the system repo at ~/.agents/.system/
+  repo pull [alias]               Git pull a repo (system | user | <extra>)
+  sync [agent]                    Re-materialize installed version homes; --local to skip fetching
   repo init --path <dir>          Scaffold your own editable repo from a template
   repo add <path|gh:user/repo>    Merge an extra repo after the system repo
   lock [--frozen]                 Write/verify agents.lock (SHA-256 of resolved resources); --frozen fails on drift


### PR DESCRIPTION
**fix** — the top-level help advertised a command that was removed, and hid the two that replaced it.

## The defect

`apps/cli/src/index.ts:439`, under **Config sync:**

```
pull    Clone or pull the system repo at ~/.agents/.system/
```

`agents pull` was split into `agents repo pull` + `agents sync` + `agents setup`. Running it says so:

```
$ agents pull --help
Removed. See `agents repo pull` + `agents sync`.
```

The **stub is correct and deliberate** — it stays registered so old muscle memory gets a redirect instead of `unknown command`, and its own `.description()` already reads *"Removed…"*.

The problem is that the top-level listing is **hand-maintained**, so it drifted: it promises the command still clones/pulls the system repo, and never lists its successors. The primary help surface was teaching a removed god-command while hiding what replaced it. `push` had already been dropped from this listing — `pull` was left behind.

## The fix

```
Config sync:
  repo pull [alias]    Git pull a repo (system | user | <extra>)
  sync [agent]         Re-materialize installed version homes; --local to skip fetching
  repo init …
  repo add …
```

The stub stays registered and reachable — just not advertised as working.

## Why it mattered

Found while auditing why **three skills still referenced `agents pull`** — including the `description:` field of the `agents-cli` skill, which is injected into every agent's context at session start (fixed in muqsitnawaz/.agents#209).

The docs weren't independently wrong. They were echoing what the CLI's own help told them. Fixing the skills without fixing this would have left the source of the drift in place.

## Verification

```
$ grep -rl "Clone or pull the system repo" apps/cli/src
(no matches outside the fixed line)
```

No test pins the old string. Docs-only string change; no behavior touched.
