### PR TITLE
feat(sessions): --orphan/--active cross-harness live discovery + richer rows (RUSH-2205)

### DIFF
--- a/apps/cli/.changelog/next/rush-2205-live-discovery.md
+++ b/apps/cli/.changelog/next/rush-2205-live-discovery.md
@@ -1,0 +1,10 @@
+- **`agents sessions --orphan`/`--active`: cross-harness live discovery + richer rows (RUSH-2205).**
+  Two fixes. (1) The headless `ps`-scan recognized only 6 agent executables, so a
+  bare-headless `grok`/`kimi`/`antigravity`/`openclaw`/`hermes`/`rush` run was
+  silently dropped from the live views; the comm→kind map is now derived from
+  `SESSION_AGENTS` × the AGENTS registry (`cliCommand`), so every discoverable
+  harness surfaces. (2) Each live row now shows the agent **version** and a human
+  **created · idle** time cell, and backfills the **ticket/PR/label** from the
+  indexed session history onto orphan rows that lack them, with the label/topic on
+  its own line — grouped-by-directory layout unchanged, rows stay width-safe.
+  Source: `apps/cli/src/lib/session/active.ts`, `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/src/commands/sessions.active-row.test.ts
+++ b/apps/cli/src/commands/sessions.active-row.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { renderActiveRowLines, backfillActiveRowsFromMeta } from './sessions.js';
+import { stringWidth } from '../lib/session/width.js';
+import type { ActiveSession } from '../lib/session/active.js';
+import type { SessionMeta } from '../lib/session/types.js';
+
+/**
+ * RUSH-2205 enriched the live `--orphan`/`--active` row: agent version, a human
+ * created/idle time cell, and ticket/PR badges backfilled from the historical
+ * index, with the label/topic on its own line — all width-safe. These pin the
+ * pure row builder (content + width) and the pure meta-backfill join.
+ */
+
+const DAY = 86_400_000;
+
+function active(over: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    kind: 'claude',
+    status: 'orphaned',
+    sessionId: '2f8a96e5-1111-2222-3333-444455556666',
+    cwd: '/home/u/src/agents-cli',
+    ...over,
+  } as ActiveSession;
+}
+
+describe('renderActiveRowLines', () => {
+  it('line 1 shows version + created/idle + ticket/PR; line 2 carries the label/topic', () => {
+    const now = Date.now();
+    const s = active({
+      version: '2.1.207',
+      startedAtMs: now - (6 * DAY + 3_600_000),
+      lastActivityMs: now - (3 * DAY + 3_600_000),
+      owner: 'muqsit@getrush.ai',
+      ticket: { id: 'RUSH-2198' },
+      pr: { url: 'https://github.com/phnx-labs/agents-cli/pull/2091', number: 2091 },
+      topic: 'picker preview collapses to empty',
+    });
+    const [line1, line2] = renderActiveRowLines(s, '  ', 120);
+
+    expect(line1).toContain('2.1.207');
+    expect(line1).toContain('created 6d');
+    expect(line1).toContain('idle 3d');
+    expect(line1).toContain('RUSH-2198');
+    expect(line1).toContain('PR#2091');
+    // The label/topic is on its own line, not buried in a grey snippet.
+    expect(line2).toContain('picker preview collapses to empty');
+  });
+
+  it('keeps every line within terminal width (no wrap under tmux/SSH), even when narrow', () => {
+    const now = Date.now();
+    const s = active({
+      version: '2.1.207',
+      startedAtMs: now - 6 * DAY,
+      lastActivityMs: now - 3 * DAY,
+      owner: 'muqsit@getrush.ai',
+      ticket: { id: 'RUSH-2198' },
+      pr: { url: 'https://github.com/phnx-labs/agents-cli/pull/2091', number: 2091 },
+      topic: 'a very long topic '.repeat(20).trim(),
+    });
+    for (const termW of [40, 60, 80, 120]) {
+      for (const line of renderActiveRowLines(s, '  ', termW)) {
+        expect(stringWidth(line), `width ${termW} overflow: <${line}>`).toBeLessThanOrEqual(termW);
+      }
+    }
+  });
+
+  it('emits a single line when there is no label/topic/project/locator to show', () => {
+    // cwd cleared too: formatActiveRowDescription surfaces the project (basename cwd)
+    // when present, which would otherwise fill line 2.
+    const s = active({ topic: undefined, label: undefined, cwd: undefined, status: 'idle' });
+    expect(renderActiveRowLines(s, '  ', 120)).toHaveLength(1);
+  });
+});
+
+function meta(over: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    id: '2f8a96e5-1111-2222-3333-444455556666',
+    shortId: '2f8a96e5',
+    agent: 'claude',
+    timestamp: '2026-07-30T10:00:00.000Z',
+    filePath: '/home/u/.agents/.history/sessions/2f8a96e5.jsonl',
+    ...over,
+  };
+}
+
+describe('backfillActiveRowsFromMeta', () => {
+  it('fills version/ticket/PR/label/created onto a live row that lacks them', () => {
+    const s = active({ sessionId: 'sid-1', version: undefined, ticket: undefined, pr: undefined, label: undefined, startedAtMs: undefined });
+    const byId = new Map<string, SessionMeta>([
+      ['sid-1', meta({ id: 'sid-1', version: '2.1.207', label: 'refresh auth', ticketId: 'RUSH-2198', prUrl: 'https://github.com/o/r/pull/2091', prNumber: 2091, timestamp: '2026-07-30T10:00:00.000Z' })],
+    ]);
+    backfillActiveRowsFromMeta([s], byId);
+    expect(s.version).toBe('2.1.207');
+    expect(s.label).toBe('refresh auth');
+    expect(s.ticket?.id).toBe('RUSH-2198');
+    expect(s.pr?.number).toBe(2091);
+    expect(s.pr?.url).toContain('/pull/2091');
+    expect(s.startedAtMs).toBe(Date.parse('2026-07-30T10:00:00.000Z'));
+  });
+
+  it('never overrides a value the live row already carries (live wins)', () => {
+    const s = active({ sessionId: 'sid-2', version: '9.9.9', ticket: { id: 'LIVE-1' }, startedAtMs: 111 });
+    const byId = new Map<string, SessionMeta>([
+      ['sid-2', meta({ id: 'sid-2', version: '2.1.207', ticketId: 'RUSH-2198', timestamp: '2026-07-30T10:00:00.000Z' })],
+    ]);
+    backfillActiveRowsFromMeta([s], byId);
+    expect(s.version).toBe('9.9.9');
+    expect(s.ticket?.id).toBe('LIVE-1');
+    expect(s.startedAtMs).toBe(111);
+  });
+
+  it('leaves a row untouched when no meta matches its id', () => {
+    const s = active({ sessionId: 'sid-3', version: undefined });
+    backfillActiveRowsFromMeta([s], new Map());
+    expect(s.version).toBeUndefined();
+  });
+});

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -34,11 +34,11 @@ import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
 import { inferSessionState } from '../lib/session/state.js';
 import { discoverSessions, queryIndexedSessions, countSessionsInScope, resolveSessionById, isCompleteSessionId, looksLikeSessionId, searchContentIndex, parseTimeFilter, getSessionRoots, scopeToManaged, type DiscoverOptions, type ScanProgress } from '../lib/session/discover.js';
-import { findSessionsById, querySessions } from '../lib/session/db.js';
+import { findSessionsById, querySessions, getSessionById } from '../lib/session/db.js';
 import { filterTeamSessions, safeTeamText } from '../lib/session/team-filter.js';
 import { parseSession } from '../lib/session/parse.js';
 import { runRemoteSessions, buildForwardedArgs, ensureWholeIndex } from '../lib/session/remote.js';
-import { formatRelativeTime, sessionAgeParts, type SessionAgeParts } from '../lib/session/relative-time.js';
+import { formatRelativeTime, formatCompactAge, sessionAgeParts, type SessionAgeParts } from '../lib/session/relative-time.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, linkPath, linkUrl, shortenModel, type FilterOptions } from '../lib/session/render.js';
 import { linearIssueUrl } from '../lib/session/linear.js';
 import { renderMarkdown } from '../lib/markdown.js';
@@ -521,6 +521,56 @@ export function indexActiveBySessionId(active: ActiveSession[]): Map<string, Act
   return byId;
 }
 
+/** The SessionMeta fields the live-row backfill reads — the enrichment a running process cannot report. */
+type BackfillMeta = Pick<SessionMeta, 'version' | 'timestamp' | 'label' | 'ticketId' | 'prUrl' | 'prNumber'>;
+
+/**
+ * Backfill display-only fields onto live rows from the indexed SessionMeta, by
+ * full session id (RUSH-2205). A running process reports no agent version, and a
+ * live orphan row usually carries no ticket/PR/label/start-time; the historical
+ * index does. Only a field the live row LACKS is filled — the live signal always
+ * wins when present. Pure (no I/O) so the join is unit-tested against fixtures;
+ * the DB read that builds `metaById` is the caller's concern.
+ */
+export function backfillActiveRowsFromMeta(
+  sessions: ActiveSession[],
+  metaById: Map<string, BackfillMeta>,
+): void {
+  for (const s of sessions) {
+    if (!s.sessionId) continue;
+    const m = metaById.get(s.sessionId);
+    if (!m) continue;
+    if (!s.version && m.version) s.version = m.version;
+    if (!s.label && m.label) s.label = m.label;
+    if (!s.ticket && m.ticketId) s.ticket = { id: m.ticketId, url: linearIssueUrl(m.ticketId) };
+    if (!s.pr && m.prUrl) s.pr = { url: m.prUrl, number: m.prNumber };
+    if (!s.startedAtMs && m.timestamp) {
+      const ts = new Date(m.timestamp).getTime();
+      if (!Number.isNaN(ts)) s.startedAtMs = ts;
+    }
+  }
+}
+
+/**
+ * Build the id→meta index the live-row backfill needs, reading the historical
+ * session DB by full id. Best-effort: a missing or locked DB yields an empty map
+ * so the live view still renders (mirrors {@link maybeLiveIndex}). Deduplicates
+ * ids so N rows in one session cost one query.
+ */
+function loadBackfillMetaFor(sessions: ActiveSession[]): Map<string, BackfillMeta> {
+  const byId = new Map<string, BackfillMeta>();
+  try {
+    for (const s of sessions) {
+      if (!s.sessionId || byId.has(s.sessionId)) continue;
+      const m = getSessionById(s.sessionId);
+      if (m) byId.set(s.sessionId, m);
+    }
+  } catch {
+    /* enrichment is best-effort — an unavailable DB leaves rows un-backfilled */
+  }
+  return byId;
+}
+
 /**
  * The live decoration for a listing row: a status glyph and the latest-turn
  * preview, when the session is still running. `●` running / `◐` waiting on the
@@ -722,30 +772,84 @@ function locatorBadge(s: ActiveSession): string {
 }
 
 /**
- * Render a single agent-session row inside an already-printed group header.
- * Indent is the leading whitespace (2 spaces for flat groups, 4 inside a
- * window sub-group). Leads with the 8-char session id (the address to read or
- * resume it); status, badges, and the live preview fill the rest, sized to the
- * terminal width so the row never wraps.
+ * The `created X · idle Y` time cell for a live row (RUSH-2205). `created` is the
+ * age of the session start ({@link ActiveSession.startedAtMs}); `idle` is the age
+ * of the last transcript write ({@link ActiveSession.lastActivityMs}) — i.e. how
+ * long it has been quiet. Compact ("6d", "3h", "now") so the row stays width-safe;
+ * either half is omitted when its epoch is unknown.
  */
-function printActiveRow(s: ActiveSession, indent: string): void {
-  // shortId (8-char) · agent · host · status · owner · badges · identity+todos+snippet
-  const idCol = chalk.dim(padToWidth((s.sessionId?.slice(0, 8)) ?? '-', 9));
-  const kindCol = colorAgent(s.kind as any)(padToWidth(truncateToWidth(s.kind, 8), 9));
-  const hostCol = chalk.gray(padToWidth(truncateToWidth(s.host ?? '-', 8), 9));
-  const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), 8), 9));
-  const ownerCol = chalk.cyan(padToWidth(truncateToWidth(ownerLabel(s), 8), 9));
+function activeTimeCell(s: ActiveSession): string {
+  const parts: string[] = [];
+  if (s.startedAtMs) parts.push(`created ${formatCompactAge(new Date(s.startedAtMs).toISOString())}`);
+  if (s.lastActivityMs) parts.push(`idle ${formatCompactAge(new Date(s.lastActivityMs).toISOString())}`);
+  return parts.join(' · ');
+}
+
+/** Column widths for line 1 of an active row (id · agent · version · status · owner). */
+const ROW_ID_W = 9;
+const ROW_AGENT_W = 8;
+const ROW_VERSION_W = 8;
+const ROW_STATUS_W = 9;
+const ROW_OWNER_W = 9;
+
+/**
+ * Build the (one or two) rendered lines for a single active-session row.
+ * Indent is the leading whitespace (2 spaces for flat groups, 4 inside a window
+ * sub-group). Sized to `termW` so no line ever wraps under tmux/SSH (RUSH-2205):
+ *
+ *   line 1: id · agent version · status · owner · created X · idle Y · ticket/PR
+ *   line 2: └ label/topic (+ checklist) · jump locator (ssh/tmux/detached)
+ *
+ * The label/topic gets its own line so it is no longer buried in a truncated grey
+ * snippet, and the actionable ticket/PR badges ride line 1. Version and the
+ * ticket/PR/label are backfilled onto the {@link ActiveSession} from the indexed
+ * SessionMeta before this renders (a live process reports none of them). Pure +
+ * exported so the row layout is unit-tested for content and width without a
+ * captured stdout.
+ */
+export function renderActiveRowLines(s: ActiveSession, indent: string, termW: number): string[] {
+  const idCol = chalk.dim(padToWidth((s.sessionId?.slice(0, 8)) ?? '-', ROW_ID_W));
+  const kindCol = colorAgent(s.kind as any)(padToWidth(truncateToWidth(s.kind, ROW_AGENT_W), ROW_AGENT_W + 1));
+  const versionCol = chalk.gray(padToWidth(truncateToWidth(s.version ?? '', ROW_VERSION_W), ROW_VERSION_W + 1));
+  const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), ROW_STATUS_W - 1), ROW_STATUS_W));
+  const ownerCol = chalk.cyan(padToWidth(truncateToWidth(ownerLabel(s), ROW_OWNER_W - 1), ROW_OWNER_W));
+  const fixedW = stringWidth(indent) + ROW_ID_W + (ROW_AGENT_W + 1) + (ROW_VERSION_W + 1) + ROW_STATUS_W + ROW_OWNER_W;
+
+  // Line 1 right side: time cell + actionable badges (fork count, plan/ask/perm,
+  // ticket, PR, worktree). Badges are the jump-to-work signal, so they win the
+  // width fight — the time cell is truncated to whatever is left before them.
   const fork = s.pidCount && s.pidCount > 1 ? chalk.dim(`×${s.pidCount} `) : '';
-  const badges = (fork ? fork : '') + [signalBadges(s), locatorBadge(s)].filter(Boolean).join(' ');
-  // Identity (label/project/ticket clickable) + checklist + live snippet.
-  // Cross-machine rows use the same path — remote ActiveSession fields arrive
-  // via the SSH fan-out already populated (including todos when the peer has them).
-  const desc = formatActiveRowDescription(s) || '-';
-  // Fill the remaining width with the preview so nothing wraps under tmux/SSH.
-  const fixed = stringWidth(indent) + 9 + 9 + 9 + 9 + 9 + (badges ? stringWidth(badges) + 1 : 0);
-  const room = Math.max(12, terminalWidth() - fixed - 1);
-  const descCol = chalk.white(truncateToWidth(desc, room));
-  console.log(indent + idCol + kindCol + hostCol + statusCol + ownerCol + (badges ? badges + ' ' : '') + descCol);
+  const badges = fork + signalBadges(s);
+  const badgesW = badges ? stringWidth(badges) : 0;
+  const remaining = Math.max(0, termW - fixedW - 1);
+  const timeRoom = Math.max(0, remaining - (badgesW ? badgesW + 2 : 0));
+  const timeCell = chalk.gray(truncateToWidth(activeTimeCell(s), timeRoom));
+  let right = timeCell;
+  if (badges) right += (stringWidth(timeCell) ? '  ' : '') + badges;
+  right = truncateToWidth(right, remaining);
+  // Final whole-line clamp so even a terminal narrower than the fixed columns
+  // truncates rather than wraps (no-wrap guarantee at any width).
+  const lines = [truncateToWidth(indent + idCol + kindCol + versionCol + statusCol + ownerCol + right, termW)];
+
+  // Line 2: label/topic + checklist (the identity, no longer buried) then the
+  // jump locator. Skipped entirely when there is nothing to say.
+  const desc = formatActiveRowDescription(s);
+  const loc = locatorBadge(s);
+  if (!desc && !loc) return lines;
+  const contIndent = indent + ' '.repeat(ROW_ID_W);
+  const room2 = Math.max(8, termW - stringWidth(contIndent) - 2);
+  const locW = loc ? stringWidth(loc) : 0;
+  const descRoom = Math.max(6, room2 - (locW ? locW + 2 : 0));
+  const descCol = chalk.white(truncateToWidth(desc || '-', descRoom));
+  let line2 = contIndent + chalk.dim('└ ') + descCol;
+  if (loc) line2 += '  ' + loc;
+  lines.push(truncateToWidth(line2, termW));
+  return lines;
+}
+
+/** Render a single agent-session row inside an already-printed group header. */
+function printActiveRow(s: ActiveSession, indent: string): void {
+  for (const line of renderActiveRowLines(s, indent, terminalWidth())) console.log(line);
 }
 
 /**
@@ -1258,6 +1362,13 @@ async function renderActiveSessions(
     ? merged.filter((session) => opts.statuses!.some((status) => matchesLiveStatus(session, status)))
     : merged;
   const sessions = statusFiltered;
+
+  // Backfill agent version + ticket/PR/label/created onto the live rows from the
+  // historical index (RUSH-2205) — a running process reports none of these, and
+  // an orphan row usually lacks them. Done before both the JSON and human paths
+  // so every consumer (incl. the SSH fan-out's remote --json) sees enriched rows;
+  // transcripts sync across the fleet, so a remote row resolves from the local DB.
+  backfillActiveRowsFromMeta(sessions, loadBackfillMetaFor(sessions));
 
   if (asJson) {
     // Resolve who is watching each local tmux pane before serializing: `viewingIn`

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -793,6 +793,21 @@ const ROW_STATUS_W = 9;
 const ROW_OWNER_W = 9;
 
 /**
+ * Fit pre-styled content (which may carry SGR colour AND OSC-8 hyperlinks — the
+ * clickable ticket/PR/project badges) into `room` display cells. Returns it raw
+ * when it already fits, preserving colour and clickable links; otherwise falls
+ * back to a width-safe truncation. `truncateToWidth` strips OSC-8 before cutting
+ * (see width.ts), so a too-narrow cell drops the hyperlink cleanly rather than
+ * slicing a hyperlink escape in half and corrupting the terminal (RUSH-2205
+ * review). Never run pre-linked content through `truncateToWidth` directly — that
+ * strips its links even when it fits; go through this helper.
+ */
+function fitCell(content: string, room: number): string {
+  if (room <= 0) return '';
+  return stringWidth(content) <= room ? content : truncateToWidth(content, room);
+}
+
+/**
  * Build the (one or two) rendered lines for a single active-session row.
  * Indent is the leading whitespace (2 spaces for flat groups, 4 inside a window
  * sub-group). Sized to `termW` so no line ever wraps under tmux/SSH (RUSH-2205):
@@ -813,37 +828,44 @@ export function renderActiveRowLines(s: ActiveSession, indent: string, termW: nu
   const versionCol = chalk.gray(padToWidth(truncateToWidth(s.version ?? '', ROW_VERSION_W), ROW_VERSION_W + 1));
   const statusCol = statusColor(s.status)(padToWidth(truncateToWidth(activityLabel(s), ROW_STATUS_W - 1), ROW_STATUS_W));
   const ownerCol = chalk.cyan(padToWidth(truncateToWidth(ownerLabel(s), ROW_OWNER_W - 1), ROW_OWNER_W));
+  const fixedCols = idCol + kindCol + versionCol + statusCol + ownerCol;
   const fixedW = stringWidth(indent) + ROW_ID_W + (ROW_AGENT_W + 1) + (ROW_VERSION_W + 1) + ROW_STATUS_W + ROW_OWNER_W;
-
-  // Line 1 right side: time cell + actionable badges (fork count, plan/ask/perm,
-  // ticket, PR, worktree). Badges are the jump-to-work signal, so they win the
-  // width fight — the time cell is truncated to whatever is left before them.
-  const fork = s.pidCount && s.pidCount > 1 ? chalk.dim(`×${s.pidCount} `) : '';
-  const badges = fork + signalBadges(s);
-  const badgesW = badges ? stringWidth(badges) : 0;
   const remaining = Math.max(0, termW - fixedW - 1);
+
+  // Line 1 right side: created/idle time + actionable badges (fork count,
+  // plan/ask/perm, ticket, PR, worktree). Badges are the jump-to-work signal, so
+  // they win the width fight — fitCell keeps them raw+clickable when they fit and
+  // drops the link cleanly when narrow; the time cell takes whatever is left.
+  const fork = s.pidCount && s.pidCount > 1 ? chalk.dim(`×${s.pidCount} `) : '';
+  const badgesCell = fitCell(fork + signalBadges(s), remaining);
+  const badgesW = stringWidth(badgesCell);
   const timeRoom = Math.max(0, remaining - (badgesW ? badgesW + 2 : 0));
   const timeCell = chalk.gray(truncateToWidth(activeTimeCell(s), timeRoom));
   let right = timeCell;
-  if (badges) right += (stringWidth(timeCell) ? '  ' : '') + badges;
-  right = truncateToWidth(right, remaining);
-  // Final whole-line clamp so even a terminal narrower than the fixed columns
-  // truncates rather than wraps (no-wrap guarantee at any width).
-  const lines = [truncateToWidth(indent + idCol + kindCol + versionCol + statusCol + ownerCol + right, termW)];
+  if (badgesCell) right += (stringWidth(timeCell) ? '  ' : '') + badgesCell;
+  // right's visible width is <= remaining by construction, so the assembled line
+  // is <= termW-1 whenever the fixed columns fit; the clamp only bites a terminal
+  // narrower than the fixed columns (where right is empty — no link to corrupt).
+  let line1 = indent + fixedCols + right;
+  if (stringWidth(line1) > termW) line1 = truncateToWidth(line1, termW);
+  const lines = [line1];
 
   // Line 2: label/topic + checklist (the identity, no longer buried) then the
-  // jump locator. Skipped entirely when there is nothing to say.
+  // jump locator. Skipped entirely when there is nothing to say. desc may carry a
+  // clickable project link, so it also goes through fitCell.
   const desc = formatActiveRowDescription(s);
   const loc = locatorBadge(s);
   if (!desc && !loc) return lines;
   const contIndent = indent + ' '.repeat(ROW_ID_W);
-  const room2 = Math.max(8, termW - stringWidth(contIndent) - 2);
-  const locW = loc ? stringWidth(loc) : 0;
-  const descRoom = Math.max(6, room2 - (locW ? locW + 2 : 0));
-  const descCol = chalk.white(truncateToWidth(desc || '-', descRoom));
-  let line2 = contIndent + chalk.dim('└ ') + descCol;
-  if (loc) line2 += '  ' + loc;
-  lines.push(truncateToWidth(line2, termW));
+  const room2 = Math.max(0, termW - stringWidth(contIndent) - 2);
+  const locCell = fitCell(loc, room2);
+  const locW = stringWidth(locCell);
+  const descRoom = Math.max(0, room2 - (locW ? locW + 2 : 0));
+  const descCell = chalk.white(fitCell(desc || '-', descRoom));
+  let line2 = contIndent + chalk.dim('└ ') + descCell;
+  if (locCell) line2 += '  ' + locCell;
+  if (stringWidth(line2) > termW) line2 = truncateToWidth(line2, termW);
+  lines.push(line2);
   return lines;
 }
 

--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels, summarizeMission } from './active.js';
+import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, sessionAgentComms, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels, summarizeMission } from './active.js';
+import { SESSION_AGENTS } from './types.js';
 import type { HookSessionIndex } from './hook-sessions.js';
 import type { DeviceProfile, DeviceRegistry } from '../devices/registry.js';
 
@@ -179,6 +180,32 @@ describe('agentKindFromComm', () => {
 
   it('does NOT match the Claude desktop app (named Claude, not the CLI claude)', () => {
     expect(agentKindFromComm('/Applications/Claude.app/Contents/MacOS/Claude')).toBeUndefined();
+  });
+
+  // Harness-parity regression guard (RUSH-2205): every SESSION_AGENTS member must
+  // resolve from at least one process comm name, so a bare-headless run of any
+  // discoverable harness (grok/kimi/antigravity/openclaw/hermes/rush) is never
+  // silently dropped by the ps-scan. Asserted off the registry-derived source so
+  // adding a SESSION_AGENT without a comm fails here instead of at runtime.
+  it('resolves every SESSION_AGENTS member to its id via at least one comm', () => {
+    for (const id of SESSION_AGENTS) {
+      const comms = sessionAgentComms(id);
+      expect(comms.length, `${id} has no process comm name`).toBeGreaterThan(0);
+      for (const comm of comms) {
+        expect(agentKindFromComm(comm), `${id} comm '${comm}' unresolved`).toBe(id);
+      }
+    }
+  });
+
+  it('recognizes the previously-dropped headless harnesses', () => {
+    // These six were the AGENT_CLI_NAMES gap before RUSH-2205 — `if (!kind) continue`
+    // silently dropped their headless processes from --orphan/--active.
+    expect(agentKindFromComm('grok')).toBe('grok');
+    expect(agentKindFromComm('kimi')).toBe('kimi');
+    expect(agentKindFromComm('agy')).toBe('antigravity');
+    expect(agentKindFromComm('openclaw')).toBe('openclaw');
+    expect(agentKindFromComm('hermes')).toBe('hermes');
+    expect(agentKindFromComm('rush')).toBe('rush');
   });
 });
 

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -36,7 +36,8 @@ import { readSessionTailWithRaw } from './tail.js';
 import { parseSession } from './parse.js';
 import { computeTokPerSec } from './throughput.js';
 import { inferSessionState, type SessionState, type SessionActivity, type AwaitingReason, type StructuredQuestion, type TodoProgress, type DetectedPr, type DetectedWorktree, type DetectedTicket } from './state.js';
-import { isSessionTrackedAgent, type SessionAgentId, type SessionAttachment, type SessionEvent } from './types.js';
+import { isSessionTrackedAgent, SESSION_AGENTS, type SessionAgentId, type SessionAttachment, type SessionEvent } from './types.js';
+import { AGENTS } from '../agents.js';
 import { detectProvenance, type SessionProvenance } from './provenance.js';
 import { loadDevices, type DeviceRegistry } from '../devices/registry.js';
 import { presenceFromStore, type Presence } from './detached.js';
@@ -173,6 +174,13 @@ export interface ActiveSession {
   attachments?: SessionAttachment[];
   sessionFile?: string;
   startedAtMs?: number;
+  /**
+   * Agent version (e.g. `2.1.207`) for the row's `agent version` cell. Not a
+   * live-scan signal — a running process does not report its own semver — so it
+   * is backfilled at render time from the indexed {@link SessionMeta} by session
+   * id (RUSH-2205), never asserted by a source.
+   */
+  version?: string;
   /**
    * Last-activity epoch — the transcript's last write (mtime). Distinct from
    * {@link startedAtMs} (session START): a session begun 3h ago but last touched
@@ -405,15 +413,46 @@ export const ABANDONED_STALE_MS = 2 * 24 * 60 * 60_000;
  */
 const TMUX_FIELD_SEP = ':';
 
-/** Executables we recognize as agent CLIs when scanning the process table. */
-const AGENT_CLI_NAMES: Record<string, string> = {
-  claude: 'claude',
-  codex: 'codex',
-  gemini: 'gemini',
-  'cursor-agent': 'cursor',
-  opencode: 'opencode',
-  droid: 'droid',
+/**
+ * Process comm names that are NOT derivable from the AGENTS registry's
+ * `cliCommand`. `rush` is a {@link SESSION_AGENTS} member with no AGENTS registry
+ * row (it is the Rush app, not a managed harness), so its executable name is
+ * mapped explicitly here. Everything else flows from the registry below.
+ */
+const EXTRA_SESSION_AGENT_COMMS: Partial<Record<SessionAgentId, string[]>> = {
+  rush: ['rush'],
 };
+
+/**
+ * Every process executable ("comm") name that identifies a given session-agent
+ * kind in the headless `ps`-scan. Driven off the AGENTS registry's `cliCommand`
+ * (the real executable name — e.g. `agy` for antigravity, `cursor-agent` for
+ * cursor) plus {@link EXTRA_SESSION_AGENT_COMMS} for members with no registry
+ * row. Exported so the completeness test can assert every {@link SESSION_AGENTS}
+ * member resolves — the fix for the harness-parity gap where bare-headless
+ * grok/kimi/antigravity/openclaw/hermes/rush were silently dropped.
+ */
+export function sessionAgentComms(id: SessionAgentId): string[] {
+  const comms = new Set<string>();
+  const cli = (AGENTS as Record<string, { cliCommand?: string }>)[id]?.cliCommand;
+  if (cli) comms.add(cli);
+  for (const extra of EXTRA_SESSION_AGENT_COMMS[id] ?? []) comms.add(extra);
+  return [...comms];
+}
+
+/**
+ * Executables we recognize as agent CLIs when scanning the process table. Built
+ * once from {@link sessionAgentComms} across {@link SESSION_AGENTS} — a single
+ * derived source, not a second hand-maintained allowlist that drifts from the
+ * discovery surface (the harness-parity code-review rule).
+ */
+const AGENT_CLI_NAMES: Record<string, SessionAgentId> = (() => {
+  const map: Record<string, SessionAgentId> = {};
+  for (const id of SESSION_AGENTS) {
+    for (const comm of sessionAgentComms(id)) map[comm] = id;
+  }
+  return map;
+})();
 
 /**
  * Resolve an agent kind from a process's reported executable. `comm` may be an

--- a/apps/cli/src/lib/session/width.test.ts
+++ b/apps/cli/src/lib/session/width.test.ts
@@ -27,6 +27,33 @@ describe('stringWidth', () => {
   });
 });
 
+describe('OSC-8 hyperlinks (RUSH-2205)', () => {
+  // osc8() form: ESC ]8;;<url> ESC \ <label> ESC ]8;; ESC \  — the URL is not
+  // visible, so a clickable RUSH-2205 badge must measure as its 9-char label and
+  // never be sliced mid-escape by truncateToWidth.
+  const link = '\x1b]8;;https://linear.app/x/issue/RUSH-2205\x1b\\RUSH-2205\x1b]8;;\x1b\\';
+
+  it('measures only the visible label, not the URL', () => {
+    expect(stringWidth(link)).toBe(9);
+    expect(stripAnsi(link)).toBe('RUSH-2205');
+  });
+
+  it('handles the BEL-terminated variant', () => {
+    const bel = '\x1b]8;;https://x\x07label\x1b]8;;\x07';
+    expect(stringWidth(bel)).toBe(5);
+    expect(stripAnsi(bel)).toBe('label');
+  });
+
+  it('truncates without leaving a corrupted (unterminated) escape', () => {
+    // A badge + trailing text truncated to below the label: the result must carry
+    // no partial OSC-8 opener (the corruption bug this fixes).
+    const out = truncateToWidth(link + ' idle 3h', 6);
+    expect(stringWidth(out)).toBeLessThanOrEqual(6);
+    // stripAnsi removes complete escapes; any residual ESC means a cut mid-sequence.
+    expect(stripAnsi(out)).not.toContain('\x1b');
+  });
+});
+
 describe('truncateToWidth', () => {
   it('leaves short strings untouched', () => {
     expect(truncateToWidth('short', 10)).toBe('short');

--- a/apps/cli/src/lib/session/width.ts
+++ b/apps/cli/src/lib/session/width.ts
@@ -12,9 +12,20 @@
 /** SGR colour sequences emitted by chalk (e.g. `\x1b[32m`). */
 const SGR_REGEX = /\x1b\[[0-9;]*m/g;
 
-/** Strip SGR colour escapes so width is measured on visible characters only. */
+/**
+ * OSC-8 hyperlink sequences (`\x1b]8;;<url>\x1b\\` … `\x1b]8;;\x1b\\`, or with a
+ * BEL `\x07` terminator) emitted by `osc8()` in render.ts for clickable
+ * ticket/PR/path badges. These carry the URL, which is NOT visible — leaving it
+ * in over-counts width and, worse, lets a truncation land *inside* the escape and
+ * corrupt it. Stripping both the opener and closer leaves only the visible label
+ * between them, so width is measured on what the user sees and `truncateToWidth`
+ * can never cut a hyperlink in half.
+ */
+const OSC8_REGEX = /\x1b\]8;[^;]*;.*?(?:\x1b\\|\x07)/g;
+
+/** Strip SGR colour + OSC-8 hyperlink escapes so width is measured on visible characters only. */
 export function stripAnsi(s: string): string {
-  return s.replace(SGR_REGEX, '');
+  return s.replace(OSC8_REGEX, '').replace(SGR_REGEX, '');
 }
 
 /**

--- a/packages/session-tracker/AGENTS.md
+++ b/packages/session-tracker/AGENTS.md
@@ -29,7 +29,7 @@ src/types.ts         SessionState, AgentId, DetectionMethod, LookupInput
 src/state-file.ts    STATE_DIR (canonical path), stateFilePath(), writeStateAtomic(), parseState()
 src/writer.ts        recordSession() / clearSession()
 src/reader.ts        descendantPids(), findStateByPid/InTree/ByTerminalId/ByLaunchId, pruneStaleSessionState()
-src/install-hook.ts  installHookFor(agent) — writes the hook into per-agent native config (idempotent)
+src/install-hook.ts  installHookFor(agent) — declarative HOOK_SUPPORT table; writes the hook into per-agent native config (idempotent)
 src/adapters/        Ground-truth test helpers (claude snapshot/await-new-session)
 tests/scenarios/     cold-spawn (50×, ≥99%) + kill-restart (20×, stale-entry regression)
 ```

