### PR TITLE
feat(cli): humans.yaml owner config, migrate notify.owner, fix perms/memory/migrate/webhooks (#2006)

### DIFF
--- a/apps/cli/.changelog/next/issue-2006.md
+++ b/apps/cli/.changelog/next/issue-2006.md
@@ -1,0 +1,11 @@
+- **`agents humans show owner [--json]`** — new command to display the owner config from `~/.agents/humans.yaml`. The file is written automatically on first run when `notify.owner` exists in `agents.yaml`. Source: `apps/cli/src/lib/humans.ts`, `apps/cli/src/commands/humans.ts`.
+
+- **`humans.yaml` — typed, versioned owner config.** `~/.agents/humans.yaml` (`version: 1`) now stores owner identity (name, timezone, quiet hours, severity), notification channels, and escalation policy. `notify.owner` in `agents.yaml` is migrated into it on first run and the `notify.owner` key is removed from `agents.yaml`; unrelated keys are preserved. `agents send --to owner` / `agents notify` prefer `humans.yaml` with a fallback to `agents.yaml` during the migration window. Source: `apps/cli/src/lib/humans.ts`, `apps/cli/src/commands/humans.ts`, `apps/cli/src/lib/migrate.ts`.
+
+- **`agents memory` ignores `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `MEMORY.md`.** These rule/index files lived in `~/.agents/memory/` but were incorrectly surfaced as memory facts. `isFactFile()` now excludes them by name (case-insensitive). Source: `apps/cli/src/lib/memory.ts`.
+
+- **Permissions write path fixed — `groups/` subdirectory.** `installPermissionSet`, `removePermissionSet`, and `savePermissionSet` now all write to the `groups/` subdirectory (matching `discoverPermissionGroups()` which already reads from `groups/`). Source: `apps/cli/src/lib/permissions.ts`.
+
+- **Stop eagerly creating webhooks directories.** `ensureAgentsDir()` no longer creates `~/.agents/webhooks/` or `~/.agents/.system/webhooks/` on startup — both dirs are created on first actual use. Source: `apps/cli/src/lib/state.ts`.
+
+- **Terminals canonically under `.cache/`.** The stale migration comment that blocked `terminals/` from moving to `~/.agents/.cache/terminals/` is replaced by the actual move. Factory already writes to `.cache/terminals/` (`foreman.registry.ts:9`), so no app-level change is needed. Source: `apps/cli/src/lib/migrate.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **`agents humans show owner [--json]`** — new command to display the owner config from `~/.agents/humans.yaml`. The file is written automatically on first run when `notify.owner` exists in `agents.yaml` or when `owner.md` carries YAML frontmatter.
-
-- **`humans.yaml` — typed, versioned owner config.** `~/.agents/humans.yaml` (`version: 1`) now stores owner identity (name, timezone, quiet hours, severity), notification channels, and escalation policy. `notify.owner` in `agents.yaml` and `owner.md` frontmatter are both migrated into it on first run and removed. `agents send --to owner` / `agents notify` prefer this file with a fallback to `agents.yaml` during the migration window. Source: `apps/cli/src/lib/humans.ts`, `apps/cli/src/commands/humans.ts`, `apps/cli/src/lib/migrate.ts`.
-
-- **`agents memory` ignores `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `MEMORY.md`.** These rule/index files lived in `~/.agents/memory/` but were incorrectly surfaced as memory facts. `isFactFile()` now excludes them by name (case-insensitive). Source: `apps/cli/src/lib/memory.ts`.
-
-- **Permissions write path fixed — `groups/` subdirectory.** `installPermissionSet`, `removePermissionSet`, and `savePermissionSet` now all write to the `groups/` subdirectory (matching `discoverPermissionGroups()` which already reads from `groups/`). Source: `apps/cli/src/lib/permissions.ts`.
-
-- **Stop eagerly creating webhooks directories.** `ensureAgentsDir()` no longer creates `~/.agents/webhooks/` or `~/.agents/.system/webhooks/` on startup — both dirs are created on first actual use. Source: `apps/cli/src/lib/state.ts`.
-
-- **Terminals canonically under `.cache/`.** The stale migration comment that blocked `terminals/` from moving to `~/.agents/.cache/terminals/` is replaced by the actual move. Factory already writes to `.cache/terminals/` (`foreman.registry.ts:9`), so no app-level change is needed. Source: `apps/cli/src/lib/migrate.ts`.
-
 ## 1.22.11
 
 - **`--blocked` iMessage notifications are now phone-actionable.** The forwarded message dropped the block's `--option`s, `--default`, and timeout and instead showed `agents focus <id>` — a CLI command that is useless on a phone. It now shows the choices (`Options: publish / wait`) and the safe-default fallback (`Default in 15 min: wait`) and omits the `agents focus` line, so a `--blocked` post that carries a `--default` self-resolves when the owner can't reply. Source: `apps/cli/src/lib/feed-broadcast.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- **`agents humans show owner [--json]`** — new command to display the owner config from `~/.agents/humans.yaml`. The file is written automatically on first run when `notify.owner` exists in `agents.yaml` or when `owner.md` carries YAML frontmatter.
+
+- **`humans.yaml` — typed, versioned owner config.** `~/.agents/humans.yaml` (`version: 1`) now stores owner identity (name, timezone, quiet hours, severity), notification channels, and escalation policy. `notify.owner` in `agents.yaml` and `owner.md` frontmatter are both migrated into it on first run and removed. `agents send --to owner` / `agents notify` prefer this file with a fallback to `agents.yaml` during the migration window. Source: `apps/cli/src/lib/humans.ts`, `apps/cli/src/commands/humans.ts`, `apps/cli/src/lib/migrate.ts`.
+
+- **`agents memory` ignores `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `MEMORY.md`.** These rule/index files lived in `~/.agents/memory/` but were incorrectly surfaced as memory facts. `isFactFile()` now excludes them by name (case-insensitive). Source: `apps/cli/src/lib/memory.ts`.
+
+- **Permissions write path fixed — `groups/` subdirectory.** `installPermissionSet`, `removePermissionSet`, and `savePermissionSet` now all write to the `groups/` subdirectory (matching `discoverPermissionGroups()` which already reads from `groups/`). Source: `apps/cli/src/lib/permissions.ts`.
+
+- **Stop eagerly creating webhooks directories.** `ensureAgentsDir()` no longer creates `~/.agents/webhooks/` or `~/.agents/.system/webhooks/` on startup — both dirs are created on first actual use. Source: `apps/cli/src/lib/state.ts`.
+
+- **Terminals canonically under `.cache/`.** The stale migration comment that blocked `terminals/` from moving to `~/.agents/.cache/terminals/` is replaced by the actual move. Factory already writes to `.cache/terminals/` (`foreman.registry.ts:9`), so no app-level change is needed. Source: `apps/cli/src/lib/migrate.ts`.
+
 ## 1.22.11
 
 - **`--blocked` iMessage notifications are now phone-actionable.** The forwarded message dropped the block's `--option`s, `--default`, and timeout and instead showed `agents focus <id>` — a CLI command that is useless on a phone. It now shows the choices (`Options: publish / wait`) and the safe-default fallback (`Default in 15 min: wait`) and omits the `agents focus` line, so a `--blocked` post that carries a `--default` self-resolves when the owner can't reply. Source: `apps/cli/src/lib/feed-broadcast.ts`.

--- a/apps/cli/src/commands/humans.ts
+++ b/apps/cli/src/commands/humans.ts
@@ -1,0 +1,93 @@
+/**
+ * `agents humans` — owner identity and notification channel management.
+ *
+ * Reads from ~/.agents/humans.yaml (created by migration from owner.md and
+ * agents.yaml notify.owner). Provides inspection commands for the current
+ * owner config.
+ */
+
+import type { Command } from 'commander';
+import { setHelpSections } from '../lib/help.js';
+import { readHumans, getOwnerFromHumans } from '../lib/humans.js';
+
+/** Register the `agents humans` command tree. */
+export function registerHumansCommands(program: Command): void {
+  const humansCmd = program
+    .command('humans')
+    .description('Inspect owner identity and notification channel config (humans.yaml)');
+
+  setHelpSections(humansCmd, {
+    examples: `
+      # Show owner identity and channel config as JSON
+      agents humans show owner --json
+
+      # Show owner identity in human-readable form
+      agents humans show owner
+    `,
+    notes: `
+      humans.yaml is the canonical owner identity file at ~/.agents/humans.yaml.
+      It is populated by migrating notify.owner from agents.yaml and frontmatter
+      from owner.md. Use \`agents humans show owner\` to inspect the current config.
+    `,
+  });
+
+  const showCmd = humansCmd
+    .command('show')
+    .description('Show config from humans.yaml');
+
+  setHelpSections(showCmd, {
+    examples: `
+      agents humans show owner
+      agents humans show owner --json
+    `,
+  });
+
+  showCmd
+    .command('owner')
+    .description('Show the configured owner identity and notification channels')
+    .option('--json', 'Output as JSON')
+    .action((opts: { json?: boolean }) => {
+      const humans = readHumans();
+      if (!humans) {
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(null) + '\n');
+        } else {
+          process.stderr.write('humans.yaml not found — run `agents` once to trigger migration\n');
+          process.exitCode = 1;
+        }
+        return;
+      }
+
+      const owner = getOwnerFromHumans();
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(owner ?? null, null, 2) + '\n');
+      } else {
+        if (!owner) {
+          process.stdout.write('No owner configured in humans.yaml\n');
+          return;
+        }
+        if (owner.name) process.stdout.write(`Name:     ${owner.name}\n`);
+        if (owner.timezone) process.stdout.write(`Timezone: ${owner.timezone}\n`);
+        if (owner.quiet_hours) process.stdout.write(`Quiet:    ${owner.quiet_hours}\n`);
+        if (owner.default_severity) process.stdout.write(`Severity: ${owner.default_severity}\n`);
+        if (owner.notify) {
+          process.stdout.write(`Notify:   channel=${owner.notify.channel} to=${owner.notify.to}\n`);
+        }
+        if (owner.channels?.length) {
+          process.stdout.write(`Channels:\n`);
+          for (const ch of owner.channels) {
+            const extra = [ch.transport, ch.intrusive ? 'intrusive' : null].filter(Boolean).join(', ');
+            process.stdout.write(`  - ${ch.id}${extra ? ` (${extra})` : ''}\n`);
+          }
+        }
+        if (owner.policy) {
+          process.stdout.write(`Policy:\n`);
+          for (const [sev, channels] of Object.entries(owner.policy)) {
+            if (Array.isArray(channels) && channels.length) {
+              process.stdout.write(`  ${sev}: ${channels.join(', ')}\n`);
+            }
+          }
+        }
+      }
+    });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1353,7 +1353,7 @@ if (process.env.AGENTS_SKIP_MIGRATION !== '1') {
     // Bumping the suffix re-runs migrations for every user; binary releases that
     // don't change the schema must NOT re-run (they would destroy user content
     // when migration steps overlap with user-authored paths). See issue #20.
-    const sentinelValue = 'v14';
+    const sentinelValue = 'v15';
     let needRun = true;
     try {
       if (fs.existsSync(sentinel) && fs.readFileSync(sentinel, 'utf-8').trim() === sentinelValue) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -189,6 +189,7 @@ import {
   loadAudit,
   loadWebhook,
   loadFunnel,
+  loadHumans,
   loadSsh,
   loadPull,
   loadPush,
@@ -1135,6 +1136,7 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadAudit);
   await reg(loadWebhook);
   await reg(loadFunnel);
+  await reg(loadHumans);
   registerHqTombstoneCommand(program);
   await reg(loadFeed);
   await reg(loadMailboxes);

--- a/apps/cli/src/lib/__tests__/migrate.test.ts
+++ b/apps/cli/src/lib/__tests__/migrate.test.ts
@@ -530,4 +530,41 @@ describe('runMigration', () => {
       expect(fs.readFileSync(path.join(cachedPlugin, 'OLD.md'), 'utf-8')).toBe('cached-only');
     });
   });
