### PR TITLE
fix(menubar): consolidate polling and watchdog execution (RUSH-2260)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ agents watchdog --nudge    # actually inject "Continue." into the stalled split
 agents watchdog --watch    # daemon loop: a tick every --interval
 ```
 
-`agents watchdog` detects a stalled session, resolves the *exact* terminal split it lives in (tmux, iTerm, VSCodium, or a raw pty), and injects a nudge -- `Continue.` by default, or set `--text`. It's dry by default; `--nudge` acts on a single tick, and `agents watchdog on|off` enables or disables the built-in routine on this device. `agents setup watchdog` chooses devices. Steer a single run with `agents watchdog policy <id> off | keep | handsoff`.
+`agents watchdog` detects a stalled session, resolves the *exact* terminal split it lives in (tmux, iTerm, VSCodium, or a raw pty), and injects a nudge -- `Continue.` by default, or set `--text`. It's dry by default; `--nudge` acts on a single tick. `agents watchdog on|off` controls the device-local daemon pass, which runs once every three minutes. Steer a single run with `agents watchdog policy <id> off | keep | handsoff`.
 
 A stalled session whose tail shows a hard account limit ("You've hit your weekly limit · resets …") is **rotated in place** instead of nudged: the watchdog gates on the same healthy-account selection `agents run auto` makes (zero healthy → one skip event per cooldown window, terminal untouched), injects the harness's exit sequence, relaunches `agents run auto --interactive --session-id <uuid>` in the *same* tab, then replays the old session's resume once the new TUI is live. Default on; `agents watchdog rotate off` disables it (nudging stays on).
 

--- a/apps/cli/.changelog/next/RUSH-2260-menubar-polling.md
+++ b/apps/cli/.changelog/next/RUSH-2260-menubar-polling.md
@@ -1,0 +1,10 @@
+- **Use one three-minute AGI Menu snapshot and one watchdog executor (RUSH-2260).**
+  The menu bar now reads routines, 40 indexed recent sessions, the daemon-warmed
+  active-session cache, and persisted watchdog state in one subprocess every three
+  minutes; `doctor --json` remains independently limited to 15 minutes. The menu no
+  longer executes watchdog ticks. The daemon is the sole automatic watchdog executor,
+  warms active sessions on the same three-minute cadence, is gated by device-local
+  `watchdog.enabled`, and cleans failed/timeout routine process groups that are still
+  alive before they can overlap a replacement run. Source:
+  `apps/cli/src/lib/menubar/snapshot.ts`, `apps/cli/src/lib/daemon.ts`,
+  `apps/cli/src/lib/routine-process-cleanup.ts`.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.22.23
 
+- **One three-minute AGI Menu snapshot and one watchdog executor (RUSH-2260).**
+  The menu bar now reads routines, 40 indexed recent sessions, the daemon-warmed
+  active-session cache, and persisted watchdog state in one subprocess every three
+  minutes; `doctor --json` remains independently limited to 15 minutes. The menu no
+  longer executes watchdog ticks. The daemon is the sole automatic watchdog executor,
+  gated by device-local `watchdog.enabled`, and cleans failed/timeout routine process
+  groups that are still alive before they can overlap a replacement run.
+
 - **Daemon-warmed cross-surface session-status cache (RUSH-2062).** Menubar,
   Factory, watchdog, and CLI used to each re-run a full `sessions --active`
   gather (~9s / ~170MB) with no sharing. The daemon now warms a local active-

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## 1.22.23
 
-- **One three-minute AGI Menu snapshot and one watchdog executor (RUSH-2260).**
-  The menu bar now reads routines, 40 indexed recent sessions, the daemon-warmed
-  active-session cache, and persisted watchdog state in one subprocess every three
-  minutes; `doctor --json` remains independently limited to 15 minutes. The menu no
-  longer executes watchdog ticks. The daemon is the sole automatic watchdog executor,
-  warms active sessions on the same three-minute cadence, is gated by device-local
-  `watchdog.enabled`, and cleans failed/timeout routine process
-  groups that are still alive before they can overlap a replacement run.
-
 - **Daemon-warmed cross-surface session-status cache (RUSH-2062).** Menubar,
   Factory, watchdog, and CLI used to each re-run a full `sessions --active`
   gather (~9s / ~170MB) with no sharing. The daemon now warms a local active-

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -7,7 +7,8 @@
   active-session cache, and persisted watchdog state in one subprocess every three
   minutes; `doctor --json` remains independently limited to 15 minutes. The menu no
   longer executes watchdog ticks. The daemon is the sole automatic watchdog executor,
-  gated by device-local `watchdog.enabled`, and cleans failed/timeout routine process
+  warms active sessions on the same three-minute cadence, is gated by device-local
+  `watchdog.enabled`, and cleans failed/timeout routine process
   groups that are still alive before they can overlap a replacement run.
 
 - **Daemon-warmed cross-surface session-status cache (RUSH-2062).** Menubar,

--- a/apps/cli/docs/README.md
+++ b/apps/cli/docs/README.md
@@ -55,7 +55,7 @@ How agents-cli is laid out on disk and how it decides what to load.
 | [Routines](03-routines.md) | Cron-scheduled and signed-webhook-triggered agent runs with sandboxed permissions and a long-running daemon. |
 | [Monitors](10-monitors.md) | Durable event-triggered watchers: watch a source, detect a change, fire an action. A routine whose trigger is a watched source instead of a clock. |
 | [Projects](11-projects.md) | Named multi-repo projects layered over the `--project` convention, plus the progress rollup — one card per project instead of a per-agent activity line. Beta. |
-| [Watchdog](watchdog.md) | Detect **idle** agents across the fleet and steer them to completion — a daemon-fired routine that analyzes a stalled session's goal and nudges it with the concrete next step (idle is its job; `waiting` belongs to the feed). |
+| [Watchdog](watchdog.md) | Detect **idle** agents across the fleet and steer them to completion — one device-local daemon pass every three minutes analyzes stalled sessions and nudges them with the concrete next step (idle is its job; `waiting` belongs to the feed). |
 
 ## Extensibility
 

--- a/apps/cli/docs/menubar.md
+++ b/apps/cli/docs/menubar.md
@@ -8,10 +8,10 @@ The menu bar helper (`MenubarHelper.app`) is a no-Dock, `.accessory` status-bar
 app. Its icon — the agents-cli `a` mark — sits in the menu bar and answers, at a
 glance, "what are my agents doing right now, and does anything need me?"
 
-It reads state **directly from disk** and never invokes the `agents` CLI to
-populate the menu, so opening it costs a few file reads and never triggers the
-sessions transcript re-index. It shells the CLI only for *actions* (starting a
-session, running a routine).
+It keeps menu state warm with one read-only `agents menubar snapshot --json`
+subprocess every three minutes. That command reads indexed/cache state and never
+re-indexes transcripts. Opening the menu uses the warm result; CLI actions remain
+explicit controls (starting a session, running a routine).
 
 macOS only. It is auto-enabled for every user (see [Lifecycle](#lifecycle)); opt
 out with `agents menubar disable`.
@@ -313,12 +313,14 @@ the helper can no longer become the second, and `status` now lists every copy.
 
 ## Data sources
 
-The helper assembles the menu by reading these directly — no CLI, no re-index:
+The helper assembles the menu from these cached/indexed sources through one snapshot
+command every three minutes; the 10-second badge/liveness checks stay local:
 
 | Source | Path | Gives |
 |---|---|---|
 | Terminals | `~/.agents/.cache/terminals/live-terminals.json` | extension-registered terminals (agent, cwd, pid, label) — cold start + 10s badge poll |
-| Active sessions | `agents sessions --active --local --json` (warm cache, 30s TTL) | every local session (tmux / IDE / headless) with running-vs-idle — feeds triage + ACTIVE once loaded |
+| Menu snapshot | `agents menubar snapshot --json` every three minutes | routines, 40 indexed recent sessions, daemon-warmed local active sessions, and persisted watchdog status in one subprocess |
+| Doctor | `agents doctor --json` every 15 minutes | install and configuration health; kept separate because it is substantially heavier |
 | Teams | `~/.agents/.history/teams/agents/<id>/meta.json` | running teammate agents |
 | Cloud | `~/.agents/.cache/cloud/tasks.db` (SQLite) | cloud tasks, incl. `input_required` or `needs_review` → "awaiting input" |
 | Attention sentinels | `~/.agents/.cache/state/attention/<sessionId>` | terminal sessions awaiting input — mtime = wait start, content = the awaiting message (written by the Notification hook). On read, sentinels whose sessionId is not in the current live-terminals set are unlinked as orphans (defense against sessions killed hard, hookless Claude versions, or sessionId mismatches). |

--- a/apps/cli/docs/specifications.md
+++ b/apps/cli/docs/specifications.md
@@ -986,7 +986,7 @@ access control (that is 1Password/Vault; this tool is device-local first).
   auto-share read therefore resolve `agentOnly: true` unconditionally
   (`commands/exec.ts` secrets injection; `lib/share/config.ts` `shareRuntimeEnv`),
   NOT gated on `isHeadlessSecretsContext()`. Gating the launch read on tty let a
-  watchdog's `agents run auto --interactive` (routine + menu-bar tick, ~2 min)
+  watchdog's `agents run auto --interactive` (daemon-owned pass)
   prompt for a `hold` bundle and pile up helper sheets. **Given** an interactive
   `agents run --secrets <hold-bundle>` whose bundle is not broker-held **When** it
   launches **Then** it fails fast naming `agents secrets unlock <bundle>`, no sheet.
@@ -2105,8 +2105,8 @@ nothing but its own view cache.
 - **SING-1 (MUST).** Every fleet-affecting capability MUST have exactly one scheduler
   and one executor: the agents-cli daemon (`agents __daemon-run`,
   `apps/cli/src/lib/daemon.ts`) or a CLI command the daemon or the user drives.
-  Status: **Current** for routines (`lib/scheduler.ts`), the watchdog
-  (the system `routines/watchdog.yml` definition, WD-1), and rotate (`lib/watchdog/rotate.ts`).
+  Status: **Current** for routines (`lib/scheduler.ts`), the daemon-native watchdog
+  (`lib/daemon.ts`, WD-1), and rotate (`lib/watchdog/rotate.ts`).
 - **SING-2 (MUST NOT).** A UI surface (apps/factory, the menubar app, the iOS app)
   MUST NOT own a timer, watcher, or loop that detects a condition and performs a
   fleet-affecting action. Detection and decision MUST live in the CLI, which holds
@@ -2219,7 +2219,7 @@ is not two daemons existing — it is two daemons consuming the **same** input.
 
 ## Watchdog
 
-The normative contract for `agents watchdog` — the routine that detects **idle** agents
+The normative contract for `agents watchdog` — the daemon-owned service that detects **idle** agents
 and steers them to completion. The how-it-works companion is [watchdog.md](watchdog.md).
 Requirement keywords **MUST / MUST NOT / SHOULD / MAY** are per RFC 2119; scenarios are
 Given/When/Then so they map 1:1 to tests.
@@ -2236,14 +2236,13 @@ not the watchdog's.
 
 #### 2.1 Trigger & lifecycle
 
-- **WD-1 (MUST).** The always-on watchdog MUST be a daemon-fired cron routine, not a
-  bespoke loop — the routine command is `agents watchdog --nudge` on
-  schedule in the system `routines/watchdog.yml`. Each fire MUST run exactly one
-  bounded tick.
+- **WD-1 (MUST).** The agents daemon MUST be the sole automatic watchdog scheduler and
+  executor. When device-local `watchdog.enabled` is true it MUST run one bounded,
+  non-overlapping pass every three minutes. UI surfaces MUST only render persisted state.
 - **WD-2 (MUST).** Delivery MUST occur only when `--nudge` is set; without it a tick is a
   dry run that reports "would nudge" and delivers nothing (`lib/watchdog/runner.ts`).
-- **WD-3 (MUST).** `enable`/`disable` MUST be backed by the routine store (create/pause the
-  job), and `status` MUST reflect the routine's real state (`commands/watchdog.ts`).
+- **WD-3 (MUST).** `on`/`off` MUST write the typed device-local `watchdog.enabled`
+  setting, and `status` MUST reflect that setting (`commands/watchdog.ts`).
 
 #### 2.2 Detection — idle is the target
 

--- a/apps/cli/docs/watchdog.md
+++ b/apps/cli/docs/watchdog.md
@@ -24,9 +24,9 @@ watchdog's #1 dependency: it must reliably tell `idle` (its job) from `waiting_i
 
 ## The loop
 
