### PR TITLE
test(sessions): stop the ssh-peer temp-home cleanup from failing unrelated PRs

### DIFF
--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -502,9 +502,27 @@ async function stopSessionResolverSshPeer(peer: SessionResolverSshPeer): Promise
  * side (an npx'd old agents-cli answering over ssh, plus the ControlPersist
  * master winding down) races into it after stop — a bare rmSync intermittently
  * dies ENOTEMPTY on CI. Retries absorb exactly that window.
+ *
+ * Two hardenings after 8 x 250ms still lost the race on a loaded runner
+ * (`ENOTEMPTY: rmdir '/tmp/sr-46716N/peer-home'`, which failed PRs whose diff
+ * never touched sessions at all):
+ *
+ *  - The window is now 20 x 500ms. `stopSessionResolverSshPeer` awaits the ssh
+ *    exit, but the ControlPersist master and the npx'd peer are separate
+ *    processes that can outlive it, so the tail is bounded by process teardown,
+ *    not by anything this test controls.
+ *  - Cleanup is best-effort. Every assertion has already run by the time this
+ *    is reached in `finally`; a leaked directory under TMPDIR on an ephemeral
+ *    runner is not a test failure, and turning one into a red shard hides which
+ *    PRs are actually broken. The failure is still reported on stderr rather
+ *    than swallowed, so a genuine leak stays visible in the CI log.
  */
 function rmTempHomeWithRetries(tempHome: string): void {
-  fs.rmSync(tempHome, { recursive: true, force: true, maxRetries: 8, retryDelay: 250 });
+  try {
+    fs.rmSync(tempHome, { recursive: true, force: true, maxRetries: 20, retryDelay: 500 });
+  } catch (err) {
+    console.warn(`[sessions.test] temp home cleanup did not complete for ${tempHome}: ${(err as Error).message}`);
+  }
 }
 
 describe('resolveSessionQuery indexed metadata coverage', () => {


### PR DESCRIPTION
**test-only — no behavior change.** Stops a flaky teardown in the ssh-peer resolver tests from failing PRs that never touch sessions.

## What happens

The peer resolver tests `rm -rf` a temp home in `finally`. `stopSessionResolverSshPeer` awaits the ssh exit, but the ControlPersist master and the npx'd old `agents-cli` are separate processes that can outlive it, so their trailing writes race the delete:

```
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/sr-46716N/peer-home'
FAIL src/commands/sessions.test.ts > agents sessions --resolve local-peer critical path
     > returns a partial fleet result when a real old peer rejects the safe resolver protocol
```

A hardened `rmTempHomeWithRetries` already existed (8 x 250ms), and it still lost the race on a loaded runner.

The cost is not confined to this file. `test-shard` is a shared gate, so this teardown **failed PR #1966**, whose diff touches only `apps/factory` and never loads `sessions.test.ts`. It cost two full CI cycles on that PR before being identified as unrelated.

## The change

| | Before | After |
|---|---|---|
| Retry window | 8 x 250ms (2s) | 20 x 500ms (10s) |
| On exhaustion | throws, fails the shard | warns on stderr, test passes |

Cleanup is now best-effort *by design*: every assertion has already run by the time `finally` executes. A leaked directory under `TMPDIR` on an ephemeral runner is not a test failure, and turning one into a red shard actively hides which PRs are genuinely broken. It is not swallowed — the failure still prints to stderr, so a real leak stays visible in the CI log.

## Run result

```
$ npx tsc --noEmit
rc=0
```

The peer tests themselves need a live ssh peer and cannot run on this machine. I checked that honestly rather than assuming: the same test fails identically on **unmodified `main`** here (`Error: Test timed out in 30000ms`), so the local failure is environmental and not introduced by this diff. CI is the real check for those cases.

No changelog fragment — test-only, no user-visible surface.
