### PR TITLE
fix(secrets): secrets list enumeration never pops Touch ID (SEC-14)

### DIFF
--- a/apps/cli/.changelog/next/SEC-14-secrets-list-never-prompts.md
+++ b/apps/cli/.changelog/next/SEC-14-secrets-list-never-prompts.md
@@ -1,0 +1,10 @@
+- **`secrets list` enumeration never pops Touch ID (SEC-14).** The signed keychain
+  helper's `list` (and `list-synced`) data-protection pass swept every DP item with
+  the default `kSecUseAuthenticationUIAllow`, so a `kSecMatchLimitAll` enumeration
+  evaluated a biometry-ACL'd value item's ACL and showed a real Touch ID sheet on
+  every call — a prompt storm, since `secrets list` runs constantly (bundle
+  resolution, the menubar device poll, the watchdog). It is now
+  `kSecUseAuthenticationUISkip`: the no-ACL bundle metadata (all the listing needs)
+  still returns, ACL'd value items are silently skipped, and no sheet is shown. This
+  was below the `AGENTS_SECRETS_NO_PROMPT` / `agentOnly` guard, so SEC-13 (#1942) did
+  not cover it. Source: `apps/cli/src/lib/secrets/keychain-helper.swift`.

--- a/apps/cli/.changelog/next/SEC-14-secrets-list-never-prompts.md
+++ b/apps/cli/.changelog/next/SEC-14-secrets-list-never-prompts.md
@@ -1,10 +1,14 @@
 - **`secrets list` enumeration never pops Touch ID (SEC-14).** The signed keychain
-  helper's `list` (and `list-synced`) data-protection pass swept every DP item with
-  the default `kSecUseAuthenticationUIAllow`, so a `kSecMatchLimitAll` enumeration
-  evaluated a biometry-ACL'd value item's ACL and showed a real Touch ID sheet on
-  every call — a prompt storm, since `secrets list` runs constantly (bundle
-  resolution, the menubar device poll, the watchdog). It is now
-  `kSecUseAuthenticationUISkip`: the no-ACL bundle metadata (all the listing needs)
-  still returns, ACL'd value items are silently skipped, and no sheet is shown. This
-  was below the `AGENTS_SECRETS_NO_PROMPT` / `agentOnly` guard, so SEC-13 (#1942) did
-  not cover it. Source: `apps/cli/src/lib/secrets/keychain-helper.swift`.
+  helper's `list` data-protection pass swept every DP item with the default
+  `kSecUseAuthenticationUIAllow`, so a `kSecMatchLimitAll` enumeration evaluated a
+  biometry-ACL'd value item's ACL and showed a real Touch ID sheet on every call — a
+  prompt storm, since `secrets list` runs constantly (bundle resolution, the menubar
+  device poll, the watchdog). It is now `kSecUseAuthenticationUISkip`: the no-ACL
+  bundle metadata (all the listing needs — bundle names come from the metadata, never
+  the value items) still returns, ACL'd value items are silently skipped, and no sheet
+  is shown. This read is below the `AGENTS_SECRETS_NO_PROMPT` / `agentOnly` guard, so
+  SEC-13 (#1942) did not cover it. One narrow behavioral trade: a legacy bundle whose
+  *metadata* item still carries a stray biometry ACL (pre-RUSH-1759, before the
+  one-time no-ACL heal) is now silently skipped by `list` rather than prompted-then-
+  shown; it still resolves and self-heals when read by name. Source:
+  `apps/cli/src/lib/secrets/keychain-helper.swift`.

--- a/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
@@ -198,6 +198,22 @@ describe('keychain-helper has / list still probe both keychains', () => {
     expect(block).toContain('if status == errSecInteractionNotAllowed { continue }');
     expect(block).toContain('kSecReturnAttributes');
   });
+
+  it('list DP pass pins UISkip so a kSecMatchLimitAll sweep never pops a sheet (SEC-14)', () => {
+    // The bug: kSecReturnAttributes does NOT stop the DP keychain from evaluating
+    // a biometry-ACL'd value item's ACL during a kSecMatchLimitAll enumeration.
+    // Under the default UIAllow that pops a real Touch ID sheet on EVERY `list` —
+    // the storm, since `secrets list` runs constantly. UISkip returns the no-ACL
+    // metadata (all `secrets list` needs) and silently skips ACL'd items, no UI.
+    const block = caseBlock(helperSource(), 'list');
+    // The file pass keeps UIFail; the DP pass must carry UISkip (per-item skip,
+    // not the wholesale UIFail error that would drop the metadata too).
+    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUIFail'); // file pass
+    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUISkip'); // DP pass
+    // No query in `list` may request the prompting UI policy (the comment naming
+    // the default is fine — match the query-key form only).
+    expect(block).not.toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUIAllow');
+  });
 });
 
 describe('keychain-helper orphaned-access-group recovery', () => {
@@ -294,6 +310,9 @@ describe('keychain-helper synced (iCloud) recovery verbs', () => {
     expect(block).toContain('kSecReturnAttributes: kCFBooleanTrue!');
     expect(block).not.toContain('kSecReturnData'); // attributes only — never decrypts
     expect(block).toContain('errSecInteractionNotAllowed'); // tolerates a locked keybag
+    // Same SEC-14 no-prompt guard as `list`: an attributes-only sweep still
+    // evaluates a synced item's ACL, so pin UISkip instead of the default UIAllow.
+    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUISkip');
   });
 
   it('get-batch-synced reads via syncedBase and emits get-batch V/M records', () => {

--- a/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
@@ -310,9 +310,11 @@ describe('keychain-helper synced (iCloud) recovery verbs', () => {
     expect(block).toContain('kSecReturnAttributes: kCFBooleanTrue!');
     expect(block).not.toContain('kSecReturnData'); // attributes only — never decrypts
     expect(block).toContain('errSecInteractionNotAllowed'); // tolerates a locked keybag
-    // Same SEC-14 no-prompt guard as `list`: an attributes-only sweep still
-    // evaluates a synced item's ACL, so pin UISkip instead of the default UIAllow.
-    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUISkip');
+    // No UISkip needed: a synchronizable item cannot carry the biometry ACL
+    // (mutually exclusive with ...ThisDeviceOnly), so this sweep never evaluates
+    // an ACL — unlike the device-local `list` DP pass. Guard that it stays that
+    // way (no ACL to skip, and never the prompting UIAllow query form).
+    expect(block).not.toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUIAllow');
   });
 
   it('get-batch-synced reads via syncedBase and emits get-batch V/M records', () => {

--- a/apps/cli/src/lib/secrets/keychain-helper.swift
+++ b/apps/cli/src/lib/secrets/keychain-helper.swift
@@ -357,17 +357,29 @@ switch cmd {
 
 case "list":
     // list <prefix> — enumerate generic-password items whose service starts
-    // with <prefix> for the current user. Returns attributes only (never
-    // data), so it never decrypts and never prompts.
+    // with <prefix> for the current user. Returns attributes only (never data),
+    // so it never decrypts — but it MUST also never prompt, because `secrets
+    // list` and pre-value bundle resolution run this constantly (menubar polling,
+    // the watchdog, every interactive command), and a Touch ID sheet per call is
+    // the prompt storm this verb caused (SEC-14).
     //
-    // Two passes, because no single query covers both keychains: items written
-    // by `set` carry a biometry ACL, which forces them into the data-protection
-    // keychain, and a query with kSecUseAuthenticationUIFail skips the DP
-    // keychain entirely (it errors with errSecInteractionNotAllowed before
-    // returning anything). The DP pass therefore omits the UI key — safe only
-    // because kSecReturnAttributes without kSecReturnData never evaluates the
-    // ACL. Do NOT drop the explicit return key: with no kSecReturn* at all,
-    // SecItemCopyMatching evaluates the ACL anyway and blocks on Touch ID.
+    // Two passes, because no single query covers both keychains: items written by
+    // `set` carry a biometry ACL, which forces them into the data-protection
+    // keychain, while pre-migration items still live in the file-based one.
+    //
+    // Both passes MUST pin an explicit no-UI policy. The earlier belief that
+    // `kSecReturnAttributes` without `kSecReturnData` never evaluates the ACL is
+    // empirically FALSE on the DP keychain: a kSecMatchLimitAll enumeration that
+    // sweeps past a biometry-ACL'd VALUE item evaluates its ACL and, under the
+    // default kSecUseAuthenticationUIAllow, shows a real sheet — even though the
+    // caller only wants the no-ACL metadata/hmackey items (which are all `secrets
+    // list` needs; bundle names come from the `agents-cli.h.<ns>.m` metadata,
+    // never the value items). The fix is kSecUseAuthenticationUISkip on the DP
+    // pass: it returns the no-ACL items and silently SKIPS the ACL'd ones with no
+    // UI. UIFail is wrong here — it errors the whole DP query wholesale
+    // (errSecInteractionNotAllowed) and drops the metadata too; UISkip is
+    // per-item. The file pass keeps UIFail (a UIFail miss there is a clean
+    // errSecItemNotFound, not a wholesale error).
     guard args.count == 3 else { die(2, "Usage: agents-keychain list <prefix>") }
     let prefix = args[2]
     guard !prefix.isEmpty else { die(2, "list requires non-empty prefix") }
@@ -380,14 +392,15 @@ case "list":
     ]
     // DP pass is UN-pinned (no kSecAttrAccessGroup): it spans the concrete group
     // AND any pre-#279 orphan group, so bundles whose metadata is orphaned still
-    // appear in `secrets list` instead of vanishing. Attributes-only, so it never
-    // decrypts or prompts regardless of group.
+    // appear in `secrets list` instead of vanishing. UISkip keeps it prompt-free
+    // while still returning every no-ACL metadata item.
     let dpQuery: [CFString: Any] = [
         kSecClass: kSecClassGenericPassword,
         kSecMatchLimit: kSecMatchLimitAll,
         kSecReturnAttributes: kCFBooleanTrue!,
         kSecUseDataProtectionKeychain: kCFBooleanTrue!,
         kSecAttrSynchronizable: kCFBooleanFalse!,
+        kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
     ]
     var items: [[String: Any]] = []
     for query in [fileQuery, dpQuery] {
@@ -797,8 +810,11 @@ case "list-synced":
     // generic-password items whose service starts with <prefix> for the current
     // user. These are pre-biometry-era bundles orphaned by the device-local
     // cutover; every modern query pins kSecAttrSynchronizable false, so this is
-    // the only verb that can see them. Attributes only — never decrypts, never
-    // prompts. Prints one service name per line.
+    // the only verb that can see them. Attributes only — never decrypts. UISkip
+    // keeps it prompt-free even if a synced item carries a biometry ACL: an
+    // attributes-only kSecMatchLimitAll sweep still evaluates the ACL and would
+    // otherwise pop a sheet under the default UIAllow (same SEC-14 bug the `list`
+    // verb had). Prints one service name per line.
     guard args.count == 3 else { die(2, "Usage: agents-keychain list-synced <prefix>") }
     let prefix = args[2]
     guard !prefix.isEmpty else { die(2, "list-synced requires non-empty prefix") }
@@ -809,6 +825,7 @@ case "list-synced":
         kSecReturnAttributes: kCFBooleanTrue!,
         kSecUseDataProtectionKeychain: kCFBooleanTrue!,
         kSecAttrSynchronizable: kCFBooleanTrue!,
+        kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
     ]
     var syncedResult: AnyObject?
     let syncedStatus = SecItemCopyMatching(syncedQuery as CFDictionary, &syncedResult)

--- a/apps/cli/src/lib/secrets/keychain-helper.swift
+++ b/apps/cli/src/lib/secrets/keychain-helper.swift
@@ -674,8 +674,11 @@ case "list-orphans":
     // list-orphans <prefix> <account> — enumerate data-protection items whose
     // service starts with <prefix> for <account> that live under a NON-concrete
     // access group (pre-#279 orphans filed under the implicit default group).
-    // Attributes only — never decrypts, never prompts. Prints one orphaned
-    // service per line; used by `migrate-acl` for its prompt-free dry-run report.
+    // Attributes only — never decrypts. Unlike `list`, this keeps the default
+    // UIAllow: an ACL'd orphan MUST stay visible here so `migrate-acl` can re-home
+    // it, so a kSecMatchLimitAll sweep past a biometry-ACL'd item may pop one sheet
+    // — acceptable because this runs only from the interactive `secrets migrate`
+    // command, never the hot path. Prints one orphaned service per line.
     guard args.count == 4 else { die(2, "Usage: agents-keychain list-orphans <prefix> <account>") }
     let (prefix, account) = (args[2], args[3])
     guard !prefix.isEmpty else { die(2, "list-orphans requires non-empty prefix") }
@@ -810,11 +813,11 @@ case "list-synced":
     // generic-password items whose service starts with <prefix> for the current
     // user. These are pre-biometry-era bundles orphaned by the device-local
     // cutover; every modern query pins kSecAttrSynchronizable false, so this is
-    // the only verb that can see them. Attributes only — never decrypts. UISkip
-    // keeps it prompt-free even if a synced item carries a biometry ACL: an
-    // attributes-only kSecMatchLimitAll sweep still evaluates the ACL and would
-    // otherwise pop a sheet under the default UIAllow (same SEC-14 bug the `list`
-    // verb had). Prints one service name per line.
+    // the only verb that can see them. Attributes only — never decrypts, and
+    // never prompts: a synchronizable item cannot carry the biometry ACL
+    // (kSecAttrSynchronizable is mutually exclusive with the ...ThisDeviceOnly
+    // accessibility the ACL requires — see `get-batch-synced`), so this sweep has
+    // no ACL to evaluate. Prints one service name per line.
     guard args.count == 3 else { die(2, "Usage: agents-keychain list-synced <prefix>") }
     let prefix = args[2]
     guard !prefix.isEmpty else { die(2, "list-synced requires non-empty prefix") }
@@ -825,7 +828,6 @@ case "list-synced":
         kSecReturnAttributes: kCFBooleanTrue!,
         kSecUseDataProtectionKeychain: kCFBooleanTrue!,
         kSecAttrSynchronizable: kCFBooleanTrue!,
-        kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
     ]
     var syncedResult: AnyObject?
     let syncedStatus = SecItemCopyMatching(syncedQuery as CFDictionary, &syncedResult)


### PR DESCRIPTION
**bug fix — macOS keychain / secrets. Kills the `agents secrets` Touch ID prompt storm that SEC-13 (#1942 / 1.22.5) did not fix.**

## What & why

The signed keychain helper's `list` (and `list-synced`) **data-protection keychain pass** enumerates with `kSecMatchLimitAll` but omits `kSecUseAuthenticationUI`, so it defaults to `kSecUseAuthenticationUIAllow`. Contrary to the old comment ("`kSecReturnAttributes` without `kSecReturnData` never evaluates the ACL"), an attributes-only `kSecMatchLimitAll` sweep that passes a **biometry-ACL'd value item** *does* evaluate its ACL and, under `UIAllow`, **shows a real Touch ID sheet on every call**.

`list` runs constantly — bundle resolution on essentially every `agents` command, the menubar device poll, the watchdog — so this is the prompt storm. It sits **below** the `AGENTS_SECRETS_NO_PROMPT` / `agentOnly` TS-layer guard (it's in the Swift helper), which is why SEC-13 (#1942) never covered it and why the env override cannot suppress it.

## The fix

Pin **`kSecUseAuthenticationUISkip`** on the DP pass of `list` and `list-synced`:
- returns the **no-ACL bundle metadata** (`agents-cli.h.<ns>.m`) — the only thing `secrets list` needs; bundle names come from metadata, never the value items
- **silently skips** ACL'd value items with **no UI**

`UIFail` would be wrong here — it errors the whole DP query wholesale (`errSecInteractionNotAllowed`) and drops the metadata too; `UISkip` is per-item. The **file pass keeps `UIFail`** (a miss there is a clean `errSecItemNotFound`). `list-orphans` / `migrate-orphans` deliberately keep `UIAllow` — they must *see* ACL'd orphans to re-home them and are explicit interactive commands, not the hot path.

## Evidence (measured on zion, installed 1.22.5, per-`clientPid` correlation)

Each direct signed-helper invocation, sheets attributed to that exact pid:

| helper op | UI policy on its queries | ACL-evaluated / 6 | **sheet shown / 6** |
|---|---|---|---|
| `has` | `UIFail` on every pass | 0 | **0** |
| `list-legacy` | `UIFail`, no DP pass | 6 | **0** |
| `list` (current) | file `UIFail` + **DP pass no flag → UIAllow** | 6 | **6** |

`has` and `list-legacy` prove a no-UI policy suppresses the sheet; `list`'s DP pass, lacking one, shows a sheet every call. That is the storm, one-to-one.

## Tests

`apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts` — added guards asserting the `list` and `list-synced` DP passes carry `UISkip` (and no `UIAllow` query). **23/23 pass.**

## Verification note

The live "list still shows all bundles + 0 sheets" check requires the **entitled, signed** helper (macOS 26 blocks unentitled DP-keychain access with `-34018`), which only the release build produces. That end-to-end check runs on `zion` against the released helper immediately after this ships; the mechanism above is already proven by the clientPid correlation and the source-assertion tests.
