### PR TITLE
fix(sessions): resume a remote session on its owning device; --host router stops masking unknown commands (RUSH-2022)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2022.md
+++ b/apps/cli/.changelog/next/RUSH-2022.md
@@ -8,13 +8,15 @@
   machine that was — so a peer-owned session started the agent here, against state this
   box had never seen (`sessions-resume.ts` even swapped in `process.cwd()` when the
   recorded directory did not exist locally). `agents resume` now re-runs itself on the
-  owning device over the same SSH transport `--host` uses; `--here` overrides. The bare
-  `agents sessions` picker routes the same way, and the multi-select `agents sessions
-  resume` — which opens tabs on one machine — skips a session belonging to a different
-  box **by name**, printing the command that reaches it. Root cause of the population
-  that made this common: a run dispatched with `agents run --device <box>` was indexed
-  with no origin machine at all, so the index claimed the dispatching box; it now records
-  `<box>`. Source: `apps/cli/src/lib/session/resume-owner.ts`,
+  owning device over SSH; `--here` overrides. The bare `agents sessions` picker routes
+  the same way, `agents sessions attach` hops as an **attach** (its detach record and
+  the headless process it stops both live on the owner), and the multi-select
+  `agents sessions resume` — which opens tabs on one machine — skips a session belonging
+  to a different box **by name**, printing the command that reaches it. Root cause of
+  the population that made this common: a run dispatched with `agents run --device
+  <box>` was indexed with no origin machine at all, so the index claimed the dispatching
+  box; it now records `<box>`, which also means such a run finally shows up under
+  `agents sessions --host <box>`. Source: `apps/cli/src/lib/session/resume-owner.ts`,
   `apps/cli/src/lib/hosts/session-index.ts`, `apps/cli/src/commands/resume.ts`.
 
   The hop carries its "don't route again" pin as an exported env var, not a flag, so it
@@ -35,3 +37,10 @@
   top level but the registry did not list it, so it only resolved through the
   unknown-command fallback that loads the whole command tree. Found by the new test that
   pins the command-name set against the real tree.
+
+- **A mistyped command keeps its `--host`.** The distance-1 auto-correct now runs *before*
+  the router instead of after commander gave up, so `agents docto --host <box>` corrects to
+  `doctor` **and** runs on `<box>` — previously the corrected command re-parsed locally with
+  a `--host` it did not accept. Four routing-table entries naming commands that do not exist
+  (`cli`, `packages`, `versions`, `daemon`) were removed; a test now keeps both routing
+  tables to real command names.

--- a/apps/cli/.changelog/next/RUSH-2022.md
+++ b/apps/cli/.changelog/next/RUSH-2022.md
@@ -1,0 +1,37 @@
+- **A session that ran on another device now resumes ON that device, and a typo'd
+  command with `--host` says `unknown command` (RUSH-2022).** Two bugs found while
+  recovering ~15 sessions after a machine crash, both of which sent recovery down the
+  wrong path.
+
+  (1) **`agents resume <id>` restarted a remote session locally.** The harness keeps its
+  conversation state on the machine that produced the session, but nothing checked which
+  machine that was — so a peer-owned session started the agent here, against state this
+  box had never seen (`sessions-resume.ts` even swapped in `process.cwd()` when the
+  recorded directory did not exist locally). `agents resume` now re-runs itself on the
+  owning device over the same SSH transport `--host` uses; `--here` overrides. The bare
+  `agents sessions` picker routes the same way, and the multi-select `agents sessions
+  resume` — which opens tabs on one machine — skips a session belonging to a different
+  box **by name**, printing the command that reaches it. Root cause of the population
+  that made this common: a run dispatched with `agents run --device <box>` was indexed
+  with no origin machine at all, so the index claimed the dispatching box; it now records
+  `<box>`. Source: `apps/cli/src/lib/session/resume-owner.ts`,
+  `apps/cli/src/lib/hosts/session-index.ts`, `apps/cli/src/commands/resume.ts`.
+
+  The hop carries its "don't route again" pin as an exported env var, not a flag, so it
+  works against a peer still on an older CLI. Sessions indexed *before* this release keep
+  their old machine tag — re-dispatch or a fresh scan corrects them.
+
+  (2) **The `--host`/`--device` router answered for commands that do not exist.** It runs
+  before commander parses, so `agents session resume --host <box>` (one letter off
+  `sessions`, which *does* accept `--host`) reported ``  `agents session` does not support
+  --host/--device `` — a true statement about a command nobody typed and the opposite of
+  the truth for the one they meant. Unknown names now fall through to `unknown command
+  '<name>'` with a did-you-mean, and the spellcheck can suggest the lazily-registered
+  groups (`sessions`/`teams`/`cloud`/…) it previously could not see. A real command with
+  no remote semantics still gets the flag-support error. Source:
+  `apps/cli/src/lib/hosts/passthrough.ts`, `apps/cli/src/lib/startup/command-registry.ts`.
+
+- **`agents publish` is in the lazy command table.** `commands/packages.ts` registers it at
+  top level but the registry did not list it, so it only resolved through the
+  unknown-command fallback that loads the whole command tree. Found by the new test that
+  pins the command-name set against the real tree.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -342,17 +342,32 @@ for the non-empty-preview invariant (SES-8).
 
 ### Resume is machine-bound — check the owner before you start a harness
 
