### PR TITLE
feat(cli): add session alias, absolute secret expiry, and effort defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ On a terminal, `agents sessions --active` (and a bare `agents sessions`) open th
 | `r` | running only | `--active` |
 | `f` | favorites only | `--favorites` |
 | `*` | star / unstar the highlighted session | `agents sessions favorite <id>` |
-| `c` | team sessions | `--teams` |
+| `c` | team sessions | `--team` (alias: `--teams`) |
 | `a` | agent (cycles) | `-a` |
 | `d` | device (cycles) | `--device` |
 | `p` | this repo ↔ all dirs | `--all` |

--- a/apps/cli/.changelog/next/RUSH-1995-1960-2005.md
+++ b/apps/cli/.changelog/next/RUSH-1995-1960-2005.md
@@ -1,0 +1,3 @@
+- Added `--team` as an alias for `agents sessions --teams`. (RUSH-1995)
+- Added absolute `agents secrets unlock --until <date>` expiry, mutually exclusive with relative `--ttl`. (RUSH-1960)
+- Added persisted per-agent-version reasoning effort defaults and surfaced them in `agents view`. (RUSH-2005)

--- a/apps/cli/docs/05-sessions.md
+++ b/apps/cli/docs/05-sessions.md
@@ -591,7 +591,7 @@ agents sessions --agent codex@0.116.0
 agents sessions "auth refactor"
 
 # Include team-spawned sessions (hidden by default)
-agents sessions --teams
+agents sessions --team   # alias of --teams
 
 # One team's whole lineage: the session that spawned it, plus (with --teams) its
 # teammates. Spans every directory and all time — a team's teammates run in their

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -404,6 +404,7 @@ The Windows push bridge is `buildWindowsStdinImportCommand` in
 | `secrets unlock [names...]` | Read a bundle once (one Touch ID) and hold it in the secrets-agent so later runs read it silently | `agents secrets unlock prod` |
 | `secrets unlock --all` | Unlock every configured bundle | `agents secrets unlock --all` |
 | `secrets unlock <name> --ttl <dur>` | Hold for a custom lifetime (default 7d) | `agents secrets unlock prod --ttl 30m` |
+| `secrets unlock <name> --until <date>` | Hold until an absolute date or timestamp | `agents secrets unlock prod --until 2026-08-06T12:00:00Z` |
 | `secrets unlock <name> --durable` | Also survive sleep + reboot (default: survives upgrade/restart, re-locks on sleep) | `agents secrets unlock prod --durable` |
 | `secrets lock [names...]` | Wipe held bundles from the agent (default: all) — next read re-prompts | `agents secrets lock` |
 | `secrets status` | Show which bundles the agent holds and when they lock, and suggest unlocking any you keep getting prompted for | `agents secrets status` |

