### PR TITLE
fix(projects): stamp local sessions so agents roster is not @local

### DIFF
--- a/apps/cli/.changelog/next/projects-stamp-local-machine.md
+++ b/apps/cli/.changelog/next/projects-stamp-local-machine.md
@@ -1,0 +1,1 @@
+- **`projects status --fleet` no longer labels this box `@local`.** Local sessions from `getActiveSessions()` lacked `machine`; host-grouped agents stamped remotes only. Locals are now filled with `machineId()` before rollup so the agents roster and fleet lines agree. Source: `apps/cli/src/lib/project-status.ts`, `commands/projects.ts`.

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -115,11 +115,12 @@ whether you typed `status` or `view`.
 ## The progress card — `agents projects status`
 
 The headline. It matches every live session to a project **by cwd** (longest root
-wins) and rolls up the signals already on disk. The live-agent rollup is over this
-machine's active sessions (the same set `agents sessions --active` shows, matched by
-local-home cwd); the **merged-PR count is repo-global** (via `gh`). A fleet-wide live
-rollup — SSH fan-out plus home-relative cwd matching so a session recorded on a
-different-home machine still matches — is a deferred follow-up (see below):
+wins) and rolls up the signals already on disk. The live-agent rollup defaults to this machine's active sessions (the same set
+`agents sessions --active` shows, matched by local-home cwd); the **merged-PR
+count is repo-global** (via `gh`). With `--fleet`, the live line also includes
+sessions fanned out over SSH — but cwd matching is still against the **local**
+home layout, so a peer session whose path uses a different home root may not
+attribute. Full home-relative matching across homes remains deferred (see below):
 
 ```
 rush  ·  23 live

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -47,6 +47,7 @@ import {
 } from '../lib/projects.js';
 import {
   rollupSessionsByProject,
+  withDefaultMachine,
   isDeadStatus,
   liveDeadSplit,
   enrichProjectSignals,
@@ -354,7 +355,12 @@ async function enrichProjectsForRender(
     extraSessions?: Awaited<ReturnType<typeof getActiveSessions>>;
   },
 ): Promise<ProjectRenderData> {
-  const roll = rollupSessionsByProject(all, [...(await getActiveSessions()), ...(opts.extraSessions ?? [])]);
+  // Local getActiveSessions() leaves `machine` unset (the sessions renderer
+  // falls back to this box). Host-grouped agents need an explicit stamp so
+  // under `--fleet` this box does not render as `@local` next to peers that
+  // carry real device ids.
+  const local = withDefaultMachine(await getActiveSessions(), machineId());
+  const roll = rollupSessionsByProject(all, [...local, ...(opts.extraSessions ?? [])]);
   const remote = new Map<string, ProjectRemoteSignals>();
   const linear = new Map<string, LinearProjectCounts>();
   // Local git, no API, no rate limit — measured 0.23s over a 897-commit week.

--- a/apps/cli/src/lib/project-status.test.ts
+++ b/apps/cli/src/lib/project-status.test.ts
@@ -9,6 +9,7 @@ import {
   enrichProjectSignals,
   sortProjectMembers,
   formatProjectMembers,
+  withDefaultMachine,
   formatProjectMembersByHost,
   formatProjectWarnings,
   warningEmoji,
@@ -335,5 +336,39 @@ describe('formatProjectWarnings', () => {
 
   it('is empty when there is nothing to say', () => {
     expect(formatProjectWarnings([])).toEqual([]);
+  });
+});
+
+describe('withDefaultMachine', () => {
+  it('fills only missing machine stamps so local rows match peer host ids', () => {
+    const out = withDefaultMachine(
+      [
+        { id: 'a', machine: undefined },
+        { id: 'b', machine: 'yosemite-s0' },
+        { id: 'c' },
+      ],
+      'zion',
+    );
+    expect(out.map((s) => s.machine)).toEqual(['zion', 'yosemite-s0', 'zion']);
+  });
+
+  it('makes host-grouped roster use the real local name, not @local', () => {
+    const sessions = withDefaultMachine(
+      [
+        { kind: 'claude', status: 'running' as const, cwd: '/x', machine: undefined },
+        { kind: 'claude', status: 'idle' as const, cwd: '/x', machine: 'yosemite-s0' },
+      ],
+      'zion',
+    );
+    // Simulate rollup member mapping
+    const members = sessions.map((s) => ({
+      agent: s.kind,
+      status: s.status,
+      host: s.machine,
+    }));
+    const lines = formatProjectMembersByHost(members).map((l) => l.replace(/\x1b\[[0-9;]*m/g, ''));
+    expect(lines.some((l) => l.startsWith('@zion'))).toBe(true);
+    expect(lines.some((l) => l.startsWith('@yosemite-s0'))).toBe(true);
+    expect(lines.some((l) => l.includes('@local'))).toBe(false);
   });
 });

--- a/apps/cli/src/lib/project-status.ts
+++ b/apps/cli/src/lib/project-status.ts
@@ -78,6 +78,18 @@ function blank(name: string): ProjectSessionRollup {
  * containing only projects with at least one matched session — callers merge
  * with the full definition list to show zero-agent projects.
  */
+
+/**
+ * Ensure every session carries a host for the card roster. Local
+ * `getActiveSessions()` omits `machine`; remotes already set it. Pure.
+ */
+export function withDefaultMachine<T extends { machine?: string }>(
+  sessions: T[],
+  defaultHost: string,
+): T[] {
+  return sessions.map((s) => (s.machine ? s : { ...s, machine: defaultHost }));
+}
+
 export function rollupSessionsByProject(
   defs: ProjectDef[],
   sessions: ActiveSession[],


### PR DESCRIPTION
## Summary

Follow-up to #1951 (independent review).

Under `projects status --fleet`, remote sessions carry `machine` but local `getActiveSessions()` leaves it unset. Host-grouped agents then labeled this box `@local` next to peers like `@yosemite-s0`.

- `withDefaultMachine(sessions, machineId())` before rollup
- Tests that mixed local+remote never yields `@local`
- Docs: clarify `--fleet` fans out sessions, but cwd matching is still local-home

## Test plan

- [x] `bun test src/lib/project-status.test.ts src/commands/projects.test.ts` (47 pass)
- [ ] `agents projects status agents-cli --fleet` shows real host for local agents, not `@local`

no-surface: host label fix only