### PR TITLE
perf(factory): persist Floor device and inventory caches

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -21,15 +21,17 @@ All notable changes to the Factory extension are documented here. Format follows
   `src/vscode/terminals.vscode.ts`, `src/core/sessions.persist.ts`.
 
 - **Floor data pipeline: last-good snapshot, no recurring fleet fan-out.** The
-  extension host persists the last successful Floor host/sessions snapshot in
-  `globalState` (`agents.floorSnapshot.v1`) and returns it immediately. Activation
+  extension host persists the last successful Floor host/sessions, device-registry,
+  and agent-inventory snapshots in `globalState` and returns them immediately. Activation
   (panel wire) seeds at most one `agents devices list --json` and one
   `agents sessions --active --local --json`. Remote fleet refresh is user-triggered
   only (`fetchHostSessions` with `force: true` → one bare `agents sessions --active
   --json`); failures keep last-good rows and record per-host freshness. Dispatch
   opens from cached inventory + last-good sessions and no longer probes per-device
-  CPU/memory. SnapshotDetector's 4s tick no longer runs `agents view --json`
-  (inventory is a 60s SWR cache shared only by panel/dispatch). Protocol adds
+  CPU/memory; sidebar/Dispatch device messages reuse the activation registry
+  cache instead of rerunning `devices list`. SnapshotDetector's 4s tick no
+  longer runs `agents view --json` (inventory is a persisted 60s SWR cache
+  shared only by panel/dispatch). Protocol adds
   optional `force` / `hostFreshness` / `fromCache` fields on floor host/local
   session messages. Source: `apps/factory/src/core/floorSnapshot.ts`,
   `apps/factory/src/vscode/remoteSessions.vscode.ts`,

