### PR TITLE
feat(cli): add daily event retention and audit alias

### DIFF
--- a/apps/cli/.changelog/next/daily-event-retention.md
+++ b/apps/cli/.changelog/next/daily-event-retention.md
@@ -1,0 +1,1 @@
+- Store operational events in daily history directories, retain 7 days and at most 50 MiB automatically, and make `agents logs audit` use the `agents events --audit` reader.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -385,7 +385,7 @@ Fields:
 | `spawnedTeam` | The team this session CREATED, read off its `agents teams create/add` command at scan time | `null` for the ~everything that never ran one; the inverse of `isTeamOrigin` |
 | `teamOrigin` | For a teammate: its `{team, handle, mode, parentSessionId}`, read from the teammate's `meta.json` | `null` for a non-teammate; `team`/`parentSessionId` absent on records predating their capture, or once the 7-day teams cleanup removes the dir |
 | `plan` | Last `ExitPlanMode` plan markdown (Claude sessions only) | `null` when the session never entered plan-review |
-| `usedBrowser` / `usedComputer` | A sessionId-scoped read of `~/.agents/.history/events/events.jsonl` for `browser.navigate`/`browser.screenshot` / `computer.action` (never a transcript re-scan) | `undefined` on a legacy row this scanner hasn't computed the field for yet — distinct from a real, computed `false` |
+| `usedBrowser` / `usedComputer` | A sessionId-scoped read of `~/.agents/.history/events/YYYY-MM-DD/` for `browser.navigate`/`browser.screenshot` / `computer.action` (never a transcript re-scan) | `undefined` on a legacy row this scanner hasn't computed the field for yet — distinct from a real, computed `false` |
 
 ### Two time fields per row
 

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -11,7 +11,7 @@ whose *consumer* and *axis* match your question, not whichever you remember firs
 
 | Command | Role (one line) | Source | Consumer |
 |---|---|---|---|
-| **`events`** | **Raw unified event stream = the ops trail.** Everything: secrets access, command invocations, version/skill/mcp/team ops, browser events, plus agent milestones. `--follow` to tail, `--audit` for ops-only. | `events.jsonl` + per-session `activity/*.jsonl`, merged by `readUnifiedEvents` | Audit, debugging, monitoring (human + machine) |
+| **`events`** | **Raw unified event stream = the ops trail.** Everything: secrets access, command invocations, version/skill/mcp/team ops, browser events, plus agent milestones. `--follow` to tail, `--audit` for ops-only. `agents logs audit` is a compatibility alias backed by this same reader. | dated `events/*.jsonl` + per-session `activity/*.jsonl`, merged by `readUnifiedEvents` | Audit, debugging, monitoring (human + machine) |
 | **`audit`** | **Tamper-evident run-dispatch chain** (hash-chained exec log). Not the same as `events`. | `~/.agents` audit log | Governance / CI verify |
 | **`perf`** | **Latency rollups.** p50/p99 for hooks, CLI commands, and `agent.run` timings. Indexed SQLite — not a full scan of the audit log. | `~/.agents/.cache/perf/perf.db` (disposable) | Humans optimizing boot/run cost + `--json` |
 | **`trends`** | **Usage analytics.** Harness/model mix, tools per session, token ratios, hottest secrets/browser profiles — baked recipes over sessions + a durable resource warehouse. Distinct from quota (`agents usage`) and latency (`agents perf`). | `sessions.db` + `~/.agents/.history/analytics/usage.db` | Humans + `--json` |
@@ -54,7 +54,8 @@ agents notify --text "same as send --to owner"
 agents feed post --title "CHANGELOG pushed" "Watching CI and mac-mini E2E"
 ```
 
-The write-stores: `~/.agents/.history/events/events.jsonl` (operational audit), per-session
+The write-stores: `~/.agents/.history/events/YYYY-MM-DD/events.jsonl`
+(operational audit), per-session
 `~/.agents/.history/activity/<id>.jsonl` (agent milestones), and the disposable
 perf warehouse `~/.agents/.cache/perf/perf.db` (latency samples). Audit + activity
 are merged at read time by `event-stream.ts::readUnifiedEvents`. Perf is a
@@ -168,9 +169,16 @@ Separate from the fleet-state sources below (which answer "what's running *now*"
 the **audit event log** answers "who did what, and from where". Every
 `agents <module> <command>` invocation is recorded — team create/disband, agent
 run, secrets access, version installs — as a structured JSONL line at
-`~/.agents/.history/events/events.jsonl` (directory `0700`, file `0600`). At 10 MB the active
-file rotates losslessly to `events.1.jsonl.gz`; older archives shift to
-`events.2.jsonl.gz`, `events.3.jsonl.gz`, and so on.
+`~/.agents/.history/events/YYYY-MM-DD/events.jsonl` (directories `0700`, files
+`0600`). Each local calendar day has its own directory. At 10 MiB that day's
+active file rotates losslessly to `events.1.jsonl.gz`; older segments shift to
+`events.2.jsonl.gz`, `events.3.jsonl.gz`, and so on. Automatic cleanup keeps at
+most seven days and 50 MiB per machine. `agents logs rotate --days <n>
+--max-mb <n>` applies both limits immediately.
+
+`agents events` is the canonical reader. `agents logs audit` registers the same
+options and invokes the same handler with audit-only mode forced, preserving the
+older spelling without a second query, renderer, or follow implementation.
 
 The recording is a single choke point — a commander `preAction`/`postAction`
 hook on the root program ([`src/index.ts`](../src/index.ts)) emits `command.start`
@@ -358,11 +366,12 @@ long-term records.
 
 ### Audit Viewer (`agents logs audit`)
 
-While `agents events` is a convenience alias, the full audit surface lives under
-`agents logs`:
+`agents events --audit` is the canonical operational-audit reader. `agents logs
+audit` is a compatibility alias wired to that same option registration and
+handler, so the two spellings cannot drift:
 
 ```bash
-agents logs audit                          # recent activity (last 100)
+agents logs audit                          # recent operational events (newest 50)
 agents logs audit --level audit            # security-relevant only
 agents logs audit --module teams           # team lifecycle events
 agents logs audit --command "secrets get"  # by command path prefix
@@ -395,15 +404,17 @@ agents logs stats --json           # machine-readable
 
 #### Log Rotation
 
-Files exceeding 10 MB rotate to numbered gzip archives without overwriting an
-earlier archive. Archives older than 7 days can be pruned explicitly with:
+Each local day writes beneath `~/.agents/.history/events/YYYY-MM-DD/`. Files
+exceeding 10 MiB rotate to numbered gzip segments without overwriting an earlier
+segment. Cleanup runs automatically, retaining at most seven days and 50 MiB per
+machine. Apply different limits immediately with:
 
 ```bash
-agents logs rotate                 # prune archives older than 7 days
-agents logs rotate --days 7        # prune files older than 7 days
+agents logs rotate                           # seven days and 50 MiB
+agents logs rotate --days 3 --max-mb 25      # explicit age and size limits
 ```
 
-The `query()` API reads the active JSONL and every numbered gzip archive
+The `query()` API reads every dated active JSONL file and numbered gzip segment
 transparently.
 
 External tools (dashboards, voice assistants, CI runners, monitoring) can read

--- a/apps/cli/docs/architecture.md
+++ b/apps/cli/docs/architecture.md
@@ -190,12 +190,13 @@ long it must live and how it's read back:
 | Transcripts | `~/.claude/projects/…`, `~/.codex/sessions/…`, … | agent-native files (read-only) | the raw truth; parsed on demand |
 | CLI pid-registry | `~/.agents/.cache/terminals/by-pid/<pid>.json` | ephemeral file | `ag run`/shim write; CLI reads (§3) |
 | Live-session state | `~/.agents/.cache/terminals/sessions/<pid>.json` | ephemeral file | hook writes; extension reads (§3) |
-| Audit log | `~/.agents/.history/events/events.jsonl` | locked shared log | `emit()` in [`src/lib/events.ts`](../src/lib/events.ts); `agents events` reads |
+| Audit log | `~/.agents/.history/events/YYYY-MM-DD/events.jsonl` | dated, locked shared log | `emit()` in [`src/lib/events.ts`](../src/lib/events.ts); `agents events` reads; `agents logs audit` aliases it |
 | Teams sentinels | `…/agents/<uuid>/exit_code`, `hosts/<id>.log` + `.exit` | ephemeral files | teammate writes exit code; supervisor reads (§6) |
 | Mailbox spool | `~/.agents/.history/mailbox/<id>/…` | append-only dirs | `agents message` / feed; `agents mailboxes` reads |
 
