### PR TITLE
feat(secrets): AGENTS_SYNC_PASSPHRASE for transport, split from the store master key (RUSH-1968)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1968-sync-passphrase.md
+++ b/apps/cli/.changelog/next/RUSH-1968-sync-passphrase.md
@@ -1,0 +1,21 @@
+- **`agents secrets push`/`pull` and `agents sync --secrets` read `AGENTS_SYNC_PASSPHRASE`
+  now; `AGENTS_SECRETS_PASSPHRASE` is the file store's master key and nothing else
+  (RUSH-1968).** One variable meant two different secrets: the local file store's master
+  key, and the passphrase that seals a bundle for transport. The store stopped needing a
+  passphrase once it auto-provisioned a machine-local key, but headless `push`/`pull`
+  still hard-failed without one — so the only way to get unattended sync on a worker box
+  was to export the **master key** fleet-wide, handing every same-user process the key to
+  the whole store. Splitting them means a box that only needs headless sync sets
+  `AGENTS_SYNC_PASSPHRASE` and never has the master key in its environment. The old name
+  still works for sync as a deprecated fallback — warned exactly once per process, so a
+  `push --all` over many bundles does not flood stderr — so scripted CI and release
+  automation keep working across the upgrade. The headless error now names the new
+  variable (`A sync passphrase is required. Run from a TTY, or set
+  AGENTS_SYNC_PASSPHRASE.`), and `agents sync`'s skip reason with it. Resolution moved to
+  one chokepoint so the once-per-process promise holds rather than being per-call-site. Also
+  corrects `SEC-29a`, which claimed the variable applied "exclusively" to the file and
+  age-vault backends: the age-vault backend never reads it (it is gated by `agents
+  login`), and sync plus the portable `--to-file` envelope were two more consumers — the
+  new `SEC-29b` states the split as a normative invariant. Source:
+  `apps/cli/src/lib/secrets/sync-passphrase.ts`, `apps/cli/src/commands/secrets-sync.ts`,
+  `apps/cli/src/commands/sync.ts`, `apps/cli/src/lib/sync-umbrella.ts`.

--- a/apps/cli/.changelog/next/RUSH-1968-sync-passphrase.md
+++ b/apps/cli/.changelog/next/RUSH-1968-sync-passphrase.md
@@ -1,5 +1,6 @@
-- **`agents secrets push`/`pull` and `agents sync --secrets` read `AGENTS_SYNC_PASSPHRASE`
-  now; `AGENTS_SECRETS_PASSPHRASE` is the file store's master key and nothing else
+- **`agents secrets push`/`pull`, `agents sync --secrets`, and `agents secrets
+  export --to-file` / `import --from-file` read `AGENTS_SYNC_PASSPHRASE` now;
+  `AGENTS_SECRETS_PASSPHRASE` is the file store's master key and nothing else
   (RUSH-1968).** One variable meant two different secrets: the local file store's master
   key, and the passphrase that seals a bundle for transport. The store stopped needing a
   passphrase once it auto-provisioned a machine-local key, but headless `push`/`pull`
@@ -11,7 +12,10 @@
   `push --all` over many bundles does not flood stderr — so scripted CI and release
   automation keep working across the upgrade. The headless error now names the new
   variable (`A sync passphrase is required. Run from a TTY, or set
-  AGENTS_SYNC_PASSPHRASE.`), and `agents sync`'s skip reason with it. Resolution moved to
+  AGENTS_SYNC_PASSPHRASE.`), and `agents sync`'s skip line with it — it previously read
+  `no passphrase available`, naming nothing an operator could act on. Note the legacy
+  fallback only works where that value is also the store's master key, since the old name
+  still keys the store; that coupling is the thing being retired. Resolution moved to
   one chokepoint so the once-per-process promise holds rather than being per-call-site. Also
   corrects `SEC-29a`, which claimed the variable applied "exclusively" to the file and
   age-vault backends: the age-vault backend never reads it (it is gated by `agents

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -384,14 +384,14 @@ The Windows push bridge is `buildWindowsStdinImportCommand` in
 | `secrets import [bundle] --from 1password:<vault>` | Import from a 1Password vault (requires `op` CLI; `--from-1password --vault <name>` is a deprecated alias) | `agents secrets import prod --from 1password:Personal` |
 | `secrets import [bundle] --from icloud` | Recover a bundle stranded in the iCloud Keychain by the pre-biometry era (macOS; omit the bundle name for an interactive multi-select of everything discovered) | `agents secrets import hetzner.com --from icloud` |
 | `secrets import --from icloud --purge` | After a successful import, delete the iCloud copies (propagates to your other devices) | `agents secrets import --from icloud --purge` |
