### PR TITLE
fix(factory): route remote access through agents ssh

### DIFF
--- a/apps/factory/src/vscode/deviceHealth.vscode.ts
+++ b/apps/factory/src/vscode/deviceHealth.vscode.ts
@@ -1,7 +1,4 @@
 import * as os from 'os';
-import * as fs from 'fs';
-import * as path from 'path';
-import { createHash } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { DeviceStats, parseUptime, parseVmStat, parseLinuxMemInfo, isDeviceOnline } from '../core/deviceHealth';
@@ -15,8 +12,6 @@ const execFileAsync = promisify(execFile);
 export interface Device {
   name: string;
   host: string;
-  secretRef?: string;
-  user?: string;
   platform?: string;
   online?: boolean;
   registeredAt: number;
@@ -33,9 +28,7 @@ export type DeviceRef = Pick<Device, 'name' | 'host' | 'online'>;
 interface AgentsDeviceEntry {
   name: string;
   platform?: string;
-  user?: string;
   address?: { via?: string; dnsName?: string; ip?: string };
-  auth?: { method?: string; bundle?: string; bundleKey?: string };
   tailscale?: { online?: boolean };
   createdAt?: string;
 }
@@ -43,8 +36,7 @@ interface AgentsDeviceEntry {
 // Source the device fleet from the canonical agents-cli registry
 // (`agents devices`, self-populated from Tailscale) rather than a hand-rolled
 // file. Online status is derived by isDeviceOnline (matching the CLI: a missing
-// tailscale block is NOT offline), the credential bundle from auth.bundle, and the
-// SSH address from address.dnsName.
+// tailscale block is NOT offline), and the SSH address from address.dnsName.
 export async function listRegisteredDevices(): Promise<Device[]> {
   try {
     const bin = await resolveAgentsBin();
@@ -62,8 +54,6 @@ export async function listRegisteredDevices(): Promise<Device[]> {
     return (parsed as AgentsDeviceEntry[]).map((d) => ({
       name: d.name,
       host: d.address?.dnsName || d.name,
-      user: d.user,
-      secretRef: d.auth?.bundle,
       platform: d.platform,
       online: isDeviceOnline(d.tailscale),
       registeredAt: d.createdAt ? Date.parse(d.createdAt) || 0 : 0,
@@ -83,16 +73,6 @@ const PROBE_TIMEOUT_MS = 4_000;
 const statsStore = createTimedCache<DeviceStats>();
 const agentCountStore = createTimedCache<number>();
 
-type SecretsFormat = 'json' | 'shell' | 'unknown';
-
-interface SecretsReadCmd {
-  base: string[];
-  flags: string[];
-  format: SecretsFormat;
-}
-
-let secretsReadCmdCache: SecretsReadCmd | null | undefined;
-
 function augmentedEnv(binPath: string): NodeJS.ProcessEnv {
   return { ...process.env, PATH: `${bootstrapPath(binPath)}:${process.env.PATH ?? ''}` };
 }
@@ -104,11 +84,11 @@ function isLocalHost(host: string): boolean {
 export async function probeReachable(host: string): Promise<boolean> {
   if (isLocalHost(host)) return true;
   try {
-    await execFileAsync(
-      'ssh',
-      ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=3', '-o', 'StrictHostKeyChecking=accept-new', '--', host, 'true'],
-      { timeout: PROBE_TIMEOUT_MS },
-    );
+    const bin = await resolveAgentsBin();
+    await execFileAsync(bin, ['ssh', host, '--', 'true'], {
+      timeout: PROBE_TIMEOUT_MS,
+      env: augmentedEnv(bin),
+    });
     return true;
   } catch {
     return false;
@@ -117,14 +97,14 @@ export async function probeReachable(host: string): Promise<boolean> {
 
 export async function fetchDeviceStats(
   host: string,
-  opts: { isLocal: boolean; identityFile?: string; user?: string },
+  opts: { isLocal: boolean },
 ): Promise<DeviceStats> {
   return cachedInFlight(statsStore, host, CACHE_TTL_MS, () => fetchDeviceStatsOnce(host, opts));
 }
 
 async function fetchDeviceStatsOnce(
   host: string,
-  opts: { isLocal: boolean; identityFile?: string; user?: string },
+  opts: { isLocal: boolean },
 ): Promise<DeviceStats> {
   const fetchedAt = Date.now();
   if (opts.isLocal) {
@@ -137,12 +117,12 @@ async function fetchDeviceStatsOnce(
       return { host, reachable: true, fetchedAt };
     }
   }
-  const target = opts.user ? `${opts.user}@${host}` : host;
-  const args = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=3', '-o', 'StrictHostKeyChecking=accept-new'];
-  if (opts.identityFile) args.push('-i', opts.identityFile);
-  args.push('--', target, 'uptime; echo ---SEP---; (vm_stat || cat /proc/meminfo)');
   try {
-    const { stdout } = await execFileAsync('ssh', args, { timeout: PROBE_TIMEOUT_MS });
+    const bin = await resolveAgentsBin();
+    const { stdout } = await execFileAsync(bin, ['ssh', host, '--', 'uptime; echo ---SEP---; (vm_stat || cat /proc/meminfo)'], {
+      timeout: PROBE_TIMEOUT_MS,
+      env: augmentedEnv(bin),
+    });
     const parts = stdout.split('---SEP---');
     const uptimePart = parts[0] ?? '';
     const memPart = parts[1] ?? '';
@@ -175,103 +155,6 @@ async function countRunningAgentsOnce(host: string, opts: { isLocal: boolean }):
   }
 }
 
-export async function resolveSecret(secretRef: string): Promise<{ user?: string; identityFile?: string }> {
-  try {
-    const bin = await resolveAgentsBin();
-    const cmd = await discoverSecretsReadCmd();
-    if (!cmd) return {};
-    const args = [...cmd.base, secretRef, ...cmd.flags];
-    const { stdout } = await execFileAsync(bin, args, { timeout: 15_000, env: augmentedEnv(bin) });
-    const entries = parseSecretsOutput(stdout, cmd.format);
-    return extractCredentials(entries);
-  } catch {
-    return {};
-  }
-}
-
-async function discoverSecretsReadCmd(): Promise<SecretsReadCmd | null> {
-  if (secretsReadCmdCache !== undefined) return secretsReadCmdCache ?? null;
-  try {
-    const bin = await resolveAgentsBin();
-    const { stdout } = await execFileAsync(bin, ['secrets', '--help'], {
-      timeout: 5_000,
-      env: augmentedEnv(bin),
-    });
-    const lower = stdout.toLowerCase();
-    if (lower.includes('export')) {
-      const { stdout: exportHelp } = await execFileAsync(bin, ['secrets', 'export', '--help'], {
-        timeout: 5_000,
-        env: augmentedEnv(bin),
-      });
-      const exportLower = exportHelp.toLowerCase();
-      if (exportLower.includes('--plaintext') && exportLower.includes('--format')) {
-        secretsReadCmdCache = { base: ['secrets', 'export'], flags: ['--plaintext', '--format', 'json'], format: 'json' };
-        return secretsReadCmdCache;
-      }
-      if (exportLower.includes('--plaintext')) {
-        secretsReadCmdCache = { base: ['secrets', 'export'], flags: ['--plaintext'], format: 'shell' };
-        return secretsReadCmdCache;
-      }
-    }
-    if (lower.includes('view')) {
-      secretsReadCmdCache = { base: ['secrets', 'view'], flags: ['--reveal', '--plaintext'], format: 'unknown' };
-      return secretsReadCmdCache;
-    }
-    secretsReadCmdCache = null;
-    return null;
-  } catch {
-    secretsReadCmdCache = null;
-    return null;
-  }
-}
-
-function parseSecretsOutput(stdout: string, format: SecretsFormat): Record<string, string> {
-  if (format === 'json') {
-    try {
-      const parsed = JSON.parse(stdout);
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, string>;
-    } catch {
-      // fall through to shell-line parsing
-    }
-  }
-  const entries: Record<string, string> = {};
-  for (const line of stdout.split('\n')) {
-    const idx = line.indexOf('=');
-    if (idx > 0) {
-      const key = line.slice(0, idx).trim();
-      const value = line.slice(idx + 1).trim();
-      if (key) entries[key] = value;
-    }
-  }
-  return entries;
-}
-
-function extractCredentials(entries: Record<string, string>): { user?: string; identityFile?: string } {
-  const keys = Object.keys(entries);
-  const userKey = keys.find((k) => /user/i.test(k) && !/key/i.test(k));
-  const keyKey =
-    keys.find((k) => /private.*key|identity.*file|ssh.*key/i.test(k)) ??
-    keys.find((k) => /key/i.test(k) && !/api|token|password/i.test(k));
-  const user = userKey ? entries[userKey] : undefined;
-  let identityFile: string | undefined;
-  if (keyKey) identityFile = materializeKey(entries[keyKey]);
-  return { user, identityFile };
-}
-
-function materializeKey(value: string): string {
-  if ((value.startsWith('/') || value.startsWith('~/')) && !value.includes('-----BEGIN')) {
-    return value.startsWith('~/') ? path.join(os.homedir(), value.slice(2)) : value;
-  }
-  const tmpDir = path.join(os.homedir(), '.agents', '.tmp');
-  fs.mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
-  // Content-addressed name so repeated resolves overwrite one file per key
-  // instead of dropping a fresh plaintext copy on every panel open / dispatch.
-  const digest = createHash('sha256').update(value).digest('hex').slice(0, 16);
-  const tmpPath = path.join(tmpDir, `ssh-key-${digest}`);
-  fs.writeFileSync(tmpPath, value, { mode: 0o600 });
-  return tmpPath;
-}
-
 function sq(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -290,7 +173,7 @@ function pathAssign(projectPath: string): string {
 export async function getDeviceSyncStatus(
   host: string,
   projectPath: string,
-  opts: { isLocal: boolean; identityFile?: string; user?: string },
+  opts: { isLocal: boolean },
 ): Promise<RepoSyncStatus> {
   const empty: RepoSyncStatus = { root: projectPath, state: 'unknown', ahead: 0, behind: 0, dirty: false, defaultBranch: '' };
   if (!projectPath) return empty;
@@ -309,12 +192,11 @@ export async function getDeviceSyncStatus(
     if (opts.isLocal) {
       ({ stdout } = await execFileAsync('/bin/sh', ['-lc', snippet], { timeout: 20_000 }));
     } else {
-      const target = opts.user ? `${opts.user}@${host}` : host;
-      const args = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', '-o', 'StrictHostKeyChecking=accept-new'];
-      if (opts.identityFile) args.push('-i', opts.identityFile);
-      // `--` guards a host/user starting with '-'; login shell so git resolves.
-      args.push('--', target, `bash -lc ${sq(snippet)}`);
-      ({ stdout } = await execFileAsync('ssh', args, { timeout: 25_000 }));
+      const bin = await resolveAgentsBin();
+      ({ stdout } = await execFileAsync(bin, ['ssh', host, '--', `bash -lc ${sq(snippet)}`], {
+        timeout: 25_000,
+        env: augmentedEnv(bin),
+      }));
     }
     const line = stdout.trim().split('\n').pop() ?? '';
     if (line.startsWith('MISSING')) return { ...empty, state: 'missing' };

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -13,7 +13,7 @@ import { AgentsMarkdownEditorProvider, swarmCurrentDocument } from './customEdit
 import { AgentsHtmlReaderProvider } from './htmlReader';
 import * as git from './git.vscode';
 import { AgentSettings, hasLoginEnabled, PromptEntry, QUICK_LAUNCH_SLOT_KEYS, getQuickLaunchSlot, QuickLaunchSlot, QuickLaunchSlotKey } from '../core/settings';
-import { listRegisteredDevices, countRunningAgents, fetchDeviceStats, resolveSecret } from './deviceHealth.vscode';
+import { listRegisteredDevices, countRunningAgents, fetchDeviceStats } from './deviceHealth.vscode';
 import { normalizeHost } from '../core/remoteSessions';
 import { pickBestHost, cappedOutDevices, noHostReason, deviceHasUsableVersion, resolveBalancePool, DeviceLoad } from '../core/launchHost';
 import {
@@ -388,9 +388,8 @@ async function refreshLaunchHealthCache(context: vscode.ExtensionContext): Promi
           fetchedAt: Date.now(),
         };
       }
-      const creds = device.secretRef ? await resolveSecret(device.secretRef) : {};
       const [stats, running, usable] = await Promise.all([
-        fetchDeviceStats(device.host, { isLocal: false, identityFile: creds.identityFile, user: creds.user || device.user }),
+        fetchDeviceStats(device.host, { isLocal: false }),
         countRunningAgents(device.name, { isLocal: false }),
         Promise.all([...AUTO_HOST_AGENT_KEYS].map(async (agentKey) => [agentKey, await hostHasUsableVersion(device.name, agentKey)] as const)),
       ]);
@@ -465,7 +464,7 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
     vscode.window.showInformationMessage('Balanced launch: no online device available — running locally.');
     return undefined;
   }
-  // Look up each eligible device's registry entry for its SSH address + creds so
+  // Look up each eligible device's registry entry for its SSH address so
   // the hardware probe can reach it (mirrors the Factory Floor device-health
   // fetch in settings.vscode.ts).
   const byName = new Map(devices.map(d => [normalizeHost(d.name), d]));
@@ -477,9 +476,8 @@ async function resolveBalancedHost(pool?: string[], agentKey?: string): Promise<
       const running = await countRunningAgents(c.name, { isLocal: false });
       if (!agentKey) return { ...c, running };
       // Agent-aware: probe hardware health + usable-version in parallel.
-      const creds = dev?.secretRef ? await resolveSecret(dev.secretRef) : {};
       const [stats, usableVersion] = await Promise.all([
-        fetchDeviceStats(host, { isLocal: false, identityFile: creds.identityFile, user: creds.user || dev?.user }),
+        fetchDeviceStats(host, { isLocal: false }),
         hostHasUsableVersion(c.name, agentKey),
       ]);
       return {

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -19,7 +19,7 @@ import { getBuiltInByTitle, configFromDef } from './agents.vscode';
 import { openSingleAgentWithQueue, runHeadlessAgent, focusSessionInTerminal } from './extension';
 import { generateClaudeSessionId } from '../core/prewarm.simple';
 import { nudgeSession } from '../mcp/watchdog-bridge';
-import { runAgents } from '../core/agentsBin';
+import { runAgents, resolveAgentsBin, bootstrapPath } from '../core/agentsBin';
 import { AgentLaunchMode, extractPlanFromSessionJson, planTextToSteps } from '../core/agents';
 import { CLAUDE_TITLE } from '../core/utils';
 import { discoverRecentSessions, getSessionPathBySessionId } from './sessions.vscode';
@@ -63,7 +63,7 @@ import { startForemanAudio, ForemanAudioSession } from './foreman.audio';
 import { runSmartTurn, capHistory } from './foreman.smart';
 import { buildTaskDispatchPrompt } from '../core/tasks';
 import { draftDispatchPrompt, type DraftTicket } from '../core/draftPrompt';
-import { listRegisteredDevices, fetchDeviceStats, countRunningAgents, resolveSecret, getDeviceSyncStatus } from './deviceHealth.vscode';
+import { listRegisteredDevices, fetchDeviceStats, countRunningAgents, getDeviceSyncStatus } from './deviceHealth.vscode';
 import { inferProjectCandidates } from '../core/projectIndex';
 import { normalizeHost, buildRemoteFocusCommand } from '../core/remoteSessions';
 import { rankRepos } from '../core/repoIndex';
@@ -345,14 +345,21 @@ function buildDeviceSyncShell(policy: 'off' | 'safe' | 'aggressive'): string {
 
 const deviceExecFileAsync = promisify(execFile);
 
-// Spawn a coding agent on a registered device over SSH, honoring the resolved
-// credentials (identity file / user) and the auto-sync policy. Fire-and-forget:
+async function runAgentsSsh(host: string, remote: string, timeout: number): Promise<void> {
+  const bin = await resolveAgentsBin();
+  await deviceExecFileAsync(bin, ['ssh', host, '--', remote], {
+    timeout,
+    env: { ...process.env, PATH: `${bootstrapPath(bin)}:${process.env.PATH ?? ''}` },
+  });
+}
+
+// Spawn a coding agent on a registered device through agents-cli's SSH broker,
+// honoring the auto-sync policy. Fire-and-forget:
 // the remote agent is backgrounded (nohup) so the ssh call returns promptly.
 // Returns an error string to surface inline, or null on success.
 async function dispatchToDevice(input: {
   agentType: string;
   host: string;
-  secretRef?: string;
   projectPath: string;
   repoSlug?: string;
   syncPolicy: 'off' | 'safe' | 'aggressive';
@@ -361,10 +368,9 @@ async function dispatchToDevice(input: {
   /** Device registry platform (windows/macos/linux) — selects remote shell. */
   platform?: string;
 }): Promise<string | null> {
-  const { agentType, host, secretRef, projectPath, repoSlug, syncPolicy, mode, prompt, platform } = input;
+  const { agentType, host, projectPath, repoSlug, syncPolicy, mode, prompt, platform } = input;
   if (!projectPath) return 'Device dispatch: no project path resolved — pick a repo/project first.';
 
-  const creds = secretRef ? await resolveSecret(secretRef) : {};
   const windows = isWindowsDevicePlatform(platform);
 
   // Windows remotes: PowerShell script (no bash). POSIX: bash snippet (unchanged).
@@ -426,13 +432,8 @@ async function dispatchToDevice(input: {
     }
   }
 
-  const target = creds.user ? `${creds.user}@${host}` : host;
-  const args = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', '-o', 'StrictHostKeyChecking=accept-new'];
-  if (creds.identityFile) args.push('-i', creds.identityFile);
-  // `--` stops ssh option parsing; shell dialect follows device platform (RUSH-1481).
-  args.push('--', target, buildDeviceDispatchRemoteCmd(remote, platform));
   try {
-    await deviceExecFileAsync('ssh', args, { timeout: 60_000 });
+    await runAgentsSsh(host, buildDeviceDispatchRemoteCmd(remote, platform), 60_000);
     return null;
   } catch (err) {
     const e = err as { stderr?: string; message?: string };
@@ -1982,9 +1983,8 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
                 return { device, stats: { host: device.host, reachable: false, runningAgents: 0, fetchedAt: Date.now() } };
               }
               const isLocal = isLocalDeviceHost(device.host);
-              const creds = device.secretRef ? await resolveSecret(device.secretRef) : {};
               const [stats, runningAgents] = await Promise.all([
-                fetchDeviceStats(device.host, { isLocal, identityFile: creds.identityFile, user: creds.user || device.user }),
+                fetchDeviceStats(device.host, { isLocal }),
                 countRunningAgents(device.host, { isLocal }),
               ]);
               return { device, stats: { ...stats, reachable: true, runningAgents } };
@@ -2021,7 +2021,6 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
       case 'repoSync': {
         const root = typeof message.root === 'string' ? message.root : '';
         const syncHost = typeof message.host === 'string' ? message.host : '';
-        const syncSecretRef = typeof message.secretRef === 'string' ? message.secretRef : undefined;
         if (!root) {
           settingsPanel?.webview.postMessage({ type: 'repoSyncData', root: '', status: null });
           break;
@@ -2031,8 +2030,7 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
           // not on the local mac. Falls back to the local repo for this-mac.
           let status;
           if (syncHost && !isLocalDeviceHost(syncHost)) {
-            const creds = syncSecretRef ? await resolveSecret(syncSecretRef) : {};
-            status = await getDeviceSyncStatus(syncHost, root, { isLocal: false, identityFile: creds.identityFile, user: creds.user });
+            status = await getDeviceSyncStatus(syncHost, root, { isLocal: false });
           } else {
             status = await getSyncStatus(root, { fetch: true });
           }
@@ -2375,12 +2373,11 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
       case 'dispatchTask': {
         const agentType = typeof message.agentType === 'string' ? message.agentType : 'claude';
         // Device target: spawn the agent on a registered machine over SSH, in the
-        // resolved project path, honoring the auto-sync policy + resolved creds.
+        // resolved project path, honoring the auto-sync policy.
         // Kept separate from the local/cloud branches below (which are unchanged).
         if (message.target === 'device') {
           const deviceHost = typeof message.host === 'string' ? message.host : '';
           const projectPath = typeof message.projectPath === 'string' ? message.projectPath : '';
-          const secretRef = typeof message.secretRef === 'string' ? message.secretRef : undefined;
           const syncPolicy: 'off' | 'safe' | 'aggressive' =
             message.syncPolicy === 'off' || message.syncPolicy === 'aggressive' ? message.syncPolicy : 'safe';
           const deviceMode: DispatchModeMsg =
@@ -2412,7 +2409,6 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
           const err = await dispatchToDevice({
             agentType,
             host: deviceHost,
-            secretRef,
             projectPath,
             repoSlug: typeof message.repoSlug === 'string' ? message.repoSlug : undefined,
             syncPolicy,
@@ -3252,7 +3248,7 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
               if (replyHost) {
                 const remote = ['tmux', '-S', reply.muxSocket!, 'send-keys', '-t', reply.muxTarget!, ...keyArgs]
                   .map(shq).join(' ');
-                await execFileAsync('ssh', [replyHost, remote], { timeout: 20_000 });
+                await runAgentsSsh(replyHost, remote, 20_000);
               } else {
                 await execFileAsync('tmux', ['-S', reply.muxSocket!, 'send-keys', '-t', reply.muxTarget!, ...keyArgs], { timeout: 20_000 });
               }
@@ -3274,12 +3270,12 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
           } else if (reply.kind === 'cloud') {
             if (!reply.cloudTaskId) { postReplyResult(false, 'Missing cloud task id'); break; }
             const args = `cloud message ${shq(reply.cloudTaskId)} ${shq(replyText)}`;
-            if (replyHost) await execFileAsync('ssh', [replyHost, 'agents', 'cloud', 'message', reply.cloudTaskId, replyText], { timeout: 30_000 });
+            if (replyHost) await runAgentsSsh(replyHost, `agents cloud message ${shq(reply.cloudTaskId)} ${shq(replyText)}`, 30_000);
             else await runAgents(args);
             postReplyResult(true);
           } else if (reply.kind === 'team') {
             if (!reply.teamName) { postReplyResult(false, 'Missing team name'); break; }
-            if (replyHost) await execFileAsync('ssh', [replyHost, 'agents', 'factory', 'answer', reply.teamName, replyText], { timeout: 30_000 });
+            if (replyHost) await runAgentsSsh(replyHost, `agents factory answer ${shq(reply.teamName)} ${shq(replyText)}`, 30_000);
             else await runAgents(`factory answer ${shq(reply.teamName)} ${shq(replyText)}`);
             postReplyResult(true);
           } else {


### PR DESCRIPTION
Fix: Factory routes every owned remote-host operation through the `agents ssh` credential broker.

## Root cause

The device-health poller resolved a device secret with `agents secrets view <bundle> --reveal --plaintext`, materialized the private key, and passed it to raw `ssh`. The reveal path read a biometry-protected keychain item on every poll, producing repeated Touch ID sheets and orphaned prompt processes.

## Before / after

| Before | After |
| --- | --- |
| Factory resolved and materialized SSH credentials | Factory does not read device credentials |
| Five direct `ssh` subprocess calls | Remote commands use `agents ssh <host> -- <command>` |
| Health and sync APIs accepted `identityFile` / `user` | Health and sync APIs accept only `isLocal` |

The devices list remains lazy: listing reads registry metadata only; health commands still run only from the existing health and launch-health paths.

## Verification

No visible UI surface changed; this is a credential-routing bug fix.

Live broker command:

```text
$ agents ssh yosemite-m0 -- uptime
06:25:06 up 2 days, 3:56, 5 users, load average: 0.18, 0.37, 0.42
```

Compile:

```text
$ bun run compile
✓ 1812 modules transformed.
✓ built in 1.44s
✓ 2171 modules transformed.
✓ built in 1.98s
```

Focused device-health tests:

```text
$ bun test src/core/deviceHealth.test.ts --timeout 30000
10 pass
0 fail
10 expect() calls
```

Required absence checks:

```text
$ rg "resolveSecret|--reveal|secrets view" apps/factory/src
# zero matches
$ rg "execFileAsync\\('ssh'|execFileAsync\\(\"ssh\"" apps/factory/src
# zero matches
```

The full local suite reached 1556 passing tests; eight failures and two module-export errors remain in untouched test surfaces and are unrelated to this three-file change.
