### PR TITLE
fix(secrets): view --reveal resolves interactively at a real terminal

### DIFF
--- a/apps/cli/.changelog/next/secrets-interactive-value-reads.md
+++ b/apps/cli/.changelog/next/secrets-interactive-value-reads.md
@@ -1,0 +1,12 @@
+- **`agents secrets view <bundle> --reveal` now resolves a locked keychain bundle
+  interactively at a real terminal.** The command hardcoded `agentOnly: true` on
+  both reveal call sites (`commands/secrets.ts`), so an explicit human `--reveal`
+  on a locked bundle went through the broker-only path and errored with an unlock
+  hint instead of raising the one Touch ID sheet the human just asked for. The
+  `agentOnly` flag is now `isHeadlessSecretsContext() || !isInteractiveTerminal()`
+  — under an agent (`AGENTS_RUNTIME`) or with no TTY it stays broker-only and
+  never prompts, but a deliberate `--reveal` typed at an interactive terminal
+  resolves the value with a single biometric sheet. This mirrors the existing
+  `reveal && !isInteractiveTerminal()` guard a few lines up. `export --plaintext`
+  and `exec` are untouched — they stay intentionally silent for release/CI
+  scripts. Source: `apps/cli/src/commands/secrets.ts`.

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -38,6 +38,7 @@ import {
   keychainRef,
   listBundles,
   healKeychainBundleMetadataAclOnce,
+  isHeadlessSecretsContext,
   migrateLegacyBundles,
   parseDotenv,
   readAndResolveBundleEnv,
@@ -1377,7 +1378,10 @@ export function registerSecretsCommands(program: Command): void {
             const { env } = readAndResolveBundleEnv(bundle.name, {
               caller: 'view --reveal --json',
               keyMode: 'storage',
-              agentOnly: true,
+              // An explicit human `--reveal` at a terminal is a deliberate value
+              // access → resolve interactively (one Touch ID). Under an agent
+              // (AGENTS_RUNTIME) or headless (no TTY) it stays broker-only.
+              agentOnly: isHeadlessSecretsContext() || !isInteractiveTerminal(),
             });
             for (const entry of entries) {
               if (entry.kind === 'keychain' && env[entry.key] !== undefined) {
@@ -1484,15 +1488,16 @@ export function registerSecretsCommands(program: Command): void {
           console.error(chalk.red('--reveal in a non-TTY requires --plaintext.'));
           process.exit(1);
         }
-        // Resolve through the broker / durable-session path. A locked keychain
-        // bundle errors with the explicit unlock hint; viewing never raises a
-        // Touch ID sheet itself.
+        // An explicit human `view --reveal` at a terminal is a deliberate value
+        // access: resolve interactively (one Touch ID) so a locked bundle shows
+        // its values. Under an agent (AGENTS_RUNTIME) or headless (no TTY) it
+        // stays broker-only and errors with the unlock hint — never a sheet.
         const revealedValues = new Map<string, string>();
         if (reveal) {
           const { env } = readAndResolveBundleEnv(bundle.name, {
             caller: 'view --reveal',
             keyMode: 'storage',
-            agentOnly: true,
+            agentOnly: isHeadlessSecretsContext() || !isInteractiveTerminal(),
           });
           for (const entry of entries) {
             if (entry.kind === 'keychain' && env[entry.key] !== undefined) {


### PR DESCRIPTION
**refactor / security-logic** — makes `agents secrets view --reveal` resolve a locked keychain bundle interactively at a real terminal. No new surface, no visual output.

## What changed
Both `view --reveal` call sites in `apps/cli/src/commands/secrets.ts` hardcoded `agentOnly: true`. So an explicit human `--reveal` on a **locked** keychain bundle took the broker-only path and errored with an "unlock first" hint instead of raising the single Touch ID sheet the human just asked for.

`agentOnly` is now:
```ts
agentOnly: isHeadlessSecretsContext() || !isInteractiveTerminal()
```

| Context | Before | After |
|---|---|---|
| Human `--reveal` at a TTY, locked bundle | error, no sheet | **one Touch ID sheet, values shown** |
| Under an agent (`AGENTS_RUNTIME`) | broker-only, no sheet | broker-only, no sheet (unchanged) |
| Headless / no TTY (`--plaintext`) | broker-only, no sheet | broker-only, no sheet (unchanged) |

This mirrors the existing `reveal && !isInteractiveTerminal()` guard a few lines up. `export --plaintext` and `exec` are untouched — they stay intentionally silent for release/CI scripts.

## Why
Closes the last item from the Touch-ID one-sheet cleanup (handoff issue #2019, RUSH-1759). PRs #1994/#1995 killed the prompt *storm*; this restores the *intended* single prompt for a deliberate human reveal.

## Verification
- `tsc --noEmit` clean.
- Runtime smoke from this branch (`tsx src/index.ts secrets list`, non-TTY): command loads, the new `isHeadlessSecretsContext` import resolves, all keychain bundles list metadata-only with **no Touch ID sheet** — confirming the module still loads and the storm fix stays live.
- Headless reveal path (`--plaintext`, no TTY) is exercised by the existing CLI test suite in CI.

Ref: #2019
