### PR TITLE
chore(release): factory 0.9.311

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Factory extension are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); `scripts/release.sh` requires a
 `## [<version>]` section for the version being published.
 
-## [Unreleased]
+## [0.9.311] - 2026-08-05
 
 - **Extension no longer orchestrates tmux.** The Factory VS Code extension previously
   wrapped agent terminals in a local tmux session so it could reattach after window


### PR DESCRIPTION
docs-only — CHANGELOG version bump to cut Factory 0.9.311 release.

Renames `## [Unreleased]` → `## [0.9.311] - 2026-08-05` so `scripts/release.sh 0.9.311` can proceed. No code changes.

Changes in this release (already merged):
- PR #2035: drop extension-level tmux wrapping
- PR #2031: floor data pipeline cache-first
- PR #1999: resume/restore unification