### PR TITLE
docs(reports): link the --cloud spec to its tracking ticket RUSH-2224

### DIFF
--- a/.agents/reports/2026-08-05/agents-run-cloud-flag-design.md
+++ b/.agents/reports/2026-08-05/agents-run-cloud-flag-design.md
@@ -124,3 +124,10 @@ agents run <agent> [prompt] --cloud [--provider <id>] [--repo <owner/repo>]...
 - **Native claude provider** (`claude --cloud` → claude.ai/code) as an
   additional provider, if direct Anthropic-infra dispatch without Rush is
   wanted. Would give `agents run claude --cloud --provider claude`.
+
+## Tracking
+
+- **RUSH-2224** — Implement `agents run --cloud` placement flag (registry-routed):
+  <https://linear.app/getrush/issue/RUSH-2224/implement-agents-run-cloud-placement-flag-registry-routed>
+  Carries this spec's acceptance criteria. The follow-ups above are out of its
+  scope; the cursor provider's adjacent parent is RUSH-2079.


### PR DESCRIPTION
**docs-only** — appends a 6-line `## Tracking` section to one existing report. No code, no behavior change. Audience: maintainers navigating between the spec and the board.

## What changed

`.agents/reports/2026-08-05/agents-run-cloud-flag-design.md` gains:

```markdown
## Tracking

- **RUSH-2224** — Implement `agents run --cloud` placement flag (registry-routed):
  <https://linear.app/getrush/issue/RUSH-2224/...>
```

## Why

The spec landed in #2104 describing a flag that does not exist yet, with no ticket behind it. RUSH-2224 now carries its acceptance criteria and links back to the spec file — this commit closes the other direction, so from the spec you can reach every ticket it spawned. Per the repo convention that a plan and its tickets point at each other.

## No run to attach

Pure doc edit — nothing executable changed, so no CHANGELOG entry. Sole change:

```
$ git show --stat dd188fa3
 .agents/reports/2026-08-05/agents-run-cloud-flag-design.md | 7 +++++++
 1 file changed, 7 insertions(+)
```

Ticket: https://linear.app/getrush/issue/RUSH-2224/implement-agents-run-cloud-placement-flag-registry-routed