### PR TITLE
docs(secrets): document the per-command Touch-ID contract

### DIFF
--- a/apps/cli/.changelog/next/secrets-touchid-spec-docs.md
+++ b/apps/cli/.changelog/next/secrets-touchid-spec-docs.md
@@ -1,0 +1,12 @@
+- **Docs: the per-command secrets Touch-ID contract is now written down and
+  accurate.** The `view --reveal` (1.22.14) and `exec` (1.22.21) interactive-unlock
+  changes shipped in code + CHANGELOG only; the reference docs still implied every
+  value command behaves the same. `docs/secrets.md` and the `secrets` skill now
+  carry an explicit Touch-ID matrix (deliberate `view --reveal`/`exec` at a real
+  terminal → one sheet on a locked bundle; `get`/`export` automation primitives →
+  never prompt, fail closed to `agents secrets unlock`; anything an agent launches →
+  broker-only), `specifications.md` adds **SEC-13b** + a `Prompts?` column on the
+  materialization table + `GWT-S2b`, and the skill's stale hold-window facts are
+  corrected (7-day default, screen-lock does not drop the hold). Docs-only; no
+  behavior change. Source: `apps/cli/docs/secrets.md`,
+  `apps/cli/docs/specifications.md`, `skills/secrets/SKILL.md`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -13,12 +13,37 @@ routine, a teammate, or the daemon that needs a locked bundle fails fast and nam
 authenticate, and because each keychain read runs in its own helper process the
 biometric assertion never reuses, so one launch used to mean one sheet per bundle.
 
-The sheet is raised only by a deliberate human request: `agents secrets unlock`,
-or an `agents secrets get/export/exec` you run **in a plain shell**. Beneath an
-agent those same commands inherit `AGENTS_RUNTIME` and resolve broker-only — there
-the agent is the caller, not you. It names the requesting
-harness, bundle, reason, and unlock duration. Approved bundles are cached for seven
-days by default.
+The sheet is raised only by a deliberate human request on a **locked** bundle:
+`agents secrets unlock`, or an `agents secrets view --reveal` / `agents secrets
+exec` you run **at a real interactive terminal** (a TTY, outside any agent
+runtime) — one sheet, then the value is revealed / the command runs. `agents
+secrets get` and every `agents secrets export` variant **never raise the sheet at
+all**, in any shell: they are automation primitives (`$(agents secrets get …)`,
+`eval "$(agents secrets export … --plaintext)"`), so a locked bundle fails fast
+toward `agents secrets unlock <bundle>` instead of blocking a pipeline on Keychain
+UI. Beneath an agent (`AGENTS_RUNTIME` set) or with no TTY, **all** of these
+resolve broker-only — there the agent is the caller, not you. See the
+[Touch-ID contract](#touch-id-contract) below for the full per-command matrix. The
+unlock names the requesting harness, bundle, reason, and duration; approved
+bundles are cached for seven days by default.
+
+### Touch-ID contract
+
+Which `agents secrets` commands can raise a biometric sheet, and when:
+
+| Command | On a locked keychain bundle |
+|---|---|
+| `list`, `view` (no `--reveal`) | never prompts — metadata / masked values only |
+| `view --reveal`, `exec` | **at an interactive terminal:** one Touch ID, then reveals / runs. Under an agent (`AGENTS_RUNTIME`) or no TTY: broker-only, fail-closed, no sheet |
+| `get`, `export` (`--plaintext` / `--to-file` / `--host` / `--to-1password`) | **never prompts, in any shell** — automation primitives; fail-closed to `agents secrets unlock` |
+| `unlock` | the one deliberate biometric entry point |
+| any command on an already-unlocked bundle | never prompts — the broker fast-path returns before Keychain is touched |
+
+The rule: a **deliberate human reveal/run** (`view --reveal`, `exec`) at a terminal
+gets one sheet; **automation primitives** (`get`, `export`) never do, because
+prompting would either dump plaintext onto a visible screen (`export`) or block a
+`$(…)` capture mid-pipeline (`get`). Everything an **agent** launches stays
+broker-only.
 
 **The same rule covers raw keychain item reads.** A profile's provider token, the
 Claude OAuth item behind `agents view`, and every other `getKeychainToken` caller

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -946,7 +946,7 @@ access control (that is 1Password/Vault; this tool is device-local first).
 - **SEC-13 (MUST).** A headless/detached (no-TTY or agent-runtime) context on macOS MUST resolve
   broker-only and fail loudly, and MUST NOT pop a Touch ID sheet on the
   interactive user's screen (`isHeadlessSecretsContext`,
-  `lib/secrets/headless.ts:37-66`, re-exported from `lib/secrets/bundles.ts`;
+  `lib/secrets/headless.ts:28-37`, re-exported from `lib/secrets/bundles.ts`;
   `commands/secrets.ts:1172-1175,1925-1929`;
   `mcp.ts:112-114`). This covers raw item reads too, not just bundles:
   `getKeychainToken`/`getKeychainTokens` consult `assertRawKeychainReadAllowed`
