### PR TITLE
fix(cli): feed SQLITE_BUSY degrade + events filter-before-limit (RUSH-2006, RUSH-2093)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2006-2093.md
+++ b/apps/cli/.changelog/next/RUSH-2006-2093.md
@@ -1,0 +1,13 @@
+- **`agents feed` no longer crashes when the session index is locked (RUSH-2006).**
+  Outcome enrichment calls `discoverSessions` against `sessions.db`; under concurrent
+  scanner/daemon pressure that open can throw `SQLITE_BUSY` / "database is locked"
+  and take down the whole feed. A lock error now degrades to an empty meta set with a
+  stderr warning so blocks still render. Source: `apps/cli/src/commands/feed.ts`.
+
+- **`agents events --event` / filtered activity reads no longer miss matches under
+  `--limit` (RUSH-2093).** The unified reader capped activity records *before*
+  applying the event-type filter, so a rare match older than the newest-N routine
+  rows (e.g. one `pr.opened` under twenty `file.edited`) was silently dropped. Event
+  types are now passed into `readRecentActivity` so the cap counts matching rows; a
+  non-`activity` `--module` skips the activity half entirely. Source:
+  `apps/cli/src/lib/event-stream.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,21 +2,6 @@
 
 ## 1.22.22
 
-- **`agents feed` no longer crashes when the session index is locked.** Outcome
-  enrichment calls `discoverSessions` against `sessions.db`; under concurrent
-  scanner/daemon pressure that open can throw `SQLITE_BUSY` / "database is
-  locked" and take down the whole feed. A lock error now degrades to an empty
-  meta set with a stderr warning so blocks still render (RUSH-2006). Source:
-  `apps/cli/src/commands/feed.ts`.
-
-- **`agents events --event` / filtered activity reads no longer miss matches
-  under `--limit`.** The unified reader capped activity records *before*
-  applying the event-type filter, so a rare match older than the newest-N
-  routine rows (e.g. one `pr.opened` under twenty `file.edited`) was silently
-  dropped. Event types are now passed into `readRecentActivity` so the cap
-  counts matching rows; a non-`activity` `--module` skips the activity half
-  entirely (RUSH-2093). Source: `apps/cli/src/lib/event-stream.ts`.
-
 - **New: `agents insights` — how you work, split by the Claude account that did the
   work.** Tool and language mix, friction (interruptions, tool-error classes, your own
   reply latency), what you changed (line deltas, files, commits), an hour-of-day

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 1.22.22
 
+- **`agents feed` no longer crashes when the session index is locked.** Outcome
+  enrichment calls `discoverSessions` against `sessions.db`; under concurrent
+  scanner/daemon pressure that open can throw `SQLITE_BUSY` / "database is
+  locked" and take down the whole feed. A lock error now degrades to an empty
+  meta set with a stderr warning so blocks still render (RUSH-2006). Source:
+  `apps/cli/src/commands/feed.ts`.
+
+- **`agents events --event` / filtered activity reads no longer miss matches
+  under `--limit`.** The unified reader capped activity records *before*
+  applying the event-type filter, so a rare match older than the newest-N
+  routine rows (e.g. one `pr.opened` under twenty `file.edited`) was silently
+  dropped. Event types are now passed into `readRecentActivity` so the cap
+  counts matching rows; a non-`activity` `--module` skips the activity half
+  entirely (RUSH-2093). Source: `apps/cli/src/lib/event-stream.ts`.
+
 - **New: `agents insights` — how you work, split by the Claude account that did the
   work.** Tool and language mix, friction (interruptions, tool-error classes, your own
   reply latency), what you changed (line deltas, files, commits), an hour-of-day

--- a/apps/cli/docs/06-observability.md
+++ b/apps/cli/docs/06-observability.md
@@ -326,7 +326,11 @@ raw records for external consumers.
 **`--limit` caps the read at 50 records by default — pass `--limit 0` before you
 aggregate.** The cap keeps an interactive `agents events` readable, but it is
 applied *after* filtering and *before* you see the records, so a group-by over a
-capped `--json` read ranks the newest 50 rather than the real set. On a 30-day
+capped `--json` read ranks the newest 50 rather than the real set. That
+filter-before-cap contract covers both halves of the unified stream: operational
+events (and their `bundle` / module filters) and agent-semantic activity events
+(`--event` / event-type filters are pushed into the activity reader so a rare
+match is not buried under routine `file.edited` churn — RUSH-2093). On a 30-day
 stream here that is 50 records out of 29,649. When a read is capped, the command
 says so — on stderr for `--json` (so a `| jq` pipeline still gets clean JSON), on
 stdout for the human view:

--- a/apps/cli/src/commands/feed.test.ts
+++ b/apps/cli/src/commands/feed.test.ts
@@ -7,6 +7,8 @@ import {
   formatFeedMastheadRight,
   formatFeedReplyHint,
   formatOutcomeHeader,
+  isSqliteBusyError,
+  loadSessionMetasForFeedEnrichment,
   mergeFeedBlocks,
   parseRemoteFeed,
   prepareLocalFeedBlocks,
@@ -112,6 +114,36 @@ describe('mergeFeedBlocks', () => {
       [block('same', 'zion', '2026-07-13T00:00:00Z')],
       [block('same', 'mac-mini', '2026-07-13T00:00:00Z')],
     )).toHaveLength(2);
+  });
+});
+
+describe('loadSessionMetasForFeedEnrichment (RUSH-2006)', () => {
+  it('recognizes SQLITE_BUSY / database-is-locked error shapes', () => {
+    expect(isSqliteBusyError(new Error('database is locked'))).toBe(true);
+    expect(isSqliteBusyError(Object.assign(new Error('busy'), { code: 'SQLITE_BUSY' }))).toBe(true);
+    expect(isSqliteBusyError(new Error('SQLITE_BUSY: database is locked'))).toBe(true);
+    expect(isSqliteBusyError(new Error('no such table: sessions'))).toBe(false);
+    expect(isSqliteBusyError(null)).toBe(false);
+  });
+
+  it('returns empty metas and skippedLock on a lock error instead of throwing', async () => {
+    // Real lock-shaped failure from the loader (no module mock). Before the
+    // guard, discoverSessions throwing here crashed `agents feed --local`.
+    const locked = await loadSessionMetasForFeedEnrichment(async () => {
+      throw Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' });
+    });
+    expect(locked).toEqual({ metas: [], skippedLock: true });
+  });
+
+  it('propagates non-lock errors so real index failures still surface', async () => {
+    await expect(loadSessionMetasForFeedEnrichment(async () => {
+      throw new Error('no such table: sessions');
+    })).rejects.toThrow(/no such table/);
+  });
+
+  it('returns loaded metas when the index is free', async () => {
+    const ok = await loadSessionMetasForFeedEnrichment(async () => [{ id: 's1' }]);
+    expect(ok).toEqual({ metas: [{ id: 's1' }], skippedLock: false });
   });
 });
 

--- a/apps/cli/src/commands/feed.ts
+++ b/apps/cli/src/commands/feed.ts
@@ -361,6 +361,41 @@ export function sessionHintsFromActive(
   }));
 }
 
+/**
+ * True when a SQLite open/query failed because another writer holds the lock.
+ * better-sqlite3 surfaces this as message "database is locked" and/or code
+ * SQLITE_BUSY (RUSH-2006).
+ */
+export function isSqliteBusyError(err: unknown): boolean {
+  if (err == null) return false;
+  const msg = err instanceof Error ? err.message : String(err);
+  const code = typeof err === 'object' && err !== null && 'code' in err
+    ? String((err as { code?: unknown }).code ?? '')
+    : '';
+  return /SQLITE_BUSY|database is locked/i.test(msg) || /SQLITE_BUSY/i.test(code);
+}
+
+/**
+ * Load session metas for feed outcome enrichment. The sessions index can be
+ * locked by a concurrent scanner/daemon — enrichment is best-effort, so a lock
+ * degrades to an empty list instead of crashing `agents feed` (RUSH-2006).
+ *
+ * `load` is injected so tests can throw a real lock-shaped error without
+ * mocking the session module.
+ */
+export async function loadSessionMetasForFeedEnrichment<T>(
+  load: () => Promise<T[]>,
+): Promise<{ metas: T[]; skippedLock: boolean }> {
+  try {
+    return { metas: await load(), skippedLock: false };
+  } catch (err) {
+    if (isSqliteBusyError(err)) {
+      return { metas: [], skippedLock: true };
+    }
+    throw err;
+  }
+}
+
 export function registerFeedCommand(program: Command): void {
   const feed = program
     .command('feed')
@@ -575,7 +610,21 @@ export function registerFeedCommand(program: Command): void {
       if (includeLocal) {
         sessions = await getActiveSessions();
       }
-      const sessionMetas = includeLocal && sessions.length > 0 ? await discoverSessions({ all: true, limit: 5000 }) : [];
+      // discoverSessions touches sessions.db; under concurrent scan pressure it
+      // can throw SQLITE_BUSY. Outcome enrichment is best-effort — degrade with
+      // a warning rather than crash the whole feed (RUSH-2006).
+      let sessionMetas: Awaited<ReturnType<typeof discoverSessions>> = [];
+      if (includeLocal && sessions.length > 0) {
+        const loaded = await loadSessionMetasForFeedEnrichment(
+          () => discoverSessions({ all: true, limit: 5000 }),
+        );
+        if (loaded.skippedLock) {
+          console.error(chalk.yellow(
+            'Feed: session index is locked; skipping local outcome enrichment',
+          ));
+        }
+        sessionMetas = loaded.metas;
+      }
       const localSignals = buildSessionSignals(sessions, sessionMetas);
 
       if (opts.pause || opts.kill) {

--- a/apps/cli/src/lib/event-stream.test.ts
+++ b/apps/cli/src/lib/event-stream.test.ts
@@ -169,4 +169,70 @@ describe('readUnifiedEvents', () => {
     expect(events[0].detail).toBe('Write tests 2/3 done');
     expect(events[0].module).toBe('activity');
   });
+
+  it('applies event-type filter BEFORE limit so a rare match survives routine churn (RUSH-2093)', () => {
+    // Mirror the activity.ts contract: without pushing eventTypes into the
+    // reader, limit:5 takes the five newest file.edited rows and the later
+    // matches() filter drops them all — silently missing the older pr.opened.
+    const { activityRoot } = setup();
+    appendActivityEvent(
+      {
+        ts: new Date(Date.now() - 60_000).toISOString(),
+        event: 'pr.opened',
+        sessionId: 's-pr',
+        mailboxId: 's-pr',
+        host: 'h',
+        runtime: 'headless',
+        agent: 'claude',
+        detail: 'gh pr create #2093',
+        url: 'https://example/pull/2093',
+      },
+      activityRoot,
+    );
+    for (let i = 0; i < 20; i++) {
+      appendActivityEvent(
+        {
+          ts: new Date(Date.now() - i * 1000).toISOString(),
+          event: 'file.edited',
+          sessionId: `s-edit-${i}`,
+          mailboxId: 's',
+          host: 'h',
+          runtime: 'headless',
+        },
+        activityRoot,
+      );
+    }
+    // Post-filter on a capped unfiltered read would miss the PR.
+    expect(
+      readUnifiedEvents({ activityRoot, limit: 5 })
+        .filter((e) => e.event === 'pr.opened'),
+    ).toHaveLength(0);
+    // Filter-before-limit surfaces it.
+    const hits = readUnifiedEvents({
+      activityRoot,
+      eventTypes: ['pr.opened'],
+      limit: 5,
+    });
+    expect(hits.map((e) => e.event)).toEqual(['pr.opened']);
+    expect(hits[0].detail).toBe('gh pr create #2093');
+  });
+
+  it('skips the activity half when --module is a non-activity module', () => {
+    const { activityRoot } = setup();
+    emit('secrets.get', { module: 'secrets', command: 'secrets get' });
+    appendActivityEvent(
+      {
+        ts: new Date(Date.now() - 1000).toISOString(),
+        event: 'pr.opened',
+        sessionId: 's1',
+        mailboxId: 's1',
+        host: 'h',
+        runtime: 'headless',
+      },
+      activityRoot,
+    );
+    const secrets = readUnifiedEvents({ activityRoot, module: 'secrets', limit: 10 });
+    expect(secrets.map((e) => e.event)).toEqual(['secrets.get']);
+    expect(secrets.every((e) => e.module === 'secrets')).toBe(true);
+  });
 });

--- a/apps/cli/src/lib/event-stream.ts
+++ b/apps/cli/src/lib/event-stream.ts
@@ -59,7 +59,9 @@ function matches(r: EventRecord, q: UnifiedQuery): boolean {
  * Read a unified, newest-first event stream. Operational events come from
  * events.ts `query()`; agent-semantic events from the activity logs, normalized
  * to the same record shape and filtered identically. `limit` caps the merged
- * result (each source is fetched up to `limit`, so the top-N is exact).
+ * result (each source is fetched up to `limit` *after* its primary filters —
+ * eventTypes for activity, eventTypes/module/bundle for ops — so the top-N is
+ * exact for those filters).
  */
 export function readUnifiedEvents(q: UnifiedQuery = {}): EventRecord[] {
   // `bundle` is filtered inside query()'s scan (before its limit cutoff) so a
@@ -80,10 +82,21 @@ export function readUnifiedEvents(q: UnifiedQuery = {}): EventRecord[] {
 
   if (q.includeActivity === false) return ops;
 
+  // Activity events always stamp module: 'activity'. A non-activity module
+  // filter can never match them — skip the activity scan entirely.
+  if (q.module != null && q.module !== 'activity') return ops;
+
+  // Push eventTypes into the activity reader so `limit` is applied AFTER the
+  // event-type filter (readRecentActivity already does this for `events`).
+  // Without this, a rare match older than the newest-`limit` window of routine
+  // churn is silently dropped — the same class of bug as the ops-side bundle
+  // pre-filter above (RUSH-2093). Remaining filters (agent, sessionId, …) still
+  // run via matches() for fields activity.ts does not pre-filter.
   const acts = readActivityAsEventRecords({
     sinceMs: q.startDate?.getTime(),
     limit: q.limit,
     root: q.activityRoot,
+    events: q.eventTypes,
   }).filter((r) => matches(r, q));
 
   const merged = [...ops, ...acts].sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts));


### PR DESCRIPTION
## Summary

Two small independent fixes for the feed and events surfaces.

### RUSH-2006 — `agents feed` crash on locked sessions.db

**Bug (pre-fix):** Outcome enrichment always awaited `discoverSessions({ all: true, limit: 5000 })` with no guard. Under concurrent scanner/daemon pressure that open can throw `SQLITE_BUSY` / `"database is locked"` and take down the whole feed.

**Fix:** Wrap the load in `loadSessionMetasForFeedEnrichment`. A lock error returns empty metas + `skippedLock`, and the command prints a stderr warning so blocks still render. Non-lock errors still throw.

### RUSH-2093 — `agents events --event` misses under `--limit`

**Bug (pre-fix):** `readUnifiedEvents` fetched activity with only `sinceMs`/`limit`/`root`, then applied `matches()` (including `eventTypes`) *after* the cap:

```ts
// pre-fix
readActivityAsEventRecords({ sinceMs, limit, root }).filter((r) => matches(r, q))
```

So one older `pr.opened` under twenty newer `file.edited` rows was silently dropped at `limit: 5`.

**Fix:** Pass `events: q.eventTypes` into `readActivityAsEventRecords` (activity.ts already applies `events` before `limit`). Also skip the activity half when `--module` is set to a non-`activity` module.

`activity.ts` needed no code change — it already had the pre-limit filter contract; this is pure wiring in `event-stream.ts`.

## Run result (no UI surface — test-only proof)

```
$ bunx vitest run src/commands/feed.test.ts src/lib/event-stream.test.ts
 ✓ src/lib/event-stream.test.ts (12 tests)
 ✓ src/commands/feed.test.ts (22 tests)
 Test Files  2 passed (2)
      Tests  34 passed (34)
```

New coverage:
- `loadSessionMetasForFeedEnrichment` degrades on `database is locked` / `SQLITE_BUSY`, rethrows other errors
- `readUnifiedEvents({ eventTypes: ['pr.opened'], limit: 5 })` finds a rare PR under 20 `file.edited` rows

## Docs / CHANGELOG

- `apps/cli/CHANGELOG.md` under 1.22.22
- `apps/cli/docs/06-observability.md` — filter-before-cap covers the activity half too

## Owned files only

- `apps/cli/src/commands/feed.ts` (lock guard only)
- `apps/cli/src/lib/event-stream.ts`
- tests + CHANGELOG + observability docs

No touch of exec/session-active/keychain surfaces.