### PR TITLE
fix(secrets): bound keychain-helper spawns + reap stuck/orphaned procs (RUSH-2231, RUSH-2232)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2231-2232-keychain-reaper.md
+++ b/apps/cli/.changelog/next/RUSH-2231-2232-keychain-reaper.md
@@ -1,0 +1,16 @@
+- **A wedged keychain can no longer pile up `agents` processes (RUSH-2231, RUSH-2232).**
+  A stalled macOS `coreauthd` used to hang the signed keychain helper's XPC receive
+  forever, so every secrets-touching `agents` command blocked and dozens of helper
+  processes plus their `<defunct>` zombies accumulated and made the machine sluggish.
+  Two fixes: **(Layer 1)** every keychain-helper `spawnSync` is now bounded and
+  hard-killed (SIGKILL) on timeout — 8s for never-prompt verbs (`has`/`set`/`delete`/
+  `list*`), 60s for the may-prompt reads (`get`/`get-batch`/`migrate-*`) — surfacing a
+  typed timeout error and arming the read back-off instead of hanging.
+  **(Layer 3)** the daemon reaps the backlog: a 5-minute tick kills orphaned helpers
+  (reparented to PID 1, past a 30s grace) and, two-sweep-debounced, the helper child of
+  an `agents` proc stuck past 90s (child first, escalating to the parent only if it
+  stays wedged) — never touching a process whose start-time can't be captured or whose
+  path doesn't match the helper. Any keychain touch now also opportunistically starts
+  the daemon so the reaper runs even on a secrets-only box. Source:
+  `apps/cli/src/lib/secrets/index.ts`, `apps/cli/src/lib/secrets/reaper.ts`,
+  `apps/cli/src/lib/daemon.ts`.

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -941,6 +941,34 @@ export async function runDaemon(): Promise<void> {
   };
   const brokerSelfHealInterval = setInterval(() => { void runBrokerSelfHeal(); }, 60_000);
 
