### PR TITLE
fix(release): follow aggregate test context

### DIFF
--- a/apps/cli/scripts/release.sh
+++ b/apps/cli/scripts/release.sh
@@ -888,14 +888,11 @@ fi
 # `test` job hanging -- would hang the release forever) and it can
 # exit 0 on a partial set. This loop waits until every expected context is
 # present AND terminal (capped at 60m), then re-asserts each is a pass and dies
-# otherwise. NOTE: these names are the job/matrix labels of ci.yml (the build
-# matrix), tests.yml (test-shard 1..3 + typecheck + compiled-smoke), and
-# secret-scan.yml (gitleaks) -- a rename/reshard there must be mirrored here, or
-# the release times out (fail-closed, never publishes). tests.yml was resharded
-# from a single `test` job into `test-shard (N)` + `typecheck` + `compiled-smoke`;
-# the stale `test` name here hung every release for the full 60m before failing
-# (found + fixed 2026-07-29 cutting 1.20.73).
-EXPECTED_CHECKS=("test-shard (1)" "test-shard (2)" "test-shard (3)" typecheck compiled-smoke gitleaks \
+# otherwise. tests.yml's final `test` job gates every component selected by the
+# scope classifier, so the release waiter follows that stable aggregate instead
+# of duplicating internal job names that change when CI is regrouped or resharded.
+# The build matrix and secret scan remain direct release gates.
+EXPECTED_CHECKS=(test gitleaks \
   "build (ubuntu-latest, 22)"  "build (ubuntu-latest, 24)" \
   "build (macos-latest, 22)"   "build (macos-latest, 24)")
 # The Windows build jobs gate the release by default. Set RELEASE_REQUIRE_WINDOWS=0 to

--- a/apps/cli/scripts/release.test.ts
+++ b/apps/cli/scripts/release.test.ts
@@ -21,4 +21,16 @@ describe('release.sh PR-head synchronization', () => {
       'wait_for_ci_green "$MERGED_RELEASE_PR" "$CI_TESTED_HEAD"',
     );
   });
+
+  it('waits on the stable aggregate test context, not internal CLI job names', () => {
+    const expectedChecks = RELEASE_SH.match(
+      /EXPECTED_CHECKS=\((?<checks>[\s\S]*?)\)\n# The Windows/,
+    )?.groups?.checks;
+
+    expect(expectedChecks).toBeDefined();
+    expect(expectedChecks).toContain('test gitleaks');
+    expect(expectedChecks).not.toContain('test-shard');
+    expect(expectedChecks).not.toContain('typecheck');
+    expect(expectedChecks).not.toContain('compiled-smoke');
+  });
 });


### PR DESCRIPTION
## What changed

- Makes the release waiter follow the stable `test` aggregate produced by `.github/workflows/tests.yml`.
- Stops duplicating internal CLI job names (`test-shard`, `typecheck`, `compiled-smoke`) that no longer exist after CI routing was consolidated.
- Adds a regression test pinning the aggregate contract.

## Why

The live 1.22.17 release PR #2064 registered `cli-test-shard (1..3)` and `cli-preflight`, while `release.sh` waited for the removed names. The fail-closed waiter would otherwise hold the release lease until its 60-minute timeout. The workflow already publishes a final `test` job specifically as the stable branch-protection and release-script context.

## Verification

No user-visible UI surface.

`bun test scripts/release.test.ts`:

```text
2 pass
0 fail
13 expect() calls
```

Live PR #2064 check-runs confirmed `test`, `cli-preflight`, and `cli-test-shard (1..3)` are the current contexts; the removed `test-shard`, `typecheck`, and `compiled-smoke` contexts never registered.