### PR TITLE
feat(agents): add Pi (Oh My Pi, omp) as a native harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ the exception.
   not qualify.)
 - **Harness parity for cross-agent features.** The CLI integrates many agent harnesses —
   Claude, Codex, Gemini, Cursor, OpenCode, OpenClaw, Grok, Droid, Copilot, Kiro, Goose,
-  Antigravity, Kimi, Forge. When a change adds or extends a capability that applies across
+  Antigravity, Kimi, Pi (Oh My Pi), Forge. When a change adds or extends a capability that applies across
   harnesses (subagents, hooks, MCP, allowlists, config sync, skills, workflows), it should
   cover **every** harness the capability applies to — or the PR states which are out of
   scope and why. Flag a diff that wires up two or three agents and silently skips the rest.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
   <a href="https://x.ai" title="Grok Build (xAI)"><strong>Grok</strong></a>
   &nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://factory.ai" title="Factory AI Droid"><strong>Droid</strong></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://omp.sh" title="Oh My Pi"><strong>Pi</strong></a>
 </p>
 
 https://agents-cli.sh/demo.mp4

--- a/apps/cli/.changelog/next/pi-harness.md
+++ b/apps/cli/.changelog/next/pi-harness.md
@@ -1,0 +1,9 @@
+- **Add Pi (Oh My Pi, `omp`) as a native harness.** agents-cli now installs, runs, and
+  syncs resources for [Oh My Pi](https://omp.sh) (`@oh-my-pi/pi-coding-agent`, binary
+  `omp`) under id `pi`. Pi is a Bun-based, terminal-first, multi-provider coding agent;
+  its cross-provider model catalog (OpenRouter, OpenAI, Anthropic, xAI, DeepSeek, …)
+  surfaces in `agents view` and `agents models pi` via `omp models --json`. It is
+  Claude-compatible: MCP (`.mcp.json`, stdio + http + headers), skills, file commands, and
+  Claude-shaped subagents all sync into `~/.omp/agent/`. Hooks, allowlist, and plugins are
+  intentionally off (omp's hook/approval/plugin models don't map to agents-cli's).
+  Source: `apps/cli/src/lib/agents.ts`, `apps/cli/src/lib/exec.ts`, `apps/cli/src/lib/models.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -255,13 +255,14 @@ Antigravity CLI, Grok CLI, OpenCode — features target these six first.
 | Goose | `goose` | ≥1.34 | ✓ | ✓ | ≥1.25 | — | ✓ | — | ✓ |
 | Droid | `droid` | ✓ | ✓ | ≥0.57.5 | ≥0.26 | ✓ | ✓ | ✓ | — |
 | Hermes | `hermes` | ≥0.11 | ✓ | — | ✓ | — | — | — | — |
+| Pi (Oh My Pi) | `pi` | — | ✓ | — | ✓ | ✓ | — | ✓ | — |
 
 ✓ = supported · — = not · version cell = only within that range (out-of-range =
 skipped silently). [`src/lib/agents.ts`](src/lib/agents.ts) is canonical — keep this
 snapshot in sync. `workflows` is `claude`/`kimi`/`goose`/`antigravity` (≥1.0.6, written to the
 shared HOME-global `~/.gemini/config/global_workflows/`, not a per-version home), `openclaw` (Lobster `.lobster` files under `.openclaw/workflows/`), and `grok` (≥0.2.111, native Rhai under `.grok/workflows/`); `mcp` is universal; `allowlist` is
 `claude`/`cursor`/`opencode`/`antigravity`/`grok`/`kimi`/`kiro`/`droid`/`goose`/`openclaw`/`copilot` (Copilot writes per-location approvals to `~/.copilot/permissions-config.json`; OpenClaw is tool-level only —
-blanket rules map to `~/.openclaw/openclaw.json` `tools.alsoAllow`/`tools.deny`, sub-command patterns skipped); `subagents` is `claude`/`codex`/`kiro`/`kimi`/`grok`/`openclaw`/`droid`/`copilot`/`antigravity`/`cursor` (≥2026.1.22).
+blanket rules map to `~/.openclaw/openclaw.json` `tools.alsoAllow`/`tools.deny`, sub-command patterns skipped); `subagents` is `claude`/`codex`/`kiro`/`kimi`/`grok`/`openclaw`/`droid`/`copilot`/`antigravity`/`cursor` (≥2026.1.22)/`pi`. **Pi (Oh My Pi, `omp`)** is Claude-compatible: it natively reads `.claude/commands`, `.mcp.json`, and Claude-shaped subagents, and keeps its own native resources under `~/.omp/agent/` (skills, commands, subagents `agents/`, `AGENTS.md` context, `.mcp.json`). `mcp` covers stdio + http + headers. `hooks`/`allowlist`/`plugins` are OFF: omp hooks are per-tool JS/TS extension modules (not event->shell-command registrations), approval is per-TOOL only (`tools.approval`, no command/path patterns), and plugins are npm/TS modules (not the Claude marketplace manifest). Its cross-provider model catalog (OpenRouter/OpenAI/Anthropic/xAI/DeepSeek/…) surfaces in `agents view` / `agents models pi` via `omp models --json`.
 **Gemini is hard-deprecated.** Keep the legacy `gemini` id only for parsing old
 sessions/config; `agents add gemini`, `agents import gemini`, and
 `agents sync gemini` fail and point users to Antigravity.

--- a/apps/cli/docs/00-concepts.md
+++ b/apps/cli/docs/00-concepts.md
@@ -216,6 +216,17 @@ contract.
 | Kimi | yes | yes | yes | yes | no | yes | yes | `AGENTS.md` | yes |
 | Droid | yes | yes | >= 0.57.5 | >= 0.26.0 | yes | yes | yes | `AGENTS.md` | no |
 | Hermes | no | yes | yes | yes | no | yes | no | `MEMORY.md` | no |
+| Pi (Oh My Pi) | no | yes | no | yes | yes | no | yes | `AGENTS.md` | no |
+
+Pi (`omp`) is Claude-compatible — it natively reads `.claude/commands`, `.mcp.json`, and
+Claude-shaped subagents, and keeps its own native resources under `~/.omp/agent/`
+(skills, commands, `agents/`, the `AGENTS.md` context file, and `.mcp.json`). Its MCP
+covers stdio + http + headers. Hooks are off (omp hooks are per-tool JS/TS extension
+modules, not event→shell-command registrations); allowlist is off (approval is per-TOOL
+only via `tools.approval`, no command/path patterns); plugins are off (npm/TS modules, not
+the Claude marketplace manifest). Its cross-provider model catalog (OpenRouter, OpenAI,
+Anthropic, xAI, DeepSeek, …) surfaces in `agents view` / `agents models pi` via
+`omp models --json`.
 
 **Gemini is hard-deprecated.** Google retired the Gemini CLI for free/Pro/Ultra
 tiers on June 18, 2026 (announced at Google I/O 2026); Antigravity CLI

--- a/apps/cli/src/commands/models.ts
+++ b/apps/cli/src/commands/models.ts
@@ -25,14 +25,14 @@ import { getModelPricing } from '../lib/pricing/index.js';
 import { terminalWidth, truncateToWidth, stringWidth } from '../lib/session/width.js';
 import { wrapJoined } from './inspect.js';
 
-const MODEL_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'opencode', 'cursor', 'openclaw', 'antigravity', 'kimi', 'grok', 'droid'];
+const MODEL_CAPABLE_AGENTS: AgentId[] = ['claude', 'codex', 'opencode', 'cursor', 'openclaw', 'antigravity', 'kimi', 'grok', 'droid', 'pi'];
 
 /**
  * Agents that don't necessarily install under ~/.agents/versions (cursor ships
  * via a curl script). For these, fall back to the PATH binary and synthesize
  * a version label from the install path so cache keys stay stable.
  */
-const PATH_ONLY_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>(['cursor']);
+const PATH_ONLY_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>(['cursor', 'pi']);
 
 /** Derive a version label from the PATH-installed binary location for agents without managed versions. */
 function fallbackPathVersion(agent: AgentId): string | null {

--- a/apps/cli/src/lib/__tests__/capabilities.test.ts
+++ b/apps/cli/src/lib/__tests__/capabilities.test.ts
@@ -142,10 +142,15 @@ describe('mcpHttp / mcpHeaders capability gates', () => {
     expect(supports('grok', 'mcpHttp').ok).toBe(false);
     expect(supports('kimi', 'mcpHttp').ok).toBe(false);
     expect(supports('droid', 'mcpHttp').ok).toBe(false);
+    // omp honors HTTP-transport MCP (mcp/types.ts MCPHttpServerConfig; config.ts
+    // infers http from a url-only server entry).
+    expect(supports('pi', 'mcpHttp').ok).toBe(true);
   });
 
-  it('mcpHeaders: only claude', () => {
+  it('mcpHeaders: claude and pi', () => {
     expect(supports('claude', 'mcpHeaders').ok).toBe(true);
+    // omp applies HTTP MCP headers (mcp/config.ts: `if (server.headers) …`).
+    expect(supports('pi', 'mcpHeaders').ok).toBe(true);
     expect(supports('codex', 'mcpHeaders').ok).toBe(false);
     expect(supports('gemini', 'mcpHeaders').ok).toBe(false);
     expect(supports('cursor', 'mcpHeaders').ok).toBe(false);
@@ -167,11 +172,12 @@ describe('mcpHttp / mcpHeaders capability gates', () => {
       'claude',
       'codex',
       'hermes',
+      'pi',
     ]);
   });
 
-  it('capableAgents(mcpHeaders) matches the old inline claude-only check', () => {
-    expect(capableAgents('mcpHeaders')).toEqual(['claude']);
+  it('capableAgents(mcpHeaders) is claude and pi (the header-honoring writers)', () => {
+    expect(capableAgents('mcpHeaders').sort()).toEqual(['claude', 'pi']);
   });
 });
 

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -348,6 +348,42 @@ export const AGENTS: Record<AgentId, AgentConfig> = {
     supportsHooks: true,
     capabilities: { hooks: { since: '0.3.130' }, mcp: true, mcpHttp: false, mcpHeaders: false, allowlist: { since: '1.1.1' }, skills: true, commands: true, plugins: true, subagents: true, rules: { file: 'AGENTS.md' }, workflows: false, memory: false, modes: ['plan', 'edit'] },
   },
+  // Oh My Pi (`omp`, omp.sh) — a Bun-based, terminal-first coding agent that runs
+  // against many model providers (OpenRouter, OpenAI, Anthropic, xAI, DeepSeek,
+  // Ollama, LM Studio, …). It is Claude-compatible: it natively discovers
+  // `.claude/commands`, `.mcp.json`, and Claude-shaped subagents, and keeps its
+  // own native resources under `~/.omp/agent/` (config dir reported by
+  // `omp config path`). configDir points AT the agent dir (not `~/.omp`) so the
+  // rules file lands at `~/.omp/agent/AGENTS.md`, the user context file omp reads.
+  pi: {
+    id: 'pi',
+    name: 'Pi',
+    color: 'magenta',
+    cliCommand: 'omp',
+    npmPackage: '@oh-my-pi/pi-coding-agent',
+    configDir: path.join(HOME, '.omp', 'agent'),
+    commandsDir: path.join(HOME, '.omp', 'agent', 'commands'),
+    commandsSubdir: 'commands',
+    skillsDir: path.join(HOME, '.omp', 'agent', 'skills'),
+    hooksDir: 'hooks',
+    instructionsFile: 'AGENTS.md',
+    format: 'markdown',
+    variableSyntax: '$ARGUMENTS',
+    // omp hooks are per-tool JS/TS extension modules discovered from
+    // `~/.omp/agent/hooks/{pre,post}/<tool>.<ext>` (loaded as HookFactory code),
+    // NOT the event->shell-command registrations agents-cli's hook sync writes.
+    // The two models don't map, so hooks stay off (capabilities.hooks:false).
+    supportsHooks: false,
+    // MCP: omp reads `.mcp.json` with the Claude `{ "mcpServers": {...} }` schema
+    // at user scope (`~/.omp/agent/.mcp.json`) and project scope (`<root>/.mcp.json`),
+    // stdio + http + sse with headers. skills (`~/.omp/agent/skills/<name>/SKILL.md`),
+    // commands (`~/.omp/agent/commands/*.md`), and subagents (`~/.omp/agent/agents/*.md`,
+    // Claude-shaped) are all native. allowlist is OFF: omp gates approval per-TOOL
+    // only (`tools.approval` record: allow|prompt|deny) with no command/path/domain
+    // patterns, so agents-cli's granular permission format has nothing to map to.
+    // plugins are npm packages / TS modules, not the Claude marketplace manifest.
+    capabilities: { hooks: false, mcp: true, mcpHttp: true, mcpHeaders: true, allowlist: false, skills: true, commands: true, plugins: false, subagents: true, rules: { file: 'AGENTS.md' }, workflows: false, memory: false, modes: ['plan', 'edit', 'skip'] },
+  },
   openclaw: {
     id: 'openclaw',
     name: 'OpenClaw',
@@ -2572,6 +2608,9 @@ export function getUserMcpConfigPath(agentId: AgentId): string {
       return path.join(agent.configDir, 'mcp.json');
     case 'hermes':
       return path.join(agent.configDir, 'config.yaml');
+    case 'pi':
+      // omp reads user-scope MCP from ~/.omp/agent/.mcp.json (Claude schema).
+      return path.join(agent.configDir, '.mcp.json');
     default:
       // Gemini and others use settings.json
       return path.join(agent.configDir, 'settings.json');
@@ -2609,6 +2648,8 @@ export function getMcpConfigPathForHome(agentId: AgentId, home: string): string 
       return path.join(home, '.factory', 'mcp.json');
     case 'hermes':
       return path.join(home, '.hermes', 'config.yaml');
+    case 'pi':
+      return path.join(home, '.omp', 'agent', '.mcp.json');
     default:
       return path.join(home, agentConfigDirName(agentId), 'settings.json');
   }
@@ -2649,6 +2690,9 @@ export function getProjectMcpConfigPath(agentId: AgentId, cwd: string = process.
       return path.join(cwd, '.factory', 'mcp.json');
     case 'hermes':
       return path.join(cwd, '.hermes', 'config.yaml');
+    case 'pi':
+      // omp reads project MCP from <root>/.mcp.json (Claude-compatible).
+      return path.join(cwd, '.mcp.json');
     default:
       return path.join(cwd, `.${agentId}`, 'settings.json');
   }

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -637,6 +637,25 @@ export const AGENT_COMMANDS: Record<AgentId, AgentCommandTemplate> = {
     jsonFlags: ['--format', 'json'],
     modelFlag: '--model',
   },
+  // Oh My Pi (`omp`). Headless is the positional MESSAGES arg + `-p/--print`.
+  // Approval modes map to omp's `--approval-mode`: always-ask (read-only tools
+  // auto-approved, writes gated -> our `plan`), write (read + workspace writes
+  // auto-approved -> `edit`), yolo (all tiers auto-approved -> `skip`). JSON is
+  // omp's `--mode json` event stream. `--model` fuzzy-matches a provider/model
+  // selector. Native resume is `-r/--resume <id-prefix>`.
+  pi: {
+    base: ['omp'],
+    promptFlag: 'positional',
+    modeFlags: {
+      plan: ['--approval-mode', 'always-ask'],
+      edit: ['--approval-mode', 'write'],
+      skip: ['--approval-mode', 'yolo'],
+    },
+    jsonFlags: ['--mode', 'json'],
+    modelFlag: '--model',
+    printFlags: ['-p'],
+    resume: { flag: '--resume' },
+  },
   openclaw: {
     base: ['openclaw'],
     promptFlag: 'positional',

--- a/apps/cli/src/lib/mcp.ts
+++ b/apps/cli/src/lib/mcp.ts
@@ -700,6 +700,7 @@ function writeMcpConfigSupportsAgent(agentId: AgentId): boolean {
     case 'grok':
     case 'opencode':
     case 'hermes':
+    case 'pi':
       return true;
     default:
       return false;
@@ -728,7 +729,11 @@ export function writeMcpConfig(
     case 'claude':
     case 'cursor':
     case 'kimi':
-    case 'droid': {
+    case 'droid':
+    // omp reads the same Claude `{ "mcpServers": {...} }` schema from .mcp.json
+    // (stdio: command/args/env; http/sse: url/headers — transport inferred from
+    // command/url presence).
+    case 'pi': {
       let config: Record<string, unknown> = {};
       if (fs.existsSync(configPath)) {
         try {

--- a/apps/cli/src/lib/model-tiers.ts
+++ b/apps/cli/src/lib/model-tiers.ts
@@ -174,7 +174,10 @@ function newer(a: string, b: string): number {
  */
 function rankCatalog(agent: AgentId, models: ModelInfo[]): Ranked[] {
   const usable = models.filter((m) => !PSEUDO.test(m.id));
-  const aggregator = agent === 'cursor';
+  // Cursor and Pi (Oh My Pi) are cross-provider aggregators: their ids are
+  // provider-qualified (`anthropic/…`, `openai/…`) and span vendors, so price of
+  // the normalized base id is the only unifying rank signal.
+  const aggregator = agent === 'cursor' || agent === 'pi';
 
   const scored = usable.map((m) => {
     const rawId = m.id;

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -306,6 +306,17 @@ export function locateModelSource(
     return null;
   }
 
+  if (agent === 'pi') {
+    // omp (Oh My Pi) installs via `bun install -g`; a version-managed install
+    // exposes it under node_modules/.bin/omp, otherwise it lives on PATH. We let
+    // the CLI produce its own catalog via `omp models --json` (extractPiCatalog).
+    const cli = path.join(versionDir, 'node_modules', '.bin', 'omp');
+    if (fs.existsSync(cli)) return { path: cli, kind: 'cli' };
+    const pathBin = findOnPath('omp');
+    if (pathBin) return { path: pathBin, kind: 'cli' };
+    return null;
+  }
+
   return null;
 }
 
@@ -985,6 +996,55 @@ function extractKimiCatalog(binaryPath: string): { models: ModelInfo[]; aliases:
 }
 
 /**
+ * Extract Oh My Pi's catalog via `omp models --json`. omp is a cross-provider
+ * aggregator: its catalog is the union of every provider it has a key for, so
+ * ids are provider-qualified selectors (`anthropic/claude-opus-4-8`,
+ * `openai/gpt-5.2`, `xai/grok-4`, `deepseek/deepseek-chat`, …) — exactly the
+ * `provider/model` convention `ModelInfo.id` already uses. Output shape:
+ *   {"models":[{"provider":"anthropic","id":"claude-opus-4-8",
+ *               "selector":"anthropic/claude-opus-4-8","name":"Claude Opus 4.8",
+ *               "cost":{...}}, ...]}
+ * The catalog is gated per-provider by key presence (no key -> that provider's
+ * models are absent, and an empty env yields `{"models":[]}`). That is truthful:
+ * the extractor surfaces exactly the providers the user has authenticated.
+ * Pricing is attached uniformly by getModelCatalog via getModelPricing(id),
+ * which strips the `provider/` prefix — so no per-catalog price shape here.
+ */
+function extractPiCatalog(binaryPath: string): { models: ModelInfo[]; aliases: Record<string, string> } {
+  let stdout: string;
+  try {
+    stdout = execFileSync(binaryPath, ['models', '--json'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 15_000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch {
+    return { models: [], aliases: {} };
+  }
+
+  let parsed: { models?: Array<{ id?: string; selector?: string; provider?: string; name?: string }> };
+  try {
+    parsed = JSON.parse(stdout.replace(/\x1b\[[0-9;]*[A-Za-z]/g, ''));
+  } catch {
+    return { models: [], aliases: {} };
+  }
+  if (!parsed || !Array.isArray(parsed.models)) return { models: [], aliases: {} };
+
+  const models: ModelInfo[] = [];
+  const seen = new Set<string>();
+  for (const m of parsed.models) {
+    // Prefer the provider-qualified selector; fall back to provider/id.
+    const id = m.selector || (m.provider && m.id ? `${m.provider}/${m.id}` : m.id);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    models.push({ id, displayName: typeof m.name === 'string' ? m.name : undefined });
+  }
+
+  return { models, aliases: {} };
+}
+
+/**
  * Build (or load from cache) the model catalog for a specific (agent, version).
  * Cache is keyed on source-file mtime (binary or js module), so re-extracts
  * automatically when the user upgrades or reinstalls a version.
@@ -1033,6 +1093,7 @@ export function getModelCatalog(agent: AgentId, version: string): ModelCatalog |
     else if (agent === 'antigravity') ({ models, aliases } = extractAntigravityCatalog(src.path));
     else if (agent === 'kimi') ({ models, aliases } = extractKimiCatalog(src.path));
     else if (agent === 'grok') ({ models, aliases } = extractGrokCatalog(src.path));
+    else if (agent === 'pi') ({ models, aliases } = extractPiCatalog(src.path));
   }
 
   // Attach per-token pricing where the offline table knows the model, so the

--- a/apps/cli/src/lib/resources/mcp.ts
+++ b/apps/cli/src/lib/resources/mcp.ts
@@ -159,6 +159,9 @@ export function getMcpConfigPath(agent: AgentId, versionHome: string): string | 
       return path.join(versionHome, '.grok', 'mcp.json');
     case 'hermes':
       return path.join(versionHome, '.hermes', 'config.yaml');
+    case 'pi':
+      // omp reads user-scope MCP from ~/.omp/agent/.mcp.json (Claude schema).
+      return path.join(versionHome, '.omp', 'agent', '.mcp.json');
     default:
       return null;
   }

--- a/apps/cli/src/lib/resources/types.ts
+++ b/apps/cli/src/lib/resources/types.ts
@@ -6,7 +6,7 @@
  * - Override on name conflict: Higher layer wins (project > user > system)
  */
 
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid' | 'hermes';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid' | 'hermes' | 'pi';
 export type Layer = 'system' | 'user' | 'project';
 export type ResourceKind = 'command' | 'hook' | 'skill' | 'rule' | 'mcp' | 'permission' | 'subagent' | 'workflow' | 'memory';
 

--- a/apps/cli/src/lib/subagents-registry.ts
+++ b/apps/cli/src/lib/subagents-registry.ts
@@ -328,6 +328,9 @@ export const SUBAGENT_TARGETS: Partial<Record<AgentId, SubagentTarget>> = {
   // Tier 1 -- flat markdown, Claude-compatible flatten.
   claude: flatFile({ subdir: ['.claude', 'agents'], ext: '.md', transform: transformSubagentForClaude }),
   grok: flatFile({ subdir: ['.grok', 'agents'], ext: '.md', transform: transformSubagentForClaude }),
+  // Oh My Pi discovers Claude-shaped agent markdown from ~/.omp/agent/agents/
+  // (`omp agents unpack` writes there); frontmatter name/description + body.
+  pi: flatFile({ subdir: ['.omp', 'agent', 'agents'], ext: '.md', transform: transformSubagentForClaude, readMeta: metaFrontmatterFallback }),
   droid: flatFile({ subdir: ['.factory', 'droids'], ext: '.md', transform: transformSubagentForDroid }),
   // Bespoke frontmatter/format, still one flat file.
   codex: flatFile({ subdir: ['.codex', 'agents'], ext: '.toml', transform: transformSubagentForCodex }),

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -10,7 +10,7 @@ import type { CloudProviderId } from './cloud/types.js';
 import type { FeedBroadcastConfig } from './feed-broadcast.js';
 
 /** Unique identifier for a current or legacy AI coding agent. */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid' | 'hermes';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'amp' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid' | 'hermes' | 'pi';
 
 /** How `agents run <agent>` chooses an installed version when none is pinned. */
 export type RunStrategy = 'pinned' | 'available' | 'balanced';

--- a/apps/cli/tests/agents.test.ts
+++ b/apps/cli/tests/agents.test.ts
@@ -113,6 +113,69 @@ describe('droid (Factory AI)', () => {
   });
 });
 
+describe('pi (Oh My Pi)', () => {
+  it('is registered with its supported resource capabilities', () => {
+    expect(ALL_AGENT_IDS).toContain('pi');
+    // Claude-compatible surfaces omp reads natively from ~/.omp/agent/.
+    expect(capableAgents('mcp')).toContain('pi');
+    expect(capableAgents('commands')).toContain('pi');
+    expect(capableAgents('skills')).toContain('pi');
+    expect(capableAgents('subagents')).toContain('pi');
+    // HTTP MCP + headers are honored (MCPHttpServerConfig).
+    expect(capableAgents('mcpHttp')).toContain('pi');
+    expect(capableAgents('mcpHeaders')).toContain('pi');
+    // omp hooks are per-tool JS/TS extension modules, not event->shell-command
+    // registrations; approval is per-TOOL only (no command/path allowlist);
+    // plugins are npm/TS modules, not the Claude marketplace manifest. All off.
+    expect(capableAgents('hooks')).not.toContain('pi');
+    expect(capableAgents('allowlist')).not.toContain('pi');
+    expect(capableAgents('plugins')).not.toContain('pi');
+    expect(capableAgents('workflows')).not.toContain('pi');
+    expect(AGENTS.pi.capabilities.hooks).toBe(false);
+    expect(AGENTS.pi.instructionsFile).toBe('AGENTS.md');
+    expect(AGENTS.pi.capabilities.rules).toEqual({ file: 'AGENTS.md' });
+  });
+
+  it('resolves MCP config to ~/.omp/agent/.mcp.json and round-trips the mcpServers shape', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-pi-mcp-'));
+    try {
+      const configPath = getMcpConfigPathForHome('pi', home);
+      expect(configPath).toBe(path.join(home, '.omp', 'agent', '.mcp.json'));
+
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ mcpServers: { ctx: { command: 'ctx-server', args: ['--stdio'], env: {} } } })
+      );
+
+      const parsed = parseMcpConfig('pi', configPath);
+      expect(Object.keys(parsed)).toContain('ctx');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('installSubagentToAgent writes ~/.omp/agent/agents/<name>.md (Claude-shaped)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-pi-sub-'));
+    const subDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-pi-subsrc-'));
+    try {
+      fs.writeFileSync(
+        path.join(subDir, 'AGENT.md'),
+        `---\nname: explorer\ndescription: Explores the codebase\n---\n\nYou explore code.\n`
+      );
+      installSubagentToAgent(subDir, 'explorer', 'pi', home);
+      const dest = path.join(home, '.omp', 'agent', 'agents', 'explorer.md');
+      expect(fs.existsSync(dest)).toBe(true);
+      const body = fs.readFileSync(dest, 'utf-8');
+      expect(body).toContain('name: explorer');
+      expect(body).toContain('You explore code.');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(subDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('Hermes install targets', () => {
   it('registers Hermes with skills, MCP, plugins, and MEMORY.md rules', () => {
     expect(ALL_AGENT_IDS).toContain('hermes');


### PR DESCRIPTION
**feat** — adds **Oh My Pi** (`omp`, [omp.sh](https://omp.sh)) as a first-class native harness under id `pi`. CLI/terminal feature — **no GUI surface**; proof is the real `agents models pi` / `agents view pi` run output below.

## What changed

`agents-cli` now installs, runs, syncs resources for, and shows the model catalog of Oh My Pi (`@oh-my-pi/pi-coding-agent`, binary `omp`) — a Bun-based, terminal-first, **multi-provider** coding agent (OpenRouter, OpenAI, Anthropic, xAI, DeepSeek, Ollama, LM Studio, …).

Pi is **Claude-compatible**: it natively reads `.claude/commands`, `.mcp.json`, and Claude-shaped subagents, and keeps its own native resources under `~/.omp/agent/` (the dir `omp config path` reports). `configDir` points at that agent dir so the rules file lands at `~/.omp/agent/AGENTS.md`, the context file omp reads.

### Wiring (harness parity)

| Subsystem | Wired | Where |
|---|---|---|
| `AgentId` unions | ✓ | `types.ts`, `resources/types.ts` |
| `AGENTS` registry entry | ✓ | `agents.ts` (id `pi`, `omp`, `~/.omp/agent`) |
| Exec command template | ✓ | `exec.ts` (`-p`, `--model`, `--approval-mode` plan/edit/skip, `--resume`, `--mode json`) |
| Model catalog + tiers | ✓ | `models.ts` (`extractPiCatalog` shells `omp models --json`; aggregator tiers in `model-tiers.ts`; `MODEL_CAPABLE_AGENTS` + `PATH_ONLY_AGENTS`) |
| MCP (`.mcp.json`, stdio/http/headers) | ✓ | `mcp.ts` writer, `resources/mcp.ts` + `agents.ts` (3 path resolvers) |
| Skills / commands / subagents | ✓ | generic dirs + `subagents-registry.ts` (Claude-shaped) |

**Intentionally off, with reasons** (fail-loud, not silent): **hooks** — omp hooks are per-tool JS/TS extension modules (`~/.omp/agent/hooks/{pre,post}/<tool>.<ext>`), not event→shell-command registrations; **allowlist** — omp gates approval per-TOOL only (`tools.approval`: allow|prompt|deny), no command/path/domain patterns; **plugins** — omp plugins are npm/TS modules, not the Claude marketplace manifest.

**Deliberate follow-up:** session-transcript indexing (`agents sessions` for omp's JSONL) is not wired — it needs omp's transcript schema reverse-engineered; scoped out here, not half-wired.

## Proof — real run (omp 17.2.9 installed; provider keys set to unlock each provider's catalog)

```
$ agents models pi
Pi installed
  tiers:
    cheap    openai/gpt-4.1-nano  ~$1/Mtok
    default  openai/gpt-4o-2024-08-06  ~$13/Mtok
    best     xai-oauth/grok-4.20-0309-reasoning  --
    ultra    openai/o1-pro  --

  115 models · `agents models pi --all` for the full list

$ agents models pi --all   (excerpt — 115 models, provider-qualified selectors)
  source: cli (~/.bun/bin/omp)
    anthropic/claude-opus-4-8 (Claude Opus 4.8)
    anthropic/claude-sonnet-4-6 (Claude Sonnet 4.6)
    openai/gpt-5.1-codex (GPT-5.1 Codex)
    xai/grok-4 (Grok 4)
    ...   # counts: anthropic 26 · openai 51 · xai 30 · xai-oauth 8

$ agents view pi
Installed Agent CLIs
Not Managed by Agents CLI
  Pi
    17.2.9 (global)
      /home/muqsit/.bun/bin/omp
    Manage: agents add pi@17.2.9 -y
```

> Provider keys are placeholders — omp's catalog is gated per-provider by key *presence*, so the extractor truthfully surfaces exactly the providers a user has configured. Empty env → `{"models":[]}` (honest, never a fabricated catalog).

## Tests

- New `pi` block in `tests/agents.test.ts` (registration, MCP path round-trip, subagent install) + `capabilities.test.ts` updates (pi ∈ mcpHttp/mcpHeaders).
- Pinning tests green: `exec.test.ts` (modeFlags↔modes drift), `subagents-registry.test.ts` (targets↔capableAgents), `capabilities.test.ts`, `tests/agents.test.ts`, plus `resources/` + `model-tiers` + `models` — **308 + 175 pass**.
- `tsc --noEmit`: 0 errors.
- Full-suite run: the only failures are pre-existing **laptop-env** contamination (live-session `AGENTS_*` vars, git-layout, missing codex binary, secrets-agent/crabbox) — clearing the ambient session env makes them pass (77/77). None reference `pi`. This is exactly why the repo offloads via `test:remote`.

Not merging/releasing — Grok review requested next.
