### PR TITLE
fix(muse): detect nested providers.meta tokens after login

### DIFF
--- a/apps/cli/.changelog/next/muse-auth-nested-providers.md
+++ b/apps/cli/.changelog/next/muse-auth-nested-providers.md
@@ -1,0 +1,8 @@
+- **Muse login is recognized under `providers.meta` (balanced no longer signed_out).**
+  Live `muse login` writes `~/.config/muse/auth.json` as
+  `{ schema_version, providers: { meta: { access_token, user_email, … } } }`.
+  The presence detector only walked one object level, so it never saw the token
+  under `providers.meta` and reported signed-out after a successful OAuth —
+  `agents run muse` under balanced then failed with "excluded: 0.1.0
+  (signed_out)". Detection now recurses into nested provider slots and surfaces
+  `user_email` when present. Source: `apps/cli/src/lib/agents.ts`.

--- a/apps/cli/src/lib/agents.test.ts
+++ b/apps/cli/src/lib/agents.test.ts
@@ -692,6 +692,49 @@ describe('getAccountInfo — token-only agents (no local email)', () => {
     expect(info.signedIn).toBe(false);
   });
 
+  it('detects Muse signed-in from providers.meta.access_token (live muse login shape)', async () => {
+    // muse login writes { schema_version, providers: { meta: { access_token, … } } }.
+    // A one-level walk only saw `providers` and reported signed_out, so balanced
+    // excluded the only install after a successful login.
+    const home = makeTempDir();
+    const dir = path.join(home, '.config', 'muse');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'auth.json'),
+      JSON.stringify({
+        schema_version: 1,
+        providers: {
+          meta: {
+            access_token: 'dca:test-token-not-real',
+            obtained_via: 'device_code',
+            mechanism: 'oauth',
+            api_key: 'LLM|test',
+            user_email: 'muqsit@example.com',
+            user_full_name: 'Muqsit',
+          },
+        },
+      }),
+      'utf-8',
+    );
+    const info = await getAccountInfo('muse', home);
+    expect(info.signedIn).toBe(true);
+    expect(info.email).toBe('muqsit@example.com');
+    expect(info.accountId).toBe('muqsit@example.com');
+  });
+
+  it('treats Muse as signed out when auth.json has no nested token', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.config', 'muse');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'auth.json'),
+      JSON.stringify({ schema_version: 1, providers: { meta: {} } }),
+      'utf-8',
+    );
+    const info = await getAccountInfo('muse', home);
+    expect(info.signedIn).toBe(false);
+  });
+
   it('decrypts auth.v2.file and surfaces the email + org from the WorkOS JWT', async () => {
     const home = makeTempDir();
     writeDroidCredential(path.join(home, '.factory'), {

--- a/apps/cli/src/lib/agents.ts
+++ b/apps/cli/src/lib/agents.ts
@@ -1624,22 +1624,41 @@ function isValidOpenCodeCredential(value: unknown): boolean {
 
 /**
  * Whether a Muse Code `~/.config/muse/auth.json` document holds any usable
- * access token. The launcher stores per-provider slots (e.g. `meta`) each with
- * an `access_token` string; a top-level `access_token` is also accepted.
- * Never returns the secret itself — presence only.
+ * access token. Live shape from `muse login` (device OAuth, Muse Code 0.1.0):
+ *   { schema_version: 1, providers: { meta: { access_token, api_key, user_email, … } } }
+ * Also accept top-level or one-level-nested tokens for older/alternate writers.
+ * Recurses into objects so `providers.meta.access_token` is found — a flat
+ * one-level walk only saw `providers` and reported signed-out after a successful
+ * login (balanced then excluded the account). Never returns the secret itself.
  */
-function museAuthHasToken(value: unknown): boolean {
+function museAuthHasToken(value: unknown, depth = 0): boolean {
+  if (depth > 4) return false;
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const root = value as Record<string, unknown>;
   if (typeof root.access_token === 'string' && root.access_token.length > 0) return true;
   if (typeof root.api_key === 'string' && root.api_key.length > 0) return true;
   for (const slot of Object.values(root)) {
-    if (!slot || typeof slot !== 'object' || Array.isArray(slot)) continue;
-    const entry = slot as Record<string, unknown>;
-    if (typeof entry.access_token === 'string' && entry.access_token.length > 0) return true;
-    if (typeof entry.api_key === 'string' && entry.api_key.length > 0) return true;
+    if (museAuthHasToken(slot, depth + 1)) return true;
   }
   return false;
+}
+
+/** Best-effort email from a Muse auth.json (providers.meta.user_email, etc.). */
+function museAuthEmail(value: unknown, depth = 0): string | null {
+  if (depth > 4) return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const root = value as Record<string, unknown>;
+  if (typeof root.user_email === 'string' && root.user_email.includes('@')) {
+    return root.user_email;
+  }
+  if (typeof root.email === 'string' && root.email.includes('@')) {
+    return root.email;
+  }
+  for (const slot of Object.values(root)) {
+    const found = museAuthEmail(slot, depth + 1);
+    if (found) return found;
+  }
+  return null;
 }
 
 /**
@@ -2074,10 +2093,8 @@ export async function getAccountInfo(
       }
       case 'muse': {
         // Muse Code authenticates with META_API_KEY (env, highest priority) or
-        // a stored OAuth/API credential at ~/.config/muse/auth.json. The auth
-        // file is launcher-managed JSON with per-provider slots holding
-        // access_token; there is no email claim, so we report signed-in + a
-        // stable identity key (env-key vs provider slots) like kimi/opencode.
+        // a stored OAuth/API credential at ~/.config/muse/auth.json. Live file
+        // shape nests under providers.meta (access_token + optional user_email).
         if (process.env.META_API_KEY?.trim() || process.env.MODEL_API_KEY?.trim()) {
           const accountKey = buildIdentityKey(agentId, [['auth', 'env']]);
           return { ...empty, signedIn: true, accountId: 'env', accountKey, lastActive };
@@ -2086,12 +2103,20 @@ export async function getAccountInfo(
         if (!authPath) return { ...empty, lastActive };
         const data = JSON.parse(await fs.promises.readFile(authPath, 'utf-8'));
         if (!data || typeof data !== 'object') return { ...empty, lastActive };
-        // auth.json shape: { meta?: { access_token }, … } or similar slots.
-        // Any object with a nested access_token (or a top-level one) counts.
-        const hasToken = museAuthHasToken(data);
-        if (!hasToken) return { ...empty, lastActive };
-        const accountKey = buildIdentityKey(agentId, [['auth', 'file']]);
-        return { ...empty, signedIn: true, accountId: 'file', accountKey, lastActive };
+        if (!museAuthHasToken(data)) return { ...empty, lastActive };
+        const email = museAuthEmail(data);
+        const accountKey = buildIdentityKey(
+          agentId,
+          email ? [['email', email]] : [['auth', 'file']],
+        );
+        return {
+          ...empty,
+          signedIn: true,
+          email,
+          accountId: email ?? 'file',
+          accountKey,
+          lastActive,
+        };
       }
       default:
         return { ...empty, lastActive };


### PR DESCRIPTION
fix — Muse login recognized under `providers.meta` (balanced signed_out).

## Bug

After `muse login` saved credentials, `agents run muse` still failed:

`no healthy muse account under strategy 'balanced' — excluded: 0.1.0 (signed_out)`

Live auth.json shape (Muse Code 0.1.0 device OAuth):

```json
{ "schema_version": 1, "providers": { "meta": { "access_token": "…", "user_email": "…" } } }
```

`museAuthHasToken` only walked one object level, so it never saw the token
under `providers.meta`.

## Fix

Recurse into nested provider slots (depth-capped) and surface `user_email`
when present.

## Run proof

```

 RUN  v4.1.9 /home/muqsit/src/github.com/muqsitnawaz/agents-cli/.agents/worktrees/muse-auth-nested/apps/cli

 ✓ src/lib/agents.test.ts (78 tests | 76 skipped) 14ms

 Test Files  1 passed (1)
      Tests  2 passed | 76 skipped (78)
   Start at  19:15:48
   Duration  972ms (transform 711ms, setup 19ms, import 840ms, tests 14ms, environment 0ms)
```

No-surface; auth detection only.