+
+  describe('migrateHumans', () => {
+    it('migrates owner.md with metadata-only fields (no name, no notify.owner) into humans.yaml', () => {
+      // A metadata-only owner.md: timezone + quiet_hours + default_severity, but no name and no
+      // agents.yaml notify.owner. Previously the two-field guard silently skipped this case.
+      const ownerMd = [
+        '---',
+        'timezone: America/New_York',
+        'quiet_hours: "22:00-08:00"',
+        'default_severity: low',
+        '---',
+        '',
+        'Some prose that is not frontmatter.',
+      ].join('\n');
+      fs.writeFileSync(path.join(userDir, 'owner.md'), ownerMd);
+
+      runRealMigration();
+
+      const humansPath = path.join(userDir, 'humans.yaml');
+      expect(fs.existsSync(humansPath)).toBe(true);
+
+      const raw = fs.readFileSync(humansPath, 'utf-8');
+      // Must carry the three metadata fields.
+      expect(raw).toContain('America/New_York');
+      expect(raw).toContain('22:00-08:00');
+      expect(raw).toContain('low');
+    });
+
+    it('does not write humans.yaml when owner.md has no owner fields', () => {
+      // owner.md with prose-only body and no YAML frontmatter at all.
+      fs.writeFileSync(path.join(userDir, 'owner.md'), 'no frontmatter here\n');
+
+      runRealMigration();
+
+      expect(fs.existsSync(path.join(userDir, 'humans.yaml'))).toBe(false);
+    });
+  });
 });

--- a/apps/cli/src/lib/channels/send.test.ts
+++ b/apps/cli/src/lib/channels/send.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Meta } from '../types.js';
 import {
   composeSendText,
@@ -6,6 +6,11 @@ import {
   readOwnerDest,
   resolveSendEnvelope,
 } from './send.js';
+import { getOwnerNotifyFromHumans } from '../humans.js';
+
+vi.mock('../humans.js', () => ({
+  getOwnerNotifyFromHumans: vi.fn(() => null),
+}));
 
 const metaWithOwner = {
   notify: { owner: { channel: 'imessage', to: '+18055550100' } },
@@ -195,5 +200,58 @@ describe('resolveSendEnvelope', () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.envelope.text).toBe('https://x.test');
+  });
+});
+
+describe('owner destination from humans.yaml', () => {
+  afterEach(() => {
+    vi.mocked(getOwnerNotifyFromHumans).mockReturnValue(null);
+  });
+
+  it('readOwnerDest prefers humans.yaml over meta.notify.owner', () => {
+    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    expect(readOwnerDest(metaWithOwner)).toEqual({ channel: 'imessage', to: '+12125550123' });
+  });
+
+  it('readOwnerDest falls back to meta.notify.owner when humans.yaml absent', () => {
+    expect(readOwnerDest(metaWithOwner)).toEqual({ channel: 'imessage', to: '+18055550100' });
+  });
+
+  it('resolveSendEnvelope uses humans.yaml for --to owner with no notify.owner', () => {
+    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    const r = resolveSendEnvelope({ text: 'ping', to: 'owner' }, metaEmpty);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.envelope.channel).toBe('imessage');
+    expect(r.envelope.to).toBe('+12125550123');
+  });
+
+  it('resolveSendEnvelope ownerMode uses humans.yaml with no notify.owner', () => {
+    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    const r = resolveSendEnvelope({ text: 'ping', ownerMode: true }, metaEmpty);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.envelope).toMatchObject({ channel: 'imessage', to: '+12125550123' });
+  });
+
+  it('explicit --channel/--to override humans.yaml', () => {
+    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    const r = resolveSendEnvelope(
+      { text: 'ping', ownerMode: true, channel: 'desktop', to: 'local' },
+      metaEmpty,
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.envelope.channel).toBe('desktop');
+    expect(r.envelope.to).toBe('local');
+  });
+
+  it('humans.yaml takes precedence over meta.notify.owner', () => {
+    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'slack', to: 'U123' });
+    const r = resolveSendEnvelope({ text: 'ping', to: 'owner' }, metaWithOwner);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.envelope.channel).toBe('slack');
+    expect(r.envelope.to).toBe('U123');
   });
 });

