### PR TITLE
test(secrets): close the add-a-word and cross-sentence holes in the docs guard (RUSH-1968)

### DIFF
--- a/apps/cli/docs/secrets.md
+++ b/apps/cli/docs/secrets.md
@@ -282,10 +282,15 @@ A file-backed bundle is encrypted at rest and reads with **no biometry** — the
 choice whenever the remote can't satisfy a Touch ID prompt. By default the remote
 encrypts it under a **machine-local key** it auto-provisions (a 0600 file under
 `~/.agents/.secrets-key/`), so the push needs no passphrase and the remote's reads are
-fully headless. Set `AGENTS_SECRETS_PASSPHRASE` locally only to **opt into** a shared
+fully headless.
+<!-- docs-hygiene:allow-master-key-discussion — `export --host` legitimately forwards the
+     MASTER key to key the remote's own store; this is store provisioning, not transport
+     sync. Reviewed; see src/lib/secrets/docs-hygiene.test.ts. -->
+Set `AGENTS_SECRETS_PASSPHRASE` locally only to **opt into** a shared
 off-disk key: when set it is forwarded over ssh stdin (never argv) and the remote keys
 the bundle under it instead — meaning that same passphrase is then required to read it,
-so only set it when you want that. Alternatively, unlock the remote login keychain
+so only set it when you want that.
+<!-- /docs-hygiene:allow-master-key-discussion --> Alternatively, unlock the remote login keychain
 first (an interactive login / `agents secrets unlock` on the target) and retry the
 keychain push. See [File-backed bundles](#file-backed-bundles-headless--remote) and
 [Recipe 8](#8-headless-release-on-a-remote-mac).
@@ -639,15 +644,12 @@ key — no Touch ID, no GUI. (`codesign` itself still needs the Developer ID ide
 unlocked keychain on the build host — a one-time `security import` of the `.p12`,
 unrelated to `agents secrets`.)
 
-<!-- docs-hygiene:allow-master-key-discussion — a bounded per-command export, sourced
-     and unset around one command. Reviewed; see src/lib/secrets/docs-hygiene.test.ts. -->
-
 **Opt-in shared passphrase.** To key the remote bundle under a shared secret held off
 disk instead of the remote's machine-local key, set `AGENTS_SECRETS_PASSPHRASE` on the
 laptop before the push — it is forwarded over ssh stdin (never argv), and the remote
 then requires that same passphrase to read the bundle. Note the shape below: sourced
-per command from the secrets store and `unset` right after, never parked in a shell rc
-file (see the warning under [File-backed bundles](#file-backed-bundles-headless--remote)).
+per command from the secrets store and `unset` right after, never persisted into your
+environment (see the warning under [File-backed bundles](#file-backed-bundles-headless--remote)).
 
 ```bash
 export AGENTS_SECRETS_PASSPHRASE="$(agents secrets exec release.key -- printenv PASSPHRASE)"
@@ -658,8 +660,6 @@ P="$(agents secrets exec release.key -- printenv PASSPHRASE)"           # one To
 ssh mac-mini 'AGENTS_SECRETS_PASSPHRASE=$(cat) \
   agents secrets exec rush.releases -- ./rush/app/scripts/release.sh 0.10.0 alpha.1 --yes' <<<"$P"
 ```
-
-<!-- /docs-hygiene:allow-master-key-discussion -->
 
 ## Demo
 
@@ -803,16 +803,16 @@ including non-interactive `ssh host 'cmd'`, so the master key lands in the
 environment of essentially everything the box runs. `agents doctor` flags such an
 export as an `rc-secret-export` finding. (Source: `src/lib/secrets/rc-hygiene.ts`.)
 
+<!-- /docs-hygiene:allow-master-key-discussion -->
+
 So: leave the machine-local key in place and set nothing. Reach for
 `AGENTS_SECRETS_PASSPHRASE` only when you have a specific reason to keep the key
-off disk **and** a way to supply it that is not a shell rc file — sourced per
-command from a password manager, or injected by a secret manager into one
-process. If what you actually need is unattended `push`/`pull`, that is
-`AGENTS_SYNC_PASSPHRASE`, a separate transport secret — see
-[Share a bundle with a teammate](#5-share-a-bundle-with-a-teammate). Exporting
-the master key to get headless sync is the exact mistake this split removes.
-
-<!-- /docs-hygiene:allow-master-key-discussion -->
+off disk **and** a way to supply it per command rather than persisting it into
+your environment — sourced from a password manager, or injected by a secret
+manager into one process. If what you actually need is unattended `push`/`pull`,
+that is `AGENTS_SYNC_PASSPHRASE`, a separate transport secret — see
+[Share a bundle with a teammate](#5-share-a-bundle-with-a-teammate). Reaching for
+the master key to get unattended sync is the exact mistake this split removes.
 
 **What the file store protects against.** Encryption-at-rest with the key in a
 0600 file — the same posture as an SSH private key. It defends against on-disk

--- a/apps/cli/src/lib/secrets/docs-hygiene.test.ts
+++ b/apps/cli/src/lib/secrets/docs-hygiene.test.ts
@@ -70,6 +70,29 @@ const RC_FILE = String.raw`~/\.(zshenv|zshrc|bashrc|bash_profile|profile)\b|\bsh
  */
 const FILE_STORE_HEADING = '## Linux: headless servers and the encrypted-file fallback';
 
+/**
+ * Matches of `claim` in `text` that are NOT negated, judged per match rather
+ * than per sentence.
+ *
+ * A whole-sentence exclusion list is defeated by adding a word — the sentence
+ * makes the prohibited claim AND contains "not" somewhere, so it is skipped
+ * entirely. Here the negation must sit in the 30 characters immediately before
+ * the match (or lead it), so appending a disclaimer elsewhere in the sentence
+ * changes nothing.
+ */
+function negatedMatches(text: string, claim: RegExp, negation: RegExp): string[] {
+  const out: string[] = [];
+  const re = new RegExp(claim.source, claim.flags.includes('g') ? claim.flags : `${claim.flags}g`);
+  for (const m of text.matchAll(re)) {
+    const at = m.index ?? 0;
+    const before = text.slice(Math.max(0, at - 30), at);
+    const lead = m[0].slice(0, 30);
+    if (negation.test(before) || negation.test(lead)) continue;
+    out.push(m[0].replace(/\s+/g, ' ').trim());
+  }
+  return out;
+}
+
 function fileStoreSection(): string {
   const text = guarded();
   const start = text.indexOf(FILE_STORE_HEADING);
@@ -79,14 +102,32 @@ function fileStoreSection(): string {
 }
 
 describe('docs/secrets.md hygiene (RUSH-1968)', () => {
-  it('marks its exception regions in matched pairs', () => {
-    // guarded() asserts termination; this pins the count so a stray opener or a
-    // deleted closer is a loud failure rather than a silently widened exception.
+  it('keeps its exceptions few, small, paired, and reviewed', () => {
+    // A marked region is a DELIBERATE override — text inside it is exempt from
+    // every check below. That is the point: the warning has to name the export
+    // it forbids, and `export --host` legitimately forwards the master key to
+    // key a remote's own store. It is also the design's soft spot, so regions
+    // are pinned three ways — how many, properly paired, and how big. Widening
+    // one, or adding a third, fails here and forces the change through review.
     const text = doc();
     const opens = text.split(ALLOW_OPEN).length - 1;
     const closes = text.split(ALLOW_CLOSE).length - 1;
     expect(opens).toBe(closes);
     expect(opens).toBe(2);
+
+    // Each region: big enough for its paragraph, far too small to hide a
+    // section in. Measured on what guarded() actually strips.
+    let i = 0;
+    const sizes: number[] = [];
+    for (;;) {
+      const open = text.indexOf(ALLOW_OPEN, i);
+      if (open === -1) break;
+      const close = text.indexOf(ALLOW_CLOSE, open);
+      sizes.push(close - open);
+      i = close + ALLOW_CLOSE.length;
+    }
+    for (const size of sizes) expect(size).toBeLessThan(1200);
+    expect(sizes.reduce((a, b) => a + b, 0)).toBeLessThan(2000);
   });
 
   it('never mentions a shell rc file outside a marked region', () => {
@@ -108,16 +149,18 @@ describe('docs/secrets.md hygiene (RUSH-1968)', () => {
   it('never equates the 0600 key file with an environment or rc export', () => {
     // The inverted claim is what made the export look sanctioned. Checked over
     // the guarded text, so the warning's own "is **not** equivalent" sentence
-    // (inside a marked region) cannot be mistaken for the claim it refutes —
+    // (inside the marked region) cannot be mistaken for the claim it refutes —
     // and no sentence can buy immunity by containing the word "not".
+    //
+    // Matched over the raw text, NOT sentence by sentence: the claim splits
+    // across a period trivially ("The key file is equivalent. It is just a shell
+    // rc export."), which a per-sentence scan misses.
     const equivalence = new RegExp(
-      String.raw`\b(identical|equivalent|the same as|no different|no safer|as safe as)\b[^.]{0,140}` +
-      String.raw`(export|rc file|shell rc|~/\.zsh|environment variable|env var)`,
-      'i',
+      String.raw`\b(identical|equivalent|the same as|no different|no safer|as safe as)\b[\s\S]{0,160}?` +
+      String.raw`(\bexport\b|\brc file\b|\bshell rc\b|~/\.zsh|\benvironment variable\b|\benv var\b)`,
+      'gi',
     );
-    const offenders = guarded()
-      .split(/(?<=[.!?])\s+|\n{2,}/)
-      .filter((s) => equivalence.test(s));
+    const offenders = guarded().match(equivalence) ?? [];
     expect(offenders).toEqual([]);
   });
 
@@ -154,13 +197,13 @@ describe('docs/secrets.md hygiene (RUSH-1968)', () => {
     const promptClaim = new RegExp(
       String.raw`\b(prompts?|asks?|asked|requests?|requested|prompted)\b[^.]{0,90}\bpassphrase\b` +
       String.raw`|\bpassphrase\b[^.]{0,60}\b(prompt|is requested|is asked)\b`,
-      'i',
+      'gi',
     );
-    const offenders = section
-      .split(/(?<=[.!?])\s+|\n{2,}/)
-      .filter((s) => promptClaim.test(s))
-      // The section must be able to state that it does NOT prompt.
-      .filter((s) => !/\bnever prompts\b|\bno prompt\b|\bdoes not prompt\b|without being prompted/i.test(s));
+    // Negation is checked PER MATCH, adjacent to the verb — not per sentence.
+    // A sentence-level exclusion list is defeated by appending a word: "the
+    // command asks for a passphrase (no prompt is needed elsewhere)" would clear
+    // a whole-sentence filter while still making the false claim.
+    const offenders = negatedMatches(section, promptClaim, /\b(never|not|no|without|neither)\b/i);
     expect(offenders).toEqual([]);
     expect(doc()).toMatch(/\*\*never prompts\*\*/i);
   });
@@ -169,16 +212,24 @@ describe('docs/secrets.md hygiene (RUSH-1968)', () => {
     const text = doc();
     expect(text).toContain('AGENTS_SYNC_PASSPHRASE');
 
-    // No passage outside a marked region may tell a headless/CI reader to set
+    // No passage outside the marked region may tell a headless/CI reader to set
     // the MASTER key so that push/pull works. That instruction is RUSH-1968.
-    const offenders = guarded()
-      .split(/(?<=[.!?])\s+|\n{2,}/)
-      .filter((s) => s.includes('AGENTS_SECRETS_PASSPHRASE'))
-      .filter((s) => /\b(headless|CI|unattended|no TTY|worker box)\b/i.test(s))
-      .filter((s) => /\b(push|pull|sync)\b/i.test(s))
-      // Descriptive mentions stating the variable is OPTIONAL are the opposite
-      // of the failure mode; only an instruction to set it counts.
-      .filter((s) => !/no passphrase|only if set|opt(-| )in|if it sets one/i.test(s));
+    //
+    // Judged per match on the imperative itself — "set AGENTS_SECRETS_PASSPHRASE"
+    // in a headless/sync context — with the negation adjacent, so appending
+    // "this is opt-in" cannot excuse it the way a sentence-level filter allowed.
+    const instruction = /\b(set|export|define|configure)\s+`?AGENTS_SECRETS_PASSPHRASE/gi;
+    const offenders = negatedMatches(guarded(), instruction, /\b(never|not|no|without|instead of|rather than)\b/i)
+      .filter((_m, i) => {
+        // Only flag when the surrounding passage is about headless/unattended sync.
+        const at = [...guarded().matchAll(instruction)][i]?.index ?? 0;
+        const around = guarded().slice(Math.max(0, at - 300), at + 300);
+        // No "but it's optional" exclusion here: that is the add-a-word hole
+        // again — appending "this is opt-in" would excuse the instruction. The
+        // imperative + a headless-sync context is the whole test.
+        return /\b(headless|CI|unattended|no TTY|worker box)\b/i.test(around)
+          && /\b(push|pull|sync)\b/i.test(around);
+      });
     expect(offenders).toEqual([]);
   });
 });


### PR DESCRIPTION
**test-only + docs wording.** No behavior change. Follow-up to #2149, which you merged at `2588ff3d` before this landed — a third non-author review pass on that diff found three false negatives still in the `docs-hygiene` guard.

Ticket: RUSH-1968.

## What the review found

| Hole | Bypass that worked | Fix |
|---|---|---|
| Negation judged per **sentence** | `the command asks you for a passphrase; no prompt is needed elsewhere` — appending a clause bought immunity for the whole sentence | `negatedMatches()` judges per **match**, requiring the negation in the 30 chars immediately before the verb |
| Same, on the headless-sync check | `set AGENTS_SECRETS_PASSPHRASE so push and pull work; this is opt-in` | the "but it's optional" escape is removed outright |
| Equivalence check ran per sentence | `The key file is equivalent. It is just a shell rc export.` — split across a period | matches over the raw guarded text with a 160-char window |

This was the third time the same class of flaw appeared: an exclusion list that a future author defeats by *adding* a word rather than removing one. Both remaining sentence-level filters are gone.

## Marked regions are smaller

`#2149` exempted more text than needed. Two passages are reworded so they need no exception at all (`never parked in a shell rc file` → `never persisted into your environment`), which deletes the release-example region entirely and ends the warning region at the warning.

One region is **added**, deliberately: the `secrets export --host` paragraph, where forwarding the master key is correct behavior — it provisions the *remote's own store*, not transport sync. Marking it beats bending a regex to special-case it.

Region count, pairing, per-region size, and total size are now all pinned, so widening one or adding a third fails the test rather than silently enlarging the exemption.

## Run output

All twelve bypasses named across the three review passes, replayed against this branch on top of current `main`:

```
AGENTS_SECRETS_PASSPHRASE controls the store key. Persist it in the login prof -> Tests  1 failed
Export AGENTS_SECRETS_PASSPHRASE in ~/.zshenv; it is not necessary to configur -> Tests  1 failed
The key file is equivalent to a shell rc export and is not dangerous.          -> Tests  2 failed
The key file is equivalent. It is just a shell rc export.                      -> Tests  2 failed
Write the key to the old ~/.agents/.cache/secrets/.passphrase path.            -> Tests  1 failed
Interactive sessions are asked for the passphrase.                             -> Tests  1 failed
The command asks you for a passphrase; no prompt is needed elsewhere.          -> Tests  1 failed
On a headless CI box, set AGENTS_SECRETS_PASSPHRASE so push and pull work.     -> Tests  1 failed
On a headless CI box, set AGENTS_SECRETS_PASSPHRASE so push and pull work; thi -> Tests  1 failed
export AGENTS_SECRETS_PASSPHRASE in ~/.zshenv to make this work.               -> Tests  1 failed
Recommended for shared/CI machines.                                            -> Tests  1 failed
For unattended sync, export AGENTS_SECRETS_PASSPHRASE; only if set will pull s -> Tests  1 failed
UNCAUGHT=0
      Tests  7 passed (7)
```

`UNCAUGHT=0`, and the real doc still passes all seven checks. No screenshot: this is a test + doc-wording change with no user-visible surface.
