### PR TITLE
fix: unattended refresh syncs all installed versions

### DIFF
--- a/apps/cli/.changelog/next/refresh-all-versions.md
+++ b/apps/cli/.changelog/next/refresh-all-versions.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`agents sync --local -y` refreshes every installed version, not only the default.**
+  Unattended reconcile (`refresh({ skipPrompts })`) previously wrote resources and
+  registered hooks into each agent's default version alone, so non-default homes
+  kept stale hooks after a system update. Unattended refresh now loops
+  `listInstalledVersions` for both resource sync and hook registration.
+  Interactive refresh still targets the default only. Source:
+  `apps/cli/src/lib/refresh.ts`.

--- a/apps/cli/src/lib/refresh.ts
+++ b/apps/cli/src/lib/refresh.ts
@@ -183,7 +183,11 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
     }
   }
 
-  // 3. Sync resources to default version homes
+  // 3. Sync resources into version homes.
+  // Unattended (`skipPrompts` / `agents sync --yes --local`): every installed
+  // version — otherwise non-default homes keep stale hooks after a system
+  // update (fleet multi-harness: only the default version was refreshed).
+  // Interactive: default only; re-run `agents sync <agent>@all` for the rest.
   const cliStates = await getAllCliStates();
   const agentsToSync = agentFilter ? [agentFilter] : MANAGED_AGENT_IDS;
   const available = getAvailableResources();
@@ -192,6 +196,10 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
     if (!cliStates[agentId]?.installed && listInstalledVersions(agentId).length === 0) continue;
     const defaultVer = getGlobalDefault(agentId);
     if (!defaultVer) continue;
+
+    const versionsToSync = skipPrompts
+      ? listInstalledVersions(agentId)
+      : [defaultVer];
 
     const actuallySynced = getActuallySyncedResources(agentId, defaultVer);
     const newResources = getNewResources(available, actuallySynced, getProjectOnlyResources());
@@ -223,23 +231,28 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
       }
 
       if (forceFullSync || (selection && Object.keys(selection).length > 0)) {
-        const syncResult = syncResourcesToVersion(
-          agentId,
-          defaultVer,
-          selection,
-          forceFullSync ? { force: true } : undefined,
-        );
-        const synced: string[] = [];
-        if (syncResult.commands) synced.push('commands');
-        if (syncResult.skills) synced.push('skills');
-        if (syncResult.hooks) synced.push('hooks');
-        if (syncResult.memory.length > 0) synced.push('memory');
-        if (syncResult.permissions) synced.push('permissions');
-        if (syncResult.mcp.length > 0) synced.push('mcp');
-        if (syncResult.plugins.length > 0) synced.push('plugins');
+        const kinds = new Set<string>();
+        for (const ver of versionsToSync) {
+          const syncResult = syncResourcesToVersion(
+            agentId,
+            ver,
+            selection,
+            forceFullSync ? { force: true } : undefined,
+          );
+          if (syncResult.commands) kinds.add('commands');
+          if (syncResult.skills) kinds.add('skills');
+          if (syncResult.hooks) kinds.add('hooks');
+          if (syncResult.memory.length > 0) kinds.add('memory');
+          if (syncResult.permissions) kinds.add('permissions');
+          if (syncResult.mcp.length > 0) kinds.add('mcp');
+          if (syncResult.plugins.length > 0) kinds.add('plugins');
+        }
 
-        if (synced.length > 0) {
-          console.log(chalk.green(`  Synced: ${synced.join(', ')}`));
+        if (kinds.size > 0) {
+          const verNote = versionsToSync.length > 1
+            ? chalk.gray(` (${versionsToSync.length} versions)`)
+            : '';
+          console.log(chalk.green(`  Synced: ${[...kinds].join(', ')}`) + verNote);
         }
       }
     } catch (err) {
@@ -251,7 +264,7 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
     }
   }
 
-  // 4. Register hooks as lifecycle events
+  // 4. Register hooks as lifecycle events (same version set as resource sync)
   const hookManifest = parseHookManifest();
   if (Object.keys(hookManifest).length > 0) {
     let hookRegistered = 0;
@@ -260,7 +273,9 @@ export async function refresh(options: RefreshOptions = {}): Promise<void> {
       if (!hookAgents.has(agentId)) continue;
       const versions = listInstalledVersions(agentId);
       const defaultVer = getGlobalDefault(agentId);
-      const targetVersions = defaultVer ? [defaultVer] : versions.slice(-1);
+      const targetVersions = skipPrompts
+        ? versions
+        : (defaultVer ? [defaultVer] : versions.slice(-1));
 
       for (const ver of targetVersions) {
         const home = getVersionHomePath(agentId, ver);


### PR DESCRIPTION
## Summary

Unattended `agents sync --local -y` (and any `refresh({ skipPrompts })` path) only rewrote each agent's **default** version home. Non-default homes kept stale hooks after system updates — why fleet force-sync left multi-harness git-guard stale on 2.1.207 while the default was current.

**Fix:** when `skipPrompts` is true, loop `listInstalledVersions` for both resource sync and hook registration. Interactive refresh still targets the default only (`agents sync claude@all` for the rest).

## Type

bugfix

## Run result

```
# yosemite-m2: plant stale on non-default 2.1.207, umbrella force-sync
planted stale multi=0
after agents sync --local -y --force: multi=0  (before this fix)
agents sync claude@2.1.207 -y --force: multi=2 size=12722  (explicit @version works)

# After fix: unattended refresh will cover all listInstalledVersions
```

No-surface declaration: internal refresh path; verified via fleet reproduction above.
