### PR TITLE
feat(cli): observe aliases inbox/timeline/roster (Phase 3)

### DIFF
--- a/apps/cli/.changelog/next/observe-umbrella.md
+++ b/apps/cli/.changelog/next/observe-umbrella.md
@@ -1,0 +1,6 @@
+- **Observe umbrella aliases: `inbox`, `timeline`, `roster` (Phase 3 surface consolidation).**
+  Thin doors onto existing readers (no store merge): `agents inbox` ≡ `feed`,
+  `agents timeline` ≡ `feed --filter updates`, `agents roster` ≡ `sessions --active`.
+  Root help gains an Observe section; `agents audit` stays the tamper-evident run
+  log (not an events alias). Source: `apps/cli/src/lib/observe-aliases.ts`,
+  `apps/cli/src/commands/feed.ts`, `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -11,12 +11,27 @@ whose *consumer* and *axis* match your question, not whichever you remember firs
 
 | Command | Role (one line) | Source | Consumer |
 |---|---|---|---|
-| **`events`** | **Raw unified event stream = the audit log.** Everything: secrets access, command invocations, version/skill/mcp/team ops, browser events, plus agent milestones. `--follow` to tail, `--audit` for ops-only. | `events.jsonl` + per-session `activity/*.jsonl`, merged by `readUnifiedEvents` | Audit, debugging, monitoring (human + machine) |
+| **`events`** | **Raw unified event stream = the ops trail.** Everything: secrets access, command invocations, version/skill/mcp/team ops, browser events, plus agent milestones. `--follow` to tail, `--audit` for ops-only. | `events.jsonl` + per-session `activity/*.jsonl`, merged by `readUnifiedEvents` | Audit, debugging, monitoring (human + machine) |
+| **`audit`** | **Tamper-evident run-dispatch chain** (hash-chained exec log). Not the same as `events`. | `~/.agents` audit log | Governance / CI verify |
 | **`perf`** | **Latency rollups.** p50/p99 for hooks, CLI commands, and `agent.run` timings. Indexed SQLite — not a full scan of the audit log. | `~/.agents/.cache/perf/perf.db` (disposable) | Humans optimizing boot/run cost + `--json` |
 | **`trends`** | **Usage analytics.** Harness/model mix, tools per session, token ratios, hottest secrets/browser profiles — baked recipes over sessions + a durable resource warehouse. Distinct from quota (`agents usage`) and latency (`agents perf`). | `sessions.db` + `~/.agents/.history/analytics/usage.db` | Humans + `--json` |
-| **`feed`** | **Consolidated cross-agent surface.** Open blocks (decisions agents are waiting on) + `feed post` status updates — "what needs you / what are agents saying." Scope to one project with `--project`. | `.history/feed/*` + active sessions | Humans (operator inbox) + agents (progress) |
+| **`feed`** / **`inbox`** | **Needs-you inbox + status posts.** Open blocks (decisions agents are waiting on) + `feed post` milestones. `inbox` ≡ `feed`. Scope with `--project`. | `.history/feed/*` + active sessions | Humans (operator inbox) + agents (progress) |
+| **`timeline`** | **Progress stream only.** Alias of `feed --filter updates` — deliberate posts, not tool noise. | same as feed updates lane | Humans + `--json` |
 | **`output`** | **Productivity accounting.** Token burn vs shipped output (PRs, commits) across agents — the "was it worth it" axis. (`agents cost` is the pure $-and-duration sibling.) | `sessions.db` + git/gh | Human + `--json` |
-| **`sessions`** | **Live agent roster + transcripts.** Which agents are running right now and their state; browse/read past conversation transcripts. A live process probe + transcript index, not an event log. | live pid/transcript probe + `sessions.db` | Human + `--json` |
+| **`sessions`** / **`roster`** | **Live agent roster + transcripts.** `roster` ≡ `sessions --active`. Browse/read past transcripts under `sessions`. | live pid/transcript probe + `sessions.db` | Human + `--json` |
+| **`snapshot`** | **One-process poll.** Inventory + active sessions (+ optional feed/sync). Not `status` (sync-only). | view + active + optional feed | Machines / Factory |
+
+### Observe aliases (Phase 3)
+
+Thin second names for the product jobs — **no store merge**:
+
+| Job | Alias | Real command |
+|---|---|---|
+| What needs me? | `agents inbox` | `agents feed` |
+| What did agents post? | `agents timeline` | `agents feed --filter updates` |
+| Who is live? | `agents roster` | `agents sessions --active` |
+
+Do **not** alias `audit` to `events` — `agents audit` is already the run-dispatch chain.
 
 ### Delivery vs record vs control (RUSH-2123)
 

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -329,7 +329,9 @@ export function sessionHintsFromActive(
 export function registerFeedCommand(program: Command): void {
   const feed = program
     .command('feed')
-    .description('Open blocks (needs you) + agent status posts (feed post)')
+    .description(
+      'Operator inbox + agent status posts (aliases: inbox = needs-you; timeline = --filter updates)',
+    )
     .option('--json', 'Output as JSON (each block stamped with its outcome + ask class)')
     .option('--filter <view>', 'What to show: needs (default) · updates · all', 'needs')
     .option('--flat', 'List one block per agent instead of grouping by outcome')
@@ -711,6 +713,48 @@ docs/06-observability.md.
       });
       for (const g of groups) renderOutcomeGroup(g, self);
       await renderTrailingActivity();
+    });
+
+  // Observe-umbrella aliases (Phase 3): intentional second names, not deprecations.
+  // Re-parse into `feed` so flags/help stay single-sourced. See lib/observe-aliases.ts.
+  registerFeedObserveAliases(program);
+}
+
+/**
+ * `inbox` / `timeline` → feed. Loaded with the feed module so lazy COMMAND_LOADERS
+ * for those names also get the real `feed` command registered for re-parse.
+ */
+function registerFeedObserveAliases(program: Command): void {
+  const reparse = async (alias: 'inbox' | 'timeline'): Promise<void> => {
+    const { expandObserveAlias } = await import('../lib/observe-aliases.js');
+    const rest = process.argv.slice(3);
+    const expanded = expandObserveAlias(alias, rest);
+    if (!expanded) {
+      console.error(chalk.red(`Unknown observe alias: ${alias}`));
+      process.exit(1);
+    }
+    if (process.stderr.isTTY) process.stderr.write(chalk.gray(`${expanded.note}\n`));
+    await program.parseAsync(['node', 'agents', ...expanded.argv]);
+  };
+
+  program
+    .command('inbox')
+    .description('Needs-you inbox (alias of `agents feed`). Open blocks waiting on you.')
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async () => {
+      await reparse('inbox');
+    });
+
+  program
+    .command('timeline')
+    .description(
+      'Agent progress stream (alias of `agents feed --filter updates`). What agents posted recently.',
+    )
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async () => {
+      await reparse('timeline');
     });
 }
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -4055,7 +4055,9 @@ export function registerSessionsCommands(program: Command): void {
     .option('--query <clause>', 'Search text; repeat with --include tools to require distinct matching calls', collectQueryClause, [])
     .option('--resolve <selector>', 'Resolve one full ID, unique prefix, or keyword query to safe session metadata (requires --json; searches the fleet unless --local)')
     .addOption(new Option('--resolve-safe-v1 <selector>').hideHelp())
-    .description('Find, browse, and read agent conversation transcripts across Claude, Codex, Gemini, and OpenCode.')
+    .description(
+      'Find, browse, and read agent conversation transcripts. Live roster: `agents sessions --active` (alias: `agents roster`).',
+    )
     .option('-a, --agent <agent>', 'Filter by agent type and version (e.g., claude, codex@0.116.0)')
     .option('--claude', 'Shorthand for --agent claude')
     .option('--codex', 'Shorthand for --agent codex')
@@ -4214,6 +4216,32 @@ export function registerSessionsCommands(program: Command): void {
   registerSessionsMigrationsCommand(sessionsCmd);
   registerSessionsBackfillCommand(sessionsCmd);
   registerSessionsStatsCommand(sessionsCmd);
+
+  // Observe-umbrella alias (Phase 3): roster → sessions --active.
+  registerSessionsObserveAliases(program);
+}
+
+/**
+ * `roster` → sessions --active. Registered with the sessions module so the
+ * lazy loader for `roster` also registers the real `sessions` command for re-parse.
+ */
+function registerSessionsObserveAliases(program: Command): void {
+  program
+    .command('roster')
+    .description('Live agent roster (alias of `agents sessions --active`). Who is running right now.')
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async () => {
+      const { expandObserveAlias } = await import('../lib/observe-aliases.js');
+      const rest = process.argv.slice(3);
+      const expanded = expandObserveAlias('roster', rest);
+      if (!expanded) {
+        console.error(chalk.red('Unknown observe alias: roster'));
+        process.exit(1);
+      }
+      if (process.stderr.isTTY) process.stderr.write(chalk.gray(`${expanded.note}\n`));
+      await program.parseAsync(['node', 'agents', ...expanded.argv]);
+    });
 }
 
 function formatNoSessionsMessage(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -425,6 +425,15 @@ Run and dispatch:
   browser                         Automate a browser — navigate, click, screenshot, console, network
   pty                             Drive interactive terminal programs (REPLs, TUIs) via a persistent PTY session
 
+Observe (read the fleet — no store merge; aliases point at the real readers):
+  feed / inbox                    Needs-you inbox (open blocks waiting on you)
+  timeline                        Agent progress stream (= feed --filter updates)
+  roster                          Live agents (= sessions --active)
+  events                          Unified ops + activity event trail
+  audit                           Tamper-evident run-dispatch log (not events)
+  snapshot                        One-process inventory + active sessions poll
+  status                          Sync/drift only (not the live fleet snapshot)
+
 Credentials and profiles:
   profile                         Activate resource profiles across skills, MCP, permissions, and secrets
   profiles                        Bundles of (host CLI, endpoint, model, auth)
@@ -432,8 +441,6 @@ Credentials and profiles:
 
 Diagnostics:
   doctor [agent[@version]]        Diagnose CLI availability, sync status, and resource divergence; --check for the CI drift gate
-  status                          Unified sync status (drift/missing) — not the live fleet snapshot
-  snapshot                        One-process poll: inventory + active sessions (+ optional feed/sync)
   usage [agent]                   Show rate-limit and quota usage per agent
   perf                            Latency rollups (hooks, commands, runs) from the disposable perf warehouse
 

--- a/apps/cli/src/lib/observe-aliases.test.ts
+++ b/apps/cli/src/lib/observe-aliases.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  expandObserveAlias,
+  hasFilterFlag,
+  hasActiveFlag,
+  OBSERVE_ALIASES,
+} from './observe-aliases.js';
+
+describe('expandObserveAlias', () => {
+  it('maps inbox → feed and preserves flags', () => {
+    expect(expandObserveAlias('inbox')).toEqual({
+      argv: ['feed'],
+      note: expect.stringContaining('feed'),
+    });
+    expect(expandObserveAlias('inbox', ['--json', '--project', 'rush'])).toEqual({
+      argv: ['feed', '--json', '--project', 'rush'],
+      note: expect.stringContaining('inbox'),
+    });
+  });
+
+  it('maps timeline → feed --filter updates unless filter already set', () => {
+    expect(expandObserveAlias('timeline', ['--json'])).toEqual({
+      argv: ['feed', '--filter', 'updates', '--json'],
+      note: expect.stringContaining('updates'),
+    });
+    expect(expandObserveAlias('timeline', ['--filter', 'all', '--json'])).toEqual({
+      argv: ['feed', '--filter', 'all', '--json'],
+      note: expect.stringContaining('timeline'),
+    });
+    expect(expandObserveAlias('timeline', ['--filter=needs'])).toEqual({
+      argv: ['feed', '--filter=needs'],
+      note: expect.stringContaining('timeline'),
+    });
+  });
+
+  it('maps roster → sessions --active unless --active already set', () => {
+    expect(expandObserveAlias('roster')).toEqual({
+      argv: ['sessions', '--active'],
+      note: expect.stringContaining('sessions --active'),
+    });
+    expect(expandObserveAlias('roster', ['--json', '--local'])).toEqual({
+      argv: ['sessions', '--active', '--json', '--local'],
+      note: expect.stringContaining('roster'),
+    });
+    expect(expandObserveAlias('roster', ['--active', '--waiting'])).toEqual({
+      argv: ['sessions', '--active', '--waiting'],
+      note: expect.stringContaining('roster'),
+    });
+  });
+
+  it('returns null for unknown names', () => {
+    expect(expandObserveAlias('feed')).toBeNull();
+    expect(expandObserveAlias('audit')).toBeNull();
+    expect(expandObserveAlias('')).toBeNull();
+  });
+});
+
+describe('flag helpers / alias list', () => {
+  it('detects --filter and --active forms', () => {
+    expect(hasFilterFlag(['--filter', 'x'])).toBe(true);
+    expect(hasFilterFlag(['--filter=x'])).toBe(true);
+    expect(hasFilterFlag(['--json'])).toBe(false);
+    expect(hasActiveFlag(['--active'])).toBe(true);
+    expect(hasActiveFlag(['--json'])).toBe(false);
+  });
+
+  it('lists the three public observe aliases', () => {
+    expect([...OBSERVE_ALIASES].sort()).toEqual(['inbox', 'roster', 'timeline']);
+  });
+});

