### PR TITLE
docs(doctor): make the severity rubrics match the code, and pin the bucket not just the name

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -108,14 +108,19 @@ gives each device its warnings plus a compact accounts/versions line (every
 installed version + its account, provable ✓ / ✗). Single-machine `agents doctor`
 collapses to the CRITICAL section plus one `▸ <machine>` block. Severity:
 **critical** is `logged-out` (provable), `missing-hook`, `missing-plugin`,
-`unwired-hook`, `never-synced` *when the version's declared resources are
-therefore absent*, `duplicate-hook-drift`, and `cli-missing`; **warning** is
-`logout-unprovable`, `missing-resource`, `content-drift`, `stale`, `never-synced`
-when the version declares nothing to miss, `repo-behind`, `repo-drift`,
-`version-skew`, `fleet-resource-gap`, `orphan`, `duplicate-hook`,
-`host-cli-missing`, `host-cli-invalid`, `rc-secret-export`, `exec-policy` and
-`stale-cli`. The same list is in the `doctor-findings.ts` module docblock — keep
-both exhaustive, since a kind missing from either is a doc that lies. The findings model,
+`unwired-hook` and `cli-missing`; **warning** is `logout-unprovable`,
+`missing-resource`, `content-drift`, `never-synced`, `stale`, `repo-behind`,
+`repo-drift`, `version-skew`, `fleet-resource-gap`, `orphan`, `duplicate-hook`,
+`duplicate-hook-drift`, `host-cli-missing`, `host-cli-invalid`,
+`rc-secret-export`, `exec-policy` and `stale-cli`. (RUSH-2162 moved
+`never-synced` and `duplicate-hook-drift` to warning — both are stale-sync states
+one `agents sync` resolves.)
+
+`FINDING_SEVERITY` in
+[`src/lib/devices/doctor-findings.ts`](src/lib/devices/doctor-findings.ts) is the
+single source of truth: the builders read their severity from it, and a test
+asserts this list and the module docblock assign every kind to the **same bucket**
+it does. Change a severity there and the test names the docs to move with it. The findings model,
 builders, `remediationFor`, and the pure `renderFindings` live in
 [`src/lib/devices/doctor-findings.ts`](src/lib/devices/doctor-findings.ts).
 
@@ -146,8 +151,8 @@ takes ~57 rows down to ~16, and the rules are unit-pinned in
   machine with five installed claudes otherwise emits two dozen identical rows.
 - **No vaguer restatement.** A version that just listed its drifted/missing
   resources gets no `sources changed since last sync` row on top, and a
-  never-synced version reports one critical (`agents sync <agent>@<version>
-  --yes`) instead of one per absent resource.
+  never-synced version reports one warning (`agents sync <agent>@<version>
+  --yes`) instead of one row per absent resource.
 
 **Every check the old overview printed is a finding now.** `renderOverviewText`
 was the ONLY text renderer for several independent checks, so deleting it dropped

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -502,17 +502,18 @@ agents doctor · zion                                        1.20.81
 
 **Severity rubric** (agent-agnostic):
 
-- **CRITICAL** (`✗`) — a **provable** logged-out version, a **missing hook or
-  plugin** from a version, a never-synced version whose declared resources are
-  therefore absent, a missing/broken CLI binary, one hook installed into several
-  version homes with **differing** content (a stale copy can gate differently from
-  the active one).
-- **WARNING** (`⚠`) — content drift, version-skew, repo-behind, repo-drift,
-  orphans, byte-identical duplicate copies of a hook across version homes,
-  a declared host CLI that is not installed, a resource another box has but this
-  one does not, a missing command/skill/rule/mcp/permission/subagent, a credential-shaped
-  export in a shell rc file, a Windows execution policy that blocks `agents.ps1`,
-  and an **unprovable** logout (hedged "could not verify sign-in").
+- **CRITICAL** (`✗`) — `logged-out` (provable), `missing-hook`,
+  `missing-plugin`, `unwired-hook`, `cli-missing`. These block the harness now.
+- **WARNING** (`⚠`) — `logout-unprovable`, `missing-resource`, `content-drift`,
+  `never-synced`, `stale`, `repo-behind`, `repo-drift`, `version-skew`,
+  `fleet-resource-gap`, `orphan`, `duplicate-hook`, `duplicate-hook-drift`,
+  `host-cli-missing`, `host-cli-invalid`, `rc-secret-export`, `exec-policy`,
+  `stale-cli`. Each is resolvable by a routine sync or cleanup.
+
+RUSH-2162 moved `never-synced` and `duplicate-hook-drift` from critical to
+warning: both are stale-sync states one `agents sync` resolves, not "needs you
+now". `FINDING_SEVERITY` in `src/lib/devices/doctor-findings.ts` is the source of
+truth for this list, and a test asserts this rubric agrees with it.
 
 **One root cause is one line.** The readout is de-duplicated before it is
 rendered, so a real machine shows ~16 rows rather than ~57:
