### PR TITLE
fix(secrets): exec resolves interactively at a real terminal

### DIFF
--- a/apps/cli/.changelog/next/secrets-exec-interactive.md
+++ b/apps/cli/.changelog/next/secrets-exec-interactive.md
@@ -1,0 +1,12 @@
+- **`agents secrets exec <bundle> -- <cmd>` now resolves a locked keychain bundle
+  interactively at a real terminal.** The local resolve hardcoded `agentOnly: true`
+  (`commands/secrets.ts`), so running `exec` on a locked bundle at a terminal
+  failed closed with "run `agents secrets unlock` first" instead of raising the one
+  Touch ID sheet the human just implied by asking to use the values. It now gates
+  `agentOnly` on `isHeadlessSecretsContext() || !isInteractiveTerminal()`: an
+  unlocked bundle still runs silently, a locked bundle at an interactive terminal
+  resolves with a single sheet and then runs the command with the secrets injected,
+  and under an agent (`AGENTS_RUNTIME`) or headless (no TTY) it stays broker-only —
+  release/CI scripts never prompt. Mirrors the same fix for `view --reveal`.
+  `--host` remote resolves and `export`/`get` are unchanged. Source:
+  `apps/cli/src/commands/secrets.ts`.

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -2454,7 +2454,13 @@ Examples:
             caller: `command ${cmd}`,
             keys: keysSubset,
             allowExpired: execOpts.allowExpired,
-            agentOnly: true,
+            // An explicit `secrets exec` at a real terminal is a deliberate use of
+            // the values: an unlocked bundle runs silently, a locked one resolves
+            // with one Touch ID sheet, then the command runs with the secrets
+            // injected. Under an agent (AGENTS_RUNTIME) or headless (no TTY) it
+            // stays broker-only and points at the explicit unlock command instead
+            // of raising a sheet — so release/CI scripts never prompt.
+            agentOnly: isHeadlessSecretsContext() || !isInteractiveTerminal(),
           }).env;
         }
         const { spawn } = await import('child_process');


### PR DESCRIPTION
**fix (behavior)** — `agents secrets exec <bundle> -- <cmd>` on a **locked** keychain bundle now resolves interactively at a real terminal instead of failing closed. No new surface.

## What changed
The local resolve in the `exec` command hardcoded `agentOnly: true`, so `exec` on a locked bundle at a terminal errored with "run `agents secrets unlock` first" — never the one Touch ID sheet the human implied by asking to *use* the values.

`agentOnly` is now `isHeadlessSecretsContext() || !isInteractiveTerminal()` (the same gate shipped for `view --reveal` in #2025).

| Context | Before | After |
|---|---|---|
| Unlocked bundle | runs silently | runs silently (unchanged) |
| Locked bundle, interactive terminal | error, no sheet | **one Touch ID sheet, then the command runs with secrets injected** |
| Agent (`AGENTS_RUNTIME`) / headless / CI | broker-only, no sheet | broker-only, no sheet (unchanged) |

`--host` remote resolves and `export`/`get` are untouched.

## Why
Matches the intended model: unlocked → no prompt; locked → one prompt, then usable. Closes the same over-correction `view --reveal` had (the storm fix made every value path `agentOnly`, which fails closed on an explicit interactive use).

## Verification
- `tsc --noEmit` clean.
- Runtime smoke (`AGENTS_RUNTIME=headless … exec <locked> -- echo`): still fails closed with the unlock hint and **no sheet** — confirms CI/agent paths are unchanged.
- The interactive single-sheet path is the identical mechanism verified live for `view --reveal` (shipped in 1.22.14/1.22.16).