-The watchdog is a **daemon-fired routine**, not a live process: the scheduler runs
-`agents watchdog --nudge` on the cron cadence declared by the system
-`routines/watchdog.yml`. Each fire is one bounded tick:
+The watchdog is owned by the agents daemon, not a UI poller or cron routine. When
+`watchdog.enabled` is true in this device's config, the daemon runs one bounded pass
+every three minutes. `agents watchdog --nudge` remains the explicit one-shot command:
 
 1. **Detect idle.** Enumerate active sessions, classify each by transcript freshness and
    inferred activity (`lib/watchdog/read.ts`, `lib/session/state.ts`). A candidate is a
@@ -137,11 +137,10 @@ rotate state.
 
 The watchdog reads the **whole fleet** (`agents sessions --active --json` fans out to every
 device, status computed on each origin host) but delivers **locally** on each session's
-origin box, where injection is reliable. Its definition ships at
-`~/.agents/.system/routines/watchdog.yml`; activation lives in each selected host's
-`~/.agents/devices/<hostname>/agents.yaml`. Run `agents setup watchdog` to choose hosts,
-or `agents watchdog on|off` on one host — see
-[routines.md](03-routines.md) and [fleet.md](fleet.md).
+origin box, where injection is reliable. Enable it per host with
+`agents watchdog on|off`; this writes the device-local `watchdog.enabled` setting under
+`~/.agents/devices/<hostname>/agents.yaml`. The menu bar only renders the daemon's
+persisted result and never executes a pass.
 
 ## Per-session policy
 
@@ -152,7 +151,7 @@ or `agents watchdog on|off` on one host — see
 
 | File | Role |
 |---|---|
-| `~/.agents/.system/routines/watchdog.yml` | Built-in cron definition (`agents watchdog --nudge`). |
+| `lib/daemon.ts` | Sole automatic scheduler: one non-overlapping pass every three minutes. |
 | `lib/watchdog/runner.ts` | One tick: enumerate → classify → decide (deterministic + smart) → deliver → log. |
 | `lib/watchdog/watchdog.ts` | `WATCHDOG_SYSTEM_PROMPT`, playbook composition, prompt render, response parse. |
 | `lib/watchdog/read.ts` | Locate a transcript and read its tail; stall thresholds. |

--- a/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/AgentsCLI.swift
@@ -72,18 +72,9 @@ enum AgentsCLI {
         return (try? JSONDecoder().decode([Routine].self, from: data)) ?? []
     }
 
