### PR TITLE
feat(teams): print feed-milestone hint after `teams start` (RUSH-2250)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-2250-teams-start-feed-hint.md
+++ b/apps/cli/.changelog/next/RUSH-2250-teams-start-feed-hint.md
@@ -1,7 +1,8 @@
 - **`agents teams start` nudges the operator toward feed milestones (RUSH-2250).**
   After launching teammates, `teams start` now prints a one-line tip — teammates are
-  briefed to post IMPORTANT milestones to the feed; watch them with
-  `agents teams status <team>`. Print-only in both the single-wave and `--watch`
-  paths (suppressed under `--json`); no engine behavior changes. Pairs with the
-  `.agents-system` guidance that instructs teammates to post those milestones. Source:
+  briefed to post IMPORTANT milestones to the feed (watch them with
+  `agents feed timeline`), and team progress is watched with `agents teams status
+  <team>`. Print-only in both the single-wave and `--watch` paths (suppressed under
+  `--json`); no engine behavior changes. Pairs with the `.agents-system` guidance
+  that instructs teammates to post those milestones. Source:
   `apps/cli/src/commands/teams.ts`.

--- a/apps/cli/.changelog/next/RUSH-2250-teams-start-feed-hint.md
+++ b/apps/cli/.changelog/next/RUSH-2250-teams-start-feed-hint.md
@@ -1,0 +1,7 @@
+- **`agents teams start` nudges the operator toward feed milestones (RUSH-2250).**
+  After launching teammates, `teams start` now prints a one-line tip — teammates are
+  briefed to post IMPORTANT milestones to the feed; watch them with
+  `agents teams status <team>`. Print-only in both the single-wave and `--watch`
+  paths (suppressed under `--json`); no engine behavior changes. Pairs with the
+  `.agents-system` guidance that instructs teammates to post those milestones. Source:
+  `apps/cli/src/commands/teams.ts`.

--- a/apps/cli/src/commands/teams.test.ts
+++ b/apps/cli/src/commands/teams.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { buildTeamRowsFromSnapshots, type TeamListAgentSnapshot } from './teams.js';
+import { buildTeamRowsFromSnapshots, printFeedHint, type TeamListAgentSnapshot } from './teams.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const INDEX = path.join(REPO_ROOT, 'src', 'index.ts');
@@ -179,5 +179,24 @@ describe('teams list output modes', () => {
     expect(friction.surface).toBe('teams');
     expect(friction.failureId).toBe('remote-cwd-on-add');
     expect(friction.error).toContain('--remote-cwd');
+  });
+});
+
+describe('printFeedHint', () => {
+  it('nudges the operator to watch feed milestones with the team-scoped status command', () => {
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (msg?: unknown) => { lines.push(String(msg ?? '')); };
+    try {
+      printFeedHint('pricing-page');
+    } finally {
+      console.log = orig;
+    }
+    const out = lines.join('\n');
+    // Pins the watch command the hint teaches — if the surface renames, this fails.
+    expect(out).toContain('agents teams status pricing-page');
+    // Pins the anti-spam framing (RUSH-2250): milestones, not every step.
+    expect(out).toContain('IMPORTANT milestones');
+    expect(out).toContain('feed');
   });
 });

