### PR TITLE
feat(projects): graduate out of beta; status defaults to whole fleet + --device/--devices

### DIFF
--- a/apps/cli/.changelog/next/projects-graduate-fleet-default.md
+++ b/apps/cli/.changelog/next/projects-graduate-fleet-default.md
@@ -1,0 +1,15 @@
+- **`agents projects` is out of beta — no `agents beta enable projects` needed.**
+  The command tree (list / add / import / status / link / …) is always registered
+  now; `projects` is dropped from the beta registry (`ALL_BETA_FEATURES`,
+  `BetaFeatureName`) and the `preAction` beta gate is removed. Any lingering
+  `beta.enabled: [projects]` entry is harmlessly ignored. Source:
+  `apps/cli/src/lib/beta.ts`, `apps/cli/src/lib/types.ts`,
+  `apps/cli/src/commands/projects.ts`.
+
+- **`agents projects status` shows every project across the whole fleet by default;
+  scope it with `--device`/`--devices`.** The old `--fleet` flag is gone — status
+  now dials every registered device's workspace (presence, branch, drift) in one
+  parallel SSH round without being asked. `--device <name...>` (repeatable) or
+  `--devices a,b,c` narrows the fan-out to a subset; with no filter the whole fleet
+  is dialled. Reuses the shared `--host`/`--device` target resolution. Source:
+  `apps/cli/src/commands/projects.ts`.

--- a/apps/cli/.changelog/next/projects-graduate-fleet-default.md
+++ b/apps/cli/.changelog/next/projects-graduate-fleet-default.md
@@ -2,9 +2,11 @@
   The command tree (list / add / import / status / link / …) is always registered
   now; `projects` is dropped from the beta registry (`ALL_BETA_FEATURES`,
   `BetaFeatureName`) and the `preAction` beta gate is removed. Any lingering
-  `beta.enabled: [projects]` entry is harmlessly ignored. Source:
+  `beta.enabled: [projects]` entry is harmlessly ignored, and `agents beta
+  enable/disable projects` prints a friendly "graduated out of beta" note and
+  no-ops instead of erroring (so old scripts survive). Source:
   `apps/cli/src/lib/beta.ts`, `apps/cli/src/lib/types.ts`,
-  `apps/cli/src/commands/projects.ts`.
+  `apps/cli/src/commands/beta.ts`, `apps/cli/src/commands/projects.ts`.
 
 - **`agents projects status` shows every project across the whole fleet by default;
   scope it with `--device`/`--devices`.** The old `--fleet` flag is gone — status

--- a/apps/cli/docs/11-projects.md
+++ b/apps/cli/docs/11-projects.md
@@ -67,7 +67,7 @@ linear:
 | `name` | Stable id, == filename. What `--project` takes. |
 | `root` | Repo / monorepo root, home-relative → portable. |
 | `defaultPath` | Where an agent's cwd lands (a monorepo subdir). Defaults to `root`. |
-| `repo` / `repos[]` | GitHub slug(s), each with an optional `subpath`, for the PR/merge rollup. `repos[].path` (home-relative) names that repo's local checkout and opts it into workspace probing (`status --fleet`). |
+| `repo` / `repos[]` | GitHub slug(s), each with an optional `subpath`, for the PR/merge rollup. `repos[].path` (home-relative) names that repo's local checkout and opts it into workspace probing (`status`). |
 | `contexts[]` | `{path, purpose}` described starting points — indexed anchors for agents. |
 | `goals[]` | `{objective, measure}` the OKR-shaped outcomes a project serves — a project may have several. The objective is the "why"; `measure` is the optional key result. Milestones (pulled from Linear) are the dated checkpoints toward them. |
 | `integrations[]` | `{kind, url, label}` external context sources. |
@@ -107,7 +107,8 @@ is no second renderer to drift.
 - **Named** (`agents projects status rush`, `view rush`, `show rush`) — the same card for one
   project, with **every** milestone and the stored definition underneath (each repo with its
   subpath and checkout, each context with its purpose, each integration with its URL, the
-  Linear link, the docs, and the YAML path). `--fleet` is available on both forms.
+  Linear link, the docs, and the YAML path). The fleet fan-out — and its
+  `--device`/`--devices` scoping — applies to both forms.
 
 Gathering still goes through `enrichProjectsForRender` so a signal added for the card appears
 whether you typed `status` or `view`.
