### PR TITLE
test: allow real old-peer resolver setup to finish

### DIFF
--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -835,7 +835,7 @@ describe('agents sessions --resolve local-peer critical path', () => {
       if (peer) await stopSessionResolverSshPeer(peer);
       rmTempHomeWithRetries(tempHome);
     }
-  });
+  }, 90_000);
 
   it('returns a partial fleet result when a real exit-zero peer emits malformed safe output', async () => {
     const tempHome = fs.mkdtempSync(path.join(sshPeerTmpBase, 'sr-'));


### PR DESCRIPTION
Test-only CI reliability fix: gives the real old-peer SSH resolver case enough time for its already-60-second npm setup contract.

## Why

The 1.22.17 release matrix failed on Ubuntu Node 22 at `sessions.test.ts:813` because the case inherited the 30-second Vitest ceiling while its real `npx @phnx-labs/agents-cli@1.20.88` preflight explicitly permits 60 seconds. GitHub killed the case at exactly 30 seconds. Production code is unchanged.

Blocking release: #2064
Failed CI job: https://github.com/phnx-labs/agents-cli/actions/runs/31003982860/job/92299320391

## Change

- Set a 90-second timeout only on the real old-peer SSH integration case.
- Keep the actual CLI, npm package, OpenSSH ControlMaster, and ssh2 peer path intact.

## Run result

No user-visible surface; test-only change.

- `bun test src/commands/sessions.test.ts -t <old-peer test>`: 1 passed, 0 failed; 7.94 seconds.
- `bun run test -- src/commands/sessions.test.ts`: 54 passed, 0 failed; 123.31 seconds.