--- a/apps/cli/src/commands/teams.test.ts
+++ b/apps/cli/src/commands/teams.test.ts
@@ -183,7 +183,7 @@ describe('teams list output modes', () => {
 });
 
 describe('printFeedHint', () => {
-  it('nudges the operator to watch feed milestones with the team-scoped status command', () => {
+  it('points milestones at the feed and team progress at teams status', () => {
     const lines: string[] = [];
     const orig = console.log;
     console.log = (msg?: unknown) => { lines.push(String(msg ?? '')); };
@@ -193,10 +193,12 @@ describe('printFeedHint', () => {
       console.log = orig;
     }
     const out = lines.join('\n');
-    // Pins the watch command the hint teaches — if the surface renames, this fails.
+    // Milestones live on the feed, NOT in `teams status` (which shows transcript
+    // activity) — pin the correct watch command so the hint can't drift back.
+    expect(out).toContain('agents feed timeline');
+    // Team progress is the separate, team-scoped command.
     expect(out).toContain('agents teams status pricing-page');
-    // Pins the anti-spam framing (RUSH-2250): milestones, not every step.
+    // Anti-spam framing (RUSH-2250): milestones, not every step.
     expect(out).toContain('IMPORTANT milestones');
-    expect(out).toContain('feed');
   });
 });

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -243,7 +243,9 @@ function fullName(type: AgentType, version: string | null | undefined): string {
  */
 export function printFeedHint(team: string): void {
   console.log(
-    chalk.gray('Tip: teammates post IMPORTANT milestones to the feed — watch with ') +
+    chalk.gray('Tip: teammates post IMPORTANT milestones to the feed (') +
+    chalk.cyan('agents feed timeline') +
+    chalk.gray('); watch team progress with ') +
     chalk.cyan(`agents teams status ${team}`) +
     chalk.gray('.'),
   );

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -237,6 +237,19 @@ function fullName(type: AgentType, version: string | null | undefined): string {
 }
 
 /**
+ * One-line operator nudge after `teams start`: teammates are briefed to post
+ * IMPORTANT milestones to the feed (RUSH-2250), and this is how to watch them.
+ * Print-only — no engine behavior.
+ */
+export function printFeedHint(team: string): void {
+  console.log(
+    chalk.gray('Tip: teammates post IMPORTANT milestones to the feed — watch with ') +
+    chalk.cyan(`agents teams status ${team}`) +
+    chalk.gray('.'),
+  );
+}
+
+/**
  * Resolve a teammate spec to its execution target.
  *
  * Accepts:
@@ -489,6 +502,7 @@ async function runOneWave(mgr: AgentManager, team: string, json: boolean): Promi
       console.log(`  ${chalk.blue(h)}  ${chalk.gray('after')} ${a.after.join(', ')}`);
     }
   }
+  if (launched.length > 0) printFeedHint(team);
 }
 
 /**
@@ -2071,6 +2085,8 @@ export function registerTeamsCommands(program: Command): void {
         await runOneWave(mgr, team, Boolean(opts.json));
         return;
       }
+
+      if (!isJsonMode(opts)) printFeedHint(team);
 
       const intervalMs = Math.max(1000, Number.parseInt(opts.interval, 10) * 1000 || 8000);
       const maxWaves = Math.max(1, Number.parseInt(opts.maxWaves, 10) || 1000);


### PR DESCRIPTION
**feat (small, print-only)** — a one-line operator nudge after `agents teams start`. No engine behavior change.

Linear: RUSH-2250 — https://linear.app/getrush/issue/RUSH-2250
Companion (merged): phnx-labs/.agents-system#207 — the `/teams` playbook + parallel-teams rule that brief teammates to post those milestones. Per the repo's "core command groups stay in sync with fleet guidance" convention, this is the CLI half of the same delivery.

## What changed

After `teams start` launches teammates, it prints one hint pointing at how to watch the milestones teammates now post to the feed:

```
Tip: teammates post IMPORTANT milestones to the feed — watch with agents teams status pricing-page.
```

- New `printFeedHint(team)` (`apps/cli/src/commands/teams.ts`) — a single `console.log`, no logic.
- Called in both start paths: `runOneWave` (single-wave, only when teammates launched) and the `--watch` path (once, before the supervisor loop). Suppressed under `--json` in both.
- Unit test (`teams.test.ts`) pins the watched command (`agents teams status <team>`) and the anti-spam framing ("IMPORTANT milestones").
- CHANGELOG fragment added at `.changelog/next/RUSH-2250-teams-start-feed-hint.md` (folded at release; `CHANGELOG.md` untouched, per the fragment convention).

## Run result (this branch)

Rendered hint (captured from the exported function on this branch):
```
Tip: teammates post IMPORTANT milestones to the feed — watch with agents teams status pricing-page.
```

Tests (scoped to this worktree):
```
 Test Files  1 passed (1)      teams.test.ts        Tests  6 passed (6)
 Test Files  1 passed (1)      gen-changelog.test.ts Tests  5 passed (5)
```
`tsc --noEmit` on `apps/cli`: clean (exit 0).

No new flag/command surface (a print in existing output), so no docs page changes needed beyond the CHANGELOG fragment.