-| `secrets import [bundle] --from-file <path>` | Recover from an AES-256-GCM encrypted offline bundle file (needs `AGENTS_SECRETS_PASSPHRASE`; server-independent, symmetric counterpart of `export --to-file`) | `agents secrets import prod --from-file prod.enc` |
+| `secrets import [bundle] --from-file <path>` | Recover from an AES-256-GCM encrypted offline bundle file (needs `AGENTS_SYNC_PASSPHRASE`; server-independent, symmetric counterpart of `export --to-file`) | `agents secrets import prod --from-file prod.enc` |
 | `secrets import [bundle] --from-ssh --host <peer>` | Pull a bundle from a fleet peer over SSH and import it locally (no dependency on api.prix.dev) | `agents secrets import prod --from-ssh --host mac-mini` |
 | `secrets import ... --all-plaintext` | Store imported values as literals, skip keychain | `agents secrets import prod --from .env --all-plaintext` |
 | `secrets import ... --force` | Overwrite existing keys | `agents secrets import prod --from .env --force` |
 | `secrets export [bundle]` | Print `KEY=VALUE` lines for shell eval | `eval "$(agents secrets export prod --plaintext)"` |
 | `secrets export [bundle] --to-1password --vault <name>` | Push bundle to a 1Password vault | `agents secrets export prod --to-1password --vault Team` |
 | `secrets export ... --force` | Overwrite existing 1Password items | `agents secrets export prod --to-1password --vault Team --force` |
-| `secrets export [bundle] --to-file <path>` | Write the bundle as an AES-256-GCM encrypted offline file (needs `AGENTS_SECRETS_PASSPHRASE`; symmetric counterpart of `import --from-file`) | `agents secrets export prod --to-file prod.enc` |
+| `secrets export [bundle] --to-file <path>` | Write the bundle as an AES-256-GCM encrypted offline file (needs `AGENTS_SYNC_PASSPHRASE`; symmetric counterpart of `import --from-file`) | `agents secrets export prod --to-file prod.enc` |
 | `secrets export [bundle] --host <target>` | Push the bundle over SSH to a remote (repeatable; `--device` is an alias). Keychain-backed by default; the push read-back-verifies the write and fails loudly if it didn't persist | `agents secrets export apple.com --host mac-mini` |
 | `secrets export ... --remote-backend file` | Push as a headless-readable file bundle (no passphrase — the remote keys it with its machine-local key; forwards `AGENTS_SECRETS_PASSPHRASE` only if set) — for a **headless sign host** whose login keychain is locked over SSH | `agents secrets export apple.com --host mac-mini --remote-backend file` |
 
@@ -574,6 +574,8 @@ agents secrets pull prod
 ```
 
 Plaintext never leaves the machine — the bundle is sealed with AES-256-GCM before upload. Source: `src/commands/secrets-sync.ts:7-8`.
+
+Headless (CI, a worker box with no TTY), set `AGENTS_SYNC_PASSPHRASE` instead of being prompted. That is the **transport** passphrase and nothing else — deliberately not `AGENTS_SECRETS_PASSPHRASE`, which is the file store's master key (see [File-backed bundles](#file-backed-bundles-headless--remote)). Exporting the master key to get headless sync hands every same-user process the key to the whole store, which is what RUSH-1968 was. The old name is still accepted here and warns once per process. Source: `src/lib/secrets/sync-passphrase.ts`.
 
 ### 6. Run a one-off command with secrets
 

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -1133,9 +1133,20 @@ access control (that is 1Password/Vault; this tool is device-local first).
 - **SEC-29a (MUST NOT).** The default keychain flow MUST NOT require a passphrase or
   read one from an environment variable to keep a bundle unlocked. On macOS the
   Keychain is gated by the OS login only; `AGENTS_SECRETS_PASSPHRASE` applies
-  **exclusively** to the encrypted-file (SEC-2) and age-vault (SEC-3) fallback
-  backends and MUST NOT be introduced into, or required by, the keychain path
-  (SEC-8 already strips it from every injected child env).
+  **exclusively** to the encrypted-file store (SEC-2) — it is that store's master
+  key and nothing else — and MUST NOT be introduced into, or required by, the
+  keychain path (SEC-8 already strips it from every injected child env). The
+  age-vault backend (SEC-3) does NOT read it; that backend is gated by
+  `agents login` (`lib/secrets/vault.ts`).
+- **SEC-29b (MUST).** Transport passphrases MUST use `AGENTS_SYNC_PASSPHRASE`, not
+  the file-store master key: `push`/`pull` (SEC-23) and the portable
+  `export --to-file` / `import --from-file` envelope seal data for a DIFFERENT
+  trust boundary than the local store. `AGENTS_SECRETS_PASSPHRASE` MUST remain
+  honoured there only as a deprecated fallback, warned exactly once per process
+  (`lib/secrets/sync-passphrase.ts`). Overloading one variable for both is what
+  put a file-store master key into a shell rc file on seven worker boxes
+  (RUSH-1968): the store stopped needing a passphrase, headless sync still did,
+  so the master key was exported fleet-wide to satisfy sync.
 
 #### 3.5 Sharing & sync
 

--- a/apps/cli/src/commands/secrets-sync.ts
+++ b/apps/cli/src/commands/secrets-sync.ts
@@ -17,10 +17,15 @@ import {
 } from '../lib/secrets/sync.js';
 import { bundleExists, listBundles } from '../lib/secrets/bundles.js';
 import { isInteractiveTerminal, isPromptCancelled } from './utils.js';
+import {
+  missingSyncPassphraseMessage,
+  resolveSyncPassphraseFromEnv,
+  warnEnvPassphraseReadableOnce,
+} from '../lib/secrets/sync-passphrase.js';
 
 async function promptPassphrase(message: string, confirm = false): Promise<string> {
   if (!isInteractiveTerminal()) {
-    throw new Error('A sync passphrase is required. Run from a TTY, or set AGENTS_SECRETS_PASSPHRASE.');
+    throw new Error(missingSyncPassphraseMessage());
   }
   const { password } = await import('@inquirer/prompts');
   const first = await password({ message, mask: true });
@@ -31,24 +36,18 @@ async function promptPassphrase(message: string, confirm = false): Promise<strin
   return first;
 }
 
-// Print the env-var-source warning at most once per process so a `--all` push
-// over many bundles doesn't flood stderr with the same notice.
-let envPassphraseWarned = false;
-
 function passphraseFromEnvOrPrompt(confirm: boolean): Promise<string> {
-  const fromEnv = process.env.AGENTS_SECRETS_PASSPHRASE;
-  if (fromEnv) {
-    if (fromEnv.length < MIN_PASSPHRASE_LEN) {
+  // Env resolution (current name, then the deprecated master-key name) lives in
+  // lib/secrets/sync-passphrase.ts so this command and `agents sync` share one
+  // chokepoint — otherwise each call site warns separately and the "once per
+  // process" promise is a lie.
+  const { value } = resolveSyncPassphraseFromEnv();
+  if (value) {
+    if (value.length < MIN_PASSPHRASE_LEN) {
       return Promise.reject(new Error(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`));
     }