@@ -117,8 +118,8 @@ whether you typed `status` or `view`.
 The headline. It matches every live session to a project **by cwd** (longest root
 wins) and rolls up the signals already on disk. The live-agent rollup defaults to this machine's active sessions (the same set
 `agents sessions --active` shows, matched by local-home cwd); the **merged-PR
-count is repo-global** (via `gh`). With `--fleet`, the live line also includes
-sessions fanned out over SSH — but cwd matching is still against the **local**
+count is repo-global** (via `gh`). The live line also includes sessions fanned
+out over SSH across the fleet — but cwd matching is still against the **local**
 home layout, so a peer session whose path uses a different home root may not
 attribute. Full home-relative matching across homes remains deferred (see below):
 
@@ -143,7 +144,7 @@ rush  ·  23 live
   active session list (`rollupSessionsByProject`) — no network. The `agents` line
   groups live agents by host (`@zion  claude · running ×9  ·  …`) so the same
   harness on two machines is not collapsed into one cell. Within a host, cells
-  collapse identical state (`×N`), sorted running-first, capped with `+N more`. Under `--fleet` the remote sessions carry their peer's hostname.
+  collapse identical state (`×N`), sorted running-first, capped with `+N more`. Remote sessions carry their peer's hostname.
 - **`ships` merged-count** is a best-effort `gh pr list` on the primary repo
   (`--no-remote` skips it; a missing `gh`/auth degrades to 0). It counts up to the
   100 most recent merges within the window. The trailing tag is the **latest release
@@ -178,11 +179,12 @@ rush  ·  23 live
   project (`lib/project-status.ts`).
 - `--window <days>` sets the merged-PR / artifact window (default 7).
 
-### `--fleet` — per-device workspace drift
+### Fleet workspace drift (default)
 
-Projects are natively multi-device, so `status --fleet` adds a `fleet` line per
-project showing the state of its workspace repos on every fleet device — present
-or missing, on which branch, ahead/behind the upstream, and uncommitted changes:
+Projects are natively multi-device, so `status` adds a `fleet` line per project
+by default, showing the state of its workspace repos on every fleet device —
+present or missing, on which branch, ahead/behind the upstream, and uncommitted
+changes:
 
 ```
 rush  ·  3 agents
@@ -206,11 +208,13 @@ rush  ·  3 agents
 - **Unreachable or older peers are named once** in a trailing note
   (`· N devices didn't answer (unreachable, older agents-cli, or timed out): …`)
   — a peer whose CLI predates the probe subcommand lands in the same skipped
-  list, never a silent gap. The `probe` subcommand itself is not beta-gated, so
-  peers answer whenever their binary carries it.
+  list, never a silent gap. Peers answer whenever their binary carries the
+  `probe` subcommand.
 - `--json` includes the fleet data: per project `workspaces: [{host, path,
   present, branch, upstream, ahead, behind, dirty, lastCommit, error}]`.
-- Default is off — `--fleet` is the opt-in because it dials the fleet.
+- **Dialed by default.** Scope it to a subset with `--device <name...>`
+  (repeatable) or `--devices a,b,c` (comma-separated); with no filter every
+  registered online device is dialed.
 
 ## Warnings footer
 
@@ -222,7 +226,7 @@ Anything that needs attention lands at the **bottom** of the card, not mid-strea
 | ⚠️ | continue | dirty tree, small behind, schedule not measurable |
 
 A local workspace probe always feeds this footer (cheap, no SSH). The full per-host
-`fleet` table still requires `--fleet`.
+`fleet` table is shown by default — scope it with `--device`/`--devices`.
 
 
 ## Command surface
@@ -233,7 +237,7 @@ A local workspace probe always feeds this footer (cheap, no SSH). The full per-h
 | `agents projects add <name>` | Scaffold `<name>.yaml`; infers `root` + origin slug from the current repo. Flags: `--root`, `--path`, `--repo`, `--context path:purpose`, `--goal objective:measure`, `--linear`. |
 | `agents projects view <name>` / `show` | Alias of `status <name>`: full card, every milestone, stored definition. |
 | `agents projects edit <name>` | Open the YAML in `$EDITOR`. |
