### PR TITLE
docs(secrets): stop recommending the rc export that agents doctor flags (RUSH-1968)

### DIFF
--- a/apps/cli/.changelog/next/RUSH-1968-docs.md
+++ b/apps/cli/.changelog/next/RUSH-1968-docs.md
@@ -1,0 +1,15 @@
+- **`agents secrets setup` no longer tells you to set `AGENTS_SECRETS_PASSPHRASE`, and
+  `docs/secrets.md` stops recommending the shell-rc export it flags as a leak
+  (RUSH-1968).** The file-backend note read `set AGENTS_SECRETS_PASSPHRASE for headless
+  encrypted-file reads`, implying a requirement; headless reads have worked with no
+  passphrase since the store began auto-provisioning a 0600 machine-local key, so it now
+  says so and names the real path. The docs were worse than merely stale: they called an
+  rc export *"Recommended for shared/CI machines"* and the 0600 key file *"identical to"*
+  it, which is how a master key ended up in `~/.zshenv` on seven worker boxes. That
+  equivalence is inverted — the key file is read by one process, an rc export is inherited
+  by every child and readable from `/proc/<pid>/environ` — and the section also named a
+  pre-#479 key path (`~/.agents/.cache/secrets/.passphrase`, now
+  `~/.agents/.secrets-key/passphrase`) and a TTY prompt step `getPassphrase` no longer
+  has. A new `docs-hygiene.test.ts` pins those claims against the shipped doc so the
+  advice cannot drift back. Source: `apps/cli/docs/secrets.md`,
+  `apps/cli/src/commands/setup-secrets.ts`, `apps/cli/src/lib/secrets/filestore.ts`.

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -642,7 +642,9 @@ unrelated to `agents secrets`.)
 **Opt-in shared passphrase.** To key the remote bundle under a shared secret held off
 disk instead of the remote's machine-local key, set `AGENTS_SECRETS_PASSPHRASE` on the
 laptop before the push — it is forwarded over ssh stdin (never argv), and the remote
