### PR TITLE
feat(sessions): move fork under `agents sessions fork` (hidden `agents fork` alias)

### DIFF
--- a/apps/cli/.changelog/next/sessions-fork.md
+++ b/apps/cli/.changelog/next/sessions-fork.md
@@ -1,0 +1,9 @@
+- **`agents fork` is now `agents sessions fork`.** Forking is a session operation, so
+  it lives under the `sessions` group next to `resume`/`focus` — `agents sessions fork
+  <id>` branches a conversation into a new, independent copy you can continue separately,
+  leaving the original untouched. The old top-level `agents fork` keeps working as a
+  hidden alias, so nothing that scripted it breaks. For a harness without a native copy
+  (anything but Claude today), the command now fails loud and names the manual branch —
+  start a fresh agent and seed it with `/continue <id>` — instead of only saying
+  "unsupported". Source: `apps/cli/src/commands/fork.ts`,
+  `apps/cli/src/commands/sessions.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -849,20 +849,21 @@ agents sessions d3470b57-2af6-4c11-b1de-3fab94f43603
 
 ## Forking (branch a conversation)
 
-`agents fork <session>` branches an existing conversation into a NEW, independent
-session. Where `resume` continues the *same* thread (same id, same file — it
-appends), `fork` copies the transcript under a fresh id, so continuing the fork
-diverges instead of mutating the original. It is the "git branch" of
+`agents sessions fork <session>` branches an existing conversation into a NEW,
+independent session. Where `resume` continues the *same* thread (same id, same
+file — it appends), `fork` copies the transcript under a fresh id, so continuing
+the fork diverges instead of mutating the original. It is the "git branch" of
 conversations — useful for exploring an alternative approach from a point you
-already reached, or fanning a promising session into two directions.
+already reached, or fanning a promising session into two directions. (`agents
+fork <session>` is kept as a hidden alias for back-compat.)
 
 ```bash
 # Fork by (partial) id, then continue the copy — the original is untouched
-agents fork 4f3a9c21
-agents resume <new-id>
+agents sessions fork 4f3a9c21
+agents sessions resume <new-id>
 
 # Name the fork
