### PR TITLE
fix(sessions): surface terminalId on tmux --active rows (RUSH-2192)

### DIFF
--- a/apps/cli/.changelog/next/rush-2192-tmux-terminal-id.md
+++ b/apps/cli/.changelog/next/rush-2192-tmux-terminal-id.md
@@ -1,0 +1,6 @@
+- **`agents sessions --active` now carries `terminalId` on tmux-hosted rows (RUSH-2192).**
+  Grok/Codex (and every `ag-*` tmux pane) get their `AGENT_TERMINAL_ID` from the launch
+  registry's by-pid entry. The ps-scan path already set `terminalId`; the tmux source —
+  which wins dedupe for interactive agents — omitted it, so Factory could never join a
+  tab to its live session even when SessionStart preserved the key. Source:
+  `apps/cli/src/lib/session/active.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **`agents sessions --active` now carries `terminalId` on tmux-hosted rows (RUSH-2192).**
-  Grok/Codex (and every `ag-*` tmux pane) get their `AGENT_TERMINAL_ID` from the launch
-  registry's by-pid entry. The ps-scan path already set `terminalId`; the tmux source —
-  which wins dedupe for interactive agents — omitted it, so Factory could never join a
-  tab to its live session even when SessionStart preserved the key. Source:
-  `apps/cli/src/lib/session/active.ts`.
-
 ## 1.22.16
 
 - **Resume exact sessions locally or across the fleet with `agents resume <id>` and `agents run <agent|auto> --resume <id>`.** Full IDs use the local SQLite index before any SSH fan-out; remote owners route to the recorded device and version home. Session metadata now records launch mode alongside harness, version, account, cwd, and machine so strict resume reconstructs the original run. Claude, Codex, Grok, Kimi, Droid, and Cursor use their verified version-specific native resume syntax; `run auto --resume` can select another healthy harness/account and continue through `/continue` when native resume is unavailable. Source: `apps/cli/src/commands/{exec,resume,sessions}.ts`, `apps/cli/src/lib/{exec,session/db}.ts`, `packages/session-tracker/src/hook.sh`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **`agents sessions --active` now carries `terminalId` on tmux-hosted rows (RUSH-2192).**
+  Grok/Codex (and every `ag-*` tmux pane) get their `AGENT_TERMINAL_ID` from the launch
+  registry's by-pid entry. The ps-scan path already set `terminalId`; the tmux source —
+  which wins dedupe for interactive agents — omitted it, so Factory could never join a
+  tab to its live session even when SessionStart preserved the key. Source:
+  `apps/cli/src/lib/session/active.ts`.
+
 ## 1.22.16
 
 - **Resume exact sessions locally or across the fleet with `agents resume <id>` and `agents run <agent|auto> --resume <id>`.** Full IDs use the local SQLite index before any SSH fan-out; remote owners route to the recorded device and version home. Session metadata now records launch mode alongside harness, version, account, cwd, and machine so strict resume reconstructs the original run. Claude, Codex, Grok, Kimi, Droid, and Cursor use their verified version-specific native resume syntax; `run auto --resume` can select another healthy harness/account and continue through `/continue` when native resume is unavailable. Source: `apps/cli/src/commands/{exec,resume,sessions}.ts`, `apps/cli/src/lib/{exec,session/db}.ts`, `packages/session-tracker/src/hook.sh`.

--- a/apps/cli/src/lib/session/active.tmux-identity.test.ts
+++ b/apps/cli/src/lib/session/active.tmux-identity.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest';
-import { agentKindFromName, shortIdFromName, resolveNamesToSessionIds, resolvePaneIdentity } from './active.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  agentKindFromName,
+  shortIdFromName,
+  resolveNamesToSessionIds,
+  resolvePaneIdentity,
+  listTmuxAgentSessions,
+} from './active.js';
 import type { HookSessionIndex } from './hook-sessions.js';
+import { writePidSessionEntry, prunePidSessionRegistry } from './pid-registry.js';
+import { isTmuxInstalled, runTmux } from '../tmux/binary.js';
+import * as tmuxPaths from '../tmux/paths.js';
 
 // These are pure functions — the DB dependency is injected — so no fixtures or
 // tmux are needed. The name-based tier is the recovery that makes a detached
@@ -89,31 +101,82 @@ describe('resolvePaneIdentity — name-based recovery (the fleet fix)', () => {
     expect(id?.sessionId).toBe('abcd1234-0000-0000-0000-000000000001');
   });
 
-  it('live registry entry retains terminalId for the tmux ActiveSession join (RUSH-2192)', () => {
-    // resolvePaneIdentity itself returns agent/sessionId/pid only — the tmux
-    // list path must copy liveEntry.terminalId onto the ActiveSession row.
-    // Guard the registry field so a future PidSessionEntry reshape cannot drop
-    // the Factory join key without a failing test here.
-    const live = {
-      pid: 42,
-      agent: 'grok',
-      sessionId: '019fd1e3-8859-7f03-a47c-49d64653b404',
-      startedAtMs: 1,
-      terminalId: 'GK-mid2-test',
-      launchId: 'LID-mid2-test',
-      tmuxPane: '%9',
-    };
-    const id = resolvePaneIdentity('%9', 'ag-grok-af7d9ff4', null, live, emptyHook, new Map());
-    expect(id).toEqual({
-      agent: 'grok',
-      sessionId: '019fd1e3-8859-7f03-a47c-49d64653b404',
-      pid: 42,
-    });
-    // The field the listTmuxAgentSessions path must forward:
-    expect(live.terminalId).toBe('GK-mid2-test');
-  });
-
   it('still drops a genuinely foreign pane (no name, no meta, no registry)', () => {
     expect(resolvePaneIdentity('%8', 'main', null, undefined, emptyHook, names)).toBeUndefined();
+  });
+});
+
+/**
+ * RUSH-2192 — pins the listTmuxAgentSessions *forward* of terminalId, not just
+ * that PidSessionEntry can hold the field. Removing
+ * `terminalId: liveEntry?.terminalId` from the tmux ActiveSession push must fail
+ * this test. Real tmux + real by-pid entry; socket redirected so we never touch
+ * the fleet's default server.
+ */
+const tmuxSkip = isTmuxInstalled() ? null : 'tmux not installed';
+
+describe.skipIf(tmuxSkip)('listTmuxAgentSessions forwards terminalId (RUSH-2192)', () => {
+  const SHORT = 'af7d9ff4';
+  const SESS = `ag-grok-${SHORT}`;
+  const TERMINAL_ID = 'GK-mid2-test-rush2192';
+  const SESSION_ID = '019fd1e3-8859-7f03-a47c-49d64653b404';
+  // High fake pid range reserved for tests — but isPidAlive needs a LIVE pid, so
+  // we bind the registry entry to the pane's real sleep pid after create.
+  let tempDir: string;
+  let socket: string;
+  let paneId: string;
+  let panePid: number;
+  let socketSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-tmux-termid-'));
+    socket = path.join(tempDir, 'server.sock');
+    await runTmux({
+      socket,
+      args: ['new-session', '-d', '-s', SESS, 'sleep', '120'],
+    });
+    const listed = await runTmux({
+      socket,
+      args: ['list-panes', '-a', '-F', '#{pane_id}:#{pane_pid}:#{session_name}'],
+    });
+    const line = listed.stdout.split('\n').filter(Boolean)[0];
+    const [pane, pidRaw, name] = line.split(':');
+    expect(name).toBe(SESS);
+    paneId = pane;
+    panePid = parseInt(pidRaw, 10);
+    expect(paneId).toMatch(/^%/);
+    expect(panePid).toBeGreaterThan(0);
+
+    // Point listTmuxAgentSessions at our throwaway server (not the fleet socket).
+    socketSpy = vi.spyOn(tmuxPaths, 'getDefaultSocketPath').mockReturnValue(socket);
+
+    writePidSessionEntry({
+      pid: panePid,
+      agent: 'grok',
+      sessionId: SESSION_ID,
+      startedAtMs: Date.now() - 60_000,
+      terminalId: TERMINAL_ID,
+      launchId: 'LID-mid2-test-rush2192',
+      tmuxPane: paneId,
+      cwd: tempDir,
+    });
+  });
+
+  afterEach(async () => {
+    socketSpy?.mockRestore();
+    prunePidSessionRegistry((pid) => pid !== panePid);
+    await runTmux({ socket, args: ['kill-server'], throwOnError: false });
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('surfaces terminalId on the tmux ActiveSession row from the by-pid entry', async () => {
+    const rows = await listTmuxAgentSessions();
+    const mine = rows.find((r) => r.sessionId === SESSION_ID || r.kind === 'grok');
+    expect(mine, `expected a grok row; got ${JSON.stringify(rows.map((r) => ({ kind: r.kind, sessionId: r.sessionId, terminalId: r.terminalId })))}`).toBeDefined();
+    // This is the Factory join key. Dropping `terminalId: liveEntry?.terminalId`
+    // from listTmuxAgentSessions makes this assertion fail.
+    expect(mine!.terminalId).toBe(TERMINAL_ID);
+    expect(mine!.kind).toBe('grok');
+    expect(mine!.host).toBe('tmux');
   });
 });

--- a/apps/cli/src/lib/session/active.tmux-identity.test.ts
+++ b/apps/cli/src/lib/session/active.tmux-identity.test.ts
@@ -89,6 +89,30 @@ describe('resolvePaneIdentity — name-based recovery (the fleet fix)', () => {
     expect(id?.sessionId).toBe('abcd1234-0000-0000-0000-000000000001');
   });
 
+  it('live registry entry retains terminalId for the tmux ActiveSession join (RUSH-2192)', () => {
+    // resolvePaneIdentity itself returns agent/sessionId/pid only — the tmux
+    // list path must copy liveEntry.terminalId onto the ActiveSession row.
+    // Guard the registry field so a future PidSessionEntry reshape cannot drop
+    // the Factory join key without a failing test here.
+    const live = {
+      pid: 42,
+      agent: 'grok',
+      sessionId: '019fd1e3-8859-7f03-a47c-49d64653b404',
+      startedAtMs: 1,
+      terminalId: 'GK-mid2-test',
+      launchId: 'LID-mid2-test',
+      tmuxPane: '%9',
+    };
+    const id = resolvePaneIdentity('%9', 'ag-grok-af7d9ff4', null, live, emptyHook, new Map());
+    expect(id).toEqual({
+      agent: 'grok',
+      sessionId: '019fd1e3-8859-7f03-a47c-49d64653b404',
+      pid: 42,
+    });
+    // The field the listTmuxAgentSessions path must forward:
+    expect(live.terminalId).toBe('GK-mid2-test');
+  });
+
   it('still drops a genuinely foreign pane (no name, no meta, no registry)', () => {
     expect(resolvePaneIdentity('%8', 'main', null, undefined, emptyHook, names)).toBeUndefined();
   });

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -1741,12 +1741,16 @@ export async function listTmuxAgentSessions(): Promise<ActiveSession[]> {
       topic,
       tokPerSec,
       sessionFile,
-      // tmux panes carry no start timestamp; derive both from the transcript
-      // (creation ≈ start, last write ≈ last activity).
-      startedAtMs: birthtimeMs,
+      // Prefer the launch registry's start when known (more accurate than
+      // transcript birth for a resumed/reused file); else transcript times.
+      startedAtMs: liveEntry?.startedAtMs ?? birthtimeMs,
       lastActivityMs: mtimeMs,
       provenance,
       owner: resolveOwner(liveEntry?.actor, id.sessionId ?? sessionIdFromFile(sessionFile)),
+      // Factory / --active join key: AGENT_TERMINAL_ID stamped on the launch
+      // registry and preserved by SessionStart. Without this, Grok/Codex tmux
+      // panes never surface terminalId even when by-pid has it (RUSH-2192).
+      terminalId: liveEntry?.terminalId,
       // An id-less pane keys its dedupe on the unique pane, so two anonymous
       // co-located panes stay two rows instead of folding into one.
       paneId: id.sessionId ?? sessionIdFromFile(sessionFile) ? undefined : pane,


### PR DESCRIPTION
**fix (CLI)** — `agents sessions --active` surfaces `terminalId` on tmux rows (RUSH-2192)

## Why
Live proof on yosemite-s1: Grok SessionStart + fixed identity hook correctly wrote
```json
{"agent":"grok","sessionId":"019fd1e3-…","terminalId":"GK-mid2-…","launchId":"LID-…"}
```
into `by-pid`, but `agents sessions --active --json --local` returned **0** rows with `terminalId`. All Grok rows were `host: "tmux"`.

The **ps-scan** path already set `terminalId: entry?.terminalId`. The **tmux** path (which runs first and wins dedupe for interactive `ag-*` panes) omitted it.

Factory status-bar join (PR #2060) needs that field.

## Change
In `listTmuxAgentSessions`, set `terminalId: liveEntry?.terminalId` on each emitted `ActiveSession` (and prefer `liveEntry.startedAtMs` for start time).

## Proof
```
# Mid-flight by-pid (hook + launcher) — SUCCESS_JOIN_KEYS
{"agent":"grok","sessionId":"019fd1e3-…","terminalId":"GK-mid2-…","launchId":"LID-mid2-…"}

# --active before this fix
with terminalId 0
host: tmux  (all grok rows)
```

Unit: `active.tmux-identity.test.ts` guards the registry field.

## Deploy
Needs CLI install ≥ this commit on fleet boxes for Factory join to see `terminalId` on Grok/Codex tmux sessions.