-| `agents projects status [name] [--json] [--window N] [--no-remote] [--fleet]` (aliases `view`, `show`) | Progress card for every project, or one named project. Named form also prints every milestone and the stored definition. `--fleet` adds per-device workspace drift over SSH. |
+| `agents projects status [name] [--json] [--window N] [--no-remote] [--device name...] [--devices a,b,c]` (aliases `view`, `show`) | Progress card for every project across the whole fleet (per-device workspace drift over SSH), or one named project. Named form also prints every milestone and the stored definition. `--device`/`--devices` scopes the fan-out to a subset. |
 | `agents projects link <name> --linear [query]` | Bind a Linear project into the def (`linear.projectId` + url). No query → auto-suggests from the def name + repo slug; ambiguous/none lists candidates and exits 1. Powers the `linear` card line. |
 | `agents projects import --from-linear` | Import the workspace's Linear projects (via the `linear` CLI) as definitions. See [Importing](#importing--linear-first-factory-gated). |
 | `agents projects import --from-factory [--min-confidence low\|medium\|high] [--all]` | Absorb `~/.agents/factory/projects.json`. Imports only `high`-confidence rows by default. |
@@ -298,11 +302,10 @@ unlinks the YAML, never the repo.
 
 ## Not yet (fast-follow)
 
-- **Fleet-wide live rollup by default.** `status --fleet` already widens the
-  live-agent count to the whole fleet (via the sessions fan-out) and adds
-  per-device workspace drift, but fleet remains opt-in, and cwd matching is
-  still local-home — a session recorded on a different-home machine only matches
-  once home-relative cwd matching lands.
+- **Home-relative cwd matching across machines.** `status` now dials the whole
+  fleet by default (live-agent count via the sessions fan-out + per-device
+  workspace drift), but cwd matching is still local-home — a session recorded on
+  a different-home machine only matches once home-relative cwd matching lands.
 - **Re-point `agents factory snapshot`** per-project Linear rollup at defined projects.
 - **Per-repo release lines** — the `ships` release tag is the primary repo only.
 - **Persisted `project_id` session column** — today membership is derived from cwd.

--- a/apps/cli/src/commands/__tests__/beta.test.ts
+++ b/apps/cli/src/commands/__tests__/beta.test.ts
@@ -92,4 +92,22 @@ describe('agents beta', () => {
     expect(factory.status).toBe(1);
     expect(outputOf(factory)).toContain('FACTORY_FLOOR_URL is not set.');
   });
+
+  it('treats a graduated feature (projects) as a friendly no-op, not an error', () => {
+    const home = makeTempHome();
+    writeUpdateCache(home);
+
+    const enable = runAgents(['beta', 'enable', 'projects'], home);
+    expect(enable.status).toBe(0);
+    expect(outputOf(enable)).toContain('graduated out of beta');
+    const yamlPath = path.join(home, '.agents', 'agents.yaml');
+    if (fs.existsSync(yamlPath)) {
+      expect(fs.readFileSync(yamlPath, 'utf-8')).not.toContain('- projects');
+    }
+
+    // A genuine typo still errors.
+    const typo = runAgents(['beta', 'enable', 'factroy'], home);
+    expect(typo.status).toBe(1);
+    expect(outputOf(typo)).toContain('Unknown beta feature');
+  });
 });

