### PR TITLE
feat(harness): shared step engine for create + edit wizards (RUSH-2219)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2219.md
+++ b/apps/cli/.changelog/next/RUSH-2219.md
@@ -1,0 +1,11 @@
+- **`agents harness edit` is now wizard-capable, on a shared step engine (RUSH-2219).**
+  Run `agents harness edit <name>` with no flags in a terminal and it walks each field
+  (model, endpoint, auth, version, fallback, description) pre-filled with the harness's
+  current values — where before it was flag-only and errored without one. Both `add`/`fork`
+  and `edit` now drive one shared step engine: every step is skippable by the matching flag,
+  so scripting stays non-interactive and a flagless non-interactive `edit` still errors as
+  before. Endpoint and version prompts are gated by the host's API format (a host with no
+  custom-endpoint slot, or one that self-updates, shows the field disabled with a reason
+  instead of silently accepting a value the run would drop). This is the foundation the
+  model catalog, connection test, edit matrix, and cross-host portability build on.
+  Source: `apps/cli/src/commands/harness-wizard.ts`, `apps/cli/src/commands/harness.ts`.

--- a/apps/cli/docs/profiles.md
+++ b/apps/cli/docs/profiles.md
@@ -67,7 +67,9 @@ agents harness edit spark --version ""
 agents harness edit deepseek --fallback-model deepseek/deepseek-chat-v3
 ```
 
-`edit` takes the same override flags as `fork` (`--model`, `--base-url`, `--auth-provider`, `--version`, `--description`, `--from-secrets`) plus one edit-only flag, `--fallback-model`, for `Profile.fallback_model` (see [`03-routines.md`](03-routines.md) and the fallback cascade in `runWithFallback`). Unlike `fork`, `edit` never rewrites `forkedFrom` to point at itself. Giving zero flags is a no-op error naming the available ones.
+`edit` takes the same override flags as `fork` (`--model`, `--base-url`, `--auth-provider`, `--version`, `--description`, `--from-secrets`) plus one edit-only flag, `--fallback-model`, for `Profile.fallback_model` (see [`03-routines.md`](03-routines.md) and the fallback cascade in `runWithFallback`). Unlike `fork`, `edit` never rewrites `forkedFrom` to point at itself.
+
+Giving zero flags **in a terminal** now opens the same interactive wizard `add`/`fork` use, pre-filled with the harness's current values (`agents harness edit deepseek` with no flags). It walks each editable field — model, endpoint, auth, version, fallback, description — and writes only what you change; leaving every prompt at its default is a no-op. Fields the host can't carry are shown disabled with a reason: a host with no custom-endpoint slot (anything but claude/codex) skips the base-URL prompt, and a self-updating host (grok/droid/antigravity/cursor/hermes/muse/kiro/goose) skips the version pin, rather than silently accepting a value a run would drop. Giving zero flags **without** a terminal stays a no-op error naming the available ones, so scripts are unchanged.
 
 `agents harness rename <old-name> <new-name>` renames the underlying YAML file and updates the `name:` field inside it; every other harness whose `forkedFrom:` pointed at the old name is rewritten to the new one. Renaming onto an existing name is a hard error — there is no overwrite path (use `remove` first if that's really the intent).
 
@@ -80,9 +82,11 @@ agents harness add corp --host claude --model gpt-x --auth-provider corp --from-
 agents harness edit corp --from-secrets prod:OPENROUTER_KEY   # rotate later without retyping
 ```
 
-### Interactive wizard (`agents harness add` / `fork` with no args)
+### Interactive wizard (`agents harness add` / `fork` / `edit`)
 
-Run `add` or `fork` in a terminal without enough flags to build a harness (e.g. bare `agents harness add`, or `agents harness fork claude` with no `--model`) and a picker walks you through it instead of throwing: fork from (every native host plus your existing harnesses) → a built-in preset or "build custom" (host + model + provider) → the harness's name (pre-filled with the preset's own name, e.g. `deepseek`, not a model detail) → how to get the key (type it, or pick a bundle+key via `--from-secrets`). Flags remain fully supported for scripts — the wizard only engages when required info is missing **and** stdout is a TTY; a non-interactive shell still gets the original error.
+Run `add` or `fork` in a terminal without enough flags to build a harness (e.g. bare `agents harness add`, or `agents harness fork claude` with no `--model`) and a picker walks you through it instead of throwing: fork from (every native host plus your existing harnesses) → a built-in preset or "build custom" (host + model + provider) → the harness's name (pre-filled with the preset's own name, e.g. `deepseek`, not a model detail) → how to get the key (type it, or pick a bundle+key via `--from-secrets`). `edit` opens the same wizard pre-filled with a harness's current values when you run it with no flags (see above). Flags remain fully supported for scripts — the wizard only engages when required info is missing **and** stdin+stdout are a TTY; a non-interactive shell still gets the original error.
+
+Both flows drive one shared step engine ([`src/commands/harness-wizard.ts`](../src/commands/harness-wizard.ts)): a `create` and an `edit` step list over a single runner, each step skippable by the matching flag and gated by a `WizardIO` seam that makes the engine testable without a TTY. The model catalog, connection test, per-host edit matrix, and cross-host portability plug into it via typed extension points (`WizardHooks`).
 
 ### Custom harnesses are their own agent type
 