-agents fork 4f3a9c21 --name "try redis instead"
+agents sessions fork 4f3a9c21 --name "try redis instead"
 ```
 
 Mechanics (`lib/session/fork.ts`): a Claude session id *is* its `<id>.jsonl`
@@ -874,8 +875,9 @@ run-name sidecar as `agents run --name`). The fork resolves immediately by
 
 Scope: v1 supports **Claude** (single-file transcript, native `--resume`). Codex
 (single-file) is a natural next step; multi-file agents (grok, kimi) and DB-only
-agents (opencode) need per-agent handling and are refused up front with a clear
-message.
+agents (opencode) need per-agent handling. For an unsupported harness the command
+fails loud and names the manual branch — start a fresh agent and seed it with
+`/continue <id>` (the source stays put) — rather than a silent no-op or fake copy.
 
 ## Background & foreground (detach / attach)
 

--- a/apps/cli/src/commands/fork.test.ts
+++ b/apps/cli/src/commands/fork.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Isolate the sessions DB + run-name sidecars under a temp HOME before
+// db.js/state.js capture the path at import time (same pattern as db.names.test).
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-fork-'));
+process.env.HOME = TEST_HOME;
+process.env.USERPROFILE = TEST_HOME;
+
+const { upsertSession, findSessionsById } = await import('../lib/session/db.js');
+const { runFork } = await import('./fork.js');
+const { isForkableAgent } = await import('../lib/session/fork.js');
+type SessionMeta = import('../lib/session/types.js').SessionMeta;
+
+// Transcripts live in their own dir; a fork lands beside its source, so the id
+// captured from the command output — not a readdir — identifies each fork.
+const PROJ_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-fork-proj-'));
+
+function seedSession(id: string, agent: string, lines: object[]): SessionMeta {
+  const filePath = path.join(PROJ_DIR, `${id}.jsonl`);
+  const body = lines.map((l) => JSON.stringify(l)).join('\n') + (lines.length ? '\n' : '');
+  fs.writeFileSync(filePath, body);
+  const meta: SessionMeta = { id, shortId: id.slice(0, 8), agent, timestamp: new Date().toISOString(), filePath };
+  upsertSession(meta, body);
+  return meta;
+}
+
+/** Capture a console channel's output as one joined string. */
+function capture(channel: 'log' | 'error') {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, channel).mockImplementation((...a: unknown[]) => {
+    lines.push(a.map(String).join(' '));
+  });
+  return {
+    get text() {
+      return lines.join('\n');
+    },
+    restore: () => spy.mockRestore(),
+  };
+}
+
+afterEach(() => {
+  process.exitCode = 0;
+});
+
+describe('agents sessions fork (shared action)', () => {
+  it('copies a claude session under a new id, leaving the original untouched', async () => {
+    const srcId = '11111111-2222-3333-4444-555555555555';
+    const src = seedSession(srcId, 'claude', [
+      { sessionId: srcId, type: 'user', message: { role: 'user', content: 'hello world' } },
+    ]);
+    const before = fs.readFileSync(src.filePath, 'utf-8');
+
+    const out = capture('log');
+    await runFork(srcId, {});
+    out.restore();
+
+    // The command reports the new short id + how to continue it.
+    expect(out.text).toMatch(/Forked .* -> /);
+    expect(out.text).toContain('agents sessions resume');
+    const forkId = out.text.match(/-> (\S+)/)?.[1];
+    expect(forkId).toBeTruthy();
+
+    // Original transcript is byte-for-byte untouched.
+    expect(fs.readFileSync(src.filePath, 'utf-8')).toBe(before);
+
+    // The fork resolves in the index as its own, distinct session.
+    const forked = findSessionsById(forkId!, {})[0];
+    expect(forked).toBeTruthy();
+    expect(forked!.id).not.toBe(srcId);
+
+    // The copy carries the conversation and rewrote the embedded session id.
+    const forkBody = fs.readFileSync(forked!.filePath, 'utf-8');
+    expect(forkBody).toContain('hello world');
+    expect(forkBody).toContain(`"sessionId":"${forked!.id}"`);
+    expect(forkBody).not.toContain(srcId);
+  });
+
+  it('applies --name as the fork label', async () => {
+    const srcId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    seedSession(srcId, 'claude', [{ sessionId: srcId, type: 'user', message: { role: 'user', content: 'x' } }]);
+
+    const out = capture('log');
+    await runFork(srcId, { name: 'try redis instead' });
+    out.restore();
+
+    const forkId = out.text.match(/-> (\S+)/)?.[1];
+    expect(findSessionsById(forkId!, {})[0]?.label).toBe('try redis instead');
+  });
+
+  it('fails loud for a non-forkable harness and names the /continue manual path', async () => {
+    const srcId = '99999999-8888-7777-6666-555555555555';
+    // Only the DB meta's agent matters — the non-forkable branch returns before
+    // the transcript is read, so no real codex file format is needed.
+    seedSession(srcId, 'codex', []);
+    expect(isForkableAgent('codex')).toBe(false);
+
+    const err = capture('error');
+    await runFork(srcId, {});
+    err.restore();
+
+    expect(process.exitCode).toBe(1);
+    expect(err.text).toContain('codex');
+    expect(err.text).toContain('/continue');
+  });
+
+  it('fails loud when no session matches the id', async () => {
+    const err = capture('error');
+    await runFork('does-not-exist-zzzz', {});
+    err.restore();
+    expect(process.exitCode).toBe(1);
+    expect(err.text).toContain('No session matching');
+  });
+});

--- a/apps/cli/src/commands/fork.ts
+++ b/apps/cli/src/commands/fork.ts
@@ -1,6 +1,7 @@
 /**
- * `agents fork <session>` — branch an existing conversation into a new,
+ * `agents sessions fork <session>` — branch an existing conversation into a new,
  * independent session you can continue separately. The original is untouched.
+ * Also exposed as the hidden top-level alias `agents fork` (back-compat).
  *
  * Thin command layer; the copy/register logic lives in `lib/session/fork.ts`.
  */
@@ -16,77 +17,107 @@ interface ForkOptions {
   name?: string;
 }
 
-/** Register the top-level `agents fork` command. */
-export function registerForkCommand(program: Command): void {
-  const cmd = program
+const FORK_HELP = {
+  examples: `
+    # Fork a session by (partial) id, then continue the fork
+    agents sessions fork 4f3a9c21
+    agents sessions resume <new-id>
+
+    # Give the fork a name
+    agents sessions fork 4f3a9c21 --name "try redis instead"
+  `,
+  notes: `
+    - 'resume' continues the SAME conversation; 'fork' copies it under a new id so the two diverge.
+    - The fork is a full copy of the conversation so far; continuing it never touches the original.
+    - Resolve the session the same way as resume: an exact or prefix id fragment.
+    - Native copy currently supports: ${FORKABLE_AGENTS.join(', ')}. For other harnesses, branch by
+      starting a fresh agent and seeding it with '/continue <id>' — the source stays put.
+  `,
+};
+
+/**
+ * Resolve the source session, copy it under a fresh id, and print how to
+ * continue the fork. Shared by `agents sessions fork` and the `agents fork` alias.
+ */
+export async function runFork(sessionArg: string, options: ForkOptions): Promise<void> {
+  // Resolve the source. Try the index first; only pay for a rescan if the id
+  // isn't found yet (mirrors the resume path's freshen-then-lookup).
+  let matches = findSessionsById(sessionArg, {});
+  if (matches.length === 0) {
+    await discoverSessions({});
+    matches = findSessionsById(sessionArg, {});
+  }
+
+  if (matches.length === 0) {
+    // Errors go to stderr and set a non-zero exit code so a script chaining on
+    // `agents sessions fork <id> && agents sessions resume <new>` doesn't proceed
+    // on a failed fork.
+    console.error(chalk.red(`No session matching "${sessionArg}".`));
+    console.error(chalk.gray('List candidates with: agents sessions'));
+    process.exitCode = 1;
+    return;
+  }
+  if (matches.length > 1) {
+    console.error(chalk.yellow(`"${sessionArg}" is ambiguous — ${matches.length} sessions match. Use a longer id:`));
+    for (const m of matches.slice(0, 8)) {
+      console.error(chalk.gray(`  ${m.shortId}  ${m.agent}  ${m.label || m.topic || ''}`));
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const source = matches[0];
+
+  if (!isForkableAgent(source.agent)) {
+    // A native copy needs the agent's transcript to be resumable by id; harnesses
+    // without that can still be branched by hand. Fail loud with the manual path
+    // rather than a silent no-op or a fake copy.
+    console.error(chalk.yellow(`A native fork copy isn't supported for ${source.agent} sessions yet (supported: ${FORKABLE_AGENTS.join(', ')}).`));
+    console.error(chalk.gray(`  Branch it by hand — start a fresh ${source.agent} and seed it with the source's context:`));
+    console.error(chalk.gray(`    agents run ${source.agent} --terminal   # then, in the new session:`));
+    console.error(chalk.gray(`    /continue ${source.shortId}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  let result;
+  try {
+    result = forkSession(source, { name: options.name });
+  } catch (err) {
+    console.error(chalk.red(`Could not fork ${source.shortId}: ${(err as Error).message}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(chalk.green(`Forked ${source.shortId} -> ${result.shortId}`));
+  console.log(chalk.gray(`  Label:    ${result.label}`));
+  console.log(chalk.gray(`  Continue: agents sessions resume ${result.shortId}`));
+  console.log(chalk.gray(`  Original ${source.shortId} is untouched.`));
+}
+
+/**
+ * Register `agents sessions fork <session>` — the canonical surface (fork is a
+ * session operation, so it lives under the `sessions` group).
+ */
+export function registerSessionsForkCommand(sessionsCmd: Command): void {
+  const cmd = sessionsCmd
     .command('fork <session>')
     .description('Branch a session into a new, independent copy you can continue separately. The original is untouched.')
     .option('--name <label>', 'Label for the fork (default: "fork of <original>")');
 
-  setHelpSections(cmd, {
-    examples: `
-      # Fork a session by (partial) id, then continue the fork
-      agents fork 4f3a9c21
-      agents resume <new-id>
+  setHelpSections(cmd, FORK_HELP);
+  cmd.action(runFork);
+}
 
-      # Give the fork a name
-      agents fork 4f3a9c21 --name "try redis instead"
-    `,
-    notes: `
-      - 'resume' continues the SAME conversation; 'fork' copies it under a new id so the two diverge.
-      - The fork is a full copy of the conversation so far; continuing it never touches the original.
-      - Resolve the session the same way as resume: an exact or prefix id fragment.
-      - Currently supports: ${FORKABLE_AGENTS.join(', ')}. Other agents are a planned follow-up.
-    `,
-  });
+/**
+ * Register the hidden top-level `agents fork` alias. Kept working for back-compat
+ * and muscle memory; the canonical, discoverable surface is `agents sessions fork`.
+ */
+export function registerForkCommand(program: Command): void {
+  const cmd = program
+    .command('fork <session>', { hidden: true })
+    .description('Alias for `agents sessions fork` — branch a session into a new, independent copy.')
+    .option('--name <label>', 'Label for the fork (default: "fork of <original>")');
 
-  cmd.action(async (sessionArg: string, options: ForkOptions) => {
-    // Resolve the source. Try the index first; only pay for a rescan if the id
-    // isn't found yet (mirrors the resume path's freshen-then-lookup).
-    let matches = findSessionsById(sessionArg, {});
-    if (matches.length === 0) {
-      await discoverSessions({});
-      matches = findSessionsById(sessionArg, {});
-    }
-
-    if (matches.length === 0) {
-      // Errors go to stderr and set a non-zero exit code so a script chaining on
-      // `agents fork <id> && agents resume <new>` doesn't proceed on a failed fork.
-      console.error(chalk.red(`No session matching "${sessionArg}".`));
-      console.error(chalk.gray('List candidates with: agents sessions'));
-      process.exitCode = 1;
-      return;
-    }
-    if (matches.length > 1) {
-      console.error(chalk.yellow(`"${sessionArg}" is ambiguous — ${matches.length} sessions match. Use a longer id:`));
-      for (const m of matches.slice(0, 8)) {
-        console.error(chalk.gray(`  ${m.shortId}  ${m.agent}  ${m.label || m.topic || ''}`));
-      }
-      process.exitCode = 1;
-      return;
-    }
-
-    const source = matches[0];
-
-    if (!isForkableAgent(source.agent)) {
-      console.error(chalk.yellow(`fork does not support ${source.agent} sessions yet.`));
-      console.error(chalk.gray(`  Supported: ${FORKABLE_AGENTS.join(', ')}.`));
-      process.exitCode = 1;
-      return;
-    }
-
-    let result;
-    try {
-      result = forkSession(source, { name: options.name });
-    } catch (err) {
-      console.error(chalk.red(`Could not fork ${source.shortId}: ${(err as Error).message}`));
-      process.exitCode = 1;
-      return;
-    }
-
-    console.log(chalk.green(`Forked ${source.shortId} -> ${result.shortId}`));
-    console.log(chalk.gray(`  Label:    ${result.label}`));
-    console.log(chalk.gray(`  Continue: agents resume ${result.shortId}`));
-    console.log(chalk.gray(`  Original ${source.shortId} is untouched.`));
-  });
+  cmd.action(runFork);
 }

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -57,6 +57,7 @@ import {
 import { setHelpSections } from '../lib/help.js';
 import { registerSessionsTailCommand } from './sessions-tail.js';
 import { registerSessionsResumeCommand } from './sessions-resume.js';
+import { registerSessionsForkCommand } from './fork.js';
 import { registerSessionsFavoriteCommand } from './sessions-favorite.js';
 import { isFavorite, listFavorites } from '../lib/session/favorites.js';
 import { registerGoCommand } from './go.js';
@@ -4410,6 +4411,7 @@ export function registerSessionsCommands(program: Command): void {
 
   registerSessionsTailCommand(sessionsCmd);
   registerSessionsResumeCommand(sessionsCmd);
+  registerSessionsForkCommand(sessionsCmd);
   registerSessionsFavoriteCommand(sessionsCmd);
   registerGoCommand(sessionsCmd);
   registerFocusCommand(sessionsCmd);


### PR DESCRIPTION
## What

Forking is a session operation, so it now lives under the `sessions` group next to `resume`/`focus` (per the CLI surface conventions — nest by relatedness):

- **`agents sessions fork <id>`** — canonical surface. Branches a conversation into a new, independent copy; the original is untouched.
- **`agents fork <id>`** — kept working as a **hidden** alias (back-compat / muscle memory), removed from the top-level `--help`.

Both delegate to one shared `runFork` action. For a harness without a native copy (only Claude today), the command **fails loud and names the manual branch** — start a fresh agent and seed it with `/continue <id>` — instead of only saying "unsupported" (matches the repo's fail-loud-at-boundaries rule; no fake copy, no silent no-op).

## Why

`agents fork` was a free-standing top-level command for a noun (`sessions`) that already owns it. This nests it correctly and makes it discoverable under `agents sessions`, without breaking the old invocation.

## Companion PR (fleet guidance)

`sessions` is a core group, so this lands with its companion in `phnx-labs/.agents-system`: a new **`/fork` slash command** — <!--SYSTEM_PR-->. That command is the ergonomic surface (fork the current session and open it in a new tab where the user works).

## Verification

- New `apps/cli/src/commands/fork.test.ts` forks a real Claude session against the real session DB and asserts: copy made under a new id, **original byte-for-byte untouched**, fork resolvable in the index, embedded `sessionId` rewritten, `--name` applied, and the non-forkable path fails loud with the `/continue` guidance.
- `bunx vitest run src/commands/sessions.test.ts src/commands/fork.test.ts` → **69 passed**.
- `tsc --noEmit` → clean.
- Real CLI wiring (from source): `agents sessions fork --help` renders the workflow examples; `agents sessions --help` lists `fork`; hidden `agents fork --help` still works; `fork` is absent from the top-level `--help`.

Docs: `apps/cli/docs/05-sessions.md` Forking section updated; changelog fragment at `apps/cli/.changelog/next/sessions-fork.md`.
