### PR TITLE
docs(sessions): session lifecycle verb matrix

### DIFF
--- a/apps/cli/.changelog/next/session-lifecycle-help-matrix.md
+++ b/apps/cli/.changelog/next/session-lifecycle-help-matrix.md
@@ -1,0 +1,5 @@
+- **`agents sessions --help` and `05-sessions.md` now teach one session-lifecycle
+  matrix.** `focus` / `focus --attach-only` / `detach` / `attach` / `resume` are
+  listed as distinct intents (not synonyms), so operators stop guessing among
+  `go` / `focus` / `attach` / `resume`. Source: `apps/cli/src/commands/sessions.ts`,
+  `apps/cli/src/commands/focus.ts`, `apps/cli/docs/05-sessions.md`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -26,8 +26,8 @@ interchangeable — pick the verb for the intent:
 
 `focus` is the default “take me there” for a live process. `attach` / `detach` are
 the presence pair (foreground ↔ background). `resume` is the multi-open / history
-path. Detail: [Background & foreground (detach / attach)](#background--foreground-detach--attach)
-below, and `agents sessions --help`.
+path. Detail in **Background & foreground (detach / attach)** below, and
+`agents sessions --help`.
 
 ## Architecture
 

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -9,6 +9,26 @@ the session-discoverable harnesses — Claude, Codex, Gemini, Antigravity, OpenC
 OpenClaw, Rush, Hermes, Grok, Kimi, Droid, and Cursor (the `SESSION_AGENTS` set in
 `src/lib/session/types.ts`).
 
+## Session lifecycle verbs
+
+These subcommands sit on one axis (get back into a conversation). They are **not**
+interchangeable — pick the verb for the intent:
+
+| Intent | Verb |
+| --- | --- |
+| Jump to a **live** session (attach its terminal, or open a new tab and resume a copy) | `agents sessions focus [id]` |
+| Attach only — never open a new tab / fork a copy | `agents sessions focus [id] --attach-only` |
+| Deprecated alias of focus --attach-only | `agents sessions go` (prints a deprecation notice) |
+| Interactive → **headless** (keep working unattended) | `agents sessions detach <id>` |
+| Headless → **interactive** in this terminal | `agents sessions attach <id>` |
+| Multi-select history and open each in a tab/split | `agents sessions resume [query]` |
+| Continue one session from a script / `run` path | `agents run <agent> --resume <id> …` |
+
+`focus` is the default “take me there” for a live process. `attach` / `detach` are
+the presence pair (foreground ↔ background). `resume` is the multi-open / history
+path. Detail: [Background & foreground (detach / attach)](#background--foreground-detach--attach)
+below, and `agents sessions --help`.
+
 ## Architecture
 
 ```

--- a/apps/cli/src/commands/focus.ts
+++ b/apps/cli/src/commands/focus.ts
@@ -30,9 +30,10 @@ import {
   type Backend,
 } from '../lib/terminal/index.js';
 import { isInteractiveTerminal } from './utils.js';
+import { setHelpSections } from '../lib/help.js';
 
 export function registerFocusCommand(program: Command): void {
-  program
+  const cmd = program
     .command('focus')
     .argument('[id]', 'Short/full session id to focus; omit for an interactive picker')
     .option('--local', 'Only this machine (skip the cross-host sweep)')
@@ -41,6 +42,27 @@ export function registerFocusCommand(program: Command): void {
     .action(async (id: string | undefined, opts: { local?: boolean; attachOnly?: boolean }) => {
       await focusAction(id, opts);
     });
+
+  setHelpSections(cmd, {
+    examples: `
+      # Jump to a live session (attach pane/tab, or open a new tab and resume)
+      agents sessions focus a1b2c3d4
+
+      # Attach only — refuse if nothing is joinable (old sessions go)
+      agents sessions focus a1b2c3d4 --attach-only
+
+      # Pick from live sessions on this machine only
+      agents sessions focus --local
+    `,
+    notes: `
+      Lifecycle siblings (not synonyms):
+        focus              live jump (default "take me there")
+        focus --attach-only  attach only; never fork (replaces go)
+        detach / attach    interactive ↔ headless presence
+        resume             multi-select history → tabs
+        run --resume       single scripted continue
+    `,
+  });
 }
 
 /**

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -4115,6 +4115,18 @@ export function registerSessionsCommands(program: Command): void {
       # Show only what's running right now (terminals, teams, cloud, headless)
       agents sessions --active
 
+      # --- Session lifecycle (one verb per intent) ---
+      # Jump to a live session (attach its terminal, or open a tab + resume)
+      agents sessions focus a1b2c3d4
+      # Attach only — never fork a copy (old: sessions go)
+      agents sessions focus a1b2c3d4 --attach-only
+      # Interactive → headless (keep working unattended)
+      agents sessions detach a1b2c3d4
+      # Headless → interactive in this terminal
+      agents sessions attach a1b2c3d4
+      # Multi-select history and open each in a tab
+      agents sessions resume
+
       # The interactive list folds in other online machines automatically,
       # labelled by host with this machine first. Stay local with --local:
       agents sessions --local
@@ -4155,6 +4167,12 @@ export function registerSessionsCommands(program: Command): void {
       agents sessions --all "deploy script" --host box-a --host box-b
     `,
     notes: `
+      Session lifecycle (pick one verb — they are not synonyms):
+        focus [id]              jump to a live session (attach, or open tab + resume)
+        focus [id] --attach-only  attach only; never fork (replaces sessions go)
+        detach <id>             interactive → headless continuation
+        attach <id>             headless → interactive in this terminal
+        resume [query]          multi-select history → open tabs (or run --resume <id>)
       - The interactive listing folds in your other online machines automatically (live over SSH, no sync) — each row is labelled by host, this machine first. Use --local to skip the fan-out; --json and single-id lookups stay local.
       - --host runs the query on the remote's own index over SSH (host alias or user@host); repeat or pass several to fan out. SSH access is the only auth.
       - --in-team matches both ends of the lineage: the session that ran 'agents teams create/add', and (with --teams) that team's teammates. In the interactive list, 't' cycles the same filter over the teams in view.


### PR DESCRIPTION
## What

**docs-only** — teach one session-lifecycle matrix so operators stop treating `go` / `focus` / `attach` / `resume` as synonyms.

| Intent | Verb |
| --- | --- |
| Jump to live (attach or open+resume) | `sessions focus` |
| Attach only, never fork | `sessions focus --attach-only` (replaces `go`) |
| Interactive → headless | `sessions detach` |
| Headless → interactive | `sessions attach` |
| Multi-select history → tabs | `sessions resume` |

## Why

Part of the surface-consolidation program (Phase 1 after feed/activity). The verbs already exist; the collision is **discoverability**.

## Audience

End users and agents reading `--help` / `05-sessions.md`.

## Run evidence

docs-only / no-surface-run — help text and docs only; no runtime behavior change.