-There is **one** audit log (`events.jsonl`), shared and file-locked because many
-processes append to it. It is the single choke point for "who did what" — see
+There is **one** audit event implementation, split into local-date files and
+file-locked because many processes append concurrently. It is the single choke
+point for "who did what" — see
 [06-observability.md](06-observability.md).
 
 ---

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -130,7 +130,7 @@ Bundle metadata (names, descriptions, variable names + references, and any non-s
 Every secret lifecycle/access event — create, import, export, view, access (a
 value read for injection), unlock — funnels through one chokepoint,
 `emitSecretAudit` (`src/lib/secrets/audit.ts`). That single call writes to **both**
-sinks: the append-only `~/.agents/.history/events/events.jsonl` audit log (surfaced by
+sinks: the append-only `~/.agents/.history/events/YYYY-MM-DD/events.jsonl` audit log (surfaced by
 `agents events --module secrets`) and a **derived per-bundle read-model** at
 `~/.agents/secrets/secrets.db` (`src/lib/secrets/usage-db.ts`). There is no second
 write path — the read-model is an index fed off the real access flow, the way

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -917,7 +917,7 @@ access control (that is 1Password/Vault; this tool is device-local first).
 - **SEC-26 (MUST).** `emitSecretAudit` (`lib/secrets/audit.ts`) MUST be the single
   write path for every secret lifecycle/access event — create, import, export,
   view, access (read), unlock. One call writes to BOTH the append-only
-  `~/.agents/.history/events/events.jsonl` audit log (via `emit()`) AND the derived per-bundle
+  `~/.agents/.history/events/YYYY-MM-DD/events.jsonl` audit log (via `emit()`) AND the derived per-bundle
   usage read-model DB (`~/.agents/secrets/secrets.db`, `lib/secrets/usage-db.ts`);
   there MUST be no standalone write path parallel to it. **Given** an access is
   recorded **When** it flows through `emitSecretAudit` **Then** it appears exactly

--- a/apps/cli/src/commands/events.ts
+++ b/apps/cli/src/commands/events.ts
@@ -1,7 +1,7 @@
 /**
  * `agents events` — read the unified event stream.
  *
- * One stream over BOTH operational events (`~/.agents/.history/events/events.jsonl`: every
+ * One stream over BOTH operational events (`~/.agents/.history/events/YYYY-MM-DD/`: every
  * `agents <module> <cmd>` invocation plus typed events like secrets access,
  * version installs) AND agent-semantic events (the per-session activity logs:
  * plans, PRs, worktrees, sub-agents, artifacts). Each is stamped with who ran
@@ -17,7 +17,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
-import { getLogsPath, type EventRecord, type EventType } from '../lib/events.js';
+import { getLogsPath, type EventRecord, type EventType, type EventLevel } from '../lib/events.js';
 import { readUnifiedEvents } from '../lib/event-stream.js';
 import { ingestBatch } from '../lib/events-ingest.js';
 import { setHelpSections } from '../lib/help.js';
@@ -50,11 +50,13 @@ export function capRecords<T>(fetched: T[], limit: number | undefined): { record
   return { records: fetched.slice(0, limit), truncated: true };
 }
 
-interface EventsOptions {
+export interface EventsOptions {
   module?: string;
   command?: string;
   event?: string[];
   agent?: string;
+  caller?: string;
+  level?: string;
   session?: string;
   bundle?: string;
   since?: string;
@@ -197,21 +199,79 @@ function registerEmitSubcommand(events: Command): void {
   });
 }
 
-export function registerEventsCommand(program: Command): void {
-  const events = program
-    .command('events')
-    .description('Read the unified event stream (operational + agent activity)')
+/** Add the one canonical event-reader option surface to a command or alias. */
+export function addEventsReadOptions(command: Command, includeAuditFlag: boolean = true): Command {
+  command
     .option('--module <name>', 'Only events from this group (e.g. teams, secrets, activity)')
     .option('--command <path>', 'Only this command path — prefix match (e.g. "teams create")')
     .option('--event <type>', 'Only this typed event (repeatable, e.g. secrets.get, secrets.unlocked, pr.opened)', collect, [])
     .option('--agent <name>', 'Only events tagged with this agent')
+    .option('--caller <kind>', 'Only this caller kind (claude-code, codex, gemini, cursor, terminal, script)')
+    .option('--level <level>', 'Only this level: audit, warn, info, debug')
     .option('--session <id>', 'Only events from this session (the provenance sessionId) — e.g. trace which session read a secret')
     .option('--bundle <name>', 'Only events carrying this bundle in their payload — e.g. `--module secrets --bundle share` for every read of the share bundle')
     .option('--since <time>', 'Only events newer than this (e.g. 2h, 7d, or ISO date)')
-    .option('--audit', 'Operational events only (skip agent activity)')
     .option('--limit <n>', 'Max records to show; 0 for no cap (default 50)', '50')
     .option('--json', 'Output raw records as JSON')
-    .option('-f, --follow', "Tail today's operational log live")
+    .option('-f, --follow', "Tail today's operational log live");
+  if (includeAuditFlag) command.option('--audit', 'Operational events only (skip agent activity)');
+  return command;
+}
+
+/** Canonical reader used by both `agents events` and `agents logs audit`. */
+export async function runEventsCommand(options: EventsOptions, forceAudit: boolean = false): Promise<void> {
+  if (options.follow) {
+    await followLog();
+    return;
+  }
+
+  let limit: number | undefined;
+  let startDate: Date | undefined;
+  try {
+    limit = resolveEventsLimit(options.limit);
+    startDate = options.since ? parseSince(options.since) : undefined;
+  } catch (err) {
+    console.error(chalk.red((err as Error).message));
+    process.exitCode = 2;
+    return;
+  }
+
+  const fetched = readUnifiedEvents({
+    startDate,
+    eventTypes: options.event && options.event.length ? (options.event as EventType[]) : undefined,
+    level: options.level as EventLevel | undefined,
+    agent: options.agent,
+    sessionId: options.session,
+    bundle: options.bundle,
+    caller: options.caller,
+    command: options.command,
+    module: options.module,
+    limit: limit === undefined ? undefined : limit + 1,
+    includeActivity: !(forceAudit || options.audit),
+  });
+  const { records, truncated } = capRecords(fetched, limit);
+  const capNote = `Showing the newest ${limit} — more events matched. Pass --limit 0 for all.`;
+
+  if (options.json) {
+    if (truncated) console.error(chalk.yellow(capNote));
+    console.log(JSON.stringify(records, null, 2));
+    return;
+  }
+
+  if (records.length === 0) {
+    console.log(chalk.gray('No matching events.'));
+    return;
+  }
+
+  for (const r of records.slice().reverse()) console.log(renderRow(r));
+  console.log(chalk.gray(`\n${records.length} event(s). Log: ${getLogsPath()}`));
+  if (truncated) console.log(chalk.yellow(capNote));
+}
+
+export function registerEventsCommand(program: Command): void {
+  const events = addEventsReadOptions(program
+    .command('events')
+    .description('Read the unified event stream (operational + agent activity)'))
     .addHelpText('after', `
 Examples:
   agents events                          Everything — ops + agent activity
@@ -227,54 +287,8 @@ Examples:
   agents events --event pr.opened --since 30d --limit 0 --json
                                          Every match — use --limit 0 whenever you
                                          aggregate, or you rank only the newest 50`)
-    .action(async (options: EventsOptions) => {
-      if (options.follow) {
-        await followLog();
-        return;
-      }
-
-      let limit: number | undefined;
-      let startDate: Date | undefined;
-      try {
-        limit = resolveEventsLimit(options.limit);
-        startDate = options.since ? parseSince(options.since) : undefined;
-      } catch (err) {
-        console.error(chalk.red((err as Error).message));
-        process.exit(2);
-      }
-
-      // Read one past the cap so we can tell a full result from a clipped one.
-      const fetched = readUnifiedEvents({
-        startDate,
-        eventTypes: options.event && options.event.length ? (options.event as EventType[]) : undefined,
-        agent: options.agent,
-        sessionId: options.session,
-        bundle: options.bundle,
-        command: options.command,
-        module: options.module,
-        limit: limit === undefined ? undefined : limit + 1,
-        includeActivity: !options.audit,
-      });
-      const { records, truncated } = capRecords(fetched, limit);
-      const capNote = `Showing the newest ${limit} — more events matched. Pass --limit 0 for all.`;
-
-      if (options.json) {
-        // Notice goes to stderr so `--json | jq` still receives clean JSON.
-        if (truncated) console.error(chalk.yellow(capNote));
-        console.log(JSON.stringify(records, null, 2));
-        return;
-      }
-
-      if (records.length === 0) {
-        console.log(chalk.gray('No matching events.'));
-        return;
-      }
-
-      // query() returns newest-first; print oldest-first so a tail reads naturally.
-      for (const r of records.slice().reverse()) console.log(renderRow(r));
-      console.log(chalk.gray(`\n${records.length} event(s). Log: ${getLogsPath()}`));
-      if (truncated) console.log(chalk.yellow(capNote));
-    });
+    .action((_options: EventsOptions, command: Command) =>
+      runEventsCommand(command.optsWithGlobals() as EventsOptions));
 
   // `events` both reads (its own action, above) and writes (this subcommand) —
   // the same shape as `feed` / `feed post`.
@@ -288,7 +302,7 @@ function collect(value: string, previous: string[]): string[] {
 
 /** Tail today's event file, printing new lines as they land. */
 async function followLog(): Promise<void> {
-  const file = getLogsPath();
+  let file = getLogsPath();
   let offset = 0;
   try {
     offset = fs.statSync(file).size;
@@ -297,6 +311,12 @@ async function followLog(): Promise<void> {
   }
   console.log(chalk.gray(`Tailing ${file} — Ctrl-C to stop`));
   const drain = () => {
+    const nextFile = getLogsPath();
+    if (nextFile !== file) {
+      file = nextFile;
+      offset = 0;
+      console.log(chalk.gray(`Tailing ${file}`));
+    }
     let size = 0;
     try {
       size = fs.statSync(file).size;

--- a/apps/cli/src/commands/logs.test.ts
+++ b/apps/cli/src/commands/logs.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { gzipSync } from 'node:zlib';
+import { spawnSync } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   emit, query, rotate, stats,
@@ -50,6 +51,35 @@ function makeRecord(overrides: Record<string, unknown> = {}) {
 }
 
 describe('logs audit subcommand data path', () => {
+  it('is a compatibility alias for the canonical events audit reader', () => {
+    const logsDir = setupLogsDir();
+    const systemDir = path.join(logsDir, '.agents', '.system');
+    fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+    const packageVersion = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8')).version;
+    fs.writeFileSync(
+      path.join(systemDir, '.update-check'),
+      JSON.stringify({ lastCheck: Date.now(), latestVersion: packageVersion }),
+    );
+    emit('info', { module: 'alias-fixture', detail: 'same-reader' });
+    const run = (args: string[]) => spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: logsDir,
+        AGENTS_EVENTS_PATH: path.join(logsDir, 'events.jsonl'),
+        AGENTS_SKIP_MIGRATION: '1',
+      },
+      encoding: 'utf-8',
+    });
+
+    const events = run(['events', '--audit', '--module', 'alias-fixture', '--json']);
+    const logs = run(['logs', 'audit', '--module', 'alias-fixture', '--json']);
+
+    expect(events.status).toBe(0);
+    expect(logs.status).toBe(0);
+    expect(JSON.parse(logs.stdout)).toEqual(JSON.parse(events.stdout));
+  });
+
   it('query reads events written by emit for audit viewer', () => {
     setupLogsDir();
     emit('teams.create', { module: 'teams', team: 'alpha' });
@@ -90,7 +120,7 @@ describe('logs audit subcommand data path', () => {
     const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     fs.utimesSync(archive, old, old);
 
-    const removed = rotate(7);
-    expect(removed).toBe(1);
+    const result = rotate(7);
+    expect(result.removedByAge).toBe(1);
   });
 });

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -23,7 +23,6 @@
 
 import type { Command } from 'commander';
 import chalk from 'chalk';
-import * as fs from 'fs';
 import type { SessionMeta } from '../lib/session/types.js';
 import { discoverSessions, resolveSessionById } from '../lib/session/discover.js';
 import { parseAgentFilter, renderSessionLog, renderSessionLogJson } from './sessions.js';
@@ -32,9 +31,9 @@ import { showHostTaskLog, hostTaskLogJson } from '../lib/hosts/logs.js';
 import { listTasks, type HostTask } from '../lib/hosts/tasks.js';
 import { itemPicker } from '../lib/picker.js';
 import {
-  query, stats, getLogsPath, rotate, levelFor,
-  type EventRecord, type EventType, type EventLevel,
+  stats, getLogsPath, rotate,
 } from '../lib/events.js';
+import { addEventsReadOptions, runEventsCommand, type EventsOptions } from './events.js';
 
 interface LogsOptions {
   host?: string;
@@ -189,21 +188,6 @@ async function runLogs(id: string | undefined, opts: LogsOptions): Promise<void>
   await showCandidate(picked.item, follow, full, !!opts.json);
 }
 
-// ─── Audit subcommand ────────────────────────────────────────────────────────
-
-interface AuditOptions {
-  module?: string;
-  command?: string;
-  event?: string[];
-  agent?: string;
-  caller?: string;
-  level?: string;
-  since?: string;
-  limit?: string;
-  json?: boolean;
-  follow?: boolean;
-}
-
 function parseSince(s: string): Date {
   const m = s.match(/^(\d+)([smhdw])$/);
   if (m) {
@@ -218,126 +202,11 @@ function parseSince(s: string): Date {
   return new Date(ms);
 }
 
-function originLabel(r: EventRecord): string {
-  if (r.transport === 'ssh') {
-    return chalk.yellow(`ssh${r.sshClientIp ? ' ' + r.sshClientIp : ''}`);
-  }
-  return chalk.gray('local');
-}
-
-function auditDetailFor(r: EventRecord): string {
-  if (r.command) return r.command;
-  const bits: string[] = [];
-  if (typeof r.team === 'string') bits.push(`team=${r.team}`);
-  if (typeof r.bundle === 'string') bits.push(`bundle=${r.bundle}`);
-  if (typeof r.skill === 'string') bits.push(`skill=${r.skill}`);
-  if (typeof r.version === 'string') bits.push(`v=${r.version}`);
-  if (typeof r.profile === 'string') bits.push(`profile=${r.profile}`);
-  if (typeof r.server === 'string') bits.push(`server=${r.server}`);
-  if (typeof r.error === 'string') bits.push(chalk.red(r.error));
-  return bits.join(' ');
-}
-
 function levelColor(level: string): string {
   if (level === 'audit') return chalk.magenta(level);
   if (level === 'warn') return chalk.yellow(level);
   if (level === 'debug') return chalk.gray(level);
   return chalk.blue(level);
-}
-
-function renderAuditRow(r: EventRecord): string {
-  const time = chalk.gray(r.ts.slice(0, 19).replace('T', ' '));
-  const user = `${r.osUser ?? '?'}@${r.hostname}`;
-  const ev = r.event.startsWith('error') ? chalk.red(r.event) : chalk.cyan(r.event);
-  const lvl = levelColor(r.level ?? levelFor(r.event as EventType));
-  const agent = r.agent ? chalk.gray(` ${r.agent}`) : '';
-  const caller = chalk.gray(`via ${r.caller ?? 'unknown'}${r.session ? ` ${r.session}` : ''}`);
-  return `${time}  ${lvl.padEnd(14)} ${originLabel(r).padEnd(24)} ${user.padEnd(22)} ${caller.padEnd(28)} ${ev.padEnd(26)}${agent}  ${auditDetailFor(r)}`;
-}
-
-function collect(value: string, previous: string[]): string[] {
-  return previous.concat([value]);
-}
-
-async function runAudit(opts: AuditOptions): Promise<void> {
-  if (opts.follow) {
-    await followAuditLog();
-    return;
-  }
-
-  const limit = Math.max(1, parseInt(opts.limit ?? '50', 10) || 50);
-  let startDate: Date | undefined;
-  try {
-    startDate = opts.since ? parseSince(opts.since) : undefined;
-  } catch (err) {
-    console.error(chalk.red((err as Error).message));
-    process.exit(2);
-  }
-
-  const records = query({
-    startDate,
-    eventTypes: opts.event?.length ? (opts.event as EventType[]) : undefined,
-    level: opts.level as EventLevel | undefined,
-    agent: opts.agent,
-    caller: opts.caller,
-    command: opts.command,
-    module: opts.module,
-    limit,
-  });
-
-  if (opts.json) {
-    console.log(JSON.stringify(records, null, 2));
-    return;
-  }
-
-  if (records.length === 0) {
-    console.log(chalk.gray('No matching events.'));
-    return;
-  }
-
-  for (const r of records.slice().reverse()) console.log(renderAuditRow(r));
-  console.log(chalk.gray(`\n${records.length} event(s). Log: ${getLogsPath()}`));
-}
-
-async function followAuditLog(): Promise<void> {
-  const file = getLogsPath();
-  let offset = 0;
-  try {
-    offset = fs.statSync(file).size;
-  } catch {
-    // File may not exist yet — start at 0.
-  }
-  console.log(chalk.gray(`Tailing ${file} — Ctrl-C to stop`));
-  const drain = () => {
-    let size = 0;
-    try {
-      size = fs.statSync(file).size;
-    } catch {
-      return;
-    }
-    if (size <= offset) {
-      if (size < offset) offset = 0;
-      return;
-    }
-    const fd = fs.openSync(file, 'r');
-    try {
-      const buf = Buffer.alloc(size - offset);
-      fs.readSync(fd, buf, 0, buf.length, offset);
-      offset = size;
-      for (const line of buf.toString('utf-8').split('\n').filter(Boolean)) {
-        try {
-          console.log(renderAuditRow(JSON.parse(line) as EventRecord));
-        } catch {
-          // Skip malformed lines.
-        }
-      }
-    } finally {
-      fs.closeSync(fd);
-    }
-  };
-  await new Promise<void>(() => {
-    setInterval(drain, 500);
-  });
 }
 
 function humanBytes(bytes: number): string {
@@ -422,19 +291,9 @@ export function registerLogsCommand(program: Command): void {
     .option('--json', 'Machine-readable JSON: a host task as { kind, task, log }, a session as the redacted { session, events } (same shape as `sessions <id> --json`)')
     .action((id: string | undefined, opts: LogsOptions) => runLogs(id, opts));
 
-  logsCmd
+  addEventsReadOptions(logsCmd
     .command('audit')
-    .description('Read the structured audit/event log (who ran what, from where)')
-    .option('--module <name>', 'Only events from this command group (e.g. teams, secrets)')
-    .option('--command <path>', 'Only this command path — prefix match (e.g. "teams create")')
-    .option('--event <type>', 'Only this typed event (repeatable)', collect, [])
-    .option('--agent <name>', 'Only events tagged with this agent')
-    .option('--caller <kind>', 'Only this caller kind (claude-code, codex, gemini, cursor, terminal, script)')
-    .option('--level <level>', 'Only this level: audit, warn, info, debug')
-    .option('--since <time>', 'Only events newer than this (e.g. 2h, 7d, or ISO date)')
-    .option('--limit <n>', 'Max records to show (default 50)', '50')
-    .option('--json', 'Output raw records as JSON')
-    .option('-f, --follow', "Tail today's log live")
+    .description('Alias for `agents events --audit`'), false)
     .addHelpText('after', `
 Examples:
   agents logs audit                          Recent activity across everything
@@ -444,7 +303,8 @@ Examples:
   agents logs audit --command "teams create" Just team creations
   agents logs audit --event secrets.get --since 7d --json
   agents logs audit -f                       Live tail`)
-    .action(async (options: AuditOptions) => runAudit(options));
+    .action((_options: EventsOptions, command: Command) =>
+      runEventsCommand(command.optsWithGlobals() as EventsOptions, true));
 
   logsCmd
     .command('stats')
@@ -455,15 +315,22 @@ Examples:
 
   logsCmd
     .command('rotate')
-    .description('Force log rotation — remove files older than the retention period')
+    .description('Apply event retention and the storage ceiling immediately')
     .option('--days <n>', 'Retention period in days (default 7)', '7')
-    .action((opts: { days?: string }) => {
+    .option('--max-mb <n>', 'Total event storage ceiling in MiB (default 50)', '50')
+    .action((opts: { days?: string; maxMb?: string }) => {
       const days = Math.max(1, parseInt(opts.days ?? '7', 10) || 7);
-      const removed = rotate(days);
+      const maxMb = Math.max(1, parseInt(opts.maxMb ?? '50', 10) || 50);
+      const result = rotate(days, maxMb * 1024 * 1024);
+      const removed = result.removedByAge + result.removedBySize;
       if (removed > 0) {
-        console.log(`Removed ${removed} log file${removed === 1 ? '' : 's'} older than ${days} day${days === 1 ? '' : 's'}.`);
+        console.log(
+          `Removed ${removed} event file${removed === 1 ? '' : 's'} ` +
+          `(${result.removedByAge} by age, ${result.removedBySize} by size); ` +
+          `reclaimed ${humanBytes(result.bytesReclaimed)}.`,
+        );
       } else {
-        console.log(chalk.gray('No log files to remove.'));
+        console.log(chalk.gray(`No event files removed (retention ${days} days, ceiling ${maxMb} MiB).`));
       }
     });
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1351,7 +1351,7 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
     // Bumping the suffix re-runs migrations for every user; binary releases that
     // don't change the schema must NOT re-run (they would destroy user content
     // when migration steps overlap with user-authored paths). See issue #20.
-    const sentinelValue = 'v13';
+    const sentinelValue = 'v14';
     let needRun = true;
     try {
       if (fs.existsSync(sentinel) && fs.readFileSync(sentinel, 'utf-8').trim() === sentinelValue) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1351,7 +1351,7 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
     // Bumping the suffix re-runs migrations for every user; binary releases that
     // don't change the schema must NOT re-run (they would destroy user content
     // when migration steps overlap with user-authored paths). See issue #20.
-    const sentinelValue = 'v14';
+    const sentinelValue = 'v13';
     let needRun = true;
     try {
       if (fs.existsSync(sentinel) && fs.readFileSync(sentinel, 'utf-8').trim() === sentinelValue) {

--- a/apps/cli/src/lib/__tests__/migrate.test.ts
+++ b/apps/cli/src/lib/__tests__/migrate.test.ts
@@ -33,60 +33,12 @@ function runRealMigration(): void {
   );
 }
 
-function queryNewestEvent(): Record<string, unknown> {
-  const modulePath = path.resolve(process.cwd(), 'src/lib/events.ts');
-  const stdout = execFileSync(
-    'bun',
-    ['-e', `import { query } from ${JSON.stringify(modulePath)}; console.log(JSON.stringify(query({ limit: 1 })[0]));`],
-    {
-      cwd: process.cwd(),
-      env: { ...process.env, HOME: testHome, AGENTS_EVENTS_PATH: '' },
-      encoding: 'utf-8',
-    },
-  );
-  return JSON.parse(stdout.trim()) as Record<string, unknown>;
-}
-
 /** Path to this machine's per-device pin file after the split migration. */
 function devicePinsFile(): string {
   return path.join(userDir, 'devices', 'testdev', 'agents.yaml');
 }
 
 describe('runMigration', () => {
-  it('moves operational event logs into the durable history bucket', () => {
-    fs.writeFileSync(path.join(userDir, 'events.jsonl'), '{"event":"info"}\n');
-    fs.writeFileSync(path.join(userDir, 'events.1.jsonl.gz'), 'archive');
-
-    runRealMigration();
-
-    const eventsDir = path.join(userDir, '.history', 'events');
-    expect(fs.readFileSync(path.join(eventsDir, 'events.jsonl'), 'utf-8')).toBe('{"event":"info"}\n');
-    expect(fs.readFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'utf-8')).toBe('archive');
-    expect(fs.existsSync(path.join(userDir, 'events.jsonl'))).toBe(false);
-    expect(fs.existsSync(path.join(userDir, 'events.1.jsonl.gz'))).toBe(false);
-  });
-
-  it('preserves root and history event logs when both layouts contain data', () => {
-    const eventsDir = path.join(userDir, '.history', 'events');
-    fs.mkdirSync(eventsDir, { recursive: true });
-    fs.writeFileSync(path.join(eventsDir, 'events.jsonl'), '{"event":"info","module":"history-new","ts":"2025-08-05T12:00:00.000Z"}\n');
-    fs.writeFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'history-archive');
-    fs.writeFileSync(path.join(userDir, 'events.jsonl'), '{"event":"info","module":"root-old","ts":"2025-08-04T12:00:00.000Z"}\n');
-    fs.writeFileSync(path.join(userDir, 'events.1.jsonl.gz'), 'root-archive');
-
-    runRealMigration();
-
-    expect(fs.readFileSync(path.join(eventsDir, 'events.jsonl'), 'utf-8')).toBe(
-      '{"event":"info","module":"root-old","ts":"2025-08-04T12:00:00.000Z"}\n' +
-      '{"event":"info","module":"history-new","ts":"2025-08-05T12:00:00.000Z"}\n',
-    );
-    expect(queryNewestEvent().module).toBe('history-new');
-    expect(fs.readFileSync(path.join(eventsDir, 'events.1.jsonl.gz'), 'utf-8')).toBe('history-archive');
-    expect(fs.readFileSync(path.join(eventsDir, 'events.2.jsonl.gz'), 'utf-8')).toBe('root-archive');
-    expect(fs.existsSync(path.join(userDir, 'events.jsonl'))).toBe(false);
-    expect(fs.existsSync(path.join(userDir, 'events.1.jsonl.gz'))).toBe(false);
-  });
-
   it('moves legacy files into the user repo and deletes dead files', () => {
     fs.writeFileSync(path.join(systemDir, 'agents.yaml'), 'agents:\n  claude: "1.0.0"\n');
     fs.writeFileSync(path.join(systemDir, 'prompts.json'), '{}');

--- a/apps/cli/src/lib/event-stream.ts
+++ b/apps/cli/src/lib/event-stream.ts
@@ -1,6 +1,6 @@
 /**
  * The unified event reader -- one stream over BOTH operational events
- * (`~/.agents/.history/events/events.jsonl` via events.ts: secrets, commands, teams, ...) and
+ * (`~/.agents/.history/events/YYYY-MM-DD/` via events.ts: secrets, commands, teams, ...) and
  * agent-semantic events (the per-session activity logs via activity.ts: plans,
  * PRs, worktrees, sub-agents, artifacts). They share one {@link EventType}
  * vocabulary and one {@link EventRecord} shape, so `agents events` and any

--- a/apps/cli/src/lib/events.test.ts
+++ b/apps/cli/src/lib/events.test.ts
@@ -1,14 +1,16 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { spawn } from 'node:child_process';
 import { gunzipSync, gzipSync } from 'node:zlib';
+import lockfile from 'proper-lockfile';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   emit, emitStart, emitCommand, emitFriction, query, rotate, stats,
   redactPrompt, redactArgs, truncate,
   detectCaller,
   levelFor, isEventType, EVENT_TYPES,
-  _resetForTest,
+  getLogsPath, _resetForTest,
 } from './events.js';
 import { resetActorCache } from './actor.js';
 
@@ -412,9 +414,142 @@ describe('events', () => {
       const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       fs.utimesSync(gzFile, old, old);
 
-      const removed = rotate(7);
-      expect(removed).toBe(1);
+      const result = rotate(7);
+      expect(result.removedByAge).toBe(1);
+      expect(result.removedBySize).toBe(0);
       expect(fs.existsSync(gzFile)).toBe(false);
+    });
+
+    it('runs retention from the central emit path', () => {
+      const logsDir = setupLogsDir();
+      const gzFile = path.join(logsDir, 'events.1.jsonl.gz');
+      fs.writeFileSync(gzFile, gzipSync(Buffer.from('{"event":"info"}\n')));
+      const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(gzFile, old, old);
+
+      emit('info', { module: 'prune-trigger' });
+
+      expect(fs.existsSync(gzFile)).toBe(false);
+      expect(query({ module: 'prune-trigger' })).toHaveLength(1);
+    });
+
+    it('writes into a local-date directory under .history/events', () => {
+      const userDir = makeTempDir();
+      _resetForTest(undefined, userDir);
+
+      emit('info', { module: 'dated-layout' });
+
+      const expectedDay = [
+        new Date().getFullYear(),
+        String(new Date().getMonth() + 1).padStart(2, '0'),
+        String(new Date().getDate()).padStart(2, '0'),
+      ].join('-');
+      const expected = path.join(userDir, '.history', 'events', expectedDay, 'events.jsonl');
+      expect(getLogsPath()).toBe(expected);
+      expect(fs.existsSync(expected)).toBe(true);
+    });
+
+    it('migrates root event files without losing queryable records', () => {
+      const userDir = makeTempDir();
+      const legacyActive = path.join(userDir, 'events.jsonl');
+      const legacyArchive = path.join(userDir, 'events.1.jsonl.gz');
+      const record = (module: string) => JSON.stringify({
+        ts: new Date().toISOString(), event: 'info', level: 'info', module,
+      }) + '\n';
+      fs.writeFileSync(legacyActive, record('legacy-active'));
+      fs.writeFileSync(legacyArchive, gzipSync(Buffer.from(record('legacy-archive'))));
+      _resetForTest(undefined, userDir);
+
+      emit('info', { module: 'new-write' });
+
+      expect(fs.existsSync(legacyActive)).toBe(false);
+      expect(fs.existsSync(legacyArchive)).toBe(false);
+      expect(query({}).map((entry) => entry.module)).toEqual(
+        expect.arrayContaining(['legacy-active', 'legacy-archive', 'new-write']),
+      );
+    });
+
+    it('removes the oldest files until the total storage ceiling is met', () => {
+      const logsDir = setupLogsDir();
+      const active = path.join(logsDir, 'events.jsonl');
+      fs.writeFileSync(active, '{"event":"info"}\n');
+      for (let i = 1; i <= 3; i++) {
+        const archive = path.join(logsDir, `events.${i}.jsonl.gz`);
+        fs.writeFileSync(archive, Buffer.alloc(1024, i));
+        const stamp = new Date(Date.now() - (4 - i) * 60_000);
+        fs.utimesSync(archive, stamp, stamp);
+      }
+
+      const result = rotate(365, 1500);
+      const remainingBytes = fs.readdirSync(logsDir)
+        .filter((name) => name === 'events.jsonl' || name.endsWith('.jsonl.gz'))
+        .reduce((sum, name) => sum + fs.statSync(path.join(logsDir, name)).size, 0);
+      expect(result.removedBySize).toBe(2);
+      expect(result.bytesReclaimed).toBe(2048);
+      expect(remainingBytes).toBeLessThanOrEqual(1500);
+    });
+
+    it('keeps the source mtime when finalizing a past day so age pruning removes it', () => {
+      const userDir = makeTempDir();
+      _resetForTest(undefined, userDir);
+      const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const day = [
+        old.getFullYear(),
+        String(old.getMonth() + 1).padStart(2, '0'),
+        String(old.getDate()).padStart(2, '0'),
+      ].join('-');
+      const dayDir = path.join(userDir, '.history', 'events', day);
+      fs.mkdirSync(dayDir, { recursive: true });
+      const raw = path.join(dayDir, 'events.jsonl');
+      fs.writeFileSync(raw, '{"event":"info"}\n');
+      fs.utimesSync(raw, old, old);
+
+      const result = rotate(7);
+
+      expect(result.removedByAge).toBe(1);
+      expect(fs.existsSync(dayDir)).toBe(false);
+    });
+
+    it('serializes past-day finalization with migration archive allocation', async () => {
+      const home = makeTempDir();
+      const dayDir = path.join(home, '.agents', '.history', 'events', '2026-07-01');
+      fs.mkdirSync(dayDir, { recursive: true });
+      const raw = path.join(dayDir, 'events.jsonl');
+      fs.writeFileSync(raw, '{"event":"info"}\n');
+      const release = await lockfile.lock(raw);
+      const modulePath = path.resolve('src/lib/events.ts');
+      const child = spawn(
+        'node',
+        ['--import', 'tsx', '-e', `console.log('READY'); const { rotate } = await import(${JSON.stringify(modulePath)}); rotate(365);`],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, HOME: home, AGENTS_EVENTS_PATH: '' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      await new Promise<void>((resolve, reject) => {
+        child.once('error', reject);
+        child.stdout.once('data', () => resolve());
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(fs.existsSync(path.join(dayDir, 'events.1.jsonl.gz'))).toBe(false);
+
+      await release();
+      const exitCode = await new Promise<number | null>((resolve) => child.once('close', resolve));
+
+      expect(exitCode).toBe(0);
+      expect(fs.existsSync(path.join(dayDir, 'events.1.jsonl.gz'))).toBe(true);
+    });
+
+    it('queries rotated archives when AGENTS_EVENTS_PATH has a custom filename', () => {
+      const logsDir = makeTempDir();
+      _resetForTest(path.join(logsDir, 'custom-events.jsonl'));
+      fs.writeFileSync(getLogsPath(), `${' '.repeat(10 * 1024 * 1024)}\n`);
+
+      emit('info', { module: 'custom-override-trigger' });
+
+      expect(query({ module: 'custom-override-trigger' })).toHaveLength(1);
+      expect(fs.existsSync(path.join(logsDir, 'events.1.jsonl.gz'))).toBe(true);
     });
   });
 

--- a/apps/cli/src/lib/events.test.ts
+++ b/apps/cli/src/lib/events.test.ts
@@ -469,6 +469,28 @@ describe('events', () => {
       );
     });
 
+    it('migrates the interim flat history layout shipped by v14', () => {
+      const userDir = makeTempDir();
+      const interimDir = path.join(userDir, '.history', 'events');
+      fs.mkdirSync(interimDir, { recursive: true });
+      const record = (module: string) => JSON.stringify({
+        ts: new Date().toISOString(), event: 'info', level: 'info', module,
+      }) + '\n';
+      const interimActive = path.join(interimDir, 'events.jsonl');
+      const interimArchive = path.join(interimDir, 'events.1.jsonl.gz');
+      fs.writeFileSync(interimActive, record('interim-active'));
+      fs.writeFileSync(interimArchive, gzipSync(Buffer.from(record('interim-archive'))));
+      _resetForTest(undefined, userDir);
+
+      emit('info', { module: 'new-write' });
+
+      expect(fs.existsSync(interimActive)).toBe(false);
+      expect(fs.existsSync(interimArchive)).toBe(false);
+      expect(query({}).map((entry) => entry.module)).toEqual(
+        expect.arrayContaining(['interim-active', 'interim-archive', 'new-write']),
+      );
+    });
+
     it('removes the oldest files until the total storage ceiling is met', () => {
       const logsDir = setupLogsDir();
       const active = path.join(logsDir, 'events.jsonl');

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -1,8 +1,8 @@
 /**
  * Centralized event logging for agents-cli.
  *
- * Structured JSONL audit log at ~/.agents/.history/events/events.jsonl with lossless numbered
- * gzip rotation at 10 MB and rich metadata for debugging/auditing.
+ * Structured JSONL audit logs at ~/.agents/.history/events/YYYY-MM-DD/events.jsonl with
+ * lossless numbered gzip rotation at 10 MiB and bounded retention.
  *
  * Features:
  * - Rich metadata: hostname, platform, arch, pid, timezone
@@ -18,7 +18,7 @@ import * as os from 'os';
 import { createHash } from 'node:crypto';
 import { gzipSync, gunzipSync } from 'node:zlib';
 import { ensureLockTarget, withFileLock } from './fs-atomic.js';
-import { getHistoryDir } from './state.js';
+import { getUserAgentsDir } from './state.js';
 import { stampProvenance, resetEventProvenanceForTest } from './event-provenance.js';
 import type { ActorKind } from './actor.js';
 
@@ -59,16 +59,46 @@ function recordPerfTiming(payload: {
 // unlike _resetForTest it survives a bare reset AND propagates to CLI subprocesses
 // a test spawns, so fixture events can never land in the user's real log (#910).
 let _eventsPath: string | undefined;
-function eventsPath(): string {
-  return (_eventsPath ??= process.env.AGENTS_EVENTS_PATH || path.join(getHistoryDir(), 'events', 'events.jsonl'));
+let _eventsPathOverride = false;
+let _legacyMigrationChecked = false;
+let _userAgentsDirOverride: string | undefined;
+function userAgentsDir(): string {
+  return _userAgentsDirOverride ?? getUserAgentsDir();
+}
+function localDateKey(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
-function eventsDir(): string {
-  return path.dirname(eventsPath());
+function eventsRoot(): string {
+  if (_eventsPathOverride && _eventsPath) return path.dirname(_eventsPath);
+  return path.join(userAgentsDir(), '.history', 'events');
+}
+
+function eventsPath(date: Date = new Date()): string {
+  if (_eventsPathOverride && _eventsPath) return _eventsPath;
+  const override = _userAgentsDirOverride ? undefined : process.env.AGENTS_EVENTS_PATH;
+  if (override) {
+    _eventsPathOverride = true;
+    return (_eventsPath = override);
+  }
+  return path.join(eventsRoot(), localDateKey(date), 'events.jsonl');
+}
+
+function eventsDir(date: Date = new Date()): string {
+  return path.dirname(eventsPath(date));
 }
 
 /** Default retention period in days. */
 const DEFAULT_RETENTION_DAYS = 7;
+
+/** Default total footprint for the active log plus gzip archives (50 MiB). */
+const DEFAULT_MAX_STORAGE_BYTES = 50 * 1024 * 1024;
+
+/** Cross-process marker used to avoid a full archive scan on every append. */
+const PRUNE_MARKER = '.last-prune';
 
 /** Default max length for truncated strings. */
 const DEFAULT_TRUNCATE_LENGTH = 500;
@@ -357,6 +387,8 @@ function getTimezoneName(): string {
 }
 
 function ensureLogsDir(): void {
+  eventsPath(); // Resolve an explicit AGENTS_EVENTS_PATH before migration checks.
+  migrateLegacyEventLogs();
   if (!fs.existsSync(eventsDir())) {
     fs.mkdirSync(eventsDir(), { recursive: true, mode: DIR_MODE });
   } else {
@@ -366,6 +398,94 @@ function ensureLogsDir(): void {
     } catch {
       // May fail if not owner
     }
+  }
+}
+
+/**
+ * Move the root-level event family into dated hidden-history directories.
+ *
+ * The common case is a whole-family rename into an empty destination. A
+ * Each segment is assigned to the local calendar day of its filesystem mtime;
+ * new writes are split by day at source. A partially completed migration keeps
+ * the destination active file authoritative and assigns a fresh archive number,
+ * so no record is overwritten or silently discarded. The legacy active-file
+ * lock serializes this with older installed processes that still append there.
+ */
+export function migrateLegacyEventLogs(userDir: string = userAgentsDir()): number {
+  if (_eventsPathOverride || _legacyMigrationChecked) return 0;
+  _legacyMigrationChecked = true;
+
+  const legacyActive = path.join(userDir, 'events.jsonl');
+  let legacyArchives: Array<{ file: string; number: number }> = [];
+  try {
+    legacyArchives = fs.readdirSync(userDir)
+      .map((file) => ({ file, match: file.match(/^events\.(\d+)\.jsonl\.gz$/) }))
+      .filter((entry): entry is { file: string; match: RegExpMatchArray } => entry.match !== null)
+      .map((entry) => ({ file: entry.file, number: Number(entry.match[1]) }))
+      .sort((a, b) => a.number - b.number);
+  } catch { /* user dir may not exist yet */ }
+
+  if (!fs.existsSync(legacyActive) && legacyArchives.length === 0) return 0;
+
+  const destinationRoot = path.join(userDir, '.history', 'events');
+  try {
+    fs.mkdirSync(destinationRoot, { recursive: true, mode: DIR_MODE });
+    ensureLockTarget(legacyActive, '', DIR_MODE);
+    return withFileLock(legacyActive, () => {
+      const currentLegacyArchives = fs.readdirSync(userDir)
+        .map((file) => ({ file, match: file.match(/^events\.(\d+)\.jsonl\.gz$/) }))
+        .filter((entry): entry is { file: string; match: RegExpMatchArray } => entry.match !== null)
+        .map((entry) => ({ file: entry.file, number: Number(entry.match[1]) }))
+        .sort((a, b) => a.number - b.number);
+      let moved = 0;
+
+      const nextArchiveNumber = (dir: string): number => {
+        const numbers = fs.readdirSync(dir)
+          .map((file) => file.match(/^events\.(\d+)\.jsonl\.gz$/))
+          .filter((match): match is RegExpMatchArray => match !== null)
+          .map((match) => Number(match[1]));
+        return (numbers.length ? Math.max(...numbers) : 0) + 1;
+      };
+      const withDestinationLock = <T>(dayDir: string, fn: () => T): T => {
+        const destinationActive = path.join(dayDir, 'events.jsonl');
+        fs.mkdirSync(dayDir, { recursive: true, mode: DIR_MODE });
+        ensureLockTarget(destinationActive, '', DIR_MODE);
+        return withFileLock(destinationActive, fn);
+      };
+
+      const activeBytes = fs.existsSync(legacyActive) ? fs.statSync(legacyActive).size : 0;
+      if (activeBytes > 0) {
+        const activeStat = fs.statSync(legacyActive);
+        const dayDir = path.join(destinationRoot, localDateKey(activeStat.mtime));
+        withDestinationLock(dayDir, () => {
+          const archivePath = path.join(dayDir, `events.${nextArchiveNumber(dayDir)}.jsonl.gz`);
+          fs.writeFileSync(archivePath, gzipSync(fs.readFileSync(legacyActive)), { mode: FILE_MODE });
+          fs.utimesSync(archivePath, activeStat.atime, activeStat.mtime);
+          fs.truncateSync(legacyActive, 0);
+        });
+        moved++;
+      }
+
+      for (const archive of currentLegacyArchives) {
+        const source = path.join(userDir, archive.file);
+        const dayDir = path.join(destinationRoot, localDateKey(fs.statSync(source).mtime));
+        withDestinationLock(dayDir, () => {
+          const destination = path.join(dayDir, `events.${nextArchiveNumber(dayDir)}.jsonl.gz`);
+          fs.renameSync(source, destination);
+        });
+        moved++;
+      }
+
+      try {
+        if (fs.existsSync(legacyActive) && fs.statSync(legacyActive).size === 0) fs.unlinkSync(legacyActive);
+      } catch { /* an older process may have reopened it */ }
+      return moved;
+    });
+  } catch {
+    // Audit logging must remain fail-soft. Files stay at the legacy path and a
+    // later process retries because this guard is process-local.
+    _legacyMigrationChecked = false;
+    return 0;
   }
 }
 
@@ -603,7 +723,8 @@ export function emit(event: EventType, payload: EventPayload = {}, overrides: { 
         }
       }
 
-      maybeGzipRotateLocked(logPath);
+      const rotated = maybeGzipRotateLocked(logPath);
+      maybePruneLocked(rotated);
     });
   } catch {
     // Silent failure - logging should never break the CLI
@@ -916,9 +1037,9 @@ export function emitFriction(
 // ─── Gzip rotation ──────────────────────────────────────────────────────────
 
 /** Rotate the active file while its append lock is held. */
-function maybeGzipRotateLocked(logPath: string): void {
+function maybeGzipRotateLocked(logPath: string): boolean {
   const stat = fs.statSync(logPath);
-  if (stat.size < GZIP_ROTATION_BYTES) return;
+  if (stat.size < GZIP_ROTATION_BYTES) return false;
 
   const raw = fs.readFileSync(logPath);
   const tmpArchive = path.join(eventsDir(), `.events.1.jsonl.gz.${process.pid}.tmp`);
@@ -939,6 +1060,7 @@ function maybeGzipRotateLocked(logPath: string): void {
     }
     fs.renameSync(tmpArchive, path.join(eventsDir(), 'events.1.jsonl.gz'));
     fs.truncateSync(logPath, 0);
+    return true;
   } catch (err) {
     try { fs.unlinkSync(tmpArchive); } catch { /* best-effort cleanup */ }
     throw err;
@@ -947,47 +1069,163 @@ function maybeGzipRotateLocked(logPath: string): void {
 
 // ─── Rotation ─────────────────────────────────────────────────────────────────
 
-/**
- * Remove log files older than the retention period.
- * Removes numbered gzip archives whose filesystem mtime exceeds retention.
- *
- * @param retentionDays - Number of days to keep (default 7, from DEFAULT_RETENTION_DAYS)
- * @returns Number of files removed
- */
-export function rotate(retentionDays: number = DEFAULT_RETENTION_DAYS): number {
-  try {
-    if (!fs.existsSync(eventsDir())) return 0;
+interface EventLogFile {
+  path: string;
+  gzip: boolean;
+  currentActive: boolean;
+  mtimeMs: number;
+  size: number;
+}
 
-    const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
-    const files = fs.readdirSync(eventsDir()).filter(f => /^events\.\d+\.jsonl\.gz$/.test(f));
-    let removed = 0;
-
-    for (const file of files) {
-      const filePath = path.join(eventsDir(), file);
-      if (fs.statSync(filePath).mtimeMs < cutoff) {
-        fs.unlinkSync(filePath);
-        removed++;
-      }
+function listEventLogFiles(): EventLogFile[] {
+  const current = eventsPath();
+  const files: EventLogFile[] = [];
+  const addFile = (filePath: string, gzip: boolean) => {
+    try {
+      const stat = fs.statSync(filePath);
+      files.push({
+        path: filePath,
+        gzip,
+        currentActive: filePath === current,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+      });
+    } catch { /* file may rotate while an unlocked reader enumerates */ }
+  };
+  const addDirectory = (dir: string) => {
+    let names: string[] = [];
+    try { names = fs.readdirSync(dir); } catch { return; }
+    for (const name of names) {
+      if (name !== 'events.jsonl' && !/^events\.\d+\.jsonl\.gz$/.test(name)) continue;
+      addFile(path.join(dir, name), name.endsWith('.gz'));
     }
+  };
 
-    return removed;
-  } catch {
-    return 0;
+  if (_eventsPathOverride) {
+    if (path.basename(current) !== 'events.jsonl') {
+      addFile(current, false);
+      let names: string[] = [];
+      try { names = fs.readdirSync(eventsDir()); } catch { return files; }
+      for (const name of names) {
+        if (/^events\.\d+\.jsonl\.gz$/.test(name)) addFile(path.join(eventsDir(), name), true);
+      }
+      return files;
+    }
+    addDirectory(eventsDir());
+    return files;
+  }
+
+  let days: string[] = [];
+  try { days = fs.readdirSync(eventsRoot()).filter((name) => /^\d{4}-\d{2}-\d{2}$/.test(name)); } catch { return files; }
+  for (const day of days) addDirectory(path.join(eventsRoot(), day));
+  return files;
+}
+
+function removeEmptyDayDirectories(): void {
+  if (_eventsPathOverride) return;
+  let days: string[] = [];
+  try { days = fs.readdirSync(eventsRoot()).filter((name) => /^\d{4}-\d{2}-\d{2}$/.test(name)); } catch { return; }
+  for (const day of days) {
+    const dir = path.join(eventsRoot(), day);
+    try { if (fs.readdirSync(dir).length === 0) fs.rmdirSync(dir); } catch { /* best effort */ }
   }
 }
 
-/**
- * Lazy rotation - runs at most once per day per process.
- */
-let lastRotationCheck = 0;
-export function maybeRotate(): void {
-  const now = Date.now();
-  const oneDayMs = 24 * 60 * 60 * 1000;
-
-  if (now - lastRotationCheck > oneDayMs) {
-    lastRotationCheck = now;
-    rotate();
+function finalizePastDayLogs(): void {
+  if (_eventsPathOverride) return;
+  const currentDay = localDateKey();
+  for (const file of listEventLogFiles()) {
+    if (path.basename(file.path) !== 'events.jsonl') continue;
+    if (path.basename(path.dirname(file.path)) === currentDay) continue;
+    try {
+      withFileLock(file.path, () => {
+        const dir = path.dirname(file.path);
+        const numbers = fs.readdirSync(dir)
+          .map((name) => name.match(/^events\.(\d+)\.jsonl\.gz$/))
+          .filter((match): match is RegExpMatchArray => match !== null)
+          .map((match) => Number(match[1]));
+        const next = (numbers.length ? Math.max(...numbers) : 0) + 1;
+        const target = path.join(dir, `events.${next}.jsonl.gz`);
+        const sourceStat = fs.statSync(file.path);
+        fs.writeFileSync(target, gzipSync(fs.readFileSync(file.path)), { mode: FILE_MODE });
+        fs.utimesSync(target, sourceStat.atime, sourceStat.mtime);
+        fs.unlinkSync(file.path);
+      });
+    } catch { /* retry on the next prune */ }
   }
+}
+
+export interface RotationResult {
+  removedByAge: number;
+  removedBySize: number;
+  bytesReclaimed: number;
+}
+
+function pruneEventLogsLocked(
+  retentionDays: number = DEFAULT_RETENTION_DAYS,
+  maxStorageBytes: number = DEFAULT_MAX_STORAGE_BYTES,
+): RotationResult {
+  finalizePastDayLogs();
+  const result: RotationResult = { removedByAge: 0, removedBySize: 0, bytesReclaimed: 0 };
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  let files = listEventLogFiles();
+
+  for (const file of files) {
+    if (file.currentActive || file.mtimeMs >= cutoff) continue;
+    try {
+      fs.unlinkSync(file.path);
+      result.removedByAge++;
+      result.bytesReclaimed += file.size;
+    } catch { /* another process may already have removed it */ }
+  }
+
+  files = listEventLogFiles();
+  let totalBytes = files.reduce((sum, file) => sum + file.size, 0);
+  const oldestFirst = files
+    .filter((file) => !file.currentActive)
+    .sort((a, b) => a.mtimeMs - b.mtimeMs || a.path.localeCompare(b.path));
+  for (const file of oldestFirst) {
+    if (totalBytes <= maxStorageBytes) break;
+    try {
+      fs.unlinkSync(file.path);
+      totalBytes -= file.size;
+      result.removedBySize++;
+      result.bytesReclaimed += file.size;
+    } catch { /* another process may already have removed it */ }
+  }
+
+  removeEmptyDayDirectories();
+  return result;
+}
+
+/** Apply age retention and the total-size ceiling immediately. */
+export function rotate(
+  retentionDays: number = DEFAULT_RETENTION_DAYS,
+  maxStorageBytes: number = DEFAULT_MAX_STORAGE_BYTES,
+): RotationResult {
+  try {
+    ensureLogsDir();
+    const active = eventsPath();
+    ensureLockTarget(active, '', DIR_MODE);
+    return withFileLock(active, () => pruneEventLogsLocked(retentionDays, maxStorageBytes));
+  } catch {
+    return { removedByAge: 0, removedBySize: 0, bytesReclaimed: 0 };
+  }
+}
+
+/** Prune daily across processes, and immediately after a size rotation. */
+function maybePruneLocked(force: boolean): void {
+  const marker = path.join(eventsRoot(), PRUNE_MARKER);
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  let due = force;
+  try { due ||= Date.now() - fs.statSync(marker).mtimeMs > oneDayMs; } catch { due = true; }
+  if (!due) return;
+
+  const maxBytes = force
+    ? DEFAULT_MAX_STORAGE_BYTES - GZIP_ROTATION_BYTES
+    : DEFAULT_MAX_STORAGE_BYTES;
+  pruneEventLogsLocked(DEFAULT_RETENTION_DAYS, maxBytes);
+  try { fs.writeFileSync(marker, '', { mode: FILE_MODE }); } catch { /* retry next append */ }
 }
 
 // ─── Query ────────────────────────────────────────────────────────────────────
@@ -1016,18 +1254,11 @@ export function query(options: {
   const { startDate, endDate = new Date(), eventTypes, level, agent, sessionId, caller, command, module, bundle, limit } = options;
   const results: EventRecord[] = [];
 
-  if (!fs.existsSync(eventsDir())) return results;
-
-  const files: Array<{ path: string; gzip: boolean }> = [];
-  if (fs.existsSync(eventsPath())) files.push({ path: eventsPath(), gzip: false });
-  const archives = fs.readdirSync(eventsDir())
-    .map((file) => ({ file, match: file.match(/^events\.(\d+)\.jsonl\.gz$/) }))
-    .filter((entry): entry is { file: string; match: RegExpMatchArray } => entry.match !== null)
-    .map((entry) => ({ file: entry.file, number: Number(entry.match[1]) }))
-    .sort((a, b) => a.number - b.number);
-  for (const archive of archives) {
-    files.push({ path: path.join(eventsDir(), archive.file), gzip: true });
-  }
+  eventsPath(); // Resolve AGENTS_EVENTS_PATH before deciding whether to migrate.
+  migrateLegacyEventLogs();
+  const files = listEventLogFiles().sort((a, b) =>
+    Number(b.currentActive) - Number(a.currentActive) || b.mtimeMs - a.mtimeMs || b.path.localeCompare(a.path)
+  );
 
   const startMs = startDate?.getTime();
   const endMs = endDate?.getTime();
@@ -1157,17 +1388,9 @@ export function stats(options: { days?: number } = {}): EventStats {
   let fileCount = 0;
   let totalBytes = 0;
   try {
-    if (fs.existsSync(eventsDir())) {
-      const files = fs.readdirSync(eventsDir()).filter(f =>
-        f === 'events.jsonl' || /^events\.\d+\.jsonl\.gz$/.test(f)
-      );
-      fileCount = files.length;
-      for (const f of files) {
-        try {
-          totalBytes += fs.statSync(path.join(eventsDir(), f)).size;
-        } catch { /* skip */ }
-      }
-    }
+    const files = listEventLogFiles();
+    fileCount = files.length;
+    totalBytes = files.reduce((sum, file) => sum + file.size, 0);
   } catch { /* skip */ }
 
   return {
@@ -1188,9 +1411,11 @@ export function getLogsPath(): string {
   return eventsPath();
 }
 
-export function _resetForTest(overrideEventsPath?: string): void {
+export function _resetForTest(overrideEventsPath?: string, overrideUserAgentsDir?: string): void {
   _eventsPath = overrideEventsPath;
+  _eventsPathOverride = Boolean(overrideEventsPath);
+  _userAgentsDirOverride = overrideUserAgentsDir;
+  _legacyMigrationChecked = false;
   resetEventProvenanceForTest();
   _chmoddedPath = undefined;
-  lastRotationCheck = 0;
 }

--- a/apps/cli/src/lib/events.ts
+++ b/apps/cli/src/lib/events.ts
@@ -402,7 +402,7 @@ function ensureLogsDir(): void {
 }
 
 /**
- * Move the root-level event family into dated hidden-history directories.
+ * Move root-level and interim flat-history event families into dated directories.
  *
  * The common case is a whole-family rename into an empty destination. A
  * Each segment is assigned to the local calendar day of its filesystem mtime;
@@ -415,71 +415,81 @@ export function migrateLegacyEventLogs(userDir: string = userAgentsDir()): numbe
   if (_eventsPathOverride || _legacyMigrationChecked) return 0;
   _legacyMigrationChecked = true;
 
+  const destinationRoot = path.join(userDir, '.history', 'events');
   const legacyActive = path.join(userDir, 'events.jsonl');
-  let legacyArchives: Array<{ file: string; number: number }> = [];
-  try {
-    legacyArchives = fs.readdirSync(userDir)
+  const interimActive = path.join(destinationRoot, 'events.jsonl');
+  const listArchives = (dir: string): Array<{ file: string; number: number }> => {
+    try {
+      return fs.readdirSync(dir)
       .map((file) => ({ file, match: file.match(/^events\.(\d+)\.jsonl\.gz$/) }))
       .filter((entry): entry is { file: string; match: RegExpMatchArray } => entry.match !== null)
       .map((entry) => ({ file: entry.file, number: Number(entry.match[1]) }))
       .sort((a, b) => a.number - b.number);
-  } catch { /* user dir may not exist yet */ }
+    } catch {
+      return [];
+    }
+  };
+  const hasSourceFiles = fs.existsSync(legacyActive) || fs.existsSync(interimActive) ||
+    listArchives(userDir).length > 0 || listArchives(destinationRoot).length > 0;
 
-  if (!fs.existsSync(legacyActive) && legacyArchives.length === 0) return 0;
+  if (!hasSourceFiles) return 0;
 
-  const destinationRoot = path.join(userDir, '.history', 'events');
   try {
     fs.mkdirSync(destinationRoot, { recursive: true, mode: DIR_MODE });
     ensureLockTarget(legacyActive, '', DIR_MODE);
     return withFileLock(legacyActive, () => {
-      const currentLegacyArchives = fs.readdirSync(userDir)
-        .map((file) => ({ file, match: file.match(/^events\.(\d+)\.jsonl\.gz$/) }))
-        .filter((entry): entry is { file: string; match: RegExpMatchArray } => entry.match !== null)
-        .map((entry) => ({ file: entry.file, number: Number(entry.match[1]) }))
-        .sort((a, b) => a.number - b.number);
-      let moved = 0;
+      ensureLockTarget(interimActive, '', DIR_MODE);
+      return withFileLock(interimActive, () => {
+        const sourceFamilies = [
+          { dir: userDir, active: legacyActive, archives: listArchives(userDir) },
+          { dir: destinationRoot, active: interimActive, archives: listArchives(destinationRoot) },
+        ];
+        let moved = 0;
 
-      const nextArchiveNumber = (dir: string): number => {
-        const numbers = fs.readdirSync(dir)
-          .map((file) => file.match(/^events\.(\d+)\.jsonl\.gz$/))
-          .filter((match): match is RegExpMatchArray => match !== null)
-          .map((match) => Number(match[1]));
-        return (numbers.length ? Math.max(...numbers) : 0) + 1;
-      };
-      const withDestinationLock = <T>(dayDir: string, fn: () => T): T => {
-        const destinationActive = path.join(dayDir, 'events.jsonl');
-        fs.mkdirSync(dayDir, { recursive: true, mode: DIR_MODE });
-        ensureLockTarget(destinationActive, '', DIR_MODE);
-        return withFileLock(destinationActive, fn);
-      };
+        const nextArchiveNumber = (dir: string): number => {
+          const numbers = fs.readdirSync(dir)
+            .map((file) => file.match(/^events\.(\d+)\.jsonl\.gz$/))
+            .filter((match): match is RegExpMatchArray => match !== null)
+            .map((match) => Number(match[1]));
+          return (numbers.length ? Math.max(...numbers) : 0) + 1;
+        };
+        const withDestinationLock = <T>(dayDir: string, fn: () => T): T => {
+          const destinationActive = path.join(dayDir, 'events.jsonl');
+          fs.mkdirSync(dayDir, { recursive: true, mode: DIR_MODE });
+          ensureLockTarget(destinationActive, '', DIR_MODE);
+          return withFileLock(destinationActive, fn);
+        };
 
-      const activeBytes = fs.existsSync(legacyActive) ? fs.statSync(legacyActive).size : 0;
-      if (activeBytes > 0) {
-        const activeStat = fs.statSync(legacyActive);
-        const dayDir = path.join(destinationRoot, localDateKey(activeStat.mtime));
-        withDestinationLock(dayDir, () => {
-          const archivePath = path.join(dayDir, `events.${nextArchiveNumber(dayDir)}.jsonl.gz`);
-          fs.writeFileSync(archivePath, gzipSync(fs.readFileSync(legacyActive)), { mode: FILE_MODE });
-          fs.utimesSync(archivePath, activeStat.atime, activeStat.mtime);
-          fs.truncateSync(legacyActive, 0);
-        });
-        moved++;
-      }
+        for (const family of sourceFamilies) {
+          const activeBytes = fs.existsSync(family.active) ? fs.statSync(family.active).size : 0;
+          if (activeBytes > 0) {
+            const activeStat = fs.statSync(family.active);
+            const dayDir = path.join(destinationRoot, localDateKey(activeStat.mtime));
+            withDestinationLock(dayDir, () => {
+              const archivePath = path.join(dayDir, `events.${nextArchiveNumber(dayDir)}.jsonl.gz`);
+              fs.writeFileSync(archivePath, gzipSync(fs.readFileSync(family.active)), { mode: FILE_MODE });
+              fs.utimesSync(archivePath, activeStat.atime, activeStat.mtime);
+              fs.truncateSync(family.active, 0);
+            });
+            moved++;
+          }
 
-      for (const archive of currentLegacyArchives) {
-        const source = path.join(userDir, archive.file);
-        const dayDir = path.join(destinationRoot, localDateKey(fs.statSync(source).mtime));
-        withDestinationLock(dayDir, () => {
-          const destination = path.join(dayDir, `events.${nextArchiveNumber(dayDir)}.jsonl.gz`);
-          fs.renameSync(source, destination);
-        });
-        moved++;
-      }
+          for (const archive of family.archives) {
+            const source = path.join(family.dir, archive.file);
+            const dayDir = path.join(destinationRoot, localDateKey(fs.statSync(source).mtime));
+            withDestinationLock(dayDir, () => {
+              const destination = path.join(dayDir, `events.${nextArchiveNumber(dayDir)}.jsonl.gz`);
+              fs.renameSync(source, destination);
+            });
+            moved++;
+          }
 
-      try {
-        if (fs.existsSync(legacyActive) && fs.statSync(legacyActive).size === 0) fs.unlinkSync(legacyActive);
-      } catch { /* an older process may have reopened it */ }
-      return moved;
+          try {
+            if (fs.existsSync(family.active) && fs.statSync(family.active).size === 0) fs.unlinkSync(family.active);
+          } catch { /* an older process may have reopened it */ }
+        }
+        return moved;
+      });
     });
   } catch {
     // Audit logging must remain fail-soft. Files stay at the legacy path and a

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -15,7 +15,7 @@ import { parseTimeout } from './routines.js';
 import { getBinaryPath, getVersionHomePath, isVersionInstalled, resolveVersion } from './versions.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
 import { isTierToken, resolveTier } from './model-tiers.js';
-import { emitStart, maybeRotate, createTimer, redactPrompt, redactArgs } from './events.js';
+import { emitStart, createTimer, redactPrompt, redactArgs } from './events.js';
 import { sanitizeProcessEnv } from './secrets/bundles.js';
 import { resolveActor, actorEnv } from './actor.js';
 import { getShimsDir, getHistoryDir, getUserAgentsDir } from './state.js';
@@ -1622,7 +1622,6 @@ async function spawnAgent(options: ExecOptions): Promise<SpawnResult> {
   options = { ...options, env: { ...options.env, AGENT_LAUNCH_ID: launchId } };
   const watcherState = await setupBudgetWatcher(options, cwd, runId);
 
-  maybeRotate();
   const timer = createTimer('agent.run', {
     agent: options.agent,
     version: options.version,

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -920,7 +920,6 @@ function migrateRuntimeToHistory(): void {
   moveDirOnce(path.join(USER_DIR, '.backups'), path.join(HISTORY_DIR, 'backups'));
   moveDirOnce(path.join(USER_DIR, 'routines', 'runs'), path.join(HISTORY_DIR, 'runs'));
   moveDirOnce(path.join(USER_DIR, 'teams', 'agents'), path.join(HISTORY_DIR, 'teams', 'agents'));
-  migrateEventLogsToHistory();
 
   // Drop any empty leftover skeletons created mid-rename (e.g. `versions/<agent>/<v>/home/`
   // recreated by a concurrent process). The real data is already under .history/.
@@ -933,62 +932,6 @@ function migrateRuntimeToHistory(): void {
     try {
       if (fs.statSync(oldSessionsDb).size === 0) fs.unlinkSync(oldSessionsDb);
     } catch { /* best-effort */ }
-  }
-}
-
-/** Move the operational event stream out of the git-backed user-repo root. */
-function migrateEventLogsToHistory(): void {
-  const destination = path.join(HISTORY_DIR, 'events');
-  let files: string[] = [];
-  try {
-    files = fs.readdirSync(USER_DIR).filter((file) =>
-      file === 'events.jsonl' || /^events\.\d+\.jsonl\.gz$/.test(file)
-    );
-  } catch {
-    return;
-  }
-  try { fs.mkdirSync(destination, { recursive: true, mode: 0o700 }); } catch { return; }
-
-  const active = files.find((file) => file === 'events.jsonl');
-  if (active) {
-    const src = path.join(USER_DIR, active);
-    const dest = path.join(destination, active);
-    if (!fs.existsSync(dest)) {
-      moveFileOnce(src, dest);
-    } else {
-      try {
-        const lines = [fs.readFileSync(src, 'utf-8'), fs.readFileSync(dest, 'utf-8')]
-          .flatMap((content) => content.split('\n').filter(Boolean))
-          .map((line, index) => {
-            try {
-              const timestamp = Date.parse((JSON.parse(line) as { ts?: string }).ts ?? '');
-              return { line, index, timestamp: Number.isNaN(timestamp) ? Number.MAX_SAFE_INTEGER : timestamp };
-            } catch {
-              return { line, index, timestamp: Number.MAX_SAFE_INTEGER };
-            }
-          })
-          .sort((a, b) => a.timestamp - b.timestamp || a.index - b.index)
-          .map(({ line }) => line);
-        atomicWriteFileSync(dest, `${lines.join('\n')}\n`, { mode: 0o600 });
-        fs.unlinkSync(src);
-      } catch { /* preserve the source for a later retry */ }
-    }
-  }
-
-  const archives = files
-    .map((file) => ({ file, match: file.match(/^events\.(\d+)\.jsonl\.gz$/) }))
-    .filter((entry): entry is { file: string; match: RegExpMatchArray } => entry.match !== null)
-    .sort((a, b) => Number(a.match[1]) - Number(b.match[1]));
-  let nextArchive = fs.readdirSync(destination).reduce((max, file) => {
-    const match = file.match(/^events\.(\d+)\.jsonl\.gz$/);
-    return match ? Math.max(max, Number(match[1])) : max;
-  }, 0) + 1;
-  for (const archive of archives) {
-    const preferred = path.join(destination, archive.file);
-    const dest = fs.existsSync(preferred)
-      ? path.join(destination, `events.${nextArchive++}.jsonl.gz`)
-      : preferred;
-    moveFileOnce(path.join(USER_DIR, archive.file), dest);
   }
 }
 

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -34,7 +34,7 @@ import { getRunsDir } from './state.js';
 import type { AgentId } from './types.js';
 import { prepareJobHome, buildSpawnEnv, getJobHomePath } from './sandbox.js';
 import { resolveModel, buildReasoningFlags } from './models.js';
-import { createTimer, maybeRotate, redactPrompt } from './events.js';
+import { createTimer, redactPrompt } from './events.js';
 import {
   normalizeMode,
   resolveHeadlessMode,
@@ -801,8 +801,6 @@ export async function executeJob(config: JobConfig, deps?: LoopDeps): Promise<Ru
   if (config.command) {
     return executeCommandJobForeground(config);
   }
-
-  maybeRotate();
 
   const launch = await resolveRoutineLaunch(config);
   const primaryVersion = launch.chain[0]?.version ?? config.version;

--- a/apps/cli/src/lib/secrets/audit.ts
+++ b/apps/cli/src/lib/secrets/audit.ts
@@ -4,7 +4,7 @@
  * This is the ONE write path for secret events. Every path that creates,
  * imports, exports, views, reads a VALUE from, or unlocks a bundle funnels its
  * audit through here, so the operational event stream — `agents events`, backed
- * by the append-only `~/.agents/.history/events/events.jsonl` audit log — carries a uniform,
+ * by the dated append-only `~/.agents/.history/events/` audit log — carries a uniform,
  * value-free provenance record: bundle, key NAMES, the resolving agent/harness
  * identity, operation, source, status. The ts / host / session / caller fields
  * are filled in by `emit()` itself. The secret VALUE is never part of the

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -412,7 +412,7 @@ export function getUserSecretsDir(): string { return USER_SECRETS_DIR; }
  * value-free usage telemetry (which bundle was created/imported/exported/viewed/
  * accessed/unlocked, when, by whom), never a secret value. It is a derived index
  * fed FROM the emitSecretAudit chokepoint alongside the append-only
- * ~/.agents/.history/events/events.jsonl audit log — the same way sessions.db indexes session
+ * ~/.agents/.history/events/YYYY-MM-DD audit log — the same way sessions.db indexes session
  * metadata off the real session flow — not a second write path.
  */
 export function getSecretsDbPath(): string {

--- a/apps/cli/tests/events-audit.test.ts
+++ b/apps/cli/tests/events-audit.test.ts
@@ -46,9 +46,15 @@ function runCli(home: string, args: string[], extraEnv: Record<string, string> =
   });
 }
 
+function currentEventsPath(home: string): string {
+  const now = new Date();
+  const day = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  return path.join(home, '.agents', '.history', 'events', day, 'events.jsonl');
+}
+
 /** Read every event record written to the canonical log under a temp HOME. */
 function readEvents(home: string): Array<Record<string, unknown>> {
-  const eventsPath = path.join(home, '.agents', '.history', 'events', 'events.jsonl');
+  const eventsPath = currentEventsPath(home);
   if (!fs.existsSync(eventsPath)) return [];
   const out: Array<Record<string, unknown>> = [];
   for (const line of fs.readFileSync(eventsPath, 'utf-8').split('\n').filter(Boolean)) {
@@ -136,7 +142,7 @@ describe('audit event log', () => {
     // the invocation; the token-shaped positional must be masked, not stored.
     runCli(home, ['secrets', 'get', 'ghp_FAKETOKENVALUE123'], { SSH_CONNECTION: '' });
 
-    const raw = fs.readFileSync(path.join(home, '.agents', '.history', 'events', 'events.jsonl'), 'utf-8');
+    const raw = fs.readFileSync(currentEventsPath(home), 'utf-8');
     expect(raw).not.toContain('ghp_FAKETOKENVALUE123');
     expect(raw).toContain('[REDACTED]');
   });

--- a/apps/cli/tests/events-limit.test.ts
+++ b/apps/cli/tests/events-limit.test.ts
@@ -47,7 +47,9 @@ const ALPHA = 55;
 const BETA = 45;
 
 function seedEvents(home: string): void {
-  const file = path.join(home, '.agents', 'events.jsonl');
+  const now = new Date();
+  const day = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const file = path.join(home, '.agents', '.history', 'events', day, 'events.jsonl');
   fs.mkdirSync(path.dirname(file), { recursive: true });
   const base = Date.now() - 6 * 60 * 60 * 1000;
   const lines: string[] = [];

--- a/apps/cli/tests/teams-events.test.ts
+++ b/apps/cli/tests/teams-events.test.ts
@@ -43,14 +43,18 @@ function runCli(home: string, args: string[]) {
 }
 
 function readEvents(home: string): Array<Record<string, unknown>> {
-  const eventsPath = path.join(home, '.agents', '.history', 'events', 'events.jsonl');
-  if (!fs.existsSync(eventsPath)) return [];
+  const eventsRoot = path.join(home, '.agents', '.history', 'events');
+  if (!fs.existsSync(eventsRoot)) return [];
   const out: Array<Record<string, unknown>> = [];
-  for (const line of fs.readFileSync(eventsPath, 'utf-8').split('\n').filter(Boolean)) {
-    try {
-      out.push(JSON.parse(line));
-    } catch {
-      /* skip */
+  for (const day of fs.readdirSync(eventsRoot)) {
+    const eventsPath = path.join(eventsRoot, day, 'events.jsonl');
+    if (!fs.existsSync(eventsPath)) continue;
+    for (const line of fs.readFileSync(eventsPath, 'utf-8').split('\n').filter(Boolean)) {
+      try {
+        out.push(JSON.parse(line));
+      } catch {
+        /* skip */
+      }
     }
   }
   return out;


### PR DESCRIPTION
Extends #2003 with the complete event-storage and command-consolidation contract. This replaces #2010 on a fresh `main` base after that PR conflicted with concurrently merged state serialization work.

## What changed

- Stores operational events under `~/.agents/.history/events/YYYY-MM-DD/events.jsonl`.
- Migrates root `events.jsonl` and numbered gzip archives into date directories without dropping records.
- Applies automatic retention at the canonical emitter: 7 days and 50 MiB total.
- Adds `agents logs rotate --max-mb <n>`; age pruning runs before size pruning and reports rule counts plus reclaimed bytes.
- Makes `agents logs audit` a compatibility alias over the same option registration, query, rendering, JSON, and follow implementation as `agents events --audit`.
- Keeps `AGENTS_EVENTS_PATH` as an exact-path test/embedding override.

## Verification

No UI surface: this changes CLI output and machine-local filesystem layout. The captured built-CLI run and full-suite result are at `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/event-log-built-cli-run.txt` (`agents share` was unavailable because its credential bundle is locked on this host).

Full remote suite:

```text
Test Files  692 passed | 5 skipped (697)
Tests       9453 passed | 98 skipped (9551)
exit=0
```

Built CLI demonstration against an isolated HOME:

```text
layout:
/.agents/.history/events/2026-08-03/events.1.jsonl.gz
/.agents/.history/events/2026-08-04/events.1.jsonl.gz
/.agents/.history/events/2026-08-05/events.jsonl
legacy_root_remaining=0
alias_equal=true audit_records=1
No event files removed (retention 7 days, ceiling 50 MiB).
```

Also passed the focused event, audit, alias, browser-emitter, team-lifecycle, build, docs, and changelog gates.

## Context

No tracker was available on the working host. Session transcript omitted because this is a public repository.
