### PR TITLE
test(factory): isolate watchdog migration dependencies

### DIFF
--- a/apps/factory/src/vscode/watchdog.vscode.test.ts
+++ b/apps/factory/src/vscode/watchdog.vscode.test.ts
@@ -1,11 +1,10 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
 
 // Minimal vscode mock — the palette handlers show status-bar / error messages;
-// the migration reads the (deleted) agents.watchdog.autoRotate setting via
-// inspect() so it only fires on an EXPLICIT false.
+// the migration receives its VS Code boundary functions explicitly so this
+// file stays deterministic when Bun runs it beside other vscode module mocks.
 const statusMessages: string[] = [];
 const errorMessages: string[] = [];
-let inspectResult: { globalValue?: boolean; workspaceValue?: boolean; workspaceFolderValue?: boolean } = {};
 
 mock.module('vscode', () => ({
   window: {
@@ -19,11 +18,7 @@ mock.module('vscode', () => ({
       return Promise.resolve(undefined);
     },
   },
-  workspace: {
-    getConfiguration: () => ({
-      inspect: () => inspectResult,
-    }),
-  },
+  workspace: {},
   ConfigurationTarget: { Global: 1, Workspace: 2 },
 }));
 
@@ -65,10 +60,29 @@ function makeDeps(behavior: 'ok' | 'fail' = 'ok') {
   };
 }
 
+function makeMigrationDeps(
+  inspect: { globalValue?: boolean; workspaceValue?: boolean; workspaceFolderValue?: boolean } = {},
+  behavior: 'ok' | 'fail' = 'ok',
+) {
+  const { calls, deps } = makeDeps(behavior);
+  return {
+    calls,
+    deps: {
+      ...deps,
+      inspectAutoRotate: () => inspect,
+      setStatusBarMessage: (message: string) => {
+        statusMessages.push(message);
+      },
+      showErrorMessage: (message: string) => {
+        errorMessages.push(message);
+      },
+    },
+  };
+}
+
 beforeEach(() => {
   statusMessages.length = 0;
   errorMessages.length = 0;
-  inspectResult = {};
 });
 
 describe('registerWatchdogPaletteCommands', () => {
@@ -140,7 +154,7 @@ describe('registerWatchdogPaletteCommands', () => {
 
 describe('migrateAutoRotateSettingOnce', () => {
   test('no explicit autoRotate setting → no CLI call, flag set (runs once)', async () => {
-    const { calls, deps } = makeDeps();
+    const { calls, deps } = makeMigrationDeps();
     const state = fakeGlobalState();
     await watchdog.migrateAutoRotateSettingOnce(state, deps);
     expect(calls).toHaveLength(0);
@@ -148,8 +162,7 @@ describe('migrateAutoRotateSettingOnce', () => {
   });
 
   test('autoRotate explicitly true → no migration', async () => {
-    inspectResult = { globalValue: true };
-    const { calls, deps } = makeDeps();
+    const { calls, deps } = makeMigrationDeps({ globalValue: true });
     const state = fakeGlobalState();
     await watchdog.migrateAutoRotateSettingOnce(state, deps);
     expect(calls).toHaveLength(0);
@@ -157,8 +170,7 @@ describe('migrateAutoRotateSettingOnce', () => {
   });
 
   test('autoRotate explicitly false → CLI watchdog rotate off once + one-time note', async () => {
-    inspectResult = { globalValue: false };
-    const { calls, deps } = makeDeps();
+    const { calls, deps } = makeMigrationDeps({ globalValue: false });
     const state = fakeGlobalState();
     await watchdog.migrateAutoRotateSettingOnce(state, deps);
     expect(calls).toEqual([{ file: '/fake/bin/agents', args: ['watchdog', 'rotate', 'off'] }]);
@@ -171,15 +183,13 @@ describe('migrateAutoRotateSettingOnce', () => {
   });
 
   test('workspace-level explicit false also migrates', async () => {
-    inspectResult = { workspaceValue: false };
-    const { calls, deps } = makeDeps();
+    const { calls, deps } = makeMigrationDeps({ workspaceValue: false });
     await watchdog.migrateAutoRotateSettingOnce(fakeGlobalState(), deps);
     expect(calls).toEqual([{ file: '/fake/bin/agents', args: ['watchdog', 'rotate', 'off'] }]);
   });
 
   test('CLI failure → error toast, flag left unset so the next activation retries', async () => {
-    inspectResult = { globalValue: false };
-    const { deps } = makeDeps('fail');
+    const { deps } = makeMigrationDeps({ globalValue: false }, 'fail');
     const state = fakeGlobalState();
     await watchdog.migrateAutoRotateSettingOnce(state, deps);
     expect(state.data.get(watchdog.WATCHDOG_ROTATE_MIGRATED_KEY)).toBeUndefined();
@@ -187,8 +197,7 @@ describe('migrateAutoRotateSettingOnce', () => {
   });
 
   test('flag already set → no-op even with an explicit false', async () => {
-    inspectResult = { globalValue: false };
-    const { calls, deps } = makeDeps();
+    const { calls, deps } = makeMigrationDeps({ globalValue: false });
     const state = fakeGlobalState({ [watchdog.WATCHDOG_ROTATE_MIGRATED_KEY]: true });
     await watchdog.migrateAutoRotateSettingOnce(state, deps);
     expect(calls).toHaveLength(0);

--- a/apps/factory/src/vscode/watchdog.vscode.ts
+++ b/apps/factory/src/vscode/watchdog.vscode.ts
@@ -162,6 +162,18 @@ interface GlobalStateLike {
   update(key: string, value: unknown): Thenable<void>;
 }
 
+interface AutoRotateSettingInspect {
+  globalValue?: boolean;
+  workspaceValue?: boolean;
+  workspaceFolderValue?: boolean;
+}
+
+export interface AutoRotateMigrationDeps extends WatchdogCliDeps {
+  inspectAutoRotate?: () => AutoRotateSettingInspect | undefined;
+  setStatusBarMessage?: (message: string, hideAfterTimeout: number) => void;
+  showErrorMessage?: (message: string) => void;
+}
+
 /**
  * The `agents.watchdog.*` settings were deleted with the in-extension loop. A
  * user who explicitly set `agents.watchdog.autoRotate: false` opted OUT of
@@ -179,11 +191,11 @@ interface GlobalStateLike {
  */
 export async function migrateAutoRotateSettingOnce(
   globalState: GlobalStateLike,
-  deps: WatchdogCliDeps = {},
+  deps: AutoRotateMigrationDeps = {},
 ): Promise<void> {
   if (globalState.get<boolean>(WATCHDOG_ROTATE_MIGRATED_KEY)) return;
 
-  const inspect = vscode.workspace
+  const inspect = deps.inspectAutoRotate?.() ?? vscode.workspace
     .getConfiguration('agents.watchdog')
     .inspect<boolean>('autoRotate');
   const explicitOff =
@@ -199,13 +211,17 @@ export async function migrateAutoRotateSettingOnce(
   try {
     await runWatchdogCli(['rotate', 'off'], deps);
     await globalState.update(WATCHDOG_ROTATE_MIGRATED_KEY, true);
-    vscode.window.setStatusBarMessage(
+    (deps.setStatusBarMessage ?? ((message, timeout) => {
+      vscode.window.setStatusBarMessage(message, timeout);
+    }))(
       'Migrated watchdog setting: auto-rotate was off — CLI watchdog rotate is off (`agents watchdog rotate on` re-enables)',
       8000,
     );
   } catch (err) {
     console.warn('[WATCHDOG] autoRotate migration failed (will retry next activation):', err);
-    vscode.window.showErrorMessage(
+    (deps.showErrorMessage ?? ((message) => {
+      void vscode.window.showErrorMessage(message);
+    }))(
       `Could not migrate the removed agents.watchdog.autoRotate setting: ${err instanceof Error ? err.message : String(err)}`
     );
   }


### PR DESCRIPTION
Test-only: make the deterministic Factory release gate independent of Bun test-file order.

## What changed

- Inject the deleted-setting inspection and message boundaries into `migrateAutoRotateSettingOnce`.
- Exercise the migration through those explicit boundaries instead of a process-global `vscode` mock.
- Leave the production defaults and migration behavior unchanged.

## Why

The full Factory suite reused another test file's `vscode` module mock, so all five migration cases failed on zion even though the focused file passed. The 0.9.311 release stopped at that deterministic gate before publishing Open VSX.

## Verification

No user-visible surface changed. This is a test-isolation fix.

- Focused: `10 pass, 0 fail, 23 expect() calls`
- Full deterministic Factory suite: `1610 pass, 3 service tests skipped, 0 fail, 4440 expect() calls`
- `git diff --check`: clean

Tracking: #2030
Plan: [.agents/plans/plan-factory-floor-performance.html](https://github.com/phnx-labs/agents-cli/blob/main/.agents/plans/plan-factory-floor-performance.html)