--- a/apps/cli/src/lib/channels/send.test.ts
+++ b/apps/cli/src/lib/channels/send.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import type { Meta } from '../types.js';
 import {
   composeSendText,
@@ -6,11 +9,6 @@ import {
   readOwnerDest,
   resolveSendEnvelope,
 } from './send.js';
-import { getOwnerNotifyFromHumans } from '../humans.js';
-
-vi.mock('../humans.js', () => ({
-  getOwnerNotifyFromHumans: vi.fn(() => null),
-}));
 
 const metaWithOwner = {
   notify: { owner: { channel: 'imessage', to: '+18055550100' } },
@@ -204,21 +202,37 @@ describe('resolveSendEnvelope', () => {
 });
 
 describe('owner destination from humans.yaml', () => {
-  afterEach(() => {
-    vi.mocked(getOwnerNotifyFromHumans).mockReturnValue(null);
+  let humansFile: string;
+
+  beforeEach(() => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'send-humans-test-'));
+    humansFile = path.join(tmp, 'humans.yaml');
+    process.env.AGENTS_HUMANS_FILE = humansFile;
   });
 
+  afterEach(() => {
+    delete process.env.AGENTS_HUMANS_FILE;
+  });
+
+  function writeOwnerNotify(channel: string, to: string): void {
+    fs.writeFileSync(
+      humansFile,
+      `version: 1\nowner:\n  notify:\n    channel: ${channel}\n    to: '${to}'\n`,
+    );
+  }
+
   it('readOwnerDest prefers humans.yaml over meta.notify.owner', () => {
-    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    writeOwnerNotify('imessage', '+12125550123');
     expect(readOwnerDest(metaWithOwner)).toEqual({ channel: 'imessage', to: '+12125550123' });
   });
 
   it('readOwnerDest falls back to meta.notify.owner when humans.yaml absent', () => {
+    // humansFile not written — getOwnerNotifyFromHumans() returns null
     expect(readOwnerDest(metaWithOwner)).toEqual({ channel: 'imessage', to: '+18055550100' });
   });
 
   it('resolveSendEnvelope uses humans.yaml for --to owner with no notify.owner', () => {
-    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    writeOwnerNotify('imessage', '+12125550123');
     const r = resolveSendEnvelope({ text: 'ping', to: 'owner' }, metaEmpty);
     expect(r.ok).toBe(true);
     if (!r.ok) return;
@@ -227,7 +241,7 @@ describe('owner destination from humans.yaml', () => {
   });
 
   it('resolveSendEnvelope ownerMode uses humans.yaml with no notify.owner', () => {
-    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    writeOwnerNotify('imessage', '+12125550123');
     const r = resolveSendEnvelope({ text: 'ping', ownerMode: true }, metaEmpty);
     expect(r.ok).toBe(true);
     if (!r.ok) return;
@@ -235,7 +249,7 @@ describe('owner destination from humans.yaml', () => {
   });
 
   it('explicit --channel/--to override humans.yaml', () => {
-    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'imessage', to: '+12125550123' });
+    writeOwnerNotify('imessage', '+12125550123');
     const r = resolveSendEnvelope(
       { text: 'ping', ownerMode: true, channel: 'desktop', to: 'local' },
       metaEmpty,
@@ -247,7 +261,7 @@ describe('owner destination from humans.yaml', () => {
   });
 
   it('humans.yaml takes precedence over meta.notify.owner', () => {
-    vi.mocked(getOwnerNotifyFromHumans).mockReturnValueOnce({ channel: 'slack', to: 'U123' });
+    writeOwnerNotify('slack', 'U123');
     const r = resolveSendEnvelope({ text: 'ping', to: 'owner' }, metaWithOwner);
     expect(r.ok).toBe(true);
     if (!r.ok) return;

--- a/apps/cli/src/lib/channels/send.ts
+++ b/apps/cli/src/lib/channels/send.ts
@@ -9,6 +9,7 @@
  * Agent control (`agents message`, `sessions inject`) stays outside this module.
  */
 import type { Meta } from '../types.js';
+import { getOwnerNotifyFromHumans } from '../humans.js';
 import { registerBuiltinProviders } from './providers/index.js';
 import { resolveTransport } from './resolve.js';
 import type { SendResult } from './registry.js';
@@ -75,8 +76,13 @@ export function composeSendText(text: string, urls?: string[]): string {
   return body ? `${body}\n${extra.join('\n')}` : extra.join('\n');
 }
 
-/** Read notify.owner; null when either field is missing. */
+/**
+ * Read the owner destination; humans.yaml is the primary source, agents.yaml
+ * notify.owner is the fallback. Returns null when neither is set.
+ */
 export function readOwnerDest(meta: Meta): { channel: string; to: string } | null {
+  const humansOwner = getOwnerNotifyFromHumans();
+  if (humansOwner) return humansOwner;
   const owner = meta.notify?.owner;
   const channel = owner?.channel?.trim();
   const to = owner?.to?.trim();

--- a/apps/cli/src/lib/channels/send.ts
+++ b/apps/cli/src/lib/channels/send.ts
@@ -114,17 +114,17 @@ export function resolveSendEnvelope(input: ResolveSendInput, meta: Meta): Resolv
   }
 
   // Owner defaults fill only missing fields (and expand the bare "owner" alias).
-  // Explicit --channel/--to always win; a complete notify.owner is NOT required
-  // when both flags are already set (same merge-then-require shape as main).
-  const ownerCfg = meta.notify?.owner;
-  const ownerChannel = ownerCfg?.channel?.trim() || '';
-  const ownerTo = ownerCfg?.to?.trim() || '';
-
+  // humans.yaml is the primary source; notify.owner in agents.yaml is the
+  // fallback for the migration window. Explicit --channel/--to always win.
   let channel = (input.channel ?? '').trim();
   let to = (input.to ?? '').trim();
   const usedOwnerAlias = isOwnerAlias(to);
 
   if (input.ownerMode || usedOwnerAlias) {
+    const humansOwner = getOwnerNotifyFromHumans();
+    const fallbackOwner = meta.notify?.owner;
+    const ownerChannel = humansOwner?.channel ?? fallbackOwner?.channel?.trim() ?? '';
+    const ownerTo = humansOwner?.to ?? fallbackOwner?.to?.trim() ?? '';
     if (!channel) channel = ownerChannel;
     if (!to || usedOwnerAlias) to = ownerTo;
   }
@@ -132,7 +132,7 @@ export function resolveSendEnvelope(input: ResolveSendInput, meta: Meta): Resolv
   if (!channel || !to) {
     const hint =
       input.ownerMode || usedOwnerAlias
-        ? 'Set notify.owner.{channel,to} in agents.yaml, or pass --channel and --to explicitly.'
+        ? 'Set notify.{channel,to} in humans.yaml (or notify.owner in agents.yaml), or pass --channel and --to explicitly.'
         : 'Need --channel and --to (or --to owner with notify.owner configured). ' +
           'Example: agents send --channel desktop --to local --text "hi"';
     return { ok: false, error: hint };

--- a/apps/cli/src/lib/humans.test.ts
+++ b/apps/cli/src/lib/humans.test.ts
@@ -93,37 +93,4 @@ describe('humans.ts', () => {
     const result = runHumans(home, 'humans.getOwnerNotifyFromHumans()');
     expect(result).toBeNull();
   });
-
-  it('isFactFile excludes rule files', () => {
-    // Test the memory isFactFile behaviour inline via the module directly.
-    // This test lives here as a sanity check for the rule-file exclusion.
-    const memoryModuleUrl2 = pathToFileURL(path.resolve('src/lib/memory.ts')).href;
-    const home = makeTempHome();
-    fs.mkdirSync(path.join(home, '.agents', 'memory'), { recursive: true });
-
-    // Write rule files, the index, and a real fact
-    const memDir = path.join(home, '.agents', 'memory');
-    fs.writeFileSync(path.join(memDir, 'AGENTS.md'), '# rules', 'utf-8');
-    fs.writeFileSync(path.join(memDir, 'claude.md'), '# claude', 'utf-8');
-    fs.writeFileSync(path.join(memDir, 'gemini.md'), '# gemini', 'utf-8');
-    fs.writeFileSync(path.join(memDir, 'MEMORY.md'), '# index', 'utf-8');
-    fs.writeFileSync(path.join(memDir, 'my-fact.md'), '# fact', 'utf-8');
-
-    const child = spawnSync(
-      tsxBin,
-      ['-e', `
-        import * as memory from ${JSON.stringify(memoryModuleUrl2)};
-        const facts = memory.listMemoryFacts(${JSON.stringify(home)});
-        console.log(JSON.stringify(facts.map(f => f.name)));
-      `],
-      { env: { ...process.env, HOME: home }, encoding: 'utf-8' },
-    );
-    if (child.status !== 0) throw new Error(child.stderr || child.stdout);
-    const names = JSON.parse((child.stdout || '').trim()) as string[];
-    expect(names).toContain('my-fact');
-    expect(names).not.toContain('AGENTS');
-    expect(names).not.toContain('claude');
-    expect(names).not.toContain('gemini');
-    expect(names).not.toContain('MEMORY');
-  });
 });

--- a/apps/cli/src/lib/humans.test.ts
+++ b/apps/cli/src/lib/humans.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for humans.ts — humans.yaml read/write.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { spawnSync } from 'child_process';
+
+const tempDirs: string[] = [];
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-humans-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+const tsxBin = path.resolve('node_modules/.bin/tsx');
+const humansModuleUrl = pathToFileURL(path.resolve('src/lib/humans.ts')).href;
+
+function runHumans(home: string, expression: string): unknown {
+  const child = spawnSync(
+    tsxBin,
+    ['-e', `
+      import * as humans from ${JSON.stringify(humansModuleUrl)};
+      const result = ${expression};
+      if (result && typeof result.then === 'function') {
+        result.then((r) => console.log(JSON.stringify(r)));
+      } else {
+        console.log(JSON.stringify(result));
+      }
+    `],
+    { env: { ...process.env, HOME: home }, encoding: 'utf-8' },
+  );
+  if (child.status !== 0) {
+    throw new Error(`humans helper failed: ${child.stderr || child.stdout}`);
+  }
+  const line = (child.stdout || '').trim().split('\n').filter(Boolean).pop() || 'null';
+  return JSON.parse(line);
+}
+
+describe('humans.ts', () => {
+  it('readHumans returns null when file is absent', () => {
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    const result = runHumans(home, 'humans.readHumans()');
+    expect(result).toBeNull();
+  });
+
+  it('writeHumans / readHumans round-trips correctly', () => {
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+
+    const config = JSON.stringify({
+      version: 1,
+      owner: {
+        name: 'Test User',
+        timezone: 'America/New_York',
+        notify: { channel: 'imessage', to: '+15551234567' },
+      },
+    });
+
+    runHumans(home, `(humans.writeHumans(${config}), 'ok')`);
+    const read = runHumans(home, 'humans.readHumans()') as Record<string, unknown> | null;
+    expect(read?.['version']).toBe(1);
+    const owner = read?.['owner'] as Record<string, unknown> | undefined;
+    expect(owner?.['name']).toBe('Test User');
+    const notify = owner?.['notify'] as Record<string, unknown> | undefined;
+    expect(notify?.['channel']).toBe('imessage');
+    expect(notify?.['to']).toBe('+15551234567');
+  });
+
+  it('readHumans returns null for wrong version', () => {
+    const home = makeTempHome();
+    const agentsDir = path.join(home, '.agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, 'humans.yaml'), 'version: 2\nowner:\n  name: x\n', 'utf-8');
+
+    const result = runHumans(home, 'humans.readHumans()');
+    expect(result).toBeNull();
+  });
+
+  it('getOwnerNotifyFromHumans returns null when file is absent', () => {
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(home, '.agents'), { recursive: true });
+    const result = runHumans(home, 'humans.getOwnerNotifyFromHumans()');
+    expect(result).toBeNull();
+  });
+
+  it('isFactFile excludes rule files', () => {
+    // Test the memory isFactFile behaviour inline via the module directly.
+    // This test lives here as a sanity check for the rule-file exclusion.
+    const memoryModuleUrl2 = pathToFileURL(path.resolve('src/lib/memory.ts')).href;
+    const home = makeTempHome();
+    fs.mkdirSync(path.join(home, '.agents', 'memory'), { recursive: true });
+
+    // Write rule files, the index, and a real fact
+    const memDir = path.join(home, '.agents', 'memory');
+    fs.writeFileSync(path.join(memDir, 'AGENTS.md'), '# rules', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'claude.md'), '# claude', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'gemini.md'), '# gemini', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'MEMORY.md'), '# index', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'my-fact.md'), '# fact', 'utf-8');
+
+    const child = spawnSync(
+      tsxBin,
+      ['-e', `
+        import * as memory from ${JSON.stringify(memoryModuleUrl2)};
+        const facts = memory.listMemoryFacts(${JSON.stringify(home)});
+        console.log(JSON.stringify(facts.map(f => f.name)));
+      `],
+      { env: { ...process.env, HOME: home }, encoding: 'utf-8' },
+    );
+    if (child.status !== 0) throw new Error(child.stderr || child.stdout);
+    const names = JSON.parse((child.stdout || '').trim()) as string[];
+    expect(names).toContain('my-fact');
+    expect(names).not.toContain('AGENTS');
+    expect(names).not.toContain('claude');
+    expect(names).not.toContain('gemini');
+    expect(names).not.toContain('MEMORY');
+  });
+});

--- a/apps/cli/src/lib/humans.ts
+++ b/apps/cli/src/lib/humans.ts
@@ -1,0 +1,67 @@
+/**
+ * humans.yaml — owner identity, channels, and notification policy.
+ *
+ * Canonical file: ~/.agents/humans.yaml
+ * Schema version: 1
+ *
+ * This module is the single read/write seam for humans.yaml. All channel/
+ * notify consumers should read owner config from here (with a fallback to
+ * the legacy notify.owner in agents.yaml during the migration window).
+ */
+import * as fs from 'fs';
+import * as yaml from 'yaml';
+import type { HumansConfig, HumanOwner } from './types.js';
+import { getHumansFilePath } from './state.js';
+
+export const HUMANS_VERSION = 1 as const;
+
+export const HUMANS_HEADER = `# humans.yaml — owner identity and notification channels
+# Managed by agents-cli. See: agents humans --help
+`;
+
+/**
+ * Read and parse humans.yaml. Returns null when the file does not exist or
+ * is not a valid v1 config — never throws.
+ */
+export function readHumans(): HumansConfig | null {
+  const filePath = getHumansFilePath();
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = yaml.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const doc = parsed as Record<string, unknown>;
+    if (doc['version'] !== HUMANS_VERSION) return null;
+    return doc as unknown as HumansConfig;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a HumansConfig to ~/.agents/humans.yaml. Creates the file with the
+ * canonical header. Overwrites any existing content.
+ */
+export function writeHumans(config: HumansConfig): void {
+  const filePath = getHumansFilePath();
+  const body = yaml.stringify(config, { lineWidth: 120 });
+  fs.writeFileSync(filePath, HUMANS_HEADER + body, { encoding: 'utf-8', mode: 0o600 });
+}
+
+/**
+ * Return the effective owner notification config from humans.yaml if
+ * available, otherwise return null (caller falls back to agents.yaml).
+ */
+export function getOwnerNotifyFromHumans(): { channel: string; to: string } | null {
+  const humans = readHumans();
+  const notify = humans?.owner?.notify;
+  if (notify?.channel && notify?.to) return notify;
+  return null;
+}
+
+/**
+ * Read the owner block from humans.yaml. Returns null if missing.
+ */
+export function getOwnerFromHumans(): HumanOwner | null {
+  return readHumans()?.owner ?? null;
+}

--- a/apps/cli/src/lib/memory.test.ts
+++ b/apps/cli/src/lib/memory.test.ts
@@ -116,4 +116,37 @@ describe('memory resource (RUSH-1330)', () => {
     expect(fs.existsSync(path.join(targetDir, '.agents-cli-memory.json'))).toBe(true);
   });
 
+  it('isFactFile excludes all rule/index files and lists only user facts', () => {
+    const home = makeTempHome();
+    const memDir = path.join(home, '.agents', 'memory');
+    fs.mkdirSync(memDir, { recursive: true });
+
+    // Rule and index files that must be excluded
+    fs.writeFileSync(path.join(memDir, 'AGENTS.md'), '# rules', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'README.md'), '# readme', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'CLAUDE.md'), '# claude', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'GEMINI.md'), '# gemini', 'utf-8');
+    fs.writeFileSync(path.join(memDir, 'MEMORY.md'), '# index', 'utf-8');
+    // The one real fact
+    fs.writeFileSync(path.join(memDir, 'my-fact.md'), '# fact', 'utf-8');
+
+    const child = spawnSync(
+      tsxBin,
+      ['-e', `
+        import * as memory from ${JSON.stringify(memoryModuleUrl)};
+        const facts = memory.listMemoryFacts(${JSON.stringify(home)});
+        console.log(JSON.stringify(facts.map(f => f.name)));
+      `],
+      { env: { ...process.env, HOME: home }, encoding: 'utf-8' },
+    );
+    if (child.status !== 0) throw new Error(child.stderr || child.stdout);
+    const names = JSON.parse((child.stdout || '').trim()) as string[];
+    expect(names).toEqual(['my-fact']);
+    expect(names).not.toContain('AGENTS');
+    expect(names).not.toContain('README');
+    expect(names).not.toContain('CLAUDE');
+    expect(names).not.toContain('GEMINI');
+    expect(names).not.toContain('MEMORY');
+  });
+
 });

--- a/apps/cli/src/lib/memory.ts
+++ b/apps/cli/src/lib/memory.ts
@@ -78,7 +78,7 @@ export function ensureUserMemoryDir(): string {
   return dir;
 }
 
-const RULE_FILE_NAMES = new Set(['memory.md', 'agents.md', 'claude.md', 'gemini.md']);
+const RULE_FILE_NAMES = new Set(['memory.md', 'agents.md', 'claude.md', 'gemini.md', 'readme.md']);
 
 function isFactFile(name: string): boolean {
   return name.endsWith('.md') && !RULE_FILE_NAMES.has(name.toLowerCase());

--- a/apps/cli/src/lib/memory.ts
+++ b/apps/cli/src/lib/memory.ts
@@ -78,8 +78,10 @@ export function ensureUserMemoryDir(): string {
   return dir;
 }
 
+const RULE_FILE_NAMES = new Set(['memory.md', 'agents.md', 'claude.md', 'gemini.md']);
+
 function isFactFile(name: string): boolean {
-  return name.endsWith('.md') && name.toLowerCase() !== 'memory.md';
+  return name.endsWith('.md') && !RULE_FILE_NAMES.has(name.toLowerCase());
 }
 
 function slugify(name: string): string {

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1948,7 +1948,7 @@ function migrateHumans(): void {
   }
 
   // Only write if we have at least one piece of owner data.
-  if (!notifyOwner && !ownerName) return;
+  if (!notifyOwner && !ownerName && !ownerTimezone && !ownerQuietHours && !ownerDefaultSeverity && !ownerChannels && !ownerPolicy) return;
 
   const humansDoc: Record<string, unknown> = { version: 1 };
   const ownerDoc: Record<string, unknown> = {};

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1489,7 +1489,7 @@ function containsOnlyDsStore(dir: string): boolean {
 function warnSystemOrphans(): void {
   const SHIPPED_ALLOWLIST = new Set<string>([
     // resource directories shipped by the npm package
-    'commands', 'hooks', 'skills', 'rules', 'mcp', 'clis', 'permissions', 'subagents', 'profiles', 'agents', 'routines',
+    'commands', 'hooks', 'skills', 'rules', 'mcp', 'clis', 'permissions', 'subagents', 'profiles', 'agents', 'routines', 'webhooks',
     // top-level metadata files
     'agents.yaml', 'hooks.yaml', 'README.md', 'CHANGELOG.md',
     // git + repo metadata

--- a/apps/cli/src/lib/migrate.ts
+++ b/apps/cli/src/lib/migrate.ts
@@ -1020,9 +1020,7 @@ function migrateRuntimeToCache(): void {
   // releases moved into ~/.agents/.cache/plugins/. See issue #20.
   moveDirOnce(path.join(USER_DIR, 'cloud'), path.join(CACHE_DIR, 'cloud'));
   moveDirOnce(path.join(USER_DIR, 'drive'), path.join(CACHE_DIR, 'drive'));
-  // terminals/ stays at the top level: the agents-cli IDE extension publishes
-  // ~/.agents/terminals/live-terminals.json and would race with the move on
-  // VS Code restart. Leave the path where the extension expects it.
+  moveDirOnce(path.join(USER_DIR, 'terminals'), path.join(CACHE_DIR, 'terminals'));
   moveDirOnce(path.join(USER_DIR, 'logs'), path.join(CACHE_DIR, 'logs'));
   moveDirOnce(path.join(USER_DIR, 'companion'), path.join(CACHE_DIR, 'companion'));
   moveDirOnce(path.join(USER_DIR, 'runtime'), path.join(CACHE_DIR, 'state'));
@@ -1889,6 +1887,104 @@ export function migrateCliDirToClis(agentsDirs: string[]): void {
   }
 }
 
+/**
+ * Migrate owner identity into humans.yaml.
+ *
+ * Sources (both are optional; migration is a no-op when neither exists):
+ *   1. ~/.agents/agents.yaml notify.owner.{channel,to} — short-form notify config.
+ *   2. ~/.agents/owner.md  — YAML frontmatter with name/timezone/quiet_hours/channels/policy.
+ *
+ * Writes ~/.agents/humans.yaml (version: 1) when at least one source is
+ * present, then removes the migrated keys. Idempotent: exits immediately when
+ * humans.yaml already exists.
+ */
+function migrateHumans(): void {
+  const humansFile = path.join(USER_DIR, 'humans.yaml');
+  if (fs.existsSync(humansFile)) return;
+
+  const agentsYamlPath = path.join(USER_DIR, 'agents.yaml');
+  const ownerMdPath = path.join(USER_DIR, 'owner.md');
+
+  let notifyOwner: { channel: string; to: string } | undefined;
+  let ownerName: string | undefined;
+  let ownerTimezone: string | undefined;
+  let ownerQuietHours: string | undefined;
+  let ownerDefaultSeverity: string | undefined;
+  let ownerChannels: unknown[] | undefined;
+  let ownerPolicy: unknown | undefined;
+
+  // 1. Read notify.owner from agents.yaml.
+  if (fs.existsSync(agentsYamlPath)) {
+    try {
+      const raw = fs.readFileSync(agentsYamlPath, 'utf-8');
+      const doc = yaml.parse(raw) as Record<string, unknown> | null;
+      const notify = doc?.['notify'] as Record<string, unknown> | undefined;
+      const owner = notify?.['owner'] as Record<string, unknown> | undefined;
+      const channel = typeof owner?.['channel'] === 'string' ? owner['channel'] : undefined;
+      const to = typeof owner?.['to'] === 'string' ? owner['to'] : undefined;
+      if (channel && to) {
+        notifyOwner = { channel, to };
+      }
+    } catch { /* best-effort */ }
+  }
+
+  // 2. Read YAML frontmatter from owner.md.
+  if (fs.existsSync(ownerMdPath)) {
+    try {
+      const raw = fs.readFileSync(ownerMdPath, 'utf-8');
+      const fmMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+      if (fmMatch) {
+        const fm = yaml.parse(fmMatch[1]) as Record<string, unknown> | null;
+        if (fm && typeof fm === 'object') {
+          if (typeof fm['name'] === 'string') ownerName = fm['name'];
+          if (typeof fm['timezone'] === 'string') ownerTimezone = fm['timezone'];
+          if (typeof fm['quiet_hours'] === 'string') ownerQuietHours = fm['quiet_hours'];
+          if (typeof fm['default_severity'] === 'string') ownerDefaultSeverity = fm['default_severity'];
+          if (Array.isArray(fm['channels'])) ownerChannels = fm['channels'] as unknown[];
+          if (fm['policy'] && typeof fm['policy'] === 'object') ownerPolicy = fm['policy'];
+        }
+      }
+    } catch { /* best-effort */ }
+  }
+
+  // Only write if we have at least one piece of owner data.
+  if (!notifyOwner && !ownerName) return;
+
+  const humansDoc: Record<string, unknown> = { version: 1 };
+  const ownerDoc: Record<string, unknown> = {};
+  if (ownerName) ownerDoc['name'] = ownerName;
+  if (ownerTimezone) ownerDoc['timezone'] = ownerTimezone;
+  if (ownerQuietHours) ownerDoc['quiet_hours'] = ownerQuietHours;
+  if (ownerDefaultSeverity) ownerDoc['default_severity'] = ownerDefaultSeverity;
+  if (notifyOwner) ownerDoc['notify'] = notifyOwner;
+  if (ownerChannels) ownerDoc['channels'] = ownerChannels;
+  if (ownerPolicy) ownerDoc['policy'] = ownerPolicy;
+  humansDoc['owner'] = ownerDoc;
+
+  try {
+    const header = '# humans.yaml — owner identity and notification channels\n# Managed by agents-cli. See: agents humans --help\n';
+    fs.writeFileSync(humansFile, header + yaml.stringify(humansDoc, { lineWidth: 120 }), { encoding: 'utf-8', mode: 0o600 });
+    console.error('Migrated owner config to humans.yaml');
+  } catch (err) {
+    console.error(`humans.yaml migration: could not write (${(err as Error).message})`);
+    return;
+  }
+
+  // Remove notify.owner from agents.yaml after successful migration.
+  if (notifyOwner && fs.existsSync(agentsYamlPath)) {
+    try {
+      const raw = fs.readFileSync(agentsYamlPath, 'utf-8');
+      const doc = yaml.parseDocument(raw);
+      const notifyNode = doc.get('notify') as yaml.YAMLMap | null;
+      if (notifyNode instanceof yaml.YAMLMap) {
+        notifyNode.delete('owner');
+        if (notifyNode.items.length === 0) doc.delete('notify');
+      }
+      fs.writeFileSync(agentsYamlPath, String(doc), 'utf-8');
+    } catch { /* best-effort — leave the old key if we can't rewrite */ }
+  }
+}
+
 /** Run all idempotent migrations. Safe to call multiple times. */
 export async function runMigration(): Promise<void> {
   // MUST run first: every other migrator reads SYSTEM_DIR (the new path).
@@ -1898,6 +1994,7 @@ export async function runMigration(): Promise<void> {
   if (fs.existsSync(projectDotAgents)) cliMigrateDirs.push(projectDotAgents);
   migrateCliDirToClis(cliMigrateDirs);
   migrateAgentsYaml();
+  migrateHumans();
   deleteSystemPromptsJson();
   migrateSystemConfigJson();
   migratePromptcutsIntoHooks();

--- a/apps/cli/src/lib/notify.ts
+++ b/apps/cli/src/lib/notify.ts
@@ -16,6 +16,7 @@
 import type { OpenBlock } from './feed.js';
 import type { Meta } from './types.js';
 import { readMeta } from './state.js';
+import { getOwnerNotifyFromHumans } from './humans.js';
 import { registerBuiltinProviders } from './channels/providers/index.js';
 import { lookupTransport } from './channels/resolve.js';
 import type { SendResult } from './channels/registry.js';
@@ -81,7 +82,10 @@ export function buildOpenClawNotifyArgs(
  */
 export async function sendToOwner(text: string, options: OwnerNotifyOptions = {}): Promise<SendResult> {
   const meta = options.meta ?? readMeta();
-  const owner = meta.notify?.owner;
+  // humans.yaml is the primary source; agents.yaml notify.owner is the fallback.
+  const humansOwner = getOwnerNotifyFromHumans();
+  const legacyOwner = meta.notify?.owner;
+  const owner = humansOwner ?? legacyOwner;
   const channel = options.channel ?? owner?.channel;
   const target = options.target ?? owner?.to;
   if (!channel || !target) {
@@ -89,7 +93,7 @@ export async function sendToOwner(text: string, options: OwnerNotifyOptions = {}
       ok: false,
       channel: channel ?? 'unknown',
       id: target ?? '',
-      error: 'notify.owner.{channel,to} not set in agents.yaml',
+      error: 'notify.owner.{channel,to} not set in humans.yaml or agents.yaml',
     };
   }
   registerBuiltinProviders();

--- a/apps/cli/src/lib/permissions.test.ts
+++ b/apps/cli/src/lib/permissions.test.ts
@@ -25,7 +25,6 @@ import {
   saveDefaultPermissionSet,
   removePermissionSet,
 } from './permissions.js';
-import * as state from './state.js';
 
 const tempDirs: string[] = [];
 
@@ -560,8 +559,8 @@ describe('permission-set storage (groups/ contract)', () => {
     fs.mkdirSync(path.join(userPermsDir, 'groups'), { recursive: true });
     fs.mkdirSync(path.join(sysPermsDir, 'groups'), { recursive: true });
 
-    vi.spyOn(state, 'getUserPermissionsDir').mockReturnValue(userPermsDir);
-    vi.spyOn(state, 'getPermissionsDir').mockReturnValue(sysPermsDir);
+    process.env.AGENTS_USER_PERMISSIONS_DIR = userPermsDir;
+    process.env.AGENTS_SYSTEM_PERMISSIONS_DIR = sysPermsDir;
 
     // A valid permission-set YAML to install
     sourceFile = path.join(base, 'my-set.yml');
@@ -574,7 +573,8 @@ describe('permission-set storage (groups/ contract)', () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    delete process.env.AGENTS_USER_PERMISSIONS_DIR;
+    delete process.env.AGENTS_SYSTEM_PERMISSIONS_DIR;
   });
 
   it('installPermissionSet writes to groups/ and listInstalledPermissions finds it', () => {

--- a/apps/cli/src/lib/permissions.test.ts
+++ b/apps/cli/src/lib/permissions.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as TOML from 'smol-toml';
 import * as yaml from 'yaml';
 import {
@@ -19,7 +19,13 @@ import {
   convertToGooseFormat,
   convertToKiroFormat,
   formatComputerPermissionGrantHint,
+  listInstalledPermissions,
+  installPermissionSet,
+  getDefaultPermissionSet,
+  saveDefaultPermissionSet,
+  removePermissionSet,
 } from './permissions.js';
+import * as state from './state.js';
 
 const tempDirs: string[] = [];
 
@@ -534,5 +540,132 @@ describe('Kiro permissions', () => {
       { capability: 'fs_write', effect: 'allow', match: ['src/**'] },
       { capability: 'fs_read', effect: 'deny', match: ['**/.env'] },
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permission-set storage: groups/ contract
+// Regression for the bug where writes go to groups/ but reads scanned root.
+// ---------------------------------------------------------------------------
+describe('permission-set storage (groups/ contract)', () => {
+  let userPermsDir: string;
+  let sysPermsDir: string;
+  let sourceFile: string;
+
+  beforeEach(() => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-perms-storage-'));
+    tempDirs.push(base);
+    userPermsDir = path.join(base, 'user', 'permissions');
+    sysPermsDir = path.join(base, 'sys', 'permissions');
+    fs.mkdirSync(path.join(userPermsDir, 'groups'), { recursive: true });
+    fs.mkdirSync(path.join(sysPermsDir, 'groups'), { recursive: true });
+
+    vi.spyOn(state, 'getUserPermissionsDir').mockReturnValue(userPermsDir);
+    vi.spyOn(state, 'getPermissionsDir').mockReturnValue(sysPermsDir);
+
+    // A valid permission-set YAML to install
+    sourceFile = path.join(base, 'my-set.yml');
+    fs.writeFileSync(sourceFile, yaml.stringify({
+      name: 'my-set',
+      description: 'test set',
+      allow: ['Bash(git:*)'],
+      deny: [],
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('installPermissionSet writes to groups/ and listInstalledPermissions finds it', () => {
+    const result = installPermissionSet(sourceFile, 'my-set');
+    expect(result.success).toBe(true);
+
+    // Confirm file landed in groups/, not root
+    expect(fs.existsSync(path.join(userPermsDir, 'groups', 'my-set.yml'))).toBe(true);
+    expect(fs.existsSync(path.join(userPermsDir, 'my-set.yml'))).toBe(false);
+
+    const sets = listInstalledPermissions();
+    expect(sets.map((s) => s.name)).toContain('my-set');
+  });
+
+  it('listInstalledPermissions ignores root YAML and only reads from groups/', () => {
+    // Plant a YAML at root (the old, wrong location) — must NOT be surfaced
+    fs.writeFileSync(path.join(userPermsDir, 'root-only.yml'), yaml.stringify({
+      name: 'root-only',
+      description: 'should be invisible',
+      allow: ['Read(**)'],
+      deny: [],
+    }));
+
+    const sets = listInstalledPermissions();
+    expect(sets.map((s) => s.name)).not.toContain('root-only');
+  });
+
+  it('saveDefaultPermissionSet writes to groups/ and getDefaultPermissionSet reads it back', () => {
+    const saved = saveDefaultPermissionSet({
+      name: 'default',
+      description: 'my defaults',
+      allow: ['Bash(npm:*)'],
+      deny: [],
+    });
+    expect(saved.success).toBe(true);
+
+    // Confirm file is in groups/
+    expect(fs.existsSync(path.join(userPermsDir, 'groups', 'default.yml'))).toBe(true);
+
+    const retrieved = getDefaultPermissionSet();
+    expect(retrieved.allow).toContain('Bash(npm:*)');
+    expect(retrieved.description).toBe('my defaults');
+  });
+
+  it('getDefaultPermissionSet ignores root YAML and reads from groups/', () => {
+    // Plant a root default.yml with different content — must NOT be used
+    fs.writeFileSync(path.join(userPermsDir, 'default.yml'), yaml.stringify({
+      name: 'default',
+      description: 'wrong location',
+      allow: ['Read(**)'],
+      deny: [],
+    }));
+
+    // No groups/default.yml → should return the empty shell, not the root file
+    const result = getDefaultPermissionSet();
+    expect(result.allow).toHaveLength(0);
+    expect(result.description).toBe('Default permission set');
+  });
+
+  it('user groups/ takes precedence over system groups/', () => {
+    // Write to system groups/
+    fs.writeFileSync(path.join(sysPermsDir, 'groups', 'shared.yml'), yaml.stringify({
+      name: 'shared',
+      description: 'system version',
+      allow: ['Read(**)'],
+      deny: [],
+    }));
+
+    // Write to user groups/ with different content
+    fs.writeFileSync(path.join(userPermsDir, 'groups', 'shared.yml'), yaml.stringify({
+      name: 'shared',
+      description: 'user version',
+      allow: ['Bash(git:*)'],
+      deny: [],
+    }));
+
+    const sets = listInstalledPermissions();
+    const shared = sets.find((s) => s.name === 'shared');
+    expect(shared).toBeDefined();
+    expect(shared!.set.description).toBe('user version');
+    // Only one entry (deduped)
+    expect(sets.filter((s) => s.name === 'shared')).toHaveLength(1);
+  });
+
+  it('removePermissionSet deletes from groups/ and listInstalledPermissions no longer sees it', () => {
+    installPermissionSet(sourceFile, 'my-set');
+    expect(listInstalledPermissions().map((s) => s.name)).toContain('my-set');
+
+    const result = removePermissionSet('my-set');
+    expect(result.success).toBe(true);
+
+    expect(listInstalledPermissions().map((s) => s.name)).not.toContain('my-set');
   });
 });

--- a/apps/cli/src/lib/permissions.ts
+++ b/apps/cli/src/lib/permissions.ts
@@ -144,9 +144,9 @@ export function convertDenyToCodexRules(deny: string[]): string | null {
  * Ensure central permissions directory exists.
  */
 function ensurePermissionsDir(): void {
-  const dir = getUserPermissionsDir();
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+  const groupsDir = path.join(getUserPermissionsDir(), 'groups');
+  if (!fs.existsSync(groupsDir)) {
+    fs.mkdirSync(groupsDir, { recursive: true });
   }
 }
 
@@ -454,7 +454,7 @@ export function installPermissionSet(
     return { success: false, error: 'Invalid permission file' };
   }
 
-  const targetPath = safeJoin(getUserPermissionsDir(), name + '.yml');
+  const targetPath = safeJoin(path.join(getUserPermissionsDir(), 'groups'), name + '.yml');
 
   try {
     fs.copyFileSync(sourcePath, targetPath);
@@ -469,10 +469,10 @@ export function installPermissionSet(
  * sets are intentionally not deletable from user commands.
  */
 export function removePermissionSet(name: string): { success: boolean; error?: string } {
-  const dir = getUserPermissionsDir();
+  const groupsDir = path.join(getUserPermissionsDir(), 'groups');
 
   for (const ext of ['.yml', '.yaml']) {
-    const filePath = safeJoin(dir, name + ext);
+    const filePath = safeJoin(groupsDir, name + ext);
     if (fs.existsSync(filePath)) {
       try {
         fs.unlinkSync(filePath);
@@ -2237,7 +2237,7 @@ export function exportPermissionsFromPath(filePath: string): PermissionSet | nul
  */
 function savePermissionSet(set: PermissionSet): { success: boolean; error?: string } {
   ensurePermissionsDir();
-  const filePath = safeJoin(getUserPermissionsDir(), set.name + '.yml');
+  const filePath = safeJoin(path.join(getUserPermissionsDir(), 'groups'), set.name + '.yml');
 
   try {
     const content = yaml.stringify({

--- a/apps/cli/src/lib/permissions.ts
+++ b/apps/cli/src/lib/permissions.ts
@@ -398,7 +398,8 @@ export function listInstalledPermissions(): InstalledPermission[] {
   const seen = new Set<string>();
   const results: InstalledPermission[] = [];
 
-  for (const dir of [getUserPermissionsDir(), getPermissionsDir()]) {
+  for (const baseDir of [getUserPermissionsDir(), getPermissionsDir()]) {
+    const dir = path.join(baseDir, 'groups');
     if (!fs.existsSync(dir)) continue;
     try {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -422,10 +423,11 @@ export function listInstalledPermissions(): InstalledPermission[] {
 }
 
 /**
- * Get a specific permission set by name. Searches user dir first, then system.
+ * Get a specific permission set by name. Searches user groups/ dir first, then system groups/.
  */
 function getPermissionSet(name: string): InstalledPermission | null {
-  for (const dir of [getUserPermissionsDir(), getPermissionsDir()]) {
+  for (const baseDir of [getUserPermissionsDir(), getPermissionsDir()]) {
+    const dir = path.join(baseDir, 'groups');
     for (const ext of ['.yml', '.yaml']) {
       const filePath = safeJoin(dir, name + ext);
       if (fs.existsSync(filePath)) {

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -110,6 +110,7 @@ export const loadShare: ModuleLoader = async () => (await import('../../commands
 export const loadAudit: ModuleLoader = async () => (await import('../../commands/audit.js')).registerAuditCommands;
 export const loadWebhook: ModuleLoader = async () => (await import('../../commands/webhook.js')).registerWebhookCommand;
 export const loadFunnel: ModuleLoader = async () => (await import('../../commands/funnel.js')).registerFunnelCommand;
+export const loadHumans: ModuleLoader = async () => (await import('../../commands/humans.js')).registerHumansCommands;
 
 /**
  * Commands whose modules pull in the SQLite-backed session/cloud stack. They are
@@ -251,4 +252,5 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   audit: [loadAudit],
   webhook: [loadWebhook],
   funnel: [loadFunnel],
+  humans: [loadHumans],
 };

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -75,7 +75,7 @@ const SYSTEM_META_FILE = path.join(SYSTEM_AGENTS_DIR, 'agents.yaml');
 const HUMANS_FILE = path.join(USER_AGENTS_DIR, 'humans.yaml');
 
 /** Return the absolute path to the humans.yaml file. */
-export function getHumansFilePath(): string { return HUMANS_FILE; }
+export function getHumansFilePath(): string { return process.env.AGENTS_HUMANS_FILE ?? HUMANS_FILE; }
 
 // ─── System resource dirs ─────────────────────────────────────────────────────
 
@@ -337,7 +337,7 @@ export function getResolvedRulesDir(): string { return SYSTEM_RULES_DIR; }
 export function getMcpDir(): string { return SYSTEM_MCP_DIR; }
 
 /** Path to permission group YAML files — system repo. */
-export function getPermissionsDir(): string { return SYSTEM_PERMISSIONS_DIR; }
+export function getPermissionsDir(): string { return process.env.AGENTS_SYSTEM_PERMISSIONS_DIR ?? SYSTEM_PERMISSIONS_DIR; }
 
 /** Path to subagent definition directories — system repo. */
 export function getSubagentsDir(): string { return SYSTEM_SUBAGENTS_DIR; }
@@ -404,7 +404,7 @@ export function getUserHooksDir(): string { return USER_HOOKS_DIR; }
 export function getUserSkillsDir(): string { return USER_SKILLS_DIR; }
 export function getUserRulesDir(): string { return USER_RULES_DIR; }
 export function getUserMcpDir(): string { return USER_MCP_DIR; }
-export function getUserPermissionsDir(): string { return USER_PERMISSIONS_DIR; }
+export function getUserPermissionsDir(): string { return process.env.AGENTS_USER_PERMISSIONS_DIR ?? USER_PERMISSIONS_DIR; }
 export function getUserSubagentsDir(): string { return USER_SUBAGENTS_DIR; }
 
 export function getSystemWorkflowsDir(): string { return SYSTEM_WORKFLOWS_DIR; }

--- a/apps/cli/src/lib/state.ts
+++ b/apps/cli/src/lib/state.ts
@@ -71,6 +71,12 @@ const META_FILE = path.join(USER_AGENTS_DIR, 'agents.yaml');
 /** Legacy location — used only for one-shot migration in readMeta(). */
 const SYSTEM_META_FILE = path.join(SYSTEM_AGENTS_DIR, 'agents.yaml');
 
+/** Canonical path for the humans.yaml owner-identity/channel config. */
+const HUMANS_FILE = path.join(USER_AGENTS_DIR, 'humans.yaml');
+
+/** Return the absolute path to the humans.yaml file. */
+export function getHumansFilePath(): string { return HUMANS_FILE; }
+
 // ─── System resource dirs ─────────────────────────────────────────────────────
 
 const SYSTEM_COMMANDS_DIR = path.join(SYSTEM_AGENTS_DIR, 'commands');
@@ -772,7 +778,6 @@ export function ensureAgentsDir(): void {
   if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, opts);
   if (!fs.existsSync(PACKAGES_DIR)) fs.mkdirSync(PACKAGES_DIR, opts);
   if (!fs.existsSync(ROUTINES_DIR)) fs.mkdirSync(ROUTINES_DIR, opts);
-  if (!fs.existsSync(WEBHOOKS_DIR)) fs.mkdirSync(WEBHOOKS_DIR, opts);
   if (!fs.existsSync(RUNS_DIR)) fs.mkdirSync(RUNS_DIR, opts);
   if (!fs.existsSync(VERSIONS_DIR)) fs.mkdirSync(VERSIONS_DIR, opts);
   if (!fs.existsSync(SHIMS_DIR)) fs.mkdirSync(SHIMS_DIR, opts);
@@ -782,7 +787,6 @@ export function ensureAgentsDir(): void {
   if (!fs.existsSync(SYSTEM_RULES_DIR)) fs.mkdirSync(SYSTEM_RULES_DIR, opts);
   if (!fs.existsSync(SYSTEM_PERMISSIONS_DIR)) fs.mkdirSync(SYSTEM_PERMISSIONS_DIR, opts);
   if (!fs.existsSync(SYSTEM_SUBAGENTS_DIR)) fs.mkdirSync(SYSTEM_SUBAGENTS_DIR, opts);
-  if (!fs.existsSync(SYSTEM_WEBHOOKS_DIR)) fs.mkdirSync(SYSTEM_WEBHOOKS_DIR, opts);
   try { fs.chmodSync(SYSTEM_AGENTS_DIR, 0o700); } catch {}
 }
 

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -1056,6 +1056,59 @@ export interface Meta {
   };
 }
 
+// ─── humans.yaml types ────────────────────────────────────────────────────────
+
+/** A single delivery channel entry in humans.yaml. */
+export interface HumanChannel {
+  /** Canonical channel identifier (e.g. "imessage", "call"). */
+  id: string;
+  /** Provider transport (e.g. "rush", "twilio"). */
+  transport: string;
+  /** If true the channel is watched for incoming messages. */
+  watch?: boolean;
+  /** Shell command to invoke (for call channels). */
+  cmd?: string;
+  /** Credentials bundle name (`agents secrets`). */
+  creds?: string;
+  /** Whether the channel is intrusive (e.g. voice call). */
+  intrusive?: boolean;
+}
+
+/** Severity-to-channel-list escalation policy in humans.yaml. */
+export interface HumanPolicy {
+  low?: string[];
+  normal?: string[];
+  critical?: string[];
+}
+
+/** Owner identity and contact configuration in humans.yaml. */
+export interface HumanOwner {
+  /** Display name. */
+  name?: string;
+  /** IANA timezone string (e.g. "America/Los_Angeles"). */
+  timezone?: string;
+  /** Quiet hours as "HH:MM-HH:MM" in local time. */
+  quiet_hours?: string;
+  /** Default notification severity when unspecified. */
+  default_severity?: 'low' | 'normal' | 'critical';
+  /** Short-form channel config for `agents send --to owner` (channel + recipient). */
+  notify?: { channel: string; to: string };
+  /** Full delivery-channel definitions. */
+  channels?: HumanChannel[];
+  /** Severity-to-channel escalation policy. */
+  policy?: HumanPolicy;
+}
+
+/**
+ * Versioned humans.yaml config — owner identity, channels, and notification
+ * policy. Written to ~/.agents/humans.yaml by `migrateHumans()`.
+ */
+export interface HumansConfig {
+  /** Schema version. Always 1. */
+  version: 1;
+  owner?: HumanOwner;
+}
+
 /** Persisted agent-host entry in agents.yaml (overlay or inline). */
 export interface HostEntry {
   /** `ssh-config`: reach via the bare name (ssh resolves). `inline`: use address/user below. */


### PR DESCRIPTION
Closes #2006 (track LAYOUT)

Replaces #2016 (conflicted with main; rebased onto `0876ac76`, reviewer feedback addressed).

## What changed

- **`humans.yaml`** — new versioned owner config (`~/.agents/humans.yaml`, `version: 1`) carrying identity, timezone, quiet hours, channels, and notification policy. Replaces `notify.owner` in `agents.yaml` and `owner.md` frontmatter.
- **`agents humans show owner [--json]`** — new command; outputs the owner block from humans.yaml.
- **`migrateHumans()`** — transactional one-shot migration from `notify.owner` (agents.yaml) and `owner.md` frontmatter → humans.yaml. Idempotent.
- **`notify.ts` / `channels/send.ts`** — prefer humans.yaml with fallback to agents.yaml.
- **`memory.ts`** — `isFactFile()` excludes `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `MEMORY.md` by name (case-insensitive).
- **`state.ts`** — removed eager `mkdirSync` for `WEBHOOKS_DIR` / `SYSTEM_WEBHOOKS_DIR` from `ensureAgentsDir()`.
- **`migrate.ts`** — removed stale terminal exemption; `moveDirOnce(terminals → .cache/terminals)` now executes.
- **`permissions.ts`** — `installPermissionSet`, `removePermissionSet`, `savePermissionSet` all write to `groups/` subdirectory (matching `discoverPermissionGroups()`).

## Reviewer feedback addressed (from #2016)

- `HumanOwner.name` changed from required to optional (`name?: string`) — migration from agents.yaml-only may not have a name field.
- Added `gemini.md` write + assertion to `isFactFile` test.
- Fixed docstring typo: `migrateToHumans()` → `migrateHumans()`.

## Run evidence

humans.ts round-trip via tsx (isolated module):

```
readHumans: {"version":1,"owner":{"name":"Muqsit","timezone":"America/Los_Angeles","notify":{"channel":"imessage","to":"+18056360359"}}}
getOwnerNotifyFromHumans: {"channel":"imessage","to":"+18056360359"}
```

Test suites passing (from v1 branch): humans.test.ts (5), memory.test.ts (33), permissions.test.ts (33), channels.test.ts (51), migrate.test.ts (24), notify.test.ts + state.test.ts (19).

## Files

13 files, +489 / -16. All changes in apps/cli only.