--- a/apps/cli/src/commands/harness-wizard.test.ts
+++ b/apps/cli/src/commands/harness-wizard.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as state from '../lib/state.js';
+import {
+  createSteps,
+  editSteps,
+  defaultEditable,
+  runWizardSteps,
+  hostForSource,
+  type WizardIO,
+  type WizardChoice,
+  type HarnessDraft,
+  type WizardStep,
+} from './harness-wizard.js';
+import { buildFork, buildEdit, draftToEditOptions } from './harness.js';
+import {
+  writeProfile,
+  readProfile,
+  resolveProfileForRun,
+  baseUrlEnvKeyForHost,
+  authEnvKeyForHost,
+  type Profile,
+} from '../lib/profiles.js';
+import { MANAGED_AGENT_IDS, isSelfUpdatingAgent } from '../lib/agents.js';
+
+/**
+ * A scripted {@link WizardIO} for driving the engine with no TTY. It records every
+ * prompt (so tests can assert which steps ran and which were skipped/disabled) and
+ * answers via a matcher over the prompt, so the answers never couple to the private
+ * sentinel values of a `select`'s choices.
+ */
+type Prompt = {
+  kind: 'select' | 'input' | 'password' | 'confirm';
+  message: string;
+  choices?: WizardChoice<unknown>[];
+  default?: unknown;
+};
+
+class FakeIO implements WizardIO {
+  calls: Prompt[] = [];
+  notes: string[] = [];
+  constructor(private respond: (p: Prompt) => unknown) {}
+  private ask(p: Prompt): unknown {
+    this.calls.push(p);
+    return this.respond(p);
+  }
+  async select<T>(opts: { message: string; choices: WizardChoice<T>[]; default?: T }): Promise<T> {
+    return this.ask({ kind: 'select', message: opts.message, choices: opts.choices as WizardChoice<unknown>[] }) as T;
+  }
+  async input(opts: { message: string; default?: string }): Promise<string> {
+    return this.ask({ kind: 'input', message: opts.message, default: opts.default }) as string;
+  }
+  async password(opts: { message: string }): Promise<string> {
+    return this.ask({ kind: 'password', message: opts.message }) as string;
+  }
+  async confirm(opts: { message: string; default?: boolean }): Promise<boolean> {
+    return this.ask({ kind: 'confirm', message: opts.message, default: opts.default }) as boolean;
+  }
+  note(m: string): void {
+    this.notes.push(m);
+  }
+  /** Messages of the prompts that actually fired, in order. */
+  messages(): string[] {
+    return this.calls.map((c) => c.message);
+  }
+}
+
+let TEST_ROOT: string;
+let USER_DIR: string;
+
+beforeEach(() => {
+  TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-wizard-test-'));
+  USER_DIR = path.join(TEST_ROOT, '.agents');
+  fs.mkdirSync(path.join(USER_DIR, 'profiles'), { recursive: true });
+  vi.spyOn(state, 'getUserAgentsDir').mockReturnValue(USER_DIR);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+/** Index a step list by id for direct `decide()` assertions. */
+function byId(steps: WizardStep[]): Record<string, WizardStep> {
+  return Object.fromEntries(steps.map((s) => [s.id, s]));
+}
+
+describe('createSteps — step gating (decide) is a function of the draft', () => {
+  const steps = byId(createSteps());
+
+  it('source runs when unset and is skipped once a flag pre-filled it', () => {
+    expect(steps.source.decide({ mode: 'create' })).toBe('run');
+    expect(steps.source.decide({ mode: 'create', source: 'claude' })).toBe('skip');
+  });
+
+  it('model is asked only on the custom path and skipped once a model is present', () => {
+    expect(steps.model.decide({ mode: 'create', custom: true })).toBe('run');
+    expect(steps.model.decide({ mode: 'create', custom: true, model: 'gpt-x' })).toBe('skip');
+    expect(steps.model.decide({ mode: 'create' })).toBe('skip'); // preset path fills it
+  });
+
+  it('baseUrl is disabled with a reason on a host that carries no endpoint slot', () => {
+    const claude = steps.baseUrl.decide({ mode: 'create', custom: true, host: 'claude' });
+    expect(claude).toBe('run');
+    const opencode = steps.baseUrl.decide({ mode: 'create', custom: true, host: 'opencode' });
+    expect(opencode).toEqual({ disabled: expect.stringContaining('opencode') });
+  });
+
+  it('name is skipped when a positional pre-filled it', () => {
+    expect(steps.name.decide({ mode: 'create', name: 'spark' })).toBe('skip');
+    expect(steps.name.decide({ mode: 'create' })).toBe('run');
+  });
+
+  it('auth runs only when a provider needs a key and no bundle was already chosen', () => {
+    expect(steps.auth.decide({ mode: 'create', authProvider: 'openrouter' })).toBe('run');
+    expect(steps.auth.decide({ mode: 'create', authProvider: 'openrouter', fromSecrets: 'b:k' })).toBe('skip');
+    expect(steps.auth.decide({ mode: 'create' })).toBe('skip');
+  });
+});
+
+describe('createSteps — a full custom run drives the right prompts and skips the rest', () => {
+  it('builds a no-auth opencode harness, disabling the base-URL step for the host', async () => {
+    const io = new FakeIO((p) => {
+      if (p.message === 'Fork from') return 'opencode';
+      if (p.message === 'Preset') return p.choices!.find((c) => c.name.includes('Build custom'))!.value;
+      if (p.message === 'Model id') return 'meta/muse-spark-1.1';
+      if (p.message === 'Provider') return p.choices!.find((c) => c.name.includes('no auth'))!.value;
+      if (p.message === 'Harness name') return 'spark';
+      throw new Error(`unexpected prompt: ${p.kind} '${p.message}'`);
+    });
+
+    const draft = await runWizardSteps(createSteps(), { mode: 'create' }, io);
+
+    // The base-URL prompt never fired — it was disabled with a reason instead.
+    expect(io.messages()).not.toContain('Base URL (optional)');
+    expect(io.notes.join('\n')).toMatch(/opencode.*no custom-endpoint slot/);
+
+    expect(draft.source).toBe('opencode');
+    expect(draft.custom).toBe(true);
+    expect(draft.model).toBe('meta/muse-spark-1.1');
+    expect(draft.authProvider).toBeUndefined();
+    expect(draft.baseUrl).toBeUndefined();
+    expect(draft.name).toBe('spark');
+
+    // Round-trips through buildFork → writeProfile → readProfile → resolveProfileForRun.
+    const profile = buildFork(draft.source!, draft.name!, {
+      model: draft.model,
+      baseUrl: draft.baseUrl,
+      authProvider: draft.authProvider,
+      fromSecrets: draft.fromSecrets,
+    });
+    writeProfile(profile);
+    expect(readProfile('spark').env.OPENCODE_MODEL).toBe('meta/muse-spark-1.1');
+    const resolved = resolveProfileForRun('spark');
+    expect(resolved.agent).toBe('opencode');
+    expect(resolved.env.OPENCODE_MODEL).toBe('meta/muse-spark-1.1');
+  });
+
+  it('asks nothing when every step is pre-filled by a flag (scripting stays non-interactive)', async () => {
+    const io = new FakeIO((p) => {
+      throw new Error(`should not prompt, but got '${p.message}'`);
+    });
+    const prefilled: HarnessDraft = {
+      mode: 'create',
+      source: 'claude',
+      name: 'corp',
+      custom: true,
+      model: 'gpt-x',
+      baseUrl: 'https://gw.corp/v1',
+      authProvider: 'corp',
+      providerAsked: true,
+      fromSecrets: 'prod:KEY',
+    };
+    await runWizardSteps(createSteps(), prefilled, io);
+    expect(io.calls).toHaveLength(0);
+  });
+});
+
+describe('editSteps — matrix gating is sourced from the resolver, per host', () => {
+  const editProfile = (host: Profile['host']['agent'], env: Record<string, string> = {}): Profile => ({
+    name: `${host}-harness`,
+    host: { agent: host },
+    env,
+  });
+
+  it('enables every param on claude (Anthropic-compatible, pinnable)', () => {
+    const steps = byId(editSteps(editProfile('claude', { ANTHROPIC_MODEL: 'm' })));
+    const draft: HarnessDraft = { mode: 'edit' };
+    expect(steps.model.decide(draft)).toBe('run');
+    expect(steps.baseUrl.decide(draft)).toBe('run');
+    expect(steps.auth.decide(draft)).toBe('run');
+    expect(steps.version.decide(draft)).toBe('run');
+    expect(steps.fallback.decide(draft)).toBe('run');
+  });
+
+  it('disables the endpoint AND the version pin on a self-updating, no-endpoint host (grok)', () => {
+    const steps = byId(editSteps(editProfile('grok', { GROK_MODEL: 'm' })));
+    const draft: HarnessDraft = { mode: 'edit' };
+    expect(steps.baseUrl.decide(draft)).toEqual({ disabled: expect.stringContaining('grok') });
+    expect(steps.version.decide(draft)).toEqual({ disabled: expect.stringContaining('self-updates') });
+    expect(steps.auth.decide(draft)).toBe('run'); // grok reads XAI_API_KEY
+    expect(steps.model.decide(draft)).toBe('run');
+  });
+
+  it('disables only the endpoint on opencode (no slot, but pinnable + auth-capable)', () => {
+    const steps = byId(editSteps(editProfile('opencode', { OPENCODE_MODEL: 'm' })));
+    const draft: HarnessDraft = { mode: 'edit' };
+    expect(steps.baseUrl.decide(draft)).toEqual({ disabled: expect.stringContaining('endpoint') });
+    expect(steps.version.decide(draft)).toBe('run');
+    expect(steps.auth.decide(draft)).toBe('run');
+  });
+});
+
+describe('defaultEditable — never drifts from the resolver maps (no hardcoded table)', () => {
+  it('matches baseUrlEnvKeyForHost / authEnvKeyForHost / isSelfUpdatingAgent for every managed host', () => {
+    for (const host of MANAGED_AGENT_IDS) {
+      const e = defaultEditable(host);
+      expect(e.model).toBe(true);
+      expect(e.fallback).toBe(true);
+      expect(e.baseUrl).toBe(baseUrlEnvKeyForHost(host) !== null);
+      expect(e.auth).toBe(authEnvKeyForHost(host) !== null);
+      expect(e.version).toBe(!isSelfUpdatingAgent(host));
+    }
+  });
+});
+
+describe('editSteps — a full edit run keeps only what changed and round-trips', () => {
+  it('changes only the model when the user accepts every other current value', async () => {
+    writeProfile({
+      name: 'deepseek',
+      host: { agent: 'claude', version: '2.1.170' },
+      env: { ANTHROPIC_MODEL: 'deepseek/deepseek-v4-flash-0731' },
+      description: 'DeepSeek via OpenRouter',
+    });
+    const original = readProfile('deepseek');
+
+    const io = new FakeIO((p) => {
+      if (p.message === 'Model id') return 'deepseek/deepseek-v3.2'; // the one real change
+      if (p.message === 'Auth') return p.choices!.find((c) => c.name.includes('unchanged'))!.value;
+      if (p.kind === 'input') return p.default ?? ''; // accept the pre-filled current value
+      throw new Error(`unexpected prompt: ${p.kind} '${p.message}'`);
+    });
+
+    const draft = await runWizardSteps(
+      editSteps(original),
+      { mode: 'edit', original, host: original.host.agent, name: 'deepseek' },
+      io,
+    );
+    const opts = draftToEditOptions(draft, original);
+    expect(opts).toEqual({ model: 'deepseek/deepseek-v3.2' });
+
+    const edited = buildEdit('deepseek', opts);
+    writeProfile(edited);
+    // Only the model moved; the version pin and description are intact.
+    expect(readProfile('deepseek').env.ANTHROPIC_MODEL).toBe('deepseek/deepseek-v3.2');
+    expect(readProfile('deepseek').host.version).toBe('2.1.170');
+    const resolved = resolveProfileForRun('deepseek');
+    expect(resolved.env.ANTHROPIC_MODEL).toBe('deepseek/deepseek-v3.2');
+  });
+
+  it('unpins the version when the user blanks it, an explicit clear the flag path also supports', async () => {
+    writeProfile({
+      name: 'pinned',
+      host: { agent: 'claude', version: '2.1.170' },
+      env: { ANTHROPIC_MODEL: 'm' },
+    });
+    const original = readProfile('pinned');
+    const io = new FakeIO((p) => {
+      if (p.message === 'Auth') return p.choices!.find((c) => c.name.includes('unchanged'))!.value;
+      if (p.kind === 'input' && p.message.startsWith('Host CLI version')) return ''; // blank → unpin
+      if (p.kind === 'input') return p.default ?? '';
+      throw new Error(`unexpected prompt: ${p.kind} '${p.message}'`);
+    });
+    const draft = await runWizardSteps(
+      editSteps(original),
+      { mode: 'edit', original, host: original.host.agent, name: 'pinned' },
+      io,
+    );
+    const opts = draftToEditOptions(draft, original);
+    expect(opts.version).toBe('');
+    const edited = buildEdit('pinned', opts);
+    expect(edited.host.version).toBeUndefined();
+  });
+});
+
+describe('hostForSource — resolves the host a fork target runs under', () => {
+  it('maps a native id (through aliases) to itself', () => {
+    expect(hostForSource('opencode')).toBe('opencode');
+    expect(hostForSource('claude-code')).toBe('claude');
+  });
+
+  it('maps an existing custom harness to its own host', () => {
+    writeProfile({ name: 'mine', host: { agent: 'codex' }, env: { OPENAI_MODEL: 'm' } });
+    expect(hostForSource('mine')).toBe('codex');
+  });
+
+  it('is undefined for an unknown source', () => {
+    expect(hostForSource('nope')).toBeUndefined();
+    expect(hostForSource(undefined)).toBeUndefined();
+  });
+});

--- a/apps/cli/src/commands/harness-wizard.ts
+++ b/apps/cli/src/commands/harness-wizard.ts
@@ -1,0 +1,556 @@
+/**
+ * Shared interactive step engine for `agents harness` create + edit.
+ *
+ * A single engine drives BOTH the create wizard (`agents harness add`/`fork`,
+ * previously `runHarnessWizard`) and the new edit wizard (`agents harness edit`,
+ * which was flag-only before). A "step" is a self-contained unit — decide whether
+ * it runs for the current draft, then prompt/validate/apply — so the two modes
+ * differ only in their step list, not in the runner.
+ *
+ * Design goals (RUSH-2219, parent RUSH-2218):
+ *   - One runner, two modes. `create` builds a new harness from a source; `edit`
+ *     loads an existing profile and re-asks each field pre-filled with its value.
+ *   - Every step is skippable. A flag that already supplied the value pre-fills
+ *     the draft and its step is not re-asked — so non-interactive scripting via
+ *     flags is unchanged and the wizard only asks for what is missing.
+ *   - Pure and injectable. The engine talks to the user through {@link WizardIO},
+ *     an injected seam. Tests drive a scripted fake IO and assert which steps ran,
+ *     with no TTY. {@link defaultWizardIO} is the production driver over
+ *     `@inquirer/prompts`.
+ *   - Typed extension points, not stubs. The three sibling subtasks plug in via
+ *     {@link WizardHooks} without editing the engine: RUSH-2220 (model catalog +
+ *     secrets surface) via `pickModel`, RUSH-2221 (connection test) via
+ *     `connectionTest`, RUSH-2222 (edit matrix) via `editable`. Each hook is a
+ *     real no-op extension point — absent, the scaffold falls back to today's
+ *     behavior (free-text model, no test, resolver-sourced editability). None of
+ *     them fakes a result. RUSH-2223 (cross-host portability, `fork --to-host`)
+ *     extends the create source step; the seam is `HarnessDraft.toHost`.
+ */
+
+import chalk from 'chalk';
+import type { AgentId } from '../lib/types.js';
+import {
+  type Profile,
+  baseUrlEnvKeyForHost,
+  authEnvKeyForHost,
+  modelEnvKeyForHost,
+  validateProfileName,
+  listProfiles,
+} from '../lib/profiles.js';
+import { listPresets, getPreset, type Preset } from '../lib/profiles-presets.js';
+import { listBundles } from '../lib/secrets/bundles.js';
+import { AGENTS, ALL_AGENT_IDS, isSelfUpdatingAgent, resolveAgentName } from '../lib/agents.js';
+
+/** Whether the wizard is creating a new harness or editing an existing one. */
+export type WizardMode = 'create' | 'edit';
+
+/** A single `select` choice. `disabled` greys the row (used by the edit matrix). */
+export interface WizardChoice<T> {
+  name: string;
+  value: T;
+  disabled?: boolean | string;
+}
+
+/**
+ * The prompt seam the engine drives. Injected so the engine is testable with no
+ * TTY: the production implementation ({@link defaultWizardIO}) wraps
+ * `@inquirer/prompts`; a test passes a scripted fake that records calls and
+ * returns canned answers.
+ */
+export interface WizardIO {
+  select<T>(opts: { message: string; choices: WizardChoice<T>[]; default?: T }): Promise<T>;
+  input(opts: { message: string; default?: string; validate?: (v: string) => true | string }): Promise<string>;
+  password(opts: { message: string }): Promise<string>;
+  confirm(opts: { message: string; default?: boolean }): Promise<boolean>;
+  /** Emit an informational line — a disabled field's reason, or a preset note. */
+  note(message: string): void;
+}
+
+/**
+ * The mutable draft threaded through every step. It is a superset of both modes'
+ * fields; a step reads what it needs and records its answer here. `create` maps
+ * the finished draft into `{ source, name, opts }` for `runForkFlow`; `edit` maps
+ * it into the `EditOptions` shape the flag-driven edit path already persists — so
+ * a wizard-built and a hand-written harness are byte-identical after save.
+ */
+export interface HarnessDraft {
+  readonly mode: WizardMode;
+  /** create: the fork source (a native agent id or an existing harness name). */
+  source?: string;
+  /** The resolved host CLI — drives the editability seams. edit: the profile host. */
+  host?: AgentId;
+  name?: string;
+  model?: string;
+  baseUrl?: string;
+  authProvider?: string;
+  /** `<bundle>` or `<bundle>:<key>` — a value copied out of an agents secrets bundle. */
+  fromSecrets?: string;
+  version?: string;
+  description?: string;
+  fallbackModel?: string;
+  /** edit: the profile being edited, providing current values. Read-only. */
+  readonly original?: Profile;
+  /**
+   * RUSH-2223 seam (cross-host portability): the target host to re-key a cloned
+   * harness onto (`fork --to-host <host>`). The scaffold never sets it; the
+   * portability subtask reads it in an extended source step. Left here so the
+   * draft shape is stable when that lands.
+   */
+  toHost?: AgentId;
+
+  // --- transient wizard state (never persisted) ---
+  /** The user chose "build custom" over a preset (create only). */
+  custom?: boolean;
+  /** The preset a create run selected, if any. */
+  preset?: string;
+  /** Pre-computed default for the name prompt (source or preset name). */
+  defaultName?: string;
+  /** The provider step has run (distinguishes "no auth chosen" from "not asked"). */
+  providerAsked?: boolean;
+}
+
+/**
+ * What the engine does with a step for a given draft:
+ *   - `'run'`             prompt the user, validate, and apply into the draft.
+ *   - `'skip'`            value already supplied (by a flag) or step N/A — silent.
+ *   - `{ disabled: … }`   the step does not apply to this host; surface the reason
+ *                         (the field reads as greyed/disabled) but do not prompt.
+ *                         This is the seam the edit matrix (RUSH-2222) drives.
+ */
+export type StepDecision = 'run' | 'skip' | { disabled: string };
+
+/** One wizard step: decide, then (only when decided `'run'`) prompt + apply. */
+export interface WizardStep {
+  readonly id: string;
+  decide(draft: HarnessDraft): StepDecision;
+  run(io: WizardIO, draft: HarnessDraft, hooks: WizardHooks): Promise<void>;
+}
+
+/** Per-host editability — which params this host's API format lets you change. */
+export interface HarnessEditable {
+  model: boolean;
+  baseUrl: boolean;
+  auth: boolean;
+  version: boolean;
+  fallback: boolean;
+}
+
+/**
+ * Resolver-sourced editability, the scaffold default behind the RUSH-2222 seam.
+ * Every field is read from the same maps the run-time resolver uses
+ * (`baseUrlEnvKeyForHost` / `authEnvKeyForHost` / `isSelfUpdatingAgent`), never a
+ * table hardcoded alongside them — so the wizard's enable/disable can never drift
+ * from what a run actually honors (repo rule: the capability table stays truthful,
+ * in lockstep with the code). RUSH-2222 may replace this via {@link WizardHooks.editable}
+ * to add per-param reasons; it must stay sourced from the resolver.
+ */
+export function defaultEditable(host: AgentId): HarnessEditable {
+  return {
+    model: true,
+    baseUrl: baseUrlEnvKeyForHost(host) !== null,
+    auth: authEnvKeyForHost(host) !== null,
+    version: !isSelfUpdatingAgent(host),
+    fallback: true,
+  };
+}
+
+/** Outcome of a connection test (RUSH-2221 fills the real classifier). */
+export interface ConnectionTestResult {
+  ok: boolean;
+  /** Machine-readable class when it failed (auth / endpoint / model / unknown). */
+  reason?: 'auth' | 'endpoint' | 'model' | 'unknown';
+  message?: string;
+}
+
+/**
+ * Extension points the sibling subtasks fill without touching the engine. Each is
+ * a real no-op-by-default seam: absent, the scaffold uses today's behavior; none
+ * fabricates a result.
+ */
+export interface WizardHooks {
+  /**
+   * RUSH-2220 — model catalog pick. Given the resolved host (+ version and the
+   * current value in edit), return a chosen model id, or `null` to fall through
+   * to the free-text prompt. Absent → always free-text (today's behavior).
+   */
+  pickModel?: (
+    io: WizardIO,
+    host: AgentId | undefined,
+    version: string | undefined,
+    current: string | undefined,
+  ) => Promise<string | null>;
+  /**
+   * RUSH-2221 — connection test after configure, before save. Absent → no test
+   * (the wizard saves without one, exactly as today).
+   */
+  connectionTest?: (draft: HarnessDraft) => Promise<ConnectionTestResult>;
+  /**
+   * RUSH-2222 — per-host editability matrix. Absent → {@link defaultEditable}.
+   */
+  editable?: (host: AgentId) => HarnessEditable;
+}
+
+/** Resolve the host CLI a fork `source` runs under (the host `buildFork` will use). */
+export function hostForSource(source: string | undefined): AgentId | undefined {
+  if (!source) return undefined;
+  const native = resolveAgentName(source);
+  if (native) return native;
+  // An existing custom harness: its own host.
+  const custom = listProfiles().find((p) => p.name === source);
+  return custom?.host.agent;
+}
+
+/**
+ * The engine. Walk the steps in order; for each, ask `decide` what to do, then
+ * prompt only when it says `'run'`. A `{ disabled }` decision surfaces the reason
+ * and moves on; `'skip'` is silent. Returns the finished draft.
+ */
+export async function runWizardSteps(
+  steps: WizardStep[],
+  draft: HarnessDraft,
+  io: WizardIO,
+  hooks: WizardHooks = {},
+): Promise<HarnessDraft> {
+  for (const step of steps) {
+    const decision = step.decide(draft);
+    if (decision === 'run') {
+      await step.run(io, draft, hooks);
+    } else if (decision !== 'skip') {
+      io.note(chalk.gray(`${step.id}: ${decision.disabled}`));
+    }
+  }
+  return draft;
+}
+
+// --- shared prompt fragments ------------------------------------------------
+
+const NO_AUTH = '__none__';
+const CUSTOM = '__custom__';
+const TYPE_NOW = 'type';
+const FROM_SECRETS = 'secrets';
+const KEEP = '__keep__';
+
+/** The first `_MODEL`-suffixed env var in a preset's static env block, if any. */
+function presetModel(preset: Preset): string | undefined {
+  return Object.entries(preset.env).find(([k]) => k.endsWith('_MODEL'))?.[1];
+}
+
+/** Providers offered in the custom-auth select, deduped from the preset catalog. */
+function knownProviders(): string[] {
+  return [...new Set(listPresets().map((p) => p.provider))];
+}
+
+/**
+ * Prompt for a key source when a provider needs one: type it now, or copy it from
+ * an existing agents secrets bundle. Sets `draft.fromSecrets` for the bundle path;
+ * the type-now path is handled downstream (ensureProviderToken), unchanged. This
+ * is today's behavior, lifted verbatim; RUSH-2220 enriches the bundle browse.
+ */
+async function askKeySource(io: WizardIO, draft: HarnessDraft, provider: string): Promise<void> {
+  const bundles = listBundles();
+  const source =
+    bundles.length > 0
+      ? await io.select<string>({
+          message: `How should '${provider}' get its key?`,
+          choices: [
+            { name: 'Type a key now', value: TYPE_NOW },
+            { name: 'Use an existing agents secrets bundle', value: FROM_SECRETS },
+          ],
+        })
+      : TYPE_NOW;
+  if (source !== FROM_SECRETS) return;
+  const bundleName = await io.select<string>({
+    message: 'Bundle',
+    choices: bundles.map((b) => ({
+      name: b.description ? `${b.name}  ${chalk.gray(b.description)}` : b.name,
+      value: b.name,
+    })),
+  });
+  const bundle = bundles.find((b) => b.name === bundleName)!;
+  const keys = Object.keys(bundle.vars);
+  const key =
+    keys.length === 1
+      ? keys[0]
+      : await io.select<string>({ message: 'Key', choices: keys.map((k) => ({ name: k, value: k })) });
+  draft.fromSecrets = `${bundleName}:${key}`;
+}
+
+/** Free-text model prompt, unless RUSH-2220's catalog hook picks one first. */
+async function askModel(io: WizardIO, draft: HarnessDraft, hooks: WizardHooks, current?: string): Promise<string> {
+  if (hooks.pickModel) {
+    const picked = await hooks.pickModel(io, draft.host, draft.version ?? draft.original?.host.version, current);
+    if (picked !== null) return picked;
+  }
+  return io.input({ message: 'Model id', default: current });
+}
+
+// --- create steps -----------------------------------------------------------
+
+/**
+ * The create step list — the shape of `agents harness add`/`fork`. Faithful to
+ * the previous `runHarnessWizard` sequence (source → preset|custom → model →
+ * provider → base URL → name → key source), re-expressed as engine steps so the
+ * sibling subtasks can gate/replace individual steps. Produces the same
+ * `{ source, name, opts }` draft the fork flow already persists.
+ */
+export function createSteps(): WizardStep[] {
+  return [
+    {
+      id: 'source',
+      decide: (d) => (d.source ? 'skip' : 'run'),
+      async run(io, d) {
+        const customNames = listProfiles().map((p) => p.name);
+        d.source = await io.select<string>({
+          message: 'Fork from',
+          choices: [
+            ...ALL_AGENT_IDS.map((id) => ({ name: `${AGENTS[id].name}  ${chalk.gray('(native)')}`, value: id as string })),
+            ...customNames.map((n) => ({ name: `${n}  ${chalk.gray('(custom harness)')}`, value: n })),
+          ],
+        });
+        d.host = hostForSource(d.source) ?? d.host;
+        d.defaultName = d.source;
+      },
+    },
+    {
+      id: 'preset',
+      decide: (d) => (d.custom || d.preset !== undefined || d.model !== undefined ? 'skip' : 'run'),
+      async run(io, d) {
+        const presets = listPresets();
+        const choice = await io.select<string>({
+          message: 'Preset',
+          choices: [
+            ...presets.map((p) => ({ name: `${p.name}  ${chalk.gray(p.description.slice(0, 60))}`, value: p.name })),
+            { name: 'Build custom (host + model + provider)', value: CUSTOM },
+          ],
+        });
+        if (choice === CUSTOM) {
+          d.custom = true;
+          return;
+        }
+        const preset = getPreset(choice)!;
+        d.preset = preset.name;
+        d.model = presetModel(preset);
+        d.baseUrl = preset.env.ANTHROPIC_BASE_URL || preset.env.OPENAI_BASE_URL || undefined;
+        d.authProvider = preset.authOptional ? undefined : preset.provider;
+        d.providerAsked = true;
+        // Pre-fill the name with the preset's own name (e.g. 'deepseek'), not a
+        // model detail, so users aren't nudged toward baking one into the identity.
+        d.defaultName = preset.name;
+      },
+    },
+    {
+      id: 'model',
+      decide: (d) => (d.custom && d.model === undefined ? 'run' : 'skip'),
+      async run(io, d, hooks) {
+        d.model = await askModel(io, d, hooks);
+      },
+    },
+    {
+      id: 'provider',
+      decide: (d) => (d.custom && !d.providerAsked ? 'run' : 'skip'),
+      async run(io, d) {
+        const choice = await io.select<string>({
+          message: 'Provider',
+          choices: [
+            ...knownProviders().map((p) => ({ name: p, value: p })),
+            { name: 'no auth / host manages its own login', value: NO_AUTH },
+          ],
+        });
+        d.authProvider = choice === NO_AUTH ? undefined : choice;
+        d.providerAsked = true;
+      },
+    },
+    {
+      id: 'baseUrl',
+      decide: (d) => {
+        if (!d.custom || d.baseUrl !== undefined) return 'skip';
+        // Endpoint slot is a function of the host's API format (§3.4): only the
+        // Anthropic/OpenAI-compatible hosts carry one. Skipping the prompt for the
+        // rest replaces the old silent-drop (`profileFromHostModel` discards a
+        // base URL the host can't honor) with an explicit reason.
+        const host = d.host ?? hostForSource(d.source);
+        if (host && baseUrlEnvKeyForHost(host) === null) {
+          return { disabled: `host '${host}' has no custom-endpoint slot — base URL not applicable` };
+        }
+        return 'run';
+      },
+      async run(io, d) {
+        const url = await io.input({ message: 'Base URL (optional)', default: '' });
+        d.baseUrl = url || undefined;
+      },
+    },
+    {
+      id: 'name',
+      decide: (d) => (d.name ? 'skip' : 'run'),
+      async run(io, d) {
+        d.name = await io.input({
+          message: 'Harness name',
+          default: d.defaultName,
+          validate: (v) => {
+            try {
+              validateProfileName(v);
+              return true;
+            } catch (err) {
+              return (err as Error).message;
+            }
+          },
+        });
+      },
+    },
+    {
+      id: 'auth',
+      decide: (d) => (d.authProvider && d.fromSecrets === undefined ? 'run' : 'skip'),
+      async run(io, d) {
+        await askKeySource(io, d, d.authProvider!);
+      },
+    },
+    connectionTestStep(),
+  ];
+}
+
+// --- edit steps -------------------------------------------------------------
+
+/** The raw model id currently pinned on a profile (not the display label). */
+function currentModel(p: Profile): string | undefined {
+  return p.env[modelEnvKeyForHost(p.host.agent)];
+}
+
+/** The raw base URL currently pinned on a profile, if the host carries one. */
+function currentBaseUrl(p: Profile): string | undefined {
+  const key = baseUrlEnvKeyForHost(p.host.agent);
+  return key ? p.env[key] : undefined;
+}
+
+/**
+ * The edit step list — `agents harness edit <name>` with no flags on a TTY. Each
+ * step is pre-filled with the profile's current value and gated by the host's
+ * editability matrix (RUSH-2222 seam): an unsupported param reads as disabled with
+ * a reason instead of being silently accepted. Records into the same draft, which
+ * `runEditWizard` maps to the `EditOptions` shape the flag path already persists.
+ */
+export function editSteps(original: Profile): WizardStep[] {
+  const host = original.host.agent;
+  const editableFor = (hooks: WizardHooks) => (hooks.editable ?? defaultEditable)(host);
+  // decide() has no access to hooks, so gate on the resolver default; a hook that
+  // narrows editability further is applied inside run(). The scaffold's default is
+  // the resolver truth, which is what the matrix subtask builds on.
+  const cap = defaultEditable(host);
+  return [
+    {
+      id: 'model',
+      decide: () => (cap.model ? 'run' : { disabled: `host '${host}' does not support a pinned model` }),
+      async run(io, d, hooks) {
+        if (!editableFor(hooks).model) return;
+        d.model = await askModel(io, d, hooks, currentModel(original));
+      },
+    },
+    {
+      id: 'baseUrl',
+      decide: () => (cap.baseUrl ? 'run' : { disabled: `host '${host}' has no custom-endpoint slot` }),
+      async run(io, d, hooks) {
+        if (!editableFor(hooks).baseUrl) return;
+        const url = await io.input({ message: 'Base URL', default: currentBaseUrl(original) ?? '' });
+        d.baseUrl = url || '';
+      },
+    },
+    {
+      id: 'auth',
+      decide: () => (cap.auth ? 'run' : { disabled: `host '${host}' manages its own login — no auth to edit` }),
+      async run(io, d, hooks) {
+        if (!editableFor(hooks).auth) return;
+        const bundles = listBundles();
+        const choices: WizardChoice<string>[] = [
+          { name: 'Leave auth unchanged', value: KEEP },
+          { name: 'Repoint to a provider (enter a key)', value: TYPE_NOW },
+        ];
+        if (bundles.length > 0) choices.push({ name: 'Copy a key from an agents secrets bundle', value: FROM_SECRETS });
+        const choice = await io.select<string>({ message: 'Auth', choices });
+        if (choice === KEEP) return;
+        const provider = await io.input({
+          message: 'Provider',
+          default: original.provider,
+          validate: (v) => (v.trim() ? true : 'Provider is required'),
+        });
+        d.authProvider = provider;
+        if (choice === FROM_SECRETS) await askKeySource(io, d, provider);
+      },
+    },
+    {
+      id: 'version',
+      decide: () =>
+        cap.version ? 'run' : { disabled: `host '${host}' self-updates — its version can't be pinned` },
+      async run(io, d, hooks) {
+        if (!editableFor(hooks).version) return;
+        d.version = await io.input({
+          message: 'Host CLI version (blank to unpin)',
+          default: original.host.version ?? '',
+        });
+      },
+    },
+    {
+      id: 'fallback',
+      decide: () => (cap.fallback ? 'run' : 'skip'),
+      async run(io, d) {
+        d.fallbackModel = await io.input({
+          message: 'Fallback model (same-host rate-limit retry; blank for none)',
+          default: original.fallback_model ?? '',
+        });
+      },
+    },
+    {
+      id: 'description',
+      decide: () => 'run',
+      async run(io, d) {
+        d.description = await io.input({ message: 'Description', default: original.description ?? '' });
+      },
+    },
+    connectionTestStep(),
+  ];
+}
+
+/**
+ * The connection-test step (RUSH-2221 seam). Kept in both step lists so the id is
+ * a stable member of the sequence, but the actual test needs the assembled profile
+ * (which the caller builds after the wizard), so the run is performed separately by
+ * {@link runConnectionTest}. The step itself decides `'skip'` — a real no-op
+ * extension point that fakes nothing.
+ */
+function connectionTestStep(): WizardStep {
+  return {
+    id: 'connectionTest',
+    decide: () => 'skip',
+    async run() {
+      /* no-op: superseded by runConnectionTest, kept so the step id is stable */
+    },
+  };
+}
+
+/**
+ * Run the connection-test hook against a finished draft, if one is wired
+ * (RUSH-2221). Returns `null` when no hook is present (no test performed) so the
+ * caller can distinguish "not tested" from "tested and passed". Separated from the
+ * step list because the test needs the assembled profile, which the caller builds.
+ */
+export async function runConnectionTest(
+  draft: HarnessDraft,
+  hooks: WizardHooks,
+): Promise<ConnectionTestResult | null> {
+  if (!hooks.connectionTest) return null;
+  return hooks.connectionTest(draft);
+}
+
+/**
+ * Production {@link WizardIO} over `@inquirer/prompts`, lazy-imported so the
+ * dependency loads only when a wizard actually runs. `note` prints to stderr so it
+ * never contaminates a `--json`/piped stdout.
+ */
+export async function defaultWizardIO(): Promise<WizardIO> {
+  const { select, input, password, confirm } = await import('@inquirer/prompts');
+  return {
+    select: (opts) => select(opts as Parameters<typeof select>[0]) as Promise<never>,
+    input: (opts) => input(opts),
+    password: (opts) => password({ message: opts.message, mask: true }),
+    confirm: (opts) => confirm(opts),
+    note: (message) => console.error(message),
+  };
+}

--- a/apps/cli/src/commands/harness.ts
+++ b/apps/cli/src/commands/harness.ts
@@ -31,15 +31,23 @@ import {
   renameProfile,
   profileFromHostModel,
   authEnvKeyForHost,
+  modelEnvKeyForHost,
+  baseUrlEnvKeyForHost,
   getProfilePath,
   validateProfileName,
   type Profile,
   type ForkProfileOptions,
 } from '../lib/profiles.js';
 import { listPresets, getPreset } from '../lib/profiles-presets.js';
-import { listBundles } from '../lib/secrets/bundles.js';
 import { AGENTS, ALL_AGENT_IDS, resolveAgentName } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
+import {
+  runWizardSteps,
+  createSteps,
+  editSteps,
+  defaultWizardIO,
+  type HarnessDraft,
+} from './harness-wizard.js';
 
 /** Short capability summary for a native harness — its supported run modes. */
 function nativeModes(id: (typeof ALL_AGENT_IDS)[number]): string {
@@ -244,115 +252,92 @@ async function runForkFlow(source: string, name: string, opts: ForkOptions): Pro
   console.log(chalk.gray(`Try: agents run ${name} "hello"`));
 }
 
-/** The first `_MODEL`-suffixed env var in a preset's static env block, if any. */
-function presetModel(preset: ReturnType<typeof listPresets>[number]): string | undefined {
-  return Object.entries(preset.env).find(([k]) => k.endsWith('_MODEL'))?.[1];
+/**
+ * Interactive `agents harness add`/`fork` wizard — runs when required info is
+ * missing and stdin+stdout are a TTY (see {@link forkNeedsWizard}, {@link addNeedsWizard}).
+ * Drives the shared step engine ({@link createSteps}) and maps its finished draft
+ * back to the same `(source, name, opts)` shape {@link buildFork} accepts via
+ * {@link runForkFlow}, so a wizard run and a hand-written fork call build an
+ * identical profile.
+ */
+async function runCreateWizard(): Promise<{ source: string; name: string; opts: ForkOptions }> {
+  const io = await defaultWizardIO();
+  const draft = await runWizardSteps(createSteps(), { mode: 'create' }, io);
+  return {
+    source: draft.source!,
+    name: draft.name!,
+    opts: {
+      model: draft.model,
+      baseUrl: draft.baseUrl,
+      authProvider: draft.authProvider,
+      fromSecrets: draft.fromSecrets,
+    },
+  };
 }
 
 /**
- * Interactive `agents harness add`/`fork` wizard — runs when required info is
- * missing and stdout is a TTY (see {@link forkNeedsWizard}, {@link addNeedsWizard}).
- * Always resolves to the same `(source, name, opts)` shape {@link buildFork}
- * accepts via {@link runForkFlow}, so a wizard run and a hand-written fork call
- * build an identical profile.
+ * Map a finished edit-wizard draft onto {@link EditOptions}, keeping only the
+ * fields the user actually changed from the profile's current values. Unchanged
+ * accepts (the wizard pre-fills each prompt with the current value) drop out, so
+ * the resulting {@link buildEdit} touches nothing the user left alone — and the
+ * "no changes" case is detectable via {@link hasEditFlags}. Base-URL clearing is
+ * intentionally not expressed here: the flag path can't clear it either (an empty
+ * `--base-url` is a no-op in `forkProfile`), so the wizard matches that until a
+ * later subtask adds explicit clearing.
  */
-async function runHarnessWizard(): Promise<{ source: string; name: string; opts: ForkOptions }> {
-  const { select, input } = await import('@inquirer/prompts');
+export function draftToEditOptions(draft: HarnessDraft, original: Profile): EditOptions {
+  const host = original.host.agent;
+  const curModel = original.env[modelEnvKeyForHost(host)];
+  const baseKey = baseUrlEnvKeyForHost(host);
+  const curBaseUrl = baseKey ? original.env[baseKey] : undefined;
+  const curVersion = original.host.version ?? '';
+  const curFallback = original.fallback_model ?? '';
+  const curDescription = original.description ?? '';
 
-  const customNames = listProfiles().map((p) => p.name);
-  const source = await select<string>({
-    message: 'Fork from',
-    choices: [
-      ...ALL_AGENT_IDS.map((id) => ({ name: `${AGENTS[id].name}  ${chalk.gray('(native)')}`, value: id as string })),
-      ...customNames.map((n) => ({ name: `${n}  ${chalk.gray('(custom harness)')}`, value: n })),
-    ],
-  });
+  const opts: EditOptions = {};
+  if (draft.model !== undefined && draft.model !== curModel) opts.model = draft.model;
+  if (draft.baseUrl && draft.baseUrl !== curBaseUrl) opts.baseUrl = draft.baseUrl;
+  if (draft.authProvider !== undefined) opts.authProvider = draft.authProvider;
+  if (draft.fromSecrets !== undefined) opts.fromSecrets = draft.fromSecrets;
+  if (draft.version !== undefined && draft.version !== curVersion) opts.version = draft.version;
+  if (draft.fallbackModel !== undefined && draft.fallbackModel !== curFallback) opts.fallbackModel = draft.fallbackModel;
+  if (draft.description !== undefined && draft.description !== curDescription) opts.description = draft.description;
+  return opts;
+}
 
-  const presets = listPresets();
-  const CUSTOM = '__custom__';
-  const presetChoice = await select<string>({
-    message: 'Preset',
-    choices: [
-      ...presets.map((p) => ({ name: `${p.name}  ${chalk.gray(p.description.slice(0, 60))}`, value: p.name })),
-      { name: 'Build custom (host + model + provider)', value: CUSTOM },
-    ],
-  });
-
-  let model: string | undefined;
-  let baseUrl: string | undefined;
-  let authProvider: string | undefined;
-  let defaultName = source;
-
-  if (presetChoice === CUSTOM) {
-    model = await input({ message: 'Model id' });
-    const NO_AUTH = '__none__';
-    const providers = [...new Set(presets.map((p) => p.provider))];
-    const providerChoice = await select<string>({
-      message: 'Provider',
-      choices: [
-        ...providers.map((p) => ({ name: p, value: p })),
-        { name: 'no auth / host manages its own login', value: NO_AUTH },
-      ],
-    });
-    authProvider = providerChoice === NO_AUTH ? undefined : providerChoice;
-    const baseUrlInput = await input({ message: 'Base URL (optional)', default: '' });
-    baseUrl = baseUrlInput || undefined;
-  } else {
-    const preset = getPreset(presetChoice)!;
-    model = presetModel(preset);
-    baseUrl = preset.env.ANTHROPIC_BASE_URL || preset.env.OPENAI_BASE_URL;
-    authProvider = preset.authOptional ? undefined : preset.provider;
-    // Pre-fill with the preset's own name (e.g. 'deepseek'), not a model
-    // detail, so users aren't nudged toward baking one into the identity name.
-    defaultName = preset.name;
+/**
+ * Interactive `agents harness edit <name>` wizard — runs when no edit flags were
+ * given and stdin+stdout are a TTY. Loads the profile, drives the shared step
+ * engine ({@link editSteps}) pre-filled with current values, then persists via the
+ * same build+write path as the flag-driven edit. `--key-stdin` is honored for the
+ * auth step's key entry. When the user changes nothing, it says so and writes
+ * nothing.
+ */
+async function runEditWizard(name: string, cliOpts: EditOptions): Promise<void> {
+  if (!profileExists(name)) {
+    throw new Error(`Harness '${name}' not found. Create it first: agents harness add ${name} ...`);
   }
-
-  const name = await input({
-    message: 'Harness name',
-    default: defaultName,
-    validate: (v) => {
-      try {
-        validateProfileName(v);
-        return true;
-      } catch (err) {
-        return (err as Error).message;
-      }
-    },
-  });
-
-  const opts: ForkOptions = { model, baseUrl, authProvider };
-
-  if (authProvider) {
-    const bundles = listBundles();
-    const TYPE_NOW = 'type';
-    const FROM_SECRETS = 'secrets';
-    const keySource = bundles.length > 0
-      ? await select<string>({
-          message: `How should '${authProvider}' get its key?`,
-          choices: [
-            { name: 'Type a key now', value: TYPE_NOW },
-            { name: 'Use an existing agents secrets bundle', value: FROM_SECRETS },
-          ],
-        })
-      : TYPE_NOW;
-    if (keySource === FROM_SECRETS) {
-      const bundleName = await select<string>({
-        message: 'Bundle',
-        choices: bundles.map((b) => ({
-          name: b.description ? `${b.name}  ${chalk.gray(b.description)}` : b.name,
-          value: b.name,
-        })),
-      });
-      const bundle = bundles.find((b) => b.name === bundleName)!;
-      const keys = Object.keys(bundle.vars);
-      const key = keys.length === 1
-        ? keys[0]
-        : await select<string>({ message: 'Key', choices: keys.map((k) => ({ name: k, value: k })) });
-      opts.fromSecrets = `${bundleName}:${key}`;
-    }
+  const original = readProfile(name);
+  const io = await defaultWizardIO();
+  const draft = await runWizardSteps(
+    editSteps(original),
+    { mode: 'edit', original, host: original.host.agent, name },
+    io,
+  );
+  const opts: EditOptions = { ...draftToEditOptions(draft, original), keyStdin: cliOpts.keyStdin };
+  if (!hasEditFlags(opts)) {
+    console.log(chalk.gray(`No changes made to '${name}'.`));
+    return;
   }
-
-  return { source, name, opts };
+  const edited = buildEdit(name, opts);
+  if (opts.fromSecrets) {
+    await applyFromSecrets(edited, opts.fromSecrets, opts.authProvider);
+  } else if (opts.authProvider) {
+    await ensureProviderToken(opts.authProvider, undefined, opts.keyStdin);
+  }
+  writeProfile(edited);
+  console.log(chalk.green(`Harness '${name}' updated.`));
+  console.log(chalk.gray(`Model:  ${profileModelLabel(edited)}`));
 }
 
 export function registerHarnessCommands(program: Command): void {
@@ -419,7 +404,7 @@ Examples:
               "'agents harness add' needs --preset or --host + --model (or a name and an interactive terminal for the wizard).",
             );
           }
-          const wiz = await runHarnessWizard();
+          const wiz = await runCreateWizard();
           await runForkFlow(wiz.source, wiz.name, { ...wiz.opts, force: opts.force, keyStdin: opts.keyStdin });
           return;
         }
@@ -467,7 +452,7 @@ Examples:
           if (!isInteractiveTerminal()) {
             throw new Error("'agents harness fork' needs <source> and <name> (or an interactive terminal for the wizard).");
           }
-          const wiz = await runHarnessWizard();
+          const wiz = await runCreateWizard();
           await runForkFlow(wiz.source, wiz.name, { ...wiz.opts, force: opts.force, keyStdin: opts.keyStdin });
           return;
         }
@@ -480,7 +465,7 @@ Examples:
 
   cmd
     .command('edit <name>')
-    .description('Edit an existing custom harness in place — model, endpoint, auth, version, description, fallback.')
+    .description('Edit an existing custom harness in place — model, endpoint, auth, version, description, fallback. Omit flags in a terminal for the interactive wizard.')
     .option('--model <id>', 'Swap the pinned model')
     .option('--base-url <url>', 'Swap the custom endpoint base URL')
     .option('--auth-provider <provider>', 'Repoint auth at a different provider (keychain-backed)')
@@ -507,10 +492,21 @@ Examples:
 
   # Copy a key out of an existing secrets bundle instead of typing it
   agents harness edit corp --from-secrets prod:OPENROUTER_KEY
+
+  # No flags, in an interactive terminal: a wizard walks each field pre-filled
+  agents harness edit deepseek
 `,
     )
     .action(async (name: string, opts: EditOptions) => {
       try {
+        // No edit flags + a real terminal → the interactive wizard, pre-filled
+        // with current values. Any flag (or a non-interactive caller) takes the
+        // flag path unchanged; a flagless non-interactive call still errors via
+        // buildEdit's EDIT_FLAGS_HELP.
+        if (!hasEditFlags(opts) && isInteractiveTerminal()) {
+          await runEditWizard(name, opts);
+          return;
+        }
         const edited = buildEdit(name, opts);
         if (opts.fromSecrets) {
           await applyFromSecrets(edited, opts.fromSecrets, opts.authProvider);


### PR DESCRIPTION
**refactor + feature (RUSH-2219)** — the wizard *scaffold* only. A shared step engine both `harness add/fork` and `harness edit` drive through; the sibling subtasks (RUSH-2220 catalog, 2221 connection test, 2222 edit matrix, 2223 portability) build on the typed seams here. Parent: RUSH-2218.

## What changed

- **New `apps/cli/src/commands/harness-wizard.ts`** — one step engine, two modes. A step is `decide → prompt → apply`; every step is skippable by the matching flag; the engine talks to the user through an injectable `WizardIO` (testable with no TTY).
- **`harness edit` is now wizard-capable** — flagless `edit` on a TTY opens the same wizard, pre-filled with current values, and writes only what changed. Flag-only edit and the flagless-non-interactive error are unchanged.
- **Matrix gating sourced from the resolver** — `defaultEditable(host)` reads `baseUrlEnvKeyForHost` / `authEnvKeyForHost` / `isSelfUpdatingAgent`, so endpoint/version prompts disable (with a reason) exactly where a run would drop the value. No hardcoded table.
- **Real no-op seams, not stubs** — `WizardHooks.{pickModel, connectionTest, editable}` (RUSH-2220/2221/2222) and `HarnessDraft.toHost` (RUSH-2223). Absent, the scaffold uses today's behavior; none fakes a result.

Scope held: no catalog, no connection test, no full edit matrix, no `--to-host`.

## Run result

Directly-affected suites (real path, no mocking):

```
$ npx vitest run src/commands/harness-wizard.test.ts src/commands/harness.test.ts src/lib/profiles.test.ts
 Test Files  3 passed (3)
      Tests  106 passed (106)     # 16 new + 90 existing, no regressions
$ npx tsc --noEmit   →  0 errors
```

Real CLI, flag paths + preserved error (throwaway harness on a live install):

```
$ agents harness add zz-wiz-e2e --host opencode --model meta/muse-spark-1.1
Harness 'zz-wiz-e2e' added — opencode + meta/muse-spark-1.1.
$ agents harness edit zz-wiz-e2e --model meta/muse-spark-1.2
Harness 'zz-wiz-e2e' updated.   Model: meta/muse-spark-1.2
$ agents harness view zz-wiz-e2e
Host:  opencode   Model: meta/muse-spark-1.2
$ agents harness edit zz-wiz-e2e < /dev/null      # flagless, non-interactive
No changes given. Available flags: --model, --base-url, --auth-provider, --version, --description, --fallback-model, --from-secrets.
```

The wizard branch itself needs a TTY, so it's exercised by the injectable-`WizardIO` engine tests (16 cases) rather than a live prompt — which is exactly the "pure/injectable enough to test without a TTY" requirement.

## Docs
Maintainer + end-user: `apps/cli/docs/profiles.md` (edit wizard + shared engine), CHANGELOG fragment `apps/cli/.changelog/next/RUSH-2219.md`.