--- a/packages/session-tracker/README.md
+++ b/packages/session-tracker/README.md
@@ -65,8 +65,18 @@ bun run install-hook claude codex cursor grok
 ```
 
 `install-hook.ts` writes into each harness's native config (Claude
-`settings.json`, Codex/Cursor `hooks.json`, Grok `hooks/session-start.json`) and is
-**idempotent** — prior registrations of this package's `hook.sh` are stripped first.
+`settings.json`, Codex/Cursor `hooks.json`, Grok `hooks/session-start.json`, Droid
+`.factory/settings.json`, Kimi `.kimi-code/config.toml`, Hermes `.hermes/config.yaml`
+`on_session_start`) and is **idempotent** — prior registrations of this package's
+`hook.sh` are stripped first.
+
+Support is a declarative capability table (`HOOK_SUPPORT` in `src/install-hook.ts`),
+not a hardcoded switch: every agent either has an installer or returns a **specific**
+reason it can't host the writer hook (gemini is deprecated; antigravity has no
+SessionStart event; opencode's SessionStart is a generated plugin, not a shell hook)
+— never an opaque "not yet implemented". `openclaw`/`rush` have no writable native
+SessionStart hook host, so they are out of scope for the writer; their headless rows
+still surface via the CLI's discovery comm-map.
 
 ## Build & test
 

--- a/packages/session-tracker/bun.lock
+++ b/packages/session-tracker/bun.lock
@@ -6,6 +6,7 @@
       "name": "@agents/session-tracker",
       "dependencies": {
         "smol-toml": "^1.4.2",
+        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -211,6 +212,8 @@
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/packages/session-tracker/package.json
+++ b/packages/session-tracker/package.json
@@ -16,7 +16,8 @@
     "install-hook": "tsx src/install-hook.ts"
   },
   "dependencies": {
-    "smol-toml": "^1.4.2"
+    "smol-toml": "^1.4.2",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/session-tracker/src/hook.sh
+++ b/packages/session-tracker/src/hook.sh
@@ -5,6 +5,7 @@
 # Each agent passes the hook payload differently:
 #   - claude/codex/cursor: JSON on stdin with session_id (+conversation_id for cursor)
 #   - grok: GROK_SESSION_ID and GROK_WORKSPACE_ROOT env vars
+#   - hermes: JSON on stdin (on_session_start payload); best-effort field probe
 #   - gemini/antigravity: TBD — add branches below as upstream payloads land
 #
 # Writes ~/.agents/.cache/terminals/sessions/<PPID>.json with the canonical
@@ -66,8 +67,9 @@ case "$AGENT" in
     CWD="${GROK_WORKSPACE_ROOT:-$PWD}"
     METHOD="hook-env"
     ;;
-  gemini|antigravity)
-    # Try stdin JSON first (covers most cases); fall through if empty.
+  hermes|gemini|antigravity)
+    # Best-effort stdin-JSON probe across the field names these harnesses use.
+    # A miss exits 0 below (no state file) — never a wrong write.
     SID="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'session_id conversation_id sessionId')"
     CWD="$(printf '%s' "$STDIN_JSON" | extract_stdin_json 'cwd workspace_roots')"
     ;;

--- a/packages/session-tracker/src/install-hook.ts
+++ b/packages/session-tracker/src/install-hook.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import * as TOML from 'smol-toml';
+import * as YAML from 'yaml';
 import type { AgentId } from './types.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -172,32 +173,87 @@ async function installKimi(opts: InstallOptions): Promise<InstallResult> {
   return { agent: 'kimi', installed: true, configPath };
 }
 
+async function installHermes(opts: InstallOptions): Promise<InstallResult> {
+  const configPath = path.join(os.homedir(), '.hermes', 'config.yaml');
+  const command = hookCommand('hermes', opts);
+  if (opts.dryRun) return { agent: 'hermes', installed: false, configPath };
+  // Read-modify-write the YAML, preserving every sibling key (mcp_servers, …) —
+  // mirrors the CLI's registerHooksForHermes. Hermes maps SessionStart to the
+  // `on_session_start` event (HERMES_EVENT_MAP in apps/cli/src/lib/hooks.ts).
+  let cfg: Record<string, unknown> = {};
+  try {
+    const parsed = YAML.parse(await fs.promises.readFile(configPath, 'utf8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) cfg = parsed as Record<string, unknown>;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  const hooks =
+    cfg.hooks && typeof cfg.hooks === 'object' && !Array.isArray(cfg.hooks)
+      ? (cfg.hooks as Record<string, Array<Record<string, unknown>>>)
+      : {};
+  const existing = Array.isArray(hooks.on_session_start) ? hooks.on_session_start : [];
+  hooks.on_session_start = [
+    ...existing.filter(
+      (h) => !(typeof h?.command === 'string' && h.command.includes('packages/session-tracker/src/hook.sh')),
+    ),
+    { command, timeout: 5 },
+  ];
+  cfg.hooks = hooks;
+  await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.promises.writeFile(configPath, YAML.stringify(cfg), 'utf8');
+  return { agent: 'hermes', installed: true, configPath };
+}
+
+/**
+ * Per-agent support for the SessionStart state-writer hook — the single source of
+ * truth, replacing a hardcoded switch whose `default` lumped "not wired up yet"
+ * together with "genuinely can't host it" under one opaque "not yet implemented"
+ * (RUSH-2205). Keyed by {@link AgentId}, so TypeScript forces an entry for every
+ * agent and the completeness test can assert each is either installable or carries
+ * a specific reason. The writer needs BOTH a native SessionStart hook the tracker
+ * can write AND a `hook.sh` branch that parses the harness's payload:
+ *
+ *   - gemini      — hard-deprecated; kept only for parsing old sessions/config.
+ *   - antigravity — its native config has no SessionStart event (only
+ *                   before_tool_call / after_model_call / on_loop_stop / on_error).
+ *   - opencode    — SessionStart is delivered by a generated TS plugin
+ *                   (session.created), not a shell-command hook this tracker emits.
+ *
+ * openclaw and rush are absent from this package's {@link AgentId} entirely — the
+ * former has no native SessionStart hook host, the latter is the Rush app, not a
+ * hook-bearing harness — so the writer cannot reach them at all. Their headless
+ * rows still surface via the discovery comm-map (apps/cli/src/lib/session/active.ts).
+ */
+type HookSupport =
+  | { install: (opts: InstallOptions) => Promise<InstallResult> }
+  | { unsupported: string };
+
+const HOOK_SUPPORT: Record<AgentId, HookSupport> = {
+  claude: { install: installClaude },
+  codex: { install: installCodex },
+  cursor: { install: installCursor },
+  grok: { install: installGrok },
+  droid: { install: installDroid },
+  kimi: { install: installKimi },
+  hermes: { install: installHermes },
+  gemini: { unsupported: 'gemini is hard-deprecated (kept only for parsing old sessions)' },
+  antigravity: { unsupported: 'antigravity has no SessionStart hook event' },
+  opencode: { unsupported: 'opencode SessionStart is a generated plugin, not a shell-command hook' },
+};
+
 export async function installHookFor(
   agent: AgentId,
   opts: InstallOptions = {},
 ): Promise<InstallResult> {
+  const support = HOOK_SUPPORT[agent];
+  if (!support) {
+    return { agent, installed: false, configPath: '', error: `unknown agent '${agent}'` };
+  }
+  if ('unsupported' in support) {
+    return { agent, installed: false, configPath: '', error: support.unsupported };
+  }
   try {
-    switch (agent) {
-      case 'claude':
-        return await installClaude(opts);
-      case 'codex':
-        return await installCodex(opts);
-      case 'cursor':
-        return await installCursor(opts);
-      case 'grok':
-        return await installGrok(opts);
-      case 'droid':
-        return await installDroid(opts);
-      case 'kimi':
-        return await installKimi(opts);
-      default:
-        return {
-          agent,
-          installed: false,
-          configPath: '',
-          error: `installation for ${agent} not yet implemented`,
-        };
-    }
+    return await support.install(opts);
   } catch (err) {
     return {
       agent,

--- a/packages/session-tracker/src/install-hook.ts
+++ b/packages/session-tracker/src/install-hook.ts
@@ -241,6 +241,10 @@ const HOOK_SUPPORT: Record<AgentId, HookSupport> = {
   opencode: { unsupported: 'opencode SessionStart is a generated plugin, not a shell-command hook' },
 };
 
+/** Every agent id the hook installer knows — the keys of the compile-time-complete
+ *  {@link HOOK_SUPPORT} table (Record<AgentId, …>), so this can never drift from AgentId. */
+export const HOOK_AGENTS = Object.keys(HOOK_SUPPORT) as AgentId[];
+
 export async function installHookFor(
   agent: AgentId,
   opts: InstallOptions = {},

--- a/packages/session-tracker/src/types.ts
+++ b/packages/session-tracker/src/types.ts
@@ -7,7 +7,8 @@ export type AgentId =
   | 'kimi'
   | 'droid'
   | 'antigravity'
-  | 'opencode';
+  | 'opencode'
+  | 'hermes';
 
 export interface TrackSpawnInput {
   agent: AgentId;

--- a/packages/session-tracker/tests/install-hook.test.ts
+++ b/packages/session-tracker/tests/install-hook.test.ts
@@ -4,8 +4,22 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as TOML from 'smol-toml';
+import * as YAML from 'yaml';
+import { installHookFor } from '../src/install-hook.js';
+import type { AgentId } from '../src/types.js';
 
 const roots: string[] = [];
+
+function tmpHome(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'session-tracker-install-'));
+  roots.push(root);
+  return root;
+}
+
+/** Every agent this package's AgentId admits — the surface the completeness test pins. */
+const ALL_AGENTS: AgentId[] = [
+  'claude', 'codex', 'gemini', 'cursor', 'grok', 'kimi', 'droid', 'antigravity', 'opencode', 'hermes',
+];
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
@@ -13,8 +27,7 @@ afterEach(() => {
 
 describe('session tracker hook installation', () => {
   it('registers Droid and Kimi SessionStart hooks in their native config formats', () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'session-tracker-install-'));
-    roots.push(root);
+    const root = tmpHome();
     const result = spawnSync('bunx', ['tsx', 'src/install-hook.ts', 'droid', 'kimi'], {
       cwd: path.join(import.meta.dirname, '..'),
       env: { ...process.env, HOME: root },
@@ -28,5 +41,64 @@ describe('session tracker hook installation', () => {
     const kimi = TOML.parse(fs.readFileSync(path.join(root, '.kimi-code', 'config.toml'), 'utf8')) as any;
     expect(kimi.hooks).toContainEqual(expect.objectContaining({ event: 'SessionStart' }));
     expect(kimi.hooks[0].command).toContain('hook.sh kimi');
+  });
+
+  // RUSH-2205: hermes is newly covered by the writer. Its native config is
+  // ~/.hermes/config.yaml, SessionStart -> `on_session_start`, read-modify-write
+  // so sibling keys (mcp_servers) survive. os.homedir() honours $HOME on POSIX.
+  it('registers the Hermes SessionStart hook in config.yaml, preserving siblings', async () => {
+    const root = tmpHome();
+    const configPath = path.join(root, '.hermes', 'config.yaml');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, YAML.stringify({ mcp_servers: { demo: { command: 'x' } } }), 'utf8');
+
+    const prevHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      const r = await installHookFor('hermes');
+      expect(r.installed, r.error).toBe(true);
+      expect(r.configPath).toBe(configPath);
+
+      const cfg = YAML.parse(fs.readFileSync(configPath, 'utf8')) as any;
+      // The managed hook landed under on_session_start...
+      expect(cfg.hooks.on_session_start[0].command).toContain('hook.sh hermes');
+      // ...and the pre-existing sibling key was preserved, not clobbered.
+      expect(cfg.mcp_servers.demo.command).toBe('x');
+
+      // Idempotent: a second install does not duplicate the managed entry.
+      await installHookFor('hermes');
+      const cfg2 = YAML.parse(fs.readFileSync(configPath, 'utf8')) as any;
+      const managed = cfg2.hooks.on_session_start.filter((h: any) =>
+        String(h.command).includes('packages/session-tracker/src/hook.sh'),
+      );
+      expect(managed.length).toBe(1);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+    }
+  });
+
+  // Truthfulness guard (RUSH-2205): no AgentId falls through to a generic
+  // "not yet implemented". Every agent either installs successfully or returns a
+  // SPECIFIC reason it genuinely cannot host the writer hook.
+  it('every AgentId is either installable or carries a specific unsupported reason', async () => {
+    const root = tmpHome();
+    const prevHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      for (const agent of ALL_AGENTS) {
+        const r = await installHookFor(agent, { dryRun: true });
+        if (r.configPath) {
+          // Installable agents resolve a real native config path (even on dry-run).
+          expect(r.configPath, `${agent} should resolve a config path`).toBeTruthy();
+        } else {
+          expect(r.error, `${agent} must state a reason`).toBeTruthy();
+          expect(r.error, `${agent} must not use the generic fallback`).not.toContain('not yet implemented');
+        }
+      }
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+    }
   });
 });

--- a/packages/session-tracker/tests/install-hook.test.ts
+++ b/packages/session-tracker/tests/install-hook.test.ts
@@ -5,8 +5,7 @@ import os from 'os';
 import path from 'path';
 import * as TOML from 'smol-toml';
 import * as YAML from 'yaml';
-import { installHookFor } from '../src/install-hook.js';
-import type { AgentId } from '../src/types.js';
+import { installHookFor, HOOK_AGENTS } from '../src/install-hook.js';
 
 const roots: string[] = [];
 
@@ -15,11 +14,6 @@ function tmpHome(): string {
   roots.push(root);
   return root;
 }
-
-/** Every agent this package's AgentId admits — the surface the completeness test pins. */
-const ALL_AGENTS: AgentId[] = [
-  'claude', 'codex', 'gemini', 'cursor', 'grok', 'kimi', 'droid', 'antigravity', 'opencode', 'hermes',
-];
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
@@ -86,7 +80,8 @@ describe('session tracker hook installation', () => {
     const prevHome = process.env.HOME;
     process.env.HOME = root;
     try {
-      for (const agent of ALL_AGENTS) {
+      expect(HOOK_AGENTS.length).toBeGreaterThanOrEqual(10);
+      for (const agent of HOOK_AGENTS) {
         const r = await installHookFor(agent, { dryRun: true });
         if (r.configPath) {
           // Installable agents resolve a real native config path (even on dry-run).


### PR DESCRIPTION
**feat(sessions)** — `agents sessions --orphan`/`--active`: cross-harness live discovery + richer rows. Fixes two defects in RUSH-2205; grouped-by-directory layout and non-interactive behavior unchanged.

## What changed

**1. Harness-parity gap (headless discovery).** The headless `ps`-scan recognized only 6 agent executables (`AGENT_CLI_NAMES`), so a bare-headless `grok`/`kimi`/`antigravity`/`openclaw`/`hermes`/`rush` process was silently dropped (`active.ts` `if (!kind) continue`). The comm→kind map is now **derived from `SESSION_AGENTS` × the AGENTS registry** (`cliCommand`, e.g. `agy`→antigravity, `cursor-agent`→cursor) plus an explicit entry for `rush` (no registry row) — one derived source, not a second hand-maintained allowlist. A completeness test asserts every `SESSION_AGENTS` member resolves.

**2. Thin rows → enriched rows.** Each live row now shows the agent **version** and a human **`created X · idle Y`** cell, and **backfills ticket/PR/label/version/created** from the indexed `SessionMeta` (by full session id) onto orphan rows that lack them (a running process reports none of these). The label/topic moves to its **own second line** so it is no longer buried in a truncated grey snippet. Rows stay width-safe (final whole-line clamp; verified at 40/60/80/120 cols).

**3. State-writer truthfulness + hermes.** `session-tracker`'s `installHookFor` was a hardcoded switch whose `default` returned an opaque "not yet implemented" for everything else. It is now a declarative `HOOK_SUPPORT` table (compile-time complete over `AgentId`): every agent either has an installer or a **specific** reason it can't host the writer hook (gemini deprecated; antigravity has no SessionStart event; opencode's SessionStart is a generated plugin). **Hermes is newly covered** end-to-end — a YAML installer for `~/.hermes/config.yaml` `on_session_start` (read-modify-write, preserves `mcp_servers`) plus a `hook.sh` hermes parse branch. (`openclaw`/`rush` have no writable native SessionStart hook host, so they stay out of the writer's scope — documented in the table; their headless rows still surface via the discovery comm-map.)

## Proof — run against the built dist (`node dist/index.js sessions --orphan --local`)

**Before** (installed 1.22.22): one line, no version, no created/idle, topic buried:
```
    9e8231f6 claude   tmux     orphan   -        ssh←zion ag-claude-9e8231f6:0.0 detached muqsit · Th…
