### PR TITLE
feat(insights): accept --all as an alias for --since all

### DIFF
--- a/apps/cli/.changelog/next/insights-all-alias.md
+++ b/apps/cli/.changelog/next/insights-all-alias.md
@@ -1,0 +1,5 @@
+- **`agents insights --all` now works as an alias for `--since all`.** It previously
+  exited with `unknown option '--all'` — a hard failure in the middle of a report the
+  user asked for, on the spelling most people reach for first. An explicit `--since`
+  still wins, so `--all --since 7d` resolves to 7d rather than silently contradicting
+  itself. Source: `apps/cli/src/commands/insights.ts`.

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -1134,7 +1134,7 @@ does — describes a fraction of the work and attributes all of it to one org.
 ```bash
 agents insights                                # last 30d, by account
 agents insights --by project --since 90d       # which repo is eating the time
-agents insights --account "Turing Labs" --since all
+agents insights --account "Turing Labs" --all  # one account, every session ever
 agents insights --json                         # stable contract for dashboards
 agents insights --narrative                    # add a written read on the numbers
 ```

--- a/apps/cli/node_modules
+++ b/apps/cli/node_modules
@@ -1,1 +1,0 @@
-/Users/taylorgagne/tools/agents-cli/.agents/worktrees/price-claude5/apps/cli/node_modules

--- a/apps/cli/node_modules
+++ b/apps/cli/node_modules
@@ -1,0 +1,1 @@
+/Users/taylorgagne/tools/agents-cli/.agents/worktrees/price-claude5/apps/cli/node_modules

--- a/apps/cli/src/commands/insights.test.ts
+++ b/apps/cli/src/commands/insights.test.ts
@@ -158,6 +158,20 @@ describe('agents insights', () => {
     expect(byProject.groups).toHaveLength(1);   // every fixture shares one cwd
   });
 
+  it('accepts --all as an alias for --since all', async () => {
+    // The spelling people reach for. Before this it was `unknown option '--all'`,
+    // which is a hard exit in the middle of a report they asked for.
+    const viaAlias = JSON.parse(await runInsights(['--json', '--all']));
+    const viaSince = JSON.parse(await runInsights(['--json', '--since', 'all']));
+    expect(viaAlias.window.since).toBeNull();
+    expect(viaAlias.analyzed).toBe(viaSince.analyzed);
+  });
+
+  it('lets an explicit --since win over --all rather than contradicting it', async () => {
+    const both = JSON.parse(await runInsights(['--json', '--all', '--since', '30d']));
+    expect(both.window.since).toBe('30d');
+  });
+
   it('filters to one account with --account', async () => {
     const payload = JSON.parse(await runInsights(['--json', '--since', 'all', '--account', 'Beta']));
     expect(payload.groups).toHaveLength(1);

--- a/apps/cli/src/commands/insights.ts
+++ b/apps/cli/src/commands/insights.ts
@@ -67,6 +67,7 @@ const execFileAsync = promisify(execFile);
 interface InsightsOptions {
   json?: boolean;
   since?: string;
+  all?: boolean;
   account?: string;
   agent?: string;
   by?: string;
@@ -418,7 +419,10 @@ async function insightsAction(options: InsightsOptions): Promise<void> {
     console.error(chalk.red('error: --min-messages must be a non-negative integer'));
     process.exit(1);
   }
-  const since = options.since ?? '30d';
+  // `--all` is the spelling people reach for; `--since all` is what the window parser
+  // speaks. Accept both rather than failing on an unknown option, and let an explicit
+  // --since win so `--all --since 7d` is not silently contradictory.
+  const since = options.since ?? (options.all ? 'all' : '30d');
   const sinceMs = since === 'all' ? undefined : parseTimeFilter(since);
 
   // Refresh the index first, exactly as `agents cost` does, so a report never silently
@@ -518,6 +522,7 @@ export function registerInsightsCommand(program: Command): void {
     .description('How you work — tools, friction, and rhythm, split by the account that did the work')
     .option('--json', 'Output the full report as JSON')
     .option('--since <time>', 'Window: 7d, 4w, 3mo, an ISO date, or "all" (default 30d)')
+    .option('--all', 'Every session ever indexed. Alias for --since all')
     .option('--by <dimension>', 'Group by: account (default), agent, project, or day')
     .option('--account <match>', 'Only sessions whose account key, email, or org contains this')
     .option('--agent <id>', 'Only one harness (claude, codex, droid, …)')
@@ -537,7 +542,7 @@ export function registerInsightsCommand(program: Command): void {
       agents insights --by project --since 90d
 
       # One account only, all of its history
-      agents insights --account "Turing Labs" --since all
+      agents insights --account "Turing Labs" --all
 
       # Machine-readable, for a dashboard or a slash command
       agents insights --json


### PR DESCRIPTION
> Small UX fix, found by watching someone use the command. Left open for a maintainer.

## The problem

```
$ agents insights --narrative --all
error: unknown option '--all'
```

`--all` is the spelling people reach for first. The window flag is `--since all`, which is discoverable from `--help` but not from instinct — and the failure is a hard exit in the middle of a report the user asked for, not a degraded result.

## The fix

`--all` is now an alias. An explicit `--since` still wins, so `--all --since 7d` resolves to `7d` rather than silently contradicting itself:

```ts
const since = options.since ?? (options.all ? 'all' : '30d');
```

The `--help` example that used `--since all` now shows `--all`, since that is the friendlier form.

## Tests

Two, both in `src/commands/insights.test.ts` against the registered command with real fixtures:

- `--all` produces the same `window.since` and the same `analyzed` count as `--since all`
- `--all --since 7d` resolves to `7d`, so precedence is pinned rather than incidental

`tsc --noEmit` clean. `insights.test.ts` + `gen-changelog.test.ts`: 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)