### PR TITLE
feat: add direct live session status filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,13 @@ the exception.
   surface but leaves the docs describing the old behavior, and flag examples/command names
   in docs that the change has made stale. Exempt: pure internal refactors, test-only
   changes, self-evident renames.
+- **Core command groups stay in sync with fleet guidance.** A change to a core
+  group such as `sessions`, `devices`, `teams`, `run`, `secrets`, or `browser`
+  MUST audit the hooks, skills, commands, and rules in the companion
+  `phnx-labs/.agents-system` repo that invoke or teach that group. Land the
+  relevant companion edits in the same delivery and link both PRs; when the
+  audit finds no consumer, state that explicitly in the agents-cli PR. A CLI
+  surface is incomplete while the fleet guidance still teaches its old shape.
 - **README / feature list for core features.** A new core capability (a new top-level
   command or a substantial subsystem) updates the README and any feature/command index so
   it's discoverable — shipping it code-only, invisible to users, is incomplete.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ Search is the past tense. `--active` is the present -- it infers what each runni
 
 ```bash
 agents sessions --active            # every live run across the fleet, with state
+agents sessions --working           # actively producing work (fleet-wide)
+agents sessions --idle              # stopped between turns (fleet-wide)
+agents sessions --orphan            # agent outlived its terminal client
+agents sessions --crashed           # terminal and agent disappeared uncleanly
 agents sessions focus a1b2c3d4      # jump back into one — attach in place, or resume
 ```
 
@@ -322,7 +326,7 @@ Filters **stack** (they AND together), the active set shows in the header, and t
 | --- | --- |
 | ![sessions browser, preview hidden](assets/demos/sessions-preview-before.png) | ![sessions browser, preview open with a links line](assets/demos/sessions-preview-after.png) |
 
-Each live session resolves to `working`, `waiting_input` (with why -- a question, a plan review, or a permission prompt), or `idle`, alongside badges for the PR it opened, the worktree it sits in, and the ticket it's working. `agents sessions focus [id]` attaches the live pane in place -- the tmux split locally or over SSH, or its Ghostty tab -- and falls back to a fresh tab + resume when the terminal is gone.
+Each live session resolves to `working`, `waiting_input` (with why -- a question, a plan review, or a permission prompt), `idle`, or a lifecycle state such as `orphaned`, `crashed`, `closed`, `abandoned`, `queued`, or `unknown`. Pass the matching flag (`--working`, `--idle`, `--waiting`, `--orphan`, `--crashed`, `--closed`, `--abandoned`, `--queued`, `--unknown`) directly; each implies `--active`, and several flags form a union. The fleet fan-out is already the default; `--local` opts out. `--all` instead widens historical directory and time scope. Rows also carry badges for the PR, worktree, and ticket. `agents sessions focus [id]` attaches the live pane in place -- the tmux split locally or over SSH, or its Ghostty tab -- and falls back to a fresh tab + resume when the terminal is gone.
 
 Landing on a session cold? `agents sessions <id>` prints a catch-up digest: an inferred title, files changed grouped by directory (created / modified / deleted), a histogram of which tools did the work (including parsed Bash commands -- `git`, `npm`, `ffmpeg`, `ssh`, and so on), and the last test verdict -- the signals to reload a task in seconds.
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.22.12
+
+- **`agents sessions` accepts direct live-state flags and remains fleet-wide by default.** `--working`, `--idle`, `--waiting`, `--orphan`/`--orphaned`, `--crashed`, `--closed`, `--abandoned`, `--queued`, and `--unknown` each imply the live scan; multiple flags form a union. `--working` is narrower than `--active`: it excludes idle, waiting, and lifecycle-failure rows. Cross-device collection was already the default and stays that way; `--local` opts out, while `--all` continues to widen historical directory and time scope. Source: `apps/cli/src/commands/sessions.ts`, `apps/cli/src/commands/sessions.test.ts`.
+
 ## 1.22.11
 
 - **`--blocked` iMessage notifications are now phone-actionable.** The forwarded message dropped the block's `--option`s, `--default`, and timeout and instead showed `agents focus <id>` — a CLI command that is useless on a phone. It now shows the choices (`Options: publish / wait`) and the safe-default fallback (`Default in 15 min: wait`) and omits the `agents focus` line, so a `--blocked` post that carries a `--default` self-resolves when the owner can't reply. Source: `apps/cli/src/lib/feed-broadcast.ts`.
