### PR TITLE
fix(muse): XDG pin for multi-version isolation (Claude/Codex pattern)

### DIFF
--- a/apps/cli/.changelog/next/muse-xdg-isolation.md
+++ b/apps/cli/.changelog/next/muse-xdg-isolation.md
@@ -1,0 +1,11 @@
+- **Muse multi-version isolation matches Claude/Codex (XDG pin, not bare symlink).**
+  Claude/Codex isolate per version with `CLAUDE_CONFIG_DIR` / `CODEX_HOME`.
+  Muse has no dedicated config env; it reads `$XDG_CONFIG_HOME/muse` and
+  `$XDG_DATA_HOME/muse`. After `agents import muse`, `~/.config/muse` is a
+  symlink into the version home — Muse refuses that path with
+  `Agent Definition filesystem source failed: SymlinkOrReparse` and exits 1
+  (the Zion `agents run muse@0.1.0` failure). Managed launches now pin
+  `XDG_CONFIG_HOME` + `XDG_DATA_HOME` into the version home from `buildExecEnv`,
+  the main shim, and versioned aliases (`muse@0.1.0`), the same way Claude pins
+  `CLAUDE_CONFIG_DIR`. Muse is also listed in `CONFIG_ENV_ISOLATED_AGENTS` so
+  `--isolated` installs are honest. Source: `apps/cli/src/lib/{exec,shims}.ts`.

--- a/apps/cli/src/lib/__tests__/exec.test.ts
+++ b/apps/cli/src/lib/__tests__/exec.test.ts
@@ -1099,6 +1099,16 @@ describe('buildExecCommand', () => {
       }
     });
 