--- a/apps/cli/src/lib/observe-aliases.ts
+++ b/apps/cli/src/lib/observe-aliases.ts
@@ -1,0 +1,72 @@
+/**
+ * Observe-umbrella aliases (Phase 3 surface consolidation).
+ *
+ * Thin name → real command expansion. No store merge — feed / sessions / events
+ * remain the stores; these are doors that point at the right reader.
+ *
+ *   inbox    → feed                  (needs-you default)
+ *   timeline → feed --filter updates (agent progress stream)
+ *   roster   → sessions --active     (live agent roster)
+ *
+ * `audit` is NOT an alias here — `agents audit` is already the tamper-evident
+ * run-dispatch log. Ops trail = `agents events` (optionally `--audit`).
+ */
+
+export type ObserveAlias = 'inbox' | 'timeline' | 'roster';
+
+export const OBSERVE_ALIASES: readonly ObserveAlias[] = ['inbox', 'timeline', 'roster'] as const;
+
+export interface ObserveExpandResult {
+  /** argv for the real command (no program name): e.g. ['feed', '--filter', 'updates'] */
+  argv: string[];
+  /** One-line note for stderr (optional); empty when silent. */
+  note: string;
+}
+
+/** True when `rest` already carries a `--filter` / `--filter=…` flag. */
+export function hasFilterFlag(rest: readonly string[]): boolean {
+  return rest.some((a) => a === '--filter' || a.startsWith('--filter='));
+}
+
+/** True when `rest` already carries `--active`. */
+export function hasActiveFlag(rest: readonly string[]): boolean {
+  return rest.some((a) => a === '--active');
+}
+
+/**
+ * Expand an observe alias + remaining user args into the real command argv.
+ * Returns null when `alias` is not an observe alias.
+ */
+export function expandObserveAlias(
+  alias: string,
+  rest: readonly string[] = [],
+): ObserveExpandResult | null {
+  const tail = [...rest];
+  switch (alias) {
+    case 'inbox':
+      return {
+        argv: ['feed', ...tail],
+        note: 'agents inbox → agents feed (needs-you inbox)',
+      };
+    case 'timeline': {
+      const argv = hasFilterFlag(tail)
+        ? ['feed', ...tail]
+        : ['feed', '--filter', 'updates', ...tail];
+      return {
+        argv,
+        note: 'agents timeline → agents feed --filter updates',
+      };
+    }
+    case 'roster': {
+      const argv = hasActiveFlag(tail)
+        ? ['sessions', ...tail]
+        : ['sessions', '--active', ...tail];
+      return {
+        argv,
+        note: 'agents roster → agents sessions --active',
+      };
+    }
+    default:
+      return null;
+  }
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -118,7 +118,16 @@ export const loadFunnel: ModuleLoader = async () => (await import('../../command
  * inherit the root's custom help formatter rather than getting the per-command
  * recursive pass. Keeping that ordering preserves their `--help` output exactly.
  */
-export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set(['sessions', 'teams', 'cloud', 'message', 'serve']);
+// `roster` is an observe-umbrella alias of `sessions --active` — same module,
+// same SQLite stack, same post-help registration order as sessions.
+export const LAZY_COMMAND_NAMES: ReadonlySet<string> = new Set([
+  'sessions',
+  'roster',
+  'teams',
+  'cloud',
+  'message',
+  'serve',
+]);
 
 /**
  * User-typed top-level command name -> ordered list of module loaders to run.
@@ -224,12 +233,17 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   setup: [loadSetup],
   uninstall: [loadUninstall],
   sessions: [loadSessions],
+  // Observe-umbrella alias of sessions --active (same lazy module).
+  roster: [loadSessions],
   teams: [loadTeams],
   cloud: [loadCloud],
   message: [loadMessage],
   send: [loadSend],
   notify: [loadSend],
   feed: [loadFeed],
+  // Observe-umbrella aliases of feed / feed --filter updates.
+  inbox: [loadFeed],
+  timeline: [loadFeed],
   mailboxes: [loadMailboxes],
   mailbox: [loadMailboxes],
   serve: [loadServe],


### PR DESCRIPTION
**Feature / docs** — Phase 3 surface consolidation: observe-umbrella aliases + root help regroup.

## What changed

Thin second names for the product jobs (no store merge):

| Job | Alias | Real command |
|---|---|---|
| What needs me? | `agents inbox` | `agents feed` |
| What did agents post? | `agents timeline` | `agents feed --filter updates` |
| Who is live? | `agents roster` | `agents sessions --active` |

- `audit` is **not** an events alias — it already means the tamper-evident run-dispatch log.
- Root help gains an **Observe** section (feed/inbox, timeline, roster, events, audit, snapshot, status).
- Docs: `06-observability.md` table + alias matrix.

## Run result

```
$ agents --help
Observe (read the fleet — no store merge; aliases point at the real readers):
  feed / inbox    Needs-you inbox
  timeline        Agent progress stream (= feed --filter updates)
  roster          Live agents (= sessions --active)
  ...

$ agents timeline --json --local   # status.posted array
$ agents roster --json --local     # active session rows
```

Unit tests: `observe-aliases.test.ts` (6 passed). Build green.

## Not in this PR

- Factory rewrites to prefer aliases
- Merging events/audit stores (explicit non-goal)