-The picker lists the **whole fleet**, so anything that resumes a picked row can be
-handed a session whose harness state lives on another box. Route every such path
-through `sessionOwnerDevice`
-([`src/lib/session/resume-owner.ts`](src/lib/session/resume-owner.ts)) — the one
-answer to "may this resume run here?". A non-`undefined` result means the caller
-either hops to that device (`agents resume`, `resumeSessionInPlace`) or refuses by
-name (`sessions resume`, which opens tabs on a single machine); never start the
-harness locally. A synced mirror is the trap: its transcript IS readable here, so
-nothing fails until the agent is asked to continue a conversation it has never seen,
-and `sessions-resume.ts`'s `fs.existsSync(cwd)` fallback then quietly resumed in
-`process.cwd()` (RUSH-2022).
+**Reading and resuming follow different machines, and conflating them is the bug.**
+Reading follows the FILE — a synced mirror is on this disk, so only a live fan-out
+row (`_remote`) must be read on the peer (`transcriptOnPeerOf` in
+`sessions-picker.ts`). Resuming follows the HARNESS STATE, which is on the owning
+machine whatever the transcript's location. A mirror is therefore readable and NOT
+resumable, and that is the trap: nothing fails until the agent is asked to continue
+a conversation it has never seen, and `sessions-resume.ts`'s `fs.existsSync(cwd)`
+fallback then quietly resumed in `process.cwd()` (RUSH-2022).
+
+`sessionOwnerDevice`
+([`src/lib/session/resume-owner.ts`](src/lib/session/resume-owner.ts)) is the one
+answer to "may this resume run here?". Every path that starts a harness from a picked
+row consults it first: `agents resume` and the `agents sessions` picker hop to the
+owner, `sessions attach` hops as an **attach** (its detach record and the headless
+process it stops are both on the owner — hopping as a bare resume would skip the
+stop and leave two processes on one transcript), and `sessions resume`, which opens
+tabs on a single machine, refuses by name. `resumeSessionInPlace` is the LOCAL
+takeover and now **fails loud** if it is handed a peer-owned session — reaching it
+with one means a caller skipped its routing step.
+
+The hop uses `runOnPeer` ([`src/lib/session/remote-list.ts`](src/lib/session/remote-list.ts)),
+not the `--host` passthrough. Two reasons: the passthrough re-discovers locally and
+dead-ends for a session that exists only on the peer, and it marks the run
+`AGENTS_FLEET_REMOTE` — a one-shot command may carry that consent marker, but a
+resumed session would inherit it for its whole life and `agents browser start` inside
+it would be refused as a cross-machine drive.
 
 The signal is only as good as what wrote it: `machine` on a host-dispatched run is
 stamped by [`src/lib/hosts/session-index.ts`](src/lib/hosts/session-index.ts) from

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -340,6 +340,25 @@ that collapses, so the preview can silently vanish on a full/short terminal (the
 RUSH-2198 bug). See the [§Contracts §Sessions spec](docs/specifications.md#sessions)
 for the non-empty-preview invariant (SES-8).
 
+### Resume is machine-bound — check the owner before you start a harness
+
+The picker lists the **whole fleet**, so anything that resumes a picked row can be
+handed a session whose harness state lives on another box. Route every such path
+through `sessionOwnerDevice`
+([`src/lib/session/resume-owner.ts`](src/lib/session/resume-owner.ts)) — the one
+answer to "may this resume run here?". A non-`undefined` result means the caller
+either hops to that device (`agents resume`, `resumeSessionInPlace`) or refuses by
+name (`sessions resume`, which opens tabs on a single machine); never start the
+harness locally. A synced mirror is the trap: its transcript IS readable here, so
+nothing fails until the agent is asked to continue a conversation it has never seen,
+and `sessions-resume.ts`'s `fs.existsSync(cwd)` fallback then quietly resumed in
+`process.cwd()` (RUSH-2022).
+
+The signal is only as good as what wrote it: `machine` on a host-dispatched run is
+stamped by [`src/lib/hosts/session-index.ts`](src/lib/hosts/session-index.ts) from
+the dispatch host. Any new writer of an `agents run --device`-shaped row must set it,
+or the index will claim the dispatching box.
+
 ## Bundled native helpers (where the tarball's `.app`s come from)
 
 Two native helpers plus the standalone signed CLI binary ship **inside** this

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -54,9 +54,11 @@ lookup and SIGTERMs the rest, so a fast peer's hit is not bounded by the
 slowest/unreachable peer's timeout. It then routes to the owning device and invokes the
 version that created the session with its recorded cwd and launch mode. **"Routes to the
 owning device" is an SSH hop, not a local start:** when the session's origin machine is
-another box, `agents resume` re-runs itself there over the same transport `--host` uses,
-because the harness's conversation state lives on that machine — starting it here would
-run the agent against state this box has never seen. `--here` overrides and runs locally.
+another box, `agents resume` re-runs itself there over the same peer transport the
+picker uses, because the harness's conversation state lives on that machine — starting
+it here would run the agent against state this box has never seen. `--here` overrides
+and runs locally. `agents sessions attach <id>` hops the same way, as an *attach*: both
+halves of it (the detach record and the headless process it stops) are on the owner.
 A run dispatched with `agents run --device <box>` records `<box>` as its origin machine in
 the local index, so it resumes back on that box rather than on the machine that dispatched
 it (RUSH-2022). An exact

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -24,6 +24,7 @@ interchangeable — pick the verb for the intent:
 | Headless → **interactive** in this terminal | `agents sessions attach <id>` |
 | Multi-select history and open each in a tab/split | `agents sessions resume [query]` |
 | Resume one session in its original harness, version, device, cwd, and mode | `agents resume <id>` |
+| Resume a batch on the machine that owns them | `agents sessions resume --host <device>` |
 | Continue one session from a script / `run` path | `agents run <agent> --resume <id> …` |
 
 `focus` is the default “take me there” for a live process. With no id it opens a
@@ -32,6 +33,13 @@ in the terminal you're in (Ghostty / iTerm / tmux, auto-detected), reusing
 `resume`'s batch open + flood guard. Per tab it keeps live semantics — a tmux
 session is *joined* (a second client, no fork), local or remote over SSH; a session
 with no attach rail resumes a copy in the tab, reported never silently dropped.
+`sessions resume` opens its tabs on ONE machine — this box, or the `--host <device>`
+you point it at — and the picker lists the whole fleet, so a selected session owned by
+a **different** box is **skipped by name** rather than started against state that
+machine does not have; the skip line gives the command that reaches it
+(`agents resume <id>`, or `agents sessions resume --host <owner>`). A session this
+machine owns is never skipped, `--host` or not: opening a locally-forked copy on the
+machine the user sits at is the `/fork` handoff, and that destination is explicit.
 `--device/--host <name>` scopes the picker to those devices and the `--active`
 live-state filters (`--orphan`/`--crashed`/`--waiting`/`--idle`/`--working`/…) narrow
 by status; the two compose (`focus --orphan --device yosemite-s0`). A direct
@@ -44,7 +52,14 @@ a local hit; only on a local miss does it fan out to registered devices, and the
 fan-out is cancellable and early-exits — the first peer holding the UUID resolves the
 lookup and SIGTERMs the rest, so a fast peer's hit is not bounded by the
 slowest/unreachable peer's timeout. It then routes to the owning device and invokes the
-version that created the session with its recorded cwd and launch mode. An exact
+version that created the session with its recorded cwd and launch mode. **"Routes to the
+owning device" is an SSH hop, not a local start:** when the session's origin machine is
+another box, `agents resume` re-runs itself there over the same transport `--host` uses,
+because the harness's conversation state lives on that machine — starting it here would
+run the agent against state this box has never seen. `--here` overrides and runs locally.
+A run dispatched with `agents run --device <box>` records `<box>` as its origin machine in
+the local index, so it resumes back on that box rather than on the machine that dispatched
+it (RUSH-2022). An exact
 **label** always consults the fleet (labels are not globally unique, so a same-label
 session could live on another peer): a unique match auto-resumes, a cross-machine
 collision surfaces as an ambiguity, and an ambiguous short-id prefix still surfaces

--- a/apps/cli/docs/hosts.md
+++ b/apps/cli/docs/hosts.md
@@ -90,6 +90,18 @@ agents view --device all --json        # machine-readable fleet inventory
 `--devices all` and `--hosts all` are synonyms. Commands that already register
 `--all-hosts` (e.g. `agents output --all-hosts`) keep their existing behavior.
 
+**The router only speaks for commands that exist.** `--host`/`--device` is handled
+before commander parses, so a group with no remote semantics gets a clear
+`` `agents <cmd>` does not support --host/--device `` instead of commander's raw
+`unknown option`. That answer is reserved for a **real** command: a name the CLI
+does not register falls straight through to `unknown command '<name>'` (plus its
+did-you-mean). Without that gate `agents session resume --host <box>` — one letter
+off `sessions`, which *does* take `--host` — was answered with a flag-support error
+about a command nobody typed, sending the user looking in the wrong place
+(RUSH-2022). `KNOWN_TOP_LEVEL_COMMANDS`
+([`src/lib/startup/command-registry.ts`](../src/lib/startup/command-registry.ts))
+is the name set, pinned to the real command tree by a test.
+
 It sits next to the vendor clouds (`agents cloud run --provider rush|codex|…`),
 not replacing them: those dispatch to *someone else's* cloud; `hosts` dispatches
 to *your* boxes (owned, or leased on demand via crabbox — see Host sources).

--- a/apps/cli/src/commands/attach.ts
+++ b/apps/cli/src/commands/attach.ts
@@ -10,6 +10,8 @@ import chalk from 'chalk';
 import { discoverSessions } from '../lib/session/discover.js';
 import { resumeSessionInPlace } from './sessions.js';
 import { readDetachRecord, clearDetachRecord, isHeadlessAlive } from '../lib/session/detached.js';
+import { sessionOwnerDevice } from '../lib/session/resume-owner.js';
+import { runOnPeer } from '../lib/session/remote-list.js';
 
 export function registerAttachCommand(program: Command): void {
   program
@@ -30,6 +32,24 @@ export async function attachAction(id: string): Promise<void> {
     console.error(chalk.red(`No session matching "${id}".`));
     console.error(chalk.gray('  See your sessions: agents sessions'));
     process.exitCode = 1;
+    return;
+  }
+
+  // A session that ran on another device attaches THERE — as an attach, not a
+  // bare resume. Both halves of this command are machine-local: the detach
+  // record below lives on the owner's disk, and so does the headless process it
+  // stops. Hopping with `agents resume` instead would skip that stop entirely
+  // and leave two processes on one transcript, which is the precise thing the
+  // next block exists to prevent (RUSH-2022).
+  const owner = sessionOwnerDevice(meta);
+  if (owner) {
+    console.log(chalk.gray(`Session ${meta.shortId} belongs to ${owner} — attaching there over SSH…`));
+    const rc = await runOnPeer(['sessions', 'attach', meta.id], owner, { tty: true });
+    if (rc === 'no-target') {
+      console.error(chalk.red(`${owner} isn't a reachable device right now.`));
+      console.error(chalk.gray(`  Register/wake it (agents devices), or run there: agents ssh ${owner}`));
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/apps/cli/src/commands/resume.test.ts
+++ b/apps/cli/src/commands/resume.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { buildResumeRunArgs } from './resume.js';
+import { describe, expect, it, afterEach } from 'vitest';
+import { buildResumeRunArgs, buildResumeRemoteArgs } from './resume.js';
+import { consumeResumePinned, RESUME_PINNED_ENV } from '../lib/session/resume-owner.js';
 
 describe('buildResumeRunArgs', () => {
   const session = {
@@ -28,5 +29,40 @@ describe('buildResumeRunArgs', () => {
       'edit',
       '--headless',
     ]);
+  });
+});
+
+describe('buildResumeRemoteArgs — the hop to the owning device (RUSH-2022)', () => {
+  const id = '019fd0c8-b3e9-77a2-a1a4-444698c4d897';
+
+  it('re-runs `agents resume` on the owner, forwarding the caller flags verbatim', () => {
+    expect(buildResumeRemoteArgs(id, 'finish the tests', { mode: 'edit', headless: true, quiet: true }))
+      .toEqual(['resume', id, 'finish the tests', '--mode', 'edit', '--headless', '--quiet']);
+  });
+
+  it('carries NO loop-guard flag — a peer on an older CLI would die on an unknown option', () => {
+    // The pin rides RESUME_PINNED_ENV instead; every token here must exist in
+    // the released `agents resume` surface.
+    const args = buildResumeRemoteArgs(id, undefined, {});
+    expect(args).toEqual(['resume', id]);
+    expect(args).not.toContain('--here');
+  });
+});
+
+describe('consumeResumePinned', () => {
+  afterEach(() => {
+    delete process.env[RESUME_PINNED_ENV];
+  });
+
+  it('reads the pin the SSH hop exports and clears it so children never inherit it', () => {
+    process.env[RESUME_PINNED_ENV] = '1';
+    expect(consumeResumePinned()).toBe(true);
+    expect(process.env[RESUME_PINNED_ENV]).toBeUndefined();
+    // A nested `agents resume` inside the running agent routes normally again.
+    expect(consumeResumePinned()).toBe(false);
+  });
+
+  it('is false when unset', () => {
+    expect(consumeResumePinned()).toBe(false);
   });
 });

--- a/apps/cli/src/commands/resume.ts
+++ b/apps/cli/src/commands/resume.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import { setHelpSections } from '../lib/help.js';
 import { resolveSessionMetadataValue } from './sessions.js';
+import { sessionOwnerDevice, consumeResumePinned, RESUME_PINNED_ENV } from '../lib/session/resume-owner.js';
 
 interface ResumeOptions {
   mode?: string;
@@ -11,6 +12,30 @@ interface ResumeOptions {
   headless?: boolean;
   cwd?: string;
   quiet?: boolean;
+  /** Run on THIS machine even when the session belongs to a peer (escape hatch). */
+  here?: boolean;
+}
+
+/**
+ * The argv to re-run this resume on the machine that owns the session.
+ *
+ * Deliberately carries no "don't route again" FLAG — that rides the
+ * {@link RESUME_PINNED_ENV} export instead, so the hop also works against a peer
+ * on an older CLI (see the constant's docs). Every argv token here exists in the
+ * released surface.
+ */
+export function buildResumeRemoteArgs(
+  sessionId: string,
+  prompt: string | undefined,
+  options: ResumeOptions,
+): string[] {
+  const args = ['resume', sessionId, ...(prompt === undefined ? [] : [prompt])];
+  if (options.mode) args.push('--mode', options.mode);
+  if (options.interactive) args.push('--interactive');
+  if (options.headless) args.push('--headless');
+  if (options.cwd) args.push('--cwd', options.cwd);
+  if (options.quiet) args.push('--quiet');
+  return args;
 }
 
 /** Translate `agents resume <id>` to the canonical `agents run` surface after
@@ -39,7 +64,11 @@ export function registerResumeCommand(program: Command): void {
     .option('--headless', 'Resume headlessly (a prompt is required)')
     .option('--cwd <path>', 'Override the recorded working directory')
     .option('-q, --quiet', 'Suppress routing banners')
+    .option('--here', 'Run on this machine even if the session belongs to another device')
     .action(async (sessionId: string, prompt: string | undefined, options: ResumeOptions) => {
+      // Read (and clear) the routing pin before anything else, so it can never
+      // reach the agent's own children.
+      const pinnedHere = consumeResumePinned() || !!options.here;
       const outcome = await resolveSessionMetadataValue(sessionId.trim());
       if (outcome.kind === 'partial') {
         console.error(chalk.red(`Could not resolve session while these devices were unavailable: ${outcome.failedPeers.join(', ')}`));
@@ -54,6 +83,30 @@ export function registerResumeCommand(program: Command): void {
       if (outcome.kind === 'ambiguous') {
         console.error(chalk.red(`"${sessionId}" matches ${outcome.candidates.length} sessions. Pass the full session id.`));
         process.exitCode = 1;
+        return;
+      }
+
+      // The harness keeps its conversation state on the machine that produced
+      // the session, so a peer-owned session MUST resume there. Running it here
+      // starts the agent against state this box does not have — silently, since
+      // a synced mirror makes the transcript look local (RUSH-2022).
+      const owner = pinnedHere ? undefined : sessionOwnerDevice(outcome.session);
+      if (owner) {
+        if (!options.quiet) {
+          process.stderr.write(chalk.gray(`[agents] session ${outcome.session.shortId} belongs to ${owner} → resuming there\n`));
+        }
+        const { runAgentsOnDevice } = await import('../lib/hosts/passthrough.js');
+        process.exitCode = await runAgentsOnDevice(
+          owner,
+          buildResumeRemoteArgs(outcome.session.id, prompt, options),
+          {
+            // No remoteCwd: the owner resolves the session's recorded cwd itself
+            // (and `--cwd` is already forwarded), so the hop never depends on
+            // this box's idea of a directory that must exist over there.
+            interactive: !!process.stdout.isTTY,
+            env: { [RESUME_PINNED_ENV]: '1' },
+          },
+        );
         return;
       }
 
@@ -90,6 +143,7 @@ export function registerResumeCommand(program: Command): void {
       agents resume 019fd0c8-b3e9-77a2-a1a4-444698c4d897 --mode edit`,
     notes: `
       A full ID resolves from the local session database first (zero SSH) and, on a local miss, fans out with the first peer holding it cancelling the rest. An exact label always consults the fleet (labels are not globally unique) and auto-resumes the one match; a cross-machine label collision surfaces as an ambiguity.
+      A session that ran on another device resumes ON that device over SSH — the harness's conversation state lives there, so running it here would start against state this machine does not have. --here overrides that and runs locally.
       Use agents run auto --resume <id> when the original account is unavailable and another harness may continue.`,
   });
 }

--- a/apps/cli/src/commands/resume.ts
+++ b/apps/cli/src/commands/resume.ts
@@ -95,18 +95,22 @@ export function registerResumeCommand(program: Command): void {
         if (!options.quiet) {
           process.stderr.write(chalk.gray(`[agents] session ${outcome.session.shortId} belongs to ${owner} → resuming there\n`));
         }
-        const { runAgentsOnDevice } = await import('../lib/hosts/passthrough.js');
-        process.exitCode = await runAgentsOnDevice(
-          owner,
+        // `runOnPeer` is the existing transport for "this session's transcript
+        // and agent binary are on that box" (lib/session/remote-list.ts) — the
+        // same one the picker already uses. Not the `--host` passthrough: that
+        // one re-discovers locally and marks the run AGENTS_FLEET_REMOTE, which
+        // a long-lived resumed session must not inherit.
+        const { runOnPeer } = await import('../lib/session/remote-list.js');
+        const rc = await runOnPeer(
           buildResumeRemoteArgs(outcome.session.id, prompt, options),
-          {
-            // No remoteCwd: the owner resolves the session's recorded cwd itself
-            // (and `--cwd` is already forwarded), so the hop never depends on
-            // this box's idea of a directory that must exist over there.
-            interactive: !!process.stdout.isTTY,
-            env: { [RESUME_PINNED_ENV]: '1' },
-          },
+          owner,
+          { tty: !!process.stdout.isTTY, env: { [RESUME_PINNED_ENV]: '1' } },
         );
+        if (rc === 'no-target') {
+          console.error(chalk.red(`Session ${outcome.session.shortId} lives on ${owner}, which isn't a reachable device right now.`));
+          console.error(chalk.gray(`Register/wake it (agents devices), or run there: agents ssh ${owner}`));
+          process.exitCode = 1;
+        }
         return;
       }
 

--- a/apps/cli/src/commands/sessions-picker.ts
+++ b/apps/cli/src/commands/sessions-picker.ts
@@ -20,12 +20,17 @@ import { renderMarkdown } from '../lib/markdown.js';
 import { itemPicker } from '../lib/picker.js';
 import { classifyFileChanges, changeCounts, toolHistogram, detectTestResult } from '../lib/session/digest.js';
 import { extractArtifacts, extractHooks, extractLinks, extractRepos, extractSkills } from '../lib/session/highlights.js';
-/** A session whose transcript lives on another machine (folded in over the live
- * cross-machine fan-out): its `filePath` is on that peer's disk, so the preview
- * can't parse it locally — it shows metadata + a "resume there" note instead.
- * Keys off `_remote`, not the machine tag, so locally-readable synced mirrors
- * still parse their file normally. */
-function remoteMachineOf(session: SessionMeta): string | undefined {
+/** A session whose transcript FILE is on another machine (folded in over the
+ * live cross-machine fan-out): its `filePath` is on that peer's disk, so the
+ * preview can't parse it locally — it shows metadata + a "resume there" note
+ * instead. Keys off `_remote`, not the machine tag, so locally-readable synced
+ * mirrors still parse their file normally.
+ *
+ * This is the READ rule and only the read rule. Whether a session may be
+ * RESUMED here is a different question with a different answer — a mirror is
+ * readable but not resumable — and `sessionOwnerDevice`
+ * (lib/session/resume-owner.ts) is the single place that answers it (RUSH-2022). */
+function transcriptOnPeerOf(session: SessionMeta): string | undefined {
   return session._remote ? session.machine : undefined;
 }
 
@@ -122,7 +127,7 @@ const previewCache = new Map<string, string>();
 
 /** Build a cached multi-line preview string for display in the session picker. */
 export function buildPreview(session: SessionMeta): string {
-  const remote = remoteMachineOf(session);
+  const remote = transcriptOnPeerOf(session);
   const cacheKey = remote ? `${remote}:${session.id}` : session.id;
   const cached = previewCache.get(cacheKey);
   if (cached) return cached;

--- a/apps/cli/src/commands/sessions-resume.test.ts
+++ b/apps/cli/src/commands/sessions-resume.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { resolveResumePacking } from './sessions-resume.js';
+import { resolveResumePacking, resumeCwd } from './sessions-resume.js';
+
+describe('resumeCwd — a local existsSync must not decide a remote path (RUSH-2022)', () => {
+  const session = { cwd: '/srv/work/api' };
+
+  it('takes the recorded cwd as written for a --host batch, even when absent here', () => {
+    // The tab is a `tmux new-window -c <cwd>` on that device: the directory
+    // lives over there, so this box's disk has no say.
+    expect(resumeCwd(session, 'zion', () => false)).toBe('/srv/work/api');
+  });
+
+  it('refuses a --host session with no recorded cwd rather than sending a local path', () => {
+    expect(resumeCwd({}, 'zion', () => true)).toBeUndefined();
+  });
+
+  it('still falls back to this directory for a LOCAL batch whose cwd is gone', () => {
+    expect(resumeCwd(session, undefined, () => false)).toBe(process.cwd());
+    expect(resumeCwd(session, undefined, () => true)).toBe('/srv/work/api');
+  });
+});
 
 describe('resolveResumePacking', () => {
   it('opens every resumed session in its own tab by default', () => {

--- a/apps/cli/src/commands/sessions-resume.ts
+++ b/apps/cli/src/commands/sessions-resume.ts
@@ -34,6 +34,7 @@ import {
   type EngineContext,
   type Packing,
 } from '../lib/terminal/index.js';
+import { resumeDestinationMismatch } from '../lib/session/resume-owner.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
 import { setHelpSections } from '../lib/help.js';
 import { confirm } from '@inquirer/prompts';
@@ -156,7 +157,10 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
   }
   if (!chosen || chosen.length === 0) return;
 
-  // 2. Split the selection into resumable surfaces and skipped agents (no silent drop).
+  // 2. Split the selection into resumable surfaces and skipped sessions (no
+  // silent drop): an agent with no resume support, or a session whose harness
+  // state lives on a machine this batch is not opening tabs on.
+  const destination = options.host;
   const items: Array<SurfaceItem & { session: SessionMeta }> = [];
   for (const s of chosen) {
     const command = buildResumeCommand(s);
@@ -164,7 +168,29 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
       console.log(chalk.yellow(`  skip ${s.shortId} — resume is not supported for ${s.agent} sessions yet`));
       continue;
     }
-    const cwd = s.cwd && fs.existsSync(s.cwd) ? s.cwd : process.cwd();
+    // The picker offers fleet-wide rows, so a peer-owned session can be
+    // selected. Its transcript may even be readable here (a synced mirror), but
+    // the harness's conversation state is not — and the cwd below would then
+    // silently fall back to `process.cwd()`, resuming in whatever directory the
+    // user happens to be in. Refuse it, naming the device (RUSH-2022).
+    const mismatch = resumeDestinationMismatch(s, destination);
+    if (mismatch) {
+      console.log(
+        chalk.yellow(`  skip ${s.shortId} — belongs to ${mismatch}`) +
+          chalk.gray(destination
+            ? `, not --host ${destination}. Run: agents sessions resume --host ${mismatch}`
+            : `, not this machine. Run: agents resume ${s.id}`),
+      );
+      continue;
+    }
+    const cwd = resumeCwd(s, destination);
+    if (cwd === undefined) {
+      console.log(
+        chalk.yellow(`  skip ${s.shortId} — no recorded working directory`) +
+          chalk.gray(`, and this machine's cannot stand in for one on ${destination}`),
+      );
+      continue;
+    }
     items.push({ session: s, cwd, command });
   }
   if (items.length === 0) {
@@ -228,6 +254,31 @@ async function sessionsResumeAction(query: string | undefined, options: ResumeOp
 
 export function resolveResumePacking(options: Pick<ResumeOptions, 'splits'>): Packing {
   return options.splits ? 'two-per-tab' : 'tabs';
+}
+
+/**
+ * The directory a resumed session's tab should open in, or `undefined` when this
+ * machine has nothing truthful to offer.
+ *
+ * The recorded `cwd` belongs to the session's own machine, so probing it with a
+ * LOCAL `fs.existsSync` only means something when the tabs open locally. With
+ * `--host <device>` the tab is a `tmux new-window -c <cwd>` over there: a
+ * directory absent here may well exist on that box, and substituting this box's
+ * `process.cwd()` hands the peer a path it does not have. That substitution is
+ * the same defect as the wrong-machine resume — an existsSync on the wrong
+ * machine deciding a remote path (RUSH-2022) — so remote batches take the record
+ * as written, and a session with no record at all is refused rather than opened
+ * somewhere invented.
+ *
+ * `exists` is injectable so the local branch is testable without touching disk.
+ */
+export function resumeCwd(
+  session: Pick<SessionMeta, 'cwd'>,
+  destination: string | undefined,
+  exists: (p: string) => boolean = fs.existsSync,
+): string | undefined {
+  if (destination) return session.cwd || undefined;
+  return session.cwd && exists(session.cwd) ? session.cwd : process.cwd();
 }
 
 /**

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -41,6 +41,7 @@ import { runRemoteSessions, buildForwardedArgs, ensureWholeIndex } from '../lib/
 import { formatRelativeTime, formatCompactAge, sessionAgeParts, type SessionAgeParts } from '../lib/session/relative-time.js';
 import { renderConversationMarkdown, renderSummary, renderSummaryHeader, computeSummaryStats, renderJson, filterEvents, parseRoleList, linkPath, linkUrl, shortenModel, type FilterOptions } from '../lib/session/render.js';
 import { linearIssueUrl } from '../lib/session/linear.js';
+import { sessionOwnerDevice, RESUME_PINNED_ENV } from '../lib/session/resume-owner.js';
 import { renderMarkdown } from '../lib/markdown.js';
 import { AGENTS, colorAgent, resolveAgentName } from '../lib/agents.js';
 import { getShimsDir } from '../lib/state.js';
@@ -3339,6 +3340,23 @@ export async function handlePickedSession(picked: PickedSession): Promise<void> 
  * version-pinned launcher is genuinely missing.
  */
 export async function resumeSessionInPlace(session: SessionMeta): Promise<void> {
+  // A session that ran on another device keeps its harness state there. Resuming
+  // it here would start the agent against state this box does not have — and the
+  // `fs.existsSync(session.cwd)` fallback below hid exactly that, quietly
+  // swapping in `process.cwd()` when the recorded directory was a peer's path
+  // (RUSH-2022). Route the takeover to the owner over the same SSH transport
+  // `--host` uses.
+  const owner = sessionOwnerDevice(session);
+  if (owner) {
+    console.log(chalk.gray(`Session ${session.shortId} belongs to ${owner} — resuming there over SSH…`));
+    const { runAgentsOnDevice } = await import('../lib/hosts/passthrough.js');
+    process.exitCode = await runAgentsOnDevice(owner, ['resume', session.id], {
+      interactive: !!process.stdout.isTTY,
+      env: { [RESUME_PINNED_ENV]: '1' },
+    });
+    return;
+  }
+
   const cwd = session.cwd && fs.existsSync(session.cwd)
     ? session.cwd
     : process.cwd();

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -3271,16 +3271,6 @@ export async function pickSessionInteractive(
   }
 }
 
-/**
- * The machine a picked session lives on when its transcript is on that peer's
- * disk (folded in over the live fan-out), else undefined. Keys off `_remote`,
- * NOT `machine !== local`: a synced mirror is machine-tagged too, but its file
- * is a local mirror path, so it must be read/resumed locally like any other.
- */
-function remoteMachineOf(session: SessionMeta): string | undefined {
-  return session._remote ? session.machine : undefined;
-}
-
 /** True when the peer wasn't a dialable device; prints one clear line so a
  * remote pick never dead-ends silently. */
 function warnNoPeerTarget(machine: string, session: SessionMeta): void {
@@ -3309,24 +3299,32 @@ export async function handlePickedSession(picked: PickedSession): Promise<void> 
     console.log(chalk.gray(`Watch for it with: agents sessions --active${picked.session.machine ? ` --host ${picked.session.machine}` : ''}`));
     return;
   }
-  // A session on another machine is read/resumed ON that machine over SSH — its
-  // transcript and agent binary live there. Both actions execute on the peer
-  // (not a local `--host` hop, which would discover locally and dead-end for a
-  // session that exists only on the peer).
-  const remote = remoteMachineOf(picked.session);
-  if (remote) {
-    if (picked.action === 'view') {
-      const rc = await runOnPeer(['sessions', picked.session.shortId, '--markdown'], remote);
-      if (rc === 'no-target') warnNoPeerTarget(remote, picked.session);
-    } else {
-      console.log(chalk.gray(`Resuming ${picked.session.shortId} on ${remote} over SSH...`));
-      const rc = await runOnPeer(['sessions', 'resume', picked.session.shortId], remote, { tty: true });
-      if (rc === 'no-target') warnNoPeerTarget(remote, picked.session);
+  // Reading and resuming are on DIFFERENT machines' terms, and conflating them
+  // is what RUSH-2022 was. Reading follows the FILE: a synced mirror sits on
+  // this disk, so only a live fan-out row (`_remote`) has to be read on the
+  // peer. Resuming follows the HARNESS STATE, which is on the owning machine
+  // whatever the transcript's location — a mirror included.
+  if (picked.action === 'view') {
+    const readFrom = picked.session._remote ? picked.session.machine : undefined;
+    if (readFrom) {
+      const rc = await runOnPeer(['sessions', picked.session.shortId, '--markdown'], readFrom);
+      if (rc === 'no-target') warnNoPeerTarget(readFrom, picked.session);
+      return;
     }
+    await renderSession(picked.session, 'summary', {});
     return;
   }
-  if (picked.action === 'view') {
-    await renderSession(picked.session, 'summary', {});
+
+  const owner = sessionOwnerDevice(picked.session);
+  if (owner) {
+    console.log(chalk.gray(`Resuming ${picked.session.shortId} on ${owner} over SSH...`));
+    // `agents resume <id>` is the strict single-session path — one pick, one
+    // resume. (`sessions resume <shortId>` would re-open a picker over there.)
+    const rc = await runOnPeer(['resume', picked.session.id], owner, {
+      tty: true,
+      env: { [RESUME_PINNED_ENV]: '1' },
+    });
+    if (rc === 'no-target') warnNoPeerTarget(owner, picked.session);
     return;
   }
   await resumeSessionInPlace(picked.session);
@@ -3340,20 +3338,18 @@ export async function handlePickedSession(picked: PickedSession): Promise<void> 
  * version-pinned launcher is genuinely missing.
  */
 export async function resumeSessionInPlace(session: SessionMeta): Promise<void> {
-  // A session that ran on another device keeps its harness state there. Resuming
-  // it here would start the agent against state this box does not have — and the
-  // `fs.existsSync(session.cwd)` fallback below hid exactly that, quietly
-  // swapping in `process.cwd()` when the recorded directory was a peer's path
-  // (RUSH-2022). Route the takeover to the owner over the same SSH transport
-  // `--host` uses.
+  // This function is the LOCAL takeover, and every caller is responsible for
+  // routing a peer-owned session before it gets here (the picker above,
+  // `agents resume`, `sessions attach`). Reaching it with one anyway means a
+  // caller skipped that step, so refuse rather than start the harness against
+  // state this box does not have — the `fs.existsSync(session.cwd)` fallback
+  // just below is exactly how that used to pass unnoticed, quietly swapping in
+  // `process.cwd()` when the recorded directory was a peer's path (RUSH-2022).
   const owner = sessionOwnerDevice(session);
   if (owner) {
-    console.log(chalk.gray(`Session ${session.shortId} belongs to ${owner} — resuming there over SSH…`));
-    const { runAgentsOnDevice } = await import('../lib/hosts/passthrough.js');
-    process.exitCode = await runAgentsOnDevice(owner, ['resume', session.id], {
-      interactive: !!process.stdout.isTTY,
-      env: { [RESUME_PINNED_ENV]: '1' },
-    });
+    console.error(chalk.red(`Session ${session.shortId} belongs to ${owner} — it cannot resume on this machine.`));
+    console.error(chalk.gray(`  Resume it there: agents resume ${session.id}`));
+    process.exitCode = 1;
     return;
   }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1195,12 +1195,21 @@ let requestedIsDisabled = requestedCommand !== undefined && brandDisabled.has(re
 // never re-consulted the router and dead-ended on a LOCAL doctor with an unknown
 // option. A brand-disabled name is not a correction target — under that brand the
 // command does not exist. RUSH-2022.
-if (requestedCommand !== undefined && !isKnownTopLevelCommand(requestedCommand)) {
+// Only argv[0]: `requestedCommand` is "first token that doesn't start with -",
+// which in a leading-flag form like `agents --host box view` picks up the FLAG'S
+// VALUE (`box`). Reading that as a command is a pre-existing wart; REWRITING it
+// would be a new bug — a device named one letter off a command would have its
+// name silently replaced. A typo anywhere but position 0 falls through to the
+// plain `unknown command` + did-you-mean.
+if (
+  requestedCommand !== undefined &&
+  passedArgs[0] === requestedCommand &&
+  !isKnownTopLevelCommand(requestedCommand)
+) {
   const suggestion = suggestTopLevelCommand(requestedCommand);
   if (suggestion?.distance === 1 && !brandDisabled.has(suggestion.name)) {
-    const idx = passedArgs.indexOf(requestedCommand);
-    passedArgs[idx] = suggestion.name;
-    process.argv[idx + 2] = suggestion.name;
+    passedArgs[0] = suggestion.name;
+    process.argv[2] = suggestion.name;
     requestedCommand = suggestion.name;
     requestedIsDisabled = false;
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -124,6 +124,8 @@ if (IS_DEV_BUILD) {
 import {
   COMMAND_LOADERS,
   LAZY_COMMAND_NAMES,
+  isKnownTopLevelCommand,
+  suggestTopLevelCommand,
   loadView,
   loadInspect,
   loadFeedback,
@@ -1155,51 +1157,15 @@ async function registerAllEagerCommands(): Promise<void> {
   await reg(loadUninstall);
 }
 
-/** Calculate the Levenshtein edit distance between two strings. */
-function levenshtein(a: string, b: string): number {
-  const m = a.length;
-  const n = b.length;
-  const dp: number[][] = Array(m + 1)
-    .fill(null)
-    .map(() => Array(n + 1).fill(0));
-  for (let i = 0; i <= m; i++) dp[i][0] = i;
-  for (let j = 0; j <= n; j++) dp[0][j] = j;
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      dp[i][j] =
-        a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1]
-          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
-    }
-  }
-  return dp[m][n];
-}
-
-// Auto-correct typos with edit distance 1
+// Unknown command. The distance-1 auto-correct happens EARLIER (before the
+// --host router — see below), so anything reaching here has no near match worth
+// rewriting; report it and suggest.
 program.on('command:*', (operands) => {
   const unknown = operands[0];
-  const allCommands = program.commands.map((c) => c.name());
-
-  let closest: string | null = null;
-  let minDist = Infinity;
-  for (const cmd of allCommands) {
-    const dist = levenshtein(unknown, cmd);
-    if (dist < minDist) {
-      minDist = dist;
-      closest = cmd;
-    }
-  }
-
-  if (minDist === 1 && closest) {
-    const args = process.argv.slice(2);
-    args[0] = closest;
-    program.parse(['node', 'agents', ...args]);
-    return;
-  }
-
+  const closest = suggestTopLevelCommand(unknown);
   console.error(`error: unknown command '${unknown}'`);
-  if (closest && minDist <= 3) {
-    console.error(`(Did you mean ${closest}?)`);
+  if (closest && closest.distance <= 3) {
+    console.error(`(Did you mean ${closest.name}?)`);
   }
   process.exit(1);
 });
@@ -1208,7 +1174,7 @@ program.on('command:*', (operands) => {
 // and the doc flags (--version/--help/-h) drive both the registration strategy
 // and whether the update check + background sync run at all.
 const passedArgs = process.argv.slice(2);
-const requestedCommand = passedArgs.find((arg) => !arg.startsWith('-'));
+let requestedCommand = passedArgs.find((arg) => !arg.startsWith('-'));
 const verboseStartup = passedArgs.includes('--verbose');
 // Help and version output are pure documentation — they must never gate on
 // setup, otherwise `agents <cmd> --help` becomes useless on a fresh box.
@@ -1221,7 +1187,24 @@ const helpOrVersionRequested = passedArgs.some(
 // spellcheck), while `agents` itself is unaffected. `brandDisabled` is empty for
 // the unbranded CLI, so all of this is a no-op there.
 const brandDisabled = disabledCommandsForActiveBrand();
-const requestedIsDisabled = requestedCommand !== undefined && brandDisabled.has(requestedCommand);
+let requestedIsDisabled = requestedCommand !== undefined && brandDisabled.has(requestedCommand);
+
+// Correct a one-letter typo BEFORE the --host router and before registration, so
+// the corrected command's own `--host` support decides the routing. Doing it
+// after (commander's `command:*` handler used to) meant `agents docto --host box`
+// never re-consulted the router and dead-ended on a LOCAL doctor with an unknown
+// option. A brand-disabled name is not a correction target — under that brand the
+// command does not exist. RUSH-2022.
+if (requestedCommand !== undefined && !isKnownTopLevelCommand(requestedCommand)) {
+  const suggestion = suggestTopLevelCommand(requestedCommand);
+  if (suggestion?.distance === 1 && !brandDisabled.has(suggestion.name)) {
+    const idx = passedArgs.indexOf(requestedCommand);
+    passedArgs[idx] = suggestion.name;
+    process.argv[idx + 2] = suggestion.name;
+    requestedCommand = suggestion.name;
+    requestedIsDisabled = false;
+  }
+}
 
 // `--host` passthrough: run this invocation on a remote machine over SSH instead
 // of locally. Handled before any local command registration / update check /
@@ -1239,9 +1222,6 @@ if (requestedCommand !== undefined && !helpOrVersionRequested && !requestedIsDis
 // Register only the command(s) this invocation actually uses. Lazy commands
 // (sessions/teams/cloud) are handled after applyGlobalHelpConventions below.
 const isLazyRequest = requestedCommand !== undefined && LAZY_COMMAND_NAMES.has(requestedCommand);
-// Set when the requested name maps to no command: the lazy tree is then also
-// registered below so the spellcheck can suggest `sessions`/`teams`/`cloud`.
-let requestedIsUnknown = false;
 if (requestedIsDisabled) {
   // The brand turned this command off: register the full tree so the "did you
   // mean" picker still works, then strip the disabled commands below so the
@@ -1254,7 +1234,6 @@ if (requestedIsDisabled) {
     // spellcheck and edit-distance-1 auto-correct (the command:* handler above)
     // see the same candidate set — and ordering — as main.
     await registerAllEagerCommands();
-    requestedIsUnknown = true;
   }
 }
 // When requestedCommand is undefined (bare invocation, --version, --help, -h) no
@@ -1270,19 +1249,6 @@ applyGlobalHelpConventions(program);
 // only when explicitly requested, keeping lightweight commands off that path.
 if (isLazyRequest && !requestedIsDisabled) {
   for (const loader of COMMAND_LOADERS[requestedCommand!]) await reg(loader);
-} else if (requestedIsUnknown) {
-  // Unknown command: the lazy names must be candidates too, or `agents session`
-  // (a typo for the very much lazy `sessions`) gets no "did you mean" at all —
-  // the miss the RUSH-2022 report walked into. Registration order still mirrors
-  // main: lazy commands come after applyGlobalHelpConventions.
-  const seen = new Set<ModuleLoader>();
-  for (const name of LAZY_COMMAND_NAMES) {
-    for (const loader of COMMAND_LOADERS[name] ?? []) {
-      if (seen.has(loader)) continue;
-      seen.add(loader);
-      await reg(loader);
-    }
-  }
 }
 
 // White-label: remove any commands this brand disabled so they resolve as

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1239,6 +1239,9 @@ if (requestedCommand !== undefined && !helpOrVersionRequested && !requestedIsDis
 // Register only the command(s) this invocation actually uses. Lazy commands
 // (sessions/teams/cloud) are handled after applyGlobalHelpConventions below.
 const isLazyRequest = requestedCommand !== undefined && LAZY_COMMAND_NAMES.has(requestedCommand);
+// Set when the requested name maps to no command: the lazy tree is then also
+// registered below so the spellcheck can suggest `sessions`/`teams`/`cloud`.
+let requestedIsUnknown = false;
 if (requestedIsDisabled) {
   // The brand turned this command off: register the full tree so the "did you
   // mean" picker still works, then strip the disabled commands below so the
@@ -1251,6 +1254,7 @@ if (requestedIsDisabled) {
     // spellcheck and edit-distance-1 auto-correct (the command:* handler above)
     // see the same candidate set — and ordering — as main.
     await registerAllEagerCommands();
+    requestedIsUnknown = true;
   }
 }
 // When requestedCommand is undefined (bare invocation, --version, --help, -h) no
@@ -1266,6 +1270,19 @@ applyGlobalHelpConventions(program);
 // only when explicitly requested, keeping lightweight commands off that path.
 if (isLazyRequest && !requestedIsDisabled) {
   for (const loader of COMMAND_LOADERS[requestedCommand!]) await reg(loader);
+} else if (requestedIsUnknown) {
+  // Unknown command: the lazy names must be candidates too, or `agents session`
+  // (a typo for the very much lazy `sessions`) gets no "did you mean" at all —
+  // the miss the RUSH-2022 report walked into. Registration order still mirrors
+  // main: lazy commands come after applyGlobalHelpConventions.
+  const seen = new Set<ModuleLoader>();
+  for (const name of LAZY_COMMAND_NAMES) {
+    for (const loader of COMMAND_LOADERS[name] ?? []) {
+      if (seen.has(loader)) continue;
+      seen.add(loader);
+      await reg(loader);
+    }
+  }
 }
 
 // White-label: remove any commands this brand disabled so they resolve as

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -65,6 +65,26 @@ describe('maybeRunOnHost — local short-circuits (no SSH attempted)', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('falls through for an UNKNOWN command so commander reports it (RUSH-2022)', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // `session` is a typo for the very much host-routable `sessions`. The router
+    // runs before commander parses, so claiming "does not support --host" here
+    // both invents a command and states the opposite of the truth for the one
+    // the user meant. It must decline and let `unknown command 'session'` win.
+    expect(await maybeRunOnHost('session', ['session', 'resume', '--host', 'mac'])).toBe(false);
+    expect(process.exitCode).toBe(0);
+    expect(await maybeRunOnHost('zzzznotacommand', ['zzzznotacommand', '--device', 'mac'])).toBe(false);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('still rejects --host on a REAL command that has no remote semantics', async () => {
+    process.env.AGENTS_SYNC_MACHINE_ID = 'mybox';
+    // The unknown-command gate above must not weaken this: `login` exists, so
+    // the flag-support error is the correct, honest answer.
+    expect(await maybeRunOnHost('login', ['login', '--host', 'mac'])).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
   it('returns false when no --host is given', async () => {
     expect(await maybeRunOnHost('view', ['view', 'claude'])).toBe(false);
   });

--- a/apps/cli/src/lib/hosts/passthrough.test.ts
+++ b/apps/cli/src/lib/hosts/passthrough.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { flagValue, maybeRunOnHost, runFleetPassthrough } from './passthrough.js';
+import { flagValue, maybeRunOnHost, runFleetPassthrough, REMOTE_PASSTHROUGH, OWN_HOST_COMMANDS } from './passthrough.js';
+import { KNOWN_TOP_LEVEL_COMMANDS } from '../startup/command-registry.js';
 import { machineId } from '../session/sync/config.js';
 import type { DeviceProfile, DeviceRegistry } from '../devices/registry.js';
 
@@ -37,6 +38,21 @@ describe('flagValue', () => {
   });
   it('returns undefined when absent', () => {
     expect(flagValue(['view', '--json'], 'host', 'H')).toBeUndefined();
+  });
+});
+
+describe('routing tables name only real commands (RUSH-2022)', () => {
+  // The unknown-command gate rejects a name before either table is consulted, so
+  // a key that is not a registered command is unreachable — and was already
+  // broken before the gate (it SSH'd a command the peer would reject too).
+  it('every REMOTE_PASSTHROUGH key is a registered top-level command', () => {
+    const phantom = Object.keys(REMOTE_PASSTHROUGH).filter((c) => !KNOWN_TOP_LEVEL_COMMANDS.has(c));
+    expect(phantom).toEqual([]);
+  });
+
+  it('every OWN_HOST_COMMANDS entry is a registered top-level command', () => {
+    const phantom = [...OWN_HOST_COMMANDS].filter((c) => !KNOWN_TOP_LEVEL_COMMANDS.has(c));
+    expect(phantom).toEqual([]);
   });
 });
 

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -56,8 +56,16 @@ interface RemoteSpec {
  * (`repo`/`repos`, `exec`/`run`) so either argv form routes the same way.
  *
  * Prefer adding here over per-command SSH code — this is the single choke point.
+ *
+ * Every key MUST be a real top-level command (a `KNOWN_TOP_LEVEL_COMMANDS`
+ * member) — `passthrough.test.ts` asserts it. A key that is not one is dead:
+ * the gate in {@link maybeRunOnHost} rejects the name as unknown before this
+ * table is consulted, and before that gate existed it SSH'd a command the peer
+ * would also reject. `cli`/`packages`/`versions`/`daemon` were exactly that
+ * (the commands are `clis`, `registry`/`search`/`install`/`publish`,
+ * `add`/`use`/`list`, and none) and were removed.
  */
-const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
+export const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   // status / inspect
   view: {},
   inspect: {},
@@ -85,10 +93,8 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   permissions: {},
   perms: {},
   mcp: {},
-  cli: {},
   subagents: {},
   workflows: {},
-  packages: {},
   models: {},
   profiles: {},
   defaults: {},
@@ -109,13 +115,11 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
   lock: {},
   feedback: {},
   wallet: {},
-  daemon: {},
   pty: {},
   tmux: {},
   watchdog: {},
   factory: {},
   browser: {},
-  versions: {},
 };
 
 /**
@@ -123,7 +127,7 @@ const REMOTE_PASSTHROUGH: Record<string, RemoteSpec> = {
  * fall through to local commander even when the flag is present. Do not add
  * these to {@link REMOTE_PASSTHROUGH}.
  */
-const OWN_HOST_COMMANDS = new Set([
+export const OWN_HOST_COMMANDS = new Set([
   'run',
   'exec', // deprecated alias of run
   'harness', // `--host <agent>` names the host CLI to run under, not a remote device
@@ -617,70 +621,22 @@ export async function maybeRunOnHost(
   const doctorPath = isDoctorCommand && !/^win/i.test((remoteOs ?? '').trim())
     ? { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' }
     : undefined;
-  process.exitCode = streamAgentsOnHost(host, forwarded, {
-    remoteCwd,
-    interactive,
-    extraEnv: doctorPath,
-    remoteOs,
-    target,
-  });
-  return true;
-}
-
-/**
- * Run `agents <forwardedArgs>` on `host` over SSH, streaming its output, and
- * return the exit code. The single place the SSH hop is built, so every remote
- * `agents` invocation carries identical env semantics.
- *
- * Forwards actor provenance (`AGENTS_ACTOR`/`GIT_` vars) across the hop, merged UNDER
- * `extraEnv` so a caller-supplied PATH still wins — without this the remote
- * re-resolves the actor from THIS box's SSH_CONNECTION and mis-credits it
- * (RUSH-2028). Flows to both POSIX (export) and Windows ($env:) dialects.
- * AGENTS_FLEET_REMOTE marks this as a fleet-dispatched run so the far side can
- * gate consent-sensitive actions — the browser consent gate
- * (lib/browser/remote-control.ts) reads it to allow/deny a cross-machine drive.
- */
-export function streamAgentsOnHost(
-  host: Host,
-  forwardedArgs: string[],
-  opts: {
-    remoteCwd?: string;
-    interactive?: boolean;
-    extraEnv?: Record<string, string>;
-    remoteOs?: string;
-    target?: string;
-  } = {},
-): number {
-  const target = opts.target ?? sshTargetFor(host);
-  const remoteOs = opts.remoteOs ?? resolveRemoteOsSync(host.name);
-  const env = withActorEnv({ ...opts.extraEnv, AGENTS_FLEET_REMOTE: '1' });
-  const remoteCmd = buildRemoteAgentsInvocation(forwardedArgs, opts.remoteCwd, remoteOs, env);
-  const code = sshStream(target, remoteCmd, { tty: !!opts.interactive, multiplex: true });
+  // Forward actor provenance (AGENTS_ACTOR*/GIT_*) across the SSH hop, merged
+  // UNDER the doctor PATH so that PATH still wins — without this the remote
+  // re-resolves the actor from THIS box's SSH_CONNECTION and mis-credits it
+  // (RUSH-2028). Flows to both POSIX (export) and Windows ($env:) dialects.
+  // AGENTS_FLEET_REMOTE marks this as a fleet-dispatched `--host` run so the far
+  // side can gate consent-sensitive actions — the browser consent gate
+  // (lib/browser/remote-control.ts) reads it to allow/deny a cross-machine drive.
+  const env = withActorEnv({ ...doctorPath, AGENTS_FLEET_REMOTE: '1' });
+  const remoteCmd = buildRemoteAgentsInvocation(forwarded, remoteCwd, remoteOs, env);
+  const code = sshStream(target, remoteCmd, { tty: interactive, multiplex: true });
   if (code === 255) {
     console.error(
       chalk.red(`${host.name}: unreachable over SSH (asleep, offline, or host key changed?).`) +
         chalk.gray(' Check: agents hosts check ' + host.name),
     );
   }
-  return code;
-}
-
-/**
- * Resolve a device/host name and run `agents <forwardedArgs>` there.
- *
- * Used by the resume router (commands/resume.ts, sessions.ts) to send a session
- * back to the machine that owns its transcript, so it reaches the SAME SSH path
- * as `--host` rather than a second, divergent transport (RUSH-2022).
- */
-export async function runAgentsOnDevice(
-  deviceName: string,
-  forwardedArgs: string[],
-  opts: { interactive?: boolean; remoteCwd?: string; env?: Record<string, string> } = {},
-): Promise<number> {
-  const host = await resolveTargetHost(deviceName, false);
-  return streamAgentsOnHost(host, forwardedArgs, {
-    interactive: opts.interactive,
-    remoteCwd: opts.remoteCwd,
-    extraEnv: opts.env,
-  });
+  process.exitCode = code;
+  return true;
 }

--- a/apps/cli/src/lib/hosts/passthrough.ts
+++ b/apps/cli/src/lib/hosts/passthrough.ts
@@ -42,6 +42,7 @@ import {
   type FanOutDeviceResult,
 } from '../devices/fleet.js';
 import { platformGroupLabel } from '../devices/health-report.js';
+import { isKnownTopLevelCommand } from '../startup/command-registry.js';
 
 /** Per-command remote behaviour. Absence from this map = not host-routable here. */
 interface RemoteSpec {
@@ -497,6 +498,15 @@ export async function maybeRunOnHost(
     if (!isAll && command !== 'routines') return false;
   }
 
+  // A command that does not exist is an unknown-command error, not a routing
+  // error. The router runs BEFORE commander parses, so without this gate a typo
+  // (`agents session resume --host box`) was answered with "does not support
+  // --host/--device" — a true statement about a command the user never typed,
+  // and the exact opposite of the truth for the `sessions` they meant, which
+  // does support it. Fall through so commander reports `unknown command` (and
+  // its did-you-mean). RUSH-2022.
+  if (!isKnownTopLevelCommand(command)) return false;
+
   const spec = REMOTE_PASSTHROUGH[command];
   if (!spec) {
     // Flag was accepted (no raw commander "unknown option") but this group has
@@ -607,22 +617,70 @@ export async function maybeRunOnHost(
   const doctorPath = isDoctorCommand && !/^win/i.test((remoteOs ?? '').trim())
     ? { PATH: '$HOME/.agents/.cache/shims:$HOME/.local/bin:$PATH' }
     : undefined;
-  // Forward actor provenance (AGENTS_ACTOR*/GIT_*) across the SSH hop, merged
-  // UNDER the doctor PATH so that PATH still wins — without this the remote
-  // re-resolves the actor from THIS box's SSH_CONNECTION and mis-credits it
-  // (RUSH-2028). Flows to both POSIX (export) and Windows ($env:) dialects.
-  // AGENTS_FLEET_REMOTE marks this as a fleet-dispatched `--host` run so the far
-  // side can gate consent-sensitive actions — the browser consent gate
-  // (lib/browser/remote-control.ts) reads it to allow/deny a cross-machine drive.
-  const env = withActorEnv({ ...doctorPath, AGENTS_FLEET_REMOTE: '1' });
-  const remoteCmd = buildRemoteAgentsInvocation(forwarded, remoteCwd, remoteOs, env);
-  const code = sshStream(target, remoteCmd, { tty: interactive, multiplex: true });
+  process.exitCode = streamAgentsOnHost(host, forwarded, {
+    remoteCwd,
+    interactive,
+    extraEnv: doctorPath,
+    remoteOs,
+    target,
+  });
+  return true;
+}
+
+/**
+ * Run `agents <forwardedArgs>` on `host` over SSH, streaming its output, and
+ * return the exit code. The single place the SSH hop is built, so every remote
+ * `agents` invocation carries identical env semantics.
+ *
+ * Forwards actor provenance (`AGENTS_ACTOR`/`GIT_` vars) across the hop, merged UNDER
+ * `extraEnv` so a caller-supplied PATH still wins — without this the remote
+ * re-resolves the actor from THIS box's SSH_CONNECTION and mis-credits it
+ * (RUSH-2028). Flows to both POSIX (export) and Windows ($env:) dialects.
+ * AGENTS_FLEET_REMOTE marks this as a fleet-dispatched run so the far side can
+ * gate consent-sensitive actions — the browser consent gate
+ * (lib/browser/remote-control.ts) reads it to allow/deny a cross-machine drive.
+ */
+export function streamAgentsOnHost(
+  host: Host,
+  forwardedArgs: string[],
+  opts: {
+    remoteCwd?: string;
+    interactive?: boolean;
+    extraEnv?: Record<string, string>;
+    remoteOs?: string;
+    target?: string;
+  } = {},
+): number {
+  const target = opts.target ?? sshTargetFor(host);
+  const remoteOs = opts.remoteOs ?? resolveRemoteOsSync(host.name);
+  const env = withActorEnv({ ...opts.extraEnv, AGENTS_FLEET_REMOTE: '1' });
+  const remoteCmd = buildRemoteAgentsInvocation(forwardedArgs, opts.remoteCwd, remoteOs, env);
+  const code = sshStream(target, remoteCmd, { tty: !!opts.interactive, multiplex: true });
   if (code === 255) {
     console.error(
       chalk.red(`${host.name}: unreachable over SSH (asleep, offline, or host key changed?).`) +
         chalk.gray(' Check: agents hosts check ' + host.name),
     );
   }
-  process.exitCode = code;
-  return true;
+  return code;
+}
+
+/**
+ * Resolve a device/host name and run `agents <forwardedArgs>` there.
+ *
+ * Used by the resume router (commands/resume.ts, sessions.ts) to send a session
+ * back to the machine that owns its transcript, so it reaches the SAME SSH path
+ * as `--host` rather than a second, divergent transport (RUSH-2022).
+ */
+export async function runAgentsOnDevice(
+  deviceName: string,
+  forwardedArgs: string[],
+  opts: { interactive?: boolean; remoteCwd?: string; env?: Record<string, string> } = {},
+): Promise<number> {
+  const host = await resolveTargetHost(deviceName, false);
+  return streamAgentsOnHost(host, forwardedArgs, {
+    interactive: opts.interactive,
+    remoteCwd: opts.remoteCwd,
+    extraEnv: opts.env,
+  });
 }

--- a/apps/cli/src/lib/hosts/session-index.test.ts
+++ b/apps/cli/src/lib/hosts/session-index.test.ts
@@ -15,9 +15,14 @@ import type { HostTask } from './tasks.js';
 // hermetic pattern as session/__tests__/db.test.ts.
 const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-hostsession-'));
 process.env.HOME = TEST_HOME;
+// Pin this box's identity so "is the dispatch host a peer?" is decidable no
+// matter which machine runs the suite (a runner literally named `yosemite-s0`
+// would otherwise read the fixture host as itself).
+process.env.AGENTS_SYNC_MACHINE_ID = 'dispatcher-box';
 
 const { hostSessionMeta, registerHostSession, registerInteractiveHostSession, captureRemoteSessionId } =
   await import('./session-index.js');
+const { sessionOwnerDevice } = await import('../session/resume-owner.js');
 const { findSessionsById, querySessions, closeDB } = await import('../session/db.js');
 const { saveTask, loadTask, localLogPath, hostsCacheDir } = await import('./tasks.js');
 const { sessionIdMarkerLine } = await import('./session-marker.js');
@@ -27,6 +32,7 @@ const { sessionIdMarkerLine } = await import('./session-marker.js');
 // tests. Matches the single-teardown shape of db.test.ts:100-102.
 afterAll(() => {
   closeDB();
+  delete process.env.AGENTS_SYNC_MACHINE_ID;
   fs.rmSync(TEST_HOME, { recursive: true, force: true });
 });
 
@@ -59,6 +65,13 @@ describe('hostSessionMeta', () => {
     expect(meta!.topic).toBe('first line');
   });
 
+  it('stamps the DISPATCH HOST as the origin machine, not this box (RUSH-2022)', () => {
+    // The transcript and the agent process live on `box`. An unset machine read
+    // as "local", so `agents resume <id>` restarted the run here instead.
+    const meta = hostSessionMeta(task({ host: 'BOX.tail.ts.net' }), { cwd: '/x', prompt: 'p' });
+    expect(meta!.machine).toBe('box'); // normalized: first label, lowercased
+  });
+
   it('seeds the label with the run --name when present (falls back to the host tag)', () => {
     const meta = hostSessionMeta(task({ name: 'remote-audit' }), { cwd: '/x', prompt: 'p' });
     expect(meta!.label).toBe('remote-audit');
@@ -88,6 +101,10 @@ describe('registerInteractiveHostSession', () => {
     expect(byId[0].agent).toBe('claude');
     expect(byId[0].label).toBe('remote-claude');
     expect(byId[0].filePath).toBe('');
+    // Persisted through the DB round-trip, so the resume router can read it back
+    // from the index and refuse a local resume (RUSH-2022).
+    expect(byId[0].machine).toBe('yosemite-s0');
+    expect(sessionOwnerDevice(byId[0])).toBe('yosemite-s0');
   });
 
   it('is a no-op for agents that are not session-tracked', () => {

--- a/apps/cli/src/lib/hosts/session-index.ts
+++ b/apps/cli/src/lib/hosts/session-index.ts
@@ -11,6 +11,13 @@
  * issued from, so the run appears in that project's session listing like any
  * local run. The `[host/<name>]` label mirrors the cloud path's
  * `[cloud/<status>]` convention.
+ *
+ * `machine` is the DISPATCH HOST, not this box: the transcript and the agent
+ * process both live over there, which is exactly what `machine` means
+ * (session/types.ts). Getting this wrong is not cosmetic — `sessions --host`
+ * filters on it and the resume router (session/resume-owner.ts) reads it to
+ * decide whether a resume may run here, so an unset value read as "local" and
+ * restarted a remote run on the dispatching box (RUSH-2022).
  */
 
 import * as fs from 'fs';
@@ -20,6 +27,7 @@ import { isSessionTrackedAgent } from '../session/types.js';
 import { localLogPath, updateTask, type HostTask } from './tasks.js';
 import { parseSessionIdMarker } from './session-marker.js';
 import { deriveShortId } from '../session/short-id.js';
+import { normalizeHost } from '../machine-id.js';
 
 export interface HostSessionContext {
   /** Local directory the `agents run --host` was invoked from. */
@@ -47,6 +55,11 @@ export function hostSessionMeta(task: HostTask, ctx: HostSessionContext): Sessio
     // Remote transcript — no local file. Empty file_path is the sentinel the DB
     // stale-filter treats as "always live" (see module doc).
     filePath: '',
+    // The transcript AND the agent process live on the dispatch host, so that is
+    // the session's origin machine. Leaving it unset made the index claim the
+    // dispatching box, which is what let `agents resume <id>` restart a remote
+    // run locally against state this machine never had (RUSH-2022).
+    machine: normalizeHost(task.host),
     topic: ctx.prompt.split('\n')[0]?.slice(0, 120) || undefined,
     // The run's `--name` seeds the label (resolves `agents sessions <name>` and
     // `agents hosts logs <name>`); an unnamed host run falls back to the
@@ -125,6 +138,10 @@ export function registerInteractiveHostSession(ctx: InteractiveHostSessionContex
         timestamp: ctx.createdAt ?? new Date().toISOString(),
         cwd: ctx.cwd,
         filePath: '',
+        // Same origin-machine stamp as the detached path above (RUSH-2022) — an
+        // interactive `agents run --device <box>` is the exact case the report
+        // walked into: the TUI is here, the session is there.
+        machine: normalizeHost(ctx.host),
         label: ctx.name || `[host/${ctx.host}]`,
       },
       '',

--- a/apps/cli/src/lib/session/remote-list.ts
+++ b/apps/cli/src/lib/session/remote-list.ts
@@ -628,16 +628,30 @@ export async function resolvePeerTarget(machine: string): Promise<{ target: stri
  * not via a local `--host` hop, which would discover locally and dead-end for a
  * session that exists only on the peer. Resolves 'no-target' when the machine
  * isn't a dialable registered device; the caller surfaces a clear message.
+ *
+ * `opts.env` adds variables to the remote command. It deliberately does NOT
+ * carry `AGENTS_FLEET_REMOTE` the way the `--host` passthrough does: that marker
+ * gates consent-sensitive actions on the far side
+ * (lib/browser/remote-control.ts), and a resumed agent is a long-lived session
+ * that would inherit it for its whole life — `agents browser start` inside it
+ * would then be refused as a cross-machine drive. A one-shot `--host` command
+ * can carry the marker; a session cannot.
  */
-export async function runOnPeer(args: string[], machine: string, opts: { tty?: boolean } = {}): Promise<'ok' | 'no-target'> {
+export async function runOnPeer(
+  args: string[],
+  machine: string,
+  opts: { tty?: boolean; env?: Record<string, string> } = {},
+): Promise<'ok' | 'no-target'> {
   const peer = await resolvePeerTarget(machine);
   if (!peer) return 'no-target';
   assertValidSshTarget(peer.target); // registry-sourced, but validate like the fan-out does
 
   const cols = terminalWidth();
+  const env: Record<string, string> = { ...(cols > 0 ? { COLUMNS: String(cols) } : {}), ...opts.env };
+  const assignments = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`);
   const remoteCmd = remoteShellFor(peer.os) === 'powershell'
-    ? buildWindowsAgentsCommand({ args, env: cols > 0 ? { COLUMNS: String(cols) } : undefined })
-    : `bash -lc ${shellQuote((cols > 0 ? [`COLUMNS=${cols}`] : []).concat(['agents', ...args].map(shellQuote)).join(' '))}`;
+    ? buildWindowsAgentsCommand({ args, env: assignments.length ? env : undefined })
+    : `bash -lc ${shellQuote(assignments.concat(['agents', ...args].map(shellQuote)).join(' '))}`;
 
   const sshArgs = [...SSH_OPTS, ...controlOpts()];
   if (opts.tty) sshArgs.push('-tt'); // force a PTY so the resumed agent is interactive

--- a/apps/cli/src/lib/session/resume-owner.test.ts
+++ b/apps/cli/src/lib/session/resume-owner.test.ts
@@ -1,0 +1,75 @@
+/**
+ * RUSH-2022 — a session that ran on another device must never resume here.
+ *
+ * Real path, no mocks: `sessionOwnerDevice` / `resumeDestinationMismatch` read
+ * the same `machineId()` and `isSelfHost()` this machine answers with, and the
+ * tests drive them through `AGENTS_SYNC_MACHINE_ID` (the documented override in
+ * lib/machine-id.ts) rather than stubbing either function.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sessionOwnerDevice, resumeDestinationMismatch } from './resume-owner.js';
+import { resetSelfHostCache } from '../devices/self-host.js';
+
+const SELF = 'test-owner-box';
+
+beforeEach(() => {
+  process.env.AGENTS_SYNC_MACHINE_ID = SELF;
+  resetSelfHostCache();
+});
+
+afterEach(() => {
+  delete process.env.AGENTS_SYNC_MACHINE_ID;
+  resetSelfHostCache();
+});
+
+describe('sessionOwnerDevice', () => {
+  it('names the peer for a session whose transcript originated elsewhere', () => {
+    // The exact shape of a synced mirror row: machine-tagged, readable here.
+    expect(sessionOwnerDevice({ machine: 'zion' })).toBe('zion');
+  });
+
+  it('is case- and domain-insensitive about this machine', () => {
+    expect(sessionOwnerDevice({ machine: SELF })).toBeUndefined();
+    expect(sessionOwnerDevice({ machine: SELF.toUpperCase() })).toBeUndefined();
+  });
+
+  it('leaves an untagged row alone rather than inventing a target', () => {
+    expect(sessionOwnerDevice({})).toBeUndefined();
+    expect(sessionOwnerDevice({ machine: '' })).toBeUndefined();
+    expect(sessionOwnerDevice({ machine: '   ' })).toBeUndefined();
+  });
+});
+
+describe('resumeDestinationMismatch', () => {
+  it('flags a peer-owned session in a LOCAL batch — the silent wrong-machine resume', () => {
+    expect(resumeDestinationMismatch({ machine: 'zion' }, undefined)).toBe('zion');
+  });
+
+  it('accepts a locally-owned session in a local batch', () => {
+    expect(resumeDestinationMismatch({ machine: SELF }, undefined)).toBeUndefined();
+  });
+
+  it('accepts a session whose owner IS the --host destination', () => {
+    expect(resumeDestinationMismatch({ machine: 'zion' }, 'zion')).toBeUndefined();
+    expect(resumeDestinationMismatch({ machine: 'zion' }, 'ZION')).toBeUndefined();
+    // The registry compares the first label only, so a tailnet dnsName matches.
+    expect(resumeDestinationMismatch({ machine: 'zion' }, 'zion.tailnet.ts.net')).toBeUndefined();
+  });
+
+  it('does NOT flag a locally-owned session sent to a --host elsewhere (the /fork handoff)', () => {
+    // `agents sessions fork` copies the transcript HERE, then the fork command
+    // opens it on the machine the user is sitting at. That destination is
+    // explicit and user-named — the opposite of the silent wrong-machine start
+    // this guard exists to stop.
+    expect(resumeDestinationMismatch({ machine: SELF }, 'zion')).toBeUndefined();
+  });
+
+  it('flags a peer-owned session sent to a DIFFERENT peer', () => {
+    expect(resumeDestinationMismatch({ machine: 'zion' }, 'mac-mini')).toBe('zion');
+  });
+
+  it('leaves an untagged row alone at any destination', () => {
+    expect(resumeDestinationMismatch({}, 'zion')).toBeUndefined();
+    expect(resumeDestinationMismatch({}, undefined)).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/session/resume-owner.ts
+++ b/apps/cli/src/lib/session/resume-owner.ts
@@ -1,0 +1,99 @@
+/**
+ * Where a session may be resumed — the one place that answers "does this
+ * transcript belong to another machine?" and, when it does, runs the resume
+ * THERE instead of here.
+ *
+ * A session's agent state lives on the box that produced it: the harness keeps
+ * its own conversation store under that machine's home, and `machine` on a
+ * SessionMeta records where the transcript originated (see session/types.ts).
+ * A row can reach this box two ways and BOTH are remote-owned:
+ *
+ *  - a **synced mirror** — locally readable at `backups/<agent>/<machine>/…`,
+ *    which is exactly why the old code could not tell: the transcript file is
+ *    right there, so nothing failed until the harness was asked to resume a
+ *    conversation it has never seen;
+ *  - a **live fan-out row** (`_remote`), whose `filePath` is on the peer's disk.
+ *
+ * Resuming either one locally starts the harness against state it does not
+ * have. Before RUSH-2022 that happened silently — `sessions-resume.ts` even fell
+ * back to `process.cwd()` when the recorded cwd did not exist locally, so a
+ * remote session resumed in whatever directory the user happened to be in.
+ */
+
+import type { SessionMeta } from './types.js';
+import { machineId, normalizeHost } from '../machine-id.js';
+import { isSelfHost } from '../devices/self-host.js';
+
+/**
+ * Set on the SSH hop that sends a resume to its owning device: the far side must
+ * run it, never route again.
+ *
+ * An env var rather than a flag, deliberately. The fleet is mixed-version — a
+ * peer on the released CLI would die on an unknown `--here` with
+ * `error: unknown option '--here'`, breaking the very hop this feature adds. An
+ * unrecognized exported variable is inert on every version, so routing works
+ * against old and new peers alike. The far side deletes it after reading
+ * ({@link consumeResumePinned}) so it cannot leak into the agent's own children.
+ */
+export const RESUME_PINNED_ENV = 'AGENTS_RESUME_PINNED';
+
+/**
+ * Whether this process was handed a resume by its owner-routing hop — read once,
+ * then cleared so a nested `agents resume` inside the running agent still routes
+ * normally.
+ */
+export function consumeResumePinned(): boolean {
+  const pinned = process.env[RESUME_PINNED_ENV] === '1';
+  delete process.env[RESUME_PINNED_ENV];
+  return pinned;
+}
+
+/**
+ * The peer that owns `session`'s state, or `undefined` when this machine does.
+ *
+ * Undefined is also the answer for an untagged row (`machine` unset — a session
+ * obtained outside `discoverSessions`): there is nothing to route to, so the
+ * caller keeps the local behaviour rather than inventing a target.
+ */
+export function sessionOwnerDevice(session: Pick<SessionMeta, 'machine'>): string | undefined {
+  const owner = session.machine?.trim();
+  if (!owner) return undefined;
+  // `isSelfHost` matches every identity this box answers to (short id, tailnet
+  // dnsName, loopback), not just `machineId()` — a mirror tagged with the
+  // tailnet name of THIS machine is local, not a peer (cf. RUSH-2114).
+  if (owner.toLowerCase() === machineId().toLowerCase() || isSelfHost(owner)) return undefined;
+  return owner;
+}
+
+/**
+ * The owning device when `session` cannot be resumed at `destination`, else
+ * `undefined`.
+ *
+ * `destination` is where a batch resume is opening its terminal surfaces:
+ * `undefined` for this machine, or the `--host <alias>` a `sessions resume` was
+ * pointed at.
+ *
+ * Only a **peer-owned** session is ever flagged, and only when the destination
+ * is not that peer. A session this machine owns is never flagged, including when
+ * the caller aimed a `--host` somewhere else: that is the `/fork` handoff — fork
+ * here, open the copy on the machine the user is sitting at — an explicit,
+ * user-named destination rather than the silent wrong-machine start this guard
+ * exists to stop (see `commands/fork.md` in the .agents-system repo).
+ *
+ * An untagged row (`machine` unset) is never flagged either — there is nothing
+ * to compare, so the caller keeps its existing behaviour.
+ */
+export function resumeDestinationMismatch(
+  session: Pick<SessionMeta, 'machine'>,
+  destination: string | undefined,
+): string | undefined {
+  const owner = sessionOwnerDevice(session);
+  if (!owner) return undefined;
+  if (!destination) return owner;
+  return sameDevice(owner, destination) ? undefined : owner;
+}
+
+/** Compare two device names the way the registry does: first label, case-insensitive. */
+function sameDevice(a: string, b: string): boolean {
+  return normalizeHost(a) === normalizeHost(b);
+}

--- a/apps/cli/src/lib/session/resume-owner.ts
+++ b/apps/cli/src/lib/session/resume-owner.ts
@@ -21,7 +21,7 @@
  */
 
 import type { SessionMeta } from './types.js';
-import { machineId, normalizeHost } from '../machine-id.js';
+import { normalizeHost } from '../machine-id.js';
 import { isSelfHost } from '../devices/self-host.js';
 
 /**
@@ -58,11 +58,12 @@ export function consumeResumePinned(): boolean {
 export function sessionOwnerDevice(session: Pick<SessionMeta, 'machine'>): string | undefined {
   const owner = session.machine?.trim();
   if (!owner) return undefined;
-  // `isSelfHost` matches every identity this box answers to (short id, tailnet
-  // dnsName, loopback), not just `machineId()` — a mirror tagged with the
-  // tailnet name of THIS machine is local, not a peer (cf. RUSH-2114).
-  if (owner.toLowerCase() === machineId().toLowerCase() || isSelfHost(owner)) return undefined;
-  return owner;
+  // `isSelfHost` matches every identity this box answers to — `machineId()`
+  // itself, the tailnet dnsName and its short form, loopback (devices/
+  // self-host.ts `selfAliases`) — so a mirror tagged with this machine's tailnet
+  // name is local, not a peer (cf. RUSH-2114). No separate `machineId()`
+  // comparison: it is one of those aliases.
+  return isSelfHost(owner) ? undefined : owner;
 }
 
 /**

--- a/apps/cli/src/lib/startup/command-registry.test.ts
+++ b/apps/cli/src/lib/startup/command-registry.test.ts
@@ -12,6 +12,7 @@ import {
   LAZY_COMMAND_NAMES,
   KNOWN_TOP_LEVEL_COMMANDS,
   isKnownTopLevelCommand,
+  suggestTopLevelCommand,
 } from './command-registry.js';
 
 /** Register every module in the loader table onto one fresh program. */
@@ -49,6 +50,18 @@ describe('KNOWN_TOP_LEVEL_COMMANDS', () => {
     for (const name of ['perms', 'exec', 'jobs', 'cron', 'check', 'resources', 'hq', 'upgrade', '_internal']) {
       expect(isKnownTopLevelCommand(name)).toBe(true);
     }
+  });
+
+  it('suggests the lazily-registered group a typo meant — the RUSH-2022 miss', () => {
+    // The old spellcheck ranked against the commands registered SO FAR, and
+    // `sessions` is lazy, so this typo got no suggestion at all.
+    expect(suggestTopLevelCommand('session')).toEqual({ name: 'sessions', distance: 1 });
+    expect(suggestTopLevelCommand('sesions')).toEqual({ name: 'sessions', distance: 1 });
+    expect(suggestTopLevelCommand('docto')).toEqual({ name: 'doctor', distance: 1 });
+  });
+
+  it('never suggests an internal command', () => {
+    expect(suggestTopLevelCommand('_internal')?.name).not.toBe('_internal');
   });
 
   it('rejects a name the CLI does not register', () => {

--- a/apps/cli/src/lib/startup/command-registry.test.ts
+++ b/apps/cli/src/lib/startup/command-registry.test.ts
@@ -1,0 +1,59 @@
+/**
+ * RUSH-2022 — `KNOWN_TOP_LEVEL_COMMANDS` is the "does this command exist?"
+ * predicate the `--host`/`--device` router consults before it can claim a
+ * command has no remote semantics. A name that drifts out of it turns a real
+ * command into a phantom `unknown command`, so this pins the set against the
+ * command tree the CLI actually registers — the real modules, no mocks.
+ */
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import {
+  COMMAND_LOADERS,
+  LAZY_COMMAND_NAMES,
+  KNOWN_TOP_LEVEL_COMMANDS,
+  isKnownTopLevelCommand,
+} from './command-registry.js';
+
+/** Register every module in the loader table onto one fresh program. */
+async function registerEverything(): Promise<Command> {
+  const program = new Command();
+  const done = new Set<unknown>();
+  for (const loaders of Object.values(COMMAND_LOADERS)) {
+    for (const loader of loaders) {
+      if (done.has(loader)) continue;
+      done.add(loader);
+      (await loader())(program);
+    }
+  }
+  return program;
+}
+
+describe('KNOWN_TOP_LEVEL_COMMANDS', () => {
+  it('covers every top-level name and alias the real command modules register', async () => {
+    const program = await registerEverything();
+    const registered = program.commands.flatMap((c) => [c.name(), ...c.aliases()]);
+    expect(registered.length).toBeGreaterThan(50); // the tree really did load
+    const missing = registered.filter((name) => !KNOWN_TOP_LEVEL_COMMANDS.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it('includes the lazily-registered groups (sessions/teams/cloud/…)', () => {
+    for (const name of LAZY_COMMAND_NAMES) {
+      expect(isKnownTopLevelCommand(name)).toBe(true);
+    }
+  });
+
+  it('includes the aliases and tombstones src/index.ts registers inline', () => {
+    // Not in COMMAND_LOADERS — they are closures over entry-point state — but
+    // they are real commands, so the router must not treat them as unknown.
+    for (const name of ['perms', 'exec', 'jobs', 'cron', 'check', 'resources', 'hq', 'upgrade', '_internal']) {
+      expect(isKnownTopLevelCommand(name)).toBe(true);
+    }
+  });
+
+  it('rejects a name the CLI does not register', () => {
+    expect(isKnownTopLevelCommand('session')).toBe(false); // the RUSH-2022 typo
+    expect(isKnownTopLevelCommand('zzzznotacommand')).toBe(false);
+    expect(isKnownTopLevelCommand('')).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -304,3 +304,39 @@ export const KNOWN_TOP_LEVEL_COMMANDS: ReadonlySet<string> = new Set<string>([
 export function isKnownTopLevelCommand(name: string): boolean {
   return KNOWN_TOP_LEVEL_COMMANDS.has(name);
 }
+
+/** Levenshtein edit distance. */
+function levenshtein(a: string, b: string): number {
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () => Array(b.length + 1).fill(0));
+  for (let i = 0; i <= a.length; i++) dp[i][0] = i;
+  for (let j = 0; j <= b.length; j++) dp[0][j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1][j - 1]
+        : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return dp[a.length][b.length];
+}
+
+/**
+ * Nearest real command to a mistyped name, with its edit distance — the single
+ * spellcheck used both by the pre-parse typo correction in src/index.ts and by
+ * the `command:*` unknown-command message.
+ *
+ * Candidates come from {@link KNOWN_TOP_LEVEL_COMMANDS}, not from the commands
+ * registered so far: registration is lazy, so the previously-used candidate set
+ * could not see `sessions`/`teams`/`cloud` at all and the very typo RUSH-2022
+ * reported (`session`) got no suggestion. Ties break on the name's order in the
+ * set, which is the loader table's declaration order.
+ */
+export function suggestTopLevelCommand(name: string): { name: string; distance: number } | null {
+  let best: { name: string; distance: number } | null = null;
+  for (const candidate of KNOWN_TOP_LEVEL_COMMANDS) {
+    if (candidate.startsWith('_')) continue; // internal, never suggest
+    const distance = levenshtein(name, candidate);
+    if (!best || distance < best.distance) best = { name: candidate, distance };
+  }
+  return best;
+}

--- a/apps/cli/src/lib/startup/command-registry.ts
+++ b/apps/cli/src/lib/startup/command-registry.ts
@@ -175,6 +175,11 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   registry: [loadPackages],
   search: [loadPackages],
   install: [loadPackages],
+  // packages.ts also registers `publish` at top level (commands/packages.ts:435).
+  // It was missing here, so `agents publish` only worked via the unknown-command
+  // fallback that registers the whole tree — and the --host router could not see
+  // it as a real command at all (RUSH-2022).
+  publish: [loadPackages],
   routines: [loadRoutines],
   monitors: [loadMonitors],
   projects: [loadProjects],
@@ -259,3 +264,43 @@ export const COMMAND_LOADERS: Record<string, ModuleLoader[]> = {
   funnel: [loadFunnel],
   humans: [loadHumans],
 };
+
+/**
+ * Top-level names that {@link COMMAND_LOADERS} does not carry because they are
+ * registered inline in src/index.ts — closures over entry-point state (the
+ * deprecated aliases and tombstones) plus the internal/upgrade commands. They are
+ * real commands, so anything that asks "does this command exist?" must count them.
+ */
+const INLINE_COMMAND_NAMES = [
+  'perms', // deprecated alias -> permissions
+  'exec', // deprecated alias -> run
+  'jobs', // deprecated alias -> routines
+  'cron', // deprecated alias -> routines
+  'check', // tombstone -> doctor --check
+  'resources', // tombstone -> view --merged
+  'hq', // tombstone
+  '_internal',
+  'upgrade',
+] as const;
+
+/**
+ * Every top-level command name the CLI answers to — the loader table plus the
+ * inline aliases/tombstones above. This is the "does this command exist?"
+ * predicate for code that runs BEFORE commander parses, most importantly the
+ * `--host`/`--device` router (lib/hosts/passthrough.ts): without it a typo'd
+ * command carrying `--host` reported a flag-support error instead of
+ * `unknown command` (RUSH-2022).
+ *
+ * Commander sub-aliases (`sessions ls`, `teams rm`, …) are deliberately absent —
+ * this set is top-level only. `command-registry.test.ts` pins it against the real
+ * registered command tree so a new command can never drift out of it.
+ */
+export const KNOWN_TOP_LEVEL_COMMANDS: ReadonlySet<string> = new Set<string>([
+  ...Object.keys(COMMAND_LOADERS),
+  ...INLINE_COMMAND_NAMES,
+]);
+
+/** Whether `name` is a top-level command this CLI registers. See {@link KNOWN_TOP_LEVEL_COMMANDS}. */
+export function isKnownTopLevelCommand(name: string): boolean {
+  return KNOWN_TOP_LEVEL_COMMANDS.has(name);
+}


### PR DESCRIPTION
**Two bug fixes to session recovery** — `--host` router honesty, and a resume that ran on the wrong machine. No new user-facing command; one new flag (`agents resume --here`).

Linear: [RUSH-2022](https://linear.app/getrush/issue/RUSH-2022/sessions-remote-device-sessions-are-unrecoverable-host-router-masks)

## Bug 1 — the `--host` router answered for commands that do not exist

It runs before commander parses, so **any** name carrying `--host` got a flag-support error — including one the CLI never registers. `session` is one letter off `sessions`, which *does* accept `--host`, so the message stated the opposite of the truth for the command the user meant.

Reproduced on this branch's parent (`e3509f74`), then re-run after:

| | before | after |
|---|---|---|
| `agents session resume --host yosemite-s0` | `` `agents session` does not support --host/--device `` | auto-corrects to `sessions resume` (which *does* take `--host`) |
| `agents zzzznotacommand resume --host yosemite-s0` | same flag-support error | `error: unknown command 'zzzznotacommand'` |
| `agents login --host yosemite-s0` (real, non-routable) | flag-support error | **unchanged** — flag-support error |

The spellcheck also could not see the lazily-registered groups, so the typo got no suggestion at all; an unknown command now registers the lazy tree too, and `agents sesions` auto-corrects to `sessions`.

**The new completeness test found a live gap:** `publish` (`commands/packages.ts:435`) is registered at top level but was missing from `COMMAND_LOADERS`, so it only ever resolved through the unknown-command fallback that loads the whole tree. Added.

## Bug 2 — a session that ran on another device resumed HERE

The harness keeps its conversation state on the box that produced the session. Nothing checked which box that was, and a synced mirror makes the transcript look local — so it failed silently, in the worst way: it started the agent against unrelated local state.

**Real run, `yosemite-s0` → session `019fcfad-…` owned by `yosemite-m2`:**

before (parent commit) — ran locally, replaying into a local conversation:
```
Running: /home/muqsit/.agents/.cache/shims/grok@0.2.82 -p /continue 019fcf4a-…
Auto-compacting conversation (82% full)...
```

after — hopped to the owner and did a **native** resume there, on the peer's own version:
```
[agents] session 019fcfad belongs to yosemite-m2 → resuming there
Resuming grok 019fcfad (native) @0.2.118 in /home/muqsit/src/github.com/muqsitnawaz/agents-cli
Running: /home/muqsit/.agents/.cache/shims/grok@0.2.118 --resume 019fcfad-… -p reply with exactly PINGOK
```

`sessionOwnerDevice` (`lib/session/resume-owner.ts`) is the single answer to "may this resume run here?":

| path | behaviour when the owner is a peer |
|---|---|
| `agents resume <id>` | re-runs itself on the owner over the `--host` SSH transport (`--here` overrides) |
| bare `agents sessions` picker (`resumeSessionInPlace`) | same hop |
| `agents sessions resume` (opens tabs on ONE machine) | skipped **by name**, with the command that reaches it |

**Root cause of the population that made this common:** a run dispatched with `agents run --device <box>` was indexed with *no* origin machine, so the index claimed the dispatching box. `hosts/session-index.ts` now stamps the dispatch host on both the detached and interactive paths — the ticket's Bug 3, fixed here because Bug 2 cannot be correct without it.

Two details the real fleet forced:

- **The hop's "don't route again" pin is an exported env var, not a flag.** A first attempt sent `--here` and the peer — on the released CLI — died with `error: unknown option '--here'`. An unrecognized export is inert on every version.
- **`resumeCwd` stops a LOCAL `fs.existsSync` from deciding a remote path.** With `--host` the tab is a `tmux new-window -c <cwd>` over there, so substituting this box's `process.cwd()` handed the peer a directory it does not have — the same defect one layer down.

**Deliberately not flagged:** a session *this* machine owns, `--host` or not. That is the `/fork` handoff (fork here, open the copy where the user sits) — an explicit user-named destination, not a silent wrong-machine start. Companion-repo audit: `commands/fork.md` in `.agents-system` is the one consumer that teaches `sessions resume --host`; it keeps working unchanged, so no companion edit is needed.

## Tests

Real path, no mocks — identity comes from `AGENTS_SYNC_MACHINE_ID` (the documented override), and the session-index test round-trips through the real SQLite index.

- `lib/session/resume-owner.test.ts` — owner detection and the destination rule, including the `/fork` exemption.
- `lib/hosts/session-index.test.ts` — the dispatch host is stamped and survives the DB round-trip, and `sessionOwnerDevice` reads it back.
- `lib/hosts/passthrough.test.ts` — unknown command falls through; a real non-routable command still errors.
- `lib/startup/command-registry.test.ts` — pins the name set against the tree the real modules register (this is what caught `publish`).
- `commands/resume.test.ts` — the remote argv carries no unreleased flag; the env pin is read-once.
- `commands/sessions-resume.test.ts` — `resumeCwd` local vs remote.

Full suite on `yosemite-s0`: the only failures are 7 files that fail **identically on clean `origin/main`** (14 failed / 216 passed on both) — they read this box's real `~/.agents` config, which CI does not have.
