### PR TITLE
fix(profiles): close the residual --from-secrets fork-clobber gap

### DIFF
--- a/apps/cli/src/commands/harness.ts
+++ b/apps/cli/src/commands/harness.ts
@@ -232,7 +232,10 @@ async function runForkFlow(source: string, name: string, opts: ForkOptions): Pro
   // nothing.
   const forked = buildFork(source, name, opts);
   if (opts.fromSecrets) {
-    await applyFromSecrets(forked, opts.fromSecrets, opts.authProvider);
+    // A fork's `auth` (when present) may just be inherited by reference from
+    // its source, not established for this harness itself -- never trust it
+    // as "safe to rotate" without an explicit --auth-provider.
+    await applyFromSecrets(forked, opts.fromSecrets, opts.authProvider, { allowInheritedAuth: false });
   } else if (opts.authProvider) {
     await ensureProviderToken(opts.authProvider, undefined, opts.keyStdin);
   }

--- a/apps/cli/src/commands/profiles.test.ts
+++ b/apps/cli/src/commands/profiles.test.ts
@@ -110,4 +110,44 @@ describe('applyFromSecrets — provider precedence and error paths', () => {
     const profile = { name: 'x', host: { agent: 'claude' as const }, env: {} };
     await expect(applyFromSecrets(profile, 'no-such-bundle', 'x')).rejects.toThrow(/not found/i);
   });
+
+  it('allowInheritedAuth: false rejects reusing an inherited auth binding (the fork-clobber gap)', async () => {
+    // Simulates forkProfile's behavior: `auth`/`provider` copied by reference
+    // from the fork's SOURCE harness, not established for this profile.
+    const sourceToken = 'REAL-OPENROUTER-KEY-FOR-SOURCE-HARNESS';
+    const kc = new MemoryKeychain();
+    kc.set(keychainItemName('openrouter'), sourceToken);
+    setKeychainBackendForTest(kc);
+    writeBundleWithItems(
+      { name: 'prod', vars: { OPENROUTER_KEY: keychainRef('OPENROUTER_KEY') } },
+      new Map([[secretsKeychainItem('prod', 'OPENROUTER_KEY'), 'sk-test-secret']]),
+    );
+
+    const forked = {
+      name: 'forked-harness',
+      host: { agent: 'claude' as const },
+      env: {},
+      provider: 'openrouter', // inherited from the source, not this profile's own
+      auth: { envVar: 'ANTHROPIC_AUTH_TOKEN', keychainItem: keychainItemName('openrouter') },
+    };
+
+    await expect(
+      applyFromSecrets(forked, 'prod', undefined, { allowInheritedAuth: false }),
+    ).rejects.toThrow(/inherited its auth binding/i);
+
+    // The source harness's real credential must survive the rejected attempt.
+    expect(getKeychainToken(keychainItemName('openrouter'))).toBe(sourceToken);
+  });
+
+  it('allowInheritedAuth: false still allows an explicit --auth-provider to rotate a fork\'s own credential', async () => {
+    const forked = {
+      name: 'forked-harness',
+      host: { agent: 'claude' as const },
+      env: {},
+      provider: 'openrouter',
+      auth: { envVar: 'ANTHROPIC_AUTH_TOKEN', keychainItem: keychainItemName('openrouter') },
+    };
+    await applyFromSecrets(forked, 'prod', 'openrouter', { allowInheritedAuth: false });
+    expect(getKeychainToken(keychainItemName('openrouter'))).toBe('sk-test-secret');
+  });
 });

--- a/apps/cli/src/commands/profiles.ts
+++ b/apps/cli/src/commands/profiles.ts
@@ -148,8 +148,23 @@ export interface AddProfileOptions {
  *
  * Attaches `profile.auth` when the profile has none yet (a bare `--host
  * --model` harness, or a native-host fork with no prior auth binding).
+ *
+ * `allowInheritedAuth` (default `true`) gates the "reuse `profile.auth`'s own
+ * provider" branch above. It must be `false` when `profile` came from
+ * **forking** an already-provisioned harness: `forkProfile` copies `auth` by
+ * reference from the source when no `--auth-provider` override is given, so
+ * `profile.auth` being set there means "the SOURCE harness's binding", not
+ * "this harness's own" — trusting it would silently overwrite the source's
+ * shared keychain item. Editing a harness's own already-established auth is
+ * the one case where reuse is genuinely correct, so callers on that path keep
+ * the default.
  */
-export async function applyFromSecrets(profile: Profile, spec: string, explicitAuthProvider?: string): Promise<void> {
+export async function applyFromSecrets(
+  profile: Profile,
+  spec: string,
+  explicitAuthProvider?: string,
+  opts?: { allowInheritedAuth?: boolean },
+): Promise<void> {
   const sep = spec.indexOf(':');
   const bundleName = sep === -1 ? spec : spec.slice(0, sep);
   const requestedKey = sep === -1 ? undefined : spec.slice(sep + 1);
@@ -179,6 +194,13 @@ export async function applyFromSecrets(profile: Profile, spec: string, explicitA
     );
   }
 
+  if (profile.auth && !explicitAuthProvider && opts?.allowInheritedAuth === false) {
+    throw new Error(
+      `Harness '${profile.name}' inherited its auth binding from the harness it was forked from ` +
+        `(provider '${profile.provider}') — pass --auth-provider <name> explicitly with --from-secrets ` +
+        `on a fork, so it never silently overwrites the source harness's shared keychain item.`,
+    );
+  }
   const provider = explicitAuthProvider || (profile.auth ? profile.provider : undefined) || bundleName;
   const item = keychainItemName(provider);
   setKeychainToken(item, value);


### PR DESCRIPTION
**Bug fix.** Follow-up to #1988's credential-clobber fix — an independent post-merge review found a sibling manifestation the fix commit didn't cover.

## The gap

PR #1988 fixed `applyFromSecrets`'s provider-precedence bug for the bare `add --host --model --from-secrets` case (a fresh harness with no prior auth). It didn't cover **forking an already-provisioned harness**: `forkProfile` copies `auth`/`provider` by reference from the source when no `--auth-provider` override is given, so `applyFromSecrets`'s "profile.auth is set → trust profile.provider" branch can't distinguish "this harness's own established auth" from "inherited from whatever it was forked from."

Reproduced directly: fork an OpenRouter-backed harness with `--from-secrets <bundle>` and no `--auth-provider` → the fork's inherited `provider` ('openrouter') gets used as the write target → the **source harness's real credential is silently overwritten** with the bundle's value.

## The fix

`applyFromSecrets()` takes a new `allowInheritedAuth` option (default `true`, preserving the legitimate "edit my own already-provisioned harness" case documented in the function's own comment). The fork action in `harness.ts` passes `allowInheritedAuth: false` — a fork with `--from-secrets` and no explicit `--auth-provider` now fails loud with a clear error instead of silently rotating a credential that belongs to a different harness.

## Ran it — confirmed the test is real, not a tautology

Temporarily disabled the new guard (`if (false && profile.auth && ...)`), reran just the new test, and it failed with the actual clobber:

```
- Expected:
Error {
  "message": "rejected promise",
}
+ Received:
undefined
 Tests  1 failed | 1 passed | 5 skipped (7)
```

Restored the guard, reran the full affected suite:

```
 Test Files  2 passed (2)
      Tests  45 passed (45)
```

`bunx tsc --noEmit -p .` — clean (exit 0).

## Not this PR

The wizard-hang fix and rename-help restoration from #1988 are unaffected and already merged.
