### PR TITLE
fix(secrets): read bundle values by declared keys, fail loud on unreadable (RUSH-2252, RUSH-2253)

### DIFF
--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -1137,6 +1137,33 @@ access control (that is 1Password/Vault; this tool is device-local first).
   macOS sheet itself emits no event. **No read path is exempt** from the audit
   funnel — a code path that resolves a value without an `emitSecretAudit` record is a
   spec violation.
+- **SEC-30 (MUST).** **An existence answer and a read answer MUST NOT contradict, and a
+  read refusal MUST be reported as a refusal, never as absence.** A bundle read MUST
+  build its keychain read set from the bundle's **declared keys** (the `keychain:` refs
+  in its metadata), not solely from an enumeration of its namespace: the macOS helper's
+  `list` omits biometry-ACL'd items (`kSecUseAuthenticationUISkip`) and skips the whole
+  data-protection pass on a locked keychain (`keychain-helper.swift` `list`), so an
+  enumeration-only read set turns a present secret into a false "not found"
+  (`readAndResolveBundleEnv` unions the declared keys with the enumeration —
+  `lib/secrets/bundles.ts`). When a declared item still resolves to no value, the read
+  MUST classify it before erroring: an item that `hasKeychainToken` reports **present**
+  (which counts `errSecInteractionNotAllowed` as present, matching what `secrets view`
+  shows) MUST be reported as **present-but-unreadable** with how to unlock, and MUST NOT
+  print a remediation that would overwrite it (`agents secrets add`); only a **proven
+  absence** may print the add remediation (`missingBundleKeychainItemError`,
+  `lib/secrets/bundles.ts`). **Given** `secrets view` shows a key as `stored` **When**
+  `secrets view --reveal` / `unlock` reads it **Then** it returns the value or an
+  explicit read-failure — never `stored item '<item>' not found`.
+- **SEC-31 (MUST).** An existence or delete probe that cannot reach the keychain MUST
+  fail loud, never answer a false "no". `hasKeychainToken` and `deleteKeychainToken`
+  (`lib/secrets/index.ts`) MUST treat only the helper's exit 0 (present / deleted) and
+  exit 1 (genuinely absent / nothing to delete) as answers; any other outcome — helper
+  error, spawn failure, or the SIGKILL timeout (`spawnKeychainHelper`,
+  `KeychainHelperTimeoutError`) — MUST throw a reachability error rather than return
+  `false`, because a swallowed failure silently disarms the destructive-write guards
+  (`bundleExists`, the `--force` overwrite checks, the rename/purge) that key on these
+  primitives (RUSH-2235). Every keychain-helper spawn stays bounded by that timeout +
+  SIGKILL so a wedged `coreauthd` can never hang the parent (RUSH-2231/2232).
 
 #### 3.4 Authorization model
 

