### PR TITLE
fix(cli): move event logs into history

### DIFF
--- a/apps/cli/.changelog/next/organize-event-logs.md
+++ b/apps/cli/.changelog/next/organize-event-logs.md
@@ -1,0 +1,1 @@
+- Move operational event logs from the git-backed `~/.agents/` root into `~/.agents/.history/events/`, including existing numbered gzip archives.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -385,7 +385,7 @@ Fields:
 | `spawnedTeam` | The team this session CREATED, read off its `agents teams create/add` command at scan time | `null` for the ~everything that never ran one; the inverse of `isTeamOrigin` |
 | `teamOrigin` | For a teammate: its `{team, handle, mode, parentSessionId}`, read from the teammate's `meta.json` | `null` for a non-teammate; `team`/`parentSessionId` absent on records predating their capture, or once the 7-day teams cleanup removes the dir |
 | `plan` | Last `ExitPlanMode` plan markdown (Claude sessions only) | `null` when the session never entered plan-review |
-| `usedBrowser` / `usedComputer` | A sessionId-scoped read of `~/.agents/events.jsonl` for `browser.navigate`/`browser.screenshot` / `computer.action` (never a transcript re-scan) | `undefined` on a legacy row this scanner hasn't computed the field for yet — distinct from a real, computed `false` |
+| `usedBrowser` / `usedComputer` | A sessionId-scoped read of `~/.agents/.history/events/events.jsonl` for `browser.navigate`/`browser.screenshot` / `computer.action` (never a transcript re-scan) | `undefined` on a legacy row this scanner hasn't computed the field for yet — distinct from a real, computed `false` |
 
 ### Two time fields per row
 

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -54,7 +54,7 @@ agents notify --text "same as send --to owner"
 agents feed post --title "CHANGELOG pushed" "Watching CI and mac-mini E2E"
 ```
 
-The write-stores: `~/.agents/events.jsonl` (operational audit), per-session
+The write-stores: `~/.agents/.history/events/events.jsonl` (operational audit), per-session
 `~/.agents/.history/activity/<id>.jsonl` (agent milestones), and the disposable
 perf warehouse `~/.agents/.cache/perf/perf.db` (latency samples). Audit + activity
 are merged at read time by `event-stream.ts::readUnifiedEvents`. Perf is a
@@ -168,7 +168,7 @@ Separate from the fleet-state sources below (which answer "what's running *now*"
 the **audit event log** answers "who did what, and from where". Every
 `agents <module> <command>` invocation is recorded — team create/disband, agent
 run, secrets access, version installs — as a structured JSONL line at
-`~/.agents/events.jsonl` (directory `0700`, file `0600`). At 10 MB the active
+`~/.agents/.history/events/events.jsonl` (directory `0700`, file `0600`). At 10 MB the active
 file rotates losslessly to `events.1.jsonl.gz`; older archives shift to
 `events.2.jsonl.gz`, `events.3.jsonl.gz`, and so on.
 

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -190,7 +190,7 @@ long it must live and how it's read back:
 | Transcripts | `~/.claude/projects/…`, `~/.codex/sessions/…`, … | agent-native files (read-only) | the raw truth; parsed on demand |
 | CLI pid-registry | `~/.agents/.cache/terminals/by-pid/<pid>.json` | ephemeral file | `ag run`/shim write; CLI reads (§3) |
 | Live-session state | `~/.agents/.cache/terminals/sessions/<pid>.json` | ephemeral file | hook writes; extension reads (§3) |
-| Audit log | `~/.agents/events.jsonl` | locked shared log | `emit()` in [`src/lib/events.ts`](../src/lib/events.ts); `agents events` reads |
+| Audit log | `~/.agents/.history/events/events.jsonl` | locked shared log | `emit()` in [`src/lib/events.ts`](../src/lib/events.ts); `agents events` reads |
 | Teams sentinels | `…/agents/<uuid>/exit_code`, `hosts/<id>.log` + `.exit` | ephemeral files | teammate writes exit code; supervisor reads (§6) |
 | Mailbox spool | `~/.agents/.history/mailbox/<id>/…` | append-only dirs | `agents message` / feed; `agents mailboxes` reads |
 

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -130,7 +130,7 @@ Bundle metadata (names, descriptions, variable names + references, and any non-s
 Every secret lifecycle/access event — create, import, export, view, access (a
 value read for injection), unlock — funnels through one chokepoint,
 `emitSecretAudit` (`src/lib/secrets/audit.ts`). That single call writes to **both**
-sinks: the append-only `~/.agents/events.jsonl` audit log (surfaced by
+sinks: the append-only `~/.agents/.history/events/events.jsonl` audit log (surfaced by
 `agents events --module secrets`) and a **derived per-bundle read-model** at
 `~/.agents/secrets/secrets.db` (`src/lib/secrets/usage-db.ts`). There is no second
 write path — the read-model is an index fed off the real access flow, the way

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -917,7 +917,7 @@ access control (that is 1Password/Vault; this tool is device-local first).
 - **SEC-26 (MUST).** `emitSecretAudit` (`lib/secrets/audit.ts`) MUST be the single
   write path for every secret lifecycle/access event — create, import, export,
   view, access (read), unlock. One call writes to BOTH the append-only
-  `~/.agents/events.jsonl` audit log (via `emit()`) AND the derived per-bundle
+  `~/.agents/.history/events/events.jsonl` audit log (via `emit()`) AND the derived per-bundle
   usage read-model DB (`~/.agents/secrets/secrets.db`, `lib/secrets/usage-db.ts`);
   there MUST be no standalone write path parallel to it. **Given** an access is
   recorded **When** it flows through `emitSecretAudit` **Then** it appears exactly

--- a/apps/cli/src/commands/events.ts
+++ b/apps/cli/src/commands/events.ts
@@ -1,7 +1,7 @@
 /**
  * `agents events` — read the unified event stream.
  *
- * One stream over BOTH operational events (`~/.agents/events.jsonl`: every
+ * One stream over BOTH operational events (`~/.agents/.history/events/events.jsonl`: every
  * `agents <module> <cmd>` invocation plus typed events like secrets access,
  * version installs) AND agent-semantic events (the per-session activity logs:
  * plans, PRs, worktrees, sub-agents, artifacts). Each is stamped with who ran

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1351,7 +1351,7 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
     // Bumping the suffix re-runs migrations for every user; binary releases that
     // don't change the schema must NOT re-run (they would destroy user content
     // when migration steps overlap with user-authored paths). See issue #20.
-    const sentinelValue = 'v13';
+    const sentinelValue = 'v14';
     let needRun = true;
     try {
       if (fs.existsSync(sentinel) && fs.readFileSync(sentinel, 'utf-8').trim() === sentinelValue) {

--- a/apps/cli/src/lib/__tests__/migrate.test.ts
+++ b/apps/cli/src/lib/__tests__/migrate.test.ts
@@ -52,6 +52,25 @@ describe('runMigration', () => {
     expect(fs.existsSync(path.join(userDir, 'events.1.jsonl.gz'))).toBe(false);
   });
 
+  it('preserves root and history event logs when both layouts contain data', () => {
+    const eventsDir = path.join(userDir, '.history', 'events');
+    fs.mkdirSync(eventsDir, { recursive: true });
+    fs.writeFileSync(path.join(eventsDir, 'events.jsonl'), '{"event":"history"}\n');
+    fs.writeFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'history-archive');
+    fs.writeFileSync(path.join(userDir, 'events.jsonl'), '{"event":"root"}\n');
+    fs.writeFileSync(path.join(userDir, 'events.1.jsonl.gz'), 'root-archive');
+
+    runRealMigration();
+
+    expect(fs.readFileSync(path.join(eventsDir, 'events.jsonl'), 'utf-8')).toBe(
+      '{"event":"history"}\n{"event":"root"}\n',
+    );
+    expect(fs.readFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'utf-8')).toBe('history-archive');
+    expect(fs.readFileSync(path.join(eventsDir, 'events.2.jsonl.gz'), 'utf-8')).toBe('root-archive');
+    expect(fs.existsSync(path.join(userDir, 'events.jsonl'))).toBe(false);
+    expect(fs.existsSync(path.join(userDir, 'events.1.jsonl.gz'))).toBe(false);
+  });
+
   it('moves legacy files into the user repo and deletes dead files', () => {
     fs.writeFileSync(path.join(systemDir, 'agents.yaml'), 'agents:\n  claude: "1.0.0"\n');
     fs.writeFileSync(path.join(systemDir, 'prompts.json'), '{}');

--- a/apps/cli/src/lib/__tests__/migrate.test.ts
+++ b/apps/cli/src/lib/__tests__/migrate.test.ts
@@ -33,6 +33,20 @@ function runRealMigration(): void {
   );
 }
 
+function queryNewestEvent(): Record<string, unknown> {
+  const modulePath = path.resolve(process.cwd(), 'src/lib/events.ts');
+  const stdout = execFileSync(
+    'bun',
+    ['-e', `import { query } from ${JSON.stringify(modulePath)}; console.log(JSON.stringify(query({ limit: 1 })[0]));`],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: testHome, AGENTS_EVENTS_PATH: '' },
+      encoding: 'utf-8',
+    },
+  );
+  return JSON.parse(stdout.trim()) as Record<string, unknown>;
+}
+
 /** Path to this machine's per-device pin file after the split migration. */
 function devicePinsFile(): string {
   return path.join(userDir, 'devices', 'testdev', 'agents.yaml');
@@ -55,16 +69,18 @@ describe('runMigration', () => {
   it('preserves root and history event logs when both layouts contain data', () => {
     const eventsDir = path.join(userDir, '.history', 'events');
     fs.mkdirSync(eventsDir, { recursive: true });
-    fs.writeFileSync(path.join(eventsDir, 'events.jsonl'), '{"event":"history"}\n');
+    fs.writeFileSync(path.join(eventsDir, 'events.jsonl'), '{"event":"info","module":"history-new","ts":"2025-08-05T12:00:00.000Z"}\n');
     fs.writeFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'history-archive');
-    fs.writeFileSync(path.join(userDir, 'events.jsonl'), '{"event":"root"}\n');
+    fs.writeFileSync(path.join(userDir, 'events.jsonl'), '{"event":"info","module":"root-old","ts":"2025-08-04T12:00:00.000Z"}\n');
     fs.writeFileSync(path.join(userDir, 'events.1.jsonl.gz'), 'root-archive');
 
     runRealMigration();
 
     expect(fs.readFileSync(path.join(eventsDir, 'events.jsonl'), 'utf-8')).toBe(
-      '{"event":"history"}\n{"event":"root"}\n',
+      '{"event":"info","module":"root-old","ts":"2025-08-04T12:00:00.000Z"}\n' +
+      '{"event":"info","module":"history-new","ts":"2025-08-05T12:00:00.000Z"}\n',
     );
+    expect(queryNewestEvent().module).toBe('history-new');
     expect(fs.readFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'utf-8')).toBe('history-archive');
     expect(fs.readFileSync(path.join(eventsDir, 'events.2.jsonl.gz'), 'utf-8')).toBe('root-archive');
     expect(fs.existsSync(path.join(userDir, 'events.jsonl'))).toBe(false);

--- a/apps/cli/src/lib/__tests__/migrate.test.ts
+++ b/apps/cli/src/lib/__tests__/migrate.test.ts
@@ -39,6 +39,19 @@ function devicePinsFile(): string {
 }
 
 describe('runMigration', () => {
+  it('moves operational event logs into the durable history bucket', () => {
+    fs.writeFileSync(path.join(userDir, 'events.jsonl'), '{"event":"info"}\n');
+    fs.writeFileSync(path.join(userDir, 'events.1.jsonl.gz'), 'archive');
+
+    runRealMigration();
+
+    const eventsDir = path.join(userDir, '.history', 'events');
+    expect(fs.readFileSync(path.join(eventsDir, 'events.jsonl'), 'utf-8')).toBe('{"event":"info"}\n');
+    expect(fs.readFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'utf-8')).toBe('archive');
+    expect(fs.existsSync(path.join(userDir, 'events.jsonl'))).toBe(false);
+    expect(fs.existsSync(path.join(userDir, 'events.1.jsonl.gz'))).toBe(false);
+  });
+
   it('moves legacy files into the user repo and deletes dead files', () => {
     fs.writeFileSync(path.join(systemDir, 'agents.yaml'), 'agents:\n  claude: "1.0.0"\n');
     fs.writeFileSync(path.join(systemDir, 'prompts.json'), '{}');

--- a/apps/cli/src/lib/event-stream.ts
+++ b/apps/cli/src/lib/event-stream.ts
@@ -1,6 +1,6 @@
 /**
  * The unified event reader -- one stream over BOTH operational events
- * (`~/.agents/events.jsonl` via events.ts: secrets, commands, teams, ...) and
+ * (`~/.agents/.history/events/events.jsonl` via events.ts: secrets, commands, teams, ...) and
  * agent-semantic events (the per-session activity logs via activity.ts: plans,
  * PRs, worktrees, sub-agents, artifacts). They share one {@link EventType}
  * vocabulary and one {@link EventRecord} shape, so `agents events` and any

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -1,7 +1,7 @@
 /**
  * Centralized event logging for agents-cli.
  *
- * Structured JSONL audit log at ~/.agents/events.jsonl with lossless numbered
+ * Structured JSONL audit log at ~/.agents/.history/events/events.jsonl with lossless numbered
  * gzip rotation at 10 MB and rich metadata for debugging/auditing.
  *
  * Features:
@@ -18,7 +18,7 @@ import * as os from 'os';
 import { createHash } from 'node:crypto';
 import { gzipSync, gunzipSync } from 'node:zlib';
 import { ensureLockTarget, withFileLock } from './fs-atomic.js';
-import { getUserAgentsDir } from './state.js';
+import { getHistoryDir } from './state.js';
 import { stampProvenance, resetEventProvenanceForTest } from './event-provenance.js';
 import type { ActorKind } from './actor.js';
 
@@ -60,7 +60,7 @@ function recordPerfTiming(payload: {
 // a test spawns, so fixture events can never land in the user's real log (#910).
 let _eventsPath: string | undefined;
 function eventsPath(): string {
-  return (_eventsPath ??= process.env.AGENTS_EVENTS_PATH || path.join(getUserAgentsDir(), 'events.jsonl'));
+  return (_eventsPath ??= process.env.AGENTS_EVENTS_PATH || path.join(getHistoryDir(), 'events', 'events.jsonl'));
 }
 
 function eventsDir(): string {

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -947,8 +947,41 @@ function migrateEventLogsToHistory(): void {
   } catch {
     return;
   }
-  for (const file of files) {
-    moveFileOnce(path.join(USER_DIR, file), path.join(destination, file));
+  try { fs.mkdirSync(destination, { recursive: true, mode: 0o700 }); } catch { return; }
+
+  const active = files.find((file) => file === 'events.jsonl');
+  if (active) {
+    const src = path.join(USER_DIR, active);
+    const dest = path.join(destination, active);
+    if (!fs.existsSync(dest)) {
+      moveFileOnce(src, dest);
+    } else {
+      try {
+        const existing = fs.readFileSync(dest);
+        const legacy = fs.readFileSync(src);
+        const separator = existing.length > 0 && existing.at(-1) !== 0x0a && legacy.length > 0
+          ? Buffer.from('\n')
+          : Buffer.alloc(0);
+        fs.appendFileSync(dest, Buffer.concat([separator, legacy]));
+        fs.unlinkSync(src);
+      } catch { /* preserve the source for a later retry */ }
+    }
+  }
+
+  const archives = files
+    .map((file) => ({ file, match: file.match(/^events\.(\d+)\.jsonl\.gz$/) }))
+    .filter((entry): entry is { file: string; match: RegExpMatchArray } => entry.match !== null)
+    .sort((a, b) => Number(a.match[1]) - Number(b.match[1]));
+  let nextArchive = fs.readdirSync(destination).reduce((max, file) => {
+    const match = file.match(/^events\.(\d+)\.jsonl\.gz$/);
+    return match ? Math.max(max, Number(match[1])) : max;
+  }, 0) + 1;
+  for (const archive of archives) {
+    const preferred = path.join(destination, archive.file);
+    const dest = fs.existsSync(preferred)
+      ? path.join(destination, `events.${nextArchive++}.jsonl.gz`)
+      : preferred;
+    moveFileOnce(path.join(USER_DIR, archive.file), dest);
   }
 }
 

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -957,12 +957,19 @@ function migrateEventLogsToHistory(): void {
       moveFileOnce(src, dest);
     } else {
       try {
-        const existing = fs.readFileSync(dest);
-        const legacy = fs.readFileSync(src);
-        const separator = existing.length > 0 && existing.at(-1) !== 0x0a && legacy.length > 0
-          ? Buffer.from('\n')
-          : Buffer.alloc(0);
-        fs.appendFileSync(dest, Buffer.concat([separator, legacy]));
+        const lines = [fs.readFileSync(src, 'utf-8'), fs.readFileSync(dest, 'utf-8')]
+          .flatMap((content) => content.split('\n').filter(Boolean))
+          .map((line, index) => {
+            try {
+              const timestamp = Date.parse((JSON.parse(line) as { ts?: string }).ts ?? '');
+              return { line, index, timestamp: Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp };
+            } catch {
+              return { line, index, timestamp: Number.MAX_SAFE_INTEGER };
+            }
+          })
+          .sort((a, b) => a.timestamp - b.timestamp || a.index - b.index)
+          .map(({ line }) => line);
+        atomicWriteFileSync(dest, `${lines.join('\n')}\n`, { mode: 0o600 });
         fs.unlinkSync(src);
       } catch { /* preserve the source for a later retry */ }
     }

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -920,6 +920,7 @@ function migrateRuntimeToHistory(): void {
   moveDirOnce(path.join(USER_DIR, '.backups'), path.join(HISTORY_DIR, 'backups'));
   moveDirOnce(path.join(USER_DIR, 'routines', 'runs'), path.join(HISTORY_DIR, 'runs'));
   moveDirOnce(path.join(USER_DIR, 'teams', 'agents'), path.join(HISTORY_DIR, 'teams', 'agents'));
+  migrateEventLogsToHistory();
 
   // Drop any empty leftover skeletons created mid-rename (e.g. `versions/<agent>/<v>/home/`
   // recreated by a concurrent process). The real data is already under .history/.
@@ -932,6 +933,22 @@ function migrateRuntimeToHistory(): void {
     try {
       if (fs.statSync(oldSessionsDb).size === 0) fs.unlinkSync(oldSessionsDb);
     } catch { /* best-effort */ }
+  }
+}
+
+/** Move the operational event stream out of the git-backed user-repo root. */
+function migrateEventLogsToHistory(): void {
+  const destination = path.join(HISTORY_DIR, 'events');
+  let files: string[] = [];
+  try {
+    files = fs.readdirSync(USER_DIR).filter((file) =>
+      file === 'events.jsonl' || /^events\.\d+\.jsonl\.gz$/.test(file)
+    );
+  } catch {
+    return;
+  }
+  for (const file of files) {
+    moveFileOnce(path.join(USER_DIR, file), path.join(destination, file));
   }
 }
 

--- a/apps/cli/src/lib/secrets/audit.ts
+++ b/apps/cli/src/lib/secrets/audit.ts
@@ -4,7 +4,7 @@
  * This is the ONE write path for secret events. Every path that creates,
  * imports, exports, views, reads a VALUE from, or unlocks a bundle funnels its
  * audit through here, so the operational event stream — `agents events`, backed
- * by the append-only `~/.agents/events.jsonl` audit log — carries a uniform,
+ * by the append-only `~/.agents/.history/events/events.jsonl` audit log — carries a uniform,
  * value-free provenance record: bundle, key NAMES, the resolving agent/harness
  * identity, operation, source, status. The ts / host / session / caller fields
  * are filled in by `emit()` itself. The secret VALUE is never part of the

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -412,7 +412,7 @@ export function getUserSecretsDir(): string { return USER_SECRETS_DIR; }
  * value-free usage telemetry (which bundle was created/imported/exported/viewed/
  * accessed/unlocked, when, by whom), never a secret value. It is a derived index
  * fed FROM the emitSecretAudit chokepoint alongside the append-only
- * ~/.agents/events.jsonl audit log — the same way sessions.db indexes session
+ * ~/.agents/.history/events/events.jsonl audit log — the same way sessions.db indexes session
  * metadata off the real session flow — not a second write path.
  */
 export function getSecretsDbPath(): string {

--- a/apps/cli/tests/events-audit.test.ts
+++ b/apps/cli/tests/events-audit.test.ts
@@ -48,7 +48,7 @@ function runCli(home: string, args: string[], extraEnv: Record<string, string> =
 
 /** Read every event record written to the canonical log under a temp HOME. */
 function readEvents(home: string): Array<Record<string, unknown>> {
-  const eventsPath = path.join(home, '.agents', 'events.jsonl');
+  const eventsPath = path.join(home, '.agents', '.history', 'events', 'events.jsonl');
   if (!fs.existsSync(eventsPath)) return [];
   const out: Array<Record<string, unknown>> = [];
   for (const line of fs.readFileSync(eventsPath, 'utf-8').split('\n').filter(Boolean)) {
@@ -136,7 +136,7 @@ describe('audit event log', () => {
     // the invocation; the token-shaped positional must be masked, not stored.
     runCli(home, ['secrets', 'get', 'ghp_FAKETOKENVALUE123'], { SSH_CONNECTION: '' });
 
-    const raw = fs.readFileSync(path.join(home, '.agents', 'events.jsonl'), 'utf-8');
+    const raw = fs.readFileSync(path.join(home, '.agents', '.history', 'events', 'events.jsonl'), 'utf-8');
     expect(raw).not.toContain('ghp_FAKETOKENVALUE123');
     expect(raw).toContain('[REDACTED]');
   });

--- a/apps/cli/tests/teams-events.test.ts
+++ b/apps/cli/tests/teams-events.test.ts
@@ -43,7 +43,7 @@ function runCli(home: string, args: string[]) {
 }
 
 function readEvents(home: string): Array<Record<string, unknown>> {
-  const eventsPath = path.join(home, '.agents', 'events.jsonl');
+  const eventsPath = path.join(home, '.agents', '.history', 'events', 'events.jsonl');
   if (!fs.existsSync(eventsPath)) return [];
   const out: Array<Record<string, unknown>> = [];
   for (const line of fs.readFileSync(eventsPath, 'utf-8').split('\n').filter(Boolean)) {


### PR DESCRIPTION
Moves agents-cli's machine-local operational audit logs out of the git-backed user configuration root.

## What changed

- Default event sink: `~/.agents/.history/events/events.jsonl`
- Numbered gzip archives rotate beside the active log.
- The startup migration moves existing root-level event files into the new directory.
- Current observability, sessions, secrets, architecture, and specification docs now show the canonical path.

## Verification

No UI surface: this changes a machine-local filesystem layout.

Actual targeted run:

```text
99 pass
0 fail
276 expect() calls
Ran 99 tests across 5 files. [25.02s]
```

The component build compiled TypeScript successfully. Its full test phase reported 14 failures: seven stale event-path assertions corrected in this PR, plus seven environment-dependent failures outside this diff (`usage`, `models`, `project-key`, `crabbox`, and routine discovery). The focused rerun above includes the corrected real-CLI audit/team tests, migration test, event unit suite, and changelog gate.

## Context

No tracker was available on the working host. Session transcript omitted because this is a public repository.
