### PR TITLE
feat(cli): agents snapshot — one-process poll for inventory + active sessions

### DIFF
--- a/apps/cli/.changelog/next/snapshot-api.md
+++ b/apps/cli/.changelog/next/snapshot-api.md
@@ -1,0 +1,8 @@
+- **`agents snapshot` — one-process poll for inventory + active sessions (Phase 4 surface consolidation).**
+  Consumers (Factory, scripts, menubar) were forking `view --json` × N harnesses plus
+  `sessions --active --json` (and sometimes feed) on every tick. `agents snapshot --json`
+  returns the same shapes in one invocation: `inventory` (view), `sessions` (active rows),
+  optional `--with-feed` / `--with-sync`. Default sessions scope is this machine; `--all-hosts`
+  matches full `sessions --active` fan-out. Does **not** redefine `agents status`, which stays
+  the UnifiedSyncStatus sync contract. Source: `apps/cli/src/commands/snapshot.ts`,
+  `apps/cli/src/lib/snapshot.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -392,8 +392,10 @@ The `query()` API reads the active JSONL and every numbered gzip archive
 transparently.
 
 External tools (dashboards, voice assistants, CI runners, monitoring) can read
-fleet state via three canonical `--json` sources. No direct DB access, no re-parsing
-of agent-specific formats, no auth to manage.
+fleet state via canonical `--json` sources. Prefer **`agents snapshot --json`** when
+you need inventory + active sessions in one process; keep `agents status --json` for
+sync drift only. No direct DB access, no re-parsing of agent-specific formats, no auth
+to manage.
 
 ## Fleet health & cross-device divergence (`agents doctor`)
 
@@ -408,6 +410,13 @@ Three diagnostics with distinct scopes (RUSH-2027):
   [`src/lib/fleet-status.ts`](../src/lib/fleet-status.ts)); the command unions
   peers' rows on demand, cache-first, ssh-reading a stale/missing peer via
   `agents fleet status --local --json` through a bounded, kill-on-timeout fan-out.
+
+- `agents snapshot` — **one-process consumer poll** for install inventory + active sessions
+  (optional feed / sync). Replaces the N× `view --json` + `sessions --active --json` fork
+  storm. Default sessions scope is this machine; `--all-hosts` matches full active fan-out.
+  JSON contract: `FleetSnapshot` version 1 (`inventory`, `sessions`, `agents`, optional
+  `feed` / `sync`). Does **not** replace `agents status` (UnifiedSyncStatus / drift).
+
   The daemon no longer force-probes every device every 3 minutes (the old N² ssh
   fan-out and orphaned-probe pile-up, RUSH-2114).
 - `agents inspect <agent>[@version]` — deep **single-harness** diff between one

--- a/apps/cli/src/commands/snapshot.ts
+++ b/apps/cli/src/commands/snapshot.ts
@@ -1,0 +1,147 @@
+/**
+ * `agents snapshot` — one-process consumer snapshot for pollers.
+ *
+ * Replaces the N× `view --json` + `sessions --active --json` (+ optional feed)
+ * fork storm with a single command. Does NOT replace `agents status`, which
+ * remains the UnifiedSyncStatus sync contract for menubar / Agency drift.
+ *
+ * JSON shape: {@link FleetSnapshot} in `lib/snapshot.ts` (version: 1).
+ */
+
+import type { Command } from 'commander';
+import chalk from 'chalk';
+
+import { addHostOption } from '../lib/hosts/option.js';
+import { setHelpSections } from '../lib/help.js';
+import { resolveAgentName, AGENTS } from '../lib/agents.js';
+import type { AgentId } from '../lib/types.js';
+import { computeSnapshot, type FleetSnapshot } from '../lib/snapshot.js';
+import { resolveSurface } from './utils.js';
+
+interface SnapshotOptions {
+  json?: boolean;
+  allHosts?: boolean;
+  withFeed?: boolean;
+  withSync?: boolean;
+  agent?: string;
+}
+
+function resolveAgentFilter(raw: string | undefined): AgentId | undefined {
+  if (!raw) return undefined;
+  const name = resolveAgentName(raw.split('@')[0]);
+  if (!name) {
+    console.error(chalk.red(`Unknown agent "${raw}".`));
+    process.exit(1);
+  }
+  return name;
+}
+
+/** Compact human summary — the JSON path is the real contract. */
+function renderHuman(snap: FleetSnapshot): void {
+  console.log(chalk.bold('Fleet snapshot') + chalk.gray(`  ·  ${snap.host}  ·  ${snap.capturedAt}`));
+
+  const invParts: string[] = [];
+  for (const a of snap.inventory) {
+    if (a.versions.length === 0) continue;
+    const def = a.versions.find((v) => v.isDefault) ?? a.versions[0];
+    const label = AGENTS[a.agent as AgentId]?.name ?? a.agent;
+    const signed = def.signedIn ? chalk.green('in') : chalk.gray('out');
+    invParts.push(`${label}@${def.version} (${signed})`);
+  }
+  console.log(
+    `  ${'Inventory'.padEnd(12)} ${invParts.length ? invParts.join(chalk.gray(' · ')) : chalk.gray('(none installed)')}`,
+  );
+
+  const { running, live, byContext, byAgent } = snap.agents;
+  const ctx = Object.entries(byContext)
+    .map(([k, n]) => `${k}:${n}`)
+    .join(' ');
+  const ag = Object.entries(byAgent)
+    .map(([k, n]) => `${k}:${n}`)
+    .join(' ');
+  console.log(
+    `  ${'Sessions'.padEnd(12)} ${live} live · ${running} running` +
+      (snap.remoteDeviceCount > 0 ? chalk.gray(` · ${snap.remoteDeviceCount} remote device(s)`) : '') +
+      (ctx ? chalk.gray(` · ${ctx}`) : '') +
+      (ag ? chalk.gray(` · ${ag}`) : ''),
+  );
+
+  if (snap.feed) {
+    console.log(
+      `  ${'Feed'.padEnd(12)} ${snap.feed.openBlocks} open block${snap.feed.openBlocks === 1 ? '' : 's'}`,
+    );
+  }
+  if (snap.sync) {
+    const need = snap.sync.agents.filter((a) => a.needsSync).length;
+    const sys =
+      snap.sync.system.unknown
+        ? 'system unknown'
+        : snap.sync.system.behind > 0
+          ? `system ${snap.sync.system.behind} behind`
+          : 'system ok';
+    console.log(
+      `  ${'Sync'.padEnd(12)} ${sys} · ${need} version${need === 1 ? '' : 's'} need sync`,
+    );
+  }
+
+  console.log(
+    chalk.gray(
+      '\n  Machine-readable: agents snapshot --json\n' +
+        '  Sync-only (unchanged): agents status --json',
+    ),
+  );
+}
+
+export function registerSnapshotCommand(program: Command): void {
+  const cmd = addHostOption(
+    program
+      .command('snapshot')
+      .description(
+        'One-process poll snapshot: install inventory + active sessions (optional feed/sync). Not the sync-status command — use `agents status` for drift.',
+      ),
+  )
+    .option('--json', 'Emit the machine-readable FleetSnapshot contract (version 1)')
+    .option(
+      '--all-hosts',
+      'Include remote devices in the sessions gather (same fan-out as `sessions --active`; default is this machine only)',
+    )
+    .option('--with-feed', 'Include open feed-block summary (needs-you count + compact rows)')
+    .option('--with-sync', 'Include UnifiedSyncStatus (same engine as `agents status`; opt-in)')
+    .option('--agent <name>', 'Restrict inventory to one agent (e.g. claude)');
+
+  setHelpSections(cmd, {
+    examples: `
+      # One-shot inventory + local active sessions (JSON)
+      agents snapshot --json
+
+      # Same, plus open feed blocks for needs-you polls
+      agents snapshot --json --with-feed
+
+      # Fleet-wide active sessions (matches sessions --active scope)
+      agents snapshot --json --all-hosts
+
+      # Inventory for one harness only (Factory-style usage poll)
+      agents snapshot --json --agent claude
+
+      # Run the whole snapshot on another device
+      agents snapshot --json --host yosemite-s0
+    `,
+  });
+
+  cmd.action(async (opts: SnapshotOptions, command: Command) => {
+    const surface = resolveSurface(command);
+    const agent = resolveAgentFilter(opts.agent);
+    const snap = await computeSnapshot({
+      agent,
+      local: opts.allHosts !== true,
+      withFeed: opts.withFeed === true,
+      withSync: opts.withSync === true,
+    });
+
+    if (surface.json || opts.json) {
+      console.log(JSON.stringify(snap, null, 2));
+      return;
+    }
+    renderHuman(snap);
+  });
+}

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -1502,7 +1502,7 @@ export function parseResourceSections(
  * agents-cli extension's "resume current session in best available version"
  * command).
  */
-async function collectAgentsJson(filterAgentId?: AgentId, resourceSections?: Set<ResourceSection>): Promise<ViewJsonAgent[]> {
+export async function collectAgentsJson(filterAgentId?: AgentId, resourceSections?: Set<ResourceSection>): Promise<ViewJsonAgent[]> {
   const agentsToShow = filterAgentId ? [filterAgentId] : ALL_AGENT_IDS;
   const wantResources = !!resourceSections && resourceSections.size > 0;
   // Only pay for the git-status + resource scans when resources were requested.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -157,6 +157,7 @@ import {
   loadDoctor,
   loadApply,
   loadStatus,
+  loadSnapshot,
   loadProfiles,
   loadHarness,
   loadSecrets,
@@ -431,6 +432,8 @@ Credentials and profiles:
 
 Diagnostics:
   doctor [agent[@version]]        Diagnose CLI availability, sync status, and resource divergence; --check for the CI drift gate
+  status                          Unified sync status (drift/missing) — not the live fleet snapshot
+  snapshot                        One-process poll: inventory + active sessions (+ optional feed/sync)
   usage [agent]                   Show rate-limit and quota usage per agent
   perf                            Latency rollups (hooks, commands, runs) from the disposable perf warehouse
 
@@ -1092,6 +1095,7 @@ async function registerAllEagerCommands(): Promise<void> {
   registerCheckTombstoneCommand(program);
   await reg(loadApply);
   await reg(loadStatus);
+  await reg(loadSnapshot);
   registerExecAliasCommand(program);
   await reg(loadProfiles);
   await reg(loadHarness);

--- a/apps/cli/src/lib/snapshot.test.ts
+++ b/apps/cli/src/lib/snapshot.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  assembleSnapshot,
+  summarizeFeedBlocks,
+  type SnapshotSessionRow,
+} from './snapshot.js';
+import type { OpenBlock } from './feed.js';
+import type { ViewJsonAgent } from '../commands/view.js';
+
+function block(partial: Partial<OpenBlock> & Pick<OpenBlock, 'blockId' | 'sessionId' | 'ts'>): OpenBlock {
+  return {
+    mailboxId: 'mb',
+    host: 'zion',
+    runtime: 'claude',
+    questions: [{ text: 'ok?', options: [] }],
+    ...partial,
+  };
+}
+
+describe('summarizeFeedBlocks', () => {
+  it('counts all open blocks and caps the row list', () => {
+    const blocks = [
+      block({ blockId: 'a', sessionId: 's1', ts: '2026-08-01T00:00:00Z' }),
+      block({ blockId: 'b', sessionId: 's2', ts: '2026-08-02T00:00:00Z', ticket: 'RUSH-1' }),
+      block({ blockId: 'c', sessionId: 's3', ts: '2026-08-03T00:00:00Z' }),
+    ];
+    const summary = summarizeFeedBlocks(blocks, 2);
+    expect(summary.openBlocks).toBe(3);
+    expect(summary.blocks).toHaveLength(2);
+    // Newest first.
+    expect(summary.blocks[0].blockId).toBe('c');
+    expect(summary.blocks[1].blockId).toBe('b');
+    expect(summary.blocks[1].ticket).toBe('RUSH-1');
+    expect(summary.blocks[0].questionCount).toBe(1);
+  });
+
+  it('returns empty rows when there are no blocks', () => {
+    expect(summarizeFeedBlocks([])).toEqual({ openBlocks: 0, blocks: [] });
+  });
+});
+
+describe('assembleSnapshot', () => {
+  it('stamps version 1, host, and agent tallies from sessions', () => {
+    const inventory: ViewJsonAgent[] = [
+      { agent: 'claude' as ViewJsonAgent['agent'], versions: [], harnesses: [] },
+    ];
+    const sessions: SnapshotSessionRow[] = [
+      {
+        status: 'running',
+        context: 'terminal',
+        kind: 'claude',
+        ticketId: null,
+        project: 'agents-cli',
+        prLink: null,
+        viewingIn: null,
+      },
+      {
+        status: 'idle',
+        context: 'teams',
+        kind: 'codex',
+        ticketId: 'RUSH-1',
+        project: null,
+        prLink: null,
+        viewingIn: null,
+      },
+    ];
+    const snap = assembleSnapshot({
+      host: 'zion',
+      capturedAt: '2026-08-05T12:00:00.000Z',
+      inventory,
+      sessions,
+      remoteDeviceCount: 0,
+    });
+    expect(snap.version).toBe(1);
+    expect(snap.host).toBe('zion');
+    expect(snap.inventory).toBe(inventory);
+    expect(snap.sessions).toHaveLength(2);
+    expect(snap.agents).toEqual({
+      running: 1,
+      live: 2,
+      byContext: { terminal: 1 },
+      byAgent: { claude: 1 },
+    });
+    expect(snap.feed).toBeUndefined();
+    expect(snap.sync).toBeUndefined();
+  });
+
+  it('includes feed and sync only when provided', () => {
+    const snap = assembleSnapshot({
+      host: 'm2',
+      capturedAt: '2026-08-05T12:00:00.000Z',
+      inventory: [],
+      sessions: [],
+      remoteDeviceCount: 2,
+      feed: { openBlocks: 1, blocks: [] },
+    });
+    expect(snap.remoteDeviceCount).toBe(2);
+    expect(snap.feed).toEqual({ openBlocks: 1, blocks: [] });
+    expect(snap.sync).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/snapshot.ts
+++ b/apps/cli/src/lib/snapshot.ts
@@ -1,0 +1,197 @@
+/**
+ * `agents snapshot` — one-process fleet consumer snapshot.
+ *
+ * Consumers (Factory watchdog, menubar, fleet scripts) used to fork:
+ *   agents view <agent> --json  × N harnesses
+ *   agents sessions --active --json
+ *   agents feed --json          (sometimes)
+ *
+ * That is N+2 process starts per poll tick. This module gathers the same
+ * shapes in one invocation so poll count drops to 1 without redefining
+ * `agents status` (which stays the UnifiedSyncStatus sync contract).
+ *
+ * Stores are not merged — inventory still comes from view, active rows from
+ * sessions, blocks from feed. Only the reader is consolidated.
+ */
+
+import { machineId } from './machine-id.js';
+import { listBlocks, type OpenBlock } from './feed.js';
+import { computeAgentCounts, type FleetAgentCounts } from './fleet-status.js';
+import type { AgentId } from './types.js';
+import type { UnifiedSyncStatus } from './sync-status.js';
+import type { ViewJsonAgent } from '../commands/view.js';
+
+/** One open-block row in the optional feed summary (no full question bodies). */
+export interface SnapshotFeedBlock {
+  blockId: string;
+  sessionId: string;
+  host: string;
+  runtime: string;
+  kind?: OpenBlock['kind'];
+  ticket?: string;
+  pr?: string;
+  questionCount: number;
+  ts: string;
+}
+
+/** Compact feed slice for needs-you polls. */
+export interface SnapshotFeedSummary {
+  openBlocks: number;
+  blocks: SnapshotFeedBlock[];
+}
+
+/** Active-session row as emitted by `sessions --active --json`. */
+export type SnapshotSessionRow = {
+  ticketId: string | null;
+  project: string | null;
+  prLink: string | null;
+  viewingIn: string | null;
+  [key: string]: unknown;
+};
+
+/**
+ * Stable machine-readable contract for `agents snapshot --json`.
+ * Bump `version` only on breaking shape changes.
+ */
+export interface FleetSnapshot {
+  version: 1;
+  /** Host that produced this snapshot (machineId). */
+  host: string;
+  /** ISO-8601 capture time. */
+  capturedAt: string;
+  /** Installed agent inventory — same shape as `agents view --json`. */
+  inventory: ViewJsonAgent[];
+  /** Live sessions — same row shape as `agents sessions --active --json`. */
+  sessions: SnapshotSessionRow[];
+  /** How many remote devices contributed sessions (0 when --local). */
+  remoteDeviceCount: number;
+  /** Running/live tallies derived from `sessions` (same as fleet-status). */
+  agents: FleetAgentCounts;
+  /** Present when --with-feed. */
+  feed?: SnapshotFeedSummary;
+  /** Present when --with-sync (UnifiedSyncStatus; does not replace `agents status`). */
+  sync?: UnifiedSyncStatus;
+}
+
+export interface ComputeSnapshotOptions {
+  /** Restrict inventory to one agent id. */
+  agent?: AgentId;
+  /** Local sessions only — no cross-machine SSH fan-out. Default true for cheap polls. */
+  local?: boolean;
+  /** Explicit host filter for the sessions gather (same semantics as sessions --active). */
+  hosts?: string[];
+  /** Include open feed-block summary. */
+  withFeed?: boolean;
+  /** Include UnifiedSyncStatus (opt-in; can be slower). */
+  withSync?: boolean;
+  /** Cap feed.blocks length (default 50). */
+  feedLimit?: number;
+}
+
+/** Summarize open blocks for the snapshot feed slice. Pure / unit-testable. */
+export function summarizeFeedBlocks(
+  blocks: ReadonlyArray<OpenBlock>,
+  limit = 50,
+): SnapshotFeedSummary {
+  const sorted = [...blocks].sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0));
+  const slice = sorted.slice(0, Math.max(0, limit));
+  return {
+    openBlocks: blocks.length,
+    blocks: slice.map((b) => ({
+      blockId: b.blockId,
+      sessionId: b.sessionId,
+      host: b.host,
+      runtime: b.runtime,
+      kind: b.kind,
+      ticket: b.ticket,
+      pr: b.pr,
+      questionCount: b.questions?.length ?? 0,
+      ts: b.ts,
+    })),
+  };
+}
+
+/**
+ * Assemble a snapshot payload from already-gathered pieces. Pure so tests do
+ * not need live process scans or network.
+ */
+export function assembleSnapshot(parts: {
+  host: string;
+  capturedAt: string;
+  inventory: ViewJsonAgent[];
+  sessions: SnapshotSessionRow[];
+  remoteDeviceCount: number;
+  feed?: SnapshotFeedSummary;
+  sync?: UnifiedSyncStatus;
+}): FleetSnapshot {
+  return {
+    version: 1,
+    host: parts.host,
+    capturedAt: parts.capturedAt,
+    inventory: parts.inventory,
+    sessions: parts.sessions,
+    remoteDeviceCount: parts.remoteDeviceCount,
+    agents: computeAgentCounts(
+      parts.sessions.map((s) => ({
+        status: typeof s.status === 'string' ? s.status : undefined,
+        context: typeof s.context === 'string' ? s.context : undefined,
+        kind: typeof s.kind === 'string' ? s.kind : undefined,
+      })),
+    ),
+    ...(parts.feed ? { feed: parts.feed } : {}),
+    ...(parts.sync ? { sync: parts.sync } : {}),
+  };
+}
+
+/**
+ * Gather inventory + active sessions (+ optional feed/sync) in one process.
+ * Default `local: true` keeps the common poll path free of SSH fan-out; pass
+ * `local: false` (or hosts) to match full `sessions --active` fleet scope.
+ */
+export async function computeSnapshot(
+  opts: ComputeSnapshotOptions = {},
+): Promise<FleetSnapshot> {
+  // Default local-only sessions (cheap poll). Explicit hosts → scoped fan-out.
+  // local: false (from --all-hosts) → full sessions --active fan-out.
+  const localOnly = opts.hosts?.length ? false : opts.local !== false;
+
+  const [{ collectAgentsJson }, sessionsMod] = await Promise.all([
+    import('../commands/view.js'),
+    import('../commands/sessions.js'),
+  ]);
+
+  const inventoryP = collectAgentsJson(opts.agent);
+  const sessionsP = sessionsMod.gatherActiveSessions({
+    local: localOnly,
+    hosts: opts.hosts,
+  });
+
+  const feedP = opts.withFeed
+    ? Promise.resolve(summarizeFeedBlocks(listBlocks(), opts.feedLimit ?? 50))
+    : Promise.resolve(undefined);
+
+  const syncP = opts.withSync
+    ? import('./sync-status.js').then((m) => m.computeSyncStatus())
+    : Promise.resolve(undefined);
+
+  const [inventory, gathered, feed, sync] = await Promise.all([
+    inventoryP,
+    sessionsP,
+    feedP,
+    syncP,
+  ]);
+
+  const sessions = sessionsMod.serializeActiveSessionsForJson(
+    gathered.sessions,
+  ) as SnapshotSessionRow[];
+
+  return assembleSnapshot({
+    host: machineId(),
+    capturedAt: new Date().toISOString(),
+    inventory,
+    sessions,
+    remoteDeviceCount: gathered.remoteDeviceCount,
+    feed,
+    sync,
+  });
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -62,6 +62,7 @@ export const loadRestore: ModuleLoader = async () => (await import('../../comman
 export const loadDoctor: ModuleLoader = async () => (await import('../../commands/doctor.js')).registerDoctorCommand;
 export const loadApply: ModuleLoader = async () => (await import('../../commands/apply.js')).registerApplyCommand;
 export const loadStatus: ModuleLoader = async () => (await import('../../commands/status.js')).registerStatusCommand;
+export const loadSnapshot: ModuleLoader = async () => (await import('../../commands/snapshot.js')).registerSnapshotCommand;
 export const loadProfiles: ModuleLoader = async () => (await import('../../commands/profiles.js')).registerProfilesCommands;
 export const loadHarness: ModuleLoader = async () => (await import('../../commands/harness.js')).registerHarnessCommands;
 export const loadSecrets: ModuleLoader = async () => (await import('../../commands/secrets.js')).registerSecretsCommands;
@@ -174,6 +175,7 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   doctor: [loadDoctor],
   apply: [loadApply],
   status: [loadStatus],
+  snapshot: [loadSnapshot],
   profile: [loadProfiles],
   profiles: [loadProfiles],
   harness: [loadHarness],


### PR DESCRIPTION
**Feature** — new `agents snapshot` command consolidates the consumer poll tax (Phase 4 of surface consolidation).

## What changed

Pollers (Factory, scripts) forked:

- `agents view <agent> --json` x N harnesses
- `agents sessions --active --json`
- sometimes `agents feed --json`

That is N+2 process starts per tick. **`agents snapshot --json`** returns the same data in **one** process.

| Field | Source |
|---|---|
| `inventory` | same shape as `view --json` |
| `sessions` | same rows as `sessions --active --json` |
| `agents` | running/live tallies (fleet-status style) |
| `feed` | optional via `--with-feed` |
| `sync` | optional via `--with-sync` (does not replace `agents status`) |

**`agents status` is unchanged** — still the UnifiedSyncStatus sync/drift contract for menubar/Agency.

## Flags

- `--json` — FleetSnapshot v1
- default sessions = this machine; `--all-hosts` = full active fan-out
- `--agent <name>` — inventory filter
- `--with-feed` / `--with-sync` — opt-in slices
- `--host` — run whole snapshot on another device (passthrough)

## Run result

```
Fleet snapshot  ·  yosemite-m2  ·  2026-08-05T04:44:35.999Z
  Inventory    Claude@2.1.220 (out) · Codex@0.146.0 (in) · Antigravity@1.1.5 (out) · Grok@0.2.118 (in) · Kimi@0.28.1 (out) · Droid@0.177.0 (in)
  Sessions     4 live · 4 running · terminal:4 · grok:4

  Machine-readable: agents snapshot --json
  Sync-only (unchanged): agents status --json
```

Unit tests: `src/lib/snapshot.test.ts` (4 passed). `bun run build` green.

## Docs / changelog

- `apps/cli/docs/06-observability.md` — prefer snapshot for inventory+sessions polls
- `.changelog/next/snapshot-api.md`

## Not in this PR

- Factory/menubar consumer rewrite to call snapshot (follow-up once shipped)
- Placement object (Phase 2), observe umbrella aliases (Phase 3)