-    static func recentSessions(limit: Int = 3) -> [RecentSession] {
-        guard let data = capture(argv(["sessions", "--all", "--limit", "\(limit)", "--json"])) else { return [] }
-        return (try? JSONDecoder().decode([RecentSession].self, from: data)) ?? []
-    }
-
-    // The session engine's live view — every local session (tmux, IDE, headless),
-    // not just extension-registered terminals. Costs seconds (transcript tails
-    // across version homes), so it is ONLY called from the warm-cache refreshers,
-    // never on the menu-open click path.
-    static func activeSessions() -> [ActiveSession] {
-        guard let data = capture(argv(["sessions", "--active", "--local", "--json"])) else { return [] }
-        return (try? JSONDecoder().decode([ActiveSession].self, from: data)) ?? []
+    static func menubarSnapshot() -> MenubarSnapshot? {
+        guard let data = capture(argv(["menubar", "snapshot", "--json"])) else { return nil }
+        return try? JSONDecoder().decode(MenubarSnapshot.self, from: data)
     }
 
     // The heaviest call the helper makes: `doctor --json` probes every installed
@@ -93,25 +84,6 @@ enum AgentsCLI {
     static func doctorOverview() -> DoctorOverview? {
         guard let data = capture(argv(["doctor", "--json"]), timeout: ChildProcess.doctorTimeout) else { return nil }
         return try? JSONDecoder().decode(DoctorOverview.self, from: data)
-    }
-
-    // RUSH-1415: is global auto-nudge on? The Swift menu-bar toggle drives this
-    // sentinel via watchdogSetEnabled; the tick reads it back to decide whether
-    // to inject or stay detect-only.
-    static func watchdogStatus() -> WatchdogStatus? {
-        guard let data = capture(argv(["watchdog", "status", "--json"])) else { return nil }
-        return try? JSONDecoder().decode(WatchdogStatus.self, from: data)
-    }
-
-    // RUSH-1415: run one watchdog tick. `nudge` actually injects "Continue." into
-    // stalled+addressable splits; without it the tick is detect-only (for the
-    // badge). The CLI's own cooldown ledger prevents re-nudging the same split, so
-    // this is safe to call on every 10s menu-bar poll.
-    static func watchdogTick(nudge: Bool) -> WatchdogTick? {
-        var a = ["watchdog", "--json"]
-        if nudge { a.append("--nudge") }
-        guard let data = capture(argv(a)) else { return nil }
-        return try? JSONDecoder().decode(WatchdogTick.self, from: data)
     }
 
     static func watchdogSetEnabled(_ on: Bool) {

--- a/apps/cli/menubar/Sources/MenubarHelper/Models.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/Models.swift
@@ -117,10 +117,20 @@ struct WatchdogCounts: Decodable {
     let skipped: Int
 }
 
-// `agents watchdog status --json` — is global auto-nudge on?
-struct WatchdogStatus: Decodable {
+// `agents menubar snapshot --json` — the single repeating CLI read owned by
+// AGI Menu. Doctor remains a separate 15-minute diagnostic refresh.
+struct MenubarSnapshot: Decodable {
+    let version: Int
+    let capturedAt: String
+    let routines: [Routine]
+    let recentSessions: [RecentSession]
+    let activeSessions: [ActiveSession]
+    let watchdog: MenubarWatchdogSnapshot
+}
+
+struct MenubarWatchdogSnapshot: Decodable {
     let enabled: Bool
-    let stateDir: String?
+    let lastTick: WatchdogTick?
 }
 
 struct DoctorOrphan: Decodable {

--- a/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
+++ b/apps/cli/menubar/Sources/MenubarHelper/StatusItemController.swift
@@ -106,13 +106,9 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // off the click path and rendered from warm caches when the menu opens.
     private var cachedRoutines: [Routine] = []
     private var routinesLoaded = false
-    private var routinesInFlight = false
-    private var routinesFetchedAt: Date?
 
     private var cachedRecentSessions: [RecentSession] = []
     private var recentSessionsLoaded = false
-    private var recentSessionsInFlight = false
-    private var recentSessionsFetchedAt: Date?
 
     // The engine's active-session list (`sessions --active --local --json`) —
     // authoritative coverage (tmux/IDE/headless), but costs seconds, so it rides
@@ -121,20 +117,19 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     // fills in.
     private var cachedActiveSessions: [ActiveSession] = []
     private var activeSessionsLoaded = false
-    private var activeSessionsInFlight = false
-    private var activeSessionsFetchedAt: Date?
 
     private var cachedDoctorOverview: DoctorOverview?
     private var doctorLoaded = false
     private var doctorInFlight = false
     private var doctorFetchedAt: Date?
 
-    // RUSH-1415: watchdog auto-nudge. Each tick runs `agents watchdog`; when the
-    // toggle (watchdogEnabled) is on it injects "Continue." into stalled splits.
+    // Watchdog state is read from the consolidated snapshot. The daemon is the
+    // sole repeating executor; this helper only toggles device-local enablement.
     private var cachedWatchdog: WatchdogTick?
     private var watchdogEnabled = false
-    private var watchdogInFlight = false
-    private var watchdogFetchedAt: Date?
+    private var snapshotInFlight = false
+    private var snapshotFetchedAt: Date?
+    private static let snapshotRefreshInterval: TimeInterval = 3 * 60
 
     // Density: rich rows carry the session title / question / routine schedule
     // inline; compact folds them to one-liners. `auto` (the default) is rich
@@ -248,11 +243,8 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             }
         }
         checkDaemonLiveness()
-        refreshRoutines()
-        refreshRecentSessions()
-        refreshActiveSessions()
+        refreshSnapshot()
         refreshDoctorOverview()
-        refreshWatchdog()
     }
 
     /// Poll the scheduler's liveness on every tick — the one check that must
@@ -292,18 +284,10 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
 
     private func loadDumpCaches() {
-        cachedRoutines = AgentsCLI.routines()
-        routinesLoaded = true
-        routinesFetchedAt = Date()
-
-        cachedRecentSessions = AgentsCLI.recentSessions(limit: 40)
-        recentSessionsLoaded = true
-        recentSessionsFetchedAt = Date()
-        promptController.updateRecentSessions(cachedRecentSessions)
-
-        cachedActiveSessions = AgentsCLI.activeSessions()
-        activeSessionsLoaded = true
-        activeSessionsFetchedAt = Date()
+        if let snapshot = AgentsCLI.menubarSnapshot() {
+            applySnapshot(snapshot)
+            snapshotFetchedAt = Date()
+        }
 
         cachedDoctorOverview = AgentsCLI.doctorOverview()
         doctorLoaded = true
@@ -311,51 +295,31 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     }
 
     // MARK: Cached CLI refreshes
-    private func refreshRoutines() {
-        if routinesInFlight { return }
-        if let t = routinesFetchedAt, Date().timeIntervalSince(t) < 20 { return }
-        routinesInFlight = true
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            let r = AgentsCLI.routines()
-            DispatchQueue.main.async {
-                guard let self else { return }
-                self.cachedRoutines = r
-                self.routinesLoaded = true
-                self.routinesFetchedAt = Date()
-                self.routinesInFlight = false
-            }
-        }
+    private func applySnapshot(_ snapshot: MenubarSnapshot) {
+        cachedRoutines = snapshot.routines
+        routinesLoaded = true
+        cachedRecentSessions = snapshot.recentSessions
+        recentSessionsLoaded = true
+        promptController.updateRecentSessions(snapshot.recentSessions)
+        cachedActiveSessions = snapshot.activeSessions
+        activeSessionsLoaded = true
+        watchdogEnabled = snapshot.watchdog.enabled
+        cachedWatchdog = snapshot.watchdog.lastTick
     }
 
-    private func refreshRecentSessions() {
-        if recentSessionsInFlight { return }
-        if let t = recentSessionsFetchedAt, Date().timeIntervalSince(t) < 45 { return }
-        recentSessionsInFlight = true
+    private func refreshSnapshot() {
+        if snapshotInFlight { return }
+        if let t = snapshotFetchedAt, Date().timeIntervalSince(t) < Self.snapshotRefreshInterval { return }
+        snapshotInFlight = true
         DispatchQueue.global(qos: .utility).async { [weak self] in
-            let s = AgentsCLI.recentSessions(limit: 40)
+            let snapshot = AgentsCLI.menubarSnapshot()
             DispatchQueue.main.async {
                 guard let self else { return }
-                self.cachedRecentSessions = s
-                self.recentSessionsLoaded = true
-                self.recentSessionsFetchedAt = Date()
-                self.recentSessionsInFlight = false
-                self.promptController.updateRecentSessions(s)
-            }
-        }
-    }
-
-    private func refreshActiveSessions() {
-        if activeSessionsInFlight { return }
-        if let t = activeSessionsFetchedAt, Date().timeIntervalSince(t) < 30 { return }
-        activeSessionsInFlight = true
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            let a = AgentsCLI.activeSessions()
-            DispatchQueue.main.async {
-                guard let self else { return }
-                self.cachedActiveSessions = a
-                self.activeSessionsLoaded = true
-                self.activeSessionsFetchedAt = Date()
-                self.activeSessionsInFlight = false
+                if let snapshot {
+                    self.applySnapshot(snapshot)
+                    self.snapshotFetchedAt = Date()
+                }
+                self.snapshotInFlight = false
             }
         }
     }
@@ -387,30 +351,6 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 self.doctorLoaded = true
                 self.doctorFetchedAt = Date()
                 self.doctorInFlight = false
-            }
-        }
-    }
-
-    // RUSH-1415: run one watchdog tick each poll. Reads the enable sentinel first,
-    // then ticks with nudge=enabled so auto-nudge fires only when the toggle is on
-    // (detect-only otherwise). No time-throttle: nudging must be timely, and the
-    // CLI's cooldown ledger already prevents re-nudging the same split.
-    private func refreshWatchdog() {
-        if watchdogInFlight { return }
-        // Throttle like the sibling refreshers: a 30s floor keeps this well under
-        // the 5m stall threshold (still timely) while cutting the two subprocess
-        // spawns per tick from 6x/min to ~2x/min on a battery-sensitive helper.
-        if let t = watchdogFetchedAt, Date().timeIntervalSince(t) < 30 { return }
-        watchdogInFlight = true
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            let enabled = AgentsCLI.watchdogStatus()?.enabled ?? false
-            let tick = AgentsCLI.watchdogTick(nudge: enabled)
-            DispatchQueue.main.async {
-                guard let self else { return }
-                self.watchdogEnabled = enabled
-                self.cachedWatchdog = tick
-                self.watchdogFetchedAt = Date()
-                self.watchdogInFlight = false
             }
         }
     }
@@ -464,11 +404,8 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                 recentSessions: cachedRecentSessions, routines: cachedRoutines,
                 doctor: cachedDoctorOverview, daemonPid: daemonPid, pending: pending, loaded: loaded)
         refreshBadge()
-        refreshRoutines()
-        refreshRecentSessions()
-        refreshActiveSessions()
+        refreshSnapshot()
         refreshDoctorOverview()
-        refreshWatchdog()
     }
 
     // The one rule: attention floats to the top triage strip (wait-time sorted,

--- a/apps/cli/src/commands/menubar.ts
+++ b/apps/cli/src/commands/menubar.ts
@@ -142,6 +142,15 @@ export function registerMenubarCommands(program: Command): void {
   });
 
   menubar
