### PR TITLE
fix(mcp): preserve comments in agents.yaml on mcp add (RUSH-2090)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2090.md
+++ b/apps/cli/.changelog/next/RUSH-2090.md
@@ -1,0 +1,6 @@
+- **`agents mcp add` no longer strips comments from `agents.yaml`.** The
+  write path (`writeManifest` / `serializeManifest` in `src/lib/manifest.ts`)
+  used plain `yaml.stringify`, which dropped every hand-written comment on
+  every add. It now round-trips via `yaml.parseDocument` and edits only the
+  keys that changed — the same approach `serializeCentral` already uses for
+  the central meta file (RUSH-2090).

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -291,7 +291,8 @@ src/
   index.ts             # CLI entry (commander.js)
   commands/            # User-facing subcommands (one file per `agents <cmd>`)
   lib/
-    state.ts           # Path constants; agents.yaml read/write
+    state.ts           # Path constants; agents.yaml read/write (serializeCentral preserves comments)
+    manifest.ts        # Project/user agents.yaml Manifest read/write (comment-preserving Document round-trip; used by mcp add, etc.)
     resources.ts       # resolveResource() / listResources() — layered resolution
     capabilities.ts    # supports() — the per-agent write gate
     agents.ts          # Per-agent capability table

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 ## 1.22.22
 
-- **`agents mcp add` no longer strips comments from `agents.yaml`.** The
-  write path (`writeManifest` / `serializeManifest` in `src/lib/manifest.ts`)
-  used plain `yaml.stringify`, which dropped every hand-written comment on
-  every add. It now round-trips via `yaml.parseDocument` and edits only the
-  keys that changed — the same approach `serializeCentral` already uses for
-  the central meta file (RUSH-2090).
-
 - **New: `agents insights` — how you work, split by the Claude account that did the
   work.** Tool and language mix, friction (interruptions, tool-error classes, your own
   reply latency), what you changed (line deltas, files, commits), an hour-of-day

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.22.22
 
+- **`agents mcp add` no longer strips comments from `agents.yaml`.** The
+  write path (`writeManifest` / `serializeManifest` in `src/lib/manifest.ts`)
+  used plain `yaml.stringify`, which dropped every hand-written comment on
+  every add. It now round-trips via `yaml.parseDocument` and edits only the
+  keys that changed — the same approach `serializeCentral` already uses for
+  the central meta file (RUSH-2090).
+
 - **New: `agents insights` — how you work, split by the Claude account that did the
   work.** Tool and language mix, friction (interruptions, tool-error classes, your own
   reply latency), what you changed (line deltas, files, commits), an hour-of-day

--- a/apps/cli/src/lib/__tests__/manifest.test.ts
+++ b/apps/cli/src/lib/__tests__/manifest.test.ts
@@ -84,3 +84,120 @@ describe('writeManifest concurrent safety', () => {
     expect(raw).toContain('claude');
   });
 });
