### PR TITLE
fix(factory): make release tests deterministic

### DIFF
--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -136,7 +136,8 @@ agents ssh mac-mini "agents computer screenshot --bundle com.microsoft.VSCode --
 
 ```bash
 bun run compile   # tsc + vite build for both webviews
-bun test          # Full test suite, no mocks
+bun test          # Deterministic test suite; no external agent login required
+bun run test:agent-integration  # Three real Claude-backed helper flows (opt-in)
 bash scripts/install.sh <version>   # Package .vsix and install to Cursor + Code + Codium
 ```
 
@@ -177,10 +178,7 @@ agents secrets unlock vs-marketplace
 Then re-run the release command.
 
 Known gotchas:
-- The release clone's test environment on `zion` currently misses some dev dependencies (`@happy-dom/global-registrator`, `gray-matter`) and cannot find `agents` on PATH for live-agent tests, so the local test run may fail even when GitHub CI is green. If CI passed and the change is release-ready, use `--skip-tests` as a hotfix path:
-  ```bash
-  bash scripts/release.sh 0.9.xxx --confirm --skip-tests
-  ```
+- The deterministic release gate installs both Factory dependency roots and does not require an agent login. Run `bun run test:agent-integration` separately when validating the three helper flows that invoke a real Claude session.
 - The script builds and publishes to both VS Code Marketplace and Open VSX. Marketplace propagation can lag a few minutes; Open VSX is usually live immediately.
 - The script installs the new `.vsix` into local VS Code / Codium windows automatically.
 

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -938,7 +938,8 @@
     "watch": "tsc -watch -p ./",
     "package": "bun run compile && vsce package",
     "rebuild": "electron-rebuild -f -w node-pty",
-    "test": "bun test --timeout 30000"
+    "test": "bun test --timeout 30000",
+    "test:agent-integration": "FACTORY_AGENT_INTEGRATION=1 bun test --timeout 95000 src/core/draftPrompt.test.ts src/core/labelgen.test.ts src/core/commitgen.test.ts"
   },
   "devDependencies": {
     "@electron/rebuild": "^3.7.1",

--- a/apps/factory/scripts/build.sh
+++ b/apps/factory/scripts/build.sh
@@ -24,6 +24,16 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 DIST_DIR="$PROJECT_ROOT/dist"
 
+# Version stamping is build input, not a source edit. Restore package.json on
+# every exit so a release clone remains reusable after both success and failure.
+PACKAGE_JSON_BACKUP="$(mktemp "${TMPDIR:-/tmp}/factory-package-json.XXXXXX")"
+cp "$PROJECT_ROOT/package.json" "$PACKAGE_JSON_BACKUP"
+restore_package_json() {
+    cp "$PACKAGE_JSON_BACKUP" "$PROJECT_ROOT/package.json"
+    rm -f "$PACKAGE_JSON_BACKUP"
+}
+trap restore_package_json EXIT
+
 # Update version in package.json
 echo "Updating version to ${VERSION}..."
 node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));pkg.version='${VERSION}';fs.writeFileSync('package.json',JSON.stringify(pkg,null,2)+'\n')"

--- a/apps/factory/scripts/release.sh
+++ b/apps/factory/scripts/release.sh
@@ -215,6 +215,7 @@ git -C "\$CACHE" checkout --quiet --detach "\$SHA"
 
 cd "\$CACHE/apps/factory"
 bun install --silent
+(cd ui && bun install --silent)
 bash scripts/release.sh "\$VERSION" $flags --publish-phase
 REMOTE_EOF
 )"

