### PR TITLE
fix(muse): global binary path for agents view

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
   &nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://factory.ai" title="Factory AI Droid"><strong>Droid</strong></a>
   &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://dev.meta.ai/docs/muse-code" title="Meta Muse Code"><strong>Muse</strong></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://omp.sh" title="Oh My Pi"><strong>Pi</strong></a>
 </p>
 

--- a/apps/cli/.changelog/next/muse-global-binary-view.md
+++ b/apps/cli/.changelog/next/muse-global-binary-view.md
@@ -1,0 +1,8 @@
+- **Muse Code global binary is visible to `agents view` / `isVersionInstalled`.**
+  Muse installs a single self-updating launcher at `~/.local/bin/muse` (same
+  shape as droid), but `getBinaryPath` still resolved a version-home
+  `node_modules/.bin/muse` that never exists. After `agents import muse` /
+  `agents add muse`, version dirs now resolve to that global path so managed
+  view, collapse, and live-version bookkeeping match what actually executes;
+  install no longer writes a self-referential shim symlink. Source:
+  `apps/cli/src/lib/versions.ts`.

--- a/apps/cli/src/lib/versions.ts
+++ b/apps/cli/src/lib/versions.ts
@@ -1021,6 +1021,17 @@ export function getBinaryPath(agent: AgentId, version: string): string {
       ? path.join(getHomeDir(), 'bin', 'droid.exe')
       : path.join(getHomeDir(), '.local', 'bin', 'droid');
   }
+  if (agent === 'muse') {
+    // Muse Code install script drops a self-updating launcher at
+    // ~/.local/bin/muse (curl -fsSL https://dev.meta.ai/install.sh | sh).
+    // Same global-binary shape as droid: one binary for every version dir,
+    // config isolation via version-home HOME rewrite. Mirror the shim's
+    // `muse` branch so isVersionInstalled / agents view / agents import
+    // agree with what executes.
+    return IS_WINDOWS
+      ? path.join(getHomeDir(), 'bin', 'muse.exe')
+      : path.join(getHomeDir(), '.local', 'bin', 'muse');
+  }
   const versionDir = getVersionDir(agent, version);
   return path.join(versionDir, 'node_modules', '.bin', agentConfig.cliCommand);
 }
@@ -1650,14 +1661,14 @@ export async function installVersion(
     // ~/.local/bin (or similar) rather than the version's node_modules/.bin.
     //
     // Agents whose binary is special-cased in getBinaryPath (grok ->
-    // ~/.grok/downloads, droid -> ~/.local/bin/droid) need no symlink — and
+    // ~/.grok/downloads, droid/muse -> ~/.local/bin/<cli>) need no symlink — and
     // creating one is actively harmful: `which <cli>` can resolve to OUR OWN
     // dispatcher shim, because ~/.agents/.cache/shims sits ahead of ~/.local/bin
     // on PATH. Symlinking node_modules/.bin/<cli> at the shim makes the shim
     // exec itself forever. So we skip the resolver-backed agents here AND, for
     // everyone else, filter the shims dir out of the `which` candidates so the
     // same race can't bite a non-special-cased installScript agent.
-    if (agent !== 'grok' && agent !== 'droid') {
+    if (agent !== 'grok' && agent !== 'droid' && agent !== 'muse') {
       // findInPath is a pure-Node PATH scan that already skips our own shims
       // dir — so it returns the genuine install, never our dispatcher shim
       // (which sits ahead of ~/.local/bin on PATH and would otherwise be

--- a/apps/cli/tests/versions.test.ts
+++ b/apps/cli/tests/versions.test.ts
@@ -97,6 +97,9 @@ vi.mock('../src/lib/state.js', () => {
     get getActiveRulesPreset() { return () => 'default'; },
     get setActiveRulesPreset() { return () => {}; },
     get getCliVersionCachePath() { return () => nodePath.join(state().AGENTS_DIR, '.cli-version-cache.json'); },
+    // droid/muse global-binary paths resolve under the real user home; pin to
+    // TEST_ROOT so path helpers stay hermetic in this suite.
+    get getHomeDir() { return () => state().TEST_ROOT || require('node:os').homedir(); },
   };
 });
 
@@ -670,6 +673,16 @@ describe('version path helpers', () => {
   it('getBinaryPath returns correct binary location', () => {
     const bin = getBinaryPath('claude', '2.0.65');
     expect(toPosix(bin)).toContain('node_modules/.bin/claude');
+  });
+
+  it('getBinaryPath for muse is the global self-updating launcher (any version)', () => {
+    // Muse installs once under ~/.local/bin/muse (or %USERPROFILE%\bin\muse.exe).
+    // Version dirs must resolve to the same path so isGlobalBinaryAgent is true
+    // and agents view / isVersionInstalled see the real binary after import.
+    const a = getBinaryPath('muse', '0.1.0');
+    const b = getBinaryPath('muse', '9.9.9');
+    expect(a).toBe(b);
+    expect(toPosix(a)).toMatch(/\/(\.local\/bin\/muse|bin\/muse\.exe)$/);
   });
 
   it('getVersionHomePath returns home subdir', () => {


### PR DESCRIPTION
fix — Muse Code harness: agents view / managed install sees the real binary.

## What

`getBinaryPath('muse')` now resolves to `~/.local/bin/muse` (Windows: `%USERPROFILE%\bin\muse.exe`), matching the install-script layout and the existing shim branch. Install skips writing a node_modules/.bin symlink that would re-exec the agents shim.

## Why

Without this, after `agents import muse` / `agents add muse`, version dirs never counted as installed and `agents view` could not manage Muse.

## Run proof

```

 RUN  v4.1.9 /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/muse-view-global-binary/apps/cli

 ✓ tests/versions.test.ts (100 tests | 98 skipped) 7ms

 Test Files  1 passed (1)
      Tests  2 passed | 98 skipped (100)
   Start at  18:07:15
   Duration  618ms (transform 409ms, setup 21ms, import 519ms, tests 7ms, environment 0ms)
```

Also updated root README harness strip with Muse.

No-surface for UI; CLI path resolution only.
