### PR TITLE
fix(sessions): guarantee the picker detail preview a minimum height (RUSH-2198)

### DIFF
--- a/apps/cli/.changelog/next/rush-2198-picker-preview.md
+++ b/apps/cli/.changelog/next/rush-2198-picker-preview.md
@@ -1,0 +1,14 @@
+- **The interactive session picker's detailed preview no longer collapses to empty.**
+  `agents sessions`, `agents sessions <query>`, and `agents sessions --active` open the
+  picker with the rich preview pane (prompt, files, hooks, errors, tests, last response)
+  on by default, but the preview had no guaranteed height: a 15-row list
+  (`PICKER_RECENT_COUNT`) on a short terminal consumed the whole viewport, the computed
+  `availablePreviewRows` went to zero, and the pane silently vanished — worse when
+  fleet-unreachable warnings and the hidden-session footer had scrolled lines above the
+  prompt. The picker now caps the visible list page so the preview keeps a floor of
+  `PREVIEW_MIN_ROWS` (6) rows, and accounts for the lines printed above the prompt so
+  those notices and the preview stay on screen together. Applied consistently across
+  `itemPicker`, `dynamicPicker`, and `multiItemPicker`, so the bare browser, the query
+  picker, and the `--active` browser all behave the same; the space/tab preview toggle
+  is unchanged. Source: `apps/cli/src/lib/picker.ts`,
+  `apps/cli/src/commands/sessions-picker.ts`, `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- **The interactive session picker's detailed preview no longer collapses to empty.**
+  `agents sessions`, `agents sessions <query>`, and `agents sessions --active` open
+  the picker with the rich preview pane (prompt, files, hooks, errors, tests, last
+  response) on by default, but the preview had no guaranteed height: a 15-row list
+  (`PICKER_RECENT_COUNT`) on a short terminal consumed the whole viewport, the
+  computed `availablePreviewRows` went to zero, and the pane silently vanished —
+  worse when fleet-unreachable warnings and the hidden-session footer had scrolled
+  lines above the prompt. The picker now caps the visible list page so the preview
+  keeps a floor of `PREVIEW_MIN_ROWS` (6) rows, and accounts for the lines printed
+  above the prompt so those notices and the preview stay on screen together. Applied
+  consistently across `itemPicker`, `dynamicPicker`, and `multiItemPicker`, so the
+  bare browser, the query picker, and the `--active` browser all behave the same; the
+  space/tab preview toggle is unchanged. Source: `apps/cli/src/lib/picker.ts`,
+  `apps/cli/src/commands/sessions-picker.ts`, `apps/cli/src/commands/sessions.ts`.
+
 ## 1.22.20
 
 - **Claude sessions are attributed to the account that produced them.** The session

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,22 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **The interactive session picker's detailed preview no longer collapses to empty.**
-  `agents sessions`, `agents sessions <query>`, and `agents sessions --active` open
-  the picker with the rich preview pane (prompt, files, hooks, errors, tests, last
-  response) on by default, but the preview had no guaranteed height: a 15-row list
-  (`PICKER_RECENT_COUNT`) on a short terminal consumed the whole viewport, the
-  computed `availablePreviewRows` went to zero, and the pane silently vanished —
-  worse when fleet-unreachable warnings and the hidden-session footer had scrolled
-  lines above the prompt. The picker now caps the visible list page so the preview
-  keeps a floor of `PREVIEW_MIN_ROWS` (6) rows, and accounts for the lines printed
-  above the prompt so those notices and the preview stay on screen together. Applied
-  consistently across `itemPicker`, `dynamicPicker`, and `multiItemPicker`, so the
-  bare browser, the query picker, and the `--active` browser all behave the same; the
-  space/tab preview toggle is unchanged. Source: `apps/cli/src/lib/picker.ts`,
-  `apps/cli/src/commands/sessions-picker.ts`, `apps/cli/src/commands/sessions.ts`.
-
 ## 1.22.20
 
 - **Claude sessions are attributed to the account that produced them.** The session

--- a/apps/cli/src/commands/sessions-picker.test.ts
+++ b/apps/cli/src/commands/sessions-picker.test.ts
@@ -13,6 +13,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { stripVTControlCharacters } from 'node:util';
 import { buildPreview, extractTiming, formatTodoCompact, githubRepoUrlFromCwd, relativizeDir } from './sessions-picker.js';
+import { limitPreviewHeight, pickerPageSize, PREVIEW_MIN_ROWS } from '../lib/picker.js';
 import { _resetLinearWorkspaceCache } from '../lib/session/linear.js';
 import type { SessionEvent, SessionMeta, TodoProgress } from '../lib/session/types.js';
 
@@ -477,5 +478,42 @@ describe('buildPreview — timing for a session with no local transcript', () =>
     expect(preview).toContain('created 3d ago');
     expect(preview).toContain('last active 2h ago');
     expect(preview).toContain('lasted 2d 22h');
+  });
+});
+
+/**
+ * RUSH-2198: the detailed preview collapsed to empty in the picker. This ties the
+ * real buildPreview output (parsed from a transcript on disk) to the picker's row
+ * budget at the default 24-row height with PICKER_RECENT_COUNT (15) list rows —
+ * the exact shape that used to leave the preview slot empty. No mocking: a real
+ * jsonl is written and parsed.
+ */
+describe('buildPreview fits the picker preview slot at default height (RUSH-2198)', () => {
+  it('is non-empty in the picker slot with a 15-row list on a 24-row terminal', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-preview-budget-'));
+    try {
+      const filePath = path.join(dir, 'session.jsonl');
+      fs.writeFileSync(filePath, [
+        JSON.stringify({ type: 'user', timestamp: '2026-08-01T14:00:00.000Z', cwd: dir, sessionId: 'budget-session', version: '2.1.112', message: { role: 'user', content: 'Fix the picker preview pane so it renders' } }),
+        JSON.stringify({ type: 'assistant', timestamp: '2026-08-01T14:00:10.000Z', message: { role: 'assistant', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 1, output_tokens: 1 }, content: [{ type: 'tool_use', id: 'e1', name: 'Edit', input: { file_path: path.join(dir, 'picker.ts') } }] } }),
+      ].join('\n') + '\n');
+
+      const preview = buildPreview(mk({ id: 'budget-session', shortId: 'budget01', filePath, cwd: dir }));
+      // The transcript really parsed into a preview with the user's prompt.
+      expect(stripVTControlCharacters(preview)).toContain('Fix the picker preview pane');
+
+      // The picker caps the list so the preview keeps its floor; feed that budget
+      // through limitPreviewHeight exactly as itemPicker does.
+      const width = 80;
+      const page = pickerPageSize({ requestedPageSize: 15, terminalRows: 24, chromeRows: 3, previewOpen: true });
+      const availablePreviewRows = 24 - (1 /*header*/ + 1 /*subtitle*/ + page + 1 /*separator*/ + 1 /*help*/);
+      expect(availablePreviewRows).toBeGreaterThanOrEqual(PREVIEW_MIN_ROWS);
+
+      const slot = limitPreviewHeight(preview, availablePreviewRows, width);
+      expect(slot).not.toBe('');
+      expect(stripVTControlCharacters(slot)).toContain('Fix the picker preview pane');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/commands/sessions-picker.ts
+++ b/apps/cli/src/commands/sessions-picker.ts
@@ -114,6 +114,8 @@ export interface SessionPickerConfig {
   initialSearch?: string;
   /** Verb shown on the Enter key in the footer (default 'resume'). */
   enterHint?: string;
+  /** Lines the caller printed above the prompt (hidden-session footer). */
+  linesAbovePrompt?: number;
 }
 
 const previewCache = new Map<string, string>();
@@ -847,6 +849,7 @@ export async function sessionPicker(config: SessionPickerConfig): Promise<Picked
     initialSearch: config.initialSearch,
     emptyMessage: 'No sessions match.',
     enterHint: config.enterHint ?? 'resume',
+    linesAbovePrompt: config.linesAbovePrompt,
   });
   if (!picked) return null;
   return { session: picked.item, action: 'resume' };

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -3096,8 +3096,13 @@ export async function pickSessionInteractive(
   hiddenCount = 0,
   enterHint?: string,
 ): Promise<PickedSession | null> {
+  // The hidden-session footer is console.log'd above the Inquirer prompt, so it
+  // scrolls the viewport the picker can't measure; tell the picker to reserve for
+  // it (see pickerPageSize) so the preview and the footer stay on screen together.
+  let linesAbovePrompt = 0;
   if (hiddenCount > 0) {
     console.log(chalk.gray(formatTeamHiddenFooter(hiddenCount)));
+    linesAbovePrompt += 1;
   }
   const cols = pickerColumnsFor(sessions);
   try {
@@ -3115,6 +3120,7 @@ export async function pickSessionInteractive(
       pageSize: PICKER_RECENT_COUNT,
       initialSearch,
       enterHint,
+      linesAbovePrompt,
     });
   } catch (err) {
     if (isPromptCancelled(err)) return null;

--- a/apps/cli/src/lib/picker.test.ts
+++ b/apps/cli/src/lib/picker.test.ts
@@ -115,7 +115,7 @@ describe('pickerPageSize', () => {
 });
 
 describe('itemPicker preview at default height (RUSH-2198 regression)', () => {
-  it('renders the detailed preview with a full 15-row list on a default-height terminal', async () => {
+  it('renders the detailed preview for a 15-row list request on a default-height terminal', async () => {
     const pickerUrl = pathToFileURL(path.resolve('src/lib/picker.ts')).href;
     // 20 rows, pageSize 15 (PICKER_RECENT_COUNT), preview open by default, plus
     // lines printed above the prompt — the exact shape that used to collapse.

--- a/apps/cli/src/lib/picker.test.ts
+++ b/apps/cli/src/lib/picker.test.ts
@@ -3,7 +3,13 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { spawn } from '@homebridge/node-pty-prebuilt-multiarch';
 import { describe, expect, it } from 'vitest';
-import { hotkeyToken, limitPreviewHeight } from './picker.js';
+import {
+  hotkeyToken,
+  limitPreviewHeight,
+  pickerPageSize,
+  PREVIEW_MIN_ROWS,
+  PICKER_MIN_LIST_ROWS,
+} from './picker.js';
 
 function renderedRows(text: string, width: number): number {
   return text.split('\n').reduce((rows, line) => {
@@ -34,6 +40,126 @@ describe('limitPreviewHeight', () => {
 
     expect(renderedRows(clipped, 20)).toBeLessThanOrEqual(3);
     expect(stripVTControlCharacters(clipped)).toContain('truncated');
+  });
+});
+
+/**
+ * The row-budget math behind RUSH-2198: PICKER_RECENT_COUNT = 15 list rows on a
+ * default 24-row terminal left `availablePreviewRows <= 0`, so `limitPreviewHeight`
+ * returned '' and the preview collapsed to nothing. pickerPageSize caps the list so
+ * the preview always keeps its PREVIEW_MIN_ROWS floor.
+ */
+describe('pickerPageSize', () => {
+  // Mirror of the itemPicker fixedRows math: header + subtitle + page + separator + help.
+  const availablePreview = (page: number, termRows: number, linesAbove = 0): number =>
+    termRows - linesAbove - (1 /*header*/ + 1 /*subtitle*/ + page + 1 /*separator*/ + 1 /*help*/);
+
+  it('caps a 15-row list so the preview keeps its floor at the default 24-row height', () => {
+    const page = pickerPageSize({
+      requestedPageSize: 15,
+      terminalRows: 24,
+      chromeRows: 3, // header + subtitle + help
+      previewOpen: true,
+    });
+    expect(page).toBeLessThan(15);
+    expect(page).toBeGreaterThanOrEqual(PICKER_MIN_LIST_ROWS);
+    // The whole point: with the capped page, the preview slot is >= its floor.
+    expect(availablePreview(page, 24)).toBeGreaterThanOrEqual(PREVIEW_MIN_ROWS);
+  });
+
+  it('reproduces the collapse without the cap and fixes it with it', () => {
+    // Uncapped on a common 20-row pane, the raw 15-row page leaves the preview a
+    // 1-row budget — limitPreviewHeight then returns only the truncation marker (or
+    // '' outright at <= 0), which is the empty pane users reported.
+    expect(availablePreview(15, 20)).toBeLessThanOrEqual(1);
+    // And it goes fully non-positive (preview === '') once the terminal is a hair shorter.
+    expect(availablePreview(15, 19)).toBeLessThanOrEqual(0);
+    // Capped: positive, at least the floor, at the same 20-row height.
+    const page = pickerPageSize({ requestedPageSize: 15, terminalRows: 20, chromeRows: 3, previewOpen: true });
+    expect(availablePreview(page, 20)).toBeGreaterThanOrEqual(PREVIEW_MIN_ROWS);
+  });
+
+  it('subtracts lines already printed above the prompt from the budget', () => {
+    const withFooter = pickerPageSize({
+      requestedPageSize: 15,
+      terminalRows: 24,
+      chromeRows: 3,
+      previewOpen: true,
+      linesAbovePrompt: 3,
+    });
+    const withoutFooter = pickerPageSize({
+      requestedPageSize: 15,
+      terminalRows: 24,
+      chromeRows: 3,
+      previewOpen: true,
+    });
+    expect(withFooter).toBeLessThan(withoutFooter);
+    // Even with the footer eating rows, the preview keeps its floor.
+    expect(availablePreview(withFooter, 24, 3)).toBeGreaterThanOrEqual(PREVIEW_MIN_ROWS);
+  });
+
+  it('never shrinks the list below its floor on a tiny terminal', () => {
+    const page = pickerPageSize({ requestedPageSize: 15, terminalRows: 10, chromeRows: 3, previewOpen: true });
+    expect(page).toBe(PICKER_MIN_LIST_ROWS);
+  });
+
+  it('honours the full requested page when the preview is closed and there is room', () => {
+    const page = pickerPageSize({ requestedPageSize: 15, terminalRows: 50, chromeRows: 3, previewOpen: false });
+    expect(page).toBe(15);
+  });
+
+  it('grows the list back to the request once the terminal is tall enough', () => {
+    const page = pickerPageSize({ requestedPageSize: 15, terminalRows: 60, chromeRows: 3, previewOpen: true });
+    expect(page).toBe(15);
+  });
+});
+
+describe('itemPicker preview at default height (RUSH-2198 regression)', () => {
+  it('renders the detailed preview with a full 15-row list on a default-height terminal', async () => {
+    const pickerUrl = pathToFileURL(path.resolve('src/lib/picker.ts')).href;
+    // 20 rows, pageSize 15 (PICKER_RECENT_COUNT), preview open by default, plus
+    // lines printed above the prompt — the exact shape that used to collapse.
+    const program = `
+      import { itemPicker } from ${JSON.stringify(pickerUrl)};
+      const items = Array.from({ length: 20 }, (_, i) => ({ id: 's' + i }));
+      await itemPicker({
+        message: 'Search sessions:',
+        subtitle: 'Tip: type to filter',
+        items,
+        filter: () => items,
+        labelFor: (it) => 'session row ' + it.id,
+        buildPreview: () => 'PREVIEW_VISIBLE\\nprompt: do the thing\\nfiles: a.ts\\nlast: done',
+        pageSize: 15,
+        linesAbovePrompt: 3,
+      });
+    `;
+    const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', program], {
+      cols: 120,
+      rows: 24,
+      cwd: process.cwd(),
+      env: { ...process.env, TERM: 'xterm-256color' },
+    });
+
+    const output = await new Promise<string>((resolve, reject) => {
+      let captured = '';
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error(`picker preview did not render:\n${stripVTControlCharacters(captured)}`));
+      }, 10_000);
+      child.onData((data) => {
+        captured += data;
+        if (!captured.includes('PREVIEW_VISIBLE')) return;
+        clearTimeout(timeout);
+        child.kill();
+        resolve(captured);
+      });
+    });
+
+    const clean = stripVTControlCharacters(output);
+    expect(clean).toContain('PREVIEW_VISIBLE');
+    // The list still shows and the separator still divides it from the preview.
+    expect(clean).toContain('session row s0');
+    expect(clean).toContain('─');
   });
 });
 

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -49,9 +49,9 @@ export interface PickerConfig<T> {
   emptyMessage?: string;
   enterHint?: string;
   /**
-   * Lines the caller already printed above the Inquirer prompt (fleet-unreachable
-   * warnings, hidden-session footers). Subtracted from the row budget so the list
-   * page is capped to keep the preview — and those notices — on screen together.
+   * Lines the caller already printed above the Inquirer prompt (e.g. the
+   * hidden-session footer). Subtracted from the row budget so the list page is
+   * capped to keep the preview — and those notices — on screen together.
    */
   linesAbovePrompt?: number;
 }
@@ -116,10 +116,11 @@ function terminalRows(): number {
  * list whatever remains, never below {@link PICKER_MIN_LIST_ROWS}.
  *
  * `chromeRows` counts the fixed non-list, non-preview lines (header, subtitle,
- * help, any flash). `linesAbovePrompt` counts lines already printed above the
- * Inquirer prompt (fleet-unreachable warnings, hidden-session footers) that have
- * scrolled the viewport but the picker cannot measure — subtracting them keeps
- * those notices on screen alongside the preview.
+ * help, any flash). `linesAbovePrompt` counts lines the caller printed above the
+ * Inquirer prompt that have scrolled the viewport but the picker cannot measure —
+ * today the session picker passes the hidden-session footer; subtracting it keeps
+ * that notice on screen alongside the preview. (The fleet browser folds its
+ * unreachable-peer warning into the header instead, so it needs no reserve here.)
  */
 export function pickerPageSize(opts: {
   requestedPageSize: number;

--- a/apps/cli/src/lib/picker.ts
+++ b/apps/cli/src/lib/picker.ts
@@ -48,6 +48,12 @@ export interface PickerConfig<T> {
   initialSearch?: string;
   emptyMessage?: string;
   enterHint?: string;
+  /**
+   * Lines the caller already printed above the Inquirer prompt (fleet-unreachable
+   * warnings, hidden-session footers). Subtracted from the row budget so the list
+   * page is capped to keep the preview — and those notices — on screen together.
+   */
+  linesAbovePrompt?: number;
 }
 
 /** The result returned when the user selects an item. */
@@ -68,6 +74,8 @@ export interface MultiPickerConfig<T> {
   initialSearch?: string;
   emptyMessage?: string;
   enterHint?: string;
+  /** See {@link PickerConfig.linesAbovePrompt}. */
+  linesAbovePrompt?: number;
 }
 
 interface Choice<T> {
@@ -78,12 +86,57 @@ interface Choice<T> {
 const DEFAULT_TERMINAL_ROWS = 24;
 const DEFAULT_TERMINAL_WIDTH = 80;
 
+/**
+ * Rows the detail preview is guaranteed when it is open and a row is selected.
+ * The list page is capped so this floor always fits the viewport — without it a
+ * long list (PICKER_RECENT_COUNT = 15) consumes the whole default 24-row
+ * terminal, `availablePreviewRows` goes <= 0, and the preview silently collapses
+ * to empty (RUSH-2198).
+ */
+export const PREVIEW_MIN_ROWS = 6;
+
+/** Floor for the visible list page, so a short terminal still shows a few rows. */
+export const PICKER_MIN_LIST_ROWS = 3;
+
 function terminalWidth(): number {
   return Math.max(1, process.stdout.columns || DEFAULT_TERMINAL_WIDTH);
 }
 
 function terminalRows(): number {
   return Math.max(1, process.stdout.rows || DEFAULT_TERMINAL_ROWS);
+}
+
+/**
+ * Cap the visible list page so an open preview keeps a guaranteed floor of rows.
+ *
+ * The picker renders header + list page + separator + preview + help. When the
+ * requested page size (e.g. 15) is large enough to fill the terminal on its own,
+ * the preview has no room left and collapses. This reserves
+ * {@link PREVIEW_MIN_ROWS} (plus its separator) for the preview and hands the
+ * list whatever remains, never below {@link PICKER_MIN_LIST_ROWS}.
+ *
+ * `chromeRows` counts the fixed non-list, non-preview lines (header, subtitle,
+ * help, any flash). `linesAbovePrompt` counts lines already printed above the
+ * Inquirer prompt (fleet-unreachable warnings, hidden-session footers) that have
+ * scrolled the viewport but the picker cannot measure — subtracting them keeps
+ * those notices on screen alongside the preview.
+ */
+export function pickerPageSize(opts: {
+  requestedPageSize: number;
+  terminalRows: number;
+  chromeRows: number;
+  previewOpen: boolean;
+  linesAbovePrompt?: number;
+  previewMinRows?: number;
+  minListRows?: number;
+}): number {
+  const previewMinRows = opts.previewMinRows ?? PREVIEW_MIN_ROWS;
+  const minListRows = opts.minListRows ?? PICKER_MIN_LIST_ROWS;
+  const linesAbove = Math.max(0, opts.linesAbovePrompt ?? 0);
+  // The separator line rides with the preview only when it is open.
+  const previewReserve = opts.previewOpen ? previewMinRows + 1 : 0;
+  const budget = opts.terminalRows - linesAbove - opts.chromeRows - previewReserve;
+  return Math.max(minListRows, Math.min(opts.requestedPageSize, budget));
 }
 
 function renderedRows(text: string, width: number): number {
@@ -238,6 +291,18 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
     const searchStr = searchTerm ? chalk.cyan(searchTerm) : chalk.gray(placeholder);
     const header = [prefix, message, searchStr].filter(Boolean).join(' ');
 
+    // Cap the list page so an open preview keeps a guaranteed floor of rows.
+    // chrome = header + optional subtitle + help; the preview separator is
+    // reserved inside pickerPageSize.
+    const chromeRows = 1 + (cfg.subtitle ? 1 : 0) + 1;
+    const effectivePageSize = pickerPageSize({
+      requestedPageSize: cfg.pageSize ?? 10,
+      terminalRows: terminalRows(),
+      chromeRows,
+      previewOpen: previewOpen && Boolean(cfg.buildPreview),
+      linesAbovePrompt: cfg.linesAbovePrompt,
+    });
+
     const page = usePagination({
       items: results as any,
       active,
@@ -247,7 +312,7 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
         const row = isActive ? chalk.bold(item.label) : item.label;
         return `${cursor} ${row}`;
       },
-      pageSize: cfg.pageSize ?? 10,
+      pageSize: effectivePageSize,
       loop: false,
     });
 
@@ -273,7 +338,7 @@ export function itemPicker<T>(config: PickerConfig<T>): Promise<PickedItem<T> | 
         renderedRows(parts.slice(1).join('\n'), width) +
         renderedRows(separator, width) +
         renderedRows(help, width);
-      const availablePreviewRows = terminalRows() - fixedRows;
+      const availablePreviewRows = terminalRows() - Math.max(0, cfg.linesAbovePrompt ?? 0) - fixedRows;
       const preview = limitPreviewHeight(cfg.buildPreview(selected.value), availablePreviewRows, width);
       if (preview) {
         parts.push(separator);
@@ -379,6 +444,18 @@ export function multiItemPicker<T>(config: MultiPickerConfig<T>): Promise<T[] | 
     const searchStr = searchTerm ? chalk.cyan(searchTerm) : chalk.gray(placeholder);
     const header = [prefix, message, searchStr].filter(Boolean).join(' ');
 
+    // Cap the list page so an open preview keeps a guaranteed floor of rows.
+    // chrome = header + help; the preview separator is reserved inside
+    // pickerPageSize.
+    const chromeRows = 2;
+    const effectivePageSize = pickerPageSize({
+      requestedPageSize: cfg.pageSize ?? 10,
+      terminalRows: terminalRows(),
+      chromeRows,
+      previewOpen: previewOpen && Boolean(cfg.buildPreview),
+      linesAbovePrompt: cfg.linesAbovePrompt,
+    });
+
     const page = usePagination({
       items: results as any,
       active,
@@ -390,7 +467,7 @@ export function multiItemPicker<T>(config: MultiPickerConfig<T>): Promise<T[] | 
         const row = isActive ? chalk.bold(item.label) : item.label;
         return `${cursor} ${box} ${row}`;
       },
-      pageSize: cfg.pageSize ?? 10,
+      pageSize: effectivePageSize,
       loop: false,
     });
 
@@ -415,7 +492,7 @@ export function multiItemPicker<T>(config: MultiPickerConfig<T>): Promise<T[] | 
         renderedRows(parts.slice(1).join('\n'), width) +
         renderedRows(separator, width) +
         renderedRows(help, width);
-      const availablePreviewRows = terminalRows() - fixedRows;
+      const availablePreviewRows = terminalRows() - Math.max(0, cfg.linesAbovePrompt ?? 0) - fixedRows;
       const preview = limitPreviewHeight(cfg.buildPreview(selected.value), availablePreviewRows, width);
       if (preview) {
         parts.push(separator);
@@ -473,6 +550,8 @@ export interface DynamicPickerConfig<T, F> {
   emptyMessage?: string;
   loadingMessage?: string;
   enterHint?: string;
+  /** See {@link PickerConfig.linesAbovePrompt}. */
+  linesAbovePrompt?: number;
 }
 
 /**
@@ -706,6 +785,19 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
     }
     const header = headerBits.filter(Boolean).join(' ');
 
+    // Cap the list page so an open preview keeps a guaranteed floor of rows.
+    // chrome = header + help + optional flash line; the preview separator is
+    // reserved inside pickerPageSize. Only the loaded list steals viewport, so
+    // skip the cap while the loading placeholder is showing.
+    const chromeRows = 2 + (flash ? renderedRows(flash, terminalWidth()) : 0);
+    const effectivePageSize = pickerPageSize({
+      requestedPageSize: cfg.pageSize ?? 12,
+      terminalRows: terminalRows(),
+      chromeRows,
+      previewOpen: previewOpen && Boolean(cfg.buildPreview) && !loading,
+      linesAbovePrompt: cfg.linesAbovePrompt,
+    });
+
     const page = usePagination({
       items: results as any,
       active,
@@ -715,7 +807,7 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
         const row = isActive ? chalk.bold(item.label) : item.label;
         return `${cursor} ${row}`;
       },
-      pageSize: cfg.pageSize ?? 12,
+      pageSize: effectivePageSize,
       loop: false,
     });
 
@@ -747,7 +839,7 @@ export function dynamicPicker<T, F>(config: DynamicPickerConfig<T, F>): Promise<
         renderedRows(separator, width) +
         renderedRows(help, width) +
         flashRows;
-      const availablePreviewRows = terminalRows() - fixedRows;
+      const availablePreviewRows = terminalRows() - Math.max(0, cfg.linesAbovePrompt ?? 0) - fixedRows;
       const preview = limitPreviewHeight(cfg.buildPreview(selected.value), availablePreviewRows, width);
       if (preview) {
         parts.push(separator);


### PR DESCRIPTION
**Bug fix** — the interactive session picker's detailed preview pane collapsed to empty ([RUSH-2198](https://linear.app/getrush/issue/RUSH-2198)).

## What changed

`agents sessions`, `agents sessions <query>`, and `agents sessions --active` open the picker with the rich preview pane on by default, but the preview had **no guaranteed height budget**: a 15-row list (`PICKER_RECENT_COUNT`) on a short terminal filled the viewport, `availablePreviewRows` went to `<= 1`, `limitPreviewHeight` returned `''`, and the pane silently vanished (worse once fleet-unreachable warnings / the hidden-session footer had scrolled lines above the prompt).

- New `pickerPageSize()` helper (`apps/cli/src/lib/picker.ts`) **caps the visible list page** so the preview keeps a floor of `PREVIEW_MIN_ROWS` (6) rows, never letting the list below `PICKER_MIN_LIST_ROWS` (3).
- Subtracts `linesAbovePrompt` (fleet warnings / hidden-session footers printed above the Inquirer prompt) from the budget, so those notices **and** the preview stay on screen together. `pickSessionInteractive` now reports the hidden-footer line count.
- Applied consistently to **`itemPicker`, `dynamicPicker`, and `multiItemPicker`**, so the bare browser, the query picker, and the `--active` browser behave the same. The space/tab preview toggle is unchanged.

## Before / after (real `itemPicker`, origin/main vs this PR, 20-row terminal, 15-row list)

Rendered proof image (on the fleet): `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/rush-2198-picker-preview/.agents/artifacts/2026-08-05/rush-2198-picker-preview.png`

**BEFORE — preview collapses to empty:**
```
> a1b2c3d0   claude   2.1.186   mac-mini   muqsit   session task 0 — work the queue
  ... (15 list rows fill the viewport) ...
  a1b2c3d14  claude   2.1.186   mac-mini   muqsit   session task 14 — work the queue
