### PR TITLE
feat(watchdog): file a feed block when session genuinely needs the human

### DIFF
--- a/apps/cli/.changelog/next/watchdog-files-block.md
+++ b/apps/cli/.changelog/next/watchdog-files-block.md
@@ -1,0 +1,14 @@
+- **Watchdog files a feed block when a session genuinely needs the human.**
+  Three paths now route the "needs human" signal to the owner's feed instead of
+  silently dropping it. (1) Brain says stuck + session is addressable: the watchdog
+  injects a self-file reminder into the agent ("You appear stuck. File it: `agents
+  feed post … --blocked`") so the agent can declare its own block. (2) Session is
+  un-addressable (refuse branch): the watchdog publishes a declared block on the
+  agent's behalf. (3) Hands-off policy — would nudge but policy prevents it: same
+  as (2). All three paths are gated by the existing cooldown ledger (at most once per
+  `WATCHDOG_COOLDOWN_MS` window) and are no-ops when a block for the session already
+  exists, preventing double-paging. Deterministic skips (session completed, no stall)
+  never trigger the block path. Source:
+  `apps/cli/src/lib/watchdog/runner.ts` (`NudgeDecision.needsHuman`,
+  `WatchdogTickOptions.publishBlockFn`, skip/refuse/handsoff branches),
+  `apps/cli/src/lib/watchdog/runner.test.ts`.

--- a/apps/cli/.changelog/next/watchdog-files-block.md
+++ b/apps/cli/.changelog/next/watchdog-files-block.md
@@ -1,14 +1,16 @@
-- **Watchdog files a feed block when a session genuinely needs the human.**
-  Three paths now route the "needs human" signal to the owner's feed instead of
-  silently dropping it. (1) Brain says stuck + session is addressable: the watchdog
+- **Watchdog files a feed block only when a session genuinely needs the human.**
+  When the smart brain concludes a stalled session must be left for the human
+  (`needsHuman`), the watchdog now surfaces that on the owner's feed instead of
+  dropping it in a menubar-only flag. Two cases: if the session is addressable it
   injects a self-file reminder into the agent ("You appear stuck. File it: `agents
-  feed post … --blocked`") so the agent can declare its own block. (2) Session is
-  un-addressable (refuse branch): the watchdog publishes a declared block on the
-  agent's behalf. (3) Hands-off policy — would nudge but policy prevents it: same
-  as (2). All three paths are gated by the existing cooldown ledger (at most once per
-  `WATCHDOG_COOLDOWN_MS` window) and are no-ops when a block for the session already
-  exists, preventing double-paging. Deterministic skips (session completed, no stall)
-  never trigger the block path. Source:
+  feed post … --blocked`") so the agent declares its own block; if it is
+  un-addressable — the case where the watchdog can't even reach the terminal to
+  remind it — the watchdog files a declared block on the agent's behalf so the owner
+  is still paged. Paging fires **only** on this confirmed-needs-human path: a plain
+  nudge-worthy drive-forward poke (un-addressable or under a hands-off policy) is
+  flagged for the tray but never texts the owner. Both paths are gated by the
+  existing cooldown ledger (at most once per `WATCHDOG_COOLDOWN_MS` window) and are
+  no-ops when a block for the session already exists, so no double-paging. Source:
   `apps/cli/src/lib/watchdog/runner.ts` (`NudgeDecision.needsHuman`,
-  `WatchdogTickOptions.publishBlockFn`, skip/refuse/handsoff branches),
+  `WatchdogTickOptions.publishBlockFn`, the needs-human skip branch),
   `apps/cli/src/lib/watchdog/runner.test.ts`.

--- a/apps/cli/src/lib/watchdog/rotate.test.ts
+++ b/apps/cli/src/lib/watchdog/rotate.test.ts
@@ -455,11 +455,16 @@ describe('runWatchdogTick — watchdog.rotate: off', () => {
     });
     const result = await run();
     expect(gateCalled).toBe(false);
-    expect(calls).toHaveLength(0);
     expect(readRotateState(stateDir, 'sess-tmux')).toBeNull();
     // The brain decided skip (synthetic decider) — crucially NOT a rotate outcome.
     expect(result.outcomes[0].decision).toBe('skip');
     expect(result.outcomes[0].reason).toBe('synthetic decider');
+    // The synthetic decider returns nudge:false → needsHuman. The session is
+    // tmux-addressable, so the ONE inject is the self-file reminder (NOT a rotate
+    // keystroke sequence). That the single call is the reminder — not the two-write
+    // rotate exit+relaunch — is the "not a rotate outcome" proof this test cares about.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].text).toMatch(/agents feed post/i);
   });
 });
 

--- a/apps/cli/src/lib/watchdog/runner.test.ts
+++ b/apps/cli/src/lib/watchdog/runner.test.ts
@@ -17,6 +17,7 @@ import type { ActiveSession } from '../session/active.js';
 import type { SessionProvenance, MuxLocation } from '../session/provenance.js';
 import type { InjectTarget } from '../terminal/inject.js';
 import type { WatchdogCandidate } from './watchdog.js';
