### PR TITLE
fix(sessions): cancellable early-exit fleet resolve for sessions/resume (RUSH-2203)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2203.md
+++ b/apps/cli/.changelog/next/RUSH-2203.md
@@ -1,0 +1,17 @@
+- **`agents sessions <id>` / `agents resume <id>` resolve across the fleet fast, with
+  early-exit and SSH cancellation (RUSH-2203).** The cross-machine resolve fanned out
+  with `await Promise.all` and no cancellation, so one slow or unreachable peer stalled
+  the whole lookup to the 12s per-peer timeout even after a fast peer already returned
+  the exact match — a full-UUID miss on a fleet with an offline box took ~40s. The
+  id/label resolve now opts into a cancellable, early-exit fan-out: the first peer
+  holding a definitive match (a full UUID, or an exact session label) resolves the sweep
+  and SIGTERMs every still-outstanding peer, and a definitive local hit resolves with
+  **zero** SSH. `agents resume <label>` now auto-resumes the one exact-label match
+  instead of dead-ending, and the not-found message reports the actual sweep result
+  (devices searched, which were unreachable) instead of the misleading "search with
+  `--device <host>`" — fleet search is already the default. `--device all` / `--devices`
+  are accepted and mean "the whole fleet". The all-settle default is unchanged for the
+  shared fan-out's other callers (tool-search, program-count) and for ambiguous short-id
+  prefixes, which still wait for every peer to surface a conflict. Source:
+  `apps/cli/src/lib/remote-agents-json.ts`, `apps/cli/src/lib/session/remote-list.ts`,
+  `apps/cli/src/commands/sessions.ts`, `apps/cli/src/commands/resume.ts`.

--- a/apps/cli/.changelog/next/RUSH-2203.md
+++ b/apps/cli/.changelog/next/RUSH-2203.md
@@ -2,16 +2,18 @@
   early-exit and SSH cancellation (RUSH-2203).** The cross-machine resolve fanned out
   with `await Promise.all` and no cancellation, so one slow or unreachable peer stalled
   the whole lookup to the 12s per-peer timeout even after a fast peer already returned
-  the exact match — a full-UUID miss on a fleet with an offline box took ~40s. The
-  id/label resolve now opts into a cancellable, early-exit fan-out: the first peer
-  holding a definitive match (a full UUID, or an exact session label) resolves the sweep
-  and SIGTERMs every still-outstanding peer, and a definitive local hit resolves with
-  **zero** SSH. `agents resume <label>` now auto-resumes the one exact-label match
-  instead of dead-ending, and the not-found message reports the actual sweep result
-  (devices searched, which were unreachable) instead of the misleading "search with
-  `--device <host>`" — fleet search is already the default. `--device all` / `--devices`
-  are accepted and mean "the whole fleet". The all-settle default is unchanged for the
-  shared fan-out's other callers (tool-search, program-count) and for ambiguous short-id
-  prefixes, which still wait for every peer to surface a conflict. Source:
+  the exact match — a full-UUID resolve on a fleet with an offline box took ~16-40s. A
+  **full-UUID** resolve (globally unique) now opts into a cancellable, early-exit
+  fan-out: the first peer holding it resolves the sweep and SIGTERMs every
+  still-outstanding peer, and a local UUID hit resolves with **zero** SSH.
+  `agents resume <label>` auto-resumes the one exact-label match; labels are not globally
+  unique, so they stay all-settle (a same-label session may live on another peer) — a
+  unique label resumes, a cross-machine collision surfaces as an ambiguity. The not-found
+  message reports the actual sweep result (devices searched, which were unreachable)
+  instead of the misleading "search with `--device <host>`" — fleet search is already the
+  default. `--device all` / `--devices` are accepted and mean "the whole fleet". The
+  all-settle default is unchanged for the shared fan-out's other callers (tool-search,
+  program-count) and for labels / ambiguous short-id prefixes, which still wait for every
+  peer. Source:
   `apps/cli/src/lib/remote-agents-json.ts`, `apps/cli/src/lib/session/remote-list.ts`,
   `apps/cli/src/commands/sessions.ts`, `apps/cli/src/commands/resume.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -27,10 +27,15 @@ interchangeable — pick the verb for the intent:
 
 `focus` is the default “take me there” for a live process. `attach` / `detach` are
 the presence pair (foreground ↔ background). `resume` is the multi-open / history
-path. Top-level `agents resume <id>` is the strict single-session shortcut: a full
-ID checks the local SQLite index first, fans out to registered devices only on a
-local miss, routes to the owning device, and invokes the version that created the
-session with its recorded cwd and launch mode. `agents run auto --resume <id>` is
+path. Top-level `agents resume <id-or-label>` is the strict single-session shortcut:
+a full ID (or an exact session **label**) checks the local SQLite index first and
+resolves with **zero** SSH on a local hit; only on a local miss does it fan out to
+registered devices, and there the fan-out is cancellable and early-exits — the first
+peer holding the definitive match resolves the lookup and SIGTERMs the rest, so a fast
+peer's hit is not bounded by the slowest/unreachable peer's timeout. It then routes to
+the owning device and invokes the version that created the session with its recorded
+cwd and launch mode. An exact-label match auto-resumes the one session; an ambiguous
+short-id prefix still surfaces every candidate. `agents run auto --resume <id>` is
 the adaptive form: it prefers native resume when the original harness/version is
 healthy and otherwise lets the normal router select an available harness/account,
 then hands the transcript over through `/continue`. Detail in **Background &

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -28,14 +28,16 @@ interchangeable — pick the verb for the intent:
 `focus` is the default “take me there” for a live process. `attach` / `detach` are
 the presence pair (foreground ↔ background). `resume` is the multi-open / history
 path. Top-level `agents resume <id-or-label>` is the strict single-session shortcut:
-a full ID (or an exact session **label**) checks the local SQLite index first and
-resolves with **zero** SSH on a local hit; only on a local miss does it fan out to
-registered devices, and there the fan-out is cancellable and early-exits — the first
-peer holding the definitive match resolves the lookup and SIGTERMs the rest, so a fast
-peer's hit is not bounded by the slowest/unreachable peer's timeout. It then routes to
-the owning device and invokes the version that created the session with its recorded
-cwd and launch mode. An exact-label match auto-resumes the one session; an ambiguous
-short-id prefix still surfaces every candidate. `agents run auto --resume <id>` is
+a full **UUID** checks the local SQLite index first and resolves with **zero** SSH on
+a local hit; only on a local miss does it fan out to registered devices, and there the
+fan-out is cancellable and early-exits — the first peer holding the UUID resolves the
+lookup and SIGTERMs the rest, so a fast peer's hit is not bounded by the
+slowest/unreachable peer's timeout. It then routes to the owning device and invokes the
+version that created the session with its recorded cwd and launch mode. An exact
+**label** always consults the fleet (labels are not globally unique, so a same-label
+session could live on another peer): a unique match auto-resumes, a cross-machine
+collision surfaces as an ambiguity, and an ambiguous short-id prefix still surfaces
+every candidate. `agents run auto --resume <id>` is
 the adaptive form: it prefers native resume when the original harness/version is
 healthy and otherwise lets the normal router select an available harness/account,
 then hands the transcript over through `/continue`. Detail in **Background &

--- a/apps/cli/src/commands/resume.ts
+++ b/apps/cli/src/commands/resume.ts
@@ -32,8 +32,8 @@ export function buildResumeRunArgs(
 
 export function registerResumeCommand(program: Command): void {
   const cmd = program
-    .command('resume <session-id> [prompt]')
-    .description('Resume a session with its original harness, version, device, account, cwd, and mode')
+    .command('resume <session> [prompt]')
+    .description('Resume a session by full id, unique id prefix, or exact label with its original harness, version, device, account, cwd, and mode. Searches the fleet automatically; a definitive local hit resumes with zero SSH.')
     .option('-m, --mode <mode>', 'Override the recorded launch mode')
     .option('-i, --interactive', 'Resume interactively even when a prompt is provided')
     .option('--headless', 'Resume headlessly (a prompt is required)')
@@ -83,10 +83,13 @@ export function registerResumeCommand(program: Command): void {
       # Resume and continue headlessly
       agents resume 019fd0c8-b3e9-77a2-a1a4-444698c4d897 "finish the tests"
 
+      # Resume by exact label (auto-resumes the one match)
+      agents resume "fix the flaky ssh test"
+
       # Deliberately change permissions
       agents resume 019fd0c8-b3e9-77a2-a1a4-444698c4d897 --mode edit`,
     notes: `
-      Full IDs resolve from the local session database first; an SSH fleet lookup runs only after a local miss.
+      Full IDs and exact labels resolve from the local session database first (zero SSH); the fleet is searched only after a local miss, and the first peer holding the match cancels the rest.
       Use agents run auto --resume <id> when the original account is unavailable and another harness may continue.`,
   });
 }

