### PR TITLE
feat(hooks): discover scripts under one-level group dirs

### DIFF
--- a/apps/cli/.changelog/next/hooks-group-dirs.md
+++ b/apps/cli/.changelog/next/hooks-group-dirs.md
@@ -1,7 +1,7 @@
-- **Hooks: one-level group subdirs (e.g. `hooks/session-starts/`) are first-class.**
-  SessionStart (and other event-family) scripts can live under `hooks/<group>/`
-  while install names stay the file basename. Dirs with top-level scripts expand
-  into individual hooks; fixture-only dirs (e.g. `tests/`) remain directory
-  bundles. Source: `apps/cli/src/lib/hooks.ts`,
+- **Hooks: one-level event dirs (`hooks/<event-name>/<script>`) are first-class.**
+  System hooks organize by harness event (`session-start/`, `pre-tool-use/`, …).
+  Install names stay the file basename. Dirs with top-level scripts expand into
+  individual hooks; fixture-only dirs remain directory bundles. Manifest `script:`
+  may be a relative path under `hooks/`. Source: `apps/cli/src/lib/hooks.ts`,
   `apps/cli/src/lib/staleness/writers/sources.ts`, `apps/cli/src/lib/versions.ts`,
   `apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts`.

--- a/apps/cli/.changelog/next/hooks-group-dirs.md
+++ b/apps/cli/.changelog/next/hooks-group-dirs.md
@@ -1,0 +1,7 @@
+- **Hooks: one-level group subdirs (e.g. `hooks/session-starts/`) are first-class.**
+  SessionStart (and other event-family) scripts can live under `hooks/<group>/`
+  while install names stay the file basename. Dirs with top-level scripts expand
+  into individual hooks; fixture-only dirs (e.g. `tests/`) remain directory
+  bundles. Source: `apps/cli/src/lib/hooks.ts`,
+  `apps/cli/src/lib/staleness/writers/sources.ts`, `apps/cli/src/lib/versions.ts`,
+  `apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **Hooks: one-level group subdirs (e.g. `hooks/session-starts/`) are first-class.**
-  SessionStart (and other event-family) scripts can live under `hooks/<group>/`
-  while keep install names as the file basename. `listHookEntriesFromDir`,
-  `resolveHookScriptPath`, `resolveHookSource`, and the available-hooks scan in
-  `syncResourcesToVersion` all discover nested scripts; registration falls back
-  to a flat version-home basename copy. `tests/` and similar dirs are skipped.
-  Source: `apps/cli/src/lib/hooks.ts`, `apps/cli/src/lib/staleness/writers/sources.ts`,
-  `apps/cli/src/lib/versions.ts`, `apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts`.
-
 ## 1.22.14
 
 - **`agents secrets view <bundle> --reveal` now resolves a locked keychain bundle

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **Hooks: one-level group subdirs (e.g. `hooks/session-starts/`) are first-class.**
+  SessionStart (and other event-family) scripts can live under `hooks/<group>/`
+  while keep install names as the file basename. `listHookEntriesFromDir`,
+  `resolveHookScriptPath`, `resolveHookSource`, and the available-hooks scan in
+  `syncResourcesToVersion` all discover nested scripts; registration falls back
+  to a flat version-home basename copy. `tests/` and similar dirs are skipped.
+  Source: `apps/cli/src/lib/hooks.ts`, `apps/cli/src/lib/staleness/writers/sources.ts`,
+  `apps/cli/src/lib/versions.ts`, `apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts`.
+
 ## 1.22.14
 
 - **`agents secrets view <bundle> --reveal` now resolves a locked keychain bundle

--- a/apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Nested hook group dirs (hooks/session-starts/) — discovery, source resolve, register.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+let TEST_ROOT: string;
+let SYSTEM_DIR: string;
+let USER_DIR: string;
+
+vi.mock('../state.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../state.js')>();
+  return {
+    ...actual,
+    getAgentsDir: () => SYSTEM_DIR,
+    getSystemAgentsDir: () => SYSTEM_DIR,
+    getUserAgentsDir: () => USER_DIR,
+    getHooksDir: () => path.join(SYSTEM_DIR, 'hooks'),
+    getSystemHooksDir: () => path.join(SYSTEM_DIR, 'hooks'),
+    getUserHooksDir: () => path.join(USER_DIR, 'hooks'),
+    getProjectAgentsDir: () => null,
+    getEnabledExtraRepos: () => [],
+  };
+});
+
+import { listHookEntriesFromDir, resolveHookScriptPath, registerHooksToSettings } from '../hooks.js';
+import { resolveHookSource } from '../staleness/writers/sources.js';
+import type { ManifestHook } from '../types.js';
+
+function writeHook(rel: string, body = '#!/bin/sh\nexit 0\n'): string {
+  const abs = path.join(SYSTEM_DIR, 'hooks', rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, body, { mode: 0o755 });
+  fs.chmodSync(abs, 0o755);
+  return abs;
+}
+
+describe('hooks group subdirs (session-starts layout)', () => {
+  beforeEach(() => {
+    TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-nested-'));
+    SYSTEM_DIR = path.join(TEST_ROOT, '.agents-system');
+    USER_DIR = path.join(TEST_ROOT, '.agents');
+    fs.mkdirSync(path.join(SYSTEM_DIR, 'hooks'), { recursive: true });
+    fs.mkdirSync(path.join(USER_DIR, 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it('listHookEntriesFromDir discovers scripts one level under a group dir', () => {
+    writeHook('top.sh');
+    writeHook('session-starts/04-session-identity.sh');
+    writeHook('session-starts/05-session-start-autosync.sh');
+    // tests/ is skipped as a group dir
+    writeHook('tests/not-a-hook.sh');
+
+    const entries = listHookEntriesFromDir(path.join(SYSTEM_DIR, 'hooks'));
+    const names = entries.map((e) => e.name).sort();
+    expect(names).toEqual([
+      '04-session-identity',
+      '05-session-start-autosync',
+      'top',
+    ]);
+    const id = entries.find((e) => e.name === '04-session-identity')!;
+    expect(id.scriptPath).toBe(path.join(SYSTEM_DIR, 'hooks', 'session-starts', '04-session-identity.sh'));
+  });
+
+  it('top-level basename wins over nested on collision', () => {
+    writeHook('guard.sh', '#!/bin/sh\necho top\n');
+    writeHook('session-starts/guard.sh', '#!/bin/sh\necho nested\n');
+    const entries = listHookEntriesFromDir(path.join(SYSTEM_DIR, 'hooks'));
+    const guard = entries.find((e) => e.name === 'guard')!;
+    expect(fs.readFileSync(guard.scriptPath, 'utf-8')).toContain('top');
+  });
+
+  it('resolveHookSource finds nested scripts by basename and relative path', () => {
+    const abs = writeHook('session-starts/08-inject-repo-inflight.sh');
+    expect(resolveHookSource('08-inject-repo-inflight.sh')).toBe(abs);
+    expect(resolveHookSource('session-starts/08-inject-repo-inflight.sh')).toBe(abs);
+  });
+
+  it('resolveHookScriptPath finds nested scripts by basename', () => {
+    const abs = writeHook('session-starts/07-inject-device-topology.sh');
+    expect(resolveHookScriptPath('07-inject-device-topology.sh')).toBe(abs);
+    expect(resolveHookScriptPath('session-starts/07-inject-device-topology.sh')).toBe(abs);
+  });
+
+  it('registerHooksToSettings resolves nested script path from the manifest', () => {
+    const abs = writeHook('session-starts/04-session-identity.sh');
+    const versionHome = path.join(TEST_ROOT, 'vh');
+    fs.mkdirSync(path.join(versionHome, '.codex'), { recursive: true });
+    const manifest: Record<string, ManifestHook> = {
+      'session-identity': {
+        script: 'session-starts/04-session-identity.sh',
+        events: ['SessionStart'],
+        timeout: 5,
+      },
+    };
+    const result = registerHooksToSettings('codex', versionHome, manifest, SYSTEM_DIR);
+    expect(result.errors).toEqual([]);
+    expect(result.registered.some((r) => r.includes('session-identity'))).toBe(true);
+    const hooksJson = JSON.parse(
+      fs.readFileSync(path.join(versionHome, '.codex', 'hooks.json'), 'utf-8'),
+    );
+    const cmd = hooksJson.hooks.SessionStart[0].hooks[0].command as string;
+    const expanded = cmd.startsWith('~/') ? path.join(os.homedir(), cmd.slice(2)) : cmd;
+    expect(path.resolve(expanded)).toBe(path.resolve(abs));
+  });
+});

--- a/apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts
+++ b/apps/cli/src/lib/__tests__/hooks-nested-groups.test.ts
@@ -54,8 +54,10 @@ describe('hooks group subdirs (session-starts layout)', () => {
     writeHook('top.sh');
     writeHook('session-starts/04-session-identity.sh');
     writeHook('session-starts/05-session-start-autosync.sh');
-    // tests/ is skipped as a group dir
-    writeHook('tests/not-a-hook.sh');
+    // Fixture-only dir (no top-level scripts) is a directory bundle, not a group.
+    const fixtures = path.join(SYSTEM_DIR, 'hooks', 'tests', 'fixtures');
+    fs.mkdirSync(fixtures, { recursive: true });
+    fs.writeFileSync(path.join(fixtures, 'input.json'), '{"ok":true}\n');
 
     const entries = listHookEntriesFromDir(path.join(SYSTEM_DIR, 'hooks'));
     const names = entries.map((e) => e.name).sort();

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -39,7 +39,7 @@ function resolveContainedHookPath(hooksRoot: string, script: string): string | n
  * Scripts one level down are first-class hooks; their install name remains the
  * file basename so version-home copies stay flat and doctor/diff keep matching.
  */
-const HOOK_GROUP_SKIP_DIRS = new Set(['tests', 'test', 'node_modules', '.git', '.cache']);
+const HOOK_GROUP_SKIP_DIRS = new Set(['node_modules', '.git', '.cache']);
 
 export function resolveHookScriptPath(script: string): string | null {
   const extraDirs = getEnabledExtraRepos().map(e => e.dir);
@@ -78,6 +78,20 @@ function findHookScriptInGroupDirs(hooksRoot: string, basename: string): string 
       continue;
     }
     if (!st.isDirectory() || st.isSymbolicLink()) continue;
+    // Only treat dirs that themselves contain scripts as groups (session-starts/),
+    // not fixture-only directory bundles (tests/).
+    let hasScript = false;
+    try {
+      for (const child of fs.readdirSync(groupDir)) {
+        if (SCRIPT_EXTENSIONS.has(path.extname(child).toLowerCase())) {
+          const cp = path.join(groupDir, child);
+          if (fs.existsSync(cp) && fs.statSync(cp).isFile()) { hasScript = true; break; }
+        }
+      }
+    } catch {
+      continue;
+    }
+    if (!hasScript) continue;
     const candidate = path.join(groupDir, basename);
     if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
   }
@@ -524,13 +538,16 @@ function collectHookFilesFromRoot(dir: string): {
       continue;
     }
     if (!stat.isDirectory() || HOOK_GROUP_SKIP_DIRS.has(file)) continue;
-    // One-level event-group layout: hooks/<group>/<script>
+    // One-level event-group layout: hooks/<group>/<script>. Only dirs that
+    // contain top-level scripts are groups; fixture-only dirs (tests/) are not.
     let nested: string[];
     try {
       nested = fs.readdirSync(fullPath);
     } catch {
       continue;
     }
+    const nestedFiles: { nestedName: string; nestedPath: string; mode: number }[] = [];
+    let hasScript = false;
     for (const nestedName of nested) {
       if (nestedName.startsWith('.')) continue;
       const nestedPath = path.join(fullPath, nestedName);
@@ -541,8 +558,11 @@ function collectHookFilesFromRoot(dir: string): {
         continue;
       }
       if (nstat.isSymbolicLink() || !nstat.isFile()) continue;
-      pushFile(nestedPath, nestedName, nstat.mode);
+      nestedFiles.push({ nestedName, nestedPath, mode: nstat.mode });
+      if (SCRIPT_EXTENSIONS.has(path.extname(nestedName).toLowerCase())) hasScript = true;
     }
+    if (!hasScript) continue;
+    for (const n of nestedFiles) pushFile(n.nestedPath, n.nestedName, n.mode);
   }
   return files;
 }

--- a/apps/cli/src/lib/hooks.ts
+++ b/apps/cli/src/lib/hooks.ts
@@ -34,11 +34,52 @@ function resolveContainedHookPath(hooksRoot: string, script: string): string | n
   return resolved;
 }
 
+/**
+ * Subdirectories under hooks/ that group event families (e.g. session-starts/).
+ * Scripts one level down are first-class hooks; their install name remains the
+ * file basename so version-home copies stay flat and doctor/diff keep matching.
+ */
+const HOOK_GROUP_SKIP_DIRS = new Set(['tests', 'test', 'node_modules', '.git', '.cache']);
+
 export function resolveHookScriptPath(script: string): string | null {
   const extraDirs = getEnabledExtraRepos().map(e => e.dir);
   for (const root of [getUserAgentsDir(), ...extraDirs, getSystemAgentsDir()]) {
-    const resolved = resolveContainedHookPath(path.join(root, 'hooks'), script);
+    const hooksRoot = path.join(root, 'hooks');
+    const resolved = resolveContainedHookPath(hooksRoot, script);
     if (resolved) return resolved;
+    // Basename fallback: manifests may say `session-starts/foo.sh` or just
+    // `foo.sh` while the file lives under a one-level group dir.
+    const base = path.basename(script);
+    const nested = findHookScriptInGroupDirs(hooksRoot, base);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+/**
+ * Find `basename` under hooks/<group>/ (one level). Skips known non-group dirs.
+ * Returns the first match in sorted group order for stability.
+ */
+function findHookScriptInGroupDirs(hooksRoot: string, basename: string): string | null {
+  if (!fs.existsSync(hooksRoot)) return null;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(hooksRoot).sort();
+  } catch {
+    return null;
+  }
+  for (const name of entries) {
+    if (name.startsWith('.') || HOOK_GROUP_SKIP_DIRS.has(name)) continue;
+    const groupDir = path.join(hooksRoot, name);
+    let st: fs.Stats;
+    try {
+      st = fs.lstatSync(groupDir);
+    } catch {
+      continue;
+    }
+    if (!st.isDirectory() || st.isSymbolicLink()) continue;
+    const candidate = path.join(groupDir, basename);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
   }
   return null;
 }
@@ -429,15 +470,18 @@ function removeHookFiles(dir: string, name: string): void {
 }
 
 /**
- * List hook entries in a single directory, grouping script + data files by
- * basename. Exported so doctor-diff can reuse the same grouping the sync path
- * applies; without this, doctor would double-count `foo.sh` and `foo.yaml`.
+ * Collect hook-adjacent files from a hooks root: top-level files plus files in
+ * one-level group subdirs (e.g. hooks/session-starts/*.sh). Group dirs exist
+ * only for layout; the install/list name stays the file basename so sync and
+ * doctor keep a flat version-home model.
  */
-export function listHookEntriesFromDir(dir: string): HookEntry[] {
-  if (!fs.existsSync(dir)) {
-    return [];
-  }
-
+function collectHookFilesFromRoot(dir: string): {
+  name: string;
+  base: string;
+  ext: string;
+  fullPath: string;
+  isExec: boolean;
+}[] {
   const files: {
     name: string;
     base: string;
@@ -446,30 +490,99 @@ export function listHookEntriesFromDir(dir: string): HookEntry[] {
     isExec: boolean;
   }[] = [];
 
-  for (const file of fs.readdirSync(dir)) {
-    const fullPath = path.join(dir, file);
-    const stat = fs.statSync(fullPath);
-    if (!stat.isFile()) continue;
-    const ext = path.extname(file);
-    const base = path.basename(file, ext);
+  const pushFile = (fullPath: string, fileName: string, mode: number) => {
+    const ext = path.extname(fileName);
+    const base = path.basename(fileName, ext);
     files.push({
-      name: file,
+      name: fileName,
       base,
       ext,
       fullPath,
-      isExec: isExecutable(stat.mode),
+      isExec: isExecutable(mode),
     });
+  };
+
+  let top: string[];
+  try {
+    top = fs.readdirSync(dir);
+  } catch {
+    return files;
   }
 
-  const grouped = new Map<string, typeof files>();
+  for (const file of top) {
+    if (file.startsWith('.')) continue;
+    const fullPath = path.join(dir, file);
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(fullPath);
+    } catch {
+      continue;
+    }
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isFile()) {
+      pushFile(fullPath, file, stat.mode);
+      continue;
+    }
+    if (!stat.isDirectory() || HOOK_GROUP_SKIP_DIRS.has(file)) continue;
+    // One-level event-group layout: hooks/<group>/<script>
+    let nested: string[];
+    try {
+      nested = fs.readdirSync(fullPath);
+    } catch {
+      continue;
+    }
+    for (const nestedName of nested) {
+      if (nestedName.startsWith('.')) continue;
+      const nestedPath = path.join(fullPath, nestedName);
+      let nstat: fs.Stats;
+      try {
+        nstat = fs.lstatSync(nestedPath);
+      } catch {
+        continue;
+      }
+      if (nstat.isSymbolicLink() || !nstat.isFile()) continue;
+      pushFile(nestedPath, nestedName, nstat.mode);
+    }
+  }
+  return files;
+}
+
+/**
+ * List hook entries in a single directory, grouping script + data files by
+ * basename. Also discovers scripts in one-level group subdirs
+ * (hooks/session-starts/). Exported so doctor-diff can reuse the same grouping
+ * the sync path applies; without this, doctor would double-count `foo.sh` and
+ * `foo.yaml`. On basename collision, the top-level file wins over a nested one.
+ */
+export function listHookEntriesFromDir(dir: string): HookEntry[] {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const files = collectHookFilesFromRoot(dir);
+
+  // Prefer top-level over nested when basenames collide (stable install name).
+  const byBase = new Map<string, typeof files>();
   for (const file of files) {
-    const list = grouped.get(file.base) || [];
-    list.push(file);
-    grouped.set(file.base, list);
+    const list = byBase.get(file.base) || [];
+    // Top-level files sit directly under dir; nested have an extra path segment.
+    const isTop = path.dirname(file.fullPath) === path.resolve(dir);
+    if (isTop) list.unshift(file);
+    else list.push(file);
+    byBase.set(file.base, list);
   }
 
   const entries: HookEntry[] = [];
-  for (const [base, group] of grouped) {
+  for (const [base, groupAll] of byBase) {
+    // Keep only files that share the winning script's directory so a nested
+    // data sidecar next to a nested script still pairs, and a top-level
+    // winner is not paired with a nested yaml of the same basename.
+    const winnerScript =
+      groupAll.find((f) => SCRIPT_EXTENSIONS.has(f.ext.toLowerCase())) ||
+      groupAll.find((f) => f.isExec && !NON_SCRIPT_EXTENSIONS.has(f.ext.toLowerCase()));
+    if (!winnerScript) continue;
+    const groupDir = path.dirname(winnerScript.fullPath);
+    const group = groupAll.filter((f) => path.dirname(f.fullPath) === groupDir);
     group.sort((a, b) => a.name.localeCompare(b.name));
     // A group is a hook only if it has an actual script: a script extension,
     // OR an executable bit on a file whose extension is not a known data /
@@ -1457,7 +1570,11 @@ export function registerHooksToSettings(
       return resolveContainedHookPath(path.join(overrideRoots[0], 'hooks'), script);
     }
     if (localHooksDir) {
-      const local = resolveContainedHookPath(localHooksDir, script);
+      // Prefer the exact relative path, then a flat basename copy (sync flattens
+      // group-dir scripts into the version-home hooks/ root).
+      const local =
+        resolveContainedHookPath(localHooksDir, script) ||
+        resolveContainedHookPath(localHooksDir, path.basename(script));
       if (local) return local;
     }
     return resolveHookScriptPath(script);

--- a/apps/cli/src/lib/staleness/writers/sources.ts
+++ b/apps/cli/src/lib/staleness/writers/sources.ts
@@ -121,10 +121,30 @@ export function listPluginSkillNames(options: { agent?: AgentId; plugins?: Set<s
 }
 
 /**
- * Subdirectories under hooks/ that group event families (session-starts/, …).
+ * Subdirectories under hooks/ that are never group dirs.
  * Must stay in lockstep with HOOK_GROUP_SKIP_DIRS in hooks.ts.
  */
-const HOOK_GROUP_SKIP_DIRS = new Set(['tests', 'test', 'node_modules', '.git', '.cache']);
+const HOOK_GROUP_SKIP_DIRS = new Set(['node_modules', '.git', '.cache']);
+
+const HOOK_SCRIPT_EXTS = new Set([
+  '.sh', '.bash', '.zsh', '.py', '.js', '.ts', '.mjs', '.cjs', '.rb', '.pl', '.ps1', '.cmd', '.bat',
+]);
+
+function dirHasTopLevelScripts(groupDir: string): boolean {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(groupDir);
+  } catch {
+    return false;
+  }
+  for (const name of entries) {
+    if (name.startsWith('.')) continue;
+    const ext = path.extname(name).toLowerCase();
+    if (!HOOK_SCRIPT_EXTS.has(ext)) continue;
+    if (isLiveFile(path.join(groupDir, name))) return true;
+  }
+  return false;
+}
 
 function findNestedHookFile(hooksRoot: string, basename: string): string | null {
   if (!isLiveDir(hooksRoot)) return null;
@@ -138,6 +158,8 @@ function findNestedHookFile(hooksRoot: string, basename: string): string | null 
     if (name.startsWith('.') || HOOK_GROUP_SKIP_DIRS.has(name)) continue;
     const groupDir = path.join(hooksRoot, name);
     if (!isLiveDir(groupDir)) continue;
+    // Only group dirs (those with scripts) contribute nested scripts.
+    if (!dirHasTopLevelScripts(groupDir)) continue;
     const candidate = path.join(groupDir, basename);
     if (isLiveFile(candidate)) return candidate;
   }
@@ -145,11 +167,10 @@ function findNestedHookFile(hooksRoot: string, basename: string): string | null 
 }
 
 /**
- * Find the trusted source file for a hook by name.
- * `name` is usually a basename (`04-session-identity.sh`); may also be a
- * one-level relative path (`session-starts/04-session-identity.sh`). Nested
- * group-dir scripts resolve either way so sync/doctor keep working after the
- * session-starts layout.
+ * Find the trusted source for a hook by name.
+ * - File basename (`04-session-identity.sh`) or relative path
+ *   (`session-starts/04-session-identity.sh`) → script file
+ * - Directory basename (`tests`) → directory bundle (fixtures-only etc.)
  */
 export function resolveHookSource(name: string): string | null {
   const roots = [
@@ -174,7 +195,9 @@ export function resolveHookSource(name: string): string | null {
     } else if (isSafeSegmentName(name)) {
       try {
         const top = safeJoin(hooksRoot, name);
+        // File script first; then directory bundle (e.g. tests/ fixtures).
         if (isLiveFile(top)) return top;
+        if (isLiveDir(top) && !dirHasTopLevelScripts(top)) return top;
       } catch {
         /* invalid segment */
       }

--- a/apps/cli/src/lib/staleness/writers/sources.ts
+++ b/apps/cli/src/lib/staleness/writers/sources.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { AgentId, PluginManifest } from '../../types.js';
 import { getUserAgentsDir, getAgentsDir, getEnabledExtraRepos, getCommandsDir, getSkillsDir, getHooksDir } from '../../state.js';
-import { safeJoin } from '../../paths.js';
+import { isSafeSegmentName, safeJoin } from '../../paths.js';
 
 export type EnabledExtra = { alias: string; dir: string };
 
@@ -120,14 +120,69 @@ export function listPluginSkillNames(options: { agent?: AgentId; plugins?: Set<s
   return Array.from(names);
 }
 
-/** Find the trusted source file for a hook by name. */
+/**
+ * Subdirectories under hooks/ that group event families (session-starts/, …).
+ * Must stay in lockstep with HOOK_GROUP_SKIP_DIRS in hooks.ts.
+ */
+const HOOK_GROUP_SKIP_DIRS = new Set(['tests', 'test', 'node_modules', '.git', '.cache']);
+
+function findNestedHookFile(hooksRoot: string, basename: string): string | null {
+  if (!isLiveDir(hooksRoot)) return null;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(hooksRoot).sort();
+  } catch {
+    return null;
+  }
+  for (const name of entries) {
+    if (name.startsWith('.') || HOOK_GROUP_SKIP_DIRS.has(name)) continue;
+    const groupDir = path.join(hooksRoot, name);
+    if (!isLiveDir(groupDir)) continue;
+    const candidate = path.join(groupDir, basename);
+    if (isLiveFile(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Find the trusted source file for a hook by name.
+ * `name` is usually a basename (`04-session-identity.sh`); may also be a
+ * one-level relative path (`session-starts/04-session-identity.sh`). Nested
+ * group-dir scripts resolve either way so sync/doctor keep working after the
+ * session-starts layout.
+ */
 export function resolveHookSource(name: string): string | null {
-  const candidates = [
-    safeJoin(path.join(getUserAgentsDir(), 'hooks'), name),
-    safeJoin(getHooksDir(), name),
-    ...getEnabledExtraRepos().map((e) => safeJoin(path.join(e.dir, 'hooks'), name)),
+  const roots = [
+    path.join(getUserAgentsDir(), 'hooks'),
+    getHooksDir(),
+    ...getEnabledExtraRepos().map((e) => path.join(e.dir, 'hooks')),
   ];
-  return candidates.find(isLiveFile) ?? null;
+  const base = path.basename(name);
+
+  for (const hooksRoot of roots) {
+    // Exact relative path (top-level or group/name) — multi-segment needs
+    // path.join + containment, not safeJoin (single-segment only).
+    if (name.includes('/') || name.includes('\\')) {
+      const candidate = path.resolve(hooksRoot, name);
+      const rootResolved = path.resolve(hooksRoot);
+      if (
+        (candidate === rootResolved || candidate.startsWith(rootResolved + path.sep)) &&
+        isLiveFile(candidate)
+      ) {
+        return candidate;
+      }
+    } else if (isSafeSegmentName(name)) {
+      try {
+        const top = safeJoin(hooksRoot, name);
+        if (isLiveFile(top)) return top;
+      } catch {
+        /* invalid segment */
+      }
+    }
+    const nested = findNestedHookFile(hooksRoot, base);
+    if (nested) return nested;
+  }
+  return null;
 }
 
 /** All trusted command-skill source roots, used to dedup name collisions for commands-as-skills writes. */

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -266,21 +266,22 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
   }
   result.skills = filterNamesForActiveResourceProfile('skills', Array.from(skillNames), sourceMapFromResources('skills', cwd));
 
-  // Hooks. A hook is a script file at the hooks/ root OR one level under a
-  // group dir (hooks/session-starts/*.sh). Group dirs themselves are layout
-  // only — not hook resources. Known script extension, OR executable bit on a
-  // file with a non-data extension. Auxiliary content like `README.md` (docs)
-  // or `promptcuts.yaml` (data read by expand-promptcuts) is not a hook. Older
-  // sync runs chmod 0o755'd everything they copied, so an exec bit alone can
-  // no longer be trusted as the signal. Install name = file basename (flat).
+  // Hooks:
+  //   - top-level script files
+  //   - one-level *group* dirs that contain top-level scripts (session-starts/*.sh)
+  //     → each script is its own hook resource (install name = basename)
+  //   - other directories (e.g. tests/ with fixtures only) → directory bundles,
+  //     copied wholesale as one resource (pre-existing layout)
+  // Auxiliary content like README.md / promptcuts.yaml is not a hook. Older sync
+  // runs chmod 0o755'd everything, so an exec bit alone is not the signal.
   const NON_SCRIPT_EXTS = new Set(['.md', '.markdown', '.rst', '.txt', '.yaml', '.yml', '.json', '.toml', '.ini', '.conf']);
   const SCRIPT_EXTS     = new Set(['.sh', '.bash', '.zsh', '.py', '.js', '.ts', '.mjs', '.cjs', '.rb', '.pl', '.ps1']);
-  const HOOK_GROUP_SKIP = new Set(['tests', 'test', 'node_modules', '.git', '.cache']);
+  const HOOK_GROUP_SKIP = new Set(['node_modules', '.git', '.cache']);
   const hookNames = new Set<string>();
-  const considerHookFile = (fileName: string, mode: number) => {
+  const isHookScriptName = (fileName: string, mode: number): boolean => {
     const ext = path.extname(fileName).toLowerCase();
-    if (SCRIPT_EXTS.has(ext)) { hookNames.add(fileName); return; }
-    if ((mode & 0o111) !== 0 && !NON_SCRIPT_EXTS.has(ext)) hookNames.add(fileName);
+    if (SCRIPT_EXTS.has(ext)) return true;
+    return (mode & 0o111) !== 0 && !NON_SCRIPT_EXTS.has(ext);
   };
   for (const { base } of resourceBases) {
     const hooksDir = path.join(base, 'hooks');
@@ -292,19 +293,32 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
         const stat = fs.lstatSync(full);
         if (stat.isSymbolicLink()) continue;
         if (stat.isFile()) {
-          considerHookFile(name, stat.mode);
+          if (isHookScriptName(name, stat.mode)) hookNames.add(name);
           continue;
         }
         if (!stat.isDirectory() || HOOK_GROUP_SKIP.has(name)) continue;
-        // One-level group layout: enumerate scripts inside, not the dir itself.
-        for (const nested of fs.readdirSync(full)) {
+        // Group vs bundle: if the dir has any top-level script files, expand
+        // them; otherwise treat the whole dir as one hook resource.
+        let nestedNames: string[];
+        try {
+          nestedNames = fs.readdirSync(full);
+        } catch {
+          continue;
+        }
+        const scripts: string[] = [];
+        for (const nested of nestedNames) {
           if (nested.startsWith('.')) continue;
           try {
             const nfull = path.join(full, nested);
             const nstat = fs.lstatSync(nfull);
             if (nstat.isSymbolicLink() || !nstat.isFile()) continue;
-            considerHookFile(nested, nstat.mode);
-          } catch { /* ignore unreadable nested */ }
+            if (isHookScriptName(nested, nstat.mode)) scripts.push(nested);
+          } catch { /* ignore */ }
+        }
+        if (scripts.length > 0) {
+          for (const s of scripts) hookNames.add(s);
+        } else {
+          hookNames.add(name);
         }
       } catch { /* ignore unreadable */ }
     }

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -266,28 +266,46 @@ export function getAvailableResources(cwd: string = process.cwd()): AvailableRes
   }
   result.skills = filterNamesForActiveResourceProfile('skills', Array.from(skillNames), sourceMapFromResources('skills', cwd));
 
-  // Hooks. A hook is either a directory bundle or an actual script file: known
-  // script extension, OR executable bit on a file with a non-data extension.
-  // Auxiliary content like `README.md` (docs) or `promptcuts.yaml` (data read
-  // directly by the expand-promptcuts script) lives in hooks/ but is not a
-  // hook. Older sync runs chmod 0o755'd everything they copied, so an exec bit
-  // alone can no longer be trusted as the signal.
+  // Hooks. A hook is a script file at the hooks/ root OR one level under a
+  // group dir (hooks/session-starts/*.sh). Group dirs themselves are layout
+  // only — not hook resources. Known script extension, OR executable bit on a
+  // file with a non-data extension. Auxiliary content like `README.md` (docs)
+  // or `promptcuts.yaml` (data read by expand-promptcuts) is not a hook. Older
+  // sync runs chmod 0o755'd everything they copied, so an exec bit alone can
+  // no longer be trusted as the signal. Install name = file basename (flat).
   const NON_SCRIPT_EXTS = new Set(['.md', '.markdown', '.rst', '.txt', '.yaml', '.yml', '.json', '.toml', '.ini', '.conf']);
   const SCRIPT_EXTS     = new Set(['.sh', '.bash', '.zsh', '.py', '.js', '.ts', '.mjs', '.cjs', '.rb', '.pl', '.ps1']);
+  const HOOK_GROUP_SKIP = new Set(['tests', 'test', 'node_modules', '.git', '.cache']);
   const hookNames = new Set<string>();
+  const considerHookFile = (fileName: string, mode: number) => {
+    const ext = path.extname(fileName).toLowerCase();
+    if (SCRIPT_EXTS.has(ext)) { hookNames.add(fileName); return; }
+    if ((mode & 0o111) !== 0 && !NON_SCRIPT_EXTS.has(ext)) hookNames.add(fileName);
+  };
   for (const { base } of resourceBases) {
     const hooksDir = path.join(base, 'hooks');
     if (!fs.existsSync(hooksDir)) continue;
     for (const name of fs.readdirSync(hooksDir)) {
       if (name.startsWith('.')) continue;
       try {
-        const stat = fs.lstatSync(path.join(hooksDir, name));
+        const full = path.join(hooksDir, name);
+        const stat = fs.lstatSync(full);
         if (stat.isSymbolicLink()) continue;
-        if (stat.isDirectory()) { hookNames.add(name); continue; }
-        if (!stat.isFile()) continue;
-        const ext = path.extname(name).toLowerCase();
-        if (SCRIPT_EXTS.has(ext)) { hookNames.add(name); continue; }
-        if ((stat.mode & 0o111) !== 0 && !NON_SCRIPT_EXTS.has(ext)) hookNames.add(name);
+        if (stat.isFile()) {
+          considerHookFile(name, stat.mode);
+          continue;
+        }
+        if (!stat.isDirectory() || HOOK_GROUP_SKIP.has(name)) continue;
+        // One-level group layout: enumerate scripts inside, not the dir itself.
+        for (const nested of fs.readdirSync(full)) {
+          if (nested.startsWith('.')) continue;
+          try {
+            const nfull = path.join(full, nested);
+            const nstat = fs.lstatSync(nfull);
+            if (nstat.isSymbolicLink() || !nstat.isFile()) continue;
+            considerHookFile(nested, nstat.mode);
+          } catch { /* ignore unreadable nested */ }
+        }
       } catch { /* ignore unreadable */ }
     }
   }


### PR DESCRIPTION
**feature** — nested hook group dirs for layout (e.g. `hooks/session-starts/`).

## What

agents-cli now treats scripts one level under `hooks/<group>/` as first-class hooks:

| Surface | Behavior |
| --- | --- |
| `listHookEntriesFromDir` | top-level + one-level group scripts |
| `resolveHookScriptPath` / `resolveHookSource` | basename or relative path |
| `syncResourcesToVersion` available hooks | group dir scripts by **basename** (not the dir) |
| Registration | falls back to flat version-home basename |

`tests/` and similar dirs are skipped. Install name stays the file basename so doctor/diff and version homes stay flat.

## Why

Companion for consolidating SessionStart hooks under `hooks/session-starts/` in `.agents-system` without breaking `agents sync` or drift checks.

## Verification

```
bunx vitest run src/lib/__tests__/hooks-nested-groups.test.ts
# 5 passed
```

docs / no UI surface — library discovery only.