@@ -25,7 +29,6 @@
   `apps/cli/src/commands/projects.ts`.
 
 - **`scripts/release.sh` home-base hop: pass a single remote argv to `agents ssh`.** Multi-arg forms (`bash -lc '…'`) are joined without re-quoting by `wrapRemoteCommand`, so the remote `cd` never ran and publish failed with `fatal: not a git repository`. One shell string keeps the command intact. Source: `apps/cli/scripts/release.sh`.
-
 ## 1.22.10
 
 - **Plugins package workflows (Phase 5 packaging slice).** A plugin’s `workflows/<name>/WORKFLOW.md` is discovered and resolved by `agents run <name>` with precedence project > user > plugin > extra > system — no separate install into `~/.agents/workflows/` required. Plugin inventory / resource groups list `workflows`. Source: `apps/cli/src/lib/workflows.ts`, `apps/cli/src/lib/plugins.ts`, `apps/cli/src/lib/resources/workflows.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.22.12
+## 1.22.13
 
 - **`agents sessions` accepts direct live-state flags and remains fleet-wide by default.** `--working`, `--idle`, `--waiting`, `--orphan`/`--orphaned`, `--crashed`, `--closed`, `--abandoned`, `--queued`, and `--unknown` each imply the live scan; multiple flags form a union. `--working` is narrower than `--active`: it excludes idle, waiting, and lifecycle-failure rows. Cross-device collection was already the default and stays that way; `--local` opts out, while `--all` continues to widen historical directory and time scope. Source: `apps/cli/src/commands/sessions.ts`, `apps/cli/src/commands/sessions.test.ts`.
 

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -276,6 +276,16 @@ SSH access (§7); rendering sessions that no harness produced.
   an export bundle or the import mirror (`lib/session/sync/agents.ts` defines
   the `.history/backups/` layout those write into), and any doc claiming
   otherwise is drift.
+- **SES-18c (MUST).** Each user-visible live state MUST have a direct
+  `agents sessions` flag: `working`, `idle`, `waiting`, `orphaned`, `crashed`,
+  `closed`, `abandoned`, `queued`, and `unknown`. These flags MUST imply the live
+  scan, MUST compose as a union, and MUST use the same predicates as the rendered
+  status (`requestedLiveStatuses` / `matchesLiveStatus`,
+  `commands/sessions.ts`; test `commands/sessions.test.ts`). `--orphan` is the
+  human-facing spelling and `--orphaned` remains its accepted alias. The live
+  scan MUST fan out to registered online devices unless `--local` is present;
+  `--all` MUST remain the historical directory/time widening flag, not a device
+  switch.
 - **SES-19 (MUST).** Detach/attach presence MUST be **derived, never asserted**:
   the record only says "this session was detached"; `background` vs `parked` is
   decided live from the recorded pid + start-time fingerprint

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -105,7 +105,7 @@ describe('live session status flags', () => {
               },
             }],
           },
-        }) + '\\n',
+        }) + '\n',
         'utf-8',
       );
       const registry = path.join(tempHome, '.agents', '.cache', 'terminals', 'live-terminals.json');

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -69,7 +69,7 @@ describe('live session status flags', () => {
     const cwd = path.join(tempHome, 'work', 'status-fixture');
     const liveSessionId = 'abcd1111-1111-4111-8111-111111111111';
     const crashedSessionId = 'abcd2222-2222-4222-8222-222222222222';
-    const sleeper = spawn('sleep', ['30'], { stdio: 'ignore' });
+    const sleeper = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30_000)'], { stdio: 'ignore' });
     try {
       writeUpdateCache(tempHome);
       const projectKey = cwd.replace(/[/.]/g, '-');
@@ -81,14 +81,41 @@ describe('live session status flags', () => {
         'Waiting for the user to choose',
         new Date(Date.now() - 15 * 60_000).toISOString(),
       );
+      fs.appendFileSync(
+        path.join(tempHome, '.claude', 'projects', projectKey, `${liveSessionId}.jsonl`),
+        JSON.stringify({
+          type: 'assistant',
+          timestamp: new Date(Date.now() - 15 * 60_000).toISOString(),
+          sessionId: liveSessionId,
+          message: {
+            role: 'assistant',
+            content: [{
+              type: 'tool_use',
+              id: 'ask-status-filter',
+              name: 'AskUserQuestion',
+              input: {
+                questions: [{
+                  question: 'Choose the next step',
+                  header: 'Scope',
+                  options: [
+                    { label: 'Continue', description: 'Keep working' },
+                    { label: 'Stop', description: 'End the session' },
+                  ],
+                }],
+              },
+            }],
+          },
+        }) + '\\n',
+        'utf-8',
+      );
       const registry = path.join(tempHome, '.agents', '.cache', 'terminals', 'live-terminals.json');
       fs.mkdirSync(path.dirname(registry), { recursive: true });
       fs.writeFileSync(registry, JSON.stringify({
         'stale-window': {
           at: new Date(Date.now() - 11 * 60_000).toISOString(),
           entries: [
-            { sessionId: liveSessionId, pid: sleeper.pid, kind: 'claude', cwd },
-            { sessionId: crashedSessionId, pid: 2_000_000_003, kind: 'claude', cwd },
+            { sessionId: liveSessionId, pid: sleeper.pid, kind: 'claude', cwd, startedAtMs: Date.now() },
+            { sessionId: crashedSessionId, pid: 2_000_000_003, kind: 'claude', cwd, startedAtMs: Date.now() },
           ],
         },
       }));
@@ -429,7 +456,7 @@ exit 1
 }
 
 function runAgents(args: string[], cwd: string, home: string, envOverrides: Record<string, string> = {}) {
-  return spawnSync(process.execPath, ['--import', tsxLoaderUrl, cliEntry, ...args], {
+  return spawnSync('node', ['--import', tsxLoaderUrl, cliEntry, ...args], {
     cwd,
     env: {
       ...process.env,

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -18,12 +18,15 @@ import {
   toolOriginSessions,
   toolSearchFleetSortError,
   toolSearchForwardedArgs,
+  matchesLiveStatus,
+  requestedLiveStatuses,
 } from './sessions.js';
 import { remoteAgentsJsonCommand } from '../lib/remote-agents-json.js';
 import { NO_FANOUT_ENV } from '../lib/session/remote-active.js';
 import { parseRemoteList } from '../lib/session/remote-list.js';
 import { needsWindowsShell, composeWin32CommandLine } from '../lib/platform/index.js';
 import type { SessionMeta } from '../lib/session/types.js';
+import type { ActiveSession } from '../lib/session/active.js';
 
 const repoRoot = process.cwd();
 const cliEntry = path.join(repoRoot, 'src', 'index.ts');
@@ -34,6 +37,33 @@ const cliEntry = path.join(repoRoot, 'src', 'index.ts');
 // problem and shell:true arg-concatenation (which would split multi-word query
 // args like "prompt text").
 const tsxLoaderUrl = pathToFileURL(createRequire(import.meta.url).resolve('tsx')).href;
+
+describe('live session status flags', () => {
+  const row = (over: Partial<ActiveSession>): ActiveSession => ({
+    context: 'terminal', kind: 'codex', status: 'running', ...over,
+  });
+
+  it('maps every convenience flag and deduplicates --orphan/--orphaned', () => {
+    expect(requestedLiveStatuses({
+      working: true, idle: true, waiting: true, orphan: true, orphaned: true,
+      crashed: true, closed: true, abandoned: true, queued: true, unknown: true,
+    })).toEqual([
+      'working', 'idle', 'waiting', 'orphaned', 'crashed', 'closed', 'abandoned', 'queued', 'unknown',
+    ]);
+  });
+
+  it('distinguishes working from idle and waiting activity', () => {
+    expect(matchesLiveStatus(row({ activity: 'working' }), 'working')).toBe(true);
+    expect(matchesLiveStatus(row({ status: 'idle', activity: 'idle' }), 'working')).toBe(false);
+    expect(matchesLiveStatus(row({ status: 'input_required', activity: 'waiting_input' }), 'waiting')).toBe(true);
+  });
+
+  it('matches lifecycle states exactly', () => {
+    for (const status of ['idle', 'orphaned', 'crashed', 'closed', 'abandoned', 'queued', 'unknown'] as const) {
+      expect(matchesLiveStatus(row({ status }), status)).toBe(true);
+    }
+  });
+});
 
 describe('toolSearchForwardedArgs', () => {
   it('removes coordinator device flags and forces a whole-index local peer query', () => {

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -63,6 +63,57 @@ describe('live session status flags', () => {
       expect(matchesLiveStatus(row({ status }), status)).toBe(true);
     }
   });
+
+  it('routes aliases, unions, and the waiting exit gate through the real CLI', () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-status-flags-'));
+    const cwd = path.join(tempHome, 'work', 'status-fixture');
+    const liveSessionId = 'abcd1111-1111-4111-8111-111111111111';
+    const crashedSessionId = 'abcd2222-2222-4222-8222-222222222222';
+    const sleeper = spawn('sleep', ['30'], { stdio: 'ignore' });
+    try {
+      writeUpdateCache(tempHome);
+      const projectKey = cwd.replace(/[/.]/g, '-');
+      writeClaudeSession(
+        tempHome,
+        projectKey,
+        liveSessionId,
+        cwd,
+        'Waiting for the user to choose',
+        new Date(Date.now() - 15 * 60_000).toISOString(),
+      );
+      const registry = path.join(tempHome, '.agents', '.cache', 'terminals', 'live-terminals.json');
+      fs.mkdirSync(path.dirname(registry), { recursive: true });
+      fs.writeFileSync(registry, JSON.stringify({
+        'stale-window': {
+          at: new Date(Date.now() - 11 * 60_000).toISOString(),
+          entries: [
+            { sessionId: liveSessionId, pid: sleeper.pid, kind: 'claude', cwd },
+            { sessionId: crashedSessionId, pid: 2_000_000_003, kind: 'claude', cwd },
+          ],
+        },
+      }));
+
+      const orphan = runAgents(['sessions', '--orphan', '--json', '--local'], cwd, tempHome);
+      const orphaned = runAgents(['sessions', '--orphaned', '--json', '--local'], cwd, tempHome);
+      expect(orphan.status, orphan.stderr).toBe(0);
+      expect(orphaned.status, orphaned.stderr).toBe(0);
+      expect(JSON.parse(orphan.stdout).map((row: ActiveSession) => row.sessionId)).toContain(liveSessionId);
+      expect(JSON.parse(orphaned.stdout)).toEqual(JSON.parse(orphan.stdout));
+
+      const union = runAgents(['sessions', '--orphan', '--crashed', '--json', '--local'], cwd, tempHome);
+      expect(union.status, union.stderr).toBe(0);
+      const unionIds = JSON.parse(union.stdout).map((row: ActiveSession) => row.sessionId);
+      expect(unionIds).toContain(liveSessionId);
+      expect(unionIds).toContain(crashedSessionId);
+
+      const waitingUnion = runAgents(['sessions', '--waiting', '--orphan', '--json', '--local'], cwd, tempHome);
+      expect(waitingUnion.status).toBe(1);
+      expect(JSON.parse(waitingUnion.stdout).map((row: ActiveSession) => row.sessionId)).toContain(liveSessionId);
+    } finally {
+      sleeper.kill('SIGTERM');
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('toolSearchForwardedArgs', () => {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -133,6 +133,16 @@ interface SessionsOptions extends SessionFilterOptions {
   flat?: boolean;
   /** With --active: show only sessions waiting on user input; exit 1 if any. */
   waiting?: boolean;
+  /** Live-state shorthand filters. Any one implies --active; several compose as OR. */
+  working?: boolean;
+  idle?: boolean;
+  orphan?: boolean;
+  orphaned?: boolean;
+  crashed?: boolean;
+  closed?: boolean;
+  abandoned?: boolean;
+  queued?: boolean;
+  unknown?: boolean;
   /** Show only favorited (starred) sessions — the `f` key's flag twin. */
   favorites?: boolean;
   /** Enrich the listing with live glyphs/preview for running rows. Default on;
@@ -1226,7 +1236,7 @@ export async function gatherActiveSessions(
 async function renderActiveSessions(
   asJson: boolean,
   waitingOnly = false,
-  opts: { local?: boolean; hosts?: string[]; favoritesOnly?: boolean } = {},
+  opts: { local?: boolean; hosts?: string[]; favoritesOnly?: boolean; statuses?: LiveStatusFilter[] } = {},
 ): Promise<void> {
   const self = machineId();
   const gathered = await gatherActiveSessions(opts);
@@ -1240,9 +1250,12 @@ async function renderActiveSessions(
     ? gathered.sessions.filter((s) => !!s.sessionId && listFavorites().has(s.sessionId))
     : gathered.sessions;
 
-  // --waiting: only sessions blocked on the user. Exits non-zero when any are
-  // present so a supervising agent or hook can poll it as a gate.
-  const sessions = waitingOnly ? merged.filter(isAwaitingUser) : merged;
+  // Status flags form a union. --waiting additionally retains its scriptable
+  // gate: exit non-zero when the union contains a session awaiting the user.
+  const statusFiltered = opts.statuses?.length
+    ? merged.filter((session) => opts.statuses!.some((status) => matchesLiveStatus(session, status)))
+    : merged;
+  const sessions = statusFiltered;
 
   if (asJson) {
     // Resolve who is watching each local tmux pane before serializing: `viewingIn`
@@ -1251,7 +1264,7 @@ async function renderActiveSessions(
     // scriptable path stays cheap — see enrichTmuxLocators.
     await enrichTmuxLocators(sessions.filter(s => !s.machine || s.machine === self));
     process.stdout.write(JSON.stringify(serializeActiveSessionsForJson(sessions), null, 2) + '\n');
-    if (waitingOnly && sessions.length > 0) process.exitCode = 1;
+    if (waitingOnly && sessions.some(isAwaitingUser)) process.exitCode = 1;
     return;
   }
 
@@ -1288,7 +1301,40 @@ async function renderActiveSessions(
   if (!opts.local && !opts.hosts?.length && remoteDeviceCount === 0) printCrossMachineTip();
 
   // Scriptable gate: a non-zero exit when anything is waiting on the user.
-  if (waitingOnly && sessions.length > 0) process.exitCode = 1;
+  if (waitingOnly && sessions.some(isAwaitingUser)) process.exitCode = 1;
+}
+
+export type LiveStatusFilter =
+  | 'working'
+  | 'idle'
+  | 'waiting'
+  | 'orphaned'
+  | 'crashed'
+  | 'closed'
+  | 'abandoned'
+  | 'queued'
+  | 'unknown';
+
+/** Match the status words users see, preserving activity's richer working signal. */
+export function matchesLiveStatus(session: ActiveSession, status: LiveStatusFilter): boolean {
+  if (status === 'working') return session.activity === 'working' || (!session.activity && session.status === 'running');
+  if (status === 'waiting') return isAwaitingUser(session);
+  return session.status === status;
+}
+
+/** Resolve convenience flags once. Multiple flags intentionally form a union. */
+export function requestedLiveStatuses(options: SessionsOptions): LiveStatusFilter[] {
+  const statuses: LiveStatusFilter[] = [];
+  if (options.working) statuses.push('working');
+  if (options.idle) statuses.push('idle');
+  if (options.waiting) statuses.push('waiting');
+  if (options.orphan || options.orphaned) statuses.push('orphaned');
+  if (options.crashed) statuses.push('crashed');
+  if (options.closed) statuses.push('closed');
+  if (options.abandoned) statuses.push('abandoned');
+  if (options.queued) statuses.push('queued');
+  if (options.unknown) statuses.push('unknown');
+  return [...new Set(statuses)];
 }
 
 /** Nudge shown when `--active` has no other machines to fold in. */
@@ -1368,6 +1414,14 @@ export function hasNoBrowserDisqualifyingFlags(
 function canonicalSessionsCommand(query: string | undefined, options: SessionsOptions): string {
   const a = ['sessions'];
   if (options.active) a.push('--active');
+  if (options.working) a.push('--working');
+  if (options.idle) a.push('--idle');
+  if (options.orphan || options.orphaned) a.push('--orphan');
+  if (options.crashed) a.push('--crashed');
+  if (options.closed) a.push('--closed');
+  if (options.abandoned) a.push('--abandoned');
+  if (options.queued) a.push('--queued');
+  if (options.unknown) a.push('--unknown');
   if (options.teams) a.push('--teams');
   if (options.inTeam) a.push('--in-team', options.inTeam);
   if (options.routine) a.push('--routine');
@@ -1604,6 +1658,8 @@ async function sessionsAction(
   limitSource?: string
 ): Promise<void> {
   const queryClauses = options.query ?? [];
+  const liveStatuses = requestedLiveStatuses(options);
+  const liveOnly = options.active === true || liveStatuses.length > 0;
   const toolOnly = options.include?.split(',').map((role) => role.trim()).filter(Boolean).join(',') === 'tools';
   const toolEvidenceMode = toolOnly;
   if (options.count && !toolOnly) {
@@ -1739,7 +1795,7 @@ async function sessionsAction(
   // keeps the legacy per-host stream (each remote's raw stdout under a
   // `── host ──` banner). With --active, the hosts are folded into the merged
   // machine-grouped view instead (handled below).
-  if (options.host && options.host.length > 0 && !options.active && !toolEvidenceMode) {
+  if (options.host && options.host.length > 0 && !liveOnly && !toolEvidenceMode) {
     // --local means "skip the SSH fan-out"; --host means "look only over there".
     // Together they ask for a peer's sessions without dialing the peer, which can
     // only ever be empty — so say that instead of rendering a blank list.
@@ -1782,7 +1838,7 @@ async function sessionsAction(
     return;
   }
 
-  if (options.active) {
+  if (liveOnly) {
     // The running view is built from the live scan, which carries no team lineage
     // (that comes off the transcript index and the teams meta dir), so --in-team
     // has nothing to match on here. Say so rather than ignoring the flag.
@@ -1799,7 +1855,7 @@ async function sessionsAction(
     // multi-host scope fall through to the static dump that already honors them.
     if (
       useInteractiveBrowser(options) &&
-      !options.waiting &&
+      liveStatuses.length === 0 &&
       !options.until &&
       !options.project &&
       !options.sort &&
@@ -1827,6 +1883,7 @@ async function sessionsAction(
       local: forceLocal,
       hosts: options.host,
       favoritesOnly: options.favorites === true,
+      statuses: liveStatuses,
     });
     return;
   }
@@ -4090,7 +4147,16 @@ export function registerSessionsCommands(program: Command): void {
     .option('--active', 'Show only sessions running right now across terminals, teams, cloud, and headless agents')
     .option('--roots', 'With --json: emit the on-disk directories scanned for session transcripts, per agent (for external watchers)')
     .option('--local', 'Only this machine — skip the cross-machine SSH fan-out (default listing and --active)')
-    .option('--waiting', 'With --active: show only sessions waiting on your input (exits non-zero if any)')
+    .option('--working', 'Show live sessions currently doing work (implies --active)')
+    .option('--idle', 'Show live sessions that have stopped between turns (implies --active)')
+    .option('--waiting', 'Show live sessions waiting on your input; exits non-zero if any (implies --active)')
+    .option('--orphan', 'Show live sessions whose process outlived its terminal client (implies --active)')
+    .option('--orphaned', 'Alias for --orphan')
+    .option('--crashed', 'Show sessions whose terminal disappeared with the process (implies --active)')
+    .option('--closed', 'Show recently observed sessions whose process exited normally (implies --active)')
+    .option('--abandoned', 'Show sessions with no transcript progress for the abandonment window (implies --active)')
+    .option('--queued', 'Show queued sessions that have not started running (implies --active)')
+    .option('--unknown', 'Show sessions whose live state cannot be determined (implies --active)')
     .option('--favorites', 'Show only favorited (starred) sessions — star them with `*` in the browser or `agents sessions favorite <id>`')
     .option('--tree', 'Group the listing by directory; drops the id/version columns for readability')
     .option('--flat', 'Plain flat table (one row per session) instead of the grouped project overview')
@@ -4118,6 +4184,12 @@ export function registerSessionsCommands(program: Command): void {
 
       # Show only what's running right now (terminals, teams, cloud, headless)
       agents sessions --active
+
+      # Filter the live fleet by the status word shown in the roster
+      agents sessions --working
+      agents sessions --idle
+      agents sessions --orphan
+      agents sessions --crashed
 
       # --- Session lifecycle (one verb per intent) ---
       # Jump to a live session (attach its terminal, or open a tab + resume)
@@ -4177,7 +4249,8 @@ export function registerSessionsCommands(program: Command): void {
         detach <id>             interactive → headless continuation
         attach <id>             headless → interactive in this terminal
         resume [query]          multi-select history → open tabs (or run --resume <id>)
-      - The interactive listing folds in your other online machines automatically (live over SSH, no sync) — each row is labelled by host, this machine first. Use --local to skip the fan-out; --json and single-id lookups stay local.
+      - The interactive listing and every live-status flag fold in your other online machines automatically (live over SSH, no sync) — each row is labelled by host, this machine first. Use --local to skip the fan-out; single-id lookups stay local.
+      - --all is not a device flag: it widens historical directory and time filters. Fleet collection is already the default. A status flag (--working/--idle/--waiting/--orphan/--crashed/--closed/--abandoned/--queued/--unknown) implies --active; combine status flags for a union.
       - --host runs the query on the remote's own index over SSH (host alias or user@host); repeat or pass several to fan out. SSH access is the only auth.
       - --in-team matches both ends of the lineage: the session that ran 'agents teams create/add', and (with --teams) that team's teammates. In the interactive list, 't' cycles the same filter over the teams in view.
       - --include and --exclude are mutually exclusive.


### PR DESCRIPTION
Adds direct fleet-wide filters for every live session state. Replaces conflicted PR #2013 on the latest `main`.

## What changed

- `--working`, `--idle`, `--waiting`, `--orphan`/`--orphaned`, `--crashed`, `--closed`, `--abandoned`, `--queued`, and `--unknown` each imply the live scan
- multiple status flags form a union
- `--working` remains narrower than `--active`
- cross-device collection remains the default; `--local` opts out and `--all` retains its historical directory/time meaning
- adds the repo rule requiring core command changes to audit and update system hooks/skills/commands/rules

## Run result

![Focused tests and real idle/working JSON assertions](https://share.agents-cli.sh/muqsitnawaz/agents-cli-test-freeze-b4d0d09c676f7d49)

[Raw terminal run asset](https://share.agents-cli.sh/muqsitnawaz/sessions-status-filters-sessions-status-filters-54d788050ac32d33)

- TypeScript build: passed on current `main`
- focused regression tests: 3 passed, 0 failed on current `main`
- real local live scan: idle predicate `true`; working predicate `true`
- full crabbox suite passed after invoking the package from `apps/cli`
- no graphical UI surface

## Tracking

Closes #2009.
Companion system guidance: https://github.com/phnx-labs/.agents-system/pull/179