### PR TITLE
fix(factory): New X (Auto) offloads to the fleet on a cold cache

### DIFF
--- a/apps/factory/AGENTS.md
+++ b/apps/factory/AGENTS.md
@@ -43,8 +43,16 @@ same flags — only host selection differs** (`launchAgent` in
 | Command | `launchAgent` opts | Host selector | Full command |
 |---|---|---|---|
 | `Agents: New X` | `{ agentKey, local: true }` | *(none — this machine)* | `agents run X --interactive --strategy balanced --mode auto` |
-| `Agents: New X (Auto)` | `{ agentKey, autoHost: true }` | `--device auto` | `agents run X --interactive --device auto --strategy balanced --mode auto` |
+| `Agents: New X (Auto)` | `{ agentKey, autoHost: true }` | `--host '<device>'` (resolved) | `agents run X --interactive --host '<device>' --strategy balanced --mode auto` |
 | `Agents: New X (Pick Host)` | `{ agentKey, pickHost: true }` | `--host '<device>'` | `agents run X --interactive --host '<device>' --strategy balanced --mode auto` |
+
+`(Auto)` resolves that device itself (it does NOT hand `--device auto` to the
+CLI): first from the warm health-cache snapshot (`resolveCachedAutoHost` →
+`pickCachedLaunchHost`), and — when that cache is cold or >5min stale — it falls
+through to the same live, favorites-aware fleet sweep the default New-agent path
+uses (`resolveBalancedHost`), honoring enable/prefer and dropping hosts with no
+usable version. It runs local only when no fleet device is genuinely eligible; a
+cold cache no longer silently pins the launch to this Mac (`launchAgent`).
 
 Claude alone adds `--session-id <id>` (minted up front for the resume/fork flow);
 that is the only per-agent addition and it never removes a flag. A **fork**

--- a/apps/factory/src/core/agents.test.ts
+++ b/apps/factory/src/core/agents.test.ts
@@ -339,7 +339,9 @@ describe('launch contract — every runner is balanced', () => {
       expect(buildAgentLaunchCommand(
         key, null, undefined, undefined, undefined, 'balanced', undefined, { local: true },
       )).toBe(`agents run ${key} --interactive --strategy balanced --mode auto`);
-      // New X (Auto) — CLI auto-picks the host via --device auto
+      // Unpinned, no host, not local (QuickLaunch balanced) — CLI affinity-picks
+      // the device via --device auto. (New X (Auto) resolves a concrete --host
+      // itself instead; see launchAgent + apps/factory/AGENTS.md launch contract.)
       expect(buildAgentLaunchCommand(
         key, null, undefined, undefined, undefined, 'balanced', undefined, {},
       )).toBe(`agents run ${key} --interactive --device auto --strategy balanced --mode auto`);

--- a/apps/factory/src/core/launchHistory.test.ts
+++ b/apps/factory/src/core/launchHistory.test.ts
@@ -7,6 +7,7 @@ import {
   pickCachedLaunchHost,
   recordLaunch,
 } from './launchHistory';
+import { DeviceLoad, pickBestHost, resolveBalancePool } from './launchHost';
 
 const NOW = 1_800_000_000_000;
 
@@ -43,6 +44,27 @@ describe('pickCachedLaunchHost', () => {
     const stale = cache([]);
     stale.refreshedAt = NOW - LAUNCH_HEALTH_MAX_AGE_MS - 1;
     expect(pickCachedLaunchHost('gemini', stale, {}, {}, NOW)).toBeNull();
+  });
+
+  // Regression: `New X (Auto)` used to run LOCAL whenever the health cache was
+  // cold/stale, because launchAgent bailed on the null cache pick instead of
+  // doing a live sweep. The cache miss is correct here (below); the fix is that
+  // a null cache pick must fall through to the live favorites-aware picker,
+  // which still resolves an eligible fleet host — not this Mac.
+  test('a cold-cache null does not mean local when a fleet host is eligible', () => {
+    const stale = cache([]);
+    stale.refreshedAt = NOW - LAUNCH_HEALTH_MAX_AGE_MS - 1;
+    expect(pickCachedLaunchHost('claude', stale, {}, {}, NOW)).toBeNull();
+
+    // The live fallback path launchAgent now takes: rank the online fleet
+    // (minus this Mac) and pick the least-loaded usable host.
+    const fleet: DeviceLoad[] = [
+      { name: 'zion', online: true, running: 0, usableVersion: true },
+      { name: 'yosemite-s0', online: true, running: 0, usableVersion: true },
+      { name: 'yosemite-m4', online: true, running: 5, usableVersion: true },
+    ];
+    const pool = resolveBalancePool(fleet, { localName: 'zion' });
+    expect(pickBestHost(pool)).toBe('yosemite-s0');
   });
 
   test('excludes devices disabled for auto-launch', () => {

--- a/apps/factory/src/vscode/extension.ts
+++ b/apps/factory/src/vscode/extension.ts
@@ -793,8 +793,15 @@ async function launchAgent(context: vscode.ExtensionContext, opts: LaunchAgentOp
   if (opts.autoHost && AUTO_HOST_AGENT_KEYS.has(agentKey)) {
     host = resolveCachedAutoHost(context, agentKey);
     if (!host) {
-      vscode.window.showWarningMessage(`No cached SSH-reachable device has a signed-in, non-throttled ${agentKey} version — running locally.`);
+      // Cache cold/stale (first launch after activation, >5min idle, or the
+      // background fleet sweep hasn't landed on a loaded box). Don't silently
+      // run local — do the same live, favorites-aware fleet sweep the default
+      // New-agent path uses (honors enable/prefer, drops hosts with no usable
+      // version, ranks by load). It only returns undefined — and we fall back
+      // to local — when no fleet device is genuinely eligible. Also warm the
+      // cache so the NEXT auto launch is instant.
       refreshLaunchHealthCacheInBackground(context);
+      host = await resolveBalancedHost(undefined, agentKey);
     }
   }
 


### PR DESCRIPTION
**fix — Factory launch logic.** `New X (Auto)` (e.g. New Claude (Auto)) now offloads to the fleet on a cold health cache instead of silently running on the local Mac.

## The gap

`New X (Auto)` = `launchAgent({ agentKey, autoHost: true })`. Host resolution was **cache-only**:

1. `extension.ts` — for `autoHost`, host comes only from `resolveCachedAutoHost` → `pickCachedLaunchHost` (a read of the persisted VS Code globalState health snapshot).
2. `launchHistory.ts:92` — that returns `null` when the snapshot is missing or `> 5min` stale.
3. `extension.ts` — the live `resolveBalancedHost` fallback the default New-agent path uses is guarded by `!opts.autoHost`, so the Auto command could not reach it.
4. `openSingleAgent` then passed `local: true`, and `buildAgentLaunchCommand` (`core/agents.ts:198`) therefore also suppressed the CLI `--device auto` path.

Net: whenever the cache was cold — first launch after activation, ~5min idle, or the background fleet SSH sweep hadn't landed on a loaded box (zion was at 468% load when this was reported) — the launch ran on this Mac, and the enable/prefer ranking never even ran. The favorites logic itself is correct; it was short-circuited before it could rank anything.

## The fix

On a null cache pick, fall through to the same live, favorites-aware `resolveBalancedHost(undefined, agentKey)` sweep the default New-agent path already uses (honors enable/prefer, drops hosts with no usable version, ranks by load). It yields local only when no fleet device is genuinely eligible — so a cold cache no longer pins the launch to this Mac. The cache is also warmed in the background so the next Auto launch stays instant.

Not chained to `--device auto`: if the favorites sweep finds no host with a usable Claude, `--device auto` would route to a box behind a login wall — local is the correct last resort there.

Also corrects the launch-contract table in `apps/factory/AGENTS.md` (it claimed `--device auto`, which was never emitted) and documents the real resolution order.

## Verification

Launch-logic change with no browser-renderable surface — the user-visible outcome is a terminal that offloads to a fleet box, which requires an installed `.vsix` on a fleet host to demo. Verified via typecheck + unit tests:

```
$ npx tsc --noEmit -p tsconfig.json   # rc=0, 0 errors
$ bun test src/core/launchHistory.test.ts src/core/launchHost.test.ts \
           src/core/agents.test.ts src/core/deviceAutoLaunch.test.ts
 110 pass  0 fail  (+ new regression: "a cold-cache null does not mean
 local when a fleet host is eligible")
```

The new regression test pins the contract at the two pure seams the fix composes: cold cache → `pickCachedLaunchHost` returns null, and the live `pickBestHost(resolveBalancePool(...))` still selects the eligible fleet host (`yosemite-s0`), not `zion`. `launchAgent`'s terminal-spawn tail is in-file with no mock seam, so a direct orchestration test would require refactoring it out — out of scope for this fix.
