### PR TITLE
feat(cli): agents install plugin: — Phase 5 install umbrella

### DIFF
--- a/apps/cli/.changelog/next/install-plugin-prefix.md
+++ b/apps/cli/.changelog/next/install-plugin-prefix.md
@@ -1,0 +1,6 @@
+- **Install: `plugin:` prefix on the unified path (Phase 5 packaging).**
+  `agents install plugin:<spec>` uses the same grammar and trust gate as
+  `agents plugins install` (`name@url`, local path, `--allow-exec-surfaces`).
+  Specialized verbs still work; `agents install` is the one add path for mcp,
+  skill, plugin, and GitHub sources. Source: `apps/cli/src/commands/packages.ts`,
+  `apps/cli/src/lib/registry.ts`.

--- a/apps/cli/docs/07-entrypoints-and-loops.md
+++ b/apps/cli/docs/07-entrypoints-and-loops.md
@@ -154,6 +154,7 @@ Resume reuses the checkpoint's loop config but lets the resume command **raise**
 |------------|-------|----------|
 | Plugin packages skills / commands / subagents / mcp / hooks | yes | — |
 | Plugin packages workflows | **partial** — `workflows/` under a plugin is discovered and resolved by `agents run <name>` (project > user > plugin > extra > system); `name@plugin` / `name@extra-alias` (optional `workflow:` prefix) pins the source; inspect/resource groups list them | full — install path no longer requires a separate central copy; unified `run:` for all entrypoint kinds |
+| Unified install umbrella | **partial** — `agents install plugin:<spec>` is the same path as `agents plugins install <spec>` (exec-surface gate, sync to default versions); `mcp:` / `skill:` / `gh:` already share `agents install` | complete — one verb for every package kind; specialized verbs remain as aliases |
 | `agents run <workflow>` | yes | — |
 | `agents run <subagent>` / `<command>` as the top-level target | no — only agent / profile / workflow | yes — unified entrypoint dispatch |
 | Routine target | `agent` or `workflow` | any entrypoint via `run:` |

