### PR TITLE
fix(computer-mac): report Screen Recording trust in trust_status RPC (RUSH-1882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **The macOS `computer` helper's `trust_status` RPC now reports Screen Recording trust, not just Accessibility (RUSH-1882).** It previously returned only
+  `AX.isTrusted()`, so a missing Screen Recording grant only surfaced indirectly
+  when a `screenshot` capture timed out after 5s. Adds a `screen_recording` field
+  via the non-prompting `CGPreflightScreenCaptureAccess()`, additive and
+  backward-compatible with callers that only read `trusted`/`pid`/`path`. Source:
+  `native/computer-mac/Sources/ComputerHelper/RPC.swift`,
+  `native/computer-mac/Sources/ComputerHelper/Screenshot.swift`.
+
 - **`agents devices list` moves "Leased boxes" behind `--all`; the default list no longer touches the keychain or pops Touch ID (RUSH-2190).** See
   `apps/cli/.changelog/next/devices-list-all-flag.md`.
 

--- a/native/computer-mac/Sources/ComputerHelper/RPC.swift
+++ b/native/computer-mac/Sources/ComputerHelper/RPC.swift
@@ -78,12 +78,16 @@ final class Dispatcher {
         case "ping":
             return ["pong": true]
         case "trust_status":
-            // Diagnostic: report AX trust + identity without throwing. Useful
-            // when TCC grants look right in the UI but AX calls still 403.
+            // Diagnostic: report AX + Screen Recording trust and identity
+            // without throwing. Useful when TCC grants look right in the UI
+            // but AX calls still 403, or screenshot capture times out.
+            // screen_recording is additive — older callers that only read
+            // `trusted`/`pid`/`path` are unaffected.
             let pid = Int(ProcessInfo.processInfo.processIdentifier)
             let path = Bundle.main.executablePath ?? CommandLine.arguments.first ?? ""
             return [
                 "trusted": AX.isTrusted(),
+                "screen_recording": Screenshot.isScreenRecordingTrusted(),
                 "pid": pid,
                 "path": path,
             ]

--- a/native/computer-mac/Sources/ComputerHelper/Screenshot.swift
+++ b/native/computer-mac/Sources/ComputerHelper/Screenshot.swift
@@ -27,6 +27,14 @@ import UniformTypeIdentifiers
 // and the backing scale factor, so a caller can map screenshot pixels to
 // global screen coordinates for click()/scroll(): global = origin + pixel/scale.
 enum Screenshot {
+    // Non-prompting Screen Recording trust check, mirrors AX.isTrusted(). Used
+    // by trust_status so a caller can tell AX and Screen Recording apart
+    // instead of only learning about a missing Screen Recording grant when a
+    // screenshot capture times out after 5s (see the `timedOut` branch below).
+    static func isScreenRecordingTrusted() -> Bool {
+        CGPreflightScreenCaptureAccess()
+    }
+
     static func capture(params: [String: Any]) throws -> [String: Any] {
         let pid = try Params.int(params, "pid")
         let quality = max(1, min(100, Params.intOpt(params, "quality") ?? 85))


### PR DESCRIPTION
## What + why

`trust_status` only reported `AX.isTrusted()`, so a caller couldn't tell Accessibility and Screen Recording apart — a missing Screen Recording grant only surfaced indirectly when a `screenshot` capture timed out after 5s (`Screenshot.swift:63`). Adds a `screen_recording` field using the non-prompting `CGPreflightScreenCaptureAccess()` check, mirroring `AX.isTrusted()`'s existing pattern.

Backward-compatible: the field is additive, existing fields (`trusted`, `pid`, `path`) are unchanged, so older callers that only read those are unaffected.

## Changes

- `native/computer-mac/Sources/ComputerHelper/Screenshot.swift` — new `Screenshot.isScreenRecordingTrusted()` static func wrapping `CGPreflightScreenCaptureAccess()`.
- `native/computer-mac/Sources/ComputerHelper/RPC.swift` — `trust_status` case now includes `"screen_recording"` in its result dict.

## Verification

No test target exists in this SwiftPM package (single `executableTarget`, no `.testTarget`) — per the ticket note, the real test is a successful build + the RPC returning the new field.

Built on `mac-mini` (macOS) via `native/computer-mac/scripts/build.sh` — compiled clean (`Build complete!`, only pre-existing unrelated deprecation warnings in `Mouse.swift`/`Apps.swift`, unrelated codesign `errSecInternalComponent` from the headless SSH session's keychain access, not from this change).

Ran the built binary directly over its stdio JSON-RPC transport (the legacy stdin/stdout mode `main.swift` falls back to when no `--socket` is passed) and quoted the real output:

```
$ printf '{"id":1,"method":"trust_status","params":{}}\n' | ./dist/computer-helper-mac
[computer-helper] started pid=62295
[computer-helper] policy loaded: 18 allowed bundle ids
[computer-helper] peers loaded: 2 allowed caller paths
{"id":1,"result":{"path":"/Users/muqsit/.../dist/computer-helper-mac","screen_recording":false,"trusted":true,"pid":62295}}
[computer-helper] exit (stdin EOF)
```

Confirms the new `screen_recording` field is present alongside the unchanged `trusted`/`pid`/`path` fields — proves both the build and the RPC behavior end to end.

Linear: RUSH-1882
