### PR TITLE
release(factory): fold CHANGELOG for 0.9.311

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.311] - 2026-08-04
+
 - **Removed the `agents.terminalMode` setting — tmux is always on when available.**
   The extension no longer exposes an `auto` / `tmux` / `native` "terminal mode".
   tmux is the default for every agent and shell terminal (giving each a named,


### PR DESCRIPTION
**release-prep / docs-only.** Promotes the `## [Unreleased]` Factory entries into a versioned `## [0.9.311]` section so `scripts/release.sh 0.9.311` can publish (it requires a matching version header).

Ships the accumulated Factory changes since 0.9.310:
- fork opens as a normal tab, not a side split (#1909)
- Enable/Disable Tmux palette commands removed (#1910)
- every agent launch is balanced (#1908)
- `agents.terminalMode` removed — tmux always on (#1939)
- fleet-health probe dedup

No code change — CHANGELOG header only.