+    .command('snapshot', { hidden: true })
+    .description('Emit the consolidated AGI Menu polling snapshot.')
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async () => {
+      const { computeMenubarSnapshot } = await import('../lib/menubar/snapshot.js');
+      process.stdout.write(`${JSON.stringify(await computeMenubarSnapshot())}\n`);
+    });
+
+  menubar
     .command('enable')
     .description('Install and start AGI Menu (launches at login)')
     .action(() => {

--- a/apps/cli/src/commands/routines.ts
+++ b/apps/cli/src/commands/routines.ts
@@ -497,6 +497,67 @@ export function buildRunsJson(runs: RunMeta[]): Record<string, unknown>[] {
   return runs.map(runMetaJson);
 }
 
+/** Build the exact structured routine rows shared by `routines list --json`
+ * and the one-process AGI Menu snapshot. */
+export function buildRoutineListJson(): Record<string, unknown>[] {
+  try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
+  const jobs = listAllJobs(process.cwd());
+  if (jobs.length === 0) return [];
+
+  const scheduler = new JobScheduler(async () => {});
+  scheduler.loadAll();
+  try {
+    const overdueSet = new Set<string>();
+    try {
+      for (const job of detectOverdueJobs()) overdueSet.add(job.name);
+    } catch {
+      // Best-effort indicator; never block the list on detection errors.
+    }
+    const now = new Date();
+    const knownProjectNames = new Set(listProjectDefs().map((project) => project.name));
+    return jobs.map((job) => {
+      const latestRun = localLatestRun(job);
+      const enabledDevices = devicesWithRoutineEnabled(job.name);
+      return {
+        name: job.name,
+        agent: job.agent ?? null,
+        workflow: job.workflow ?? null,
+        command: job.command ?? null,
+        repo: job.repo ?? null,
+        schedule: job.schedule ?? null,
+        scheduleHuman: fireConditionLabel(job),
+        trigger: job.trigger ?? null,
+        timezone: job.timezone ?? null,
+        devices: enabledDevices,
+        enabledDevices,
+        host: job.host ?? null,
+        hostStrategy: resolveHostStrategy(job),
+        source: job.source ?? null,
+        sourceRepo: job.source?.repo ?? job.repo ?? null,
+        sourceBranch: job.source?.branch ?? null,
+        runOnce: Boolean(job.runOnce),
+        catchup: job.catchup !== false,
+        oneShot: isOneShotRoutine(job),
+        expired: isPastOneShotRoutine(job, now),
+        runsHere: jobRunsOnThisDevice(job),
+        enabled: job.enabled,
+        overdue: overdueSet.has(job.name),
+        nextRun: nextRunForDisplay(job, scheduler)?.toISOString() ?? null,
+        nextRunHuman: nextRunLabel(job, scheduler, now),
+        lastStatus: latestRun?.status ?? null,
+        exitCode: latestRun?.exitCode ?? null,
+        failureReason: latestRun?.errorMessage ?? null,
+        lastRunStartedAt: latestRun?.startedAt ?? null,
+        lastRunCompletedAt: latestRun?.completedAt ?? null,
+        projects: job.projects ?? [],
+        projectGroup: computeProjectGroup(job.projects, knownProjectNames),
+      };
+    });
+  } finally {
+    scheduler.stopAll();
+  }
+}
+
 /** Detect Ctrl+C or premature stream close during an interactive prompt. */
 function isPromptCancelled(err: unknown): boolean {
   return (
@@ -661,6 +722,10 @@ export function registerRoutinesCommands(program: Command): void {
         console.error(chalk.red(`Unsupported --group-by '${options.groupBy}'. Use: project (default) or device`));
         process.exit(1);
       }
+      if (options.json) {
+        process.stdout.write(JSON.stringify(buildRoutineListJson()) + '\n');
+        return;
+      }
       try { monitorRunningJobs(); } catch { /* best-effort orphan reap */ }
       const jobs = listAllJobs(process.cwd());
       if (jobs.length === 0) {
@@ -682,54 +747,6 @@ export function registerRoutinesCommands(program: Command): void {
         for (const j of detectOverdueJobs()) overdueSet.add(j.name);
       } catch {
         // Best-effort indicator; never block the list on detection errors.
-      }
-
-      // Machine-readable path: same data the table renders, but structured.
-      // The menu bar helper relies on this so it never reimplements cron math.
-      if (options.json) {
-        const nowJson = new Date();
-        const knownProjectNames = new Set(listProjectDefs().map((p) => p.name));
-        const payload = jobs.map((job) => {
-          const latestRun = localLatestRun(job);
-          const enabledDevices = devicesWithRoutineEnabled(job.name);
-          return {
-            name: job.name,
-            agent: job.agent ?? null,
-            workflow: job.workflow ?? null,
-            command: job.command ?? null,
-            repo: job.repo ?? null,
-            schedule: job.schedule ?? null,
-            scheduleHuman: fireConditionLabel(job),
-            trigger: job.trigger ?? null,
-            timezone: job.timezone ?? null,
-            devices: enabledDevices,
-            enabledDevices,
-            host: job.host ?? null,
-            hostStrategy: resolveHostStrategy(job),
-            source: job.source ?? null,
-            sourceRepo: job.source?.repo ?? job.repo ?? null,
-            sourceBranch: job.source?.branch ?? null,
-            runOnce: Boolean(job.runOnce),
-            catchup: job.catchup !== false,
-            oneShot: isOneShotRoutine(job),
-            expired: isPastOneShotRoutine(job, nowJson),
-            runsHere: jobRunsOnThisDevice(job),
-            enabled: job.enabled,
-            overdue: overdueSet.has(job.name),
-            nextRun: nextRunForDisplay(job, scheduler)?.toISOString() ?? null,
-            nextRunHuman: nextRunLabel(job, scheduler, nowJson),
-            lastStatus: latestRun?.status ?? null,
-            exitCode: latestRun?.exitCode ?? null,
-            failureReason: latestRun?.errorMessage ?? null,
-            lastRunStartedAt: latestRun?.startedAt ?? null,
-            lastRunCompletedAt: latestRun?.completedAt ?? null,
-            projects: job.projects ?? [],
-            projectGroup: computeProjectGroup(job.projects, knownProjectNames),
-          };
-        });
-        scheduler.stopAll();
-        process.stdout.write(JSON.stringify(payload) + '\n');
-        return;
       }
 
       console.log(chalk.bold('Scheduled Jobs\n'));

--- a/apps/cli/src/commands/setup-watchdog.ts
+++ b/apps/cli/src/commands/setup-watchdog.ts
@@ -4,19 +4,13 @@ import { spawnSync } from 'node:child_process';
 import { getCliLaunch } from '../lib/cli-entry.js';
 import { loadDevices } from '../lib/devices/registry.js';
 import { machineId, normalizeHost } from '../lib/machine-id.js';
-import { devicesWithRoutineEnabled } from '../lib/routine-activation.js';
-import { readJob, setJobEnabled } from '../lib/routines.js';
+import { getConfigValue, setConfigValue } from '../lib/device-config.js';
 import { isPromptCancelled, requireInteractiveSelection } from './utils.js';
 
-const ROUTINE = 'watchdog';
-
 export async function runWatchdogSetupWizard(): Promise<void> {
-  if (!readJob(ROUTINE)) {
-    throw new Error("Built-in routine 'watchdog' is missing. Run: agents repo pull system");
-  }
   const registry = await loadDevices();
   const devices = [...new Set([...Object.keys(registry), machineId()].map(normalizeHost))].sort();
-  const enabled = new Set(devicesWithRoutineEnabled(ROUTINE).map(normalizeHost));
+  const enabled = new Set(devices.filter((device) => getConfigValue('watchdog.enabled', { device }).value === true));
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     requireInteractiveSelection('watchdog devices', ['agents watchdog on', 'agents watchdog on --host <device>']);
   }
@@ -31,10 +25,10 @@ export async function runWatchdogSetupWizard(): Promise<void> {
     for (const device of devices) {
       const on = selectedSet.has(device);
       if (device === normalizeHost(machineId())) {
-        setJobEnabled(ROUTINE, on);
+        setConfigValue('watchdog.enabled', on);
         continue;
       }
-      const launch = getCliLaunch(['routines', on ? 'resume' : 'pause', ROUTINE, '--host', device]);
+      const launch = getCliLaunch(['watchdog', on ? 'on' : 'off', '--host', device]);
       const result = spawnSync(launch.command, launch.args, { stdio: 'inherit', env: process.env });
       if ((result.status ?? 1) !== 0) throw new Error(`Could not configure watchdog on ${device}`);
     }
@@ -52,6 +46,6 @@ export async function runWatchdogSetupWizard(): Promise<void> {
 
 export function registerSetupWatchdogCommand(setup: Command): void {
   setup.command('watchdog')
-    .description('Choose the devices where the built-in watchdog routine runs.')
+    .description('Choose the devices where the daemon watchdog pass runs.')
     .action(runWatchdogSetupWizard);
 }

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -349,7 +349,7 @@ export function registerSetupCommand(program: Command): void {
         agents setup share       # provision or join a Cloudflare share endpoint
         agents setup secrets     # choose secrets backend/policy defaults + import
         agents setup fleet       # discover Tailscale devices + configure SSH access
-        agents setup watchdog    # choose which devices run the watchdog routine
+        agents setup watchdog    # choose which devices run the daemon watchdog pass
 
       To install CLIs from agents.yaml and sync resources into version homes:
         agents sync --local -y

--- a/apps/cli/src/commands/watchdog.ts
+++ b/apps/cli/src/commands/watchdog.ts
@@ -10,12 +10,11 @@
  *   agents watchdog --nudge            one tick, actually injects (explicit opt-in)
  *   agents watchdog --watch            manual poll loop (dry unless --nudge)
  *   agents watchdog --json             machine-readable tick output (for the menu-bar)
- *   agents watchdog on|off             turn the always-on watchdog routine on/off
+ *   agents watchdog on|off             turn the device-local daemon pass on/off
  *   agents watchdog policy <id> <p>    per-session policy: off | keep | handsoff
  *
- * The always-on watchdog is a daemon-fired ROUTINE, not a private sentinel + a
- * hand-rolled loop. Its immutable definition comes from the system DotAgents
- * repo; on/off only changes this device's routine membership.
+ * The agents daemon is the sole automatic watchdog scheduler. The menu bar reads
+ * persisted state; it never runs a tick.
  */
 
 import type { Command } from 'commander';
@@ -24,14 +23,9 @@ import * as path from 'path';
 import { setHelpSections } from '../lib/help.js';
 import { parseDuration } from '../lib/hooks/cache.js';
 import { getRuntimeStateDir } from '../lib/state.js';
-import { readJob, setJobEnabled } from '../lib/routines.js';
-import { getActiveSessions, type ActiveSession } from '../lib/session/active.js';
-import { loadLocalActiveSessions } from '../lib/session/session-cache.js';
-import { mailboxIdForActiveSession } from '../lib/mailbox-target.js';
-import { gcMailbox } from '../lib/mailbox-gc.js';
-import { devicesWithRoutineEnabled, routineEnabledOnThisDevice } from '../lib/routine-activation.js';
+import { getConfigValue, setConfigValue } from '../lib/device-config.js';
+import type { ActiveSession } from '../lib/session/active.js';
 import {
-  runWatchdogTick,
   writePolicySentinel,
   DEFAULT_THRESHOLDS,
   type WatchdogPolicy,
@@ -40,8 +34,7 @@ import {
   type SessionOutcome,
 } from '../lib/watchdog/runner.js';
 import { isWatchdogRotateEnabled, listRotateStates, setWatchdogRotateEnabled } from '../lib/watchdog/rotate.js';
-
-const WATCHDOG_ROUTINE_NAME = 'watchdog';
+import { loadWatchdogSessions, runWatchdogPass } from '../lib/watchdog/service.js';
 
 /** Default state dir the runner and these subcommands share. */
 function stateDir(): string {
@@ -73,23 +66,6 @@ function humanMs(ms: number): string {
   if (ms >= 3600_000) return `${Math.round(ms / 3600_000)}h`;
   if (ms >= 60_000) return `${Math.round(ms / 60_000)}m`;
   return `${Math.round(ms / 1000)}s`;
-}
-
-/**
- * Run the mailbox liveness sweep against the same session set the tick just used.
- * Idempotent and cheap: archiving a message twice is a no-op, and GC only scans
- * directories. Failures are swallowed so a mailbox-root problem cannot break the
- * watchdog tick.
- */
-async function runMailboxGc(sessions: ActiveSession[]): Promise<void> {
-  const activeBoxIds = new Set(
-    sessions.map(mailboxIdForActiveSession).filter((id): id is string => !!id),
-  );
-  try {
-    gcMailbox(activeBoxIds);
-  } catch {
-    // GC is best-effort housekeeping; the next tick will retry.
-  }
 }
 
 function colorForOutcome(o: SessionOutcome): (s: string) => string {
@@ -155,49 +131,38 @@ export function registerWatchdogCommand(program: Command): void {
       };
       // Injection gate: --nudge is the explicit opt-in to actually inject. Bare
       // `agents watchdog` (and `--watch` without `--nudge`) is dry. The always-on
-      // path is the daemon routine, which runs `agents watchdog --nudge` — so the
-      // routine's enabled state IS the on/off switch, not a flag read here.
+      // path is the daemon-owned pass. Device config is its on/off switch; this
+      // explicit command still requires --nudge before it can inject.
       const computeWillInject = (): boolean => opts.nudge === true;
 
       const tickOnce = async (willInject: boolean, sessions: ActiveSession[]): Promise<WatchdogTickResult> =>
-        runWatchdogTick({
+        runWatchdogPass({
           nudge: willInject,
           nudgeText: opts.text,
           smart: opts.smart === true,
           smartAgent: opts.smartAgent,
           thresholds,
           allowGhosttyFocus: opts.allowGhosttyFocus === true,
-          stateDir: stateDir(),
           sessions,
         });
 
       // RUSH-2062: share the daemon-warmed local active-session snapshot with
       // menubar/CLI/Factory instead of re-running a full gather every tick.
-      const loadWatchdogSessions = async () => {
-        const loaded = await loadLocalActiveSessions({
-          // Force a live gather only when the warm path is unavailable; the
-          // cache layer already re-gathers past DEFAULT_ACTIVE_CACHE_MAX_AGE_MS.
-          gather: () => getActiveSessions({ localOnly: true }),
-        });
-        return loaded.sessions;
-      };
-
       if (!opts.watch) {
         const willInject = computeWillInject();
         const sessions = await loadWatchdogSessions();
         const result = await tickOnce(willInject, sessions);
-        await runMailboxGc(sessions);
         if (opts.json) console.log(JSON.stringify(result, null, 2));
         else printTick(result, willInject);
         return;
       }
 
-      // Manual poll loop (for ad-hoc use; the always-on path is `enable`'s routine).
+      // Manual poll loop for ad-hoc use; the daemon owns the automatic cadence.
       const intervalMs = durationMsOr(opts.interval, 30_000);
       if (!computeWillInject() && !opts.json) {
         console.log(chalk.yellow(
           `watchdog --watch is DETECT-ONLY. Pass --nudge to inject, ` +
-          `or run 'agents watchdog on' for the always-on daemon routine.`,
+          `or run 'agents watchdog on' for the daemon-owned pass.`,
         ));
       }
       // eslint-disable-next-line no-constant-condition
@@ -206,7 +171,6 @@ export function registerWatchdogCommand(program: Command): void {
         const willInject = computeWillInject();
         const sessions = await loadWatchdogSessions();
         const result = await tickOnce(willInject, sessions);
-        await runMailboxGc(sessions);
         if (opts.json) console.log(JSON.stringify(result));
         else printTick(result, willInject);
         await sleep(intervalMs);
@@ -227,10 +191,10 @@ export function registerWatchdogCommand(program: Command): void {
       # Machine-readable for the menu-bar
       agents watchdog --json
 
-      # Turn on the ALWAYS-ON watchdog (a daemon-fired routine)
+      # Turn on the daemon-owned watchdog pass (every three minutes)
       agents watchdog on
 
-      # Show the routine, rotate config, and any in-flight in-place rotates
+      # Show device enablement, rotate config, and in-flight rotates
       agents watchdog status
 
       # Leave one session detected-but-untouched
@@ -273,10 +237,10 @@ export function registerWatchdogCommand(program: Command): void {
       'watchdog.rotate: off' to ~/.agents/agents.yaml; nudging stays on).
       State machine: ~/.agents/.cache/state/watchdog/rotate/<sessionId>.json.
 
-      Always-on: 'agents watchdog on' enables the system-defined 'watchdog' routine
-      on this device and reloads the daemon; 'off' disables it here. Inspect it with
-      'agents routines list'. Defaults
-      OFF. Per-session policy: off (ignore), keep (default), handsoff (detect + flag).
+      Always-on: 'agents watchdog on' enables one daemon-owned pass every three
+      minutes on this device and reloads the daemon; 'off' disables it here.
+      Defaults OFF. Per-session policy: off (ignore), keep (default), handsoff
+      (detect + flag).
 
       State (tray-readable): ${path.join('~/.agents/.cache/state/watchdog', '{nudges,flags,last-tick}.json')}
     `,
@@ -285,27 +249,24 @@ export function registerWatchdogCommand(program: Command): void {
   // --- always-on enable/disable/status (backed by the daemon routine) --------
 
   const turnOn = async (): Promise<void> => {
-      const routine = readJob(WATCHDOG_ROUTINE_NAME);
-      if (!routine) throw new Error("Built-in routine 'watchdog' is missing. Run: agents repo pull system");
-      setJobEnabled(WATCHDOG_ROUTINE_NAME, true);
+      setConfigValue('watchdog.enabled', true);
       await reloadDaemonForRoutine(true);
-      console.log(chalk.green(`watchdog: ON on this device (${routine.schedule ?? 'event-triggered'})`));
+      console.log(chalk.green('watchdog: ON on this device (every 3 minutes)'));
   };
   const turnOff = async (): Promise<void> => {
-      if (!readJob(WATCHDOG_ROUTINE_NAME)) throw new Error("Built-in routine 'watchdog' is missing. Run: agents repo pull system");
-      setJobEnabled(WATCHDOG_ROUTINE_NAME, false);
+      setConfigValue('watchdog.enabled', false);
       await reloadDaemonForRoutine(false);
       console.log(chalk.yellow('watchdog: OFF on this device'));
   };
 
   cmd.command('on')
-    .description('Enable the built-in watchdog routine on this device.')
+    .description('Enable the daemon watchdog pass on this device.')
     .action(async () => {
       await turnOn();
     });
 
   cmd.command('off')
-    .description('Disable the built-in watchdog routine on this device.')
+    .description('Disable the daemon watchdog pass on this device.')
     .action(async () => {
       await turnOff();
     });
@@ -333,7 +294,7 @@ export function registerWatchdogCommand(program: Command): void {
     });
 
   cmd.command('status')
-    .description('Show whether the always-on watchdog routine is enabled and where state is written.')
+    .description('Show whether the daemon watchdog pass is enabled and where state is written.')
     .option('--json', 'Emit status as JSON (for the menu-bar / scripts)')
     .action((_opts, command) => {
       // The parent `watchdog` command also declares --json and greedily parses it
@@ -341,16 +302,14 @@ export function registerWatchdogCommand(program: Command): void {
       // parent, not this subcommand. optsWithGlobals() merges both levels, so we
       // read it correctly regardless of which command commander bound it to.
       const json = command.optsWithGlobals().json === true;
-      const on = routineEnabledOnThisDevice(WATCHDOG_ROUTINE_NAME) === true;
-      const enabledDevices = devicesWithRoutineEnabled(WATCHDOG_ROUTINE_NAME);
+      const on = getConfigValue('watchdog.enabled').value === true;
       const rotate = isWatchdogRotateEnabled() ? 'on' : 'off';
       const rotates = listRotateStates(stateDir());
       const inflight = rotates.filter((r) => r.phase !== 'done' && r.phase !== 'failed');
       if (json) {
         console.log(JSON.stringify({
           enabled: on,
-          enabledDevices,
-          routine: WATCHDOG_ROUTINE_NAME,
+          cadenceMs: 180_000,
           stateDir: stateDir(),
           rotate,
           rotates: rotates.map((r) => ({
@@ -364,8 +323,7 @@ export function registerWatchdogCommand(program: Command): void {
         }));
         return;
       }
-      console.log(`always-on watchdog: ${on ? chalk.green('ON') : chalk.dim('off')} (routine '${WATCHDOG_ROUTINE_NAME}')`);
-      console.log(`enabled devices: ${enabledDevices.length > 0 ? enabledDevices.join(', ') : chalk.dim('none')}`);
+      console.log(`always-on watchdog: ${on ? chalk.green('ON') : chalk.dim('off')} (every 3 minutes on this device)`);
       console.log(`rotate: ${rotate === 'on' ? chalk.green('on') : chalk.yellow('off')} (watchdog.rotate in agents.yaml) · ${inflight.length} in-flight`);
       for (const r of inflight) {
         console.log(`  ${chalk.magenta(r.phase.padEnd(12))} ${chalk.bold(r.sessionId.slice(0, 8))} → ${r.newSessionId.slice(0, 8)}${r.error ? chalk.red(`  ${r.error}`) : ''}`);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -25,7 +25,9 @@ import { BrowserService } from './browser/service.js';
 import { BrowserIPCServer } from './browser/ipc.js';
 import { redactSecrets } from './redact.js';
 import { getAgentsBinPath, getCliLaunch, BUN_VIRTUAL_ROOT } from './cli-entry.js';
-import { isSchedulerEnabled, assertSchedulerEnabled } from './device-config.js';
+import { getConfigValue, isSchedulerEnabled, assertSchedulerEnabled } from './device-config.js';
+import { reapTerminalRoutineProcesses } from './routine-process-cleanup.js';
+import { runWatchdogPass } from './watchdog/service.js';
 
 const PID_FILE = 'daemon.pid';
 const LOCK_FILE = 'daemon.lock';
@@ -36,6 +38,7 @@ const LOG_ROTATE_COUNT = 3;
 const PLIST_NAME = 'com.phnx-labs.agents-daemon';
 const SYSTEMD_UNIT = 'agents-daemon.service';
 const MONITOR_TICK_MS = 60_000;
+const WATCHDOG_TICK_MS = 3 * 60_000;
 /**
  * How often to re-scan for missed fires. Deliberately slower than the monitor
  * tick: detection walks a week of cron occurrences per routine
@@ -575,6 +578,25 @@ export async function runDaemon(): Promise<void> {
 
   if (schedulerEnabledAtBoot) bootScheduler();
 
+  let watchdogInFlight = false;
+  const runDaemonWatchdog = async () => {
+    if (watchdogInFlight || getConfigValue('watchdog.enabled').value !== true) return;
+    watchdogInFlight = true;
+    try {
+      const result = await runWatchdogPass({ nudge: true });
+      log(
+        'INFO',
+        `watchdog: ${result.counts.total} live, ${result.counts.stalled} stalled, ${result.counts.nudged} nudged`,
+      );
+    } catch (err) {
+      log('ERROR', `watchdog tick failed: ${(err as Error).message}`);
+    } finally {
+      watchdogInFlight = false;
+    }
+  };
+  const watchdogInterval = setInterval(() => { void runDaemonWatchdog(); }, WATCHDOG_TICK_MS);
+  const watchdogKickoff = setTimeout(() => { void runDaemonWatchdog(); }, 30_000);
+
   // Monitor engine: event-triggered watchers, beside the cron scheduler. Same
   // daemon, same dispatch seam — a monitor is a routine whose trigger is a
   // watched source instead of a clock. Reloads on SIGHUP alongside the scheduler.
@@ -681,6 +703,8 @@ export async function runDaemon(): Promise<void> {
   const monitorInterval = setInterval(() => {
     writeHeartbeat();
     monitorRunningJobs();
+    const reaped = reapTerminalRoutineProcesses();
+    if (reaped.length > 0) log('WARN', `Reaped ${reaped.length} terminal routine process group(s): ${reaped.join(', ')}`);
   }, MONITOR_TICK_MS);
 
   // Resource safety check: heal gaps between what DotAgents repos define and
@@ -1031,6 +1055,7 @@ export async function runDaemon(): Promise<void> {
       const reloaded = scheduler!.listScheduled();
       log('INFO', `Reloaded ${reloaded.length} jobs`);
     }
+    void runDaemonWatchdog();
     try {
       monitorEngine.reload();
     } catch (err) {
@@ -1044,6 +1069,8 @@ export async function runDaemon(): Promise<void> {
     monitorEngine.stop();
     await browserIPC.stop();
     clearInterval(monitorInterval);
+    clearInterval(watchdogInterval);
+    clearTimeout(watchdogKickoff);
     clearInterval(healInterval);
     clearTimeout(healKickoff);
     clearInterval(autoDispatchInterval);

--- a/apps/cli/src/lib/daemon.ts
+++ b/apps/cli/src/lib/daemon.ts
@@ -1055,7 +1055,6 @@ export async function runDaemon(): Promise<void> {
       const reloaded = scheduler!.listScheduled();
       log('INFO', `Reloaded ${reloaded.length} jobs`);
     }
-    void runDaemonWatchdog();
     try {
       monitorEngine.reload();
     } catch (err) {

--- a/apps/cli/src/lib/device-config.test.ts
+++ b/apps/cli/src/lib/device-config.test.ts
@@ -193,6 +193,7 @@ describe('listConfig', () => {
     const { listConfig, setConfigValue } = await freshModules();
     setConfigValue('interactive.host', 'zion');
     setConfigValue('scheduler.enabled', true);
+    setConfigValue('watchdog.enabled', false);
 
     const entries = listConfig();
     const byName = Object.fromEntries(entries.map((e) => [e.spec.name, e]));
@@ -203,9 +204,11 @@ describe('listConfig', () => {
       'interactive.host',
       'notes',
       'scheduler.enabled',
+      'watchdog.enabled',
     ]);
     expect(byName['interactive.host']).toMatchObject({ value: 'zion', layer: 'user' });
     expect(byName['scheduler.enabled']).toMatchObject({ value: true, layer: 'device' });
+    expect(byName['watchdog.enabled']).toMatchObject({ value: false, layer: 'device' });
     expect(byName['notes'].value).toBeUndefined();
     expect(byName['notes'].layer).toBeUndefined();
   });

--- a/apps/cli/src/lib/device-config.ts
+++ b/apps/cli/src/lib/device-config.ts
@@ -112,6 +112,13 @@ export const CONFIG_KEYS: readonly ConfigKeySpec[] = [
     description: 'Whether the routines scheduler (daemon) may fire on this device.',
   },
   {
+    name: 'watchdog.enabled',
+    yamlKey: 'watchdogEnabled',
+    scope: 'device',
+    type: 'bool',
+    description: 'Whether the daemon runs the watchdog pass on this device.',
+  },
+  {
     name: 'browser.remote-control',
     yamlKey: 'browserRemoteControl',
     scope: 'device',

--- a/apps/cli/src/lib/menubar/snapshot.test.ts
+++ b/apps/cli/src/lib/menubar/snapshot.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { readLastWatchdogTick } from './snapshot.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('menubar snapshot', () => {
+  it('reads the daemon-owned watchdog result without running a watchdog tick', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'menubar-snapshot-'));
+    dirs.push(dir);
+    const tick = {
+      didNudge: true,
+      counts: { total: 2, stalled: 1, nudged: 1, unaddressable: 0, skipped: 1 },
+      outcomes: [],
+    };
+    fs.writeFileSync(path.join(dir, 'last-tick.json'), JSON.stringify(tick));
+
+    expect(readLastWatchdogTick(dir)).toEqual(tick);
+  });
+
+  it('returns null when the daemon has not published a watchdog result', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'menubar-snapshot-'));
+    dirs.push(dir);
+    expect(readLastWatchdogTick(dir)).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/menubar/snapshot.ts
+++ b/apps/cli/src/lib/menubar/snapshot.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { buildRoutineListJson } from '../../commands/routines.js';
+import { serializeActiveSessionsForJson, serializeSessionsJson } from '../../commands/sessions.js';
+import { getConfigValue } from '../device-config.js';
+import { querySessions } from '../session/db.js';
+import { readActiveSessionsCache } from '../session/session-cache.js';
+import { getRuntimeStateDir } from '../state.js';
+import type { WatchdogTickResult } from '../watchdog/runner.js';
+
+export interface MenubarSnapshot {
+  version: 1;
+  capturedAt: string;
+  routines: Record<string, unknown>[];
+  recentSessions: Record<string, unknown>[];
+  activeSessions: Record<string, unknown>[];
+  watchdog: {
+    enabled: boolean;
+    lastTick: Pick<WatchdogTickResult, 'didNudge' | 'counts'> | null;
+  };
+}
+
+export function readLastWatchdogTick(
+  stateDir = path.join(getRuntimeStateDir(), 'watchdog'),
+): WatchdogTickResult | null {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(stateDir, 'last-tick.json'), 'utf-8')) as WatchdogTickResult;
+  } catch {
+    return null;
+  }
+}
+
+/** One-process read model for AGI Menu's repeating three-minute refresh. */
+export async function computeMenubarSnapshot(): Promise<MenubarSnapshot> {
+  const [routines, recent] = await Promise.all([
+    Promise.resolve(buildRoutineListJson()),
+    Promise.resolve(querySessions({ limit: 40, skipExistenceCheck: true })),
+  ]);
+  const active = readActiveSessionsCache('local');
+  return {
+    version: 1,
+    capturedAt: new Date().toISOString(),
+    routines,
+    recentSessions: JSON.parse(serializeSessionsJson(recent)) as Record<string, unknown>[],
+    activeSessions: serializeActiveSessionsForJson(active?.sessions ?? []) as Record<string, unknown>[],
+    watchdog: {
+      enabled: getConfigValue('watchdog.enabled').value === true,
+      lastTick: (() => {
+        const tick = readLastWatchdogTick();
+        return tick ? { didNudge: tick.didNudge, counts: tick.counts } : null;
+      })(),
+    },
+  };
+}

--- a/apps/cli/src/lib/routine-process-cleanup.test.ts
+++ b/apps/cli/src/lib/routine-process-cleanup.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { reapTerminalRoutineProcesses } from './routine-process-cleanup.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function writeRun(root: string, name: string, status: string, pid: number, completedAt?: string): void {
+  const dir = path.join(root, 'job', name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.json'), JSON.stringify({
+    runId: name,
+    jobName: 'job',
+    status,
+    pid,
+    startedAt: new Date().toISOString(),
+    completedAt: status === 'running' ? null : completedAt ?? new Date(Date.now() - 10_000).toISOString(),
+    exitCode: status === 'failed' ? 1 : null,
+  }));
+}
+
+describe('terminal routine process cleanup', () => {
+  it('terminates a live failed process group and leaves running records alone', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'routine-cleanup-'));
+    dirs.push(root);
+    writeRun(root, 'failed', 'failed', 101);
+    writeRun(root, 'timeout', 'timeout', 102);
+    writeRun(root, 'completed', 'completed', 103);
+    const terminated: number[] = [];
+
+    expect(reapTerminalRoutineProcesses({
+      runsDir: root,
+      alive: () => true,
+      owns: () => true,
+      terminate: (pid) => terminated.push(pid),
+    })).toEqual([101, 102]);
+    expect(terminated).toEqual([101, 102]);
+  });
+
+  it('gives a newly terminal process five seconds to exit itself', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'routine-cleanup-'));
+    dirs.push(root);
+    writeRun(root, 'failed', 'failed', 104, new Date().toISOString());
+    expect(reapTerminalRoutineProcesses({
+      runsDir: root,
+      alive: () => true,
+      owns: () => true,
+      terminate: () => { throw new Error('must not terminate during grace'); },
+    })).toEqual([]);
+  });
+
+  it('does not signal a terminal record whose pid is no longer live', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'routine-cleanup-'));
+    dirs.push(root);
+    writeRun(root, 'failed', 'failed', 103);
+    const terminated: number[] = [];
+    expect(reapTerminalRoutineProcesses({
+      runsDir: root,
+      alive: () => false,
+      owns: () => true,
+      terminate: (pid) => terminated.push(pid),
+    })).toEqual([]);
+    expect(terminated).toEqual([]);
+  });
+});

--- a/apps/cli/src/lib/routine-process-cleanup.ts
+++ b/apps/cli/src/lib/routine-process-cleanup.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+import { isAlive, killTree } from './platform/index.js';
+import { getRunsDir } from './state.js';
+import type { RunMeta } from './routines.js';
+
+export interface RoutineProcessCleanupOptions {
+  runsDir?: string;
+  alive?: (pid: number) => boolean;
+  owns?: (meta: RunMeta) => boolean;
+  terminate?: (pid: number) => void;
+}
+
+function processMatchesRun(meta: RunMeta): boolean {
+  if (!meta.pid || !meta.spawnedAt) return false;
+  if (process.platform === 'win32') return true;
+  try {
+    const elapsed = execFileSync('ps', ['-p', String(meta.pid), '-o', 'etime='], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!elapsed) return false;
+    const fields = elapsed.replace(/-/g, ':').split(':').reverse();
+    const seconds = Number(fields[0] ?? 0)
+      + Number(fields[1] ?? 0) * 60
+      + Number(fields[2] ?? 0) * 3600
+      + Number(fields[3] ?? 0) * 86400;
+    return Math.abs((Date.now() - seconds * 1000) - meta.spawnedAt) < 30_000;
+  } catch {
+    return false;
+  }
+}
+
+/** Reap process groups whose durable run record is already terminal. */
+export function reapTerminalRoutineProcesses(opts: RoutineProcessCleanupOptions = {}): number[] {
+  const runsDir = opts.runsDir ?? getRunsDir();
+  const alive = opts.alive ?? isAlive;
+  const owns = opts.owns ?? processMatchesRun;
+  const terminate = opts.terminate ?? ((pid: number) => killTree(process.platform === 'win32' ? pid : -pid));
+  if (!fs.existsSync(runsDir)) return [];
+
+  const reaped: number[] = [];
+  for (const job of fs.readdirSync(runsDir, { withFileTypes: true })) {
+    if (!job.isDirectory()) continue;
+    const jobDir = path.join(runsDir, job.name);
+    for (const run of fs.readdirSync(jobDir, { withFileTypes: true })) {
+      if (!run.isDirectory()) continue;
+      try {
+        const meta = JSON.parse(
+          fs.readFileSync(path.join(jobDir, run.name, 'meta.json'), 'utf-8'),
+        ) as RunMeta;
+        if (!['failed', 'timeout'].includes(meta.status) || !meta.pid || meta.hostTaskId || meta.cloudTaskId) continue;
+        const completedAt = Date.parse(meta.completedAt ?? '');
+        if (!Number.isFinite(completedAt) || Date.now() - completedAt < 5_000) continue;
+        if (!alive(meta.pid)) continue;
+        if (!owns(meta)) continue;
+        terminate(meta.pid);
+        reaped.push(meta.pid);
+      } catch {
+        // Corrupt or concurrently-replaced records are left untouched.
+      }
+    }
+  }
+  return reaped;
+}

--- a/apps/cli/src/lib/routine-process-cleanup.ts
+++ b/apps/cli/src/lib/routine-process-cleanup.ts
@@ -15,8 +15,17 @@ export interface RoutineProcessCleanupOptions {
 
 function processMatchesRun(meta: RunMeta): boolean {
   if (!meta.pid || !meta.spawnedAt) return false;
-  if (process.platform === 'win32') return true;
   try {
+    if (process.platform === 'win32') {
+      const startedAt = execFileSync('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `(Get-Process -Id ${meta.pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToString("o")`,
+      ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true }).trim();
+      const processStart = Date.parse(startedAt);
+      return Number.isFinite(processStart) && Math.abs(processStart - meta.spawnedAt) < 30_000;
+    }
     const elapsed = execFileSync('ps', ['-p', String(meta.pid), '-o', 'etime='], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],

--- a/apps/cli/src/lib/runner.test.ts
+++ b/apps/cli/src/lib/runner.test.ts
@@ -357,6 +357,16 @@ describe('command-mode routines (executeJobDetached — daemon/cron path)', () =
     expect(final.status).toBe('completed');
   });
 
+  it('blocks a replacement while a failed record still owns a live process', async () => {
+    const command = `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 5000)"`;
+    const config = commandConfig('cmd-det-failed-live', command);
+    const first = await executeJobDetached(config);
+    writeRunMeta({ ...first, status: 'failed', completedAt: new Date().toISOString(), exitCode: 1 });
+
+    await expect(executeJobDetached(config)).rejects.toBeInstanceOf(RoutineAlreadyRunningError);
+    await waitTerminal(config.name, first.runId, 7000);
+  });
+
   it('monitorRunningJobs kills a detached process after its persisted deadline', async () => {
     const jobName = 'cmd-det-restart-timeout';
     jobs.push(jobName);

--- a/apps/cli/src/lib/runner.ts
+++ b/apps/cli/src/lib/runner.ts
@@ -95,7 +95,7 @@ function activeRoutineRun(config: Pick<JobConfig, 'name' | 'timeout'>): RunMeta 
   const runs = listRuns(config.name);
   for (let i = runs.length - 1; i >= 0; i--) {
     const run = runs[i];
-    if (run.status !== 'running') continue;
+    if (!['running', 'failed', 'timeout'].includes(run.status)) continue;
     if (run.pid && isPidOurs(run.pid, run.spawnedAt)) return run;
     if (!run.pid) {
       const startedAt = Date.parse(run.startedAt);

--- a/apps/cli/src/lib/session/session-cache.ts
+++ b/apps/cli/src/lib/session/session-cache.ts
@@ -38,13 +38,13 @@ const IMMUTABLE_FILE = '.active-session-immutable.json';
  * Short on purpose: live status (running/idle/waiting) must not go stale.
  * The daemon warm tick uses the same cadence (see {@link SESSION_CACHE_WARM_INTERVAL_MS}).
  */
-export const DEFAULT_ACTIVE_CACHE_MAX_AGE_MS = 15_000;
+export const DEFAULT_ACTIVE_CACHE_MAX_AGE_MS = 4 * 60_000;
 
 /** Daemon warm interval — keep in sync with the setInterval in `lib/daemon.ts`. */
-export const SESSION_CACHE_WARM_INTERVAL_MS = 15_000;
+export const SESSION_CACHE_WARM_INTERVAL_MS = 3 * 60_000;
 
-/** Kick off the first warm ~25s after daemon start (staggered off other ticks). */
-export const SESSION_CACHE_WARM_KICKOFF_MS = 25_000;
+/** Kick off the first warm 30s after daemon start (staggered off other ticks). */
+export const SESSION_CACHE_WARM_KICKOFF_MS = 30_000;
 
 /** Snapshot scope: this host only, or a fleet-wide merge written by a reader. */
 export type ActiveCacheScope = 'local' | 'fleet';

--- a/apps/cli/src/lib/watchdog/service.test.ts
+++ b/apps/cli/src/lib/watchdog/service.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { runWatchdogPass } from './service.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('watchdog service', () => {
+  it('runs the daemon/CLI shared pass and publishes the menu snapshot source', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'watchdog-service-'));
+    dirs.push(stateDir);
+    const result = await runWatchdogPass({
+      nudge: true,
+      sessions: [],
+      stateDir,
+      mailboxGc: false,
+    });
+
+    expect(result.didNudge).toBe(true);
+    expect(result.counts.total).toBe(0);
+    expect(JSON.parse(fs.readFileSync(path.join(stateDir, 'last-tick.json'), 'utf-8'))).toEqual(result);
+  });
+});

--- a/apps/cli/src/lib/watchdog/service.ts
+++ b/apps/cli/src/lib/watchdog/service.ts
@@ -1,0 +1,55 @@
+import * as path from 'path';
+
+import { gcMailbox } from '../mailbox-gc.js';
+import { mailboxIdForActiveSession } from '../mailbox-target.js';
+import { getActiveSessions, type ActiveSession } from '../session/active.js';
+import { loadLocalActiveSessions } from '../session/session-cache.js';
+import { getRuntimeStateDir } from '../state.js';
+import { runWatchdogTick, type WatchdogThresholds, type WatchdogTickResult } from './runner.js';
+
+export interface WatchdogPassOptions {
+  nudge: boolean;
+  nudgeText?: string;
+  smart?: boolean;
+  smartAgent?: string;
+  thresholds?: WatchdogThresholds;
+  allowGhosttyFocus?: boolean;
+  sessions?: ActiveSession[];
+  stateDir?: string;
+  mailboxGc?: boolean;
+}
+
+export async function loadWatchdogSessions(): Promise<ActiveSession[]> {
+  const loaded = await loadLocalActiveSessions({
+    gather: () => getActiveSessions({ localOnly: true }),
+  });
+  return loaded.sessions;
+}
+
+export function runWatchdogMailboxGc(sessions: ActiveSession[]): void {
+  const activeBoxIds = new Set(
+    sessions.map(mailboxIdForActiveSession).filter((id): id is string => Boolean(id)),
+  );
+  try {
+    gcMailbox(activeBoxIds);
+  } catch {
+    // Housekeeping is retried by the next daemon tick.
+  }
+}
+
+/** Execute one watchdog pass from the daemon or the explicit CLI command. */
+export async function runWatchdogPass(opts: WatchdogPassOptions): Promise<WatchdogTickResult> {
+  const sessions = opts.sessions ?? await loadWatchdogSessions();
+  const result = await runWatchdogTick({
+    nudge: opts.nudge,
+    nudgeText: opts.nudgeText,
+    smart: opts.smart,
+    smartAgent: opts.smartAgent,
+    thresholds: opts.thresholds,
+    allowGhosttyFocus: opts.allowGhosttyFocus,
+    stateDir: opts.stateDir ?? path.join(getRuntimeStateDir(), 'watchdog'),
+    sessions,
+  });
+  if (opts.mailboxGc !== false) runWatchdogMailboxGc(sessions);
+  return result;
+}


### PR DESCRIPTION
Fixes RUSH-2260 for AGI Menu users on zion and the macOS fleet.

## What changed

- Replaced the 20–45 second routines/session/watchdog subprocess loops with one read-only `agents menubar snapshot --json` every three minutes.
- The snapshot reads 40 indexed recent sessions plus the daemon-published active-session cache; it never re-indexes transcripts.
- Kept `doctor --json` on its independent 15-minute cadence.
- Moved automatic watchdog execution into one non-overlapping daemon pass every three minutes, gated by device-local `watchdog.enabled`.
- Prevented failed/timeout routine records with live owned processes from overlapping replacements, then reaped them after a five-second exit grace.

## Verification

No visual UI layout changed; this is a process/cadence and lifecycle fix.

Actual captured run screenshot: `zion:/private/tmp/rush2260-run.txt.png`

The captured run reports 1.98 seconds, snapshot version 1, 10 routines, 40 recent sessions, 85 cached active sessions, and watchdog disabled.

- 49 targeted tests passed across runner, cleanup, device config, snapshot, and watchdog service.
- TypeScript build passed.
- Swift compile and `menubar/scripts/test-menubar.sh` passed.
- Full remote suite could not start locally because zion resolved the `hetzner.com` bundle with an empty HCLOUD_TOKEN; GitHub CI is the clean-room full-suite gate.

## Tracking

Linear: RUSH-2260