### PR TITLE
fix(doctor): standardize --check verdict + fix cold/never-synced badge mismatch (RUSH-2234)

### DIFF
--- a/apps/cli/.changelog/next/rush-2234-doctor-check-verdict.md
+++ b/apps/cli/.changelog/next/rush-2234-doctor-check-verdict.md
@@ -1,0 +1,8 @@
+- **`agents doctor --check` verdict lines now carry a `check:` prefix and a total
+  version count**, so CI logs and log-scrapers get one consistent, grep-alike shape
+  whether the result is clean or drifted: `check: ok — 3 version(s) in sync` /
+  `check: drift — 2 stale, 1 never-synced across 3 version(s)`. The per-version
+  status badge for a never-synced version now reads `never-synced` (its real
+  status) instead of the unrelated `cold` label, and all three badges
+  (`stale`/`never-synced`/`unwired`) share one fixed-width column so the rows
+  align. Source: `apps/cli/src/commands/doctor.ts` (`runCheckGate`).

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1229,26 +1229,34 @@ function runCheckGate(opts: DoctorOptions, cwd: string): void {
     const orphanNote = drift.orphanVersionCount > 0
       ? chalk.gray(` (${drift.orphanVersionCount} version(s) carry orphans — run \`agents prune cleanup\`)`)
       : '';
-    console.log(`${chalk.green('ok')}  ${drift.syncRows.length} version(s) in sync${orphanNote}`);
+    console.log(`${chalk.gray('check:')} ${chalk.green('ok')} — ${drift.syncRows.length} version(s) in sync${orphanNote}`);
     process.exit(0);
   }
 
-  // Drift: one-line verdict always, per-version detail unless --quiet.
+  // Drift: one-line verdict always, per-version detail unless --quiet. The
+  // `check:` prefix and total count make every verdict line grep/parse-alike
+  // whether it's clean or drifted, instead of the bare `drift  <parts>` shape
+  // that gave CI logs no anchor to search on.
   const parts: string[] = [];
   if (drift.staleCount > 0) parts.push(`${drift.staleCount} stale`);
   if (drift.neverSyncedCount > 0) parts.push(`${drift.neverSyncedCount} never-synced`);
   if (drift.unwiredHookVersions > 0) parts.push(`${drift.unwiredHookVersions} with unwired hooks`);
   if (drift.sourceBehind.length > 0) parts.push(`${drift.sourceBehind.length} source layer(s) behind origin`);
-  console.error(`${chalk.red('drift')}  ${parts.join(', ')}`);
+  console.error(`${chalk.gray('check:')} ${chalk.red('drift')} — ${parts.join(', ')} across ${drift.syncRows.length} version(s)`);
 
   if (!opts.quiet) {
+    // Fixed-width, left-aligned so rows form a real column; the badge text is
+    // the actual status name ('never-synced'), not the unrelated 'cold' label
+    // that used to hide it. Width is 'never-synced'.length + a 2-space gap so
+    // the longest badge still separates cleanly from the label that follows.
+    const STATUS_BADGE_WIDTH = 'never-synced'.length + 2;
     for (const row of drift.syncRows) {
       const unwired = (row.unwiredHooks ?? 0) > 0;
       if (row.status === 'fresh' && !unwired) continue;
-      const tag = row.status === 'stale' ? chalk.yellow('stale')
-        : row.status === 'never-synced' ? chalk.gray('cold ')
-        : chalk.red('unwired'); // fresh but hooks not wired into settings.json
-      console.error(`  ${tag}  ${checkLabel(row)}`);
+      const tag = row.status === 'stale' ? chalk.yellow('stale'.padEnd(STATUS_BADGE_WIDTH))
+        : row.status === 'never-synced' ? chalk.gray('never-synced'.padEnd(STATUS_BADGE_WIDTH))
+        : chalk.red('unwired'.padEnd(STATUS_BADGE_WIDTH)); // fresh but hooks not wired into settings.json
+      console.error(`  ${tag}${checkLabel(row)}`);
       for (const line of row.divergence ?? []) {
         console.error(chalk.gray(`           ${line}`));
       }


### PR DESCRIPTION
**Bug fix, no new flags.** Standardizes `agents doctor --check`'s one-line verdict and fixes a stale status label — no behavior change to what triggers drift.

## Context

Follow-up from PR #1672 (RUSH-1234 deprecation tombstones). A Kimi review of `doctor.ts` at the time proposed several output improvements — most were **superseded same-day by the RUSH-2069 findings rewrite** (`a6d535ca`, landed a few hours after the review's snapshot), which already collapses noise, prioritizes critical-first, and gives every finding its own remediation command. I re-verified against the current `agents doctor` output (see RUSH-2234) before touching anything, rather than implementing a stale review against code that no longer exists in that shape.

One piece of the old review's item 5 still applied: `runCheckGate` — the CI drift gate, a separate codepath RUSH-2069 didn't touch — had no `check:` prefix or total-version count on its verdict line, and its per-row badge printed `cold` for a version whose real status is `never-synced`.

## What changed

`apps/cli/src/commands/doctor.ts` (`runCheckGate`):

- **Verdict lines now carry a `check:` prefix + total count**, one shape whether clean or drifted:
  - `check: ok — 1 version(s) in sync`
  - `check: drift — 1 stale, 1 never-synced across 2 version(s)`
- **`cold` → `never-synced`** — the badge now names the real status instead of an unrelated word.
- **Fixed-width badge column** so `stale` / `never-synced` / `unwired` align.

## Verified

Real fixture (not just the unit suite) — built the CLI, seeded a temp HOME with an installed + a never-synced version, ran the actual binary:

```
$ agents doctor --check --cwd <proj>     # clean
check: ok — 1 version(s) in sync
exit=0

$ agents doctor --check --cwd <proj>     # drift
check: drift — 1 stale, 1 never-synced across 2 version(s)
  stale         Claude@2.0.0
           commands    1 drifted
  never-synced  Claude@2.1.0

Reconcile with `agents doctor --fix` (or `agents doctor <agent>@<version> --fix`).
exit=1
```

That real run caught a bug the review-only pass missed: `'never-synced'.padEnd(12)` is exactly 12 chars, so the first version of this change glued the badge onto the label (`never-syncedClaude@2.1.0`) with no visible separator. Fixed by sizing the pad width to the longest badge plus an explicit gap, then re-verified against the same fixture.

`bunx vitest run src/commands/doctor.check.test.ts src/commands/doctor.test.ts` — 36/36 passing (existing assertions match on `'in sync'` / `'drift'` substrings, so the added prefix doesn't break them).

## Not in scope

The rest of the original Kimi review (overview-section collapsing, per-row fix commands in the human report, target-mode diff paths) is already implemented by the RUSH-2069 findings model — confirmed by running `agents doctor` / `agents doctor <agent>@<version>` live and reading the current renderer/finding-builder source, not by re-reading the stale review.

CHANGELOG: `apps/cli/.changelog/next/rush-2234-doctor-check-verdict.md`. Ticket: https://linear.app/getrush/issue/RUSH-2234