### PR TITLE
Shape phone forwards to a text, not a wall (truncate long feed-post body)

### DIFF
--- a/apps/cli/.changelog/next/feed-broadcast-truncate.md
+++ b/apps/cli/.changelog/next/feed-broadcast-truncate.md
@@ -1,0 +1,9 @@
+- **Phone forwards are shaped to a text, not a wall.** `agents feed post`
+  (`--level important` / `--blocked`), `agents notify`, and `agents send --to owner`
+  all forward to the owner's phone through one seam, `composeBroadcastMessage`; it now
+  keeps the post **title** (the scannable headline) and truncates a long **body** to a
+  short excerpt marked `… (full in feed)` (caps: 500 chars / 8 lines). The full post is
+  untouched in the feed — only the outbound phone copy is shortened — so a requested
+  long write is not lost, and enforcing it at this seam covers every sink (owner alias,
+  in-process `channel:`, spawned `command:` via `{message}`), which a per-command shell
+  hook cannot. Source: `apps/cli/src/lib/feed-broadcast.ts` (`truncateBroadcastBody`).

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- **Phone forwards are shaped to a text, not a wall.** `agents feed post`
+  (`--level important` / `--blocked`), `agents notify`, and `agents send --to owner`
+  all forward through one seam, `composeBroadcastMessage`; it now keeps the post
+  **title** (the scannable headline) and truncates a long **body** to a short excerpt
+  marked `… (full in feed)` (caps: 500 chars / 8 lines). The full post is untouched in
+  the feed — only the outbound phone copy is shortened — so a requested long write is
+  not lost, and enforcing it here covers every sink (owner alias, in-process `channel:`,
+  spawned `command:`), which a per-command shell hook cannot. Source:
+  `apps/cli/src/lib/feed-broadcast.ts` (`truncateBroadcastBody`).
+
 ## 1.22.22
 
 - **New: `agents insights` — how you work, split by the Claude account that did the

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,17 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- **Phone forwards are shaped to a text, not a wall.** `agents feed post`
-  (`--level important` / `--blocked`), `agents notify`, and `agents send --to owner`
-  all forward through one seam, `composeBroadcastMessage`; it now keeps the post
-  **title** (the scannable headline) and truncates a long **body** to a short excerpt
-  marked `… (full in feed)` (caps: 500 chars / 8 lines). The full post is untouched in
-  the feed — only the outbound phone copy is shortened — so a requested long write is
-  not lost, and enforcing it here covers every sink (owner alias, in-process `channel:`,
-  spawned `command:`), which a per-command shell hook cannot. Source:
-  `apps/cli/src/lib/feed-broadcast.ts` (`truncateBroadcastBody`).
-
 ## 1.22.22
 
 - **New: `agents insights` — how you work, split by the Claude account that did the

--- a/apps/cli/src/lib/feed-broadcast.test.ts
+++ b/apps/cli/src/lib/feed-broadcast.test.ts
@@ -140,6 +140,43 @@ describe('message composition', () => {
     expect(msg).toContain('Default in 15 min: wait');
     expect(msg).not.toContain('agents focus');
   });
