### PR TITLE
feat(sessions): daemon-warmed cross-surface active-session cache (RUSH-2062)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2062.md
+++ b/apps/cli/.changelog/next/RUSH-2062.md
@@ -1,0 +1,10 @@
+- **Daemon-warmed cross-surface session-status cache (RUSH-2062).** Menubar,
+  Factory, watchdog, and CLI used to each re-run a full `sessions --active`
+  gather (~9s / ~170MB) with no sharing. The daemon now warms a local active-
+  session snapshot every 15s; those surfaces read the warm file when fresh.
+  `session/remote.ts` is cache-first too — a reachable host skips SSH while its
+  cache is within the freshness window (it used to replay only on
+  unreachable). Immutable per-session fields (topic, label, cwd, …) are memoized
+  by transcript mtime; live status never rides that memo. Source:
+  `apps/cli/src/lib/session/session-cache.ts`, `apps/cli/src/lib/session/remote.ts`,
+  `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -661,6 +661,16 @@ device over SSH, through one shared gather — `gatherActiveSessions` in
 `src/commands/sessions.ts`. `--host`/`--device` **scopes** that sweep to the named
 machines rather than adding to it.
 
+**Cross-surface cache (RUSH-2062).** The default path is cache-first against a
+daemon-warmed snapshot (`src/lib/session/session-cache.ts`, ~15s freshness). The
+daemon publishes this host's local active set on a short tick; menubar, Factory,
+watchdog, and CLI share it instead of each re-running the full gather. Live status
+stays inside that short window (`forceRefresh` / `AGENTS_SESSIONS_FORCE_REFRESH=1`
+re-gathers). Immutable identity fields are memoized by transcript mtime and never
+carry live status. `sessions --host` is likewise cache-first in
+`src/lib/session/remote.ts` (a reachable host skips SSH while the cache is fresh;
+unreachable still falls back to any age).
+
 On a TTY it opens the interactive browser seeded to running-only; `--json`,
 `--waiting`, and `--no-interactive` print the static grouped view instead. Both read
 the same gather, so they always agree on what is live.

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -29,6 +29,10 @@ import { mapPanesToTargets, listClients } from '../lib/tmux/session.js';
 import { resolveViewingIn, viewingInLabel } from '../lib/session/viewing-in.js';
 import { machineId, normalizeHost } from '../lib/session/sync/config.js';
 import { gatherRemoteActive, NO_FANOUT_ENV } from '../lib/session/remote-active.js';
+import {
+  loadFleetActiveSessions,
+  loadLocalActiveSessions,
+} from '../lib/session/session-cache.js';
 import { gatherRemoteList, gatherRemoteToolProgramCounts, gatherRemoteToolSearch, runOnPeer } from '../lib/session/remote-list.js';
 import { stringWidth, truncateToWidth, padToWidth, terminalWidth } from '../lib/session/width.js';
 import type { SessionActivity, AwaitingReason } from '../lib/session/state.js';
@@ -1330,8 +1334,52 @@ export function remoteHostsToDial(hosts: string[] | undefined, self: string): st
  * call it, so the browser can never disagree with `--active --json` about which
  * sessions are live (it used to call the local-only `getActiveSessions()` directly
  * and silently hid every remote session).
+ *
+ * RUSH-2062: default path is cache-first against the daemon-warmed shared
+ * snapshot (`session-cache.ts`). Menubar / Factory / watchdog / CLI share one
+ * warm result instead of each re-running the full SSH fan-out. `forceRefresh`
+ * (or `AGENTS_SESSIONS_FORCE_REFRESH=1`) re-gathers live; scoped `--host` lists
+ * always gather live so a filter never returns a wrong unscoped snapshot.
  */
 export async function gatherActiveSessions(
+  opts: { local?: boolean; hosts?: string[]; forceRefresh?: boolean } = {},
+): Promise<{ sessions: ActiveSession[]; remoteDeviceCount: number }> {
+  const forceRefresh = opts.forceRefresh === true
+    || process.env.AGENTS_SESSIONS_FORCE_REFRESH === '1';
+  // Scoped host lists are not represented in the unscoped fleet/local snapshot
+  // — always gather live so a filter cannot return the wrong set.
+  const scoped = (opts.hosts?.length ?? 0) > 0;
+
+  if (opts.local && !scoped) {
+    const loaded = await loadLocalActiveSessions({
+      forceRefresh,
+      gather: async () => {
+        const rows = await getActiveSessions({ localOnly: true });
+        const self = machineId();
+        for (const s of rows) if (!s.machine) s.machine = self;
+        return rows;
+      },
+    });
+    return { sessions: loaded.sessions, remoteDeviceCount: 0 };
+  }
+
+  if (!opts.local && !scoped) {
+    const loaded = await loadFleetActiveSessions({
+      forceRefresh,
+      gather: () => gatherActiveSessionsLive({ local: false }),
+    });
+    return { sessions: loaded.sessions, remoteDeviceCount: loaded.remoteDeviceCount };
+  }
+
+  return gatherActiveSessionsLive(opts);
+}
+
+/**
+ * Live (uncached) gather — the work the daemon / force-refresh path pays once
+ * so other surfaces can share the snapshot. Kept separate so the cache layer
+ * never recursively re-enters itself.
+ */
+async function gatherActiveSessionsLive(
   opts: { local?: boolean; hosts?: string[] } = {},
 ): Promise<{ sessions: ActiveSession[]; remoteDeviceCount: number }> {
   const self = machineId();
@@ -1341,7 +1389,9 @@ export async function gatherActiveSessions(
   // remote-host teammate over ssh even for this machine's OWN local gather —
   // "this machine only" must mean zero ssh, not just "skip the cross-machine
   // device fan-out below".
-  const local = shouldIncludeLocal(opts.hosts, self) ? await getActiveSessions({ localOnly: opts.local }) : [];
+  const local = shouldIncludeLocal(opts.hosts, self)
+    ? await getActiveSessions({ localOnly: opts.local })
+    : [];
   for (const s of local) if (!s.machine) s.machine = self;
 
   let remoteDeviceCount = 0;

--- a/apps/cli/src/commands/watchdog.ts
+++ b/apps/cli/src/commands/watchdog.ts
@@ -26,6 +26,7 @@ import { parseDuration } from '../lib/hooks/cache.js';
 import { getRuntimeStateDir } from '../lib/state.js';
 import { readJob, setJobEnabled } from '../lib/routines.js';
 import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
+import { loadLocalActiveSessions } from '../lib/session/session-cache.js';
 import { mailboxIdForActiveSession } from '../lib/mailbox-target.js';
 import { gcMailbox } from '../lib/mailbox-gc.js';
 import { devicesWithRoutineEnabled, routineEnabledOnThisDevice } from '../lib/routine-activation.js';
@@ -170,9 +171,20 @@ export function registerWatchdogCommand(program: Command): void {
           sessions,
         });
 
+      // RUSH-2062: share the daemon-warmed local active-session snapshot with
+      // menubar/CLI/Factory instead of re-running a full gather every tick.
+      const loadWatchdogSessions = async () => {
+        const loaded = await loadLocalActiveSessions({
+          // Force a live gather only when the warm path is unavailable; the
+          // cache layer already re-gathers past DEFAULT_ACTIVE_CACHE_MAX_AGE_MS.
+          gather: () => getActiveSessions({ localOnly: true }),
+        });
+        return loaded.sessions;
+      };
+
       if (!opts.watch) {
         const willInject = computeWillInject();
-        const sessions = await getActiveSessions();
+        const sessions = await loadWatchdogSessions();
         const result = await tickOnce(willInject, sessions);
         await runMailboxGc(sessions);
         if (opts.json) console.log(JSON.stringify(result, null, 2));
@@ -192,7 +204,7 @@ export function registerWatchdogCommand(program: Command): void {
       while (true) {
         // Re-evaluated each tick: picks up enable/disable flips mid-run.
         const willInject = computeWillInject();
-        const sessions = await getActiveSessions();
+        const sessions = await loadWatchdogSessions();
         const result = await tickOnce(willInject, sessions);
         await runMailboxGc(sessions);
         if (opts.json) console.log(JSON.stringify(result));

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -883,17 +883,20 @@ export async function runDaemon(): Promise<void> {
   // live status fresh; forceRefresh still re-gathers. Additive sibling of
   // fleetCacheInterval — does not touch the reaper tick.
   let warmingSessionCache = false;
+  // Import once so the interval/kickoff constants stay the single source of truth
+  // (SESSION_CACHE_WARM_* in session-cache.ts). Dynamic import of the warm fn
+  // itself stays inside the tick so a cold daemon boot does not pay the load.
+  const sessionCacheWarmTiming = import('./session/session-cache.js').then((m) => ({
+    intervalMs: m.SESSION_CACHE_WARM_INTERVAL_MS,
+    kickoffMs: m.SESSION_CACHE_WARM_KICKOFF_MS,
+    publish: m.publishLocalActiveSessions,
+  }));
   const runSessionCacheWarm = async () => {
     if (warmingSessionCache) return;
     warmingSessionCache = true;
     try {
-      const {
-        publishLocalActiveSessions,
-        SESSION_CACHE_WARM_INTERVAL_MS,
-      } = await import('./session/session-cache.js');
-      // INTERVAL is imported so a greppable reference keeps daemon + module in sync.
-      void SESSION_CACHE_WARM_INTERVAL_MS;
-      const r = await publishLocalActiveSessions();
+      const { publish } = await sessionCacheWarmTiming;
+      const r = await publish();
       log('INFO', `session cache warm: ${r.sessions.length} local session(s)`);
     } catch (err) {
       log('ERROR', `session cache warm failed: ${(err as Error).message}`);
@@ -901,9 +904,14 @@ export async function runDaemon(): Promise<void> {
       warmingSessionCache = false;
     }
   };
-  // Keep the numeric interval aligned with SESSION_CACHE_WARM_INTERVAL_MS (15s).
-  const sessionCacheInterval = setInterval(() => { void runSessionCacheWarm(); }, 15_000);
-  const sessionCacheKickoff = setTimeout(() => { void runSessionCacheWarm(); }, 25_000);
+  // Intervals resolved from the module constants (fallback matches the defaults
+  // if the import is still pending — the first tick uses the live import).
+  let sessionCacheInterval: ReturnType<typeof setInterval> | undefined;
+  let sessionCacheKickoff: ReturnType<typeof setTimeout> | undefined;
+  void sessionCacheWarmTiming.then(({ intervalMs, kickoffMs }) => {
+    sessionCacheInterval = setInterval(() => { void runSessionCacheWarm(); }, intervalMs);
+    sessionCacheKickoff = setTimeout(() => { void runSessionCacheWarm(); }, kickoffMs);
+  });
 
   // Usage refresh: keep the usage cache the `agents run` router reads
   // (RUSH-2061, readOnly hot path) fresh, WITHOUT the hot path ever fetching.
@@ -1025,8 +1033,8 @@ export async function runDaemon(): Promise<void> {
     clearTimeout(launchHealthKickoff);
     clearInterval(fleetCacheInterval);
     clearTimeout(fleetCacheKickoff);
-    clearInterval(sessionCacheInterval);
-    clearTimeout(sessionCacheKickoff);
+    if (sessionCacheInterval) clearInterval(sessionCacheInterval);
+    if (sessionCacheKickoff) clearTimeout(sessionCacheKickoff);
     clearInterval(usageRefreshInterval);
     clearTimeout(usageRefreshKickoff);
     clearInterval(brokerSelfHealInterval);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -876,6 +876,35 @@ export async function runDaemon(): Promise<void> {
   const fleetCacheInterval = setInterval(() => { void runFleetCacheWarm(); }, 3 * 60_000);
   const fleetCacheKickoff = setTimeout(() => { void runFleetCacheWarm(); }, 60_000);
 
+  // Session-status cache warm (RUSH-2062): publish THIS host's local active
+  // sessions so menubar / Factory / watchdog / CLI share one warm snapshot
+  // instead of each re-running a full ~9s / ~170MB gather. Publish-own only
+  // (no cross-host SSH — same N² lesson as RUSH-2061). Short interval keeps
+  // live status fresh; forceRefresh still re-gathers. Additive sibling of
+  // fleetCacheInterval — does not touch the reaper tick.
+  let warmingSessionCache = false;
+  const runSessionCacheWarm = async () => {
+    if (warmingSessionCache) return;
+    warmingSessionCache = true;
+    try {
+      const {
+        publishLocalActiveSessions,
+        SESSION_CACHE_WARM_INTERVAL_MS,
+      } = await import('./session/session-cache.js');
+      // INTERVAL is imported so a greppable reference keeps daemon + module in sync.
+      void SESSION_CACHE_WARM_INTERVAL_MS;
+      const r = await publishLocalActiveSessions();
+      log('INFO', `session cache warm: ${r.sessions.length} local session(s)`);
+    } catch (err) {
+      log('ERROR', `session cache warm failed: ${(err as Error).message}`);
+    } finally {
+      warmingSessionCache = false;
+    }
+  };
+  // Keep the numeric interval aligned with SESSION_CACHE_WARM_INTERVAL_MS (15s).
+  const sessionCacheInterval = setInterval(() => { void runSessionCacheWarm(); }, 15_000);
+  const sessionCacheKickoff = setTimeout(() => { void runSessionCacheWarm(); }, 25_000);
+
   // Usage refresh: keep the usage cache the `agents run` router reads
   // (RUSH-2061, readOnly hot path) fresh, WITHOUT the hot path ever fetching.
   // This host is the sole writer for its own local accounts. The tick wakes
@@ -996,6 +1025,8 @@ export async function runDaemon(): Promise<void> {
     clearTimeout(launchHealthKickoff);
     clearInterval(fleetCacheInterval);
     clearTimeout(fleetCacheKickoff);
+    clearInterval(sessionCacheInterval);
+    clearTimeout(sessionCacheKickoff);
     clearInterval(usageRefreshInterval);
     clearTimeout(usageRefreshKickoff);
     clearInterval(brokerSelfHealInterval);

--- a/apps/cli/src/lib/session/README.md
+++ b/apps/cli/src/lib/session/README.md
@@ -50,6 +50,18 @@ provenance (`provenance.ts:66`). `ActiveSession` carries runtime facts that no
 persisted `SessionMeta` has — notably the origin device and a live fork/subagent
 count — and those facts are lost the moment the process exits unless we persist them.
 
+### Cross-surface active-session cache (RUSH-2062)
+
+`session-cache.ts` is the daemon-warmed shared snapshot menubar / Factory /
+watchdog / CLI read so they do not each re-fan-out a full gather. The daemon
+publishes **this host only** every ~15s (`publishLocalActiveSessions` from
+`daemon.ts`); `gatherActiveSessions` is cache-first for unscoped local/fleet
+loads. Live status fields (`status`, `activity`, `preview`, …) only ride that
+short snapshot — never the immutable memo. Immutable identity fields (topic,
+label, cwd, …) are memoized by `(sessionId, transcriptMtimeMs)` so a transcript
+rewrite invalidates them. `remote.ts` is also cache-first: a reachable host
+skips SSH while its cache is fresh (it used to replay only on unreachable).
+
 ## The session preview contract
 
 There are two distinct renders. Do not confuse them.

--- a/apps/cli/src/lib/session/remote.test.ts
+++ b/apps/cli/src/lib/session/remote.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'child_process';
+import * as fs from 'fs';
 import * as path from 'path';
 import {
   buildForwardedArgs,
@@ -10,6 +11,12 @@ import {
   remoteCachePath,
   formatStaleBanner,
   formatUnreachable,
+  isRemoteCacheFresh,
+  REMOTE_CACHE_MAX_AGE_MS,
+  readRemoteCache,
+  writeRemoteCache,
+  serveWarmRemoteCache,
+  replayRemoteCache,
 } from './remote.js';
 
 /**
@@ -222,5 +229,80 @@ describe('offline banners', () => {
     const msg = formatUnreachable('mac-mini');
     expect(msg).toContain('mac-mini');
     expect(msg.toLowerCase()).toContain('unreachable');
+  });
+});
+
+describe('remote cache freshness (RUSH-2062 — reachable host skips SSH)', () => {
+  it('isRemoteCacheFresh is true only inside the max-age window', () => {
+    expect(isRemoteCacheFresh(1000, 1000 + REMOTE_CACHE_MAX_AGE_MS, REMOTE_CACHE_MAX_AGE_MS)).toBe(true);
+    expect(isRemoteCacheFresh(1000, 1000 + REMOTE_CACHE_MAX_AGE_MS + 1, REMOTE_CACHE_MAX_AGE_MS)).toBe(false);
+  });
+
+  it('write + read with maxAge serves a fresh entry (reachable path skips SSH)', () => {
+    const host = `test-host-fresh-${process.pid}`;
+    const args = ['sessions', '--active', '--json', `q-${Date.now()}`];
+    writeRemoteCache(host, args, 'SESSION_ROWS_OK\n');
+    const hit = readRemoteCache(host, args, { maxAgeMs: REMOTE_CACHE_MAX_AGE_MS, nowMs: Date.now() });
+    expect(hit).not.toBeNull();
+    expect(hit!.output).toBe('SESSION_ROWS_OK\n');
+  });
+
+  it('read with maxAge returns null for a deliberately aged entry', () => {
+    const host = `test-host-stale-${process.pid}`;
+    const args = ['sessions', '--active', '--json', `stale-${Date.now()}`];
+    writeRemoteCache(host, args, 'OLD_ROWS\n');
+    // Force mtime into the past by touching the file.
+    const p = remoteCachePath(host, args);
+    const old = (Date.now() - REMOTE_CACHE_MAX_AGE_MS - 5_000) / 1000;
+    fs.utimesSync(p, old, old);
+    const hit = readRemoteCache(host, args, { maxAgeMs: REMOTE_CACHE_MAX_AGE_MS, nowMs: Date.now() });
+    expect(hit).toBeNull();
+    // Unreachable fallback still accepts any age.
+    const anyAge = readRemoteCache(host, args);
+    expect(anyAge?.output).toBe('OLD_ROWS\n');
+  });
+
+  it('serveWarmRemoteCache writes stdout for a fresh hit and returns true', () => {
+    const host = `test-host-serve-${process.pid}`;
+    const args = ['sessions', `serve-${Date.now()}`];
+    writeRemoteCache(host, args, 'WARM_OUT\n');
+    const chunks: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    (process.stdout as { write: typeof process.stdout.write }).write = ((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      expect(serveWarmRemoteCache(host, args, { nowMs: Date.now() })).toBe(true);
+      expect(chunks.join('')).toBe('WARM_OUT\n');
+    } finally {
+      process.stdout.write = orig;
+    }
+  });
+
+  it('replayRemoteCache serves any-age cache with a stale banner on stderr', () => {
+    const host = `test-host-replay-${process.pid}`;
+    const args = ['sessions', `replay-${Date.now()}`];
+    writeRemoteCache(host, args, 'REPLAY_OUT\n');
+    const out: string[] = [];
+    const err: string[] = [];
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    (process.stdout as { write: typeof process.stdout.write }).write = ((c: string | Uint8Array) => {
+      out.push(typeof c === 'string' ? c : Buffer.from(c).toString());
+      return true;
+    }) as typeof process.stdout.write;
+    (process.stderr as { write: typeof process.stderr.write }).write = ((c: string | Uint8Array) => {
+      err.push(typeof c === 'string' ? c : Buffer.from(c).toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      expect(replayRemoteCache(host, args)).toBe(true);
+      expect(out.join('')).toBe('REPLAY_OUT\n');
+      expect(err.join('').toLowerCase()).toContain('cached');
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    }
   });
 });

--- a/apps/cli/src/lib/session/remote.ts
+++ b/apps/cli/src/lib/session/remote.ts
@@ -9,13 +9,14 @@
  * upfront copy, always current, but the peer must be reachable. SSH access is the
  * only auth — if you can `ssh <host>`, you own the box (no identity layer by design).
  *
- * Offline degradation (no sync, still fetch-first): every *successful* fetch is
+ * Cache-first (RUSH-2062) + offline degradation: every *successful* fetch is
  * cached to `~/.agents/.cache/remote-sessions/`, keyed by host + the exact query.
- * When a later run finds the host unreachable, the cache is replayed with a clearly
- * labelled "showing cached results" banner instead of returning nothing. The cache
- * is a byproduct of fetches you already made — never a background job, freely
- * deletable — so the fetch-don't-replicate model holds; this is just graceful
- * degradation when the peer is asleep.
+ * A later call with a *fresh* cache serves it without SSH (same daemon-warmed
+ * shared-cache shape as `stats-cache.ts`) so a reachable host is not re-probed
+ * on every menubar/CLI/watchdog tick. When the host is unreachable, any cache
+ * (even stale) is replayed with a clearly labelled "showing cached results"
+ * banner. The cache is a byproduct of fetches you already made — freely
+ * deletable — so the fetch-don't-replicate model holds.
  *
  * Mirrors the transport already used by `agents secrets export --host`
  * (`src/commands/secrets.ts`): `ssh -o BatchMode=yes <host> bash -lc '<cmd>'`,
@@ -149,6 +150,13 @@ export function classifySshFailure(res: { error?: Error | null; status: number |
 const REMOTE_CACHE_DIR = join(getCacheDir(), 'remote-sessions');
 
 /**
+ * How long a successful remote fetch may be served without re-SSHing.
+ * Short on purpose: session listings must stay near-live (RUSH-2062). Match the
+ * active-session snapshot window so surfaces share one freshness model.
+ */
+export const REMOTE_CACHE_MAX_AGE_MS = 15_000;
+
+/**
  * Deterministic cache path for a (host, forwarded-args) pair. The forwarded args
  * are hashed so distinct queries cache independently; the host stays readable in
  * the filename (sanitised so `user@host` and aliases are filesystem-safe).
@@ -157,6 +165,48 @@ export function remoteCachePath(host: string, forwardedArgs: string[]): string {
   const hash = createHash('sha256').update(forwardedArgs.join('\u0000')).digest('hex').slice(0, 16);
   const safeHost = host.replace(/[^a-zA-Z0-9._@-]/g, '_');
   return join(REMOTE_CACHE_DIR, `${safeHost}__${hash}.txt`);
+}
+
+/**
+ * Pure freshness check for a remote-sessions cache entry. A reachable host
+ * skips SSH only while this returns true; unreachable fallback ignores age.
+ */
+export function isRemoteCacheFresh(
+  mtimeMs: number,
+  nowMs: number,
+  maxAgeMs: number = REMOTE_CACHE_MAX_AGE_MS,
+): boolean {
+  if (!Number.isFinite(mtimeMs) || !Number.isFinite(maxAgeMs) || maxAgeMs < 0) return false;
+  return nowMs - mtimeMs <= maxAgeMs;
+}
+
+export interface RemoteCacheHit {
+  output: string;
+  mtimeMs: number;
+}
+
+/**
+ * Read a cached remote fetch. When `maxAgeMs` is set, returns null if the
+ * entry is older than the window (cache-first path for reachable hosts).
+ * Omit `maxAgeMs` to accept any age (unreachable fallback).
+ */
+export function readRemoteCache(
+  host: string,
+  forwardedArgs: string[],
+  opts: { maxAgeMs?: number; nowMs?: number } = {},
+): RemoteCacheHit | null {
+  try {
+    const p = remoteCachePath(host, forwardedArgs);
+    if (!existsSync(p)) return null;
+    const mtimeMs = statSync(p).mtimeMs;
+    if (opts.maxAgeMs !== undefined) {
+      const now = opts.nowMs ?? Date.now();
+      if (!isRemoteCacheFresh(mtimeMs, now, opts.maxAgeMs)) return null;
+    }
+    return { output: readFileSync(p, 'utf8'), mtimeMs };
+  } catch {
+    return null;
+  }
 }
 
 /** Banner shown above replayed cache rows when the peer is offline. */
@@ -172,9 +222,9 @@ export function formatUnreachable(host: string): string {
   );
 }
 
-/** Persist a successful fetch for later offline replay. Best-effort: a cache
- * write must never break the live query. */
-function writeRemoteCache(host: string, forwardedArgs: string[], output: string): void {
+/** Persist a successful fetch for later cache-first / offline replay.
+ * Best-effort: a cache write must never break the live query. Exported for tests. */
+export function writeRemoteCache(host: string, forwardedArgs: string[], output: string): void {
   try {
     mkdirSync(REMOTE_CACHE_DIR, { recursive: true });
     writeFileSync(remoteCachePath(host, forwardedArgs), output);
@@ -183,25 +233,55 @@ function writeRemoteCache(host: string, forwardedArgs: string[], output: string)
   }
 }
 
-/** Replay a cached fetch for an unreachable host. Banner goes to stderr (so a
- * piped stdout stays exactly the cached rows); returns false when nothing is
- * cached for this exact (host, query). */
-function replayRemoteCache(host: string, forwardedArgs: string[]): boolean {
-  try {
-    const p = remoteCachePath(host, forwardedArgs);
-    if (!existsSync(p)) return false;
-    process.stderr.write(formatStaleBanner(host, statSync(p).mtimeMs) + '\n');
-    process.stdout.write(readFileSync(p, 'utf8'));
-    return true;
-  } catch {
-    return false;
-  }
+/**
+ * Serve a *fresh* cache entry for a reachable-host skip (no banner — the data
+ * is still within the freshness window). Returns false when missing/stale so
+ * the caller SSHes. RUSH-2062: without this, a reachable host never skipped SSH
+ * even when the cache was just written.
+ */
+export function serveWarmRemoteCache(
+  host: string,
+  forwardedArgs: string[],
+  opts: { maxAgeMs?: number; nowMs?: number } = {},
+): boolean {
+  const hit = readRemoteCache(host, forwardedArgs, {
+    maxAgeMs: opts.maxAgeMs ?? REMOTE_CACHE_MAX_AGE_MS,
+    nowMs: opts.nowMs,
+  });
+  if (!hit) return false;
+  process.stdout.write(hit.output);
+  return true;
+}
+
+/** Replay a cached fetch for an unreachable host (any age). Banner goes to
+ * stderr (so a piped stdout stays exactly the cached rows); returns false when
+ * nothing is cached for this exact (host, query). */
+export function replayRemoteCache(host: string, forwardedArgs: string[]): boolean {
+  const hit = readRemoteCache(host, forwardedArgs); // no maxAge — any age ok
+  if (!hit) return false;
+  process.stderr.write(formatStaleBanner(host, hit.mtimeMs) + '\n');
+  process.stdout.write(hit.output);
+  return true;
+}
+
+export interface RunRemoteSessionsOptions {
+  /** Skip warm cache and SSH every host (force-refresh). */
+  forceRefresh?: boolean;
+  /** Override freshness window for the warm path. */
+  maxAgeMs?: number;
+  /** Clock (tests). */
+  nowMs?: number;
 }
 
 /**
  * Run the current `agents sessions` invocation on one or more remote machines over
- * SSH, writing each remote's output to the terminal. A successful fetch is cached;
- * an unreachable host falls back to that cache (with a stale banner) when present.
+ * SSH, writing each remote's output to the terminal.
+ *
+ * Cache policy (RUSH-2062):
+ * - **Default:** serve a fresh cache hit without SSH; SSH only on miss/stale.
+ * - **`forceRefresh`:** always SSH, then rewrite the cache.
+ * - **Unreachable:** fall back to any cached output (with a stale banner).
+ *
  * Sets `process.exitCode = 1` if any host could not be answered (live or cached).
  * Reads the invocation from `process.argv` (override via `argv` for testing).
  *
@@ -209,16 +289,32 @@ function replayRemoteCache(host: string, forwardedArgs: string[]): boolean {
  * Session output is small and the remote returns quickly, so buffering is
  * imperceptible; `maxBuffer` is generous for the rare large `--markdown <id>` dump.
  */
-export function runRemoteSessions(hosts: string[], argv: string[] = process.argv): void {
+export function runRemoteSessions(
+  hosts: string[],
+  argv: string[] = process.argv,
+  opts: RunRemoteSessionsOptions = {},
+): void {
   for (const host of hosts) assertValidSshTarget(host); // fail fast on any bad target
 
   const forwarded = ensureWholeIndex(buildForwardedArgs(argv, new Set(hosts)));
   const cols = terminalWidth();
   const multi = hosts.length > 1;
   let failures = 0;
+  const forceRefresh = opts.forceRefresh === true
+    || process.env.AGENTS_SESSIONS_FORCE_REFRESH === '1';
 
   for (const host of hosts) {
     if (multi) process.stdout.write(chalk.cyan(`\n── ${host} ──\n`));
+
+    // Cache-first: a warm hit skips SSH entirely so reachable hosts share one
+    // snapshot across menubar/CLI/watchdog instead of re-fanning every call.
+    if (!forceRefresh && serveWarmRemoteCache(host, forwarded, {
+      maxAgeMs: opts.maxAgeMs,
+      nowMs: opts.nowMs,
+    })) {
+      continue;
+    }
+
     // Per-host: a Windows peer needs a PowerShell command, POSIX peers `bash -lc`.
     const remoteCmd = buildRemoteCommand(forwarded, cols, resolveRemoteOsSync(host));
     const res = spawnSync('ssh', [...SSH_OPTS, ...controlOpts(), host, remoteCmd], {

--- a/apps/cli/src/lib/session/session-cache.test.ts
+++ b/apps/cli/src/lib/session/session-cache.test.ts
@@ -199,6 +199,35 @@ describe('loadFleetActiveSessions — fleet snapshot share', () => {
     expect(res.remoteDeviceCount).toBe(3);
     expect(res.sessions[0].machine).toBe('box-a');
   });
+
+  it('rewrites local to empty when a live fleet gather has no local rows (no ghost sessions)', async () => {
+    // Prior warm left a local session; the next fleet gather has only remotes
+    // — the local snapshot must not keep ghosting the dead row.
+    writeActiveSessionsCache(
+      'local',
+      [session({ sessionId: 'ghost', status: 'running', lastActivityMs: 1 })],
+      { capturedAt: 500 },
+    );
+
+    await loadFleetActiveSessions({
+      forceRefresh: true,
+      nowMs: 10_000,
+      gather: async () => ({
+        sessions: [
+          session({ sessionId: 'remote-only', machine: 'other-box', status: 'running' }),
+        ],
+        remoteDeviceCount: 1,
+      }),
+    });
+
+    const local = readActiveSessionsCache('local');
+    // When machineId() is available, local is rewritten at nowMs and must not
+    // contain `ghost`. When machineId is unavailable the write is skipped —
+    // assert the invariant only when the rewrite ran.
+    if (local && local.capturedAt === 10_000) {
+      expect(local.sessions.some((s) => s.sessionId === 'ghost')).toBe(false);
+    }
+  });
 });
 
 describe('immutable memo — mtime-keyed, never carries live status', () => {

--- a/apps/cli/src/lib/session/session-cache.test.ts
+++ b/apps/cli/src/lib/session/session-cache.test.ts
@@ -1,0 +1,331 @@
+/**
+ * RUSH-2062 — cross-surface active-session cache invariants.
+ *
+ * Real disk files under a temp dir (no mocks of the cache layer itself). The
+ * live gather is injected as a pure function so the test pins cache behaviour
+ * without SSH / process-table cost; the critical path under test is the
+ * freshness/staleness + immutable-memo contract.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { ActiveSession } from './active.js';
+import {
+  DEFAULT_ACTIVE_CACHE_MAX_AGE_MS,
+  IMMUTABLE_FIELD_KEYS,
+  LIVE_STATUS_KEYS,
+  applyImmutableMemo,
+  assertNoLiveStatusFields,
+  isActiveSnapshotFresh,
+  loadFleetActiveSessions,
+  loadLocalActiveSessions,
+  pickImmutableFields,
+  publishLocalActiveSessions,
+  readActiveSessionsCache,
+  readImmutableMemo,
+  setActiveSessionsSnapshotPathForTest,
+  setImmutableMemoPathForTest,
+  stripLiveStatusKeys,
+  transcriptMtimeMs,
+  updateImmutableMemos,
+  writeActiveSessionsCache,
+  writeImmutableMemo,
+} from './session-cache.js';
+
+function tmpPair(): { snap: string; imm: string; dir: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-cache-'));
+  return {
+    dir,
+    snap: path.join(dir, 'snap.json'),
+    imm: path.join(dir, 'imm.json'),
+  };
+}
+
+function session(partial: Partial<ActiveSession> & { sessionId: string }): ActiveSession {
+  return {
+    context: 'terminal',
+    kind: 'claude',
+    status: 'running',
+    ...partial,
+  } as ActiveSession;
+}
+
+describe('isActiveSnapshotFresh (live-status window)', () => {
+  it('serves a snapshot only while within maxAgeMs', () => {
+    expect(isActiveSnapshotFresh(1000, 1000 + DEFAULT_ACTIVE_CACHE_MAX_AGE_MS, DEFAULT_ACTIVE_CACHE_MAX_AGE_MS)).toBe(true);
+    expect(isActiveSnapshotFresh(1000, 1000 + DEFAULT_ACTIVE_CACHE_MAX_AGE_MS + 1, DEFAULT_ACTIVE_CACHE_MAX_AGE_MS)).toBe(false);
+  });
+
+  it('rejects nonsense ages so a bad clock cannot freeze live status forever', () => {
+    expect(isActiveSnapshotFresh(1000, 2000, -1)).toBe(false);
+    expect(isActiveSnapshotFresh(Number.NaN, 2000, 15_000)).toBe(false);
+  });
+});
+
+describe('loadLocalActiveSessions — cross-surface snapshot', () => {
+  let paths: ReturnType<typeof tmpPair>;
+  let prevSnap: string | null;
+  let prevImm: string | null;
+
+  beforeEach(() => {
+    paths = tmpPair();
+    prevSnap = setActiveSessionsSnapshotPathForTest(paths.snap);
+    prevImm = setImmutableMemoPathForTest(paths.imm);
+  });
+
+  afterEach(() => {
+    setActiveSessionsSnapshotPathForTest(prevSnap);
+    setImmutableMemoPathForTest(prevImm);
+    fs.rmSync(paths.dir, { recursive: true, force: true });
+  });
+
+  it('serves a fresh warm snapshot without re-gathering (cross-surface share)', async () => {
+    const warm = [session({ sessionId: 'a', status: 'running', topic: 'warm topic' })];
+    writeActiveSessionsCache('local', warm, { capturedAt: 10_000 });
+
+    let gathers = 0;
+    const res = await loadLocalActiveSessions({
+      nowMs: 10_000 + 5_000, // still within 15s window
+      gather: async () => {
+        gathers++;
+        return [session({ sessionId: 'b', status: 'idle' })];
+      },
+    });
+
+    expect(gathers).toBe(0);
+    expect(res.servedFromCache).toBe(true);
+    expect(res.sessions).toEqual(warm);
+    expect(res.sessions[0].status).toBe('running'); // live status rides the snapshot
+  });
+
+  it('re-gathers when the snapshot is older than maxAgeMs (live status never stale)', async () => {
+    writeActiveSessionsCache('local', [session({ sessionId: 'stale', status: 'running' })], {
+      capturedAt: 10_000,
+    });
+
+    let gathers = 0;
+    const fresh = [session({ sessionId: 'fresh', status: 'idle', lastActivityMs: 20_000 })];
+    const res = await loadLocalActiveSessions({
+      nowMs: 10_000 + DEFAULT_ACTIVE_CACHE_MAX_AGE_MS + 1,
+      gather: async () => {
+        gathers++;
+        return fresh;
+      },
+    });
+
+    expect(gathers).toBe(1);
+    expect(res.servedFromCache).toBe(false);
+    expect(res.sessions[0].sessionId).toBe('fresh');
+    expect(res.sessions[0].status).toBe('idle'); // live status from the gather, not the stale snap
+    // And the cache is rewritten so the next surface shares the fresh result.
+    const onDisk = readActiveSessionsCache('local');
+    expect(onDisk?.sessions[0].sessionId).toBe('fresh');
+  });
+
+  it('forceRefresh always re-gathers even when the snapshot is brand new', async () => {
+    writeActiveSessionsCache('local', [session({ sessionId: 'cached', status: 'running' })], {
+      capturedAt: 50_000,
+    });
+
+    let gathers = 0;
+    const res = await loadLocalActiveSessions({
+      forceRefresh: true,
+      nowMs: 50_000,
+      gather: async () => {
+        gathers++;
+        return [session({ sessionId: 'live', status: 'input_required' })];
+      },
+    });
+
+    expect(gathers).toBe(1);
+    expect(res.servedFromCache).toBe(false);
+    expect(res.sessions[0].status).toBe('input_required');
+  });
+
+  it('publishLocalActiveSessions force-writes a local snapshot (daemon warm path)', async () => {
+    let gathers = 0;
+    const r = await publishLocalActiveSessions({
+      nowMs: 99_000,
+      gather: async () => {
+        gathers++;
+        return [session({ sessionId: 'daemon', status: 'running', lastActivityMs: 98_000, topic: 't' })];
+      },
+    });
+    expect(gathers).toBe(1);
+    expect(r.sessions).toHaveLength(1);
+    const onDisk = readActiveSessionsCache('local');
+    expect(onDisk?.capturedAt).toBe(99_000);
+    expect(onDisk?.sessions[0].sessionId).toBe('daemon');
+  });
+});
+
+describe('loadFleetActiveSessions — fleet snapshot share', () => {
+  let paths: ReturnType<typeof tmpPair>;
+  let prevSnap: string | null;
+  let prevImm: string | null;
+
+  beforeEach(() => {
+    paths = tmpPair();
+    prevSnap = setActiveSessionsSnapshotPathForTest(paths.snap);
+    prevImm = setImmutableMemoPathForTest(paths.imm);
+  });
+
+  afterEach(() => {
+    setActiveSessionsSnapshotPathForTest(prevSnap);
+    setImmutableMemoPathForTest(prevImm);
+    fs.rmSync(paths.dir, { recursive: true, force: true });
+  });
+
+  it('serves a warm fleet snapshot so a second surface skips the SSH fan-out', async () => {
+    writeActiveSessionsCache(
+      'fleet',
+      [session({ sessionId: 'remote-1', machine: 'box-a', status: 'running' })],
+      { capturedAt: 1000, remoteDeviceCount: 3 },
+    );
+
+    let gathers = 0;
+    const res = await loadFleetActiveSessions({
+      nowMs: 1000 + 1_000,
+      gather: async () => {
+        gathers++;
+        return { sessions: [], remoteDeviceCount: 0 };
+      },
+    });
+
+    expect(gathers).toBe(0);
+    expect(res.servedFromCache).toBe(true);
+    expect(res.remoteDeviceCount).toBe(3);
+    expect(res.sessions[0].machine).toBe('box-a');
+  });
+});
+
+describe('immutable memo — mtime-keyed, never carries live status', () => {
+  let paths: ReturnType<typeof tmpPair>;
+  let prevSnap: string | null;
+  let prevImm: string | null;
+
+  beforeEach(() => {
+    paths = tmpPair();
+    prevSnap = setActiveSessionsSnapshotPathForTest(paths.snap);
+    prevImm = setImmutableMemoPathForTest(paths.imm);
+  });
+
+  afterEach(() => {
+    setActiveSessionsSnapshotPathForTest(prevSnap);
+    setImmutableMemoPathForTest(prevImm);
+    fs.rmSync(paths.dir, { recursive: true, force: true });
+  });
+
+  it('memoizes immutable fields keyed on transcript mtime', () => {
+    const s = session({
+      sessionId: 's1',
+      topic: 'fix the auth bug',
+      label: 'auth',
+      cwd: '/tmp/wt',
+      lastActivityMs: 42_000,
+      status: 'running',
+      preview: 'live preview must not be memoized',
+    });
+
+    updateImmutableMemos([s], 50_000);
+
+    const hit = readImmutableMemo('s1', 42_000);
+    expect(hit).not.toBeNull();
+    expect(hit!.topic).toBe('fix the auth bug');
+    expect(hit!.label).toBe('auth');
+    expect(hit!.cwd).toBe('/tmp/wt');
+    // Live status must not be in the memo.
+    expect(assertNoLiveStatusFields(hit as Record<string, unknown>)).toBe(true);
+    expect((hit as Record<string, unknown>).status).toBeUndefined();
+    expect((hit as Record<string, unknown>).preview).toBeUndefined();
+  });
+
+  it('invalidates the memo when transcript mtime changes', () => {
+    writeImmutableMemo('s1', 100, { topic: 'old topic' }, 1);
+    expect(readImmutableMemo('s1', 100)?.topic).toBe('old topic');
+    // Same session, newer transcript write → miss (must re-derive).
+    expect(readImmutableMemo('s1', 200)).toBeNull();
+  });
+
+  it('pickImmutableFields never includes live-status keys', () => {
+    const s = session({
+      sessionId: 's2',
+      topic: 't',
+      status: 'running',
+      activity: 'working',
+      preview: 'p',
+      tokPerSec: 12,
+      pidAlive: true,
+      lastActivityMs: 1,
+    });
+    const fields = pickImmutableFields(s);
+    expect(assertNoLiveStatusFields(fields as Record<string, unknown>)).toBe(true);
+    for (const k of LIVE_STATUS_KEYS) {
+      expect(k in fields).toBe(false);
+    }
+    for (const k of IMMUTABLE_FIELD_KEYS) {
+      // only assert the ones we set
+      if (k === 'topic') expect(fields.topic).toBe('t');
+    }
+  });
+
+  it('stripLiveStatusKeys defends against a poisoned write', () => {
+    const poisoned = stripLiveStatusKeys({
+      topic: 'ok',
+      status: 'running',
+      preview: 'nope',
+      pidAlive: false,
+    } as Record<string, unknown>);
+    expect(poisoned.topic).toBe('ok');
+    expect(poisoned.status).toBeUndefined();
+    expect(poisoned.preview).toBeUndefined();
+    expect(poisoned.pidAlive).toBeUndefined();
+  });
+
+  it('applyImmutableMemo fills missing identity fields only when mtime matches', () => {
+    writeImmutableMemo(
+      's3',
+      77,
+      { topic: 'memoized topic', label: 'memo-label', cwd: '/memo' },
+      1,
+    );
+
+    // Live gather produced a row with status (live) but no topic yet.
+    const live = session({
+      sessionId: 's3',
+      status: 'idle', // live — must stay
+      lastActivityMs: 77, // mtime match
+    });
+    applyImmutableMemo(live);
+    expect(live.topic).toBe('memoized topic');
+    expect(live.label).toBe('memo-label');
+    expect(live.cwd).toBe('/memo');
+    expect(live.status).toBe('idle'); // live status untouched
+
+    // Mtime mismatch → no fill.
+    const other = session({ sessionId: 's3', status: 'running', lastActivityMs: 99 });
+    applyImmutableMemo(other);
+    expect(other.topic).toBeUndefined();
+    expect(other.status).toBe('running');
+  });
+
+  it('applyImmutableMemo never overwrites a live-derived immutable field', () => {
+    writeImmutableMemo('s4', 1, { topic: 'from-memo' }, 1);
+    const live = session({
+      sessionId: 's4',
+      topic: 'from-live-gather',
+      lastActivityMs: 1,
+      status: 'running',
+    });
+    applyImmutableMemo(live);
+    expect(live.topic).toBe('from-live-gather');
+  });
+
+  it('transcriptMtimeMs prefers lastActivityMs over startedAtMs', () => {
+    expect(transcriptMtimeMs(session({ sessionId: 'x', lastActivityMs: 9, startedAtMs: 1 }))).toBe(9);
+    expect(transcriptMtimeMs(session({ sessionId: 'x', startedAtMs: 3 }))).toBe(3);
+    expect(transcriptMtimeMs(session({ sessionId: 'x' }))).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/session/session-cache.ts
+++ b/apps/cli/src/lib/session/session-cache.ts
@@ -498,10 +498,14 @@ export async function loadFleetActiveSessions(
   } catch {
     self = undefined;
   }
-  const localOnly = live.sessions.filter(
-    (s) => !s.machine || (self !== undefined && s.machine === self),
-  );
-  if (localOnly.length > 0) {
+  // Always rewrite the local slice when we know self — including the empty
+  // case. If the last local session just died, leaving a still-fresh snapshot
+  // with ghost rows would make watchdog / `--local` report sessions that are
+  // gone (review on RUSH-2062 / PR #2116).
+  if (self !== undefined) {
+    const localOnly = live.sessions.filter(
+      (s) => !s.machine || s.machine === self,
+    );
     writeCache('local', localOnly, { capturedAt: now });
   }
   return {

--- a/apps/cli/src/lib/session/session-cache.ts
+++ b/apps/cli/src/lib/session/session-cache.ts
@@ -1,0 +1,528 @@
+/**
+ * Daemon-warmed cross-surface cache for live session status (RUSH-2062).
+ *
+ * Problem: menubar / Factory / watchdog / CLI each independently run a full
+ * `sessions --active` gather (~9s wall / ~170MB) with no sharing. Measured on
+ * zion: back-to-back runs were 9.22s then 8.16s — no speedup, full SSH fan-out
+ * every call.
+ *
+ * Pattern mirrors {@link ../devices/stats-cache.ts} / {@link ../fleet-status.ts}:
+ *
+ * - **Daemon warm:** each daemon publishes THIS host's local active sessions
+ *   on a short tick (`publishLocalActiveSessions`). Publish-own only — no
+ *   cross-host SSH from the daemon (avoids the N² fan-out of RUSH-2061).
+ * - **Readers** (`loadLocalActiveSessions`, fleet path in `gatherActiveSessions`)
+ *   serve the warm snapshot when it is within {@link DEFAULT_ACTIVE_CACHE_MAX_AGE_MS};
+ *   `forceRefresh` / age expiry re-gathers live.
+ * - **Immutable memo:** per-session fields that only change when the transcript
+ *   does (topic, label, cwd, …) are keyed on `(sessionId, transcriptMtimeMs)`.
+ *   Live status fields (`status`, `activity`, `preview`, `pidAlive`, …) are
+ *   NEVER stored in that memo — they only ride the short-lived snapshot.
+ *
+ * Best-effort disk IO: a missing/corrupt cache never throws; the caller falls
+ * through to a live gather.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { getCacheDir } from '../state.js';
+import type { ActiveSession } from './active.js';
+
+/** Snapshot file under `getCacheDir()` (regenerable, gitignored). */
+const SNAPSHOT_FILE = '.active-sessions.json';
+/** Immutable-field memo file (keyed by sessionId + transcript mtime). */
+const IMMUTABLE_FILE = '.active-session-immutable.json';
+
+/**
+ * How long a snapshot may be served before a reader re-gathers.
+ * Short on purpose: live status (running/idle/waiting) must not go stale.
+ * The daemon warm tick uses the same cadence (see {@link SESSION_CACHE_WARM_INTERVAL_MS}).
+ */
+export const DEFAULT_ACTIVE_CACHE_MAX_AGE_MS = 15_000;
+
+/** Daemon warm interval — keep in sync with the setInterval in `lib/daemon.ts`. */
+export const SESSION_CACHE_WARM_INTERVAL_MS = 15_000;
+
+/** Kick off the first warm ~25s after daemon start (staggered off other ticks). */
+export const SESSION_CACHE_WARM_KICKOFF_MS = 25_000;
+
+/** Snapshot scope: this host only, or a fleet-wide merge written by a reader. */
+export type ActiveCacheScope = 'local' | 'fleet';
+
+export interface ActiveSessionsSnapshot {
+  version: 1;
+  scope: ActiveCacheScope;
+  /** Epoch ms the sessions array was captured. */
+  capturedAt: number;
+  sessions: ActiveSession[];
+  /** Peer count from the last fleet gather (fleet scope only). */
+  remoteDeviceCount?: number;
+}
+
+interface SnapshotFile {
+  version: 1;
+  entries: Partial<Record<ActiveCacheScope, ActiveSessionsSnapshot>>;
+}
+
+/**
+ * Per-session fields that are stable until the transcript changes. Keyed on
+ * transcript mtime so a rewrite invalidates them. Live status is intentionally
+ * absent — see {@link LIVE_STATUS_KEYS}.
+ */
+export interface ImmutableSessionFields {
+  topic?: string;
+  label?: string;
+  name?: string;
+  cwd?: string;
+  project?: string | null;
+  attachments?: ActiveSession['attachments'];
+  startedAtMs?: number;
+  version?: string;
+  pr?: ActiveSession['pr'];
+  worktree?: ActiveSession['worktree'];
+  ticket?: ActiveSession['ticket'];
+  createdTickets?: string[];
+  spawnedTeam?: string;
+  sessionFile?: string;
+  owner?: string;
+  assignedTask?: string;
+  kind?: string;
+  context?: ActiveSession['context'];
+}
+
+/** Keys stored in the immutable memo (transcript-stable). */
+export const IMMUTABLE_FIELD_KEYS = [
+  'topic',
+  'label',
+  'name',
+  'cwd',
+  'project',
+  'attachments',
+  'startedAtMs',
+  'version',
+  'pr',
+  'worktree',
+  'ticket',
+  'createdTickets',
+  'spawnedTeam',
+  'sessionFile',
+  'owner',
+  'assignedTask',
+  'kind',
+  'context',
+] as const satisfies ReadonlyArray<keyof ImmutableSessionFields>;
+
+/**
+ * Live / volatile fields that MUST NOT be served from the immutable memo.
+ * They either change without a transcript write (pid death, attach state) or
+ * are short-window signals (preview, tok/s). The short snapshot TTL is the
+ * only cache that may carry them — and only as a whole-row snapshot.
+ */
+export const LIVE_STATUS_KEYS = [
+  'status',
+  'activity',
+  'preview',
+  'tokPerSec',
+  'awaitingReason',
+  'question',
+  'todos',
+  'tail',
+  'lastActivityMs',
+  'hostLink',
+  'presence',
+  'pidAlive',
+  'tmuxClients',
+  'windowHeartbeatMs',
+  'provenance',
+  'rateLimited',
+  'plan',
+] as const satisfies ReadonlyArray<keyof ActiveSession>;
+
+interface ImmutableMemoEntry {
+  mtimeMs: number;
+  fields: ImmutableSessionFields;
+  /** When this memo row was written (debug / eviction). */
+  writtenAt: number;
+}
+
+interface ImmutableMemoFile {
+  version: 1;
+  /** sessionId → memo. */
+  entries: Record<string, ImmutableMemoEntry>;
+}
+
+// ── path overrides (test seam) ─────────────────────────────────────────────
+
+let snapshotPathOverride: string | null = null;
+let immutablePathOverride: string | null = null;
+
+/** Test seam: redirect the snapshot file. Returns the previous override. */
+export function setActiveSessionsSnapshotPathForTest(p: string | null): string | null {
+  const prev = snapshotPathOverride;
+  snapshotPathOverride = p;
+  return prev;
+}
+
+/** Test seam: redirect the immutable-memo file. Returns the previous override. */
+export function setImmutableMemoPathForTest(p: string | null): string | null {
+  const prev = immutablePathOverride;
+  immutablePathOverride = p;
+  return prev;
+}
+
+function snapshotPath(): string {
+  return snapshotPathOverride ?? path.join(getCacheDir(), SNAPSHOT_FILE);
+}
+
+function immutablePath(): string {
+  return immutablePathOverride ?? path.join(getCacheDir(), IMMUTABLE_FILE);
+}
+
+// ── snapshot read / write ──────────────────────────────────────────────────
+
+/** Read one scope from the snapshot file (best-effort; missing/corrupt → null). */
+export function readActiveSessionsCache(scope: ActiveCacheScope): ActiveSessionsSnapshot | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(snapshotPath(), 'utf-8')) as SnapshotFile;
+    if (!parsed || parsed.version !== 1 || !parsed.entries) return null;
+    const entry = parsed.entries[scope];
+    if (!entry || !Array.isArray(entry.sessions) || typeof entry.capturedAt !== 'number') return null;
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a snapshot for one scope (best-effort). Other scopes are preserved
+ * so a local warm never drops a fleet snapshot a reader just wrote.
+ */
+export function writeActiveSessionsCache(
+  scope: ActiveCacheScope,
+  sessions: ActiveSession[],
+  opts: { capturedAt?: number; remoteDeviceCount?: number } = {},
+): ActiveSessionsSnapshot {
+  const snap: ActiveSessionsSnapshot = {
+    version: 1,
+    scope,
+    capturedAt: opts.capturedAt ?? Date.now(),
+    sessions,
+    ...(opts.remoteDeviceCount !== undefined ? { remoteDeviceCount: opts.remoteDeviceCount } : {}),
+  };
+  try {
+    const dir = path.dirname(snapshotPath());
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    let entries: SnapshotFile['entries'] = {};
+    try {
+      const prev = JSON.parse(fs.readFileSync(snapshotPath(), 'utf-8')) as SnapshotFile;
+      if (prev?.entries && typeof prev.entries === 'object') entries = { ...prev.entries };
+    } catch {
+      // empty
+    }
+    entries[scope] = snap;
+    const body: SnapshotFile = { version: 1, entries };
+    // Atomic replace so a concurrent reader never sees a partial write.
+    const tmp = `${snapshotPath()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(body));
+    fs.renameSync(tmp, snapshotPath());
+  } catch {
+    // best-effort
+  }
+  return snap;
+}
+
+/**
+ * True when a snapshot is still within the freshness window. Pure — the
+ * staleness invariant for live status lives here.
+ */
+export function isActiveSnapshotFresh(
+  capturedAt: number,
+  nowMs: number,
+  maxAgeMs: number = DEFAULT_ACTIVE_CACHE_MAX_AGE_MS,
+): boolean {
+  if (!Number.isFinite(capturedAt) || !Number.isFinite(maxAgeMs)) return false;
+  if (maxAgeMs < 0) return false;
+  return nowMs - capturedAt <= maxAgeMs;
+}
+
+// ── immutable memo ─────────────────────────────────────────────────────────
+
+/** Pull only the transcript-stable fields from a live row. */
+export function pickImmutableFields(s: ActiveSession): ImmutableSessionFields {
+  const out: ImmutableSessionFields = {};
+  for (const k of IMMUTABLE_FIELD_KEYS) {
+    const v = s[k as keyof ActiveSession];
+    if (v !== undefined) (out as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Transcript mtime used as the memo key. Prefer {@link ActiveSession.lastActivityMs}
+ * (the transcript's last write); fall back to `startedAtMs` when no activity
+ * stamp exists. Returns null when neither is known — caller must not memoize.
+ */
+export function transcriptMtimeMs(s: ActiveSession): number | null {
+  if (typeof s.lastActivityMs === 'number' && Number.isFinite(s.lastActivityMs)) return s.lastActivityMs;
+  if (typeof s.startedAtMs === 'number' && Number.isFinite(s.startedAtMs)) return s.startedAtMs;
+  return null;
+}
+
+function readImmutableFile(): ImmutableMemoFile {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(immutablePath(), 'utf-8')) as ImmutableMemoFile;
+    if (parsed && parsed.version === 1 && parsed.entries && typeof parsed.entries === 'object') {
+      return parsed;
+    }
+  } catch {
+    // missing/corrupt
+  }
+  return { version: 1, entries: {} };
+}
+
+/**
+ * Read memoized immutable fields for `(sessionId, mtimeMs)`.
+ * Returns null when missing OR when the stored mtime does not match — a
+ * transcript rewrite must force re-derivation of topic/label/etc.
+ */
+export function readImmutableMemo(
+  sessionId: string,
+  mtimeMs: number,
+): ImmutableSessionFields | null {
+  if (!sessionId || !Number.isFinite(mtimeMs)) return null;
+  const file = readImmutableFile();
+  const entry = file.entries[sessionId];
+  if (!entry || entry.mtimeMs !== mtimeMs) return null;
+  // Defence in depth: strip any live-status key that snuck into a bad write.
+  return stripLiveStatusKeys({ ...entry.fields }) as ImmutableSessionFields;
+}
+
+/** Persist immutable fields for `(sessionId, mtimeMs)`. Live keys are stripped. */
+export function writeImmutableMemo(
+  sessionId: string,
+  mtimeMs: number,
+  fields: ImmutableSessionFields,
+  nowMs: number = Date.now(),
+): void {
+  if (!sessionId || !Number.isFinite(mtimeMs)) return;
+  try {
+    const dir = path.dirname(immutablePath());
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const file = readImmutableFile();
+    file.entries[sessionId] = {
+      mtimeMs,
+      fields: stripLiveStatusKeys({ ...fields }) as ImmutableSessionFields,
+      writtenAt: nowMs,
+    };
+    const tmp = `${immutablePath()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(file));
+    fs.renameSync(tmp, immutablePath());
+  } catch {
+    // best-effort
+  }
+}
+
+/** Drop every live-status key from a field bag (defence in depth). */
+export function stripLiveStatusKeys<T extends Record<string, unknown>>(fields: T): T {
+  const out = { ...fields };
+  for (const k of LIVE_STATUS_KEYS) {
+    if (k in out) delete out[k];
+  }
+  return out;
+}
+
+/**
+ * True when `fields` contains no live-status key. The invariant the tests pin:
+ * the immutable memo never carries status/activity/preview/etc.
+ */
+export function assertNoLiveStatusFields(fields: Record<string, unknown>): boolean {
+  for (const k of LIVE_STATUS_KEYS) {
+    if (k in fields && fields[k as string] !== undefined) return false;
+  }
+  return true;
+}
+
+/**
+ * Write immutable memos for every session that has an id + transcript mtime.
+ * Called after a live gather so the next gather (when mtime is unchanged) can
+ * refill identity fields without re-deriving them.
+ */
+export function updateImmutableMemos(sessions: ReadonlyArray<ActiveSession>, nowMs: number = Date.now()): void {
+  for (const s of sessions) {
+    if (!s.sessionId) continue;
+    const mtime = transcriptMtimeMs(s);
+    if (mtime === null) continue;
+    writeImmutableMemo(s.sessionId, mtime, pickImmutableFields(s), nowMs);
+  }
+}
+
+/**
+ * Fill missing immutable fields on a live row from the memo when the transcript
+ * mtime matches. Never overwrites a field the live gather already set, and
+ * never copies live-status keys.
+ */
+export function applyImmutableMemo(s: ActiveSession): ActiveSession {
+  if (!s.sessionId) return s;
+  const mtime = transcriptMtimeMs(s);
+  if (mtime === null) return s;
+  const memo = readImmutableMemo(s.sessionId, mtime);
+  if (!memo) return s;
+  for (const k of IMMUTABLE_FIELD_KEYS) {
+    if (s[k as keyof ActiveSession] === undefined && memo[k] !== undefined) {
+      (s as unknown as Record<string, unknown>)[k] = memo[k];
+    }
+  }
+  return s;
+}
+
+// ── cache-first load ───────────────────────────────────────────────────────
+
+export interface LoadLocalActiveSessionsOptions {
+  /** Skip the cache and re-gather (the force-refresh path). */
+  forceRefresh?: boolean;
+  /** Freshness window; defaults to {@link DEFAULT_ACTIVE_CACHE_MAX_AGE_MS}. */
+  maxAgeMs?: number;
+  /** Clock (injectable for tests). */
+  nowMs?: number;
+  /**
+   * Live gather. Defaults to `getActiveSessions({ localOnly: true })` so a
+   * warm never dials a remote-host teammate (RUSH-2118).
+   */
+  gather?: () => Promise<ActiveSession[]>;
+  /** Injectable cache IO for tests. */
+  readCache?: typeof readActiveSessionsCache;
+  writeCache?: typeof writeActiveSessionsCache;
+}
+
+export interface LoadLocalActiveSessionsResult {
+  sessions: ActiveSession[];
+  /** True when the row set came from the warm snapshot, not a live gather. */
+  servedFromCache: boolean;
+  capturedAt: number;
+}
+
+/**
+ * Cache-first load of THIS host's active sessions. Default path serves the
+ * daemon-warmed snapshot when fresh; `forceRefresh` or an expired snapshot
+ * re-gathers and rewrites the cache.
+ */
+export async function loadLocalActiveSessions(
+  opts: LoadLocalActiveSessionsOptions = {},
+): Promise<LoadLocalActiveSessionsResult> {
+  const now = opts.nowMs ?? Date.now();
+  const maxAge = opts.maxAgeMs ?? DEFAULT_ACTIVE_CACHE_MAX_AGE_MS;
+  const readCache = opts.readCache ?? readActiveSessionsCache;
+  const writeCache = opts.writeCache ?? writeActiveSessionsCache;
+
+  if (!opts.forceRefresh) {
+    const cached = readCache('local');
+    if (cached && isActiveSnapshotFresh(cached.capturedAt, now, maxAge)) {
+      return {
+        sessions: cached.sessions,
+        servedFromCache: true,
+        capturedAt: cached.capturedAt,
+      };
+    }
+  }
+
+  const gather =
+    opts.gather ??
+    (async () => {
+      const { getActiveSessions } = await import('./active.js');
+      return getActiveSessions({ localOnly: true });
+    });
+
+  const sessions = await gather();
+  for (const s of sessions) applyImmutableMemo(s);
+  updateImmutableMemos(sessions, now);
+  const snap = writeCache('local', sessions, { capturedAt: now });
+  return { sessions, servedFromCache: false, capturedAt: snap.capturedAt };
+}
+
+export interface LoadFleetActiveSessionsOptions {
+  forceRefresh?: boolean;
+  maxAgeMs?: number;
+  nowMs?: number;
+  /** Live fleet gather (local + remote). Required — this module does not own SSH. */
+  gather: () => Promise<{ sessions: ActiveSession[]; remoteDeviceCount: number }>;
+  readCache?: typeof readActiveSessionsCache;
+  writeCache?: typeof writeActiveSessionsCache;
+}
+
+export interface LoadFleetActiveSessionsResult {
+  sessions: ActiveSession[];
+  remoteDeviceCount: number;
+  servedFromCache: boolean;
+  capturedAt: number;
+}
+
+/**
+ * Cache-first load of the fleet-wide active set. A prior gather (or any surface
+ * that just paid the SSH cost) leaves a fleet snapshot; subsequent menubar /
+ * Factory / CLI / watchdog calls within the freshness window share it.
+ */
+export async function loadFleetActiveSessions(
+  opts: LoadFleetActiveSessionsOptions,
+): Promise<LoadFleetActiveSessionsResult> {
+  const now = opts.nowMs ?? Date.now();
+  const maxAge = opts.maxAgeMs ?? DEFAULT_ACTIVE_CACHE_MAX_AGE_MS;
+  const readCache = opts.readCache ?? readActiveSessionsCache;
+  const writeCache = opts.writeCache ?? writeActiveSessionsCache;
+
+  if (!opts.forceRefresh) {
+    const cached = readCache('fleet');
+    if (cached && isActiveSnapshotFresh(cached.capturedAt, now, maxAge)) {
+      return {
+        sessions: cached.sessions,
+        remoteDeviceCount: cached.remoteDeviceCount ?? 0,
+        servedFromCache: true,
+        capturedAt: cached.capturedAt,
+      };
+    }
+  }
+
+  const live = await opts.gather();
+  for (const s of live.sessions) applyImmutableMemo(s);
+  updateImmutableMemos(live.sessions, now);
+  const snap = writeCache('fleet', live.sessions, {
+    capturedAt: now,
+    remoteDeviceCount: live.remoteDeviceCount,
+  });
+  // Also refresh the local slice so a `--local` reader benefits from this gather.
+  // Identity is machineId() when available; fall back to "rows with no machine
+  // stamp" so a pure-local gather that never set machine still warms the cache.
+  let self: string | undefined;
+  try {
+    const { machineId } = await import('../machine-id.js');
+    self = machineId();
+  } catch {
+    self = undefined;
+  }
+  const localOnly = live.sessions.filter(
+    (s) => !s.machine || (self !== undefined && s.machine === self),
+  );
+  if (localOnly.length > 0) {
+    writeCache('local', localOnly, { capturedAt: now });
+  }
+  return {
+    sessions: live.sessions,
+    remoteDeviceCount: live.remoteDeviceCount,
+    servedFromCache: false,
+    capturedAt: snap.capturedAt,
+  };
+}
+
+/**
+ * Daemon warm entry point: live-gather THIS host and write the local snapshot.
+ * Never SSHes. Returns the published row count for the daemon log line.
+ */
+export async function publishLocalActiveSessions(
+  opts: { gather?: () => Promise<ActiveSession[]>; nowMs?: number } = {},
+): Promise<{ sessions: ActiveSession[]; capturedAt: number }> {
+  const result = await loadLocalActiveSessions({
+    forceRefresh: true,
+    gather: opts.gather,
+    nowMs: opts.nowMs,
+  });
+  return { sessions: result.sessions, capturedAt: result.capturedAt };
+}


### PR DESCRIPTION
## Summary

**User-visible:** menubar / Factory / watchdog / CLI no longer each re-run a full ~9s / ~170MB `sessions --active` gather. They share a daemon-warmed snapshot (15s freshness). `sessions --host` skips SSH for a reachable host when the cache is warm (was fallback-only on unreachable).

**Ticket:** [RUSH-2062](https://linear.app/getrush/issue/RUSH-2062/session-status-has-no-cross-surface-cache-menubarfactorywatchdogcli)

## What changed

| Area | Change |
|------|--------|
| `session-cache.ts` | New module — local + fleet snapshot, immutable memo by transcript mtime, publish-own warm |
| `daemon.ts` | Additive session-warm `setInterval` (15s) sibling of fleet cache warm — does not touch reaper |
| `remote.ts` | Cache-first for reachable hosts; unreachable still falls back to any-age cache |
| `gatherActiveSessions` | Cache-first for unscoped local/fleet; scoped `--host` always live |
| `watchdog.ts` | Reads warm local snapshot |

## Invariants (pinned by tests)

1. Fresh snapshot → `servedFromCache: true`, no re-gather
2. Snapshot older than 15s → re-gather (live status never stale)
3. `forceRefresh` always re-gathers
4. Immutable memo keyed on `(sessionId, mtime)` — miss on mtime change
5. Live keys (`status`, `preview`, `pidAlive`, …) never stored in immutable memo
6. Reachable-host remote cache serves when fresh; stale requires SSH; unreachable accepts any age

## Must not touch (boundary)

- Provenance loop in `active.ts` (Codex / RUSH-2063)
- `secrets/*`
- Reaper tick in `daemon.ts` (Kimi)

## Run proof

```
$ bun test src/lib/session/session-cache.test.ts src/lib/session/remote.test.ts
50 pass
0 fail
116 expect() calls
Ran 50 tests across 2 files. [269.00ms]
```

No UI surface (CLI/daemon cache) — test run is the verification artifact.

## Test plan

- [x] `session-cache.test.ts` — freshness / forceRefresh / immutable memo / live keys excluded
- [x] `remote.test.ts` — cache-first + unreachable any-age + serveWarm
- [ ] CI green
- [ ] Non-author review (prix-cloud paused #1767 → subagent)