### PR TITLE
test(routines): isolate activation from host state

### DIFF
--- a/apps/cli/src/lib/__tests__/runner.test.ts
+++ b/apps/cli/src/lib/__tests__/runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -17,6 +17,15 @@ import { getBinaryPath, getVersionDir } from '../versions.js';
 import { rotationFailoverChain, type RotateCandidate, type RotateResult } from '../rotate.js';
 import { detectRateLimit } from '../exec.js';
 import { buildExecCommand } from '../exec.js';
+import * as activation from '../routine-activation.js';
+
+beforeEach(() => {
+  vi.spyOn(activation, 'routineEnabledOnThisDevice').mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function baseJob(overrides: Partial<JobConfig> = {}): JobConfig {
   return {

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -9,6 +9,18 @@ import type { JobConfig, RunMeta } from './routines.js';
 import type { RotateCandidate, RotateResult } from './rotate.js';
 import { saveTask, hostsCacheDir } from './hosts/tasks.js';
 import { _resetPerfDbForTest, aggregateSamples } from './perf/db.js';
+import * as activation from './routine-activation.js';
+
+beforeEach(() => {
+  // These tests pass synthetic definitions directly to the runner. Exercise
+  // legacy definition eligibility explicitly instead of inheriting the host's
+  // real device manifest from a reused local/CI worker.
+  vi.spyOn(activation, 'routineEnabledOnThisDevice').mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 /** Remove every run directory for a job (its parent dir), best-effort. */
 function cleanupJobRuns(jobName: string): void {

--- a/apps/cli/src/lib/triggers/webhook.test.ts
+++ b/apps/cli/src/lib/triggers/webhook.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as http from 'http';
@@ -18,6 +18,15 @@ import {
   createFileDeliveryStore,
   type IncomingWebhook,
 } from './webhook.js';
+import * as activation from '../routine-activation.js';
+
+beforeEach(() => {
+  vi.spyOn(activation, 'routineEnabledOnThisDevice').mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 /** Build a JobConfig with sensible defaults for tests. */
 function job(partial: Partial<JobConfig> & Pick<JobConfig, 'name'>): JobConfig {

--- a/apps/cli/tests/runner-loop.test.ts
+++ b/apps/cli/tests/runner-loop.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'os';
 import type { JobConfig } from '../src/lib/routines.js';
 import type { ExecOptions } from '../src/lib/exec.js';
 import type { LoopDeps, IterationResult } from '../src/lib/loop.js';
+import * as activation from '../src/lib/routine-activation.js';
 
 // Hoist state the same way jobs.test.ts does (works with both vitest's hoist and Bun).
 // The string literal is used inside vi.mock to avoid TDZ issues with const references.
@@ -76,9 +77,11 @@ function makeLoopDeps(calls: ExecOptions[]): LoopDeps {
 beforeEach(() => {
   hoistedState.TEST_DIR = mkdtempSync(join(tmpdir(), 'agents-runner-loop-'));
   mkdirSync(join(hoistedState.TEST_DIR, 'runs'), { recursive: true });
+  vi.spyOn(activation, 'routineEnabledOnThisDevice').mockReturnValue(null);
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   rmSync(hoistedState.TEST_DIR, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
test-only: make direct runner and webhook tests deterministic on reused workers.

## What changed
- Explicitly select legacy definition eligibility in synthetic runner/webhook tests.
- Prevent a real `~/.agents/devices/<hostname>/agents.yaml` from disabling test-only jobs.

## Verification
No user-visible surface; test-only change.

`bunx vitest run src/lib/runner.test.ts src/lib/__tests__/runner.test.ts tests/runner-loop.test.ts src/lib/triggers/webhook.test.ts`

Result: 4 files passed, 78 tests passed.

## Context
Release preflight on a reused crabbox reproduced 24 failures because its real device manifest contained only built-in routines. PR #2029 introduced device-owned activation; these fixtures pass definitions directly and must choose their activation mode explicitly.