--- a/apps/cli/src/lib/secrets/bundles.declared-keys.test.ts
+++ b/apps/cli/src/lib/secrets/bundles.declared-keys.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression for RUSH-2248 / RUSH-2252 / RUSH-2253: a present keychain secret
+ * read as "stored item not found" because the read set was built from a lossy
+ * enumeration instead of the bundle's declared keys.
+ *
+ * On macOS the keychain helper's `list` omits every biometry-ACL'd item and
+ * skips the whole data-protection pass when the keychain is locked. A `hold`
+ * bundle's value items are all ACL'd, so enumeration returned them as absent and
+ * `--reveal` / `unlock` failed with `stored item '<item>' not found`, telling the
+ * user to `secrets add` — which would overwrite the good secret — even though
+ * `secrets view` (a direct point probe) reported the same key as `stored`.
+ *
+ * The `list`-drop is simulated with a backend whose `list()` hides value items
+ * (mirroring the helper's UISkip) while `has()` / `get()` answer per item — no
+ * real Keychain, per the storage-test convention (see bundles-storage.test.ts).
+ *
+ * RUSH-2252: the declared key is still read (declared-key union), despite the
+ *            empty enumeration.
+ * RUSH-2253: a present-but-unreadable item reports LOCKED (with how to unlock),
+ *            never "not found" / "add the key"; a genuinely-absent key still
+ *            reports not-found.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { readAndResolveBundleEnv, writeBundle } from './bundles.js';
+import { _resetFileStoreForTest } from './filestore.js';
+import {
+  SECRETS_ITEM_PREFIX,
+  secretsKeychainItem,
+  setKeychainBackendForTest,
+  type KeychainBackend,
+} from './index.js';
+
+/**
+ * A backend that models the three states the secrets stack must tell apart:
+ *   - readable  → `get()` returns a value  (present + unlocked)
+ *   - locked    → present but `get()` throws (biometry ACL held / keychain
+ *                 locked); `has()` still reports it present
+ *   - absent    → nowhere
+ * and whose `list()` drops value items (`agents-cli.secrets.*`), reproducing the
+ * macOS helper's biometry/locked enumeration blind spot. Metadata items
+ * (`agents-cli.bundles.*`) are no-ACL and still enumerate.
+ */
+class ProbeKeychain implements KeychainBackend {
+  readable = new Map<string, string>();
+  locked = new Set<string>();
+  /** Items whose existence probe (`has`) fails — the keychain is unreachable
+   * for them. Models the RUSH-2235 fail-loud contract: `hasKeychainToken` throws
+   * rather than answering a false "no". */
+  unreachable = new Set<string>();
+
+  has(item: string): boolean {
+    if (this.unreachable.has(item)) throw new Error(`keychain unreachable probing ${item}`);
+    return this.readable.has(item) || this.locked.has(item);
+  }
+  get(item: string): string {
+    if (this.locked.has(item)) throw new Error(`keychain locked for ${item}`);
+    const v = this.readable.get(item);
+    if (v === undefined) throw new Error(`missing ${item}`);
+    return v;
+  }
+  set(item: string, value: string): void {
+    this.readable.set(item, value);
+    this.locked.delete(item);
+  }
+  delete(item: string): boolean {
+    this.locked.delete(item);
+    return this.readable.delete(item);
+  }
+  list(prefix: string): string[] {
+    const names = [...this.readable.keys(), ...this.locked.keys()].filter((k) => k.startsWith(prefix));
+    // The helper's `list` cannot see biometry-ACL'd value items — drop them so
+    // the read set can only be completed from the bundle's declared keys.
+    return names.filter((k) => !k.startsWith(SECRETS_ITEM_PREFIX));
+  }
+}
+
+const NAME = 'rush2252-declared.test';
+let probe: ProbeKeychain;
+let prevBackend: ReturnType<typeof setKeychainBackendForTest>;
+let fileDir: string;
+
+beforeEach(() => {
+  probe = new ProbeKeychain();
+  prevBackend = setKeychainBackendForTest(probe);
+  fileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secrets-declared-'));
+  _resetFileStoreForTest({ fileDir });
+});
+
+afterEach(() => {
+  setKeychainBackendForTest(prevBackend);
+  _resetFileStoreForTest();
+  try { fs.rmSync(fileDir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('readAndResolveBundleEnv builds the read set from declared keys (RUSH-2252)', () => {
+  it('resolves a declared keychain key whose item the enumeration dropped', () => {
+    writeBundle({ name: NAME, policy: 'hold', vars: { API: 'keychain:API' } });
+    // The value item exists and is readable, but list() hides it — exactly the
+    // biometry-drop that made --reveal report "stored item not found".
+    probe.readable.set(secretsKeychainItem(NAME, 'API'), 'the-secret');
+
+    const { env } = readAndResolveBundleEnv(NAME, { noAgent: true });
+    expect(env.API).toBe('the-secret');
+  });
+
+  it('reads every declared key of a multi-key bundle behind the enumeration drop', () => {
+    writeBundle({ name: NAME, policy: 'hold', vars: { A: 'keychain:A', B: 'keychain:B', LIT: 'plain' } });
+    probe.readable.set(secretsKeychainItem(NAME, 'A'), 'aval');
+    probe.readable.set(secretsKeychainItem(NAME, 'B'), 'bval');
+
+    const { env } = readAndResolveBundleEnv(NAME, { noAgent: true });
+    expect(env).toEqual({ A: 'aval', B: 'bval', LIT: 'plain' });
+  });
+});
+
+describe('present-but-unreadable is not reported as absent (RUSH-2253)', () => {
+  it('a present-but-locked item reports LOCKED with how to unlock, never "add the key"', () => {
+    writeBundle({ name: NAME, policy: 'hold', vars: { API: 'keychain:API' } });
+    // Present (has() sees it) but unreadable (get() throws) — a locked keychain
+    // / held biometry ACL, the RUSH-2248 divergence between `view` and `--reveal`.
+    probe.locked.add(secretsKeychainItem(NAME, 'API'));
+
+    let caught: Error | undefined;
+    try {
+      readAndResolveBundleEnv(NAME, { noAgent: true });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toMatch(/present but could not be read/i);
+    expect(caught!.message).toMatch(/agents secrets unlock/);
+    // The dangerous remediation must NOT be OFFERED for a present secret (the
+    // message may still name it to warn the user off it).
+    expect(caught!.message).not.toMatch(/Run: agents secrets add/);
+    expect(caught!.message).not.toMatch(/\bnot found\b/i);
+  });
+
+  it('a genuinely-absent declared key still reports not-found with the add remediation', () => {
+    writeBundle({ name: NAME, policy: 'hold', vars: { API: 'keychain:API' } });
+    // Nothing seeded: the item exists nowhere.
+
+    let caught: Error | undefined;
+    try {
+      readAndResolveBundleEnv(NAME, { noAgent: true });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toMatch(/not found/i);
+    expect(caught!.message).toMatch(new RegExp(`agents secrets add ${NAME} API`));
+    // An absence must not masquerade as the locked state.
+    expect(caught!.message).not.toMatch(/present but could not be read/i);
+  });
+
+  it('an unreachable keychain surfaces the reachability failure, never a false not-found (RUSH-2235)', () => {
+    writeBundle({ name: NAME, policy: 'hold', vars: { API: 'keychain:API' } });
+    // The value item can't be read AND its existence can't be proven — the
+    // keychain is unreachable. `has` fails loud, so the classifier must not
+    // guess "absent" (which would tell the user to overwrite a maybe-present
+    // secret).
+    probe.unreachable.add(secretsKeychainItem(NAME, 'API'));
+
+    let caught: Error | undefined;
+    try {
+      readAndResolveBundleEnv(NAME, { noAgent: true });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toMatch(/unreachable/i);
+    expect(caught!.message).not.toMatch(/Run: agents secrets add/);
+    expect(caught!.message).not.toMatch(/\bnot found\b/i);
+  });
+});

--- a/apps/cli/src/lib/secrets/bundles.ts
+++ b/apps/cli/src/lib/secrets/bundles.ts
@@ -420,6 +420,27 @@ export function readBundle(name: string): SecretsBundle {
     if (vaultExists() && !getVaultSession().loggedIn) {
       throw new Error(`Synced secrets are locked. Run: agents login`);
     }
+    // Distinguish a genuinely-absent bundle from a present-but-unreadable one
+    // (a locked login keychain, or a legacy ACL'd metadata item before first
+    // unlock). `has` counts an unreadable item as present, so a metadata item
+    // that exists but could not be read must not report as "not found" — an
+    // existence answer and a read answer may not contradict (RUSH-2253).
+    if (backend === 'keychain') {
+      let present: boolean;
+      try {
+        present = hasKeychainToken(bundleMetaItem(name));
+      } catch (probeErr) {
+        // Keychain unreachable (RUSH-2235 fail-loud): neither absent nor
+        // add-the-key — surface the reachability failure, not a false absence.
+        throw new Error(`Secrets bundle '${name}': ${(probeErr as Error).message}`);
+      }
+      if (present) {
+        throw new Error(
+          `Secrets bundle '${name}' is present but its metadata could not be read — the keychain is locked. ` +
+          `Unlock it (log in, or reboot then log in) and retry. (${(err as Error).message})`,
+        );
+      }
+    }
     throw new Error(`Secrets bundle '${name}' not found.`);
   }
   let parsed: Partial<SecretsBundle>;
@@ -1268,6 +1289,106 @@ export function assertRemoteBundleFlagsUnsupported(
   );
 }
 
+/**
+ * A declared `keychain:` ref resolved to NO value in the batch read. Classify
+ * genuinely-absent vs present-but-unreadable before choosing the error, so a
+ * read can never contradict what `agents secrets view` reports (RUSH-2248,
+ * RUSH-2253). `view`'s "stored" badge comes from `hasKeychainToken` — the exact
+ * existence probe used here — which counts a biometry-ACL'd or locked-keychain
+ * item (`errSecInteractionNotAllowed`) as present. So:
+ *
+ *   - present  ⇒ the item exists but this context could not read it (keychain
+ *     locked, or Touch ID not granted). Report HOW to unlock; NEVER
+ *     "add the key", whose remediation (`secrets add`) would overwrite a good
+ *     secret.
+ *   - absent   ⇒ genuinely not stored on this machine — the honest "not found"
+ *     with the `secrets add` remediation.
+ *   - probe throws ⇒ the keychain itself is unreachable (RUSH-2235 fail-loud):
+ *     neither absent nor add-the-key — surface the reachability failure verbatim.
+ *
+ * Only the keychain backend has a locked/biometry state; a file/vault miss is
+ * genuinely absent.
+ */
+function missingBundleKeychainItemError(
+  bundleName: string,
+  key: string,
+  item: string,
+  backendKind: SecretsBackend,
+): Error {
+  if (backendKind === 'keychain') {
+    let present: boolean;
+    try {
+      present = hasKeychainToken(item);
+    } catch (err) {
+      return new Error(`Bundle '${bundleName}' key '${key}': ${(err as Error).message}`);
+    }
+    if (present) {
+      return new Error(
+        `Bundle '${bundleName}' key '${key}': stored item '${item}' is present but could not be read — ` +
+        `the keychain is locked or Touch ID was not granted for this read. ` +
+        `Run: agents secrets unlock ${bundleName}  (or read it once at an interactive terminal so Touch ID can be granted). ` +
+        `Do NOT run 'agents secrets add' — the secret is already stored and adding would overwrite it.`,
+      );
+    }
+  }
+  return new Error(
+    `Bundle '${bundleName}' key '${key}': stored item '${item}' not found. ` +
+    `Run: agents secrets add ${bundleName} ${key}`,
+  );
+}
+
+/**
+ * Resolve every selected key of an already-read bundle into a flat env map,
+ * given a pre-fetched keychain batch. The single per-key resolution loop shared
+ * by `resolveBundleEnv` and `readAndResolveBundleEnv` so the keychain lookup and
+ * the missing-item classification can never diverge again (RUSH-2252: the two
+ * paths drifted — one did the hashed-alias fallback lookup and one did not, and
+ * only one classified a missing item honestly).
+ *
+ * The keychain lookup tries the cleartext name first (Linux / file store), then
+ * its hashed storage alias (macOS with #316 hashing active) — the batch keys its
+ * results by the names it was ASKED for, which for the metadata + declared keys
+ * is the cleartext form and for an enumerated leftover is the hashed form.
+ */
+function assembleBundleEnv(
+  bundle: SecretsBundle,
+  selectedKeys: Set<string>,
+  parsedByKey: Map<string, { literal: string } | { ref: SecretRef }>,
+  fetched: Map<string, string>,
+  keyMode: ResolveBundleOptions['keyMode'],
+  backendKind: SecretsBackend,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  const owners = new Map<string, string>();
+  for (const [key] of Object.entries(bundle.vars)) {
+    if (!selectedKeys.has(key)) continue;
+    const parsed = parsedByKey.get(key)!;
+    if ('literal' in parsed) {
+      assignResolvedEnvValue(env, bundle, key, parsed.literal, keyMode, owners);
+      continue;
+    }
+    if (parsed.ref.provider === 'keychain') {
+      const item = secretsKeychainItem(bundle.name, parsed.ref.value);
+      const value = fetched.get(item) ?? fetched.get(keychainServiceAlias(item));
+      if (value === undefined) {
+        throw missingBundleKeychainItemError(bundle.name, key, item, backendKind);
+      }
+      assignResolvedEnvValue(env, bundle, key, value, keyMode, owners);
+      continue;
+    }
+    try {
+      const value = resolveRef(parsed.ref, {
+        allowExec: bundle.allow_exec,
+        keychainItemFor: (shortId: string) => secretsKeychainItem(bundle.name, shortId),
+      });
+      assignResolvedEnvValue(env, bundle, key, value, keyMode, owners);
+    } catch (err) {
+      throw new Error(`Bundle '${bundle.name}' key '${key}': ${(err as Error).message}`);
+    }
+  }
+  return env;
+}
+
 // Walk the bundle and produce a flat env map. Every keychain: ref is gathered
 // into a single batch read so macOS shows ONE Touch ID prompt for the whole
 // bundle — including the metadata fetch that already happened in readBundle
@@ -1305,37 +1426,14 @@ export function resolveBundleEnv(bundle: SecretsBundle, _opts: ResolveBundleOpti
       : store.getBatch(keychainItemsToFetch)
     : new Map<string, string>();
 
-  const env: Record<string, string> = {};
-  const owners = new Map<string, string>();
-  for (const [key, raw] of Object.entries(bundle.vars)) {
-    if (!selectedKeys.has(key)) continue;
-    const parsed = parsedByKey.get(key)!;
-    if ('literal' in parsed) {
-      assignResolvedEnvValue(env, bundle, key, parsed.literal, _opts.keyMode, owners);
-      continue;
-    }
-    if (parsed.ref.provider === 'keychain') {
-      const item = secretsKeychainItem(bundle.name, parsed.ref.value);
-      const value = fetched.get(item);
-      if (value === undefined) {
-        throw new Error(
-          `Bundle '${bundle.name}' key '${key}': stored item '${item}' not found. ` +
-          `Run: agents secrets add ${bundle.name} ${key}`
-        );
-      }
-      assignResolvedEnvValue(env, bundle, key, value, _opts.keyMode, owners);
-      continue;
-    }
-    try {
-      const value = resolveRef(parsed.ref, {
-        allowExec: bundle.allow_exec,
-        keychainItemFor: (shortId: string) => secretsKeychainItem(bundle.name, shortId),
-      });
-      assignResolvedEnvValue(env, bundle, key, value, _opts.keyMode, owners);
-    } catch (err) {
-      throw new Error(`Bundle '${bundle.name}' key '${key}': ${(err as Error).message}`);
-    }
-  }
+  const env = assembleBundleEnv(
+    bundle,
+    selectedKeys,
+    parsedByKey,
+    fetched,
+    _opts.keyMode,
+    bundle.backend ?? 'keychain',
+  );
   // `caller` is intentionally unused; see ResolveBundleOptions.
   void _opts.caller;
   return env;
@@ -1551,6 +1649,52 @@ export function readAndResolveBundleEnv(
   const keys = [...selectedKeys].sort();
   keychainKeys.sort();
 
+  // RUSH-2252: complete the read set from the bundle's DECLARED keys, not only
+  // from the enumeration above. `store.list()` derives the batch by enumerating
+  // the bundle's namespace, and that enumeration is lossy by construction — the
+  // macOS helper's `list` omits every biometry-ACL'd item
+  // (`kSecUseAuthenticationUISkip`) and skips the whole data-protection pass when
+  // the keychain is locked, so a `hold`-policy bundle's value items never appear
+  // and a present secret reads as "not found" (RUSH-2248). A declared key whose
+  // item did not enumerate is therefore absent from `fetched`; read those exact
+  // items directly — a point read DOES evaluate the ACL, so it triggers Touch ID
+  // and returns the value the enumeration could not see. The enumeration still
+  // earns its place (it catches hashed/aliased storage names and stale leftovers
+  // not named in the metadata), so this is a UNION, not a replacement.
+  //
+  // One Touch ID sheet is preserved: the items missing from `fetched` are exactly
+  // the ACL'd ones the enumeration dropped, so the first batch (metadata plus any
+  // no-ACL / `never` items) raised no sheet, and this second batch raises the
+  // single sheet that covers all of them. When the enumeration is healthy every
+  // declared item is already in `fetched`, `missingDeclared` is empty, and this
+  // is skipped entirely — zero behavior change and no extra spawn on the hot path.
+  if (backend === 'keychain') {
+    const missingDeclared: string[] = [];
+    for (const key of keychainKeys) {
+      const p = parsedByKey.get(key)!;
+      if (!('ref' in p) || p.ref.provider !== 'keychain') continue;
+      const item = secretsKeychainItem(bundle.name, p.ref.value);
+      if (fetched.get(item) === undefined && fetched.get(keychainServiceAlias(item)) === undefined) {
+        missingDeclared.push(item);
+      }
+    }
+    if (missingDeclared.length > 0) {
+      const declaredFetched = getKeychainTokens([...new Set(missingDeclared)], {
+        agent: opts.agent || process.env.AGENTS_AGENT_NAME || 'Agents CLI',
+        bundle: name,
+        sessionId: process.env.AGENT_SESSION_ID || process.env.AGENTS_SESSION_ID,
+        reason: opts.caller ? `to ${opts.caller}` : reason,
+        duration: opts.duration || humanUnlockDuration(secretsHoldMs()),
+        // The policy is known now (metadata parsed), so the prompt names the real
+        // duration instead of the pre-read default the first batch had to guess.
+        defaultPolicy: bundlePolicy(bundle),
+        forceDuration: Boolean(opts.duration),
+        silentNoAcl: verifiedNoAclBundle,
+      });
+      for (const [k, v] of declaredFetched) fetched.set(k, v);
+    }
+  }
+
   const emitReadAudit = (status: 'success' | 'error', err?: unknown) => {
     emitSecretAudit({
       event: 'secrets.get',
@@ -1567,40 +1711,10 @@ export function readAndResolveBundleEnv(
   };
 
   try {
-    const env: Record<string, string> = {};
-    const owners = new Map<string, string>();
-    for (const [key] of Object.entries(bundle.vars)) {
-      if (!selectedKeys.has(key)) continue;
-      const p = parsedByKey.get(key)!;
-      if ('literal' in p) {
-        assignResolvedEnvValue(env, bundle, key, p.literal, opts.keyMode, owners);
-        continue;
-      }
-      if (p.ref.provider === 'keychain') {
-        const item = secretsKeychainItem(bundle.name, p.ref.value);
-        // The batch keys results by the names it was ASKED for: the cleartext
-        // metaItem, plus enumerated storage names. Look up the cleartext name
-        // first (Linux / file store), then its hashed storage alias (macOS).
-        const value = fetched.get(item) ?? fetched.get(keychainServiceAlias(item));
-        if (value === undefined) {
-          throw new Error(
-            `Bundle '${bundle.name}' key '${key}': stored item '${item}' not found. ` +
-            `Run: agents secrets add ${bundle.name} ${key}`,
-          );
-        }
-        assignResolvedEnvValue(env, bundle, key, value, opts.keyMode, owners);
-        continue;
-      }
-      try {
-        const value = resolveRef(p.ref, {
-          allowExec: bundle.allow_exec,
-          keychainItemFor: (shortId: string) => secretsKeychainItem(bundle.name, shortId),
-        });
-        assignResolvedEnvValue(env, bundle, key, value, opts.keyMode, owners);
-      } catch (err) {
-        throw new Error(`Bundle '${bundle.name}' key '${key}': ${(err as Error).message}`);
-      }
-    }
+    // Shared per-key resolver: same keychain lookup (cleartext name, then hashed
+    // storage alias) and same missing-item classification as resolveBundleEnv, so
+    // the two paths can never diverge again (RUSH-2252, RUSH-2253).
+    const env = assembleBundleEnv(bundle, selectedKeys, parsedByKey, fetched, opts.keyMode, backend);
     emitReadAudit('success');
     // Auto-cache: this was a real keychain read (the agent fast-path returned
     // earlier on a hit). If the bundle opts into the `daily` policy and the user

--- a/apps/cli/src/lib/secrets/index.ts
+++ b/apps/cli/src/lib/secrets/index.ts
@@ -906,9 +906,23 @@ export function hasKeychainToken(item: string): boolean {
     }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
   }
   const bin = getKeychainHelperPath();
-  return spawnKeychainHelper(bin, ['has', item, os.userInfo().username], {
+  const r = spawnKeychainHelper(bin, ['has', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
+  // The helper exits 0 = present (incl. errSecInteractionNotAllowed — a locked or
+  // biometry-ACL'd item still EXISTS), 1 = genuinely absent. Any other outcome
+  // (bad args, helper failure, spawn error) means the keychain could not be
+  // reached — and a false "absent" silently disarms every destructive-write guard
+  // that calls this (see the docblock), so it MUST fail loud rather than answer
+  // "no" (RUSH-2235). Timeouts already throw inside spawnKeychainHelper.
+  if (r.status === 0) return true;
+  if (r.status === 1) return false;
+  const stderr = r.stderr?.toString().trim();
+  throw new Error(
+    stderr ||
+    `keychain existence check for '${item}' failed (helper exit ${r.status ?? 'null'}` +
+    `${r.error ? `: ${r.error.message}` : ''}) — keychain unreachable, not a proven absence.`,
+  );
 }
 
 /**
@@ -1314,13 +1328,27 @@ export function deleteKeychainToken(item: string): boolean {
   if (isLinux()) return linuxBackend.delete(item);
   if (isWindows()) return windowsBackend.delete(item);
   const bin = getKeychainHelperPath();
-  const deleted = spawnKeychainHelper(bin, ['delete', item, os.userInfo().username], {
+  const r = spawnKeychainHelper(bin, ['delete', item, os.userInfo().username], {
     stdio: ['ignore', 'pipe', 'pipe'],
-  }, KEYCHAIN_SILENT_TIMEOUT_MS).status === 0;
-  // A deleted item must fail its next read as plain "not found", not with a
-  // stale back-off error left over from a pre-delete cancel.
-  if (deleted) clearKeychainReadBackoff(requested);
-  return deleted;
+  }, KEYCHAIN_SILENT_TIMEOUT_MS);
+  // The helper exits 0 = an item was removed from at least one keychain, 1 =
+  // nothing to delete (genuinely absent). Any other outcome means the keychain
+  // could not be reached; like hasKeychainToken this must fail loud rather than
+  // report a false "nothing was there" (RUSH-2235) — a swallowed failure lets a
+  // rename/purge believe it cleared a name it did not.
+  if (r.status === 0) {
+    // A deleted item must fail its next read as plain "not found", not with a
+    // stale back-off error left over from a pre-delete cancel.
+    clearKeychainReadBackoff(requested);
+    return true;
+  }
+  if (r.status === 1) return false;
+  const stderr = r.stderr?.toString().trim();
+  throw new Error(
+    stderr ||
+    `keychain delete for '${item}' failed (helper exit ${r.status ?? 'null'}` +
+    `${r.error ? `: ${r.error.message}` : ''}) — keychain unreachable, deletion unproven.`,
+  );
 }
 
 /**


### PR DESCRIPTION
**Bug fix, secrets bundle reads (TypeScript).** Fixes [RUSH-2252](https://linear.app/getrush/issue/RUSH-2252) + [RUSH-2253](https://linear.app/getrush/issue/RUSH-2253), both children of [RUSH-2248](https://linear.app/getrush/issue/RUSH-2248) (`agents secrets view` reports a key "stored", but `--reveal`/`unlock` says "stored item not found").

## Root cause

`readAndResolveBundleEnv` built its keychain read set from the helper's `list` enumeration. That enumeration is lossy by construction — the macOS helper's data-protection pass omits every biometry-ACL'd item, and skips entirely when the keychain is locked — so a `hold`-policy bundle's value items never show up in the batch, and a present secret reads as "not found" even though `view`'s existence check (`hasKeychainToken`, which does trigger the ACL) says it's there.

## What changed

- **RUSH-2252** (`bundles.ts`): after the enumeration-based batch read, diff it against the bundle's *declared* keys. Anything declared but missing from the batch gets a direct point read (which does evaluate the ACL and prompt Touch ID) — a union, not a replacement, so the enumeration still catches hashed/aliased storage names. Extracted the per-key resolution loop (`assembleBundleEnv`) so `resolveBundleEnv` and `readAndResolveBundleEnv` share one implementation instead of two that can drift.
- **RUSH-2253** (`bundles.ts`, `index.ts`): classify a missing keychain item as present-but-unreadable (locked/biometry-blocked) vs genuinely-absent before choosing the error. Present-but-unreadable now says "unlock it" (never "add the key" — that would overwrite a good secret). `hasKeychainToken` and `deleteKeychainToken` now fail loud on an unreachable keychain instead of silently answering "absent" (RUSH-2235) — a false negative there disarms destructive-write guards.

## Ran it — real output

```
 Test Files  38 passed | 1 skipped (39)
      Tests  593 passed | 14 skipped (607)
```

Full `apps/cli` secrets suite (`bunx vitest run src/lib/secrets/`), including the new `bundles.declared-keys.test.ts` (5/5) and `bundles.unreadable.test.ts` (4/4, pre-existing). `bunx tsc --noEmit` clean.

## Provenance

Implemented by a prior agent session on this ticket that stranded before pushing (committed nothing, left the diff uncommitted in a worktree). Recovered the diff, rebased onto fresh `origin/main` in a new worktree, verified typecheck + full secrets suite pass, then committed/pushed/opened this PR.
