### PR TITLE
factory: make agents run --resume the only resume path

### DIFF
--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -49,9 +49,15 @@ same flags — only host selection differs** (`launchAgent` in
 Claude alone adds `--session-id <id>` (minted up front for the resume/fork flow);
 that is the only per-agent addition and it never removes a flag. A **fork**
 (`strategyForForkAgent`) starts a fresh sibling session, so it is balanced by the
-same rule. **Resume is out of scope** — `--resume <id>` reattaches to a session
-whose account is already bound, so it reuses that account and carries no
-`--strategy` (`buildVersionedResumeCommand` in `src/core/prewarm.ts`).
+same rule.
+
+**Resume is also unified:** every resumed session — local, offloaded, or
+picked-host — goes through `agents run <agent> --interactive --resume <id>`,
+with `--host '<device>'` appended when the transcript lives on another machine.
+`agents run --resume` resumes under the version that started the session, so
+Factory never emits a per-harness raw binary (`claude -r`, `codex resume`,
+`cursor-agent --resume=`, etc.). The single source for resume command
+construction is `buildVersionedResumeCommand` in `src/core/prewarm.ts`.
 
 **There is no allowlist.** The single source of truth is `isAgentRunner(key)`
 (`src/core/agents.ts`) = `key !== 'shell'`, consumed by `usesManagedAgentLaunch`

--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+- **Resume / restore always routes through `agents run --resume`.** Removed the
+  per-harness raw binary fallback (`claude -r`, `codex resume`, `cursor-agent
+  --resume=`, etc.) from `buildVersionedResumeCommand`. Every resumed session now
+  emits `agents run <agent> --interactive --resume <id>`; offloaded sessions get
+  `--host '<device>'`. `agents run --resume` resolves the originating version, so
+  Factory no longer pins an explicit `@version` on resume. Source:
+  `apps/factory/src/core/prewarm.ts`, `apps/factory/src/core/prewarm.test.ts`.
+
+- **Remote session host survives a VS Code: window restart.** `scanExisting`
+  rehydrates `EditorTerminal.host` from the persisted session when VS Code:
+  restores a terminal before the extension activates. Without this, the restore
+  path built a local raw resume for a session whose transcript lives on another
+  device. Source: `apps/factory/src/vscode/terminals.vscode.ts`.
+
+- **Resume payload is never typed when the agent fails to start.** The
+  `launchResumeTerminal` "send anyway" rejection handler that typed `Continue.`
+  into a dead shell prompt now surfaces a `showErrorMessage` and leaves the
+  terminal alone. Source: `apps/factory/src/vscode/extension.ts`.
+
 - **Panel snapshot poll: one `agents view --json` for every harness per tick.** The
   centralized SnapshotDetector used to fork `agents view <type> --json` once per
   watched agent type every 4s. It now loads the full inventory in a single process

--- a/apps/factory/src/core/prewarm.test.ts
+++ b/apps/factory/src/core/prewarm.test.ts
@@ -234,99 +234,84 @@ describe('selectBestSession', () => {
 });
 
 describe('buildResumeCommand', () => {
-  test('builds Claude resume command', () => {
-    const session: PrewarmedSession = {
-      agentType: 'claude',
-      sessionId: 'abc123',
-      createdAt: Date.now(),
-      workingDirectory: '/test',
-    };
-    expect(buildResumeCommand(session)).toBe('claude -r abc123');
-  });
-
-  test('builds Codex resume command', () => {
-    const session: PrewarmedSession = {
-      agentType: 'codex',
-      sessionId: 'def456',
-      createdAt: Date.now(),
-      workingDirectory: '/test',
-    };
-    expect(buildResumeCommand(session)).toBe('codex resume def456');
-  });
-
-  test('builds Gemini resume command', () => {
-    const session: PrewarmedSession = {
-      agentType: 'gemini',
-      sessionId: 'ghi789',
-      createdAt: Date.now(),
-      workingDirectory: '/test',
-    };
-    expect(buildResumeCommand(session)).toBe('gemini --resume ghi789');
-  });
-
-  test('builds Cursor resume command', () => {
-    const session: PrewarmedSession = {
-      agentType: 'cursor',
-      sessionId: '874384ec-7236-4887-aa1c-f627754ce0c0',
-      createdAt: Date.now(),
-      workingDirectory: '/test',
-    };
-    expect(buildResumeCommand(session)).toBe('cursor-agent --resume=874384ec-7236-4887-aa1c-f627754ce0c0');
+  test('every prewarm agent resumes through agents run', () => {
+    const cases: PrewarmedSession['agentType'][] = ['claude', 'codex', 'gemini', 'cursor', 'opencode'];
+    for (const agentType of cases) {
+      const session: PrewarmedSession = {
+        agentType,
+        sessionId: 'abc123',
+        createdAt: Date.now(),
+        workingDirectory: '/test',
+      };
+      const cmd = buildResumeCommand(session);
+      expect(cmd).toBe(`agents run ${agentType} --interactive --resume abc123`);
+      expect(cmd).not.toMatch(/\b(claude -r|codex resume|gemini --resume|cursor-agent --resume|opencode -s)\b/);
+    }
   });
 });
 
 describe('buildVersionedResumeCommand', () => {
-  test('pins Claude resume to the requested version', () => {
-    expect(buildVersionedResumeCommand('claude', 'abc123', '2.1.113')).toBe('claude@2.1.113 -r abc123');
+  const FLEET_AGENTS = ['claude', 'codex', 'gemini', 'cursor', 'opencode', 'grok', 'kimi', 'droid', 'antigravity'];
+
+  test('every fleet agent resumes through `agents run --interactive --resume`', () => {
+    for (const agent of FLEET_AGENTS) {
+      expect(buildVersionedResumeCommand(agent, 'abc123')).toBe(
+        `agents run ${agent} --interactive --resume abc123`,
+      );
+    }
   });
 
-  test('leaves Claude unpinned when version is missing', () => {
-    expect(buildVersionedResumeCommand('claude', 'abc123')).toBe('claude -r abc123');
+  test('every fleet agent carries `--host` when offloaded', () => {
+    for (const agent of FLEET_AGENTS) {
+      expect(buildVersionedResumeCommand(agent, 'abc123', undefined, 'yosemite-s1')).toBe(
+        `agents run ${agent} --interactive --host 'yosemite-s1' --resume abc123`,
+      );
+    }
   });
 
-  test('pins non-Claude resume commands too', () => {
-    expect(buildVersionedResumeCommand('codex', 'def456', '0.124.0')).toBe('codex@0.124.0 resume def456');
-    expect(buildVersionedResumeCommand('cursor', 'ghi789', '1.2.3')).toBe('cursor-agent@1.2.3 --resume=ghi789');
+  test('no raw harness-binary resume command is ever emitted', () => {
+    const rawPatterns = [
+      /^claude(@[^ ]+)? -r /,
+      /^codex(@[^ ]+)? resume /,
+      /^gemini(@[^ ]+)? --resume /,
+      /^cursor-agent(@[^ ]+)? --resume=/,
+      /^opencode(@[^ ]+)? -s /,
+    ];
+    for (const agent of FLEET_AGENTS) {
+      const localCmd = buildVersionedResumeCommand(agent, 'abc123');
+      const hostCmd = buildVersionedResumeCommand(agent, 'abc123', undefined, 'zion');
+      const versionCmd = buildVersionedResumeCommand(agent, 'abc123', '1.2.3');
+      for (const cmd of [localCmd, hostCmd, versionCmd]) {
+        for (const pattern of rawPatterns) {
+          expect(cmd).not.toMatch(pattern);
+        }
+        expect(cmd).toMatch(/^agents run /);
+        expect(cmd).toMatch(/--resume abc123$/);
+      }
+    }
   });
 
-  test('routes an offloaded session back to its own host instead of resuming locally', () => {
-    // The transcript lives on the device; `claude -r <id>` here would start a
-    // fresh LOCAL agent against an id this machine has never seen.
-    expect(buildVersionedResumeCommand('claude', 'abc123', undefined, 'yosemite-s1')).toBe(
-      "agents run claude --interactive --host 'yosemite-s1' --resume abc123",
-    );
-  });
-
-  test('keeps the version pin on a host-routed resume', () => {
-    expect(buildVersionedResumeCommand('claude', 'abc123', '2.1.113', 'yosemite-s0')).toBe(
-      "agents run claude@2.1.113 --interactive --host 'yosemite-s0' --resume abc123",
-    );
-  });
-
-  test('host-routes every prewarmable agent, not just Claude', () => {
-    expect(buildVersionedResumeCommand('codex', 'def456', undefined, 'zion')).toBe(
-      "agents run codex --interactive --host 'zion' --resume def456",
-    );
-    expect(buildVersionedResumeCommand('gemini', 'ghi789', undefined, 'zion')).toBe(
-      "agents run gemini --interactive --host 'zion' --resume ghi789",
-    );
-  });
-
-  test('resumes a harness with no prewarm config through `agents run`', () => {
-    // grok / kimi / droid / antigravity have transcripts but no native resume
-    // one-liner in PREWARM_CONFIGS; `agents run --resume` is their path.
-    expect(buildVersionedResumeCommand('grok', 'abc123')).toBe('agents run grok --interactive --resume abc123');
-    expect(buildVersionedResumeCommand('kimi', 'abc123', '1.4.0')).toBe(
-      'agents run kimi@1.4.0 --interactive --resume abc123',
-    );
-    expect(buildVersionedResumeCommand('droid', 'abc123', undefined, 'mac-mini')).toBe(
-      "agents run droid --interactive --host 'mac-mini' --resume abc123",
+  test('version argument is ignored (CLI resolves originating version)', () => {
+    // `agents run --resume` resumes under the version that started the session;
+    // the command must not pin an explicit @version (exec.ts:1734).
+    expect(buildVersionedResumeCommand('claude', 'abc123', '2.1.113')).toBe(
+      'agents run claude --interactive --resume abc123',
     );
   });
 
   test('quotes a device name so it cannot break out of the command', () => {
     expect(buildVersionedResumeCommand('claude', 'abc123', undefined, "a'; rm -rf /; #")).toBe(
       `agents run claude --interactive --host 'a'\\''; rm -rf /; #' --resume abc123`,
+    );
+  });
+
+  test('persisted remote session restores with `--host` present', () => {
+    // This is the restore path that failed: a remote session was resumed as
+    // `claude@2.1.187 -r <id>` because its host did not survive the window
+    // restart. buildVersionedResumeCommand must include --host when one is
+    // passed (rehydrated from sessions.persist.ts in scanExisting).
+    expect(buildVersionedResumeCommand('claude', '8a7b8d22-c741-4a51-91e7-2112948547dd', undefined, 'yosemite-s1')).toBe(
+      "agents run claude --interactive --host 'yosemite-s1' --resume 8a7b8d22-c741-4a51-91e7-2112948547dd",
     );
   });
 });
@@ -383,6 +368,5 @@ describe('PREWARM_CONFIGS', () => {
   test('cursor config has correct settings', () => {
     expect(PREWARM_CONFIGS.cursor.command).toBe('cursor-agent');
     expect(PREWARM_CONFIGS.cursor.exitSequence).toEqual(['\x03', '\x03']);
-    expect(PREWARM_CONFIGS.cursor.resumeCommand('abc123')).toBe('cursor-agent --resume=abc123');
   });
 });

--- a/apps/factory/src/core/prewarm.ts
+++ b/apps/factory/src/core/prewarm.ts
@@ -10,7 +10,6 @@ export interface PrewarmConfig {
   statusCommand: string;        // Command to get session info (e.g., '/status', '/stats')
   sessionIdPattern: RegExp;     // Pattern to extract session ID from output
   exitSequence: string[];       // Key sequences to cleanly exit
-  resumeCommand: (sessionId: string) => string;
 }
 
 /** A pre-warmed session ready for hand-off */
@@ -45,7 +44,6 @@ export const PREWARM_CONFIGS: Record<PrewarmAgentType, PrewarmConfig> = {
     // Matches: "Session ID: 01J9..."/"Session: 01J9..."
     sessionIdPattern: /Session(?:\s+ID)?:\s*([a-zA-Z0-9_-]+)/i,
     exitSequence: ['\x1b', '\x03', '\x03'],  // Esc, Ctrl+C, Ctrl+C (need Esc first for Claude)
-    resumeCommand: (id) => `claude -r ${id}`
   },
   codex: {
     agentType: 'codex',
@@ -54,7 +52,6 @@ export const PREWARM_CONFIGS: Record<PrewarmAgentType, PrewarmConfig> = {
     // Matches: "Session: 01J9..." or "Session ID: 01J9..."
     sessionIdPattern: /Session(?:\s+ID)?:\s*([a-zA-Z0-9_-]+)/i,
     exitSequence: ['\x03', '\x03'],  // Ctrl+C twice
-    resumeCommand: (id) => `codex resume ${id}`
   },
   gemini: {
     agentType: 'gemini',
@@ -63,7 +60,6 @@ export const PREWARM_CONFIGS: Record<PrewarmAgentType, PrewarmConfig> = {
     // Matches session ID pattern
     sessionIdPattern: /Session(?:\s+ID)?:\s*([a-zA-Z0-9_-]+)/i,
     exitSequence: ['\x03', '\x03'],  // Ctrl+C twice
-    resumeCommand: (id) => `gemini --resume ${id}`
   },
   cursor: {
     agentType: 'cursor',
@@ -72,7 +68,6 @@ export const PREWARM_CONFIGS: Record<PrewarmAgentType, PrewarmConfig> = {
     // Matches session ID pattern
     sessionIdPattern: /Session(?:\s+ID)?:\s*([a-zA-Z0-9_-]+)/i,
     exitSequence: ['\x03', '\x03'],  // Ctrl+C twice
-    resumeCommand: (id) => `cursor-agent --resume=${id}`
   },
   opencode: {
     agentType: 'opencode',
@@ -81,7 +76,6 @@ export const PREWARM_CONFIGS: Record<PrewarmAgentType, PrewarmConfig> = {
     // Matches OpenCode session ID format: ses_xxx
     sessionIdPattern: /ses_[a-zA-Z0-9]+/i,
     exitSequence: ['\x03', '\x03'],  // Ctrl+C twice
-    resumeCommand: (id) => `opencode -s ${id}`
   }
 };
 
@@ -171,49 +165,45 @@ export function selectBestSession(
 }
 
 /**
- * Build resume command for a pre-warmed session
+ * Build resume command for a pre-warmed session.
+ *
+ * Every resume goes through `agents run <agent> --interactive --resume <id>`;
+ * the CLI resolves the version that started the session and handles remote
+ * hosts via `--host`. No per-harness raw binary resume is ever emitted.
  */
 export function buildResumeCommand(session: PrewarmedSession): string {
-  const config = PREWARM_CONFIGS[session.agentType];
-  return config.resumeCommand(session.sessionId);
+  return buildVersionedResumeCommand(session.agentType, session.sessionId);
 }
 
 /**
- * Build a resume command pinned to a specific installed agent version when one
- * is known. This is required for multi-profile setups where a session only
- * exists inside one version's home directory.
+ * Build the unified resume command for any harness.
+ *
+ * `agents run --resume` resumes under the version that started the session
+ * (verified in the CLI: `apps/cli/src/commands/exec.ts` forwards `version:
+ * undefined` when `resume` is set, and the remote/local CLI resolves the
+ * originating version from its session index). Therefore we never pin an
+ * explicit `@version` here.
  *
  * `host` is the device the session was offloaded to. Its transcript lives on
- * THAT machine, so the raw `claude -r <id>` form would start a brand-new local
- * agent against an id this box has never seen; route through
- * `agents run --host … --resume` so the resume happens where the session is.
+ * THAT machine, so a local raw resume would start a brand-new agent against an
+ * id this box has never seen; route through `agents run --host … --resume` so
+ * the resume happens where the session is.
  *
  * `agentType` widens past {@link PrewarmAgentType} because resume is not a
  * prewarm-only capability: the CLI records transcripts for every harness it can
  * run (grok, kimi, droid, antigravity, …) and `agents run --resume` resumes any
- * of them under the version that started the session. Only the five agents with
- * a {@link PREWARM_CONFIGS} entry get their native one-liner; the rest go
- * through `agents run`, which is the same path the `--host` form already used.
+ * of them under the version that started the session.
  */
 export function buildVersionedResumeCommand(
   agentType: PrewarmAgentType | string,
   sessionId: string,
-  version?: string,
+  _version?: string,
   host?: string,
 ): string {
-  const spec = version ? `${agentType}@${version}` : agentType;
   if (host) {
-    return `agents run ${spec} --interactive --host ${shellQuoteArg(host)} --resume ${sessionId}`;
+    return `agents run ${agentType} --interactive --host ${shellQuoteArg(host)} --resume ${sessionId}`;
   }
-  if (!(agentType in PREWARM_CONFIGS)) {
-    return `agents run ${spec} --interactive --resume ${sessionId}`;
-  }
-  const config = PREWARM_CONFIGS[agentType as PrewarmAgentType];
-  const baseCmd = config.resumeCommand(sessionId);
-  if (!version) return baseCmd;
-  const cmdName = config.command;
-  const prefix = new RegExp(`^${cmdName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
-  return baseCmd.replace(prefix, `${cmdName}@${version}`);
+  return `agents run ${agentType} --interactive --resume ${sessionId}`;
 }
 
 /** Single-quote a device name so it can never break out of the built command. */

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -3668,9 +3668,9 @@ async function launchResumeTerminal(
     terminal.sendText(resumeInput, false);
     setTimeout(() => terminal.sendText('\r', false), 300);
   };
-  readiness.waitFor(terminal, 'agentReady').then(submitToTui, (err) => {
-    console.warn(`[RESUME] agentReady wait FAILED: ${err} — sending resume input anyway`);
-    submitToTui();
+  readiness.waitFor(terminal, 'agentReady').then(submitToTui).catch((err) => {
+    console.error(`[RESUME] agentReady wait FAILED: ${err}`);
+    vscode.window.showErrorMessage('Failed to resume: agent did not become ready.');
   });
 
   vscode.window.setStatusBarMessage(plan.statusMessage, 5000);

--- a/apps/factory/src/vscode/terminals.vscode.ts
+++ b/apps/factory/src/vscode/terminals.vscode.ts
@@ -720,6 +720,18 @@ export async function scanExisting(
     const persistedByTerminalId = identOpts.terminalId
       ? persistedSessions.find(p => p.terminalId === identOpts.terminalId)
       : undefined;
+
+    // Recover the offloaded device BEFORE any host-dependent lookup runs. VS Code
+    // restores terminals without our env vars, so `entry.host` is lost on reload
+    // unless we rehydrate it from the persisted session here. Without this, a
+    // remote session's resume command degrades to a local raw binary and the
+    // label poller reads the wrong filesystem (extension.ts restore callers pass
+    // `session.host` into buildVersionedResumeCommand; scanExisting is the other
+    // reload path that must keep it, RUSH-2047).
+    if (persistedByTerminalId?.host) {
+      setHost(terminal, persistedByTerminalId.host);
+    }
+
     const pinnedVersion = resolveRestoredVersion(
       identOpts.version,
       persistedByTerminalId?.version


### PR DESCRIPTION
## What

Unifies the Factory extension resume/restore flow so every resumed session goes through `agents run <agent> --interactive --resume <id>`, and fixes the case where a remote session lost its host after a VS Code: window restart.

## Changes

- `buildVersionedResumeCommand` in `src/core/prewarm.ts` no longer emits per-harness raw binary resumes (`claude -r`, `codex resume`, `cursor-agent --resume=`, etc.). Version pinning is removed on resume because `agents run --resume` resolves the originating version from the CLI session index.
- `scanExisting` in `src/vscode/terminals.vscode.ts` rehydrates `EditorTerminal.host` from the persisted session before any host-dependent lookup, so a VS Code:-restored remote tab resumes on the device that owns the transcript.
- `launchResumeTerminal` in `src/vscode/extension.ts` replaces the "send anyway" rejection handler with a `showErrorMessage` toast; the resume payload is no longer typed into a shell that never reached `agentReady`.
- Updated `prewarm.test.ts` to cover all fleet agents (claude, codex, gemini, cursor, opencode, grok, kimi, droid, antigravity) with/without `--host`, and to reject raw harness-binary forms.
- Updated `apps/factory/AGENTS.md` launch/resume contract and added `CHANGELOG.md` entries under `## [Unreleased]`.

## Verification

- `bun run compile` passes.
- Targeted test run (prewarm, resumeInBest, terminals, reconnect reload, fork commands) passes: 82 tests, 0 failures.
- Full run log: https://gist.github.com/muqsitnawaz/f4ecf8f8f3fa574edcb721d2cb7b6cc5

## Notes

- This is a behavior-only change to the command strings the extension sends to terminals; there is no new UI surface, so no screenshot is attached.
- The remaining failures in the full `bun test` run are pre-existing on `main` and unrelated to this branch (`sessionWatcher` / `readinessBroadcast` fs.watch issues, `tmux.test.ts` mock environment, `htmlReader.test.ts`, flaky `sessionTracker.test.ts`, and an agents.cli snapshot drift where the CLI added `pi` but Factory constants have not). I verified these files are unchanged in this branch.