### PR TITLE
feat(menubar): group routines by projectGroup in rich and All-routines views

### DIFF
--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -211,6 +211,10 @@ One rule shapes the menu: **attention floats up, context groups down.**
   failure reason when available; overdue routines are labeled `overdue` even when
   their previous run succeeded. Each submenu has Run now / Pause / Logs, and Logs
   opens the concise routine summary in a text viewer.
+  When routines carry a `projectGroup` field (from `agents routines list --json`),
+  both the inline rows and the "All routines…" submenu are grouped by that label.
+  Routines with no `projectGroup` (cross-project or unassigned) appear last,
+  ungrouped. Compact mode remains one summary row regardless of grouping.
 - **RECENT TICKETS / RECENT** — tickets filed via quick dispatch and recent
   sessions, unchanged dedicated sections.
 - **System** — setup staleness + the auto-nudge watchdog collapsed into one row;

--- a/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/IssueSelfTest.swift
@@ -22,6 +22,7 @@ enum IssueSelfTest {
         testRecentTicketsMerge()
         testDraftPreservation()
         testRoutineFailureReason()
+        testRoutineGrouping()
         testLinearProjectResolution()
         testLinearTicketRanking()
         testLinearTicketFilter()
@@ -321,6 +322,41 @@ enum IssueSelfTest {
         check("failed routine still falls back to exit code",
               routineFailureDetail(failed, max: 72) == "exit 2",
               detail: routineFailureDetail(failed, max: 72) ?? "nil")
+    }
+
+    // groupedRoutines preserves first-occurrence order, groups correctly, and puts
+    // nil-projectGroup routines into the ungrouped tail.
+    private static func testRoutineGrouping() {
+        let cli1  = routine(name: "nightly-cli", projectGroup: "agents-cli")
+        let web   = routine(name: "standup",     projectGroup: "rush-app")
+        let cli2  = routine(name: "ci-check", lastStatus: "failed", exitCode: 1, overdue: false,
+                            projectGroup: "agents-cli")
+        let cross = routine(name: "healthcheck", projectGroup: nil)
+
+        let (grouped, ungrouped) = groupedRoutines([cli1, web, cli2, cross])
+        check("two project groups present", grouped.count == 2,
+              detail: grouped.map { $0.0 }.joined(separator: ","))
+        check("first group is agents-cli (first occurrence)",
+              grouped.first.map { $0.0 } == "agents-cli",
+              detail: grouped.first.map { $0.0 } ?? "nil")
+        check("agents-cli group has both routines", grouped[0].1.count == 2,
+              detail: "\(grouped[0].1.count)")
+        check("rush-app group has one routine", grouped[1].1.count == 1)
+        check("nil projectGroup lands in ungrouped",
+              ungrouped.count == 1 && ungrouped[0].name == "healthcheck",
+              detail: ungrouped.map { $0.name }.joined(separator: ","))
+
+        // Within a group, insertion order (upcoming-first) is preserved.
+        check("first agents-cli entry is the one that appeared first",
+              grouped[0].1[0].name == "nightly-cli")
+
+        // All-ungrouped: no groups, everything in the tail.
+        let (g2, u2) = groupedRoutines([cross])
+        check("no projectGroup means all ungrouped", g2.isEmpty && u2.count == 1)
+
+        // Empty input.
+        let (g3, u3) = groupedRoutines([])
+        check("empty input yields empty output", g3.isEmpty && u3.isEmpty)
     }
 
     // The repo picker drives the ticket scope, so `agents-cli` has to land on the
@@ -685,16 +721,21 @@ enum IssueSelfTest {
     }
 
     private static func routine(
-        lastStatus: String?,
-        exitCode: Int?,
-        failureReason: String?,
-        overdue: Bool
+        name: String = "nightly",
+        lastStatus: String? = nil,
+        exitCode: Int? = nil,
+        failureReason: String? = nil,
+        overdue: Bool = false,
+        projects: [String]? = nil,
+        projectGroup: String? = nil
     ) -> Routine {
         Routine(
-            name: "nightly",
+            name: name,
             agent: "claude",
             workflow: nil,
             repo: nil,
+            projects: projects,
+            projectGroup: projectGroup,
             schedule: "0 3 * * *",
             scheduleHuman: nil,
             enabled: true,

--- a/apps/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -7,6 +7,9 @@ struct Routine: Decodable {
     let agent: String?
     let workflow: String?
     let repo: String?
+    // project membership decoded from CLI JSON; absent keys decode as nil for both fields.
+    let projects: [String]?    // repos this routine belongs to
+    let projectGroup: String?  // menu display grouping label; nil = cross-project / ungrouped
     let schedule: String
     let scheduleHuman: String?
     let enabled: Bool

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -1135,6 +1135,8 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // Routines stay a dedicated, glanceable section. Compact: one summary row
     // (submenu = all). Rich: a section with the next few upcoming + any failing
     // routine inline, then "All routines…" for the rest.
+    // When any routine carries a `projectGroup`, both the inline rows and the
+    // "All routines…" submenu are grouped by that label (ungrouped routines last).
     private func addRoutines(_ menu: NSMenu, routines: [Routine], rich: Bool) {
         let summary: String
         if routines.isEmpty {
@@ -1160,20 +1162,44 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             .filter { r in r.enabled && !failing.contains(where: { $0.name == r.name }) && r.nextRun != nil }
             .sorted { ($0.nextRun ?? "") < ($1.nextRun ?? "") }
             .prefix(3)
-        for r in upcoming {
-            let row = statusRow("◔", idleC, "\(r.name)  \(r.nextRunHuman ?? r.schedule)")
-            row.submenu = routineSubmenu(r)
-            menu.addItem(row)
-        }
-        for r in failing {
-            let why = routineFailureSummary(r, max: 48)
-            let row = statusRow(routineIsMiss(r) ? "⃠" : "✕", routineIsMiss(r) ? wait : fail, "\(r.name)  \(why)")
-            row.submenu = routineSubmenu(r)
-            menu.addItem(row)
+
+        let hasGroups = routines.contains { $0.projectGroup != nil }
+        if hasGroups {
+            let (grouped, ungrouped) = groupedRoutines(Array(upcoming) + failing)
+            for (label, group) in grouped {
+                menu.addItem(disabled("  \(label)"))
+                for r in group { menu.addItem(inlineRoutineRow(r)) }
+            }
+            for r in ungrouped { menu.addItem(inlineRoutineRow(r)) }
+        } else {
+            for r in upcoming {
+                let row = statusRow("◔", idleC, "\(r.name)  \(r.nextRunHuman ?? r.schedule)")
+                row.submenu = routineSubmenu(r)
+                menu.addItem(row)
+            }
+            for r in failing {
+                let why = routineFailureSummary(r, max: 48)
+                let row = statusRow(routineIsMiss(r) ? "⃠" : "✕", routineIsMiss(r) ? wait : fail, "\(r.name)  \(why)")
+                row.submenu = routineSubmenu(r)
+                menu.addItem(row)
+            }
         }
         let all = NSMenuItem(title: "  All routines…", action: nil, keyEquivalent: "")
         all.submenu = allRoutinesSubmenu(routines)
         menu.addItem(all)
+    }
+
+    // One colored inline row for the ROUTINES section (upcoming or failing).
+    private func inlineRoutineRow(_ r: Routine) -> NSMenuItem {
+        let row: NSMenuItem
+        if routineNeedsAttention(r) {
+            let why = routineFailureSummary(r, max: 48)
+            row = statusRow(routineIsMiss(r) ? "⃠" : "✕", routineIsMiss(r) ? wait : fail, "\(r.name)  \(why)")
+        } else {
+            row = statusRow("◔", idleC, "\(r.name)  \(r.nextRunHuman ?? r.schedule)")
+        }
+        row.submenu = routineSubmenu(r)
+        return row
     }
 
     // Setup + watchdog collapsed into one System row — the health noise lives in
@@ -1317,15 +1343,33 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
     private func allRoutinesSubmenu(_ routines: [Routine]) -> NSMenu {
         let sub = NSMenu()
-        for r in routines {
-            let mark = routineNeedsAttention(r) ? "! "
-                : (r.enabled ? "  " : "· ")
-            let when = routineFailureDetail(r, max: 52) ?? (r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused")
-            let item = NSMenuItem(title: "\(mark)\(r.name)  \(when)", action: nil, keyEquivalent: "")
-            item.submenu = routineSubmenu(r)
-            sub.addItem(item)
+        let hasGroups = routines.contains { $0.projectGroup != nil }
+        if hasGroups {
+            let (grouped, ungrouped) = groupedRoutines(routines)
+            for i in grouped.indices {
+                if i > 0 { sub.addItem(.separator()) }
+                let (label, group) = grouped[i]
+                sub.addItem(disabled("  \(label)"))
+                for r in group { sub.addItem(routineListRow(r)) }
+            }
+            if !ungrouped.isEmpty {
+                if !grouped.isEmpty { sub.addItem(.separator()) }
+                for r in ungrouped { sub.addItem(routineListRow(r)) }
+            }
+        } else {
+            for r in routines { sub.addItem(routineListRow(r)) }
         }
         return sub
+    }
+
+    // One flat row for the "All routines…" submenu.
+    private func routineListRow(_ r: Routine) -> NSMenuItem {
+        let mark = routineNeedsAttention(r) ? "! "
+            : (r.enabled ? "  " : "· ")
+        let when = routineFailureDetail(r, max: 52) ?? (r.enabled ? (r.nextRunHuman ?? r.schedule) : "paused")
+        let item = NSMenuItem(title: "\(mark)\(r.name)  \(when)", action: nil, keyEquivalent: "")
+        item.submenu = routineSubmenu(r)
+        return item
     }
 
     private func setupSummary(_ doctor: DoctorOverview?) -> String {
@@ -1579,4 +1623,22 @@ func routineFailureDetail(_ r: Routine, max: Int) -> String? {
 private func trimText(_ value: String, _ max: Int) -> String {
     if value.count <= max { return value }
     return String(value.prefix(max - 1)) + "…"
+}
+
+/// Partitions routines by `projectGroup`, preserving the order of first occurrence.
+/// Returns ordered (label, routines) pairs and an ungrouped tail for routines whose
+/// `projectGroup` is nil (cross-project / not associated with a single project).
+func groupedRoutines(_ routines: [Routine]) -> (grouped: [(String, [Routine])], ungrouped: [Routine]) {
+    var order: [String] = []
+    var byGroup: [String: [Routine]] = [:]
+    var ungrouped: [Routine] = []
+    for r in routines {
+        if let g = r.projectGroup {
+            if byGroup[g] == nil { order.append(g) }
+            byGroup[g, default: []].append(r)
+        } else {
+            ungrouped.append(r)
+        }
+    }
+    return (order.map { ($0, byGroup[$0]!) }, ungrouped)
 }


### PR DESCRIPTION
## Summary

Groups menu-bar routines by `projectGroup` in the rich ROUTINES section and the "All routines…" submenu. Compact mode is unchanged (one summary row).

**New JSON fields decoded** (optional, backward-compatible — absent keys decode as `nil`):
- `projects: [String]?` — repos the routine belongs to
- `projectGroup: String?` — display group label; `nil` = cross-project / ungrouped

**Menu behavior:**
- When any routine carries `projectGroup`, both the inline rich rows and the submenu are split into labeled groups, in first-occurrence order.
- Routines with no `projectGroup` appear last, ungrouped.
- The global "⚠ NEEDS YOU" section is never grouped.
- Compact mode: unchanged (one summary row).

## Changes

| File | What changed |
|---|---|
| `Models.swift` | Added `projects` and `projectGroup` optional fields to `Routine: Decodable` |
| `StatusItemController.swift` | `addRoutines` + `allRoutinesSubmenu` grouping; new `inlineRoutineRow`, `routineListRow`, `groupedRoutines()` |
| `IssueSelfTest.swift` | `testRoutineGrouping()` — 8 new cases; updated `routine()` helper signature |
| `docs/menubar.md` | Documents the `projectGroup` grouping behavior |

## Self-test output (all 123 pass)

```
  PASS  two project groups present
  PASS  first group is agents-cli (first occurrence)
  PASS  agents-cli group has both routines
  PASS  rush-app group has one routine
  PASS  nil projectGroup lands in ungrouped
  PASS  first agents-cli entry is the one that appeared first
  PASS  no projectGroup means all ungrouped
  PASS  empty input yields empty output
...
ALL PASS
```

Run on mac-mini with `MENUBAR_ISSUE_TEST=1 .build/debug/MenubarHelper` (Apple Swift 6.2.3, SwiftPM, platforms: .macOS(.v14)). Full 123-test run clean.

## Reviewer note

`prix-cloud` is paused (#1767). Handing off to `/root` for review.