-    if (!envPassphraseWarned) {
-      envPassphraseWarned = true;
-      process.stderr.write(chalk.yellow(
-        'warn: using AGENTS_SECRETS_PASSPHRASE. Env vars are readable by other same-user processes ' +
-        '(/proc, ps, crash dumps, CI logs) — rotate the passphrase after CI use.\n',
-      ));
-    }
-    return Promise.resolve(fromEnv);
+    warnEnvPassphraseReadableOnce();
+    return Promise.resolve(value);
   }
   return promptPassphrase('Sync passphrase', confirm);
 }

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -113,6 +113,7 @@ import { readMeta } from '../lib/state.js';
 import { parseDuration } from '../lib/hooks/cache.js';
 import { emit, query } from '../lib/events.js';
 import { emitSecretAudit } from '../lib/secrets/audit.js';
+import { SYNC_PASSPHRASE_ENV, resolveSyncPassphraseFromEnv } from '../lib/secrets/sync-passphrase.js';
 import {
   getBundleUsage,
   getAllBundleUsage,
@@ -2070,7 +2071,7 @@ Examples:
     .option('--synced', 'When creating the bundle, store it in the age-encrypted synced secrets file')
     .option('--force', 'Overwrite an existing key in the bundle')
     .option('--purge', 'With --from icloud: delete the iCloud copies after a successful import (iCloud propagates the deletion to your other devices)')
-    .option('--from-file <path>', 'Import from an AES-256-GCM encrypted offline bundle file (needs AGENTS_SECRETS_PASSPHRASE; symmetric counterpart of export --to-file)')
+    .option('--from-file <path>', `Import from an AES-256-GCM encrypted offline bundle file (needs ${SYNC_PASSPHRASE_ENV}; symmetric counterpart of export --to-file)`)
     .option('--from-ssh', 'Pull the bundle from a fleet peer over SSH and import it locally (requires --host)')
     .option('--host <peer>', 'SSH peer to pull from when using --from-ssh (host alias or user@host)')
     .action(async (bundleName: string | undefined, opts: {
@@ -2100,10 +2101,11 @@ Examples:
           );
         }
         if (opts.fromFile) {
-          const passphrase = process.env.AGENTS_SECRETS_PASSPHRASE ?? '';
+          // Transport, not the local store's master key — see lib/secrets/sync-passphrase.ts.
+          const passphrase = resolveSyncPassphraseFromEnv().value ?? '';
           if (!passphrase) {
             throw new Error(
-              '--from-file needs AGENTS_SECRETS_PASSPHRASE set to decrypt the bundle file.'
+              `--from-file needs ${SYNC_PASSPHRASE_ENV} set to decrypt the bundle file.`
             );
           }
           const env = importBundleFromFile(opts.fromFile, passphrase);
@@ -2194,7 +2196,7 @@ Examples:
     .option('--remote-backend <backend>', 'Backend for the bundle on the remote (with --host): keychain (default) or file. file is headless-readable via the remote\'s machine-local key; it forwards AGENTS_SECRETS_PASSPHRASE over stdin only if set (opt-in).', 'keychain')
     .option('--force', 'Overwrite existing keys/items on the target (used with --to-1password and --host)')
     .option('--format <shell|json>', 'Output for --plaintext export: shell (default) or json (lossless, machine-readable; used by remote resolve)', 'shell')
-    .option('--to-file <path>', 'Write the bundle as an AES-256-GCM encrypted offline file (needs AGENTS_SECRETS_PASSPHRASE; symmetric counterpart of import --from-file)')
+    .option('--to-file <path>', `Write the bundle as an AES-256-GCM encrypted offline file (needs ${SYNC_PASSPHRASE_ENV}; symmetric counterpart of import --from-file)`)
     .action(async (bundleName: string | undefined, opts: {
       plaintext?: boolean;
       to1password?: boolean;
@@ -2215,10 +2217,11 @@ Examples:
         const resolvedBundleName = bundleName ?? (await pickBundleName('export'));
 
         if (opts.toFile) {
-          const passphrase = process.env.AGENTS_SECRETS_PASSPHRASE ?? '';
+          // Transport, not the local store's master key — see lib/secrets/sync-passphrase.ts.
+          const passphrase = resolveSyncPassphraseFromEnv().value ?? '';
           if (!passphrase) {
             throw new Error(
-              '--to-file needs AGENTS_SECRETS_PASSPHRASE set to encrypt the bundle. ' +
+              `--to-file needs ${SYNC_PASSPHRASE_ENV} set to encrypt the bundle. ` +
               'Set it for this command, then supply the same value when importing.'
             );
           }

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -33,6 +33,7 @@
 import * as path from 'path';
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { resolveSyncPassphraseFromEnv } from '../lib/secrets/sync-passphrase.js';
 import { agentLabel, resolveAgentName, MANAGED_AGENT_IDS, isAgentHardDeprecated, hardDeprecationError } from '../lib/agents.js';
 import type { AgentId } from '../lib/types.js';
 import {
@@ -279,7 +280,9 @@ async function runUmbrella(
     cloud: opts.cloud,
     local: opts.local,
   };
-  const passphrase = process.env.AGENTS_SECRETS_PASSPHRASE || undefined;
+  // Same chokepoint as `agents secrets push/pull` — prefers AGENTS_SYNC_PASSPHRASE,
+  // falls back to the deprecated master-key name with a single warning.
+  const passphrase = resolveSyncPassphraseFromEnv().value ?? undefined;
 
   if (!quiet) outLog(chalk.bold('Syncing this machine…'));
   try {

--- a/apps/cli/src/lib/secrets/sync-passphrase.test.ts
+++ b/apps/cli/src/lib/secrets/sync-passphrase.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  LEGACY_PASSPHRASE_ENV,
+  SYNC_PASSPHRASE_ENV,
+  missingSyncPassphraseMessage,
+  resetSyncPassphraseWarnings,
+  resolveSyncPassphraseFromEnv,
+  warnEnvPassphraseReadableOnce,
+} from './sync-passphrase.js';
+
+/** Capture stderr for the duration of `fn` — the warnings are the behavior under
+ *  test, so they are observed, never stubbed away. */
+function captureStderr(fn: () => void): string {
+  const chunks: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  (process.stderr as NodeJS.WriteStream).write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    fn();
+  } finally {
+    (process.stderr as NodeJS.WriteStream).write = original;
+  }
+  return chunks.join('');
+}
+
+describe('sync passphrase resolution (RUSH-1968 — split from the file-store master key)', () => {
+  const saved = {
+    sync: process.env[SYNC_PASSPHRASE_ENV],
+    legacy: process.env[LEGACY_PASSPHRASE_ENV],
+  };
+
+  beforeEach(() => {
+    delete process.env[SYNC_PASSPHRASE_ENV];
+    delete process.env[LEGACY_PASSPHRASE_ENV];
+    resetSyncPassphraseWarnings();
+  });
+
+  afterEach(() => {
+    if (saved.sync === undefined) delete process.env[SYNC_PASSPHRASE_ENV];
+    else process.env[SYNC_PASSPHRASE_ENV] = saved.sync;
+    if (saved.legacy === undefined) delete process.env[LEGACY_PASSPHRASE_ENV];
+    else process.env[LEGACY_PASSPHRASE_ENV] = saved.legacy;
+    resetSyncPassphraseWarnings();
+  });
+
+  it('neither set → no value, no source, and nothing printed', () => {
+    const err = captureStderr(() => {
+      expect(resolveSyncPassphraseFromEnv()).toEqual({ value: null, source: null });
+    });
+    expect(err).toBe('');
+  });
+
+  it('the current variable wins and warns nothing about deprecation', () => {
+    process.env[SYNC_PASSPHRASE_ENV] = 'sync-secret';
+    const err = captureStderr(() => {
+      expect(resolveSyncPassphraseFromEnv()).toEqual({ value: 'sync-secret', source: 'sync-env' });
+    });
+    expect(err).toBe('');
+  });
+
+  it('the current variable beats the legacy one when BOTH are set', () => {
+    // The migration case: a box that has set the new name while the old export
+    // is still lying around must not silently keep using the master key.
+    process.env[SYNC_PASSPHRASE_ENV] = 'sync-secret';
+    process.env[LEGACY_PASSPHRASE_ENV] = 'file-store-master-key';
+    const err = captureStderr(() => {
+      expect(resolveSyncPassphraseFromEnv().value).toBe('sync-secret');
+    });
+    expect(err).toBe('');
+  });
+
+  it('falls back to the legacy variable so scripted CI keeps working', () => {
+    process.env[LEGACY_PASSPHRASE_ENV] = 'file-store-master-key';
+    let out = '';
+    out = captureStderr(() => {
+      expect(resolveSyncPassphraseFromEnv()).toEqual({
+        value: 'file-store-master-key',
+        source: 'legacy-env',
+      });
+    });
+    expect(out).toContain(LEGACY_PASSPHRASE_ENV);
+    expect(out).toContain('deprecated');
+    expect(out).toContain(SYNC_PASSPHRASE_ENV);
+  });
+
+  it('the deprecation warning fires exactly ONCE per process, not per call', () => {
+    // `push --all` resolves once per bundle; without the latch this floods stderr.
+    process.env[LEGACY_PASSPHRASE_ENV] = 'file-store-master-key';
+    const first = captureStderr(() => { resolveSyncPassphraseFromEnv(); });
+    const second = captureStderr(() => { resolveSyncPassphraseFromEnv(); });
+    const third = captureStderr(() => { resolveSyncPassphraseFromEnv(); });
+    expect(first).toContain('deprecated');
+    expect(second).toBe('');
+    expect(third).toBe('');
+  });
+
+  it('the readability warning is separate and also fires once', () => {
+    // A caller on the CURRENT variable still deserves the /proc readability
+    // notice — it must not be swallowed by the deprecation latch.
+    const first = captureStderr(() => { warnEnvPassphraseReadableOnce(); });
+    const second = captureStderr(() => { warnEnvPassphraseReadableOnce(); });
+    expect(first).toContain('readable by other');
+    expect(second).toBe('');
+  });
+
+  it('the headless error names the CURRENT variable, not the master key', () => {
+    // This message is what an operator follows when sync fails on a worker box.
+    // Naming the master key here is what put it into ~/.zshenv on seven boxes.
+    const msg = missingSyncPassphraseMessage();
+    expect(msg).toContain(SYNC_PASSPHRASE_ENV);
+    expect(msg).not.toContain(LEGACY_PASSPHRASE_ENV);
+  });
+});

--- a/apps/cli/src/lib/secrets/sync-passphrase.ts
+++ b/apps/cli/src/lib/secrets/sync-passphrase.ts
@@ -1,0 +1,95 @@
+/**
+ * The passphrase that seals a bundle for TRANSPORT — `secrets push`/`pull` and
+ * the portable `export --to-file` / `import --from-file` envelope.
+ *
+ * This is deliberately a DIFFERENT secret from the file store's master key
+ * (`AGENTS_SECRETS_PASSPHRASE`, `filestore.ts:getPassphrase`). The two were one
+ * variable, and that overload is what put a master key into `~/.zshenv` on seven
+ * worker boxes (RUSH-1968): the file store stopped needing a passphrase once it
+ * auto-provisioned a machine-local key, but headless `push`/`pull` still hard-
+ * failed without one, so an operator exported the master key fleet-wide to make
+ * sync work — handing every same-user process the key to the whole store.
+ *
+ * Splitting them means a box that only needs headless sync sets
+ * `AGENTS_SYNC_PASSPHRASE` and never has the store's master key in its
+ * environment at all.
+ *
+ * Resolution order:
+ *   1. `AGENTS_SYNC_PASSPHRASE`        — the current name.
+ *   2. `AGENTS_SECRETS_PASSPHRASE`     — deprecated fallback, warns once.
+ *   3. (caller prompts, or fails)
+ *
+ * The fallback exists so already-scripted CI and release automation keep working
+ * across the upgrade; it is not a second supported spelling.
+ */
+import chalk from 'chalk';
+
+/** The current variable for transport/sync passphrases. */
+export const SYNC_PASSPHRASE_ENV = 'AGENTS_SYNC_PASSPHRASE';
+/** The file-store master key, honoured for sync only as a deprecated fallback. */
+export const LEGACY_PASSPHRASE_ENV = 'AGENTS_SECRETS_PASSPHRASE';
+
+/** Warn at most once per process: a `--all` push over many bundles must not
+ *  flood stderr with the same notice. */
+let deprecatedVarWarned = false;
+/** Same, for the "this came from an env var at all" readability notice. */
+let envPassphraseWarned = false;
+
+/** Reset the one-shot warning latches. Tests only — production never re-warns. */
+export function resetSyncPassphraseWarnings(): void {
+  deprecatedVarWarned = false;
+  envPassphraseWarned = false;
+}
+
+/** Where a resolved sync passphrase came from, so callers can report honestly. */
+export type SyncPassphraseSource = 'sync-env' | 'legacy-env' | null;
+
+export interface ResolvedSyncPassphrase {
+  value: string | null;
+  source: SyncPassphraseSource;
+}
+
+/**
+ * Read the transport passphrase from the environment, preferring the current
+ * variable and falling back to the deprecated one with a single warning.
+ * Returns `{ value: null }` when neither is set — the caller decides whether to
+ * prompt (TTY) or fail (headless). Never prompts, never throws.
+ */
+export function resolveSyncPassphraseFromEnv(): ResolvedSyncPassphrase {
+  const current = process.env[SYNC_PASSPHRASE_ENV];
+  if (current) return { value: current, source: 'sync-env' };
+
+  const legacy = process.env[LEGACY_PASSPHRASE_ENV];
+  if (legacy) {
+    if (!deprecatedVarWarned) {
+      deprecatedVarWarned = true;
+      process.stderr.write(chalk.yellow(
+        `warn: ${LEGACY_PASSPHRASE_ENV} is deprecated for sync — it is the file store's master key, ` +
+        `not a transport passphrase. Set ${SYNC_PASSPHRASE_ENV} instead; the old name still works ` +
+        'for now. Keeping the master key in the environment exposes the whole store to every ' +
+        'same-user process (RUSH-1968).\n',
+      ));
+    }
+    return { value: legacy, source: 'legacy-env' };
+  }
+  return { value: null, source: null };
+}
+
+/**
+ * The one-shot reminder that an env-sourced passphrase is readable by other
+ * same-user processes. Separate from the deprecation notice above so a caller
+ * using the CURRENT variable still gets the readability warning exactly once.
+ */
+export function warnEnvPassphraseReadableOnce(): void {
+  if (envPassphraseWarned) return;
+  envPassphraseWarned = true;
+  process.stderr.write(chalk.yellow(
+    'warn: using a sync passphrase from the environment. Env vars are readable by other ' +
+    'same-user processes (/proc, ps, crash dumps, CI logs) — rotate after CI use.\n',
+  ));
+}
+
+/** The message a headless caller shows when no passphrase is available. */
+export function missingSyncPassphraseMessage(): string {
+  return `A sync passphrase is required. Run from a TTY, or set ${SYNC_PASSPHRASE_ENV}.`;
+}

--- a/apps/cli/src/lib/sync-umbrella.ts
+++ b/apps/cli/src/lib/sync-umbrella.ts
@@ -19,6 +19,7 @@
 import { pullRepo } from './git.js';
 import { getUserAgentsDir, getEnabledExtraRepos } from './state.js';
 import { listRemoteBundles, pullBundle } from './secrets/sync.js';
+import { SYNC_PASSPHRASE_ENV } from './secrets/sync-passphrase.js';
 
 /** The umbrella flags off `agents sync`. */
 export interface UmbrellaFlags {
@@ -116,10 +117,10 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
       result.secrets = {
         pulled: 0,
         skipped: true,
-        reason: 'no passphrase — set AGENTS_SYNC_PASSPHRASE or run `agents login` (#366)',
+        reason: `no passphrase — set ${SYNC_PASSPHRASE_ENV} or run \`agents login\` (#366)`,
         errors: [],
       };
-      log('secrets: skipped (no passphrase available)');
+      log(`secrets: skipped (no passphrase — set ${SYNC_PASSPHRASE_ENV})`);
     } else {
       let pulled = 0;
       const errors: string[] = [];

--- a/apps/cli/src/lib/sync-umbrella.ts
+++ b/apps/cli/src/lib/sync-umbrella.ts
@@ -116,7 +116,7 @@ export async function runUmbrellaSync(args: RunUmbrellaArgs): Promise<UmbrellaRe
       result.secrets = {
         pulled: 0,
         skipped: true,
-        reason: 'no passphrase — set AGENTS_SECRETS_PASSPHRASE or run `agents login` (#366)',
+        reason: 'no passphrase — set AGENTS_SYNC_PASSPHRASE or run `agents login` (#366)',
         errors: [],
       };
       log('secrets: skipped (no passphrase available)');

--- a/apps/cli/tests/secrets-transport-passphrase.test.ts
+++ b/apps/cli/tests/secrets-transport-passphrase.test.ts
@@ -1,0 +1,167 @@
+/**
+ * End-to-end: the portable `export --to-file` / `import --from-file` envelope
+ * reads the TRANSPORT passphrase (`AGENTS_SYNC_PASSPHRASE`), not the file
+ * store's master key (RUSH-1968).
+ *
+ * These two are the third consumer of the old overloaded variable. The unit
+ * tests in src/lib/secrets/sync-passphrase.test.ts cover the resolver; this
+ * suite proves the two command call sites are actually wired to it, by driving
+ * the REAL CLI entry under a temp HOME and round-tripping a bundle through an
+ * encrypted file. No mocking — the same path a real invocation takes.
+ *
+ * The store itself stays on its auto-provisioned machine-local key throughout,
+ * which is the whole point: a box can seal a bundle for transport without ever
+ * holding the master key to its own store.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGE_VERSION = (JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'),
+) as { version: string }).version;
+
+const SYNC_ENV = 'AGENTS_SYNC_PASSPHRASE';
+const LEGACY_ENV = 'AGENTS_SECRETS_PASSPHRASE';
+/** Not a real credential — a literal used only to key a throwaway temp bundle. */
+const TRANSPORT_PASS = 'transport-pass-not-a-real-key';
+
+const tempHomes: string[] = [];
+
+function makeTempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-cli-transport-'));
+  tempHomes.push(home);
+  const systemDir = path.join(home, '.agents', '.system');
+  fs.mkdirSync(path.join(systemDir, '.git'), { recursive: true });
+  fs.writeFileSync(
+    path.join(systemDir, '.update-check'),
+    JSON.stringify({ lastCheck: Date.now(), latestVersion: PACKAGE_VERSION }),
+  );
+  return home;
+}
+
+/** Drive the real CLI. `env` REPLACES both passphrase vars so a value leaking
+ *  in from the developer's own shell can never make a negative case pass. */
+function runCli(home: string, args: string[], extraEnv: Record<string, string> = {}) {
+  const env: Record<string, string> = { ...process.env as Record<string, string>, HOME: home, SHELL: '/bin/zsh' };
+  delete env[SYNC_ENV];
+  delete env[LEGACY_ENV];
+  return spawnSync('node', ['--import', 'tsx', 'src/index.ts', ...args], {
+    cwd: REPO_ROOT,
+    env: { ...env, ...extraEnv },
+    encoding: 'utf-8',
+  });
+}
+
+/**
+ * Seed a file-backed bundle with one key, headlessly.
+ *
+ * `storeEnv` keys the store: pass `{}` for the default machine-local key, or
+ * `{ AGENTS_SECRETS_PASSPHRASE }` to model a pre-upgrade box that exports the
+ * master key. That distinction matters — the legacy variable is the STORE key,
+ * so reading a bundle back with it set only works if the store was written
+ * under the same value. That coupling is exactly what this split removes.
+ */
+function seedBundle(
+  home: string, bundle: string, key: string, value: string,
+  storeEnv: Record<string, string> = {},
+): void {
+  const dotenv = path.join(home, 'seed.env');
+  fs.writeFileSync(dotenv, `${key}=${value}\n`);
+  const res = runCli(
+    home,
+    ['secrets', 'import', bundle, '--from', dotenv, '--backend', 'file', '--all-plaintext'],
+    storeEnv,
+  );
+  expect(res.stderr + res.stdout).toContain('Imported');
+}
+
+afterEach(() => {
+  while (tempHomes.length) {
+    const home = tempHomes.pop()!;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe('export --to-file / import --from-file use AGENTS_SYNC_PASSPHRASE (RUSH-1968)', () => {
+  it('round-trips a bundle through an encrypted file under the NEW variable', () => {
+    const home = makeTempHome();
+    seedBundle(home, 'src-bundle', 'DEMO_TOKEN', 'demo-value-123');
+    const sealed = path.join(home, 'bundle.enc');
+
+    const exported = runCli(home, ['secrets', 'export', 'src-bundle', '--to-file', sealed], {
+      [SYNC_ENV]: TRANSPORT_PASS,
+    });
+    expect(exported.stderr + exported.stdout).toContain('Exported');
+    expect(fs.existsSync(sealed)).toBe(true);
+    // Sealed, not plaintext: the value must not be readable in the file.
+    expect(fs.readFileSync(sealed, 'utf-8')).not.toContain('demo-value-123');
+
+    const imported = runCli(
+      home,
+      ['secrets', 'import', 'dst-bundle', '--from-file', sealed, '--backend', 'file'],
+      { [SYNC_ENV]: TRANSPORT_PASS },
+    );
+    expect(imported.stderr + imported.stdout).toContain('Imported 1 key');
+  });
+
+  it('with NEITHER variable set, both halves error naming the NEW variable', () => {
+    const home = makeTempHome();
+    seedBundle(home, 'src-bundle', 'DEMO_TOKEN', 'demo-value-123');
+    const sealed = path.join(home, 'bundle.enc');
+
+    const exported = runCli(home, ['secrets', 'export', 'src-bundle', '--to-file', sealed]);
+    const exportOut = exported.stderr + exported.stdout;
+    expect(exportOut).toContain(SYNC_ENV);
+    // Naming the master key here is what taught operators to export it.
+    expect(exportOut).not.toContain(LEGACY_ENV);
+
+    const imported = runCli(home, ['secrets', 'import', 'dst', '--from-file', sealed]);
+    const importOut = imported.stderr + imported.stdout;
+    expect(importOut).toContain(SYNC_ENV);
+    expect(importOut).not.toContain(LEGACY_ENV);
+  });
+
+  it('still accepts the LEGACY variable on a pre-upgrade box, with a deprecation warning', () => {
+    // The box that already exports the master key — the configuration this PR
+    // exists to retire. Its store is keyed to that same value, so the export
+    // works and nothing scripted breaks across the upgrade.
+    const home = makeTempHome();
+    seedBundle(home, 'src-bundle', 'DEMO_TOKEN', 'demo-value-123', { [LEGACY_ENV]: TRANSPORT_PASS });
+    const sealed = path.join(home, 'bundle.enc');
+
+    const exported = runCli(home, ['secrets', 'export', 'src-bundle', '--to-file', sealed], {
+      [LEGACY_ENV]: TRANSPORT_PASS,
+    });
+    expect(exported.stderr + exported.stdout).toContain('Exported');
+    expect(exported.stderr).toContain('deprecated');
+    expect(exported.stderr).toContain(SYNC_ENV);
+  });
+
+  it('a file sealed on a LEGACY box opens on an upgraded box using the NEW variable', () => {
+    // Same secret, two spellings, two machines: the upgrade must not strand a
+    // file sealed by the other side of the version boundary. Two temp HOMEs,
+    // because each box keys its own store differently.
+    const sender = makeTempHome();
+    const receiver = makeTempHome();
+    seedBundle(sender, 'src-bundle', 'DEMO_TOKEN', 'demo-value-123', { [LEGACY_ENV]: TRANSPORT_PASS });
+    const sealed = path.join(sender, 'bundle.enc');
+
+    const exported = runCli(sender, ['secrets', 'export', 'src-bundle', '--to-file', sealed], {
+      [LEGACY_ENV]: TRANSPORT_PASS,
+    });
+    expect(exported.stderr + exported.stdout).toContain('Exported');
+
+    // The receiver never holds the sender's master key — only the transport one.
+    const imported = runCli(
+      receiver,
+      ['secrets', 'import', 'dst-bundle', '--from-file', sealed, '--backend', 'file'],
+      { [SYNC_ENV]: TRANSPORT_PASS },
+    );
+    expect(imported.stderr + imported.stdout).toContain('Imported 1 key');
+  });
+});


### PR DESCRIPTION
**New `AGENTS_SYNC_PASSPHRASE` for transport, so `AGENTS_SECRETS_PASSPHRASE` means only one thing: the file store's master key.** Behavior change, backward compatible — the old name still works for sync with a one-time deprecation warning.

Ticket: RUSH-1968 (Urgent, open).

## Why

One variable meant two different secrets:

| Consumer | What it meant there | Required? |
|---|---|---|
| File-store master key (`filestore.ts:getPassphrase`) | the key to the whole local store | **opt-in** since `84182805` — the store auto-provisions a 0600 machine-local key |
| `secrets push`/`pull`, `sync --secrets` | the passphrase that seals a bundle for transport | **required, no fallback** |
| `secrets export --to-file` / `import --from-file` | the passphrase that seals the portable envelope | **required, no fallback** |

The store stopped needing a passphrase, but headless `push`/`pull` still hard-failed without one. So the only way to get unattended sync on a worker box was to export the **master key** fleet-wide — which is what happened: `~/.zshenv:8` on **yosemite-m0…m6** (7 boxes) exports it in plaintext, inherited by every child process and readable from `/proc/<pid>/environ` by any same-user process. That is RUSH-1968.

Splitting the two means a box that only needs headless sync sets `AGENTS_SYNC_PASSPHRASE` and never has the store's master key in its environment at all. This unblocks removing those exports; the remediation itself is a separate change.

## What changed

- **New `apps/cli/src/lib/secrets/sync-passphrase.ts`** — one chokepoint for transport-passphrase resolution: `AGENTS_SYNC_PASSPHRASE` → `AGENTS_SECRETS_PASSPHRASE` (deprecated, warns once per process) → `{ value: null }` for the caller to prompt or fail. Two call sites (`secrets-sync.ts`, `sync.ts:282`) read the env independently before; collapsing them is what makes the once-per-process promise real rather than per-call-site.
- **`secrets-sync.ts`** — the headless error now reads `A sync passphrase is required. Run from a TTY, or set AGENTS_SYNC_PASSPHRASE.`
- **`secrets.ts:2103` / `:2218`** — `--from-file` / `--to-file`, the portable envelope, migrated to the same resolver, along with their two `--help` strings and the `docs/secrets.md` command table.
- **`sync-umbrella.ts`** — the terminal skip line named no variable (`secrets: skipped (no passphrase available)`), leaving an operator nothing to act on. Both it and the structured `reason` now read the name from `SYNC_PASSPHRASE_ENV`.
- **`docs/specifications.md`** — `SEC-29a` claimed the variable applied "exclusively" to the file and age-vault backends. Both halves were false: `lib/secrets/vault.ts` never reads it (0 mentions; the vault is gated by `agents login`), and sync plus the portable `--to-file` envelope were two more consumers. Corrected, and new `SEC-29b` states the split as a normative invariant.
- CHANGELOG fragment under `.changelog/next/`.

Deliberately **not** changed: `scripts/headless-sign-context.sh` uses the variable for file-store *reads* (SEC-2 territory), not sync, so it is unaffected.

## Run output

Full capture: `yosemite-s1:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-05/rush-1968-sync-passphrase-run.txt` — a path on the fleet, not an embed, since this is a no-UI change.

```
=== 1. headless, NEITHER var set -> secrets push errors naming the NEW variable ===
A sync passphrase is required. Run from a TTY, or set AGENTS_SYNC_PASSPHRASE.

=== 2. NEITHER var set -> agents sync --secrets skips, naming the NEW variable ===
  secrets: skipped (no passphrase — set AGENTS_SYNC_PASSPHRASE)

=== 3. LEGACY var only -> still honoured, deprecation warning printed exactly ONCE ===
  warn: AGENTS_SECRETS_PASSPHRASE is deprecated for sync — it is the file store's
  master key, not a transport passphrase. Set AGENTS_SYNC_PASSPHRASE instead; the
  old name still works for now. [...] (RUSH-1968).
  (occurrences: 1)
```

No secret value was printed or transmitted during this verification: run 3 uses the literal string `bogus-not-a-real-key`, and no `secrets push` upload was performed.

## One caveat worth knowing

The legacy fallback is narrower than "the old name keeps working everywhere": `AGENTS_SECRETS_PASSPHRASE` still keys the **store**, so reading a bundle back with it set only succeeds where the store was written under that same value. On a box whose store uses the machine-local key, setting the old name for transport makes the store read fail (`failed to decrypt`). That is the coupling being retired, not a regression — the pre-split code had the identical behavior. It is pinned by a test and stated in the CHANGELOG.

## Tests

`tests/secrets-transport-passphrase.test.ts` (new) — 4 end-to-end tests driving the **real CLI** under a temp HOME, round-tripping a bundle through a sealed file. Proves the two command call sites are actually wired to the resolver, not just that the resolver works:

- round-trips under the new variable, and the sealed file does not contain the plaintext value
- with neither set, both halves error naming the new variable and **not** the legacy one
- a pre-upgrade box (store keyed to the old value) still exports, and warns
- a file sealed on a legacy box opens on an upgraded box using only the transport passphrase — two temp HOMEs, so the receiver never holds the sender's master key

`src/lib/secrets/sync-passphrase.test.ts` — 7 tests, real `process.env` mutation, stderr captured rather than stubbed (repo bans mocking):

- neither set → no value, nothing printed
- the current variable wins and warns nothing
- the current variable beats the legacy one when **both** are set (the migration case — a box that adopted the new name must not silently keep using the master key)
- the legacy fallback works and warns
- the deprecation warning fires exactly once across three calls (`push --all` resolves per bundle; without the latch it floods stderr)
- the readability warning is a separate latch, also once
- the headless error names the current variable and **not** the legacy one — naming the master key in that message is what put it into `~/.zshenv` on seven boxes