--- a/apps/cli/src/commands/__tests__/beta.test.ts
+++ b/apps/cli/src/commands/__tests__/beta.test.ts
@@ -81,14 +81,13 @@ describe('agents beta', () => {
     writeUpdateCache(home);
     fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
 
-    const enable = runAgents(['beta', 'enable', 'factory', 'projects'], home);
+    const enable = runAgents(['beta', 'enable', 'factory'], home);
     const list = runAgents(['beta', 'list'], home);
     const factory = runAgents(['factory', 'submit', 'EXAMPLE-1'], home);
 
     expect(enable.status).toBe(0);
     expect(fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8')).toContain('beta:');
     expect(fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8')).toContain('- factory');
-    expect(fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8')).toContain('- projects');
     expect(outputOf(list)).toContain(path.join(home, '.agents', 'agents.yaml'));
     expect(factory.status).toBe(1);
     expect(outputOf(factory)).toContain('FACTORY_FLOOR_URL is not set.');

--- a/apps/cli/src/commands/beta.ts
+++ b/apps/cli/src/commands/beta.ts
@@ -10,7 +10,6 @@ import type { BetaFeatureName } from '../lib/types.js';
 
 const BETA_DESCRIPTIONS: Record<BetaFeatureName, string> = {
   factory: 'Cloud-based agent dispatch via Rush Factory',
-  projects: 'Named multi-repo projects with a progress rollup (agents projects)',
 };
 
 function parseFeatures(values: string[]): BetaFeatureName[] {

--- a/apps/cli/src/commands/beta.ts
+++ b/apps/cli/src/commands/beta.ts
@@ -12,15 +12,23 @@ const BETA_DESCRIPTIONS: Record<BetaFeatureName, string> = {
   factory: 'Cloud-based agent dispatch via Rush Factory',
 };
 
+// Features that used to be beta and are now always-on. `beta enable/disable` on
+// one of these is a friendly no-op, not an "Unknown beta feature" error — so
+// muscle memory and old bootstrap scripts survive the graduation.
+const GRADUATED_FEATURES = new Set<string>(['projects']);
+
 function parseFeatures(values: string[]): BetaFeatureName[] {
   const valid = new Set<BetaFeatureName>(ALL_BETA_FEATURES);
-  const invalid = values.filter((value) => !valid.has(value as BetaFeatureName));
-  if (invalid.length > 0) {
-    console.error(chalk.red(`Unknown beta feature: ${invalid.join(', ')}`));
+  for (const g of values.filter((v) => GRADUATED_FEATURES.has(v))) {
+    console.error(chalk.gray(`'${g}' has graduated out of beta — it is on by default; no action needed.`));
+  }
+  const unknown = values.filter((v) => !valid.has(v as BetaFeatureName) && !GRADUATED_FEATURES.has(v));
+  if (unknown.length > 0) {
+    console.error(chalk.red(`Unknown beta feature: ${unknown.join(', ')}`));
     console.error(chalk.gray(`Valid features: ${ALL_BETA_FEATURES.join(', ')}`));
     process.exit(1);
   }
-  return values as BetaFeatureName[];
+  return values.filter((v) => valid.has(v as BetaFeatureName)) as BetaFeatureName[];
 }
 
 export function registerBetaCommands(program: Command): void {
@@ -54,8 +62,10 @@ Examples:
     .command('enable <features...>')
     .description('Enable one or more beta features.')
     .action((features: string[]) => {
-      const result = setBetaEnabled(parseFeatures(features), true);
-      console.log(chalk.green(`Enabled: ${features.join(', ')}`));
+      const parsed = parseFeatures(features);
+      if (parsed.length === 0) return; // only graduated/no-op names
+      const result = setBetaEnabled(parsed, true);
+      console.log(chalk.green(`Enabled: ${parsed.join(', ')}`));
       console.log(chalk.gray(`Saved to ${result.path}`));
     });
 
@@ -63,8 +73,10 @@ Examples:
     .command('disable <features...>')
     .description('Disable one or more beta features.')
     .action((features: string[]) => {
-      const result = setBetaEnabled(parseFeatures(features), false);
-      console.log(chalk.green(`Disabled: ${features.join(', ')}`));
+      const parsed = parseFeatures(features);
+      if (parsed.length === 0) return; // only graduated/no-op names
+      const result = setBetaEnabled(parsed, false);
+      console.log(chalk.green(`Disabled: ${parsed.join(', ')}`));
       console.log(chalk.gray(`Saved to ${result.path}`));
     });
 }

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -1,8 +1,7 @@
 /**
  * `agents projects` — named, multi-repo projects and the progress
  * rollup. Definitions live in `~/.agents/projects/<name>.yaml` (see
- * `lib/projects.ts`); this registers the command tree over them. Beta-gated on
- * `isBetaEnabled('projects')`, mirroring `agents factory`.
+ * `lib/projects.ts`); this registers the command tree over them.
  *
  * The headline is `status`: instead of the vague per-agent activity line, it
  * rolls every session up by project (matched on cwd) into one card — agents by
@@ -15,7 +14,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 
-import { betaEnableHint, isBetaEnabled } from '../lib/beta.js';
 import { setHelpSections } from '../lib/help.js';
 import { getMainRepoRoot } from '../lib/git.js';
 import { parseOwnerRepoFromRemote } from '../lib/registry.js';
@@ -504,9 +502,8 @@ function renderCard(
 }
 
 export function registerProjectsCommands(program: Command): void {
-  const enabled = isBetaEnabled('projects');
   const projects = program
-    .command('projects', { hidden: !enabled })
+    .command('projects')
     .description('Named multi-repo projects with a progress rollup.');
 
   setHelpSections(projects, {
@@ -514,33 +511,22 @@ export function registerProjectsCommands(program: Command): void {
       agents projects import --from-linear  # the projects you actually track
       agents projects add rush --repo phnx-labs/rush --path apps/web
       agents projects list
-      agents projects status              # progress card for every project
+      agents projects status              # every project, across the whole fleet
       agents projects status rush         # one project (same body as view/show)
       agents projects view rush           # alias of status <name>
-      agents projects status --fleet      # + per-device workspace drift over SSH
+      agents projects status --device s0  # scope to one device (or --devices a,b,c)
       agents projects link rush --linear  # bind the Linear project (auto-suggest)
       agents run --project rush           # land an agent in the project
     `,
     notes: `
       Definitions are hand-editable YAML in ~/.agents/projects/ and sync across
-      machines with 'agents push/pull'. Enable with: agents beta enable projects.
+      machines with 'agents push/pull'.
 
       'import --from-factory' reads Factory's auto-detected registry, which
       guesses from checkouts on disk — it imports only 'high' confidence rows by
       default. Widen with --min-confidence medium or --all, and drop a bad guess
       with 'agents projects rm <name>'.
     `,
-  });
-
-  projects.hook('preAction', (_thisCommand, actionCommand) => {
-    if (enabled) return;
-    // `probe` is the peer half of `status --fleet`: it must answer whenever the
-    // binary carries it, even where the beta flag is off — a gated peer would
-    // look unreachable to every fleet member on a newer CLI.
-    if (actionCommand.name() === 'probe') return;
-    console.error(chalk.red('agents projects is in beta.'));
-    console.error(chalk.gray(betaEnableHint('projects')));
-    process.exit(1);
   });
 
   // ---- list ----
@@ -642,8 +628,19 @@ export function registerProjectsCommands(program: Command): void {
     json?: boolean;
     window?: string;
     remote?: boolean;
-    fleet?: boolean;
+    // Scope the fleet fan-out to specific devices; undefined = the whole fleet.
+    deviceFilter?: string[];
   };
+
+  /** Merge `--device a b` (variadic) and `--devices a,b,c` (comma list) into one
+   *  deduped device filter; undefined when neither was given (= whole fleet). */
+  function resolveDeviceFilter(device?: string[], devices?: string): string[] | undefined {
+    const merged = [
+      ...(device ?? []),
+      ...(devices ? devices.split(',').map((s) => s.trim()).filter(Boolean) : []),
+    ];
+    return merged.length ? [...new Set(merged)] : undefined;
+  }
 
   /** Print the YAML-side fields that sit under the shared card in `view` mode. */
   function printProjectDefinition(def: ProjectDef, name: string): void {
@@ -692,16 +689,16 @@ export function registerProjectsCommands(program: Command): void {
     const windowDays = Math.max(1, Number.parseInt(opts.window ?? '7', 10) || 7);
     const nowMs = Date.now();
 
-    // --fleet: probe each shown def's workspace paths (root + repos[].path)
-    // locally and on every peer in one parallel SSH round, and widen the
-    // live-session rollup to the whole fleet via the existing sessions
-    // fan-out. Both are opt-in — they dial the fleet. `view` accepts the flag
-    // too so the two verbs stay interchangeable once a name is given.
-    const fleetTargets = opts.fleet ? [...new Set(defs.flatMap(workspaceTargetsForDef))] : [];
+    // Fleet is the default: probe each shown def's workspace paths (root +
+    // repos[].path) locally AND on every peer in one parallel SSH round, and
+    // widen the live-session rollup to the fleet via the sessions fan-out.
+    // `--device`/`--devices` scopes the remote fan-out to a subset; with no
+    // filter every registered device is dialled.
+    const fleetTargets = [...new Set(defs.flatMap(workspaceTargetsForDef))];
     let fleetWs: HostWorkspaceStatus[] = [];
     let fleetSkipped: string[] = [];
     let fleetSessions: Awaited<ReturnType<typeof getActiveSessions>> = [];
-    if (opts.fleet) {
+    {
       const self = machineId();
       fleetWs.push(...probeProjectWorkspaces(fleetTargets).map((s) => ({ ...s, host: self })));
       const [probeRes, activeRes] = await Promise.all([
@@ -709,11 +706,12 @@ export function registerProjectsCommands(program: Command): void {
           ? gatherRemoteAgentsJson({
               args: ['projects', 'probe', '--json', ...fleetTargets],
               noFanoutEnv: PROJECTS_NO_FANOUT_ENV,
+              hosts: opts.deviceFilter,
               parse: parseRemoteProbe,
               quiet: true,
             })
           : Promise.resolve({ items: [] as HostWorkspaceStatus[], deviceCount: 0, skipped: [] as string[] }),
-        gatherRemoteActive(undefined, { quiet: true }),
+        gatherRemoteActive(opts.deviceFilter, { quiet: true }),
       ]);
       fleetWs.push(...probeRes.items);
       fleetSkipped = probeRes.skipped;
@@ -731,17 +729,6 @@ export function registerProjectsCommands(program: Command): void {
     const fleetFor = (d: ProjectDef): HostWorkspaceStatus[] => {
       const targets = new Set(workspaceTargetsForDef(d));
       return fleetWs.filter((s) => targets.has(s.path));
-    };
-
-    /** Local-only workspace probe for the warnings footer when --fleet is off. */
-    const localWsCache = new Map<string, HostWorkspaceStatus[]>();
-    const localWsFor = (d: ProjectDef): HostWorkspaceStatus[] => {
-      const cached = localWsCache.get(d.name);
-      if (cached) return cached;
-      const self = machineId();
-      const rows = probeProjectWorkspaces(workspaceTargetsForDef(d)).map((s) => ({ ...s, host: self }));
-      localWsCache.set(d.name, rows);
-      return rows;
     };
 
     if (opts.json) {
@@ -775,7 +762,7 @@ export function registerProjectsCommands(program: Command): void {
               lastArtifact: rem?.lastArtifact ?? null,
               windowDays,
               repos: [d.repo, ...(d.repos ?? []).map((r2) => r2.slug)].filter(Boolean),
-              ...(opts.fleet ? { workspaces: fleetFor(d) } : {}),
+              workspaces: fleetFor(d),
             };
           }),
           null,
@@ -792,15 +779,15 @@ export function registerProjectsCommands(program: Command): void {
         d,
         roll.get(d.name),
         remote.get(d.name),
-        opts.fleet ? fleetFor(d) : undefined,
+        fleetFor(d),
         linear.get(d.name),
         nowMs,
         milestoneLimit,
         focus.get(d.name) ?? [],
         detail,
-        // Always feed workspace rows into the warnings footer — full fleet when
-        // --fleet, otherwise a local-only probe so behind/dirty is never silent.
-        opts.fleet ? fleetFor(d) : localWsFor(d),
+        // Always feed workspace rows into the warnings footer so behind/dirty
+        // is never silent.
+        fleetFor(d),
       );
       if (detail) printProjectDefinition(d, d.name);
     }
@@ -811,15 +798,23 @@ export function registerProjectsCommands(program: Command): void {
     .command('status [name]')
     .alias('view')
     .alias('show')
-    .description('Progress card for every project, or one named project (aliases: view, show). Named form also prints every milestone and the stored definition.')
+    .description('Progress card for every project across the whole fleet, or one named project (aliases: view, show). Named form also prints every milestone and the stored definition.')
     .option('--json', 'Machine-readable output')
     .option('--window <days>', 'Window for merged PRs, artifacts, and focus areas', '7')
     .option('--no-remote', 'Skip the GitHub and Linear lookups; faster, offline')
-    .option('--fleet', 'Also dial every fleet device for workspace presence, branch, and drift (one SSH per peer)')
-    .action(async (name: string | undefined, opts: ProjectCardOpts) => {
+    .option('--device <name...>', 'Scope fleet status to one or more devices (repeatable)')
+    .option('--devices <names>', 'Scope fleet status to a comma-separated list of devices')
+    .action(async (name: string | undefined, rawOpts: ProjectCardOpts & { device?: string[]; devices?: string }) => {
       // Named invocation = `view` depth (all milestones + definition). Unnamed
       // stays the scannable multi-project rollup. `view`/`show` are commander
       // aliases of this same command, so there is only one implementation.
+      // Fleet is dialled by default; --device/--devices narrows it to a subset.
+      const opts: ProjectCardOpts = {
+        json: rawOpts.json,
+        window: rawOpts.window,
+        remote: rawOpts.remote,
+        deviceFilter: resolveDeviceFilter(rawOpts.device, rawOpts.devices),
+      };
       const mode: 'status' | 'view' = name ? 'view' : 'status';
       await runProjectCard(name, opts, mode);
     });

--- a/apps/cli/src/lib/beta.ts
+++ b/apps/cli/src/lib/beta.ts
@@ -13,7 +13,7 @@ import type { BetaFeatureName, Manifest, Meta } from './types.js';
 import { getAgentsDir, getOptionalUserAgentsDir, readMeta, writeMeta } from './state.js';
 import { readManifest, writeManifest } from './manifest.js';
 
-export const ALL_BETA_FEATURES = ['factory', 'projects'] as const satisfies readonly BetaFeatureName[];
+export const ALL_BETA_FEATURES = ['factory'] as const satisfies readonly BetaFeatureName[];
 
 function isBetaFeatureName(value: unknown): value is BetaFeatureName {
   return typeof value === 'string' && ALL_BETA_FEATURES.includes(value as BetaFeatureName);

--- a/apps/cli/src/lib/project-probe.ts
+++ b/apps/cli/src/lib/project-probe.ts
@@ -1,5 +1,5 @@
 /**
- * Project workspace probing — the drift signal behind `projects status --fleet`.
+ * Project workspace probing — the drift signal behind `projects status`.
  *
  * Projects are natively multi-device: the same definition (home-relative paths)
  * re-roots on every fleet machine, and the question is whether the project's

--- a/apps/cli/src/lib/projects.ts
+++ b/apps/cli/src/lib/projects.ts
@@ -45,7 +45,7 @@ export interface ProjectRepo {
   /**
    * Optional home-relative local checkout of this repo. The def's `root` only
    * knows the primary repo on disk; `path` opts an additional repo into
-   * workspace probing (`projects status --fleet`).
+   * workspace probing (`projects status`).
    */
   path?: string;
 }

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -90,7 +90,7 @@ export interface BudgetConfig {
 }
 
 /** Preview features that users can opt into via `agents beta`. */
-export type BetaFeatureName = 'factory' | 'projects';
+export type BetaFeatureName = 'factory';
 
 /** Subset of chalk color names used for agent-specific terminal output. */
 export type ChalkColor = 'magenta' | 'green' | 'blue' | 'cyan' | 'yellowBright' | 'redBright' | 'whiteBright' | 'blueBright' | 'greenBright' | 'magentaBright' | 'cyanBright';


### PR DESCRIPTION
**What + type:** CLI feature — graduate `agents projects` out of beta and make `projects status` fleet-wide by default. No new deps; touches the projects command surface + the beta registry.

## Why

`agents projects` was beta-gated behind `agents beta enable projects`. The beta flag lives in `agents.yaml`, which is rewritten across a version-skewed fleet and silently loses keys it doesn't model — so the opt-in (and the imported projects) kept vanishing. Graduating the command removes that failure surface. Separately, drift is the whole reason `projects status` exists, so it should show the **whole fleet** without an opt-in flag.

## What changed

- **`agents projects` is no longer beta-gated.** Dropped `projects` from `ALL_BETA_FEATURES` / `BetaFeatureName` and removed the `preAction` gate + hidden-command flag. A lingering `beta.enabled: [projects]` entry is harmlessly ignored.
- **`agents projects status` dials the whole fleet by default.** Removed the `--fleet` opt-in (breaking: the flag is gone); the workspace presence/branch/drift fan-out always runs. Added `--device <name...>` (repeatable) and `--devices a,b,c` to scope the fan-out to a subset, reusing the shared `--host`/`--device` target resolution. Dropped the now-unused local-only probe.

## Verification (ran it)

`tsc --noEmit` clean · `beta.test.ts` green · `projects status --help` shows the new surface:

```
Usage: agents projects status [options] [name]

Progress card for every project across the whole fleet, or one named project
(aliases: view, show). ...

Options:
  --json              Machine-readable output
  --window <days>     Window for merged PRs, artifacts, and focus areas (default: "7")
  --no-remote         Skip the GitHub and Linear lookups; faster, offline
  --device <name...>  Scope fleet status to one or more devices (repeatable)
  --devices <names>   Scope fleet status to a comma-separated list of devices
  -h, --help          Show help
```

CHANGELOG queue fragment added under `.changelog/next/`.

## Not in this PR (follow-ups)

- The **root cause of the config loss** — `serializeCentral` (`state.ts`) deleting top-level `agents.yaml` keys a version doesn't model (it ate `notify.owner`/`feed:` before, per commit `04295e3`) — is a cross-cutting serializer change and lands in its own PR.
- A **harness-agnostic git guard** (global `core.hooksPath` pre-commit) so default-branch protection covers every harness, not just via per-harness PreToolUse hooks.
