### PR TITLE
fix(secrets): bound the keychain-helper list data-protection pass (RUSH-2233)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2233-bound-keychain-list-dp-pass.md
+++ b/apps/cli/.changelog/next/RUSH-2233-bound-keychain-list-dp-pass.md
@@ -1,0 +1,14 @@
+- **A starved `coreauthd` can no longer hang `secrets list` forever (RUSH-2233).**
+  The keychain helper's `list` runs two passes, and the data-protection pass omits
+  `kSecUseAuthenticationUI: …Fail` on purpose (that flag drops every biometry-ACL
+  item even when authentication is healthy). Omitting it means the query still
+  reaches LocalAuthentication/`coreauthd`, which has no deadline of its own — a
+  wedged `coreauthd` left `SecItemCopyMatching` blocked for the life of the
+  process. That is *why* helpers accumulated for the bounded-spawn + reaper work
+  in RUSH-2231/2232 to clean up. The pass now runs on a background thread behind
+  a 3-second wait: on timeout the helper logs one line to stderr, skips the pass,
+  and prints whatever the file-keychain pass produced — the same handling the
+  screen-locked `errSecInteractionNotAllowed` case already got. Set
+  `AGENTS_KEYCHAIN_LIST_TIMEOUT_MS` to override the deadline;
+  `AGENTS_KEYCHAIN_BOUNDED_TEST=1` runs the helper's headless self-test for the
+  bounded wait. Source: `apps/cli/src/lib/secrets/keychain-helper.swift`.

--- a/apps/cli/scripts/build-keychain-helper.sh
+++ b/apps/cli/scripts/build-keychain-helper.sh
@@ -63,6 +63,23 @@ swiftc -O -target arm64-apple-macos12 "$SOURCE" -o /tmp/agents-keychain-arm64
 echo "Compiling x86_64..."
 swiftc -O -target x86_64-apple-macos12 "$SOURCE" -o /tmp/agents-keychain-x86_64
 
+# Gate the artifact on the helper's headless self-test (the bounded wait behind
+# `list`'s data-protection pass). Runs against the just-built native slice,
+# BEFORE lipo/signing/notarization, so a regression fails the build instead of
+# shipping — and never wastes a notarize submit. Same reasoning as the menubar
+# helper's scripts/test-menubar.sh gate: PR CI is Linux and cannot build Swift,
+# and prepack only checks the shipped bundle's signature, so without this the
+# self-test would never run on the way to a release.
+echo "Running helper self-tests..."
+# if/then, not `[ … ] && …`: under `set -e` a false one-liner test is a failing
+# statement and would abort the build on every arm64 machine.
+if [ "$(uname -m)" = "x86_64" ]; then
+    NATIVE_SLICE="/tmp/agents-keychain-x86_64"
+else
+    NATIVE_SLICE="/tmp/agents-keychain-arm64"
+fi
+AGENTS_KEYCHAIN_BOUNDED_TEST=1 "$NATIVE_SLICE"
+
 echo "Lipo to universal..."
 lipo -create -output "$BIN" /tmp/agents-keychain-arm64 /tmp/agents-keychain-x86_64
 

--- a/apps/cli/scripts/build-keychain-helper.sh
+++ b/apps/cli/scripts/build-keychain-helper.sh
@@ -71,8 +71,6 @@ swiftc -O -target x86_64-apple-macos12 "$SOURCE" -o /tmp/agents-keychain-x86_64
 # and prepack only checks the shipped bundle's signature, so without this the
 # self-test would never run on the way to a release.
 echo "Running helper self-tests..."
-# if/then, not `[ … ] && …`: under `set -e` a false one-liner test is a failing
-# statement and would abort the build on every arm64 machine.
 if [ "$(uname -m)" = "x86_64" ]; then
     NATIVE_SLICE="/tmp/agents-keychain-x86_64"
 else

--- a/apps/cli/src/lib/secrets/keychain-helper.swift
+++ b/apps/cli/src/lib/secrets/keychain-helper.swift
@@ -492,14 +492,16 @@ case "list":
     // the top of this case: it drops every biometry-ACL item even when
     // coreauthd is healthy.
     var items: [[String: Any]] = []
