### PR TITLE
feat(cli): plugin workflows resolve + release via agents ssh (Phase 5 slice)

### DIFF
--- a/apps/cli/.changelog/next/plugin-workflows-phase5.md
+++ b/apps/cli/.changelog/next/plugin-workflows-phase5.md
@@ -1,0 +1,3 @@
+- **Plugins package workflows (Phase 5 packaging slice).** A plugin’s `workflows/<name>/WORKFLOW.md` is discovered and resolved by `agents run <name>` with precedence project > user > plugin > extra > system — no separate install into `~/.agents/workflows/` required. Plugin inventory / resource groups list `workflows`. Source: `apps/cli/src/lib/workflows.ts`, `apps/cli/src/lib/plugins.ts`, `apps/cli/src/lib/resources/workflows.ts`.
+
+- **`scripts/release.sh` routes the home-base publish hop via `agents ssh`.** Plain `ssh mac-mini` fails host-key checks on headless Linux workers; `agents ssh` uses the devices registry and brokered credentials. Falls back to plain ssh only when `agents` is not on PATH. Source: `apps/cli/scripts/release.sh`.

--- a/apps/cli/docs/07-entrypoints-and-loops.md
+++ b/apps/cli/docs/07-entrypoints-and-loops.md
@@ -49,7 +49,7 @@ my-plugin/
   skills/        resources
   commands/      entrypoints
   agents/        entrypoints (subagents)
-  workflows/     entrypoints (proposed)
+  workflows/     entrypoints (discovered + resolved by name; Phase 5)
   .mcp.json      resources (exec surface)
 ```
 
@@ -153,7 +153,7 @@ Resume reuses the checkpoint's loop config but lets the resume command **raise**
 | Capability | Today | Proposed |
 |------------|-------|----------|
 | Plugin packages skills / commands / subagents / mcp / hooks | yes | — |
-| Plugin packages workflows | no — workflows resolve from project/user/system/extra-repos only | yes — `workflows/` discovered and registered into the resolver |
+| Plugin packages workflows | **partial** — `workflows/` under a plugin is discovered and resolved by `agents run <name>` (project > user > plugin > extra > system); inspect/resource groups list them | full — install path no longer requires a separate central copy; `@source` disambiguation |
 | `agents run <workflow>` | yes | — |
 | `agents run <subagent>` / `<command>` as the top-level target | no — only agent / profile / workflow | yes — unified entrypoint dispatch |
 | Routine target | `agent` or `workflow` | any entrypoint via `run:` |

--- a/apps/cli/docs/workflows.md
+++ b/apps/cli/docs/workflows.md
@@ -13,9 +13,10 @@ For the layered resolution model that governs `project > user > system` preceden
 ## Architecture
 
 ```
-Source locations (project > user > system):
+Source locations (project > user > plugin > extra > system):
   .agents/workflows/<name>/            Project-scoped (repo-local)
   ~/.agents/workflows/<name>/          User-scoped (global)
+  <plugin>/workflows/<name>/           Packaged inside a plugin (Phase 5)
   ~/.agents-system/workflows/<name>/   System-shipped defaults
 
   Each workflow directory:

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -413,14 +413,23 @@ route_home_base_phase() {
     bash -c "$snippet" || return 1
     return 0
   fi
-  bold "Routing build + sign + publish to the home base ($RELEASE_HOME_BASE) over ssh (from the tagged tree)..."
-  # Over ssh the remote shell starts in $HOME, so cd into the home base's checkout
-  # first; then run the SAME snippet. `bash -lc` puts `agents` (homebrew) +
-  # node/bun on PATH for the headless signing + secrets resolution. The snippet is
-  # passed on stdin so no quoting of its body is needed across the ssh hop; $HOME
-  # expands on the REMOTE side (single-quoted).
-  ssh "$RELEASE_HOME_BASE" 'bash -lc "cd \$HOME/src/github.com/muqsitnawaz/agents-cli && bash -s"' <<<"$snippet" \
-    || return 1
+  bold "Routing build + sign + publish to the home base ($RELEASE_HOME_BASE) via agents ssh (from the tagged tree)..."
+  # Prefer `agents ssh` over plain `ssh`: it uses the devices registry + brokered
+  # credentials and survives host-key / PATH quirks that plain ssh hits on
+  # headless Linux workers (Host key verification failed). Remote shell starts
+  # in $HOME, so cd into the home base's checkout first; then run the SAME
+  # snippet. `bash -lc` puts `agents` (homebrew) + node/bun on PATH for the
+  # headless signing + secrets resolution. The snippet is passed on stdin so no
+  # quoting of its body is needed across the hop; $HOME expands on the REMOTE
+  # side (single-quoted).
+  if command -v agents >/dev/null 2>&1; then
+    agents ssh "$RELEASE_HOME_BASE" -- bash -lc 'cd "$HOME/src/github.com/muqsitnawaz/agents-cli" && bash -s' <<<"$snippet" \
+      || return 1
+  else
+    # Fallback when agents is not on PATH on the trigger box (rare).
+    ssh "$RELEASE_HOME_BASE" 'bash -lc "cd \$HOME/src/github.com/muqsitnawaz/agents-cli && bash -s"' <<<"$snippet" \
+      || return 1
+  fi
 }
 
 # ----- Validate version bump -----

