### PR TITLE
fix(routines): run scheduled routines on a per-account setup-token instead of deleting it

### DIFF
--- a/apps/cli/.changelog/next/routine-setup-token.md
+++ b/apps/cli/.changelog/next/routine-setup-token.md
@@ -1,0 +1,16 @@
+- **Scheduled routines now run on a per-account `claude setup-token` when one is
+  provisioned, instead of throwing it away.** `buildRoutineSpawnEnv` unconditionally
+  deleted `CLAUDE_CODE_OAUTH_TOKEN`, so even after `buildExecEnv` injected a long-lived,
+  non-rotating setup-token from the reserved file-backed `auth` bundle
+  (`resolveClaudeSetupToken`), a routine still fell back to the version home's rotating
+  `.credentials.json` login. With one Claude account signed into several version homes
+  (or several fleet boxes), that rotating login is the single-use-refresh-token
+  revocation storm — one home's refresh silently revokes every sibling copy, so an
+  unattended routine keeps landing on a just-revoked token and dies with `auth_failed:
+  OAuth access token has been revoked` / `Please run /login`, even though `agents view`
+  shows the account healthy. The delete now distinguishes the two flavours: a
+  per-account setup-token (keyed to this home's own account) is re-asserted and KEPT; an
+  inherited *ambient* token (a shared value the daemon env happened to carry — the
+  RUSH-1822 fleet-logout path) is still stripped so a routine never runs on it.
+  Provision the token with `/fleet:mint-auth`. Source:
+  `apps/cli/src/lib/runner.ts` (`buildRoutineSpawnEnv`).

--- a/apps/cli/src/lib/runner.setup-token.test.ts
+++ b/apps/cli/src/lib/runner.setup-token.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { buildRoutineSpawnEnv } from './runner.js';
+import { claudeAccountTokenKey } from './claude-account-token.js';
+import { bundleItemStore, keychainRef, writeBundle, type SecretsBundle } from './secrets/bundles.js';
+import { _resetFileStoreForTest } from './secrets/filestore.js';
+import { secretsKeychainItem } from './secrets/index.js';
+import { getVersionHomePath } from './versions.js';
+
+// A routine authenticates through a per-account, non-rotating `claude setup-token`
+// (the mint-auth cure for the single-use-refresh-token revocation storm). The daemon
+// path builds its spawn env via buildRoutineSpawnEnv, which historically DELETED
+// CLAUDE_CODE_OAUTH_TOKEN unconditionally — throwing away a legitimately-provisioned
+// setup-token and forcing the routine back onto the rotating login. These tests pin
+// the two-flavour rule: KEEP a per-account setup-token, STRIP an inherited ambient one.
+const PASS = 'runner-setup-token-test-pass';
+
+let fileDir: string;
+let versionDirs: string[] = [];
+let prevNoAgent: string | undefined;
+let prevPassphrase: string | undefined;
+let prevClaudeToken: string | undefined;
+
+beforeEach(() => {
+  fileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runner-setup-token-store-'));
+  versionDirs = [];
+  prevNoAgent = process.env.AGENTS_SECRETS_NO_AGENT;
+  prevPassphrase = process.env.AGENTS_SECRETS_PASSPHRASE;
+  prevClaudeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  process.env.AGENTS_SECRETS_NO_AGENT = '1';
+  process.env.AGENTS_SECRETS_PASSPHRASE = PASS;
+  _resetFileStoreForTest({ fileDir, passphrase: PASS });
+});
+
+afterEach(() => {
+  _resetFileStoreForTest({});
+  if (prevNoAgent === undefined) delete process.env.AGENTS_SECRETS_NO_AGENT;
+  else process.env.AGENTS_SECRETS_NO_AGENT = prevNoAgent;
+  if (prevPassphrase === undefined) delete process.env.AGENTS_SECRETS_PASSPHRASE;
+  else process.env.AGENTS_SECRETS_PASSPHRASE = prevPassphrase;
+  if (prevClaudeToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  else process.env.CLAUDE_CODE_OAUTH_TOKEN = prevClaudeToken;
+  for (const dir of versionDirs) fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(fileDir, { recursive: true, force: true });
+});
+
+/** Create a real version home for `version` signed into `email` (writes .claude.json). */
+function makeVersionHome(version: string, email: string): void {
+  const versionHome = getVersionHomePath('claude', version);
+  versionDirs.push(path.dirname(versionHome));
+  const configDir = path.join(versionHome, '.claude');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(configDir, '.claude.json'),
+    JSON.stringify({ oauthAccount: { emailAddress: email } }),
+  );
+}
+
+function writeAuthBundle(values: Record<string, string>): void {
+  const bundle: SecretsBundle = { name: 'auth', backend: 'file', vars: {} };
+  for (const [key, value] of Object.entries(values)) {
+    bundleItemStore('file').set(secretsKeychainItem('auth', key), value);
+    bundle.vars[key] = keychainRef(key);
+  }
+  writeBundle(bundle);
+}
+
+describe('buildRoutineSpawnEnv — CLAUDE_CODE_OAUTH_TOKEN handling', () => {
+  it('KEEPS a per-account setup-token even when an ambient token is inherited', () => {
+    const version = `rush-setup-keep-${process.pid}`;
+    const email = 'alpha@example.com';
+    makeVersionHome(version, email);
+    writeAuthBundle({ [claudeAccountTokenKey(email)]: 'sk-ant-oat01-alpha' });
+    // A stale/rotating value inherited from the daemon env must NOT win.
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-inherited-ambient';
+
+    const env = buildRoutineSpawnEnv({ ...process.env } as Record<string, string>, 'claude', version);
+
+    // The routine runs on the non-rotating per-account setup-token, not the ambient one.
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-alpha');
+  });
+
+  it('STRIPS an inherited ambient token when no per-account setup-token is provisioned', () => {
+    const version = `rush-setup-strip-${process.pid}`;
+    // Version home is signed in, but the `auth` bundle has no token for this account.
+    makeVersionHome(version, 'beta@example.com');
+    // Inherited shared/rotating token — the RUSH-1822 fleet-wide-logout path.
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-inherited-ambient';
+
+    const env = buildRoutineSpawnEnv({ ...process.env } as Record<string, string>, 'claude', version);
+
+    // No provisioned setup-token → the ambient value is dropped, routine uses the
+    // version home's own login instead.
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -56,7 +56,8 @@ import { backgroundSpawnOptions, killTree } from './platform/process.js';
 import lockfile from 'proper-lockfile';
 import { ensureLockTarget } from './fs-atomic.js';
 import { walkForFiles } from './fs-walk.js';
-import { getBinaryPath, isVersionInstalled, resolveVersion } from './versions.js';
+import { getBinaryPath, isVersionInstalled, resolveVersion, getVersionHomePath } from './versions.js';
+import { resolveClaudeSetupToken } from './claude-account-token.js';
 import {
   getConfiguredRunStrategy,
   resolveRunVersion,
@@ -636,22 +637,24 @@ export function buildRoutineSpawnEnv(
   for (const [k, v] of Object.entries(execEnv)) {
     if (v !== undefined) out[k] = v;
   }
-  // A routine authenticates through the pinned account's own CLAUDE_CONFIG_DIR
-  // login on THIS box (buildExecEnv points it at the per-account version home).
-  // Claude Code's interactive session refreshes itself per-device; keeping the
-  // daemon out of the credential entirely is what avoids the fleet-wide rotation
-  // logout — a shared/rotating token was the cause, not the fix.
-  //
-  // Injecting a token was already ruled out, but INHERITING one was not:
-  // buildExecEnv spreads the ambient process.env (exec.ts) and sanitizeProcessEnv
-  // only strips loader/interpreter vars, never credentials. So on any box whose
-  // daemon environment happens to carry CLAUDE_CODE_OAUTH_TOKEN, every routine
-  // spawn silently ran on that one shared rotating token instead of the host's
-  // own login — the exact fleet-wide-logout path, arriving by inheritance rather
-  // than injection. CI never caught it because CI has no token to inherit; a
-  // provisioned box does. Drop it here so a routine always uses the login of the
-  // machine it runs on.
-  delete out.CLAUDE_CODE_OAUTH_TOKEN;
+  // CLAUDE_CODE_OAUTH_TOKEN comes in two flavours, and only one is safe for a
+  // routine. KEEP a per-account `claude setup-token` (long-lived, NON-rotating,
+  // keyed to this home's own account) that buildExecEnv injected from the reserved
+  // `auth` bundle (resolveClaudeSetupToken) — that is the durable cure for the
+  // single-use-refresh-token revocation storm: a setup-token never rotates, so a
+  // scheduled routine can't land on a sibling home's just-rotated-out credential.
+  // STRIP an INHERITED ambient value instead: buildExecEnv spreads process.env
+  // (exec.ts) and sanitizeProcessEnv leaves credentials, so a daemon env that
+  // happens to carry a shared/rotating CLAUDE_CODE_OAUTH_TOKEN would otherwise make
+  // every routine run on that one token — the RUSH-1822 fleet-wide-logout path.
+  // Distinguish by value: only the resolved setup-token survives.
+  // Authoritative: buildExecEnv injects the setup-token but then spreads the caller
+  // env over it, so an ambient CLAUDE_CODE_OAUTH_TOKEN would win — re-assert here.
+  const setupToken = agent === 'claude' && version
+    ? resolveClaudeSetupToken(getVersionHomePath('claude', version))
+    : null;
+  if (setupToken) out.CLAUDE_CODE_OAUTH_TOKEN = setupToken;
+  else delete out.CLAUDE_CODE_OAUTH_TOKEN;
   if (agent === 'cursor' && overlayHome) {
     // prepareJobHome links this host's Cursor auth file here. Pin XDG_CONFIG_HOME
     // to the overlay so an ambient value cannot bypass the routine sandbox.


### PR DESCRIPTION
**fix** · routine auth · no UI surface. Makes scheduled (cron) routines actually use a long-lived, non-rotating `claude setup-token` when one is provisioned — curing the intermittent `auth_failed: OAuth access token has been revoked` / `Please run /login` that kills unattended routines.

## The bug
`buildRoutineSpawnEnv` (`apps/cli/src/lib/runner.ts`) did `delete out.CLAUDE_CODE_OAUTH_TOKEN` unconditionally. But `buildExecEnv` had just injected a per-account setup-token from the reserved file-backed `auth` bundle (`resolveClaudeSetupToken`, exec.ts:420-425). So the routine threw the non-rotating token away and fell back to the version home's **rotating** `.credentials.json` login.

With one Claude account signed into several version homes (and across fleet boxes), that rotating login is the **single-use-refresh-token revocation storm** the code itself documents (RUSH-1822 / RUSH-1957): any one home's refresh rotates the token server-side and silently revokes every sibling copy. An unattended routine on `balanced` rotation keeps landing on a just-revoked copy and dies — while `agents view` still shows the account "signed in" (a local file heuristic that can't see the revocation).

Verified live: run metadata across `drain-*`, `hetzner-lease-gc`, `security-sweep` shows `agent=claude v=- status=failed err=auth_failed: OAuth access token has been revoked`; the same accounts are duplicated locally (`muqsit@trp.so` in homes 2.1.221 + 2.1.187) and on `zion`. Independently confirmed by three blind agents (opus, sonnet, codex).

## The fix
Distinguish the two flavours of `CLAUDE_CODE_OAUTH_TOKEN` by value:
- **KEEP** a per-account setup-token (keyed to this home's own account) — re-asserted authoritatively, since `buildExecEnv` spreads the caller env over its own injection and an ambient value would otherwise win.
- **STRIP** an inherited *ambient* token (a shared/rotating value the daemon env happened to carry — the RUSH-1822 fleet-logout path), unchanged.

Provision the token with `/fleet:mint-auth` (agent-driven `claude setup-token`, stored per-account in the `auth` bundle).

## Proof — real run (no mocking)
New `apps/cli/src/lib/runner.setup-token.test.ts` builds a real version home + file-backed `auth` bundle and calls the real `buildRoutineSpawnEnv`. Full captured run log on disk:

`yosemite-s0:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/.agents/artifacts/2026-08-05/routine-setup-token-test-run.log`

New tests:
- ✓ KEEPS a per-account setup-token even when an ambient token is inherited
- ✓ STRIPS an inherited ambient token when no per-account setup-token is provisioned

Regression run — `runner.setup-token.test.ts` + `runner.test.ts` + `routines.test.ts` + `routine-notify.test.ts`: **all green** (128 in the captured 3-suite run; 146 including routine-notify). No existing behavior changed.

## Scope note
Fixes the local routine spawn (`buildRoutineSpawnEnv`). Remote `--host` routines rely on the target box having its own `auth` bundle (mint-auth is per-box) — out of scope here. This is the code half of the cure; the operational half is minting fresh per-account setup-tokens into the `auth` bundle.