+
+/**
+ * RUSH-2090: writeManifest used plain yaml.stringify and stripped every comment
+ * from agents.yaml. The mcp-add path is read → mutate mcp → writeManifest; it
+ * must keep hand-written annotations (matching serializeCentral in state.ts).
+ */
+describe('writeManifest comment preservation (RUSH-2090)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-comments-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function run(script: string): string {
+    return execFileSync('bun', ['-e', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: testDir },
+      stdio: 'pipe',
+      encoding: 'utf8',
+    }).trim();
+  }
+
+  it('keeps document + inline comments when mcp add mutates the manifest', () => {
+    const yamlPath = path.join(testDir, 'agents.yaml');
+    fs.writeFileSync(
+      yamlPath,
+      [
+        '# keep this hand-written comment',
+        'agents:',
+        '  claude: 2.1.0  # pin note',
+        'mcp: {}',
+        'defaults:',
+        '  method: symlink  # prefer symlinks',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    // Same shape as commands/mcp.ts mcp-add: read → set mcp[name] → writeManifest.
+    const out = run(`
+      import * as fs from 'fs';
+      const { readManifest, writeManifest } = await import(${JSON.stringify(manifestPath)});
+      const dir = ${JSON.stringify(testDir)};
+      const manifest = readManifest(dir) || {};
+      manifest.mcp = manifest.mcp || {};
+      manifest.mcp.demo = {
+        command: 'demo-server',
+        transport: 'stdio',
+        scope: 'user',
+        agents: ['claude'],
+      };
+      writeManifest(dir, manifest);
+      const after = fs.readFileSync(dir + '/agents.yaml', 'utf8');
+      console.log(JSON.stringify({
+        headerComment: after.includes('keep this hand-written comment'),
+        inlinePinComment: after.includes('# pin note'),
+        defaultsComment: after.includes('# prefer symlinks'),
+        demoAdded: after.includes('demo') && after.includes('demo-server'),
+        claudePin: after.includes('claude: 2.1.0'),
+      }));
+    `);
+
+    const r = JSON.parse(out);
+    expect(r.headerComment).toBe(true);
+    expect(r.inlinePinComment).toBe(true);
+    expect(r.defaultsComment).toBe(true);
+    expect(r.demoAdded).toBe(true);
+    expect(r.claudePin).toBe(true);
+  });
+
+  it('returns byte-identical content when nothing in the manifest changed', () => {
+    const yamlPath = path.join(testDir, 'agents.yaml');
+    const before = [
+      '# do not clobber me',
+      'agents:',
+      '  claude: 2.1.0  # pin',
+      'mcp: {}',
+      '',
+    ].join('\n');
+    fs.writeFileSync(yamlPath, before, 'utf-8');
+
+    const out = run(`
+      import * as fs from 'fs';
+      const { readManifest, writeManifest } = await import(${JSON.stringify(manifestPath)});
+      const dir = ${JSON.stringify(testDir)};
+      const before = fs.readFileSync(dir + '/agents.yaml', 'utf8');
+      writeManifest(dir, readManifest(dir));
+      const after = fs.readFileSync(dir + '/agents.yaml', 'utf8');
+      console.log(JSON.stringify({ byteIdentical: before === after }));
+    `);
+
+    expect(JSON.parse(out).byteIdentical).toBe(true);
+  });
+
+  it('falls back to plain stringify for a brand-new manifest file', () => {
+    const out = run(`
+      import * as fs from 'fs';
+      const { writeManifest, readManifest } = await import(${JSON.stringify(manifestPath)});
+      const dir = ${JSON.stringify(testDir)};
+      writeManifest(dir, { agents: { claude: '1.0.0' }, mcp: {} });
+      const raw = fs.readFileSync(dir + '/agents.yaml', 'utf8');
+      const parsed = readManifest(dir);
+      console.log(JSON.stringify({
+        hasClaude: raw.includes('claude'),
+        parsedClaude: parsed?.agents?.claude ?? null,
+      }));
+    `);
+
+    const r = JSON.parse(out);
+    expect(r.hasClaude).toBe(true);
+    expect(r.parsedClaude).toBe('1.0.0');
+  });
+});

--- a/apps/cli/src/lib/manifest.ts
+++ b/apps/cli/src/lib/manifest.ts
@@ -21,9 +21,55 @@ export function parseManifest(content: string): Manifest {
   return yaml.parse(content) as Manifest;
 }
 