+  // RUSH-2232: reap orphaned macOS keychain-helper processes and `agents` procs
+  // stuck on a keychain read. A wedged coreauthd hangs the signed helper; before
+  // Layer 1 (RUSH-2231) bounded the helper spawnSync, dozens of orphans + their
+  // <defunct> zombies piled up and made the machine sluggish. Layer 1 stops NEW
+  // pileups; this clears the backlog on a 5-min tick. The candidate list carries
+  // the two-sweep debounce state in memory across ticks (the daemon is the sole
+  // executor). Overlap-guarded; macOS-only work happens inside the reaper (no-op
+  // elsewhere). Best-effort — a flaky ps snapshot must not crash the daemon.
+  let reapingKeychain = false;
+  let keychainReapCandidates: import('./secrets/reaper.js').KeychainReapCandidate[] = [];
+  const runKeychainReap = async () => {
+    if (reapingKeychain) return;
+    reapingKeychain = true;
+    try {
+      const { reapOrphanedKeychainProcesses } = await import('./secrets/reaper.js');
+      const r = reapOrphanedKeychainProcesses(keychainReapCandidates);
+      keychainReapCandidates = r.nextCandidates;
+      if (r.reaped > 0) {
+        log('WARN', `Keychain reaper: killed ${r.reaped} stuck/orphaned process(es) — ${r.killed.map((k) => `${k.role} pid ${k.pid}`).join(', ')}`);
+      }
+    } catch (err) {
+      log('WARN', `Keychain reaper skipped: ${(err as Error).message}`);
+    } finally {
+      reapingKeychain = false;
+    }
+  };
+  const keychainReapInterval = setInterval(() => { void runKeychainReap(); }, 5 * 60_000);
+
   const handleReload = () => {
     log('INFO', 'Reloading jobs (SIGHUP)');
     // Refresh user-layer copies of opted-in project routines BEFORE the
@@ -999,6 +1027,7 @@ export async function runDaemon(): Promise<void> {
     clearInterval(usageRefreshInterval);
     clearTimeout(usageRefreshKickoff);
     clearInterval(brokerSelfHealInterval);
+    clearInterval(keychainReapInterval);
     hostedBroker?.close();
     removeDaemonPid();
     removeHeartbeat();

--- a/apps/cli/src/lib/secrets/index.test.ts
+++ b/apps/cli/src/lib/secrets/index.test.ts
@@ -23,16 +23,86 @@ import {
   HMAC_KEY_ITEM,
   keychainServiceAlias,
   keychainOperationPrompt,
+  KeychainHelperTimeoutError,
+  KEYCHAIN_SILENT_TIMEOUT_MS,
+  KEYCHAIN_INTERACTIVE_TIMEOUT_MS,
   listKeychainItems,
   parseOrphanMigrationOutput,
   readHmacKeyRecord,
   rekeyServiceNames,
   setKeychainBackendForTest,
+  setKeychainDaemonBootForTest,
   setKeychainServiceHashingForTest,
   setKeychainToken,
+  spawnKeychainHelper,
   withRawKeychainServiceNames,
   type KeychainBackend,
 } from './index.js';
+import {
+  KEYCHAIN_READ_BACKOFF_TTL_MS,
+  isKeychainReadBackedOff,
+  noteKeychainReadFailure,
+  setKeychainReadBackoffDirForTest,
+} from './read-backoff.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('spawnKeychainHelper (RUSH-2231: bounded helper spawn, SIGKILL on timeout)', () => {
+  it('hard-kills and throws the typed error when the helper hangs past the bound', () => {
+    const started = Date.now();
+    // A real hung child (sleeps far longer than the bound) stands in for a wedged
+    // helper on a stalled coreauthd; the wrapper must not wait for it.
+    let thrown: unknown;
+    try {
+      spawnKeychainHelper('/bin/sh', ['-c', 'sleep 30'], { stdio: ['ignore', 'pipe', 'pipe'] }, 300);
+    } catch (err) {
+      thrown = err;
+    }
+    const elapsed = Date.now() - started;
+    expect(thrown).toBeInstanceOf(KeychainHelperTimeoutError);
+    expect((thrown as KeychainHelperTimeoutError).timeoutMs).toBe(300);
+    expect(elapsed).toBeLessThan(5_000); // returned ~at the bound, not after 30s
+  });
+
+  it('returns the result for a command that completes inside the bound', () => {
+    const r = spawnKeychainHelper('/bin/sh', ['-c', 'printf ok'], { stdio: ['ignore', 'pipe', 'pipe'] }, 8_000);
+    expect(r.status).toBe(0);
+    expect(r.stdout?.toString()).toBe('ok');
+  });
+
+  it('exposes the two timeout buckets', () => {
+    expect(KEYCHAIN_SILENT_TIMEOUT_MS).toBe(8_000);
+    expect(KEYCHAIN_INTERACTIVE_TIMEOUT_MS).toBe(60_000);
+  });
+
+  it('a caught timeout arms the read back-off (the getKeychainToken glue)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kc-backoff-'));
+    setKeychainReadBackoffDirForTest(dir);
+    try {
+      const key = 'some-item';
+      expect(isKeychainReadBackedOff(key)).toBe(false);
+      try {
+        spawnKeychainHelper('/bin/sh', ['-c', 'sleep 30'], { stdio: ['ignore', 'pipe', 'pipe'] }, 200);
+      } catch (err) {
+        if (err instanceof KeychainHelperTimeoutError) noteKeychainReadFailure(key);
+        else throw err;
+      }
+      expect(isKeychainReadBackedOff(key)).toBe(true);
+      expect(isKeychainReadBackedOff(key, Date.now() + KEYCHAIN_READ_BACKOFF_TTL_MS + 1)).toBe(false);
+    } finally {
+      setKeychainReadBackoffDirForTest(null);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('setKeychainDaemonBootForTest toggles the once-per-process boot guard', () => {
+    // Under vitest the boot is disabled by default; the seam exists to flip it.
+    expect(() => setKeychainDaemonBootForTest(false)).not.toThrow();
+    expect(() => setKeychainDaemonBootForTest(true)).not.toThrow();
+    setKeychainDaemonBootForTest(false); // leave it off for the rest of the suite
+  });
+});
 
 describe('keychainOperationPrompt', () => {
   it('names the harness, bundle, reason, and duration', () => {

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -813,6 +813,94 @@ export function rekeyStatus(): {
 }
 
 /**
+ * Timeout for never-prompt helper verbs (has/set/delete/list*), and the two
+ * silent `/usr/bin/security` probes: a wedged `coreauthd` can hang the helper's
+ * XPC receive forever, so bound it. These never raise a Touch ID sheet, so the
+ * only reason to hang is a broken keychain — 8s is generous for a local query.
+ */
+export const KEYCHAIN_SILENT_TIMEOUT_MS = 8_000;
+
+/**
+ * Timeout for may-prompt helper verbs (get/get-batch/get-batch-synced/
+ * migrate-*), all gated by `assertRawKeychainReadAllowed` so they only reach a
+ * TTY where a human can answer Touch ID. 60s leaves room to authenticate while
+ * still bounding a wedged `coreauthd` that would otherwise hang forever.
+ */
+export const KEYCHAIN_INTERACTIVE_TIMEOUT_MS = 60_000;
+
+/**
+ * Thrown when a keychain-helper (or `/usr/bin/security`) spawn is hard-killed on
+ * its timeout — the wedged-`coreauthd` case (RUSH-2231). Typed so read callers
+ * can arm the read back-off before rethrowing, and so a caller distinguishes a
+ * hung keychain from a plain non-zero exit.
+ */
+export class KeychainHelperTimeoutError extends Error {
+  constructor(public readonly bin: string, public readonly timeoutMs: number) {
+    super(
+      `Keychain helper timed out after ${Math.round(timeoutMs / 1000)}s ` +
+        `(keychain locked / LocalAuthentication unresponsive) — retry; ` +
+        `if it persists, lock/unlock the screen or reboot.`,
+    );
+    this.name = 'KeychainHelperTimeoutError';
+  }
+}
+
+/** Whether the once-per-process daemon boot has been attempted (Layer-3 boot). */
+let daemonBootAttempted = false;
+/** Under the vitest runner, do not spawn a background daemon from a keychain
+ *  touch; a test can re-enable via {@link setKeychainDaemonBootForTest}. */
+let daemonBootEnabled = !process.env.VITEST;
+
+export function setKeychainDaemonBootForTest(enabled: boolean): void {
+  daemonBootEnabled = enabled;
+  daemonBootAttempted = false;
+}
+
+/**
+ * Bring the reaper online opportunistically (RUSH-2232 boot path). A
+ * secrets-only machine (e.g. a SessionStart hook doing `secrets get`) never
+ * reaches `secrets unlock`/broker code, so the daemon — which runs the keychain
+ * reaper on a tick — would never start there. Every keychain touch is a chance
+ * to start it. Once per process, macOS only, fire-and-forget: a keychain read
+ * must never block on (or fail because of) daemon startup, and the dynamic
+ * import keeps the daemon's heavy deps out of every secrets process's static graph.
+ */
+function ensureReaperDaemonOnce(): void {
+  if (daemonBootAttempted || !daemonBootEnabled) return;
+  daemonBootAttempted = true;
+  if (process.platform !== 'darwin') return; // the keychain reaper is macOS only
+  void import('../daemon.js')
+    .then(({ ensureDaemonStarted }) => {
+      try { ensureDaemonStarted(); } catch { /* best-effort */ }
+    })
+    .catch(() => { /* daemon module unavailable — best-effort */ });
+}
+
+/**
+ * Run a keychain-helper (or `/usr/bin/security`) `spawnSync`, bounded by
+ * `timeoutMs` and hard-killed (SIGKILL, not the default SIGTERM — the hang is a
+ * Mach `mach_msg` receive that ignores SIGTERM). A timeout leaves `status` null
+ * with the kill signal recorded (and, for the deadline, an `ETIMEDOUT` error);
+ * either shape is surfaced as a typed {@link KeychainHelperTimeoutError} so a
+ * wedged `coreauthd` can no longer hang the parent forever. Also fires the
+ * once-per-process reaper-daemon boot.
+ */
+export function spawnKeychainHelper(
+  bin: string,
+  args: readonly string[],
+  opts: SpawnSyncOptions,
+  timeoutMs: number,
+): ReturnType<typeof spawnSync> {
+  ensureReaperDaemonOnce();
+  const result = spawnSync(bin, args as string[], { ...opts, timeout: timeoutMs, killSignal: 'SIGKILL' });
+  const timedOut =
+    (result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT' ||
+    (result.status === null && result.signal != null);
+  if (timedOut) throw new KeychainHelperTimeoutError(bin, timeoutMs);
+  return result;
+}
+
+/**
  * Check if a keychain/keyring item exists. Never prompts for biometry.
  *
  * Throws when the item cannot be reached — on macOS, when the signed helper is
@@ -833,14 +921,14 @@ export function hasKeychainToken(item: string): boolean {
   if (isLinux()) return linuxBackend.has(item);
   if (isWindows()) return windowsBackend.has(item);
   if (!isOurItem(item)) {
-    return spawnSync('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item], {
+    return spawnKeychainHelper('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item], {
       stdio: ['ignore', 'ignore', 'ignore'],
-    }).status === 0;
+    }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
   }
   const bin = getKeychainHelperPath();
-  return spawnSync(bin, ['has', item, os.userInfo().username], {
+  return spawnKeychainHelper(bin, ['has', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }).status === 0;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
 }
 
 /**
@@ -947,9 +1035,19 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
   if (isLinux()) return linuxBackend.get(item);
   if (isWindows()) return windowsBackend.get(item);
   if (!isOurItem(item)) {
-    const sec = spawnSync('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item, '-w'], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    // Bare no-ACL items normally read silently, but a legacy trusted-app item
+    // could pop the password sheet — bound it interactively so a user can type,
+    // yet a wedged coreauthd still can't hang forever. A timeout arms the
+    // back-off (like any failed read) before rethrowing.
+    let sec: ReturnType<typeof spawnSync>;
+    try {
+      sec = spawnKeychainHelper('/usr/bin/security', ['find-generic-password', '-a', os.userInfo().username, '-s', item, '-w'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
+    } catch (err) {
+      if (err instanceof KeychainHelperTimeoutError && !context.silentNoAcl) noteKeychainReadFailure(requested);
+      throw err;
+    }
     if (sec.status === 0) {
       const token = sec.stdout?.toString().trim();
       if (token) {
@@ -960,15 +1058,23 @@ export function getKeychainToken(item: string, context: KeychainReadContext = {}
     throw new Error(`Keychain item '${requested}' not found.`);
   }
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['get', item, os.userInfo().username], {
-    env: {
-      ...process.env,
-      AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
-      AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
-      AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
-    },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  let result: ReturnType<typeof spawnSync>;
+  try {
+    result = spawnKeychainHelper(bin, ['get', item, os.userInfo().username], {
+      env: {
+        ...process.env,
+        AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
+        AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
+        AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
+  } catch (err) {
+    // A still-wedged coreauthd keeps timing out; arm the back-off so the next
+    // poll fails fast instead of re-hanging (RUSH-2231).
+    if (err instanceof KeychainHelperTimeoutError && !context.silentNoAcl) noteKeychainReadFailure(requested);
+    throw err;
+  }
   // Exit 1 is a plain miss — no prompt was raised, so it opens no back-off.
   if (result.status === 1) throw new Error(`Keychain item '${requested}' not found.`);
   if (result.status !== 0) {
@@ -1038,19 +1144,27 @@ export function getKeychainTokens(items: string[], context: KeychainReadContext 
     return result;
   }
   const bin = getKeychainHelperPath();
-  const child = spawnSync(bin, ['get-batch', os.userInfo().username, ...storageItems], {
-    env: {
-      ...process.env,
-      AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
-      AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
-      AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
-      // The signed helper's own vocabulary is unchanged (it predates the rename
-      // and ships as a separately-versioned binary), so map to its legacy token.
-      AGENTS_KEYCHAIN_DEFAULT_POLICY: (context.defaultPolicy ?? 'hold') === 'hold' ? 'daily' : (context.defaultPolicy as string),
-      AGENTS_KEYCHAIN_FORCE_DURATION: context.forceDuration ? '1' : '0',
-    },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  let child: ReturnType<typeof spawnSync>;
+  try {
+    child = spawnKeychainHelper(bin, ['get-batch', os.userInfo().username, ...storageItems], {
+      env: {
+        ...process.env,
+        AGENTS_KEYCHAIN_PROMPT: keychainOperationPrompt(context),
+        AGENTS_KEYCHAIN_PROMPT_BASE: keychainOperationPrompt({ ...context, duration: undefined }),
+        AGENTS_KEYCHAIN_SKIP_AUTH_UI: context.silentNoAcl ? '1' : '0',
+        // The signed helper's own vocabulary is unchanged (it predates the rename
+        // and ships as a separately-versioned binary), so map to its legacy token.
+        AGENTS_KEYCHAIN_DEFAULT_POLICY: (context.defaultPolicy ?? 'hold') === 'hold' ? 'daily' : (context.defaultPolicy as string),
+        AGENTS_KEYCHAIN_FORCE_DURATION: context.forceDuration ? '1' : '0',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
+  } catch (err) {
+    // One back-off memo covers the whole batch (like a cancel below): a wedged
+    // coreauthd keeps timing out, so suppress the next retry (RUSH-2231).
+    if (err instanceof KeychainHelperTimeoutError && !context.silentNoAcl) noteKeychainReadFailure(backoffKey);
+    throw err;
+  }
   if (child.status !== 0 && !context.silentNoAcl) noteKeychainReadFailure(backoffKey);
   if (child.status === 4) {
     throw new Error(`Touch ID cancelled while reading ${items.length} keychain item(s).`);
@@ -1199,10 +1313,10 @@ export function setKeychainToken(item: string, value: string, opts?: { noAcl?: b
   // re-notarized helper; an older pinned helper dies with "Unknown command:
   // set-no-acl" (exit 2), surfaced below — never a silent ACL'd downgrade.
   const helperCmd = opts?.noAcl ? 'set-no-acl' : 'set';
-  const result = spawnSync(bin, [helperCmd, item, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, [helperCmd, item, os.userInfo().username], {
     input: value,
     stdio: ['pipe', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     if (opts?.noAcl && /unknown command/i.test(msg ?? '')) {
@@ -1229,9 +1343,9 @@ export function deleteKeychainToken(item: string): boolean {
   if (isLinux()) return linuxBackend.delete(item);
   if (isWindows()) return windowsBackend.delete(item);
   const bin = getKeychainHelperPath();
-  const deleted = spawnSync(bin, ['delete', item, os.userInfo().username], {
+  const deleted = spawnKeychainHelper(bin, ['delete', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }).status === 0;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
   // A deleted item must fail its next read as plain "not found", not with a
   // stale back-off error left over from a pre-delete cancel.
   if (deleted) clearKeychainReadBackoff(requested);
@@ -1267,9 +1381,9 @@ export function listKeychainItems(prefix: string): string[] {
   if (isLinux()) return apply(linuxBackend.list(mapped.prefix));
   if (isWindows()) return apply(windowsBackend.list(mapped.prefix));
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list', mapped.prefix], {
+  const result = spawnKeychainHelper(bin, ['list', mapped.prefix], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate keychain items with prefix '${prefix}'.`);
@@ -1293,9 +1407,9 @@ export function listLegacyKeychainItems(prefix: string): string[] {
   assertSupportedPlatform();
   if (isLinux()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list-legacy', prefix], {
+  const result = spawnKeychainHelper(bin, ['list-legacy', prefix], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate legacy keychain items with prefix '${prefix}'.`);
@@ -1340,9 +1454,9 @@ export function listSyncedKeychainItems(prefix: string): string[] {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list-synced', prefix], {
+  const result = spawnKeychainHelper(bin, ['list-synced', prefix], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate iCloud keychain items with prefix '${prefix}'.`);
@@ -1365,9 +1479,9 @@ export function getSyncedKeychainTokens(items: string[]): Map<string, string> {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return result;
   const bin = getKeychainHelperPath();
-  const child = spawnSync(bin, ['get-batch-synced', os.userInfo().username, ...items], {
+  const child = spawnKeychainHelper(bin, ['get-batch-synced', os.userInfo().username, ...items], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
   if (child.status === 4) {
     throw new Error(`Auth cancelled while reading ${items.length} iCloud keychain item(s).`);
   }
@@ -1391,9 +1505,9 @@ export function deleteSyncedKeychainItem(item: string): boolean {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return false;
   const bin = getKeychainHelperPath();
-  return spawnSync(bin, ['delete-synced', item, os.userInfo().username], {
+  return spawnKeychainHelper(bin, ['delete-synced', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }).status === 0;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
 }
 
 /**
@@ -1410,9 +1524,9 @@ export function migrateKeychainItem(item: string): boolean {
   if (isLinux()) return linuxBackend.has(item);
   if (isWindows()) return windowsBackend.has(item);
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['migrate-acl', item, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, ['migrate-acl', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
   if (result.status === 0) return true;
   if (result.status === 1) return false;
   const msg = result.stderr?.toString().trim();
@@ -1431,9 +1545,9 @@ export function listOrphanedKeychainItems(prefix: string): string[] {
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['list-orphans', prefix, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, ['list-orphans', prefix, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();
     throw new Error(msg || `Failed to enumerate orphaned keychain items with prefix '${prefix}'.`);
@@ -1494,9 +1608,9 @@ export function migrateOrphanedKeychainItems(prefix: string): OrphanMigrationRes
   assertSupportedPlatform();
   if (isLinux() || isWindows()) return [];
   const bin = getKeychainHelperPath();
-  const result = spawnSync(bin, ['migrate-orphans', prefix, os.userInfo().username], {
+  const result = spawnKeychainHelper(bin, ['migrate-orphans', prefix, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }, KEYCHAIN_INTERACTIVE_TIMEOUT_MS);
   if (result.status === 4) throw new Error('Touch ID cancelled during orphan migration.');
   if (result.status !== 0) {
     const msg = result.stderr?.toString().trim();

--- a/apps/cli/src/lib/secrets/install-helper.ts
+++ b/apps/cli/src/lib/secrets/install-helper.ts
@@ -46,6 +46,18 @@ function installedExecutablePath(): string {
 }
 
 /**
+ * The installed helper's executable path WITHOUT any install side effect —
+ * unlike {@link getKeychainHelperPath}, this never copies or re-signs the
+ * bundle. The reaper (`reaper.ts`) needs the path to exact-match against a `ps`
+ * snapshot; a missing install just means no process matches (nothing to reap),
+ * so triggering an install from a cleanup sweep would be wrong. Pure path math
+ * (no darwin assertion) so it is callable from the platform-agnostic reaper.
+ */
+export function getInstalledKeychainHelperExecPath(): string {
+  return installedExecutablePath();
+}
+
+/**
  * Locate the source `.app` bundle shipped alongside the compiled JS.
  *
  * Resolution order:

--- a/apps/cli/src/lib/secrets/reaper.test.ts
+++ b/apps/cli/src/lib/secrets/reaper.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import {
+  planKeychainReap,
+  parseEtimeSecs,
+  parsePsSnapshot,
+  reapOrphanedKeychainProcesses,
+  KEYCHAIN_ORPHAN_GRACE_SECS,
+  KEYCHAIN_STUCK_CHILD_SECS,
+  type KeychainProcSnapshot,
+  type KeychainReapCandidate,
+} from './reaper.js';
+import { isAlive } from '../platform/index.js';
+
+const HELPER = '/Users/x/Library/Application Support/agents-cli/Agents CLI.app/Contents/MacOS/Agents CLI';
+
+function helperProc(over: Partial<KeychainProcSnapshot>): KeychainProcSnapshot {
+  return { pid: 100, ppid: 1, elapsedSecs: 120, command: HELPER, startTime: 'st-100', ...over };
+}
+
+describe('parseEtimeSecs', () => {
+  it('parses mm:ss', () => expect(parseEtimeSecs('05:32')).toBe(5 * 60 + 32));
+  it('parses hh:mm:ss', () => expect(parseEtimeSecs('01:05:32')).toBe(3600 + 5 * 60 + 32));
+  it('parses dd-hh:mm:ss', () => expect(parseEtimeSecs('2-03:04:05')).toBe(((2 * 24 + 3) * 60 + 4) * 60 + 5));
+  it('tolerates surrounding whitespace', () => expect(parseEtimeSecs('  00:45 ')).toBe(45));
+  it('returns null on garbage', () => {
+    expect(parseEtimeSecs('')).toBeNull();
+    expect(parseEtimeSecs('nope')).toBeNull();
+    expect(parseEtimeSecs('12')).toBeNull();
+  });
+});
+
+describe('parsePsSnapshot', () => {
+  it('parses columns and keeps a space-containing command whole', () => {
+    const out = [
+      `  100     1 02:00 ${HELPER}`,
+      ` 2000  1500 00:30 /usr/bin/node`,
+      '', // blank line ignored
+    ].join('\n');
+    const rows = parsePsSnapshot(out);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ pid: 100, ppid: 1, elapsedSecs: 120, command: HELPER, startTime: null });
+    expect(rows[1]).toMatchObject({ pid: 2000, ppid: 1500, elapsedSecs: 30, command: '/usr/bin/node' });
+  });
+  it('skips unparseable lines', () => {
+    expect(parsePsSnapshot('garbage\n  x y z w')).toHaveLength(0);
+  });
+});
+
+describe('planKeychainReap — class (a) orphaned helper', () => {
+  it('reaps PPID==1 + path-match + older than grace', () => {
+    const plan = planKeychainReap([helperProc({ pid: 100, ppid: 1, elapsedSecs: KEYCHAIN_ORPHAN_GRACE_SECS + 1 })], HELPER);
+    expect(plan.kills).toHaveLength(1);
+    expect(plan.kills[0]).toMatchObject({ pid: 100, role: 'orphaned-helper' });
+  });
+  it('does NOT reap within the grace window', () => {
+    const plan = planKeychainReap([helperProc({ ppid: 1, elapsedSecs: KEYCHAIN_ORPHAN_GRACE_SECS })], HELPER);
+    expect(plan.kills).toHaveLength(0);
+  });
+  it('does NOT reap a path mismatch even at PPID 1', () => {
+    const plan = planKeychainReap([helperProc({ command: '/usr/bin/node', ppid: 1, elapsedSecs: 999 })], HELPER);
+    expect(plan.kills).toHaveLength(0);
+  });
+  it('fails closed when start-time could not be captured', () => {
+    const plan = planKeychainReap([helperProc({ ppid: 1, elapsedSecs: 999, startTime: null })], HELPER);
+    expect(plan.kills).toHaveLength(0);
+  });
+  it('fails closed when the age is unknowable', () => {
+    const plan = planKeychainReap([helperProc({ ppid: 1, elapsedSecs: null })], HELPER);
+    expect(plan.kills).toHaveLength(0);
+  });
+});
+
+describe('planKeychainReap — class (b) stuck helper child of a live parent', () => {
+  const parent = { pid: 500, ppid: 1, elapsedSecs: 300, command: '/usr/bin/node', startTime: 'st-500' };
+  const child = helperProc({ pid: 100, ppid: 500, elapsedSecs: KEYCHAIN_STUCK_CHILD_SECS + 5 });
+
+  it('single sweep: records a candidate, kills nothing (debounce)', () => {
+    const plan = planKeychainReap([parent, child], HELPER, []);
+    expect(plan.kills).toHaveLength(0);
+    expect(plan.nextCandidates).toHaveLength(1);
+    expect(plan.nextCandidates[0]).toMatchObject({ childPid: 100, parentPid: 500, stage: 'sighted' });
+  });
+
+  it('second sweep: kills the child (frees the parent), carries a child-killed record', () => {
+    const prev: KeychainReapCandidate[] = [
+      { childPid: 100, childStartTime: 'st-100', parentPid: 500, parentStartTime: 'st-500', stage: 'sighted' },
+    ];
+    const plan = planKeychainReap([parent, child], HELPER, prev);
+    expect(plan.kills).toHaveLength(1);
+    expect(plan.kills[0]).toMatchObject({ pid: 100, role: 'stuck-helper-child' });
+    expect(plan.nextCandidates).toEqual([
+      expect.objectContaining({ parentPid: 500, parentStartTime: 'st-500', stage: 'child-killed' }),
+    ]);
+  });
+
+  it('never reaps a live parent that owns NO helper child (a normal long session)', () => {
+    const normalParent = { pid: 500, ppid: 1, elapsedSecs: 99999, command: '/usr/bin/node', startTime: 'st-500' };
+    const plan = planKeychainReap([normalParent], HELPER, []);
+    expect(plan.kills).toHaveLength(0);
+    expect(plan.nextCandidates).toHaveLength(0);
+  });
+
+  it('does NOT treat a young helper child as stuck', () => {
+    const young = helperProc({ pid: 100, ppid: 500, elapsedSecs: KEYCHAIN_STUCK_CHILD_SECS });
+    const plan = planKeychainReap([parent, young], HELPER, []);
+    expect(plan.kills).toHaveLength(0);
+    expect(plan.nextCandidates).toHaveLength(0);
+  });
+
+  it('does NOT reap a child whose parent is absent from the snapshot', () => {
+    const plan = planKeychainReap([child], HELPER, []); // no parent pid 500
+    expect(plan.kills).toHaveLength(0);
+    expect(plan.nextCandidates).toHaveLength(0);
+  });
+
+  it('escalates to the parent when it stays wedged a sweep after the child kill', () => {
+    const prev: KeychainReapCandidate[] = [
+      { childPid: 100, childStartTime: 'st-old', parentPid: 500, parentStartTime: 'st-500', stage: 'child-killed' },
+    ];
+    // The parent (still alive, same fingerprint) STILL owns an old helper child.
+    const newChild = helperProc({ pid: 101, ppid: 500, elapsedSecs: KEYCHAIN_STUCK_CHILD_SECS + 5, startTime: 'st-101' });
+    const plan = planKeychainReap([parent, newChild], HELPER, prev);
+    expect(plan.kills.some((k) => k.pid === 500 && k.role === 'stuck-parent')).toBe(true);
+  });
+
+  it('does NOT escalate when the parent recovered (no stuck child remains)', () => {
+    const prev: KeychainReapCandidate[] = [
+      { childPid: 100, childStartTime: 'st-old', parentPid: 500, parentStartTime: 'st-500', stage: 'child-killed' },
+    ];
+    const plan = planKeychainReap([parent], HELPER, prev); // parent alive, no helper child now
+    expect(plan.kills).toHaveLength(0);
+  });
+
+  it('does NOT escalate to a reused parent pid (start-time changed)', () => {
+    const prev: KeychainReapCandidate[] = [
+      { childPid: 100, childStartTime: 'st-old', parentPid: 500, parentStartTime: 'st-500', stage: 'child-killed' },
+    ];
+    const reusedParent = { pid: 500, ppid: 1, elapsedSecs: 300, command: '/usr/bin/node', startTime: 'st-DIFFERENT' };
+    const newChild = helperProc({ pid: 101, ppid: 500, elapsedSecs: 999, startTime: 'st-101' });
+    const plan = planKeychainReap([reusedParent, newChild], HELPER, prev);
+    expect(plan.kills.some((k) => k.pid === 500)).toBe(false);
+  });
+});
+
+describe('reapOrphanedKeychainProcesses (impure)', () => {
+  it('is a no-op off darwin', () => {
+    if (process.platform === 'darwin') return; // real behavior is exercised below on darwin
+    const r = reapOrphanedKeychainProcesses();
+    expect(r).toEqual({ reaped: 0, killed: [], nextCandidates: [] });
+  });
+
+  it.runIf(process.platform === 'darwin')('does not touch a normal (non-helper) process', () => {
+    // A real, harmless sleeper whose command is NOT the helper path must survive.
+    const child = spawn('sleep', ['5'], { stdio: 'ignore' });
+    try {
+      const r = reapOrphanedKeychainProcesses();
+      expect(r.killed.some((k) => k.pid === child.pid)).toBe(false);
+      expect(isAlive(child.pid!)).toBe(true);
+    } finally {
+      child.kill('SIGKILL');
+    }
+  });
+});

--- a/apps/cli/src/lib/secrets/reaper.ts
+++ b/apps/cli/src/lib/secrets/reaper.ts
@@ -1,0 +1,297 @@
+/**
+ * Reaper for orphaned macOS keychain-helper processes and `agents` procs stuck
+ * on a keychain call (RUSH-2232, Layer 3 of RUSH-2229).
+ *
+ * The failure it cleans up: a wedged `coreauthd` XPC hangs the signed keychain
+ * helper (`Agents CLI.app`) mid-read. Before Layer 1 (RUSH-2231) bounded every
+ * helper `spawnSync`, the parent `agents` process blocked forever; when that
+ * parent then died, the helper reparented to PID 1 and kept hanging. Dozens of
+ * such orphans plus their `<defunct>` zombies pile up and make the machine
+ * sluggish. Layer 1 stops NEW pileups at the source; this reaper clears the
+ * BACKLOG (and any straggler that outlives its bound), running from the daemon
+ * on a 5-minute tick (the "one executor" rule — CLAUDE.md §Scheduling).
+ *
+ * The planner {@link planKeychainReap} is PURE (no `ps`, no clock, no kill) so
+ * every reap class and every never-reap guard is unit-testable without a real
+ * process. {@link reapOrphanedKeychainProcesses} is the thin impure shell: it
+ * runs `ps` once, fingerprints only the pids it might act on with
+ * {@link captureProcessStartTime} (pid-reuse guard), plans, and kills via
+ * {@link killTree}. Mirrors `isExpiredPoolStray` (crabbox/lease.ts) in shape.
+ */
+
+import { spawnSync } from 'child_process';
+import { captureProcessStartTime, killTree } from '../platform/index.js';
+import { getInstalledKeychainHelperExecPath } from './install-helper.js';
+
+/** Idle grace before an orphaned (PPID==1) helper is reaped — a helper mid-boot
+ *  is not yet stuck. */
+export const KEYCHAIN_ORPHAN_GRACE_SECS = 30;
+
+/** Age (> Layer-1's 60s interactive timeout) at which a helper child of a LIVE
+ *  parent counts as stuck: a healthy read returns well inside the bound, so a
+ *  helper child this old means the parent's `spawnSync` is not returning. */
+export const KEYCHAIN_STUCK_CHILD_SECS = 90;
+
+/** One row of the `ps` snapshot the planner reasons over. Platform-agnostic so
+ *  the planner is testable off darwin. */
+export interface KeychainProcSnapshot {
+  pid: number;
+  ppid: number;
+  /** Seconds since the process started (`ps` etime), or null if unparseable —
+   *  an unknowable age is never old enough to reap (fail closed). */
+  elapsedSecs: number | null;
+  /** The executable path (`ps` comm), exact-matched against the helper path. */
+  command: string;
+  /** A stable start-time fingerprint for pid-reuse safety across sweeps
+   *  ({@link captureProcessStartTime}), or null when it could not be captured —
+   *  a proc with no fingerprint is NEVER reaped (fail closed). Only populated
+   *  for pids the reaper might act on (helper procs and their parents). */
+  startTime: string | null;
+}
+
+/** A stuck helper-child carried between sweeps to debounce a racy `ps` snapshot.
+ *  `stage` advances: first sighting → `sighted` (no kill); still there next
+ *  sweep → the child is killed and the record flips to `child-killed`, which
+ *  survives ONE more sweep to allow escalating to a genuinely wedged parent. */
+export interface KeychainReapCandidate {
+  childPid: number;
+  childStartTime: string;
+  parentPid: number;
+  parentStartTime: string | null;
+  stage: 'sighted' | 'child-killed';
+}
+
+/** One process the plan says to kill this sweep. */
+export interface KeychainReapKill {
+  pid: number;
+  startTime: string;
+  role: 'orphaned-helper' | 'stuck-helper-child' | 'stuck-parent';
+  reason: string;
+}
+
+export interface KeychainReapPlan {
+  /** Processes to SIGKILL this sweep (children before parents by construction —
+   *  a parent is only ever escalated on a LATER sweep than its child's kill). */
+  kills: KeychainReapKill[];
+  /** Candidates to feed back as `prevCandidates` on the next sweep. Bounded by
+   *  the number of currently-stuck helper procs; never accumulates. */
+  nextCandidates: KeychainReapCandidate[];
+}
+
+export interface KeychainReapOptions {
+  orphanGraceSecs?: number;
+  stuckChildSecs?: number;
+}
+
+/**
+ * Decide which keychain-related processes to reap this sweep. Pure.
+ *
+ * Two conservative reap classes:
+ *
+ *  (a) Orphaned helper — a proc whose command exactly matches `helperPath`, with
+ *      PPID==1 (its parent already died, so nothing will ever reap it) and an
+ *      age past the idle grace. Reaped immediately (no debounce needed: PPID==1
+ *      is a durable, unambiguous "orphaned" signal).
+ *
+ *  (b) Stuck parent's helper child — a helper proc with a LIVE parent (PPID!=1,
+ *      the parent pid present in the snapshot) that is older than the stuck
+ *      threshold. Two-sweep debounced against a racy `ps` snapshot: first
+ *      sighting is only recorded; a second consecutive sighting kills the CHILD
+ *      (which frees the parent's blocked `spawnSync`). If, a sweep after that,
+ *      the SAME parent still owns an old helper child, the parent is genuinely
+ *      wedged and is escalated (killed).
+ *
+ * Never reaped (fail closed): a proc with a null start-time fingerprint, a
+ * command that is not an exact match for `helperPath`, or a normal `agents`
+ * session that owns no keychain-helper child.
+ */
+export function planKeychainReap(
+  snapshots: readonly KeychainProcSnapshot[],
+  helperPath: string,
+  prevCandidates: readonly KeychainReapCandidate[] = [],
+  opts: KeychainReapOptions = {},
+): KeychainReapPlan {
+  const orphanGrace = opts.orphanGraceSecs ?? KEYCHAIN_ORPHAN_GRACE_SECS;
+  const stuckSecs = opts.stuckChildSecs ?? KEYCHAIN_STUCK_CHILD_SECS;
+  const kills: KeychainReapKill[] = [];
+  const nextCandidates: KeychainReapCandidate[] = [];
+
+  const byPid = new Map<number, KeychainProcSnapshot>();
+  for (const s of snapshots) byPid.set(s.pid, s);
+  const isHelper = (s: KeychainProcSnapshot | undefined): boolean => !!s && s.command === helperPath;
+
+  const helpers = snapshots.filter((s) => s.command === helperPath);
+
+  // (a) Orphaned helpers — immediate.
+  for (const s of helpers) {
+    if (s.ppid !== 1) continue;
+    if (s.startTime === null) continue; // fail closed: no fingerprint, no kill
+    if (s.elapsedSecs === null || s.elapsedSecs <= orphanGrace) continue;
+    kills.push({
+      pid: s.pid,
+      startTime: s.startTime,
+      role: 'orphaned-helper',
+      reason: `orphaned keychain helper (PPID 1) alive ${s.elapsedSecs}s (> ${orphanGrace}s grace)`,
+    });
+  }
+
+  // (b) Stuck helper children of a live parent — two-sweep debounced.
+  for (const s of helpers) {
+    if (s.ppid === 1) continue; // handled by (a)
+    if (s.startTime === null) continue; // fail closed
+    if (s.elapsedSecs === null || s.elapsedSecs <= stuckSecs) continue;
+    const parent = byPid.get(s.ppid);
+    if (!parent) continue; // parent not live in this snapshot — nothing to free
+    const seen = prevCandidates.find(
+      (c) => c.stage === 'sighted' && c.childPid === s.pid && c.childStartTime === s.startTime,
+    );
+    if (seen) {
+      // Second consecutive sighting: kill the child, freeing the parent's
+      // blocked spawnSync. Carry a record so a still-wedged parent escalates.
+      kills.push({
+        pid: s.pid,
+        startTime: s.startTime,
+        role: 'stuck-helper-child',
+        reason: `keychain helper child of live agents pid ${s.ppid} stuck ${s.elapsedSecs}s (> ${stuckSecs}s), two sweeps`,
+      });
+      nextCandidates.push({
+        childPid: s.pid,
+        childStartTime: s.startTime,
+        parentPid: s.ppid,
+        parentStartTime: parent.startTime,
+        stage: 'child-killed',
+      });
+    } else {
+      // First sighting: record only, do not kill (debounce a racy snapshot).
+      nextCandidates.push({
+        childPid: s.pid,
+        childStartTime: s.startTime,
+        parentPid: s.ppid,
+        parentStartTime: parent.startTime,
+        stage: 'sighted',
+      });
+    }
+  }
+
+  // (b, escalation) A parent whose child we killed last sweep but which STILL
+  // owns an old helper child is genuinely wedged — kill the parent. Pid-reuse
+  // guarded on the parent's fingerprint; a recovered/exited parent is dropped.
+  for (const c of prevCandidates) {
+    if (c.stage !== 'child-killed') continue;
+    const parent = byPid.get(c.parentPid);
+    if (!parent) continue; // parent gone — it recovered or exited
+    if (parent.startTime === null || parent.startTime !== c.parentStartTime) continue; // reuse: fail closed
+    const stillStuck = snapshots.some(
+      (h) =>
+        h.ppid === c.parentPid &&
+        isHelper(h) &&
+        h.startTime !== null &&
+        h.elapsedSecs !== null &&
+        h.elapsedSecs > stuckSecs,
+    );
+    if (stillStuck) {
+      kills.push({
+        pid: c.parentPid,
+        startTime: parent.startTime,
+        role: 'stuck-parent',
+        reason: `agents pid ${c.parentPid} still wedged on a keychain read a sweep after its helper child was killed`,
+      });
+    }
+    // else: parent recovered — drop (do not re-carry).
+  }
+
+  return { kills, nextCandidates };
+}
+
+/**
+ * `ps` etime → seconds. Format is `[[dd-]hh:]mm:ss`. Returns null on any shape
+ * it does not recognize (an unknowable age fails closed in the planner).
+ */
+export function parseEtimeSecs(etime: string): number | null {
+  const m = etime.trim().match(/^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/);
+  if (!m) return null;
+  const days = m[1] ? parseInt(m[1], 10) : 0;
+  const hours = m[2] ? parseInt(m[2], 10) : 0;
+  const mins = parseInt(m[3], 10);
+  const secs = parseInt(m[4], 10);
+  return ((days * 24 + hours) * 60 + mins) * 60 + secs;
+}
+
+/**
+ * Parse `ps -Ao pid=,ppid=,etime=,comm=` output. `comm` is LAST because on
+ * darwin it is the full executable path and may contain spaces (the helper lives
+ * under "Application Support/agents-cli/Agents CLI.app/…"); everything after the
+ * three leading numeric/token columns is the command. Rows that don't parse are
+ * skipped. `startTime` is left null here — the impure layer fills it in for only
+ * the pids that might be acted on.
+ */
+export function parsePsSnapshot(out: string): KeychainProcSnapshot[] {
+  const rows: KeychainProcSnapshot[] = [];
+  for (const line of out.split('\n')) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+    if (!m) continue;
+    rows.push({
+      pid: parseInt(m[1], 10),
+      ppid: parseInt(m[2], 10),
+      elapsedSecs: parseEtimeSecs(m[3]),
+      command: m[4],
+      startTime: null,
+    });
+  }
+  return rows;
+}
+
+export interface KeychainReapResult {
+  /** How many processes were killed this sweep. */
+  reaped: number;
+  killed: KeychainReapKill[];
+  /** Feed back as `prevCandidates` on the next sweep. */
+  nextCandidates: KeychainReapCandidate[];
+}
+
+/**
+ * Run one reap sweep. macOS only (the keychain helper exists only there); a
+ * no-op returning an empty result on every other platform. Best-effort: a `ps`
+ * failure yields an empty sweep, never throws — the daemon tick must not crash
+ * on a flaky snapshot.
+ */
+export function reapOrphanedKeychainProcesses(
+  prevCandidates: readonly KeychainReapCandidate[] = [],
+  opts: KeychainReapOptions = {},
+): KeychainReapResult {
+  const empty: KeychainReapResult = { reaped: 0, killed: [], nextCandidates: [] };
+  if (process.platform !== 'darwin') return empty;
+
+  let out: string;
+  try {
+    const ps = spawnSync('ps', ['-Ao', 'pid=,ppid=,etime=,comm='], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      killSignal: 'SIGKILL',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    if (ps.status !== 0 || typeof ps.stdout !== 'string') return empty;
+    out = ps.stdout;
+  } catch {
+    return empty;
+  }
+
+  const helperPath = getInstalledKeychainHelperExecPath();
+  const rows = parsePsSnapshot(out);
+
+  // Fingerprint only the pids the planner might act on: helper procs and the
+  // parents of helper procs. Everything else keeps startTime=null (ignored).
+  const helperPids = new Set<number>();
+  for (const r of rows) if (r.command === helperPath) helperPids.add(r.pid);
+  const needFingerprint = new Set<number>(helperPids);
+  for (const r of rows) if (helperPids.has(r.pid)) needFingerprint.add(r.ppid);
+
+  const snapshots = rows.map((r) =>
+    needFingerprint.has(r.pid) ? { ...r, startTime: captureProcessStartTime(r.pid) } : r,
+  );
+
+  const plan = planKeychainReap(snapshots, helperPath, prevCandidates, opts);
+  for (const k of plan.kills) killTree(k.pid);
+  return { reaped: plan.kills.length, killed: plan.kills, nextCandidates: plan.nextCandidates };
+}


### PR DESCRIPTION
**fix (behavior) — no user-facing command/flag change.** Bounds every macOS keychain-helper spawn and adds a daemon reaper so a wedged `coreauthd` can no longer pile up `agents` processes. Ships RUSH-2231 (Layer 1) + RUSH-2232 (Layer 3) of RUSH-2229 together.

## Problem
A stalled `coreauthd` hangs the signed keychain helper's XPC receive forever. Before this, every secrets-touching `agents` command blocked on an unbounded `spawnSync`, and when the parent later died the helper reparented to PID 1 and kept hanging — dozens of live helpers plus their `<defunct>` zombies accumulated and made the machine sluggish.

## What changed

**Layer 1 (RUSH-2231) — bound every helper spawn.** One shared `spawnKeychainHelper()` wrapper (no 13 copies) wraps all 13 helper verbs **and** the 2 silent `/usr/bin/security` probes with `{ timeout, killSignal: 'SIGKILL' }` — SIGKILL because the hang is a Mach `mach_msg` receive that ignores SIGTERM. Two buckets:
- `KEYCHAIN_SILENT_TIMEOUT_MS = 8_000` — never-prompt verbs (`has`/`set`/`set-no-acl`/`delete`/`list`/`list-legacy`/`list-synced`/`delete-synced`/`list-orphans`).
- `KEYCHAIN_INTERACTIVE_TIMEOUT_MS = 60_000` — may-prompt verbs, all gated by `assertRawKeychainReadAllowed` (`get`/`get-batch`/`get-batch-synced`/`migrate-acl`/`migrate-orphans`), plus the `/usr/bin/security -w` read (a legacy item could pop a sheet a user must answer).

A timeout throws a typed `KeychainHelperTimeoutError`; `getKeychainToken`/`getKeychainTokens` catch it and arm the read back-off before rethrowing so a still-wedged `coreauthd` keeps failing fast. The `/usr/bin/security` add-generic-password **write** path already had `timeout: 10_000` (the in-file precedent) and is left unchanged.

**Layer 3 (RUSH-2232) — reap the backlog.** New `secrets/reaper.ts`:
- **Pure** `planKeychainReap(snapshots, helperPath, prevCandidates)` (mirrors `isExpiredPoolStray`) — unit-testable with no `ps`/clock/kill.
- **Impure** `reapOrphanedKeychainProcesses()` — shells `ps` once, fingerprints only the pids it might act on via `captureProcessStartTime` (pid-reuse guard), kills via `killTree`.

Two conservative reap classes:
- **(a) Orphaned helper** — exact path match to the installed helper, `PPID==1`, older than a 30s grace → reap immediately.
- **(b) Stuck `agents` proc** — a helper child of a live parent older than 90s (> Layer-1's interactive bound), **two-sweep debounced** against a racy snapshot: first sighting records only, second kills the **child first** (freeing the parent's `spawnSync`), escalating to the parent only if it stays wedged.

Never reaps a proc whose start-time can't be captured (**fail closed**), a path mismatch, or a normal `agents` session with no helper child. Runs on a 5-min daemon tick beside `runBrokerSelfHeal`, overlap-guarded, cleared in `handleShutdown`; the debounce state lives in memory across ticks (the daemon is the sole executor). Every keychain touch also opportunistically boots the daemon (once per process, macOS-only, fire-and-forget) so the reaper comes online even on a secrets-only box (e.g. a SessionStart hook doing `secrets get`).

## Scope
`OWNS`: `secrets/index.ts`, `secrets/reaper.ts` (new), the reaper tick in `daemon.ts` (+ a small non-installing path getter in `install-helper.ts`). Did **not** touch `session/*`, `keychain-helper.swift`, or the session-warming tick in `daemon.ts`. The SEC-* bounded-spawn **spec** requirement is tracked separately (RUSH-2235), so no `specifications.md` edit here; the change preserves SEC-6/7/11/13/14/16 (SEC-16: throwing an actionable error is correct, not a swallowed no-op). No command/flag/config surface changed, so no reference-doc edit is needed; behavior is noted in the CHANGELOG fragment.

## Run result (real path, no mocking)

`vitest run src/lib/secrets/reaper.test.ts src/lib/secrets/index.test.ts` → **65 passed, 1 skipped** (the darwin-only integration test; suite runs on Linux CI). Wider check: `daemon.test.ts` + all of `secrets/` → **643 passed**.

Behavior demo (real hung child + pure planner), quoted output:

```
[Layer 1] threw KeychainHelperTimeoutError after 503ms (bound=500ms)
[Layer 1] message: Keychain helper timed out after 1s (keychain locked / LocalAuthentication unresponsive) — retry; if it persists, lock/unlock the screen or reboot.
[Layer 1] typed error? true
[Layer 3] orphaned helper pid 4242 -> [{"pid":4242,"role":"orphaned-helper","reason":"orphaned keychain helper (PPID 1) alive 120s (> 30s grace)"}]
[Layer 3] stuck child sweep 1 (debounce): kills=0 nextCandidates=1
[Layer 3] stuck child sweep 2 (confirmed) -> [{"pid":100,"role":"stuck-helper-child","reason":"keychain helper child of live agents pid 500 stuck 220s (> 90s), two sweeps"}]
```

Tickets: RUSH-2231, RUSH-2232 (parent RUSH-2229).