@@ -524,7 +525,7 @@ rendered, so a real machine shows ~16 rows rather than ~57:
 | One orphan row per version | one `orphans` line per machine — `agents prune cleanup --all` clears them all |
 | One row per hook duplicated across version homes | one row per (agent, severity) — `agents sync <agent>@all --yes` reconciles them all |
 | `sources changed since last sync` on a version that already listed its drift | nothing — the specific row already said it |
-| One critical per absent resource on a never-synced version | one critical → `agents sync <agent>@<version> --yes` |
+| One row per absent resource on a never-synced version | one warning → `agents sync <agent>@<version> --yes` |
 
 An **isolated** version never folds into a collapsed row: the agent-wide `--fix`
 sweep deliberately skips isolated copies, so it keeps its own

--- a/apps/cli/src/lib/devices/doctor-findings.test.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   ALL_FINDING_KINDS,
+  FINDING_SEVERITY,
   buildLocalFindings,
   collapseAcrossVersions,
   fleetDivergenceToFindings,
@@ -445,27 +446,104 @@ describe('signInToFindings — provable vs unprovable logout', () => {
   });
 });
 
-describe('the severity rubric is exhaustive (docs cannot silently drift from the kinds)', () => {
-  // Five separate review rounds landed a new FindingKind; three of them left one
-  // of the two prose rubrics behind, each time producing a doc that lied. Pin it:
-  // every kind must be named in BOTH the module docblock and apps/cli/AGENTS.md.
-  const read = (rel: string) =>
-    fs.readFileSync(path.join(__dirname, rel), 'utf8');
+describe('the severity rubric matches the code (docs cannot drift from behavior)', () => {
+  // The earlier version of this suite only checked that each kind was NAMED in
+  // both rubrics. RUSH-2162 then moved never-synced and duplicate-hook-drift from
+  // critical to warning, the rubrics kept saying critical, and the test stayed
+  // green for three days — a kind can be named in the wrong bucket. So assert the
+  // BUCKET, against FINDING_SEVERITY, which the builders themselves read.
+  const read = (rel: string) => fs.readFileSync(path.join(__dirname, rel), 'utf8');
 
-  it('every FindingKind appears in the module docblock rubric', () => {
-    const src = read('./doctor-findings.ts');
-    const rubric = src.slice(src.indexOf(' * Severity rubric'), src.indexOf(' */'));
-    const missing = ALL_FINDING_KINDS.filter((k) => !rubric.includes(k));
-    expect(missing).toEqual([]);
+  /** Split a rubric into its critical and warning halves. */
+  function buckets(text: string, criticalMark: string, warningMark: string) {
+    const c = text.indexOf(criticalMark);
+    const w = text.indexOf(warningMark);
+    expect(c).toBeGreaterThan(-1);
+    expect(w).toBeGreaterThan(c);
+    return { critical: text.slice(c, w), warning: text.slice(w) };
+  }
+
+  /** Kinds named in the wrong half, as `kind: documented-as -> actually`. */
+  function misplaced(critical: string, warning: string): string[] {
+    const out: string[] = [];
+    for (const kind of ALL_FINDING_KINDS) {
+      const actual = FINDING_SEVERITY[kind];
+      const inCritical = critical.includes(kind);
+      const inWarning = warning.includes(kind);
+      if (!inCritical && !inWarning) { out.push(`${kind}: absent -> ${actual}`); continue; }
+      // `duplicate-hook` is a substring of `duplicate-hook-drift`; require the
+      // longer name to be matched on its own before crediting the shorter one.
+      const only = (half: string) =>
+        half.split(kind).length - 1 > (kind === 'duplicate-hook' ? half.split('duplicate-hook-drift').length - 1 : 0);
+      const documented = only(critical) ? 'critical' : only(warning) ? 'warning' : null;
+      if (documented !== actual) out.push(`${kind}: ${documented ?? 'absent'} -> ${actual}`);
+    }
+    return out;
+  }
+
+  it('every builder emits the severity FINDING_SEVERITY declares', () => {
+    // Drive the builders and compare what actually comes out.
+    const emitted = [
+      ...buildLocalFindings(localInput({
+        reports: [report('claude', '2.1.0', {
+          hooks: [{ kind: 'hooks', name: 'h', status: 'missing' }],
+          plugins: [{ kind: 'plugins', name: 'p', status: 'missing' }],
+          commands: [{ kind: 'commands', name: 'c', status: 'missing' }],
+          skills: [{ kind: 'skills', name: 's', status: 'diff' }],
+        })],
+        syncRows: [{ agent: 'codex', version: '1.0', status: 'stale', isDefault: true }],
+        repoBehind: [{ alias: 'user', dir: '/u', ahead: 0, behind: 3, branch: 'origin/main', fetchedAt: 0 }],
+        orphanRows: [{ agent: 'claude', version: '2.1.0', commands: 1, skills: 0, hooks: 0 }],
+        hostClis: { statuses: [{ name: 'mq', installed: false }], errors: [{ file: 'f', reason: 'r' }] },
+        rcSecrets: [{ file: '.zshrc', line: 1, name: 'X_TOKEN', isMasterPassphrase: false }],
+        execPolicy: { platform: 'win32', policy: 'Restricted' },
+        duplicateHooks: [{
+          agent: 'claude', name: 'h', kind: 'drift',
+          authoritative: { agent: 'claude', version: '2', name: 'h', path: '/p', hash: 'x', active: true },
+          copies: [{ agent: 'claude', version: '1', name: 'h', path: '/p', hash: 'y', active: false },
+                   { agent: 'claude', version: '2', name: 'h', path: '/p', hash: 'x', active: true }],
+        }],
+        cliMissing: ['grok'],
+        signIn: { codex: [{ version: '1', signedIn: false, account: null, provable: true }] },
+      })),
+      ...fleetDivergenceToFindings([
+        { kind: 'agent-version-missing-remote', device: 'b', category: 'claude', name: '1', message: 'm' },
+        { kind: 'repo-drift', device: 'b', category: 'agents', name: '.agents', message: 'm' },
+        { kind: 'resource-missing-remote', device: 'b', category: 'skills', name: 's', message: 'm' },
+      ], 'a'),
+    ];
+    expect(emitted.length).toBeGreaterThan(8);
+    const wrong = emitted
+      .filter((f) => f.severity !== FINDING_SEVERITY[f.kind])
+      .map((f) => `${f.kind}: emitted ${f.severity}, declared ${FINDING_SEVERITY[f.kind]}`);
+    expect(wrong).toEqual([]);
   });
 
-  it('every FindingKind appears in the AGENTS.md severity rubric', () => {
+  it('the module docblock rubric puts every kind in the right bucket', () => {
+    const src = read('./doctor-findings.ts');
+    const rubric = src.slice(src.indexOf(' * Severity rubric'), src.indexOf('\n */'));
+    const { critical, warning } = buckets(rubric, 'CRITICAL', 'WARNING');
+    expect(misplaced(critical, warning)).toEqual([]);
+  });
+
+  it('the docs/06-observability.md rubric puts every kind in the right bucket', () => {
+    // A THIRD rubric — missed by the previous version of this test, and stale for
+    // the same three days. Every prose copy of the severities gets pinned.
+    const doc = read('../../../docs/06-observability.md');
+    const start = doc.indexOf('**Severity rubric**');
+    expect(start).toBeGreaterThan(-1);
+    const rubric = doc.slice(start, start + 1400);
+    const { critical, warning } = buckets(rubric, '**CRITICAL**', '**WARNING**');
+    expect(misplaced(critical, warning)).toEqual([]);
+  });
+
+  it('the AGENTS.md rubric puts every kind in the right bucket', () => {
     const doc = read('../../../AGENTS.md');
     const start = doc.indexOf('**critical** is `logged-out`');
     expect(start).toBeGreaterThan(-1);
-    const rubric = doc.slice(start, start + 1400);
-    const missing = ALL_FINDING_KINDS.filter((k) => !rubric.includes(k));
-    expect(missing).toEqual([]);
+    const rubric = doc.slice(start, start + 1600);
+    const { critical, warning } = buckets(rubric, '**critical**', '**warning**');
+    expect(misplaced(critical, warning)).toEqual([]);
   });
 });
 

--- a/apps/cli/src/lib/devices/doctor-findings.test.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.test.ts
@@ -463,23 +463,38 @@ describe('the severity rubric matches the code (docs cannot drift from behavior)
     return { critical: text.slice(c, w), warning: text.slice(w) };
   }
 
+  /**
+   * Whether a rubric names this kind as a WHOLE token. Plain `includes` credits a
+   * kind whenever a LONGER kind contains it — `cli-missing` inside
+   * `host-cli-missing`, `stale` inside `stale-cli`, `duplicate-hook` inside
+   * `duplicate-hook-drift`. Three such pairs exist today and more will appear, so
+   * this is a boundary match, not a per-pair special case: a kind must not be
+   * flanked by another id character.
+   */
+  const names = (half: string, kind: string): boolean =>
+    new RegExp(`(^|[^a-z-])${kind}($|[^a-z-])`).test(half);
+
   /** Kinds named in the wrong half, as `kind: documented-as -> actually`. */
   function misplaced(critical: string, warning: string): string[] {
     const out: string[] = [];
     for (const kind of ALL_FINDING_KINDS) {
       const actual = FINDING_SEVERITY[kind];
-      const inCritical = critical.includes(kind);
-      const inWarning = warning.includes(kind);
-      if (!inCritical && !inWarning) { out.push(`${kind}: absent -> ${actual}`); continue; }
-      // `duplicate-hook` is a substring of `duplicate-hook-drift`; require the
-      // longer name to be matched on its own before crediting the shorter one.
-      const only = (half: string) =>
-        half.split(kind).length - 1 > (kind === 'duplicate-hook' ? half.split('duplicate-hook-drift').length - 1 : 0);
-      const documented = only(critical) ? 'critical' : only(warning) ? 'warning' : null;
+      const documented = names(critical, kind) ? 'critical' : names(warning, kind) ? 'warning' : null;
       if (documented !== actual) out.push(`${kind}: ${documented ?? 'absent'} -> ${actual}`);
     }
     return out;
   }
+
+  it('the token matcher does not credit a kind that is only a substring of a longer one', () => {
+    // Guards the guard: these three pairs are why plain `includes` was wrong.
+    expect(names('host-cli-missing', 'cli-missing')).toBe(false);
+    expect(names('stale-cli', 'stale')).toBe(false);
+    expect(names('duplicate-hook-drift', 'duplicate-hook')).toBe(false);
+    // …while still matching the real thing in prose and in backticks.
+    expect(names('`cli-missing` and more', 'cli-missing')).toBe(true);
+    expect(names('· stale ·', 'stale')).toBe(true);
+    expect(names('duplicate-hook, host-cli-missing', 'duplicate-hook')).toBe(true);
+  });
 
   it('every builder emits the severity FINDING_SEVERITY declares', () => {
     // Drive the builders and compare what actually comes out.

--- a/apps/cli/src/lib/devices/doctor-findings.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.ts
@@ -92,29 +92,30 @@ export type FindingSeverity = 'critical' | 'warning';
 
 /** A machine-stable class for a finding — drives {@link remediationFor} and lets
  *  the JSON consumer group by kind. */
+/** Every finding class. Severity is NOT annotated here — {@link FINDING_SEVERITY}
+ *  below owns it, and a second copy in these comments is a fourth place to drift. */
 export const ALL_FINDING_KINDS = [
-  'logged-out',          // provable per-version logout (CRITICAL)
-  'logout-unprovable',   // credential absent but not provable (WARNING)
-  'missing-hook',        // a declared hook absent from a version home (CRITICAL)
-  'missing-plugin',      // a declared plugin absent from a version home (CRITICAL)
-  'unwired-hook',        // hook present on disk but not wired into settings.json (CRITICAL)
-  'cli-missing',         // a managed agent whose binary won't resolve (CRITICAL)
-  'missing-resource',    // a missing command/skill/rule/mcp/permission/subagent (WARNING)
-  'content-drift',       // a resource diverged from source (WARNING)
-  'never-synced',        // installed but never synced — CRITICAL when its declared
-                          // resources are therefore absent, WARNING when it declares none
-  'stale',               // sources changed since last sync (WARNING)
-  'repo-behind',         // a config repo behind origin (WARNING)
-  'repo-drift',          // a config repo diverged from the fleet baseline (WARNING)
-  'fleet-resource-gap',  // a resource in another box's central repos, absent here (WARNING)
-  'host-cli-missing',    // a declared host CLI not installed on this box (WARNING)
-  'host-cli-invalid',    // a host-CLI manifest that failed to parse (WARNING)
-  'version-skew',        // an agent version present elsewhere, absent here (WARNING)
-  'orphan',              // orphan resources in a version home (WARNING)
-  'duplicate-hook',      // one hook materialized in several version homes, byte-identical (WARNING)
-  'duplicate-hook-drift',// …with differing content, so a stale copy can disagree (CRITICAL)
-  'rc-secret-export',    // credential-shaped export in a shell rc file (WARNING)
-  'exec-policy',         // Windows execution policy blocks agents.ps1 (WARNING)
+  'logged-out',          // provable per-version logout
+  'logout-unprovable',   // credential absent but not provable
+  'missing-hook',        // a declared hook absent from a version home
+  'missing-plugin',      // a declared plugin absent from a version home
+  'unwired-hook',        // hook present on disk but not wired into settings.json
+  'cli-missing',         // a managed agent whose binary won't resolve
+  'missing-resource',    // a missing command/skill/rule/mcp/permission/subagent
+  'content-drift',       // a resource diverged from source
+  'never-synced',         // installed but never synced
+  'stale',               // sources changed since last sync
+  'repo-behind',         // a config repo behind origin
+  'repo-drift',          // a config repo diverged from the fleet baseline
+  'fleet-resource-gap',  // a resource in another box's central repos, absent here
+  'host-cli-missing',    // a declared host CLI not installed on this box
+  'host-cli-invalid',    // a host-CLI manifest that failed to parse
+  'version-skew',        // an agent version present elsewhere, absent here
+  'orphan',              // orphan resources in a version home
+  'duplicate-hook',      // one hook materialized in several version homes, byte-identical
+  'duplicate-hook-drift',// …with differing content, so a stale copy can disagree
+  'rc-secret-export',    // credential-shaped export in a shell rc file
+  'exec-policy',         // Windows execution policy blocks agents.ps1
   'stale-cli',
 ] as const;
 

--- a/apps/cli/src/lib/devices/doctor-findings.ts
+++ b/apps/cli/src/lib/devices/doctor-findings.ts
@@ -18,13 +18,14 @@
  * with. Keep this list exhaustive; a kind missing from it is a doc that lies.
  *   CRITICAL — logged-out (provable) · missing-hook · missing-plugin ·
  *              unwired-hook (a hook on disk that settings.json never fires) ·
- *              never-synced WHEN the version's declared resources are absent ·
- *              duplicate-hook-drift (copies that DIFFER) · cli-missing.
+ *              cli-missing.
  *   WARNING  — logout-unprovable (hedged) · missing-resource · content-drift ·
- *              stale · never-synced when the version declares nothing to miss ·
- *              repo-behind · repo-drift · version-skew · fleet-resource-gap ·
- *              orphan · duplicate-hook (identical copies) · host-cli-missing ·
- *              host-cli-invalid · rc-secret-export · exec-policy · stale-cli.
+ *              never-synced · stale · repo-behind · repo-drift · version-skew ·
+ *              fleet-resource-gap · orphan · duplicate-hook ·
+ *              duplicate-hook-drift · host-cli-missing · host-cli-invalid ·
+ *              rc-secret-export · exec-policy · stale-cli.
+ *   (RUSH-2162 moved never-synced and duplicate-hook-drift to WARNING: both are
+ *   stale-sync states one `agents sync` resolves, not "needs you now".)
  *
  * This module is pure: it maps already-collected signals (drift rows, orphan
  * rows, repo-behind markers, per-version resource diffs, cross-device divergence,
@@ -116,6 +117,46 @@ export const ALL_FINDING_KINDS = [
   'exec-policy',         // Windows execution policy blocks agents.ps1 (WARNING)
   'stale-cli',
 ] as const;
+
+/**
+ * The severity each kind is emitted with - the SINGLE source of truth, read by
+ * the builders below and asserted against both prose rubrics by
+ * `doctor-findings.test.ts`.
+ *
+ * It exists because severity drifted: the rubrics claimed `never-synced` and
+ * `duplicate-hook-drift` were critical for three days after RUSH-2162 downgraded
+ * them, and the exhaustiveness test missed it because it only checked that a kind
+ * was *named* in the rubric, not which bucket it sat in. Change a severity HERE
+ * and the test names the docs that must move with it.
+ */
+export const FINDING_SEVERITY: Record<FindingKind, FindingSeverity> = {
+  // Needs you now: the harness cannot do its job until this is fixed.
+  'logged-out': 'critical',
+  'missing-hook': 'critical',
+  'missing-plugin': 'critical',
+  'unwired-hook': 'critical',
+  'cli-missing': 'critical',
+  // Everything else is resolvable by a routine sync/cleanup and does not block
+  // the harness right now. RUSH-2162 moved never-synced and duplicate-hook-drift
+  // here: both are stale-sync states that one `agents sync` resolves.
+  'logout-unprovable': 'warning',
+  'missing-resource': 'warning',
+  'content-drift': 'warning',
+  'never-synced': 'warning',
+  'stale': 'warning',
+  'repo-behind': 'warning',
+  'repo-drift': 'warning',
+  'fleet-resource-gap': 'warning',
+  'version-skew': 'warning',
+  'orphan': 'warning',
+  'duplicate-hook': 'warning',
+  'duplicate-hook-drift': 'warning',
+  'host-cli-missing': 'warning',
+  'host-cli-invalid': 'warning',
+  'rc-secret-export': 'warning',
+  'exec-policy': 'warning',
+  'stale-cli': 'warning',
+};
 
 /** A machine-stable class for a finding. Derived from the runtime list above so
  *  the rubric test can enumerate every kind. */
@@ -350,7 +391,7 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
   // cli-missing (managed agent, binary broken) — critical.
   for (const agent of input.cliMissing ?? []) {
     out.push(finding({
-      severity: 'critical', kind: 'cli-missing', device, agent,
+      severity: FINDING_SEVERITY['cli-missing'], kind: 'cli-missing', device, agent,
       message: `${agentName(agent)} binary not found`,
     }));
   }
@@ -364,18 +405,18 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
     if (w?.supported) {
       if (w.settingsMissing) {
         out.push(finding({
-          severity: 'critical', kind: 'unwired-hook', device, agent, version,
+          severity: FINDING_SEVERITY['unwired-hook'], kind: 'unwired-hook', device, agent, version,
           message: `settings.json missing — ${w.expected ?? 0} declared hook${(w.expected ?? 0) === 1 ? '' : 's'} never fire`,
         }));
       } else if (w.settingsUnparseable) {
         out.push(finding({
-          severity: 'critical', kind: 'unwired-hook', device, agent, version,
+          severity: FINDING_SEVERITY['unwired-hook'], kind: 'unwired-hook', device, agent, version,
           message: `settings.json unparseable — hook wiring can't be verified`,
         }));
       } else {
         for (const u of w.unwired) {
           out.push(finding({
-            severity: 'critical', kind: 'unwired-hook', device, agent, version,
+            severity: FINDING_SEVERITY['unwired-hook'], kind: 'unwired-hook', device, agent, version,
             message: `hook '${u.name}' present on disk but not wired into settings.json`,
           }));
         }
@@ -425,16 +466,16 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
           missingPlugins.length ? `${missingPlugins.length} plugin${missingPlugins.length === 1 ? '' : 's'}` : '',
         ].filter(Boolean).join(', ');
         out.push(finding({
-          severity: 'warning', kind: 'never-synced', device, agent, version,
+          severity: FINDING_SEVERITY['never-synced'], kind: 'never-synced', device, agent, version,
           message: `never synced — ${total} resource${total === 1 ? '' : 's'}${breakdown ? ` (incl. ${breakdown})` : ''} not installed`,
         }));
       }
     } else {
       // Synced-but-drifted: one line per kind of gap on this version.
-      emitGroup(out, missingHooks, 'critical', 'missing-hook', device, agent, version, 'hook', 'missing');
-      emitGroup(out, missingPlugins, 'critical', 'missing-plugin', device, agent, version, 'plugin', 'missing');
-      emitGroup(out, missingOther, 'warning', 'missing-resource', device, agent, version, 'resource', 'missing');
-      emitGroup(out, drifted, 'warning', 'content-drift', device, agent, version, 'resource', 'drifted');
+      emitGroup(out, missingHooks, FINDING_SEVERITY['missing-hook'], 'missing-hook', device, agent, version, 'hook', 'missing');
+      emitGroup(out, missingPlugins, FINDING_SEVERITY['missing-plugin'], 'missing-plugin', device, agent, version, 'plugin', 'missing');
+      emitGroup(out, missingOther, FINDING_SEVERITY['missing-resource'], 'missing-resource', device, agent, version, 'resource', 'missing');
+      emitGroup(out, drifted, FINDING_SEVERITY['content-drift'], 'content-drift', device, agent, version, 'resource', 'drifted');
       if (missingHooks.length + missingPlugins.length + missingOther.length + drifted.length > 0) {
         detailedVersions.add(`${agent}@${version}`);
       }
@@ -450,7 +491,7 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
     if (row.status === 'stale') {
       if (detailedVersions.has(`${row.agent}@${row.version}`)) continue;
       out.push(finding({
-        severity: 'warning', kind: 'stale', device, agent: row.agent, version: row.version,
+        severity: FINDING_SEVERITY['stale'], kind: 'stale', device, agent: row.agent, version: row.version,
         message: 'sources changed since last sync',
       }));
     } else if (row.status === 'never-synced') {
@@ -463,7 +504,7 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
       );
       if (!hadCritical) {
         out.push(finding({
-          severity: 'warning', kind: 'never-synced', device, agent: row.agent, version: row.version,
+          severity: FINDING_SEVERITY['never-synced'], kind: 'never-synced', device, agent: row.agent, version: row.version,
           message: 'installed but never synced',
         }));
       }
@@ -477,7 +518,7 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
     const stales = input.syncRows.filter((r) => r.status === 'stale').length;
     const staleNote = stales > 0 ? ` → stales ${stales} version${stales === 1 ? '' : 's'}` : '';
     out.push(finding({
-      severity: 'warning', kind: 'repo-behind', device, version: m.alias,
+      severity: FINDING_SEVERITY['repo-behind'], kind: 'repo-behind', device, version: m.alias,
       message: `${m.behind} behind ${m.branch}${staleNote}`,
     }));
   }
@@ -493,7 +534,7 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
   const missingClis = (input.hostClis?.statuses ?? []).filter((c) => !c.installed).map((c) => c.name);
   if (missingClis.length > 0) {
     out.push({
-      severity: 'warning', kind: 'host-cli-missing', device,
+      severity: FINDING_SEVERITY['host-cli-missing'], kind: 'host-cli-missing', device,
       message: missingClis.length === 1
         ? `host CLI '${missingClis[0]}' declared but not installed`
         : `${missingClis.length} declared host CLIs not installed (${missingClis.slice(0, 2).join(', ')}${missingClis.length > 2 ? ', …' : ''})`,
@@ -509,7 +550,7 @@ export function buildLocalFindings(input: LocalFindingInputs): DoctorFinding[] {
   // row per bad file, since each needs its own edit.
   for (const e of input.hostClis?.errors ?? []) {
     out.push(finding({
-      severity: 'warning', kind: 'host-cli-invalid', device,
+      severity: FINDING_SEVERITY['host-cli-invalid'], kind: 'host-cli-invalid', device,
       message: `host-CLI manifest ${e.file} could not be read: ${e.reason}`,
     }));
   }
@@ -545,7 +586,7 @@ function orphanFinding(device: string, rows: OrphanRow[]): DoctorFinding[] {
     ? `${affected[0].agent}@${affected[0].version}`
     : `${affected.length} versions`;
   return [finding({
-    severity: 'warning', kind: 'orphan', device,
+    severity: FINDING_SEVERITY['orphan'], kind: 'orphan', device,
     message: `${total} orphaned resource${total === 1 ? '' : 's'} on ${where} (cleanup only)`,
   })];
 }
@@ -585,7 +626,7 @@ function duplicateHookFindings(device: string, dups: DuplicateVersionHook[]): Do
       // stale/sync drift, not a missing hook. Resolvable by one sync; a WARNING,
       // not a "needs you now" critical. (A genuinely MISSING hook stays critical
       // via the missing-hook path.)
-      severity: 'warning',
+      severity: FINDING_SEVERITY[drift ? 'duplicate-hook-drift' : 'duplicate-hook'],
       kind: drift ? 'duplicate-hook-drift' : 'duplicate-hook',
       device, agent, versions, message,
       remediation: `agents sync ${agent}@all --yes`,
@@ -628,7 +669,7 @@ function rcSecretFindings(device: string, rc: RcSecretFinding[]): DoctorFinding[
         ? 'agents secrets add, then delete the rc line'
         : `agents secrets add once per export (${n}), then delete each rc line`;
     out.push({
-      severity: 'warning', kind: 'rc-secret-export', device,
+      severity: FINDING_SEVERITY['rc-secret-export'], kind: 'rc-secret-export', device,
       message: `${what} (${examples}) — readable by any same-user process`,
       remediation,
     });
@@ -651,7 +692,7 @@ function execPolicyFinding(
   if (!execPolicy || execPolicy.platform !== 'win32') return null;
   if (!blocksLocalScripts(execPolicy.policy)) return null;
   return finding({
-    severity: 'warning', kind: 'exec-policy', device,
+    severity: FINDING_SEVERITY['exec-policy'], kind: 'exec-policy', device,
     message: `PowerShell execution policy is ${execPolicy.policy} — it blocks the generated agents.ps1 launcher (agents.cmd still works)`,
   });
 }
@@ -744,13 +785,13 @@ export function signInToFindings(
       if (row.signedIn) continue;
       if (row.provable) {
         out.push(finding({
-          severity: 'critical', kind: 'logged-out', device, agent, version: row.version,
+          severity: FINDING_SEVERITY['logged-out'], kind: 'logged-out', device, agent, version: row.version,
           account: row.account ?? null,
           message: 'logged out — no account signed in',
         }));
       } else {
         out.push(finding({
-          severity: 'warning', kind: 'logout-unprovable', device, agent, version: row.version,
+          severity: FINDING_SEVERITY['logout-unprovable'], kind: 'logout-unprovable', device, agent, version: row.version,
           account: row.account ?? null,
           message: 'could not verify sign-in',
         }));
@@ -779,14 +820,14 @@ export function fleetDivergenceToFindings(
       case 'agent-version-missing-remote':
       case 'agent-version-missing-local':
         out.push(finding({
-          severity: 'warning', kind: 'version-skew', device: laggingDevice,
+          severity: FINDING_SEVERITY['version-skew'], kind: 'version-skew', device: laggingDevice,
           agent: d.category as AgentId, version: d.name,
           message: 'not installed (present elsewhere in the fleet)',
         }));
         break;
       case 'repo-drift':
         out.push(finding({
-          severity: 'warning', kind: 'repo-drift', device: laggingDevice,
+          severity: FINDING_SEVERITY['repo-drift'], kind: 'repo-drift', device: laggingDevice,
           // `category` is the repo ('agents' | 'system'); carry it as the alias
           // `agents repo pull` expects — ~/.agents is the `user` repo.
           version: d.category === 'system' ? 'system' : 'user',
@@ -796,7 +837,7 @@ export function fleetDivergenceToFindings(
       case 'resource-missing-remote':
       case 'resource-missing-local':
         out.push(finding({
-          severity: 'warning', kind: 'fleet-resource-gap', device: laggingDevice,
+          severity: FINDING_SEVERITY['fleet-resource-gap'], kind: 'fleet-resource-gap', device: laggingDevice,
           message: `${d.category.replace(/s$/, '')} '${d.name}' missing (present elsewhere)`,
         }));
         break;


### PR DESCRIPTION
**docs + refactor + test-only — no behavior change.** Every emitted severity is byte-identical to what RUSH-2162 set; this makes the docs tell the truth about it and makes that mechanically enforced.

## What was wrong

`RUSH-2162` (#1904) moved `never-synced` and `duplicate-hook-drift` from critical to warning. The code changed; **three** prose rubrics did not, and have claimed the wrong severity since 2026-08-02:

| Rubric | Claimed | Actual |
|---|---|---|
| `apps/cli/AGENTS.md` | `never-synced`, `duplicate-hook-drift` critical | warning |
| `doctor-findings.ts` module docblock | same | warning |
| `docs/06-observability.md` | same | warning |

Caught by running the **installed** `agents doctor` (1.22.13) and noticing `never synced` rendering under `⚠` while every rubric said `✗`.

## Why the existing guard missed it

#1645 added a test asserting every `FindingKind` is *named* in a rubric. A kind named in the **wrong half** still passed — so the guard was one level shy of the invariant it existed for. It also only knew about two of the three rubrics.

## The fix

- **`FINDING_SEVERITY` is the single source of truth.** The builders read their severity from it instead of repeating a literal (22 call sites), so a builder cannot disagree with the declared severity.
- **All three rubrics corrected**, and the test now asserts each kind sits in the correct **bucket** of each — including `docs/06-observability.md`, which the old test did not cover at all.
- **A fourth test drives the real builders** and asserts every emitted finding's `severity === FINDING_SEVERITY[kind]`, so a new builder that hardcodes one fails too.

## Proof the guard bites

Re-introducing the exact drift — moving `never-synced` back to the critical list in `AGENTS.md`:

```
AssertionError: expected [ 'never-synced: critical -> warning' ] to deeply equal []
      Tests  1 failed | 63 skipped (64)
```

It names the kind and both severities, so the failure says what to change.

## Run result

`agents doctor` from this branch, unchanged from `main`'s behavior — `never synced` and duplicate-hook drift render as `⚠`, matching the corrected rubrics:

```
▸ yosemite-s1 · this machine  ✗ 5 critical (above)
    ⚠ claude (2 versions)       never synced — 2 resources (incl. 2 hooks) not installed → agents sync claude@all --yes
    ⚠ antigravity (2 versions)  never synced — 16 resources (incl. 16 hooks) not installed → agents sync antigravity@all --yes
    ⚠ claude (7 versions)       17 hooks differ across 7 versions (incl. '01-git-require-clean-tree', …) — 2.1.219 is authoritative → agents sync claude@all --yes
```

383 tests pass across the touched modules; `tsc --noEmit` clean.

Follow-up to #1645 · related: #1904 (RUSH-2162).
