### PR TITLE
fix(harness)!: finish removing --label from 'agents harness fork'

### DIFF
--- a/apps/cli/docs/profiles.md
+++ b/apps/cli/docs/profiles.md
@@ -47,7 +47,7 @@ agents harness fork claude corp --model gpt-x --base-url https://gw.corp/v1 --au
 agents harness fork deepseek deepseek-chat --model deepseek/deepseek-chat-v3
 ```
 
-Forking a **native** harness requires `--model` — there is no model to inherit. Forking a **custom** harness copies everything (env, endpoint, auth binding, `fallback_model`, host version pin) and applies only the flags you pass; the two diverge from that point, so removing the source never affects the fork. `--label` sets the name `agents view` prints, `--force` overwrites an existing harness of the same name. The fork records its parent as `forkedFrom:` in the YAML — display-only lineage.
+Forking a **native** harness requires `--model` — there is no model to inherit. Forking a **custom** harness copies everything (env, endpoint, auth binding, `fallback_model`, host version pin) and applies only the flags you pass; the two diverge from that point, so removing the source never affects the fork. `--force` overwrites an existing harness of the same name. The name `agents view` prints is derived from the harness `name` — `deepseek-flash` renders as `DeepSeek Flash` — so there is no flag to set it. The fork records its parent as `forkedFrom:` in the YAML — display-only lineage.
 
 ### Custom harnesses are their own agent type
 

--- a/apps/cli/src/commands/harness.ts
+++ b/apps/cli/src/commands/harness.ts
@@ -69,7 +69,6 @@ export interface ForkOptions {
   baseUrl?: string;
   authProvider?: string;
   version?: string;
-  label?: string;
   description?: string;
   keyStdin?: boolean;
   force?: boolean;
@@ -186,7 +185,6 @@ Examples:
     .option('--base-url <url>', 'Custom endpoint base URL (claude/codex hosts)')
     .option('--auth-provider <provider>', 'Attach a keychain-backed API key under this provider')
     .option('--version <version>', 'Pin the host CLI version (e.g., 1.16.0)')
-    .option('--label <text>', 'Human-facing name shown by `agents view` (defaults to <name>)')
     .option('--description <text>', 'One-line description')
     .option('--key-stdin', 'Read the API key from stdin instead of prompting (for scripts/CI)')
     .option('--force', 'Overwrite an existing harness with the same name')


### PR DESCRIPTION
**Two-line follow-up to #1963 — removes a flag that was still accepted but silently ignored.** Breaking, but the break is already documented in the queued changelog.

## The inconsistency

#1963 restored the derived-title behavior after #1970's collateral revert, but it only dropped the two `label: opts.label` assignments. The flag registration and the `ForkOptions.label` field survived, leaving three sources on `main` disagreeing about the same flag:

| Source | Claim |
|---|---|
| `apps/cli/src/commands/harness.ts:189` | `--label` accepted; value never read (`profileLabel()` derives from `name`) |
| `.changelog/next/profiles-label-edit-rename.md` | "any script that passes `--label` to `agents harness fork` will receive a CLI error" |
| `apps/cli/docs/profiles.md:50` | "`--label` sets the name `agents view` prints" |

The code was the worst of the three: a documented flag that parses fine and does nothing. `855ea42a9` (`fix(harness)!: remove --label`) and the queued changelog are the intended spec, so the flag goes and the docs follow.

## Run result

The flag now behaves as the changelog already promises:

```
$ node --import tsx src/index.ts harness fork claude probe --model x --label 'Should Fail'
error: unknown option '--label'
```

Typecheck and the affected suites, on this branch:

```
$ npx tsc --noEmit
rc=0

$ node ./node_modules/vitest/vitest.mjs run src/lib/profiles.test.ts src/commands/view.harness.test.ts
 Test Files  2 passed (2)
      Tests  62 passed (62)
```

No UI surface to screenshot — this removes a CLI flag; the `error:` line above is the user-visible outcome.

## Changelog

No new fragment. `apps/cli/.changelog/next/profiles-label-edit-rename.md` already documents this exact removal as a breaking change — this PR makes that entry true rather than aspirational.
