### PR TITLE
fix(secrets): enforce one-sheet unlock invariant

### DIFF
--- a/apps/cli/.changelog/1.20.77.md
+++ b/apps/cli/.changelog/1.20.77.md
@@ -94,10 +94,8 @@
   `agentOnly` guard; and `isHeadlessSecretsContext` recognized the `headless` and
   `teams` runtimes but not `terminal`, which is what an interactive run sets. Agent
   launches now resolve broker-only and a locked bundle fails fast naming
-  `agents secrets unlock <bundle>`; `AGENTS_SECRETS_NO_PROMPT=1` is no longer needed
-  as a workaround. `agents secrets get/export/exec` typed in a **plain shell** still
-  prompts — it carries no `AGENTS_RUNTIME`, so the guard does not apply. Run beneath
-  an agent it refuses, because there the agent is the caller. This narrows the
+  `agents secrets unlock <bundle>`. Direct read commands use the same broker-only
+  path even from a plain shell; only an explicit unlock may authenticate. This narrows the
   agent-triggered approval added in RUSH-2032, which is unreleased.
 
 - **`release.sh` now borrows the npm token from a primary device when the local box

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2857,10 +2857,8 @@
   `agentOnly` guard; and `isHeadlessSecretsContext` recognized the `headless` and
   `teams` runtimes but not `terminal`, which is what an interactive run sets. Agent
   launches now resolve broker-only and a locked bundle fails fast naming
-  `agents secrets unlock <bundle>`; `AGENTS_SECRETS_NO_PROMPT=1` is no longer needed
-  as a workaround. `agents secrets get/export/exec` typed in a **plain shell** still
-  prompts — it carries no `AGENTS_RUNTIME`, so the guard does not apply. Run beneath
-  an agent it refuses, because there the agent is the caller. This narrows the
+  `agents secrets unlock <bundle>`. Direct read commands use the same broker-only
+  path even from a plain shell; only an explicit unlock may authenticate. This narrows the
   agent-triggered approval added in RUSH-2032, which is unreleased.
 
 - **`release.sh` now borrows the npm token from a primary device when the local box

--- a/apps/cli/src/commands/browser.ts
+++ b/apps/cli/src/commands/browser.ts
@@ -27,7 +27,7 @@ import {
   AUTH_SIGNATURES,
 } from '../lib/browser/login-detection.js';
 import { parseSecretRef } from '../lib/browser/secret-ref.js';
