### PR TITLE
fix(secrets): reaper must never kill the watch-lock watcher (RUSH-2232)

### DIFF
--- a/apps/cli/.changelog/next/reaper-watch-lock-exclusion.md
+++ b/apps/cli/.changelog/next/reaper-watch-lock-exclusion.md
@@ -1,0 +1,10 @@
+- **The keychain reaper no longer kills the auto-lock-on-sleep watcher (RUSH-2232 follow-up).**
+  The reaper (shipped in 1.22.23) classified a process as a reap target purely by the
+  helper binary path, which also matches the broker's deliberately long-lived
+  `watch-lock` watcher — a healthy child of the live daemon that wipes the in-memory
+  secret store on sleep. Its class-(b) rule ("helper child of a live parent, older than
+  90s") therefore killed the watcher on its second sweep (~10 min after the daemon
+  started hosting the broker), silently disabling auto-lock-on-sleep. Reap-eligibility
+  now matches the full command line and excludes the `watch-lock` verb, so only the
+  short-lived keychain reads/writes a wedged `coreauthd` can hang are ever reaped.
+  Source: `apps/cli/src/lib/secrets/reaper.ts` (`isReapableHelperCommand`).

--- a/apps/cli/src/lib/secrets/reaper.test.ts
+++ b/apps/cli/src/lib/secrets/reaper.test.ts
@@ -12,6 +12,7 @@ import {
   planKeychainReap,
   reapOrphanedKeychainProcesses,
   parseEtimeToSeconds,
+  isReapableHelperCommand,
   ORPHAN_GRACE_SEC,
   STUCK_GRACE_SEC,
   resetKeychainReaperCandidatesForTest,
@@ -25,6 +26,8 @@ import {
 // release until it was fixed. Node BUILTIN requires (child_process/os/path/fs)
 // resolve fine, which is why only these two broke.
 import { setInstallRootForTest } from './install-helper.js';
+
+const HELPER_PATH = '/Users/x/Library/Application Support/agents-cli/Agents CLI.app/Contents/MacOS/Agents CLI';
 
 function snap(overrides: Partial<KeychainProcessSnapshot> & Pick<KeychainProcessSnapshot, 'pid'>): KeychainProcessSnapshot {
   return {
@@ -314,4 +317,63 @@ describe('reapOrphanedKeychainProcesses (darwin integration)', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 60_000);
+});
+
+describe('isReapableHelperCommand — never target the long-lived watch-lock watcher', () => {
+  it('excludes the watch-lock watcher (the auto-lock-on-sleep child)', () => {
+    expect(isReapableHelperCommand(`${HELPER_PATH} watch-lock`, HELPER_PATH)).toBe(false);
+  });
+
+  it('includes the short-lived keychain verbs a wedged coreauthd can hang', () => {
+    for (const verb of ['get', 'has', 'list', 'set', 'delete', 'migrate-acl', 'get-batch']) {
+      expect(isReapableHelperCommand(`${HELPER_PATH} ${verb} some-item user`, HELPER_PATH)).toBe(true);
+    }
+  });
+
+  it('includes a bare helper exec with no verb (still not watch-lock)', () => {
+    expect(isReapableHelperCommand(HELPER_PATH, HELPER_PATH)).toBe(true);
+  });
+
+  it('excludes any non-helper command', () => {
+    expect(isReapableHelperCommand('/usr/bin/node index.js', HELPER_PATH)).toBe(false);
+    // A different binary whose name merely CONTAINS the helper path as a substring
+    // must not match — the guard requires the exact path as a prefix + a space.
+    expect(isReapableHelperCommand(`${HELPER_PATH}-evil watch-lock`, HELPER_PATH)).toBe(false);
+  });
+});
+
+describe('planKeychainReap — the watch-lock regression (RUSH-2232 follow-up)', () => {
+  // A watch-lock watcher is a helper child of a LIVE parent (the broker/daemon),
+  // long-lived (days). The driver marks it isHelper=false via isReapableHelperCommand,
+  // so the planner must never record or kill it, even across many sweeps.
+  const brokerPid = 400;
+  const watchLockPid = 401;
+  const parent = snap({ pid: brokerPid, ppid: 1, elapsedSec: 1_000_000, isHelper: false, startTime: 'st-broker' });
+  const watchLock = snap({
+    pid: watchLockPid,
+    ppid: brokerPid,
+    elapsedSec: STUCK_GRACE_SEC + 100_000, // far past the stuck threshold
+    isHelper: false, // excluded by isReapableHelperCommand
+    startTime: 'st-watchlock',
+  });
+
+  it('never kills or records the watch-lock watcher across three sweeps', () => {
+    let candidates = new Map<number, StuckParentCandidate>();
+    for (let sweep = 0; sweep < 3; sweep++) {
+      const plan = planKeychainReap([parent, watchLock], Date.now() + sweep * 300_000, candidates);
+      expect(plan.kill).toEqual([]);
+      expect(plan.nextCandidates.size).toBe(0);
+      candidates = plan.nextCandidates;
+    }
+  });
+
+  it('still kills a genuinely stuck read verb on the second sweep (fix does not weaken reaping)', () => {
+    // Same shape, but this helper child IS reap-eligible (a stuck `get`).
+    const stuckGet = snap({ pid: 402, ppid: brokerPid, elapsedSec: STUCK_GRACE_SEC + 50, isHelper: true, startTime: 'st-get' });
+    const sweep1 = planKeychainReap([parent, stuckGet], 1_000, new Map());
+    expect(sweep1.kill).toEqual([]);
+    expect(sweep1.nextCandidates.size).toBe(1);
+    const sweep2 = planKeychainReap([parent, stuckGet], 2_000, sweep1.nextCandidates);
+    expect(sweep2.kill).toContain(402);
+  });
 });

--- a/apps/cli/src/lib/secrets/reaper.ts
+++ b/apps/cli/src/lib/secrets/reaper.ts
@@ -33,7 +33,12 @@ export interface KeychainProcessSnapshot {
    * `null` means "could not capture" — the planner must fail closed.
    */
   startTime: string | null;
-  /** True when this process's executable path matches the installed helper. */
+  /**
+   * True when this process is a REAP-ELIGIBLE helper invocation — the installed
+   * helper binary running a short-lived keychain verb. False for a non-helper
+   * process AND for the long-lived `watch-lock` watcher (see
+   * {@link isReapableHelperCommand}), which must never be reaped.
+   */
   isHelper: boolean;
 }
 
@@ -183,6 +188,31 @@ function parsePsLine(line: string): {
   return { pid, ppid, elapsedSec, command };
 }
 
+/**
+ * The one helper verb that is DELIBERATELY long-lived: the broker's auto-lock
+ * sleep/lock watcher (`spawn(getKeychainHelperPath(), ['watch-lock'], …)` in
+ * `agent.ts`). It lives for the broker's whole hold — potentially days — as a
+ * healthy child of the live broker/daemon, emitting LOCK/SLEEP lines that wipe
+ * the in-memory secret store on sleep. It is NOT a stuck keychain read, so the
+ * reaper must never target it: killing it silently disables auto-lock-on-sleep.
+ */
+const HELPER_WATCH_LOCK_VERB = 'watch-lock';
+
+/**
+ * Whether a `ps` command line is a REAP-ELIGIBLE helper invocation: the installed
+ * helper binary running a short-lived keychain verb (get/has/list/set/delete/
+ * migrate-*) that a wedged `coreauthd` can hang. Returns false for a non-helper
+ * command AND for the deliberately long-lived `watch-lock` watcher — matching by
+ * the full argv (`ps … command=`), so a live-parent `watch-lock` child is never
+ * mistaken for a stuck read and killed. Pure; unit-tested.
+ */
+export function isReapableHelperCommand(command: string, helperPath: string): boolean {
+  if (command === helperPath) return true; // bare exec, no verb — never watch-lock
+  if (!command.startsWith(`${helperPath} `)) return false; // not our helper
+  const firstArg = command.slice(helperPath.length + 1).trimStart().split(/\s+/)[0];
+  return firstArg !== HELPER_WATCH_LOCK_VERB;
+}
+
 /** Module-state for the two-sweep stuck-parent debounce. */
 let stuckParentCandidates = new Map<number, StuckParentCandidate>();
 
@@ -245,9 +275,11 @@ export function reapOrphanedKeychainProcesses(): {
     const parsed = parsePsLine(line);
     if (!parsed) continue;
     const { pid, ppid, elapsedSec, command } = parsed;
-    // Exact path-match: the helper invocation's command line begins with the
-    // absolute helper path, followed by a space and its arguments (or nothing).
-    const isHelper = command === helperPath || command.startsWith(`${helperPath} `);
+    // Reap-eligible = the helper binary running a short-lived keychain verb. The
+    // full-argv match excludes the deliberately long-lived `watch-lock` watcher,
+    // whose live-parent child would otherwise be killed as if it were stuck
+    // (RUSH-2232 — that silently disabled auto-lock-on-sleep).
+    const isHelper = isReapableHelperCommand(command, helperPath);
     rows.push({ pid, ppid, elapsedSec, isHelper, startTime: null });
   }
 


### PR DESCRIPTION
**bug fix (behavior).** Fixes a real regression shipped in 1.22.23 (PR #2119, RUSH-2232).

## Bug
The keychain reaper decided reap-eligibility by the **helper binary path only** (`command === helperPath || command.startsWith(\`${helperPath} \`)`, `reaper.ts` driver). That also matches the broker's **`watch-lock`** watcher — the deliberately long-lived helper the broker spawns (`spawn(getKeychainHelperPath(), ['watch-lock'], …)`, `agent.ts:769,838`) that lives for the whole hold (days) as a healthy child of the live daemon and drives **auto-lock-on-sleep** (wipes the in-memory secret store on SLEEP).

The reaper's class-(b) rule — "a helper child of a live parent older than 90s" — therefore matched `watch-lock` every time: recorded on one 5-min sweep, **killed on the next** (~10 min after the daemon starts hosting the broker). That silently disables auto-lock-on-sleep (a security feature). The daemon-self-kill path was already guarded (`pid === process.pid`), but the watcher is a *different* pid, so it was unprotected.

## Fix
Reap-eligibility now matches the **full `ps` command line** and excludes the `watch-lock` verb, via a new pure, unit-tested `isReapableHelperCommand(command, helperPath)`. Only the short-lived keychain reads/writes a wedged `coreauthd` can hang are ever reaped; the long-lived watcher is left alone.

## Why not caught before
The merged version's tests only asserted a non-helper `sleep` survives; nothing modelled a real `watch-lock`-shaped helper child of a live parent. This was surfaced by the **non-author review** of my (duplicate, now-closed) PR #2123.

## Tests (real path, no mocking)
`vitest run src/lib/secrets/reaper.test.ts` → **20 passed, 1 skipped** (darwin integration). New coverage:
- `isReapableHelperCommand`: excludes `watch-lock`; includes get/has/list/set/delete/migrate-*/bare; excludes non-helper + a path-prefix-collision binary.
- planner regression: a long-lived `watch-lock` child of a live parent is **never** killed or recorded across three sweeps; a genuinely stuck `get` **is** still killed on sweep 2 (the fix doesn't weaken reaping).

```
✓ isReapableHelperCommand — never target the long-lived watch-lock watcher > excludes the watch-lock watcher (the auto-lock-on-sleep child)
✓ planKeychainReap — the watch-lock regression (RUSH-2232 follow-up) > never kills or records the watch-lock watcher across three sweeps
✓ planKeychainReap — the watch-lock regression (RUSH-2232 follow-up) > still kills a genuinely stuck read verb on the second sweep (fix does not weaken reaping)
```

Ticket: RUSH-2232 (the reaper).