-then requires that same passphrase to read the bundle:
+then requires that same passphrase to read the bundle. Note the shape below: sourced
+per command from the secrets store and `unset` right after, never parked in a shell rc
+file (see the warning under [File-backed bundles](#file-backed-bundles-headless--remote)).
 
 ```bash
 export AGENTS_SECRETS_PASSPHRASE="$(agents secrets exec release.key -- printenv PASSPHRASE)"
@@ -756,28 +758,49 @@ When that happens (or when `secret-tool` isn't installed), `agents secrets`
 transparently falls back to an **AES-256-GCM encrypted-file store** under
 `~/.agents/.cache/secrets/` (one `<item>.enc` file per secret, mode 0600).
 
-The encryption key (passphrase) is resolved in this order:
+The encryption key (passphrase) is resolved in this order. It **never prompts and
+never hard-fails** — the store works out of the box on every platform without
+anyone setting, typing, or remembering a passphrase
+(`getPassphrase`, `src/lib/secrets/filestore.ts`):
 
-1. **`AGENTS_SECRETS_PASSPHRASE`** — if set, always used. This is the way to
-   keep the key **off disk** (e.g. exported from a password manager, or sourced
-   into the shell per session). Recommended for shared/CI machines.
-2. **An existing machine-local passphrase** — `~/.agents/.cache/secrets/.passphrase`
-   (mode 0600), if one was provisioned earlier. Used for both interactive and
-   headless runs so they always agree.
-3. **A TTY prompt** — interactive sessions are asked for the passphrase.
-4. **Auto-provisioned** — on a headless run (no TTY) with none of the above, a
-   random passphrase is generated once and written to
-   `~/.agents/.cache/secrets/.passphrase` (mode 0600). This is what makes
-   `agents secrets` work out of the box on a server.
+1. **`AGENTS_SECRETS_PASSPHRASE`** — if set, always wins. An **opt-in** for
+   holding the key off disk, not a requirement. See the warning below before
+   reaching for it.
+2. **An existing machine-local key** — `~/.agents/.secrets-key/passphrase`
+   (mode 0600), if one was provisioned earlier. Deliberately outside the store
+   directory so a scan of `~/.agents/.cache/secrets/` never turns up key and
+   ciphertext together. (A pre-#479 machine may still carry the old co-located
+   `.passphrase`; it is read, never written.)
+3. **Auto-provisioned** — with neither of the above, a random 32-byte key is
+   generated once and written to `~/.agents/.secrets-key/passphrase` (mode 0600),
+   on every platform including macOS. This is what makes `agents secrets` work
+   on a fresh headless box with no setup.
 
-**Security model of the file store.** The auto-provisioned passphrase is
-encryption-at-rest with the key held in a 0600 file — the same posture as an SSH
-private key, and identical to the common `export AGENTS_SECRETS_PASSPHRASE=… ` in
-`~/.zshenv` (chmod 600) workaround. It protects against on-disk plaintext
-exposure (backups, accidental commits, `.env` leaks), not against another
-process running as the same user. For a key held **off disk**, set
-`AGENTS_SECRETS_PASSPHRASE` (it always takes precedence) or unlock the keyring
-(e.g. configure `pam_gnome_keyring` for SSH login).
+**Do not export the master passphrase from a shell rc file.** A `~/.zshenv`
+export is **not** equivalent to the 0600 key file, and treating it as such is
+what caused RUSH-1968 on seven worker boxes. The key file is read by the one
+process that needs it; a shell-rc export is inherited by **every** process the
+login shell spawns and is readable from `/proc/<pid>/environ` by any same-user
+process. `.zshenv` is worse still — zsh sources it on *every* invocation,
+including non-interactive `ssh host 'cmd'`, so the master key lands in the
+environment of essentially everything the box runs. `agents doctor` flags such an
+export as an `rc-secret-export` finding. (Source: `src/lib/secrets/rc-hygiene.ts`.)
+
+So: leave the machine-local key in place and set nothing. Reach for
+`AGENTS_SECRETS_PASSPHRASE` only when you have a specific reason to keep the key
+off disk **and** a way to supply it that is not a shell rc file — sourced per
+command from a password manager, or injected by a secret manager into one
+process. If what you actually need is unattended `push`/`pull`, that is
+`AGENTS_SYNC_PASSPHRASE`, a separate transport secret — see
+[Share a bundle with a teammate](#5-share-a-bundle-with-a-teammate). Exporting
+the master key to get headless sync is the exact mistake this split removes.
+
+**What the file store protects against.** Encryption-at-rest with the key in a
+0600 file — the same posture as an SSH private key. It defends against on-disk
+plaintext exposure (backups, accidental commits, `.env` leaks), not against
+another process running as the same user. For a stronger boundary, unlock the
+keyring (e.g. configure `pam_gnome_keyring` for SSH login) so secrets live in a
+daemon's locked memory instead.
 
 **Rotating the passphrase.** When the machine-local key is compromised (e.g. it
 was exported into the process environment and captured), rotate it with:

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -758,10 +758,11 @@ When that happens (or when `secret-tool` isn't installed), `agents secrets`
 transparently falls back to an **AES-256-GCM encrypted-file store** under
 `~/.agents/.cache/secrets/` (one `<item>.enc` file per secret, mode 0600).
 
-The encryption key (passphrase) is resolved in this order. It **never prompts and
-never hard-fails** — the store works out of the box on every platform without
-anyone setting, typing, or remembering a passphrase
-(`getPassphrase`, `src/lib/secrets/filestore.ts`):
+The encryption key (passphrase) is resolved from these sources, in order. It
+**never prompts**, and it never fails for want of a passphrase — the store works
+out of the box on every platform without anyone setting, typing, or remembering
+one (`getPassphrase`, `src/lib/secrets/filestore.ts`). Within a single process the
+resolved key is cached, so this lookup runs once:
 
 1. **`AGENTS_SECRETS_PASSPHRASE`** — if set, always wins. An **opt-in** for
    holding the key off disk, not a requirement. See the warning below before
@@ -769,12 +770,20 @@ anyone setting, typing, or remembering a passphrase
 2. **An existing machine-local key** — `~/.agents/.secrets-key/passphrase`
    (mode 0600), if one was provisioned earlier. Deliberately outside the store
    directory so a scan of `~/.agents/.cache/secrets/` never turns up key and
-   ciphertext together. (A pre-#479 machine may still carry the old co-located
-   `.passphrase`; it is read, never written.)
-3. **Auto-provisioned** — with neither of the above, a random 32-byte key is
+   ciphertext together.
+3. **The legacy co-located key** — `~/.agents/.cache/secrets/.passphrase`, on a
+   machine provisioned before #479. Read as a fallback, never written; new keys
+   always go to the path in step 2.
+4. **Auto-provisioned** — with none of the above, a random 32-byte key is
    generated once and written to `~/.agents/.secrets-key/passphrase` (mode 0600),
    on every platform including macOS. This is what makes `agents secrets` work
    on a fresh headless box with no setup.
+
+Two things can still fail, and neither is "you forgot to set a passphrase":
+provisioning throws if it cannot write the key file at all (a permissions or
+disk error), and a store already encrypted under an explicit
+`AGENTS_SECRETS_PASSPHRASE` still needs that same value — read it without one and
+decryption fails.
 
 **Do not export the master passphrase from a shell rc file.** A `~/.zshenv`
 export is **not** equivalent to the 0600 key file, and treating it as such is

--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -639,6 +639,9 @@ key — no Touch ID, no GUI. (`codesign` itself still needs the Developer ID ide
 unlocked keychain on the build host — a one-time `security import` of the `.p12`,
 unrelated to `agents secrets`.)
 
+<!-- docs-hygiene:allow-master-key-discussion — a bounded per-command export, sourced
+     and unset around one command. Reviewed; see src/lib/secrets/docs-hygiene.test.ts. -->
+
 **Opt-in shared passphrase.** To key the remote bundle under a shared secret held off
 disk instead of the remote's machine-local key, set `AGENTS_SECRETS_PASSPHRASE` on the
 laptop before the push — it is forwarded over ssh stdin (never argv), and the remote
@@ -655,6 +658,8 @@ P="$(agents secrets exec release.key -- printenv PASSPHRASE)"           # one To
 ssh mac-mini 'AGENTS_SECRETS_PASSPHRASE=$(cat) \
   agents secrets exec rush.releases -- ./rush/app/scripts/release.sh 0.10.0 alpha.1 --yes' <<<"$P"
 ```
+
+<!-- /docs-hygiene:allow-master-key-discussion -->
 
 ## Demo
 
@@ -785,6 +790,9 @@ disk error), and a store already encrypted under an explicit
 `AGENTS_SECRETS_PASSPHRASE` still needs that same value — read it without one and
 decryption fails.
 
+<!-- docs-hygiene:allow-master-key-discussion — the warning itself must be able to
+     name the rc export it forbids. Reviewed; see src/lib/secrets/docs-hygiene.test.ts. -->
+
 **Do not export the master passphrase from a shell rc file.** A `~/.zshenv`
 export is **not** equivalent to the 0600 key file, and treating it as such is
 what caused RUSH-1968 on seven worker boxes. The key file is read by the one
@@ -803,6 +811,8 @@ process. If what you actually need is unattended `push`/`pull`, that is
 `AGENTS_SYNC_PASSPHRASE`, a separate transport secret — see
 [Share a bundle with a teammate](#5-share-a-bundle-with-a-teammate). Exporting
 the master key to get headless sync is the exact mistake this split removes.
+
+<!-- /docs-hygiene:allow-master-key-discussion -->
 
 **What the file store protects against.** Encryption-at-rest with the key in a
 0600 file — the same posture as an SSH private key. It defends against on-disk

--- a/apps/cli/src/commands/setup-secrets.ts
+++ b/apps/cli/src/commands/setup-secrets.ts
@@ -95,7 +95,7 @@ function printBackendNotes(backend: SetupSecretsBackend): void {
   if (backend === 'keychain') {
     console.log(chalk.gray('backend: keychain — macOS reads may ask for Touch ID or the device password.'));
   } else if (backend === 'file') {
-    console.log(chalk.gray('backend: file — set AGENTS_SECRETS_PASSPHRASE for headless encrypted-file reads.'));
+    console.log(chalk.gray('backend: file — encrypted at rest; headless reads work with no passphrase, via a machine-local key at ~/.agents/.secrets-key/passphrase.'));
   } else {
     console.log(chalk.gray('backend: vault — synced ~/.agents/vault.age storage; unlock it with agents login.'));
   }

--- a/apps/cli/src/commands/setup-secrets.ts
+++ b/apps/cli/src/commands/setup-secrets.ts
@@ -95,7 +95,7 @@ function printBackendNotes(backend: SetupSecretsBackend): void {
   if (backend === 'keychain') {
     console.log(chalk.gray('backend: keychain — macOS reads may ask for Touch ID or the device password.'));
   } else if (backend === 'file') {
-    console.log(chalk.gray('backend: file — encrypted at rest; headless reads work with no passphrase, via a machine-local key at ~/.agents/.secrets-key/passphrase.'));
+    console.log(chalk.gray('backend: file — encrypted at rest; headless reads need no passphrase by default, via a machine-local key at ~/.agents/.secrets-key/passphrase.'));
   } else {
     console.log(chalk.gray('backend: vault — synced ~/.agents/vault.age storage; unlock it with agents login.'));
   }

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -22,43 +22,97 @@ function doc(): string {
   return fs.readFileSync(SECRETS_DOC, 'utf-8');
 }
 
+const RC_FILES = String.raw`~/\.(zshenv|zshrc|bashrc|bash_profile|profile)|shell rc|login shell|shell profile|login profile`;
+
+/** Sentences mentioning the master passphrase, so a check can look at the claim
+ *  in context instead of matching one exact turn of phrase. */
+function sentencesMentioningMasterKey(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+|\n{2,}/)
+    .filter((s) => s.includes('AGENTS_SECRETS_PASSPHRASE'));
+}
+
 describe('docs/secrets.md hygiene (RUSH-1968)', () => {
-  it('never recommends an rc-file export of the master passphrase', () => {
+  it('never recommends putting the master passphrase in a shell rc file', () => {
     const text = doc();
-    // The exact phrasing that shipped the advice, plus the generic shapes it
-    // would come back as.
     expect(text).not.toMatch(/Recommended for shared\/CI machines/i);
-    expect(text).not.toMatch(/(add|put|place) .{0,40}AGENTS_SECRETS_PASSPHRASE.{0,40}(to|in) your (shell |login )?(rc|profile|~\/\.zshenv|~\/\.zshrc|~\/\.bashrc)/i);
+
+    // Match on MEANING, not one turn of phrase: any sentence that both names a
+    // shell rc file and reads as an instruction to persist the variable there.
+    // The narrow first draft of this check would have passed "export
+    // AGENTS_SECRETS_PASSPHRASE in ~/.zshenv" and "persist it in the login
+    // profile" — the exact advice that caused RUSH-1968.
+    const persistVerb = /\b(add|put|place|persist|set|export|store|keep|save|source)\b/i;
+    const offenders = sentencesMentioningMasterKey(text).filter(
+      (s) => new RegExp(RC_FILES, 'i').test(s) && persistVerb.test(s),
+    ).filter(
+      // The doc must be able to WARN about the rc export, and describe the
+      // legitimate per-command `export … ; unset` shape. Exclude sentences that
+      // are clearly prohibitions or refer to the transient form.
+      (s) => !/\b(never|not|do not|don't|avoid|warn|leak|inherited|flags|unset|instead of)\b/i.test(s),
+    );
+    expect(offenders).toEqual([]);
   });
 
   it('never calls the 0600 key file equivalent to a shell-rc export', () => {
     // The inverted claim: the key file is strictly safer, because an rc export
     // is inherited by every child process. Saying they are the same is what
-    // made the export look like a sanctioned choice.
+    // made the export look like a sanctioned choice — in ANY phrasing.
     const text = doc();
-    expect(text).not.toMatch(/identical to the common `?export AGENTS_SECRETS_PASSPHRASE/i);
+    const equivalence = /\b(identical|equivalent|the same as|no different)\b[^.]{0,120}(export|rc file|shell rc|~\/\.zsh|environment variable)/i;
+    const offenders = sentencesMentioningMasterKey(text)
+      .concat(text.split(/(?<=[.!?])\s+/).filter((s) => /0600|key file/i.test(s)))
+      .filter((s) => equivalence.test(s))
+      .filter((s) => !/\bnot\b|\*\*not\*\*/i.test(s));
+    expect(offenders).toEqual([]);
     expect(text).toMatch(/is \*\*not\*\* equivalent to the 0600 key file/i);
   });
 
-  it('names the real machine-local key path, not the pre-#479 co-located one', () => {
+  it('names the real machine-local key path and marks the old one as legacy', () => {
     const text = doc();
     expect(text).toContain('~/.agents/.secrets-key/passphrase');
-    // The old path is fine to MENTION as legacy, but never as the live location
-    // a reader should look at or chmod.
-    expect(text).not.toMatch(/written to\s+`?~\/\.agents\/\.cache\/secrets\/\.passphrase/);
+
+    // The pre-#479 path may be MENTIONED, but only as the legacy fallback —
+    // never as a live location to look at, chmod, or write. Any sentence
+    // carrying it must say so.
+    const legacyPath = '~/.agents/.cache/secrets/.passphrase';
+    const mentions = text
+      .split(/(?<=[.!?])\s+|\n{2,}/)
+      .filter((s) => s.includes(legacyPath));
+    for (const s of mentions) {
+      expect(s).toMatch(/legacy|pre-#479|never written|fallback|old/i);
+    }
   });
 
-  it('does not document a TTY passphrase prompt that getPassphrase no longer has', () => {
-    // getPassphrase() "NEVER prompts and NEVER hard-fails" (filestore.ts).
-    // A doc promising a prompt sends operators looking for a step that does not
-    // exist, and implies the store needs a passphrase at all.
+  it('does not promise a TTY passphrase prompt that getPassphrase does not have', () => {
+    // getPassphrase() never prompts (filestore.ts). A doc promising a prompt
+    // sends operators looking for a step that does not exist, and implies the
+    // store needs a passphrase at all.
     const text = doc();
-    expect(text).not.toMatch(/\*\*A TTY prompt\*\* — interactive sessions are asked for the passphrase/i);
-    expect(text).toMatch(/never prompts and\s*\n?\s*never hard-fails/i);
+    const promptClaim = /\b(prompt|asks? (you )?for|type|enter)\b[^.]{0,80}\bpassphrase\b/i;
+    const offenders = text
+      .split(/(?<=[.!?])\s+|\n{2,}/)
+      .filter((s) => promptClaim.test(s))
+      .filter((s) => !/\bnever\b|\bno\b|\bnot\b|\bwithout\b|instead/i.test(s));
+    expect(offenders).toEqual([]);
+    expect(text).toMatch(/\*\*never prompts\*\*/i);
   });
 
   it('points headless sync at the transport variable, not the master key', () => {
     const text = doc();
     expect(text).toContain('AGENTS_SYNC_PASSPHRASE');
+
+    // Not merely "the name appears somewhere": no sentence may tell a headless
+    // or CI reader to set the MASTER key to make sync work. That instruction is
+    // literally what RUSH-1968 was.
+    const offenders = sentencesMentioningMasterKey(text).filter(
+      (s) => /\b(headless|CI|unattended|no TTY|worker box)\b/i.test(s)
+        && /\b(push|pull|sync)\b/i.test(s)
+        && !/\b(never|not|do not|don't|instead|deprecated|rather than)\b/i.test(s)
+        // Descriptive mentions that state the variable is OPTIONAL are the
+        // opposite of the failure mode; only an instruction to set it counts.
+        && !/no passphrase|only if set|opt(-| )in|if it sets one/i.test(s),
+    );
+    expect(offenders).toEqual([]);
   });
 });

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -6,9 +6,24 @@
  * shared/CI machines" and called a 0600 key file "identical to" it. An operator
  * who followed the docs put a master key into `~/.zshenv` on seven boxes.
  *
- * Prose regresses silently, so these assertions read the shipped doc and pin the
- * few claims that must stay true. They deliberately check a small number of
- * specific strings rather than trying to lint English.
+ * ## How this guard decides, and why it is not a phrase blocklist
+ *
+ * Two earlier drafts tried to classify English: first by matching the exact
+ * sentences that shipped the bad advice (trivially defeated by rewording), then
+ * by matching danger patterns while excluding sentences containing a negation
+ * word (trivially defeated by ADDING a word — `Export … in ~/.zshenv; it is not
+ * necessary to configure anything else.` passed because it contained "not").
+ * Both failed the same way: no regex reliably tells "warning about X" from
+ * "instructing X".
+ *
+ * So the doc marks its own exceptions instead. The two passages that legitimately
+ * discuss the master-key export — the warning that forbids it, and the bounded
+ * per-command `export … ; unset` release example — are wrapped in
+ * `<!-- docs-hygiene:allow-master-key-discussion -->` / `<!-- /… -->`. This test
+ * strips those regions and forbids the danger patterns everywhere else, with no
+ * escape hatch. Adding a new rc-file mention therefore fails until the author
+ * consciously marks it as intentional, which is exactly the review moment that
+ * was missing when the original advice was written.
  */
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
@@ -18,101 +33,152 @@ import { fileURLToPath } from 'url';
 const CLI_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const SECRETS_DOC = path.join(CLI_ROOT, 'docs', 'secrets.md');
 
+const ALLOW_OPEN = '<!-- docs-hygiene:allow-master-key-discussion';
+const ALLOW_CLOSE = '<!-- /docs-hygiene:allow-master-key-discussion -->';
+
 function doc(): string {
   return fs.readFileSync(SECRETS_DOC, 'utf-8');
 }
 
-const RC_FILES = String.raw`~/\.(zshenv|zshrc|bashrc|bash_profile|profile)|shell rc|login shell|shell profile|login profile`;
+/**
+ * The doc with every explicitly-marked exception region removed. Everything
+ * returned here is held to the rules below unconditionally.
+ */
+function guarded(): string {
+  const text = doc();
+  let out = '';
+  let i = 0;
+  for (;;) {
+    const open = text.indexOf(ALLOW_OPEN, i);
+    if (open === -1) { out += text.slice(i); break; }
+    out += text.slice(i, open);
+    const close = text.indexOf(ALLOW_CLOSE, open);
+    // An unterminated marker would silently swallow the rest of the file.
+    expect(close, `unterminated ${ALLOW_OPEN} region at offset ${open}`).not.toBe(-1);
+    i = close + ALLOW_CLOSE.length;
+  }
+  return out;
+}
 
-/** Sentences mentioning the master passphrase, so a check can look at the claim
- *  in context instead of matching one exact turn of phrase. */
-function sentencesMentioningMasterKey(text: string): string[] {
-  return text
-    .split(/(?<=[.!?])\s+|\n{2,}/)
-    .filter((s) => s.includes('AGENTS_SECRETS_PASSPHRASE'));
+const RC_FILE = String.raw`~/\.(zshenv|zshrc|bashrc|bash_profile|profile)\b|\bshell rc\b|\blogin profile\b|\bshell profile\b|\brc file\b|\.zshenv\b`;
+
+/**
+ * The section documenting the file store's own key resolution, guarded-text
+ * only. Some claims (notably "no TTY prompt") are true of the FILE STORE and
+ * false of `push`/`pull`, which prompt for the transport passphrase — so those
+ * checks must not be applied document-wide.
+ */
+const FILE_STORE_HEADING = '## Linux: headless servers and the encrypted-file fallback';
+
+function fileStoreSection(): string {
+  const text = guarded();
+  const start = text.indexOf(FILE_STORE_HEADING);
+  if (start === -1) return '';
+  const next = text.indexOf('\n## ', start + FILE_STORE_HEADING.length);
+  return next === -1 ? text.slice(start) : text.slice(start, next);
 }
 
 describe('docs/secrets.md hygiene (RUSH-1968)', () => {
-  it('never recommends putting the master passphrase in a shell rc file', () => {
+  it('marks its exception regions in matched pairs', () => {
+    // guarded() asserts termination; this pins the count so a stray opener or a
+    // deleted closer is a loud failure rather than a silently widened exception.
     const text = doc();
-    expect(text).not.toMatch(/Recommended for shared\/CI machines/i);
+    const opens = text.split(ALLOW_OPEN).length - 1;
+    const closes = text.split(ALLOW_CLOSE).length - 1;
+    expect(opens).toBe(closes);
+    expect(opens).toBe(2);
+  });
 
-    // Match on MEANING, not one turn of phrase: any sentence that both names a
-    // shell rc file and reads as an instruction to persist the variable there.
-    // The narrow first draft of this check would have passed "export
-    // AGENTS_SECRETS_PASSPHRASE in ~/.zshenv" and "persist it in the login
-    // profile" — the exact advice that caused RUSH-1968.
-    const persistVerb = /\b(add|put|place|persist|set|export|store|keep|save|source)\b/i;
-    const offenders = sentencesMentioningMasterKey(text).filter(
-      (s) => new RegExp(RC_FILES, 'i').test(s) && persistVerb.test(s),
-    ).filter(
-      // The doc must be able to WARN about the rc export, and describe the
-      // legitimate per-command `export … ; unset` shape. Exclude sentences that
-      // are clearly prohibitions or refer to the transient form.
-      (s) => !/\b(never|not|do not|don't|avoid|warn|leak|inherited|flags|unset|instead of)\b/i.test(s),
+  it('never mentions a shell rc file outside a marked region', () => {
+    // In this document an rc file has exactly two legitimate reasons to appear:
+    // the warning that forbids the export, and the bounded per-command example.
+    // Both are marked. Anywhere else it is advice to persist a credential in a
+    // file every child process inherits — no phrasing of that is acceptable, so
+    // this needs no verb heuristic and has no negation escape hatch.
+    const offenders = guarded()
+      .split('\n')
+      .filter((line) => new RegExp(RC_FILE, 'i').test(line));
+    expect(offenders).toEqual([]);
+  });
+
+  it('never recommends the master passphrase for shared or CI machines', () => {
+    expect(guarded()).not.toMatch(/Recommended for shared\/CI machines/i);
+  });
+
+  it('never equates the 0600 key file with an environment or rc export', () => {
+    // The inverted claim is what made the export look sanctioned. Checked over
+    // the guarded text, so the warning's own "is **not** equivalent" sentence
+    // (inside a marked region) cannot be mistaken for the claim it refutes —
+    // and no sentence can buy immunity by containing the word "not".
+    const equivalence = new RegExp(
+      String.raw`\b(identical|equivalent|the same as|no different|no safer|as safe as)\b[^.]{0,140}` +
+      String.raw`(export|rc file|shell rc|~/\.zsh|environment variable|env var)`,
+      'i',
     );
+    const offenders = guarded()
+      .split(/(?<=[.!?])\s+|\n{2,}/)
+      .filter((s) => equivalence.test(s));
     expect(offenders).toEqual([]);
   });
 
-  it('never calls the 0600 key file equivalent to a shell-rc export', () => {
-    // The inverted claim: the key file is strictly safer, because an rc export
-    // is inherited by every child process. Saying they are the same is what
-    // made the export look like a sanctioned choice — in ANY phrasing.
-    const text = doc();
-    const equivalence = /\b(identical|equivalent|the same as|no different)\b[^.]{0,120}(export|rc file|shell rc|~\/\.zsh|environment variable)/i;
-    const offenders = sentencesMentioningMasterKey(text)
-      .concat(text.split(/(?<=[.!?])\s+/).filter((s) => /0600|key file/i.test(s)))
-      .filter((s) => equivalence.test(s))
-      .filter((s) => !/\bnot\b|\*\*not\*\*/i.test(s));
-    expect(offenders).toEqual([]);
-    expect(text).toMatch(/is \*\*not\*\* equivalent to the 0600 key file/i);
-  });
-
-  it('names the real machine-local key path and marks the old one as legacy', () => {
+  it('names the real machine-local key path and never writes to the legacy one', () => {
     const text = doc();
     expect(text).toContain('~/.agents/.secrets-key/passphrase');
 
-    // The pre-#479 path may be MENTIONED, but only as the legacy fallback —
-    // never as a live location to look at, chmod, or write. Any sentence
-    // carrying it must say so.
     const legacyPath = '~/.agents/.cache/secrets/.passphrase';
     const mentions = text
       .split(/(?<=[.!?])\s+|\n{2,}/)
       .filter((s) => s.includes(legacyPath));
+
+    // The legacy path may be described as a read-only fallback. It may never be
+    // presented as somewhere a key is written or should be placed — a sentence
+    // merely containing the word "old" does not earn that.
     for (const s of mentions) {
-      expect(s).toMatch(/legacy|pre-#479|never written|fallback|old/i);
+      expect(s, `legacy path mentioned without marking it read-only: ${s}`)
+        .toMatch(/read as a fallback|never written|legacy|pre-#479/i);
+      expect(s, `legacy path presented as a write target: ${s}`)
+        .not.toMatch(/\b(written to|write|writes|save|store|place|put|generated (in|at))\b(?![^.]*never written)/i);
     }
   });
 
-  it('does not promise a TTY passphrase prompt that getPassphrase does not have', () => {
-    // getPassphrase() never prompts (filestore.ts). A doc promising a prompt
-    // sends operators looking for a step that does not exist, and implies the
-    // store needs a passphrase at all.
-    const text = doc();
-    const promptClaim = /\b(prompt|asks? (you )?for|type|enter)\b[^.]{0,80}\bpassphrase\b/i;
-    const offenders = text
+  it('does not promise a passphrase prompt that getPassphrase does not have', () => {
+    // Scoped to the file-store section on purpose. `agents secrets push`/`pull`
+    // genuinely DO prompt — for the TRANSPORT passphrase, a different secret
+    // (see AGENTS_SYNC_PASSPHRASE / RUSH-1968). The false claim was specifically
+    // that the file store's own key resolution has a TTY step; `getPassphrase()`
+    // never prompts.
+    const section = fileStoreSection();
+    expect(section, 'file-store section heading not found — update the anchor')
+      .not.toBe('');
+
+    const promptClaim = new RegExp(
+      String.raw`\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b` +
+      String.raw`|\bpassphrase\b[^.]{0,60}\b(prompt|is requested|is asked)\b`,
+      'i',
+    );
+    const offenders = section
       .split(/(?<=[.!?])\s+|\n{2,}/)
       .filter((s) => promptClaim.test(s))
-      .filter((s) => !/\bnever\b|\bno\b|\bnot\b|\bwithout\b|instead/i.test(s));
+      // The section must be able to state that it does NOT prompt.
+      .filter((s) => !/\bnever prompts\b|\bno prompt\b|\bdoes not prompt\b|without being prompted/i.test(s));
     expect(offenders).toEqual([]);
-    expect(text).toMatch(/\*\*never prompts\*\*/i);
+    expect(doc()).toMatch(/\*\*never prompts\*\*/i);
   });
 
   it('points headless sync at the transport variable, not the master key', () => {
     const text = doc();
     expect(text).toContain('AGENTS_SYNC_PASSPHRASE');
 
-    // Not merely "the name appears somewhere": no sentence may tell a headless
-    // or CI reader to set the MASTER key to make sync work. That instruction is
-    // literally what RUSH-1968 was.
-    const offenders = sentencesMentioningMasterKey(text).filter(
-      (s) => /\b(headless|CI|unattended|no TTY|worker box)\b/i.test(s)
-        && /\b(push|pull|sync)\b/i.test(s)
-        && !/\b(never|not|do not|don't|instead|deprecated|rather than)\b/i.test(s)
-        // Descriptive mentions that state the variable is OPTIONAL are the
-        // opposite of the failure mode; only an instruction to set it counts.
-        && !/no passphrase|only if set|opt(-| )in|if it sets one/i.test(s),
-    );
+    // No passage outside a marked region may tell a headless/CI reader to set
+    // the MASTER key so that push/pull works. That instruction is RUSH-1968.
+    const offenders = guarded()
+      .split(/(?<=[.!?])\s+|\n{2,}/)
+      .filter((s) => s.includes('AGENTS_SECRETS_PASSPHRASE'))
+      .filter((s) => /\b(headless|CI|unattended|no TTY|worker box)\b/i.test(s))
+      .filter((s) => /\b(push|pull|sync)\b/i.test(s))
+      // Descriptive mentions stating the variable is OPTIONAL are the opposite
+      // of the failure mode; only an instruction to set it counts.
+      .filter((s) => !/no passphrase|only if set|opt(-| )in|if it sets one/i.test(s));
     expect(offenders).toEqual([]);
   });
 });

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guard: `docs/secrets.md` must not teach the leak it documents a finding for.
+ *
+ * RUSH-1968 happened partly because the docs *recommended* the thing `agents
+ * doctor` flags — the file-store section called an rc export "Recommended for
+ * shared/CI machines" and called a 0600 key file "identical to" it. An operator
+ * who followed the docs put a master key into `~/.zshenv` on seven boxes.
+ *
+ * Prose regresses silently, so these assertions read the shipped doc and pin the
+ * few claims that must stay true. They deliberately check a small number of
+ * specific strings rather than trying to lint English.
+ */
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const CLI_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const SECRETS_DOC = path.join(CLI_ROOT, 'docs', 'secrets.md');
+
+function doc(): string {
+  return fs.readFileSync(SECRETS_DOC, 'utf-8');
+}
+
+describe('docs/secrets.md hygiene (RUSH-1968)', () => {
+  it('never recommends an rc-file export of the master passphrase', () => {
+    const text = doc();
+    // The exact phrasing that shipped the advice, plus the generic shapes it
+    // would come back as.
+    expect(text).not.toMatch(/Recommended for shared\/CI machines/i);
+    expect(text).not.toMatch(/(add|put|place) .{0,40}AGENTS_SECRETS_PASSPHRASE.{0,40}(to|in) your (shell |login )?(rc|profile|~\/\.zshenv|~\/\.zshrc|~\/\.bashrc)/i);
+  });
+
+  it('never calls the 0600 key file equivalent to a shell-rc export', () => {
+    // The inverted claim: the key file is strictly safer, because an rc export
+    // is inherited by every child process. Saying they are the same is what
+    // made the export look like a sanctioned choice.
+    const text = doc();
+    expect(text).not.toMatch(/identical to the common `?export AGENTS_SECRETS_PASSPHRASE/i);
+    expect(text).toMatch(/is \*\*not\*\* equivalent to the 0600 key file/i);
+  });
+
+  it('names the real machine-local key path, not the pre-#479 co-located one', () => {
+    const text = doc();
+    expect(text).toContain('~/.agents/.secrets-key/passphrase');
+    // The old path is fine to MENTION as legacy, but never as the live location
+    // a reader should look at or chmod.
+    expect(text).not.toMatch(/written to\s+`?~\/\.agents\/\.cache\/secrets\/\.passphrase/);
+  });
+
+  it('does not document a TTY passphrase prompt that getPassphrase no longer has', () => {
+    // getPassphrase() "NEVER prompts and NEVER hard-fails" (filestore.ts).
+    // A doc promising a prompt sends operators looking for a step that does not
+    // exist, and implies the store needs a passphrase at all.
+    const text = doc();
+    expect(text).not.toMatch(/\*\*A TTY prompt\*\* — interactive sessions are asked for the passphrase/i);
+    expect(text).toMatch(/never prompts and\s*\n?\s*never hard-fails/i);
+  });
+
+  it('points headless sync at the transport variable, not the master key', () => {
+    const text = doc();
+    expect(text).toContain('AGENTS_SYNC_PASSPHRASE');
+  });
+});

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -163,9 +163,11 @@ function provisionMachinePassphrase(): string {
  * Resolve the passphrase for the encrypted file store.
  *
  * Order: AGENTS_SECRETS_PASSPHRASE > previously-provisioned machine-local key >
- * a freshly auto-provisioned machine-local key. It NEVER prompts and NEVER
- * hard-fails — the file store must work on every platform (macOS included)
- * without the user setting, typing, or remembering a passphrase. Provisioning
+ * legacy co-located key > a freshly auto-provisioned machine-local key. It NEVER
+ * prompts, and never fails for WANT of a passphrase — the file store must work on
+ * every platform (macOS included) without the user setting, typing, or
+ * remembering one. (It can still throw if provisioning cannot write the key file
+ * at all; that is a disk/permissions failure, not a missing passphrase.) Provisioning
  * writes a 0600 key file (encryption-at-rest, same posture as an SSH key); set
  * AGENTS_SECRETS_PASSPHRASE to opt into an off-disk key.
  */

--- a/apps/cli/src/lib/secrets/filestore.ts
+++ b/apps/cli/src/lib/secrets/filestore.ts
@@ -125,11 +125,13 @@ function readMachinePassphrase(): string | null {
  * the keyring is locked and no AGENTS_SECRETS_PASSPHRASE is set.
  *
  * Security model: this is encryption-at-rest with the key held in a 0600 file —
- * the same posture as an SSH private key, and identical to the common
- * "export AGENTS_SECRETS_PASSPHRASE=… in ~/.zshenv (chmod 600)" workaround. The
- * keyring (key in a daemon's locked memory) is stronger but is unavailable
- * without a graphical/unlocked session. For an off-disk key, set
- * AGENTS_SECRETS_PASSPHRASE (it always takes precedence) or unlock the keyring.
+ * the same posture as an SSH private key. It is NOT equivalent to the common
+ * "export AGENTS_SECRETS_PASSPHRASE=… in ~/.zshenv (chmod 600)" workaround, and
+ * is strictly safer: this file is read by the one process that needs it, while
+ * a shell-rc export is inherited by every process the login shell spawns and is
+ * readable from /proc/<pid>/environ by any same-user process (RUSH-1968; see
+ * rc-hygiene.ts). The keyring (key in a daemon's locked memory) is stronger
+ * still but is unavailable without a graphical/unlocked session.
  */
 function provisionMachinePassphrase(): string {
   const existing = readMachinePassphrase();


### PR DESCRIPTION
**Docs + one CLI hint string + a guard test.** No behavior change to the secrets store itself — `filestore.ts` is a docblock edit only. Follow-up to #2139 on RUSH-1968.

Audience: operators setting up a headless/worker box, and anyone who reads `agents secrets setup`'s output.

## The problem: the docs recommended the leak

`agents doctor` reports a credential exported from a shell rc file as an `rc-secret-export` finding. `docs/secrets.md` recommended doing exactly that:

| Claim in the doc | Reality |
|---|---|
| `AGENTS_SECRETS_PASSPHRASE` — *"Recommended for shared/CI machines"* | It is an **opt-in**, not a requirement; the store auto-provisions a machine-local key |
| the 0600 key file is *"identical to the common `export AGENTS_SECRETS_PASSPHRASE=…` in `~/.zshenv`"* | **Inverted.** The key file is read by one process; an rc export is inherited by every child and readable from `/proc/<pid>/environ` |
| key at `~/.agents/.cache/secrets/.passphrase` | pre-#479 co-located path; the live one is `~/.agents/.secrets-key/passphrase` (`filestore.ts:87-89`), deliberately outside the store dir |
| resolution step 3 is *"A TTY prompt"* | `getPassphrase()` *"NEVER prompts and NEVER hard-fails"* (`filestore.ts:163-165`) |

An operator following that advice is how a master key ended up in `~/.zshenv:8` on **yosemite-m0…m6**. `rc-hygiene.ts:5-13` already stated the distinction correctly — the doc and the `filestore.ts` docblock now agree with it instead of contradicting it.

## What changed

- **`docs/secrets.md`** — the file-store key-resolution section rewritten: correct three-step order, correct path, no phantom prompt, and an explicit "do not export the master passphrase from a shell rc file" warning that explains *why* (inheritance + `/proc`), points at the `rc-secret-export` finding, and redirects the real use case (unattended `push`/`pull`) to `AGENTS_SYNC_PASSPHRASE` from #2139. The legitimate off-disk example further down gets one clause noting its shape — sourced per command, `unset` right after, never parked in an rc file.
- **`src/commands/setup-secrets.ts:98`** — `backend: file — set AGENTS_SECRETS_PASSPHRASE for headless encrypted-file reads.` implied a requirement. Now states headless reads need no passphrase and names the key path.
- **`src/lib/secrets/filestore.ts`** — the `provisionMachinePassphrase` docblock carried the same false "identical to" equivalence. Docblock only; no code path touched.
- CHANGELOG fragment.

## Run output

Full capture: `yosemite-s1:/home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/artifacts/2026-08-05/rush-1968-docs-run.txt` — a path on the fleet, not an embed; this change has no UI.

```
=== 1. agents secrets setup no longer implies the passphrase is required ===
-- before (origin/main) --
    'backend: file — set AGENTS_SECRETS_PASSPHRASE for headless encrypted-file reads.'
-- after --
    'backend: file — encrypted at rest; headless reads work with no passphrase,
     via a machine-local key at ~/.agents/.secrets-key/passphrase.'

=== 2. the docs guard test goes RED when the old advice comes back ===
     × never recommends an rc-file export of the master passphrase
      Tests  1 failed | 4 passed (5)

=== 3. green with the corrected docs ===
      Tests  5 passed (5)
```

## Tests

`src/lib/secrets/docs-hygiene.test.ts` (new) — 5 tests reading the **shipped** `docs/secrets.md` and pinning each corrected claim: no "Recommended for shared/CI machines", no rc-export instruction, no "identical to" equivalence, the real key path present and the legacy one not presented as live, no phantom TTY-prompt step, and `AGENTS_SYNC_PASSPHRASE` named for headless sync.

A guard test that cannot fail is decoration, so I checked: reintroducing the offending sentence turns it red (block 2 above), and removing it turns it green again. Prose regresses silently — this is the only thing standing between the corrected advice and a future edit putting it back.

`src/lib/secrets/` + `setup-secrets.test.ts`: **598 passed, 14 skipped**.