@@ -971,6 +971,27 @@ access control (that is 1Password/Vault; this tool is device-local first).
   This does NOT cover the explicit `agents share` / `agents share setup` commands —
   those are user-initiated, not launches, and keep the `isHeadlessSecretsContext()`
   gate (`readWriteTokenFromBundle`, `readCloudflareCreds`).
+- **SEC-13b (MUST).** A **deliberate human reveal/run** at a real interactive
+  terminal on a **locked** keychain bundle MUST resolve with **exactly one** Touch
+  ID sheet, then reveal the value / run the command. This covers exactly two
+  commands: `agents secrets view --reveal` and `agents secrets exec` — both gate
+  `agentOnly` on `isHeadlessSecretsContext() || !isInteractiveTerminal()`
+  (`commands/secrets.ts:1384`, `:1500`, `:2463`). Conversely, the **automation
+  primitives** `agents secrets get` and every `agents secrets export` variant
+  (`--plaintext`, `--to-file`, `--host`, `--to-1password`) MUST stay `agentOnly:
+  true` **unconditionally** and MUST NOT prompt even at an interactive terminal
+  (`commands/secrets.ts:1593`, `:2229`, `:2259`, `:2350`, `:2392`) — prompting there
+  would either dump plaintext onto a visible screen (`export`, which prints) or
+  block a `$(…)` capture mid-pipeline (`get`). Under an agent (`AGENTS_RUNTIME`) or
+  no TTY, **all** of these stay broker-only and fail closed per SEC-13. **Given** a
+  human at a TTY (no `AGENTS_RUNTIME`) runs `agents secrets view --reveal <locked>`
+  or `agents secrets exec <locked> -- <cmd>` **When** the bundle is not
+  broker-held **Then** exactly one Touch ID sheet is raised and the value is
+  revealed / command run; whereas the same `get`/`export` on the same locked bundle
+  fails fast naming `agents secrets unlock <bundle>`, no sheet. This is the
+  reveal-vs-automation split — `view --reveal`/`exec` are the only interactive
+  biometric surfaces besides `unlock` (SEC-13a governs the separate `agents run
+  --secrets` launch-injection path, which is always `agentOnly`).
 - **SEC-14 (MUST).** A broker `get` for a bundle it does not hold MUST return
   `{ ok:true, hit:false }` — never an error, never a prompt, never a human
   escalation — and the caller MUST fall through to the real store
@@ -1143,17 +1164,23 @@ flags and examples; this spec governs the **guarantees** behind them.
 
 #### 4.2 Materialization classification (normative)
 
