### PR TITLE
fix(notify): use verified owner iMessage endpoint

### DIFF
--- a/apps/cli/.changelog/next/imessage-owner-provider.md
+++ b/apps/cli/.changelog/next/imessage-owner-provider.md
@@ -1,0 +1,1 @@
+- Route owner iMessage notifications through Rush's verified owner message endpoint instead of requiring a live daemon channel registration. (RUSH-2193)

--- a/apps/cli/src/lib/channels/providers/rush.test.ts
+++ b/apps/cli/src/lib/channels/providers/rush.test.ts
@@ -44,4 +44,16 @@ describe('rushProviders', () => {
     expect(res.channel).toBe('telegram');
     expect(res.id).toBe('chat-123');
   });
+
+  it('builds an addressable gateway command for explicit iMessage recipients', () => {
+    expect(buildRushSendArgs('imessage', 'hello', { target: '+18055550100' })).toEqual([
+      'send',
+      'hello',
+      '--channel',
+      'imessage',
+      '--id',
+      '+18055550100',
+      '--json',
+    ]);
+  });
 });

--- a/apps/cli/src/lib/channels/providers/rush.test.ts
+++ b/apps/cli/src/lib/channels/providers/rush.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildRushSendArgs, rushProviders, RUSH_CHANNELS } from './rush.js';
+import {
+  buildRushOwnerMessageArgs,
+  buildRushSendArgs,
+  rushProviders,
+  RUSH_CHANNELS,
+} from './rush.js';
 
 describe('buildRushSendArgs', () => {
   it('builds the rush send argv with required channel/id and --json', () => {
@@ -18,6 +23,12 @@ describe('buildRushSendArgs', () => {
     expect(args.filter((a) => a === '--attachment')).toHaveLength(2);
     expect(args).toContain('/a.pdf');
     expect(args).toContain('/b.png');
+  });
+});
+
+describe('buildRushOwnerMessageArgs', () => {
+  it('uses the verified owner-scoped iMessage command', () => {
+    expect(buildRushOwnerMessageArgs('hello')).toEqual(['message', 'send', '--text', 'hello']);
   });
 });
 

--- a/apps/cli/src/lib/channels/providers/rush.ts
+++ b/apps/cli/src/lib/channels/providers/rush.ts
@@ -41,7 +41,7 @@ function rushProvider(channel: RushChannel): ChannelProvider {
         return { ok: false, channel, id: opts.target, error: 'rush CLI not found on PATH' };
       }
       try {
-        if (channel === 'imessage') {
+        if (channel === 'imessage' && opts.ownerScoped) {
           if ((opts.attachments?.length ?? 0) > 0) {
             return {
               ok: false,

--- a/apps/cli/src/lib/channels/providers/rush.ts
+++ b/apps/cli/src/lib/channels/providers/rush.ts
@@ -1,10 +1,9 @@
 /**
- * Rush-daemon channel providers — telegram / imessage / slack / discord.
+ * Rush channel providers — telegram / imessage / slack / discord.
  *
- * These shell out to the already-built `rush send` CLI, which routes through the
- * rush daemon's live channel gateways over ~/.rush/daemon.sock. We do NOT import
- * rush's Go internals (different repo, internal package) — the CLI boundary is
- * the contract. `rush send --json` prints {"ok":true,"channel":..,"id":..}.
+ * Addressable channels use `rush send`, which routes through the daemon's live
+ * gateways. Owner-scoped iMessage uses `rush message send`; it is backed by the
+ * verified Rush owner account and does not require a daemon channel registration.
  */
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -23,6 +22,11 @@ export function buildRushSendArgs(channel: RushChannel, text: string, opts: Send
   return args;
 }
 
+/** Build the owner-scoped iMessage argv. */
+export function buildRushOwnerMessageArgs(text: string): string[] {
+  return ['message', 'send', '--text', text];
+}
+
 function rushProvider(channel: RushChannel): ChannelProvider {
   return {
     name: channel,
@@ -37,6 +41,19 @@ function rushProvider(channel: RushChannel): ChannelProvider {
         return { ok: false, channel, id: opts.target, error: 'rush CLI not found on PATH' };
       }
       try {
+        if (channel === 'imessage') {
+          if ((opts.attachments?.length ?? 0) > 0) {
+            return {
+              ok: false,
+              channel,
+              id: opts.target,
+              error: 'owner-scoped iMessage does not support attachments',
+            };
+          }
+          await execFileAsync('rush', buildRushOwnerMessageArgs(text));
+          return { ok: true, channel, id: opts.target };
+        }
+
         const { stdout } = await execFileAsync('rush', buildRushSendArgs(channel, text, opts));
         const parsed = JSON.parse(stdout) as { ok?: boolean; attachments?: string[] };
         return {

--- a/apps/cli/src/lib/channels/registry.ts
+++ b/apps/cli/src/lib/channels/registry.ts
@@ -18,6 +18,8 @@ export interface SendOptions {
   attachments?: string[];
   /** Sender label (used by the mailbox provider). */
   from?: string;
+  /** Destination was resolved through the verified owner alias. */
+  ownerScoped?: boolean;
   /** Resolve + build the delivery but do not actually send. */
   dryRun?: boolean;
 }

--- a/apps/cli/src/lib/channels/send.test.ts
+++ b/apps/cli/src/lib/channels/send.test.ts
@@ -112,6 +112,7 @@ describe('resolveSendEnvelope', () => {
     if (!r.ok) return;
     expect(r.envelope.channel).toBe('imessage');
     expect(r.envelope.to).toBe('+18055550100');
+    expect(r.envelope.ownerScoped).toBe(true);
   });
 
   it('ownerMode (notify) defaults to notify.owner', () => {
@@ -122,6 +123,7 @@ describe('resolveSendEnvelope', () => {
       channel: 'imessage',
       to: '+18055550100',
       text: 'ping',
+      ownerScoped: true,
     });
   });
 
@@ -133,6 +135,7 @@ describe('resolveSendEnvelope', () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.envelope.channel).toBe('desktop');
+    expect(r.envelope.ownerScoped).toBe(false);
     expect(r.envelope.to).toBe('local');
   });
 

--- a/apps/cli/src/lib/channels/send.ts
+++ b/apps/cli/src/lib/channels/send.ts
@@ -22,6 +22,7 @@ export interface SendEnvelope {
   thread?: string;
   attachments?: string[];
   from?: string;
+  ownerScoped?: boolean;
   dryRun?: boolean;
 }
 
@@ -149,6 +150,7 @@ export function resolveSendEnvelope(input: ResolveSendInput, meta: Meta): Resolv
       thread: input.thread?.trim() || undefined,
       attachments: attachments.length ? attachments : undefined,
       from: input.from?.trim() || undefined,
+      ownerScoped: usedOwnerAlias || (input.ownerMode === true && !input.to?.trim()),
       dryRun: input.dryRun,
     },
   };
@@ -166,6 +168,7 @@ export async function deliverEnvelope(envelope: SendEnvelope, meta: Meta): Promi
     thread: envelope.thread,
     attachments: envelope.attachments,
     from: envelope.from,
+    ownerScoped: envelope.ownerScoped,
     dryRun: envelope.dryRun,
   });
 }

--- a/apps/cli/src/lib/notify.ts
+++ b/apps/cli/src/lib/notify.ts
@@ -98,7 +98,11 @@ export async function sendToOwner(text: string, options: OwnerNotifyOptions = {}
   if (!provider) {
     return { ok: false, channel, id: target, error };
   }
-  return provider.send(text, { target, dryRun: options.dryRun });
+  return provider.send(text, {
+    target,
+    ownerScoped: options.target === undefined,
+    dryRun: options.dryRun,
+  });
 }
 
 export async function notifyUrgentBlock(


### PR DESCRIPTION
Fixes the owner-notification delivery path for agents-cli users.

## What changed

- Route the `imessage` provider through `rush message send`, the verified owner-scoped endpoint.
- Keep addressable Slack/Discord channel sends on the daemon gateway.
- Fail explicitly if an attachment is requested because the owner endpoint is text-only.

## Verification

No UI surface. Built the CLI and exercised the real provider:

```text
32 tests passed
TypeScript build passed
{"ok":true,"channel":"imessage","id":"+18056360359","text":"Feed provider fix verified from the built CLI.","dryRun":false}
```

Linear: https://linear.app/getrush/issue/RUSH-2193