+    it('injects XDG config/data homes for pinned Muse versions', () => {
+      // Muse has no MUSE_CONFIG_DIR; isolation is XDG (Claude/Codex pattern).
+      // Without this, adopt leaves ~/.config/muse as a symlink and Muse dies
+      // with SymlinkOrReparse.
+      const env = buildExecEnv(opts({ agent: 'muse', version: '0.1.0' }));
+      const versionHome = path.join(HOME, '.agents', '.history', 'versions', 'muse', '0.1.0', 'home');
+      expect(env.XDG_CONFIG_HOME).toBe(path.join(versionHome, '.config'));
+      expect(env.XDG_DATA_HOME).toBe(path.join(versionHome, '.local', 'share'));
+    });
+
     it('injects KIMI_CODE_HOME for pinned Kimi versions', () => {
       const env = buildExecEnv(opts({ agent: 'kimi', version: '0.11.0' }));
       expect(env.KIMI_CODE_HOME).toBe(

--- a/apps/cli/src/lib/__tests__/shims.isolation-capability.test.ts
+++ b/apps/cli/src/lib/__tests__/shims.isolation-capability.test.ts
@@ -18,6 +18,9 @@ const CONFIG_ENV_BY_AGENT: Record<(typeof CONFIG_ENV_ISOLATED_AGENTS)[number], s
   grok: 'GROK_HOME',
   kimi: 'KIMI_CODE_HOME',
   opencode: 'OPENCODE_CONFIG_DIR',
+  // Muse has no dedicated config env; isolation is XDG (proved: empty
+  // XDG_CONFIG_HOME works; adopt symlink at ~/.config/muse fails SymlinkOrReparse).
+  muse: 'XDG_CONFIG_HOME',
 };
 const ALL_CONFIG_ENVS = Object.values(CONFIG_ENV_BY_AGENT);
 

--- a/apps/cli/src/lib/__tests__/shims.test.ts
+++ b/apps/cli/src/lib/__tests__/shims.test.ts
@@ -96,8 +96,8 @@ describe('addShimsToPath', () => {
 });
 
 describe('SHIM_SCHEMA_VERSION', () => {
-  it('is 28 (Codex direct shims use the safe writable permission profile)', () => {
-    expect(SHIM_SCHEMA_VERSION).toBe(28);
+  it('is 29 (Muse XDG pin for multi-version isolation)', () => {
+    expect(SHIM_SCHEMA_VERSION).toBe(29);
   });
 });
 
@@ -169,7 +169,7 @@ describe('generateShimScript — config-dir env vars', () => {
 describe('generateVersionedAliasScript', () => {
   it('uses ~/.agents/.history for direct alias binary and config paths', () => {
     const script = generateVersionedAliasScript('codex', '0.125.0');
-    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(14);
+    expect(VERSIONED_ALIAS_SCHEMA_VERSION).toBe(15);
     expect(script).toContain('$HOME/.agents/.history/versions/codex/0.125.0');
     expect(script).not.toContain('$HOME/.agents-system/versions/codex/0.125.0');
   });

--- a/apps/cli/src/lib/exec.ts
+++ b/apps/cli/src/lib/exec.ts
@@ -490,6 +490,27 @@ export function buildExecEnv(options: ExecOptions): NodeJS.ProcessEnv {
     delete result.CLAUDE_CONFIG_DIR;
     delete result.CODEX_HOME;
     delete result.COPILOT_HOME;
+  } else if (options.agent === 'muse') {
+    // Muse has no MUSE_CONFIG_DIR. Config is XDG-based:
+    //   $XDG_CONFIG_HOME/muse  (settings, skills, hooks, auth)
+    //   $XDG_DATA_HOME/muse    (sessions, plugins)
+    // Pin both into the version home so multi-version isolation matches
+    // Claude's CLAUDE_CONFIG_DIR / Codex's CODEX_HOME, and so Muse never
+    // resolves through the adopt-time ~/.config/muse symlink (SymlinkOrReparse).
+    const cwd = options.cwd || process.cwd();
+    const resolvedVersion = options.version ?? resolveVersion('muse', cwd);
+    const version = options.version
+      ? resolvedVersion
+      : (resolvedVersion && isVersionInstalled('muse', resolvedVersion) ? resolvedVersion : null);
+    if (version) {
+      const versionHome = getVersionHomePath('muse', version);
+      result.XDG_CONFIG_HOME = path.join(versionHome, '.config');
+      result.XDG_DATA_HOME = path.join(versionHome, '.local', 'share');
+    }
+    delete result.CLAUDE_CONFIG_DIR;
+    delete result.CODEX_HOME;
+    delete result.COPILOT_HOME;
+    delete result.KIMI_CODE_HOME;
   } else {
     delete result.CLAUDE_CONFIG_DIR;
     delete result.CODEX_HOME;

--- a/apps/cli/src/lib/shims.ts
+++ b/apps/cli/src/lib/shims.ts
@@ -252,7 +252,7 @@ async function promptConflictStrategy(
 //        The old dispatcher checked only the global dir, so a pinned grok that
 //        installed into the versioned home fell through to the "not installed"
 //        error.
-export const SHIM_SCHEMA_VERSION = 28;
+export const SHIM_SCHEMA_VERSION = 29;
 
 /** Internal marker string used to embed the schema version in shim scripts. */
 const SHIM_VERSION_MARKER = 'agents-shim-version:';
@@ -336,7 +336,18 @@ export OPENCODE_CONFIG_DIR="$VERSION_DIR/home/.config/opencode"
 # mcp.json, sessions, skills, hooks). Point it at the versioned home.
 export KIMI_CODE_HOME="$VERSION_DIR/home/${configDirName}"
 `
-            : '';
+            : agent === 'muse'
+              ? `
+# Muse Code has no MUSE_CONFIG_DIR. It resolves config via XDG:
+#   $XDG_CONFIG_HOME/muse  (settings, skills, hooks, auth)
+#   $XDG_DATA_HOME/muse    (sessions, plugins)
+# Pin XDG into the version home so managed runs never walk the adopt-time
+# ~/.config/muse -> version-home symlink — Muse refuses agent-definition
+# sources that are SymlinkOrReparse (exit 1). Same idea as CLAUDE_CONFIG_DIR.
+export XDG_CONFIG_HOME="$VERSION_DIR/home/.config"
+export XDG_DATA_HOME="$VERSION_DIR/home/.local/share"
+`
+              : '';
 
   const launchArgs = agent === 'codex' ? ` ${codexShimLaunchArgs()}` : '';
 
@@ -925,7 +936,7 @@ export function removeShim(agent: AgentId): boolean {
  *        the versioned home (installer run with GROK_HOME set, or grok
  *        self-update under the shim).
  */
-export const VERSIONED_ALIAS_SCHEMA_VERSION = 14;
+export const VERSIONED_ALIAS_SCHEMA_VERSION = 15;
 
 /** Internal marker string used to embed the schema version in versioned alias scripts. */
 const VERSIONED_ALIAS_VERSION_MARKER = 'agents-versioned-alias-version:';
@@ -956,7 +967,7 @@ function assertSafeVersion(version: string): void {
  * KEEP IN SYNC with the `managedEnv` switch in `generateVersionedAliasScript`.
  * The colocated test `shims.isolation-capability.test.ts` enforces this.
  */
-export const CONFIG_ENV_ISOLATED_AGENTS: readonly AgentId[] = ['claude', 'codex', 'copilot', 'grok', 'kimi', 'opencode'];
+export const CONFIG_ENV_ISOLATED_AGENTS: readonly AgentId[] = ['claude', 'codex', 'copilot', 'grok', 'kimi', 'opencode', 'muse'];
 
 /**
  * Whether an agent supports a clean `--isolated` install — i.e. its config
@@ -1019,7 +1030,15 @@ export OPENCODE_CONFIG_DIR="$HOME/.agents/.history/versions/${agent}/${version}/
 # mcp.json, sessions, skills, hooks). Point direct aliases at the versioned home.
 export KIMI_CODE_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/${configDirName}"
 `
-            : '';
+            : agent === 'muse'
+              ? `
+# Muse Code: no dedicated config env var. Pin XDG so config/sessions live under
+# the version home as real directories (not via the adopt symlink at
+# ~/.config/muse, which Muse rejects with SymlinkOrReparse).
+export XDG_CONFIG_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/.config"
+export XDG_DATA_HOME="$HOME/.agents/.history/versions/${agent}/${version}/home/.local/share"
+`
+              : '';
   const launchArgs = agent === 'codex' ? ` ${codexShimLaunchArgs()}` : '';
 
   // Resolve the binary the same way the main shim does (see generateShimScript).


### PR DESCRIPTION
fix — Muse multi-version isolation (Claude/Codex pattern).

## Root cause (Zion)

`agents import muse` left `~/.config/muse` as a **symlink** into the version home.
`agents run muse@0.1.0` used the versioned alias, which exec'd the binary **without**
redirecting config. Muse then resolved the symlink and failed:

`Agent Definition filesystem source failed: SymlinkOrReparse` → exit 1

## Claude / Codex comparison

| Harness | Isolation mechanism |
|---|---|
| Claude | `CLAUDE_CONFIG_DIR=$versionHome/.claude` |
| Codex | `CODEX_HOME=$versionHome/.codex` (short path on macOS) |
| Muse | **No native config env** — uses XDG: `$XDG_CONFIG_HOME/muse`, `$XDG_DATA_HOME/muse` |

## Fix

Pin `XDG_CONFIG_HOME` + `XDG_DATA_HOME` into the version home from:
- `buildExecEnv` (`agents run`)
- main shim + versioned alias (`muse@0.1.0`)
- `CONFIG_ENV_ISOLATED_AGENTS` (honest `--isolated`)

Shim schema bump 28→29 / alias 14→15 so existing shims refresh.

## Run proof

```

 RUN  v4.1.9 /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/muse-xdg-isolation/apps/cli

 ✓ src/lib/__tests__/shims.isolation-capability.test.ts (4 tests) 4ms
 ✓ src/lib/__tests__/exec.test.ts (214 tests | 213 skipped) 6ms

 Test Files  2 passed (2)
      Tests  5 passed | 213 skipped (218)
   Start at  18:51:18
   Duration  1.19s (transform 1.25s, setup 51ms, import 1.74s, tests 10ms, environment 0ms)
```

No-surface UI; CLI isolation only.
