### PR TITLE
docs: complete AGENTS.md coverage across the monorepo + refresh sessions notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,17 @@ from one place.
 
 > Phoenix Labs OSS · Apache-2.0.
 
-**This file is the repo map + repo-wide policy.** Each component has its own
-`AGENTS.md` (agent map) and/or `README.md` (usage). Start there for anything
-component-specific — this file deliberately stays shallow.
+**Two main projects live here:** (a) the **agents CLI** — [`apps/cli`](apps/cli),
+the published `@phnx-labs/agents-cli` — and (b) the **CLI's VS Code extension,
+Factory** — [`apps/factory`](apps/factory). Everything else (`apps/ios`,
+`native/computer-*`, `packages/*`) is a **helper app / library for one feature**,
+not a main project.
+
+**This file is the repo map + repo-wide policy — it deliberately stays shallow.**
+**Read the nearest component `AGENTS.md` (recursively) before working in it** — for
+Claude that's `CLAUDE.md`, a symlink to the same file — and keep going down: the
+component file, not this one, is where component-specific detail lives. Every
+component with a real `AGENTS.md` carries `CLAUDE.md`/`GEMINI.md` symlinks to it.
 
 ## Repo map
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -337,7 +337,7 @@ Gotcha: the preview pane has **no guaranteed height** — `availablePreviewRows 
 terminalRows() - fixedRows` (`picker.ts`), and `limitPreviewHeight` returns `''` when
 that collapses, so the preview can silently vanish on a full/short terminal (the
 RUSH-2198 bug). See the [§Contracts §Sessions spec](docs/specifications.md#sessions)
-for the non-empty-preview invariant (SES-1, SES-3).
+for the non-empty-preview invariant (SES-8).
 
 ## Bundled native helpers (where the tarball's `.app`s come from)
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -317,6 +317,28 @@ Note: `src/lib/session/` here is the transcript **reader**. The live-session
 **writer** is a separate package, [`packages/session-tracker`](../../packages/session-tracker)
 — different data, different consumer; see its AGENTS.md.
 
+### `agents sessions` preview architecture (map before you touch it)
+
+The interactive UI is three picker variants in `src/lib/picker.ts`: `itemPicker`
+(single-select, `space` toggles preview), `dynamicPicker` (async data source, used
+by the session browser, `tab` toggles preview), and a multi-select variant. All
+render a right/bottom **preview pane** built by `buildPreview(session)` in
+`src/commands/sessions-picker.ts` — a header (agent/model/cwd/tokens/ticket/PR) plus
+`formatCompactPreview` (prompt, files/changes, hooks, errors, tests, last response).
+
+Routing lives in `src/commands/sessions.ts`: `isBareBrowserListing`
+(+`hasNoBrowserDisqualifyingFlags`) gates the bare fleet-wide listing to the rich
+`runSessionBrowser` ([`src/commands/sessions-browser.ts`](src/commands/sessions-browser.ts));
+a query/filter falls through to `pickSessionInteractive` → `sessionPicker`.
+`--flat`/`--tree`/`--json`/`--no-interactive` print non-interactive views with no
+preview. `PICKER_RECENT_COUNT = 15` caps the picker's list rows.
+
+Gotcha: the preview pane has **no guaranteed height** — `availablePreviewRows =
+terminalRows() - fixedRows` (`picker.ts`), and `limitPreviewHeight` returns `''` when
+that collapses, so the preview can silently vanish on a full/short terminal (the
+RUSH-2198 bug). See the [§Contracts §Sessions spec](docs/specifications.md#sessions)
+for the non-empty-preview invariant (SES-1, SES-3).
+
 ## Bundled native helpers (where the tarball's `.app`s come from)
 
 Two native helpers plus the standalone signed CLI binary ship **inside** this

--- a/apps/cli/CLAUDE.md
+++ b/apps/cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/cli/GEMINI.md
+++ b/apps/cli/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/ios/CLAUDE.md
+++ b/apps/ios/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/ios/GEMINI.md
+++ b/apps/ios/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/native/computer-mac/CLAUDE.md
+++ b/native/computer-mac/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/native/computer-mac/GEMINI.md
+++ b/native/computer-mac/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/native/computer-win/CLAUDE.md
+++ b/native/computer-win/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/native/computer-win/GEMINI.md
+++ b/native/computer-win/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/agi-cli/AGENTS.md
+++ b/packages/agi-cli/AGENTS.md
@@ -1,0 +1,11 @@
+# @phnx-labs/agi-cli (deprecated alias)
+
+**Deprecated front-brand alias of the canonical `@phnx-labs/agents-cli`.** It ships
+no independent code — it re-exports the same tool under three interchangeable
+commands (`agents`, `ag`, `agi`) so existing `@phnx-labs/agi-cli` installs keep
+working. It lags the canonical package and receives no development.
+
+New work goes to **[`apps/cli`](../../apps/cli)** — the canonical
+`@phnx-labs/agents-cli`. Don't add features here.
+
+See [README.md](README.md) for the migration steps.

--- a/packages/agi-cli/CLAUDE.md
+++ b/packages/agi-cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/agi-cli/GEMINI.md
+++ b/packages/agi-cli/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/session-tracker/CLAUDE.md
+++ b/packages/session-tracker/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/session-tracker/GEMINI.md
+++ b/packages/session-tracker/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/swarmify-mirror/AGENTS.md
+++ b/packages/swarmify-mirror/AGENTS.md
@@ -1,0 +1,10 @@
+# @companion/agents-cli (deprecated redirect)
+
+**Legacy npm-redirect stub.** It only depends on the canonical
+`@phnx-labs/agents-cli` and re-exports its `agents` / `ag` commands, kept published
+so old `@companion/agents-cli` installs keep resolving. No independent development.
+
+New work goes to **[`apps/cli`](../../apps/cli)** — the canonical
+`@phnx-labs/agents-cli`. Don't add features here.
+
+See [README.md](README.md) for the migration steps.

--- a/packages/swarmify-mirror/CLAUDE.md
+++ b/packages/swarmify-mirror/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/swarmify-mirror/GEMINI.md
+++ b/packages/swarmify-mirror/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
**docs-only** — no code, no behavior change. No run/screenshot required.

Completes `AGENTS.md` coverage across the monorepo so an agent working inside any
component (notably `apps/cli`, previously bare) gets its auto-loaded memory, and
frames the root file so agents navigate down into components. `AGENTS.md` is
canonical; only `AGENTS.md` files were edited — `CLAUDE.md`/`GEMINI.md` are symlinks.

## What changed

| Change | Where |
|---|---|
| Add `CLAUDE.md`/`GEMINI.md` → `AGENTS.md` relative symlinks (mode 120000) | `apps/cli`, `apps/ios`, `native/computer-mac`, `native/computer-win`, `packages/session-tracker` |
| New stub `AGENTS.md` (+ symlinks) — what it is, deprecated, pointer to `@phnx-labs/agents-cli` | `packages/agi-cli`, `packages/swarmify-mirror` |
| Root `AGENTS.md`: name the two main projects (`apps/cli`, `apps/factory`), label the rest as feature helpers, add explicit "read the nearest component `AGENTS.md` recursively" directive; kept shallow | `AGENTS.md` |
| Refresh sessions-subsystem notes: tight preview-architecture map (3 picker variants, `buildPreview`, routing in `sessions.ts`, `PICKER_RECENT_COUNT`, the no-guaranteed-height RUSH-2198 gotcha) | `apps/cli/AGENTS.md` |

## Verification

- `git ls-files -s` shows every new `CLAUDE.md`/`GEMINI.md` as mode `120000` (symlink), target the relative `AGENTS.md` — no accidental copies.
- Every component dir with a real `AGENTS.md` now carries all three files.
- `apps/factory/src/core/testdata/agentlinks/*` (test fixtures) left untouched.
- Symbols cited in the sessions notes (`itemPicker`, `dynamicPicker`, `buildPreview`, `formatCompactPreview`, `isBareBrowserListing`, `runSessionBrowser`, `availablePreviewRows`, `limitPreviewHeight`, `PICKER_RECENT_COUNT = 15`) verified present in the source.

Closes RUSH-2201.