--- a/apps/factory/src/core/commitgen.test.ts
+++ b/apps/factory/src/core/commitgen.test.ts
@@ -45,8 +45,10 @@ describe('sanitizeCommitMessage', () => {
 });
 
 describe('generateCommitMessageWithClaude (integration, may be slow)', () => {
-  test('produces a conventional-commit message for a simple diff', async () => {
-    const prompt = `Write ONE conventional-commit message for the staged changes below.
+  test.skipIf(process.env.FACTORY_AGENT_INTEGRATION !== '1')(
+    'produces a conventional-commit message for a simple diff',
+    async () => {
+      const prompt = `Write ONE conventional-commit message for the staged changes below.
 
 Respond IMMEDIATELY with only the commit message. Do NOT investigate, do NOT read files, do NOT use tools.
 
@@ -68,8 +70,10 @@ File: README.md (2 lines changed)
 
 Output the commit message and nothing else.`;
 
-    const result = await generateCommitMessageWithClaude(prompt, 90_000);
-    expect(result).not.toBeNull();
-    expect(result).toMatch(/^[a-z]+:\s+\S/);
-  }, 95_000);
+      const result = await generateCommitMessageWithClaude(prompt, 90_000);
+      expect(result).not.toBeNull();
+      expect(result).toMatch(/^[a-z]+:\s+\S/);
+    },
+    95_000,
+  );
 });

--- a/apps/factory/src/core/draftPrompt.test.ts
+++ b/apps/factory/src/core/draftPrompt.test.ts
@@ -63,16 +63,20 @@ describe('draftDispatchPrompt', () => {
     expect(await draftDispatchPrompt([{ title: '  ' }], '  ')).toBeNull();
   });
 
-  it('drafts a real work order from a ticket (headless agent)', async () => {
-    const result = await draftDispatchPrompt(
-      [{ identifier: 'RUSH-1262', title: 'PKCE token exchange uses an unpinned http client', description: 'The rush CLI OAuth PKCE flow depends on an http client without a pinned version, a supply-chain risk. Pin it and add a regression test.' }],
-      undefined,
-      60000,
-    );
-    expect(result).toBeTruthy();
-    expect(result!.length).toBeGreaterThan(20);
-    expect(result!).not.toMatch(/^```/);
-  }, 65000);
+  it.skipIf(process.env.FACTORY_AGENT_INTEGRATION !== '1')(
+    'drafts a real work order from a ticket (headless agent)',
+    async () => {
+      const result = await draftDispatchPrompt(
+        [{ identifier: 'RUSH-1262', title: 'PKCE token exchange uses an unpinned http client', description: 'The rush CLI OAuth PKCE flow depends on an http client without a pinned version, a supply-chain risk. Pin it and add a regression test.' }],
+        undefined,
+        60000,
+      );
+      expect(result).toBeTruthy();
+      expect(result!.length).toBeGreaterThan(20);
+      expect(result!).not.toMatch(/^```/);
+    },
+    65000,
+  );
 
   it('returns null when the timeout is too short to complete', async () => {
     const result = await draftDispatchPrompt([{ title: 'Build a large feature' }], undefined, 1);

--- a/apps/factory/src/core/labelgen.test.ts
+++ b/apps/factory/src/core/labelgen.test.ts
@@ -8,17 +8,21 @@ describe('generateLabelWithLLM', () => {
     expect(await generateLabelWithLLM('   \n  ')).toBeNull();
   });
 
-  it('returns a short title for a real task description', async () => {
-    const result = await generateLabelWithLLM(
-      'Refactor the database connection pool to use lazy initialization. Add a maximum size of 50 and a timeout of 30 seconds.',
-      20000
-    );
-    expect(result).toBeTruthy();
-    expect(result!.length).toBeLessThanOrEqual(50);
-    expect(result!.split('\n').length).toBe(1);
-    expect(result!).not.toMatch(/^["'`]/);
-    expect(result!).not.toMatch(/[.!?]$/);
-  }, 25000);
+  it.skipIf(process.env.FACTORY_AGENT_INTEGRATION !== '1')(
+    'returns a short title for a real task description',
+    async () => {
+      const result = await generateLabelWithLLM(
+        'Refactor the database connection pool to use lazy initialization. Add a maximum size of 50 and a timeout of 30 seconds.',
+        20000
+      );
+      expect(result).toBeTruthy();
+      expect(result!.length).toBeLessThanOrEqual(50);
+      expect(result!.split('\n').length).toBe(1);
+      expect(result!).not.toMatch(/^["'`]/);
+      expect(result!).not.toMatch(/[.!?]$/);
+    },
+    25000,
+  );
 
   it('returns null when timeout is too short to complete', async () => {
     const result = await generateLabelWithLLM(


### PR DESCRIPTION
Internal release/test-only fix: Factory publishing no longer depends on a Claude login.

## What changed

- Gate the three real-Claude helper tests behind `FACTORY_AGENT_INTEGRATION=1` and expose `bun run test:agent-integration`.
- Install both Factory dependency roots in the clean publish clone.
- Restore `package.json` after every build exit so version stamping cannot dirty the reusable clone.
- Remove the documented `--skip-tests` workaround.

## Run result

```text
1610 pass
3 skip (the opt-in real-Claude cases)
0 fail
4440 expect() calls
```

A forced Linux packaging failure returned exit 1 and printed `package-json-restored=yes`, reproducing and verifying the interrupted-build cleanup path.

## Context

- Tracks the Factory Floor delivery in #2030.
- No user-visible UI surface; this changes only release/test behavior.