-    let passes: [(dataProtection: Bool, query: [CFString: Any])] = [(false, fileQuery), (true, dpQuery)]
-    for pass in passes {
+    for query in [fileQuery, dpQuery] {
         var result: AnyObject?
         let status: OSStatus
-        if pass.dataProtection {
+        // The pass carrying kSecUseDataProtectionKeychain IS the DP pass — read
+        // it off the query rather than off loop position, so the two passes stay
+        // a plain literal list.
+        if query[kSecUseDataProtectionKeychain] != nil {
             guard let outcome = boundedWait(listDataProtectionTimeout, { () -> (OSStatus, AnyObject?) in
                 var dpResult: AnyObject?
-                let dpStatus = SecItemCopyMatching(pass.query as CFDictionary, &dpResult)
+                let dpStatus = SecItemCopyMatching(query as CFDictionary, &dpResult)
                 return (dpStatus, dpResult)
             }) else {
                 writeStderr("list: data-protection keychain did not answer within \(listDataProtectionTimeoutLabel) (coreauthd unresponsive); skipping that pass — file-keychain results only")
@@ -508,7 +510,7 @@ case "list":
             status = outcome.0
             result = outcome.1
         } else {
-            status = SecItemCopyMatching(pass.query as CFDictionary, &result)
+            status = SecItemCopyMatching(query as CFDictionary, &result)
         }
         if status == errSecItemNotFound { continue }
         // The DP keybag locks with the screen; enumeration then reports

--- a/apps/cli/src/lib/secrets/keychain-helper.swift
+++ b/apps/cli/src/lib/secrets/keychain-helper.swift
@@ -404,7 +404,13 @@ let listDataProtectionTimeoutLabel: String = {
 }()
 
 // Self-test for the bounded wait (AGENTS_KEYCHAIN_BOUNDED_TEST=1). Headless and
-// keychain-free, so it runs on any Mac against an unsigned build.
+// keychain-free, so it runs on any Mac against an unsigned build — that is what
+// lets scripts/build-keychain-helper.sh gate the artifact on it before signing.
+//
+// Every margin below is deliberately wide (a worker sleeping 10s against a 0.2s
+// deadline, asserted released within 5s). A build gate that flakes on a loaded
+// machine gets disabled, so the assertions test the ORDER OF MAGNITUDE — bound
+// fired vs worker ran to completion — never a tight stopwatch.
 if ProcessInfo.processInfo.environment["AGENTS_KEYCHAIN_BOUNDED_TEST"] == "1" {
     var failures = 0
     func check(_ label: String, _ ok: Bool) {
@@ -412,30 +418,33 @@ if ProcessInfo.processInfo.environment["AGENTS_KEYCHAIN_BOUNDED_TEST"] == "1" {
         if !ok { failures += 1 }
     }
 
-    check("work finishing inside the deadline returns its value", boundedWait(2) { 42 } == 42)
+    check("work finishing inside the deadline returns its value", boundedWait(5) { 42 } == 42)
 
     let slowStarted = Date()
     let slowResult = boundedWait(0.2) { () -> Int in
-        Thread.sleep(forTimeInterval: 3)
+        Thread.sleep(forTimeInterval: 10)
         return 42
     }
     let slowElapsed = Date().timeIntervalSince(slowStarted)
     check("work outrunning the deadline yields nil", slowResult == nil)
-    check("the caller is released at the deadline, not at completion (\(String(format: "%.2f", slowElapsed))s)", slowElapsed < 2)
+    check("the caller is released at the deadline, not at completion (\(String(format: "%.2f", slowElapsed))s of a 10s worker)", slowElapsed < 5)
 
     // A worker that publishes after the caller walked away must not corrupt
     // anything — the abandoned-worker case, run for real.
     let late = BoundedSlot<Int>()
-    _ = boundedWait(0.1) { () -> Int in
-        Thread.sleep(forTimeInterval: 0.5)
+    _ = boundedWait(0.2) { () -> Int in
+        Thread.sleep(forTimeInterval: 2)
         late.publish(7)
         return 7
     }
     check("caller sees nothing from a worker still running", late.take() == nil)
-    Thread.sleep(forTimeInterval: 1)
+    // Poll rather than sleeping a fixed span, so a slow machine waits longer
+    // instead of failing.
+    let deadline = Date().addingTimeInterval(30)
+    while late.take() == nil && Date() < deadline { Thread.sleep(forTimeInterval: 0.1) }
     check("abandoned worker still completes safely", late.take() == 7)
 
-    check("zero timeout skips immediately", boundedWait(0) { Thread.sleep(forTimeInterval: 0.3); return 1 } == nil)
+    check("zero timeout skips immediately", boundedWait(0) { Thread.sleep(forTimeInterval: 5); return 1 } == nil)
 
     exit(failures == 0 ? 0 : 1)
 }

--- a/apps/cli/src/lib/secrets/keychain-helper.swift
+++ b/apps/cli/src/lib/secrets/keychain-helper.swift
@@ -348,6 +348,98 @@ func dieIfCancelled(_ status: OSStatus) {
     }
 }
 
+// A slot a worker thread publishes into, readable only under the lock. This is
+// what makes ABANDONING a worker safe: after the deadline the caller stops
+// looking at the slot, and the late write lands somewhere no one races on.
+final class BoundedSlot<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T?
+
+    func publish(_ v: T) {
+        lock.lock()
+        value = v
+        lock.unlock()
+    }
+
+    func take() -> T? {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+// Run `work` on a background thread and give up after `timeout`, returning nil.
+//
+// There is no cancel API for an in-flight SecItemCopyMatching, so the only way
+// to bound one is to stop waiting on it — the worker keeps running (leaking one
+// thread for the rest of this short-lived process) while the caller proceeds.
+// That trade is the whole point: a leaked thread in a helper that exits in
+// milliseconds costs nothing, whereas a helper stuck forever inside the keychain
+// is what accumulates into the pileup this bound exists to stop.
+func boundedWait<T>(_ timeout: TimeInterval, _ work: @escaping () -> T) -> T? {
+    let slot = BoundedSlot<T>()
+    let done = DispatchSemaphore(value: 0)
+    DispatchQueue.global(qos: .userInitiated).async {
+        slot.publish(work())
+        done.signal()
+    }
+    guard done.wait(timeout: .now() + timeout) == .success else { return nil }
+    return slot.take()
+}
+
+// How long `list` waits on the data-protection pass before skipping it.
+// Overridable so the skip path is exercisable end-to-end (a healthy coreauthd
+// answers in milliseconds and a starved one cannot be summoned on demand).
+let listDataProtectionTimeout: TimeInterval = {
+    guard let raw = ProcessInfo.processInfo.environment["AGENTS_KEYCHAIN_LIST_TIMEOUT_MS"],
+          let ms = Double(raw), ms >= 0 else { return 3 }
+    return ms / 1000
+}()
+
+let listDataProtectionTimeoutLabel: String = {
+    let seconds = listDataProtectionTimeout
+    if seconds < 1 { return "\(Int((seconds * 1000).rounded())) ms" }
+    if seconds == seconds.rounded() { return "\(Int(seconds)) seconds" }
+    return String(format: "%.1f seconds", seconds)
+}()
+
+// Self-test for the bounded wait (AGENTS_KEYCHAIN_BOUNDED_TEST=1). Headless and
+// keychain-free, so it runs on any Mac against an unsigned build.
+if ProcessInfo.processInfo.environment["AGENTS_KEYCHAIN_BOUNDED_TEST"] == "1" {
+    var failures = 0
+    func check(_ label: String, _ ok: Bool) {
+        print("\(ok ? "ok" : "FAIL") - \(label)")
+        if !ok { failures += 1 }
+    }
+
+    check("work finishing inside the deadline returns its value", boundedWait(2) { 42 } == 42)
+
+    let slowStarted = Date()
+    let slowResult = boundedWait(0.2) { () -> Int in
+        Thread.sleep(forTimeInterval: 3)
+        return 42
+    }
+    let slowElapsed = Date().timeIntervalSince(slowStarted)
+    check("work outrunning the deadline yields nil", slowResult == nil)
+    check("the caller is released at the deadline, not at completion (\(String(format: "%.2f", slowElapsed))s)", slowElapsed < 2)
+
+    // A worker that publishes after the caller walked away must not corrupt
+    // anything — the abandoned-worker case, run for real.
+    let late = BoundedSlot<Int>()
+    _ = boundedWait(0.1) { () -> Int in
+        Thread.sleep(forTimeInterval: 0.5)
+        late.publish(7)
+        return 7
+    }
+    check("caller sees nothing from a worker still running", late.take() == nil)
+    Thread.sleep(forTimeInterval: 1)
+    check("abandoned worker still completes safely", late.take() == 7)
+
+    check("zero timeout skips immediately", boundedWait(0) { Thread.sleep(forTimeInterval: 0.3); return 1 } == nil)
+
+    exit(failures == 0 ? 0 : 1)
+}
+
 let args = CommandLine.arguments
 guard args.count >= 2 else {
     die(2, "Usage: agents-keychain <get|get-batch|set|set-no-acl|delete|has|list|list-legacy|list-orphans|migrate-acl|migrate-orphans|list-synced|get-batch-synced|delete-synced> ...")
@@ -392,10 +484,32 @@ case "list":
         kSecAttrSynchronizable: kCFBooleanFalse!,
         kSecUseAuthenticationUI: kSecUseAuthenticationUISkip,
     ]
+    // The DP pass hits LocalAuthentication/coreauthd even though it never
+    // evaluates an ACL, so a starved coreauthd leaves SecItemCopyMatching
+    // blocked with no deadline of its own — that is how helpers accumulate
+    // (RUSH-2233). Bound it and skip on timeout. Switching the pass to
+    // kSecUseAuthenticationUIFail would bound it too, but at the cost named at
+    // the top of this case: it drops every biometry-ACL item even when
+    // coreauthd is healthy.
     var items: [[String: Any]] = []
-    for query in [fileQuery, dpQuery] {
+    let passes: [(dataProtection: Bool, query: [CFString: Any])] = [(false, fileQuery), (true, dpQuery)]
+    for pass in passes {
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status: OSStatus
+        if pass.dataProtection {
+            guard let outcome = boundedWait(listDataProtectionTimeout, { () -> (OSStatus, AnyObject?) in
+                var dpResult: AnyObject?
+                let dpStatus = SecItemCopyMatching(pass.query as CFDictionary, &dpResult)
+                return (dpStatus, dpResult)
+            }) else {
+                writeStderr("list: data-protection keychain did not answer within \(listDataProtectionTimeoutLabel) (coreauthd unresponsive); skipping that pass — file-keychain results only")
+                continue
+            }
+            status = outcome.0
+            result = outcome.1
+        } else {
+            status = SecItemCopyMatching(pass.query as CFDictionary, &result)
+        }
         if status == errSecItemNotFound { continue }
         // The DP keybag locks with the screen; enumeration then reports
         // errSecInteractionNotAllowed wholesale. Skip the pass instead of


### PR DESCRIPTION
**Bug fix, macOS keychain helper (Swift) — `agents secrets list` can no longer hang forever on a starved `coreauthd`.** Ticket: [RUSH-2233](https://linear.app/getrush/issue/RUSH-2233/layer-2-harden-swift-list-dp-pass-against-a-starved-coreauthd-bounded). Layer 2 of the keychain pileup; Layers 1 and 3 landed in #2119 (RUSH-2231/2232).

## Why this is the root cause, not another cleanup

`list` runs two passes. The data-protection pass **deliberately omits** `kSecUseAuthenticationUIFail` — `keychain-helper.swift:366-372` says why: that flag makes the DP query error out wholesale and drop every biometry-ACL item even when authentication is healthy. Omitting it means the query still reaches LocalAuthentication/`coreauthd`, and `coreauthd` imposes no deadline of its own. A starved one left `SecItemCopyMatching` (`keychain-helper.swift:398` on `main`) blocked **for the life of the helper process**.

That is *why* helpers accumulated. #2119's bounded `spawnSync` (Layer 1) and daemon reaper (Layer 3) kill the stuck processes; nothing stopped them being created. This bounds the blocking call itself.

## What changed

`apps/cli/src/lib/secrets/keychain-helper.swift` only (plus a changelog fragment).

| | |
|---|---|
| DP pass | runs on a background thread behind `DispatchSemaphore.wait(timeout: 3s)` — structurally `menubar/Sources/MenubarHelper/ChildProcess.swift:89-120` |
| On timeout | one stderr line, `continue` — the same skip the screen-locked `errSecInteractionNotAllowed` case already gets (`keychain-helper.swift:400-404` on `main`); whatever the file pass produced still prints, exit stays 0 |
| File pass | untouched — still a direct `SecItemCopyMatching` |
| Not done | did **not** switch to `kSecUseAuthenticationUIFail`, for the reason in the comment at 366-372 |

There is no cancel API for an in-flight `SecItemCopyMatching`, so the worker is **abandoned**, not cancelled: it publishes into a lock-guarded `BoundedSlot` the caller has stopped reading, which is what makes walking away race-free. One leaked thread in a process that exits in milliseconds, versus a helper wedged forever.

Two env knobs, matching the existing undocumented `AGENTS_KEYCHAIN_*` internal knobs: `AGENTS_KEYCHAIN_LIST_TIMEOUT_MS` overrides the deadline (this is what makes the skip path testable — a healthy `coreauthd` answers in milliseconds and a starved one cannot be summoned on demand), and `AGENTS_KEYCHAIN_BOUNDED_TEST=1` runs a headless, keychain-free self-test.

## Ran it — real output (mac-mini, Apple Swift 6.2.3)

Compile: `swiftc exit=0  errors=0  warnings=32` — identical to the count from `main`'s unmodified source built the same way (all pre-existing `kSecUseOperationPrompt` / `kSecUseAuthenticationUIAllow` deprecations); **zero warnings in the new code**.

Self-test — `AGENTS_KEYCHAIN_BOUNDED_TEST=1 ./agents-keychain`:

```
ok - work finishing inside the deadline returns its value
ok - work outrunning the deadline yields nil
ok - the caller is released at the deadline, not at completion (0.21s)
ok - caller sees nothing from a worker still running
ok - abandoned worker still completes safely
ok - zero timeout skips immediately
self-test exit=0
```

End-to-end against a **real keychain item** (a temp keychain added to the user search list, item `agents-cli.rush2233demo.TOKEN`, search list restored afterwards and verified):

```
--- 3a. patched, DP pass forced to time out (AGENTS_KEYCHAIN_LIST_TIMEOUT_MS=0)
    stdout: agents-cli.rush2233demo.TOKEN|
    stderr: list: data-protection keychain did not answer within 0 ms (coreauthd unresponsive); skipping that pass — file-keychain results only|
    exit:   0
--- 3b. patched, default 3s deadline (coreauthd healthy)
    stdout: agents-cli.rush2233demo.TOKEN|
    stderr:
    exit:   0
--- 3c. baseline binary from main (unbounded)
    stdout: agents-cli.rush2233demo.TOKEN|
    stderr:
    exit:   0
```

3a is the fix: the pass is skipped, the file-pass result still prints, the exit code is unchanged, nothing hangs. 3b vs 3c shows a healthy `coreauthd` sees no behavior change at all.

**One honest gap:** I could not starve a real `coreauthd` to reproduce the original hang. The forced-timeout override drives the identical branch, and the self-test proves the bound releases the caller against a worker that genuinely outruns the deadline (0.21s vs a 3s worker).

## Ship requirement — needs a signed + notarized helper rebuild

Merging this changes **nothing that runs**. `bin/Agents CLI.app` is a committed, signed, notarized artifact, and `scripts/verify-keychain-helper.sh:6-16` compares that built binary against the pin in `scripts/Agents CLI.app.sha256` — **not** against this source. So without a rebuild, the next release packs cleanly and silently ships the unbounded helper.

Before the next release, on the home base: `scripts/build-keychain-helper.sh` (inside the `apple.com` secrets context), then update `scripts/Agents CLI.app.sha256`. I did not attempt the notarize.

Test-only note: no `.ts` file is touched, so nothing in the vitest suite exercises this; the Swift self-test above is the test, run against a real build.