--- a/apps/cli/docs/plugins.md
+++ b/apps/cli/docs/plugins.md
@@ -49,6 +49,7 @@ For the layered resource model that governs plugin resolution, see [02-resource-
 | `agents plugins view <name>` | Metadata, resources, and installation status for one plugin |
 | `agents plugins info <name>` | Alias for `view` |
 | `agents plugins install <spec>` | Install from a git URL or local path |
+| `agents install plugin:<spec>` | Same install path (Phase 5 umbrella); same `--allow-exec-surfaces` gate |
 | `agents plugins update [name]` | Re-pull from original source and re-sync (all plugins if no name given) |
 | `agents plugins sync <name> [agent]` | Apply a plugin to the default version of an agent (all supported agents if none given) |
 | `agents plugins remove [name]` | Unsync from all agent versions; optionally delete source directory |

--- a/apps/cli/src/commands/packages.ts
+++ b/apps/cli/src/commands/packages.ts
@@ -70,6 +70,7 @@ import {
   syncResourcesToVersion,
 } from '../lib/versions.js';
 import {
+  formatPath,
   isInteractiveTerminal,
   isPromptCancelled,
   parseCommaSeparatedList,
@@ -544,7 +545,7 @@ the sha256 in the index and abort on mismatch.
 
   program
     .command('install <identifier>')
-    .description('Install a package by registry name (mcp:notion), GitHub URL (gh:user/repo), or skill identifier')
+    .description('Install a package: mcp:, skill:, plugin:, or GitHub (gh:user/repo) — one install path (Phase 5)')
     .option('-a, --agents <list>', 'Targets: claude, codex@0.116.0, or cursor@default')
     .option(
       '--types <list>',
@@ -555,32 +556,25 @@ the sha256 in the index and abort on mismatch.
       'When source is a repo: comma-separated resource names within the selected types'
     )
     .option('-y, --yes', 'Auto-install any missing agent versions without prompting')
+    .option('--allow-exec-surfaces', 'With plugin: allow plugins that ship hooks/mcp/bin (same as agents plugins install)')
     .addHelpText('after', `
-Install resolves the package type (MCP server, skill, command, hook) and installs to the specified agents. Packages can come from registries (mcp:, skill:), GitHub (gh:user/repo), or direct URLs.
+Install is the unified add path (Phase 5 packaging). Prefix the identifier:
+
+  mcp:<name>       MCP server from a registry
+  skill:<name>     skill from a registry (or gh: fallback)
+  plugin:<spec>    plugin — same grammar as agents plugins install (name@url or path)
+  gh:user/repo     clone a DotAgents / multi-resource repo and install selected types
 
 Examples:
-  # Install an MCP server from a registry
   agents install mcp:notion --agents claude
-
-  # Install skills and commands from GitHub
+  agents install skill:animator --agents claude,codex
+  agents install plugin:my-plugin@https://github.com/user/my-plugin.git
+  agents install plugin:~/Projects/rush-toolkit
   agents install gh:anthropics/skills --agents codex,claude
-
-  # Install using GitHub shorthand
-  agents install gh:user/repo --agents claude@2.1.112
-
-  # Install only specific resource types from a multi-resource repo
   agents install gh:phnx-labs/.agents-system --types skills,workflows --agents claude@all
 
-  # Install specific resources by name
-  agents install gh:phnx-labs/.agents-system --types skills --names animator,composer --agents claude@all
-
-  # Install to all installed agents (uses defaults or prompts)
-  agents install mcp:postgres
-
-When to use:
-  - After search: 'agents search notion' then 'agents install mcp:notion'
-  - Team setup: 'agents install gh:team/resources' to sync everyone's tooling
-  - Quick MCP add: 'agents install mcp:<name>' when you know the package name
+Specialized verbs still work (agents plugins install, agents skills add) and
+delegate to the same underlying installers.
 `)
     .action(async (identifier: string, options) => {
       const spinner = ora('Resolving package...').start();
@@ -590,11 +584,105 @@ When to use:
 
         if (!resolved) {
           spinner.fail('Package not found');
-          console.log(chalk.gray('\nTip: Use explicit prefix (mcp:, skill:, gh:) or check the identifier.'));
+          console.log(chalk.gray('\nTip: Use explicit prefix (mcp:, skill:, plugin:, gh:) or check the identifier.'));
           process.exit(1);
         }
 
         spinner.succeed(`Found ${resolved.type} package`);
+
+        if (resolved.type === 'plugin') {
+          spinner.stop();
+          const spec = resolved.pluginSpec ?? resolved.source;
+          console.log(chalk.gray(`Installing plugin from: ${spec}`));
+          const {
+            installPlugin,
+            getPlugin,
+            inspectPluginCapabilities,
+            pluginCapabilityLabels,
+            parseInstallSpec,
+            checkPluginDependencies,
+            hasPluginExecSurfaces,
+            pluginSupportsAgent,
+            syncPluginToVersion,
+            pluginResourceGroups,
+          } = await import('../lib/plugins.js');
+          const { listInstalledVersions, getGlobalDefault, getVersionHomePath, syncResourcesToVersion } =
+            await import('../lib/versions.js');
+          const { agentLabel } = await import('../lib/agents.js');
+
+          let name: string;
+          let root: string;
+          try {
+            const result = await installPlugin(spec);
+            name = result.name;
+            root = result.root;
+          } catch (err) {
+            console.log(chalk.red(`Install failed: ${(err as Error).message}`));
+            process.exit(1);
+          }
+
+          const plugin = getPlugin(name);
+          if (!plugin) {
+            console.log(chalk.red(`Installed but could not load plugin '${name}'`));
+            process.exit(1);
+          }
+          const capabilities = inspectPluginCapabilities(root);
+          const allowExec = options.allowExecSurfaces === true;
+          if (hasPluginExecSurfaces(capabilities) && !allowExec) {
+            const source = parseInstallSpec(spec).source;
+            console.error(chalk.red('Install refused: plugin ships executable surfaces:'));
+            for (const label of pluginCapabilityLabels(capabilities)) {
+              console.error(`  ${label}`);
+            }
+            console.error(
+              `Re-run with --allow-exec-surfaces if you trust the source: ${source}@HEAD`,
+            );
+            fs.rmSync(root, { recursive: true, force: true });
+            process.exit(1);
+          }
+
+          const missingDeps = checkPluginDependencies(plugin.manifest);
+          if (missingDeps.length > 0) {
+            console.log(chalk.yellow(`Warning: missing dependencies: ${missingDeps.join(', ')}`));
+            console.log(chalk.gray('Install them with: agents install plugin:<name>@<source>'));
+          }
+
+          // Same sync loop as `agents plugins install` (default version per harness).
+          console.log();
+          let synced = 0;
+          for (const agentId of capableAgents('plugins')) {
+            if (!pluginSupportsAgent(plugin, agentId)) continue;
+            const versions = listInstalledVersions(agentId);
+            if (versions.length === 0) continue;
+            const defaultVer = getGlobalDefault(agentId);
+            const targetVersions = defaultVer ? [defaultVer] : [versions[versions.length - 1]];
+            for (const version of targetVersions) {
+              const didSync = allowExec
+                ? syncPluginToVersion(plugin, agentId, getVersionHomePath(agentId, version), {
+                    allowExecSurfaces: true,
+                  }).success
+                : syncResourcesToVersion(agentId, version, { plugins: [name] }).plugins.length > 0;
+              if (didSync) {
+                console.log(chalk.green(`  Synced to ${agentLabel(agentId)}@${version}`));
+                synced++;
+              }
+            }
+          }
+          if (synced === 0) {
+            console.log(
+              chalk.gray('  No supported agent versions installed — run "agents use <agent>@<version>" to sync.'),
+            );
+          }
+
+          console.log(chalk.bold(`\nInstalled ${plugin.name} v${plugin.manifest.version} to ${formatPath(root)}`));
+          const groups = pluginResourceGroups(plugin);
+          if (groups.length > 0) {
+            for (const g of groups) {
+              console.log(chalk.gray(`  ${g.label}: ${g.items.slice(0, 8).join(', ')}${g.items.length > 8 ? '…' : ''}`));
+            }
+          }
+          return;
+        }
 
         if (resolved.type === 'mcp') {
           // Install MCP server

--- a/apps/cli/src/lib/registry.ts
+++ b/apps/cli/src/lib/registry.ts
@@ -487,7 +487,7 @@ export async function search(
 
 /** Parse a package identifier into its type (mcp, skill, git) and name. */
 export function parsePackageIdentifier(identifier: string): {
-  type: RegistryType | 'git' | 'unknown';
+  type: RegistryType | 'git' | 'plugin' | 'unknown';
   name: string;
 } {
   // mcp:filesystem -> MCP registry
@@ -498,6 +498,12 @@ export function parsePackageIdentifier(identifier: string): {
   // skill:user/repo -> skill registry (or git fallback)
   if (identifier.startsWith('skill:')) {
     return { type: 'skill', name: identifier.slice(6) };
+  }
+
+  // plugin:name@source | plugin:/path | plugin:gh:user/repo — Phase 5 packaging
+  // umbrella. Spec after the prefix is the same grammar as `agents plugins install`.
+  if (identifier.startsWith('plugin:')) {
+    return { type: 'plugin', name: identifier.slice('plugin:'.length) };
   }
 
   // gh:user/repo -> git source
@@ -532,6 +538,12 @@ export function parsePackageIdentifier(identifier: string): {
 /** Resolve a package identifier to an installable package with source metadata. */
 export async function resolvePackage(identifier: string): Promise<ResolvedPackage | null> {
   const parsed = parsePackageIdentifier(identifier);
+
+  if (parsed.type === 'plugin') {
+    const spec = parsed.name.trim();
+    if (!spec) return null;
+    return { type: 'plugin', source: spec, pluginSpec: spec };
+  }
 
   if (parsed.type === 'git') {
     return { type: 'git', source: parsed.name };

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -569,10 +569,16 @@ export interface RegistrySearchResult {
 
 /** A package that has been resolved from a registry and is ready to install. */
 export interface ResolvedPackage {
-  type: 'mcp' | 'skill' | 'git';
+  /** `plugin` is Phase 5 packaging: `agents install plugin:<spec>` → plugins install. */
+  type: 'mcp' | 'skill' | 'git' | 'plugin';
   source: string;
   mcpEntry?: McpServerEntry;
   skillEntry?: SkillEntry;
+  /**
+   * Plugin install spec (`name@url`, path, or bare source) when `type === 'plugin'`.
+   * Same grammar as `agents plugins install <spec>`.
+   */
+  pluginSpec?: string;
 }
 
 /** Categories of resources that can be synced into an agent version home. */

--- a/apps/cli/tests/registry.test.ts
+++ b/apps/cli/tests/registry.test.ts
@@ -36,6 +36,18 @@ describe('parsePackageIdentifier', () => {
     expect(result).toEqual({ type: 'skill', name: 'user/repo' });
   });
 
+  it('parses plugin: prefix (Phase 5 install umbrella)', () => {
+    expect(parsePackageIdentifier('plugin:my-plugin@https://github.com/user/my-plugin.git')).toEqual({
+      type: 'plugin',
+      name: 'my-plugin@https://github.com/user/my-plugin.git',
+    });
+    expect(parsePackageIdentifier('plugin:~/Projects/rush-toolkit')).toEqual({
+      type: 'plugin',
+      name: '~/Projects/rush-toolkit',
+    });
+    expect(parsePackageIdentifier('plugin:')).toEqual({ type: 'plugin', name: '' });
+  });
+
   it('parses gh: prefix as git', () => {
     const result = parsePackageIdentifier('gh:example-user/.agents');
     expect(result).toEqual({ type: 'git', name: 'gh:example-user/.agents' });
@@ -167,6 +179,20 @@ describe('resolvePackage', () => {
   it('resolves skill: prefix to git fallback', async () => {
     const result = await resolvePackage('skill:user/repo');
     expect(result).toEqual({ type: 'git', source: 'gh:user/repo' });
+  });
+
+  it('resolves plugin: to plugin package (does not hit registries)', async () => {
+    const result = await resolvePackage('plugin:my-plugin@https://github.com/user/p.git');
+    expect(result).toEqual({
+      type: 'plugin',
+      source: 'my-plugin@https://github.com/user/p.git',
+      pluginSpec: 'my-plugin@https://github.com/user/p.git',
+    });
+  });
+
+  it('returns null for empty plugin: spec', async () => {
+    expect(await resolvePackage('plugin:')).toBeNull();
+    expect(await resolvePackage('plugin:   ')).toBeNull();
   });
 
   it('resolves unknown user/repo to git fallback', async () => {


### PR DESCRIPTION
## Summary

**Feature (Phase 5 packaging).** `agents install plugin:<spec>` is the unified add path for plugins — same grammar and trust gate as `agents plugins install`.

- `parsePackageIdentifier` / `resolvePackage` accept `plugin:` and return `ResolvedPackage { type: 'plugin', pluginSpec }`
- Install action calls `installPlugin`, refuses exec surfaces unless `--allow-exec-surfaces`, syncs to default versions per harness
- Help documents `mcp:` / `skill:` / `plugin:` / `gh:` as one install umbrella
- Docs: `07-entrypoints-and-loops.md` today/proposed row; `plugins.md` command table
- Changelog fragment: `.changelog/next/install-plugin-prefix.md`

Specialized verbs (`agents plugins install`, …) remain.

## Run result (no UI surface — CLI help + unit tests)

```
$ node dist/index.js install --help
Install a package: mcp:, skill:, plugin:, or GitHub (gh:user/repo) — one install path (Phase 5)
  --allow-exec-surfaces  With plugin: allow plugins that ship hooks/mcp/bin
  plugin:<spec>    plugin — same grammar as agents plugins install
  agents install plugin:my-plugin@https://github.com/user/my-plugin.git
  agents install plugin:~/Projects/rush-toolkit

$ bun test tests/registry.test.ts
  parsePackageIdentifier > parses plugin: prefix (Phase 5 install umbrella)  pass
  resolvePackage > resolves plugin: to plugin package (does not hit registries)  pass
  resolvePackage > returns null for empty plugin: spec  pass
  20 pass, 7 skip, 0 fail
$ bun run build  # tsc clean
```

## Test plan

- [x] Unit: `plugin:` parse + resolve (empty null)
- [x] `bun run build` clean
- [ ] CI green
- [ ] Optional smoke after merge: `agents install plugin:<local fixture>` with and without `--allow-exec-surfaces`