--- a/apps/factory/src/core/floorSnapshot.test.ts
+++ b/apps/factory/src/core/floorSnapshot.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import type { HostInfo, RemoteSession } from './remoteSessions';
 import {
   FLOOR_SNAPSHOT_KEY,
+  FLOOR_DEVICES_KEY,
+  FLOOR_INVENTORY_KEY,
   INVENTORY_CACHE_TTL_MS,
   LOCAL_SESSIONS_BACKSTOP_MS,
   acceptSuccessfulFloorFetch,
@@ -9,7 +11,10 @@ import {
   isInventoryStale,
   isLocalSessionsStale,
   mergeLocalSessionsIntoSnapshot,
+  mergeHostRosterIntoSnapshot,
   parseFloorSnapshot,
+  parseFloorDevicesSnapshot,
+  parseFloorInventorySnapshot,
   retainLastGoodOnFailure,
   shouldRunBareFleetFetch,
   type FloorHostSessionsSnapshot,
@@ -53,6 +58,18 @@ function snap(partial: Partial<FloorHostSessionsSnapshot> = {}): FloorHostSessio
 describe('floorSnapshot pure model', () => {
   test('FLOOR_SNAPSHOT_KEY is stable for globalState', () => {
     expect(FLOOR_SNAPSHOT_KEY).toBe('agents.floorSnapshot.v1');
+    expect(FLOOR_DEVICES_KEY).toBe('agents.floorDevices.v1');
+    expect(FLOOR_INVENTORY_KEY).toBe('agents.floorInventory.v1');
+  });
+
+  test('persisted device and inventory snapshots reject drift', () => {
+    expect(parseFloorDevicesSnapshot({ devices: [], fetchedAt: 10 })).toEqual({ devices: [], fetchedAt: 10 });
+    expect(parseFloorDevicesSnapshot({ devices: [{ name: 's0' }], fetchedAt: 10 })).toBeUndefined();
+    expect(parseFloorInventorySnapshot({ data: { claude: { installed: true } }, fetchedAt: 20 })).toEqual({
+      data: { claude: { installed: true } },
+      fetchedAt: 20,
+    });
+    expect(parseFloorInventorySnapshot({ data: [], fetchedAt: 20 })).toBeUndefined();
   });
 
   test('parseFloorSnapshot rejects drift and accepts a valid shape', () => {
@@ -126,6 +143,28 @@ describe('floorSnapshot pure model', () => {
     expect(merged.hostFreshness['this-mac']).toBe(5000);
     expect(merged.hostFreshness.yosemite).toBe(1000);
     expect(merged.sessions.find((s) => s.host === 'yosemite')?.sessionId).toBe('b');
+  });
+
+  test('mergeHostRosterIntoSnapshot renders registered hosts without erasing last-good rows', () => {
+    const merged = mergeHostRosterIntoSnapshot(snap(), [
+      host('this-mac', true),
+      host('yosemite', false),
+      host('newbox', true),
+    ]);
+    expect(merged.hosts.find((h) => h.name === 'yosemite')).toMatchObject({
+      online: false,
+      agents: 2,
+      uses: 2,
+    });
+    expect(merged.hosts.find((h) => h.name === 'newbox')).toMatchObject({
+      online: true,
+      agents: 0,
+      uses: 0,
+    });
+    expect(merged.sessions.map((s) => s.sessionId).sort()).toEqual(['a', 'b']);
+    expect(merged.hostFreshness.yosemite).toBe(1000);
+    expect(merged.hostFreshness.newbox).toBe(0);
+    expect(merged.fromCache).toBe(true);
   });
 
   test('shouldRunBareFleetFetch: force or cold start only — no recurring fan-out', () => {

--- a/apps/factory/src/core/floorSnapshot.test.ts
+++ b/apps/factory/src/core/floorSnapshot.test.ts
@@ -167,10 +167,8 @@ describe('floorSnapshot pure model', () => {
     expect(merged.fromCache).toBe(true);
   });
 
-  test('shouldRunBareFleetFetch: force or cold start only — no recurring fan-out', () => {
-    expect(shouldRunBareFleetFetch(false, true)).toBe(false); // poll with last-good
-    expect(shouldRunBareFleetFetch(true, true)).toBe(true); // user refresh
-    expect(shouldRunBareFleetFetch(false, false)).toBe(true); // cold seed
-    expect(shouldRunBareFleetFetch(true, false)).toBe(true);
+  test('shouldRunBareFleetFetch: explicit user refresh only', () => {
+    expect(shouldRunBareFleetFetch(false)).toBe(false);
+    expect(shouldRunBareFleetFetch(true)).toBe(true);
   });
 });

--- a/apps/factory/src/core/floorSnapshot.ts
+++ b/apps/factory/src/core/floorSnapshot.ts
@@ -11,6 +11,12 @@ import type { HostGroup, HostInfo, RemoteSession } from './remoteSessions';
 /** globalState key for the last successful Floor host/sessions snapshot. */
 export const FLOOR_SNAPSHOT_KEY = 'agents.floorSnapshot.v1';
 
+/** globalState key for the last successful devices registry read. */
+export const FLOOR_DEVICES_KEY = 'agents.floorDevices.v1';
+
+/** globalState key for the last successful agent inventory read. */
+export const FLOOR_INVENTORY_KEY = 'agents.floorInventory.v1';
+
 /**
  * How long a non-force local seed may stand before a bounded local-only
  * backstop revalidates (`sessions --active --local --json` only — never SSH).
@@ -33,6 +39,65 @@ export interface FloorHostSessionsSnapshot {
   hostFreshness: Record<string, number>;
   /** True when this result was served from cache without a fresh CLI call. */
   fromCache?: boolean;
+}
+
+/** Persisted registry row. Kept core-only so parsing does not depend on VS Code. */
+export interface FloorDevice {
+  name: string;
+  host: string;
+  platform?: string;
+  online?: boolean;
+  registeredAt: number;
+}
+
+export interface FloorDevicesSnapshot {
+  devices: FloorDevice[];
+  fetchedAt: number;
+}
+
+export interface FloorInventorySnapshot {
+  data: Record<string, unknown>;
+  fetchedAt: number;
+}
+
+/** Shape-check persisted device registry data before hydrating the module cache. */
+export function parseFloorDevicesSnapshot(raw: unknown): FloorDevicesSnapshot | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const candidate = raw as Partial<FloorDevicesSnapshot>;
+  if (!Array.isArray(candidate.devices)) return undefined;
+  if (typeof candidate.fetchedAt !== 'number' || !Number.isFinite(candidate.fetchedAt)) return undefined;
+  const devices: FloorDevice[] = [];
+  for (const value of candidate.devices) {
+    if (!value || typeof value !== 'object') return undefined;
+    const device = value as Partial<FloorDevice>;
+    if (
+      typeof device.name !== 'string'
+      || !device.name
+      || typeof device.host !== 'string'
+      || !device.host
+      || typeof device.registeredAt !== 'number'
+      || !Number.isFinite(device.registeredAt)
+    ) {
+      return undefined;
+    }
+    devices.push({
+      name: device.name,
+      host: device.host,
+      platform: typeof device.platform === 'string' ? device.platform : undefined,
+      online: typeof device.online === 'boolean' ? device.online : undefined,
+      registeredAt: device.registeredAt,
+    });
+  }
+  return { devices, fetchedAt: candidate.fetchedAt };
+}
+
+/** Shape-check persisted agent inventories without assuming vendor-specific fields. */
+export function parseFloorInventorySnapshot(raw: unknown): FloorInventorySnapshot | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const candidate = raw as Partial<FloorInventorySnapshot>;
+  if (!candidate.data || typeof candidate.data !== 'object' || Array.isArray(candidate.data)) return undefined;
+  if (typeof candidate.fetchedAt !== 'number' || !Number.isFinite(candidate.fetchedAt)) return undefined;
+  return { data: candidate.data as Record<string, unknown>, fetchedAt: candidate.fetchedAt };
 }
 
 /** Shape-check a value read back from globalState; returns undefined on drift. */
@@ -163,6 +228,42 @@ export function mergeLocalSessionsIntoSnapshot(
     fetchedAt: previous?.fetchedAt && previous.fetchedAt > fetchedAt ? previous.fetchedAt : fetchedAt,
     hostFreshness,
     fromCache: false,
+  };
+}
+
+/**
+ * Fold the registry roster into last-good Floor state without claiming a
+ * sessions refresh. Existing counts/load/freshness survive; newly registered
+ * hosts render immediately with zero counts and freshness 0.
+ */
+export function mergeHostRosterIntoSnapshot(
+  previous: FloorHostSessionsSnapshot | null | undefined,
+  roster: readonly HostInfo[],
+): FloorHostSessionsSnapshot {
+  const previousHosts = new Map((previous?.hosts ?? []).map((host) => [host.name, host]));
+  const sessions = previous?.sessions ?? [];
+  const sessionHosts = new Set(sessions.map((session) => session.host));
+  const hosts = roster.map((host) => {
+    const prior = previousHosts.get(host.name);
+    return prior
+      ? { ...prior, online: host.online }
+      : host;
+  });
+  const rosterNames = new Set(hosts.map((host) => host.name));
+  for (const prior of previous?.hosts ?? []) {
+    if (!rosterNames.has(prior.name) && sessionHosts.has(prior.name)) hosts.push(prior);
+  }
+  const hostFreshness: Record<string, number> = { ...(previous?.hostFreshness ?? {}) };
+  for (const host of hosts) {
+    if (hostFreshness[host.name] === undefined) hostFreshness[host.name] = 0;
+  }
+  return {
+    hosts,
+    sessions,
+    groups: previous?.groups ?? [],
+    fetchedAt: previous?.fetchedAt ?? 0,
+    hostFreshness,
+    fromCache: true,
   };
 }
 

--- a/apps/factory/src/core/floorSnapshot.ts
+++ b/apps/factory/src/core/floorSnapshot.ts
@@ -277,13 +277,7 @@ export function isInventoryStale(
   return now - fetchedAt >= ttlMs;
 }
 
-/**
- * Whether a `fetchHostSessions` call should invoke the bare fleet CLI.
- * force=true always; otherwise only on cold start (no last-good).
- */
-export function shouldRunBareFleetFetch(
-  force: boolean,
-  hasLastGood: boolean,
-): boolean {
-  return force || !hasLastGood;
+/** Only an explicit user refresh may invoke the bare fleet CLI. */
+export function shouldRunBareFleetFetch(force: boolean): boolean {
+  return force;
 }

--- a/apps/factory/src/vscode/deviceHealth.vscode.test.ts
+++ b/apps/factory/src/vscode/deviceHealth.vscode.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, test } from 'bun:test';
+import {
+  getRegisteredDevicesCache,
+  setRegisteredDevicesCache,
+  __deviceHealthTestCounters,
+} from './deviceHealth.vscode';
+
+afterEach(() => {
+  setRegisteredDevicesCache(null);
+  __deviceHealthTestCounters.reset();
+});
+
+test('registered-device cache returns last-good rows without a CLI call', () => {
+  setRegisteredDevicesCache([
+    { name: 'yosemite-s0', host: 'yosemite-s0.tailnet', online: true, registeredAt: 1 },
+  ]);
+  const before = __deviceHealthTestCounters.registeredDeviceCliCalls;
+  const first = getRegisteredDevicesCache();
+  const second = getRegisteredDevicesCache();
+  expect(__deviceHealthTestCounters.registeredDeviceCliCalls).toBe(before);
+  expect(first).toEqual(second);
+  expect(first?.[0]?.name).toBe('yosemite-s0');
+});
+
+test('registered-device cache does not expose mutable internal rows', () => {
+  setRegisteredDevicesCache([
+    { name: 'yosemite-s0', host: 'yosemite-s0.tailnet', online: true, registeredAt: 1 },
+  ]);
+  const read = getRegisteredDevicesCache();
+  read![0].online = false;
+  expect(getRegisteredDevicesCache()?.[0]?.online).toBe(true);
+});

--- a/apps/factory/src/vscode/deviceHealth.vscode.ts
+++ b/apps/factory/src/vscode/deviceHealth.vscode.ts
@@ -42,27 +42,53 @@ interface AgentsDeviceEntry {
 // Floor background paths MUST use this registry read only — never
 // `agents doctor`, `agents devices status`, `agents fleet status`, or
 // `agents projects status` on a recurring/activation path.
+let registeredDevicesCache: Device[] | null = null;
+
+export const __deviceHealthTestCounters = {
+  registeredDeviceCliCalls: 0,
+  reset() {
+    this.registeredDeviceCliCalls = 0;
+  },
+};
+
+export function setRegisteredDevicesCache(devices: readonly Device[] | null): void {
+  registeredDevicesCache = devices ? devices.map((device) => ({ ...device })) : null;
+}
+
+export function getRegisteredDevicesCache(): Device[] | null {
+  return registeredDevicesCache?.map((device) => ({ ...device })) ?? null;
+}
+
+/** Strict registry read used by the one activation seed. */
+export async function fetchRegisteredDevices(): Promise<Device[]> {
+  __deviceHealthTestCounters.registeredDeviceCliCalls++;
+  const bin = await resolveAgentsBin();
+  // 20s, not 8s: on a loaded box the CLI's per-run startup alone can exceed
+  // 8s. The Floor never blocks rendering on this call; it starts with persisted
+  // data and refreshes the cache once in the background.
+  const { stdout } = await execFileAsync(bin, ['devices', 'list', '--json'], {
+    timeout: 20_000,
+    env: augmentedEnv(bin),
+  });
+  const parsed = JSON.parse(stdout) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('agents devices list --json: expected a JSON array');
+  }
+  const devices = (parsed as AgentsDeviceEntry[]).map((d) => ({
+    name: d.name,
+    host: d.address?.dnsName || d.name,
+    platform: d.platform,
+    online: isDeviceOnline(d.tailscale),
+    registeredAt: d.createdAt ? Date.parse(d.createdAt) || 0 : 0,
+  }));
+  setRegisteredDevicesCache(devices);
+  return devices;
+}
+
+/** Existing non-Floor callers keep their empty-list error contract. */
 export async function listRegisteredDevices(): Promise<Device[]> {
   try {
-    const bin = await resolveAgentsBin();
-    // 20s, not 8s: on a loaded box the CLI's per-run startup alone can exceed
-    // 8s. The host picker's render path never waits on this (it renders from
-    // the persisted snapshot and refreshes in the background); cold-start
-    // callers like the browse-device switcher and balanced-launch still await
-    // it directly, so the timeout stays bounded rather than removed.
-    const { stdout } = await execFileAsync(bin, ['devices', 'list', '--json'], {
-      timeout: 20_000,
-      env: augmentedEnv(bin),
-    });
-    const parsed = JSON.parse(stdout) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return (parsed as AgentsDeviceEntry[]).map((d) => ({
-      name: d.name,
-      host: d.address?.dnsName || d.name,
-      platform: d.platform,
-      online: isDeviceOnline(d.tailscale),
-      registeredAt: d.createdAt ? Date.parse(d.createdAt) || 0 : 0,
-    }));
+    return await fetchRegisteredDevices();
   } catch {
     return [];
   }

--- a/apps/factory/src/vscode/remoteSessions.vscode.test.ts
+++ b/apps/factory/src/vscode/remoteSessions.vscode.test.ts
@@ -6,8 +6,14 @@ import {
   __resetRemoteSessionsCachesForTests,
   fetchHostSessions,
   fetchLocalSessions,
+  discoverHosts,
+  seedFloorHostsFromDevices,
   __remoteSessionsTestCounters,
 } from './remoteSessions.vscode';
+import {
+  __deviceHealthTestCounters,
+  setRegisteredDevicesCache,
+} from './deviceHealth.vscode';
 import {
   acceptSuccessfulFloorFetch,
   retainLastGoodOnFailure,
@@ -58,6 +64,8 @@ test('an empty list resolves to an empty array', async () => {
 
 afterEach(() => {
   __resetRemoteSessionsCachesForTests();
+  setRegisteredDevicesCache(null);
+  __deviceHealthTestCounters.reset();
 });
 
 function sampleSnap(): FloorHostSessionsSnapshot {
@@ -145,3 +153,29 @@ test('hydrate retains full last-good including remote rows; fail path cannot emp
   expect(kept?.fromCache).toBe(true);
 });
 
+test('discoverHosts reuses the activation device cache without another devices CLI call', async () => {
+  setRegisteredDevicesCache([
+    { name: 'worker', host: 'worker.tailnet', online: true, registeredAt: 1 },
+  ]);
+  const before = __deviceHealthTestCounters.registeredDeviceCliCalls;
+  const hosts = await discoverHosts();
+  expect(__deviceHealthTestCounters.registeredDeviceCliCalls).toBe(before);
+  expect(hosts.some((host) => host.name === 'worker' && host.online)).toBe(true);
+});
+
+test('activation device seed adds registered hosts while retaining last-good sessions', () => {
+  const snap = sampleSnap();
+  let written: FloorHostSessionsSnapshot | null = null;
+  setFloorSnapshotStore({
+    read: () => snap,
+    write: (next) => {
+      written = next;
+    },
+  });
+  const merged = seedFloorHostsFromDevices([
+    { name: 'newbox', host: 'newbox.tailnet', online: true },
+  ]);
+  expect(merged.hosts.some((host) => host.name === 'newbox')).toBe(true);
+  expect(merged.sessions.map((session) => session.sessionId).sort()).toEqual(['local-1', 'remote-1']);
+  expect(written?.hosts.some((host) => host.name === 'newbox')).toBe(true);
+});

--- a/apps/factory/src/vscode/remoteSessions.vscode.test.ts
+++ b/apps/factory/src/vscode/remoteSessions.vscode.test.ts
@@ -98,7 +98,7 @@ test('setFloorSnapshotStore hydrates last-good so non-force fetchHostSessions do
     },
   });
   expect(getLastGoodFloorSnapshot()?.sessions).toHaveLength(2);
-  expect(shouldRunBareFleetFetch(false, true)).toBe(false);
+  expect(shouldRunBareFleetFetch(false)).toBe(false);
 
   __remoteSessionsTestCounters.reset();
   const before = __remoteSessionsTestCounters.bareActiveCalls;
@@ -111,6 +111,21 @@ test('setFloorSnapshotStore hydrates last-good so non-force fetchHostSessions do
   expect(b.sessions.map((s) => s.sessionId).sort()).toEqual(['local-1', 'remote-1']);
   expect(c.hostFreshness?.yosemite).toBe(1000);
   expect(written).toBeNull(); // non-force read does not rewrite
+});
+
+test('cold non-force host read is cache-only before activation seeding', async () => {
+  __remoteSessionsTestCounters.reset();
+  __deviceHealthTestCounters.reset();
+
+  const result = await fetchHostSessions(Date.now(), { force: false });
+
+  expect(result.fromCache).toBe(true);
+  expect(result.hosts).toEqual([
+    { name: 'this-mac', online: true, agents: 0, load: 'idle', uses: 0 },
+  ]);
+  expect(result.sessions).toEqual([]);
+  expect(__remoteSessionsTestCounters.bareActiveCalls).toBe(0);
+  expect(__deviceHealthTestCounters.registeredDeviceCliCalls).toBe(0);
 });
 
 test('retainLastGoodOnFailure keeps remote rows when a refresh fails', () => {

--- a/apps/factory/src/vscode/remoteSessions.vscode.ts
+++ b/apps/factory/src/vscode/remoteSessions.vscode.ts
@@ -37,11 +37,17 @@ import { deriveHostLoad, parseRemoteCpuRatio } from '../core/dispatchRanking';
 import {
   acceptSuccessfulFloorFetch,
   isLocalSessionsStale,
+  mergeHostRosterIntoSnapshot,
   mergeLocalSessionsIntoSnapshot,
   retainLastGoodOnFailure,
   type FloorHostSessionsSnapshot,
 } from '../core/floorSnapshot';
-import { listRegisteredDevices, type Device, type DeviceRef } from './deviceHealth.vscode';
+import {
+  getRegisteredDevicesCache,
+  listRegisteredDevices,
+  type Device,
+  type DeviceRef,
+} from './deviceHealth.vscode';
 
 const execFileAsync = promisify(execFile);
 const execAsync = promisify(exec);
@@ -253,13 +259,36 @@ async function findAgentsCli(): Promise<string> {
  * and threads the same list through).
  */
 export async function discoverHosts(devices?: readonly DeviceRef[]): Promise<ReconciledHost[]> {
-  const registered = devices ?? await listRegisteredDevices();
+  const registered = devices ?? getRegisteredDevicesCache() ?? await listRegisteredDevices();
   const inputs: RegisteredDeviceInput[] = registered.map((d) => ({
     name: d.name,
     address: d.host,
     online: d.online === true,
   }));
   return reconcileHosts(inputs, LOCAL_HOST);
+}
+
+/** Render the activation registry roster into last-good Floor state without SSH. */
+export function seedFloorHostsFromDevices(devices: readonly DeviceRef[]): FloorHostSessionsSnapshot {
+  const inputs: RegisteredDeviceInput[] = devices.map((device) => ({
+    name: device.name,
+    address: device.host,
+    online: device.online === true,
+  }));
+  const roster = reconcileHosts(inputs, LOCAL_HOST).map((host): HostInfo => {
+    const name = host.isLocal ? LOCAL_LABEL : normalizeHost(host.name);
+    const online = host.isLocal || host.online;
+    return {
+      name,
+      online,
+      agents: 0,
+      load: online ? 'idle' : 'off',
+      uses: 0,
+    };
+  });
+  const merged = mergeHostRosterIntoSnapshot(lastGoodFloor, roster);
+  persistFloor(merged);
+  return merged;
 }
 
 // --- Tier-1: active fetch ---------------------------------------------------

--- a/apps/factory/src/vscode/remoteSessions.vscode.ts
+++ b/apps/factory/src/vscode/remoteSessions.vscode.ts
@@ -152,7 +152,7 @@ const FANOUT_TIMEOUT_MS = 15000;
 const DETAIL_TIMEOUT_MS = 15000;
 // Remote fleet refresh is user-triggered only — short TTL no longer revalidates
 // the bare SSH sweep on every poll. Last-good is retained indefinitely until
-// force or cold seed.
+// an explicit manual refresh.
 const CACHE_TTL_MS = 4000;
 // Local polls used to re-spawn every 1.5s; the Floor performance track uses a
 // 60s local-only backstop instead (see isLocalSessionsStale). Concurrent callers
@@ -609,8 +609,8 @@ function offlineHostInfo(name: string): HostInfo {
 /**
  * Tier-1 fleet sessions.
  *
- * - force=false + last-good exists → return last-good immediately (no CLI).
- * - force=true OR cold start → ONE bare `agents sessions --active --json`.
+ * - force=false → return last-good or an empty local snapshot immediately (no CLI).
+ * - force=true → ONE bare `agents sessions --active --json`.
  * - Failure → retain last-good rows (never wipe the Floor).
  * - Concurrent callers share the in-flight promise (coalescing).
  *
@@ -625,20 +625,39 @@ export async function fetchHostSessions(
   const projectRules = opts.projectRules ?? [];
   const rulesKey = projectRulesKey(projectRules);
 
-  // Serve last-good without a fleet CLI call unless forced or cold.
-  // Policy: shouldRunBareFleetFetch(force, !!lastGoodFloor) === false here.
-  if (!force && lastGoodFloor) {
-    const cached = toHostSessionsResult({ ...lastGoodFloor, fromCache: true });
-    return cached;
-  }
-  if (!force && activeCache && fetchedAt - activeCache.at < CACHE_TTL_MS && activeCache.rulesKey === rulesKey) {
-    return { ...activeCache.result, fromCache: true };
+  // Every non-forced read is cache-only, including a true cold start before the
+  // activation seed has populated globalState. This prevents panel mount and
+  // Dispatch from racing activation into a fleet SSH sweep.
+  if (!force) {
+    if (lastGoodFloor) {
+      return toHostSessionsResult({ ...lastGoodFloor, fromCache: true });
+    }
+    if (activeCache && fetchedAt - activeCache.at < CACHE_TTL_MS && activeCache.rulesKey === rulesKey) {
+      return { ...activeCache.result, fromCache: true };
+    }
+    const local: HostInfo = {
+      name: LOCAL_LABEL,
+      online: true,
+      agents: 0,
+      load: 'idle',
+      uses: 0,
+    };
+    return {
+      hosts: [local],
+      sessions: [],
+      groups: [{ host: LOCAL_LABEL, online: true, fetchedAt: 0, sessions: [] }],
+      fetchedAt: 0,
+      hostFreshness: { [LOCAL_LABEL]: 0 },
+      fromCache: true,
+    };
   }
   if (activeInFlight) return activeInFlight;
 
   activeInFlight = (async () => {
     try {
-      const hosts = await discoverHosts();
+      // Reuse the activation registry cache. Even a manual refresh must run only
+      // the one bare active-session command, never a second devices-list command.
+      const hosts = await discoverHosts(getRegisteredDevicesCache() ?? []);
       // ONE bare fan-out: the CLI runs its own cross-machine SSH sweep.
       __remoteSessionsTestCounters.bareActiveCalls++;
       const fan = await withHardTimeout(

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -63,7 +63,14 @@ import { startForemanAudio, ForemanAudioSession } from './foreman.audio';
 import { runSmartTurn, capHistory } from './foreman.smart';
 import { buildTaskDispatchPrompt } from '../core/tasks';
 import { draftDispatchPrompt, type DraftTicket } from '../core/draftPrompt';
-import { listRegisteredDevices, getDeviceSyncStatus } from './deviceHealth.vscode';
+import {
+  fetchRegisteredDevices,
+  getRegisteredDevicesCache,
+  getDeviceSyncStatus,
+  listRegisteredDevices,
+  setRegisteredDevicesCache,
+  type Device,
+} from './deviceHealth.vscode';
 import { inferProjectCandidates } from '../core/projectIndex';
 import { normalizeHost, buildRemoteFocusCommand } from '../core/remoteSessions';
 import { rankRepos } from '../core/repoIndex';
@@ -71,7 +78,11 @@ import { detectProjects } from '../core/projectDetect';
 import { getSyncStatus } from '../core/repoSync';
 import {
   FLOOR_SNAPSHOT_KEY,
-  INVENTORY_CACHE_TTL_MS,
+  FLOOR_DEVICES_KEY,
+  FLOOR_INVENTORY_KEY,
+  isInventoryStale,
+  parseFloorDevicesSnapshot,
+  parseFloorInventorySnapshot,
   parseFloorSnapshot,
 } from '../core/floorSnapshot';
 import {
@@ -1529,15 +1540,22 @@ let cachedInventories: { data: Record<string, AgentInventory>; fetchedAt: number
 let inventoryFetchInflight: Promise<Record<string, AgentInventory>> | null = null;
 /** Activation seed ran once for this extension host lifetime. */
 let floorActivationSeeded = false;
+let floorActivationSeedPromise: Promise<void> | null = null;
+let floorDataContext: vscode.ExtensionContext | null = null;
 
-async function getCachedAgentInventories(force = false): Promise<Record<string, AgentInventory>> {
-  if (!force && cachedInventories && Date.now() - cachedInventories.fetchedAt < INVENTORY_CACHE_TTL_MS) {
-    return cachedInventories.data;
-  }
+async function revalidateAgentInventories(): Promise<Record<string, AgentInventory>> {
   if (inventoryFetchInflight) return inventoryFetchInflight;
   inventoryFetchInflight = (async () => {
     const data = await fetchAgentInventories(INVENTORY_AGENT_KEYS);
-    cachedInventories = { data, fetchedAt: Date.now() };
+    const fetchedAt = Date.now();
+    cachedInventories = { data, fetchedAt };
+    if (floorDataContext) {
+      await floorDataContext.globalState.update(FLOOR_INVENTORY_KEY, { data, fetchedAt });
+    }
+    settingsPanel?.webview.postMessage({
+      type: 'agentInventoriesData',
+      agentInventories: data,
+    });
     return data;
   })();
   try {
@@ -1547,8 +1565,19 @@ async function getCachedAgentInventories(force = false): Promise<Record<string, 
   }
 }
 
+async function getCachedAgentInventories(force = false): Promise<Record<string, AgentInventory>> {
+  if (force) return revalidateAgentInventories();
+  const current = cachedInventories?.data ?? {};
+  if (isInventoryStale(cachedInventories?.fetchedAt)) {
+    void revalidateAgentInventories().catch((err) =>
+      console.error('[SETTINGS] Agent inventory revalidation failed:', err),
+    );
+  }
+  return current;
+}
+
 function invalidateAgentInventoryCache(): void {
-  cachedInventories = null;
+  if (cachedInventories) cachedInventories.fetchedAt = 0;
 }
 
 /**
@@ -1559,20 +1588,53 @@ function invalidateAgentInventoryCache(): void {
  */
 export async function seedFloorDataPipeline(context: vscode.ExtensionContext): Promise<void> {
   const remote = await import('./remoteSessions.vscode');
+  floorDataContext = context;
   remote.setFloorSnapshotStore({
     read: () => parseFloorSnapshot(context.globalState.get(FLOOR_SNAPSHOT_KEY)) ?? null,
     write: (snap) => {
       void context.globalState.update(FLOOR_SNAPSHOT_KEY, snap);
     },
   });
+  const persistedDevices = parseFloorDevicesSnapshot(context.globalState.get(FLOOR_DEVICES_KEY));
+  if (persistedDevices) {
+    setRegisteredDevicesCache(persistedDevices.devices as Device[]);
+    remote.seedFloorHostsFromDevices(persistedDevices.devices);
+  }
+  const persistedInventory = parseFloorInventorySnapshot(context.globalState.get(FLOOR_INVENTORY_KEY));
+  if (persistedInventory && !cachedInventories) {
+    cachedInventories = {
+      data: persistedInventory.data as Record<string, AgentInventory>,
+      fetchedAt: persistedInventory.fetchedAt,
+    };
+  }
+  if (floorActivationSeedPromise) return floorActivationSeedPromise;
   if (floorActivationSeeded) return;
   floorActivationSeeded = true;
   // One registry read (devices list --json) + one local sessions seed. Never
   // doctor / devices status / fleet status / projects status.
-  await Promise.all([
-    listRegisteredDevices(),
+  floorActivationSeedPromise = Promise.all([
+    (async () => {
+      try {
+        const devices = await fetchRegisteredDevices();
+        const fetchedAt = Date.now();
+        await context.globalState.update(FLOOR_DEVICES_KEY, { devices, fetchedAt });
+        remote.seedFloorHostsFromDevices(devices);
+        settingsPanel?.webview.postMessage({
+          type: 'devicesData',
+          devices,
+          local: normalizeHost(hostname()),
+        });
+      } catch (err) {
+        console.error('[SETTINGS] Device registry activation seed failed:', err);
+      }
+    })(),
     remote.seedLocalSessionsOnce(getSettings(context).projectRules ?? []),
-  ]);
+  ]).then(() => undefined);
+  try {
+    await floorActivationSeedPromise;
+  } finally {
+    floorActivationSeedPromise = null;
+  }
 }
 
 export function openPanel(context: vscode.ExtensionContext): void {
@@ -2031,13 +2093,8 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         // session bucket into this name so the machine shows once under its real
         // name instead of duplicated as 'this-mac' + the registry name.
         const local = normalizeHost(hostname());
-        try {
-          const devices = await listRegisteredDevices();
-          settingsPanel?.webview.postMessage({ type: 'devicesData', devices, local });
-        } catch (err) {
-          console.error('[SETTINGS] Error listing devices:', err);
-          settingsPanel?.webview.postMessage({ type: 'devicesData', devices: [], local });
-        }
+        const devices = getRegisteredDevicesCache() ?? [];
+        settingsPanel?.webview.postMessage({ type: 'devicesData', devices, local });
         break;
       }
       case 'deviceHealth': {
@@ -2046,23 +2103,18 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         // from this path (Factory Floor performance track): online/offline comes
         // from `agents devices list --json` only. Live load is not required to
         // open Dispatch; ranking uses last-good session counts when present.
-        try {
-          const devices = await listRegisteredDevices();
-          const now = Date.now();
-          const health = devices.map((device) => ({
-            device,
-            stats: {
-              host: device.host,
-              reachable: device.online === true,
-              runningAgents: 0,
-              fetchedAt: now,
-            },
-          }));
-          settingsPanel?.webview.postMessage({ type: 'deviceHealthData', health });
-        } catch (err) {
-          console.error('[SETTINGS] Error fetching device health:', err);
-          settingsPanel?.webview.postMessage({ type: 'deviceHealthData', health: [] });
-        }
+        const devices = getRegisteredDevicesCache() ?? [];
+        const now = Date.now();
+        const health = devices.map((device) => ({
+          device,
+          stats: {
+            host: device.host,
+            reachable: device.online === true,
+            runningAgents: 0,
+            fetchedAt: now,
+          },
+        }));
+        settingsPanel?.webview.postMessage({ type: 'deviceHealthData', health });
         break;
       }
       case 'projectCandidates': {
@@ -2433,8 +2485,8 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         // Throughput now rides the CLI payload (ActiveSession.tokPerSec, issue
         // #741): sum the rows belonging to this window's live terminals instead
         // of re-reading and re-parsing each transcript here. fetchLocalSessions
-        // is short-TTL cached, so the 2.5s webview poll shares subprocesses with
-        // the feed poll.
+        // is served from the 60s local last-good backstop, so the 2.5s webview
+        // animation read does not create a recurring CLI subprocess.
         let total = 0;
         try {
           const { fetchLocalSessions } = await import('./remoteSessions.vscode');

--- a/apps/factory/src/vscode/settings.vscode.ts
+++ b/apps/factory/src/vscode/settings.vscode.ts
@@ -1968,22 +1968,14 @@ function wirePanel(panel: vscode.WebviewPanel, context: vscode.ExtensionContext)
         // Dispatch opens from persisted/cached inventory + last-good host sessions.
         // Never probeCpu and never per-device CPU/memory + sessions fan-out.
         try {
-          const { fetchHostSessions, LOCAL_LABEL, getLastGoodFloorSnapshot } = await import('./remoteSessions.vscode');
+          const { fetchHostSessions, LOCAL_LABEL } = await import('./remoteSessions.vscode');
           const inventories = await getCachedAgentInventories();
-          // Prefer last-good (no CLI). Cold open with no snapshot: one non-force
-          // fetchHostSessions may seed once; subsequent opens stay cache-only.
-          const lastGood = getLastGoodFloorSnapshot();
-          const hostResult = lastGood
-            ? {
-                hosts: lastGood.hosts,
-                sessions: lastGood.sessions,
-                groups: lastGood.groups,
-                fetchedAt: lastGood.fetchedAt,
-              }
-            : await fetchHostSessions(Date.now(), {
-                force: false,
-                projectRules: getSettings(context).projectRules ?? [],
-              });
+          // Non-force is cache-only even on a true cold start; activation owns
+          // the one device-registry read and local-session seed.
+          const hostResult = await fetchHostSessions(Date.now(), {
+            force: false,
+            projectRules: getSettings(context).projectRules ?? [],
+          });
           const defaultTitle = context.globalState.get<string>('agents.defaultAgentTitle', 'CC');
           const defaultAgentId = getBuiltInDefByTitle(defaultTitle)?.key ?? 'claude';
           const agents = mapInventoriesToInstalledAgents(inventories, defaultAgentId);


### PR DESCRIPTION
## What changed

Factory now persists the device registry and agent inventory alongside the existing Floor session snapshot. Panel and Dispatch reads reuse those last-good caches. Even a true cold non-forced read returns an empty local cache snapshot, so it cannot race activation into device discovery or fleet SSH.

This is the post-merge completion for #2031 and closes the remaining extension-host cache gaps tracked in #2030.

## Performance contract

- Activation runs at most one `agents devices list --json` and one local `agents sessions --active --local --json`.
- Sidebar, Dispatch, panel mount, and all other non-forced host reads perform zero CLI calls, including cold start.
- A manual remote refresh performs one bare `agents sessions --active --json`; its host roster comes from the activation registry cache.
- Agent inventory is a persisted 60-second stale-while-revalidate cache.
- No Factory daemon is added. Scheduling remains owned by the agents-cli daemon.

## Run result

No new visual surface in this PR; the cache-first UI is in #2033.

```text
bun test src/core/floorSnapshot.test.ts src/vscode/remoteSessions.vscode.test.ts src/vscode/deviceHealth.vscode.test.ts
24 pass
0 fail
78 expect() calls

bun run compile:ext
$ tsc -p ./
```

The broader Factory test directory was also exercised. Three unrelated existing failures remain in removed tmux tests and `htmlReader.test.ts`; none intersects these changed files.

## Review fix

The first independent review found that cold non-forced reads could still fall through to the fleet call. Commit `b2840d17` makes every non-forced read cache-only and adds a zero-CLI cold-start regression test.

## Visual context

![Factory Floor cached agents](https://files.catbox.moe/2aquvk.png)

![Factory Dispatch cached state](https://files.catbox.moe/g6bc3r.png)

Tracking: #2030