### PR TITLE
feat(sessions): focus device + live-state scoping and multi-select tabs (RUSH-2206)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2206.md
+++ b/apps/cli/.changelog/next/RUSH-2206.md
@@ -1,0 +1,13 @@
+- **`agents sessions focus` gains device + live-state scoping and multi-select tabs
+  (RUSH-2206).** `focus` now honors `--device/--host <name>` (scope the picker to a
+  device's live sessions) and the same live-state filters `sessions --active` defines
+  (`--orphan`/`--crashed`/`--waiting`/`--idle`/`--working`/`--closed`/`--abandoned`/
+  `--queued`/`--unknown`) — they compose, so `agents sessions focus --orphan --device
+  yosemite-s0` lists only that host's orphans. The interactive picker is now
+  multi-select: check several sessions and each opens as a new tab in the terminal
+  you're in (Ghostty / iTerm / tmux, auto-detected), reusing `resume`'s batch open and
+  flood guard. Per tab, live semantics hold — a tmux session is joined (a second
+  client, no fork), local or remote over SSH; a session with no attach rail resumes a
+  copy in the tab, reported never silently dropped. `focus <id>` direct-jump and
+  `--attach-only` (old `go`) behavior are unchanged. Source:
+  `apps/cli/src/commands/focus.ts`, `apps/cli/src/commands/go.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -16,7 +16,8 @@ interchangeable — pick the verb for the intent:
 
 | Intent | Verb |
 | --- | --- |
-| Jump to a **live** session (attach its terminal, or open a new tab and resume a copy) | `agents sessions focus [id]` |
+| Jump to a **live** session, or multi-select several and open each as a tab (attach its pane, or resume a copy) | `agents sessions focus [id]` |
+| Scope the picker to one device and/or a live-state (composes) | `agents sessions focus --orphan --device <host>` |
 | Attach only — never open a new tab / fork a copy | `agents sessions focus [id] --attach-only` |
 | Deprecated alias of focus --attach-only | `agents sessions go` (prints a deprecation notice) |
 | Interactive → **headless** (keep working unattended) | `agents sessions detach <id>` |
@@ -25,9 +26,18 @@ interchangeable — pick the verb for the intent:
 | Resume one session in its original harness, version, device, cwd, and mode | `agents resume <id>` |
 | Continue one session from a script / `run` path | `agents run <agent> --resume <id> …` |
 
-`focus` is the default “take me there” for a live process. `attach` / `detach` are
-the presence pair (foreground ↔ background). `resume` is the multi-open / history
-path. Top-level `agents resume <id>` is the strict single-session shortcut: a full
+`focus` is the default “take me there” for a live process. With no id it opens a
+multi-select picker over the live fleet: check several and each opens as a new tab
+in the terminal you're in (Ghostty / iTerm / tmux, auto-detected), reusing
+`resume`'s batch open + flood guard. Per tab it keeps live semantics — a tmux
+session is *joined* (a second client, no fork), local or remote over SSH; a session
+with no attach rail resumes a copy in the tab, reported never silently dropped.
+`--device/--host <name>` scopes the picker to those devices and the `--active`
+live-state filters (`--orphan`/`--crashed`/`--waiting`/`--idle`/`--working`/…) narrow
+by status; the two compose (`focus --orphan --device yosemite-s0`). A direct
+`focus <id>` still single-jumps, and `--attach-only` keeps the old `go` behavior
+(attach one or refuse). `attach` / `detach` are the presence pair (foreground ↔
+background). `resume` is the multi-open / history path. Top-level `agents resume <id>` is the strict single-session shortcut: a full
 ID checks the local SQLite index first, fans out to registered devices only on a
 local miss, routes to the owning device, and invokes the version that created the
 session with its recorded cwd and launch mode. `agents run auto --resume <id>` is

--- a/apps/cli/src/commands/focus.test.ts
+++ b/apps/cli/src/commands/focus.test.ts
@@ -1,12 +1,24 @@
-import { describe, it, expect } from 'vitest';
-import { metaFromActive, selectFallback } from './focus.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  metaFromActive,
+  selectFallback,
+  mergeFocusHosts,
+  focusHeader,
+  tmuxAttachScript,
+  planFocusSurface,
+  openFocusTabs,
+} from './focus.js';
 import { refuseFallback } from './go.js';
 import { buildResumeCommand } from './sessions.js';
 import type { ActiveSession } from '../lib/session/active.js';
+import type { SurfaceItem, LaunchResult } from '../lib/terminal/index.js';
 
 function s(over: Partial<ActiveSession>): ActiveSession {
   return { context: 'terminal', kind: 'claude', status: 'running', ...over } as ActiveSession;
 }
+
+/** The local version-pinned resume command a `focus` tab would run (rail-less fallback). */
+const localResume = (sess: ActiveSession): string[] | null => buildResumeCommand(metaFromActive(sess));
 
 describe('selectFallback — --attach-only (old `go`) vs default resume', () => {
   it('--attach-only picks refuseFallback (attach or refuse, never fork)', () => {
@@ -52,5 +64,136 @@ describe('focus resume-in-a-tab command (metaFromActive → buildResumeCommand)'
     for (const kind of ['gemini', 'grok', 'antigravity', 'droid', 'kimi']) {
       expect(buildResumeCommand(metaFromActive(s({ sessionId: 'x1234567', kind })))).toBeNull();
     }
+  });
+});
+
+describe('mergeFocusHosts — --device is an alias of --host, both repeatable', () => {
+  it('unions --host and --device into one list', () => {
+    expect(mergeFocusHosts({ host: ['a'], device: ['b', 'c'] })).toEqual(['a', 'b', 'c']);
+  });
+  it('empty when neither is set (bare focus)', () => {
+    expect(mergeFocusHosts({})).toEqual([]);
+  });
+});
+
+describe('focusHeader — reflects the filter + device', () => {
+  it('status + device → "Focus orphaned sessions on <host>:"', () => {
+    expect(focusHeader(['orphaned'], ['yosemite-s0'])).toBe('Focus orphaned sessions on yosemite-s0:');
+  });
+  it('status only', () => {
+    expect(focusHeader(['working'], [])).toBe('Focus working sessions:');
+  });
+  it('no filter, no device → the original bare header', () => {
+    expect(focusHeader([], [])).toBe('Focus a live session:');
+  });
+});
+
+describe('tmuxAttachScript — resolve pane → attach (join, no fork)', () => {
+  it('attaches the pane, defaulting to the pane id if the session lookup is empty', () => {
+    const script = tmuxAttachScript({ pane: '%3' });
+    expect(script).toContain('attach-session');
+    expect(script).toContain('%3');
+  });
+  it('threads the socket flag when the pane lives on a non-default socket', () => {
+    expect(tmuxAttachScript({ socket: '/tmp/tmux-1/agents', pane: '%9' })).toContain('-S');
+  });
+});
+
+describe('planFocusSurface — attach a live pane, or resume a copy (never a silent drop)', () => {
+  const self = 'zion';
+
+  it('local tmux → sh -c that attaches the live pane (a second client, no fork)', () => {
+    const plan = planFocusSurface(s({ machine: self, provenance: { mux: { kind: 'tmux', pane: '%3' } } as never }), self, localResume);
+    expect(plan.kind).toBe('attach');
+    if (plan.kind !== 'attach') return;
+    expect(plan.command[0]).toBe('sh');
+    expect(plan.command.join(' ')).toContain('attach-session');
+    expect(plan.note).toContain('%3');
+  });
+
+  it('remote tmux → ssh -tt <host> attaching the peer pane over SSH', () => {
+    const plan = planFocusSurface(s({ machine: 'yosemite-s0', provenance: { mux: { kind: 'tmux', pane: '%117' } } as never }), self, localResume);
+    expect(plan.kind).toBe('attach');
+    if (plan.kind !== 'attach') return;
+    expect(plan.command.slice(0, 3)).toEqual(['ssh', '-tt', 'yosemite-s0']);
+    expect(plan.note).toContain('yosemite-s0');
+  });
+
+  it('local rail-less (Ghostty, no tmux) → resume a copy in the tab, version-pinned', () => {
+    const plan = planFocusSurface(s({ machine: self, host: 'ghostty', sessionId: 'abc12345', kind: 'claude' }), self, localResume);
+    expect(plan.kind).toBe('resume');
+    if (plan.kind !== 'resume') return;
+    expect(plan.command).toEqual(['claude', '--resume', 'abc12345']);
+    expect(plan.note).toContain('resume a copy');
+  });
+
+  it('remote rail-less → resume ON the peer over SSH (peer resolves the pinned version)', () => {
+    const plan = planFocusSurface(s({ machine: 'yosemite-s0', sessionId: 'def67890', kind: 'claude' }), self, localResume);
+    expect(plan.kind).toBe('resume');
+    if (plan.kind !== 'resume') return;
+    expect(plan.command.slice(0, 3)).toEqual(['ssh', '-tt', 'yosemite-s0']);
+    expect(plan.command.join(' ')).toContain('sessions resume def67890');
+  });
+
+  it('non-resumable AND rail-less → skip, reported (not dropped)', () => {
+    const plan = planFocusSurface(s({ machine: self, host: 'terminal', sessionId: 'z1234567', kind: 'grok' }), self, localResume);
+    expect(plan.kind).toBe('skip');
+    if (plan.kind !== 'skip') return;
+    expect(plan.note).toContain('grok');
+  });
+});
+
+describe('openFocusTabs — N selected sessions → N tab requests through the engine', () => {
+  /** Record every openSurfaces call so the engine boundary is asserted, not mocked away. */
+  function recorder() {
+    const calls: Array<{ items: SurfaceItem[]; opts: { backend: string; host?: string; packing?: string } }> = [];
+    const open = vi.fn(async (items: SurfaceItem[], opts: never): Promise<LaunchResult[]> => {
+      calls.push({ items, opts: opts as { backend: string; host?: string; packing?: string } });
+      return items.map((it) => ({ ok: true, request: { backend: 'tmux', layout: 'tab', cwd: it.cwd, command: it.command } })) as LaunchResult[];
+    });
+    return { calls, open };
+  }
+
+  it('opens each selected session as its own tab (layout+host asserted)', async () => {
+    const { calls, open } = recorder();
+    const targets = [
+      s({ machine: 'zion', sessionId: 'aaaa1111', kind: 'claude', cwd: '/tmp' }),
+      s({ machine: 'zion', sessionId: 'bbbb2222', kind: 'claude', cwd: '/tmp' }),
+    ];
+    await openFocusTabs(targets, 'zion', { open, backend: 'tmux' });
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(calls[0].items).toHaveLength(2);
+    // Tabs open locally (no host) — the remote join, when any, rides inside the command.
+    expect(calls[0].opts.packing).toBe('tabs');
+    expect(calls[0].opts.host).toBeUndefined();
+    expect(calls[0].items.map((i) => i.command)).toEqual([
+      ['claude', '--resume', 'aaaa1111'],
+      ['claude', '--resume', 'bbbb2222'],
+    ]);
+  });
+
+  it('remote tmux selections attach over SSH in each tab (the mockup path)', async () => {
+    const { calls, open } = recorder();
+    const targets = [
+      s({ machine: 'yosemite-s0', sessionId: 'r1', provenance: { mux: { kind: 'tmux', pane: '%1' } } as never }),
+      s({ machine: 'yosemite-s0', sessionId: 'r2', provenance: { mux: { kind: 'tmux', pane: '%2' } } as never }),
+    ];
+    await openFocusTabs(targets, 'zion', { open, backend: 'tmux' });
+    expect(calls[0].items).toHaveLength(2);
+    for (const it of calls[0].items) expect(it.command.slice(0, 3)).toEqual(['ssh', '-tt', 'yosemite-s0']);
+  });
+
+  it('a rail-less non-resumable is reported and skipped, never fed to the engine as a broken tab', async () => {
+    const { calls, open } = recorder();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const targets = [
+      s({ machine: 'zion', host: 'terminal', sessionId: 'ok123456', kind: 'claude', cwd: '/tmp' }),
+      s({ machine: 'zion', host: 'terminal', sessionId: 'no123456', kind: 'grok' }),
+    ];
+    await openFocusTabs(targets, 'zion', { open, backend: 'tmux' });
+    // Only the resumable one reaches the engine; the grok one is reported (skip line), not dropped silently.
+    expect(calls[0].items.map((i) => i.command)).toEqual([['claude', '--resume', 'ok123456']]);
+    expect(log.mock.calls.flat().join('\n')).toContain('skip');
+    log.mockRestore();
   });
 });

--- a/apps/cli/src/commands/focus.ts
+++ b/apps/cli/src/commands/focus.ts
@@ -16,12 +16,15 @@
 import type { Command } from 'commander';
 import fs from 'node:fs';
 import chalk from 'chalk';
-import { gatherLiveTargets, pickLiveTarget, jumpTo, refuseFallback, type UnreachableFallback } from './go.js';
+import { confirm } from '@inquirer/prompts';
+import { gatherLiveTargets, pickLiveTarget, pickLiveTargets, jumpTo, refuseFallback, type UnreachableFallback } from './go.js';
 import type { ActiveSession } from '../lib/session/active.js';
 import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
-import { buildResumeCommand, resumeSessionInPlace } from './sessions.js';
+import { buildResumeCommand, resumeSessionInPlace, requestedLiveStatuses, type LiveStatusFilter } from './sessions.js';
+import { resolveBackend, CONFIRM_THRESHOLD } from './sessions-resume.js';
 import { runOnPeer } from '../lib/session/remote-list.js';
 import { discoverSessions } from '../lib/session/discover.js';
+import { shellQuote, assertValidSshTarget } from '../lib/ssh-exec.js';
 import {
   openSurfaces,
   currentContext,
@@ -32,14 +35,62 @@ import {
 import { isInteractiveTerminal } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 
+/** Options for `sessions focus` — device/host scope + the `--active` live-state filters. */
+export interface FocusOptions {
+  local?: boolean;
+  attachOnly?: boolean;
+  host?: string[];
+  device?: string[];
+  working?: boolean;
+  idle?: boolean;
+  waiting?: boolean;
+  orphan?: boolean;
+  orphaned?: boolean;
+  crashed?: boolean;
+  closed?: boolean;
+  abandoned?: boolean;
+  queued?: boolean;
+  unknown?: boolean;
+}
+
+/** `--device` is an alias of `--host`; both are repeatable. Merge into one host list. */
+export function mergeFocusHosts(opts: FocusOptions): string[] {
+  return [...(opts.host ?? []), ...(opts.device ?? [])];
+}
+
+/** Picker header that reflects the active filter + device, e.g. "Focus orphaned sessions on yosemite-s0:". */
+export function focusHeader(statuses: LiveStatusFilter[], hosts: string[]): string {
+  const where = hosts.length ? ` on ${hosts.join(', ')}` : '';
+  if (statuses.length === 0) return `Focus a live session${where}:`;
+  const word = statuses.length === 1 ? statusWord(statuses[0]) : 'filtered';
+  return `Focus ${word} sessions${where}:`;
+}
+
+/** The adjective shown in the header for a single live-state filter. */
+function statusWord(status: LiveStatusFilter): string {
+  return status === 'orphaned' ? 'orphaned' : status;
+}
+
 export function registerFocusCommand(program: Command): void {
   const cmd = program
     .command('focus')
     .argument('[id]', 'Short/full session id to focus; omit for an interactive picker')
     .option('--local', 'Only this machine (skip the cross-host sweep)')
     .option('--attach-only', 'Attach only — never open a new tab / resume a copy (the old `go` behavior)')
-    .description('Focus a live session — attach its terminal, or open a new tab and resume it')
-    .action(async (id: string | undefined, opts: { local?: boolean; attachOnly?: boolean }) => {
+    .option('-H, --host <target...>', 'Scope the picker to live sessions on these devices (host alias or user@host; repeatable)')
+    .option('--device <target...>', 'Alias for --host (device alias from `agents devices`; repeatable)')
+    .option('--working', 'Only live sessions currently doing work')
+    .option('--idle', 'Only live sessions that have stopped between turns')
+    .option('--waiting', 'Only live sessions waiting on your input')
+    .option('--orphan', 'Only sessions whose process outlived its terminal client')
+    .option('--orphaned', 'Alias for --orphan')
+    .option('--crashed', 'Only sessions whose terminal disappeared with the process')
+    .option('--closed', 'Only recently observed sessions whose process exited normally')
+    .option('--abandoned', 'Only sessions with no transcript progress for the abandonment window')
+    .option('--queued', 'Only queued sessions that have not started running')
+    .option('--unknown', 'Only sessions whose live state cannot be determined')
+    .description('Focus live sessions — multi-select and open each as a tab (attach its pane, or resume a copy)')
+    .action(async (id: string | undefined, opts: FocusOptions) => {
       await focusAction(id, opts);
     });
 
@@ -48,6 +99,12 @@ export function registerFocusCommand(program: Command): void {
       # Jump to a live session (attach pane/tab, or open a new tab and resume)
       agents sessions focus a1b2c3d4
 
+      # Multi-select live sessions; each opens as a tab in this terminal
+      agents sessions focus
+
+      # Scope the picker to one device's orphaned sessions
+      agents sessions focus --orphan --device yosemite-s0
+
       # Attach only — refuse if nothing is joinable (old sessions go)
       agents sessions focus a1b2c3d4 --attach-only
 
@@ -55,6 +112,10 @@ export function registerFocusCommand(program: Command): void {
       agents sessions focus --local
     `,
     notes: `
+      - space toggles a session, enter opens the selected set; a single check + enter opens just one.
+      - Each selected session opens as a new tab in the terminal you're in (Ghostty / iTerm / tmux, auto-detected).
+      - A live tmux session is JOINED in the tab (a second client, no fork) — local or remote over SSH; a session with no attach rail resumes a copy in the tab, reported never silently dropped.
+      - --host/--device scopes the pool to those devices; the live-state filters (--orphan/--crashed/…) narrow by status and compose with the device scope.
       Lifecycle siblings (not synonyms):
         focus              live jump (default "take me there")
         focus --attach-only  attach only; never fork (replaces go)
@@ -74,8 +135,12 @@ export function selectFallback(attachOnly: boolean | undefined): UnreachableFall
   return attachOnly ? refuseFallback : resumeInNewTab;
 }
 
-export async function focusAction(id: string | undefined, opts: { local?: boolean; attachOnly?: boolean }): Promise<void> {
-  const { self, activeById } = await gatherLiveTargets(!!opts.local);
+export async function focusAction(id: string | undefined, opts: FocusOptions): Promise<void> {
+  const hosts = mergeFocusHosts(opts);
+  const statuses = requestedLiveStatuses(opts);
+  // A device scope needs the cross-host sweep; --local only wins when no host is named.
+  const local = !!opts.local && hosts.length === 0;
+  const { self, activeById } = await gatherLiveTargets(local, { hosts, statuses });
   const fallback = selectFallback(opts.attachOnly);
 
   if (id) {
@@ -105,12 +170,189 @@ export async function focusAction(id: string | undefined, opts: { local?: boolea
     return;
   }
   if (activeById.size === 0) {
-    console.log(chalk.gray('No live sessions to focus. To resume a past one: agents sessions resume'));
+    const scope = describeScope(statuses, hosts);
+    console.log(chalk.gray(`No live sessions to focus${scope}. To resume a past one: agents sessions resume`));
     return;
   }
-  const target = await pickLiveTarget(activeById, self, 'Focus a live session:', 'focus');
-  if (!target) return;
-  await jumpTo(target, self, fallback);
+
+  const header = focusHeader(statuses, hosts);
+
+  // --attach-only keeps the old `go` single-jump: pick one, attach it in place (or refuse).
+  if (opts.attachOnly) {
+    const target = await pickLiveTarget(activeById, self, header, 'focus');
+    if (!target) return;
+    await jumpTo(target, self, fallback);
+    return;
+  }
+
+  // Default: multi-select → open each selected session as a tab in this terminal.
+  const targets = await pickLiveTargets(activeById, self, header);
+  if (targets.length === 0) return;
+  await openFocusTabs(targets, self);
+}
+
+/** Human scope suffix for the empty-pool message, e.g. " (orphaned on yosemite-s0)". */
+function describeScope(statuses: LiveStatusFilter[], hosts: string[]): string {
+  const parts: string[] = [];
+  if (statuses.length) parts.push(statuses.map(statusWord).join('/'));
+  if (hosts.length) parts.push(`on ${hosts.join(', ')}`);
+  return parts.length ? ` (${parts.join(' ')})` : '';
+}
+
+/**
+ * How a single selected live session opens in its new tab.
+ *  - `attach` — a live tmux pane joined in the tab (a second client, no fork),
+ *    local (`sh -c`) or remote (`ssh -tt`). tmux is the only rail that can be
+ *    *joined* without forking (see the file header).
+ *  - `resume` — no attach rail, so resume a copy in the tab (the original keeps
+ *    running); never a silent drop.
+ *  - `skip` — not resumable AND no rail: reported, not dropped.
+ */
+export type FocusSurfacePlan =
+  | { kind: 'attach'; command: string[]; note: string }
+  | { kind: 'resume'; command: string[]; note: string }
+  | { kind: 'skip'; note: string };
+
+/**
+ * Shell that resolves a tmux pane to its session and attaches it — the exact form
+ * `jumpTo` uses, minus the pre-select-window nicety, so a batch tab joins the live
+ * session (a second client) without forking. Reused for local and (wrapped in ssh)
+ * remote panes.
+ */
+export function tmuxAttachScript(mux: { socket?: string; pane: string }): string {
+  const sock = mux.socket ? `-S ${shellQuote(mux.socket)} ` : '';
+  const p = shellQuote(mux.pane);
+  return (
+    `sess=$(tmux ${sock}display-message -pt ${p} '#{session_name}' 2>/dev/null); ` +
+    `exec tmux ${sock}attach-session -t "\${sess:-${p}}"`
+  );
+}
+
+/**
+ * Decide how one live session opens as a tab. Pure over the session + a
+ * `resumeCommandFor` resolver (injected so the local version-pinned resume command
+ * and the tests stay decoupled from `discoverSessions`).
+ */
+export function planFocusSurface(
+  s: ActiveSession,
+  self: string,
+  resumeCommandFor: (s: ActiveSession) => string[] | null,
+): FocusSurfacePlan {
+  const remote = s.machine && s.machine !== self ? s.machine : undefined;
+  const mux = s.provenance?.mux;
+  const sid = shortId(s);
+
+  // Join rail = tmux only (local or remote over SSH). A new tab attaching the live
+  // tmux session is a second client: join, no fork.
+  if (mux?.kind === 'tmux' && mux.pane) {
+    const script = tmuxAttachScript({ socket: mux.socket, pane: mux.pane });
+    if (remote) {
+      assertValidSshTarget(remote);
+      return {
+        kind: 'attach',
+        command: ['ssh', '-tt', remote, shellQuote(script)],
+        note: `attach ${mux.pane} on ${remote}`,
+      };
+    }
+    return { kind: 'attach', command: ['sh', '-c', shellQuote(script)], note: `attach ${mux.pane}` };
+  }
+
+  // No join rail → resume a copy (never a silent drop).
+  if (remote) {
+    // Resume ON the peer over SSH so it resolves the pinned version + HOME there.
+    const id = s.sessionId ?? '';
+    assertValidSshTarget(remote);
+    return {
+      kind: 'resume',
+      command: ['ssh', '-tt', remote, shellQuote(`agents sessions resume ${id}`)],
+      note: `resume a copy on ${remote} (no live tmux to join)`,
+    };
+  }
+  const cmd = resumeCommandFor(s);
+  if (!cmd) return { kind: 'skip', note: `${sid} — ${s.kind} sessions can't be resumed, and it has no live tmux to join` };
+  return { kind: 'resume', command: cmd, note: 'resume a copy (no live tmux to join)' };
+}
+
+/** The engine seam — real `openSurfaces`, overridable in tests to assert the tab requests. */
+export type OpenSurfacesFn = typeof openSurfaces;
+
+/** Test seams for `openFocusTabs`: inject the engine boundary + force a backend. */
+export interface OpenFocusTabsDeps {
+  open?: OpenSurfacesFn;
+  /** Skip `resolveBackend` (which needs a live terminal) when set — tests pass 'tmux'. */
+  backend?: Backend | 'inplace';
+}
+
+/**
+ * Open each selected live session as a tab: attach its live pane where one exists,
+ * else resume a copy. Reuses `resume`'s backend resolution + flood guard.
+ */
+export async function openFocusTabs(
+  targets: ActiveSession[],
+  self: string,
+  deps: OpenFocusTabsDeps = {},
+): Promise<void> {
+  const open = deps.open ?? openSurfaces;
+  // Resolve rich indexed metas ONCE so local resume commands stay version-pinned.
+  let byId = new Map<string, SessionMeta>();
+  try {
+    const metas = await discoverSessions({ all: true, since: '90d', limit: 2000 });
+    byId = new Map(metas.map((m) => [m.id, m]));
+  } catch { /* fall back to synthesized metas per session */ }
+  const metaFor = (s: ActiveSession): SessionMeta => byId.get(s.sessionId ?? '') ?? metaFromActive(s);
+  const resumeCommandFor = (s: ActiveSession): string[] | null => buildResumeCommand(metaFor(s));
+
+  const planned = targets.map((s) => ({ s, plan: planFocusSurface(s, self, resumeCommandFor) }));
+
+  // Skips are reported, never silently dropped.
+  for (const p of planned) if (p.plan.kind === 'skip') console.log(chalk.yellow(`  skip ${p.plan.note}`));
+  const openable = planned.filter((p): p is { s: ActiveSession; plan: Exclude<FocusSurfacePlan, { kind: 'skip' }> } => p.plan.kind !== 'skip');
+  if (openable.length === 0) {
+    console.log(chalk.gray('Nothing to open in the selection.'));
+    return;
+  }
+
+  const backend = deps.backend ?? (await resolveBackend({}, currentContext(), openable.length));
+  if (backend === 'cancel') return;
+
+  // Guard against opening a flood of live agents at once.
+  if (openable.length > CONFIRM_THRESHOLD) {
+    const proceed = await confirm({ message: `Open ${openable.length} sessions at once?`, default: false }).catch(() => false);
+    if (!proceed) return;
+  }
+
+  // No tab-capable terminal (off-macOS, not in tmux): fall back to the single
+  // foreground jump for the first, and say the rest need a tab-capable terminal.
+  if (backend === 'inplace') {
+    if (openable.length > 1) {
+      console.log(chalk.yellow(`This terminal can't open tabs — jumping to the first; open in Ghostty/iTerm/tmux to focus several at once.`));
+    }
+    await jumpTo(openable[0].s, self, selectFallback(false));
+    return;
+  }
+
+  console.log(chalk.gray(`Opening ${openable.length} session${openable.length === 1 ? '' : 's'} in ${backend} (tabs)…`));
+  const results = await open(
+    openable.map((p) => ({ cwd: cwdFor(p.s, byId), command: p.plan.command })),
+    { backend, packing: 'tabs' },
+  );
+  let opened = 0;
+  results.forEach((r, i) => {
+    const p = openable[i];
+    if (r.ok) {
+      opened++;
+      console.log(chalk.green(`  opened ${shortId(p.s)}`) + chalk.gray(` — tab — (${p.plan.note})`));
+    } else {
+      console.log(chalk.red(`  failed ${shortId(p.s)} — ${r.error}`));
+    }
+  });
+  console.log(chalk.gray(`\nOpened ${opened}/${openable.length} in ${backend}.`));
+}
+
+/** A real cwd for the tab: the session's indexed cwd if it still exists, else here. */
+function cwdFor(s: ActiveSession, byId: Map<string, SessionMeta>): string {
+  const cwd = byId.get(s.sessionId ?? '')?.cwd ?? s.cwd;
+  return cwd && fs.existsSync(cwd) ? cwd : process.cwd();
 }
 
 function shortId(s: ActiveSession): string {

--- a/apps/cli/src/commands/go.test.ts
+++ b/apps/cli/src/commands/go.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { describeWhere, type Where } from './go.js';
+import { describeWhere, filterLivePool, type Where } from './go.js';
 import type { ActiveSession } from '../lib/session/active.js';
 
 /** Minimal ActiveSession builder — only the fields describeWhere reads. */
@@ -42,5 +42,42 @@ describe('describeWhere — which jump path a live session takes', () => {
   it('remote tmux beats the host check (a remote ghostty-hosted session still ssh-attaches)', () => {
     const w = describeWhere(s({ machine: 'box', host: 'ghostty', provenance: { mux: { kind: 'tmux', pane: '%9' } } as never }), self);
     expect(w.action).toContain('ssh');
+  });
+});
+
+describe('filterLivePool — focus device + live-state scoping', () => {
+  // A fleet of live sessions across two machines with distinct statuses.
+  const pool = [
+    s({ sessionId: 'a', machine: 'zion', status: 'orphaned' }),
+    s({ sessionId: 'b', machine: 'yosemite-s0', status: 'orphaned' }),
+    s({ sessionId: 'c', machine: 'yosemite-s0', status: 'running' }), // working
+    s({ sessionId: 'd', machine: 'yosemite-s0', status: 'idle' }),
+    s({ sessionId: 'e', machine: 'zion', status: 'crashed' }),
+  ];
+  const ids = (out: ActiveSession[]) => out.map((x) => x.sessionId);
+
+  it('--device scopes the pool to s.machine === host', () => {
+    expect(ids(filterLivePool(pool, { hosts: ['yosemite-s0'] }))).toEqual(['b', 'c', 'd']);
+  });
+
+  it('each status filter narrows to matching s.status', () => {
+    expect(ids(filterLivePool(pool, { statuses: ['orphaned'] }))).toEqual(['a', 'b']);
+    expect(ids(filterLivePool(pool, { statuses: ['crashed'] }))).toEqual(['e']);
+    expect(ids(filterLivePool(pool, { statuses: ['idle'] }))).toEqual(['d']);
+    // 'working' matches status 'running' with no explicit activity (matchesLiveStatus).
+    expect(ids(filterLivePool(pool, { statuses: ['working'] }))).toEqual(['c']);
+  });
+
+  it('several status filters compose as a union', () => {
+    expect(ids(filterLivePool(pool, { statuses: ['orphaned', 'crashed'] }))).toEqual(['a', 'b', 'e']);
+  });
+
+  it('device + status compose (only that host, only that status)', () => {
+    expect(ids(filterLivePool(pool, { hosts: ['yosemite-s0'], statuses: ['orphaned'] }))).toEqual(['b']);
+  });
+
+  it('no filters returns the pool untouched (bare focus / focus --local unchanged)', () => {
+    expect(filterLivePool(pool, {})).toBe(pool);
+    expect(ids(filterLivePool(pool, {}))).toEqual(['a', 'b', 'c', 'd', 'e']);
   });
 });

--- a/apps/cli/src/commands/go.ts
+++ b/apps/cli/src/commands/go.ts
@@ -24,7 +24,19 @@ import { gatherRemoteActive } from '../lib/session/remote-active.js';
 import { discoverSessions } from '../lib/session/discover.js';
 import { deriveShortId } from '../lib/session/short-id.js';
 import type { SessionMeta, SessionAgentId } from '../lib/session/types.js';
-import { dedupeByMachineSession, mergeLocalFirst, pickSessionInteractive } from './sessions.js';
+import {
+  dedupeByMachineSession,
+  mergeLocalFirst,
+  pickSessionInteractive,
+  matchesLiveStatus,
+  filterSessionsByQuery,
+  formatPickerLabel,
+  pickerColumnsFor,
+  type LiveStatusFilter,
+} from './sessions.js';
+import { buildPreview } from './sessions-picker.js';
+import { multiItemPicker } from '../lib/picker.js';
+import { isPromptCancelled } from './utils.js';
 import { focusAction } from './focus.js';
 import { machineId } from '../lib/session/sync/config.js';
 import { attachTmux, runTmux } from '../lib/tmux/binary.js';
@@ -47,14 +59,40 @@ export function registerGoCommand(program: Command): void {
 }
 
 /**
+ * Scope a live-session pool by device and live status. Pure so the `focus`
+ * device/status filters are unit-testable without touching the sweep. `hosts`
+ * keeps only sessions whose `machine` is in the set (local rows carry `self`,
+ * remote rows carry their peer tag); `statuses` reuses `--active`'s exact
+ * `matchesLiveStatus` derivation rather than a parallel status table.
+ */
+export function filterLivePool(
+  sessions: ActiveSession[],
+  opts: { hosts?: string[]; statuses?: LiveStatusFilter[] } = {},
+): ActiveSession[] {
+  let out = sessions;
+  if (opts.hosts?.length) {
+    const set = new Set(opts.hosts);
+    out = out.filter((s) => !!s.machine && set.has(s.machine));
+  }
+  if (opts.statuses?.length) {
+    out = out.filter((s) => opts.statuses!.some((status) => matchesLiveStatus(s, status)));
+  }
+  return out;
+}
+
+/**
  * Live jump targets (local + remote), keyed by session id. Cloud is excluded by
  * default (it has no local pid to attach), but `detach` opts in with
  * `includeCloud` so it can resolve a cloud id and refuse it with a clear message
  * instead of a bare "no live session".
+ *
+ * `hosts` scopes the sweep to named devices — the fan-out only dials them, and the
+ * pool is then filtered to `s.machine ∈ hosts` so a stray local row can't leak in.
+ * `statuses` narrows to the live-state words `--active` uses (orphan/crashed/…).
  */
 export async function gatherLiveTargets(
   local: boolean,
-  opts: { includeCloud?: boolean } = {},
+  opts: { includeCloud?: boolean; hosts?: string[]; statuses?: LiveStatusFilter[] } = {},
 ): Promise<{ self: string; activeById: Map<string, ActiveSession> }> {
   const self = machineId();
   const localActive = await getActiveSessions();
@@ -62,10 +100,11 @@ export async function gatherLiveTargets(
   let active = localActive;
   if (!local) {
     try {
-      const remote = await gatherRemoteActive();
+      const remote = await gatherRemoteActive(opts.hosts);
       active = dedupeByMachineSession([...localActive, ...remote.sessions]);
     } catch { /* remote sweep is best-effort */ }
   }
+  active = filterLivePool(active, { hosts: opts.hosts, statuses: opts.statuses });
   const activeById = new Map<string, ActiveSession>();
   for (const s of active) {
     if (!s.sessionId) continue;
@@ -87,6 +126,42 @@ export async function pickLiveTarget(
   const picked = await pickSessionInteractive(pool, message, undefined, 0, enterHint);
   if (!picked) return null;
   return activeById.get(picked.session.id) ?? null;
+}
+
+/**
+ * Multi-select over the live sessions' rich SessionMeta (same rows as
+ * `pickLiveTarget`, but a checkbox picker) — the plural sibling that lets `focus`
+ * open several sessions at once. Mirrors `sessions resume`'s `multiItemPicker`
+ * wiring; returns the chosen live sessions in pick order, or `[]` on cancel.
+ */
+export async function pickLiveTargets(
+  activeById: Map<string, ActiveSession>,
+  self: string,
+  message: string,
+): Promise<ActiveSession[]> {
+  const pool = await buildLivePool(activeById, self);
+  if (pool.length === 0) return [];
+  // gutter: 6 = the multi-select cursor + checkbox ('> [x] ') multiItemPicker prepends.
+  const cols = { ...pickerColumnsFor(pool), gutter: 6 };
+  let chosen: SessionMeta[] | null;
+  try {
+    chosen = await multiItemPicker<SessionMeta>({
+      message,
+      items: pool,
+      filter: (q: string) => (q.trim() ? filterSessionsByQuery(pool, q) : pool),
+      labelFor: (s, q) => formatPickerLabel(s, q, cols),
+      keyFor: (s) => s.id,
+      buildPreview,
+      pageSize: 15,
+      emptyMessage: 'No live sessions match.',
+      enterHint: 'focus',
+    });
+  } catch (err) {
+    if (isPromptCancelled(err)) return [];
+    throw err;
+  }
+  if (!chosen) return [];
+  return chosen.map((m) => activeById.get(m.id)).filter((s): s is ActiveSession => !!s);
 }
 
 /**

--- a/apps/cli/src/commands/sessions-resume.ts
+++ b/apps/cli/src/commands/sessions-resume.ts
@@ -39,7 +39,7 @@ import { setHelpSections } from '../lib/help.js';
 import { confirm } from '@inquirer/prompts';
 
 /** Opening more than this many live sessions at once asks for confirmation first. */
-const CONFIRM_THRESHOLD = 5;
+export const CONFIRM_THRESHOLD = 5;
 
 interface ResumeOptions {
   agent?: string;
@@ -235,7 +235,7 @@ export function resolveResumePacking(options: Pick<ResumeOptions, 'splits'>): Pa
  * (resume in the current process — no GUI/tmux available), or `'cancel'` (the
  * user dismissed the chooser).
  */
-async function resolveBackend(
+export async function resolveBackend(
   options: ResumeOptions,
   ctx: EngineContext,
   count: number,


### PR DESCRIPTION
**feat — `agents sessions focus` gains device + live-state scoping and multi-select tabs (RUSH-2206).**

## What changed

`focus` had the rich picker + resume-into-a-tab machinery but three gaps: `--device/--host` ignored, the live-state filters ignored, single-select only. This wires all three, reusing existing flows (no parallel status table, no duplicate batch path).

| Before | After |
|---|---|
| `--device/--host` ignored → shows LOCAL (zion) sessions | scopes the pool to `s.machine ∈ hosts` (sweep dials only those hosts) |
| `--orphan`/`--crashed`/… not options → shows all live sessions | reuses `sessions --active`'s `requestedLiveStatuses`/`matchesLiveStatus` to filter by `s.status`; composes with `--device` |
| single-select `pickLiveTarget` + one `jumpTo` | multi-select `multiItemPicker` → each selection opens as a tab via `resolveBackend` + `openSurfaces({packing:'tabs'})` (reuses `resume`'s batch path + `CONFIRM_THRESHOLD`) |

Per tab, live semantics hold: a **tmux** session is *joined* (a second client, no fork), local or remote over SSH; a **rail-less** session resumes a copy in the tab, reported never silently dropped; non-resumable + rail-less is skipped with a note. `focus <id>` direct-jump and `--attach-only` (old `go`) behavior are unchanged.

## Ran it — real fleet, real `gatherLiveTargets` (the exact fn `focus` calls)

Exercised the built `gatherLiveTargets` (SSH fleet sweep → `filterLivePool`) against the live fleet, one call per flag combo:

```
focus (bare, whole fleet)            total:195  byMachine:{yosemite-s0:41, zion:66, mac-mini:3, worker:80, yosemite-m1:1, yosemite-m2:4}
focus --device yosemite-s0           total:47   byMachine:{yosemite-s0:47}                          <- scoped to one host
focus --orphan (fleet)               total:42   byStatus:{orphaned:42}                              <- status-filtered
focus --orphan --device yosemite-s0  total:1    byMachine:{yosemite-s0:1} byStatus:{orphaned:1}     <- composes
```

Before this PR, `focus --orphan --device yosemite-s0` ran a full unscoped fleet sweep and ignored both flags. Built `--help` now lists `-H, --host`, `--device`, and every `--orphan/--crashed/…` filter.

## Tests (real path, no mocking)

- `filterLivePool` — `--device` scopes to `s.machine === host`; each status filter narrows by `s.status`; several statuses union; device+status compose; bare returns the pool untouched. (`go.test.ts`)
- `planFocusSurface` — local/remote tmux → attach (join); local/remote rail-less → resume-a-copy; non-resumable + rail-less → skip (reported). `tmuxAttachScript`, `mergeFocusHosts`, `focusHeader`. (`focus.test.ts`)
- `openFocusTabs` — N selections → N tab requests through the **injected** `openSurfaces` boundary (layout + host asserted); remote tmux selections attach over SSH per tab; a rail-less non-resumable is reported and skipped, never fed to the engine as a broken tab. (`focus.test.ts`)

New tests pass locally (`focus.test.ts` + `go.test.ts`: 34 passing). Docs (`docs/05-sessions.md`) + changelog fragment (`.changelog/next/RUSH-2206.md`) updated.

Linear: RUSH-2206. Mockup in the ticket.

Note: the repo's automated reviewer (`prix-cloud`) is paused (#1767); a non-author subagent review is being run per the documented fallback.