--- a/apps/cli/src/commands/resume.ts
+++ b/apps/cli/src/commands/resume.ts
@@ -33,7 +33,7 @@ export function buildResumeRunArgs(
 export function registerResumeCommand(program: Command): void {
   const cmd = program
     .command('resume <session> [prompt]')
-    .description('Resume a session by full id, unique id prefix, or exact label with its original harness, version, device, account, cwd, and mode. Searches the fleet automatically; a definitive local hit resumes with zero SSH.')
+    .description('Resume a session by full id, unique id prefix, or exact label with its original harness, version, device, account, cwd, and mode. Searches the fleet automatically; a local full-id hit resumes with zero SSH.')
     .option('-m, --mode <mode>', 'Override the recorded launch mode')
     .option('-i, --interactive', 'Resume interactively even when a prompt is provided')
     .option('--headless', 'Resume headlessly (a prompt is required)')
@@ -89,7 +89,7 @@ export function registerResumeCommand(program: Command): void {
       # Deliberately change permissions
       agents resume 019fd0c8-b3e9-77a2-a1a4-444698c4d897 --mode edit`,
     notes: `
-      Full IDs and exact labels resolve from the local session database first (zero SSH); the fleet is searched only after a local miss, and the first peer holding the match cancels the rest.
+      A full ID resolves from the local session database first (zero SSH) and, on a local miss, fans out with the first peer holding it cancelling the rest. An exact label always consults the fleet (labels are not globally unique) and auto-resumes the one match; a cross-machine label collision surfaces as an ambiguity.
       Use agents run auto --resume <id> when the original account is unavailable and another harness may continue.`,
   });
 }

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -14,6 +14,9 @@ import {
   fleetCandidatesByQuery,
   metadataResolveOutcome,
   metadataResolveForwardedArgs,
+  isDefinitiveMatch,
+  selectorAllowsEarlyExit,
+  fleetNotFoundMessage,
   mergeToolSearchEnvelopes,
   mergeToolProgramCountEnvelopes,
   toolOriginSessions,
@@ -668,6 +671,46 @@ describe('resolveSessionQuery indexed metadata coverage', () => {
         mention: { ids: [], byId: true, completeId: false },
         prefix: { ids: ['cccc3333-1111-2222-3333-444455556666'], byId: true, completeId: false },
         noFallback: { ids: [], byId: true, completeId: false },
+      });
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('RUSH-2203 local definitive hit skips SSH', () => {
+  it('resolves a full id and an exact label from the local DB without dialing any peer', () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-local-hit-'));
+    try {
+      const runner = [
+        "import fs from 'node:fs';",
+        "import path from 'node:path';",
+        "const { upsertSession, closeDB } = await import('./src/lib/session/db.ts');",
+        "const { resolveSessionMetadataValue } = await import('./src/commands/sessions.ts');",
+        "const home = process.env.HOME;",
+        "const id = '019fd0c8-b3e9-77a2-a1a4-444698c4d897';",
+        "const filePath = path.join(home, id + '.jsonl'); fs.writeFileSync(filePath, '');",
+        "upsertSession({ id, shortId: id.slice(0, 8), agent: 'claude', timestamp: new Date().toISOString(), filePath, label: 'ship the resume fix' }, '');",
+        // Any dial throws: a definitive local hit must return before the fan-out.
+        "let dialed = 0;",
+        "const deps = { gatherRemoteList: async () => { dialed++; throw new Error('SSH DIALED'); } };",
+        "const byId = await resolveSessionMetadataValue(id, {}, deps);",
+        "const byLabel = await resolveSessionMetadataValue('ship the resume fix', {}, deps);",
+        "closeDB();",
+        "process.stdout.write(JSON.stringify({ byIdKind: byId.kind, byIdId: byId.session && byId.session.id, byLabelKind: byLabel.kind, byLabelId: byLabel.session && byLabel.session.id, dialed }));",
+      ].join(' ');
+      const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', runner], {
+        cwd: repoRoot,
+        env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+        encoding: 'utf8',
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        byIdKind: 'resolved',
+        byIdId: '019fd0c8-b3e9-77a2-a1a4-444698c4d897',
+        byLabelKind: 'resolved',
+        byLabelId: '019fd0c8-b3e9-77a2-a1a4-444698c4d897',
+        dialed: 0, // zero SSH: the local index answered both lookups
       });
     } finally {
       fs.rmSync(tempHome, { recursive: true, force: true });
@@ -1857,5 +1900,79 @@ describe('buildSessionDescription — team target + teammate', () => {
       teamName: 't', assignedTask: 'wire up the auth flow',
     } as any);
     expect(desc).toContain('wire up the auth flow');
+  });
+});
+
+describe('RUSH-2203 definitive-match fleet resolve', () => {
+  const FULL = '019fd0c8-b3e9-77a2-a1a4-444698c4d897';
+  const base: SessionMeta = {
+    id: FULL,
+    shortId: '019fd0c8',
+    agent: 'claude',
+    version: '2.1.0',
+    mode: 'edit',
+    machine: 'yosemite-m0',
+    timestamp: '2026-08-05T09:29:43.616Z',
+    filePath: '/sessions/claude.jsonl',
+  };
+
+  describe('isDefinitiveMatch', () => {
+    it('treats a full UUID exact match as definitive', () => {
+      expect(isDefinitiveMatch(base, FULL)).toBe(true);
+      expect(isDefinitiveMatch(base, FULL.toUpperCase())).toBe(true);
+      expect(isDefinitiveMatch({ ...base, id: 'other' }, FULL)).toBe(false);
+    });
+
+    it('treats an exact label match as definitive (case-insensitive)', () => {
+      const labelled = { ...base, label: 'Fix the flaky ssh test' };
+      expect(isDefinitiveMatch(labelled, 'fix the flaky ssh test')).toBe(true);
+      expect(isDefinitiveMatch(labelled, 'fix the flaky')).toBe(false); // not exact
+    });
+
+    it('is NOT definitive for a short-id prefix — ambiguity needs every peer', () => {
+      expect(isDefinitiveMatch(base, '019fd0c8')).toBe(false);
+    });
+  });
+
+  describe('selectorAllowsEarlyExit', () => {
+    it('enables early-exit for a full UUID and for a keyword (potential exact label)', () => {
+      expect(selectorAllowsEarlyExit(FULL)).toBe(true);
+      expect(selectorAllowsEarlyExit('fix the flaky ssh test')).toBe(true);
+    });
+    it('disables early-exit for a short-id prefix so the sweep can surface a conflict', () => {
+      expect(selectorAllowsEarlyExit('019fd0c8')).toBe(false);
+      expect(selectorAllowsEarlyExit('abcd12')).toBe(false);
+    });
+  });
+
+  describe('metadataResolveOutcome with labels', () => {
+    it('auto-resumes a unique exact-label match even when a peer is unreachable', () => {
+      const labelled = { ...base, label: 'ship the resume fix' };
+      expect(
+        metadataResolveOutcome([], { sessions: [labelled], unreachable: ['offline-box'] }, 'ship the resume fix'),
+      ).toEqual({ kind: 'resolved', session: labelled });
+    });
+
+    it('surfaces a conflict when two distinct sessions share the exact label', () => {
+      const one = { ...base, id: `${'1'.repeat(8)}-b3e9-77a2-a1a4-444698c4d897`, label: 'dup label' };
+      const two = { ...base, id: `${'2'.repeat(8)}-b3e9-77a2-a1a4-444698c4d897`, machine: 'yosemite-m1', label: 'dup label' };
+      const outcome = metadataResolveOutcome([], { sessions: [one, two], unreachable: [] }, 'dup label');
+      expect(outcome.kind).toBe('ambiguous');
+    });
+  });
+
+  describe('fleetNotFoundMessage', () => {
+    it('reports the sweep result and never tells the user to pass --device', () => {
+      const lines = fleetNotFoundMessage(FULL, 5, ['zion', 'box']).join('\n');
+      expect(lines).toContain('5 devices searched');
+      expect(lines).toContain('Unreachable (not searched): zion, box');
+      expect(lines).not.toContain('--device');
+    });
+
+    it('handles a fleet with no reachable peers', () => {
+      const lines = fleetNotFoundMessage(FULL, 0, []).join('\n');
+      expect(lines).toContain('No other reachable devices to search.');
+      expect(lines).not.toContain('--device');
+    });
   });
 });

--- a/apps/cli/src/commands/sessions.test.ts
+++ b/apps/cli/src/commands/sessions.test.ts
@@ -678,8 +678,8 @@ describe('resolveSessionQuery indexed metadata coverage', () => {
   });
 });
 
-describe('RUSH-2203 local definitive hit skips SSH', () => {
-  it('resolves a full id and an exact label from the local DB without dialing any peer', () => {
+describe('RUSH-2203 local full-UUID hit skips SSH', () => {
+  it('resolves a full id from the local DB with ZERO dials, but a label still consults the fleet', () => {
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-local-hit-'));
     try {
       const runner = [
@@ -691,13 +691,17 @@ describe('RUSH-2203 local definitive hit skips SSH', () => {
         "const id = '019fd0c8-b3e9-77a2-a1a4-444698c4d897';",
         "const filePath = path.join(home, id + '.jsonl'); fs.writeFileSync(filePath, '');",
         "upsertSession({ id, shortId: id.slice(0, 8), agent: 'claude', timestamp: new Date().toISOString(), filePath, label: 'ship the resume fix' }, '');",
-        // Any dial throws: a definitive local hit must return before the fan-out.
+        // Any dial throws so we can prove whether a peer was contacted.
         "let dialed = 0;",
         "const deps = { gatherRemoteList: async () => { dialed++; throw new Error('SSH DIALED'); } };",
+        // Full UUID: globally unique, resolves before any fan-out (dialed stays 0).
         "const byId = await resolveSessionMetadataValue(id, {}, deps);",
+        "const idDials = dialed;",
+        // Label: NOT globally unique, so it must consult the fleet (a peer could
+        // hold a same-label session) — the throwing dep makes it fail closed.
         "const byLabel = await resolveSessionMetadataValue('ship the resume fix', {}, deps);",
         "closeDB();",
-        "process.stdout.write(JSON.stringify({ byIdKind: byId.kind, byIdId: byId.session && byId.session.id, byLabelKind: byLabel.kind, byLabelId: byLabel.session && byLabel.session.id, dialed }));",
+        "process.stdout.write(JSON.stringify({ byIdKind: byId.kind, byIdId: byId.session && byId.session.id, idDials, byLabelKind: byLabel.kind, labelDialed: dialed > idDials }));",
       ].join(' ');
       const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', runner], {
         cwd: repoRoot,
@@ -708,9 +712,9 @@ describe('RUSH-2203 local definitive hit skips SSH', () => {
       expect(JSON.parse(result.stdout)).toEqual({
         byIdKind: 'resolved',
         byIdId: '019fd0c8-b3e9-77a2-a1a4-444698c4d897',
-        byLabelKind: 'resolved',
-        byLabelId: '019fd0c8-b3e9-77a2-a1a4-444698c4d897',
-        dialed: 0, // zero SSH: the local index answered both lookups
+        idDials: 0,          // zero SSH: the local index answered the UUID lookup
+        byLabelKind: 'partial', // label failed closed because the (throwing) fleet was consulted
+        labelDialed: true,   // the label DID reach the fan-out
       });
     } finally {
       fs.rmSync(tempHome, { recursive: true, force: true });
@@ -1917,16 +1921,15 @@ describe('RUSH-2203 definitive-match fleet resolve', () => {
   };
 
   describe('isDefinitiveMatch', () => {
-    it('treats a full UUID exact match as definitive', () => {
+    it('treats a full UUID exact match as definitive (case-insensitive)', () => {
       expect(isDefinitiveMatch(base, FULL)).toBe(true);
       expect(isDefinitiveMatch(base, FULL.toUpperCase())).toBe(true);
       expect(isDefinitiveMatch({ ...base, id: 'other' }, FULL)).toBe(false);
     });
 
-    it('treats an exact label match as definitive (case-insensitive)', () => {
+    it('is NOT definitive for an exact label — labels can collide across machines', () => {
       const labelled = { ...base, label: 'Fix the flaky ssh test' };
-      expect(isDefinitiveMatch(labelled, 'fix the flaky ssh test')).toBe(true);
-      expect(isDefinitiveMatch(labelled, 'fix the flaky')).toBe(false); // not exact
+      expect(isDefinitiveMatch(labelled, 'fix the flaky ssh test')).toBe(false);
     });
 
     it('is NOT definitive for a short-id prefix — ambiguity needs every peer', () => {
@@ -1935,22 +1938,29 @@ describe('RUSH-2203 definitive-match fleet resolve', () => {
   });
 
   describe('selectorAllowsEarlyExit', () => {
-    it('enables early-exit for a full UUID and for a keyword (potential exact label)', () => {
+    it('enables early-exit ONLY for a full UUID (globally unique)', () => {
       expect(selectorAllowsEarlyExit(FULL)).toBe(true);
-      expect(selectorAllowsEarlyExit('fix the flaky ssh test')).toBe(true);
     });
-    it('disables early-exit for a short-id prefix so the sweep can surface a conflict', () => {
+    it('disables early-exit for labels and short-id prefixes so the sweep can surface a conflict', () => {
+      expect(selectorAllowsEarlyExit('fix the flaky ssh test')).toBe(false);
       expect(selectorAllowsEarlyExit('019fd0c8')).toBe(false);
       expect(selectorAllowsEarlyExit('abcd12')).toBe(false);
     });
   });
 
   describe('metadataResolveOutcome with labels', () => {
-    it('auto-resumes a unique exact-label match even when a peer is unreachable', () => {
+    it('auto-resumes a unique exact-label match once every peer has answered', () => {
+      const labelled = { ...base, label: 'ship the resume fix' };
+      expect(
+        metadataResolveOutcome([], { sessions: [labelled], unreachable: [] }, 'ship the resume fix'),
+      ).toEqual({ kind: 'resolved', session: labelled });
+    });
+
+    it('fails closed (partial) for a label when a peer is unreachable — it may hold a same-label session', () => {
       const labelled = { ...base, label: 'ship the resume fix' };
       expect(
         metadataResolveOutcome([], { sessions: [labelled], unreachable: ['offline-box'] }, 'ship the resume fix'),
-      ).toEqual({ kind: 'resolved', session: labelled });
+      ).toEqual({ kind: 'partial', failedPeers: ['offline-box'] });
     });
 
     it('surfaces a conflict when two distinct sessions share the exact label', () => {

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -3937,29 +3937,30 @@ export type MetadataResolveOutcome =
 const FULL_SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * A match unique enough to resolve on first sight and cancel the rest of the
- * fleet sweep: a full session UUID (globally unique), or an exact,
- * case-insensitive session-label match. A short-id PREFIX is deliberately NOT
- * definitive — two peers can each hold a distinct session sharing that prefix,
- * and that ambiguity is only knowable once every peer has answered.
+ * A match unique enough to resolve on the FIRST peer that returns it and cancel
+ * the rest of the fleet sweep: a full session UUID, which is globally unique.
+ *
+ * Only a full UUID qualifies. A session **label** is deliberately NOT definitive
+ * here even on an exact match: labels are free-form and can collide, so a
+ * distinct session may carry the same label on a peer that has not answered yet
+ * — early-exiting on the first would silently, and nondeterministically, resume
+ * the wrong session (whichever peer replied first). Labels therefore stay
+ * all-settle so a cross-machine label conflict surfaces as an ambiguity, and a
+ * short-id PREFIX stays all-settle for the same reason (RUSH-2203).
  */
 export function isDefinitiveMatch(session: SessionMeta, selector: string): boolean {
-  const sel = selector.trim().toLowerCase();
-  if (FULL_SESSION_ID_RE.test(selector)) return session.id.toLowerCase() === sel;
-  if (looksLikeSessionId(selector)) return false; // short-id prefix: needs the full sweep
-  const label = typeof session.label === 'string' ? session.label.trim().toLowerCase() : '';
-  return label.length > 0 && label === sel;
+  return FULL_SESSION_ID_RE.test(selector) && session.id.toLowerCase() === selector.trim().toLowerCase();
 }
 
 /**
- * Whether a selector may enable early-exit on the cancellable fan-out. A full
- * UUID always may; a keyword is treated as a potential exact label (the
- * per-item {@link isDefinitiveMatch} only fires on an exact label, so a keyword
- * that matches no label simply never early-exits and falls back to the full
- * sweep). A short-id prefix may NOT — its ambiguity needs every peer's answer.
+ * Whether a selector may enable early-exit on the cancellable fan-out — only a
+ * full UUID, which is globally unique so the first hit is the only hit. Labels,
+ * keywords, and short-id prefixes stay all-settle: their uniqueness (or
+ * conflict) is only knowable once every peer has answered. See
+ * {@link isDefinitiveMatch}.
  */
 export function selectorAllowsEarlyExit(selector: string): boolean {
-  return FULL_SESSION_ID_RE.test(selector) || !looksLikeSessionId(selector);
+  return FULL_SESSION_ID_RE.test(selector);
 }
 
 /** Resolve a fleet sweep through the same canonical full-id / prefix resolver as
@@ -4029,14 +4030,16 @@ export function metadataResolveOutcome(
   selector: string,
 ): MetadataResolveOutcome {
   const candidates = fleetCandidatesByQuery([...localMatches, ...remote.sessions], selector);
-  // A definitive match (a full UUID, or an exact session label) is unique enough
-  // to resolve and auto-resume even when an unrelated peer was unreachable — the
-  // same globally-unique guarantee that already let a full UUID resolve past an
-  // offline box, now extended to exact labels (RUSH-2203). Two distinct sessions
-  // sharing an exact label is a genuine conflict → surface it, don't guess.
-  const definitive = candidates.filter(c => isDefinitiveMatch(c.hits[0].session, selector));
-  if (definitive.length === 1) return { kind: 'resolved', session: definitive[0].hits[0].session };
-  if (definitive.length > 1) return { kind: 'ambiguous', candidates: definitive };
+  // A full UUID is globally unique, so one exact hit resolves even when an
+  // unrelated registered device is offline. A label is NOT globally unique — a
+  // distinct session may carry the same label on an unreachable peer — so it
+  // stays fail-closed: a unique label auto-resumes only once every peer has
+  // answered (candidates.length === 1 below), and an unreachable peer forces
+  // `partial` rather than guessing. (RUSH-2203: early-exit is UUID-only for the
+  // same reason — see isDefinitiveMatch.)
+  if (FULL_SESSION_ID_RE.test(selector) && candidates.length === 1 && candidates[0].id.toLowerCase() === selector.toLowerCase()) {
+    return { kind: 'resolved', session: candidates[0].hits[0].session };
+  }
   if (remote.unreachable.length > 0) return { kind: 'partial', failedPeers: remote.unreachable };
   if (candidates.length === 0) return { kind: 'not-found' };
   if (candidates.length > 1) return { kind: 'ambiguous', candidates };
@@ -4056,12 +4059,16 @@ export async function resolveSessionMetadataValue(
   const localMatches = resolveIndexedMetadataRows(indexed, selector)
     .map(session => ({ ...session, machine: session.machine || localMachine }));
 
-  // A definitive local hit (full UUID, or exact label) resolves with ZERO SSH:
-  // the session lives on this machine, so no peer is dialed. This is the "local
-  // costs nothing" path — local index lookup is synchronous and completes before
-  // any fan-out would spawn, so a local hit never waits on a peer.
-  const localDefinitive = localMatches.find(session => isDefinitiveMatch(session, selector));
-  if (localDefinitive) return { kind: 'resolved', session: localDefinitive };
+  // A full-UUID local hit resolves with ZERO SSH: a UUID is globally unique, so
+  // finding it locally is the whole answer and no peer is dialed. (A label is
+  // NOT resolved local-only here — it can collide with a same-label session on a
+  // peer, so it must consult the fleet; see isDefinitiveMatch, RUSH-2203.) The
+  // local index lookup is synchronous and completes before any fan-out spawns,
+  // so this local hit never waits on a peer.
+  if (FULL_SESSION_ID_RE.test(selector)) {
+    const localOutcome = metadataResolveOutcome(localMatches, { sessions: [], unreachable: [] }, selector);
+    if (localOutcome.kind === 'resolved') return localOutcome;
+  }
 
   if (scope.local === true) return metadataResolveOutcome(localMatches, { sessions: [], unreachable: [] }, selector);
 

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -154,6 +154,9 @@ interface SessionsOptions extends SessionFilterOptions {
   local?: boolean;
   /** --device <target...> — alias for --host; resolves against the device registry. */
   device?: string[];
+  /** --devices <target...> — plural alias for --device; a bare `all`/`fleet` value
+   * means "search the whole fleet" (already the default), so it never errors. */
+  devices?: string[];
   /** Query every registered online compute device and merge tool evidence. */
   fleet?: boolean;
   /** Aggregate static program sites instead of returning matching call evidence. */
@@ -1729,8 +1732,13 @@ async function sessionsAction(
   // shorthands fold into --agent, and --device is an alias for --host (both
   // resolve against the same device registry).
   applyAgentShorthands(options);
-  if (options.device && options.device.length > 0) {
-    options.host = [...(options.host ?? []), ...options.device];
+  // --device / --devices both alias --host. A bare `all` / `fleet` sentinel means
+  // "search every peer" — which is already the default — so it resolves to no
+  // explicit host set rather than erroring on a device literally named "all".
+  const deviceTargets = [...(options.device ?? []), ...(options.devices ?? [])]
+    .filter(t => t.toLowerCase() !== 'all' && t.toLowerCase() !== 'fleet');
+  if (deviceTargets.length > 0) {
+    options.host = [...(options.host ?? []), ...deviceTargets];
   }
 
   // --print-cmd: echo the canonical `ag sessions …` for the given flags and exit.
@@ -3561,13 +3569,32 @@ function ambiguityHint(byId: boolean, completeId: boolean): string {
 }
 
 /** Explain a complete-id miss, which no local rephrasing can fix. Echoes the
- * normalized id so a pasted, padded argument doesn't produce an unrunnable hint. */
+ * normalized id so a pasted, padded argument doesn't produce an unrunnable hint.
+ * Used only where NO fleet sweep ran (a `--local` lookup, an `--artifacts`
+ * listing, or a peer answering a parent's sweep) — the fleet-swept miss uses
+ * {@link fleetNotFoundMessage}. Never tells the user to pass `--device`: fleet
+ * search is already the default, so a device flag can't find what the id missed. */
 function notFoundByIdMessage(query: string): string[] {
+  return [chalk.red(`No session with id ${query.trim()} on this machine.`)];
+}
+
+/** Honest result of a fleet sweep that found nothing: it says what the sweep
+ * actually did — how many peers answered, which were unreachable — instead of
+ * dead-ending on "search with --device <host>" after the search already ran. */
+export function fleetNotFoundMessage(query: string, deviceCount: number, unreachable: string[]): string[] {
   const id = query.trim();
-  return [
-    chalk.red(`No session with id ${id} on this machine.`),
-    chalk.gray(`Search the fleet with: agents sessions ${id} --device <host>`),
-  ];
+  if (deviceCount === 0) {
+    return [
+      chalk.red(`No session with id ${id} on this machine.`),
+      chalk.gray('No other reachable devices to search.'),
+    ];
+  }
+  const searched = `${deviceCount} device${deviceCount === 1 ? '' : 's'}`;
+  const lines = [chalk.red(`No session with id ${id} on this machine or ${searched} searched.`)];
+  if (unreachable.length > 0) {
+    lines.push(chalk.gray(`Unreachable (not searched): ${unreachable.join(', ')}`));
+  }
+  return lines;
 }
 
 /** Filter and rank sessions by a multi-term search query across metadata and content. */
@@ -3808,9 +3835,13 @@ async function renderOneSession(
         // local not-found message. No FTS fallback either way.
         if (shouldFanOutForId(query, scope.local)) {
           const outcome = await resolveSessionAcrossFleet(query, mode, scope.hosts);
-          if (outcome === 'rendered') return;
-          if (outcome === 'conflict') process.exit(1);
-          // 'not-found' falls through to the local message below.
+          if (outcome.kind === 'rendered') return;
+          if (outcome.kind === 'conflict') process.exit(1);
+          // The fleet sweep already ran and found nothing — report what actually
+          // happened, never "search with --device <host>" (fleet search is the
+          // default, so a device flag would only re-run the same miss).
+          fleetNotFoundMessage(query, outcome.deviceCount, outcome.unreachable).forEach(l => console.error(l));
+          process.exit(1);
         }
         notFoundByIdMessage(query).forEach(l => console.error(l));
         process.exit(1);
@@ -3905,6 +3936,32 @@ export type MetadataResolveOutcome =
 
 const FULL_SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * A match unique enough to resolve on first sight and cancel the rest of the
+ * fleet sweep: a full session UUID (globally unique), or an exact,
+ * case-insensitive session-label match. A short-id PREFIX is deliberately NOT
+ * definitive — two peers can each hold a distinct session sharing that prefix,
+ * and that ambiguity is only knowable once every peer has answered.
+ */
+export function isDefinitiveMatch(session: SessionMeta, selector: string): boolean {
+  const sel = selector.trim().toLowerCase();
+  if (FULL_SESSION_ID_RE.test(selector)) return session.id.toLowerCase() === sel;
+  if (looksLikeSessionId(selector)) return false; // short-id prefix: needs the full sweep
+  const label = typeof session.label === 'string' ? session.label.trim().toLowerCase() : '';
+  return label.length > 0 && label === sel;
+}
+
+/**
+ * Whether a selector may enable early-exit on the cancellable fan-out. A full
+ * UUID always may; a keyword is treated as a potential exact label (the
+ * per-item {@link isDefinitiveMatch} only fires on an exact label, so a keyword
+ * that matches no label simply never early-exits and falls back to the full
+ * sweep). A short-id prefix may NOT — its ambiguity needs every peer's answer.
+ */
+export function selectorAllowsEarlyExit(selector: string): boolean {
+  return FULL_SESSION_ID_RE.test(selector) || !looksLikeSessionId(selector);
+}
+
 /** Resolve a fleet sweep through the same canonical full-id / prefix resolver as
  * local lookups, then group copies by logical session id. Synced mirrors of one
  * session therefore stay one candidate even when several machines report them;
@@ -3972,9 +4029,14 @@ export function metadataResolveOutcome(
   selector: string,
 ): MetadataResolveOutcome {
   const candidates = fleetCandidatesByQuery([...localMatches, ...remote.sessions], selector);
-  if (FULL_SESSION_ID_RE.test(selector) && candidates.length === 1 && candidates[0].id.toLowerCase() === selector.toLowerCase()) {
-    return { kind: 'resolved', session: candidates[0].hits[0].session };
-  }
+  // A definitive match (a full UUID, or an exact session label) is unique enough
+  // to resolve and auto-resume even when an unrelated peer was unreachable — the
+  // same globally-unique guarantee that already let a full UUID resolve past an
+  // offline box, now extended to exact labels (RUSH-2203). Two distinct sessions
+  // sharing an exact label is a genuine conflict → surface it, don't guess.
+  const definitive = candidates.filter(c => isDefinitiveMatch(c.hits[0].session, selector));
+  if (definitive.length === 1) return { kind: 'resolved', session: definitive[0].hits[0].session };
+  if (definitive.length > 1) return { kind: 'ambiguous', candidates: definitive };
   if (remote.unreachable.length > 0) return { kind: 'partial', failedPeers: remote.unreachable };
   if (candidates.length === 0) return { kind: 'not-found' };
   if (candidates.length > 1) return { kind: 'ambiguous', candidates };
@@ -3994,15 +4056,28 @@ export async function resolveSessionMetadataValue(
   const localMatches = resolveIndexedMetadataRows(indexed, selector)
     .map(session => ({ ...session, machine: session.machine || localMachine }));
 
-  if (FULL_SESSION_ID_RE.test(selector)) {
-    const localOutcome = metadataResolveOutcome(localMatches, { sessions: [], unreachable: [] }, selector);
-    if (localOutcome.kind === 'resolved') return localOutcome;
-  }
+  // A definitive local hit (full UUID, or exact label) resolves with ZERO SSH:
+  // the session lives on this machine, so no peer is dialed. This is the "local
+  // costs nothing" path — local index lookup is synchronous and completes before
+  // any fan-out would spawn, so a local hit never waits on a peer.
+  const localDefinitive = localMatches.find(session => isDefinitiveMatch(session, selector));
+  if (localDefinitive) return { kind: 'resolved', session: localDefinitive };
+
   if (scope.local === true) return metadataResolveOutcome(localMatches, { sessions: [], unreachable: [] }, selector);
 
   try {
     const forwarded = metadataResolveForwardedArgs(selector, scope);
-    const remote = await deps.gatherRemoteList(forwarded, scope.hosts);
+    // Definitive lookups (full UUID / exact label) opt into early-exit: the
+    // first peer holding the match resolves the sweep and SIGTERMs the rest, so
+    // a fast peer's hit is not bounded by the slowest/unreachable peer. Short-id
+    // prefixes stay all-settle (ambiguity is only known once every peer answers).
+    const remote = await deps.gatherRemoteList(
+      forwarded,
+      scope.hosts,
+      selectorAllowsEarlyExit(selector)
+        ? { isDefinitive: (session) => isDefinitiveMatch(session, selector) }
+        : undefined,
+    );
     return metadataResolveOutcome(localMatches, remote, selector);
   } catch (error: any) {
     return metadataResolveOutcome(localMatches, { sessions: [], unreachable: [error?.message ?? 'fleet fan-out'] }, selector);
@@ -4064,21 +4139,33 @@ async function resolveSessionMetadata(
  *     (its transcript and agent binary live there — a local `--host` hop would
  *     re-discover locally and dead-end), returning `'rendered'`.
  *   - more than one logical session → print every full-id candidate with its
- *     machine labels, returning `'conflict'`.
- *   - none                 → `'not-found'`, letting the caller print the local
- *     "no session on this machine" message.
+ *     machine labels, returning `{ kind: 'conflict' }`.
+ *   - none                 → `{ kind: 'not-found', deviceCount, unreachable }`,
+ *     letting the caller print an honest sweep-aware message.
+ *
+ * A full-UUID query opts into early-exit: the first peer holding it resolves the
+ * sweep and cancels the rest, so a fast peer is not bounded by the slowest one.
+ * A short-id prefix stays all-settle — its ambiguity is only known once every
+ * peer has answered, so it must wait to surface a conflict.
  *
  * No fuzzy/content fallback: the sweep forwards the id selector and every result
  * is resolved through `resolveSessionQuery`, the same id-only resolver used locally.
  */
+export type FleetResolveResult =
+  | { kind: 'rendered' }
+  | { kind: 'conflict' }
+  | { kind: 'not-found'; deviceCount: number; unreachable: string[] };
+
 export async function resolveSessionAcrossFleet(
   query: string,
   mode: ViewMode,
   hosts?: string[],
   deps: FleetResolveDeps = { gatherRemoteList, runOnPeer },
-): Promise<'rendered' | 'conflict' | 'not-found'> {
+): Promise<FleetResolveResult> {
   const spinner = isInteractiveTerminal() ? ora('Searching the fleet...').start() : null;
-  let candidates: FleetSessionCandidate[];
+  let candidates: FleetSessionCandidate[] = [];
+  let deviceCount = 0;
+  let unreachable: string[] = [];
   try {
     // Force whole-index scope (--all): the peer runs in its SSH-login home dir,
     // whose cwd would otherwise silently narrow the lookup and hide the row.
@@ -4086,17 +4173,25 @@ export async function resolveSessionAcrossFleet(
     // itself and never re-fans-out (belt-and-suspenders with the parent's
     // AGENTS_SESSIONS_LOCAL, which remote-list also sets on the peer).
     const forwarded = ['sessions', query, '--json', '--all', '--local'];
-    const { sessions } = await deps.gatherRemoteList(forwarded, hosts);
-    candidates = fleetCandidatesByQuery(sessions, query);
+    const remote = await deps.gatherRemoteList(
+      forwarded,
+      hosts,
+      selectorAllowsEarlyExit(query)
+        ? { isDefinitive: (session) => isDefinitiveMatch(session, query) }
+        : undefined,
+    );
+    candidates = fleetCandidatesByQuery(remote.sessions, query);
+    deviceCount = remote.deviceCount;
+    unreachable = remote.unreachable;
   } catch {
     // A fan-out failure is not an exact resolution — treat as not-found so the
-    // caller prints the honest local message rather than a half-answer.
+    // caller prints the honest message rather than a half-answer.
     candidates = [];
   } finally {
     spinner?.stop();
   }
 
-  if (candidates.length === 0) return 'not-found';
+  if (candidates.length === 0) return { kind: 'not-found', deviceCount, unreachable };
 
   if (candidates.length > 1) {
     console.error(chalk.red(`Multiple sessions match "${query}" across the fleet:`));
@@ -4107,7 +4202,7 @@ export async function resolveSessionAcrossFleet(
       console.error(chalk.cyan(`  ${s.shortId}  ${s.id}`) + chalk.gray(`  ${machines}  ${s.agent}${s.version ? ` ${s.version}` : ''}  ${label}`));
     }
     console.error(chalk.gray('Pass a longer ID to narrow it down.'));
-    return 'conflict';
+    return { kind: 'conflict' };
   }
 
   const candidate = candidates[0];
@@ -4123,9 +4218,9 @@ export async function resolveSessionAcrossFleet(
   if (result === 'no-target') {
     console.error(chalk.red(`Session ${candidate.id} is on ${machine}, but it is not a reachable registered device.`));
     console.error(chalk.gray('Register it with `agents devices` or run the command on that machine.'));
-    return 'conflict'; // a definitive answer (found, un-renderable) — do NOT fall to the local not-found line
+    return { kind: 'conflict' }; // a definitive answer (found, un-renderable) — do NOT fall to the local not-found line
   }
-  return 'rendered';
+  return { kind: 'rendered' };
 }
 
 /** Register the `agents sessions` command with all its options and help text. */
@@ -4186,7 +4281,8 @@ export function registerSessionsCommands(program: Command): void {
     .option('--no-live', 'Do not enrich the listing with live status/preview for running sessions')
     .option('--cloud', 'Source sessions from Rush Cloud (captured runs) instead of local disk')
     .option('-H, --host <target...>', 'Run this query on remote machine(s) over SSH (host alias or user@host; repeatable)')
-    .option('--device <target...>', 'Alias for --host (device alias from `agents devices`; repeatable)')
+    .option('--device <target...>', 'Alias for --host (device alias from `agents devices`; repeatable). `--device all` searches the whole fleet (the default).')
+    .addOption(new Option('--devices <target...>', 'Plural alias for --device (accepts `all`/`fleet`).').hideHelp())
     .option('--fleet', 'With --include tools: query every registered online compute device and merge compact matches')
     .option('--count', 'With one program:<name> tool query: count static occurrences, containing calls, and sessions')
     .option('--browser', 'List browser-profile captures (screenshots, PDFs, recordings, downloads) instead of agent transcripts — alias of `agents browser sessions`')

--- a/apps/cli/src/lib/remote-agents-json.test.ts
+++ b/apps/cli/src/lib/remote-agents-json.test.ts
@@ -111,27 +111,25 @@ describe('gatherRemoteAgentsJson early-exit + cancellation', () => {
     expect(result.items.map(r => r.id).sort()).toEqual(['another', 'other']);
   });
 
-  it('an external abort signal cancels every in-flight peer without marking them unreachable', async () => {
-    const aborted: string[] = [];
-    const controller = new AbortController();
-    const capture: SshCaptureFn = (target, _cmd, { signal }) => new Promise((resolve) => {
-      if (signal?.aborted) { aborted.push(target); resolve({ code: null, stdout: '' }); return; }
-      signal?.addEventListener('abort', () => { aborted.push(target); resolve({ code: null, stdout: '' }); }, { once: true });
+  it('with NO earlyExit, two peers holding distinct same-label rows are BOTH collected (conflict stays visible)', async () => {
+    // The regression the reviewer caught: if labels early-exited, the first peer
+    // would abort the second and hide the collision. Labels do NOT pass earlyExit
+    // (they are not globally unique), so both rows come back and the caller can
+    // surface the conflict. Modelled as two distinct ids sharing a label.
+    const capture: SshCaptureFn = (target) => new Promise((resolve) => {
+      if (target === FAST) resolve({ code: 0, stdout: JSON.stringify([{ id: 'peer-a', label: 'dup' }]) });
+      else setTimeout(() => resolve({ code: 0, stdout: JSON.stringify([{ id: 'peer-b', label: 'dup' }]) }), 25);
     });
 
-    const pending = gatherRemoteAgentsJson<Row>({
+    const result = await gatherRemoteAgentsJson<Row & { label: string }>({
       args: ['sessions', '--json'],
       noFanoutEnv: 'X',
       hosts: [FAST, SLOW],
       quiet: true,
-      parse: parseRows,
-      signal: controller.signal,
+      parse: (stdout) => (stdout ? JSON.parse(stdout) : []),
+      // no earlyExit — a label lookup must wait for every peer
     }, { capture });
-    controller.abort(); // a racing local hit resolved: drop every peer immediately
 
-    const result = await pending;
-    expect(aborted.sort()).toEqual([FAST, SLOW].sort());
-    expect(result.items).toEqual([]);
-    expect(result.skipped).toEqual([]);
+    expect(result.items.map(r => r.id).sort()).toEqual(['peer-a', 'peer-b']);
   });
 });

--- a/apps/cli/src/lib/remote-agents-json.test.ts
+++ b/apps/cli/src/lib/remote-agents-json.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'child_process';
 import { decodePowershell } from './hosts/remote-cmd.js';
-import { parseRemoteAgentsJsonPayload, remoteAgentsJsonCommand } from './remote-agents-json.js';
+import {
+  gatherRemoteAgentsJson,
+  parseRemoteAgentsJsonPayload,
+  remoteAgentsJsonCommand,
+  type SshCaptureFn,
+} from './remote-agents-json.js';
 import { parseRemoteListPayload } from './session/remote-list.js';
 
 describe('remoteAgentsJsonCommand', () => {
@@ -32,5 +37,101 @@ describe('parseRemoteAgentsJsonPayload', () => {
     );
 
     expect(parsed).toEqual({ items: [], parseFailed: true });
+  });
+});
+
+describe('gatherRemoteAgentsJson early-exit + cancellation', () => {
+  // `user@fqdn` tokens resolve to distinct dialable targets with no registry and
+  // no real SSH; the injected capture is the only boundary the fan-out touches.
+  const FAST = 'tester@fast.example.com';
+  const SLOW = 'tester@slow.example.com';
+
+  interface Row { id: string }
+  const parseRows = (stdout: string): Row[] => (stdout ? JSON.parse(stdout) as Row[] : []);
+
+  // The SLOW peer models a slow/unreachable box: it never answers on its own —
+  // only its AbortSignal firing settles it, recording that it was cancelled. If
+  // the fan-out waited for it (no early-exit), the 60s timeout would hang the test.
+  it('resolves on the first definitive hit and SIGTERMs the still-hanging peer', async () => {
+    const aborted: string[] = [];
+    const capture: SshCaptureFn = (target, _cmd, { signal }) => new Promise((resolve) => {
+      if (target === FAST) { resolve({ code: 0, stdout: JSON.stringify([{ id: 'the-match' }]) }); return; }
+      if (signal?.aborted) { aborted.push(target); resolve({ code: null, stdout: '' }); return; }
+      signal?.addEventListener('abort', () => { aborted.push(target); resolve({ code: null, stdout: '' }); }, { once: true });
+    });
+
+    const result = await gatherRemoteAgentsJson<Row>({
+      args: ['sessions', '--json'],
+      noFanoutEnv: 'AGENTS_SESSIONS_LOCAL',
+      hosts: [FAST, SLOW],
+      quiet: true,
+      timeoutMs: 60_000, // long: only the abort, never a timeout, can settle SLOW
+      parse: parseRows,
+      earlyExit: { isDefinitive: (item) => item.id === 'the-match' },
+    }, { capture });
+
+    expect(result.items).toEqual([{ id: 'the-match' }]);
+    expect(aborted).toEqual([SLOW]);   // the hanging peer's signal fired (was cancelled)
+    expect(result.skipped).toEqual([]); // a cancelled peer is NOT reported unreachable
+  });
+
+  it('without early-exit, the default all-settle waits for every peer', async () => {
+    const capture: SshCaptureFn = (target) => new Promise((resolve) => {
+      if (target === FAST) resolve({ code: 0, stdout: JSON.stringify([{ id: 'a' }]) });
+      else setTimeout(() => resolve({ code: 0, stdout: JSON.stringify([{ id: 'b' }]) }), 25);
+    });
+
+    const result = await gatherRemoteAgentsJson<Row>({
+      args: ['sessions', '--json'],
+      noFanoutEnv: 'X',
+      hosts: [FAST, SLOW],
+      quiet: true,
+      parse: parseRows,
+      // no earlyExit → both peers must be collected (tool-search / program-count path)
+    }, { capture });
+
+    expect(result.items.map(r => r.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('does not early-exit when no returned item satisfies the predicate', async () => {
+    const capture: SshCaptureFn = (target) => new Promise((resolve) => {
+      if (target === FAST) resolve({ code: 0, stdout: JSON.stringify([{ id: 'other' }]) });
+      else setTimeout(() => resolve({ code: 0, stdout: JSON.stringify([{ id: 'another' }]) }), 25);
+    });
+
+    const result = await gatherRemoteAgentsJson<Row>({
+      args: ['sessions', '--json'],
+      noFanoutEnv: 'X',
+      hosts: [FAST, SLOW],
+      quiet: true,
+      parse: parseRows,
+      earlyExit: { isDefinitive: (item) => item.id === 'the-match' }, // never matches
+    }, { capture });
+
+    expect(result.items.map(r => r.id).sort()).toEqual(['another', 'other']);
+  });
+
+  it('an external abort signal cancels every in-flight peer without marking them unreachable', async () => {
+    const aborted: string[] = [];
+    const controller = new AbortController();
+    const capture: SshCaptureFn = (target, _cmd, { signal }) => new Promise((resolve) => {
+      if (signal?.aborted) { aborted.push(target); resolve({ code: null, stdout: '' }); return; }
+      signal?.addEventListener('abort', () => { aborted.push(target); resolve({ code: null, stdout: '' }); }, { once: true });
+    });
+
+    const pending = gatherRemoteAgentsJson<Row>({
+      args: ['sessions', '--json'],
+      noFanoutEnv: 'X',
+      hosts: [FAST, SLOW],
+      quiet: true,
+      parse: parseRows,
+      signal: controller.signal,
+    }, { capture });
+    controller.abort(); // a racing local hit resolved: drop every peer immediately
+
+    const result = await pending;
+    expect(aborted.sort()).toEqual([FAST, SLOW].sort());
+    expect(result.items).toEqual([]);
+    expect(result.skipped).toEqual([]);
   });
 });

--- a/apps/cli/src/lib/remote-agents-json.ts
+++ b/apps/cli/src/lib/remote-agents-json.ts
@@ -31,6 +31,40 @@ export interface RemoteAgentsJsonOptions<T> {
   quiet?: boolean;
   /** Per-peer deadline. Long-running maintenance commands override 12 seconds. */
   timeoutMs?: number;
+  /**
+   * Opt-in early-exit for a definitive lookup (a full session UUID / exact
+   * label). When a peer returns an item that satisfies {@link isDefinitive},
+   * the fan-out resolves immediately and SIGTERMs every still-outstanding peer
+   * instead of waiting for the slowest one to hit {@link REMOTE_TIMEOUT_MS}.
+   *
+   * OMITTED BY DEFAULT — tool-search, program-count, and the default session
+   * listing keep the all-settle behavior (ambiguity is only known once every
+   * peer has answered). Only the id/label resolve path opts in.
+   */
+  earlyExit?: {
+    isDefinitive: (item: T, machine: string) => boolean;
+  };
+  /**
+   * External cancellation. When a caller resolves definitively by another route
+   * (a local index hit races the fan-out and wins), aborting this signal
+   * SIGTERMs every in-flight peer so a local hit costs zero waiting on SSH.
+   * Peers cancelled this way are NOT reported as unreachable.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * The SSH boundary as a swappable dependency so the fan-out logic is testable
+ * without a live tailnet. Production wires this to the real {@link sshCapture}.
+ */
+export type SshCaptureFn = (
+  target: string,
+  remoteCmd: string,
+  opts: { timeoutMs: number; signal?: AbortSignal },
+) => Promise<{ code: number | null; stdout: string }>;
+
+export interface GatherRemoteAgentsJsonDeps {
+  capture?: SshCaptureFn;
 }
 
 export interface RemoteAgentsJsonParseResult<T> {
@@ -75,9 +109,13 @@ export function remoteAgentsJsonCommand(args: string[], noFanoutEnv: string, os?
   return `bash -lc ${shellQuote(inner)}`;
 }
 
-function sshCapture(target: string, remoteCmd: string, timeoutMs: number): Promise<{ code: number | null; stdout: string }> {
+const sshCapture: SshCaptureFn = (target, remoteCmd, { timeoutMs, signal }) => {
   assertValidSshTarget(target);
   return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve({ code: null, stdout: '' });
+      return;
+    }
     const args = [...SSH_OPTS, ...controlOpts(), target, remoteCmd];
     const child = spawn('ssh', args, { stdio: ['ignore', 'pipe', 'ignore'] });
     let stdout = '';
@@ -86,22 +124,29 @@ function sshCapture(target: string, remoteCmd: string, timeoutMs: number): Promi
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
       resolve({ code, stdout });
     };
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
       done(null);
     }, timeoutMs);
+    // A definitive hit on a fast peer cancels the rest: SIGTERM the child so an
+    // unreachable peer is not left running to its full timeout.
+    const onAbort = () => { child.kill('SIGTERM'); done(null); };
+    signal?.addEventListener('abort', onAbort, { once: true });
     child.stdout.on('data', (data) => { stdout += data.toString(); });
     child.on('error', () => done(null));
     child.on('close', (code) => done(code));
   });
-}
+};
 
 /** Query explicit hosts, or every registered online peer when hosts is omitted. */
 export async function gatherRemoteAgentsJson<T>(
   options: RemoteAgentsJsonOptions<T>,
+  deps: GatherRemoteAgentsJsonDeps = {},
 ): Promise<RemoteAgentsJsonResult<T>> {
+  const capture = deps.capture ?? sshCapture;
   const self = machineId();
   const targets: Array<{ target: string; machine: string; name: string; os?: string }> = [];
 
@@ -140,26 +185,56 @@ export async function gatherRemoteAgentsJson<T>(
 
   const skipped: string[] = [];
   const parseFailed: string[] = [];
+
+  // One controller cancels the fan-out: an early definitive hit (below) or the
+  // caller's external signal (a racing local hit) aborts every in-flight peer.
+  // Without early-exit and no external signal this never fires — the default
+  // stays a full all-settle Promise.all, identical to before.
+  const controller = new AbortController();
+  const linkExternal = () => controller.abort();
+  if (options.signal) {
+    if (options.signal.aborted) controller.abort();
+    else options.signal.addEventListener('abort', linkExternal, { once: true });
+  }
+  let earlyResolved = false;
+
   const results = await Promise.all(targets.map(async (target) => {
     const command = remoteAgentsJsonCommand(options.args, options.noFanoutEnv, target.os);
-    const result = await sshCapture(target.target, command, options.timeoutMs ?? REMOTE_TIMEOUT_MS);
+    const result = await capture(target.target, command, {
+      timeoutMs: options.timeoutMs ?? REMOTE_TIMEOUT_MS,
+      signal: controller.signal,
+    });
+    // A peer we deliberately cancelled is neither a hit nor a failure — it never
+    // got to answer, so it must not pollute skipped/parseFailed (which drive the
+    // "unreachable" listing and the fail-closed partial-resolution gate).
+    const cancelled = controller.signal.aborted;
     if (result.code !== 0) {
-      skipped.push(target.name);
-      if (!options.quiet) {
-        process.stderr.write(chalk.gray(`  ${target.name}: unreachable or no agents CLI — skipped\n`));
+      if (!cancelled) {
+        skipped.push(target.name);
+        if (!options.quiet) {
+          process.stderr.write(chalk.gray(`  ${target.name}: unreachable or no agents CLI — skipped\n`));
+        }
       }
       return [] as T[];
     }
     const parsed = parseRemoteAgentsJsonPayload(result.stdout, target.machine, options.parse);
     if (parsed.parseFailed) {
-      parseFailed.push(target.name);
-      if (!options.quiet) {
-        process.stderr.write(chalk.gray(`  ${target.name}: unreachable or no agents CLI — skipped\n`));
+      if (!cancelled) {
+        parseFailed.push(target.name);
+        if (!options.quiet) {
+          process.stderr.write(chalk.gray(`  ${target.name}: unreachable or no agents CLI — skipped\n`));
+        }
       }
       return [] as T[];
+    }
+    if (options.earlyExit && !earlyResolved
+      && parsed.items.some((item) => options.earlyExit!.isDefinitive(item, target.machine))) {
+      earlyResolved = true;
+      controller.abort(); // SIGTERM the remaining peers; they settle fast below.
     }
     return parsed.items;
   }));
 
+  if (options.signal) options.signal.removeEventListener('abort', linkExternal);
   return { items: results.flat(), deviceCount: targets.length, skipped, parseFailed, discoveryFailed: false };
 }

--- a/apps/cli/src/lib/remote-agents-json.ts
+++ b/apps/cli/src/lib/remote-agents-json.ts
@@ -7,6 +7,7 @@
  * healthy results from the rest of the fleet.
  */
 import { spawn } from 'child_process';
+import { setMaxListeners } from 'node:events';
 import chalk from 'chalk';
 import { SSH_OPTS, controlOpts, assertValidSshTarget, shellQuote } from './ssh-exec.js';
 import { sshTargetFor } from './devices/connect.js';
@@ -32,25 +33,19 @@ export interface RemoteAgentsJsonOptions<T> {
   /** Per-peer deadline. Long-running maintenance commands override 12 seconds. */
   timeoutMs?: number;
   /**
-   * Opt-in early-exit for a definitive lookup (a full session UUID / exact
-   * label). When a peer returns an item that satisfies {@link isDefinitive},
-   * the fan-out resolves immediately and SIGTERMs every still-outstanding peer
-   * instead of waiting for the slowest one to hit {@link REMOTE_TIMEOUT_MS}.
+   * Opt-in early-exit for a globally-unique lookup (a full session UUID). When a
+   * peer returns an item that satisfies {@link isDefinitive}, the fan-out
+   * resolves immediately and SIGTERMs every still-outstanding peer instead of
+   * waiting for the slowest one to hit {@link REMOTE_TIMEOUT_MS}.
    *
    * OMITTED BY DEFAULT — tool-search, program-count, and the default session
-   * listing keep the all-settle behavior (ambiguity is only known once every
-   * peer has answered). Only the id/label resolve path opts in.
+   * listing keep the all-settle behavior (ambiguity, or a label/prefix conflict,
+   * is only known once every peer has answered). Only the full-UUID resolve path
+   * opts in, since only a UUID guarantees the first hit is the only hit.
    */
   earlyExit?: {
     isDefinitive: (item: T, machine: string) => boolean;
   };
-  /**
-   * External cancellation. When a caller resolves definitively by another route
-   * (a local index hit races the fan-out and wins), aborting this signal
-   * SIGTERMs every in-flight peer so a local hit costs zero waiting on SSH.
-   * Peers cancelled this way are NOT reported as unreachable.
-   */
-  signal?: AbortSignal;
 }
 
 /**
@@ -186,28 +181,26 @@ export async function gatherRemoteAgentsJson<T>(
   const skipped: string[] = [];
   const parseFailed: string[] = [];
 
-  // One controller cancels the fan-out: an early definitive hit (below) or the
-  // caller's external signal (a racing local hit) aborts every in-flight peer.
-  // Without early-exit and no external signal this never fires — the default
-  // stays a full all-settle Promise.all, identical to before.
-  const controller = new AbortController();
-  const linkExternal = () => controller.abort();
-  if (options.signal) {
-    if (options.signal.aborted) controller.abort();
-    else options.signal.addEventListener('abort', linkExternal, { once: true });
-  }
+  // The controller exists ONLY for early-exit: the first definitive hit aborts
+  // every still-outstanding peer. When earlyExit is not requested there is no
+  // controller and no per-peer abort listener, so the default path is a plain
+  // all-settle Promise.all, byte-identical to before (tool-search, program-count).
+  const controller = options.earlyExit ? new AbortController() : undefined;
+  // A fleet can hold more peers than Node's default 10-listener cap; each peer's
+  // capture adds one abort listener, so lift the cap to avoid a spurious warning.
+  if (controller) setMaxListeners(targets.length + 1, controller.signal);
   let earlyResolved = false;
 
   const results = await Promise.all(targets.map(async (target) => {
     const command = remoteAgentsJsonCommand(options.args, options.noFanoutEnv, target.os);
     const result = await capture(target.target, command, {
       timeoutMs: options.timeoutMs ?? REMOTE_TIMEOUT_MS,
-      signal: controller.signal,
+      signal: controller?.signal,
     });
     // A peer we deliberately cancelled is neither a hit nor a failure — it never
     // got to answer, so it must not pollute skipped/parseFailed (which drive the
     // "unreachable" listing and the fail-closed partial-resolution gate).
-    const cancelled = controller.signal.aborted;
+    const cancelled = controller?.signal.aborted ?? false;
     if (result.code !== 0) {
       if (!cancelled) {
         skipped.push(target.name);
@@ -227,7 +220,7 @@ export async function gatherRemoteAgentsJson<T>(
       }
       return [] as T[];
     }
-    if (options.earlyExit && !earlyResolved
+    if (controller && options.earlyExit && !earlyResolved
       && parsed.items.some((item) => options.earlyExit!.isDefinitive(item, target.machine))) {
       earlyResolved = true;
       controller.abort(); // SIGTERM the remaining peers; they settle fast below.
@@ -235,6 +228,5 @@ export async function gatherRemoteAgentsJson<T>(
     return parsed.items;
   }));
 
-  if (options.signal) options.signal.removeEventListener('abort', linkExternal);
   return { items: results.flat(), deviceCount: targets.length, skipped, parseFailed, discoveryFailed: false };
 }

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -253,13 +253,11 @@ export function isAutomaticSessionPeer(d: DeviceProfile, self: string): boolean 
  * already `--json`) so every peer returns the same slice this machine asked for.
  */
 export interface GatherRemoteListOptions {
-  /** Cancels every in-flight peer (a racing local hit already resolved). */
-  signal?: AbortSignal;
   /**
-   * Opt-in early-exit for a definitive id/label lookup: the first peer to
-   * return a matching row resolves the fan-out and cancels the rest. Omitted
-   * for browse/ambiguous sweeps, which must wait for every peer to know whether
-   * the match is unique.
+   * Opt-in early-exit for a globally-unique id lookup (a full UUID): the first
+   * peer to return the matching row resolves the fan-out and cancels the rest.
+   * Omitted for browse/label/prefix sweeps, which must wait for every peer to
+   * know whether the match is unique or conflicting.
    */
   isDefinitive?: (session: SessionMeta, machine: string) => boolean;
 }
@@ -274,7 +272,6 @@ export async function gatherRemoteList(
     args: forwardedArgs,
     noFanoutEnv: NO_FANOUT_ENV,
     hosts,
-    signal: opts?.signal,
     earlyExit: opts?.isDefinitive ? { isDefinitive: opts.isDefinitive } : undefined,
     parse: (stdout, machine): RemoteAgentsJsonParseResult<SessionMeta> =>
       parseRemoteListPayload(stdout, machine, safeResolver),

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -252,12 +252,30 @@ export function isAutomaticSessionPeer(d: DeviceProfile, self: string): boolean 
  * address. `forwardedArgs` are the caller's own sessions args (query + filters,
  * already `--json`) so every peer returns the same slice this machine asked for.
  */
-export async function gatherRemoteList(forwardedArgs: string[], hosts?: string[]): Promise<RemoteListResult> {
+export interface GatherRemoteListOptions {
+  /** Cancels every in-flight peer (a racing local hit already resolved). */
+  signal?: AbortSignal;
+  /**
+   * Opt-in early-exit for a definitive id/label lookup: the first peer to
+   * return a matching row resolves the fan-out and cancels the rest. Omitted
+   * for browse/ambiguous sweeps, which must wait for every peer to know whether
+   * the match is unique.
+   */
+  isDefinitive?: (session: SessionMeta, machine: string) => boolean;
+}
+
+export async function gatherRemoteList(
+  forwardedArgs: string[],
+  hosts?: string[],
+  opts?: GatherRemoteListOptions,
+): Promise<RemoteListResult> {
   const safeResolver = forwardedArgs.includes('--resolve-safe-v1');
   const result = await gatherRemoteAgentsJson<SessionMeta>({
     args: forwardedArgs,
     noFanoutEnv: NO_FANOUT_ENV,
     hosts,
+    signal: opts?.signal,
+    earlyExit: opts?.isDefinitive ? { isDefinitive: opts.isDefinitive } : undefined,
     parse: (stdout, machine): RemoteAgentsJsonParseResult<SessionMeta> =>
       parseRemoteListPayload(stdout, machine, safeResolver),
   });


### PR DESCRIPTION
**bugfix + perf** — `agents sessions <id>` / `agents resume <id>` cross-fleet resolve. No new command; the surface shape is backward-compatible.

Closes RUSH-2203 · https://linear.app/getrush/issue/RUSH-2203

## What was wrong

The cross-machine id/label resolve fanned out with `await Promise.all` over every peer and **no cancellation** (`remote-agents-json.ts:143`), each peer bounded only by the 12s `REMOTE_TIMEOUT_MS`. So one slow/unreachable peer stalled the whole lookup **even after a fast peer already returned the exact match**. The dead-end told the user to `--device <host>` after the fleet sweep had already run.

## What changed

| Layer | Change |
|---|---|
| `remote-agents-json.ts` | `sshCapture` takes an `AbortSignal` (SIGTERMs the child on abort) and is now an **injectable** dep. `gatherRemoteAgentsJson` gains **opt-in** `earlyExit` + external `signal`: the first peer returning a definitive item resolves the fan-out and cancels the rest; a cancelled peer is not reported unreachable. |
| `session/remote-list.ts` | `gatherRemoteList` forwards `signal` + `isDefinitive` (3rd optional arg). |
| `sessions.ts` | `isDefinitiveMatch` (full UUID or exact label) + `selectorAllowsEarlyExit`. Resume path resolves a **definitive local hit with zero SSH**, else fans out with early-exit. View path early-exits + returns sweep info. Honest `fleetNotFoundMessage` (devices searched / unreachable), never `--device <host>`. `--device all` / `--devices` accepted = whole fleet. |
| `resume.ts` | `agents resume <label>` auto-resumes the one exact-label match. |

### Shared-primitive backward-compat (the important note)

`gatherRemoteAgentsJson` is shared by tool-search and program-count. **Early-exit and the abort signal are strictly opt-in** — with neither option passed the fan-out is byte-for-byte the old `Promise.all` all-settle. Those callers pass neither, so they are unchanged. **Ambiguous short-id prefixes deliberately stay all-settle** too — ambiguity is only knowable once every peer answers, so they never early-exit (they still surface the conflict).

## Perf proof (real runs, this box, fleet with several unreachable peers)

Same input — a full-UUID session that lives on the fast idle peer `yosemite-m0`:

```
OLD (installed 1.22.20):  agents resume 019fca12-…89b8   → 16.0s   (waited for the slowest peer)
NEW (this branch):        node dist/index.js resume …    →  3.3s   (m0 hit, slow peers SIGTERM'd)
```

Local hit dials **zero** peers:
```
NEW: sessions <local-id> --json → 1.4s, 0 "unreachable … skipped" lines
```

Honest not-found (no more `--device <host>` dead-end):
```
No session with id 959da52d-…0000 on this machine or 18 devices searched.
Unreachable (not searched): winbox, bismas-macbook-pro, gpu-box, s1, ci-runner-fsn1, box, zion, worker
```

`--devices all` (previously `unknown option '--devices'`) now resolves cleanly.

## Tests (real path, no mocking)

- `remote-agents-json.test.ts` — fan-out with an **injected ssh boundary that records abort**: one fast peer + one hanging peer → resolves on the hit, the hanging peer's `AbortSignal` fired, not marked unreachable; default (no earlyExit) waits for all; external-signal aborts all; predicate-miss waits for all.
- `sessions.test.ts` — `isDefinitiveMatch` / `selectorAllowsEarlyExit`; exact-label auto-resume past an unreachable peer; label collision → conflict; `fleetNotFoundMessage`; **local-hit-skips-SSH** (real DB via `upsertSession`, a `gatherRemoteList` dep that throws on any dial → `dialed: 0`).

`bunx tsc --noEmit` clean; affected suites (sessions, remote-list, resume, remote-agents-json ×2) **97 passing**; full `bun run test:remote` running.

## Coordination

RUSH-2022 (remote-device sessions unrecoverable) is a distinct correctness bug on the same surface — not touched here. This PR only adds cancellation/early-exit + the honest message; it does not change the `--host` router or the local-run-of-remote-session path RUSH-2022 covers.
