### PR TITLE
fix(secrets): bound keychain-helper spawns with timeout + SIGKILL; add daemon reaper (RUSH-2231, RUSH-2232)

### DIFF
--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -941,6 +941,29 @@ export async function runDaemon(): Promise<void> {
   };
   const brokerSelfHealInterval = setInterval(() => { void runBrokerSelfHeal(); }, 60_000);
 
+  // RUSH-2232: reap orphaned keychain helpers and `agents` processes stuck on a
+  // keychain call. Runs as a 5-min interval in the daemon (the single executor)
+  // so no UI surface can race it. The reaper shells `ps` once, plans kills in a
+  // pure function, and executes via killTree.
+  let reapingKeychain = false;
+  const runKeychainReap = async () => {
+    if (reapingKeychain) return;
+    reapingKeychain = true;
+    try {
+      const { reapOrphanedKeychainProcesses } = await import('./secrets/reaper.js');
+      const result = reapOrphanedKeychainProcesses();
+      if (result.reaped > 0) {
+        log('WARN', `Reaped ${result.reaped} keychain orphan/stuck process(es)`);
+        for (const d of result.details) log('WARN', `  ${d}`);
+      }
+    } catch (err) {
+      log('ERROR', `Keychain reaper failed: ${(err as Error).message}`);
+    } finally {
+      reapingKeychain = false;
+    }
+  };
+  const keychainReapInterval = setInterval(() => { void runKeychainReap(); }, 5 * 60_000);
+
   const handleReload = () => {
     log('INFO', 'Reloading jobs (SIGHUP)');
     // Refresh user-layer copies of opted-in project routines BEFORE the
@@ -999,6 +1022,7 @@ export async function runDaemon(): Promise<void> {
     clearInterval(usageRefreshInterval);
     clearTimeout(usageRefreshKickoff);
     clearInterval(brokerSelfHealInterval);
+    clearInterval(keychainReapInterval);
     hostedBroker?.close();
     removeDaemonPid();
     removeHeartbeat();

--- a/apps/cli/src/lib/secrets/index.test.ts
+++ b/apps/cli/src/lib/secrets/index.test.ts
@@ -21,6 +21,7 @@ import {
   hashedServiceName,
   healHmacKeyNoAclOnce,
   HMAC_KEY_ITEM,
+  KeychainHelperTimeoutError,
   keychainServiceAlias,
   keychainOperationPrompt,
   listKeychainItems,
@@ -28,8 +29,10 @@ import {
   readHmacKeyRecord,
   rekeyServiceNames,
   setKeychainBackendForTest,
+  setKeychainDaemonBootForTest,
   setKeychainServiceHashingForTest,
   setKeychainToken,
+  spawnKeychainHelperForTest,
   withRawKeychainServiceNames,
   type KeychainBackend,
 } from './index.js';
@@ -150,6 +153,23 @@ describe('parseOrphanMigrationOutput', () => {
   it('returns [] for empty output', () => {
     expect(parseOrphanMigrationOutput('')).toEqual([]);
     expect(parseOrphanMigrationOutput('\n\n')).toEqual([]);
+  });
+});
+
+describe('spawnKeychainHelper timeout (RUSH-2231)', () => {
+  beforeEach(() => {
+    setKeychainDaemonBootForTest(false);
+  });
+  afterEach(() => {
+    setKeychainDaemonBootForTest(true);
+  });
+
+  it('kills a sleeping helper within the timeout and throws KeychainHelperTimeoutError', () => {
+    const start = Date.now();
+    expect(() =>
+      spawnKeychainHelperForTest('/bin/sh', ['-c', 'sleep 30'], { stdio: ['ignore', 'pipe', 'pipe'] }, 300),
+    ).toThrow(KeychainHelperTimeoutError);
+    expect(Date.now() - start).toBeLessThan(2_000);
   });
 });
 

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -23,7 +23,7 @@
  * rather than the system's cloud-keychain path.
  */
 
-import { execFileSync, spawnSync, type SpawnSyncOptions } from 'child_process';
+import { execFileSync, spawnSync, type SpawnSyncOptions, type SpawnSyncReturns } from 'child_process';
 import { createHmac, randomBytes } from 'node:crypto';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -46,6 +46,74 @@ import { deriveShortId } from '../session/short-id.js';
 const SERVICE_PREFIX = 'agents-cli';
 export const SECRETS_ITEM_PREFIX = `${SERVICE_PREFIX}.secrets.`;
 const BUNDLES_ITEM_PREFIX = `${SERVICE_PREFIX}.bundles.`;
+
+/** Timeout for keychain-helper verbs that never raise a user prompt. */
+const KEYCHAIN_SILENT_TIMEOUT_MS = 8_000;
+/** Timeout for verbs that may raise Touch ID / password auth UI. */
+const KEYCHAIN_INTERACTIVE_TIMEOUT_MS = 60_000;
+
+/**
+ * Thrown when a keychain helper / security spawnSync is killed because it
+ * exceeded its timeout. A wedged coreauthd / LocalAuthentication dialog can hang
+ * the parent forever; this makes the failure explicit and arms the read back-off.
+ */
+export class KeychainHelperTimeoutError extends Error {
+  constructor(
+    public readonly bin: string,
+    public readonly args: string[],
+  ) {
+    super(
+      `keychain helper timed out (${bin} ${args.join(' ')}) — keychain locked / ` +
+      `LocalAuthentication unresponsive — retry; if it persists, lock/unlock the screen or reboot`,
+    );
+    this.name = 'KeychainHelperTimeoutError';
+  }
+}
+
+let keychainDaemonBootEnabled = true;
+let keychainDaemonBootAttempted = false;
+
+/** Test seam: suppress the side-effect daemon boot in unit tests. */
+export function setKeychainDaemonBootForTest(enabled: boolean): void {
+  keychainDaemonBootEnabled = enabled;
+}
+
+/**
+ * Single wrapper for every keychain-helper (and /usr/bin/security) spawnSync.
+ * Applies a hard timeout + SIGKILL so a wedged coreauthd can never hang the
+ * parent process. Throws {@link KeychainHelperTimeoutError} when the child is
+ * killed by the timeout. Also boots the daemon once per process so the reaper
+ * can clean up any stuck helpers this or prior invocations left behind.
+ */
+function spawnKeychainHelper(
+  bin: string,
+  args: string[],
+  opts: SpawnSyncOptions,
+  timeoutMs: number,
+): SpawnSyncReturns<Buffer> {
+  if (keychainDaemonBootEnabled && !keychainDaemonBootAttempted) {
+    keychainDaemonBootAttempted = true;
+    // Fire-and-forget: daemon start must not block the foreground secrets op.
+    import('../daemon.js')
+      .then(({ ensureDaemonStarted }) => ensureDaemonStarted())
+      .catch(() => { /* best effort */ });
+  }
+  const result = spawnSync(bin, args, { ...opts, timeout: timeoutMs, killSignal: 'SIGKILL' }) as SpawnSyncReturns<Buffer>;
+  if (result.signal) {
+    throw new KeychainHelperTimeoutError(bin, args);
+  }
+  return result;
+}
+
+/** Test seam: exercise the timeout wrapper with an arbitrary binary. */
+export function spawnKeychainHelperForTest(
+  bin: string,
+  args: string[],
+  opts: SpawnSyncOptions,
+  timeoutMs: number,
+): SpawnSyncReturns<Buffer> {
+  return spawnKeychainHelper(bin, args, opts, timeoutMs);
+}
 
 /** Supported secret resolution backends. */
 export type SecretProvider = 'keychain' | 'env' | 'file' | 'exec';
@@ -833,14 +901,14 @@ export function hasKeychainToken(item: string): boolean {
   if (isLinux()) return linuxBackend.has(item);
   if (isWindows()) return windowsBackend.has(item);
   if (!isOurItem(item)) {
-    return spawnSync('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item], {
+    return spawnKeychainHelper('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item], {
       stdio: ['ignore', 'ignore', 'ignore'],
-    }).status === 0;
+    }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
   }
   const bin = getKeychainHelperPath();
-  return spawnSync(bin, ['has', item, os.userInfo().username], {
+  return spawnKeychainHelper(bin, ['has', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }).status === 0;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
 }
 
 /**
@@ -947,9 +1015,9 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
   if (isLinux()) return linuxBackend.get(item);
   if (isWindows()) return windowsBackend.get(item);
   if (!isOurItem(item)) {
-    const sec = spawnSync('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item, '-w'], {
+    const sec = spawnKeychainHelper('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item, '-w'], {
       stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    }, KEYCHAIN_SILENT_TIMEOUT_MS);
     if (sec.status === 0) {
       const token = sec.stdout?.toString().trim();
       if (token) {
@@ -960,15 +1028,23 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
     throw new Error(`Keychain item '${requested}' not found.`);
   }
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['get', item, os.userInfo().username], {
-    env: {
-      ...process.env,
-      AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
-      AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
-      AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
-    },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  let result: SpawnSyncReturns<Buffer>;
+  try {
+    result = spawnKeychainHelper(bin, ['get', item, os.userInfo().username], {
+      env: {
+        ...process.env,
+        AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
+        AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
+        AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
+  } catch (err) {
+    if (err instanceof KeychainHelperTimeoutError && !context.silentNoAcl) {
+      noteKeychainReadFailure(requested);
+    }
+    throw err;
+  }
   // Exit 1 is a plain miss — no prompt was raised, so it opens no back-off.
   if (result.status === 1) throw new Error(`Keychain item '${requested}' not found.`);
   if (result.status !== 0) {
@@ -1038,19 +1114,27 @@ export function getKeychainTokens(items: string[], context: KeychainReadContext 
     return result;
   }
   const bin = getKeychainHelperPath();
-  const child = spawnSync(bin, ['get-batch', os.userInfo().username, ...storageItems], {
-    env: {
-      ...process.env,
-      AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
-      AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
-      AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
-      // The signed helper's own vocabulary is unchanged (it predates the rename
-      // and ships as a separately-versioned binary), so map to its legacy token.
-      AGENTS_KEYCHAIN_DEFAULT_POLICY: (context.defaultPolicy ?? 'hold') === 'hold' ? 'daily' : (context.defaultPolicy as string),
-      AGENTS_KEYCHAIN_FORCE_DURATION: context.forceDuration ? '1' : '0',
-    },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  let child: SpawnSyncReturns<Buffer>;
+  try {
+    child = spawnKeychainHelper(bin, ['get-batch', os.userInfo().username, ...storageItems], {
+      env: {
+        ...process.env,
+        AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
+        AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
+        AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
+        // The signed helper's own vocabulary is unchanged (it predates the rename
+        // and ships as a separately-versioned binary), so map to its legacy token.
+        AGENTS_KEYCHAIN_DEFAULT_POLICY: (context.defaultPolicy ?? 'hold') === 'hold' ? 'daily' : (context.defaultPolicy as string),
+        AGENTS_KEYCHAIN_FORCE_DURATION: context.forceDuration ? '1' : '0',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
+  } catch (err) {
+    if (err instanceof KeychainHelperTimeoutError && !context.silentNoAcl) {
+      noteKeychainReadFailure(backoffKey);
+    }
+    throw err;
+  }
   if (child.status !== 0 && !context.silentNoAcl) noteKeychainReadFailure(backoffKey);
   if (child.status === 4) {
     throw new Error(`Touch ID cancelled while reading ${items.length} keychain item(s).`);
@@ -1181,10 +1265,11 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
     // controlling terminal, so readpassphrase always falls back to our piped
     // stdin. Without it, an interactive `agents view` (refreshing+saving a Claude
     // OAuth token) or `agents secrets add` pops a keychain password sheet.
-    const sec = spawnSync(
+    const sec = spawnKeychainHelper(
       '/usr/bin/security',
       buildAddGenericPasswordArgs(os.userInfo().username, item),
       buildAddGenericPasswordSpawnOptions(value),
+      KEYCHAIN_SILENT_TIMEOUT_MS,
     );
     if (sec.status !== 0) {
       const msg = sec.stderr?.toString().trim();
@@ -1199,10 +1284,10 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
   // re-notarized helper; an older pinned helper dies with "Unknown command:
   // set-no-acl" (exit 2), surfaced below — never a silent ACL'd downgrade.
   const helperCmd = opts?.noAcl ? 'set-no-acl' : 'set';
-  const result = spawnSync(bin, [helperCmd, item, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, [helperCmd, item, os.userInfo().username], {
     input: value,
     stdio: ['pipe', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     if (opts?.noAcl && /unknown command/i.test(msg ?? '')) {
@@ -1229,9 +1314,9 @@ export function deleteKeychainToken(item: string): boolean {
   if (isLinux()) return linuxBackend.delete(item);
   if (isWindows()) return windowsBackend.delete(item);
   const bin = getKeychainHelperPath();
-  const deleted = spawnSync(bin, ['delete', item, os.userInfo().username], {
+  const deleted = spawnKeychainHelper(bin, ['delete', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }).status === 0;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
   // A deleted item must fail its next read as plain "not found", not with a
   // stale back-off error left over from a pre-delete cancel.
   if (deleted) clearKeychainReadBackoff(requested);
@@ -1267,9 +1352,9 @@ export function listKeychainItems(prefix: string): string[] {
   if (isLinux()) return apply(linuxBackend.list(mapped.prefix));
   if (isWindows()) return apply(windowsBackend.list(mapped.prefix));
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list', mapped.prefix], {
+  const result = spawnKeychainHelper(bin, ['list', mapped.prefix], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate keychain items with prefix '${prefix}'.`);
@@ -1293,9 +1378,9 @@ export function listLegacyKeychainItems(prefix: string): string[] {
   assertSupportedPlatform();
   if (isLinux()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list-legacy', prefix], {
+  const result = spawnKeychainHelper(bin, ['list-legacy', prefix], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate legacy keychain items with prefix '${prefix}'.`);
@@ -1340,9 +1425,9 @@ export function listSyncedKeychainItems(prefix: string): string[] {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list-synced', prefix], {
+  const result = spawnKeychainHelper(bin, ['list-synced', prefix], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate iCloud keychain items with prefix '${prefix}'.`);
@@ -1365,9 +1450,9 @@ export function getSyncedKeychainTokens(items: string[]): Map<string, string> {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return result;
   const bin = getKeychainHelperPath();
-  const child = spawnSync(bin, ['get-batch-synced', os.userInfo().username, ...items], {
+  const child = spawnKeychainHelper(bin, ['get-batch-synced', os.userInfo().username, ...items], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
   if (child.status === 4) {
     throw new Error(`Auth cancelled while reading ${items.length} iCloud keychain item(s).`);
   }
@@ -1391,9 +1476,9 @@ export function deleteSyncedKeychainItem(item: string): boolean {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return false;
   const bin = getKeychainHelperPath();
-  return spawnSync(bin, ['delete-synced', item, os.userInfo().username], {
+  return spawnKeychainHelper(bin, ['delete-synced', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }).status === 0;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
 }
 
 /**
@@ -1410,9 +1495,9 @@ export function migrateKeychainItem(item: string): boolean {
   if (isLinux()) return linuxBackend.has(item);
   if (isWindows()) return windowsBackend.has(item);
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['migrate-acl', item, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, ['migrate-acl', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
   if (result.status === 0) return true;
   if (result.status === 1) return false;
   const msg = result.stderr?.toString().trim();
@@ -1431,9 +1516,9 @@ export function listOrphanedKeychainItems(prefix: string): string[] {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list-orphans', prefix, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, ['list-orphans', prefix, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate orphaned keychain items with prefix '${prefix}'.`);
@@ -1494,9 +1579,9 @@ export function migrateOrphanedKeychainItems(prefix: string): OrphanMigrationRes
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['migrate-orphans', prefix, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, ['migrate-orphans', prefix, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
   if (result.status === 4) throw new Error('Touch ID cancelled during orphan migration.');
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();

--- a/apps/cli/src/lib/secrets/reaper.test.ts
+++ b/apps/cli/src/lib/secrets/reaper.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the keychain-helper reaper planner.
+ *
+ * The planner is pure: it accepts a `ps`-like snapshot and previous candidate
+ * state, and returns which PIDs to kill plus the next candidate map. These tests
+ * run on every platform; the impure `ps` driver is exercised separately in a
+ * darwin-gated integration test.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  planKeychainReap,
+  ORPHAN_GRACE_SEC,
+  STUCK_GRACE_SEC,
+  resetKeychainReaperCandidatesForTest,
+  type KeychainProcessSnapshot,
+  type StuckParentCandidate,
+} from './reaper.js';
+
+function snap(overrides: Partial<KeychainProcessSnapshot> & Pick<KeychainProcessSnapshot, 'pid'>): KeychainProcessSnapshot {
+  return {
+    ppid: 1,
+    elapsedSec: ORPHAN_GRACE_SEC + 1,
+    startTime: `st-${overrides.pid}`,
+    isHelper: true,
+    ...overrides,
+  };
+}
+
+function candidatesFrom(entries: [number, StuckParentCandidate][]): Map<number, StuckParentCandidate> {
+  return new Map(entries);
+}
+
+beforeEach(() => {
+  resetKeychainReaperCandidatesForTest();
+});
+
+describe('planKeychainReap — orphaned helper class (PPID==1)', () => {
+  it('reaps an old helper whose parent is init/launchd', () => {
+    const snapshots = [snap({ pid: 101, ppid: 1, elapsedSec: ORPHAN_GRACE_SEC + 5 })];
+    const plan = planKeychainReap(snapshots, 1_000, new Map());
+    expect(plan.kill).toEqual([101]);
+    expect(plan.nextCandidates.size).toBe(0);
+  });
+
+  it('never reaps an orphaned helper still inside the grace window', () => {
+    const snapshots = [snap({ pid: 102, ppid: 1, elapsedSec: ORPHAN_GRACE_SEC - 1 })];
+    const plan = planKeychainReap(snapshots, 1_000, new Map());
+    expect(plan.kill).toEqual([]);
+  });
+
+  it('never reaps when the start-time fingerprint cannot be captured (fail closed)', () => {
+    const snapshots = [snap({ pid: 103, ppid: 1, elapsedSec: ORPHAN_GRACE_SEC + 5, startTime: null })];
+    const plan = planKeychainReap(snapshots, 1_000, new Map());
+    expect(plan.kill).toEqual([]);
+  });
+
+  it('never reaps a non-helper process even if PPID==1 and old', () => {
+    const snapshots = [snap({ pid: 104, ppid: 1, isHelper: false })];
+    const plan = planKeychainReap(snapshots, 1_000, new Map());
+    expect(plan.kill).toEqual([]);
+  });
+});
+
+describe('planKeychainReap — stuck agents parent class (live helper child)', () => {
+  const parentPid = 500;
+  const helperPid = 501;
+  const parentStart = 'st-500';
+  const helperStart = 'st-501';
+
+  const stuckPair = (): KeychainProcessSnapshot[] => [
+    snap({ pid: parentPid, ppid: 1, elapsedSec: 200, isHelper: false, startTime: parentStart }),
+    snap({ pid: helperPid, ppid: parentPid, elapsedSec: STUCK_GRACE_SEC + 10, startTime: helperStart }),
+  ];
+
+  it('records a candidate on the first sweep but does NOT reap', () => {
+    const plan = planKeychainReap(stuckPair(), 1_000, new Map());
+    expect(plan.kill).toEqual([]);
+    expect(plan.nextCandidates.has(parentPid)).toBe(true);
+    const c = plan.nextCandidates.get(parentPid)!;
+    expect(c.helperPid).toBe(helperPid);
+    expect(c.helperStartTime).toBe(helperStart);
+    expect(c.startTime).toBe(parentStart);
+    expect(c.stage).toBe('watch');
+  });
+
+  it('kills the helper child on the second consecutive sweep', () => {
+    const first = planKeychainReap(stuckPair(), 1_000, new Map());
+    const second = planKeychainReap(stuckPair(), 2_000, first.nextCandidates);
+    expect(second.kill).toEqual([helperPid]);
+    // Parent is now staged for escalation if it is still stuck next sweep.
+    expect(second.nextCandidates.get(parentPid)?.stage).toBe('escalate');
+  });
+
+  it('kills the parent on the third sweep if the helper child is still present', () => {
+    const first = planKeychainReap(stuckPair(), 1_000, new Map());
+    const second = planKeychainReap(stuckPair(), 2_000, first.nextCandidates);
+    const third = planKeychainReap(stuckPair(), 3_000, second.nextCandidates);
+    expect(third.kill).toEqual([parentPid]);
+    expect(third.nextCandidates.has(parentPid)).toBe(false);
+  });
+
+  it('drops the candidate once the helper child disappears', () => {
+    const first = planKeychainReap(stuckPair(), 1_000, new Map());
+    const resolved = [snap({ pid: parentPid, ppid: 1, elapsedSec: 200, isHelper: false, startTime: parentStart })];
+    const next = planKeychainReap(resolved, 2_000, first.nextCandidates);
+    expect(next.kill).toEqual([]);
+    expect(next.nextCandidates.has(parentPid)).toBe(false);
+  });
+
+  it('never reaps a helper whose parent is missing from the snapshot', () => {
+    const snapshots = [snap({ pid: helperPid, ppid: parentPid, elapsedSec: STUCK_GRACE_SEC + 10, startTime: helperStart })];
+    const plan = planKeychainReap(snapshots, 1_000, new Map());
+    expect(plan.kill).toEqual([]);
+    expect(plan.nextCandidates.size).toBe(0);
+  });
+
+  it('resets the debounce when the parent pid is reused (startTime changed)', () => {
+    const first = planKeychainReap(stuckPair(), 1_000, new Map());
+    const reusedParent = stuckPair().map((s) =>
+      s.pid === parentPid ? { ...s, startTime: 'st-500-reused' } : s,
+    );
+    const second = planKeychainReap(reusedParent, 2_000, first.nextCandidates);
+    // A reused pid is a different process; start over as a watch candidate.
+    expect(second.kill).toEqual([]);
+    expect(second.nextCandidates.get(parentPid)?.startTime).toBe('st-500-reused');
+  });
+
+  it('resets the debounce when the helper pid is reused (startTime changed)', () => {
+    const first = planKeychainReap(stuckPair(), 1_000, new Map());
+    const reusedHelper = stuckPair().map((s) =>
+      s.pid === helperPid ? { ...s, startTime: 'st-501-reused' } : s,
+    );
+    const second = planKeychainReap(reusedHelper, 2_000, first.nextCandidates);
+    expect(second.kill).toEqual([]);
+    expect(second.nextCandidates.get(parentPid)?.helperStartTime).toBe('st-501-reused');
+  });
+
+  it('fails closed when the helper startTime cannot be captured', () => {
+    const snapshots = [
+      snap({ pid: parentPid, ppid: 1, elapsedSec: 200, isHelper: false, startTime: parentStart }),
+      snap({ pid: helperPid, ppid: parentPid, elapsedSec: STUCK_GRACE_SEC + 10, startTime: null }),
+    ];
+    const plan = planKeychainReap(snapshots, 1_000, new Map());
+    expect(plan.kill).toEqual([]);
+    expect(plan.nextCandidates.size).toBe(0);
+  });
+
+  it('fails closed when the parent startTime cannot be captured', () => {
+    const snapshots = [
+      snap({ pid: parentPid, ppid: 1, elapsedSec: 200, isHelper: false, startTime: null }),
+      snap({ pid: helperPid, ppid: parentPid, elapsedSec: STUCK_GRACE_SEC + 10, startTime: helperStart }),
+    ];
+    const plan = planKeychainReap(snapshots, 1_000, new Map());
+    expect(plan.kill).toEqual([]);
+    expect(plan.nextCandidates.size).toBe(0);
+  });
+});
+
+describe('planKeychainReap — mixed snapshots', () => {
+  it('handles orphans and stuck parents in the same pass', () => {
+    const snapshots = [
+      snap({ pid: 1, ppid: 0, elapsedSec: 1_000_000, isHelper: false, startTime: 'st-1' }),
+      snap({ pid: 200, ppid: 1, elapsedSec: ORPHAN_GRACE_SEC + 5, startTime: 'st-200' }),
+      snap({ pid: 300, ppid: 1, elapsedSec: 1_000, isHelper: false, startTime: 'st-300' }),
+      snap({ pid: 301, ppid: 300, elapsedSec: STUCK_GRACE_SEC + 5, startTime: 'st-301' }),
+    ];
+    const prev = candidatesFrom([
+      [
+        300,
+        {
+          pid: 300,
+          startTime: 'st-300',
+          helperPid: 301,
+          helperStartTime: 'st-301',
+          firstSeenAt: 1,
+          stage: 'watch',
+        },
+      ],
+    ]);
+    const plan = planKeychainReap(snapshots, 2_000, prev);
+    expect(plan.kill).toContain(200); // orphan
+    expect(plan.kill).toContain(301); // stuck helper child on second sweep
+    expect(plan.nextCandidates.get(300)?.stage).toBe('escalate');
+  });
+});
+
+describe('reapOrphanedKeychainProcesses (darwin integration)', () => {
+  it.skipIf(process.platform !== 'darwin')('reaps a real orphaned sleeper that matches the helper path', () => {
+    const { spawn, execFileSync } = require('child_process');
+    const os = require('os');
+    const path = require('path');
+    const fs = require('fs');
+
+    // Build a fake installed helper at the exact path getKeychainHelperPath()
+    // resolves to under the test install root. The reaper does an exact
+    // path-match against this string, so the sleeper's argv[0] must equal it.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-reaper-'));
+    const fakeHelper = path.join(
+      tmpDir,
+      'Library',
+      'Application Support',
+      'agents-cli',
+      'Agents CLI.app',
+      'Contents',
+      'MacOS',
+      'Agents CLI',
+    );
+    fs.mkdirSync(path.dirname(fakeHelper), { recursive: true });
+    fs.writeFileSync(fakeHelper, '#!/bin/sh\nsleep 300\n', { mode: 0o755 });
+
+    // Launch through a disposable shell that exits immediately, so the sleeper
+    // is reparented to init (PPID 1).
+    const launcher = spawn('sh', ['-c', `${JSON.stringify(fakeHelper)} &`], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    launcher.unref();
+
+    // Wait long enough to exceed the orphan grace window.
+    const deadline = Date.now() + 2_000 + (ORPHAN_GRACE_SEC * 1_000);
+    while (Date.now() < deadline) { /* spin synchronously to stay inside the test */ }
+
+    // Confirm the sleeper is actually orphaned before the reaper runs.
+    let sleeperPid = 0;
+    try {
+      const psOut = execFileSync('ps', ['-ax', '-o', 'pid=,ppid=,etimes=,command='], { encoding: 'utf-8' });
+      for (const line of psOut.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith(fakeHelper) || trimmed.includes(fakeHelper)) {
+          const pid = parseInt(trimmed.match(/^(\d+)/)?.[1] ?? '0', 10);
+          if (pid > 0) { sleeperPid = pid; break; }
+        }
+      }
+    } catch { /* ignore */ }
+
+    try {
+      const { setInstallRootForTest } = require('./install-helper.js');
+      const { reapOrphanedKeychainProcesses } = require('./reaper.js');
+      const prevRoot = setInstallRootForTest(tmpDir);
+      try {
+        const result = reapOrphanedKeychainProcesses();
+        expect(result.reaped).toBeGreaterThanOrEqual(1);
+        expect(result.details.some((d: string) => d.includes(String(sleeperPid)))).toBe(true);
+      } finally {
+        setInstallRootForTest(prevRoot);
+      }
+    } finally {
+      if (sleeperPid) {
+        try { process.kill(sleeperPid, 'SIGKILL'); } catch { /* may already be reaped */ }
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/apps/cli/src/lib/secrets/reaper.ts
+++ b/apps/cli/src/lib/secrets/reaper.ts
@@ -1,0 +1,241 @@
+/**
+ * Reaper for orphaned / wedged keychain-helper processes.
+ *
+ * macOS keychain-helper calls are synchronous spawnSync invocations. When
+ * coreauthd / LocalAuthentication hangs, the helper process (and sometimes its
+ * parent `agents` process) can pile up forever. This module detects two classes
+ * of stale process and kills them.
+ *
+ * The design splits cleanly into:
+ *   - a pure planner ({@link planKeychainReap}) that is unit-testable without a
+ *     real `ps` shell, and
+ *   - an impure driver ({@link reapOrphanedKeychainProcesses}) that shells `ps`
+ *     once per tick and executes kills through {@link killTree}.
+ */
+
+import { execFileSync } from 'child_process';
+import { killTree, captureProcessStartTime } from '../platform/process.js';
+import { getKeychainHelperPath } from './install-helper.js';
+
+/** Elapsed grace before a helper whose parent exited is considered an orphan. */
+export const ORPHAN_GRACE_SEC = 30;
+/** Elapsed grace before a helper with a live parent is considered stuck. */
+export const STUCK_GRACE_SEC = 90;
+
+/** Snapshot of one process row from `ps`, fed into the pure planner. */
+export interface KeychainProcessSnapshot {
+  pid: number;
+  ppid: number;
+  /** Elapsed seconds since the process started. */
+  elapsedSec: number;
+  /**
+   * Stable start-time fingerprint from {@link captureProcessStartTime}.
+   * `null` means "could not capture" — the planner must fail closed.
+   */
+  startTime: string | null;
+  /** True when this process's executable path matches the installed helper. */
+  isHelper: boolean;
+}
+
+/**
+ * Tracked state for a stuck `agents` parent that has a live helper child.
+ * Keyed by parent PID. The two-sweep debounce avoids acting on a racy `ps`
+ * snapshot; the `stage` field drives child-first kill then parent escalation.
+ */
+export interface StuckParentCandidate {
+  pid: number;
+  startTime: string | null;
+  helperPid: number;
+  helperStartTime: string | null;
+  firstSeenAt: number;
+  stage: 'watch' | 'escalate';
+}
+
+/** Result of one planning pass. */
+export interface ReapPlan {
+  /** PIDs that should be killed this tick. */
+  kill: number[];
+  /** Candidates to carry forward to the next sweep. */
+  nextCandidates: Map<number, StuckParentCandidate>;
+}
+
+/**
+ * Pure predicate: decide which processes to kill given a `ps`-like snapshot.
+ *
+ * Mirrors the shape of {@link isExpiredPoolStray} in `lib/crabbox/lease.ts`:
+ * a side-effect-free classifier that the impure driver shells `ps` for. Two
+ * conservative reap classes:
+ *
+ *   1. Orphaned helper: PPID == 1, path-matches the helper, alive longer than
+ *      {@link ORPHAN_GRACE_SEC}.
+ *   2. Stuck `agents` parent: helper child alive longer than
+ *      {@link STUCK_GRACE_SEC}. Recorded on first sight, child killed on the
+ *      second consecutive sweep with the same PID + startTime, parent killed on
+ *      the third sweep if the helper child is still present.
+ *
+ * Never reaps a process whose start time could not be captured, whose path does
+ * not match the helper, or whose parent is no longer in the snapshot.
+ */
+export function planKeychainReap(
+  snapshots: KeychainProcessSnapshot[],
+  now: number,
+  prevCandidates: ReadonlyMap<number, StuckParentCandidate>,
+): ReapPlan {
+  const pidMap = new Map<number, KeychainProcessSnapshot>(snapshots.map((s) => [s.pid, s]));
+  const kill: number[] = [];
+  const nextCandidates = new Map<number, StuckParentCandidate>();
+
+  for (const s of snapshots) {
+    if (!s.isHelper) continue;
+
+    if (s.ppid === 1) {
+      // Orphaned helper: parent is init/launchd. Fail closed if we can't prove
+      // the process identity with a start-time fingerprint.
+      if (s.elapsedSec <= ORPHAN_GRACE_SEC) continue;
+      if (s.startTime == null) continue;
+      kill.push(s.pid);
+      continue;
+    }
+
+    // Stuck agents: a helper with a live parent that has been wedged for longer
+    // than the interactive timeout. The parent must still exist in the snapshot.
+    if (s.elapsedSec <= STUCK_GRACE_SEC) continue;
+    const parent = pidMap.get(s.ppid);
+    if (!parent) continue;
+    if (s.startTime == null || parent.startTime == null) continue;
+
+    const prev = prevCandidates.get(parent.pid);
+    if (
+      prev &&
+      prev.helperPid === s.pid &&
+      prev.helperStartTime === s.startTime &&
+      prev.startTime === parent.startTime
+    ) {
+      if (prev.stage === 'watch') {
+        // Second sweep: kill the child first so the parent's spawnSync returns.
+        // Keep the parent candidate at stage 'escalate' for the next sweep.
+        kill.push(s.pid);
+        nextCandidates.set(parent.pid, { ...prev, stage: 'escalate' });
+        continue;
+      }
+      // Third sweep: child did not free the parent, so the parent itself is wedged.
+      kill.push(parent.pid);
+      continue;
+    }
+
+    // First sight of this (parent, helper) pair — record it and wait.
+    nextCandidates.set(parent.pid, {
+      pid: parent.pid,
+      startTime: parent.startTime,
+      helperPid: s.pid,
+      helperStartTime: s.startTime,
+      firstSeenAt: now,
+      stage: 'watch',
+    });
+  }
+
+  return { kill, nextCandidates };
+}
+
+/**
+ * Parse one `ps` output line.
+ *
+ * Expected format from `ps -ax -o pid=,ppid=,etimes=,command=`:
+ *   "<pid> <ppid> <etimes> <command...>"
+ * The command field is the remainder of the line and may contain spaces.
+ */
+function parsePsLine(line: string): {
+  pid: number;
+  ppid: number;
+  elapsedSec: number;
+  command: string;
+} | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const m = trimmed.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/);
+  if (!m) return null;
+  const pid = parseInt(m[1], 10);
+  const ppid = parseInt(m[2], 10);
+  const elapsedSec = parseInt(m[3], 10);
+  const command = m[4];
+  if (isNaN(pid) || isNaN(ppid) || isNaN(elapsedSec)) return null;
+  return { pid, ppid, elapsedSec, command };
+}
+
+/** Module-state for the two-sweep stuck-parent debounce. */
+let stuckParentCandidates = new Map<number, StuckParentCandidate>();
+
+/** Test seam: reset the persisted candidate state. */
+export function resetKeychainReaperCandidatesForTest(): void {
+  stuckParentCandidates = new Map<number, StuckParentCandidate>();
+}
+
+/**
+ * Impure driver: snapshot all processes once with `ps`, plan the reap, then
+ * execute kills through {@link killTree}.
+ *
+ * Path-matching uses the full helper path (proc_pidpath-style), not just the
+ * executable name, so an unrelated binary named "Agents CLI" is never targeted.
+ *
+ * Returns on non-darwin platforms without shelling anything — the helper only
+ * exists on macOS.
+ */
+export function reapOrphanedKeychainProcesses(): {
+  reaped: number;
+  details: string[];
+  plan: ReapPlan;
+} {
+  const details: string[] = [];
+  if (process.platform !== 'darwin') {
+    return { reaped: 0, details, plan: { kill: [], nextCandidates: new Map() } };
+  }
+
+  let helperPath: string;
+  try {
+    helperPath = getKeychainHelperPath();
+  } catch (err) {
+    return { reaped: 0, details: [`helper path resolution failed: ${(err as Error).message}`], plan: { kill: [], nextCandidates: new Map() } };
+  }
+
+  let out: string;
+  try {
+    out = execFileSync('ps', ['-ax', '-o', 'pid=,ppid=,etimes=,command='], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch (err) {
+    return { reaped: 0, details: [`ps failed: ${(err as Error).message}`], plan: { kill: [], nextCandidates: new Map() } };
+  }
+
+  const snapshots: KeychainProcessSnapshot[] = [];
+  for (const line of out.split('\n')) {
+    const parsed = parsePsLine(line);
+    if (!parsed) continue;
+    const { pid, ppid, elapsedSec, command } = parsed;
+    // Exact path-match: the helper invocation's command line begins with the
+    // absolute helper path, followed by a space and its arguments (or nothing).
+    const isHelper = command === helperPath || command.startsWith(`${helperPath} `);
+    snapshots.push({
+      pid,
+      ppid,
+      elapsedSec,
+      startTime: captureProcessStartTime(pid),
+      isHelper,
+    });
+  }
+
+  const plan = planKeychainReap(snapshots, Date.now(), stuckParentCandidates);
+  stuckParentCandidates = plan.nextCandidates;
+
+  for (const pid of plan.kill) {
+    if (pid === process.pid) continue; // never self-terminate the reaper
+    try {
+      killTree(pid);
+      details.push(`killed pid ${pid}`);
+    } catch (err) {
+      details.push(`failed to kill pid ${pid}: ${(err as Error).message}`);
+    }
+  }
+
+  return { reaped: plan.kill.length, details, plan };
+}


### PR DESCRIPTION
- Layer 1: spawnKeychainHelper wrapper applies 8s/60s timeouts and SIGKILL to
  every keychain-helper and /usr/bin/security spawnSync in secrets/index.ts.
  Throws KeychainHelperTimeoutError; getKeychainToken/getKeychainTokens arm the
  read back-off before rethrowing.
- Layer 3: new secrets/reaper.ts with pure planKeychainReap predicate and
  impure reapOrphanedKeychainProcesses driver. Reaps orphaned helpers (PPID==1,
  >30s) and stuck agents parents (live helper child >90s, two-sweep debounce,
  child-first kill, parent escalation).
- Daemon tick: 5-min overlap-guarded interval beside runBrokerSelfHeal; cleared
  in handleShutdown. spawnKeychainHelper boots the daemon once per process so
  secrets-only machines get the reaper online.
- Tests: pure planner unit tests; spawnSync timeout test; darwin-gated orphan
  integration test.
