### PR TITLE
fix: expand nested hooks in listResources for sync patterns

### DIFF
--- a/apps/cli/.changelog/next/hooks-nested-listresources.md
+++ b/apps/cli/.changelog/next/hooks-nested-listresources.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`agents sync` re-copies nested system hooks after content changes.**
+  `listResources('hooks')` treated event-group directories (`pre-tool-use/`) as
+  resource names, so `system:*` pattern expansion never included nested scripts
+  like `git-guard.sh`. Force sync then left stale flat copies in version homes
+  forever. Hooks discovery now expands one-level group dirs the same way as
+  `getAvailableResources` / `listHookEntriesFromDir`. Source:
+  `apps/cli/src/lib/resources.ts`.

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -200,21 +200,97 @@ export function listResources(
   // Hooks use a one-level event-group layout (hooks/pre-tool-use/git-guard.sh).
   // A flat readdir treats `pre-tool-use` as the resource name, so `system:*`
   // pattern expansion never includes nested scripts — and `agents sync --force`
-  // leaves stale flat copies in version homes forever. Enumerate via
-  // listHookEntriesFromDir (same discovery as the writer / doctor) and use the
-  // file basename WITH extension so names match getAvailableResources.
+  // leaves stale flat copies in version homes forever. Enumerate the same way as
+  // getAvailableResources: expand group dirs that hold scripts (install name =
+  // file basename with extension), and keep fixture-only dirs as directory
+  // bundles (e.g. hooks/tests/fixtures).
   if (kind === 'hooks') {
+    const HOOK_SCRIPT_EXTS = new Set([
+      '.sh', '.bash', '.zsh', '.py', '.js', '.ts', '.mjs', '.cjs', '.rb', '.pl', '.ps1', '.cmd', '.bat',
+    ]);
+    const HOOK_GROUP_SKIP = new Set(['node_modules', '.git', '.cache']);
     for (const [dir, source, repoRoot] of roots) {
       if (!fs.existsSync(dir)) continue;
+      let top: string[];
+      try {
+        top = fs.readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const name of top) {
+        if (name.startsWith('.')) continue;
+        const full = path.join(dir, name);
+        let stat: fs.Stats;
+        try {
+          stat = fs.lstatSync(full);
+        } catch {
+          continue;
+        }
+        if (stat.isSymbolicLink()) continue;
+        if (stat.isFile()) {
+          // Top-level scripts only (not README/promptcuts — listHookEntriesFromDir
+          // is the gate for what is a real hook script).
+          continue;
+        }
+        if (!stat.isDirectory() || HOOK_GROUP_SKIP.has(name)) continue;
+        let nested: string[];
+        try {
+          nested = fs.readdirSync(full);
+        } catch {
+          continue;
+        }
+        const scripts: string[] = [];
+        for (const nestedName of nested) {
+          if (nestedName.startsWith('.')) continue;
+          const nfull = path.join(full, nestedName);
+          let nstat: fs.Stats;
+          try {
+            nstat = fs.lstatSync(nfull);
+          } catch {
+            continue;
+          }
+          if (nstat.isSymbolicLink() || !nstat.isFile()) continue;
+          if (HOOK_SCRIPT_EXTS.has(path.extname(nestedName).toLowerCase())) {
+            scripts.push(nestedName);
+          }
+        }
+        if (scripts.length > 0) {
+          // Event group: each script is its own resource (name = basename w/ ext).
+          for (const script of scripts) {
+            if (seen.has(script)) continue;
+            if (!resourceIsActive(kind, script, source)) continue;
+            seen.add(script);
+            results.push(withProvenance({
+              name: script,
+              path: path.join(full, script),
+              source,
+              repoRoot,
+            }));
+          }
+        } else {
+          // Fixture-only directory bundle (hooks/tests/fixtures/…).
+          if (seen.has(name)) continue;
+          if (!resourceIsActive(kind, name, source)) continue;
+          seen.add(name);
+          results.push(withProvenance({
+            name,
+            path: full,
+            source,
+            repoRoot,
+          }));
+        }
+      }
+      // Top-level hook scripts via the shared grouper (also drops docs/data files).
       for (const entry of listHookEntriesFromDir(dir)) {
-        // Install / available name is the script filename (git-guard.sh), not
-        // the extension-stripped HookEntry.name (git-guard).
-        const name = path.basename(entry.scriptPath);
-        if (seen.has(name)) continue;
-        if (!resourceIsActive(kind, name, source)) continue;
-        seen.add(name);
+        // Only top-level winners here — nested were already expanded above.
+        // listHookEntriesFromDir also returns nested; skip if already seen.
+        const scriptName = path.basename(entry.scriptPath);
+        if (seen.has(scriptName)) continue;
+        if (path.dirname(entry.scriptPath) !== path.resolve(dir)) continue;
+        if (!resourceIsActive(kind, scriptName, source)) continue;
+        seen.add(scriptName);
         results.push(withProvenance({
-          name,
+          name: scriptName,
           path: entry.scriptPath,
           source,
           repoRoot,

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -9,7 +9,7 @@ import type { AgentId } from './types.js';
 import { AGENTS, listInstalledMcpsWithScope } from './agents.js';
 import { listInstalledCommandsWithScope } from './commands.js';
 import { listInstalledSkillsWithScope, type SkillParseError } from './skills.js';
-import { listInstalledHooksWithScope, listHookEntriesFromDir } from './hooks.js';
+import { listInstalledHooksWithScope } from './hooks.js';
 import { listInstalledInstructionsWithScope } from './rules/rules.js';
 import { getEffectiveHome } from './versions.js';
 import { listMcpServerConfigs } from './mcp.js';
@@ -200,15 +200,24 @@ export function listResources(
   // Hooks use a one-level event-group layout (hooks/pre-tool-use/git-guard.sh).
   // A flat readdir treats `pre-tool-use` as the resource name, so `system:*`
   // pattern expansion never includes nested scripts — and `agents sync --force`
-  // leaves stale flat copies in version homes forever. Enumerate the same way as
-  // getAvailableResources: expand group dirs that hold scripts (install name =
-  // file basename with extension), and keep fixture-only dirs as directory
-  // bundles (e.g. hooks/tests/fixtures).
+  // leaves stale flat copies in version homes forever. Mirror getAvailableResources:
+  // expand group dirs that hold scripts (install name = basename with extension),
+  // keep fixture-only dirs as bundles, and keep top-level scripts as resources.
+  // Keep this logic self-contained (no hooks.ts import) so vi.mock of hooks.js
+  // in versions tests does not break listResources.
   if (kind === 'hooks') {
     const HOOK_SCRIPT_EXTS = new Set([
       '.sh', '.bash', '.zsh', '.py', '.js', '.ts', '.mjs', '.cjs', '.rb', '.pl', '.ps1', '.cmd', '.bat',
     ]);
+    const HOOK_NON_SCRIPT_EXTS = new Set([
+      '.md', '.markdown', '.rst', '.txt', '.yaml', '.yml', '.json', '.toml', '.ini', '.conf',
+    ]);
     const HOOK_GROUP_SKIP = new Set(['node_modules', '.git', '.cache']);
+    const isHookScriptName = (fileName: string, mode: number): boolean => {
+      const ext = path.extname(fileName).toLowerCase();
+      if (HOOK_SCRIPT_EXTS.has(ext)) return true;
+      return (mode & 0o111) !== 0 && !HOOK_NON_SCRIPT_EXTS.has(ext);
+    };
     for (const [dir, source, repoRoot] of roots) {
       if (!fs.existsSync(dir)) continue;
       let top: string[];
@@ -228,8 +237,19 @@ export function listResources(
         }
         if (stat.isSymbolicLink()) continue;
         if (stat.isFile()) {
-          // Top-level scripts only (not README/promptcuts — listHookEntriesFromDir
-          // is the gate for what is a real hook script).
+          if (!isHookScriptName(name, stat.mode)) continue;
+          // Docs that live beside hooks (README/AGENTS) are not resources.
+          const raw = name.replace(/\.(md|yaml|yml)$/, '');
+          if (isDirectoryDoc(kind, raw)) continue;
+          if (seen.has(name)) continue;
+          if (!resourceIsActive(kind, name, source)) continue;
+          seen.add(name);
+          results.push(withProvenance({
+            name,
+            path: full,
+            source,
+            repoRoot,
+          }));
           continue;
         }
         if (!stat.isDirectory() || HOOK_GROUP_SKIP.has(name)) continue;
@@ -250,12 +270,9 @@ export function listResources(
             continue;
           }
           if (nstat.isSymbolicLink() || !nstat.isFile()) continue;
-          if (HOOK_SCRIPT_EXTS.has(path.extname(nestedName).toLowerCase())) {
-            scripts.push(nestedName);
-          }
+          if (isHookScriptName(nestedName, nstat.mode)) scripts.push(nestedName);
         }
         if (scripts.length > 0) {
-          // Event group: each script is its own resource (name = basename w/ ext).
           for (const script of scripts) {
             if (seen.has(script)) continue;
             if (!resourceIsActive(kind, script, source)) continue;
@@ -279,22 +296,6 @@ export function listResources(
             repoRoot,
           }));
         }
-      }
-      // Top-level hook scripts via the shared grouper (also drops docs/data files).
-      for (const entry of listHookEntriesFromDir(dir)) {
-        // Only top-level winners here — nested were already expanded above.
-        // listHookEntriesFromDir also returns nested; skip if already seen.
-        const scriptName = path.basename(entry.scriptPath);
-        if (seen.has(scriptName)) continue;
-        if (path.dirname(entry.scriptPath) !== path.resolve(dir)) continue;
-        if (!resourceIsActive(kind, scriptName, source)) continue;
-        seen.add(scriptName);
-        results.push(withProvenance({
-          name: scriptName,
-          path: entry.scriptPath,
-          source,
-          repoRoot,
-        }));
       }
     }
     return results;

--- a/apps/cli/src/lib/resources.ts
+++ b/apps/cli/src/lib/resources.ts
@@ -9,7 +9,7 @@ import type { AgentId } from './types.js';
 import { AGENTS, listInstalledMcpsWithScope } from './agents.js';
 import { listInstalledCommandsWithScope } from './commands.js';
 import { listInstalledSkillsWithScope, type SkillParseError } from './skills.js';
-import { listInstalledHooksWithScope } from './hooks.js';
+import { listInstalledHooksWithScope, listHookEntriesFromDir } from './hooks.js';
 import { listInstalledInstructionsWithScope } from './rules/rules.js';
 import { getEffectiveHome } from './versions.js';
 import { listMcpServerConfigs } from './mcp.js';
@@ -196,6 +196,33 @@ export function listResources(
     [path.join(getSystemAgentsDir(), kind), 'system', getSystemAgentsDir()],
     ...extraRepos.map((e): [string, string, string] => [path.join(e.dir, kind), e.alias, e.dir]),
   ];
+
+  // Hooks use a one-level event-group layout (hooks/pre-tool-use/git-guard.sh).
+  // A flat readdir treats `pre-tool-use` as the resource name, so `system:*`
+  // pattern expansion never includes nested scripts — and `agents sync --force`
+  // leaves stale flat copies in version homes forever. Enumerate via
+  // listHookEntriesFromDir (same discovery as the writer / doctor) and use the
+  // file basename WITH extension so names match getAvailableResources.
+  if (kind === 'hooks') {
+    for (const [dir, source, repoRoot] of roots) {
+      if (!fs.existsSync(dir)) continue;
+      for (const entry of listHookEntriesFromDir(dir)) {
+        // Install / available name is the script filename (git-guard.sh), not
+        // the extension-stripped HookEntry.name (git-guard).
+        const name = path.basename(entry.scriptPath);
+        if (seen.has(name)) continue;
+        if (!resourceIsActive(kind, name, source)) continue;
+        seen.add(name);
+        results.push(withProvenance({
+          name,
+          path: entry.scriptPath,
+          source,
+          repoRoot,
+        }));
+      }
+    }
+    return results;
+  }
 
   for (const [dir, source, repoRoot] of roots) {
     if (!fs.existsSync(dir)) continue;

--- a/apps/cli/src/lib/versions.test.ts
+++ b/apps/cli/src/lib/versions.test.ts
@@ -1277,6 +1277,32 @@ describe('buildRepoScopedSelection — agents sync <agent> --repo <name>', () =>
     expect(sel.skills).toEqual(['system-only']);
   });
 
+  it('expands nested hooks/<event>/ scripts under system:* (not the group dir name)', () => {
+    // After hooks/<event-name>/<script> layout, listResources must expand group
+    // dirs so buildRepoScopedSelection('system') includes git-guard.sh — otherwise
+    // agents sync --force never re-copies nested system hooks into version homes.
+    const home = makeTempHome();
+    const nested = path.join(home, '.agents', '.system', 'hooks', 'pre-tool-use');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, 'git-guard.sh'), '#!/bin/sh\necho multi\n', 'utf-8');
+    fs.chmodSync(path.join(nested, 'git-guard.sh'), 0o755);
+    // Flat top-level still works.
+    fs.writeFileSync(
+      path.join(home, '.agents', '.system', 'hooks', 'registration_test.sh'),
+      '#!/bin/sh\n',
+      'utf-8',
+    );
+    // User-layer hook must NOT appear under --repo system.
+    const userHook = path.join(home, '.agents', 'hooks', 'user-only.sh');
+    fs.mkdirSync(path.dirname(userHook), { recursive: true });
+    fs.writeFileSync(userHook, '#!/bin/sh\n', 'utf-8');
+
+    const sel = runBuildScoped(home, 'system') as { hooks?: string[] };
+    expect(sel.hooks).toEqual(expect.arrayContaining(['git-guard.sh', 'registration_test.sh']));
+    expect(sel.hooks).not.toContain('pre-tool-use');
+    expect(sel.hooks).not.toContain('user-only.sh');
+  });
+
   it('scopes to the user repo — only user-layer skills, not system', () => {
     const home = makeTempHome();
     scaffoldSkills(home);


### PR DESCRIPTION
## Summary

**Bug:** After nested hooks layout (`hooks/pre-tool-use/git-guard.sh`), `listResources('hooks')` treated event-group directories as resource names. Pattern expansion for `system:*` therefore never selected nested scripts, so `agents sync --force` never re-copied them into version homes — stale flat guards stayed forever.

**Fix:** Enumerate hooks via `listHookEntriesFromDir` (same discovery as writers/doctor) and use script basenames with extension so names match `getAvailableResources`.

## Type

bugfix (hooks sync)

## Run result

```
bunx vitest run src/lib/versions.test.ts -t 'expands nested hooks'
✓ expands nested hooks/<event>/ scripts under system:* (not the group dir name)

listResources('hooks') on this host:
  has git-guard.sh true
  has pre-tool-use as name false
  system count 30
```

## Notes

No-surface declaration beyond unit test output above (internal listResources path).