+
+  it('truncates a many-line body to a phone excerpt, keeping the title', () => {
+    const wall = Array.from({ length: 18 }, (_, i) => `line ${i + 1} of the session summary`).join('\n');
+    const msg = composeBroadcastMessage(ctx({ title: 'Session summary', text: wall }));
+    expect(msg).toContain('Session summary'); // title (headline) preserved
+    expect(msg).toContain('line 1 of the session summary');
+    expect(msg).toContain('line 8 of the session summary');
+    expect(msg).not.toContain('line 9 of the session summary'); // capped at 8 body lines
+    expect(msg).toContain('… (full in feed)'); // plain pointer, not a CLI command
+    expect(msg).not.toContain('agents focus');
+  });
+
+  it('truncates a very long single-line body by character count', () => {
+    const wall = 'x'.repeat(900);
+    const msg = composeBroadcastMessage(ctx({ title: 'Big update', text: wall }));
+    expect(msg).toContain('Big update');
+    expect(msg).toContain('… (full in feed)');
+    // The forwarded copy is far shorter than the 900-char body.
+    expect(msg.length).toBeLessThan(700);
+  });
+
+  it('truncates a no-title long body too (body becomes the head)', () => {
+    const wall = Array.from({ length: 12 }, (_, i) => `row ${i + 1}`).join('\n');
+    const msg = composeBroadcastMessage(
+      ctx({ title: undefined, text: wall, agent: undefined, host: undefined, session: undefined }),
+    );
+    expect(msg).toContain('row 1');
+    expect(msg).toContain('row 8');
+    expect(msg).not.toContain('row 9');
+    expect(msg).toContain('… (full in feed)');
+  });
+
+  it('leaves a short body untouched (no truncation marker)', () => {
+    const msg = composeBroadcastMessage(ctx({ title: 'CI green', text: 'PR #1690 merged, no action.' }));
+    expect(msg).toContain('PR #1690 merged, no action.');
+    expect(msg).not.toContain('full in feed');
+  });
 });
 
 describe('broadcast planning', () => {

--- a/apps/cli/src/lib/feed-broadcast.ts
+++ b/apps/cli/src/lib/feed-broadcast.ts
@@ -298,9 +298,39 @@ export function composeBroadcastFooter(ctx: FeedBroadcastContext): string | unde
  * so the safe default is the fallback and the message carries it. Prefer `{message}`
  * over bare `{text}` in messaging sinks.
  */
+/**
+ * The phone copy is a text, not a report. A long body reaches the owner's phone
+ * as an unreadable wall, and the `feed post` forwarding path is where that has to
+ * be shaped: every sink (owner alias, in-process `channel:`, spawned `command:`)
+ * funnels through {@link composeBroadcastMessage}, which is the only seam a shell
+ * hook cannot reach. Keep the title (the scannable headline) and cap the BODY to a
+ * short excerpt, marking the cut with a plain "(full in feed)" — NOT a CLI command
+ * (unusable from a phone, see the note on composeBroadcastMessage). Nothing is
+ * lost: this shapes only the outbound sink text; the full post stays in the feed.
+ */
+const PHONE_BODY_MAX_CHARS = 500;
+const PHONE_BODY_MAX_LINES = 8;
+
+export function truncateBroadcastBody(body: string): string {
+  if (!body) return body;
+  let out = body;
+  let cut = false;
+  const lines = out.split('\n');
+  if (lines.length > PHONE_BODY_MAX_LINES) {
+    out = lines.slice(0, PHONE_BODY_MAX_LINES).join('\n');
+    cut = true;
+  }
+  if (out.length > PHONE_BODY_MAX_CHARS) {
+    out = out.slice(0, PHONE_BODY_MAX_CHARS);
+    cut = true;
+  }
+  if (!cut) return body;
+  return `${out.trimEnd()}\n… (full in feed)`;
+}
+
 export function composeBroadcastMessage(ctx: FeedBroadcastContext): string {
   const title = scrubOutboundDashes(ctx.title ?? '');
-  const body = scrubOutboundDashes(ctx.text ?? '');
+  const body = truncateBroadcastBody(scrubOutboundDashes(ctx.text ?? ''));
   // Title preferred; if an older post has no title, body alone still sends.
   const head = title || body;
   const mid = title && body && title !== body ? body : undefined;


### PR DESCRIPTION
## Why

`agents feed post` (`--level important` / `--blocked`), `agents notify`, and `agents send --to owner` all forward to the owner's phone through **one seam** — `composeBroadcastMessage` (`src/lib/feed-broadcast.ts`). It kept the post body verbatim, so a long body arrived as an unreadable wall of text.

This is the **correct layer** to enforce brevity, and the only one that works: a per-command shell hook can't see `agents feed post`, and the **in-process `channel:` sink delivers with no subprocess at all**, so no shell hook can ever intercept it. Every sink — owner alias, in-process `channel:`, spawned `command:` — funnels through this one function.

## What

Keep the **title** (the scannable headline) and truncate a long **body** to a short excerpt marked `… (full in feed)` — a plain-language pointer, **not** a CLI command (phones can't run `agents focus`). Caps: **500 chars / 8 lines** (`truncateBroadcastBody`). Nothing is lost: this shapes only the *outbound phone copy*; the full post stays in the feed store — which also resolves the "but I asked for a detailed report" tension.

## Proof — real run of the feature

Ran `composeBroadcastMessage` from this branch on a real 18-line / 908-char body. Full capture: `yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/feed-broadcast-truncate/apps/cli/.agents/artifacts/feed-truncate-run.txt`

```
=== INPUT: title + 18-line body (908 chars) ===
--- OUTBOUND PHONE COPY (494 chars) ---
Session summary - 2 things shipped

line 1: did a thing in the session summary report
...
line 8: did a thing in the session summary report
… (full in feed)

Sent from claude/544aa5ac on yosemite-s0
```

908-char body → 494-char phone copy; title preserved, body capped at 8 lines + pointer, footer intact.

## Tests

`src/lib/feed-broadcast.test.ts` — 5 new cases (many-line body, long single-line body, no-title body, short body untouched, pointer-is-not-a-CLI-command). Targeted run: **30 passed**. The 3 unrelated failures locally are the pre-existing `rush CLI not found on PATH` env gap (real-delivery tests; pass on the crabbox/CI). `tsc --noEmit` clean.

## Notes

- Auto-reviewer `prix-cloud` is PAUSED (#1767) → a non-author subagent review covers this PR per the documented fallback.
- Follow-up: the `.agents-system` `user-message-guard` shell hook becomes redundant for the forwarding path once this lands; keep as a backstop for direct manual `imsg send` or retire.
