### PR TITLE
fix(sessions): bound provenance probes (RUSH-2063)

### DIFF
--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveCwds, LSOF_CONCURRENCY, agentKindFromComm, sessionAgentComms, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels, summarizeMission } from './active.js';
+import { resolveCwds, enrichProvenance, LSOF_CONCURRENCY, agentKindFromComm, sessionAgentComms, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels, summarizeMission } from './active.js';
 import { SESSION_AGENTS } from './types.js';
 import type { HookSessionIndex } from './hook-sessions.js';
 import type { DeviceProfile, DeviceRegistry } from '../devices/registry.js';
@@ -256,6 +256,27 @@ describe('resolveCwds', () => {
     };
     const cwds = await resolveCwds(pids, probe);
     expect(cwds).toEqual(['cwd-5', 'cwd-4', 'cwd-3', 'cwd-2', 'cwd-1']);
+  });
+});
+
+describe('enrichProvenance', () => {
+  it('bounds provenance probes to LSOF_CONCURRENCY', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const sessions = Array.from({ length: 30 }, (_, i) => ({ pid: i + 1000 })) as Parameters<typeof enrichProvenance>[0];
+    const probe = async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await delay(20);
+      inFlight--;
+      return { host: 'test', transport: 'local' as const };
+    };
+
+    await enrichProvenance(sessions, probe);
+
+    expect(maxInFlight).toBeLessThanOrEqual(LSOF_CONCURRENCY);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(sessions.every(s => s.provenance?.host === 'test')).toBe(true);
   });
 });
 

--- a/apps/cli/src/lib/session/active.test.ts
+++ b/apps/cli/src/lib/session/active.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { resolveCwds, enrichProvenance, LSOF_CONCURRENCY, agentKindFromComm, sessionAgentComms, activeStatusFromCloudStatus, resolveFallbackStatus, lifecycleStatus, ABANDONED_STALE_MS, resolvePaneIdentity, matchOriginDevice, annotateOrchestratorLabels, summarizeMission } from './active.js';
 import { SESSION_AGENTS } from './types.js';
 import type { HookSessionIndex } from './hook-sessions.js';
@@ -260,16 +262,19 @@ describe('resolveCwds', () => {
 });
 
 describe('enrichProvenance', () => {
-  it('bounds provenance probes to LSOF_CONCURRENCY', async () => {
+  it('bounds real provenance subprocesses to LSOF_CONCURRENCY', async () => {
     let inFlight = 0;
     let maxInFlight = 0;
     const sessions = Array.from({ length: 30 }, (_, i) => ({ pid: i + 1000 })) as Parameters<typeof enrichProvenance>[0];
     const probe = async () => {
       inFlight++;
       maxInFlight = Math.max(maxInFlight, inFlight);
-      await delay(20);
-      inFlight--;
-      return { host: 'test', transport: 'local' as const };
+      try {
+        await promisify(execFile)(process.execPath, ['-e', 'setTimeout(() => {}, 20)']);
+        return { host: 'test', transport: 'local' as const, reply: null };
+      } finally {
+        inFlight--;
+      }
     };
 
     await enrichProvenance(sessions, probe);

--- a/apps/cli/src/lib/session/active.ts
+++ b/apps/cli/src/lib/session/active.ts
@@ -1966,7 +1966,9 @@ function foldPresence(rows: ActiveSession[]): void {
  * session that has a live pid. Mutates in place. Runs after dedupe so we probe
  * each session once, not once per fork pid. Probes run in parallel — each is a
  * single /proc read (Linux) or `ps` call (macOS); failures leave `provenance`
- * undefined rather than blocking the listing.
+ * undefined rather than blocking the listing. The probes use the same bounded
+ * concurrency as the adjacent per-PID lsof sweep so large session lists cannot
+ * spawn one `ps eww` subprocess per row at once on macOS.
  *
  * A row that already carries provenance (the tmux path, which knows its exact
  * mux/reply from the pane) is not skipped — it is probe-and-MERGED. The tmux
@@ -1976,11 +1978,15 @@ function foldPresence(rows: ActiveSession[]): void {
  * authoritative mux/reply the pane already gave us. Skipping this (the old
  * behavior) is exactly why ssh-launched tmux sessions rendered as local.
  */
-async function enrichProvenance(sessions: ActiveSession[]): Promise<void> {
-  await Promise.all(
-    sessions.map(async (s) => {
+export async function enrichProvenance(
+  sessions: ActiveSession[],
+  probe: (pid: number) => Promise<SessionProvenance | undefined> = detectProvenance,
+): Promise<void> {
+  await mapBounded(
+    sessions,
+    async (s) => {
       if (!s.pid) return;
-      const probed = await detectProvenance(s.pid);
+      const probed = await probe(s.pid);
       if (!probed) return;
       if (!s.provenance) {
         s.provenance = probed;
@@ -1993,7 +1999,8 @@ async function enrichProvenance(sessions: ActiveSession[]): Promise<void> {
         s.provenance.ssh = probed.ssh;
       }
       if (probed.term && !s.provenance.term) s.provenance.term = probed.term;
-    }),
+    },
+    { concurrency: LSOF_CONCURRENCY },
   );
 }
 


### PR DESCRIPTION
Bounds the per-session provenance `ps eww` fan-out for every session-status gather.

## What changed

- Routes provenance enrichment through the existing `mapBounded` scheduler at `LSOF_CONCURRENCY` (4).
- Preserves probe results, merge behavior, and input ordering; only subprocess scheduling changes.
- Adds a real scheduler-path test that drives 30 asynchronous probes and asserts peak in-flight work never exceeds the cap.

## Verification

No UI surface; internal scheduling-only fix. [Captured focused test-run asset](https://gist.githubusercontent.com/muqsitnawaz/6d102dd846069bdf37ca51cc3a379ecd/raw/f56c2944bf2ce9054f028c4e7e8396a54ef9d294/rush-2063-test.txt): 41 pass, 0 fail, 90 assertions.

TypeScript: `bunx tsc --noEmit` exited 0.

Linear: RUSH-2063