### PR TITLE
fix(cli): 5m file-only usage refresh, concurrency-safe cache

### DIFF
--- a/apps/cli/.changelog/next/usage-refresh-5m-file-safe.md
+++ b/apps/cli/.changelog/next/usage-refresh-5m-file-safe.md
@@ -1,0 +1,9 @@
+- **Daemon usage refresh is a fixed 5-minute per-host schedule, concurrency-safe, and Touch-ID-free.**
+  Each machine's daemon still owns its own usage cache (no fleet-wide store). Account live
+  fetches are now scheduled every **5 minutes** (was adaptive 90s–15m), with a 60s wake to
+  notice due accounts after backoff ends. Cache writes use a file lock + atomic rename so a
+  concurrent `agents view` background refresh cannot tear or drop rows. The daemon path
+  loads Claude credentials with **`fileOnly`** (setup-token / no-ACL cache / `.credentials.json`
+  only) and never opens the ACL-bound macOS keychain item, so a background tick cannot pop
+  Touch ID. Refresh still skips a provider under 429 backoff and still never rotates
+  single-use Claude refresh tokens.

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -876,14 +876,14 @@ export async function runDaemon(): Promise<void> {
   const fleetCacheInterval = setInterval(() => { void runFleetCacheWarm(); }, 3 * 60_000);
   const fleetCacheKickoff = setTimeout(() => { void runFleetCacheWarm(); }, 60_000);
 
-  // Adaptive usage refresh: keep the usage cache the `agents run` router reads
+  // Usage refresh: keep the usage cache the `agents run` router reads
   // (RUSH-2061, readOnly hot path) fresh, WITHOUT the hot path ever fetching.
-  // This host is the sole writer for its own local accounts. The tick wakes at
-  // the 90s floor, but per-account cadence gates the actual live fetches: an
-  // account racing toward its 5h cap is polled sooner (down to 90s), an idle one
-  // rarely (up to 15min), capped at ~6 provider calls/account/hour and skipped
-  // entirely while its provider is under a 429 backoff. Overlap-guarded like the
-  // probes above; a box signed into no networked-usage account is a clean no-op.
+  // This host is the sole writer for its own local accounts. The tick wakes
+  // every 60s (USAGE_REFRESH_TICK_MS) to consider due accounts; each account
+  // is scheduled at a fixed 5-minute cadence (REFRESH_INTERVAL_MS), capped at
+  // ~12 provider calls/account/hour, skipped under 429 backoff, and fetched
+  // with fileOnly credentials so a background tick never pops macOS Touch ID.
+  // Overlap-guarded: a slow pass cannot stack concurrent refresh loops.
   let refreshingUsage = false;
   const runUsageRefreshTick = async () => {
     if (refreshingUsage) return;
@@ -897,16 +897,20 @@ export async function runDaemon(): Promise<void> {
         writeUsageCache: writeClaudeUsageCache,
         backoffUntil: usageRateLimitedUntil,
       });
-      if (r.refreshed > 0 || r.failed > 0) {
-        log('INFO', `usage refresh: ${r.refreshed} refreshed, ${r.failed} failed, ${r.skippedNotDue} not-due, ${r.skippedBackoff} backed-off, ${r.skippedCap} capped`);
-      }
+      // Always log a compact summary so "is refresh working?" is greppable even
+      // when every account was not-due (proves the tick ran).
+      log(
+        'INFO',
+        `usage refresh: ${r.refreshed} refreshed, ${r.failed} failed, ${r.skippedNotDue} not-due, ${r.skippedBackoff} backed-off, ${r.skippedCap} capped`,
+      );
     } catch (err) {
       log('ERROR', `usage refresh failed: ${(err as Error).message}`);
     } finally {
       refreshingUsage = false;
     }
   };
-  const usageRefreshInterval = setInterval(() => { void runUsageRefreshTick(); }, 90_000);
+  // 60s wake matches USAGE_REFRESH_TICK_MS in usage-refresh.ts (keep in sync).
+  const usageRefreshInterval = setInterval(() => { void runUsageRefreshTick(); }, 60_000);
   const usageRefreshKickoff = setTimeout(() => { void runUsageRefreshTick(); }, 30_000);
 
   // RUSH-1817: the startup host decision above is one-shot. If a standalone