```

**After** (this branch): version + created/idle + backfilled PR badge, label/topic on its own line:
```
▸ yosemite-s0 (2)  ← this machine
  ~ (1)  1 orphaned
    9e8231f6 claude   2.1.187  orphan   -        created 5d · idle 52m  PR#1460
             └ muqsit · That background notification was …  ssh←zion ag-claude-9e8231f6:0.0 detached

  ~/src/github.com/muqsitnawaz (1)  1 orphaned
    80b76514 claude   2.1.186  orphan   -        created Jul 16 · idle 53m
             └ muqsitnawaz · Re-read the full conversatio…  ssh←zion ag-claude-80b76514:0.0 detached
```

Hermes hook end-to-end (payload → state file):
```
$ echo '{"session_id":"hermes-abc-123","cwd":"/tmp/wk"}' | HOME=$T bash src/hook.sh hermes
{"session_id":"hermes-abc-123","agent":"hermes","cwd":"/tmp/wk", ...}
```

## Tests (real path, no mocking)

- `agentKindFromComm` resolves **every** `SESSION_AGENTS` comm (asserted off the registry-derived source so a new agent can't be silently dropped) + the six previously-dropped harnesses.
- `backfillActiveRowsFromMeta` populates version/ticket/PR/label/created from `SessionMeta`, and never overrides a value the live row already carries.
- `renderActiveRowLines` includes version + created/idle + ticket/PR badge; every line stays within terminal width at 40/60/80/120.
- session-tracker: hermes install writes correct `on_session_start` YAML preserving siblings + idempotent; a truthfulness guard asserts no `AgentId` returns the generic "not yet implemented".

## Docs

- `.changelog/next/rush-2205-live-discovery.md` fragment.
- session-tracker README + AGENTS.md updated for the capability table + hermes config format.

Ticket: RUSH-2205
