### PR TITLE
fix(cli): release home-base hop must be a single agents ssh argv

### DIFF
--- a/apps/cli/.changelog/next/release-agents-ssh-single-arg.md
+++ b/apps/cli/.changelog/next/release-agents-ssh-single-arg.md
@@ -1,0 +1,1 @@
+- **`scripts/release.sh` home-base hop: pass a single remote argv to `agents ssh`.** Multi-arg forms (`bash -lc '…'`) are joined without re-quoting by `wrapRemoteCommand`, so the remote `cd` never ran and publish failed with `fatal: not a git repository`. One shell string keeps the command intact. Source: `apps/cli/scripts/release.sh`.

--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -416,18 +416,22 @@ route_home_base_phase() {
   bold "Routing build + sign + publish to the home base ($RELEASE_HOME_BASE) via agents ssh (from the tagged tree)..."
   # Prefer `agents ssh` over plain `ssh`: it uses the devices registry + brokered
   # credentials and survives host-key / PATH quirks that plain ssh hits on
-  # headless Linux workers (Host key verification failed). Remote shell starts
-  # in $HOME, so cd into the home base's checkout first; then run the SAME
-  # snippet. `bash -lc` puts `agents` (homebrew) + node/bun on PATH for the
-  # headless signing + secrets resolution. The snippet is passed on stdin so no
-  # quoting of its body is needed across the hop; $HOME expands on the REMOTE
-  # side (single-quoted).
+  # headless Linux workers (Host key verification failed).
+  #
+  # CRITICAL: pass the remote command as ONE argv element. `agents ssh` joins
+  # cmd[] with spaces via wrapRemoteCommand (lib/devices/connect.ts) before
+  # handing OpenSSH a single remote string — multi-arg forms like
+  #   agents ssh host -- bash -lc 'cd … && bash -s'
+  # become `bash -lc cd … && bash -s` (quotes stripped), so `cd` runs with no
+  # argument and the snippet's `git rev-parse` fails: "not a git repository".
+  # A single quoted string preserves the remote shell syntax. Snippet on stdin
+  # (`bash -s`); $HOME expands on the REMOTE side.
   if command -v agents >/dev/null 2>&1; then
-    agents ssh "$RELEASE_HOME_BASE" -- bash -lc 'cd "$HOME/src/github.com/muqsitnawaz/agents-cli" && bash -s' <<<"$snippet" \
+    agents ssh "$RELEASE_HOME_BASE" -- 'cd $HOME/src/github.com/muqsitnawaz/agents-cli && bash -s' <<<"$snippet" \
       || return 1
   else
     # Fallback when agents is not on PATH on the trigger box (rare).
-    ssh "$RELEASE_HOME_BASE" 'bash -lc "cd \$HOME/src/github.com/muqsitnawaz/agents-cli && bash -s"' <<<"$snippet" \
+    ssh "$RELEASE_HOME_BASE" 'cd $HOME/src/github.com/muqsitnawaz/agents-cli && bash -s' <<<"$snippet" \
       || return 1
   fi
 }


### PR DESCRIPTION
**fix** — release publish hop

## What

`scripts/release.sh` now passes a **single** remote command string to `agents ssh` for the home-base phase.

## Why

`wrapRemoteCommand` joins `cmd[]` with spaces before OpenSSH gets one remote string. Multi-arg:

```
agents ssh mac-mini -- bash -lc 'cd … && bash -s'
```

becomes `bash -lc cd … && bash -s` (quotes gone). Remote `cd` no-ops; `git rev-parse` fails with `fatal: not a git repository`. That blocked 1.22.10 publish after tag/merge.

## Proof

Manual repro + fix verified on mac-mini:

```
# broken (pwd stays $HOME)
agents ssh mac-mini -- bash -lc 'cd $HOME/src/…/agents-cli && pwd'

# fixed (lands in repo)
agents ssh mac-mini -- 'cd $HOME/src/…/agents-cli && pwd'
```

1.22.10 home-base phase re-run with the single-arg form (in progress separately).

## Docs / CHANGELOG

`.changelog/next/release-agents-ssh-single-arg.md`