### PR TITLE
fix(state): serializeCentral preserves unknown top-level agents.yaml keys

### DIFF
--- a/apps/cli/.changelog/next/serialize-central-preserve-unknown-keys.md
+++ b/apps/cli/.changelog/next/serialize-central-preserve-unknown-keys.md
@@ -7,7 +7,8 @@
   vanished" data-loss (see the restore in commit `04295e3`). The delete pass now
   consults a `Record<keyof Meta, 'central' | 'device'>` scope map (compile-time
   exhaustive — a new `Meta` field that isn't classified fails the build) and
-  deletes **only keys this version models as central**; a key it doesn't know is
+  deletes **only keys this version knows** (a cleared central key, or a device
+  key that is legacy cruft in the synced file); a key it doesn't know is
   preserved verbatim. Once a machine runs a CLI carrying this fix, it can never
   drop a newer version's key again. Source: `apps/cli/src/lib/state.ts`,
   `apps/cli/src/lib/__tests__/state.test.ts`.

--- a/apps/cli/.changelog/next/serialize-central-preserve-unknown-keys.md
+++ b/apps/cli/.changelog/next/serialize-central-preserve-unknown-keys.md
@@ -1,0 +1,13 @@
+- **`agents.yaml` no longer silently loses top-level keys across a version-skewed
+  fleet.** `serializeCentral` (`lib/state.ts`) rewrote the synced `agents.yaml`
+  with a delete-any-key-not-in-the-in-memory-object pass. An **older CLI version
+  whose `Meta` type predated a key** (`beta:`, `notify.owner`, `feed:`, imported
+  `projects`) would parse the file, never surface that key, delete it on the next
+  write, and sync the deletion to every machine — the recurring "my config
+  vanished" data-loss (see the restore in commit `04295e3`). The delete pass now
+  consults a `Record<keyof Meta, 'central' | 'device'>` scope map (compile-time
+  exhaustive — a new `Meta` field that isn't classified fails the build) and
+  deletes **only keys this version models as central**; a key it doesn't know is
+  preserved verbatim. Once a machine runs a CLI carrying this fix, it can never
+  drop a newer version's key again. Source: `apps/cli/src/lib/state.ts`,
+  `apps/cli/src/lib/__tests__/state.test.ts`.

--- a/apps/cli/src/lib/__tests__/state.test.ts
+++ b/apps/cli/src/lib/__tests__/state.test.ts
@@ -182,6 +182,32 @@ describe('readMeta merges agents.yaml from both repos', () => {
     expect(agents.claude).toBe('2.0.0');
   });
 
+  it('preserves an unknown top-level key on write, but still deletes a cleared known key', () => {
+    // On disk: an unknown key (as if a newer CLI version wrote it) + a known
+    // central key.
+    fs.writeFileSync(
+      path.join(userDir, 'agents.yaml'),
+      'futureUnknownKey: keep-me\nprojectRoot: ~/old\n',
+    );
+
+    // Simulate a CLI whose Meta predates `futureUnknownKey`: its write path never
+    // surfaces that key, and it clears projectRoot. The old delete loop dropped
+    // BOTH (and synced the deletion fleet-wide); the fix must keep the unmodeled
+    // key and only delete the known one.
+    runStateScript(testDir, `
+      const { updateMeta } = await import(${JSON.stringify(modulePath)});
+      updateMeta((meta) => {
+        const { futureUnknownKey, projectRoot, ...rest } = meta;
+        return { ...rest, source: 'set-by-write' };
+      });
+    `);
+
+    const out = fs.readFileSync(path.join(userDir, 'agents.yaml'), 'utf8');
+    expect(out).toContain('futureUnknownKey: keep-me'); // unmodeled key survives
+    expect(out).not.toContain('projectRoot'); // cleared KNOWN central key removed
+    expect(out).toContain('source: set-by-write'); // the write that triggered it landed
+  });
+
   it('does not lose concurrent updateMeta callback writes', async () => {
     // Hold the meta lock through the callback longer than the old count-bounded
     // retry budget (~750ms). The loser of the race must wait this out and still

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -883,6 +883,58 @@ function writeIfChanged(filePath: string, content: string): void {
  * `agents:` / `versions:` are not written (no empty committed files).
  */
 /**
+ * Every `Meta` key, classified as `central` (synced via agents.yaml) or `device`
+ * (routed to the per-machine device file by {@link writeMetaUnlocked}). The
+ * `Record<keyof Meta, …>` type makes this EXHAUSTIVE: adding a field to `Meta`
+ * without classifying it here is a compile error. That guarantee is what lets
+ * `serializeCentral` delete only keys THIS version models — a key a newer CLI
+ * version added (absent from this map) is preserved verbatim instead of being
+ * dropped and synced fleet-wide as data loss. This is the fix for the recurring
+ * agents.yaml key-loss (beta flags, `notify.owner`, and `feed:` all vanished
+ * this way when an older-versioned CLI on the fleet rewrote the file).
+ */
+const META_KEY_SCOPE: Record<keyof Meta, 'central' | 'device'> = {
+  // Device-local — writeMetaUnlocked destructures these out; never in central.
+  agents: 'device',
+  isolatedAgents: 'device',
+  versions: 'device',
+  defaultBrowserProfile: 'device',
+  deviceConfig: 'device',
+  // Central — synced via agents.yaml.
+  run: 'central',
+  model: 'central',
+  watchdog: 'central',
+  lease: 'central',
+  secrets: 'central',
+  budget: 'central',
+  feed: 'central',
+  beta: 'central',
+  registries: 'central',
+  profiles: 'central',
+  source: 'central',
+  projectRoot: 'central',
+  extraRepos: 'central',
+  brands: 'central',
+  actors: 'central',
+  seededPresets: 'central',
+  hooks: 'central',
+  browser: 'central',
+  config: 'central',
+  hosts: 'central',
+  fleet: 'central',
+  share: 'central',
+  notify: 'central',
+  routines: 'central',
+};
+
+/** Central (synced) Meta keys — the only keys serializeCentral may delete. */
+const CENTRAL_META_KEYS: ReadonlySet<string> = new Set(
+  Object.entries(META_KEY_SCOPE)
+    .filter(([, scope]) => scope === 'central')
+    .map(([key]) => key),
+);
+
+/**
  * Serialize the central (synced) meta to `agents.yaml` WITHOUT destroying the
  * hand-written comments in the committed file.
  *
@@ -921,7 +973,11 @@ function serializeCentral(central: Record<string, unknown>): string {
     }
   }
   for (const k of Object.keys(current)) {
-    if (!(k in central)) {
+    // Only delete a key THIS version models as central. A key not in
+    // CENTRAL_META_KEYS (e.g. one a newer CLI version added) is preserved
+    // verbatim — deleting it here would drop it and sync the deletion
+    // fleet-wide (the agents.yaml config data-loss bug).
+    if (!(k in central) && CENTRAL_META_KEYS.has(k)) {
       doc.delete(k);
       changed = true;
     }

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -927,12 +927,15 @@ const META_KEY_SCOPE: Record<keyof Meta, 'central' | 'device'> = {
   routines: 'central',
 };
 
-/** Central (synced) Meta keys — the only keys serializeCentral may delete. */
-const CENTRAL_META_KEYS: ReadonlySet<string> = new Set(
-  Object.entries(META_KEY_SCOPE)
-    .filter(([, scope]) => scope === 'central')
-    .map(([key]) => key),
-);
+/**
+ * Every key this version models (central + device). serializeCentral deletes an
+ * on-disk key only when it is KNOWN and absent from the write's in-memory object:
+ * a central key the caller cleared, OR a device key that is legacy cruft in the
+ * synced file (device keys are routed to the per-machine file, so one lingering
+ * in central is stale and must be migrated out). A key NOT listed here — e.g. one
+ * a newer CLI version added — is preserved verbatim, never dropped + synced away.
+ */
+const KNOWN_META_KEYS: ReadonlySet<string> = new Set(Object.keys(META_KEY_SCOPE));
 
 /**
  * Serialize the central (synced) meta to `agents.yaml` WITHOUT destroying the
@@ -973,11 +976,12 @@ function serializeCentral(central: Record<string, unknown>): string {
     }
   }
   for (const k of Object.keys(current)) {
-    // Only delete a key THIS version models as central. A key not in
-    // CENTRAL_META_KEYS (e.g. one a newer CLI version added) is preserved
-    // verbatim — deleting it here would drop it and sync the deletion
-    // fleet-wide (the agents.yaml config data-loss bug).
-    if (!(k in central) && CENTRAL_META_KEYS.has(k)) {
+    // Only delete a key THIS version knows about. A key not in KNOWN_META_KEYS
+    // (e.g. one a newer CLI version added) is preserved verbatim — deleting it
+    // here would drop it and sync the deletion fleet-wide (the agents.yaml
+    // config data-loss bug). A known device key lingering in the synced file is
+    // still removed — it belongs in the per-machine file, not here.
+    if (!(k in central) && KNOWN_META_KEYS.has(k)) {
       doc.delete(k);
       changed = true;
     }


### PR DESCRIPTION
**What + type:** Bug fix — stop `agents.yaml` from silently losing top-level keys across a version-skewed fleet. Touches the config serializer (`lib/state.ts`) + a test.

## Why (this is a real, recurring data-loss)

`serializeCentral` rewrote the synced `agents.yaml` with a **delete-any-key-not-in-the-in-memory-object** pass (`state.ts`):

```ts
for (const k of Object.keys(current))
  if (!(k in central)) doc.delete(k);
```

An **older CLI version on the fleet whose `Meta` type predates a key** parses `agents.yaml`, never surfaces that key into `central`, deletes it on the next write, and **syncs the deletion to every machine**. This already ate `notify.owner` + the `feed:` block (restored in commit `04295e3`, whose message documents this exact loop), and it's why a user's `beta.enabled: [projects]` and imported Linear projects kept vanishing.

## What changed

- A `Record<keyof Meta, 'central' | 'device'>` **scope map** now drives the delete pass. It's **compile-time exhaustive** — adding a field to `Meta` without classifying it fails `tsc` — so the known-central-key set can never silently drift.
- The delete pass deletes **only keys this version models as central**; a key it doesn't know (e.g. one a newer CLI added) is **preserved verbatim**. Once a machine runs a CLI carrying this fix, it can never drop a newer version's key again.

## Verification

- `tsc --noEmit` clean — the `Record<keyof Meta>` exhaustiveness check passed, confirming the 24 central / 5 device classification matches `Meta` exactly (no missing or stray key).
- New test in `state.test.ts`: writes an unknown key + a known central key, runs a `updateMeta` whose callback drops both (simulating an old CLI that clears `projectRoot` and doesn't model the unknown key), and asserts the **unknown key survives** while the **cleared known key is deleted**. (Runs as a `bun -e` subprocess like the sibling state tests — validated in CI; local runs can't spawn subprocesses here due to an unrelated shell-nvm issue.)

## Context

This is the root cause behind "why did my beta setting / projects keep disappearing" — the companion to the just-merged #2000 (projects out of beta). A harness-agnostic git guard is a separate follow-up.