-| Command | Boundary side | Evidence |
-|---|---|---|
-| `secrets exec <b> -- <cmd>` | **Inject** (child env) | `commands/secrets.ts:2006-2009` |
-| `run --secrets <b>` | **Inject** (run child env) | `commands/exec.ts:2181` |
-| `secrets export --host` (SSH push) | **Inject** (over ssh stdin) | `commands/secrets.ts:1850` |
-| `secrets export --to-1password` / `--to-file` | **Neither** (to `op` argv / AES file) | `commands/secrets.ts:1905,1794` |
-| `secrets mcp` (`get_secret`) | **JIT, per-request** — never `process.env`, names-only in `tools/list` | `lib/secrets/mcp.ts:83-91,173-188` |
-| `secrets export --plaintext` | **Materialize** | `commands/secrets.ts:1946` |
-| `secrets view --reveal` | **Materialize** | `commands/secrets.ts:1117-1126` |
-| `secrets get [b] [KEY]` | **Materialize** (automation primitive, ungated) | `commands/secrets.ts:1156,1181` |
-| `list` / `view` (default) / all CRUD / `unlock` / `lock` / `status` / `push` / `pull` | **Neither** (metadata/status/counts only) | e.g. `commands/secrets.ts:1115,2262` |
+Two orthogonal axes: **Boundary side** (does a plaintext value cross into the
+agent's process / a child / stdout?) and **Prompts (locked)?** (can this raise a
+Touch ID sheet on a *locked* bundle — see SEC-13b). They are independent: `exec`
+injects yet CAN prompt interactively, while `export --plaintext` materializes yet
+NEVER prompts.
+
+| Command | Boundary side | Prompts (locked)? | Evidence |
+|---|---|---|---|
+| `secrets exec <b> -- <cmd>` | **Inject** (child env) | **interactive TTY only** (SEC-13b) | `commands/secrets.ts:2454,2463` |
+| `run --secrets <b>` | **Inject** (run child env) | never (SEC-13a) | `commands/exec.ts` secrets injection |
+| `secrets export --host` (SSH push) | **Inject** (over ssh stdin) | never | `commands/secrets.ts:2259` |
+| `secrets export --to-1password` / `--to-file` | **Neither** (to `op` argv / AES file) | never | `commands/secrets.ts:2350,2229` |
+| `secrets mcp` (`get_secret`) | **JIT, per-request** — never `process.env`, names-only in `tools/list` | never | `lib/secrets/mcp.ts` |
+| `secrets export --plaintext` | **Materialize** | never (automation primitive) | `commands/secrets.ts:2390,2392` |
+| `secrets view --reveal` | **Materialize** | **interactive TTY only** (SEC-13b) | `commands/secrets.ts:1498,1500` |
+| `secrets get [b] [KEY]` | **Materialize** (automation primitive, ungated) | never | `commands/secrets.ts:1593` |
+| `list` / `view` (default) / all CRUD / `unlock` / `lock` / `status` / `push` / `pull` | **Neither** (metadata/status/counts only) | only `unlock` prompts | e.g. `commands/secrets.ts` list/view/unlock |
 
 Rule of thumb (normative): **if `--plaintext`, `--reveal`, or `get` appears in an
 agent's transcript, a key entered the agent's context there.** Injection and MCP
@@ -1294,9 +1321,23 @@ tool-call output or the session `.jsonl`.
 **GWT-S2 — `get` always materializes, by design.**
 Given the same bundle; When an agent runs `agents secrets get prod STRIPE_API_KEY`;
 Then the plaintext is written to stdout with no TTY gate
-(`commands/secrets.ts:1181`) and lands in the agent's context + transcript — this
+(`commands/secrets.ts:1593`) and lands in the agent's context + transcript — this
 is the automation primitive, and its appearance in a transcript is the audit
-signal, not a bug.
+signal, not a bug. It never raises a Touch ID sheet, even run directly at a
+terminal on a locked bundle (`agentOnly: true` unconditionally) — a locked bundle
+fails fast to `agents secrets unlock`.
+
+**GWT-S2b — `view --reveal` / `exec` prompt once, interactively, by design (SEC-13b).**
+Given a locked `hold` bundle `prod` not held by the broker; When a **human** at a
+real terminal (no `AGENTS_RUNTIME`) runs `agents secrets view --reveal prod` or
+`agents secrets exec prod -- ./deploy.sh`; Then exactly **one** Touch ID sheet is
+raised and the value is revealed / the command runs
+(`agentOnly: isHeadlessSecretsContext() || !isInteractiveTerminal()` →
+`false` for a TTY human, `commands/secrets.ts:1500,2463`). Whereas the same command
+under an agent runtime or with no TTY resolves broker-only and fails fast naming
+`agents secrets unlock prod`, no sheet — so release/CI scripts never prompt. This
+is the sole difference between the two deliberate reveal/run commands and the
+`get`/`export` automation primitives (GWT-S2).
 
 **GWT-S3 — `list` is silent and value-free.**
 Given several `hold`/`always` bundles; When the human runs `agents secrets list`;

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -156,13 +156,28 @@ agents secrets add prod LOG_LEVEL --env LOG_LEVEL
 macOS prompts Touch ID **per bundle, per process**, so running several agents at once (`agents teams`, parallel `agents run --secrets`) re-prompts once each. There's no OS setting to quiet it — but the **secrets-agent** does (macOS only):
 
 ```bash
-agents secrets unlock prod        # one Touch ID; held for 24h
+agents secrets unlock prod        # one Touch ID; held ~7 days (default)
 agents teams start my-feature     # every teammate reads prod silently
 agents secrets status             # what's held, and when it locks
 agents secrets lock               # wipe it; next read re-prompts
 ```
 