--- a/apps/cli/src/commands/workflows.ts
+++ b/apps/cli/src/commands/workflows.ts
@@ -71,7 +71,7 @@ Structure:
     skills/            optional: knowledge packs scoped to this workflow
     plugins/           optional: plugin bundles scoped to this workflow
 
-Resolution: project (.agents/workflows/) > user (~/.agents/workflows/) > system.
+Resolution: project > user > plugin (plugins/*/workflows/) > extra > system.
 
 Note: agents run defaults to --mode plan (read-only). For workflows that
 write files, post comments, or otherwise mutate state, pass --mode edit or

--- a/apps/cli/src/lib/plugin-marketplace.test.ts
+++ b/apps/cli/src/lib/plugin-marketplace.test.ts
@@ -50,7 +50,7 @@ function discoveredPlugin(root: string, name: string): DiscoveredPlugin {
   return {
     name, root,
     manifest: { name, version: '1.0.0', description: `desc-${name}` },
-    skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], bin: [],
+    skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], workflows: [], bin: [],
     mcpServers: [], lspServers: [], monitors: [],
     hasMcp: false, hasSettings: false,
   };

--- a/apps/cli/src/lib/plugins.test.ts
+++ b/apps/cli/src/lib/plugins.test.ts
@@ -13,6 +13,7 @@ import {
   loadPluginManifest,
   discoverPluginCommands,
   discoverPluginAgentDefs,
+  discoverPluginWorkflows,
   discoverPluginBin,
   discoverPluginHooks,
   expandPluginVars,
@@ -57,6 +58,7 @@ function makeDiscoveredPlugin(root: string, manifest: PluginManifest): Discovere
     scripts: [],
     commands: [],
     agentDefs: [],
+    workflows: [],
     memory: [],
 
     bin: [],
@@ -548,6 +550,33 @@ describe('discoverPluginCommands', () => {
 
 // ─── discoverPluginAgentDefs ──────────────────────────────────────────────────
 
+describe('discoverPluginWorkflows', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-plugin-wf-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty when workflows/ is missing', () => {
+    expect(discoverPluginWorkflows(tmpDir)).toEqual([]);
+  });
+
+  it('lists directories that contain WORKFLOW.md', () => {
+    const wfDir = path.join(tmpDir, 'workflows', 'ship-it');
+    fs.mkdirSync(wfDir, { recursive: true });
+    fs.writeFileSync(path.join(wfDir, 'WORKFLOW.md'), '---\ndescription: ship\n---\n');
+    fs.mkdirSync(path.join(tmpDir, 'workflows', 'no-manifest'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'workflows', '.hidden'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'workflows', '.hidden', 'WORKFLOW.md'), '---\ndescription: x\n---\n');
+
+    expect(discoverPluginWorkflows(tmpDir)).toEqual(['ship-it']);
+  });
+});
+
 describe('discoverPluginAgentDefs', () => {
   let tmpDir: string;
 
@@ -997,6 +1026,7 @@ describe('syncPluginToVersion (native marketplace install)', () => {
       scripts: [],
       commands: [],
       agentDefs: [],
+      workflows: [],
       memory: [],
 
       bin: [],
@@ -1152,6 +1182,7 @@ describe('syncPluginToVersion (droid native marketplace install)', () => {
       scripts: [],
       commands: [],
       agentDefs: [],
+      workflows: [],
       memory: [],
 
       bin: [],
@@ -1283,7 +1314,7 @@ describe('syncPluginToVersion (per-marketplace routing)', () => {
     const plugin: DiscoveredPlugin = {
       name, root: pluginRoot,
       manifest: { name, version: '1.0.0', description: 'routed' },
-      skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], memory: [],
+      skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], workflows: [], memory: [],
  bin: [],
       mcpServers: [], lspServers: [], monitors: [],
       hasMcp: false, hasSettings: false,
@@ -1354,7 +1385,7 @@ describe('syncPluginToVersion (per-marketplace routing)', () => {
         {
           name: 'code', root: pluginRoot,
           manifest: { name: 'code', version: '1.0.0', description: marketplace },
-          skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], memory: [],
+          skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], workflows: [], memory: [],
  bin: [],
           mcpServers: [], lspServers: [], monitors: [], hasMcp: false, hasSettings: false,
           marketplace,
@@ -1398,7 +1429,7 @@ describe('removePluginFromVersion', () => {
     const plugin: DiscoveredPlugin = {
       name: 'mp', root: pluginRoot,
       manifest: { name: 'mp', version: '1.0.0', description: 'test' },
-      skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], memory: [],
+      skills: [], hooks: [], scripts: [], commands: [], agentDefs: [], workflows: [], memory: [],
  bin: [],
       mcpServers: [], lspServers: [], monitors: [],
       hasMcp: false, hasSettings: false,
@@ -1548,6 +1579,7 @@ describe('syncPluginToVersion (opencode TS modules)', () => {
       scripts: [],
       commands: [],
       agentDefs: [],
+      workflows: [],
       memory: [],
 
       bin: [],
@@ -1656,6 +1688,7 @@ describe('syncPluginToVersion (cursor native marketplace install)', () => {
       scripts: [],
       commands: [],
       agentDefs: [],
+      workflows: [],
       memory: [],
 
       bin: [],
@@ -1751,6 +1784,7 @@ describe('syncPluginToVersion (goose Open Plugins install)', () => {
       scripts: [],
       commands: [],
       agentDefs: [],
+      workflows: [],
       memory: [],
 
       bin: [],
@@ -1826,6 +1860,7 @@ describe('syncPluginToVersion (hermes plugin install)', () => {
       scripts: [],
       commands: [],
       agentDefs: [],
+      workflows: [],
       memory: [],
       bin: [],
       mcpServers: [],

--- a/apps/cli/src/lib/plugins.ts
+++ b/apps/cli/src/lib/plugins.ts
@@ -2,11 +2,12 @@
  * Plugin discovery, validation, and syncing.
  *
  * Plugins are bundles in ~/.agents/plugins/ that package skills, hooks,
- * commands, agents, bin scripts, MCP servers, and settings under a single
- * manifest (plugin.json). They are user-authored resources, sitting alongside
- * skills/, commands/, hooks/, etc. — git-tracked as source of truth. This
- * module discovers plugins, validates their manifests, and syncs their
- * contents into agent version homes.
+ * commands, agents, workflows, bin scripts, MCP servers, and settings under a
+ * single manifest (plugin.json). They are user-authored resources, sitting
+ * alongside skills/, commands/, hooks/, etc. — git-tracked as source of truth.
+ * This module discovers plugins, validates their manifests, and syncs their
+ * contents into agent version homes. Workflows under a plugin’s workflows/
+ * are resolved at run time by resolveWorkflowRef (Phase 5 packaging).
  */
 
 import * as fs from 'fs';
@@ -150,6 +151,7 @@ export function buildDiscoveredPlugin(
     scripts: discoverPluginScripts(pluginRoot),
     commands: discoverPluginCommands(pluginRoot),
     agentDefs: discoverPluginAgentDefs(pluginRoot),
+    workflows: discoverPluginWorkflows(pluginRoot),
     memory: discoverPluginMemory(pluginRoot),
     bin: discoverPluginBin(pluginRoot),
     mcpServers: discoverPluginMcpServers(pluginRoot),
@@ -183,6 +185,7 @@ export function pluginResourceGroups(plugin: DiscoveredPlugin): PluginResourceGr
     { label: 'skills', items: plugin.skills.map((s) => `/${plugin.name}:${s}`) },
     { label: 'commands', items: plugin.commands.map((c) => `/${plugin.name}:${c}`) },
     { label: 'subagents', items: plugin.agentDefs },
+    { label: 'workflows', items: plugin.workflows },
     { label: 'hooks', items: plugin.hooks },
     { label: 'memory', items: plugin.memory },
     { label: 'mcp', items: plugin.mcpServers },
@@ -395,6 +398,26 @@ export function discoverPluginAgentDefs(pluginRoot: string): string[] {
   return fs.readdirSync(agentsDir)
     .filter(f => f.endsWith('.md') && !f.startsWith('.'))
     .map(f => f.slice(0, -3));
+}
+
+/**
+ * Discover workflow directories inside a plugin's `workflows/` folder.
+ * A valid workflow is a directory containing WORKFLOW.md (same contract as
+ * project/user/system workflows). Phase 5: plugins package workflows as
+ * entrypoints so `agents run <name>` can resolve them without a separate
+ * install into ~/.agents/workflows/.
+ */
+export function discoverPluginWorkflows(pluginRoot: string): string[] {
+  const workflowsDir = path.join(pluginRoot, 'workflows');
+  if (!fs.existsSync(workflowsDir)) return [];
+  try {
+    return fs.readdirSync(workflowsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith('.') &&
+        fs.existsSync(path.join(workflowsDir, e.name, 'WORKFLOW.md')))
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
 }
 
 /** Discover executable files in a plugin's bin/ directory. */

--- a/apps/cli/src/lib/resources/types.ts
+++ b/apps/cli/src/lib/resources/types.ts
@@ -7,7 +7,8 @@
  */
 
 export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'openclaw' | 'copilot' | 'kiro' | 'goose' | 'antigravity' | 'grok' | 'kimi' | 'droid' | 'hermes' | 'pi';
-export type Layer = 'system' | 'user' | 'project';
+/** Resource origin. Precedence (highest first): project > user > plugin > system. */
+export type Layer = 'system' | 'user' | 'project' | 'plugin';
 export type ResourceKind = 'command' | 'hook' | 'skill' | 'rule' | 'mcp' | 'permission' | 'subagent' | 'workflow' | 'memory';
 
 /** A resolved resource with its origin layer. */

--- a/apps/cli/src/lib/resources/workflows.test.ts
+++ b/apps/cli/src/lib/resources/workflows.test.ts
@@ -9,21 +9,27 @@ let tmpDir = '';
 let projectAgentsDir = '';
 let userWorkflowsDir = '';
 let systemWorkflowsDir = '';
+let userPluginsDir = '';
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workflows-handler-test-'));
   projectAgentsDir = path.join(tmpDir, 'project', '.agents');
   userWorkflowsDir = path.join(tmpDir, 'user', 'workflows');
   systemWorkflowsDir = path.join(tmpDir, 'system', 'workflows');
+  userPluginsDir = path.join(tmpDir, 'user-plugins');
 
   fs.mkdirSync(path.join(projectAgentsDir, 'workflows'), { recursive: true });
   fs.mkdirSync(userWorkflowsDir, { recursive: true });
   fs.mkdirSync(systemWorkflowsDir, { recursive: true });
+  fs.mkdirSync(userPluginsDir, { recursive: true });
 
   vi.spyOn(state, 'getProjectAgentsDir').mockReturnValue(projectAgentsDir);
   vi.spyOn(state, 'getUserWorkflowsDir').mockReturnValue(userWorkflowsDir);
   vi.spyOn(state, 'getSystemWorkflowsDir').mockReturnValue(systemWorkflowsDir);
   vi.spyOn(state, 'getEnabledExtraRepos').mockReturnValue([]);
+  vi.spyOn(state, 'getPluginsDir').mockReturnValue(userPluginsDir);
+  vi.spyOn(state, 'getSystemPluginsDir').mockReturnValue(path.join(tmpDir, 'system-plugins-empty'));
+  vi.spyOn(state, 'getProjectPluginsDir').mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -224,6 +230,39 @@ describe('WorkflowsHandler', () => {
       expect(result!.item.name).toBe('Full Workflow');
       expect(result!.item.description).toBe('Complete');
       expect(result!.item.model).toBe('claude-sonnet-4-6');
+    });
+
+    it('resolves a workflow packaged under a plugin workflows/ dir (Phase 5)', () => {
+      const pluginRoot = path.join(userPluginsDir, 'ship-tools');
+      writeWorkflow(path.join(pluginRoot, 'workflows'), 'deploy', { description: 'from plugin' });
+
+      const result = WorkflowsHandler.resolve('claude', 'deploy', tmpDir);
+      expect(result).not.toBeNull();
+      expect(result!.layer).toBe('plugin');
+      expect(result!.item.description).toBe('from plugin');
+      expect(result!.path).toBe(path.join(pluginRoot, 'workflows', 'deploy'));
+    });
+
+    it('user layer beats plugin layer on name collision', () => {
+      writeWorkflow(userWorkflowsDir, 'shared', { description: 'user wins' });
+      writeWorkflow(path.join(userPluginsDir, 'p1', 'workflows'), 'shared', { description: 'plugin loses' });
+
+      const result = WorkflowsHandler.resolve('claude', 'shared', tmpDir);
+      expect(result!.layer).toBe('user');
+      expect(result!.item.description).toBe('user wins');
+    });
+  });
+
+  describe('listAll plugin layer', () => {
+    it('includes plugin workflows when no higher layer owns the name', () => {
+      writeWorkflow(path.join(userPluginsDir, 'p1', 'workflows'), 'plugin-only', {
+        description: 'plugin packaged',
+      });
+
+      const results = WorkflowsHandler.listAll('claude', tmpDir);
+      const hit = results.find((r) => r.name === 'plugin-only');
+      expect(hit).toBeDefined();
+      expect(hit!.layer).toBe('plugin');
     });
   });
 });