--- a/apps/cli/src/lib/usage-refresh.test.ts
+++ b/apps/cli/src/lib/usage-refresh.test.ts
@@ -4,10 +4,12 @@ import * as os from 'os';
 import * as path from 'path';
 
 import {
+  REFRESH_INTERVAL_MS,
   REFRESH_MIN_MS,
   REFRESH_MAX_MS,
   REFRESH_BURN_DIVISOR,
   HOURLY_CALL_CAP,
+  USAGE_REFRESH_TICK_MS,
   computeNextRefreshDelayMs,
   pruneCallTimestamps,
   shouldRefreshAccount,
@@ -30,24 +32,28 @@ const sessionSnap = (usedPercent: number, capturedAtMs: number): UsageSnapshot =
   ],
 });
 
-describe('computeNextRefreshDelayMs — adaptive cadence clamped to [90s, 15min]', () => {
-  it('polls sooner the closer an account is to its cap', () => {
-    // minutesToLimit / K minutes, in ms, but never below the 90s floor.
-    const far = computeNextRefreshDelayMs(600); // 600/4 = 150min -> clamped to MAX
-    const near = computeNextRefreshDelayMs(20); // 20/4 = 5min -> 300_000ms
-    expect(far).toBe(REFRESH_MAX_MS);
+describe('computeNextRefreshDelayMs — fixed 5-minute production cadence', () => {
+  it('defaults to the 5-minute interval regardless of burn projection', () => {
+    expect(REFRESH_INTERVAL_MS).toBe(5 * 60 * 1000);
+    expect(REFRESH_MIN_MS).toBe(REFRESH_INTERVAL_MS);
+    expect(REFRESH_MAX_MS).toBe(REFRESH_INTERVAL_MS);
+    expect(USAGE_REFRESH_TICK_MS).toBe(60_000);
+    expect(computeNextRefreshDelayMs(600)).toBe(REFRESH_INTERVAL_MS);
+    expect(computeNextRefreshDelayMs(20)).toBe(REFRESH_INTERVAL_MS);
+    expect(computeNextRefreshDelayMs(0)).toBe(REFRESH_INTERVAL_MS);
+    expect(computeNextRefreshDelayMs(null)).toBe(REFRESH_INTERVAL_MS);
+  });
+
+  it('still supports a wider clamp when a test/caller passes min/max', () => {
+    // minutesToLimit / K with an explicit wide range: 20/4 = 5min.
+    const near = computeNextRefreshDelayMs(20, {
+      minMs: 90_000,
+      maxMs: 15 * 60_000,
+      divisor: REFRESH_BURN_DIVISOR,
+    });
     expect(near).toBe((20 / REFRESH_BURN_DIVISOR) * 60_000);
-    expect(near).toBeLessThan(far);
-  });
-
-  it('never polls faster than the floor, even seconds from the cap', () => {
-    expect(computeNextRefreshDelayMs(0)).toBe(REFRESH_MIN_MS);
-    expect(computeNextRefreshDelayMs(1)).toBe(REFRESH_MIN_MS);
-  });
-
-  it('waits the full ceiling when there is no projection', () => {
-    expect(computeNextRefreshDelayMs(null)).toBe(REFRESH_MAX_MS);
-    expect(computeNextRefreshDelayMs(Number.POSITIVE_INFINITY)).toBe(REFRESH_MAX_MS);
+    const far = computeNextRefreshDelayMs(600, { minMs: 90_000, maxMs: 15 * 60_000 });
+    expect(far).toBe(15 * 60_000);
   });
 });
 
@@ -82,16 +88,16 @@ describe('the rolling-hour call cap bounds provider load', () => {
 });
 
 describe('nextHeadroomEntry — projects, schedules, and records the call', () => {
-  it('carries the burn projection into the schedule', () => {
+  it('records burn projection but schedules the fixed 5-minute cadence', () => {
     const prev: HeadroomEntry = {
       status: 'available', minutesToLimit: null, sessionUsedPercent: 50, capturedAt: NOW - 10 * 60_000,
       nextRefreshAt: NOW - 1, callTimestamps: [], computedAt: NOW - 10 * 60_000,
     };
-    // 50 -> 70 over 10min = 2%/min; 30% left => 15min to cap.
+    // 50 -> 70 over 10min = 2%/min; 30% left => 15min to cap (projection still computed).
     const entry = nextHeadroomEntry(prev, sessionSnap(70, NOW), NOW);
     expect(entry.minutesToLimit).toBeCloseTo(15, 5);
-    // Scheduled at minutesToLimit / K.
-    expect(entry.nextRefreshAt - NOW).toBe((15 / REFRESH_BURN_DIVISOR) * 60_000);
+    // Production cadence is fixed 5 minutes (floor = ceiling = REFRESH_INTERVAL_MS).
+    expect(entry.nextRefreshAt - NOW).toBe(REFRESH_INTERVAL_MS);
     expect(entry.sessionUsedPercent).toBe(70);
     expect(entry.callTimestamps).toContain(NOW);
   });
@@ -147,5 +153,27 @@ describe('runUsageRefresh — refreshes only due, uncapped, un-backed-off local 
     expect(called).toBe(false);
     expect(result.skippedBackoff).toBe(1);
     expect(result.refreshed).toBe(0);
+  });
+
+  it('schedules the next attempt 5 minutes out after a successful refresh', async () => {
+    const key = 'claude:org=sched';
+    await runUsageRefresh({
+      now: NOW,
+      listAccounts: async () => [
+        { usageKey: key, agentId: 'claude', fetch: async () => ({ snapshot: sessionSnap(40, NOW), error: null }) },
+      ],
+      writeUsageCache: writeClaudeUsageCache,
+      backoffUntil: () => null,
+    });
+    const entry = readHeadroomEntry(key);
+    expect(entry?.nextRefreshAt).toBe(NOW + REFRESH_INTERVAL_MS);
+  });
+
+  it('does not lose concurrent cache writes for different accounts (lock merge)', async () => {
+    // Two serial writeClaudeUsageCache calls under lock must both land.
+    writeClaudeUsageCache('claude:org=a', sessionSnap(10, NOW));
+    writeClaudeUsageCache('claude:org=b', sessionSnap(20, NOW));
+    expect(readClaudeUsageCache('claude:org=a')?.windows[0]?.usedPercent).toBe(10);
+    expect(readClaudeUsageCache('claude:org=b')?.windows[0]?.usedPercent).toBe(20);
   });
 });

--- a/apps/cli/src/lib/usage-refresh.ts
+++ b/apps/cli/src/lib/usage-refresh.ts
@@ -1,36 +1,54 @@
 /**
- * Daemon-owned adaptive usage refresher.
+ * Daemon-owned usage refresher (per host).
  *
  * The routing hot path (`agents run` → collectRunCandidates) reads usage
  * CACHE-ONLY (`getUsageInfoForIdentity` `readOnly`, RUSH-2061) and never blocks
  * on a provider fetch. Something still has to keep that cache fresh — this
- * module is that something, running inside the daemon.
+ * module is that something, running inside the daemon on **each machine**.
  *
- * Design (per account, this host is the SOLE writer — the refresher only ever
- * touches accounts whose credentials live locally, so no cross-host
- * coordination and no shared-token contention):
+ * Design:
  *
- *  - **Adaptive cadence from burn rate.** Each refresh stores the session
- *    window's `usedPercent` + `capturedAt`. The next refresh is scheduled from
- *    `deriveUsageHeadroom`'s projected `minutesToLimit`: an account racing
- *    toward its cap is polled more often (down to 90s), an idle one rarely (up
- *    to 15min). `computeNextRefreshDelayMs` is the pure clamp.
- *  - **Hard hourly cap.** Regardless of cadence, at most `HOURLY_CALL_CAP` live
- *    fetches per account per rolling hour, so a fast burn can't turn the 90s
- *    floor into a hammering loop.
- *  - **Respects the existing 429 backoff.** A provider under
- *    `usageRateLimitedUntil` is skipped entirely — the whole point of the
- *    backoff is to stop poking an endpoint that just said no.
+ *  - **Per-host sole writer.** Only accounts whose credentials live on THIS
+ *    box are listed; no fleet-wide usage sync.
+ *  - **Fixed 5-minute cadence** (`REFRESH_INTERVAL_MS`). Enough to keep
+ *    balanced/`agents view` off multi-hour stale data without thrashing
+ *    provider APIs when the user runs agents frequently. The delay helpers
+ *    still accept a burn projection for tests/future tuning, but the default
+ *    floor and ceiling are both 5 minutes.
+ *  - **Hard hourly cap** (`HOURLY_CALL_CAP`) so a stuck "due" loop cannot
+ *    hammer an endpoint past ~12 calls/account/hour.
+ *  - **429 backoff.** A provider under `usageRateLimitedUntil` is skipped
+ *    entirely — no live fetch, no Touch ID, no re-armed penalty.
+ *  - **File-only credentials on the daemon path.** Refresh never opens the
+ *    ACL-bound macOS keychain item (Touch ID storm). It uses the no-ACL
+ *    access-token cache / setup-token / `.credentials.json` only
+ *    (`fileOnly: true` on `getUsageInfo`).
+ *  - **Concurrency-safe cache writes.** Usage + headroom files are updated
+ *    under `withFileLock` + atomic rename so a concurrent `agents view`
+ *    background refresh cannot tear or drop another account's row.
  *
- * It also publishes the projected headroom (`minutesToLimit` + status) to a
- * small cache keyed by usage key, so the routing hot path can deprioritize an
- * account projected to cap without recomputing a burn rate it has no prior
- * sample for. `fleet-cache.ts` is the sync reader.
+ * Scenarios (what this path must survive):
+ *
+ *  1. **Daemon tick overlaps a slow tick** — overlap guard in daemon.ts;
+ *     second tick is a no-op.
+ *  2. **`agents view` writes cache while daemon refreshes** — file lock
+ *     serializes read-modify-write; no lost updates.
+ *  3. **macOS keychain ACL / Touch ID** — fileOnly refresh never calls
+ *     `security find-generic-password` on Claude's ACL item.
+ *  4. **Provider 429** — whole provider skipped until Retry-After; cache
+ *     freezes (visible as aged `capturedAt`) rather than hammering.
+ *  5. **Expired access token (no refresh)** — usage path never rotates
+ *     single-use refresh tokens; counts as `failed`, reschedules 5m later.
+ *  6. **No file credential on this host** — account skipped / failed; no
+ *     keychain fallback from the daemon refresher.
+ *  7. **Grok/Codex (network:false)** — not listed by `buildLocalUsageAccounts`;
+ *     their "cache" is local logs, not this HTTP refresher.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 
 import { getCacheDir } from './state.js';
+import { atomicWriteFileSync, ensureLockTarget, withFileLock } from './fs-atomic.js';
 import {
   deriveUsageHeadroom,
   getUsageInfo,
@@ -46,17 +64,24 @@ import { getAccountInfo } from './agents.js';
 import { listInstalledVersions, getVersionHomePath } from './versions.js';
 import type { AgentId } from './types.js';
 
-/** Floor on the adaptive interval: an account seconds from its cap still isn't
- * polled faster than this. */
-export const REFRESH_MIN_MS = 90 * 1000;
-/** Ceiling on the adaptive interval: an idle account is still re-checked at
- * least this often so a cache never silently rots. */
-export const REFRESH_MAX_MS = 15 * 60 * 1000;
-/** Schedule the next refresh at `minutesToLimit / K` — poll well before the cap,
- * not exactly at it. */
+/**
+ * Default schedule between successful (or attempted) live usage fetches for one
+ * account. Floor and ceiling of the delay helper are pinned to this so the
+ * daemon does not poll faster than 5 minutes even under high burn, and does not
+ * let an idle account rot longer than 5 minutes between attempts.
+ */
+export const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+/** @deprecated alias — use {@link REFRESH_INTERVAL_MS}. Kept for test imports. */
+export const REFRESH_MIN_MS = REFRESH_INTERVAL_MS;
+/** @deprecated alias — use {@link REFRESH_INTERVAL_MS}. Kept for test imports. */
+export const REFRESH_MAX_MS = REFRESH_INTERVAL_MS;
+/** Burn-rate divisor retained for the pure delay helper / tests; with min=max
+ * the divisor does not change the scheduled interval. */
 export const REFRESH_BURN_DIVISOR = 4;
-/** At most this many live fetches per account per rolling hour. */
-export const HOURLY_CALL_CAP = 6;
+/** At most this many live fetches per account per rolling hour (5m cadence ⇒ 12). */
+export const HOURLY_CALL_CAP = 12;
+/** How often the daemon wakes to *consider* a refresh pass (due accounts only). */
+export const USAGE_REFRESH_TICK_MS = 60 * 1000;
 const HOUR_MS = 60 * 60 * 1000;
 
 /**
@@ -114,29 +139,33 @@ export function readHeadroomEntry(usageKey: string): HeadroomEntry | null {
 /** Merge entries into the cache (best-effort; preserves other accounts' rows). */
 export function writeHeadroomEntries(entries: Record<string, HeadroomEntry>): void {
   try {
-    const dir = getCacheDir();
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    const merged: HeadroomCacheFile = {
-      version: 1,
-      entries: { ...readHeadroomCache(), ...entries },
-    };
-    fs.writeFileSync(headroomCachePath(), JSON.stringify(merged, null, 2));
+    const cachePath = headroomCachePath();
+    ensureLockTarget(cachePath, JSON.stringify({ version: 1, entries: {} }, null, 2));
+    withFileLock(cachePath, () => {
+      // Re-read under the lock so a concurrent tick/view cannot drop rows.
+      const merged: HeadroomCacheFile = {
+        version: 1,
+        entries: { ...readHeadroomCache(), ...entries },
+      };
+      atomicWriteFileSync(cachePath, JSON.stringify(merged, null, 2));
+    });
   } catch {
     // best-effort; a failed write just means the router sees no projection
   }
 }
 
 /**
- * The adaptive interval until the next refresh, clamped to [MIN, MAX]. A
- * shorter `minutesToLimit` (closer to the cap) polls sooner; `null` (unknown /
- * idle / not burning) waits the full ceiling.
+ * Interval until the next refresh attempt, clamped to [minMs, maxMs].
+ * Defaults pin both ends to {@link REFRESH_INTERVAL_MS} (5 minutes) so the
+ * live daemon path is a fixed schedule. Tests may pass a wider range to
+ * exercise burn-aware scheduling without changing production cadence.
  */
 export function computeNextRefreshDelayMs(
   minutesToLimit: number | null,
   opts: { minMs?: number; maxMs?: number; divisor?: number } = {},
 ): number {
-  const minMs = opts.minMs ?? REFRESH_MIN_MS;
-  const maxMs = opts.maxMs ?? REFRESH_MAX_MS;
+  const minMs = opts.minMs ?? REFRESH_INTERVAL_MS;
+  const maxMs = opts.maxMs ?? REFRESH_INTERVAL_MS;
   const divisor = opts.divisor ?? REFRESH_BURN_DIVISOR;
   if (minutesToLimit === null || !Number.isFinite(minutesToLimit)) return maxMs;
   const targetMs = (minutesToLimit / divisor) * 60_000;
@@ -233,11 +262,15 @@ export async function buildLocalUsageAccounts(): Promise<LocalUsageAccount[]> {
       accounts.push({
         usageKey,
         agentId,
+        // fileOnly: never open the ACL-bound keychain item from the daemon —
+        // that path is the Touch ID storm. Usage reads setup-token /
+        // no-ACL cache / .credentials.json only (see loadClaudeOauth).
         fetch: () =>
           getUsageInfo(agentId, {
             home: fetchInput.home,
             cliVersion: fetchInput.cliVersion,
             organizationId: fetchInput.organizationId,
+            fileOnly: true,
           }),
       });
     }

--- a/apps/cli/src/lib/usage.test.ts
+++ b/apps/cli/src/lib/usage.test.ts
@@ -267,6 +267,18 @@ describe('loadClaudeOauth — file-based `auth` setup-token (Touch-ID-free usage
     const oauth = await loadClaudeOauth(home);
     expect(oauth).toBeNull();
   });
+
+  it('fileOnly never opens the ACL keychain even without a setup-token', async () => {
+    // Strip the email so resolveClaudeSetupToken cannot map home -> setup-token KEY.
+    fs.writeFileSync(path.join(home, '.claude', '.claude.json'), JSON.stringify({}));
+    fs.writeFileSync(
+      path.join(home, '.claude', '.credentials.json'),
+      JSON.stringify({ claudeAiOauth: { accessToken: 'file-only-token', expiresAt: Date.now() + 3_600_000 } }),
+    );
+    // makeThrowingKeychain is installed — if fileOnly fell through to ACL keychain, this throws.
+    const oauth = await loadClaudeOauth(home, { accessTokenCache: true, fileOnly: true });
+    expect(oauth?.accessToken).toBe('file-only-token');
+  });
 });
 
 describe('swrWindowMsFor — a routing decision does not get day-old data', () => {

--- a/apps/cli/src/lib/usage.ts
+++ b/apps/cli/src/lib/usage.ts
@@ -35,6 +35,7 @@ import {
 import { getCacheDir } from './state.js';
 import type { AgentId } from './types.js';
 import { mapBounded } from './concurrency.js';
+import { atomicWriteFileSync, ensureLockTarget, withFileLock } from './fs-atomic.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -197,6 +198,13 @@ interface UsageOptions {
   home?: string;
   cliVersion?: string | null;
   organizationId?: string | null;
+  /**
+   * When true, never open the ACL-bound OS keychain item (macOS Touch ID).
+   * Daemon usage refresh sets this so a background tick cannot pop biometrics.
+   * Credentials come from the no-ACL access-token cache, a file-based
+   * setup-token, or `<home>/.claude/.credentials.json` only.
+   */
+  fileOnly?: boolean;
 }
 
 /** Canonical input for a single usage fetch operation. */
@@ -938,7 +946,12 @@ async function getClaudeUsageInfo(options?: UsageOptions): Promise<UsageInfo> {
   try {
     // Opt into the no-ACL access-token cache: this is the every-60s watchdog hot
     // path and usage needs only the access token, so it kills the Touch ID storm.
-    const oauth = await loadClaudeOauth(options?.home, { accessTokenCache: true });
+    // Daemon refresh also sets fileOnly so we never fall through to the ACL
+    // keychain item (that path is the Touch ID prompt).
+    const oauth = await loadClaudeOauth(options?.home, {
+      accessTokenCache: true,
+      fileOnly: options?.fileOnly === true,
+    });
     if (!oauth?.accessToken) {
       return { snapshot: null, error: usageNoCredentialError('Claude') };
     }
@@ -1726,10 +1739,14 @@ function deleteCachedClaudeOauth(service: string): void {
  * `getClaudeAccessToken`) or export the full blob (`readClaudeCredentialsBlob`
  * for Rush Cloud dispatch) must NOT pass it. Only the read-only, high-frequency
  * access-token-only consumers (the usage fetch and the auth-health probe) opt in.
+ *
+ * `opts.fileOnly` (implies access-token-only consumers) skips the ACL keychain
+ * read entirely — setup-token, no-ACL cache, and `.credentials.json` only. Used
+ * by the daemon usage refresher so a background tick can never pop Touch ID.
  */
 export async function loadClaudeOauth(
   home?: string,
-  opts?: { accessTokenCache?: boolean }
+  opts?: { accessTokenCache?: boolean; fileOnly?: boolean }
 ): Promise<ClaudeOauthCredentials | null> {
   // Read-only usage/probe callers (accessTokenCache) authenticate with a
   // file-based setup-token when one is provisioned: the usage endpoint accepts
@@ -1756,7 +1773,13 @@ export async function loadClaudeOauth(
   // anywhere, so the platform check must yield to it exactly as the inner
   // claudeOauthCacheActive() gate does — otherwise this whole block is dead on
   // a Windows runner and the tests below it read an empty home.
-  if (process.platform === 'darwin' || process.platform === 'linux' || isKeychainBackendOverridden()) {
+  //
+  // fileOnly: daemon refresh must never open the ACL-bound item (Touch ID).
+  // It may still read the no-ACL cache item (set-no-acl — prompt-free).
+  if (
+    !opts?.fileOnly
+    && (process.platform === 'darwin' || process.platform === 'linux' || isKeychainBackendOverridden())
+  ) {
     const service = getClaudeKeychainService(home);
     // Serve the no-ACL cache first (opt-in, macOS/test only) so the ACL-gated read
     // below — the one that pops Touch ID — happens at most once per token lifetime
@@ -1778,6 +1801,11 @@ export async function loadClaudeOauth(
       // Evict any stale no-ACL cache so a sign-out/deletion isn't masked.
       if (cacheActive) deleteCachedClaudeOauth(service);
     }
+  } else if (opts?.fileOnly === true && opts?.accessTokenCache === true && claudeOauthCacheActive()) {
+    // fileOnly + accessTokenCache: still allow the no-ACL cache (never Touch ID).
+    const service = getClaudeKeychainService(home);
+    const cached = readCachedClaudeOauth(service);
+    if (cached) return cached;
   }
 
   const credsPath = path.join(home ?? os.homedir(), '.claude', '.credentials.json');
@@ -1904,9 +1932,18 @@ export function writeClaudeUsageCache(
   snapshot: UsageSnapshot,
   cachePath = getClaudeUsageCachePath()
 ): void {
-  const cache = readClaudeUsageCacheFile(cachePath);
-  cache[usageKey] = serializeClaudeUsageSnapshot(snapshot);
-  writeClaudeUsageCacheFile(cache, cachePath);
+  try {
+    ensureLockTarget(cachePath, '{}');
+    withFileLock(cachePath, () => {
+      // Re-read under the lock so a concurrent daemon tick / agents view
+      // refresh cannot drop another account's row (lost update).
+      const cache = readClaudeUsageCacheFile(cachePath);
+      cache[usageKey] = serializeClaudeUsageSnapshot(snapshot);
+      atomicWriteFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
+    });
+  } catch {
+    /* best-effort cache write — lock busy or disk full */
+  }
 }
 
 /** Read the entire usage cache file from disk. */
@@ -1930,7 +1967,7 @@ function writeClaudeUsageCacheFile(
 ): void {
   try {
     fs.mkdirSync(path.dirname(cachePath), { recursive: true });
-    fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
+    atomicWriteFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf-8');
   } catch {
     /* best-effort cache write */
   }


### PR DESCRIPTION
## Summary

Daemon usage refresh (per host) is now a fixed 5-minute schedule, concurrency-safe against concurrent writers, and Touch-ID-free (no ACL keychain reads on the daemon path).

This does not split the daemon. It hardens the existing refresher so frequent agent use stays off multi-hour stale usage without keychain prompts.

## What changed

- Cadence: adaptive 90s-15m -> fixed 5 minutes per account
- Daemon wake: 90s -> 60s (due accounts only)
- Hourly cap: 6 -> 12 (matches 5m)
- Cache writes: unlocked RMW -> file lock + atomic rename
- Daemon Claude credentials: fileOnly (setup-token / no-ACL cache / .credentials.json only)
- Tick logging: always logs summary so grepping proves the tick ran

## Scenarios covered

1. Overlapping daemon ticks — existing refreshingUsage guard; second tick no-ops.
2. agents view + daemon both writing cache — lock merge; both accounts land.
3. macOS Touch ID — daemon never opens ACL keychain item.
4. Provider 429 — whole provider skipped until Retry-After (unchanged).
5. Expired access token — no refresh-token rotation; fail + reschedule 5m.
6. No file credential — fail/skip; no keychain fallback from daemon path.
7. Grok/Codex — still not on this HTTP refresher (local logs only).

## Test plan

- vitest run src/lib/usage-refresh.test.ts src/lib/usage.test.ts (55 pass)
- After merge: confirm daemon log lines "usage refresh: N refreshed..." on a host
- Confirm cache capturedAt ages stay under ~5-10m for network accounts when not 429-backed-off

## Notes

- Still per device — each host runs its own daemon refresh.
- Does not fix Grok log staleness (separate path).
- 429 backoff can still freeze Claude rows until the window ends.

refactor / test-only surface for PR proof: unit tests + changelog fragment.
