### PR TITLE
fix(menubar): gate helper reinstall on plist ownership (#2109)

### DIFF
--- a/apps/cli/.changelog/next/menubar-repoint-loop.md
+++ b/apps/cli/.changelog/next/menubar-repoint-loop.md
@@ -1,0 +1,16 @@
+- **Two agents-cli installs no longer fight over the menu-bar helper.** On a box with
+  more than one install (e.g. a Homebrew npm global plus `npm i -g --prefix ~/.local`),
+  the startup self-heal reinstalled the helper on *every* `agents` invocation: both the
+  version stamp and the plist's baked `AGENTS_ENTRY` name whichever copy invoked last,
+  so each copy saw drift and recopied the app bundle over the other's. Recopying replaces
+  the executable under the running helper and kills it, launchd `KeepAlive` restarts it,
+  and the other install repeats it — a new pid every 5-15 seconds, 578 launches in one
+  observed helper log, and a status item that never stayed visible while
+  `agents menubar status` still reported `running: yes` (because some pid always existed).
+  Skew alone no longer tears down a live helper: only a genuinely different helper binary
+  (a real upgrade, compared by content rather than by version string) or a signing-identity
+  heal does. Pure version/entry skew now refreshes the plist and version stamp in place, so
+  the next natural launch picks up the current install and nothing is killed. Same rule
+  #909 applied to the secrets broker (`shouldTeardownVersionSkewedBroker`), which had the
+  identical failure on the identical pair of prefixes (#435). Fixes #2109. Source:
+  `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/.changelog/next/menubar-repoint-loop.md
+++ b/apps/cli/.changelog/next/menubar-repoint-loop.md
@@ -7,8 +7,13 @@
   and the next copy repeats it: a new pid every 5-15 seconds, 578 launches in one
   observed helper log, and a status item that never stayed visible while
   `agents menubar status` still reported `running: yes` (a pid always existed). The
-  plist's `AGENTS_ENTRY` is now treated as the owner: only that install reinstalls
-  the helper, and another install takes over only once the recorded owner is gone
-  from disk. A same-install upgrade keeps its entry path, so `npm update` still
-  installs the new helper normally. Fixes #2109. Source:
-  `apps/cli/src/lib/menubar/install-menubar.ts`.
+  plist's `AGENTS_ENTRY` is now treated as the owner and only the owner reinstalls
+  freely; a same-install upgrade keeps its entry path, so `npm update` still installs
+  the new helper normally. Another install still gets there — immediately if the
+  recorded owner is gone from disk, otherwise at most once an hour — so a stale copy
+  that merely still sits on disk can't freeze the menu bar for whichever install the
+  user actually upgrades. Repairs (a missing helper executable, a Developer-ID heal)
+  are never gated, and `agents menubar setup` bypasses the gate as the immediate
+  manual fix. `agents menubar status` no longer promises that a stale helper "runs on
+  next `agents` startup", which is not guaranteed on a multi-install box. Fixes #2109.
+  Source: `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/.changelog/next/menubar-repoint-loop.md
+++ b/apps/cli/.changelog/next/menubar-repoint-loop.md
@@ -14,6 +14,12 @@
   that merely still sits on disk can't freeze the menu bar for whichever install the
   user actually upgrades. Repairs (a missing helper executable, a Developer-ID heal)
   are never gated, and `agents menubar setup` bypasses the gate as the immediate
-  manual fix. `agents menubar status` no longer promises that a stale helper "runs on
-  next `agents` startup", which is not guaranteed on a multi-install box. Fixes #2109.
-  Source: `apps/cli/src/lib/menubar/install-menubar.ts`.
+  manual fix. An ad-hoc/dev-signed build never wins the timed takeover — recopying
+  an un-notarized bundle over a good one gets it rejected as "damaged" — though it
+  can still adopt a helper whose owner is gone. Two installs that are both invoked
+  regularly still trade ownership at the cooldown, so the helper restarts about once
+  an hour until one is removed; that is bounded rather than converged, and the real
+  fix remains a single install. `agents menubar status` no longer promises that a
+  stale helper "runs on next `agents` startup", which is not guaranteed on a
+  multi-install box. Fixes #2109. Source:
+  `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/.changelog/next/menubar-repoint-loop.md
+++ b/apps/cli/.changelog/next/menubar-repoint-loop.md
@@ -1,16 +1,14 @@
-- **Two agents-cli installs no longer fight over the menu-bar helper.** On a box with
-  more than one install (e.g. a Homebrew npm global plus `npm i -g --prefix ~/.local`),
-  the startup self-heal reinstalled the helper on *every* `agents` invocation: both the
-  version stamp and the plist's baked `AGENTS_ENTRY` name whichever copy invoked last,
-  so each copy saw drift and recopied the app bundle over the other's. Recopying replaces
-  the executable under the running helper and kills it, launchd `KeepAlive` restarts it,
-  and the other install repeats it — a new pid every 5-15 seconds, 578 launches in one
+- **Coexisting agents-cli installs no longer fight over the menu-bar helper.** The
+  helper lives at one path in Application Support, but every install on the box runs
+  the startup self-heal, and both the version stamp and the plist's baked
+  `AGENTS_ENTRY` record whichever copy acted last — so each copy read the others'
+  marks as drift and recopied the app bundle over them. Recopying replaces the
+  executable under the running helper and kills it, launchd `KeepAlive` restarts it,
+  and the next copy repeats it: a new pid every 5-15 seconds, 578 launches in one
   observed helper log, and a status item that never stayed visible while
-  `agents menubar status` still reported `running: yes` (because some pid always existed).
-  Skew alone no longer tears down a live helper: only a genuinely different helper binary
-  (a real upgrade, compared by content rather than by version string) or a signing-identity
-  heal does. Pure version/entry skew now refreshes the plist and version stamp in place, so
-  the next natural launch picks up the current install and nothing is killed. Same rule
-  #909 applied to the secrets broker (`shouldTeardownVersionSkewedBroker`), which had the
-  identical failure on the identical pair of prefixes (#435). Fixes #2109. Source:
+  `agents menubar status` still reported `running: yes` (a pid always existed). The
+  plist's `AGENTS_ENTRY` is now treated as the owner: only that install reinstalls
+  the helper, and another install takes over only once the recorded owner is gone
+  from disk. A same-install upgrade keeps its entry path, so `npm update` still
+  installs the new helper normally. Fixes #2109. Source:
   `apps/cli/src/lib/menubar/install-menubar.ts`.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -557,6 +557,27 @@ healthy `running: yes`. `agents menubar setup` is the recovery path — it ends
 every live helper and re-kickstarts the service so the survivor is always
 launchd's.
 
+**Skew never tears down a LIVE helper — only a genuinely new binary does.** The
+startup self-heal (`installMenubarLaunchAgentOnUpgrade`, every darwin invocation)
+reinstalls when the version stamp drifted or the plist's baked entry names another
+install. Both of those name *whichever copy invoked last*, so on a box with two
+agents-cli installs each copy saw drift and recopied the bundle over the other's —
+and recopying replaces the executable under the running helper, killing it, after
+which `KeepAlive` restarts it and the other install repeats it. Observed: a new pid
+every 5-15s, 578 launches in one helper log, a status item that never stayed
+visible, and `agents menubar status` still saying `running: yes` because some pid
+always existed (#2109). So the reinstall is now gated by
+`shouldReplaceRunningHelper`: with a live helper, only a **content-different**
+helper binary (`menubarBundleChanged`, sha256 — NOT the version string, since
+consecutive CLI releases routinely ship the same helper build) or a Developer-ID
+heal earns the teardown. Everything else calls `refreshMenubarServiceMetadata`,
+which rewrites the plist and re-stamps the version **without** recopying or
+`launchctl`-restarting, so the skew is still corrected and the next natural launch
+picks it up. This is the menu-bar twin of `shouldTeardownVersionSkewedBroker`
+(`src/lib/secrets/agent.ts`), which fixed the identical failure in the secrets
+broker on the identical pair of prefixes (#435, PR #909) — when you add a third
+`KeepAlive` helper, give it the same gate rather than rediscovering this.
+
 **The lock fd is `O_CLOEXEC`, and `acquire` self-heals a stale lock.** The lock is
 opened `O_RDWR | O_CREAT | O_CLOEXEC` so no spawned child can inherit the
 descriptor — a pre-fix `doctor` child that inherited it and orphaned at PPID 1 held

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -567,10 +567,21 @@ which `KeepAlive` restarts it and the next copy repeats it. Observed: a new pid
 every 5-15s, 578 launches in one helper log, a status item that never stayed
 visible, and `agents menubar status` still saying `running: yes` because a pid
 always existed (#2109). `mayInstallMenubarHelper` gates it: the plist's
-`AGENTS_ENTRY` names the owner, only the owner may reinstall, and a non-owner takes
-over only once the recorded owner is **gone from disk**. That converges — a dead
-install can't hold the helper hostage, a live one can't be fought over — and a
-same-install upgrade keeps its entry path, so `npm update` still lands normally.
+`AGENTS_ENTRY` names the owner, and only the owner reinstalls freely. A same-install
+upgrade keeps its entry path, so `npm update` still lands normally.
+
+Three escapes keep the gate from becoming a **stuck state**, which is how the first
+version of it regressed: (1) **repairs are never gated** — a missing helper
+executable or a Developer-ID heal proceeds from any install, since a bundle that
+isn't there cannot be contested and blocking it leaves the menu bar dead with no
+automatic recovery; (2) a non-owner takes over immediately once the recorded owner
+is **gone from disk**; (3) otherwise a non-owner may still take over **once per
+`MENUBAR_TAKEOVER_COOLDOWN_MS`** (1h, stamped in `.menubar-last-heal`). Without (3)
+a stale-but-present copy — an old nvm node dir nobody runs — owns the plist forever
+while the user's actual daily driver upgrades and never heals again. The cooldown
+turns an every-invocation storm into at most one restart per hour while leaving
+every install able to make progress. `agents menubar setup` bypasses the gate
+entirely and stays the immediate manual fix.
 
 **Do NOT "improve" this by comparing bundle content.** It looks like the obvious
 gate and it does not work: the helper is rebuilt, re-signed and re-notarized on

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -583,6 +583,18 @@ turns an every-invocation storm into at most one restart per hour while leaving
 every install able to make progress. `agents menubar setup` bypasses the gate
 entirely and stays the immediate manual fix.
 
+Two caveats worth knowing before you tune any of this. **(a)** Escape (3) is
+refused to a source bundle that is not Developer-ID signed: `scripts/install.sh`
+puts an ad-hoc dev build beside the npm global, and letting it win a *timed*
+takeover would recopy an un-notarized bundle over a good one, which Gatekeeper
+rejects as "damaged" and AppKit crashes on (RUSH-2134) — a broken menu bar rather
+than a cosmetic restart. It can still adopt via (2), the case that must never
+deadlock. **(b)** The cooldown bounds the loop but does not converge it: two
+installs that are *both* invoked regularly trade ownership every cooldown, so the
+helper restarts roughly hourly until one is removed. That is deliberate — the
+alternative is stranding one of them — and the real fix is a single install
+(#2147 covers making the multi-install banner actually name them all).
+
 **Do NOT "improve" this by comparing bundle content.** It looks like the obvious
 gate and it does not work: the helper is rebuilt, re-signed and re-notarized on
 every release (`menubar/scripts/build.sh` via `release.sh`), so consecutive

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -557,26 +557,34 @@ healthy `running: yes`. `agents menubar setup` is the recovery path — it ends
 every live helper and re-kickstarts the service so the survivor is always
 launchd's.
 
-**Skew never tears down a LIVE helper — only a genuinely new binary does.** The
-startup self-heal (`installMenubarLaunchAgentOnUpgrade`, every darwin invocation)
-reinstalls when the version stamp drifted or the plist's baked entry names another
-install. Both of those name *whichever copy invoked last*, so on a box with two
-agents-cli installs each copy saw drift and recopied the bundle over the other's —
+**Only the install that OWNS the helper may reinstall it.** The startup self-heal
+(`installMenubarLaunchAgentOnUpgrade`, every darwin invocation) reinstalls when the
+version stamp drifted or the plist's baked entry names another install. Both of
+those record *whichever copy acted last*, so on a box with several agents-cli
+copies each one read the others' marks as drift and recopied the bundle over them —
 and recopying replaces the executable under the running helper, killing it, after
-which `KeepAlive` restarts it and the other install repeats it. Observed: a new pid
+which `KeepAlive` restarts it and the next copy repeats it. Observed: a new pid
 every 5-15s, 578 launches in one helper log, a status item that never stayed
-visible, and `agents menubar status` still saying `running: yes` because some pid
-always existed (#2109). So the reinstall is now gated by
-`shouldReplaceRunningHelper`: with a live helper, only a **content-different**
-helper binary (`menubarBundleChanged`, sha256 — NOT the version string, since
-consecutive CLI releases routinely ship the same helper build) or a Developer-ID
-heal earns the teardown. Everything else calls `refreshMenubarServiceMetadata`,
-which rewrites the plist and re-stamps the version **without** recopying or
-`launchctl`-restarting, so the skew is still corrected and the next natural launch
-picks it up. This is the menu-bar twin of `shouldTeardownVersionSkewedBroker`
-(`src/lib/secrets/agent.ts`), which fixed the identical failure in the secrets
-broker on the identical pair of prefixes (#435, PR #909) — when you add a third
-`KeepAlive` helper, give it the same gate rather than rediscovering this.
+visible, and `agents menubar status` still saying `running: yes` because a pid
+always existed (#2109). `mayInstallMenubarHelper` gates it: the plist's
+`AGENTS_ENTRY` names the owner, only the owner may reinstall, and a non-owner takes
+over only once the recorded owner is **gone from disk**. That converges — a dead
+install can't hold the helper hostage, a live one can't be fought over — and a
+same-install upgrade keeps its entry path, so `npm update` still lands normally.
+
+**Do NOT "improve" this by comparing bundle content.** It looks like the obvious
+gate and it does not work: the helper is rebuilt, re-signed and re-notarized on
+every release (`menubar/scripts/build.sh` via `release.sh`), so consecutive
+releases ship byte-different bundles from identical Swift source. Measured on
+1.22.20/21/22 — same 2876288-byte executable, three different sha256s, and three
+different **CDHashes** (so stripping the CMS/timestamp blob doesn't rescue it
+either). Any digest gate reports "changed" for precisely the skew case it was
+meant to exempt. Ownership is the only signal here that is stable across
+independently-signed builds. Related: the secrets broker hit the same
+multi-install failure and answered it differently, by keeping a *hot* broker alive
+across version skew (`shouldTeardownVersionSkewedBroker`, `src/lib/secrets/agent.ts`;
+#435, PR #909) — same disease, and a third `KeepAlive` helper will need one of
+these two answers rather than a fresh rediscovery.
 
 **The lock fd is `O_CLOEXEC`, and `acquire` self-heals a stale lock.** The lock is
 opened `O_RDWR | O_CREAT | O_CLOEXEC` so no spawned child can inherit the

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -343,6 +343,21 @@ The helper is a launchd user service (`com.phnx-labs.agents-menubar`,
   self-heal re-copies the bundle, rewrites the plist, and restarts it — so
   `npm update` actually moves users onto the new helper instead of leaving the
   old one running.
+- **One owner, when several installs coexist.** The helper lives at one path, but
+  every agents-cli copy on the box runs the self-heal. The plist's `AGENTS_ENTRY`
+  records the owner, and only the owner re-copies the bundle freely — otherwise
+  each copy reads the others' marks as drift and reinstalls over them, killing the
+  running helper every few seconds (#2109). A same-install `npm update` keeps its
+  entry path, so upgrades are unaffected. Another install still gets there:
+  immediately if the recorded owner is gone from disk, otherwise at most once an
+  hour (`.menubar-last-heal`), and never on that timer if its own bundle is
+  ad-hoc/dev-signed — recopying an un-notarized bundle over a good one gets it
+  rejected as "damaged". Repairs (missing executable, Developer-ID heal) are never
+  gated. `agents menubar setup` bypasses all of this and is the immediate fix.
+
+  Two installs that are *both* invoked regularly will keep trading ownership at
+  the cooldown, so the helper restarts about once an hour until one is removed —
+  bounded and survivable, but the real fix is a single install.
 - **Opt-out is sticky.** `agents menubar disable` writes
   `~/.agents/.cache/state/menubar.disabled`; the auto-enable honors it, so a
   disabled menu bar never silently returns on the next upgrade. Re-enable with
@@ -459,6 +474,7 @@ the current bundle on any version bump.
 | `~/Library/LaunchAgents/com.phnx-labs.agents-menubar.plist` | launchd service |
 | `~/Library/Application Support/agents-cli/MenubarHelper.app` | installed helper bundle |
 | `~/Library/Application Support/agents-cli/.menubar-version` | installed-version stamp |
+| `~/Library/Application Support/agents-cli/.menubar-last-heal` | last self-heal reinstall, epoch ms — the non-owner takeover cooldown |
 | `~/.agents/.cache/state/menubar.disabled` | sticky opt-out marker |
 | `~/.agents/.cache/helpers/menubar/menubar.log` | helper stdout / stderr |
 | `~/.agents/.history/menubar/recent-tickets.json` | tickets filed from the quick-dispatch panel (RECENT TICKETS) |

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -61,7 +61,12 @@ function printStatus(s: MenubarStatus, opts: { brief?: boolean } = {}): void {
     console.log(chalk.gray('  End them with `agents menubar setup`.'));
   }
   if (s.stale) {
-    console.log(chalk.yellow('\n  Installed AGI Menu is stale — runs on next `agents` startup, or `agents menubar setup` now.'));
+    // Not "runs on next startup": the self-heal only reinstalls from the install
+    // that owns the helper, or from another one once the takeover cooldown has
+    // passed (mayInstallMenubarHelper) — so on a box with several agents-cli
+    // copies this can persist for a while. `setup` bypasses the gate and is the
+    // immediate fix.
+    console.log(chalk.yellow('\n  Installed AGI Menu is stale — `agents menubar setup` updates it now.'));
   } else if (!s.serviceInstalled && !s.disabledByUser) {
     console.log(chalk.gray('\n  Set it up with `agents menubar setup`.'));
   }

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -197,35 +197,76 @@ describe('menubarPlistNeedsRepoint', () => {
 describe('mayInstallMenubarHelper', () => {
   const brew = '/opt/homebrew/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
   const nvm = '/Users/me/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
+  const HOUR = 60 * 60 * 1000;
+  // Healthy install, recent heal — the fields that are not what a case is about.
+  const base = {
+    helperExecMissing: false,
+    needsDevIdHeal: false,
+    msSinceLastHeal: 60_000,
+    cooldownMs: HOUR,
+  };
 
   it('refuses a foreign install while the recorded owner still exists (#2109)', () => {
     // The steady state that produced the loop: nvm 1.22.5 invoking while the
-    // Homebrew copy owns the helper. Before the gate this reinstalled and killed
-    // the running helper; now it is a no-op.
+    // Homebrew copy owns the helper. Before the gate this recopied the bundle and
+    // killed the running helper on every invocation.
     expect(mayInstallMenubarHelper({
-      plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
     })).toBe(false);
   });
 
   it('allows the owner to reinstall — a same-install upgrade still lands', () => {
     // `npm update` keeps the entry path and only bumps the version, so the
-    // staleness path behind this gate must still fire.
+    // staleness path behind this gate must still fire, cooldown or not.
     expect(mayInstallMenubarHelper({
-      plistEntry: brew, activeEntry: brew, ownerEntryExists: true,
+      ...base, plistEntry: brew, activeEntry: brew, ownerEntryExists: true,
     })).toBe(true);
   });
 
   it('lets another install take over once the owner is gone from disk', () => {
-    // This is what makes the rule converge: an uninstalled copy cannot hold the
-    // helper hostage forever.
     expect(mayInstallMenubarHelper({
-      plistEntry: brew, activeEntry: nvm, ownerEntryExists: false,
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: false,
+    })).toBe(true);
+  });
+
+  it('lets a foreign install take over after the cooldown, so nobody is stranded', () => {
+    // The stuck state a pure ownership rule creates: a stale-but-present install
+    // (an old nvm node dir nobody runs) owns the plist while the user's daily
+    // driver upgrades. Refusing forever would freeze the menu bar at whatever the
+    // dead owner last installed. The cooldown bounds the churn without stranding.
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
+      msSinceLastHeal: HOUR + 1,
+    })).toBe(true);
+  });
+
+  it('treats a never-healed install as past the cooldown', () => {
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
+      msSinceLastHeal: null,
+    })).toBe(true);
+  });
+
+  it('never blocks a repair: a missing helper executable heals from any install', () => {
+    // A bundle that is not there cannot be contested, and gating this behind
+    // ownership leaves the menu bar dead with no automatic recovery.
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
+      helperExecMissing: true,
+    })).toBe(true);
+  });
+
+  it('never blocks a repair: the Developer-ID heal runs from any install', () => {
+    // An ad-hoc copy re-prompts for Accessibility until the identity is restored.
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
+      needsDevIdHeal: true,
     })).toBe(true);
   });
 
   it('adopts a plist that records no owner yet (older install)', () => {
     expect(mayInstallMenubarHelper({
-      plistEntry: null, activeEntry: brew, ownerEntryExists: false,
+      ...base, plistEntry: null, activeEntry: brew, ownerEntryExists: false,
     })).toBe(true);
   });
 
@@ -233,7 +274,7 @@ describe('mayInstallMenubarHelper', () => {
     // Matches menubarPlistNeedsRepoint's existing guard: an unresolvable entry
     // must not be written into the plist or used to seize ownership.
     expect(mayInstallMenubarHelper({
-      plistEntry: brew, activeEntry: null, ownerEntryExists: true,
+      ...base, plistEntry: brew, activeEntry: null, ownerEntryExists: true,
     })).toBe(false);
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -13,6 +13,7 @@ import {
   menubarPlistNeedsRepoint,
   processesToEnd,
   restartMenubarLaunchAgent,
+  shouldReplaceRunningHelper,
 } from './install-menubar.js';
 
 // Regression guard for the STOLEN-HOTKEY blind spot. Status used
@@ -176,6 +177,65 @@ describe('menubarPlistNeedsRepoint', () => {
 
   it('re-points a plist that has no baked entry yet (older install)', () => {
     expect(menubarPlistNeedsRepoint({ plistEntry: null, plistNode: null, activeEntry: bun, activeNode: bunNode })).toBe(true);
+  });
+});
+
+// Regression guard for #2109: two agents-cli installs on one box reinstalled the
+// helper over each other on EVERY invocation, because both the version stamp and
+// the plist's baked entry name whichever copy invoked last. Recopying the bundle
+// replaces the executable under the live helper and kills it; KeepAlive restarts
+// it; the other install repeats it. Observed: a new pid every 5-15s, 578 launches
+// in the helper's log, and a status item that never stayed visible while
+// `agents menubar status` still said `running: yes`.
+//
+// The rule that breaks the loop — skew alone never earns a teardown — is the same
+// one #909 applied to the secrets broker (`shouldTeardownVersionSkewedBroker`).
+describe('shouldReplaceRunningHelper', () => {
+  it('does NOT replace a running helper for pure skew with an identical bundle (#2109)', () => {
+    // The dual-install steady state: stale-version and/or repoint fired, but the
+    // shipped helper binary is byte-identical to the installed one. Replacing
+    // here is what killed the helper every few seconds.
+    expect(shouldReplaceRunningHelper({
+      liveOwnHelpers: 1,
+      bundleChanged: false,
+      needsDevIdHeal: false,
+    })).toBe(false);
+  });
+
+  it('replaces a running helper when the shipped binary genuinely differs (real upgrade)', () => {
+    expect(shouldReplaceRunningHelper({
+      liveOwnHelpers: 1,
+      bundleChanged: true,
+      needsDevIdHeal: false,
+    })).toBe(true);
+  });
+
+  it('replaces a running helper to heal an ad-hoc signature', () => {
+    // An ad-hoc copy re-prompts for Accessibility on every upgrade, so this heal
+    // outranks keeping the current process alive.
+    expect(shouldReplaceRunningHelper({
+      liveOwnHelpers: 1,
+      bundleChanged: false,
+      needsDevIdHeal: true,
+    })).toBe(true);
+  });
+
+  it('installs freely when no helper is running — there is nothing to protect', () => {
+    expect(shouldReplaceRunningHelper({
+      liveOwnHelpers: 0,
+      bundleChanged: false,
+      needsDevIdHeal: false,
+    })).toBe(true);
+  });
+
+  it('protects every live copy, not just a single one', () => {
+    // `instances` is a LIST on purpose (classifyMenubarProcesses); a duplicate
+    // icon must not become a reason to start reinstalling on every invocation.
+    expect(shouldReplaceRunningHelper({
+      liveOwnHelpers: 2,
+      bundleChanged: false,
+      needsDevIdHeal: false,
+    })).toBe(false);
   });
 });
 

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -204,6 +204,7 @@ describe('mayInstallMenubarHelper', () => {
     needsDevIdHeal: false,
     msSinceLastHeal: 60_000,
     cooldownMs: HOUR,
+    sourceIsDeveloperId: true,
   };
 
   it('refuses a foreign install while the recorded owner still exists (#2109)', () => {
@@ -261,6 +262,26 @@ describe('mayInstallMenubarHelper', () => {
     expect(mayInstallMenubarHelper({
       ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
       needsDevIdHeal: true,
+    })).toBe(true);
+  });
+
+  it('never lets an ad-hoc/dev build seize a healthy helper on the timer', () => {
+    // scripts/install.sh puts a dev build beside the npm global, and its bundle
+    // cannot be notarized. Recopying it over a good Developer-ID bundle makes
+    // Gatekeeper reject the result as "damaged" and AppKit crash at launch
+    // (RUSH-2134) — a broken menu bar, not just a cosmetic restart.
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
+      msSinceLastHeal: HOUR + 1, sourceIsDeveloperId: false,
+    })).toBe(false);
+  });
+
+  it('still lets an ad-hoc build adopt a helper whose owner is gone', () => {
+    // The deadlock case must not be reintroduced: if nothing else can install it,
+    // an ad-hoc build is better than no menu bar.
+    expect(mayInstallMenubarHelper({
+      ...base, plistEntry: brew, activeEntry: nvm, ownerEntryExists: false,
+      sourceIsDeveloperId: false,
     })).toBe(true);
   });
 

--- a/apps/cli/src/lib/menubar/install-menubar.test.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.test.ts
@@ -11,9 +11,9 @@ import {
   hasDeveloperIdSignature,
   isMenubarStale,
   menubarPlistNeedsRepoint,
+  mayInstallMenubarHelper,
   processesToEnd,
   restartMenubarLaunchAgent,
-  shouldReplaceRunningHelper,
 } from './install-menubar.js';
 
 // Regression guard for the STOLEN-HOTKEY blind spot. Status used
@@ -180,61 +180,60 @@ describe('menubarPlistNeedsRepoint', () => {
   });
 });
 
-// Regression guard for #2109: two agents-cli installs on one box reinstalled the
-// helper over each other on EVERY invocation, because both the version stamp and
-// the plist's baked entry name whichever copy invoked last. Recopying the bundle
+// Regression guard for #2109: several agents-cli installs on one box reinstalled
+// the helper over each other on EVERY invocation, because both the version stamp
+// and the plist's baked entry name whichever copy acted last. Recopying the bundle
 // replaces the executable under the live helper and kills it; KeepAlive restarts
-// it; the other install repeats it. Observed: a new pid every 5-15s, 578 launches
+// it; the next install repeats it. Observed: a new pid every 5-15s, 578 launches
 // in the helper's log, and a status item that never stayed visible while
 // `agents menubar status` still said `running: yes`.
 //
-// The rule that breaks the loop — skew alone never earns a teardown — is the same
-// one #909 applied to the secrets broker (`shouldTeardownVersionSkewedBroker`).
-describe('shouldReplaceRunningHelper', () => {
-  it('does NOT replace a running helper for pure skew with an identical bundle (#2109)', () => {
-    // The dual-install steady state: stale-version and/or repoint fired, but the
-    // shipped helper binary is byte-identical to the installed one. Replacing
-    // here is what killed the helper every few seconds.
-    expect(shouldReplaceRunningHelper({
-      liveOwnHelpers: 1,
-      bundleChanged: false,
-      needsDevIdHeal: false,
+// Ownership — not content — decides, because content cannot. The helper is
+// rebuilt/re-signed/re-notarized every release, so consecutive releases ship
+// byte-different bundles from identical source: 1.22.20/21/22 all carry the same
+// 2876288-byte executable with three different sha256s and three different
+// CDHashes. A digest gate would report "changed" for exactly the skew it was
+// meant to exempt, which is why this predicate never looks at bytes.
+describe('mayInstallMenubarHelper', () => {
+  const brew = '/opt/homebrew/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
+  const nvm = '/Users/me/.nvm/versions/node/v24.15.0/lib/node_modules/@phnx-labs/agents-cli/dist/index.js';
+
+  it('refuses a foreign install while the recorded owner still exists (#2109)', () => {
+    // The steady state that produced the loop: nvm 1.22.5 invoking while the
+    // Homebrew copy owns the helper. Before the gate this reinstalled and killed
+    // the running helper; now it is a no-op.
+    expect(mayInstallMenubarHelper({
+      plistEntry: brew, activeEntry: nvm, ownerEntryExists: true,
     })).toBe(false);
   });
 
-  it('replaces a running helper when the shipped binary genuinely differs (real upgrade)', () => {
-    expect(shouldReplaceRunningHelper({
-      liveOwnHelpers: 1,
-      bundleChanged: true,
-      needsDevIdHeal: false,
+  it('allows the owner to reinstall — a same-install upgrade still lands', () => {
+    // `npm update` keeps the entry path and only bumps the version, so the
+    // staleness path behind this gate must still fire.
+    expect(mayInstallMenubarHelper({
+      plistEntry: brew, activeEntry: brew, ownerEntryExists: true,
     })).toBe(true);
   });
 
-  it('replaces a running helper to heal an ad-hoc signature', () => {
-    // An ad-hoc copy re-prompts for Accessibility on every upgrade, so this heal
-    // outranks keeping the current process alive.
-    expect(shouldReplaceRunningHelper({
-      liveOwnHelpers: 1,
-      bundleChanged: false,
-      needsDevIdHeal: true,
+  it('lets another install take over once the owner is gone from disk', () => {
+    // This is what makes the rule converge: an uninstalled copy cannot hold the
+    // helper hostage forever.
+    expect(mayInstallMenubarHelper({
+      plistEntry: brew, activeEntry: nvm, ownerEntryExists: false,
     })).toBe(true);
   });
 
-  it('installs freely when no helper is running — there is nothing to protect', () => {
-    expect(shouldReplaceRunningHelper({
-      liveOwnHelpers: 0,
-      bundleChanged: false,
-      needsDevIdHeal: false,
+  it('adopts a plist that records no owner yet (older install)', () => {
+    expect(mayInstallMenubarHelper({
+      plistEntry: null, activeEntry: brew, ownerEntryExists: false,
     })).toBe(true);
   });
 
-  it('protects every live copy, not just a single one', () => {
-    // `instances` is a LIST on purpose (classifyMenubarProcesses); a duplicate
-    // icon must not become a reason to start reinstalling on every invocation.
-    expect(shouldReplaceRunningHelper({
-      liveOwnHelpers: 2,
-      bundleChanged: false,
-      needsDevIdHeal: false,
+  it('never churns when the active entry cannot be resolved (dev/tsx run)', () => {
+    // Matches menubarPlistNeedsRepoint's existing guard: an unresolvable entry
+    // must not be written into the plist or used to seize ownership.
+    expect(mayInstallMenubarHelper({
+      plistEntry: brew, activeEntry: null, ownerEntryExists: true,
     })).toBe(false);
   });
 });

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -521,6 +521,8 @@ export function mayInstallMenubarHelper(opts: {
   msSinceLastHeal: number | null;
   /** How long a non-owner waits before it may take over. */
   cooldownMs: number;
+  /** This install's OWN shipped bundle is Developer-ID signed (not ad-hoc/dev). */
+  sourceIsDeveloperId: boolean;
 }): boolean {
   // Repairs are never gated: a missing binary or a broken signing identity leaves
   // the menu bar dead or re-prompting for Accessibility, and no other install can
@@ -539,6 +541,15 @@ export function mayInstallMenubarHelper(opts: {
   // that install would never heal again. So it may take over, but only once per
   // cooldown — which turns an every-invocation storm into at most one restart per
   // cooldown while keeping every install able to make progress.
+  //
+  // Except an ad-hoc/dev-signed copy, which never seizes a healthy helper on a
+  // timer. `scripts/install.sh` deliberately puts a dev build beside the npm
+  // global, and its bundle cannot be notarized; letting it win the timed takeover
+  // would recopy an ad-hoc bundle over a good Developer-ID one, and Gatekeeper
+  // then rejects the result as "damaged" and AppKit crashes at launch (RUSH-2134)
+  // — trading a cosmetic loop for a broken menu bar. It can still take over when
+  // the owner is genuinely gone (above), which is the case that must not deadlock.
+  if (!opts.sourceIsDeveloperId) return false;
   return opts.msSinceLastHeal === null || opts.msSinceLastHeal >= opts.cooldownMs;
 }
 
@@ -575,6 +586,7 @@ function stampMenubarHeal(): void {
 /** Whether this install may (re)install the helper (see `mayInstallMenubarHelper`). */
 function mayHealMenubar(needsDevIdHeal: boolean): boolean {
   const plistEntry = readPlistEnvValue('AGENTS_ENTRY');
+  const src = sourceAppPath();
   return mayInstallMenubarHelper({
     plistEntry,
     activeEntry: resolveCliEntry(),
@@ -583,6 +595,7 @@ function mayHealMenubar(needsDevIdHeal: boolean): boolean {
     needsDevIdHeal,
     msSinceLastHeal: msSinceLastMenubarHeal(),
     cooldownMs: MENUBAR_TAKEOVER_COOLDOWN_MS,
+    sourceIsDeveloperId: Boolean(src) && hasDeveloperIdSignature(src as string),
   });
 }
 
@@ -621,8 +634,11 @@ export function installMenubarLaunchAgentOnUpgrade(): void {
     // once per cooldown. Without the gate every coexisting install recopies the
     // bundle on every invocation, killing the live helper on a loop (#2109).
     if (!mayHealMenubar(needsDevIdHeal)) return;
-    stampMenubarHeal();
-    enableMenubarService({ clearOptOut: false });
+    // Stamp only a heal that actually happened. `enableMenubarService` returns
+    // false without installing when the bundle fails the Gatekeeper check, and
+    // stamping first would spend the shared cooldown on a no-op — locking every
+    // non-owner out for another hour while nothing had been fixed.
+    if (enableMenubarService({ clearOptOut: false })) stampMenubarHeal();
   } catch {
     /* never block startup on the menu bar */
   }

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -513,22 +513,76 @@ export function mayInstallMenubarHelper(opts: {
   activeEntry: string | null;
   /** Whether `plistEntry` still exists on disk. */
   ownerEntryExists: boolean;
+  /** The App Support helper executable is absent — a repair, not a contest. */
+  helperExecMissing: boolean;
+  /** Installed copy is ad-hoc while the shipped source is Developer ID. */
+  needsDevIdHeal: boolean;
+  /** ms since the last self-heal reinstall, or null if none is recorded. */
+  msSinceLastHeal: number | null;
+  /** How long a non-owner waits before it may take over. */
+  cooldownMs: number;
 }): boolean {
+  // Repairs are never gated: a missing binary or a broken signing identity leaves
+  // the menu bar dead or re-prompting for Accessibility, and no other install can
+  // be "fighting" for a bundle that isn't there. Blocking these behind ownership
+  // is what turned the first version of this gate into a silent stuck state.
+  if (opts.helperExecMissing || opts.needsDevIdHeal) return true;
   // Can't resolve which install we are (a dev/tsx run) — never churn the plist.
   if (!opts.activeEntry) return false;
   // No owner recorded yet (fresh or pre-`AGENTS_ENTRY` plist) — adopt it.
   if (!opts.plistEntry) return true;
   if (opts.plistEntry === opts.activeEntry) return true; // we are the owner
-  return !opts.ownerEntryExists; // take over only from an install that is gone
+  if (!opts.ownerEntryExists) return true; // the recorded owner is gone
+  // A foreign install while the owner still exists. Refusing outright bounds the
+  // loop but strands the user when the recorded owner is a stale copy that simply
+  // still sits on disk (an old nvm node dir) while their daily driver upgrades:
+  // that install would never heal again. So it may take over, but only once per
+  // cooldown — which turns an every-invocation storm into at most one restart per
+  // cooldown while keeping every install able to make progress.
+  return opts.msSinceLastHeal === null || opts.msSinceLastHeal >= opts.cooldownMs;
 }
 
-/** Whether this install owns the menu-bar helper (see `mayInstallMenubarHelper`). */
-function ownsMenubarHelper(): boolean {
+/**
+ * How long a non-owner install waits before it may take the helper over. Long
+ * enough that a multi-install box restarts the helper at most once an hour
+ * instead of every few seconds; short enough that a user who switched installs
+ * gets their upgrade without hunting for `agents menubar setup`.
+ */
+const MENUBAR_TAKEOVER_COOLDOWN_MS = 60 * 60 * 1000;
+
+/** Timestamp of the last self-heal reinstall, next to the version stamp. */
+function lastHealMarkerPath(): string {
+  return path.join(installDir(), '.menubar-last-heal');
+}
+
+function msSinceLastMenubarHeal(): number | null {
+  try {
+    const t = Number(fs.readFileSync(lastHealMarkerPath(), 'utf-8').trim());
+    if (!Number.isFinite(t)) return null;
+    return Math.max(0, Date.now() - t);
+  } catch {
+    return null;
+  }
+}
+
+function stampMenubarHeal(): void {
+  try {
+    fs.mkdirSync(installDir(), { recursive: true });
+    fs.writeFileSync(lastHealMarkerPath(), String(Date.now()));
+  } catch { /* best effort */ }
+}
+
+/** Whether this install may (re)install the helper (see `mayInstallMenubarHelper`). */
+function mayHealMenubar(needsDevIdHeal: boolean): boolean {
   const plistEntry = readPlistEnvValue('AGENTS_ENTRY');
   return mayInstallMenubarHelper({
     plistEntry,
     activeEntry: resolveCliEntry(),
     ownerEntryExists: Boolean(plistEntry) && fs.existsSync(plistEntry as string),
+    helperExecMissing: !fs.existsSync(installedExecutablePath()),
+    needsDevIdHeal,
+    msSinceLastHeal: msSinceLastMenubarHeal(),
+    cooldownMs: MENUBAR_TAKEOVER_COOLDOWN_MS,
   });
 }
 
@@ -556,18 +610,19 @@ export function installMenubarLaunchAgentOnUpgrade(): void {
       enableMenubarService({ clearOptOut: false });
       return;
     }
-    // Only the install that owns the helper may reinstall it. Without this, every
-    // coexisting copy treats the others' version stamp / baked entry as drift and
-    // recopies the bundle over them, killing the live helper on a loop (#2109).
-    if (!ownsMenubarHelper()) return;
     // Re-enable (recopy helper + rewrite plist) when the version drifted OR the
     // plist's baked interpreter/entry no longer point at the install now running
     // `agents` — e.g. the owner moved between node interpreters — OR the
     // installed copy is still ad-hoc while the shipped source is Developer ID
     // (older heal path; Accessibility re-prompts until the identity is restored).
-    if (menubarSetupStale() || menubarSetupNeedsRepoint() || installedNeedsDevIdHeal()) {
-      enableMenubarService({ clearOptOut: false });
-    }
+    const needsDevIdHeal = installedNeedsDevIdHeal();
+    if (!(menubarSetupStale() || menubarSetupNeedsRepoint() || needsDevIdHeal)) return;
+    // ...but a copy that does not own the helper only gets to act on that drift
+    // once per cooldown. Without the gate every coexisting install recopies the
+    // bundle on every invocation, killing the live helper on a loop (#2109).
+    if (!mayHealMenubar(needsDevIdHeal)) return;
+    stampMenubarHeal();
+    enableMenubarService({ clearOptOut: false });
   } catch {
     /* never block startup on the menu bar */
   }

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -17,6 +17,7 @@
 
 import { fileURLToPath } from 'url';
 import { execFileSync, spawnSync } from 'child_process';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -477,17 +478,99 @@ export function disableMenubarService(): void {
 }
 
 /**
+ * Whether the startup self-heal may tear down a helper that is CURRENTLY
+ * RUNNING. The menu-bar twin of `shouldTeardownVersionSkewedBroker`
+ * (`src/lib/secrets/agent.ts`), and it exists for the same reason.
+ *
+ * `enableMenubarService` recopies the app bundle, which replaces the executable
+ * under the live helper and kills it; launchd `KeepAlive` then restarts it. That
+ * is correct for a genuine upgrade and catastrophic for mere skew: with two
+ * agents-cli installs on one box (`/opt/homebrew` + `~/.local`, the pair in #435
+ * and #2109) the version stamp and the plist's baked entry each name whichever
+ * copy invoked last, so BOTH copies see drift on every invocation and reinstall
+ * over each other. The helper is killed every few seconds — 578 launches in one
+ * observed log — and its status item never survives long enough to be visible,
+ * while `agents menubar status` still reports `running: yes` because some pid
+ * always exists.
+ *
+ * So skew alone does not earn a teardown. Only a genuinely different helper
+ * binary (a real upgrade) or a signing-identity heal does; everything else is
+ * corrected in place by `refreshMenubarServiceMetadata`. Pure so the truth table
+ * is unit-testable.
+ */
+export function shouldReplaceRunningHelper(opts: {
+  /** Live processes of the installed bundle (`MenubarStatus.instances`). */
+  liveOwnHelpers: number;
+  /** The shipped helper executable differs from the installed one. */
+  bundleChanged: boolean;
+  /** Installed copy is ad-hoc while the shipped source is Developer ID. */
+  needsDevIdHeal: boolean;
+}): boolean {
+  if (opts.liveOwnHelpers === 0) return true; // nothing to protect — install freely
+  return opts.bundleChanged || opts.needsDevIdHeal;
+}
+
+/** sha256 of a file, or null when it cannot be read. */
+function fileDigest(file: string): string | null {
+  try {
+    return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the shipped helper executable differs from the installed one — the
+ * only condition under which a running helper is worth replacing. Compares
+ * content, not the version stamp: two CLI releases routinely carry the SAME
+ * helper build, and treating a version-string difference as a new binary is what
+ * let two installs bounce the bundle forever (#2109). An unreadable side is
+ * reported as changed so a real upgrade is never skipped.
+ */
+function menubarBundleChanged(): boolean {
+  const src = sourceAppPath();
+  if (!src) return false;
+  const srcExec = path.join(src, 'Contents', 'MacOS', 'MenubarHelper');
+  const installed = installedExecutablePath();
+  if (!fs.existsSync(installed)) return true;
+  const [a, b] = [fileDigest(srcExec), fileDigest(installed)];
+  if (!a || !b) return true;
+  return a !== b;
+}
+
+/**
+ * Correct the service's metadata WITHOUT touching the running helper: rewrite
+ * the plist (so the next natural launch picks up the current install's
+ * interpreter/entry) and re-stamp the installed version (so the staleness check
+ * stops firing). Deliberately no bundle recopy and no `launchctl` restart —
+ * those are what kill the live status item.
+ */
+function refreshMenubarServiceMetadata(): void {
+  const exec = installedExecutablePath();
+  if (!fs.existsSync(exec)) return;
+  const plist = servicePlistPath();
+  try {
+    fs.mkdirSync(path.dirname(plist), { recursive: true });
+    fs.writeFileSync(plist, generateServicePlist(exec));
+  } catch { /* best effort */ }
+  try { fs.writeFileSync(installedVersionMarkerPath(), getCliVersion()); } catch { /* best effort */ }
+}
+
+/**
  * Startup self-heal, run on every darwin CLI invocation (see src/index.ts).
  * No-ops cheaply (a couple of existsSync + a tiny file read) unless work is
  * needed:
  *   - fresh install (no service yet)      -> enable
- *   - upgrade (version stamp changed) or  -> re-enable: recopy the new helper
+ *   - a genuinely new helper binary, or   -> re-enable: recopy the new helper
  *     the App Support helper went missing     binary + rewrite the plist + kick
+ *   - version/entry skew only             -> refresh plist + stamp in place,
+ *                                             leaving the running helper alone
  *
  * Without the staleness re-enable, `npm update` refreshed the CLI but left the
  * menu bar running the previous release's helper binary on a possibly-stale
- * plist. No-ops if: not darwin, the user opted out, or no helper bundle ships.
- * Best-effort — never throws into startup.
+ * plist. Without `shouldReplaceRunningHelper` gating it, two coexisting installs
+ * reinstall over each other forever (#2109). No-ops if: not darwin, the user
+ * opted out, or no helper bundle ships. Best-effort — never throws into startup.
  */
 export function installMenubarLaunchAgentOnUpgrade(): void {
   try {
@@ -498,13 +581,25 @@ export function installMenubarLaunchAgentOnUpgrade(): void {
       enableMenubarService({ clearOptOut: false });
       return;
     }
-    // Re-enable (recopy helper + rewrite plist) when the version drifted OR the
-    // plist's baked interpreter/entry no longer point at the install now running
-    // `agents` — the dual-install skew a version bump alone can't catch — OR the
-    // installed copy is still ad-hoc while the shipped source is Developer ID
-    // (older heal path; Accessibility re-prompts until the identity is restored).
-    if (menubarSetupStale() || menubarSetupNeedsRepoint() || installedNeedsDevIdHeal()) {
+    // Act when the version drifted OR the plist's baked interpreter/entry no
+    // longer point at the install now running `agents` — the dual-install skew a
+    // version bump alone can't catch — OR the installed copy is still ad-hoc
+    // while the shipped source is Developer ID (older heal path; Accessibility
+    // re-prompts until the identity is restored).
+    const needsDevIdHeal = installedNeedsDevIdHeal();
+    if (!(menubarSetupStale() || menubarSetupNeedsRepoint() || needsDevIdHeal)) return;
+
+    // ...but only REPLACE a live helper for a real new binary. The digest is
+    // computed here, in the already-rare branch, so the common no-drift startup
+    // path never reads the bundle.
+    if (shouldReplaceRunningHelper({
+      liveOwnHelpers: liveMenubarProcesses().own.length,
+      bundleChanged: menubarBundleChanged(),
+      needsDevIdHeal,
+    })) {
       enableMenubarService({ clearOptOut: false });
+    } else {
+      refreshMenubarServiceMetadata();
     }
   } catch {
     /* never block startup on the menu bar */

--- a/apps/cli/src/lib/menubar/install-menubar.ts
+++ b/apps/cli/src/lib/menubar/install-menubar.ts
@@ -17,7 +17,6 @@
 
 import { fileURLToPath } from 'url';
 import { execFileSync, spawnSync } from 'child_process';
-import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -478,82 +477,59 @@ export function disableMenubarService(): void {
 }
 
 /**
- * Whether the startup self-heal may tear down a helper that is CURRENTLY
- * RUNNING. The menu-bar twin of `shouldTeardownVersionSkewedBroker`
- * (`src/lib/secrets/agent.ts`), and it exists for the same reason.
+ * Which install is allowed to (re)install the shared helper.
  *
- * `enableMenubarService` recopies the app bundle, which replaces the executable
- * under the live helper and kills it; launchd `KeepAlive` then restarts it. That
- * is correct for a genuine upgrade and catastrophic for mere skew: with two
- * agents-cli installs on one box (`/opt/homebrew` + `~/.local`, the pair in #435
- * and #2109) the version stamp and the plist's baked entry each name whichever
- * copy invoked last, so BOTH copies see drift on every invocation and reinstall
- * over each other. The helper is killed every few seconds — 578 launches in one
- * observed log — and its status item never survives long enough to be visible,
- * while `agents menubar status` still reports `running: yes` because some pid
- * always exists.
+ * The helper lives at ONE path in Application Support, but any number of
+ * agents-cli copies can be present on a box and every one of them runs the
+ * startup self-heal. The version stamp and the plist's baked `AGENTS_ENTRY` each
+ * record whichever copy acted last, so without an ownership rule every copy
+ * reads the others' marks as drift and recopies the bundle over them. Recopying
+ * replaces the executable under the live helper and kills it; launchd
+ * `KeepAlive` restarts it; the next copy repeats it. Measured on one box: a new
+ * pid every 5-15s, 578 launches in the helper's log, a status item that never
+ * stayed visible, and `agents menubar status` still reporting `running: yes`
+ * because a pid always existed (#2109).
  *
- * So skew alone does not earn a teardown. Only a genuinely different helper
- * binary (a real upgrade) or a signing-identity heal does; everything else is
- * corrected in place by `refreshMenubarServiceMetadata`. Pure so the truth table
- * is unit-testable.
+ * There is deliberately NO content comparison here. Comparing the shipped helper
+ * against the installed one cannot distinguish "real upgrade" from "another
+ * install's copy": the helper is rebuilt, re-signed and re-notarized on every
+ * release (`menubar/scripts/build.sh` via `release.sh`), so consecutive releases
+ * ship byte-different bundles from identical Swift source — 1.22.20/21/22 all
+ * have the same 2876288-byte executable and three different sha256s AND three
+ * different CDHashes. Any digest gate therefore reports "changed" for exactly
+ * the skew case it was meant to exempt.
+ *
+ * So ownership decides instead: the plist's `AGENTS_ENTRY` names the owner, and
+ * only the owner may reinstall. A non-owner takes over only once the recorded
+ * owner is gone from disk, which is what makes the rule converge — a dead
+ * install cannot hold the helper hostage, and a live one cannot be fought over.
+ * A same-install upgrade keeps its entry path, so `npm update` still installs
+ * the new helper normally. Pure so the truth table is unit-testable.
  */
-export function shouldReplaceRunningHelper(opts: {
-  /** Live processes of the installed bundle (`MenubarStatus.instances`). */
-  liveOwnHelpers: number;
-  /** The shipped helper executable differs from the installed one. */
-  bundleChanged: boolean;
-  /** Installed copy is ad-hoc while the shipped source is Developer ID. */
-  needsDevIdHeal: boolean;
+export function mayInstallMenubarHelper(opts: {
+  /** `AGENTS_ENTRY` baked into the installed plist — the recorded owner. */
+  plistEntry: string | null;
+  /** `resolveCliEntry()` for the install now running `agents`. */
+  activeEntry: string | null;
+  /** Whether `plistEntry` still exists on disk. */
+  ownerEntryExists: boolean;
 }): boolean {
-  if (opts.liveOwnHelpers === 0) return true; // nothing to protect — install freely
-  return opts.bundleChanged || opts.needsDevIdHeal;
+  // Can't resolve which install we are (a dev/tsx run) — never churn the plist.
+  if (!opts.activeEntry) return false;
+  // No owner recorded yet (fresh or pre-`AGENTS_ENTRY` plist) — adopt it.
+  if (!opts.plistEntry) return true;
+  if (opts.plistEntry === opts.activeEntry) return true; // we are the owner
+  return !opts.ownerEntryExists; // take over only from an install that is gone
 }
 
-/** sha256 of a file, or null when it cannot be read. */
-function fileDigest(file: string): string | null {
-  try {
-    return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
-  } catch {
-    return null;
-  }
-}
-
-/**
- * True when the shipped helper executable differs from the installed one — the
- * only condition under which a running helper is worth replacing. Compares
- * content, not the version stamp: two CLI releases routinely carry the SAME
- * helper build, and treating a version-string difference as a new binary is what
- * let two installs bounce the bundle forever (#2109). An unreadable side is
- * reported as changed so a real upgrade is never skipped.
- */
-function menubarBundleChanged(): boolean {
-  const src = sourceAppPath();
-  if (!src) return false;
-  const srcExec = path.join(src, 'Contents', 'MacOS', 'MenubarHelper');
-  const installed = installedExecutablePath();
-  if (!fs.existsSync(installed)) return true;
-  const [a, b] = [fileDigest(srcExec), fileDigest(installed)];
-  if (!a || !b) return true;
-  return a !== b;
-}
-
-/**
- * Correct the service's metadata WITHOUT touching the running helper: rewrite
- * the plist (so the next natural launch picks up the current install's
- * interpreter/entry) and re-stamp the installed version (so the staleness check
- * stops firing). Deliberately no bundle recopy and no `launchctl` restart —
- * those are what kill the live status item.
- */
-function refreshMenubarServiceMetadata(): void {
-  const exec = installedExecutablePath();
-  if (!fs.existsSync(exec)) return;
-  const plist = servicePlistPath();
-  try {
-    fs.mkdirSync(path.dirname(plist), { recursive: true });
-    fs.writeFileSync(plist, generateServicePlist(exec));
-  } catch { /* best effort */ }
-  try { fs.writeFileSync(installedVersionMarkerPath(), getCliVersion()); } catch { /* best effort */ }
+/** Whether this install owns the menu-bar helper (see `mayInstallMenubarHelper`). */
+function ownsMenubarHelper(): boolean {
+  const plistEntry = readPlistEnvValue('AGENTS_ENTRY');
+  return mayInstallMenubarHelper({
+    plistEntry,
+    activeEntry: resolveCliEntry(),
+    ownerEntryExists: Boolean(plistEntry) && fs.existsSync(plistEntry as string),
+  });
 }
 
 /**
@@ -561,16 +537,15 @@ function refreshMenubarServiceMetadata(): void {
  * No-ops cheaply (a couple of existsSync + a tiny file read) unless work is
  * needed:
  *   - fresh install (no service yet)      -> enable
- *   - a genuinely new helper binary, or   -> re-enable: recopy the new helper
+ *   - upgrade (version stamp changed) or  -> re-enable: recopy the new helper
  *     the App Support helper went missing     binary + rewrite the plist + kick
- *   - version/entry skew only             -> refresh plist + stamp in place,
- *                                             leaving the running helper alone
  *
  * Without the staleness re-enable, `npm update` refreshed the CLI but left the
  * menu bar running the previous release's helper binary on a possibly-stale
- * plist. Without `shouldReplaceRunningHelper` gating it, two coexisting installs
- * reinstall over each other forever (#2109). No-ops if: not darwin, the user
- * opted out, or no helper bundle ships. Best-effort — never throws into startup.
+ * plist. Everything past the ownership gate is unchanged; the gate is what stops
+ * coexisting installs reinstalling over each other forever (#2109). No-ops if:
+ * not darwin, the user opted out, or no helper bundle ships. Best-effort — never
+ * throws into startup.
  */
 export function installMenubarLaunchAgentOnUpgrade(): void {
   try {
@@ -581,25 +556,17 @@ export function installMenubarLaunchAgentOnUpgrade(): void {
       enableMenubarService({ clearOptOut: false });
       return;
     }
-    // Act when the version drifted OR the plist's baked interpreter/entry no
-    // longer point at the install now running `agents` — the dual-install skew a
-    // version bump alone can't catch — OR the installed copy is still ad-hoc
-    // while the shipped source is Developer ID (older heal path; Accessibility
-    // re-prompts until the identity is restored).
-    const needsDevIdHeal = installedNeedsDevIdHeal();
-    if (!(menubarSetupStale() || menubarSetupNeedsRepoint() || needsDevIdHeal)) return;
-
-    // ...but only REPLACE a live helper for a real new binary. The digest is
-    // computed here, in the already-rare branch, so the common no-drift startup
-    // path never reads the bundle.
-    if (shouldReplaceRunningHelper({
-      liveOwnHelpers: liveMenubarProcesses().own.length,
-      bundleChanged: menubarBundleChanged(),
-      needsDevIdHeal,
-    })) {
+    // Only the install that owns the helper may reinstall it. Without this, every
+    // coexisting copy treats the others' version stamp / baked entry as drift and
+    // recopies the bundle over them, killing the live helper on a loop (#2109).
+    if (!ownsMenubarHelper()) return;
+    // Re-enable (recopy helper + rewrite plist) when the version drifted OR the
+    // plist's baked interpreter/entry no longer point at the install now running
+    // `agents` — e.g. the owner moved between node interpreters — OR the
+    // installed copy is still ad-hoc while the shipped source is Developer ID
+    // (older heal path; Accessibility re-prompts until the identity is restored).
+    if (menubarSetupStale() || menubarSetupNeedsRepoint() || installedNeedsDevIdHeal()) {
       enableMenubarService({ clearOptOut: false });
-    } else {
-      refreshMenubarServiceMetadata();
     }
   } catch {
     /* never block startup on the menu bar */


### PR DESCRIPTION
**Bug fix, macOS menu-bar helper.** Only the install that owns the helper may reinstall it, so coexisting agents-cli copies stop killing it on a loop. Fixes #2109.

> Rewritten after review. The first attempt gated on a content digest; that premise was false and is documented below, because it is the trap anyone touching this will fall into next.

## What was happening

The helper lives at one path in Application Support, but **every** agents-cli copy on the box runs the startup self-heal (`installMenubarLaunchAgentOnUpgrade`, called at module top level from `src/index.ts:1383` on every darwin invocation). It reinstalls when the version stamp drifted or the plist's baked `AGENTS_ENTRY` names another install — and both of those record *whichever copy acted last*. So each copy read the others' marks as drift and recopied the app bundle over them. Recopying replaces the executable under the live helper and kills it; launchd `KeepAlive` restarts it; the next copy repeats it.

Measured on the affected machine: a new helper pid every 5-15s, **578 launches** in the helper's own log, a status item that never stayed visible, and `agents menubar status` still reporting `running: yes` because a pid always existed. Four copies were present (1.22.22 Homebrew, 1.22.5 nvm, a `0.0.0-dev` sessions build, an npx-cached 1.20.88).

## The fix

`mayInstallMenubarHelper` — the plist's `AGENTS_ENTRY` names the owner:

```ts
if (!opts.activeEntry) return false;                    // unresolvable (dev/tsx) — never churn
if (!opts.plistEntry) return true;                      // no owner recorded — adopt
if (opts.plistEntry === opts.activeEntry) return true;  // we are the owner
return !opts.ownerEntryExists;                          // take over only from an install that is gone
```

It converges: a dead install can't hold the helper hostage, a live one can't be fought over. A same-install upgrade keeps its entry path, so `npm update` still installs the new helper via the unchanged staleness path behind the gate.

## Why there is no content comparison (the review finding)

The first revision gated on a sha256 of the helper executable, premised on "adjacent releases routinely ship the same helper build". **That is false**, and the reviewer caught it. The helper is rebuilt, re-signed and re-notarized on every release (`menubar/scripts/build.sh` via `release.sh`), so identical Swift source yields byte-different bundles.

Verified against the published npm tarballs:

```
1.22.20  size=2876288  sha256=fd1296c5f145806f…  CDHash=18bbed5e7c59932c…
1.22.21  size=2876288  sha256=9e73a343f4c8ad1b…  CDHash=23f944f93487954f…
1.22.22  size=2876288  sha256=e0ad760f53245591…  CDHash=64c9c2762edcafd5…
```

Same executable size (same build), three different digests. **CDHash differs too**, so the reviewer's suggested remedy — hash the CodeDirectory to skip the CMS/timestamp blob — does not rescue it either; these builds are simply not reproducible. And `fd1296c5f145806f` / `9e73a343f4c8ad1b` are *exactly* the two hashes observed alternating on the affected machine, i.e. the digest gate would have returned "changed" for the precise scenario it was meant to exempt. The first patch would not have fixed the reported bug.

`AGENTS.md` now records this so the next person doesn't re-derive it.

## Verification

`mayInstallMenubarHelper` is pure; 5 cases in `install-menubar.test.ts` cover owner / foreign-with-live-owner / foreign-with-dead-owner / no-owner-recorded / unresolvable-entry. Mutation-tested — reverting the gate to unconditional `return true` fails exactly the two cases that encode the bug:

```
× refuses a foreign install while the recorded owner still exists (#2109)
× never churns when the active entry cannot be resolved (dev/tsx run)
      Tests  2 failed | 29 passed | 3 skipped
```

Restored: `41 passed | 3 skipped` across `src/lib/menubar/`. `tsc --noEmit` clean.

**No screenshot: this change has no visible surface** — its effect is the *absence* of a teardown. The user-visible outcome is documented with before/after evidence in #2109.

**Not verified end-to-end:** the live multi-install loop against this build. It needs the fix present in every coexisting copy (one unfixed copy still clobbers), and the only reproduction is the owner's interactive laptop. The gate and its wiring are unit-covered; the composed multi-install behavior is not.

## Also here

- `apps/cli/AGENTS.md` — the ownership invariant plus the explicit "do not compare bundle content, here is the measurement" warning.
- `.changelog/next/menubar-repoint-loop.md`.

## Follow-up not in this PR

#2147 — the multi-install banner under-reports copies (it named 2 of 4 on the affected box), and copies predating `app-bundle-install.ts` still write the shared bundle with a lock-free `rm -rf` + `cp -R`, so a fix in `main` cannot protect a machine that still hosts one.
