### PR TITLE
fix(factory): sync Muse agent registry snapshot

### DIFF
--- a/apps/factory/src/core/agents.cli.ts
+++ b/apps/factory/src/core/agents.cli.ts
@@ -31,6 +31,7 @@ export const CLI_AGENT_IDS = [
   'droid',
   'hermes',
   'pi',
+  'muse',
 ] as const;
 
 /** Mirror of the CLI's AgentId union. */
@@ -61,6 +62,7 @@ export const CLI_AGENT_META: Record<CliAgentId, CliAgentMeta> = {
   droid: { name: 'Droid', cliCommand: 'droid' },
   hermes: { name: 'Hermes', cliCommand: 'hermes' },
   pi: { name: 'Pi', cliCommand: 'omp' },
+  muse: { name: 'Muse', cliCommand: 'muse' },
 };
 
 /** Type guard against the CLI agent id set. */


### PR DESCRIPTION
Factory test-fix only: restores the checked-in agent registry snapshot parity after Muse was added to the CLI.

## What changed

- Adds `muse` to `CLI_AGENT_IDS`.
- Mirrors Muse display name and CLI command in `CLI_AGENT_META`.

## Run result

No UI behavior changes. `bun test src/core/agents.cli.test.ts`: 2 passed, 0 failed. This fixes the exact full-release-suite failure encountered while publishing Factory 0.9.313.