--- a/apps/cli/src/commands/defaults.test.ts
+++ b/apps/cli/src/commands/defaults.test.ts
@@ -36,20 +36,23 @@ describe('defaults command', () => {
   });
 
   it('sets, lists, and unsets run defaults', () => {
-    const setOut = runAgents(home, ['defaults', 'run', 'set', 'claude@2.1.45', '--mode', 'full', '--model', 'opus']);
+    const setOut = runAgents(home, ['defaults', 'run', 'set', 'claude@2.1.45', '--mode', 'full', '--model', 'opus', '--effort', 'high']);
     expect(setOut).toContain('claude:2.1.45');
     expect(setOut).toContain('mode skip');
     expect(setOut).toContain('model opus');
+    expect(setOut).toContain('effort high');
 
     const yaml = fs.readFileSync(path.join(home, '.agents', 'agents.yaml'), 'utf-8');
     expect(yaml).toContain('claude:2.1.45');
     expect(yaml).toContain('mode: skip');
     expect(yaml).toContain('model: opus');
+    expect(yaml).toContain('effort: high');
 
     const listOut = runAgents(home, ['defaults', 'run', 'list']);
     expect(listOut).toContain('claude:2.1.45');
     expect(listOut).toContain('mode skip');
     expect(listOut).toContain('model opus');
+    expect(listOut).toContain('effort high');
 
     const unsetOut = runAgents(home, ['defaults', 'run', 'unset', 'claude:2.1.45']);
     expect(unsetOut).toContain('Removed run default claude:2.1.45');

--- a/apps/cli/src/commands/defaults.ts
+++ b/apps/cli/src/commands/defaults.ts
@@ -18,6 +18,7 @@ import { getProjectRoot, setProjectRoot } from '../lib/project-root.js';
 interface RunDefaultsSetOptions {
   mode?: string;
   model?: string;
+  effort?: string;
 }
 
 export function registerDefaultsCommands(program: Command): void {
@@ -65,11 +66,13 @@ export function registerDefaultsCommands(program: Command): void {
     .description('Set defaults for an agent/version selector')
     .option('--mode <mode>', "Default mode: plan, edit, auto, skip. 'full' accepted as alias for skip.")
     .option('--model <model>', 'Default model or model alias, forwarded via --model')
+    .option('--effort <effort>', 'Default reasoning effort: low, medium, high, xhigh, max, or auto')
     .action((selector: string, options: RunDefaultsSetOptions) => {
       try {
         const entry = setRunDefault(selector, {
           ...(options.mode !== undefined ? { mode: options.mode } : {}),
           ...(options.model !== undefined ? { model: options.model } : {}),
+          ...(options.effort !== undefined ? { effort: options.effort } : {}),
         });
         console.log(chalk.green('Set run default:'));
         console.log(`  ${formatRunDefaultEntry(entry)}`);

--- a/apps/cli/src/commands/exec.ts
+++ b/apps/cli/src/commands/exec.ts
@@ -2839,7 +2839,8 @@ export function registerRunCommand(program: Command): void {
         process.exit(1);
       }
 
-      const effort = options.effort as ExecEffort;
+      const effortSource = runCmd.getOptionValueSource('effort');
+      const effort = (effortSource === 'default' && runDefaults.effort ? runDefaults.effort : options.effort) as ExecEffort;
       if (!['low', 'medium', 'high', 'xhigh', 'max', 'auto'].includes(effort)) {
         console.error(chalk.red(`Invalid effort: ${effort}. Use 'low', 'medium', 'high', 'xhigh', 'max', or 'auto'`));
         process.exit(1);

--- a/apps/cli/src/commands/secrets.test.ts
+++ b/apps/cli/src/commands/secrets.test.ts
@@ -9,6 +9,7 @@ import {
   assertValidSshTarget,
   assertNeverPolicyAcknowledged,
   buildRemoteUnlockArgs,
+  resolveUnlockTtlMs,
   buildSecretsExecEnv,
   bundleEnvToDotenv,
   exportBundleToFile,
@@ -707,6 +708,20 @@ describe('readImportDotenv', () => {
   });
 });
 
+describe('resolveUnlockTtlMs', () => {
+  const now = Date.parse('2026-08-05T12:00:00Z');
+
+  it('converts an absolute date to the remaining TTL', () => {
+    expect(resolveUnlockTtlMs(undefined, '2026-08-06T12:00:00Z', now)).toBe(86_400_000);
+  });
+
+  it('rejects invalid, past, and conflicting dates', () => {
+    expect(() => resolveUnlockTtlMs(undefined, 'not-a-date', now)).toThrow('Invalid --until');
+    expect(() => resolveUnlockTtlMs(undefined, '2026-08-04', now)).toThrow('date must be in the future');
+    expect(() => resolveUnlockTtlMs('2h', '2026-08-06', now)).toThrow('mutually exclusive');
+  });
+});
+
 describe('buildRemoteUnlockArgs (unlock --host wiring)', () => {
   it('forwards explicit bundle names', () => {
     expect(buildRemoteUnlockArgs(['a', 'b'], {})).toEqual(['unlock', 'a', 'b']);
@@ -722,6 +737,11 @@ describe('buildRemoteUnlockArgs (unlock --host wiring)', () => {
 
   it('--all wins over any stray names', () => {
     expect(buildRemoteUnlockArgs(['x'], { all: true })).toEqual(['unlock', '--all']);
+  });
+
+  it('forwards --until verbatim for the remote to parse', () => {
+    expect(buildRemoteUnlockArgs(['a'], { until: '2026-08-06T12:00:00Z' }))
+      .toEqual(['unlock', 'a', '--until', '2026-08-06T12:00:00Z']);
   });
 
   it('forwards --durable so the remote honors it (not silently downgraded)', () => {

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -378,11 +378,28 @@ function maybePrintSyncedHint(name: string, stillPresent: boolean): void {
  * defaults). Shared with the command action so the wiring is unit-testable
  * without a live SSH session.
  */
-export function buildRemoteUnlockArgs(names: string[], opts: { all?: boolean; ttl?: string; durable?: boolean }): string[] {
+export function resolveUnlockTtlMs(ttl: string | undefined, until: string | undefined, now: number = Date.now()): number {
+  if (ttl && until) throw new Error('--ttl and --until are mutually exclusive.');
+  if (until) {
+    const expiresAt = Date.parse(until);
+    if (!Number.isFinite(expiresAt)) throw new Error("Invalid --until '" + until + "'. Use an ISO date or timestamp.");
+    if (expiresAt <= now) throw new Error("Invalid --until '" + until + "': date must be in the future.");
+    return expiresAt - now;
+  }
+  if (ttl) {
+    const secs = parseDuration(ttl);
+    if (!secs) throw new Error("Invalid --ttl '" + ttl + "'. Use e.g. 30m, 2h, 8h, 3d.");
+    return secs * 1000;
+  }
+  return secretsHoldMs();
+}
+
+export function buildRemoteUnlockArgs(names: string[], opts: { all?: boolean; ttl?: string; until?: string; durable?: boolean }): string[] {
   return [
     'unlock',
     ...(opts.all ? ['--all'] : names),
     ...(opts.ttl ? ['--ttl', opts.ttl] : []),
+    ...(opts.until ? ['--until', opts.until] : []),
     // Forward --durable so a remote unlock honors it too; without this the remote
     // silently falls back to its own secrets.agent.durable default (off).
     ...(opts.durable ? ['--durable'] : []),
@@ -2636,11 +2653,16 @@ Examples:
     .command('unlock [names...]')
     .description('Hold a bundle in the secrets-agent after one Touch ID, so concurrent runs read it without re-prompting (macOS). With --host, unlock FILE-backed bundle(s) on a remote (the passphrase prompt surfaces over the SSH TTY); keychain/biometry bundles are GUI-only and can\'t be remote-unlocked.')
     .option('--ttl <duration>', 'How long to hold it (e.g. 30m, 8h, 3d). Default 7d.')
+    .option('--until <date>', 'Hold until this absolute date or timestamp (for example 2026-08-06T12:00:00Z). Mutually exclusive with --ttl.')
     .option('--durable', 'Keep the unlock across sleep + reboot too (default: survives upgrade/restart but re-locks on sleep). Set secrets.agent.durable in agents.yaml to make this the default.')
     .option('--for <agent>', 'Narrow the unlock to ONE harness type (for example claude, codex, or kimi). Default: the grant is global — every harness and a plain shell can read it, so one Touch ID covers them all.')
     .option('--all', 'Unlock every configured bundle')
     .option('--host <target>', 'Unlock the bundle(s) on this remote machine over SSH instead of locally (file-backed bundles only — the remote\'s passphrase prompt surfaces on your terminal over a -tt session). Single-valued (NOT variadic) so it never swallows the bundle name: `unlock <name> --host <machine>`.')
-    .action(async (names: string[], opts: { ttl?: string; durable?: boolean; all?: boolean; host?: string; for?: string }) => {
+    .action(async (names: string[], opts: { ttl?: string; until?: string; durable?: boolean; all?: boolean; host?: string; for?: string }) => {
+      if (opts.ttl && opts.until) {
+        console.error(chalk.red('--ttl and --until are mutually exclusive.'));
+        process.exit(1);
+      }
       // Single-valued (not variadic): a variadic --host greedily consumes the
       // positional bundle name (`unlock --host mac wztest` -> host=[mac,wztest],
       // names=[]). Unlock targets one remote at a time anyway.
@@ -2675,6 +2697,12 @@ Examples:
         if (failures > 0) process.exit(1);
         return;
       }
+      if (opts.until) {
+        try { resolveUnlockTtlMs(undefined, opts.until); } catch (err) {
+          console.error(chalk.red((err as Error).message));
+          process.exit(1);
+        }
+      }
       if (process.platform !== 'darwin') {
         // No broker + no biometry prompt off darwin: secrets already resolve
         // durably from the OS store (libsecret / Credential Manager) on every
@@ -2688,15 +2716,14 @@ Examples:
         console.error(chalk.red('Specify one or more bundle names, or --all.'));
         process.exit(1);
       }
-      let ttlMs = secretsHoldMs(); // default hold, capped by secrets.agent.holdMs
-      if (opts.ttl) {
-        const secs = parseDuration(opts.ttl);
-        if (!secs) {
-          console.error(chalk.red(`Invalid --ttl '${opts.ttl}'. Use e.g. 30m, 2h, 8h, 3d.`));
-          process.exit(1);
-        }
-        ttlMs = secs * 1000;
+      let ttlMs: number;
+      try {
+        ttlMs = resolveUnlockTtlMs(opts.ttl, opts.until);
+      } catch (err) {
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
       }
+      const expiresAt = Date.now() + ttlMs;
       if (!(await ensureAgentRunning())) {
         console.error(chalk.red('Could not start the secrets broker.'));
         process.exit(1);
@@ -2722,7 +2749,7 @@ Examples:
             noAgent: true,
             caller: 'unlock secrets',
             agent: harness,
-            duration: humanRemaining(Date.now() + ttlMs),
+            duration: humanRemaining(expiresAt),
             keyMode: 'storage',
           });
           // Migrations are authorized only by this explicit unlock. The bundle
@@ -2738,7 +2765,7 @@ Examples:
             saveSession(name, {
               bundle,
               env,
-              expiresAt: Date.now() + ttlMs,
+              expiresAt,
               sleepPersist: durable,
               harness,
             });
@@ -2757,7 +2784,7 @@ Examples:
               agent: harness,
               ttlMs,
             });
-            console.log(`${chalk.green('unlocked')} ${chalk.cyan(name)} ${chalk.gray(`(${Object.keys(env).length} keys, ${humanRemaining(Date.now() + ttlMs)})`)}`);
+            console.log(`${chalk.green('unlocked')} ${chalk.cyan(name)} ${chalk.gray(`(${Object.keys(env).length} keys, ${humanRemaining(expiresAt)})`)}`);
           } else {
             console.error(chalk.red(`Failed to load '${name}' into the agent.`));
           }

--- a/apps/cli/src/commands/sessions-lifecycle.test.ts
+++ b/apps/cli/src/commands/sessions-lifecycle.test.ts
@@ -39,3 +39,11 @@ describe('sessions lifecycle verbs are grouped under `sessions`', () => {
     expect(migrate!.aliases()).not.toContain('detach');
   });
 });
+
+describe('sessions team filter aliases', () => {
+  it('registers --team as an alias of --teams', () => {
+    const teams = sessionsGroup().options.find((option) => option.long === '--teams');
+    expect(teams).toBeDefined();
+    expect(teams!.short).toBe('--team');
+  });
+});

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -4456,7 +4456,7 @@ export function registerSessionsCommands(program: Command): void {
     .option('--opencode', 'Shorthand for --agent opencode')
     .option('--all', 'Widen every non-status filter to "all": every directory (not just this project) and all time (no window cap). Status filters like --active still compose; -a/--device/--since still narrow their axis.')
     .option('--unmanaged', "Also show sessions from your own ~/.<agent> installs (hidden once agents-cli manages that agent)")
-    .option('--teams', 'Include team-spawned sessions (hidden by default)')
+    .option('--team, --teams', 'Include team-spawned sessions (hidden by default)')
     .option('--in-team <name>', "Only this team: the session that spawned it plus (with --teams) its teammates. Spans every directory and all time, since a team's worktrees and history sit outside the default window.")
     .option('--routine', 'Show only sessions archived from routine runs')
     .option('-p, --project <name>', 'Filter by project name (searches across all directories)')

--- a/apps/cli/src/commands/view.ts
+++ b/apps/cli/src/commands/view.ts
@@ -686,6 +686,7 @@ async function showInstalledVersions(
         const runDefaults = resolveRunDefaults(agentId, version);
         const runDefaultBits: string[] = [];
         if (runDefaults.mode) runDefaultBits.push(`mode:${runDefaults.mode}`);
+        if (runDefaults.effort) runDefaultBits.push('effort:' + runDefaults.effort);
 
         if (!hasEmail && !hasUsage && !signedIn) {
           // No per-version credential. That is NOT the same as unusable: Claude

--- a/apps/cli/src/lib/run-defaults.test.ts
+++ b/apps/cli/src/lib/run-defaults.test.ts
@@ -44,9 +44,11 @@ describe('run defaults', () => {
         'claude:*': {
           mode: 'auto',
           model: 'opus',
+          effort: 'medium',
         },
         'claude:2.1.45': {
           mode: 'plan',
+          effort: 'high',
         },
       },
     };
@@ -54,9 +56,11 @@ describe('run defaults', () => {
     expect(resolveRunDefaultsFromConfig(config, 'claude', '2.1.45')).toEqual({
       mode: 'plan',
       model: 'opus',
+      effort: 'high',
       sources: {
         mode: 'claude:2.1.45',
         model: 'claude:*',
+        effort: 'claude:2.1.45',
       },
     });
   });
@@ -106,5 +110,9 @@ describe('run defaults', () => {
         model: 'claude:*',
       },
     });
+  });
+  it('rejects invalid configured effort', () => {
+    expect(() => resolveRunDefaultsFromConfig({ defaults: { 'codex:*': { effort: 'extreme' as never } } }, 'codex', '0.1.0'))
+      .toThrow(/Invalid effort/);
   });
 });

--- a/apps/cli/src/lib/run-defaults.ts
+++ b/apps/cli/src/lib/run-defaults.ts
@@ -12,7 +12,7 @@
  *         mode: plan
  */
 
-import type { AgentId, Mode, RunConfig, RunDefaults } from './types.js';
+import type { AgentId, Mode, RunConfig, RunDefaults, RunEffort } from './types.js';
 import { ALL_MODES } from './types.js';
 import { AGENTS } from './agents.js';
 import { readMeta, updateMeta } from './state.js';
@@ -31,6 +31,7 @@ export interface ResolvedRunDefaults extends RunDefaults {
   sources: {
     mode?: string;
     model?: string;
+    effort?: string;
   };
 }
 
@@ -42,7 +43,10 @@ export interface RunDefaultEntry {
 type RunDefaultsInput = {
   mode?: unknown;
   model?: unknown;
+  effort?: unknown;
 };
+
+const RUN_EFFORTS: readonly RunEffort[] = ['low', 'medium', 'high', 'xhigh', 'max', 'auto'];
 
 function isAgentId(value: string): value is AgentId {
   return value in AGENTS;
@@ -70,6 +74,13 @@ function normalizeRunDefaults(defaults: RunDefaultsInput, selector: string): Run
       throw new Error(`Invalid model in run.defaults.${selector}: expected a non-empty string.`);
     }
     out.model = defaults.model.trim();
+  }
+
+  if (defaults.effort !== undefined) {
+    if (typeof defaults.effort !== 'string' || !RUN_EFFORTS.includes(defaults.effort as RunEffort)) {
+      throw new Error('Invalid effort in run.defaults.' + selector + ': use one of: ' + RUN_EFFORTS.join(', ') + '.');
+    }
+    out.effort = defaults.effort as RunEffort;
   }
 
   return out;
@@ -138,6 +149,10 @@ export function resolveRunDefaultsFromConfig(
     resolved.model = wildcard.model;
     resolved.sources.model = wildcardSelector;
   }
+  if (wildcard?.effort) {
+    resolved.effort = wildcard.effort;
+    resolved.sources.effort = wildcardSelector;
+  }
 
   if (exactSelector && defaults[exactSelector]) {
     const exact = normalizeRunDefaults(defaults[exactSelector], exactSelector);
@@ -148,6 +163,10 @@ export function resolveRunDefaultsFromConfig(
     if (exact.model) {
       resolved.model = exact.model;
       resolved.sources.model = exactSelector;
+    }
+    if (exact.effort) {
+      resolved.effort = exact.effort;
+      resolved.sources.effort = exactSelector;
     }
   }
 
@@ -171,6 +190,10 @@ export function resolveRunDefaultsFromConfigs(
       resolved.model = next.model;
       resolved.sources.model = next.sources.model;
     }
+    if (next.effort) {
+      resolved.effort = next.effort;
+      resolved.sources.effort = next.sources.effort;
+    }
   }
 
   return resolved;
@@ -189,6 +212,7 @@ export function formatRunDefaultEntry(entry: RunDefaultEntry): string {
   const parts: string[] = [];
   if (entry.defaults.mode) parts.push(`mode ${chalk.white(entry.defaults.mode)}`);
   if (entry.defaults.model) parts.push(`model ${chalk.white(entry.defaults.model)}`);
+  if (entry.defaults.effort) parts.push('effort ' + chalk.white(entry.defaults.effort));
   return `${chalk.cyan(entry.selector.padEnd(22))} ${parts.join('  ')}`;
 }
 
@@ -205,8 +229,8 @@ export function listRunDefaults(): RunDefaultEntry[] {
 export function setRunDefault(selectorInput: string, defaultsInput: RunDefaultsInput): RunDefaultEntry {
   const parsed = parseRunDefaultSelector(selectorInput);
   const defaults = normalizeRunDefaults(defaultsInput, parsed.selector);
-  if (!defaults.mode && !defaults.model) {
-    throw new Error('Set at least one default: --mode <mode> or --model <model>.');
+  if (!defaults.mode && !defaults.model && !defaults.effort) {
+    throw new Error('Set at least one default: --mode <mode>, --model <model>, or --effort <effort>.');
   }
 
   updateMeta((meta) => {

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -15,6 +15,8 @@ export type AgentId = 'claude' | 'codex' | 'gemini' | 'cursor' | 'opencode' | 'o
 /** How `agents run <agent>` chooses an installed version when none is pinned. */
 export type RunStrategy = 'pinned' | 'available' | 'balanced';
 
+export type RunEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
+
 /**
  * Reserved `<agent>` keyword for `agents run auto` — full-auto dispatch:
  * host (14d launch affinity) → harness (best-account headroom, weighted) →
@@ -43,6 +45,7 @@ export interface AgentRunConfig {
 export interface RunDefaults {
   mode?: Mode;
   model?: string;
+  effort?: RunEffort;
 }
 
 /** `run:` section in agents.yaml. Agent keys keep strategy; `defaults` stores selector rules. */


### PR DESCRIPTION
Adds three small CLI features for RUSH-1995, RUSH-1960, and RUSH-2005.

## What changed

- `agents sessions --team` is now an alias of `--teams`.
- `agents secrets unlock --until <date>` converts an absolute date to the existing expiry timestamp and rejects use with `--ttl`.
- Per-agent-version run defaults now persist `effort`, apply it when `--effort` is omitted, and show it in `agents view`.

## Verification

No UI surface. The real built help output and targeted test run were captured at `yosemite-s0:/tmp/rush-1995-1960-2005-verification.txt`. Public asset upload was unavailable because the configured `share` bundle is locked.

- `bun run build` passed against current `origin/main`.
- Targeted Vitest run: 4 files passed, 85 tests passed.
- Built help output contains `--team, --teams`.
- Built help output contains `--until <date>` and its mutual-exclusion wording.

## Tracking

RUSH-1995 · RUSH-1960 · RUSH-2005
