### PR TITLE
docs(factory): CHANGELOG 0.9.312 (New X (Auto) cold-cache offload)

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.312] - 2026-08-05
+
+- **`New X (Auto)` offloads to the fleet on a cold cache (was: silently local).**
+  `New Claude (Auto)` — and every `New <Agent> (Auto)` — resolved its launch host only
+  from the warm health-cache snapshot. On a cold or >5-min-stale miss, `launchAgent` bailed
+  straight to a local launch: the live favorites-aware `resolveBalancedHost` sweep was
+  guarded out by `!opts.autoHost`, and `local: true` also suppressed the CLI `--device
+  auto`, so the enable/prefer ranking never ran. Fix: on a cache miss, fall through to the
+  same live `resolveBalancedHost` sweep the default New-agent path uses (honors
+  enable/prefer, drops hosts with no usable version); it runs local only when no fleet
+  device is genuinely eligible. Source: `src/vscode/extension.ts` (`launchAgent`),
+  `src/core/launchHistory.test.ts` (regression), `AGENTS.md` launch contract.
+
 - **Status bar session id: CLI join by `AGENT_TERMINAL_ID`, no per-tab poll thrash (RUSH-2192).**
   Grok / Codex / other non-Claude tabs often showed a bare `Agents: Grok` (no id) or a
   Codex `rollout-<timestamp>-<uuid>` stem instead of the real UUID. Root causes: only


### PR DESCRIPTION
**docs-only.** Adds the Factory `CHANGELOG.md` entry for **0.9.312** (already published to the VS Code Marketplace) and promotes the queued `[Unreleased]` RUSH-2192 note into that release section.

## Why
PR #2088 (the `New X (Auto)` cold-cache fleet-offload fix, merged `fc9f621e`) shipped without a Factory CHANGELOG entry — the reviewer convention requires one for user-visible changes. This closes that gap and documents the change under the version it actually shipped in (0.9.312).

## Audience
Maintainers / release history. No code change, no behavior change.
