### PR TITLE
docs(changelog): add the missing RUSH-2231/2232 keychain-reaper fragment

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2231-2232-keychain-reaper.md
+++ b/apps/cli/.changelog/next/RUSH-2231-2232-keychain-reaper.md
@@ -1,0 +1,16 @@
+- **A wedged keychain can no longer pile up `agents` processes (RUSH-2231, RUSH-2232).**
+  A stalled macOS `coreauthd` used to hang the signed keychain helper's XPC receive
+  forever, so every secrets-touching `agents` command blocked and dozens of helper
+  processes plus their `<defunct>` zombies accumulated and made the machine sluggish.
+  Two fixes: **(Layer 1)** every keychain-helper `spawnSync` is now bounded and
+  hard-killed (SIGKILL) on timeout — 8s for never-prompt verbs (`has`/`set`/`delete`/
+  `list*`), 60s for the may-prompt reads (`get`/`get-batch`/`migrate-*`) — surfacing a
+  typed timeout error and arming the read back-off instead of hanging.
+  **(Layer 3)** the daemon reaps the backlog: a 5-minute tick kills orphaned helpers
+  (reparented to PID 1, past a 30s grace) and, two-sweep-debounced, the helper child of
+  an `agents` proc stuck past 90s (child first, escalating to the parent only if it
+  stays wedged) — never touching a process whose start-time can't be captured or whose
+  path doesn't match the helper. Any keychain touch now also opportunistically starts
+  the daemon so the reaper runs even on a secrets-only box. Source:
+  `apps/cli/src/lib/secrets/index.ts`, `apps/cli/src/lib/secrets/reaper.ts`,
+  `apps/cli/src/lib/daemon.ts`.


### PR DESCRIPTION
**docs-only (CHANGELOG fragment).** No code change.

PR #2119 landed the RUSH-2231 + RUSH-2232 keychain-helper spawn bounding and daemon reaper, but merged with only 5 code/test files and **no `.changelog/next/` fragment**. Per this repo's convention (`apps/cli/.changelog/next/README.md`, "every user-visible PR"), the behavior change — a wedged macOS `coreauthd` no longer hangs secrets-touching `agents` commands or piles up helper processes — needs a changelog note so it appears at the next release. This adds the one missing fragment.

**Audience:** end users (release notes).

- Adds `apps/cli/.changelog/next/RUSH-2231-2232-keychain-reaper.md`.
- `scripts/gen-changelog.test.ts` still passes (5/5).

No run/screenshot applies (pure doc fragment). Verified the aggregate generator accepts it.

Tickets: RUSH-2231, RUSH-2232 (both already Done via #2119).