────────────────────────────────────────────────────────────────────────────────
... preview truncated to fit terminal
↑↓ navigate · space: close preview · ⏎ select · esc: cancel
```

**AFTER — list capped, detailed preview renders:**
```
> a1b2c3d0   claude   2.1.186   mac-mini   muqsit   session task 0 — work the queue
  ... (list capped to 10 rows) ...
  a1b2c3d9   claude   2.1.186   mac-mini   muqsit   session task 9 — work the queue
────────────────────────────────────────────────────────────────────────────────
Claude v2.1.186 · a1b2c3d0 · muqsit@getrush.ai
~/src/github.com/muqsitnawaz/agents-cli · agents-cli · fix/rush-2198 · created 2h ago · lasted 27m
4 msgs · 12.3k tokens
  Prompt: fix the detailed preview pane so it renders reliably
  Files:  picker.ts (+104) sessions.ts (+6) picker.test.ts (+128)
  Hooks:  SessionStart:startup ×4
↑↓ navigate · space: close preview · ⏎ resume · esc: cancel
```

At rows <= 19 the released build renders **no separator and no preview at all**; the real `agents sessions rush --local` run on this box confirmed the empty pane at rows=18 and the full preview after the fix.

## Tests (no mocking — real critical path)

- `src/lib/picker.test.ts` — unit tests for `pickerPageSize` (cap, floor, `linesAbovePrompt`, preview-closed/-open) + a PTY regression that `itemPicker` renders the preview with a 15-row list on a 24-row terminal.
- `src/commands/sessions-picker.test.ts` — writes a real transcript, parses it via `buildPreview`, and asserts the picker preview slot is non-empty at default height with the capped page.
- **56/56 picker + sessions-picker tests pass.**

The full suite has 18 pre-existing failures across 8 env/network-dependent files (`exec`, `models`, `usage`, `feed-broadcast`, `crabbox/cli`, `monitors/dispatch`, `exec-lineage`, `project-key`) — the **same 8 files fail identically on untouched `origin/main`** (telegram send, claude-auth model catalog, crabbox provisioning). This diff touches only picker/sessions files and is disjoint from all of them.

## Out of scope

Adding the preview to the non-interactive `--flat`/`--tree`/`--json`/`--no-interactive` printed paths (tracked separately per the ticket).