-/** Serialize a Manifest object to a YAML string with 2-space indentation. */
-export function serializeManifest(manifest: Manifest): string {
-  return yaml.stringify(manifest, { indent: 2 });
+/**
+ * Serialize a Manifest to YAML WITHOUT destroying hand-written comments.
+ *
+ * Plain `yaml.stringify(manifest)` drops every comment, so `agents mcp add`
+ * (and every other writeManifest caller) used to clobber annotations in
+ * agents.yaml. Matching `serializeCentral` in state.ts: when existing file
+ * text is provided, parse it into a `yaml.Document` (comments + key order
+ * preserved) and edit only keys that actually changed. Untouched keys and
+ * their comments stay byte-stable. Falls back to plain stringify when there
+ * is no existing document yet.
+ */
+export function serializeManifest(manifest: Manifest, existingContent?: string | null): string {
+  const entries = Object.entries(manifest as Record<string, unknown>).filter(
+    ([, v]) => v !== undefined,
+  );
+  const isEmpty = entries.length === 0;
+
+  if (existingContent == null || existingContent.trim() === '') {
+    return isEmpty ? '' : yaml.stringify(manifest, { indent: 2 });
+  }
+
+  const doc = yaml.parseDocument(existingContent);
+  const current: Record<string, unknown> = (doc.toJSON() as Record<string, unknown>) ?? {};
+  let changed = false;
+
+  for (const [k, v] of entries) {
+    if (JSON.stringify(current[k]) !== JSON.stringify(v)) {
+      doc.set(k, v);
+      changed = true;
+    }
+  }
+
+  // Full-document write: callers do read-modify-write, so keys absent from the
+  // new manifest are intentional removals (e.g. clearing beta).
+  for (const k of Object.keys(current)) {
+    const next = (manifest as Record<string, unknown>)[k];
+    if (!(k in (manifest as object)) || next === undefined) {
+      doc.delete(k);
+      changed = true;
+    }
+  }
+
+  // Nothing changed → keep the file byte-identical (comments intact).
+  if (!changed) return existingContent;
+
+  // Force BLOCK style: an existing flow root (e.g. legacy `{}`) would otherwise
+  // make edited nodes render flow. collectionStyle pins the whole doc block
+  // while parseDocument still preserves comments + key ordering.
+  return isEmpty ? '' : doc.toString({ collectionStyle: 'block' });
 }
 
 /** Read and parse agents.yaml from a directory. Returns null if the file does not exist. */
@@ -61,8 +107,21 @@ function withManifestLock<T>(filePath: string, fn: () => T): T {
 /** Write a Manifest object to agents.yaml in the given directory. */
 export function writeManifest(repoPath: string, manifest: Manifest): void {
   const manifestPath = safeJoin(repoPath, MANIFEST_FILENAME);
-  const content = serializeManifest(manifest);
-  withManifestLock(manifestPath, () => atomicWriteFileSync(manifestPath, content));
+  withManifestLock(manifestPath, () => {
+    let existing: string | null = null;
+    try {
+      existing = fs.readFileSync(manifestPath, 'utf-8');
+    } catch {
+      /* first write — no file yet (or empty lock target) */
+    }
+    // ensureLockTarget may have created an empty file for the lock path.
+    if (existing !== null && existing.trim() === '') existing = null;
+    const content = serializeManifest(manifest, existing);
+    // Skip the atomic rewrite when nothing changed so comments stay byte-stable
+    // and concurrent readers never see a no-op churn.
+    if (existing !== null && content === existing) return;
+    atomicWriteFileSync(manifestPath, content);
+  });
 }
 
 /** Create a Manifest with sensible defaults for a fresh agents repo. */


### PR DESCRIPTION
**Bug fix** — `agents mcp add` no longer strips every comment from `agents.yaml`.

## What / why

`writeManifest` / `serializeManifest` rewrote the file with plain `yaml.stringify`, which drops comments. That is the write path used by `agents mcp add` (and other callers), so any hand-written annotation in `agents.yaml` disappeared on every add.

## Fix

Match the existing `serializeCentral` approach in `state.ts` (not modified here):

1. Read the existing `agents.yaml` text under the manifest lock
2. `yaml.parseDocument` (preserves comments + key order)
3. `doc.set` / `doc.delete` only for keys that actually changed
4. No-op writes return the existing bytes (byte-identical, no churn)
5. New files still use plain stringify

## Owned files

- `apps/cli/src/lib/manifest.ts` — comment-preserving serialize/write
- `apps/cli/src/lib/__tests__/manifest.test.ts` — real-path regression tests
- `apps/cli/CHANGELOG.md`, `apps/cli/AGENTS.md`

`mcp.ts` needed no change: it already calls `writeManifest` after mutating `manifest.mcp`.

## Ticket

https://linear.app/getrush/issue/RUSH-2090/agents-mcp-add-silently-strips-all-comments-from-agentsyaml

## Run result (real output)

**Before (plain stringify path — the bug):**
```
plain stringify comment survived: false
```

**After (`writeManifest` mcp-add shape: read → set mcp.demo → write):**
```
# keep this hand-written comment
agents:
  claude: 2.1.0 # pin note
mcp:
  demo:
    command: demo-server
    transport: stdio
    scope: user
    agents:
      - claude

header comment survived: true
inline comment survived: true
demo added: true
```

**Tests:**
```
✓ src/lib/__tests__/manifest.test.ts (5 tests)
  - leaves a valid YAML file under concurrent writes
  - leaves no temp files when write succeeds
  - keeps document + inline comments when mcp add mutates the manifest
  - returns byte-identical content when nothing changed
  - falls back to plain stringify for a brand-new manifest file
```

No UI surface — CLI config write path only; proof is the command output above.