-import { readAndResolveBundleEnv, isHeadlessSecretsContext, bundleExists, readBundle, describeBundle } from '../lib/secrets/bundles.js';
+import { readAndResolveBundleEnv, bundleExists, readBundle, describeBundle } from '../lib/secrets/bundles.js';
 import { findBrowserPath, getPortOccupant, isLauncherScript } from '../lib/browser/chrome.js';
 import {
   listProfileCacheDirs,
@@ -1622,7 +1622,7 @@ function registerTaskCommands(browser: Command): void {
           process.exit(1);
         }
         try {
-          const { env } = readAndResolveBundleEnv(parsed.bundle, { caller: 'browser type', keys: [parsed.key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(parsed.bundle, { caller: 'browser type', keys: [parsed.key], keyMode: 'storage', agentOnly: true });
           if (!(parsed.key in env)) {
             console.error(`Key "${parsed.key}" not in bundle "${parsed.bundle}".`);
             process.exit(1);

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -2379,10 +2379,8 @@ Examples:
           process.exit(1);
         }
         // `agents secrets export --plaintext` is what release/CI scripts eval.
-        // When it runs detached (both stdio non-TTY) or beneath ANY agent — which
-        // inherits AGENTS_RUNTIME — resolve broker-only so it can never pop a Touch
-        // ID sheet on the interactive user's screen. An `eval "$(...)"` typed in a
-        // plain shell carries no AGENTS_RUNTIME, so it is not headless and still prompts.
+        // Every caller is broker-only, including a plain shell, so export never
+        // raises Touch ID on the interactive user's screen.
         const { env } = readAndResolveBundleEnv(resolvedBundleName, {
           caller: `export to shell`,
           keyMode: 'process',

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -37,10 +37,10 @@ import {
   keychainItemsForBundle,
   keychainRef,
   listBundles,
+  healKeychainBundleMetadataAclOnce,
   migrateLegacyBundles,
   parseDotenv,
   readAndResolveBundleEnv,
-  isHeadlessSecretsContext,
   readBundle,
   readBundleIfDecryptable,
   reAclBundleItems,
@@ -77,10 +77,10 @@ import {
 import { encryptForFallback, decryptForFallback, type EncFile } from '../lib/secrets/filestore.js';
 import {
   getKeychainToken,
-  getKeychainTokens,
   hasKeychainToken,
   secretsKeychainItem,
   setKeychainToken,
+  maybeAutoRekey,
 } from '../lib/secrets/index.js';
 import {
   assertOpAvailable,
@@ -1374,13 +1374,15 @@ export function registerSecretsCommands(program: Command): void {
           }
           const revealed = new Map<string, string>();
           if (reveal) {
-            const items = entries
-              .filter((e) => e.kind === 'keychain')
-              .map((e) => secretsKeychainItem(bundle.name, e.detail));
-            try {
-              for (const [item, value] of getKeychainTokens(items)) revealed.set(item, value);
-            } catch {
-              /* cancelled / batch failure — fall through to masked (null) values */
+            const { env } = readAndResolveBundleEnv(bundle.name, {
+              caller: 'view --reveal --json',
+              keyMode: 'storage',
+              agentOnly: true,
+            });
+            for (const entry of entries) {
+              if (entry.kind === 'keychain' && env[entry.key] !== undefined) {
+                revealed.set(secretsKeychainItem(bundle.name, entry.detail), env[entry.key]);
+              }
             }
             const exposed = revealed.size + entries.filter((e) => e.kind === 'literal').length;
             if (exposed > 0) {
@@ -1482,21 +1484,20 @@ export function registerSecretsCommands(program: Command): void {
           console.error(chalk.red('--reveal in a non-TTY requires --plaintext.'));
           process.exit(1);
         }
-        // Batch every backend read into one helper call where supported, so
-        // keychain --reveal pops Touch ID once and synced/file bundles use
-        // their declared storage.
+        // Resolve through the broker / durable-session path. A locked keychain
+        // bundle errors with the explicit unlock hint; viewing never raises a
+        // Touch ID sheet itself.
         const revealedValues = new Map<string, string>();
         if (reveal) {
-          const items = entries
-            .filter((e) => e.kind === 'keychain')
-            .map((e) => secretsKeychainItem(bundle.name, e.detail));
-          try {
-            const fetched = bundle.backend
-              ? new Map(items.map((item) => [item, bundleItemStore(bundle.backend).get(item)]))
-              : getKeychainTokens(items);
-            for (const [item, value] of fetched) revealedValues.set(item, value);
-          } catch {
-            // Fall through to masked output on cancellation / batch failure.
+          const { env } = readAndResolveBundleEnv(bundle.name, {
+            caller: 'view --reveal',
+            keyMode: 'storage',
+            agentOnly: true,
+          });
+          for (const entry of entries) {
+            if (entry.kind === 'keychain' && env[entry.key] !== undefined) {
+              revealedValues.set(secretsKeychainItem(bundle.name, entry.detail), env[entry.key]);
+            }
           }
           // Revealing plaintext bypasses readAndResolveBundleEnv (the usual
           // audit chokepoint), so emit here — a `--reveal` exposes real values
@@ -1582,10 +1583,9 @@ export function registerSecretsCommands(program: Command): void {
           process.exit(1);
         }
         // `secrets get` is the scriptable automation primitive ($(agents secrets
-        // get bundle KEY)); when embedded in a headless routine/CI script — or run
-        // beneath any agent, which inherits AGENTS_RUNTIME — it must not pop an
-        // unwatched Touch ID prompt. Typed in a plain shell it still prompts.
-        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+        // get bundle KEY)). Every read is broker-only; a locked bundle points at
+        // the explicit unlock command instead of raising Touch ID.
+        const { env } = readAndResolveBundleEnv(item, { caller: 'secrets get', keys: [key], keyMode: 'storage', agentOnly: true });
         if (!(key in env)) {
           console.error(chalk.red(`Key '${key}' not in bundle '${item}'.`));
           process.exit(1);
@@ -2221,7 +2221,7 @@ Examples:
               'Set it for this command, then supply the same value when importing.'
             );
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: 'export --to-file', keyMode: 'storage', agentOnly: true });
           exportBundleToFile(env, opts.toFile, passphrase);
           emitSecretAudit({ event: 'secrets.export', bundle: resolvedBundleName, operation: 'export --to-file', source: 'file', status: 'success', keyCount: Object.keys(env).length });
           console.log(chalk.green(`Exported ${Object.keys(env).length} key(s) to ${opts.toFile}`));
@@ -2251,7 +2251,7 @@ Examples:
               );
             }
           }
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `ssh export`, keyMode: 'storage', agentOnly: true });
           const dotenv = bundleEnvToDotenv(env);
           const keyCount = Object.keys(env).length;
           // Drive the remote's own `agents secrets import --from -` so the values
@@ -2342,7 +2342,7 @@ Examples:
         if (opts.to1password) {
           assertOpAvailable();
           const vault = await resolveVault(opts.vault);
-          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: isHeadlessSecretsContext() });
+          const { env } = readAndResolveBundleEnv(resolvedBundleName, { caller: `1Password vault ${vault}`, keyMode: 'storage', agentOnly: true });
           let created = 0;
           let overwritten = 0;
           let skipped = 0;
@@ -2386,7 +2386,7 @@ Examples:
         const { env } = readAndResolveBundleEnv(resolvedBundleName, {
           caller: `export to shell`,
           keyMode: 'process',
-          agentOnly: isHeadlessSecretsContext(),
+          agentOnly: true,
         });
         if (opts.format === 'json') {
           // Machine-readable form consumed by `remoteResolveEnv` over SSH.
@@ -2451,7 +2451,7 @@ Examples:
             caller: `command ${cmd}`,
             keys: keysSubset,
             allowExpired: execOpts.allowExpired,
-            agentOnly: isHeadlessSecretsContext(),
+            agentOnly: true,
           }).env;
         }
         const { spawn } = await import('child_process');
@@ -2724,6 +2724,11 @@ Examples:
             duration: humanRemaining(Date.now() + ttlMs),
             keyMode: 'storage',
           });
+          // Migrations are authorized only by this explicit unlock. The bundle
+          // metadata was included in the successful authenticated batch, so the
+          // ACL heal can rewrite that already-read value without another read.
+          maybeAutoRekey();
+          healKeychainBundleMetadataAclOnce(new Map([[bundle.name, JSON.stringify(bundle)]]));
           if (await agentLoad(name, bundle, env, ttlMs, harness)) {
             loaded++;
             // Persist a durable session snapshot so the unlock survives a daemon

--- a/apps/cli/src/commands/share.test.ts
+++ b/apps/cli/src/commands/share.test.ts
@@ -35,14 +35,14 @@ async function freshShareModules() {
   const mem = makeMemoryBackend();
   const secrets = await import('../lib/secrets/index.js');
   secrets.setKeychainBackendForTest(mem.backend);
+  const bundles = await import('../lib/secrets/bundles.js');
+  bundles.setKeychainAgentOnlyBypassForTest(true);
   const filestore = await import('../lib/secrets/filestore.js');
   filestore._resetFileStoreForTest({ fileDir: path.join(tmpHome, '.file-secrets') });
   const share = await import('./share.js');
   const config = await import('../lib/share/config.js');
   return { share, config, mem };
 }
-
-let previousNoPrompt: string | undefined;
 
 beforeEach(() => {
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-share-command-'));
@@ -51,11 +51,7 @@ beforeEach(() => {
   previousPath = process.env.PATH;
   previousShareGitHubUser = process.env.AGENTS_SHARE_GITHUB_USER;
   delete process.env.AGENTS_SHARE_GITHUB_USER;
-  // Reads go to a temp HOME with no real keychain/agent; on darwin-headless (the
-  // release-gated macOS CI matrix) isHeadlessSecretsContext() would force the
-  // agentOnly no-prompt throw. Pin NO_PROMPT=0 so the direct read runs on every OS.
-  previousNoPrompt = process.env.AGENTS_SECRETS_NO_PROMPT;
-  process.env.AGENTS_SECRETS_NO_PROMPT = '0';
+  // Reads go to a temp HOME with an in-memory keychain backend.
   vi.spyOn(console, 'log').mockImplementation(() => {});
 });
 
@@ -68,8 +64,6 @@ afterEach(() => {
   else process.env.PATH = previousPath;
   if (previousShareGitHubUser === undefined) delete process.env.AGENTS_SHARE_GITHUB_USER;
   else process.env.AGENTS_SHARE_GITHUB_USER = previousShareGitHubUser;
-  if (previousNoPrompt === undefined) delete process.env.AGENTS_SECRETS_NO_PROMPT;
-  else process.env.AGENTS_SECRETS_NO_PROMPT = previousNoPrompt;
   fs.rmSync(tmpHome, { recursive: true, force: true });
 });
 

--- a/apps/cli/src/commands/ssh.ts
+++ b/apps/cli/src/commands/ssh.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getCliVersion } from '../lib/version.js';
-import { readAndResolveBundleEnv, isHeadlessSecretsContext } from '../lib/secrets/bundles.js';
+import { readAndResolveBundleEnv } from '../lib/secrets/bundles.js';
 import { machineId } from '../lib/session/sync/config.js';
 import { isDeviceAuto, resolveDeviceAffinity } from '../lib/smart-launch.js';
 import { registerFleetCaptureCommand } from './fleet-capture.js';
@@ -1625,9 +1625,8 @@ async function runAskpass(): Promise<void> {
   }
   // A read-only stats probe sets ASKPASS_AGENT_ONLY_ENV to force a broker-only
   // resolve even under a TTY — so `agents devices` never pops Touch ID just to
-  // render load/mem for an uncached password-auth device (RUSH-1970). Otherwise
-  // fall back to the headless-context heuristic.
-  const agentOnly = process.env[ASKPASS_AGENT_ONLY_ENV] === '1' || isHeadlessSecretsContext();
+  // render load/mem for an uncached password-auth device (RUSH-1970).
+  const agentOnly = true;
   try {
     const { env } = readAndResolveBundleEnv(bundle, { caller: 'agents ssh', keys: [key], keyMode: 'storage', agentOnly });
     const value = env[key];

--- a/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
+++ b/apps/cli/src/lib/secrets/__tests__/keychain-helper.test.ts
@@ -37,6 +37,13 @@ describe('keychain-helper Touch ID policy', () => {
     expect(source).toContain('case "get":');
     expect(source).toContain('case "get-batch":');
   });
+
+  it('silent no-ACL reads skip authentication UI instead of raising a sheet', () => {
+    const source = helperSource();
+    const block = source.slice(source.indexOf('func readItem('), source.indexOf('func migrateInline('));
+    expect(source).toContain('let skipAuthenticationUI = ProcessInfo.processInfo.environment["AGENTS_KEYCHAIN_SKIP_AUTH_UI"] == "1"');
+    expect(block.match(/skipAuthenticationUI \? kSecUseAuthenticationUISkip : kSecUseAuthenticationUIAllow/g)).toHaveLength(3);
+  });
 });
 
 describe('keychain-helper data-protection keychain routing', () => {
@@ -197,6 +204,13 @@ describe('keychain-helper has / list still probe both keychains', () => {
     expect(block).toContain('for query in [fileQuery, dpQuery]');
     expect(block).toContain('if status == errSecInteractionNotAllowed { continue }');
     expect(block).toContain('kSecReturnAttributes');
+    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUISkip');
+  });
+
+  it('list-synced skips authentication UI while enumerating attributes', () => {
+    const block = caseBlock(helperSource(), 'list-synced');
+    expect(block).toContain('kSecReturnAttributes');
+    expect(block).toContain('kSecUseAuthenticationUI: kSecUseAuthenticationUISkip');
   });
 });
 

--- a/apps/cli/src/lib/secrets/bundles.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.test.ts
@@ -251,43 +251,12 @@ describe('readAndResolveBundleEnv agent-only reads', () => {
 });
 
 describe('isHeadlessSecretsContext', () => {
-  // The branch carrying this guard's entire safety argument: a person in a plain
-  // shell must still get their prompt. Nothing reached it before — the TTY state was
-  // read from process.* directly, so a mutant that made a plain shell NEVER prompt
-  // (which would strand every cold bundle) left the whole suite green.
-  // The DEFAULT binding, not just the branch. Parameterizing the TTY state split one
-  // untested expression into a tested branch plus an untested default; a miswired
-  // default would make a detached release script `( ... ) >log 2>&1 </dev/null`
-  // classify as non-headless and pop a sheet nobody is watching — the exact failure
-  // this guard exists to prevent. Calls the TWO-arg form so the default is exercised.
-  it('defaults to the live process TTY state when none is passed', () => {
-    const d = (k: 'stdin' | 'stdout') => Object.getOwnPropertyDescriptor(process[k], 'isTTY');
-    const set = (k: 'stdin' | 'stdout', v: boolean | undefined) =>
-      Object.defineProperty(process[k], 'isTTY', { value: v, configurable: true, writable: true });
-    const [pin, pout] = [d('stdin'), d('stdout')];
-    try {
-      set('stdin', undefined); set('stdout', undefined);
-      expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin')).toBe(true);
-      set('stdin', true); set('stdout', true);
-      expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin')).toBe(false);
-    } finally {
-      if (pin) Object.defineProperty(process.stdin, 'isTTY', pin);
-      if (pout) Object.defineProperty(process.stdout, 'isTTY', pout);
-    }
-  });
-
-  it('a plain human shell with a TTY is NOT headless — it still prompts', () => {
-    expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin', { stdin: true, stdout: true })).toBe(false);
-  });
-
-  it('a detached process with no TTY IS headless — it must not prompt', () => {
-    expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin', { stdin: false, stdout: false })).toBe(true);
-  });
-
-  it('an agent runtime is headless even with a TTY — the agent is the caller', () => {
+  it('is true only for structural agent runtimes on darwin', () => {
     for (const runtime of ['headless', 'teams', 'terminal']) {
-      expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: runtime } as NodeJS.ProcessEnv, 'darwin', { stdin: true, stdout: true })).toBe(true);
+      expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: runtime } as NodeJS.ProcessEnv, 'darwin')).toBe(true);
     }
+    expect(isHeadlessSecretsContext({} as NodeJS.ProcessEnv, 'darwin')).toBe(false);
+    expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'interactive' } as NodeJS.ProcessEnv, 'darwin')).toBe(false);
   });
 
   it('is true for headless/teams runtime on darwin (where the Touch ID sheet exists)', () => {
@@ -307,12 +276,6 @@ describe('isHeadlessSecretsContext', () => {
     // real (prompt-less) backend answers.
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'headless' } as NodeJS.ProcessEnv, 'linux')).toBe(false);
     expect(isHeadlessSecretsContext({ AGENTS_RUNTIME: 'teams' } as NodeJS.ProcessEnv, 'win32')).toBe(false);
-    expect(isHeadlessSecretsContext({ AGENTS_SECRETS_NO_PROMPT: '1' } as NodeJS.ProcessEnv, 'linux')).toBe(false);
-  });
-
-  it('honors AGENTS_SECRETS_NO_PROMPT override on darwin (1 forces headless-safe, 0 force-allows)', () => {
-    expect(isHeadlessSecretsContext({ AGENTS_SECRETS_NO_PROMPT: '1', AGENTS_RUNTIME: 'terminal' } as NodeJS.ProcessEnv, 'darwin')).toBe(true);
-    expect(isHeadlessSecretsContext({ AGENTS_SECRETS_NO_PROMPT: '0', AGENTS_RUNTIME: 'headless' } as NodeJS.ProcessEnv, 'darwin')).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -135,6 +135,13 @@ const vaultStore: ItemStore = {
   list: vaultListItems,
 };
 
+let keychainAgentOnlyBypassForTest = false;
+
+/** Disable the broker-only guard for in-memory keychain tests. */
+export function setKeychainAgentOnlyBypassForTest(bypass: boolean): void {
+  keychainAgentOnlyBypassForTest = bypass;
+}
+
 function itemStore(backend: SecretsBackend): ItemStore {
   if (backend === 'file') return fileItemStore;
   if (backend === 'vault') return vaultStore;
@@ -745,7 +752,7 @@ export function healKeychainBundleMetadata(metaJsonByName: Map<string, string>):
  * backend has no real keychain — and gated by a sentinel so it runs at most
  * once. Best-effort: a heal failure never breaks bundle listing.
  */
-function healKeychainBundleMetadataAclOnce(metaJsonByName: Map<string, string>): void {
+export function healKeychainBundleMetadataAclOnce(metaJsonByName: Map<string, string>): void {
   if (metaJsonByName.size === 0) return;
   if (process.platform !== 'darwin') return;
   if (isKeychainBackendOverridden()) return;
@@ -817,7 +824,6 @@ export function listBundles(): SecretsBundle[] {
         // still prompt once; it heals on the next interactive scan.)
         const fetched = getKeychainTokens(keychainServices, { silentNoAcl: true });
         const keychainBundles: SecretsBundle[] = [];
-        const metaJsonByName = new Map<string, string>();
         for (const service of keychainServices) {
           const json = fetched.get(service);
           if (json === undefined) continue;
@@ -827,7 +833,6 @@ export function listBundles(): SecretsBundle[] {
           const bundle = parseBundleMeta(nameHint, json, 'keychain');
           if (bundle) {
             keychainBundles.push(bundle);
-            metaJsonByName.set(bundle.name, json);
           }
         }
         for (const bundle of keychainBundles) out.push(bundle);
@@ -838,13 +843,6 @@ export function listBundles(): SecretsBundle[] {
         if (useAgent && keychainBundles.length > 0) {
           agentAutoLoadMetaSync(nameSetHash, keychainBundles, secretsHoldMs());
         }
-        // One-time RUSH-1759 heal: bundles written before the metadata-no-ACL
-        // change carry an ACL'd metadata item, so this fresh read (a broker miss)
-        // popped Touch ID just to enumerate them. Re-home each metadata item
-        // no-ACL now — reusing the JSON we just read, so the heal adds no extra
-        // prompt — and every later enumeration is silent. Runs at most once (a
-        // sentinel under the regenerable helpers dir).
-        healKeychainBundleMetadataAclOnce(metaJsonByName);
       }
     }
   }
@@ -1322,24 +1320,14 @@ export function readAndResolveBundleEnv(
     }
   }
 
-  // Never/no-ACL bundles remain prompt-free regardless. No agent launch — harness,
-  // teammate, routine, or the always-on daemon — may raise the sheet itself.
-  // Explicit opt-in ONLY — a deliberate NARROWING of the agent-triggered approval
-  // added in RUSH-2032 (b99796f8 removed this throw so an agent could raise the
-  // sheet itself; 4eeada68 generalized the daemon rule into `!interactiveUnlock`).
-  // That default — true whenever an agent name was present — was the spec, not a
-  // bug. It is unwanted: each keychain read runs in its own helper process, so the
-  // biometric assertion never reuses and one agent launch meant one sheet per
-  // bundle. `agentOnly` decides alone now; a human in a plain shell carries no
-  // AGENTS_RUNTIME, so isHeadlessSecretsContext() is false, agentOnly is false, the
-  // guard never fires, and they still get their prompt. No caller passes this flag;
-  // it remains the seam for a future unlock path that wants the sheet on purpose.
+  // Never/no-ACL bundles remain prompt-free regardless. Every ordinary caller
+  // sets agentOnly; only the unlock handler opts into interactive authentication.
   const interactiveUnlock = opts.interactiveUnlock ?? false;
   // A `never`-policy bundle's items carry no biometry ACL, so once the policy
   // check below proves that, the batch read is silent even in a headless
   // context — attest it to the raw-read storm guard via `silentNoAcl`.
   let verifiedNoAclBundle = false;
-  if (opts.agentOnly && backend === 'keychain' && !interactiveUnlock) {
+  if (opts.agentOnly && backend === 'keychain' && !interactiveUnlock && !keychainAgentOnlyBypassForTest) {
     try { verifiedNoAclBundle = bundlePolicy(readBundle(name)) === 'never'; } catch { /* fail closed */ }
     if (!verifiedNoAclBundle) {
       throw new Error(

--- a/apps/cli/src/lib/secrets/headless.ts
+++ b/apps/cli/src/lib/secrets/headless.ts
@@ -6,22 +6,13 @@
  */
 
 /**
- * True when the current process is a background / non-interactive context that
- * must NEVER raise a Keychain biometry prompt on the interactive user's screen —
- * a prompt nobody is watching. Two signals, either sufficient:
+ * True when the current process was structurally launched by an agent runtime
+ * that must NEVER raise a Keychain biometry prompt on the user's screen:
  *   - `AGENTS_RUNTIME` is `headless`, `teams`, or `terminal` — i.e. ANY agent
  *     launch, interactive included, and inherited by everything spawned beneath
  *     one (set on the child env by `agents run --headless`, scheduled routines,
  *     teammates, and interactive runs — see exec.ts:430, runner.ts,
  *     teams/agents.ts).
- *   - neither stdin nor stdout is a TTY (a detached/backgrounded task whose
- *     stdio is redirected to a log — e.g. a release script run in the
- *     background as `( ... ) >log 2>&1 </dev/null`).
- * `AGENTS_SECRETS_NO_PROMPT=1` forces headless-safe; `=0` force-allows a prompt
- * even in a non-TTY context. An `eval "$(agents secrets export X)"` typed in a
- * PLAIN shell has no AGENTS_RUNTIME, so it is not classified headless and still
- * prompts. Run beneath an agent it inherits AGENTS_RUNTIME and resolves
- * broker-only — the agent, not the human, is the caller there.
  *
  * Only **macOS keychain** reads pop an interactive Touch ID sheet — the secrets
  * broker itself is a no-op off darwin (see agent.ts), and libsecret (Linux) /
@@ -37,27 +28,10 @@
 export function isHeadlessSecretsContext(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
-  // Injected so the TTY branch below is testable: it is the branch that decides a
-  // plain human shell still prompts, which is this guard's entire safety argument,
-  // and reading process.* directly made it unreachable from a test.
-  tty: { stdin?: boolean; stdout?: boolean } = { stdin: process.stdin.isTTY, stdout: process.stdout.isTTY },
 ): boolean {
   if (platform !== 'darwin') return false; // no biometry prompt to suppress off-darwin
-  const override = env.AGENTS_SECRETS_NO_PROMPT;
-  if (override === '1') return true;
-  if (override === '0') return false;
-  // Every AGENT-LAUNCH runtime resolves broker-only, interactive included.
-  // `terminal` was missing, which made an agent terminal the one launch path
-  // still allowed to pop Touch ID: exec.ts sets AGENTS_RUNTIME='terminal' for an
-  // interactive run (exec.ts:430), that fell through to the TTY check below, and
-  // a TTY meant "a human is watching, so prompting is fine". It is not fine —
-  // opening a terminal is not a request to authenticate, and a launch that needs
-  // a locked bundle should say so and point at `agents secrets unlock`, not grab
-  // the fingerprint sensor. AGENTS_RUNTIME is INHERITED by everything spawned under
-  // an agent, so `agents secrets export` run beneath one resolves broker-only too —
-  // correctly: there the agent, not the human, is the caller. A plain shell carries
-  // no AGENTS_RUNTIME, so a person running it themselves still gets the sheet.
+  // Every agent-launch runtime resolves broker-only, interactive included.
   const runtime = env.AGENTS_RUNTIME;
   if (runtime === 'headless' || runtime === 'teams' || runtime === 'terminal') return true;
-  return !tty.stdin && !tty.stdout;
+  return false;
 }

--- a/apps/cli/src/lib/secrets/index.test.ts
+++ b/apps/cli/src/lib/secrets/index.test.ts
@@ -301,7 +301,7 @@ describe('service-name hashing through the primitives', () => {
     expect(healHmacKeyNoAclOnce(stored)).toBe(false);
   });
 
-  it('readHmacKeyRecord heals a stale ACL-stamped hmackey ON READ, once (converges the devices-probe hot path)', () => {
+  it('readHmacKeyRecord never mutates a stale ACL-stamped hmackey on the read path', () => {
     const rec = { v: 1, k: 'cd'.repeat(32), migrated: true };
     // A hmackey an old helper left biometry-ACL'd: present in the store, but NOT
     // written through the no-ACL path — so a real read pops the generic Touch ID
@@ -309,19 +309,18 @@ describe('service-name hashing through the primitives', () => {
     mem.set(HMAC_KEY_ITEM, JSON.stringify(rec));
     expect(mem.noAclWrites.has(HMAC_KEY_ITEM)).toBe(false);
 
-    // The very read every hashed lookup performs (the devices-list stats probe,
-    // any background read) now re-stores it no-ACL once, preserving the key.
+    // Ordinary hashed lookups only read; they do not run the migration.
     const read = readHmacKeyRecord();
     expect(read?.k).toBe(rec.k);
-    expect(read?.healedNoAcl).toBe(true);
-    expect(mem.noAclWrites.has(HMAC_KEY_ITEM)).toBe(true);
+    expect(read?.healedNoAcl).toBeUndefined();
+    expect(mem.noAclWrites.has(HMAC_KEY_ITEM)).toBe(false);
     const stored = JSON.parse(mem.store.get(HMAC_KEY_ITEM) as string);
-    expect(stored.healedNoAcl).toBe(true);
+    expect(stored.healedNoAcl).toBeUndefined();
     expect(stored.k).toBe(rec.k);
 
-    // A subsequent read is silent (already healed) — no repeat no-ACL churn.
+    // A subsequent read remains non-mutating too.
     mem.noAclWrites.delete(HMAC_KEY_ITEM);
-    expect(readHmacKeyRecord()?.healedNoAcl).toBe(true);
+    expect(readHmacKeyRecord()?.healedNoAcl).toBeUndefined();
     expect(mem.noAclWrites.has(HMAC_KEY_ITEM)).toBe(false);
   });
 

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -332,29 +332,7 @@ export function readHmacKeyRecord(): HmacKeyRecord | null {
   } catch {
     return null;
   }
-  const record = parseHmacKeyRecord(raw);
-  // Converge a stale-ACL'd hmackey to silent, on the HOT read path. An old helper
-  // (pre the metadata/hmackey no-ACL migration fix) re-stamped this
-  // contractually-no-ACL item with a biometry ACL, so the read just above pops the
-  // generic "Agents CLI needs to authenticate" sheet on EVERY hashed lookup — the
-  // `agents devices list` stats probe the SessionStart hook runs, and every other
-  // background hashed read. `maybeAutoRekey`'s one-shot heal only fires on a
-  // cleartext-bundle resolve and is bypassed for the hmackey/hashed-name path
-  // (prepareServiceName returns early for HMAC_KEY_ITEM before maybeAutoRekey), so
-  // it never converged exactly these reads and the machine prompted forever.
-  // Re-store the record no-ACL once per machine here (the read that produced it has
-  // already happened — and already prompted if the item was ACL'd); every
-  // subsequent read, in this process and all future ones, is silent.
-  if (record && !record.healedNoAcl) {
-    try {
-      healHmacKeyNoAclOnce(record);
-      record.healedNoAcl = true;
-    } catch {
-      // A failed no-ACL re-store leaves the item still ACL'd (a still-prompting
-      // read) rather than a silent wrong state; the next process retries.
-    }
-  }
-  return record;
+  return parseHmacKeyRecord(raw);
 }
 
 function writeHmacKeyRecord(rec: HmacKeyRecord): void {
@@ -411,11 +389,10 @@ export function keychainServiceAlias(item: string): string {
   return prepareServiceName(item);
 }
 
-function prepareServiceName(item: string, opts?: { autoRekey?: boolean }): string {
+function prepareServiceName(item: string): string {
   if (rawScopeDepth > 0) return item;
   if (!isOurItem(item)) return item;
   if (item === HMAC_KEY_ITEM || item.startsWith(HASHED_SERVICE_PREFIX)) return item;
-  if (opts?.autoRekey) maybeAutoRekey();
   const st = resolveHashState();
   if (!st.active || !st.key) return item;
   return hashedServiceName(item, st.key);
@@ -438,7 +415,6 @@ function prepareListPrefix(prefix: string): MappedListPrefix {
   if (rawScopeDepth > 0) return { prefix };
   if (!prefix.startsWith(`${SERVICE_PREFIX}.`)) return { prefix };
   if (prefix.startsWith(HASHED_SERVICE_PREFIX)) return { prefix };
-  maybeAutoRekey();
   const st = resolveHashState();
   if (!st.active || !st.key) return { prefix };
   if (prefix === BUNDLES_ITEM_PREFIX) {
@@ -519,7 +495,7 @@ function finishPendingDeletes(rec: HmacKeyRecord): void {
  * Never throws — a failed attempt leaves the process on cleartext names
  * (exact pre-#316 behavior) and the next process retries.
  */
-function maybeAutoRekey(): void {
+export function maybeAutoRekey(): void {
   if (autoRekeyAttempted || rekeyRunning || rawScopeDepth > 0) return;
   autoRekeyAttempted = true;
   if (forcedTestKey || backend) return;
@@ -530,10 +506,13 @@ function maybeAutoRekey(): void {
   if (process.env.AGENTS_SECRETS_HASH_NAMES === '0') return;
   const st = resolveHashState();
   if (st.active) {
-    // The stale-ACL'd-hmackey heal now runs on the hot read path
-    // (readHmacKeyRecord), which the resolveHashState() above just went through —
-    // so st.record is already healed here regardless of how this machine reached
-    // "hashing active". Nothing to do but finish any pending deletes.
+    if (st.record && !st.record.healedNoAcl) {
+      try {
+        healHmacKeyNoAclOnce(st.record);
+      } catch {
+        /* the next explicit unlock retries */
+      }
+    }
     if (st.record?.pendingDeletes?.length) {
       try {
         finishPendingDeletes(st.record);
@@ -961,7 +940,7 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
   // Errors keep the requested (human-readable) name; the storage name may be
   // an opaque hash.
   const requested = item;
-  item = prepareServiceName(item, { autoRekey: true });
+  item = prepareServiceName(item);
   if (backend) return backend.get(item);
   assertRawKeychainReadAllowed(requested, context);
   assertSupportedPlatform();
@@ -986,6 +965,7 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
       ...process.env,
       AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
       AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
+      AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
     },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -1024,7 +1004,7 @@ export function getKeychainTokens(items: string[], context: KeychainReadContext 
   // whether those were cleartext (hashed here) or already-hashed (enumerated).
   const requestedByStorage = new Map<string, string>();
   const storageItems = items.map((item) => {
-    const storage = prepareServiceName(item, { autoRekey: true });
+    const storage = prepareServiceName(item);
     if (!requestedByStorage.has(storage)) requestedByStorage.set(storage, item);
     return storage;
   });
@@ -1063,6 +1043,7 @@ export function getKeychainTokens(items: string[], context: KeychainReadContext 
       ...process.env,
       AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
       AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
+      AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
       // The signed helper's own vocabulary is unchanged (it predates the rename
       // and ships as a separately-versioned binary), so map to its legacy token.
       AGENTS_KEYCHAIN_DEFAULT_POLICY: (context.defaultPolicy ?? 'hold') === 'hold' ? 'daily' : (context.defaultPolicy as string),
@@ -1161,7 +1142,7 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
   // resolve the storage name.
   if (/[\x00=\r\n]/.test(item)) throw new Error('Secret item name contains invalid characters.');
   const requested = item;
-  item = prepareServiceName(item, { autoRekey: true });
+  item = prepareServiceName(item);
   if (backend) { backend.set(item, value, opts); return; }
   assertSupportedPlatform();
   assertValueStorable(value);

--- a/apps/cli/src/lib/secrets/keychain-helper.swift
+++ b/apps/cli/src/lib/secrets/keychain-helper.swift
@@ -28,6 +28,8 @@ let authContext: LAContext = {
     return ctx
 }()
 
+let skipAuthenticationUI = ProcessInfo.processInfo.environment["AGENTS_KEYCHAIN_SKIP_AUTH_UI"] == "1"
+
 // Build the access control that gates every item we write: unlock requires a
 // current-enrollment biometry match OR the device passcode, and the item is
 // scoped to this device only. The OS itself enforces this on every
@@ -208,7 +210,7 @@ func readItem(service: String, account: String) -> ReadOutcome {
     dpQuery[kSecReturnData] = kCFBooleanTrue!
     dpQuery[kSecMatchLimit] = kSecMatchLimitOne
     dpQuery[kSecUseAuthenticationContext] = authContext
-    dpQuery[kSecUseAuthenticationUI] = kSecUseAuthenticationUIAllow
+    dpQuery[kSecUseAuthenticationUI] = skipAuthenticationUI ? kSecUseAuthenticationUISkip : kSecUseAuthenticationUIAllow
     dpQuery[kSecUseOperationPrompt] = operationPrompt as CFString
     var dpResult: AnyObject?
     let dpStatus = SecItemCopyMatching(dpQuery as CFDictionary, &dpResult)
@@ -231,7 +233,7 @@ func readItem(service: String, account: String) -> ReadOutcome {
     orphanQuery[kSecReturnPersistentRef] = kCFBooleanTrue!
     orphanQuery[kSecMatchLimit] = kSecMatchLimitOne
     orphanQuery[kSecUseAuthenticationContext] = authContext
-    orphanQuery[kSecUseAuthenticationUI] = kSecUseAuthenticationUIAllow
+    orphanQuery[kSecUseAuthenticationUI] = skipAuthenticationUI ? kSecUseAuthenticationUISkip : kSecUseAuthenticationUIAllow
     orphanQuery[kSecUseOperationPrompt] = operationPrompt as CFString
     var orphanResult: AnyObject?
     let orphanStatus = SecItemCopyMatching(orphanQuery as CFDictionary, &orphanResult)
@@ -250,7 +252,7 @@ func readItem(service: String, account: String) -> ReadOutcome {
     fileQuery[kSecReturnData] = kCFBooleanTrue!
     fileQuery[kSecMatchLimit] = kSecMatchLimitOne
     fileQuery[kSecUseAuthenticationContext] = authContext
-    fileQuery[kSecUseAuthenticationUI] = kSecUseAuthenticationUIAllow
+    fileQuery[kSecUseAuthenticationUI] = skipAuthenticationUI ? kSecUseAuthenticationUISkip : kSecUseAuthenticationUIAllow
     fileQuery[kSecUseOperationPrompt] = operationPrompt as CFString
     var fileResult: AnyObject?
     let fileStatus = SecItemCopyMatching(fileQuery as CFDictionary, &fileResult)
@@ -388,6 +390,7 @@ case "list":
         kSecReturnAttributes: kCFBooleanTrue!,
         kSecUseDataProtectionKeychain: kCFBooleanTrue!,
         kSecAttrSynchronizable: kCFBooleanFalse!,
+        kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
     ]
     var items: [[String: Any]] = []
     for query in [fileQuery, dpQuery] {
@@ -807,6 +810,7 @@ case "list-synced":
         kSecClass: kSecClassGenericPassword,
         kSecMatchLimit: kSecMatchLimitAll,
         kSecReturnAttributes: kCFBooleanTrue!,
+        kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
         kSecUseDataProtectionKeychain: kCFBooleanTrue!,
         kSecAttrSynchronizable: kCFBooleanTrue!,
     ]

--- a/apps/cli/src/lib/share/config.test.ts
+++ b/apps/cli/src/lib/share/config.test.ts
@@ -24,17 +24,12 @@ const prevHome = process.env.HOME;
 const prevEnvToken = process.env.SHARE_WRITE_TOKEN;
 const prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
 const prevNoUsage = process.env.AGENTS_NO_USAGE_TRACK;
-const prevNoPrompt = process.env.AGENTS_SECRETS_NO_PROMPT;
 
 process.env.HOME = HOME;
 process.env.AGENTS_SECRETS_NO_AGENT = '1';
 process.env.AGENTS_NO_USAGE_TRACK = '1';
-// These tests install an in-memory keychain backend (no real Touch ID) and read
-// it directly. On darwin-headless (the release-gated macOS CI matrix)
-// isHeadlessSecretsContext() would otherwise be true, forcing the agentOnly
-// no-prompt path to throw before the in-memory read. Pin NO_PROMPT=0 so reads go
-// straight to the seeded backend, matching the direct-read intent on every OS.
-process.env.AGENTS_SECRETS_NO_PROMPT = '0';
+// These tests install an in-memory keychain backend and explicitly bypass the
+// production broker-only guard.
 
 const {
   secretsKeychainItem,
@@ -42,7 +37,8 @@ const {
   setKeychainServiceHashingForTest,
   setKeychainToken,
 } = await import('../secrets/index.js');
-const { readAndResolveBundleEnv, readBundle, writeBundle } = await import('../secrets/bundles.js');
+const { readAndResolveBundleEnv, readBundle, writeBundle, setKeychainAgentOnlyBypassForTest } = await import('../secrets/bundles.js');
+setKeychainAgentOnlyBypassForTest(true);
 const {
   DEFAULT_CF_BUNDLE,
   generateWriteToken,
@@ -147,6 +143,7 @@ describe('share config', () => {
   });
 
   it('auto-share NEVER raises Touch ID on a biometry-gated bundle — returns undefined, not a prompt', () => {
+    setKeychainAgentOnlyBypassForTest(false);
     writeShareConfig({
       baseUrl: 'https://share.example.com',
       accountId: 'acct',
@@ -163,7 +160,11 @@ describe('share config', () => {
     // The auto-inject read is agentOnly: on a locked keychain bundle it resolves to
     // undefined (no token injected) rather than popping a sheet — the per-run storm
     // fix (SEC-13). The agent can still publish via its own explicit `agents share`.
-    expect(shareRuntimeEnv()).toBeUndefined();
+    try {
+      expect(shareRuntimeEnv()).toBeUndefined();
+    } finally {
+      setKeychainAgentOnlyBypassForTest(true);
+    }
   });
 
   it('uses the injected token for runtime env without touching the bundle', () => {
@@ -221,6 +222,5 @@ afterAll(() => {
   else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
   if (prevNoUsage === undefined) delete process.env.AGENTS_NO_USAGE_TRACK;
   else process.env.AGENTS_NO_USAGE_TRACK = prevNoUsage;
-  if (prevNoPrompt === undefined) delete process.env.AGENTS_SECRETS_NO_PROMPT;
-  else process.env.AGENTS_SECRETS_NO_PROMPT = prevNoPrompt;
+  setKeychainAgentOnlyBypassForTest(false);
 });

--- a/apps/cli/src/lib/share/config.ts
+++ b/apps/cli/src/lib/share/config.ts
@@ -14,7 +14,6 @@ import {
   bundleExists,
   bundleItemStore,
   bundlePolicy,
-  isHeadlessSecretsContext,
   keychainRef,
   readAndResolveBundleEnv,
   readBundle,
@@ -104,10 +103,8 @@ export function storeWriteToken(token: string): void {
 export function readWriteTokenFromBundle(): string {
   const { env } = readAndResolveBundleEnv(SHARE_BUNDLE, {
     caller: 'share',
-    // Explicit `agents share` command (a human published a file): a headless agent
-    // subprocess resolves broker-only, an interactive human may unlock. This is NOT
-    // an agent LAUNCH read (that is exec.ts's --secrets injection, always agentOnly).
-    agentOnly: isHeadlessSecretsContext(),
+    // Explicit share commands are reads, not authorization to authenticate.
+    agentOnly: true,
   });
   const token = env[SHARE_TOKEN_KEY];
   if (!token) {
@@ -168,8 +165,8 @@ export function readCloudflareCreds(
   }
   const { env } = readAndResolveBundleEnv(bundle, {
     caller: 'share',
-    // Explicit `agents share setup` provisioning read — not an agent launch.
-    agentOnly: isHeadlessSecretsContext(),
+    // Setup is still a read; only `agents secrets unlock` may authenticate.
+    agentOnly: true,
   });
   const find = (re: RegExp): string => {
     for (const [k, v] of Object.entries(env)) if (re.test(k) && v) return v;

--- a/apps/cli/src/lib/share/publish-file.test.ts
+++ b/apps/cli/src/lib/share/publish-file.test.ts
@@ -14,7 +14,6 @@ let tmpDir: string;
 const keychain = new Map<string, string>();
 let originalHome: string | undefined;
 let originalNoAgent: string | undefined;
-let originalNoPrompt: string | undefined;
 let restoreKeychain: KeychainBackend | null;
 
 beforeAll(async () => {
@@ -23,15 +22,12 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-share-publish-files-'));
   originalHome = process.env.HOME;
   originalNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
-  originalNoPrompt = process.env.AGENTS_SECRETS_NO_PROMPT;
   process.env.HOME = tmpHome;
   process.env.AGENTS_SECRETS_NO_AGENT = '1';
-  // The token is read from an in-memory keychain backend (installed below), which
-  // never prompts Touch ID. On darwin-headless (the release-gated macOS CI matrix)
-  // isHeadlessSecretsContext() would otherwise force the agentOnly no-prompt path
-  // to throw before the direct read. Pin NO_PROMPT=0 so the read runs on every OS.
-  process.env.AGENTS_SECRETS_NO_PROMPT = '0';
+  // The token is read from an in-memory keychain backend installed below.
   const secrets = await import('../secrets/index.js');
+  const bundles = await import('../secrets/bundles.js');
+  bundles.setKeychainAgentOnlyBypassForTest(true);
   restoreKeychain = secrets.setKeychainBackendForTest({
     has: (item) => keychain.has(item),
     get: (item) => {
@@ -56,13 +52,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   const secrets = await import('../secrets/index.js');
+  const bundles = await import('../secrets/bundles.js');
+  bundles.setKeychainAgentOnlyBypassForTest(false);
   secrets.setKeychainBackendForTest(restoreKeychain);
   if (originalHome === undefined) delete process.env.HOME;
   else process.env.HOME = originalHome;
   if (originalNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
   else process.env.AGENTS_SECRETS_NO_AGENT = originalNoAgent;
-  if (originalNoPrompt === undefined) delete process.env.AGENTS_SECRETS_NO_PROMPT;
-  else process.env.AGENTS_SECRETS_NO_PROMPT = originalNoPrompt;
   vi.resetModules();
   fs.rmSync(tmpHome, { recursive: true, force: true });
   fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
Enforces the one-sheet invariant for macOS secrets: only `agents secrets unlock <bundle>` may raise Touch ID. All other reads use the broker, durable session, or no-ACL path and fail with the unlock hint when a protected bundle is locked.

## What changed

- Deletes the secrets prompt override environment variable and removes TTY detection from the structural runtime detector.
- Makes every remaining non-unlock bundle read explicitly `agentOnly: true`, including get, export, share, browser typing, and SSH askpass.
- Routes `secrets view --reveal` and JSON/plaintext reveal through `readAndResolveBundleEnv` instead of direct keychain batch reads.
- Adds `kSecUseAuthenticationUISkip` to both macOS enumeration queries and makes silent no-ACL value reads skip authentication UI too.
- Moves service-name rekeying, HMAC no-ACL healing, and bundle metadata ACL healing to the explicit unlock handler.
- Adds a test-only broker-guard bypass for in-memory keychain suites; removes the production prompt override from tests and docs.

## Before / after

| Before | After |
| --- | --- |
| List enumeration could evaluate a biometry ACL and raise Touch ID. | `list` and `list-synced` explicitly skip authentication UI. |
| Plain-shell reads and reveal paths could read the keychain directly. | Every non-unlock read is broker-only or no-ACL and a locked protected bundle points to `agents secrets unlock <bundle>`. |
| Read/list hot paths could trigger rekey or ACL healing. | Migrations run only after an explicit unlock succeeds. |
| A process environment variable could force-enable or force-disable prompt behavior. | The override is deleted; structural runtime detection has no toggle. |

## Verification

No UI surface changed; verification is command/test output.

```text
$ rg AGENTS_SECRETS_NO_PROMPT apps/
(0 matches)
$ rg "agentOnly: isHeadlessSecretsContext" apps/
(0 matches)
$ rg -n maybeAutoRekey apps/cli/src
apps/cli/src/lib/secrets/index.ts:498:export function maybeAutoRekey(): void {
apps/cli/src/commands/secrets.ts:2730:          maybeAutoRekey();

$ bun run build
(exit 0)

$ bun run test -- src/lib/secrets
Test Files  34 passed | 1 skipped (35)
Tests       556 passed | 13 skipped (569)

$ bun run test -- <focused one-sheet files>
Test Files  7 passed (7)
Tests       133 passed (133)
```

The Swift source-policy assertions passed on Linux. The macOS-only helper compile/runtime tests were skipped here and must be exercised by macOS CI; this PR does not claim they passed locally.
