### PR TITLE
chore(factory): prepare 0.9.313 release

### DIFF
--- a/apps/factory/CHANGELOG.md
+++ b/apps/factory/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Factory extension are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.9.313] - 2026-08-05
+
 - **Resume delegates session lifecycle to agents-cli.** The picker keeps its
   cross-device session list but starts with no rows selected. A chosen row sends
   only `agents sessions resume <canonical-id>`; the CLI decides whether to attach


### PR DESCRIPTION
Release-only metadata for Factory 0.9.313.

## What changed

- Moves the shipped session-resume behavior into a dated 0.9.313 changelog section.
- Leaves `Unreleased` ready for subsequent changes.

## Verification

Release-only change; `apps/factory/scripts/release.sh 0.9.313 --confirm` validates the section before publishing.