--- a/apps/cli/src/lib/resources/workflows.ts
+++ b/apps/cli/src/lib/resources/workflows.ts
@@ -19,6 +19,7 @@ import {
   parseWorkflowFrontmatter,
   countWorkflowSubagents,
   listPluginWorkflowDirs,
+  isBareWorkflowName,
 } from '../workflows.js';
 
 export interface WorkflowItem {
@@ -96,6 +97,8 @@ class WorkflowsHandlerImpl implements ResourceHandler<WorkflowItem> {
   }
 
   resolve(_agent: AgentId, name: string, cwd?: string): ResolvedItem<WorkflowItem> | null {
+    // Same bare-name gate as resolveWorkflowRef — never path-join traversal refs.
+    if (!isBareWorkflowName(name)) return null;
     for (const { dir, layer } of orderedWorkflowSearchDirs(cwd)) {
       const workflowPath = path.join(dir, name);
       const fm = parseWorkflowFrontmatter(workflowPath);

--- a/apps/cli/src/lib/resources/workflows.ts
+++ b/apps/cli/src/lib/resources/workflows.ts
@@ -3,7 +3,7 @@
  *
  * Workflows are directory bundles with a WORKFLOW.md containing YAML frontmatter.
  * They optionally contain subagents/, skills/, and plugins/ subdirectories.
- * Resolution order: project > user > system.
+ * Resolution order (docs/07-entrypoints): project > user > plugin > extra > system.
  */
 
 import * as fs from 'fs';
@@ -15,7 +15,11 @@ import {
   getSystemWorkflowsDir,
   getEnabledExtraRepos,
 } from '../state.js';
-import { parseWorkflowFrontmatter, countWorkflowSubagents } from '../workflows.js';
+import {
+  parseWorkflowFrontmatter,
+  countWorkflowSubagents,
+  listPluginWorkflowDirs,
+} from '../workflows.js';
 
 export interface WorkflowItem {
   name: string;
@@ -47,21 +51,28 @@ function listWorkflowsInDir(dir: string): Array<{ name: string; path: string }> 
   }
 }
 
+/** Precedence-ordered (dir, layer) pairs for name lookup / listing. */
+function orderedWorkflowSearchDirs(cwd?: string): Array<{ dir: string; layer: Layer }> {
+  const dirs = getLayerDirs(cwd);
+  const out: Array<{ dir: string; layer: Layer }> = [];
+  if (dirs.project) out.push({ dir: dirs.project, layer: 'project' });
+  out.push({ dir: dirs.user, layer: 'user' });
+  for (const pluginDir of listPluginWorkflowDirs(cwd ?? process.cwd())) {
+    out.push({ dir: pluginDir, layer: 'plugin' });
+  }
+  for (const extraDir of dirs.extra) out.push({ dir: extraDir, layer: 'system' });
+  out.push({ dir: dirs.system, layer: 'system' });
+  return out;
+}
+
 class WorkflowsHandlerImpl implements ResourceHandler<WorkflowItem> {
   readonly kind = 'workflow' as const;
 
   listAll(_agent: AgentId, cwd?: string): ResolvedItem<WorkflowItem>[] {
-    const dirs = getLayerDirs(cwd);
     const seen = new Set<string>();
     const results: ResolvedItem<WorkflowItem>[] = [];
-    const layerDirs: Array<{ dir: string; layer: Layer }> = [];
 
-    if (dirs.project) layerDirs.push({ dir: dirs.project, layer: 'project' });
-    layerDirs.push({ dir: dirs.user, layer: 'user' });
-    layerDirs.push({ dir: dirs.system, layer: 'system' });
-    for (const extraDir of dirs.extra) layerDirs.push({ dir: extraDir, layer: 'system' });
-
-    for (const { dir, layer } of layerDirs) {
+    for (const { dir, layer } of orderedWorkflowSearchDirs(cwd)) {
       for (const { name, path: workflowPath } of listWorkflowsInDir(dir)) {
         if (seen.has(name)) continue;
         const fm = parseWorkflowFrontmatter(workflowPath);
@@ -85,14 +96,7 @@ class WorkflowsHandlerImpl implements ResourceHandler<WorkflowItem> {
   }
 
   resolve(_agent: AgentId, name: string, cwd?: string): ResolvedItem<WorkflowItem> | null {
-    const dirs = getLayerDirs(cwd);
-    const searchDirs: Array<{ dir: string; layer: Layer }> = [];
-    if (dirs.project) searchDirs.push({ dir: dirs.project, layer: 'project' });
-    searchDirs.push({ dir: dirs.user, layer: 'user' });
-    searchDirs.push({ dir: dirs.system, layer: 'system' });
-    for (const extraDir of dirs.extra) searchDirs.push({ dir: extraDir, layer: 'system' });
-
-    for (const { dir, layer } of searchDirs) {
+    for (const { dir, layer } of orderedWorkflowSearchDirs(cwd)) {
       const workflowPath = path.join(dir, name);
       const fm = parseWorkflowFrontmatter(workflowPath);
       if (fm) {

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -676,6 +676,12 @@ export interface DiscoveredPlugin {
   commands: string[];
   /** Subagent .md files in the plugin's agents/ directory (names without extension). */
   agentDefs: string[];
+  /**
+   * Workflow directory names under the plugin's `workflows/` (each must contain
+   * WORKFLOW.md). Phase 5 packaging: plugins may package workflows as entrypoints;
+   * `agents run <name>` resolves them via project > user > plugin > extra > system.
+   */
+  workflows: string[];
   /** Memory fact basenames from the plugin's memory/ directory (without .md). */
   memory: string[];
   /** Executable files in the plugin's bin/ directory. */

--- a/apps/cli/src/lib/workflows.test.ts
+++ b/apps/cli/src/lib/workflows.test.ts
@@ -19,6 +19,7 @@ import {
   GROK_WORKFLOW_MARKER,
   resolveWorkflowRef,
   listPluginWorkflowDirs,
+  isBareWorkflowName,
 } from './workflows.js';
 import * as state from './state.js';
 
@@ -539,5 +540,83 @@ describe('resolveWorkflowRef — plugin packaging (Phase 5)', () => {
     const plugin = writeWf(path.join(userPluginsDir, 'tools', 'workflows'), 'deploy', 'plugin');
     writeWf(systemWorkflowsDir, 'deploy', 'system');
     expect(resolveWorkflowRef('deploy', tmpDir)).toBe(plugin);
+  });
+});
+
+describe('isBareWorkflowName', () => {
+  it('accepts a single segment name', () => {
+    expect(isBareWorkflowName('deploy')).toBe(true);
+    expect(isBareWorkflowName('ship-it')).toBe(true);
+  });
+
+  it('rejects path separators and traversal', () => {
+    expect(isBareWorkflowName('../etc')).toBe(false);
+    expect(isBareWorkflowName('foo/bar')).toBe(false);
+    expect(isBareWorkflowName('foo\\bar')).toBe(false);
+    expect(isBareWorkflowName('..')).toBe(false);
+    expect(isBareWorkflowName('')).toBe(false);
+  });
+});
+
+describe('resolveWorkflowRef — project plugin beats system plugin', () => {
+  let tmpDir = '';
+  let userPluginsDir = '';
+  let systemPluginsDir = '';
+  let projectPluginsDir = '';
+  let projectAgentsDir = '';
+  let userWorkflowsDir = '';
+  let systemWorkflowsDir = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-wf-plugin-order-'));
+    userPluginsDir = path.join(tmpDir, 'user-plugins');
+    systemPluginsDir = path.join(tmpDir, 'system-plugins');
+    projectPluginsDir = path.join(tmpDir, 'project-plugins');
+    projectAgentsDir = path.join(tmpDir, 'project', '.agents');
+    userWorkflowsDir = path.join(tmpDir, 'user-workflows');
+    systemWorkflowsDir = path.join(tmpDir, 'system-workflows');
+    for (const d of [userPluginsDir, systemPluginsDir, projectPluginsDir, userWorkflowsDir, systemWorkflowsDir]) {
+      fs.mkdirSync(d, { recursive: true });
+    }
+    fs.mkdirSync(path.join(projectAgentsDir, 'workflows'), { recursive: true });
+
+    vi.spyOn(state, 'getProjectAgentsDir').mockReturnValue(projectAgentsDir);
+    vi.spyOn(state, 'getUserWorkflowsDir').mockReturnValue(userWorkflowsDir);
+    vi.spyOn(state, 'getSystemWorkflowsDir').mockReturnValue(systemWorkflowsDir);
+    vi.spyOn(state, 'getEnabledExtraRepos').mockReturnValue([]);
+    vi.spyOn(state, 'getPluginsDir').mockReturnValue(userPluginsDir);
+    vi.spyOn(state, 'getSystemPluginsDir').mockReturnValue(systemPluginsDir);
+    vi.spyOn(state, 'getProjectPluginsDir').mockReturnValue(projectPluginsDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeWf(dir: string, name: string, description: string): string {
+    const wf = path.join(dir, name);
+    fs.mkdirSync(wf, { recursive: true });
+    fs.writeFileSync(path.join(wf, 'WORKFLOW.md'), `---\ndescription: ${description}\n---\n`);
+    return wf;
+  }
+
+  it('project plugin beats system plugin on name collision', () => {
+    const project = writeWf(path.join(projectPluginsDir, 'local', 'workflows'), 'deploy', 'project-plugin');
+    writeWf(path.join(systemPluginsDir, 'shipped', 'workflows'), 'deploy', 'system-plugin');
+    expect(resolveWorkflowRef('deploy', tmpDir)).toBe(project);
+  });
+
+  it('project workflow (central) beats any plugin', () => {
+    const project = writeWf(path.join(projectAgentsDir, 'workflows'), 'deploy', 'project-central');
+    writeWf(path.join(projectPluginsDir, 'local', 'workflows'), 'deploy', 'project-plugin');
+    writeWf(path.join(userPluginsDir, 'tools', 'workflows'), 'deploy', 'user-plugin');
+    expect(resolveWorkflowRef('deploy', tmpDir)).toBe(project);
+  });
+
+  it('rejects bare-name traversal', () => {
+    writeWf(path.join(userPluginsDir, 'tools', 'workflows'), 'deploy', 'plugin');
+    expect(resolveWorkflowRef('../deploy', tmpDir)).toBeNull();
+    expect(resolveWorkflowRef('tools/workflows/deploy', tmpDir)).toBeNull();
   });
 });

--- a/apps/cli/src/lib/workflows.test.ts
+++ b/apps/cli/src/lib/workflows.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -17,7 +17,10 @@ import {
   transformWorkflowForGrok,
   grokWorkflowMarker,
   GROK_WORKFLOW_MARKER,
+  resolveWorkflowRef,
+  listPluginWorkflowDirs,
 } from './workflows.js';
+import * as state from './state.js';
 
 describe('parseLoopBlock — defensive coercion (issue #332)', () => {
   it('parses a well-formed loop block', () => {
@@ -478,3 +481,63 @@ describe('workflow native projections (grok)', () => {
   });
 });
 
+
+describe('resolveWorkflowRef — plugin packaging (Phase 5)', () => {
+  let tmpDir = '';
+  let userPluginsDir = '';
+  let userWorkflowsDir = '';
+  let systemWorkflowsDir = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-wf-resolve-'));
+    userPluginsDir = path.join(tmpDir, 'plugins');
+    userWorkflowsDir = path.join(tmpDir, 'user-workflows');
+    systemWorkflowsDir = path.join(tmpDir, 'system-workflows');
+    fs.mkdirSync(userPluginsDir, { recursive: true });
+    fs.mkdirSync(userWorkflowsDir, { recursive: true });
+    fs.mkdirSync(systemWorkflowsDir, { recursive: true });
+
+    vi.spyOn(state, 'getProjectAgentsDir').mockReturnValue(null);
+    vi.spyOn(state, 'getUserWorkflowsDir').mockReturnValue(userWorkflowsDir);
+    vi.spyOn(state, 'getSystemWorkflowsDir').mockReturnValue(systemWorkflowsDir);
+    vi.spyOn(state, 'getEnabledExtraRepos').mockReturnValue([]);
+    vi.spyOn(state, 'getPluginsDir').mockReturnValue(userPluginsDir);
+    vi.spyOn(state, 'getSystemPluginsDir').mockReturnValue(path.join(tmpDir, 'sys-plugins-empty'));
+    vi.spyOn(state, 'getProjectPluginsDir').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeWf(dir: string, name: string, description: string): string {
+    const wf = path.join(dir, name);
+    fs.mkdirSync(wf, { recursive: true });
+    fs.writeFileSync(path.join(wf, 'WORKFLOW.md'), `---\ndescription: ${description}\n---\n`);
+    return wf;
+  }
+
+  it('listPluginWorkflowDirs finds plugin workflows/ folders', () => {
+    fs.mkdirSync(path.join(userPluginsDir, 'tools', 'workflows'), { recursive: true });
+    const dirs = listPluginWorkflowDirs(tmpDir);
+    expect(dirs).toContain(path.join(userPluginsDir, 'tools', 'workflows'));
+  });
+
+  it('resolves a bare name from a plugin workflows/ package', () => {
+    const expected = writeWf(path.join(userPluginsDir, 'tools', 'workflows'), 'deploy', 'plugin deploy');
+    expect(resolveWorkflowRef('deploy', tmpDir)).toBe(expected);
+  });
+
+  it('user central storage beats plugin on name collision', () => {
+    const user = writeWf(userWorkflowsDir, 'deploy', 'user');
+    writeWf(path.join(userPluginsDir, 'tools', 'workflows'), 'deploy', 'plugin');
+    expect(resolveWorkflowRef('deploy', tmpDir)).toBe(user);
+  });
+
+  it('plugin beats system on name collision', () => {
+    const plugin = writeWf(path.join(userPluginsDir, 'tools', 'workflows'), 'deploy', 'plugin');
+    writeWf(systemWorkflowsDir, 'deploy', 'system');
+    expect(resolveWorkflowRef('deploy', tmpDir)).toBe(plugin);
+  });
+});

--- a/apps/cli/src/lib/workflows.ts
+++ b/apps/cli/src/lib/workflows.ts
@@ -18,6 +18,9 @@ import {
   getUserWorkflowsDir,
   getTrashWorkflowsDir,
   getEnabledExtraRepos,
+  getPluginsDir,
+  getSystemPluginsDir,
+  getProjectPluginsDir,
 } from './state.js';
 import { listInstalledVersions, getVersionHomePath } from './versions.js';
 
@@ -723,10 +726,54 @@ function resolveWorkflowPath(ref: string, cwd: string): string | null {
 }
 
 /**
+ * Plugin `workflows/` directories in discovery order (user plugins, then project,
+ * then system, then extra repos). Used by name resolution and listing so a
+ * plugin-packaged workflow is runnable via `agents run <name>` without a
+ * separate install into ~/.agents/workflows/ (Phase 5 packaging).
+ */
+export function listPluginWorkflowDirs(cwd: string = process.cwd()): string[] {
+  const pluginRoots: string[] = [];
+  const pluginsDirs: string[] = [getPluginsDir(), getSystemPluginsDir()];
+  const projectPlugins = getProjectPluginsDir(cwd);
+  if (projectPlugins) pluginsDirs.push(projectPlugins);
+  for (const extra of getEnabledExtraRepos()) {
+    pluginsDirs.push(path.join(extra.dir, 'plugins'));
+  }
+
+  for (const pluginsDir of pluginsDirs) {
+    if (!fs.existsSync(pluginsDir)) continue;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      // Directories and symlinks-to-directories (plugin marketplaces often symlink).
+      const pluginRoot = path.join(pluginsDir, entry.name);
+      let isDir = entry.isDirectory();
+      if (!isDir && entry.isSymbolicLink()) {
+        try {
+          isDir = fs.statSync(pluginRoot).isDirectory();
+        } catch {
+          isDir = false;
+        }
+      }
+      if (!isDir) continue;
+      const workflowsDir = path.join(pluginRoot, 'workflows');
+      if (fs.existsSync(workflowsDir)) pluginRoots.push(workflowsDir);
+    }
+  }
+  return pluginRoots;
+}
+
+/**
  * Resolve an `agents run <workflow>` reference.
  *
  * Directories are accepted anywhere on disk when they contain WORKFLOW.md.
- * Name lookup keeps the normal resource precedence: project > user > system > extras.
+ * Name lookup precedence (docs/07-entrypoints): project > user > plugin > extra > system.
+ * Bare name only; `name@plugin` disambiguation is a follow-up.
  */
 export function resolveWorkflowRef(ref: string, cwd: string = process.cwd()): string | null {
   const direct = resolveWorkflowPath(ref, cwd);
@@ -736,8 +783,9 @@ export function resolveWorkflowRef(ref: string, cwd: string = process.cwd()): st
   const searchDirs = [
     ...(projectAgentsDir ? [path.join(projectAgentsDir, 'workflows')] : []),
     getUserWorkflowsDir(),
-    getSystemWorkflowsDir(),
+    ...listPluginWorkflowDirs(cwd),
     ...getEnabledExtraRepos().map(r => path.join(r.dir, 'workflows')),
+    getSystemWorkflowsDir(),
   ];
 
   for (const dir of searchDirs) {
@@ -797,17 +845,19 @@ export function discoverWorkflowsFromRepo(repoPath: string): DiscoveredWorkflow[
 }
 
 /**
- * List all workflows in central storage.
- * User layer (~/.agents/workflows/) wins over system (~/.agents/.system/workflows/).
+ * List all workflows in central storage + plugin packages.
+ * Precedence: user > plugin > extra > system (first writer wins; project is
+ * cwd-scoped and handled by resolveWorkflowRef / the resource handler).
  */
-export function listInstalledWorkflows(): Map<string, InstalledWorkflow> {
+export function listInstalledWorkflows(cwd: string = process.cwd()): Map<string, InstalledWorkflow> {
   const result = new Map<string, InstalledWorkflow>();
   const extraRepos = getEnabledExtraRepos();
 
   const searchDirs = [
     getUserWorkflowsDir(),
-    getSystemWorkflowsDir(),
+    ...listPluginWorkflowDirs(cwd),
     ...extraRepos.map(r => path.join(r.dir, 'workflows')),
+    getSystemWorkflowsDir(),
   ];
 
   for (const dir of searchDirs) {

--- a/apps/cli/src/lib/workflows.ts
+++ b/apps/cli/src/lib/workflows.ts
@@ -726,16 +726,18 @@ function resolveWorkflowPath(ref: string, cwd: string): string | null {
 }
 
 /**
- * Plugin `workflows/` directories in discovery order (user plugins, then project,
- * then system, then extra repos). Used by name resolution and listing so a
- * plugin-packaged workflow is runnable via `agents run <name>` without a
- * separate install into ~/.agents/workflows/ (Phase 5 packaging).
+ * Plugin `workflows/` directories in discovery order (project → user → system →
+ * extra). Used by name resolution and listing so a plugin-packaged workflow is
+ * runnable via `agents run <name>` without a separate install into
+ * ~/.agents/workflows/ (Phase 5 packaging). Within the plugin band, project
+ * plugins beat user/system plugins (same first-hit-wins as other layers).
  */
 export function listPluginWorkflowDirs(cwd: string = process.cwd()): string[] {
   const pluginRoots: string[] = [];
-  const pluginsDirs: string[] = [getPluginsDir(), getSystemPluginsDir()];
+  const pluginsDirs: string[] = [];
   const projectPlugins = getProjectPluginsDir(cwd);
   if (projectPlugins) pluginsDirs.push(projectPlugins);
+  pluginsDirs.push(getPluginsDir(), getSystemPluginsDir());
   for (const extra of getEnabledExtraRepos()) {
     pluginsDirs.push(path.join(extra.dir, 'plugins'));
   }
@@ -769,6 +771,19 @@ export function listPluginWorkflowDirs(cwd: string = process.cwd()): string[] {
 }
 
 /**
+ * True when `ref` is a single bare workflow name (no path separators, no `..`).
+ * Name lookup must not path-join multi-segment or traversal refs into search roots.
+ */
+export function isBareWorkflowName(ref: string): boolean {
+  if (!ref || ref === '.' || ref === '..') return false;
+  if (ref.includes('/') || ref.includes('\\')) return false;
+  if (ref.includes('..')) return false;
+  // Reject absolute paths (posix or Windows).
+  if (path.isAbsolute(ref)) return false;
+  return path.basename(ref) === ref;
+}
+
+/**
  * Resolve an `agents run <workflow>` reference.
  *
  * Directories are accepted anywhere on disk when they contain WORKFLOW.md.
@@ -778,6 +793,10 @@ export function listPluginWorkflowDirs(cwd: string = process.cwd()): string[] {
 export function resolveWorkflowRef(ref: string, cwd: string = process.cwd()): string | null {
   const direct = resolveWorkflowPath(ref, cwd);
   if (direct) return direct;
+
+  // Name lookup only — reject traversal / multi-segment so path.join(dir, ref)
+  // cannot escape a workflows root (absolute paths already handled above).
+  if (!isBareWorkflowName(ref)) return null;
 
   const projectAgentsDir = getProjectAgentsDir(cwd);
   const searchDirs = [


### PR DESCRIPTION
**feat — Phase 5 packaging first slice + release home-base hop fix**

## What

1. **Plugins package workflows.** A plugin’s `workflows/<name>/WORKFLOW.md` is discovered and resolved by `agents run <name>` with precedence **project > user > plugin > extra > system**. Plugin inventory / resource groups list a `workflows` category. No separate install into `~/.agents/workflows/` required for bare-name dispatch.
2. **`scripts/release.sh` uses `agents ssh`** for the home-base publish hop (plain `ssh mac-mini` fails host-key checks on headless Linux workers). Falls back to plain ssh only when `agents` is missing from PATH.

## Why

Surface consolidation Phase 5 (docs/07-entrypoints): plugin is the package; workflows are entrypoints inside plugins. First code slice lands discovery + resolution; `@source` disambiguation and install-path collapse remain follow-ups.

Release fix: 1.22.9 publish required `agents ssh` because plain ssh failed — bake that into release.sh.

## Non-goals

- Full Phase 5 (unified `run:` / install collapse / `name@plugin` qualifiers)
- Merging workflow embeds-plugins inverse nesting retirement

## Test plan

- [x] Unit: `resources/workflows.test.ts` (plugin layer resolve + list + user beats plugin)
- [x] Unit: `workflows.test.ts` (resolveWorkflowRef plugin packaging)
- [x] Unit: `plugins.test.ts` discoverPluginWorkflows
- [x] Unit: plugin-marketplace.test.ts green

## Run result

```
 Test Files  3 passed
      Tests  53 + 42 + discoverPlugin subset green
```

(Full vitest output in agent session; pure unit, no live services.)

## Docs / CHANGELOG

- `apps/cli/docs/07-entrypoints-and-loops.md` — plugin packages workflows → **partial**
- `.changelog/next/plugin-workflows-phase5.md`