+import type { OpenBlock } from '../feed.js';
 import {
   runWatchdogTick,
   DEFAULT_THRESHOLDS,
@@ -193,7 +194,8 @@ describe('runWatchdogTick — parked-on-question escalates to the brain', () => 
     expect(o.decision).toBe('skip');
     expect(o.injected).toBeUndefined();
     expect(o.reason).toMatch(/human/i);
-    expect(readLedger()['sess-tmux']).toBeUndefined();
+    // Brain said "needs human" → reminder is injected → cooldown is recorded.
+    expect(readLedger()['sess-tmux']).toBe(NOW);
   });
 
   it('an ambiguous stall (no promise, no completion, not waiting) also escalates', async () => {
@@ -243,7 +245,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
   it('SKIPS and FLAGS an un-addressable stall (ghostty, no tmux) — never injects a guessed target', async () => {
     const result = await run({
       sessions: [ghosttySession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
-      tailFor: () => PROMISE_TAIL,
+      tailFor: () => PROMISE_TAIL, publishBlockFn: () => { /* collector — no real feed dir */ },
     });
     const o = result.outcomes[0];
     expect(o.decision).toBe('skip');
@@ -255,8 +257,8 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     const flags = readFlags();
     expect(flags['sess-ghostty']).toBeDefined();
     expect(flags['sess-ghostty'].host).toBe('ghostty');
-    // Nothing delivered → no cooldown entry.
-    expect(readLedger()['sess-ghostty']).toBeUndefined();
+    // A declared block is filed on the agent's behalf → cooldown is recorded.
+    expect(readLedger()['sess-ghostty']).toBe(NOW);
   });
 
   it('SKIPS within cooldown (rate-limited by a recent nudge)', async () => {
@@ -278,7 +280,7 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     const policyFor = (): WatchdogPolicy => 'handsoff';
     const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
-      tailFor: () => PROMISE_TAIL, policyFor,
+      tailFor: () => PROMISE_TAIL, policyFor, publishBlockFn: () => { /* collector — no real feed dir */ },
     });
     const o = result.outcomes[0];
     expect(o.policy).toBe('handsoff');
@@ -286,7 +288,8 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     expect(o.addressable).toBe(true);
     expect(o.injected).toBe(false);          // ...but never does
     expect(o.reason).toMatch(/handsoff/i);
-    expect(readLedger()['sess-tmux']).toBeUndefined();
+    // A declared block is filed on the agent's behalf → cooldown is recorded.
+    expect(readLedger()['sess-tmux']).toBe(NOW);
     // Flagged for the tray to surface "would-nudge but hands-off".
     const flags = readFlags();
     expect(flags['sess-tmux']).toBeDefined();
@@ -397,5 +400,162 @@ describe('runWatchdogTick — the cooldown ledger is lock-serialized (no lost up
     expect(ledger['sess-a']).toBe(NOW);
     expect(ledger['sess-b']).toBe(NOW);
     fs.rmSync(shared, { recursive: true, force: true });
+  });
+});
+
+describe('runWatchdogTick — brain says needs-human → wires the owner feed', () => {
+  // The brain marks a session "leave for human". The watchdog must surface that
+  // signal on the owner's feed — not drop it silently in a menubar-only flag.
+  // Three paths depending on addressability and policy:
+  //   A. Addressable (tmux): inject a self-file reminder into the agent's terminal.
+  //   B. Un-addressable (ghostty, no tmux): file a declared block on the agent's behalf.
+  //   C. Handsoff policy: same as B — file a block, never inject.
+  // All three paths are gated by the same cooldown ledger as a nudge (at most once
+  // per cooldown window) and are no-ops when a block already exists for the session.
+
+  const needsHumanDecider: SmartDecider = async () => ({ nudge: false, reason: 'credentials required — needs the human' });
+
+  describe('A. addressable session (tmux) — inject a self-file reminder', () => {
+    it('injects the reminder text and records the cooldown', async () => {
+      let capturedText: string | null = null;
+      const injectFn = async (_target: InjectTarget, text: string, _o: { dryRun?: boolean }) => {
+        capturedText = text;
+        return { ok: true as const, backend: 'tmux' as const, writes: 2 };
+      };
+      const result = await run({
+        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => ASK_TAIL, smartDecider: needsHumanDecider, injectFn,
+        openBlockFor: () => null,
+      });
+      const o = result.outcomes[0];
+      expect(o.decision).toBe('skip');
+      expect(o.reason).toMatch(/credentials/i);
+      // The reminder text must mention agents feed post --blocked.
+      expect(capturedText).not.toBeNull();
+      expect(capturedText).toMatch(/agents feed post/i);
+      expect(capturedText).toMatch(/--blocked/i);
+      // Cooldown is recorded so the next tick within cooldownMs is rate-limited.
+      expect(readLedger()['sess-tmux']).toBe(NOW);
+    });
+
+    it('does NOT inject when a block already exists for the session', async () => {
+      let injected = false;
+      const injectFn = async () => { injected = true; return { ok: true as const, backend: 'tmux' as const, writes: 2 }; };
+      const existingBlock = { blockId: 'block-sess-tmux', sessionId: 'sess-tmux', mailboxId: 'sess-tmux' } as OpenBlock;
+      await run({
+        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => ASK_TAIL, smartDecider: needsHumanDecider, injectFn,
+        openBlockFor: () => existingBlock,
+      });
+      expect(injected).toBe(false);
+      expect(readLedger()['sess-tmux']).toBeUndefined();
+    });
+
+    it('does NOT inject a second time within the cooldown window', async () => {
+      // Seed a ledger entry 1 minute ago — inside the default 20m cooldown.
+      fs.writeFileSync(path.join(stateDir, 'nudges.json'), JSON.stringify({ 'sess-tmux': NOW - 60_000 }));
+      let injected = false;
+      const injectFn = async () => { injected = true; return { ok: true as const, backend: 'tmux' as const, writes: 2 }; };
+      await run({
+        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => ASK_TAIL, smartDecider: needsHumanDecider, injectFn,
+        openBlockFor: () => null,
+      });
+      // Reminder is suppressed by the cooldown — no inject, timestamp untouched.
+      expect(injected).toBe(false);
+      expect(readLedger()['sess-tmux']).toBe(NOW - 60_000);
+    });
+  });
+
+  describe('B. un-addressable session (ghostty, no tmux) — file a declared block', () => {
+    it('publishes a declared block and records the cooldown', async () => {
+      const published: OpenBlock[] = [];
+      const publishBlockFn = (b: OpenBlock) => { published.push(b); };
+      const result = await run({
+        sessions: [ghosttySession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => PROMISE_TAIL, publishBlockFn,
+        openBlockFor: () => null,
+      });
+      const o = result.outcomes[0];
+      expect(o.decision).toBe('skip');
+      expect(o.addressable).toBe(false);
+      // One block published with the session's id.
+      expect(published).toHaveLength(1);
+      expect(published[0].sessionId).toBe('sess-ghostty');
+      expect(published[0].costOfDelay).toBe('high');
+      // Cooldown is recorded.
+      expect(readLedger()['sess-ghostty']).toBe(NOW);
+    });
+
+    it('does NOT publish when a block already exists', async () => {
+      const published: OpenBlock[] = [];
+      const existingBlock = { blockId: 'block-sess-ghostty', sessionId: 'sess-ghostty', mailboxId: 'sess-ghostty' } as OpenBlock;
+      await run({
+        sessions: [ghosttySession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => PROMISE_TAIL, publishBlockFn: (b) => published.push(b),
+        openBlockFor: () => existingBlock,
+      });
+      expect(published).toHaveLength(0);
+      expect(readLedger()['sess-ghostty']).toBeUndefined();
+    });
+
+    it('does NOT publish a second time within the cooldown window', async () => {
+      fs.writeFileSync(path.join(stateDir, 'nudges.json'), JSON.stringify({ 'sess-ghostty': NOW - 60_000 }));
+      const published: OpenBlock[] = [];
+      await run({
+        sessions: [ghosttySession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => PROMISE_TAIL, publishBlockFn: (b) => published.push(b),
+        openBlockFor: () => null,
+      });
+      expect(published).toHaveLength(0);
+      expect(readLedger()['sess-ghostty']).toBe(NOW - 60_000);
+    });
+  });
+
+  describe('C. handsoff policy — file a declared block, never inject', () => {
+    it('publishes a block and records the cooldown (handsoff + nudge-worthy + no existing block)', async () => {
+      const published: OpenBlock[] = [];
+      const publishBlockFn = (b: OpenBlock) => { published.push(b); };
+      let injected = false;
+      const injectFn = async () => { injected = true; return { ok: true as const, backend: 'tmux' as const, writes: 2 }; };
+      const result = await run({
+        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => PROMISE_TAIL, policyFor: () => 'handsoff',
+        publishBlockFn, injectFn, openBlockFor: () => null,
+      });
+      const o = result.outcomes[0];
+      expect(o.policy).toBe('handsoff');
+      expect(o.injected).toBe(false);  // handsoff never injects
+      expect(injected).toBe(false);
+      // A declared block is filed instead.
+      expect(published).toHaveLength(1);
+      expect(published[0].sessionId).toBe('sess-tmux');
+      expect(published[0].costOfDelay).toBe('high');
+      expect(readLedger()['sess-tmux']).toBe(NOW);
+    });
+
+    it('does NOT publish when a block already exists (handsoff)', async () => {
+      const published: OpenBlock[] = [];
+      const existingBlock = { blockId: 'block-sess-tmux', sessionId: 'sess-tmux', mailboxId: 'sess-tmux' } as OpenBlock;
+      await run({
+        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => PROMISE_TAIL, policyFor: () => 'handsoff',
+        publishBlockFn: (b) => published.push(b), openBlockFor: () => existingBlock,
+      });
+      expect(published).toHaveLength(0);
+      expect(readLedger()['sess-tmux']).toBeUndefined();
+    });
+
+    it('does NOT publish a second time within the cooldown window (handsoff)', async () => {
+      fs.writeFileSync(path.join(stateDir, 'nudges.json'), JSON.stringify({ 'sess-tmux': NOW - 60_000 }));
+      const published: OpenBlock[] = [];
+      await run({
+        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => PROMISE_TAIL, policyFor: () => 'handsoff',
+        publishBlockFn: (b) => published.push(b), openBlockFor: () => null,
+      });
+      expect(published).toHaveLength(0);
+      expect(readLedger()['sess-tmux']).toBe(NOW - 60_000);
+    });
   });
 });

--- a/apps/cli/src/lib/watchdog/runner.test.ts
+++ b/apps/cli/src/lib/watchdog/runner.test.ts
@@ -242,10 +242,14 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     expect(readLedger()['sess-tmux']).toBeUndefined();
   });
 
-  it('SKIPS and FLAGS an un-addressable stall (ghostty, no tmux) — never injects a guessed target', async () => {
+  it('SKIPS and FLAGS an un-addressable NUDGE-WORTHY stall (ghostty, no tmux) — flag only, NEVER pages the owner', async () => {
+    // PROMISE_TAIL → isLikelyTrulyBlocked → deterministic `nudge` (a drive-forward
+    // poke, NOT needsHuman). An un-addressable poke must NOT page Muqsit's phone —
+    // it flags for the tray only. No block published, no cooldown recorded.
+    const blocks: OpenBlock[] = [];
     const result = await run({
       sessions: [ghosttySession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
-      tailFor: () => PROMISE_TAIL, publishBlockFn: () => { /* collector — no real feed dir */ },
+      tailFor: () => PROMISE_TAIL, publishBlockFn: (b) => blocks.push(b),
     });
     const o = result.outcomes[0];
     expect(o.decision).toBe('skip');
@@ -257,8 +261,9 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     const flags = readFlags();
     expect(flags['sess-ghostty']).toBeDefined();
     expect(flags['sess-ghostty'].host).toBe('ghostty');
-    // A declared block is filed on the agent's behalf → cooldown is recorded.
-    expect(readLedger()['sess-ghostty']).toBe(NOW);
+    // A drive-forward poke is NOT a page: no block, no cooldown write.
+    expect(blocks).toHaveLength(0);
+    expect(readLedger()['sess-ghostty']).toBeUndefined();
   });
 
   it('SKIPS within cooldown (rate-limited by a recent nudge)', async () => {
@@ -276,11 +281,15 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     expect(readLedger()['sess-tmux']).toBe(NOW - 60_000);
   });
 
-  it('handsoff policy: detects + flags a nudge-worthy stall but NEVER injects', async () => {
+  it('handsoff policy: detects + flags a nudge-worthy stall but NEVER injects or pages', async () => {
+    // PROMISE_TAIL → deterministic `nudge` (drive-forward poke, NOT needsHuman).
+    // Hands-off means "don't nudge it forward" — it must NOT page Muqsit for a poke.
+    // Flag only: no block published, no cooldown recorded.
     const policyFor = (): WatchdogPolicy => 'handsoff';
+    const blocks: OpenBlock[] = [];
     const result = await run({
       sessions: [tmuxSession()], nowMs: NOW, nudge: true, injectDryRun: true, stateDir,
-      tailFor: () => PROMISE_TAIL, policyFor, publishBlockFn: () => { /* collector — no real feed dir */ },
+      tailFor: () => PROMISE_TAIL, policyFor, publishBlockFn: (b) => blocks.push(b),
     });
     const o = result.outcomes[0];
     expect(o.policy).toBe('handsoff');
@@ -288,8 +297,9 @@ describe('runWatchdogTick — skips (no nudge)', () => {
     expect(o.addressable).toBe(true);
     expect(o.injected).toBe(false);          // ...but never does
     expect(o.reason).toMatch(/handsoff/i);
-    // A declared block is filed on the agent's behalf → cooldown is recorded.
-    expect(readLedger()['sess-tmux']).toBe(NOW);
+    // A drive-forward poke under hands-off is NOT a page: no block, no cooldown write.
+    expect(blocks).toHaveLength(0);
+    expect(readLedger()['sess-tmux']).toBeUndefined();
     // Flagged for the tray to surface "would-nudge but hands-off".
     const flags = readFlags();
     expect(flags['sess-tmux']).toBeDefined();
@@ -404,14 +414,17 @@ describe('runWatchdogTick — the cooldown ledger is lock-serialized (no lost up
 });
 
 describe('runWatchdogTick — brain says needs-human → wires the owner feed', () => {
-  // The brain marks a session "leave for human". The watchdog must surface that
-  // signal on the owner's feed — not drop it silently in a menubar-only flag.
-  // Three paths depending on addressability and policy:
+  // The brain marks a session "leave for human" (decision.nudge === false →
+  // needsHuman === true). The watchdog must surface that signal on the owner's feed —
+  // not drop it silently in a menubar-only flag. Two paths depending on addressability:
   //   A. Addressable (tmux): inject a self-file reminder into the agent's terminal.
   //   B. Un-addressable (ghostty, no tmux): file a declared block on the agent's behalf.
-  //   C. Handsoff policy: same as B — file a block, never inject.
-  // All three paths are gated by the same cooldown ledger as a nudge (at most once
-  // per cooldown window) and are no-ops when a block already exists for the session.
+  // Both paths are gated by the same cooldown ledger as a nudge (at most once per
+  // cooldown window) and are no-ops when a block already exists for the session.
+  //
+  // Owner-paging fires ONLY on this confirmed-needsHuman path. A nudge-worthy
+  // drive-forward poke (decision.nudge === true) that is un-addressable or under a
+  // hands-off policy is NEVER paged — see section C, which pins that no-page.
 
   const needsHumanDecider: SmartDecider = async () => ({ nudge: false, reason: 'credentials required — needs the human' });
 
@@ -468,18 +481,24 @@ describe('runWatchdogTick — brain says needs-human → wires the owner feed', 
   });
 
   describe('B. un-addressable session (ghostty, no tmux) — file a declared block', () => {
+    // The MOST important case: the session genuinely needs the human AND the watchdog
+    // cannot even reach its terminal to remind it. It must NOT silently vanish — the
+    // only way to reach Muqsit is to file a declared block on the agent's behalf.
+    // A waiting_input ghostty session deterministically escalates to the brain, which
+    // returns nudge:false (needsHuman), and the resolver reports it un-addressable.
+    const unaddressableNeedsHuman = () => ghosttySession({ activity: 'waiting_input', awaitingReason: 'question' });
+
     it('publishes a declared block and records the cooldown', async () => {
       const published: OpenBlock[] = [];
       const publishBlockFn = (b: OpenBlock) => { published.push(b); };
       const result = await run({
-        sessions: [ghosttySession()], nowMs: NOW, nudge: true, stateDir,
-        tailFor: () => PROMISE_TAIL, publishBlockFn,
+        sessions: [unaddressableNeedsHuman()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => ASK_TAIL, smartDecider: needsHumanDecider, publishBlockFn,
         openBlockFor: () => null,
       });
       const o = result.outcomes[0];
       expect(o.decision).toBe('skip');
-      expect(o.addressable).toBe(false);
-      // One block published with the session's id.
+      // One block published with the session's id, phone-urgent.
       expect(published).toHaveLength(1);
       expect(published[0].sessionId).toBe('sess-ghostty');
       expect(published[0].costOfDelay).toBe('high');
@@ -491,8 +510,9 @@ describe('runWatchdogTick — brain says needs-human → wires the owner feed', 
       const published: OpenBlock[] = [];
       const existingBlock = { blockId: 'block-sess-ghostty', sessionId: 'sess-ghostty', mailboxId: 'sess-ghostty' } as OpenBlock;
       await run({
-        sessions: [ghosttySession()], nowMs: NOW, nudge: true, stateDir,
-        tailFor: () => PROMISE_TAIL, publishBlockFn: (b) => published.push(b),
+        sessions: [unaddressableNeedsHuman()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => ASK_TAIL, smartDecider: needsHumanDecider,
+        publishBlockFn: (b) => published.push(b),
         openBlockFor: () => existingBlock,
       });
       expect(published).toHaveLength(0);
@@ -503,8 +523,9 @@ describe('runWatchdogTick — brain says needs-human → wires the owner feed', 
       fs.writeFileSync(path.join(stateDir, 'nudges.json'), JSON.stringify({ 'sess-ghostty': NOW - 60_000 }));
       const published: OpenBlock[] = [];
       await run({
-        sessions: [ghosttySession()], nowMs: NOW, nudge: true, stateDir,
-        tailFor: () => PROMISE_TAIL, publishBlockFn: (b) => published.push(b),
+        sessions: [unaddressableNeedsHuman()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => ASK_TAIL, smartDecider: needsHumanDecider,
+        publishBlockFn: (b) => published.push(b),
         openBlockFor: () => null,
       });
       expect(published).toHaveLength(0);
@@ -512,50 +533,46 @@ describe('runWatchdogTick — brain says needs-human → wires the owner feed', 
     });
   });
 
-  describe('C. handsoff policy — file a declared block, never inject', () => {
-    it('publishes a block and records the cooldown (handsoff + nudge-worthy + no existing block)', async () => {
+  describe('C. a nudge-worthy (NOT needsHuman) session is NEVER paged', () => {
+    // The over-paging guard: the refuse and handsoff branches are reached only for a
+    // drive-forward poke (decision.nudge === true), which is NEVER needsHuman. Those
+    // sessions "just need a poke" — they must not text Muqsit's phone. This pins the
+    // fix: neither an un-addressable poke nor a hands-off poke publishes a block.
+
+    it('un-addressable NUDGE-worthy poke → flag only, no block, no cooldown write', async () => {
+      // PROMISE_TAIL → isLikelyTrulyBlocked → deterministic nudge (drive-forward).
       const published: OpenBlock[] = [];
-      const publishBlockFn = (b: OpenBlock) => { published.push(b); };
+      const result = await run({
+        sessions: [ghosttySession()], nowMs: NOW, nudge: true, stateDir,
+        tailFor: () => PROMISE_TAIL, publishBlockFn: (b) => published.push(b),
+        openBlockFor: () => null,
+      });
+      const o = result.outcomes[0];
+      expect(o.decision).toBe('skip');
+      expect(o.addressable).toBe(false);
+      // Flagged for the tray, but the owner is NOT paged.
+      expect(readFlags()['sess-ghostty']).toBeDefined();
+      expect(published).toHaveLength(0);
+      expect(readLedger()['sess-ghostty']).toBeUndefined();
+    });
+
+    it('handsoff NUDGE-worthy poke → flag only, never injects, no block, no cooldown write', async () => {
+      const published: OpenBlock[] = [];
       let injected = false;
       const injectFn = async () => { injected = true; return { ok: true as const, backend: 'tmux' as const, writes: 2 }; };
       const result = await run({
         sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
         tailFor: () => PROMISE_TAIL, policyFor: () => 'handsoff',
-        publishBlockFn, injectFn, openBlockFor: () => null,
+        publishBlockFn: (b) => published.push(b), injectFn, openBlockFor: () => null,
       });
       const o = result.outcomes[0];
       expect(o.policy).toBe('handsoff');
       expect(o.injected).toBe(false);  // handsoff never injects
       expect(injected).toBe(false);
-      // A declared block is filed instead.
-      expect(published).toHaveLength(1);
-      expect(published[0].sessionId).toBe('sess-tmux');
-      expect(published[0].costOfDelay).toBe('high');
-      expect(readLedger()['sess-tmux']).toBe(NOW);
-    });
-
-    it('does NOT publish when a block already exists (handsoff)', async () => {
-      const published: OpenBlock[] = [];
-      const existingBlock = { blockId: 'block-sess-tmux', sessionId: 'sess-tmux', mailboxId: 'sess-tmux' } as OpenBlock;
-      await run({
-        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
-        tailFor: () => PROMISE_TAIL, policyFor: () => 'handsoff',
-        publishBlockFn: (b) => published.push(b), openBlockFor: () => existingBlock,
-      });
+      // Flagged for the tray, but the owner is NOT paged for a poke.
+      expect(readFlags()['sess-tmux']).toBeDefined();
       expect(published).toHaveLength(0);
       expect(readLedger()['sess-tmux']).toBeUndefined();
-    });
-
-    it('does NOT publish a second time within the cooldown window (handsoff)', async () => {
-      fs.writeFileSync(path.join(stateDir, 'nudges.json'), JSON.stringify({ 'sess-tmux': NOW - 60_000 }));
-      const published: OpenBlock[] = [];
-      await run({
-        sessions: [tmuxSession()], nowMs: NOW, nudge: true, stateDir,
-        tailFor: () => PROMISE_TAIL, policyFor: () => 'handsoff',
-        publishBlockFn: (b) => published.push(b), openBlockFor: () => null,
-      });
-      expect(published).toHaveLength(0);
-      expect(readLedger()['sess-tmux']).toBe(NOW - 60_000);
     });
   });
 });

--- a/apps/cli/src/lib/watchdog/runner.ts
+++ b/apps/cli/src/lib/watchdog/runner.ts
@@ -992,7 +992,7 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
             // Determine addressability without planning the full nudge (no text needed).
             const resolution = resolveInjectTargetForSession(session, { allowGhosttyFocus: opts.allowGhosttyFocus });
             if (resolution.addressable) {
-              // Inject a reminder asking the agent to self-file a feed block.
+              // Addressable → inject a reminder asking the agent to self-file a feed block.
               const reminderText =
                 'You appear stuck. If you genuinely need Muqsit, file it: ' +
                 'agents feed post "<one-line ask>" --blocked --default "<safe default>". ' +
@@ -1003,6 +1003,24 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
                 // Swallow inject errors — reminder is best-effort; flag set below.
               }
               ledgerUpdates[session.sessionId] = nowMs;
+            } else {
+              // Un-addressable → we can't reach the terminal to remind it, so the ONLY
+              // way to reach Muqsit is to file a declared block on the agent's behalf.
+              // This is the most important case: the session genuinely needs the human
+              // AND the watchdog can't even nudge it. Never let it silently vanish.
+              const mailboxId = mailboxIdForActiveSession(session) ?? session.sessionId;
+              const machineHost = session.provenance?.host ?? 'unknown';
+              const runtime = session.kind;
+              try {
+                const declaredBlock = buildDeclaredBlock(
+                  { sessionId: session.sessionId, mailboxId, host: machineHost, runtime, cwd: session.cwd },
+                  { text: `Session genuinely needs Muqsit and is un-addressable — ${decision.reason}. Needs attention.` },
+                );
+                publishBlockFn(declaredBlock);
+                ledgerUpdates[session.sessionId] = nowMs;
+              } catch {
+                // publishBlock failure is non-fatal — best-effort owner page.
+              }
             }
           }
         }
@@ -1021,31 +1039,13 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
 
     if (plan.via === 'refuse') {
       // No addressable rail and not headless-resumable — flag, NEVER guess.
-      // File a declared block on the agent's behalf so the owner sees it on the feed.
-      // Gated by the same cooldown as a nudge — at most once per cooldown window.
+      // This branch is reached ONLY for a nudge-worthy (decision.nudge === true)
+      // drive-forward poke, which is NEVER needsHuman (needsHuman is set only when
+      // decision.nudge === false). So we do NOT page the owner here — a short "just
+      // needs a poke" stall must not text Muqsit's phone. Owner-paging for an
+      // un-addressable session happens only on the confirmed needsHuman skip path
+      // above. Here we only flag it for the tray.
       flags[session.sessionId] = { reason: plan.reason, host: session.host, atMs: nowMs };
-      if (opts.nudge && session.sessionId) {
-        const lastNudgeMs = ledger[session.sessionId] ?? 0;
-        const withinCooldown = nowMs - lastNudgeMs < thresholds.cooldownMs;
-        if (!withinCooldown) {
-          const existingBlock = openBlockFor(session);
-          if (existingBlock === null) {
-            const mailboxId = mailboxIdForActiveSession(session) ?? session.sessionId;
-            const machineHost = session.provenance?.host ?? 'unknown';
-            const runtime = session.kind;
-            try {
-              const declaredBlock = buildDeclaredBlock(
-                { sessionId: session.sessionId, mailboxId, host: machineHost, runtime, cwd: session.cwd },
-                { text: `Session stalled and un-addressable — ${plan.reason}. Needs attention.` },
-              );
-              publishBlockFn(declaredBlock);
-              ledgerUpdates[session.sessionId] = nowMs;
-            } catch {
-              // publishBlock failure is non-fatal — the flag is already set for the tray.
-            }
-          }
-        }
-      }
       outcomes.push({
         ...base, decision: 'skip', addressable: false,
         reason: `nudge-worthy but un-addressable — ${plan.reason}`,
@@ -1055,36 +1055,19 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
     }
 
     // handsoff = detect + flag, but never deliver via inject/mailbox.
-    // File a declared block on the agent's behalf so the owner sees it on the feed.
-    // Gated by the same cooldown as a nudge — at most once per cooldown window.
+    // This branch is reached ONLY for a nudge-worthy (decision.nudge === true)
+    // drive-forward poke, which is NEVER needsHuman. A hands-off policy means "don't
+    // nudge it forward" — it must NOT translate into paging Muqsit for a poke. So we
+    // only flag it for the tray, no owner page. A genuinely needs-human session (even
+    // under hands-off) is paged by the confirmed-needsHuman skip path above, which
+    // does not consult policy — hands-off silences the forward nudge, not the
+    // "it's actually stuck" signal.
     if (policy === 'handsoff') {
       flags[session.sessionId] = {
         reason: `handsoff: would nudge via ${viaLabel(plan)} but policy is hands-off`,
         host: session.host,
         atMs: nowMs,
       };
-      if (opts.nudge && session.sessionId) {
-        const lastNudgeMs = ledger[session.sessionId] ?? 0;
-        const withinCooldown = nowMs - lastNudgeMs < thresholds.cooldownMs;
-        if (!withinCooldown) {
-          const existingBlock = openBlockFor(session);
-          if (existingBlock === null) {
-            const mailboxId = mailboxIdForActiveSession(session) ?? session.sessionId;
-            const machineHost = session.provenance?.host ?? 'unknown';
-            const runtime = session.kind;
-            try {
-              const declaredBlock = buildDeclaredBlock(
-                { sessionId: session.sessionId, mailboxId, host: machineHost, runtime, cwd: session.cwd },
-                { text: `Session stalled (hands-off policy) — would nudge via ${viaLabel(plan)}. Needs attention.` },
-              );
-              publishBlockFn(declaredBlock);
-              ledgerUpdates[session.sessionId] = nowMs;
-            } catch {
-              // publishBlock failure is non-fatal — the flag is already set for the tray.
-            }
-          }
-        }
-      }
       outcomes.push({
         ...base, decision: 'nudge', addressable, rail, via: plan.via, injected: false,
         reason: `handsoff: flagged, not delivered (would nudge via ${viaLabel(plan)})`,

--- a/apps/cli/src/lib/watchdog/runner.ts
+++ b/apps/cli/src/lib/watchdog/runner.ts
@@ -68,7 +68,7 @@ import { withFileLock, atomicWriteFileSync, ensureLockTarget } from '../fs-atomi
 import { resolveAnswerRoute, isOpenQuestionBlock } from '../answer-router.js';
 import { enqueue, mailboxDir } from '../mailbox.js';
 import { mailboxIdForActiveSession } from '../mailbox-target.js';
-import { readBlock, blockIdForSession, type OpenBlock } from '../feed.js';
+import { readBlock, blockIdForSession, buildDeclaredBlock, publishBlock, type OpenBlock } from '../feed.js';
 import { summarizeWatchdogTail } from './watchdogTail.js';
 import { appendWatchdogEvents, type WatchdogEvent } from './log.js';
 import {
@@ -160,6 +160,11 @@ export interface WatchdogTickOptions {
   openBlockFor?: (s: ActiveSession) => OpenBlock | null;
   /** Inject primitive. Default injectIntoTerminal — tests capture the resolved target. */
   injectFn?: (target: InjectTarget, text: string, opts: { dryRun?: boolean; enter?: boolean }) => Promise<InjectResult>;
+  /**
+   * Publish a declared block on the owner's feed. Default publishBlock() — tests
+   * inject a collector so no real feed dir is touched.
+   */
+  publishBlockFn?: (block: OpenBlock) => void;
   /** Override the canonical watchdog.log path (tests point at a tmp file). */
   logPath?: string;
 
@@ -321,6 +326,14 @@ export interface NudgeDecision {
   nudge: boolean;
   reason: string;
   text?: string;
+  /**
+   * Set to `true` when the brain (smart decider) explicitly concluded the session
+   * needs the human — as opposed to a cheap deterministic skip (session is done,
+   * not stalled, etc.). Only `true` when the brain escalation path ran and returned
+   * `nudge: false`. The watchdog uses this to gate the self-file reminder: a
+   * "session is done" skip does NOT trigger a reminder.
+   */
+  needsHuman?: boolean;
 }
 
 /**
@@ -619,6 +632,7 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
   const smartDecider = opts.smartDecider ?? makeDefaultSmartDecider(opts.smartAgent ?? 'claude');
   const openBlockFor = opts.openBlockFor ?? defaultOpenBlockFor;
   const injectFn = opts.injectFn ?? injectIntoTerminal;
+  const publishBlockFn = opts.publishBlockFn ?? publishBlock;
 
   // Rotate seams (watchdog/rotate.ts). The config is read fresh per tick
   // (readMeta is mtime-cached), so a `watchdog.rotate` flip is honored on the
@@ -930,12 +944,19 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
     // forces every stalled candidate through the brain.
     let decision: NudgeDecision;
     if (opts.smart) {
-      decision = await smartDecider(session, candidate);
+      const d = await smartDecider(session, candidate);
+      // Mark needsHuman when the brain explicitly concluded "leave for human".
+      decision = d.nudge ? d : { ...d, needsHuman: true };
     } else {
       const det = deterministicDecision(session, candidate);
-      decision = det.kind === 'escalate'
-        ? await smartDecider(session, candidate)
-        : { nudge: det.kind === 'nudge', reason: det.reason };
+      if (det.kind === 'escalate') {
+        const d = await smartDecider(session, candidate);
+        // Mark needsHuman when the brain escalation path concluded "leave for human".
+        decision = d.nudge ? d : { ...d, needsHuman: true };
+      } else {
+        // Cheap deterministic path — completion or clear stall. Never "needs human".
+        decision = { nudge: det.kind === 'nudge', reason: det.reason };
+      }
     }
     const chosenText = decision.text ?? nudgeText;
 
@@ -956,6 +977,36 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
     });
 
     if (!decision.nudge) {
+      // Brain explicitly concluded "leave for human" (needsHuman === true). Inject a
+      // self-file reminder into the agent's terminal so it knows to post a feed block.
+      // Cheap deterministic skips (session done, no stall) are NOT reminder-worthy —
+      // guard on needsHuman so a finished session is never poked.
+      // Gated by the same cooldown as a nudge to prevent re-firing every 2-minute tick.
+      if (decision.needsHuman) {
+        const lastNudgeMs = ledger[session.sessionId ?? ''] ?? 0;
+        const cooldownMs = thresholds.cooldownMs;
+        const withinCooldown = nowMs - lastNudgeMs < cooldownMs;
+        if (opts.nudge && session.sessionId && !withinCooldown) {
+          const existingBlock = openBlockFor(session);
+          if (existingBlock === null) {
+            // Determine addressability without planning the full nudge (no text needed).
+            const resolution = resolveInjectTargetForSession(session, { allowGhosttyFocus: opts.allowGhosttyFocus });
+            if (resolution.addressable) {
+              // Inject a reminder asking the agent to self-file a feed block.
+              const reminderText =
+                'You appear stuck. If you genuinely need Muqsit, file it: ' +
+                'agents feed post "<one-line ask>" --blocked --default "<safe default>". ' +
+                'Otherwise keep going.';
+              try {
+                await injectFn(resolution.target, reminderText, { dryRun: opts.injectDryRun });
+              } catch {
+                // Swallow inject errors — reminder is best-effort; flag set below.
+              }
+              ledgerUpdates[session.sessionId] = nowMs;
+            }
+          }
+        }
+      }
       outcomes.push({ ...base, decision: 'skip', reason: decision.reason });
       continue;
     }
@@ -970,7 +1021,31 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
 
     if (plan.via === 'refuse') {
       // No addressable rail and not headless-resumable — flag, NEVER guess.
+      // File a declared block on the agent's behalf so the owner sees it on the feed.
+      // Gated by the same cooldown as a nudge — at most once per cooldown window.
       flags[session.sessionId] = { reason: plan.reason, host: session.host, atMs: nowMs };
+      if (opts.nudge && session.sessionId) {
+        const lastNudgeMs = ledger[session.sessionId] ?? 0;
+        const withinCooldown = nowMs - lastNudgeMs < thresholds.cooldownMs;
+        if (!withinCooldown) {
+          const existingBlock = openBlockFor(session);
+          if (existingBlock === null) {
+            const mailboxId = mailboxIdForActiveSession(session) ?? session.sessionId;
+            const machineHost = session.provenance?.host ?? 'unknown';
+            const runtime = session.kind;
+            try {
+              const declaredBlock = buildDeclaredBlock(
+                { sessionId: session.sessionId, mailboxId, host: machineHost, runtime, cwd: session.cwd },
+                { text: `Session stalled and un-addressable — ${plan.reason}. Needs attention.` },
+              );
+              publishBlockFn(declaredBlock);
+              ledgerUpdates[session.sessionId] = nowMs;
+            } catch {
+              // publishBlock failure is non-fatal — the flag is already set for the tray.
+            }
+          }
+        }
+      }
       outcomes.push({
         ...base, decision: 'skip', addressable: false,
         reason: `nudge-worthy but un-addressable — ${plan.reason}`,
@@ -979,13 +1054,37 @@ export async function runWatchdogTick(opts: WatchdogTickOptions = {}): Promise<W
       continue;
     }
 
-    // handsoff = detect + flag, but never deliver.
+    // handsoff = detect + flag, but never deliver via inject/mailbox.
+    // File a declared block on the agent's behalf so the owner sees it on the feed.
+    // Gated by the same cooldown as a nudge — at most once per cooldown window.
     if (policy === 'handsoff') {
       flags[session.sessionId] = {
         reason: `handsoff: would nudge via ${viaLabel(plan)} but policy is hands-off`,
         host: session.host,
         atMs: nowMs,
       };
+      if (opts.nudge && session.sessionId) {
+        const lastNudgeMs = ledger[session.sessionId] ?? 0;
+        const withinCooldown = nowMs - lastNudgeMs < thresholds.cooldownMs;
+        if (!withinCooldown) {
+          const existingBlock = openBlockFor(session);
+          if (existingBlock === null) {
+            const mailboxId = mailboxIdForActiveSession(session) ?? session.sessionId;
+            const machineHost = session.provenance?.host ?? 'unknown';
+            const runtime = session.kind;
+            try {
+              const declaredBlock = buildDeclaredBlock(
+                { sessionId: session.sessionId, mailboxId, host: machineHost, runtime, cwd: session.cwd },
+                { text: `Session stalled (hands-off policy) — would nudge via ${viaLabel(plan)}. Needs attention.` },
+              );
+              publishBlockFn(declaredBlock);
+              ledgerUpdates[session.sessionId] = nowMs;
+            } catch {
+              // publishBlock failure is non-fatal — the flag is already set for the tray.
+            }
+          }
+        }
+      }
       outcomes.push({
         ...base, decision: 'nudge', addressable, rail, via: plan.via, injected: false,
         reason: `handsoff: flagged, not delivered (would nudge via ${viaLabel(plan)})`,


### PR DESCRIPTION
feat(watchdog): file a feed block when a session genuinely needs the human

## What changed

The watchdog detected "needs human" stalls but silently dropped the signal. This
wires the confirmed-needs-human signal to the owner's feed (which forwards to
iMessage) — and **only** that signal, so a plain drive-forward poke never pages the
owner's phone.

## Who pages the owner (a filed feed block)

| Decision | addressable | un-addressable |
|---|---|---|
| **needsHuman** (brain: leave for human) | inject self-file **reminder**, no page | **file a block → PAGE** |
| nudge-worthy poke (drive-forward) | inject nudge, no page | flag only, **no page** |
| hands-off + nudge-worthy poke | flag only, **no page** | flag only, **no page** |
| deterministic skip (done / no stall) | nothing | nothing |

`needsHuman` is set **only** when the smart brain runs and returns `nudge: false`.
A deterministic `nudge` (promise-without-toolcall, ≥15-min force-review) is a
drive-forward poke, never `needsHuman` — so it is never paged.

## The two bugs review caught (both fixed in this branch)

1. **Escalation-inversion — the most important case was dropped.** In the
   needsHuman skip branch the self-file reminder ran only when
   `resolution.addressable === true`. A genuinely-needs-human session that was
   **un-addressable** got nothing: no reminder, no block, no page. Fixed with an
   `else` that files a declared block on the agent's behalf — so the owner is
   reached whether or not the terminal is addressable.

2. **Over-paging.** The `refuse` and `handsoff` branches published a block for
   **any** nudge-worthy session. Those branches are reached only for a drive-forward
   poke (`decision.nudge === true`), which is never `needsHuman`. Reverted both to
   flag-only. Owner-paging now fires only on the confirmed-needsHuman path.

## Double-fire safety (unchanged)

1. **Per-session block file** — `block-<sessionId>.json` is named by session id;
   `openBlockFor(session) != null` short-circuits the publish/inject, so a block that
   already exists is never duplicated across ticks or machines.
2. **Cooldown ledger** — `ledgerUpdates[sessionId] = nowMs` gates every action to at
   most once per `WATCHDOG_COOLDOWN_MS` window.

Never a raw `agents notify` — owner delivery is always via the per-session feed block.

## New seam: `opts.publishBlockFn`

Injectable `(block: OpenBlock) => void`, default `publishBlock`. Every test path uses
a collector instead of the real feed directory.

## Test run

```
 Test Files  8 passed (8)
      Tests  132 passed (132)
```

Full `src/lib/watchdog/` suite green (runner + rotate + the rest). `bunx tsc --noEmit`
clean.

No user-visible UI surface — internal watchdog behaviour only.