-`unlock` reads the bundle once and keeps the resolved values in a local broker behind a user-only socket; later runs read from memory with no prompt. The hold ends on its TTL (default 24h, `--ttl 30m`), when you `lock`, or when the screen locks / the machine sleeps. Nothing is written to disk.
+`unlock` reads the bundle once and keeps the resolved values in a local broker behind a user-only socket; later runs read from memory with no prompt. The hold ends on its TTL (**default 7 days**, `--ttl 30m` to shorten), when you `lock`, or when the machine **sleeps / you log out**. A bare **screen-lock does NOT drop the hold** (it's already gated by the login session). Nothing is written to disk.
+
+### When does Touch ID actually appear?
+
+On a **locked** keychain bundle:
+
+| You run | Touch ID? |
+|---|---|
+| `secrets list`, `secrets view` (no `--reveal`) | never — metadata / masked values only |
+| `secrets view --reveal`, `secrets exec` **at your terminal** | one sheet, then reveals / runs (a deliberate human reveal/run) |
+| `secrets get`, `secrets export` (any variant) | **never** — automation primitives for `$(…)` / `eval`; they fail fast to `agents secrets unlock` instead |
+| `secrets unlock` | one sheet — the deliberate unlock |
+| anything an **agent** launches (`AGENTS_RUNTIME`) or any no-TTY context | never — resolves broker-only, fails fast if not held |
+| anything on an **already-unlocked** bundle | never — served from the broker |
+
+So a sheet only ever appears for a deliberate human action (`unlock`, or a `view --reveal` / `exec` you type) on a *locked* bundle. `get`/`export` stay silent so they never block a script mid-pipeline.
 
 For a machine running lots of agents, run `agents secrets start` once — it installs the broker as a persistent background service (launchd) that stays up across the session, so a cold-started broker can't get starved under load. It self-heals onto new code after `npm i -g` upgrades. `agents secrets status` shows whether it's installed.
 


### PR DESCRIPTION
**docs-only** — audience: agents-cli maintainers + users who run `agents secrets`. No behavior change.

## Why
The `view --reveal` (1.22.14, #2025) and `exec` (1.22.21, #2083) interactive-unlock changes shipped in **code + CHANGELOG only** — the reference docs/spec/skill were never updated. Worse, `docs/secrets.md` actively said `get`/`export`/`exec` all raise the sheet "in a plain shell," which directly contradicts the code (`get`/`export` are unconditionally broker-only). This PR makes the docs match the actual per-command Touch-ID contract.

## The contract now documented (verified against code)

| Command | On a **locked** keychain bundle |
|---|---|
| `list`, `view` (no `--reveal`) | never prompts — metadata/masked only |
| `view --reveal`, `exec` | **interactive TTY → one sheet, then reveals/runs**; agent/headless → broker-only, no sheet |
| `get`, `export` (all variants) | **never prompts** — automation primitives; fail-closed to `agents secrets unlock` |
| `unlock` | the one deliberate biometric entry point |
| already-unlocked bundle | never — broker fast-path |

The split: deliberate human reveal/run prompts once; automation primitives never (prompting would dump plaintext to a visible screen for `export`, or block a `$(…)` capture for `get`).

## Changes
- **`docs/secrets.md`** — fix the wrong "plain shell" claim; add a `Touch-ID contract` table.
- **`docs/specifications.md`** — add **SEC-13b** (reveal-vs-automation MUST) + **GWT-S2b** (testable scenario); add a `Prompts?` column to the §4.2 materialization table; fix the stale `headless.ts:37-66`→`:28-37` citation and the `get`/`view --reveal` line refs.
- **`skills/secrets/SKILL.md`** — add the Touch-ID contract; correct the stale hold-window facts (**7-day** default, not 24h; a bare **screen-lock does NOT drop** the hold — wipe is on sleep/logout).

Also synced the corrected skill to the local runtime copy at `~/.agents/.system/skills/secrets/SKILL.md` (that copy predated a full rewrite of the skill).

## Verification
- `get` and `export` audited (parallel sub-agents, file:line evidence) — both **correct as-is**, no code change needed.
- `scripts/verify-docs.sh` passes.
- Confirmed against code: `commands/secrets.ts:1384,1500,2463` (conditional gate) vs `:1593,2229,2259,2350,2392` (unconditional `agentOnly:true`); 7-day hold at `bundles.ts:202,475`; screen-lock non-drop at `agent.ts:20,441`.
